### PR TITLE
Refactor repeated regex usage

### DIFF
--- a/src/engine/tools/engine-bench/src/engine_bench/scripts/flamegraph.pl
+++ b/src/engine/tools/engine-bench/src/engine_bench/scripts/flamegraph.pl
@@ -647,12 +647,12 @@ foreach (<>) {
 	$line = $_;
 	if ($stackreverse) {
 		# there may be an extra samples column for differentials
-		# XXX todo: redo these REs as one. It's repeated below.
-		my($stack, $samples) = (/^(.*)\s+?(\d+(?:\.\d*)?)$/);
+		my $re = qr/^(.*)\s+?(\d+(?:\.\d*)?)$/;
+		my($stack, $samples) = $line =~ $re;
 		my $samples2 = undef;
-		if ($stack =~ /^(.*)\s+?(\d+(?:\.\d*)?)$/) {
+		if (defined $stack && $stack =~ $re) {
 			$samples2 = $samples;
-			($stack, $samples) = $stack =~ (/^(.*)\s+?(\d+(?:\.\d*)?)$/);
+			($stack, $samples) = $stack =~ $re;
 			unshift @Data, join(";", reverse split(";", $stack)) . " $samples $samples2";
 		} else {
 			unshift @Data, join(";", reverse split(";", $stack)) . " $samples";


### PR DESCRIPTION
## Description

This pull request refactors duplicated regular expression usage in flamegraph.pl by extracting the pattern into a reusable variable.


## Proposed Changes

Extracted repeated regular expression into a single reusable variable


### Results and Evidence

Verified locally using identical input data. Output differences were only due to ordering; after normalizing the output by sorting, no functional changes were seen. Behaviour remains unchanged.


### Manual tests with their corresponding evidence

N/A

### Artifacts Affected

src/engine/tools/engine-bench/src/engine_bench/scripts/flamegraph.pl


### Configuration Changes

N/A

### Tests Introduced

N/A

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

