### PR TITLE
Migrate agent + server CI artifacts to S3 — 5.0.0 (#5300, #5298)

### DIFF
--- a/.github/actions/check_files/action.yml
+++ b/.github/actions/check_files/action.yml
@@ -2,6 +2,19 @@ name: "Check installed files"
 description: "Validates that the installed files are the ones expected and with the right stats"
 
 inputs:
+  aws_region:
+    description: "AWS region for S3 (pass the CI_AWS_REGION secret)."
+    required: false
+    default: "us-east-1"
+
+  bucket:
+    description: "Target S3 bucket URI (pass the CI_INTERNAL_S3_BUCKET secret)."
+    required: false
+    default: ""
+  aws_role:
+    description: "IAM role (OIDC) to assume for S3 access (pass the CI_OIDC_ROLE_ARN secret)."
+    required: false
+    default: ""
   expected_files:
     required: true
     description: "Path to the 'expected files' CSV file"
@@ -76,8 +89,11 @@ runs:
 
   - name: Upload current stats
     if: success()
-    uses: actions/upload-artifact@v4
+    uses: ./.github/actions/upload_s3_artifact
     with:
+      aws_region: ${{ inputs.aws_region }}
+      bucket: ${{ inputs.bucket }}
+      aws_role: ${{ inputs.aws_role }}
       name: current_stats_${{ env.UUID }}
       path: ${{ inputs.current_status }}
 
@@ -96,8 +112,11 @@ runs:
 
   - name: Upload validation results
     if: always()
-    uses: actions/upload-artifact@v4
+    uses: ./.github/actions/upload_s3_artifact
     with:
+      aws_region: ${{ inputs.aws_region }}
+      bucket: ${{ inputs.bucket }}
+      aws_role: ${{ inputs.aws_role }}
       name: validation_results_${{ env.UUID }}
       path: ${{ inputs.report_file }}
 

--- a/.github/actions/clang_format/action.yml
+++ b/.github/actions/clang_format/action.yml
@@ -10,6 +10,20 @@ inputs:
     required: true
     description: "Module identifier, used to name the artifact"
 
+  aws_region:
+    description: "AWS region for S3 (pass the CI_AWS_REGION secret)."
+    required: false
+    default: "us-east-1"
+
+  bucket:
+    description: "Target S3 bucket URI (pass the CI_INTERNAL_S3_BUCKET secret)."
+    required: false
+    default: ""
+  aws_role:
+    description: "IAM role (OIDC) to assume for S3 access (pass the CI_OIDC_ROLE_ARN secret)."
+    required: false
+    default: ""
+
 runs:
   using: "composite"
   steps:
@@ -107,9 +121,11 @@ runs:
           fi
 
       # Upload errors as an artifact, when failed
-      - uses: actions/upload-artifact@v4
+      - uses: ./.github/actions/upload_s3_artifact
         if: failure()
         with:
+          aws_region: ${{ inputs.aws_region }}
+          bucket: ${{ inputs.bucket }}
+          aws_role: ${{ inputs.aws_role }}
           name: Clang-format errors - ${{ inputs.id }}
           path: ${{ inputs.path }}/clang_format_errors.txt
-          retention-days: 1

--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -9,6 +9,20 @@ inputs:
     required: true
     description: "Module identifier, used to name the artifact"
 
+  aws_region:
+    description: "AWS region for S3 (pass the CI_AWS_REGION secret)."
+    required: false
+    default: "us-east-1"
+
+  bucket:
+    description: "Target S3 bucket URI (pass the CI_INTERNAL_S3_BUCKET secret)."
+    required: false
+    default: ""
+  aws_role:
+    description: "IAM role (OIDC) to assume for S3 access (pass the CI_OIDC_ROLE_ARN secret)."
+    required: false
+    default: ""
+
 runs:
   using: "composite"
   steps:
@@ -105,11 +119,13 @@ runs:
       # Upload the coverage report as an artifact
       - name: Uploading coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ inputs.aws_region }}
+          bucket: ${{ inputs.bucket }}
+          aws_role: ${{ inputs.aws_role }}
           name: Coverage Report - ${{ inputs.id }}
           path: ./${{ inputs.path }}/build/coverage_report
-          retention-days: 1
 
       # Check whether the coverage is greater than 90% both for lines and functions
       - name: Validate coverage

--- a/.github/actions/coverage_cpp/action.yml
+++ b/.github/actions/coverage_cpp/action.yml
@@ -20,6 +20,20 @@ inputs:
     description: "Whether to validate function coverage or not"
     default: "true"
 
+  aws_region:
+    description: "AWS region for S3 (pass the CI_AWS_REGION secret)."
+    required: false
+    default: "us-east-1"
+
+  bucket:
+    description: "Target S3 bucket URI (pass the CI_INTERNAL_S3_BUCKET secret)."
+    required: false
+    default: ""
+  aws_role:
+    description: "IAM role (OIDC) to assume for S3 access (pass the CI_OIDC_ROLE_ARN secret)."
+    required: false
+    default: ""
+
 runs:
   using: "composite"
   steps:
@@ -95,11 +109,13 @@ runs:
       # Upload the coverage report as an artifact
       - name: Uploading coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ inputs.aws_region }}
+          bucket: ${{ inputs.bucket }}
+          aws_role: ${{ inputs.aws_role }}
           name: Coverage Report - ${{ inputs.id }}
           path: ./src/build/coverage_report
-          retention-days: 1
         continue-on-error: true
 
       # Check whether the coverage is greater than 90% both for lines and functions

--- a/.github/actions/download_manager_package/action.yml
+++ b/.github/actions/download_manager_package/action.yml
@@ -1,0 +1,88 @@
+name: "Download manager package from S3"
+description: >
+  Downloads the manager package(s) produced by a manager-multiples build run from
+  the internal CI S3 bucket (passed via the CI_INTERNAL_S3_BUCKET secret), matching the package name by regexp.
+  A drop-in replacement for the dawidd6/action-download-artifact step used before
+  the manager package upload was migrated to S3 (see wazuh-automation#3502).
+  AWS credentials are configured by the action itself via OIDC, so the calling job
+  only needs `permissions: id-token: write`. Requires the AWS CLI on the runner.
+
+inputs:
+  build_run_id:
+    description: "Run ID of the manager-multiples build that produced the package."
+    required: true
+  name_regexp:
+    description: "Regexp the package name segment must match."
+    required: false
+    default: 'wazuh-manager.*amd64.*\.deb'
+  path:
+    description: "Destination directory for the extracted package(s)."
+    required: false
+    default: "/tmp/packages"
+  producer_workflow:
+    description: "Workflow segment of the S3 key (the build's entry workflow)."
+    required: false
+    default: "5_builderpackage_manager-multiples"
+  repository:
+    description: "Repository segment of the S3 key."
+    required: false
+    default: "wazuh"
+  bucket:
+    description: "Source S3 bucket URI."
+    required: false
+    default: ""
+  aws_role:
+    description: "IAM role (OIDC) to assume for S3 access (pass the CI_OIDC_ROLE_ARN secret)."
+    required: false
+    default: ""
+  aws_region:
+    description: "Fallback AWS region."
+    required: false
+    default: "us-east-1"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: ${{ inputs.aws_role }}
+        aws-region: ${{ inputs.aws_region }}
+
+    - name: Download manager package from S3
+      shell: bash
+      env:
+        BUCKET: ${{ inputs.bucket }}
+        REPO: ${{ inputs.repository }}
+        PRODUCER_WF: ${{ inputs.producer_workflow }}
+        BUILD_RUN_ID: ${{ inputs.build_run_id }}
+        NAME_RE: ${{ inputs.name_regexp }}
+        DEST: ${{ inputs.path }}
+      run: |
+        set -euo pipefail
+        base="${BUCKET}/${REPO}/${PRODUCER_WF}"
+        mkdir -p "$DEST"
+        # The producer uploads each artifact at <repo>/<workflow>/<name>/artifacts_<run_id>.zip,
+        # so list the producer workflow's objects and keep those whose <name> segment matches
+        # the regexp for this build run (the package name carries a commit hash, so it can't be
+        # addressed by exact name).
+        keys="$(aws s3 ls "${base}/" --recursive | awk '{print $4}' \
+          | grep -E "/${PRODUCER_WF}/${NAME_RE}/artifacts_${BUILD_RUN_ID}\.zip$" || true)"
+        if [ -z "$keys" ]; then
+          echo "::error::No artifact matching '${NAME_RE}' found in S3 for build run ${BUILD_RUN_ID} under ${base}/"
+          exit 1
+        fi
+        while IFS= read -r key; do
+          [ -z "$key" ] && continue
+          tmp="$(mktemp -d)"
+          aws s3 cp "${BUCKET}/${key}" "${tmp}/pkg.zip" --only-show-errors
+          if command -v 7z >/dev/null 2>&1; then
+            7z x -y "${tmp}/pkg.zip" -o"$DEST" >/dev/null
+          elif command -v unzip >/dev/null 2>&1; then
+            unzip -o -q "${tmp}/pkg.zip" -d "$DEST"
+          else
+            python3 -c "import sys,zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])" "${tmp}/pkg.zip" "$DEST"
+          fi
+        done <<< "$keys"
+        echo "Downloaded artifact(s) to ${DEST}:"
+        ls -la "$DEST"

--- a/.github/actions/download_s3_artifact/action.yml
+++ b/.github/actions/download_s3_artifact/action.yml
@@ -1,0 +1,113 @@
+name: "Download artifact from S3"
+description: >
+  Drop-in replacement for actions/download-artifact that retrieves an artifact from
+  the internal CI S3 bucket (passed via the CI_INTERNAL_S3_BUCKET secret) instead of GitHub artifact storage
+  (see https://github.com/wazuh/wazuh-automation/issues/3502).
+  Downloads and extracts the archive previously uploaded by upload_s3_artifact from:
+    <bucket>/<repository>/<workflow>/<name>/artifacts_<run_id>.zip
+  AWS credentials are configured by the action itself via OIDC, so the calling
+  job only needs `permissions: id-token: write`. Pass the region via the
+  `aws_region` input (set it to the CI_AWS_REGION secret at the call site).
+  Requires `7z` and the AWS CLI on the runner.
+
+inputs:
+  name:
+    description: "Artifact name. Must match the name used by the producer upload_s3_artifact step."
+    required: true
+  path:
+    description: "Destination directory for the extracted files. Defaults to the current directory."
+    required: false
+    default: ""
+  bucket:
+    description: "Source S3 bucket URI."
+    required: false
+    default: ""
+  aws_role:
+    description: "IAM role (OIDC) to assume for S3 access (pass the CI_OIDC_ROLE_ARN secret)."
+    required: false
+    default: ""
+  aws_region:
+    description: "Fallback AWS region, used only when the AWS_REGION environment variable is not set."
+    required: false
+    default: "us-east-1"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Resolve S3 key for ${{ inputs.name }}"
+      id: key
+      shell: bash
+      env:
+        ARTIFACT_NAME: ${{ inputs.name }}
+        BUCKET: ${{ inputs.bucket }}
+        REPO_NAME: ${{ github.event.repository.name }}
+        WORKFLOW_REF: ${{ github.workflow_ref }}
+        RUN_ID: ${{ github.run_id }}
+      run: |
+        set -euo pipefail
+        # Derive the workflow file basename, e.g. 4_testcomponent_sysinfo-windows
+        ref_no_at="${WORKFLOW_REF%@*}"
+        wf_file="${ref_no_at##*/}"
+        wf="${wf_file%.*}"
+        # Make the artifact name safe for use as a single S3 key segment
+        safe_name="$(printf '%s' "$ARTIFACT_NAME" | tr ' /\\:' '____')"
+        echo "s3_uri=${BUCKET}/${REPO_NAME}/${wf}/${safe_name}/artifacts_${RUN_ID}.zip" >> "$GITHUB_OUTPUT"
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: ${{ inputs.aws_role }}
+        aws-region: ${{ inputs.aws_region }}
+
+    - name: "Download ${{ inputs.name }} from S3 (Unix)"
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        ARTIFACT_NAME: ${{ inputs.name }}
+        DEST_PATH: ${{ inputs.path }}
+        S3_URI: ${{ steps.key.outputs.s3_uri }}
+      run: |
+        set -euo pipefail
+        tmp="$(mktemp -d)"
+        zip_file="${tmp}/artifacts.zip"
+        aws s3 cp "$S3_URI" "$zip_file" --only-show-errors
+        dest="${DEST_PATH:-.}"
+        mkdir -p "$dest"
+        # Extract: prefer 7z, then unzip, then a Python fallback for runner images
+        # that ship neither (e.g. the arm64 CodeBuild agent image).
+        if command -v 7z >/dev/null 2>&1; then
+          7z x -y "$zip_file" -o"$dest" >/dev/null
+        elif command -v unzip >/dev/null 2>&1; then
+          unzip -o -q "$zip_file" -d "$dest"
+        else
+          python3 - "$zip_file" "$dest" <<'PY'
+        import sys, zipfile
+        with zipfile.ZipFile(sys.argv[1]) as z:
+            z.extractall(sys.argv[2])
+        PY
+        fi
+        echo "Downloaded artifact '${ARTIFACT_NAME}' from ${S3_URI} into ${dest}"
+
+    - name: "Download ${{ inputs.name }} from S3 (Windows)"
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        ARTIFACT_NAME: ${{ inputs.name }}
+        DEST_PATH: ${{ inputs.path }}
+        S3_URI: ${{ steps.key.outputs.s3_uri }}
+      run: |
+        $ErrorActionPreference = "Stop"
+        $tmp = Join-Path $env:RUNNER_TEMP ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+        $zip = Join-Path $tmp "artifacts.zip"
+        aws s3 cp $env:S3_URI $zip --only-show-errors
+        $dest = if ([string]::IsNullOrEmpty($env:DEST_PATH)) { "." } else { $env:DEST_PATH }
+        New-Item -ItemType Directory -Force -Path $dest | Out-Null
+        # Prefer 7z; fall back to PowerShell's native Expand-Archive for runner
+        # images that lack 7z (e.g. the CodeBuild Windows image).
+        if (Get-Command 7z -ErrorAction SilentlyContinue) {
+          7z x -y $zip "-o$dest" | Out-Null
+        } else {
+          Expand-Archive -Path $zip -DestinationPath $dest -Force
+        }
+        Write-Host "Downloaded artifact '$env:ARTIFACT_NAME' from $env:S3_URI into $dest"

--- a/.github/actions/doxygen/action.yml
+++ b/.github/actions/doxygen/action.yml
@@ -14,6 +14,20 @@ inputs:
     required: true
     description: "Module identifier, used to name the artifact"
 
+  aws_region:
+    description: "AWS region for S3 (pass the CI_AWS_REGION secret)."
+    required: false
+    default: "us-east-1"
+
+  bucket:
+    description: "Target S3 bucket URI (pass the CI_INTERNAL_S3_BUCKET secret)."
+    required: false
+    default: ""
+  aws_role:
+    description: "IAM role (OIDC) to assume for S3 access (pass the CI_OIDC_ROLE_ARN secret)."
+    required: false
+    default: ""
+
 runs:
   using: "composite"
   steps:
@@ -58,17 +72,21 @@ runs:
           fi
 
       # Upload errors as an artifact, when failed
-      - uses: actions/upload-artifact@v4
+      - uses: ./.github/actions/upload_s3_artifact
         if: failure()
         with:
+          aws_region: ${{ inputs.aws_region }}
+          bucket: ${{ inputs.bucket }}
+          aws_role: ${{ inputs.aws_role }}
           name: Doxygen errors - ${{ inputs.id }}
           path: ${{ inputs.path }}/doxygen_errors.txt
-          retention-days: 1
 
       # Upload the documentation as an artifact, when successful
-      - uses: actions/upload-artifact@v4
+      - uses: ./.github/actions/upload_s3_artifact
         if: success()
         with:
+          aws_region: ${{ inputs.aws_region }}
+          bucket: ${{ inputs.bucket }}
+          aws_role: ${{ inputs.aws_role }}
           name: Doxygen Documentation - ${{ inputs.id }}
           path: ${{ inputs.path }}/doc
-          retention-days: 1

--- a/.github/actions/upload_s3_artifact/action.yml
+++ b/.github/actions/upload_s3_artifact/action.yml
@@ -1,0 +1,157 @@
+name: "Upload artifact to S3"
+description: >
+  Drop-in replacement for actions/upload-artifact that stores the artifact in the
+  internal CI S3 bucket (passed via the CI_INTERNAL_S3_BUCKET secret) instead of GitHub artifact storage
+  (see https://github.com/wazuh/wazuh-automation/issues/3502).
+  The artifact is archived with 7-Zip and uploaded to:
+    <bucket>/<repository>/<workflow>/<name>/artifacts_<run_id>.zip
+  AWS credentials are configured by the action itself via OIDC, so the calling
+  job only needs `permissions: id-token: write`. Pass the region via the
+  `aws_region` input (set it to the CI_AWS_REGION secret at the call site).
+  Requires `7z` and the AWS CLI on the runner (present on the CodeBuild and
+  GitHub-hosted windows-2025 images used by these workflows).
+
+inputs:
+  name:
+    description: "Artifact name. Must match the name used by the consumer download_s3_artifact step."
+    required: true
+  path:
+    description: "File, directory or wildcard to upload (same intent as actions/upload-artifact `path`)."
+    required: true
+  bucket:
+    description: "Target S3 bucket URI."
+    required: false
+    default: ""
+  aws_role:
+    description: "IAM role (OIDC) to assume for S3 access (pass the CI_OIDC_ROLE_ARN secret)."
+    required: false
+    default: ""
+  aws_region:
+    description: "Fallback AWS region, used only when the AWS_REGION environment variable is not set."
+    required: false
+    default: "us-east-1"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Resolve S3 key for ${{ inputs.name }}"
+      id: key
+      shell: bash
+      env:
+        ARTIFACT_NAME: ${{ inputs.name }}
+        BUCKET: ${{ inputs.bucket }}
+        REPO_NAME: ${{ github.event.repository.name }}
+        WORKFLOW_REF: ${{ github.workflow_ref }}
+        RUN_ID: ${{ github.run_id }}
+      run: |
+        set -euo pipefail
+        # Derive the workflow file basename, e.g. 4_testcomponent_sysinfo-windows
+        ref_no_at="${WORKFLOW_REF%@*}"
+        wf_file="${ref_no_at##*/}"
+        wf="${wf_file%.*}"
+        # Make the artifact name safe for use as a single S3 key segment
+        safe_name="$(printf '%s' "$ARTIFACT_NAME" | tr ' /\\:' '____')"
+        echo "s3_uri=${BUCKET}/${REPO_NAME}/${wf}/${safe_name}/artifacts_${RUN_ID}.zip" >> "$GITHUB_OUTPUT"
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: ${{ inputs.aws_role }}
+        aws-region: ${{ inputs.aws_region }}
+
+    - name: "Upload ${{ inputs.name }} to S3 (Unix)"
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        ARTIFACT_NAME: ${{ inputs.name }}
+        ARTIFACT_PATH: ${{ inputs.path }}
+        S3_URI: ${{ steps.key.outputs.s3_uri }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob globstar 2>/dev/null || true
+        # Archive helper: prefer 7z, then zip, then a Python fallback for runner
+        # images that ship neither (e.g. the arm64 CodeBuild agent image).
+        mkzip() {
+          if command -v 7z >/dev/null 2>&1; then
+            7z a -tzip -y "$zip_file" "$@" >/dev/null
+          elif command -v zip >/dev/null 2>&1; then
+            zip -q -r "$zip_file" "$@" >/dev/null
+          else
+            python3 - "$zip_file" "$@" <<'PY'
+        import os, sys, zipfile
+        with zipfile.ZipFile(sys.argv[1], "w", zipfile.ZIP_DEFLATED) as z:
+            for a in sys.argv[2:]:
+                if os.path.isdir(a):
+                    for root, _, files in os.walk(a):
+                        for n in files:
+                            full = os.path.join(root, n)
+                            z.write(full, os.path.relpath(full, a))
+                elif os.path.isfile(a):
+                    z.write(a, os.path.basename(a))
+        PY
+          fi
+        }
+        tmp="$(mktemp -d)"
+        zip_file="${tmp}/artifacts.zip"
+        p="$ARTIFACT_PATH"
+        if [ -d "$p" ]; then
+          ( cd "$p" && mkzip . )
+        elif [ -f "$p" ]; then
+          mkzip "$p"
+        else
+          # Wildcard: stage the matching files into a tree (preserving relative
+          # paths) and archive that, so 7-Zip does not flatten them to basenames
+          # (which collides when several dirs contain the same filename).
+          stage="$(mktemp -d)"
+          found=0
+          for m in $p; do
+            if [ -f "$m" ]; then
+              mkdir -p "${stage}/$(dirname "$m")"
+              cp "$m" "${stage}/${m}"
+              found=1
+            fi
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "::warning::No files found for path '${p}'; skipping upload of artifact '${ARTIFACT_NAME}'."
+            exit 0
+          fi
+          ( cd "$stage" && mkzip . )
+        fi
+        aws s3 cp "$zip_file" "$S3_URI" --only-show-errors
+        echo "Uploaded artifact '${ARTIFACT_NAME}' to ${S3_URI}"
+
+    - name: "Upload ${{ inputs.name }} to S3 (Windows)"
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        ARTIFACT_NAME: ${{ inputs.name }}
+        ARTIFACT_PATH: ${{ inputs.path }}
+        S3_URI: ${{ steps.key.outputs.s3_uri }}
+      run: |
+        $ErrorActionPreference = "Stop"
+        $tmp = Join-Path $env:RUNNER_TEMP ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+        $zip = Join-Path $tmp "artifacts.zip"
+        $p = $env:ARTIFACT_PATH
+        # Prefer 7z; fall back to PowerShell's native Compress-Archive for runner
+        # images that lack 7z (e.g. the CodeBuild Windows image).
+        $have7z = [bool](Get-Command 7z -ErrorAction SilentlyContinue)
+        if (Test-Path -PathType Container -LiteralPath $p) {
+          if ($have7z) { Push-Location $p; 7z a -tzip -y $zip "." | Out-Null; Pop-Location }
+          else { Compress-Archive -Path (Join-Path $p '*') -DestinationPath $zip -Force }
+        }
+        elseif (Test-Path -PathType Leaf -LiteralPath $p) {
+          if ($have7z) { 7z a -tzip -y $zip $p | Out-Null }
+          else { Compress-Archive -Path $p -DestinationPath $zip -Force }
+        }
+        else {
+          # Treat as a wildcard
+          if ($have7z) { 7z a -tzip -y $zip $p | Out-Null }
+          else { Compress-Archive -Path $p -DestinationPath $zip -Force -ErrorAction SilentlyContinue }
+          if (-not (Test-Path -LiteralPath $zip)) {
+            Write-Warning "No files found for path '$p'; skipping upload of artifact '$env:ARTIFACT_NAME'."
+            exit 0
+          }
+        }
+        aws s3 cp $zip $env:S3_URI --only-show-errors
+        Write-Host "Uploaded artifact '$env:ARTIFACT_NAME' to $env:S3_URI"

--- a/.github/test_modules_manager.json
+++ b/.github/test_modules_manager.json
@@ -5,7 +5,7 @@
       "suite_type": "manager_install",
       "pytest_target": "test_api/",
       "tiers": ["0 1"],
-      "timeout_minutes": 60,
+      "timeout_minutes": 120,
       "_comment_tiers": "Each element produces one matrix row; space-separated values become individual --tier flags",
       "_comment_rbac": "rbac tests live under test_api/test_rbac/ — covered as a subset of test_api/. framework/wazuh/rbac/** is listed here so rbac-only changes also trigger this suite.",
       "paths": [
@@ -26,7 +26,7 @@
       "suite_type": "manager_install",
       "pytest_target": "test_wazuh_db/",
       "tiers": ["0"],
-      "timeout_minutes": 60,
+      "timeout_minutes": 120,
       "_comment_tiers": "wazuh-db integration tests are all tier 0 (smoke/functional against the wdb socket)",
       "paths": [
         ".github/workflows/5_builderpackage_manager-multiples.yml",
@@ -47,7 +47,7 @@
       "suite_type": "manager_install",
       "pytest_target": "test_remoted/",
       "tiers": ["0 1"],
-      "timeout_minutes": 60,
+      "timeout_minutes": 120,
       "paths": [
         ".github/workflows/5_builderpackage_manager-multiples.yml",
         ".github/workflows/5_testintegration_manager.yml",
@@ -67,7 +67,7 @@
       "suite_type": "manager_install",
       "pytest_target": "test_remoted/",
       "tiers": ["2"],
-      "timeout_minutes": 60,
+      "timeout_minutes": 120,
       "paths": [
         ".github/workflows/5_builderpackage_manager-multiples.yml",
         ".github/workflows/5_testintegration_manager.yml",
@@ -85,7 +85,7 @@
     {
       "name": "inventory_sync",
       "suite_type": "inventory_sync",
-      "timeout_minutes": 60,
+      "timeout_minutes": 120,
       "paths": [
         ".github/workflows/5_builderpackage_manager-multiples.yml",
         ".github/workflows/5_testintegration_inventory-sync.yml",
@@ -102,7 +102,7 @@
       "suite_type": "manager_install",
       "pytest_target": "test_authd/",
       "tiers": ["0 1"],
-      "timeout_minutes": 60,
+      "timeout_minutes": 120,
       "paths": [
         ".github/workflows/5_builderpackage_manager-multiples.yml",
         ".github/workflows/5_testintegration_manager.yml",

--- a/.github/workflows/5_builderpackage_agent-linux.yml
+++ b/.github/workflows/5_builderpackage_agent-linux.yml
@@ -183,6 +183,9 @@ jobs:
           retention-days: 7
 
   test-deb:
+    permissions:
+      id-token: write
+      contents: read
     needs: build-deb
     runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
@@ -291,6 +294,8 @@ jobs:
       - name: Check installed files
         uses: ./.github/actions/check_files
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           expected_files: ${{ env.CSV_FILENAME }}
           installation_directory: /var/ossec
           wazuh_uid: ${{ env.WAZUH_UID }}
@@ -524,6 +529,9 @@ jobs:
           retention-days: 7
 
   test-rpm:
+    permissions:
+      id-token: write
+      contents: read
     needs: build-rpm
     runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
@@ -640,6 +648,8 @@ jobs:
       - name: Check installed files
         uses: ./.github/actions/check_files
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           expected_files: ${{ env.CSV_FILENAME }}
           installation_directory: /var/ossec
           wazuh_uid: ${{ env.WAZUH_UID }}

--- a/.github/workflows/5_builderpackage_manager-multiples.yml
+++ b/.github/workflows/5_builderpackage_manager-multiples.yml
@@ -87,6 +87,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+  packages: write
+
 jobs:
   select-targets:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -239,6 +244,7 @@ jobs:
     name: Build Wazuh Manager
     needs: select-targets
     permissions:
+        id-token: write
         contents: read
         packages: write
     strategy:

--- a/.github/workflows/5_builderpackage_manager.yml
+++ b/.github/workflows/5_builderpackage_manager.yml
@@ -99,6 +99,7 @@ on:
 jobs:
   Build-manager-packages:
     permissions:
+      id-token: write
       contents: read
       packages: write
     env:
@@ -260,6 +261,8 @@ jobs:
       - name: Check installed files
         uses: ./.github/actions/check_files
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           expected_files: manager_base.csv
           wazuh_uid: ${{ env.WAZUH_UID }}
           wazuh_gid: ${{ env.WAZUH_GID }}
@@ -432,23 +435,27 @@ jobs:
           container: ${{ env.UPGRADE_CONTAINER }}
           package_path: /packages/${{ env.PACKAGE_NAME }}
 
-      - name: Upload package to GitHub
+      - name: Upload package to S3
         if: always()
         timeout-minutes: 10
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: ${{ env.PACKAGE_NAME }}
           path: /tmp/${{ env.PACKAGE_NAME }}
-          if-no-files-found: error
 
-      - name: Upload debug symbols to GitHub
+      - name: Upload debug symbols to S3
         if: always()
         timeout-minutes: 10
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: ${{ env.PACKAGE_SYMBOLS_NAME }}
           path: /tmp/${{ env.PACKAGE_SYMBOLS_NAME }}
-          if-no-files-found: error
 
       - name: Set up AWS CLI
         if: ${{ env.SHOULD_UPLOAD == 'true' }}

--- a/.github/workflows/5_codeanalysis_coverity.yml
+++ b/.github/workflows/5_codeanalysis_coverity.yml
@@ -34,6 +34,10 @@ on:
 env:
   REGISTRY: ghcr.io
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   prepare:
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
@@ -80,6 +84,7 @@ jobs:
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     needs: prepare
     permissions:
+      id-token: write
       contents: read
       packages: read
     steps:
@@ -131,8 +136,11 @@ jobs:
         run: tar czf wazuh.tgz cov-int
 
       - name: Upload Coverity artifact
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: wazuh.tgz
           path: wazuh.tgz
 
@@ -146,8 +154,11 @@ jobs:
           ref: ${{ github.ref_name }}
 
       - name: Download Coverity artifact
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: wazuh.tgz
 
       - name: Upload to Coverity Scan

--- a/.github/workflows/5_codeanalysis_scanbuild.yml
+++ b/.github/workflows/5_codeanalysis_scanbuild.yml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   scan-build-linux:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
@@ -40,8 +44,11 @@ jobs:
           scan-build-14 --status-bugs --force-analyze-debug-code -o scan-build-report --exclude external/ make TARGET=${{ matrix.target }} DEBUG=1 -j$(nproc)
       - name: Upload scan-build report
         if: steps.build_step.outcome == 'failure'
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: linux-${{ matrix.target }}-scan-build-report
           path: src/scan-build-report/
       - name: Fail job if build failed
@@ -73,8 +80,11 @@ jobs:
           scan-build-14 --status-bugs --use-cc=/usr/bin/i686-w64-mingw32-gcc --use-c++=/usr/bin/i686-w64-mingw32-g++-posix --analyzer-target=i686-w64-mingw32 --force-analyze-debug-code -o scan-build-report --exclude external/ --exclude syscheckd/src/registry/ make TARGET=winagent DEBUG=1 -j$(nproc)
       - name: Upload scan-build report
         if: steps.build_step.outcome == 'failure'
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: windows-agent-scan-build-report
           path: src/scan-build-report/
       - name: Fail job if build failed
@@ -101,8 +111,11 @@ jobs:
           /opt/homebrew/opt/llvm@14/bin/scan-build --status-bugs --force-analyze-debug-code -o scan-build-report --exclude external/ make TARGET=agent DEBUG=1 -j3
       - name: Upload scan-build report
         if: steps.build_step.outcome == 'failure'
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: macos-agent-scan-build-report
           path: src/scan-build-report/
       - name: Fail job if build failed

--- a/.github/workflows/5_codelinter_clangformat.yml
+++ b/.github/workflows/5_codelinter_clangformat.yml
@@ -19,6 +19,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   style:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -43,6 +47,8 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/clang_format
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/shared_modules/router
           id: router
 
@@ -52,6 +58,8 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/clang_format
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/shared_modules/indexer_connector
           id: indexer_connector
 
@@ -61,6 +69,8 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/clang_format
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/shared_modules/content_manager
           id: content_manager
 
@@ -70,6 +80,8 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/clang_format
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/wazuh_modules/inventory_sync
           id: inventory_sync
 
@@ -79,6 +91,8 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/clang_format
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/wazuh_modules/vulnerability_scanner
           id: vulnerability_scanner
 
@@ -88,6 +102,8 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/clang_format
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/shared_modules/utils
           id: utils
 

--- a/.github/workflows/5_testcomponent_agent_info-rtr.yml
+++ b/.github/workflows/5_testcomponent_agent_info-rtr.yml
@@ -17,6 +17,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   Agent-Info-Unit-Tests:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
@@ -47,7 +51,10 @@ jobs:
           python build.py --target ${{ matrix.target }} --readytoreview ${{ matrix.module }}
       - name: Uploading coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: coverage_report ${{ matrix.target }}
           path: ./**/coverage_report/**

--- a/.github/workflows/5_testcomponent_agent_metadata-rtr.yml
+++ b/.github/workflows/5_testcomponent_agent_metadata-rtr.yml
@@ -15,6 +15,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   rtr:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
@@ -45,7 +49,10 @@ jobs:
           python build.py --target ${{ matrix.target }} --readytoreview ${{ matrix.module }}
       - name: Uploading coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: coverage_report ${{ matrix.target }}
           path: ./**/coverage_report/**

--- a/.github/workflows/5_testcomponent_sca-rtr.yml
+++ b/.github/workflows/5_testcomponent_sca-rtr.yml
@@ -17,6 +17,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   SCA-Unit-Tests:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
@@ -47,7 +51,10 @@ jobs:
           python build.py --target ${{ matrix.target }} --readytoreview ${{ matrix.module }}
       - name: Uploading coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: coverage_report ${{ matrix.target }}
           path: ./**/coverage_report/**

--- a/.github/workflows/5_testcomponent_schema_validator-rtr.yml
+++ b/.github/workflows/5_testcomponent_schema_validator-rtr.yml
@@ -15,6 +15,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   rtr:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
@@ -45,7 +49,10 @@ jobs:
           python build.py --target ${{ matrix.target }} --readytoreview ${{ matrix.module }}
       - name: Uploading coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: coverage_report ${{ matrix.target }}
           path: ./**/coverage_report/**

--- a/.github/workflows/5_testcomponent_shared_modules_file_helper-rtr.yml
+++ b/.github/workflows/5_testcomponent_shared_modules_file_helper-rtr.yml
@@ -15,6 +15,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   rtr:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
@@ -45,7 +49,10 @@ jobs:
           python build.py --target ${{ matrix.target }} --readytoreview ${{ matrix.module }}
       - name: Uploading coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: coverage_report ${{ matrix.target }}
           path: ./**/coverage_report/**

--- a/.github/workflows/5_testcomponent_sync_protocol-rtr.yml
+++ b/.github/workflows/5_testcomponent_sync_protocol-rtr.yml
@@ -15,6 +15,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   rtr:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
@@ -45,7 +49,10 @@ jobs:
           python build.py --target ${{ matrix.target }} --readytoreview ${{ matrix.module }}
       - name: Uploading coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: coverage_report ${{ matrix.target }}
           path: ./**/coverage_report/**

--- a/.github/workflows/5_testcomponent_syscheck-rtr.yml
+++ b/.github/workflows/5_testcomponent_syscheck-rtr.yml
@@ -17,6 +17,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   rtr:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
@@ -49,7 +53,10 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: coverage_report_${{ matrix.target }}
           path: ./**/coverage_report/**

--- a/.github/workflows/5_testcomponent_syscollector-rtr.yml
+++ b/.github/workflows/5_testcomponent_syscollector-rtr.yml
@@ -18,6 +18,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   rtr:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
@@ -56,7 +60,10 @@ jobs:
           echo "ARTIFACT_NAME=$name" >> $GITHUB_ENV
       - name: Uploading coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: coverage_report ${{ env.ARTIFACT_NAME }} ${{ matrix.target }}
           path: ./**/coverage_report/**

--- a/.github/workflows/5_testcomponent_windows-dll-hijack.yml
+++ b/.github/workflows/5_testcomponent_windows-dll-hijack.yml
@@ -37,6 +37,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
@@ -67,8 +71,11 @@ jobs:
           cp src/build/bin/*.dll src/exe_files/ 2>/dev/null || true
           cp src/build/lib/*.dll src/exe_files/ 2>/dev/null || true
 
-      - uses: actions/upload-artifact@v4
+      - uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: executables
           path: src/exe_files
 
@@ -80,8 +87,11 @@ jobs:
           sed -i 's+windows.debug=0+windows.debug=2+g' etc/internal_options.conf || exit 1
           cp etc/internal_options.conf src/configuration_files/internal_options.conf || exit 1
 
-      - uses: actions/upload-artifact@v4
+      - uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: configuration
           path: src/configuration_files
 
@@ -100,13 +110,19 @@ jobs:
           python-version-file: ".github/workflows/.python-version"
           architecture: x64
 
-      - uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: executables
           path: C:\executables\
 
-      - uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: configuration
           path: C:\configuration_files\
 
@@ -140,7 +156,10 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit 1 }
 
       - if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: csv_files_${{ matrix.os }}
           path: C:\executables\*.csv

--- a/.github/workflows/5_testcomponent_windows-files.yml
+++ b/.github/workflows/5_testcomponent_windows-files.yml
@@ -36,6 +36,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
@@ -69,8 +73,11 @@ jobs:
           rm -f src/bin_files/libgcc_s_dw2-1.dll
           rm -f src/bin_files/libstdc++-6.dll
       - name: Upload Artifact binaries
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: binaries
           path: src/bin_files
   check_binaries_details:
@@ -87,8 +94,11 @@ jobs:
           python-version-file: ".github/workflows/.python-version"
           architecture: x64
       - name: Download Artifact binaries
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: binaries
           path: C:\binaries\
       - name: Install dependencies

--- a/.github/workflows/5_testcomponent_windows-installer-upgrade.yml
+++ b/.github/workflows/5_testcomponent_windows-installer-upgrade.yml
@@ -36,6 +36,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
@@ -62,8 +66,11 @@ jobs:
       - name: Compress folder
         run: 7z a win-agent-base.zip ./*
       - name: Upload base branch folder
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: win-agent-base.zip
           path: win-agent-base.zip
 
@@ -128,8 +135,11 @@ jobs:
           mkdir C:\win-agent-released
           python -m wget https://packages.wazuh.com/4.x/windows/wazuh-agent-${{ matrix.wazuh_version }}.msi -o C:\win-agent-released
       - name: Download base folder
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: win-agent-base.zip
           path: C:\win-agent-base
       - name: Unzip base folder
@@ -153,13 +163,19 @@ jobs:
           python -m pytest -vv ./test_win_upgrade.py
       - name: Upload release installation log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: release_log
           path: C:\win-agent-released\win-agent-released.log
       - name: Upload base installation log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: base_log
           path: C:\win-agent-base\win-agent-base.log

--- a/.github/workflows/5_testintegration_inventory-sync.yml
+++ b/.github/workflows/5_testintegration_inventory-sync.yml
@@ -34,6 +34,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   run-test:
     timeout-minutes: ${{ fromJSON(inputs.timeout_minutes || '60') }}
@@ -62,19 +66,14 @@ jobs:
 
       # ── Path A: use pre-built artifact ────────────────────────────────────
 
-      - name: Download manager package artifact
+      - name: Download manager package from S3
         if: inputs.build_run_id != ''
-        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
+        uses: ./.github/actions/download_manager_package
         with:
-          workflow: 5_builderpackage_manager-multiples.yml
-          run_id: ${{ inputs.build_run_id }}
-          workflow_conclusion: success
-          name_is_regexp: true
-          name: wazuh-manager.*amd64.*\.deb
-          path: /tmp/packages
-          if_no_artifact_found: fail
-          check_artifacts: true
-          search_artifacts: true
+          build_run_id: ${{ inputs.build_run_id }}
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
 
       - name: Install wazuh-manager from artifact
         if: inputs.build_run_id != ''

--- a/.github/workflows/5_testintegration_manager.yml
+++ b/.github/workflows/5_testintegration_manager.yml
@@ -50,6 +50,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}-${{ inputs.module_name || inputs.modules || 'all' }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   expand:
     name: Build execution matrix
@@ -140,19 +144,14 @@ jobs:
 
       # ── Path A: use pre-built artifact ────────────────────────────────────
 
-      - name: Download manager package artifact
+      - name: Download manager package from S3
         if: inputs.build_run_id != ''
-        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
+        uses: ./.github/actions/download_manager_package
         with:
-          workflow: 5_builderpackage_manager-multiples.yml
-          run_id: ${{ inputs.build_run_id }}
-          workflow_conclusion: success
-          name_is_regexp: true
-          name: wazuh-manager.*amd64.*\.deb
-          path: /tmp/packages
-          if_no_artifact_found: fail
-          check_artifacts: true
-          search_artifacts: true
+          build_run_id: ${{ inputs.build_run_id }}
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
 
       - name: Install wazuh-manager from artifact
         if: inputs.build_run_id != ''
@@ -276,17 +275,20 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: ${{ matrix.name }}-test-results-${{ github.run_id }}-${{ github.run_attempt }}
           path: ./tests/integration/results.html
-          retention-days: 7
 
       - name: Upload wazuh logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: wazuh-logs-${{ matrix.name }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/wazuh-logs
-          retention-days: 7
-          if-no-files-found: warn

--- a/.github/workflows/5_testintegration_vulnerability-scanner.yml
+++ b/.github/workflows/5_testintegration_vulnerability-scanner.yml
@@ -18,6 +18,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   vulnerability-scanner-integration:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -65,7 +69,10 @@ jobs:
 
       - name: Upload log files
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: QA log files
           path: ${{ github.workspace }}/qa_logs

--- a/.github/workflows/5_testunit_contentmanager.yml
+++ b/.github/workflows/5_testunit_contentmanager.yml
@@ -17,6 +17,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   contentmanager-modules:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -54,6 +58,8 @@ jobs:
       - name: Content manager - Coverage
         uses: ./.github/actions/coverage_cpp
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/shared_modules/content_manager
           id: content_manager
           threshold: "65"

--- a/.github/workflows/5_testunit_indexerconnector.yml
+++ b/.github/workflows/5_testunit_indexerconnector.yml
@@ -17,6 +17,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   indexerconnector-modules:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -54,6 +58,8 @@ jobs:
       - name: Indexer connector - Coverage
         uses: ./.github/actions/coverage_cpp
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/shared_modules/indexer_connector
           id: indexer_connector
           validate_function_coverage: "false"

--- a/.github/workflows/5_testunit_inventorysync.yml
+++ b/.github/workflows/5_testunit_inventorysync.yml
@@ -17,6 +17,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   inventorysync-modules:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -54,6 +58,8 @@ jobs:
       - name: Inventory sync - Coverage
         uses: ./.github/actions/coverage_cpp
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/wazuh_modules/inventory_sync
           test_directory: src/wazuh_modules/inventory_sync
           id: inventory_sync

--- a/.github/workflows/5_testunit_router.yml
+++ b/.github/workflows/5_testunit_router.yml
@@ -17,6 +17,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   router-modules:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -54,6 +58,8 @@ jobs:
       - name: Router - Coverage
         uses: ./.github/actions/coverage_cpp
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/shared_modules/router
           id: router
           validate_function_coverage: "false"

--- a/.github/workflows/5_testunit_shared_modules_utils.yml
+++ b/.github/workflows/5_testunit_shared_modules_utils.yml
@@ -16,6 +16,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   shared_modules_utils-modules:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -56,6 +60,8 @@ jobs:
       - name: Shared modules utils - Coverage
         uses: ./.github/actions/coverage_cpp
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/shared_modules/utils
           id: utils_utest
           validate_function_coverage: "false"

--- a/.github/workflows/5_testunit_vulnerability-scanner.yml
+++ b/.github/workflows/5_testunit_vulnerability-scanner.yml
@@ -18,6 +18,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   vulnerability-scanner-modules:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -58,6 +62,8 @@ jobs:
       - name: Vulnerability scanner - Coverage
         uses: ./.github/actions/coverage_cpp
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/wazuh_modules/vulnerability_scanner
           id: vulnerability_scanner
           validate_function_coverage: "false"

--- a/.github/workflows/6_builderpackage_server.yml
+++ b/.github/workflows/6_builderpackage_server.yml
@@ -94,6 +94,11 @@ env:
   S3_PRECOMPILED_STORE: s3://xdrsiem-packages-dev-internal/development/wazuh/6.x/main/engine-store/store.tar.gz
   LOCAL_PRECOMPILED_STORE_PATH: src/engine/engine_precompiled_store.tar.gz # Also used in the build script
 
+permissions:
+  id-token: write
+  contents: read
+  packages: read
+
 jobs:
   Build-server-packages:
     runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && format('codebuild-github-actions-codebuild-runner-server-arm-{0}-{1}', github.run_id, github.run_attempt) || 'ubuntu-24.04' }}
@@ -208,18 +213,22 @@ jobs:
           fi
 
       - name: Upload package to GitHub
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: ${{ env.PACKAGE_NAME }}
           path: /tmp/${{ env.PACKAGE_NAME }}
-          if-no-files-found: error
 
       - name: Upload debug symbols to GitHub
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: ${{ env.PACKAGE_SYMBOLS_NAME }}
           path: /tmp/${{ env.PACKAGE_SYMBOLS_NAME }}
-          if-no-files-found: error
 
       - name: Upload package to S3
         working-directory: packages


### PR DESCRIPTION
## Description

Part of the [GitHub artifacts migration to S3](https://github.com/wazuh/wazuh-automation/issues/3502). Migrates the **agent (#5300)** and **server/shared (#5298)** CI GitHub Actions artifacts to an internal CI S3 bucket, replacing `actions/upload-artifact` / `actions/download-artifact` with composite actions that `aws s3 cp` against:

```
s3://<bucket>/<repository>/<workflow>/<artifact-name>/artifacts_<run_id>.zip
```

> Neither the bucket URI nor the role ARN is hardcoded — both are provided via repository secrets (`CI_INTERNAL_S3_BUCKET`, `CI_OIDC_ROLE_ARN`) and passed per call, so these private identifiers don't appear in source or logs. **DevOps must create both secrets** (alongside the existing `CI_AWS_REGION`) or the artifact/auth steps will fail.

Authentication is OIDC (`aws-actions/configure-aws-credentials@v6` with `permissions: id-token: write`), following the pattern from wazuh/wazuh-indexer#1674.

Resolves https://github.com/wazuh/internal-devel-requests/issues/5300
Resolves https://github.com/wazuh/internal-devel-requests/issues/5298

> Targets the **5.0.0** release branch. The 4.14.7 counterpart is #37186.

## Proposed changes

**New composite actions**
- `.github/actions/upload_s3_artifact` — archives the path and uploads it to S3.
- `.github/actions/download_s3_artifact` — downloads from S3 and extracts it.

Drop-in replacements for the GitHub artifact actions. They configure OIDC credentials internally, so a calling job only needs `permissions: id-token: write`. Archiving prefers `7z`, then `zip`, then a `python3` `zipfile` fallback for runner images that ship neither (the arm64 CodeBuild agent image).

**Agent (#5300)**
- Per-module RTR coverage (8): `5_testcomponent_{syscheck,syscollector,sca,agent_info,agent_metadata,sync_protocol,shared_modules_file_helper,schema_validator}-rtr`
- Windows component (3): `5_testcomponent_{windows-dll-hijack,windows-files,windows-installer-upgrade}`

**Server / shared (#5298)**
- Shared composite actions (5): `check_files`, `clang_format`, `coverage`, `coverage_cpp`, `doxygen` — now upload via `upload_s3_artifact` (they gain an `aws_region` input).
- Package build: `5_builderpackage_{manager,manager-multiples}`, `6_builderpackage_server` — the package → integration-test handoff moves to S3; the existing publish to the packages bucket (static keys) is unchanged.
- Code analysis: `5_codeanalysis_{coverity,scanbuild}`, `5_codelinter_clangformat`.
- Tests: `5_testintegration_{manager,vulnerability-scanner}`, `5_testunit_{contentmanager,indexerconnector,inventorysync,router,shared_modules_utils,vulnerability-scanner}`.
- `5_builderpackage_agent-linux`: the `test-deb`/`test-rpm` jobs gain `id-token` for the migrated `check_files`; the package-artifact handoffs stay on GitHub artifacts (out of scope — they use `download-artifact` patterns).

## Authentication

OIDC via `aws-actions/configure-aws-credentials@v6`. The composite actions assume a DevOps-provided IAM role scoped to `GetObject`/`PutObject` on the bucket; the role ARN is passed per call via the `CI_OIDC_ROLE_ARN` secret rather than hardcoded, so neither the role nor the AWS account ID appears in source or logs. Workflows that upload/download directly pass `aws_region: ${{ secrets.CI_AWS_REGION }}`, `bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}` and `aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}` per call; workflows that only invoke the shared composite actions pass `bucket` and `aws_role` and add `permissions: id-token: write` (the shared actions default the region to `us-east-1`). Reusable workflows (`manager`, called by `manager-multiples`) propagate `id-token` from the calling job.

> DevOps: the role's trust policy must allow the `pull_request` OIDC subject (`repo:wazuh/wazuh:pull_request`), since these run mostly on PRs.

## Notes on the 5.0.0 retarget

5.0.0 predates `main`'s actions-refactoring consolidation, so its agent coverage workflows are the **per-module** `*-rtr` set (there is no `rtr-router`), and `agent-linux` keeps the separate deb/rpm build/test/upload jobs. The migration was re-derived against that structure rather than rebased from `main`.

## Out of scope

Engine artifacts (`engine-standalone` and engine tests), agent integration tests (the MSI cross-workflow handoff), agent package builds (`agent-macos`/`agent-windows`/`agent-linux-arm64`), `legacy_unit_tests_run`, and the toolchain/externals workflows.

## Tests / evidence

The composite actions and migration pattern are validated **green end-to-end** on the 4.14.7 PR (#37186) across every artifact shape — cross-job build→test, leaf-file, leaf-glob coverage, and real package builds uploading `.deb`/`.rpm` to S3.

On 5.0.0 the `5_testcomponent_*` / `5_*` workflows skip while this PR is a draft (`if: github.event_name != 'pull_request' || !github.event.pull_request.draft`), so they are validated either via `workflow_dispatch` on the branch (which exercises OIDC under a branch-ref subject) or by marking the PR ready for review. `actionlint` is clean on the changed workflows (only pre-existing warnings remain).
