### PR TITLE
Lower stale-session indexer log to debug

### DIFF
--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -704,9 +704,9 @@ public:
                     std::shared_lock sessionLock(m_agentSessionsMutex);
                     if (m_agentSessions.find(res.context->sessionId) == m_agentSessions.end())
                     {
-                        logWarn(LOGGER_DEFAULT_TAG,
-                                "InventorySyncFacade::start: Session not found, sessionId: %llu",
-                                res.context->sessionId);
+                        logDebug2(LOGGER_DEFAULT_TAG,
+                                  "InventorySyncFacade::start: Session not found, sessionId: %llu",
+                                  res.context->sessionId);
                         return;
                     }
                 }


### PR DESCRIPTION
## Description

Closes #37122

The inventory sync indexer queue callback logged `Session not found` at `WARNING` level whenever it picked up a queued response for a session that no longer existed in `m_agentSessions`.

This is an expected condition under load, not an error. A response is enqueued once per session and stays pending until the indexer flush completes. Before that happens, the session can legitimately be removed by:

- **Agent restart / retransmission**: the agent does not get its final ack in time, restarts the sync, and the new `Start` runs `cleanupStaleSessionForAgentModule`, which removes the still-pending session.
- **Timeout reaping**: under saturation the response sits in the queue longer than the session timeout and the sweeper removes the session.

In both cases the callback just discards the stale response and returns, which is correct: the old session's data was already deleted and the agent re-sends everything in the new session. No data loss, no double ack, no leak.

This was the source of the noise reported in #37122 (performance/saturation tests with retransmissions). The fix lowers the message to `logDebug2`, matching every other "session not found" path in the same file, which were already debug level. Behavior is unchanged.

