### PR TITLE
Fix host.os.full inconsistency

### DIFF
--- a/src/data_provider/src/osinfo/sysOsParsers.cpp
+++ b/src/data_provider/src/osinfo/sysOsParsers.cpp
@@ -105,7 +105,7 @@ static bool findVersionInStream(std::istream& in,
         line = Utils::trim(line);
         ret |= Utils::findRegexInString(line, data, pattern, matchIndex, start);
 
-        if (ret)
+        if (ret && !output.contains("os_version"))
         {
             output["os_version"] = data;
             findMajorMinorVersionInString(data, output);

--- a/src/data_provider/src/osinfo/sysOsParsers.cpp
+++ b/src/data_provider/src/osinfo/sysOsParsers.cpp
@@ -194,7 +194,10 @@ bool UbuntuOsParser::parseFile(std::istream& in, nlohmann::json& output)
 
 bool CentosOsParser::parseFile(std::istream& in, nlohmann::json& output)
 {
-    constexpr auto PATTERN_MATCH{R"([0-9].*\.[0-9]*)"};
+    // Matches "major.minor[.patch]" optionally followed by " (Codename)", e.g.
+    // "8.10 (Cerulean Leopard)" or "8.2.2004 (Core)".
+    // The dot is required so CentOS Stream versions like "9" are not matched.
+    constexpr auto PATTERN_MATCH{R"([0-9][0-9]*\.[0-9.]*(?:\s+\([^)]+\))?)"};
 
     if (!output.contains("os_name")) output["os_name"] = "Centos Linux";
 

--- a/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
+++ b/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
@@ -254,6 +254,259 @@ TEST_F(SysInfoParsersTest, CentosBased)
     EXPECT_EQ("8.8 (Green Obsidian)", output["os_version"]);
 }
 
+TEST_F(SysInfoParsersTest, Centos7)
+{
+    constexpr auto CENTOS_RELEASE_FILE
+    {
+        "CentOS Linux release 7.9.2009 (Core)"
+    };
+    nlohmann::json output;
+    std::stringstream info{CENTOS_RELEASE_FILE};
+    const auto spParser{FactorySysOsParser::create("centos")};
+    EXPECT_TRUE(spParser->parseFile(info, output));
+    EXPECT_EQ("7.9.2009 (Core)", output["os_version"]);
+    EXPECT_EQ("Centos Linux", output["os_name"]);
+    EXPECT_EQ("centos", output["os_platform"]);
+    EXPECT_EQ("Core", output["os_codename"]);
+    EXPECT_EQ("7", output["os_major"]);
+    EXPECT_EQ("9", output["os_minor"]);
+    EXPECT_EQ("2009", output["os_patch"]);
+}
+
+TEST_F(SysInfoParsersTest, CentosStream8)
+{
+    constexpr auto CENTOS_STREAM_RELEASE_FILE
+    {
+        "NAME=\"CentOS Stream\"\n"
+        "VERSION=\"8\"\n"
+        "ID=\"centos\"\n"
+        "ID_LIKE=\"rhel fedora\"\n"
+        "VERSION_ID=\"8\"\n"
+        "PLATFORM_ID=\"platform:el8\"\n"
+        "PRETTY_NAME=\"CentOS Stream 8\"\n"
+        "ANSI_COLOR=\"0;31\"\n"
+        "CPE_NAME=\"cpe:/o:centos:centos:8\"\n"
+        "HOME_URL=\"https://centos.org/\"\n"
+        "BUG_REPORT_URL=\"https://bugzilla.redhat.com/\"\n"
+        "REDHAT_SUPPORT_PRODUCT=\"Red Hat Enterprise Linux 8\"\n"
+        "REDHAT_SUPPORT_PRODUCT_VERSION=\"CentOS Stream\"\n"
+    };
+    nlohmann::json output;
+    std::stringstream info{CENTOS_STREAM_RELEASE_FILE};
+    const auto spParser1{FactorySysOsParser::create("unix")};
+    EXPECT_TRUE(spParser1->parseFile(info, output));
+    info.clear();
+    info.seekg(0, std::ios::beg);
+    info << CENTOS_STREAM_RELEASE_FILE;
+    const auto spParser2{FactorySysOsParser::create("centos")};
+    EXPECT_FALSE(spParser2->parseFile(info, output));
+    EXPECT_EQ("8", output["os_major"]);
+    EXPECT_EQ("CentOS Stream", output["os_name"]);
+    EXPECT_EQ("centos", output["os_platform"]);
+    EXPECT_EQ("8", output["os_version"]);
+}
+
+TEST_F(SysInfoParsersTest, CentosStream10)
+{
+    constexpr auto CENTOS_STREAM_RELEASE_FILE
+    {
+        "NAME=\"CentOS Stream\"\n"
+        "VERSION=\"10 (Coughlan)\"\n"
+        "ID=\"centos\"\n"
+        "ID_LIKE=\"rhel fedora\"\n"
+        "VERSION_ID=\"10\"\n"
+        "PLATFORM_ID=\"platform:el10\"\n"
+        "PRETTY_NAME=\"CentOS Stream 10 (Coughlan)\"\n"
+        "ANSI_COLOR=\"0;31\"\n"
+        "CPE_NAME=\"cpe:/o:centos:centos:10\"\n"
+        "HOME_URL=\"https://centos.org/\"\n"
+        "BUG_REPORT_URL=\"https://bugzilla.redhat.com/\"\n"
+        "REDHAT_SUPPORT_PRODUCT=\"Red Hat Enterprise Linux 10\"\n"
+        "REDHAT_SUPPORT_PRODUCT_VERSION=\"CentOS Stream\"\n"
+    };
+    nlohmann::json output;
+    std::stringstream info{CENTOS_STREAM_RELEASE_FILE};
+    const auto spParser1{FactorySysOsParser::create("unix")};
+    EXPECT_TRUE(spParser1->parseFile(info, output));
+    info.clear();
+    info.seekg(0, std::ios::beg);
+    info << CENTOS_STREAM_RELEASE_FILE;
+    const auto spParser2{FactorySysOsParser::create("centos")};
+    EXPECT_FALSE(spParser2->parseFile(info, output));
+    EXPECT_EQ("10", output["os_major"]);
+    EXPECT_EQ("CentOS Stream", output["os_name"]);
+    EXPECT_EQ("centos", output["os_platform"]);
+    EXPECT_EQ("10 (Coughlan)", output["os_version"]);
+    EXPECT_EQ("Coughlan", output["os_codename"]);
+}
+
+TEST_F(SysInfoParsersTest, RockyLinux9)
+{
+    constexpr auto ROCKY_LINUX_RELEASE_FILE
+    {
+        "NAME=\"Rocky Linux\"\n"
+        "VERSION=\"9.3 (Blue Onyx)\"\n"
+        "ID=\"rocky\"\n"
+        "ID_LIKE=\"rhel centos fedora\"\n"
+        "VERSION_ID=\"9.3\"\n"
+        "PLATFORM_ID=\"platform:el9\"\n"
+        "PRETTY_NAME=\"Rocky Linux 9.3 (Blue Onyx)\"\n"
+        "ANSI_COLOR=\"0;32\"\n"
+        "LOGO=\"fedora-logo-icon\"\n"
+        "CPE_NAME=\"cpe:/o:rocky:rocky:9:GA\"\n"
+        "HOME_URL=\"https://rockylinux.org/\"\n"
+        "BUG_REPORT_URL=\"https://bugs.rockylinux.org/\"\n"
+        "SUPPORT_END=\"2032-05-31\"\n"
+        "ROCKY_SUPPORT_PRODUCT=\"Rocky-Linux-9\"\n"
+        "ROCKY_SUPPORT_PRODUCT_VERSION=\"9.3\"\n"
+        "REDHAT_SUPPORT_PRODUCT=\"Rocky Linux\"\n"
+        "REDHAT_SUPPORT_PRODUCT_VERSION=\"9.3\"\n"
+    };
+    nlohmann::json output;
+    std::stringstream info{ROCKY_LINUX_RELEASE_FILE};
+    const auto spParser1{FactorySysOsParser::create("unix")};
+    EXPECT_TRUE(spParser1->parseFile(info, output));
+    info.clear();
+    info.seekg(0, std::ios::beg);
+    info << ROCKY_LINUX_RELEASE_FILE;
+    const auto spParser2{FactorySysOsParser::create("centos")};
+    EXPECT_TRUE(spParser2->parseFile(info, output));
+    EXPECT_EQ("Blue Onyx", output["os_codename"]);
+    EXPECT_EQ("9", output["os_major"]);
+    EXPECT_EQ("3", output["os_minor"]);
+    EXPECT_EQ("Rocky Linux", output["os_name"]);
+    EXPECT_EQ("rocky", output["os_platform"]);
+    EXPECT_EQ("9.3 (Blue Onyx)", output["os_version"]);
+}
+
+TEST_F(SysInfoParsersTest, AlmaLinux8)
+{
+    constexpr auto ALMALINUX_RELEASE_FILE
+    {
+        "NAME=\"AlmaLinux\"\n"
+        "VERSION=\"8.9 (Midnight Oncilla)\"\n"
+        "ID=\"almalinux\"\n"
+        "ID_LIKE=\"rhel centos fedora\"\n"
+        "VERSION_ID=\"8.9\"\n"
+        "PLATFORM_ID=\"platform:el8\"\n"
+        "PRETTY_NAME=\"AlmaLinux 8.9 (Midnight Oncilla)\"\n"
+        "ANSI_COLOR=\"0;34\"\n"
+        "LOGO=\"fedora-logo-icon\"\n"
+        "CPE_NAME=\"cpe:/o:almalinux:almalinux:8::baseos\"\n"
+        "HOME_URL=\"https://almalinux.org/\"\n"
+        "BUG_REPORT_URL=\"https://bugs.almalinux.org/\"\n"
+        "ALMALINUX_MANTISBT_PROJECT=\"AlmaLinux-8\"\n"
+        "ALMALINUX_MANTISBT_PROJECT_VERSION=\"8.9\"\n"
+        "REDHAT_SUPPORT_PRODUCT=\"AlmaLinux\"\n"
+        "REDHAT_SUPPORT_PRODUCT_VERSION=\"8.9\"\n"
+    };
+    nlohmann::json output;
+    std::stringstream info{ALMALINUX_RELEASE_FILE};
+    const auto spParser1{FactorySysOsParser::create("unix")};
+    EXPECT_TRUE(spParser1->parseFile(info, output));
+    info.clear();
+    info.seekg(0, std::ios::beg);
+    info << ALMALINUX_RELEASE_FILE;
+    const auto spParser2{FactorySysOsParser::create("centos")};
+    EXPECT_TRUE(spParser2->parseFile(info, output));
+    EXPECT_EQ("Midnight Oncilla", output["os_codename"]);
+    EXPECT_EQ("8", output["os_major"]);
+    EXPECT_EQ("9", output["os_minor"]);
+    EXPECT_EQ("AlmaLinux", output["os_name"]);
+    EXPECT_EQ("almalinux", output["os_platform"]);
+    EXPECT_EQ("8.9 (Midnight Oncilla)", output["os_version"]);
+}
+
+TEST_F(SysInfoParsersTest, AlmaLinux9)
+{
+    constexpr auto ALMALINUX_RELEASE_FILE
+    {
+        "NAME=\"AlmaLinux\"\n"
+        "VERSION=\"9.3 (Shamrock Pampas Cat)\"\n"
+        "ID=\"almalinux\"\n"
+        "ID_LIKE=\"rhel centos fedora\"\n"
+        "VERSION_ID=\"9.3\"\n"
+        "PLATFORM_ID=\"platform:el9\"\n"
+        "PRETTY_NAME=\"AlmaLinux 9.3 (Shamrock Pampas Cat)\"\n"
+        "ANSI_COLOR=\"0;34\"\n"
+        "LOGO=\"fedora-logo-icon\"\n"
+        "CPE_NAME=\"cpe:/o:almalinux:almalinux:9\"\n"
+        "HOME_URL=\"https://almalinux.org/\"\n"
+        "BUG_REPORT_URL=\"https://bugs.almalinux.org/\"\n"
+        "ALMALINUX_MANTISBT_PROJECT=\"AlmaLinux-9\"\n"
+        "ALMALINUX_MANTISBT_PROJECT_VERSION=\"9.3\"\n"
+        "REDHAT_SUPPORT_PRODUCT=\"AlmaLinux\"\n"
+        "REDHAT_SUPPORT_PRODUCT_VERSION=\"9.3\"\n"
+    };
+    nlohmann::json output;
+    std::stringstream info{ALMALINUX_RELEASE_FILE};
+    const auto spParser1{FactorySysOsParser::create("unix")};
+    EXPECT_TRUE(spParser1->parseFile(info, output));
+    info.clear();
+    info.seekg(0, std::ios::beg);
+    info << ALMALINUX_RELEASE_FILE;
+    const auto spParser2{FactorySysOsParser::create("centos")};
+    EXPECT_TRUE(spParser2->parseFile(info, output));
+    EXPECT_EQ("Shamrock Pampas Cat", output["os_codename"]);
+    EXPECT_EQ("9", output["os_major"]);
+    EXPECT_EQ("3", output["os_minor"]);
+    EXPECT_EQ("AlmaLinux", output["os_name"]);
+    EXPECT_EQ("almalinux", output["os_platform"]);
+    EXPECT_EQ("9.3 (Shamrock Pampas Cat)", output["os_version"]);
+}
+
+TEST_F(SysInfoParsersTest, OracleLinux8)
+{
+    constexpr auto ORACLE_RELEASE_FILE
+    {
+        "NAME=\"Oracle Linux Server\"\n"
+        "VERSION=\"8.9\"\n"
+        "ID=\"ol\"\n"
+        "ID_LIKE=\"fedora\"\n"
+        "VERSION_ID=\"8.9\"\n"
+        "PLATFORM_ID=\"platform:el8\"\n"
+        "PRETTY_NAME=\"Oracle Linux Server 8.9\"\n"
+        "ANSI_COLOR=\"0;31\"\n"
+        "HOME_URL=\"https://linux.oracle.com/\"\n"
+        "BUG_REPORT_URL=\"https://bugzilla.oracle.com/\"\n"
+    };
+    nlohmann::json output;
+    std::stringstream info{ORACLE_RELEASE_FILE};
+    const auto spParser{FactorySysOsParser::create("unix")};
+    EXPECT_TRUE(spParser->parseFile(info, output));
+    EXPECT_EQ("8.9", output["os_version"]);
+    EXPECT_EQ("Oracle Linux Server", output["os_name"]);
+    EXPECT_EQ("ol", output["os_platform"]);
+    EXPECT_EQ("8", output["os_major"]);
+    EXPECT_EQ("9", output["os_minor"]);
+}
+
+TEST_F(SysInfoParsersTest, OracleLinux9)
+{
+    constexpr auto ORACLE_RELEASE_FILE
+    {
+        "NAME=\"Oracle Linux Server\"\n"
+        "VERSION=\"9.3\"\n"
+        "ID=\"ol\"\n"
+        "ID_LIKE=\"fedora\"\n"
+        "VERSION_ID=\"9.3\"\n"
+        "PLATFORM_ID=\"platform:el9\"\n"
+        "PRETTY_NAME=\"Oracle Linux Server 9.3\"\n"
+        "ANSI_COLOR=\"0;31\"\n"
+        "HOME_URL=\"https://linux.oracle.com/\"\n"
+        "BUG_REPORT_URL=\"https://bugzilla.oracle.com/\"\n"
+    };
+    nlohmann::json output;
+    std::stringstream info{ORACLE_RELEASE_FILE};
+    const auto spParser{FactorySysOsParser::create("unix")};
+    EXPECT_TRUE(spParser->parseFile(info, output));
+    EXPECT_EQ("9.3", output["os_version"]);
+    EXPECT_EQ("Oracle Linux Server", output["os_name"]);
+    EXPECT_EQ("ol", output["os_platform"]);
+    EXPECT_EQ("9", output["os_major"]);
+    EXPECT_EQ("3", output["os_minor"]);
+}
+
 TEST_F(SysInfoParsersTest, BSDFreeBSD)
 {
     constexpr auto FREE_BSD_UNAME

--- a/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
+++ b/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
@@ -172,7 +172,7 @@ TEST_F(SysInfoParsersTest, Centos)
     std::stringstream info{CENTOS_RELEASE_FILE};
     const auto spParser{FactorySysOsParser::create("centos")};
     EXPECT_TRUE(spParser->parseFile(info, output));
-    EXPECT_EQ("8.2.2004", output["os_version"]);
+    EXPECT_EQ("8.2.2004 (Core)", output["os_version"]);
     EXPECT_EQ("Centos Linux", output["os_name"]);
     EXPECT_EQ("centos", output["os_platform"]);
     EXPECT_EQ("Core", output["os_codename"]);
@@ -251,7 +251,7 @@ TEST_F(SysInfoParsersTest, CentosBased)
     EXPECT_EQ("8", output["os_minor"]);
     EXPECT_EQ("Rocky Linux", output["os_name"]);
     EXPECT_EQ("rocky", output["os_platform"]);
-    EXPECT_EQ("8.8", output["os_version"]);
+    EXPECT_EQ("8.8 (Green Obsidian)", output["os_version"]);
 }
 
 TEST_F(SysInfoParsersTest, BSDFreeBSD)


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->
Closes #36760

On certain Linux distributions, os_full was being populated inconsistently — using NAME + VERSION_ID on some distros (e.g. CentOS) and PRETTY_NAME on others (e.g.
  Ubuntu). This was caused by two independent issues in the OS info parser:

  - Version overwrite: findVersionInStream could match multiple lines in the same file (e.g. both VERSION_ID and PRETTY_NAME), with later matches silently overwriting
  the first. Added an early-exit guard so the first valid os_version match wins.
  - CentOS regex too broad: The version regex [0-9].*\.[0-9]* was imprecise — it matched partial strings and didn't correctly capture codenames like 8.2.2004 (Core) or
  8.8 (Green Obsidian). Replaced with [0-9][0-9]*\.[0-9.]*(?:\s+\([^)]+\))?, which requires a dot (filtering out CentOS Stream "9"-style versions) and optionally
  captures the codename suffix.


## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

- Fix 1: Prevent os_version from being overwritten (findVersionInStream)

  Before: The function scanned every line of the OS release file and overwrote os_version each time the regex matched. On distros like Ubuntu where both
  VERSION_ID="22.04" and PRETTY_NAME="Ubuntu 22.04.5 LTS" exist, the version extracted from PRETTY_NAME would overwrite the cleaner value from VERSION_ID.

  After: Added && !output.contains("os_version") — once a version is found, subsequent matches are ignored. First match wins.

- Fix 2: CentOS regex now requires a dot and captures the codename

  Before: [0-9].*\.[0-9]* — overly permissive. The .* in the middle could match almost anything, and it didn't capture the codename in parentheses (e.g. (Core)), so
  os_version was "8.2.2004" instead of "8.2.2004 (Core)". It also risked matching CentOS Stream version strings like "9" in unintended ways.

  After: [0-9][0-9]*\.[0-9.]*(?:\s+\([^)]+\))?
  - [0-9][0-9]* — one or more digits (no wildcard in the middle)                                                                                                        
  - \. — requires a dot, so bare integers like "9" don't match                                                                                                          
  - [0-9.]* — matches the rest of the numeric version (2.2004, .8, etc.)                                                                                                
  - (?:\s+\([^)]+\))? — optionally captures the codename suffix like  (Core) or  (Green Obsidian) 

  This made os_version consistent with what the codename field already reported, and the unit tests were updated to reflect the corrected expected values.


### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

Before Fix:
<img width="1900" height="257" alt="almalinux 8" src="https://github.com/user-attachments/assets/0852cdb2-eb3c-4e91-80b5-59995e3875b0" />

After Fix:
<img width="1900" height="257" alt="Screenshot From 2026-07-02 08-54-45" src="https://github.com/user-attachments/assets/b9ad35b0-ce03-4918-9d75-7b57b33af8cc" />


### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->
- SysOsParsers.cpp
- sysInfoParsers_test.cpp

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

- N/A

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

- N/A
## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
