### PR TITLE
Align VD feed-download log levels with indexer consumer state

### DIFF
--- a/src/shared_modules/content_manager/doc/components/INDEXER_DOWNLOADER.md
+++ b/src/shared_modules/content_manager/doc/components/INDEXER_DOWNLOADER.md
@@ -28,8 +28,10 @@ If `consumerStatusIndex` and `consumerStatusId` are configured, the downloader p
 
 - missing document: wait 1 minute and retry
 - empty `status`: wait 1 minute and retry
-- `status = updating`: wait 1 minute and retry
-- `status = idle`: start the download
+- `status = running`: wait 1 minute and retry
+- `status = failed`: wait 1 minute and retry (logged at debug, escalating to a warning after repeated failures)
+- `status = ready`: start the download
+- any other value: wait 1 minute and retry (logged as a warning with the received status)
 
 This gate answers only one question: whether it is safe to start reading from Indexer. It does not replace the consumer-side validation of the downloaded local feed.
 

--- a/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
@@ -65,15 +65,15 @@ private:
     {
         Missing,
         Empty,
-        Updating,
-        Idle,
+        Running,
+        Ready,
+        Failed,
         Unknown
     };
 
     static constexpr std::chrono::seconds INDEXER_RETRY_INTERVAL {30};
 
-    /// Failed initial-load attempts logged below WARNING before escalating (indexer is commonly
-    /// overloaded right after a restart, so early failures are expected).
+    /// Consecutive failures tolerated below WARNING before escalating (indexer settling after restart).
     static constexpr std::size_t INDEXER_WARN_AFTER_ATTEMPTS {3};
 
     nlohmann::json m_config;
@@ -129,16 +129,15 @@ private:
     }
 
     /**
-     * @brief Reads the current consumer status document from `.wazuh-cti-consumers`.
+     * @brief Reads the consumer status from `.wazuh-cti-consumers`: "ready" (safe to query),
+     *        "running" (indexing, wait), "failed", or empty/missing (not ready yet).
      *
-     * The indexer-side contract guarantees that the document status is:
-     *   - empty / missing while the consumer is not ready yet,
-     *   - "updating" while the feed is still being indexed,
-     *   - "idle" only when the consumer can be queried safely.
+     * @param outRawStatus If non-null, receives the raw status string for logging.
      */
     ConsumerStatus readConsumerStatus(IndexerConnectorSync& syncConnector,
                                       std::string_view consumerStatusIndex,
-                                      std::string_view consumerStatusId) const
+                                      std::string_view consumerStatusId,
+                                      std::string* outRawStatus = nullptr) const
     {
         const auto query =
             nlohmann::json {{"ids", {{"values", nlohmann::json::array({std::string {consumerStatusId}})}}}};
@@ -168,29 +167,37 @@ private:
 
         std::string status;
         source.at("status").get_to(status);
+        if (outRawStatus)
+        {
+            *outRawStatus = status;
+        }
         if (status.empty())
         {
             return ConsumerStatus::Empty;
         }
-        if (status == "idle")
+        if (status == "ready")
         {
-            return ConsumerStatus::Idle;
+            return ConsumerStatus::Ready;
         }
-        if (status == "updating")
+        if (status == "running")
         {
-            return ConsumerStatus::Updating;
+            return ConsumerStatus::Running;
+        }
+        if (status == "failed")
+        {
+            return ConsumerStatus::Failed;
         }
 
         return ConsumerStatus::Unknown;
     }
 
     /**
-     * @brief Waits until the consumer status document becomes `idle`.
+     * @brief Waits until the consumer status document becomes `ready`.
      *
      * If the consumer status settings are not configured, the wait is skipped so
      * non-VD users of IndexerDownloader keep the previous behaviour.
      */
-    bool waitUntilConsumerIdle(UpdaterContext& context) const
+    bool waitUntilConsumerReady(UpdaterContext& context) const
     {
         static constexpr auto CONSUMER_STATUS_POLL_INTERVAL {std::chrono::minutes {1}};
 
@@ -205,95 +212,143 @@ private:
         if (context.spUpdaterBaseContext->spStopCondition->check())
         {
             logInfo(WM_CONTENTUPDATER,
-                    "IndexerDownloader: Stop requested before waiting for consumer '%s' to become idle.",
+                    "IndexerDownloader: Stop requested before waiting for consumer '%s' to become ready.",
                     consumerStatusId.c_str());
             return false;
         }
 
         IndexerConnectorSync syncConnector(m_config.at("indexer"), LoggingContext {WM_CONTENTUPDATER, {}});
 
+        const auto pollSeconds = static_cast<size_t>(
+            std::chrono::duration_cast<std::chrono::seconds>(CONSUMER_STATUS_POLL_INTERVAL).count());
+
+        // Early query/failed-status results are expected (indexer still settling): DEBUG until the threshold.
+        size_t queryFailures = 0;
+        size_t failedStatusCount = 0;
+
         while (true)
         {
             if (context.spUpdaterBaseContext->spStopCondition->check())
             {
                 logInfo(WM_CONTENTUPDATER,
-                        "IndexerDownloader: Stop requested while waiting for consumer '%s' to become idle.",
+                        "IndexerDownloader: Stop requested while waiting for consumer '%s' to become ready.",
                         consumerStatusId.c_str());
                 return false;
             }
 
             try
             {
-                switch (readConsumerStatus(syncConnector, consumerStatusIndex, consumerStatusId))
+                std::string rawStatus;
+                const auto status =
+                    readConsumerStatus(syncConnector, consumerStatusIndex, consumerStatusId, &rawStatus);
+                queryFailures = 0; // Indexer reachable again.
+                if (status != ConsumerStatus::Failed)
                 {
-                    case ConsumerStatus::Idle:
+                    failedStatusCount = 0;
+                }
+
+                switch (status)
+                {
+                    case ConsumerStatus::Ready:
                         logInfo(WM_CONTENTUPDATER,
-                                "IndexerDownloader: Consumer '%s' in index '%s' is idle. Starting feed download.",
+                                "IndexerDownloader: Consumer '%s' in index '%s' is ready. Starting feed download.",
                                 consumerStatusId.c_str(),
                                 consumerStatusIndex.c_str());
                         return true;
 
                     case ConsumerStatus::Missing:
                         logInfo(WM_CONTENTUPDATER,
-                                "IndexerDownloader: Consumer '%s' not found in '%s'. Waiting %zu s before retrying.",
+                                "IndexerDownloader: Consumer '%s' not found in '%s'. Waiting %zus before retrying.",
                                 consumerStatusId.c_str(),
                                 consumerStatusIndex.c_str(),
-                                static_cast<size_t>(
-                                    std::chrono::duration_cast<std::chrono::seconds>(CONSUMER_STATUS_POLL_INTERVAL)
-                                        .count()));
+                                pollSeconds);
                         break;
 
                     case ConsumerStatus::Empty:
                         logInfo(WM_CONTENTUPDATER,
-                                "IndexerDownloader: Consumer '%s' has empty status in '%s'. Waiting %zu s before "
+                                "IndexerDownloader: Consumer '%s' has empty status in '%s'. Waiting %zus before "
                                 "retrying.",
                                 consumerStatusId.c_str(),
                                 consumerStatusIndex.c_str(),
-                                static_cast<size_t>(
-                                    std::chrono::duration_cast<std::chrono::seconds>(CONSUMER_STATUS_POLL_INTERVAL)
-                                        .count()));
+                                pollSeconds);
                         break;
 
-                    case ConsumerStatus::Updating:
+                    case ConsumerStatus::Running:
                         logInfo(WM_CONTENTUPDATER,
-                                "IndexerDownloader: Consumer '%s' is still updating in '%s'. Waiting %zu s before "
+                                "IndexerDownloader: Consumer '%s' is still running in '%s'. Waiting %zus before "
                                 "retrying.",
                                 consumerStatusId.c_str(),
                                 consumerStatusIndex.c_str(),
-                                static_cast<size_t>(
-                                    std::chrono::duration_cast<std::chrono::seconds>(CONSUMER_STATUS_POLL_INTERVAL)
-                                        .count()));
+                                pollSeconds);
+                        break;
+
+                    case ConsumerStatus::Failed:
+                        ++failedStatusCount;
+                        if (failedStatusCount >= INDEXER_WARN_AFTER_ATTEMPTS)
+                        {
+                            logWarn(WM_CONTENTUPDATER,
+                                    "IndexerDownloader: Consumer '%s' in '%s' reports a failed status. Waiting %zus "
+                                    "before retrying.",
+                                    consumerStatusId.c_str(),
+                                    consumerStatusIndex.c_str(),
+                                    pollSeconds);
+                        }
+                        else
+                        {
+                            logDebug2(WM_CONTENTUPDATER,
+                                      "IndexerDownloader: Consumer '%s' in '%s' reports a failed status — waiting %zus "
+                                      "before retrying (attempt %zu/%zu).",
+                                      consumerStatusId.c_str(),
+                                      consumerStatusIndex.c_str(),
+                                      pollSeconds,
+                                      failedStatusCount,
+                                      INDEXER_WARN_AFTER_ATTEMPTS);
+                        }
                         break;
 
                     case ConsumerStatus::Unknown:
                         logWarn(WM_CONTENTUPDATER,
-                                "IndexerDownloader: Consumer '%s' in '%s' returned an unknown status. Waiting %zu s "
-                                "before retrying.",
+                                "IndexerDownloader: Consumer '%s' in '%s' returned an unknown status '%s'. Waiting "
+                                "%zus before retrying.",
                                 consumerStatusId.c_str(),
                                 consumerStatusIndex.c_str(),
-                                static_cast<size_t>(
-                                    std::chrono::duration_cast<std::chrono::seconds>(CONSUMER_STATUS_POLL_INTERVAL)
-                                        .count()));
+                                rawStatus.c_str(),
+                                pollSeconds);
                         break;
                 }
             }
             catch (const std::exception& e)
             {
-                logWarn(WM_CONTENTUPDATER,
-                        "IndexerDownloader: Failed to query consumer '%s' in '%s' (%s). Waiting %zu s before "
-                        "retrying.",
-                        consumerStatusId.c_str(),
-                        consumerStatusIndex.c_str(),
-                        e.what(),
-                        static_cast<size_t>(
-                            std::chrono::duration_cast<std::chrono::seconds>(CONSUMER_STATUS_POLL_INTERVAL).count()));
+                ++queryFailures;
+                if (queryFailures >= INDEXER_WARN_AFTER_ATTEMPTS)
+                {
+                    logWarn(WM_CONTENTUPDATER,
+                            "IndexerDownloader: Failed to query consumer '%s' in '%s' (%s). Waiting %zus before "
+                            "retrying.",
+                            consumerStatusId.c_str(),
+                            consumerStatusIndex.c_str(),
+                            e.what(),
+                            pollSeconds);
+                }
+                else
+                {
+                    logDebug2(WM_CONTENTUPDATER,
+                              "IndexerDownloader: Indexer not available yet — cannot query consumer '%s' in '%s' (%s). "
+                              "Waiting %zus before retrying (attempt %zu/%zu).",
+                              consumerStatusId.c_str(),
+                              consumerStatusIndex.c_str(),
+                              e.what(),
+                              pollSeconds,
+                              queryFailures,
+                              INDEXER_WARN_AFTER_ATTEMPTS);
+                }
             }
 
             if (context.spUpdaterBaseContext->spStopCondition->waitFor(
                     std::chrono::duration_cast<std::chrono::milliseconds>(CONSUMER_STATUS_POLL_INTERVAL)))
             {
                 logInfo(WM_CONTENTUPDATER,
-                        "IndexerDownloader: Stop requested while waiting for consumer '%s' to become idle.",
+                        "IndexerDownloader: Stop requested while waiting for consumer '%s' to become ready.",
                         consumerStatusId.c_str());
                 return false;
             }
@@ -329,8 +384,8 @@ private:
             return;
         }
 
-        logWarn(WM_CONTENTUPDATER,
-                "IndexerDownloader: invalidating stored cursor and forcing a full reload on the next attempt.");
+        logDebug2(WM_CONTENTUPDATER,
+                  "IndexerDownloader: invalidating stored cursor and forcing a full reload on the next attempt.");
         context.spUpdaterBaseContext->spRocksDB->put(
             Utils::getCompactTimestamp(std::time(nullptr)), "0", Components::Columns::CURRENT_OFFSET);
     }
@@ -696,7 +751,7 @@ private:
                 errors.push_back("Slice " + std::to_string(sliceId) + ": " + e.what());
                 if (escalateLogs)
                 {
-                    logError(WM_CONTENTUPDATER, "IndexerDownloader: Slice %zu failed: %s", sliceId, e.what());
+                    logWarn(WM_CONTENTUPDATER, "IndexerDownloader: Slice %zu failed: %s", sliceId, e.what());
                 }
                 else
                 {
@@ -778,19 +833,19 @@ private:
                 if (escalate)
                 {
                     logWarn(WM_CONTENTUPDATER,
-                            "IndexerDownloader: Initial load failed (%s) — retrying in %zu s.",
+                            "IndexerDownloader: Initial load failed (%s) — retrying in %zus.",
                             e.what(),
                             static_cast<size_t>(INDEXER_RETRY_INTERVAL.count()));
                 }
                 else
                 {
-                    logInfo(WM_CONTENTUPDATER,
-                            "IndexerDownloader: Indexer not available yet (%s) — retrying in %zu s "
-                            "(attempt %zu/%zu).",
-                            e.what(),
-                            static_cast<size_t>(INDEXER_RETRY_INTERVAL.count()),
-                            attempt + 1,
-                            INDEXER_WARN_AFTER_ATTEMPTS);
+                    logDebug2(WM_CONTENTUPDATER,
+                              "IndexerDownloader: Indexer not available yet (%s) — retrying in %zus "
+                              "(attempt %zu/%zu).",
+                              e.what(),
+                              static_cast<size_t>(INDEXER_RETRY_INTERVAL.count()),
+                              attempt + 1,
+                              INDEXER_WARN_AFTER_ATTEMPTS);
                 }
             }
 
