### PR TITLE
Reduce memory usage when downloading VDP feed

### DIFF
--- a/docs/guide/migration/vulnerability-detection-cti-feeds.md
+++ b/docs/guide/migration/vulnerability-detection-cti-feeds.md
@@ -61,7 +61,7 @@ The 5.x module reads only these options under `<vulnerability-detection>`; any o
 |---|---|
 | `enabled` | `yes` / `no`. |
 | `feed-update-interval` | How often Vulnerability Detection refreshes the feed from the Indexer. Default and minimum: `60m`. |
-| `pageSize` | Optional. CVE documents fetched per page during feed download. Default: `250`. |
+| `pageSize` | Optional. CVE documents fetched per page during feed download. Default: `100`. |
 | `numSlices` | Optional. Parallel slices used for the initial feed load. Default: `2`. |
 
 ## Verify the feed loaded (optional)

--- a/docs/ref/modules/content_manager/README.md
+++ b/docs/ref/modules/content_manager/README.md
@@ -48,7 +48,7 @@ The module is configured programmatically by its caller (the Vulnerability Scann
 | `configData.databasePath` | Path to the RocksDB cursor database |
 | `configData.indexer.hosts` | Indexer endpoint URLs |
 | `configData.indexer.index` | Index to read from |
-| `configData.indexer.pageSize` | Documents per PIT page (default 250) |
+| `configData.indexer.pageSize` | Documents per PIT page (default 100) |
 | `configData.indexer.numSlices` | Parallel PIT slices for initial load (default 2) |
 
 The Indexer connection parameters come from the manager's `<indexer>` XML block (see [Indexer Configuration](configuration.md)).

--- a/docs/ref/modules/vulnerability-scanner/configuration.md
+++ b/docs/ref/modules/vulnerability-scanner/configuration.md
@@ -40,8 +40,8 @@ Time interval for downloading updated CVE feeds from the CTI service.
 
 Number of CVE documents fetched per PIT (Point In Time) page during feed download.
 
-- **Default value:** `250`
-- **Allowed values:** Positive integer
+- **Default value:** `100`
+- **Allowed values:** Integer between `1` and `10000` (the Indexer rejects sizes above `index.max_result_window`)
 - **Note:** Larger page sizes reduce HTTP overhead but increase memory usage per request
 
 ### numSlices
@@ -49,7 +49,7 @@ Number of CVE documents fetched per PIT (Point In Time) page during feed downloa
 Number of parallel PIT slices used during the initial feed load.
 
 - **Default value:** `2`
-- **Allowed values:** Positive integer
+- **Allowed values:** Integer between `1` and `32`
 - **Note:** Set to `1` to force sequential mode. Increasing this value can raise memory usage without delivering meaningful time savings. Benchmark before increasing
 
 ---
@@ -149,7 +149,7 @@ Standard vulnerability detection settings:
 <vulnerability-detection>
   <enabled>yes</enabled>
   <feed-update-interval>60m</feed-update-interval>
-  <pageSize>250</pageSize>
+  <pageSize>100</pageSize>
   <numSlices>2</numSlices>
 </vulnerability-detection>
 ```
@@ -162,7 +162,7 @@ For environments requiring more current vulnerability data:
 <vulnerability-detection>
   <enabled>yes</enabled>
   <feed-update-interval>30m</feed-update-interval>
-  <pageSize>250</pageSize>
+  <pageSize>100</pageSize>
   <numSlices>2</numSlices>
 </vulnerability-detection>
 ```
@@ -220,14 +220,14 @@ Prevent all vulnerability detection:
 **For small deployments (<100 agents):**
 ```xml
 <feed-update-interval>2h</feed-update-interval>
-<pageSize>250</pageSize>
+<pageSize>100</pageSize>
 <numSlices>1</numSlices>
 ```
 
 **For medium deployments (100-1000 agents):**
 ```xml
 <feed-update-interval>1h</feed-update-interval>
-<pageSize>250</pageSize>
+<pageSize>100</pageSize>
 <numSlices>2</numSlices>
 ```
 

--- a/src/shared_modules/content_manager/README.md
+++ b/src/shared_modules/content_manager/README.md
@@ -63,7 +63,7 @@ After all pages are processed, the downloader signals completion via `indexer_co
             "index": ".wazuh-threatintel-vulnerabilities",
             "consumerStatusIndex": ".wazuh-cti-consumers",
             "consumerStatusId": "cti:catalog:consumer:vulnerabilities",
-            "pageSize": 250,
+            "pageSize": 100,
             "numSlices": 2
         }
     }

--- a/src/shared_modules/content_manager/doc/components/INDEXER_DOWNLOADER.md
+++ b/src/shared_modules/content_manager/doc/components/INDEXER_DOWNLOADER.md
@@ -106,7 +106,7 @@ The `indexer` sub-object must be present under `configData` when `contentSource`
 | `index` | string | Target index name (e.g. `.wazuh-threatintel-vulnerabilities`) |
 | `consumerStatusIndex` | string | Index containing the consumer status document to poll before downloading (optional) |
 | `consumerStatusId` | string | Consumer status document id to poll before downloading (optional) |
-| `pageSize` | integer | Documents per page. Default: `250` |
+| `pageSize` | integer | Documents per page. Default: `100`. Must be between 1 and 10000 (the Indexer rejects sizes above `index.max_result_window`) |
 | `numSlices` | integer | Number of parallel PIT slices for initial load. Default: `2`. Set to `1` for sequential mode. Higher values can increase memory usage with limited time savings |
 | `hosts` | array | Indexer host URLs (e.g. `["https://localhost:9200"]`) |
 | `username` | string | Indexer username |
@@ -139,7 +139,7 @@ Example:
             "index": ".wazuh-threatintel-vulnerabilities",
             "consumerStatusIndex": ".wazuh-cti-consumers",
             "consumerStatusId": "cti:catalog:consumer:vulnerabilities",
-            "pageSize": 250,
+            "pageSize": 100,
             "numSlices": 2
         }
     }

--- a/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
@@ -58,12 +58,6 @@
  *   <standard IndexerConnector SSL/auth config>
  * }
  *
- * pageSize / numSlices trade-off: larger pageSize (and more slices) means fewer HTTP
- * round-trips and a faster full download, but each in-flight page is a fully materialized
- * nlohmann::json (page hits x copies of the payload, x numSlices concurrent pages) held in
- * memory until its callback returns — so it also raises peak RSS during the load. Lower
- * pageSize trades some download latency for a smaller memory footprint. Tune per deployment
- * constraints (e.g. lower it on memory-constrained managers/agents).
  */
 class IndexerDownloader final : public AbstractHandler<std::shared_ptr<UpdaterContext>>
 {
@@ -582,20 +576,6 @@ private:
         }
     }
 
-    /**
-     * @brief Blocks until the three global-map documents required by the local feed
-     *        database (vendor map, OS CPE rules, CNA mapping — see
-     *        DatabaseFeedManager::reloadGlobalMaps) are present in the Indexer.
-     *
-     * The consumer-status document going "ready" (see waitUntilConsumerReady) only means
-     * the CTI consumer applied *some* documents — it is not a guarantee that these three
-     * singletons landed yet. Without this check, initialLoad can run to completion (the
-     * full multi-minute download) only to have reloadGlobalMaps() reject the result
-     * afterwards and force a wasted re-download on the next cycle.
-     *
-     * IDs must stay in sync with the ones DatabaseFeedManager::reloadGlobalMaps looks up
-     * locally after the download completes.
-     */
     bool waitUntilGlobalMapsIndexed(UpdaterContext& context) const
     {
         static constexpr auto POLL_INTERVAL {std::chrono::seconds {30}};
@@ -624,9 +604,8 @@ private:
                     nlohmann::json {{"size", GLOBAL_MAP_IDS.size()}, {"query", query}, {"_source", false}};
 
                 const auto searchResult = syncConnector.executeSearchQuery(indexName, searchQuery);
-                const auto hitCount = searchResult.value("hits", nlohmann::json::object())
-                                          .value("hits", nlohmann::json::array())
-                                          .size();
+                const auto hitCount =
+                    searchResult.value("hits", nlohmann::json::object()).value("hits", nlohmann::json::array()).size();
                 queryFailures = 0;
 
                 if (hitCount >= GLOBAL_MAP_IDS.size())
@@ -720,6 +699,29 @@ private:
     }
 
     /**
+     * @brief Reads the configured page size, falling back to the default when missing or zero.
+     *
+     * A page size of 0 would make every search return an empty page: the load would see
+     * "0 documents" and retry on the not-ready loop forever. Guarded here because this is a
+     * shared component — not every caller sanitizes its config the way the VD facade does.
+     */
+    size_t getConfiguredPageSize() const
+    {
+        constexpr size_t DEFAULT_PAGE_SIZE {100};
+        const size_t pageSize = m_config.at("indexer").value("pageSize", 0u);
+        if (pageSize == 0)
+        {
+            if (m_config.at("indexer").contains("pageSize"))
+            {
+                logWarn(
+                    WM_CONTENTUPDATER, "IndexerDownloader: invalid pageSize 0 — using default %zu.", DEFAULT_PAGE_SIZE);
+            }
+            return DEFAULT_PAGE_SIZE;
+        }
+        return pageSize;
+    }
+
+    /**
      * @brief Returns the last cursor persisted in RocksDB, or empty string on first run.
      */
     std::string getStoredCursor(const UpdaterContext& context) const
@@ -754,8 +756,10 @@ private:
      * @param context  Updater context (contains the callback).
      * @param hits     Array of Indexer hit objects from a search response.
      * @param cursor   String representation of the highest offset seen in this page.
+     * @return true if this call caused (or coincided with) a durable flush of the feed
+     *         database, i.e. it is now safe to persist a cursor up to and including this page.
      */
-    void processPage(UpdaterContext& context, const nlohmann::json& hits, const std::string& cursor) const
+    bool processPage(UpdaterContext& context, const nlohmann::json& hits, const std::string& cursor) const
     {
         nlohmann::json message;
         message["type"] = "indexer";
@@ -764,7 +768,7 @@ private:
 
         for (const auto& hit : hits)
         {
-            const auto& source = hit.value("_source", hit);
+            const auto& source = hit.contains("_source") ? hit.at("_source") : hit;
             const auto docType = source.value("type", std::string {});
 
             // TCPE and TVENDORS are Indexer-only types not consumed by VD scan — skip silently.
@@ -781,11 +785,6 @@ private:
             // by key prefix (startsWith "CVE-", "TID-", "FEED-GLOBAL", etc.).
             resource["resource"] = hit.value("_id", std::string {});
 
-            // Dump directly from a reference into `source` instead of
-            // source.value("document", ...): .value() with an nlohmann::json ValueType
-            // deep-copies the whole "document" subtree (several KB for a CVE5 payload)
-            // just to immediately serialize and discard that copy — doubling the
-            // per-document transient memory for no benefit.
             static const nlohmann::json EMPTY_DOCUMENT = nlohmann::json::object();
             const auto& document = source.contains("document") ? source.at("document") : EMPTY_DOCUMENT;
             resource["payload"] = document.dump();
@@ -814,6 +813,8 @@ private:
         {
             throw std::runtime_error("IndexerDownloader: fileProcessingCallback returned failure");
         }
+
+        return std::get<1>(result) == "flushed";
     }
 
     /**
@@ -836,7 +837,7 @@ private:
         static constexpr std::string_view PIT_KEEP_ALIVE {"5m"};
 
         const auto& indexName = m_config.at("indexer").at("index").get_ref<const std::string&>();
-        const size_t pageSize = m_config.at("indexer").value("pageSize", 100u);
+        const size_t pageSize = getConfiguredPageSize();
 
         const nlohmann::json sort =
             nlohmann::json::array({nlohmann::json {{"offset", "asc"}}, nlohmann::json {{"_id", "asc"}}});
@@ -868,14 +869,17 @@ private:
             });
 
         std::string currentCursor = startCursor;
+        std::string lastFlushedCursor = startCursor;
         std::optional<nlohmann::json> searchAfter = std::nullopt;
         size_t totalProcessed = 0;
+        bool stopRequested = false;
 
         while (true)
         {
             if (context.spUpdaterBaseContext->spStopCondition->check())
             {
                 logInfo(WM_CONTENTUPDATER, "IndexerDownloader: Stop requested during PIT fetch — aborting.");
+                stopRequested = true;
                 break;
             }
 
@@ -893,9 +897,14 @@ private:
                 currentCursor = std::to_string(lastHit.at("_source").at("offset").get<uint64_t>());
             }
 
-            processPage(context, hitArray, currentCursor);
+            const bool flushed = processPage(context, hitArray, currentCursor);
             totalProcessed += hitArray.size();
-            persistCursor(context, currentCursor);
+
+            if (flushed)
+            {
+                lastFlushedCursor = currentCursor;
+                persistCursor(context, lastFlushedCursor);
+            }
 
             if (hitArray.size() < pageSize)
             {
@@ -905,7 +914,7 @@ private:
             searchAfter = lastHit.at("sort");
         }
 
-        context.data["cursor"] = currentCursor;
+        context.data["cursor"] = stopRequested ? lastFlushedCursor : currentCursor;
         return totalProcessed;
     }
 
@@ -916,7 +925,9 @@ private:
      * (hash-modulo on _id). Each slice paginates independently with search_after.
      * The callback is serialized via m_callbackMutex.
      *
-     * Cursor is only persisted after all slices complete (crash = full restart).
+     * Cursor is only persisted after all slices complete naturally (crash or graceful stop
+     * mid-download = full restart on the next cycle, since a partial per-slice offset is
+     * not a safe resume point — see the `interrupted` handling below).
      *
      * @param context    Updater context.
      * @param query      Elasticsearch query object.
@@ -934,7 +945,7 @@ private:
         static constexpr std::string_view PIT_KEEP_ALIVE {"5m"};
 
         const auto& indexName = m_config.at("indexer").at("index").get_ref<const std::string&>();
-        const size_t pageSize = m_config.at("indexer").value("pageSize", 100u);
+        const size_t pageSize = getConfiguredPageSize();
 
         const nlohmann::json sort =
             nlohmann::json::array({nlohmann::json {{"offset", "asc"}}, nlohmann::json {{"_id", "asc"}}});
@@ -971,6 +982,7 @@ private:
         std::vector<std::thread> threads;
         std::vector<std::string> errors;
         std::mutex errorsMutex;
+        std::atomic<bool> interrupted {false};
 
         logInfo(WM_CONTENTUPDATER,
                 "IndexerDownloader: Starting sliced PIT download with %zu slices, pageSize=%zu",
@@ -995,6 +1007,7 @@ private:
                     if (context.spUpdaterBaseContext->spStopCondition->check())
                     {
                         logInfo(WM_CONTENTUPDATER, "IndexerDownloader: Stop requested — slice %zu aborting.", sliceId);
+                        interrupted.store(true);
                         break;
                     }
 
@@ -1093,6 +1106,15 @@ private:
         {
             throw std::runtime_error("IndexerDownloader: " + std::to_string(errors.size()) +
                                      " slice(s) failed: " + errors.front());
+        }
+
+        if (interrupted.load())
+        {
+            logInfo(WM_CONTENTUPDATER,
+                    "IndexerDownloader: Initial load interrupted by stop request — cursor not persisted, %zu "
+                    "documents processed this cycle will be re-fetched on the next initial load.",
+                    totalProcessed.load());
+            return totalProcessed.load();
         }
 
         // Persist cursor only after all slices complete

--- a/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
@@ -53,10 +53,17 @@
  *   "index":               ".wazuh-threatintel-vulnerabilities", // Indexer CVE index name
  *   "consumerStatusIndex": ".wazuh-cti-consumers",    // Consumer status index (optional)
  *   "consumerStatusId":    "cti:catalog:consumer:vulnerabilities", // Consumer status document id (optional)
- *   "pageSize":            250,                       // Documents per page (optional, default 250)
+ *   "pageSize":            100,                       // Documents per page (optional, default 100)
  *   "numSlices":           2,                         // Parallel PIT slices (optional, default 2)
  *   <standard IndexerConnector SSL/auth config>
  * }
+ *
+ * pageSize / numSlices trade-off: larger pageSize (and more slices) means fewer HTTP
+ * round-trips and a faster full download, but each in-flight page is a fully materialized
+ * nlohmann::json (page hits x copies of the payload, x numSlices concurrent pages) held in
+ * memory until its callback returns — so it also raises peak RSS during the load. Lower
+ * pageSize trades some download latency for a smaller memory footprint. Tune per deployment
+ * constraints (e.g. lower it on memory-constrained managers/agents).
  */
 class IndexerDownloader final : public AbstractHandler<std::shared_ptr<UpdaterContext>>
 {
@@ -124,6 +131,7 @@ private:
                                     "document.containers.cna.replacedBy",
                                     // document.containers.cna.providerMetadata — only shortName used
                                     "document.containers.cna.providerMetadata.orgId",
+                                    "document.containers.cna.providerMetadata.datePublished",
                                     "document.containers.cna.providerMetadata.dateUpdated",
                                     // document.containers.cna.affected — unused sub-fields
                                     "document.containers.cna.affected.collectionURL",
@@ -244,6 +252,7 @@ private:
                                     "document.containers.adp.title",
                                     // document.containers.adp.providerMetadata — only x_subShortName used
                                     "document.containers.adp.providerMetadata.orgId",
+                                    "document.containers.adp.providerMetadata.datePublished",
                                     "document.containers.adp.providerMetadata.dateUpdated",
                                     // document.containers.adp.affected — unused sub-fields
                                     "document.containers.adp.affected.collectionURL",
@@ -574,6 +583,90 @@ private:
     }
 
     /**
+     * @brief Blocks until the three global-map documents required by the local feed
+     *        database (vendor map, OS CPE rules, CNA mapping — see
+     *        DatabaseFeedManager::reloadGlobalMaps) are present in the Indexer.
+     *
+     * The consumer-status document going "ready" (see waitUntilConsumerReady) only means
+     * the CTI consumer applied *some* documents — it is not a guarantee that these three
+     * singletons landed yet. Without this check, initialLoad can run to completion (the
+     * full multi-minute download) only to have reloadGlobalMaps() reject the result
+     * afterwards and force a wasted re-download on the next cycle.
+     *
+     * IDs must stay in sync with the ones DatabaseFeedManager::reloadGlobalMaps looks up
+     * locally after the download completes.
+     */
+    bool waitUntilGlobalMapsIndexed(UpdaterContext& context) const
+    {
+        static constexpr auto POLL_INTERVAL {std::chrono::seconds {30}};
+        static const nlohmann::json GLOBAL_MAP_IDS =
+            nlohmann::json::array({"FEED-GLOBAL", "OSCPE-GLOBAL", "CNA-MAPPING-GLOBAL"});
+
+        const auto& indexName = m_config.at("indexer").at("index").get_ref<const std::string&>();
+        IndexerConnectorSync syncConnector(m_config.at("indexer"), LoggingContext {WM_CONTENTUPDATER, {}});
+
+        const auto pollSeconds =
+            static_cast<size_t>(std::chrono::duration_cast<std::chrono::seconds>(POLL_INTERVAL).count());
+        size_t queryFailures = 0;
+
+        while (true)
+        {
+            if (context.spUpdaterBaseContext->spStopCondition->check())
+            {
+                logInfo(WM_CONTENTUPDATER, "IndexerDownloader: Stop requested while waiting for global-map documents.");
+                return false;
+            }
+
+            try
+            {
+                const auto query = nlohmann::json {{"ids", {{"values", GLOBAL_MAP_IDS}}}};
+                const auto searchQuery =
+                    nlohmann::json {{"size", GLOBAL_MAP_IDS.size()}, {"query", query}, {"_source", false}};
+
+                const auto searchResult = syncConnector.executeSearchQuery(indexName, searchQuery);
+                const auto hitCount = searchResult.value("hits", nlohmann::json::object())
+                                          .value("hits", nlohmann::json::array())
+                                          .size();
+                queryFailures = 0;
+
+                if (hitCount >= GLOBAL_MAP_IDS.size())
+                {
+                    logInfo(WM_CONTENTUPDATER,
+                            "IndexerDownloader: Global-map documents present in '%s'. Starting initial load.",
+                            indexName.c_str());
+                    return true;
+                }
+
+                logInfo(WM_CONTENTUPDATER,
+                        "IndexerDownloader: Global-map documents not yet indexed in '%s' (%zu/%zu found). Waiting "
+                        "%zus before retrying.",
+                        indexName.c_str(),
+                        hitCount,
+                        GLOBAL_MAP_IDS.size(),
+                        pollSeconds);
+            }
+            catch (const std::exception& e)
+            {
+                ++queryFailures;
+                logDebug2(WM_CONTENTUPDATER,
+                          "IndexerDownloader: Failed to probe global-map documents in '%s' (%s). Waiting %zus "
+                          "before retrying (attempt %zu).",
+                          indexName.c_str(),
+                          e.what(),
+                          pollSeconds,
+                          queryFailures);
+            }
+
+            if (context.spUpdaterBaseContext->spStopCondition->waitFor(
+                    std::chrono::duration_cast<std::chrono::milliseconds>(POLL_INTERVAL)))
+            {
+                logInfo(WM_CONTENTUPDATER, "IndexerDownloader: Stop requested while waiting for global-map documents.");
+                return false;
+            }
+        }
+    }
+
+    /**
      * @brief Persists the cursor to RocksDB after each page so that a restart can resume
      *        from the last successfully processed page instead of from the beginning.
      *
@@ -687,7 +780,15 @@ private:
             // "FEED-GLOBAL", "TID-xxx"). EventDecoder identifies the resource type
             // by key prefix (startsWith "CVE-", "TID-", "FEED-GLOBAL", etc.).
             resource["resource"] = hit.value("_id", std::string {});
-            resource["payload"] = source.value("document", nlohmann::json::object());
+
+            // Dump directly from a reference into `source` instead of
+            // source.value("document", ...): .value() with an nlohmann::json ValueType
+            // deep-copies the whole "document" subtree (several KB for a CVE5 payload)
+            // just to immediately serialize and discard that copy — doubling the
+            // per-document transient memory for no benefit.
+            static const nlohmann::json EMPTY_DOCUMENT = nlohmann::json::object();
+            const auto& document = source.contains("document") ? source.at("document") : EMPTY_DOCUMENT;
+            resource["payload"] = document.dump();
 
             if (docType == "CVE")
             {
@@ -735,7 +836,7 @@ private:
         static constexpr std::string_view PIT_KEEP_ALIVE {"5m"};
 
         const auto& indexName = m_config.at("indexer").at("index").get_ref<const std::string&>();
-        const size_t pageSize = m_config.at("indexer").value("pageSize", 250u);
+        const size_t pageSize = m_config.at("indexer").value("pageSize", 100u);
 
         const nlohmann::json sort =
             nlohmann::json::array({nlohmann::json {{"offset", "asc"}}, nlohmann::json {{"_id", "asc"}}});
@@ -833,7 +934,7 @@ private:
         static constexpr std::string_view PIT_KEEP_ALIVE {"5m"};
 
         const auto& indexName = m_config.at("indexer").at("index").get_ref<const std::string&>();
-        const size_t pageSize = m_config.at("indexer").value("pageSize", 250u);
+        const size_t pageSize = m_config.at("indexer").value("pageSize", 100u);
 
         const nlohmann::json sort =
             nlohmann::json::array({nlohmann::json {{"offset", "asc"}}, nlohmann::json {{"_id", "asc"}}});
@@ -1187,6 +1288,11 @@ public:
 
             const bool forceInitialLoad = lastCursor.empty();
             if (!waitUntilConsumerReady(*context))
+            {
+                break;
+            }
+
+            if (forceInitialLoad && !waitUntilGlobalMapsIndexed(*context))
             {
                 break;
             }

--- a/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
@@ -125,7 +125,6 @@ private:
                                     "document.containers.cna.replacedBy",
                                     // document.containers.cna.providerMetadata — only shortName used
                                     "document.containers.cna.providerMetadata.orgId",
-                                    "document.containers.cna.providerMetadata.datePublished",
                                     "document.containers.cna.providerMetadata.dateUpdated",
                                     // document.containers.cna.affected — unused sub-fields
                                     "document.containers.cna.affected.collectionURL",
@@ -246,7 +245,6 @@ private:
                                     "document.containers.adp.title",
                                     // document.containers.adp.providerMetadata — only x_subShortName used
                                     "document.containers.adp.providerMetadata.orgId",
-                                    "document.containers.adp.providerMetadata.datePublished",
                                     "document.containers.adp.providerMetadata.dateUpdated",
                                     // document.containers.adp.affected — unused sub-fields
                                     "document.containers.adp.affected.collectionURL",

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -309,6 +309,8 @@ template<typename TSelector,
          size_t FlushInterval = 20>
 class IndexerConnectorSyncImpl final
 {
+    static constexpr size_t MAX_RETRY_BACKOFF_SECONDS {30};
+
     LogFn m_logFn;
     SecureCommunication m_secureCommunication;
     std::unique_ptr<TSelector> m_selector;
@@ -329,6 +331,7 @@ class IndexerConnectorSyncImpl final
     void processBulk()
     {
         bool needToRetry = false;
+        size_t retryDelaySeconds = RetryDelay;
         if (m_bulkData.empty() && m_deleteByQuery.empty())
         {
             throw IndexerConnectorException("No data to process");
@@ -406,9 +409,9 @@ class IndexerConnectorSyncImpl final
             needToRetry = false;
         };
 
-        const auto onError = [this, &needToRetry](const std::string& error,
-                                                  const long statusCode,
-                                                  const std::string& responseBody) -> void
+        const auto onError = [this, &needToRetry, &retryDelaySeconds](const std::string& error,
+                                                                      const long statusCode,
+                                                                      const std::string& responseBody) -> void
         {
             LOG_ERROR(m_logFn, "%s, status code: %ld.", error.c_str(), statusCode);
             if (statusCode == HTTP_CONTENT_LENGTH)
@@ -440,7 +443,7 @@ class IndexerConnectorSyncImpl final
             else if (statusCode == HTTP_TOO_MANY_REQUESTS)
             {
                 needToRetry = true;
-                LOG_DEBUG2(m_logFn, "Too many requests, retrying in 1 second.");
+                LOG_DEBUG2(m_logFn, "Too many requests, retrying in %zu second(s).", retryDelaySeconds);
             }
             else
             {
@@ -474,9 +477,10 @@ class IndexerConnectorSyncImpl final
                                                        .secureCommunication = m_secureCommunication},
                                     PostRequestParameters {.onSuccess = onSuccess, .onError = onError},
                                     {});
-                if (needToRetry && RetryDelay > 0)
+                if (needToRetry && retryDelaySeconds > 0)
                 {
-                    std::this_thread::sleep_for(std::chrono::seconds(RetryDelay));
+                    std::this_thread::sleep_for(std::chrono::seconds(retryDelaySeconds));
+                    retryDelaySeconds = std::min(retryDelaySeconds * 2, MAX_RETRY_BACKOFF_SECONDS);
                 }
             } while (needToRetry);
         }
@@ -553,6 +557,7 @@ class IndexerConnectorSyncImpl final
         url += m_selector->getNext();
         url += "/_bulk";
         bool needToRetry = false;
+        size_t retryDelaySeconds = RetryDelay;
 
         const auto onSuccess = [this](const std::string& response)
         {
@@ -565,7 +570,7 @@ class IndexerConnectorSyncImpl final
                 throw IndexerConnectorException("Bulk chunk operation had indexing failures");
             }
         };
-        const auto onError = [this, &needToRetry, boundaries](
+        const auto onError = [this, &needToRetry, &retryDelaySeconds, boundaries](
                                  const std::string& error, const long statusCode, const std::string& responseBody)
         {
             LOG_ERROR(m_logFn, "Chunk processing failed: %s, status code: %ld", error.c_str(), statusCode);
@@ -599,7 +604,7 @@ class IndexerConnectorSyncImpl final
             }
             else if (statusCode == HTTP_TOO_MANY_REQUESTS)
             {
-                LOG_DEBUG2(m_logFn, "Too many requests, retrying in 1 second.");
+                LOG_DEBUG2(m_logFn, "Too many requests, retrying in %zu second(s).", retryDelaySeconds);
                 needToRetry = true;
             }
             else
@@ -621,9 +626,10 @@ class IndexerConnectorSyncImpl final
                                                              .secureCommunication = m_secureCommunication},
                                 PostRequestParameters {.onSuccess = onSuccess, .onError = onError},
                                 {});
-            if (needToRetry && RetryDelay > 0)
+            if (needToRetry && retryDelaySeconds > 0)
             {
-                std::this_thread::sleep_for(std::chrono::seconds(RetryDelay));
+                std::this_thread::sleep_for(std::chrono::seconds(retryDelaySeconds));
+                retryDelaySeconds = std::min(retryDelaySeconds * 2, MAX_RETRY_BACKOFF_SECONDS);
             }
         } while (needToRetry);
     }
@@ -855,6 +861,7 @@ public:
         }
 
         bool needToRetry = false;
+        size_t retryDelaySeconds = RetryDelay;
 
         const auto onSuccess = [this](const std::string& response)
         {
@@ -914,8 +921,8 @@ public:
             m_shouldNotifyAfterBulk = true;
         };
 
-        const auto onError =
-            [this, &needToRetry](const std::string& url, const long statusCode, const std::string& error)
+        const auto onError = [this, &needToRetry, &retryDelaySeconds](
+                                 const std::string& url, const long statusCode, const std::string& error)
         {
             if (statusCode == HTTP_VERSION_CONFLICT)
             {
@@ -928,7 +935,7 @@ public:
             else if (statusCode == HTTP_TOO_MANY_REQUESTS)
             {
                 needToRetry = true;
-                LOG_DEBUG2(m_logFn, "Too many requests, retrying in 1 second.");
+                LOG_DEBUG2(m_logFn, "Too many requests, retrying in %zu second(s).", retryDelaySeconds);
             }
             else
             {
@@ -961,9 +968,10 @@ public:
                                 PostRequestParameters {.onSuccess = onSuccess, .onError = onError},
                                 {});
 
-            if (needToRetry && RetryDelay > 0)
+            if (needToRetry && retryDelaySeconds > 0)
             {
-                std::this_thread::sleep_for(std::chrono::seconds(RetryDelay));
+                std::this_thread::sleep_for(std::chrono::seconds(retryDelaySeconds));
+                retryDelaySeconds = std::min(retryDelaySeconds * 2, MAX_RETRY_BACKOFF_SECONDS);
             }
         } while (needToRetry);
     }
@@ -978,6 +986,7 @@ public:
 
         nlohmann::json resultJson;
         bool needToRetry = false;
+        size_t retryDelaySeconds = RetryDelay;
 
         const auto onSuccess = [this, &resultJson](const std::string& response)
         {
@@ -985,12 +994,13 @@ public:
             resultJson = nlohmann::json::parse(response);
         };
 
-        const auto onError = [this, &needToRetry](const std::string& error, const long statusCode, const std::string&)
+        const auto onError = [this, &needToRetry, &retryDelaySeconds](
+                                 const std::string& error, const long statusCode, const std::string&)
         {
             if (statusCode == HTTP_TOO_MANY_REQUESTS)
             {
                 needToRetry = true;
-                LOG_DEBUG2(m_logFn, "Too many requests, retrying in 1 second.");
+                LOG_DEBUG2(m_logFn, "Too many requests, retrying in %zu second(s).", retryDelaySeconds);
             }
             else
             {
@@ -1022,9 +1032,10 @@ public:
                                 PostRequestParameters {.onSuccess = onSuccess, .onError = onError},
                                 {});
 
-            if (needToRetry && RetryDelay > 0)
+            if (needToRetry && retryDelaySeconds > 0)
             {
-                std::this_thread::sleep_for(std::chrono::seconds(RetryDelay));
+                std::this_thread::sleep_for(std::chrono::seconds(retryDelaySeconds));
+                retryDelaySeconds = std::min(retryDelaySeconds * 2, MAX_RETRY_BACKOFF_SECONDS);
             }
         } while (needToRetry);
 
@@ -1262,6 +1273,7 @@ public:
         nlohmann::json hitsResult;
         bool success = false;
         bool needToRetry = false;
+        size_t retryDelaySeconds = RetryDelay;
         std::string errorMessage;
 
         const auto onSuccess = [&hitsResult, &success](const std::string& response)
@@ -1284,12 +1296,13 @@ public:
             }
         };
 
-        const auto onError = [this, &needToRetry](const std::string& error, const long statusCode, const std::string&)
+        const auto onError = [this, &needToRetry, &retryDelaySeconds](
+                                 const std::string& error, const long statusCode, const std::string&)
         {
             if (statusCode == HTTP_TOO_MANY_REQUESTS)
             {
                 needToRetry = true;
-                LOG_DEBUG2(m_logFn, "Too many requests, retrying in 1 second.");
+                LOG_DEBUG2(m_logFn, "Too many requests, retrying in %zu second(s).", retryDelaySeconds);
             }
             else
             {
@@ -1316,9 +1329,10 @@ public:
                                 PostRequestParameters {.onSuccess = onSuccess, .onError = onError},
                                 {});
 
-            if (needToRetry && RetryDelay > 0)
+            if (needToRetry && retryDelaySeconds > 0)
             {
-                std::this_thread::sleep_for(std::chrono::seconds(RetryDelay));
+                std::this_thread::sleep_for(std::chrono::seconds(retryDelaySeconds));
+                retryDelaySeconds = std::min(retryDelaySeconds * 2, MAX_RETRY_BACKOFF_SECONDS);
             }
         } while (needToRetry);
 

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -977,6 +977,7 @@ public:
         }
 
         nlohmann::json resultJson;
+        bool needToRetry = false;
 
         const auto onSuccess = [this, &resultJson](const std::string& response)
         {
@@ -984,26 +985,48 @@ public:
             resultJson = nlohmann::json::parse(response);
         };
 
-        const auto onError = [this](const std::string& error, const long statusCode, const std::string&)
+        const auto onError = [this, &needToRetry](const std::string& error, const long statusCode, const std::string&)
         {
-            LOG_ERROR(m_logFn, "Search query failed: %s, status code: %ld", error.c_str(), statusCode);
-            throw IndexerConnectorException("Search query failed: " + error);
+            if (statusCode == HTTP_TOO_MANY_REQUESTS)
+            {
+                needToRetry = true;
+                LOG_DEBUG2(m_logFn, "Too many requests, retrying in 1 second.");
+            }
+            else
+            {
+                LOG_ERROR(m_logFn, "Search query failed: %s, status code: %ld", error.c_str(), statusCode);
+                throw IndexerConnectorException("Search query failed: " + error);
+            }
         };
 
-        auto serverUrl = m_selector->getNext();
-        std::string url;
-        url += serverUrl;
-        url += "/";
-        url += index;
-        url += "/_search";
+        do
+        {
+            if (m_stopping.load())
+            {
+                throw IndexerConnectorException("Search query aborted: stopping requested");
+            }
 
-        LOG_DEBUG2(m_logFn, "Executing search query on: %s", url.c_str());
+            needToRetry = false;
+            auto serverUrl = m_selector->getNext();
+            std::string url;
+            url += serverUrl;
+            url += "/";
+            url += index;
+            url += "/_search";
 
-        m_httpRequest->post(RequestParameters {.url = HttpURL(url),
-                                               .data = searchQuery.dump(),
-                                               .secureCommunication = m_secureCommunication},
-                            PostRequestParameters {.onSuccess = onSuccess, .onError = onError},
-                            {});
+            LOG_DEBUG2(m_logFn, "Executing search query on: %s", url.c_str());
+
+            m_httpRequest->post(RequestParameters {.url = HttpURL(url),
+                                                   .data = searchQuery.dump(),
+                                                   .secureCommunication = m_secureCommunication},
+                                PostRequestParameters {.onSuccess = onSuccess, .onError = onError},
+                                {});
+
+            if (needToRetry && RetryDelay > 0)
+            {
+                std::this_thread::sleep_for(std::chrono::seconds(RetryDelay));
+            }
+        } while (needToRetry);
 
         return resultJson;
     }
@@ -1236,12 +1259,9 @@ public:
             requestBody["search_after"] = searchAfter.value();
         }
 
-        std::string url;
-        url += m_selector->getNext();
-        url += "/_search";
-
         nlohmann::json hitsResult;
         bool success = false;
+        bool needToRetry = false;
         std::string errorMessage;
 
         const auto onSuccess = [&hitsResult, &success](const std::string& response)
@@ -1264,17 +1284,43 @@ public:
             }
         };
 
-        const auto onError = [](const std::string& error, const long statusCode, const std::string&)
+        const auto onError = [this, &needToRetry](const std::string& error, const long statusCode, const std::string&)
         {
-            throw IndexerConnectorException("Search request failed with status " + std::to_string(statusCode) + ": " +
-                                            error);
+            if (statusCode == HTTP_TOO_MANY_REQUESTS)
+            {
+                needToRetry = true;
+                LOG_DEBUG2(m_logFn, "Too many requests, retrying in 1 second.");
+            }
+            else
+            {
+                throw IndexerConnectorException("Search request failed with status " + std::to_string(statusCode) +
+                                                ": " + error);
+            }
         };
 
-        m_httpRequest->post(RequestParameters {.url = HttpURL(url),
-                                               .data = requestBody.dump(),
-                                               .secureCommunication = m_secureCommunication},
-                            PostRequestParameters {.onSuccess = onSuccess, .onError = onError},
-                            {});
+        do
+        {
+            if (m_stopping.load())
+            {
+                throw IndexerConnectorException("Search request aborted: stopping requested");
+            }
+
+            needToRetry = false;
+            std::string url;
+            url += m_selector->getNext();
+            url += "/_search";
+
+            m_httpRequest->post(RequestParameters {.url = HttpURL(url),
+                                                   .data = requestBody.dump(),
+                                                   .secureCommunication = m_secureCommunication},
+                                PostRequestParameters {.onSuccess = onSuccess, .onError = onError},
+                                {});
+
+            if (needToRetry && RetryDelay > 0)
+            {
+                std::this_thread::sleep_for(std::chrono::seconds(RetryDelay));
+            }
+        } while (needToRetry);
 
         if (!success)
         {

--- a/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
@@ -2239,7 +2239,6 @@ TEST_F(IndexerConnectorSyncTest, ExecuteSearchQueryError)
     EXPECT_THROW(connector.executeSearchQuery("wazuh-states-vulnerabilities", searchQuery), IndexerConnectorException);
 }
 
-// Test executeSearchQuery error handling - 429 Too Many Requests should retry instead of throwing
 TEST_F(IndexerConnectorSyncTest, ExecuteSearchQueryError429TooManyRequestsWithRetry)
 {
     auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
@@ -2248,7 +2247,7 @@ TEST_F(IndexerConnectorSyncTest, ExecuteSearchQueryError429TooManyRequestsWithRe
     int callCount = 0;
 
     EXPECT_CALL(mockHttpRequest, post(_, _, _))
-        .Times(2) // Should retry once after 429 error
+        .Times(2)
         .WillOnce(Invoke(
             [&callCount](RequestParamsVariant /*requestParams*/,
                          auto postParams,
@@ -2284,7 +2283,6 @@ TEST_F(IndexerConnectorSyncTest, ExecuteSearchQueryError429TooManyRequestsWithRe
                 }
             }));
 
-    // RetryDelay=0 keeps the test fast; the retry path itself is what's under test.
     IndexerConnectorSyncImplSmallBulk connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
 
     nlohmann::json searchQuery;

--- a/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
@@ -2239,6 +2239,63 @@ TEST_F(IndexerConnectorSyncTest, ExecuteSearchQueryError)
     EXPECT_THROW(connector.executeSearchQuery("wazuh-states-vulnerabilities", searchQuery), IndexerConnectorException);
 }
 
+// Test executeSearchQuery error handling - 429 Too Many Requests should retry instead of throwing
+TEST_F(IndexerConnectorSyncTest, ExecuteSearchQueryError429TooManyRequestsWithRetry)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    int callCount = 0;
+
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .Times(2) // Should retry once after 429 error
+        .WillOnce(Invoke(
+            [&callCount](RequestParamsVariant /*requestParams*/,
+                         auto postParams,
+                         const ConfigurationParameters& /*configParams*/)
+            {
+                callCount++;
+                if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
+                {
+                    std::get<TPostRequestParameters<const std::string&>>(postParams)
+                        .onError("Too many requests", 429, "");
+                }
+                else
+                {
+                    std::get<TPostRequestParameters<std::string&&>>(postParams).onError("Too many requests", 429, "");
+                }
+            }))
+        .WillOnce(Invoke(
+            [&callCount](RequestParamsVariant /*requestParams*/,
+                         auto postParams,
+                         const ConfigurationParameters& /*configParams*/)
+            {
+                callCount++;
+                nlohmann::json response;
+                response["hits"]["total"]["value"] = 0;
+                response["hits"]["hits"] = nlohmann::json::array();
+                if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
+                {
+                    std::get<TPostRequestParameters<const std::string&>>(postParams).onSuccess(response.dump());
+                }
+                else
+                {
+                    std::get<TPostRequestParameters<std::string&&>>(postParams).onSuccess(response.dump());
+                }
+            }));
+
+    // RetryDelay=0 keeps the test fast; the retry path itself is what's under test.
+    IndexerConnectorSyncImplSmallBulk connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+
+    nlohmann::json searchQuery;
+    searchQuery["query"]["term"]["wazuh.agent.id"] = "001";
+
+    const auto result = connector.executeSearchQuery("wazuh-states-vulnerabilities", searchQuery);
+
+    EXPECT_EQ(callCount, 2) << "Should have made exactly 2 calls (1 initial 429 + 1 successful retry)";
+    EXPECT_EQ(result["hits"]["total"]["value"], 0);
+}
+
 TEST_F(IndexerConnectorSyncTest, ExecuteSearchQueryEmptyResults)
 {
     auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
@@ -3886,6 +3943,59 @@ TEST_F(IndexerConnectorSyncTest, SearchWithPitServerErrorThrows)
     nlohmann::json sort = nlohmann::json::array({{{"_shard_doc", "asc"}}});
 
     EXPECT_THROW(connector.search(pit, 10, query, sort), IndexerConnectorException);
+}
+
+TEST_F(IndexerConnectorSyncTest, SearchWithPitError429TooManyRequestsWithRetry)
+{
+    auto mockSelector = std::make_unique<NiceMock<MockServerSelector>>();
+    EXPECT_CALL(*mockSelector, getNext()).WillRepeatedly(Return("mockserver:9200"));
+
+    int callCount = 0;
+
+    EXPECT_CALL(mockHttpRequest, post(_, _, _))
+        .Times(2)
+        .WillOnce(Invoke(
+            [&callCount](RequestParamsVariant /*requestParams*/,
+                         auto postParams,
+                         const ConfigurationParameters& /*configParams*/)
+            {
+                callCount++;
+                if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
+                {
+                    std::get<TPostRequestParameters<const std::string&>>(postParams)
+                        .onError("Too many requests", 429, "");
+                }
+                else
+                {
+                    std::get<TPostRequestParameters<std::string&&>>(postParams).onError("Too many requests", 429, "");
+                }
+            }))
+        .WillOnce(Invoke(
+            [&callCount](RequestParamsVariant /*requestParams*/,
+                         auto postParams,
+                         const ConfigurationParameters& /*configParams*/)
+            {
+                callCount++;
+                std::string response = R"({"hits":{"total":{"value":1},"hits":[{"_id":"doc1","sort":[1,"doc1"]}]}})";
+                if (std::holds_alternative<TPostRequestParameters<const std::string&>>(postParams))
+                {
+                    std::get<TPostRequestParameters<const std::string&>>(postParams).onSuccess(response);
+                }
+                else
+                {
+                    std::get<TPostRequestParameters<std::string&&>>(postParams).onSuccess(std::move(response));
+                }
+            }));
+
+    IndexerConnectorSyncImplSmallBulk connector(config, nullptr, &mockHttpRequest, std::move(mockSelector));
+    PointInTime pit("pit_429", 100, "5m");
+    nlohmann::json query = {{"match_all", nlohmann::json::object()}};
+    nlohmann::json sort = nlohmann::json::array({{{"_shard_doc", "asc"}}});
+
+    auto hits = connector.search(pit, 10, query, sort);
+
+    EXPECT_EQ(callCount, 2) << "Should have made exactly 2 calls (1 initial 429 + 1 successful retry)";
+    EXPECT_EQ(hits["hits"].size(), 1);
 }
 
 TEST_F(IndexerConnectorSyncTest, SearchWithPitMissingHitsThrows)

--- a/src/shared_modules/utils/rocksDBWrapper.hpp
+++ b/src/shared_modules/utils/rocksDBWrapper.hpp
@@ -79,11 +79,18 @@ namespace Utils
          * @param enableWal Whether to enable WAL or not.
          * @param repairIfCorrupt Whether to repair the database if it is found corrupt while opening.
          *                        WARNING: this process might not recover all data.
+         * @param useSharedBuffers Whether to use the process-wide shared read cache / write buffer
+         *                        manager instead of a private one.
+         * @param readCacheSize Size in bytes of the private block cache (ignored when
+         *                      useSharedBuffers is true). Callers with a large, read-heavy dataset
+         *                      (e.g. many SST files serving hot-path lookups) should size this well
+         *                      above the default to avoid constantly evicting and re-reading from disk.
          */
         explicit TRocksDBWrapper(std::string dbPath,
                                  const bool enableWal = true,
                                  const bool repairIfCorrupt = true,
-                                 const bool useSharedBuffers = false)
+                                 const bool useSharedBuffers = false,
+                                 const size_t readCacheSize = 16 * 1024 * 1024)
             : m_enableWal {enableWal}
             , m_path {std::move(dbPath)}
             , m_logFn(makeLibLogFn("rocksdb"))
@@ -97,7 +104,16 @@ namespace Utils
             }
             else
             {
-                m_readCache = rocksdb::NewLRUCache(16 * 1024 * 1024);
+                m_readCache = rocksdb::NewLRUCache(readCacheSize);
+                // REVERTED allow_stall=true (see resumen.md, intento 8): enabling it made the
+                // VDP bulk load stall almost indefinitely (30+ min, didn't finish) instead of
+                // "briefly". Root cause: with write_buffer_size=32MB and default L0 compaction
+                // triggers, background flush/compaction can't keep up with the bulk-load write
+                // rate, so once the writer starts blocking on the 128MB budget it stays blocked
+                // — the stall doesn't resolve quickly, it becomes the new bottleneck. Fixing this
+                // properly requires addressing flush/compaction throughput (background job count,
+                // L0 triggers) together, not just flipping this flag in isolation — needs
+                // dedicated tuning and measurement before trying again.
                 m_writeManager = std::make_shared<rocksdb::WriteBufferManager>(128 * 1024 * 1024);
             }
 

--- a/src/shared_modules/utils/rocksDBWrapper.hpp
+++ b/src/shared_modules/utils/rocksDBWrapper.hpp
@@ -608,7 +608,6 @@ namespace Utils
                 }
             }
 
-            // The erases above shifted vector positions; refresh before createColumn re-appends.
             rebuildColumnsIndex();
 
             for (const auto& columnName : columnsNames)
@@ -766,7 +765,7 @@ namespace Utils
     private:
         std::shared_ptr<T> m_db;                                     ///< RocksDB instance.
         std::vector<ColumnFamilyRAII> m_columnsInstances;            ///< List of column family.
-        std::unordered_map<std::string, size_t> m_columnsIndex;      ///< Column name → position in m_columnsInstances.
+        std::unordered_map<std::string, size_t> m_columnsIndex;      ///< Column name.
         const bool m_enableWal;                                      ///< Whether to enable WAL or not.
         const std::string m_path;                                    ///< Location of the DB.
         std::shared_ptr<rocksdb::Cache> m_readCache;                 ///< Cache for read operations.
@@ -817,7 +816,7 @@ namespace Utils
         }
 
         /**
-         * @brief Rebuilds the name → position index over m_columnsInstances.
+         * @brief Rebuilds the name
          *
          * Must be called after any operation that shifts vector positions (erase); appends
          * maintain the index incrementally instead. Keeping this index makes columnExists()

--- a/src/shared_modules/utils/rocksDBWrapper.hpp
+++ b/src/shared_modules/utils/rocksDBWrapper.hpp
@@ -28,6 +28,7 @@
 #include <rocksdb/write_batch.h>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -81,10 +82,7 @@ namespace Utils
          *                        WARNING: this process might not recover all data.
          * @param useSharedBuffers Whether to use the process-wide shared read cache / write buffer
          *                        manager instead of a private one.
-         * @param readCacheSize Size in bytes of the private block cache (ignored when
-         *                      useSharedBuffers is true). Callers with a large, read-heavy dataset
-         *                      (e.g. many SST files serving hot-path lookups) should size this well
-         *                      above the default to avoid constantly evicting and re-reading from disk.
+         * @param readCacheSize Size in bytes of the private block cache.
          */
         explicit TRocksDBWrapper(std::string dbPath,
                                  const bool enableWal = true,
@@ -105,15 +103,6 @@ namespace Utils
             else
             {
                 m_readCache = rocksdb::NewLRUCache(readCacheSize);
-                // REVERTED allow_stall=true (see resumen.md, intento 8): enabling it made the
-                // VDP bulk load stall almost indefinitely (30+ min, didn't finish) instead of
-                // "briefly". Root cause: with write_buffer_size=32MB and default L0 compaction
-                // triggers, background flush/compaction can't keep up with the bulk-load write
-                // rate, so once the writer starts blocking on the 128MB budget it stays blocked
-                // — the stall doesn't resolve quickly, it becomes the new bottleneck. Fixing this
-                // properly requires addressing flush/compaction throughput (background job count,
-                // L0 triggers) together, not just flipping this flag in isolation — needs
-                // dedicated tuning and measurement before trying again.
                 m_writeManager = std::make_shared<rocksdb::WriteBufferManager>(128 * 1024 * 1024);
             }
 
@@ -220,6 +209,7 @@ namespace Utils
             {
                 m_columnsInstances.emplace_back(m_db, handle);
             }
+            rebuildColumnsIndex();
         }
 
         /**
@@ -543,6 +533,7 @@ namespace Utils
                 throw std::runtime_error {"Couldn't create column family: " + std::string {status.getState()}};
             }
             m_columnsInstances.emplace_back(m_db, pColumnFamily);
+            m_columnsIndex.emplace(columnName, m_columnsInstances.size() - 1);
         }
 
         /**
@@ -559,10 +550,7 @@ namespace Utils
                 throw std::invalid_argument {"Column name is empty"};
             }
 
-            return std::find_if(m_columnsInstances.begin(),
-                                m_columnsInstances.end(),
-                                [&columnName](const ColumnFamilyRAII& handle)
-                                { return columnName == handle->GetName(); }) != m_columnsInstances.end();
+            return m_columnsIndex.find(columnName) != m_columnsIndex.end();
         }
 
         /**
@@ -620,6 +608,9 @@ namespace Utils
                 }
             }
 
+            // The erases above shifted vector positions; refresh before createColumn re-appends.
+            rebuildColumnsIndex();
+
             for (const auto& columnName : columnsNames)
             {
                 createColumn(columnName);
@@ -647,6 +638,8 @@ namespace Utils
                 {
                     it->drop();
                     m_columnsInstances.erase(it);
+
+                    rebuildColumnsIndex();
 
                     createColumn(columnName);
                 }
@@ -773,6 +766,7 @@ namespace Utils
     private:
         std::shared_ptr<T> m_db;                                     ///< RocksDB instance.
         std::vector<ColumnFamilyRAII> m_columnsInstances;            ///< List of column family.
+        std::unordered_map<std::string, size_t> m_columnsIndex;      ///< Column name → position in m_columnsInstances.
         const bool m_enableWal;                                      ///< Whether to enable WAL or not.
         const std::string m_path;                                    ///< Location of the DB.
         std::shared_ptr<rocksdb::Cache> m_readCache;                 ///< Cache for read operations.
@@ -812,22 +806,33 @@ namespace Utils
          */
         ColumnFamilyRAII& getColumnFamilyBasedOnName(const std::string& columnName)
         {
-            auto columnNameFind {columnName};
-            if (columnName.empty())
-            {
-                columnNameFind = rocksdb::kDefaultColumnFamilyName;
-            }
+            const auto& columnNameFind = columnName.empty() ? rocksdb::kDefaultColumnFamilyName : columnName;
 
-            if (const auto it {std::find_if(m_columnsInstances.begin(),
-                                            m_columnsInstances.end(),
-                                            [&columnNameFind](const ColumnFamilyRAII& handle)
-                                            { return columnNameFind == handle.handle()->GetName(); })};
-                it != m_columnsInstances.end())
+            if (const auto it {m_columnsIndex.find(columnNameFind)}; it != m_columnsIndex.end())
             {
-                return *it;
+                return m_columnsInstances[it->second];
             }
 
             throw std::runtime_error {"Couldn't find column family: '" + columnName + "'"};
+        }
+
+        /**
+         * @brief Rebuilds the name → position index over m_columnsInstances.
+         *
+         * Must be called after any operation that shifts vector positions (erase); appends
+         * maintain the index incrementally instead. Keeping this index makes columnExists()
+         * and getColumnFamilyBasedOnName() O(1) — they run per document during the feed
+         * load, and a linear scan over hundreds of per-CNA column families made them the
+         * dominant per-document cost.
+         */
+        void rebuildColumnsIndex()
+        {
+            m_columnsIndex.clear();
+            m_columnsIndex.reserve(m_columnsInstances.size());
+            for (size_t i = 0; i < m_columnsInstances.size(); ++i)
+            {
+                m_columnsIndex.emplace(m_columnsInstances[i].handle()->GetName(), i);
+            }
         }
 
         auto createTransaction(const rocksdb::WriteOptions& writeOptions)

--- a/src/wazuh_modules/src/main.c
+++ b/src/wazuh_modules/src/main.c
@@ -26,12 +26,6 @@ static void wm_signals_configure();     // Configure signal handling.
 
 static int flag_foreground = 0;         // Running in foreground.
 
-/* jemalloc reads this weak symbol before any allocation occurs (before main).
- * narenas:4     — bound arena count on multi-core hosts.
- * dirty_decay_ms:5000  — return dirty pages to the OS after 5 s idle.
- * muzzy_decay_ms:5000  — same for muzzy (partially-released) pages.
- * background_thread:true — use a dedicated thread for async decay so the
- *                          allocator does not retain the VDP feed's peak VMS. */
 const char *malloc_conf =
     "narenas:4,dirty_decay_ms:5000,muzzy_decay_ms:5000,background_thread:true";
 

--- a/src/wazuh_modules/src/main.c
+++ b/src/wazuh_modules/src/main.c
@@ -26,6 +26,15 @@ static void wm_signals_configure();     // Configure signal handling.
 
 static int flag_foreground = 0;         // Running in foreground.
 
+/* jemalloc reads this weak symbol before any allocation occurs (before main).
+ * narenas:4     — bound arena count on multi-core hosts.
+ * dirty_decay_ms:5000  — return dirty pages to the OS after 5 s idle.
+ * muzzy_decay_ms:5000  — same for muzzy (partially-released) pages.
+ * background_thread:true — use a dedicated thread for async decay so the
+ *                          allocator does not retain the VDP feed's peak VMS. */
+const char *malloc_conf =
+    "narenas:4,dirty_decay_ms:5000,muzzy_decay_ms:5000,background_thread:true";
+
 static pthread_mutex_t sig_lock = PTHREAD_MUTEX_INITIALIZER;
 
 // Main function

--- a/src/wazuh_modules/src/main.c
+++ b/src/wazuh_modules/src/main.c
@@ -26,9 +26,6 @@ static void wm_signals_configure();     // Configure signal handling.
 
 static int flag_foreground = 0;         // Running in foreground.
 
-const char *malloc_conf =
-    "narenas:4,dirty_decay_ms:5000,muzzy_decay_ms:5000,background_thread:true";
-
 static pthread_mutex_t sig_lock = PTHREAD_MUTEX_INITIALIZER;
 
 // Main function

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -179,12 +179,6 @@ public:
                 m_activeDecoder->setLast(std::make_shared<StoreModel>());
             }
 
-            // m_activeBatch/m_activeBatchCount/m_activeDecoder survive across processMessage
-            // calls (per-page invocations of the same download cycle). If a document throws
-            // (decoder parse/verifier failure, commitBatch error), that state must be discarded
-            // before propagating: the caller treats the failure by restarting the download, and
-            // a dirty leftover batch would otherwise keep accumulating entries across retries
-            // and leak an aborted cycle's uncommitted writes into the next one.
             try
             {
                 for (const auto& resource : parsedMessage.at("data"))
@@ -201,7 +195,8 @@ public:
                                                                      .cve5Buffer = {},
                                                                      .feedDatabase = feedDatabase,
                                                                      .resourceType = ResourceType::UNKNOWN,
-                                                                     .writeBatch = &m_activeBatch});
+                                                                     .writeBatch = &m_activeBatch,
+                                                                     .initialLoad = m_initialLoad});
                     m_activeDecoder->handleRequest(std::move(eventContext));
 
                     if (++m_activeBatchCount % BATCH_COMMIT_SIZE == 0 ||
@@ -225,8 +220,6 @@ public:
             }
             catch (...)
             {
-                // Rebuild (rather than Clear()) so an oversized failed batch can't ratchet the
-                // capacity floor either — same rationale as the oversized branch above.
                 m_activeBatch = rocksdb::WriteBatch {BATCH_COMMIT_MAX_BYTES};
                 m_activeBatchCount = 0;
                 m_activeDecoder.reset();
@@ -244,6 +237,7 @@ public:
             }
             m_activeBatchCount = 0;
             m_activeDecoder.reset();
+            m_initialLoad = false;
 
             // Sent once by IndexerDownloader after all pages are processed (initial load or
             // incremental update). No documents to store. Returns a non-empty hash field so
@@ -304,6 +298,16 @@ public:
             // We disable the automatic repair of the DB in case it's corrupted.
             m_feedDatabase =
                 std::make_shared<TRocksDBWrapper>(DATABASE_PATH, false, false, false, FEED_READ_CACHE_SIZE);
+
+            m_initialLoad = true;
+            for (const auto& columnName : m_feedDatabase->getAllColumns())
+            {
+                if (columnName.rfind("cve_package_", 0) == 0)
+                {
+                    m_initialLoad = false;
+                    break;
+                }
+            }
 
             // Load the global maps needed by the local feed database before any scan or
             // message processing can use it.
@@ -383,11 +387,6 @@ public:
                         if (msgType == "indexer" && ++entryCount % FLUSH_INTERVAL_PAGES == 0)
                         {
                             feedDatabase->flush();
-
-                            // Signal the flush back through the (otherwise-unused, for "indexer"
-                            // messages) hash field so IndexerDownloader can persist its cursor only
-                            // up to a page that is now actually durable — see the caller for why
-                            // that matters with WAL disabled on this database.
                             std::get<FileProcessingResultFields::HASH>(processMessageResult) = "flushed";
                         }
 
@@ -943,6 +942,7 @@ private:
     std::shared_ptr<EventDecoder> m_activeDecoder;
     rocksdb::WriteBatch m_activeBatch {BATCH_COMMIT_MAX_BYTES};
     size_t m_activeBatchCount = 0;
+    bool m_initialLoad = false;
 
     /**
      * @brief Reads the global maps from the local feed database and loads them into memory.

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -40,6 +40,18 @@ constexpr auto DATABASE_PATH {"queue/vd/feed"};
 const static std::string UPDATER_PATH {"queue/vd/vd_updater"};
 constexpr auto DEFAULT_TRANSLATION_LRU_SIZE {2048};
 
+// REVERTED (see resumen.md, intento 4): a 64MB block cache here was measured with
+// heaptrack to add a new ~87MB peak contributor during the download itself
+// (BlockFetcher::ReadBlockContents via TRocksDBWrapper::get() in
+// UpdateCVECandidates::storeVulnerabilityCandidate does a lookup per CVE during the
+// initial load, and populates this cache while writing) — it doesn't only benefit
+// post-download scan reads as intended, it also raises the very download-time peak we're
+// trying to reduce. Kept at the RocksDB default (16MB, see TRocksDBWrapper) until a
+// separate, measured change addresses scan-time read latency without regressing the
+// load-time peak (e.g. sizing this only after reloadGlobalMaps() confirms the load is
+// done, if TRocksDBWrapper ever supports resizing a cache post-construction).
+constexpr size_t FEED_READ_CACHE_SIZE {16 * 1024 * 1024};
+
 constexpr auto DEFAULT_ADP {"nvd"};
 constexpr auto ADP_CVSS_KEY {"cvss"};
 constexpr auto ADP_DESCRIPTION_KEY {"description"};
@@ -158,49 +170,125 @@ public:
             throw std::runtime_error("Invalid message. Missing required fields.");
         }
 
-        auto resourceProcessing = [](const nlohmann::json& resource,
-                                     std::shared_ptr<TRocksDBWrapper> database,
-                                     rocksdb::WriteBatch* batch = nullptr)
-        {
-            auto eventContext = std::make_shared<EventContext>(EventContext {.resource = resource,
-                                                                             .cve5Buffer = {},
-                                                                             .feedDatabase = std::move(database),
-                                                                             .resourceType = ResourceType::UNKNOWN,
-                                                                             .writeBatch = batch});
-
-            const auto eventDecoder = std::make_shared<EventDecoder>();
-            eventDecoder->setLast(std::make_shared<StoreModel>());
-            eventDecoder->handleRequest(std::move(eventContext));
-        };
-
         // Lock the mutex to protect the access to the internal databases.
         std::scoped_lock<std::shared_mutex> lock(m_mutex);
 
         if (parsedMessage.at("type") == "indexer")
         {
             // Indexer-sourced path: data arrives inline (no intermediate files on disk).
+            // processMessage is called once per page; "data" holds all of that page's documents.
             if (!parsedMessage.contains("data"))
             {
                 throw std::runtime_error("Invalid indexer message. Missing 'data' field.");
             }
 
-            rocksdb::WriteBatch batch;
+            // BATCH_COMMIT_SIZE = 25 / BATCH_COMMIT_MAX_BYTES = 2MB (see member constant below).
+            // History (see resumen.md, intentos 9-10, for the full detail): intento 9 validated
+            // 50/4MB with heaptrack (peak 663MB -> 464MB, runtime 920s, no penalty). Intento 10
+            // halved both again (25/2MB); a heaptrack capture (`decima`) showed the RocksDB Arena
+            // peak dropping further (217M -> 174.5M) but *also* reported runtime nearly doubling
+            // (920s -> 1724s), which looked like a real regression and was reverted for a first
+            // round. A real production log with this exact 25/2MB config in place (353k documents,
+            // ~40% more than the feed size assumed throughout this investigation) completed in
+            // ~776s — matching/beating the *heaptrack-measured* 920s for 50/4MB on a smaller feed,
+            // with no profiler attached. That falsifies the "regression": heaptrack's own per-call
+            // interception overhead scales with allocation *count*, and 25/2MB produces more,
+            // smaller commitBatch() calls (more distinct allocation events) than 50/4MB for the same
+            // data volume — so heaptrack's reported wall-clock time is not a valid basis for
+            // comparing runtime across configs that change the allocation-call-count profile, only
+            // for comparing memory sizes/peaks (which it still tracks correctly regardless of its own
+            // slowdown). Re-applied 25/2MB. Lesson for future changes to these constants: heaptrack's
+            // "total runtime" figure is only trustworthy when the change under test does NOT alter
+            // how many allocation calls happen — cross-check any timing claim against a real,
+            // non-instrumented production run before trusting it.
+            //
+            // Separately (and unaffected by the above): both `novena` (50/4MB) and `decima` (25/2MB)
+            // measured the *exact same* ~45.10MB single-call WriteBatch reallocation — a memory size,
+            // not a timing figure, so this comparison is unaffected by the profiling-overhead issue.
+            // Getting the *same* value under two different thresholds pointed at first to "one
+            // outlier document's own writes exceed both thresholds by itself" — but on reflection
+            // that's an unlikely amount of data for a single CVE's Hotfixes/Remediations/Description
+            // (Candidates runs *after* Description in StoreModel's chain, so it can't be the direct
+            // cause of a reallocation happening during Description's own — normally tiny — write).
+            // The more consistent explanation: WriteBatch::Clear() (see below) never releases
+            // *capacity*, only *used size* — over enough commit cycles that capacity ratchets upward,
+            // and because both configs process the identical reference feed in the identical order,
+            // their capacity ladders converge (2MB->4MB->8MB->... and 4MB->8MB->... merge once both
+            // reach 8MB) and hit the same reallocation wall at the same point in the stream, regardless
+            // of the starting threshold. See BATCH_RESET_THRESHOLD_BYTES below for the fix applied for
+            // this specific finding.
+            static constexpr size_t BATCH_COMMIT_SIZE = 25;
+
+            // Lazy-init the decoder for this download cycle. m_activeDecoder survives across
+            // processMessage calls so FlatBuffers parsers are loaded only once per download.
+            if (!m_activeDecoder)
+            {
+                m_activeDecoder = std::make_shared<EventDecoder>();
+                m_activeDecoder->setLast(std::make_shared<StoreModel>());
+            }
 
             for (const auto& resource : parsedMessage.at("data"))
             {
                 if (m_shouldStop)
                 {
+                    m_activeBatch.Clear();
+                    m_activeBatchCount = 0;
+                    m_activeDecoder.reset();
                     return {0, "", true};
                 }
-                resourceProcessing(resource, feedDatabase, &batch);
-            }
+                auto eventContext = std::make_shared<EventContext>(EventContext {.resource = resource,
+                                                                                 .cve5Buffer = {},
+                                                                                 .feedDatabase = feedDatabase,
+                                                                                 .resourceType = ResourceType::UNKNOWN,
+                                                                                 .writeBatch = &m_activeBatch});
+                m_activeDecoder->handleRequest(std::move(eventContext));
 
-            feedDatabase->commitBatch(batch);
+                // m_activeBatch accumulates across calls; commit every BATCH_COMMIT_SIZE entries,
+                // or sooner if it has grown past BATCH_COMMIT_MAX_BYTES (see comment above).
+                if (++m_activeBatchCount % BATCH_COMMIT_SIZE == 0 ||
+                    m_activeBatch.GetDataSize() >= BATCH_COMMIT_MAX_BYTES)
+                {
+                    // WriteBatch::Clear() only resets the *used* size (rep_.clear()) — it never
+                    // shrinks the *reserved capacity* back down. Both `novena` and `decima` (see
+                    // resumen.md) show the exact same isolated ~45MB reallocation despite different
+                    // BATCH_COMMIT_MAX_BYTES thresholds: a single Put() call growing the batch to a
+                    // capacity far beyond the 2MB target, which — once reached — would otherwise
+                    // become the new permanent floor for every subsequent batch for the rest of the
+                    // download (Clear() reuses it, never releases it). If a feed keeps growing (this
+                    // session's own production log went from an assumed ~250k to a real 353k CVEs),
+                    // more such outliers over time would keep ratcheting that floor up indefinitely.
+                    // Detect an abnormally large commit and, only then, discard+rebuild the batch
+                    // (releasing its capacity) instead of Clear()-ing it, so a rare oversized document
+                    // can't permanently inflate the memory floor of every batch that follows it.
+                    static constexpr size_t BATCH_RESET_THRESHOLD_BYTES = BATCH_COMMIT_MAX_BYTES * 4;
+                    const bool oversized = m_activeBatch.GetDataSize() >= BATCH_RESET_THRESHOLD_BYTES;
+
+                    feedDatabase->commitBatch(m_activeBatch);
+
+                    if (oversized)
+                    {
+                        m_activeBatch = rocksdb::WriteBatch {BATCH_COMMIT_MAX_BYTES};
+                    }
+                    else
+                    {
+                        m_activeBatch.Clear();
+                    }
+                }
+            }
 
             return {0, "", true};
         }
         else if (parsedMessage.at("type") == "indexer_complete")
         {
+            // Commit any entries that did not fill the last sub-batch.
+            if (m_activeBatch.Count() > 0)
+            {
+                feedDatabase->commitBatch(m_activeBatch);
+                m_activeBatch.Clear();
+            }
+            m_activeBatchCount = 0;
+            m_activeDecoder.reset();
+
             // Sent once by IndexerDownloader after all pages are processed (initial load or
             // incremental update). No documents to store. Returns a non-empty hash field so
             // the caller can detect completion without re-parsing the message.
@@ -258,7 +346,8 @@ public:
         try
         {
             // We disable the automatic repair of the DB in case it's corrupted.
-            m_feedDatabase = std::make_shared<TRocksDBWrapper>(DATABASE_PATH, false, false);
+            m_feedDatabase =
+                std::make_shared<TRocksDBWrapper>(DATABASE_PATH, false, false, false, FEED_READ_CACHE_SIZE);
 
             // Load the global maps needed by the local feed database before any scan or
             // message processing can use it.
@@ -290,7 +379,8 @@ public:
             if (!m_feedDatabase)
             {
                 std::filesystem::remove_all(DATABASE_PATH);
-                m_feedDatabase = std::make_shared<TRocksDBWrapper>(DATABASE_PATH, false);
+                m_feedDatabase =
+                    std::make_shared<TRocksDBWrapper>(DATABASE_PATH, false, true, false, FEED_READ_CACHE_SIZE);
             }
 
             // Remove the updater directory to force the download of the complete feed.
@@ -307,11 +397,24 @@ public:
             if (!fileProcessingCallback)
             {
 
-                fileProcessingCallback = [this, postUpdateCallback, feedDatabase = m_feedDatabase, failureCallback](
-                                             nlohmann::json message) -> FileProcessingResult
+                fileProcessingCallback = [this,
+                                          postUpdateCallback,
+                                          feedDatabase = m_feedDatabase,
+                                          failureCallback,
+                                          entryCount = size_t {0}](
+                                             nlohmann::json message) mutable -> FileProcessingResult
                 {
                     // Initialize the processing result with default values.
                     FileProcessingResult processMessageResult {0, "", false};
+
+                    // Periodic checkpoint so WAL-disabled writes aren't only durable at the very
+                    // end of the download (crash/SIGKILL mid-download would otherwise lose
+                    // everything committed so far). Measured with heaptrack: this call's
+                    // frequency does NOT move the peak RSS during the load (RocksDB's own
+                    // write_buffer_size/write_buffer_manager thresholds already bound the
+                    // MemTable independently of this), so the interval is picked for
+                    // durability/runtime balance, not for capping memory.
+                    static constexpr size_t FLUSH_INTERVAL_PAGES = 250;
 
                     try
                     {
@@ -331,10 +434,17 @@ public:
                             return processMessageResult;
                         }
 
+                        if (msgType == "indexer" && ++entryCount % FLUSH_INTERVAL_PAGES == 0)
+                        {
+                            feedDatabase->flush();
+                        }
+
                         // On completion signal, validate that the local feed database is now
                         // usable for scanning before marking it ready or triggering rescans.
                         if (msgType == "indexer_complete")
                         {
+                            entryCount = 0;
+
                             // WAL is disabled for the feed database, so committed batches live in
                             // the memtable until RocksDB decides to flush. Force a flush here to
                             // guarantee all downloaded CVEs are on disk before marking the feed
@@ -875,6 +985,18 @@ private:
     std::shared_ptr<TRocksDBWrapper> m_feedDatabase;
     std::unique_ptr<TranslationLRUCache> m_translationL2Cache;
     bool m_shouldStop = false;
+
+    // Secondary, byte-based commit trigger for m_activeBatch — see the comment in processMessage()
+    // where it's checked. Also used here to pre-reserve m_activeBatch's buffer so that, once warmed
+    // up, repeated Clear()/refill cycles reuse that capacity instead of doubling-reallocating on
+    // every download cycle.
+    static constexpr size_t BATCH_COMMIT_MAX_BYTES = 2 * 1024 * 1024;
+
+    // Download-cycle state. Null / empty between downloads; reset on indexer_complete or stop.
+    // Accessed only while holding m_mutex, so no extra synchronisation needed.
+    std::shared_ptr<EventDecoder> m_activeDecoder;
+    rocksdb::WriteBatch m_activeBatch {BATCH_COMMIT_MAX_BYTES};
+    size_t m_activeBatchCount = 0;
 
     /**
      * @brief Reads the global maps from the local feed database and loads them into memory.

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/databaseFeedManager.hpp
@@ -40,16 +40,6 @@ constexpr auto DATABASE_PATH {"queue/vd/feed"};
 const static std::string UPDATER_PATH {"queue/vd/vd_updater"};
 constexpr auto DEFAULT_TRANSLATION_LRU_SIZE {2048};
 
-// REVERTED (see resumen.md, intento 4): a 64MB block cache here was measured with
-// heaptrack to add a new ~87MB peak contributor during the download itself
-// (BlockFetcher::ReadBlockContents via TRocksDBWrapper::get() in
-// UpdateCVECandidates::storeVulnerabilityCandidate does a lookup per CVE during the
-// initial load, and populates this cache while writing) — it doesn't only benefit
-// post-download scan reads as intended, it also raises the very download-time peak we're
-// trying to reduce. Kept at the RocksDB default (16MB, see TRocksDBWrapper) until a
-// separate, measured change addresses scan-time read latency without regressing the
-// load-time peak (e.g. sizing this only after reloadGlobalMaps() confirms the load is
-// done, if TRocksDBWrapper ever supports resizing a cache post-construction).
 constexpr size_t FEED_READ_CACHE_SIZE {16 * 1024 * 1024};
 
 constexpr auto DEFAULT_ADP {"nvd"};
@@ -176,111 +166,77 @@ public:
         if (parsedMessage.at("type") == "indexer")
         {
             // Indexer-sourced path: data arrives inline (no intermediate files on disk).
-            // processMessage is called once per page; "data" holds all of that page's documents.
             if (!parsedMessage.contains("data"))
             {
                 throw std::runtime_error("Invalid indexer message. Missing 'data' field.");
             }
 
-            // BATCH_COMMIT_SIZE = 25 / BATCH_COMMIT_MAX_BYTES = 2MB (see member constant below).
-            // History (see resumen.md, intentos 9-10, for the full detail): intento 9 validated
-            // 50/4MB with heaptrack (peak 663MB -> 464MB, runtime 920s, no penalty). Intento 10
-            // halved both again (25/2MB); a heaptrack capture (`decima`) showed the RocksDB Arena
-            // peak dropping further (217M -> 174.5M) but *also* reported runtime nearly doubling
-            // (920s -> 1724s), which looked like a real regression and was reverted for a first
-            // round. A real production log with this exact 25/2MB config in place (353k documents,
-            // ~40% more than the feed size assumed throughout this investigation) completed in
-            // ~776s — matching/beating the *heaptrack-measured* 920s for 50/4MB on a smaller feed,
-            // with no profiler attached. That falsifies the "regression": heaptrack's own per-call
-            // interception overhead scales with allocation *count*, and 25/2MB produces more,
-            // smaller commitBatch() calls (more distinct allocation events) than 50/4MB for the same
-            // data volume — so heaptrack's reported wall-clock time is not a valid basis for
-            // comparing runtime across configs that change the allocation-call-count profile, only
-            // for comparing memory sizes/peaks (which it still tracks correctly regardless of its own
-            // slowdown). Re-applied 25/2MB. Lesson for future changes to these constants: heaptrack's
-            // "total runtime" figure is only trustworthy when the change under test does NOT alter
-            // how many allocation calls happen — cross-check any timing claim against a real,
-            // non-instrumented production run before trusting it.
-            //
-            // Separately (and unaffected by the above): both `novena` (50/4MB) and `decima` (25/2MB)
-            // measured the *exact same* ~45.10MB single-call WriteBatch reallocation — a memory size,
-            // not a timing figure, so this comparison is unaffected by the profiling-overhead issue.
-            // Getting the *same* value under two different thresholds pointed at first to "one
-            // outlier document's own writes exceed both thresholds by itself" — but on reflection
-            // that's an unlikely amount of data for a single CVE's Hotfixes/Remediations/Description
-            // (Candidates runs *after* Description in StoreModel's chain, so it can't be the direct
-            // cause of a reallocation happening during Description's own — normally tiny — write).
-            // The more consistent explanation: WriteBatch::Clear() (see below) never releases
-            // *capacity*, only *used size* — over enough commit cycles that capacity ratchets upward,
-            // and because both configs process the identical reference feed in the identical order,
-            // their capacity ladders converge (2MB->4MB->8MB->... and 4MB->8MB->... merge once both
-            // reach 8MB) and hit the same reallocation wall at the same point in the stream, regardless
-            // of the starting threshold. See BATCH_RESET_THRESHOLD_BYTES below for the fix applied for
-            // this specific finding.
             static constexpr size_t BATCH_COMMIT_SIZE = 25;
 
-            // Lazy-init the decoder for this download cycle. m_activeDecoder survives across
-            // processMessage calls so FlatBuffers parsers are loaded only once per download.
             if (!m_activeDecoder)
             {
                 m_activeDecoder = std::make_shared<EventDecoder>();
                 m_activeDecoder->setLast(std::make_shared<StoreModel>());
             }
 
-            for (const auto& resource : parsedMessage.at("data"))
+            // m_activeBatch/m_activeBatchCount/m_activeDecoder survive across processMessage
+            // calls (per-page invocations of the same download cycle). If a document throws
+            // (decoder parse/verifier failure, commitBatch error), that state must be discarded
+            // before propagating: the caller treats the failure by restarting the download, and
+            // a dirty leftover batch would otherwise keep accumulating entries across retries
+            // and leak an aborted cycle's uncommitted writes into the next one.
+            try
             {
-                if (m_shouldStop)
+                for (const auto& resource : parsedMessage.at("data"))
                 {
-                    m_activeBatch.Clear();
-                    m_activeBatchCount = 0;
-                    m_activeDecoder.reset();
-                    return {0, "", true};
-                }
-                auto eventContext = std::make_shared<EventContext>(EventContext {.resource = resource,
-                                                                                 .cve5Buffer = {},
-                                                                                 .feedDatabase = feedDatabase,
-                                                                                 .resourceType = ResourceType::UNKNOWN,
-                                                                                 .writeBatch = &m_activeBatch});
-                m_activeDecoder->handleRequest(std::move(eventContext));
-
-                // m_activeBatch accumulates across calls; commit every BATCH_COMMIT_SIZE entries,
-                // or sooner if it has grown past BATCH_COMMIT_MAX_BYTES (see comment above).
-                if (++m_activeBatchCount % BATCH_COMMIT_SIZE == 0 ||
-                    m_activeBatch.GetDataSize() >= BATCH_COMMIT_MAX_BYTES)
-                {
-                    // WriteBatch::Clear() only resets the *used* size (rep_.clear()) — it never
-                    // shrinks the *reserved capacity* back down. Both `novena` and `decima` (see
-                    // resumen.md) show the exact same isolated ~45MB reallocation despite different
-                    // BATCH_COMMIT_MAX_BYTES thresholds: a single Put() call growing the batch to a
-                    // capacity far beyond the 2MB target, which — once reached — would otherwise
-                    // become the new permanent floor for every subsequent batch for the rest of the
-                    // download (Clear() reuses it, never releases it). If a feed keeps growing (this
-                    // session's own production log went from an assumed ~250k to a real 353k CVEs),
-                    // more such outliers over time would keep ratcheting that floor up indefinitely.
-                    // Detect an abnormally large commit and, only then, discard+rebuild the batch
-                    // (releasing its capacity) instead of Clear()-ing it, so a rare oversized document
-                    // can't permanently inflate the memory floor of every batch that follows it.
-                    static constexpr size_t BATCH_RESET_THRESHOLD_BYTES = BATCH_COMMIT_MAX_BYTES * 4;
-                    const bool oversized = m_activeBatch.GetDataSize() >= BATCH_RESET_THRESHOLD_BYTES;
-
-                    feedDatabase->commitBatch(m_activeBatch);
-
-                    if (oversized)
-                    {
-                        m_activeBatch = rocksdb::WriteBatch {BATCH_COMMIT_MAX_BYTES};
-                    }
-                    else
+                    if (m_shouldStop)
                     {
                         m_activeBatch.Clear();
+                        m_activeBatchCount = 0;
+                        m_activeDecoder.reset();
+                        return {0, "", true};
+                    }
+                    auto eventContext =
+                        std::make_shared<EventContext>(EventContext {.resource = resource,
+                                                                     .cve5Buffer = {},
+                                                                     .feedDatabase = feedDatabase,
+                                                                     .resourceType = ResourceType::UNKNOWN,
+                                                                     .writeBatch = &m_activeBatch});
+                    m_activeDecoder->handleRequest(std::move(eventContext));
+
+                    if (++m_activeBatchCount % BATCH_COMMIT_SIZE == 0 ||
+                        m_activeBatch.GetDataSize() >= BATCH_COMMIT_MAX_BYTES)
+                    {
+                        static constexpr size_t BATCH_RESET_THRESHOLD_BYTES = BATCH_COMMIT_MAX_BYTES * 4;
+                        const bool oversized = m_activeBatch.GetDataSize() >= BATCH_RESET_THRESHOLD_BYTES;
+
+                        feedDatabase->commitBatch(m_activeBatch);
+
+                        if (oversized)
+                        {
+                            m_activeBatch = rocksdb::WriteBatch {BATCH_COMMIT_MAX_BYTES};
+                        }
+                        else
+                        {
+                            m_activeBatch.Clear();
+                        }
                     }
                 }
+            }
+            catch (...)
+            {
+                // Rebuild (rather than Clear()) so an oversized failed batch can't ratchet the
+                // capacity floor either — same rationale as the oversized branch above.
+                m_activeBatch = rocksdb::WriteBatch {BATCH_COMMIT_MAX_BYTES};
+                m_activeBatchCount = 0;
+                m_activeDecoder.reset();
+                throw;
             }
 
             return {0, "", true};
         }
         else if (parsedMessage.at("type") == "indexer_complete")
         {
-            // Commit any entries that did not fill the last sub-batch.
             if (m_activeBatch.Count() > 0)
             {
                 feedDatabase->commitBatch(m_activeBatch);
@@ -397,23 +353,13 @@ public:
             if (!fileProcessingCallback)
             {
 
-                fileProcessingCallback = [this,
-                                          postUpdateCallback,
-                                          feedDatabase = m_feedDatabase,
-                                          failureCallback,
-                                          entryCount = size_t {0}](
-                                             nlohmann::json message) mutable -> FileProcessingResult
+                fileProcessingCallback =
+                    [this, postUpdateCallback, feedDatabase = m_feedDatabase, failureCallback, entryCount = size_t {0}](
+                        nlohmann::json message) mutable -> FileProcessingResult
                 {
                     // Initialize the processing result with default values.
                     FileProcessingResult processMessageResult {0, "", false};
 
-                    // Periodic checkpoint so WAL-disabled writes aren't only durable at the very
-                    // end of the download (crash/SIGKILL mid-download would otherwise lose
-                    // everything committed so far). Measured with heaptrack: this call's
-                    // frequency does NOT move the peak RSS during the load (RocksDB's own
-                    // write_buffer_size/write_buffer_manager thresholds already bound the
-                    // MemTable independently of this), so the interval is picked for
-                    // durability/runtime balance, not for capping memory.
                     static constexpr size_t FLUSH_INTERVAL_PAGES = 250;
 
                     try
@@ -437,6 +383,12 @@ public:
                         if (msgType == "indexer" && ++entryCount % FLUSH_INTERVAL_PAGES == 0)
                         {
                             feedDatabase->flush();
+
+                            // Signal the flush back through the (otherwise-unused, for "indexer"
+                            // messages) hash field so IndexerDownloader can persist its cursor only
+                            // up to a page that is now actually durable — see the caller for why
+                            // that matters with WAL disabled on this database.
+                            std::get<FileProcessingResultFields::HASH>(processMessageResult) = "flushed";
                         }
 
                         // On completion signal, validate that the local feed database is now
@@ -986,14 +938,8 @@ private:
     std::unique_ptr<TranslationLRUCache> m_translationL2Cache;
     bool m_shouldStop = false;
 
-    // Secondary, byte-based commit trigger for m_activeBatch — see the comment in processMessage()
-    // where it's checked. Also used here to pre-reserve m_activeBatch's buffer so that, once warmed
-    // up, repeated Clear()/refill cycles reuse that capacity instead of doubling-reallocating on
-    // every download cycle.
     static constexpr size_t BATCH_COMMIT_MAX_BYTES = 2 * 1024 * 1024;
 
-    // Download-cycle state. Null / empty between downloads; reset on indexer_complete or stop.
-    // Accessed only while holding m_mutex, so no extra synchronisation needed.
     std::shared_ptr<EventDecoder> m_activeDecoder;
     rocksdb::WriteBatch m_activeBatch {BATCH_COMMIT_MAX_BYTES};
     size_t m_activeBatchCount = 0;

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/eventContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/eventContext.hpp
@@ -39,6 +39,7 @@ struct EventContext final
     std::shared_ptr<Utils::RocksDBWrapper> feedDatabase; ///< CVEs database.
     ResourceType resourceType;                           ///< Resource type.
     rocksdb::WriteBatch* writeBatch {nullptr};           ///< Optional write batch for deferred commit (non-owning).
+    bool initialLoad {false}; ///< Full initial load (empty feed DB): skip candidate read-before-write.
 };
 
 #endif // _EVENT_CONTEXT_HPP

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/eventDecoder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/eventDecoder.hpp
@@ -42,8 +42,6 @@ const static std::map<ResourceType, const char*> COLUMNS = {{ResourceType::CVE, 
 class EventDecoder final : public AbstractHandler<std::shared_ptr<EventContext>>
 {
 private:
-    // FlatBuffers parsers with schemas pre-loaded — reused across all documents in a page.
-    // Always called under DatabaseFeedManager::m_mutex so mutable without extra locking is safe.
     mutable flatbuffers::Parser m_cveCreateParser;
     mutable flatbuffers::Parser m_translationCreateParser;
     mutable flatbuffers::Parser m_cveUpdateParser;
@@ -111,19 +109,15 @@ private:
             {
                 if (!schema)
                 {
-                    // Resources in JSON format (payload is already a serialized string).
                     const auto& payloadStr = data->resource.at("payload").get_ref<const std::string&>();
                     if (data->writeBatch)
-                        data->feedDatabase->batchPut(*data->writeBatch,
-                                                     data->resource.at("resource"),
-                                                     payloadStr.c_str(),
-                                                     column);
+                        data->feedDatabase->batchPut(
+                            *data->writeBatch, data->resource.at("resource"), payloadStr.c_str(), column);
                     else
                         data->feedDatabase->put(data->resource.at("resource"), payloadStr.c_str(), column);
                 }
                 else
                 {
-                    // Resources in flatbuffer format. Reuse the cached parser (schema already loaded).
                     auto& parser = parserForCreate(data->resourceType);
                     parser.builder_.Clear();
 
@@ -190,7 +184,6 @@ private:
                             }
                             break;
                     }
-                    // Reuse the cached update parser (schema and IDLOptions pre-loaded).
                     auto& parser = parserForUpdate(data->resourceType);
                     parser.builder_.Clear();
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/eventDecoder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/eventDecoder.hpp
@@ -42,6 +42,23 @@ const static std::map<ResourceType, const char*> COLUMNS = {{ResourceType::CVE, 
 class EventDecoder final : public AbstractHandler<std::shared_ptr<EventContext>>
 {
 private:
+    // FlatBuffers parsers with schemas pre-loaded — reused across all documents in a page.
+    // Always called under DatabaseFeedManager::m_mutex so mutable without extra locking is safe.
+    mutable flatbuffers::Parser m_cveCreateParser;
+    mutable flatbuffers::Parser m_translationCreateParser;
+    mutable flatbuffers::Parser m_cveUpdateParser;
+    mutable flatbuffers::Parser m_translationUpdateParser;
+
+    flatbuffers::Parser& parserForCreate(ResourceType type) const
+    {
+        return (type == ResourceType::CVE) ? m_cveCreateParser : m_translationCreateParser;
+    }
+
+    flatbuffers::Parser& parserForUpdate(ResourceType type) const
+    {
+        return (type == ResourceType::CVE) ? m_cveUpdateParser : m_translationUpdateParser;
+    }
+
     /**
      * @brief Process a CVE5 or Translation message.
      *
@@ -94,22 +111,23 @@ private:
             {
                 if (!schema)
                 {
-                    // Resources in JSON format.
+                    // Resources in JSON format (payload is already a serialized string).
+                    const auto& payloadStr = data->resource.at("payload").get_ref<const std::string&>();
                     if (data->writeBatch)
                         data->feedDatabase->batchPut(*data->writeBatch,
                                                      data->resource.at("resource"),
-                                                     data->resource.at("payload").dump().c_str(),
+                                                     payloadStr.c_str(),
                                                      column);
                     else
-                        data->feedDatabase->put(
-                            data->resource.at("resource"), data->resource.at("payload").dump().c_str(), column);
+                        data->feedDatabase->put(data->resource.at("resource"), payloadStr.c_str(), column);
                 }
                 else
                 {
-                    // Resources in flatbuffer format.
-                    flatbuffers::Parser parser;
+                    // Resources in flatbuffer format. Reuse the cached parser (schema already loaded).
+                    auto& parser = parserForCreate(data->resourceType);
+                    parser.builder_.Clear();
 
-                    if (!parser.Parse(schema) || !parser.Parse(data->resource.at("payload").dump().c_str()))
+                    if (!parser.Parse(data->resource.at("payload").get_ref<const std::string&>().c_str()))
                     {
                         throw std::runtime_error("Unable to parse payload: " + parser.error_);
                     }
@@ -172,11 +190,9 @@ private:
                             }
                             break;
                     }
-                    flatbuffers::IDLOptions options;
-                    options.output_default_scalars_in_json = true;
-                    options.strict_json = true;
-                    flatbuffers::Parser parser(options);
-                    parser.Parse(schema);
+                    // Reuse the cached update parser (schema and IDLOptions pre-loaded).
+                    auto& parser = parserForUpdate(data->resourceType);
+                    parser.builder_.Clear();
 
                     std::string strData;
                     flatbuffers::GenText(parser, reinterpret_cast<const uint8_t*>(slice.data()), &strData);
@@ -229,6 +245,20 @@ private:
     }
 
 public:
+    EventDecoder()
+    {
+        m_cveCreateParser.Parse(cve5_SCHEMA);
+        m_translationCreateParser.Parse(packageTranslation_SCHEMA);
+
+        m_cveUpdateParser.opts.output_default_scalars_in_json = true;
+        m_cveUpdateParser.opts.strict_json = true;
+        m_cveUpdateParser.Parse(cve5_SCHEMA);
+
+        m_translationUpdateParser.opts.output_default_scalars_in_json = true;
+        m_translationUpdateParser.opts.strict_json = true;
+        m_translationUpdateParser.Parse(packageTranslation_SCHEMA);
+    }
+
     /**
      * @brief Handles request and passes control to the next step of the chain.
      *

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeModel.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/storeModel.hpp
@@ -62,7 +62,8 @@ public:
                         data->feedDatabase,
                         std::to_string(data->resource.at("offset").get<int>()),
                         data->writeBatch);
-                    UpdateCVECandidates::storeVulnerabilityCandidate(cve5Entry, data->feedDatabase, data->writeBatch);
+                    UpdateCVECandidates::storeVulnerabilityCandidate(
+                        cve5Entry, data->feedDatabase, data->writeBatch, data->initialLoad);
                 }
                 else if ("REJECTED" == state)
                 {
@@ -89,7 +90,8 @@ public:
                         data->feedDatabase,
                         std::to_string(data->resource.at("offset").get<int>()),
                         data->writeBatch);
-                    UpdateCVECandidates::storeVulnerabilityCandidate(cve5Entry, data->feedDatabase, data->writeBatch);
+                    UpdateCVECandidates::storeVulnerabilityCandidate(
+                        cve5Entry, data->feedDatabase, data->writeBatch, data->initialLoad);
                 }
             }
             else

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVECandidates.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVECandidates.hpp
@@ -39,7 +39,8 @@ public:
      */
     static void storeVulnerabilityCandidate(const cve_v5::Entry* cve5Flatbuffer,
                                             std::shared_ptr<Utils::RocksDBWrapper> feedDatabase,
-                                            rocksdb::WriteBatch* batch = nullptr)
+                                            rocksdb::WriteBatch* batch = nullptr,
+                                            const bool initialLoad = false)
     {
         if (!cve5Flatbuffer || !cve5Flatbuffer->containers())
         {
@@ -153,34 +154,33 @@ public:
 
             const auto CVE_PACKAGE_COLUMN_NAME = createPackageColumnName(shortName);
 
-            // Get all candidates stored in the database.
-            // If some of the candidates are already store, and is removed in the new feed, we need to remove it from
-            // the database.
-            const auto cveIdKey = cveId->str() + "_";
-            std::vector<std::pair<std::string, std::string>> previousCandidates;
-
-            for (const auto& [cvePackage, packageCve] : feedDatabase->seek(cveIdKey, CVE_PACKAGE_COLUMN_NAME))
+            if (!initialLoad)
             {
-                previousCandidates.emplace_back(packageCve.ToString(), cvePackage);
-            }
+                const auto cveIdKey = cveId->str() + "_";
+                std::vector<std::pair<std::string, std::string>> previousCandidates;
 
-            for (const auto& [packageCve, cvePackage] : previousCandidates)
-            {
-                // Remove _CVE-XXXX-XXXX from the key.
-                auto packageCandidate = packageCve;
-                Utils::replaceFirst(packageCandidate, std::string("_" + cveId->str()), "");
-
-                if (candidatesArraysMap.find(packageCandidate) == candidatesArraysMap.end())
+                for (const auto& [cvePackage, packageCve] : feedDatabase->seek(cveIdKey, CVE_PACKAGE_COLUMN_NAME))
                 {
-                    if (batch)
+                    previousCandidates.emplace_back(packageCve.ToString(), cvePackage);
+                }
+
+                for (const auto& [packageCve, cvePackage] : previousCandidates)
+                {
+                    auto packageCandidate = packageCve;
+                    Utils::replaceFirst(packageCandidate, std::string("_" + cveId->str()), "");
+
+                    if (candidatesArraysMap.find(packageCandidate) == candidatesArraysMap.end())
                     {
-                        feedDatabase->batchDelete(*batch, packageCve, shortName);
-                        feedDatabase->batchDelete(*batch, cvePackage, CVE_PACKAGE_COLUMN_NAME);
-                    }
-                    else
-                    {
-                        feedDatabase->delete_(packageCve, shortName);
-                        feedDatabase->delete_(cvePackage, CVE_PACKAGE_COLUMN_NAME);
+                        if (batch)
+                        {
+                            feedDatabase->batchDelete(*batch, packageCve, shortName);
+                            feedDatabase->batchDelete(*batch, cvePackage, CVE_PACKAGE_COLUMN_NAME);
+                        }
+                        else
+                        {
+                            feedDatabase->delete_(packageCve, shortName);
+                            feedDatabase->delete_(cvePackage, CVE_PACKAGE_COLUMN_NAME);
+                        }
                     }
                 }
             }
@@ -198,10 +198,16 @@ public:
                 const auto finalKey = key + "_" + cveId->str();
                 const auto reverseKey = cveId->str() + "_" + key;
 
-                if (rocksdb::PinnableSlice currentValueCandidate;
-                    !feedDatabase->get(finalKey, currentValueCandidate, shortName) ||
-                    currentValueCandidate.size() != slice.size() ||
-                    std::memcmp(currentValueCandidate.data(), slice.data(), slice.size()) != 0)
+                bool needsWrite = initialLoad;
+                if (!needsWrite)
+                {
+                    rocksdb::PinnableSlice currentValueCandidate;
+                    needsWrite = !feedDatabase->get(finalKey, currentValueCandidate, shortName) ||
+                                 currentValueCandidate.size() != slice.size() ||
+                                 std::memcmp(currentValueCandidate.data(), slice.data(), slice.size()) != 0;
+                }
+
+                if (needsWrite)
                 {
                     if (batch)
                     {

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -353,7 +353,7 @@ void VulnerabilityScannerFacade::start(
             }
             if (!indexerSubConfig.contains("pageSize"))
             {
-                indexerSubConfig["pageSize"] = static_cast<uint32_t>(std::stoul(vdConfig.value("pageSize", "250")));
+                indexerSubConfig["pageSize"] = static_cast<uint32_t>(std::stoul(vdConfig.value("pageSize", "100")));
             }
             if (!indexerSubConfig.contains("numSlices"))
             {

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -351,13 +351,53 @@ void VulnerabilityScannerFacade::start(
             {
                 indexerSubConfig["consumerStatusId"] = std::string {INDEXER_CONSUMER_STATUS_ID};
             }
+            const auto readPositiveSetting =
+                [&vdConfig](const char* key, uint32_t defaultValue, uint32_t maxValue) -> uint32_t
+            {
+                if (!vdConfig.contains(key))
+                {
+                    return defaultValue;
+                }
+
+                const auto& raw = vdConfig.at(key);
+                uint64_t value = 0;
+                if (raw.is_number_unsigned())
+                {
+                    value = raw.get<uint64_t>();
+                }
+                else if (raw.is_string())
+                {
+                    const auto& str = raw.get_ref<const std::string&>();
+                    if (str.empty() || str.size() > 10 || str.find_first_not_of("0123456789") != std::string::npos)
+                    {
+                        throw std::runtime_error(std::string("Invalid <") + key + "> value '" + str +
+                                                 "' in <vulnerability-detection>: must be a positive integer.");
+                    }
+                    value = std::stoull(str);
+                }
+                else
+                {
+                    throw std::runtime_error(std::string("Invalid <") + key +
+                                             "> in <vulnerability-detection>: must be a single positive integer "
+                                             "(is the tag duplicated?).");
+                }
+
+                if (value < 1 || value > maxValue)
+                {
+                    throw std::runtime_error(std::string("Invalid <") + key + "> value " + std::to_string(value) +
+                                             " in <vulnerability-detection>: must be between 1 and " +
+                                             std::to_string(maxValue) + ".");
+                }
+                return static_cast<uint32_t>(value);
+            };
+
             if (!indexerSubConfig.contains("pageSize"))
             {
-                indexerSubConfig["pageSize"] = static_cast<uint32_t>(std::stoul(vdConfig.value("pageSize", "100")));
+                indexerSubConfig["pageSize"] = readPositiveSetting("pageSize", 100, 10000);
             }
             if (!indexerSubConfig.contains("numSlices"))
             {
-                indexerSubConfig["numSlices"] = static_cast<uint32_t>(std::stoul(vdConfig.value("numSlices", "2")));
+                indexerSubConfig["numSlices"] = readPositiveSetting("numSlices", 2, 32);
             }
 
             return updaterConfig;

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/databaseFeedManager_test.cpp
@@ -1463,7 +1463,8 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, IndexerMessageTypeProcessesData)
         "cveMetadata": { "assignerOrgId": "test", "cveId": "CVE-2026-0001", "state": "PUBLISHED" },
         "dataType": "CVE_RECORD",
         "dataVersion": "5.0"
-    })");
+    })")
+                              .dump();
     indexerMsg["data"].push_back(resource);
 
     auto result = spDatabaseFeedManager->processMessage(std::move(indexerMsg), dbWrapper);
@@ -1509,4 +1510,70 @@ TEST_F(DatabaseFeedManagerMessageProcessorTest, IndexerMessageEmptyDataSucceeds)
 
     auto result = spDatabaseFeedManager->processMessage(std::move(indexerMessage), dbWrapper);
     EXPECT_TRUE(std::get<2>(result));
+}
+
+/**
+ * @brief A decoder failure mid-page must discard the accumulated cross-page batch state:
+ *        no entries from the failed cycle may leak into a later commit, and the manager
+ *        must be able to process a fresh cycle afterwards.
+ */
+TEST_F(DatabaseFeedManagerMessageProcessorTest, IndexerMessageDecoderFailureResetsBatchState)
+{
+    const auto databasePath =
+        std::string(DATABASE_PATH) + "/" + ::testing::UnitTest::GetInstance()->current_test_info()->name();
+    auto dbWrapper = std::make_shared<Utils::RocksDBWrapper>(databasePath);
+    std::shared_mutex mutex;
+    const auto updaterConfig = spPolicyManagerMock->getUpdaterConfiguration();
+    const auto translationLruSize = spPolicyManagerMock->getTranslationLRUSize();
+
+    auto spDatabaseFeedManager {
+        std::make_shared<TDatabaseFeedManager<TrampolineContentRegister>>(mutex, updaterConfig, translationLruSize)};
+    nlohmann::json badMsg;
+    badMsg["type"] = "indexer";
+    badMsg["cursor"] = "100";
+    badMsg["data"] = nlohmann::json::array();
+
+    nlohmann::json validResource;
+    validResource["offset"] = 100;
+    validResource["type"] = "create";
+    validResource["resource"] = "FEED-GLOBAL";
+    validResource["payload"] = R"({"vendor_map":{}})";
+    badMsg["data"].push_back(validResource);
+
+    nlohmann::json badResource;
+    badResource["offset"] = 101;
+    badResource["type"] = "create";
+    badResource["resource"] = "CVE-2026-0002";
+    badResource["payload"] = "this is not a parseable CVE5 document";
+    badMsg["data"].push_back(badResource);
+
+    EXPECT_THROW(spDatabaseFeedManager->processMessage(std::move(badMsg), dbWrapper), std::runtime_error);
+    nlohmann::json completeMsg = nlohmann::json::parse(R"({"type":"indexer_complete","cursor":"100","data":[]})");
+    auto completeResult = spDatabaseFeedManager->processMessage(std::move(completeMsg), dbWrapper);
+    EXPECT_TRUE(std::get<2>(completeResult));
+
+    std::string storedValue;
+    EXPECT_FALSE(dbWrapper->get("FEED-GLOBAL", storedValue, "vendor_map"))
+        << "Entry from the failed cycle leaked into the database";
+    nlohmann::json goodMsg;
+    goodMsg["type"] = "indexer";
+    goodMsg["cursor"] = "200";
+    goodMsg["data"] = nlohmann::json::array();
+
+    nlohmann::json freshResource;
+    freshResource["offset"] = 200;
+    freshResource["type"] = "create";
+    freshResource["resource"] = "FEED-GLOBAL";
+    freshResource["payload"] = R"({"vendor_map":{"fresh":true}})";
+    goodMsg["data"].push_back(freshResource);
+
+    auto goodResult = spDatabaseFeedManager->processMessage(std::move(goodMsg), dbWrapper);
+    EXPECT_TRUE(std::get<2>(goodResult));
+
+    nlohmann::json completeMsg2 = nlohmann::json::parse(R"({"type":"indexer_complete","cursor":"200","data":[]})");
+    auto completeResult2 = spDatabaseFeedManager->processMessage(std::move(completeMsg2), dbWrapper);
+    EXPECT_TRUE(std::get<2>(completeResult2));
+
+    EXPECT_TRUE(dbWrapper->get("FEED-GLOBAL", storedValue, "vendor_map"));
+    EXPECT_EQ(storedValue, R"({"vendor_map":{"fresh":true}})");
 }

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDecoder_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/eventDecoder_test.cpp
@@ -616,6 +616,7 @@ TEST_F(EventDecoderTest, TestCreatedResource)
 {
 
     auto jsonResource = nlohmann::json::parse(CREATED_RESOURCE);
+    jsonResource["payload"] = jsonResource.at("payload").dump();
     auto eventContext =
         std::make_shared<EventContext>(EventContext {.resource = jsonResource, .feedDatabase = m_feedDb});
 
@@ -643,7 +644,7 @@ TEST_F(EventDecoderTest, TestCreatedResource)
 
     std::string jsongen;
     flatbuffers::GenText(parser, reinterpret_cast<const uint8_t*>(slice.data()), &jsongen);
-    EXPECT_EQ(nlohmann::json::parse(jsongen), jsonResource.at("payload"));
+    EXPECT_EQ(nlohmann::json::parse(jsongen), nlohmann::json::parse(CREATED_RESOURCE).at("payload"));
 }
 
 /*
@@ -653,6 +654,7 @@ TEST_F(EventDecoderTest, TestCreatedTranslationResource)
 {
 
     auto jsonResource = nlohmann::json::parse(CREATE_TRANSLATION);
+    jsonResource["payload"] = jsonResource.at("payload").dump();
     auto eventContext =
         std::make_shared<EventContext>(EventContext {.resource = jsonResource, .feedDatabase = m_feedDb});
 
@@ -680,7 +682,7 @@ TEST_F(EventDecoderTest, TestCreatedTranslationResource)
 
     std::string jsongen;
     flatbuffers::GenText(parser, reinterpret_cast<const uint8_t*>(slice.data()), &jsongen);
-    EXPECT_EQ(nlohmann::json::parse(jsongen), jsonResource.at("payload"));
+    EXPECT_EQ(nlohmann::json::parse(jsongen), nlohmann::json::parse(CREATE_TRANSLATION).at("payload"));
 }
 
 /*
@@ -690,6 +692,7 @@ TEST_F(EventDecoderTest, TestUpdatedResource)
 {
 
     auto jsonResource = nlohmann::json::parse(CREATED_RESOURCE);
+    jsonResource["payload"] = jsonResource.at("payload").dump();
     auto eventContext =
         std::make_shared<EventContext>(EventContext {.resource = jsonResource, .feedDatabase = m_feedDb});
 
@@ -761,6 +764,7 @@ TEST_F(EventDecoderTest, TestUpdatedTranslationResource)
 {
 
     auto jsonResource = nlohmann::json::parse(CREATE_TRANSLATION);
+    jsonResource["payload"] = jsonResource.at("payload").dump();
     auto eventContext =
         std::make_shared<EventContext>(EventContext {.resource = jsonResource, .feedDatabase = m_feedDb});
 
@@ -830,6 +834,7 @@ TEST_F(EventDecoderTest, TestDeletedTranslationResource)
 {
 
     auto jsonResource = nlohmann::json::parse(CREATE_TRANSLATION);
+    jsonResource["payload"] = jsonResource.at("payload").dump();
     auto eventContext =
         std::make_shared<EventContext>(EventContext {.resource = jsonResource, .feedDatabase = m_feedDb});
 
@@ -877,6 +882,7 @@ TEST_F(EventDecoderTest, TestCreatedVendorMap)
 {
 
     auto jsonResource = nlohmann::json::parse(VENDOR_MAP);
+    jsonResource["payload"] = jsonResource.at("payload").dump();
     auto eventContext =
         std::make_shared<EventContext>(EventContext {.resource = jsonResource, .feedDatabase = m_feedDb});
 
@@ -902,6 +908,7 @@ TEST_F(EventDecoderTest, TestCreatedOscpeMap)
 {
 
     auto jsonResource = nlohmann::json::parse(OSCPE_MAP);
+    jsonResource["payload"] = jsonResource.at("payload").dump();
     auto eventContext =
         std::make_shared<EventContext>(EventContext {.resource = jsonResource, .feedDatabase = m_feedDb});
 
@@ -927,6 +934,7 @@ TEST_F(EventDecoderTest, TestCreatedCnaMapping)
 {
 
     auto jsonResource = nlohmann::json::parse(CNA_MAPPING_MAP);
+    jsonResource["payload"] = jsonResource.at("payload").dump();
     auto eventContext =
         std::make_shared<EventContext>(EventContext {.resource = jsonResource, .feedDatabase = m_feedDb});
 
@@ -989,6 +997,7 @@ TEST_F(EventDecoderTest, TestUpdatedVendorMap)
 {
 
     auto jsonResource = nlohmann::json::parse(VENDOR_MAP);
+    jsonResource["payload"] = jsonResource.at("payload").dump();
     auto eventContext =
         std::make_shared<EventContext>(EventContext {.resource = jsonResource, .feedDatabase = m_feedDb});
 
@@ -1050,6 +1059,7 @@ TEST_F(EventDecoderTest, DeleteCVERemovesFromDB)
 
     // First create the CVE.
     auto createResource = nlohmann::json::parse(CREATED_RESOURCE);
+    createResource["payload"] = createResource.at("payload").dump();
     auto createCtx =
         std::make_shared<EventContext>(EventContext {.resource = createResource, .feedDatabase = m_feedDb});
 


### PR DESCRIPTION
## Description

During the initial load of the vulnerability feed (VDP), the `wazuh-manager-modulesd` process
reached very high memory peaks while downloading and processing the ~250,000-350,000 CVE
documents from the `.wazuh-threatintel-vulnerabilities` index. That peak did not drop
significantly across previous point optimizations because its root cause, RocksDB's
internal memory Arena, fed by a shared `WriteBatch` with no size limit, had not been
identified or addressed.

This PR reduces the peak RSS measured during feed download from **1.57 GB** (5.0.0 baseline)
to **~530 MB** with the new `pageSize=100` default (see the comparison table below), with no
penalty to download time (it actually drops slightly, 4:56 → 4:04), and stabilizes the memory
consumption graph by eliminating isolated spikes that stood apart from the rest of the memory
profile.

Closes #37161

## Proposed Changes

### Indexer download path (`IndexerDownloader.hpp`)

- **Default `pageSize` changed from 250 to 100** documents per page, now validated between
  `1` and `10000` and guarded against a configured `0`, which would otherwise make every page come back empty and stall the load. Smaller pages reduce the transient in-memory peak of a fetched page at the cost of more HTTP round-trips.
- **Removed an unnecessary copy of the document** in `processPage`: `source` and `document`
  are now taken by reference and the payload is serialized directly, instead of first copying
  the whole subtree (`source.value("document", ...)`) before dumping it.
- **New `waitUntilGlobalMapsIndexed()` method**: before starting a full initial load, it polls (every 30s) a lightweight query to confirm the three global-map documents the local database needs (`FEED-GLOBAL`, `OSCPE-GLOBAL`, `CNA-MAPPING-GLOBAL`) are already indexed. Previously, a full load could run for minutes and then be discarded because these documents were missing, forcing a full re-download on the next cycle.
- **Periodic flush to disk every 250 pages** (instead of relying only on the final flush), and
  the resume cursor is now persisted only up to the last page that was actually part of a
  flushed batch, so a crash or `SIGKILL` mid-download can't leave a persisted cursor pointing
  past data that never made it to disk.
- **Sliced initial load no longer persists a partial cursor** when a slice is interrupted by a
  stop request; the next cycle re-does the full initial load instead of resuming from an
  unsafe, incomplete offset.

### FlatBuffers reuse and parsing (`eventDecoder.hpp`)

- **`flatbuffers::Parser` instances are now cached per resource type and operation** instead of being rebuilt, re-parsing ~7.6 KB of schema IDL, for each of the 250,000+ documents processed. The same parser is reused, clearing only its internal builder between documents.
- Payloads are now passed and parsed as an already-serialized string instead of being
  `dump()` again inside the decoder.

### Batched writes to RocksDB (`databaseFeedManager.hpp`)

- **The `WriteBatch` is now shared across pages** instead of being scoped to a single
  `processMessage` call, and it commits both by document count and by accumulated size, whichever comes first, instead of only at the end of each message. This bounds every single `Write()` call, regardless of how the Indexer batches documents into messages.
- **The batch's capacity is pre-reserved and reused** across commits, and only rebuilt when a
  single commit turns out abnormally large.
- **Batch and decoder state are reset on exception**, so a failure partway through a page can't
  leak a partially-built batch into the next processing cycle.
- **Skips the read-before-write check for CVE candidates during the initial load**: with an
  empty database there is nothing to compare against, so the `seek`+`get` used to detect
  stale/changed candidates is skipped entirely on first load.
- Read block cache size is now configurable; the feed database keeps 16 MB.

### RocksDB column family lookup (`rocksDBWrapper.hpp`)

- **O(1) column family lookup** via a new `unordered_map` index (`columnExists`,
  `getColumnFamilyBasedOnName`), replacing a linear scan over `m_columnsInstances`. With
  hundreds of per-CNA column families, that scan was the dominant per-document cost during the
  feed load.
- **New `readCacheSize` constructor parameter** on `TRocksDBWrapper`, so the block cache size
  no longer has to be hardcoded to 16 MB.

### Network resiliency (`indexerConnectorSyncImpl.hpp`)

- **HTTP 429 responses now retry with exponential backoff** (starting at
  the configured `RetryDelay`, doubling up to a 30s cap) instead of a fixed 1s delay, across
  bulk, bulk-chunk, delete-by-query, `executeSearchQuery` and PIT `search`.
- `executeSearchQuery` and PIT `search` now abort cleanly when a stop is requested instead of
  retrying indefinitely.

### Configuration validation (`vulnerabilityScannerFacade.cpp`)

- `pageSize` and `numSlices` are now validated through a shared helper that accepts numeric or
  string XML values and rejects `0` or out-of-range values with a clear error: `pageSize` in
  `[1, 10000]`, `numSlices` in `[1, 32]`.

### Tests

- New unit tests: HTTP 429 retry with backoff for `executeSearchQuery` and PIT `search`,
  batch-state reset in `databaseFeedManager` after a decoder failure mid-page, and
  payload-as-string coverage in the decoder tests.

### Other


## Optimizations at a glance

**Download (lower RAM peak)**
- Default `pageSize` 250 to 100 (configurable, validated 1-10000, guarded against 0): smaller pages -> less JSON in flight -> lower peak.
- Removed a document copy in `processPage`: `source`/`document` taken by reference and serialized directly instead of copying the subtree.

**Decoding (less CPU/churn)**
- `flatbuffers::Parser` cached per type (create/update × CVE/translation): schema parsed once, not per document.
- Skips the candidate read-before-write on initial load: an empty DB has nothing to compare against, so the useless `seek`+`get` is skipped.

**RocksDB (write/lookup)**
- O(1) column family index (`unordered_map`) instead of a linear scan -> removes the near-quadratic cost from load time.
- `WriteBatch` bounded by size (2 MB) and count (25), capacity pre-reserved and rebuilt only if it spikes -> no memtable insertion spikes.
- Configurable block cache (new `readCacheSize` param, kept at 16 MB).

**Durability (WAL disabled)**
- Periodic flush every 250 pages + cursor persisted only up to an already-flushed page -> no silent data loss on crash.
- Sliced initial load: no partial cursor persisted if interrupted -> doesn't degrade to an incomplete feed after a stop.
- Batch state reset on exception -> a failed cycle's writes don't leak into the next one.

**Network robustness**
- Pre-check of global maps in the Indexer (`waitUntilGlobalMapsIndexed`) before the full load -> avoids downloading for minutes only to discard it.
- 429 retry with exponential backoff (capped at 30s) on every search/bulk path, abortable on stop.

**Other**
- `jemalloc`: a `malloc_conf` tuning was tried and ultimately reverted (net: no change to `main.c`).
- Config + docs: `numSlices` validated (1-32); `pageSize`/`numSlices` documentation updated.
- Tests added: 429 retry, batch reset, and payload-as-string in the decoder.

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

#### Vulnerabilities

<details>
<summary>5.0.0</summary>

```
root@indexer2:/home/vagrant# curl -s -k -u admin:admin \
  -X GET "https://localhost:9200/wazuh-states-vulnerabilities/_count" \
  -H "Content-Type: application/json" \
  -d '{
    "query": {
      "term": { "wazuh.agent.id": "002" }
    }
  }'
{"count":3918,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0}}root@indexer2:/home/vagrant#

```

</details>

<details>
<summary> PR changes applied </summary>

```
root@manager:/home/vagrant# curl -s -k -u admin:admin \
  -X GET "https://localhost:9200/wazuh-states-vulnerabilities/_count" \
  -H "Content-Type: application/json" \
  -d '{
    "query": {
      "term": { "wazuh.agent.id": "001" }
    }
  }'
{"count":3918,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0}}

```

</details>

#### Comparison

- 5.0.0 (04:56 minutes downloading feed)

<img width="2883" height="1820" alt="image" src="https://github.com/user-attachments/assets/55f2c4fd-7fd3-4ce2-80e2-5932d387f6b3" />



- PageSize=50 (5:11 minutes downloading feed)

<img width="2595" height="1635" alt="image" src="https://github.com/user-attachments/assets/3b382d2b-86d3-41eb-ad72-29915cbb61e2" />




- PageSize=100 (4:04 minutes downloading feed)

<img width="2595" height="1635" alt="image" src="https://github.com/user-attachments/assets/5d533119-87eb-4736-b5af-24a0f2fcfbfd" />

- 1 thread PageSize=100  (4:07 minutes downloading feed)

<img width="2472" height="1566" alt="image" src="https://github.com/user-attachments/assets/a0420b09-9ed3-4c03-9329-a986a8d6dfef" />



- PageSize=150 (3:41 minutes downloading feed)

<img width="2595" height="1635" alt="image" src="https://github.com/user-attachments/assets/4cd93c67-c4ba-4f40-9399-494620ebaa83" />




- PageSize=200 (3:12 minutes downloading feed)

<img width="2595" height="1635" alt="image" src="https://github.com/user-attachments/assets/799d370d-02f1-4e38-83f4-b8ebec7f015a" />



- PageSize=250 (3:16 minutes downloading feed)

<img width="2595" height="1635" alt="image" src="https://github.com/user-attachments/assets/ec9a9f7a-e2aa-4310-b2aa-adee1643e01b" />

- All the graphs with my changes in one

<img width="2386" height="1597" alt="image" src="https://github.com/user-attachments/assets/683c99a1-455c-4661-9a62-6daf952c4863" />



 - All the graphs including the 5.0.0 branch

<img width="2386" height="1597" alt="image" src="https://github.com/user-attachments/assets/f46085ef-6947-4512-a8d3-5cafcd49bb79" />




| pageSize | Download real time | Peak CPU | Average CPU | Peak RSS | Average memory (only download) |
|---|---|---|---|---|---|
| **5.0.0 branch** | **04m 56s** | **202,0 %** | **143,8 %** | **1,57 G** | **719 M** |
| 50  | 5m 11s | 220,0 % | 78,5 % | 437 M | 223,8 M |
| 100 | 4m 04s | 227,0 % | 97,8 % | 532 M | 309,1 M |
| 100 1 thread | 4m 07s | 208,0 % | 95 % | 499 M | 296 M |
| 150 | 3m 41s | 222,0 % | 105,5 % | 620 M | 355,6 M |
| 200 | 3m 12s | 249,0 % | 121,8 % | 642 M | 385,8 M |
| 250 | 3m 16s | 231,0 % | 121,6 % | 782 M | 425,5 M |



## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
