### PR TITLE
Bound decompressed size when processing sync archives

### DIFF
--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -459,6 +459,38 @@ async def async_decompress_files(zip_path, ko_files_name="files_metadata.json"):
     return decompress_files(zip_path, ko_files_name)
 
 
+def decompress_to_file(content, full_path, max_size):
+    """Decompress a single archive member to disk, bounding the decompressed size.
+
+    The compressed content is decompressed in fixed-size chunks that are written to disk
+    as they are produced, so the peak memory usage is limited to one chunk regardless of
+    the decompressed size. This prevents a peer-supplied member from forcing the whole
+    decompressed payload to be materialised in memory at once. If the decompressed output
+    exceeds 'max_size', an exception is raised; the partial output is cleaned up by the
+    caller.
+
+    Parameters
+    ----------
+    content : bytes
+        Compressed content of the archive member.
+    full_path : str
+        Destination path where the decompressed content is written.
+    max_size : int
+        Maximum allowed decompressed size, in bytes.
+    """
+    decompressor = zlib.decompressobj()
+    chunk_size = 1024 * 1024  # 1 MiB
+    total = 0
+    with open(full_path, 'wb') as f:
+        chunk = decompressor.decompress(content, chunk_size)
+        while chunk:
+            total += len(chunk)
+            if total > max_size:
+                raise WazuhInternalError(3053)
+            f.write(chunk)
+            chunk = decompressor.decompress(decompressor.unconsumed_tail, chunk_size)
+
+
 def decompress_files(compress_path, ko_files_name="files_metadata.json"):
     """Decompress files in a directory and load the files_metadata.json as a dict.
 
@@ -483,6 +515,7 @@ def decompress_files(compress_path, ko_files_name="files_metadata.json"):
     compressed_data = b''
     window_size = 1024 * 1024 * 10  # 10 MiB
     decompress_dir = compress_path + 'dir'
+    max_zip_size = get_cluster_items()['intervals']['communication']['max_zip_size']
 
     try:
         mkdir_with_mode(decompress_dir)
@@ -498,7 +531,6 @@ def decompress_files(compress_path, ko_files_name="files_metadata.json"):
 
                 for file in files:
                     filepath, content = file.split(PATH_SEP.encode(), 1)
-                    content = zlib.decompress(content)
                     full_path = safe_join(decompress_dir, filepath.decode())
                     if not os.path.exists(os.path.dirname(full_path)):
                         try:
@@ -506,8 +538,7 @@ def decompress_files(compress_path, ko_files_name="files_metadata.json"):
                         except OSError as exc:  # Guard against race condition
                             if exc.errno != errno.EEXIST:
                                 raise
-                    with open(full_path, 'wb') as f:
-                        f.write(content)
+                    decompress_to_file(content, full_path, max_zip_size)
 
                 if not new_data:
                     break

--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -466,8 +466,8 @@ def decompress_to_file(content, full_path, max_size):
     as they are produced, so the peak memory usage is limited to one chunk regardless of
     the decompressed size. This prevents a peer-supplied member from forcing the whole
     decompressed payload to be materialised in memory at once. If the decompressed output
-    exceeds 'max_size', an exception is raised; the partial output is cleaned up by the
-    caller.
+    exceeds 'max_size', or the compressed stream is truncated or corrupted, an exception is
+    raised; the partial output is cleaned up by the caller.
 
     Parameters
     ----------
@@ -477,6 +477,11 @@ def decompress_to_file(content, full_path, max_size):
         Destination path where the decompressed content is written.
     max_size : int
         Maximum allowed decompressed size, in bytes.
+
+    Returns
+    -------
+    int
+        Number of decompressed bytes written.
     """
     decompressor = zlib.decompressobj()
     chunk_size = 1024 * 1024  # 1 MiB
@@ -489,6 +494,12 @@ def decompress_to_file(content, full_path, max_size):
                 raise WazuhInternalError(3053)
             f.write(chunk)
             chunk = decompressor.decompress(decompressor.unconsumed_tail, chunk_size)