@@ -810,17 +865,17 @@ private:
                 if (escalate)
                 {
                     logWarn(WM_CONTENTUPDATER,
-                            "IndexerDownloader: Indexer index not ready (0 documents) — retrying in %zu s.",
+                            "IndexerDownloader: Indexer index not ready (0 documents) — retrying in %zus.",
                             static_cast<size_t>(INDEXER_RETRY_INTERVAL.count()));
                 }
                 else
                 {
-                    logInfo(WM_CONTENTUPDATER,
-                            "IndexerDownloader: Indexer index not ready yet (0 documents) — retrying in %zu s "
-                            "(attempt %zu/%zu).",
-                            static_cast<size_t>(INDEXER_RETRY_INTERVAL.count()),
-                            attempt + 1,
-                            INDEXER_WARN_AFTER_ATTEMPTS);
+                    logDebug2(WM_CONTENTUPDATER,
+                              "IndexerDownloader: Indexer index not ready yet (0 documents) — retrying in %zus "
+                              "(attempt %zu/%zu).",
+                              static_cast<size_t>(INDEXER_RETRY_INTERVAL.count()),
+                              attempt + 1,
+                              INDEXER_WARN_AFTER_ATTEMPTS);
                 }
             }
 
@@ -880,6 +935,9 @@ public:
     {
         logDebug1(WM_CONTENTUPDATER, "IndexerDownloader - Starting process");
 
+        // Early completion-validation failures are expected (indexer settling): DEBUG until the threshold.
+        size_t completionFailures = 0;
+
         while (!context->spUpdaterBaseContext->spStopCondition->check())
         {
             auto lastCursor = getStoredCursor(*context);
@@ -905,7 +963,7 @@ public:
             }
 
             const bool forceInitialLoad = lastCursor.empty();
-            if (!waitUntilConsumerIdle(*context))
+            if (!waitUntilConsumerReady(*context))
             {
                 break;
             }
@@ -933,10 +991,23 @@ public:
             }
 
             invalidateCursor(*context);
-            logWarn(WM_CONTENTUPDATER,
-                    "IndexerDownloader: downloaded feed is not ready after completion validation. "
-                    "The stored cursor was invalidated and a full reload will be retried in %zu s.",
-                    static_cast<size_t>(INDEXER_RETRY_INTERVAL.count()));
+            ++completionFailures;
+            if (completionFailures >= INDEXER_WARN_AFTER_ATTEMPTS)
+            {
+                logWarn(WM_CONTENTUPDATER,
+                        "IndexerDownloader: downloaded feed is not ready after completion validation. "
+                        "The stored cursor was invalidated and a full reload will be retried in %zus.",
+                        static_cast<size_t>(INDEXER_RETRY_INTERVAL.count()));
+            }
+            else
+            {
+                logDebug2(WM_CONTENTUPDATER,
+                          "IndexerDownloader: downloaded feed not ready yet after completion validation — "
+                          "invalidating cursor and retrying a full reload in %zus (attempt %zu/%zu).",
+                          static_cast<size_t>(INDEXER_RETRY_INTERVAL.count()),
+                          completionFailures,
+                          INDEXER_WARN_AFTER_ATTEMPTS);
+            }
 
             if (context->spUpdaterBaseContext->spStopCondition->waitFor(
                     std::chrono::duration_cast<std::chrono::milliseconds>(INDEXER_RETRY_INTERVAL)))

--- a/src/wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py
+++ b/src/wazuh_modules/vulnerability_scanner/qa/test_efficacy_log.py
@@ -144,7 +144,7 @@ def seed_cti_consumer_status():
 
     status_response = requests.put(
         f"{OPENSEARCH_URL}/{CTI_CONSUMERS_INDEX}/_doc/{CTI_CONSUMER_DOC_ID}?refresh=true",
-        json={"status": "idle"},
+        json={"status": "ready"},
         headers={"Content-Type": "application/json"},
     )
     if status_response.status_code not in [200, 201]:
@@ -152,7 +152,7 @@ def seed_cti_consumer_status():
             f"Failed to seed {CTI_CONSUMERS_INDEX}: {status_response.status_code} {status_response.text}"
         )
 
-    LOGGER.info("Seeded %s with idle consumer '%s'", CTI_CONSUMERS_INDEX, CTI_CONSUMER_DOC_ID)
+    LOGGER.info("Seeded %s with ready consumer '%s'", CTI_CONSUMERS_INDEX, CTI_CONSUMER_DOC_ID)
 
 def init_opensearch(low_resources):
     client = docker.from_env()

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -265,7 +265,7 @@ public:
                     if (std::filesystem::exists(UPDATER_PATH))
                     {
                         std::filesystem::remove_all(UPDATER_PATH);
-                        logWarn(WM_VULNSCAN_LOGTAG,
+                        logInfo(WM_VULNSCAN_LOGTAG,
                                 "The local feed database is incomplete at startup: required global maps are missing. "
                                 "Clearing updater state to force a clean rebuild.");
                     }
@@ -290,7 +290,7 @@ public:
             // Remove the updater directory to force the download of the complete feed.
             std::filesystem::remove_all(UPDATER_PATH);
 
-            logError(WM_VULNSCAN_LOGTAG, "Error opening the database: %s.", ex.what());
+            logWarn(WM_VULNSCAN_LOGTAG, "Error opening the database: %s.", ex.what());
         }
 
         // We first check if the content updater should be initialized.
