### PR TITLE
Revert wazuh-server indexer credentials and propagate log context in indexer connector

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -2769,7 +2769,7 @@ components:
             - warning
         tag:
           type: string
-          format: alphanumeric
+          format: alphanumeric_symbols
           description: "Wazuh component that logged the event"
         timestamp:
           type: string
@@ -3771,7 +3771,7 @@ components:
       description: "Wazuh component that logged the event"
       schema:
         type: string
-        format: alphanumeric
+        format: alphanumeric_symbols
     log_level:
       in: query
       name: level

--- a/api/test/integration/env/base/manager/manager.Dockerfile
+++ b/api/test/integration/env/base/manager/manager.Dockerfile
@@ -17,6 +17,7 @@ RUN wget http://archive.ubuntu.com/ubuntu/pool/main/r/rtmpdump/librtmp1_2.4+2015
     rm -rf /var/lib/apt/lists/* && ldconfig
 
 # INSTALL MANAGER
+# Cache invalidated: WazuhLogs tag schema updated to allow parentheses in log tags (alphanumeric_symbols).
 ARG WAZUH_BRANCH
 
 ADD base/manager/supervisord.conf /etc/supervisor/conf.d/

--- a/src/shared_modules/indexer_connector/src/indexerConnectorAsyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorAsyncImpl.hpp
@@ -209,13 +209,13 @@ public:
         static auto password = Keystore::get(INDEXER_COLUMN, PASSWORD_KEY);
         if (username.empty() && password.empty())
         {
-            username = "wazuh-server";
-            password = "wazuh-server";
+            username = "admin";
+            password = "admin";
             LOG_WARN(m_logFn, "No username and password found in the keystore, using default values.");
         }
         if (username.empty())
         {
-            username = "wazuh-server";
+            username = "admin";
             LOG_WARN(m_logFn, "No username found in the keystore, using default value.");
         }
         m_secureCommunication = SecureCommunication::builder();

--- a/src/shared_modules/indexer_connector/src/indexerConnectorAsyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorAsyncImpl.hpp
@@ -142,6 +142,9 @@ public:
         , m_logFn {}
     {
         m_logFn = LogFn {callerName}.compose("indexer-connector");
+        // Install caller context so sub-objects (RocksDB queues, dispatchers) pick up the right base tag
+        // via makeLibLogFn(). Restores the previous TL value when the constructor exits.
+        const Log::ScopedModuleLogFn guard {callerName.empty() ? LogFn {"indexer-connector"} : LogFn {callerName}};
 
         if (m_queueId.empty())
         {

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -669,13 +669,13 @@ public:
         static auto password = Keystore::get(INDEXER_COLUMN, PASSWORD_KEY);
         if (username.empty() && password.empty())
         {
-            username = "wazuh-server";
-            password = "wazuh-server";
+            username = "admin";
+            password = "admin";
             LOG_WARN(m_logFn, "No username and password found in the keystore, using default values.");
         }
         if (username.empty())
         {
-            username = "wazuh-server";
+            username = "admin";
             LOG_WARN(m_logFn, "No username found in the keystore, using default value.");
         }
         m_secureCommunication = SecureCommunication::builder();

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -616,6 +616,9 @@ public:
         , m_httpRequest(httpRequest ? httpRequest : &THttpRequest::instance())
     {
         m_logFn = LogFn {callerName}.compose("indexer-connector");
+        // Install caller context so sub-objects (RocksDB queues, dispatchers) pick up the right base tag
+        // via makeLibLogFn(). Restores the previous TL value when the constructor exits.
+        const Log::ScopedModuleLogFn guard {callerName.empty() ? LogFn {"indexer-connector"} : LogFn {callerName}};
 
         if (logFunction)
         {

--- a/src/shared_modules/utils/loggerHelper.h
+++ b/src/shared_modules/utils/loggerHelper.h
@@ -354,6 +354,38 @@ namespace Log
      * Example: Log::setModuleLogFn(LogFn{WM_INVENTORY_SYNC_LOGTAG});
      */
     inline void setModuleLogFn(LogFn fn) { currentModuleLogFn() = std::move(fn); }
