### PR TITLE
Migrate 4.x Windows test runners to AWS CodeBuild 

### DIFF
--- a/.github/actions/setup_wix/action.yml
+++ b/.github/actions/setup_wix/action.yml
@@ -1,0 +1,27 @@
+name: "Set up WiX Toolset (MSI build)"
+description: "Ensures the WiX v3 toolset (candle.exe/light.exe) is available on PATH for building the Windows MSI."
+
+# TODO(codebuild-temp): Remove once the CodeBuild Windows image ships WiX.
+# wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
+# GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up WiX Toolset (MSI build)
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
+          Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
+        } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
+          Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
+          Write-Host "WiX found via `$WIX: $env:WIX"
+        } else {
+          $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
+          Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
+          $wixDir = 'C:\wix314'
+          Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
+          Add-Content -Path $env:GITHUB_PATH -Value $wixDir
+          Write-Host "WiX extracted to $wixDir"
+        }

--- a/.github/workflows/4_testcomponent_sysinfo-windows.yml
+++ b/.github/workflows/4_testcomponent_sysinfo-windows.yml
@@ -85,7 +85,7 @@ jobs:
           path: src/wazuh_modules/syscollector/build/bin
   run-on-windows:
     needs: build
-    runs-on: windows-2025
+    runs-on: codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testcomponent_windows-dll-hijack.yml
+++ b/.github/workflows/4_testcomponent_windows-dll-hijack.yml
@@ -59,6 +59,10 @@ jobs:
           name: configuration
           path: src/configuration_files
   check_dll_on_windows:
+    # NOTE: stays on the GitHub-hosted Windows runners. This test drives Process Monitor, which
+    # captures via a kernel minifilter driver. CodeBuild's Windows fleet runs process-isolated
+    # containers (no FltMgr / kernel-driver loading), so Procmon captures zero events there.
+    # Tracked in wazuh-automation#3497.
     strategy:
           matrix:
               os: [windows-2025, windows-2022]

--- a/.github/workflows/4_testcomponent_windows-files.yml
+++ b/.github/workflows/4_testcomponent_windows-files.yml
@@ -45,7 +45,7 @@ jobs:
           name: binaries
           path: src/bin_files
   check_binaries_details:
-    runs-on: windows-2025
+    runs-on: codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
     needs: build
     steps:
       - name: Checkout Repo

--- a/.github/workflows/4_testcomponent_windows-installer-upgrade.yml
+++ b/.github/workflows/4_testcomponent_windows-installer-upgrade.yml
@@ -55,25 +55,7 @@ jobs:
           python-version-file: ".github/workflows/.python-version"
           architecture: x64
       - name: Set up WiX Toolset (MSI build)
-        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships WiX.
-        # wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
-        # GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
-            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
-          } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
-            Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
-            Write-Host "WiX found via `$WIX: $env:WIX"
-          } else {
-            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
-            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
-            $wixDir = 'C:\wix314'
-            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
-            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
-            Write-Host "WiX extracted to $wixDir"
-          }
+        uses: ./.github/actions/setup_wix
       - name: Set up 7-Zip (MSI/zip extraction)
         # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships 7-Zip.
         # The upgrade test unzips the base archive and extracts the MSI (`7z e`); an MSI is an

--- a/.github/workflows/4_testcomponent_windows-installer-upgrade.yml
+++ b/.github/workflows/4_testcomponent_windows-installer-upgrade.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
           matrix:
               wazuh_version: [4.5.2-1]
-    runs-on: windows-2025
+    runs-on: codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
     needs: build
     steps:
       - name: Checkout Repo
@@ -54,9 +54,42 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version"
           architecture: x64
