### PR TITLE
Indexer connector bulk size and flush interval configurable

### DIFF
--- a/docs/ref/modules/engine/README.md
+++ b/docs/ref/modules/engine/README.md
@@ -2707,6 +2707,8 @@ Edit the file and restart the `wazuh-manager` service for changes to take effect
 | Setting | Description | Default |
 |:--------|:------------|:-------:|
 | `analysisd.indexer_queue_max_events` | Maximum number of events waiting in the indexer output queue. Events can be dropped when this queue is full. | `131072` |
+| `analysisd.indexer_bulk_size` | Maximum number of **documents** accumulated in the asynchronous indexer bulk buffer before a `_bulk` request is dispatched to `wazuh-indexer`. Counts documents, not bytes (the byte-oriented threshold used by `wazuh-modulesd` lives under different keys). Allowed range: `1` to `1000000`. | `25000` |
+| `analysisd.indexer_flush_interval` | Seconds between periodic flushes of the asynchronous indexer bulk buffer. Drives the background timer that forwards buffered events to `wazuh-indexer` when the document-count threshold has not been reached. Allowed range: `1` to `3600`. | `20` |
 
 ### Synchronization settings
 

--- a/docs/ref/modules/indexer_connector/README.md
+++ b/docs/ref/modules/indexer_connector/README.md
@@ -31,15 +31,16 @@ The library provides two classes depending on the use case:
 
 ### Sync flush behavior
 
-- Buffer up to 10 MB of events before flushing.
-- Flush automatically after 20 seconds of inactivity.
+- Buffer up to 10 MB of serialized events before flushing (configurable: `wazuh_modules.indexer_bulk_size_bytes` for Vulnerability Scanner, `wazuh_modules.inventory_sync_indexer_bulk_size_bytes` for Inventory Sync).
+- Flush automatically after 20 seconds of inactivity (configurable: `wazuh_modules.indexer_flush_interval` for Vulnerability Scanner, `wazuh_modules.inventory_sync_indexer_flush_interval` for Inventory Sync).
 - If the indexer returns HTTP 413 (payload too large), the batch is split and retried.
 - Version conflicts at the document level are handled per-document.
 
 ### Async flush behavior
 
 - Events are queued to RocksDB immediately and flushed by a background thread.
-- Up to 25,000 documents per flush batch.
+- Up to 25,000 documents per flush batch (configurable via `analysisd.indexer_bulk_size`).
+- Flush automatically after 20 seconds of inactivity (configurable via `analysisd.indexer_flush_interval`).
 - If `max_queue_size` is set, events that exceed the limit are dropped and counted.
 - The queue survives manager restarts.
 

--- a/docs/ref/modules/inventory-sync/configuration.md
+++ b/docs/ref/modules/inventory-sync/configuration.md
@@ -87,7 +87,7 @@ Current manager-side behavior:
 
 Inventory Sync reads the indexer bulk-size threshold from the internal option `wazuh_modules.inventory_sync_indexer_bulk_size_bytes`.
 
-The value is forwarded to the Indexer Connector as the `max_bulk_size` field of its JSON configuration and bounds the NDJSON payload size accumulated in the bulk buffer before a synchronous flush to `wazuh-indexer` is triggered. It applies independently of any other connector instance (the vulnerability scanner module has its own equivalent option, `wazuh_modulesd.indexer_bulk_size_bytes`).
+The value is forwarded to the Indexer Connector as the `max_bulk_size` field of its JSON configuration and bounds the NDJSON payload size accumulated in the bulk buffer before a synchronous flush to `wazuh-indexer` is triggered. It applies independently of any other connector instance (the vulnerability scanner module has its own equivalent option, `wazuh_modules.indexer_bulk_size_bytes`).
 
 Current manager-side behavior:
 
@@ -99,7 +99,7 @@ Current manager-side behavior:
 
 Inventory Sync reads the indexer periodic flush interval from the internal option `wazuh_modules.inventory_sync_indexer_flush_interval`.
 
-The value is forwarded to the Indexer Connector as the `flush_interval_seconds` field of its JSON configuration and drives the background timer that flushes the bulk buffer when the size threshold has not been reached. It applies independently of any other connector instance (the vulnerability scanner module has its own equivalent option, `wazuh_modulesd.indexer_flush_interval`).
+The value is forwarded to the Indexer Connector as the `flush_interval_seconds` field of its JSON configuration and drives the background timer that flushes the bulk buffer when the size threshold has not been reached. It applies independently of any other connector instance (the vulnerability scanner module has its own equivalent option, `wazuh_modules.indexer_flush_interval`).
 
 Current manager-side behavior:
 

--- a/docs/ref/modules/inventory-sync/configuration.md
+++ b/docs/ref/modules/inventory-sync/configuration.md
@@ -12,6 +12,8 @@ The runtime configuration passed to Inventory Sync contains:
 - **`maxSessions`**: the session cap derived from internal options.
 - **`queueSize`**: the input worker queue cap derived from internal options.
 - **`dataValueQuota`**: the global `DataValue` quota derived from internal options.
+- **`indexerBulkSize`**: the indexer bulk-size threshold (bytes) derived from internal options. Forwarded to the Indexer Connector as `max_bulk_size`.
+- **`indexerFlushInterval`**: the indexer periodic flush interval (seconds) derived from internal options. Forwarded to the Indexer Connector as `flush_interval_seconds`.
 
 The module refuses to start if `clusterName` is missing.
 
@@ -37,7 +39,9 @@ Example configuration payload passed to the module:
   "clusterNodeName": "node01",
   "maxSessions": 1000,
   "queueSize": 10000,
