### PR TITLE
Repair RPM builder toolchain downloads

### DIFF
--- a/packages/rpms/amd64/agent/Dockerfile
+++ b/packages/rpms/amd64/agent/Dockerfile
@@ -56,7 +56,7 @@ RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     cd / && rm -rf gcc-9.4.0*
 
 # -------------------------------------------------------------------
-# Binutils
+# Binutils: GNU release tarball (the bminor GitHub archive zip 404s)
 # -------------------------------------------------------------------
 RUN yum install -y flex && \
     curl -OL https://ftp.gnu.org/gnu/binutils/binutils-2.41.tar.gz && \

--- a/packages/rpms/amd64/agent/Dockerfile
+++ b/packages/rpms/amd64/agent/Dockerfile
@@ -45,6 +45,7 @@ RUN mkdir -p /usr/local/var/lib/rpm && \
 # -------------------------------------------------------------------
 RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     tar xzf gcc-9.4.0.tar.gz && cd gcc-9.4.0 && \
+    sed -i "s|^base_url=.*|base_url='https://gcc.gnu.org/pub/gcc/infrastructure/'|" contrib/download_prerequisites && \
     ./contrib/download_prerequisites && \
     ./configure --prefix=/usr/local/gcc-9.4.0 \
         --enable-languages=c,c++ \
@@ -80,7 +81,9 @@ RUN curl -LO https://github.com/Kitware/CMake/releases/download/v3.22.0/cmake-3.
 # GCC 14.3.0 (set as final compiler)
 # -------------------------------------------------------------------
 RUN curl -OL https://ftp.fu-berlin.de/unix/languages/gcc/releases/gcc-14.3.0/gcc-14.3.0.tar.gz && \
-    tar xzf gcc-14.3.0.tar.gz && cd gcc-14.3.0 && ./contrib/download_prerequisites && \
+    tar xzf gcc-14.3.0.tar.gz && cd gcc-14.3.0 && \
+    sed -i "s|^base_url=.*|base_url='https://gcc.gnu.org/pub/gcc/infrastructure/'|" contrib/download_prerequisites && \
+    ./contrib/download_prerequisites && \
     mkdir build && cd build && \
     CC=/usr/local/gcc-9.4.0/bin/gcc \
     CXX=/usr/local/gcc-9.4.0/bin/g++ \

--- a/packages/rpms/amd64/agent/Dockerfile
+++ b/packages/rpms/amd64/agent/Dockerfile
@@ -58,15 +58,15 @@ RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
 # Binutils
 # -------------------------------------------------------------------
 RUN yum install -y flex && \
-    curl -OL https://github.com/bminor/binutils-gdb/archive/refs/tags/binutils-2_41.zip && \
-    unzip binutils-2_41.zip && rm -f binutils-2_41.zip && \
-    cd binutils-gdb-binutils-2_41 && mkdir build && cd build && \
+    curl -OL https://ftp.gnu.org/gnu/binutils/binutils-2.41.tar.gz && \
+    tar xzf binutils-2.41.tar.gz && rm -f binutils-2.41.tar.gz && \
+    cd binutils-2.41 && mkdir build && cd build && \
     ../configure --disable-gdb --disable-werror --disable-zlib \
         --disable-gprofng --disable-gdbserver --disable-gdbsupport \
         --disable-gnulib --disable-gold --disable-gprof --disable-texinfo \
         --disable-binutils --disable-sim && \
     make MAKEINFO=true -j$(nproc) && make MAKEINFO=true install && \
-    cd / && rm -rf binutils-gdb-binutils-2_41 && \
+    cd / && rm -rf binutils-2.41 && \
     ln -fs /usr/local/bin/ld /usr/bin/ld
 
 # -------------------------------------------------------------------

--- a/packages/rpms/amd64/gcc/Dockerfile
+++ b/packages/rpms/amd64/gcc/Dockerfile
@@ -27,6 +27,7 @@ WORKDIR /usr/src
 RUN wget https://ftp.gnu.org/gnu/gcc/gcc-${GCC_MAJOR_VERSION}.${GCC_MINOR_VERSION}.0/gcc-${GCC_MAJOR_VERSION}.${GCC_MINOR_VERSION}.0.tar.xz \
  && tar -xf gcc-${GCC_MAJOR_VERSION}.${GCC_MINOR_VERSION}.0.tar.xz \
  && cd gcc-${GCC_MAJOR_VERSION}.${GCC_MINOR_VERSION}.0 \
