### PR TITLE
fix: persist engine startup state for CMSync route logging

### DIFF
--- a/src/engine/source/main.cpp
+++ b/src/engine/source/main.cpp
@@ -49,6 +49,7 @@
 #include <schemf/schema.hpp>
 #include <store/drivers/fileDriver.hpp>
 #include <store/store.hpp>
+#include <store/utils.hpp>
 #include <streamlog/logger.hpp>
 #include <wiconnector/windexerconnector.hpp>
 
@@ -256,6 +257,7 @@ int main(int argc, char* argv[])
     std::shared_ptr<cm::crud::ICrudService> cmCrudService;
     std::shared_ptr<cm::sync::CMSync> cmSyncService;
     std::shared_ptr<ioc::sync::IocSync> iocSyncService;
+    bool firstStart {false};
 
     try
     {
@@ -305,6 +307,7 @@ int main(int argc, char* argv[])
             auto fileDriver = std::make_shared<store::drivers::FileDriver>(fileStorage);
             store = std::make_shared<store::Store>(fileDriver);
             LOG_INFO("Store initialized");
+            firstStart = store::utils::updateStartStatus(store, engineUptimeISO);
         }
 
         // Content Manager
@@ -880,7 +883,7 @@ int main(int argc, char* argv[])
             auto lastWarned = std::make_shared<std::optional<bool>>();
 
             // Logs only on state transitions (no routes <-> at least one enabled route).