-      - name: Add WiX toolkit to PATH
-        shell: bash
-        run: echo "${WIX}bin" >> $GITHUB_PATH
+      - name: Set up WiX Toolset (MSI build)
+        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships WiX.
+        # wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
+        # GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
+            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
+          } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
+            Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
+            Write-Host "WiX found via `$WIX: $env:WIX"
+          } else {
+            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
+            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
+            $wixDir = 'C:\wix314'
+            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
+            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
+            Write-Host "WiX extracted to $wixDir"
+          }
+      - name: Set up 7-Zip (MSI/zip extraction)
+        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships 7-Zip.
+        # The upgrade test unzips the base archive and extracts the MSI (`7z e`); an MSI is an
+        # OLE/CAB container that tar/Expand-Archive cannot open, so full 7-Zip is required.
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (Get-Command 7z.exe -ErrorAction SilentlyContinue) {
+            Write-Host "7-Zip already available: $((Get-Command 7z.exe).Source)"
+          } else {
+            $installer = Join-Path $env:TEMP '7z-x64.exe'
+            Invoke-WebRequest -Uri 'https://www.7-zip.org/a/7z2408-x64.exe' -OutFile $installer
+            Start-Process -FilePath $installer -ArgumentList '/S' -Wait
+            Add-Content -Path $env:GITHUB_PATH -Value 'C:\Program Files\7-Zip'
+            Write-Host "7-Zip installed to C:\Program Files\7-Zip"
+          }
       - name: Install dependencies
         run: |
           pip install -r src/win32/qa/requirements.txt

--- a/.github/workflows/4_testintegration_agentd-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_agentd-tier-0-1-win.yml
@@ -72,25 +72,7 @@ jobs:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
       - name: Set up WiX Toolset (MSI build)
-        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships WiX.
-        # wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
-        # GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
-            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
-          } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
-            Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
-            Write-Host "WiX found via `$WIX: $env:WIX"
-          } else {
-            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
-            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
-            $wixDir = 'C:\wix314'
-            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
-            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
-            Write-Host "WiX extracted to $wixDir"
-          }
+        uses: ./.github/actions/setup_wix
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: ./.github/actions/download_s3_artifact

--- a/.github/workflows/4_testintegration_agentd-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_agentd-tier-0-1-win.yml
@@ -62,7 +62,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: windows-2022
+    runs-on: codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -71,9 +71,26 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: Add WiX toolkit to PATH
-        shell: bash
-        run: echo "${WIX}bin" >> $GITHUB_PATH
+      - name: Set up WiX Toolset (MSI build)
+        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships WiX.
+        # wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
+        # GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
+            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
+          } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
+            Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
+            Write-Host "WiX found via `$WIX: $env:WIX"
+          } else {
+            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
+            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
+            $wixDir = 'C:\wix314'
+            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
+            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
+            Write-Host "WiX extracted to $wixDir"
+          }
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: ./.github/actions/download_s3_artifact

--- a/.github/workflows/4_testintegration_enrollment-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_enrollment-tier-0-1-win.yml
@@ -63,7 +63,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: windows-2025
+    runs-on: codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -72,9 +72,26 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: Add WiX toolkit to PATH
-        shell: bash
-        run: echo "${WIX}bin" >> $GITHUB_PATH
+      - name: Set up WiX Toolset (MSI build)
+        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships WiX.
+        # wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
+        # GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
+            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
+          } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
+            Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
+            Write-Host "WiX found via `$WIX: $env:WIX"
+          } else {
+            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
+            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
+            $wixDir = 'C:\wix314'
+            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
+            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
+            Write-Host "WiX extracted to $wixDir"
+          }
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: ./.github/actions/download_s3_artifact

--- a/.github/workflows/4_testintegration_enrollment-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_enrollment-tier-0-1-win.yml
@@ -73,25 +73,7 @@ jobs:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
       - name: Set up WiX Toolset (MSI build)
-        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships WiX.
-        # wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
-        # GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
-            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
-          } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
-            Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
-            Write-Host "WiX found via `$WIX: $env:WIX"
-          } else {
-            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
-            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
-            $wixDir = 'C:\wix314'
-            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
-            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
-            Write-Host "WiX extracted to $wixDir"
-          }
+        uses: ./.github/actions/setup_wix
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: ./.github/actions/download_s3_artifact

