### PR TITLE
Propagate sync errors to each module

### DIFF
--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
@@ -56,7 +56,7 @@ class AgentSyncProtocol : public IAgentSyncProtocol
                                        uint64_t version) override;
 
         /// @copydoc IAgentSyncProtocol::synchronizeModule
-        bool synchronizeModule(Mode mode, Option option = Option::SYNC) override;
+        SyncModuleResult synchronizeModule(Mode mode, Option option = Option::SYNC) override;
 
         /// @copydoc IAgentSyncProtocol::requiresFullSync
         bool requiresFullSync(const std::string& index,
@@ -66,7 +66,7 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         void clearInMemoryData() override;
 
         /// @copydoc IAgentSyncProtocol::synchronizeMetadataOrGroups
-        bool synchronizeMetadataOrGroups(Mode mode, const std::vector<std::string>& indices, uint64_t globalVersion) override;
+        SyncModuleResult synchronizeMetadataOrGroups(Mode mode, const std::vector<std::string>& indices, uint64_t globalVersion) override;
 
         /// @copydoc IAgentSyncProtocol::notifyDataClean
         bool notifyDataClean(const std::vector<std::string>& indices, Option option = Option::SYNC) override;

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface.h
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface.h
@@ -69,12 +69,12 @@ void asp_persist_diff_in_memory(AgentSyncProtocolHandle* handle,
                                 const char* data,
                                 uint64_t version);
 
-// @brief Triggers synchronization of a module.
+/// @brief Triggers synchronization of a module.
 ///
 /// @param handle Pointer to the AgentSyncProtocol handle.
 /// @param mode Synchronization mode (e.g., full, delta).
-/// @return true if the sync was successfully processed; false otherwise.
-bool asp_sync_module(AgentSyncProtocolHandle* handle,
+/// @return SyncModuleResult_t with success flag and an optional failure reason string.
+SyncModuleResult_t asp_sync_module(AgentSyncProtocolHandle* handle,
                      Mode_t mode);
 
 /// @brief Checks if a module index requires full synchronization.
@@ -107,12 +107,12 @@ void asp_clear_in_memory_data(AgentSyncProtocolHandle* handle);
 /// @param indices Array of index name strings that will be updated by the manager.
 /// @param indices_count Number of indices in the array.
 /// @param global_version Global version to include in the Start message
-/// @return true if synchronization completed successfully, false otherwise
-bool asp_sync_metadata_or_groups(AgentSyncProtocolHandle* handle,
-                                 Mode_t mode,
-                                 const char** indices,
-                                 size_t indices_count,
-                                 uint64_t global_version);
+/// @return SyncModuleResult_t with success flag and failure reason if unsuccessful
+SyncModuleResult_t asp_sync_metadata_or_groups(AgentSyncProtocolHandle* handle,
+                                               Mode_t mode,
+                                               const char** indices,
+                                               size_t indices_count,
+                                               uint64_t global_version);
 
 /// @brief Notifies the manager about data cleaning for specified indices.
 ///

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface_types.h
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface_types.h
@@ -11,12 +11,26 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <stdbool.h>
+
+#define SYNC_FAILURE_REASON_MAX_LEN 2048
 
 #include "logging_helper.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/// @brief Result of a module synchronization operation.
+///
+/// Returned by sync entry points to report both outcome and failure detail.
+/// @var success        true if synchronization completed successfully; false otherwise.
+/// @var failure_reason Human-readable reason string when available; may be empty if no specific reason was recorded.
+typedef struct SyncModuleResult_t
+{
+    bool success;
+    char failure_reason[SYNC_FAILURE_REASON_MAX_LEN];
+} SyncModuleResult_t;
 
 /// @brief Defines the type of modification operation.
 typedef enum

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_types.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_types.hpp
@@ -20,7 +20,16 @@ using LoggerFunc = std::function<void(modules_log_level_t, const std::string&)>;
 enum class SyncResult
 {
     SUCCESS,             ///< Operation completed successfully
-    COMMUNICATION_ERROR, ///< Manager is offline or unreachable
+    COMMUNICATION_ERROR, ///< Failed to communicate with the manager
     CHECKSUM_ERROR,      ///< Checksum validation failed
-    GENERIC_ERROR        ///< Generic synchronization error
+    START_TIMEOUT_ERROR,       ///< Exceeded maximum retries waiting for a response for the Start message
+    END_TIMEOUT_ERROR,       ///< Exceeded maximum retries waiting for a response for the End message
+    PROTOCOL_ERROR,       ///< Manager sent an unexpected or invalid response
+    NO_GROUPS_ERROR,     ///< No groups available in metadata.
+};
+
+struct SyncModuleResult
+{
+    bool success{false};
+    std::string failureReason;
 };

--- a/src/shared_modules/sync_protocol/include/iagent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/include/iagent_sync_protocol.hpp
@@ -49,8 +49,8 @@ class IAgentSyncProtocol
         /// @brief Synchronize a module with the server
         /// @param mode Sync mode
         /// @param option Synchronization option.
-        /// @return true if the sync was successfully processed; false otherwise.
-        virtual bool synchronizeModule(Mode mode, Option option = Option::SYNC) = 0;
+        /// @return SyncModuleResult with success flag and an optional failure reason string.
+        virtual SyncModuleResult synchronizeModule(Mode mode, Option option = Option::SYNC) = 0;
 
         /// @brief Checks if a module index requires full synchronization
         /// @param index The index/table to check
@@ -71,8 +71,8 @@ class IAgentSyncProtocol
         /// @param mode Synchronization mode (must be MetadataDelta, MetadataCheck, GroupDelta, or GroupCheck)
         /// @param indices Vector of index names that will be updated by the manager
         /// @param globalVersion Global version to include in the Start message (optional, only for Delta modes)
-        /// @return true if synchronization completed successfully, false otherwise
-        virtual bool synchronizeMetadataOrGroups(Mode mode, const std::vector<std::string>& indices, uint64_t globalVersion = 0) = 0;
+        /// @return SyncModuleResult with success flag and failure reason if unsuccessful
+        virtual SyncModuleResult synchronizeMetadataOrGroups(Mode mode, const std::vector<std::string>& indices, uint64_t globalVersion = 0) = 0;
 
         /// @brief Notifies the manager about data cleaning for specified indices.
         ///

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "agent_sync_protocol.hpp"
+#include "agent_sync_protocol_types.hpp"
 #include "ipersistent_queue.hpp"
 #include "mqueue_transport.hpp"
 #include "persistent_queue.hpp"
@@ -19,6 +20,44 @@
 #include <thread>
 #include <set>
 #include <unistd.h>
+
+// Various synchronization functions write a SyncResult into `m_syncState.lastSyncResult`
+// We use that to generate a std::string message which will be reported as a warning by each module (FIM, SCA, Syscollector, AgentInfo).
+static std::string determineSyncFailureReasonBasedOnSyncResult(SyncResult result)
+{
+    std::string failureReason;
+
+    switch (result)
+    {
+        case SyncResult::COMMUNICATION_ERROR:
+            failureReason = "Failed to communicate with the manager.";
+            break;
+
+
+        case SyncResult::START_TIMEOUT_ERROR:
+            failureReason = "Timed out waiting for manager response to Start message.";
+            break;
+
+        case SyncResult::END_TIMEOUT_ERROR:
+            failureReason = "Timed out waiting for manager response to End message.";
+            break;
+
+        case SyncResult::PROTOCOL_ERROR:
+            failureReason = "Manager sent an unexpected or invalid response.";
+            break;
+
+        case SyncResult::NO_GROUPS_ERROR:
+            failureReason = "No groups available in metadata. Waiting for the server to synchronize the groups. Cannot proceed with synchronization.";
+            break;
+
+        // SyncResult::CHECKSUM_ERROR is not returned by either synchronizeModule() or synchronizeMetadataOrGroups()
+
+        default:
+            break;
+    }
+
+    return failureReason;
+}
 
 AgentSyncProtocol::AgentSyncProtocol(const std::string& moduleName, std::optional<std::string> dbPath, MQ_Functions mqFuncs, LoggerFunc logger, std::chrono::seconds syncEndDelay,
                                      std::chrono::seconds timeout,
@@ -116,18 +155,18 @@ void AgentSyncProtocol::persistDifferenceInMemory(const std::string& id,
     // LCOV_EXCL_STOP
 }
 
-bool AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
+SyncModuleResult AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
 {
     // Validate synchronization mode
     if (mode != Mode::FULL && mode != Mode::DELTA)
     {
         m_logger(LOG_ERROR, "Invalid synchronization mode: " + std::to_string(static_cast<int>(mode)));
-        return false;
+        return {false, {}};
     }
 
     if (!m_transport->checkStatus())
     {
-        return false;
+        return {false, {}};
     }
 
     // Guard against concurrent calls. The timer thread and the AsyncFlushController
@@ -139,7 +178,7 @@ bool AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
     if (!m_syncInProgress.compare_exchange_strong(expected, true))
     {
         m_logger(LOG_DEBUG, "Synchronization already in progress, skipping concurrent request");
-        return true;
+        return {true, {}};
     }
 
     struct SyncInProgressGuard
@@ -174,8 +213,9 @@ bool AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
         }
         catch (const std::exception& e)
         {
-            m_logger(LOG_ERROR, std::string("Failed to fetch items for sync: ") + e.what());
-            return false;
+            const std::string reason = std::string("Failed to fetch items for sync: ") + e.what();
+            m_logger(LOG_ERROR, reason);
+            return {false, {}};
         }
     }
 
@@ -183,7 +223,7 @@ bool AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
     {
         const std::string modeStr = (mode == Mode::FULL) ? "FULL" : "DELTA";
         m_logger(LOG_DEBUG, "No items to synchronize in " + modeStr + " mode");
-        return true;
+        return {true, {}};
     }
 
     for (size_t i = 0; i < dataToSync.size(); ++i)
@@ -275,8 +315,9 @@ bool AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
         m_logger(LOG_ERROR, std::string("Failed to finalize sync state: ") + e.what());
     }
 
+    std::string failureReason = determineSyncFailureReasonBasedOnSyncResult(m_syncState.lastSyncResult);
     clearSyncState();
-    return success;
+    return {success, failureReason};
 }
 
 bool AgentSyncProtocol::requiresFullSync(const std::string& index,
@@ -341,21 +382,21 @@ void AgentSyncProtocol::clearInMemoryData()
     m_inMemoryData.clear();
 }
 
-bool AgentSyncProtocol::synchronizeMetadataOrGroups(Mode mode,
-                                                    const std::vector<std::string>& indices,
-                                                    uint64_t globalVersion)
+SyncModuleResult AgentSyncProtocol::synchronizeMetadataOrGroups(Mode mode,
+                                                                const std::vector<std::string>& indices,
+                                                                uint64_t globalVersion)
 {
     // Validate synchronization mode - only allow metadata and group modes
     if (mode != Mode::METADATA_DELTA && mode != Mode::METADATA_CHECK &&
             mode != Mode::GROUP_DELTA && mode != Mode::GROUP_CHECK)
     {
         m_logger(LOG_ERROR, "Invalid synchronization mode for metadata/groups: " + std::to_string(static_cast<int>(mode)));
-        return false;
+        return {false, {}};
     }
 
     if (!m_transport->checkStatus())
     {
-        return false;
+        return {false, {}};
     }
 
     clearSyncState();
@@ -390,8 +431,9 @@ bool AgentSyncProtocol::synchronizeMetadataOrGroups(Mode mode,
         m_logger(LOG_DEBUG, "Synchronization failed for metadata/groups mode");
     }
 
+    std::string failureReason = determineSyncFailureReasonBasedOnSyncResult(m_syncState.lastSyncResult);
     clearSyncState();
-    return success;
+    return {success, failureReason};
 }
 
 bool AgentSyncProtocol::notifyDataClean(const std::vector<std::string>& indices,
@@ -528,6 +570,7 @@ bool AgentSyncProtocol::sendStartAndWaitAck(Mode mode,
         else
         {
             m_logger(LOG_DEBUG, "No groups available in metadata. Waiting for the server to synchronize the groups. Cannot proceed with synchronization.");
+            m_syncState.lastSyncResult = SyncResult::NO_GROUPS_ERROR;
 
             if (has_metadata)
             {
@@ -661,6 +704,7 @@ bool AgentSyncProtocol::sendStartAndWaitAck(Mode mode,
         else
         {
             m_logger(LOG_DEBUG, "Exceeded maximum retries for Start message.");
+            m_syncState.lastSyncResult = SyncResult::START_TIMEOUT_ERROR;
         }
 
         return false;
@@ -1014,6 +1058,7 @@ bool AgentSyncProtocol::sendEndAndWaitAck(uint64_t session,
                 if (ranges.empty())
                 {
                     m_logger(LOG_DEBUG, "Received ReqRet with empty ranges. Aborting current sync attempt.");
+                    m_syncState.lastSyncResult = SyncResult::PROTOCOL_ERROR;
                     return false;
                 }
 
@@ -1022,12 +1067,14 @@ bool AgentSyncProtocol::sendEndAndWaitAck(uint64_t session,
                 if (rangeData.empty())
                 {
                     m_logger(LOG_DEBUG, "ReqRet asked for ranges that yield no data. Aborting.");
+                    m_syncState.lastSyncResult = SyncResult::PROTOCOL_ERROR;
                     return false;
                 }
 
                 if (!sendDataMessages(session, rangeData))
                 {
                     m_logger(LOG_DEBUG, "Failed to resend data for ReqRet.");
+                    m_syncState.lastSyncResult = SyncResult::COMMUNICATION_ERROR;
                     return false;
                 }
 
@@ -1058,6 +1105,7 @@ bool AgentSyncProtocol::sendEndAndWaitAck(uint64_t session,
         else
         {
             m_logger(LOG_DEBUG, "Exceeded maximum retries for End message.");
+            m_syncState.lastSyncResult = SyncResult::END_TIMEOUT_ERROR;
         }
 
         return false;
@@ -1110,6 +1158,9 @@ bool AgentSyncProtocol::parseResponseBuffer(const uint8_t* data, size_t length)
                                 startAck->status() == Wazuh::SyncSchema::Status::Offline)
                         {
                             m_logger(LOG_DEBUG, "Received StartAck with error status. Aborting synchronization.");
+                            m_syncState.lastSyncResult = (startAck->status() == Wazuh::SyncSchema::Status::Offline)
+                                                         ? SyncResult::COMMUNICATION_ERROR
+                                                         : SyncResult::PROTOCOL_ERROR;
                             m_syncState.syncFailed = true;
                             m_syncState.cv.notify_all();
                             break;
@@ -1158,7 +1209,7 @@ bool AgentSyncProtocol::parseResponseBuffer(const uint8_t* data, size_t length)
                         }
                         else if (endAck->status() == Wazuh::SyncSchema::Status::Error)
                         {
-                            m_syncState.lastSyncResult = SyncResult::GENERIC_ERROR;
+                            m_syncState.lastSyncResult = SyncResult::PROTOCOL_ERROR;
                             m_logger(LOG_DEBUG, "Received EndAck with Error status. Aborting synchronization.");
                         }
 

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol_c_interface.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol_c_interface.cpp
@@ -2,6 +2,7 @@
 #include "agent_sync_protocol.hpp"
 #include "agent_sync_protocol_types.hpp"
 #include "agent_sync_protocol_c_wrapper.hpp"
+#include <cstring>
 #include <memory>
 #include <string>
 
@@ -106,23 +107,34 @@ extern "C" {
         }
     }
 
-    bool asp_sync_module(AgentSyncProtocolHandle* handle,
-                         Mode_t mode)
+    SyncModuleResult_t asp_sync_module(AgentSyncProtocolHandle* handle,
+                                       Mode_t mode)
     {
         try
         {
-            if (!handle) return false;
+            if (!handle) return {false, {}};
 
             auto* wrapper = reinterpret_cast<AgentSyncProtocolWrapper*>(handle);
-            return wrapper->impl->synchronizeModule(static_cast<Mode>(mode));
+
+            SyncModuleResult cppResult = wrapper->impl->synchronizeModule(static_cast<Mode>(mode));
+
+            SyncModuleResult_t cResult;
+
+            cResult.success = cppResult.success;
+
+            strncpy(cResult.failure_reason, cppResult.failureReason.c_str(), SYNC_FAILURE_REASON_MAX_LEN - 1);
+
+            cResult.failure_reason[SYNC_FAILURE_REASON_MAX_LEN - 1] = '\0';
+
+            return cResult;
         }
         catch (const std::exception& ex)
         {
-            return false;
+            return {false, {}};
         }
         catch (...)
         {
-            return false;
+            return {false, {}};
         }
     }
 
@@ -185,18 +197,19 @@ extern "C" {
         }
     }
 
-    bool asp_sync_metadata_or_groups(AgentSyncProtocolHandle* handle,
-                                     Mode_t mode,
-                                     const char** indices,
-                                     size_t indices_count,
-                                     uint64_t global_version)
+    SyncModuleResult_t asp_sync_metadata_or_groups(AgentSyncProtocolHandle* handle,
+                                                   Mode_t mode,
+                                                   const char** indices,
+                                                   size_t indices_count,
+                                                   uint64_t global_version)
     {
         try
         {
-            if (!handle || !indices || indices_count == 0) return false;
+            if (!handle || !indices || indices_count == 0) return {false, {}};
 
             // Convert C array of strings to C++ vector
             std::vector<std::string> indices_vec;
+
             indices_vec.reserve(indices_count);
 
             for (size_t i = 0; i < indices_count; ++i)
@@ -207,21 +220,31 @@ extern "C" {
                 }
             }
 
-            if (indices_vec.empty()) return false;
+            if (indices_vec.empty()) return {false, {}};
 
             auto* wrapper = reinterpret_cast<AgentSyncProtocolWrapper*>(handle);
 
-            return wrapper->impl->synchronizeMetadataOrGroups(static_cast<Mode>(mode),
-                                                              indices_vec,
-                                                              global_version);
+            SyncModuleResult cppResult = wrapper->impl->synchronizeMetadataOrGroups(static_cast<Mode>(mode),
+                                                                                    indices_vec,
+                                                                                    global_version);
+
+            SyncModuleResult_t cResult;
+
+            cResult.success = cppResult.success;
+
+            strncpy(cResult.failure_reason, cppResult.failureReason.c_str(), SYNC_FAILURE_REASON_MAX_LEN - 1);
+
+            cResult.failure_reason[SYNC_FAILURE_REASON_MAX_LEN - 1] = '\0';
+
+            return cResult;
         }
         catch (const std::exception& ex)
         {
-            return false;
+            return {false, {}};
         }
         catch (...)
         {
-            return false;
+            return {false, {}};
         }
     }
 

--- a/src/shared_modules/sync_protocol/tests/mocks/mock_agent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/tests/mocks/mock_agent_sync_protocol.hpp
@@ -20,13 +20,13 @@ class MockAgentSyncProtocol : public IAgentSyncProtocol
                     (const std::string& id, Operation operation, const std::string& index, const std::string& data, uint64_t version),
                     (override));
 
-        MOCK_METHOD(bool, synchronizeModule, (Mode mode, Option option), (override));
+        MOCK_METHOD(SyncModuleResult, synchronizeModule, (Mode mode, Option option), (override));
 
         MOCK_METHOD(bool, requiresFullSync, (const std::string& index, const std::string& checksum), (override));
 
         MOCK_METHOD(void, clearInMemoryData, (), (override));
 
-        MOCK_METHOD(bool, synchronizeMetadataOrGroups, (Mode mode, const std::vector<std::string>& indices, uint64_t globalVersion), (override));
+        MOCK_METHOD(SyncModuleResult, synchronizeMetadataOrGroups, (Mode mode, const std::vector<std::string>& indices, uint64_t globalVersion), (override));
 
         MOCK_METHOD(bool, notifyDataClean, (const std::vector<std::string>& indices, Option option), (override));
 

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -11,6 +11,7 @@
 #include "gmock/gmock.h"
 
 #include "agent_sync_protocol.hpp"
+#include "agent_sync_protocol_types.hpp"
 #include "ipersistent_queue.hpp"
 #include "agent_sync_protocol_c_interface.h"
 #include "metadata_provider.h"
@@ -198,11 +199,12 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleNoQueueAvailable)
     protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", failingStartMqFuncs, testLogger, std::chrono::seconds(syncEndDelay), std::chrono::seconds(min_timeout), retries, maxEps,
                                                    mockQueue);
 
-    bool result = protocol->synchronizeModule(
+    SyncModuleResult result = protocol->synchronizeModule(
                       Mode::DELTA
                   );
 
-    EXPECT_FALSE(result);
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.failureReason, "");
 }
 
 TEST_F(AgentSyncProtocolTest, SynchronizeModuleFetchAndMarkForSyncThrowsException)
@@ -222,11 +224,11 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleFetchAndMarkForSyncThrowsExceptio
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
     .WillOnce(::testing::Throw(std::runtime_error("Test exception")));
 
-    bool result = protocol->synchronizeModule(
+    SyncModuleResult result = protocol->synchronizeModule(
                       Mode::DELTA
                   );
 
-    EXPECT_FALSE(result);
+    EXPECT_FALSE(result.success);
 }
 
 TEST_F(AgentSyncProtocolTest, SynchronizeModuleDataToSyncEmpty)
@@ -246,11 +248,11 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleDataToSyncEmpty)
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
     .WillOnce(Return(std::vector<PersistedData> {}));
 
-    bool result = protocol->synchronizeModule(
+    SyncModuleResult result = protocol->synchronizeModule(
                       Mode::DELTA
                   );
 
-    EXPECT_TRUE(result);
+    EXPECT_TRUE(result.success);
 }
 
 // Tests for synchronizeModule with Mode::FULL (using in-memory data)
@@ -272,11 +274,11 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleFullModeWithEmptyInMemoryData)
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
     .Times(0);
 
-    bool result = protocol->synchronizeModule(
+    SyncModuleResult result = protocol->synchronizeModule(
                       Mode::FULL
                   );
 
-    EXPECT_TRUE(result);  // Should return true for empty in-memory data
+    EXPECT_TRUE(result.success);  // Should return true for empty in-memory data
 }
 
 TEST_F(AgentSyncProtocolTest, SynchronizeModuleFullModeWithInMemoryData)
@@ -310,10 +312,10 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleFullModeWithInMemoryData)
     // Start synchronization in FULL mode
     std::thread syncThread([this]()
     {
-        bool result = protocol->synchronizeModule(
+        SyncModuleResult result = protocol->synchronizeModule(
                           Mode::FULL
                       );
-        EXPECT_TRUE(result);
+        EXPECT_TRUE(result.success);
     });
 
     // Wait for start
@@ -381,11 +383,12 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleFullModeFailureKeepsInMemoryData)
     .Times(0);
 
     // Simulate synchronization failure (timeout)
-    bool result = protocol->synchronizeModule(
+    SyncModuleResult result = protocol->synchronizeModule(
                       Mode::FULL
                   );
 
-    EXPECT_FALSE(result);  // Should fail due to timeout
+    EXPECT_FALSE(result.success);  // Should fail due to timeout
+    EXPECT_EQ(result.failureReason, "Timed out waiting for manager response to Start message.");
 
     // In-memory data should be kept for potential retry, so we can add more data
     EXPECT_NO_THROW(protocol->persistDifferenceInMemory("memory_id_2", Operation::MODIFY, "memory_index_2", "memory_data_2", 2));
@@ -416,11 +419,11 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleInvalidModeValidation)
     // Test invalid mode by casting an invalid integer to Mode enum
     Mode invalidMode = static_cast<Mode>(999);
 
-    bool result = protocol->synchronizeModule(
+    SyncModuleResult result = protocol->synchronizeModule(
                       invalidMode
                   );
 
-    EXPECT_FALSE(result);  // Should fail due to invalid mode validation
+    EXPECT_FALSE(result.success);  // Should fail due to invalid mode validation
 }
 
 TEST_F(AgentSyncProtocolTest, SynchronizeModuleSendStartFails)
@@ -450,11 +453,12 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSendStartFails)
     EXPECT_CALL(*mockQueue, resetSyncingItems())
     .Times(1);
 
-    bool result = protocol->synchronizeModule(
+    SyncModuleResult result = protocol->synchronizeModule(
                       Mode::DELTA
                   );
 
-    EXPECT_FALSE(result);
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.failureReason, "Timed out waiting for manager response to Start message.");
 }
 
 TEST_F(AgentSyncProtocolTest, SendStartWaitsUntilMetadataAvailable)
@@ -481,7 +485,7 @@ TEST_F(AgentSyncProtocolTest, SendStartWaitsUntilMetadataAvailable)
     std::atomic<bool> syncDone{false};
     auto syncFuture = std::async(std::launch::async, [&]()
     {
-        bool result = protocol->synchronizeModule(Mode::FULL);
+        SyncModuleResult result = protocol->synchronizeModule(Mode::FULL);
         syncDone = true;
         return result;
     });
@@ -517,7 +521,7 @@ TEST_F(AgentSyncProtocolTest, SendStartWaitsUntilMetadataAvailable)
         FAIL() << "Sync thread did not finish in time; metadata unblocking may be broken";
     }
 
-    EXPECT_FALSE(syncFuture.get()); // Times out on StartAck, but it did get past the metadata wait
+    EXPECT_FALSE(syncFuture.get().success); // Times out on StartAck, but it did get past the metadata wait
 }
 
 TEST_F(AgentSyncProtocolTest, SendStartAbortedOnStopWhileWaitingForMetadata)
@@ -560,7 +564,7 @@ TEST_F(AgentSyncProtocolTest, SendStartAbortedOnStopWhileWaitingForMetadata)
         FAIL() << "Sync thread did not respond to stop() in time; stop handling may be broken";
     }
 
-    EXPECT_FALSE(syncFuture.get());
+    EXPECT_FALSE(syncFuture.get().success);
 }
 
 TEST_F(AgentSyncProtocolTest, SynchronizeModuleStartFailDueToManager)
@@ -592,10 +596,11 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleStartFailDueToManager)
     // Start synchronization
     std::thread syncThread([this]()
     {
-        bool result = protocol->synchronizeModule(
+        SyncModuleResult result = protocol->synchronizeModule(
                           Mode::DELTA
                       );
-        EXPECT_FALSE(result);
+        EXPECT_FALSE(result.success);
+        EXPECT_EQ(result.failureReason, "Manager sent an unexpected or invalid response.");
     });
 
     // Wait for start
@@ -647,11 +652,12 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleStartAckTimeout)
     EXPECT_CALL(*mockQueue, resetSyncingItems())
     .Times(1);
 
-    bool result = protocol->synchronizeModule(
+    SyncModuleResult result = protocol->synchronizeModule(
                       Mode::DELTA
                   );
 
-    EXPECT_FALSE(result);
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.failureReason, "Timed out waiting for manager response to Start message.");
 }
 
 TEST_F(AgentSyncProtocolTest, SynchronizeModuleSendDataMessagesFails)
@@ -693,10 +699,10 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSendDataMessagesFails)
     // Start synchronization
     std::thread syncThread([this]()
     {
-        bool result = protocol->synchronizeModule(
+        SyncModuleResult result = protocol->synchronizeModule(
                           Mode::DELTA
                       );
-        EXPECT_FALSE(result);
+        EXPECT_FALSE(result.success);
     });
 
     // Wait for start
@@ -761,10 +767,11 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSendEndFails)
     // Start synchronization
     std::thread syncThread([this]()
     {
-        bool result = protocol->synchronizeModule(
+        SyncModuleResult result = protocol->synchronizeModule(
                           Mode::DELTA
                       );
-        EXPECT_FALSE(result);
+        EXPECT_FALSE(result.success);
+        EXPECT_EQ(result.failureReason, "Timed out waiting for manager response to End message.");
     });
 
     // Wait for start
@@ -859,7 +866,7 @@ TEST_F(AgentSyncProtocolTest, SendEndAbortedOnStopDuringSyncEndDelay)
                << "cv.wait_for may not be interruptible";
     }
 
-    EXPECT_FALSE(syncFuture.get());
+    EXPECT_FALSE(syncFuture.get().success);
 }
 
 TEST_F(AgentSyncProtocolTest, SynchronizeModuleEndFailDueToManager)
@@ -891,10 +898,11 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleEndFailDueToManager)
     // Start synchronization
     std::thread syncThread([this]()
     {
-        bool result = protocol->synchronizeModule(
+        SyncModuleResult result = protocol->synchronizeModule(
                           Mode::DELTA
                       );
-        EXPECT_FALSE(result);
+        EXPECT_FALSE(result.success);
+        EXPECT_EQ(result.failureReason, "Manager sent an unexpected or invalid response.");
     });
 
     // Wait for start
@@ -969,10 +977,11 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleWithReqRetAndRangesEmpty)
     // Start synchronization
     std::thread syncThread([this]()
     {
-        bool result = protocol->synchronizeModule(
+        SyncModuleResult result = protocol->synchronizeModule(
                           Mode::DELTA
                       );
-        EXPECT_FALSE(result);
+        EXPECT_FALSE(result.success);
+        EXPECT_EQ(result.failureReason, "Manager sent an unexpected or invalid response.");
     });
 
     // Wait for start
@@ -1047,10 +1056,11 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleWithReqRetAndRangesDataEmpty)
     // Start synchronization
     std::thread syncThread([this]()
     {
-        bool result = protocol->synchronizeModule(
+        SyncModuleResult result = protocol->synchronizeModule(
                           Mode::DELTA
                       );
-        EXPECT_FALSE(result);
+        EXPECT_FALSE(result.success);
+        EXPECT_EQ(result.failureReason, "Manager sent an unexpected or invalid response.");
     });
 
     // Wait for start
@@ -1121,12 +1131,12 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleWithReqRetAndDataResendFails)
         {
             callCount++;
 
-            if (callCount > 4)
+            if (callCount > 3)
             {
                 return -1; // Fail data resend for ReqRet
             }
 
-            return 0; // Allow Start, initial Data messages and End
+            return 0; // Allow Start, single DataBatch (both items), and End
         }
     };
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
@@ -1148,10 +1158,11 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleWithReqRetAndDataResendFails)
     // Start synchronization
     std::thread syncThread([this]()
     {
-        bool result = protocol->synchronizeModule(
+        SyncModuleResult result = protocol->synchronizeModule(
                           Mode::DELTA
                       );
-        EXPECT_FALSE(result);
+        EXPECT_FALSE(result.success);
+        EXPECT_EQ(result.failureReason, "Failed to communicate with the manager.");
     });
 
     // Wait for start
@@ -1235,10 +1246,11 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleEndAckTimeout)
     // Start synchronization
     std::thread syncThread([this]()
     {
-        bool result = protocol->synchronizeModule(
+        SyncModuleResult result = protocol->synchronizeModule(
                           Mode::DELTA
                       );
-        EXPECT_FALSE(result);
+        EXPECT_FALSE(result.success);
+        EXPECT_EQ(result.failureReason, "Timed out waiting for manager response to End message.");
     });
 
     // Wait for start
@@ -1294,10 +1306,10 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSuccessWithNoReqRet)
     // Start synchronization
     std::thread syncThread([this]()
     {
-        bool result = protocol->synchronizeModule(
+        SyncModuleResult result = protocol->synchronizeModule(
                           Mode::DELTA
                       );
-        EXPECT_TRUE(result);
+        EXPECT_TRUE(result.success);
     });
 
     // Wait for start
@@ -1373,10 +1385,10 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSuccessWithReqRet)
     // Start synchronization
     std::thread syncThread([this]()
     {
-        bool result = protocol->synchronizeModule(
+        SyncModuleResult result = protocol->synchronizeModule(
                           Mode::DELTA
                       );
-        EXPECT_TRUE(result);
+        EXPECT_TRUE(result.success);
     });
 
     // Wait for start
@@ -1491,8 +1503,8 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleFinalizeSyncStateException)
     // Start synchronization in background
     std::thread syncThread([this]()
     {
-        bool result = protocol->synchronizeModule(Mode::DELTA);
-        EXPECT_TRUE(result); // Should still return true despite the exception in finalization
+        SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
+        EXPECT_TRUE(result.success); // Should still return true despite the exception in finalization
     });
 
     // Wait for start
@@ -2618,11 +2630,11 @@ TEST_F(AgentSyncProtocolTest, EnsureQueueAvailableException)
                                                    mockQueue);
 
     // Try to synchronize, which should trigger ensureQueueAvailable() and catch the exception
