### PR TITLE
Defer cluster payload buffer allocation until data is received

### DIFF
--- a/.github/workflows/4_testunit_framework.yml
+++ b/.github/workflows/4_testunit_framework.yml
@@ -19,7 +19,7 @@ on:
       - 'src/Makefile'
 
 jobs:
-  build: 
+  build:
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     strategy:
       fail-fast: false
@@ -45,9 +45,9 @@ jobs:
 
       - name: Run Framework tests
         run: |
-          set -o pipefail 
+          set -o pipefail
           python -m pytest framework -vv --ignore=tests --cov=framework | tee ${TEST_REPORT_PATH}
-      
+
       - name: Generate test report
         if: inputs.generate_report
         run: |

--- a/framework/wazuh/core/cluster/client.py
+++ b/framework/wazuh/core/cluster/client.py
@@ -198,6 +198,7 @@ class AbstractClient(common.Handler):
             'None' means a regular EOF is received, or the connection was aborted or closed
             by this side of the connection.
         """
+        self._cancel_payload_deadline()
         if exc is None:
             self.logger.info('The master closed the connection')
         else:

--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -43,6 +43,11 @@ MAX_TOTAL_SIZE = 268435456  # maximum total size of the message to receive in by
 
 MAX_CHUNK_SIZE = 10485760  # maximum chunk size of the message to receive in bytes (10 MiB)
 
+# Seconds a connection may hold an open header (sent header bytes but not yet
+# the declared payload) before being closed.  Bounds memory hold-time for
+# half-open messages regardless of source IP.
+PRE_AUTH_PAYLOAD_TIMEOUT = 30
+
 MAX_CONCURRENT_DIVIDED_MSGS = 10  # maximum number of concurrent divided messages being received. This is used to mitigate DoS attacks with many divided messages.
 
 class Response:
@@ -91,7 +96,7 @@ class InBuffer:
         """
         if total > MAX_TOTAL_SIZE:
             raise exception.WazuhClusterError(3050, extra_message=str(total))
-        self.payload = bytearray(total)  # array to store the message's data
+        self.payload = bytearray()  # grows incrementally as data is received
         self.total = total  # total of bytes to receive
         self.received = 0  # number of received bytes
         self.cmd = ''  # request's command in header
@@ -124,7 +129,7 @@ class InBuffer:
         self.cmd = cmd[:-1].split(b' ')[0]
         if self.total > MAX_TOTAL_SIZE :
             raise exception.WazuhClusterError(3050, extra_message=f"Header total size out of range: {self.total}")
-        self.payload = bytearray(self.total)
+        self.payload = bytearray()  # grows incrementally; no pre-allocation on peer-controlled size
         return header[header_size:]
 
     def receive_data(self, data: bytes) -> bytes:
@@ -139,8 +144,9 @@ class InBuffer:
         -------
             Extended data buffer.
         """
-        len_data = len(data[:self.total - self.received])
-        self.payload[self.received:len_data + self.received] = data[:self.total - self.received]
+        chunk = data[:self.total - self.received]
+        len_data = len(chunk)
+        self.payload.extend(chunk)
         self.received += len_data
         return data[len_data:]
 
@@ -374,6 +380,30 @@ class Handler(asyncio.Protocol):
         self.loop = None
         # Abstract server object.
         self.server = None
+        # Handle for the per-message payload-completion deadline timer.
+        self._payload_deadline = None
+
+    def _start_payload_deadline(self) -> None:
+        """Arm a timer that closes this connection if the payload never completes."""
+        self._cancel_payload_deadline()
+        try:
+            loop = asyncio.get_running_loop()
+            self._payload_deadline = loop.call_later(PRE_AUTH_PAYLOAD_TIMEOUT, self._close_on_payload_deadline)
+        except RuntimeError:
+            pass  # no running event loop (e.g. unit tests calling msg_parse directly)
+
+    def _cancel_payload_deadline(self) -> None:
+        """Cancel an armed payload-completion deadline, if any."""
+        if self._payload_deadline is not None:
+            self._payload_deadline.cancel()
+            self._payload_deadline = None
+
+    def _close_on_payload_deadline(self) -> None:
+        """Close the transport when a declared payload never arrives within the deadline."""
+        self.logger.warning("Closing connection: incomplete message payload not received within deadline.")
+        if self.transport is not None:
+            self.transport.close()
+        self._payload_deadline = None
 
     def push(self, message: bytes):
         """Send a message to peer.
@@ -475,6 +505,10 @@ class Handler(asyncio.Protocol):
                                                                   header_format=self.header_format,
                                                                   header_size=self.header_len)
                 self.in_buffer = self.in_msg.receive_data(data=self.in_buffer)
