### PR TITLE
Recognize renamed indexer consumer status in engine sync

### DIFF
--- a/src/engine/source/cmsync/include/cmsync/cmsync.hpp
+++ b/src/engine/source/cmsync/include/cmsync/cmsync.hpp
@@ -59,7 +59,7 @@ private:
      * @param originSpace Define the source space in the indexer
      * @param dstNamespace Define the destination namespace in the local store (Must not exist)
      * @param consumerId Optional consumer ID to validate during policy retrieval
-     * @return true if the download succeeded, false if consumer is not idle
+     * @return true if the download succeeded, false if consumer is not ready
      * @throws std::runtime_error on errors.
      */
     bool downloadNamespace(std::string_view originSpace,
@@ -72,7 +72,7 @@ private:
      * @param space Space name in the indexer
      * @param consumerId Optional consumer ID to validate within PIT
      * @return An optional pair containing the policy hash and enabled status.
-     *         Returns std::nullopt if the consumer is provided and is not idle.
+     *         Returns std::nullopt if the consumer is provided and is not ready.
      * @throws std::runtime_error on errors.
      */
     std::optional<std::pair<std::string, bool>>
@@ -91,7 +91,7 @@ private:
      *
      * @param originSpace The source space name in the wazuh-indexer to download from
      * @param consumerId Optional consumer ID to validate during policy retrieval
-     * @return An optional NamespaceId. Returns std::nullopt if consumer is provided and not idle.
+     * @return An optional NamespaceId. Returns std::nullopt if consumer is provided and not ready.
      * @throws std::runtime_error if any step of the process fails
      * @warning There is no ganrantee that the returned namespace is valid, should be verified by the router.
      * @note If the operation fails at any point, the temporary namespace is automatically deleted

--- a/src/engine/source/cmsync/src/cmsync.cpp
+++ b/src/engine/source/cmsync/src/cmsync.cpp
@@ -286,7 +286,7 @@ bool CMSync::downloadNamespace(std::string_view originSpace,
         m_waitSeconds,
         m_shutdownRequested);
 
-    // If consumer is not idle, getPolicy returns nullopt
+    // If consumer is not ready, getPolicy returns nullopt
     if (!policyResource.has_value())
     {
         return false;
@@ -356,7 +356,7 @@ CMSync::downloadAndEnrichNamespace(std::string_view originSpace, const std::opti
 
     if (!downloadNamespace(originSpace, newNs, consumerId))
     {
-        return std::nullopt; // Consumer not idle
+        return std::nullopt; // Consumer not ready
     }
 
     // Enrich the namespace with local-only assets
@@ -587,7 +587,7 @@ void CMSync::synchronize()
                 return;
             }
 
-            // Pre-flight check: verify consumer is idle and has data (local_offset != 0)
+            // Pre-flight check: verify consumer is ready and has data (local_offset != 0)
             if (nsState.getConsumerId().has_value())
             {
                 auto indexerPtr = base::utils::lockWeakPtr(m_indexerPtr, "IndexerConnector");
@@ -616,7 +616,7 @@ void CMSync::synchronize()
             if (!hashResult.has_value())
             {
                 LOG_INFO("[{}] Synchronization skipped for space '{}' because wazuh-indexer is updating the policy "
-                         "or consumer is not idle (consumer ID: '{}')",
+                         "or consumer is not ready (consumer ID: '{}')",
                          LOG_MODULE_NAME,
                          nsState.getOriginSpace(),
                          nsState.getConsumerId().value_or("unknown"));
@@ -745,7 +745,7 @@ void CMSync::synchronize()
             const auto newNsIdOpt = downloadAndEnrichNamespace(nsState.getOriginSpace(), nsState.getConsumerId());
             if (!newNsIdOpt.has_value())
             {
-                LOG_INFO("[{}] Download skipped for space '{}' because consumer is not idle",
+                LOG_INFO("[{}] Download skipped for space '{}' because consumer is not ready",
                          LOG_MODULE_NAME,
                          nsState.getOriginSpace());
                 nsState.setSyncStatus(base::SyncStatus::READY);

--- a/src/engine/source/iocsync/include/iocsync/iocsync.hpp
+++ b/src/engine/source/iocsync/include/iocsync/iocsync.hpp
@@ -62,7 +62,7 @@ private:
     /**
      * @brief Get remote per-type hashes from special IOC hashes document.
      *
-     * @return Optional Map(type -> hash). Returns std::nullopt if the IOC consumer is not idle.
+     * @return Optional Map(type -> hash). Returns std::nullopt if the IOC consumer is not ready.
      * @throws std::runtime_error on errors.
      */
     std::optional<std::unordered_map<std::string, std::string>> getRemoteHashesFromRemote();
@@ -75,7 +75,7 @@ private:
      *
      * @param iocType IOC type to filter (e.g., connection, url_domain, url_full, hash_md5, hash_sha1, hash_sha256)
      * @param dbName Database name in kvdbioc to populate
-     * @return true if the download succeeded, false if the IOC consumer is not idle (data is being updated)
+     * @return true if the download succeeded, false if the IOC consumer is not ready (data is being updated)
      * @throws std::runtime_error on errors.
      */
     bool downloadAndPopulateDB(std::string_view iocType, const std::string& dbName);

--- a/src/engine/source/iocsync/src/iocsync.cpp
+++ b/src/engine/source/iocsync/src/iocsync.cpp
@@ -222,10 +222,10 @@ bool IocSync::downloadAndPopulateDB(std::string_view iocType, const std::string&
             },
             wiconnector::IOC_ENRICHMENT_CONSUMER_ID);
 
-        // Consumer is not idle — rollback and signal caller
+        // Consumer is not ready — rollback and signal caller
         if (!processedDocsOpt.has_value())
         {
-            LOG_DEBUG("[IOC::Sync] Consumer is not idle for IOC type '{}', "
+            LOG_DEBUG("[IOC::Sync] Consumer is not ready for IOC type '{}', "
                       "rolling back database '{}'",
                       iocType,
                       dbName);
@@ -236,7 +236,7 @@ bool IocSync::downloadAndPopulateDB(std::string_view iocType, const std::string&
             catch (const std::exception& ex)
             {
                 LOG_WARNING("[IOC::Sync] Failed to rollback database '{}' after consumer "
-                            "not idle: {}",
+                            "not ready: {}",
                             dbName,
                             ex.what());
             }
@@ -413,7 +413,7 @@ bool IocSync::syncIOCType(SyncedIOCDatabase& dbState,
         {
             if (!downloadAndPopulateDB(dbState.getIocType(), tempDBName))
             {
-                LOG_DEBUG("[IOC::Sync] IOC consumer is not idle for type '{}', skipping", dbState.getIocType());
+                LOG_DEBUG("[IOC::Sync] IOC consumer is not ready for type '{}', skipping", dbState.getIocType());
                 return false;
             }
         }
@@ -494,7 +494,7 @@ void IocSync::synchronize()
         const auto kvdbiocPtr = base::utils::lockWeakPtr(m_kvdbiocManagerPtr, "KVDBIOCManager");
         std::unique_lock lock(m_mutex);
 
-        // Pre-flight check: verify IOC consumer is idle and has data (local_offset != 0)
+        // Pre-flight check: verify IOC consumer is ready and has data (local_offset != 0)
         {
             auto indexerPtr = base::utils::lockWeakPtr(m_indexerPtr, "IndexerConnector");
             const bool ready = base::utils::executeWithRetry(
@@ -522,11 +522,11 @@ void IocSync::synchronize()
             return;
         }
 
-        // Get remote hashes (returns nullopt if IOC consumer is not idle)
+        // Get remote hashes (returns nullopt if IOC consumer is not ready)
         const auto remoteTypeHashesOpt = getRemoteHashesFromRemote();
         if (!remoteTypeHashesOpt.has_value())
         {
-            LOG_INFO("[IOC::Sync] IOC syncronization skipped because the IOC consumer is not idle (data/hash is being "
+            LOG_INFO("[IOC::Sync] IOC syncronization skipped because the IOC consumer is not ready (data/hash is being "
                      "updated in the indexer)");
             reportSyncFailure();
             return;

--- a/src/engine/source/wiconnector/interface/wiconnector/iwindexerconnector.hpp
+++ b/src/engine/source/wiconnector/interface/wiconnector/iwindexerconnector.hpp
@@ -64,8 +64,8 @@ public:
      * @param space The name of the space from which to retrieve policy resources
      * @param consumerIdToValidate Optional consumer document ID in `.wazuh-cti-consumers` to validate.
      *        When provided, the PIT will include `.wazuh-cti-consumers` and the consumer document
-     *        will be verified as `idle` within the PIT snapshot to ensure consistency.
-     * @return An optional PolicyResources. Returns std::nullopt if the consumer is provided and is not idle.
+     *        will be verified as `ready` within the PIT snapshot to ensure consistency.
+     * @return An optional PolicyResources. Returns std::nullopt if the consumer is provided and is not ready.
      * @throws std::invalid_argument if the space name is empty or invalid
      * @throws IndexerConnectorException if there is an error during retrieval
      * @throws std::exception for other unexpected errors
@@ -83,9 +83,9 @@ public:
      * @param space The name of the space to retrieve the information for
      * @param consumerIdToValidate Optional consumer document ID in `.wazuh-cti-consumers` to validate.
      *        When provided, a PIT will include `.wazuh-cti-consumers` and the consumer document
-     *        will be verified as `idle` within the PIT snapshot to ensure consistency.
+     *        will be verified as `ready` within the PIT snapshot to ensure consistency.
      * @return An optional pair containing the SHA-256 hash and enabled status.
-     *         Returns std::nullopt if the consumer is provided and is not idle.
+     *         Returns std::nullopt if the consumer is provided and is not ready.
      * @throws std::invalid_argument if the space name is empty
      * @throws IndexerConnectorException if the query returns zero or more than one result, or if required fields are
      * missing
@@ -123,8 +123,8 @@ public:
      *
      * @param consumerIdToValidate Optional consumer document ID in `.wazuh-cti-consumers` to validate.
      *        When provided, a PIT will include `.wazuh-cti-consumers` and the consumer document
-     *        will be verified as `idle` within the PIT snapshot to ensure consistency.
-     * @return An optional map(type -> sha256 hash). Returns std::nullopt if the consumer is provided and is not idle.
+     *        will be verified as `ready` within the PIT snapshot to ensure consistency.
+     * @return An optional map(type -> sha256 hash). Returns std::nullopt if the consumer is provided and is not ready.
      * @throws IndexerConnectorException if the manifest is missing or invalid
      */
     virtual std::optional<std::unordered_map<std::string, std::string>>
@@ -142,9 +142,9 @@ public:
      * @param onIoc Callback invoked for each valid IOC record
      * @param consumerIdToValidate Optional consumer document ID in `.wazuh-cti-consumers` to validate.
      *        When provided, the PIT will include `.wazuh-cti-consumers` and the consumer document
-     *        will be verified as `idle` within the PIT snapshot to ensure consistency.
+     *        will be verified as `ready` within the PIT snapshot to ensure consistency.
      * @return An optional number of IOC documents delivered to the callback.
-     *         Returns std::nullopt if the consumer is provided and is not idle.
+     *         Returns std::nullopt if the consumer is provided and is not ready.
      * @throws IndexerConnectorException if there is an indexer/query error
      */
     virtual std::optional<std::size_t>
@@ -158,7 +158,7 @@ public:
      *
      * Queries `.wazuh-cti-consumers` for the specified consumer document and verifies
      * two conditions:
-     *   1. `status` == `"idle"` — the indexer is not actively updating data.
+     *   1. `status` == `"ready"` — the indexer is not actively updating data.
      *   2. `local_offset` != 0 — the consumer has received at least one CTI update,
      *      so hash/data documents actually exist in the data indices.
      *
@@ -166,7 +166,7 @@ public:
      * hashes or data, to avoid unnecessary network calls when the consumer has no data yet.
      *
      * @param consumerId The `_id` of the consumer document (e.g. `STANDARD_RULESET_CONSUMER_ID`).
-     * @return true if the consumer is idle and has a non-zero local_offset; false otherwise
+     * @return true if the consumer is ready and has a non-zero local_offset; false otherwise
      *         (including on any error — safe default to skip sync).
      */
     virtual bool isConsumerReadyForSync(std::string_view consumerId) = 0;

--- a/src/engine/source/wiconnector/src/windexerconnector.cpp
+++ b/src/engine/source/wiconnector/src/windexerconnector.cpp
@@ -254,18 +254,18 @@ std::vector<std::string> buildPitIndices(std::vector<std::string> baseIndices,
 }
 
 /**
- * @brief Validates that a CTI consumer is in "idle" state within a PIT snapshot.
+ * @brief Validates that a CTI consumer is in "ready" state within a PIT snapshot.
  *
  * Queries the consumer document by ID inside the given PIT and checks its status field.
  *
  * @param async Reference to the async connector.
  * @param pit The PIT snapshot to query within.
  * @param consumerId The consumer document ID to look up.
- * @return true if consumer status is "idle".
- * @return false if consumer status is NOT "idle" (logs DEBUG).
+ * @return true if consumer status is "ready".
+ * @return false if consumer status is NOT "ready" (logs DEBUG).
  * @throws IndexerConnectorException if the consumer document is not found or has invalid structure.
  */
-bool validateConsumerIdleInPit(IIndexerConnectorAsync& async, const PointInTime& pit, std::string_view consumerId)
+bool validateConsumerReadyInPit(IIndexerConnectorAsync& async, const PointInTime& pit, std::string_view consumerId)
 {
     nlohmann::json consumerQuery = {{"ids", {{"values", {consumerId}}}}};
     nlohmann::json consumerSort = getSortCriteria();
@@ -293,15 +293,15 @@ bool validateConsumerIdleInPit(IIndexerConnectorAsync& async, const PointInTime&
     }
 
     const auto status = consumerSrc["status"].get<std::string>();
-    if (status != "idle")
+    if (status != "ready")
     {
-        LOG_DEBUG("[indexer-connector] Consumer '{}' is not idle (status: {}), returning nullopt",
+        LOG_DEBUG("[indexer-connector] Consumer '{}' is not ready (status: {}), returning nullopt",
                   std::string(consumerId),
                   status);
         return false;
     }
 
-    LOG_DEBUG("[indexer-connector] Consumer '{}' PIT check: idle", std::string(consumerId));
+    LOG_DEBUG("[indexer-connector] Consumer '{}' PIT check: ready", std::string(consumerId));
     return true;
 }
 
@@ -517,10 +517,10 @@ std::optional<PolicyResources> WIndexerConnector::getPolicy(std::string_view spa
     auto pit = m_indexerConnectorAsync->createPointInTime(pitIndices, PIT_KEEP_ALIVE, true);
     auto pitGuard = makePitGuard(pit, *m_indexerConnectorAsync);
 
-    // --- Pre-check: validate consumer is idle within the PIT snapshot ---
+    // --- Pre-check: validate consumer is ready within the PIT snapshot ---
     if (consumerIdToValidate.has_value())
     {
-        if (!validateConsumerIdleInPit(*m_indexerConnectorAsync, pit, *consumerIdToValidate))
+        if (!validateConsumerReadyInPit(*m_indexerConnectorAsync, pit, *consumerIdToValidate))
         {
             return std::nullopt;
         }
@@ -674,7 +674,7 @@ WIndexerConnector::getPolicyHashAndEnabled(std::string_view space,
         auto pit = m_indexerConnectorAsync->createPointInTime(pitIndices, PIT_KEEP_ALIVE, true);
         auto pitGuard = makePitGuard(pit, *m_indexerConnectorAsync);
 
-        if (!validateConsumerIdleInPit(*m_indexerConnectorAsync, pit, *consumerIdToValidate))
+        if (!validateConsumerReadyInPit(*m_indexerConnectorAsync, pit, *consumerIdToValidate))
         {
             return std::nullopt;
         }
@@ -832,7 +832,7 @@ bool WIndexerConnector::isConsumerReadyForSync(std::string_view consumerId)
 
         const auto& src = hitArray[0]["_source"];
 
-        // Check status == "idle"
+        // Check status == "ready"
         if (!src.contains("status") || !src["status"].is_string())
         {
             LOG_DEBUG("[indexer-connector] Consumer '{}' missing 'status' field", std::string(consumerId));
@@ -840,9 +840,9 @@ bool WIndexerConnector::isConsumerReadyForSync(std::string_view consumerId)
         }
 
         const auto status = src["status"].get<std::string>();
-        if (status != "idle")
+        if (status != "ready")
         {
-            LOG_DEBUG("[indexer-connector] Consumer '{}' is not idle (status: {})", std::string(consumerId), status);
+            LOG_DEBUG("[indexer-connector] Consumer '{}' is not ready (status: {})", std::string(consumerId), status);
             return false;
         }
 
@@ -862,7 +862,7 @@ bool WIndexerConnector::isConsumerReadyForSync(std::string_view consumerId)
             return false;
         }
 
-        LOG_DEBUG("[indexer-connector] Consumer '{}' is ready for sync (idle, local_offset={})",
+        LOG_DEBUG("[indexer-connector] Consumer '{}' is ready for sync (ready, local_offset={})",
                   std::string(consumerId),
                   localOffset);
         return true;
@@ -878,7 +878,7 @@ std::optional<std::unordered_map<std::string, std::string>>
 WIndexerConnector::getIocTypeHashes(const std::optional<std::string_view>& consumerIdToValidate)
 {
     // Hash retrieval with consumer validation delegated to queryByBatches
-    // (creates a single PIT including CTI consumers index and validates idle atomically)
+    // (creates a single PIT including CTI consumers index and validates ready atomically)
     std::optional<json::Json> hashesDoc = std::nullopt;
     const std::string queryBody = fmt::format(R"({{"ids": {{"values": ["{}"]}}}})", IOC_HASHES_DOC_ID);
 
@@ -900,7 +900,7 @@ WIndexerConnector::getIocTypeHashes(const std::optional<std::string_view>& consu
         std::nullopt,
         consumerIdToValidate);
 
-    // Consumer was not idle — propagate nullopt
+    // Consumer was not ready — propagate nullopt
     if (!result.has_value())
     {
         return std::nullopt;
@@ -1015,10 +1015,10 @@ WIndexerConnector::queryByBatches(std::string_view indexName,
     auto pit = m_indexerConnectorAsync->createPointInTime(pitIndices, PIT_KEEP_ALIVE, true);
     auto pitGuard = makePitGuard(pit, *m_indexerConnectorAsync);
 
-    // Validate consumer is idle within the PIT snapshot before streaming
+    // Validate consumer is ready within the PIT snapshot before streaming
     if (consumerIdToValidate.has_value())
     {
-        if (!validateConsumerIdleInPit(*m_indexerConnectorAsync, pit, *consumerIdToValidate))
+        if (!validateConsumerReadyInPit(*m_indexerConnectorAsync, pit, *consumerIdToValidate))
         {
             return std::nullopt;
         }

--- a/src/engine/source/wiconnector/test/src/unit/wic_test.cpp
+++ b/src/engine/source/wiconnector/test/src/unit/wic_test.cpp
@@ -990,25 +990,25 @@ nlohmann::json consumerReadyResponse(const std::string& status, int64_t offset)
 /**************************
  * isConsumerReadyForSync
  **************************/
-TEST_F(WIndexerConnectorMockTest, IsConsumerReadyForSyncIdleWithOffset)
+TEST_F(WIndexerConnectorMockTest, IsConsumerReadyForSyncWhenReadyWithOffset)
 {
-    nlohmann::json resp = consumerReadyResponse("idle", 42);
+    nlohmann::json resp = consumerReadyResponse("ready", 42);
     EXPECT_CALL(*mock, search(An<std::string_view>(), 1U, _, _)).WillOnce(Return(resp));
     auto connector = makeConnector();
     EXPECT_TRUE(connector->isConsumerReadyForSync("my-consumer"));
 }
 
-TEST_F(WIndexerConnectorMockTest, IsConsumerReadyForSyncNotIdle)
+TEST_F(WIndexerConnectorMockTest, IsConsumerReadyForSyncWhenNotReady)
 {
-    nlohmann::json resp = consumerReadyResponse("updating", 42);
+    nlohmann::json resp = consumerReadyResponse("running", 42);
     EXPECT_CALL(*mock, search(An<std::string_view>(), 1U, _, _)).WillOnce(Return(resp));
     auto connector = makeConnector();
     EXPECT_FALSE(connector->isConsumerReadyForSync("my-consumer"));
 }
 
-TEST_F(WIndexerConnectorMockTest, IsConsumerReadyForSyncIdleWithZeroOffset)
+TEST_F(WIndexerConnectorMockTest, IsConsumerReadyForSyncWhenReadyWithZeroOffset)
 {
-    nlohmann::json resp = consumerReadyResponse("idle", 0);
+    nlohmann::json resp = consumerReadyResponse("ready", 0);
     EXPECT_CALL(*mock, search(An<std::string_view>(), 1U, _, _)).WillOnce(Return(resp));
     auto connector = makeConnector();
     EXPECT_FALSE(connector->isConsumerReadyForSync("my-consumer"));
@@ -1035,7 +1035,7 @@ TEST_F(WIndexerConnectorMockTest, IsConsumerReadyForSyncMissingStatusField)
 TEST_F(WIndexerConnectorMockTest, IsConsumerReadyForSyncMissingLocalOffsetField)
 {
     nlohmann::json resp = {{"total", {{"value", 1}}},
-                           {"hits", {{{"_source", {{"status", "idle"}}}, {"sort", nlohmann::json::array({1, "a"})}}}}};
+                           {"hits", {{{"_source", {{"status", "ready"}}}, {"sort", nlohmann::json::array({1, "a"})}}}}};
     EXPECT_CALL(*mock, search(An<std::string_view>(), 1U, _, _)).WillOnce(Return(resp));
     auto connector = makeConnector();
     EXPECT_FALSE(connector->isConsumerReadyForSync("my-consumer"));
@@ -1058,15 +1058,15 @@ TEST_F(WIndexerConnectorMockTest, IsConsumerReadyForSyncReturnsFalseOnException)
 /**************************
  * getPolicyHashAndEnabled with consumerIdToValidate
  **************************/
-TEST_F(WIndexerConnectorMockTest, GetPolicyHashAndEnabledWithConsumerIdle)
+TEST_F(WIndexerConnectorMockTest, GetPolicyHashAndEnabledWithConsumerReady)
 {
     auto pit = makePit();
     EXPECT_CALL(*mock, createPointInTime(_, _, _)).WillOnce(Return(pit));
     EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
 
-    // First PIT search: consumer validation → idle
+    // First PIT search: consumer validation → ready
     // Second PIT search: policy hash query
-    nlohmann::json consumerResp = consumerResponse("idle");
+    nlohmann::json consumerResp = consumerResponse("ready");
     nlohmann::json policyResp = {{"total", {{"value", 1}}}, {"hits", {policyHit("hash-abc", true)}}};
 
     EXPECT_CALL(*mock, search(An<const PointInTime&>(), _, _, _, _, _))
@@ -1080,13 +1080,13 @@ TEST_F(WIndexerConnectorMockTest, GetPolicyHashAndEnabledWithConsumerIdle)
     EXPECT_TRUE(result->second);
 }
 
-TEST_F(WIndexerConnectorMockTest, GetPolicyHashAndEnabledWithConsumerNotIdle)
+TEST_F(WIndexerConnectorMockTest, GetPolicyHashAndEnabledWithConsumerNotReady)
 {
     auto pit = makePit();
     EXPECT_CALL(*mock, createPointInTime(_, _, _)).WillOnce(Return(pit));
     EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
 
-    nlohmann::json consumerResp = consumerResponse("updating");
+    nlohmann::json consumerResp = consumerResponse("running");
 
     EXPECT_CALL(*mock, search(An<const PointInTime&>(), _, _, _, _, _)).WillOnce(Return(consumerResp));
 
@@ -1128,21 +1128,21 @@ TEST_F(WIndexerConnectorMockTest, GetPolicyHashAndEnabledWithConsumerMissingStat
 /**************************
  * getPolicy with consumerIdToValidate
  **************************/
-TEST_F(WIndexerConnectorMockTest, GetPolicyWithConsumerIdle)
+TEST_F(WIndexerConnectorMockTest, GetPolicyWithConsumerReady)
 {
     auto pit = makePit();
     EXPECT_CALL(*mock, createPointInTime(_, _, _)).WillOnce(Return(pit));
     EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
 
-    // First PIT search: consumer validation → idle
-    nlohmann::json consumerResp = consumerResponse("idle");
+    // First PIT search: consumer validation → ready
+    nlohmann::json consumerResp = consumerResponse("ready");
     // Second PIT search: policy resources (includes a consumer index hit that should be skipped)
     nlohmann::json policyPage = {
         {"total", {{"value", 3}}},
         {"hits",
          {// Consumer hit from PIT — should be skipped
           {{"_index", ".wazuh-cti-consumers"},
-           {"_source", {{"status", "idle"}}},
+           {"_source", {{"status", "ready"}}},
            {"sort", nlohmann::json::array({0, "z"})}},
           makePolicyHit("wazuh-threatintel-decoders", "d1", nlohmann::json::array({1, "a"})),
           makePolicyHit(
@@ -1161,13 +1161,13 @@ TEST_F(WIndexerConnectorMockTest, GetPolicyWithConsumerIdle)
     EXPECT_TRUE(resources->kvdbs.empty());
 }
 
-TEST_F(WIndexerConnectorMockTest, GetPolicyWithConsumerNotIdle)
+TEST_F(WIndexerConnectorMockTest, GetPolicyWithConsumerNotReady)
 {
     auto pit = makePit();
     EXPECT_CALL(*mock, createPointInTime(_, _, _)).WillOnce(Return(pit));
     EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
 
-    nlohmann::json consumerResp = consumerResponse("updating");
+    nlohmann::json consumerResp = consumerResponse("running");
     EXPECT_CALL(*mock, search(An<const PointInTime&>(), _, _, _, _, _)).WillOnce(Return(consumerResp));
 
     auto connector = makeConnector();
@@ -1192,14 +1192,14 @@ TEST_F(WIndexerConnectorMockTest, GetPolicyWithConsumerNotFound)
 /**************************
  * getIocTypeHashes with consumerIdToValidate
  **************************/
-TEST_F(WIndexerConnectorMockTest, GetIocTypeHashesWithConsumerIdle)
+TEST_F(WIndexerConnectorMockTest, GetIocTypeHashesWithConsumerReady)
 {
     auto pit = makePit();
     EXPECT_CALL(*mock, createPointInTime(_, _, _)).WillOnce(Return(pit));
     EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
 
-    // First PIT search: consumer validation → idle
-    nlohmann::json consumerResp = consumerResponse("idle");
+    // First PIT search: consumer validation → ready
+    nlohmann::json consumerResp = consumerResponse("ready");
     // Second PIT search: hash document
     nlohmann::json hashPage = {{"hits",
                                 {{{"_id", "__ioc_type_hashes__"},
@@ -1219,13 +1219,13 @@ TEST_F(WIndexerConnectorMockTest, GetIocTypeHashesWithConsumerIdle)
     EXPECT_EQ((*result)["ip"], "h-ip");
 }
 
-TEST_F(WIndexerConnectorMockTest, GetIocTypeHashesWithConsumerNotIdle)
+TEST_F(WIndexerConnectorMockTest, GetIocTypeHashesWithConsumerNotReady)
 {
     auto pit = makePit();
     EXPECT_CALL(*mock, createPointInTime(_, _, _)).WillOnce(Return(pit));
     EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
 
-    nlohmann::json consumerResp = consumerResponse("updating");
+    nlohmann::json consumerResp = consumerResponse("running");
     EXPECT_CALL(*mock, search(An<const PointInTime&>(), _, _, _, _, _)).WillOnce(Return(consumerResp));
 
     auto connector = makeConnector();
@@ -1250,13 +1250,13 @@ TEST_F(WIndexerConnectorMockTest, GetIocTypeHashesWithConsumerNotFound)
 /**************************
  * streamIocsByType with consumerIdToValidate
  **************************/
-TEST_F(WIndexerConnectorMockTest, StreamIocsByTypeWithConsumerIdle)
+TEST_F(WIndexerConnectorMockTest, StreamIocsByTypeWithConsumerReady)
 {
     auto pit = makePit();
     EXPECT_CALL(*mock, createPointInTime(_, _, _)).WillOnce(Return(pit));
     EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
 
-    nlohmann::json consumerResp = consumerResponse("idle");
+    nlohmann::json consumerResp = consumerResponse("ready");
     nlohmann::json iocPage = {{"hits",
                                {{{"_id", "ioc1"},
                                  {"_source", {{"document", {{"name", "ioc1"}, {"type", "ip"}}}}},
@@ -1279,13 +1279,13 @@ TEST_F(WIndexerConnectorMockTest, StreamIocsByTypeWithConsumerIdle)
     EXPECT_EQ(received[0], "ioc1");
 }
 
-TEST_F(WIndexerConnectorMockTest, StreamIocsByTypeWithConsumerNotIdle)
+TEST_F(WIndexerConnectorMockTest, StreamIocsByTypeWithConsumerNotReady)
 {
     auto pit = makePit();
     EXPECT_CALL(*mock, createPointInTime(_, _, _)).WillOnce(Return(pit));
     EXPECT_CALL(*mock, deletePointInTime(_)).Times(1);
 
-    nlohmann::json consumerResp = consumerResponse("updating");
+    nlohmann::json consumerResp = consumerResponse("running");
     EXPECT_CALL(*mock, search(An<const PointInTime&>(), _, _, _, _, _)).WillOnce(Return(consumerResp));
 
     auto connector = makeConnector();


### PR DESCRIPTION
## Description

The Wazuh Indexer renamed the CTI consumer status values (see `wazuh/wazuh-indexer-plugins#1288`): `idle` → `ready`, `updating` → `running`, and added `failed`. This rename applies to **all** consumers.

The engine still matched the consumer status against the literal `"idle"` when validating readiness in the `wiconnector`. With the new status names, `status != "idle"` is always true, so every consumer is treated as **not ready** and the engine's synchronization never proceeds:

- **CMSync** (`cti:catalog:consumer:ruleset`) — ruleset sync blocked.
- **IOCSync** (IOC consumer) — IOC sync blocked.

This is the engine-side counterpart of the Vulnerability Detector fix in #37199 (which adapted the VD content updater to the new names).



# Test

- Full log, E2E environment:

<details>

```
2026/06/26 14:08:20 wazuh-manager-authd: INFO: Started (pid: 375067).
2026/06/26 14:08:20 wazuh-manager-db: INFO: Started (pid: 375073).
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: Store initialized
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: Content Manager initialized
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: KVDB initialized
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: IOC initialized
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: GEO initialized
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: Fast metrics initialized
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: Schema initialized
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: HLP initialized
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: Scheduler initialized
2026/06/26 14:08:20 wazuh-manager-analysisd (indexer-connector): WARNING: No username and password found in the keystore, using default values.
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: Indexer Connector initialized
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: Stream logger initialized
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: Builder initialized
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: Content Manager CRUD Service initialized
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: Raw Event Indexer initialized
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: Orchestrator initialized and started with event queue size: 131072, events per second: unlimited.
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: Content Manager Sync Service initialized
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: [IOC::Sync] First setup detected, initializing default IOC types to sync
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: [IOC::Sync] Added IOC type 'connection' to the sync list
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: [IOC::Sync] Added IOC type 'url_full' to the sync list
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: [IOC::Sync] Added IOC type 'url_domain' to the sync list
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: [IOC::Sync] Added IOC type 'hash_md5' to the sync list
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: [IOC::Sync] Added IOC type 'hash_sha1' to the sync list
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: [IOC::Sync] Added IOC type 'hash_sha256' to the sync list
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: IOC Sync Service initialized
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: Dumper Events initialized
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: Remote engine's server initialized and started
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: Engine started
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: Scheduler started
2026/06/26 14:08:20 wazuh-manager-analysisd: WARNING: [CMSync] No active routes available. Incoming events will be discarded until content synchronization completes
2026/06/26 14:08:20 wazuh-manager-monitord: INFO: Started (pid: 375315).
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: [CM::Sync] Changes detected for space 'standard', updating...
2026/06/26 14:08:20 wazuh-manager-remoted: INFO: Started (pid: 375309). Listening on port 1514/TCP (secure).
2026/06/26 14:08:20 wazuh-manager-analysisd: INFO: [IOC::Sync] Changes detected for IOC type 'connection', updating...
2026/06/26 14:08:20 wazuh-manager-modulesd: INFO: Started (pid: 375345).
2026/06/26 14:08:20 wazuh-manager-modulesd:control: INFO: Starting control thread.
2026/06/26 14:08:20 wazuh-manager-modulesd:vulnerability-scanner: INFO: Started (pid: 375345).
2026/06/26 14:08:20 wazuh-manager-modulesd:inventory-sync: INFO: Started (pid: 375345).
2026/06/26 14:08:20 wazuh-manager-modulesd:agent-upgrade: INFO: Started (pid: 375345).
2026/06/26 14:08:20 wazuh-manager-modulesd:router: INFO: Started (pid: 375345).
2026/06/26 14:08:20 wazuh-manager-modulesd:database: INFO: Started (pid: 375345).
2026/06/26 14:08:20 wazuh-manager-modulesd:content_manager: INFO: Started (pid: 375345).
2026/06/26 14:08:20 wazuh-manager-modulesd:task-manager: INFO: Started (pid: 375345).
2026/06/26 14:08:20 wazuh-manager-modulesd:vulnerability-scanner (indexer-connector): WARNING: No username and password found in the keystore, using default values.
2026/06/26 14:08:20 wazuh-manager-modulesd:vulnerability-scanner: INFO: No existing local vulnerability feed detected at startup. A full feed will be downloaded.
2026/06/26 14:08:20 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Consumer 'cti:catalog:consumer:vulnerabilities' in index '.wazuh-cti-consumers' is ready. Starting feed download.
2026/06/26 14:08:20 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting initial full load (slices=2)
2026/06/26 14:08:20 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Starting sliced PIT download with 2 slices, pageSize=250
2026/06/26 14:08:21 wazuh-manager-modulesd:vulnerability-scanner: INFO: CVE feed not yet available — per-agent scans deferred until initial load completes.
2026/06/26 14:08:24 wazuh-manager-analysisd: INFO: [CM::Sync] Successfully synchronized space 'standard'
2026/06/26 14:08:24 wazuh-manager-analysisd: INFO: [CMSync] Event processing is now active
2026/06/26 14:08:25 wazuh-manager-analysisd: INFO: [Geo::Manager] Changes detected for CITY database 'GeoLite2-City.mmdb', updating...
2026/06/26 14:08:27 wazuh-manager-analysisd: INFO: [IOC::Sync] Synchronized IOC type 'connection'
2026/06/26 14:08:27 wazuh-manager-analysisd: INFO: [IOC::Sync] Changes detected for IOC type 'url_full', updating...
2026/06/26 14:08:28 wazuh-manager-analysisd: INFO: [Geo::Manager] Successfully updated CITY database 'GeoLite2-City.mmdb'
2026/06/26 14:08:28 wazuh-manager-analysisd: INFO: [Geo::Manager] Changes detected for ASN database 'GeoLite2-ASN.mmdb', updating...
2026/06/26 14:08:28 wazuh-manager-analysisd: INFO: [IOC::Sync] Synchronized IOC type 'url_full'
2026/06/26 14:08:28 wazuh-manager-analysisd: INFO: [IOC::Sync] Changes detected for IOC type 'url_domain', updating...
2026/06/26 14:08:28 wazuh-manager-analysisd: INFO: [Geo::Manager] Successfully updated ASN database 'GeoLite2-ASN.mmdb'
2026/06/26 14:08:28 wazuh-manager-analysisd: INFO: [RemoteConfig] Remote settings synchronized: changes detected and applied
2026/06/26 14:08:29 wazuh-manager-remoted: WARNING: (1408): Invalid ID 001 for the source ip: '192.168.72.170' (name 'unknown').
2026/06/26 14:08:30 wazuh-manager-monitord: INFO: wazuh: Manager started.
2026/06/26 14:08:33 wazuh-manager-analysisd: INFO: [IOC::Sync] Synchronized IOC type 'url_domain'
2026/06/26 14:08:33 wazuh-manager-analysisd: INFO: [IOC::Sync] Changes detected for IOC type 'hash_md5', updating...
2026/06/26 14:08:34 wazuh-manager-analysisd: INFO: [IOC::Sync] Synchronized IOC type 'hash_md5'
2026/06/26 14:08:34 wazuh-manager-analysisd: INFO: [IOC::Sync] Changes detected for IOC type 'hash_sha1', updating...
2026/06/26 14:08:34 wazuh-manager-analysisd: INFO: [IOC::Sync] Synchronized IOC type 'hash_sha1'
2026/06/26 14:08:34 wazuh-manager-analysisd: INFO: [IOC::Sync] Changes detected for IOC type 'hash_sha256', updating...
2026/06/26 14:08:34 wazuh-manager-analysisd: INFO: [IOC::Sync] Synchronized IOC type 'hash_sha256'
2026/06/26 14:09:40 wazuh-manager-remoted: WARNING: (1408): Invalid ID 001 for the source ip: '192.168.72.170' (name 'unknown').
2026/06/26 14:10:33 wazuh-manager-remoted: WARNING: (1408): Invalid ID 001 for the source ip: '192.168.72.170' (name 'unknown').
2026/06/26 14:11:10 wazuh-manager-remoted: INFO: (1410): Reading authentication keys file.
2026/06/26 14:14:15 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 1 (2/2) complete — 176507 docs in 354070ms
2026/06/26 14:14:15 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Slice 0 (1/2) complete — 176513 docs in 354098ms
2026/06/26 14:14:15 wazuh-manager-modulesd:content-updater: INFO: IndexerDownloader: Initial load download phase complete — 353020 documents, cursor: '465835'
2026/06/26 14:14:16 wazuh-manager-modulesd:vulnerability-scanner: INFO: Feed update process completed (changed=true).
2026/06/26 14:14:16 wazuh-manager-modulesd:vulnerability-scanner: INFO: CVE feed fully loaded — per-agent scans unblocked.
2026/06/26 14:14:16 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan started after feed update: full scan for all agents.
2026/06/26 14:14:16 logger-helper: INFO: Locked agent 001 from creating new sessions - Reason: Feed update full scan in progress
2026/06/26 14:14:16 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan start: agent='001' (v5.0.0) type=full reason=feed_update
2026/06/26 14:14:16 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '001' - Packages scan completed in 363 ms: 905 packages scanned, 0 skipped, 120 vulnerable packages
2026/06/26 14:14:16 wazuh-manager-modulesd:vulnerability-scanner: INFO: Agent '001' - Vulnerability scan completed: 0 new, 0 solved
2026/06/26 14:14:16 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan completed: agent='001' type=full reason=feed_update
2026/06/26 14:14:16 logger-helper: INFO: Unlocked agent 001 for new sessions
2026/06/26 14:14:16 wazuh-manager-modulesd:vulnerability-scanner: INFO: Vulnerability scan finished after feed update: full scan for all agents (agents=1, status=ok).
```

</details>

- Example of finding:

<details>

```
{
  "_index": ".ds-wazuh-findings-v5-security-000001",
  "_id": "5HtMBJ8BLXMlF_LQSiGc",
  "_score": null,
  "_source": {
    "observer": {
      "vendor": "Wazuh"
    },
    "@timestamp": "2026-06-26T14:17:22.175Z",
    "package": {
      "name": "Django",
      "description": "A high-level Python Web framework that encourages rapid development and clean, pragmatic design.",
      "type": "pypi",
      "version": "3.2.13"
    },
    "data_stream": {
      "type": "logs",
      "dataset": "wazuh.vd"
    },
    "wazuh": {
      "cluster": {
        "node": "node01",
        "name": "wazuh"
      },
      "protocol": {
        "location": "vulnerability-scanner",
        "queue": 118
      },
      "agent": {
        "host": {
          "hostname": "ubuntu24",
          "os": {
            "name": "Ubuntu",
            "type": "linux",
            "version": "24.04.3 LTS (Noble Numbat)",
            "platform": "ubuntu"
          },
          "architecture": "aarch64"
        },
        "name": "ubuntu24",
        "groups": [
          "default"
        ],
        "id": "001",
        "version": "v5.0.0"
      },
      "integration": {
        "name": "wazuh-vd",
        "decoders": [
          "decoder/core-wazuh-message/0",
          "decoder/wazuh-vd/0"
        ],
        "category": "security"
      },
      "rule": {
        "sigma_id": "61f16843-5b00-41bf-beee-700013e62575",
        "level": "informational",
        "compliance": {
          "iso_27001": [
            "A.12.6.1",
            "A.14.2.3"
          ],
          "hipaa": [
            "164.308.a.1.ii.D",
            "164.308.a.8"
          ],
          "pci_dss": [
            "6.3.3",
            "11.3"
          ],
          "tsc": [
            "A1.2",
            "CC7.1"
          ],
          "nis2": [
            "21.2.a",
            "21.2.e"
          ],
          "nist_800_171": [
            "3.11.3",
            "3.14.4"
          ],
          "fedramp": [
            "CA-7",
            "RA-5",
            "SI-2",
            "SI-4"
          ],
          "nist_800_53": [
            "CA-7",
            "RA-5",
            "SI-2"
          ],
          "cmmc": [
            "AU.L2-3.3.1",
            "CA.L2-3.12.1",
            "RA.L2-3.11.1",
            "RA.L2-3.11.3",
            "SI.L2-3.14.1"
          ],
          "gdpr": [
            "IV_32.1.a"
          ]
        },
        "mitre": {
          "technique": {
            "name": [
              "Exploitation for Privilege Escalation",
              "Exploit Public-Facing Application"
            ],
            "id": [
              "T1068",
              "T1190"
            ]
          },
          "tactic": {
            "name": [
              "Initial Access",
              "Privilege Escalation"
            ],
            "id": [
              "TA0001",
              "TA0004"
            ]
          }
        },
        "id": "61f16843-5b00-41bf-beee-700013e62575",
        "title": "Wazuh VD - Vulnerability CVE-2025-64458 remediated",
        "tags": [
          "informational",
          "wazuh-vd",
          "attack.initial-access",
          "attack.privilege-escalation",
          "attack.t1190",
          "attack.t1068"
        ],
        "status": "stable"
      },
      "event": {
        "id": "a4eb6259-fa61-45e4-9264-d27deb9dc841"
      },
      "space": {
        "name": "standard"
      }
    },
    "vulnerability": {
      "severity": "High",
      "score": {
        "version": "3.1",
        "base": 7.5
      },
      "scanner": {
        "reference": "https://cti.wazuh.com/vulnerabilities/cves/CVE-2025-64458",
        "condition": "Unknown"
      },
      "id": "CVE-2025-64458",
      "category": [
        "Packages"
      ],
      "published_at": "2025-11-05T15:15:40Z",
      "under_evaluation": false
    },
    "event": {
      "original": "{\"collector\":\"packages\",\"data\":{\"event\":{\"created\":\"2026-06-26T14:17:22.159Z\",\"type\":\"delete\"},\"host\":{\"os\":{\"full\":\"Ubuntu 24.04.3 LTS (Noble Numbat)\",\"name\":\"Ubuntu\",\"platform\":\"ubuntu\",\"type\":\"linux\"}},\"package\":{\"description\":\"A high-level Python Web framework that encourages rapid development and clean, pragmatic design.\",\"name\":\"Django\",\"path\":\"/usr/local/lib/python3.12/dist-packages/Django-3.2.13.dist-info/METADATA\",\"type\":\"pypi\",\"version\":\"3.2.13\"},\"vulnerability\":{\"category\":\"Packages\",\"detected_at\":\"2026-06-26T14:17:22.153Z\",\"id\":\"CVE-2025-64458\",\"published_at\":\"2025-11-05T15:15:40Z\",\"scanner\":{\"condition\":\"Unknown\",\"reference\":\"https://cti.wazuh.com/vulnerabilities/cves/CVE-2025-64458\",\"vendor\":\"Wazuh\"},\"score\":{\"base\":7.5,\"version\":\"3.1\"},\"severity\":\"High\",\"under_evaluation\":false}},\"module\":\"vulnerability-scanner\"}",
      "provider": "packages",
      "kind": "event",
      "start": "2026-06-26T14:17:22.153Z",
      "action": "vulnerability-resolved",
      "index": ".ds-wazuh-events-v5-security-000001",
      "category": [
        "vulnerability"
      ],
      "type": [
        "indicator"
      ],
      "dataset": "wazuh.vd",
      "doc_id": "NntLBJ8BLXMlF_LQJSE3",
      "outcome": "success"
    }
  },
  "fields": {
    "event.start": [
      "2026-06-26T14:17:22.153Z"
    ],
    "@timestamp": [
      "2026-06-26T14:17:22.175Z"
    ],
    "vulnerability.published_at": [
      "2025-11-05T15:15:40.000Z"
    ]
  },
  "sort": [
    1782483442175
  ]
}
```

</details>