### PR TITLE
Validate asset resource names before policy promotion

### DIFF
--- a/src/engine/source/base/include/base/name.hpp
+++ b/src/engine/source/base/include/base/name.hpp
@@ -1,10 +1,12 @@
 #ifndef _BASE_NAME_HPP
 #define _BASE_NAME_HPP
 
+#include <algorithm>
 #include <initializer_list>
 #include <iostream>
 #include <numeric>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <fmt/core.h>
@@ -38,12 +40,12 @@ private:
     std::vector<std::string> m_parts;
 
     /**
-     * @brief Validate the number of parts and ensure none are empty.
+     * @brief Validate the number and contents of the name parts.
      *
      * @param size Number of parts.
-     * @throws std::runtime_error If size is 0, exceeds MAX_PARTS, or any part is empty.
+     * @throws std::runtime_error If size is 0, exceeds MAX_PARTS, or any part is invalid.
      */
-    void assertSize(size_t size) const
+    void assertValid(size_t size) const
     {
         if (0 == size)
         {
@@ -54,12 +56,9 @@ private:
             throw std::runtime_error(fmt::format(
                 "Name size must have {} parts at most at most, but the one inserted has {}", MAX_PARTS, size));
         }
-        for (const auto& part : m_parts)
+        if (!std::all_of(m_parts.begin(), m_parts.end(), isValidPart))
         {
-            if (part.empty())
-            {
-                throw std::runtime_error(fmt::format("Name cannot have empty parts"));
-            }
+            throw std::runtime_error(fmt::format("Invalid resource name: '{}'", toStr()));
         }
     }
 
