### PR TITLE
Fix syscheck API scan_day and scan_time serialization

### DIFF
--- a/src/config/include/syscheck-config.h
+++ b/src/config/include/syscheck-config.h
@@ -395,8 +395,10 @@ typedef struct _config {
     OSList *directories;                               /* List of directories to be monitored */
     OSList *wildcards;                                 /* List of wildcards to be monitored */
 
-    char *scan_day;                                    /* run syscheck on this day */
-    char *scan_time;                                   /* run syscheck at this time */
+    char *scan_day;                                    /* run syscheck on this day (internal bitmap) */
+    char *scan_time;                                   /* run syscheck at this time (internal encoded format) */
+    char *scan_day_str;                                /* original scan_day string from configuration */
+    char *scan_time_str;                               /* original scan_time string from configuration */
 
     unsigned int file_limit_enabled;                   /* Enable FIM file entry max limits */
     int file_entry_limit;                              /* maximum number of files to monitor */

--- a/src/config/src/syscheck-config.c
+++ b/src/config/src/syscheck-config.c
@@ -77,6 +77,8 @@ int initialize_syscheck_configuration(syscheck_config *syscheck) {
     syscheck->nodiff_regex                    = NULL;
     syscheck->scan_day                        = NULL;
     syscheck->scan_time                       = NULL;
+    syscheck->scan_day_str                    = NULL;
+    syscheck->scan_time_str                   = NULL;
     syscheck->file_limit_enabled              = true;
     syscheck->file_entry_limit                = 100000;
     syscheck->directories                     = OSList_Create();
@@ -1759,21 +1761,35 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
         }
         /* Get scan time */
         else if (strcmp(node[i]->element, xml_scantime) == 0) {
-            syscheck->scan_time = OS_IsValidUniqueTime(node[i]->content);
-            if (!syscheck->scan_time) {
+            char *validated_time = OS_IsValidUniqueTime(node[i]->content);
+            if (!validated_time) {
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
+            /* Free previous values in case the option is set more than once */
+            os_free(syscheck->scan_time);
+            os_free(syscheck->scan_time_str);
+            /* Keep the internal encoded value for the scheduler and the
+             * original string for the configuration report */
+            syscheck->scan_time = validated_time;
+            os_strdup(node[i]->content, syscheck->scan_time_str);
         }
 
         /* Get scan day */
         else if (strcmp(node[i]->element, xml_scanday) == 0) {
-            syscheck->scan_day = OS_IsValidDay(node[i]->content);
-            if (!syscheck->scan_day) {
+            char *validated_day = OS_IsValidDay(node[i]->content);
+            if (!validated_day) {
                 mwarn(INVALID_DAY, node[i]->content);
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
+            /* Free previous values in case the option is set more than once */
+            os_free(syscheck->scan_day);
+            os_free(syscheck->scan_day_str);
+            /* Keep the internal bitmap for the scheduler and the original
+             * string for the configuration report */
+            syscheck->scan_day = validated_day;
+            os_strdup(node[i]->content, syscheck->scan_day_str);
         }
 
         /* Get file limit */
@@ -2287,6 +2303,12 @@ void Free_Syscheck(syscheck_config * config) {
         }
         if (config->scan_time) {
             free(config->scan_time);
+        }
+        if (config->scan_day_str) {
+            free(config->scan_day_str);
+        }
+        if (config->scan_time_str) {
+            free(config->scan_time_str);
         }
         if (config->ignore) {
             for (i=0; config->ignore[i] != NULL; i++) {

--- a/src/syscheckd/src/config.c
+++ b/src/syscheckd/src/config.c
@@ -138,8 +138,8 @@ cJSON *getSyscheckConfig(void) {
     cJSON_AddStringToObject(syscfg, "skip_dev", syscheck.skip_fs.dev ? "yes" : "no");
     cJSON_AddStringToObject(syscfg, "skip_sys", syscheck.skip_fs.sys ? "yes" : "no");
     cJSON_AddStringToObject(syscfg, "skip_proc", syscheck.skip_fs.proc ? "yes" : "no");
-    if (syscheck.scan_day) cJSON_AddStringToObject(syscfg,"scan_day",syscheck.scan_day);
-    if (syscheck.scan_time) cJSON_AddStringToObject(syscfg,"scan_time",syscheck.scan_time);
+    if (syscheck.scan_day_str) cJSON_AddStringToObject(syscfg,"scan_day",syscheck.scan_day_str);
+    if (syscheck.scan_time_str) cJSON_AddStringToObject(syscfg,"scan_time",syscheck.scan_time_str);
     cJSON_AddNumberToObject(syscfg, "max_files_per_second", syscheck.max_files_per_second);
 
     cJSON * file_limit = cJSON_CreateObject();

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -175,6 +175,8 @@ if(${TARGET} STREQUAL "winagent")
                  "syscheckd/test_syscheck_top_level.conf" NEWLINE_STYLE WIN32)
   configure_file("config_files/test_syscheck_config_win.conf"
                  "syscheckd/test_syscheck_config.conf" NEWLINE_STYLE WIN32)
+  configure_file("config_files/test_syscheck_scan_schedule_win.conf"
+                 "syscheckd/test_syscheck_scan_schedule.conf" NEWLINE_STYLE WIN32)
 else()
   configure_file("config_files/test_syscheck.conf"
                  "syscheckd/test_syscheck.conf" COPYONLY)
@@ -196,6 +198,8 @@ else()
                  "syscheckd/test_syscheck_top_level.conf" COPYONLY)
   configure_file("config_files/test_syscheck.conf"
                  "syscheckd/test_syscheck_config.conf" COPYONLY)
+  configure_file("config_files/test_syscheck_scan_schedule.conf"
+                 "syscheckd/test_syscheck_scan_schedule.conf" COPYONLY)
 endif()
 
 # Coverage

--- a/src/unit_tests/config_files/test_syscheck_scan_schedule.conf
+++ b/src/unit_tests/config_files/test_syscheck_scan_schedule.conf
@@ -1,0 +1,16 @@
+<ossec_config>
+  <syscheck>
+    <disabled>no</disabled>
+    <scan_on_start>no</scan_on_start>
+
+    <!-- Frequency that syscheck is executed -->
+    <frequency>86400</frequency>
+
+    <!-- Scheduled scan options -->
+    <scan_time>01:00</scan_time>
+    <scan_day>sunday</scan_day>
+
+    <!-- Directories to check -->
+    <directories>/etc</directories>
+  </syscheck>
+</ossec_config>

--- a/src/unit_tests/config_files/test_syscheck_scan_schedule_win.conf
+++ b/src/unit_tests/config_files/test_syscheck_scan_schedule_win.conf
@@ -1,0 +1,16 @@
+<ossec_config>
+  <syscheck>
+    <disabled>no</disabled>
+    <scan_on_start>no</scan_on_start>
+
+    <!-- Frequency that syscheck is executed -->
+    <frequency>86400</frequency>
+
+    <!-- Scheduled scan options -->
+    <scan_time>01:00</scan_time>
+    <scan_day>sunday</scan_day>
+
+    <!-- Directories to check -->
+    <directories recursion_level="0">%WINDIR%</directories>
+  </syscheck>
+</ossec_config>

--- a/src/unit_tests/syscheckd/test_config.c
+++ b/src/unit_tests/syscheckd/test_config.c
@@ -396,6 +396,48 @@ void test_getSyscheckConfig(void **state)
     assert_int_equal(sys_process_priority->valueint, 10);
 }
 
+void test_getSyscheckConfig_scan_schedule(void **state)
+{
+    (void) state;
+    cJSON * ret;
+
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+
+    expect_any_always(__wrap__mdebug1, formatted_msg);
+    expect_any_always(__wrap__minfo, formatted_msg);
+
+    Read_Syscheck_Config("test_syscheck_scan_schedule.conf");
+    ret = getSyscheckConfig();
+    *state = ret;
+
+    assert_non_null(ret);
+
+    cJSON *sys_items = cJSON_GetObjectItem(ret, "syscheck");
+    assert_non_null(sys_items);
+
+    /* scan_day must be the human-readable day name, not a binary bitmap */
+    cJSON *scan_day = cJSON_GetObjectItem(sys_items, "scan_day");
+    assert_non_null(scan_day);
+    char *scan_day_value = cJSON_GetStringValue(scan_day);
+    assert_non_null(scan_day_value);
+    assert_string_equal(scan_day_value, "sunday");
+    /* The first byte must be printable, never the 0x01 bitmap marker */
+    assert_true(scan_day_value[0] >= 0x20);
+
+    /* scan_time must be the original HH:MM string, not the encoded range */
+    cJSON *scan_time = cJSON_GetObjectItem(sys_items, "scan_time");
+    assert_non_null(scan_time);
+    char *scan_time_value = cJSON_GetStringValue(scan_time);
+    assert_non_null(scan_time_value);
+    assert_string_equal(scan_time_value, "01:00");
+    /* The encoded internal format starts with a leading '.' (e.g. ".01:0001:00") */
+    assert_int_not_equal(scan_time_value[0], '.');
+}
+
 void test_getSyscheckConfig_no_audit(void **state)
 {
     (void) state;
@@ -870,6 +912,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_Read_Syscheck_Config_undefined, setup_read_config, restart_syscheck),
         cmocka_unit_test_setup_teardown(test_Read_Syscheck_Config_unparsed, setup_read_config, restart_syscheck),
         cmocka_unit_test_setup_teardown(test_getSyscheckConfig, setup_read_config, restart_syscheck),
+        cmocka_unit_test_setup_teardown(test_getSyscheckConfig_scan_schedule, setup_read_config, restart_syscheck),
         cmocka_unit_test_setup_teardown(test_getSyscheckConfig_no_audit, setup_read_config, restart_syscheck),
         cmocka_unit_test_setup_teardown(test_getSyscheckConfig_no_directories, setup_read_config, restart_syscheck),
         cmocka_unit_test_setup_teardown(test_getSyscheckInternalOptions, setup_read_config, restart_syscheck),


### PR DESCRIPTION
## Description

`GET /agents/{id}/config/syscheck/syscheck` returns unreadable values for `scan_day` and `scan_time` when those settings are configured in the agent `ossec.conf`.

The syscheck daemon converts these configuration values into internal scheduler representations at parse time, and `getSyscheckConfig()` serialized those internal values directly to JSON without converting them back to a human-readable form:

- `scan_day` was emitted as the 9-byte weekday bitmap produced by `OS_IsValidDay()` (non-printable bytes).
- `scan_time` was emitted as the dot-prefixed encoded range produced by `OS_IsValidUniqueTime()` — e.g. `.01:0001:00` for `01:00`.

Resolves #37181.

## Root cause

| Location | Problem |
| --- | --- |
| `src/syscheckd/src/config.c` `getSyscheckConfig()` | Serialized the raw internal `scan_day` (binary bitmap) and `scan_time` (encoded range) to JSON. |
| `src/config/src/syscheck-config.c` | On parse, `scan_day`/`scan_time` are overwritten with the internal representations and the original strings are discarded. |

## Proposed Changes

- Add two fields to `syscheck_config`: `scan_day_str` and `scan_time_str`, holding the original strings parsed from XML.
- In `Read_Syscheck`, validate `<scan_day>`/`<scan_time>` exactly as before, and only after validation succeeds store the original XML string in the new `*_str` field while keeping the internal value in `scan_day`/`scan_time` for the scheduler.
- Free previous values when the option is parsed more than once, and free the new fields in `Free_Syscheck` (no leaks).
- In `getSyscheckConfig()`, serialize the human-readable `scan_day_str` / `scan_time_str` instead of the internal fields.

The scheduler keeps consuming the internal `scan_day`/`scan_time` via `OS_IsonDay()` / `OS_IsAfterTime()` unchanged, so scheduling behavior is preserved.

### Resulting API output

With:

```xml
<syscheck>
  <disabled>no</disabled>
  <scan_on_start>no</scan_on_start>
  <frequency>86400</frequency>
  <scan_time>01:00</scan_time>
  <scan_day>sunday</scan_day>
</syscheck>
```

the config report now contains:

```json
{
  "scan_day": "sunday",
  "scan_time": "01:00"
}
```

and no longer returns non-printable bytes for `scan_day` or `.01:0001:00` for `scan_time`.

## Out of scope

The `frequency` field still reflects the runtime value (`604800`) when `scan_day`/`scan_time` is set, because `syscheck.time` is reset to weekly at daemon startup in `run_check.c`. That behavior is intentional and left unchanged here; this PR only addresses the serialization of `scan_day`/`scan_time`.

## Tests

- Added `test_getSyscheckConfig_scan_schedule` (`src/unit_tests/syscheckd/test_config.c`) with a dedicated fixture (`test_syscheck_scan_schedule.conf` / `_win.conf`) that asserts the JSON contains `scan_day: "sunday"` and `scan_time: "01:00"`, explicitly verifying the output is not the binary bitmap and not the `.01:0001:00` encoded form.
- Built the agent with `make TARGET=agent TEST=1` and ran the `syscheckd` config suite under AddressSanitizer/LeakSanitizer: **21/21 tests pass with no memory leaks**, including all pre-existing config and scheduler tests (no regression) and the invalid-value paths, which still fail as before.