+        # A complete zlib stream sets 'eof' after its trailing checksum is validated.
+        # Reject truncated or corrupted members, mirroring the check zlib.decompress() does.
+        if not decompressor.eof:
+            raise zlib.error('Error -5 while decompressing data: incomplete or truncated stream')
+
+    return total
 
 
 def decompress_files(compress_path, ko_files_name="files_metadata.json"):
@@ -516,6 +527,7 @@ def decompress_files(compress_path, ko_files_name="files_metadata.json"):
     window_size = 1024 * 1024 * 10  # 10 MiB
     decompress_dir = compress_path + 'dir'
     max_zip_size = get_cluster_items()['intervals']['communication']['max_zip_size']
+    total_decompressed = 0
 
     try:
         mkdir_with_mode(decompress_dir)
@@ -538,7 +550,10 @@ def decompress_files(compress_path, ko_files_name="files_metadata.json"):
                         except OSError as exc:  # Guard against race condition
                             if exc.errno != errno.EEXIST:
                                 raise
-                    decompress_to_file(content, full_path, max_zip_size)
+                    # Bound the aggregate decompressed size across all members, not just per
+                    # member, so an archive cannot exceed max_zip_size by stacking entries.
+                    total_decompressed += decompress_to_file(content, full_path,
+                                                             max_zip_size - total_decompressed)
 
                 if not new_data:
                     break

--- a/framework/wazuh/core/cluster/tests/test_cluster.py
+++ b/framework/wazuh/core/cluster/tests/test_cluster.py
@@ -393,7 +393,7 @@ async def test_async_decompress_files(decompress_files_mock):
 @pytest.mark.asyncio
 @patch('wazuh.core.cluster.cluster.get_cluster_items',
        return_value={'intervals': {'communication': {'max_zip_size': 1073741824}}})
-@patch('wazuh.core.cluster.cluster.decompress_to_file')
+@patch('wazuh.core.cluster.cluster.decompress_to_file', return_value=0)
 @patch('os.makedirs')
 @patch('os.path.exists', side_effect=[False, True, True])
 @patch('wazuh.core.cluster.cluster.remove')
@@ -426,8 +426,9 @@ def test_decompress_to_file_ok(tmp_path):
     content = b'A' * 1024
     dest = str(tmp_path / 'out.bin')
 
-    cluster.decompress_to_file(zlib.compress(content), dest, max_size=1024 * 1024)
+    written = cluster.decompress_to_file(zlib.compress(content), dest, max_size=1024 * 1024)
 
+    assert written == len(content)
     with open(dest, 'rb') as f:
         assert f.read() == content
 
@@ -443,6 +444,32 @@ def test_decompress_to_file_exceeds_limit(tmp_path):
 
     with pytest.raises(WazuhInternalError, match=r'.* 3053 .*'):
         cluster.decompress_to_file(bomb, dest, max_size=10 * 1024 * 1024)
+
+
+def test_decompress_to_file_truncated(tmp_path):
+    """Check that a truncated/corrupted member is rejected instead of silently accepted."""
+    compressed = zlib.compress(b'Z' * 4096)
+    dest = str(tmp_path / 'trunc.bin')
+
+    with pytest.raises(zlib.error):
+        cluster.decompress_to_file(compressed[:-2], dest, max_size=1024 * 1024)
+
+
+@patch('wazuh.core.cluster.cluster.get_cluster_items',
+       return_value={'intervals': {'communication': {'max_zip_size': 1500}}})
+def test_decompress_files_aggregate_limit(get_cluster_items_mock, tmp_path):
+    """Two members each under the cap but exceeding it in aggregate must be rejected."""
+    path_sep = cluster.PATH_SEP.encode()
+    file_sep = cluster.FILE_SEP.encode()
+    archive = (b'a.txt' + path_sep + zlib.compress(b'A' * 1000) + file_sep +
+               b'b.txt' + path_sep + zlib.compress(b'B' * 1000) + file_sep +
+               b'pad' + path_sep + zlib.compress(b''))
+    zip_path = str(tmp_path / 'agg.zip')
+    with open(zip_path, 'wb') as f:
+        f.write(archive)
+
+    with pytest.raises(WazuhInternalError, match=r'.* 3053 .*'):
+        cluster.decompress_files(zip_path)
 
 
 @pytest.mark.asyncio

