### PR TITLE
Delay IndexerDownloader connection warnings until 3 failed attempts

### DIFF
--- a/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
@@ -72,6 +72,10 @@ private:
 
     static constexpr std::chrono::seconds INDEXER_RETRY_INTERVAL {30};
 
+    /// Failed initial-load attempts logged below WARNING before escalating (indexer is commonly
+    /// overloaded right after a restart, so early failures are expected).
+    static constexpr std::size_t INDEXER_WARN_AFTER_ATTEMPTS {3};
+
     nlohmann::json m_config;
     mutable std::mutex m_callbackMutex; ///< Serializes processPage calls across parallel slices.
 
@@ -447,9 +451,13 @@ private:
      * @param context   Updater context.
      * @param query     Elasticsearch query object (match_all or range).
      * @param startCursor  Starting cursor value (empty for initial load, lastCursor for incremental).
+     * @param escalateLogs  If false, transient failures are logged at DEBUG instead of WARNING.
      * @return Number of documents processed.
      */
-    size_t fetchWithPit(UpdaterContext& context, const nlohmann::json& query, const std::string& startCursor) const
+    size_t fetchWithPit(UpdaterContext& context,
+                        const nlohmann::json& query,
+                        const std::string& startCursor,
+                        const bool escalateLogs = true) const
     {
         static constexpr std::string_view PIT_KEEP_ALIVE {"5m"};
 
@@ -466,7 +474,7 @@ private:
         auto pit = syncConnector.createPointInTime({indexName}, PIT_KEEP_ALIVE);
         auto pitGuard = std::unique_ptr<PointInTime, std::function<void(PointInTime*)>>(
             &pit,
-            [&syncConnector](auto* p)
+            [&syncConnector, escalateLogs](auto* p)
             {
                 try
                 {
@@ -474,7 +482,14 @@ private:
                 }
                 catch (const std::exception& e)
                 {
-                    logWarn(WM_CONTENTUPDATER, "IndexerDownloader: Failed to delete PIT: %s", e.what());
+                    if (escalateLogs)
+                    {
+                        logWarn(WM_CONTENTUPDATER, "IndexerDownloader: Failed to delete PIT: %s", e.what());
+                    }
+                    else
+                    {
+                        logDebug2(WM_CONTENTUPDATER, "IndexerDownloader: Failed to delete PIT: %s", e.what());
+                    }
                 }
             });
 
@@ -533,12 +548,14 @@ private:
      * @param query      Elasticsearch query object.
      * @param startCursor Starting cursor value.
      * @param numSlices  Number of parallel slices.
+     * @param escalateLogs  If false, transient failures are logged at DEBUG instead of ERROR/WARNING.
      * @return Total number of documents processed across all slices.
      */
     size_t fetchWithSlicedPit(UpdaterContext& context,
                               const nlohmann::json& query,
                               const std::string& startCursor,
-                              size_t numSlices) const
+                              size_t numSlices,
+                              const bool escalateLogs = true) const
     {
         static constexpr std::string_view PIT_KEEP_ALIVE {"5m"};
 
@@ -555,7 +572,7 @@ private:
         auto pit = syncConnector.createPointInTime({indexName}, PIT_KEEP_ALIVE);
         auto pitGuard = std::unique_ptr<PointInTime, std::function<void(PointInTime*)>>(
             &pit,
-            [&syncConnector](auto* p)
+            [&syncConnector, escalateLogs](auto* p)
             {
                 try
                 {
@@ -563,7 +580,14 @@ private:
                 }
                 catch (const std::exception& e)
                 {
-                    logWarn(WM_CONTENTUPDATER, "IndexerDownloader: Failed to delete PIT: %s", e.what());
+                    if (escalateLogs)
+                    {
+                        logWarn(WM_CONTENTUPDATER, "IndexerDownloader: Failed to delete PIT: %s", e.what());
+                    }
+                    else
+                    {
+                        logDebug2(WM_CONTENTUPDATER, "IndexerDownloader: Failed to delete PIT: %s", e.what());
+                    }
                 }
             });
 
@@ -670,7 +694,14 @@ private:
             {
                 std::lock_guard<std::mutex> lock(errorsMutex);
                 errors.push_back("Slice " + std::to_string(sliceId) + ": " + e.what());
-                logError(WM_CONTENTUPDATER, "IndexerDownloader: Slice %zu failed: %s", sliceId, e.what());
+                if (escalateLogs)
+                {
+                    logError(WM_CONTENTUPDATER, "IndexerDownloader: Slice %zu failed: %s", sliceId, e.what());
+                }
+                else
+                {
+                    logDebug2(WM_CONTENTUPDATER, "IndexerDownloader: Slice %zu failed: %s", sliceId, e.what());
+                }
             }
         };
 
@@ -724,6 +755,9 @@ private:
                     WM_CONTENTUPDATER, "IndexerDownloader: Retrying initial full load (attempt %zu) ...", attempt + 1);
             }
 
+            // Stay at INFO/DEBUG for the first attempts, escalate to WARNING/ERROR afterwards.
+            const bool escalate = (attempt + 1) >= INDEXER_WARN_AFTER_ATTEMPTS;
+
             size_t totalProcessed = 0;
             bool exceptionOccurred = false;
 
@@ -731,20 +765,33 @@ private:
             {
                 if (numSlices > 1)
                 {
-                    totalProcessed = fetchWithSlicedPit(context, query, "", numSlices);
+                    totalProcessed = fetchWithSlicedPit(context, query, "", numSlices, escalate);
                 }
                 else
                 {
-                    totalProcessed = fetchWithPit(context, query, "");
+                    totalProcessed = fetchWithPit(context, query, "", escalate);
                 }
             }
             catch (const std::exception& e)
             {
                 exceptionOccurred = true;
-                logWarn(WM_CONTENTUPDATER,
-                        "IndexerDownloader: Initial load failed (%s) — retrying in %zu s.",
-                        e.what(),
-                        static_cast<size_t>(INDEXER_RETRY_INTERVAL.count()));
+                if (escalate)
+                {
+                    logWarn(WM_CONTENTUPDATER,
+                            "IndexerDownloader: Initial load failed (%s) — retrying in %zu s.",
+                            e.what(),
+                            static_cast<size_t>(INDEXER_RETRY_INTERVAL.count()));
+                }
+                else
+                {
+                    logInfo(WM_CONTENTUPDATER,
+                            "IndexerDownloader: Indexer not available yet (%s) — retrying in %zu s "
+                            "(attempt %zu/%zu).",
+                            e.what(),
+                            static_cast<size_t>(INDEXER_RETRY_INTERVAL.count()),
+                            attempt + 1,
+                            INDEXER_WARN_AFTER_ATTEMPTS);
+                }
             }
 
             if (totalProcessed > 0)
@@ -760,9 +807,21 @@ private:
 
             if (!exceptionOccurred)
             {
-                logWarn(WM_CONTENTUPDATER,
-                        "IndexerDownloader: Indexer index not ready (0 documents) — retrying in %zu s.",
-                        static_cast<size_t>(INDEXER_RETRY_INTERVAL.count()));
+                if (escalate)
+                {
+                    logWarn(WM_CONTENTUPDATER,
+                            "IndexerDownloader: Indexer index not ready (0 documents) — retrying in %zu s.",
+                            static_cast<size_t>(INDEXER_RETRY_INTERVAL.count()));
+                }
+                else
+                {
+                    logInfo(WM_CONTENTUPDATER,
+                            "IndexerDownloader: Indexer index not ready yet (0 documents) — retrying in %zu s "
+                            "(attempt %zu/%zu).",
+                            static_cast<size_t>(INDEXER_RETRY_INTERVAL.count()),
+                            attempt + 1,
+                            INDEXER_WARN_AFTER_ATTEMPTS);
+                }
             }
 
             ++attempt;


