### PR TITLE
Fix agent process lingers after service stop causing MSI 1603

### DIFF
--- a/src/client-agent/src/receiver.c
+++ b/src/client-agent/src/receiver.c
@@ -314,17 +314,35 @@ int receive_msg()
     return 0;
 }
 
-/* Set to 1 by OssecServiceCtrlHandler before reporting SERVICE_STOPPED.
- * receiver_messages() polls this at the top of its loop so the process
- * exits cleanly without relying on ExitProcess(). */
+/* Set to 1 by w_agentd_force_stop() (from OssecServiceCtrlHandler) before
+ * reporting SERVICE_STOPPED.  Both the connection retry loop in start_agent()
+ * and receiver_messages() poll this so the process exits cleanly on service
+ * stop without relying on ExitProcess(). */
 volatile int receiver_should_stop = 0;
 
 #ifdef WIN32
-/* Mirrors the active socket fd so OssecServiceCtrlHandler can close it
- * without needing access to the full agent struct.  Closing the socket
- * unblocks any in-progress OS_SendSecureTCP (SO_SNDTIMEO or select),
- * making the exit latency effectively zero instead of up to 30 s. */
-volatile SOCKET receiver_agent_sock = INVALID_SOCKET;
+/* Called by OssecServiceCtrlHandler on service stop.  Signals the connection
+ * and receive loops to abort and closes whatever socket the agent currently
+ * holds, so any thread blocked inside connect()/recv()/send() returns
+ * immediately and the main thread can unwind.  This keeps wazuh-agent.exe from
+ * lingering after the service reports SERVICE_STOPPED (a lingering process
+ * holds handles under the install dir and delays MSI file removal).
+ *
+ * The socket is closed without taking the send mutex on purpose: the goal is
+ * precisely to interrupt a thread that may be blocked holding it inside
+ * send()/recv().  A connect() that has not yet published its fd into agt->sock
+ * cannot be interrupted this way and will run to its TCP timeout before the
+ * loop next checks the flag; that is bounded and far better than blocking
+ * forever. */
+void w_agentd_force_stop(void)
+{
+    receiver_should_stop = 1;
+
+    const int current_sock = agt->sock;
+    if (current_sock >= 0) {
+        OS_CloseSocket(current_sock);
+    }
+}
 #endif
 
 #ifdef WIN32
@@ -351,22 +369,17 @@ int receiver_messages()
 
         /* sock must be set */
         if (agt->sock == -1) {
-            receiver_agent_sock = INVALID_SOCKET;
             sleep(5);
             continue;
         }
 
-        /* Snapshot the atomic fd before any use: the stop handler (or
-         * sendmsg on a WSAETIMEDOUT) may write -1 concurrently.
+        /* Snapshot the atomic fd before any use: the stop handler (closing the
+         * socket) or sendmsg (on a WSAETIMEDOUT) may write -1 concurrently.
          * FD_SET/select need a stable, non-negative descriptor. */
         const int sock = agt->sock;
         if (sock == -1) {
-            receiver_agent_sock = INVALID_SOCKET;
             continue;
         }
-
-        /* Keep the mirror in sync so the stop handler can close it. */
-        receiver_agent_sock = (SOCKET)sock;
 
         run_notify();
 

--- a/src/client-agent/src/receiver.c
+++ b/src/client-agent/src/receiver.c
@@ -314,6 +314,19 @@ int receive_msg()
     return 0;
 }
 
+/* Set to 1 by OssecServiceCtrlHandler before reporting SERVICE_STOPPED.
+ * receiver_messages() polls this at the top of its loop so the process
+ * exits cleanly without relying on ExitProcess(). */
+volatile int receiver_should_stop = 0;
+
+#ifdef WIN32
+/* Mirrors the active socket fd so OssecServiceCtrlHandler can close it
+ * without needing access to the full agent struct.  Closing the socket
+ * unblocks any in-progress OS_SendSecureTCP (SO_SNDTIMEO or select),
+ * making the exit latency effectively zero instead of up to 30 s. */
+volatile SOCKET receiver_agent_sock = INVALID_SOCKET;
+#endif
+
 #ifdef WIN32
 /* Receive events from the server */
 int receiver_messages()