+                # If payload bytes are still outstanding, arm the completion deadline so a
+                # peer that stops after the header cannot hold memory indefinitely.
+                if self.in_msg.total > 0 and self.in_msg.received < self.in_msg.total:
+                    self._start_payload_deadline()
                 return True
             elif self.in_msg.received != 0:
                 # The previous message has not been completely received yet. No header to parse, just payload.
@@ -505,6 +539,8 @@ class Handler(asyncio.Protocol):
 
         while parsed:
             if self.in_msg.received == self.in_msg.total:
+                # Full payload received — cancel any outstanding completion deadline.
+                self._cancel_payload_deadline()
                 # Decrypt received message if it is not a part of a divided message
                 try:
                     decrypted_payload = \

--- a/framework/wazuh/core/cluster/server.py
+++ b/framework/wazuh/core/cluster/server.py
@@ -20,6 +20,9 @@ from wazuh.core import common, exception, utils
 from wazuh.core.cluster import common as c_common
 from wazuh.core.cluster.utils import ClusterFilter, context_tag
 
+# Maximum simultaneous cluster TCP connections accepted from a single source IP.
+MAX_CONNECTIONS_PER_IP = 10
+
 
 class AbstractServerHandler(c_common.Handler):
     """
@@ -57,6 +60,8 @@ class AbstractServerHandler(c_common.Handler):
         self.transport = None
         self.handler_tasks = []
         self.broadcast_queue = asyncio.Queue()
+        # Tracks whether this handler was counted in server.connection_counts.
+        self._counted_connection = False
 
     def to_dict(self) -> Dict:
         """Get basic info from AbstractServerHandler instance.
@@ -77,8 +82,15 @@ class AbstractServerHandler(c_common.Handler):
             Socket to write data on.
         """
         peername = transport.get_extra_info('peername')
-        self.logger.info(f'Connection from {peername}')
         self.ip = peername[0]
+        count = self.server.connection_counts.get(self.ip, 0)
+        if count >= MAX_CONNECTIONS_PER_IP:
+            self.logger.warning(f"Too many connections from {self.ip} ({count}), rejecting.")
+            transport.close()
+            return
+        self.server.connection_counts[self.ip] = count + 1
+        self._counted_connection = True
+        self.logger.info(f'Connection from {peername}')
         self.transport = transport
 
     def process_request(self, command: bytes, data: bytes) -> Tuple[bytes, bytes]:
@@ -183,6 +195,13 @@ class AbstractServerHandler(c_common.Handler):
         exc : Exception
             In case the connection was lost due to an exception, it will be contained in this variable.
         """
+        self._cancel_payload_deadline()
+        if self._counted_connection:
+            count = self.server.connection_counts.get(self.ip, 0)
+            if count <= 1:
+                self.server.connection_counts.pop(self.ip, None)
+            else:
+                self.server.connection_counts[self.ip] = count - 1
         if self.name:
             if exc is None:
                 self.logger.debug(f"Disconnected {self.name}.")
@@ -281,6 +300,8 @@ class AbstractServer:
         self.handler_class = AbstractServerHandler
         self.loop = asyncio.get_running_loop()
         self.broadcast_results = {}