--- a/framework/wazuh/core/cluster/tests/test_cluster.py
+++ b/framework/wazuh/core/cluster/tests/test_cluster.py
@@ -391,14 +391,16 @@ async def test_async_decompress_files(decompress_files_mock):
 
 
 @pytest.mark.asyncio
-@patch('zlib.decompress')
+@patch('wazuh.core.cluster.cluster.get_cluster_items',
+       return_value={'intervals': {'communication': {'max_zip_size': 1073741824}}})
+@patch('wazuh.core.cluster.cluster.decompress_to_file')
 @patch('os.makedirs')
 @patch('os.path.exists', side_effect=[False, True, True])
 @patch('wazuh.core.cluster.cluster.remove')
 @patch('wazuh.core.cluster.cluster.mkdir_with_mode')
 @patch('json.loads', return_value="some string with files")
 async def test_decompress_files_ok(json_loads_mock, mkdir_with_mode_mock, remove_mock, os_path_exists_mock,
-                                   mock_makedirs, zlib_mock):
+                                   mock_makedirs, decompress_to_file_mock, get_cluster_items_mock):
     """Check if the decompressing function is working properly."""
     zip_path = '/foo/bar/'
     compress_data = f'path{cluster.PATH_SEP}content{cluster.FILE_SEP}path2{cluster.PATH_SEP}content2'.encode()