@@ -329,24 +342,49 @@ int receiver_messages()
             ExecdTimeoutRun();
         }
 
+        /* Exit cleanly when the service stop handler has signalled shutdown.
+         * Checked before the sock==-1 sleep so the process does not wait an
+         * extra 5 seconds after OssecServiceCtrlHandler returns. */
+        if (receiver_should_stop) {
+            return 0;
+        }
+
         /* sock must be set */
         if (agt->sock == -1) {
+            receiver_agent_sock = INVALID_SOCKET;
             sleep(5);
             continue;
         }
 
+        /* Snapshot the atomic fd before any use: the stop handler (or
+         * sendmsg on a WSAETIMEDOUT) may write -1 concurrently.
+         * FD_SET/select need a stable, non-negative descriptor. */
+        const int sock = agt->sock;
+        if (sock == -1) {
+            receiver_agent_sock = INVALID_SOCKET;
+            continue;
+        }
+
+        /* Keep the mirror in sync so the stop handler can close it. */
+        receiver_agent_sock = (SOCKET)sock;
+
         run_notify();
 
         FD_ZERO(&fdset);
-        FD_SET(agt->sock, &fdset);
+        FD_SET(sock, &fdset);
 
-        /* Wait for 1 second */
+        /* Wait up to 1 second for incoming data */
         selecttime.tv_sec = 1;
         selecttime.tv_usec = 0;
 
         /* Wait with a timeout for any descriptor */
-        rc = select(agt->sock + 1, &fdset, NULL, NULL, &selecttime);
+        rc = select(sock + 1, &fdset, NULL, NULL, &selecttime);
         if (rc == -1) {
+            /* WSAEBADF / WSAENOTSOCK can occur when the stop handler closes
+             * agt->sock while select() is in flight; treat it as shutdown. */
+            if (receiver_should_stop) {
+                return 0;
+            }
             merror(SELECT_ERROR, WSAGetLastError(), win_strerror(WSAGetLastError()));
             sleep(30);
             continue;

--- a/src/client-agent/src/sendmsg.c
+++ b/src/client-agent/src/sendmsg.c
@@ -85,18 +85,57 @@ int send_msg(const char *msg, ssize_t msg_length)
             agt->sock = -1;
         }
     }
-#endif
+#else  /* WIN32 */
+    /* Mirror the Linux dead-socket detection for Windows.
+     * WSAGetLastError() must be called immediately after the failed Winsock
+     * call and before w_mutex_unlock() to avoid a race where another thread
+     * calls a Winsock function in between.
+     * PR #36790 added SO_SNDTIMEO=30s on all platforms (start_agent.c) but
+     * only wired up the error handling on Linux; complete the port here so
+     * agt->sock is invalidated on terminal errors and receiver_messages()
+     * can detect the dead connection and exit. */
+    if (retval != 0) {
+        error = WSAGetLastError();
+        bool socket_dead = true;
+        switch (error) {
+        case WSAECONNRESET:
+            mdebug2("Connection reset by manager.");
+            break;
+        case WSAETIMEDOUT:
+            /* SO_SNDTIMEO expiry or TCP retransmit exhaustion. */
+            mdebug2(SEND_ERROR, "server", win_strerror(error));
+            break;
+        case WSAEWOULDBLOCK:
+            mdebug2(SEND_ERROR, "server", win_strerror(error));
+            break;
+        case WSAECONNREFUSED:
+            mdebug2(CONN_REF);
+            break;
+        case WSAENOTCONN:
+        case WSAESHUTDOWN:
+            mdebug2("Socket not connected.");
+            break;
+        case WSAEBADF:
+        case WSAENOTSOCK:
+            /* Socket was closed by the stop handler concurrently. */
+            mdebug2("Socket closed by stop handler.");
+            break;
+        default:
+            mwarn(SEND_ERROR, "server", win_strerror(error));
+            socket_dead = false;
+            break;
+        }
+        if (socket_dead && agt->sock >= 0) {
+            OS_CloseSocket(agt->sock);
+            agt->sock = -1;
+        }
+    }
+#endif  /* WIN32 */
     w_mutex_unlock(&send_mutex);
 
     if (retval == 0) {
         w_agentd_state_update(INCREMENT_MSG_SEND, NULL);
     }
-#ifdef WIN32
-    else {
-        error = WSAGetLastError();
-        mwarn(SEND_ERROR, "server", win_strerror(error));
-    }
-#endif
 
     return retval;
 }

--- a/src/client-agent/src/start_agent.c
+++ b/src/client-agent/src/start_agent.c
@@ -41,6 +41,27 @@ static void w_agentd_keys_init (void);
 STATIC bool agent_handshake_to_server(int server_id, bool is_startup);
 STATIC void send_msg_on_startup(void);
 
+#ifdef WIN32
+/* Set by w_agentd_force_stop() (receiver.c) when the Windows service is
+ * stopping.  The connection retry loop polls it so the process can exit
+ * promptly instead of looping here forever when no server is reachable. */
+extern volatile int receiver_should_stop;
+
+/* sleep() that wakes early if a service stop has been signalled, so the retry
+ * back-off never delays shutdown by more than ~1 second. */
+STATIC void w_agentd_retry_sleep(int seconds) {
+    for (int i = 0; i < seconds && !receiver_should_stop; i++) {
+        sleep(1);
+    }
+}
+
+#define AGENTD_STOPPING()     (receiver_should_stop != 0)
+#define AGENTD_RETRY_SLEEP(s) w_agentd_retry_sleep(s)
+#else
+#define AGENTD_STOPPING()     (0)
+#define AGENTD_RETRY_SLEEP(s) sleep(s)
+#endif
+
 /**
  * @brief Get a required integer field from a JSON object
  * @param parent Parent JSON object
@@ -439,6 +460,13 @@ void start_agent(int is_startup)
 
     int current_server_id = agt->rip_id;
     while (1) {
+        /* Abort the retry loop if the service is stopping (Windows), so the
+         * process can exit instead of looping here when no server is reachable.
+         * No-op on other platforms. */
+        if (AGENTD_STOPPING()) {
+            return;
+        }
+
         // (max_retries - 1) attempts
 
         for (int attempts = 0; attempts < agt->server[current_server_id].max_retries - 1; attempts++) {
@@ -446,7 +474,11 @@ void start_agent(int is_startup)
                 return;
             }
 
-            sleep(agt->server[current_server_id].retry_interval);
+            if (AGENTD_STOPPING()) {
+                return;
+            }
+
+            AGENTD_RETRY_SLEEP(agt->server[current_server_id].retry_interval);
         }
 
         // Last attempt
@@ -465,7 +497,11 @@ void start_agent(int is_startup)
             }
         }
 
-        sleep(agt->server[current_server_id].retry_interval);
+        if (AGENTD_STOPPING()) {
+            return;
+        }
+
+        AGENTD_RETRY_SLEEP(agt->server[current_server_id].retry_interval);
 
         /* Wait for server reply */
         mwarn(AG_WAIT_SERVER, agt->server[current_server_id].rip, __wazuh_version);

--- a/src/win32/win_service.c
+++ b/src/win32/win_service.c
@@ -283,6 +283,15 @@ VOID WINAPI OssecServiceCtrlHandler(DWORD dwOpcode)
 #ifdef OSSECHIDS
                 extern bool is_fim_shutdown;
 
+                extern volatile int receiver_should_stop;
+                extern volatile SOCKET receiver_agent_sock;
+                receiver_should_stop = 1;
+                SOCKET sock_to_close = receiver_agent_sock;
+                if (sock_to_close != INVALID_SOCKET) {
+                    receiver_agent_sock = INVALID_SOCKET;
+                    closesocket(sock_to_close);
+                }
+
                 ossecServiceStatus.dwCurrentState           = SERVICE_STOP_PENDING;
                 SetServiceStatus (ossecServiceStatusHandle, &ossecServiceStatus);
                 plain_minfo("Set pending exit signal.");

