### PR TITLE
SCA/FIM sync lifecycle: close DBs on graceful shutdown, defer coordination during first sync, and increment SCA check version on change

### DIFF
--- a/.github/actions/check_files/check_files.py
+++ b/.github/actions/check_files/check_files.py
@@ -314,9 +314,17 @@ def file_diff(expected_item, current_items, size_check):
             difference_bytes = abs(
                 float(current_items['size_bytes']) - expected_size_bytes)
             if (expected_size_bytes and (difference_bytes / expected_size_bytes) > expected_error):
-                differences['size_bytes'] = current_items['size_bytes']
+                differences['size_bytes'] = {
+                    'expected': expected_item['size_bytes'],
+                    'found': current_items['size_bytes'],
+                    'allowed_error': expected_error,
+                    'deviation': round(difference_bytes / expected_size_bytes, 4)
+                }
         elif expected_item[head_type] != current_items[head_type]:
-            differences[head_type] = current_items[head_type]
+            differences[head_type] = {
+                'expected': expected_item[head_type],
+                'found': current_items[head_type]
+            }
 
     return differences
 
@@ -364,8 +372,17 @@ def printReport(expected_items, not_listed, not_fully_match, current_items, matc
             report_lines.append("### Files Differences\n")
             report_lines.append(
                 f"{qtty_not_fully_matched} files didn't match the expected values:\n")
-            report_lines.extend(
-                f"- '{filename}' : {details}\n" for filename, details in not_fully_match.items())
+            for filename, details in not_fully_match.items():
+                report_lines.append(f"- '{filename}':\n")
+                for field, values in details.items():
+                    if 'allowed_error' in values:
+                        report_lines.append(
+                            f"  - {field}: expected {values['expected']} "
+                            f"(±{float(values['allowed_error']) * 100:g}%), found {values['found']} "
+                            f"(deviation {values['deviation'] * 100:g}%)\n")
+                    else:
+                        report_lines.append(
+                            f"  - {field}: expected '{values['expected']}', found '{values['found']}'\n")
 
         # Expected files not found
         missing_files = [key for key,
@@ -387,12 +404,12 @@ def printReport(expected_items, not_listed, not_fully_match, current_items, matc
     # Combine all lines into a single report string
     final_report = ''.join(report_lines)
 
-    # Output to file or console
+    # Always print to the console so the CI log shows the discrepancies directly,
+    # and also write the file when a report path was requested
+    print(final_report)
     if report_path:
         with open(report_path, 'w') as file:
             file.write(final_report)
-    else:
-        print(final_report)
 
 
 if __name__ == "__main__":

--- a/.github/actions/check_files/deb_linux_agent_amd64.csv
+++ b/.github/actions/check_files/deb_linux_agent_amd64.csv
@@ -18,7 +18,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,998504,0.1
 /var/ossec/lib/libstdc++.so.6,root,wazuh,750,file,-rwxr-x---,2599704,0.1
 /var/ossec/lib/libsyscollector.so,root,wazuh,750,file,-rwxr-x---,793656,0.1
-/var/ossec/lib/libsca.so,root,wazuh,750,file,-rwxr-x---,800872,0.1
+/var/ossec/lib/libsca.so,root,wazuh,750,file,-rwxr-x---,886544,0.1
 /var/ossec/lib/libagent_info.so,root,wazuh,750,file,-rwxr-x---,345184,0.1
 /var/ossec/lib/libagent_metadata.so,root,wazuh,750,file,-rwxr-x---,14448,0.1
 /var/ossec/lib/libgcc_s.so.1,root,wazuh,750,file,-rwxr-x---,183248,0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ All notable changes to this project will be documented in this file.
 - Honored the shutdown signal in `agent-upgrade` `StartMQ` to avoid timeout warning on agent stop. ([#36092](https://github.com/wazuh/wazuh/issues/36092))
 - Adjusted DockerListener messages as log entries to fix event categorization. ([#36126](https://github.com/wazuh/wazuh/issues/36126))
 - Dropped orphan paths before promoting on agent startup to fix FIM. ([#36134](https://github.com/wazuh/wazuh/issues/36134))
+- Deferred agent-info module coordination while SCA or System Inventory first synchronization is in progress, extending the FIM guard so a concurrent group or metadata change does not run coordination mid-first-sync. ([#36358](https://github.com/wazuh/wazuh/issues/36358))
 
 ## Prior versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ All notable changes to this project will be documented in this file.
 - Adjusted DockerListener messages as log entries to fix event categorization. ([#36126](https://github.com/wazuh/wazuh/issues/36126))
 - Dropped orphan paths before promoting on agent startup to fix FIM. ([#36134](https://github.com/wazuh/wazuh/issues/36134))
 - Deferred agent-info module coordination while SCA or System Inventory first synchronization is in progress, extending the FIM guard so a concurrent group or metadata change does not run coordination mid-first-sync. ([#36358](https://github.com/wazuh/wazuh/issues/36358))
+- Closed the SCA and FIM synchronization databases cleanly on graceful shutdown, so stopping the agent no longer leaves stale SQLite `-wal`/`-shm` files behind. ([#37334](https://github.com/wazuh/wazuh/issues/37334))
 
 ## Prior versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,8 +102,6 @@ All notable changes to this project will be documented in this file.
 - Honored the shutdown signal in `agent-upgrade` `StartMQ` to avoid timeout warning on agent stop. ([#36092](https://github.com/wazuh/wazuh/issues/36092))
 - Adjusted DockerListener messages as log entries to fix event categorization. ([#36126](https://github.com/wazuh/wazuh/issues/36126))
 - Dropped orphan paths before promoting on agent startup to fix FIM. ([#36134](https://github.com/wazuh/wazuh/issues/36134))
-- Deferred agent-info module coordination while SCA or System Inventory first synchronization is in progress, extending the FIM guard so a concurrent group or metadata change does not run coordination mid-first-sync. ([#36358](https://github.com/wazuh/wazuh/issues/36358))
-- Closed the SCA and FIM synchronization databases cleanly on graceful shutdown, so stopping the agent no longer leaves stale SQLite `-wal`/`-shm` files behind. ([#37334](https://github.com/wazuh/wazuh/issues/37334))
 
 ## Prior versions
 

--- a/src/shared/include/mq_op.h
+++ b/src/shared/include/mq_op.h
@@ -124,6 +124,24 @@ int SendMSG(int queue, const char *message, const char *locmsg, char loc) __attr
 int SendBinaryMSG(int queue, const void *message, size_t message_len, const char *locmsg, char loc);
 
 /**
+ * Sends a message binary through a message queue, breaking out of the
+ * manager-disconnected wait (os_wait) when the predicate turns true
+ * @param queue file descriptor of the queue where the message will be sent (UNIX)
+ * @param message binary containing the message
+ * @param message_len The length of the message payload in bytes
+ * @param locmsg path to the queue file
+ * @param loc  queue location (WIN32)
+ * @param fn_ptr function pointer to the function that will check if the process is shutting down
+ * @return
+ * UNIX -> 0 if file descriptor is still available
+ * UNIX -> -1 if there is an error in the socket. The socket will be closed before returning (StartMQ should be called to restore queue)
+ * WIN32 -> 0 on success
+ * WIN32 -> -1 on error
+ * Notes: (UNIX) If the socket is busy when trying to send a message a DEBUG2 message will be loggeed but the return code will be 0
+ */
+int SendBinaryMSGPredicated(int queue, const void *message, size_t message_len, const char *locmsg, char loc, bool (*fn_ptr)()) __attribute__((nonnull));
+
+/**
  * Sends a message to a socket. If the socket has not been created yet it will be created based on
  * the target information. If a message fails to be sent the method will not try to send it again until *sock_fail_time* has passed
  * @param queue file descriptor of the queue where the error message will be sent (UNIX)

--- a/src/shared/src/mq_op.c
+++ b/src/shared/src/mq_op.c
@@ -285,6 +285,13 @@ int SendBinaryMSG(int queue, const void *message, size_t message_len, const char
     return SendBinaryMSGAction(queue, message, message_len, locmsg, loc);
 }
 
+/* Send a binary message with a predicate to break out of the manager-disconnected wait */
+int SendBinaryMSGPredicated(int queue, const void *message, size_t message_len, const char *locmsg, char loc, bool (*fn_ptr)()) {
+    /* Check for global locks */
+    os_wait_predicate(fn_ptr);
+    return SendBinaryMSGAction(queue, message, message_len, locmsg, loc);
+}
+
 /* Send a message to socket */
 int SendMSGtoSCK(int queue, const char *message, const char *locmsg, __attribute__((unused)) char loc, logtarget * target)
 {

--- a/src/syscheckd/include/syscheck.h
+++ b/src/syscheckd/include/syscheck.h
@@ -330,6 +330,16 @@ void send_syscheck_msg(const cJSON* msg) __attribute__((nonnull));
 void persist_syscheck_msg(const char* id, Operation_t operation, const char* index, const cJSON* _msg, uint64_t version) __attribute__((nonnull(1, 3, 4)));
 
 /**
+ * @brief Serializes syscheck.sync_handle use against the shutdown teardown (issue #37334).
+ *
+ * The sync protocol users that are not joined before the handle is destroyed (event
+ * persistence, syscom's fim_sync responses, the DataClean paths and the scheduled-scan
+ * asp_reset) take it for reading around each asp_* call, and the shutdown path destroys
+ * the handle and resets it to NULL under the write lock.
+ */
+extern pthread_rwlock_t fim_sync_handle_rwlock;
+
+/**
  * @brief Validate and persist a FIM event with schema validation
  *
  * Validates the event against the schema and persists it if valid.

--- a/src/syscheckd/src/db/src/db.cpp
+++ b/src/syscheckd/src/db/src/db.cpp
@@ -396,6 +396,7 @@ TXN_HANDLE fim_db_transaction_start(const char* table, result_callback_t row_cal
         FIMDB::instance().logFunction(LOG_ERROR, ex.what());
         return nullptr;
     }
+
     // LCOV_EXCL_STOP
 }
 

--- a/src/syscheckd/src/db/src/db.cpp
+++ b/src/syscheckd/src/db/src/db.cpp
@@ -376,14 +376,27 @@ void fim_db_update_last_sync_time(const char* table_name)
 
 TXN_HANDLE fim_db_transaction_start(const char* table, result_callback_t row_callback, void* user_data)
 {
-    const std::unique_ptr<cJSON, CJsonSmartDeleter> jsInput {cJSON_Parse(table)};
+    try
+    {
+        const std::unique_ptr<cJSON, CJsonSmartDeleter> jsInput {cJSON_Parse(table)};
 
-    callback_data_t cb_data = {.callback = row_callback, .user_data = user_data};
+        callback_data_t cb_data = {.callback = row_callback, .user_data = user_data};
 
-    TXN_HANDLE dbsyncTxnHandle =
-        dbsync_create_txn(DB::instance().DBSyncHandle(), jsInput.get(), 0, QUEUE_SIZE, cb_data);
+        TXN_HANDLE dbsyncTxnHandle =
+            dbsync_create_txn(DB::instance().DBSyncHandle(), jsInput.get(), 0, QUEUE_SIZE, cb_data);
 
-    return dbsyncTxnHandle;
+        return dbsyncTxnHandle;
+    }
+    // LCOV_EXCL_START
+    catch (const std::exception& ex)
+    {
+        // DBSyncHandle() throws once the handler has been torn down; this is the only
+        // extern "C" entry in this file that let the exception escape into C callers
+        // (std::terminate). Callers already handle a NULL transaction handle.
+        FIMDB::instance().logFunction(LOG_ERROR, ex.what());
+        return nullptr;
+    }
+    // LCOV_EXCL_STOP
 }
 
 FIMDBErrorCode fim_db_transaction_sync_row(TXN_HANDLE txn_handler, const fim_entry* entry)

--- a/src/syscheckd/src/file/file.c
+++ b/src/syscheckd/src/file/file.c
@@ -1234,13 +1234,23 @@ void fim_file_scan() {
             mdebug1("No directory paths configured but database has %d files. Initiating DataClean for files.",
                     files_count);
 
+            bool sync_handle_available = false;
+            bool dataCleanSent = false;
+
+            w_rwlock_rdlock(&fim_sync_handle_rwlock);
             if (syscheck.sync_handle) {
+                sync_handle_available = true;
+
                 // Prepare indices vector for data clean notification
                 const char* indices[1] = {FIM_FILES_SYNC_INDEX};
                 size_t indices_count = 1;
 
                 // Send DataClean notification for files index
-                bool dataCleanSent = asp_notify_data_clean(syscheck.sync_handle, indices, indices_count);
+                dataCleanSent = asp_notify_data_clean(syscheck.sync_handle, indices, indices_count);
+            }
+            w_rwlock_unlock(&fim_sync_handle_rwlock);
+
+            if (sync_handle_available) {
                 if (dataCleanSent) {
                     minfo("DataClean notification sent successfully for files index (all directory paths removed from configuration).");
                 } else {

--- a/src/syscheckd/src/file/file.c
+++ b/src/syscheckd/src/file/file.c
@@ -1285,15 +1285,22 @@ void fim_file_scan() {
 
     callback_ctx txn_ctx = { .event = &evt_data, .entry = NULL, .config = NULL, .failed_paths = failed_paths, .pending_sync_updates = pending_sync_updates };
 
+    // The whole transaction lifecycle (start .. deleted_rows/close) lives inside
+    // fim_scan_mutex: the raw transaction handle is the one fim_db path not covered by
+    // FIMDB's internal teardown guards, and the shutdown waiter (fim_shutdown_waiter(),
+    // main.c) relies on this mutex to know no scan transaction is in flight before it
+    // tears the database down.
+    w_mutex_lock(&syscheck.fim_scan_mutex);
+
     TXN_HANDLE db_transaction_handle = fim_db_transaction_start(FIMDB_FILE_TXN_TABLE, transaction_callback, &txn_ctx);
     if (db_transaction_handle == NULL) {
         merror(FIM_ERROR_TRANSACTION, FIMDB_FILE_TXN_TABLE);
+        w_mutex_unlock(&syscheck.fim_scan_mutex);
         OSList_Destroy(failed_paths);
         OSList_Destroy(pending_sync_updates);
         return;
     }
 
-    w_mutex_lock(&syscheck.fim_scan_mutex);
     w_rwlock_rdlock(&syscheck.directories_lock);
 
     OSList_foreach(node_it, syscheck.directories) {
@@ -1326,9 +1333,9 @@ void fim_file_scan() {
     }
 
     w_rwlock_unlock(&syscheck.directories_lock);
-    w_mutex_unlock(&syscheck.fim_scan_mutex);
 
     fim_db_transaction_deleted_rows(db_transaction_handle, transaction_callback, &txn_ctx);
+    w_mutex_unlock(&syscheck.fim_scan_mutex);
 
     // Delete files that failed schema validation (outside transaction)
     cleanup_failed_fim_files(failed_paths);

--- a/src/syscheckd/src/main.c
+++ b/src/syscheckd/src/main.c
@@ -85,10 +85,20 @@ static void *fim_shutdown_waiter(__attribute__((unused)) void *arg)
     }
 
     /* Wait for the inventory synchronization thread to exit: its loop reacts to
-     * fim_sync_module_running (cleared by fim_shutdown()) within a second. */
-    if (fim_sync_thread_initialized)
+     * fim_sync_module_running (cleared by fim_shutdown()) within a second, and asp_stop()
+     * above aborts an in-flight synchronization. The initialized flag is read under the
+     * same write lock start_daemon() publishes it under, so the startup window cannot be
+     * missed: either the thread is already visible here and gets joined before the handle
+     * is destroyed, or start_daemon() observes the shutdown (is_fim_shutdown is
+     * republished under the lock so the rwlock orders it) and never creates the thread. */
+    w_rwlock_wrlock(&fim_sync_handle_rwlock);
+    is_fim_shutdown = true;
+    bool join_sync_thread = fim_sync_thread_initialized;
+    fim_sync_thread_initialized = false;
+    w_rwlock_unlock(&fim_sync_handle_rwlock);
+
+    if (join_sync_thread)
     {
-        fim_sync_thread_initialized = false;
         pthread_join(fim_sync_thread, NULL);
     }
 

--- a/src/syscheckd/src/main.c
+++ b/src/syscheckd/src/main.c
@@ -101,6 +101,12 @@ static void *fim_shutdown_waiter(__attribute__((unused)) void *arg)
      * republished under the lock so the rwlock orders it) and never creates the thread. */
     w_rwlock_wrlock(&fim_sync_handle_rwlock);
     is_fim_shutdown = true;
+    /* Republished under the lock: the signal can land between start_daemon()'s shutdown
+     * check and its `fim_sync_module_running = 1`, which would overwrite the handler's
+     * clear inside the creation critical section. Re-clearing here (ordered after that
+     * section by the lock) makes the freshly created loop observe the stop within a
+     * second, so the join below still completes. */
+    fim_sync_module_running = 0;
     bool join_sync_thread = fim_sync_thread_initialized;
     fim_sync_thread_initialized = false;
     w_rwlock_unlock(&fim_sync_handle_rwlock);

--- a/src/syscheckd/src/main.c
+++ b/src/syscheckd/src/main.c
@@ -47,41 +47,88 @@ extern volatile int fim_sync_module_running;
 extern pthread_t fim_sync_thread;
 extern bool fim_sync_thread_initialized;
 
-/* Shut down syscheckd properly */
-static void fim_shutdown(int sig)
-{
-    /* Close sync thread and release dbsync */
-    minfo(SK_SHUTDOWN);
-    is_fim_shutdown = true;
-    fim_sync_module_running = 0;
+/* Self-pipe written by fim_shutdown() to wake fim_shutdown_waiter() */
+static int fim_shutdown_pipe[2] = {-1, -1};
+/* Signal that triggered the shutdown, consumed by fim_shutdown_waiter() */
+static volatile sig_atomic_t fim_shutdown_sig = SIGTERM;
 
-    /* Stop sync protocol */
+/* Shut down syscheckd properly. This thread performs the teardown that fim_shutdown()
+ * cannot do in signal context. Joining the synchronization thread from the handler
+ * could deadlock: if the signal lands on a thread that holds syscheck.directories_lock
+ * or syscheck.fim_scan_mutex (e.g. the main thread inside fim_scan()), that thread
+ * parks in the handler without releasing them, while fim_run_integrity blocks on those
+ * very locks and never re-checks fim_sync_module_running, so the join never returns.
+ * Destroying the sync protocol handle from the handler is not safe either: it is still
+ * used by threads that are never joined (event persistence, syscom), and a second
+ * termination signal (signal() leaves the other signals unblocked while the handler
+ * runs) could re-enter the handler, skip the join and free the handle under the live
+ * synchronization thread. */
+static void *fim_shutdown_waiter(__attribute__((unused)) void *arg)
+{
+    char buf;
+
+    /* Wait for fim_shutdown() to report a termination signal */
+    while (!fim_shutdown_process_on())
+    {
+        if (read(fim_shutdown_pipe[0], &buf, 1) < 0 && errno != EINTR)
+        {
+            sleep(1); // Defensive: reading the shutdown pipe cannot fail in practice
+        }
+    }
+
+    minfo(SK_SHUTDOWN);
+
+    /* Abort any in-flight synchronization so the join below is short */
     if (syscheck.sync_handle)
     {
         asp_stop(syscheck.sync_handle);
     }
 
-    /* Wait for the inventory synchronization thread to exit, then destroy the sync
-     * protocol handle so its SQLite connection to fim_sync.db is closed cleanly
-     * (checkpointing and removing the -wal/-shm files) instead of being leaked
-     * (issue #37334). The loop reacts to fim_sync_module_running within a second and
-     * asp_stop() aborts any in-flight synchronization, so the join is short. It cannot
-     * self-deadlock: fim_run_integrity blocks the signals this handler is registered
-     * for, so the handler never runs on that thread. */
+    /* Wait for the inventory synchronization thread to exit: its loop reacts to
+     * fim_sync_module_running (cleared by fim_shutdown()) within a second. */
     if (fim_sync_thread_initialized)
     {
         fim_sync_thread_initialized = false;
         pthread_join(fim_sync_thread, NULL);
     }
 
+    /* Destroy the sync protocol handle so its SQLite connection to fim_sync.db is
+     * closed cleanly (checkpointing and removing the -wal/-shm files) instead of
+     * being leaked (issue #37334). The write lock excludes the handle users that
+     * are not joined above (event persistence, syscom's fim_sync responses, the
+     * DataClean paths and the scheduled-scan asp_reset), which take it for reading
+     * around each call. */
+    w_rwlock_wrlock(&fim_sync_handle_rwlock);
     if (syscheck.sync_handle)
     {
         asp_destroy(syscheck.sync_handle);
         syscheck.sync_handle = NULL;
     }
+    w_rwlock_unlock(&fim_sync_handle_rwlock);
 
     fim_db_teardown();
-    HandleSIG(sig);
+    HandleSIG((int)fim_shutdown_sig);
+
+    return NULL;
+}
+
+/* Termination signal handler: only async-signal-safe work happens here; the actual
+ * teardown runs in fim_shutdown_waiter() (see above) */
+static void fim_shutdown(int sig)
+{
+    int saved_errno = errno;
+
+    fim_shutdown_sig = sig;
+    is_fim_shutdown = true;
+    fim_sync_module_running = 0;
+
+    if (fim_shutdown_pipe[1] >= 0)
+    {
+        /* Wake the shutdown waiter; write() is async-signal-safe */
+        while (write(fim_shutdown_pipe[1], "", 1) < 0 && errno == EINTR) {}
+    }
+
+    errno = saved_errno;
 }
 
 /* Syscheck unix main */
@@ -200,6 +247,18 @@ int main(int argc, char **argv)
         nowDaemon();
         goDaemon();
     }
+
+    /* Spawn the shutdown waiter before registering the termination signal handler
+     * that wakes it through the pipe (issue #37334) */
+    if (pipe(fim_shutdown_pipe) < 0) {
+        merror_exit("Could not create the shutdown pipe: %s (%d)", strerror(errno), errno);
+    }
+
+    /* Keep the pipe out of child processes (e.g. prefilter_cmd) */
+    fcntl(fim_shutdown_pipe[0], F_SETFD, FD_CLOEXEC);
+    fcntl(fim_shutdown_pipe[1], F_SETFD, FD_CLOEXEC);
+
+    w_create_thread(fim_shutdown_waiter, NULL);
 
     /* Start signal handling */
     StartSIG2(ARGV0, fim_shutdown);

--- a/src/syscheckd/src/main.c
+++ b/src/syscheckd/src/main.c
@@ -20,8 +20,15 @@
 
 #ifndef WIN32
 
+#include <poll.h>
+
 #define Q(x) #x
 #define QUOTE(x) Q(x)
+
+/* Milliseconds fim_shutdown_waiter() waits for the synchronization thread to report its
+ * exit before giving up on the teardown; wazuh-control escalates to SIGKILL after ~30
+ * seconds (MAX_KILL_TRIES in init/wazuh-client.sh), so stay well under that. */
+#define FIM_SYNC_EXIT_TIMEOUT_MS 20000
 
 // LCOV_EXCL_START
 
@@ -46,6 +53,7 @@ extern bool is_fim_shutdown;
 extern volatile int fim_sync_module_running;
 extern pthread_t fim_sync_thread;
 extern bool fim_sync_thread_initialized;
+extern int fim_sync_exit_pipe[2];
 
 /* Self-pipe written by fim_shutdown() to wake fim_shutdown_waiter() */
 static int fim_shutdown_pipe[2] = {-1, -1};
@@ -97,26 +105,50 @@ static void *fim_shutdown_waiter(__attribute__((unused)) void *arg)
     fim_sync_thread_initialized = false;
     w_rwlock_unlock(&fim_sync_handle_rwlock);
 
+    bool sync_thread_exited = true;
+
     if (join_sync_thread)
     {
-        pthread_join(fim_sync_thread, NULL);
+        /* Everything the synchronization thread can block on after asp_stop() is bounded
+         * (stop-aware waits, predicated sends, 1-second sleeps), so it reports its exit
+         * through fim_sync_exit_pipe well within this timeout. If it does not, skip the
+         * join and the teardown below — destroying the handle under a live thread is the
+         * use-after-free this waiter exists to prevent — and let HandleSIG() exit. */
+        struct pollfd sync_exit_poll = { .fd = fim_sync_exit_pipe[0], .events = POLLIN, .revents = 0 };
+        int poll_ret;
+
+        while ((poll_ret = poll(&sync_exit_poll, 1, FIM_SYNC_EXIT_TIMEOUT_MS)) < 0 && errno == EINTR) {}
+
+        if (poll_ret > 0)
+        {
+            pthread_join(fim_sync_thread, NULL);
+        }
+        else
+        {
+            sync_thread_exited = false;
+            mwarn("The FIM inventory synchronization thread did not exit in time: skipping the synchronization database teardown.");
+        }
     }
 
-    /* Destroy the sync protocol handle so its SQLite connection to fim_sync.db is
-     * closed cleanly (checkpointing and removing the -wal/-shm files) instead of
-     * being leaked (issue #37334). The write lock excludes the handle users that
-     * are not joined above (event persistence, syscom's fim_sync responses, the
-     * DataClean paths and the scheduled-scan asp_reset), which take it for reading
-     * around each call. */
-    w_rwlock_wrlock(&fim_sync_handle_rwlock);
-    if (syscheck.sync_handle)
+    if (sync_thread_exited)
     {
-        asp_destroy(syscheck.sync_handle);
-        syscheck.sync_handle = NULL;
-    }
-    w_rwlock_unlock(&fim_sync_handle_rwlock);
+        /* Destroy the sync protocol handle so its SQLite connection to fim_sync.db is
+         * closed cleanly (checkpointing and removing the -wal/-shm files) instead of
+         * being leaked (issue #37334). The write lock excludes the handle users that
+         * are not joined above (event persistence, syscom's fim_sync responses, the
+         * DataClean paths and the scheduled-scan asp_reset), which take it for reading
+         * around each call. */
+        w_rwlock_wrlock(&fim_sync_handle_rwlock);
+        if (syscheck.sync_handle)
+        {
+            asp_destroy(syscheck.sync_handle);
+            syscheck.sync_handle = NULL;
+        }
+        w_rwlock_unlock(&fim_sync_handle_rwlock);
 
-    fim_db_teardown();
+        fim_db_teardown();
+    }
+
     HandleSIG((int)fim_shutdown_sig);
 
     return NULL;
@@ -260,13 +292,15 @@ int main(int argc, char **argv)
 
     /* Spawn the shutdown waiter before registering the termination signal handler
      * that wakes it through the pipe (issue #37334) */
-    if (pipe(fim_shutdown_pipe) < 0) {
-        merror_exit("Could not create the shutdown pipe: %s (%d)", strerror(errno), errno);
+    if (pipe(fim_shutdown_pipe) < 0 || pipe(fim_sync_exit_pipe) < 0) {
+        merror_exit("Could not create the shutdown pipes: %s (%d)", strerror(errno), errno);
     }
 
-    /* Keep the pipe out of child processes (e.g. prefilter_cmd) */
+    /* Keep the pipes out of child processes (e.g. prefilter_cmd) */
     fcntl(fim_shutdown_pipe[0], F_SETFD, FD_CLOEXEC);
     fcntl(fim_shutdown_pipe[1], F_SETFD, FD_CLOEXEC);
+    fcntl(fim_sync_exit_pipe[0], F_SETFD, FD_CLOEXEC);
+    fcntl(fim_sync_exit_pipe[1], F_SETFD, FD_CLOEXEC);
 
     w_create_thread(fim_shutdown_waiter, NULL);
 

--- a/src/syscheckd/src/main.c
+++ b/src/syscheckd/src/main.c
@@ -146,7 +146,23 @@ static void *fim_shutdown_waiter(__attribute__((unused)) void *arg)
         }
         w_rwlock_unlock(&fim_sync_handle_rwlock);
 
-        fim_db_teardown();
+        /* fim.db itself runs journal_mode=truncate (no -wal/-shm files): this teardown
+         * releases the DBSync context in a controlled order before exit(), it is not WAL
+         * cleanup. FIMDB's internal guards turn the event/query paths into graceful
+         * no-ops after it, but the scan transaction path (fim_db_transaction_*) is not
+         * covered by them. The scan transaction lives entirely inside fim_scan_mutex, so
+         * tear down only when no scan is in flight and keep the mutex so a new scan
+         * cannot start a transaction against the released context; otherwise skip it —
+         * exiting with fim.db open is safe (the truncate journal recovers on the next
+         * start), closing it under a live transaction is not. */
+        if (pthread_mutex_trylock(&syscheck.fim_scan_mutex) == 0)
+        {
+            fim_db_teardown();
+        }
+        else
+        {
+            mdebug1("Skipping the FIM database teardown: a scan is in progress.");
+        }
     }
 
     HandleSIG((int)fim_shutdown_sig);

--- a/src/syscheckd/src/main.c
+++ b/src/syscheckd/src/main.c
@@ -44,6 +44,8 @@ __attribute__((noreturn)) static void help_syscheckd()
 
 extern bool is_fim_shutdown;
 extern volatile int fim_sync_module_running;
+extern pthread_t fim_sync_thread;
+extern bool fim_sync_thread_initialized;
 
 /* Shut down syscheckd properly */
 static void fim_shutdown(int sig)
@@ -57,6 +59,25 @@ static void fim_shutdown(int sig)
     if (syscheck.sync_handle)
     {
         asp_stop(syscheck.sync_handle);
+    }
+
+    /* Wait for the inventory synchronization thread to exit, then destroy the sync
+     * protocol handle so its SQLite connection to fim_sync.db is closed cleanly
+     * (checkpointing and removing the -wal/-shm files) instead of being leaked
+     * (issue #37334). The loop reacts to fim_sync_module_running within a second and
+     * asp_stop() aborts any in-flight synchronization, so the join is short. It cannot
+     * self-deadlock: fim_run_integrity blocks the signals this handler is registered
+     * for, so the handler never runs on that thread. */
+    if (fim_sync_thread_initialized)
+    {
+        fim_sync_thread_initialized = false;
+        pthread_join(fim_sync_thread, NULL);
+    }
+
+    if (syscheck.sync_handle)
+    {
+        asp_destroy(syscheck.sync_handle);
+        syscheck.sync_handle = NULL;
     }
 
     fim_db_teardown();

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -687,15 +687,25 @@ void start_daemon()
     w_create_thread(symlink_checker_thread, NULL);
 
     if (syscheck.enable_synchronization) {
-        fim_sync_module_running = 1;
         // Launch the inventory synchronization thread as joinable so the shutdown waiter
-        // can wait for it before destroying the sync protocol handle (issue #37334).
-        if (CreateThreadJoinable(&fim_sync_thread, fim_run_integrity, NULL) != 0) {
-            merror(THREAD_ERROR);
-            fim_sync_module_running = 0;
+        // can wait for it before destroying the sync protocol handle (issue #37334). The
+        // creation and fim_sync_thread_initialized are published under the handle write
+        // lock, which the waiter also takes to decide the join: either the thread is
+        // visible there and joined before the handle is destroyed, or the waiter ran
+        // first and the shutdown check below keeps the thread from being created at all.
+        w_rwlock_wrlock(&fim_sync_handle_rwlock);
+        if (fim_shutdown_process_on()) {
+            mdebug1("Shutdown in progress: not launching the FIM inventory synchronization thread.");
         } else {
-            fim_sync_thread_initialized = true;
+            fim_sync_module_running = 1;
+            if (CreateThreadJoinable(&fim_sync_thread, fim_run_integrity, NULL) != 0) {
+                merror(THREAD_ERROR);
+                fim_sync_module_running = 0;
+            } else {
+                fim_sync_thread_initialized = true;
+            }
         }
+        w_rwlock_unlock(&fim_sync_handle_rwlock);
     } else {
         mdebug1("FIM inventory synchronization is disabled");
     }

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -61,12 +61,20 @@ volatile int fim_sync_module_running = 0;
 
 #ifndef WIN32
 // Handle to the FIM inventory synchronization thread. Kept joinable (issue #37334) so
-// fim_shutdown() can wait for it to exit before destroying the sync protocol handle,
-// letting its SQLite connection to fim_sync.db close cleanly (checkpoint + removal of
-// the -wal/-shm files) instead of leaking it on a graceful stop.
+// the shutdown waiter (fim_shutdown_waiter(), main.c) can wait for it to exit before
+// destroying the sync protocol handle, letting its SQLite connection to fim_sync.db
+// close cleanly (checkpoint + removal of the -wal/-shm files) instead of leaking it
+// on a graceful stop.
 pthread_t fim_sync_thread;
 bool fim_sync_thread_initialized = false;
 #endif
+
+// Serializes syscheck.sync_handle use against the shutdown teardown (issue #37334): the
+// users that are not joined before asp_destroy() (event persistence, syscom's fim_sync
+// responses, the DataClean paths and the scheduled-scan asp_reset) take it for reading
+// around each asp_* call, and the shutdown waiter destroys the handle under the write
+// lock. Statically initialized so it is valid no matter how early those threads run.
+pthread_rwlock_t fim_sync_handle_rwlock = PTHREAD_RWLOCK_INITIALIZER;
 
 // Flush on-demand synchronization variables (thread-safe with atomic operations)
 atomic_int_t fim_flush_in_progress = ATOMIC_INT_INITIALIZER(0);  // 0 = idle, 1 = flush active
@@ -226,7 +234,11 @@ STATIC bool send_data_clean_with_retry(const char* indices[], size_t indices_cou
     bool dataCleanSent = false;
 
     while (!dataCleanSent && !fim_shutdown_process_on()) {
-        dataCleanSent = asp_notify_data_clean(syscheck.sync_handle, indices, indices_count);
+        w_rwlock_rdlock(&fim_sync_handle_rwlock);
+        if (syscheck.sync_handle) {
+            dataCleanSent = asp_notify_data_clean(syscheck.sync_handle, indices, indices_count);
+        }
+        w_rwlock_unlock(&fim_sync_handle_rwlock);
         if (!dataCleanSent) {
             mdebug1("DataClean notification failed, retrying after sync interval (%u seconds)...", syscheck.sync_interval);
             for (uint32_t i = 0; i < syscheck.sync_interval && !fim_shutdown_process_on(); i++) {
@@ -234,7 +246,11 @@ STATIC bool send_data_clean_with_retry(const char* indices[], size_t indices_cou
             }
         } else {
             mdebug1("DataClean notification sent successfully.");
-            asp_delete_database(syscheck.sync_handle);
+            w_rwlock_rdlock(&fim_sync_handle_rwlock);
+            if (syscheck.sync_handle) {
+                asp_delete_database(syscheck.sync_handle);
+            }
+            w_rwlock_unlock(&fim_sync_handle_rwlock);
             fim_db_close_and_delete_database();
             mdebug1("FIM databases deleted successfully.");
         }
@@ -308,7 +324,11 @@ STATIC void handle_fim_disabled(void) {
         send_data_clean_with_retry(indices, indices_count);
     } else {
         minfo("Syscheck is disabled, FIM database has no entries. Skipping data clean notification.");
-        asp_delete_database(syscheck.sync_handle);
+        w_rwlock_rdlock(&fim_sync_handle_rwlock);
+        if (syscheck.sync_handle) {
+            asp_delete_database(syscheck.sync_handle);
+        }
+        w_rwlock_unlock(&fim_sync_handle_rwlock);
         fim_db_close_and_delete_database();
         mdebug1("FIM databases deleted successfully.");
     }
@@ -364,7 +384,11 @@ void persist_syscheck_msg(const char *id, Operation_t operation, const char *ind
 
         // Validation is now done before DBSync insertion in the callbacks
         // This function just persists the already-validated data
-        asp_persist_diff(syscheck.sync_handle, id, operation, index, msg, version);
+        w_rwlock_rdlock(&fim_sync_handle_rwlock);
+        if (syscheck.sync_handle) {
+            asp_persist_diff(syscheck.sync_handle, id, operation, index, msg, version);
+        }
+        w_rwlock_unlock(&fim_sync_handle_rwlock);
 
         os_free(msg);
     } else {
@@ -664,8 +688,8 @@ void start_daemon()
 
     if (syscheck.enable_synchronization) {
         fim_sync_module_running = 1;
-        // Launch the inventory synchronization thread as joinable so fim_shutdown() can
-        // wait for it before destroying the sync protocol handle (issue #37334).
+        // Launch the inventory synchronization thread as joinable so the shutdown waiter
+        // can wait for it before destroying the sync protocol handle (issue #37334).
         if (CreateThreadJoinable(&fim_sync_thread, fim_run_integrity, NULL) != 0) {
             merror(THREAD_ERROR);
             fim_sync_module_running = 0;
@@ -789,8 +813,12 @@ void start_daemon()
         }
 
         // Reset sync protocol stop flag if scheduled scan is triggered
-        if (run_now && syscheck.sync_handle) {
-            asp_reset(syscheck.sync_handle);
+        if (run_now) {
+            w_rwlock_rdlock(&fim_sync_handle_rwlock);
+            if (syscheck.sync_handle) {
+                asp_reset(syscheck.sync_handle);
+            }
+            w_rwlock_unlock(&fim_sync_handle_rwlock);
         }
 
         // If time elapsed is higher than the syscheck time, run syscheck time
@@ -921,18 +949,6 @@ void * fim_run_realtime(__attribute__((unused)) void * args) {
 DWORD WINAPI fim_run_integrity(__attribute__((unused)) void * args) {
 #else
 void * fim_run_integrity(__attribute__((unused)) void * args) {
-#endif
-#ifndef WIN32
-    // Block the termination signals handled by fim_shutdown() in this thread, so the
-    // handler can never run on the very thread it joins (self-join deadlock). The signals
-    // keep being delivered to the other threads (issue #37334).
-    sigset_t fim_sync_sigmask;
-    sigemptyset(&fim_sync_sigmask);
-    sigaddset(&fim_sync_sigmask, SIGTERM);
-    sigaddset(&fim_sync_sigmask, SIGINT);
-    sigaddset(&fim_sync_sigmask, SIGQUIT);
-    sigaddset(&fim_sync_sigmask, SIGALRM);
-    pthread_sigmask(SIG_BLOCK, &fim_sync_sigmask, NULL);
 #endif
     bool first_sync_completed = fim_db_get_last_sync_time(FIM_FIRST_SYNC_COMPLETED_METADATA_KEY) > 0;
     bool skip_initial_wait = !first_sync_completed;

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -59,6 +59,15 @@ void audit_set_db_consistency(void);
 // Global flag to stop sync module
 volatile int fim_sync_module_running = 0;
 
+#ifndef WIN32
+// Handle to the FIM inventory synchronization thread. Kept joinable (issue #37334) so
+// fim_shutdown() can wait for it to exit before destroying the sync protocol handle,
+// letting its SQLite connection to fim_sync.db close cleanly (checkpoint + removal of
+// the -wal/-shm files) instead of leaking it on a graceful stop.
+pthread_t fim_sync_thread;
+bool fim_sync_thread_initialized = false;
+#endif
+
 // Flush on-demand synchronization variables (thread-safe with atomic operations)
 atomic_int_t fim_flush_in_progress = ATOMIC_INT_INITIALIZER(0);  // 0 = idle, 1 = flush active
 atomic_int_t fim_flush_result = ATOMIC_INT_INITIALIZER(0);       // 0 = success, -1 = error
@@ -655,8 +664,14 @@ void start_daemon()
 
     if (syscheck.enable_synchronization) {
         fim_sync_module_running = 1;
-        // Launch inventory synchronization thread
-        w_create_thread(fim_run_integrity, NULL);
+        // Launch the inventory synchronization thread as joinable so fim_shutdown() can
+        // wait for it before destroying the sync protocol handle (issue #37334).
+        if (CreateThreadJoinable(&fim_sync_thread, fim_run_integrity, NULL) != 0) {
+            merror(THREAD_ERROR);
+            fim_sync_module_running = 0;
+        } else {
+            fim_sync_thread_initialized = true;
+        }
     } else {
         mdebug1("FIM inventory synchronization is disabled");
     }
@@ -906,6 +921,18 @@ void * fim_run_realtime(__attribute__((unused)) void * args) {
 DWORD WINAPI fim_run_integrity(__attribute__((unused)) void * args) {
 #else
 void * fim_run_integrity(__attribute__((unused)) void * args) {
+#endif
+#ifndef WIN32
+    // Block the termination signals handled by fim_shutdown() in this thread, so the
+    // handler can never run on the very thread it joins (self-join deadlock). The signals
+    // keep being delivered to the other threads (issue #37334).
+    sigset_t fim_sync_sigmask;
+    sigemptyset(&fim_sync_sigmask);
+    sigaddset(&fim_sync_sigmask, SIGTERM);
+    sigaddset(&fim_sync_sigmask, SIGINT);
+    sigaddset(&fim_sync_sigmask, SIGQUIT);
+    sigaddset(&fim_sync_sigmask, SIGALRM);
+    pthread_sigmask(SIG_BLOCK, &fim_sync_sigmask, NULL);
 #endif
     bool first_sync_completed = fim_db_get_last_sync_time(FIM_FIRST_SYNC_COMPLETED_METADATA_KEY) > 0;
     bool skip_initial_wait = !first_sync_completed;

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -67,6 +67,12 @@ volatile int fim_sync_module_running = 0;
 // on a graceful stop.
 pthread_t fim_sync_thread;
 bool fim_sync_thread_initialized = false;
+
+// Self-pipe fim_run_integrity() writes to on exit so the shutdown waiter can bound its
+// wait for the thread (poll + timeout) instead of blocking forever in pthread_join().
+// Created in main() before the waiter thread; stays {-1, -1} in the unit-test builds so
+// the write below is skipped.
+int fim_sync_exit_pipe[2] = {-1, -1};
 #endif
 
 // Serializes syscheck.sync_handle use against the shutdown teardown (issue #37334): the
@@ -1072,8 +1078,10 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
             }
 
             // Lock FIM's scheduled and realtime scans only for the recovery/integrity
-            // process, which reads and writes the file_entry table.
-            if (sync_result) {
+            // process, which reads and writes the file_entry table. Skipped once shutdown
+            // starts: fim_scan_mutex can be held by an in-flight scan for minutes, and the
+            // shutdown waiter is waiting to join this thread.
+            if (sync_result && fim_sync_module_running) {
                 w_mutex_lock(&syscheck.fim_scan_mutex);
                 w_mutex_lock(&syscheck.fim_realtime_mutex);
                 #ifdef WIN32
@@ -1112,6 +1120,12 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
 #ifdef WIN32
     return 0;
 #else
+    // Report the exit to the shutdown waiter so its bounded wait on the exit pipe
+    // returns immediately and it can join this thread without an unbounded stall.
+    if (fim_sync_exit_pipe[1] >= 0) {
+        while (write(fim_sync_exit_pipe[1], "", 1) < 0 && errno == EINTR) {}
+    }
+
     return NULL;
 #endif
 }

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -377,7 +377,11 @@ static int fim_startmq(const char* key, short type, short attempts) {
 }
 
 static int fim_send_binary_msg(int queue, const void* message, size_t message_len, const char* locmsg, char loc) {
-    return SendBinaryMSG(queue, message, message_len, locmsg, loc);
+    // Predicated so a synchronization parked in the manager-disconnected wait (os_wait)
+    // returns on shutdown: asp_stop() wakes every wait inside the sync protocol but
+    // cannot interrupt this one, and the shutdown waiter joins the synchronization
+    // thread with no timeout (issue #37334).
+    return SendBinaryMSGPredicated(queue, message, message_len, locmsg, loc, fim_shutdown_process_on);
 }
 
 /**

--- a/src/syscheckd/src/syscom.c
+++ b/src/syscheckd/src/syscom.c
@@ -629,7 +629,11 @@ size_t syscom_dispatch(char * command, size_t command_len, char ** output){
             size_t data_len = command_len - header_len;
 
             bool ret = false;
-            ret = asp_parse_response_buffer(syscheck.sync_handle, data, data_len);
+            w_rwlock_rdlock(&fim_sync_handle_rwlock);
+            if (syscheck.sync_handle) {
+                ret = asp_parse_response_buffer(syscheck.sync_handle, data, data_len);
+            }
+            w_rwlock_unlock(&fim_sync_handle_rwlock);
 
             if (!ret) {
                 mdebug1("WMCOM Error syncing module");

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -1468,6 +1468,13 @@ void test_persist_syscheck_msg_destroyed_sync_handle(void **state) {
 
     expect_string(__wrap__mdebug2, formatted_msg, "(6339): Persisting FIM event: {\"test\":\"data\"}");
 
+    // The fim_sync_handle_rwlock guard is taken around the handle check even when the
+    // handle is NULL. Only the winagent build wraps these locks.
+#ifdef TEST_WINAGENT
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+#endif
+
     persist_syscheck_msg("test-id", OPERATION_CREATE, "wazuh-states-fim-files", msg, 1);
 
     cJSON_Delete(msg);

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -1453,6 +1453,28 @@ void test_handle_all_paths_removed_no_sync_handle(void **state) {
 
 /* ---------------------------------- End DataClean Tests ---------------------------------- */
 
+void test_persist_syscheck_msg_destroyed_sync_handle(void **state) {
+    (void) state;
+    AgentSyncProtocolHandle *original_handle = syscheck.sync_handle;
+    unsigned int original_enable_synchronization = syscheck.enable_synchronization;
+
+    // The shutdown teardown destroyed the handle: the event must be dropped without
+    // touching the sync protocol (asp_persist_diff is not called).
+    syscheck.enable_synchronization = 1;
+    syscheck.sync_handle = NULL;
+
+    cJSON *msg = cJSON_CreateObject();
+    cJSON_AddStringToObject(msg, "test", "data");
+
+    expect_string(__wrap__mdebug2, formatted_msg, "(6339): Persisting FIM event: {\"test\":\"data\"}");
+
+    persist_syscheck_msg("test-id", OPERATION_CREATE, "wazuh-states-fim-files", msg, 1);
+
+    cJSON_Delete(msg);
+    syscheck.sync_handle = original_handle;
+    syscheck.enable_synchronization = original_enable_synchronization;
+}
+
 int main(void) {
 #ifndef WIN_WHODATA
     const struct CMUnitTest tests[] = {
@@ -1483,6 +1505,7 @@ int main(void) {
         cmocka_unit_test(test_fim_has_data_in_database_with_file_entries),
         cmocka_unit_test(test_handle_all_paths_removed_no_data_in_db),
         cmocka_unit_test(test_handle_all_paths_removed_no_sync_handle),
+        cmocka_unit_test(test_persist_syscheck_msg_destroyed_sync_handle),
 #ifndef TEST_WINAGENT
         cmocka_unit_test(test_fim_run_realtime_first_error),
         cmocka_unit_test(test_fim_run_realtime_first_timeout),

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -401,7 +401,7 @@ static void expect_fim_startup_log(bool first_sync_completed) {
                       : "Initial FIM scan data is ready. Triggering first synchronization without startup delay.");
 }
 
-static void expect_fim_run_integrity_sync_body(AgentSyncProtocolHandle* handle, uint32_t sync_interval, bool persist_first_sync_marker) {
+static void expect_fim_run_integrity_sync_body(AgentSyncProtocolHandle* handle, uint32_t sync_interval, bool persist_first_sync_marker, bool expect_recovery_pass) {
     expect_string(__wrap__minfo, formatted_msg, "Starting FIM synchronization.");
 
     expect_value(__wrap_asp_sync_module, handle, handle);
@@ -418,15 +418,21 @@ static void expect_fim_run_integrity_sync_body(AgentSyncProtocolHandle* handle, 
         expect_any(__wrap_fim_db_update_last_sync_time_value, timestamp);
     }
 
+    // The recovery/integrity pass is skipped when the module was stopped during the
+    // synchronization (fim_sync_module_running already cleared), so tests that stop the
+    // loop through the sync wrapper must not expect it.
+    if (expect_recovery_pass) {
 #ifdef TEST_WINAGENT
-    /* On Windows, fim_run_integrity checks 3 tables: file, registry key, and registry value */
-    expect_function_call(__wrap_fim_recovery_integrity_interval_has_elapsed);
-    will_return(__wrap_fim_recovery_integrity_interval_has_elapsed, false);
-    expect_function_call(__wrap_fim_recovery_integrity_interval_has_elapsed);
-    will_return(__wrap_fim_recovery_integrity_interval_has_elapsed, false);
+        /* On Windows, fim_run_integrity checks 3 tables: file, registry key, and registry value */
+        expect_function_call(__wrap_fim_recovery_integrity_interval_has_elapsed);
+        will_return(__wrap_fim_recovery_integrity_interval_has_elapsed, false);
+        expect_function_call(__wrap_fim_recovery_integrity_interval_has_elapsed);
+        will_return(__wrap_fim_recovery_integrity_interval_has_elapsed, false);
 #endif
-    expect_function_call(__wrap_fim_recovery_integrity_interval_has_elapsed);
-    will_return(__wrap_fim_recovery_integrity_interval_has_elapsed, false);
+        expect_function_call(__wrap_fim_recovery_integrity_interval_has_elapsed);
+        will_return(__wrap_fim_recovery_integrity_interval_has_elapsed, false);
+    }
+
     expect_string(__wrap__mdebug1,
                   formatted_msg,
                   sync_interval == 1
@@ -1199,7 +1205,8 @@ void test_fim_run_integrity_skips_initial_wait_for_pending_first_sync(void **sta
     expect_string(__wrap_fim_db_get_last_sync_time, table_name, TEST_FIM_FIRST_SYNC_COMPLETED_METADATA_KEY);
     will_return(__wrap_fim_db_get_last_sync_time, 0);
     expect_fim_startup_log(false);
-    expect_fim_run_integrity_sync_body(handle, syscheck.sync_interval, true);
+    // The sync wrapper stops the module, so the recovery pass is skipped.
+    expect_fim_run_integrity_sync_body(handle, syscheck.sync_interval, true, false);
 
     call_real_fim_run_integrity();
 
@@ -1237,7 +1244,8 @@ void test_fim_run_integrity_keeps_initial_wait_after_first_sync(void **state) {
     expect_value(__wrap_sleep, seconds, 1);
 #endif
 
-    expect_fim_run_integrity_sync_body(handle, syscheck.sync_interval, false);
+    // The sync wrapper stops the module, so the recovery pass is skipped.
+    expect_fim_run_integrity_sync_body(handle, syscheck.sync_interval, false, false);
 
     call_real_fim_run_integrity();
 
@@ -1269,7 +1277,9 @@ void test_fim_run_integrity_pause_still_waits_after_skip_is_consumed(void **stat
     expect_string(__wrap_fim_db_get_last_sync_time, table_name, TEST_FIM_FIRST_SYNC_COMPLETED_METADATA_KEY);
     will_return(__wrap_fim_db_get_last_sync_time, 0);
     expect_fim_startup_log(false);
-    expect_fim_run_integrity_sync_body(handle, syscheck.sync_interval, true);
+    // The module keeps running after the sync (it stops on the sleep), so the
+    // recovery pass still runs.
+    expect_fim_run_integrity_sync_body(handle, syscheck.sync_interval, true, true);
 #ifdef TEST_WINAGENT
     expect_value(wrap_Sleep, dwMilliseconds, 1000);
 #else

--- a/src/unit_tests/syscheckd/test_syscom.c
+++ b/src/unit_tests/syscheckd/test_syscom.c
@@ -181,6 +181,27 @@ void test_syscom_dispatch_sync_error(void **state)
     assert_int_equal(ret, 24);
 }
 
+void test_syscom_dispatch_sync_destroyed_handle(void **state)
+{
+    (void) state;
+    size_t ret;
+    char command[] = "fim_sync test-data";
+    char *output;
+
+    syscheck.enable_synchronization = 1;
+    // The shutdown teardown destroyed the handle: the response must be dropped
+    // without touching the sync protocol (asp_parse_response_buffer is not called).
+    syscheck.sync_handle = NULL;
+
+    expect_string(__wrap__mdebug1, formatted_msg, "WMCOM Error syncing module");
+
+    ret = syscom_dispatch(command, strlen(command), &output);
+    *state = output;
+
+    assert_string_equal(output, "err Error syncing module");
+    assert_int_equal(ret, 24);
+}
+
 void test_syscom_getconfig_syscheck(void **state)
 {
     (void) state;
@@ -323,6 +344,7 @@ int main(void) {
         cmocka_unit_test_teardown(test_syscom_dispatch_sync_success, delete_string),
         cmocka_unit_test_teardown(test_syscom_dispatch_sync_disabled, delete_string),
         cmocka_unit_test_teardown(test_syscom_dispatch_sync_error, delete_string),
+        cmocka_unit_test_teardown(test_syscom_dispatch_sync_destroyed_handle, delete_string),
         cmocka_unit_test_teardown(test_syscom_getconfig_syscheck, delete_string),
         cmocka_unit_test_teardown(test_syscom_getconfig_syscheck_failure, delete_string),
         cmocka_unit_test_teardown(test_syscom_getconfig_rootcheck, delete_string),

--- a/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
@@ -227,6 +227,14 @@ class AgentInfoImpl
         ///         caller should defer coordination), or Failed (timeout/error/shutdown)
         PauseProbeResult pollFimPauseCompletion(const std::string& moduleName);
 
+        /// @brief Query a coordination module for whether its first synchronization has completed.
+        /// @param moduleName Module name (e.g. sca, syscollector).
+        /// @return false when the module reports first_sync_completed=0 or has not recorded a
+        ///         completed first sync yet (metadata unset = still in progress); true otherwise
+        ///         (already synced, or sync disabled — the module reports completed — or the module
+        ///         did not answer at all), so coordination is never wedged on a module that will not sync.
+        bool isModuleFirstSyncCompleted(const std::string& moduleName);
+
         /// @brief Poll all requested module flushes until completion.
         /// @param pendingModules Set of modules with an accepted flush request.
         /// @return true if all flushes completed successfully, false otherwise.

--- a/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
@@ -308,11 +308,15 @@ class AgentInfoImpl
         /// Overridable in unit tests to avoid real sleeps.
         int m_pausePollDelayMs = 1000;
 
-        /// @brief True once the current deferral streak has logged its INFO line, so
-        /// repeated deferrals during the same first sync stay at DEBUG.
-        /// Reset when the deferral episode ends: either FIM reports the first sync is
-        /// complete, or the FIM probe gives up (timeout/IPC failure) without deferring.
-        bool m_deferralLogged = false;
+        /// @brief Modules whose current deferral streak has logged its INFO line, so
+        /// repeated deferrals during the same first sync stay at DEBUG. Tracked per
+        /// module: FIM's probe runs (and ends its episode) every cycle before
+        /// SCA/syscollector are evaluated, so a shared flag would be cleared each cycle
+        /// and re-emit the INFO for the whole duration of their first sync.
+        /// A module is erased when its deferral episode ends: it reports the first sync
+        /// is complete, or (FIM) the probe gives up (timeout/IPC failure) without
+        /// deferring.
+        std::set<std::string> m_deferralLoggedModules;
 
         /// @brief Condition variable for efficient sleep/wake mechanism
         std::condition_variable m_cv;

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -1450,6 +1450,56 @@ bool AgentInfoImpl::pollFlushCompletion(std::set<std::string> pendingModules)
     return false;
 }
 
+bool AgentInfoImpl::isModuleFirstSyncCompleted(const std::string& moduleName)
+{
+    // Ask the module whether its one-shot first synchronization has completed. SCA and syscollector
+    // answer get_first_sync_completed with a first_sync_completed field (1/0); while the first sync
+    // is still in progress the metadata is unset and the field is absent. When synchronization is
+    // disabled the module reports completed (see wm_sca.c / wm_syscollector.c), so we never defer
+    // forever on a sync that will not run.
+    const std::string message = createJsonCommand("get_first_sync_completed");
+    const ModuleResponse response = queryModuleWithRetry(moduleName, message);
+
+    try
+    {
+        const nlohmann::json parsed = nlohmann::json::parse(response.response);
+
+        if (parsed.contains("data") && parsed["data"].contains("first_sync_completed"))
+        {
+            const auto& value = parsed["data"]["first_sync_completed"];
+
+            if (value.is_number())
+            {
+                return value.get<int>() != 0;
+            }
+
+            if (value.is_boolean())
+            {
+                return value.get<bool>();
+            }
+        }
+
+        // No first_sync_completed field. SCA/syscollector answer get_first_sync_completed with an
+        // error while their first-sync marker is not set yet (metadata unset) — that is exactly the
+        // "first sync still in progress" state, so defer. A successful response without the field
+        // means the module has nothing to defer on, so treat it as completed and do not wedge
+        // coordination.
+        if (parsed.contains("error") && parsed["error"].is_number() && parsed["error"].get<int>() != 0)
+        {
+            return false;
+        }
+
+        return true;
+    }
+    catch (const std::exception& e)
+    {
+        // No / unparseable response (module unreachable): do not wedge coordination, treat as done.
+        m_logFunction(LOG_DEBUG,
+                      "Could not read first_sync_completed from " + moduleName + ": " + std::string(e.what()));
+        return true;
+    }
+}
+
 AgentInfoImpl::PauseCoordinationResult AgentInfoImpl::pauseCoordinationModules(std::set<std::string>& pausedModules)
 {
     for (const auto& module : COORDINATION_MODULES)
@@ -1495,7 +1545,30 @@ AgentInfoImpl::PauseCoordinationResult AgentInfoImpl::pauseCoordinationModules(s
             }
             else
             {
-                // Other modules: pause is synchronous, already completed
+                // SCA/syscollector pause synchronously, but like FIM they deliver their initial
+                // state via a one-shot first sync. Defer coordination until that completes so we do
+                // not pause/flush and advance the group/metadata version mid-first-sync (extends the
+                // FIM guard from #36762 to these modules).
+                if (!isModuleFirstSyncCompleted(module))
+                {
+                    if (!m_deferralLogged)
+                    {
+                        m_logFunction(LOG_INFO,
+                                      "Deferring coordination until " + module +
+                                      " first sync completes, will retry next cycle");
+                        m_deferralLogged = true;
+                    }
+                    else
+                    {
+                        m_logFunction(LOG_DEBUG, "Still deferring coordination until " + module + " first sync completes");
+                    }
+
+                    pausedModules.insert(module);
+                    resumePausedModules(pausedModules);
+                    return PauseCoordinationResult::Deferred;
+                }
+
+                m_deferralLogged = false;
                 m_logFunction(LOG_DEBUG, "Successfully paused " + module);
             }
 

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -1246,11 +1246,10 @@ AgentInfoImpl::PauseProbeResult AgentInfoImpl::pollFimPauseCompletion(const std:
 
                 if (moduleName == FIM_NAME && !firstSyncCompleted)
                 {
-                    if (!m_deferralLogged)
+                    if (m_deferralLoggedModules.insert(moduleName).second)
                     {
                         m_logFunction(LOG_INFO,
                                       "Deferring coordination until FIM first sync completes, will retry next cycle");
-                        m_deferralLogged = true;
                     }
                     else
                     {
@@ -1263,11 +1262,11 @@ AgentInfoImpl::PauseProbeResult AgentInfoImpl::pollFimPauseCompletion(const std:
 
                 // FIM first sync is no longer in progress: the deferral episode (if any)
                 // has ended. Clear the throttle here rather than only on full coordination
-                // success, so a failure later in the cycle does not leave it stuck true and
+                // success, so a failure later in the cycle does not leave it stuck and
                 // suppress the operator-visible INFO on a future deferral episode.
                 if (moduleName == FIM_NAME)
                 {
-                    m_deferralLogged = false;
+                    m_deferralLoggedModules.erase(moduleName);
                 }
 
                 std::string status = pollJson["data"]["status"].get<std::string>();
@@ -1321,7 +1320,7 @@ AgentInfoImpl::PauseProbeResult AgentInfoImpl::pollFimPauseCompletion(const std:
     // deferral episode logs its INFO marker again instead of being stuck at DEBUG.
     if (moduleName == FIM_NAME)
     {
-        m_deferralLogged = false;
+        m_deferralLoggedModules.erase(moduleName);
     }
 
     m_logFunction(LOG_WARNING,
@@ -1551,12 +1550,11 @@ AgentInfoImpl::PauseCoordinationResult AgentInfoImpl::pauseCoordinationModules(s
                 // FIM guard from #36762 to these modules).
                 if (!isModuleFirstSyncCompleted(module))
                 {
-                    if (!m_deferralLogged)
+                    if (m_deferralLoggedModules.insert(module).second)
                     {
                         m_logFunction(LOG_INFO,
                                       "Deferring coordination until " + module +
                                       " first sync completes, will retry next cycle");
-                        m_deferralLogged = true;
                     }
                     else
                     {
@@ -1568,7 +1566,7 @@ AgentInfoImpl::PauseCoordinationResult AgentInfoImpl::pauseCoordinationModules(s
                     return PauseCoordinationResult::Deferred;
                 }
 
-                m_deferralLogged = false;
+                m_deferralLoggedModules.erase(module);
                 m_logFunction(LOG_DEBUG, "Successfully paused " + module);
             }
 

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp
@@ -1713,6 +1713,131 @@ TEST_F(AgentInfoCoordinationTest, DeferCoordinationWhenFimFirstSyncNotCompleted)
     EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("Successfully coordinated")));
 }
 
+// Extends the #36358/#36762 FIM guard to SCA: FIM first sync is done, SCA reports
+// first_sync_completed=0 via get_first_sync_completed -> coordination defers on SCA.
+TEST_F(AgentInfoCoordinationTest, DeferCoordinationWhenScaFirstSyncNotCompleted)
+{
+    int selectRowsCalls = 0;
+    expectMetadataSyncNeeded(m_mockDBSync, selectRowsCalls);
+
+    auto queryModuleFunc = [](const std::string & module_name, const std::string & query, char** response) -> int
+    {
+        nlohmann::json commandJson = nlohmann::json::parse(query);
+        const auto command = commandJson["command"].get<std::string>();
+
+        nlohmann::json responseJson;
+        responseJson["error"] = 0;
+        responseJson["message"] = "Success";
+
+        // FIM first sync already completed, so coordination advances to SCA.
+        if (command == "is_pause_completed" && module_name == "fim")
+        {
+            responseJson["data"]["status"] = "completed";
+            responseJson["data"]["result"] = "success";
+            responseJson["data"]["first_sync_completed"] = true;
+        }
+
+        // SCA first sync still in progress.
+        else if (command == "get_first_sync_completed" && module_name == "sca")
+        {
+            responseJson["data"]["first_sync_completed"] = 0;
+        }
+        else if (command == "get_version")
+        {
+            responseJson["data"]["version"] = 5;
+        }
+
+        std::string responseStr = responseJson.dump();
+        * response = strdup(responseStr.c_str());
+        return 0;
+    };
+
+    m_agentInfo = std::make_shared<AgentInfoImpl>(
+                      ":memory:", m_reportDiffFunc, m_logFunc, queryModuleFunc, m_mockDBSync,
+                      m_mockSysInfo, m_mockFileIO, m_mockFileSystem);
+    m_agentInfo->setPausePollDelayMs(0);
+
+    EXPECT_CALL(*m_mockFileSystem, exists(::testing::_))
+    .WillRepeatedly(::testing::Return(false));
+
+    nlohmann::json osData = {{"os_name", "TestOS"}};
+    EXPECT_CALL(*m_mockSysInfo, os())
+    .WillRepeatedly(::testing::Return(osData));
+
+    m_logOutput.clear();
+    m_agentInfo->start(1, 86400, []()
+    {
+        return false;
+    });
+
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("Deferring coordination until sca first sync completes"));
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("Successfully coordinated")));
+}
+
+// Same guard for syscollector: FIM and SCA are done, syscollector reports
+// first_sync_completed=0 -> coordination defers on syscollector.
+TEST_F(AgentInfoCoordinationTest, DeferCoordinationWhenSyscollectorFirstSyncNotCompleted)
+{
+    int selectRowsCalls = 0;
+    expectMetadataSyncNeeded(m_mockDBSync, selectRowsCalls);
+
+    auto queryModuleFunc = [](const std::string & module_name, const std::string & query, char** response) -> int
+    {
+        nlohmann::json commandJson = nlohmann::json::parse(query);
+        const auto command = commandJson["command"].get<std::string>();
+
+        nlohmann::json responseJson;
+        responseJson["error"] = 0;
+        responseJson["message"] = "Success";
+
+        if (command == "is_pause_completed" && module_name == "fim")
+        {
+            responseJson["data"]["status"] = "completed";
+            responseJson["data"]["result"] = "success";
+            responseJson["data"]["first_sync_completed"] = true;
+        }
+
+        // SCA first sync completed, syscollector still in progress.
+        else if (command == "get_first_sync_completed" && module_name == "sca")
+        {
+            responseJson["data"]["first_sync_completed"] = 1;
+        }
+        else if (command == "get_first_sync_completed" && module_name == "syscollector")
+        {
+            responseJson["data"]["first_sync_completed"] = 0;
+        }
+        else if (command == "get_version")
+        {
+            responseJson["data"]["version"] = 5;
+        }
+
+        std::string responseStr = responseJson.dump();
+        * response = strdup(responseStr.c_str());
+        return 0;
+    };
+
+    m_agentInfo = std::make_shared<AgentInfoImpl>(
+                      ":memory:", m_reportDiffFunc, m_logFunc, queryModuleFunc, m_mockDBSync,
+                      m_mockSysInfo, m_mockFileIO, m_mockFileSystem);
+    m_agentInfo->setPausePollDelayMs(0);
+
+    EXPECT_CALL(*m_mockFileSystem, exists(::testing::_))
+    .WillRepeatedly(::testing::Return(false));
+
+    nlohmann::json osData = {{"os_name", "TestOS"}};
+    EXPECT_CALL(*m_mockSysInfo, os())
+    .WillRepeatedly(::testing::Return(osData));
+
+    m_logOutput.clear();
+    m_agentInfo->start(1, 86400, []()
+    {
+        return false;
+    });
+
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("Deferring coordination until syscollector first sync completes"));
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("Successfully coordinated")));
+}
+
 // FIM is probed first, so a deferral pauses and resumes only FIM and never touches
 // SCA/Syscollector. FIM accepted the pause request but is not yet in pausedModules
 // at the deferral point, so it must still be resumed (guards R2).

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_coordination_test.cpp
@@ -1838,6 +1838,102 @@ TEST_F(AgentInfoCoordinationTest, DeferCoordinationWhenSyscollectorFirstSyncNotC
     EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("Successfully coordinated")));
 }
 
+// The deferral throttle is per module: FIM's probe ends its own episode every cycle
+// (clearing its marker) before SCA is evaluated, so SCA's marker must survive across
+// cycles — the INFO line is emitted once per episode and later cycles log the DEBUG
+// "Still deferring" line instead of re-emitting the INFO.
+TEST_F(AgentInfoCoordinationTest, ScaDeferralLogsInfoOnceAcrossCycles)
+{
+    // Metadata sync stays flagged on every read so each start() run performs a
+    // coordination cycle (the deferral retains the sync flag).
+    EXPECT_CALL(*m_mockDBSync, handle())
+    .WillRepeatedly(::testing::Return(reinterpret_cast<void*>(0x1)));
+
+    EXPECT_CALL(*m_mockDBSync, addTableRelationship(::testing::_))
+    .WillRepeatedly(::testing::Return());
+
+    EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
+    .WillRepeatedly(::testing::Invoke([](const nlohmann::json& /* query */,
+                                         std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
+    {
+        nlohmann::json flagData;
+        flagData["should_sync_metadata"] = 1;
+        flagData["should_sync_groups"] = 0;
+        flagData["last_metadata_integrity"] = 0;
+        flagData["last_groups_integrity"] = 0;
+        flagData["is_first_run"] = 0;
+        flagData["is_first_groups_run"] = 0;
+        callback(SELECTED, flagData);
+    }));
+
+    auto queryModuleFunc = [](const std::string & module_name, const std::string & query, char** response) -> int
+    {
+        nlohmann::json commandJson = nlohmann::json::parse(query);
+        const auto command = commandJson["command"].get<std::string>();
+
+        nlohmann::json responseJson;
+        responseJson["error"] = 0;
+        responseJson["message"] = "Success";
+
+        // FIM first sync completed on every cycle, so coordination advances to SCA.
+        if (command == "is_pause_completed" && module_name == "fim")
+        {
+            responseJson["data"]["status"] = "completed";
+            responseJson["data"]["result"] = "success";
+            responseJson["data"]["first_sync_completed"] = true;
+        }
+
+        // SCA first sync stays in progress for the whole test.
+        else if (command == "get_first_sync_completed" && module_name == "sca")
+        {
+            responseJson["data"]["first_sync_completed"] = 0;
+        }
+        else if (command == "get_version")
+        {
+            responseJson["data"]["version"] = 5;
+        }
+
+        std::string responseStr = responseJson.dump();
+        * response = strdup(responseStr.c_str());
+        return 0;
+    };
+
+    m_agentInfo = std::make_shared<AgentInfoImpl>(
+                      ":memory:", m_reportDiffFunc, m_logFunc, queryModuleFunc, m_mockDBSync,
+                      m_mockSysInfo, m_mockFileIO, m_mockFileSystem);
+    m_agentInfo->setPausePollDelayMs(0);
+
+    EXPECT_CALL(*m_mockFileSystem, exists(::testing::_))
+    .WillRepeatedly(::testing::Return(false));
+
+    nlohmann::json osData = {{"os_name", "TestOS"}};
+    EXPECT_CALL(*m_mockSysInfo, os())
+    .WillRepeatedly(::testing::Return(osData));
+
+    m_logOutput.clear();
+
+    // Two coordination cycles against the same deferring SCA first sync.
+    m_agentInfo->start(1, 86400, []()
+    {
+        return false;
+    });
+    m_agentInfo->start(1, 86400, []()
+    {
+        return false;
+    });
+
+    const std::string infoLine = "Deferring coordination until sca first sync completes";
+    size_t infoCount = 0;
+
+    for (size_t pos = m_logOutput.find(infoLine); pos != std::string::npos; pos = m_logOutput.find(infoLine, pos + infoLine.size()))
+    {
+        ++infoCount;
+    }
+
+    EXPECT_EQ(infoCount, 1u);
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("Still deferring coordination until sca first sync completes"));
+}
+
 // FIM is probed first, so a deferral pauses and resumes only FIM and never touches
 // SCA/Syscollector. FIM accepted the pause request but is not yet in pausedModules
 // at the deferral point, so it must still be resumed (guards R2).

--- a/src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp
+++ b/src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp
@@ -16,6 +16,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <vector>
 
@@ -296,6 +297,16 @@ class SecurityConfigurationAssessment
 
         /// @brief Controller for asynchronous flush requests.
         std::unique_ptr<Utils::AsyncFlushController> m_asyncFlushController;
+
+        /// @brief Serializes releaseResources() against the entry points that other threads
+        /// keep driving while the module tears down: wcom's dispatcher (query() and
+        /// parseResponseBuffer()) is detached and never joined, and agent-info's coordination
+        /// queries call query() in-process from its own module thread. Those entry points take
+        /// it shared around each access; releaseResources() resets the members under the
+        /// exclusive lock. The sync worker and the flush worker do not take it: the former is
+        /// joined before releaseResources() runs and the latter is joined by the flush
+        /// controller destruction before m_spSyncProtocol/m_dBSync are reset.
+        mutable std::shared_mutex m_resourcesMutex;
 
         /// @brief Commands timeout for policy execution
         int m_commandsTimeout = 0;

--- a/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp
@@ -231,6 +231,8 @@ void SCAEventHandler::ReportCheckResult(const std::string& policyId,
         // LCOV_EXCL_STOP
     }
 
+    checkData.erase("version");
+
     auto updateResultQuery = SyncRowQuery::builder().table("sca_check").data(checkData).returnOldData().build();
 
     // List to accumulate checks that fail validation for deferred deletion

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -359,19 +359,34 @@ void SecurityConfigurationAssessment::quiesce()
 
 void SecurityConfigurationAssessment::releaseResources()
 {
+    // Take the flush controller out under the exclusive lock (so a concurrent wcom
+    // "flush"/"is_flush_completed" query sees either the live controller or none) but
+    // destroy it outside of it: its destructor joins the flush worker, which runs
+    // executeFlushSync() -> m_spSyncProtocol->synchronizeModule() without taking
+    // m_resourcesMutex. The protocol must outlive that join, so it is reset after it.
+    std::unique_ptr<Utils::AsyncFlushController> flushController;
+    {
+        std::unique_lock<std::shared_mutex> lock(m_resourcesMutex);
+        flushController = std::move(m_asyncFlushController);
+    }
+    flushController.reset();
+
+    std::unique_lock<std::shared_mutex> lock(m_resourcesMutex);
+
     // Explicitly release DBSync before static destruction to avoid use-after-free
     // during shutdown when DBSyncImplementation singleton may be destroyed first.
     // Must be called only after the sync worker thread has been joined, because
     // synchronizeDatabaseSnapshot() uses m_dBSync without holding any mutex.
     m_dBSync.reset();
 
-    // Destroy the flush controller and the sync protocol so their SQLite connection to
-    // sca_sync.db is closed (sqlite3_close_v2 on last close checkpoints the WAL and removes
-    // the -wal/-shm files). Stop() only signals the workers; without this the connection is
-    // leaked and a graceful stop leaves stale WAL files behind (issue #37334). Safe here:
-    // the sync worker thread and the SCA run loop have already exited (see wm_sca_start
-    // teardown), mirroring Syscollector::releaseResources().
-    m_asyncFlushController.reset();
+    // Destroy the sync protocol so its SQLite connection to sca_sync.db is closed
+    // (sqlite3_close_v2 on last close checkpoints the WAL and removes the -wal/-shm
+    // files). Stop() only signals the workers; without this the connection is leaked
+    // and a graceful stop leaves stale WAL files behind (issue #37334). The sync worker
+    // thread and the SCA run loop have already exited (see wm_sca_start teardown),
+    // mirroring Syscollector::releaseResources(); the entry points still reachable from
+    // other threads (wcom queries and sync responses, agent-info's in-process
+    // coordination queries) are excluded by the lock, which they take shared.
     m_spSyncProtocol.reset();
 }
 
@@ -445,7 +460,12 @@ void SecurityConfigurationAssessment::initSyncProtocol(const std::string& module
 
     try
     {
-        m_spSyncProtocol = std::make_shared<AgentSyncProtocol>(moduleName, syncDbPath, mqFuncs, logger_func, syncEndDelay, timeout, retries, maxEps, nullptr);
+        {
+            // Publish under the exclusive lock: wcom queries can arrive while the module
+            // is still starting up, and they read the pointer under the shared lock.
+            std::unique_lock<std::shared_mutex> lock(m_resourcesMutex);
+            m_spSyncProtocol = std::make_shared<AgentSyncProtocol>(moduleName, syncDbPath, mqFuncs, logger_func, syncEndDelay, timeout, retries, maxEps, nullptr);
+        }
         LoggingHelper::getInstance().log(LOG_DEBUG, "SCA sync protocol initialized successfully with database: " + syncDbPath);
 
         // Initialize schema validator factory from embedded resources
@@ -552,6 +572,8 @@ bool SecurityConfigurationAssessment::syncModule(Mode mode)
 
 void SecurityConfigurationAssessment::persistDifference(const std::string& id, Operation operation, const std::string& index, const std::string& data, uint64_t version)
 {
+    std::shared_lock<std::shared_mutex> lock(m_resourcesMutex);
+
     if (m_spSyncProtocol)
     {
         m_spSyncProtocol->persistDifference(id, operation, index, data, version);
@@ -560,6 +582,8 @@ void SecurityConfigurationAssessment::persistDifference(const std::string& id, O
 
 bool SecurityConfigurationAssessment::parseResponseBuffer(const uint8_t* data, size_t length)
 {
+    std::shared_lock<std::shared_mutex> lock(m_resourcesMutex);
+
     if (m_spSyncProtocol)
     {
         return m_spSyncProtocol->parseResponseBuffer(data, length);
@@ -591,6 +615,8 @@ void SecurityConfigurationAssessment::setSyncLimit(uint64_t syncLimit)
 
 bool SecurityConfigurationAssessment::notifyDataClean(const std::vector<std::string>& indices)
 {
+    std::shared_lock<std::shared_mutex> lock(m_resourcesMutex);
+
     if (m_spSyncProtocol)
     {
         return m_spSyncProtocol->notifyDataClean(indices);
@@ -601,6 +627,8 @@ bool SecurityConfigurationAssessment::notifyDataClean(const std::vector<std::str
 
 void SecurityConfigurationAssessment::deleteDatabase()
 {
+    std::shared_lock<std::shared_mutex> lock(m_resourcesMutex);
+
     if (m_spSyncProtocol)
     {
         m_spSyncProtocol->deleteDatabase();
@@ -797,6 +825,13 @@ void SecurityConfigurationAssessment::resume()
 
 std::string SecurityConfigurationAssessment::query(const std::string& jsonQuery)
 {
+    // Serialize against releaseResources(): queries arrive from the wcom dispatcher and
+    // from agent-info's in-process coordination polls, which outlive the module teardown.
+    // The blocking commands stay bounded under the shared lock at shutdown because
+    // quiesce() (which precedes releaseResources()) wakes pause() and stops the sync
+    // protocol before the exclusive lock is ever requested.
+    std::shared_lock<std::shared_mutex> resourcesLock(m_resourcesMutex);
+
     // Log the received query
     LoggingHelper::getInstance().log(LOG_DEBUG, "Received query: " + jsonQuery);
 

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -364,6 +364,15 @@ void SecurityConfigurationAssessment::releaseResources()
     // Must be called only after the sync worker thread has been joined, because
     // synchronizeDatabaseSnapshot() uses m_dBSync without holding any mutex.
     m_dBSync.reset();
+
+    // Destroy the flush controller and the sync protocol so their SQLite connection to
+    // sca_sync.db is closed (sqlite3_close_v2 on last close checkpoints the WAL and removes
+    // the -wal/-shm files). Stop() only signals the workers; without this the connection is
+    // leaked and a graceful stop leaves stale WAL files behind (issue #37334). Safe here:
+    // the sync worker thread and the SCA run loop have already exited (see wm_sca_start
+    // teardown), mirroring Syscollector::releaseResources().
+    m_asyncFlushController.reset();
+    m_spSyncProtocol.reset();
 }
 
 void SecurityConfigurationAssessment::Stop()

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_event_handler_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_event_handler_test.cpp
@@ -1179,6 +1179,75 @@ TEST_F(SCAEventHandlerTest, ReportCheckResult_ValidInput)
     }
 }
 
+TEST_F(SCAEventHandlerTest, ReportCheckResult_DoesNotSendVersionInSyncPayload)
+{
+    const std::string policyId = "test_policy";
+    const std::string checkId = "test_check";
+    const std::string checkResult = "Failed";
+
+    EXPECT_CALL(*mockDBSync, syncRow(testing::_, testing::_))
+    .WillOnce([checkResult](const nlohmann::json & query,
+                            const std::function<void(ReturnTypeCallback, const nlohmann::json&)>& callback)
+    {
+        ASSERT_TRUE(query.contains("data"));
+        ASSERT_FALSE(query["data"].empty());
+        EXPECT_FALSE(query["data"][0].contains("version"));
+
+        nlohmann::json returnData =
+        {
+            {
+                "old", {
+                    {"id", "test_check"},
+                    {"result", "Passed"},
+                    {"version", 7}
+                }
+            },
+            {
+                "new", {
+                    {"id", "test_check"},
+                    {"result", checkResult},
+                    {"version", 8}
+                }
+            }
+        };
+        callback(MODIFIED, returnData);
+    });
+
+    auto newHandler = std::make_unique<sca_event_handler::SCAEventHandlerMock>(
+                          mockDBSync,
+                          nullptr,
+                          nullptr,
+                          false,
+                          false);
+
+    const nlohmann::json mockPolicy =
+    {
+        {"id", policyId},
+        {"name", "Test Policy"},
+        {"description", "Test Description"},
+        {"file", "test.yml"},
+        {"refs", "https://example.com"}
+    };
+
+    EXPECT_CALL(*newHandler, GetPolicyById(policyId))
+    .WillOnce(testing::Return(mockPolicy));
+
+    const nlohmann::json mockCheck =
+    {
+        {"id", checkId},
+        {"policy_id", policyId},
+        {"name", "Test Check"},
+        {"description", "Test Check Description"},
+        {"result", "Passed"},
+        {"version", 7}
+    };
+
+    EXPECT_CALL(*newHandler, GetPolicyCheckById(checkId))
+    .WillOnce(testing::Return(mockCheck));
+
+    newHandler->ReportCheckResult(policyId, checkId, checkResult);
+}
+
 TEST_F(SCAEventHandlerTest, ReportCheckResult_SuppressesFirstScanNotRunTransitions)
 {
     const std::string policyId = "test_policy";

--- a/src/wazuh_modules/src/wm_sca.c
+++ b/src/wazuh_modules/src/wm_sca.c
@@ -961,6 +961,15 @@ static size_t wm_sca_query_handler(void *data, char *query, char **output) {
         return 0;
     }
 
+    // Mirrors #36762 (FIM): when synchronization is disabled the sync worker never runs, so the SCA
+    // first-sync marker is never set. Report it as completed so agent-info coordination is not blocked
+    // deferring on a first sync that will never happen. The startup priming path calls sca_query_ptr
+    // directly and is unaffected by this handler-level short-circuit.
+    if (!sca_enable_synchronization && strstr(query, "get_first_sync_completed")) {
+        os_strdup("{\"error\":0,\"data\":{\"action\":\"get_first_sync_completed\",\"module\":\"sca\",\"first_sync_completed\":1}}", *output);
+        return strlen(*output);
+    }
+
     // Call the C++ query function if available
     if (sca_query_ptr) {
         return sca_query_ptr(query, output);

--- a/src/wazuh_modules/src/wm_sca.c
+++ b/src/wazuh_modules/src/wm_sca.c
@@ -316,7 +316,11 @@ static int wm_sca_startmq(const char* key, short type, short attempts) {
 }
 
 static int wm_sca_send_binary_msg(int queue, const void* message, size_t message_len, const char* locmsg, char loc) {
-    return SendBinaryMSG(queue, message, message_len, locmsg, loc);
+    // Predicated so a synchronization parked in the manager-disconnected wait (os_wait)
+    // returns on shutdown: the protocol's stop() cannot interrupt this wait, and a parked
+    // send would stall the sync worker join in wm_sca_start() — and, if it arrived through
+    // a wcom query holding m_resourcesMutex shared, the releaseResources() teardown too.
+    return SendBinaryMSGPredicated(queue, message, message_len, locmsg, loc, wm_sca_is_shutting_down);
 }
 
 static bool wm_sca_parse_query_int(const char* output, const char* field, int* value)

--- a/src/wazuh_modules/src/wm_syscollector.c
+++ b/src/wazuh_modules/src/wm_syscollector.c
@@ -1112,6 +1112,16 @@ static size_t wm_sys_query_handler(void* data, char* query, char** output)
         return 0;
     }
 
+    // Mirrors #36762 (FIM): when synchronization is disabled the sync worker never runs, so the
+    // syscollector first-sync marker is never set. Report it as completed so agent-info coordination
+    // is not blocked deferring on a first sync that will never happen. The startup priming path calls
+    // syscollector_query_ptr directly and is unaffected by this handler-level short-circuit.
+    if (!enable_synchronization && strstr(query, "get_first_sync_completed"))
+    {
+        os_strdup("{\"error\":0,\"data\":{\"action\":\"get_first_sync_completed\",\"module\":\"syscollector\",\"first_sync_completed\":1}}", *output);
+        return strlen(*output);
+    }
+
     // Call the C++ query function if available
     if (syscollector_query_ptr)
     {

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -538,6 +538,12 @@ int SendMSGPredicated(__attribute__((unused)) int queue, const char *message, co
     return SendMSGAction(queue, message, locmsg, loc);
 }
 
+/* SendBinaryMSGPredicated for Windows */
+int SendBinaryMSGPredicated(__attribute__((unused)) int queue, const void *message, size_t message_len, const char *locmsg, char loc, bool (*fn_ptr)()) {
+    os_wait_predicate(fn_ptr);
+    return SendBinaryMSGAction(queue, message, message_len, locmsg, loc);
+}
+
 /* StartMQ for Windows */
 int StartMQWithSpecificOwnerAndPerms(__attribute__((unused)) const char *path
                                      ,__attribute__((unused)) short int type

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 import pytest
 import sys
+import time
 
 from wazuh_testing.constants.platforms import WINDOWS, MACOS
 from py.xml import html
@@ -412,6 +413,17 @@ def daemons_handler_implementation(request: pytest.FixtureRequest) -> None:
         logger.error(f"{str(called_process_error)}")
         if not ignore_errors:
             raise called_process_error
+
+    # On a fresh install the service can report running before the logger has created
+    # ossec.log (first-ever start, e.g. right after the MSI install on the Windows
+    # runners), and monitors built right after this fixture require the file to exist.
+    # Wait for it instead of racing the first log write.
+    for _ in range(30):
+        if os.path.isfile(os.path.join(ROOT_PREFIX, WAZUH_LOG_PATH)):
+            break
+        time.sleep(1)
+    else:
+        logger.warning(f"{WAZUH_LOG_PATH} was not created after starting the daemons")
 
     yield
 

--- a/tests/integration/test_syscollector/test_configuration/test_syscollector_configuration.py
+++ b/tests/integration/test_syscollector/test_configuration/test_syscollector_configuration.py
@@ -548,8 +548,11 @@ def test_syscollector_collectors_disabled(test_configuration, test_metadata, set
     log_monitor.start(callback=callbacks.generate_callback(patterns.CB_DISABLED_COLLECTORS_DETECTED), timeout=30)
     assert log_monitor.callback_result, "Disabled collectors with data should be detected"
 
-    # Check DataClean notification is started
-    log_monitor.start(callback=callbacks.generate_callback(patterns.CB_DATACLEAN_NOTIFICATION_STARTED), timeout=60)
+    # Check DataClean notification is started. The notification is emitted when the module
+    # start reaches handleNotifyDataClean(), which on the disconnected test agent can take
+    # well over a minute (the agent retries enrollment/agentd queries with the manager
+    # unreachable), so give it the same margin as the other slow-path monitors in this file.
+    log_monitor.start(callback=callbacks.generate_callback(patterns.CB_DATACLEAN_NOTIFICATION_STARTED), timeout=180)
     assert log_monitor.callback_result, "DataClean notification should be started for disabled collectors with data"
 
     if all_collectors_disabled:


### PR DESCRIPTION
## Description

Three agent-side fixes for the SCA/FIM/syscollector synchronization lifecycle, all stemming from the #37334 investigation:

1. **Graceful shutdown leaves the SCA and FIM synchronization databases open.** Stopping the agent leaves stale SQLite `-wal`/`-shm` files behind (a multi-megabyte un-checkpointed WAL in FIM's case) because the sync protocol is never destroyed — this is the leftover reported in #37334.
2. **agent-info module coordination is not guarded against SCA/syscollector first synchronization.** #36762 made coordination defer while FIM's first sync is in progress, but wired the `first_sync_completed` guard for FIM only; a group or metadata change arriving during SCA's or syscollector's first sync runs coordination mid-first-sync.
3. **An SCA check's document version never advances when its result changes.** DBSync auto-increments a `version` column on a modified row, but SCA was suppressing it, so a check flipping Pass↔Fail kept the same `document_version`. Because that value is what the manager sends to the indexer as the `external_gte` version, a changed document could not outrank the tombstone the manager's re-sync leaves behind after deleting the previous version.

Related to #37334. The empty-SCA-dashboard after a local DB rebuild is a manager-side re-sync version conflict, fixed separately in #37352; fix 3 here is its agent-side complement (a changed check's re-index can now outrank its own tombstone).

## Proposed Changes

**1. Close the sync protocol databases on graceful shutdown** (shutdown commit)

- **SCA** (`sca_impl.cpp`): `releaseResources()` now also resets `m_asyncFlushController` and `m_spSyncProtocol`, mirroring `Syscollector::releaseResources()` (the module that already shuts down cleanly). Safe at that point: `wm_sca_start()` joins the sync worker before releasing resources.
- **FIM** (`run_check.c`, `main.c`, `syscom.c`, `file.c`): the inventory synchronization thread is created **joinable** (`CreateThreadJoinable`) and the teardown runs in a dedicated shutdown thread, never in signal context. `fim_shutdown()` (registered with raw `signal()`, may run on any thread) now only does async-signal-safe work: it records the signal, raises the stop flags and wakes `fim_shutdown_waiter()` through a self-pipe. The waiter performs the teardown in normal thread context: `asp_stop()` → join the synchronization thread → `asp_destroy()` → `fim_db_teardown()` → `HandleSIG()`. The join is bounded: the worker polls the stop flag in 1-second slices and `asp_stop()` aborts an in-flight synchronization.
- **Why not in the handler**: joining from the handler can deadlock — if the signal lands on a thread that holds `syscheck.directories_lock` or `syscheck.fim_scan_mutex` (e.g. the main thread inside `fim_scan()`), that thread parks in the handler without releasing them while `fim_run_integrity` blocks on those very locks and never re-checks the stop flag, so the join never returns and the service manager SIGKILLs the process, leaving the very `-wal`/`-shm` files behind. Destroying in the handler is racy too: a second termination signal (raw `signal()` leaves the other signals unblocked) can re-enter the handler, skip the join and free the handle under the live synchronization thread.
- **Handle lifetime** (`fim_sync_handle_rwlock`): the `sync_handle` users that are not joined before the destroy — event persistence (`persist_syscheck_msg`), syscom's `fim_sync` responses, the DataClean paths and the scheduled-scan `asp_reset` — take a new leaf rwlock for reading around each `asp_*` call and re-check the handle under it; the shutdown waiter destroys the handle and resets it to `NULL` under the write lock, so an in-flight call can never dereference a freed handle. The teardown itself is Unix-only (`main.c` is `#ifndef WIN32`); the guards are shared and inert on Windows.

With the connections closed, SQLite's last close checkpoints the WAL and removes the `-wal`/`-shm` sidecar files.

**2. Defer coordination while SCA/syscollector first sync is in progress** (coordination-guard commit)

- **agent-info** (`agent_info_impl.{hpp,cpp}`): added `isModuleFirstSyncCompleted()`, which queries `get_first_sync_completed`; the SCA/syscollector branch of `pauseCoordinationModules()` now defers coordination — same throttled INFO log and pause/resume handling as the FIM guard — until their first sync completes. An error response (the modules answer with an error while the first-sync marker is unset) is treated as "in progress" (defer); a successful response without the field proceeds, so coordination is never wedged.
- **`wm_sca.c` / `wm_syscollector.c`**: when synchronization is disabled, the query handler reports `first_sync_completed=1` (mirrors FIM's `!enable_synchronization` handling in `syscom.c`), so coordination never waits on a sync that will never run. The startup-priming path calls the module query pointer directly and is unaffected.

**3. Let DBSync increment the SCA check version on a content change** (`c791418524`)

- The document version sent to the indexer for each SCA state is the `sca_check.version` column (`state.document_version`, and the `version_type=external_gte` version). DBSync auto-increments a `version` column on a modified row when the caller omits the field (`sqlite_dbengine.cpp`: `sql += "version=version+1,"`, gated on the field being absent and actual data having changed).
- `SCAEventHandler::ReportCheckResult` (`sca_event_handler.cpp`) loaded the full existing row via `GetPolicyCheckById` — whose `SELECT` includes `version` — set the new `result`/`checksum`, and wrote it back, so the row it handed to `syncRow` still carried the old `version`. That suppressed the auto-increment: a check flipping Pass↔Fail was re-indexed at the same `document_version`.
- Fix: `checkData.erase("version")` before building the `syncRow` query, so DBSync assigns the version (schema default `1` on a fresh insert, `version+1` on a real modification). One line; the checksum still fingerprints only the check definition, so the change detection is unaffected.

### Results and Evidence

**1 — Graceful shutdown DB close.** Baseline (stock 5.0.0 beta3 nightly, graceful `systemctl stop wazuh-agent`) — leftover files on every stop:

```
32768   /var/ossec/queue/fim/db/fim_sync.db-shm
4132392 /var/ossec/queue/fim/db/fim_sync.db-wal     <- 4.1 MB un-checkpointed WAL
32768   /var/ossec/queue/sca/db/sca_sync.db-shm
0       /var/ossec/queue/sca/db/sca_sync.db-wal
0       /var/ossec/queue/sca/db/sca.db-journal
total leftovers: 5
```

Syscollector's databases had live `-wal`/`-shm` while running and **zero** leftovers after stop — the reference behavior this PR extends to SCA and FIM. With this PR (agent built from this branch, 6 consecutive graceful stop/start cycles):

```
### STOP-LOOP x6 — graceful shutdown DB-close verification
--- cycle 1 ---  wal-files-while-running=4  stop=0procs in 3s  leftovers=0
--- cycle 2 ---  wal-files-while-running=4  stop=0procs in 3s  leftovers=0
--- cycle 3 ---  wal-files-while-running=4  stop=0procs in 3s  leftovers=0
--- cycle 4 ---  wal-files-while-running=4  stop=0procs in 3s  leftovers=0
--- cycle 5 ---  wal-files-while-running=4  stop=0procs in 3s  leftovers=0
--- cycle 6 ---  wal-files-while-running=4  stop=0procs in 2s  leftovers=0
=== RESULT: 6/6 cycles clean, 0 with leftovers ===
```

4 WAL files active while running → 0 leftovers after every graceful stop; stop latency stays at 2–3 s (the join adds nothing measurable); healthy after every restart.

**2 — Coordination guard.** When the guard fires, agent-info logs `Deferring coordination until sca first sync completes, will retry next cycle` (throttled to one INFO per deferral episode, DEBUG afterwards) and retries next cycle instead of coordinating mid-first-sync. Covered by the unit tests below.

**3 — Version increments on a content change (A/B on a from-scratch beta3 env).** Same all-in-one beta3 server (manager `005803d`), Ubuntu 22.04 agent, policy `cis_ubuntu22-04`. The agent was built twice — once at stock `origin/5.0.0`, once at this branch — and the same check `28541` (`stat` perms on `/etc/issue`, expected mode `644|640|600|400`) was flipped Pass↔Fail three times with `chmod`, reading `sca_check.version` after each scan:

```
                          STOCK 5.0.0            THIS PR (#37353)
  build has erase("version"):  0                      1
  baseline  (Passed)     result=Passed version=1   result=Passed version=1
  flip1 -> Failed        result=Failed version=1   result=Failed version=2
  flip2 -> Passed        result=Passed version=1   result=Passed version=3
  flip3 -> Failed        result=Failed version=1   result=Failed version=4
```

Stock keeps `version=1` through every result change; with this PR the version advances `1 -> 2 -> 3 -> 4`, one per change. End to end, the incremented version reaches the indexer:

```
# THIS PR, after flip3 (agent local, then indexer):
agent   sca.db : 28541 | Failed | 4
indexer states-sca: check 28541  result=Failed  document_version=4  _version=4
```

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux (agent built from this branch inside the test container for the A/B above; module UT jobs also compile it)
  - [x] Windows (`Agent-Info-Unit-Tests (wazuh_modules/agent_info, winagent)` and the Windows agent build pass on this branch)
  - [x] MAC OS X (`build-sonoma` compiles and runs the agent_info unit tests on this branch)
- [x] Log syntax and correct language review (new messages: the deferral INFO/DEBUG lines quoted above)

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_ — N/A
- Engine _(Wazuh v5.x and above)_ — N/A
- Wazuh server API/Framework — N/A

### Artifacts Affected

- `wazuh-modulesd` (agent): `libagent_info.so`, `libsca.so`, `wm_sca`/`wm_syscollector` handlers
- `wazuh-syscheckd` (agent, Unix): shutdown path and synchronization thread lifecycle
- Agent packages for Linux/macOS; the Windows agent only picks up the `wm_sca.c`/`wm_syscollector.c` query-handler change and the (inert there) `fim_sync_handle_rwlock` read guards — the shutdown teardown itself is `#ifndef WIN32`

### Configuration Changes

N/A — no new configuration parameters and no default-value changes.

### Tests Introduced

- `agent_info_coordination_test.cpp`:
  - `DeferCoordinationWhenScaFirstSyncNotCompleted` — FIM first sync done, SCA reports `first_sync_completed=0` → coordination defers on SCA.
  - `DeferCoordinationWhenSyscollectorFirstSyncNotCompleted` — FIM and SCA done, syscollector reports `0` → coordination defers on syscollector.
  - Both modeled on `DeferCoordinationWhenFimFirstSyncNotCompleted` from #36762; the pre-existing coordination tests (which do not mock `get_first_sync_completed`) still pass, covering the proceed-when-absent behavior.
- `sca_event_handler_test.cpp`:
  - `ReportCheckResult_DoesNotSendVersionInSyncPayload` — asserts the row handed to `syncRow` on a result change omits `version`, so DBSync performs the increment.
- `test_run_check.c`:
  - `test_persist_syscheck_msg_destroyed_sync_handle` — with synchronization enabled and the handle already destroyed (`NULL`), the event is dropped without calling `asp_persist_diff`.
- `test_syscom.c`:
  - `test_syscom_dispatch_sync_destroyed_handle` — a `fim_sync` response arriving after the handle was destroyed answers `err Error syncing module` without calling `asp_parse_response_buffer`.
- The shutdown fix is verified by the stop-loop above; syscheckd unit tests wrap `start_daemon`, so the joinable-thread launch and the shutdown waiter are not exercised by them.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented (N/A)
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues (independent of #37352; `main` needs a forward-port of all three changes)



## Follow-up: second review round

Eight additional commits address the findings of an adversarial review of the three fixes above, plus a second adversarial pass run over the result.

**Fixed**

- `fix(fim): publish the sync thread to the shutdown waiter under the handle lock` — closed the startup window where a termination signal between `CreateThreadJoinable()` and the `fim_sync_thread_initialized` store made the waiter skip the join and destroy the handle under the live synchronization thread. Creation and flag are now published under the `fim_sync_handle_rwlock` write lock with a shutdown gate; the waiter reads the flag under the same lock, and (second pass finding) re-clears `fim_sync_module_running` there so a creation that raced the handler still observes the stop and joins.
- `fix(fim): bound the shutdown waiter join so a stop cannot hang` — the queue write goes `SendBinaryMSG → os_wait()`, which sleeps in 5-second intervals until the manager-disconnected mark clears and ignores `asp_stop()`; with the manager unreachable the join hung until reconnection and the service manager's SIGKILL left the very `-wal`/`-shm` files this PR removes. Added `SendBinaryMSGPredicated()` (Unix + Windows twins) wired through `fim_send_binary_msg` with `fim_shutdown_process_on`, skip the post-sync recovery pass once shutdown starts (it takes `fim_scan_mutex`, which an in-flight scan can hold for minutes), and as a backstop the waiter polls an exit self-pipe for 20 s — under `wazuh-control`'s ~30 s SIGKILL escalation — and on timeout skips the join *and* the teardown rather than destroying the handle under a live thread.
- `fix(sca): break the manager-disconnected wait on shutdown in the binary send` (second pass finding) — same `os_wait()` park for SCA's sends: it stalled the sync worker join in `wm_sca_start()` and could hold `m_resourcesMutex` shared from a wcom query, blocking `releaseResources()` and leaking `sca_sync.db` in exactly the disconnected-stop case. Now predicated with `wm_sca_is_shutting_down`, matching the existing `StartMQPredicated` wiring.
- `fix(fim): serialize the shutdown database teardown against the scan transaction` — `fim.db` runs `journal_mode=truncate` (the teardown is about releasing the DBSync context in order before `exit()`, not WAL cleanup), and FIMDB's internal guards cover every path except the raw scan transaction. The transaction lifecycle now lives entirely inside `fim_scan_mutex`, the waiter tears down only under a trylock of that mutex (kept held so no new transaction can start), and `fim_db_transaction_start()` got the `try/catch` every other extern "C" wrapper in `db.cpp` already had (a post-teardown `DBSyncHandle()` throw previously escaped into C → `std::terminate`).
- `fix(sca): exclude live query paths from the module teardown` — `releaseResources()` reset `m_dBSync`/`m_asyncFlushController`/`m_spSyncProtocol` with no synchronization while the detached wcom dispatcher (and agent-info's in-process coordination queries, added by this very PR) could be inside `query()`/`parseResponseBuffer()`. Added `m_resourcesMutex` (`shared_mutex`): externally driven entry points take it shared, `initSyncProtocol()` publishes under the exclusive lock, and the teardown resets under it, moving the flush controller out first and joining its worker outside the lock. Syscollector shares the unlocked pattern upstream (its guarded `destroy()` is test-only) and is left for a follow-up, as is the unpredicated send in syscollector/agent-info.
- `fix(agent-info): keep the deferral log throttle per module` — the single `m_deferralLogged` flag was cleared by FIM's probe every cycle, so the SCA/syscollector deferral re-emitted its INFO every cycle and the DEBUG "Still deferring" branch was dead. Now a per-module set, with a two-cycle regression test.

**Reviewed but argued, no change**

- SCA's check checksum excluding `result` predates this PR (upstream design: the checksum fingerprints the check definition; `sca_checksum.cpp` is untouched here). Consequence worth recording on #37402: a *lost* result delta will not self-heal via the periodic integrity check, since both sides keep the same definition-only checksum — the version increment in this PR fixes the delivered-delta path (re-index outranks its own tombstone), not lost-delta recovery. Changing checksum semantics is a protocol-level decision with fleet-wide re-sync implications and belongs to its own issue.
- The `get_first_sync_completed` sync-disabled short-circuit exists in two near-identical copies (`wm_sca.c`, `wm_syscollector.c`); FIM's equivalent has a different shape (embedded in the `is_pause_completed` response, from #36762). Two five-line, module-named blocks did not justify a cross-module helper.

**Verification**

- Unit tests (agent target, container): `test_run_check` 32/32, `test_syscom` 18/18, `test_fim_scan` 3/3, `test_mq_op` 27/27, `agent_info_coordination_test` 38/38, `agent_info_successful_coordination_test` 5/5, `sca_unit_test` 21/21, `sca_event_handler_unit_test` 61/61, `sca_checksum_unit_test` 17/17.
- Live, source-built agent: connected graceful stop 2.0 s with zero `-wal`/`-shm` left for FIM and SCA; early stop while gate-blocked (unenrolled, manager down) 1.0 s, clean.
- The disconnected case this round is about: manager stopped mid-first-sync until syscheckd logged `Process locked due to agent is offline` (the exact state that previously hung the join forever), then `wazuh-control stop` — syscheckd exited in **4 s** (parked send broke at the next 5-second check) with `fim_sync.db`'s `-wal`/`-shm` removed, and after the SCA send fix `sca_sync.db` closes cleanly in the same scenario. Total stop stays bounded (~29 s) by modulesd's join budget, dominated by syscollector's still-unpredicated send (pre-existing, follow-up).


