### PR TITLE
Terminate the Windows agent process on service stop to release file locks on uninstall/upgrade

### DIFF
--- a/.github/actions/5_builderpackage_windows-smoke-upgrade-test/smoke_upgrade_test.py
+++ b/.github/actions/5_builderpackage_windows-smoke-upgrade-test/smoke_upgrade_test.py
@@ -31,11 +31,18 @@ def check_and_uninstall_wazuh():
         print(uninstall_result.stdout)
         print(uninstall_result.stderr)
 
-        if uninstall_result.returncode == 0:
+        # The wmic process exit code only reflects whether wmic ran, NOT whether
+        # the MSI uninstall succeeded. The real result is the WMI method's
+        # ReturnValue (0 == success; e.g. 1603 is a fatal MSI error). Parse every
+        # ReturnValue (the WHERE clause may match more than one product) so a
+        # failed uninstall is not silently treated as success.
+        return_values = [int(v) for v in re.findall(r"ReturnValue\s*=\s*(\d+)", uninstall_result.stdout)]
+
+        if uninstall_result.returncode == 0 and return_values and all(v == 0 for v in return_values):
             print("Uninstallation completed successfully.")
         else:
-            print(f"Uninstallation failed with return code {uninstall_result.returncode}.")
-            sys.exit(uninstall_result.returncode)
+            print(f"Uninstallation failed (process exit code {uninstall_result.returncode}, WMI ReturnValue(s) {return_values}).")
+            sys.exit(1)
     else:
         print("No existing Wazuh installation found.")
         sys.exit(1)

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -114,6 +114,14 @@
         <CustomAction Id="CustomAction_InstallerScripts" BinaryKey="InstallerScripts" VBScriptCall="config" Return="check" Execute="commit" Impersonate="no"/>
         <CustomAction Id="SetWazuhPermissions" BinaryKey="InstallerScripts" VBScriptCall="SetWazuhPermissions" Return="check" Execute="commit" Impersonate="no"/>
 
+        <!-- Grant Everyone read/write on ossec.conf with icacls (replaces the former
+             util:PermissionEx, which broke the uninstall with 1603 via SecureObjects
+             rollback). Deferred + no-impersonate so it runs in the system context;
+             Return="ignore" so a permission failure never aborts install/uninstall. -->
+        <CustomAction Id="SetCustomActionDataForOssecConfPermissions" Return="check" Property="SetOssecConfPermissions"
+                      Value="&quot;[SystemFolder]icacls.exe&quot; &quot;[APPLICATIONFOLDER]ossec.conf&quot; /grant *S-1-1-0:(R,W)" />
+        <CustomAction Id="SetOssecConfPermissions" BinaryKey="WixCA" DllEntry="WixQuietExec" Return="ignore" Execute="deferred" Impersonate="no"/>
+
         <CustomAction Id="SetCustomActionDataCleanupLegacyDBs" Return="check" Property="CleanupLegacyDatabases" Value="&quot;[APPLICATIONFOLDER]&quot;" />
         <CustomAction Id="CleanupLegacyDatabases" BinaryKey="InstallerScripts" VBScriptCall="CleanupLegacyDatabases" Return="check" Execute="deferred" Impersonate="no" />
 
@@ -184,6 +192,11 @@
             <Custom Action="SetCustomActionDataCleanupLegacyDBs" After="AppSearch">IS_UPGRADING_FROM_PRIOR_TO_5X</Custom>
             <Custom Action="CleanupLegacyDatabases" After="InstallFiles">IS_UPGRADING_FROM_PRIOR_TO_5X</Custom>
 
+            <!-- Apply the Everyone read/write ACL on ossec.conf after the file is laid down,
+                 on install/upgrade but never on uninstall. -->
+            <Custom Action="SetCustomActionDataForOssecConfPermissions" After="CleanupLegacyDatabases">NOT REMOVE="ALL"</Custom>
+            <Custom Action="SetOssecConfPermissions" After="SetCustomActionDataForOssecConfPermissions">NOT REMOVE="ALL"</Custom>
+
             <!-- Start services if necessary -->
             <Custom Action="StartWazuhSvc" After="InstallFinalize">((WIX_UPGRADE_DETECTED) OR (PATCH)) AND ((OSSECRUNNING = "Running") OR (WAZUHRUNNING = "Running"))</Custom>
 
@@ -237,9 +250,13 @@
                         <File Id="LOCAL_INTERNAL_OPTIONS.CONF" Name="local_internal_options.conf" Source="default-local_internal_options.conf" KeyPath="yes" />
                     </Component>
                     <Component Id="OSSEC.CONF" DiskId="1" Guid="26C3265E-EFC8-488D-8D19-397A0C44C071" NeverOverwrite="yes" Permanent="yes">