--- a/src/win32/win_service.c
+++ b/src/win32/win_service.c
@@ -283,14 +283,13 @@ VOID WINAPI OssecServiceCtrlHandler(DWORD dwOpcode)
 #ifdef OSSECHIDS
                 extern bool is_fim_shutdown;
 
-                extern volatile int receiver_should_stop;
-                extern volatile SOCKET receiver_agent_sock;
-                receiver_should_stop = 1;
-                SOCKET sock_to_close = receiver_agent_sock;
-                if (sock_to_close != INVALID_SOCKET) {
-                    receiver_agent_sock = INVALID_SOCKET;
-                    closesocket(sock_to_close);
-                }
+                /* Signal the connection (start_agent) and receive
+                 * (receiver_messages) loops to stop and close the in-flight
+                 * socket, so the agent's main thread unwinds and the process
+                 * exits promptly instead of lingering after SERVICE_STOPPED.
+                 * Done before the teardown below so it can run in parallel. */
+                extern void w_agentd_force_stop(void);
+                w_agentd_force_stop();
 
                 ossecServiceStatus.dwCurrentState           = SERVICE_STOP_PENDING;
                 SetServiceStatus (ossecServiceStatusHandle, &ossecServiceStatus);

--- a/tests/integration/test_agentd/test_shutdown/__init__.py
+++ b/tests/integration/test_agentd/test_shutdown/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (C) 2015-2024, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+from pathlib import Path
+
+# Constants & base paths
+DATA_PATH = Path(Path(__file__).parent, 'data')
+CONFIGS_PATH = Path(DATA_PATH, 'configuration_templates')
+TEST_CASES_PATH = Path(DATA_PATH, 'test_cases')

--- a/tests/integration/test_agentd/test_shutdown/data/configuration_templates/wazuh_conf.yaml
+++ b/tests/integration/test_agentd/test_shutdown/data/configuration_templates/wazuh_conf.yaml
@@ -1,0 +1,9 @@
+    - sections:
+      - section: client
+        elements:
+            - manager:
+                elements:
+                - address:
+                    value: '127.0.0.1'
+                - port:
+                    value: '1514'

--- a/tests/integration/test_agentd/test_shutdown/data/test_cases/cases_shutdown.yaml
+++ b/tests/integration/test_agentd/test_shutdown/data/test_cases/cases_shutdown.yaml
@@ -1,0 +1,15 @@
+- name: Connected agent exits promptly on service stop
+  description: With the agent connected to a (simulated) manager, stopping WazuhSvc must
+    let wazuh-agent.exe exit within the grace period instead of lingering in the
+    receiver_messages() select loop.
+  configuration_parameters:
+  metadata:
+    connect_to_manager: true
+
+- name: Never-connected agent exits promptly on service stop
+  description: With no manager reachable (agent looping in start_agent()), stopping
+    WazuhSvc must let wazuh-agent.exe exit within the grace period instead of
+    lingering in the connection retry loop.
+  configuration_parameters:
+  metadata:
+    connect_to_manager: false

