### PR TITLE
Add cluster readiness endpoint

### DIFF
--- a/api/api/controllers/cluster_controller.py
+++ b/api/api/controllers/cluster_controller.py
@@ -217,7 +217,11 @@ async def get_config(pretty: bool = False, wait_for_complete: bool = False) -> C
 
 
 async def get_status_node(node_id: str, pretty: bool = False, wait_for_complete: bool = False) -> ConnexionResponse:
-    """Get a specified node's Wazuh daemons status.
+    """Get a specified node's status (whether it is ready to process events).
+
+    Reports per-daemon status (`ready` + `running`); analysisd embeds the engine resources
+    (spaces/IOC/geo) and modulesd embeds vulnerability-detector. The node is ready only when every
+    daemon is ready.
 
     Parameters
     ----------

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -6921,8 +6921,8 @@ paths:
     get:
       tags:
         - Cluster
-      summary: "Get node status"
-      description: "Return the status of all Wazuh daemons in node node_id"
+      summary: "Get node readiness"
+      description: "Return whether the node is ready to process events. Each daemon reports running (PID check) and ready; analysisd embeds the engine resources (spaces/IOC/geo) and modulesd embeds vulnerability-detector. The node-level ready is true only when every daemon is ready."
       operationId: api.controllers.cluster_controller.get_status_node
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/cluster:read'
@@ -6932,7 +6932,7 @@ paths:
         - $ref: '#/components/parameters/node_id'
       responses:
         '200':
-          description: "Node wazuh daemons statuses"
+          description: "Node readiness"
           content:
             application/json:
               schema:
@@ -6941,22 +6941,54 @@ paths:
                   - type: object
                     properties:
                       data:
-                        $ref: '#/components/schemas/WazuhDaemonsStatus'
+                        type: object
+                        properties:
+                          affected_items:
+                            type: array
+                            items:
+                              type: object
+                              additionalProperties: true
+                          total_affected_items:
+                            type: integer
+                          total_failed_items:
+                            type: integer
+                          failed_items:
+                            type: array
+                            items:
+                              type: object
               example:
                 data:
                   affected_items:
-                    - wazuh-manager-analysisd: running
-                      wazuh-manager-authd: stopped
-                      wazuh-manager-monitord: running
-                      wazuh-manager-remoted: running
-                      wazuh-manager-apid: running
-                      wazuh-manager-clusterd: running
-                      wazuh-manager-db: running
-                      wazuh-manager-modulesd: running
+                    - ready: false
+                      wazuh-manager-analysisd:
+                        ready: false
+                        running: true
+                        spaces:
+                          standard: { available: true, enabled: true, status: ready, hash: "abc", last_successful_update: 1750068600 }
+                          custom: { available: false, enabled: false, status: ready, hash: "", last_successful_update: 0 }
+                        ioc:
+                          connection: { available: true, status: ready, hash: "h", last_successful_update: 1750068600 }
+                          url_domain: { available: true, status: ready, hash: "h", last_successful_update: 1750068600 }
+                          url_full: { available: true, status: ready, hash: "h", last_successful_update: 1750068600 }
+                          hash_md5: { available: true, status: ready, hash: "h", last_successful_update: 1750068600 }
+                          hash_sha1: { available: true, status: ready, hash: "h", last_successful_update: 1750068600 }
+                          hash_sha256: { available: true, status: ready, hash: "h", last_successful_update: 1750068600 }
+                        geo:
+                          city: { available: true, status: ready, hash: "h", last_successful_update: 1750066800 }
+                          asn: { available: false, status: running, hash: "", last_successful_update: 0 }
+                      wazuh-manager-modulesd:
+                        ready: true
+                        running: true
+                        vulnerability-detector: { available: true, status: ready, enabled: true, offset: 0, last_successful_update: 0 }
+                      wazuh-manager-remoted: { ready: true, running: true }
+                      wazuh-manager-db: { ready: true, running: true }
+                      wazuh-manager-authd: { ready: false, running: false }
+                      wazuh-manager-clusterd: { ready: true, running: true }
+                      wazuh-manager-apid: { ready: true, running: true }
                   total_affected_items: 1
                   total_failed_items: 0
                   failed_items: []
