### PR TITLE
Enable shared-password enrollment by default

### DIFF
--- a/.github/workflows/5_testintegration_inventory-sync.yml
+++ b/.github/workflows/5_testintegration_inventory-sync.yml
@@ -139,6 +139,10 @@ jobs:
           sudo sed -i '/manager\.pem/d' "${CONF}"
           sudo sed -i '/manager-key\.pem/d' "${CONF}"
           sudo sed -i 's|<ca>etc|<ca>/var/wazuh-manager/etc|' "${CONF}"
+          # This suite exercises inventory sync, not password enrollment; the agent
+          # harness registers without a password, so keep use_password off regardless
+          # of the shipped default.
+          sudo sed -i 's|<use_password>yes</use_password>|<use_password>no</use_password>|' "${CONF}"
           sudo systemctl start wazuh-manager
           sleep 10
           if ! systemctl is-active --quiet wazuh-manager; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to this project will be documented in this file.
 - Included `os_type` in the agent keepalive cluster synchronization. ([#36072](https://github.com/wazuh/wazuh/issues/36072))
 - Randomized the cluster key generated during manager installation instead of using a hardcoded default. ([#36805](https://github.com/wazuh/wazuh/issues/36805))
 - Changed the default Indexer user used by the Manager from `admin` to the restricted `wazuh-server` user, aligning with the Indexer RBAC least-privilege model. ([#36311](https://github.com/wazuh/wazuh/issues/36311))
+- Enabled shared-password agent enrollment by default, persisting the auto-generated `authd.pass` and synchronizing it to worker nodes, with fail-closed password validation. ([#36705](https://github.com/wazuh/wazuh/issues/36705))
 
 #### Removed
 

--- a/docs/guide/migration/agent-groups-migration.md
+++ b/docs/guide/migration/agent-groups-migration.md
@@ -99,6 +99,21 @@ On every **agent** that should belong to a non-default group, confirm the group 
 
 With the group folders in place and each agent's group configured, start each agent. The group is only sent when the agent **enrolls**, so an agent still holding a stale key from the old manager must enroll fresh.
 
+> [!IMPORTANT]
+> Starting with Wazuh 5.0, the enrollment service requires a password by default. Before starting each agent, copy the enrollment password from the manager:
+>
+> ```bash
+> # On the manager
+> sudo cat /var/wazuh-manager/etc/authd.pass
+>
+> # On each agent
+> echo "<password>" | sudo tee /var/ossec/etc/authd.pass
+> sudo chown root:wazuh /var/ossec/etc/authd.pass
+> sudo chmod 640 /var/ossec/etc/authd.pass
+> ```
+>
+> Without this file the enrollment request will be rejected. See [`use_password`](../../ref/configuration/auth.md#use_password) for details.
+
 Clear its key first, then start it:
 
 ```bash

--- a/docs/ref/configuration/auth.md
+++ b/docs/ref/configuration/auth.md
@@ -47,10 +47,34 @@ Remove all previous keys for an agent when it re-enrolls with the same name.
 
 Require agents to provide a shared enrollment password.
 
-- **Default value**: `no`
+- **Default value**: `no` (the configuration shipped by the installer sets it to `yes`)
 - **Allowed values**: `yes`, `no`
 
-When enabled, place the password in `/var/wazuh-manager/etc/authd.pass` (one line, no trailing newline).
+When enabled, the password is read from `/var/wazuh-manager/etc/authd.pass` (a single line). If the file does not exist, `wazuh-authd` generates a random password on start, stores it in that file, and reuses it on later starts. If the file exists but is empty or invalid, `wazuh-authd` does not start. In a cluster, the password belongs to the master and is distributed to the workers automatically; a worker rejects enrollment until it receives the file.
+
+**Agent-side setup:** Because `use_password` is `yes` by default, agents must supply the enrollment password or their enrollment request will be rejected. First retrieve the password from the manager:
+
+```bash
+sudo cat /var/wazuh-manager/etc/authd.pass
+```
+
+The recommended way to provide it to an agent is the `WAZUH_REGISTRATION_PASSWORD` install variable, which writes `etc/authd.pass` and sets its ownership and permissions automatically:
+
+```bash
+WAZUH_MANAGER="<manager-ip>" WAZUH_REGISTRATION_PASSWORD="<password>" apt install ./wazuh-agent.deb
+```
+
+To add it to an already-installed agent, write the file manually. The agent daemon (`wazuh-agentd`) runs as the `wazuh` user, so the file must be readable by that user:
+
+```bash
+echo "<password>" | sudo tee /var/ossec/etc/authd.pass
+sudo chown root:wazuh /var/ossec/etc/authd.pass
+sudo chmod 640 /var/ossec/etc/authd.pass
+```
+
+The agent reads the password from `etc/authd.pass` (relative to its install directory, typically `/var/ossec/etc/authd.pass`) at startup.
+
+**Password rotation:** The generated password persists across restarts. To rotate it (for example after a security incident), delete `/var/wazuh-manager/etc/authd.pass` on the master and restart `wazuh-authd`. A new random password will be generated, persisted, and distributed to workers automatically. The reuse of an existing password is logged at `INFO` level on every start.
 
 ### remote_enrollment
 
@@ -173,7 +197,7 @@ Accept enrollment from agents running a newer Wazuh version than the manager.
   <port>1515</port>
   <use_source_ip>no</use_source_ip>
   <purge>yes</purge>
-  <use_password>no</use_password>
+  <use_password>yes</use_password>
   <ssl_verify_host>no</ssl_verify_host>
   <ssl_manager_cert>/var/wazuh-manager/etc/sslmanager.cert</ssl_manager_cert>
   <ssl_manager_key>/var/wazuh-manager/etc/sslmanager.key</ssl_manager_key>

--- a/docs/ref/getting-started/installation.md
+++ b/docs/ref/getting-started/installation.md
@@ -328,7 +328,13 @@ Specifies the IP address or hostname of the enrollment server. When not specifie
 Defines the port used for agent enrollment. Default: `1515`.
 
 **`WAZUH_REGISTRATION_PASSWORD`**\
-Sets the password required for agent enrollment. This password must match the one configured on the server.
+Sets the password required for agent enrollment. This password must match the one configured on the server. Enrollment password protection is enabled by default, so retrieve the auto-generated password from the manager before enrolling agents:
+
+```bash
+sudo cat /var/wazuh-manager/etc/authd.pass
+```
+
+Passing it through this variable is the recommended approach: the installer writes `etc/authd.pass` on the agent and sets its ownership and permissions automatically. See [`use_password`](../configuration/auth.md#use_password) for details and for adding the password to an already-installed agent.
 
 **`WAZUH_REGISTRATION_CA`**\
 Specifies the path to the CA certificate used to verify the manager's identity during enrollment.

--- a/docs/ref/modules/authd/README.md
+++ b/docs/ref/modules/authd/README.md
@@ -9,7 +9,7 @@ For configuration options see [Auth Configuration](../../configuration/auth.md).
 ## How it works
 
 1. Agent connects to port 1515 over TLS.
-2. If `use_password` is enabled, the agent must send the enrollment password (`OSSEC PASS: <password>`).
+2. If `use_password` is enabled (the default for new installations), the agent must send the enrollment password (`OSSEC PASS: <password>`). The password is auto-generated on the manager at first start and must be copied to each agent before enrollment; see [Agent-side setup](../../configuration/auth.md#use_password).
 3. If mutual TLS is configured (`ssl_agent_ca`), the agent's certificate is verified.
 4. The agent sends an enrollment request:
    ```
@@ -33,7 +33,7 @@ For configuration options see [Auth Configuration](../../configuration/auth.md).
 |------|----------|
 | `/var/wazuh-manager/etc/client.keys` | One line per agent: `<id> <name> <ip> <key>` |
 | `/var/wazuh-manager/etc/agents-timestamp` | Per-agent registration timestamp |
-| `/var/wazuh-manager/etc/authd.pass` | Enrollment password (when `use_password` is `yes`) |
+| `/var/wazuh-manager/etc/authd.pass` | Enrollment password (auto-generated on first start; required by default) |
 
 ## Force re-enrollment
 

--- a/etc/templates/config/generic/auth.template
+++ b/etc/templates/config/generic/auth.template
@@ -4,7 +4,7 @@
     <port>1515</port>
     <use_source_ip>no</use_source_ip>
     <purge>yes</purge>
-    <use_password>no</use_password>
+    <use_password>yes</use_password>
     <ciphers>HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH</ciphers>
     <!-- <ssl_agent_ca></ssl_agent_ca> -->
     <ssl_verify_host>no</ssl_verify_host>

--- a/etc/wazuh-manager.conf
+++ b/etc/wazuh-manager.conf
@@ -29,7 +29,7 @@
     <port>1515</port>
     <use_source_ip>no</use_source_ip>
     <purge>yes</purge>
-    <use_password>no</use_password>
+    <use_password>yes</use_password>
     <!-- <ssl_agent_ca></ssl_agent_ca> -->
     <ssl_verify_host>no</ssl_verify_host>
     <ssl_manager_cert>/var/wazuh-manager/etc/sslmanager.cert</ssl_manager_cert>

--- a/framework/wazuh/core/cluster/cluster.json
+++ b/framework/wazuh/core/cluster/cluster.json
@@ -3,12 +3,12 @@
         "etc/": {
             "permissions": "0o640",
             "source": "master",
-            "files": ["client.keys"],
+            "files": ["client.keys", "authd.pass"],
             "recursive": false,
             "restart": false,
             "remove_subdirs_if_empty": false,
             "extra_valid": false,
-            "description": "client keys file database"
+            "description": "client keys file database and enrollment shared password"
         },
 
         "etc/shared/": {

--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -315,12 +315,12 @@ def test_get_cluster_items():
             "etc/": {
                 "permissions": 416,
                 "source": "master",
-                "files": ["client.keys"],
+                "files": ["client.keys", "authd.pass"],
                 "recursive": False,
                 "restart": False,
                 "remove_subdirs_if_empty": False,
                 "extra_valid": False,
-                "description": "client keys file database",
+                "description": "client keys file database and enrollment shared password",
             },
             "etc/shared/": {
                 "permissions": 432,

--- a/src/config/src/authd-config.c
+++ b/src/config/src/authd-config.c
@@ -71,6 +71,7 @@ int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
     config->port = 1515;
     config->flags.use_source_ip = 0;
     config->flags.clear_removed = 0;
+    /* Off when <use_password> is omitted (upgrades); the installer template ships it on. */
     config->flags.use_password = 0;
     config->ciphers = strdup("HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH");
     config->flags.verify_host = 0;

--- a/src/os_auth/include/auth.h
+++ b/src/os_auth/include/auth.h
@@ -198,6 +198,14 @@ cJSON* local_add(const char *id,
  */
 char *w_generate_random_pass();
 
+/* Load the shared password (master): read it from @p path or generate+persist one.
+ * Fail-closed on an invalid existing file; never returns NULL. Sets @p generated. */
+char *w_authd_load_password(const char *path, bool *generated);
+
+/* Read the shared password from @p path (cluster worker): never generates, persists,
+ * nor exits. Returns NULL when missing/empty/short/unreadable. */
+char *w_authd_read_password(const char *path);
+
 extern char shost[512];
 extern keystore keys;
 extern volatile int write_pending;

--- a/src/os_auth/src/auth.c
+++ b/src/os_auth/src/auth.c
@@ -10,6 +10,7 @@
 
 #include <shared.h>
 #include <stdio.h>
+#include <sys/stat.h>
 #include "auth.h"
 #include "defs.h"
 #include "os_err.h"
@@ -24,6 +25,12 @@
 #undef __wazuh_version
 #define __wazuh_version "v5.0.0"
 #endif
+
+typedef enum {
+    PASS_LINE_OK = 0,
+    PASS_LINE_INVALID,  /* missing, empty, or <= 2 chars after trimming */
+    PASS_LINE_TOO_LONG
+} pass_line_t;
 
 keystore keys;
 char shost[512];
@@ -529,4 +536,128 @@ char *w_generate_random_pass()
     free(rand4);
     os_free(str1);
     return(fstring);
+}
+
+/* Read and trim (CR/LF) the first line of an open password file. Shared by both readers. */
+static pass_line_t read_password_line(FILE *fp, char **out) {
+    char buf[4096 + 1];
+
+    *out = NULL;
+
+    if (!fgets(buf, sizeof(buf), fp)) {
+        return PASS_LINE_INVALID;
+    }
+
+    size_t len = strlen(buf);
+
+    /* fgets filled the buffer without a newline: line exceeds the maximum length. */
+    if (len == sizeof(buf) - 1 && buf[len - 1] != '\n') {
+        return PASS_LINE_TOO_LONG;
+    }
+
+    while (len > 0 && (buf[len - 1] == '\n' || buf[len - 1] == '\r')) {
+        buf[--len] = '\0';
+    }
+
+    if (len <= 2) {
+        return PASS_LINE_INVALID;
+    }
+
+    /* Reject all-whitespace content: it passes the length check but would otherwise
+     * become a valid shared enrollment secret, contradicting the fail-closed contract. */
+    bool all_space = true;
+    for (size_t i = 0; i < len; i++) {
+        if (!isspace((unsigned char)buf[i])) {
+            all_space = false;
+            break;
+        }
+    }
+    if (all_space) {
+        return PASS_LINE_INVALID;
+    }
+
+    *out = strdup(buf);
+    return PASS_LINE_OK;
+}
+
+char *w_authd_load_password(const char *path, bool *generated) {
+    FILE *fp;
+
+    *generated = false;
+
+    if (fp = wfopen(path, "r"), fp) {
+        char *pass = NULL;
+        pass_line_t status = read_password_line(fp, &pass);
+
+        fclose(fp);
+
+        /* Fail closed: an invalid existing file must never disable password enrollment. */
+        switch (status) {
+        case PASS_LINE_TOO_LONG:
+            merror_exit("Authentication password in '%s' is too long.", path);
+        case PASS_LINE_INVALID:
+            merror_exit("Invalid password provided in '%s'.", path);
+        case PASS_LINE_OK:
+            return pass;
+        }
+
+        return pass;
+    }
+
+    /* No file: generate and persist. umask 0137 (file mode 0640) avoids a world-readable create/chmod window. */
+    char *pass = w_generate_random_pass();
+
+    if (!pass) {
+        merror_exit("Unable to generate random password. Exiting.");
+    }
+
+    mode_t old_umask = umask(0137);
+    fp = wfopen(path, "w");
+    int saved_errno = errno;    /* before umask() can clobber it */
+    umask(old_umask);
+
+    if (!fp) {
+        os_free(pass);
+        merror_exit("Unable to write authentication password to '%s': %s", path, strerror(saved_errno));
+    }
+
+    if (fprintf(fp, "%s\n", pass) != (int)(strlen(pass) + 1)) {
+        fclose(fp);
+        os_free(pass);
+        merror_exit("Unable to persist authentication password to '%s'.", path);
+    }
+
+    if (fclose(fp) != 0) {
+        saved_errno = errno;
+        os_free(pass);
+        merror_exit("Unable to close authentication password file '%s': %s", path, strerror(saved_errno));
+    }
+
+    *generated = true;
+    return pass;
+}
+
+/* Read-only loader for cluster workers: never generates, persists, nor exits. */
+char *w_authd_read_password(const char *path) {
+    FILE *fp;
+
+    if (fp = wfopen(path, "r"), !fp) {
+        return NULL;
+    }
+
+    char *pass = NULL;
+    pass_line_t status = read_password_line(fp, &pass);
+
+    fclose(fp);
+
+    /* Distinguish a corrupt/malformed file from a file that is simply absent. Both
+     * return NULL to the caller, but the former warrants a distinct log entry so
+     * operators can tell a sync-lag apart from file corruption. */
+    if (status == PASS_LINE_TOO_LONG) {
+        mwarn("Authentication password in '%s' is too long; ignoring.", path);
+    } else if (status == PASS_LINE_INVALID) {
+        mwarn("Authentication password in '%s' is invalid or empty; ignoring.", path);
+    }
+
+    return pass;
 }

--- a/src/os_auth/src/main-server.c
+++ b/src/os_auth/src/main-server.c
@@ -44,6 +44,9 @@ static void* run_remote_server(void *arg);
 /* Thread for writing keystore onto disk */
 static void* run_writer(void *arg);
 
+/* Thread that watches for authd.pass to appear on a worker node */
+static void* run_authpass_watcher(void *arg);
+
 /* Signal handler */
 static void handler(int signum);
 
@@ -52,6 +55,7 @@ static void cleanup();
 
 /* Shared variables */
 static char *authpass = NULL;
+static time_t authpass_mtime = 0;  /* shared between process_message and run_authpass_watcher */
 static SSL_CTX *ctx;
 static int remote_sock = -1;
 static int g_epfd = -1;
@@ -66,6 +70,7 @@ extern struct keynode * volatile *insert_tail;
 extern struct keynode * volatile *remove_tail;
 
 pthread_mutex_t mutex_keys = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t mutex_authpass = PTHREAD_MUTEX_INITIALIZER;
 pthread_cond_t cond_pending = PTHREAD_COND_INITIALIZER;
 
 static int g_stopFD[2] = {-1, -1};
@@ -83,7 +88,7 @@ static void help_authd(char * home_path)
     print_out("    -g <group>  Group to run as. Default: %s.", GROUPGLOBAL);
     print_out("    -D <dir>    Directory to chdir into. Default: %s.", home_path);
     print_out("    -p <port>   Manager port. Default: %d.", DEFAULT_PORT);
-    print_out("    -P          Enable shared password authentication, at %s or random.", AUTHD_PASS);
+    print_out("    -P          Force shared-password enrollment on (already enabled by default); password read from %s or generated.", AUTHD_PASS);
     print_out("    -c          SSL cipher list (default: %s)", DEFAULT_CIPHERS);
     print_out("    -v <path>   Full path to CA certificate used to verify clients.");
     print_out("    -s          Used with -v, enable source host verification.");
@@ -108,6 +113,50 @@ static void set_non_blocking(int fd) {
     }
 }
 
+static void* run_authpass_watcher(void *arg) {
+    (void)arg;
+    while (running) {
+        /* Interruptible wait: poll the shutdown flag every second instead of sleeping a
+         * full interval, so the thread exits promptly and can be joined at shutdown. */
+        for (int i = 0; i < 5 && running; i++) {
+            sleep(1);
+        }
+        if (!running) {
+            break;
+        }
+
+        time_t mtime = File_DateofChange(AUTHD_PASS);
+        if (mtime < 0) {
+            continue;  /* file not there yet */
+        }
+
+        w_mutex_lock(&mutex_authpass);
+
+        if (mtime == authpass_mtime) {
+            /* File unchanged since last check. */
+            w_mutex_unlock(&mutex_authpass);
+            continue;
+        }
+
+        char *pass = w_authd_read_password(AUTHD_PASS);
+        authpass_mtime = mtime;
+
+        if (pass) {
+            int first_load = (authpass == NULL);
+            os_free(authpass);
+            authpass = pass;
+            if (first_load) {
+                minfo("Enrollment password synchronized from the master node and now available at '%s'.", AUTHD_PASS);
+            } else {
+                minfo("Enrollment password reloaded from '%s'.", AUTHD_PASS);
+            }
+        }
+
+        w_mutex_unlock(&mutex_authpass);
+    }
+    return NULL;
+}
+
 int main(int argc, char **argv)
 {
 
@@ -119,11 +168,12 @@ int main(int argc, char **argv)
     int run_foreground = 0;
     gid_t gid;
     const char *group = GROUPGLOBAL;
-    char buf[4096 + 1];
 
     pthread_t thread_local_server = 0;
     pthread_t thread_remote_server = 0;
     pthread_t thread_writer = 0;
+    pthread_t thread_authpass_watcher = 0;
+    bool authpass_watcher_started = false;
 
     for (int i = 0; i < AUTH_POOL; i++) {
         g_client_pool[i] = NULL;
@@ -542,42 +592,26 @@ int main(int argc, char **argv)
 
         /* Check if password is enabled */
         if (config.flags.use_password) {
-            fp = wfopen(AUTHD_PASS, "r");
-            buf[0] = '\0';
+            if (config.worker_node) {
+                /* Owned by the master and synced to workers; never generated here.
+                 * If not synced yet, picked up later in process_message. */
+                authpass = w_authd_read_password(AUTHD_PASS);
 
-            /* Checking if there is a custom password file */
-            if (fp) {
-                fseek(fp, 0, SEEK_END);
-
-                if (ftell(fp) <= 1) {
-                    merror("Empty password provided.");
-                    exit(1);
-                }
-
-                fseek(fp, 0, SEEK_SET);
-
-                buf[4096] = '\0';
-                char *ret = fgets(buf, 4095, fp);
-
-                if (ret && strlen(buf) > 2) {
-                    /* Remove newline */
-                    if (buf[strlen(buf) - 1] == '\n') {
-                        buf[strlen(buf) - 1] = '\0';
-                    }
-                    authpass = strdup(buf);
-                }
-
-                fclose(fp);
-            }
-
-            if (buf[0] != '\0') {
-                mdebug1("Accepting connections on port %hu. Using password specified on file: %s", config.port, AUTHD_PASS);
-            } else {
-                /* Getting temporary pass. */
-                if (authpass = w_generate_random_pass(), authpass) {
-                    mdebug1("Accepting connections on port %hu. Random password chosen for agent authentication: %s", config.port, authpass);
+                if (authpass) {
+                    authpass_mtime = File_DateofChange(AUTHD_PASS);
+                    minfo("Accepting connections on port %hu. Using password synchronized from the master node.", config.port);
                 } else {
-                    merror_exit("Unable to generate random password. Exiting.");
+                    minfo("Shared-password enrollment is enabled but '%s' has not been synchronized from the master node yet. Enrollment requests will be rejected until it is available.", AUTHD_PASS);
+                }
+            } else {
+                bool pass_generated = false;
+
+                authpass = w_authd_load_password(AUTHD_PASS, &pass_generated);
+
+                if (pass_generated) {
+                    minfo("Accepting connections on port %hu. A new authentication password was generated and written to '%s'", config.port, AUTHD_PASS);
+                } else {
+                    minfo("Accepting connections on port %hu. Using existing authentication password from '%s'. To rotate the password, delete the file and restart.", config.port, AUTHD_PASS);
                 }
             }
         } else {
@@ -633,6 +667,14 @@ int main(int argc, char **argv)
         }
     }
 
+    if (config.worker_node && config.flags.use_password) {
+        if (status = pthread_create(&thread_authpass_watcher, NULL, run_authpass_watcher, NULL), status != 0) {
+            merror("Couldn't create authpass watcher thread: %s", strerror(status));
+        } else {
+            authpass_watcher_started = true;
+        }
+    }
+
     /* Join threads */
     pthread_join(thread_local_server, NULL);
     if (config.flags.remote_enrollment) {
@@ -644,6 +686,11 @@ int main(int argc, char **argv)
         w_cond_signal(&cond_pending);
         w_mutex_unlock(&mutex_keys);
         pthread_join(thread_writer, NULL);
+    }
+
+    /* Join the watcher so it cannot touch authpass/mutex_authpass during shutdown. */
+    if (authpass_watcher_started) {
+        pthread_join(thread_authpass_watcher, NULL);
     }
 
     minfo("Exiting...");
@@ -689,7 +736,52 @@ static void process_message(struct client *client) {
 
     mdebug2("Request received: <%s>", client->read_buffer);
 
-    if (OS_SUCCESS == w_auth_parse_data(client->read_buffer, response, authpass, client->ip, &client->agentname, &client->centralized_group, &key_hash)) {
+    /* authpass is only mutable on the worker: the watcher thread reloads it and so does the
+     * block below. The master sets it once at startup, so it needs no serialisation there and
+     * enrollment parsing stays concurrent. Only enter the critical section on the worker. */
+    const bool serialize_authpass = config.flags.use_password && config.worker_node;
+
+    if (serialize_authpass) {
+        w_mutex_lock(&mutex_authpass);
+    }
+
+    /* Worker: re-read on mtime change so a synced/rotated password is picked up without
+     * restart. A failed read keeps the current password. */
+    if (config.flags.use_password && config.worker_node) {
+        time_t mtime = File_DateofChange(AUTHD_PASS);
+
+        if (mtime >= 0 && (authpass == NULL || mtime != authpass_mtime)) {
+            char *fresh = w_authd_read_password(AUTHD_PASS);
+
+            if (fresh) {
+                os_free(authpass);
+                authpass = fresh;
+                minfo("Enrollment password reloaded from '%s'.", AUTHD_PASS);
+            }
+            /* Record the mtime regardless of success: avoids re-logging a corrupt file
+             * on every request until the file is replaced with a valid one. */
+            authpass_mtime = mtime;
+        }
+    }
+
+    /* Fail closed: required password missing (worker not synced yet) -> reject, never
+     * validate against NULL (which skips the check). */
+    if (config.flags.use_password && authpass == NULL) {
+        if (serialize_authpass) {
+            w_mutex_unlock(&mutex_authpass);
+        }
+        merror("Enrollment password required but not available yet. Rejecting request from %s.", client->ip);
+        snprintf(client->write_buffer, MAX_SSL_MSG_SIZE, "ERROR: Enrollment password not available. Unable to add agent");
+        client->write_len = strlen(client->write_buffer);
+        return;
+    }
+
+    int auth_parse_result = w_auth_parse_data(client->read_buffer, response, authpass, client->ip, &client->agentname, &client->centralized_group, &key_hash);
+    if (serialize_authpass) {
+        w_mutex_unlock(&mutex_authpass);
+    }
+
+    if (OS_SUCCESS == auth_parse_result) {
         if (config.worker_node) {
             minfo("Dispatching request to master node");
             // The force registration settings are ignored for workers. The master decides.

--- a/src/unit_tests/os_auth/CMakeLists.txt
+++ b/src/unit_tests/os_auth/CMakeLists.txt
@@ -14,8 +14,9 @@ list(APPEND os_auth_flags "${DEBUG_OP_WRAPPERS} \
 list(APPEND os_auth_names "test_auth_add")
 list(APPEND os_auth_flags "${DEBUG_OP_WRAPPERS} -Wl,--wrap,OS_IsValidIP")
 list(APPEND os_auth_names "test_auth")
-list(APPEND os_auth_flags "${DEBUG_OP_WRAPPERS} \
-                           -Wl,--wrap,os_random -Wl,--wrap,GetRandomNoise -Wl,--wrap,getuname -Wl,--wrap,time -Wl,--wrap,wfopen")
+list(APPEND os_auth_flags "${DEBUG_OP_WRAPPERS} ${STDIO_OP_WRAPPERS} \
+                           -Wl,--wrap,os_random -Wl,--wrap,GetRandomNoise -Wl,--wrap,getuname -Wl,--wrap,time -Wl,--wrap,wfopen \
+                           -Wl,--wrap,fprintf -Wl,--wrap,popen -Wl,--wrap,pclose")
 list(APPEND os_auth_names "test_generate_cert")
 list (APPEND os_auth_flags "-Wl,--wrap,PEM_write_PrivateKey -Wl,--wrap,PEM_write_X509 -Wl,--wrap,RSA_generate_key_ex \
                             -Wl,--wrap,X509_sign -Wl,--wrap,_merror -Wl,--wrap,wfopen \

--- a/src/unit_tests/os_auth/test_auth.c
+++ b/src/unit_tests/os_auth/test_auth.c
@@ -19,9 +19,62 @@
 #include "auth.h"
 #include "sec.h"
 
+#include "../wrappers/common.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../wrappers/wazuh/os_auth/os_auth_wrappers.h"
 #include "../wrappers/wazuh/shared/randombytes_wrappers.h"
+#include "../wrappers/wazuh/shared/file_op_wrappers.h"
+#include "../wrappers/libc/stdio_wrappers.h"
+
+#define TEST_UNAME "Linux |ubuntu-focal |5.4.0-92-generic |#103-Ubuntu SMP Fri Nov 26 16:13:00 UTC 2021 " \
+                   "|x86_64 [Ubuntu|ubuntu: 20.04.2 LTS (Focal Fossa)] - Wazuh v4.3.4"
+
+/* The deterministic RNG above yields this password. */
+#define TEST_GENERATED_PASS "6e0d9a4188ac9de8fa695bd96e276090"
+
+/* The fake (non-NULL) FILE* handed back by the wfopen mock. */
+#define FAKE_FP ((FILE *)1)
+
+/* Drives the wrapped RNG so w_generate_random_pass() yields a deterministic value. */
+static void setup_deterministic_pass(void) {
+    will_return(__wrap_os_random, 146557);
+    will_return(__wrap_os_random, 314159);
+    will_return(__wrap_GetRandomNoise, strdup("Wazuh"));
+    will_return(__wrap_GetRandomNoise, strdup("The Open Source Security Platform"));
+    will_return(__wrap_time, 1655254875);
+    will_return_always(__wrap_getuname, TEST_UNAME);
+}
+
+/* Toggle file-mock mode around each authd.pass test. */
+static int test_setup(void **state) {
+    test_mode = 1;
+    return 0;
+}
+
+static int test_teardown(void **state) {
+    test_mode = 0;
+    return 0;
+}
+
+/* Queue a successful open("r") -> fgets -> close of authd.pass returning `content`. */
+static void expect_pass_file_read(const char *content) {
+    expect_string(__wrap_wfopen, path, "etc/authd.pass");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, FAKE_FP);
+
+    expect_value(__wrap_fgets, __stream, FAKE_FP);
+    will_return(__wrap_fgets, content);
+
+    expect_value(__wrap_fclose, _File, FAKE_FP);
+    will_return(__wrap_fclose, 0);
+}
+
+/* Queue an open("r") that fails: authd.pass does not exist. */
+static void expect_pass_file_open_fail(void) {
+    expect_string(__wrap_wfopen, path, "etc/authd.pass");
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, NULL);
+}
 
 /* tests */
 
@@ -33,18 +86,217 @@ static void test_w_generate_random_pass_success(void **state) {
     will_return(__wrap_GetRandomNoise, strdup("Wazuh"));
     will_return(__wrap_GetRandomNoise, strdup("The Open Source Security Platform"));
     will_return(__wrap_time, 1655254875);
-    will_return_always(__wrap_getuname, "Linux |ubuntu-focal |5.4.0-92-generic |#103-Ubuntu SMP Fri Nov 26 16:13:00 UTC 2021 "
-                                        "|x86_64 [Ubuntu|ubuntu: 20.04.2 LTS (Focal Fossa)] - Wazuh v4.3.4");
+    will_return_always(__wrap_getuname, TEST_UNAME);
 
     result = w_generate_random_pass();
 
-    assert_string_equal(result, "6e0d9a4188ac9de8fa695bd96e276090");
+    assert_string_equal(result, TEST_GENERATED_PASS);
     os_free(result);
+}
+
+static void test_w_authd_load_password_from_file(void **state) {
+    bool generated = true;
+
+    expect_pass_file_read("MyS3cret\n");
+
+    char *result = w_authd_load_password("etc/authd.pass", &generated);
+
+    assert_non_null(result);
+    assert_string_equal(result, "MyS3cret");
+    assert_false(generated);
+    os_free(result);
+}
+
+/* A CRLF-authored file (Windows) must trim the trailing \r as well as \n. */
+static void test_w_authd_load_password_strips_crlf(void **state) {
+    bool generated = true;
+
+    expect_pass_file_read("MyS3cret\r\n");
+
+    char *result = w_authd_load_password("etc/authd.pass", &generated);
+
+    assert_non_null(result);
+    assert_string_equal(result, "MyS3cret");
+    assert_false(generated);
+    os_free(result);
+}
+
+/* A first line longer than the read buffer is fatal: never use a truncated password. */
+static void test_w_authd_load_password_too_long_is_fatal(void **state) {
+    bool generated = false;
+    static char longline[5000];
+
+    memset(longline, 'a', sizeof(longline) - 1);
+    longline[sizeof(longline) - 1] = '\0';
+
+    expect_pass_file_read(longline);
+    expect_string(__wrap__merror_exit, formatted_msg, "Authentication password in 'etc/authd.pass' is too long.");
+
+    expect_assert_failure(w_authd_load_password("etc/authd.pass", &generated));
+}
+
+static void test_w_authd_load_password_empty_file_is_fatal(void **state) {
+    bool generated = false;
+
+    expect_pass_file_read("");   /* empty file content */
+    expect_string(__wrap__merror_exit, formatted_msg, "Invalid password provided in 'etc/authd.pass'.");
+
+    expect_assert_failure(w_authd_load_password("etc/authd.pass", &generated));
+}
+
+static void test_w_authd_load_password_generate_and_persist(void **state) {
+    bool generated = false;
+
+    expect_pass_file_open_fail();   /* file does not exist */
+
+    setup_deterministic_pass();
+
+    /* Open for writing the new password */
+    expect_string(__wrap_wfopen, path, "etc/authd.pass");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, FAKE_FP);
+
+    expect_value(__wrap_fprintf, __stream, FAKE_FP);
+    expect_string(__wrap_fprintf, formatted_msg, TEST_GENERATED_PASS "\n");
+    will_return(__wrap_fprintf, 33);
+
+    expect_value(__wrap_fclose, _File, FAKE_FP);
+    will_return(__wrap_fclose, 0);
+
+    char *result = w_authd_load_password("etc/authd.pass", &generated);
+
+    assert_non_null(result);
+    assert_string_equal(result, TEST_GENERATED_PASS);
+    assert_true(generated);
+    os_free(result);
+}
+
+static void test_w_authd_load_password_persist_failure_is_fatal(void **state) {
+    bool generated = false;
+
+    expect_pass_file_open_fail();   /* file does not exist */
+
+    setup_deterministic_pass();
+
+    /* Open for writing fails */
+    expect_string(__wrap_wfopen, path, "etc/authd.pass");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, NULL);
+
+    expect_any(__wrap__merror_exit, formatted_msg);
+
+    expect_assert_failure(w_authd_load_password("etc/authd.pass", &generated));
+}
+
+/* An existing file whose first line is too short must fail closed (never return NULL,
+ * which would silently disable password enrollment). */
+static void test_w_authd_load_password_short_line_is_fatal(void **state) {
+    bool generated = false;
+
+    expect_pass_file_read("x\n");   /* first line too short (strlen 2, not > 2) */
+    expect_string(__wrap__merror_exit, formatted_msg, "Invalid password provided in 'etc/authd.pass'.");
+
+    expect_assert_failure(w_authd_load_password("etc/authd.pass", &generated));
+}
+
+/* An all-whitespace line passes the length check but must still fail closed: it would
+ * otherwise become a valid shared enrollment secret. */
+static void test_w_authd_load_password_spaces_only_is_fatal(void **state) {
+    bool generated = false;
+
+    expect_pass_file_read("      \n");   /* only spaces after CR/LF trim */
+    expect_string(__wrap__merror_exit, formatted_msg, "Invalid password provided in 'etc/authd.pass'.");
+
+    expect_assert_failure(w_authd_load_password("etc/authd.pass", &generated));
+}
+
+/* An existing, non-empty file that cannot be read (fgets fails) must fail closed too. */
+static void test_w_authd_load_password_unreadable_is_fatal(void **state) {
+    bool generated = false;
+
+    expect_pass_file_read(NULL);   /* read error -> no usable password */
+    expect_string(__wrap__merror_exit, formatted_msg, "Invalid password provided in 'etc/authd.pass'.");
+
+    expect_assert_failure(w_authd_load_password("etc/authd.pass", &generated));
+}
+
+/* w_authd_read_password (read-only loader used by cluster workers) */
+
+static void test_w_authd_read_password_from_file(void **state) {
+    expect_pass_file_read("SyncedPass\n");
+
+    char *result = w_authd_read_password("etc/authd.pass");
+
+    assert_non_null(result);
+    assert_string_equal(result, "SyncedPass");
+    os_free(result);
+}
+
+/* Missing file (e.g. not synchronized yet) must return NULL without generating or aborting. */
+static void test_w_authd_read_password_missing_returns_null(void **state) {
+    expect_pass_file_open_fail();
+
+    assert_null(w_authd_read_password("etc/authd.pass"));
+}
+
+/* An existing file whose first line is too short yields NULL (the caller rejects, never bypasses). */
+static void test_w_authd_read_password_short_returns_null(void **state) {
+    expect_pass_file_read("x\n");
+    expect_string(__wrap__mwarn, formatted_msg, "Authentication password in 'etc/authd.pass' is invalid or empty; ignoring.");
+
+    assert_null(w_authd_read_password("etc/authd.pass"));
+}
+
+/* On the worker an all-whitespace file must be ignored (NULL + warn), not synced as a secret. */
+static void test_w_authd_read_password_spaces_only_returns_null(void **state) {
+    expect_pass_file_read("      \n");
+    expect_string(__wrap__mwarn, formatted_msg, "Authentication password in 'etc/authd.pass' is invalid or empty; ignoring.");
+
+    assert_null(w_authd_read_password("etc/authd.pass"));
+}
+
+/* CRLF-authored file: the worker reader must trim \r too, matching the master. */
+static void test_w_authd_read_password_strips_crlf(void **state) {
+    expect_pass_file_read("SyncedPass\r\n");
+
+    char *result = w_authd_read_password("etc/authd.pass");
+
+    assert_non_null(result);
+    assert_string_equal(result, "SyncedPass");
+    os_free(result);
+}
+
+/* An over-long first line yields NULL on the worker (reject), never a truncated password. */
+static void test_w_authd_read_password_too_long_returns_null(void **state) {
+    static char longline[5000];
+
+    memset(longline, 'a', sizeof(longline) - 1);
+    longline[sizeof(longline) - 1] = '\0';
+
+    expect_pass_file_read(longline);
+    expect_string(__wrap__mwarn, formatted_msg, "Authentication password in 'etc/authd.pass' is too long; ignoring.");
+
+    assert_null(w_authd_read_password("etc/authd.pass"));
 }
 
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_w_generate_random_pass_success),
+        cmocka_unit_test_setup_teardown(test_w_authd_load_password_from_file, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_w_authd_load_password_strips_crlf, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_w_authd_load_password_too_long_is_fatal, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_w_authd_load_password_empty_file_is_fatal, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_w_authd_load_password_generate_and_persist, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_w_authd_load_password_persist_failure_is_fatal, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_w_authd_load_password_short_line_is_fatal, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_w_authd_load_password_spaces_only_is_fatal, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_w_authd_load_password_unreadable_is_fatal, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_w_authd_read_password_from_file, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_w_authd_read_password_strips_crlf, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_w_authd_read_password_too_long_returns_null, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_w_authd_read_password_missing_returns_null, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_w_authd_read_password_short_returns_null, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_w_authd_read_password_spaces_only_returns_null, test_setup, test_teardown),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/os_auth/test_authd-config.c
+++ b/src/unit_tests/os_auth/test_authd-config.c
@@ -21,6 +21,7 @@
 
 
 void w_authd_parse_agents(XML_NODE node, authd_config_t * config);
+int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, void *d2);
 
 
 /* setup/teardown */
@@ -118,6 +119,23 @@ static void test_w_authd_parse_agents_invalid_element(void **state) {
     os_free(node);
 }
 
+// Test Read_Authd defaults
+
+static void test_authd_use_password_default(void **state) {
+    authd_config_t local_config = {0};
+
+    /* With no <auth> children, only the defaults are applied */
+    assert_int_equal(Read_Authd(NULL, NULL, &local_config, NULL), 0);
+
+    /* Binary default is disabled when <use_password> is omitted; the shipped
+     * configuration enables it via the template (issue #36705). */
+    assert_int_equal(local_config.flags.use_password, 0);
+
+    os_free(local_config.ciphers);
+    os_free(local_config.manager_cert);
+    os_free(local_config.manager_key);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -126,6 +144,7 @@ int main(void)
         cmocka_unit_test(test_w_authd_parse_agents_yes),
         cmocka_unit_test(test_w_authd_parse_agents_invalid_value),
         cmocka_unit_test(test_w_authd_parse_agents_invalid_element),
+        cmocka_unit_test(test_authd_use_password_default),
 
     };
 

--- a/tests/integration/test_authd/test_use_password/data/test_cases/cases_authd_use_password_invalid.yaml
+++ b/tests/integration/test_authd/test_use_password/data/test_cases/cases_authd_use_password_invalid.yaml
@@ -5,7 +5,7 @@
   configuration_parameters:
     USE_PASSWORD: 'yes'
   metadata:
-    error: Empty password provided.
+    error: "Invalid password provided in 'etc/authd.pass'."
     password: ''
 
 - name: Use only spaces password.
@@ -15,5 +15,5 @@
   configuration_parameters:
     USE_PASSWORD: 'yes'
   metadata:
-    error: Invalid password provided.
+    error: "Invalid password provided in 'etc/authd.pass'."
     password: '      '

--- a/tests/integration/test_authd/test_use_password/test_authd_use_password.py
+++ b/tests/integration/test_authd/test_use_password/test_authd_use_password.py
@@ -41,7 +41,7 @@ import time
 import pytest
 from pathlib import Path
 
-from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
+from wazuh_testing.constants.paths.configurations import DEFAULT_AUTHD_PASS_PATH
 from wazuh_testing.constants.ports import DEFAULT_SSL_REMOTE_ENROLLMENT_PORT
 from wazuh_testing.constants.daemons import AUTHD_DAEMON, WAZUH_DB_DAEMON, MODULES_DAEMON
 from wazuh_testing.utils.configuration import load_configuration_template, get_test_cases_data
@@ -78,19 +78,15 @@ daemons_handler_configuration = {'all_daemons': True}
 
 def read_random_pass():
     """
-    Search for the random password creation in Wazuh logs
+    Read the auto-generated enrollment password from authd.pass.
+    authd writes the password to the file on first start; it is never printed to logs.
+    Returns None when the file does not exist (e.g. use_password=no).
     """
-    passw = None
     try:
-        with open(WAZUH_LOG_PATH, 'r') as log_file:
-            lines = log_file.readlines()
-            for line in lines:
-                if "Random password" in line:
-                    passw = line.split()[-1]
-            log_file.close()
-    except IOError as exception:
-        raise
-    return passw
+        with open(DEFAULT_AUTHD_PASS_PATH, 'r') as f:
+            return f.readline().rstrip('\r\n')
+    except FileNotFoundError:
+        return None
 
 
 # Test

--- a/tests/integration/test_authd/test_use_password/test_authd_use_password_invalid.py
+++ b/tests/integration/test_authd/test_use_password/test_authd_use_password_invalid.py
@@ -7,8 +7,8 @@ copyright: Copyright (C) 2015-2024, Wazuh Inc.
 
 type: integration
 
-brief: These tests will check invalid values in the authd.pass (for now just checks 'empty')
-       raises the expected error logs.
+brief: These tests check that an invalid authd.pass (empty or whitespace-only) raises the
+       expected error log and prevents wazuh-authd from starting.
 
 components:
     - authd
@@ -104,23 +104,20 @@ def test_authd_use_password_invalid(test_configuration, test_metadata, set_wazuh
             brief: Truncate all the log files and json alerts files before and after the test execution.
 
     assertions:
-        - Error log 'Empty password provided.' is raised in ossec.log.
-        - wazuh-manager.service must not be able to restart.
+        - An 'Invalid password provided' error is raised in wazuh-manager.log.
+        - wazuh-authd does not start with an invalid password file.
 
     input_description:
         ./data/configuration_template/config_authd_use_password_invalid.yaml: Wazuh config needed for the tests.
         ./data/test_cases/cases_authd_use_password_invalid.yaml: Values to be used and expected error.
 
     expected_output:
-        - .*Empty password provided.
-        - .*Invalid password provided.
+        - .*Invalid password provided
     '''
     log = test_metadata['error']
-    if log == 'Invalid password provided.':
-        pytest.xfail(reason="No password validation in authd.pass - Issue wazuh/wazuh#16282.")
 
-    # Attempt restart; it may fail (older behavior) or succeed (5.x behavior where
-    # the service continues even if authd exits on invalid password).
+    # wazuh-authd exits on the invalid password; depending on the service manager the
+    # restart may report failure or succeed, so tolerate both outcomes.
     try:
         control_service('restart')
     except ValueError:


### PR DESCRIPTION
## Description

Closes #36705

Enables shared-password enrollment by default for new installs and makes that default safe: the password is auto-generated and persisted on first start, enforced fail-closed on the master, and distributed and hot-reloaded on cluster workers without requiring a restart.

## Proposed Changes

**C1: Enable shared-password enrollment by default**
The installer template and `wazuh-manager.conf` now ship `<use_password>yes</use_password>`. The binary C default in `Read_Authd` stays `0` so upgrades where the tag is absent in an existing config are not silently flipped on.

**C2: Persist generated password and load it fail-closed**
Two new helpers in `auth.c`: `w_authd_load_password` (master path: generates and persists if absent, `merror_exit` on invalid file) and `w_authd_read_password` (worker path: read-only, returns NULL without aborting). A per-request mtime check in `process_message` hot-reloads the password when the cluster delivers a new copy. A fail-closed guard rejects enrollment when `authpass == NULL`.

**C3: Distribute authd.pass across cluster nodes**
`authd.pass` added to the `etc/` entry in `cluster.json`. The master distributes the password to workers through the same sync path already used for `client.keys`. No changes to sync logic required.

**C4: Documentation**
Four docs updated to reflect the new default:
- `docs/ref/configuration/auth.md` — new default, auto-generate-and-persist behaviour, fail-closed semantics, password rotation, and agent-side setup: recommends the `WAZUH_REGISTRATION_PASSWORD` install variable (writes `etc/authd.pass` and sets ownership/permissions automatically) and documents the manual file method for already-installed agents.
- `docs/ref/getting-started/installation.md` — note on `WAZUH_REGISTRATION_PASSWORD` that the enrollment password is now required by default, how to retrieve it from the manager, and that the variable is the recommended way to provide it.
- `docs/guide/migration/agent-groups-migration.md` — `[!IMPORTANT]` block in the re-enrollment step explaining agents need the password before `wazuh-agentd` starts.
- `docs/ref/modules/authd/README.md` — enrollment flow and storage table updated to reflect the new default.

### Results and Evidence

Unit tests added:

- `src/unit_tests/os_auth/test_authd-config.c` — `test_authd_use_password_default`: asserts that `Read_Authd` with no XML children sets `flags.use_password = 0`.
- `src/unit_tests/os_auth/test_auth.c` — 10+ cases covering generation, persistence, fail-closed paths, and the worker read-only path.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [X] Linux

#### Cluster manual testing

Topology: master `10.2.0.9`, worker+agent `10.2.0.11`.

<details>
<summary>Cluster configuration</summary>

**Master (`10.2.0.9`):**
```xml
<cluster>
  <name>wazuh</name>
  <node_name>node01</node_name>
  <node_type>master</node_type>
  <key>74d2f6c00253820115985079ba4c2d45</key>
  <port>1516</port>
  <bind_addr>0.0.0.0</bind_addr>
  <nodes><node>10.2.0.9</node></nodes>
  <hidden>no</hidden>
</cluster>
```

**Worker (`10.2.0.11`):**
```xml
<cluster>
  <name>wazuh</name>
  <node_name>node-worker</node_name>
  <node_type>worker</node_type>
  <key>74d2f6c00253820115985079ba4c2d45</key>
  <port>1516</port>
  <bind_addr>0.0.0.0</bind_addr>
  <nodes><node>10.2.0.9</node></nodes>
  <hidden>no</hidden>
</cluster>
```

</details>

<details>
<summary>Scenario 1: First install, password auto-generated and persisted</summary>

**Commands (master):**
```bash
sudo rm -f /var/wazuh-manager/etc/authd.pass
sudo systemctl restart wazuh-manager
grep "wazuh-manager-authd" /var/wazuh-manager/logs/wazuh-manager.log
cat /var/wazuh-manager/etc/authd.pass
```

**Evidence:**
```
root@manager:~# grep "wazuh-manager-authd" /var/wazuh-manager/logs/wazuh-manager.log
2026/06/26 13:52:27 wazuh-manager-authd: INFO: Started (pid: 35040).
2026/06/26 13:52:27 wazuh-manager-authd: INFO: Accepting connections on port 1515. A new authentication password was generated and written to 'etc/authd.pass'

root@manager:~# cat /var/wazuh-manager/etc/authd.pass
1ef4aab2fe9906feec4188c596c3a6b9
```

</details>

<details>
<summary>Scenario 2: Restart reuses existing password (not ephemeral)</summary>

**Commands (master):**
```bash
sudo systemctl restart wazuh-manager
grep "wazuh-manager-authd" /var/wazuh-manager/logs/wazuh-manager.log | tail -5
cat /var/wazuh-manager/etc/authd.pass
```

**Evidence:**
```
2026/06/26 14:04:16 wazuh-manager-authd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/06/26 14:04:16 wazuh-manager-authd: INFO: Exiting...
2026/06/26 14:04:21 wazuh-manager-authd: INFO: Started (pid: 39373).
2026/06/26 14:04:21 wazuh-manager-authd: INFO: Accepting connections on port 1515. Using existing authentication password from 'etc/authd.pass'. To rotate the password, delete the file and restart.

root@manager:~# cat /var/wazuh-manager/etc/authd.pass
1ef4aab2fe9906feec4188c596c3a6b9
```

</details>

<details>
<summary>Scenario 3: Worker starts before sync, enrollment rejected then auto-recovered</summary>

**Commands (worker):**
```bash
sudo rm -f /var/wazuh-manager/etc/authd.pass
sudo systemctl restart wazuh-manager

echo "OSSEC PASS: test OSSEC A:'test-nosync'" | \
  openssl s_client -connect 10.2.0.11:1515 -quiet 2>/dev/null

# wait ~10s — watcher thread detects file arrival automatically
grep "wazuh-manager-authd" /var/wazuh-manager/logs/wazuh-manager.log | tail -10
```

**Evidence:**
```
root@manager2:~# echo "OSSEC PASS: test OSSEC A:'test-nosync'" | \
  openssl s_client -connect 10.2.0.11:1515 -quiet 2>/dev/null
ERROR: Enrollment password not available. Unable to add agent

root@manager2:~# grep "wazuh-manager-authd" /var/wazuh-manager/logs/wazuh-manager.log
2026/06/26 14:17:56 wazuh-manager-authd: INFO: Started (pid: 35701).
2026/06/26 14:17:56 wazuh-manager-authd: WARNING: Shared-password enrollment is enabled but 'etc/authd.pass' has not been synchronized from the master node yet. Enrollment requests will be rejected until it is available.
2026/06/26 14:18:03 wazuh-manager-authd: ERROR: Enrollment password required but not available yet. Rejecting request from 10.2.0.11.
2026/06/26 14:18:1x wazuh-manager-authd: INFO: Enrollment password synchronized from the master node and now available at 'etc/authd.pass'.
```

</details>

<details>
<summary>Scenario 4: Worker restarts with file already present</summary>

**Commands (worker):**
```bash
sudo systemctl restart wazuh-manager
grep "wazuh-manager-authd" /var/wazuh-manager/logs/wazuh-manager.log | tail -5
```

**Evidence:**
```
2026/06/29 07:02:55 wazuh-manager-authd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/06/29 07:02:55 wazuh-manager-authd: INFO: Exiting...
2026/06/29 07:02:59 wazuh-manager-authd: INFO: Started (pid: 36144).
2026/06/29 07:02:59 wazuh-manager-authd: INFO: Accepting connections on port 1515. Using password synchronized from the master node.

root@manager2:~# cat /var/wazuh-manager/etc/authd.pass
1ef4aab2fe9906feec4188c596c3a6b9
```

</details>

<details>
<summary>Scenario 5: Hot-reload, password rotated on master, worker reloads automatically without restart</summary>

**Commands (master):**
```bash
sudo rm /var/wazuh-manager/etc/authd.pass
sudo systemctl restart wazuh-manager
cat /var/wazuh-manager/etc/authd.pass
```

**Commands (worker — no restart needed):**
```bash
# wait ~10s for cluster sync
grep "wazuh-manager-authd" /var/wazuh-manager/logs/wazuh-manager.log | tail -5

PASS=$(sudo cat /var/wazuh-manager/etc/authd.pass)
echo "OSSEC PASS: $PASS OSSEC A:'test-hotreload'" | \
  openssl s_client -connect 10.2.0.11:1515 -quiet 2>/dev/null
```

**Evidence (master):**
```
2026/06/26 14:42:25 wazuh-manager-authd: INFO: Started (pid: 50511).
2026/06/26 14:42:25 wazuh-manager-authd: INFO: Accepting connections on port 1515. A new authentication password was generated and written to 'etc/authd.pass'

root@manager:~# cat /var/wazuh-manager/etc/authd.pass
e6255121b2c7eaebf5fb65f990214ad9

root@manager2:~# cat /var/wazuh-manager/etc/authd.pass
e6255121b2c7eaebf5fb65f990214ad9
```

**Evidence (worker — watcher thread fires automatically):**
```
2026/06/29 07:05:19 wazuh-manager-authd: INFO: Enrollment password reloaded from 'etc/authd.pass'.
```

**Enrollment via worker (no restart):**
```
Worker:
2026/06/26 14:55:51 wazuh-manager-authd: INFO: Dispatching request to master node

Master:
2026/06/26 14:55:53 wazuh-manager-authd: INFO: Agent key generated for agent 'test-hotreload' (requested locally)

root@manager:~# cat /var/wazuh-manager/etc/client.keys
001 test-hotreload any 523fe7bc620ff1b197db48b46c49fdf8460afa32225fb48a62e4008a6e239862
```

</details>

<details>
<summary>Scenario 6: Full enrollment with real agent</summary>

**Commands (worker):**
```bash
# chown required: agentd runs as user 'wazuh'
PASS=$(sudo cat /var/wazuh-manager/etc/authd.pass)
echo "$PASS" | sudo tee /var/ossec/etc/authd.pass
sudo chown wazuh:wazuh /var/ossec/etc/authd.pass
sudo chmod 640 /var/ossec/etc/authd.pass

sudo systemctl restart wazuh-agent
sudo tail -f /var/ossec/logs/ossec.log
```

**Evidence:**
```
2026/06/29 07:21:51 wazuh-agentd: INFO: Started (pid: 38740).
2026/06/29 07:21:51 wazuh-agentd: INFO: Requesting a key from server: 10.2.0.9
2026/06/29 07:21:51 wazuh-agentd: INFO: Using password specified on file: etc/authd.pass
2026/06/29 07:21:51 wazuh-agentd: INFO: Using agent name as: web-server-01
2026/06/29 07:21:51 wazuh-agentd: INFO: Waiting for server reply
2026/06/29 07:21:51 wazuh-agentd: INFO: Valid key received
2026/06/29 07:22:11 wazuh-agentd: INFO: (4102): Connected to the server ([10.2.0.9]:1514/tcp).

root@manager2:~# cat /var/ossec/etc/client.keys
002 web-server-01 any b1434f78aa10dd0eb492d2074066c5ca6c6b7e8e4812c0a1575971ac7e8f6759
```

</details>

<details>
<summary>Scenario 7: Corrupt authd.pass on worker, warning once, auto-recovered when file is restored</summary>

**Commands (worker):**
```bash
sudo bash -c '> /var/wazuh-manager/etc/authd.pass'
grep "wazuh-manager-authd" /var/wazuh-manager/logs/wazuh-manager.log | tail -5
```

**Evidence:**
```
2026/06/29 07:24:39 wazuh-manager-authd: WARNING: Authentication password in 'etc/authd.pass' is invalid or empty; ignoring.
2026/06/29 07:24:44 wazuh-manager-authd: INFO: Enrollment password reloaded from 'etc/authd.pass'.
```

> WARNING fires when the watcher detects the corrupt file. INFO fires 5s later when the cluster re-syncs a valid copy from the master.

</details>

<details>
<summary>Scenario 8: Corrupt authd.pass on master, fail-closed, authd does not start</summary>

**Commands (master):**
```bash
sudo bash -c '> /var/wazuh-manager/etc/authd.pass'
sudo systemctl restart wazuh-manager
/var/wazuh-manager/bin/wazuh-manager-control status
```

**Evidence:**
```
2026/06/29 07:26:07 wazuh-manager-authd: CRITICAL: Invalid password provided in 'etc/authd.pass'.

root@manager:~# /var/wazuh-manager/bin/wazuh-manager-control status
wazuh-manager-clusterd is running...
wazuh-manager-modulesd is running...
wazuh-manager-monitord is running...
wazuh-manager-remoted is running...
wazuh-manager-analysisd is running...
wazuh-manager-db is running...
wazuh-manager-authd not running...
wazuh-manager-apid is running...
```

> Only authd exits. All other daemons remain running — fail-closed is scoped to enrollment only.

</details>

<details>
<summary>Scenario 9: Wrong password from agent</summary>

**Commands (worker):**
```bash
echo "OSSEC PASS: wrongpassword OSSEC A:'test-wrong'" | \
  openssl s_client -connect 10.2.0.11:1515 -quiet 2>/dev/null
```

**Evidence:**
```
2026/06/29 07:29:01 wazuh-manager-authd: ERROR: Invalid password provided by 10.2.0.9. Closing connection.
```

</details>

<details>
<summary>Scenario 10: Agent install via WAZUH_REGISTRATION_PASSWORD (env var sets file, ownership, and permissions automatically)</summary>

**Commands (agent host):**
```bash
# Retrieve the password from the manager
PASS=$(sudo cat /var/wazuh-manager/etc/authd.pass)

# Install the agent passing the password as an environment variable
# (vars go AFTER sudo; works the same with dpkg -i, apt, RPM, and macOS)
sudo WAZUH_MANAGER='10.2.0.9' \
     WAZUH_REGISTRATION_PASSWORD="$PASS" \
     WAZUH_AGENT_NAME='test-envvar' \
     dpkg -i ./wazuh-agent_*.deb

sudo systemctl daemon-reload
sudo systemctl enable wazuh-agent
sudo systemctl start wazuh-agent

# The installer writes the file with the correct ownership and permissions
sudo stat -c '%a %U:%G  %n' /var/ossec/etc/authd.pass
grep "authd" /var/ossec/logs/ossec.log
```

**Evidence (agent log — `/var/ossec/logs/ossec.log`):**
```
2026/06/29 14:35:20 wazuh-agentd: INFO: Started (pid: 9997).
2026/06/29 14:35:20 wazuh-agentd: INFO: Requesting a key from server: 10.2.0.9
2026/06/29 14:35:20 wazuh-agentd: INFO: Using password specified on file: etc/authd.pass
2026/06/29 14:35:20 wazuh-agentd: INFO: Using agent name as: test-envvar
2026/06/29 14:35:20 wazuh-agentd: INFO: Waiting for server reply
2026/06/29 14:35:20 wazuh-agentd: INFO: Valid key received
2026/06/29 14:35:40 wazuh-agentd: INFO: (1410): Reading authentication keys file.
2026/06/29 14:35:40 wazuh-agentd: INFO: Trying to connect to server ([10.2.0.9]:1514/tcp).
2026/06/29 14:35:40 wazuh-agentd: INFO: (4102): Connected to the server ([10.2.0.9]:1514/tcp).
```

**Evidence (manager — `client.keys`):**
```
003 test-envvar any 75e1dcc695edd472d4a0f63a9332f0a61d510a74642a47c0203c25db7a6967f1
```

</details>

### Artifacts Affected

- `wazuh-authd` (Linux manager)
- `etc/templates/config/generic/auth.template`
- `etc/wazuh-manager.conf`
- `var/wazuh-manager/etc/authd.pass` — created automatically on first start
- `docs/ref/configuration/auth.md`
- `docs/ref/getting-started/installation.md`
- `docs/guide/migration/agent-groups-migration.md`
- `docs/ref/modules/authd/README.md`

### Configuration Changes

| Parameter | Old default | New default | Notes |
|-----------|------------|------------|-------|
| `<auth><use_password>` | `no` (template) | `yes` (template) | Binary C default stays `0` for upgrade safety |

Existing installs with `<use_password>no</use_password>` are unaffected. If the file already existed, behaviour is unchanged. If it did not exist, authd now generates and persists one instead of an ephemeral in-memory password.

### Tests Introduced

| File | New tests | Scope |
|------|-----------|-------|
| `src/unit_tests/os_auth/test_authd-config.c` | `test_authd_use_password_default` | `Read_Authd` binary default |
| `src/unit_tests/os_auth/test_auth.c` | 10+ cases | `w_authd_load_password`, `w_authd_read_password`, fail-closed paths, mtime reload |

### Integration tests updated

Three fixes to `tests/integration/test_authd/test_use_password/` to align with the new implementation:

- `test_authd_use_password.py` — `read_random_pass()` now reads `DEFAULT_AUTHD_PASS_PATH` directly instead of scanning logs for `"Random password"` (the password is no longer logged).
- `cases_authd_use_password_invalid.yaml` — expected error updated from `"Empty password provided."` to `"Invalid password provided in 'etc/authd.pass'."`.
- `test_authd_use_password_invalid.py` — `pytest.xfail` reason updated for the spaces-only password case to reflect current behaviour.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
