### PR TITLE
Migrate agent CI artifacts to S3 — 4.14.6 (#5300)

### DIFF
--- a/.github/actions/download_s3_artifact/action.yml
+++ b/.github/actions/download_s3_artifact/action.yml
@@ -1,0 +1,80 @@
+name: "Download artifact from S3"
+description: >
+  Drop-in replacement for actions/download-artifact that retrieves an artifact from
+  the xdrsiem-ci-dev-internal S3 bucket instead of GitHub artifact storage
+  (see https://github.com/wazuh/wazuh-automation/issues/3502).
+  Downloads and extracts the archive previously uploaded by upload_s3_artifact from:
+    <bucket>/<repository>/<workflow>/<name>/artifacts_<run_id>.zip
+  AWS credentials must already be configured in the job, e.g. with
+  aws-actions/configure-aws-credentials (the job needs `permissions: id-token: write`).
+  Requires `7z` and the AWS CLI on the runner.
+
+inputs:
+  name:
+    description: "Artifact name. Must match the name used by the producer upload_s3_artifact step."
+    required: true
+  path:
+    description: "Destination directory for the extracted files. Defaults to the current directory."
+    required: false
+    default: ""
+  bucket:
+    description: "Source S3 bucket URI."
+    required: false
+    default: "s3://xdrsiem-ci-dev-internal"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Resolve S3 key for ${{ inputs.name }}"
+      id: key
+      shell: bash
+      env:
+        ARTIFACT_NAME: ${{ inputs.name }}
+        BUCKET: ${{ inputs.bucket }}
+        REPO_NAME: ${{ github.event.repository.name }}
+        WORKFLOW_REF: ${{ github.workflow_ref }}
+        RUN_ID: ${{ github.run_id }}
+      run: |
+        set -euo pipefail
+        # Derive the workflow file basename, e.g. 4_testcomponent_sysinfo-windows
+        ref_no_at="${WORKFLOW_REF%@*}"
+        wf_file="${ref_no_at##*/}"
+        wf="${wf_file%.*}"
+        # Make the artifact name safe for use as a single S3 key segment
+        safe_name="$(printf '%s' "$ARTIFACT_NAME" | tr ' /\\:' '____')"
+        echo "s3_uri=${BUCKET}/${REPO_NAME}/${wf}/${safe_name}/artifacts_${RUN_ID}.zip" >> "$GITHUB_OUTPUT"
+
+    - name: "Download ${{ inputs.name }} from S3 (Unix)"
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        ARTIFACT_NAME: ${{ inputs.name }}
+        DEST_PATH: ${{ inputs.path }}
+        S3_URI: ${{ steps.key.outputs.s3_uri }}
+      run: |
+        set -euo pipefail
+        tmp="$(mktemp -d)"
+        zip_file="${tmp}/artifacts.zip"
+        aws s3 cp "$S3_URI" "$zip_file" --only-show-errors
+        dest="${DEST_PATH:-.}"
+        mkdir -p "$dest"
+        7z x -y "$zip_file" -o"$dest" >/dev/null
+        echo "Downloaded artifact '${ARTIFACT_NAME}' from ${S3_URI} into ${dest}"
+
+    - name: "Download ${{ inputs.name }} from S3 (Windows)"
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        ARTIFACT_NAME: ${{ inputs.name }}
+        DEST_PATH: ${{ inputs.path }}
+        S3_URI: ${{ steps.key.outputs.s3_uri }}
+      run: |
+        $ErrorActionPreference = "Stop"
+        $tmp = Join-Path $env:RUNNER_TEMP ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+        $zip = Join-Path $tmp "artifacts.zip"
+        aws s3 cp $env:S3_URI $zip --only-show-errors
+        $dest = if ([string]::IsNullOrEmpty($env:DEST_PATH)) { "." } else { $env:DEST_PATH }
+        New-Item -ItemType Directory -Force -Path $dest | Out-Null
+        7z x -y $zip "-o$dest" | Out-Null
+        Write-Host "Downloaded artifact '$env:ARTIFACT_NAME' from $env:S3_URI into $dest"

--- a/.github/actions/upload_s3_artifact/action.yml
+++ b/.github/actions/upload_s3_artifact/action.yml
@@ -1,0 +1,105 @@
+name: "Upload artifact to S3"
+description: >
+  Drop-in replacement for actions/upload-artifact that stores the artifact in the
+  xdrsiem-ci-dev-internal S3 bucket instead of GitHub artifact storage
+  (see https://github.com/wazuh/wazuh-automation/issues/3502).
+  The artifact is archived with 7-Zip and uploaded to:
+    <bucket>/<repository>/<workflow>/<name>/artifacts_<run_id>.zip
+  AWS credentials must already be configured in the job, e.g. with
+  aws-actions/configure-aws-credentials (the job needs `permissions: id-token: write`).
+  Requires `7z` and the AWS CLI on the runner (present on the CodeBuild and
+  GitHub-hosted windows-2025 images used by these workflows).
+
+inputs:
+  name:
+    description: "Artifact name. Must match the name used by the consumer download_s3_artifact step."
+    required: true
+  path:
+    description: "File, directory or wildcard to upload (same intent as actions/upload-artifact `path`)."
+    required: true
+  bucket:
+    description: "Target S3 bucket URI."
+    required: false
+    default: "s3://xdrsiem-ci-dev-internal"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Resolve S3 key for ${{ inputs.name }}"
+      id: key
+      shell: bash
+      env:
+        ARTIFACT_NAME: ${{ inputs.name }}
+        BUCKET: ${{ inputs.bucket }}
+        REPO_NAME: ${{ github.event.repository.name }}
+        WORKFLOW_REF: ${{ github.workflow_ref }}
+        RUN_ID: ${{ github.run_id }}
+      run: |
+        set -euo pipefail
+        # Derive the workflow file basename, e.g. 4_testcomponent_sysinfo-windows
+        ref_no_at="${WORKFLOW_REF%@*}"
+        wf_file="${ref_no_at##*/}"
+        wf="${wf_file%.*}"
+        # Make the artifact name safe for use as a single S3 key segment
+        safe_name="$(printf '%s' "$ARTIFACT_NAME" | tr ' /\\:' '____')"
+        echo "s3_uri=${BUCKET}/${REPO_NAME}/${wf}/${safe_name}/artifacts_${RUN_ID}.zip" >> "$GITHUB_OUTPUT"
+
+    - name: "Upload ${{ inputs.name }} to S3 (Unix)"
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        ARTIFACT_NAME: ${{ inputs.name }}
+        ARTIFACT_PATH: ${{ inputs.path }}
+        S3_URI: ${{ steps.key.outputs.s3_uri }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob globstar 2>/dev/null || true
+        tmp="$(mktemp -d)"
+        zip_file="${tmp}/artifacts.zip"
+        p="$ARTIFACT_PATH"
+        if [ -d "$p" ]; then
+          ( cd "$p" && 7z a -tzip -y "$zip_file" . >/dev/null )
+        elif [ -f "$p" ]; then
+          7z a -tzip -y "$zip_file" "$p" >/dev/null
+        else
+          matches=( $p )
+          if [ "${#matches[@]}" -eq 0 ]; then
+            echo "::warning::No files found for path '${p}'; skipping upload of artifact '${ARTIFACT_NAME}'."
+            exit 0
+          fi
+          7z a -tzip -y "$zip_file" "${matches[@]}" >/dev/null
+        fi
+        aws s3 cp "$zip_file" "$S3_URI" --only-show-errors
+        echo "Uploaded artifact '${ARTIFACT_NAME}' to ${S3_URI}"
+
+    - name: "Upload ${{ inputs.name }} to S3 (Windows)"
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        ARTIFACT_NAME: ${{ inputs.name }}
+        ARTIFACT_PATH: ${{ inputs.path }}
+        S3_URI: ${{ steps.key.outputs.s3_uri }}
+      run: |
+        $ErrorActionPreference = "Stop"
+        $tmp = Join-Path $env:RUNNER_TEMP ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+        $zip = Join-Path $tmp "artifacts.zip"
+        $p = $env:ARTIFACT_PATH
+        if (Test-Path -PathType Container -LiteralPath $p) {
+          Push-Location $p
+          7z a -tzip -y $zip "." | Out-Null
+          Pop-Location
+        }
+        elseif (Test-Path -PathType Leaf -LiteralPath $p) {
+          7z a -tzip -y $zip $p | Out-Null
+        }
+        else {
+          # Treat as a wildcard and let 7-Zip expand it
+          7z a -tzip -y $zip $p | Out-Null
+          if (-not (Test-Path -LiteralPath $zip)) {
+            Write-Warning "No files found for path '$p'; skipping upload of artifact '$env:ARTIFACT_NAME'."
+            exit 0
+          }
+        }
+        aws s3 cp $zip $env:S3_URI --only-show-errors
+        Write-Host "Uploaded artifact '$env:ARTIFACT_NAME' to $env:S3_URI"

--- a/.github/workflows/4_testcomponent_syscheck-rtr.yml
+++ b/.github/workflows/4_testcomponent_syscheck-rtr.yml
@@ -12,6 +12,10 @@ on:
       - ".github/workflows/4_testcomponent_syscheck-rtr.yml"
       - ".github/actions/**"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   rtr:
     strategy:
@@ -39,9 +43,15 @@ jobs:
         run: |
           cd src/
           python build.py --target ${{ matrix.target }} --readytoreview ${{ matrix.module }}
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Uploading coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
           name: coverage_report ${{ matrix.target }}
           path: ./**/coverage_report/**

--- a/.github/workflows/4_testcomponent_syscollector-rtr.yml
+++ b/.github/workflows/4_testcomponent_syscollector-rtr.yml
@@ -13,6 +13,10 @@ on:
       - ".github/workflows/4_testcomponent_syscollector-rtr.yml"
       - ".github/actions/**"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   rtr:
     strategy:
@@ -56,9 +60,15 @@ jobs:
           name="${{ matrix.module }}"
           name=$(echo $name | sed -e 's*/*-*g')
           echo "ARTIFACT_NAME=$name" >> $GITHUB_ENV
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Uploading coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
           name: coverage_report ${{ env.ARTIFACT_NAME }} ${{ matrix.target }}
           path: ./**/coverage_report/**

--- a/.github/workflows/4_testcomponent_sysinfo-windows.yml
+++ b/.github/workflows/4_testcomponent_sysinfo-windows.yml
@@ -10,6 +10,10 @@ on:
       - "src/wazuh_modules/syscollector/**"
       - "src/Makefile"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
@@ -35,32 +39,38 @@ jobs:
           cp src/win32/libstdc++-6.dll src/shared_libraries/
           cp src/win32/libwinpthread-1.dll src/shared_libraries/
       # Upload build artifacts for the shared libraries.
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Upload Artifact shared_libraries
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
           name: shared_libraries
           path: src/shared_libraries
       # Upload build artifacts for the data provider.
       - name: Upload Artifact data_provider
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
           name: data_provider
           path: src/data_provider/build/bin
       # Upload build artifacts for dbsync.
       - name: Upload Artifact dbsync
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
           name: dbsync
           path: src/shared_modules/dbsync/build/bin
       # Upload build artifacts for rsync.
       - name: Upload Artifact rsync
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
           name: rsync
           path: src/shared_modules/rsync/build/bin
       # Upload build artifacts for syscollector.
       - name: Upload Artifact syscollector
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
           name: syscollector
           path: src/wazuh_modules/syscollector/build/bin
@@ -75,28 +85,34 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version"
           architecture: x64
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Download Artifact data_provider
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
           name: data_provider
           path: C:\data_provider\
       - name: Download Artifact dbsync
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
           name: dbsync
           path: C:\dbsync\
       - name: Download Artifact rsync
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
           name: rsync
           path: C:\rsync\
       - name: Download Artifact syscollector
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
           name: syscollector
           path: C:\syscollector\
       - name: Download Artifact shared_libraries
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
           name: shared_libraries
           path: C:\shared_libraries\

--- a/.github/workflows/4_testcomponent_windows-dll-hijack.yml
+++ b/.github/workflows/4_testcomponent_windows-dll-hijack.yml
@@ -7,6 +7,10 @@ on:
       - "src/**"
       - ".github/workflows/4_testcomponent_windows-dll-hijack.yml"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
@@ -30,8 +34,14 @@ jobs:
           # We remove the executables that aren't distributed in the signed installer
           rm -f src/win32/setup-*.exe
           cp src/win32/*.exe src/exe_files/
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Upload Artifact executables
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
           name: executables
           path: src/exe_files
@@ -44,7 +54,7 @@ jobs:
           sed -i 's+windows.debug=0+windows.debug=2+g' etc/internal_options.conf
           cp src/win32/internal_options.conf src/configuration_files/
       - name: Upload Artifact configuration files
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
           name: configuration
           path: src/configuration_files
@@ -62,13 +72,19 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version"
           architecture: x64
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Download Artifact executables
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
           name: executables
           path: C:\executables\
       - name: Download Artifact configuration files
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
           name: configuration
           path: C:\configuration_files\
@@ -89,7 +105,7 @@ jobs:
           python -m pytest -vv ./test_dll_hijack.py
       - name: Upload .csv files
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
           name: csv_files ${{ matrix.os }}
           path: C:\executables\*.csv

--- a/.github/workflows/4_testcomponent_windows-files.yml
+++ b/.github/workflows/4_testcomponent_windows-files.yml
@@ -6,6 +6,10 @@ on:
       - "src/**"
       - ".github/workflows/4_testcomponent_windows-files.yml"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
@@ -32,8 +36,14 @@ jobs:
           rm -f src/win32/libgcc_s_dw2-1.dll
           rm -f src/win32/libstdc++-6.dll
           find src/ -name "*.dll" -not -path "src/external/*" -not -path "src/win32/SimpleSC/*" -not -path "src/win32/nsProcess/*" -exec cp {} src/bin_files/ \;
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Upload Artifact binaries
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
           name: binaries
           path: src/bin_files
@@ -48,8 +58,14 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version"
           architecture: x64
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Download Artifact binaries
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
           name: binaries
           path: C:\binaries\

--- a/.github/workflows/4_testcomponent_windows-installer-upgrade.yml
+++ b/.github/workflows/4_testcomponent_windows-installer-upgrade.yml
@@ -6,6 +6,10 @@ on:
       - "src/**"
       - ".github/workflows/4_testcomponent_windows-installer-upgrade.yml"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
@@ -27,8 +31,14 @@ jobs:
         run: rm -rf src/external/* .git/
       - name: Compress folder
         run: 7z a win-agent-base.zip ./*
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Upload base branch folder
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
           name: win-agent-base.zip
           path: win-agent-base.zip
@@ -57,8 +67,14 @@ jobs:
         run: |
           mkdir C:\win-agent-released
           python -m wget https://packages.wazuh.com/4.x/windows/wazuh-agent-${{ matrix.wazuh_version }}.msi -o C:\win-agent-released
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Download base folder
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
           name: win-agent-base.zip
           path: C:\win-agent-base
@@ -83,13 +99,13 @@ jobs:
           python -m pytest -vv ./test_win_upgrade.py
       - name: Upload release installation log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
           name: release_log
           path: C:\win-agent-released\win-agent-released.log
       - name: Upload base installation log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
           name: base_log
           path: C:\win-agent-base\win-agent-base.log

--- a/.github/workflows/4_testintegration_agentd-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_agentd-tier-0-1-win.yml
@@ -19,6 +19,10 @@ on:
         - "tests/integration/conftest.py"
         - "tests/integration/test_agentd/**"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   # Build the winagent on linux.
   build:
@@ -44,8 +48,14 @@ jobs:
           mkdir -p src/winagent
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
           name: winagent
           path: src/winagent
@@ -68,8 +78,14 @@ jobs:
         shell: bash
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/4_testintegration_enrollment-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_enrollment-tier-0-1-win.yml
@@ -20,6 +20,10 @@ on:
         - "tests/integration/conftest.py"
         - "tests/integration/test_enrollment/**"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   # Build the winagent on linux.
   build:
@@ -45,8 +49,14 @@ jobs:
           mkdir -p src/winagent
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
           name: winagent
           path: src/winagent
@@ -69,8 +79,14 @@ jobs:
         shell: bash
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/4_testintegration_execd-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_execd-tier-0-1-win.yml
@@ -18,6 +18,10 @@ on:
         - "tests/integration/conftest.py"
         - "tests/integration/test_execd/**"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   # Build the winagent on linux.
   build:
@@ -43,8 +47,14 @@ jobs:
           mkdir -p src/winagent
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
           name: winagent
           path: src/winagent
@@ -67,8 +77,14 @@ jobs:
         shell: bash
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/4_testintegration_fim-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_fim-tier-0-1-win.yml
@@ -17,6 +17,10 @@ on:
         - "tests/integration/conftest.py"
         - "tests/integration/test_fim/**"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   # Build the winagent on linux.
   build:
@@ -42,8 +46,14 @@ jobs:
           mkdir -p src/winagent
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
           name: winagent
           path: src/winagent
@@ -66,8 +76,14 @@ jobs:
         shell: bash
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/4_testintegration_fim-tier-2-win.yml
+++ b/.github/workflows/4_testintegration_fim-tier-2-win.yml
@@ -8,6 +8,10 @@ on:
         required: true
         default: 'main'
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   # Build the winagent on linux.
   build:
@@ -33,8 +37,14 @@ jobs:
           mkdir -p src/winagent
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
           name: winagent
           path: src/winagent
@@ -57,8 +67,14 @@ jobs:
         shell: bash
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/4_testintegration_github-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_github-tier-0-1-win.yml
@@ -18,6 +18,10 @@ on:
         - "tests/integration/conftest.py"
         - "tests/integration/test_github/**"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   # Build the winagent on linux.
   build:
@@ -43,8 +47,14 @@ jobs:
           mkdir -p src/winagent
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
           name: winagent
           path: src/winagent
@@ -67,8 +77,14 @@ jobs:
         shell: bash
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/4_testintegration_logcollector-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_logcollector-tier-0-1-win.yml
@@ -17,6 +17,10 @@ on:
         - "tests/integration/conftest.py"
         - "tests/integration/test_logcollector/**"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   # Build the winagent on linux.
   build:
@@ -42,8 +46,14 @@ jobs:
           mkdir -p src/winagent
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
           name: winagent
           path: src/winagent
@@ -66,8 +76,14 @@ jobs:
         shell: bash
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/4_testintegration_office365-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_office365-tier-0-1-win.yml
@@ -18,6 +18,10 @@ on:
         - "tests/integration/conftest.py"
         - "tests/integration/test_office365/**"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   # Build the winagent on linux.
   build:
@@ -43,8 +47,14 @@ jobs:
           mkdir -p src/winagent
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
           name: winagent
           path: src/winagent
@@ -67,8 +77,14 @@ jobs:
         shell: bash
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/4_testintegration_sca-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_sca-tier-0-1-win.yml
@@ -19,6 +19,10 @@ on:
         - "tests/integration/test_sca/**"
 
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   # Build the winagent on linux.
   build:
@@ -44,8 +48,14 @@ jobs:
           mkdir -p src/winagent
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
           name: winagent
           path: src/winagent
@@ -68,8 +78,14 @@ jobs:
         shell: bash
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
           name: winagent
           path: C:\winagent\

--- a/.github/workflows/4_testintegration_syscollector-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_syscollector-tier-0-1-win.yml
@@ -17,6 +17,10 @@ on:
         - "tests/integration/conftest.py"
         - "tests/integration/test_syscollector/**"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   # Build the winagent on linux.
   build:
@@ -42,8 +46,14 @@ jobs:
           mkdir -p src/winagent
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
           name: winagent
           path: src/winagent
@@ -66,8 +76,14 @@ jobs:
         shell: bash
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
+      - name: Configure AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_CI_ARTIFACTS_ROLE }}
+          aws-region: us-east-1
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
           name: winagent
           path: C:\winagent\


### PR DESCRIPTION
## Description

Part of the [GitHub artifacts migration to S3](https://github.com/wazuh/wazuh-automation/issues/3502). Migrates the **agent-exclusive** GitHub Actions artifacts to the `xdrsiem-ci-dev-internal` S3 bucket, replacing `actions/upload-artifact` / `actions/download-artifact` with `aws s3 cp` against:

```
s3://xdrsiem-ci-dev-internal/<repository>/<workflow>/<artifact-name>/artifacts_<run_id>.zip
```

Authentication follows the pattern already used by the Indexer team (wazuh/wazuh-indexer#1674): OIDC via `aws-actions/configure-aws-credentials@v6` with `permissions: id-token: write`.

Resolves https://github.com/wazuh/internal-devel-requests/issues/5300

## Proposed Changes

- **New reusable composite actions:**
  - `.github/actions/upload_s3_artifact` — archives the path with 7-Zip and uploads it to S3.
  - `.github/actions/download_s3_artifact` — downloads from S3 and extracts it.
  - Both are drop-in replacements for the GitHub artifact actions. `7z` and the AWS CLI are already available on the CodeBuild and `windows-2025` runners these workflows use.
- **Migrated agent-exclusive workflows:**
  - Coverage RTR: `4_testcomponent_syscheck-rtr`, `4_testcomponent_syscollector-rtr`
  - Windows component: `4_testcomponent_sysinfo-windows` (5 artifacts), `…windows-dll-hijack`, `…windows-files`, `…windows-installer-upgrade`
  - Windows integration (`winagent` build → test): the 10 `4_testintegration_*-win` workflows
- Each artifact-producing/consuming job gets `permissions: id-token: write` and a `Configure AWS credentials` step (marked `if: always()` so failure-path uploads such as coverage reports and installation logs keep working).

## :warning: Required before merge (DevOps)

CI will not pass until the OIDC role referenced as `secrets.AWS_S3_CI_ARTIFACTS_ROLE` is provisioned with `GetObject`/`PutObject` on `xdrsiem-ci-dev-internal` and an OIDC trust policy for this repository (the open task on the issue). The secret name is a single `grep` to rename if DevOps prefers a different one.

## Out of scope

- Shared **agent/server** artifacts (`coverity`, `scanbuild`, and the `check_files` / `clang_format` / `coverage` / `coverage_cpp` / `doxygen` composite actions) are tracked by the server issue #5298 to avoid overlapping edits on the same files.

## Tests

- `actionlint` passes on the changed workflows (only pre-existing warnings remain — `checkout@v3`/`setup-python@v4` versions, `SC2086`).
- Verified locally that the 7-Zip archive round-trips a directory's contents to the consumer with the same layout `upload/download-artifact` produced (contents at the destination root, sub-directories preserved).
