### PR TITLE
Migrate agent + server CI artifacts to S3 — 4.14.7 (#5300, #5298)

### DIFF
--- a/.github/actions/check_files/action.yml
+++ b/.github/actions/check_files/action.yml
@@ -2,6 +2,19 @@ name: "Check installed files"
 description: "Validates that the installed files are the ones expected and with the right stats"
 
 inputs:
+  aws_region:
+    description: "AWS region for S3 (pass the CI_AWS_REGION secret)."
+    required: false
+    default: "us-east-1"
+
+  bucket:
+    description: "Target S3 bucket URI (pass the CI_INTERNAL_S3_BUCKET secret)."
+    required: false
+    default: ""
+  aws_role:
+    description: "IAM role (OIDC) to assume for S3 access (pass the CI_OIDC_ROLE_ARN secret)."
+    required: false
+    default: ""
   expected_files:
     required: true
     description: "Path to the 'expected files' CSV file"
@@ -68,8 +81,11 @@ runs:
 
   - name: Upload current stats
     if: success()
-    uses: actions/upload-artifact@v4
+    uses: ./.github/actions/upload_s3_artifact
     with:
+      aws_region: ${{ inputs.aws_region }}
+      bucket: ${{ inputs.bucket }}
+      aws_role: ${{ inputs.aws_role }}
       name: current_stats_${{ env.UUID }}
       path: ${{ inputs.current_status }}
 
@@ -88,8 +104,11 @@ runs:
 
   - name: Upload validation results
     if: always()
-    uses: actions/upload-artifact@v4
+    uses: ./.github/actions/upload_s3_artifact
     with:
+      aws_region: ${{ inputs.aws_region }}
+      bucket: ${{ inputs.bucket }}
+      aws_role: ${{ inputs.aws_role }}
       name: validation_results_${{ env.UUID }}
       path: ${{ inputs.report_file }}
 

--- a/.github/actions/clang_format/action.yml
+++ b/.github/actions/clang_format/action.yml
@@ -2,6 +2,19 @@ name: "Coding style check"
 description: "Validates the Coding style of a given module"
 
 inputs:
+  aws_region:
+    description: "AWS region for S3 (pass the CI_AWS_REGION secret)."
+    required: false
+    default: "us-east-1"
+
+  bucket:
+    description: "Target S3 bucket URI (pass the CI_INTERNAL_S3_BUCKET secret)."
+    required: false
+    default: ""
+  aws_role:
+    description: "IAM role (OIDC) to assume for S3 access (pass the CI_OIDC_ROLE_ARN secret)."
+    required: false
+    default: ""
   path:
     required: true
     description: "Path to validate"
@@ -113,9 +126,11 @@ runs:
           fi
 
       # Upload errors as an artifact, when failed
-      - uses: actions/upload-artifact@v4
+      - uses: ./.github/actions/upload_s3_artifact
         if: failure()
         with:
+          aws_region: ${{ inputs.aws_region }}
+          bucket: ${{ inputs.bucket }}
+          aws_role: ${{ inputs.aws_role }}
           name: Clang-format errors - ${{ inputs.id }}
           path: ${{ inputs.path }}/clang_format_errors.txt
-          retention-days: 1

--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -2,6 +2,19 @@ name: "Coverage"
 description: "Calculates the coverage for a module located on a given path"
 
 inputs:
+  aws_region:
+    description: "AWS region for S3 (pass the CI_AWS_REGION secret)."
+    required: false
+    default: "us-east-1"
+
+  bucket:
+    description: "Target S3 bucket URI (pass the CI_INTERNAL_S3_BUCKET secret)."
+    required: false
+    default: ""
+  aws_role:
+    description: "IAM role (OIDC) to assume for S3 access (pass the CI_OIDC_ROLE_ARN secret)."
+    required: false
+    default: ""
   path:
     required: true
     description: "Path to the module"
@@ -99,11 +112,13 @@ runs:
       # Upload the coverage report as an artifact
       - name: Uploading coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ inputs.aws_region }}
+          bucket: ${{ inputs.bucket }}
+          aws_role: ${{ inputs.aws_role }}
           name: Coverage Report - ${{ inputs.id }}
           path: ./${{ inputs.path }}/build/coverage_report
-          retention-days: 1
 
       # Check whether the coverage is greater than 90% both for lines and functions
       - name: Validate coverage

--- a/.github/actions/coverage_cpp/action.yml
+++ b/.github/actions/coverage_cpp/action.yml
@@ -2,6 +2,19 @@ name: "Coverage CPP"
 description: "Calculates the coverage for a module located on a given path"
 
 inputs:
+  aws_region:
+    description: "AWS region for S3 (pass the CI_AWS_REGION secret)."
+    required: false
+    default: "us-east-1"
+
+  bucket:
+    description: "Target S3 bucket URI (pass the CI_INTERNAL_S3_BUCKET secret)."
+    required: false
+    default: ""
+  aws_role:
+    description: "IAM role (OIDC) to assume for S3 access (pass the CI_OIDC_ROLE_ARN secret)."
+    required: false
+    default: ""
   path:
     required: true
     description: "Path to the module"
@@ -84,11 +97,13 @@ runs:
       # Upload the coverage report as an artifact
       - name: Uploading coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ inputs.aws_region }}
+          bucket: ${{ inputs.bucket }}
+          aws_role: ${{ inputs.aws_role }}
           name: Coverage Report - ${{ inputs.id }}
           path: ./src/build/coverage_report
-          retention-days: 1
 
       # Check whether the coverage is greater than 90% both for lines and functions
       - name: Validate coverage

