### PR TITLE
Add libcrypt fix (#36782) to 4.14.6 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ All notable changes to this project will be documented in this file.
 - Updated `cryptography`, `urllib3` and `python-multipart` Python dependencies. ([#35982](https://github.com/wazuh/wazuh/pull/35982))
 - Updated eBPF libraries: `libbpf` to 1.7.0 and `bpftool` to 7.7.0. ([#36467](https://github.com/wazuh/wazuh/pull/36467))
 
+#### Fixed
+
+- Fixed `wazuh-manager` startup failure on RHEL 10 by dropping the `libcrypt` dependency from embedded Python. ([#36782](https://github.com/wazuh/wazuh/pull/36782))
+
 
 ## [v4.14.5]
 


### PR DESCRIPTION
## Description

Adds the missing changelog entry for the libcrypt fix (#36782) that was merged into `4.14.6` after the `v4.14.6-rc1` tag, ahead of cutting `v4.14.6-rc2` (#37173).

#36782 fixes a regression where `wazuh-manager` fails to start on systems without `libxcrypt-compat` (e.g. RHEL 10) because the embedded Python interpreter was linked against `libcrypt.so.1`. The regression was introduced within the 4.14.6 cycle by #35982; this entry documents the net fix shipped in the release.

## Changes

- Added a `Fixed` entry under the `Other` section of the `[v4.14.6]` changelog block referencing #36782.

## Tests

- [x] CHANGELOG.md entry renders correctly and links to the public PR.
