### PR TITLE
Add parameterized target selection to Coverity scan workflow

### DIFF
--- a/.github/workflows/5_codeanalysis_coverity.yml
+++ b/.github/workflows/5_codeanalysis_coverity.yml
@@ -15,6 +15,14 @@ on:
         required: false
         default: 0
         type: number
+      target:
+        description: "Compilation target (manager or agent)"
+        required: true
+        type: choice
+        default: 'manager'
+        options:
+          - manager
+          - agent
       docker_image_tag:
         description: |
           Tag name of the Docker image to be uploaded.
@@ -76,7 +84,7 @@ jobs:
           ref: ${{ github.ref_name }}
 
       - name: Download dependencies
-        run: make -C src deps -j${{ needs.prepare.outputs.jobs }}
+        run: make -C src deps TARGET=${{ github.event.inputs.target }} -j${{ needs.prepare.outputs.jobs }}
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -95,7 +103,7 @@ jobs:
       - name: Build Coverity artifact
         uses: ./.github/actions/coverity/build
         with:
-          command: make -C src TARGET=manager COVERITY=YES -j${{ needs.prepare.outputs.jobs }}
+          command: make -C src TARGET=${{ github.event.inputs.target }} COVERITY=YES -j${{ needs.prepare.outputs.jobs }}
           docker_image_tag: ${{ github.event.inputs.docker_image_tag }}
 
       - name: List files


### PR DESCRIPTION
# Description

The Coverity workflow hardcoded `TARGET=manager` in both the dependency download and the build command, making it impossible to scan the agent target without manually editing the file. This change introduces a `target` dropdown input so any user can trigger a manager or agent scan from the GitHub Actions UI or CLI without touching the YAML. It also fixes a latent dependency bug: as of the current `main` branch, `make deps` only downloads agent-specific libraries (e.g., `libdb`) when `TARGET=agent` is passed — running it without a target silently skipped those deps, causing the agent build to fail inside the Coverity container. Resolves #36168.

## Proposed Changes

- **`.github/workflows/5_codeanalysis_coverity.yml`** — Added a `target` `workflow_dispatch` input of type `choice` with options `manager` and `agent` (default: `manager`) so the compilation target can be selected at trigger time without modifying the workflow file.
- **`.github/workflows/5_codeanalysis_coverity.yml`** — Threaded `TARGET=${{ github.event.inputs.target }}` into the `make -C src deps` step so that target-gated external dependencies (e.g., `libdb`, `popt`, `lua`, `rpm`, `dbus`) are downloaded correctly for the selected target before the build runs.
- **`.github/workflows/5_codeanalysis_coverity.yml`** — Replaced the hardcoded `TARGET=manager` in the `Build Coverity artifact` step's `make` command with `TARGET=${{ github.event.inputs.target }}`.

### Results and Evidence

<details><summary>Workflow triggered for agent target via GitHub CLI</summary>

```bash
gh workflow run 5_codeanalysis_coverity.yml \
  --ref enhancement/36168-add-agent-target-to-coverity \
  --field project=ossec-wazuh \
  --field target=agent \
  --field threads=0 \
  --field docker_image_tag=5.x
```

</details>

<details><summary>Successful workflow run — agent target (326 compilation units emitted)</summary>

Run: https://github.com/wazuh/wazuh/actions/runs/28131426975

```
Coverity Build Capture (64-bit) version 2024.12.1 on Linux 6.17.0-1018-azure x86_64

General settings:
    TARGET:             agent
    RESOURCES_URL:      https://packages.wazuh.com/deps/99-29585

Done building agent

Emitted 326 C/C++ compilation units (100%) successfully
326 C/C++ compilation units (100%) are ready for analysis
The cov-build utility completed successfully.
```

</details>

### Artifacts Affected

This change affects only the CI workflow — no runtime binaries, daemons, shared libraries, or configuration files are modified.

### Configuration Changes

_No configuration changes._

### Documentation Updates

_No documentation changes required._

### Tests Introduced

_No new tests introduced — this is a CI workflow change validated by a manual workflow run._

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