@@ -82,6 +81,22 @@ public:
     ~Name() = default;
 
     /**
+     * @brief Check whether a name part contains only supported characters.
+     *
+     * @param part Name part to validate.
+     * @return true if the part matches [a-zA-Z0-9_-]+.
+     */
+    static bool isValidPart(std::string_view part)
+    {
+        const auto isAllowedChar = [](const char c)
+        {
+            return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '-';
+        };
+
+        return !part.empty() && std::all_of(part.begin(), part.end(), isAllowedChar);
+    }
+
+    /**
      * @brief Construct a new Name object from a vector of parts.
      *
      * @param parts Parts of the name.
@@ -89,8 +104,8 @@ public:
      */
     Name(const std::vector<std::string>& parts)
     {
-        assertSize(parts.size());
         m_parts = parts;
+        assertValid(m_parts.size());
     }
 
     /**
@@ -102,7 +117,7 @@ public:
     Name(std::vector<std::string>&& parts)
     {
         m_parts = std::move(parts);
-        assertSize(m_parts.size());
+        assertValid(m_parts.size());
     }
 
     /**
@@ -114,7 +129,7 @@ public:
     Name(const std::string& fullName)
     {
         m_parts = base::utils::string::split(fullName, SEPARATOR_C);
-        assertSize(m_parts.size());
+        assertValid(m_parts.size());
     }
 
     /**

--- a/src/engine/source/base/test/src/unit/name_test.cpp
+++ b/src/engine/source/base/test/src/unit/name_test.cpp
@@ -30,6 +30,25 @@ TEST_F(NameTest, InitializationParts)
     ASSERT_EQ(name.parts()[2], "version");
 }
 
+TEST_F(NameTest, ValidPartCharacters)
+{
+    EXPECT_TRUE(base::Name::isValidPart("Resource-name_01"));
+}
+
+TEST_F(NameTest, InvalidPartCharacters)
+{
+    EXPECT_FALSE(base::Name::isValidPart(""));
+    EXPECT_FALSE(base::Name::isValidPart("resource name"));
+    EXPECT_FALSE(base::Name::isValidPart("resource/name"));
+    EXPECT_FALSE(base::Name::isValidPart("resource@name"));
+}
+
+TEST_F(NameTest, InitializationInvalidPart)
+{
+    EXPECT_THROW(base::Name({"type", "invalid name", "version"}), std::runtime_error);
+    EXPECT_THROW(base::Name("type/invalid name/version"), std::runtime_error);
+}
+
 TEST_F(NameTest, InitializationPartsMax)
 {
     ASSERT_THROW(base::Name({"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}), std::runtime_error);

--- a/src/engine/source/builder/test/src/component/validator_test.cpp
+++ b/src/engine/source/builder/test/src/component/validator_test.cpp
@@ -199,69 +199,60 @@ TEST_P(ValidateAsset, Doc)
     }
 }
 
-INSTANTIATE_TEST_SUITE_P(Asset,
-                         ValidateAsset,
-                         ::testing::Values(
-                             // Empty object
-                             ValidateA(json::Json(R"({})"),
-                                       false,
-                                       FAILURE(FailureExpected::Behaviour {[](const auto&, const auto&)
-                                                                           {
-                                                                               return "Document is empty";
-                                                                           }})),
-                             // Missing name
-                             ValidateA(json::Json(R"({"check": []})"),
-                                       false,
-                                       FAILURE(FailureExpected::Behaviour {[](const auto&, const auto&)
-                                                                           {
-                                                                               return "name";
-                                                                           }})),
-                             // Invalid name format
-                             ValidateA(json::Json(R"({"name": "decoder//"})"),
-                                       false,
-                                       FAILURE(FailureExpected::Behaviour {[](const auto&, const auto&)
-                                                                           {
-                                                                               return "Name cannot have empty parts";
-                                                                           }})),
-                             // Valid decoder (shallow)
-                             ValidateA(json::Json(R"({
+INSTANTIATE_TEST_SUITE_P(
+    Asset,
+    ValidateAsset,
+    ::testing::Values(
+        // Empty object
+        ValidateA(json::Json(R"({})"),
+                  false,
+                  FAILURE(FailureExpected::Behaviour {[](const auto&, const auto&) { return "Document is empty"; }})),
+        // Missing name
+        ValidateA(json::Json(R"({"check": []})"),
+                  false,
+                  FAILURE(FailureExpected::Behaviour {[](const auto&, const auto&) { return "name"; }})),
+        // Invalid name format
+        ValidateA(json::Json(R"({"name": "decoder//"})"),
+                  false,
+                  FAILURE(FailureExpected::Behaviour {[](const auto&, const auto&)
+                                                      { return "Invalid resource name"; }})),
+        // Valid decoder (shallow)
+        ValidateA(json::Json(R"({
                       "name": "decoder/test/0",
                       "parents": ["decoder/Input"],
                       "check": [{"event.code": 2}]
                   })"),
-                                       false,
-                                       SUCCESS(SuccessExpected::Behaviour {[](const auto&, const auto&)
-                                                                           {
-                                                                               return None {};
-                                                                           }})),
-                             // Decoder with missing parent (deep validation)
-                             ValidateA(json::Json(R"({
+                  false,
+                  SUCCESS(SuccessExpected::Behaviour {[](const auto&, const auto&) { return None {}; }})),
+        // Decoder with missing parent (deep validation)
+        ValidateA(json::Json(R"({
                       "name": "decoder/test/0",
                       "parents": ["decoder/missing/0"],
                       "check": [{"event.code": 2}]
                   })"),
-                                       true,
-                                       FAILURE(FailureExpected::Behaviour {
-                                           [](const auto& store, const auto& reader)
-                                           {
-                                               EXPECT_CALL(*reader, assetExistsByName(base::Name("decoder/missing/0")))
-                                                   .WillOnce(testing::Return(false));
-                                               return "Parent 'decoder/missing/0' referenced by asset";
-                                           }})),
-                             // Valid decoder with existing parent (deep validation)
-                             ValidateA(json::Json(R"({
+                  true,
+                  FAILURE(FailureExpected::Behaviour {[](const auto& store, const auto& reader)
+                                                      {
+                                                          EXPECT_CALL(
+                                                              *reader,
+                                                              assetExistsByName(base::Name("decoder/missing/0")))
+                                                              .WillOnce(testing::Return(false));
+                                                          return "Parent 'decoder/missing/0' referenced by asset";
+                                                      }})),
+        // Valid decoder with existing parent (deep validation)
+        ValidateA(json::Json(R"({
                       "name": "decoder/test/0",
                       "parents": ["decoder/Input"],
                       "check": [{"event.code": 2}]
                   })"),
-                                       true,
-                                       SUCCESS(SuccessExpected::Behaviour {
-                                           [](const auto& store, const auto& reader)
-                                           {
-                                               EXPECT_CALL(*reader, assetExistsByName(base::Name("decoder/Input")))
-                                                   .WillOnce(testing::Return(true));
-                                               return None {};
-                                           }}))));
+                  true,
+                  SUCCESS(SuccessExpected::Behaviour {[](const auto& store, const auto& reader)
+                                                      {
+                                                          EXPECT_CALL(*reader,
+                                                                      assetExistsByName(base::Name("decoder/Input")))
+                                                              .WillOnce(testing::Return(true));
+                                                          return None {};
+                                                      }}))));
 
 // Integration validation tests
 using ValidateI = std::tuple<dataType::Integration, Expc>;

--- a/src/engine/source/cmcrud/src/cmcrudservice.cpp
+++ b/src/engine/source/cmcrud/src/cmcrudservice.cpp
@@ -1,5 +1,7 @@
 #include <fmt/format.h>
 
+#include <algorithm>
+
 #include <base/logging.hpp>
 #include <cmstore/detail.hpp>
 #include <cmstore/types.hpp>
@@ -52,15 +54,66 @@ cm::store::dataType::KVDB kvdbFromDocument(const json::Json& kvdbDocument, bool 
     return cm::store::dataType::KVDB::fromJson(kvdbDocument, requireUUID);
 }
 
-base::Name assetNameFromJson(const json::Json& jsonDoc)
+std::string resourceNameStringFromJson(const json::Json& jsonDoc)
 {
     std::string name;
     if (jsonDoc.getString(name, "/name") != json::RetGet::Success || name.empty())
     {
         throw std::runtime_error("Missing or empty asset name at JSON path '/name'");
     }
+    return name;
+}
+
+bool isValidResourceNameComponent(std::string_view component)
+{
+    return !component.empty()
+           && std::all_of(component.begin(),
+                          component.end(),
+                          [](char c)
+                          {
+                              return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+                                     || c == '_' || c == '-';
+                          });
+}
+
+void validateSimpleResourceName(std::string_view name, cm::store::ResourceType type)
+{
+    if (!isValidResourceNameComponent(name))
+    {
+        throw std::runtime_error(
+            fmt::format("Invalid resource name: '{}' for resource '{}'", name, cm::store::resourceTypeToString(type)));
+    }
+}
+
+void validateAssetResourceName(std::string_view name, cm::store::ResourceType type)
+{
+    std::size_t start = 0;
+    while (true)
+    {
+        const auto end = name.find('/', start);
+        const auto part = name.substr(start, end == std::string_view::npos ? std::string_view::npos : end - start);
+
+        if (!isValidResourceNameComponent(part))
+        {
+            throw std::runtime_error(fmt::format(
+                "Invalid resource name: '{}' for resource '{}'", name, cm::store::resourceTypeToString(type)));
+        }
+
+        if (end == std::string_view::npos)
+        {
+            break;
+        }
+        start = end + 1;
+    }
+}
+
+base::Name validatedAssetNameFromJson(const json::Json& jsonDoc, cm::store::ResourceType type)
+{
+    const auto name = resourceNameStringFromJson(jsonDoc);
+    validateAssetResourceName(name, type);
     return base::Name {name};
 }
+
 } // namespace
 
 namespace cm::crud
@@ -250,6 +303,7 @@ cm::store::dataType::Policy CrudService::importNamespace(const cm::store::Namesp
                         case cm::store::ResourceType::INTEGRATION:
                         {
                             auto integ = cm::store::dataType::Integration::fromJson(item, /*requireUUID:*/ true);
+                            validateSimpleResourceName(integ.getName(), type);
                             if (!force)
                             {
                                 validateIntegration(nsReader, integ);
@@ -263,6 +317,7 @@ cm::store::dataType::Policy CrudService::importNamespace(const cm::store::Namesp
                         case cm::store::ResourceType::KVDB:
                         {
                             auto kvdb = cm::store::dataType::KVDB::fromJson(item, /*requireUUID:*/ true);
+                            validateSimpleResourceName(kvdb.getName(), type);
 
                             const std::string& name = kvdb.getName();
                             ns->createResource(name, type, kvdb.toJson());
@@ -284,7 +339,7 @@ cm::store::dataType::Policy CrudService::importNamespace(const cm::store::Namesp
                                 __builtin_unreachable();
                             }();
 
-                            auto name = assetNameFromJson(assetJson);
+                            auto name = validatedAssetNameFromJson(assetJson, type);
 
                             (void)assetUuidFromJson(assetJson, name);
 
@@ -372,13 +427,14 @@ void CrudService::importNamespace(const cm::store::NamespaceId& nsId,
     for (const auto& jkvdb : kvdbs)
     {
         auto kvdb = cm::store::dataType::KVDB::fromJson(jkvdb, true);
+        validateSimpleResourceName(kvdb.getName(), cm::store::ResourceType::KVDB);
         ns->createResource(kvdb.getName(), cm::store::ResourceType::KVDB, kvdb.toJson());
     }
 
     for (const auto& jdec : decoders)
     {
         auto assetJson = store::detail::adaptDecoder(jdec);
-        auto name = assetNameFromJson(assetJson);
+        auto name = validatedAssetNameFromJson(assetJson, cm::store::ResourceType::DECODER);
         const auto resourceStr = cm::store::resourceTypeToString(cm::store::ResourceType::DECODER);
 
         if (resourceStr != name.parts().front())
@@ -397,7 +453,7 @@ void CrudService::importNamespace(const cm::store::NamespaceId& nsId,
     for (const auto& jfilt : filters)
     {
         auto assetJson = store::detail::adaptFilter(jfilt);
-        auto name = assetNameFromJson(assetJson);
+        auto name = validatedAssetNameFromJson(assetJson, cm::store::ResourceType::FILTER);
         const auto resourceStr = cm::store::resourceTypeToString(cm::store::ResourceType::FILTER);
 
         if (resourceStr != name.parts().front())
@@ -416,6 +472,7 @@ void CrudService::importNamespace(const cm::store::NamespaceId& nsId,
     for (const auto& jinteg : integrations)
     {
         auto integ = cm::store::dataType::Integration::fromJson(jinteg, true);
+        validateSimpleResourceName(integ.getName(), cm::store::ResourceType::INTEGRATION);
         if (!softValidation)
         {
             validator->softIntegrationValidate(nsReader, integ);
@@ -604,7 +661,7 @@ void CrudService::upsertResource(const cm::store::NamespaceId& nsId,
                     __builtin_unreachable();
                 }();
 
-                auto name = assetNameFromJson(adaptedPayload);
+                auto name = validatedAssetNameFromJson(adaptedPayload, type);
                 const auto resource = resourceTypeToString(type);
 
                 if (resource != name.parts().front())
@@ -674,7 +731,7 @@ void CrudService::validateResource(cm::store::ResourceType type, const json::Jso
                     adaptedPayload = cm::store::detail::adaptFilter(payload);
                 }
 
-                auto name = assetNameFromJson(adaptedPayload);
+                auto name = validatedAssetNameFromJson(adaptedPayload, type);
 
                 (void)assetUuidFromJson(adaptedPayload, name);
 
@@ -693,13 +750,15 @@ void CrudService::validateResource(cm::store::ResourceType type, const json::Jso
 
             case cm::store::ResourceType::INTEGRATION:
             {
-                (void)cm::store::dataType::Integration::fromJson(payload, /*requireUUID:*/ true);
+                auto integration = cm::store::dataType::Integration::fromJson(payload, /*requireUUID:*/ true);
+                validateSimpleResourceName(integration.getName(), type);
                 return;
             }
 
             case cm::store::ResourceType::KVDB:
             {
-                (void)cm::store::dataType::KVDB::fromJson(payload, /*requireUUID:*/ true);
+                auto kvdb = cm::store::dataType::KVDB::fromJson(payload, /*requireUUID:*/ true);
+                validateSimpleResourceName(kvdb.getName(), type);
                 return;
             }
 

--- a/src/engine/source/cmcrud/src/cmcrudservice.cpp
+++ b/src/engine/source/cmcrud/src/cmcrudservice.cpp
@@ -1,8 +1,7 @@
 #include <fmt/format.h>
 
-#include <algorithm>
-
 #include <base/logging.hpp>
+#include <base/utils/stringUtils.hpp>
 #include <cmstore/detail.hpp>
 #include <cmstore/types.hpp>
 
@@ -54,63 +53,14 @@ cm::store::dataType::KVDB kvdbFromDocument(const json::Json& kvdbDocument, bool 
     return cm::store::dataType::KVDB::fromJson(kvdbDocument, requireUUID);
 }
 
-std::string resourceNameStringFromJson(const json::Json& jsonDoc)
+base::Name assetNameFromJson(const json::Json& jsonDoc)
 {
     std::string name;
     if (jsonDoc.getString(name, "/name") != json::RetGet::Success || name.empty())
     {
         throw std::runtime_error("Missing or empty asset name at JSON path '/name'");
     }
-    return name;
-}
 
-bool isValidResourceNameComponent(std::string_view component)
-{
-    return !component.empty()
-           && std::all_of(component.begin(),
-                          component.end(),
-                          [](char c)
-                          {
-                              return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
-                                     || c == '_' || c == '-';
-                          });
-}
-
-void validateSimpleResourceName(std::string_view name, cm::store::ResourceType type)
-{
-    if (!isValidResourceNameComponent(name))
-    {
-        throw std::runtime_error(
-            fmt::format("Invalid resource name: '{}' for resource '{}'", name, cm::store::resourceTypeToString(type)));
-    }
-}
-
-void validateAssetResourceName(std::string_view name, cm::store::ResourceType type)
-{
-    std::size_t start = 0;
-    while (true)
-    {
-        const auto end = name.find('/', start);
-        const auto part = name.substr(start, end == std::string_view::npos ? std::string_view::npos : end - start);
-
-        if (!isValidResourceNameComponent(part))
-        {
-            throw std::runtime_error(fmt::format(
-                "Invalid resource name: '{}' for resource '{}'", name, cm::store::resourceTypeToString(type)));
-        }
-
-        if (end == std::string_view::npos)
-        {
-            break;
-        }
-        start = end + 1;
-    }
-}
-
-base::Name validatedAssetNameFromJson(const json::Json& jsonDoc, cm::store::ResourceType type)
-{
-    const auto name = resourceNameStringFromJson(jsonDoc);
-    validateAssetResourceName(name, type);
     return base::Name {name};
 }
 
@@ -303,7 +253,12 @@ cm::store::dataType::Policy CrudService::importNamespace(const cm::store::Namesp
                         case cm::store::ResourceType::INTEGRATION:
                         {
                             auto integ = cm::store::dataType::Integration::fromJson(item, /*requireUUID:*/ true);
-                            validateSimpleResourceName(integ.getName(), type);
+                            if (!base::Name::isValidPart(integ.getName()))
+                            {
+                                throw std::runtime_error(fmt::format("Invalid resource name: '{}' for resource '{}'",
+                                                                     integ.getName(),
+                                                                     cm::store::resourceTypeToString(type)));
+                            }
                             if (!force)
                             {
                                 validateIntegration(nsReader, integ);
@@ -317,7 +272,12 @@ cm::store::dataType::Policy CrudService::importNamespace(const cm::store::Namesp
                         case cm::store::ResourceType::KVDB:
                         {
                             auto kvdb = cm::store::dataType::KVDB::fromJson(item, /*requireUUID:*/ true);
-                            validateSimpleResourceName(kvdb.getName(), type);
+                            if (!base::Name::isValidPart(kvdb.getName()))
+                            {
+                                throw std::runtime_error(fmt::format("Invalid resource name: '{}' for resource '{}'",
+                                                                     kvdb.getName(),
+                                                                     cm::store::resourceTypeToString(type)));
+                            }
 
                             const std::string& name = kvdb.getName();
                             ns->createResource(name, type, kvdb.toJson());
@@ -339,7 +299,7 @@ cm::store::dataType::Policy CrudService::importNamespace(const cm::store::Namesp
                                 __builtin_unreachable();
                             }();
 
-                            auto name = validatedAssetNameFromJson(assetJson, type);
+                            auto name = assetNameFromJson(assetJson);
 
                             (void)assetUuidFromJson(assetJson, name);
 
@@ -427,14 +387,19 @@ void CrudService::importNamespace(const cm::store::NamespaceId& nsId,
     for (const auto& jkvdb : kvdbs)
     {
         auto kvdb = cm::store::dataType::KVDB::fromJson(jkvdb, true);
-        validateSimpleResourceName(kvdb.getName(), cm::store::ResourceType::KVDB);
+        if (!base::Name::isValidPart(kvdb.getName()))
+        {
+            throw std::runtime_error(fmt::format("Invalid resource name: '{}' for resource '{}'",
+                                                 kvdb.getName(),
+                                                 cm::store::resourceTypeToString(cm::store::ResourceType::KVDB)));
+        }
         ns->createResource(kvdb.getName(), cm::store::ResourceType::KVDB, kvdb.toJson());
     }
 
     for (const auto& jdec : decoders)
     {
         auto assetJson = store::detail::adaptDecoder(jdec);
-        auto name = validatedAssetNameFromJson(assetJson, cm::store::ResourceType::DECODER);
+        auto name = assetNameFromJson(assetJson);
         const auto resourceStr = cm::store::resourceTypeToString(cm::store::ResourceType::DECODER);
 
         if (resourceStr != name.parts().front())
@@ -453,7 +418,7 @@ void CrudService::importNamespace(const cm::store::NamespaceId& nsId,
     for (const auto& jfilt : filters)
     {
         auto assetJson = store::detail::adaptFilter(jfilt);
-        auto name = validatedAssetNameFromJson(assetJson, cm::store::ResourceType::FILTER);
+        auto name = assetNameFromJson(assetJson);
         const auto resourceStr = cm::store::resourceTypeToString(cm::store::ResourceType::FILTER);
 
         if (resourceStr != name.parts().front())
@@ -472,7 +437,13 @@ void CrudService::importNamespace(const cm::store::NamespaceId& nsId,
     for (const auto& jinteg : integrations)
     {
         auto integ = cm::store::dataType::Integration::fromJson(jinteg, true);
-        validateSimpleResourceName(integ.getName(), cm::store::ResourceType::INTEGRATION);
+        if (!base::Name::isValidPart(integ.getName()))
+        {
+            throw std::runtime_error(
+                fmt::format("Invalid resource name: '{}' for resource '{}'",
+                            integ.getName(),
+                            cm::store::resourceTypeToString(cm::store::ResourceType::INTEGRATION)));
+        }
         if (!softValidation)
         {
             validator->softIntegrationValidate(nsReader, integ);
@@ -661,7 +632,7 @@ void CrudService::upsertResource(const cm::store::NamespaceId& nsId,
                     __builtin_unreachable();
                 }();
 
-                auto name = validatedAssetNameFromJson(adaptedPayload, type);
+                auto name = assetNameFromJson(adaptedPayload);
                 const auto resource = resourceTypeToString(type);
 
                 if (resource != name.parts().front())
@@ -731,7 +702,7 @@ void CrudService::validateResource(cm::store::ResourceType type, const json::Jso
                     adaptedPayload = cm::store::detail::adaptFilter(payload);
                 }
 
-                auto name = validatedAssetNameFromJson(adaptedPayload, type);
+                auto name = assetNameFromJson(adaptedPayload);
 
                 (void)assetUuidFromJson(adaptedPayload, name);
 
@@ -751,14 +722,24 @@ void CrudService::validateResource(cm::store::ResourceType type, const json::Jso
             case cm::store::ResourceType::INTEGRATION:
             {
                 auto integration = cm::store::dataType::Integration::fromJson(payload, /*requireUUID:*/ true);
-                validateSimpleResourceName(integration.getName(), type);
+                if (!base::Name::isValidPart(integration.getName()))
+                {
+                    throw std::runtime_error(fmt::format("Invalid resource name: '{}' for resource '{}'",
+                                                         integration.getName(),
+                                                         cm::store::resourceTypeToString(type)));
+                }
                 return;
             }
 
             case cm::store::ResourceType::KVDB:
             {
                 auto kvdb = cm::store::dataType::KVDB::fromJson(payload, /*requireUUID:*/ true);
-                validateSimpleResourceName(kvdb.getName(), type);
+                if (!base::Name::isValidPart(kvdb.getName()))
+                {
+                    throw std::runtime_error(fmt::format("Invalid resource name: '{}' for resource '{}'",
+                                                         kvdb.getName(),
+                                                         cm::store::resourceTypeToString(type)));
+                }
                 return;
             }
 

--- a/src/engine/source/cmcrud/test/src/unit/cmcrudservice_test.cpp
+++ b/src/engine/source/cmcrud/test/src/unit/cmcrudservice_test.cpp
@@ -844,17 +844,43 @@ TEST_F(CrudServiceValidateResourceTest, ValidateResource_Decoder_CallsValidateAs
 {
     static constexpr const char* kDecoderJsonStr = R"(
     {
-      "name": "decoder/syslog/0",
+      "name": "decoder/my-decoder/0",
       "id": "3f086ce2-32a4-42b0-be7e-40dcfb9c6160",
       "enabled": true,
       "metadata": { "module": "syslog" }
     })";
 
     json::Json payload {kDecoderJsonStr};
-    payload = cm::store::detail::adaptDecoder(payload);
     EXPECT_CALL(*validator, validateAssetShallow(_)).Times(1).WillOnce(Return(base::noError()));
 
     EXPECT_NO_THROW(service->validateResource(ResourceType::DECODER, payload));
+}
+
+TEST_F(CrudServiceValidateResourceTest, ValidateResource_Decoder_InvalidNameThrowsBeforeValidation)
+{
+    static constexpr const char* kDecoderJsonStr = R"(
+    {
+      "name": "decoder/my decoder/0",
+      "id": "3f086ce2-32a4-42b0-be7e-40dcfb9c6160",
+      "enabled": true,
+      "metadata": { "module": "syslog" }
+    })";
+
+    json::Json payload {kDecoderJsonStr};
+
+    EXPECT_CALL(*validator, validateAssetShallow(_)).Times(0);
+
+    try
+    {
+        service->validateResource(ResourceType::DECODER, payload);
+        FAIL() << "Expected std::runtime_error";
+    }
+    catch (const std::runtime_error& e)
+    {
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("Invalid resource name"));
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("decoder/my decoder/0"));
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("decoder"));
+    }
 }
 
 TEST_F(CrudServiceValidateResourceTest, ValidateResource_Decoder_ValidationFailureThrows)
@@ -868,7 +894,6 @@ TEST_F(CrudServiceValidateResourceTest, ValidateResource_Decoder_ValidationFailu
     })";
 
     json::Json payload {kDecoderJsonStr};
-    payload = cm::store::detail::adaptDecoder(payload);
     EXPECT_CALL(*validator, validateAssetShallow(_)).Times(1).WillOnce(Return(base::Error {"bad asset"}));
 
     try
@@ -882,13 +907,42 @@ TEST_F(CrudServiceValidateResourceTest, ValidateResource_Decoder_ValidationFailu
     }
 }
 
+TEST_F(CrudServiceValidateResourceTest, ValidateResource_Filter_InvalidNameThrowsBeforeValidation)
+{
+    static constexpr const char* kFilterJsonStr = R"(
+    {
+      "name": "filter/bad filter/0",
+      "id": "f1111111-1111-4111-a111-111111111111",
+      "enabled": true,
+      "type": "pre-filter",
+      "metadata": { "title": "Test Pre-Filter" },
+      "check": "$host.os.platform == 'ubuntu'"
+    })";
+
+    json::Json payload {kFilterJsonStr};
+
+    EXPECT_CALL(*validator, validateAssetShallow(_)).Times(0);
+
+    try
+    {
+        service->validateResource(ResourceType::FILTER, payload);
+        FAIL() << "Expected std::runtime_error";
+    }
+    catch (const std::runtime_error& e)
+    {
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("Invalid resource name"));
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("filter/bad filter/0"));
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("filter"));
+    }
+}
+
 TEST_F(CrudServiceValidateResourceTest, ValidateResource_Integration_SuccessDoesNotTouchValidator)
 {
     static constexpr const char* kIntegrationJsonStr = R"(
     {
       "id": "5c1df6b6-1458-4b2e-9001-96f67a8b12c8",
       "metadata": {
-        "title": "windows"
+        "title": "windows-security"
       },
       "enabled": true,
       "category": "security",
@@ -909,13 +963,45 @@ TEST_F(CrudServiceValidateResourceTest, ValidateResource_Integration_SuccessDoes
     EXPECT_NO_THROW(service->validateResource(ResourceType::INTEGRATION, payload));
 }
 
+TEST_F(CrudServiceValidateResourceTest, ValidateResource_Integration_InvalidNameThrows)
+{
+    static constexpr const char* kIntegrationJsonStr = R"(
+    {
+      "id": "5c1df6b6-1458-4b2e-9001-96f67a8b12c8",
+      "metadata": {
+        "title": "bad integration"
+      },
+      "enabled": true,
+      "category": "security",
+      "default_parent": "3f086ce2-32a4-42b0-be7e-40dcfb9c6160",
+      "decoders": [
+        "85853f26-5779-469b-86c4-c47ee7d400b4"
+      ],
+      "kvdbs": []
+    })";
+
+    json::Json payload {kIntegrationJsonStr};
+
+    try
+    {
+        service->validateResource(ResourceType::INTEGRATION, payload);
+        FAIL() << "Expected std::runtime_error";
+    }
+    catch (const std::runtime_error& e)
+    {
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("Invalid resource name"));
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("bad integration"));
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("integration"));
+    }
+}
+
 TEST_F(CrudServiceValidateResourceTest, ValidateResource_KVDB_SuccessDoesNotTouchValidator)
 {
     static constexpr const char* kKvdbJsonStr = R"(
     {
       "id": "82e215c4-988a-4f64-8d15-b98b2fc03a4f",
       "metadata": {
-        "title": "windows_kerberos_status_code_to_code_name"
+        "title": "windows-kerberos_status_code_to_code_name"
       },
       "content": {
         "0x0": "KDC_ERR_NONE",
@@ -929,6 +1015,35 @@ TEST_F(CrudServiceValidateResourceTest, ValidateResource_KVDB_SuccessDoesNotTouc
     EXPECT_CALL(*validator, validateAssetShallow(_)).Times(0);
 
     EXPECT_NO_THROW(service->validateResource(ResourceType::KVDB, payload));
+}
+
+TEST_F(CrudServiceValidateResourceTest, ValidateResource_KVDB_InvalidNameThrows)
+{
+    static constexpr const char* kKvdbJsonStr = R"(
+    {
+      "id": "82e215c4-988a-4f64-8d15-b98b2fc03a4f",
+      "metadata": {
+        "title": "bad/kvdb"
+      },
+      "content": {
+        "0x0": "KDC_ERR_NONE"
+      },
+      "enabled": true
+    })";
+
+    json::Json payload {kKvdbJsonStr};
+
+    try
+    {
+        service->validateResource(ResourceType::KVDB, payload);
+        FAIL() << "Expected std::runtime_error";
+    }
+    catch (const std::runtime_error& e)
+    {
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("Invalid resource name"));
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("bad/kvdb"));
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("kvdb"));
+    }
 }
 
 // ---------------------------------------------------------------------
@@ -1249,6 +1364,59 @@ TEST_F(CrudServiceImportNsFromVectorTest, ImportsIntegration)
 
     EXPECT_NO_THROW(service->importNamespace(
         nsId, {}, {}, {}, integrations, makeJsonPayload(kPolicyJson), /*softValidation=*/true));
+}
+
+TEST_F(CrudServiceImportNsFromVectorTest, InvalidDecoderNameThrowsBeforeCreate)
+{
+    static constexpr const char* kDecoderJsonInvalidName = R"({
+      "name": "decoder/my decoder/0",
+      "id": "3f086ce2-32a4-42b0-be7e-40dcfb9c6160",
+      "enabled": true,
+      "metadata": {"module": "syslog", "title": "Syslog Decoder"}
+    })";
+
+    std::vector<json::Json> decoders = {makeJsonPayload(kDecoderJsonInvalidName)};
+
+    EXPECT_CALL(*nsPtr, createResource(_, _, _)).Times(0);
+
+    try
+    {
+        service->importNamespace(nsId, {}, decoders, {}, {}, makeJsonPayload(kPolicyJson), /*softValidation=*/true);
+        FAIL() << "Expected std::runtime_error";
+    }
+    catch (const std::runtime_error& e)
+    {
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("Invalid resource name"));
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("decoder/my decoder/0"));
+    }
+}
+
+TEST_F(CrudServiceImportNsFromVectorTest, InvalidIntegrationNameThrowsBeforeCreate)
+{
+    static constexpr const char* kIntegrationJsonInvalidName = R"({
+      "id": "5c1df6b6-1458-4b2e-9001-96f67a8b12c8",
+      "metadata": {"title": "bad/integration"},
+      "enabled": true,
+      "category": "security",
+      "default_parent": "3f086ce2-32a4-42b0-be7e-40dcfb9c6160",
+      "decoders": [],
+      "kvdbs": []
+    })";
+
+    std::vector<json::Json> integrations = {makeJsonPayload(kIntegrationJsonInvalidName)};
+
+    EXPECT_CALL(*nsPtr, createResource(_, _, _)).Times(0);
+
+    try
+    {
+        service->importNamespace(nsId, {}, {}, {}, integrations, makeJsonPayload(kPolicyJson), /*softValidation=*/true);
+        FAIL() << "Expected std::runtime_error";
+    }
+    catch (const std::runtime_error& e)
+    {
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("Invalid resource name"));
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("bad/integration"));
+    }
 }
 
 // Policy is upserted after all resources
@@ -1766,6 +1934,165 @@ TEST_F(CrudServiceImportNsFromDocTest, ImportsIntegration)
     EXPECT_CALL(*nsPtr, createResource("windows", ResourceType::INTEGRATION, _)).Times(1);
 
     EXPECT_NO_THROW(service->importNamespace(nsId, kImportDocWithIntegration, "", /*force=*/true));
+}
+
+TEST_F(CrudServiceImportNsFromDocTest, InvalidKVDBNameThrowsBeforeCreate)
+{
+    static constexpr const char* kImportDocWithInvalidKVDB = R"({
+      "policy": {
+        "enabled": true,
+        "root_decoder": "decoder/wazuh-core-message/0",
+        "integrations": [],
+        "filters": [],
+        "enrichments": [],
+        "index_unclassified_events": false,
+        "index_discarded_events": false
+      },
+      "resources": {
+        "kvdbs": [
+          {
+            "id": "82e215c4-988a-4f64-8d15-b98b2fc03a4f",
+            "metadata": {"title": "bad kvdb"},
+            "content": {"0x0": "KDC_ERR_NONE"},
+            "enabled": true
+          }
+        ]
+      }
+    })";
+
+    EXPECT_CALL(*nsPtr, createResource(_, _, _)).Times(0);
+
+    try
+    {
+        service->importNamespace(nsId, kImportDocWithInvalidKVDB, "", /*force=*/true);
+        FAIL() << "Expected std::runtime_error";
+    }
+    catch (const std::runtime_error& e)
+    {
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("Failed to import namespace"));
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("Invalid resource name"));
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("bad kvdb"));
+    }
+}
+
+TEST_F(CrudServiceImportNsFromDocTest, InvalidDecoderNameThrowsBeforeCreate)
+{
+    static constexpr const char* kImportDocWithInvalidDecoder = R"({
+      "policy": {
+        "enabled": true,
+        "root_decoder": "decoder/wazuh-core-message/0",
+        "integrations": [],
+        "filters": [],
+        "enrichments": [],
+        "index_unclassified_events": false,
+        "index_discarded_events": false
+      },
+      "resources": {
+        "decoders": [
+          {
+            "name": "decoder/my:decoder/0",
+            "id": "3f086ce2-32a4-42b0-be7e-40dcfb9c6160",
+            "enabled": true,
+            "metadata": {"module": "syslog", "title": "Syslog Decoder"}
+          }
+        ]
+      }
+    })";
+
+    EXPECT_CALL(*nsPtr, createResource(_, _, _)).Times(0);
+
+    try
+    {
+        service->importNamespace(nsId, kImportDocWithInvalidDecoder, "", /*force=*/true);
+        FAIL() << "Expected std::runtime_error";
+    }
+    catch (const std::runtime_error& e)
+    {
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("Failed to import namespace"));
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("Invalid resource name"));
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("decoder/my:decoder/0"));
+    }
+}
+
+TEST_F(CrudServiceImportNsFromDocTest, InvalidIntegrationNameThrowsBeforeCreate)
+{
+    static constexpr const char* kImportDocWithInvalidIntegration = R"({
+      "policy": {
+        "enabled": true,
+        "root_decoder": "decoder/wazuh-core-message/0",
+        "integrations": [],
+        "filters": [],
+        "enrichments": [],
+        "index_unclassified_events": false,
+        "index_discarded_events": false
+      },
+      "resources": {
+        "integrations": [
+          {
+            "id": "5c1df6b6-1458-4b2e-9001-96f67a8b12c8",
+            "metadata": {"title": "bad@integration"},
+            "enabled": true,
+            "category": "security",
+            "default_parent": "3f086ce2-32a4-42b0-be7e-40dcfb9c6160",
+            "decoders": [],
+            "kvdbs": []
+          }
+        ]
+      }
+    })";
+
+    EXPECT_CALL(*nsPtr, createResource(_, _, _)).Times(0);
+
+    try
+    {
+        service->importNamespace(nsId, kImportDocWithInvalidIntegration, "", /*force=*/true);
+        FAIL() << "Expected std::runtime_error";
+    }
+    catch (const std::runtime_error& e)
+    {
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("Failed to import namespace"));
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("Invalid resource name"));
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("bad@integration"));
+    }
+}
+
+TEST_F(CrudServiceImportNsFromDocTest, InvalidOutputNameThrowsBeforeCreate)
+{
+    static constexpr const char* kImportDocWithInvalidOutput = R"({
+      "policy": {
+        "enabled": true,
+        "root_decoder": "decoder/wazuh-core-message/0",
+        "integrations": [],
+        "filters": [],
+        "enrichments": [],
+        "index_unclassified_events": false,
+        "index_discarded_events": false
+      },
+      "resources": {
+        "outputs": [
+          {
+            "name": "output/bad output/0",
+            "id": "b1111111-1111-4111-a111-111111111111",
+            "enabled": true,
+            "metadata": {"title": "Indexer Output"}
+          }
+        ]
+      }
+    })";
+
+    EXPECT_CALL(*nsPtr, createResource(_, _, _)).Times(0);
+
+    try
+    {
+        service->importNamespace(nsId, kImportDocWithInvalidOutput, "", /*force=*/true);
+        FAIL() << "Expected std::runtime_error";
+    }
+    catch (const std::runtime_error& e)
+    {
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("Failed to import namespace"));
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("Invalid resource name"));
+        EXPECT_THAT(std::string {e.what()}, HasSubstr("output/bad output/0"));
+    }
 }
 
 // Policy is upserted after resources

