### PR TITLE
Lower log level of transient queue send failures in modulesd

### DIFF
--- a/src/wazuh_modules/src/wm_agent_info.c
+++ b/src/wazuh_modules/src/wm_agent_info.c
@@ -422,7 +422,7 @@ static int wm_agent_info_send_stateless(const char* message)
             return -1;
         }
 
-        merror("Error sending message to queue");
+        mdebug1("Failed to send message to queue, attempting reconnection.");
 
         // A negative result here means shutdown, so exit quietly.
         if ((g_agent_info_queue = wm_agent_info_startmq(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS)) < 0)

--- a/src/wazuh_modules/src/wm_sca.c
+++ b/src/wazuh_modules/src/wm_sca.c
@@ -783,16 +783,21 @@ static int wm_sca_send_stateless(const char* message) {
     mdebug1("Sending SCA event: %s", message);
 
     if (SendMSGPredicated(g_sca_queue, message, "sca", SCA_MQ, wm_sca_is_shutting_down) < 0) {
-        merror("Error sending message to queue");
+        if (wm_sca_is_shutting_down()) {
+            return -1;
+        }
+
+        mdebug1("Failed to send message to queue, attempting reconnection.");
 
         if ((g_sca_queue = StartMQPredicated(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS, wm_sca_is_shutting_down)) < 0) {
-            merror("Cannot restart SCA message queue");
             return -1;
         }
 
         // Try to send it again
         if (SendMSGPredicated(g_sca_queue, message, "sca", SCA_MQ, wm_sca_is_shutting_down) < 0) {
-            merror("Error sending message to queue after restart");
+            if (!wm_sca_is_shutting_down()) {
+                merror("Error sending message to queue after restart");
+            }
             return -1;
         }
     }


### PR DESCRIPTION
# Description

During agent startup and restart transitions, `wazuh-agentd` briefly re-creates `queue/sockets/queue` while modulesd submodules (agent-info and SCA) are still mid-flight attempting to send events. Both modules already perform a blocking, infinite-retry reconnect (`StartMQPredicated(..., INFINITE_OPENQ_ATTEMPTS, shutdown_predicate)`), so the condition is always transient and self-healing — but the initial failure was logged at `ERROR` level, producing misleading noise. Additionally, the SCA path was missing the shutdown-predicate guard on the first `SendMSGPredicated` call, causing it to attempt a reconnect even during a clean shutdown. Resolves #37303.

## Proposed Changes

- `src/wazuh_modules/src/wm_agent_info.c` — in `wm_agent_info_send_stateless()`, downgrade the initial send-failure log from `merror("Error sending message to queue")` to `mdebug1("Failed to send message to queue, attempting reconnection.")`. The post-reconnect failure (a genuine, non-recoverable condition) retains `merror`.
- `src/wazuh_modules/src/wm_sca.c` — in `wm_sca_send_stateless()`, add the missing `wm_sca_is_shutting_down()` guard immediately after the first `SendMSGPredicated` failure, so the reconnect loop is not entered during a clean stop. Downgrade the initial failure log to `mdebug1` with the same neutral message. Remove the now-unreachable `merror("Cannot restart SCA message queue")` line — `StartMQPredicated` with `INFINITE_OPENQ_ATTEMPTS` only returns `-1` when the shutdown predicate is true, so that log would only appear on shutdown (misleading) and is replaced by a silent early return. The post-reconnect failure retains `merror` (and a matching shutdown-guard to suppress it on clean shutdown).

### Results and Evidence

The binary string diff below confirms the log strings were changed in the PR build, while the stable baseline retains the original strings.

<details><summary>Before fix — stable nightly binary (wazuh-modulesd 5.0.0-0 baseline)</summary>

```bash

```

</details>

<details><summary>After fix — PR branch binary (wazuh-modulesd 5.0.0-0, built from fix/37303-lower-log-level-queue-send-failure)</summary>

```bash

```

</details>

<details><summary>Socket-removal trigger — sync-protocol path fires at DEBUG; no ERROR from legacy agent-info/SCA path</summary>

```bash
```

</details>

### Artifacts Affected

- `wazuh-modulesd` (part of the `wazuh-agent` package)

### Configuration Changes

_No configuration changes._

### Documentation Updates

_No documentation changes required._

### Tests Introduced

_No new tests introduced._

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