--- a/.github/actions/download_s3_artifact/action.yml
+++ b/.github/actions/download_s3_artifact/action.yml
@@ -1,0 +1,113 @@
+name: "Download artifact from S3"
+description: >
+  Drop-in replacement for actions/download-artifact that retrieves an artifact from
+  the internal CI S3 bucket (passed via the CI_INTERNAL_S3_BUCKET secret) instead of GitHub artifact storage
+  (see https://github.com/wazuh/wazuh-automation/issues/3502).
+  Downloads and extracts the archive previously uploaded by upload_s3_artifact from:
+    <bucket>/<repository>/<workflow>/<name>/artifacts_<run_id>.zip
+  AWS credentials are configured by the action itself via OIDC, so the calling
+  job only needs `permissions: id-token: write`. Pass the region via the
+  `aws_region` input (set it to the CI_AWS_REGION secret at the call site).
+  Requires `7z` and the AWS CLI on the runner.
+
+inputs:
+  name:
+    description: "Artifact name. Must match the name used by the producer upload_s3_artifact step."
+    required: true
+  path:
+    description: "Destination directory for the extracted files. Defaults to the current directory."
+    required: false
+    default: ""
+  bucket:
+    description: "Source S3 bucket URI."
+    required: false
+    default: ""
+  aws_role:
+    description: "IAM role (OIDC) to assume for S3 access (pass the CI_OIDC_ROLE_ARN secret)."
+    required: false
+    default: ""
+  aws_region:
+    description: "Fallback AWS region, used only when the AWS_REGION environment variable is not set."
+    required: false
+    default: "us-east-1"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Resolve S3 key for ${{ inputs.name }}"
+      id: key
+      shell: bash
+      env:
+        ARTIFACT_NAME: ${{ inputs.name }}
+        BUCKET: ${{ inputs.bucket }}
+        REPO_NAME: ${{ github.event.repository.name }}
+        WORKFLOW_REF: ${{ github.workflow_ref }}
+        RUN_ID: ${{ github.run_id }}
+      run: |
+        set -euo pipefail
+        # Derive the workflow file basename, e.g. 4_testcomponent_sysinfo-windows
+        ref_no_at="${WORKFLOW_REF%@*}"
+        wf_file="${ref_no_at##*/}"
+        wf="${wf_file%.*}"
+        # Make the artifact name safe for use as a single S3 key segment
+        safe_name="$(printf '%s' "$ARTIFACT_NAME" | tr ' /\\:' '____')"
+        echo "s3_uri=${BUCKET}/${REPO_NAME}/${wf}/${safe_name}/artifacts_${RUN_ID}.zip" >> "$GITHUB_OUTPUT"
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: ${{ inputs.aws_role }}
+        aws-region: ${{ inputs.aws_region }}
+
+    - name: "Download ${{ inputs.name }} from S3 (Unix)"
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        ARTIFACT_NAME: ${{ inputs.name }}
+        DEST_PATH: ${{ inputs.path }}
+        S3_URI: ${{ steps.key.outputs.s3_uri }}
+      run: |
+        set -euo pipefail
+        tmp="$(mktemp -d)"
+        zip_file="${tmp}/artifacts.zip"
+        aws s3 cp "$S3_URI" "$zip_file" --only-show-errors
+        dest="${DEST_PATH:-.}"
+        mkdir -p "$dest"
+        # Extract: prefer 7z, then unzip, then a Python fallback for runner images
+        # that ship neither (e.g. the arm64 CodeBuild agent image).
+        if command -v 7z >/dev/null 2>&1; then
+          7z x -y "$zip_file" -o"$dest" >/dev/null
+        elif command -v unzip >/dev/null 2>&1; then
+          unzip -o -q "$zip_file" -d "$dest"
+        else
+          python3 - "$zip_file" "$dest" <<'PY'
+        import sys, zipfile
+        with zipfile.ZipFile(sys.argv[1]) as z:
+            z.extractall(sys.argv[2])
+        PY
+        fi
+        echo "Downloaded artifact '${ARTIFACT_NAME}' from ${S3_URI} into ${dest}"
+
+    - name: "Download ${{ inputs.name }} from S3 (Windows)"
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        ARTIFACT_NAME: ${{ inputs.name }}
+        DEST_PATH: ${{ inputs.path }}
+        S3_URI: ${{ steps.key.outputs.s3_uri }}
+      run: |
+        $ErrorActionPreference = "Stop"
+        $tmp = Join-Path $env:RUNNER_TEMP ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+        $zip = Join-Path $tmp "artifacts.zip"
+        aws s3 cp $env:S3_URI $zip --only-show-errors
+        $dest = if ([string]::IsNullOrEmpty($env:DEST_PATH)) { "." } else { $env:DEST_PATH }
+        New-Item -ItemType Directory -Force -Path $dest | Out-Null
+        # Prefer 7z; fall back to PowerShell's native Expand-Archive for runner
+        # images that lack 7z (e.g. the CodeBuild Windows image).
+        if (Get-Command 7z -ErrorAction SilentlyContinue) {
+          7z x -y $zip "-o$dest" | Out-Null
+        } else {
+          Expand-Archive -Path $zip -DestinationPath $dest -Force
+        }
+        Write-Host "Downloaded artifact '$env:ARTIFACT_NAME' from $env:S3_URI into $dest"

--- a/.github/actions/doxygen/action.yml
+++ b/.github/actions/doxygen/action.yml
@@ -2,6 +2,19 @@ name: "Doxygen documentation generartion"
 description: "Generates the documentation for a given module"
 
 inputs:
+  aws_region:
+    description: "AWS region for S3 (pass the CI_AWS_REGION secret)."
+    required: false
+    default: "us-east-1"
+
+  bucket:
+    description: "Target S3 bucket URI (pass the CI_INTERNAL_S3_BUCKET secret)."
+    required: false
+    default: ""
+  aws_role:
+    description: "IAM role (OIDC) to assume for S3 access (pass the CI_OIDC_ROLE_ARN secret)."
+    required: false
+    default: ""
   path:
     required: true
     description: "Path to the module we want to generate documentation for"
@@ -58,17 +71,21 @@ runs:
           fi
 
       # Upload errors as an artifact, when failed
-      - uses: actions/upload-artifact@v4
+      - uses: ./.github/actions/upload_s3_artifact
         if: failure()
         with:
+          aws_region: ${{ inputs.aws_region }}
+          bucket: ${{ inputs.bucket }}
+          aws_role: ${{ inputs.aws_role }}
           name: Doxygen errors - ${{ inputs.id }}
           path: ${{ inputs.path }}/doxygen_errors.txt
-          retention-days: 1
 
       # Upload the documentation as an artifact, when successful
-      - uses: actions/upload-artifact@v4
+      - uses: ./.github/actions/upload_s3_artifact
         if: success()
         with:
+          aws_region: ${{ inputs.aws_region }}
+          bucket: ${{ inputs.bucket }}
+          aws_role: ${{ inputs.aws_role }}
           name: Doxygen Documentation - ${{ inputs.id }}
           path: ${{ inputs.path }}/doc
-          retention-days: 1

--- a/.github/actions/upload_s3_artifact/action.yml
+++ b/.github/actions/upload_s3_artifact/action.yml
@@ -1,0 +1,157 @@
+name: "Upload artifact to S3"
+description: >
+  Drop-in replacement for actions/upload-artifact that stores the artifact in the
+  internal CI S3 bucket (passed via the CI_INTERNAL_S3_BUCKET secret) instead of GitHub artifact storage
+  (see https://github.com/wazuh/wazuh-automation/issues/3502).
+  The artifact is archived with 7-Zip and uploaded to:
+    <bucket>/<repository>/<workflow>/<name>/artifacts_<run_id>.zip
+  AWS credentials are configured by the action itself via OIDC, so the calling
+  job only needs `permissions: id-token: write`. Pass the region via the
+  `aws_region` input (set it to the CI_AWS_REGION secret at the call site).
+  Requires `7z` and the AWS CLI on the runner (present on the CodeBuild and
+  GitHub-hosted windows-2025 images used by these workflows).
+
+inputs:
+  name:
+    description: "Artifact name. Must match the name used by the consumer download_s3_artifact step."
+    required: true
+  path:
+    description: "File, directory or wildcard to upload (same intent as actions/upload-artifact `path`)."
+    required: true
+  bucket:
+    description: "Target S3 bucket URI."
+    required: false
+    default: ""
+  aws_role:
+    description: "IAM role (OIDC) to assume for S3 access (pass the CI_OIDC_ROLE_ARN secret)."
+    required: false
+    default: ""
+  aws_region:
+    description: "Fallback AWS region, used only when the AWS_REGION environment variable is not set."
+    required: false
+    default: "us-east-1"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Resolve S3 key for ${{ inputs.name }}"
+      id: key
+      shell: bash
+      env:
+        ARTIFACT_NAME: ${{ inputs.name }}
+        BUCKET: ${{ inputs.bucket }}
+        REPO_NAME: ${{ github.event.repository.name }}
+        WORKFLOW_REF: ${{ github.workflow_ref }}
+        RUN_ID: ${{ github.run_id }}
+      run: |
+        set -euo pipefail
+        # Derive the workflow file basename, e.g. 4_testcomponent_sysinfo-windows
+        ref_no_at="${WORKFLOW_REF%@*}"
+        wf_file="${ref_no_at##*/}"
+        wf="${wf_file%.*}"
+        # Make the artifact name safe for use as a single S3 key segment
+        safe_name="$(printf '%s' "$ARTIFACT_NAME" | tr ' /\\:' '____')"
+        echo "s3_uri=${BUCKET}/${REPO_NAME}/${wf}/${safe_name}/artifacts_${RUN_ID}.zip" >> "$GITHUB_OUTPUT"
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: ${{ inputs.aws_role }}
+        aws-region: ${{ inputs.aws_region }}
+
+    - name: "Upload ${{ inputs.name }} to S3 (Unix)"
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        ARTIFACT_NAME: ${{ inputs.name }}
+        ARTIFACT_PATH: ${{ inputs.path }}
+        S3_URI: ${{ steps.key.outputs.s3_uri }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob globstar 2>/dev/null || true
+        # Archive helper: prefer 7z, then zip, then a Python fallback for runner
+        # images that ship neither (e.g. the arm64 CodeBuild agent image).
+        mkzip() {
+          if command -v 7z >/dev/null 2>&1; then
+            7z a -tzip -y "$zip_file" "$@" >/dev/null
+          elif command -v zip >/dev/null 2>&1; then
+            zip -q -r "$zip_file" "$@" >/dev/null
+          else
+            python3 - "$zip_file" "$@" <<'PY'
+        import os, sys, zipfile
+        with zipfile.ZipFile(sys.argv[1], "w", zipfile.ZIP_DEFLATED) as z:
+            for a in sys.argv[2:]:
+                if os.path.isdir(a):
+                    for root, _, files in os.walk(a):
+                        for n in files:
+                            full = os.path.join(root, n)
+                            z.write(full, os.path.relpath(full, a))
+                elif os.path.isfile(a):
+                    z.write(a, os.path.basename(a))
+        PY
+          fi
+        }
+        tmp="$(mktemp -d)"
+        zip_file="${tmp}/artifacts.zip"
+        p="$ARTIFACT_PATH"
+        if [ -d "$p" ]; then
+          ( cd "$p" && mkzip . )
+        elif [ -f "$p" ]; then
+          mkzip "$p"
+        else
+          # Wildcard: stage the matching files into a tree (preserving relative
+          # paths) and archive that, so 7-Zip does not flatten them to basenames
+          # (which collides when several dirs contain the same filename).
+          stage="$(mktemp -d)"
+          found=0
+          for m in $p; do
+            if [ -f "$m" ]; then
+              mkdir -p "${stage}/$(dirname "$m")"
+              cp "$m" "${stage}/${m}"
+              found=1
+            fi
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "::warning::No files found for path '${p}'; skipping upload of artifact '${ARTIFACT_NAME}'."
+            exit 0
+          fi
+          ( cd "$stage" && mkzip . )
+        fi
+        aws s3 cp "$zip_file" "$S3_URI" --only-show-errors
+        echo "Uploaded artifact '${ARTIFACT_NAME}' to ${S3_URI}"
+
+    - name: "Upload ${{ inputs.name }} to S3 (Windows)"
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        ARTIFACT_NAME: ${{ inputs.name }}
+        ARTIFACT_PATH: ${{ inputs.path }}
+        S3_URI: ${{ steps.key.outputs.s3_uri }}
+      run: |
+        $ErrorActionPreference = "Stop"
+        $tmp = Join-Path $env:RUNNER_TEMP ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+        $zip = Join-Path $tmp "artifacts.zip"
+        $p = $env:ARTIFACT_PATH
+        # Prefer 7z; fall back to PowerShell's native Compress-Archive for runner
+        # images that lack 7z (e.g. the CodeBuild Windows image).
+        $have7z = [bool](Get-Command 7z -ErrorAction SilentlyContinue)
+        if (Test-Path -PathType Container -LiteralPath $p) {
+          if ($have7z) { Push-Location $p; 7z a -tzip -y $zip "." | Out-Null; Pop-Location }
+          else { Compress-Archive -Path (Join-Path $p '*') -DestinationPath $zip -Force }
+        }
+        elseif (Test-Path -PathType Leaf -LiteralPath $p) {
+          if ($have7z) { 7z a -tzip -y $zip $p | Out-Null }
+          else { Compress-Archive -Path $p -DestinationPath $zip -Force }
+        }
+        else {
+          # Treat as a wildcard
+          if ($have7z) { 7z a -tzip -y $zip $p | Out-Null }
+          else { Compress-Archive -Path $p -DestinationPath $zip -Force -ErrorAction SilentlyContinue }
+          if (-not (Test-Path -LiteralPath $zip)) {
+            Write-Warning "No files found for path '$p'; skipping upload of artifact '$env:ARTIFACT_NAME'."
+            exit 0
+          }
+        }
+        aws s3 cp $zip $env:S3_URI --only-show-errors
+        Write-Host "Uploaded artifact '$env:ARTIFACT_NAME' to $env:S3_URI"

--- a/.github/workflows/4_builderpackage_manager-multiples.yml
+++ b/.github/workflows/4_builderpackage_manager-multiples.yml
@@ -30,6 +30,11 @@ on:
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
 
+permissions:
+  id-token: write
+  contents: read
+  packages: read
+
 jobs:
   select-targets:
     name: Select build targets (Wazuh Managers)

--- a/.github/workflows/4_builderpackage_manager.yml
+++ b/.github/workflows/4_builderpackage_manager.yml
@@ -96,6 +96,11 @@ on:
         type: string
         required: false
 
+permissions:
+  id-token: write
+  contents: read
+  packages: read
+
 jobs:
   Build-manager-packages:
     env:
@@ -250,6 +255,8 @@ jobs:
       - name: Check installed files
         uses: ./.github/actions/check_files
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           expected_files: manager_base.csv
           wazuh_uid: ${{ env.WAZUH_UID }}
           wazuh_gid: ${{ env.WAZUH_GID }}
@@ -382,19 +389,23 @@ jobs:
 
       - name: Upload package to GitHub
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: ${{ env.PACKAGE_NAME }}
           path: /tmp/${{ env.PACKAGE_NAME }}
-          if-no-files-found: error
 
       - name: Upload debug symbols to GitHub
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: ${{ env.PACKAGE_SYMBOLS_NAME }}
           path: /tmp/${{ env.PACKAGE_SYMBOLS_NAME }}
-          if-no-files-found: error
 
       - name: Set up AWS CLI
         if: ${{ env.SHOULD_UPLOAD == 'true' }}

--- a/.github/workflows/4_builderprecompiled_vdscanner-testtools.yml
+++ b/.github/workflows/4_builderprecompiled_vdscanner-testtools.yml
@@ -35,6 +35,10 @@ env:
   TOOLS_DIR: ${{github.workspace}}/src/wazuh_modules/vulnerability_scanner/build/testtool/
   TOOLS_FILE_NAME: legacy_vdscanner_testtools
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     name: VD Scanner Tools Delivery
@@ -126,10 +130,10 @@ jobs:
       # Upload vdscanner tools
       - name: Upload vdscanner tools
         if: ${{ success() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: ${{env.TOOLS_FILE_NAME}}
           path: ${{env.TOOLS_FILE_NAME}}.tar.xz
-          if-no-files-found: error
-          compression-level: 0
-          overwrite: true

--- a/.github/workflows/4_codeanalysis_coverity.yml
+++ b/.github/workflows/4_codeanalysis_coverity.yml
@@ -19,6 +19,10 @@ on:
 env:
   REGISTRY: ghcr.io
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   prepare:
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
@@ -94,8 +98,11 @@ jobs:
         run: tar czf wazuh.tgz cov-int
 
       - name: Upload Coverity artifact
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: wazuh.tgz
           path: wazuh.tgz
 
@@ -109,8 +116,11 @@ jobs:
           ref: ${{ github.ref_name }}
 
       - name: Download Coverity artifact
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: wazuh.tgz
 
       - name: Upload to Coverity Scan

--- a/.github/workflows/4_codeanalysis_scanbuild.yml
+++ b/.github/workflows/4_codeanalysis_scanbuild.yml
@@ -6,6 +6,10 @@ on:
       - "src/**"
       - ".github/workflows/4_codeanalysis_scanbuild.yml"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   scan-build-linux:
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
@@ -35,8 +39,11 @@ jobs:
           scan-build-14 --status-bugs --force-analyze-debug-code -o scan-build-report --exclude external/ make TARGET=${{ matrix.target }} DEBUG=1 -j$(nproc)
       - name: Upload scan-build report
         if: steps.build_step.outcome == 'failure'
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: linux-${{ matrix.target }}-scan-build-report
           path: src/scan-build-report/
       - name: Fail job if build failed
@@ -69,8 +76,11 @@ jobs:
           scan-build-14 --status-bugs --use-cc=/usr/bin/i686-w64-mingw32-gcc --use-c++=/usr/bin/i686-w64-mingw32-g++-posix --analyzer-target=i686-w64-mingw32 --force-analyze-debug-code -o scan-build-report --exclude external/ make TARGET=winagent DEBUG=1 -j$(nproc)
       - name: Upload scan-build report
         if: steps.build_step.outcome == 'failure'
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: windows-agent-scan-build-report
           path: src/scan-build-report/
       - name: Fail job if build failed
@@ -95,8 +105,11 @@ jobs:
           /opt/homebrew/opt/llvm@14/bin/scan-build --status-bugs --force-analyze-debug-code -o scan-build-report --exclude external/ make TARGET=agent DEBUG=1 -j3
       - name: Upload scan-build report
         if: steps.build_step.outcome == 'failure'
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: macos-agent-scan-build-report
           path: src/scan-build-report/
       - name: Fail job if build failed

--- a/.github/workflows/4_codelinter_clangformat.yml
+++ b/.github/workflows/4_codelinter_clangformat.yml
@@ -6,6 +6,10 @@ on:
     # Pull request events
     types: [synchronize, opened, reopened, ready_for_review]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   style:
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
@@ -25,4 +29,6 @@ jobs:
       - name: Inventory harvester - Coding style
         uses: ./.github/actions/clang_format
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/wazuh_modules/inventory_harvester

--- a/.github/workflows/4_testcomponent_indexer-connector.yml
+++ b/.github/workflows/4_testcomponent_indexer-connector.yml
@@ -13,6 +13,11 @@ on:
       - "src/shared_modules/indexer_connector/**"
       - "src/wazuh_modules/http-request/**"
 
+permissions:
+  id-token: write
+  contents: read
+  packages: read
+
 jobs:
   indexer_connector-qa:
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
@@ -63,7 +68,10 @@ jobs:
       # Upload log files of the tests
       - name: Upload log files
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: QA log files
           path: ${{ github.workspace }}/qa_logs

--- a/.github/workflows/4_testcomponent_syscheck-rtr.yml
+++ b/.github/workflows/4_testcomponent_syscheck-rtr.yml
@@ -12,6 +12,10 @@ on:
       - ".github/workflows/4_testcomponent_syscheck-rtr.yml"
       - ".github/actions/**"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   rtr:
     strategy:
@@ -41,7 +45,10 @@ jobs:
           python build.py --target ${{ matrix.target }} --readytoreview ${{ matrix.module }}
       - name: Uploading coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: coverage_report ${{ matrix.target }}
           path: ./**/coverage_report/**

--- a/.github/workflows/4_testcomponent_syscollector-rtr.yml
+++ b/.github/workflows/4_testcomponent_syscollector-rtr.yml
@@ -13,6 +13,10 @@ on:
       - ".github/workflows/4_testcomponent_syscollector-rtr.yml"
       - ".github/actions/**"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   rtr:
     strategy:
@@ -58,7 +62,10 @@ jobs:
           echo "ARTIFACT_NAME=$name" >> $GITHUB_ENV
       - name: Uploading coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: coverage_report ${{ env.ARTIFACT_NAME }} ${{ matrix.target }}
           path: ./**/coverage_report/**

--- a/.github/workflows/4_testcomponent_sysinfo-windows.yml
+++ b/.github/workflows/4_testcomponent_sysinfo-windows.yml
@@ -10,6 +10,10 @@ on:
       - "src/wazuh_modules/syscollector/**"
       - "src/Makefile"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
@@ -36,32 +40,47 @@ jobs:
           cp src/win32/libwinpthread-1.dll src/shared_libraries/
       # Upload build artifacts for the shared libraries.
       - name: Upload Artifact shared_libraries
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: shared_libraries
           path: src/shared_libraries
       # Upload build artifacts for the data provider.
       - name: Upload Artifact data_provider
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: data_provider
           path: src/data_provider/build/bin
       # Upload build artifacts for dbsync.
       - name: Upload Artifact dbsync
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: dbsync
           path: src/shared_modules/dbsync/build/bin
       # Upload build artifacts for rsync.
       - name: Upload Artifact rsync
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: rsync
           path: src/shared_modules/rsync/build/bin
       # Upload build artifacts for syscollector.
       - name: Upload Artifact syscollector
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: syscollector
           path: src/wazuh_modules/syscollector/build/bin
   run-on-windows:
@@ -76,28 +95,43 @@ jobs:
           python-version-file: ".github/workflows/.python-version"
           architecture: x64
       - name: Download Artifact data_provider
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: data_provider
           path: C:\data_provider\
       - name: Download Artifact dbsync
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: dbsync
           path: C:\dbsync\
       - name: Download Artifact rsync
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: rsync
           path: C:\rsync\
       - name: Download Artifact syscollector
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: syscollector
           path: C:\syscollector\
       - name: Download Artifact shared_libraries
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: shared_libraries
           path: C:\shared_libraries\
       # Copy dbsync, rsync and sysinfo libraries into syscollector.

--- a/.github/workflows/4_testcomponent_vulnerability-scanner.yml
+++ b/.github/workflows/4_testcomponent_vulnerability-scanner.yml
@@ -17,6 +17,10 @@ on:
       - "src/wazuh_modules/http-request/**"
       - "src/shared_modules/utils/**"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   style-and-documentation:
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
@@ -75,6 +79,8 @@ jobs:
         if: env.ROUTER
         uses: ./.github/actions/clang_format
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/shared_modules/router
           id: router
 
@@ -82,6 +88,8 @@ jobs:
         if: env.ROUTER
         uses: ./.github/actions/doxygen
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/shared_modules/router
           id: router
 
@@ -90,6 +98,8 @@ jobs:
         if: env.INDEXER_CONNECTOR
         uses: ./.github/actions/clang_format
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/shared_modules/indexer_connector
           id: indexer_connector
 
@@ -97,6 +107,8 @@ jobs:
         if: env.INDEXER_CONNECTOR
         uses: ./.github/actions/doxygen
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/shared_modules/indexer_connector
           id: indexer_connector
 
@@ -105,6 +117,8 @@ jobs:
         if: env.CONTENT_MANAGER
         uses: ./.github/actions/clang_format
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/shared_modules/content_manager
           id: content_manager
 
@@ -112,6 +126,8 @@ jobs:
         if: env.CONTENT_MANAGER
         uses: ./.github/actions/doxygen
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/shared_modules/content_manager
           id: content_manager
 
@@ -120,6 +136,8 @@ jobs:
         if: env.VULNERABILITY_SCANNER
         uses: ./.github/actions/clang_format
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/wazuh_modules/vulnerability_scanner
           id: vulnerability_scanner
 
@@ -127,6 +145,8 @@ jobs:
         if: env.VULNERABILITY_SCANNER
         uses: ./.github/actions/doxygen
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/wazuh_modules/vulnerability_scanner
           id: vulnerability_scanner
 
@@ -159,6 +179,8 @@ jobs:
       - name: Router - Coverage
         uses: ./.github/actions/coverage
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/shared_modules/router
           id: router
 
@@ -171,6 +193,8 @@ jobs:
       - name: Indexer connector - Coverage
         uses: ./.github/actions/coverage
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/shared_modules/indexer_connector
           id: indexer_connector
 
@@ -183,6 +207,8 @@ jobs:
       - name: Content manager - Coverage
         uses: ./.github/actions/coverage
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/shared_modules/content_manager
           id: content_manager
 
@@ -196,6 +222,8 @@ jobs:
       - name: Utils - Coverage
         uses: ./.github/actions/coverage
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/shared_modules/utils
           id: utils
 
@@ -208,6 +236,8 @@ jobs:
       - name: Vulnerability scanner - Coverage
         uses: ./.github/actions/coverage
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/wazuh_modules/vulnerability_scanner
           id: vulnerability_scanner
 
@@ -383,7 +413,10 @@ jobs:
       # Upload log files of the tests
       - name: Upload log files
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: QA log files
           path: ${{ github.workspace }}/qa_logs

--- a/.github/workflows/4_testcomponent_windows-dll-hijack.yml
+++ b/.github/workflows/4_testcomponent_windows-dll-hijack.yml
@@ -7,6 +7,10 @@ on:
       - "src/**"
       - ".github/workflows/4_testcomponent_windows-dll-hijack.yml"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
@@ -31,8 +35,11 @@ jobs:
           rm -f src/win32/setup-*.exe
           cp src/win32/*.exe src/exe_files/
       - name: Upload Artifact executables
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: executables
           path: src/exe_files
       - name: Copy configuration files
@@ -44,8 +51,11 @@ jobs:
           sed -i 's+windows.debug=0+windows.debug=2+g' etc/internal_options.conf
           cp src/win32/internal_options.conf src/configuration_files/
       - name: Upload Artifact configuration files
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: configuration
           path: src/configuration_files
   check_dll_on_windows:
@@ -63,13 +73,19 @@ jobs:
           python-version-file: ".github/workflows/.python-version"
           architecture: x64
       - name: Download Artifact executables
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: executables
           path: C:\executables\
       - name: Download Artifact configuration files
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: configuration
           path: C:\configuration_files\
       - name: Copy configuration files
@@ -89,7 +105,10 @@ jobs:
           python -m pytest -vv ./test_dll_hijack.py
       - name: Upload .csv files
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: csv_files ${{ matrix.os }}
           path: C:\executables\*.csv

--- a/.github/workflows/4_testcomponent_windows-files.yml
+++ b/.github/workflows/4_testcomponent_windows-files.yml
@@ -6,6 +6,10 @@ on:
       - "src/**"
       - ".github/workflows/4_testcomponent_windows-files.yml"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
@@ -33,8 +37,11 @@ jobs:
           rm -f src/win32/libstdc++-6.dll
           find src/ -name "*.dll" -not -path "src/external/*" -not -path "src/win32/SimpleSC/*" -not -path "src/win32/nsProcess/*" -exec cp {} src/bin_files/ \;
       - name: Upload Artifact binaries
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: binaries
           path: src/bin_files
   check_binaries_details:
@@ -49,8 +56,11 @@ jobs:
           python-version-file: ".github/workflows/.python-version"
           architecture: x64
       - name: Download Artifact binaries
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: binaries
           path: C:\binaries\
       - name: Install dependencies

--- a/.github/workflows/4_testcomponent_windows-installer-upgrade.yml
+++ b/.github/workflows/4_testcomponent_windows-installer-upgrade.yml
@@ -6,6 +6,10 @@ on:
       - "src/**"
       - ".github/workflows/4_testcomponent_windows-installer-upgrade.yml"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
@@ -28,8 +32,11 @@ jobs:
       - name: Compress folder
         run: 7z a win-agent-base.zip ./*
       - name: Upload base branch folder
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: win-agent-base.zip
           path: win-agent-base.zip
 
@@ -58,8 +65,11 @@ jobs:
           mkdir C:\win-agent-released
           python -m wget https://packages.wazuh.com/4.x/windows/wazuh-agent-${{ matrix.wazuh_version }}.msi -o C:\win-agent-released
       - name: Download base folder
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: win-agent-base.zip
           path: C:\win-agent-base
       - name: Unzip base folder
@@ -83,13 +93,19 @@ jobs:
           python -m pytest -vv ./test_win_upgrade.py
       - name: Upload release installation log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: release_log
           path: C:\win-agent-released\win-agent-released.log
       - name: Upload base installation log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: base_log
           path: C:\win-agent-base\win-agent-base.log

--- a/.github/workflows/4_testintegration_agentd-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_agentd-tier-0-1-win.yml
@@ -19,6 +19,10 @@ on:
         - "tests/integration/conftest.py"
         - "tests/integration/test_agentd/**"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   # Build the winagent on linux.
   build:
@@ -45,8 +49,11 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: winagent
           path: src/winagent
   # Execute the tests on windows.
@@ -69,8 +76,11 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: winagent
           path: C:\winagent\
       # Decompress the winagent files.

--- a/.github/workflows/4_testintegration_api-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_api-tier-0-1.yml
@@ -16,6 +16,10 @@ on:
         - "tests/integration/conftest.py"
         - "tests/integration/test_api/**"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     env:
@@ -112,7 +116,10 @@ jobs:
       # Upload logs artifact if test fails
       - name: Upload logs artifact
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: wazuh-logs-${{ github.job }}
           path: /tmp/wazuh-logs

--- a/.github/workflows/4_testintegration_api-tier-2.yml
+++ b/.github/workflows/4_testintegration_api-tier-2.yml
@@ -8,6 +8,10 @@ on:
         required: true
         default: 'main'
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     env:
@@ -98,7 +102,10 @@ jobs:
       # Upload logs artifact if test fails
       - name: Upload logs artifact
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: wazuh-logs-${{ github.job }}
           path: /tmp/wazuh-logs

--- a/.github/workflows/4_testintegration_enrollment-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_enrollment-tier-0-1-win.yml
@@ -20,6 +20,10 @@ on:
         - "tests/integration/conftest.py"
         - "tests/integration/test_enrollment/**"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   # Build the winagent on linux.
   build:
@@ -46,8 +50,11 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: winagent
           path: src/winagent
   # Execute the tests on windows.
@@ -70,8 +77,11 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: winagent
           path: C:\winagent\
       # Decompress the winagent files.

--- a/.github/workflows/4_testintegration_execd-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_execd-tier-0-1-win.yml
@@ -18,6 +18,10 @@ on:
         - "tests/integration/conftest.py"
         - "tests/integration/test_execd/**"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   # Build the winagent on linux.
   build:
@@ -44,8 +48,11 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: winagent
           path: src/winagent
   # Execute the tests on windows.
@@ -68,8 +75,11 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: winagent
           path: C:\winagent\
       # Decompress the winagent files.

--- a/.github/workflows/4_testintegration_fim-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_fim-tier-0-1-win.yml
@@ -17,6 +17,10 @@ on:
         - "tests/integration/conftest.py"
         - "tests/integration/test_fim/**"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   # Build the winagent on linux.
   build:
@@ -43,8 +47,11 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: winagent
           path: src/winagent
   # Execute the tests on windows.
@@ -67,8 +74,11 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: winagent
           path: C:\winagent\
       # Decompress the winagent files.

--- a/.github/workflows/4_testintegration_fim-tier-2-win.yml
+++ b/.github/workflows/4_testintegration_fim-tier-2-win.yml
@@ -8,6 +8,10 @@ on:
         required: true
         default: 'main'
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   # Build the winagent on linux.
   build:
@@ -34,8 +38,11 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: winagent
           path: src/winagent
   # Execute the tests on windows.
@@ -58,8 +65,11 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: winagent
           path: C:\winagent\
       # Decompress the winagent files.

--- a/.github/workflows/4_testintegration_github-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_github-tier-0-1-win.yml
@@ -18,6 +18,10 @@ on:
         - "tests/integration/conftest.py"
         - "tests/integration/test_github/**"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   # Build the winagent on linux.
   build:
@@ -44,8 +48,11 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: winagent
           path: src/winagent
   # Execute the tests on windows.
@@ -68,8 +75,11 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: winagent
           path: C:\winagent\
       # Decompress the winagent files.

--- a/.github/workflows/4_testintegration_logcollector-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_logcollector-tier-0-1-win.yml
@@ -17,6 +17,10 @@ on:
         - "tests/integration/conftest.py"
         - "tests/integration/test_logcollector/**"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   # Build the winagent on linux.
   build:
@@ -43,8 +47,11 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: winagent
           path: src/winagent
   # Execute the tests on windows.
@@ -67,8 +74,11 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: winagent
           path: C:\winagent\
       # Decompress the winagent files.

--- a/.github/workflows/4_testintegration_office365-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_office365-tier-0-1-win.yml
@@ -18,6 +18,10 @@ on:
         - "tests/integration/conftest.py"
         - "tests/integration/test_office365/**"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   # Build the winagent on linux.
   build:
@@ -44,8 +48,11 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: winagent
           path: src/winagent
   # Execute the tests on windows.
@@ -68,8 +75,11 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: winagent
           path: C:\winagent\
       # Decompress the winagent files.

--- a/.github/workflows/4_testintegration_rbac-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_rbac-tier-0-1.yml
@@ -15,6 +15,10 @@ on:
         - "tests/integration/conftest.py"
         - "tests/integration/test_api/test_rbac/**"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     env:
@@ -103,7 +107,10 @@ jobs:
       # Upload logs artifact if test fails
       - name: Upload logs artifact
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: wazuh-logs-${{ github.job }}
           path: /tmp/wazuh-logs

--- a/.github/workflows/4_testintegration_sca-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_sca-tier-0-1-win.yml
@@ -19,6 +19,10 @@ on:
         - "tests/integration/test_sca/**"
 
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   # Build the winagent on linux.
   build:
@@ -45,8 +49,11 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: winagent
           path: src/winagent
   # Execute the tests on windows.
@@ -69,8 +76,11 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: winagent
           path: C:\winagent\
       # Decompress the winagent files.

--- a/.github/workflows/4_testintegration_syscollector-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_syscollector-tier-0-1-win.yml
@@ -17,6 +17,10 @@ on:
         - "tests/integration/conftest.py"
         - "tests/integration/test_syscollector/**"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   # Build the winagent on linux.
   build:
@@ -43,8 +47,11 @@ jobs:
           cp ../wazuh.zip src/winagent/wazuh.zip
       # Upload build artifacts.
       - name: Upload Artifact winagent
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: winagent
           path: src/winagent
   # Execute the tests on windows.
@@ -67,8 +74,11 @@ jobs:
         run: echo "${WIX}bin" >> $GITHUB_PATH
       # Download the compressed winagent build.
       - name: Download Artifact winagent
-        uses: actions/download-artifact@v4
+        uses: ./.github/actions/download_s3_artifact
         with:
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: winagent
           path: C:\winagent\
       # Decompress the winagent files.

--- a/.github/workflows/4_testunit_inventory-harvester.yml
+++ b/.github/workflows/4_testunit_inventory-harvester.yml
@@ -11,6 +11,10 @@ on:
       - "src/shared_modules/utils/**"
       - "src/wazuh_modules/inventory_harvester/**"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   inventory-harvester-modules:
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
@@ -49,6 +53,8 @@ jobs:
       - name: Inventory harvester - Coverage
         uses: ./.github/actions/coverage_cpp
         with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/wazuh_modules/inventory_harvester
           id: inventory_harvester
 


### PR DESCRIPTION
## Description

Part of the [GitHub artifacts migration to S3](https://github.com/wazuh/wazuh-automation/issues/3502). Migrates the **agent (#5300)** and **server/shared (#5298)** CI GitHub Actions artifacts to an internal CI S3 bucket, replacing `actions/upload-artifact` / `actions/download-artifact` with composite actions that `aws s3 cp` against:

```
s3://<bucket>/<repository>/<workflow>/<artifact-name>/artifacts_<run_id>.zip
```

> Neither the bucket URI nor the role ARN is hardcoded — both are provided via repository secrets (`CI_INTERNAL_S3_BUCKET`, `CI_OIDC_ROLE_ARN`) and passed per call, so these private identifiers don't appear in source or logs. **DevOps must create both secrets** (alongside the existing `CI_AWS_REGION`) or the artifact/auth steps will fail.

Authentication is OIDC (`aws-actions/configure-aws-credentials@v6` with `permissions: id-token: write`), following the pattern from wazuh/wazuh-indexer#1674.

Resolves https://github.com/wazuh/internal-devel-requests/issues/5300
Resolves https://github.com/wazuh/internal-devel-requests/issues/5298

> Targets **4.14.7**. The 5.0.0 counterpart is #37185.

## Proposed changes

**New composite actions**
- `.github/actions/upload_s3_artifact` — archives the path and uploads it to S3.
- `.github/actions/download_s3_artifact` — downloads from S3 and extracts it.

Drop-in replacements that configure OIDC credentials internally; a calling job only needs `permissions: id-token: write`. Archiving prefers `7z`, then `zip`, then a `python3` `zipfile` fallback for runner images that ship neither.

**Agent (#5300)**
- Coverage RTR (2): `4_testcomponent_{syscheck,syscollector}-rtr`
- Windows component (4): `4_testcomponent_{sysinfo-windows,windows-dll-hijack,windows-files,windows-installer-upgrade}`
- Windows integration, `winagent` build → test (10): the `4_testintegration_*-win` workflows

**Server / shared (#5298)**
- Shared composite actions (5): `check_files`, `clang_format`, `coverage`, `coverage_cpp`, `doxygen` — now upload via `upload_s3_artifact` (they gain an `aws_region` input).
- Package build: `4_builderpackage_{manager,manager-multiples}`, `4_builderprecompiled_vdscanner-testtools` — the package → test handoff moves to S3; the existing publish to the packages bucket (static keys) is unchanged.
- Code analysis: `4_codeanalysis_{coverity,scanbuild}`, `4_codelinter_clangformat`.
- Tests: `4_testcomponent_{indexer-connector,vulnerability-scanner}`, `4_testintegration_{api-tier-0-1,api-tier-2,rbac-tier-0-1}`, `4_testunit_inventory-harvester`.

## Authentication

OIDC via `aws-actions/configure-aws-credentials@v6`. The composite actions assume a DevOps-provided IAM role scoped to `GetObject`/`PutObject` on the bucket; the role ARN is passed per call via the `CI_OIDC_ROLE_ARN` secret rather than hardcoded, so neither the role nor the AWS account ID appears in source or logs. Workflows that upload/download directly pass `aws_region: ${{ secrets.CI_AWS_REGION }}`, `bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}` and `aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}` per call; workflows that only invoke the shared composite actions pass `bucket` and `aws_role` and add `permissions: id-token: write` (the shared actions default the region to `us-east-1`). Reusable workflows (`manager`, called by `manager-multiples`) propagate `id-token` from the calling job.

> DevOps: the role's trust policy must allow the `pull_request` OIDC subject (`repo:wazuh/wazuh:pull_request`), since these run mostly on PRs.

## Out of scope

Engine artifacts, the agent integration tests beyond the migrated `*-win` set, agent package builds (macos/linux), `legacy_unit_tests_run`, and the toolchain/externals workflows.

## Tests / evidence

The cross-job artifacts are verified **end-to-end, not merely present**: each is uploaded by a build job and then *downloaded and consumed* by a test job that passes — a missing or corrupt object would fail that download.

| Workflow | Artifact(s) | Producer → consumer (both green) | Run |
|---|---|---|---|
| `sysinfo-windows` | shared_libraries, data_provider, dbsync, rsync, syscollector | CodeBuild build → `windows-2025` test | [run](https://github.com/wazuh/wazuh/actions/runs/28195875241) |
| `*-win` integration | winagent | CodeBuild build → `windows-2025` test | [enrollment](https://github.com/wazuh/wazuh/actions/runs/28195875202), [fim](https://github.com/wazuh/wazuh/actions/runs/28195875242) |
| `windows-dll-hijack` | executables, configuration | build → `windows-2025` test | [run](https://github.com/wazuh/wazuh/actions/runs/28195875237) |
| `syscheck-rtr` | coverage_report_{agent,winagent} | leaf upload (`./**/coverage_report/**` glob) | [run](https://github.com/wazuh/wazuh/actions/runs/28195875246) |

Server scope: the `manager-multiples` build uploaded real package artifacts (`wazuh-manager_*.deb`, `..._*.rpm`) plus `check_files`' stats/validation reports to S3 ([run](https://github.com/wazuh/wazuh/actions/runs/28249203022)); the nested composite action (`coverage_cpp` → `upload_s3_artifact`) is green via `testunit_router`. Remaining reds on the PR are pre-existing (the flaky `syscollector` RTR and CodeBuild runner-provisioning), not the migration. `actionlint` is clean on the changed workflows.
