### PR TITLE
Bind agent index selection and scope deletes by cluster

### DIFF
--- a/src/shared_modules/indexer_connector/include/indexerConnector.hpp
+++ b/src/shared_modules/indexer_connector/include/indexerConnector.hpp
@@ -119,12 +119,12 @@ public:
     ~IndexerConnectorSync();
 
     /**
-     * @brief Publish a message into the queue map.
-     *
-     * @param message Message to be published.
-     * @param index Index name.
+     * @brief Stage a delete-by-query for one agent.
+     * @param index Target index name.
+     * @param agentId wazuh.agent.id filter.
+     * @param clusterName Manager-side cluster name; when set, also filters by wazuh.cluster.name.
      */
-    void deleteByQuery(const std::string& index, const std::string& agentId);
+    void deleteByQuery(const std::string& index, const std::string& agentId, const std::string& clusterName = {});
 
     /**
      * @brief Execute an update by query operation on OpenSearch/Elasticsearch.

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSync.cpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSync.cpp
@@ -28,9 +28,9 @@ public:
     {
     }
 
-    void deleteByQuery(const std::string& index, const std::string& agentId)
+    void deleteByQuery(const std::string& index, const std::string& agentId, const std::string& clusterName)
     {
-        m_impl.deleteByQuery(index, agentId);
+        m_impl.deleteByQuery(index, agentId, clusterName);
     }
 
     void executeUpdateByQuery(const std::vector<std::string>& indices, const nlohmann::json& updateQuery)
@@ -125,9 +125,11 @@ IndexerConnectorSync::IndexerConnectorSync(const nlohmann::json& config, Logging
 
 IndexerConnectorSync::~IndexerConnectorSync() = default;
 
-void IndexerConnectorSync::deleteByQuery(const std::string& index, const std::string& agentId)
+void IndexerConnectorSync::deleteByQuery(const std::string& index,
+                                         const std::string& agentId,
+                                         const std::string& clusterName)
 {
-    m_impl->deleteByQuery(index, agentId);
+    m_impl->deleteByQuery(index, agentId, clusterName);
 }
 
 void IndexerConnectorSync::executeUpdateByQuery(const std::vector<std::string>& indices,

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -734,7 +734,7 @@ public:
             });
     }
 
-    void deleteByQuery(const std::string& index, const std::string& agentId)
+    void deleteByQuery(const std::string& index, const std::string& agentId, const std::string& clusterName = {})
     {
         if (!isSafeIndexName(index))
         {
@@ -744,8 +744,27 @@ public:
                     index.c_str());
             throw IndexerConnectorException("Unsafe index name");
         }
+
         auto [it, success] = m_deleteByQuery.try_emplace(index, nlohmann::json::object());
-        it->second["query"]["bool"]["filter"]["terms"]["wazuh.agent.id"].push_back(agentId);
+        auto& boolQuery = it->second["query"]["bool"];
+
+        if (clusterName.empty())
+        {
+            // No cluster name: filter by agent.id only.
+            boolQuery["filter"]["terms"]["wazuh.agent.id"].push_back(agentId);
+            return;
+        }
+
+        // Filter by agent.id and cluster.name.
+        if (success)
+        {
+            nlohmann::json agentClause;
+            agentClause["terms"]["wazuh.agent.id"] = nlohmann::json::array();
+            nlohmann::json clusterClause;
+            clusterClause["term"]["wazuh.cluster.name"] = clusterName;
+            boolQuery["filter"] = nlohmann::json::array({agentClause, clusterClause});
+        }
+        boolQuery["filter"][0]["terms"]["wazuh.agent.id"].push_back(agentId);
     }
 
     void executeUpdateByQuery(const std::vector<std::string>& indices, const nlohmann::json& updateQuery)

--- a/src/shared_modules/indexer_connector/tests/component/indexerConnector_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/component/indexerConnector_test.cpp
@@ -294,6 +294,38 @@ TEST_F(IndexerConnectorTest, SyncDeleteByQueryAndFlush)
     ASSERT_EQ(body["query"]["bool"]["filter"]["terms"]["wazuh.agent.id"], nlohmann::json::array({agentId}));
 }
 
+/// With a cluster name, the delete query filters by agent.id and cluster.name.
+TEST_F(IndexerConnectorTest, SyncDeleteByQueryScopedByClusterName)
+{
+    std::atomic<bool> callbackCalled {false};
+    std::string receivedBody;
+
+    m_indexerServers[A_IDX]->setPublishCallback(
+        [&](const std::string& body)
+        {
+            receivedBody = body;
+            callbackCalled = true;
+        });
+
+    nlohmann::json config;
+    config["hosts"] = nlohmann::json::array({A_ADDRESS});
+    IndexerConnectorSync connector(config);
+
+    const std::string agentId {"001"};
+    const std::string clusterName {"prod-cluster"};
+    connector.deleteByQuery(INDEXER_NAME, agentId, clusterName);
+    ASSERT_NO_THROW(connector.flush());
+
+    ASSERT_TRUE(callbackCalled);
+
+    const auto body = nlohmann::json::parse(receivedBody);
+    const auto& filter = body["query"]["bool"]["filter"];
+    ASSERT_TRUE(filter.is_array());
+    ASSERT_EQ(filter.size(), 2u);
+    EXPECT_EQ(filter[0]["terms"]["wazuh.agent.id"], nlohmann::json::array({agentId}));
+    EXPECT_EQ(filter[1]["term"]["wazuh.cluster.name"], clusterName);
+}
+
 /**
  * @brief IDs containing characters that require JSON escaping (control bytes,
  * backslashes, double quotes) are transmitted correctly over real HTTP so that

--- a/src/wazuh_modules/inventory_sync/src/agentSession.hpp
+++ b/src/wazuh_modules/inventory_sync/src/agentSession.hpp
@@ -40,18 +40,11 @@ struct Response
 using WorkersQueue = Utils::AsyncValueDispatcher<std::vector<char>, std::function<void(const std::vector<char>&)>>;
 using IndexerQueue = Utils::AsyncValueDispatcher<Response, std::function<void(const Response&)>>;
 
-/**
- * @brief Inventory-sync business rule: an index name must belong to the
- *        wazuh-states-* family and have a non-empty suffix.
- *
- * The connector layer applies an independent safety check (non-empty, only
- * [a-zA-Z0-9._*-]) that prevents URL/JSON injection regardless of caller. This
- * helper only encodes the inventory_sync-specific domain rule.
- */
-inline bool isInventoryStateIndex(std::string_view idx) noexcept
+/// Allowlist of state indices an agent session may target (its own scope).
+inline bool isAgentScopedStateIndex(std::string_view idx) noexcept
 {
-    constexpr std::string_view kPrefix = "wazuh-states-";
-    return idx.starts_with(kPrefix) && idx.size() > kPrefix.size();
+    return idx.starts_with("wazuh-states-inventory-") || idx == "wazuh-states-vulnerabilities" ||
+           idx.starts_with("wazuh-states-fim-") || idx == "wazuh-states-sca" || idx.starts_with("wazuh-states-sca-");
 }
 
 class AgentSessionException : public std::exception