### PR DESCRIPTION
## Description

The indexer is routinely overloaded right after a manager restart, so the first feed-download attempts failing is expected and benign. The `IndexerDownloader` was logging those transient failures as `ERROR`/`WARNING`, producing noisy false alarms such as:

```
ERROR: IndexerDownloader: Slice 0 failed: Search request failed with status -1: Could not connect to server
WARNING: IndexerDownloader: Failed to delete PIT: No available server
WARNING: IndexerDownloader: Initial load failed (...) — retrying in 30 s.
```

This PR keeps those connection-failure messages at `INFO` (aggregated) and `DEBUG` (per-slice detail and PIT cleanup) during the first attempts, and restores the original `WARNING`/`ERROR` severity only from the third consecutive failed attempt onwards (`INDEXER_WARN_AFTER_ATTEMPTS = 3`, retry interval 30 s → ~60-90 s of tolerance). The incremental update path keeps its original behaviour.

This complements the engine-side noise reduction; it covers the `content-updater` path, which was not addressed there.

## Evidences
- Tested by forcing the indexer to restart just as the download begins:
```
2026/06/25 10:13:01 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Consumer 'cti:catalog:consumer:vulnerabilities' not found in '.wazuh-cti-consumers'. Waiting 60 s before retrying.
2026/06/25 10:14:01 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Consumer 'cti:catalog:consumer:vulnerabilities' is still updating in '.wazuh-cti-consumers'. Waiting 60 s before retrying.
2026/06/25 10:15:01 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Consumer 'cti:catalog:consumer:vulnerabilities' in index '.wazuh-cti-consumers' is idle. Starting feed download.
2026/06/25 10:15:01 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting initial full load (slices=2)
2026/06/25 10:15:02 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting sliced PIT download with 2 slices, pageSize=250
2026/06/25 10:15:15 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Indexer not available yet (IndexerDownloader: 2 slice(s) failed: Slice 1: Search request failed with status -1: Could not connect to server) — retrying in 30 s (attempt 1/3).
2026/06/25 10:15:45 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Retrying initial full load (attempt 2) ...
2026/06/25 10:15:45 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting sliced PIT download with 2 slices, pageSize=250
2026/06/25 10:21:09 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 1 (2/2) complete — 176507 docs in 323738ms
2026/06/25 10:21:09 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 0 (1/2) complete — 176513 docs in 323732ms
2026/06/25 10:21:09 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Initial load download phase complete — 353020 documents, cursor: '465835'
2026/06/25 10:21:10 wazuh-manager-modulesd:vulnerability-scanner: INFO: Feed update process completed (changed=true).
2026/06/25 10:21:10 wazuh-manager-modulesd:vulnerability-scanner: INFO: CVE feed fully loaded — per-agent scans unblocked.
2026/06/25 10:21:10 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan started after feed update: full scan for all agents.
2026/06/25 10:21:10 wazuh-manager-modulesd:vulnerability-scanner: INFO: Skipping feed update scan for agent 001: already covered by VDFirst.
2026/06/25 10:21:10 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan finished after feed update: full scan for all agents (agents=1, status=ok).
2026/06/25 10:21:10 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan start: agent='001' (v5.0.0) type=full reason=first_scan option=VDFirst
2026/06/25 10:21:10 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '001' - Packages scan completed in 191 ms: 893 packages scanned, 0 skipped, 117 vulnerable packages
2026/06/25 10:21:10 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '001' - Vulnerability scan completed: 3666 new, 0 solved
2026/06/25 10:21:11 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '001' - First vulnerability scan completed: vulnerabilities indexed, no security alerts generated (alerts are suppressed on first scan)
2026/06/25 10:21:11 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan completed: agent='001' type=full reason=first_scan option=VDFirst
```