--- a/.github/workflows/4_testintegration_execd-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_execd-tier-0-1-win.yml
@@ -61,7 +61,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: windows-2025
+    runs-on: codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -70,9 +70,26 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: Add WiX toolkit to PATH
-        shell: bash
-        run: echo "${WIX}bin" >> $GITHUB_PATH
+      - name: Set up WiX Toolset (MSI build)
+        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships WiX.
+        # wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
+        # GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
+            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
+          } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
+            Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
+            Write-Host "WiX found via `$WIX: $env:WIX"
+          } else {
+            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
+            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
+            $wixDir = 'C:\wix314'
+            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
+            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
+            Write-Host "WiX extracted to $wixDir"
+          }
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: ./.github/actions/download_s3_artifact

--- a/.github/workflows/4_testintegration_execd-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_execd-tier-0-1-win.yml
@@ -71,25 +71,7 @@ jobs:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
       - name: Set up WiX Toolset (MSI build)
-        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships WiX.
-        # wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
-        # GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
-            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
-          } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
-            Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
-            Write-Host "WiX found via `$WIX: $env:WIX"
-          } else {
-            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
-            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
-            $wixDir = 'C:\wix314'
-            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
-            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
-            Write-Host "WiX extracted to $wixDir"
-          }
+        uses: ./.github/actions/setup_wix
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: ./.github/actions/download_s3_artifact

--- a/.github/workflows/4_testintegration_fim-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_fim-tier-0-1-win.yml
@@ -70,25 +70,7 @@ jobs:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
       - name: Set up WiX Toolset (MSI build)
-        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships WiX.
-        # wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
-        # GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
-            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
-          } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
-            Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
-            Write-Host "WiX found via `$WIX: $env:WIX"
-          } else {
-            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
-            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
-            $wixDir = 'C:\wix314'
-            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
-            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
-            Write-Host "WiX extracted to $wixDir"
-          }
+        uses: ./.github/actions/setup_wix
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: ./.github/actions/download_s3_artifact

--- a/.github/workflows/4_testintegration_fim-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_fim-tier-0-1-win.yml
@@ -60,7 +60,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: windows-2025
+    runs-on: codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -69,9 +69,26 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: Add WiX toolkit to PATH
-        shell: bash
-        run: echo "${WIX}bin" >> $GITHUB_PATH
+      - name: Set up WiX Toolset (MSI build)
+        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships WiX.
+        # wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
+        # GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
+            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
+          } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
+            Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
+            Write-Host "WiX found via `$WIX: $env:WIX"
+          } else {
+            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
+            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
+            $wixDir = 'C:\wix314'
+            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
+            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
+            Write-Host "WiX extracted to $wixDir"
+          }
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: ./.github/actions/download_s3_artifact
@@ -113,4 +130,4 @@ jobs:
         run: |
           NET START wazuh
           cd C:\wazuh\tests\integration
-          python -m pytest --tier 0 --tier 1 test_fim\
+          python -m pytest -k "not whodata and not Who-data" --tier 0 --tier 1 test_fim\

--- a/.github/workflows/4_testintegration_fim-tier-2-win.yml
+++ b/.github/workflows/4_testintegration_fim-tier-2-win.yml
@@ -51,7 +51,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: windows-2025
+    runs-on: codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -60,9 +60,26 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: Add WiX toolkit to PATH
-        shell: bash
-        run: echo "${WIX}bin" >> $GITHUB_PATH
+      - name: Set up WiX Toolset (MSI build)
+        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships WiX.
+        # wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
+        # GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
+            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
+          } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
+            Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
+            Write-Host "WiX found via `$WIX: $env:WIX"
+          } else {
+            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
+            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
+            $wixDir = 'C:\wix314'
+            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
+            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
+            Write-Host "WiX extracted to $wixDir"
+          }
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: ./.github/actions/download_s3_artifact
@@ -104,4 +121,4 @@ jobs:
         run: |
           NET START wazuh
           cd C:\wazuh\tests\integration
-          python -m pytest --tier 2 test_fim\
+          python -m pytest -k "not whodata and not Who-data" --tier 2 test_fim\

