### PR TITLE
Fix RBAC permission check to verify allow effect in update_config rules

### DIFF
--- a/framework/wazuh/rbac/decorators.py
+++ b/framework/wazuh/rbac/decorators.py
@@ -520,7 +520,7 @@ def _has_update_permissions() -> bool:
     perms = rbac.get() or {}
     for action in ("manager:update_config", "cluster:update_config"):
         action_map = perms.get(action)
-        if isinstance(action_map, dict) and len(action_map) > 0:
+        if isinstance(action_map, dict) and any(effect == 'allow' for effect in action_map.values()):
             return True
     return False
 

--- a/framework/wazuh/rbac/tests/test_decorators.py
+++ b/framework/wazuh/rbac/tests/test_decorators.py
@@ -238,6 +238,76 @@ def test_has_update_permissions_none_rbac(db_setup):
     assert db_setup._has_update_permissions() is False
 
 
+def test_has_update_permissions_deny_manager_update_config(db_setup):
+    """Returns False when manager:update_config has effect=deny."""
+    db_setup.rbac.set({'rbac_mode': 'white', 'manager:update_config': {'*:*': 'deny'}})
+    assert db_setup._has_update_permissions() is False
+
+
+def test_has_update_permissions_deny_cluster_update_config(db_setup):
+    """Returns False when cluster:update_config has effect=deny."""
+    db_setup.rbac.set({'rbac_mode': 'white', 'cluster:update_config': {'node:id:master-node': 'deny'}})
+    assert db_setup._has_update_permissions() is False
+
+
+def test_has_update_permissions_mixed_deny_allow_allows(db_setup):
+    """Returns True when at least one resource carries allow, even if others carry deny."""
+    db_setup.rbac.set({
+        'rbac_mode': 'white',
+        'manager:update_config': {
+            'node:id:worker-1': 'deny',
+            'node:id:master': 'allow'
+        }
+    })
+    assert db_setup._has_update_permissions() is True
+
+
+def test_has_update_permissions_all_deny(db_setup):
+    """Returns False when all resources carry deny."""
+    db_setup.rbac.set({
+        'rbac_mode': 'white',
+        'manager:update_config': {
+            'node:id:worker-1': 'deny',
+            'node:id:worker-2': 'deny'
+        }
+    })
+    assert db_setup._has_update_permissions() is False
+
+
+def test_mask_sensitive_config_raw_xml_with_deny_rule(db_setup):
+    """Verifies that cluster.key is masked when user has manager:update_config deny rule."""
+    db_setup.rbac.set({
+        'rbac_mode': 'white',
+        'manager:read': {'*:*': 'allow'},
+        'manager:update_config': {'*:*': 'deny'}
+    })
+
+    @db_setup.mask_sensitive_config()
+    def get_conf_raw():
+        return _XML_WITH_CLUSTER_KEY
+
+    result = get_conf_raw()
+    assert "SECRETCLUSTERKEY" not in result
+    assert "<key>*****</key>" in result
+
+
+def test_mask_sensitive_config_raw_xml_with_cluster_deny_rule(db_setup):
+    """Verifies that cluster.key is masked when user has cluster:update_config deny rule."""
+    db_setup.rbac.set({
+        'rbac_mode': 'white',
+        'cluster:read': {'*:*': 'allow'},
+        'cluster:update_config': {'node:id:master-node': 'deny'}
+    })
+
+    @db_setup.mask_sensitive_config()
+    def get_conf_raw():
+        return _XML_WITH_CLUSTER_KEY
+
+    result = get_conf_raw()
+    assert "SECRETCLUSTERKEY" not in result
+    assert "<key>*****</key>" in result
+
+
 # ---------------------------------------------------------------------------
 # Tests for raw XML masking ( _mask_payload str branch)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

This PR fixes an issue in the RBAC permission verification logic where deny rules were incorrectly interpreted as granted permissions. The `_has_update_permissions()` function was only checking if an action map existed, without verifying whether the effect was `allow` or `deny`.

This caused the sensitive configuration masking to be disabled for users with explicit deny rules on `manager:update_config` or `cluster:update_config`, when it should have remained enabled.

**Credit:** Issue reported by @ImDuong.

## Proposed Changes

### Modified Files

- `framework/wazuh/rbac/decorators.py`: Updated `_has_update_permissions()` to check for `effect='allow'`
- `framework/wazuh/rbac/tests/test_decorators.py`: Added test coverage for deny rule handling

### Key Change

The permission check now verifies that at least one resource has `effect='allow'` instead of just checking if the action map is non-empty:

```python
# Before
if isinstance(action_map, dict) and len(action_map) > 0:
    return True

# After
if isinstance(action_map, dict) and any(effect == 'allow' for effect in action_map.values()):
    return True
```

### Results and Evidence

All 130 tests pass successfully, including 6 new tests specifically covering:
- Deny rules on `manager:update_config`
- Deny rules on `cluster:update_config`
- Mixed allow/deny scenarios
- End-to-end masking behavior with deny rules

```
================== 130 passed, 8 warnings in 79.76s ==================
```

### Artifacts Affected

- **Component:** RBAC Authorization
- **Module:** `wazuh.rbac.decorators`
- **Function:** `_has_update_permissions()`
- **Decorator:** `@mask_sensitive_config()`

### Configuration Changes

None. This is a code-only fix with no configuration changes required.

### Documentation Updates

None required. The fix corrects internal behavior without changing the external API or user-facing functionality.

### Tests Introduced

Added 6 new test cases in `framework/wazuh/rbac/tests/test_decorators.py`:

1. `test_has_update_permissions_deny_manager_update_config` - Verifies deny on manager:update_config returns False
2. `test_has_update_permissions_deny_cluster_update_config` - Verifies deny on cluster:update_config returns False
3. `test_has_update_permissions_mixed_deny_allow_allows` - Verifies mixed rules return True when at least one allow exists
4. `test_has_update_permissions_all_deny` - Verifies all deny rules return False
5. `test_mask_sensitive_config_raw_xml_with_deny_rule` - End-to-end test with manager:update_config deny
6. `test_mask_sensitive_config_raw_xml_with_cluster_deny_rule` - End-to-end test with cluster:update_config deny

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented (N/A)
- [ ] Developer documentation reflects the changes (N/A - internal fix)
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