@@ -309,8 +309,6 @@ public:
 
                     try
                     {
-                        logDebug2(WM_VULNSCAN_LOGTAG, "Initiating feed update process.");
-
                         // Extract fields needed after processMessage consumes the JSON.
                         const auto msgType = message.value("type", std::string {});
                         const bool changed = message.value("changed", true);


### PR DESCRIPTION
## Description

Closes #37197 and reduces warning noise during the VD feed download.

Two root causes:

1. The indexer renamed the CTI consumer status values (`idle`→`ready`, `updating`→`running`, added `failed`). The downloader still matched only `idle`/`updating`, so the new `ready`/`running` values fell through to "unknown status", producing the spurious warning reported in #37197.
2. Several transient conditions during start-up — consumer query failures, a `failed` consumer status and completion-validation failures while the indexer is still settling — were logged as `WARNING` on every retry.

## Log levels overview

| Log message | Level |
|---|---|
| `Failed to query consumer '...' (...)` | DEBUG → WARNING (3rd) |
| `Consumer '...' reports a failed status` | DEBUG → WARNING (3rd) |
| `Slice N failed: ...` | DEBUG → WARNING (3rd) |
| `Failed to delete PIT: ...` | DEBUG → WARNING (3rd) |
| `Initial load failed (...)` | DEBUG → WARNING (3rd) |
| `Indexer index not ready (0 documents)` | DEBUG → WARNING (3rd) |
| `downloaded feed is not ready after completion validation` | DEBUG → WARNING (3rd) |
| `Consumer '...' is ready / not found / empty / still running` | INFO |
| `Starting / Retrying initial full load`, `Starting sliced PIT download` | INFO |
| `Slice N complete`, `Initial load / Incremental update download phase complete` | INFO |
| `Starting incremental update from offset ...` | INFO |
| `Stop requested ...` (shutdown) | INFO |
| `local feed database is incomplete at startup ... Clearing updater state` (VD) | INFO |
| `No existing local vulnerability feed detected at startup` (VD) | INFO |
| `Consumer '...' returned an unknown status '<value>'` | WARNING |
| `Slice N failed to parse cursor '...'` | WARNING |
| `stored cursor '...' is not a valid integer` | WARNING |
| `Feed download completed, but the local feed database is still incomplete` (VD) | WARNING |
| `local feed database is incomplete: oscpe_rules or cna_mapping column is missing` (VD) | WARNING |
| `Error opening the database: ...` (VD) | WARNING |

`DEBUG → WARNING (3rd)`: logged at DEBUG for the first two consecutive failures, escalated on the third.


## Log example
- Forcing the indexer to restart every time the feed begins to download (3 times):
<details>

```
2026/06/26 10:35:03 wazuh-manager-modulesd[299452] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2026/06/26 10:35:03 wazuh-manager-modulesd[299452] main.c:90 at main(): DEBUG: Wazuh home directory: /var/wazuh-manager
2026/06/26 10:35:03 wazuh-manager-modulesd:router[299452] wm_router.c:98 at wm_router_read(): DEBUG: Loaded router module.
2026/06/26 10:35:03 wazuh-manager-modulesd:content_manager[299452] wm_content_manager.c:87 at wm_content_manager_read(): DEBUG: Loaded content_manager module.
2026/06/26 10:35:03 wazuh-manager-modulesd:inventory-sync[299452] wm_inventory_sync.c:140 at wm_inventory_sync_read(): DEBUG: Loaded Inventory sync module.
2026/06/26 10:35:04 wazuh-manager-authd: INFO: Started (pid: 299503).
2026/06/26 10:35:04 wazuh-manager-db: INFO: Started (pid: 299512).
2026/06/26 10:35:04 wazuh-manager-analysisd: INFO: Store initialized
2026/06/26 10:35:04 wazuh-manager-analysisd: INFO: Content Manager initialized
2026/06/26 10:35:04 wazuh-manager-analysisd: INFO: KVDB initialized
2026/06/26 10:35:04 wazuh-manager-analysisd: INFO: IOC initialized
2026/06/26 10:35:04 wazuh-manager-analysisd: INFO: GEO initialized
2026/06/26 10:35:04 wazuh-manager-analysisd: INFO: Fast metrics initialized
2026/06/26 10:35:04 wazuh-manager-analysisd: INFO: Schema initialized
2026/06/26 10:35:04 wazuh-manager-analysisd: INFO: HLP initialized
2026/06/26 10:35:04 wazuh-manager-analysisd: INFO: Scheduler initialized
2026/06/26 10:35:04 wazuh-manager-analysisd (indexer-connector): WARNING: No username and password found in the keystore, using default values.
2026/06/26 10:35:04 wazuh-manager-analysisd: INFO: Indexer Connector initialized
2026/06/26 10:35:04 wazuh-manager-analysisd: INFO: Stream logger initialized
2026/06/26 10:35:04 wazuh-manager-analysisd: INFO: Builder initialized
2026/06/26 10:35:04 wazuh-manager-analysisd: INFO: Content Manager CRUD Service initialized
2026/06/26 10:35:04 wazuh-manager-analysisd: INFO: Raw Event Indexer initialized
2026/06/26 10:35:04 wazuh-manager-analysisd: INFO: Orchestrator initialized and started with event queue size: 131072, events per second: unlimited.
2026/06/26 10:35:04 wazuh-manager-analysisd: INFO: Content Manager Sync Service initialized
2026/06/26 10:35:04 wazuh-manager-analysisd: INFO: IOC Sync Service initialized
2026/06/26 10:35:04 wazuh-manager-analysisd: INFO: Dumper Events initialized
2026/06/26 10:35:04 wazuh-manager-analysisd: INFO: Remote engine's server initialized and started
2026/06/26 10:35:04 wazuh-manager-analysisd: INFO: Engine started
2026/06/26 10:35:04 wazuh-manager-analysisd: INFO: Scheduler started
2026/06/26 10:35:04 wazuh-manager-analysisd: WARNING: [CMSync] No active routes available. Incoming events will be discarded until content synchronization completes
2026/06/26 10:35:04 wazuh-manager-analysisd: INFO: [IOC::Sync] IOC syncronization skipped because wazuh-indexer consumer for IOCs is not ready for sync (might be updating or no data yet)
2026/06/26 10:35:04 wazuh-manager-analysisd: INFO: [CM::Sync] Synchronization skipped for space 'standard' because wazuh-indexer consumer 'cti:catalog:consumer:ruleset' is not ready for sync (might be updating or no data)
2026/06/26 10:35:05 wazuh-manager-monitord: INFO: Started (pid: 299771).
2026/06/26 10:35:05 wazuh-manager-remoted: INFO: Started (pid: 299765). Listening on port 1514/TCP (secure).
2026/06/26 10:35:05 wazuh-manager-modulesd[299788] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2026/06/26 10:35:05 wazuh-manager-modulesd[299788] main.c:90 at main(): DEBUG: Wazuh home directory: /var/wazuh-manager
2026/06/26 10:35:05 wazuh-manager-modulesd:router[299788] wm_router.c:98 at wm_router_read(): DEBUG: Loaded router module.
2026/06/26 10:35:05 wazuh-manager-modulesd:content_manager[299788] wm_content_manager.c:87 at wm_content_manager_read(): DEBUG: Loaded content_manager module.
2026/06/26 10:35:05 wazuh-manager-modulesd:inventory-sync[299788] wm_inventory_sync.c:140 at wm_inventory_sync_read(): DEBUG: Loaded Inventory sync module.
2026/06/26 10:35:05 wazuh-manager-modulesd[299788] main.c:111 at main(): INFO: Started (pid: 299801).
2026/06/26 10:35:05 wazuh-manager-modulesd[299788] pthreads_op.c:49 at CreateThreadJoinable(): DEBUG: Thread stack size set to: 8192 KiB
2026/06/26 10:35:05 wazuh-manager-modulesd[299788] main.c:124 at main(): DEBUG: Created new thread for the 'control' module.
2026/06/26 10:35:05 wazuh-manager-modulesd[299788] pthreads_op.c:49 at CreateThreadJoinable(): DEBUG: Thread stack size set to: 8192 KiB
2026/06/26 10:35:05 wazuh-manager-modulesd[299788] main.c:140 at main(): DEBUG: Created new thread for the 'agent-upgrade' module.
2026/06/26 10:35:05 wazuh-manager-modulesd[299788] pthreads_op.c:49 at CreateThreadJoinable(): DEBUG: Thread stack size set to: 8192 KiB
2026/06/26 10:35:05 wazuh-manager-modulesd:control[299788] wm_control.c:36 at wm_control_main(): INFO: Starting control thread.
2026/06/26 10:35:05 wazuh-manager-modulesd[299788] main.c:140 at main(): DEBUG: Created new thread for the 'task-manager' module.
2026/06/26 10:35:05 wazuh-manager-modulesd[299788] pthreads_op.c:49 at CreateThreadJoinable(): DEBUG: Thread stack size set to: 8192 KiB
2026/06/26 10:35:05 wazuh-manager-modulesd[299788] main.c:140 at main(): DEBUG: Created new thread for the 'vulnerability_scanner' module.
2026/06/26 10:35:05 wazuh-manager-modulesd[299788] pthreads_op.c:49 at CreateThreadJoinable(): DEBUG: Thread stack size set to: 8192 KiB
2026/06/26 10:35:05 wazuh-manager-modulesd[299788] main.c:140 at main(): DEBUG: Created new thread for the 'router' module.
2026/06/26 10:35:05 wazuh-manager-modulesd[299788] pthreads_op.c:49 at CreateThreadJoinable(): DEBUG: Thread stack size set to: 8192 KiB
2026/06/26 10:35:05 wazuh-manager-modulesd[299788] main.c:140 at main(): DEBUG: Created new thread for the 'content_manager' module.
2026/06/26 10:35:05 wazuh-manager-modulesd[299788] pthreads_op.c:49 at CreateThreadJoinable(): DEBUG: Thread stack size set to: 8192 KiB
2026/06/26 10:35:05 wazuh-manager-modulesd:vulnerability-scanner[299788] wm_vulnerability_scanner.c:52 at wm_vulnerability_scanner_main(): INFO: Started (pid: 299801).
2026/06/26 10:35:05 wazuh-manager-modulesd[299788] main.c:140 at main(): DEBUG: Created new thread for the 'inventory_sync' module.
2026/06/26 10:35:05 wazuh-manager-modulesd[299788] pthreads_op.c:49 at CreateThreadJoinable(): DEBUG: Thread stack size set to: 8192 KiB
2026/06/26 10:35:05 wazuh-manager-modulesd[299788] main.c:140 at main(): DEBUG: Created new thread for the 'database' module.
2026/06/26 10:35:05 wazuh-manager-modulesd[299788] pthreads_op.c:49 at CreateThreadJoinable(): DEBUG: Thread stack size set to: 8192 KiB
2026/06/26 10:35:05 wazuh-manager-modulesd:agent-upgrade[299788] wm_agent_upgrade_manager.c:93 at wm_agent_upgrade_start_manager_module(): INFO: Started (pid: 299801).
2026/06/26 10:35:05 wazuh-manager-modulesd:content_manager[299788] wm_content_manager.c:39 at wm_content_manager_main(): INFO: Started (pid: 299801).
2026/06/26 10:35:05 wazuh-manager-modulesd:inventory-sync[299788] wm_inventory_sync.c:56 at wm_inventory_sync_main(): INFO: Started (pid: 299801).
2026/06/26 10:35:05 wazuh-manager-modulesd:database[299788] wm_database.c:99 at wm_database_main(): INFO: Started (pid: 299801).
2026/06/26 10:35:05 wazuh-manager-modulesd:router[299788] wm_router.c:40 at wm_router_main(): INFO: Started (pid: 299801).
2026/06/26 10:35:05 wazuh-manager-modulesd[299788] pthreads_op.c:49 at CreateThreadJoinable(): DEBUG: Thread stack size set to: 8192 KiB
2026/06/26 10:35:05 wazuh-manager-modulesd[299788] wmcom.c:133 at wmcom_main(): DEBUG: Local requests thread ready
2026/06/26 10:35:05 wazuh-manager-modulesd:task-manager[299788] wm_task_manager.c:141 at wm_task_manager_main(): INFO: Started (pid: 299801).
2026/06/26 10:35:05 wazuh-manager-modulesd:vulnerability-scanner[299788] wm_vulnerability_scanner.c:45 at wm_vulnerability_scanner_log_config(): DEBUG: {"vulnerability-detection":{"enabled":"yes","feed-update-interval":"60m"},"wmMaxEps":100,"translationLRUSize":2048,"osdataLRUSize":1000,"remediationLRUSize":2048,"managerDisabledScan":1,"reportQueueSize":262144,"indexer":{"hosts":["https://localhost:9200"],"ssl":{"certificate_authorities":["/var/wazuh-manager/etc/certs/root-ca.pem"],"certificate":"/var/wazuh-manager/etc/certs/manager.pem","key":"/var/wazuh-manager/etc/certs/manager-key.pem"}},"clusterName":"wazuh","clusterNodeName":"node01","clusterIsWorker":false}
2026/06/26 10:35:05 wazuh-manager-modulesd:inventory-sync[299788] wm_inventory_sync.c:48 at wm_inventory_sync_log_config(): DEBUG: {"indexer":{"hosts":["https://localhost:9200"],"ssl":{"certificate_authorities":["/var/wazuh-manager/etc/certs/root-ca.pem"],"certificate":"/var/wazuh-manager/etc/certs/manager.pem","key":"/var/wazuh-manager/etc/certs/manager-key.pem"}},"clusterName":"wazuh","clusterNodeName":"node01","maxSessions":1000,"queueSize":10000,"dataValueQuota":500000}
2026/06/26 10:35:05 wazuh-manager-modulesd:vulnerability-scanner[299788] vulnerabilityScannerFacade.cpp:180 at start(): DEBUG: Schema validator initialized successfully from embedded resources.
2026/06/26 10:35:05 :router[299788] logging_helper.c:37 at taggedLogFunction(): DEBUG: Router initialized successfully.
2026/06/26 10:35:05 :router[299788] logging_helper.c:37 at taggedLogFunction(): DEBUG: Router started successfully.
2026/06/26 10:35:05 logger-helper[299788] responseDispatcher.hpp:67 at operator()(): DEBUG: Connected to queue/sockets/ar
2026/06/26 10:35:05 logger-helper[299788] inventorySyncFacade.hpp:609 at start(): DEBUG: Configuration: {"clusterName":"wazuh","clusterNodeName":"node01","dataValueQuota":500000,"indexer":{"hosts":["https://localhost:9200"],"ssl":{"certificate":"/var/wazuh-manager/etc/certs/manager.pem","certificate_authorities":["/var/wazuh-manager/etc/certs/root-ca.pem"],"key":"/var/wazuh-manager/etc/certs/manager-key.pem"}},"maxSessions":1000,"queueSize":10000}
2026/06/26 10:35:05 wazuh-manager-modulesd:vulnerability-scanner (indexer-connector)[299788] indexerConnectorSyncImpl.hpp:670 at IndexerConnectorSyncImpl(): WARNING: No username and password found in the keystore, using default values.
2026/06/26 10:35:05 logger-helper[299788] inventorySyncFacade.hpp:625 at start(): DEBUG: InventorySync session limit: 1000
2026/06/26 10:35:05 logger-helper[299788] inventorySyncFacade.hpp:637 at start(): DEBUG: InventorySync queue size: 10000, DataValue quota: 500000
2026/06/26 10:35:05 logger-helper[299788] inventorySyncFacade.hpp:642 at start(): DEBUG: Cluster name to be used in indexer: wazuh
2026/06/26 10:35:05 logger-helper[299788] inventorySyncFacade.hpp:1542 at start(): DEBUG: InventorySyncFacade started.
2026/06/26 10:35:05 wazuh-manager-modulesd:vulnerability-scanner[299788] databaseFeedManager.hpp:876 at readGlobalMapsNoLock(): DEBUG: Global maps are not yet available in the local feed database, skipping reload.
2026/06/26 10:35:05 wazuh-manager-modulesd:vulnerability-scanner[299788] databaseFeedManager.hpp:274 at TDatabaseFeedManager(): INFO: No existing local vulnerability feed detected at startup. A full feed will be downloaded.
2026/06/26 10:35:05 wazuh-manager-modulesd:content-updater[299788] actionOrchestrator.hpp:85 at ActionOrchestrator(): DEBUG: Creating 'vulnerability_feed_manager' Content Updater orchestration
2026/06/26 10:35:05 wazuh-manager-modulesd:content-updater[299788] executionContext.hpp:218 at handleRequest(): DEBUG: ExecutionContext - Starting process
2026/06/26 10:35:05 wazuh-manager-modulesd:content-updater[299788] executionContext.hpp:129 at createRocksDB(): DEBUG: Column 'current_offset' doesn't exist so it will be created
2026/06/26 10:35:05 wazuh-manager-modulesd:content-updater[299788] executionContext.hpp:129 at createRocksDB(): DEBUG: Column 'downloaded_file_hash' doesn't exist so it will be created
2026/06/26 10:35:05 wazuh-manager-modulesd:content-updater[299788] factoryContentUpdater.hpp:51 at create(): DEBUG: FactoryContentUpdater - Starting process
2026/06/26 10:35:05 wazuh-manager-modulesd:content-updater[299788] actionOrchestrator.hpp:93 at ActionOrchestrator(): DEBUG: Content updater orchestration created
2026/06/26 10:35:05 wazuh-manager-modulesd:content-updater[299788] action.hpp:119 at runActionScheduled(): DEBUG: Starting scheduled action for 'vulnerability_feed_manager'
2026/06/26 10:35:05 wazuh-manager-modulesd:content-updater[299788] action.hpp:210 at runAction(): DEBUG: Action for 'vulnerability_feed_manager' started
2026/06/26 10:35:05 wazuh-manager-modulesd:content-updater[299788] actionOrchestrator.hpp:151 at runContentUpdate(): DEBUG: Running 'vulnerability_feed_manager' content update (forceFullReload=false)
2026/06/26 10:35:05 wazuh-manager-modulesd:content-updater[299788] IndexerDownloader.hpp:936 at handleRequest(): DEBUG: IndexerDownloader - Starting process
2026/06/26 10:35:05 wazuh-manager-modulesd:content-updater (indexer-connector)[299788] indexerConnectorSyncImpl.hpp:928 at executeSearchQuery(): DEBUG: Executing search query on: https://localhost:9200/.wazuh-cti-consumers/_search
2026/06/26 10:35:05 wazuh-manager-modulesd:content-updater (indexer-connector)[299788] indexerConnectorSyncImpl.hpp:911 at operator()(): DEBUG: Search query response: {"took":1,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":1.0,"hits":[{"_index":".wazuh-cti-consumers","_id":"cti:catalog:consumer:vulnerabilities","_score":1.0,"_source":{"status":"ready"}}]}}
2026/06/26 10:35:05 wazuh-manager-modulesd:content-updater[299788] IndexerDownloader.hpp:253 at waitUntilConsumerReady(): INFO: IndexerDownloader: Consumer 'cti:catalog:consumer:vulnerabilities' in index '.wazuh-cti-consumers' is ready. Starting feed download.
2026/06/26 10:35:05 wazuh-manager-modulesd:content-updater[299788] IndexerDownloader.hpp:805 at initialLoad(): INFO: IndexerDownloader: Starting initial full load (slices=2)
2026/06/26 10:35:05 wazuh-manager-modulesd:content-updater (indexer-connector)[299788] indexerConnectorSyncImpl.hpp:1072 at operator()(): DEBUG: PIT created successfully. PIT ID: g-O6QQEkLndhenVoLXRocmVhdGludGVsLXZ1bG5lcmFiaWxpdGllcy1hFmJJMkx3dlFLU1dpSGlJNEwxUVNFNWcAFnhDTzBKcXA5UXZlaVQ5ajJ3VFJzLWcAAAAAAAAAB_cWQU5heTFSUlVRaEtQb0Q4UExGcFQ3QQEWYkkyTHd2UUtTV2lIaUk0TDFRU0U1ZwAA, Creation time: 1782470105617
2026/06/26 10:35:05 wazuh-manager-modulesd:content-updater[299788] IndexerDownloader.hpp:656 at fetchWithSlicedPit(): INFO: IndexerDownloader: Starting sliced PIT download with 2 slices, pageSize=250
2026/06/26 10:35:05 wazuh-manager-modulesd:vulnerability-scanner[299788] vulnerabilityScannerFacade.cpp:443 at start(): INFO: CVE feed not yet available — per-agent scans deferred until initial load completes.
2026/06/26 10:35:05 wazuh-manager-modulesd:vulnerability-scanner[299788] vulnerabilityScannerFacade.cpp:447 at start(): DEBUG: Vulnerability scanner module started.
2026/06/26 10:35:10 wazuh-manager-modulesd:database[299788] wm_database.c:216 at wm_sync_agents(): DEBUG: Synchronizing agents.
2026/06/26 10:35:10 wazuh-manager-modulesd[299788] keys.c:337 at OS_ReadKeys(): DEBUG: (1751): File client.keys not found or empty.
2026/06/26 10:35:10 wazuh-manager-modulesd:database[299788] wm_database.c:223 at wm_sync_agents(): DEBUG: Agents synchronization completed.
2026/06/26 10:35:10 wazuh-manager-modulesd:database[299788] wm_database.c:226 at wm_sync_agents(): DEBUG: wm_sync_agents(): 1.330 ms (1.380 clock ms).
2026/06/26 10:35:10 wazuh-manager-modulesd[299788] pthreads_op.c:49 at CreateThreadJoinable(): DEBUG: Thread stack size set to: 8192 KiB
2026/06/26 10:35:10 wazuh-manager-modulesd:database[299788] wm_database.c:575 at wm_inotify_setup(): DEBUG: wd_agents='1'
2026/06/26 10:35:10 wazuh-manager-modulesd:database[299788] wm_database.c:581 at wm_inotify_setup(): DEBUG: wd_shared_groups='2'
2026/06/26 10:35:10 wazuh-manager-modulesd:database[299788] wm_database.c:603 at wm_inotify_start(): DEBUG: Waiting for event notification...
2026/06/26 10:35:15 wazuh-manager-monitord: INFO: wazuh: Manager started.
2026/06/26 10:35:35 wazuh-manager-modulesd:agent-upgrade[299788] wm_agent_upgrade_tasks.c:213 at wm_agent_send_task_information_master(): DEBUG: (8157): Sending message to task_manager module: '{"origin":{"name":"node01","module":"upgrade_module"},"command":"upgrade_cancel_tasks","parameters":{}}'
2026/06/26 10:35:35 wazuh-manager-modulesd:task-manager[299788] wm_task_manager.c:54 at wm_task_manager_dispatch(): DEBUG: (8204): Incomming message: '{"origin":{"name":"node01","module":"upgrade_module"},"command":"upgrade_cancel_tasks","parameters":{}}'
2026/06/26 10:35:35 wazuh-manager-modulesd:task-manager[299788] wm_task_manager.c:96 at wm_task_manager_dispatch(): DEBUG: (8205): Response to message: '{"error":0,"data":[{"error":0,"message":"Success"}],"message":"Success"}'
2026/06/26 10:35:35 wazuh-manager-modulesd:agent-upgrade[299788] wm_agent_upgrade_tasks.c:231 at wm_agent_send_task_information_master(): DEBUG: (8158): Receiving message from task_manager module: '{"error":0,"data":[{"error":0,"message":"Success"}],"message":"Success"}'
2026/06/26 10:35:35 wazuh-manager-modulesd[299788] pthreads_op.c:49 at CreateThreadJoinable(): DEBUG: Thread stack size set to: 8192 KiB
2026/06/26 10:35:35 wazuh-manager-modulesd[299788] pthreads_op.c:49 at CreateThreadJoinable(): DEBUG: Thread stack size set to: 8192 KiB
2026/06/26 10:35:35 wazuh-manager-modulesd:agent-upgrade[299788] wm_agent_upgrade_manager.c:281 at wm_agent_upgrade_router_subscriber_thread(): DEBUG: Starting router subscriber thread for upgrade notifications
2026/06/26 10:35:35 wazuh-manager-modulesd:agent-upgrade[299788] wm_agent_upgrade_manager.c:307 at wm_agent_upgrade_router_subscriber_thread(): DEBUG: Successfully subscribed to router topic 'upgrade_notifications'
2026/06/26 10:35:45 wazuh-manager-modulesd:content-updater[299788] IndexerDownloader.hpp:758 at operator()(): DEBUG: IndexerDownloader: Slice 1 failed: Search request failed with status -1: Could not connect to server
2026/06/26 10:35:46 wazuh-manager-modulesd:content-updater[299788] IndexerDownloader.hpp:758 at operator()(): DEBUG: IndexerDownloader: Slice 0 failed: Search request failed with status -1: Could not connect to server
2026/06/26 10:35:46 wazuh-manager-modulesd:content-updater[299788] IndexerDownloader.hpp:644 at operator()(): DEBUG: IndexerDownloader: Failed to delete PIT: Failed to delete PIT g-O6QQEkLndhenVoLXRocmVhdGludGVsLXZ1bG5lcmFiaWxpdGllcy1hFmJJMkx3dlFLU1dpSGlJNEwxUVNFNWcAFnhDTzBKcXA5UXZlaVQ5ajJ3VFJzLWcAAAAAAAAAB_cWQU5heTFSUlVRaEtQb0Q4UExGcFQ3QQEWYkkyTHd2UUtTV2lIaUk0TDFRU0U1ZwAA. Error: Could not connect to server, Status: -1
2026/06/26 10:35:46 wazuh-manager-modulesd:content-updater[299788] IndexerDownloader.hpp:842 at initialLoad(): DEBUG: IndexerDownloader: Indexer not available yet (IndexerDownloader: 2 slice(s) failed: Slice 1: Search request failed with status -1: Could not connect to server) — retrying in 30s (attempt 1/3).
2026/06/26 10:35:54 monitoring: INFO: Indexer node 'https://localhost:9200' is no longer available. Reason: Could not connect to server
2026/06/26 10:35:55 monitoring[299788] monitoring.hpp:203 at healthCheck(): INFO: Indexer node 'https://localhost:9200' is no longer available. Reason: Cluster reported unhealthy status
2026/06/26 10:35:55 monitoring[299788] monitoring.hpp:203 at healthCheck(): INFO: Indexer node 'https://localhost:9200' is no longer available. Reason: Cluster reported unhealthy status
2026/06/26 10:36:04 monitoring: INFO: Indexer node 'https://localhost:9200' is available again.
2026/06/26 10:36:05 monitoring[299788] monitoring.hpp:210 at healthCheck(): INFO: Indexer node 'https://localhost:9200' is available again.
2026/06/26 10:36:05 monitoring[299788] monitoring.hpp:210 at healthCheck(): INFO: Indexer node 'https://localhost:9200' is available again.
2026/06/26 10:36:16 wazuh-manager-modulesd:content-updater[299788] IndexerDownloader.hpp:809 at initialLoad(): INFO: IndexerDownloader: Retrying initial full load (attempt 2) ...
2026/06/26 10:36:16 wazuh-manager-modulesd:content-updater (indexer-connector)[299788] indexerConnectorSyncImpl.hpp:1072 at operator()(): DEBUG: PIT created successfully. PIT ID: g-O6QQEkLndhenVoLXRocmVhdGludGVsLXZ1bG5lcmFiaWxpdGllcy1hFmJJMkx3dlFLU1dpSGlJNEwxUVNFNWcAFnhDTzBKcXA5UXZlaVQ5ajJ3VFJzLWcAAAAAAAAAASUWQm5Lc1dmc3dTY0c2ZkR2Wm85WUdBQQEWYkkyTHd2UUtTV2lIaUk0TDFRU0U1ZwAA, Creation time: 1782470176038
2026/06/26 10:36:16 wazuh-manager-modulesd:content-updater[299788] IndexerDownloader.hpp:656 at fetchWithSlicedPit(): INFO: IndexerDownloader: Starting sliced PIT download with 2 slices, pageSize=250
2026/06/26 10:36:20 wazuh-manager-modulesd:content-updater[299788] IndexerDownloader.hpp:758 at operator()(): DEBUG: IndexerDownloader: Slice 0 failed: Search request failed with status -1: Could not connect to server
2026/06/26 10:36:20 wazuh-manager-modulesd:content-updater[299788] IndexerDownloader.hpp:758 at operator()(): DEBUG: IndexerDownloader: Slice 1 failed: Search request failed with status -1: Could not connect to server
2026/06/26 10:36:20 wazuh-manager-modulesd:content-updater[299788] IndexerDownloader.hpp:644 at operator()(): DEBUG: IndexerDownloader: Failed to delete PIT: Failed to delete PIT g-O6QQEkLndhenVoLXRocmVhdGludGVsLXZ1bG5lcmFiaWxpdGllcy1hFmJJMkx3dlFLU1dpSGlJNEwxUVNFNWcAFnhDTzBKcXA5UXZlaVQ5ajJ3VFJzLWcAAAAAAAAAASUWQm5Lc1dmc3dTY0c2ZkR2Wm85WUdBQQEWYkkyTHd2UUtTV2lIaUk0TDFRU0U1ZwAA. Error: Could not connect to server, Status: -1
2026/06/26 10:36:20 wazuh-manager-modulesd:content-updater[299788] IndexerDownloader.hpp:842 at initialLoad(): DEBUG: IndexerDownloader: Indexer not available yet (IndexerDownloader: 2 slice(s) failed: Slice 0: Search request failed with status -1: Could not connect to server) — retrying in 30s (attempt 2/3).
2026/06/26 10:36:24 monitoring: INFO: Indexer node 'https://localhost:9200' is no longer available. Reason: Could not connect to server
2026/06/26 10:36:25 monitoring[299788] monitoring.hpp:174 at operator()(): DEBUG: Health check failed for 'https://localhost:9200' - Could not connect to server
2026/06/26 10:36:25 monitoring[299788] monitoring.hpp:203 at healthCheck(): INFO: Indexer node 'https://localhost:9200' is no longer available. Reason: Could not connect to server
2026/06/26 10:36:25 monitoring[299788] monitoring.hpp:174 at operator()(): DEBUG: Health check failed for 'https://localhost:9200' - Could not connect to server
2026/06/26 10:36:25 monitoring[299788] monitoring.hpp:203 at healthCheck(): INFO: Indexer node 'https://localhost:9200' is no longer available. Reason: Could not connect to server
2026/06/26 10:36:34 monitoring: INFO: Indexer node 'https://localhost:9200' is available again.
2026/06/26 10:36:35 monitoring[299788] monitoring.hpp:210 at healthCheck(): INFO: Indexer node 'https://localhost:9200' is available again.
2026/06/26 10:36:35 monitoring[299788] monitoring.hpp:210 at healthCheck(): INFO: Indexer node 'https://localhost:9200' is available again.
2026/06/26 10:36:50 wazuh-manager-modulesd:content-updater[299788] IndexerDownloader.hpp:809 at initialLoad(): INFO: IndexerDownloader: Retrying initial full load (attempt 3) ...
2026/06/26 10:36:50 wazuh-manager-modulesd:content-updater (indexer-connector)[299788] indexerConnectorSyncImpl.hpp:1072 at operator()(): DEBUG: PIT created successfully. PIT ID: g-O6QQEkLndhenVoLXRocmVhdGludGVsLXZ1bG5lcmFiaWxpdGllcy1hFmJJMkx3dlFLU1dpSGlJNEwxUVNFNWcAFnhDTzBKcXA5UXZlaVQ5ajJ3VFJzLWcAAAAAAAAAASsWN2d6MlhUOEhUTEdVVzdSSWNHTE5qZwEWYkkyTHd2UUtTV2lIaUk0TDFRU0U1ZwAA, Creation time: 1782470210362
2026/06/26 10:36:50 wazuh-manager-modulesd:content-updater[299788] IndexerDownloader.hpp:656 at fetchWithSlicedPit(): INFO: IndexerDownloader: Starting sliced PIT download with 2 slices, pageSize=250
2026/06/26 10:36:51 wazuh-manager-modulesd:content-updater[299788] IndexerDownloader.hpp:754 at operator()(): WARNING: IndexerDownloader: Slice 1 failed: Search request failed with status -1: Could not connect to server
2026/06/26 10:36:51 wazuh-manager-modulesd:content-updater[299788] IndexerDownloader.hpp:754 at operator()(): WARNING: IndexerDownloader: Slice 0 failed: Search request failed with status -1: Could not connect to server
2026/06/26 10:36:51 wazuh-manager-modulesd:content-updater[299788] IndexerDownloader.hpp:640 at operator()(): WARNING: IndexerDownloader: Failed to delete PIT: Failed to delete PIT g-O6QQEkLndhenVoLXRocmVhdGludGVsLXZ1bG5lcmFiaWxpdGllcy1hFmJJMkx3dlFLU1dpSGlJNEwxUVNFNWcAFnhDTzBKcXA5UXZlaVQ5ajJ3VFJzLWcAAAAAAAAAASsWN2d6MlhUOEhUTEdVVzdSSWNHTE5qZwEWYkkyTHd2UUtTV2lIaUk0TDFRU0U1ZwAA. Error: Could not connect to server, Status: -1
2026/06/26 10:36:51 wazuh-manager-modulesd:content-updater[299788] IndexerDownloader.hpp:835 at initialLoad(): WARNING: IndexerDownloader: Initial load failed (IndexerDownloader: 2 slice(s) failed: Slice 1: Search request failed with status -1: Could not connect to server) — retrying in 30s.
2026/06/26 10:36:54 monitoring: INFO: Indexer node 'https://localhost:9200' is no longer available. Reason: Could not connect to server
2026/06/26 10:36:55 monitoring[299788] monitoring.hpp:174 at operator()(): DEBUG: Health check failed for 'https://localhost:9200' - Could not connect to server
2026/06/26 10:36:55 monitoring[299788] monitoring.hpp:174 at operator()(): DEBUG: Health check failed for 'https://localhost:9200' - Could not connect to server
2026/06/26 10:36:55 monitoring[299788] monitoring.hpp:203 at healthCheck(): INFO: Indexer node 'https://localhost:9200' is no longer available. Reason: Could not connect to server
2026/06/26 10:36:55 monitoring[299788] monitoring.hpp:203 at healthCheck(): INFO: Indexer node 'https://localhost:9200' is no longer available. Reason: Could not connect to server
2026/06/26 10:37:04 wazuh-manager-analysisd: INFO: [CMSync] Check 'standard' space in wazuh-indexer - Attempt 1/3: No available server. Unavailable nodes: https://localhost:9200: Could not connect to server
2026/06/26 10:37:04 wazuh-manager-analysisd: INFO: [ConfRemote] Checking remote settings from indexer - Attempt 1/3: No available server. Unavailable nodes: https://localhost:9200: Could not connect to server
2026/06/26 10:37:04 monitoring: INFO: Indexer node 'https://localhost:9200' is available again.
2026/06/26 10:37:05 monitoring[299788] monitoring.hpp:210 at healthCheck(): INFO: Indexer node 'https://localhost:9200' is available again.
2026/06/26 10:37:05 monitoring[299788] monitoring.hpp:210 at healthCheck(): INFO: Indexer node 'https://localhost:9200' is available again.
2026/06/26 10:37:09 wazuh-manager-analysisd: INFO: [CM::Sync] Synchronization skipped for space 'standard' because wazuh-indexer consumer 'cti:catalog:consumer:ruleset' is not ready for sync (might be updating or no data)
2026/06/26 10:37:21 wazuh-manager-modulesd:content-updater[299788] IndexerDownloader.hpp:809 at initialLoad(): INFO: IndexerDownloader: Retrying initial full load (attempt 4) ...
2026/06/26 10:37:22 wazuh-manager-modulesd:content-updater (indexer-connector)[299788] indexerConnectorSyncImpl.hpp:1072 at operator()(): DEBUG: PIT created successfully. PIT ID: g-O6QQEkLndhenVoLXRocmVhdGludGVsLXZ1bG5lcmFiaWxpdGllcy1hFmJJMkx3dlFLU1dpSGlJNEwxUVNFNWcAFnhDTzBKcXA5UXZlaVQ5ajJ3VFJzLWcAAAAAAAAAAS4WTmVWR0QwOFZTYkNIbjdDTm9jSEtwQQEWYkkyTHd2UUtTV2lIaUk0TDFRU0U1ZwAA, Creation time: 1782470242003
2026/06/26 10:37:22 wazuh-manager-modulesd:content-updater[299788] IndexerDownloader.hpp:656 at fetchWithSlicedPit(): INFO: IndexerDownloader: Starting sliced PIT download with 2 slices, pageSize=250

```

</details>