--- a/src/engine/source/store/test/src/unit/fileDriver_test.cpp
+++ b/src/engine/source/store/test/src/unit/fileDriver_test.cpp
@@ -118,11 +118,11 @@ TEST_F(FileDriverTest, AddMultipleVersions)
     FileDriver fDriver(m_path);
     base::OptError error;
 
-    base::Name name1({TEST_NAME.parts()[0], TEST_NAME.parts()[1], "1.0.0"});
+    base::Name name1({TEST_NAME.parts()[0], TEST_NAME.parts()[1], "1_0_0"});
     ASSERT_NO_THROW(error = fDriver.createDoc(name1, TEST_JSON));
     ASSERT_FALSE(error);
 
-    base::Name name2({TEST_NAME.parts()[0], TEST_NAME.parts()[1], "2.0.0"});
+    base::Name name2({TEST_NAME.parts()[0], TEST_NAME.parts()[1], "2_0_0"});
     ASSERT_NO_THROW(error = fDriver.createDoc(name2, TEST_JSON));
     ASSERT_FALSE(error);
 


### PR DESCRIPTION
## Description

This PR fixes a validation gap in `wazuh-engine` where resource names with unsupported characters could pass the validate-only path, but later fail during policy promotion when CM::Store attempted to create the corresponding resource files.