--- a/.github/workflows/4_testintegration_fim-tier-2-win.yml
+++ b/.github/workflows/4_testintegration_fim-tier-2-win.yml
@@ -61,25 +61,7 @@ jobs:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
       - name: Set up WiX Toolset (MSI build)
-        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships WiX.
-        # wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
-        # GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
-            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
-          } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
-            Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
-            Write-Host "WiX found via `$WIX: $env:WIX"
-          } else {
-            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
-            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
-            $wixDir = 'C:\wix314'
-            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
-            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
-            Write-Host "WiX extracted to $wixDir"
-          }
+        uses: ./.github/actions/setup_wix
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: ./.github/actions/download_s3_artifact

--- a/.github/workflows/4_testintegration_github-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_github-tier-0-1-win.yml
@@ -61,7 +61,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: windows-2025
+    runs-on: codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -70,9 +70,26 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: Add WiX toolkit to PATH
-        shell: bash
-        run: echo "${WIX}bin" >> $GITHUB_PATH
+      - name: Set up WiX Toolset (MSI build)
+        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships WiX.
+        # wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
+        # GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
+            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
+          } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
+            Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
+            Write-Host "WiX found via `$WIX: $env:WIX"
+          } else {
+            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
+            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
+            $wixDir = 'C:\wix314'
+            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
+            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
+            Write-Host "WiX extracted to $wixDir"
+          }
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: ./.github/actions/download_s3_artifact

--- a/.github/workflows/4_testintegration_github-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_github-tier-0-1-win.yml
@@ -71,25 +71,7 @@ jobs:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
       - name: Set up WiX Toolset (MSI build)
-        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships WiX.
-        # wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
-        # GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
-            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
-          } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
-            Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
-            Write-Host "WiX found via `$WIX: $env:WIX"
-          } else {
-            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
-            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
-            $wixDir = 'C:\wix314'
-            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
-            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
-            Write-Host "WiX extracted to $wixDir"
-          }
+        uses: ./.github/actions/setup_wix
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: ./.github/actions/download_s3_artifact

--- a/.github/workflows/4_testintegration_logcollector-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_logcollector-tier-0-1-win.yml
@@ -60,7 +60,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: windows-2025
+    runs-on: codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -69,9 +69,26 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: Add WiX toolkit to PATH
-        shell: bash
-        run: echo "${WIX}bin" >> $GITHUB_PATH
+      - name: Set up WiX Toolset (MSI build)
+        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships WiX.
+        # wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
+        # GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
+            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
+          } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
+            Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
+            Write-Host "WiX found via `$WIX: $env:WIX"
+          } else {
+            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
+            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
+            $wixDir = 'C:\wix314'
+            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
+            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
+            Write-Host "WiX extracted to $wixDir"
+          }
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: ./.github/actions/download_s3_artifact

--- a/.github/workflows/4_testintegration_logcollector-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_logcollector-tier-0-1-win.yml
@@ -70,25 +70,7 @@ jobs:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
       - name: Set up WiX Toolset (MSI build)
-        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships WiX.
-        # wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
-        # GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
-            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
-          } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
-            Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
-            Write-Host "WiX found via `$WIX: $env:WIX"
-          } else {
-            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
-            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
-            $wixDir = 'C:\wix314'
-            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
-            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
-            Write-Host "WiX extracted to $wixDir"
-          }
+        uses: ./.github/actions/setup_wix
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: ./.github/actions/download_s3_artifact

--- a/.github/workflows/4_testintegration_office365-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_office365-tier-0-1-win.yml
@@ -61,7 +61,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: windows-2025
+    runs-on: codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -70,9 +70,26 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: Add WiX toolkit to PATH
-        shell: bash
-        run: echo "${WIX}bin" >> $GITHUB_PATH
+      - name: Set up WiX Toolset (MSI build)
+        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships WiX.
+        # wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
+        # GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
+            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
+          } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
+            Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
+            Write-Host "WiX found via `$WIX: $env:WIX"
+          } else {
+            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
+            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
+            $wixDir = 'C:\wix314'
+            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
+            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
+            Write-Host "WiX extracted to $wixDir"
+          }
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: ./.github/actions/download_s3_artifact

--- a/.github/workflows/4_testintegration_office365-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_office365-tier-0-1-win.yml
@@ -71,25 +71,7 @@ jobs:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
       - name: Set up WiX Toolset (MSI build)
-        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships WiX.
-        # wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
-        # GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
-            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
-          } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
-            Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
-            Write-Host "WiX found via `$WIX: $env:WIX"
-          } else {
-            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
-            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
-            $wixDir = 'C:\wix314'
-            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
-            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
-            Write-Host "WiX extracted to $wixDir"
-          }
+        uses: ./.github/actions/setup_wix
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: ./.github/actions/download_s3_artifact

--- a/.github/workflows/4_testintegration_sca-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_sca-tier-0-1-win.yml
@@ -62,7 +62,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: windows-2025
+    runs-on: codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -71,9 +71,26 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: Add WiX toolkit to PATH
-        shell: bash
-        run: echo "${WIX}bin" >> $GITHUB_PATH
+      - name: Set up WiX Toolset (MSI build)
+        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships WiX.
+        # wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
+        # GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
+            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
+          } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
+            Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
+            Write-Host "WiX found via `$WIX: $env:WIX"
+          } else {
+            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
+            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
+            $wixDir = 'C:\wix314'
+            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
+            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
+            Write-Host "WiX extracted to $wixDir"
+          }
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: ./.github/actions/download_s3_artifact

--- a/.github/workflows/4_testintegration_sca-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_sca-tier-0-1-win.yml
@@ -72,25 +72,7 @@ jobs:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
       - name: Set up WiX Toolset (MSI build)
-        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships WiX.
-        # wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
-        # GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
-            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
-          } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
-            Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
-            Write-Host "WiX found via `$WIX: $env:WIX"
-          } else {
-            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
-            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
-            $wixDir = 'C:\wix314'
-            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
-            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
-            Write-Host "WiX extracted to $wixDir"
-          }
+        uses: ./.github/actions/setup_wix
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: ./.github/actions/download_s3_artifact

--- a/.github/workflows/4_testintegration_syscollector-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_syscollector-tier-0-1-win.yml
@@ -60,7 +60,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: windows-2025
+    runs-on: codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -69,9 +69,26 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
-      - name: Add WiX toolkit to PATH
-        shell: bash
-        run: echo "${WIX}bin" >> $GITHUB_PATH
+      - name: Set up WiX Toolset (MSI build)
+        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships WiX.
+        # wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
+        # GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
+            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
+          } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
+            Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
+            Write-Host "WiX found via `$WIX: $env:WIX"
+          } else {
+            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
+            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
+            $wixDir = 'C:\wix314'
+            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
+            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
+            Write-Host "WiX extracted to $wixDir"
+          }
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: ./.github/actions/download_s3_artifact

--- a/.github/workflows/4_testintegration_syscollector-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_syscollector-tier-0-1-win.yml
@@ -70,25 +70,7 @@ jobs:
           python-version-file: ".github/workflows/.python-version-it"
           architecture: x64
       - name: Set up WiX Toolset (MSI build)
-        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships WiX.
-        # wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
-        # GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
-            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
-          } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
-            Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
-            Write-Host "WiX found via `$WIX: $env:WIX"
-          } else {
-            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
-            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
-            $wixDir = 'C:\wix314'
-            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
-            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
-            Write-Host "WiX extracted to $wixDir"
-          }
+        uses: ./.github/actions/setup_wix
       # Download the compressed winagent build.
       - name: Download Artifact winagent
         uses: ./.github/actions/download_s3_artifact


### PR DESCRIPTION
## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.
-->

Migrate the **Windows test legs** of the 4.x agent integration / component test workflows
from the GitHub-hosted `windows-2025` / `windows-2022` runners to the **AWS CodeBuild**
Windows agent fleet
(`codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}`).

