### PR TITLE
Suppress version-coordination WARNINGs on stop/unavailable module

### DIFF
--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -1578,9 +1578,13 @@ int AgentInfoImpl::calculateNewVersion(const std::set<std::string>& pausedModule
 
         if (!response.success)
         {
-            m_logFunction(LOG_WARNING,
-                          "Failed to get version from " + module + " (error " + std::to_string(response.errorCode) +
-                          "), aborting coordination");
+            if (!m_stopped && !response.isModuleUnavailable)
+            {
+                m_logFunction(LOG_WARNING,
+                              "Failed to get version from " + module + " (error " + std::to_string(response.errorCode) +
+                              "), aborting coordination");
+            }
+
             return -1;
         }
 
@@ -1639,9 +1643,13 @@ int AgentInfoImpl::calculateNewVersion(const std::set<std::string>& pausedModule
 
         if (!response.success)
         {
-            m_logFunction(LOG_WARNING,
-                          "Failed to set version on " + module + " (error " + std::to_string(response.errorCode) +
-                          "), aborting coordination");
+            if (!m_stopped && !response.isModuleUnavailable)
+            {
+                m_logFunction(LOG_WARNING,
+                              "Failed to set version on " + module + " (error " + std::to_string(response.errorCode) +
+                              "), aborting coordination");
+            }
+
             return -1;
         }
 

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -1178,7 +1178,10 @@ void AgentInfoImpl::resumePausedModules(const std::set<std::string>& pausedModul
 
         if (!response.success)
         {
-            m_logFunction(LOG_WARNING, "Failed to resume module " + module + ": " + response.response);
+            if (!m_stopped && !response.isModuleUnavailable)
+            {
+                m_logFunction(LOG_WARNING, "Failed to resume module " + module + ": " + response.response);
+            }
         }
     }
 }


### PR DESCRIPTION
# Description

`AgentInfoImpl::calculateNewVersion()` logs a `WARNING: Failed to set/get version on <module> (error 52), aborting coordination` whenever a paused module's socket disappears mid-coordination — most commonly because the agent is stopping or the module is intentionally disabled, both transient/expected conditions rather than real problems. Resolves #37312.

## Proposed Changes

- `src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp`, `resumePausedModules()`: the `Failed to resume module <module>: <response>` WARNING is now only logged when `!m_stopped && !response.isModuleUnavailable`.
- Same file, `calculateNewVersion()` (`get_version` path): the `Failed to get version from <module> (error N), aborting coordination` WARNING is now guarded by the same `!m_stopped && !response.isModuleUnavailable` condition; coordination still aborts (`return -1`) in every case — only the log line is conditional.
- Same file, `calculateNewVersion()` (`set_version` path): the `Failed to set version on <module> (error N), aborting coordination` WARNING gets the identical guard.
- `response.isModuleUnavailable` is set via `MQ_IS_MODULE_UNAVAILABLE(errorCode)`, which covers error codes 50-53 — including error 52 (`MQ_ERR_MODULE_NOT_RUNNING`), the exact error reported in #37312. So the WARNING is now suppressed whenever the target module reports itself unavailable (e.g. disabled, or its socket is gone) or the agent is already shutting down, while still firing for genuine unexpected failures outside those two cases.
- The second commit (`fix: suppress resume-failure warning during shutdown or when module is unavailable`) was added after reproduction work surfaced a previously-undocumented secondary WARNING — `Failed to resume module fim: {"error":52,...}` — that fires immediately after the target `set_version` WARNING from the same root cause; it was folded into this PR's guard rather than left as a separate follow-up.

### Results and Evidence

Reproduction setup: two agent containers enrolled against the same manager — one running the latest nightly (pre-fix baseline, "stable-agent"), one running this PR's build (post-fix, "pr-agent")
. A background watcher tails each agent's log for `Response from fim get_version` and immediately kills only the `wazuh-syscheckd` process (not the whole agent), landing the race precisely betwe
en the coordinator's `get_version` and `set_version` calls while `wazuh-modulesd` (the process that logs the WARNING) keeps running. This reproduces both WARNINGs this PR targets, one per commit
, on both builds for a direct before/after comparison.

**Commit 1 — `fix: lower log level of transient version coordination failures in agent-info`** (targets `WARNING: Failed to set version on fim (error 52), aborting coordination`):

<details><summary>Before fix — stable-agent-37312 (pre-fix baseline), ossec.log excerpt, coordination cycle where set_version fails with error 52</summary>

```bash
2026/07/02 02:08:19 wazuh-modulesd:agent-info[36943] wm_agent_info.c:190 at agent_info_log_callback(): DEBUG: Synchronization needed for agent_groups
2026/07/02 02:08:19 wazuh-modulesd:agent-info[36943] wm_agent_info.c:192 at agent_info_log_callback(): INFO: Starting module coordination process
2026/07/02 02:08:19 wazuh-modulesd:agent-info[36943] wm_agent_info.c:192 at agent_info_log_callback(): INFO: Pausing fim module for synchronization coordination
2026/07/02 02:08:23 wazuh-modulesd:agent-info[36943] wm_agent_info.c:192 at agent_info_log_callback(): INFO: Pausing sca module for synchronization coordination
2026/07/02 02:08:23 wazuh-modulesd:agent-info[36943] wm_agent_info.c:192 at agent_info_log_callback(): INFO: Pausing syscollector module for synchronization coordination
2026/07/02 02:08:23 wazuh-modulesd:agent-info[36943] wm_agent_info.c:190 at agent_info_log_callback(): DEBUG: Sending JSON command to fim: {"command":"get_version","parameters":{}}
2026/07/02 02:08:23 wazuh-modulesd:agent-info[36943] wm_agent_info.c:228 at wm_agent_info_query_module_wrapper(): DEBUG: Received JSON for fim: {"command":"get_version","parameters":{}}
2026/07/02 02:08:23 wazuh-modulesd:agent-info[36943] wm_agent_info.c:190 at agent_info_log_callback(): DEBUG: Response from fim get_version: {"error":0,"message":"FIM version retrieved","data":{"version":1}}
2026/07/02 02:08:23 wazuh-modulesd:agent-info[36943] wm_agent_info.c:190 at agent_info_log_callback(): DEBUG: Sending JSON command to fim: {"command":"set_version","parameters":{"version":1}}
2026/07/02 02:08:23 wazuh-modulesd:agent-info[36943] wm_agent_info.c:228 at wm_agent_info_query_module_wrapper(): DEBUG: Received JSON for fim: {"command":"set_version","parameters":{"version":1}}
2026/07/02 02:08:24 wazuh-modulesd:agent-info[36943] wm_agent_info.c:228 at wm_agent_info_query_module_wrapper(): DEBUG: Received JSON for fim: {"command":"set_version","parameters":{"version":1}}
2026/07/02 02:08:27 wazuh-modulesd:agent-info[36943] wm_agent_info.c:190 at agent_info_log_callback(): DEBUG: Response from fim set_version: {"error":52,"message":"Syscheck module refused connection. The component might be disabled"}
2026/07/02 02:08:27 wazuh-modulesd:agent-info[36943] wm_agent_info.c:193 at agent_info_log_callback(): WARNING: Failed to set version on fim (error 52), aborting coordination
```

</details>

Re-ran the same reproduction against **pr-agent-37312** (`wazuh-agent_5.0.0-0_amd64_7501d78.deb`, this PR's HEAD — both commits). The same error-52 condition lands, but the WARNING is gone, replaced by a new DEBUG line that makes the suppression explicit:

<details><summary>After fix — pr-agent-37312 (this PR, commit 7501d78), same error-52 condition, WARNING suppressed</summary>

```bash
2026/07/02 14:47:24 wazuh-modulesd:agent-info[12345] wm_agent_info.c:192 at agent_info_log_callback(): INFO: Starting module coordination process
2026/07/02 14:47:24 wazuh-modulesd:agent-info[12345] wm_agent_info.c:192 at agent_info_log_callback(): INFO: Pausing fim module for synchronization coordination
2026/07/02 14:47:24 wazuh-modulesd:agent-info[12345] wm_agent_info.c:190 at agent_info_log_callback(): DEBUG: Sending JSON command to fim: {"command":"get_version","parameters":{}}
2026/07/02 14:47:24 wazuh-modulesd:agent-info[12345] wm_agent_info.c:228 at wm_agent_info_query_module_wrapper(): DEBUG: Received JSON for fim: {"command":"get_version","parameters":{}}
2026/07/02 14:47:24 wazuh-modulesd:agent-info[12345] wm_agent_info.c:190 at agent_info_log_callback(): DEBUG: Response from fim get_version: {"error":0,"message":"FIM version retrieved","data":{"version":6}}
2026/07/02 14:47:24 wazuh-modulesd:agent-info[12345] wm_agent_info.c:190 at agent_info_log_callback(): DEBUG: Sending JSON command to fim: {"command":"set_version","parameters":{"version":6}}
2026/07/02 14:47:24 wazuh-modulesd:agent-info[12345] wm_agent_info.c:228 at wm_agent_info_query_module_wrapper(): DEBUG: Received JSON for fim: {"command":"set_version","parameters":{"version":6}}
2026/07/02 14:47:25 wazuh-modulesd:agent-info[12345] wm_agent_info.c:228 at wm_agent_info_query_module_wrapper(): DEBUG: Received JSON for fim: {"command":"set_version","parameters":{"version":6}}
2026/07/02 14:47:25 wazuh-modulesd:agent-info[12345] wm_agent_info.c:190 at agent_info_log_callback(): DEBUG: fim module is unavailable (error 52): {"error":52,"message":"Syscheck module refused connection. The component might be disabled"}
2026/07/02 14:47:25 wazuh-modulesd:agent-info[12345] wm_agent_info.c:190 at agent_info_log_callback(): DEBUG: Response from fim set_version: {"error":52,"message":"Syscheck module refused connection. The component might be disabled"}
```

</details>

No `WARNING: Failed to set version on fim` line anywhere in the agent's `ossec.log` for this run (confirmed via `docker exec pr-agent-37312 grep "Failed to set version on fim" /var/ossec/logs/ossec.log` — zero matches), versus exactly 1 match on stable-agent-37312 for the same reproduction. The new `fim module is unavailable (error 52)` DEBUG line is the `isModuleUnavailable` branch from this commit firing in place of the WARNING.

**Commit 2 — `fix: suppress resume-failure warning during shutdown or when module is unavailable`** (targets `WARNING: Failed to resume module fim: ...`, the secondary WARNING discovered immediately after the one above, from the same root cause):

<details><summary>Before fix — stable-agent-37312 (pre-fix baseline), ossec.log excerpt, secondary resume-failure WARNING</summary>

```bash
2026/07/02 02:08:27 wazuh-modulesd:agent-info[36943] wm_agent_info.c:193 at agent_info_log_callback(): WARNING: Failed to set version on fim (error 52), aborting coordination
2026/07/02 02:08:27 wazuh-modulesd:agent-info[36943] wm_agent_info.c:193 at agent_info_log_callback(): WARNING: Failed to resume module fim: {"error":52,"message":"Syscheck module refused connection. The component might be disabled"}
```

</details>

Same pr-agent-37312 run (commit 7501d78): the coordinator still attempts to resume `fim` after the failed `set_version` — logged at INFO, not WARNING — and even though the underlying resume call fails at the socket level (a separate `wm_fim_query_json` ERROR, not this module's own warning path), no `Failed to resume module fim` WARNING is ever logged:

<details><summary>After fix — pr-agent-37312, resume attempt after the error-52 set_version, no WARNING</summary>

```bash
2026/07/02 14:47:25 wazuh-modulesd:agent-info[12345] wm_agent_info.c:190 at agent_info_log_callback(): DEBUG: Response from fim set_version: {"error":52,"message":"Syscheck module refused connection. The component might be disabled"}
2026/07/02 14:47:25 wazuh-modulesd:agent-info[12345] wm_agent_info.c:192 at agent_info_log_callback(): INFO: Resuming paused module: fim
2026/07/02 14:47:25 wazuh-modulesd:agent-info[12345] wm_agent_info.c:190 at agent_info_log_callback(): DEBUG: Sending JSON command to fim: {"command":"resume","parameters":{}}
2026/07/02 14:47:25 wazuh-modulesd:agent-info[12345] wm_agent_info.c:228 at wm_agent_info_query_module_wrapper(): DEBUG: Received JSON for fim: {"command":"resume","parameters":{}}
2026/07/02 14:47:25 wazuh-modulesd[12345] wmodules.c:500 at wm_fim_query_json(): DEBUG: WM_FIM_QUERY_JSON: Attempting to connect to socket: queue/sockets/syscheck
2026/07/02 14:47:25 wazuh-modulesd[12345] wmodules.c:502 at wm_fim_query_json(): ERROR: WM_FIM_QUERY_JSON: Failed to connect to socket, errno=111
```

</details>

Confirmed via `docker exec pr-agent-37312 grep "Failed to resume module" /var/ossec/logs/ossec.log` — zero matches, versus exactly 1 match on stable-agent-37312 for the same reproduction. The agent later self-heals: the next coordination cycle at `14:52:10` reaches `Response from fim set_version: {"error":0,...}` and completes normally.

### Artifacts Affected

- `wazuh-modulesd` (agent-info module) via `src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp`
- `wazuh-agent` package (Linux/Windows/macOS — the affected module is platform-agnostic)

### Configuration Changes

_No configuration changes._

### Documentation Updates

_No documentation changes required._

### Tests Introduced

_No new tests introduced._

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
