### PR TITLE
Add cluster name validation

### DIFF
--- a/src/remoted/src/secure.c
+++ b/src/remoted/src/secure.c
@@ -1115,7 +1115,7 @@ bool router_message_forward(char* msg, size_t msg_length, const char* agent_id) 
         size_t msg_size = msg_length - payload_offset;
 
         // Send the raw flatbuffer to inventory sync with anti-spoofing validation
-        if (router_provider_send_sync(router_sync_handle, msg_to_send, msg_size, agent_id) != 0) {
+        if (router_provider_send_sync(router_sync_handle, msg_to_send, msg_size, agent_id, cluster_name) != 0) {
             mdebug2("Unable to forward message for agent '%s'.", agent_id);
             return false;
         }

--- a/src/shared_modules/router/CMakeLists.txt
+++ b/src/shared_modules/router/CMakeLists.txt
@@ -29,12 +29,14 @@ include_directories(${SRC_FOLDER}/external/nlohmann)
 include_directories(${SRC_FOLDER}/external/cJSON)
 include_directories(${SRC_FOLDER}/external/flatbuffers/include)
 include_directories(${SRC_FOLDER}/external/simdjson/include)
+include_directories(${SRC_FOLDER}/external/fmt/include)
 include_directories(${SHARED_MODULES}/utils)
 include_directories(${SHARED_MODULES}/utils/flatbuffers/include)
 
 # Link directories
 link_directories(${SRC_FOLDER}/external/flatbuffers/build/)
 link_directories(${SRC_FOLDER}/external/simdjson/build/)
+link_directories(${SRC_FOLDER}/external/fmt/build/)
 link_directories(${SRC_FOLDER})
 link_directories(${SRC_FOLDER}/build/lib)
 
@@ -42,7 +44,7 @@ file(GLOB ROUTER_SRC "src/*.cpp")
 
 add_library(router SHARED ${ROUTER_SRC})
 
-target_link_libraries(router PRIVATE gcc_s flatbuffers wazuhext simdjson)
+target_link_libraries(router PRIVATE gcc_s flatbuffers wazuhext simdjson fmt)
 
 set_target_properties(router PROPERTIES BUILD_RPATH_USE_ORIGIN TRUE
                                         BUILD_RPATH "$ORIGIN/../lib")

--- a/src/shared_modules/router/include/router.h
+++ b/src/shared_modules/router/include/router.h
@@ -121,21 +121,23 @@ extern "C"
     /**
      * @brief Send inventory sync message with anti-spoofing validation.
      *
-     * Validates that the agent ID in the flatbuffer message matches the authenticated agent ID.
-     * If validation passes, forwards the message to inventory sync. If validation fails, logs
-     * a security event and returns an error.
+     * Validates that the agent ID and cluster name in the flatbuffer message match the
+     * authenticated values from the manager. If validation passes, forwards the message
+     * to inventory sync. If validation fails, logs a security event and returns an error.
      *
      * @param handle Handle to the router provider.
      * @param message Inventory sync flatbuffer message to send.
      * @param message_size Size of the flatbuffer message.
      * @param authenticated_agent_id Agent ID from the authenticated session (from keystore).
+     * @param manager_cluster_name Manager's authoritative cluster name.
      * @return 0 if the message was validated and sent successfully.
      * @return -1 if validation failed or the message was not sent successfully.
      */
     EXPORTED int router_provider_send_sync(ROUTER_PROVIDER_HANDLE handle,
                                            const char* message,
                                            unsigned int message_size,
-                                           const char* authenticated_agent_id);
+                                           const char* authenticated_agent_id,
+                                           const char* manager_cluster_name);
 
     /**
      * @brief Destroy a router provider.
@@ -221,7 +223,8 @@ typedef bool (*router_provider_send_func)(ROUTER_PROVIDER_HANDLE handle,
 typedef int (*router_provider_send_sync_func)(ROUTER_PROVIDER_HANDLE handle,
                                               const char* message,
                                               unsigned int message_size,
-                                              const char* authenticated_agent_id);
+                                              const char* authenticated_agent_id,
+                                              const char* manager_cluster_name);
 
 typedef void (*router_provider_destroy_func)(ROUTER_PROVIDER_HANDLE handle);
 

--- a/src/shared_modules/router/src/router.cpp
+++ b/src/shared_modules/router/src/router.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cstring>
+#include <fmt/format.h>
 #include <functional>
 #include <iostream>
 #include <string>
@@ -346,9 +347,11 @@ extern "C"
 
                 if (!isNumeric(authenticated_agent_id) || !isNumeric(claimedAgentId))
                 {
-                    logMessage(modules_log_level_t::LOG_ERROR,
-                               std::string("Agent ID validation failed: non-numeric ID. Authenticated: '") +
-                                   authenticated_agent_id + "', Claimed: '" + std::string(claimedAgentId) + "'");
+                    logMessage(
+                        modules_log_level_t::LOG_ERROR,
+                        fmt::format("Agent ID validation failed: non-numeric ID. Authenticated: '{}', Claimed: '{}'",
+                                    authenticated_agent_id,
+                                    claimedAgentId));
                     return -1;
                 }
 
@@ -359,14 +362,15 @@ extern "C"
                 if (authIdInt != claimIdInt)
                 {
                     logMessage(modules_log_level_t::LOG_WARNING,
-                               std::string("Agent ID spoofing detected! Authenticated agent '") +
-                                   authenticated_agent_id + "' claimed to be '" + std::string(claimedAgentId) +
-                                   "'. Connection rejected.");
+                               fmt::format("Agent ID spoofing detected! Authenticated agent '{}' claimed to be '{}'. "
+                                           "Connection rejected.",
+                                           authenticated_agent_id,
+                                           claimedAgentId));
                     return -1;
                 }
 
                 logMessage(modules_log_level_t::LOG_DEBUG,
-                           std::string("Agent ID validation passed for agent '") + authenticated_agent_id + "'");
+                           fmt::format("Agent ID validation passed for agent '{}'", authenticated_agent_id));
 
                 // Start message MUST have a cluster name
                 if (!startMsg->cluster_name() || startMsg->cluster_name()->size() == 0)
@@ -383,16 +387,18 @@ extern "C"
                     strncmp(claimedClusterName.data(), manager_cluster_name, managerClusterNameLen) != 0)
                 {
                     logMessage(modules_log_level_t::LOG_WARNING,
-                               std::string("Cluster name spoofing detected! Agent '") + authenticated_agent_id +
-                                   "' claimed cluster name '" + std::string(claimedClusterName) +
-                                   "' but manager cluster name is '" + manager_cluster_name +
-                                   "'. Connection rejected.");
+                               fmt::format("Cluster name spoofing detected! Agent '{}' claimed cluster name '{}' but "
+                                           "manager cluster name is '{}'. Connection rejected.",
+                                           authenticated_agent_id,
+                                           claimedClusterName,
+                                           manager_cluster_name));
                     return -1;
                 }
 
                 logMessage(modules_log_level_t::LOG_DEBUG,
-                           std::string("Cluster name validation passed for agent '") + authenticated_agent_id +
-                               "' in cluster '" + manager_cluster_name + "'");
+                           fmt::format("Cluster name validation passed for agent '{}' in cluster '{}'",
+                                       authenticated_agent_id,
+                                       manager_cluster_name));
             }
 
             // Validation passed, send the message

--- a/src/shared_modules/router/src/router.cpp
+++ b/src/shared_modules/router/src/router.cpp
@@ -14,6 +14,7 @@
 #include "logging_helper.h"
 #include <algorithm>
 #include <cctype>
+#include <cstring>
 #include <functional>
 #include <iostream>
 #include <string>
@@ -335,36 +336,37 @@ extern "C"
                     return -1;
                 }
 
-                std::string claimedAgentId(startMsg->agentid()->str());
+                auto claimedAgentId = startMsg->agentid()->string_view();
 
                 // Validate that both IDs contain only digits
-                auto isNumeric = [](const std::string& str)
+                auto isNumeric = [](std::string_view str)
                 {
                     return !str.empty() && std::all_of(str.begin(), str.end(), ::isdigit);
                 };
 
-                std::string authId(authenticated_agent_id);
-                if (!isNumeric(authId) || !isNumeric(claimedAgentId))
+                if (!isNumeric(authenticated_agent_id) || !isNumeric(claimedAgentId))
                 {
                     logMessage(modules_log_level_t::LOG_ERROR,
-                               "Agent ID validation failed: non-numeric ID. Authenticated: '" + authId +
-                                   "', Claimed: '" + claimedAgentId + "'");
+                               std::string("Agent ID validation failed: non-numeric ID. Authenticated: '") +
+                                   authenticated_agent_id + "', Claimed: '" + std::string(claimedAgentId) + "'");
                     return -1;
                 }
 
                 // Compare agent IDs as integers to handle leading zeros
                 int authIdInt = std::atoi(authenticated_agent_id);
-                int claimIdInt = std::atoi(claimedAgentId.c_str());
+                int claimIdInt = std::atoi(claimedAgentId.data());
 
                 if (authIdInt != claimIdInt)
                 {
-                    logMessage(modules_log_level_t::LOG_ERROR,
-                               "Agent ID spoofing detected! Authenticated agent '" + authId + "' claimed to be '" +
-                                   claimedAgentId + "'. Connection rejected.");
+                    logMessage(modules_log_level_t::LOG_WARNING,
+                               std::string("Agent ID spoofing detected! Authenticated agent '") +
+                                   authenticated_agent_id + "' claimed to be '" + std::string(claimedAgentId) +
+                                   "'. Connection rejected.");
                     return -1;
                 }
 
-                logMessage(modules_log_level_t::LOG_DEBUG, "Agent ID validation passed for agent '" + authId + "'");
+                logMessage(modules_log_level_t::LOG_DEBUG,
+                           std::string("Agent ID validation passed for agent '") + authenticated_agent_id + "'");
 
                 // Start message MUST have a cluster name
                 if (!startMsg->cluster_name() || startMsg->cluster_name()->size() == 0)
@@ -374,21 +376,23 @@ extern "C"
                     return -1;
                 }
 
-                std::string claimedClusterName(startMsg->cluster_name()->str());
-                std::string managerClusterName(manager_cluster_name);
+                auto claimedClusterName = startMsg->cluster_name()->string_view();
+                size_t managerClusterNameLen = strlen(manager_cluster_name);
 
-                if (claimedClusterName != managerClusterName)
+                if (claimedClusterName.size() != managerClusterNameLen ||
+                    strncmp(claimedClusterName.data(), manager_cluster_name, managerClusterNameLen) != 0)
                 {
-                    logMessage(modules_log_level_t::LOG_ERROR,
-                               "Cluster name spoofing detected! Agent '" + authId + "' claimed cluster name '" +
-                                   claimedClusterName + "' but manager cluster name is '" + managerClusterName +
+                    logMessage(modules_log_level_t::LOG_WARNING,
+                               std::string("Cluster name spoofing detected! Agent '") + authenticated_agent_id +
+                                   "' claimed cluster name '" + std::string(claimedClusterName) +
+                                   "' but manager cluster name is '" + manager_cluster_name +
                                    "'. Connection rejected.");
                     return -1;
                 }
 
                 logMessage(modules_log_level_t::LOG_DEBUG,
-                           "Cluster name validation passed for agent '" + authId + "' in cluster '" +
-                               managerClusterName + "'");
+                           std::string("Cluster name validation passed for agent '") + authenticated_agent_id +
+                               "' in cluster '" + manager_cluster_name + "'");
             }
 
             // Validation passed, send the message

--- a/src/shared_modules/router/src/router.cpp
+++ b/src/shared_modules/router/src/router.cpp
@@ -288,7 +288,8 @@ extern "C"
     int router_provider_send_sync(ROUTER_PROVIDER_HANDLE handle,
                                   const char* message,
                                   unsigned int message_size,
-                                  const char* authenticated_agent_id)
+                                  const char* authenticated_agent_id,
+                                  const char* manager_cluster_name)
     {
         try
         {
@@ -300,6 +301,11 @@ extern "C"
             if (!authenticated_agent_id || strlen(authenticated_agent_id) == 0)
             {
                 throw std::runtime_error("Authenticated agent ID is empty");
+            }
+
+            if (!manager_cluster_name || strlen(manager_cluster_name) == 0)
+            {
+                throw std::runtime_error("Manager cluster name is empty");
             }
 
             // Verify flatbuffer structure
@@ -359,6 +365,30 @@ extern "C"
                 }
 
                 logMessage(modules_log_level_t::LOG_DEBUG, "Agent ID validation passed for agent '" + authId + "'");
+
+                // Start message MUST have a cluster name
+                if (!startMsg->cluster_name() || startMsg->cluster_name()->size() == 0)
+                {
+                    logMessage(modules_log_level_t::LOG_ERROR,
+                               "Cluster name validation failed: Start message missing cluster name");
+                    return -1;
+                }
+
+                std::string claimedClusterName(startMsg->cluster_name()->str());
+                std::string managerClusterName(manager_cluster_name);
+
+                if (claimedClusterName != managerClusterName)
+                {
+                    logMessage(modules_log_level_t::LOG_ERROR,
+                               "Cluster name spoofing detected! Agent '" + authId + "' claimed cluster name '" +
+                                   claimedClusterName + "' but manager cluster name is '" + managerClusterName +
+                                   "'. Connection rejected.");
+                    return -1;
+                }
+
+                logMessage(modules_log_level_t::LOG_DEBUG,
+                           "Cluster name validation passed for agent '" + authId + "' in cluster '" +
+                               managerClusterName + "'");
             }
 
             // Validation passed, send the message

--- a/src/shared_modules/router/tests/unit/routerApi_test.cpp
+++ b/src/shared_modules/router/tests/unit/routerApi_test.cpp
@@ -652,11 +652,12 @@ TEST_F(RouterAPITest, TestMultipleStartCalls)
 // }
 
 // Helper to create a Start message for testing
-static std::vector<uint8_t> createStartMessage(const std::string& agentId)
+static std::vector<uint8_t> createStartMessage(const std::string& agentId, const std::string& clusterName = "")
 {
     flatbuffers::FlatBufferBuilder builder;
     auto agentIdOffset = builder.CreateString(agentId);
     auto moduleOffset = builder.CreateString("test-module");
+    auto clusterNameOffset = clusterName.empty() ? 0 : builder.CreateString(clusterName);
 
     auto startMsg = Wazuh::SyncSchema::CreateStart(builder,
                                                    moduleOffset,                       // module
@@ -672,7 +673,10 @@ static std::vector<uint8_t> createStartMessage(const std::string& agentId)
                                                    0,                                  // osversion
                                                    0,                                  // agentversion
                                                    0,                                  // agentname
-                                                   agentIdOffset);                     // agentid
+                                                   agentIdOffset,                      // agentid
+                                                   0,                                  // groups
+                                                   0,                                  // global_version
+                                                   clusterNameOffset);                 // cluster_name
 
     auto msg = Wazuh::SyncSchema::CreateMessage(builder, Wazuh::SyncSchema::MessageType_Start, startMsg.Union());
 
@@ -689,11 +693,13 @@ TEST_F(RouterAPITest, TestProviderSendSyncValidMatch)
     ROUTER_PROVIDER_HANDLE handle = router_provider_create(providerName, true);
     EXPECT_NE(nullptr, handle);
 
-    // Create Start message with agent ID "001"
-    auto message = createStartMessage("001");
+    // Create Start message with agent ID "001" and cluster name "wazuh"
+    auto message = createStartMessage("001", "wazuh");
 
     // Should succeed: authenticated agent "1" matches claimed "001" (integer comparison)
-    EXPECT_EQ(0, router_provider_send_sync(handle, reinterpret_cast<const char*>(message.data()), message.size(), "1"));
+    EXPECT_EQ(
+        0,
+        router_provider_send_sync(handle, reinterpret_cast<const char*>(message.data()), message.size(), "1", "wazuh"));
 
     router_provider_destroy(handle);
     router_stop();
@@ -707,12 +713,13 @@ TEST_F(RouterAPITest, TestProviderSendSyncSpoofingDetected)
     ROUTER_PROVIDER_HANDLE handle = router_provider_create(providerName, true);
     EXPECT_NE(nullptr, handle);
 
-    // Create Start message with agent ID "123"
-    auto message = createStartMessage("123");
+    // Create Start message with agent ID "123" and cluster name "wazuh"
+    auto message = createStartMessage("123", "wazuh");
 
     // Should fail: authenticated agent "456" doesn't match claimed "123"
     EXPECT_EQ(-1,
-              router_provider_send_sync(handle, reinterpret_cast<const char*>(message.data()), message.size(), "456"));
+              router_provider_send_sync(
+                  handle, reinterpret_cast<const char*>(message.data()), message.size(), "456", "wazuh"));
 
     router_provider_destroy(handle);
     router_stop();
@@ -726,12 +733,13 @@ TEST_F(RouterAPITest, TestProviderSendSyncEmptyAgentId)
     ROUTER_PROVIDER_HANDLE handle = router_provider_create(providerName, true);
     EXPECT_NE(nullptr, handle);
 
-    // Create Start message with empty agent ID
-    auto message = createStartMessage("");
+    // Create Start message with empty agent ID and cluster name "wazuh"
+    auto message = createStartMessage("", "wazuh");
 
     // Should fail: Start message must have agent ID
     EXPECT_EQ(-1,
-              router_provider_send_sync(handle, reinterpret_cast<const char*>(message.data()), message.size(), "123"));
+              router_provider_send_sync(
+                  handle, reinterpret_cast<const char*>(message.data()), message.size(), "123", "wazuh"));
 
     router_provider_destroy(handle);
     router_stop();
@@ -745,12 +753,13 @@ TEST_F(RouterAPITest, TestProviderSendSyncNonNumericAgentId)
     ROUTER_PROVIDER_HANDLE handle = router_provider_create(providerName, true);
     EXPECT_NE(nullptr, handle);
 
-    // Create Start message with non-numeric agent ID
-    auto message = createStartMessage("abc");
+    // Create Start message with non-numeric agent ID and cluster name "wazuh"
+    auto message = createStartMessage("abc", "wazuh");
 
     // Should fail: agent IDs must be numeric
     EXPECT_EQ(-1,
-              router_provider_send_sync(handle, reinterpret_cast<const char*>(message.data()), message.size(), "123"));
+              router_provider_send_sync(
+                  handle, reinterpret_cast<const char*>(message.data()), message.size(), "123", "wazuh"));
 
     router_provider_destroy(handle);
     router_stop();
@@ -764,12 +773,13 @@ TEST_F(RouterAPITest, TestProviderSendSyncNullAuthAgentId)
     ROUTER_PROVIDER_HANDLE handle = router_provider_create(providerName, true);
     EXPECT_NE(nullptr, handle);
 
-    // Create Start message with agent ID "123"
-    auto message = createStartMessage("123");
+    // Create Start message with agent ID "123" and cluster name "wazuh"
+    auto message = createStartMessage("123", "wazuh");
 
     // Should fail: authenticated agent ID is NULL
-    EXPECT_EQ(
-        -1, router_provider_send_sync(handle, reinterpret_cast<const char*>(message.data()), message.size(), nullptr));
+    EXPECT_EQ(-1,
+              router_provider_send_sync(
+                  handle, reinterpret_cast<const char*>(message.data()), message.size(), nullptr, "wazuh"));
 
     router_provider_destroy(handle);
     router_stop();
@@ -783,12 +793,73 @@ TEST_F(RouterAPITest, TestProviderSendSyncLeadingZeros)
     ROUTER_PROVIDER_HANDLE handle = router_provider_create(providerName, true);
     EXPECT_NE(nullptr, handle);
 
-    // Create Start message with agent ID "0042"
-    auto message = createStartMessage("0042");
+    // Create Start message with agent ID "0042" and cluster name "wazuh"
+    auto message = createStartMessage("0042", "wazuh");
 
     // Should succeed: "42" matches "0042" (integer comparison)
     EXPECT_EQ(0,
-              router_provider_send_sync(handle, reinterpret_cast<const char*>(message.data()), message.size(), "42"));
+              router_provider_send_sync(
+                  handle, reinterpret_cast<const char*>(message.data()), message.size(), "42", "wazuh"));
+
+    router_provider_destroy(handle);
+    router_stop();
+}
+
+TEST_F(RouterAPITest, TestProviderSendSyncClusterNameMatch)
+{
+    router_initialize(NULL);
+
+    const char* providerName = "inventory-sync";
+    ROUTER_PROVIDER_HANDLE handle = router_provider_create(providerName, true);
+    EXPECT_NE(nullptr, handle);
+
+    // Create Start message with agent ID "001" and cluster name "wazuh"
+    auto message = createStartMessage("001", "wazuh");
+
+    // Should succeed: cluster name matches
+    EXPECT_EQ(
+        0,
+        router_provider_send_sync(handle, reinterpret_cast<const char*>(message.data()), message.size(), "1", "wazuh"));
+
+    router_provider_destroy(handle);
+    router_stop();
+}
+
+TEST_F(RouterAPITest, TestProviderSendSyncClusterNameSpoofing)
+{
+    router_initialize(NULL);
+
+    const char* providerName = "inventory-sync";
+    ROUTER_PROVIDER_HANDLE handle = router_provider_create(providerName, true);
+    EXPECT_NE(nullptr, handle);
+
+    // Create Start message with agent ID "001" and fake cluster name
+    auto message = createStartMessage("001", "FAKE-CLUSTER");
+
+    // Should fail: cluster name doesn't match
+    EXPECT_EQ(
+        -1,
+        router_provider_send_sync(handle, reinterpret_cast<const char*>(message.data()), message.size(), "1", "wazuh"));
+
+    router_provider_destroy(handle);
+    router_stop();
+}
+
+TEST_F(RouterAPITest, TestProviderSendSyncEmptyClusterName)
+{
+    router_initialize(NULL);
+
+    const char* providerName = "inventory-sync";
+    ROUTER_PROVIDER_HANDLE handle = router_provider_create(providerName, true);
+    EXPECT_NE(nullptr, handle);
+
+    // Create Start message with agent ID "001" and no cluster name
+    auto message = createStartMessage("001", "");
+
+    // Should fail: Start message must have cluster name
+    EXPECT_EQ(
+        -1,
+        router_provider_send_sync(handle, reinterpret_cast<const char*>(message.data()), message.size(), "1", "wazuh"));
 
     router_provider_destroy(handle);
     router_stop();

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -2963,6 +2963,7 @@ void test_HandleSecureMessage_inventory_sync_preserves_trailing_null(void** stat
     expect_value(__wrap_router_provider_send_sync, message_size,
                  g_expected_flatbuf_len);
     expect_string(__wrap_router_provider_send_sync, authenticated_agent_id, "001");
+    expect_any(__wrap_router_provider_send_sync, manager_cluster_name);
     will_return(__wrap_router_provider_send_sync, 0);
     expect_string(__wrap_rem_inc_recv_states, agent_id, "001");
 

--- a/src/unit_tests/wrappers/wazuh/shared_modules/router_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared_modules/router_wrappers.c
@@ -29,10 +29,12 @@ int __wrap_router_provider_send(__attribute__((unused)) ROUTER_PROVIDER_HANDLE h
 int __wrap_router_provider_send_sync(__attribute__((unused)) ROUTER_PROVIDER_HANDLE handle,
                                      const char* message,
                                      unsigned int message_size,
-                                     const char* authenticated_agent_id) {
+                                     const char* authenticated_agent_id,
+                                     const char* manager_cluster_name) {
     check_expected_ptr(message);
     check_expected(message_size);
     check_expected(authenticated_agent_id);
+    check_expected(manager_cluster_name);
     return mock();
 }
 

--- a/src/unit_tests/wrappers/wazuh/shared_modules/router_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared_modules/router_wrappers.h
@@ -21,7 +21,8 @@ int __wrap_router_provider_send(ROUTER_PROVIDER_HANDLE handle, const char* messa
 int __wrap_router_provider_send_sync(ROUTER_PROVIDER_HANDLE handle,
                                      const char* message,
                                      unsigned int message_size,
-                                     const char* authenticated_agent_id);
+                                     const char* authenticated_agent_id,
+                                     const char* manager_cluster_name);
 
 ROUTER_PROVIDER_HANDLE __wrap_router_provider_create(const char* name);
 

--- a/src/wazuh_modules/inventory_sync/qa/flatbuffers_manager.py
+++ b/src/wazuh_modules/inventory_sync/qa/flatbuffers_manager.py
@@ -115,6 +115,8 @@ class FlatBuffersManager:
                 agentid_str = builder.CreateString(data.get('agentid', '001'))
                 agentname_str = builder.CreateString(data.get('agentname', 'test-agent'))
                 agentversion_str = builder.CreateString(data.get('agentversion', '4.8.0'))
+                cluster_name_str = builder.CreateString(data.get('cluster_name', ''))
+                cluster_node_str = builder.CreateString(data.get('cluster_node', ''))
 
                 StartModule.StartStart(builder)
                 StartModule.StartAddModule(builder, module_str)
@@ -123,6 +125,8 @@ class FlatBuffersManager:
                 StartModule.StartAddAgentid(builder, agentid_str)
                 StartModule.StartAddAgentname(builder, agentname_str)
                 StartModule.StartAddAgentversion(builder, agentversion_str)
+                StartModule.StartAddClusterName(builder, cluster_name_str)
+                StartModule.StartAddClusterNode(builder, cluster_node_str)
                 start = StartModule.StartEnd(builder)
                 content = start
 

--- a/src/wazuh_modules/inventory_sync/qa/test_data/basic_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/basic_flow.json
@@ -9,7 +9,8 @@
         "size": 1,
         "agentid": "001",
         "agentname": "test-agent",
-        "agentversion": "4.8.0"
+        "agentversion": "4.8.0",
+        "cluster_name": "wazuh"
       },
       "description": "Start synchronization session",
       "delay": 0.5,
@@ -22,7 +23,10 @@
         "operation": 0,
         "id": "doc123",
         "index": "wazuh-states-inventory-system",
-        "data": {"message": "Hello", "timestamp": "2025-08-20T10:00:00Z"}
+        "data": {
+          "message": "Hello",
+          "timestamp": "2025-08-20T10:00:00Z"
+        }
       },
       "description": "Send data message using session from start response",
       "delay": 0.5,

--- a/src/wazuh_modules/inventory_sync/qa/test_data/data_clean_multiple_indices_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/data_clean_multiple_indices_flow.json
@@ -9,7 +9,8 @@
         "size": 3,
         "agentid": "001",
         "agentname": "test-agent",
-        "agentversion": "4.8.0"
+        "agentversion": "4.8.0",
+        "cluster_name": "wazuh"
       },
       "description": "Start synchronization session for DataClean with 3 indices",
       "delay": 0.5,

--- a/src/wazuh_modules/inventory_sync/qa/test_data/data_clean_single_index_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/data_clean_single_index_flow.json
@@ -9,7 +9,8 @@
         "size": 1,
         "agentid": "001",
         "agentname": "test-agent",
-        "agentversion": "4.8.0"
+        "agentversion": "4.8.0",
+        "cluster_name": "wazuh"
       },
       "description": "Start synchronization session for DataClean",
       "delay": 0.5,

--- a/src/wazuh_modules/inventory_sync/qa/test_data/data_context_multiple_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/data_context_multiple_flow.json
@@ -9,7 +9,8 @@
         "size": 3,
         "agentid": "001",
         "agentname": "test-agent",
-        "agentversion": "4.8.0"
+        "agentversion": "4.8.0",
+        "cluster_name": "wazuh"
       },
       "description": "Start synchronization session for DataContext with 3 messages",
       "delay": 0.5,
@@ -21,7 +22,10 @@
         "seq": 0,
         "id": "context-id-0",
         "index": "wazuh-states-vulnerabilities",
-        "data": {"cve": "CVE-2024-1234", "severity": "high"}
+        "data": {
+          "cve": "CVE-2024-1234",
+          "severity": "high"
+        }
       },
       "description": "Send first DataContext message",
       "delay": 0.3,
@@ -33,7 +37,10 @@
         "seq": 1,
         "id": "context-id-1",
         "index": "wazuh-states-vulnerabilities",
-        "data": {"cve": "CVE-2024-5678", "severity": "medium"}
+        "data": {
+          "cve": "CVE-2024-5678",
+          "severity": "medium"
+        }
       },
       "description": "Send second DataContext message",
       "delay": 0.3,
@@ -45,7 +52,10 @@
         "seq": 2,
         "id": "context-id-2",
         "index": "wazuh-states-vulnerabilities",
-        "data": {"cve": "CVE-2024-9012", "severity": "critical"}
+        "data": {
+          "cve": "CVE-2024-9012",
+          "severity": "critical"
+        }
       },
       "description": "Send third DataContext message",
       "delay": 0.3,

--- a/src/wazuh_modules/inventory_sync/qa/test_data/data_context_single_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/data_context_single_flow.json
@@ -9,7 +9,8 @@
         "size": 1,
         "agentid": "001",
         "agentname": "test-agent",
-        "agentversion": "4.8.0"
+        "agentversion": "4.8.0",
+        "cluster_name": "wazuh"
       },
       "description": "Start synchronization session for DataContext",
       "delay": 0.5,
@@ -21,7 +22,10 @@
         "seq": 0,
         "id": "context-id-123",
         "index": "wazuh-states-vulnerabilities",
-        "data": {"cve": "CVE-2024-1234", "severity": "high"}
+        "data": {
+          "cve": "CVE-2024-1234",
+          "severity": "high"
+        }
       },
       "description": "Send DataContext message for vulnerability context",
       "delay": 0.5,

--- a/src/wazuh_modules/inventory_sync/qa/test_data/data_value_quota_exhausted_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/data_value_quota_exhausted_flow.json
@@ -9,7 +9,8 @@
         "size": 500001,
         "agentid": "001",
         "agentname": "quota-test-agent",
-        "agentversion": "5.0.0"
+        "agentversion": "5.0.0",
+        "cluster_name": "wazuh"
       },
       "description": "Start request declaring size=500001, one above the default DataValue quota - manager must refuse with Status_Offline",
       "delay": 0.5,

--- a/src/wazuh_modules/inventory_sync/qa/test_data/forbidden_index_in_checksum_module_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/forbidden_index_in_checksum_module_flow.json
@@ -16,7 +16,8 @@
         "osname": "Linux",
         "osplatform": "linux",
         "ostype": "linux",
-        "osversion": "5.0"
+        "osversion": "5.0",
+        "cluster_name": "wazuh"
       },
       "description": "Start a ModuleCheck (mode=2) session - no indices field so res.context->indices stays empty",
       "delay": 0.5,

--- a/src/wazuh_modules/inventory_sync/qa/test_data/forbidden_index_in_dataclean_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/forbidden_index_in_dataclean_flow.json
@@ -9,7 +9,8 @@
         "size": 2,
         "agentid": "001",
         "agentname": "dataclean-filter-agent",
-        "agentversion": "5.0.0"
+        "agentversion": "5.0.0",
+        "cluster_name": "wazuh"
       },
       "description": "Start a ModuleDelta session declaring 2 sequenced messages (one DataClean + one DataValue)",
       "delay": 0.5,
@@ -32,7 +33,9 @@
         "operation": 0,
         "id": "doc-valid",
         "index": "wazuh-states-inventory-system",
-        "data": {"value": 1}
+        "data": {
+          "value": 1
+        }
       },
       "description": "Legitimate DataValue with a wazuh-states-* index - must be indexed normally",
       "delay": 0.3,

--- a/src/wazuh_modules/inventory_sync/qa/test_data/forbidden_index_in_datavalue_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/forbidden_index_in_datavalue_flow.json
@@ -9,7 +9,8 @@
         "size": 1,
         "agentid": "001",
         "agentname": "forbidden-index-agent",
-        "agentversion": "5.0.0"
+        "agentversion": "5.0.0",
+        "cluster_name": "wazuh"
       },
       "description": "Start a ModuleFull session declaring 1 DataValue",
       "delay": 0.5,
@@ -22,7 +23,9 @@
         "operation": 0,
         "id": "doc-forbidden",
         "index": "forbidden-index",
-        "data": {"x": 42}
+        "data": {
+          "x": 42
+        }
       },
       "description": "DataValue with a non wazuh-states-* index - must be skipped by the bulk loop",
       "delay": 0.3,

--- a/src/wazuh_modules/inventory_sync/qa/test_data/groups_delta_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/groups_delta_flow.json
@@ -8,7 +8,11 @@
         "mode": 5,
         "size": 0,
         "option": 0,
-        "indices": ["wazuh-states-fim-files", "wazuh-states-sca", "wazuh-states-inventory-packages"],
+        "indices": [
+          "wazuh-states-fim-files",
+          "wazuh-states-sca",
+          "wazuh-states-inventory-packages"
+        ],
         "agentid": "001",
         "agentname": "groups-test-agent",
         "agentversion": "4.9.0",
@@ -18,8 +22,13 @@
         "osplatform": "debian",
         "ostype": "linux",
         "osversion": "11",
-        "groups": ["webservers", "production", "eu-west"],
-        "global_version": 54321
+        "groups": [
+          "webservers",
+          "production",
+          "eu-west"
+        ],
+        "global_version": 54321,
+        "cluster_name": "wazuh"
       },
       "description": "Start GroupDelta synchronization - updates agent groups across all indices",
       "delay": 0.5,
@@ -37,10 +46,18 @@
   "verification": {
     "check_opensearch": true,
     "expected_updates": {
-      "indices": ["wazuh-states-fim-files", "wazuh-states-sca", "wazuh-states-inventory-packages"],
+      "indices": [
+        "wazuh-states-fim-files",
+        "wazuh-states-sca",
+        "wazuh-states-inventory-packages"
+      ],
       "agent_id": "001",
       "fields": {
-        "wazuh.agent.groups": ["webservers", "production", "eu-west"],
+        "wazuh.agent.groups": [
+          "webservers",
+          "production",
+          "eu-west"
+        ],
         "state.document_version": 54321
       }
     }

--- a/src/wazuh_modules/inventory_sync/qa/test_data/metadata_delta_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/metadata_delta_flow.json
@@ -8,7 +8,11 @@
         "mode": 3,
         "size": 0,
         "option": 0,
-        "indices": ["wazuh-states-fim-files", "wazuh-states-sca", "wazuh-states-inventory-system"],
+        "indices": [
+          "wazuh-states-fim-files",
+          "wazuh-states-sca",
+          "wazuh-states-inventory-system"
+        ],
         "agentid": "001",
         "agentname": "metadata-test-agent",
         "agentversion": "4.9.0",
@@ -18,8 +22,12 @@
         "osplatform": "ubuntu",
         "ostype": "linux",
         "osversion": "22.04",
-        "groups": ["default", "production"],
-        "global_version": 12345
+        "groups": [
+          "default",
+          "production"
+        ],
+        "global_version": 12345,
+        "cluster_name": "wazuh"
       },
       "description": "Start MetadataDelta synchronization - updates agent metadata across all indices",
       "delay": 0.5,
@@ -37,7 +45,11 @@
   "verification": {
     "check_opensearch": true,
     "expected_updates": {
-      "indices": ["wazuh-states-fim-files", "wazuh-states-sca", "wazuh-states-inventory-system"],
+      "indices": [
+        "wazuh-states-fim-files",
+        "wazuh-states-sca",
+        "wazuh-states-inventory-system"
+      ],
       "agent_id": "001",
       "fields": {
         "wazuh.agent.name": "metadata-test-agent",

--- a/src/wazuh_modules/inventory_sync/qa/test_data/module_check_match_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/module_check_match_flow.json
@@ -8,7 +8,9 @@
         "mode": 6,
         "size": 0,
         "option": 0,
-        "indices": ["wazuh-states-vulnerabilities"],
+        "indices": [
+          "wazuh-states-vulnerabilities"
+        ],
         "agentid": "001",
         "agentname": "module-check-agent",
         "agentversion": "4.9.0",
@@ -17,7 +19,8 @@
         "osname": "Ubuntu",
         "osplatform": "ubuntu",
         "ostype": "linux",
-        "osversion": "22.04"
+        "osversion": "22.04",
+        "cluster_name": "wazuh"
       },
       "description": "Start ModuleCheck synchronization - verifies checksum matches",
       "delay": 0.5,

--- a/src/wazuh_modules/inventory_sync/qa/test_data/module_check_mismatch_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/module_check_mismatch_flow.json
@@ -8,7 +8,9 @@
         "mode": 6,
         "size": 0,
         "option": 0,
-        "indices": ["wazuh-states-vulnerabilities"],
+        "indices": [
+          "wazuh-states-vulnerabilities"
+        ],
         "agentid": "001",
         "agentname": "module-check-mismatch-agent",
         "agentversion": "4.9.0",
@@ -17,7 +19,8 @@
         "osname": "Ubuntu",
         "osplatform": "ubuntu",
         "ostype": "linux",
-        "osversion": "22.04"
+        "osversion": "22.04",
+        "cluster_name": "wazuh"
       },
       "description": "Start ModuleCheck synchronization - verifies checksum mismatch",
       "delay": 0.5,

--- a/src/wazuh_modules/inventory_sync/qa/test_data/nodata_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/nodata_flow.json
@@ -1,19 +1,20 @@
 {
-    "description": "Basic inventory sync flow test: start",
-    "messages": [
-      {
-        "type": "start",
-        "data": {
-          "module": "inventory_sync",
-          "mode": 0,
-          "size": 0,
-          "agentid": "001",
-          "agentname": "test-agent",
-          "agentversion": "4.8.0"
-        },
-        "description": "Start synchronization session",
-        "delay": 0.5,
-        "expect_session_response": true
-      }
-    ]
-  }
+  "description": "Basic inventory sync flow test: start",
+  "messages": [
+    {
+      "type": "start",
+      "data": {
+        "module": "inventory_sync",
+        "mode": 0,
+        "size": 0,
+        "agentid": "001",
+        "agentname": "test-agent",
+        "agentversion": "4.8.0",
+        "cluster_name": "wazuh"
+      },
+      "description": "Start synchronization session",
+      "delay": 0.5,
+      "expect_session_response": true
+    }
+  ]
+}

--- a/src/wazuh_modules/inventory_sync/qa/test_data/out_of_range_seq_rejection_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/out_of_range_seq_rejection_flow.json
@@ -9,7 +9,8 @@
         "size": 2,
         "agentid": "001",
         "agentname": "out-of-range-agent",
-        "agentversion": "5.0.0"
+        "agentversion": "5.0.0",
+        "cluster_name": "wazuh"
       },
       "description": "Start a ModuleDelta session declaring exactly 2 DataValues (valid seqs are 0 and 1)",
       "delay": 0.5,
@@ -23,7 +24,9 @@
         "operation": 0,
         "id": "doc-valid-0",
         "index": "wazuh-states-inventory-system",
-        "data": {"description": "first valid datavalue"}
+        "data": {
+          "description": "first valid datavalue"
+        }
       },
       "description": "Legitimate DataValue with seq=0 (in range)",
       "delay": 0.3,
@@ -36,7 +39,9 @@
         "operation": 0,
         "id": "doc-out-of-range",
         "index": "wazuh-states-inventory-system",
-        "data": {"description": "should be rejected"}
+        "data": {
+          "description": "should be rejected"
+        }
       },
       "description": "DataValue with seq=5 (declaredSize is 2) - GapSet::observe throws and the message is dropped; the GapSet must NOT be flipped to allObserved",
       "delay": 0.3,
@@ -56,7 +61,9 @@
         "operation": 0,
         "id": "doc-valid-1",
         "index": "wazuh-states-inventory-system",
-        "data": {"description": "second valid datavalue retransmitted"}
+        "data": {
+          "description": "second valid datavalue retransmitted"
+        }
       },
       "description": "Retransmit the still-missing seq=1",
       "delay": 0.3,

--- a/src/wazuh_modules/inventory_sync/qa/test_data/reqret_end_flow.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/reqret_end_flow.json
@@ -9,7 +9,8 @@
         "size": 5,
         "agentid": "001",
         "agentname": "test-agent",
-        "agentversion": "4.8.0"
+        "agentversion": "4.8.0",
+        "cluster_name": "wazuh"
       },
       "description": "Start synchronization session expecting 5 messages (seq 0-4)",
       "delay": 0.5,
@@ -23,7 +24,10 @@
         "operation": 0,
         "id": "doc001",
         "index": "wazuh-states-inventory-system",
-        "data": {"message": "First message", "timestamp": "2025-01-20T10:00:00Z"}
+        "data": {
+          "message": "First message",
+          "timestamp": "2025-01-20T10:00:00Z"
+        }
       },
       "description": "Send first data message (seq=0)",
       "delay": 0.3,
@@ -36,7 +40,10 @@
         "operation": 0,
         "id": "doc003",
         "index": "wazuh-states-inventory-system",
-        "data": {"message": "Third message", "timestamp": "2025-01-20T10:02:00Z"}
+        "data": {
+          "message": "Third message",
+          "timestamp": "2025-01-20T10:02:00Z"
+        }
       },
       "description": "Send third data message (seq=2) - skip seq=1 to create gap",
       "delay": 0.3,
@@ -49,7 +56,10 @@
         "operation": 0,
         "id": "doc005",
         "index": "wazuh-states-inventory-system",
-        "data": {"message": "Fifth message", "timestamp": "2025-01-20T10:04:00Z"}
+        "data": {
+          "message": "Fifth message",
+          "timestamp": "2025-01-20T10:04:00Z"
+        }
       },
       "description": "Send fifth data message (seq=4) - skip seq=3 to create another gap",
       "delay": 0.3,
@@ -69,7 +79,10 @@
         "operation": 0,
         "id": "doc002",
         "index": "wazuh-states-inventory-system",
-        "data": {"message": "Second message (after reqret)", "timestamp": "2025-01-20T10:01:00Z"}
+        "data": {
+          "message": "Second message (after reqret)",
+          "timestamp": "2025-01-20T10:01:00Z"
+        }
       },
       "description": "Retransmit missing seq=1 after receiving ReqRet",
       "delay": 0.3,
@@ -82,7 +95,10 @@
         "operation": 0,
         "id": "doc004",
         "index": "wazuh-states-inventory-system",
-        "data": {"message": "Fourth message (after reqret)", "timestamp": "2025-01-20T10:03:00Z"}
+        "data": {
+          "message": "Fourth message (after reqret)",
+          "timestamp": "2025-01-20T10:03:00Z"
+        }
       },
       "description": "Retransmit missing seq=3 after receiving ReqRet",
       "delay": 0.3,

--- a/src/wazuh_modules/inventory_sync/qa/test_data/simple_reqret_test.json
+++ b/src/wazuh_modules/inventory_sync/qa/test_data/simple_reqret_test.json
@@ -9,7 +9,8 @@
         "size": 3,
         "agentid": "001",
         "agentname": "test-agent",
-        "agentversion": "4.8.0"
+        "agentversion": "4.8.0",
+        "cluster_name": "wazuh"
       },
       "description": "Start session expecting 3 messages (seq 0, 1, 2)",
       "delay": 0.5,
@@ -23,7 +24,10 @@
         "operation": 0,
         "id": "doc001",
         "index": "wazuh-states-inventory-system",
-        "data": {"message": "Message 0", "seq": 0}
+        "data": {
+          "message": "Message 0",
+          "seq": 0
+        }
       },
       "description": "Send message seq=0",
       "delay": 0.2,
@@ -36,7 +40,10 @@
         "operation": 0,
         "id": "doc003",
         "index": "wazuh-states-inventory-system",
-        "data": {"message": "Message 2", "seq": 2}
+        "data": {
+          "message": "Message 2",
+          "seq": 2
+        }
       },
       "description": "Send message seq=2 (skip seq=1 intentionally)",
       "delay": 0.2,
@@ -56,7 +63,10 @@
         "operation": 0,
         "id": "doc002",
         "index": "wazuh-states-inventory-system",
-        "data": {"message": "Message 1 (retransmitted)", "seq": 1}
+        "data": {
+          "message": "Message 1 (retransmitted)",
+          "seq": 1
+        }
       },
       "description": "Send missing seq=1 after receiving ReqRet",
       "delay": 0.2,


### PR DESCRIPTION
## Description

This pull request adds a new validation in the Wazuh manager to ensure that documents sent by the agent have the expected cluster name.

## Proposed Changes

- Add `cluster_name` validation in router layer.

### Results and Evidence

```
2026/06/26 20:44:21 :router: ERROR: Cluster name spoofing detected! Agent '001' claimed cluster name 'SPOOFED-CLUSTER-NAME' but manager cluster name is 'wazuh'. Connection rejected.
2026/06/26 20:44:22 :router: ERROR: Cluster name spoofing detected! Agent '001' claimed cluster name 'SPOOFED-CLUSTER-NAME' but manager cluster name is 'wazuh'. Connection rejected.
2026/06/26 20:44:25 :router: ERROR: Cluster name spoofing detected! Agent '001' claimed cluster name 'SPOOFED-CLUSTER-NAME' but manager cluster name is 'wazuh'. Connection rejected.
```

### Artifacts Affected

Manager

### Configuration Changes

N/A

### Tests Introduced

- TestProviderSendSyncClusterNameMatch
- TestProviderSendSyncClusterNameSpoofing
- TestProviderSendSyncEmptyClusterName

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues