### PR TITLE
fix(ci): correct S3 artifact run directory layout for 5.0.0

### DIFF
--- a/.github/actions/download_package/action.yml
+++ b/.github/actions/download_package/action.yml
@@ -10,7 +10,7 @@ description: >
 
 inputs:
   build_run_id:
-    description: "Run ID of the manager-multiples build that produced the package."
+    description: "Run ID of the build workflow that produced the package."
     required: true
   name_regexp:
     description: "Regexp the package name segment must match."
@@ -70,14 +70,14 @@ runs:
         SUBDIR: ${{ inputs.extract_into_name_subdir }}
       run: |
         set -euo pipefail
-        base="${BUCKET}/${REPO}/${PRODUCER_WF}"
+        base="${BUCKET}/${REPO}/${PRODUCER_WF}/${BUILD_RUN_ID}"
         mkdir -p "$DEST"
-        # The producer uploads each artifact at <repo>/<workflow>/<name>/artifacts_<run_id>.zip,
-        # so list the producer workflow's objects and keep those whose <name> segment matches
+        # The producer uploads each artifact at <repo>/<workflow>/<run_id>/<name>.zip,
+        # so list the producer run's objects and keep those whose <name> segment matches
         # the regexp for this build run (the package name carries a commit hash, so it can't be
         # addressed by exact name).
         keys="$(aws s3 ls "${base}/" --recursive | awk '{print $4}' \
-          | grep -E "/${PRODUCER_WF}/${NAME_RE}/artifacts_${BUILD_RUN_ID}\.zip$" || true)"
+          | grep -E "/${PRODUCER_WF}/${BUILD_RUN_ID}/${NAME_RE}(\.zip)?$" || true)"
         if [ -z "$keys" ]; then
           echo "::error::No artifact matching '${NAME_RE}' found in S3 for build run ${BUILD_RUN_ID} under ${base}/"
           exit 1
@@ -86,7 +86,9 @@ runs:
           [ -z "$key" ] && continue
           dest="$DEST"
           if [ "$SUBDIR" = "true" ]; then
-            name_seg="${key#*/${PRODUCER_WF}/}"; name_seg="${name_seg%%/*}"
+            name_seg="${key#*/${PRODUCER_WF}/${BUILD_RUN_ID}/}"
+            name_seg="${name_seg%%/*}"
+            name_seg="${name_seg%.zip}"
             dest="${DEST}/${name_seg}"
             mkdir -p "$dest"
           fi
@@ -116,13 +118,13 @@ runs:
         SUBDIR: ${{ inputs.extract_into_name_subdir }}
       run: |
         $ErrorActionPreference = "Stop"
-        $base = "$env:BUCKET/$env:REPO/$env:PRODUCER_WF"
+        $base = "$env:BUCKET/$env:REPO/$env:PRODUCER_WF/$env:BUILD_RUN_ID"
         New-Item -ItemType Directory -Force -Path $env:DEST | Out-Null
-        # The producer uploads each artifact at <repo>/<workflow>/<name>/artifacts_<run_id>.zip,
-        # so list the producer workflow's objects and keep those whose <name> segment matches
+        # The producer uploads each artifact at <repo>/<workflow>/<run_id>/<name>.zip,
+        # so list the producer run's objects and keep those whose <name> segment matches
         # the regexp for this build run (the package name carries a commit hash, so it can't be
         # addressed by exact name).
-        $pattern = "/$env:PRODUCER_WF/$env:NAME_RE/artifacts_$($env:BUILD_RUN_ID)\.zip$"
+        $pattern = "/$env:PRODUCER_WF/$env:BUILD_RUN_ID/$env:NAME_RE(\.zip)?$"
         $keys = aws s3 ls "$base/" --recursive |
           ForEach-Object { ($_.Trim() -split '\s+', 4)[3] } |
           Where-Object { $_ -match $pattern }
