### PR TITLE
Ruleset: fix false positive in Vipre rule 90535

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ All notable changes to this project will be documented in this file.
 - Fixed TypeError when sorting agents by version with empty version strings. ([#37323](https://github.com/wazuh/wazuh/pull/37323))
 - Improved sensitive data masking in cluster configuration endpoint. ([#37039](https://github.com/wazuh/wazuh/pull/37039))
 
+### Ruleset
+
+#### Fixed
+
+- Fixed rule 90535 false positive by scoping it to the Vipre provider. ([#37363](https://github.com/wazuh/wazuh/pull/37363))
+
 ## [v4.14.6]
 
 ### Manager

--- a/ruleset/rules/0601-win-vipre_rules.xml
+++ b/ruleset/rules/0601-win-vipre_rules.xml
@@ -269,6 +269,7 @@
 
 <rule id="90535" level="4">
     <if_sid>60600</if_sid>
+    <field name="win.system.providerName">^SBAMSvc$</field>
     <field name="win.system.eventID">^4139$</field>
     <description>An item has been quarantined</description>
     <options>no_full_log</options>


### PR DESCRIPTION
## Description

Rule 90535 only matched `win.system.eventID` (`4139`) without checking the event provider. Windows/Microsoft reuses event IDs across unrelated products, so any provider emitting eventID 4139 (e.g. `MSExchangeRepl`) triggers this Vipre-specific "item has been quarantined" rule as a false positive.

## Fix

Add a `win.system.providerName` constraint (`^SBAMSvc$`, the actual Vipre/Sunbelt service name already used by rule 90499 in the same file) so rule 90535 only fires for genuine Vipre quarantine events.

```xml
<rule id="90535" level="4">
    <if_sid>60600</if_sid>
    <field name="win.system.providerName">^SBAMSvc$</field>
    <field name="win.system.eventID">^4139$</field>
    <description>An item has been quarantined</description>
    <options>no_full_log</options>
</rule>
```

## Reproduction (before fix)

Given this non-Vipre event:

```json
"win": {
  "system": {
    "eventID": "4139",
    "severityValue": "INFORMATION",
    "channel": "Application",
    "providerName": "MSExchangeRepl"
  }
}
```

Rule 90535 incorrectly fired with description "An item has been quarantined". After the fix, this event falls through to rule 60600 (generic informational event) as expected.

Fixes #17504