@@ -148,9 +141,7 @@ public:
             }
         }
 
-        // Extract indices. Only keep entries that belong to the wazuh-states-* family
-        // (inventory_sync's domain rule). The connector layer applies an additional
-        // safety check that rejects characters outside [a-zA-Z0-9._*-].
+        // Keep only indices within the agent's scope (see isAgentScopedStateIndex).
         std::vector<std::string> indices;
 
         if (data->index())
@@ -160,10 +151,10 @@ public:
                 if (index)
                 {
                     auto entry = index->str();
-                    if (!isInventoryStateIndex(entry))
+                    if (!isAgentScopedStateIndex(entry))
                     {
                         logWarn(LOGGER_DEFAULT_TAG,
-                                "Start: ignoring index '%s' (does not belong to wazuh-states-* family) for "
+                                "Start: rejecting index '%s' (outside the agent's authorized state-index scope) for "
                                 "agent '%.*s' (session %llu).",
                                 entry.c_str(),
                                 static_cast<int>(agentId.size()),
@@ -336,10 +327,10 @@ public:
         if (data->index())
         {
             auto candidate = data->index()->str();
-            if (!isInventoryStateIndex(candidate))
+            if (!isAgentScopedStateIndex(candidate))
             {
                 logWarn(LOGGER_DEFAULT_TAG,
-                        "ChecksumModule: ignoring index '%s' (does not belong to wazuh-states-* family) for "
+                        "ChecksumModule: rejecting index '%s' (outside the agent's authorized state-index scope) for "
                         "session %llu.",
                         candidate.c_str(),
                         m_context->sessionId);
@@ -464,10 +455,10 @@ public:
         if (data->index())
         {
             std::string index = data->index()->str();
-            if (!isInventoryStateIndex(index))
+            if (!isAgentScopedStateIndex(index))
             {
                 logWarn(LOGGER_DEFAULT_TAG,
-                        "DataClean: ignoring index '%s' (does not belong to wazuh-states-* family) for "
+                        "DataClean: rejecting index '%s' (outside the agent's authorized state-index scope) for "
                         "session %llu, seq %llu.",
                         index.c_str(),
                         m_context->sessionId,

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -446,7 +446,8 @@ class InventorySyncFacadeImpl final
         while (true)
         {
             nlohmann::json searchQuery;
-            searchQuery["query"]["term"]["wazuh.agent.id"] = agentId;
+            searchQuery["query"]["bool"]["must"] = nlohmann::json::array({{{"term", {{"wazuh.agent.id", agentId}}}}});
+            InventorySyncQueryBuilder::addClusterScope(searchQuery, m_clusterName);
             searchQuery["_source"] = nlohmann::json::array({"checksum.hash.sha1"});
             searchQuery["sort"] = nlohmann::json::array({nlohmann::json::object({{"checksum.hash.sha1", "asc"}})});
             searchQuery["size"] = BATCH_SIZE;
@@ -800,6 +801,7 @@ public:
                                                                                 res.context->ostype,
                                                                                 res.context->osversion,
                                                                                 res.context->globalVersion);
+                        InventorySyncQueryBuilder::addClusterScope(metadataQuery, m_clusterName);
 
                         // Execute the update using generic infrastructure method
                         m_indexerConnector->executeUpdateByQuery(res.context->indices, metadataQuery);
@@ -833,6 +835,7 @@ public:
                         // Build the groups update query using domain logic
                         auto groupsQuery = InventorySyncQueryBuilder::buildGroupsUpdateQuery(
                             res.context->agentId, res.context->groups, res.context->globalVersion);
+                        InventorySyncQueryBuilder::addClusterScope(groupsQuery, m_clusterName);
 
                         // Execute the update using generic infrastructure method
                         m_indexerConnector->executeUpdateByQuery(res.context->indices, groupsQuery);
@@ -874,6 +877,7 @@ public:
                                                                                res.context->osplatform,
                                                                                res.context->ostype,
                                                                                res.context->osversion);
+                        InventorySyncQueryBuilder::addClusterScope(metadataCheckQuery, m_clusterName);
 
                         logInfo(LOGGER_DEFAULT_TAG,
                                 "Disaster recovery: Checking and recovering metadata inconsistencies for agent %s "
@@ -913,6 +917,7 @@ public:
                         // Build the groups check query - compares groups and only updates mismatches
                         auto groupsCheckQuery =
                             InventorySyncQueryBuilder::buildGroupsCheckQuery(res.context->agentId, res.context->groups);
+                        InventorySyncQueryBuilder::addClusterScope(groupsCheckQuery, m_clusterName);
 
                         logInfo(LOGGER_DEFAULT_TAG,
                                 "Disaster recovery: Checking and recovering groups inconsistencies for agent %s across "
@@ -1053,7 +1058,7 @@ public:
                                           res.context->agentId.c_str());
                                 try
                                 {
-                                    m_indexerConnector->deleteByQuery(index, res.context->agentId);
+                                    m_indexerConnector->deleteByQuery(index, res.context->agentId, m_clusterName);
                                     hasDeleteByQueryEnqueued = true;
                                 }
                                 catch (const std::exception& e)
@@ -1079,7 +1084,7 @@ public:
                             {
                                 try
                                 {
-                                    m_indexerConnector->deleteByQuery(index, res.context->agentId);
+                                    m_indexerConnector->deleteByQuery(index, res.context->agentId, m_clusterName);
                                     hasDeleteByQueryEnqueued = true;
                                 }
                                 catch (const std::exception& e)
@@ -1123,16 +1128,26 @@ public:
                                     throw InventorySyncException("Invalid data message");
                                 }
 
-                                // Validate the per-document index against the inventory_sync domain rule
+                                // Per-document index must be in the agent's scope.
                                 const auto rawIndex = data->index() ? data->index()->string_view() : std::string_view();
-                                if (!isInventoryStateIndex(rawIndex))
+                                if (!isAgentScopedStateIndex(rawIndex))
                                 {
                                     logWarn(LOGGER_DEFAULT_TAG,
                                             "InventorySyncFacade::start: skipping bulk entry for session %llu - "
-                                            "index '%.*s' does not belong to wazuh-states-* family.",
+                                            "index '%.*s' is outside the agent's authorized state-index scope.",
                                             res.context->sessionId,
                                             static_cast<int>(rawIndex.size()),
                                             rawIndex.data());
+                                    continue;
+                                }
+
+                                // Agents may clean wazuh-states-vulnerabilities (DataClean) but not write to it.
+                                if (rawIndex == "wazuh-states-vulnerabilities")
+                                {
+                                    logWarn(LOGGER_DEFAULT_TAG,
+                                            "InventorySyncFacade::start: rejecting agent write to "
+                                            "'wazuh-states-vulnerabilities' (session %llu).",
+                                            res.context->sessionId);
                                     continue;
                                 }
 
@@ -2042,9 +2057,9 @@ private:
 
         try
         {
-            // Delete all agent data from wazuh-states-* indexes using wildcard pattern
+            // Delete this agent's data across wazuh-states-*, scoped to this cluster.
             auto lock = m_indexerConnector->scopeLock();
-            m_indexerConnector->deleteByQuery(WAZUH_STATES_INDEX_PATTERN, agentId);
+            m_indexerConnector->deleteByQuery(WAZUH_STATES_INDEX_PATTERN, agentId, m_clusterName);
 
             logInfo(LOGGER_DEFAULT_TAG,
                     "InventorySyncFacade::deleteAgent: Successfully deleted data for agent '%s'",

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncQueryBuilder.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncQueryBuilder.hpp
@@ -19,6 +19,15 @@
 
 namespace InventorySyncQueryBuilder
 {
+    /// Append a cluster.name filter to a bool/must query (no-op if @p clusterName is empty).
+    inline void addClusterScope(nlohmann::json& query, const std::string& clusterName)
+    {
+        if (!clusterName.empty())
+        {
+            query["query"]["bool"]["must"].push_back({{"term", {{"wazuh.cluster.name", clusterName}}}});
+        }
+    }
+
     /// @brief Build update query for agent metadata across all documents
     /// @param agentId Agent ID to match
     /// @param agentName New agent name
@@ -372,10 +381,12 @@ namespace InventorySyncQueryBuilder
     inline nlohmann::json
     buildContextGetQuery(const std::string& agentId, std::size_t size, const std::string& searchAfter = "")
     {
-        nlohmann::json query = {{"_source", nlohmann::json::array({"vulnerability.id", "vulnerability.score"})},
-                                {"query", {{"term", {{"wazuh.agent.id", agentId}}}}},
-                                {"size", size},
-                                {"sort", {{{"_id", {{"order", "asc"}}}}}}};
+        // bool/must so callers can append a cluster.name filter via addClusterScope.
+        nlohmann::json query = {
+            {"_source", nlohmann::json::array({"vulnerability.id", "vulnerability.score"})},
+            {"query", {{"bool", {{"must", nlohmann::json::array({{{"term", {{"wazuh.agent.id", agentId}}}}})}}}}},
+            {"size", size},
+            {"sort", {{{"_id", {{"order", "asc"}}}}}}};
 
         if (!searchAfter.empty())
         {

--- a/src/wazuh_modules/inventory_sync/tests/unit/agentSession_test.cpp
+++ b/src/wazuh_modules/inventory_sync/tests/unit/agentSession_test.cpp
@@ -746,9 +746,7 @@ TEST_F(AgentSessionTest, Constructor_StartIndices_FiltersOutNonStatePrefix)
 
 TEST_F(AgentSessionTest, Constructor_StartIndices_EmptyPrefixOnlyRejected)
 {
-    // "wazuh-states-" exactly (empty suffix) must be rejected, even though it
-    // starts with the prefix — isInventoryStateIndex requires a non-empty
-    // suffix because an empty suffix would collapse to an unusable index name.
+    // "wazuh-states-" (empty suffix) matches no agent-scoped family: rejected.
     auto startMsg = createStartWithIndices(builder, 1, {"wazuh-states-"});
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
@@ -770,6 +768,69 @@ TEST_F(AgentSessionTest, Constructor_StartIndices_AllValidPassedThrough)
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher);
 
     EXPECT_EQ(session.getContext()->indices.size(), 3u);
+}
+
+// A wazuh-states-* name outside the agent scope must be rejected.
+TEST_F(AgentSessionTest, Constructor_StartIndices_RejectsOutOfScopeStateIndex)
+{
+    auto startMsg = createStartWithIndices(
+        builder, 1, {"wazuh-states-inventory-packages", "wazuh-states-something-else", "wazuh-states-rules"});
+    builder.Finish(startMsg);
+    auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
+
+    EXPECT_CALL(mockResponseDispatcher, sendStartAck(Wazuh::SyncSchema::Status_Ok, _, _, _)).Times(1);
+    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher);
+
+    const auto& storedIndices = session.getContext()->indices;
+    ASSERT_EQ(storedIndices.size(), 1u);
+    EXPECT_EQ(storedIndices[0], "wazuh-states-inventory-packages");
+}
+
+// Manager-governance indices must be rejected.
+TEST_F(AgentSessionTest, Constructor_StartIndices_RejectsManagerGovernanceIndices)
+{
+    auto startMsg = createStartWithIndices(builder,
+                                           1,
+                                           {"wazuh-states-agent-management",
+                                            "wazuh-states-cluster-nodes",
+                                            "wazuh-states-manager-status",
+                                            "wazuh-states-vulnerabilities"},
+                                           Wazuh::SyncSchema::Mode_ModuleFull,
+                                           "syscollector_vd");
+    builder.Finish(startMsg);
+    auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
+
+    EXPECT_CALL(mockResponseDispatcher, sendStartAck(Wazuh::SyncSchema::Status_Ok, _, _, _)).Times(1);
+    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher);
+
+    // Only the in-scope vulnerabilities index survives.
+    const auto& storedIndices = session.getContext()->indices;
+    ASSERT_EQ(storedIndices.size(), 1u);
+    EXPECT_EQ(storedIndices[0], "wazuh-states-vulnerabilities");
+}
+
+// Direct coverage of the index-authorization predicate.
+TEST_F(AgentSessionTest, IsAgentScopedStateIndex_AllowlistAndBlocklist)
+{
+    // In-scope families.
+    EXPECT_TRUE(isAgentScopedStateIndex("wazuh-states-inventory-packages"));
+    EXPECT_TRUE(isAgentScopedStateIndex("wazuh-states-inventory-system"));
+    EXPECT_TRUE(isAgentScopedStateIndex("wazuh-states-vulnerabilities"));
+    EXPECT_TRUE(isAgentScopedStateIndex("wazuh-states-fim-files"));
+    EXPECT_TRUE(isAgentScopedStateIndex("wazuh-states-fim-registry-keys"));
+    EXPECT_TRUE(isAgentScopedStateIndex("wazuh-states-sca"));
+
+    // Manager-governance indices: denied (not in the allowlist).
+    EXPECT_FALSE(isAgentScopedStateIndex("wazuh-states-agent-management"));
+    EXPECT_FALSE(isAgentScopedStateIndex("wazuh-states-cluster-nodes"));
+    EXPECT_FALSE(isAgentScopedStateIndex("wazuh-states-manager-status"));
+
+    // Out-of-scope / malformed names.
+    EXPECT_FALSE(isAgentScopedStateIndex("wazuh-states-"));
+    EXPECT_FALSE(isAgentScopedStateIndex("wazuh-states-rules"));
+    EXPECT_FALSE(isAgentScopedStateIndex("wazuh-other-foo"));
+    EXPECT_FALSE(isAgentScopedStateIndex("random"));
+    EXPECT_FALSE(isAgentScopedStateIndex(""));
 }
 
 TEST_F(AgentSessionTest, HandleChecksumModule_NonStateIndex_Ignored)

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/eventGetContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/eventGetContext.hpp
@@ -250,7 +250,7 @@ public:
                 }
                 osType = Utils::toLowerCase(osType);
 
-                const auto updateQuery = InventorySyncQueryBuilder::buildVulnerabilitiesHostOsUpdateQuery(
+                auto updateQuery = InventorySyncQueryBuilder::buildVulnerabilitiesHostOsUpdateQuery(
                     agentId,
                     std::string {data->osName()},
                     osPlatform,
@@ -258,6 +258,8 @@ public:
                     data->buildOSVersion(),
                     data->buildOSFullName(),
                     std::string {data->osKernelRelease()});
+                // Filter by the manager cluster so the update stays within this cluster.
+                InventorySyncQueryBuilder::addClusterScope(updateQuery, std::string(data->managerClusterName()));
 
                 m_indexerConnector->executeUpdateByQuery({index}, updateQuery);
 
@@ -281,6 +283,8 @@ public:
             auto query = InventorySyncQueryBuilder::buildContextGetQuery(agentId,
                                                                          DEFAULT_PAGE_SIZE,
                                                                          ""); // first page, no search_after
+            // Filter by the manager cluster so reconciliation only reads this cluster's documents.
+            InventorySyncQueryBuilder::addClusterScope(query, std::string(data->managerClusterName()));
 
             m_indexerConnector->executeSearchQueryWithPagination(
                 index,

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/eventGetCve.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/eventGetCve.hpp
@@ -131,6 +131,8 @@ public:
                 // which map to package.path and package.type in the index.
                 auto query = InventorySyncQueryBuilder::buildCveGetQuery(
                     agentId, pkgCtx.name, pkgCtx.version, pkgCtx.location, pkgCtx.format, PAGE_SIZE, "");
+                // Filter by the manager cluster.
+                InventorySyncQueryBuilder::addClusterScope(query, std::string(data->managerClusterName()));
 
                 logDebug2(WM_VULNSCAN_LOGTAG, "TEventGetCve - Query string '%s'", query.dump().c_str());
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
@@ -49,10 +49,17 @@ private:
     static nlohmann::json buildInventoryQuery(const std::string& agentId,
                                               std::size_t size,
                                               const std::string& searchAfter,
-                                              const std::vector<std::string>& sourceFields)
+                                              const std::vector<std::string>& sourceFields,
+                                              const std::string& clusterName)
     {
+        nlohmann::json must = nlohmann::json::array({{{"term", {{"wazuh.agent.id", agentId}}}}});
+        if (!clusterName.empty())
+        {
+            must.push_back({{"term", {{"wazuh.cluster.name", clusterName}}}});
+        }
+
         nlohmann::json query = {{"_source", sourceFields},
-                                {"query", {{"term", {{"wazuh.agent.id", agentId}}}}},
+                                {"query", {{"bool", {{"must", must}}}}},
                                 {"size", size},
                                 {"sort", {{{"_id", {{"order", "asc"}}}}}}};
 
@@ -68,13 +75,14 @@ private:
     void fetchInventoryDocuments(const std::string& index,
                                  const std::string& agentId,
                                  const std::vector<std::string>& sourceFields,
+                                 const std::string& clusterName,
                                  Callback&& onHit) const
     {
         std::string searchAfter;
 
         while (true)
         {
-            const auto query = buildInventoryQuery(agentId, DEFAULT_PAGE_SIZE, searchAfter, sourceFields);
+            const auto query = buildInventoryQuery(agentId, DEFAULT_PAGE_SIZE, searchAfter, sourceFields, clusterName);
             const auto response = m_indexerConnector->executeSearchQuery(index, query);
 
             if (!response.contains("hits") || !response["hits"].is_object())
@@ -283,7 +291,7 @@ private:
         return context;
     }
 
-    void scanAgent(const AgentContextData& agent, const bool noIndex) const
+    void scanAgent(const AgentContextData& agent, const bool noIndex, const std::string& clusterName) const
     {
         // Skip agents already covered by a concurrent VDFirst session in this post feed update scan cycle.
         if (m_shouldSkipAgent && m_shouldSkipAgent(agent.id))
@@ -333,6 +341,7 @@ private:
             fetchInventoryDocuments(std::string(OS_INDEX),
                                     agent.id,
                                     {"host"},
+                                    clusterName,
                                     [&](const nlohmann::json& hit)
                                     {
                                         if (!hit.contains("_source") || !hit["_source"].is_object())
@@ -364,6 +373,7 @@ private:
             fetchInventoryDocuments(std::string(PACKAGE_INDEX),
                                     agent.id,
                                     {"package"},
+                                    clusterName,
                                     [&](const nlohmann::json& hit)
                                     {
                                         if (!hit.contains("_source") || !hit["_source"].is_object())
@@ -410,6 +420,7 @@ private:
             fetchInventoryDocuments(std::string(HOTFIX_INDEX),
                                     agent.id,
                                     {"package"},
+                                    clusterName,
                                     [&](const nlohmann::json& hit)
                                     {
                                         if (!hit.contains("_source") || !hit["_source"].is_object())
@@ -482,7 +493,7 @@ public:
             try
             {
                 logDebug2(WM_VULNSCAN_LOGTAG, "Processing agent %s", agent.id.c_str());
-                scanAgent(agent, data->isNoIndex());
+                scanAgent(agent, data->isNoIndex(), std::string(data->managerClusterName()));
             }
             catch (const std::exception& e)
             {

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanContext.hpp
@@ -1177,6 +1177,12 @@ public:
         return !m_clusterName.empty() ? m_clusterName : s_clusterName;
     }
 
+    /// Manager-configured cluster name (not the agent-supplied value).
+    std::string_view managerClusterName() const noexcept
+    {
+        return s_clusterName;
+    }
+
     /**
      * @brief Get cluster node name.
      * Returns per-agent cluster node from inventory sync if available,

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
@@ -150,7 +150,10 @@ public:
 
                 {
                     auto indexerLock = m_indexerConnector->scopeLock();
-                    m_indexerConnector->deleteByQuery("wazuh-states-vulnerabilities", inventorySyncContext.agentId);
+                    // Scope the pre-rescan delete by agent.id and the manager cluster.
+                    m_indexerConnector->deleteByQuery("wazuh-states-vulnerabilities",
+                                                      inventorySyncContext.agentId,
+                                                      std::string(scanContext->managerClusterName()));
                     m_firstFullScanOrchestration->handleRequest(scanContext);
                 }
                 m_indexerConnector->flush();

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockIndexerConnector.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/MockIndexerConnector.hpp
@@ -86,7 +86,10 @@ public:
     /**
      * @brief Mock method for delete by query.
      */
-    MOCK_METHOD(void, deleteByQuery, (const std::string& index, const std::string& agentId), ());
+    MOCK_METHOD(void,
+                deleteByQuery,
+                (const std::string& index, const std::string& agentId, const std::string& clusterName),
+                ());
 
     /**
      * @brief Mock method for scopeLock.

--- a/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolineScanContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/mocks/TrampolineScanContext.hpp
@@ -49,6 +49,16 @@ public:
         return "001";
     }
 
+    std::string_view clusterName() const
+    {
+        return "cluster01";
+    }
+
+    std::string_view managerClusterName() const
+    {
+        return "cluster01";
+    }
+
     std::string_view agentVersion() const
     {
         return "5.0.0";

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_test.cpp
@@ -3401,7 +3401,7 @@ TEST_F(ScanOrchestratorTest, VDFirstScan_EmptyPackageInventory_ShouldAbort)
     auto spIndexerConnectorMock = std::make_shared<MockIndexerConnector>();
 
     // deleteByQuery should NOT be called when package count is 0
-    EXPECT_CALL(*spIndexerConnectorMock, deleteByQuery(_, _)).Times(0);
+    EXPECT_CALL(*spIndexerConnectorMock, deleteByQuery(_, _, _)).Times(0);
     EXPECT_CALL(*spIndexerConnectorMock, flush()).Times(0);
     EXPECT_CALL(*spIndexerConnectorMock, scopeLock()).Times(0);
 


### PR DESCRIPTION
## Description

An enrolled agent could choose which `wazuh-states-*` index an inventory-sync session writes to or deletes from. The manager only checked the broad `wazuh-states-*` prefix, so a low-privileged agent could target manager-authored indices such as `wazuh-states-vulnerabilities` and delete or forge its own vulnerability state. In a shared-indexer multi-cluster deployment, deletes scoped only by `agent.id` could also affect same-id agents in other clusters.

## Changes

- Replace the prefix-only index check with `isAgentScopedStateIndex`: only `wazuh-states-inventory-*`, `wazuh-states-vulnerabilities`, `wazuh-states-fim-*` and `wazuh-states-sca[-*]` are accepted; `wazuh-states-agent-management`, `wazuh-states-cluster-*` and `wazuh-states-manager-*` are rejected. Applied to Start, DataClean, ChecksumModule and the per-document bulk path.
- Add a manager-authoritative `clusterName` to `deleteByQuery`; the query now filters by `wazuh.agent.id` AND `wazuh.cluster.name`. The cluster name comes from the manager configuration, never from the agent message. Same scoping applied to the VD scanner pre-rescan wipe.
- Regression tests for the allowlist/blocklist and the cluster-scoped delete query.

## Tests

- [x] Unit/component tests added (inventory-sync, indexer-connector, vulnerability-scanner)