### PR TITLE
Update bumper script and bump git refs version

### DIFF
--- a/tools/get_git_refs.sh
+++ b/tools/get_git_refs.sh
@@ -34,13 +34,13 @@ METHODS (executed in order):
     1. Git command OR .git directory: Returns current branch and/or tag
        - Method 1 and 2 are mutually exclusive (git command takes precedence)
     2. VERSION.json: Always executed, returns branch and tag based on version
-       - Special case: version 5.0.0 also returns refs/heads/main as fallback
+       - Special case: version 5.0.1 also returns refs/heads/main as fallback
 
 EXAMPLES:
     $ $(basename "$0")
     refs/heads/enhancement/32855-checkout-indexer-templates
-    refs/heads/5.0.0
-    refs/tags/v5.0.0
+    refs/heads/5.0.1
+    refs/tags/v5.0.1
     refs/heads/main
 
     $ $(basename "$0")  # On a tagged commit with version 4.14.0
@@ -185,8 +185,8 @@ get_version_json_refs() {
     if [ -n "$version" ]; then
         echo "refs/heads/$version"
 
-        # Special case: for version 5.0.0, also try main branch as fallback
-        if [ "$version" = "5.0.0" ]; then
+        # Special case: for version 5.0.1, also try main branch as fallback
+        if [ "$version" = "5.0.1" ]; then
             echo "refs/heads/main"
         fi
 

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -535,6 +535,27 @@ update_root_changelog() {
     log_action "Modified $changelog_file with new version: $new_version"
 }
 
+update_file_git_refs() {
+    local new_version="$1"
+
+    [[ -z "$new_version" ]] && return
+
+    local refs_file="$DIR_ROOT/tools/get_git_refs.sh"
+    local current_version
+    current_version=$(grep -E 'if \[ "\$version" = "[0-9]+\.[0-9]+\.[0-9]+" \]' "$refs_file" \
+        | sed -E 's/.*if \[ "\$version" = "([0-9]+\.[0-9]+\.[0-9]+)" \].*/\1/')
+
+    if [[ -n "$current_version" && "$current_version" != "$new_version" ]]; then
+        local old_escaped="${current_version//./\\.}"
+        sed -i -E "s|(if \[ \"\\\$version\" = \")${old_escaped}(\" \])|\1${new_version}\2|" "$refs_file"
+        sed -i -E "s|(# Special case: for version )${old_escaped}(,)|\1${new_version}\2|" "$refs_file"
+        sed -i -E "s|(- Special case: version )${old_escaped}( also returns)|\1${new_version}\2|" "$refs_file"
+        sed -i -E "s|(refs/heads/)${old_escaped}$|\1${new_version}|" "$refs_file"
+        sed -i -E "s|(refs/tags/v)${old_escaped}$|\1${new_version}|" "$refs_file"
+        log_action "Modified $refs_file with new version: $new_version"
+    fi
+}
+
 update_version() {
     local current_version="$1"
     local current_stage="$2"
@@ -551,6 +572,7 @@ update_version() {
     update_file_sources "$new_version" "$new_stage"
     update_file_framework "$new_version" "$new_stage"
     update_file_api "$new_version" "$new_stage"
+    update_file_git_refs "$new_version"
     update_root_changelog "$new_version"
 
     local final_version="${new_version:-$current_version}"


### PR DESCRIPTION
## Summary

- **`tools/get_git_refs.sh`:** Changed all three hard-coded `5.0.0` references to `5.0.1` — the docstring comment, the example output lines, the inline code comment, and the actual condition `if [ "$version" = "5.0.1" ]`.

- **`tools/repository_bumper.sh`:** Added `update_file_git_refs()` (before `update_version()`), modeled on `update_file_framework`'s direct `sed -i` pattern. It returns early on empty `new_version`, greps the current hard-coded version out of the `if [ "$version" = "..." ]` line, and only rewrites when it differs — updating the condition, the inline comment, the docstring comment, and the `refs/heads/`/`refs/tags/v` example lines, then logging via `log_action`. It's wired into `update_version()` as `update_file_git_refs "$new_version"`, placed before `update_file_packages`.


### Results and Evidence

- `bash -n` passes on both files.
- Sanity greps confirm `get_git_refs.sh` is on `5.0.1` and the function is defined and called.
- A functional dry-run on a copy (simulating a 5.0.1 → 5.0.2 bump) correctly updated all five locations **and left the unrelated `4.14.0` example block untouched**.

