### PR TITLE
Add netifaces to remoted tier 2 IT setup

### DIFF
--- a/.github/workflows/4_testintegration_remoted-tier-2.yml
+++ b/.github/workflows/4_testintegration_remoted-tier-2.yml
@@ -77,7 +77,7 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/
+          sudo pip install --ignore-installed --break-system-packages qa-integration-framework/ netifaces
           sudo rm -rf qa-integration-framework/
       # Run remoted integration tests.
       - name: Run remoted integration tests


### PR DESCRIPTION
## Description

The manager `remoted` tier 2 integration test suite fails during pytest collection with `ModuleNotFoundError: No module named 'netifaces'`, before any test runs.

This PR adds `netifaces` to the pip install step of `.github/workflows/4_testintegration_remoted-tier-2.yml`, aligning the tier 2 setup with tier 0-1. 


No functional or product code changes , CI/test setup only.

## Testing evidence

CI: build https://github.com/wazuh/wazuh/actions/runs/28579227667

`remoted` tier 2 suite collects without errors and runs to completion after the change:

```
cd tests/integration
sudo python -m pytest --tier 2 test_remoted/
```
<img width="643" height="281" alt="image" src="https://github.com/user-attachments/assets/89011331-dc3e-4113-9369-00ffd331fda6" />

**Without netifaces**

<img width="643" height="412" alt="image" src="https://github.com/user-attachments/assets/a6c42bf5-ac0b-4c7e-b209-a9b0ce9209be" />


Closes #37293