+
+    /**
+     * @brief RAII guard that temporarily installs a module LogFn on the calling thread.
+     *
+     * Saves the current thread-local LogFn on construction, installs the provided one,
+     * and restores the saved value on destruction. Use before constructing objects that
+     * call makeLibLogFn() so they inherit the correct caller context rather than the
+     * default "logger-helper" fallback.
+     *
+     * The guard must not outlive the thread that created it — do not store it on the heap
+     * or pass it to another thread.
+     *
+     * Example:
+     *   {
+     *       const Log::ScopedModuleLogFn guard {LogFn {callerName}};
+     *       m_queue = std::make_unique<RocksDBQueue>(...);  // picks up callerName
+     *   }  // previous context restored here
+     */
+    class ScopedModuleLogFn
+    {
+        LogFn m_saved;
+
+    public:
+        explicit ScopedModuleLogFn(LogFn fn)
+            : m_saved(currentModuleLogFn())
+        {
+            setModuleLogFn(std::move(fn));
+        }
+        ~ScopedModuleLogFn() { setModuleLogFn(std::move(m_saved)); }
+        ScopedModuleLogFn(const ScopedModuleLogFn&) = delete;
+        ScopedModuleLogFn& operator=(const ScopedModuleLogFn&) = delete;
+    };
 } // namespace Log
 
 /**

--- a/src/shared_modules/utils/tests/loggerHelper_test.cpp
+++ b/src/shared_modules/utils/tests/loggerHelper_test.cpp
@@ -13,6 +13,7 @@
 #include <chrono>
 #include <regex>
 #include <sstream>
+#include <stdexcept>
 
 namespace Log
 {
@@ -202,6 +203,51 @@ TEST_F(LogFnTest, MakeLibLogFnReplacesExistingLib)
 {
     Log::setModuleLogFn(LogFn {"proc(oldlib)"});
     EXPECT_EQ(makeLibLogFn("newlib").m_tag, "proc(newlib)");
+}
+
+TEST_F(LogFnTest, ScopedModuleLogFnRestoresPreviousContext)
+{
+    Log::setModuleLogFn(LogFn {"parent-module"});
+
+    {
+        const Log::ScopedModuleLogFn guard {LogFn {"child-module"}};
+        EXPECT_EQ(makeLibLogFn("rocksdb").m_tag, "child-module(rocksdb)");
+    }
+
+    EXPECT_EQ(Log::currentModuleLogFn().m_tag, "parent-module");
+}
+
+TEST_F(LogFnTest, ScopedModuleLogFnRestoresNestedContexts)
+{
+    Log::setModuleLogFn(LogFn {"root-module"});
+
+    {
+        const Log::ScopedModuleLogFn outerGuard {LogFn {"outer-module"}};
+        EXPECT_EQ(Log::currentModuleLogFn().m_tag, "outer-module");
+
+        {
+            const Log::ScopedModuleLogFn innerGuard {LogFn {"inner-module"}};
+            EXPECT_EQ(Log::currentModuleLogFn().m_tag, "inner-module");
+        }
+
+        EXPECT_EQ(Log::currentModuleLogFn().m_tag, "outer-module");
+    }
+
+    EXPECT_EQ(Log::currentModuleLogFn().m_tag, "root-module");
+}
+
+TEST_F(LogFnTest, ScopedModuleLogFnRestoresContextAfterException)
+{
+    Log::setModuleLogFn(LogFn {"original-module"});
+
+    EXPECT_THROW(
+        {
+            const Log::ScopedModuleLogFn guard {LogFn {"temporary-module"}};
+            throw std::runtime_error {"test exception"};
+        },
+        std::runtime_error);
+
+    EXPECT_EQ(Log::currentModuleLogFn().m_tag, "original-module");
 }
 
 TEST_F(LogFnTest, ThreadLocalStartsWithDefault)


### PR DESCRIPTION
## Summary

- **Reverts #37061 (#36311)**: Restores `"admin"` as the default indexer credential fallback. The `wazuh-server` change was premature — the `CN=admin` entry still present in `admin_dn` on the indexer side grants admin-equivalent access via the client certificate path, so the switch provided no actual least-privilege improvement. All files that #37061 touched are restored (C++ connectors, engine config defaults, keystore help text, dev-env entrypoint, installation docs, Python test mock, CHANGELOG).
- **Fixes logging context propagation (P2)**: `IndexerConnectorAsyncImpl` and `IndexerConnectorSyncImpl` compose `m_logFn` from `callerName` but never install that name as the thread-local module context. Sub-objects created during construction (`RocksDBQueue`, `AsyncValueDispatcher`, `ThreadEventDispatcher`) call `makeLibLogFn()` which reads the thread-local, producing `"logger-helper(rocksdb)"` tags when the caller has not called `setModuleLogFn()` (e.g. `analysisd`, content-manager worker threads).

  The fix adds `Log::ScopedModuleLogFn` to `loggerHelper.h` — a non-copyable RAII guard that saves, installs, and restores the thread-local `LogFn`. Both connector constructors install the guard immediately after `m_logFn` is built, so all sub-objects and the keystore static credential initialization inherit the correct base tag. The guard restores the previous value on scope exit, preventing TL contamination of the caller's thread.