The validation now rejects invalid decoder, integration, and KVDB resource names earlier, before the assets are stored or promoted.

Closes #37053 

## Proposed changes

- Add resource name validation for decoder, integration, and KVDB validation flows.
- Enforce `[a-zA-Z0-9_-]+` for each resource name component.
- Reject resource names containing spaces, path separators in simple names, or unsupported characters.
- Return a clear validation error with the invalid resource name and resource type.
- Add unit tests for valid and invalid decoder, integration, and KVDB names.


## Results and Evidence

**Indexer build to test:**  https://github.com/wazuh/wazuh-indexer/actions/runs/28185253867

### Build &/ install

```bash

General settings:
    TARGET:             manager
    V:                  
    DEBUG:              yes
    INSTALLDIR:         
    RESOURCES_URL:      https://packages.wazuh.com/deps/99-29734
    EXTERNAL_SRC_ONLY:  
    HTTP_REQUEST_BRANCH:ebf9d2f82533ff2f84c3304ab29db01fcfb6735e
User settings:
    WAZUH_GROUP:        wazuh-manager
    WAZUH_USER:         wazuh-manager
USE settings:
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          no
    IMAGE_TRUST_CHECKS: 1
    CA_NAME:            DigiCert Assured ID Root CA
Compiler:
    CC                cc
    MAKE              /usr/bin/make
make[1]: Leaving directory '/workspaces/Wazuh_5x/wazuh/src'

Done building manager


(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/37053-resource-name-validation●› 
╰─# ctest --test-dir src/build --output-on-failure

100% tests passed, 0 tests failed out of 9775

Total Test time (real) = 646.90 sec

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/37053-resource-name-validation●› 
╰─# service wazuh-manager status                                                                                                       1 ↵
wazuh-manager-clusterd is running...
wazuh-manager-modulesd is running...
wazuh-manager-monitord is running...
wazuh-manager-remoted is running...
wazuh-manager-analysisd is running...
wazuh-manager-db is running...
wazuh-manager-authd is running...
wazuh-manager-apid is running...

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/37053-resource-name-validation●› 
╰─# engine-private ns list
engine-router list

- cmsync_standard_93e2

source /workspaces/Wazuh_5x/venv/bin/activate
- entry_status: ENABLED
  name: cmsync_standard
  namespaceId: cmsync_standard_93e2
  priority: 1
  uptime: 165


```