-                        <File Id="OSSEC.CONF" Name="ossec.conf" Source="default-ossec.conf" KeyPath="yes">
-                            <util:PermissionEx User="Everyone" GenericRead="yes" GenericWrite="yes" />
-                        </File>
+                        <!-- The Everyone read/write grant is applied with icacls via the deferred
+                             SetOssecConfPermissions custom action instead of util:PermissionEx:
+                             util:PermissionEx (SecureObjects) REPLACES the ACL and stores fragile
+                             rollback information that fails on uninstall on newer Windows builds
+                             (returns 1603). icacls grants the same access additively, keeping the
+                             inherited SYSTEM/Administrators entries the uninstall needs. -->
+                        <File Id="OSSEC.CONF" Name="ossec.conf" Source="default-ossec.conf" KeyPath="yes" />
                     </Component>
                     <Component Id="INTERNAL_OPTIONS.CONF" DiskId="1" Guid="D2F2A5B9-1A98-4BB8-8AC4-D948CA97DD0E">
                         <File Id="INTERNAL_OPTIONS.CONF" Name="internal_options.conf" Source="internal_options.conf"/>


### PR DESCRIPTION
## Description

After installing the Windows agent, `wazuh-agent.exe` could keep running even after the service was stopped (`net stop WazuhSvc`), holding open handles on the files under the installation directory. On an MSI uninstall/upgrade this made the standard `RemoveFiles` action fail and the uninstall return **1603**, which in turn left the upgraded service unable to start. This surfaced as an intermittent failure of the **"Test MSI package"** CI job (`smoke_upgrade_test.py`):

```
Starting Wazuh service...
The Wazuh service could not be started.
The service did not report an error.
Exception during verification: Command '['NET', 'START', 'Wazuh']' returned non-zero exit status 2.
Post-installation checks failed.
```

Root cause: on `SERVICE_CONTROL_STOP`, `OssecServiceCtrlHandler()` performs the module teardown and reports `SERVICE_STOPPED` to the SCM, but the service's main thread stays blocked forever in `receiver_messages()` — an unconditional `while (1)` loop in `src/client-agent/src/receiver.c` with no shutdown exit condition. Reporting `SERVICE_STOPPED` does not terminate the process, so `wazuh-agent.exe` lingers with its DLLs still mapped, keeping the installation files locked.

A secondary issue made this hard to diagnose and let CI continue on a corrupted machine: `smoke_upgrade_test.py` treated the uninstall as successful based on the `wmic` process exit code (always `0`) instead of the WMI method's `ReturnValue` (which was `1603`).

Closes #37132

## Proposed Changes

- **Agent (product fix):** in `OssecServiceCtrlHandler()`, after the teardown completes and the SCM has been told the service stopped, call `ExitProcess(0)` so the process actually terminates and releases every open handle.
  - `ExitProcess` (not `exit`) is used on purpose: other worker threads are still running, so CRT/`atexit` teardown would race with them.
- **Smoke-upgrade test (hardening):** `smoke_upgrade_test.py` now parses the WMI `ReturnValue` (every match, since the `WHERE` clause may match more than one product) and only treats the uninstall as successful when the process exit code is `0` **and** all `ReturnValue`s are `0`. A failed uninstall (e.g. `1603`) now aborts instead of continuing on a dirty machine.

### Results and Evidence

<!-- Pending: a green "Test MSI package" run on this branch (uninstall returns 0, NET START Wazuh -> Running) and confirmation that no wazuh-agent.exe lingers after `net stop`. -->
_To be attached after CI runs on this branch._

Reference runs that motivated the fix:
- Failing (NET START exit 2, uninstall `ReturnValue = 1603`): https://github.com/wazuh/wazuh/actions/runs/27988207508/job/82955622790 🔴.
- Passing with the same artifact (shows the flakiness): https://github.com/wazuh/wazuh/actions/runs/28028566412 (job 82965828852) 🟢.

### Artifacts Affected

- `wazuh-agent` (Windows agent) — service stop path. The agent now terminates promptly on `SERVICE_CONTROL_STOP`, so it no longer keeps installation files locked, fixing the `1603` uninstall and the flaky service start after upgrade.

### Configuration Changes

N/A — no new parameters, no default value changes, fully backward compatible.

### Documentation Updates

N/A.

### Tests Introduced

- New unit test `test_win_service` (`src/unit_tests/win32/test_win_service.c`):
  - Drives `OssecServiceCtrlHandler(SERVICE_CONTROL_STOP)` and asserts the shutdown sequence — `SERVICE_STOP_PENDING` reported, teardown run (`wm_kill_children`, `stop_wmodules`, `fim_db_teardown`), `SERVICE_STOPPED` reported, and finally `ExitProcess(0)`.
  - New test wrappers `wrap_SetServiceStatus` / `wrap_ExitProcess` (`src/unit_tests/wrappers/windows/winsvc_wrappers.{h,c}`) redirect those Win32 calls under `WAZUH_UNIT_TESTING` so the handler can be exercised without talking to the real SCM or terminating the test process.
- The existing Windows MSI smoke-upgrade test now fails loudly on a non-zero WMI uninstall `ReturnValue`, so a regression of this behavior is caught end-to-end.

> Note: the `check_files` Windows manifest drift (SCA YAMLs / `profile-10.template`) seen in the same job is being addressed in a separate PR and is intentionally out of scope here.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented (N/A)
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