-    bool result = protocol->synchronizeModule(
+    SyncModuleResult result = protocol->synchronizeModule(
                       Mode::DELTA
                   );
 
-    EXPECT_FALSE(result); // Should fail due to exception in ensureQueueAvailable
+    EXPECT_FALSE(result.success); // Should fail due to exception in ensureQueueAvailable
 
     // Verify that the exception error was logged
     EXPECT_TRUE(loggedMessage.find("Exception when checking queue availability") != std::string::npos);
@@ -2667,11 +2679,11 @@ TEST_F(AgentSyncProtocolTest, SendStartAndWaitAckException)
     .WillOnce(testing::Return(testData));
 
     // Try to synchronize, which should trigger sendStartAndWaitAck and catch the exception
-    bool result = protocol->synchronizeModule(
+    SyncModuleResult result = protocol->synchronizeModule(
                       Mode::DELTA
                   );
 
-    EXPECT_FALSE(result); // Should fail due to exception in sendStartAndWaitAck
+    EXPECT_FALSE(result.success); // Should fail due to exception in sendStartAndWaitAck
 
     // Verify that the exception error was logged
     EXPECT_TRUE(loggedMessage.find("Exception when sending Start message") != std::string::npos);
@@ -2730,10 +2742,10 @@ TEST_F(AgentSyncProtocolTest, SendDataMessagesException)
     // Start synchronization in background
     std::thread syncThread([this]()
     {
-        bool result = protocol->synchronizeModule(
+        SyncModuleResult result = protocol->synchronizeModule(
                           Mode::DELTA
                       );
-        EXPECT_FALSE(result); // Should fail due to exception in sendDataMessages
+        EXPECT_FALSE(result.success); // Should fail due to exception in sendDataMessages
     });
 
     // Wait for start
@@ -2829,11 +2841,12 @@ TEST_F(AgentSyncProtocolTest, ClearInMemoryDataAfterFailedFullSync)
     .Times(0);
 
     // Simulate synchronization failure (timeout)
-    bool result = protocol->synchronizeModule(
+    SyncModuleResult result = protocol->synchronizeModule(
                       Mode::FULL
                   );
 
-    EXPECT_FALSE(result);  // Should fail due to timeout
+    EXPECT_FALSE(result.success);  // Should fail due to timeout
+    EXPECT_EQ(result.failureReason, "Timed out waiting for manager response to Start message.");
 
     // Clear in-memory data after failed sync
     EXPECT_NO_THROW(protocol->clearInMemoryData());
@@ -2896,12 +2909,12 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithMetadataDeltaMode)
     std::thread syncThread([this]()
     {
         std::vector<std::string> testIndices = {"test-index-1", "test-index-2"};
-        bool result = protocol->synchronizeMetadataOrGroups(
+        SyncModuleResult result = protocol->synchronizeMetadataOrGroups(
                           Mode::METADATA_DELTA,
                           testIndices,
                           12345 // globalVersion
                       );
-        EXPECT_TRUE(result);
+        EXPECT_TRUE(result.success);
     });
 
     // Wait for start message
@@ -2967,12 +2980,12 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithMetadataCheckMode)
     std::thread syncThread([this]()
     {
         std::vector<std::string> testIndices = {"test-index-1", "test-index-2"};
-        bool result = protocol->synchronizeMetadataOrGroups(
+        SyncModuleResult result = protocol->synchronizeMetadataOrGroups(
                           Mode::METADATA_CHECK,
                           testIndices,
                           12345 // globalVersion
                       );
-        EXPECT_TRUE(result);
+        EXPECT_TRUE(result.success);
     });
 
     // Wait for start message
@@ -3038,12 +3051,12 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithGroupDeltaMode)
     std::thread syncThread([this]()
     {
         std::vector<std::string> testIndices = {"test-index-1", "test-index-2"};
-        bool result = protocol->synchronizeMetadataOrGroups(
+        SyncModuleResult result = protocol->synchronizeMetadataOrGroups(
                           Mode::GROUP_DELTA,
                           testIndices,
                           12345 // globalVersion
                       );
-        EXPECT_TRUE(result);
+        EXPECT_TRUE(result.success);
     });
 
     // Wait for start message
@@ -3109,12 +3122,12 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithGroupCheckMode)
     std::thread syncThread([this]()
     {
         std::vector<std::string> testIndices = {"test-index-1", "test-index-2"};
-        bool result = protocol->synchronizeMetadataOrGroups(
+        SyncModuleResult result = protocol->synchronizeMetadataOrGroups(
                           Mode::GROUP_CHECK,
                           testIndices,
                           12345 // globalVersion
                       );
-        EXPECT_TRUE(result);
+        EXPECT_TRUE(result.success);
     });
 
     // Wait for start message
@@ -3174,13 +3187,13 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithInvalidMode)
 
     // Try with Mode::DELTA (not allowed for synchronizeMetadataOrGroups)
     std::vector<std::string> testIndices = {"test-index-1", "test-index-2"};
-    bool result = protocol->synchronizeMetadataOrGroups(
+    SyncModuleResult result = protocol->synchronizeMetadataOrGroups(
                       Mode::DELTA,
                       testIndices,
                       12345 // globalVersion
                   );
 
-    EXPECT_FALSE(result);
+    EXPECT_FALSE(result.success);
 }
 
 TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithFailedQueueStart)
@@ -3200,13 +3213,14 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithFailedQueueStart)
                                                    mockQueue);
 
     std::vector<std::string> testIndices = {"test-index-1", "test-index-2"};
-    bool result = protocol->synchronizeMetadataOrGroups(
+    SyncModuleResult result = protocol->synchronizeMetadataOrGroups(
                       Mode::METADATA_DELTA,
                       testIndices,
                       12345 // globalVersion
                   );
 
-    EXPECT_FALSE(result);
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.failureReason, "");
 }
 
 TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsStartAckTimeout)
@@ -3225,13 +3239,14 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsStartAckTimeout)
 
     // Don't send any response, causing timeout
     std::vector<std::string> testIndices = {"test-index-1", "test-index-2"};
-    bool result = protocol->synchronizeMetadataOrGroups(
+    SyncModuleResult result = protocol->synchronizeMetadataOrGroups(
                       Mode::METADATA_CHECK,
                       testIndices,
                       12345 // globalVersion
                   );
 
-    EXPECT_FALSE(result);
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.failureReason, "Timed out waiting for manager response to Start message.");
 }
 
 TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsEndAckTimeout)
@@ -3252,12 +3267,13 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsEndAckTimeout)
     std::thread syncThread([this]()
     {
         std::vector<std::string> testIndices = {"test-index-1", "test-index-2"};
-        bool result = protocol->synchronizeMetadataOrGroups(
+        SyncModuleResult result = protocol->synchronizeMetadataOrGroups(
                           Mode::GROUP_DELTA,
                           testIndices,
                           12345 // globalVersion
                       );
-        EXPECT_FALSE(result);
+        EXPECT_FALSE(result.success);
+        EXPECT_EQ(result.failureReason, "Timed out waiting for manager response to End message.");
     });
 
     // Wait for start message
@@ -3302,12 +3318,13 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithStartAckError)
     std::thread syncThread([this]()
     {
         std::vector<std::string> testIndices = {"test-index-1", "test-index-2"};
-        bool result = protocol->synchronizeMetadataOrGroups(
+        SyncModuleResult result = protocol->synchronizeMetadataOrGroups(
                           Mode::METADATA_DELTA,
                           testIndices,
                           12345 // globalVersion
                       );
-        EXPECT_FALSE(result);
+        EXPECT_FALSE(result.success);
+        EXPECT_EQ(result.failureReason, "Manager sent an unexpected or invalid response.");
     });
 
     // Wait for start message
@@ -3350,12 +3367,12 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithEndAckError)
     std::thread syncThread([this]()
     {
         std::vector<std::string> testIndices = {"test-index-1", "test-index-2"};
-        bool result = protocol->synchronizeMetadataOrGroups(
+        SyncModuleResult result = protocol->synchronizeMetadataOrGroups(
                           Mode::GROUP_CHECK,
                           testIndices,
                           12345 // globalVersion
                       );
-        EXPECT_FALSE(result);
+        EXPECT_FALSE(result.success);
     });
 
     // Wait for start message
@@ -4090,10 +4107,10 @@ TEST_F(AgentSyncProtocolTest, SendEndMessageException)
     // Start synchronization in background to trigger sendEndAndWaitAck
     std::thread syncThread([&testProtocol, this]()
     {
-        bool result = testProtocol->synchronizeModule(
+        SyncModuleResult result = testProtocol->synchronizeModule(
                           Mode::DELTA
                       );
-        EXPECT_FALSE(result); // Should fail due to exception in sendEndAndWaitAck
+        EXPECT_FALSE(result.success); // Should fail due to exception in sendEndAndWaitAck
     });
 
     // Wait for start
@@ -4209,9 +4226,9 @@ TEST_F(AgentSyncProtocolTest, DeltaModeSyncLogsErrorWithoutQueue)
                                                    retries, maxEps, nullptr);
 
     // DELTA mode should return false and log error when no queue is available
-    bool result = protocol->synchronizeModule(Mode::DELTA);
+    SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
 
-    EXPECT_FALSE(result);
+    EXPECT_FALSE(result.success);
     EXPECT_EQ(loggedLevel, LOG_ERROR);
     EXPECT_TRUE(loggedMessage.find("Failed to fetch items for sync") != std::string::npos);
     EXPECT_TRUE(loggedMessage.find("requires a persistent queue") != std::string::npos);
@@ -4445,8 +4462,8 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckChecksumMismatch)
 
         EXPECT_CALL(*mockQueue, fetchAndMarkForSync()).WillOnce(Return(testData));
 
-        bool syncResult = protocol->synchronizeModule(Mode::DELTA);
-        EXPECT_FALSE(syncResult);
+        SyncModuleResult syncResult = protocol->synchronizeModule(Mode::DELTA);
+        EXPECT_FALSE(syncResult.success);
     });
 
     // Wait for WaitingStartAck phase
@@ -4524,8 +4541,8 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckGenericError)
 
         EXPECT_CALL(*mockQueue, fetchAndMarkForSync()).WillOnce(Return(testData));
 
-        bool syncResult = protocol->synchronizeModule(Mode::DELTA);
-        EXPECT_FALSE(syncResult);
+        SyncModuleResult syncResult = protocol->synchronizeModule(Mode::DELTA);
+        EXPECT_FALSE(syncResult.success);
     });
 
     // Wait for WaitingStartAck phase
@@ -5608,8 +5625,8 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckProcessing)
 
     std::thread syncThread([this]()
     {
-        bool result = protocol->synchronizeModule(Mode::DELTA);
-        EXPECT_TRUE(result);
+        SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
+        EXPECT_TRUE(result.success);
     });
 
     // StartAck
@@ -5680,8 +5697,8 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleProcessingAckThenEndAckSuccess)
 
     std::thread syncThread([this]()
     {
-        bool result = protocol->synchronizeModule(Mode::DELTA);
-        EXPECT_TRUE(result);
+        SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
+        EXPECT_TRUE(result.success);
     });
 
     // StartAck
@@ -5758,8 +5775,8 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleProcessingAckDoesNotConsumeRetry)
 
     std::thread syncThread([this]()
     {
-        bool result = protocol->synchronizeModule(Mode::DELTA);
-        EXPECT_TRUE(result);
+        SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
+        EXPECT_TRUE(result.success);
     });
 
     // StartAck
@@ -5828,8 +5845,8 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleProcessingAckThenEndAckError)
 
     std::thread syncThread([this]()
     {
-        bool result = protocol->synchronizeModule(Mode::DELTA);
-        EXPECT_FALSE(result);
+        SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
+        EXPECT_FALSE(result.success);
     });
 
     // StartAck
@@ -5929,8 +5946,8 @@ TEST_F(AgentSyncProtocolTest, EndMessageRetryExhaustionDuringStopLogsDebug)
 
     std::thread syncThread([this]()
     {
-        bool result = protocol->synchronizeModule(Mode::DELTA);
-        EXPECT_FALSE(result);
+        SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
+        EXPECT_FALSE(result.success);
     });
 
     // Helper: always stop + join on early exit (prevents std::terminate on ASSERT failure).