-  "dataValueQuota": 500000
+  "dataValueQuota": 500000,
+  "indexerBulkSize": 10485760,
+  "indexerFlushInterval": 20
 }
 ```
 
@@ -78,6 +82,30 @@ Current manager-side behavior:
 - Default on manager builds: `500000`.
 - If the requested `size` exceeds the remaining quota, the Start message is rejected with `Status_Offline` (the agent will retry later, mirroring the `max_sessions` rejection shape).
 - Quota-rejection events are always logged (no rate limiting).
+
+### Indexer bulk-size threshold
+
+Inventory Sync reads the indexer bulk-size threshold from the internal option `wazuh_modules.inventory_sync_indexer_bulk_size_bytes`.
+
+The value is forwarded to the Indexer Connector as the `max_bulk_size` field of its JSON configuration and bounds the NDJSON payload size accumulated in the bulk buffer before a synchronous flush to `wazuh-indexer` is triggered. It applies independently of any other connector instance (the vulnerability scanner module has its own equivalent option, `wazuh_modulesd.indexer_bulk_size_bytes`).
+
+Current manager-side behavior:
+
+- Allowed range: `4096` to `104857600` (4 KB to 100 MB).
+- Default on manager builds: `10485760` (10 MB).
+- The lower bound is set well above the worst-case per-item JSON overhead (`{"index":{"_index":"...","_id":"..."}}` plus a 32 B version slot ≈ 65 B baseline, before index name and `_id`). Smaller values would not crash the connector — the size check in `bulkIndex` / `bulkDelete` is gated by a `!m_bulkData.empty()` precondition — but they degrade the connector into "one HTTP request per document", which is rarely desirable.
+
+### Indexer flush interval
+
+Inventory Sync reads the indexer periodic flush interval from the internal option `wazuh_modules.inventory_sync_indexer_flush_interval`.
+
+The value is forwarded to the Indexer Connector as the `flush_interval_seconds` field of its JSON configuration and drives the background timer that flushes the bulk buffer when the size threshold has not been reached. It applies independently of any other connector instance (the vulnerability scanner module has its own equivalent option, `wazuh_modulesd.indexer_flush_interval`).
+
+Current manager-side behavior:
+
+- Allowed range: `1` to `3600` (1 second to 1 hour).
+- Default on manager builds: `20` seconds.
+- When the timer fires on an empty buffer, no HTTP request is issued.
 
 ## Operational constants
 

--- a/docs/ref/modules/vulnerability-scanner/configuration.md
+++ b/docs/ref/modules/vulnerability-scanner/configuration.md
@@ -87,3 +87,29 @@ If client authentication is enabled, include the client certificate and key:
 ```console
 curl --cacert <root_CA_path> --cert <cert_path> --key <key_path> https://<indexer-ip>:9200/_cluster/health
 ```
+
+## Internal options
+
+### Indexer bulk-size threshold
+
+Vulnerability Scanner reads the indexer bulk-size threshold from the internal option `wazuh_modules.indexer_bulk_size_bytes`.
+
+The value is forwarded to the Indexer Connector as the `max_bulk_size` field of its JSON configuration and bounds the NDJSON payload size accumulated in the bulk buffer before a synchronous flush to `wazuh-indexer` is triggered. It applies independently of any other connector instance (the inventory sync module has its own equivalent option, `wazuh_modules.inventory_sync_indexer_bulk_size_bytes`).
+
+Current manager-side behavior:
+
+- Allowed range: `4096` to `104857600` (4 KB to 100 MB).
+- Default on manager builds: `10485760` (10 MB).
+- The lower bound is set well above the worst-case per-item JSON overhead. Smaller values would not crash the connector — the size check is gated by a `!m_bulkData.empty()` precondition — but they degrade the connector into "one HTTP request per document", which is rarely desirable.
+
+### Indexer flush interval
+
+Vulnerability Scanner reads the indexer periodic flush interval from the internal option `wazuh_modules.indexer_flush_interval`.
+
+The value is forwarded to the Indexer Connector as the `flush_interval_seconds` field of its JSON configuration and drives the background timer that flushes the bulk buffer when the size threshold has not been reached. It applies independently of any other connector instance (the inventory sync module has its own equivalent option, `wazuh_modules.inventory_sync_indexer_flush_interval`).
+
+Current manager-side behavior:
+
+- Allowed range: `1` to `3600` (1 second to 1 hour).
+- Default on manager builds: `20` seconds.
+- When the timer fires on an empty buffer, no HTTP request is issued.

--- a/src/engine/source/conf/include/conf/keys.hpp
+++ b/src/engine/source/conf/include/conf/keys.hpp
@@ -32,7 +32,7 @@ constexpr std::string_view INDEXER_SSL_CA_BUNDLE = "analysisd.indexer_ssl_certif
 constexpr std::string_view INDEXER_SSL_CERTIFICATE = "analysisd.indexer_ssl_certificate";
 constexpr std::string_view INDEXER_SSL_KEY = "analysisd.indexer_ssl_key";
 constexpr std::string_view INDEXER_QUEUE_MAX_EVENTS = "analysisd.indexer_queue_max_events";
-constexpr std::string_view INDEXER_ELEMENTS_PER_BULK = "analysisd.indexer_bulk_size";
+constexpr std::string_view INDEXER_ELEMENTS_PER_BULK = "analysisd.indexer_bulk_size_events";
 constexpr std::string_view INDEXER_FLUSH_INTERVAL = "analysisd.indexer_flush_interval";
 
 constexpr std::string_view IOC_INDEXER_CONNECTOR_MAX_RETRIES = "analysisd.ioc_indexer_connector_max_retries";

--- a/src/engine/source/conf/include/conf/keys.hpp
+++ b/src/engine/source/conf/include/conf/keys.hpp
@@ -32,6 +32,8 @@ constexpr std::string_view INDEXER_SSL_CA_BUNDLE = "analysisd.indexer_ssl_certif
 constexpr std::string_view INDEXER_SSL_CERTIFICATE = "analysisd.indexer_ssl_certificate";
 constexpr std::string_view INDEXER_SSL_KEY = "analysisd.indexer_ssl_key";
 constexpr std::string_view INDEXER_QUEUE_MAX_EVENTS = "analysisd.indexer_queue_max_events";
+constexpr std::string_view INDEXER_ELEMENTS_PER_BULK = "analysisd.indexer_bulk_size";
+constexpr std::string_view INDEXER_FLUSH_INTERVAL = "analysisd.indexer_flush_interval";
 
 constexpr std::string_view IOC_INDEXER_CONNECTOR_MAX_RETRIES = "analysisd.ioc_indexer_connector_max_retries";
 constexpr std::string_view IOC_INDEXER_CONNECTOR_RETRY_INTERVAL = "analysisd.ioc_indexer_connector_retry_interval";

--- a/src/engine/source/conf/src/conf.cpp
+++ b/src/engine/source/conf/src/conf.cpp
@@ -64,6 +64,8 @@ Conf::Conf(std::shared_ptr<IFileLoader> fileLoader)
     addUnit<std::string>(key::INDEXER_SSL_CERTIFICATE, "WAZUH_INDEXER_SSL_CERTIFICATE", "");
     addUnit<std::string>(key::INDEXER_SSL_KEY, "WAZUH_INDEXER_SSL_KEY", "");
     addUnit<size_t>(key::INDEXER_QUEUE_MAX_EVENTS, "WAZUH_INDEXER_QUEUE_MAX_EVENTS", 0x1 << 17);
+    addUnit<size_t>(key::INDEXER_ELEMENTS_PER_BULK, "WAZUH_INDEXER_ELEMENTS_PER_BULK", 25000);
+    addUnit<size_t>(key::INDEXER_FLUSH_INTERVAL, "WAZUH_INDEXER_FLUSH_INTERVAL", 20);
     addUnit<size_t>(
         key::CMSYNC_INDEXER_CONNECTOR_SYNC_BATCH_SIZE, "WAZUH_CMSYNC_INDEXER_CONNECTOR_SYNC_BATCH_SIZE", 100);
     // IOC Sync

--- a/src/engine/source/main.cpp
+++ b/src/engine/source/main.cpp
@@ -429,7 +429,7 @@ int main(int argc, char* argv[])
                 if (elementsPerBulk == 0 || elementsPerBulk > INDEXER_ELEMENTS_PER_BULK_MAX)
                 {
                     throw std::runtime_error(
-                        fmt::format("analysisd.indexer_bulk_size must be between 1 and {} (got {})",
+                        fmt::format("analysisd.indexer_bulk_size_events must be between 1 and {} (got {})",
                                     INDEXER_ELEMENTS_PER_BULK_MAX,
                                     elementsPerBulk));
                 }

--- a/src/engine/source/main.cpp
+++ b/src/engine/source/main.cpp
@@ -423,6 +423,29 @@ int main(int argc, char* argv[])
                 json::Json jsonCnf(baseJsonCnf);
                 const auto maxQueueSize = confManager.get<size_t>(conf::key::INDEXER_QUEUE_MAX_EVENTS);
                 jsonCnf.setUint64(maxQueueSize, "/max_queue_size");
+
+                constexpr size_t INDEXER_ELEMENTS_PER_BULK_MAX = 1000000;
+                const auto elementsPerBulk = confManager.get<size_t>(conf::key::INDEXER_ELEMENTS_PER_BULK);
+                if (elementsPerBulk == 0 || elementsPerBulk > INDEXER_ELEMENTS_PER_BULK_MAX)
+                {
+                    throw std::runtime_error(
+                        fmt::format("analysisd.indexer_bulk_size must be between 1 and {} (got {})",
+                                    INDEXER_ELEMENTS_PER_BULK_MAX,
+                                    elementsPerBulk));
+                }
+                jsonCnf.setUint64(elementsPerBulk, "/elements_per_bulk");
+
+                constexpr size_t INDEXER_FLUSH_INTERVAL_MAX = 3600;
+                const auto flushInterval = confManager.get<size_t>(conf::key::INDEXER_FLUSH_INTERVAL);
+                if (flushInterval == 0 || flushInterval > INDEXER_FLUSH_INTERVAL_MAX)
+                {
+                    throw std::runtime_error(
+                        fmt::format("analysisd.indexer_flush_interval must be between 1 and {} (got {})",
+                                    INDEXER_FLUSH_INTERVAL_MAX,
+                                    flushInterval));
+                }
+                jsonCnf.setUint64(flushInterval, "/flush_interval_seconds");
+
                 const auto maxHitsPerRequest =
                     confManager.get<std::size_t>(conf::key::CMSYNC_INDEXER_CONNECTOR_SYNC_BATCH_SIZE);
 

--- a/src/shared_modules/indexer_connector/src/indexerConnectorAsyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorAsyncImpl.hpp
@@ -237,10 +237,9 @@ public:
                 ? config.at("flush_interval_seconds").get<size_t>()
                 : FlushInterval;
 
-        m_elementsPerBulk =
-            config.contains("elements_per_bulk") && config.at("elements_per_bulk").is_number_integer()
-                ? config.at("elements_per_bulk").get<size_t>()
-                : ElementsPerBulk;
+        m_elementsPerBulk = config.contains("elements_per_bulk") && config.at("elements_per_bulk").is_number_integer()
+                                ? config.at("elements_per_bulk").get<size_t>()
+                                : ElementsPerBulk;
 
         m_loggerProcessor = std::make_unique<ThreadLoggerQueue>(
             [this](const IndexerResponse& data)

--- a/src/shared_modules/indexer_connector/src/indexerConnectorAsyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorAsyncImpl.hpp
@@ -121,6 +121,7 @@ class IndexerConnectorAsyncImpl final
     size_t m_successCount {0};
     size_t m_maxQueueSize {0};
     size_t m_flushInterval {FlushInterval};
+    size_t m_elementsPerBulk {ElementsPerBulk};
     std::unique_ptr<ThreadDispatchQueue> m_dispatcher;
 
 public:
@@ -235,6 +236,11 @@ public:
             config.contains("flush_interval_seconds") && config.at("flush_interval_seconds").is_number_integer()
                 ? config.at("flush_interval_seconds").get<size_t>()
                 : FlushInterval;
+
+        m_elementsPerBulk =
+            config.contains("elements_per_bulk") && config.at("elements_per_bulk").is_number_integer()
+                ? config.at("elements_per_bulk").get<size_t>()
+                : ElementsPerBulk;
 
         m_loggerProcessor = std::make_unique<ThreadLoggerQueue>(
             [this](const IndexerResponse& data)
@@ -409,10 +415,10 @@ public:
 
                 const auto onSuccess = [this, &bulkData, &boundaries](std::string&& response)
                 {
-                    if (m_dispatcher->bulkSize() != ElementsPerBulk && m_successCount == MaxSuccessCount)
+                    if (m_dispatcher->bulkSize() != m_elementsPerBulk && m_successCount == MaxSuccessCount)
                     {
-                        logDebug2(m_logTag.c_str(), "Resetting bulk size to %zu.", ElementsPerBulk);
-                        m_dispatcher->bulkSize(ElementsPerBulk);
+                        logDebug2(m_logTag.c_str(), "Resetting bulk size to %zu.", m_elementsPerBulk);
+                        m_dispatcher->bulkSize(m_elementsPerBulk);
                         m_error413Logged = false;
                     }
 
@@ -505,7 +511,7 @@ public:
                                     {});
             },
             m_dbPath,
-            ElementsPerBulk,
+            m_elementsPerBulk,
             m_maxQueueSize,
             RetryDelay,
             m_flushInterval);

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -685,10 +685,9 @@ public:
         m_selector =
             selector ? std::move(selector) : std::make_unique<TSelector>(config.at("hosts"), 10, m_secureCommunication);
 
-        m_maxBulkSize =
-            config.contains("max_bulk_size") && config.at("max_bulk_size").is_number_integer()
-                ? config.at("max_bulk_size").get<size_t>()
-                : MaxBulkSize;
+        m_maxBulkSize = config.contains("max_bulk_size") && config.at("max_bulk_size").is_number_integer()
+                            ? config.at("max_bulk_size").get<size_t>()
+                            : MaxBulkSize;
 
         m_flushInterval =
             config.contains("flush_interval_seconds") && config.at("flush_interval_seconds").is_number_integer()

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -286,6 +286,8 @@ class IndexerConnectorSyncImpl final
     std::atomic<bool> m_stopping {false};
     std::vector<size_t> m_boundaries;
     bool m_shouldNotifyAfterBulk {false};
+    size_t m_maxBulkSize {MaxBulkSize};
+    size_t m_flushInterval {FlushInterval};
 
     void processBulk()
     {
@@ -683,6 +685,16 @@ public:
         m_selector =
             selector ? std::move(selector) : std::make_unique<TSelector>(config.at("hosts"), 10, m_secureCommunication);
 
+        m_maxBulkSize =
+            config.contains("max_bulk_size") && config.at("max_bulk_size").is_number_integer()
+                ? config.at("max_bulk_size").get<size_t>()
+                : MaxBulkSize;
+
+        m_flushInterval =
+            config.contains("flush_interval_seconds") && config.at("flush_interval_seconds").is_number_integer()
+                ? config.at("flush_interval_seconds").get<size_t>()
+                : FlushInterval;
+
         m_lastBulkTime = std::chrono::steady_clock::now();
         m_bulkThread = std::thread(
             [this]()
@@ -691,7 +703,7 @@ public:
                 while (!m_stopping.load())
                 {
                     auto timeoutResult = m_cv.wait_for(
-                        timeoutLock, std::chrono::seconds(FlushInterval), [this] { return m_stopping.load(); });
+                        timeoutLock, std::chrono::seconds(m_flushInterval), [this] { return m_stopping.load(); });
 
                     // Process bulk data or deleteByQuery if there's data to process
                     if (!m_bulkData.empty() || !m_deleteByQuery.empty())
@@ -1247,8 +1259,8 @@ public:
             throw IndexerConnectorException("Unsafe index name");
         }
 
-        if (constexpr auto FORMATTED_SIZE {DELETE_FORMATTED_LENGTH};
-            m_bulkData.length() + FORMATTED_SIZE + index.size() + id.size() > MaxBulkSize)
+        if (const auto FORMATTED_SIZE {DELETE_FORMATTED_LENGTH};
+            m_bulkData.length() + FORMATTED_SIZE + index.size() + id.size() > m_maxBulkSize)
         {
             processBulk();
         }
@@ -1297,7 +1309,7 @@ public:
         const auto totalSize =
             m_bulkData.length() + FORMATTED_SIZE + VERSION_SIZE + index.size() + id.size() + data.size();
 
-        if (totalSize > MaxBulkSize)
+        if (totalSize > m_maxBulkSize)
         {
             processBulk();
         }

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -1258,8 +1258,9 @@ public:
             throw IndexerConnectorException("Unsafe index name");
         }
 
+        // Only flush if there is data already buffered.
         if (const auto FORMATTED_SIZE {DELETE_FORMATTED_LENGTH};
-            m_bulkData.length() + FORMATTED_SIZE + index.size() + id.size() > m_maxBulkSize)
+            !m_bulkData.empty() && m_bulkData.length() + FORMATTED_SIZE + index.size() + id.size() > m_maxBulkSize)
         {
             processBulk();
         }
@@ -1308,7 +1309,8 @@ public:
         const auto totalSize =
             m_bulkData.length() + FORMATTED_SIZE + VERSION_SIZE + index.size() + id.size() + data.size();
 
-        if (totalSize > m_maxBulkSize)
+        // Only flush if there is data already buffered.
+        if (!m_bulkData.empty() && totalSize > m_maxBulkSize)
         {
             processBulk();
         }

--- a/src/shared_modules/indexer_connector/tests/unit/indexerConnectorAsync_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/indexerConnectorAsync_test.cpp
@@ -28,6 +28,8 @@ using IndexerConnectorAsyncImplSmallBulk = IndexerConnectorAsyncImpl<MockServerS
 using IndexerConnectorAsyncImplSmallBulkPair = IndexerConnectorAsyncImpl<MockServerSelector, MockHTTPRequest, 2, 5, 0>;
 using IndexerConnectorAsyncImplSmallBulkNoFlushInterval =
     IndexerConnectorAsyncImpl<MockServerSelector, MockHTTPRequest, 5, 0, 0>;
+// Large template bulk (25000) with a 5-second flush timer and no retry delay.
+using IndexerConnectorAsyncImplLargeBulk = IndexerConnectorAsyncImpl<MockServerSelector, MockHTTPRequest, 25000, 5, 0>;
 
 // Test fixture using GMock for async implementation
 class IndexerConnectorAsyncTest : public ::testing::Test
@@ -2468,4 +2470,153 @@ TEST_F(IndexerConnectorAsyncTest, GetDroppedEventsInitiallyZero)
     IndexerConnectorAsyncImplTest connector(config, nullptr, "test-dropped", &mockHttpRequest, std::move(mockSelector));
 
     EXPECT_EQ(connector.getDroppedEvents(), 0ULL);
+}
+
+// JSON config override tests for elements_per_bulk and flush_interval_seconds
+TEST_F(IndexerConnectorAsyncTest, ElementsPerBulkFromJsonConfigTriggersBulk)
+{
+    // elements_per_bulk=5 in JSON overrides the template default of 25000.
+    // flush_interval_seconds=60 prevents the periodic timer from firing during the test window.
+    // If the JSON value is honoured, pushing exactly 5 elements immediately triggers a bulk send.
+    config["elements_per_bulk"] = 5;
+    config["flush_interval_seconds"] = 60;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    std::promise<void> bulkSentPromise;
+    std::future<void> bulkSentFuture = bulkSentPromise.get_future();
+
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .Times(AtLeast(1))
+        .WillRepeatedly(Invoke(
+            [this, &bulkSentPromise](
+                RequestParamsVariant requestParams, auto postParams, const ConfigurationParameters& configParams)
+            {
+                this->simulateSuccessfulPost(requestParams, postParams, configParams);
+                try
+                {
+                    bulkSentPromise.set_value();
+                }
+                catch (...)
+                {
+                }
+            }));
+
+    IndexerConnectorAsyncImplLargeBulk connector(
+        config, nullptr, "test-elements-per-bulk-json", &mockHttpRequest, std::move(mockSelector));
+
+    for (int i = 0; i < 5; ++i)
+    {
+        connector.bulkIndex("id" + std::to_string(i), "test_index", R"({"data":"x"})");
+    }
+
+    auto status = bulkSentFuture.wait_for(std::chrono::seconds(5));
+    EXPECT_EQ(status, std::future_status::ready) << "Bulk not sent after pushing elements_per_bulk items";
+    EXPECT_GT(callCount, 0);
+}
+
+TEST_F(IndexerConnectorAsyncTest, ElementsPerBulkMinValueOneFlushesImmediately)
+{
+    // Extreme low value: elements_per_bulk=1 means every single element triggers its own bulk send.
+    // flush_interval_seconds=60 ensures the count trigger —not the timer— is responsible.
+    config["elements_per_bulk"] = 1;
+    config["flush_interval_seconds"] = 60;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    std::promise<void> bulkSentPromise;
+    std::future<void> bulkSentFuture = bulkSentPromise.get_future();
+
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .Times(AtLeast(1))
+        .WillRepeatedly(Invoke(
+            [this, &bulkSentPromise](
+                RequestParamsVariant requestParams, auto postParams, const ConfigurationParameters& configParams)
+            {
+                this->simulateSuccessfulPost(requestParams, postParams, configParams);
+                try
+                {
+                    bulkSentPromise.set_value();
+                }
+                catch (...)
+                {
+                }
+            }));
+
+    IndexerConnectorAsyncImplLargeBulk connector(
+        config, nullptr, "test-min-elements-per-bulk", &mockHttpRequest, std::move(mockSelector));
+
+    connector.bulkIndex("id0", "test_index", R"({"data":"x"})");
+
+    auto status = bulkSentFuture.wait_for(std::chrono::seconds(5));
+    EXPECT_EQ(status, std::future_status::ready)
+        << "Single element should trigger immediate bulk with elements_per_bulk=1";
+    EXPECT_GT(callCount, 0);
+}
+
+TEST_F(IndexerConnectorAsyncTest, ElementsPerBulkBelowThresholdNoFlush)
+{
+    // Negative path: pushing N-1 elements must NOT trigger a bulk send.
+    config["elements_per_bulk"] = 5;
+    config["flush_interval_seconds"] = 60;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    IndexerConnectorAsyncImplLargeBulk connector(
+        config, nullptr, "test-below-threshold", &mockHttpRequest, std::move(mockSelector));
+
+    for (int i = 0; i < 4; ++i)
+    {
+        connector.bulkIndex("id" + std::to_string(i), "test_index", R"({"data":"x"})");
+    }
+
+    // Allow the async worker enough time to process any spurious flush.
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    EXPECT_EQ(callCount, 0) << "No bulk should be sent when fewer than elements_per_bulk items are queued";
+}
+
+TEST_F(IndexerConnectorAsyncTest, FlushIntervalSecondsFromJsonConfigTimerFires)
+{
+    // Verify that flush_interval_seconds from JSON config actually drives the periodic flush timer.
+    config["flush_interval_seconds"] = 1;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    std::promise<void> timerFiredPromise;
+    std::future<void> timerFiredFuture = timerFiredPromise.get_future();
+
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .Times(AtLeast(1))
+        .WillRepeatedly(Invoke(
+            [this, &timerFiredPromise](
+                RequestParamsVariant requestParams, auto postParams, const ConfigurationParameters& configParams)
+            {
+                this->simulateSuccessfulPost(requestParams, postParams, configParams);
+                try
+                {
+                    timerFiredPromise.set_value();
+                }
+                catch (...)
+                {
+                }
+            }));
+
+    IndexerConnectorAsyncImplLargeBulk connector(
+        config, nullptr, "test-flush-interval-timer", &mockHttpRequest, std::move(mockSelector));
+
+    // 3 items — below the 25000-element count threshold
+    connector.bulkIndex("id0", "test_index", R"({"data":"x"})");
+    connector.bulkIndex("id1", "test_index", R"({"data":"x"})");
+    connector.bulkIndex("id2", "test_index", R"({"data":"x"})");
+
+    // 3s window
+    auto status = timerFiredFuture.wait_for(std::chrono::seconds(3));
+    EXPECT_EQ(status, std::future_status::ready)
+        << "Expected 1s timer (from JSON flush_interval_seconds) to fire within 3s";
+    EXPECT_GT(callCount, 0);
 }

--- a/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
@@ -4323,9 +4323,7 @@ TEST_F(IndexerConnectorSyncTest, MaxBulkSizeFromJsonConfigTriggersFlush)
 
     EXPECT_CALL(mockHttpRequest, post(_, _, _))
         .Times(AtLeast(1))
-        .WillRepeatedly(Invoke([this](auto requestParams,
-                                     auto postParams,
-                                     auto configParams)
+        .WillRepeatedly(Invoke([this](auto requestParams, auto postParams, auto configParams)
                                { this->simulateSuccessfulPost(requestParams, postParams, configParams); }));
 
     // SmallBulk
@@ -4350,9 +4348,7 @@ TEST_F(IndexerConnectorSyncTest, MaxBulkSizeMinValueTriggersFlushOnSecondElement
 
     EXPECT_CALL(mockHttpRequest, post(_, _, _))
         .Times(AtLeast(1))
-        .WillRepeatedly(Invoke([this](auto requestParams,
-                                     auto postParams,
-                                     auto configParams)
+        .WillRepeatedly(Invoke([this](auto requestParams, auto postParams, auto configParams)
                                { this->simulateSuccessfulPost(requestParams, postParams, configParams); }));
 
     IndexerConnectorSyncImplSmallBulk connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
@@ -4394,9 +4390,7 @@ TEST_F(IndexerConnectorSyncTest, FlushIntervalSecondsFromJsonConfigTimerFires)
 
     EXPECT_CALL(mockHttpRequest, post(_, _, _))
         .Times(AtLeast(1))
-        .WillRepeatedly(Invoke([this](auto requestParams,
-                                     auto postParams,
-                                     auto configParams)
+        .WillRepeatedly(Invoke([this](auto requestParams, auto postParams, auto configParams)
                                { this->simulateSuccessfulPost(requestParams, postParams, configParams); }));
 
     IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));

--- a/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
@@ -4418,3 +4418,109 @@ TEST_F(IndexerConnectorSyncTest, FlushIntervalTimerDoesNotFlushWhenNoData)
 
     EXPECT_EQ(callCount, 0) << "No HTTP post should be made when the timer fires on an empty buffer";
 }
+
+// Empty-buffer guard tests
+TEST_F(IndexerConnectorSyncTest, BulkIndexOnEmptyBufferDoesNotThrowWhenSingleDocExceedsMaxBulkSize)
+{
+    // max_bulk_size=1 forces totalSize > m_maxBulkSize on every call.
+    config["max_bulk_size"] = 1;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    IndexerConnectorSyncImplSmallBulk connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    EXPECT_NO_THROW(connector.bulkIndex("id1", "test_index", R"({"data":"x"})"))
+        << "First bulkIndex must not throw when totalSize > max_bulk_size on an empty buffer";
+    EXPECT_EQ(callCount, 0) << "Empty-buffer guard must suppress the flush on the first call";
+}
+
+TEST_F(IndexerConnectorSyncTest, BulkIndexFlushesPreviousBufferWhenMaxBulkSizeIsTiny)
+{
+    // With max_bulk_size=1, every call after the first sees a non-empty buffer
+    // and totalSize > 1, so the guard does NOT inhibit flushing.
+    config["max_bulk_size"] = 1;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .Times(AtLeast(2))
+        .WillRepeatedly(Invoke([this](auto requestParams, auto postParams, auto configParams)
+                               { this->simulateSuccessfulPost(requestParams, postParams, configParams); }));
+
+    IndexerConnectorSyncImplSmallBulk connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    EXPECT_NO_THROW(connector.bulkIndex("id1", "test_index", R"({"data":"x"})"));
+    EXPECT_EQ(callCount, 0) << "First call: empty buffer, no flush expected";
+
+    EXPECT_NO_THROW(connector.bulkIndex("id2", "test_index", R"({"data":"x"})"));
+    EXPECT_EQ(callCount, 1) << "Second call must flush the previously buffered element";
+
+    EXPECT_NO_THROW(connector.bulkIndex("id3", "test_index", R"({"data":"x"})"));
+    EXPECT_EQ(callCount, 2) << "Third call must flush the second element";
+}
+
+TEST_F(IndexerConnectorSyncTest, BulkDeleteOnEmptyBufferDoesNotThrowWhenSingleDocExceedsMaxBulkSize)
+{
+    // Symmetric to BulkIndexOnEmptyBufferDoesNotThrow… but for the delete path,
+    // which has its own size guard using DELETE_FORMATTED_LENGTH as overhead.
+    config["max_bulk_size"] = 1;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    IndexerConnectorSyncImplSmallBulk connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    EXPECT_NO_THROW(connector.bulkDelete("id1", "test_index"))
+        << "First bulkDelete must not throw when totalSize > max_bulk_size on an empty buffer";
+    EXPECT_EQ(callCount, 0) << "Empty-buffer guard must suppress the flush on the first delete";
+}
+
+TEST_F(IndexerConnectorSyncTest, BulkDeleteFlushesPreviousBufferWhenMaxBulkSizeIsTiny)
+{
+    // Symmetric to BulkIndexFlushesPreviousBufferWhenMaxBulkSizeIsTiny for the
+    // delete path.
+    config["max_bulk_size"] = 1;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .Times(AtLeast(2))
+        .WillRepeatedly(Invoke([this](auto requestParams, auto postParams, auto configParams)
+                               { this->simulateSuccessfulPost(requestParams, postParams, configParams); }));
+
+    IndexerConnectorSyncImplSmallBulk connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    EXPECT_NO_THROW(connector.bulkDelete("id1", "test_index"));
+    EXPECT_EQ(callCount, 0) << "First call: empty buffer, no flush expected";
+
+    EXPECT_NO_THROW(connector.bulkDelete("id2", "test_index"));
+    EXPECT_EQ(callCount, 1) << "Second delete must flush the previously buffered delete";
+
+    EXPECT_NO_THROW(connector.bulkDelete("id3", "test_index"));
+    EXPECT_EQ(callCount, 2) << "Third delete must flush the second delete";
+}
+
+TEST_F(IndexerConnectorSyncTest, MixedBulkIndexAndDeleteRespectEmptyBufferGuard)
+{
+    // Proves the guard and the size check share buffer state across both entry points
+    config["max_bulk_size"] = 1;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .Times(AtLeast(1))
+        .WillRepeatedly(Invoke([this](auto requestParams, auto postParams, auto configParams)
+                               { this->simulateSuccessfulPost(requestParams, postParams, configParams); }));
+
+    IndexerConnectorSyncImplSmallBulk connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    EXPECT_NO_THROW(connector.bulkDelete("id1", "test_index"));
+    EXPECT_EQ(callCount, 0) << "Empty buffer + bulkDelete: guard suppresses flush";
+
+    EXPECT_NO_THROW(connector.bulkIndex("id2", "test_index", R"({"data":"x"})"));
+    EXPECT_EQ(callCount, 1) << "bulkIndex must flush the previously buffered bulkDelete";
+}

--- a/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
@@ -4304,3 +4304,123 @@ TEST_F(IndexerConnectorSyncTest, IsSafeIndexName_Allowlist)
     EXPECT_TRUE(isSafeIndexName("wazuh-states-*"));
     EXPECT_TRUE(isSafeIndexName("Idx_With.MixedCase-1.2.3"));
 }
+
+// JSON config override tests for max_bulk_size and flush_interval_seconds
+TEST_F(IndexerConnectorSyncTest, MaxBulkSizeFromJsonConfigTriggersFlush)
+{
+    // SmallBulk but setting max_bulk_size=100 in config overrides the 1024-byte threshold to 100 bytes.
+    // processBulk() is called synchronously from within bulkIndex() when the size check fires,
+    // so callCount increments on the calling thread—no race with the 20s background timer.
+    //
+    // Size math for bulkIndex("id1", "test_index", R"({"data":"x"})"):
+    //   FORMATTED_SIZE(33) + VERSION_SIZE(32) + "test_index"(10) + "id1"(3) + R"({"data":"x"})"(13) = 91
+    // First call:  m_bulkData(0) + 91 = 91 <= 100 → no flush, ~60 bytes appended to buffer.
+    // Second call: m_bulkData(60) + 91 = 151 > 100 → processBulk() called synchronously.
+    config["max_bulk_size"] = 100;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .Times(AtLeast(1))
+        .WillRepeatedly(Invoke([this](auto requestParams,
+                                     auto postParams,
+                                     auto configParams)
+                               { this->simulateSuccessfulPost(requestParams, postParams, configParams); }));
+
+    // SmallBulk
+    IndexerConnectorSyncImplSmallBulk connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    connector.bulkIndex("id1", "test_index", R"({"data":"x"})");
+    EXPECT_EQ(callCount, 0) << "Flush should not occur before the configured size is exceeded";
+
+    connector.bulkIndex("id2", "test_index", R"({"data":"x"})");
+    EXPECT_GT(callCount, 0) << "processBulk() was not called when max_bulk_size was exceeded";
+}
+
+TEST_F(IndexerConnectorSyncTest, MaxBulkSizeMinValueTriggersFlushOnSecondElement)
+{
+    // Extreme low value: max_bulk_size=91 is the smallest value where the first element still fits
+    // (totalSize check = 91, condition is strictly >, so 91 > 91 is false → element added).
+    // The second element's check (60 + 91 = 151 > 91) triggers an immediate synchronous flush.
+    config["max_bulk_size"] = 91;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .Times(AtLeast(1))
+        .WillRepeatedly(Invoke([this](auto requestParams,
+                                     auto postParams,
+                                     auto configParams)
+                               { this->simulateSuccessfulPost(requestParams, postParams, configParams); }));
+
+    IndexerConnectorSyncImplSmallBulk connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    EXPECT_NO_THROW(connector.bulkIndex("id1", "test_index", R"({"data":"x"})"))
+        << "First element should fit at max_bulk_size=91 without triggering processBulk on empty buffer";
+    EXPECT_EQ(callCount, 0) << "No flush expected after first element";
+
+    EXPECT_NO_THROW(connector.bulkIndex("id2", "test_index", R"({"data":"x"})"))
+        << "Second element should trigger flush without throwing";
+    EXPECT_GT(callCount, 0) << "Flush should have been triggered by second element";
+}
+
+TEST_F(IndexerConnectorSyncTest, MaxBulkSizeDefaultUsedWhenAbsentFromJsonConfig)
+{
+    // No max_bulk_size in JSON config. SmallBulk's template default is MaxBulkSize=1024 bytes
+    // Two small elements whose total size check (~151 bytes) is below 1024 must NOT trigger a flush.
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    // SmallBulk
+    IndexerConnectorSyncImplSmallBulk connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    connector.bulkIndex("id1", "test_index", R"({"data":"x"})");
+    connector.bulkIndex("id2", "test_index", R"({"data":"x"})");
+
+    EXPECT_EQ(callCount, 0) << "No flush should occur: total ~151 bytes is below the 1024-byte template default";
+}
+
+TEST_F(IndexerConnectorSyncTest, FlushIntervalSecondsFromJsonConfigTimerFires)
+{
+    // Verify that flush_interval_seconds from JSON config actually drives the background timer.
+    // Pushing one small element (well below the 10 MB size threshold) means only the timer
+    // can cause a flush.
+    config["flush_interval_seconds"] = 1;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .Times(AtLeast(1))
+        .WillRepeatedly(Invoke([this](auto requestParams,
+                                     auto postParams,
+                                     auto configParams)
+                               { this->simulateSuccessfulPost(requestParams, postParams, configParams); }));
+
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    connector.bulkIndex("id1", "test_index", R"({"data":"timer-test"})");
+
+    // 2s is enough for the 1s timer.
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    EXPECT_GT(callCount, 0) << "Expected 1s timer (from JSON flush_interval_seconds) to fire within 2s";
+}
+
+TEST_F(IndexerConnectorSyncTest, FlushIntervalTimerDoesNotFlushWhenNoData)
+{
+    // When the periodic timer fires but the buffer is empty, processBulk() must NOT be called.
+    config["flush_interval_seconds"] = 1;
+
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    IndexerConnectorSyncImplTest connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    // Let the timer fire at least once with no data in the buffer.
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    EXPECT_EQ(callCount, 0) << "No HTTP post should be made when the timer fires on an empty buffer";
+}

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -608,8 +608,23 @@ public:
         m_responseDispatcher = std::make_unique<TResponseDispatcher>();
 
         logDebug2(LOGGER_DEFAULT_TAG, "Configuration: %s", configuration.dump().c_str());
-        m_indexerConnector = std::make_unique<TIndexerConnector>(
-            configuration.at("indexer"), LoggingContext {WM_INVENTORY_SYNC_LOGTAG, logFunction});
+
+        nlohmann::json indexerConfig = configuration.contains("indexer") && configuration.at("indexer").is_object()
+                                           ? configuration.at("indexer")
+                                           : nlohmann::json::object();
+
+        if (configuration.contains("indexerBulkSize") && configuration.at("indexerBulkSize").is_number_integer())
+        {
+            indexerConfig["max_bulk_size"] = configuration.at("indexerBulkSize").get<size_t>();
+        }
+        if (configuration.contains("indexerFlushInterval") &&
+            configuration.at("indexerFlushInterval").is_number_integer())
+        {
+            indexerConfig["flush_interval_seconds"] = configuration.at("indexerFlushInterval").get<size_t>();
+        }
+
+        m_indexerConnector =
+            std::make_unique<TIndexerConnector>(indexerConfig, LoggingContext {WM_INVENTORY_SYNC_LOGTAG, logFunction});
 
         if (!configuration.contains("clusterName"))
         {

--- a/src/wazuh_modules/src/wm_inventory_sync.c
+++ b/src/wazuh_modules/src/wm_inventory_sync.c
@@ -93,6 +93,14 @@
              int data_value_quota = getDefine_Int_default("wazuh_modules", "inventory_sync_data_value_quota", 1, 1000000000, 500000);
              cJSON_AddNumberToObject(config_json, "dataValueQuota", data_value_quota);
 
+             // Add indexer bulk-size threshold (bytes) from internal_options.
+             int indexer_bulk_size_bytes = getDefine_Int_default("wazuh_modules", "inventory_sync_indexer_bulk_size_bytes", 4096, 100 * 1024 * 1024, 10 * 1024 * 1024);
+             cJSON_AddNumberToObject(config_json, "indexerBulkSize", indexer_bulk_size_bytes);
+
+             // Add indexer periodic flush interval (seconds) from internal_options.
+             int indexer_flush_interval = getDefine_Int_default("wazuh_modules", "inventory_sync_indexer_flush_interval", 1, 3600, 20);
+             cJSON_AddNumberToObject(config_json, "indexerFlushInterval", indexer_flush_interval);
+
              wm_inventory_sync_log_config(config_json);
              inventory_sync_start_ptr(mtLoggingFunctionsWrapper, config_json);
              cJSON_Delete(config_json);

--- a/src/wazuh_modules/src/wm_vulnerability_scanner.c
+++ b/src/wazuh_modules/src/wm_vulnerability_scanner.c
@@ -88,10 +88,10 @@ void* wm_vulnerability_scanner_main(wm_vulnerability_scanner_t* data) {
 
             cJSON_AddNumberToObject(config_json,
                                     "indexerBulkSize",
-                                    getDefine_Int_default("wazuh_modulesd", "indexer_bulk_size_bytes", 4096, 100 * 1024 * 1024, 10 * 1024 * 1024));
+                                    getDefine_Int_default("wazuh_modules", "indexer_bulk_size_bytes", 4096, 100 * 1024 * 1024, 10 * 1024 * 1024));
             cJSON_AddNumberToObject(config_json,
                                     "indexerFlushInterval",
-                                    getDefine_Int_default("wazuh_modulesd", "indexer_flush_interval", 1, 3600, 20));
+                                    getDefine_Int_default("wazuh_modules", "indexer_flush_interval", 1, 3600, 20));
 
             if (indexer_config == NULL) {
                 cJSON_AddItemToObject(config_json, "indexer", cJSON_CreateObject());

--- a/src/wazuh_modules/src/wm_vulnerability_scanner.c
+++ b/src/wazuh_modules/src/wm_vulnerability_scanner.c
@@ -88,7 +88,7 @@ void* wm_vulnerability_scanner_main(wm_vulnerability_scanner_t* data) {
 
             cJSON_AddNumberToObject(config_json,
                                     "indexerBulkSize",
-                                    getDefine_Int_default("wazuh_modulesd", "indexer_bulk_size_bytes", 1, 100 * 1024 * 1024, 10 * 1024 * 1024));
+                                    getDefine_Int_default("wazuh_modulesd", "indexer_bulk_size_bytes", 4096, 100 * 1024 * 1024, 10 * 1024 * 1024));
             cJSON_AddNumberToObject(config_json,
                                     "indexerFlushInterval",
                                     getDefine_Int_default("wazuh_modulesd", "indexer_flush_interval", 1, 3600, 20));

--- a/src/wazuh_modules/src/wm_vulnerability_scanner.c
+++ b/src/wazuh_modules/src/wm_vulnerability_scanner.c
@@ -86,6 +86,13 @@ void* wm_vulnerability_scanner_main(wm_vulnerability_scanner_t* data) {
                                     "reportQueueSize",
                                     getDefine_Int_default("vulnerability-detection", "report_queue_size", 0, 2147483647, 262144));
 
+            cJSON_AddNumberToObject(config_json,
+                                    "indexerBulkSize",
+                                    getDefine_Int_default("wazuh_modulesd", "indexer_bulk_size", 1, 1073741824, 10 * 1024 * 1024));
+            cJSON_AddNumberToObject(config_json,
+                                    "indexerFlushInterval",
+                                    getDefine_Int_default("wazuh_modulesd", "indexer_flush_interval", 1, 3600, 20));
+
             if (indexer_config == NULL) {
                 cJSON_AddItemToObject(config_json, "indexer", cJSON_CreateObject());
             }

--- a/src/wazuh_modules/src/wm_vulnerability_scanner.c
+++ b/src/wazuh_modules/src/wm_vulnerability_scanner.c
@@ -88,7 +88,7 @@ void* wm_vulnerability_scanner_main(wm_vulnerability_scanner_t* data) {
 
             cJSON_AddNumberToObject(config_json,
                                     "indexerBulkSize",
-                                    getDefine_Int_default("wazuh_modulesd", "indexer_bulk_size", 1, 1073741824, 10 * 1024 * 1024));
+                                    getDefine_Int_default("wazuh_modulesd", "indexer_bulk_size_bytes", 1, 100 * 1024 * 1024, 10 * 1024 * 1024));
             cJSON_AddNumberToObject(config_json,
                                     "indexerFlushInterval",
                                     getDefine_Int_default("wazuh_modulesd", "indexer_flush_interval", 1, 3600, 20));

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -245,6 +245,17 @@ void VulnerabilityScannerFacade::start(
             }
 
             indexerConfig["name"] = Utils::toLowerCase(STATES_VD_INDEX_NAME_PREFIX);
+
+            if (configuration.contains("indexerBulkSize") && configuration.at("indexerBulkSize").is_number_integer())
+            {
+                indexerConfig["max_bulk_size"] = configuration.at("indexerBulkSize").get<size_t>();
+            }
+            if (configuration.contains("indexerFlushInterval") &&
+                configuration.at("indexerFlushInterval").is_number_integer())
+            {
+                indexerConfig["flush_interval_seconds"] = configuration.at("indexerFlushInterval").get<size_t>();
+            }
+
             return indexerConfig;
         };
 


### PR DESCRIPTION
## Description

Closes #36845 

Makes four previously compile-time-only template parameters of the indexer connector configurable
at runtime through `wazuh-manager-internal-options.conf`, without changing any default behaviour.

Two distinct parameter sets are exposed, one per daemon that owns an indexer connection. The
`wazuh-modulesd` daemon hosts two independent `IndexerConnectorSync` instances (vulnerability
detection + inventory sync), so each gets its own namespaced pair:

| Option | Daemon / module | Semantics | Default | Range |
|---|---|---|---|---|
| `analysisd.indexer_bulk_size` | `wazuh-engine` | **Document count** per bulk request | `25000` | `[1, 1000000]` |
| `analysisd.indexer_flush_interval` | `wazuh-engine` | Periodic flush interval (seconds) | `20` | `[1, 3600]` |
| `wazuh_modules.indexer_bulk_size_bytes` | `wazuh-modulesd` / vulnerability detection | **Byte size** threshold before flushing | `10485760` (10 MB) | `[4096, 104857600]` |
| `wazuh_modules.indexer_flush_interval` | `wazuh-modulesd` / vulnerability detection | Periodic flush interval (seconds) | `20` | `[1, 3600]` |
| `wazuh_modules.inventory_sync_indexer_bulk_size_bytes` | `wazuh-modulesd` / inventory sync | **Byte size** threshold before flushing | `10485760` (10 MB) | `[4096, 104857600]` |
| `wazuh_modules.inventory_sync_indexer_flush_interval` | `wazuh-modulesd` / inventory sync | Periodic flush interval (seconds) | `20` | `[1, 3600]` |

> **Important:** `analysisd.indexer_bulk_size` and the two `*_bulk_size_bytes` options share a
> concept (how much to accumulate before flushing) but measure different things.
> `analysisd.indexer_bulk_size` counts **documents** (used by `IndexerConnectorAsyncImpl`);
> the `*_bulk_size_bytes` options count **bytes** of NDJSON payload (used by
> `IndexerConnectorSyncImpl`).
>
> **Floor of 4096 B on byte thresholds.** The synchronous connector's `bulkIndex`/`bulkDelete`
> evaluate the size guard *before* appending; with a tiny `m_maxBulkSize` the guard fires on an
> empty buffer and `processBulk()` aborts with `IndexerConnectorException("No data to process")`.
> The 4 KB floor sits well above the worst-case per-item JSON overhead (`FORMATTED_LENGTH +
> VERSION_SIZE ≈ 65 B` plus index name and `_id`), which keeps configuration mistakes from turning
> into runtime exceptions. The connector itself was hardened in the same change with a
> `!m_bulkData.empty()` precondition on the size-based flush, so the floor is a usability cushion
> rather than a load-bearing invariant.

## Proposed Changes

### `libindexer_connector` — runtime member injection

Both connector implementations previously consumed their tuning parameters only as
non-type template arguments. Because `libindexer_connector.so` does not link against the Wazuh
shared C library, `getDefine_Int_default` cannot be called from inside the library; values must
be read by the caller daemon and injected as JSON fields.

- **`src/shared_modules/indexer_connector/src/indexerConnectorAsyncImpl.hpp`**
  - Added runtime member `m_elementsPerBulk {ElementsPerBulk}` (document count).
  - Constructor reads JSON key `"elements_per_bulk"` when present; falls back to the template
    argument `ElementsPerBulk` (25 000).
  - All three internal usages of `ElementsPerBulk` (dispatcher construction, adaptive-bulk reset
    comparison, reset log message) replaced with `m_elementsPerBulk`.

- **`src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp`**
  - Added runtime members `m_maxBulkSize {MaxBulkSize}` (bytes) and
    `m_flushInterval {FlushInterval}` (seconds).
  - Constructor reads JSON keys `"max_bulk_size"` and `"flush_interval_seconds"` when present;
    falls back to the respective template arguments (`10 * 1024 * 1024` and `20`).
  - Background timer updated: `std::chrono::seconds(FlushInterval)` →
    `std::chrono::seconds(m_flushInterval)`.
  - Size guards in `bulkIndex` and `bulkDelete` updated to compare against `m_maxBulkSize`
    instead of `MaxBulkSize`. (`constexpr auto FORMATTED_SIZE` in `bulkDelete` relaxed to
    `const auto` as the enclosing comparison is now a runtime expression.)

### `wazuh-engine` (`analysisd`) — conf system integration

The engine has its own C++ conf layer (`conf::FileLoader`) that parses
`wazuh-manager-internal-options.conf` under the `analysisd.*` namespace.

- **`src/engine/source/conf/include/conf/keys.hpp`**
  - Added `INDEXER_ELEMENTS_PER_BULK = "analysisd.indexer_bulk_size"`.
  - Added `INDEXER_FLUSH_INTERVAL = "analysisd.indexer_flush_interval"`.

- **`src/engine/source/conf/src/conf.cpp`**
  - Registered both keys with defaults and optional env-var overrides
    (`WAZUH_INDEXER_ELEMENTS_PER_BULK`, `WAZUH_INDEXER_FLUSH_INTERVAL`).

- **`src/engine/source/main.cpp`**
  - Reads both values from `confManager`, validates ranges (fails with a clear message on
    out-of-range values: `[1, 1 000 000]` and `[1, 3 600]` respectively), then injects them
    into the JSON config blob passed to `WIndexerConnector` as `"/elements_per_bulk"` and
    `"/flush_interval_seconds"`.

### `wazuh-modulesd` (vulnerability scanner) — `getDefine_Int_default` path

- **`src/wazuh_modules/src/wm_vulnerability_scanner.c`**
  - Reads `wazuh_modules.indexer_bulk_size_bytes` (range `[4096, 104857600]`, default `10485760`)
    and `wazuh_modules.indexer_flush_interval` (range `[1, 3 600]`, default `20`) via
    `getDefine_Int_default`, which calls `merror_exit` on out-of-range values.
  - Injects the results into the `config_json` blob passed to the vulnerability scanner module
    as `"indexerBulkSize"` and `"indexerFlushInterval"`.

- **`src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp`**
  - `buildIndexerConfig` lambda reads `"indexerBulkSize"` and `"indexerFlushInterval"` from
    the incoming `configuration` object and forwards them to the `IndexerConnectorSyncImpl`
    JSON config as `"max_bulk_size"` and `"flush_interval_seconds"`.

### `wazuh-modulesd` (inventory sync) — `getDefine_Int_default` path

`wazuh-modulesd` hosts a second `IndexerConnectorSync` instance for inventory sync, with its own
buffer / thread / retry state, so it needs its own pair of options. The same wmodule-wrapper →
facade → connector flow is used:

- **`src/wazuh_modules/src/wm_inventory_sync.c`**
  - Reads `wazuh_modules.inventory_sync_indexer_bulk_size_bytes` (range `[4096, 104857600]`,
    default `10485760`) and `wazuh_modules.inventory_sync_indexer_flush_interval`
    (range `[1, 3 600]`, default `20`) via `getDefine_Int_default`.
  - Injects the results into the `config_json` blob passed to the inventory sync module as
    `"indexerBulkSize"` and `"indexerFlushInterval"`.

- **`src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp`**
  - In `start()`, builds a mutable copy of `configuration["indexer"]` and injects the new
    `max_bulk_size` / `flush_interval_seconds` keys when the wrapper provided them, before
    forwarding to the `TIndexerConnector` constructor. Mirrors the `buildIndexerConfig` lambda
    in `vulnerabilityScannerFacade.cpp`.

### `libindexer_connector` — empty-buffer hardening

- **`src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp`**
  - `bulkIndex` and `bulkDelete` now gate the size-based flush with
    `if (!m_bulkData.empty() && totalSize > m_maxBulkSize)`. Without this guard, a small
    `m_maxBulkSize` (or a pathologically large single document) makes the size check fire on
    an empty buffer; `processBulk()` then throws `IndexerConnectorException("No data to
    process")` because both `m_bulkData` and `m_deleteByQuery` are empty. The new guard makes
    the size check semantically correct ("flush only when there is something to flush"); a
    single oversized document is appended and gets flushed by the next call or by the periodic
    timer.

### Unit tests

- **`src/shared_modules/indexer_connector/tests/unit/indexerConnectorAsync_test.cpp`**
  - New type alias `IndexerConnectorAsyncImplLargeBulk`
    (`ElementsPerBulk=25000`, `FlushInterval=5s`) to isolate JSON config as the only
    meaningful trigger in the new tests.
  - `ElementsPerBulkFromJsonConfigTriggersBulk` — sets `elements_per_bulk=5` and
    `flush_interval_seconds=60` in JSON; pushes exactly 5 elements and asserts the HTTP
    POST fires within 5 s. The 60 s timer proves the timer is not the trigger; without the
    JSON override the 25 000-element template threshold would also not fire.
  - `ElementsPerBulkMinValueOneFlushesImmediately` — extreme low value `elements_per_bulk=1`
    causes a bulk send after a single `bulkIndex` call.
  - `ElementsPerBulkBelowThresholdNoFlush` — negative path: `elements_per_bulk=5`,
    `flush_interval_seconds=60`, push 4 elements; `callCount` must remain 0 after 500 ms.
  - `FlushIntervalSecondsFromJsonConfigTimerFires` — sets `flush_interval_seconds=1`
    (overriding the template's 5 s); pushes 3 elements (below the 25 000-element count
    threshold). The bulk must arrive within a 3-second window. If the template's 5 s value
    were used instead, the future would not be ready within 3 s and the test would fail,
    providing a discriminating proof of the JSON override.

- **`src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp`**
  - `MaxBulkSizeFromJsonConfigTriggersFlush` — sets `max_bulk_size=100` on a
    `SmallBulk` connector (template MaxBulkSize=1024, FlushInterval=20 s). First element
    (check=91 bytes) fits; second element (check=151 bytes) exceeds 100 → synchronous
    `processBulk()` increments `callCount`. Without the JSON override 151 < 1024 and no
    flush would occur.
  - `MaxBulkSizeMinValueTriggersFlushOnSecondElement` — extreme: `max_bulk_size=91`
    (the tightest value where the first element still fits, since `91 > 91` is false). The
    second element's check (151 > 91) triggers a flush; both calls must not throw.
  - `MaxBulkSizeDefaultUsedWhenAbsentFromJsonConfig` — no JSON key; template default
    (1024 bytes) means two small elements (total check ~151 bytes) never trigger a flush.
  - `FlushIntervalSecondsFromJsonConfigTimerFires` — sets `flush_interval_seconds=1`
    (overriding the template's 20 s default of `IndexerConnectorSyncImplTest`); one small
    element is pushed (well below 10 MB size threshold). After a 2-second sleep
    `callCount > 0`, proving the JSON 1 s timer fired. If the 20 s template timer were
    active, `callCount` would still be 0.
  - `FlushIntervalTimerDoesNotFlushWhenNoData` — sets `flush_interval_seconds=1`, pushes
    nothing, sleeps 2 s; verifies `callCount == 0` (the background thread's empty-data
    guard prevents a spurious HTTP call).
  - `BulkIndexOnEmptyBufferDoesNotThrowWhenSingleDocExceedsMaxBulkSize` — empty-buffer
    guard regression test: with `max_bulk_size=1` the first `bulkIndex` call's `totalSize`
    already exceeds the threshold. Without the `!m_bulkData.empty()` guard the old code
    would invoke `processBulk()` on an empty buffer and throw
    `IndexerConnectorException("No data to process")`; the new guard must skip the flush
    and append the document. Asserts `EXPECT_NO_THROW` and `callCount == 0`.
  - `BulkIndexFlushesPreviousBufferWhenMaxBulkSizeIsTiny` — positive counterpart of the
    above: with `max_bulk_size=1`, three successive `bulkIndex` calls must produce
    exactly `callCount == 2` (first call appends, second and third flush the buffered
    item before appending). Proves the guard does not over-suppress when there IS data
    to flush.
  - `BulkDeleteOnEmptyBufferDoesNotThrowWhenSingleDocExceedsMaxBulkSize` — same as the
    `bulkIndex` empty-buffer test, but for the delete path (which has its own size
    guard using `DELETE_FORMATTED_LENGTH` overhead).
  - `BulkDeleteFlushesPreviousBufferWhenMaxBulkSizeIsTiny` — same as the `bulkIndex`
    "flushes previous buffer" test, but for the delete path.
  - `MixedBulkIndexAndDeleteRespectEmptyBufferGuard` — cross-path coverage:
    `bulkDelete("id1")` on an empty buffer must not flush (guard works for delete);
    a subsequent `bulkIndex("id2")` on the now-non-empty buffer must flush exactly once.
    Proves `bulkIndex` and `bulkDelete` share `m_bulkData` and the guard cooperates
    across both entry points.

## Results and Evidence

<img width="530" height="938" alt="image" src="https://github.com/user-attachments/assets/e2975ff5-92c5-4399-aa0d-100cf7c31070" />


### Manual tests with their corresponding evidence

 * config default

<details><summary>Details</summary>
<p>


```console
╰─# /var/wazuh-manager/bin/wazuh-manager-control restart ; tail -f /var/wazuh-manager/logs/wazuh-manager.log
Killing wazuh-manager-clusterd...
Killing wazuh-manager-modulesd...
Killing wazuh-manager-monitord...
Killing wazuh-manager-remoted...
Killing wazuh-manager-analysisd...
Killing wazuh-manager-db...
Killing wazuh-manager-authd...
Killing wazuh-manager-apid...
Wazuh v5.0.0 Stopped
Starting Wazuh v5.0.0...
Started wazuh-manager-apid...
Started wazuh-manager-authd...
Started wazuh-manager-db...
Started wazuh-manager-analysisd...
Started wazuh-manager-remoted...
Started wazuh-manager-monitord...
Started wazuh-manager-modulesd...
Started wazuh-manager-clusterd...
Completed.
2026/06/24 18:56:06 wazuh-manager-modulesd:router: INFO: Started (pid: 205776).
2026/06/24 18:56:06 wazuh-manager-modulesd:content_manager: INFO: Started (pid: 205776).
2026/06/24 18:56:06 wazuh-manager-modulesd:inventory-sync: INFO: Started (pid: 205776).
2026/06/24 18:56:06 wazuh-manager-modulesd:database: INFO: Started (pid: 205776).
2026/06/24 18:56:06 wazuh-manager-modulesd:task-manager: INFO: Started (pid: 205776).
2026/06/24 18:56:06 wazuh-manager-modulesd:vulnerability-scanner: WARNING: The local feed database is incomplete at startup: required global maps are missing. Clearing updater state to force a clean rebuild.
2026/06/24 18:56:06 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Consumer 'cti:catalog:consumer:vulnerabilities' in index '.wazuh-cti-consumers' is idle. Starting feed download.
2026/06/24 18:56:06 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting initial full load (slices=2)
2026/06/24 18:56:06 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting sliced PIT download with 2 slices, pageSize=250
2026/06/24 18:56:06 wazuh-manager-modulesd:vulnerability-scanner: INFO: CVE feed not yet available — per-agent scans deferred until initial load completes.
2026/06/24 18:56:16 wazuh-manager-monitord: INFO: wazuh: Manager started.
2026/06/24 18:56:17 wazuh-manager-analysisd: INFO: [IOC::Sync] Synchronized IOC type 'connection'
2026/06/24 18:56:17 wazuh-manager-analysisd: INFO: [IOC::Sync] Changes detected for IOC type 'url_full', updating...
2026/06/24 18:56:20 wazuh-manager-analysisd: INFO: [IOC::Sync] Synchronized IOC type 'url_full'
2026/06/24 18:56:20 wazuh-manager-analysisd: INFO: [IOC::Sync] Changes detected for IOC type 'url_domain', updating...
2026/06/24 18:56:30 wazuh-manager-analysisd: INFO: [IOC::Sync] Synchronized IOC type 'url_domain'
2026/06/24 18:56:30 wazuh-manager-analysisd: INFO: [IOC::Sync] Changes detected for IOC type 'hash_md5', updating...
2026/06/24 18:56:31 wazuh-manager-analysisd: INFO: [IOC::Sync] Synchronized IOC type 'hash_md5'
2026/06/24 18:56:31 wazuh-manager-analysisd: INFO: [IOC::Sync] Changes detected for IOC type 'hash_sha1', updating...
2026/06/24 18:56:32 wazuh-manager-analysisd: INFO: [IOC::Sync] Synchronized IOC type 'hash_sha1'
2026/06/24 18:56:32 wazuh-manager-analysisd: INFO: [IOC::Sync] Changes detected for IOC type 'hash_sha256', updating...
2026/06/24 18:56:32 wazuh-manager-analysisd: INFO: [IOC::Sync] Synchronized IOC type 'hash_sha256'
2026/06/24 18:56:33 wazuh-manager-analysisd: INFO: Remote settings synchronized: changes detected and applied.
2026/06/24 18:57:12 wazuh-manager-analysisd: INFO: [CMSync] Successfully synchronized space 'standard'
2026/06/24 18:57:12 wazuh-manager-analysisd: INFO: [CMSync] Event processing is now active.
```


</p>
</details>  
 
 * config changed analysisd
 
 <details><summary>Details</summary>
<p>


```console
╰─# cat  /var/wazuh-manager/etc/wazuh-manager-internal-options.conf | grep indexer_bulk_size_events                                                                                                                   1 ↵
analysisd.indexer_bulk_size_events=99999999      # [1..1000000]   document count per bulk (wazuh-engine)
╭─root@6982f6889913 /workspaces/devContainer/wazuh ‹enhancement/36845-IC-bulk-size-and-flush-interval-configurable●› 
╰─# /var/wazuh-manager/bin/wazuh-manager-control start ; tail -f /var/wazuh-manager/logs/wazuh-manager.log
Starting Wazuh v5.0.0...
Started wazuh-manager-apid...
Started wazuh-manager-authd...
Started wazuh-manager-db...
wazuh-manager-analysisd died during event dumper check.
wazuh-manager-analysisd did not start correctly.
2026/06/24 19:52:44 wazuh-manager-analysisd: INFO: Store initialized.
2026/06/24 19:52:44 wazuh-manager-analysisd: INFO: Content Manager initialized.
2026/06/24 19:52:44 wazuh-manager-analysisd: INFO: KVDB initialized.
2026/06/24 19:52:44 wazuh-manager-analysisd: INFO: IOC initialized.
2026/06/24 19:52:45 wazuh-manager-analysisd: INFO: GEO initialized.
2026/06/24 19:52:45 wazuh-manager-analysisd: INFO: Fast metrics initialized.
2026/06/24 19:52:45 wazuh-manager-analysisd: INFO: Schema initialized.
2026/06/24 19:52:45 wazuh-manager-analysisd: INFO: HLP initialized.
2026/06/24 19:52:45 wazuh-manager-analysisd: INFO: Scheduler initialized.
2026/06/24 19:52:45 wazuh-manager-analysisd: ERROR: An error occurred while initializing the modules: Could not initialize Indexer Connector: analysisd.indexer_bulk_size_events must be between 1 and 1000000 (got 99999999).
^C
╭─root@6982f6889913 /workspaces/devContainer/wazuh ‹enhancement/36845-IC-bulk-size-and-flush-interval-configurable●› 
╰─# cat  /var/wazuh-manager/etc/wazuh-manager-internal-options.conf | grep indexer_bulk_size_events                                                                                                                 130 ↵
analysisd.indexer_bulk_size_events=0      # [1..1000000]   document count per bulk (wazuh-engine)
╭─root@6982f6889913 /workspaces/devContainer/wazuh ‹enhancement/36845-IC-bulk-size-and-flush-interval-configurable●› 
╰─# /var/wazuh-manager/bin/wazuh-manager-control start ; tail -f /var/wazuh-manager/logs/wazuh-manager.log
Starting Wazuh v5.0.0...
wazuh-manager-apid already running...
wazuh-manager-authd already running...
wazuh-manager-db already running...
wazuh-manager-analysisd: Process 246600 not used by Wazuh, removing...
wazuh-manager-analysisd died during event dumper check.
wazuh-manager-analysisd did not start correctly.
2026/06/24 19:52:54 wazuh-manager-analysisd: INFO: Store initialized.
2026/06/24 19:52:54 wazuh-manager-analysisd: INFO: Content Manager initialized.
2026/06/24 19:52:54 wazuh-manager-analysisd: INFO: KVDB initialized.
2026/06/24 19:52:55 wazuh-manager-analysisd: INFO: IOC initialized.
2026/06/24 19:52:55 wazuh-manager-analysisd: INFO: GEO initialized.
2026/06/24 19:52:55 wazuh-manager-analysisd: INFO: Fast metrics initialized.
2026/06/24 19:52:55 wazuh-manager-analysisd: INFO: Schema initialized.
2026/06/24 19:52:55 wazuh-manager-analysisd: INFO: HLP initialized.
2026/06/24 19:52:55 wazuh-manager-analysisd: INFO: Scheduler initialized.
2026/06/24 19:52:55 wazuh-manager-analysisd: ERROR: An error occurred while initializing the modules: Could not initialize Indexer Connector: analysisd.indexer_bulk_size_events must be between 1 and 1000000 (got 0).
^C
╰─# cat  /var/wazuh-manager/etc/wazuh-manager-internal-options.conf | grep analysisd.indexer_flush_interval
analysisd.indexer_flush_interval=0    # [1..3600]       seconds between periodic flushes (wazuh-engine)
╭─root@6982f6889913 /workspaces/devContainer/wazuh ‹enhancement/36845-IC-bulk-size-and-flush-interval-configurable●› 
╰─# /var/wazuh-manager/bin/wazuh-manager-control start ; tail -f /var/wazuh-manager/logs/wazuh-manager.log 
Starting Wazuh v5.0.0...
Started wazuh-manager-apid...
Started wazuh-manager-authd...
Started wazuh-manager-db...
wazuh-manager-analysisd died during event dumper check.
wazuh-manager-analysisd did not start correctly.
2026/06/24 19:55:32 wazuh-manager-analysisd: INFO: Store initialized.
2026/06/24 19:55:32 wazuh-manager-analysisd: INFO: Content Manager initialized.
2026/06/24 19:55:32 wazuh-manager-analysisd: INFO: KVDB initialized.
2026/06/24 19:55:32 wazuh-manager-analysisd: INFO: IOC initialized.
2026/06/24 19:55:32 wazuh-manager-analysisd: INFO: GEO initialized.
2026/06/24 19:55:32 wazuh-manager-analysisd: INFO: Fast metrics initialized.
2026/06/24 19:55:32 wazuh-manager-analysisd: INFO: Schema initialized.
2026/06/24 19:55:32 wazuh-manager-analysisd: INFO: HLP initialized.
2026/06/24 19:55:32 wazuh-manager-analysisd: INFO: Scheduler initialized.
2026/06/24 19:55:32 wazuh-manager-analysisd: ERROR: An error occurred while initializing the modules: Could not initialize Indexer Connector: analysisd.indexer_flush_interval must be between 1 and 3600 (got 0).
^C
╭─root@6982f6889913 /workspaces/devContainer/wazuh ‹enhancement/36845-IC-bulk-size-and-flush-interval-configurable●› 
╰─# cat  /var/wazuh-manager/etc/wazuh-manager-internal-options.conf | grep analysisd.indexer_flush_interval                                                                                                         130 ↵
analysisd.indexer_flush_interval=9999    # [1..3600]       seconds between periodic flushes (wazuh-engine)
╭─root@6982f6889913 /workspaces/devContainer/wazuh ‹enhancement/36845-IC-bulk-size-and-flush-interval-configurable●› 
╰─# /var/wazuh-manager/bin/wazuh-manager-control start ; tail -f /var/wazuh-manager/logs/wazuh-manager.log 
Starting Wazuh v5.0.0...
wazuh-manager-apid already running...
wazuh-manager-authd already running...
wazuh-manager-db already running...
wazuh-manager-analysisd: Process 250704 not used by Wazuh, removing...
wazuh-manager-analysisd died during event dumper check.
wazuh-manager-analysisd did not start correctly.
2026/06/24 19:55:50 wazuh-manager-analysisd: INFO: Store initialized.
2026/06/24 19:55:50 wazuh-manager-analysisd: INFO: Content Manager initialized.
2026/06/24 19:55:50 wazuh-manager-analysisd: INFO: KVDB initialized.
2026/06/24 19:55:50 wazuh-manager-analysisd: INFO: IOC initialized.
2026/06/24 19:55:50 wazuh-manager-analysisd: INFO: GEO initialized.
2026/06/24 19:55:50 wazuh-manager-analysisd: INFO: Fast metrics initialized.
2026/06/24 19:55:50 wazuh-manager-analysisd: INFO: Schema initialized.
2026/06/24 19:55:50 wazuh-manager-analysisd: INFO: HLP initialized.
2026/06/24 19:55:50 wazuh-manager-analysisd: INFO: Scheduler initialized.
2026/06/24 19:55:50 wazuh-manager-analysisd: ERROR: An error occurred while initializing the modules: Could not initialize Indexer Connector: analysisd.indexer_flush_interval must be between 1 and 3600 (got 9999).
^C
```


</p>
</details> 
 
 * config changed modulesd

<details><summary>Details</summary>
<p>


```console
╰─# /var/wazuh-manager/bin/wazuh-manager-control start ; tail -f /var/wazuh-manager/logs/wazuh-manager.log
Starting Wazuh v5.0.0...
Started wazuh-manager-apid...
Started wazuh-manager-authd...
Started wazuh-manager-db...
Started wazuh-manager-analysisd...
Started wazuh-manager-remoted...
Started wazuh-manager-monitord...
Started wazuh-manager-modulesd...
Started wazuh-manager-clusterd...
Completed.
2026/06/24 20:01:57 wazuh-manager-modulesd: INFO: Started (pid: 256169).
2026/06/24 20:01:57 wazuh-manager-modulesd:control: INFO: Starting control thread.
2026/06/24 20:01:57 wazuh-manager-modulesd:agent-upgrade: INFO: Started (pid: 256169).
2026/06/24 20:01:57 wazuh-manager-modulesd:vulnerability-scanner: INFO: Started (pid: 256169).
2026/06/24 20:01:57 wazuh-manager-modulesd:router: INFO: Started (pid: 256169).
2026/06/24 20:01:57 wazuh-manager-modulesd:content_manager: INFO: Started (pid: 256169).
2026/06/24 20:01:57 wazuh-manager-modulesd:inventory-sync: INFO: Started (pid: 256169).
2026/06/24 20:01:57 wazuh-manager-modulesd:database: INFO: Started (pid: 256169).
2026/06/24 20:01:57 wazuh-manager-modulesd:task-manager: INFO: Started (pid: 256169).
2026/06/24 20:01:57 wazuh-manager-modulesd: CRITICAL: (2302): Invalid definition for wazuh_modules.indexer_bulk_size_bytes: '0  # [1..104857600]  NDJSON payload bytes before flush (wazuh-modulesd)'.
^C
╭─root@6982f6889913 /workspaces/devContainer/wazuh ‹enhancement/36845-IC-bulk-size-and-flush-interval-configurable●› 
╰─# cat  /var/wazuh-manager/etc/wazuh-manager-internal-options.conf | grep wazuh_modules.indexer_bulk_size_bytes                                                                                                   130 ↵
wazuh_modules.indexer_bulk_size_bytes=0  # [1..104857600]  NDJSON payload bytes before flush (wazuh-modulesd)
╰─# /var/wazuh-manager/bin/wazuh-manager-control start ; tail -f /var/wazuh-manager/logs/wazuh-manager.log
Starting Wazuh v5.0.0...
Started wazuh-manager-apid...
Started wazuh-manager-authd...
Started wazuh-manager-db...
Started wazuh-manager-analysisd...
Started wazuh-manager-remoted...
Started wazuh-manager-monitord...
Started wazuh-manager-modulesd...
Started wazuh-manager-clusterd...
Completed.
2026/06/24 20:02:55 wazuh-manager-modulesd: INFO: Started (pid: 257654).
2026/06/24 20:02:55 wazuh-manager-modulesd:control: INFO: Starting control thread.
2026/06/24 20:02:55 wazuh-manager-modulesd:agent-upgrade: INFO: Started (pid: 257654).
2026/06/24 20:02:55 wazuh-manager-modulesd:vulnerability-scanner: INFO: Started (pid: 257654).
2026/06/24 20:02:55 wazuh-manager-modulesd:router: INFO: Started (pid: 257654).
2026/06/24 20:02:55 wazuh-manager-modulesd:content_manager: INFO: Started (pid: 257654).
2026/06/24 20:02:55 wazuh-manager-modulesd:inventory-sync: INFO: Started (pid: 257654).
2026/06/24 20:02:55 wazuh-manager-modulesd:database: INFO: Started (pid: 257654).
2026/06/24 20:02:55 wazuh-manager-modulesd:task-manager: INFO: Started (pid: 257654).
2026/06/24 20:02:55 wazuh-manager-modulesd: CRITICAL: (2302): Invalid definition for wazuh_modules.indexer_bulk_size_bytes: '1048576000  # [1..104857600]  NDJSON payload bytes before flush (wazuh-modulesd)'.
2026/06/24 20:03:05 wazuh-manager-monitord: INFO: wazuh: Manager started.
^C
╭─root@6982f6889913 /workspaces/devContainer/wazuh ‹enhancement/36845-IC-bulk-size-and-flush-interval-configurable●› 
╰─# cat  /var/wazuh-manager/etc/wazuh-manager-internal-options.conf | grep wazuh_modules.indexer_bulk_size_bytes                                                                                                   130 ↵
wazuh_modules.indexer_bulk_size_bytes=1048576000  # [1..104857600]  NDJSON payload bytes before flush (wazuh-modulesd)
```


</p>
</details> 

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini" — N/A
  - [ ] `runtests.py` executed without errors — N/A

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine

- Wazuh server API/Framework
  - [ ] Run API Integration Tests — N/A (no API changes)

## Artifacts Affected

- **`wazuh-engine`**: reads two new keys from `wazuh-manager-internal-options.conf`; fails fast
  on invalid values so misconfiguration is caught at startup, not silently ignored.
- **`wazuh-modulesd`** (vulnerability scanner): same two new keys under the `wazuh_modules.*`
  namespace, read via `getDefine_Int_default` (calls `merror_exit` on violation).
- **`libindexer_connector.so`**: source-level changes only in `.hpp` template headers;
  no ABI change. Default behaviour is identical when the options are absent from the conf file.
- **New test binary artefacts**: 14 additional test cases spread across the two existing
  `indexer_connector_utest` test suites.

## Configuration Changes

Three new option pairs are available in `wazuh-manager-internal-options.conf`.
All six options are optional; omitting them preserves the current compiled-in defaults.

```
# analysisd.indexer_bulk_size=25000      # [1..1000000]   document count per bulk (wazuh-engine)
# analysisd.indexer_flush_interval=20    # [1..3600]       seconds between periodic flushes (wazuh-engine)
# wazuh_modules.indexer_bulk_size_bytes=10485760           # [4096..104857600]  NDJSON payload bytes before flush (vulnerability detection)
# wazuh_modules.indexer_flush_interval=20                  # [1..3600]          seconds between periodic flushes (vulnerability detection)
# wazuh_modules.inventory_sync_indexer_bulk_size_bytes=10485760  # [4096..104857600]  NDJSON payload bytes before flush (inventory sync)
# wazuh_modules.inventory_sync_indexer_flush_interval=20         # [1..3600]          seconds between periodic flushes (inventory sync)
```

Note: `analysisd.indexer_bulk_size` counts **documents**;
the `*_bulk_size_bytes` options count **bytes**. The shared concept (how much to accumulate
before flushing) is implemented by two different connector flavours
(`IndexerConnectorAsyncImpl` and `IndexerConnectorSyncImpl`).

The 4096 B lower bound on the byte thresholds is a usability cushion (see the description
section). Values below 4 KB would not crash the connector — the
`!m_bulkData.empty()` guard in `bulkIndex`/`bulkDelete` prevents the `"No data to process"`
exception — but they would degrade into effectively "one bulk request per document", which is
never what an operator actually wants.

## Tests Introduced

**`IndexerConnectorAsyncTest`** — 4 new cases:

| Test | What it proves |
|---|---|
| `ElementsPerBulkFromJsonConfigTriggersBulk` | JSON `elements_per_bulk` overrides 25 000-element template default; count-based trigger fires after exactly N elements |
| `ElementsPerBulkMinValueOneFlushesImmediately` | `elements_per_bulk=1` causes a bulk send on every single element |
| `ElementsPerBulkBelowThresholdNoFlush` | Pushing N−1 elements with a long timer does not trigger a flush |
| `FlushIntervalSecondsFromJsonConfigTimerFires` | JSON `flush_interval_seconds=1` overrides 5 s template; timer-based flush fires within 3 s window |

**`IndexerConnectorSyncTest`** — 10 new cases:

| Test | What it proves |
|---|---|
| `MaxBulkSizeFromJsonConfigTriggersFlush` | JSON `max_bulk_size=100` overrides 1024-byte template; size-triggered `processBulk()` fires on second element |
| `MaxBulkSizeMinValueTriggersFlushOnSecondElement` | `max_bulk_size=91` (tightest valid value) — first element fits, second triggers flush, neither throws |
| `MaxBulkSizeDefaultUsedWhenAbsentFromJsonConfig` | Absent key → template default (1024 bytes) is used; two small elements do not flush |
| `FlushIntervalSecondsFromJsonConfigTimerFires` | JSON `flush_interval_seconds=1` overrides 20 s template; timer-based flush occurs within 2 s sleep |
| `FlushIntervalTimerDoesNotFlushWhenNoData` | Timer fires repeatedly on empty buffer without producing spurious HTTP calls |
| `BulkIndexOnEmptyBufferDoesNotThrowWhenSingleDocExceedsMaxBulkSize` | `bulkIndex` with `max_bulk_size=1`: empty-buffer guard skips the flush on the first call; old (unguarded) code would have thrown `"No data to process"` |
| `BulkIndexFlushesPreviousBufferWhenMaxBulkSizeIsTiny` | `bulkIndex` with `max_bulk_size=1`: 3 successive calls produce exactly `callCount==2` — guard fires only when buffer is empty, never inhibits a legitimate flush |
| `BulkDeleteOnEmptyBufferDoesNotThrowWhenSingleDocExceedsMaxBulkSize` | Same as the `bulkIndex` empty-buffer test, but exercises the `bulkDelete` size-guard path (uses `DELETE_FORMATTED_LENGTH` overhead) |
| `BulkDeleteFlushesPreviousBufferWhenMaxBulkSizeIsTiny` | Same as `BulkIndexFlushesPreviousBuffer…` but for `bulkDelete` |
| `MixedBulkIndexAndDeleteRespectEmptyBufferGuard` | Cross-path: `bulkDelete` then `bulkIndex` share `m_bulkData`; guard suppresses the first flush (empty buffer) and the second call flushes the buffered delete exactly once |

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