+ && sed -i "s|^base_url=.*|base_url='https://gcc.gnu.org/pub/gcc/infrastructure/'|" contrib/download_prerequisites \
  && ./contrib/download_prerequisites \
  && mkdir build && cd build \
  && ../configure \

--- a/packages/rpms/arm64/agent/Dockerfile
+++ b/packages/rpms/arm64/agent/Dockerfile
@@ -33,6 +33,7 @@ RUN yum install -y gcc make wget git \
 # -------------------------------------------------------------------
 RUN curl -OL http://packages.wazuh.com/utils/gcc/gcc-9.4.0.tar.gz && \
     tar xzf gcc-9.4.0.tar.gz && cd gcc-9.4.0 && \
+    sed -i "s|^base_url=.*|base_url='https://gcc.gnu.org/pub/gcc/infrastructure/'|" contrib/download_prerequisites && \
     ./contrib/download_prerequisites && \
     ./configure --prefix=/usr/local/gcc-9.4.0 \
         --enable-languages=c,c++ \
@@ -53,7 +54,9 @@ RUN curl -LO https://github.com/Kitware/CMake/releases/download/v3.22.0/cmake-3.
 # GCC 14.3.0
 # -------------------------------------------------------------------
 RUN curl -OL https://ftp.fu-berlin.de/unix/languages/gcc/releases/gcc-14.3.0/gcc-14.3.0.tar.gz && \
-    tar xzf gcc-14.3.0.tar.gz && cd gcc-14.3.0 && ./contrib/download_prerequisites && \
+    tar xzf gcc-14.3.0.tar.gz && cd gcc-14.3.0 && \
+    sed -i "s|^base_url=.*|base_url='https://gcc.gnu.org/pub/gcc/infrastructure/'|" contrib/download_prerequisites && \
+    ./contrib/download_prerequisites && \
     mkdir build && cd build && \
     CC=/usr/local/gcc-9.4.0/bin/gcc \
     CXX=/usr/local/gcc-9.4.0/bin/g++ \

--- a/packages/rpms/arm64/gcc/Dockerfile
+++ b/packages/rpms/arm64/gcc/Dockerfile
@@ -22,6 +22,7 @@ ARG GCC_STAGE1_VER=8.5.0
 RUN curl -LO https://ftp.gnu.org/gnu/gcc/gcc-${GCC_STAGE1_VER}/gcc-${GCC_STAGE1_VER}.tar.xz && \
     tar -xf gcc-${GCC_STAGE1_VER}.tar.xz && \
     cd gcc-${GCC_STAGE1_VER} && \
+    sed -i "s|^base_url=.*|base_url='https://gcc.gnu.org/pub/gcc/infrastructure/'|" contrib/download_prerequisites && \
     ./contrib/download_prerequisites && \
     mkdir build && cd build && \
     ../configure --prefix=/opt/gcc-${GCC_STAGE1_VER} \
@@ -39,6 +40,7 @@ ENV PATH=/opt/gcc-8.5.0/bin:$PATH \
 RUN wget https://ftp.gnu.org/gnu/gcc/gcc-${GCC_MAJOR_VERSION}.${GCC_MINOR_VERSION}.0/gcc-${GCC_MAJOR_VERSION}.${GCC_MINOR_VERSION}.0.tar.xz \
  && tar -xf gcc-${GCC_MAJOR_VERSION}.${GCC_MINOR_VERSION}.0.tar.xz \
  && cd gcc-${GCC_MAJOR_VERSION}.${GCC_MINOR_VERSION}.0 \
+ && sed -i "s|^base_url=.*|base_url='https://gcc.gnu.org/pub/gcc/infrastructure/'|" contrib/download_prerequisites \
  && ./contrib/download_prerequisites \
  && mkdir build && cd build \
  && ../configure \


### PR DESCRIPTION
## Description

