### PR TITLE
Lower DBSync-not-available shutdown messages to DEBUG

### DIFF
--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -752,7 +752,7 @@ bool AgentInfoImpl::updateChanges(const std::string& table, const nlohmann::json
 
         if (!m_dBSync)
         {
-            m_logFunction(LOG_DEBUG, "DBSync not available for table " + table);
+            m_logFunction(m_stopped ? LOG_DEBUG : LOG_WARNING, "DBSync not available for table " + table);
             return false;
         }
 
@@ -1793,7 +1793,7 @@ void AgentInfoImpl::setSyncFlag(const std::string& table, bool value)
 
             if (!m_dBSync)
             {
-                m_logFunction(LOG_DEBUG, "Cannot set sync flag: DBSync not available");
+                m_logFunction(m_stopped ? LOG_DEBUG : LOG_WARNING, "Cannot set sync flag: DBSync not available");
                 return;
             }
         }
@@ -1830,7 +1830,7 @@ void AgentInfoImpl::loadSyncFlags()
 
             if (!m_dBSync)
             {
-                m_logFunction(LOG_DEBUG, "Cannot load sync flags: DBSync not available");
+                m_logFunction(m_stopped ? LOG_DEBUG : LOG_WARNING, "Cannot load sync flags: DBSync not available");
                 return;
             }
 
@@ -2010,7 +2010,7 @@ void AgentInfoImpl::updateLastIntegrityTime(const std::string& table)
 
             if (!m_dBSync)
             {
-                m_logFunction(LOG_DEBUG, "Cannot update last integrity time: DBSync not available");
+                m_logFunction(m_stopped ? LOG_DEBUG : LOG_WARNING, "Cannot update last integrity time: DBSync not available");
                 return;
             }
         }

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -1695,7 +1695,7 @@ AgentInfoImpl::CoordinationResult AgentInfoImpl::coordinateModules(const std::st
 
             if (!syncSuccess)
             {
-                m_logFunction(LOG_WARNING, "Failed to synchronize " + table);
+                m_logFunction(m_stopped ? LOG_DEBUG : LOG_WARNING, "Failed to synchronize " + table);
                 return CoordinationResult::Failed;
             }
 
@@ -2130,7 +2130,7 @@ bool AgentInfoImpl::performIntegritySync(const std::string& table)
         }
         else
         {
-            m_logFunction(LOG_WARNING, "Failed integrity check for " + table);
+            m_logFunction(m_stopped ? LOG_DEBUG : LOG_WARNING, "Failed integrity check for " + table);
         }
 
         return success;

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -752,7 +752,7 @@ bool AgentInfoImpl::updateChanges(const std::string& table, const nlohmann::json
 
         if (!m_dBSync)
         {
-            m_logFunction(LOG_WARNING, "DBSync not available for table " + table);
+            m_logFunction(LOG_DEBUG, "DBSync not available for table " + table);
             return false;
         }
 
@@ -1793,7 +1793,7 @@ void AgentInfoImpl::setSyncFlag(const std::string& table, bool value)
 
             if (!m_dBSync)
             {
-                m_logFunction(LOG_WARNING, "Cannot set sync flag: DBSync not available");
+                m_logFunction(LOG_DEBUG, "Cannot set sync flag: DBSync not available");
                 return;
             }
         }
@@ -1830,7 +1830,7 @@ void AgentInfoImpl::loadSyncFlags()
 
             if (!m_dBSync)
             {
-                m_logFunction(LOG_WARNING, "Cannot load sync flags: DBSync not available");
+                m_logFunction(LOG_DEBUG, "Cannot load sync flags: DBSync not available");
                 return;
             }
 
@@ -2010,7 +2010,7 @@ void AgentInfoImpl::updateLastIntegrityTime(const std::string& table)
 
             if (!m_dBSync)
             {
-                m_logFunction(LOG_WARNING, "Cannot update last integrity time: DBSync not available");
+                m_logFunction(LOG_DEBUG, "Cannot update last integrity time: DBSync not available");
                 return;
             }
         }


### PR DESCRIPTION
## Description

Closes #37302

Adjusts six `wazuh-modulesd:agent-info` log messages so they are logged at `DEBUG` during module shutdown and remain `WARNING` during normal operation. These messages report a benign shutdown/restart race: `stop()` sets `m_stopped = true`, then resets the DBSync handle (`m_dBSync`), then stops the sync protocol (`m_spSyncProtocol`), in that order. As a result, when any of these guards fire because the handle is gone or a sync call fails during teardown, `m_stopped` is already `true`, so it reliably distinguishes the expected shutdown race from a genuine runtime fault.

Following review feedback (#37325), the severity is gated on `m_stopped` rather than flattened unconditionally to `DEBUG`:

```cpp
m_logFunction(m_stopped ? LOG_DEBUG : LOG_WARNING, "<message>");
```

This keeps the message visible at `WARNING` if the same condition were ever observed outside shutdown (for example, if `m_dBSync` became null while the module is running, which is not possible today but would signal a real defect), while silencing the benign shutdown noise at the default log level.

This aligns these messages with their siblings that guard the identical `!m_dBSync` condition: `Cannot reset sync flag: DBSync not available` (already lowered to `DEBUG` in #36786), and the early guards in `performDeltaSync` / `performIntegritySync` (already `DEBUG`). The early-return behavior is already correct and is unchanged; only the severity is adjusted.

## Proposed Changes

- Gate severity on `m_stopped` (`DEBUG` during shutdown, `WARNING` otherwise) for the following `agent-info` messages.

DBSync-not-available guards (the original four):

  - `DBSync not available for table <table>`
  - `Cannot set sync flag: DBSync not available`
  - `Cannot load sync flags: DBSync not available`
  - `Cannot update last integrity time: DBSync not available`

Sync-failure messages reachable during the same shutdown race, when `synchronizeMetadataOrGroups()` fails because the sync protocol is being stopped (`m_spSyncProtocol->stop()` runs after `m_stopped` is set):

  - `Failed to synchronize <table>` (`coordinateModules`, delta sync path)
  - `Failed integrity check for <table>` (`performIntegritySync`)

### Results and Evidence

Before (nightly):

```sql
2026/06/29 20:57:06 wazuh-modulesd:agent-info: WARNING: DBSync not available for table agent_metadata
2026/06/29 20:57:06 wazuh-modulesd:agent-info: WARNING: DBSync not available for table agent_groups
2026/06/29 20:57:06 wazuh-modulesd:agent-info: WARNING: Cannot update last integrity time: DBSync not available
2026/06/30 04:19:23 wazuh-modulesd:agent-info: WARNING: Cannot set sync flag: DBSync not available
```

After: during shutdown the same conditions are logged at `DEBUG` and no longer appear at the default log level. Outside shutdown (`m_stopped == false`) the messages are still emitted at `WARNING`, so a genuine fault would remain visible.

Local validation: the modified translation unit (`agent_info_impl.cpp`) compiles cleanly with the project's native toolchain and flags (`AGENT_INFO_IMPL` object target builds; `g++ -fsyntax-only` returns no diagnostics on the TU). The change is a pure log-severity adjustment with no control-flow change; no existing unit test asserts on the severity of the affected messages.

### Artifacts Affected

- `src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp` (Agent, `wazuh-modulesd`).

### Configuration Changes

- None.

### Documentation Updates

- None.

### Tests Introduced

- None.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues