### PR TITLE
Use restricted wazuh-server user for Manager Indexer authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to this project will be documented in this file.
 - Updated JSON property names in the Wodle event payload. ([#35992](https://github.com/wazuh/wazuh/issues/35992))
 - Included `os_type` in the agent keepalive cluster synchronization. ([#36072](https://github.com/wazuh/wazuh/issues/36072))
 - Randomized the cluster key generated during manager installation instead of using a hardcoded default. ([#36805](https://github.com/wazuh/wazuh/issues/36805))
+- Changed the default Indexer user used by the Manager from `admin` to the restricted `wazuh-server` user, aligning with the Indexer RBAC least-privilege model. ([#36311](https://github.com/wazuh/wazuh/issues/36311))
 
 #### Removed
 

--- a/api/tools/env/wazuh-manager/entrypoint.sh
+++ b/api/tools/env/wazuh-manager/entrypoint.sh
@@ -15,9 +15,9 @@ while [ ! -f "${WAZUH_CERTS_DIR}/root-ca.pem" ]; do
 done
 echo "Certificates found."
 
-# Set indexer credentials (default: admin/admin)
-echo 'admin' | /var/wazuh-manager/bin/wazuh-manager-keystore -f indexer -k username
-echo 'admin' | /var/wazuh-manager/bin/wazuh-manager-keystore -f indexer -k password
+# Set indexer credentials (default: wazuh-server/wazuh-server)
+echo 'wazuh-server' | /var/wazuh-manager/bin/wazuh-manager-keystore -f indexer -k username
+echo 'wazuh-server' | /var/wazuh-manager/bin/wazuh-manager-keystore -f indexer -k password
 
 # Configure wazuh configuration file and api.yaml based on the Master role
 if [ "$ROLE" == "master" ]; then

--- a/docs/ref/getting-started/installation.md
+++ b/docs/ref/getting-started/installation.md
@@ -56,9 +56,9 @@ sudo chown -R wazuh-manager:wazuh-manager /var/wazuh-manager/etc/certs
 Configure the Wazuh server to connect to the Wazuh indexer using the secure keystore:
 
 ```bash
-# Set indexer credentials (default: admin/admin)
-sudo /var/wazuh-manager/bin/wazuh-manager-keystore -f indexer -k username -v admin
-sudo /var/wazuh-manager/bin/wazuh-manager-keystore -f indexer -k password -v admin
+# Set indexer credentials (default: wazuh-server/wazuh-server)
+sudo /var/wazuh-manager/bin/wazuh-manager-keystore -f indexer -k username -v wazuh-server
+sudo /var/wazuh-manager/bin/wazuh-manager-keystore -f indexer -k password -v wazuh-server
 ```
 
 Update the indexer configuration in `/var/wazuh-manager/etc/wazuh-manager.conf` to specify the indexer IP address:

--- a/framework/wazuh/core/indexer/tests/test_indexer.py
+++ b/framework/wazuh/core/indexer/tests/test_indexer.py
@@ -29,8 +29,8 @@ async def test_get_indexer_client_resolves_relative_certificate_paths():
     client.close = AsyncMock()
     keystore_client = MagicMock()
     keystore_client.__enter__.return_value.get.side_effect = [
-        {"value": "admin"},
-        {"value": "admin"},
+        {"value": "wazuh-server"},
+        {"value": "wazuh-server"},
     ]
 
     wazuh_config = {
@@ -64,8 +64,8 @@ async def test_get_indexer_client_resolves_relative_certificate_paths():
     create_indexer.assert_awaited_once_with(
         hosts=["localhost"],
         ports=[9200],
-        user="admin",
-        password="admin",
+        user="wazuh-server",
+        password="wazuh-server",
         use_ssl=True,
         verify_certs=True,
         client_cert_path="/var/wazuh-manager/etc/certs/manager.pem",

--- a/src/engine/source/conf/src/conf.cpp
+++ b/src/engine/source/conf/src/conf.cpp
@@ -58,8 +58,8 @@ Conf::Conf(std::shared_ptr<IFileLoader> fileLoader)
 
     // Indexer connector
     addUnit<std::vector<std::string>>(key::INDEXER_HOST, "WAZUH_INDEXER_HOSTS", {"http://localhost:9200"});
-    addUnit<std::string>(key::INDEXER_USER, "WAZUH_INDEXER_USER", "admin");
-    addUnit<std::string>(key::INDEXER_PASSWORD, "WAZUH_INDEXER_PASSWORD", "admin");
+    addUnit<std::string>(key::INDEXER_USER, "WAZUH_INDEXER_USER", "wazuh-server");
+    addUnit<std::string>(key::INDEXER_PASSWORD, "WAZUH_INDEXER_PASSWORD", "wazuh-server");
     addUnit<std::vector<std::string>>(key::INDEXER_SSL_CA_BUNDLE, "WAZUH_INDEXER_SSL_CA_BUNDLE", {});
     addUnit<std::string>(key::INDEXER_SSL_CERTIFICATE, "WAZUH_INDEXER_SSL_CERTIFICATE", "");
     addUnit<std::string>(key::INDEXER_SSL_KEY, "WAZUH_INDEXER_SSL_KEY", "");

--- a/src/shared_modules/indexer_connector/src/indexerConnectorAsyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorAsyncImpl.hpp
@@ -206,13 +206,13 @@ public:
         static auto password = Keystore::get(INDEXER_COLUMN, PASSWORD_KEY);
         if (username.empty() && password.empty())
         {
-            username = "admin";
-            password = "admin";
+            username = "wazuh-server";
+            password = "wazuh-server";
             logWarn(m_logTag.c_str(), "No username and password found in the keystore, using default values.");
         }
         if (username.empty())
         {
-            username = "admin";
+            username = "wazuh-server";
             logWarn(m_logTag.c_str(), "No username found in the keystore, using default value.");
         }
         m_secureCommunication = SecureCommunication::builder();

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -665,13 +665,13 @@ public:
         static auto password = Keystore::get(INDEXER_COLUMN, PASSWORD_KEY);
         if (username.empty() && password.empty())
         {
-            username = "admin";
-            password = "admin";
+            username = "wazuh-server";
+            password = "wazuh-server";
             logWarn(m_logTag.c_str(), "No username and password found in the keystore, using default values.");
         }
         if (username.empty())
         {
-            username = "admin";
+            username = "wazuh-server";
             logWarn(m_logTag.c_str(), "No username found in the keystore, using default value.");
         }
         m_secureCommunication = SecureCommunication::builder();

--- a/src/shared_modules/keystore/src/argsParser.hpp
+++ b/src/shared_modules/keystore/src/argsParser.hpp
@@ -103,7 +103,7 @@ public:
                   << "\t-vp VALUE_PATH\t\tPath to a file containing the value to read (single line). Only use one value option at the time.\n"
                   << "\tNOTE: if both value parameters are empty, stdin will be read.\n"
                   << "\nExample:"
-                  << "\n\t./wazuh-manager-keystore -f indexer -k username -v admin\n"
+                  << "\n\t./wazuh-manager-keystore -f indexer -k username -v wazuh-server\n"
                   << "\n\t./wazuh-manager-keystore -f indexer -k password -vp /path/to/file.txt\n"
                   << "\n\t./wazuh-manager-keystore -f indexer -k password < /path/to/file.txt\n"
                   << "\n\techo 'pass' | ./wazuh-manager-keystore -f indexer -k password\n"

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -547,7 +547,7 @@ class InventorySyncFacadeImpl final
                         }
                         else
                         {
-                            result["value"] = "admin";
+                            result["value"] = "wazuh-server";
                         }
                     }
                     else if (queryOp == "PUT")


### PR DESCRIPTION
## Description

As part of the Indexer API RBAC revamp, the Wazuh Manager must stop using the Indexer `admin` user and operate with the new restricted `wazuh-server` user, following the principle of least privilege defined for Manager interactions with the Indexer.

This PR replaces the default `admin` Indexer user with `wazuh-server` across all Manager-to-Indexer authentication paths (C++ and Python), and updates the credential provisioning defaults and documentation accordingly.

Closes #36311

## Proposed Changes

- **C++ indexer-connector** — change the fallback credentials used when the keystore is empty from `admin/admin` to `wazuh-server/wazuh-server`, in both the synchronous and asynchronous implementations.
- **Engine configuration** — change the `WAZUH_INDEXER_USER` / `WAZUH_INDEXER_PASSWORD` default values from `admin` to `wazuh-server`.
- **Keystore socket server** — change the fallback value returned to the Python credential client (`credential_manager.py`) from `admin` to `wazuh-server`.
- **Dev environment** — update the `wazuh-manager` container entrypoint to seed the keystore with `wazuh-server` credentials.
- **Documentation** — update the installation guide and the keystore CLI usage example to reference the `wazuh-server` user.
- **Tests** — align the indexer client unit-test mocks with the new default user.

The `wazuh-server` user, its role and role-mapping are already defined on the Indexer side (`internal_users.wazuh.yml`, `roles.wazuh.yml`, `roles_mapping.wazuh.yml`), with a default password of `wazuh-server`.

## Results and Evidence
- Full E2E functions OK:
<img width="1696" height="1321" alt="image" src="https://github.com/user-attachments/assets/46d188c5-7f55-4c5c-afa0-f119acc5c995" />

### Indexer RBAC `wazuh-server` principal confirmed

```
root@ubuntu24:/vagrant/packages# sudo grep -i "wazuh-server" /var/log/wazuh-indexer/*.log 2>/dev/null | tail -10
/var/log/wazuh-indexer/wazuh-cluster.log:[2026-06-17T09:08:45,917][INFO ][o.o.s.p.PrivilegesEvaluatorImpl] [node-1] No index-level perm match for User [name=wazuh-server, backend_roles=[], requestedTenant=null] Resolved [aliases=[], allIndices=[wazuh-active-responses], types=[*], originalRequested=[wazuh-active-responses], remoteIndices=[]]: Insufficient permissions for the referenced index [Action [indices:data/read/search]] [RolesChecked [stateful-read, cm_subscription_read, stateless-write, stateful-delete, stateful-write, own_index]]
```

### Stateful indices, expected 200

```
root@ubuntu24:/vagrant/packages# U='-u wazuh-server:wazuh-server'
root@ubuntu24:/vagrant/packages# curl -sk $U "https://localhost:9200/wazuh-states-*/_count" -w "  states _count HTTP:%{http_code}\n" | tail -1
{"count":11814,"_shards":{"total":18,"successful":18,"skipped":0,"failed":0}}  states _count HTTP:200
root@ubuntu24:/vagrant/packages# curl -sk $U "https://localhost:9200/wazuh-states-vulnerabilities/_count" -w "  vuln _count HTTP:%{http_code}\n" | tail -1
{"count":3643,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0}}  vuln _count HTTP:200
```

### Indices outside current role scope, expected 403


```
root@ubuntu24:/vagrant/packages# curl -sk $U "https://localhost:9200/_plugins/_security/api/internalusers" -w "  security API HTTP:%{http_code}\n" | tail -1
{"status":"FORBIDDEN","message":"No permission to access REST API: User wazuh-server with Security roles [stateful-read, cm_subscription_read, stateless-write, stateful-delete, stateful-write, own_index] does not have any role privileged for admin access. No client TLS certificate found in request"}  security API HTTP:403
root@ubuntu24:/vagrant/packages# curl -sk $U -XDELETE "https://localhost:9200/wazuh-states-vulnerabilities" -w "  delete index HTTP:%{http_code}\n" | tail -1
{"error":{"root_cause":[{"type":"security_exception","reason":"no permissions for [indices:admin/delete] and User [name=wazuh-server, backend_roles=[], requestedTenant=null]"}],"type":"security_exception","reason":"no permissions for [indices:admin/delete] and User [name=wazuh-server, backend_roles=[], requestedTenant=null]"},"status":403}  delete index HTTP:403
```