@@ -410,20 +412,46 @@ async def test_decompress_files_ok(json_loads_mock, mkdir_with_mode_mock, remove
         ko_files, zip_dir = cluster.decompress_files(compress_path=zip_path)
         assert ko_files == "some string with files"
         assert zip_dir == zip_path + 'dir'
-        zlib_mock.assert_has_calls([call(b'content'), call(b'content2')])
+        decompress_to_file_mock.assert_has_calls([call(b'content', '/foo/bar/dir/path', 1073741824),
+                                                  call(b'content2', '/foo/bar/dir/path2', 1073741824)])
         mock_makedirs.assert_called_once_with(zip_path + 'dir')
         json_loads_mock.assert_called_once()
         mkdir_with_mode_mock.assert_called_once_with(zip_dir)
         remove_mock.assert_called_once_with(zip_path)
-        assert open_mock.call_args_list == [call('/foo/bar/', 'rb'), call('/foo/bar/dir/path', 'wb'),
-                                            call('/foo/bar/dir/path2', 'wb'), call('/foo/bar/dir/files_metadata.json')]
+        assert open_mock.call_args_list == [call('/foo/bar/', 'rb'), call('/foo/bar/dir/files_metadata.json')]
+
+
+def test_decompress_to_file_ok(tmp_path):
+    """Check that a compressed member is decompressed and written to disk."""
+    content = b'A' * 1024
+    dest = str(tmp_path / 'out.bin')
+
+    cluster.decompress_to_file(zlib.compress(content), dest, max_size=1024 * 1024)
+
+    with open(dest, 'rb') as f:
+        assert f.read() == content
+
+
+def test_decompress_to_file_exceeds_limit(tmp_path):
+    """Check that a decompression bomb is rejected once the size cap is exceeded."""
+    # ~100 MiB of 'A' compresses to a few KiB but must be rejected when the cap is lower.
+    co = zlib.compressobj(9)
+    parts = [co.compress(b'A' * (1024 * 1024)) for _ in range(100)]
+    parts.append(co.flush())
+    bomb = b''.join(parts)
+    dest = str(tmp_path / 'bomb.bin')
+
+    with pytest.raises(WazuhInternalError, match=r'.* 3053 .*'):
+        cluster.decompress_to_file(bomb, dest, max_size=10 * 1024 * 1024)
 
 
 @pytest.mark.asyncio
+@patch('wazuh.core.cluster.cluster.get_cluster_items',
+       return_value={'intervals': {'communication': {'max_zip_size': 1073741824}}})
 @patch('shutil.rmtree')
-@patch('zlib.decompress', return_value=Exception)
+@patch('wazuh.core.cluster.cluster.decompress_to_file', side_effect=Exception)
 @patch('wazuh.core.cluster.cluster.mkdir_with_mode')
-async def test_decompress_files_ko(mkdir_with_mode_mock, zlib_mock, rmtree_mock):
+async def test_decompress_files_ko(mkdir_with_mode_mock, decompress_to_file_mock, rmtree_mock, get_cluster_items_mock):
     """Check if the decompressing function is raising the necessary exceptions."""
 
     # Raising the expected Exception
@@ -433,7 +461,7 @@ async def test_decompress_files_ko(mkdir_with_mode_mock, zlib_mock, rmtree_mock)
         with patch('os.path.exists', return_value=True) as os_path_exists_mock:
             assert cluster.decompress_files(zip_dir) == "some string with files", zip_dir + "dir"
             mkdir_with_mode_mock.assert_called_once_with(zip_dir)
-            zlib_mock.assert_called_once()
+            decompress_to_file_mock.assert_called_once()
             os_path_exists_mock.assert_called_once()
             rmtree_mock.assert_called_once()
 

--- a/framework/wazuh/core/cluster/tests/test_cluster.py
+++ b/framework/wazuh/core/cluster/tests/test_cluster.py
@@ -393,7 +393,7 @@ async def test_async_decompress_files(decompress_files_mock):
 @pytest.mark.asyncio
 @patch('wazuh.core.cluster.cluster.get_cluster_items',
        return_value={'intervals': {'communication': {'max_zip_size': 1073741824}}})
-@patch('wazuh.core.cluster.cluster.decompress_to_file', return_value=0)
+@patch('wazuh.core.cluster.cluster.decompress_to_file', side_effect=[100, 200])
 @patch('os.makedirs')
 @patch('os.path.exists', side_effect=[False, True, True])
 @patch('wazuh.core.cluster.cluster.remove')
@@ -412,8 +412,10 @@ async def test_decompress_files_ok(json_loads_mock, mkdir_with_mode_mock, remove
         ko_files, zip_dir = cluster.decompress_files(compress_path=zip_path)
         assert ko_files == "some string with files"
         assert zip_dir == zip_path + 'dir'
+        # The second member's budget must be reduced by the first member's decompressed size,
+        # exercising the rolling 'max_zip_size - total_decompressed' aggregate budget.
         decompress_to_file_mock.assert_has_calls([call(b'content', '/foo/bar/dir/path', 1073741824),
-                                                  call(b'content2', '/foo/bar/dir/path2', 1073741824)])
+                                                  call(b'content2', '/foo/bar/dir/path2', 1073741824 - 100)])
         mock_makedirs.assert_called_once_with(zip_path + 'dir')
         json_loads_mock.assert_called_once()
         mkdir_with_mode_mock.assert_called_once_with(zip_dir)
@@ -470,6 +472,9 @@ def test_decompress_files_aggregate_limit(get_cluster_items_mock, tmp_path):
 
     with pytest.raises(WazuhInternalError, match=r'.* 3053 .*'):
         cluster.decompress_files(zip_path)
+
+    # On rejection, decompress_files must remove the partial decompressed output.
+    assert not os.path.exists(zip_path + 'dir')
 
 
 @pytest.mark.asyncio

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -528,6 +528,7 @@ class WazuhException(Exception):
         3050: "Payload size exceeds maximum allowed limit",
         3051: "Too many concurrent divided messages",
         3052: "Invalid cluster file parameter",
