### PR TITLE
Fix test_worker failing unit test

### DIFF
--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -549,7 +549,7 @@ async def test_worker_handler_error_receiving_integrity(error_receiving_file_moc
 @patch("wazuh.core.cluster.worker.analysis.send_reload_ruleset_msg", new_callable=AsyncMock, return_value={"error": 0})
 async def test_worker_handler_sync_integrity_ok_from_master_ruleset_reload(send_reload_mock, log_reload_mock, event_loop):
     """Check that ruleset reload is awaited and properly handled when sync integrity finishes on the worker."""
-    
+
     worker_handler = get_worker_handler(event_loop)
     worker_handler.integrity_check_status = {"date_start": 0}
 
@@ -1212,8 +1212,10 @@ async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, w
                                              call(core_common.WAZUH_PATH, 'queue/TYPE/name'),
                                              call(core_common.WAZUH_PATH, 'cluster_item_key'),
                                              call(core_common.WAZUH_PATH, 'filename1'),
+                                             call(core_common.WAZUH_PATH, 'cluster_item_key'),
                                              call('/zip/path', 'filename1'),
-                                             call(core_common.WAZUH_PATH, 'filename3')])
+                                             call(core_common.WAZUH_PATH, 'filename3'),
+                                             call(core_common.WAZUH_PATH, 'cluster_item_key')])
             wazuh_uid_mock.assert_called_with()
             wazuh_gid_mock.assert_called_with()
             mkdir_with_mode_mock.assert_any_call("queue/testing")
@@ -1310,6 +1312,7 @@ async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, w
                                                            "File filename3 doesn't exist."]}
             assert result_logs['generic_errors'] == []
             path_join_mock.assert_has_calls([call(core_common.WAZUH_PATH, "filename3"),
+                                             call(core_common.WAZUH_PATH, "cluster_item_key"),
                                              call(core_common.WAZUH_PATH, "")])
             wazuh_uid_mock.assert_not_called()
             wazuh_gid_mock.assert_not_called()
@@ -1336,6 +1339,7 @@ async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, w
     assert result_logs['generic_errors'] == ["Found errors: 0 overwriting, 0 creating and 1 removing"]
 
     path_join_mock.assert_has_calls([call(core_common.WAZUH_PATH, "filename3"),
+                                     call(core_common.WAZUH_PATH, "cluster_item_key"),
                                      call(core_common.WAZUH_PATH, "")])
     wazuh_uid_mock.assert_not_called()
     wazuh_gid_mock.assert_not_called()


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

This PR fixes the failing test in `testworker.py` file.

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

- Fixed `test_worker_handler_update_master_files_in_worker_ok` in `test_worker.py` to account for the `safe_join(WAZUH_PATH, item_key)` calls added in the missing and extra file branches by a previous commit.

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->


---
| **Test name** | **Pass** | **XPass** | **Skip** | **XFail** | **Fail** | **Issues Ref.** | **Status** |
|--|--|--|--|--|--|--|--|
| framework/scripts/tests/test_agent_groups.py | 14 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/scripts/tests/test_agent_upgrade.py | 16 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/scripts/tests/test_cluster_control.py | 6 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/scripts/tests/test_rbac_control.py | 9 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/scripts/tests/test_wazuh_clusterd.py | 8 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/scripts/tests/test_wazuh_logtest.py | 22 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/cluster/dapi/tests/test_dapi.py | 47 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/cluster/hap_helper/tests/test_hap_helper.py | 55 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/cluster/hap_helper/tests/test_proxy.py | 104 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/cluster/hap_helper/tests/test_wazuh.py | 10 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/cluster/tests/test_client.py | 16 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/cluster/tests/test_cluster.py | 54 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/cluster/tests/test_cluster_file_validation.py | 12 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/cluster/tests/test_common.py | 104 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/cluster/tests/test_control.py | 11 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/cluster/tests/test_local_client.py | 14 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/cluster/tests/test_local_server.py | 23 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/cluster/tests/test_master.py | 52 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/cluster/tests/test_server.py | 29 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/cluster/tests/test_utils.py | 95 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/cluster/tests/test_worker.py | 38 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_active_response.py | 19 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_agent.py | 147 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_analysis.py | 17 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_cdb_list.py | 38 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_common.py | 11 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_configuration.py | 91 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_decoder.py | 16 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_decorators.py | 6 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_exception.py | 10 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_input_validator.py | 3 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_logtest.py | 3 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_manager.py | 31 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_mitre.py | 13 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_pyDaemonModule.py | 5 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_results.py | 40 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_results_security.py | 28 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_rootcheck.py | 13 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_rule.py | 23 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_sca.py | 29 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_security.py | 13 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_stats.py | 40 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_syscheck.py | 7 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_syscollector.py | 3 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_task.py | 8 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_utils.py | 321 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_wazuh_queue.py | 23 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_wazuh_socket.py | 38 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_wdb.py | 31 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_wdb_http.py | 11 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/core/tests/test_wlogging.py | 12 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/rbac/tests/test_auth_context.py | 2 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/rbac/tests/test_decorators.py | 130 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/rbac/tests/test_default_configuration.py | 55 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/rbac/tests/test_orm.py | 62 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/rbac/tests/test_orm_timing.py | 9 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/rbac/tests/test_preprocessor.py | 11 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/rbac/tests/test_utils.py | 3 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/tests/test_active_response.py | 10 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/tests/test_agent.py | 131 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/tests/test_analysis.py | 4 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/tests/test_cdb_list.py | 53 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/tests/test_ciscat.py | 33 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/tests/test_cluster.py | 14 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/tests/test_decoder.py | 58 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/tests/test_event.py | 4 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/tests/test_logtest.py | 6 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/tests/test_manager.py | 40 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/tests/test_mitre.py | 7 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/tests/test_rootcheck.py | 50 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/tests/test_rule.py | 74 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/tests/test_sca.py | 11 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/tests/test_security.py | 72 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/tests/test_stats.py | 15 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/tests/test_syscheck.py | 25 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/tests/test_syscollector.py | 12 | 0 | 0 | 0 | 0 |  | :green_circle: |
| framework/wazuh/tests/test_task.py | 28 | 0 | 0 | 0 | 0 |  | :green_circle: |

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
- [ ] Log syntax and correct language review

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