@@ -133,7 +135,7 @@ runs:
           if ([string]::IsNullOrWhiteSpace($key)) { continue }
           $dest = $env:DEST
           if ($env:SUBDIR -eq 'true') {
-            $nameSeg = ($key -replace ".*/$env:PRODUCER_WF/([^/]+)/artifacts_.*", '$1')
+            $nameSeg = ($key -replace ".*/$env:PRODUCER_WF/$env:BUILD_RUN_ID/([^/]+)$", '$1') -replace '\.zip$', ''
             $dest = Join-Path $env:DEST $nameSeg
             New-Item -ItemType Directory -Force -Path $dest | Out-Null
           }

--- a/.github/actions/download_s3_artifact/action.yml
+++ b/.github/actions/download_s3_artifact/action.yml
@@ -4,7 +4,7 @@ description: >
   the internal CI S3 bucket (passed via the CI_INTERNAL_S3_BUCKET secret) instead of GitHub artifact storage
   (see https://github.com/wazuh/wazuh-automation/issues/3502).
   Downloads and extracts the archive previously uploaded by upload_s3_artifact from:
-    <bucket>/<repository>/<workflow>/<name>/artifacts_<run_id>.zip
+    <bucket>/<repository>/<workflow>/<run_id>/<name>.zip
   AWS credentials are configured by the action itself via OIDC, so the calling
   job only needs `permissions: id-token: write`. Pass the region via the
   `aws_region` input (set it to the CI_AWS_REGION secret at the call site).
@@ -51,7 +51,7 @@ runs:
         wf="${wf_file%.*}"
         # Make the artifact name safe for use as a single S3 key segment
         safe_name="$(printf '%s' "$ARTIFACT_NAME" | tr ' /\\:' '____')"
-        echo "s3_uri=${BUCKET}/${REPO_NAME}/${wf}/${safe_name}/artifacts_${RUN_ID}.zip" >> "$GITHUB_OUTPUT"
+        echo "s3_uri=${BUCKET}/${REPO_NAME}/${wf}/${RUN_ID}/${safe_name}.zip" >> "$GITHUB_OUTPUT"
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v6

--- a/.github/actions/upload_s3_artifact/action.yml
+++ b/.github/actions/upload_s3_artifact/action.yml
@@ -4,7 +4,7 @@ description: >
   internal CI S3 bucket (passed via the CI_INTERNAL_S3_BUCKET secret) instead of GitHub artifact storage
   (see https://github.com/wazuh/wazuh-automation/issues/3502).
   The artifact is archived with 7-Zip and uploaded to:
-    <bucket>/<repository>/<workflow>/<name>/artifacts_<run_id>.zip
+    <bucket>/<repository>/<workflow>/<run_id>/<name>.zip
   AWS credentials are configured by the action itself via OIDC, so the calling
   job only needs `permissions: id-token: write`. Pass the region via the
   `aws_region` input (set it to the CI_AWS_REGION secret at the call site).
@@ -34,7 +34,14 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: "Skip empty artifact upload"
+      if: ${{ inputs.name == '' || inputs.path == '' }}
+      shell: bash
+      run: |
+        echo "::warning::Skipping S3 artifact upload because name or path is empty."
+
     - name: "Resolve S3 key for ${{ inputs.name }}"
+      if: ${{ inputs.name != '' && inputs.path != '' }}
       id: key
       shell: bash
       env:
@@ -51,16 +58,17 @@ runs:
         wf="${wf_file%.*}"
         # Make the artifact name safe for use as a single S3 key segment
         safe_name="$(printf '%s' "$ARTIFACT_NAME" | tr ' /\\:' '____')"
-        echo "s3_uri=${BUCKET}/${REPO_NAME}/${wf}/${safe_name}/artifacts_${RUN_ID}.zip" >> "$GITHUB_OUTPUT"
+        echo "s3_uri=${BUCKET}/${REPO_NAME}/${wf}/${RUN_ID}/${safe_name}.zip" >> "$GITHUB_OUTPUT"
 
     - name: Configure AWS credentials
+      if: ${{ inputs.name != '' && inputs.path != '' }}
       uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.aws_role }}
         aws-region: ${{ inputs.aws_region }}
 
     - name: "Upload ${{ inputs.name }} to S3 (Unix)"