The RPM agent builder images fail to build from scratch because of dead upstream toolchain download URLs in the RPM builder `Dockerfile`s. The failures were masked by the GHCR image cache and only surfaced when the `wazuh-agent-packages` workflows were migrated to AWS CodeBuild (wazuh/wazuh-agent-packages#837), which forced the builder images to be rebuilt. The migration is the trigger, not the cause.

This resolves the root cause reported in wazuh/wazuh-agent-packages#849. The upload workflow checks out `wazuh/wazuh` at `source_reference=main`, so the fix belongs here. DEB builders are unaffected.

## Proposed Changes

### Root cause 1 — binutils (amd64 / x86_64)

`packages/rpms/amd64/agent/Dockerfile` downloaded binutils from the GitHub archive tag:

```
https://github.com/bminor/binutils-gdb/archive/refs/tags/binutils-2_41.zip
```

That URL now returns `404 Not Found`, so `unzip` fails and the image cannot be built. Switched to the official GNU tarball (`https://ftp.gnu.org/gnu/binutils/binutils-2.41.tar.gz`), matching what `packages/debs/amd64/agent/Dockerfile` already uses. The tarball unpacks to `binutils-2.41/`, so the `cd`/`rm` paths change accordingly.

### Root cause 2 — GCC prerequisites over FTP (arm64 / aarch64)

GCC's `contrib/download_prerequisites` fetches gmp/mpfr/mpc/isl from `gcc.gnu.org`. GCC 8.5.0 and 9.4.0 hardcode `ftp://`, GCC 14.3.0 uses plain `http://`. The FTP endpoint is no longer reliable and the arm builders failed downloading `gmp-6.1.0.tar.bz2` on every retry. The Dockerfiles now rewrite `base_url` to HTTPS before invoking the script:

```
sed -i "s|^base_url=.*|base_url='https://gcc.gnu.org/pub/gcc/infrastructure/'|" contrib/download_prerequisites
```

Same archives and checksums, only the transport changes. Applied to both the agent and gcc builder Dockerfiles, on both arches: amd64's FTP fetch currently succeeds only intermittently and uses the same dead path, so hardening it now avoids a near-certain follow-up failure on the next scratch rebuild.

Files changed:
- `packages/rpms/amd64/agent/Dockerfile` — binutils source + HTTPS prerequisites
- `packages/rpms/arm64/agent/Dockerfile` — HTTPS prerequisites
- `packages/rpms/amd64/gcc/Dockerfile` — HTTPS prerequisites
- `packages/rpms/arm64/gcc/Dockerfile` — HTTPS prerequisites

These four files are byte-identical on `main` and `5.0.0`, so the change applies cleanly to both.

### Results and Evidence

- The dead URL `https://github.com/bminor/binutils-gdb/archive/refs/tags/binutils-2_41.zip` returns `404 Not Found`.
- The replacement `https://ftp.gnu.org/gnu/binutils/binutils-2.41.tar.gz` returns `200` and extracts to `binutils-2.41/` with a working `configure`.
- Every GCC prerequisite for 8.5.0 / 9.4.0 (gmp-6.1.0, mpfr-3.1.4, mpc-1.0.3, isl-0.18) and 14.3.0 (gmp-6.2.1, mpfr-4.1.0, mpc-1.2.1, isl-0.24) returns `200` over `https://gcc.gnu.org/pub/gcc/infrastructure/`.
- End-to-end test of the HTTPS rewrite against a GCC 9.4.0 source tree: the script downloaded all four prerequisites over HTTPS, passed sha512 verification, and extracted them:

```
2026-... URL:https://gcc.gnu.org/pub/gcc/infrastructure/gmp-6.1.0.tar.bz2 ... -> "./gmp-6.1.0.tar.bz2"
...
gmp-6.1.0.tar.bz2: OK
mpfr-3.1.4.tar.bz2: OK
mpc-1.0.3.tar.gz: OK
isl-0.18.tar.bz2: OK
All prerequisites downloaded successfully.
```

### Manual tests with their corresponding evidence

N/A for compilation/memory/engine/API checks — this PR only changes RPM builder `Dockerfile`s (no Wazuh source code). The relevant validation is the download/extract evidence above. A full builder image rebuild per arch (which compiles GCC twice) should be run by the upload workflow to confirm the images build and push to GHCR.

- Compilation without warnings on every supported platform
  - [ ] Linux — N/A (no source changes)
  - [ ] Windows — N/A
  - [ ] MAC OS X — N/A
- [x] Log syntax and correct language review

### Artifacts Affected

- RPM agent builder images: `pkg_rpm_agent_builder_{x86_64,amd64,aarch64,arm64}`.
- RPM GCC builder images (same latent FTP risk, also hardened here).
- Indirectly, the RPM agent packages built from these images.

### Configuration Changes

N/A.

### Tests Introduced

N/A — no automated tests exist for these `Dockerfile`s. Validation is the manual download/extract evidence above.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality — N/A (Dockerfile change)
- [x] Configuration changes documented — N/A
- [ ] Developer documentation reflects the changes — N/A
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