+        3053: "Decompressed file exceeds the maximum allowed size",
         3060: {'message': "Invalid node name format",
                'remediation': f"Check and fix [worker names](https://documentation.wazuh.com/{DOCU_VERSION}/"
                               f"user-manual/reference/ossec-conf/cluster.html#node-name)"


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/internal-devel-requests/issues/4975|

## Description

`decompress_files` decompressed every peer-supplied archive member with a single
unbounded `zlib.decompress(content)` call, materialising the full decompressed
payload in memory before writing it to disk. A peer holding the cluster key could
upload a small extra-valid sync archive whose member decompresses to gigabytes
(amplification ~1000:1) and force the master to allocate that payload transiently,
which can OOM-kill `wazuh-clusterd` on a default-sized manager.

The sender (`compress_files`) already caps outbound files at `max_zip_size`, but the
receiver enforced no corresponding bound on decompressed size.

This PR replaces the single decompress call with a streaming decompression
(`zlib.decompressobj()`) that writes the output to disk in fixed 1 MiB chunks and
rejects any member whose decompressed size exceeds `max_zip_size`, mirroring the
sender-side cap. Peak memory is now bounded to a single chunk regardless of the
decompressed size, and oversized members raise error `3053` (cleaning up the partial
output).

## Changes

- `framework/wazuh/core/cluster/cluster.py`: new `decompress_to_file()` helper; `decompress_files()` now streams each member to disk under the `max_zip_size` budget.
- `framework/wazuh/core/exception.py`: new error `3053` "Decompressed file exceeds the maximum allowed size".
- `framework/wazuh/core/cluster/tests/test_cluster.py`: updated existing decompression tests and added regression tests (round-trip + bomb rejection).

## Tests

- [x] Unit tests pass (`test_cluster.py`, `test_exception.py`).
- Verified out of band that a 200 MiB bomb (~200 KB on the wire) is rejected with peak process allocation bounded to ~1 chunk instead of materialising the full payload.


## Manual testing

Tested on the official `wazuh/wazuh-manager:4.14.5` image, calling the real
`decompress_files()` with a malicious sync archive (wire format `PATH_SEP`/`FILE_SEP`,
`max_zip_size = 1 GiB`), measuring worker RSS. Stock code vs this fix.

| Test (bomb → decompressed) | Stock 4.14.5 | With fix |
|---|---|---|
| 500 MiB, ~510 KB wire (under cap) | peak **976.6 MiB**, processed | peak **57.2 MiB**, processed |
| 1500 MiB, ~1.5 MB wire (over cap) | peak **~3 GiB**, processed | peak **62.1 MiB**, **rejected (3053)** |
| 1500 MiB, manager capped at 1.5 GiB RAM | **OOM-killed (SIGKILL)** | survives, **rejected (3053)** |
| Legitimate multi-chunk archive | — | decompressed byte-exact |

Output:

```
# 500 MiB bomb
STOCK   : peak RSS 976.6 MiB | SUCCEEDED
FIX     : peak RSS  57.2 MiB | SUCCEEDED

# 1500 MiB bomb
STOCK   : peak RSS 3001.3 MiB | SUCCEEDED
FIX     : peak RSS   62.1 MiB | REJECTED -> WazuhInternalError 3053 (Decompressed file exceeds the maximum allowed size)

# 1500 MiB bomb, container --memory=1500m
STOCK   : peak RSS 1499.5 MiB | PROCESS KILLED by signal 9 (OOM)
FIX     : peak RSS   62.0 MiB | REJECTED -> WazuhInternalError 3053

# legitimate archive (3 MiB binary spanning multiple chunks + XML)
FIX     : r1 (3 MiB) matches: True | r2 (xml) matches: True | metadata loaded OK
```

Peak memory is bounded to one chunk regardless of decompressed size, oversized members are
rejected, the OOM is prevented, and legitimate decompression is unaffected.

## Credit

Thanks to @moltenbit for reporting this issue.