### PR TITLE
Fix unit test workflow paths and report handling

### DIFF
--- a/.github/workflows/4_testunit_api.yml
+++ b/.github/workflows/4_testunit_api.yml
@@ -16,7 +16,9 @@ on:
     paths:
       - '.github/workflows/4_testunit_api.yml'
       - 'api/**'
-      - 'src/Makefile'
+      - 'framework/wazuh/**'
+      - 'framework/requirements.txt'
+      - 'framework/requirements-dev.txt'
 
 jobs:
   build: 

--- a/.github/workflows/4_testunit_api.yml
+++ b/.github/workflows/4_testunit_api.yml
@@ -27,7 +27,6 @@ jobs:
         python-version: ['3.10']
     env:
       PYTHONPATH: ${{ github.workspace }}/api:${{ github.workspace }}/framework
-      TEST_REPORT_PATH: ${{ runner.temp }}/test_report.txt
     steps:
       - uses: actions/checkout@v4
 
@@ -44,13 +43,16 @@ jobs:
           pip install -r framework/requirements-dev.txt --no-build-isolation
 
       - name: Run API tests
+        env:
+          TEST_REPORT_PATH: ${{ runner.temp }}/test_report.txt
         run: |
           set -o pipefail
-          python -m pytest api/api -vv --ignore=test --cov=api | tee ${TEST_REPORT_PATH}
+          python -m pytest api/api -vv --ignore=test --cov=api | tee "${TEST_REPORT_PATH}"
       
       - name: Generate test report
         if: inputs.generate_report
+        env:
+          TEST_REPORT_PATH: ${{ runner.temp }}/test_report.txt
         run: |
           git clone -b ${{ inputs.qa_branch }} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          python qa-integration-framework/src/wazuh_testing/scripts/pytest_results_parser.py -f ${TEST_REPORT_PATH}
-
+          python qa-integration-framework/src/wazuh_testing/scripts/pytest_results_parser.py -f "${TEST_REPORT_PATH}"

--- a/.github/workflows/4_testunit_external-integrations.yml
+++ b/.github/workflows/4_testunit_external-integrations.yml
@@ -27,7 +27,6 @@ jobs:
         python-version: ['3.10']
     env:
       PYTHONPATH: ${{ github.workspace }}/api:${{ github.workspace }}/framework
-      TEST_REPORT_PATH: ${{ runner.temp }}/test_report.txt
     steps:
       - uses: actions/checkout@v4
 
@@ -44,12 +43,16 @@ jobs:
           pip install -r framework/requirements-dev.txt --no-build-isolation
 
       - name: Run External integrations tests
+        env:
+          TEST_REPORT_PATH: ${{ runner.temp }}/test_report.txt
         run: |
           set -o pipefail
-          python -m pytest integrations -vv --ignore=tests --cov=integrations | tee ${TEST_REPORT_PATH}
+          python -m pytest integrations -vv --ignore=tests --cov=integrations | tee "${TEST_REPORT_PATH}"
       
       - name: Generate test report
         if: inputs.generate_report
+        env:
+          TEST_REPORT_PATH: ${{ runner.temp }}/test_report.txt
         run: |
           git clone -b ${{ inputs.qa_branch }} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          python qa-integration-framework/src/wazuh_testing/scripts/pytest_results_parser.py -f ${TEST_REPORT_PATH}
+          python qa-integration-framework/src/wazuh_testing/scripts/pytest_results_parser.py -f "${TEST_REPORT_PATH}"

--- a/.github/workflows/4_testunit_external-integrations.yml
+++ b/.github/workflows/4_testunit_external-integrations.yml
@@ -16,7 +16,8 @@ on:
     paths:
       - '.github/workflows/4_testunit_external-integrations.yml'
       - 'integrations/**'
-      - 'src/Makefile'
+      - 'framework/requirements.txt'
+      - 'framework/requirements-dev.txt'
 
 jobs:
   build: 

--- a/.github/workflows/4_testunit_framework.yml
+++ b/.github/workflows/4_testunit_framework.yml
@@ -16,7 +16,7 @@ on:
     paths:
       - '.github/workflows/4_testunit_framework.yml'
       - 'framework/**'
-      - 'src/Makefile'
+      - 'api/**'
 
 jobs:
   build: 

--- a/.github/workflows/4_testunit_framework.yml
+++ b/.github/workflows/4_testunit_framework.yml
@@ -27,7 +27,6 @@ jobs:
         python-version: ['3.10']
     env:
       PYTHONPATH: ${{ github.workspace }}/api:${{ github.workspace }}/framework