--- a/tests/integration/test_agentd/test_shutdown/test_agentd_shutdown_on_service_stop.py
+++ b/tests/integration/test_agentd/test_shutdown/test_agentd_shutdown_on_service_stop.py
@@ -1,0 +1,188 @@
+'''
+copyright: Copyright (C) 2015-2024, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: The 'wazuh-agentd' program is the client-side daemon that communicates with the server.
+       These tests verify that, on Windows, stopping the service ('net stop WazuhSvc') makes the
+       'wazuh-agent.exe' process terminate promptly instead of lingering after the Service Control
+       Manager reports SERVICE_STOPPED. A lingering process keeps open handles under the install
+       directory, which delays/breaks MSI file removal (uninstall/upgrade) and slows shutdown for
+       real users.
+
+       Two scenarios are exercised, one per affected code path:
+         - connected: the agent reached receiver_messages() and is blocked in select(); the stop
+           handler must close the socket so the loop unblocks and returns.
+         - never-connected: the agent never completed a handshake and is looping in start_agent();
+           the stop handler must signal the retry loop so it aborts (this path is NOT covered by
+           closing the socket, since there is no live connection).
+
+       A dedicated "send blocked on SO_SNDTIMEO" scenario is intentionally omitted: a blocked
+       send() is interrupted by the very same socket close exercised by the 'connected' case, so it
+       shares its code path and would only add non-determinism (it requires the manager to stall
+       reads until the socket buffer fills).
+
+components:
+    - agentd
+
+targets:
+    - agent
+
+daemons:
+    - wazuh-agentd
+
+os_platform:
+    - windows
+
+os_version:
+    - Windows Server 2022
+    - Windows Server 2019
+    - Windows 10
+
+tags:
+    - shutdown
+    - simulator
+'''
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from wazuh_testing.constants.platforms import WINDOWS
+from wazuh_testing.modules.agentd.configuration import AGENTD_WINDOWS_DEBUG, AGENTD_TIMEOUT
+from wazuh_testing.tools.simulators.remoted_simulator import RemotedSimulator
+from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
+from wazuh_testing.utils.services import check_if_process_is_running, control_service
+
+from . import CONFIGS_PATH, TEST_CASES_PATH
+from utils import wait_connect
+
+# Marks: Windows-only; the prompt-shutdown logic under test is specific to the Windows service.
+pytestmark = [pytest.mark.agent, pytest.mark.win32, pytest.mark.tier(level=0)]
+
+# Configuration and cases data.
+configs_path = Path(CONFIGS_PATH, 'wazuh_conf.yaml')
+cases_path = Path(TEST_CASES_PATH, 'cases_shutdown.yaml')
+
+config_parameters, test_metadata, test_cases_ids = get_test_cases_data(cases_path)
+test_configuration = load_configuration_template(configs_path, config_parameters, test_metadata)
+
+local_internal_options = {AGENTD_WINDOWS_DEBUG: '2', AGENTD_TIMEOUT: '5'}
+daemons_handler_configuration = {'all_daemons': True}
+
+# Name of the agent process as reported by psutil on Windows.
+AGENT_PROCESS = 'wazuh-agent.exe'
+# Maximum time wazuh-agent.exe may take to exit after 'net stop WazuhSvc' returns.
+# The fix exits in ~1 s; the unfixed agent lingers up to SO_SNDTIMEO (30 s) or forever.
+SHUTDOWN_GRACE = 10
+# Seconds to let the agent settle into its loop (start_agent retry / receiver select) before stopping.
+SETTLE_TIME = 5
+
+
+def _wait_process_exit(process_name, timeout):
+    '''Poll until `process_name` is gone, returning the elapsed seconds, or None on timeout.
+
+    control_service('stop') on Windows runs `net stop WazuhSvc`, which returns as soon as the SCM
+    reports SERVICE_STOPPED. It does NOT wait for, nor kill, the process; so a lingering agent is
+    observable here as the process still running after the stop returned.
+    '''
+    start = time.time()
+    while time.time() - start < timeout:
+        if not check_if_process_is_running(process_name):
+            return time.time() - start
+        time.sleep(0.25)
+    return None
+
+
+@pytest.mark.parametrize('test_configuration, test_metadata', zip(test_configuration, test_metadata),
+                         ids=test_cases_ids)
+def test_agentd_shutdown_on_service_stop(test_configuration, test_metadata, set_wazuh_configuration,
+                                         configure_local_internal_options, truncate_monitored_files,
+                                         clean_keys, add_keys, daemons_handler):
+    '''
+    description: Check that 'wazuh-agent.exe' terminates promptly when the Windows service is stopped,
+                 both when the agent is connected to the manager and when it has never connected.
+
+    wazuh_min_version: 5.0.0
+
+    tier: 0
+
+    parameters:
+        - test_configuration:
+            type: data
+            brief: Configuration loaded from the template.
+        - test_metadata:
+            type: data
+            brief: Case metadata (selects the connected / never-connected scenario).
+        - set_wazuh_configuration:
+            type: fixture
+            brief: Configure a custom environment for testing.
+        - configure_local_internal_options:
+            type: fixture
+            brief: Set internal configuration for testing.
+        - truncate_monitored_files:
+            type: fixture
+            brief: Reset the 'ossec.log' file and start a new monitor.
+        - clean_keys:
+            type: fixture
+            brief: Cleans keys file content.
+        - add_keys:
+            type: fixture
+            brief: Adds a key so the agent connects without enrollment.
+        - daemons_handler:
+            type: fixture
+            brief: Starts the Wazuh agent service before the test and stops it on teardown.
+
+    assertions:
+        - Verify the agent process is running before the stop.
+        - Verify wazuh-agent.exe exits within SHUTDOWN_GRACE seconds of 'net stop WazuhSvc' returning.
+
+    expected_output:
+        - wazuh-agent.exe no longer running shortly after the service stop.
+
+    tags:
+        - shutdown
+    '''
+    if sys.platform != WINDOWS:
+        pytest.skip('The prompt-shutdown behaviour under test is Windows-specific.')
+
+    remoted_server = None
+    try:
+        if test_metadata['connect_to_manager']:
+            # Bring the agent to a connected state: blocked in receiver_messages() select().
+            remoted_server = RemotedSimulator(protocol='tcp')
+            remoted_server.start()
+            wait_connect()
+        else:
+            # No manager: the agent stays looping in start_agent()'s connection retry.
+            time.sleep(SETTLE_TIME)
+
+        # Sanity: the agent must be alive right before we stop it.
+        assert check_if_process_is_running(AGENT_PROCESS), \
+            f'{AGENT_PROCESS} is not running before the service stop.'
+
+        # Stop the service. net stop returns at SERVICE_STOPPED, without waiting for the process.
+        control_service('stop')
+
+        latency = _wait_process_exit(AGENT_PROCESS, SHUTDOWN_GRACE)
+        assert latency is not None, (
+            f'{AGENT_PROCESS} is still running {SHUTDOWN_GRACE}s after the service stopped '
+            f'(scenario: connected={test_metadata["connect_to_manager"]}). The agent lingered '
+            f'instead of exiting on service stop.')
+    finally:
+        if remoted_server is not None:
+            remoted_server.destroy()
+        # Make sure a lingering process (failed case) does not leak into the next test.
+        if check_if_process_is_running(AGENT_PROCESS):
+            import psutil
+            for proc in psutil.process_iter():
+                try:
+                    if proc.name() == AGENT_PROCESS:
+                        proc.kill()
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    pass


