### PR TITLE
Retry `OS_SendUnix` on `ENOBUFS` to stop dropping binary sync messages on macOS

### DIFF
--- a/src/shared/os_net/os_net.c
+++ b/src/shared/os_net/os_net.c
@@ -527,6 +527,17 @@ int OS_RecvUnix(int socket, int sizet, char *ret)
 
 /* Send a message using a Unix socket
  * Returns the OS_SOCKETERR if it fails
+ *
+ * On ENOBUFS (the receiver's datagram buffer is transiently full) we retry with
+ * a short, bounded backoff instead of dropping the message immediately. macOS
+ * does not apply blocking flow-control to AF_UNIX SOCK_DGRAM sockets: when the
+ * peer buffer is full it returns ENOBUFS right away (even on a blocking socket)
+ * rather than waiting for space as Linux does, and its default buffer is tiny
+ * (~4 KB). The userspace backoff emulates that flow-control so a brief
+ * backpressure spike (e.g. the FIM/inventory sync burst at agent startup while
+ * agentd is momentarily not draining the queue) no longer costs a message.
+ * Kept in microseconds on purpose: this is the local hot path, unlike
+ * OS_SendUDPbySize (a remote socket) which can afford whole-second waits.
  */
 int OS_SendUnix(int socket, const char *msg, int size)
 {
@@ -534,15 +545,23 @@ int OS_SendUnix(int socket, const char *msg, int size)
         size = strlen(msg) + 1;
     }
 
-    if (send(socket, msg, size, 0) < size) {
-        if (errno == ENOBUFS) {
+    for (int attempt = 0; ; attempt++) {
+        if (send(socket, msg, size, 0) >= size) {
+            return (OS_SUCCESS);
+        }
+
+        if (errno != ENOBUFS) {
+            return (OS_SOCKTERR);
+        }
+
+        if (attempt >= OS_UNIX_SEND_RETRIES) {
+            /* Still congested after the backoff budget: keep the original
+             * contract so the caller drops the message and warns once. */
             return (OS_SOCKBUSY);
         }
 
-        return (OS_SOCKTERR);
+        usleep((useconds_t)OS_UNIX_SEND_BACKOFF_US << attempt);
     }
-
-    return (OS_SUCCESS);
 }
 #endif
 

--- a/src/shared/os_net/os_net.h
+++ b/src/shared/os_net/os_net.h
@@ -34,6 +34,10 @@ typedef int gid_t;
 
 #define WAZUH_IPC_TIMEOUT 600    // seconds
 
+/* OS_SendUnix: bounded ENOBUFS retry (local Unix datagram backpressure). */
+#define OS_UNIX_SEND_RETRIES     5
+#define OS_UNIX_SEND_BACKOFF_US  1000
+
 /* OS_Bindport*
  * Bind a specific port (protocol and a ip).
  * If the IP is not set, it is going to use ADDR_ANY

--- a/src/unit_tests/os_net/CMakeLists.txt
+++ b/src/unit_tests/os_net/CMakeLists.txt
@@ -34,7 +34,7 @@ list(APPEND os_net_flags "-Wl,--wrap,socket -Wl,--wrap,listen -Wl,--wrap,bind -W
                           -Wl,--wrap,getsockopt -Wl,--wrap,connect -Wl,--wrap,accept -Wl,--wrap,send \
                           -Wl,--wrap,recv -Wl,--wrap,recvfrom -Wl,--wrap,chmod -Wl,--wrap,chown -Wl,--wrap,getuid -Wl,--wrap,getgid -Wl,--wrap,stat -Wl,--wrap,fcntl \
                           -Wl,--wrap,getaddrinfo -Wl,--wrap,OS_IsValidIP -Wl,--wrap,OS_GetIPv4FromIPv6 -Wl,--wrap,OS_ExpandIPv6 \
-                          -Wl,--wrap,sleep -Wl,--wrap,getpid ${DEBUG_OP_WRAPPERS}")
+                          -Wl,--wrap,sleep -Wl,--wrap,usleep -Wl,--wrap,getpid ${DEBUG_OP_WRAPPERS}")
 
 # Compiling tests
 list(LENGTH os_net_names count)

--- a/src/unit_tests/os_net/test_os_net.c
+++ b/src/unit_tests/os_net/test_os_net.c
@@ -12,6 +12,7 @@
 #include <cmocka.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 
 #include "shared.h"
 #include "os_err.h"
@@ -525,6 +526,54 @@ void test_send_unix(void **state) {
     assert_int_equal(OS_SendUnix(data->client_socket, SENDSTRING, 0), 0);
 }
 
+/* ENOBUFS is transient backpressure: OS_SendUnix must retry and, if the buffer
+ * drains within the backoff budget, succeed instead of dropping the message. */
+void test_send_unix_enobufs_retry_success(void **state) {
+    test_struct_t *data = (test_struct_t *)*state;
+    const int size = strlen(SENDSTRING);
+
+    data->client_socket = 3;
+    test_wrap_send_errno = ENOBUFS;         /* every failing send() reports ENOBUFS */
+    will_return(__wrap_send, -1);           /* attempt 0: busy */
+    expect_function_call(__wrap_usleep);
+    will_return(__wrap_send, -1);           /* attempt 1: busy */
+    expect_function_call(__wrap_usleep);
+    will_return(__wrap_send, size);         /* attempt 2: drained -> sent */
+
+    assert_int_equal(OS_SendUnix(data->client_socket, SENDSTRING, size), OS_SUCCESS);
+    test_wrap_send_errno = 0;
+}
+
+/* If congestion outlasts the retry budget, keep the original contract:
+ * return OS_SOCKBUSY so the caller drops the message and warns once. */
+void test_send_unix_enobufs_retry_exhausted(void **state) {
+    test_struct_t *data = (test_struct_t *)*state;
+    const int size = strlen(SENDSTRING);
+
+    data->client_socket = 3;
+    test_wrap_send_errno = ENOBUFS;
+    for (int i = 0; i <= OS_UNIX_SEND_RETRIES; i++) {   /* initial send + retries */
+        will_return(__wrap_send, -1);
+    }
+    expect_function_calls(__wrap_usleep, OS_UNIX_SEND_RETRIES);
+
+    assert_int_equal(OS_SendUnix(data->client_socket, SENDSTRING, size), OS_SOCKBUSY);
+    test_wrap_send_errno = 0;
+}
+
+/* A non-ENOBUFS send error is a real socket failure: fail fast, no retry. */
+void test_send_unix_non_enobufs_no_retry(void **state) {
+    test_struct_t *data = (test_struct_t *)*state;
+    const int size = strlen(SENDSTRING);
+
+    data->client_socket = 3;
+    test_wrap_send_errno = EPIPE;
+    will_return(__wrap_send, -1);           /* single send, then immediate error */
+
+    assert_int_equal(OS_SendUnix(data->client_socket, SENDSTRING, size), OS_SOCKTERR);
+    test_wrap_send_errno = 0;
+}
+
 void test_recv_unix(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     char buffer[BUFFERSIZE];
@@ -1020,6 +1069,9 @@ int main(void) {
         /* Send a message using a Unix socket */
         cmocka_unit_test_setup_teardown(test_send_unix, test_setup, test_teardown),
         cmocka_unit_test(test_send_unix_invalid_sockets),
+        cmocka_unit_test_setup_teardown(test_send_unix_enobufs_retry_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_send_unix_enobufs_retry_exhausted, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_send_unix_non_enobufs_no_retry, test_setup, test_teardown),
 
         /* Receive a message using a Unix socket */
         cmocka_unit_test_setup_teardown(test_recv_unix, test_setup, test_teardown),

--- a/src/unit_tests/wrappers/linux/socket_wrappers.c
+++ b/src/unit_tests/wrappers/linux/socket_wrappers.c
@@ -15,10 +15,17 @@
 #include <cmocka.h>
 #include <string.h>
 #include <stdlib.h>
+#include <errno.h>
 #include "../common.h"
 
 #define BUFFERSIZE 1024
 #define SENDSTRING "Hello World!\n"
+
+/* Opt-in errno for __wrap_send: cmocka's mock() may clobber errno, so a test
+ * that needs send() to fail with a specific errno (e.g. ENOBUFS to exercise the
+ * OS_SendUnix backpressure retry) sets this and the wrapper applies it on every
+ * failing call. Default 0 keeps the historical behaviour (errno untouched). */
+int test_wrap_send_errno = 0;
 
 int __wrap_socket(__attribute__((unused))int __domain, __attribute__((unused))int __type, __attribute__((unused))int __protocol) {
     return mock();
@@ -55,7 +62,11 @@ int __wrap_accept(__attribute__((unused))int __fd, struct sockaddr * __addr, __a
 }
 
 ssize_t __wrap_send(__attribute__((unused))int __fd, __attribute__((unused))const void *__buf, __attribute__((unused))size_t __n, __attribute__((unused))int __flags) {
-    return mock();
+    ssize_t ret = mock();
+    if (ret < 0 && test_wrap_send_errno != 0) {
+        errno = test_wrap_send_errno;
+    }
+    return ret;
 }
 
 ssize_t __wrap_sendto(__attribute__((unused)) int __fd, __attribute__((unused)) const void *__buf, __attribute__((unused)) size_t __n, __attribute__((unused)) int __flags,

--- a/src/unit_tests/wrappers/linux/socket_wrappers.h
+++ b/src/unit_tests/wrappers/linux/socket_wrappers.h
@@ -14,6 +14,11 @@
 #include <sys/socket.h>
 #include <netdb.h>
 
+/* When non-zero, __wrap_send sets errno to this value on a failing (mock < 0)
+ * call. Lets a test drive OS_SendUnix's ENOBUFS backpressure retry. Default 0
+ * leaves errno untouched (historical behaviour). Reset it in test teardown. */
+extern int test_wrap_send_errno;
+
 int __wrap_socket(__attribute__((unused))int __domain,__attribute__((unused))int __type,__attribute__((unused))int __protocol);
 
 int __wrap_bind(__attribute__((unused))int __fd, __attribute__((unused))__CONST_SOCKADDR_ARG __addr, __attribute__((unused))socklen_t __len);


### PR DESCRIPTION
## Description

macOS agents intermittently log the following warning shortly after startup:

```
wazuh-syscheckd: WARNING: Socket busy, discarding binary message.
wazuh-modulesd: WARNING: Socket busy, discarding binary message.
```

This is emitted by `SendBinaryMSGAction` (`src/shared/src/mq_op.c`) when `OS_SendUnix` returns `OS_SOCKBUSY`, i.e. when `send()` on the local agent queue (an `AF_UNIX` `SOCK_DGRAM` socket) fails with `errno == ENOBUFS`. The message is dropped and the function returns success, so the sync protocol is not notified and does not retry immediately; the lost delta is only recovered on the next integrity/reconciliation cycle.

### Root cause (confirmed on macOS 15):

1. **No blocking flow-control for AF_UNIX datagrams.** The agent queue sockets are blocking (only `FD_CLOEXEC` is set). On Linux a blocking `send()` to a full datagram buffer blocks until space is available; on macOS it returns `ENOBUFS` **immediately**, dropping the datagram. This is the dominant macOS-specific factor.
2. **Fixed, non-autotuning receive buffer.** The agent raises the queue socket's `SO_RCVBUF` to `OS_MAXSTR + 512` (~64 KB) in `OS_SetSocketSize` (so `net.local.dgram.recvspace`, the 4 KB default, is *not* the operative value — the code overrides it and macOS honours the override). Unlike Linux, that 64 KB is fixed and does not autotune, so a large enough startup sync burst that outpaces `wazuh-agentd`'s draining can still fill it.

These behaviours combine when several modules synchronize at once. The observed trigger is a **shared-configuration reload**: right after the agent enrolls and connects, the manager pushes shared config, the agent reloads (restarts all daemons together), and SCA, syscollector and FIM then begin synchronizing within ~1–2 s of each other. That concurrent, multi-emitter burst overruns the ~64 KB queue while `wazuh-agentd` (just reconnected) is momentarily not draining it, so `send()` returns `ENOBUFS` and the message is dropped instead of waiting for space. The warning fires once per process (`static reported` guard), which is why the two duplicate issues each saw a different daemon (`syscheckd`/FIM in #37300, `modulesd`/SCA in #37335): both use the same code path and the same shared local queue.

This is **not** a shutdown/teardown condition: a closed/torn-down socket yields `OS_SOCKTERR` (logged at debug), a different branch.

## Proposed Changes

`OS_SendUnix` now retries on `ENOBUFS` with a short, bounded exponential backoff instead of dropping the message on the first failure. This emulates in userspace the flow-control that Linux provides natively in the kernel.

- New tunables in `os_net.h`: `OS_UNIX_SEND_RETRIES = 5`, `OS_UNIX_SEND_BACKOFF_US = 1000` (1/2/4/8/16 ms → ~31 ms worst-case budget).
- Behaviour preserved for every other case: success → `OS_SUCCESS`; non-`ENOBUFS` error → immediate `OS_SOCKTERR` (fail fast, no retry); still congested after the budget → `OS_SOCKBUSY`, keeping the original drop-and-warn-once contract.
- Kept in microseconds on purpose: this is the local hot path, unlike `OS_SendUDPbySize` (a remote socket) which can afford whole-second waits.
- Transparent to all `OS_SendUnix` callers (`SendMSGAction`, `SendBinaryMSGAction`, execd receiver, `wm_control`, `SendMSGtoSCK`): their existing retry loops only react to `OS_SOCKTERR`, so the new `ENOBUFS` backoff does not compound.

### Results and Evidence

Validated on a macOS 15 (build 24A335) agent VM running Wazuh 5.0.0.

**macOS kernel defaults:**

```
net.local.dgram.recvspace: 4096      # default only; the agent overrides SO_RCVBUF to ~64 KB
net.local.dgram.maxdgram:  2048
kern.ipc.maxsockbuf:       8388608   # hard cap for setsockopt(SO_RCVBUF)
```

**Blocking-socket behaviour (the confirmed macOS deviation, dominant factor):** a blocking `AF_UNIX` `SOCK_DGRAM` `send()` to a full buffer returned `errno 55 (ENOBUFS)` immediately, without waiting for a 500 ms `SO_SNDTIMEO` — i.e. it drops instead of blocking (Linux would block until space frees).

**Datagram capacity before `ENOBUFS` (deterministic socket probe, 350 B messages) — scales with `SO_RCVBUF`:**

| `SO_RCVBUF` | Datagrams accepted before `ENOBUFS` |
|-------------|-------------------------------------|
| 4096 (kernel default, not used by the agent) | 11 |
| **65536 (≈ the agent's operative buffer)** | **179** |
| 262144 | 716 |
| 1048576 | 2864 |

So the agent's queue holds ~180 small deltas before `ENOBUFS`; the startup baseline burst can exceed that while `agentd` is not draining. Confirmed the agent sets this buffer via the `(unix_domain) Maximum send buffer set to: '65792'` debug line and the `OS_SetSocketSize(RECV_SOCK, OS_MAXSTR + 512)` call path.

**A/B of the fix on real macOS socket semantics** (buffer full, reader resumes draining after a delay):

| Scenario | Old (single send) | New (bounded retry) |
|----------|-------------------|---------------------|
| Reader drains at 10 ms | `OS_SOCKBUSY` (drop), 0 ms | **`OS_SUCCESS`** (~23 ms) |
| Reader drains at 100 ms (beyond budget) | `OS_SOCKBUSY` (drop), 0 ms | `OS_SOCKBUSY` (drop, bounded), ~45 ms |

The retry saves the message under transient congestion (the failing scenario) and still gives up gracefully — bounded — when congestion truly persists.

**End-to-end reproduction and fix validation (macOS 15 agent, `debug=0`):** the failure was reproduced on the packaged agent by forcing a shared-configuration reload — install the agent pointing at a wrong manager address, start it (cannot connect), then correct the address and start again: the agent enrolls, reloads on the shared config, and the concurrent SCA/syscollector/FIM sync burst triggers the warning.

<details><summary>Before fix</summary>

```console
2026/07/02 15:21:19 wazuh-agentd: INFO: Started (pid: 1859).
2026/07/02 15:21:19 wazuh-agentd: INFO: Requesting a key from server: 10.0.0.2
2026/07/02 15:21:22 wazuh-modulesd: INFO: Started (pid: 1903).
2026/07/02 15:21:22 wazuh-modulesd:control: INFO: Starting control thread.
2026/07/02 15:22:16 wazuh-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2026/07/02 15:22:16 wazuh-syscheckd: INFO: (1756): Shutdown received. Releasing resources.
2026/07/02 15:22:16 wazuh-syscheckd: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2026/07/02 15:22:16 wazuh-agentd: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2026/07/02 15:22:16 wazuh-execd: INFO: (1314): Shutdown received. Deleting responses.
2026/07/02 15:22:16 wazuh-execd: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2026/07/02 15:23:10 wazuh-agentd: INFO: Started (pid: 2197).
2026/07/02 15:23:10 wazuh-agentd: INFO: Requesting a key from server: 172.31.71.160
2026/07/02 15:23:10 wazuh-agentd: INFO: No authentication password provided
2026/07/02 15:23:10 wazuh-agentd: INFO: Using agent name as: ip-172-31-39-235.ec2.internal
2026/07/02 15:23:10 wazuh-agentd: INFO: Waiting for server reply
2026/07/02 15:23:10 wazuh-agentd: INFO: Valid key received
2026/07/02 15:23:13 wazuh-modulesd: INFO: Started (pid: 2240).
2026/07/02 15:23:13 wazuh-modulesd:control: INFO: Starting control thread.
2026/07/02 15:23:30 wazuh-agentd: INFO: (1410): Reading authentication keys file.
2026/07/02 15:23:30 wazuh-agentd: INFO: Trying to connect to server ([172.31.71.160]:1514/tcp).
2026/07/02 15:23:30 wazuh-agentd: INFO: (4102): Connected to the server ([172.31.71.160]:1514/tcp).
2026/07/02 15:23:51 wazuh-agentd: INFO: Agent is reloading due to shared configuration changes.
2026/07/02 15:23:51 wazuh-modulesd:control: INFO: Requested 'reload' via Wazuh-launcher (flag 'var/run/wazuh-control.request')
2026/07/02 15:23:53 wazuh-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2026/07/02 15:23:53 wazuh-syscheckd: INFO: (1756): Shutdown received. Releasing resources.
2026/07/02 15:23:53 wazuh-syscheckd: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2026/07/02 15:23:53 wazuh-execd: INFO: (1314): Shutdown received. Deleting responses.
2026/07/02 15:23:53 wazuh-execd: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2026/07/02 15:23:59 wazuh-modulesd: INFO: Started (pid: 2421).
2026/07/02 15:23:59 wazuh-modulesd:control: INFO: Starting control thread.
2026/07/02 15:24:11 wazuh-execd: INFO: Started (pid: 2383).
2026/07/02 15:24:11 wazuh-rootcheck: INFO: Started (pid: 2398).
2026/07/02 15:24:11 wazuh-syscheckd: INFO: Started (pid: 2398).
2026/07/02 15:24:11 wazuh-syscheckd: INFO: (6000): Starting daemon...
2026/07/02 15:24:11 wazuh-rootcheck: INFO: Starting rootcheck scan.
2026/07/02 15:24:11 wazuh-syscheckd: INFO: (6010): File integrity monitoring scan frequency: 43200 seconds
2026/07/02 15:24:11 wazuh-syscheckd: INFO: (6008): File integrity monitoring scan started.
2026/07/02 15:24:11 wazuh-syscheckd: INFO: (6961): Configured path '/etc' is a symbolic link to '/private/etc'. Without 'follow_symbolic_link' enabled, only the symlink itself will be monitored, not the directory contents. Consider monitoring '/private/etc' directly or enabling 'follow_symbolic_link'.
2026/07/02 15:24:11 wazuh-modulesd:agent-upgrade: INFO: Started (pid: 2421).
2026/07/02 15:24:11 wazuh-modulesd:agent-info: INFO: Started (pid: 2421).
2026/07/02 15:24:11 wazuh-modulesd:sca: INFO: Started (pid: 2421).
2026/07/02 15:24:11 wazuh-modulesd:syscollector: INFO: Started (pid: 2421).
2026/07/02 15:24:11 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/07/02 15:24:11 wazuh-modulesd:sca: INFO: Scan started.
2026/07/02 15:24:12 wazuh-logcollector: INFO: (1604): Monitoring macOS logs with: /usr/bin/log stream --style syslog --type activity --type log --type trace --level info --predicate (process == "sudo") or (process == "sessionlogoutd" and message contains "logout is complete.") or (process == "sshd") or (process == "tccd" and message contains "Update Access Record") or (message contains "SessionAgentNotificationCenter") or (process == "screensharingd" and message contains "Authentication") or (process == "securityd" and eventMessage contains "Session" and subsystem == "com.apple.securityd").
2026/07/02 15:24:12 wazuh-logcollector: INFO: Started (pid: 2410).
2026/07/02 15:24:12 wazuh-logcollector: INFO: Startup completed. Runtime-discovered files will be read from beginning.
2026/07/02 15:24:14 wazuh-modulesd:sca: INFO: Scan ended.
2026/07/02 15:24:15 wazuh-modulesd:sca: INFO: Starting SCA synchronization.
2026/07/02 15:24:15 wazuh-modulesd: WARNING: Socket busy, discarding binary message.
2026/07/02 15:24:15 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2026/07/02 15:24:16 wazuh-modulesd:syscollector: INFO: Starting inventory synchronization.
2026/07/02 15:24:16 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2026/07/02 15:24:16 wazuh-syscheckd: INFO: Starting FIM synchronization.
2026/07/02 15:24:16 wazuh-syscheckd: WARNING: Socket busy, discarding binary message.
2026/07/02 15:24:55 wazuh-rootcheck: INFO: Rootcheck scan ended.
2026/07/02 15:25:17 wazuh-modulesd:sca: INFO: SCA synchronization finished successfully.
2026/07/02 15:25:37 wazuh-syscheckd: INFO: FIM synchronization finished successfully.
2026/07/02 15:25:57 wazuh-modulesd:syscollector: INFO: VD first sync completed, metadata marker persisted.
2026/07/02 15:25:57 wazuh-modulesd:syscollector: INFO: Syscollector synchronization process finished successfully.
```

</details> 

<details><summary>After fix</summary>

```console
2026/07/02 16:30:25 wazuh-agentd: INFO: Started (pid: 14499).
2026/07/02 16:30:25 wazuh-agentd: INFO: Requesting a key from server: 10.0.0.2
2026/07/02 16:30:28 wazuh-modulesd: INFO: Started (pid: 14540).
2026/07/02 16:30:28 wazuh-modulesd:control: INFO: Starting control thread.
2026/07/02 16:30:53 wazuh-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2026/07/02 16:30:53 wazuh-syscheckd: INFO: (1756): Shutdown received. Releasing resources.
2026/07/02 16:30:53 wazuh-syscheckd: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2026/07/02 16:30:53 wazuh-agentd: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2026/07/02 16:30:53 wazuh-execd: INFO: (1314): Shutdown received. Deleting responses.
2026/07/02 16:30:53 wazuh-execd: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2026/07/02 16:31:43 wazuh-agentd: INFO: Started (pid: 14742).
2026/07/02 16:31:43 wazuh-agentd: INFO: Requesting a key from server: 172.31.71.160
2026/07/02 16:31:43 wazuh-agentd: INFO: No authentication password provided
2026/07/02 16:31:43 wazuh-agentd: INFO: Using agent name as: ip-172-31-39-235.ec2.internal
2026/07/02 16:31:43 wazuh-agentd: INFO: Waiting for server reply
2026/07/02 16:31:43 wazuh-agentd: INFO: Valid key received
2026/07/02 16:31:46 wazuh-modulesd: INFO: Started (pid: 14787).
2026/07/02 16:31:46 wazuh-modulesd:control: INFO: Starting control thread.
2026/07/02 16:32:03 wazuh-agentd: INFO: (1410): Reading authentication keys file.
2026/07/02 16:32:03 wazuh-agentd: INFO: Trying to connect to server ([172.31.71.160]:1514/tcp).
2026/07/02 16:32:04 wazuh-agentd: INFO: (4102): Connected to the server ([172.31.71.160]:1514/tcp).
2026/07/02 16:32:24 wazuh-agentd: INFO: Agent is reloading due to shared configuration changes.
2026/07/02 16:32:24 wazuh-modulesd:control: INFO: Requested 'reload' via Wazuh-launcher (flag 'var/run/wazuh-control.request')
2026/07/02 16:32:25 wazuh-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2026/07/02 16:32:25 wazuh-syscheckd: INFO: (1756): Shutdown received. Releasing resources.
2026/07/02 16:32:25 wazuh-syscheckd: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2026/07/02 16:32:25 wazuh-execd: INFO: (1314): Shutdown received. Deleting responses.
2026/07/02 16:32:25 wazuh-execd: INFO: (1225): SIGNAL [(15)-(Terminated: 15)] Received. Exit Cleaning...
2026/07/02 16:32:32 wazuh-modulesd: INFO: Started (pid: 14967).
2026/07/02 16:32:32 wazuh-modulesd:control: INFO: Starting control thread.
2026/07/02 16:32:44 wazuh-modulesd:agent-upgrade: INFO: Started (pid: 14967).
2026/07/02 16:32:44 wazuh-modulesd:agent-info: INFO: Started (pid: 14967).
2026/07/02 16:32:44 wazuh-modulesd:sca: INFO: Started (pid: 14967).
2026/07/02 16:32:44 wazuh-modulesd:syscollector: INFO: Started (pid: 14967).
2026/07/02 16:32:44 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/07/02 16:32:44 wazuh-modulesd:sca: INFO: Scan started.
2026/07/02 16:32:44 wazuh-logcollector: INFO: (1604): Monitoring macOS logs with: /usr/bin/log stream --style syslog --type activity --type log --type trace --level info --predicate (process == "sudo") or (process == "sessionlogoutd" and message contains "logout is complete.") or (process == "sshd") or (process == "tccd" and message contains "Update Access Record") or (message contains "SessionAgentNotificationCenter") or (process == "screensharingd" and message contains "Authentication") or (process == "securityd" and eventMessage contains "Session" and subsystem == "com.apple.securityd").
2026/07/02 16:32:44 wazuh-logcollector: INFO: Started (pid: 14955).
2026/07/02 16:32:44 wazuh-logcollector: INFO: Startup completed. Runtime-discovered files will be read from beginning.
2026/07/02 16:32:45 wazuh-execd: INFO: Started (pid: 14928).
2026/07/02 16:32:45 wazuh-rootcheck: INFO: Started (pid: 14943).
2026/07/02 16:32:45 wazuh-syscheckd: INFO: Started (pid: 14943).
2026/07/02 16:32:45 wazuh-syscheckd: INFO: (6000): Starting daemon...
2026/07/02 16:32:45 wazuh-rootcheck: INFO: Starting rootcheck scan.
2026/07/02 16:32:45 wazuh-syscheckd: INFO: (6010): File integrity monitoring scan frequency: 43200 seconds
2026/07/02 16:32:45 wazuh-syscheckd: INFO: (6008): File integrity monitoring scan started.
2026/07/02 16:32:45 wazuh-syscheckd: INFO: (6961): Configured path '/etc' is a symbolic link to '/private/etc'. Without 'follow_symbolic_link' enabled, only the symlink itself will be monitored, not the directory contents. Consider monitoring '/private/etc' directly or enabling 'follow_symbolic_link'.
2026/07/02 16:32:47 wazuh-modulesd:sca: INFO: Scan ended.
2026/07/02 16:32:47 wazuh-modulesd:sca: INFO: Starting SCA synchronization.
2026/07/02 16:32:48 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2026/07/02 16:32:49 wazuh-modulesd:syscollector: INFO: Starting inventory synchronization.
2026/07/02 16:32:50 wazuh-syscheckd: INFO: (6009): File integrity monitoring scan ended.
2026/07/02 16:32:50 wazuh-syscheckd: INFO: Starting FIM synchronization.
2026/07/02 16:32:58 wazuh-modulesd:sca: INFO: SCA synchronization finished successfully.
2026/07/02 16:32:58 wazuh-syscheckd: INFO: FIM synchronization finished successfully.
2026/07/02 16:33:18 wazuh-modulesd:syscollector: INFO: VD first sync completed, metadata marker persisted.
2026/07/02 16:33:18 wazuh-modulesd:syscollector: INFO: Syscollector synchronization process finished successfully.
```

</details> 


> Note: this must be measured with `debug=0`. Enabling `syscheck.debug=2` / `wazuh_modules.debug=2` masks the bug — the extra per-message logging I/O throttles the sender enough that `agentd` keeps the queue drained and the overflow never happens. The `WARNING` is warning-level (always logged), so its absence under `debug=2` means the drop genuinely did not occur.

### Artifacts Affected

- `src/shared/os_net/os_net.c` — `OS_SendUnix` retry logic.
- `src/shared/os_net/os_net.h` — `OS_UNIX_SEND_RETRIES` / `OS_UNIX_SEND_BACKOFF_US`.
- `src/unit_tests/os_net/test_os_net.c` — new unit tests.
- `src/unit_tests/os_net/CMakeLists.txt` — wrap `usleep` for the test target.
- `src/unit_tests/wrappers/linux/socket_wrappers.{c,h}` — opt-in `errno` hook for the `send` wrapper (default off; existing tests unaffected).

### Configuration Changes

None. The retry budget is defined by compile-time constants; there are no new `ossec.conf`/`local_internal_options.conf` settings.

### Documentation Updates

None required — no user-facing behaviour or configuration surface changes.

### Tests Introduced

- `test_send_unix_enobufs_retry_success` — two `ENOBUFS` failures then success → `OS_SUCCESS`, `usleep` called twice.
- `test_send_unix_enobufs_retry_exhausted` — congestion beyond the budget → `OS_SOCKBUSY`, `usleep` called `OS_UNIX_SEND_RETRIES` times.
- `test_send_unix_non_enobufs_no_retry` — non-`ENOBUFS` error → immediate `OS_SOCKTERR`, no retry.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented (none)
- [x] Developer documentation reflects the changes (none required)
- [ ] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