-      if: runner.os != 'Windows'
+      if: ${{ inputs.name != '' && inputs.path != '' && runner.os != 'Windows' }}
       shell: bash
       env:
         ARTIFACT_NAME: ${{ inputs.name }}
@@ -126,7 +134,7 @@ runs:
         echo "Uploaded artifact '${ARTIFACT_NAME}' to ${S3_URI}"
 
     - name: "Upload ${{ inputs.name }} to S3 (Windows)"
-      if: runner.os == 'Windows'
+      if: ${{ inputs.name != '' && inputs.path != '' && runner.os == 'Windows' }}
       shell: pwsh
       env:
         ARTIFACT_NAME: ${{ inputs.name }}

--- a/.github/workflows/5_builderpackage_agent-linux.yml
+++ b/.github/workflows/5_builderpackage_agent-linux.yml
@@ -9,6 +9,8 @@ on:
       - "packages/**"
       - "ruleset/**"
       - ".github/actions/check_files/**"
+      - ".github/actions/upload_s3_artifact/**"
+      - ".github/actions/download_package/**"
       - ".github/workflows/5_builderpackage_agent-linux.yml"
       - ".github/workflows/5_testintegration_agent-start.yml"
       - ".github/workflows/5_testintegration_linux-integration-tests.yml"

--- a/.github/workflows/5_builderpackage_agent-windows.yml
+++ b/.github/workflows/5_builderpackage_agent-windows.yml
@@ -9,6 +9,8 @@ on:
       - "packages/**"
       - "ruleset/**"
       - ".github/actions/check_files/**"
+      - ".github/actions/upload_s3_artifact/**"
+      - ".github/actions/download_s3_artifact/**"
       - ".github/workflows/5_builderpackage_agent-windows.yml"
       - ".github/workflows/5_testintegration_agent-start.yml"
       - ".github/test_modules_windows.json"


### PR DESCRIPTION
## Description

Fixes the CI S3 artifact path introduced by the GitHub artifact migration for the `5.0.0` branch.

The parent issue requires artifact objects to be grouped by workflow run:

```text
s3://xdrsiem-ci-dev-internal/{repo-name}/{workflow-name}/{workflow_id}/{artifact}
```

The implementation used `<repo>/<workflow>/<artifact>/artifacts_<run_id>.zip`, which missed the `workflow_id` directory and made manual-dispatch/cross-run artifact downloads look in the wrong place.

Related to wazuh/wazuh-automation#3502.

## Proposed Changes

- Update `upload_s3_artifact` to upload archives to `<bucket>/<repo>/<workflow>/<run_id>/<artifact>.zip`.
- Update `download_s3_artifact` to resolve the same run-scoped path.
- Update `download_package` so manual-dispatch and cross-run downloads list under the selected `build_run_id` directory and match artifact object names there.
- Keep current archive/extraction behavior unchanged.

### Results and Evidence

- YAML parsed successfully for:
  - `.github/actions/upload_s3_artifact/action.yml`
  - `.github/actions/download_s3_artifact/action.yml`
  - `.github/actions/download_package/action.yml`
- `git diff --check` passed.
- A stale-layout scan returned no matches for `artifacts_<run_id>` / `/artifacts_` in `.github/actions` and `.github/workflows`.
- Regex checks passed for representative package and externals object keys under `<workflow>/<run_id>/`.

### Manual tests with their corresponding evidence

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

N/A for compilation, memory, decoder/rule, engine runtime, and API/framework checks. This PR only changes GitHub composite action path resolution.

### Artifacts Affected

- CI artifacts uploaded through `.github/actions/upload_s3_artifact`.
- CI artifacts downloaded through `.github/actions/download_s3_artifact`.
- Package artifacts downloaded through `.github/actions/download_package`.

### Configuration Changes

N/A. No user-facing configuration changes. The S3 object layout changes from `<repo>/<workflow>/<artifact>/artifacts_<run_id>.zip` to `<repo>/<workflow>/<run_id>/<artifact>.zip`.

### Tests Introduced

N/A. No repository tests were added; validation was limited to YAML parsing, diff whitespace checks, stale-layout scans, and representative key-matching checks.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