### PR DESCRIPTION
## Description

The Windows agent does not terminate promptly when the service is stopped. After `net stop WazuhSvc`, the SCM stop handler reports `SERVICE_STOPPED` and returns, but `wazuh-agent.exe` can stay alive because the main thread is blocked in a socket operation or looping with no way to break out. A lingering process keeps open handles on files under the install directory, which delays/blocks operations that need those files released (e.g. an MSI upgrade/uninstall that runs `RemoveFiles` while the old agent is still running).

This is an incomplete Windows port of PR #36790 ("Fix agent permanently stuck when TCP connection is silently half-closed"), which was designed for Linux and only half-ported to Windows:

- `OS_SetSendTimeout(sock, 30s)` is applied unconditionally (no `WIN32` guard), so the Windows socket also gets the 30 s `SO_SNDTIMEO`, making a blocked `send` linger.
- The companion dead-socket detection in `sendmsg.c` was `#ifndef WIN32` (Linux only), so Windows never invalidated the socket on terminal errors.
- `receiver_messages()` (Windows-only) loops on `while (1)` with no shutdown exit.
- `start_agent()`'s connection retry loop (`while (1)`) also has no shutdown exit, so an agent that has **not yet connected** (unreachable manager) or is **reconnecting** never unwinds either — this path is reached before/instead of `receiver_messages()`.

### Relationship with #37132 and the MSI 1603

Issue #37132 surfaced this as an MSI `1603` failure in the `Test MSI package` CI job. Investigation while preparing this PR showed the CI `1603` is **environmental**, not the agent:

