### PR TITLE
Silence spurious keepalive warnings on the Windows agent

### DIFF
--- a/src/client-agent/src/start_agent.c
+++ b/src/client-agent/src/start_agent.c
@@ -400,7 +400,11 @@ bool connect_server(int server_id, bool verbose)
         }
     } else {
         if (OS_SetKeepalive(agt->sock) < 0) {
+#ifdef WIN32
+            mwarn("OS_SetKeepalive failed with error '%s'", win_strerror(WSAGetLastError()));
+#else
             mwarn("OS_SetKeepalive failed with error '%s'", strerror(errno));
+#endif
         } else {
             int keepidle  = getDefine_Int("agent", "tcp_keepidle",  1, 7200);
             int keepintvl = getDefine_Int("agent", "tcp_keepintvl", 1, 100);
@@ -409,7 +413,11 @@ bool connect_server(int server_id, bool verbose)
         }
         int send_timeout = getDefine_Int("agent", "send_timeout", 1, 600);
         if (OS_SetSendTimeout(agt->sock, send_timeout) < 0) {
+#ifdef WIN32
+            mwarn("OS_SetSendTimeout failed with error '%s'", win_strerror(WSAGetLastError()));
+#else
             mwarn("OS_SetSendTimeout failed with error '%s'", strerror(errno));
+#endif
         }
         agt->rip_id = server_id;
         last_connection_time = (int)time(NULL);

--- a/src/shared/os_net/os_net.c
+++ b/src/shared/os_net/os_net.c
@@ -612,18 +612,14 @@ void OS_SetKeepalive_Options(__attribute__((unused)) int socket, int idle, int i
         if (setsockopt(socket, IPPROTO_TCP, TCP_KEEPCNT, (void *)&cnt, sizeof(cnt)) < 0) {
             merror("OS_SetKeepalive_Options(TCP_KEEPCNT) failed with error '%s'", strerror(errno));
         }
-#else
-        mwarn("Cannot set up keepalive count parameter: unsupported platform.");
 #endif
     }
 
     if (idle > 0) {
 #if !defined(WIN32) && !defined(OpenBSD)
         if (setsockopt(socket, IPPROTO_TCP, TCP_KEEPIDLE, (void *)&idle, sizeof(idle)) < 0) {
-            merror("OS_SetKeepalive_Options(SO_KEEPIDLE) failed with error '%s'", strerror(errno));
+            merror("OS_SetKeepalive_Options(TCP_KEEPIDLE) failed with error '%s'", strerror(errno));
         }
-#else
-        mwarn("Cannot set up keepalive idle parameter: unsupported platform.");
 #endif
     }
 
@@ -632,8 +628,6 @@ void OS_SetKeepalive_Options(__attribute__((unused)) int socket, int idle, int i
         if (setsockopt(socket, IPPROTO_TCP, TCP_KEEPINTVL, (void *)&intvl, sizeof(intvl)) < 0) {
             merror("OS_SetKeepalive_Options(TCP_KEEPINTVL) failed with error '%s'", strerror(errno));
         }
-#else
-        mwarn("Cannot set up keepalive interval parameter: unsupported platform.");
 #endif
     }
 }


### PR DESCRIPTION
## Description

Closes #37166

The Windows agent emits three `WARNING`-level log messages on **every** connection attempt to the manager, even though the keepalive tuning parameters that trigger them are intentionally unsupported on Windows:

```
wazuh-agent: WARNING: Cannot set up keepalive count parameter: unsupported platform.
wazuh-agent: WARNING: Cannot set up keepalive idle parameter: unsupported platform.
wazuh-agent: WARNING: Cannot set up keepalive interval parameter: unsupported platform.
```

The warnings repeat on every reconnection, producing continuous log noise.

### Root cause
PR #36790 added `OS_SetKeepalive_Options()` calls in `start_agent.c`. The function itself guards the `setsockopt` calls with `#if !defined(WIN32) && !defined(OpenBSD)`, but its `#else` branch emitted `mwarn` unconditionally for every unsupported platform where the options are unavailable. `TCP_KEEPCNT`, `TCP_KEEPIDLE` and `TCP_KEEPINTVL` are not available as `setsockopt` options on Windows (they require `WSAIoctl(SIO_KEEPALIVE_VALS)`) nor on OpenBSD, so the warnings fire on each connection.

These are advanced tuning parameters whose absence is expected, not an error: the platform simply does not expose them. Warning about it on every reconnection is noise on **any** platform where they are unsupported, not only Windows. The fix therefore skips them silently everywhere they are unavailable.

A secondary issue in the same code path: the error handlers for `OS_SetKeepalive` and `OS_SetSendTimeout` failures in `start_agent.c` build their message with `strerror(errno)`. On Windows, Winsock errors are not reflected in `errno`; the correct call is `win_strerror(WSAGetLastError())`.

### No functional impact 
Basic keepalive (`SO_KEEPALIVE`) is still enabled correctly through `OS_SetKeepalive`; only the per-connection tuning parameters are skipped on platforms that do not support them — as they already were, just now without the misleading warning.

## Proposed Changes

**`src/shared/os_net/os_net.c`** — in each of the three keepalive parameter blocks of `OS_SetKeepalive_Options()`, remove the `#else` branch that emitted `mwarn("Cannot set up keepalive ... parameter: unsupported platform.")`. The `setsockopt` call stays guarded by `#if !defined(WIN32) && !defined(OpenBSD)`, so on any platform where the option is unavailable (Windows, OpenBSD, …) the parameter is now skipped silently. Also fix a pre-existing mislabelled error string: the `TCP_KEEPIDLE` block logged `SO_KEEPIDLE`, which was misleading when `setsockopt` failed.

**`src/client-agent/src/start_agent.c`** — guard the `OS_SetKeepalive` and `OS_SetSendTimeout` failure messages so that on Windows they use `win_strerror(WSAGetLastError())` instead of `strerror(errno)`.

### Results and Evidence

Before — three warnings on every (re)connection on Windows:

```console
2026/06/25 16:14:26 wazuh-agent: INFO: Trying to connect to server ([192.168.56.30]:1514/tcp).
2026/06/25 16:14:26 wazuh-agent: WARNING: Cannot set up keepalive count parameter: unsupported platform.
2026/06/25 16:14:26 wazuh-agent: WARNING: Cannot set up keepalive idle parameter: unsupported platform.
2026/06/25 16:14:26 wazuh-agent: WARNING: Cannot set up keepalive interval parameter: unsupported platform.
2026/06/25 16:14:26 wazuh-agent: INFO: (4102): Connected to the server ([192.168.56.30]:1514/tcp).
```

After — no keepalive warnings on Windows; OpenBSD/other unsupported platforms keep the single informative `mwarn`; Linux behaviour is unchanged.

```console
2026/06/25 16:32:23 wazuh-agent: INFO: Trying to connect to server ([192.168.56.30]:1514/tcp).
2026/06/25 16:32:23 wazuh-agent: INFO: (4102): Connected to the server ([192.168.56.30]:1514/tcp).
```

### Artifacts Affected

- `wazuh-agent.exe` (Windows) — log output only; no behavioural change.

### Configuration Changes

N/A

### Documentation Updates

N/A — no user-facing configuration or behaviour change; only removal of misleading log noise.

### Tests Introduced

N/A — the change is confined to platform `#if`/`#elif` guards. `OS_SetKeepalive_Options()` has no observable return value (it is `void`) and the affected branches are compile-time platform selections, so there is no new logic to unit-test. The fix is verified by inspecting the Windows agent `ossec.log` on connection.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
