### PR TITLE
Report unavailable CPU speed as null instead of 0 in hardware inventory

### DIFF
--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -866,7 +866,7 @@ nlohmann::json Syscollector::ecsHardwareData(const nlohmann::json& originalData,
         {
             const auto& value = originalData["cpu_speed"];
 
-            if (value.is_number())
+            if (value.is_number() && value.get<double>() != 0.0)
             {
                 ret[pointer] = value.get<int64_t>();
             }

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -4859,6 +4859,100 @@ TEST_F(SyscollectorImpTest, schemaValidationWithCorrectedDataTypes)
     SchemaValidator::SchemaValidatorFactory::getInstance().reset();
 }
 
+TEST_F(SyscollectorImpTest, hardwareCpuSpeedZeroIsReportedAsNull)
+{
+    const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
+
+    // cpu_speed as 0.0 represents an unavailable value (e.g. macOS ARM) and must be
+    // reported as null instead of a misleading 0.
+    const std::string hardwareJson = R"({"serial_number":"Apple Inc.", "cpu_speed":0.0,"cpu_cores":8,"cpu_name":"Apple M1","memory_free":1000000,"memory_total":2000000,"memory_used":1000000})";
+
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json::parse(hardwareJson)));
+    EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, ports()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, packages(_)).Times(0);
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, processes(_)).Times(0);
+    EXPECT_CALL(*spInfoWrapper, groups()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, users()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, services()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, browserExtensions()).WillRepeatedly(Return(nlohmann::json{}));
+
+    CallbackMock wrapperDelta;
+    std::function<void(const std::string&)> callbackDataDelta
+    {
+        [&wrapperDelta](const std::string & data)
+        {
+            wrapperDelta.callbackMock(data);
+        }
+    };
+
+    CallbackMockPersist wrapperPersist;
+    std::function<void(const std::string&, Operation_t, const std::string&, const std::string&, uint64_t)> callbackDataPersist
+    {
+        [&wrapperPersist](const std::string & id, Operation_t operation, const std::string & index, const std::string & data, uint64_t version)
+        {
+            if (index == "wazuh-states-inventory-hardware")
+            {
+                auto jsonData = nlohmann::json::parse(data);
+
+                // cpu_speed 0.0 must be reported as null, not as a literal 0
+                EXPECT_TRUE(jsonData["host"]["cpu"]["speed"].is_null());
+            }
+
+            wrapperPersist.callbackMock(id, operation, index, data, version);
+        }
+    };
+
+    EXPECT_CALL(wrapperPersist, callbackMock(testing::_, testing::_, testing::Eq("wazuh-states-inventory-hardware"), testing::_, testing::_)).Times(1);
+
+    std::thread t
+    {
+        [&spInfoWrapper, &callbackDataDelta, &callbackDataPersist]()
+        {
+            Syscollector::instance().init(spInfoWrapper,
+                                          callbackDataDelta,
+                                          callbackDataPersist,
+                                          logFunction,
+                                          SYSCOLLECTOR_DB_PATH,
+                                          "",
+                                          "",
+                                          5, true, true, false, false, false, false, false, false, false, false, false, false, false, false);
+
+            // Initialize sync protocol to enable schema validation
+            MQ_Functions mqFuncs;
+            mqFuncs.start = [](const char*, short, short) -> int { return 0; };
+            mqFuncs.send_binary = [](int, const void*, size_t, const char*, char) -> int { return 0; };
+
+            Syscollector::instance().initSyncProtocol(
+                "syscollector",
+                ":memory:",
+                ":memory:",
+                mqFuncs,
+                std::chrono::seconds(10),
+                std::chrono::seconds(5),
+                3,
+                100,
+                86400
+            );
+
+            Syscollector::instance().start();
+        }
+    };
+
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+    Syscollector::instance().destroy();
+
+    if (t.joinable())
+    {
+        t.join();
+    }
+
+    // Reset factory after test
+    SchemaValidator::SchemaValidatorFactory::getInstance().reset();
+}
+
 // Schema validation test using mock to force rejection
 TEST_F(SyscollectorImpTest, schemaValidationRejectsInvalidDataWithMock)
 {


### PR DESCRIPTION
## Description

On macOS Apple Silicon (ARM) agents, the CPU frequency cannot be retrieved through user-space APIs in all cases. When this happens, the IT Hygiene System inventory displays a misleading `0 MHz` for the processor speed instead of indicating that the value is unavailable.

This change ensures that when the collected `cpu_speed` is `0`, the field is reported as `null` in the stateful data sent to the indexer, consistent with how other unavailable hardware fields are already handled.

## Proposed Changes

- Updated `Syscollector::ecsHardwareData` in `syscollectorImp.cpp` so that a numeric `cpu_speed` equal to `0` is mapped to `null` for `host.cpu.speed`, instead of being forwarded as a literal `0`.
- The transformation is applied at the syscollector layer, at the boundary where dbsync output is converted into the outgoing ECS document. This avoids storing `null` inside dbsync's internal SQLite table, since the library's row-comparison logic does not evaluate `NULL` equality correctly and could cause diffs to be missed.
- No changes were required in the indexer template (`inventory-hardware.json`): the `host.cpu.speed` field is already mapped as `long` without a not-null constraint, so it accepts `null` natively.

### Results and Evidence

- Before: `cpu_speed: 0` → `host.cpu.speed: 0` (displayed as `0 MHz` in the dashboard).
- After: `cpu_speed: 0` → `host.cpu.speed: null` (no misleading value shown).
- Non-zero and float `cpu_speed` values continue to be converted to integers as before.

**Dashboard screenshot — CPU speed available:**

<img width="1397" height="590" alt="Screenshot 2026-07-02 100550" src="https://github.com/user-attachments/assets/832aa145-cf06-43ce-b839-9cb73e5a13fc" />

**Dashboard screenshot — CPU speed unavailable:**

<img width="1395" height="629" alt="Screenshot 2026-07-02 095518" src="https://github.com/user-attachments/assets/b8c2c4cb-8033-4084-ab71-5f92d36e256a" />

<details><summary><b>Resulting state document (<code>wazuh-states-inventory-hardware</code>):</b></summary>

```json
{
  "_index": "wazuh-states-inventory-hardware",
  "_id": "wazuh_002_9a81b6222962556ab5efb3c0452c3337663c232e",
  "_score": 0,
  "_source": {
    "checksum": {
      "hash": {
        "sha1": "8c3b41f3755fa5391771d6619c8090bc72ac9dc1"
      }
    },
    "host": {
      "cpu": {
        "cores": 12,
        "name": "Apple M3 Pro",
        "speed": null
      },
      "memory": {
        "free": 197787648,
        "total": 19327352832,
        "used": 19129565184
      },
      "serial_number": "XWCNKGFX7M"
    },
    "state": {
      "document_version": 5,
      "modified_at": "2026-07-03T07:16:00.195Z"
    },
    "wazuh": {
      "agent": {
        "groups": [
          "default"
        ],
        "host": {
          "architecture": "arm64",
          "hostname": "Vikmans-MacBook-Pro.local",
          "os": {
            "name": "macOS",
            "platform": "darwin",
            "type": "macos",
            "version": "26.5.1"
          }
        },
        "id": "002",
        "name": "Vikmans-MacBook-Pro.local",
        "version": "v5.0.0"
      },
      "cluster": {
        "name": "wazuh"
      }
    }
  },
  "fields": {
    "state.modified_at": [
      "2026-07-03T07:16:00.195Z"
    ]
  }
}
```

</details>

### Artifacts Affected

- `wazuh-modulesd` (Syscollector module)

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

- Added `SyscollectorImpTest.hardwareCpuSpeedZeroIsReportedAsNull` in `syscollectorImp_test.cpp`, verifying that a hardware scan with `cpu_speed: 0.0` produces a persisted document where `host.cpu.speed` is `null`.
- Verified the existing `SyscollectorImpTest.schemaValidationWithCorrectedDataTypes` test still passes, confirming non-zero float `cpu_speed` values are still converted to integers correctly.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