- In the failing CI job the agent service is **never started** before the uninstall (a clean MSI install does not start the service), so there is no `wazuh-agent.exe` holding files when `1603` occurs — the `1603` cannot be the lingering process there.
- The `1603` reproduces on `main` too and only on the **GitHub-hosted `windows-2022` image**; it passes on AWS CodeBuild and on a clean Windows Server 2022 VM. It is bracketed to a Windows OS cumulative update in the runner image (image OS build `20260527.539` → `20260611.554`, `msi.dll 5.0.20348.5020`) that changed how the MSI `SecureObjects`/ACL step behaves on uninstall (`ExecSecureObjects` → `ACCESS_DENIED`).

The CI job was unblocked by moving `Test MSI package` to the CodeBuild runner (#37165). **This PR addresses the other half of #37132: the real agent regression** — the Windows agent lingering on service stop — which affects real users doing an upgrade/uninstall while the agent is running.

Closes #37132

## Proposed Changes

Complete the Windows port of PR #36790 and guarantee prompt shutdown in **all** agent states (connected, connected-but-send-blocked, never-connected, reconnecting):

**`src/client-agent/src/sendmsg.c`**
- Mirror the Linux dead-socket detection in the Windows error path: on terminal Winsock errors (`WSAETIMEDOUT`, `WSAECONNRESET`, `WSAENOTCONN`, `WSAESHUTDOWN`, `WSAEWOULDBLOCK`, `WSAECONNREFUSED`, `WSAEBADF`, `WSAENOTSOCK`) close the socket and set `agt->sock = -1`.
- `WSAGetLastError()` is captured inside the send mutex, right after `OS_SendSecureTCP`, before `w_mutex_unlock()`, to avoid another thread overwriting the last error code.

**`src/client-agent/src/receiver.c`**
- Defines `volatile int receiver_should_stop` and a new `w_agentd_force_stop()` that sets the flag **and** closes the in-flight `agt->sock`, so any thread blocked in `connect()`/`recv()`/`send()`/`select()` returns immediately.
- `receiver_messages()` checks the flag at the top of the loop and again in the `select() == -1` path, and snapshots `agt->sock` (an `_Atomic int`) into a local before `FD_SET`/`select` to avoid a TOCTOU with the concurrent close.

**`src/client-agent/src/start_agent.c`**
- The connection retry loop now polls `receiver_should_stop` and uses an interruptible sleep on Windows (compiles to a plain `sleep`/no-op elsewhere), so a never-connected or reconnecting agent unwinds instead of looping forever. This closes a gap the earlier iteration missed (only `receiver_messages()` was covered).

**`src/win32/win_service.c`**
- `OssecServiceCtrlHandler` calls `w_agentd_force_stop()` at the start of the `#ifdef OSSECHIDS` block, before reporting `SERVICE_STOP_PENDING`, so the main thread starts unwinding in parallel with module teardown.

**Expected exit latency after `net stop WazuhSvc`:**

| Agent state | Latency |
|---|---|
| Connected, idle or send completes | ≤ 1 s (socket closed by the stop handler) |
| Connected, send blocked on `SO_SNDTIMEO` | ≤ 1 s (socket close aborts the send) |
| Reconnecting / never connected (retry back-off) | ≤ 1 s (interruptible sleep) |
| Blocked in a `connect()` whose fd is not yet published | ≤ TCP connect timeout, then unwinds |

### Results and Evidence

The `Test MSI package` smoke-upgrade CI job does **not** exercise this fix: it never starts the agent service, so the shutdown path is never hit. The fix is instead validated by a new directed integration test (below).

CI on this branch: the `IT Windows - agentd (tier-0-1)` job — which starts, connects and stops the agent, and includes the new shutdown test — passes, together with the other agent-connection suites (enrollment, execd, github, office365) and `Test MSI package`.

### Artifacts Affected

- `wazuh-agent.exe` (Windows)

### Configuration Changes

N/A

### Tests Introduced

- `tests/integration/test_agentd/test_shutdown` (Windows-only): starts the agent against a `RemotedSimulator`, then measures that `wazuh-agent.exe` terminates within a grace period after `net stop WazuhSvc`, covering both the connected (`receiver_messages`) and never-connected (`start_agent`) code paths. It relies on `control_service('stop')` returning at `SERVICE_STOPPED` without waiting for the process, so a lingering agent is directly observable.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
