### PR TITLE
Run the Windows MSI package test on the AWS CodeBuild runner

### DIFF
--- a/.github/workflows/5_builderpackage_agent-windows.yml
+++ b/.github/workflows/5_builderpackage_agent-windows.yml
@@ -251,7 +251,7 @@ jobs:
 
   test-windows-i686:
     needs: package-windows-i686
-    runs-on: windows-2022
+    runs-on: codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
     name: Test MSI package
 


### PR DESCRIPTION
## Description

The `Test MSI package` job (`5.X - Build Wazuh agent Windows (MSI)`) fails on 5.0.0 in the *"Test uninstall and upgrade from 4.14.5 to 5.0.0"* step: the uninstall of the installed agent returns Windows Installer **1603** (masked by the old test as a later flaky `NET START`).

Root cause (full analysis in #37132): on `net stop`, the Windows agent's main thread stays blocked in a `recv` inside `receiver_messages()`, so `wazuh-agent.exe` lingers and keeps the installation files mapped; the MSI `RemoveFiles` then fails with 1603. This was made (near‑)deterministic on 5.0.0 by the incomplete Windows port of #36790 (keepalive/send-timeout are applied on Windows, but the dead-socket handling that unblocks the loop is `#ifndef WIN32`), and it only manifests on the current GitHub-hosted Windows runner image.

The uninstall succeeds on the **AWS CodeBuild Windows runner** (and on a clean Windows Server 2022 VM with the same MSI), so moving the test job to the CodeBuild runner unblocks CI. This is consistent with the agent-workflow CodeBuild migration (#37027).

This PR is the **CI fix** for #37132. The underlying agent shutdown regression (incomplete Windows port of #36790) is tracked separately as the real product fix.

Refs #37132

## Proposed Changes

- Change the `test-windows-i686` job runner from the GitHub-hosted Windows image to the AWS CodeBuild Windows runner:

  ```yaml
  test-windows-i686:
    needs: package-windows-i686
    runs-on: codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
  ```

### Results and Evidence

- Green `Test MSI package` run on the CodeBuild runner: https://github.com/wazuh/wazuh/actions/runs/28112839050
- Failing run on the GitHub-hosted runner (uninstall 1603 → flaky `NET START`): https://github.com/wazuh/wazuh/actions/runs/27988207508

### Artifacts Affected

None. CI-only change; the shipped agent, installer and package are unchanged.

### Configuration Changes

N/A.

### Documentation Updates

N/A.

### Tests Introduced

None. This restores the existing Windows MSI smoke-upgrade test to a passing state by running it on the CodeBuild runner.

> Note: this unblocks CI but does not fix the underlying agent bug (the agent lingers on service stop on the affected Windows builds, which can also affect real uninstall/upgrade scenarios). That is tracked as a separate issue/PR — completing the Windows port of #36790 and ensuring the agent process terminates cleanly on service stop.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [x] Tests cover the new functionality (N/A — CI runner change)
- [x] Configuration changes documented (N/A)
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues