### PR TITLE
fix: overwrite re-indexed docs after a data-clean instead of gating on external version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to this project will be documented in this file.
 - Fixed `wazuh-db` error assigning groups by avoiding the keyentries counter as index. ([#34082](https://github.com/wazuh/wazuh/issues/34082))
 - Fixed token validation race condition after revoke. ([#35043](https://github.com/wazuh/wazuh/issues/35043))
 - Handled the stop signal during vulnerability feed download. ([#35638](https://github.com/wazuh/wazuh/issues/35638))
+- Fixed module state (e.g. SCA) disappearing from the indexer after a data-clean and re-sync, where re-indexed documents were rejected as version conflicts and silently dropped. ([#37334](https://github.com/wazuh/wazuh/issues/37334))
 
 ### Agent
 

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -1109,6 +1109,21 @@ public:
                             }
                         }
 
+                        // #37334: an index whose docs were just deleted in this session (a DataClean above,
+                        // or the Mode_ModuleFull delete-by-query) must be re-indexed so the re-sync WINS over
+                        // the delete. Those deletes use internal versioning and bump the doc/tombstone
+                        // _version, while a normal re-index is gated by external_gte carrying the agent's
+                        // per-doc version — which the agent resets when it rebuilds its module DB after a
+                        // data-clean (e.g. SCA re-creates sca_check at version 1). provided < retained then
+                        // makes every re-synced doc 409 ("version conflict") and get silently dropped, leaving
+                        // the index empty. For a just-cleared index the re-index is authoritative, so we skip
+                        // the external_gte guard below and overwrite unconditionally.
+                        std::set<std::string> clearedIndices = res.context->dataCleanIndices;
+                        if (res.context->mode == Wazuh::SyncSchema::Mode_ModuleFull)
+                        {
+                            clearedIndices.insert(res.context->indices.begin(), res.context->indices.end());
+                        }
+
                         const auto prefix = std::format("{}_", res.context->sessionId);
 
                         // Track if we have any bulk data to send to indexer
@@ -1256,7 +1271,12 @@ public:
                                     dataString = document.dump();
 
                                     const auto version = data->version();
-                                    if (version && version > 0)
+                                    // #37334: skip the external_gte guard when this index was just cleared
+                                    // (DataClean / Mode_ModuleFull). The delete bumped the tombstone above the
+                                    // agent's reset version, so a guarded re-index would 409 and be dropped;
+                                    // the re-index is authoritative here, so overwrite unconditionally.
+                                    const bool indexWasCleared = clearedIndices.count(std::string(rawIndex)) != 0;
+                                    if (version && version > 0 && !indexWasCleared)
                                     {
                                         m_indexerConnector->bulkIndex(
                                             elementId, rawIndex, dataString, std::to_string(version));


### PR DESCRIPTION
## Description

After a state module's data is cleaned and re-synchronized (for example SCA disabled and re-enabled through group configuration, or the module's local database being lost/recreated), the indexer silently rejects every re-synced document as a version conflict. The module logs "synchronization finished successfully" and latches its first-sync marker, but the `wazuh-states-*` index stays empty — permanently, since the latch prevents any retry. In the field this presents as an **empty SCA dashboard** that looks like database corruption.

Related to #37334 (the empty-dashboard symptom investigated there; the leftover `-wal`/`-shm` shutdown item is addressed separately in #37353).

## Proposed Changes

`wazuh-states-*` documents are indexed with `version_type=external_gte` carrying the agent's per-document version, while the deletes the manager performs (`deleteByQuery` for a DataClean, and the `Mode_ModuleFull` delete-by-query every full sync runs before re-indexing) carry **no version** and therefore use OpenSearch internal versioning, which bumps the delete tombstone to `old + 1`. When the agent rebuilds its module database (data-clean on disable, checksum recovery, lost/corrupt DB), it re-syncs every document at the **reset** version (`sca_check.version` starts at 1), so `provided < retained tombstone` and every document gets a 409, which the connector counts as an "acceptable version conflict" (success, no retry, not surfaced).

Fix, in `InventorySyncFacade` (one file):
- Build a `clearedIndices` set = the session's `dataCleanIndices` ∪ (for `Mode_ModuleFull`, the Start indices) before the re-index loop.
- In the upsert branch, documents whose index was just cleared in this session are indexed through the **plain `bulkIndex` overload** (no `external_gte`), so the authoritative re-sync overwrites the delete tombstones instead of being rejected by them.
- Normal delta synchronizations keep the `external_gte` guard unchanged.

The manager is the right place for the fix: it is the only party that knows the index was just cleared, and the agent cannot outrank tombstones it cannot see (its versions were just reset to 1).

### Results and Evidence

**Mechanism proof (direct against OpenSearch):** a versioned document, deleted internally, rejects an equal-version external re-index:

```
doc _version = 11
plain DELETE                     -> tombstone _version = 12
re-index external_gte version=11 -> 409 version_conflict_engine_exception
re-index external_gte version=12 -> created
```

**Reproduction on a coherent 5.0.0 beta3 (nightly packages, stock manager)** — SCA disabled via group config (data-clean) and re-enabled; also reproduced with *no* group changes at all by removing the module's local DB while its documents were still indexed:

```
agent:   SCA synchronization finished successfully
manager: inventory-sync(indexer-connector): Bulk operation summary:
         207 total, 0 success, 207 acceptable version conflicts, 0 failures
result:  wazuh-states-sca for the agent = 0, held indefinitely (first_sync latched, 207 checks local)
```

The rejection happens at the same second the agent reports success, and even a retried synchronization is fully rejected again (two consecutive all-conflict bulk summaries observed).

**With this PR (manager rebuilt from this branch, same sequences):**

```
baseline 207 -> data-clean -> re-enable:
  t+40s: wazuh-states-sca = 207 recovered   (was 0 forever on stock)
  acceptable-version-conflict lines in manager log: 0
full original sequence (adds a tight third group change): 0 -> 207, stable for 120 s
all four agents disabled/re-enabled: {001:207, 002:207, 003:207, 004:207} = 828
stress: 6/6 iterations of multi-agent data-clean -> re-enable (tight timing,
        plus a group change mid-resync on even iterations) all recovered to 828,
        zero version conflicts
```

Control case: a full re-sync **without** a version reset (local DB intact) never conflicted before or after the fix — the change only affects documents whose index was cleared in the same session.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux (manager built from this branch inside the test container; manager package builds for deb/rpm on amd64/arm64 pass on this PR)
  - [ ] Windows — N/A (manager-only change)
  - [ ] MAC OS X — N/A (manager-only change)
- [x] Log syntax and correct language review (no new log messages introduced)

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows — N/A
- Memory tests for macOS — N/A

- Decoder/Rule tests _(Wazuh v4.x)_ — N/A
- Engine _(Wazuh v5.x and above)_ — N/A
- Wazuh server API/Framework — N/A

### Artifacts Affected

- `wazuh-manager` packages (Linux deb/rpm, amd64/arm64): `libinventory_sync.so` (`wazuh-manager-modulesd` inventory-sync module)

### Configuration Changes

N/A — no new configuration parameters and no default-value changes.

### Tests Introduced

N/A — the change is a 22-line conditional in the session End handler, verified end-to-end above. `indexerConnectorSync_test.cpp` already covers the `external_gte` emission and the acceptable-version-conflict accounting this fix routes around; a facade-level unit test for the cleared-index path can be added if reviewers want the regression pinned (the failure mode is silent, so it would guard against the guard being dropped in a refactor).

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented (N/A)
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues (independent of #37353; `main` carries the same guarded re-index and needs a forward-port)