@@ -6069,8 +6086,8 @@ TEST_F(AgentSyncProtocolTest, FailedToSendEndMessageDuringStopLogsDebug)
 
     std::thread syncThread([this]()
     {
-        bool result = protocol->synchronizeModule(Mode::DELTA);
-        EXPECT_FALSE(result);
+        SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
+        EXPECT_FALSE(result.success);
     });
 
     auto stopAndJoin = [&]()
@@ -6179,8 +6196,8 @@ TEST_F(AgentSyncProtocolTest, FailedToSendStartMessageDuringStopLogsDebug)
     // Request stop *before* synchronizing so shouldStop() is true while Start is attempted.
     protocol->stop();
 
-    bool result = protocol->synchronizeModule(Mode::DELTA);
-    EXPECT_FALSE(result);
+    SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
+    EXPECT_FALSE(result.success);
 
     auto findLog = [&capturedLogs](const std::string & needle)
     {
@@ -6249,7 +6266,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleConcurrentCallIsSkippedAndDoesNot
     EXPECT_CALL(*mockQueue, clearSyncedItems()).Times(1);
 
     // Thread 1: starts the in-flight sync (will block waiting for StartAck).
-    std::promise<bool> firstResult;
+    std::promise<SyncModuleResult> firstResult;
     auto firstFuture = firstResult.get_future();
     std::thread syncThread([this, &firstResult]()
     {
@@ -6269,7 +6286,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleConcurrentCallIsSkippedAndDoesNot
     // The concurrent call must complete quickly (it is skipped, not blocked).
     auto status = concurrentFuture.wait_for(std::chrono::seconds(2));
     ASSERT_EQ(status, std::future_status::ready) << "Concurrent call did not return quickly — likely blocked inside synchronizeModule instead of being skipped";
-    EXPECT_TRUE(concurrentFuture.get()) << "Concurrent call should return true (skipped, not an error)";
+    EXPECT_TRUE(concurrentFuture.get().success) << "Concurrent call should return true (skipped, not an error)";
 
     // Complete Thread 1's sync normally: StartAck then EndAck.
     {
@@ -6295,9 +6312,9 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleConcurrentCallIsSkippedAndDoesNot
     syncThread.join();
 
     // Thread 1 must have succeeded — session state was not corrupted by the concurrent call.
-    EXPECT_TRUE(firstFuture.get()) << "In-flight sync failed, likely due to session state corruption from concurrent call";
+    EXPECT_TRUE(firstFuture.get().success) << "In-flight sync failed, likely due to session state corruption from concurrent call";
 
     // After Thread 1 completes, m_syncInProgress must be cleared.
     // A fresh call with an empty queue must run to completion (not be skipped).
-    EXPECT_TRUE(protocol->synchronizeModule(Mode::DELTA)) << "Post-sync call was skipped — m_syncInProgress was not reset after completion";
+    EXPECT_TRUE(protocol->synchronizeModule(Mode::DELTA).success) << "Post-sync call was skipped — m_syncInProgress was not reset after completion";
 }

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol_datacontext.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol_datacontext.cpp
@@ -140,8 +140,8 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleWithOnlyDataValueItems
     std::thread syncThread(
         [this]()
     {
-        bool result = protocol->synchronizeModule(Mode::DELTA);
-        EXPECT_TRUE(result);
+        SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
+        EXPECT_TRUE(result.success);
     });
 
     // Wait for start
@@ -212,8 +212,8 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleWithOnlyDataContextIte
     std::thread syncThread(
         [this]()
     {
-        bool result = protocol->synchronizeModule(Mode::DELTA);
-        EXPECT_TRUE(result);
+        SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
+        EXPECT_TRUE(result.success);
     });
 
     // Wait for start
@@ -310,8 +310,8 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleWithMixedDataValueAndD
     std::thread syncThread(
         [this]()
     {
-        bool result = protocol->synchronizeModule(Mode::DELTA);
-        EXPECT_TRUE(result);
+        SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
+        EXPECT_TRUE(result.success);
     });
 
     // Wait for start
@@ -398,8 +398,8 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleDataContextFailureDoes
     std::thread syncThread(
         [this]()
     {
-        bool result = protocol->synchronizeModule(Mode::DELTA);
-        EXPECT_FALSE(result); // Should fail due to DataContext send failure
+        SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
+        EXPECT_FALSE(result.success); // Should fail due to DataContext send failure
     });
 
     // Wait for start
@@ -487,8 +487,8 @@ TEST_F(AgentSyncProtocolDataContextTest, DataBatch_DataValuesAreBatchedTogether)
     std::thread syncThread(
         [this]()
     {
-        bool result = protocol->synchronizeModule(Mode::DELTA);
-        EXPECT_TRUE(result);
+        SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
+        EXPECT_TRUE(result.success);
     });
 
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
@@ -580,8 +580,8 @@ TEST_F(AgentSyncProtocolDataContextTest, DataBatch_BatchContainsExpectedDataValu
     std::thread syncThread(
         [this]()
     {
-        bool result = protocol->synchronizeModule(Mode::DELTA);
-        EXPECT_TRUE(result);
+        SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
+        EXPECT_TRUE(result.success);
     });
 
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));

--- a/src/shared_modules/sync_protocol/testtool/main.cpp
+++ b/src/shared_modules/sync_protocol/testtool/main.cpp
@@ -83,7 +83,7 @@ int main()
         proto.persistDifference("id1", Operation::CREATE, "idx1", "{\"k\":\"v1\"}", 1);
         proto.persistDifference("id2", Operation::MODIFY, "idx2", "{\"k\":\"v2\"}", 2);
 
-        bool ok = proto.synchronizeModule(Mode::FULL);
+        bool ok = proto.synchronizeModule(Mode::FULL).success;
         std::cout << (ok ? "OK" : "FAIL") << std::endl;
         return ok ? 0 : 1;
     }

--- a/src/syscheckd/src/recovery/recovery.c
+++ b/src/syscheckd/src/recovery/recovery.c
@@ -241,12 +241,12 @@ void fim_recovery_persist_table_and_resync(char* table_name, AgentSyncProtocolHa
     cJSON_Delete(items);
 
     // Synchronize
-    bool success = asp_sync_module(handle, MODE_FULL);
+    SyncModuleResult_t result = asp_sync_module(handle, MODE_FULL);
 
-    if (success) {
+    if (result.success) {
         mdebug1("Recovery completed successfully");
     } else {
-        mdebug1("Recovery synchronization failed, will retry later");
+        mdebug1("Recovery synchronization failed, will retry later%s%s", result.failure_reason[0] != '\0' ? ": " : "", result.failure_reason);
     }
 }
 

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -1023,17 +1023,23 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
         if (pause_requested && flush_request_detected) {
             minfo("Starting FIM synchronization requested by agent-info.");
 
-            bool sync_result = asp_sync_module(syscheck.sync_handle,
+            SyncModuleResult_t sync_result = asp_sync_module(syscheck.sync_handle,
                                                MODE_DELTA);
 
-            minfo("FIM synchronization requested by agent-info finished.");
+            if (sync_result.success) {
+                minfo("FIM synchronization requested by agent-info finished successfully.");
+            } else {
+                mwarn("FIM synchronization requested by agent-info failed%s%s",
+                      sync_result.failure_reason[0] != '\0' ? ": " : "",
+                      sync_result.failure_reason);
+            }
 
             // Mark the flush as completed (flush_request_detected is always true here).
-            int result = sync_result ? 0 : -1;
+            int result = sync_result.success ? 0 : -1;
             atomic_int_set(&fim_flush_result, result);
             atomic_int_set(&fim_flush_in_progress, 0);
 
-            if (sync_result && !first_sync_completed) {
+            if (sync_result.success && !first_sync_completed) {
                 fim_db_update_last_sync_time_value(FIM_FIRST_SYNC_COMPLETED_METADATA_KEY, (int64_t)time(NULL));
                 first_sync_completed = true;
                 atomic_int_set(&syscheck.fim_first_sync_completed, 1);
@@ -1053,9 +1059,9 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
 
             minfo("Starting FIM synchronization.");
 
-            bool sync_result = asp_sync_module(syscheck.sync_handle,
+            SyncModuleResult_t sync_result = asp_sync_module(syscheck.sync_handle,
                                                MODE_DELTA);
-            if (sync_result) {
+            if (sync_result.success) {
                 minfo("FIM synchronization finished successfully.");
 
                 if (!first_sync_completed) {
@@ -1064,14 +1070,14 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
                     atomic_int_set(&syscheck.fim_first_sync_completed, 1);
                 }
             } else {
-                minfo("FIM synchronization failed.");
+                mwarn("FIM synchronization failed%s%s", sync_result.failure_reason[0] != '\0' ? ": " : "", sync_result.failure_reason);
             }
 
             // If a flush was triggered while paused but processed here (after resume),
             // clear the flush state so pollFlushCompletion() can return "completed".
             // Touches only atomics, so it stays outside the scan mutex.
             if (flush_request_detected) {
-                int result = sync_result ? 0 : -1;
+                int result = sync_result.success ? 0 : -1;
                 atomic_int_set(&fim_flush_result, result);
                 atomic_int_set(&fim_flush_in_progress, 0);
                 mdebug1("Pending flush request completed via normal sync path.");
@@ -1081,7 +1087,7 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
             // process, which reads and writes the file_entry table. Skipped once shutdown
             // starts: fim_scan_mutex can be held by an in-flight scan for minutes, and the
             // shutdown waiter is waiting to join this thread.
-            if (sync_result && fim_sync_module_running) {
+            if (sync_result.success && fim_sync_module_running) {
                 w_mutex_lock(&syscheck.fim_scan_mutex);
                 w_mutex_lock(&syscheck.fim_realtime_mutex);
                 #ifdef WIN32

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -447,7 +447,7 @@ static void expect_fim_flush_sync_body(AgentSyncProtocolHandle* handle, bool per
     expect_value(__wrap_asp_sync_module, mode, MODE_DELTA);
     will_return(__wrap_asp_sync_module, true);
 
-    expect_string(__wrap__minfo, formatted_msg, "FIM synchronization requested by agent-info finished.");
+    expect_string(__wrap__minfo, formatted_msg, "FIM synchronization requested by agent-info finished successfully.");
 
     if (persist_first_sync_marker) {
 #ifndef TEST_WINAGENT

--- a/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.c
@@ -42,12 +42,14 @@ void __wrap_asp_persist_diff(AgentSyncProtocolHandle* handle,
     check_expected(version);
 }
 
-bool __wrap_asp_sync_module(AgentSyncProtocolHandle* handle,
+SyncModuleResult_t __wrap_asp_sync_module(AgentSyncProtocolHandle* handle,
                             int mode) {
     check_expected_ptr(handle);
     check_expected(mode);
     __wrap_asp_sync_module_hook();
-    return mock_type(bool);
+    SyncModuleResult_t result = {0};
+    result.success = mock_type(bool);
+    return result;
 }
 
 void __wrap_asp_persist_diff_in_memory(AgentSyncProtocolHandle* handle,
@@ -82,11 +84,13 @@ void __wrap_asp_clear_in_memory_data(AgentSyncProtocolHandle* handle) {
     check_expected_ptr(handle);
 }
 
-bool __wrap_asp_sync_metadata_or_groups(AgentSyncProtocolHandle* handle,
-                                        int mode) {
+SyncModuleResult_t __wrap_asp_sync_metadata_or_groups(AgentSyncProtocolHandle* handle,
+                                                      int mode) {
     check_expected_ptr(handle);
     check_expected(mode);
-    return mock_type(bool);
+    SyncModuleResult_t result = {0};
+    result.success = mock_type(bool);
+    return result;
 }
 
 bool __wrap_asp_notify_data_clean(AgentSyncProtocolHandle* handle,

--- a/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.h
@@ -34,8 +34,8 @@ void __wrap_asp_persist_diff_in_memory(AgentSyncProtocolHandle* handle,
                                        const char* index,
                                        const char* data);
 
-bool __wrap_asp_sync_module(AgentSyncProtocolHandle* handle,
-                            int mode);
+SyncModuleResult_t __wrap_asp_sync_module(AgentSyncProtocolHandle* handle,
+                                          int mode);
 
 bool __wrap_asp_requires_full_sync(AgentSyncProtocolHandle* handle,
                                    const char* index,
@@ -45,8 +45,8 @@ bool __wrap_asp_parse_response_buffer(AgentSyncProtocolHandle* handle, const uin
 
 void __wrap_asp_clear_in_memory_data(AgentSyncProtocolHandle* handle);
 
-bool __wrap_asp_sync_metadata_or_groups(AgentSyncProtocolHandle* handle,
-                                        int mode);
+SyncModuleResult_t __wrap_asp_sync_metadata_or_groups(AgentSyncProtocolHandle* handle,
+                                                      int mode);
 
 bool __wrap_asp_notify_data_clean(AgentSyncProtocolHandle* handle,
                                   const char** indices,

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -1833,12 +1833,13 @@ AgentInfoImpl::CoordinationResult AgentInfoImpl::coordinateModules(const std::st
 
         if (m_spSyncProtocol)
         {
-            bool syncSuccess = m_spSyncProtocol->synchronizeMetadataOrGroups(
-                                   TABLE_DELTA_MODE_MAP.at(table), indicesToSync, newVersion);
+            SyncModuleResult syncResult = m_spSyncProtocol->synchronizeMetadataOrGroups(
+                                              TABLE_DELTA_MODE_MAP.at(table), indicesToSync, newVersion);
 
-            if (!syncSuccess)
+            if (!syncResult.success)
             {
-                m_logFunction(LOG_WARNING, "Failed to synchronize " + table);
+                m_logFunction(LOG_WARNING, "Failed to synchronize " + table +
+                              (syncResult.failureReason.empty() ? "." : ": " + syncResult.failureReason));
                 return CoordinationResult::Failed;
             }
 
@@ -2261,22 +2262,23 @@ bool AgentInfoImpl::performIntegritySync(const std::string& table)
         }
 
         // Perform integrity check - no globalVersion needed for CHECK modes
-        bool success = m_spSyncProtocol->synchronizeMetadataOrGroups(TABLE_CHECK_MODE_MAP.at(table), indicesToCheck);
+        SyncModuleResult syncResult = m_spSyncProtocol->synchronizeMetadataOrGroups(TABLE_CHECK_MODE_MAP.at(table), indicesToCheck);
 
         // Update the last sync time regardless of the synchronization result
         // This ensures we always wait for integrity_interval before trying again
         updateLastIntegrityTime(table);
 
-        if (success)
+        if (syncResult.success)
         {
             m_logFunction(LOG_INFO, "Successfully completed integrity check for " + table);
         }
         else
         {
-            m_logFunction(LOG_WARNING, "Failed integrity check for " + table);
+            m_logFunction(LOG_WARNING, "Failed integrity check for " + table +
+                          (syncResult.failureReason.empty() ? "." : ": " + syncResult.failureReason));
         }
 
-        return success;
+        return syncResult.success;
     }
     catch (const std::exception& e)
     {

--- a/src/wazuh_modules/sca/include/sca.h
+++ b/src/wazuh_modules/sca/include/sca.h
@@ -2,6 +2,7 @@
 #define _SCA_H
 
 // Define EXPORTED for any platform
+#include "agent_sync_protocol_c_interface.h"
 #ifdef _WIN32
 #ifdef WIN_EXPORT
 #define EXPORTED __declspec(dllexport)

--- a/src/wazuh_modules/sca/include/sca.hpp
+++ b/src/wazuh_modules/sca/include/sca.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "agent_sync_protocol_types.hpp"
 #include "sca.h"
 #include <sca_impl.hpp>
 
@@ -87,7 +88,7 @@ class EXPORTED SCA final
         /// parameters.
         ///
         /// @param mode Synchronization mode (FULL or DELTA)
-        /// @return true if synchronization succeeds, false otherwise
+        /// @return true on success, false on failure (a WARNING with the reason is logged internally).
         bool syncModule(Mode mode);
 
         /// @brief Persists a difference entry for synchronization.

--- a/src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp
+++ b/src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp
@@ -5,6 +5,7 @@
 #include <idbsync.hpp>
 #include <ifilesystem_wrapper.hpp>
 #include <sca_utils.hpp>
+#include "agent_sync_protocol_types.hpp"
 #include "asyncFlushController.hpp"
 #include "iagent_sync_protocol.hpp"
 
@@ -103,7 +104,7 @@ class SecurityConfigurationAssessment
 
         /// @brief Synchronize the module
         /// @param mode Synchronization mode
-        /// @return true if synchronization was successful, false otherwise
+        /// @return true on success, false on failure (a WARNING with the reason is logged internally).
         bool syncModule(Mode mode);
 
         /// @brief Persist a difference
@@ -223,11 +224,11 @@ class SecurityConfigurationAssessment
         /// @brief Synchronize the current DB snapshot using FULL mode.
         /// @param increaseVersions Whether to bump versions before building the snapshot.
         /// @param syncReason Reason used in logs.
-        /// @return true on success.
-        bool synchronizeDatabaseSnapshot(bool increaseVersions, const std::string& syncReason);
+        /// @return SyncModuleResult with success flag and an optional failure reason string.
+        SyncModuleResult synchronizeDatabaseSnapshot(bool increaseVersions, const std::string& syncReason);
 
         /// @brief Perform full recovery: load all checks and resync
-        /// @return true on success
+        /// @return true on success, false on failure.
         bool performRecovery();
 
         /// @brief Check with manager if full sync required via checksum

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -15,6 +15,7 @@
 #include <thread>
 
 #include "agent_sync_protocol.hpp"
+#include "agent_sync_protocol_types.hpp"
 #include "logging_helper.hpp"
 #include "hashHelper.h"
 #include "sca.h"
@@ -528,7 +529,7 @@ bool SecurityConfigurationAssessment::syncModule(Mode mode)
 
     const bool firstSyncPending = !m_firstSyncCompleted.load();
 
-    bool result = false;
+    SyncModuleResult result;
 
     if (firstSyncPending)
     {
@@ -542,7 +543,7 @@ bool SecurityConfigurationAssessment::syncModule(Mode mode)
         result = m_spSyncProtocol->synchronizeModule(mode);
     }
 
-    if (result)
+    if (result.success)
     {
         if (firstSyncPending)
         {
@@ -558,16 +559,16 @@ bool SecurityConfigurationAssessment::syncModule(Mode mode)
         m_pauseCv.notify_all();
     }
 
-    if (result)
+    if (result.success)
     {
         LoggingHelper::getInstance().log(LOG_INFO, "SCA synchronization finished successfully.");
     }
     else
     {
-        LoggingHelper::getInstance().log(LOG_INFO, "SCA synchronization failed.");
+        LoggingHelper::getInstance().log(LOG_WARNING, "SCA synchronization failed" + (result.failureReason.empty() ? "." : ": " + result.failureReason));
     }
 
-    return result;
+    return result.success;
 }
 
 void SecurityConfigurationAssessment::persistDifference(const std::string& id, Operation operation, const std::string& index, const std::string& data, uint64_t version)
@@ -798,9 +799,9 @@ int SecurityConfigurationAssessment::executeFlushSync()
     }
 
     // Trigger immediate synchronization to flush pending messages
-    bool result = m_spSyncProtocol->synchronizeModule(Mode::DELTA);
+    SyncModuleResult result = m_spSyncProtocol->synchronizeModule(Mode::DELTA);
 
-    if (result)
+    if (result.success)
     {
         LoggingHelper::getInstance().log(LOG_DEBUG, "SCA flush completed successfully");
         return 0;
@@ -1123,10 +1124,10 @@ bool SecurityConfigurationAssessment::checkIfRecoveryRequired(const std::string&
 
 bool SecurityConfigurationAssessment::performRecovery()
 {
-    return synchronizeDatabaseSnapshot(true, "recovery");
+    return synchronizeDatabaseSnapshot(true, "recovery").success;
 }
 
-bool SecurityConfigurationAssessment::synchronizeDatabaseSnapshot(bool increaseVersions, const std::string& syncReason)
+SyncModuleResult SecurityConfigurationAssessment::synchronizeDatabaseSnapshot(bool increaseVersions, const std::string& syncReason)
 {
     LoggingHelper::getInstance().log(LOG_DEBUG, "Starting SCA " + syncReason + " full synchronization");
 
@@ -1135,13 +1136,13 @@ bool SecurityConfigurationAssessment::synchronizeDatabaseSnapshot(bool increaseV
         if (!m_dBSync)
         {
             LoggingHelper::getInstance().log(LOG_ERROR, "DBSync is null, cannot synchronize SCA snapshot");
-            return false;
+            return {false, {}};
         }
 
         if (!m_spSyncProtocol)
         {
             LoggingHelper::getInstance().log(LOG_DEBUG, "Sync protocol not initialized, cannot synchronize SCA snapshot");
-            return false;
+            return {false, {}};
         }
 
         if (increaseVersions)
@@ -1254,9 +1255,9 @@ bool SecurityConfigurationAssessment::synchronizeDatabaseSnapshot(bool increaseV
         }
 
         LoggingHelper::getInstance().log(LOG_DEBUG, "Triggering full synchronization for SCA " + syncReason);
-        const bool success = m_spSyncProtocol->synchronizeModule(Mode::FULL);
+        SyncModuleResult result = m_spSyncProtocol->synchronizeModule(Mode::FULL);
 
-        if (success)
+        if (result.success)
         {
             LoggingHelper::getInstance().log(LOG_DEBUG, "SCA " + syncReason + " completed successfully");
         }
@@ -1267,12 +1268,12 @@ bool SecurityConfigurationAssessment::synchronizeDatabaseSnapshot(bool increaseV
             LoggingHelper::getInstance().log(LOG_DEBUG, "SCA " + syncReason + " failed");
         }
 
-        return success;
+        return result;
     }
     catch (const std::exception& err)
     {
         LoggingHelper::getInstance().log(LOG_ERROR, "Error during SCA " + syncReason + ": " + std::string(err.what()));
-        return false;
+        return {false, {}};
     }
 }
 

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp
@@ -613,7 +613,7 @@ TEST_F(ScaTest, SyncModule_PerformsInitialFullSnapshotBeforeFirstSync)
         EXPECT_EQ(payload["policy"]["id"], "policy-1");
     }));
     EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::FULL, Option::SYNC))
-    .WillOnce(testing::Return(true));
+    .WillOnce(testing::Return(SyncModuleResult{true}));
     EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
     .Times(0);
     EXPECT_CALL(*mockSyncProtocol, persistDifference(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
@@ -645,7 +645,7 @@ TEST_F(ScaTest, SyncModule_UsesDeltaAfterFirstSyncCompleted)
     insertRow(dbSync, "sca_metadata", {{"key", "first_sync_completed"}, {"value", 123456}});
 
     EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
-    .WillOnce(testing::Return(true));
+    .WillOnce(testing::Return(SyncModuleResult{true}));
     EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::FULL, Option::SYNC))
     .Times(0);
     EXPECT_CALL(*mockSyncProtocol, clearInMemoryData())

--- a/src/wazuh_modules/sca/src/sca.cpp
+++ b/src/wazuh_modules/sca/src/sca.cpp
@@ -451,6 +451,8 @@ std::string SCA::query(const std::string& jsonQuery)
 bool sca_sync_module(Mode_t mode)
 {
     Mode syncMode = (mode == MODE_FULL) ? Mode::FULL : Mode::DELTA;
+    // The C++ syncModule() already logs a WARNING with the failure reason before returning.
+    // The C caller only needs the bool to track sync state (e.g. first_sync_completed).
     return SCA::instance().syncModule(syncMode);
 }
 

--- a/src/wazuh_modules/src/wm_syscollector.c
+++ b/src/wazuh_modules/src/wm_syscollector.c
@@ -1068,15 +1068,15 @@ void* wm_sync_module(__attribute__((unused)) void* args)
         if (syscollector_sync_module_ptr)
         {
             // Do not hold scan mutex while waiting for sync ACKs.
-            bool sync_result = syscollector_sync_module_ptr(MODE_DELTA);
+            bool sync_succeeded = syscollector_sync_module_ptr(MODE_DELTA);
 
-            if (sync_result && !first_sync_completed)
+            if (sync_succeeded && !first_sync_completed)
             {
                 first_sync_completed = true;
             }
 
             // Recovery touches shared state; keep this section serialized.
-            if (sync_result && sync_module_running && syscollector_run_recovery_process_ptr)
+            if (sync_succeeded && sync_module_running && syscollector_run_recovery_process_ptr)
             {
                 if (syscollector_lock_scan_mutex_ptr && syscollector_unlock_scan_mutex_ptr)
                 {

--- a/src/wazuh_modules/syscollector/include/syscollector.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector.hpp
@@ -24,6 +24,7 @@
 #include "syscollectorNormalizer.hpp"
 #include "syscollector.h"
 #include "asyncFlushController.hpp"
+#include "agent_sync_protocol_types.hpp"
 #include "iagent_sync_protocol.hpp"
 
 // Define EXPORTED for any platform
@@ -93,7 +94,7 @@ class EXPORTED Syscollector final
         void initSyncProtocol(const std::string& moduleName, const std::string& syncDbPath, const std::string& syncDbPathVD, MQ_Functions mqFuncs, std::chrono::seconds syncEndDelay,
                               std::chrono::seconds timeout, unsigned int retries,
                               size_t maxEps, uint32_t integrityInterval);
-        bool syncModule(Mode mode);
+        SyncModuleResult syncModule(Mode mode);
         void persistDifference(const std::string& id, Operation operation, const std::string& index, const std::string& data, uint64_t version, bool isDataContext = false);
         bool parseResponseBuffer(const uint8_t* data, size_t length);
         bool parseResponseBufferVD(const uint8_t* data, size_t length);

--- a/src/wazuh_modules/syscollector/src/syscollector.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollector.cpp
@@ -170,7 +170,9 @@ void syscollector_init_sync(const char* moduleName, const char* syncDbPath, cons
 bool syscollector_sync_module(Mode_t mode)
 {
     Mode syncMode = (mode == MODE_FULL) ? Mode::FULL : Mode::DELTA;
-    return Syscollector::instance().syncModule(syncMode);
+    // Syscollector::syncModule() already logs a WARNING with the failure reason before returning.
+    // The C caller only needs the bool to track sync state (e.g. first_sync_completed).
+    return Syscollector::instance().syncModule(syncMode).success;
 }
 
 void syscollector_persist_diff(const char* id, Operation_t operation, const char* index, const char* data, uint64_t version)

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -2247,7 +2247,7 @@ void Syscollector::initSyncProtocol(const std::string& moduleName, const std::st
 }
 
 // LCOV_EXCL_START
-bool Syscollector::syncModule(Mode mode)
+SyncModuleResult Syscollector::syncModule(Mode mode)
 {
     if (m_paused || m_stopping.load())
     {
@@ -2256,7 +2256,7 @@ bool Syscollector::syncModule(Mode mode)
             m_logFunction(LOG_DEBUG, "Syscollector module is paused or stopping, skipping synchronization");
         }
 
-        return false;
+        return {false, {}};
     }
 
     m_logFunction(LOG_INFO, "Starting inventory synchronization.");
@@ -2264,14 +2264,15 @@ bool Syscollector::syncModule(Mode mode)
     // RAII guard ensures m_syncing is set to false even if function exits early
     ScanGuard syncGuard(m_syncing, m_pauseCv);
 
-    bool success = true;
+    bool overallSuccess = true;
+    std::string failureReason;
 
     // Sync regular (non-VD) data
     if (m_spSyncProtocol)
     {
-        success = m_spSyncProtocol->synchronizeModule(mode, Option::SYNC);
+        SyncModuleResult result = m_spSyncProtocol->synchronizeModule(mode, Option::SYNC);
 
-        if (success)
+        if (result.success)
         {
             int64_t firstSyncCompleted = 0;
 
@@ -2280,13 +2281,20 @@ bool Syscollector::syncModule(Mode mode)
                 updateMetadataValue(SYSCOLLECTOR_FIRST_SYNC_COMPLETED_METADATA_KEY, Utils::getSecondsFromEpoch());
             }
         }
+        else
+        {
+            overallSuccess = false;
+            failureReason = result.failureReason;
+            m_logFunction(LOG_WARNING, "Syscollector synchronization failed" +
+                          (result.failureReason.empty() ? "." : ": " + result.failureReason));
+        }
     }
 
     // Check if stopping before proceeding with VD sync
     if (m_stopping.load())
     {
         m_logFunction(LOG_DEBUG, "Stop received during synchronization, skipping VD sync");
-        return false;
+        return {false, {}};
     }
 
     // Sync VD data with appropriate option based on first scan status
@@ -2307,23 +2315,30 @@ bool Syscollector::syncModule(Mode mode)
             vdOption = firstSyncDone ? Option::VDSYNC : Option::VDFIRST;
         }
 
-        bool vdSuccess = m_spSyncProtocolVD->synchronizeModule(mode, vdOption);
+        SyncModuleResult vdResult = m_spSyncProtocolVD->synchronizeModule(mode, vdOption);
 
-        persistVDFirstSyncIfNeeded(vdSuccess, firstSyncDone);
+        persistVDFirstSyncIfNeeded(vdResult.success, firstSyncDone);
 
-        success = vdSuccess && success;
+        if (!vdResult.success)
+        {
+            overallSuccess = false;
+
+            if (failureReason.empty())
+            {
+                failureReason = vdResult.failureReason;
+            }
+
+            m_logFunction(LOG_WARNING, "Syscollector VD synchronization failed" +
+                          (vdResult.failureReason.empty() ? "." : ": " + vdResult.failureReason));
+        }
     }
 
-    if (success)
+    if (overallSuccess)
     {
         m_logFunction(LOG_INFO, "Syscollector synchronization process finished successfully.");
     }
-    else
-    {
-        m_logFunction(LOG_INFO, "Syscollector synchronization process failed.");
-    }
 
-    return success;
+    return {overallSuccess, failureReason};
 }
 // LCOV_EXCL_STOP
 
@@ -2829,8 +2844,8 @@ int Syscollector::executeFlushSync()
     }
 
     // Trigger immediate synchronization to flush pending messages.
-    bool result = true;
-    bool vdResult = true;
+    SyncModuleResult result = {true, {}};
+    SyncModuleResult vdResult = {true, {}};
 
     if (m_spSyncProtocol)
     {
@@ -2853,10 +2868,10 @@ int Syscollector::executeFlushSync()
 
         vdResult = m_spSyncProtocolVD->synchronizeModule(Mode::DELTA, vdOption);
 
-        persistVDFirstSyncIfNeeded(vdResult, firstSyncDone);
+        persistVDFirstSyncIfNeeded(vdResult.success, firstSyncDone);
     }
 
-    const bool overallSuccess = result && vdResult;
+    const bool overallSuccess = result.success && vdResult.success;
 
     if (overallSuccess)
     {
@@ -2881,14 +2896,22 @@ int Syscollector::executeFlushSync()
         {
             std::string failedQueues;
 
-            if (!result && !vdResult)
+            if (!result.success && !vdResult.success)
                 failedQueues = "both syscollector and VD queues";
-            else if (!result)
+            else if (!result.success)
                 failedQueues = "syscollector queue";
             else
                 failedQueues = "VD queue";
 
-            m_logFunction(LOG_WARNING, "Syscollector flush failed: " + failedQueues);
+            std::string reason;
+
+            if (!result.success && !result.failureReason.empty())
+                reason = result.failureReason;
+
+            if (!vdResult.success && !vdResult.failureReason.empty())
+                reason += (reason.empty() ? "" : "; VD: ") + vdResult.failureReason;
+
+            m_logFunction(LOG_WARNING, "Syscollector flush failed: " + failedQueues + (reason.empty() ? "" : ": " + reason));
         }
     }
 
@@ -4582,9 +4605,9 @@ void Syscollector::runRecoveryProcess()
 
                 m_logFunction(LOG_DEBUG, "Persisted " + std::to_string(items.size()) + " recovery items in memory");
                 m_logFunction(LOG_DEBUG, "Starting recovery synchronization...");
-                bool success = syncModule(Mode::FULL);
+                bool recoverySucceeded = syncModule(Mode::FULL).success;
 
-                if (success)
+                if (recoverySucceeded)
                 {
                     m_logFunction(LOG_DEBUG, "Recovery completed successfully");
                 }


### PR DESCRIPTION
## Description

Closes https://github.com/wazuh/wazuh/issues/37159

The sync protocol reports any sinc-related errors only on `DEBUG` mode. If this mode isn't set up, the user only sees the FIM, Syscollector, SCA and agent info modules report the sync failure, with no explanation regarding what caused it:
```
wazuh-modulesd:agent-info: INFO: Starting Synchronization ....
wazuh-modulesd:agent-info: WARNING: Failed to synchronize agent_metadata
```

This PR extends the return type of the sync protocol's sync functions so that they now return a `std::string` containing the failure reason. 
```
struct SyncModuleResult
{
    bool success;
    std::string failureReason;
};
```
This string is then consumed by each of the modules to produce a more descriptive error for the sync failure. For example in SCA:
```
    SyncModuleResult result = m_spSyncProtocol->synchronizeModule(mode);

    if (result.success)
    {
        LoggingHelper::getInstance().log(LOG_INFO, "SCA synchronization finished successfully.");
    }
    else
    {
        LoggingHelper::getInstance().log(LOG_WARNING, "SCA synchronization failed" + (result.failureReason.empty() ? "." : ": " + result.failureReason));
    }

```

## Proposed Changes

* Extend the sync protocol's function's return type so that they expose the failure reason.
* Adapt all four modules that consume the sync protocl (FIM, SCA, Syscollector, AgentInfo) so that they now consume this failure reason and report them on sync failures.
* Extend sync protocol and each module's tests so that they perform assertions on the `failureReason` string.

### Results and Evidence

Tested by modifying the manager's code to produce the desired error codes. Changing `agentSession.hpp` ~line 217
  `sendStartAck(STATUS_CODE);  // was Status_Ok`

For agent info i forced the integrity_interval to be 1m. So that we can trigger these errors:

`agent_info->integrity_interval = 60; // Integrity check every 24 hours (86400 seconds)`

## `Protocol error`
```
# Syscollector
`2026/06/30 15:44:58 wazuh-modulesd:syscollector: WARNING: Syscollector synchronization failed: Manager sent an unexpected or invalid response.`
`2026/06/30 15:44:58 wazuh-modulesd:syscollector: WARNING: Syscollector VD synchronization failed: Manager sent an unexpected or invalid response.`

# FIM
`2026/06/30 15:39:41 wazuh-syscheckd: WARNING: FIM synchronization failed: Manager sent an unexpected or invalid response.`

# SCA
2026/07/01 11:35:04 wazuh-modulesd:sca: WARNING: SCA synchronization failed: Manager sent an unexpected or invalid response.

# Agent info
2026/07/01 14:29:19 wazuh-modulesd:agent-info: INFO: Starting integrity check for agent_metadata
2026/07/01 14:29:19 wazuh-modulesd:agent-info: WARNING: Failed integrity check for agent_metadata: Manager sent an unexpected or invalid response.
2026/07/01 14:29:19 wazuh-modulesd:agent-info: INFO: Starting integrity check for agent_groups
2026/07/01 14:29:19 wazuh-modulesd:agent-info: WARNING: Failed integrity check for agent_groups: Manager sent an unexpected or invalid response.

```

## `Timeout waiting for Start Ack error`
```
# Syscollector
2026/07/07 18:41:27 wazuh-modulesd:syscollector: WARNING: Syscollector synchronization failed: Timed out waiting for manager response to Start message.

# FIM
2026/07/07 18:41:28 wazuh-syscheckd: WARNING: FIM synchronization failed: Timed out waiting for manager response to Start message.

# SCA
2026/07/07 18:41:28 wazuh-modulesd:sca: WARNING: SCA synchronization failed: Timed out waiting for manager response to Start message.

# Agent info
2026/07/07 18:40:30 wazuh-modulesd:agent-info: WARNING: Failed integrity check for agent_metadata: Timed out waiting for manager response to Start message.
2026/07/07 18:42:30 wazuh-modulesd:agent-info: WARNING: Failed integrity check for agent_groups: Timed out waiting for manager response to Start message.

```

## `Timeout waiting for End Ack error`
```
# Syscollector
2026/07/07 19:41:34 wazuh-modulesd:syscollector: WARNING: Syscollector synchronization failed: Timed out waiting for manager response to End message.

# FIM
2026/07/07 19:41:36 wazuh-syscheckd: WARNING: FIM synchronization failed: Timed out waiting for manager response to End message.

# SCA
2026/07/07 19:41:35 wazuh-modulesd:sca: WARNING: SCA synchronization failed: Timed out waiting for manager response to End message.

# Agent info

2026/07/07 19:40:37 wazuh-modulesd:agent-info: WARNING: Failed integrity check for agent_metadata: Timed out waiting for manager response to End message.
2026/07/07 19:42:38 wazuh-modulesd:agent-info: WARNING: Failed integrity check for agent_groups: Timed out waiting for manager response to End message.

```

## `No groups error`
```
# Syscollector
wazuh-modulesd:syscollector: WARNING: Syscollector synchronization failed: No groups available in metadata. Waiting for the server to synchronize the groups. Cannot proceed with synchronizatization
wazuh-modulesd:syscollector: WARNING: Syscollector VD synchronization failed: No groups available in metadata. Waiting for the server to synchronize the groups. Cannot proceed with synchronization

# FIM
wazuh-syscheckd: WARNING: FIM synchronization failed: No groups available in metadata. Waiting for the server to synchronize the groups. Cannot proceed with synchronization.

# SCA
wazuh-modulesd:sca: WARNING: SCA synchronization failed: No groups available in metadata. Waiting for the server to synchronize the groups. Cannot proceed with synchronization.

# Agent info
2026/07/01 12:27:52 wazuh-modulesd:agent-info: INFO: Starting integrity check for agent_metadata
2026/07/01 12:27:52 wazuh-modulesd:agent-info: WARNING: Failed integrity check for agent_metadata: No groups available in metadata. Waiting for the server to synchronize the groups. Cannot proceed with synchronization.
2026/07/01 12:27:52 wazuh-modulesd:agent-info: INFO: Starting integrity check for agent_groups
2026/07/01 12:27:52 wazuh-modulesd:agent-info: WARNING: Failed integrity check for agent_groups: No groups available in metadata. Waiting for the server to synchronize the groups. Cannot proceed with synchronization.

```

## `Communication error`
```
# Syscollector
2026/07/01 10:13:43 wazuh-modulesd:syscollector: WARNING: Syscollector synchronization failed: Failed to communicate with the manager.
2026/07/01 10:13:43 wazuh-modulesd:syscollector: WARNING: Syscollector VD synchronization failed: Failed to communicate with the manager.

# FIM
2026/07/01 10:13:44 wazuh-syscheckd: WARNING: FIM synchronization failed: Failed to communicate with the manager.

# SCA
2026/07/01 11:30:04 wazuh-modulesd:sca: WARNING: SCA synchronization failed: Failed to communicate with the manager.

# Agent info
2026/07/01 14:34:24 wazuh-modulesd:agent-info: INFO: Starting integrity check for agent_metadata
2026/07/01 14:34:24 wazuh-modulesd:agent-info: WARNING: Failed integrity check for agent_metadata: Failed to communicate with the manager.
2026/07/01 14:34:24 wazuh-modulesd:agent-info: INFO: Starting integrity check for agent_groups
2026/07/01 14:34:24 wazuh-modulesd:agent-info: WARNING: Failed integrity check for agent_groups: Failed to communicate with the manager.

```

## Sync module still reports DEBUG messages. With debug=1 we see more detail about the sync failure in some scenarios
```
## `No groups error` scenario

wazuh-modulesd:syscollector[88220] logging_helper.c:31 at taggedLogFunction(): INFO: Starting inventory synchronization.
wazuh-modulesd:syscollector[88220] logging_helper.c:37 at taggedLogFunction(): DEBUG: No groups available in metadata. Waiting for the server to synchronize the groups. Cannot proceed with synchronization.
wazuh-modulesd:syscollector[88220] logging_helper.c:34 at taggedLogFunction(): WARNING: Syscollector synchronization failed: No groups available in metadata. Waiting for the server to synchronize the groups. Cannot proceed with synchronization.
wazuh-modulesd:syscollector[88220] logging_helper.c:37 at taggedLogFunction(): DEBUG: syscollector_vd: No groups available in metadata. Waiting for the server to synchronize the groups. Cannot proceed with synchronization.
wazuh-modulesd:syscollector[88220] logging_helper.c:37 at taggedLogFunction(): DEBUG: VD sync was not successful, metadata marker not persisted.
wazuh-modulesd:syscollector[88220] logging_helper.c:34 at taggedLogFunction(): WARNING: Syscollector VD synchronization failed: No groups available in metadata. Waiting for the server to synchronize the groups. Cannot proceed with synchronization.

# `Protocol error` scenario

wazuh-syscheckd[95652] run_check.c:1001 at fim_run_integrity(): INFO: Starting FIM synchronization.
wazuh-syscheckd[95652] logging_helper.c:62 at loggingFunction(): DEBUG: Metadata available. Proceed with synchronization.
wazuh-syscheckd[95652] logging_helper.c:62 at loggingFunction(): DEBUG: Received StartAck with error status. Aborting synchronization.
wazuh-syscheckd[95652] logging_helper.c:62 at loggingFunction(): DEBUG: Synchronization failed due to manager error.
wazuh-syscheckd[95652] run_check.c:1014 at fim_run_integrity(): WARNING: FIM synchronization failed: Manager sent an unexpected or invalid response.
wazuh-syscheckd[95652] run_check.c:1061 at fim_run_integrity(): DEBUG: FIM synchronization finished, waiting for 60 seconds before next run.

wazuh-modulesd:sca[95681] wm_sca.c:299 at sca_log_callback(): INFO: Starting SCA synchronization.
wazuh-modulesd:sca[95681] wm_sca.c:293 at sca_log_callback(): DEBUG: SCA first synchronization is pending. Sending a full snapshot after scan completion.
wazuh-modulesd:sca[95681] wm_sca.c:293 at sca_log_callback(): DEBUG: initial synchronization full synchronization
wazuh-modulesd:sca[95681] wm_sca.c:293 at sca_log_callback(): DEBUG: Retrieved 279 synced checks from database for SCA initial synchronization
wazuh-modulesd:sca[95681] wm_sca.c:293 at sca_log_callback(): DEBUG: Triggering full synchronization for SCA initial synchronization
wazuh-modulesd:sca[95681] wm_sca.c:293 at sca_log_callback(): DEBUG: Metadata available. Proceed with synchronization.
wazuh-modulesd:sca[95681] wm_sca.c:293 at sca_log_callback(): DEBUG: Received StartAck with error status. Aborting synchronization.
wazuh-modulesd:sca[95681] wm_sca.c:293 at sca_log_callback(): DEBUG: Synchronization failed due to manager error.
wazuh-modulesd:sca[95681] wm_sca.c:293 at sca_log_callback(): DEBUG: SCA initial synchronization failed
wazuh-modulesd:sca[95681] wm_sca.c:302 at sca_log_callback(): WARNING: SCA synchronization failed: Manager sent an unexpected or invalid response.
wazuh-modulesd:sca[95681] wm_sca.c:293 at sca_log_callback(): DEBUG: Received query: {"command":"resume"}
wazuh-modulesd:sca[95681] wm_sca.c:293 at sca_log_callback(): DEBUG: Executing command: resume
wazuh-modulesd:sca[95681] wm_sca.c:293 at sca_log_callback(): DEBUG: SCA scanning resumed after coordination
wazuh-modulesd:sca[95681] wm_sca.c:942 at wm_sca_sync_module(): DEBUG: SCA synchronization cycle finished, waiting for 60 seconds before next run.
wazuh-modulesd:sca[95681] wm_sca.c:293 at sca_log_callback(): DEBUG: Received query: {"command":"pause"}
wazuh-modulesd:sca[95681] wm_sca.c:293 at sca_log_callback(): DEBUG: Executing command: pause
wazuh-modulesd:sca[95681] wm_sca.c:293 at sca_log_callback(): DEBUG: SCA module pause requested
wazuh-modulesd:sca[95681] wm_sca.c:293 at sca_log_callback(): DEBUG: SCA module paused successfully
```


### Manual tests with their corresponding evidence
N/A

### Artifacts Affected

N/A

### Configuration Changes
 
N/A

### Tests Introduced

Added some assertions to existing tests
## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->


