### PR TITLE
change: Allow null root_decoder as alias of empty string on policy cr…

### DIFF
--- a/src/engine/source/cmstore/interface/cmstore/datapolicy.hpp
+++ b/src/engine/source/cmstore/interface/cmstore/datapolicy.hpp
@@ -169,13 +169,15 @@ public:
             return enabledOpt.value();
         }();
 
-        // Get root decoder
+        // Get root decoder (treat null as an empty string)
         auto rootDecoder = [&]()
         {
             std::string rootDecoder;
-            if (policyJson.getString(rootDecoder, jsonpolicy::PATH_KEY_ROOT_PARENT) != json::RetGet::Success)
+            if (policyJson.getString(rootDecoder, jsonpolicy::PATH_KEY_ROOT_PARENT) != json::RetGet::Success
+                && !policyJson.isNull(jsonpolicy::PATH_KEY_ROOT_PARENT))
             {
-                throw std::runtime_error("Policy JSON must have a 'root_decoder' field");
+
+                throw std::runtime_error("Policy JSON must have a 'root_decoder' string field or null");
             }
             return rootDecoder;
         }();

--- a/src/engine/source/cmstore/test/src/unit/cmstore_test.cpp
+++ b/src/engine/source/cmstore/test/src/unit/cmstore_test.cpp
@@ -1382,6 +1382,22 @@ TEST(PolicyTest, FromJsonMissingRootDecoderThrows)
     EXPECT_THROW(cm::store::dataType::Policy::fromJson(j), std::runtime_error);
 }
 
+TEST(PolicyTest, FromJsonRootDecoderNullUUIDIsEmpty)
+{
+    auto j = makeValidPolicyJson();
+    j.setNull("/root_decoder");
+
+    auto p = cm::store::dataType::Policy::fromJson(j);
+    EXPECT_TRUE(p.getRootDecoderUUID().empty());
+}
+
+ TEST(PolicyTest, FromJsonRootDecoderWrongTypeThrows)
+ {
+     auto j = makeValidPolicyJson();
+     j.setInt(42, "/root_decoder");
+     EXPECT_THROW(cm::store::dataType::Policy::fromJson(j), std::runtime_error);
+ }
+
 TEST(PolicyTest, FromJsonMissingIntegrationsThrows)
 {
     auto j = makeValidPolicyJson();


### PR DESCRIPTION

## Description

This change allows the value within the `root_decoder` field of the policy to be accepted and treated as an alias for an empty string. This enables Wazuh-Indexer to promote policies with a `root_decoder` set to null without using an empty string. Note that while it can validate this, it will only attempt to promote it in `logtest` when the array of strings for the integrations is not empty.

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence


Tests:


```bash
(venv) ╭─root@38c14ebe6832 /workspaces/wazuh-5.x/wazuh ‹change/37344-allow-null-root-decoder●› 
╰─# cat ../z_temp_files/draft/test.json |  engine-public cm policy-validate -n test --load-in-tester 
(venv) ╭─root@38c14ebe6832 /workspaces/wazuh-5.x/wazuh ‹change/37344-allow-null-root-decoder●› 
╰─# cat ../z_temp_files/draft/test.json |  engine-public cm policy-validate -n test --load-in-tester 
Error validating policy: Failed to import namespace 'logtest_23faf0': Policy JSON must have a 'root_decoder' string field or null
```


Base policy for test:

```json
{
  "policy": {
    "index_discarded_events": false,
    "metadata": {
      "date": "2026-07-01T13:38:15Z",
      "references": [],
      "author": "Custom",
      "documentation": "",
      "modified": "2026-07-01T15:38:36.595670016Z",
      "description": "Custom space",
      "title": "Custom space",
      "compatibility": []
    },
    "root_decoder": null,
    "id": "4a2bbfac-1235-37ba-ac04-0cefe3ecace0",
    "filters": [],
    "integrations": [],
    "enrichments": [],
    "enabled": false,
    "index_unclassified_events": false
  },
  "resources": {
    "integrations": [],
    "kvdbs": [],
    "decoders": [],
    "filters": []
  }
}
```



### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- Public API

### Configuration Changes

N/A

### Tests Introduced

N/A

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
