### PR TITLE
Add byte based capacity limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Added Engine content management. ([#2445](https://github.com/wazuh/internal-devel-requests/issues/2445))
 - Added Engine content management tier 2. ([#3166](https://github.com/wazuh/internal-devel-requests/issues/3166))
 - Added manager watermarks. ([#35579](https://github.com/wazuh/wazuh/issues/35579))
+- Added byte-based capacity limits to wazuh-manager-remoted. ([#37052](https://github.com/wazuh/wazuh/issues/37052))
 
 #### Changed
 

--- a/docs/guide/migration/manager-configuration-migration.md
+++ b/docs/guide/migration/manager-configuration-migration.md
@@ -424,6 +424,8 @@ remoted.control_msg_queue_size
 remoted.router_forwarding_disabled
 remoted.batch_events_capacity
 remoted.batch_events_per_agent_capacity
+remoted.queue_max_bytes
+remoted.batch_events_max_bytes
 remoted.enrich_cache_expire_time
 remoted.debug
 wazuh_db.worker_pool_size

--- a/docs/ref/modules/remoted/configuration.md
+++ b/docs/ref/modules/remoted/configuration.md
@@ -51,7 +51,7 @@ remoted.batch_events_capacity=131072
 
 # Queue byte limits (0 = unlimited)
 remoted.queue_max_bytes=67108864
-remoted.batch_events_max_bytes=24117248
+remoted.batch_events_max_bytes=33554432
 ```
 
 ## Stateless Metadata Configuration

--- a/docs/ref/modules/remoted/configuration.md
+++ b/docs/ref/modules/remoted/configuration.md
@@ -48,6 +48,10 @@ remoted.sender_pool=8
 # Queues (important for stateless metadata)
 remoted.control_msg_queue_size=16384
 remoted.batch_events_capacity=131072
+
+# Queue byte limits (0 = unlimited)
+remoted.queue_max_bytes=67108864
+remoted.batch_events_max_bytes=24117248
 ```
 
 ## Stateless Metadata Configuration
@@ -82,6 +86,36 @@ remoted.batch_events_capacity=131072  # Default: 131072
 - Small (<1K agents): control=4096, batch=32768
 - Medium (1K-10K agents): control=16384, batch=131072 (defaults)
 - Large (>10K agents): control=32768, batch=262144
+
+### Queue Byte Limits
+
+Caps total memory used by each queue regardless of event count. Useful when agents send large events that would otherwise cause unbounded memory growth even at normal event rates.
+
+```conf
+# Maximum bytes held in the input queue (messages received from agents)
+# Default: 67108864 (64 MiB). Set to 0 to disable.
+remoted.queue_max_bytes=67108864
+
+# Maximum bytes held in the events queue (events forwarded to the engine)
+# Default: 33554432 (32 MiB). Set to 0 to disable.
+remoted.batch_events_max_bytes=33554432
+```
+
+| Option | Default | Min | Description |
+|--------|---------|-----|-------------|
+| `remoted.queue_max_bytes` | `67108864` | `1024` | Byte cap for the input message queue |
+| `remoted.batch_events_max_bytes` | `33554432` | `1024` | Byte cap for the outbound events queue toward the engine |
+
+**Behavior when the limit is reached**:
+- Events that individually exceed the limit are dropped immediately.
+- Events that would push the total over the limit are dropped until space is freed.
+- Dropped events increment the same discard counter as a full queue (`discarded_count` in the state file).
+- A warning is logged at most once every 5 seconds to avoid log flooding.
+
+**Guidelines**:
+- The byte limit and the event-count limit (`batch_events_capacity`) are independent. An event is dropped if either limit is reached.
+- Values between 1 and 1023 bytes are rejected at startup as they are almost certainly a configuration error.
+- Set to `0` to revert to count-only limiting.
 
 ### Hash Table Tuning
 

--- a/src/engine/source/conf/include/conf/keys.hpp
+++ b/src/engine/source/conf/include/conf/keys.hpp
@@ -52,6 +52,7 @@ constexpr std::string_view REMOTE_CONF_SYNC_INTERVAL = "analysisd.remote_conf_sy
 
 constexpr std::string_view EVENT_QUEUE_SIZE = "analysisd.event_queue_size";
 constexpr std::string_view EVENT_QUEUE_EPS = "analysisd.event_queue_eps";
+constexpr std::string_view EVENT_QUEUE_MAX_BYTES = "analysisd.event_queue_max_bytes";
 
 constexpr std::string_view ORCHESTRATOR_THREADS = "analysisd.orchestrator_threads";
 

--- a/src/engine/source/conf/src/conf.cpp
+++ b/src/engine/source/conf/src/conf.cpp
@@ -87,6 +87,7 @@ Conf::Conf(std::shared_ptr<IFileLoader> fileLoader)
     // Queue event module
     addUnit<size_t>(key::EVENT_QUEUE_SIZE, "WAZUH_EVENT_QUEUE_SIZE", 0x1 << 17);
     addUnit<size_t>(key::EVENT_QUEUE_EPS, "WAZUH_EVENT_QUEUE_EPS", 0);
+    addUnit<size_t>(key::EVENT_QUEUE_MAX_BYTES, "WAZUH_EVENT_QUEUE_MAX_BYTES", 0x1 << 25); // 0 = unlimited
 
     // Orchestrator module
     addUnit<int>(key::ORCHESTRATOR_THREADS, "WAZUH_ORCHESTRATOR_THREADS", 0);

--- a/src/engine/source/fastqueue/include/fastqueue/cqueue.hpp
+++ b/src/engine/source/fastqueue/include/fastqueue/cqueue.hpp
@@ -71,8 +71,9 @@ private:
         const std::size_t prev = m_currentBytes.fetch_sub(sz, std::memory_order_relaxed);
         if (prev < sz)
         {
-            // Underflow: another thread already clamped; restore to 0.
-            m_currentBytes.store(0, std::memory_order_relaxed);
+            // Underflow: compensate without clobbering concurrent increments.
+            // store(0) would destroy any fetch_add that landed between our fetch_sub and here.
+            m_currentBytes.fetch_add(sz - prev, std::memory_order_relaxed);
         }
     }
 
@@ -175,7 +176,7 @@ public:
                     return false; // Single element exceeds the entire byte budget.
                 }
                 const std::size_t prev = m_currentBytes.fetch_add(sz, std::memory_order_relaxed);
-                if (prev + sz > m_maxBytes)
+                if (prev >= m_maxBytes || sz > m_maxBytes - prev)
                 {
                     m_currentBytes.fetch_sub(sz, std::memory_order_relaxed);
                     return false; // Byte quota exceeded.
@@ -210,7 +211,7 @@ public:
                     return false;
                 }
                 const std::size_t prev = m_currentBytes.fetch_add(sz, std::memory_order_relaxed);
-                if (prev + sz > m_maxBytes)
+                if (prev >= m_maxBytes || sz > m_maxBytes - prev)
                 {
                     m_currentBytes.fetch_sub(sz, std::memory_order_relaxed);
                     return false;

--- a/src/engine/source/fastqueue/include/fastqueue/cqueue.hpp
+++ b/src/engine/source/fastqueue/include/fastqueue/cqueue.hpp
@@ -60,6 +60,22 @@ private:
     std::size_t m_minCapacity;                            ///< The minimum capacity of the queue.
     std::unique_ptr<RateLimiter> m_rateLimiter;           ///< Optional rate limiter (nullptr = no limiting)
 
+    // Byte-capacity tracking (disabled when m_maxBytes == 0)
+    std::size_t m_maxBytes {0};
+    std::atomic<std::size_t> m_currentBytes {0};
+    std::function<std::size_t(const T&)> m_sizeOf;
+
+    // Atomically subtract sz from m_currentBytes, clamping to 0 on underflow.
+    inline void releaseBytes(std::size_t sz) noexcept
+    {
+        const std::size_t prev = m_currentBytes.fetch_sub(sz, std::memory_order_relaxed);
+        if (prev < sz)
+        {
+            // Underflow: another thread already clamped; restore to 0.
+            m_currentBytes.store(0, std::memory_order_relaxed);
+        }
+    }
+
 public:
     /**
      * @brief Construct a new Concurrent Queue object
@@ -125,14 +141,94 @@ public:
     }
 
     /**
+     * @copydoc IQueue::setByteLimit
+     */
+    void setByteLimit(std::size_t maxBytes, std::function<std::size_t(const T&)> sizeOf) override
+    {
+        m_maxBytes = maxBytes;
+        m_sizeOf = std::move(sizeOf);
+        m_currentBytes.store(0, std::memory_order_relaxed);
+    }
+
+    /**
+     * @copydoc IQueue::bytesUsed
+     */
+    std::size_t bytesUsed() const noexcept override { return m_currentBytes.load(std::memory_order_relaxed); }
+
+    /**
+     * @copydoc IQueue::maxBytes
+     */
+    std::size_t maxBytes() const noexcept override { return m_maxBytes; }
+
+    /**
      * @copydoc IQueue::push
      */
-    inline bool push(T&& element) override { return m_queue.try_enqueue(std::move(element)); }
+    inline bool push(T&& element) override
+    {
+        if (m_sizeOf)
+        {
+            const std::size_t sz = m_sizeOf(element);
+            if (m_maxBytes > 0)
+            {
+                if (sz > m_maxBytes)
+                {
+                    return false; // Single element exceeds the entire byte budget.
+                }
+                const std::size_t prev = m_currentBytes.fetch_add(sz, std::memory_order_relaxed);
+                if (prev + sz > m_maxBytes)
+                {
+                    m_currentBytes.fetch_sub(sz, std::memory_order_relaxed);
+                    return false; // Byte quota exceeded.
+                }
+            }
+            else
+            {
+                m_currentBytes.fetch_add(sz, std::memory_order_relaxed);
+            }
+            if (!m_queue.try_enqueue(std::move(element)))
+            {
+                m_currentBytes.fetch_sub(sz, std::memory_order_relaxed);
+                return false; // Element-count limit hit.
+            }
+            return true;
+        }
+        return m_queue.try_enqueue(std::move(element));
+    }
 
     /**
      * @copydoc IQueue::tryPush
      */
-    inline bool tryPush(const T& element) override { return m_queue.try_enqueue(element); }
+    inline bool tryPush(const T& element) override
+    {
+        if (m_sizeOf)
+        {
+            const std::size_t sz = m_sizeOf(element);
+            if (m_maxBytes > 0)
+            {
+                if (sz > m_maxBytes)
+                {
+                    return false;
+                }
+                const std::size_t prev = m_currentBytes.fetch_add(sz, std::memory_order_relaxed);
+                if (prev + sz > m_maxBytes)
+                {
+                    m_currentBytes.fetch_sub(sz, std::memory_order_relaxed);
+                    return false;
+                }
+            }
+            else
+            {
+                m_currentBytes.fetch_add(sz, std::memory_order_relaxed);
+            }
+            if (!m_queue.try_enqueue(element))
+            {
+                m_currentBytes.fetch_sub(sz, std::memory_order_relaxed);
+                return false;
+            }
+            return true;
+        }
+        return m_queue.try_enqueue(element);
+    }
 
     /**
      * @copydoc IQueue::waitPop
@@ -146,6 +242,7 @@ public:
     {
         const int64_t normalizedTimeout = (timeout < 0) ? 0 : timeout;
 
+        bool result;
         if (m_rateLimiter)
         {
             auto startTime = std::chrono::steady_clock::now();
@@ -162,10 +259,18 @@ public:
             int64_t remainingTimeout = normalizedTimeout - elapsed.count();
             remainingTimeout = (remainingTimeout < 0) ? 0 : remainingTimeout;
 
-            return m_queue.wait_dequeue_timed(element, remainingTimeout);
+            result = m_queue.wait_dequeue_timed(element, remainingTimeout);
+        }
+        else
+        {
+            result = m_queue.wait_dequeue_timed(element, normalizedTimeout);
         }
 
-        return m_queue.wait_dequeue_timed(element, normalizedTimeout);
+        if (result && m_sizeOf)
+        {
+            releaseBytes(m_sizeOf(element));
+        }
+        return result;
     }
 
     /**
@@ -178,7 +283,15 @@ public:
         {
             return false;
         }
-        return m_queue.try_dequeue(element);
+        if (!m_queue.try_dequeue(element))
+        {
+            return false;
+        }
+        if (m_sizeOf)
+        {
+            releaseBytes(m_sizeOf(element));
+        }
+        return true;
     }
 
     /**
@@ -217,7 +330,17 @@ public:
         {
             return 0;
         }
-        return m_queue.try_dequeue_bulk(elements, max);
+        const std::size_t dequeued = m_queue.try_dequeue_bulk(elements, max);
+        if (dequeued > 0 && m_sizeOf)
+        {
+            std::size_t totalBytes = 0;
+            for (std::size_t i = 0; i < dequeued; ++i)
+            {
+                totalBytes += m_sizeOf(elements[i]);
+            }
+            releaseBytes(totalBytes);
+        }
+        return dequeued;
     }
 };
 

--- a/src/engine/source/fastqueue/include/fastqueue/stdqueue.hpp
+++ b/src/engine/source/fastqueue/include/fastqueue/stdqueue.hpp
@@ -227,6 +227,12 @@ public:
     }
 
     /**
+     * @copydoc IQueue::setByteLimit
+     * @note StdQueue does not implement byte-based capacity; this is a no-op.
+     */
+    void setByteLimit(std::size_t /*maxBytes*/, std::function<std::size_t(const T&)> /*sizeOf*/) override {}
+
+    /**
      * @copydoc IQueue::tryPopBulk
      * @note If rate limiting is enabled, this method will acquire tokens for ALL requested elements
      *       or return 0 if insufficient tokens are available. This maintains the atomicity of bulk operations.

--- a/src/engine/source/fastqueue/interface/fastqueue/iqueue.hpp
+++ b/src/engine/source/fastqueue/interface/fastqueue/iqueue.hpp
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 
 namespace fastqueue
 {
@@ -93,6 +94,32 @@ public:
      * @note This is more efficient than calling tryPop multiple times.
      */
     virtual std::size_t tryPopBulk(T* elements, std::size_t max) = 0;
+
+    /**
+     * @brief Get the approximate number of bytes currently held in the queue.
+     *
+     * @return Bytes used, or 0 if byte tracking is not configured.
+     */
+    virtual std::size_t bytesUsed() const noexcept { return 0; }
+
+    /**
+     * @brief Get the maximum byte capacity of the queue.
+     *
+     * @return Byte capacity, or 0 if byte limiting is not configured.
+     */
+    virtual std::size_t maxBytes() const noexcept { return 0; }
+
+    /**
+     * @brief Configure a byte-based capacity limit after construction.
+     *
+     * Once set, push() rejects any element that would cause the accumulated
+     * byte total to exceed @p maxBytes, and any single element larger than
+     * @p maxBytes is immediately rejected.
+     *
+     * @param maxBytes  Maximum total bytes of enqueued elements (0 = unlimited).
+     * @param sizeOf    Function that returns the byte size of a given element.
+     */
+    virtual void setByteLimit(std::size_t maxBytes, std::function<std::size_t(const T&)> sizeOf) = 0;
 };
 
 } // namespace fastqueue

--- a/src/engine/source/fastqueue/test/mocks/queue/mockQueue.hpp
+++ b/src/engine/source/fastqueue/test/mocks/queue/mockQueue.hpp
@@ -20,6 +20,7 @@ public:
     MOCK_METHOD(size_t, size, (), (const, noexcept, override));
     MOCK_METHOD(size_t, aproxFreeSlots, (), (const, noexcept, override));
     MOCK_METHOD(size_t, tryPopBulk, (T * elements, size_t max), (override));
+    MOCK_METHOD(void, setByteLimit, (size_t maxBytes, std::function<size_t(const T&)> sizeOf), (override));
 };
 
 } // namespace fastqueue::mocks

--- a/src/engine/source/fastqueue/test/src/component/cqueue_test.cpp
+++ b/src/engine/source/fastqueue/test/src/component/cqueue_test.cpp
@@ -887,3 +887,166 @@ TEST_F(CQueueTest, RateLimiterWaitPopMultipleThreads)
     ASSERT_LE(totalPopped, expectedMax);
     ASSERT_GT(totalPopped, 0); // Should have popped something
 }
+
+// =============================================================================
+// Byte-limit tests
+// =============================================================================
+
+// Helper: a simple string-typed queue with a size function
+static std::size_t stringSizeOf(const std::string& s)
+{
+    return s.size();
+}
+
+// Item-count limit is still enforced alongside byte limit
+TEST_F(CQueueTest, ByteLimit_ItemCountLimitCoexists)
+{
+    CQueue<std::string> cq(MIN_QUEUE_CAPACITY);
+    cq.setByteLimit(1000, stringSizeOf);
+
+    EXPECT_EQ(cq.bytesUsed(), 0u);
+    EXPECT_EQ(cq.maxBytes(), 1000u);
+}
+
+// Byte limit reached: queue rejects events once accumulated bytes exceed the cap
+TEST_F(CQueueTest, ByteLimit_GlobalLimitRejectsExtra)
+{
+    CQueue<std::string> cq(MIN_QUEUE_CAPACITY);
+    cq.setByteLimit(10, stringSizeOf); // only 10 bytes total
+
+    ASSERT_TRUE(cq.push(std::string("12345"))); // 5 bytes → total 5
+    EXPECT_EQ(cq.bytesUsed(), 5u);
+
+    ASSERT_TRUE(cq.push(std::string("12345"))); // 5 bytes → total 10
+    EXPECT_EQ(cq.bytesUsed(), 10u);
+
+    ASSERT_FALSE(cq.push(std::string("x"))); // 1 byte → quota full, rejected
+    EXPECT_EQ(cq.bytesUsed(), 10u);          // unchanged
+}
+
+// Oversized individual event is rejected even if the queue is otherwise empty
+TEST_F(CQueueTest, ByteLimit_OversizedEventRejected)
+{
+    CQueue<std::string> cq(MIN_QUEUE_CAPACITY);
+    cq.setByteLimit(5, stringSizeOf);
+
+    ASSERT_FALSE(cq.push(std::string("123456"))); // 6 bytes > limit of 5
+    EXPECT_EQ(cq.bytesUsed(), 0u);
+    EXPECT_TRUE(cq.empty());
+}
+
+// Byte quota is released when an event is popped
+TEST_F(CQueueTest, ByteLimit_QuotaRecoveryAfterPop)
+{
+    CQueue<std::string> cq(MIN_QUEUE_CAPACITY);
+    cq.setByteLimit(10, stringSizeOf);
+
+    ASSERT_TRUE(cq.push(std::string("12345"))); // 5 bytes
+    ASSERT_TRUE(cq.push(std::string("12345"))); // 5 bytes → quota full
+    ASSERT_FALSE(cq.push(std::string("x")));    // rejected
+
+    std::string out;
+    ASSERT_TRUE(cq.tryPop(out)); // consume 5 bytes
+    EXPECT_EQ(cq.bytesUsed(), 5u);
+
+    ASSERT_TRUE(cq.push(std::string("xyz"))); // 3 bytes → now fits (5 + 3 = 8)
+    EXPECT_EQ(cq.bytesUsed(), 8u);
+}
+
+// waitPop also decrements the byte counter
+TEST_F(CQueueTest, ByteLimit_WaitPopReleasesBytes)
+{
+    CQueue<std::string> cq(MIN_QUEUE_CAPACITY);
+    cq.setByteLimit(20, stringSizeOf);
+
+    ASSERT_TRUE(cq.push(std::string("hello"))); // 5 bytes
+    EXPECT_EQ(cq.bytesUsed(), 5u);
+
+    std::string out;
+    ASSERT_TRUE(cq.waitPop(out, WAIT_DEQUEUE_TIMEOUT_USEC));
+    EXPECT_EQ(out, "hello");
+    EXPECT_EQ(cq.bytesUsed(), 0u);
+}
+
+// tryPopBulk releases bytes for all elements popped
+TEST_F(CQueueTest, ByteLimit_TryPopBulkReleasesBytes)
+{
+    CQueue<std::string> cq(MIN_QUEUE_CAPACITY);
+    cq.setByteLimit(100, stringSizeOf);
+
+    ASSERT_TRUE(cq.push(std::string("abc")));   // 3 bytes
+    ASSERT_TRUE(cq.push(std::string("defgh"))); // 5 bytes
+    EXPECT_EQ(cq.bytesUsed(), 8u);
+
+    std::string buf[2];
+    std::size_t n = cq.tryPopBulk(buf, 2);
+    EXPECT_EQ(n, 2u);
+    EXPECT_EQ(cq.bytesUsed(), 0u);
+}
+
+// Without byte limit configured, bytesUsed() stays 0 and pushes are unrestricted
+TEST_F(CQueueTest, ByteLimit_DisabledByDefault)
+{
+    CQueue<std::string> cq(MIN_QUEUE_CAPACITY);
+    EXPECT_EQ(cq.maxBytes(), 0u);
+    EXPECT_EQ(cq.bytesUsed(), 0u);
+
+    for (int i = 0; i < 10; ++i)
+    {
+        ASSERT_TRUE(cq.push(std::string(1000, 'x')));
+    }
+    EXPECT_EQ(cq.bytesUsed(), 0u); // no tracking when disabled
+}
+
+// Concurrent producers and consumer: byte counter returns to 0 after full drain
+TEST_F(CQueueTest, ByteLimit_ConcurrentProducersConsumer)
+{
+    constexpr int ITEMS = 500;
+    constexpr std::size_t ITEM_SIZE = 10;
+    constexpr std::size_t BYTE_CAP = ITEMS * ITEM_SIZE * 2; // generous cap
+
+    CQueue<std::string> cq(MIN_QUEUE_CAPACITY * 4);
+    cq.setByteLimit(BYTE_CAP, stringSizeOf);
+
+    std::atomic<int> produced {0};
+    std::atomic<int> consumed {0};
+
+    auto producerFn = [&]()
+    {
+        for (int i = 0; i < ITEMS; ++i)
+        {
+            std::string item(ITEM_SIZE, static_cast<char>('a' + (i % 26)));
+            while (!cq.push(std::move(item)))
+            {
+                std::this_thread::yield(); // retry on quota or count limit
+                item = std::string(ITEM_SIZE, static_cast<char>('a' + (i % 26)));
+            }
+            ++produced;
+        }
+    };
+
+    auto consumerFn = [&]()
+    {
+        while (consumed.load() < ITEMS * 2)
+        {
+            std::string out;
+            if (cq.waitPop(out, WAIT_DEQUEUE_TIMEOUT_USEC))
+            {
+                ++consumed;
+            }
+        }
+    };
+
+    std::thread p1(producerFn);
+    std::thread p2(producerFn);
+    std::thread c(consumerFn);
+
+    p1.join();
+    p2.join();
+    c.join();
+
+    EXPECT_EQ(produced.load(), ITEMS * 2);
+    EXPECT_EQ(consumed.load(), ITEMS * 2);
+    EXPECT_EQ(cq.bytesUsed(), 0u);
+    EXPECT_TRUE(cq.empty());
+}

--- a/src/engine/source/main.cpp
+++ b/src/engine/source/main.cpp
@@ -597,8 +597,10 @@ int main(int argc, char* argv[])
         {
             const auto qSize = confManager.get<size_t>(conf::key::EVENT_QUEUE_SIZE);
             const auto qEps = confManager.get<size_t>(conf::key::EVENT_QUEUE_EPS);
+            const auto qMaxBytes = confManager.get<size_t>(conf::key::EVENT_QUEUE_MAX_BYTES);
 
             const auto eventQueue = std::make_shared<fastqueue::CQueue<router::IngestEvent>>(qSize, qEps);
+            eventQueue->setByteLimit(qMaxBytes, [](const router::IngestEvent& e) { return e.second.size(); });
             const auto testQueue = std::make_shared<fastqueue::StdQueue<router::test::EventTest>>(qSize);
 
             router::Orchestrator::Options config {.m_numThreads = confManager.get<int>(conf::key::ORCHESTRATOR_THREADS),
@@ -615,9 +617,12 @@ int main(int argc, char* argv[])
 
             exitHandler.add([orchestrator]() { orchestrator->requestShutdown(); });
             const auto epsDescription = qEps > 0 ? std::to_string(qEps) : std::string("unlimited");
-            LOG_INFO("Orchestrator initialized and started with event queue size: {}, events per second: {}.",
-                     qSize,
-                     epsDescription);
+            const auto bytesDescription = qMaxBytes > 0 ? std::to_string(qMaxBytes) : std::string("unlimited");
+            LOG_INFO(
+                "Orchestrator initialized and started with event queue size: {}, events per second: {}, max bytes: {}.",
+                qSize,
+                epsDescription,
+                bytesDescription);
         }
 
         // CMsync
@@ -649,12 +654,14 @@ int main(int argc, char* argv[])
             auto iocSyncInterval = confManager.get<std::size_t>(conf::key::IOC_SYNC_INTERVAL);
             if (iocSyncInterval > 0)
             {
-                scheduler->scheduleTask(
-                    "ioc-sync-task",
-                    scheduler::TaskConfig {.interval = iocSyncInterval,
-                                           .runImmediately = true,
-                                           .CPUPriority = 0,
-                                           .taskFunction = [iocSyncService]() { iocSyncService->synchronize(); }});
+                scheduler->scheduleTask("ioc-sync-task",
+                                        scheduler::TaskConfig {.interval = iocSyncInterval,
+                                                               .runImmediately = true,
+                                                               .CPUPriority = 0,
+                                                               .taskFunction = [iocSyncService]()
+                                                               {
+                                                                   iocSyncService->synchronize();
+                                                               }});
                 LOG_DEBUG("IOC Sync task scheduled with interval: {} seconds, {} max retries, {} seconds for retry "
                           "interval and {} for batch size",
                           iocSyncInterval,
@@ -688,7 +695,9 @@ int main(int argc, char* argv[])
                                            .runImmediately = true,
                                            .CPUPriority = 0,
                                            .taskFunction = [geoManager, manifestUrl, cityPath, asnPath]()
-                                           { geoManager->remoteUpsert(manifestUrl, cityPath, asnPath); }});
+                                           {
+                                               geoManager->remoteUpsert(manifestUrl, cityPath, asnPath);
+                                           }});
                 LOG_DEBUG("Geo sync scheduled with interval: {} seconds", geoSyncInterval);
             }
             else
@@ -720,12 +729,14 @@ int main(int argc, char* argv[])
         if (enableProcessing)
         {
             const auto remoteConfSyncInterval = confManager.get<std::size_t>(conf::key::REMOTE_CONF_SYNC_INTERVAL);
-            scheduler->scheduleTask(
-                "remote-conf-sync",
-                scheduler::TaskConfig {.interval = remoteConfSyncInterval,
-                                       .runImmediately = true,
-                                       .CPUPriority = 0,
-                                       .taskFunction = [remoteConf]() { remoteConf->synchronize(); }});
+            scheduler->scheduleTask("remote-conf-sync",
+                                    scheduler::TaskConfig {.interval = remoteConfSyncInterval,
+                                                           .runImmediately = true,
+                                                           .CPUPriority = 0,
+                                                           .taskFunction = [remoteConf]()
+                                                           {
+                                                               remoteConf->synchronize();
+                                                           }});
             LOG_DEBUG("Remote configuration synchronize scheduled with interval: {} seconds", remoteConfSyncInterval);
         }
 
@@ -823,7 +834,9 @@ int main(int argc, char* argv[])
                                                      .runImmediately = false,
                                                      .CPUPriority = 0,
                                                      .taskFunction = [metricsWriter, metricsManager]()
-                                                     { metricsManager->writeAllMetrics(metricsWriter); }};
+                                                     {
+                                                         metricsManager->writeAllMetrics(metricsWriter);
+                                                     }};
 
                 scheduler->scheduleTask("MetricsLogger", std::move(metricsConfig));
                 LOG_INFO("Metrics stream logging enabled (interval: {} seconds, on-demand channel creation).",

--- a/src/engine/source/router/src/orchestrator.cpp
+++ b/src/engine/source/router/src/orchestrator.cpp
@@ -208,8 +208,12 @@ void Orchestrator::postEvent(IngestEvent&& event)
     const auto queueSize = m_eventQueue->size();
     const auto freeSlots = m_eventQueue->aproxFreeSlots();
     const auto totalSlots = queueSize + freeSlots;
+    const auto bytesUsed = m_eventQueue->bytesUsed();
+    const auto maxBytes = m_eventQueue->maxBytes();
 
-    const bool isContended = totalSlots > 0 && (queueSize * 100) >= (totalSlots * CONTENTION_LOAD_PERCENT_THRESHOLD);
+    const bool isCountContended = totalSlots > 0 && (queueSize * 100) >= (totalSlots * CONTENTION_LOAD_PERCENT_THRESHOLD);
+    const bool isBytesContended = maxBytes > 0 && (bytesUsed * 100) >= (maxBytes * CONTENTION_LOAD_PERCENT_THRESHOLD);
+    const bool isContended = isCountContended || isBytesContended;
 
     if (!isContended)
     {
@@ -256,11 +260,14 @@ void Orchestrator::postEvent(IngestEvent&& event)
 
     LOG_WARNING("[Orchestrator::Router] Event queue has remained contended for at least {} seconds. Dropped events "
                 "during contention: {}. "
-                "Approx queue size: {}, approx free slots: {}.",
+                "Approx queue size: {}, approx free slots: {}. "
+                "Bytes used: {}, max bytes: {}.",
                 CONTENTION_WARNING_INTERVAL_SEC,
                 m_droppedEventsInContention.load(std::memory_order_relaxed),
                 queueSize,
-                freeSlots);
+                freeSlots,
+                bytesUsed,
+                maxBytes);
 }
 
 void Orchestrator::Options::validate() const

--- a/src/remoted/include/remoted.h
+++ b/src/remoted/include/remoted.h
@@ -130,6 +130,9 @@ void key_unlock(void);
 // Init message queue
 void rem_msginit(size_t size);
 
+// Free the message queue (unit tests only)
+void rem_msgdestroy(void);
+
 // Push message into queue
 int rem_msgpush(const char* buffer, unsigned long size, struct sockaddr_storage* addr, int sock);
 
@@ -144,6 +147,9 @@ size_t rem_get_tsize();
 
 // Free message
 void rem_msgfree(message_t* message);
+
+// Set the maximum total bytes for the input message queue (0 = unlimited)
+void rem_set_input_queue_max_bytes(size_t max_bytes);
 
 // Read config
 cJSON* getRemoteConfig(void);
@@ -231,6 +237,8 @@ extern int shared_reload_interval;
 extern size_t global_counter;
 extern size_t batch_events_capacity;
 extern size_t batch_events_per_agent_capacity;
+extern size_t queue_max_bytes;
+extern size_t batch_events_max_bytes;
 extern int enrich_cache_expire_time;
 
 extern module_limits_t manager_module_limits;

--- a/src/remoted/src/config.c
+++ b/src/remoted/src/config.c
@@ -45,6 +45,8 @@ int shared_reload_interval;
 int disk_storage;
 size_t batch_events_capacity;
 size_t batch_events_per_agent_capacity;
+size_t queue_max_bytes;
+size_t batch_events_max_bytes;
 int enrich_cache_expire_time;
 
 /* Manager's module limits instance */
@@ -120,6 +122,9 @@ int RemotedConfig(const char *cfgfile, remoted *cfg)
     _s_verify_counter = getDefine_Int_default("remoted", "verify_msg_id", 0, 1, 0);
     batch_events_capacity = (size_t)getDefine_Int_default("remoted", "batch_events_capacity", 0, 0x1<<20, 131072);
     batch_events_per_agent_capacity = (size_t)getDefine_Int_default("remoted", "batch_events_per_agent_capacity", 0, 0x1<<20, 131072);
+    // Byte-capacity limits (0 = unlimited).  Values < 1 KiB are rejected at startup.
+    queue_max_bytes = (size_t)getDefine_Int_default("remoted", "queue_max_bytes", 0, INT_MAX, 64 * 1024 * 1024);
+    batch_events_max_bytes = (size_t)getDefine_Int_default("remoted", "batch_events_max_bytes", 0, INT_MAX, 32 * 1024 * 1024);
     enrich_cache_expire_time = getDefine_Int_default("remoted", "enrich_cache_expire_time", 60, 86400, 300);
 
     /* Setting default values for global parameters */
@@ -138,6 +143,16 @@ int RemotedConfig(const char *cfgfile, remoted *cfg)
 
     if (cfg->queue_size > 262144) {
         mwarn("Queue size is very high. The application may run out of memory.");
+    }
+
+    if (queue_max_bytes > 0 && queue_max_bytes < 1024) {
+        merror("remoted.queue_max_bytes (%zu) is below the minimum of 1024 bytes.", queue_max_bytes);
+        return OS_INVALID;
+    }
+
+    if (batch_events_max_bytes > 0 && batch_events_max_bytes < 1024) {
+        merror("remoted.batch_events_max_bytes (%zu) is below the minimum of 1024 bytes.", batch_events_max_bytes);
+        return OS_INVALID;
     }
 
     /* Get node name and cluster name of the manager */
@@ -236,6 +251,8 @@ cJSON *getRemoteInternalConfig(void) {
     cJSON_AddNumberToObject(remoted,"state_interval",state_interval);
     cJSON_AddNumberToObject(remoted,"batch_events_capacity",batch_events_capacity);
     cJSON_AddNumberToObject(remoted,"batch_events_per_agent_capacity",batch_events_per_agent_capacity);
+    cJSON_AddNumberToObject(remoted,"queue_max_bytes",(double)queue_max_bytes);
+    cJSON_AddNumberToObject(remoted,"batch_events_max_bytes",(double)batch_events_max_bytes);
     cJSON_AddNumberToObject(remoted,"enrich_cache_expire_time",enrich_cache_expire_time);
 
     cJSON_AddItemToObject(internals,"remoted",remoted);

--- a/src/remoted/src/queue.c
+++ b/src/remoted/src/queue.c
@@ -71,7 +71,7 @@ int rem_msgpush(const char * buffer, unsigned long size, struct sockaddr_storage
             { time_t _t = time(NULL); if (_t - last_discard_warn >= 5) { mwarn("Input queue discarded %zu event(s) in the last 5 seconds.", pending_discards); pending_discards = 0; last_discard_warn = _t; } }
             return -1;
         }
-        if (rem_input_bytes_used + size > rem_input_max_bytes) {
+        if (rem_input_bytes_used >= rem_input_max_bytes || size > rem_input_max_bytes - rem_input_bytes_used) {
             // Byte quota full.
             w_mutex_unlock(&mutex);
             rem_msgfree(message);

--- a/src/remoted/src/queue.c
+++ b/src/remoted/src/queue.c
@@ -16,17 +16,37 @@ static w_queue_t * queue;
 static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t available = PTHREAD_COND_INITIALIZER;
 
+static size_t rem_input_max_bytes = 0;   ///< 0 = unlimited
+static size_t rem_input_bytes_used = 0;  ///< protected by mutex
 
 // Init message queue
 void rem_msginit(size_t size) {
     queue = queue_init(size);
 }
 
+// Free the message queue (used by unit tests to avoid leaks between test cases)
+void rem_msgdestroy(void) {
+    if (queue) {
+        queue_free(queue);
+        queue = NULL;
+    }
+    rem_input_bytes_used = 0;
+    rem_input_max_bytes  = 0;
+}
+
+// Configure the byte capacity limit for the input queue (0 = unlimited)
+void rem_set_input_queue_max_bytes(size_t max_bytes) {
+    w_mutex_lock(&mutex);
+    rem_input_max_bytes = max_bytes;
+    w_mutex_unlock(&mutex);
+}
+
 // Push message into queue
 int rem_msgpush(const char * buffer, unsigned long size, struct sockaddr_storage * addr, int sock) {
     message_t * message;
     int result;
-    static int reported = 0;
+    static time_t last_discard_warn = 0;
+    static size_t pending_discards = 0;
 
     os_malloc(sizeof(message_t), message);
     os_malloc(size, message->buffer);
@@ -39,7 +59,32 @@ int rem_msgpush(const char * buffer, unsigned long size, struct sockaddr_storage
 
     message->counter = ++global_counter;
 
+    // Byte capacity check (must be inside mutex to keep rem_input_bytes_used consistent)
+    if (rem_input_max_bytes > 0) {
+        if (size > rem_input_max_bytes) {
+            // Individual event exceeds the configured byte limit.
+            w_mutex_unlock(&mutex);
+            rem_msgfree(message);
+            mdebug2("Discarding oversized event from host (%lu bytes > %zu byte limit).", size, rem_input_max_bytes);
+            rem_inc_recv_discarded();
+            pending_discards++;
+            { time_t _t = time(NULL); if (_t - last_discard_warn >= 5) { mwarn("Input queue discarded %zu event(s) in the last 5 seconds.", pending_discards); pending_discards = 0; last_discard_warn = _t; } }
+            return -1;
+        }
+        if (rem_input_bytes_used + size > rem_input_max_bytes) {
+            // Byte quota full.
+            w_mutex_unlock(&mutex);
+            rem_msgfree(message);
+            mdebug2("Discarding event from host: byte quota reached (%zu/%zu bytes).", rem_input_bytes_used, rem_input_max_bytes);
+            rem_inc_recv_discarded();
+            pending_discards++;
+            { time_t _t = time(NULL); if (_t - last_discard_warn >= 5) { mwarn("Input queue discarded %zu event(s) in the last 5 seconds.", pending_discards); pending_discards = 0; last_discard_warn = _t; } }
+            return -1;
+        }
+    }
+
     if (result = queue_push(queue, message), result == 0) {
+        rem_input_bytes_used += size;
         w_cond_signal(&available);
     }
 
@@ -49,10 +94,9 @@ int rem_msgpush(const char * buffer, unsigned long size, struct sockaddr_storage
         rem_msgfree(message);
         mdebug2("Discarding event from host.");
         rem_inc_recv_discarded();
-        if (!reported) {
-            mwarn("Message queue is full (%zu). Events may be lost.", queue->size);
-            reported = 1;
-        }
+        pending_discards++;
+        { time_t _t = time(NULL); if (_t - last_discard_warn >= 5) { mwarn("Input queue discarded %zu event(s) in the last 5 seconds.", pending_discards); pending_discards = 0; last_discard_warn = _t; } }
+
     }
 
     return result;
@@ -86,6 +130,12 @@ message_t * rem_msgpop() {
 
     while (message = (message_t *)queue_pop(queue), !message) {
         w_cond_wait(&available, &mutex);
+    }
+
+    if (message->size <= rem_input_bytes_used) {
+        rem_input_bytes_used -= message->size;
+    } else {
+        rem_input_bytes_used = 0;
     }
 
     w_mutex_unlock(&mutex);

--- a/src/remoted/src/secure.c
+++ b/src/remoted/src/secure.c
@@ -29,8 +29,28 @@
 #define STATIC static
 #endif
 
-static time_t s_last_events_drop_warn = 0;
-static size_t s_pending_events_drop = 0;
+static _Atomic time_t s_last_events_drop_warn = 0;
+static _Atomic size_t s_pending_events_drop = 0;
+
+/**
+ * @brief Increment the pending-drop counter and emit a rate-limited warning.
+ *
+ * At most one warning per 5-second window is printed. The CAS on
+ * s_last_events_drop_warn ensures exactly one thread wins the print slot when
+ * multiple handler threads discard events simultaneously.
+ */
+static void maybe_log_events_queue_drop(void) {
+    atomic_fetch_add_explicit(&s_pending_events_drop, 1, memory_order_relaxed);
+
+    time_t now  = time(NULL);
+    time_t last = atomic_load_explicit(&s_last_events_drop_warn, memory_order_relaxed);
+    if (now - last >= 5 &&
+        atomic_compare_exchange_strong_explicit(&s_last_events_drop_warn, &last, now,
+                                                memory_order_relaxed, memory_order_relaxed)) {
+        size_t count = atomic_exchange_explicit(&s_pending_events_drop, 0, memory_order_relaxed);
+        mwarn("Events queue discarded %zu event(s) in the last 5 seconds.", count);
+    }
+}
 
 /* Global variables */
 w_indexed_queue_t *control_msg_queue = NULL;
@@ -1047,8 +1067,7 @@ STATIC void HandleSecureMessage(const message_t *message, w_indexed_queue_t * co
         if (rc < 0) {
             dispose_evt_item(e);
             rem_inc_recv_events_failed();
-            s_pending_events_drop++;
-            { time_t _t = time(NULL); if (_t - s_last_events_drop_warn >= 5) { mwarn("Events queue discarded %zu event(s) in the last 5 seconds.", s_pending_events_drop); s_pending_events_drop = 0; s_last_events_drop_warn = _t; } }
+            maybe_log_events_queue_drop();
         } else {
             rem_inc_recv_events(agentid_str);
         }

--- a/src/remoted/src/secure.c
+++ b/src/remoted/src/secure.c
@@ -29,6 +29,9 @@
 #define STATIC static
 #endif
 
+static time_t s_last_events_drop_warn = 0;
+static size_t s_pending_events_drop = 0;
+
 /* Global variables */
 w_indexed_queue_t *control_msg_queue = NULL;
 w_rr_queue_t *events_queue = NULL;
@@ -169,6 +172,11 @@ static void dispose_evt_item(void *p) {
     os_free(e);
 }
 
+static size_t evt_item_get_bytes(const void *p) {
+    const evt_item_t *e = (const evt_item_t *)p;
+    return e ? e->len : 0;
+}
+
 void * dispach_events_thread(void * queue);
 
 typedef struct {
@@ -190,8 +198,9 @@ void HandleSecure()
 
     events_queue = batch_queue_init(batch_events_capacity);
     batch_queue_set_dispose(events_queue, (void (*)(void *))dispose_evt_item);
-
+    batch_queue_set_get_item_bytes(events_queue, evt_item_get_bytes);
     batch_queue_set_agent_max(events_queue, batch_events_per_agent_capacity);
+    batch_queue_set_bytes_limit(events_queue, batch_events_max_bytes);
 
     uhttp_global_init();
 
@@ -213,8 +222,9 @@ void HandleSecure()
     /* Initialize manager */
     manager_init();
 
-    // Initialize messag equeue
+    // Initialize message queue
     rem_msginit(logr.queue_size);
+    rem_set_input_queue_max_bytes(queue_max_bytes);
 
     /* Initialize the agent key table mutex */
     key_lock_init();
@@ -1036,8 +1046,9 @@ STATIC void HandleSecureMessage(const message_t *message, w_indexed_queue_t * co
         int rc = batch_queue_enqueue_ex(batch_queue, agentid_str, e);
         if (rc < 0) {
             dispose_evt_item(e);
-            mwarn("Dropping event for agent '%s' (rc=%d)", agentid_str, rc);
             rem_inc_recv_events_failed();
+            s_pending_events_drop++;
+            { time_t _t = time(NULL); if (_t - s_last_events_drop_warn >= 5) { mwarn("Events queue discarded %zu event(s) in the last 5 seconds.", s_pending_events_drop); s_pending_events_drop = 0; s_last_events_drop_warn = _t; } }
         } else {
             rem_inc_recv_events(agentid_str);
         }

--- a/src/shared/include/batch_queue_op.h
+++ b/src/shared/include/batch_queue_op.h
@@ -63,8 +63,12 @@ typedef struct w_rr_queue {
     size_t max_items_per_agent;       ///< Per-agent item limit (0 = unlimited)
     _Atomic size_t items_global;      ///< Approximate global item count
 
+    size_t max_bytes_global;          ///< Global byte limit (0 = unlimited)
+    _Atomic size_t bytes_global;      ///< Approximate total bytes currently enqueued
+
     /* Callbacks */
     void (*dispose)(void *);          ///< Called to dispose an item dropped without processing (optional)
+    size_t (*get_item_bytes)(const void *); ///< Returns the byte size of an item (optional; NULL = no byte accounting)
 } w_rr_queue_t;
 
 /*==============================================================================
@@ -106,6 +110,29 @@ void batch_queue_set_dispose(w_rr_queue_t *sched, void (*dispose)(void *));
  * @param max_items_per_agent Maximum number of queued items per agent
  */
 void batch_queue_set_agent_max(w_rr_queue_t *sched, size_t max_items_per_agent);
+
+/**
+ * @brief Set a global byte capacity limit (0 = unlimited).
+ *
+ * Enqueue operations that would exceed this limit return `-ENOSPC`.
+ * An individual item whose size exceeds this limit is always rejected.
+ * Requires `get_item_bytes` to be configured; no-op otherwise.
+ *
+ * @param sched     Scheduler
+ * @param max_bytes Maximum total bytes of enqueued items (0 = unlimited)
+ */
+void batch_queue_set_bytes_limit(w_rr_queue_t *sched, size_t max_bytes);
+
+/**
+ * @brief Set the callback used to measure the byte size of an enqueued item.
+ *
+ * Must be called before byte accounting takes effect.  The callback receives
+ * a const pointer to the item and must return its size in bytes.
+ *
+ * @param sched     Scheduler
+ * @param get_bytes Size callback; may be NULL to disable byte accounting
+ */
+void batch_queue_set_get_item_bytes(w_rr_queue_t *sched, size_t (*get_bytes)(const void *));
 
 /*==============================================================================
  * Production (Multiple Producers)
@@ -187,6 +214,14 @@ int batch_queue_empty(const w_rr_queue_t *sched);
  * @return Approximate number of queued items.
  */
 size_t batch_queue_size(const w_rr_queue_t *sched);
+
+/**
+ * @brief Approximate total bytes currently enqueued across all agents.
+ *
+ * @param sched Scheduler
+ * @return Approximate number of bytes.
+ */
+size_t batch_queue_bytes(const w_rr_queue_t *sched);
 
 /**
  * @brief Number of active slots currently in the ring.

--- a/src/shared/src/batch_queue_op.c
+++ b/src/shared/src/batch_queue_op.c
@@ -154,11 +154,17 @@ static w_rr_agent_slot_t *make_slot(const char *agent_key) {
 
 /**
  * @brief Free a slot and optionally adjust the global item counter.
- * @param sched          Scheduler handle (for dispose and global counters).
+ * @param sched          Scheduler handle (for global counters).
  * @param s              Slot to free.
  * @param adjust_global  If non-zero, subtract drained items from global counter.
+ * @param dispose_snap   Snapshotted dispose callback (may be NULL). Callers must
+ *                       capture sched->dispose under ring_mu before releasing it.
+ * @param get_bytes_snap Snapshotted get_item_bytes callback (may be NULL). Same
+ *                       rationale: avoids a data race with the setter.
  */
-static void free_slot(w_rr_queue_t *sched, w_rr_agent_slot_t *s, int adjust_global) {
+static void free_slot(w_rr_queue_t *sched, w_rr_agent_slot_t *s, int adjust_global,
+                      void (*dispose_snap)(void *),
+                      size_t (*get_bytes_snap)(const void *)) {
     if (!s) return;
     w_linked_queue_node_t *chain = NULL;
     size_t n = steal_chain(s->q, &chain);
@@ -166,10 +172,10 @@ static void free_slot(w_rr_queue_t *sched, w_rr_agent_slot_t *s, int adjust_glob
     size_t freed_bytes = 0;
     while (chain) {
         w_linked_queue_node_t *nx = chain->next;
-        if (adjust_global && sched->get_item_bytes && chain->data) {
-            freed_bytes += sched->get_item_bytes(chain->data);
+        if (adjust_global && get_bytes_snap && chain->data) {
+            freed_bytes += get_bytes_snap(chain->data);
         }
-        if (sched->dispose) sched->dispose(chain->data);
+        if (dispose_snap) dispose_snap(chain->data);
         os_free(chain);
         chain = nx;
     }
@@ -233,7 +239,9 @@ void batch_queue_free(w_rr_queue_t *sched) {
     while (hm_iter_next(&it, &k, &val)) {
         w_rr_agent_slot_t *slot = (w_rr_agent_slot_t*)val;
         // No need to touch the ring: we are shutting everything down.
-        free_slot(sched, slot, /*adjust_global=*/0);
+        // adjust_global=0: no byte accounting needed; dispose/get_bytes callbacks
+        // don't race here because batch_queue_free is called after all producers stop.
+        free_slot(sched, slot, /*adjust_global=*/0, sched->dispose, NULL);
     }
 
     hm_destroy(&sched->agent_index);
@@ -292,48 +300,30 @@ void batch_queue_set_get_item_bytes(w_rr_queue_t *sched, size_t (*get_bytes)(con
  * @return 0 on success; -ENOSPC if limits exceeded; -ENOMEM on allocation errors;
  *         -EINVAL on invalid args.
  *
+ * Ownership: on success (0) the queue owns @p data and will call dispose() when
+ * the item is eventually dropped or the queue is destroyed. On any error the
+ * queue never takes ownership — the caller is responsible for disposing @p data.
+ *
  * Steps (summarized):
- * 0) Approximate global limit check (lock-free); roll back on failure later.
+ * 0) Item-count pre-check (lock-free). max_items_global is init-only, no data race.
  * 1) Under ring_mu: lookup or create the agent slot in the hashmap.
  * 2) Lock the per-agent queue BEFORE releasing ring_mu (safe handover).
+ *    Snapshot get_item_bytes and max_bytes_global under ring_mu to avoid data races
+ *    with their setters (which write under ring_mu).
  * 3) Release ring_mu to reduce global contention.
+ * 3b) Byte accounting with snapshotted callback and limit; enforce byte cap if set.
  * 4) Push the item into the agent queue (respecting per-agent cap).
  * 5) If the queue transitioned empty→non-empty, (re)append to ring and signal.
  */
 int batch_queue_enqueue_ex(w_rr_queue_t *sched, const char *agent_key, void *data) {
     if (!sched || !agent_key || !data) return -EINVAL;
 
-    // 0) Approximate global limits (lock-free). Roll back if later steps fail.
-
-    // Byte tracking and optional limit enforcement, before taking any lock.
-    size_t item_bytes = 0;
-    if (sched->get_item_bytes) {
-        item_bytes = sched->get_item_bytes(data);
-        if (sched->max_bytes_global) {
-            if (item_bytes > sched->max_bytes_global) {
-                // Single oversized item can never fit.
-                if (sched->dispose) sched->dispose(data);
-                return -ENOSPC;
-            }
-            size_t prev_bytes = atomic_fetch_add_explicit(&sched->bytes_global, item_bytes, memory_order_relaxed);
-            if (prev_bytes + item_bytes > sched->max_bytes_global) {
-                atomic_fetch_sub_explicit(&sched->bytes_global, item_bytes, memory_order_relaxed);
-                if (sched->dispose) sched->dispose(data);
-                return -ENOSPC;
-            }
-        } else {
-            // No limit configured — just track bytes for observability.
-            atomic_fetch_add_explicit(&sched->bytes_global, item_bytes, memory_order_relaxed);
-        }
-    }
-
+    // 0) Approximate item-count pre-check (lock-free).
+    // max_items_global is written only at init and never modified again, so reading
+    // it here without a lock is safe (no concurrent writer exists).
     size_t prev = atomic_fetch_add_explicit(&sched->items_global, 1, memory_order_relaxed);
     if (sched->max_items_global && prev + 1 > sched->max_items_global) {
         atomic_fetch_sub_explicit(&sched->items_global, 1, memory_order_relaxed);
-        if (item_bytes) {
-            atomic_fetch_sub_explicit(&sched->bytes_global, item_bytes, memory_order_relaxed);
-        }
-        if (sched->dispose) sched->dispose(data);
         return -ENOSPC;
     }
 
@@ -349,32 +339,52 @@ int batch_queue_enqueue_ex(w_rr_queue_t *sched, const char *agent_key, void *dat
         if (!slot) {
             w_mutex_unlock(&sched->ring_mu);
             atomic_fetch_sub_explicit(&sched->items_global, 1, memory_order_relaxed);
-            if (item_bytes) {
-                atomic_fetch_sub_explicit(&sched->bytes_global, item_bytes, memory_order_relaxed);
-            }
-            if (sched->dispose) sched->dispose(data);
             return -ENOMEM;
         }
         if (hm_put(&sched->agent_index, agent_key, slot) != 0) {
             w_mutex_unlock(&sched->ring_mu);
-            free_slot(sched, slot, /*adjust_global=*/0);
+            free_slot(sched, slot, /*adjust_global=*/0, NULL, NULL);
             atomic_fetch_sub_explicit(&sched->items_global, 1, memory_order_relaxed);
-            if (item_bytes) {
-                atomic_fetch_sub_explicit(&sched->bytes_global, item_bytes, memory_order_relaxed);
-            }
-            if (sched->dispose) sched->dispose(data);
             return -ENOMEM;
         }
     }
 
-    // 2) Take the queue lock **before releasing ring_mu** (safe handover)
+    // 2) Take the queue lock **before releasing ring_mu** (safe handover).
+    // Snapshot all configuration fields under ring_mu to avoid data races with
+    // their setters (batch_queue_set_agent_max, batch_queue_set_bytes_limit,
+    // batch_queue_set_get_item_bytes), which all write under ring_mu.
     w_mutex_lock(&slot->q->mutex);
-    // Read max_items_per_agent under ring_mu before releasing it, to avoid a data
-    // race with batch_queue_set_agent_max(), which writes it under ring_mu.
     const size_t max_per_agent = sched->max_items_per_agent;
+    const size_t max_bytes = sched->max_bytes_global;
+    size_t (*const get_bytes)(const void *) = sched->get_item_bytes;
 
     // 3) Release ring_mu to reduce global contention
     w_mutex_unlock(&sched->ring_mu);
+
+    // 3b) Byte accounting using snapshotted values — no data race.
+    // slot->q->mutex is still held, which is fine.
+    size_t item_bytes = 0;
+    if (get_bytes) {
+        item_bytes = get_bytes(data);
+        if (max_bytes) {
+            if (item_bytes > max_bytes) {
+                // Single oversized item can never fit.
+                w_mutex_unlock(&slot->q->mutex);
+                atomic_fetch_sub_explicit(&sched->items_global, 1, memory_order_relaxed);
+                return -ENOSPC;
+            }
+            size_t prev_bytes = atomic_fetch_add_explicit(&sched->bytes_global, item_bytes, memory_order_relaxed);
+            if (prev_bytes >= max_bytes || item_bytes > max_bytes - prev_bytes) {
+                atomic_fetch_sub_explicit(&sched->bytes_global, item_bytes, memory_order_relaxed);
+                w_mutex_unlock(&slot->q->mutex);
+                atomic_fetch_sub_explicit(&sched->items_global, 1, memory_order_relaxed);
+                return -ENOSPC;
+            }
+        } else {
+            // No limit configured — just track bytes for observability.
+            atomic_fetch_add_explicit(&sched->bytes_global, item_bytes, memory_order_relaxed);
+        }
+    }
 
     // 4) Enqueue into the agent queue
     int reject = 0;
@@ -391,7 +401,6 @@ int batch_queue_enqueue_ex(w_rr_queue_t *sched, const char *agent_key, void *dat
             if (item_bytes) {
                 atomic_fetch_sub_explicit(&sched->bytes_global, item_bytes, memory_order_relaxed);
             }
-            if (sched->dispose) sched->dispose(data);
             return -ENOMEM;
         }
         n->data = data;
@@ -415,7 +424,6 @@ int batch_queue_enqueue_ex(w_rr_queue_t *sched, const char *agent_key, void *dat
         if (item_bytes) {
             atomic_fetch_sub_explicit(&sched->bytes_global, item_bytes, memory_order_relaxed);
         }
-        if (sched->dispose) sched->dispose(data);
         return -ENOSPC;
     }
 
@@ -475,8 +483,11 @@ size_t batch_queue_drain_next_ex(w_rr_queue_t *sched,
     ring_remove_node(sched, slot, prev);
     if (out_agent_key) *out_agent_key = slot->key;
 
-    // Queue handover: lock per-queue BEFORE releasing ring_mu (lock order respected)
+    // Queue handover: lock per-queue BEFORE releasing ring_mu (lock order respected).
+    // Also snapshot get_item_bytes here, while ring_mu is still held, to avoid a
+    // data race with batch_queue_set_get_item_bytes() which writes under ring_mu.
     w_mutex_lock(&slot->q->mutex);
+    size_t (*const get_bytes_snap)(const void *) = sched->get_item_bytes;
     w_mutex_unlock(&sched->ring_mu);
 
     // Snapshot-detach the whole queue in O(1)
@@ -492,8 +503,8 @@ size_t batch_queue_drain_next_ex(w_rr_queue_t *sched,
     for (w_linked_queue_node_t *n = head; n; ) {
         w_linked_queue_node_t *next = n->next;
         drained++;
-        if (sched->get_item_bytes && n->data) {
-            drained_bytes += sched->get_item_bytes(n->data);
+        if (get_bytes_snap && n->data) {
+            drained_bytes += get_bytes_snap(n->data);
         }
         consume(n->data, user);
         os_free(n);
@@ -611,9 +622,15 @@ int batch_queue_drop_agent(w_rr_queue_t *sched, const char *agent_key) {
     w_mutex_lock(&slot->q->mutex);
     w_mutex_unlock(&slot->q->mutex);
 
-    w_mutex_unlock(&sched->ring_mu); 
+    // Snapshot callbacks under ring_mu before releasing it. free_slot() will be
+    // called outside the lock, so reading sched->dispose / sched->get_item_bytes
+    // there without ring_mu would be a data race with their setters.
+    void (*const dispose_snap)(void *) = sched->dispose;
+    size_t (*const get_bytes_snap)(const void *) = sched->get_item_bytes;
+
+    w_mutex_unlock(&sched->ring_mu);
 
     // Outside the ring monitor: release resources and update global counters
-    free_slot(sched, slot, /*adjust_global=*/1);
+    free_slot(sched, slot, /*adjust_global=*/1, dispose_snap, get_bytes_snap);
     return 1;
 }

--- a/src/shared/src/batch_queue_op.c
+++ b/src/shared/src/batch_queue_op.c
@@ -163,14 +163,23 @@ static void free_slot(w_rr_queue_t *sched, w_rr_agent_slot_t *s, int adjust_glob
     w_linked_queue_node_t *chain = NULL;
     size_t n = steal_chain(s->q, &chain);
 
+    size_t freed_bytes = 0;
     while (chain) {
         w_linked_queue_node_t *nx = chain->next;
+        if (adjust_global && sched->get_item_bytes && chain->data) {
+            freed_bytes += sched->get_item_bytes(chain->data);
+        }
         if (sched->dispose) sched->dispose(chain->data);
         os_free(chain);
         chain = nx;
     }
-    if (adjust_global && n) {
-        atomic_fetch_sub_explicit(&sched->items_global, n, memory_order_relaxed);
+    if (adjust_global) {
+        if (n) {
+            atomic_fetch_sub_explicit(&sched->items_global, n, memory_order_relaxed);
+        }
+        if (freed_bytes) {
+            atomic_fetch_sub_explicit(&sched->bytes_global, freed_bytes, memory_order_relaxed);
+        }
     }
 
     linked_queue_free(s->q);
@@ -202,7 +211,10 @@ w_rr_queue_t *batch_queue_init(size_t max_items_global) {
     q->max_items_per_agent = 0;
     q->ring_slots = 0;
     atomic_store(&q->items_global, 0);
+    q->max_bytes_global = 0;
+    atomic_store(&q->bytes_global, 0);
     q->dispose = NULL;
+    q->get_item_bytes = NULL;
     return q;
 }
 
@@ -250,6 +262,26 @@ void batch_queue_set_agent_max(w_rr_queue_t *sched, size_t max_items_per_agent) 
     w_mutex_unlock(&sched->ring_mu);
 }
 
+/**
+ * @brief Set the global byte capacity limit (0 = unlimited).
+ */
+void batch_queue_set_bytes_limit(w_rr_queue_t *sched, size_t max_bytes) {
+    if (!sched) return;
+    w_mutex_lock(&sched->ring_mu);
+    sched->max_bytes_global = max_bytes;
+    w_mutex_unlock(&sched->ring_mu);
+}
+
+/**
+ * @brief Set the callback used to measure the byte size of an item.
+ */
+void batch_queue_set_get_item_bytes(w_rr_queue_t *sched, size_t (*get_bytes)(const void *)) {
+    if (!sched) return;
+    w_mutex_lock(&sched->ring_mu);
+    sched->get_item_bytes = get_bytes;
+    w_mutex_unlock(&sched->ring_mu);
+}
+
 // ======================= Enqueue (multi-producer) =======================
 //
 // Single monitor: ring_mu protects the index, ring, and slot lifecycles.
@@ -271,10 +303,36 @@ void batch_queue_set_agent_max(w_rr_queue_t *sched, size_t max_items_per_agent) 
 int batch_queue_enqueue_ex(w_rr_queue_t *sched, const char *agent_key, void *data) {
     if (!sched || !agent_key || !data) return -EINVAL;
 
-    // 0) Approximate global limit (lock-free). Roll back if later steps fail.
+    // 0) Approximate global limits (lock-free). Roll back if later steps fail.
+
+    // Byte tracking and optional limit enforcement, before taking any lock.
+    size_t item_bytes = 0;
+    if (sched->get_item_bytes) {
+        item_bytes = sched->get_item_bytes(data);
+        if (sched->max_bytes_global) {
+            if (item_bytes > sched->max_bytes_global) {
+                // Single oversized item can never fit.
+                if (sched->dispose) sched->dispose(data);
+                return -ENOSPC;
+            }
+            size_t prev_bytes = atomic_fetch_add_explicit(&sched->bytes_global, item_bytes, memory_order_relaxed);
+            if (prev_bytes + item_bytes > sched->max_bytes_global) {
+                atomic_fetch_sub_explicit(&sched->bytes_global, item_bytes, memory_order_relaxed);
+                if (sched->dispose) sched->dispose(data);
+                return -ENOSPC;
+            }
+        } else {
+            // No limit configured — just track bytes for observability.
+            atomic_fetch_add_explicit(&sched->bytes_global, item_bytes, memory_order_relaxed);
+        }
+    }
+
     size_t prev = atomic_fetch_add_explicit(&sched->items_global, 1, memory_order_relaxed);
     if (sched->max_items_global && prev + 1 > sched->max_items_global) {
         atomic_fetch_sub_explicit(&sched->items_global, 1, memory_order_relaxed);
+        if (item_bytes) {
+            atomic_fetch_sub_explicit(&sched->bytes_global, item_bytes, memory_order_relaxed);
+        }
         if (sched->dispose) sched->dispose(data);
         return -ENOSPC;
     }
@@ -291,6 +349,9 @@ int batch_queue_enqueue_ex(w_rr_queue_t *sched, const char *agent_key, void *dat
         if (!slot) {
             w_mutex_unlock(&sched->ring_mu);
             atomic_fetch_sub_explicit(&sched->items_global, 1, memory_order_relaxed);
+            if (item_bytes) {
+                atomic_fetch_sub_explicit(&sched->bytes_global, item_bytes, memory_order_relaxed);
+            }
             if (sched->dispose) sched->dispose(data);
             return -ENOMEM;
         }
@@ -298,6 +359,9 @@ int batch_queue_enqueue_ex(w_rr_queue_t *sched, const char *agent_key, void *dat
             w_mutex_unlock(&sched->ring_mu);
             free_slot(sched, slot, /*adjust_global=*/0);
             atomic_fetch_sub_explicit(&sched->items_global, 1, memory_order_relaxed);
+            if (item_bytes) {
+                atomic_fetch_sub_explicit(&sched->bytes_global, item_bytes, memory_order_relaxed);
+            }
             if (sched->dispose) sched->dispose(data);
             return -ENOMEM;
         }
@@ -324,6 +388,9 @@ int batch_queue_enqueue_ex(w_rr_queue_t *sched, const char *agent_key, void *dat
         if (!n) {
             w_mutex_unlock(&slot->q->mutex);
             atomic_fetch_sub_explicit(&sched->items_global, 1, memory_order_relaxed);
+            if (item_bytes) {
+                atomic_fetch_sub_explicit(&sched->bytes_global, item_bytes, memory_order_relaxed);
+            }
             if (sched->dispose) sched->dispose(data);
             return -ENOMEM;
         }
@@ -345,6 +412,9 @@ int batch_queue_enqueue_ex(w_rr_queue_t *sched, const char *agent_key, void *dat
 
     if (reject) {
         atomic_fetch_sub_explicit(&sched->items_global, 1, memory_order_relaxed);
+        if (item_bytes) {
+            atomic_fetch_sub_explicit(&sched->bytes_global, item_bytes, memory_order_relaxed);
+        }
         if (sched->dispose) sched->dispose(data);
         return -ENOSPC;
     }
@@ -418,17 +488,24 @@ size_t batch_queue_drain_next_ex(w_rr_queue_t *sched,
 
     // Process detached chain without any locks
     size_t drained = 0;
+    size_t drained_bytes = 0;
     for (w_linked_queue_node_t *n = head; n; ) {
         w_linked_queue_node_t *next = n->next;
         drained++;
+        if (sched->get_item_bytes && n->data) {
+            drained_bytes += sched->get_item_bytes(n->data);
+        }
         consume(n->data, user);
         os_free(n);
         n = next;
     }
 
-    // Adjust global items metric
+    // Adjust global counters
     if (drained) {
         atomic_fetch_sub_explicit(&sched->items_global, drained, memory_order_relaxed);
+    }
+    if (drained_bytes) {
+        atomic_fetch_sub_explicit(&sched->bytes_global, drained_bytes, memory_order_relaxed);
     }
 
     // If new items arrived meanwhile, producers have already re-appended this slot
@@ -456,6 +533,14 @@ int batch_queue_empty(const w_rr_queue_t *sched) {
 size_t batch_queue_size(const w_rr_queue_t *sched) {
     if (!sched) return 0;
     return atomic_load_explicit(&sched->items_global, memory_order_relaxed);
+}
+
+/**
+ * @brief Total bytes enqueued across all agents (approximate).
+ */
+size_t batch_queue_bytes(const w_rr_queue_t *sched) {
+    if (!sched) return 0;
+    return atomic_load_explicit(&sched->bytes_global, memory_order_relaxed);
 }
 
 /**

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -103,6 +103,9 @@ list(APPEND remoted_flags "-Wl,--wrap,rem_create_state_json -Wl,--wrap,OS_BindUn
                            -Wl,--wrap,assign_group_to_agent \
                            -Wl,--wrap,wdb_get_agents_ids_of_current_node -Wl,--wrap,json_parse_agents -Wl,--wrap,getpid -Wl,--wrap,w_query_agentd ${DEBUG_OP_WRAPPERS}")
 
+list(APPEND remoted_names "test_queue")
+list(APPEND remoted_flags "-Wl,--wrap,rem_inc_recv_discarded -Wl,--wrap,_mdebug2 -Wl,--wrap,_mwarn")
+
 list(LENGTH remoted_names count)
 math(EXPR count "${count} - 1")
 foreach(counter RANGE ${count})

--- a/src/unit_tests/remoted/test_queue.c
+++ b/src/unit_tests/remoted/test_queue.c
@@ -1,0 +1,304 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+/*
+ * Unit tests for the remoted input message queue (src/remoted/src/queue.c).
+ *
+ * Covers:
+ *  - basic push / pop (event-count limit)
+ *  - byte-limit enforcement (queue_max_bytes)
+ *  - oversized individual events
+ *  - byte quota recovery after dequeue
+ *  - concurrent producers and consumer
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#include "remoted.h"   /* rem_msginit, rem_msgpush, rem_msgpop, rem_msgfree,
+                        * rem_set_input_queue_max_bytes */
+#include "state.h"     /* rem_inc_recv_discarded */
+
+/* ── Mocks ────────────────────────────────────────────────────────────────── */
+
+/*
+ * Atomic counter instead of cmocka's function_called() so that the concurrent
+ * test can trigger arbitrary discards (transient retries) without pre-declaring
+ * every expected call.
+ */
+static atomic_int g_discard_count;
+
+void __wrap_rem_inc_recv_discarded(void) {
+    atomic_fetch_add(&g_discard_count, 1);
+}
+
+/* Suppress debug/warn output */
+void __wrap__mdebug2(const char *msg, ...) { (void)msg; }
+void __wrap__mwarn(const char *msg, ...)   { (void)msg; }
+
+/* global_counter is referenced by queue.c */
+size_t global_counter = 0;
+
+/* ── Helpers ──────────────────────────────────────────────────────────────── */
+
+static struct sockaddr_storage dummy_addr(void) {
+    struct sockaddr_storage addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.ss_family = AF_INET;
+    return addr;
+}
+
+/* ── Setup / Teardown ─────────────────────────────────────────────────────── */
+
+static int setup(void **state) {
+    (void)state;
+    global_counter = 0;
+    atomic_store(&g_discard_count, 0);
+    /* Re-initialize a small queue (8 slots → fits 7 messages) */
+    rem_msginit(8);
+    /* Disable the byte limit; individual tests override this */
+    rem_set_input_queue_max_bytes(0);
+    return 0;
+}
+
+static int teardown(void **state) {
+    (void)state;
+    rem_msgdestroy();
+    return 0;
+}
+
+/* ── Test cases ───────────────────────────────────────────────────────────── */
+
+/* Basic push and pop without any byte limit */
+static void test_basic_push_pop(void **state) {
+    (void)state;
+
+    struct sockaddr_storage addr = dummy_addr();
+    const char payload[] = "hello";
+
+    int rc = rem_msgpush(payload, sizeof(payload) - 1, &addr, 1);
+    assert_int_equal(0, rc);
+
+    message_t *msg = rem_msgpop();
+    assert_non_null(msg);
+    assert_int_equal((int)(sizeof(payload) - 1), (int)msg->size);
+    assert_memory_equal(payload, msg->buffer, msg->size);
+    rem_msgfree(msg);
+
+    assert_int_equal(0, atomic_load(&g_discard_count));
+}
+
+/* Event-count limit: 8-slot queue holds at most 7 messages */
+static void test_event_count_limit(void **state) {
+    (void)state;
+
+    struct sockaddr_storage addr = dummy_addr();
+    const char payload[] = "x";
+    int rc;
+
+    /* Fill 7 slots */
+    for (int i = 0; i < 7; i++) {
+        rc = rem_msgpush(payload, 1, &addr, 1);
+        assert_int_equal(0, rc);
+    }
+
+    /* 8th push must fail (queue full) */
+    rc = rem_msgpush(payload, 1, &addr, 1);
+    assert_int_equal(-1, rc);
+    assert_int_equal(1, atomic_load(&g_discard_count));
+
+    /* Drain */
+    for (int i = 0; i < 7; i++) {
+        message_t *msg = rem_msgpop();
+        assert_non_null(msg);
+        rem_msgfree(msg);
+    }
+}
+
+/* Byte limit: quota exhausted → new events are discarded */
+static void test_byte_limit_exhausted_discards(void **state) {
+    (void)state;
+
+    rem_set_input_queue_max_bytes(20); /* 20-byte total cap */
+
+    struct sockaddr_storage addr = dummy_addr();
+
+    /* 10 bytes → fits */
+    int rc = rem_msgpush("0123456789", 10, &addr, 1);
+    assert_int_equal(0, rc);
+
+    /* another 10 bytes → exactly fills the quota */
+    rc = rem_msgpush("abcdefghij", 10, &addr, 1);
+    assert_int_equal(0, rc);
+
+    /* 1 more byte → quota exceeded → discarded */
+    rc = rem_msgpush("!", 1, &addr, 1);
+    assert_int_equal(-1, rc);
+    assert_int_equal(1, atomic_load(&g_discard_count));
+
+    /* Drain */
+    for (int i = 0; i < 2; i++) {
+        message_t *msg = rem_msgpop();
+        assert_non_null(msg);
+        rem_msgfree(msg);
+    }
+}
+
+/* Oversized event: a single message larger than max_bytes is rejected */
+static void test_byte_limit_oversized_event_rejected(void **state) {
+    (void)state;
+
+    rem_set_input_queue_max_bytes(5); /* only 5-byte cap */
+
+    struct sockaddr_storage addr = dummy_addr();
+
+    /* 6-byte message exceeds the entire limit → rejected */
+    int rc = rem_msgpush("123456", 6, &addr, 1);
+    assert_int_equal(-1, rc);
+    assert_int_equal(1, atomic_load(&g_discard_count));
+
+    /* Queue must still be empty; a small message still fits */
+    rc = rem_msgpush("AB", 2, &addr, 1);
+    assert_int_equal(0, rc);
+
+    message_t *msg = rem_msgpop();
+    assert_non_null(msg);
+    assert_int_equal(2, (int)msg->size);
+    rem_msgfree(msg);
+}
+
+/* Byte quota recovery: after popping an event its bytes are freed */
+static void test_byte_limit_recovery_after_dequeue(void **state) {
+    (void)state;
+
+    rem_set_input_queue_max_bytes(10);
+
+    struct sockaddr_storage addr = dummy_addr();
+
+    /* Push exactly to the limit */
+    assert_int_equal(0, rem_msgpush("1234567890", 10, &addr, 1));
+
+    /* Next push must fail */
+    assert_int_equal(-1, rem_msgpush("x", 1, &addr, 1));
+    assert_int_equal(1, atomic_load(&g_discard_count));
+
+    /* Pop frees 10 bytes */
+    message_t *msg = rem_msgpop();
+    assert_non_null(msg);
+    rem_msgfree(msg);
+
+    /* Now a 7-byte message fits */
+    assert_int_equal(0, rem_msgpush("abcdefg", 7, &addr, 1));
+
+    msg = rem_msgpop();
+    assert_non_null(msg);
+    assert_int_equal(7, (int)msg->size);
+    rem_msgfree(msg);
+}
+
+/* ── Concurrent producers / consumer ─────────────────────────────────────── */
+
+#define CONCURRENT_ITEMS   200
+#define CONCURRENT_THREADS 4
+#define PAYLOAD_SIZE       8
+/* Byte cap: holds ~50 messages at a time so producers must retry */
+#define CONCURRENT_BYTE_CAP (50 * PAYLOAD_SIZE)
+
+static atomic_int concurrent_produced;
+static atomic_int concurrent_consumed;
+
+static void *concurrent_producer(void *arg) {
+    (void)arg;
+    struct sockaddr_storage addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.ss_family = AF_INET;
+
+    char payload[PAYLOAD_SIZE];
+    memset(payload, 'x', PAYLOAD_SIZE);
+
+    for (int i = 0; i < CONCURRENT_ITEMS; i++) {
+        int rc;
+        /* Retry until accepted; byte or count quota may be temporarily full */
+        do {
+            rc = rem_msgpush(payload, PAYLOAD_SIZE, &addr, 1);
+        } while (rc != 0);
+        atomic_fetch_add(&concurrent_produced, 1);
+    }
+    return NULL;
+}
+
+static void *concurrent_consumer(void *arg) {
+    int total = *(int *)arg;
+    int consumed = 0;
+    while (consumed < total) {
+        message_t *msg = rem_msgpop();
+        if (msg) {
+            rem_msgfree(msg);
+            consumed++;
+            atomic_fetch_add(&concurrent_consumed, 1);
+        }
+    }
+    return NULL;
+}
+
+static int setup_concurrent(void **state) {
+    (void)state;
+    global_counter = 0;
+    atomic_store(&g_discard_count, 0);
+    atomic_store(&concurrent_produced, 0);
+    atomic_store(&concurrent_consumed, 0);
+    /* Larger queue to reduce count-limit contention */
+    rem_msginit(256);
+    rem_set_input_queue_max_bytes(CONCURRENT_BYTE_CAP);
+    return 0;
+}
+
+static void test_concurrent_producers_consumer(void **state) {
+    (void)state;
+
+    int total_expected = CONCURRENT_THREADS * CONCURRENT_ITEMS;
+
+    pthread_t producers[CONCURRENT_THREADS];
+    pthread_t consumer;
+
+    pthread_create(&consumer, NULL, concurrent_consumer, &total_expected);
+    for (int i = 0; i < CONCURRENT_THREADS; i++) {
+        pthread_create(&producers[i], NULL, concurrent_producer, NULL);
+    }
+    for (int i = 0; i < CONCURRENT_THREADS; i++) {
+        pthread_join(producers[i], NULL);
+    }
+    pthread_join(consumer, NULL);
+
+    assert_int_equal(total_expected, atomic_load(&concurrent_produced));
+    assert_int_equal(total_expected, atomic_load(&concurrent_consumed));
+}
+
+/* ── Test Suite ───────────────────────────────────────────────────────────── */
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_basic_push_pop,                      setup, teardown),
+        cmocka_unit_test_setup_teardown(test_event_count_limit,                   setup, teardown),
+        cmocka_unit_test_setup_teardown(test_byte_limit_exhausted_discards,       setup, teardown),
+        cmocka_unit_test_setup_teardown(test_byte_limit_oversized_event_rejected, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_byte_limit_recovery_after_dequeue,   setup, teardown),
+        cmocka_unit_test_setup_teardown(test_concurrent_producers_consumer, setup_concurrent, teardown),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/remoted/test_remote-config.c
+++ b/src/unit_tests/remoted/test_remote-config.c
@@ -333,6 +333,8 @@ static void test_remoted_internal_options_config(void **state) {
     will_return(__wrap_getDefine_Int_default, 107);    // _s_verify_counter
     will_return(__wrap_getDefine_Int_default, 109);    // batch_events_capacity
     will_return(__wrap_getDefine_Int_default, 113);    // batch_events_per_agent_capacity
+    will_return(__wrap_getDefine_Int_default, 1031);   // queue_max_bytes (prime >= 1024 to pass validation)
+    will_return(__wrap_getDefine_Int_default, 1033);   // batch_events_max_bytes (prime >= 1024 to pass validation)
     will_return(__wrap_getDefine_Int_default, 127);    // enrich_cache_expire_time
 
     // Mock ReadConfig calls
@@ -392,6 +394,8 @@ static void test_remoted_internal_options_config(void **state) {
     assert_int_equal(cJSON_GetObjectItem(remoted_obj, "verify_msg_id")->valueint, 107);
     assert_int_equal(cJSON_GetObjectItem(remoted_obj, "batch_events_capacity")->valueint, 109);
     assert_int_equal(cJSON_GetObjectItem(remoted_obj, "batch_events_per_agent_capacity")->valueint, 113);
+    assert_int_equal(cJSON_GetObjectItem(remoted_obj, "queue_max_bytes")->valueint, 1031);
+    assert_int_equal(cJSON_GetObjectItem(remoted_obj, "batch_events_max_bytes")->valueint, 1033);
     assert_int_equal(cJSON_GetObjectItem(remoted_obj, "enrich_cache_expire_time")->valueint, 127);
 
     cJSON_Delete(json);

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -1291,7 +1291,8 @@ void test_HandleSecureMessage_close_idle_sock(void** state)
     expect_string(__wrap_batch_queue_enqueue_ex, agent_key, "001");
     expect_any(__wrap_batch_queue_enqueue_ex, data);
     will_return(__wrap_batch_queue_enqueue_ex, -1);
-    expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '001' (rc=-1)");
+    expect_value(__wrap_time, time, NULL);
+    will_return(__wrap_time, 0);
     expect_function_call(__wrap_rem_inc_recv_events_failed);
 
     HandleSecureMessage(&message, control_msg_queue, events_queue);
@@ -1387,7 +1388,8 @@ void test_HandleSecureMessage_close_idle_sock_2(void** state)
     expect_string(__wrap_batch_queue_enqueue_ex, agent_key, "001");
     expect_any(__wrap_batch_queue_enqueue_ex, data);
     will_return(__wrap_batch_queue_enqueue_ex, -1);
-    expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '001' (rc=-1)");
+    expect_value(__wrap_time, time, NULL);
+    will_return(__wrap_time, 0);
     expect_function_call(__wrap_rem_inc_recv_events_failed);
 
     HandleSecureMessage(&message, control_msg_queue, events_queue);
@@ -1978,7 +1980,8 @@ void test_HandleSecureMessage_close_same_sock(void** state)
     expect_string(__wrap_batch_queue_enqueue_ex, agent_key, "001");
     expect_any(__wrap_batch_queue_enqueue_ex, data);
     will_return(__wrap_batch_queue_enqueue_ex, -1);
-    expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '001' (rc=-1)");
+    expect_value(__wrap_time, time, NULL);
+    will_return(__wrap_time, 0);
     expect_function_call(__wrap_rem_inc_recv_events_failed);
 
     HandleSecureMessage(&message, control_msg_queue, events_queue);
@@ -2053,7 +2056,8 @@ void test_HandleSecureMessage_close_same_sock_2(void** state)
     expect_string(__wrap_batch_queue_enqueue_ex, agent_key, "001");
     expect_any(__wrap_batch_queue_enqueue_ex, data);
     will_return(__wrap_batch_queue_enqueue_ex, -1);
-    expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '001' (rc=-1)");
+    expect_value(__wrap_time, time, NULL);
+    will_return(__wrap_time, 0);
     expect_function_call(__wrap_rem_inc_recv_events_failed);
 
     HandleSecureMessage(&message, control_msg_queue, events_queue);
@@ -2205,7 +2209,8 @@ void test_HandleSecureMessage_router_forwarding_upgrade_ack_no_handle(void** sta
     expect_string(__wrap_batch_queue_enqueue_ex, agent_key, "001");
     expect_any(__wrap_batch_queue_enqueue_ex, data);
     will_return(__wrap_batch_queue_enqueue_ex, -1);
-    expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '001' (rc=-1)");
+    expect_value(__wrap_time, time, NULL);
+    will_return(__wrap_time, 0);
     expect_function_call(__wrap_rem_inc_recv_events_failed);
 
     HandleSecureMessage(&message, control_msg_queue, events_queue);
@@ -2282,7 +2287,8 @@ void test_HandleSecureMessage_router_forwarding_upgrade_ack_invalid_json(void** 
     expect_string(__wrap_batch_queue_enqueue_ex, agent_key, "001");
     expect_any(__wrap_batch_queue_enqueue_ex, data);
     will_return(__wrap_batch_queue_enqueue_ex, -1);
-    expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '001' (rc=-1)");
+    expect_value(__wrap_time, time, NULL);
+    will_return(__wrap_time, 0);
     expect_function_call(__wrap_rem_inc_recv_events_failed);
 
     HandleSecureMessage(&message, control_msg_queue, events_queue);
@@ -2360,7 +2366,8 @@ void test_HandleSecureMessage_router_forwarding_upgrade_ack_json_without_paramet
     expect_string(__wrap_batch_queue_enqueue_ex, agent_key, "001");
     expect_any(__wrap_batch_queue_enqueue_ex, data);
     will_return(__wrap_batch_queue_enqueue_ex, -1);
-    expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '001' (rc=-1)");
+    expect_value(__wrap_time, time, NULL);
+    will_return(__wrap_time, 0);
     expect_function_call(__wrap_rem_inc_recv_events_failed);
 
     HandleSecureMessage(&message, control_msg_queue, events_queue);
@@ -2444,7 +2451,8 @@ void test_HandleSecureMessage_router_forwarding_upgrade_ack_send_failed(void** s
     expect_string(__wrap_batch_queue_enqueue_ex, agent_key, "042");
     expect_any(__wrap_batch_queue_enqueue_ex, data);
     will_return(__wrap_batch_queue_enqueue_ex, -1);
-    expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '042' (rc=-1)");
+    expect_value(__wrap_time, time, NULL);
+    will_return(__wrap_time, 0);
     expect_function_call(__wrap_rem_inc_recv_events_failed);
 
     HandleSecureMessage(&message, control_msg_queue, events_queue);
@@ -2524,7 +2532,8 @@ void test_HandleSecureMessage_router_forwarding_disabled(void** state)
     expect_string(__wrap_batch_queue_enqueue_ex, agent_key, "001");
     expect_any(__wrap_batch_queue_enqueue_ex, data);
     will_return(__wrap_batch_queue_enqueue_ex, -1);
-    expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '001' (rc=-1)");
+    expect_value(__wrap_time, time, NULL);
+    will_return(__wrap_time, 0);
     expect_function_call(__wrap_rem_inc_recv_events_failed);
 
     HandleSecureMessage(&message, control_msg_queue, events_queue);
@@ -2690,7 +2699,8 @@ void test_HandleSecureMessage_event_without_trailing_null(void** state)
     expect_string(__wrap_batch_queue_enqueue_ex, agent_key, "001");
     expect_check(__wrap_batch_queue_enqueue_ex, data, check_evt_item_sentinel, NULL);
     will_return(__wrap_batch_queue_enqueue_ex, -1);
-    expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '001' (rc=-1)");
+    expect_value(__wrap_time, time, NULL);
+    will_return(__wrap_time, 0);
     expect_function_call(__wrap_rem_inc_recv_events_failed);
 
     HandleSecureMessage(&message, control_msg_queue, events_queue);
@@ -2863,7 +2873,8 @@ void test_HandleSecureMessage_event_with_trailing_null(void** state)
     expect_string(__wrap_batch_queue_enqueue_ex, agent_key, "001");
     expect_check(__wrap_batch_queue_enqueue_ex, data, check_evt_item_trimmed, NULL);
     will_return(__wrap_batch_queue_enqueue_ex, -1);
-    expect_string(__wrap__mwarn, formatted_msg, "Dropping event for agent '001' (rc=-1)");
+    expect_value(__wrap_time, time, NULL);
+    will_return(__wrap_time, 0);
     expect_function_call(__wrap_rem_inc_recv_events_failed);
 
     HandleSecureMessage(&message, control_msg_queue, events_queue);

--- a/src/unit_tests/shared/test_batch_queue_op.c
+++ b/src/unit_tests/shared/test_batch_queue_op.c
@@ -269,6 +269,249 @@ static void test_ring_slots_zero_after_last_removal(void **state) {
     assert_int_equal(0, (int)batch_queue_ring_size(q));
 }
 
+/* ====================== Byte-limit helpers ====================== */
+
+typedef struct {
+    int  v;
+    size_t sz; ///< Byte size reported to the scheduler
+} sized_payload_t;
+
+static sized_payload_t *make_sized(int v, size_t sz) {
+    sized_payload_t *p = (sized_payload_t *)malloc(sizeof(sized_payload_t));
+    assert_non_null(p);
+    p->v  = v;
+    p->sz = sz;
+    return p;
+}
+
+static size_t get_bytes_cb(const void *data) {
+    const sized_payload_t *p = (const sized_payload_t *)data;
+    return p ? p->sz : 0;
+}
+
+static void dispose_sized(void *x) {
+    if (x) { ++g_disposed; free(x); }
+}
+
+static void consumer_sized(void *data, void *user) {
+    (void)user;
+    assert_true(consumed_n < MAX_CONSUMED);
+    sized_payload_t *p = (sized_payload_t *)data;
+    consumed_vals[consumed_n++] = p->v;
+    free(p);
+}
+
+/* ====================== Byte-limit test cases ====================== */
+
+/*
+ * Byte limit reached:
+ * - queue created with max_bytes = 100
+ * - first two items (40 + 60 bytes) fit exactly
+ * - third item is rejected with -ENOSPC and disposed
+ * - batch_queue_bytes() reflects the accumulated usage
+ */
+static void test_byte_limit_global_rejects_extra(void **state) {
+    (void)state;
+
+    w_rr_queue_t *q = batch_queue_init(/*max_items_global=*/0);
+    assert_non_null(q);
+    batch_queue_set_dispose(q, dispose_sized);
+    batch_queue_set_get_item_bytes(q, get_bytes_cb);
+    batch_queue_set_bytes_limit(q, 100);
+
+    g_disposed = 0;
+
+    expect_value(__wrap_pthread_cond_signal, cond, &q->any_available);
+    assert_int_equal(0, batch_queue_enqueue_ex(q, "agent/A", make_sized(1, 40)));
+    assert_int_equal(40, (int)batch_queue_bytes(q));
+
+    expect_value(__wrap_pthread_cond_signal, cond, &q->any_available);
+    assert_int_equal(0, batch_queue_enqueue_ex(q, "agent/B", make_sized(2, 60)));
+    assert_int_equal(100, (int)batch_queue_bytes(q));
+
+    /* Third item exceeds byte quota → disposed, no signal */
+    int rc = batch_queue_enqueue_ex(q, "agent/C", make_sized(3, 1));
+    assert_int_equal(-ENOSPC, rc);
+    assert_int_equal(1, g_disposed);
+    assert_int_equal(100, (int)batch_queue_bytes(q)); /* unchanged */
+
+    batch_queue_free(q);
+}
+
+/*
+ * Oversized individual event:
+ * - single item whose byte size exceeds the configured limit is rejected
+ * - byte counter remains 0 after rejection
+ */
+static void test_byte_limit_oversized_item_rejected(void **state) {
+    (void)state;
+
+    w_rr_queue_t *q = batch_queue_init(/*max_items_global=*/0);
+    assert_non_null(q);
+    batch_queue_set_dispose(q, dispose_sized);
+    batch_queue_set_get_item_bytes(q, get_bytes_cb);
+    batch_queue_set_bytes_limit(q, 50);
+
+    g_disposed = 0;
+
+    /* Item of 51 bytes is larger than the limit (50) → rejected immediately */
+    int rc = batch_queue_enqueue_ex(q, "agent/A", make_sized(1, 51));
+    assert_int_equal(-ENOSPC, rc);
+    assert_int_equal(1, g_disposed);
+    assert_int_equal(0, (int)batch_queue_bytes(q));
+
+    batch_queue_free(q);
+}
+
+/*
+ * Byte quota recovery after dequeue:
+ * - fill the queue to its byte limit
+ * - drain one item to free its bytes
+ * - a previously-rejected item can now be enqueued
+ */
+static void test_byte_limit_recovers_after_drain(void **state) {
+    (void)state;
+
+    w_rr_queue_t *q = batch_queue_init(/*max_items_global=*/0);
+    assert_non_null(q);
+    batch_queue_set_dispose(q, dispose_sized);
+    batch_queue_set_get_item_bytes(q, get_bytes_cb);
+    batch_queue_set_bytes_limit(q, 100);
+
+    g_disposed = 0;
+    reset_consumed();
+
+    /* Fill exactly to the limit */
+    expect_value(__wrap_pthread_cond_signal, cond, &q->any_available);
+    assert_int_equal(0, batch_queue_enqueue_ex(q, "agent/A", make_sized(1, 60)));
+    expect_value(__wrap_pthread_cond_signal, cond, &q->any_available);
+    assert_int_equal(0, batch_queue_enqueue_ex(q, "agent/B", make_sized(2, 40)));
+    assert_int_equal(100, (int)batch_queue_bytes(q));
+
+    /* Byte quota full — 41-byte item cannot fit */
+    int rc = batch_queue_enqueue_ex(q, "agent/C", make_sized(3, 41));
+    assert_int_equal(-ENOSPC, rc);
+    assert_int_equal(1, g_disposed);
+
+    /* Drain agent/A (60 bytes) */
+    const char *agent = NULL;
+    (void)batch_queue_drain_next_ex(q, NULL, consumer_sized, NULL, &agent);
+    assert_int_equal(40, (int)batch_queue_bytes(q)); /* 100 - 60 */
+
+    /* Now the 41-byte item fits */
+    expect_value(__wrap_pthread_cond_signal, cond, &q->any_available);
+    assert_int_equal(0, batch_queue_enqueue_ex(q, "agent/C", make_sized(4, 41)));
+    assert_int_equal(81, (int)batch_queue_bytes(q)); /* 40 + 41 */
+
+    batch_queue_free(q);
+}
+
+/*
+ * Drop-agent adjusts the byte counter:
+ * - enqueue one item for an agent
+ * - drop the agent; bytes_global must return to 0
+ */
+static void test_byte_limit_drop_agent_releases_bytes(void **state) {
+    (void)state;
+
+    w_rr_queue_t *q = batch_queue_init(/*max_items_global=*/0);
+    assert_non_null(q);
+    batch_queue_set_dispose(q, dispose_sized);
+    batch_queue_set_get_item_bytes(q, get_bytes_cb);
+    batch_queue_set_bytes_limit(q, 200);
+
+    g_disposed = 0;
+
+    expect_value(__wrap_pthread_cond_signal, cond, &q->any_available);
+    assert_int_equal(0, batch_queue_enqueue_ex(q, "agent/Z", make_sized(7, 75)));
+    assert_int_equal(75, (int)batch_queue_bytes(q));
+
+    assert_int_equal(1, batch_queue_drop_agent(q, "agent/Z"));
+    assert_int_equal(1, g_disposed);
+    assert_int_equal(0, (int)batch_queue_bytes(q));
+
+    batch_queue_free(q);
+}
+
+/*
+ * Byte limit and item-count limit coexist:
+ * - scheduler created with max_items_global = 2 AND max_bytes = 100
+ * - item-count limit triggers before byte limit is exhausted
+ */
+static void test_byte_limit_and_item_count_limit_coexist(void **state) {
+    (void)state;
+
+    w_rr_queue_t *q = batch_queue_init(/*max_items_global=*/2);
+    assert_non_null(q);
+    batch_queue_set_dispose(q, dispose_sized);
+    batch_queue_set_get_item_bytes(q, get_bytes_cb);
+    batch_queue_set_bytes_limit(q, 100);
+
+    g_disposed = 0;
+
+    expect_value(__wrap_pthread_cond_signal, cond, &q->any_available);
+    assert_int_equal(0, batch_queue_enqueue_ex(q, "agent/A", make_sized(1, 10)));
+    expect_value(__wrap_pthread_cond_signal, cond, &q->any_available);
+    assert_int_equal(0, batch_queue_enqueue_ex(q, "agent/B", make_sized(2, 10)));
+
+    /* Item count (2) is reached; byte quota (20/100) is NOT exhausted */
+    int rc = batch_queue_enqueue_ex(q, "agent/C", make_sized(3, 5));
+    assert_int_equal(-ENOSPC, rc);
+    assert_int_equal(1, g_disposed);
+    assert_int_equal(20, (int)batch_queue_bytes(q)); /* unchanged */
+
+    batch_queue_free(q);
+}
+
+/*
+ * Byte counter stays consistent across many enqueue/drop cycles (simulates
+ * the producer/consumer pattern that real concurrent code would exercise):
+ * - enqueue N items for two agents, drop one agent, drain the other
+ * - after all operations the byte counter must reach 0
+ *
+ * Note: the unit-test framework replaces pthread primitives with no-op stubs
+ * so real multi-threaded tests cannot be conducted here.  The interleaving
+ * below exercises the atomic byte accounting paths without spawning threads.
+ */
+static void test_byte_counter_consistent_enqueue_drop_drain(void **state) {
+    (void)state;
+
+    w_rr_queue_t *q = batch_queue_init(/*max_items_global=*/0);
+    assert_non_null(q);
+    batch_queue_set_dispose(q, dispose_sized);
+    batch_queue_set_get_item_bytes(q, get_bytes_cb);
+
+    g_disposed = 0;
+    reset_consumed();
+
+    /* Enqueue 3 items for agent/A (10 bytes each) and 2 for agent/B (25 bytes each) */
+    expect_value(__wrap_pthread_cond_signal, cond, &q->any_available);
+    assert_int_equal(0, batch_queue_enqueue_ex(q, "agent/A", make_sized(1, 10)));
+    assert_int_equal(0, batch_queue_enqueue_ex(q, "agent/A", make_sized(2, 10)));
+    assert_int_equal(0, batch_queue_enqueue_ex(q, "agent/A", make_sized(3, 10)));
+
+    expect_value(__wrap_pthread_cond_signal, cond, &q->any_available);
+    assert_int_equal(0, batch_queue_enqueue_ex(q, "agent/B", make_sized(4, 25)));
+    assert_int_equal(0, batch_queue_enqueue_ex(q, "agent/B", make_sized(5, 25)));
+
+    assert_int_equal(80, (int)batch_queue_bytes(q)); /* 3*10 + 2*25 */
+    assert_int_equal(5, (int)batch_queue_size(q));
+
+    /* Drop agent/B (2 * 25 = 50 bytes freed) */
+    assert_int_equal(1, batch_queue_drop_agent(q, "agent/B"));
+    assert_int_equal(2, g_disposed);
+    assert_int_equal(30, (int)batch_queue_bytes(q)); /* 80 - 50 */
+    assert_int_equal(3, (int)batch_queue_size(q));
+
+    /* Drain agent/A (3 * 10 = 30 bytes freed) */
+    size_t drained = batch_queue_drain_next_ex(q, NULL, consumer_sized, NULL, NULL);
+    assert_int_equal(3, (int)drained);
+    assert_int_equal(0, (int)batch_queue_bytes(q));
+    assert_int_equal(0, (int)batch_queue_size(q));
+
+    batch_queue_free(q);
+}
+
 /* ================================ Test Suite ================================ */
 
 int main(void) {
@@ -281,6 +524,13 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_drop_agent_removes_and_frees, setup_sched, teardown_sched),
         cmocka_unit_test_setup_teardown(test_enqueue_invalid_args, setup_sched, teardown_sched),
         cmocka_unit_test_setup_teardown(test_ring_slots_zero_after_last_removal, setup_sched, teardown_sched),
+        /* Byte-limit tests */
+        cmocka_unit_test(test_byte_limit_global_rejects_extra),
+        cmocka_unit_test(test_byte_limit_oversized_item_rejected),
+        cmocka_unit_test(test_byte_limit_recovers_after_drain),
+        cmocka_unit_test(test_byte_limit_drop_agent_releases_bytes),
+        cmocka_unit_test(test_byte_limit_and_item_count_limit_coexist),
+        cmocka_unit_test(test_byte_counter_consistent_enqueue_drop_drain),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/shared/test_batch_queue_op.c
+++ b/src/unit_tests/shared/test_batch_queue_op.c
@@ -159,7 +159,7 @@ static void test_enqueue_two_agents_round_robin_and_drain(void **state) {
  * Per-agent capacity:
  * - set cap to 1 for agent/C
  * - first enqueue succeeds and signals
- * - second enqueue is rejected with -ENOSPC and the payload is disposed
+ * - second enqueue is rejected with -ENOSPC; caller retains ownership and frees it
  * - draining consumes the single allowed item
  */
 static void test_per_agent_cap_and_dispose(void **state) {
@@ -172,10 +172,12 @@ static void test_per_agent_cap_and_dispose(void **state) {
     expect_value(__wrap_pthread_cond_signal, cond, &q->any_available);
     assert_int_equal(0, batch_queue_enqueue_ex(q, "agent/C", make_payload(10)));
 
-    /* this one is rejected due to per-agent cap → no signal */
-    int rc = batch_queue_enqueue_ex(q, "agent/C", make_payload(11));
+    /* this one is rejected due to per-agent cap → no signal, caller owns it */
+    payload_t *rejected = make_payload(11);
+    int rc = batch_queue_enqueue_ex(q, "agent/C", rejected);
     assert_int_equal(-ENOSPC, rc);
-    assert_int_equal(1, g_disposed);
+    assert_int_equal(0, g_disposed); /* queue must NOT call dispose on rejection */
+    free(rejected);                  /* caller retains ownership → free manually */
 
     const char *agent = NULL;
     size_t n = batch_queue_drain_next_ex(q, NULL, consumer_append, NULL, &agent);
@@ -201,9 +203,11 @@ static void test_global_cap_rejects_extra(void **state) {
     expect_value(__wrap_pthread_cond_signal, cond, &q->any_available);
     assert_int_equal(0, batch_queue_enqueue_ex(q, "agent/B", make_payload(2)));
 
-    /* exceeds global cap → no signal, returns -ENOSPC */
-    int rc = batch_queue_enqueue_ex(q, "agent/C", make_payload(3));
+    /* exceeds global cap → no signal, returns -ENOSPC; caller retains ownership */
+    payload_t *rejected = make_payload(3);
+    int rc = batch_queue_enqueue_ex(q, "agent/C", rejected);
     assert_int_equal(-ENOSPC, rc);
+    free(rejected);
 
     batch_queue_free(q);
 }
@@ -307,7 +311,7 @@ static void consumer_sized(void *data, void *user) {
  * Byte limit reached:
  * - queue created with max_bytes = 100
  * - first two items (40 + 60 bytes) fit exactly
- * - third item is rejected with -ENOSPC and disposed
+ * - third item is rejected with -ENOSPC; caller retains ownership and frees it
  * - batch_queue_bytes() reflects the accumulated usage
  */
 static void test_byte_limit_global_rejects_extra(void **state) {
@@ -329,11 +333,13 @@ static void test_byte_limit_global_rejects_extra(void **state) {
     assert_int_equal(0, batch_queue_enqueue_ex(q, "agent/B", make_sized(2, 60)));
     assert_int_equal(100, (int)batch_queue_bytes(q));
 
-    /* Third item exceeds byte quota → disposed, no signal */
-    int rc = batch_queue_enqueue_ex(q, "agent/C", make_sized(3, 1));
+    /* Third item exceeds byte quota → rejected, no signal; caller retains ownership */
+    sized_payload_t *rejected = make_sized(3, 1);
+    int rc = batch_queue_enqueue_ex(q, "agent/C", rejected);
     assert_int_equal(-ENOSPC, rc);
-    assert_int_equal(1, g_disposed);
+    assert_int_equal(0, g_disposed); /* queue must NOT call dispose on rejection */
     assert_int_equal(100, (int)batch_queue_bytes(q)); /* unchanged */
+    free(rejected);
 
     batch_queue_free(q);
 }
@@ -354,11 +360,13 @@ static void test_byte_limit_oversized_item_rejected(void **state) {
 
     g_disposed = 0;
 
-    /* Item of 51 bytes is larger than the limit (50) → rejected immediately */
-    int rc = batch_queue_enqueue_ex(q, "agent/A", make_sized(1, 51));
+    /* Item of 51 bytes is larger than the limit (50) → rejected; caller retains ownership */
+    sized_payload_t *rejected = make_sized(1, 51);
+    int rc = batch_queue_enqueue_ex(q, "agent/A", rejected);
     assert_int_equal(-ENOSPC, rc);
-    assert_int_equal(1, g_disposed);
+    assert_int_equal(0, g_disposed); /* queue must NOT call dispose on rejection */
     assert_int_equal(0, (int)batch_queue_bytes(q));
+    free(rejected);
 
     batch_queue_free(q);
 }
@@ -388,10 +396,12 @@ static void test_byte_limit_recovers_after_drain(void **state) {
     assert_int_equal(0, batch_queue_enqueue_ex(q, "agent/B", make_sized(2, 40)));
     assert_int_equal(100, (int)batch_queue_bytes(q));
 
-    /* Byte quota full — 41-byte item cannot fit */
-    int rc = batch_queue_enqueue_ex(q, "agent/C", make_sized(3, 41));
+    /* Byte quota full — 41-byte item cannot fit; caller retains ownership */
+    sized_payload_t *rejected = make_sized(3, 41);
+    int rc = batch_queue_enqueue_ex(q, "agent/C", rejected);
     assert_int_equal(-ENOSPC, rc);
-    assert_int_equal(1, g_disposed);
+    assert_int_equal(0, g_disposed); /* queue must NOT call dispose on rejection */
+    free(rejected);
 
     /* Drain agent/A (60 bytes) */
     const char *agent = NULL;
@@ -454,11 +464,13 @@ static void test_byte_limit_and_item_count_limit_coexist(void **state) {
     expect_value(__wrap_pthread_cond_signal, cond, &q->any_available);
     assert_int_equal(0, batch_queue_enqueue_ex(q, "agent/B", make_sized(2, 10)));
 
-    /* Item count (2) is reached; byte quota (20/100) is NOT exhausted */
-    int rc = batch_queue_enqueue_ex(q, "agent/C", make_sized(3, 5));
+    /* Item count (2) is reached; byte quota (20/100) is NOT exhausted; caller retains ownership */
+    sized_payload_t *rejected = make_sized(3, 5);
+    int rc = batch_queue_enqueue_ex(q, "agent/C", rejected);
     assert_int_equal(-ENOSPC, rc);
-    assert_int_equal(1, g_disposed);
+    assert_int_equal(0, g_disposed); /* queue must NOT call dispose on rejection */
     assert_int_equal(20, (int)batch_queue_bytes(q)); /* unchanged */
+    free(rejected);
 
     batch_queue_free(q);
 }


### PR DESCRIPTION
## Description

Prior to this change, the remoted input queue and the batch-events output queue
were bounded only by event count. Under high-throughput conditions a burst of
large messages (e.g. FIM first-sync or syscollector full dumps) could exhaust
memory before the event-count ceiling was reached, because each event is
allocated on the heap and the total byte footprint was unbounded.

This PR introduces **byte-based capacity limits** for both queues, configurable
via `internal_options.conf`. When the limit is reached, excess events are
discarded and a rate-limited warning is written to the manager log (at most once
every 5 seconds). A limit of `0` preserves the previous unlimited behaviour.

A pre-existing **thread-safety bug** in the engine's `CQueue` was also found and
fixed: the `waitPop`, `tryPop`, and `tryPopBulk` methods decremented
`m_currentBytes` with a non-atomic load-modify-store, which could corrupt the
counter under concurrent consumers and prevent the byte budget from ever
returning to zero.

## Proposed changes

### `src/remoted/src/queue.c`
- Added `rem_input_max_bytes` and `rem_input_bytes_used` static variables to
  track the byte footprint of the input queue.
- Added `rem_set_input_queue_max_bytes(size_t)` to configure the limit at
  runtime (called from `HandleSecure` startup).
- `rem_msgpush` now rejects events when `size > max_bytes` (oversized single
  event) or `used + size > max_bytes` (quota exhausted), calling
  `rem_inc_recv_discarded()` and emitting a rate-limited `mwarn`.
- Added `rem_msgdestroy()` to release queue memory between unit-test cases.

### `src/remoted/src/config.c`
- Added `queue_max_bytes` and `batch_events_max_bytes` internal options
  (defaults: 100 MiB each; values between 1–1023 bytes are rejected at startup
  with `merror`).
- Both fields are now exported by `getRemoteInternalConfig()` so they are
  visible through the manager API.

### `src/remoted/src/secure.c`
- `HandleSecure` calls `rem_set_input_queue_max_bytes(queue_max_bytes)` and
  `batch_queue_set_bytes_limit(events_queue, batch_events_max_bytes)` during
  initialisation.

### `src/remoted/include/remoted.h`
- Declared `rem_set_input_queue_max_bytes`, `rem_msgdestroy`, `queue_max_bytes`,
  and `batch_events_max_bytes`.

### `src/engine/source/fastqueue/include/fastqueue/cqueue.hpp`
- Fixed non-atomic `m_currentBytes` decrement in `waitPop`, `tryPop`, and
  `tryPopBulk` by introducing a private `releaseBytes()` helper that uses
  `fetch_sub` with an underflow guard, matching the `fetch_add` already used in
  `push`.

### `src/unit_tests/remoted/test_queue.c` _(new)_
- Six unit tests covering: basic push/pop, event-count limit, byte-quota
  exhaustion, oversized-event rejection, quota recovery after dequeue, and
  concurrent producers with one consumer under a byte cap.

### `src/unit_tests/remoted/test_remote-config.c`
- Added `will_return` mocks and `assert_int_equal` checks for the two new
  internal-config fields.

### `src/unit_tests/remoted/test_secure.c`
- Fixed 12 pre-existing test failures caused by an unregistered `__wrap_time`
  mock expectation introduced when `HandleSecureMessage` adopted a rate-limited
  `mwarn` pattern for batch-queue drops.


## Results and Evidence

### Bad limit to remoted's input queue remoted

```
(venv) ╭─root@89ebd703d7af /workspaces/devContainer/wazuh/src ‹enhancement/37052-add-byte-based-capacity-limits›
╰─# service wazuh-manager restart
Killing wazuh-manager-clusterd...
Killing wazuh-manager-modulesd...
Killing wazuh-manager-monitord...
Killing wazuh-manager-remoted...
Killing wazuh-manager-analysisd...
Killing wazuh-manager-db...
Killing wazuh-manager-authd...
Killing wazuh-manager-apid...
Wazuh v5.0.0 Stopped
2026/06/29 22:05:02 wazuh-manager-remoted: ERROR: remoted.queue_max_bytes (500) is below the minimum of 1024 bytes.
2026/06/29 22:05:02 wazuh-manager-remoted: CRITICAL: (1202): Configuration error at 'etc/wazuh-manager.conf'.
wazuh-manager-remoted: Configuration error. Exiting
```

### Bad limit to remoted's output queue remoted
```
╭─root@89ebd703d7af /workspaces/devContainer/wazuh/src ‹enhancement/37052-add-byte-based-capacity-limits●›
╰─# service wazuh-manager restart                                                                               130 ↵
Killing wazuh-manager-clusterd...
Killing wazuh-manager-modulesd...
Killing wazuh-manager-monitord...
wazuh-manager-remoted: Process 945011 not used by Wazuh, removing...
wazuh-manager-remoted not running...
Killing wazuh-manager-analysisd...
Killing wazuh-manager-db...
Killing wazuh-manager-authd...
Killing wazuh-manager-apid...
Wazuh v5.0.0 Stopped
2026/06/29 23:39:52 wazuh-manager-remoted: ERROR: remoted.batch_events_max_bytes (500) is below the minimum of 1024 bytes.
2026/06/29 23:39:52 wazuh-manager-remoted: CRITICAL: (1202): Configuration error at 'etc/wazuh-manager.conf'.
wazuh-manager-remoted: Configuration error. Exiting
```

### Exceeded limit of the input queue using ineventory_sync simulator
```
remoted.batch_events_max_bytes=2048
remoted.queue_max_bytes=2048
cat > /workspaces/devContainer/wazuh/src/wazuh_modules/inventory_sync/benchmark/scenarios/test_queue_pressure.json << 'EOF'
{
  "name": "test_queue_pressure",
  "description": "Presion sobre batch queue con router forwarding deshabilitado",
  "lanes": {
    "fim": [
      {
        "dump": "sample_payloads/fim/ubuntu22_fim_first_sync.json",
        "max_eps": 0,
        "use_databatch": true
      }
    ]
  },
  "total_agents": 5,
  "parallel_agents": 5,
  "repeat_until": 120
}
EOF
(venv) ╭─root@89ebd703d7af /workspaces/devContainer/wazuh/src/wazuh_modules/inventory_sync/benchmark ‹enhancement/37052-add-byte-based-capacity-limits●›
╰─# cd /workspaces/devContainer/wazuh/src/wazuh_modules/inventory_sync/benchmark
./run_benchmark.sh --scenario scenarios/test_queue_pressure.json --label pr-evidence
remoted.batch_events_max_bytes=2048
remoted.queue_max_bytes=2048
╭─root@89ebd703d7af /workspaces/devContainer/wazuh/src ‹enhancement/37052-add-byte-based-capacity-limits●›
╰─# tail -f /var/wazuh-manager/logs/wazuh-manager.log | grep -E "discarded|byte quota|queue_max"
2026/06/29 23:09:17 wazuh-manager-remoted: WARNING: Input queue discarded 1 event(s) in the last 5 seconds.
2026/06/29 23:09:33 wazuh-manager-remoted: WARNING: Input queue discarded 51 event(s) in the last 5 seconds.
2026/06/29 23:09:54 wazuh-manager-remoted: WARNING: Input queue discarded 51 event(s) in the last 5 seconds.
2026/06/29 23:10:14 wazuh-manager-remoted: WARNING: Input queue discarded 50 event(s) in the last 5 seconds.
```

### Exceeded limit of the output queue using agent simulator
FIM sync messages (prefixed with s:) go directly to the router/engine — bypassing the batch_queue. The batch_events_max_bytes limit applies to traditional events (syslog, alerts) that pass through the analysisd path.
```
remoted.batch_events_max_bytes=2048
remoted.queue_max_bytes=2048
╭─root@89ebd703d7af /workspaces/devContainer/wazuh/src ‹enhancement/37052-add-byte-based-capacity-limits●›
╰─# python3 /workspaces/devContainer/wazuh-qa-automation/legacy/qa/wazuh_testing/wazuh_testing/scripts/simulate_agents.py \
  -a 127.0.0.1 \
  -n 5 \
  -m logcollector \
  -s 1000 \
  -t 60 \
  -v 5.0.0 \
  --debug 2>&1 | grep -E "Logcollector|logcollector|KeepAlive|error" | head -20
INFO:P947612:{'keepalive': {'status': 'enabled', 'frequency': 10.0}, 'fim': {'status': 'disabled', 'eps': 0}, 'fim_integrity': {'status': 'disabled', 'eps': 0}, 'syscollector': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'vulnerability': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'rootcheck': {'status': 'disabled', 'frequency': 60.0, 'eps': 0}, 'sca': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'hostinfo': {'status': 'disabled', 'eps': 0}, 'winevt': {'status': 'disabled', 'eps': 0}, 'logcollector': {'status': 'enabled', 'eps': 1000}, 'receive_messages': {'status': 'enabled'}}
INFO:P947612:{'keepalive': {'status': 'enabled', 'frequency': 10.0}, 'fim': {'status': 'disabled', 'eps': 0}, 'fim_integrity': {'status': 'disabled', 'eps': 0}, 'syscollector': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'vulnerability': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'rootcheck': {'status': 'disabled', 'frequency': 60.0, 'eps': 0}, 'sca': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'hostinfo': {'status': 'disabled', 'eps': 0}, 'winevt': {'status': 'disabled', 'eps': 0}, 'logcollector': {'status': 'enabled', 'eps': 1000}, 'receive_messages': {'status': 'enabled'}}
INFO:P947612:{'keepalive': {'status': 'enabled', 'frequency': 10.0}, 'fim': {'status': 'disabled', 'eps': 0}, 'fim_integrity': {'status': 'disabled', 'eps': 0}, 'syscollector': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'vulnerability': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'rootcheck': {'status': 'disabled', 'frequency': 60.0, 'eps': 0}, 'sca': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'hostinfo': {'status': 'disabled', 'eps': 0}, 'winevt': {'status': 'disabled', 'eps': 0}, 'logcollector': {'status': 'enabled', 'eps': 1000}, 'receive_messages': {'status': 'enabled'}}
INFO:P947612:{'keepalive': {'status': 'enabled', 'frequency': 10.0}, 'fim': {'status': 'disabled', 'eps': 0}, 'fim_integrity': {'status': 'disabled', 'eps': 0}, 'syscollector': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'vulnerability': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'rootcheck': {'status': 'disabled', 'frequency': 60.0, 'eps': 0}, 'sca': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'hostinfo': {'status': 'disabled', 'eps': 0}, 'winevt': {'status': 'disabled', 'eps': 0}, 'logcollector': {'status': 'enabled', 'eps': 1000}, 'receive_messages': {'status': 'enabled'}}
INFO:P947612:{'keepalive': {'status': 'enabled', 'frequency': 10.0}, 'fim': {'status': 'disabled', 'eps': 0}, 'fim_integrity': {'status': 'disabled', 'eps': 0}, 'syscollector': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'vulnerability': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'rootcheck': {'status': 'disabled', 'frequency': 60.0, 'eps': 0}, 'sca': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'hostinfo': {'status': 'disabled', 'eps': 0}, 'winevt': {'status': 'disabled', 'eps': 0}, 'logcollector': {'status': 'enabled', 'eps': 1000}, 'receive_messages': {'status': 'enabled'}}
DEBUG:root:Starting - 1-Adqirub76n4RXPYF-debian8(2031)(debian8) - logcollector
DEBUG:root:Starting - 1-4O3SJqPahU7s6peN-debian8(2032)(debian8) - logcollector
DEBUG:root:Starting - 1-h9wOnymj8IoAx73i-debian8(2033)(debian8) - logcollector
DEBUG:root:Starting - 1-rRTmPQGq1pO46ClV-debian8(2034)(debian8) - logcollector
DEBUG:root:Starting - 1-ZLGH7NnD1jpBra9P-debian8(2035)(debian8) - logcollector
DEBUG:root:KeepAlive - 1-Adqirub76n4RXPYF-debian8(2031)
DEBUG:root:KeepAlive - 1-4O3SJqPahU7s6peN-debian8(2032)
DEBUG:root:KeepAlive - 1-rRTmPQGq1pO46ClV-debian8(2034)
DEBUG:root:KeepAlive - 1-h9wOnymj8IoAx73i-debian8(2033)
DEBUG:root:KeepAlive - 1-ZLGH7NnD1jpBra9P-debian8(2035)
WARNING:root:Broken Pipe error while sending event. Creating new socket...
WARNING:root:Broken Pipe error while sending event. Creating new socket...
WARNING:root:Broken Pipe error while sending event. Creating new socket...
WARNING:root:Broken Pipe error while sending event. Creating new socket...
WARNING:root:Broken Pipe error while sending event. Creating new socket...

(venv) ╭─root@89ebd703d7af /workspaces/devContainer/wazuh/src/wazuh_modules/inventory_sync/benchmark ‹enhancement/37052-add-byte-based-capacity-limits●›
╰─# tail -f /var/wazuh-manager/logs/wazuh-manager.log | grep -E "discarded|byte quota|queue_max"                130 ↵
2026/06/29 23:28:08 wazuh-manager-remoted: WARNING: Input queue discarded 1 event(s) in the last 5 seconds.
2026/06/29 23:28:08 wazuh-manager-remoted: WARNING: Events queue discarded 1 event(s) in the last 5 seconds.
```

### Excess bytes in the orchestrator queue as seen with metrics
```
╭─root@89ebd703d7af /workspaces/devContainer/wazuh/src ‹enhancement/37052-add-byte-based-capacity-limits●› 
╰─# python3 /workspaces/devContainer/wazuh-qa-automation/legacy/qa/wazuh_testing/wazuh_testing/scripts/simulate_agents.py \
  -a 127.0.0.1 \
  -n 5 \
  -m logcollector \
  -s 1000 \
  -t 60 \
  -v 5.0.0 \
  --debug 2>&1 | grep -E "Logcollector|logcollector|KeepAlive|error" | head -20
INFO:P1006041:{'keepalive': {'status': 'enabled', 'frequency': 10.0}, 'fim': {'status': 'disabled', 'eps': 0}, 'fim_integrity': {'status': 'disabled', 'eps': 0}, 'syscollector': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'vulnerability': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'rootcheck': {'status': 'disabled', 'frequency': 60.0, 'eps': 0}, 'sca': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'hostinfo': {'status': 'disabled', 'eps': 0}, 'winevt': {'status': 'disabled', 'eps': 0}, 'logcollector': {'status': 'enabled', 'eps': 1000}, 'receive_messages': {'status': 'enabled'}}
INFO:P1006041:{'keepalive': {'status': 'enabled', 'frequency': 10.0}, 'fim': {'status': 'disabled', 'eps': 0}, 'fim_integrity': {'status': 'disabled', 'eps': 0}, 'syscollector': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'vulnerability': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'rootcheck': {'status': 'disabled', 'frequency': 60.0, 'eps': 0}, 'sca': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'hostinfo': {'status': 'disabled', 'eps': 0}, 'winevt': {'status': 'disabled', 'eps': 0}, 'logcollector': {'status': 'enabled', 'eps': 1000}, 'receive_messages': {'status': 'enabled'}}
INFO:P1006041:{'keepalive': {'status': 'enabled', 'frequency': 10.0}, 'fim': {'status': 'disabled', 'eps': 0}, 'fim_integrity': {'status': 'disabled', 'eps': 0}, 'syscollector': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'vulnerability': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'rootcheck': {'status': 'disabled', 'frequency': 60.0, 'eps': 0}, 'sca': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'hostinfo': {'status': 'disabled', 'eps': 0}, 'winevt': {'status': 'disabled', 'eps': 0}, 'logcollector': {'status': 'enabled', 'eps': 1000}, 'receive_messages': {'status': 'enabled'}}
INFO:P1006041:{'keepalive': {'status': 'enabled', 'frequency': 10.0}, 'fim': {'status': 'disabled', 'eps': 0}, 'fim_integrity': {'status': 'disabled', 'eps': 0}, 'syscollector': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'vulnerability': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'rootcheck': {'status': 'disabled', 'frequency': 60.0, 'eps': 0}, 'sca': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'hostinfo': {'status': 'disabled', 'eps': 0}, 'winevt': {'status': 'disabled', 'eps': 0}, 'logcollector': {'status': 'enabled', 'eps': 1000}, 'receive_messages': {'status': 'enabled'}}
INFO:P1006041:{'keepalive': {'status': 'enabled', 'frequency': 10.0}, 'fim': {'status': 'disabled', 'eps': 0}, 'fim_integrity': {'status': 'disabled', 'eps': 0}, 'syscollector': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'vulnerability': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'rootcheck': {'status': 'disabled', 'frequency': 60.0, 'eps': 0}, 'sca': {'status': 'disabled', 'frequency': 60, 'eps': 0}, 'hostinfo': {'status': 'disabled', 'eps': 0}, 'winevt': {'status': 'disabled', 'eps': 0}, 'logcollector': {'status': 'enabled', 'eps': 1000}, 'receive_messages': {'status': 'enabled'}}
DEBUG:root:Starting - 1-rRXEsD4AUnx8BLV2-debian8(2056)(debian8) - logcollector
DEBUG:root:Starting - 1-J0gykfdL2PA43ltu-debian8(2057)(debian8) - logcollector
DEBUG:root:Starting - 1-KpS6I5ZbzVUTYGRH-debian8(2058)(debian8) - logcollector
DEBUG:root:Starting - 1-kxDlOw4YCPjJGRyF-debian8(2059)(debian8) - logcollector
DEBUG:root:Starting - 1-k3XVOeLlKWb0tgYv-debian8(2060)(debian8) - logcollector
DEBUG:root:KeepAlive - 1-rRXEsD4AUnx8BLV2-debian8(2056)
DEBUG:root:KeepAlive - 1-J0gykfdL2PA43ltu-debian8(2057)
DEBUG:root:KeepAlive - 1-KpS6I5ZbzVUTYGRH-debian8(2058)
DEBUG:root:KeepAlive - 1-kxDlOw4YCPjJGRyF-debian8(2059)
DEBUG:root:KeepAlive - 1-k3XVOeLlKWb0tgYv-debian8(2060)
DEBUG:root:KeepAlive - 1-rRXEsD4AUnx8BLV2-debian8(2056)
DEBUG:root:KeepAlive - 1-J0gykfdL2PA43ltu-debian8(2057)
DEBUG:root:KeepAlive - 1-KpS6I5ZbzVUTYGRH-debian8(2058)
DEBUG:root:KeepAlive - 1-kxDlOw4YCPjJGRyF-debian8(2059)
DEBUG:root:KeepAlive - 1-k3XVOeLlKWb0tgYv-debian8(2060)
```
<img width="1572" height="834" alt="Screenshot from 2026-06-30 11-36-43" src="https://github.com/user-attachments/assets/ed01c0d5-71b7-42a4-851e-7b5a358b0618" />

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