-      TEST_REPORT_PATH: ${{ runner.temp }}/test_report.txt
     steps:
       - uses: actions/checkout@v4
 
@@ -44,12 +43,16 @@ jobs:
           pip install -r framework/requirements-dev.txt --no-build-isolation
 
       - name: Run Framework tests
+        env:
+          TEST_REPORT_PATH: ${{ runner.temp }}/test_report.txt
         run: |
           set -o pipefail 
-          python -m pytest framework -vv --ignore=tests --cov=framework | tee ${TEST_REPORT_PATH}
+          python -m pytest framework -vv --ignore=tests --cov=framework | tee "${TEST_REPORT_PATH}"
       
       - name: Generate test report
         if: inputs.generate_report
+        env:
+          TEST_REPORT_PATH: ${{ runner.temp }}/test_report.txt
         run: |
           git clone -b ${{ inputs.qa_branch }} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          python qa-integration-framework/src/wazuh_testing/scripts/pytest_results_parser.py -f ${TEST_REPORT_PATH}
+          python qa-integration-framework/src/wazuh_testing/scripts/pytest_results_parser.py -f "${TEST_REPORT_PATH}"

--- a/.github/workflows/4_testunit_wodles.yml
+++ b/.github/workflows/4_testunit_wodles.yml
@@ -16,7 +16,8 @@ on:
     paths:
       - '.github/workflows/4_testunit_wodles.yml'
       - 'wodles/**'
-      - 'src/Makefile'
+      - 'framework/requirements.txt'
+      - 'framework/requirements-dev.txt'
 
 jobs:
   build: 

--- a/.github/workflows/4_testunit_wodles.yml
+++ b/.github/workflows/4_testunit_wodles.yml
@@ -27,7 +27,6 @@ jobs:
         python-version: ['3.10']
     env:
       PYTHONPATH: ${{ github.workspace }}/api:${{ github.workspace }}/framework
-      TEST_REPORT_PATH: ${{ runner.temp }}/test_report.txt
     steps:
       - uses: actions/checkout@v4
 
@@ -44,12 +43,16 @@ jobs:
           pip install -r framework/requirements-dev.txt --no-build-isolation
 
       - name: Run Wodles tests
+        env:
+          TEST_REPORT_PATH: ${{ runner.temp }}/test_report.txt
         run: |
           set -o pipefail
-          python -m pytest wodles -vv --ignore=tests --cov=wodles | tee ${TEST_REPORT_PATH}
+          python -m pytest wodles -vv --ignore=tests --cov=wodles | tee "${TEST_REPORT_PATH}"
       
       - name: Generate test report
         if: inputs.generate_report
+        env:
+          TEST_REPORT_PATH: ${{ runner.temp }}/test_report.txt
         run: |
           git clone -b ${{ inputs.qa_branch }} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          python qa-integration-framework/src/wazuh_testing/scripts/pytest_results_parser.py -f ${TEST_REPORT_PATH}
+          python qa-integration-framework/src/wazuh_testing/scripts/pytest_results_parser.py -f "${TEST_REPORT_PATH}"


### PR DESCRIPTION
## What changed

- Move `TEST_REPORT_PATH` from the job-level environment to the steps that use it in the API, external integrations, framework, and Wodles unit test workflows.
- Keep reports under `${{ runner.temp }}` and quote their shell path usages.
- Align each `pull_request.paths` filter with the code and dependency files used by its test suite.
- Remove `src/Makefile` from these filters because none of the four jobs consumes it.

## Why

The workflows failed validation before creating a job with:

```text
Unrecognized named-value: 'runner'
```

`runner` is unavailable in `jobs.<job_id>.env` because GitHub evaluates that section before assigning the CodeBuild runner. It is available in step-level `env` after runner assignment.

The previous path filters also omitted real cross-dependencies between API and framework tests, and omitted the shared Python requirement files used by every workflow.

## Impact

- All four workflows can start on CodeBuild runners again.
- API checks run for changes under `api/`, `framework/wazuh/`, or the shared requirements.
- Framework checks run for changes under `framework/` or `api/`.
- External integrations and Wodles checks run for their own source trees or shared requirement changes.

## Validation

- Parsed all four workflow files successfully as YAML.
- Ran `git diff --check` successfully.
- All four unit test workflows passed after the report path fix.
- Verified the commits contain no additional authorship trailers.
