### PR TITLE
Use github.workspace for wodles report paths

### DIFF
--- a/.github/workflows/5_testunit_wodles.yml
+++ b/.github/workflows/5_testunit_wodles.yml
@@ -36,8 +36,8 @@ jobs:
         python-version: ['3.10']
     env:
       PYTHONPATH: ${{ github.workspace }}/api:${{ github.workspace }}/framework
-      TEST_REPORT_PATH: ${{ runner.temp }}/test_report.txt
-      COVERAGE_REPORT_PATH: ${{ runner.temp }}/coverage_report
+      TEST_REPORT_PATH: ${{ github.workspace }}/test_report.txt
+      COVERAGE_REPORT_PATH: ${{ github.workspace }}/coverage_report
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

The `5.X - Wodles - Unit tests` workflow (`.github/workflows/5_testunit_wodles.yml`) fails on **every** run with a **startup failure** — no job is created and no logs are produced. The GitHub UI shows *"This run likely failed because of a workflow file issue."* (e.g. run [28478254956](https://github.com/wazuh/wazuh/actions/runs/28478254956)).

The cause is that the **job-level** `env:` block references the `runner` context, which is **not available at job level**:

```yaml
jobs:
  build:
    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
    env:
      PYTHONPATH: ${{ github.workspace }}/api:${{ github.workspace }}/framework
      TEST_REPORT_PATH: ${{ runner.temp }}/test_report.txt        # invalid at job level
      COVERAGE_REPORT_PATH: ${{ runner.temp }}/coverage_report    # invalid at job level
```

Per GitHub's [context availability](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability) rules, `runner` is only available at **step level** (`jobs.<job_id>.steps.*.env`) or in `jobs.<job_id>.container.env`, never in `jobs.<job_id>.env`. The job-level `env` block is evaluated at compile time, before a runner is assigned, so `${{ runner.temp }}` is an *Unrecognized named-value* and the workflow **fails to compile** → `startup_failure`. Because the file cannot be compiled, GitHub cannot evaluate the triggers, which is why failed placeholder runs appear even on `push`/merge events that this workflow does not subscribe to.

Closes #<issue_number>

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

Use `${{ github.workspace }}` for the two report paths, matching the `PYTHONPATH` line directly above and keeping the job-level `env` block internally consistent (`github` **is** available at job level):

```diff
     env:
       PYTHONPATH: ${{ github.workspace }}/api:${{ github.workspace }}/framework
-      TEST_REPORT_PATH: ${{ runner.temp }}/test_report.txt
-      COVERAGE_REPORT_PATH: ${{ runner.temp }}/coverage_report
+      TEST_REPORT_PATH: ${{ github.workspace }}/test_report.txt
+      COVERAGE_REPORT_PATH: ${{ github.workspace }}/coverage_report
```

- **Bug fixed:** the workflow no longer references the `runner` context at job scope, so it compiles and the Wodles unit-test job runs again.
- The report file and coverage directory now live under the checked-out workspace. This is safe on ephemeral CI runners: `pytest` is invoked as `pytest wodles …` so it only collects under `wodles/` and does not pick up root-level artifacts, and the `Upload coverage report` step reads from `${{ env.COVERAGE_REPORT_PATH }}` unchanged.

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Screenshots
- Before/after comparisons
-->

- **Before:** runs end in `startup_failure` with 0 jobs and no logs.

  ```
  X 5.0.0 .github/workflows/5_testunit_wodles.yml · 28478254956
  X This run likely failed because of a workflow file issue.
  ```

- **After:** the workflow compiles (YAML + expression contexts all valid at their scope), a CodeBuild runner is assigned, and the Wodles unit-test job runs as it did before the migration.
- The CodeBuild fleet itself is confirmed healthy: sibling workflows on the same `codebuild-github-actions-codebuild-runner-server-amd-…` label (`5_codeanalysis_python_bandit_pr.yml`, `5_testunit_shared_modules_utils.yml`, `5_testcomponent_sca-rtr.yml`) are green.

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

- `.github/workflows/5_testunit_wodles.yml` (CI only). No executables, packages, or default configuration files are affected.

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

None. The change only moves two workflow environment variables from `${{ runner.temp }}` to `${{ github.workspace }}`; no product configuration is involved.

### Documentation Updates

<!--
If applicable, list the sections of documentation that have been updated as part of this pull request.
-->

None required.

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

None. This is a CI workflow fix; test selection, coverage config, and artifact upload behavior are unchanged. The fix is validated by the Wodles unit-test job compiling and running successfully again.

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality — N/A (CI workflow fix; no product code changed)
- [ ] Configuration changes documented — N/A (none)
- [ ] Developer documentation reflects the changes — N/A (none)
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
