### PR TITLE
fix: close SCA and FIM sync protocol databases on graceful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ All notable changes to this project will be documented in this file.
 - Honored the shutdown signal in `agent-upgrade` `StartMQ` to avoid timeout warning on agent stop. ([#36092](https://github.com/wazuh/wazuh/issues/36092))
 - Adjusted DockerListener messages as log entries to fix event categorization. ([#36126](https://github.com/wazuh/wazuh/issues/36126))
 - Dropped orphan paths before promoting on agent startup to fix FIM. ([#36134](https://github.com/wazuh/wazuh/issues/36134))
+- Closed the SCA and FIM synchronization databases cleanly on graceful shutdown, so stopping the agent no longer leaves stale SQLite `-wal`/`-shm` files behind. ([#37334](https://github.com/wazuh/wazuh/issues/37334))
 
 ## Prior versions
 

--- a/src/syscheckd/src/main.c
+++ b/src/syscheckd/src/main.c
@@ -44,6 +44,8 @@ __attribute__((noreturn)) static void help_syscheckd()
 
 extern bool is_fim_shutdown;
 extern volatile int fim_sync_module_running;
+extern pthread_t fim_sync_thread;
+extern bool fim_sync_thread_initialized;
 
 /* Shut down syscheckd properly */
 static void fim_shutdown(int sig)
@@ -57,6 +59,25 @@ static void fim_shutdown(int sig)
     if (syscheck.sync_handle)
     {
         asp_stop(syscheck.sync_handle);
+    }
+
+    /* Wait for the inventory synchronization thread to exit, then destroy the sync
+     * protocol handle so its SQLite connection to fim_sync.db is closed cleanly
+     * (checkpointing and removing the -wal/-shm files) instead of being leaked
+     * (issue #37334). The loop reacts to fim_sync_module_running within a second and
+     * asp_stop() aborts any in-flight synchronization, so the join is short. It cannot
+     * self-deadlock: fim_run_integrity blocks the signals this handler is registered
+     * for, so the handler never runs on that thread. */
+    if (fim_sync_thread_initialized)
+    {
+        fim_sync_thread_initialized = false;
+        pthread_join(fim_sync_thread, NULL);
+    }
+
+    if (syscheck.sync_handle)
+    {
+        asp_destroy(syscheck.sync_handle);
+        syscheck.sync_handle = NULL;
     }
 
     fim_db_teardown();

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -59,6 +59,15 @@ void audit_set_db_consistency(void);
 // Global flag to stop sync module
 volatile int fim_sync_module_running = 0;
 
+#ifndef WIN32
+// Handle to the FIM inventory synchronization thread. Kept joinable (issue #37334) so
+// fim_shutdown() can wait for it to exit before destroying the sync protocol handle,
+// letting its SQLite connection to fim_sync.db close cleanly (checkpoint + removal of
+// the -wal/-shm files) instead of leaking it on a graceful stop.
+pthread_t fim_sync_thread;
+bool fim_sync_thread_initialized = false;
+#endif
+
 // Flush on-demand synchronization variables (thread-safe with atomic operations)
 atomic_int_t fim_flush_in_progress = ATOMIC_INT_INITIALIZER(0);  // 0 = idle, 1 = flush active
 atomic_int_t fim_flush_result = ATOMIC_INT_INITIALIZER(0);       // 0 = success, -1 = error
@@ -655,8 +664,14 @@ void start_daemon()
 
     if (syscheck.enable_synchronization) {
         fim_sync_module_running = 1;
-        // Launch inventory synchronization thread
-        w_create_thread(fim_run_integrity, NULL);
+        // Launch the inventory synchronization thread as joinable so fim_shutdown() can
+        // wait for it before destroying the sync protocol handle (issue #37334).
+        if (CreateThreadJoinable(&fim_sync_thread, fim_run_integrity, NULL) != 0) {
+            merror(THREAD_ERROR);
+            fim_sync_module_running = 0;
+        } else {
+            fim_sync_thread_initialized = true;
+        }
     } else {
         mdebug1("FIM inventory synchronization is disabled");
     }
@@ -906,6 +921,18 @@ void * fim_run_realtime(__attribute__((unused)) void * args) {
 DWORD WINAPI fim_run_integrity(__attribute__((unused)) void * args) {
 #else
 void * fim_run_integrity(__attribute__((unused)) void * args) {
+#endif
+#ifndef WIN32
+    // Block the termination signals handled by fim_shutdown() in this thread, so the
+    // handler can never run on the very thread it joins (self-join deadlock). The signals
+    // keep being delivered to the other threads (issue #37334).
+    sigset_t fim_sync_sigmask;
+    sigemptyset(&fim_sync_sigmask);
+    sigaddset(&fim_sync_sigmask, SIGTERM);
+    sigaddset(&fim_sync_sigmask, SIGINT);
+    sigaddset(&fim_sync_sigmask, SIGQUIT);
+    sigaddset(&fim_sync_sigmask, SIGALRM);
+    pthread_sigmask(SIG_BLOCK, &fim_sync_sigmask, NULL);
 #endif
     bool first_sync_completed = fim_db_get_last_sync_time(FIM_FIRST_SYNC_COMPLETED_METADATA_KEY) > 0;
     bool skip_initial_wait = !first_sync_completed;

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -364,6 +364,15 @@ void SecurityConfigurationAssessment::releaseResources()
     // Must be called only after the sync worker thread has been joined, because
     // synchronizeDatabaseSnapshot() uses m_dBSync without holding any mutex.
     m_dBSync.reset();
+
+    // Destroy the flush controller and the sync protocol so their SQLite connection to
+    // sca_sync.db is closed (sqlite3_close_v2 on last close checkpoints the WAL and removes
+    // the -wal/-shm files). Stop() only signals the workers; without this the connection is
+    // leaked and a graceful stop leaves stale WAL files behind (issue #37334). Safe here:
+    // the sync worker thread and the SCA run loop have already exited (see wm_sca_start
+    // teardown), mirroring Syscollector::releaseResources().
+    m_asyncFlushController.reset();
+    m_spSyncProtocol.reset();
 }
 
 void SecurityConfigurationAssessment::Stop()


### PR DESCRIPTION
## Description

Closes the SCA and FIM synchronization databases cleanly on a graceful agent shutdown. This is the `-wal`/`-shm` leftover reported in #37334.

## Analysis

On a graceful stop, every stopped agent leaves stale SQLite sidecar files behind:

| database | leftover after graceful stop | cause |
|---|---|---|
| `queue/fim/db/fim_sync.db` | `-wal` (multi-MB, un-checkpointed) + `-shm` | sync protocol handle never destroyed; the sync thread is detached so shutdown has nothing to wait on |
| `queue/sca/db/sca_sync.db` | `-wal` + `-shm` | `releaseResources()` resets only `m_dBSync`; the sync protocol and flush controller leak |
| `queue/syscollector/db/*_sync.db` | none | **reference behavior** — `Syscollector::releaseResources()` resets every handle, so the last close checkpoints the WAL and removes the sidecars |

A leaked connection means the process exits without SQLite's last-close cleanup (`sqlite3_close_v2` checkpoints the WAL and removes `-wal`/`-shm`). The WAL replays on the next open, so this is not by itself data loss, but it leaves multi-megabyte artifacts on every stop, reads as corruption in the field, and unclean local DB state is exactly what arms the re-sync loss fixed in #37352.

## Proposed changes

- **SCA** (`sca_impl.cpp`): `releaseResources()` also resets `m_asyncFlushController` and `m_spSyncProtocol`, mirroring syscollector. Safe at that point: `wm_sca_start()` joins the sync worker before releasing resources.
- **FIM** (`run_check.c`, `main.c`): the inventory synchronization thread is created **joinable**; `fim_shutdown()` joins it after `asp_stop()` and then destroys the sync protocol handle (`asp_destroy`). The join is bounded — the worker polls the stop flag every second and `asp_stop()` aborts an in-flight synchronization.
- **Signal safety**: `fim_run_integrity` blocks the signals `fim_shutdown()` is registered for (SIGTERM/INT/QUIT/ALRM), so the handler can never run on the very thread it joins (no self-join deadlock).
- Unix-only, `#ifndef WIN32`-guarded (the Windows agent has no `fim_shutdown` signal path).

## Verification

Built the agent from this branch (5.0.0, arm64 container) and ran 6 consecutive graceful stop/start cycles against a beta3 manager:

```
before fix (stock beta3): 5 leftover files on every stop
  fim_sync.db-wal (4.1 MB), fim_sync.db-shm, sca_sync.db-wal, sca_sync.db-shm, sca.db-journal

after fix: 6/6 cycles
  wal-files-while-running=4 -> leftovers after stop = 0
  stop latency 2-3 s (join adds nothing measurable)
  agent healthy after every restart (5 daemons, 0 log errors), synchronization works
```

## Notes

- Related to #37334; the empty-SCA-dashboard part of that investigation is addressed separately in #37352 (manager-side re-sync version conflict) — this PR is the shutdown-hygiene half.
- `main` has the same shutdown behavior and needs the same change.
