### PR TITLE
Limit recursion depth in XML parser

### DIFF
--- a/src/os_xml/os_xml.c
+++ b/src/os_xml/os_xml.c
@@ -27,7 +27,7 @@ static int _writememory(const char *str, XML_TYPE type, size_t size,
                         unsigned int parent, OS_XML *_lxml) __attribute__((nonnull));
 static int _xml_fgetc(FILE *fp, OS_XML *_lxml) __attribute__((nonnull));
 int _xml_sgetc(OS_XML *_lxml)  __attribute__((nonnull));
-static int _getattributes(unsigned int parent, OS_XML *_lxml, bool flag_truncate, const int delim) __attribute__((nonnull));
+static int _getattributes(unsigned int parent, OS_XML *_lxml, bool flag_truncate, const int delim, unsigned int depth) __attribute__((nonnull));
 static void xml_error(OS_XML *_lxml, const char *msg, ...) __attribute__((format(printf, 2, 3), nonnull));
 
 /**
@@ -345,7 +345,7 @@ static int _ReadElem(unsigned int parent, OS_XML *_lxml, unsigned int recursion_
             }
             _currentlycont = _lxml->cur - 1;
             if (isspace(c)) {
-                if ((_ga = _getattributes(parent, _lxml, flag_truncate, cmp)) < 0) {
+                if ((_ga = _getattributes(parent, _lxml, flag_truncate, cmp, 0)) < 0) {
                     goto end;
                 }
             }
@@ -536,7 +536,7 @@ static int _writecontent(const char *str, __attribute__((unused)) size_t size, u
 }
 
 /* Read the attributes of an element */
-static int _getattributes(unsigned int parent, OS_XML *_lxml, bool flag_truncate, const int delim)
+static int _getattributes(unsigned int parent, OS_XML *_lxml, bool flag_truncate, const int delim, unsigned int depth)
 {
     int location = 0;
     unsigned int count = 0;
@@ -545,6 +545,11 @@ static int _getattributes(unsigned int parent, OS_XML *_lxml, bool flag_truncate
 
     char attr[XML_MAXSIZE + 1];
     char value[XML_MAXSIZE + 1];
+
+    if (depth > XML_MAX_ATTR_DEPTH) {
+        xml_error(_lxml, "XMLERR: Too many attributes.");
+        return (-1);
+    }
 
     memset(attr, '\0', XML_MAXSIZE + 1);
     memset(value, '\0', XML_MAXSIZE + 1);
@@ -638,7 +643,7 @@ static int _getattributes(unsigned int parent, OS_XML *_lxml, bool flag_truncate
             }
             c = xml_getc_fun(_lxml->fp, _lxml);
             if (isspace(c)) {
-                return (_getattributes(parent, _lxml, flag_truncate, delim));
+                return (_getattributes(parent, _lxml, flag_truncate, delim, depth + 1));
             } else if (c == _R_CONFE) {
                 return (0);
             } else if (c == '/') {

--- a/src/os_xml/os_xml_internal.h
+++ b/src/os_xml/os_xml_internal.h
@@ -18,6 +18,7 @@
 #define LEOF        -2
 
 #define XML_MAXSIZE           20480
+#define XML_MAX_ATTR_DEPTH    48
 #define XML_VARIABLE_MAXSIZE  256
 
 #define XML_VAR              "var"

--- a/src/unit_tests/os_xml/test_os_xml.c
+++ b/src/unit_tests/os_xml/test_os_xml.c
@@ -16,7 +16,7 @@
 
 #include "../../headers/shared.h"
 #include "../../os_xml/os_xml.h"
-#include "../os_xml/os_xml_internal.h"
+#include "../../os_xml/os_xml_internal.h"
 #include "../wrappers/common.h"
 #include "../../headers/defs.h"
 
@@ -1074,6 +1074,25 @@ void OS_ReadXMLString_simple_invalid_xml(void **state) {
     }
 }
 
+void test_too_many_attributes(void **state) {
+    test_struct_t *data = (test_struct_t *)*state;
+
+    // Build XML with more attributes than XML_MAX_ATTR_DEPTH
+    char xml_string[16384];
+    strcpy(xml_string, "<root ");
+    for (int i = 0; i <= XML_MAX_ATTR_DEPTH + 1; i++) {
+        char attr[32];
+        snprintf(attr, sizeof(attr), "a%d=\"v\" ", i);
+        strcat(xml_string, attr);
+    }
+    strcat(xml_string, "/>");
+
+    create_xml_file(xml_string, data->xml_file_name, 256);
+
+    assert_int_not_equal(OS_ReadXML(data->xml_file_name, &data->xml), 0);
+    assert_string_equal(data->xml.err, "XMLERR: Too many attributes.");
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
 
@@ -1256,6 +1275,9 @@ int main(void) {
 
         // OS_ReadXMLString tests
         cmocka_unit_test(OS_ReadXMLString_simple_invalid_xml),
+
+        // Too many attributes test
+        cmocka_unit_test_setup_teardown(test_too_many_attributes, test_setup, test_teardown),
 
     };
 


### PR DESCRIPTION
## Description

Add recursion depth limit to `_getattributes()` function in the XML parser to prevent stack exhaustion when processing elements with a large number of attributes.

## Proposed Changes

- Add `XML_MAX_ATTR_DEPTH` constant (48) to `os_xml_internal.h`
- Add `depth` parameter to `_getattributes()` function signature
- Check recursion depth before processing and return error if exceeded
- Increment depth on each recursive call

### Results and Evidence

```
[  PASSED  ] 77 test(s).
```

All existing tests pass, plus the new test for attribute depth limit.

### Artifacts Affected

All binaries (XML parsing is used across the codebase).

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

- `test_too_many_attributes`: Verifies that XML with more attributes than `XML_MAX_ATTR_DEPTH` is rejected with appropriate error message.

## Credit

Thanks to @ShadowByte1 for reporting this issue.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
