### PR TITLE
Lower log level of transient cluster IPC failures (#37277, #37276)

### DIFF
--- a/src/shared/src/agent_op.c
+++ b/src/shared/src/agent_op.c
@@ -528,11 +528,11 @@ int w_send_clustered_message(const char* command, const char* payload, char* res
                 if (response_length = OS_RecvSecureClusterTCP(sock, response, OS_MAXSTR), response_length <= 0) {
                     switch (response_length) {
                     case -2:
-                        mwarn("Cluster error detected");
+                        mdebug1("Cluster error detected");
                         send_error = TRUE;
                         break;
                     case -1:
-                        mwarn("OS_RecvSecureClusterTCP(): %s", strerror(errno));
+                        mdebug1("OS_RecvSecureClusterTCP(): %s", strerror(errno));
                         send_error = TRUE;
                         break;
                     case 0:
@@ -546,14 +546,14 @@ int w_send_clustered_message(const char* command, const char* payload, char* res
                 }
             }
             else {
-                mwarn("OS_SendSecureTCPCluster(): %s", strerror(errno));
+                mdebug1("OS_SendSecureTCPCluster(): %s", strerror(errno));
                 send_error = TRUE;
                 result = -2;
             }
             close(sock);
         }
         else {
-            mwarn("Could not connect to socket '%s': %s (%d).", sockname, strerror(errno), errno);
+            mdebug1("Could not connect to socket '%s': %s (%d).", sockname, strerror(errno), errno);
             result = -2;
             send_error = TRUE;
         }
@@ -561,7 +561,7 @@ int w_send_clustered_message(const char* command, const char* payload, char* res
         if (!send_error) {
             break;
         } else if (send_attempts == CLUSTER_SEND_MESSAGE_ATTEMPTS - 1) {
-            merror("Could not send message through the cluster after '%d' attempts.", CLUSTER_SEND_MESSAGE_ATTEMPTS);
+            mwarn("Could not send message through the cluster after '%d' attempts.", CLUSTER_SEND_MESSAGE_ATTEMPTS);
         } else {
             sleep(1);
         }

--- a/src/unit_tests/shared/test_agent_op.c
+++ b/src/unit_tests/shared/test_agent_op.c
@@ -201,11 +201,11 @@ void test_w_send_clustered_message_connection_error(void **state) {
         will_return(__wrap_external_socket_connect, -1);
 
         will_return(__wrap_strerror, "ERROR");
-        expect_string(__wrap__mwarn, formatted_msg, "Could not connect to socket 'queue/cluster/c-internal.sock': ERROR (0).");
+        expect_string(__wrap__mdebug1, formatted_msg, "Could not connect to socket 'queue/cluster/c-internal.sock': ERROR (0).");
     }
     expect_value_count(__wrap_sleep, seconds, 1, 9);
 
-    expect_string(__wrap__merror, formatted_msg, "Could not send message through the cluster after '10' attempts.");
+    expect_string(__wrap__mwarn, formatted_msg, "Could not send message through the cluster after '10' attempts.");
 
     assert_int_equal(w_send_clustered_message("command", "payload", response), -2);
 }
@@ -227,11 +227,11 @@ void test_w_send_clustered_message_send_error(void **state) {
         will_return(__wrap_OS_SendSecureTCPCluster, -1);
 
         will_return(__wrap_strerror, "ERROR");
-        expect_string(__wrap__mwarn, formatted_msg, "OS_SendSecureTCPCluster(): ERROR");
+        expect_string(__wrap__mdebug1, formatted_msg, "OS_SendSecureTCPCluster(): ERROR");
     }
     expect_value_count(__wrap_sleep, seconds, 1, 9);
 
-    expect_string(__wrap__merror, formatted_msg, "Could not send message through the cluster after '10' attempts.");
+    expect_string(__wrap__mwarn, formatted_msg, "Could not send message through the cluster after '10' attempts.");
 
     assert_int_equal(w_send_clustered_message(command, payload, response), -2);
 }
@@ -258,11 +258,11 @@ void test_w_send_clustered_message_recv_cluster_error_detected(void **state) {
         will_return(__wrap_OS_RecvSecureClusterTCP, recv_response);
         will_return(__wrap_OS_RecvSecureClusterTCP, -2);
 
-        expect_string(__wrap__mwarn, formatted_msg, "Cluster error detected");
+        expect_string(__wrap__mdebug1, formatted_msg, "Cluster error detected");
     }
     expect_value_count(__wrap_sleep, seconds, 1, 9);
 
-    expect_string(__wrap__merror, formatted_msg, "Could not send message through the cluster after '10' attempts.");
+    expect_string(__wrap__mwarn, formatted_msg, "Could not send message through the cluster after '10' attempts.");
 
     assert_int_equal(w_send_clustered_message(command, payload, response), -1);
 }
@@ -290,11 +290,11 @@ void test_w_send_clustered_message_recv_error(void **state) {
         will_return(__wrap_OS_RecvSecureClusterTCP, -1);
 
         will_return(__wrap_strerror, "ERROR");
-        expect_string(__wrap__mwarn, formatted_msg, "OS_RecvSecureClusterTCP(): ERROR");
+        expect_string(__wrap__mdebug1, formatted_msg, "OS_RecvSecureClusterTCP(): ERROR");
     }
     expect_value_count(__wrap_sleep, seconds, 1, 9);
 
-    expect_string(__wrap__merror, formatted_msg, "Could not send message through the cluster after '10' attempts.");
+    expect_string(__wrap__mwarn, formatted_msg, "Could not send message through the cluster after '10' attempts.");
 
     assert_int_equal(w_send_clustered_message(command, payload, response), -1);
 }
@@ -387,7 +387,7 @@ void test_w_send_clustered_message_success_after_connection_error(void **state) 
     will_return(__wrap_external_socket_connect, -1);
 
     will_return(__wrap_strerror, "ERROR");
-    expect_string(__wrap__mwarn, formatted_msg, "Could not connect to socket 'queue/cluster/c-internal.sock': ERROR (0).");
+    expect_string(__wrap__mdebug1, formatted_msg, "Could not connect to socket 'queue/cluster/c-internal.sock': ERROR (0).");
     expect_value(__wrap_sleep, seconds, 1);
 
     will_return(__wrap_external_socket_connect, sock_num);
@@ -424,7 +424,7 @@ void test_w_send_clustered_message_success_after_send_error(void **state) {
     will_return(__wrap_OS_SendSecureTCPCluster, -1);
 
     will_return(__wrap_strerror, "ERROR");
-    expect_string(__wrap__mwarn, formatted_msg, "OS_SendSecureTCPCluster(): ERROR");
+    expect_string(__wrap__mdebug1, formatted_msg, "OS_SendSecureTCPCluster(): ERROR");
 
     expect_value(__wrap_sleep, seconds, 1);
 
@@ -466,7 +466,7 @@ void test_w_send_clustered_message_success_after_cluster_error(void **state) {
     will_return(__wrap_OS_RecvSecureClusterTCP, recv_response);
     will_return(__wrap_OS_RecvSecureClusterTCP, -2);
 
-    expect_string(__wrap__mwarn, formatted_msg, "Cluster error detected");
+    expect_string(__wrap__mdebug1, formatted_msg, "Cluster error detected");
     expect_value(__wrap_sleep, seconds, 1);
 
     will_return(__wrap_external_socket_connect, sock_num);
@@ -508,7 +508,7 @@ void test_w_send_clustered_message_success_after_recv_error(void **state) {
     will_return(__wrap_OS_RecvSecureClusterTCP, -1);
 
     will_return(__wrap_strerror, "ERROR");
-    expect_string(__wrap__mwarn, formatted_msg, "OS_RecvSecureClusterTCP(): ERROR");
+    expect_string(__wrap__mdebug1, formatted_msg, "OS_RecvSecureClusterTCP(): ERROR");
     expect_value(__wrap_sleep, seconds, 1);
 
     will_return(__wrap_external_socket_connect, sock_num);

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_tasks_callbacks.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_tasks_callbacks.c
@@ -528,6 +528,42 @@ void test_wm_agent_upgrade_task_module_callback_no_callbacks_error(void **state)
     assert_null(cJSON_GetArrayItem(output, 2));
 }
 
+void test_wm_agent_upgrade_task_module_callback_cancel_error_debug(void **state)
+{
+    cJSON *output = cJSON_CreateArray();
+
+    cJSON *input = cJSON_CreateObject();
+    cJSON *origin = cJSON_CreateObject();
+    cJSON *parameters = cJSON_CreateObject();
+
+    cJSON_AddStringToObject(origin, "module", "upgrade_module");
+    cJSON_AddItemToObject(input, "origin", origin);
+    cJSON_AddStringToObject(input, "command", "upgrade_cancel_tasks");
+    cJSON_AddItemToObject(input, "parameters", parameters);
+
+    cJSON *task_response = cJSON_CreateObject();
+    cJSON *data = cJSON_CreateArray();
+
+    cJSON_AddNumberToObject(task_response, "error", 1);
+    cJSON_AddItemToObject(task_response, "data", data);
+    cJSON_AddStringToObject(task_response, "message", "Error");
+
+    expect_memory(__wrap_wm_agent_upgrade_send_tasks_information, message_object, input, sizeof(input));
+    will_return(__wrap_wm_agent_upgrade_send_tasks_information, task_response);
+
+    // The startup cancellation is best-effort: a task manager communication failure is logged at debug level
+    expect_string(__wrap__mtdebug1, tag, "wazuh-manager-modulesd:agent-upgrade");
+    expect_string(__wrap__mtdebug1, formatted_msg, "(8123): There has been an error executing the request in the tasks manager.");
+
+    int result = wm_agent_upgrade_task_module_callback(output, input, NULL, NULL);
+
+    state[0] = (void *)input;
+    state[1] = (void *)output;
+
+    assert_int_equal(result, OS_INVALID);
+    assert_int_equal(cJSON_GetArraySize(output), 0);
+}
+
 void test_wm_agent_upgrade_task_module_callback_error_callback_error(void **state)
 {
     cJSON *output = cJSON_CreateArray();
@@ -737,6 +773,7 @@ int main(void) {
         cmocka_unit_test_teardown(test_wm_agent_upgrade_task_module_callback_no_callbacks_ok, teardown_jsons),
         cmocka_unit_test_teardown(test_wm_agent_upgrade_task_module_callback_success_callback_ok, teardown_jsons),
         cmocka_unit_test_teardown(test_wm_agent_upgrade_task_module_callback_no_callbacks_error, teardown_jsons),
+        cmocka_unit_test_teardown(test_wm_agent_upgrade_task_module_callback_cancel_error_debug, teardown_jsons),
         cmocka_unit_test_teardown(test_wm_agent_upgrade_task_module_callback_error_callback_error, teardown_jsons),
         cmocka_unit_test_teardown(test_wm_agent_upgrade_task_module_callback_success_error_callback_error, teardown_jsons)
     };

--- a/src/wazuh_modules/src/agent_upgrade/manager/wm_agent_upgrade_tasks_callbacks.c
+++ b/src/wazuh_modules/src/agent_upgrade/manager/wm_agent_upgrade_tasks_callbacks.c
@@ -68,7 +68,16 @@ int wm_agent_upgrade_task_module_callback(cJSON *data_array, const cJSON* task_m
                 cJSON_AddItemToArray(data_array, error_json);
             }
         }
-        mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_TASK_MANANAGER_ERROR);
+        // The startup cancellation of pending upgrades is a best-effort cleanup. If the task manager
+        // is not reachable yet (e.g. a worker starting before the cluster socket is ready), the failure
+        // is transient and recoverable, so it should not be reported as an error.
+        cJSON *command = cJSON_GetObjectItem(task_module_request, task_manager_json_keys[WM_TASK_COMMAND]);
+        if (command && (command->type == cJSON_String) &&
+            !strcmp(command->valuestring, task_manager_commands_list[WM_TASK_UPGRADE_CANCEL_TASKS])) {
+            mtdebug1(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_TASK_MANANAGER_ERROR);
+        } else {
+            mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_TASK_MANANAGER_ERROR);
+        }
     } else {
         while (cJSON_GetArraySize(temp_array) > 0) {
             cJSON *item = cJSON_DetachItemFromArray(temp_array, 0);


### PR DESCRIPTION
## Description

On a worker node, at startup the agent-upgrade module (`modulesd`) runs a best-effort cancellation of pending upgrades, and other components (`remoted`, `authd`) talk to the master through the cluster socket via `w_send_clustered_message()`, which already retries up to 10 times with a backoff. During install/restart the cluster daemon may not be ready yet (or is shutting down) and either refuses (`ECONNREFUSED`) or resets (`ECONNRESET`) the connection.

On worker nodes, the `#37276` line:  `WARNING: Could not connect to socket 'queue/cluster/c-internal.sock': Connection refused (111)` is exactly this `ECONNREFUSED` case: the best-effort startup upgrade-cancel reaches the master's task manager through the cluster local socket (`c-internal.sock`, bound by `wazuh-clusterd`, which starts after `modulesd`), so during install/restart the socket may exist but not be accepting yet.

Since the operation recovers on a later attempt and none of the callers treat the failure as fatal, this logging was too severe. This PR lowers the noise:

- Per-attempt cluster IPC failures in `w_send_clustered_message` → `debug` (transient, retried).
- All attempts exhausted → `warning` instead of `error` (recoverable, does not break the Wazuh flow).
- The task manager communication error `(8123)` emitted by the startup upgrade-cancel cleanup → `debug`. Real upgrade requests keep logging it as an `error`.

No functional change: return values, retry count and backoff are unchanged. Unit tests updated/added to cover the new levels.

Closes #37277
Closes #37276