-                message: "Processes status was successfully read in specified node"
+                message: "Node readiness was successfully read in specified node"
                 error: 0
         '400':
           $ref: '#/components/responses/ResponseError'

--- a/framework/wazuh/core/engine_http.py
+++ b/framework/wazuh/core/engine_http.py
@@ -46,3 +46,32 @@ class EngineHTTPClient:
             return response.json()
         except ValueError as exc:
             raise WazuhInternalError(2022, extra_message=f'Invalid JSON in Engine API response: {exc}')
+
+    def get_status(self) -> dict:
+        """Retrieve the Engine readiness status from the analysisd socket.
+
+        Returns
+        -------
+        dict
+            The engine status: global `ready` flag plus per-resource state of
+            spaces, IOC databases and geo databases.
+        """
+        try:
+            response = self._client.get(
+                url=f'{self.API_URL}/status',
+                headers={'Content-Type': 'application/json'},
+            )
+        except httpx.TimeoutException as exc:
+            raise WazuhInternalError(2020, extra_message=str(exc))
+        except httpx.ConnectError as exc:
+            raise WazuhInternalError(2021, extra_message=str(exc))
+        except httpx.RequestError as exc:
+            raise WazuhError(2013, extra_message=str(exc))
+
+        if response.is_error:
+            raise WazuhError(2019, extra_message=response.text)
+
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise WazuhInternalError(2022, extra_message=f'Invalid JSON in Engine API response: {exc}')

--- a/framework/wazuh/core/tests/test_engine_http.py
+++ b/framework/wazuh/core/tests/test_engine_http.py
@@ -100,6 +100,88 @@ def test_get_metrics_dump_request_error():
     assert exc_info.value.code == 2013
 
 
+STATUS_RESPONSE = {
+    "status": "OK",
+    "ready": True,
+    "spaces": {
+        "standard": {"available": True, "enabled": True, "status": "ready", "hash": "abc", "last_successful_update": 1},
+    },
+    "ioc": {
+        "connection": {"available": True, "status": "ready", "hash": "def", "last_successful_update": 1},
+    },
+    "geo": {
+        "city": {"available": True, "status": "ready", "hash": "ghi", "last_successful_update": 1},
+    },
+}
+
+
+def test_get_status_ok():
+    client = _make_client()
+    mock_response = MagicMock()
+    mock_response.is_error = False
+    mock_response.json.return_value = STATUS_RESPONSE
+    client._client.get.return_value = mock_response
+
+    result = client.get_status()
+
+    client._client.get.assert_called_once_with(
+        url='http://localhost/status',
+        headers={'Content-Type': 'application/json'},
+    )
+    assert result == STATUS_RESPONSE
+
+
+def test_get_status_http_error():
+    client = _make_client()
+    mock_response = MagicMock()
+    mock_response.is_error = True
+    mock_response.text = 'internal error'
+    client._client.get.return_value = mock_response
+
+    with pytest.raises(WazuhError) as exc_info:
+        client.get_status()
+    assert exc_info.value.code == 2019
+
+
+def test_get_status_invalid_json():
+    client = _make_client()
+    mock_response = MagicMock()
+    mock_response.is_error = False
+    mock_response.json.side_effect = ValueError("not valid json")
+    client._client.get.return_value = mock_response
+
+    with pytest.raises(WazuhInternalError) as exc_info:
+        client.get_status()
+    assert exc_info.value.code == 2022
+
+
+def test_get_status_timeout():
+    client = _make_client()
+    client._client.get.side_effect = httpx.TimeoutException("timed out", request=MagicMock())
+
+    with pytest.raises(WazuhInternalError) as exc_info:
+        client.get_status()
+    assert exc_info.value.code == 2020
+
+
+def test_get_status_connect_error():
+    client = _make_client()
+    client._client.get.side_effect = httpx.ConnectError("refused", request=MagicMock())
+
+    with pytest.raises(WazuhInternalError) as exc_info:
+        client.get_status()
+    assert exc_info.value.code == 2021
+
+
+def test_get_status_request_error():
+    client = _make_client()
+    client._client.get.side_effect = httpx.RequestError("network error", request=MagicMock())
+
+    with pytest.raises(WazuhError) as exc_info:
+        client.get_status()
+    assert exc_info.value.code == 2013
+
+
 def test_engine_http_client_init_error():
     """Test that the client raises WazuhInternalError(2018) if httpx instantiation fails."""
     with patch('wazuh.core.common.ANALYSISD_SOCKET', '/var/wazuh-manager/queue/sockets/analysis'):

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -10,7 +10,8 @@ from wazuh.core import common, configuration
 from wazuh.core.cluster.cluster import get_node
 from wazuh.core.cluster.utils import manager_restart, manager_reload
 from wazuh.core.configuration import get_ossec_conf, write_ossec_conf
-from wazuh.core.exception import WazuhError, WazuhInternalError
+from wazuh.core.engine_http import EngineHTTPClient
+from wazuh.core.exception import WazuhError, WazuhException, WazuhInternalError
 from wazuh.core.manager import status, get_api_conf, get_wazuh_logs, \
     get_logs_summary, validate_ossec_conf, WAZUH_LOG_FIELDS
 from wazuh.core.results import AffectedItemsWazuhResult
@@ -20,23 +21,95 @@ from wazuh.rbac.decorators import expose_resources, mask_sensitive_config
 node_id = get_node().get('node')
 
 
+def _analysisd_status(running: bool) -> dict:
+    """Build the status entry for analysisd from the Engine `/status` endpoint.
+
+    The engine reports the global `ready` flag plus the per-resource state of spaces, IOC and geo
+    databases. If analysisd is not running or the engine is unreachable, the daemon is not ready.
+    """
+    if not running:
+        return {'ready': False}
+
+    client = None
+    try:
+        client = EngineHTTPClient()
+        engine = client.get_status()
+    except WazuhException:
+        # Engine unreachable / error → analysisd cannot be considered ready.
+        return {'ready': False}
+    finally:
+        if client is not None:
+            client.close()
+
+    return {
+        'ready': bool(engine.get('ready', False)),
+        'spaces': engine.get('spaces', {}),
+        'ioc': engine.get('ioc', {}),
+        'geo': engine.get('geo', {}),
+    }
+
+
+def _modulesd_status(running: bool) -> dict:
+    """Build the status entry for modulesd.
+
+    NOTE: mocked for now. The real criteria for `ready` (expected: a valid vulnerability-detector feed
+    loaded) must be agreed with the modulesd/VD team. Tracked as an open item in the issue.
+    The vulnerability-detector `status` vocabulary is: ready | updating | failed.
+    """
+    if not running:
+        return {'ready': False}
+
+    # MOCK — replace with the real modulesd ready criteria once defined by the VD team.
+    return {
+        'ready': True,
+        'vulnerability-detector': {
+            'available': True,
+            'status': 'ready',  # ready | updating | failed
+            'enabled': True,
+            'offset': 0,
+            'last_successful_update': 0,
+        },
+    }
+
+
 @expose_resources(actions=['cluster:read'], resources=[f'node:id:{node_id}'])
 def get_status() -> AffectedItemsWazuhResult:
-    """Wrapper for status().
+    """Report the node status: whether it is ready to process events, per daemon.
+
+    Each daemon exposes `running` (PID check by the framework) and `ready`. analysisd embeds the
+    Engine `/status` resources (spaces/IOC/geo); modulesd embeds vulnerability-detector (mocked).
+    Daemons without a richer status contract are ready when running. The node-level `ready` is true
+    only when every daemon is ready.
 
     Returns
     -------
     AffectedItemsWazuhResult
-        Affected items.
+        Single affected item: the node status object.
     """
-    result = AffectedItemsWazuhResult(all_msg=f"Processes status was successfully read"
-                                              f"{' in specified node' if node_id != 'manager' else ''}",
-                                      some_msg='Could not read basic information in some nodes',
-                                      none_msg=f"Could not read processes status"
-                                               f"{' in specified node' if node_id != 'manager' else ''}"
-                                      )
+    result = AffectedItemsWazuhResult(
+        all_msg=f"Node status was successfully read{' in specified node' if node_id != 'manager' else ''}",
+        none_msg=f"Could not read node status{' in specified node' if node_id != 'manager' else ''}",
+    )
 
-    result.affected_items.append(status())
+    daemons = status()  # {daemon_name: status_string}
+    node_status = {}
+    node_ready = True
+
+    for daemon, daemon_status in daemons.items():
+        running = daemon_status == 'running'
+        entry = {'ready': running, 'running': running}
+
+        if daemon == 'wazuh-manager-analysisd':
+            entry.update(_analysisd_status(running))
+        elif daemon == 'wazuh-manager-modulesd':
+            entry.update(_modulesd_status(running))
+
+        node_ready = node_ready and bool(entry['ready'])
+        node_status[daemon] = entry
+
+    node_status['ready'] = node_ready
+
+    result.affected_items.append(node_status)
     result.total_affected_items = len(result.affected_items)
 
     return result

--- a/framework/wazuh/tests/test_manager.py
+++ b/framework/wazuh/tests/test_manager.py
@@ -53,14 +53,77 @@ manager_status = {'wazuh-manager-analysisd': 'running', 'wazuh-manager-authd': '
  'wazuh-manager-clusterd': 'running', 'wazuh-manager-modulesd': 'running',
  'wazuh-manager-db': 'running', 'wazuh-manager-apid': 'running'}
 
-@patch('wazuh.core.manager.status', return_value=manager_status)
-def test_get_status(mock_status):
-    """Tests get_status() function works"""
-    result = get_status()
+ENGINE_STATUS_READY = {
+    'ready': True,
+    'spaces': {'standard': {'available': True, 'enabled': True, 'status': 'ready', 'hash': 'h',
+                            'last_successful_update': 1}},
+    'ioc': {'connection': {'available': True, 'status': 'ready', 'hash': 'h', 'last_successful_update': 1}},
+    'geo': {'city': {'available': True, 'status': 'ready', 'hash': 'h', 'last_successful_update': 1}},
+}
 
-    # Assert there are no errors and type returned
-    assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
-    assert result.render()['data']['total_failed_items'] == 0
+
+@patch('wazuh.manager.EngineHTTPClient')
+@patch('wazuh.manager.status', return_value=manager_status)
+def test_get_status_all_ready(mock_status, mock_engine_cls):
+    """Node ready: all daemons running, analysisd engine ready, modulesd mock ready."""
+    mock_engine = MagicMock()
+    mock_engine.get_status.return_value = ENGINE_STATUS_READY
+    mock_engine_cls.return_value = mock_engine
+
+    result = get_status()
+    assert isinstance(result, AffectedItemsWazuhResult)
+    data = result.affected_items[0]
+
+    assert data['ready'] is True
+    # analysisd embeds the engine resources
+    assert data['wazuh-manager-analysisd']['running'] is True
+    assert data['wazuh-manager-analysisd']['ready'] is True
+    assert 'spaces' in data['wazuh-manager-analysisd']
+    assert 'ioc' in data['wazuh-manager-analysisd']
+    assert 'geo' in data['wazuh-manager-analysisd']
+    # modulesd is mocked
+    assert data['wazuh-manager-modulesd']['ready'] is True
+    assert 'vulnerability-detector' in data['wazuh-manager-modulesd']
+    # plain daemon: ready iff running, no extra resources
+    assert data['wazuh-manager-remoted'] == {'ready': True, 'running': True}
+
+
+@patch('wazuh.manager.EngineHTTPClient')
+@patch('wazuh.manager.status', return_value=manager_status)
+def test_get_status_analysisd_not_ready(mock_status, mock_engine_cls):
+    """analysisd engine not ready → node not ready."""
+    mock_engine = MagicMock()
+    mock_engine.get_status.return_value = {'ready': False, 'spaces': {}, 'ioc': {}, 'geo': {}}
+    mock_engine_cls.return_value = mock_engine
+
+    data = get_status().affected_items[0]
+    assert data['wazuh-manager-analysisd']['ready'] is False
+    assert data['ready'] is False
+
+
+@patch('wazuh.manager.EngineHTTPClient')
+@patch('wazuh.manager.status', return_value=manager_status)
+def test_get_status_engine_unreachable(mock_status, mock_engine_cls):
+    """Engine unreachable → analysisd not ready → node not ready."""
+    from wazuh.core.exception import WazuhInternalError
+    mock_engine = MagicMock()
+    mock_engine.get_status.side_effect = WazuhInternalError(2021)
+    mock_engine_cls.return_value = mock_engine
+
+    data = get_status().affected_items[0]
+    assert data['wazuh-manager-analysisd']['ready'] is False
+    assert data['ready'] is False
+
+
+@patch('wazuh.manager.EngineHTTPClient')
+@patch('wazuh.manager.status', return_value={**manager_status, 'wazuh-manager-analysisd': 'stopped'})
+def test_get_status_analysisd_stopped(mock_status, mock_engine_cls):
+    """analysisd stopped → not running, not ready, engine not queried."""
+    data = get_status().affected_items[0]
+    assert data['wazuh-manager-analysisd']['running'] is False
+    assert data['wazuh-manager-analysisd']['ready'] is False
+    assert data['ready'] is False
+    mock_engine_cls.assert_not_called()
 
 
 @pytest.mark.parametrize('tag, level, total_items, sort_by, sort_ascending', [


### PR DESCRIPTION
## Description

Changes the existing `GET /cluster/{node_id}/status` endpoint so it reports whether a cluster node is **ready to process events**, instead of only the OS-level running state of its daemons.

Each daemon now exposes:
- **`running`** — added by the Python framework via PID check.
- **`ready`** — whether the daemon has valid data/resources to process events.

The node-level **`ready`** is `true` only when **every daemon is ready**.

- **analysisd** embeds the engine `GET /status` response (per-resource `spaces` / `ioc` / `geo`). It is ready when all *enabled* resources are available; disabled spaces are ignored; a resource that is `running`/updating can still be `available` if it serves a valid snapshot.
- **modulesd** embeds `vulnerability-detector` — **mocked** for now; the real `ready` criteria is to be defined with the modulesd/VD team.
- Other daemons (remoted, db, authd, clusterd, apid, monitord) report `ready = running`.

RBAC unchanged: `cluster:read`.

Part of the XDR/Cloud initial setup & healthcheck initiative. Related: wazuh-indexer-plugins#1288.

## Proposed Changes

**Engine HTTP client** (`framework/wazuh/core/engine_http.py`)
- `EngineHTTPClient.get_status()` → `GET /status` over the engine's analysisd unix socket (mirrors `get_metrics_dump`, same error codes 2019–2022).

**Framework** (`framework/wazuh/manager.py`)
- `get_status()` reworked to return the **node status** object: iterates the manager daemons (PID check via `status()`), builds `{ready, running}` per daemon, and aggregates the node-level `ready` (AND of all daemons).
- `_analysisd_status()` — queries the engine `/status` and embeds `ready` + `spaces`/`ioc`/`geo`; not ready if analysisd is down or the engine is unreachable.
- `_modulesd_status()` — **mock** of `vulnerability-detector` (`available`, `status` ∈ `ready|updating|failed`, `enabled`, `offset`, `last_successful_update`); marked TBD with the VD team.

**Controller** (`api/api/controllers/cluster_controller.py`)
- `get_status_node` now dispatches `manager.get_status` (unchanged signature/RBAC).

**API spec** (`api/api/spec/spec.yaml`)
- `/cluster/{node_id}/status`: updated summary, description, response schema and example to the per-daemon node-status shape (real engine resource keys: `connection`, `url_domain`, `url_full`, `hash_md5`, `hash_sha1`, `hash_sha256`, `city`, `asn`).

**Tests**
- `framework/wazuh/core/tests/test_engine_http.py` — `get_status` (ok / http_error / invalid_json / timeout / connect / request error).
- `framework/wazuh/tests/test_manager.py` — `get_status` node aggregation: all-ready, analysisd-not-ready, engine-unreachable, analysisd-stopped.
- `api/api/controllers/test/test_cluster_controller.py` — `get_status_node` dispatches `manager.get_status` (kept green).



### Results and Evidence

#### Token and node

```
(venv) ╭─root@89ebd703d7af /workspaces/devContainer/wazuh ‹enhancement/36990-add-status-endpoint●› 
╰─# TOKEN=$(curl -u wazuh:wazuh -k -X POST "https://localhost:55000/security/user/authenticate?raw=true")
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   429  100   429    0     0   3259      0 --:--:-- --:--:-- --:--:--  3250
(venv) ╭─root@89ebd703d7af /workspaces/devContainer/wazuh ‹enhancement/36989-add-cluster-readiness-endpoint●› 
╰─# curl -s -k -H "Authorization: Bearer $TOKEN" \                                                       
  "https://localhost:55000/cluster/nodes?pretty=true&select=name"
{
   "data": {
      "affected_items": [
         {
            "name": "node01"
         }
      ],
      "total_affected_items": 1,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "All selected nodes information was returned",
   "error": 0
}
```


#### Before Start Indexer
```
(venv) ╭─root@89ebd703d7af /workspaces/devContainer/wazuh ‹enhancement/36990-add-status-endpoint●› 
╰─# curl -s -k -H "Authorization: Bearer $TOKEN" \                                                       
  "https://localhost:55000/cluster/node01/status?pretty=true"
{
   "data": {
      "affected_items": [
         {
            "wazuh-manager-analysisd": {
               "ready": false,
               "running": true,
               "spaces": {
                  "standard": {
                     "available": false,
                     "enabled": false,
                     "status": "ready",
                     "hash": "",
                     "last_successful_update": 0
                  },
                  "custom": {
                     "available": false,
                     "enabled": false,
                     "status": "ready",
                     "hash": "",
                     "last_successful_update": 0
                  }
               },
               "ioc": {
                  "url_full": {
                     "available": false,
                     "status": "failed",
                     "hash": "",
                     "last_successful_update": 0
                  },
                  "hash_sha256": {
                     "available": false,
                     "status": "failed",
                     "hash": "",
                     "last_successful_update": 0
                  },
                  "connection": {
                     "available": false,
                     "status": "failed",
                     "hash": "",
                     "last_successful_update": 0
                  },
                  "hash_sha1": {
                     "available": false,
                     "status": "failed",
                     "hash": "",
                     "last_successful_update": 0
                  },
                  "hash_md5": {
                     "available": false,
                     "status": "failed",
                     "hash": "",
                     "last_successful_update": 0
                  },
                  "url_domain": {
                     "available": false,
                     "status": "failed",
                     "hash": "",
                     "last_successful_update": 0
                  }
               },
               "geo": {
                  "city": {
                     "available": true,
                     "status": "updating",
                     "hash": "3f377dd93bc3f9a4a0bfb7d994a61b60",
                     "last_successful_update": 0
                  },
                  "asn": {
                     "available": true,
                     "status": "ready",
                     "hash": "5dac0370da55c96b47676213e7ac6cb9",
                     "last_successful_update": 0
                  }
               }
            },
            "wazuh-manager-authd": {
               "ready": true,
               "running": true
            },
            "wazuh-manager-monitord": {
               "ready": true,
               "running": true
            },
            "wazuh-manager-remoted": {
               "ready": true,
               "running": true
            },
            "wazuh-manager-clusterd": {
               "ready": true,
               "running": true
            },
            "wazuh-manager-modulesd": {
               "ready": true,
               "running": true,
               "vulnerability-detector": {
                  "available": true,
                  "status": "ready",
                  "enabled": true,
                  "offset": 0,
                  "last_successful_update": 0
               }
            },
            "wazuh-manager-db": {
               "ready": true,
               "running": true
            },
            "wazuh-manager-apid": {
               "ready": true,
               "running": true
            },
            "ready": false
         }
      ],
      "total_affected_items": 1,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "Node status was successfully read in specified node",
   "error": 0
}
```
#### After Start Indexer

```
(venv) ╭─root@89ebd703d7af /workspaces/devContainer/wazuh ‹enhancement/36989-add-cluster-readiness-endpoint●› 
╰─# curl -s -k -H "Authorization: Bearer $TOKEN" \
  "https://localhost:55000/cluster/node01/status?pretty=true"
{
   "data": {
      "affected_items": [
         {
            "wazuh-manager-analysisd": {
               "ready": true,
               "running": true,
               "spaces": {
                  "standard": {
                     "available": true,
                     "enabled": true,
                     "status": "ready",
                     "hash": "005e5d6e50e2033aaf04d755f9c9627d788ad0da8cad8e02eaed789791103c9d",
                     "last_successful_update": 1782235948
                  },
                  "custom": {
                     "available": false,
                     "enabled": false,
                     "status": "ready",
                     "hash": "",
                     "last_successful_update": 0
                  }
               },
               "ioc": {
                  "connection": {
                     "available": true,
                     "status": "ready",
                     "hash": "9e0195c3ee3533e769509a9bb8bd32eb7b294ce5f6577678bb04c7243f724287",
                     "last_successful_update": 1782235923
                  },
                  "hash_md5": {
                     "available": true,
                     "status": "ready",
                     "hash": "cd1def6116de2107da8992363ed0edda61f31e6196cf7c28053e4163cc16f846",
                     "last_successful_update": 1782235937
                  },
                  "url_domain": {
                     "available": true,
                     "status": "ready",
                     "hash": "fc6e5ce589d3fdc50bcdc2252cfe059864e58522ee77d3d9a3a1bbaef41eceb0",
                     "last_successful_update": 1782235936
                  },
                  "hash_sha256": {
                     "available": true,
                     "status": "ready",
                     "hash": "7b2849b775f8e71b96a3e352d86a20b3c72737cdab403ab43be511031f64d194",
                     "last_successful_update": 1782235940
                  },
                  "hash_sha1": {
                     "available": true,
                     "status": "ready",
                     "hash": "d7060d83df83659b9fe58294a8b411599d0a96df4c60659cedc2991dfbbd2fe8",
                     "last_successful_update": 1782235938
                  },
                  "url_full": {
                     "available": true,
                     "status": "ready",
                     "hash": "90e3a7797f913b18e5fdede5f4c18c21695641fd6190830bf9054035fb2b58b5",
                     "last_successful_update": 1782235925
                  }
               },
               "geo": {
                  "city": {
                     "available": true,
                     "status": "ready",
                     "hash": "34ea4ac55b9c88064f477e1980790337",
                     "last_successful_update": 1782235099
                  },
                  "asn": {
                     "available": true,
                     "status": "ready",
                     "hash": "b7f415b46242caff21748a03dd8ee3cb",
                     "last_successful_update": 1782235104
                  }
               }
            },
            "wazuh-manager-authd": {
               "ready": true,
               "running": true
            },
            "wazuh-manager-monitord": {
               "ready": true,
               "running": true
            },
            "wazuh-manager-remoted": {
               "ready": true,
               "running": true
            },
            "wazuh-manager-clusterd": {
               "ready": true,
               "running": true
            },
            "wazuh-manager-modulesd": {
               "ready": true,
               "running": true,
               "vulnerability-detector": {
                  "available": true,
                  "status": "ready",
                  "enabled": true,
                  "offset": 0,
                  "last_successful_update": 0
               }
            },
            "wazuh-manager-db": {
               "ready": true,
               "running": true
            },
            "wazuh-manager-apid": {
               "ready": true,
               "running": true
            },
            "ready": true
         }
      ],
      "total_affected_items": 1,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "Node status was successfully read in specified node",
   "error": 0
}
```


### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