-            const auto reportRouteStatus = [hasEnabledRoutes, lastWarned]()
+            const auto reportRouteStatus = [hasEnabledRoutes, lastWarned, firstStart]()
             {
                 const bool shouldWarn = !hasEnabledRoutes();
                 if (*lastWarned == shouldWarn)
@@ -890,8 +893,16 @@ int main(int argc, char* argv[])
                 *lastWarned = shouldWarn;
                 if (shouldWarn)
                 {
-                    LOG_WARNING("[CMSync] No active routes available. Incoming events will be discarded "
-                                "until content synchronization completes");
+                    if (firstStart)
+                    {
+                        LOG_INFO("[CMSync] No active routes available. Incoming events will be discarded "
+                                 "until content synchronization completes");
+                    }
+                    else
+                    {
+                        LOG_WARNING("[CMSync] No active routes available. Incoming events will be discarded "
+                                    "until content synchronization completes");
+                    }
                 }
                 else
                 {

--- a/src/engine/source/store/CMakeLists.txt
+++ b/src/engine/source/store/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(store::fileDriver ALIAS store_fileDriver)
 ## Store
 add_library(store STATIC
     ${SRC_DIR}/store.cpp
+    ${SRC_DIR}/utils.cpp
 )
 target_include_directories(store
     PUBLIC

--- a/src/engine/source/store/interface/store/utils.hpp
+++ b/src/engine/source/store/interface/store/utils.hpp
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <optional>
+#include <string_view>
 #include <variant>
 
 #include <base/error.hpp>
@@ -43,6 +44,15 @@ jsonGenerator(const json::Json& contentJson, const std::string& original, const 
 
     return wrappedContent;
 }
+
+/**
+ * @brief Creates or updates a component start status document.
+ *
+ * @param store Store used to persist the status.
+ * @param timestamp Current start timestamp.
+ * @return true when the document is created for the first time, false otherwise or on persistence failure.
+ */
+bool updateStartStatus(const std::shared_ptr<IStore>& store, std::string_view timestamp);
 
 } // namespace utils
 } // namespace store

--- a/src/engine/source/store/src/utils.cpp
+++ b/src/engine/source/store/src/utils.cpp
@@ -1,0 +1,67 @@
+#include <store/utils.hpp>
+
+#include <base/logging.hpp>
+
+namespace
+{
+const base::Name ENGINE_STATUS_DOC {"engine/status/0"};
+} // namespace
+
+namespace store::utils
+{
+
+bool updateStartStatus(const std::shared_ptr<IStore>& store, std::string_view timestamp)
+{
+    const auto& document = ENGINE_STATUS_DOC;
+    if (!store)
+    {
+        LOG_WARNING("[Store] Cannot update start status document '{}': Store is unavailable", document.fullName());
+        return false;
+    }
+
+    const bool firstStart = !store->existsDoc(document);
+    bool initializeStatus = firstStart;
+    json::Json status;
+
+    if (!firstStart)
+    {
+        auto response = store->readDoc(document);
+        if (base::isError(response))
+        {
+            LOG_WARNING("[Store] Failed to read start status document '{}': {}. Recreating it",
+                        document.fullName(),
+                        base::getError(response).message);
+            initializeStatus = true;
+        }
+        else
+        {
+            status = std::move(base::getResponse(response));
+            std::string firstStartTimestamp;
+            initializeStatus = !status.isObject()
+                               || status.getString(firstStartTimestamp, "/first_start") != json::RetGet::Success
+                               || firstStartTimestamp.empty();
+
+            if (initializeStatus)
+            {
+                LOG_WARNING("[Store] Invalid start status document '{}'. Recreating it", document.fullName());
+            }
+        }
+    }
+
+    if (initializeStatus)
+    {
+        status.setObject();
+        status.setString(timestamp, "/first_start");
+    }
+
+    status.setString(timestamp, "/last_start");
+    if (const auto error = store->upsertDoc(document, status); base::isError(error))
+    {
+        LOG_WARNING("[Store] Failed to persist start status document '{}': {}", document.fullName(), error->message);
+        return false;
+    }
+
+    return firstStart;
+}
+
+} // namespace store::utils

--- a/src/engine/source/store/test/src/unit/store_test.cpp
+++ b/src/engine/source/store/test/src/unit/store_test.cpp
@@ -2,7 +2,9 @@
 
 #include <base/logging.hpp>
 #include <store/mockDriver.hpp>
+#include <store/mockStore.hpp>
 #include <store/store.hpp>
+#include <store/utils.hpp>
 
 using namespace store;
 using namespace store::mocks;
@@ -161,4 +163,122 @@ TEST_F(StoreTest, existsDoc_true)
 {
     EXPECT_CALL(*driver, existsDoc(base::Name("x"))).WillOnce(testing::Return(true));
     ASSERT_TRUE(store->existsDoc("x"));
+}
+
+class StoreUtilsTest : public ::testing::Test
+{
+protected:
+    const base::Name statusDoc {"engine/status/0"};
+    std::shared_ptr<MockStore> mockStore;
+
+    void SetUp() override
+    {
+        logging::testInit();
+        mockStore = std::make_shared<MockStore>();
+    }
+};
+
+TEST_F(StoreUtilsTest, updateStartStatusCreatesDocumentOnFirstStart)
+{
+    const std::string timestamp {"2026-07-02T05:24:45.886Z"};
+
+    EXPECT_CALL(*mockStore, existsDoc(statusDoc)).WillOnce(testing::Return(false));
+    EXPECT_CALL(*mockStore, upsertDoc(statusDoc, testing::_))
+        .WillOnce(testing::Invoke(
+            [&timestamp](const base::Name&, const store::Doc& status)
+            {
+                std::string firstStart;
+                std::string lastStart;
+                EXPECT_EQ(status.getString(firstStart, "/first_start"), json::RetGet::Success);
+                EXPECT_EQ(status.getString(lastStart, "/last_start"), json::RetGet::Success);
+                EXPECT_EQ(firstStart, timestamp);
+                EXPECT_EQ(lastStart, timestamp);
+                return storeOk();
+            }));
+
+    EXPECT_TRUE(store::utils::updateStartStatus(mockStore, timestamp));
+}
+
+TEST_F(StoreUtilsTest, updateStartStatusPreservesFirstStart)
+{
+    const std::string firstTimestamp {"2026-07-02T05:24:45.886Z"};
+    const std::string currentTimestamp {"2026-07-02T05:36:17.128Z"};
+    const store::Doc persisted {
+        R"({"first_start":"2026-07-02T05:24:45.886Z","last_start":"2026-07-02T05:24:45.886Z"})"};
+
+    EXPECT_CALL(*mockStore, existsDoc(statusDoc)).WillOnce(testing::Return(true));
+    EXPECT_CALL(*mockStore, readDoc(statusDoc)).WillOnce(testing::Return(storeReadDocResp(persisted)));
+    EXPECT_CALL(*mockStore, upsertDoc(statusDoc, testing::_))
+        .WillOnce(testing::Invoke(
+            [&firstTimestamp, &currentTimestamp](const base::Name&, const store::Doc& status)
+            {
+                std::string firstStart;
+                std::string lastStart;
+                EXPECT_EQ(status.getString(firstStart, "/first_start"), json::RetGet::Success);
+                EXPECT_EQ(status.getString(lastStart, "/last_start"), json::RetGet::Success);
+                EXPECT_EQ(firstStart, firstTimestamp);
+                EXPECT_EQ(lastStart, currentTimestamp);
+                return storeOk();
+            }));
+
+    EXPECT_FALSE(store::utils::updateStartStatus(mockStore, currentTimestamp));
+}
+
+TEST_F(StoreUtilsTest, updateStartStatusRecreatesUnreadableDocumentResetsTimestamps)
+{
+    const std::string timestamp {"2026-07-02T05:36:17.128Z"};
+
+    EXPECT_CALL(*mockStore, existsDoc(statusDoc)).WillOnce(testing::Return(true));
+    EXPECT_CALL(*mockStore, readDoc(statusDoc)).WillOnce(testing::Return(storeReadError<store::Doc>()));
+    EXPECT_CALL(*mockStore, upsertDoc(statusDoc, testing::_))
+        .WillOnce(testing::Invoke(
+            [&timestamp](const base::Name&, const store::Doc& status)
+            {
+                std::string firstStart;
+                std::string lastStart;
+                EXPECT_EQ(status.getString(firstStart, "/first_start"), json::RetGet::Success);
+                EXPECT_EQ(status.getString(lastStart, "/last_start"), json::RetGet::Success);
+                EXPECT_EQ(firstStart, timestamp);
+                EXPECT_EQ(lastStart, timestamp);
+                return storeOk();
+            }));
+
+    EXPECT_FALSE(store::utils::updateStartStatus(mockStore, timestamp));
+}
+
+TEST_F(StoreUtilsTest, updateStartStatusRecreatesInvalidDocument)
+{
+    const std::string timestamp {"2026-07-02T05:36:17.128Z"};
+    const store::Doc persisted {R"([])"};
+
+    EXPECT_CALL(*mockStore, existsDoc(statusDoc)).WillOnce(testing::Return(true));
+    EXPECT_CALL(*mockStore, readDoc(statusDoc)).WillOnce(testing::Return(storeReadDocResp(persisted)));
+    EXPECT_CALL(*mockStore, upsertDoc(statusDoc, testing::_))
+        .WillOnce(testing::Invoke(
+            [&timestamp](const base::Name&, const store::Doc& status)
+            {
+                std::string firstStart;
+                EXPECT_EQ(status.getString(firstStart, "/first_start"), json::RetGet::Success);
+                EXPECT_EQ(firstStart, timestamp);
+                return storeOk();
+            }));
+
+    EXPECT_FALSE(store::utils::updateStartStatus(mockStore, timestamp));
+}
+
+TEST_F(StoreUtilsTest, updateStartStatusReturnsFalseOnPersistenceFailure)
+{
+    const std::string timestamp {"2026-07-02T05:24:45.886Z"};
+
+    EXPECT_CALL(*mockStore, existsDoc(statusDoc)).WillOnce(testing::Return(false));
+    EXPECT_CALL(*mockStore, upsertDoc(statusDoc, testing::_)).WillOnce(testing::Return(storeError()));
+
+    EXPECT_FALSE(store::utils::updateStartStatus(mockStore, timestamp));
+}
+
+TEST_F(StoreUtilsTest, updateStartStatusReturnsFalseOnNullStore)
+{
+    const std::string timestamp {"2026-07-02T05:24:45.886Z"};
+
+    EXPECT_FALSE(store::utils::updateStartStatus(nullptr, timestamp));
 }


### PR DESCRIPTION
## Description

This PR distinguishes the expected absence of active routes during the first Engine startup from the same condition on subsequent startups:

```text
[CMSync] No active routes available. Incoming events will be discarded until content synchronization completes
```

The route status is checked before CMSync runs. On a clean first startup, no routes are available yet because the initial content synchronization has not completed. This is an expected transient state and is now logged as `INFO`.

On subsequent startups, the same condition remains a `WARNING` because the Engine has already been initialized and incoming events are being discarded without an active route.

To identify each case across restarts, the Engine persists its first and latest startup timestamps in the internal Store.

Closes #37275  

## Proposed Changes

- Add a Store utility that creates or updates `engine/status/0` and reports whether the persisted state corresponds to the first startup.
- Set `first_start` and `last_start` when the document is created.
- Preserve `first_start` and update `last_start` on subsequent startups.
- Recreate the document with the current startup timestamp when it cannot be read or has an invalid structure.
- Log the absence of active routes as `INFO` only when the first-start state is persisted successfully; otherwise, log it as `WARNING`.
- Add unit tests for document creation, update, recovery from unreadable or invalid content, and persistence failure.

The persisted document has the following structure:

```json
{
  "first_start": "2026-07-02T05:24:45.886Z",
  "last_start": "2026-07-02T05:36:17.128Z"
}
```

## Evidence

### Build and installation

```console
General settings:
    TARGET:             manager
    V:                  
    DEBUG:              yes
    INSTALLDIR:         
    RESOURCES_URL:      https://packages.wazuh.com/deps/99-29734
    EXTERNAL_SRC_ONLY:  
    HTTP_REQUEST_BRANCH:ebf9d2f82533ff2f84c3304ab29db01fcfb6735e
User settings:
    WAZUH_GROUP:        wazuh-manager
    WAZUH_USER:         wazuh-manager
USE settings:
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          no
    IMAGE_TRUST_CHECKS: 1
    CA_NAME:            DigiCert Assured ID Root CA
Compiler:
    CC                cc
    MAKE              /usr/bin/make
make[1]: Leaving directory '/workspaces/Wazuh_5x/wazuh/src'

Done building manager

╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/37275-persist-engine-startup-state●› 
╰─# ctest --test-dir src/build --output-on-failure

100% tests passed, 0 tests failed out of 9784

Total Test time (real) = 615.30 sec

╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/37275-persist-engine-startup-state●› 
╰─# service wazuh-manager start
Starting Wazuh v5.0.0...
Started wazuh-manager-apid...
Started wazuh-manager-authd...
Started wazuh-manager-db...
Started wazuh-manager-analysisd...
Started wazuh-manager-remoted...
Started wazuh-manager-monitord...
Started wazuh-manager-modulesd...
Started wazuh-manager-clusterd...
Completed.
```

### Scenario 1: clean first startup without active routes

```console
╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/37275-persist-engine-startup-state●› 
╰─# ls -la /var/wazuh-manager/data/store/engine/status/0 
-rw-r----- 1 root wazuh-manager 95 Jul  2 05:24 /var/wazuh-manager/data/store/engine/status/0

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/37275-persist-engine-startup-state●› 
╰─# engine-private ns list                                                                                                                      1 ↵
engine-router list

- cmsync_standard_81b8

- entry_status: ENABLED
  name: cmsync_standard
  namespaceId: cmsync_standard_81b8
  priority: 1
  uptime: 95


026/07/02 05:24:57 wazuh-manager-analysisd: INFO: IOC Sync Service initialized
2026/07/02 05:24:57 wazuh-manager-analysisd: INFO: Dumper Events initialized
2026/07/02 05:24:57 wazuh-manager-analysisd: INFO: Remote engine's server initialized and started
2026/07/02 05:24:57 wazuh-manager-analysisd: INFO: Engine started
2026/07/02 05:24:57 wazuh-manager-analysisd: INFO: Scheduler started
2026/07/02 05:24:57 wazuh-manager-analysisd: INFO: [CMSync] No active routes available. Incoming events will be discarded until content synchronization completes

2026/07/02 05:25:08 wazuh-manager-monitord: INFO: wazuh: Manager started.

{
    "first_start": "2026-07-02T05:24:45.886Z",
    "last_start": "2026-07-02T05:24:45.886Z"
}
```

### Scenario 2: subsequent startup without persisted routes

```console
(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/37275-persist-engine-startup-state●› 
╰─# service wazuh-manager stop

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/37275-persist-engine-startup-state●› 
╰─# cp /var/wazuh-manager/data/store/router/router/0 /tmp/router-router-0.backup                                                              127 ↵
(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/37275-persist-engine-startup-state●› 
╰─# rm /var/wazuh-manager/data/store/router/router/0  


2026/07/02 05:36:21 wazuh-manager-analysisd: INFO: Dumper Events initialized
2026/07/02 05:36:21 wazuh-manager-analysisd: INFO: Remote engine's server initialized and started
2026/07/02 05:36:21 wazuh-manager-analysisd: INFO: Engine started
2026/07/02 05:36:21 wazuh-manager-analysisd: INFO: Scheduler started
2026/07/02 05:36:21 wazuh-manager-analysisd: WARNING: [CMSync] No active routes available. Incoming events will be discarded until content synchronization completes
2026/07/02 05:36:32 wazuh-manager-monitord: INFO: wazuh: Manager started.

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/37275-persist-engine-startup-state●› 
╰─# cat /var/wazuh-manager/data/store/engine/status/0
{
    "first_start": "2026-07-02T05:24:45.886Z",
    "last_start": "2026-07-02T05:36:17.128Z"
}#    


(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/37275-persist-engine-startup-state●› 
╰─# rg "Successfully synchronized space|Event processing is now active" \
  /var/wazuh-manager/logs/wazuh-manager.log | tail
2026/07/02 05:27:09 wazuh-manager-analysisd: INFO: [CM::Sync] Successfully synchronized space 'standard'
2026/07/02 05:27:10 wazuh-manager-analysisd: INFO: [CMSync] Event processing is now active
2026/07/02 05:38:20 wazuh-manager-analysisd: INFO: [CM::Sync] Successfully synchronized space 'standard'
2026/07/02 05:38:20 wazuh-manager-analysisd: INFO: [CMSync] Event processing is now active
```

### Scenario 3:broken file

```bash

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/37275-persist-engine-startup-state●› 
╰─# service wazuh-manager stop
Killing wazuh-manager-clusterd...
Killing wazuh-manager-modulesd...
Killing wazuh-manager-monitord...
Killing wazuh-manager-remoted...
Killing wazuh-manager-analysisd...
Killing wazuh-manager-db...
Killing wazuh-manager-authd...
Killing wazuh-manager-apid...
Wazuh v5.0.0 Stopped

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/37275-persist-engine-startup-state●› 
╰─# cp /var/wazuh-manager/data/store/engine/status/0 /tmp/engine-status-0.backup

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/37275-persist-engine-startup-state●› 
╰─# printf '{broken-json\n' > /var/wazuh-manager/data/store/engine/status/0

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/37275-persist-engine-startup-state●› 
╰─# cat /var/wazuh-manager/data/store/engine/status/0
{broken-json

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/37275-persist-engine-startup-state●› 
╰─# service wazuh-manager start
Starting Wazuh v5.0.0...
Started wazuh-manager-apid...
Started wazuh-manager-authd...
Started wazuh-manager-db...
Started wazuh-manager-analysisd...
Started wazuh-manager-remoted...
Started wazuh-manager-monitord...
Started wazuh-manager-modulesd...
Started wazuh-manager-clusterd...
Completed.

(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/37275-persist-engine-startup-state●› 
╰─# cat /var/wazuh-manager/data/store/engine/status/0
{
    "first_start": "2026-07-03T00:35:56.935Z",
    "last_start": "2026-07-03T00:35:56.935Z"
}#    


```

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
