### PR TITLE
Handle eol amazon inspector classic

### DIFF
--- a/.github/actions/check_files/deb_linux_agent_amd64.csv
+++ b/.github/actions/check_files/deb_linux_agent_amd64.csv
@@ -104,7 +104,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/wodles/aws/buckets_s3/waf.py,root,wazuh,750,file,-rwxr-x---,3012,0.1
 /var/ossec/wodles/aws/services/__init__.py,root,wazuh,750,file,-rwxr-x---,344,0.1
 /var/ossec/wodles/aws/services/cloudwatchlogs.py,root,wazuh,750,file,-rwxr-x---,24992,0.1
-/var/ossec/wodles/aws/services/inspector.py,root,wazuh,750,file,-rwxr-x---,10084,0.1
+/var/ossec/wodles/aws/services/inspector.py,root,wazuh,750,file,-rwxr-x---,8586,0.1
 /var/ossec/wodles/aws/services/aws_service.py,root,wazuh,750,file,-rwxr-x---,6222,0.1
 /var/ossec/wodles/aws/subscribers/sqs_message_processor.py,root,wazuh,750,file,-rwxr-x---,1825,0.1
 /var/ossec/wodles/aws/subscribers/__init__.py,root,wazuh,750,file,-rwxr-x---,380,0.1

--- a/.github/actions/check_files/deb_linux_agent_i386.csv
+++ b/.github/actions/check_files/deb_linux_agent_i386.csv
@@ -104,7 +104,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/wodles/aws/buckets_s3/waf.py,root,wazuh,750,file,-rwxr-x---,3012,0.1
 /var/ossec/wodles/aws/services/__init__.py,root,wazuh,750,file,-rwxr-x---,344,0.1
 /var/ossec/wodles/aws/services/cloudwatchlogs.py,root,wazuh,750,file,-rwxr-x---,24992,0.1
-/var/ossec/wodles/aws/services/inspector.py,root,wazuh,750,file,-rwxr-x---,10084,0.1
+/var/ossec/wodles/aws/services/inspector.py,root,wazuh,750,file,-rwxr-x---,8586,0.1
 /var/ossec/wodles/aws/services/aws_service.py,root,wazuh,750,file,-rwxr-x---,6222,0.1
 /var/ossec/wodles/aws/subscribers/sqs_message_processor.py,root,wazuh,750,file,-rwxr-x---,1825,0.1
 /var/ossec/wodles/aws/subscribers/__init__.py,root,wazuh,750,file,-rwxr-x---,380,0.1

--- a/.github/actions/check_files/rpm_linux_agent_amd64.csv
+++ b/.github/actions/check_files/rpm_linux_agent_amd64.csv
@@ -174,7 +174,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/wodles/aws/buckets_s3/waf.py,root,wazuh,750,file,-rwxr-x---,3012,0.1
 /var/ossec/wodles/aws/services/__init__.py,root,wazuh,750,file,-rwxr-x---,344,0.1
 /var/ossec/wodles/aws/services/cloudwatchlogs.py,root,wazuh,750,file,-rwxr-x---,24992,0.1
-/var/ossec/wodles/aws/services/inspector.py,root,wazuh,750,file,-rwxr-x---,10084,0.1
+/var/ossec/wodles/aws/services/inspector.py,root,wazuh,750,file,-rwxr-x---,8586,0.1
 /var/ossec/wodles/aws/services/aws_service.py,root,wazuh,750,file,-rwxr-x---,6222,0.1
 /var/ossec/wodles/aws/subscribers/sqs_message_processor.py,root,wazuh,750,file,-rwxr-x---,1825,0.1
 /var/ossec/wodles/aws/subscribers/__init__.py,root,wazuh,750,file,-rwxr-x---,380,0.1

--- a/.github/actions/check_files/rpm_linux_agent_i386.csv
+++ b/.github/actions/check_files/rpm_linux_agent_i386.csv
@@ -174,7 +174,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/wodles/aws/buckets_s3/waf.py,root,wazuh,750,file,-rwxr-x---,3012,0.1
 /var/ossec/wodles/aws/services/__init__.py,root,wazuh,750,file,-rwxr-x---,344,0.1
 /var/ossec/wodles/aws/services/cloudwatchlogs.py,root,wazuh,750,file,-rwxr-x---,24992,0.1
