### PR TITLE
Eliminate TOCTOU races in healthcheck file operations

### DIFF
--- a/src/syscheckd/src/ebpf/src/ebpf_whodata.cpp
+++ b/src/syscheckd/src/ebpf/src/ebpf_whodata.cpp
@@ -230,7 +230,8 @@ static bool modify_healthcheck_file_content(const char* file_path, char* detail,
 static bool modify_healthcheck_file_metadata(const char* file_path, char* detail, size_t detail_size) {
     struct stat file_stat = {};
 
-    if (stat(file_path, &file_stat) != 0) {
+    int fd = open(file_path, O_RDONLY);
+    if (fd < 0) {
         snprintf(detail,
                  detail_size,
                  FIM_EBPF_HEALTHCHECK_STAT_DETAIL,
@@ -239,18 +240,32 @@ static bool modify_healthcheck_file_metadata(const char* file_path, char* detail
         return false;
     }
 
+    if (fstat(fd, &file_stat) != 0) {
+        int saved_errno = errno;
+        close(fd);
+        snprintf(detail,
+                 detail_size,
+                 FIM_EBPF_HEALTHCHECK_STAT_DETAIL,
+                 file_path,
+                 strerror(saved_errno));
+        return false;
+    }
+
     mode_t current_mode = file_stat.st_mode & 0777;
     mode_t new_mode = (current_mode ^ S_IXUSR) & 0777;
 
-    if (chmod(file_path, new_mode) != 0) {
+    if (fchmod(fd, new_mode) != 0) {
+        int saved_errno = errno;
+        close(fd);
         snprintf(detail,
                  detail_size,
                  FIM_EBPF_HEALTHCHECK_CHMOD_DETAIL,
                  file_path,
-                 strerror(errno));
+                 strerror(saved_errno));
         return false;
     }
 
+    close(fd);
     return true;
 }
 
@@ -629,7 +644,6 @@ int ebpf_whodata_healthcheck() {
     auto abspathFn = fimebpf::instance().m_abspath;
     char ebpf_hc_abs_path[PATH_MAX] = {0};
     bool healthcheck_failed = false;
-    bool healthcheck_file_available = false;
 
     if (!bpf_helpers) {
         bpf_helpers = std::make_unique<w_bpf_helpers_t>();
@@ -654,44 +668,42 @@ int ebpf_whodata_healthcheck() {
     }
 
     event_received = false;
-    ebpf_hc_created = false;
     abspathFn(EBPF_HC_FILE, ebpf_hc_abs_path, sizeof(ebpf_hc_abs_path));
 
     if (std::remove(ebpf_hc_abs_path) == 0) {
         logFn(LOG_DEBUG_VERBOSE, FIM_EBPF_HEALTHCHECK_CLEANUP);
     }
 
-    healthcheck_failed |= !run_healthcheck_action(rb,
+    bool file_created = run_healthcheck_action(rb,
                                                   "create file",
                                                   ebpf_hc_abs_path,
                                                   create_healthcheck_file,
                                                   true);
-    ebpf_hc_created = (access(ebpf_hc_abs_path, F_OK) == 0);
-    healthcheck_file_available = ebpf_hc_created;
+
+    healthcheck_failed |= !file_created;
 
     healthcheck_failed |= !run_healthcheck_action(rb,
                                                   "modify content",
                                                   ebpf_hc_abs_path,
                                                   modify_healthcheck_file_content,
-                                                  healthcheck_file_available);
+                                                  file_created);
 
     healthcheck_failed |= !run_healthcheck_action(rb,
                                                   "modify metadata",
                                                   ebpf_hc_abs_path,
                                                   modify_healthcheck_file_metadata,
-                                                  healthcheck_file_available);
+                                                  file_created);
 
     healthcheck_failed |= !run_healthcheck_action(rb,
                                                   "delete file",
                                                   ebpf_hc_abs_path,
                                                   delete_healthcheck_file,
-                                                  healthcheck_file_available);
-    healthcheck_file_available = (access(ebpf_hc_abs_path, F_OK) == 0);
+                                                  file_created);
 
     // Free healthcheck ring buffer
     bpf_helpers->ring_buffer_free(rb);
 
-    if (healthcheck_file_available && std::remove(ebpf_hc_abs_path) != 0 && errno != ENOENT) {
+    if (std::remove(ebpf_hc_abs_path) != 0 && errno != ENOENT) {
         char error_message[4200] = {0};
         snprintf(error_message, sizeof(error_message), FIM_ERROR_EBPF_HEALTHCHECK_FILE_DEL, ebpf_hc_abs_path);
         logFn(LOG_ERROR, error_message);

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_create_after_delete_dir.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_create_after_delete_dir.py
@@ -69,7 +69,7 @@ from pathlib import Path
 from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.constants.platforms import WINDOWS
 from wazuh_testing.modules.agentd.configuration import AGENTD_DEBUG, AGENTD_WINDOWS_DEBUG
-from wazuh_testing.modules.fim.patterns import EVENT_TYPE_ADDED, EVENT_TYPE_DELETED, MONITORING_PATH
+from wazuh_testing.modules.fim.patterns import EVENT_TYPE_ADDED, EVENT_TYPE_DELETED, EVENT_TYPE_SCAN_END
 from wazuh_testing.modules.fim.utils import get_fim_event_data
 from wazuh_testing.modules.monitord.configuration import MONITORD_ROTATE_LOG
 from wazuh_testing.modules.fim.configuration import SYSCHECK_DEBUG
@@ -165,7 +165,7 @@ def test_create_after_delete(test_configuration, test_metadata, configure_local_
 
     wazuh_log_monitor = FileMonitor(WAZUH_LOG_PATH)
 
-    wazuh_log_monitor.start(generate_callback(MONITORING_PATH), timeout=60)
+    wazuh_log_monitor.start(generate_callback(EVENT_TYPE_SCAN_END), timeout=60)
     assert wazuh_log_monitor.callback_result
 
     fim_mode = test_metadata.get('fim_mode')


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

Closes #37131
This PR addresses two Time-Of-Check Time-Of-Use (TOCTOU) issues reported by Coverity in the eBPF healthcheck code.

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

- Removed the existence check performed with access() before deleting the healthcheck file. The cleanup now directly invokes remove() and handles ENOENT as a non-error condition.

- Reworked the metadata modification logic to avoid performing stat() and chmod() on the same pathname in separate operations. The implementation now uses a file descriptor and performs metadata retrieval and permission changes through fstat() and fchmod(), ensuring both operations target the same file instance.

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

The first commit was not enough to completely fix the issue, which is why the issue was completely fixed after two coverity scans:

<img width="1320" height="150" alt="Screenshot From 2026-06-25 12-36-57" src="https://github.com/user-attachments/assets/40693b79-2b0d-4795-ae89-643c68a960b2" />

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->
- ebpf_whodata.cpp
### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->
 N/A
### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->
N/A
## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
