### PR TITLE
Add Null Check for Inode and Dev Fields in FIM Whodata Event Handler

### DIFF
--- a/src/syscheckd/src/create_db.c
+++ b/src/syscheckd/src/create_db.c
@@ -994,12 +994,14 @@ void fim_whodata_event(whodata_evt * w_evt) {
         fim_process_missing_entry(w_evt->path, FIM_WHODATA, w_evt);
         w_rwlock_unlock(&syscheck.directories_lock);
 #ifndef WIN32
-        const unsigned long int inode = strtoul(w_evt->inode, NULL, 10);
-        const unsigned long int dev = strtoul(w_evt->dev, NULL, 10);
-        callback_context_t callback_data;
-        callback_data.callback = create_windows_who_data_events;
-        callback_data.context = w_evt;
-        fim_db_file_inode_search(inode, dev, callback_data);
+        if (w_evt->inode && w_evt->dev) {
+            const unsigned long int inode = strtoul(w_evt->inode, NULL, 10);
+            const unsigned long int dev = strtoul(w_evt->dev, NULL, 10);
+            callback_context_t callback_data;
+            callback_data.callback = create_windows_who_data_events;
+            callback_data.context = w_evt;
+            fim_db_file_inode_search(inode, dev, callback_data);
+        }
 #endif
     }
 }

--- a/src/unit_tests/syscheckd/test_create_db.c
+++ b/src/unit_tests/syscheckd/test_create_db.c
@@ -3402,6 +3402,47 @@ static void test_fim_whodata_event_file_missing(void **state) {
     errno = 0;
 }
 
+static void test_fim_whodata_event_file_missing_null_inode(void **state) {
+    fim_data_t *fim_data = *state;
+    struct stat buf = { .st_mode = 0 };
+
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+#ifndef TEST_WINAGENT
+    expect_string(__wrap_lstat, filename, fim_data->w_evt->path);
+    will_return(__wrap_lstat, &buf);
+    will_return(__wrap_lstat, -1);
+
+    // Save original values to restore after test
+    char *saved_inode = fim_data->w_evt->inode;
+    char *saved_dev = fim_data->w_evt->dev;
+
+    // Set inode and dev to NULL to test the null check
+    fim_data->w_evt->inode = NULL;
+    fim_data->w_evt->dev = NULL;
+
+    // Should not call fim_db_file_inode_search when inode/dev are NULL
+#else
+    expect_string(__wrap_utf8_stat64, pathname, fim_data->w_evt->path);
+    will_return(__wrap_utf8_stat64, &buf);
+    will_return(__wrap_utf8_stat64, -1);
+#endif
+    errno = ENOENT;
+
+    expect_string(__wrap__mdebug2, formatted_msg, "(6319): No configuration found for (file):'./test/test.file'");
+    fim_whodata_event(fim_data->w_evt);
+
+#ifndef TEST_WINAGENT
+    // Restore original values
+    fim_data->w_evt->inode = saved_inode;
+    fim_data->w_evt->dev = saved_dev;
+#endif
+    errno = 0;
+}
+
 /* fim_process_missing_entry */
 
 static void test_fim_process_missing_entry_null_configuration(void **state) {
@@ -4460,6 +4501,7 @@ int main(void) {
         /* fim_whodata_event */
         cmocka_unit_test(test_fim_whodata_event_file_exists),
         cmocka_unit_test(test_fim_whodata_event_file_missing),
+        cmocka_unit_test(test_fim_whodata_event_file_missing_null_inode),
 
         /* fim_process_missing_entry */
         cmocka_unit_test(test_fim_process_missing_entry_null_configuration),


### PR DESCRIPTION
## Description
The `fim_whodata_event()` function passes `w_evt->inode` and `w_evt->dev` to `strtoul()` without checking if they are NULL. This fix adds a null check to prevent potential issues if future code paths call this function without proper guards.

## Proposed Changes

- **src/syscheckd/src/create_db.c**: Added null check guard around lines 997-1004 to ensure `w_evt->inode` and `w_evt->dev` are non-NULL before dereferencing them in `strtoul()` calls.

- **src/unit_tests/syscheckd/test_create_db.c**: Added new test `test_fim_whodata_event_file_missing_null_inode` to verify the function handles NULL inode/dev fields gracefully without calling `fim_db_file_inode_search()`.

### Results and Evidence

**Test behavior**:
- **Before fix**: Without the null check, passing NULL values to `strtoul()` would cause undefined behavior (segmentation fault).
- **After fix**: The new test `test_fim_whodata_event_file_missing_null_inode` verifies that when `w_evt->inode` and `w_evt->dev` are NULL, the function skips the inode search and returns safely.
- **Existing tests**: The existing test `test_fim_whodata_event_file_missing` continues to pass, verifying that the normal code path (with valid inode/dev) still works correctly.

The fix matches the defensive pattern already used in `audit_parse.c` where all calls to `fim_whodata_event()` are guarded by `if (w_evt->inode)` checks (lines 770, 794, 829, 885, 903, 941).

### Artifacts Affected

- `wazuh-agent` binary (Linux builds only, as the code is in `#ifndef WIN32` block)

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

- **src/unit_tests/syscheckd/test_create_db.c**: New test `test_fim_whodata_event_file_missing_null_inode` (lines 3405-3436) that verifies the function handles NULL inode/dev fields correctly.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