-/var/ossec/wodles/aws/services/inspector.py,root,wazuh,750,file,-rwxr-x---,10084,0.1
+/var/ossec/wodles/aws/services/inspector.py,root,wazuh,750,file,-rwxr-x---,8586,0.1
 /var/ossec/wodles/aws/services/aws_service.py,root,wazuh,750,file,-rwxr-x---,6222,0.1
 /var/ossec/wodles/aws/subscribers/sqs_message_processor.py,root,wazuh,750,file,-rwxr-x---,1825,0.1
 /var/ossec/wodles/aws/subscribers/__init__.py,root,wazuh,750,file,-rwxr-x---,380,0.1

--- a/tests/integration/test_aws/README.md
+++ b/tests/integration/test_aws/README.md
@@ -55,7 +55,11 @@ wazuh/tests/integration/test_aws
 
 - [Testing framework](https://github.com/wazuh/qa-integration-framework) installed.
 
-- An Inspector assessment with test data in AWS. The rest of the necessary resources are created in test execution time.
+- An Inspector v2 environment with test data in AWS. The rest of the necessary resources are created in test execution time.
+
+> **NOTE:**
+> Amazon Inspector Classic (v1) reached its AWS end-of-life on May 20, 2026 and is no longer supported by this integration.
+> Only Inspector v2 (`inspector2`) is used. The Classic IAM permissions (`inspector:ListFindings`, `inspector:DescribeFindings`) are no longer required.
 
 For a step-by-step example guide using linux go to the [test setup section](#linux)
 
@@ -63,7 +67,7 @@ For a step-by-step example guide using linux go to the [test setup section](#lin
 ## Configuration settings
 
 - **Credentials**:
-    Set the credentials at `$HOME/.aws/credentials` (being `HOME` the home directory of the user who runs the tests, 
+    Set the credentials at `$HOME/.aws/credentials` (being `HOME` the home directory of the user who runs the tests,
  more information [here](https://documentation.wazuh.com/current/amazon/services/prerequisites/credentials.html#profiles) with the content:
 
 ```ini
@@ -76,7 +80,7 @@ aws_access_key_id = <access-key-value>
 aws_secret_access_key = <secret-key-value>
 ```
 
-Set the configurations at `$HOME/.aws/config` (being `HOME` the home directory of the user who runs the tests, 
+Set the configurations at `$HOME/.aws/config` (being `HOME` the home directory of the user who runs the tests,
  more information [here](https://documentation.wazuh.com/current/amazon/services/prerequisites/credentials.html#profiles) with the content:
 
  ```ini
@@ -134,8 +138,6 @@ The provided credentials must have the following set of minimum permissions defi
     "sqs:GetQueueAttributes",
     "sqs:GetQueueUrl"
 
-    "inspector:ListFindings",
-    "inspector:DescribeFindings",
     "inspector2:ListFindings"
 ```
 
@@ -173,11 +175,11 @@ _We are using **Ubuntu 22.04** for this example:_
 
     # Clone the `qa-integration-framework` repository withing your testing environment
     git clone https://github.com/wazuh/qa-integration-framework.git
-  
+
     # Install tests dependencies
     python3 -m pip install qa-integration-framework/
     ```
-  
+
 
 ## Integration tests
 

--- a/tests/integration/test_aws/data/configuration_template/discard_regex_test_module/configuration_inspector_discard_regex.yaml
+++ b/tests/integration/test_aws/data/configuration_template/discard_regex_test_module/configuration_inspector_discard_regex.yaml
@@ -9,6 +9,8 @@
             attributes:
               - type: SERVICE_TYPE
             elements:
+              - aws_profile:
+                  value: inspector_tests
               - only_logs_after:
                   value: ONLY_LOGS_AFTER
               - regions:

--- a/tests/integration/test_aws/data/test_cases/discard_regex_test_module/cases_inspector_discard_regex.yaml
+++ b/tests/integration/test_aws/data/test_cases/discard_regex_test_module/cases_inspector_discard_regex.yaml
@@ -1,18 +1,19 @@
 - name: inspector_discard_regex
   description: >
-    Inspector configuration for an event being discarded when the regex matches
+    Inspector v2 configuration for an event being discarded when the regex matches
     the content in the specified field inside the incoming JSON log
   configuration_parameters:
     SERVICE_TYPE: inspector
-    REGIONS: us-east-1
-    DISCARD_FIELD: assetAttributes.tags.key
-    DISCARD_REGEX: .*inspector-integration-test.*
-    ONLY_LOGS_AFTER: 2023-JAN-12
+    REGIONS: us-east-2
+    DISCARD_FIELD: status
+    DISCARD_REGEX: ACTIVE
+    ONLY_LOGS_AFTER: 2025-SEP-15
   metadata:
     resource_type: finding
     service_type: inspector
-    only_logs_after: 2023-JAN-12
-    discard_field: assetAttributes.tags.key
-    discard_regex: .*inspector-integration-test.*
-    regions: us-east-1
-    skipped_logs: 11
+    aws_profile: inspector_tests
+    only_logs_after: 2025-SEP-15
+    discard_field: status
+    discard_regex: ACTIVE
+    regions: us-east-2
+    skipped_logs: 1

--- a/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_inspector_with_only_logs_after.yaml
+++ b/tests/integration/test_aws/data/test_cases/only_logs_after_test_module/cases_inspector_with_only_logs_after.yaml
@@ -7,8 +7,5 @@
     service_type: inspector
     aws_profile: inspector_tests
     only_logs_after: 2025-SEP-15
-    # Validate V1 and V2 separately:
-    # - V1 must execute successfully (can return 0+ events)
-    # - V2 must execute successfully (returns 106-155 events for this dataset)
-    # - Total must be at least 106 events
+    # V2 returns 106-155 events for this dataset; total must be at least 106
     expected_results_min: 106

--- a/tests/integration/test_aws/data/test_cases/regions_test_module/cases_inspector_regions.yaml
+++ b/tests/integration/test_aws/data/test_cases/regions_test_module/cases_inspector_regions.yaml
@@ -8,10 +8,7 @@
     aws_profile: inspector_tests
     only_logs_after: 2025-SEP-15
     regions: us-east-2
-    # Validate V1 and V2 separately:
-    # - V1 must execute successfully (can return 0+ events)
-    # - V2 must execute successfully (returns 106-155 events for this dataset)
-    # - Total must be at least 106 events
+    # V2 returns 106-155 events for this dataset; total must be at least 106
     expected_results_min: 106
 
 - name: inspector_inexistent_region

--- a/tests/integration/test_aws/test_discard_regex.py
+++ b/tests/integration/test_aws/test_discard_regex.py
@@ -485,6 +485,7 @@ def test_inspector_discard_regex(
         - The `cases_inspector_discard_regex` file provides the test cases.
     """
     service_type = metadata.get('service_type')
+    aws_profile = metadata.get('aws_profile')
     only_logs_after = metadata.get('only_logs_after')
     regions: str = metadata.get('regions')
     discard_field = metadata.get('discard_field', '')
@@ -497,6 +498,7 @@ def test_inspector_discard_regex(
     parameters = [
         'wodles/aws/aws-s3',
         '--service', service_type,
+        '--aws_profile', aws_profile,
         '--only_logs_after', only_logs_after,
         '--regions', regions,
         '--discard-field', discard_field,

--- a/tests/integration/test_aws/test_only_logs_after.py
+++ b/tests/integration/test_aws/test_only_logs_after.py
@@ -664,15 +664,8 @@ def test_inspector_with_only_logs_after(
 
     assert log_monitor.callback_result is not None, ERROR_MESSAGE['incorrect_parameters']
 
-    # For inspector, validate V1 and V2 APIs both execute successfully
+    # For inspector, validate InspectorV2 API executed successfully
     if service_type == 'inspector' and expected_results_min is not None:
-        # Validate InspectorV1 API executed (can return 0+ events)
-        log_monitor.start(
-            timeout=TIMEOUT[10],
-            callback=event_monitor.make_aws_callback(r'.*\[InspectorV1\] \d+ events collected and processed'),
-        )
-        assert log_monitor.callback_result is not None, 'InspectorV1 API did not execute - check logs'
-
         # Validate InspectorV2 API executed (can return 0+ events or report no updates)
         log_monitor.start(
             timeout=TIMEOUT[10],
@@ -951,14 +944,6 @@ def test_inspector_multiple_calls(
     # Call the module with only_logs_after set in the past and check that the expected number of logs were processed.
     # Validate V1 and V2 APIs both execute successfully, and total events meets minimum (106)
     command_output = call_aws_module(*base_parameters, ONLY_LOGS_AFTER_PARAM, '2025-SEP-15')
-
-    # Validate InspectorV1 API executed (can return 0+ events)
-    analyze_command_output(
-        command_output=command_output,
-        callback=event_monitor.make_aws_callback(r'.*\[InspectorV1\] \d+ events collected and processed'),
-        expected_results=1,
-        error_message='InspectorV1 API did not execute - check logs'
-    )
 
     # Validate InspectorV2 API executed (can return 0+ events or report no updates)
     analyze_command_output(

--- a/tests/integration/test_aws/test_regions.py
+++ b/tests/integration/test_aws/test_regions.py
@@ -142,7 +142,7 @@ def test_regions(
             accumulations=expected_results
         )
         assert log_monitor.callback_result is not None, ERROR_MESSAGE['incorrect_event_number']
-        
+
         assert path_exist(path=S3_CLOUDTRAIL_DB_PATH)
 
         # Validate database updates
@@ -157,7 +157,7 @@ def test_regions(
         for region in regions_list:
             if region not in ALL_REGIONS:
                 invalid_region = region
-                break        
+                break
         log_monitor.start(
             timeout=session_parameters.default_timeout,
             callback=event_monitor.make_aws_callback(
@@ -432,15 +432,8 @@ def test_inspector_regions(
 
     assert log_monitor.callback_result is not None, ERROR_MESSAGE['incorrect_parameters']
 
-    # For inspector, validate V1 and V2 APIs both execute successfully
+    # For inspector, validate InspectorV2 API executed successfully
     if service_type == 'inspector' and expected_results_min is not None:
-        # Validate InspectorV1 API executed (can return 0+ events)
-        log_monitor.start(
-            timeout=TIMEOUT[10],
-            callback=event_monitor.make_aws_callback(r'.*\[InspectorV1\] \d+ events collected and processed'),
-        )
-        assert log_monitor.callback_result is not None, 'InspectorV1 API did not execute - check logs'
-
         # Validate InspectorV2 API executed (can return 0+ events or report no updates)
         log_monitor.start(
             timeout=TIMEOUT[10],

--- a/wodles/aws/aws_s3.py
+++ b/wodles/aws/aws_s3.py
@@ -124,7 +124,7 @@ def main(argv):
                         aws_tools.debug(
                             "+++ Warning: No regions were specified, trying to get events from supported regions", 1
                         )
-                        options.regions = services.inspector.INSPECTOR_V1_REGIONS + services.inspector.INSPECTOR_V2_REGIONS
+                        options.regions = services.inspector.INSPECTOR_V2_REGIONS
                     else:
                         aws_tools.debug(
                             "+++ Warning: No regions were specified, trying to get events from all regions", 1

--- a/wodles/aws/services/inspector.py
+++ b/wodles/aws/services/inspector.py
@@ -4,7 +4,7 @@
 
 import sys
 from os import path
-from datetime import datetime
+from datetime import datetime, timezone
 
 sys.path.append(path.dirname(path.realpath(__file__)))
 import aws_service
@@ -12,15 +12,12 @@ import aws_service
 sys.path.insert(0, path.dirname(path.dirname(path.abspath(__file__))))
 import aws_tools
 
-INSPECTOR_V1_REGIONS = (
-    'ap-northeast-1', 'ap-northeast-2', 'ap-south-1', 'ap-southeast-2', 'eu-central-1', 'eu-north-1', 'eu-west-1',
-    'eu-west-2', 'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2'
-)
-
-INSPECTOR_V2_REGIONS = INSPECTOR_V1_REGIONS + (
-    'af-south-1', 'ap-east-1', 'ap-northeast-3', 'ap-southeast-1', 'ap-southeast-3', 'ap-southeast-4', 'ap-southeast-5',
-    'ap-southeast-7', 'ap-south-2', 'ca-central-1', 'ca-west-1', 'eu-west-3', 'eu-central-2', 'eu-south-1',
-    'eu-south-2', 'il-central-1', 'me-central-1', 'sa-east-1', 'mx-central-1'
+INSPECTOR_V2_REGIONS = (
+    'af-south-1', 'ap-east-1', 'ap-northeast-1', 'ap-northeast-2', 'ap-northeast-3', 'ap-south-1', 'ap-south-2',
+    'ap-southeast-1', 'ap-southeast-2', 'ap-southeast-3', 'ap-southeast-4', 'ap-southeast-5', 'ap-southeast-7',
+    'ca-central-1', 'ca-west-1', 'eu-central-1', 'eu-central-2', 'eu-north-1', 'eu-south-1', 'eu-south-2',
+    'eu-west-1', 'eu-west-2', 'eu-west-3', 'il-central-1', 'me-central-1', 'mx-central-1', 'sa-east-1',
+    'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2'
 )
 
 
@@ -74,29 +71,7 @@ class AWSInspector(aws_service.AWSService):
         # max DB records for region
         self.retain_db_records = 5
         self.sent_events = 0
-        self.sent_events_v1 = 0
         self.sent_events_v2 = 0
-
-    def send_describe_findings(self, arn_list: list):
-        """
-        Collect and send to analysisd the requested findings.
-
-        Parameters
-        ----------
-        arn_list : list[str]
-            The ARN of the findings that should be requested to AWS and sent to analysisd.
-        """
-        if arn_list:
-            response = self.client.describe_findings(findingArns=arn_list)['findings']
-            aws_tools.debug(f"+++ [InspectorV1] Processing {len(response)} events", 3)
-            for elem in response:
-                if self.event_should_be_skipped(elem):
-                    aws_tools.debug(f'+++ [InspectorV1] The "{self.discard_regex.pattern}" regex found a match in the '
-                                    f'"{self.discard_field}" field. The event will be skipped.', 2)
-                    continue
-                self.send_msg(self.format_message(elem))
-                self.sent_events += 1
-                self.sent_events_v1 += 1
 
     def get_alerts(self):
         self.init_db(self.sql_create_table.format(table_name=self.db_table_name))
@@ -127,37 +102,15 @@ class AWSInspector(aws_service.AWSService):
             date_scan = date_only_logs if date_only_logs > date_last_scan else date_last_scan
 
         # get current time (UTC)
-        date_current = datetime.utcnow()
+        date_current = datetime.now(timezone.utc).replace(tzinfo=None)
 
-        # Note: Regions in both INSPECTOR_V1_REGIONS and INSPECTOR_V2_REGIONS will process
-        # findings from both APIs, accumulating events in self.sent_events
-        if self.region in INSPECTOR_V1_REGIONS:
-            aws_tools.debug(f"+++ Listing findings from {date_scan}", 2)
-            response = self.client.list_findings(maxResults=100,
-                                                 filter={'creationTimeRange': {'beginDate': date_scan,
-                                                                               'endDate': date_current}})
-            self.send_describe_findings(response['findingArns'])
+        aws_tools.debug(f"+++ Attempting to fetch Inspector V2 findings from {date_scan}", 2)
+        self.get_alerts_inspector_v2(date_scan, date_current)
 
-            while 'nextToken' in response:
-                response = self.client.list_findings(maxResults=100,
-                                                     nextToken=response['nextToken'],
-                                                     filter={'creationTimeRange': {'beginDate': date_scan,
-                                                                                   'endDate': date_current}})
-                self.send_describe_findings(response['findingArns'])
-
-        if self.region in INSPECTOR_V2_REGIONS:
-            aws_tools.debug(f"+++ Attempting to fetch Inspector V2 findings from {date_scan}", 2)
-            self.get_alerts_inspector_v2(date_scan, date_current)
-
-        # Log events collected from each API separately for validation
-        if self.region in INSPECTOR_V1_REGIONS:
-            aws_tools.debug(f"+++ [InspectorV1] {self.sent_events_v1} events collected and processed", 1)
-
-        if self.region in INSPECTOR_V2_REGIONS:
-            if self.sent_events_v2 > 0:
-                aws_tools.debug(f"+++ [InspectorV2] {self.sent_events_v2} events collected and processed", 1)
-            else:
-                aws_tools.debug(f"+++ [InspectorV2] No findings with recent updates in the specified time range", 1)
+        if self.sent_events_v2 > 0:
+            aws_tools.debug(f"+++ [InspectorV2] {self.sent_events_v2} events collected and processed", 1)
+        else:
+            aws_tools.debug(f"+++ [InspectorV2] No findings with recent updates in the specified time range", 1)
 
         if self.sent_events:
             aws_tools.debug(f"+++ Total: {self.sent_events} events collected and processed in {self.region}", 1)
@@ -169,7 +122,7 @@ class AWSInspector(aws_service.AWSService):
             'service_name': self.service_name,
             'aws_account_id': self.account_id,
             'aws_region': self.region,
-            'scan_date': date_current})
+            'scan_date': date_current.strftime('%Y-%m-%d %H:%M:%S.%f')})
         # DB maintenance
         self.db_cursor.execute(self.sql_db_maintenance.format(table_name=self.db_table_name), {
             'service_name': self.service_name,
@@ -250,5 +203,5 @@ class AWSInspector(aws_service.AWSService):
 
     @staticmethod
     def check_region(region: str) -> None:
-        if region not in INSPECTOR_V1_REGIONS and region not in INSPECTOR_V2_REGIONS:
+        if region not in INSPECTOR_V2_REGIONS:
             raise ValueError(f"Unsupported region '{region}'")

--- a/wodles/aws/tests/test_aws_s3.py
+++ b/wodles/aws/tests/test_aws_s3.py
@@ -60,7 +60,7 @@ def test_main(mock_arguments, args: list[str], class_):
         instance.iter_bucket.assert_called_once()
     elif 'service' in args[1]:
         if args[2] == 'inspector':
-            total_regions = len(services.inspector.INSPECTOR_V1_REGIONS) + len(services.inspector.INSPECTOR_V2_REGIONS)
+            total_regions = len(services.inspector.INSPECTOR_V2_REGIONS)
             assert mocked_class.call_count == total_regions
             assert instance.get_alerts.call_count == total_regions
         else:

--- a/wodles/aws/tests/test_inspector.py
+++ b/wodles/aws/tests/test_inspector.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -19,32 +19,21 @@ TEST_SERVICES_SCHEMA = 'schema_services_test.sql'
 
 
 def mock_get_client(*args, **kwargs):
-    if kwargs.get('region') in inspector.INSPECTOR_V2_REGIONS:
-        mock_client = MagicMock()
-        mock_client.list_findings.side_effect = [
-            {
-                'findings': [
-                    {'arn': 'arn1', 'schemaVersion': 123, 'service': 'inspector2'}
-                ],
-                'nextToken': 'tok1'
-            },
-            {
-                'findings': [
-                    {'arn': 'arn2', 'schemaVersion': 123, 'service': 'inspector2'}
-                ]
-            }
-        ]
-        return mock_client
-    else:
-        mock_client = MagicMock()
-        mock_client.list_findings.return_value = {'findingArns': ['arn1', 'arn2']}
-        mock_client.describe_findings.return_value = {
+    mock_client = MagicMock()
+    mock_client.list_findings.side_effect = [
+        {
             'findings': [
-                {'arn': 'arn1', 'schemaVersion': 123, 'service': 'inspector_service'},
-                {'arn': 'arn2', 'schemaVersion': 123, 'service': 'inspector_service'}
+                {'arn': 'arn1', 'schemaVersion': 123, 'service': 'inspector2'}
+            ],
+            'nextToken': 'tok1'
+        },
+        {
+            'findings': [
+                {'arn': 'arn2', 'schemaVersion': 123, 'service': 'inspector2'}
             ]
         }
-        return mock_client
+    ]
+    return mock_client
 
 
 @patch('wazuh_integration.WazuhIntegration.get_sts_client')
@@ -58,42 +47,15 @@ def test_aws_inspector_initializes_properly(mock_aws_service, mock_sts_client):
     assert instance.sent_events == 0
 
 
-@patch('aws_service.AWSService.get_sts_client')
-def test_aws_inspector_send_describe_findings(mock_sts_client):
-    """Test 'send_describe_findings' method sends the findings to Analysisd and updates the instance's sent_events attribute accordingly to the number of findings."""
-    arn_list = ['arn1']
-
-    instance = utils.get_mocked_service(class_=inspector.AWSInspector)
-
-    mock_client = MagicMock()
-    instance.client = mock_client
-    instance.client.describe_findings.return_value = {
-        'findings': [
-            {
-                'arn': 'arn1',
-                'schemaVersion': 123,
-                'service': 'string',
-            }
-        ]
-    }
-    with patch('wazuh_integration.WazuhIntegration.send_msg') as mock_send_msg, \
-            patch('aws_service.AWSService.format_message') as mock_format:
-        instance.send_describe_findings(arn_list)
-        assert instance.sent_events == 1
-        mock_send_msg.assert_called_once()
-        mock_format.assert_called_once()
-
-
 @pytest.mark.parametrize('reparse', [True, False])
 @pytest.mark.parametrize('only_logs_after', [utils.TEST_ONLY_LOGS_AFTER, None])
 @patch('wazuh_integration.WazuhAWSDatabase.init_db')
 @patch('wazuh_integration.WazuhAWSDatabase.close_db')
-@patch('inspector.AWSInspector.send_describe_findings')
 @patch('inspector.aws_tools.debug')
 @patch('wazuh_integration.WazuhIntegration.get_sts_client')
 @patch('wazuh_integration.WazuhIntegration.send_msg')
 @patch.object(inspector.AWSInspector, 'get_client', mock_get_client)
-def test_aws_inspector_get_alerts(mock_send_msg, mock_sts_client, mock_debug, mock_send_describe_findings, mock_init_db, mock_close_db,
+def test_aws_inspector_get_alerts(mock_send_msg, mock_sts_client, mock_debug, mock_init_db, mock_close_db,
                                   only_logs_after, reparse, custom_database):
     """Test 'get_alerts' method sends the collected events and updates the DB accordingly."""
     utils.database_execute_script(custom_database, TEST_SERVICES_SCHEMA)
@@ -106,11 +68,6 @@ def test_aws_inspector_get_alerts(mock_send_msg, mock_sts_client, mock_debug, mo
     instance.db_connector = custom_database
     instance.db_cursor = instance.db_connector.cursor()
 
-    instance.client = MagicMock()
-    mock_list_findings = instance.client.list_findings
-    mock_list_findings.side_effect = [{'findingArns': ['arn1'], 'nextToken': None},
-                                      {'findingArns': ['arn2']}]
-
     instance.get_alerts()
 
     last_scan_date = utils.database_execute_query(custom_database,
@@ -121,7 +78,7 @@ def test_aws_inspector_get_alerts(mock_send_msg, mock_sts_client, mock_debug, mo
                                                       'aws_region': instance.region}
                                                   )
 
-    assert datetime.strptime(last_scan_date.split(' ')[0], "%Y-%m-%d").strftime("%Y%m%d") == datetime.utcnow().strftime(
+    assert datetime.strptime(last_scan_date.split(' ')[0], "%Y-%m-%d").strftime("%Y%m%d") == datetime.now(timezone.utc).strftime(
         "%Y%m%d")
 
 
@@ -143,10 +100,6 @@ def test_aws_inspector_v2_get_alerts(mock_send_msg, mock_sts_client, mock_debug,
     instance.db_connector = custom_database
     instance.db_cursor = instance.db_connector.cursor()
 
-    instance.client = MagicMock()
-    instance.client.list_findings.return_value = {'findingArns': []}
-    instance.client.describe_findings.return_value = {'findings': []}
-
     instance.get_alerts()
 
     last_scan_date = utils.database_execute_query(
@@ -158,4 +111,84 @@ def test_aws_inspector_v2_get_alerts(mock_send_msg, mock_sts_client, mock_debug,
             'aws_region': instance.region
         }
     )
-    assert datetime.strptime(last_scan_date.split(' ')[0], "%Y-%m-%d").strftime("%Y%m%d") == datetime.utcnow().strftime("%Y%m%d")
+    assert datetime.strptime(last_scan_date.split(' ')[0], "%Y-%m-%d").strftime("%Y%m%d") == datetime.now(timezone.utc).strftime("%Y%m%d")
+
+
+@patch('wazuh_integration.WazuhAWSDatabase.init_db')
+@patch('wazuh_integration.WazuhAWSDatabase.close_db')
+@patch('wazuh_integration.WazuhIntegration.send_msg')
+@patch('wazuh_integration.WazuhIntegration.get_sts_client')
+@patch('inspector.aws_tools.debug')
+def test_aws_inspector_v2_get_alerts_logs_no_findings_when_sent_events_v2_is_zero(
+        mock_debug, mock_sts_client, mock_send_msg, mock_close_db, mock_init_db, custom_database):
+    """Test get_alerts logs 'No findings' message when InspectorV2 returns 0 findings."""
+    utils.database_execute_script(custom_database, TEST_SERVICES_SCHEMA)
+    region = inspector.INSPECTOR_V2_REGIONS[-1]
+
+    instance = utils.get_mocked_service(class_=inspector.AWSInspector, region=region)
+    instance.account_id = utils.TEST_ACCOUNT_ID
+    instance.db_connector = custom_database
+    instance.db_cursor = instance.db_connector.cursor()
+
+    v2_client = MagicMock()
+    v2_client.list_findings.return_value = {'findings': []}
+
+    with patch.object(instance, 'get_client', return_value=v2_client):
+        instance.get_alerts()
+
+    mock_debug.assert_any_call(
+        f"+++ [InspectorV2] No findings with recent updates in the specified time range", 1)
+
+
+@patch('wazuh_integration.WazuhAWSDatabase.init_db')
+@patch('wazuh_integration.WazuhAWSDatabase.close_db')
+@patch('wazuh_integration.WazuhIntegration.send_msg')
+@patch('wazuh_integration.WazuhIntegration.get_sts_client')
+@patch('inspector.aws_tools.debug')
+def test_aws_inspector_get_alerts_logs_no_new_events_when_nothing_sent(
+        mock_debug, mock_sts_client, mock_send_msg, mock_close_db, mock_init_db, custom_database):
+    """Test get_alerts logs 'no new events' when sent_events is 0 (V2 returns nothing)."""
+    utils.database_execute_script(custom_database, TEST_SERVICES_SCHEMA)
+    region = inspector.INSPECTOR_V2_REGIONS[0]
+
+    instance = utils.get_mocked_service(class_=inspector.AWSInspector, region=region)
+    instance.account_id = utils.TEST_ACCOUNT_ID
+    instance.db_connector = custom_database
+    instance.db_cursor = instance.db_connector.cursor()
+
+    v2_client = MagicMock()
+    v2_client.list_findings.return_value = {'findings': []}
+
+    with patch.object(instance, 'get_client', return_value=v2_client):
+        instance.get_alerts()
+
+    mock_debug.assert_any_call(
+        f'+++ There are no new events in the "{region}" region', 1)
+
+
+@patch('wazuh_integration.WazuhIntegration.send_msg')
+@patch('wazuh_integration.WazuhIntegration.get_sts_client')
+@patch('inspector.aws_tools.debug')
+def test_aws_inspector_v2_get_alerts_inspector_v2_skips_event_matching_discard_field(
+        mock_debug, mock_sts_client, mock_send_msg):
+    """Test get_alerts_inspector_v2 skips a finding when event_should_be_skipped returns True."""
+    instance = utils.get_mocked_service(
+        class_=inspector.AWSInspector,
+        region=inspector.INSPECTOR_V2_REGIONS[0],
+        discard_field='severity',
+        discard_regex='LOW'
+    )
+
+    v2_client = MagicMock()
+    v2_client.list_findings.return_value = {
+        'findings': [{'severity': 'LOW', 'findingArn': 'arn:low'}]
+    }
+
+    with patch.object(instance, 'get_client', return_value=v2_client):
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        instance.get_alerts_inspector_v2(now, now)
+
+    mock_send_msg.assert_not_called()
+    mock_debug.assert_any_call(
+        f'+++ [InspectorV2] The "LOW" regex found a match in the '
+        f'"severity" field. The event will be skipped.', 2)


### PR DESCRIPTION
## Description

Amazon Inspector Classic (v1) reached its AWS end-of-life on May 20, 2026. After that date, the Classic `inspector` API endpoints no longer respond, so any integration still calling them will silently fail or produce errors at runtime.

The AWS integration kept an active Classic code path: regions in `INSPECTOR_V1_REGIONS` would call `list_findings()` and `describe_findings()` (Classic APIs), and the 12 regions that appeared in both lists would query both Classic and v2 on every run. The default-region fallback in `aws_s3.py` also concatenated both lists, producing 12 duplicate regions that would be iterated twice.

This pull request removes the Classic path entirely, keeping only the Inspector v2 code path.

Closes #36733

## Proposed Changes

- Removed `INSPECTOR_V1_REGIONS` constant and flattened `INSPECTOR_V2_REGIONS` into a single self-contained 31-region tuple in `inspector.py`.
- Removed `send_describe_findings()` method and `sent_events_v1` counter.
- Removed all Classic API call blocks from `get_alerts()` — the method now calls `get_alerts_inspector_v2()` unconditionally.
- Simplified `check_region()` to validate against `INSPECTOR_V2_REGIONS` only.
- Fixed `aws_s3.py` default-region fallback: replaced `INSPECTOR_V1_REGIONS + INSPECTOR_V2_REGIONS` (43 entries, 12 duplicates) with `INSPECTOR_V2_REGIONS` (31 entries).
- Fixed `datetime.utcnow()` deprecation (Python 3.12) in `inspector.py` and `test_inspector.py`.
- Fixed sqlite3 default datetime adapter deprecation (Python 3.12): `date_current` is now explicitly formatted as a string before being stored.

**Files changed:**
- `wodles/aws/services/inspector.py`
- `wodles/aws/aws_s3.py`
- `wodles/aws/tests/test_inspector.py`

### Results and Evidence

```
39 passed, 0 failed
```

Warnings originating from our files before and after:

| Warning | Before | After |
|---|---|---|
| `datetime.utcnow()` deprecation (`inspector.py`) | 37 | 0 |
| sqlite3 datetime adapter deprecation (`inspector.py`) | 37 | 0 |
| `datetime.utcnow()` deprecation (`test_inspector.py`) | 77 | 0 |

Remaining warnings are from third-party packages (`pytest` 7.3.1 / `pytest-asyncio`) and `wazuh_integration.py` (base class, out of scope).

### Artifacts Affected

- `wodles/aws/services/inspector.py` — Inspector service module
- `wodles/aws/aws_s3.py` — AWS integration entry point

### Configuration Changes

None. The `inspector` service name in `ossec.conf` is unchanged. All 31 Inspector v2 regions continue to be supported. The only behavioral change is that Classic API calls are no longer made.

### Documentation Updates

Pending — the documentation review for Inspector Classic removal is tracked in #36733.

### Tests Introduced

No new tests added. Removed 2 obsolete v1-only tests:

- `test_aws_inspector_send_describe_findings`
- `test_aws_inspector_send_describe_findings_skips_event_matching_discard_field`

Updated 5 existing tests to remove stale v1 mock setup (`describe_findings`, v1 `list_findings` side effects, `INSPECTOR_V1_REGIONS` references).

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