The Linux **build** legs of these workflows already run on CodeBuild (`server-amd`); this PR
only moves the Windows **run-test** legs. It is the 4.14.7 counterpart of the 5.0.0 migration
(#37051) and reuses the fixes proven there.

Part of #37027.

## Proposed Changes

<!--
Summarize the changes made in this pull request.
-->

### Windows runner migration (`windows-2025` / `windows-2022` → CodeBuild Windows)

Each Windows integration-test workflow recompiles the winagent on the Linux build leg
(`server-amd`, already on CodeBuild), then the Windows leg downloads the artifact, builds the
MSI, installs the agent and runs pytest. The Windows leg is what moves to CodeBuild here:

- **Integration tests** (`4_testintegration_<module>-tier-0-1-win.yml`): `agentd`,
  `enrollment`, `execd`, `github`, `logcollector`, `office365`, `sca`, `syscollector`.
- **FIM**: `4_testintegration_fim-tier-0-1-win.yml` and `4_testintegration_fim-tier-2-win.yml`.
- **Component tests**: `4_testcomponent_sysinfo-windows.yml`, `4_testcomponent_windows-files.yml`,
  `4_testcomponent_windows-installer-upgrade.yml`.

### WiX Toolset (MSI build on the Windows leg)

Every integration-test Windows leg (and `windows-installer-upgrade`) builds the MSI with
`wazuh-installer-build-msi.bat`, which uses WiX v3 (`candle.exe` / `light.exe`). GitHub-hosted
images exposed WiX via `$WIX`; the CodeBuild Windows image does not ship it. The
`Add WiX toolkit to PATH` step (which only echoed `$WIX/bin`) is replaced by a
`Set up WiX Toolset (MSI build)` step that detects WiX (PATH or `$WIX`) and otherwise downloads
the WiX 3.14 binaries to `C:\wix314` and adds them to `PATH`. `TODO(codebuild-temp)`.

### 7-Zip (`windows-installer-upgrade`)

The upgrade test unzips the base archive and extracts the MSI with `7z e`. An MSI is an
OLE/CAB container that `tar` / `Expand-Archive` cannot open, so **full** 7-Zip is required.
Added a `Set up 7-Zip (MSI/zip extraction)` step that detects `7z.exe` and otherwise silently
installs 7-Zip and adds it to `PATH`. `TODO(codebuild-temp)`.

### Skipped on CodeBuild — container limitations

- **FIM whodata** (`fim-tier-0-1-win`, `fim-tier-2-win`): excluded via
  `-k "not whodata and not Who-data"`. whodata needs Windows object-access auditing
  (SACL + Security-log event 4663); in the process-isolated CodeBuild Windows container the
  audit policy can be enabled but the kernel never delivers the 4663 events, so whodata cases
  fail. scheduled/realtime FIM still runs on CodeBuild. Same class as the Linux `CAP_AUDIT`
  exclusion.
- **`4_testcomponent_windows-dll-hijack.yml`** (`check_dll_on_windows`): **kept on the
  GitHub-hosted** `windows-2025` / `windows-2022` runners. It drives Process Monitor, which
  captures via a kernel minifilter driver (`FltMgr.sys`) that cannot be loaded in a
  process-isolated container. Its Linux `build` leg still runs on CodeBuild.

Both are tracked for the image owners in
[wazuh-automation#3497](https://github.com/wazuh/wazuh-automation/issues/3497).

### Artifacts Affected

No build or test artifacts change. Only CI runner placement for the Windows test legs.

### Configuration Changes

CI-only: the Windows test legs now run on the
`codebuild-github-actions-codebuild-runner-agent-windows-amd` fleet, which must be available.
The `dll-hijack` job remains on GitHub-hosted Windows runners.

### Tests Introduced

None. Existing tests are unchanged except for the runner they execute on; whodata FIM cases
are excluded on CodeBuild (tracked above).

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Configuration changes documented
- [ ] CodeBuild Windows agent fleet (`agent-windows-amd`) provisioned and reachable for 4.x
