### PR TITLE
Skip FIM whodata cases on the tier-2 Linux job (CodeBuild)

### DIFF
--- a/.github/workflows/4_testintegration_fim-tier-2-lin.yml
+++ b/.github/workflows/4_testintegration_fim-tier-2-lin.yml
@@ -88,4 +88,5 @@ jobs:
       - name: Run fim integration tests
         run: |
           cd tests/integration
-          sudo python -m pytest --tier 2 test_fim/
+          sudo python -m pytest --tier 2 test_fim/ \
+            -k "not whodata and not Who-data"


### PR DESCRIPTION
## Description

### Problem

After migrating the FIM Linux integration-test workflows to AWS CodeBuild (parent #37027,
5.x equivalent PR #37051), the `4_testintegration_fim-tier-2-lin` job fails: **83 failed,
229 passed, 213 deselected, 1 xfailed** — and **all 83 failures are whodata-mode cases**.

FIM `whodata` mode relies on the Linux kernel netlink audit socket (`NETLINK_AUDIT`):
`syscheckd` calls `auditctl` to register rules. Inside CodeBuild containers the required
capabilities (`CAP_AUDIT_CONTROL`, `CAP_AUDIT_WRITE`, `CAP_AUDIT_READ`) are blocked by the
seccomp profile, so `auditctl` exits 255 and `syscheckd` silently falls back from `whodata`
to `realtime`. Tests asserting `mode == 'whodata'` then fail with `assert 'realtime' ==
'whodata'`.

When whodata was filtered out of the **tier 0-1** Linux job during the migration, the
**tier-2** Linux job was left running the whodata cases. The tier-2 job is launched manually,
not on PR checks, so the gap was not caught at merge time and only surfaced during the
Release 4.14.6 RC run (#37236).

### Solution

Apply to the tier-2 Linux job the same whodata exclusion the tier 0-1 Linux job already uses,
so the suite does not exercise a FIM mode the CodeBuild environment cannot support. This is a
CI-only change: no product code is touched and FIM behaviour is unchanged.

This exclusion is temporary and is tracked for re-enablement in #37189, the issue that
collects every IT skipped because of the CodeBuild migration and where coverage will be
restored once the environment can support whodata.

Closes #37273

## Proposed Changes

**FIM tier-2 Linux workflow** (`.github/workflows/4_testintegration_fim-tier-2-lin.yml`)

- Add the whodata filter to the pytest invocation, mirroring
  `4_testintegration_fim-tier-0-1-lin.yml`:

```diff
           cd tests/integration
-          sudo python -m pytest --tier 2 test_fim/
+          sudo python -m pytest --tier 2 test_fim/ \
+            -k "not whodata and not Who-data"
```

- The `--ignore=.../test_follow_symbolic_link/test_audit_rules_with_symlink.py` used by the
  tier 0-1 job is **not** added here: that test is marked `pytest.mark.tier(level=0)` only, so
  it is never collected under `--tier 2`.

## Results and Evidence

- Failing run (before): https://github.com/wazuh/wazuh/actions/runs/28255178161 — 83
  whodata-mode failures, every other tier-2 FIM case passing.
- `-k "not whodata and not Who-data"` deselects exactly the whodata-mode cases; the identical
  expression is already validated on the tier 0-1 Linux job, which is green on CodeBuild.
- After this change the tier-2 Linux job runs the non-whodata tier-2 FIM suite with no
  audit-related failures, unblocking the `4_testintegration_fim-tier-2-lin` gate in #37236.

Manual run:
https://github.com/wazuh/wazuh/actions/runs/28400266611/job/84149415625

## Artifacts Affected

None. No packaged artifact changes — the edit is limited to a CI workflow file.

## Configuration Changes

None. No runtime or build configuration is modified.

## Documentation Updates

None in-tree. The whodata/CodeBuild root cause and the coverage-restoration follow-up are
tracked in #37189 and wazuh/wazuh-automation#3497. This newly-skipped tier-2 Linux exclusion
is added to the "What was skipped" list in #37189.

## Tests Introduced

No new test cases. This PR **excludes** the whodata-mode tier-2 cases on CI; it does not fix
or remove them. Restoring whodata execution (an audit-capable runner, or granting the
CodeBuild role the audit capabilities) is tracked in #37189.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