```console

2026/06/25 20:34:22 wazuh-manager-analysisd: INFO: Content Manager Sync Service initialized.
2026/06/25 20:34:22 wazuh-manager-analysisd: INFO: IOC Sync Service initialized.
2026/06/25 20:34:22 wazuh-manager-analysisd: INFO: Dumper Events initialized.
2026/06/25 20:34:22 wazuh-manager-analysisd: INFO: Remote engine's server initialized and started.
2026/06/25 20:34:22 wazuh-manager-analysisd: INFO: Engine started.
2026/06/25 20:34:33 wazuh-manager-monitord: INFO: wazuh: Manager started.

```

### Testing


```bash

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/37053-resource-name-validation●› 
╰─# engine-public cm validate decoder <<'EOF'
{
  "name": "decoder/my decoder/0",
  "id": "3f086ce2-32a4-42b0-be7e-40dcfb9c6160",
  "enabled": true,
  "metadata": { "module": "syslog" }
}
EOF
Error validating resource: Failed to validate resource of type 'decoder': Invalid resource name: 'decoder/my decoder/0' for resource 'decoder'

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/37053-resource-name-validation●› 
╰─# engine-public cm validate decoder <<'EOF'                                                                                          1 ↵
{
  "name": "decoder/my-decoder_02/0",
  "id": "3f086ce2-32a4-42b0-be7e-40dcfb9c6160",
  "enabled": true,
  "metadata": { "module": "syslog" }
}
EOF

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/37053-resource-name-validation●› 
╰─# engine-public cm validate integration <<'EOF'
{
  "id": "5c1df6b6-1458-4b2e-9001-96f67a8b12c8",
  "metadata": { "title": "bad integration" },
  "enabled": true,
  "category": "security",
  "default_parent": "3f086ce2-32a4-42b0-be7e-40dcfb9c6160",
  "decoders": ["85853f26-5779-469b-86c4-c47ee7d400b4"],
  "kvdbs": []
}
EOF
Error validating resource: Failed to validate resource of type 'integration': Invalid resource name: 'bad integration' for resource 'integration'


(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/37053-resource-name-validation●› 
╰─# engine-public cm validate integration <<'EOF'
{
  "id": "5c1df6b6-1458-4b2e-9001-96f67a8b12c8",
  "metadata": { "title": "good-integration_01" },
  "enabled": true,
  "category": "security",
  "default_parent": "3f086ce2-32a4-42b0-be7e-40dcfb9c6160",
  "decoders": ["85853f26-5779-469b-86c4-c47ee7d400b4"],
  "kvdbs": []
}
EOF


(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/37053-resource-name-validation●› 
╰─# engine-public cm validate kvdb <<'EOF'
{
  "id": "82e215c4-988a-4f64-8d15-b98b2fc03a4f",
  "metadata": { "title": "bad kvdb" },
  "content": { "key1": "val1" },
  "enabled": true
}
EOF
Error validating resource: Failed to validate resource of type 'kvdb': Invalid resource name: 'bad kvdb' for resource 'kvdb'



(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/37053-resource-name-validation●› 
╰─# engine-public cm validate kvdb <<'EOF'
{
  "id": "82e215c4-988a-4f64-8d15-b98b2fc03a4f",
  "metadata": { "title": "good-kvdb_01" },
  "content": { "key1": "val1" },
  "enabled": true
}
EOF

```

### Dashboard

**Invalid Decoder**

```yaml

name: decoder/my decoder/0
enabled: true
metadata:
  title: Placeholder Decoder
  description: This is a placeholder decoder. Please update the fields accordingly.
  author: User
  references: []
  documentation: ''
  supports: []

```
<img width="1835" height="886" alt="Captura desde 2026-06-25 13-35-23" src="https://github.com/user-attachments/assets/eeb9ea6a-6a1d-4d66-8a03-be0ac33bd608" />

**Valid Decoder**

```yaml

name: decoder/my-decoder_01/0
enabled: true
metadata:
  title: Placeholder Decoder
  description: This is a placeholder decoder. Please update the fields accordingly.
  author: User
  references: []
  documentation: ''
  supports: []

```
<img width="1835" height="886" alt="Captura desde 2026-06-25 13-44-49" src="https://github.com/user-attachments/assets/a99177a8-022d-4e39-b00c-e47ba3316af6" />

<img width="1835" height="886" alt="Captura desde 2026-06-25 13-45-59" src="https://github.com/user-attachments/assets/d60a1aee-e6d7-4d44-a45c-d49d042e0697" />

<img width="1819" height="893" alt="Captura desde 2026-07-01 10-04-27" src="https://github.com/user-attachments/assets/22542deb-0e8c-49b4-8924-9144e017de52" />


<img width="1852" height="963" alt="Captura desde 2026-06-25 15-04-55" src="https://github.com/user-attachments/assets/7aefcf23-bd12-41c6-9c8a-c8777dcf5c8d" />

