### PR TITLE
Update 0999-malicious-ioc-rules.xml

### DIFF
--- a/ruleset/rules/0999-malicious-ioc-rules.xml
+++ b/ruleset/rules/0999-malicious-ioc-rules.xml
@@ -37,15 +37,16 @@
     <if_sid>5715</if_sid>
     <list field="srcip" lookup="match_key">etc/lists/malicious-ioc/malicious-ip</list>
     <description>sshd: Authentication succeeded from a malicious IP address $(srcip).</description>
-    <group>authentication_failed,authentication_success,pci_dss_10.2.4,pci_dss_10.2.5,</group>
+    <group>authentication_success,pci_dss_10.2.4,pci_dss_10.2.5,</group>
   </rule>
 
   <rule id="99904" level="9">
     <if_sid>5716</if_sid>
-  <list field="srcip" lookup="match_key">etc/lists/malicious-ioc/malicious-ip</list>
+    <list field="srcip" lookup="match_key">etc/lists/malicious-ioc/malicious-ip</list>
     <description>sshd: Authentication failed from a malicious IP address $(srcip).</description>
-    <group>authentication_failed,authentication_success,pci_dss_10.2.4,pci_dss_10.2.5,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
   </rule>
+  
 </group>
 
 <group name="web,accesslog,">


### PR DESCRIPTION
|Wazuh version| Component | Action type |
|---| --- | --- |
| 4.13.0 - 4.14.5 | Rules | Improve |

## Description
Default rules `99903` and `99904` in `0999-malicious-ioc-rules.xml` are assigned to both the `authentication_success` and `authentication_failed` rule groups.

This mapping is incorrect because:
- Rule `99903` detects a successful SSH authentication from a malicious IP address and should only belong to `authentication_success`.
- Rule `99904` detects a failed SSH authentication from a malicious IP address and should only belong to `authentication_failed`.

The incorrect group assignments affect rule analysis and dashboard visualizations. For example, rule `99904` can appear in the Authentication success visualization because it contains the `authentication_success` group, even though the rule represents a failed authentication attempt.

The issue appears to have been present since Wazuh `4.13.0` and is still present in `4.14.5`.

### Current results
Both rules are assigned to both authentication groups:
```bash
<group name="syslog,sshd,">

  <rule id="99903" level="14">
    <if_sid>5715</if_sid>
    <list field="srcip" lookup="match_key">etc/lists/malicious-ioc/malicious-ip</list>
    <description>sshd: Authentication succeeded from a malicious IP address $(srcip).</description>
    <group>authentication_failed,authentication_success,pci_dss_10.2.4,pci_dss_10.2.5,</group>
  </rule>

  <rule id="99904" level="9">
    <if_sid>5716</if_sid>
  <list field="srcip" lookup="match_key">etc/lists/malicious-ioc/malicious-ip</list>
    <description>sshd: Authentication failed from a malicious IP address $(srcip).</description>
    <group>authentication_failed,authentication_success,pci_dss_10.2.4,pci_dss_10.2.5,</group>
  </rule>
</group>
```

### Expected results
Each rule should be assigned only to the authentication group that matches the event it detects:
```bash
<group name="syslog,sshd,">

  <rule id="99903" level="14">
    <if_sid>5715</if_sid>
    <list field="srcip" lookup="match_key">etc/lists/malicious-ioc/malicious-ip</list>
    <description>sshd: Authentication succeeded from a malicious IP address $(srcip).</description>
    <group>authentication_success,pci_dss_10.2.4,pci_dss_10.2.5,</group>
  </rule>

  <rule id="99904" level="9">
    <if_sid>5716</if_sid>
  <list field="srcip" lookup="match_key">etc/lists/malicious-ioc/malicious-ip</list>
    <description>sshd: Authentication failed from a malicious IP address $(srcip).</description>
    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
  </rule>
</group>
```

## Impact
The incorrect rule-group mapping can cause:
- Failed authentication alerts to appear in authentication-success visualizations.
- Successful authentication alerts to appear in authentication-failure visualizations.
- Incorrect alert counts on the Wazuh dashboard.
- Misleading authentication statistics and reports.
- Inaccurate queries or integrations that filter alerts using rule.groups.

## Proposed fix
Update the rule groups as follows:
- Remove `authentication_failed` from rule `99903`.
- Remove `authentication_success` from rule `99904`.

## Resources
Wazuh 4.13.0 ruleset file: https://github.com/wazuh/wazuh/blob/v4.13.0/ruleset/rules/0999-malicious-ioc-rules.xml
Related community issue: https://github.com/wazuh/community/issues/65361

<img width="1747" height="917" alt="Image" src="https://github.com/user-attachments/assets/9b97825a-e624-44f7-bbd6-358c2d38e4c4" />