+        # Per-source-IP connection counts; bounded by MAX_CONNECTIONS_PER_IP.
+        self.connection_counts = {}
 
     def broadcast(self, f, *args, **kwargs):
         """Add a function to the broadcast_queue of each server handler.

--- a/framework/wazuh/core/cluster/tests/test_common.py
+++ b/framework/wazuh/core/cluster/tests/test_common.py
@@ -13,7 +13,7 @@ import struct
 import sys
 from contextvars import ContextVar
 from datetime import datetime
-from unittest.mock import patch, MagicMock, call, ANY, AsyncMock, mock_open
+from unittest.mock import patch, MagicMock, Mock, call, ANY, AsyncMock, mock_open
 
 import cryptography
 import pytest
@@ -131,7 +131,8 @@ def test_inbuffer_get_info_from_header(unpack_mock):
     # If the flag value is the same as divide_flag, we will forward this value to the flag_divided attribute.
     assert in_buffer.cmd == b"pw"
     assert in_buffer.flag_divided == b"d"
-    assert in_buffer.payload == bytearray(in_buffer.total)
+    # Payload starts empty; memory is committed only as bytes arrive (lazy allocation).
+    assert in_buffer.payload == bytearray()
 
     unpack_mock.return_value = (0, 2048, b'echo')
     in_buffer.get_info_from_header(b"header", "hhl", 1)
@@ -171,6 +172,69 @@ def test_inbuffer_receive_data():
 
     assert isinstance(in_buffer.receive_data(b"data"), bytes)
     assert in_buffer.received == 1028
+
+
+def test_inbuffer_lazy_allocation():
+    """Validate that get_info_from_header does not pre-allocate the full declared payload.
+
+    A peer can declare any size up to MAX_TOTAL_SIZE.  Memory must only be
+    committed as bytes actually arrive, so that a connection that sends only
+    the 20-byte header cannot pin the full declared amount.
+    """
+    buf = cluster_common.InBuffer()
+    # Simulate parsing a header that declares the maximum allowed payload size.
+    with patch('struct.unpack', return_value=(1, cluster_common.MAX_TOTAL_SIZE, b'cmd---------')):
+        buf.get_info_from_header(b'x' * 20, '!2I12s', 20)
+
+    # Payload buffer must be empty immediately after header parsing — no pre-allocation.
+    assert buf.total == cluster_common.MAX_TOTAL_SIZE
+    assert len(buf.payload) == 0
+
+    # After receiving some bytes the payload grows by exactly that amount.
+    remaining = buf.receive_data(b'hello')
+    assert len(buf.payload) == 5
+    assert buf.received == 5
+    assert remaining == b''
+
+
+@pytest.mark.asyncio
+async def test_handler_payload_deadline_fires():
+    """Validate that a connection is closed if declared payload bytes never arrive.
+
+    The deadline must fire after PRE_AUTH_PAYLOAD_TIMEOUT and call
+    transport.close() so memory for the outstanding payload is released.
+    """
+    handler = cluster_common.Handler(fernet_key, cluster_items)
+    transport_mock = Mock()
+    handler.transport = transport_mock
+
+    handler._start_payload_deadline()
+    assert handler._payload_deadline is not None
+
+    # Advance the event loop past the deadline.
+    await asyncio.sleep(cluster_common.PRE_AUTH_PAYLOAD_TIMEOUT + 0.1)
+
+    transport_mock.close.assert_called_once()
+    # Timer handle is consumed once it fires.
+    assert handler._payload_deadline is None
+
+
+@pytest.mark.asyncio
+async def test_handler_payload_deadline_cancelled_on_complete():
+    """Validate that the deadline is cancelled once the full payload arrives."""
+    handler = cluster_common.Handler(fernet_key, cluster_items)
+    transport_mock = Mock()
+    handler.transport = transport_mock
+
+    handler._start_payload_deadline()
+    assert handler._payload_deadline is not None
+
+    handler._cancel_payload_deadline()
+    assert handler._payload_deadline is None
+
+    # Give the loop a turn — transport must not be closed.
+    await asyncio.sleep(0)
+    transport_mock.close.assert_not_called()
 
 
 # Test SendStringTask methods

--- a/framework/wazuh/core/cluster/tests/test_server.py
+++ b/framework/wazuh/core/cluster/tests/test_server.py
@@ -64,20 +64,45 @@ async def test_AbstractServerHandler_to_dict(event_loop):
 def test_AbstractServerHandler_connection_made(event_loop):
     """Check that the connection_made function correctly assigns the IP and the transport."""
 
+    class ServerMock:
+        def __init__(self):
+            self.connection_counts = {}
+
     def get_extra_info(self, name):
         return ["peername", "mock"]
 
     transport = Transport()
     logger = Logger("test_connection_made")
+    server_mock = ServerMock()
     with patch("logging.getLogger", return_value=logger):
         with patch.object(logger, "info") as mock_logger:
-            abstract_server_handler = AbstractServerHandler(server="Test", loop=event_loop, fernet_key=fernet_key,
+            abstract_server_handler = AbstractServerHandler(server=server_mock, loop=event_loop,
+                                                            fernet_key=fernet_key,
                                                             cluster_items={"test": "server"})
             with patch.object(asyncio.Transport, "get_extra_info", get_extra_info):
                 abstract_server_handler.connection_made(transport=transport)
                 assert abstract_server_handler.ip == "peername"
                 assert abstract_server_handler.transport == transport
+                assert abstract_server_handler._counted_connection is True
+                assert server_mock.connection_counts == {"peername": 1}
                 mock_logger.assert_called_once_with("Connection from ['peername', 'mock']")
+
+    # Verify that a second handler from the same IP up to the limit is accepted,
+    # and that a connection that exceeds MAX_CONNECTIONS_PER_IP is rejected.
+    with patch("logging.getLogger", return_value=logger):
+        server_mock2 = ServerMock()
+        server_mock2.connection_counts = {"1.2.3.4": MAX_CONNECTIONS_PER_IP}
+
+        rejected_handler = AbstractServerHandler(server=server_mock2, loop=event_loop,
+                                                 fernet_key=fernet_key,
+                                                 cluster_items={"test": "server"})
+        mock_transport = Mock()
+        mock_transport.get_extra_info = lambda name: ["1.2.3.4", 9999]
+        rejected_handler.connection_made(transport=mock_transport)
+        mock_transport.close.assert_called_once()
+        assert rejected_handler._counted_connection is False
+        # Count must not have been incremented for the rejected connection.
+        assert server_mock2.connection_counts["1.2.3.4"] == MAX_CONNECTIONS_PER_IP
 
 
 @pytest.mark.asyncio
@@ -211,6 +236,28 @@ async def test_AbstractServerHandler_connection_lost(event_loop):
             mock_debug_logger.assert_called_once_with("Disconnected unit.")
             task_mock.cancel.assert_called_once()
 
+    # Verify that connection_counts is decremented when _counted_connection is True.
+    class ServerMockCounts:
+        def __init__(self):
+            self.clients = {}
+            self.configuration = {"node_name": "elif_test"}
+            self.connection_counts = {"1.2.3.4": 3}
+
+    with patch("logging.getLogger", return_value=logger):
+        counted_handler = AbstractServerHandler(server=ServerMockCounts(), loop=event_loop,
+                                                fernet_key=fernet_key,
+                                                cluster_items={"test": "server"})
+        counted_handler.ip = "1.2.3.4"
+        counted_handler._counted_connection = True
+        counted_handler.connection_lost(exc=None)
+        assert counted_handler.server.connection_counts["1.2.3.4"] == 2
+
+        # When count reaches 1, the key is removed entirely.
+        counted_handler.server.connection_counts["1.2.3.4"] = 1
+        counted_handler._counted_connection = True
+        counted_handler.connection_lost(exc=None)
+        assert "1.2.3.4" not in counted_handler.server.connection_counts
+
 
 @pytest.mark.asyncio
 @patch("asyncio.Queue")
@@ -278,6 +325,7 @@ def test_AbstractServer_init(AbstractServerHandler_mock, keepalive_mock):
         assert mock_contextvar.get() == "test"
         assert abstract_server.logger == logger
         assert abstract_server.broadcast_results == {}
+        assert abstract_server.connection_counts == {}
 
 
 @patch("asyncio.get_running_loop", new=Mock())


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

The cluster TCP listener on port 1516 allocated a payload buffer of the full peer-declared size immediately after parsing the 20-byte header, before any Fernet decryption or authentication. With the only guard being an upper cap of 256 MiB, a single unauthenticated connection could pin ~256 MiB of master process memory for as long as the socket stayed open. Three connections were sufficient to consume ~768 MiB, confirmed by RSS measurement. This PR fixes the allocation strategy and adds two complementary limits to bound both per-IP connection count and payload-completion time.

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

- Changed `InBuffer.__init__` and `get_info_from_header` in `framework/wazuh/core/cluster/common.py` to initialize `self.payload` as an empty `bytearray()` instead of `bytearray(total)`, growing it incrementally via `.extend()` as bytes arrive.
- Added `PRE_AUTH_PAYLOAD_TIMEOUT` = 30 constant and `_start_payload_deadline` / `_cancel_payload_deadline` / `_close_on_payload_deadline` methods to Handler in `common.py` to close connections that send a header but never deliver the declared payload within 30 seconds.
- Added `MAX_CONNECTIONS_PER_IP` = 10 constant and `connection_counts` dict to `AbstractServer` in `framework/wazuh/core/cluster/server.py`, enforced in `AbstractServerHandler.connection_made` to reject excess connections from a single source IP before any buffer is allocated.
- Added `_cancel_payload_deadline()` call to `client.py` `connection_lost` to ensure the deadline timer is cleaned up on the client side.

### Manual tests with their corresponding evidence

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
- [ ] Log syntax and correct language review

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

- `framework/wazuh/core/cluster/tests/test_common.py::test_inbuffer_lazy_allocation`: Verifies that `get_info_from_header` does not pre-allocate the full declared payload size, and that the buffer grows exactly as bytes are received.
- `framework/wazuh/core/cluster/tests/test_common.py::test_handler_payload_deadline_fires`: Verifies that `transport.close()` is called when the payload-completion deadline expires without a full payload being received.
- `framework/wazuh/core/cluster/tests/test_common.py::test_handler_payload_deadline_cancelled_on_complete`: Verifies that the deadline is cancelled once the full payload arrives.
- Extended `framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServerHandler_connection_made` to cover per-IP connection count tracking and rejection when the cap is exceeded.
- Extended `framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServerHandler_connection_lost` to cover correct decrement of connection_counts on disconnect.
- Extended `framework/wazuh/core/cluster/tests/test_server.py::test_AbstractServer_init` to verify connection_counts is initialized as an empty dict.

## Credit

Kudos to @moltenbit for reporting this bug.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
