### PR TITLE
Fix false negatives in CIS Apple macOS 15 Sequoia SCA policy (checks 35046, 35058, 35060)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## [v5.0.1]
 
+### Ruleset
+
+#### Fixed
+
+- Fixed false negatives in the CIS Apple macOS 15 Sequoia SCA policy (checks 35046, 35058, 35060). ([#37209](https://github.com/wazuh/wazuh/pull/37209))
+
 ## [v5.0.0]
 
 ### Manager

--- a/ruleset/sca/darwin/24/cis_apple_macOS_15.x.yml
+++ b/ruleset/sca/darwin/24/cis_apple_macOS_15.x.yml
@@ -1298,7 +1298,7 @@ checks:
     condition: all
     rules:
       - 'c:pwpolicy -n /Local/Default -getglobalpolicy -> n:maxFailedLoginAttempts=(\d+) compare <= 5'
-      - 'c:pwpolicy -n /Local/Default -getglobalpolicy -> n:policyAttributeMinutesUntilFailedAuthenticationReset=(\d+) compare >= 15'
+      - 'c:pwpolicy -n /Local/Default -getglobalpolicy -> n:minutesUntilFailedLoginReset=(\d+) compare >= 15'
 
   # 5.2.2 Ensure Password Minimum Length Is Configured. (Automated)
   - id: 35047
@@ -1624,7 +1624,7 @@ checks:
     condition: all
     rules:
       - "d:/Library/Security -> r:^PolicyBanner"
-      - 'c:stat -f %A /Library/Security/PolicyBanner.* -> r:\d\d4'
+      - 'c:sh -c "stat -f %A /Library/Security/PolicyBanner.*" -> r:\d\d4'
 
   # 5.9 Ensure the Guest Home Folder Does Not Exist. (Automated)
   - id: 35059
@@ -1682,7 +1682,7 @@ checks:
       subtechnique: ["T1562.001", "T1562.002", "T1070.004"]
     condition: all
     rules:
-      - 'c:sh -c "launchctl list | grep -c com.apple.XProtect.daemon.scan" -> r:^1$'
+      - 'c:sh -c "launchctl list | grep -c com.apple.XProtect.daemon.scan$" -> r:^1$'
       - 'c:sh -c "launchctl list | grep -c com.apple.XProtect.daemon.scan.startup" -> r:^1$'
 
   # 6.1.1 Ensure Show All Filename Extensions Setting is Enabled. (Automated) - Not Implemented


### PR DESCRIPTION
## Description

Three checks in the **CIS Apple macOS 15 Sequoia** SCA policy
(`ruleset/sca/darwin/24/cis_apple_macOS_15.x.yml`) report **false negatives**:
they fail even when the underlying CIS control is correctly configured. The root
cause in each case is the *detection rule*, not the system state. Verified on
macOS 15.7.7 (Sequoia) with a Wazuh 4.13.1 agent.

## Proposed Changes

Three one-line rule fixes (remediation text untouched):

- **Check 35046** (Password Account Lockout Threshold) — the rule greps
  `policyAttributeMinutesUntilFailedAuthenticationReset`, but modern macOS
  `pwpolicy -getglobalpolicy` emits `minutesUntilFailedLoginReset`. The key is
  never found, so the check fails even when the reset delay is set.
  Fix: match the key actually emitted by macOS.

- **Check 35058** (Login Window Banner) — the rule is
  `c:stat -f %A /Library/Security/PolicyBanner.*`. SCA `c:` commands are executed
  **without a shell**, so the `*` glob is not expanded; `stat` receives the
  literal path and fails even when `PolicyBanner.txt` exists with mode `0644`.
  Fix: wrap in `sh -c` (consistent with check 35060, which already does).

- **Check 35060** (XProtect Running and Updated) — the rule
  `grep -c com.apple.XProtect.daemon.scan` also matches
  `com.apple.XProtect.daemon.scan.startup` (substring), so it returns **2** when
  XProtect is fully loaded, failing the `^1$` test. Fix: anchor with `$`.

```diff
-      - 'c:pwpolicy -n /Local/Default -getglobalpolicy -> n:policyAttributeMinutesUntilFailedAuthenticationReset=(\d+) compare >= 15'
+      - 'c:pwpolicy -n /Local/Default -getglobalpolicy -> n:minutesUntilFailedLoginReset=(\d+) compare >= 15'

-      - 'c:stat -f %A /Library/Security/PolicyBanner.* -> r:\d\d4'
+      - 'c:sh -c "stat -f %A /Library/Security/PolicyBanner.*" -> r:\d\d4'

-      - 'c:sh -c "launchctl list | grep -c com.apple.XProtect.daemon.scan" -> r:^1$'
+      - 'c:sh -c "launchctl list | grep -c com.apple.XProtect.daemon.scan$" -> r:^1$'
```

### Results and Evidence

On a Sequoia host where all three controls were correctly remediated, the policy
scored **96/100** with 35046, 35058 and 35060 still flagged as failed. After
applying these rule fixes and re-running the SCA scan, the same host reaches
**100/100 (61/61 pass)**.

Reproduction of each underlying bug:

```console
# 35058 — c: has no shell, the glob is not expanded
$ stat -f %A /Library/Security/PolicyBanner.*            # 644 in an interactive shell…
                                                          # …but SCA passes the literal path -> fails

# 35046 — the key actually emitted by macOS
$ pwpolicy -n /Local/Default -getglobalpolicy
... minutesUntilFailedLoginReset=15 ...                   # not policyAttributeMinutesUntilFailedAuthenticationReset

# 35060 — substring double-count
$ sudo launchctl list | grep -c com.apple.XProtect.daemon.scan     # 2  (scan + scan.startup)
$ sudo launchctl list | grep -c com.apple.XProtect.daemon.scan$    # 1
```

### Manual tests with their corresponding evidence

- macOS 15.7.7 (Sequoia), agent Wazuh v4.13.1.
- Audited the full policy (61 checks) for the same bug classes (unescaped globs in
  `c:`, substring `grep -c` collisions, obsolete `getglobalpolicy` keys): these
  three are the only affected checks.
- Before fix: 35046/35058/35060 = failed (control actually in place).
- After fix: all three pass; policy 61/61.
