### PR TITLE
Resolve logging macro collisions and improve LogFn design (#37354)

### DIFF
--- a/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
+++ b/src/shared_modules/content_manager/src/components/IndexerDownloader.hpp
@@ -982,10 +982,10 @@ private:
         std::mutex errorsMutex;
         std::atomic<bool> interrupted {false};
 
-        logInfo(WM_CONTENTUPDATER,
-                "IndexerDownloader: Starting sliced PIT download with %zu slices, pageSize=%zu",
-                numSlices,
-                pageSize);
+        logDebug1(WM_CONTENTUPDATER,
+                  "IndexerDownloader: Starting sliced PIT download with %zu slices, pageSize=%zu",
+                  numSlices,
+                  pageSize);
 
         auto sliceWorker = [&](size_t sliceId)
         {

--- a/src/shared_modules/indexer_connector/src/indexerConnectorAsyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorAsyncImpl.hpp
@@ -190,12 +190,12 @@ public:
         {
             username = "wazuh-manager";
             password = "wazuh-manager";
-            LOG_WARN(m_logFn, "No username and password found in the keystore, using default values.");
+            LOGFN_WARN(m_logFn, "No username and password found in the keystore, using default values.");
         }
         if (username.empty())
         {
             username = "wazuh-manager";
-            LOG_WARN(m_logFn, "No username found in the keystore, using default value.");
+            LOGFN_WARN(m_logFn, "No username found in the keystore, using default value.");
         }
         m_secureCommunication = SecureCommunication::builder();
         m_secureCommunication.basicAuth(username + ":" + password)
@@ -232,7 +232,7 @@ public:
                 if (auto parseResult = parser.parse(data.m_response).get(parsedResponse);
                     parseResult != simdjson::SUCCESS)
                 {
-                    LOG_DEBUG2(m_logFn, "Failed to parse the indexer response %s", data.m_response.c_str());
+                    LOGFN_DEBUG2(m_logFn, "Failed to parse the indexer response %s", data.m_response.c_str());
                     return;
                 }
 
@@ -254,10 +254,10 @@ public:
                 const size_t itemsSize = itemsArray.size();
                 if (data.m_boundaries.size() != itemsSize)
                 {
-                    LOG_WARN(m_logFn,
-                             "Mismatch between the number of events (%zu) and response items (%zu)",
-                             data.m_boundaries.size(),
-                             itemsSize);
+                    LOGFN_WARN(m_logFn,
+                               "Mismatch between the number of events (%zu) and response items (%zu)",
+                               data.m_boundaries.size(),
+                               itemsSize);
                     return;
                 }
 
@@ -339,30 +339,30 @@ public:
                     // Build error message with caused_by info if available
                     if (!causedByReason.empty() && !causedByType.empty())
                     {
-                        LOG_WARN(m_logFn,
-                                 "Error indexing document (type %.*s - reason: '%.*s' - caused by: %.*s - '%.*s') - "
-                                 "Associated event: %.*s",
-                                 static_cast<int>(errorType.size()),
-                                 errorType.data(),
-                                 static_cast<int>(errorReason.size()),
-                                 errorReason.data(),
-                                 static_cast<int>(causedByType.size()),
-                                 causedByType.data(),
-                                 static_cast<int>(causedByReason.size()),
-                                 causedByReason.data(),
-                                 static_cast<int>(payload.size()),
-                                 payload.data());
+                        LOGFN_WARN(m_logFn,
+                                   "Error indexing document (type %.*s - reason: '%.*s' - caused by: %.*s - '%.*s') - "
+                                   "Associated event: %.*s",
+                                   static_cast<int>(errorType.size()),
+                                   errorType.data(),
+                                   static_cast<int>(errorReason.size()),
+                                   errorReason.data(),
+                                   static_cast<int>(causedByType.size()),
+                                   causedByType.data(),
+                                   static_cast<int>(causedByReason.size()),
+                                   causedByReason.data(),
+                                   static_cast<int>(payload.size()),
+                                   payload.data());
                     }
                     else
                     {
-                        LOG_WARN(m_logFn,
-                                 "Error indexing document (type %.*s - reason: '%.*s') - Associated event: %.*s",
-                                 static_cast<int>(errorType.size()),
-                                 errorType.data(),
-                                 static_cast<int>(errorReason.size()),
-                                 errorReason.data(),
-                                 static_cast<int>(payload.size()),
-                                 payload.data());
+                        LOGFN_WARN(m_logFn,
+                                   "Error indexing document (type %.*s - reason: '%.*s') - Associated event: %.*s",
+                                   static_cast<int>(errorType.size()),
+                                   errorType.data(),
+                                   static_cast<int>(errorReason.size()),
+                                   errorReason.data(),
+                                   static_cast<int>(payload.size()),
+                                   payload.data());
                     }
 
                     ++itemIndex;
@@ -374,7 +374,7 @@ public:
             {
                 if (m_stopping.load())
                 {
-                    LOG_DEBUG2(m_logFn, "IndexerConnector is stopping, event processing will be skipped.");
+                    LOGFN_DEBUG2(m_logFn, "IndexerConnector is stopping, event processing will be skipped.");
                     throw IndexerConnectorException("IndexerConnector is stopping, event processing will be skipped.");
                 }
 
@@ -395,7 +395,7 @@ public:
                 {
                     if (m_queue->bulkMaxBytes() != m_bulkMaxBytes && m_successCount == MaxSuccessCount)
                     {
-                        LOG_DEBUG2(m_logFn, "Resetting bulk max bytes to %zu.", m_bulkMaxBytes);
+                        LOGFN_DEBUG2(m_logFn, "Resetting bulk max bytes to %zu.", m_bulkMaxBytes);
                         m_queue->bulkMaxBytes(m_bulkMaxBytes);
                         m_error413Logged = false;
                     }
@@ -415,7 +415,7 @@ public:
                     if (statusCode == HTTP_CONTENT_LENGTH)
                     {
                         constexpr size_t MINIMAL_BULK_BYTES {4096};
-                        LOG_DEBUG2(m_logFn, "Received 413 error (Payload Too Large). Reducing bulk threshold.");
+                        LOGFN_DEBUG2(m_logFn, "Received 413 error (Payload Too Large). Reducing bulk threshold.");
                         const auto currentBulkMax = m_queue->bulkMaxBytes();
                         const auto halved = currentBulkMax / 2;
 
@@ -428,19 +428,19 @@ public:
                             if (!m_error413Logged)
                             {
                                 m_error413Logged = true;
-                                LOG_ERROR(m_logFn,
-                                          "Bulk threshold too small to halve further (%zu bytes). "
-                                          "Review 'http.max_content_length' in wazuh-indexer settings. "
-                                          "Current payload size: %zu bytes. Discarding this batch.",
-                                          currentBulkMax,
-                                          bulkData.size());
+                                LOGFN_ERROR(m_logFn,
+                                            "Bulk threshold too small to halve further (%zu bytes). "
+                                            "Review 'http.max_content_length' in wazuh-indexer settings. "
+                                            "Current payload size: %zu bytes. Discarding this batch.",
+                                            currentBulkMax,
+                                            bulkData.size());
                             }
                             // Do not throw, avoid infinite retry loop. Drop this batch and continue with the next.
                             return;
                         }
                         else
                         {
-                            LOG_DEBUG2(m_logFn, "Reducing bulk max bytes from %zu to %zu.", currentBulkMax, halved);
+                            LOGFN_DEBUG2(m_logFn, "Reducing bulk max bytes from %zu to %zu.", currentBulkMax, halved);
                             this->m_queue->bulkMaxBytes(halved);
                             m_successCount = 0;
                             throw IndexerConnectorException("Bulk payload too large, reducing threshold.");
@@ -448,24 +448,24 @@ public:
                     }
                     else if (statusCode == HTTP_VERSION_CONFLICT)
                     {
-                        LOG_DEBUG2(m_logFn, "Document version conflict, retrying in 1 second.");
+                        LOGFN_DEBUG2(m_logFn, "Document version conflict, retrying in 1 second.");
                         throw IndexerConnectorException(error);
                     }
                     else if (statusCode == HTTP_TOO_MANY_REQUESTS)
                     {
-                        LOG_DEBUG2(m_logFn, "Too many requests, retrying in 1 second.");
+                        LOGFN_DEBUG2(m_logFn, "Too many requests, retrying in 1 second.");
                         throw IndexerConnectorException(error);
                     }
                     else
                     {
-                        LOG_ERROR(m_logFn, "%s, status code: %ld.", error.c_str(), statusCode);
+                        LOGFN_ERROR(m_logFn, "%s, status code: %ld.", error.c_str(), statusCode);
                     }
                 };
 
                 std::string url;
                 url = m_selector->getNext();
                 url += "/_bulk";
-                LOG_DEBUG2(m_logFn, "Bulk data: %s", bulkData.c_str());
+                LOGFN_DEBUG2(m_logFn, "Bulk data: %s", bulkData.c_str());
 
                 m_httpRequest->post(RequestParameters {.url = HttpURL(url),
                                                        .data = bulkData,
@@ -493,18 +493,19 @@ public:
         // Validate input parameters
         if (index.empty())
         {
-            LOG_ERROR(m_logFn, "Index name cannot be empty for document: %.*s", static_cast<int>(id.size()), id.data());
+            LOGFN_ERROR(
+                m_logFn, "Index name cannot be empty for document: %.*s", static_cast<int>(id.size()), id.data());
             throw IndexerConnectorException("Index name cannot be empty");
         }
 
         if (data.empty())
         {
-            LOG_WARN(m_logFn,
-                     "Empty data provided for document %.*s in index %.*s",
-                     static_cast<int>(id.size()),
-                     id.data(),
-                     static_cast<int>(index.size()),
-                     index.data());
+            LOGFN_WARN(m_logFn,
+                       "Empty data provided for document %.*s in index %.*s",
+                       static_cast<int>(id.size()),
+                       id.data(),
+                       static_cast<int>(index.size()),
+                       index.data());
         }
 
         std::string bulkData;
@@ -522,19 +523,19 @@ public:
             }
             else
             {
-                LOG_ERROR(m_logFn, "Id must be provided if version value is provided");
+                LOGFN_ERROR(m_logFn, "Id must be provided if version value is provided");
                 throw IndexerConnectorException("Id must be provided if version value is provided");
             }
 
             bulkData.append(R"(","version":")");
             bulkData.append(version);
             bulkData.append(R"(","version_type":"external_gte)");
-            LOG_DEBUG2(m_logFn,
-                       "Using external version %.*s for document %.*s",
-                       static_cast<int>(version.size()),
-                       version.data(),
-                       static_cast<int>(id.size()),
-                       id.data());
+            LOGFN_DEBUG2(m_logFn,
+                         "Using external version %.*s for document %.*s",
+                         static_cast<int>(version.size()),
+                         version.data(),
+                         static_cast<int>(id.size()),
+                         id.data());
         }
         else
         {
@@ -543,10 +544,10 @@ public:
                 bulkData.append(R"(","_id":")");
                 appendEscapedId(bulkData, id);
             }
-            LOG_DEBUG2(m_logFn,
-                       "No version specified for document %.*s, using default versioning",
-                       static_cast<int>(id.size()),
-                       id.data());
+            LOGFN_DEBUG2(m_logFn,
+                         "No version specified for document %.*s, using default versioning",
+                         static_cast<int>(id.size()),
+                         id.data());
         }
         bulkData.append(R"("}})");
         bulkData.append("\n");
@@ -677,13 +678,13 @@ public:
                 creationTime = jsonResponse["creation_time"].get<uint64_t>();
                 success = true;
 
-                LOG_DEBUG2(
+                LOGFN_DEBUG2(
                     m_logFn, "PIT created successfully. PIT ID: %s, Creation time: %lu", pitId.c_str(), creationTime);
             }
             catch (const std::exception& e)
             {
                 errorMessage = std::string("Failed to parse PIT response: ") + e.what();
-                LOG_DEBUG1(m_logFn, "%s", errorMessage.c_str());
+                LOGFN_DEBUG1(m_logFn, "%s", errorMessage.c_str());
             }
         };
 
@@ -692,7 +693,7 @@ public:
         {
             errorMessage = "Failed to create PIT. Error: " + error + ", Status code: " + std::to_string(statusCode) +
                            ", Response: " + responseBody;
-            LOG_DEBUG1(m_logFn, "%s", errorMessage.c_str());
+            LOGFN_DEBUG1(m_logFn, "%s", errorMessage.c_str());
         };
 
         // Execute the POST request synchronously
@@ -730,7 +731,7 @@ public:
 
             const auto onSuccess = [this](const std::string& response)
             {
-                LOG_DEBUG2(m_logFn, "PIT successfully deleted. Response: %s", response.c_str());
+                LOGFN_DEBUG2(m_logFn, "PIT successfully deleted. Response: %s", response.c_str());
             };
 
             const auto onError =

--- a/src/shared_modules/indexer_connector/src/indexerConnectorAsyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorAsyncImpl.hpp
@@ -428,12 +428,12 @@ public:
                             if (!m_error413Logged)
                             {
                                 m_error413Logged = true;
-                                LOGFN_ERROR(m_logFn,
-                                            "Bulk threshold too small to halve further (%zu bytes). "
-                                            "Review 'http.max_content_length' in wazuh-indexer settings. "
-                                            "Current payload size: %zu bytes. Discarding this batch.",
-                                            currentBulkMax,
-                                            bulkData.size());
+                                LOGFN_WARN(m_logFn,
+                                           "Bulk threshold too small to halve further (%zu bytes). "
+                                           "Review 'http.max_content_length' in wazuh-indexer settings. "
+                                           "Current payload size: %zu bytes. Discarding this batch.",
+                                           currentBulkMax,
+                                           bulkData.size());
                             }
                             // Do not throw, avoid infinite retry loop. Drop this batch and continue with the next.
                             return;
@@ -458,7 +458,7 @@ public:
                     }
                     else
                     {
-                        LOGFN_ERROR(m_logFn, "%s, status code: %ld.", error.c_str(), statusCode);
+                        LOGFN_WARN(m_logFn, "%s, status code: %ld.", error.c_str(), statusCode);
                     }
                 };
 

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -340,7 +340,7 @@ class IndexerConnectorSyncImpl final
         auto serverUrl = m_selector->getNext();
         const auto onSuccessDeleteByQuery = [this](const std::string& response)
         {
-            LOG_DEBUG2(m_logFn, "Response: %s", response.c_str());
+            LOGFN_DEBUG2(m_logFn, "Response: %s", response.c_str());
         };
 
         const auto onErrorDeleteByQuery =
@@ -349,24 +349,24 @@ class IndexerConnectorSyncImpl final
             if (statusCode == HTTP_NOT_FOUND)
             {
                 // Index doesn't exist - this is OK, nothing to delete
-                LOG_DEBUG2(m_logFn, "Index not found (404) for deleteByQuery - nothing to delete, continuing.");
+                LOGFN_DEBUG2(m_logFn, "Index not found (404) for deleteByQuery - nothing to delete, continuing.");
                 return;
             }
             else if (statusCode == HTTP_VERSION_CONFLICT)
             {
-                LOG_DEBUG2(m_logFn, "Document version conflict for deleteByQuery - continuing.");
+                LOGFN_DEBUG2(m_logFn, "Document version conflict for deleteByQuery - continuing.");
                 // For deleteByQuery, we don't retry - just log and continue
                 return;
             }
             else if (statusCode == HTTP_TOO_MANY_REQUESTS)
             {
-                LOG_DEBUG2(m_logFn, "Too many requests for deleteByQuery - continuing.");
+                LOGFN_DEBUG2(m_logFn, "Too many requests for deleteByQuery - continuing.");
                 // For deleteByQuery, we don't retry - just log and continue
                 return;
             }
             else
             {
-                LOG_ERROR(m_logFn, "deleteByQuery error: %s, status code: %ld.", error.c_str(), statusCode);
+                LOGFN_ERROR(m_logFn, "deleteByQuery error: %s, status code: %ld.", error.c_str(), statusCode);
                 m_bulkData.clear();
                 m_lastBulkTime = std::chrono::steady_clock::now();
                 throw IndexerConnectorException(error);
@@ -383,7 +383,7 @@ class IndexerConnectorSyncImpl final
             url += "/";
             url += index;
             url += "/_delete_by_query";
-            LOG_DEBUG2(m_logFn, "Deleting by query: %s", url.c_str());
+            LOGFN_DEBUG2(m_logFn, "Deleting by query: %s", url.c_str());
             m_httpRequest->post(
                 RequestParameters {
                     .url = HttpURL(url), .data = query.dump(), .secureCommunication = m_secureCommunication},
@@ -393,12 +393,12 @@ class IndexerConnectorSyncImpl final
 
         const auto onSuccess = [this, &needToRetry](const std::string& response)
         {
-            LOG_DEBUG2(m_logFn, "Response: %s", response.c_str());
+            LOGFN_DEBUG2(m_logFn, "Response: %s", response.c_str());
 
             // Validate bulk response at document level
             if (!validateBulkResponse(response, m_logFn.c_str()))
             {
-                LOG_ERROR(m_logFn, "Bulk operation had indexing failures");
+                LOGFN_ERROR(m_logFn, "Bulk operation had indexing failures");
                 m_bulkData.clear();
                 m_boundaries.clear();
                 m_lastBulkTime = std::chrono::steady_clock::now();
@@ -413,17 +413,17 @@ class IndexerConnectorSyncImpl final
                                                                       const long statusCode,
                                                                       const std::string& responseBody) -> void
         {
-            LOG_ERROR(m_logFn, "%s, status code: %ld.", error.c_str(), statusCode);
+            LOGFN_ERROR(m_logFn, "%s, status code: %ld.", error.c_str(), statusCode);
             if (statusCode == HTTP_CONTENT_LENGTH)
             {
-                LOG_DEBUG2(m_logFn, "Received 413 error (Payload Too Large). Splitting bulk data.");
+                LOGFN_DEBUG2(m_logFn, "Received 413 error (Payload Too Large). Splitting bulk data.");
                 if (const size_t currentOperations = m_boundaries.size(); currentOperations <= 1)
                 {
-                    LOG_ERROR(m_logFn,
-                              "Unable to send data even with single operation. "
-                              "Consider increasing http.max_content_length in OpenSearch settings. "
-                              "Current data size: %zu bytes.",
-                              m_bulkData.size());
+                    LOGFN_ERROR(m_logFn,
+                                "Unable to send data even with single operation. "
+                                "Consider increasing http.max_content_length in OpenSearch settings. "
+                                "Current data size: %zu bytes.",
+                                m_bulkData.size());
                     m_bulkData.clear();
                     m_boundaries.clear();
                     throw IndexerConnectorException("Single operation exceeds server payload limits");
@@ -432,9 +432,9 @@ class IndexerConnectorSyncImpl final
             }
             else if (statusCode == HTTP_VERSION_CONFLICT)
             {
-                LOG_WARN(m_logFn,
-                         "Bulk request returned 409 version conflict at request level. Document-level conflicts are "
-                         "handled by validateBulkResponse().");
+                LOGFN_WARN(m_logFn,
+                           "Bulk request returned 409 version conflict at request level. Document-level conflicts are "
+                           "handled by validateBulkResponse().");
                 m_bulkData.clear();
                 m_boundaries.clear();
                 m_lastBulkTime = std::chrono::steady_clock::now();
@@ -443,11 +443,11 @@ class IndexerConnectorSyncImpl final
             else if (statusCode == HTTP_TOO_MANY_REQUESTS)
             {
                 needToRetry = true;
-                LOG_DEBUG2(m_logFn, "Too many requests, retrying in %zu second(s).", retryDelaySeconds);
+                LOGFN_DEBUG2(m_logFn, "Too many requests, retrying in %zu second(s).", retryDelaySeconds);
             }
             else
             {
-                LOG_ERROR(m_logFn, "%s, status code: %ld.", error.c_str(), statusCode);
+                LOGFN_ERROR(m_logFn, "%s, status code: %ld.", error.c_str(), statusCode);
                 m_bulkData.clear();
                 m_boundaries.clear();
                 m_lastBulkTime = std::chrono::steady_clock::now();
@@ -462,15 +462,15 @@ class IndexerConnectorSyncImpl final
             {
                 if (m_stopping.load())
                 {
-                    LOG_DEBUG2(m_logFn, "Stopping requested, aborting bulk processing");
+                    LOGFN_DEBUG2(m_logFn, "Stopping requested, aborting bulk processing");
                     return;
                 }
 
                 std::string url;
                 url += m_selector->getNext();
                 url += "/_bulk";
-                LOG_DEBUG2(m_logFn, "Sending bulk data to: %s", url.c_str());
-                LOG_DEBUG2(m_logFn, "Bulk data: %s", m_bulkData.c_str());
+                LOGFN_DEBUG2(m_logFn, "Sending bulk data to: %s", url.c_str());
+                LOGFN_DEBUG2(m_logFn, "Bulk data: %s", m_bulkData.c_str());
 
                 m_httpRequest->post(RequestParameters {.url = HttpURL(url),
                                                        .data = m_bulkData,
@@ -505,7 +505,7 @@ class IndexerConnectorSyncImpl final
                 "Cannot split bulk data with less than two operations. Consider increasing http.max_content_length in "
                 "Wazuh-Indexer settings.");
         }
-        LOG_DEBUG2(m_logFn, "Splitting %zu operations into two halves", totalOperations);
+        LOGFN_DEBUG2(m_logFn, "Splitting %zu operations into two halves", totalOperations);
 
         const size_t midPoint = totalOperations / 2;
         std::span<size_t> firstBoundaries(m_boundaries.begin(), m_boundaries.begin() + midPoint);
@@ -524,7 +524,7 @@ class IndexerConnectorSyncImpl final
             }
             catch (const IndexerConnectorException& e)
             {
-                LOG_ERROR(m_logFn, "Failed to process first half: %s", e.what());
+                LOGFN_ERROR(m_logFn, "Failed to process first half: %s", e.what());
                 allProcessed = false;
                 throw;
             }
@@ -537,7 +537,7 @@ class IndexerConnectorSyncImpl final
             }
             catch (const IndexerConnectorException& e)
             {
-                LOG_ERROR(m_logFn, "Failed to process second half: %s", e.what());
+                LOGFN_ERROR(m_logFn, "Failed to process second half: %s", e.what());
                 allProcessed = false;
                 throw;
             }
@@ -561,24 +561,24 @@ class IndexerConnectorSyncImpl final
 
         const auto onSuccess = [this](const std::string& response)
         {
-            LOG_DEBUG2(m_logFn, "Chunk processed successfully: %s", response.c_str());
+            LOGFN_DEBUG2(m_logFn, "Chunk processed successfully: %s", response.c_str());
 
             // Validate bulk response at document level
             if (!validateBulkResponse(response, m_logFn.c_str()))
             {
-                LOG_ERROR(m_logFn, "Bulk chunk operation had indexing failures");
+                LOGFN_ERROR(m_logFn, "Bulk chunk operation had indexing failures");
                 throw IndexerConnectorException("Bulk chunk operation had indexing failures");
             }
         };
         const auto onError = [this, &needToRetry, &retryDelaySeconds, boundaries](
                                  const std::string& error, const long statusCode, const std::string& responseBody)
         {
-            LOG_ERROR(m_logFn, "Chunk processing failed: %s, status code: %ld", error.c_str(), statusCode);
+            LOGFN_ERROR(m_logFn, "Chunk processing failed: %s, status code: %ld", error.c_str(), statusCode);
             if (statusCode == HTTP_CONTENT_LENGTH)
             {
                 if (boundaries.size() > 1)
                 {
-                    LOG_DEBUG2(m_logFn, "Chunk still too large, splitting recursively");
+                    LOGFN_DEBUG2(m_logFn, "Chunk still too large, splitting recursively");
                     const size_t midPoint = boundaries.size() / 2;
                     std::span<size_t> firstBoundaries(boundaries.begin(),
                                                       boundaries.begin() + static_cast<long>(midPoint));
@@ -592,19 +592,19 @@ class IndexerConnectorSyncImpl final
                     processBulkChunk(secondHalf, secondBoundaries);
                     return;
                 }
-                LOG_ERROR(m_logFn, "Single operation too large for server limits");
+                LOGFN_ERROR(m_logFn, "Single operation too large for server limits");
                 throw IndexerConnectorException("Single operation exceeds server limits");
             }
             else if (statusCode == HTTP_VERSION_CONFLICT)
             {
-                LOG_WARN(m_logFn,
-                         "Bulk chunk returned 409 version conflict at request level. Document-level conflicts are "
-                         "handled by validateBulkResponse().");
+                LOGFN_WARN(m_logFn,
+                           "Bulk chunk returned 409 version conflict at request level. Document-level conflicts are "
+                           "handled by validateBulkResponse().");
                 throw IndexerConnectorException("Bulk version conflict at request level");
             }
             else if (statusCode == HTTP_TOO_MANY_REQUESTS)
             {
-                LOG_DEBUG2(m_logFn, "Too many requests, retrying in %zu second(s).", retryDelaySeconds);
+                LOGFN_DEBUG2(m_logFn, "Too many requests, retrying in %zu second(s).", retryDelaySeconds);
                 needToRetry = true;
             }
             else
@@ -616,11 +616,11 @@ class IndexerConnectorSyncImpl final
         {
             if (m_stopping.load())
             {
-                LOG_DEBUG2(m_logFn, "Stopping requested, aborting bulk chunk processing");
+                LOGFN_DEBUG2(m_logFn, "Stopping requested, aborting bulk chunk processing");
                 return;
             }
             needToRetry = false;
-            LOG_DEBUG2(m_logFn, "Sending bulk chunk to: %s", url.c_str());
+            LOGFN_DEBUG2(m_logFn, "Sending bulk chunk to: %s", url.c_str());
             m_httpRequest->post(RequestParametersStringView {.url = HttpURL(url),
                                                              .data = data,
                                                              .secureCommunication = m_secureCommunication},
@@ -717,12 +717,12 @@ public:
         {
             username = "wazuh-manager";
             password = "wazuh-manager";
-            LOG_WARN(m_logFn, "No username and password found in the keystore, using default values.");
+            LOGFN_WARN(m_logFn, "No username and password found in the keystore, using default values.");
         }
         if (username.empty())
         {
             username = "wazuh-manager";
-            LOG_WARN(m_logFn, "No username found in the keystore, using default value.");
+            LOGFN_WARN(m_logFn, "No username found in the keystore, using default value.");
         }
         m_secureCommunication = SecureCommunication::builder();
         m_secureCommunication.basicAuth(username + ":" + password)
@@ -776,11 +776,11 @@ public:
                         }
                         catch (const IndexerConnectorException& e)
                         {
-                            LOG_ERROR(m_logFn, "Error processing bulk: %s", e.what());
+                            LOGFN_ERROR(m_logFn, "Error processing bulk: %s", e.what());
                         }
                         catch (const std::exception& e)
                         {
-                            LOG_DEBUG2(m_logFn, "Cannot process bulk: %s", e.what());
+                            LOGFN_DEBUG2(m_logFn, "Cannot process bulk: %s", e.what());
                         }
                     }
 
@@ -797,10 +797,10 @@ public:
     {
         if (!isSafeIndexName(index))
         {
-            LOG_WARN(m_logFn,
-                     "Refusing deleteByQuery for unsafe index name '%s' (empty or contains characters outside "
-                     "[a-zA-Z0-9._*-]).",
-                     index.c_str());
+            LOGFN_WARN(m_logFn,
+                       "Refusing deleteByQuery for unsafe index name '%s' (empty or contains characters outside "
+                       "[a-zA-Z0-9._*-]).",
+                       index.c_str());
             throw IndexerConnectorException("Unsafe index name");
         }
 
@@ -834,10 +834,10 @@ public:
         {
             if (!isSafeIndexName(idx))
             {
-                LOG_WARN(m_logFn,
-                         "Skipping index '%s' for update by query: empty or contains characters outside "
-                         "[a-zA-Z0-9._*-].",
-                         idx.c_str());
+                LOGFN_WARN(m_logFn,
+                           "Skipping index '%s' for update by query: empty or contains characters outside "
+                           "[a-zA-Z0-9._*-].",
+                           idx.c_str());
                 continue;
             }
 
@@ -850,9 +850,9 @@ public:
 
         if (indexList.empty())
         {
-            LOG_WARN(m_logFn,
-                     "Update by query skipped: no valid indices after filtering (input had %zu entries)",
-                     indices.size());
+            LOGFN_WARN(m_logFn,
+                       "Update by query skipped: no valid indices after filtering (input had %zu entries)",
+                       indices.size());
             // No HTTP request needed, but pending notify callbacks (e.g. unlockAgent +
             // sendEndAck) must still fire so the session terminates cleanly. Treat the
             // missing/filtered indices as a no-op success.
@@ -865,7 +865,7 @@ public:
 
         const auto onSuccess = [this](const std::string& response)
         {
-            LOG_DEBUG2(m_logFn, "Update by query response: %s", response.c_str());
+            LOGFN_DEBUG2(m_logFn, "Update by query response: %s", response.c_str());
 
             // Parse response to extract update statistics and check for failures
             try
@@ -876,13 +876,13 @@ public:
                 if (responseJson.contains("failures") && !responseJson["failures"].empty())
                 {
                     auto failures = responseJson["failures"];
-                    LOG_ERROR(m_logFn, "Update by query completed with %zu failures", failures.size());
+                    LOGFN_ERROR(m_logFn, "Update by query completed with %zu failures", failures.size());
 
                     // Log first few failures for debugging
                     size_t logCount = std::min<size_t>(failures.size(), 3);
                     for (size_t i = 0; i < logCount; ++i)
                     {
-                        LOG_ERROR(m_logFn, "Failure %zu: %s", i + 1, failures[i].dump().c_str());
+                        LOGFN_ERROR(m_logFn, "Failure %zu: %s", i + 1, failures[i].dump().c_str());
                     }
                 }
 
@@ -895,27 +895,28 @@ public:
 
                     if (updated > 0)
                     {
-                        LOG_INFO(m_logFn,
-                                 "Update by query completed: %d documents updated out of %d total (%d unchanged, %zu "
-                                 "failures)",
-                                 updated,
-                                 total,
-                                 noops,
-                                 failures);
+                        LOGFN_INFO(m_logFn,
+                                   "Update by query completed: %d documents updated out of %d total (%d unchanged, %zu "
+                                   "failures)",
+                                   updated,
+                                   total,
+                                   noops,
+                                   failures);
                     }
                     else
                     {
-                        LOG_DEBUG2(m_logFn,
-                                   "Update by query completed: no documents needed updating (all %d documents already "
-                                   "up-to-date, %zu failures)",
-                                   total,
-                                   failures);
+                        LOGFN_DEBUG2(
+                            m_logFn,
+                            "Update by query completed: no documents needed updating (all %d documents already "
+                            "up-to-date, %zu failures)",
+                            total,
+                            failures);
                     }
                 }
             }
             catch (const std::exception& e)
             {
-                LOG_DEBUG2(m_logFn, "Could not parse update by query response: %s", e.what());
+                LOGFN_DEBUG2(m_logFn, "Could not parse update by query response: %s", e.what());
             }
 
             m_shouldNotifyAfterBulk = true;
@@ -926,20 +927,20 @@ public:
         {
             if (statusCode == HTTP_VERSION_CONFLICT)
             {
-                LOG_WARN(m_logFn,
-                         "Update by query returned 409 version conflict. This indicates documents were modified by "
-                         "another process.");
+                LOGFN_WARN(m_logFn,
+                           "Update by query returned 409 version conflict. This indicates documents were modified by "
+                           "another process.");
                 m_notify.clear();
                 throw IndexerConnectorException("Update by query version conflict");
             }
             else if (statusCode == HTTP_TOO_MANY_REQUESTS)
             {
                 needToRetry = true;
-                LOG_DEBUG2(m_logFn, "Too many requests, retrying in %zu second(s).", retryDelaySeconds);
+                LOGFN_DEBUG2(m_logFn, "Too many requests, retrying in %zu second(s).", retryDelaySeconds);
             }
             else
             {
-                LOG_ERROR(m_logFn, "Update by query failed: %s, status code: %ld.", error.c_str(), statusCode);
+                LOGFN_ERROR(m_logFn, "Update by query failed: %s, status code: %ld.", error.c_str(), statusCode);
                 m_notify.clear();
                 throw IndexerConnectorException(error);
             }
@@ -949,7 +950,7 @@ public:
         {
             if (m_stopping.load())
             {
-                LOG_DEBUG2(m_logFn, "Stopping requested, aborting update by query");
+                LOGFN_DEBUG2(m_logFn, "Stopping requested, aborting update by query");
                 m_notify.clear();
                 return;
             }
@@ -990,7 +991,7 @@ public:
 
         const auto onSuccess = [this, &resultJson](const std::string& response)
         {
-            LOG_DEBUG2(m_logFn, "Search query response: %s", response.c_str());
+            LOGFN_DEBUG2(m_logFn, "Search query response: %s", response.c_str());
             resultJson = nlohmann::json::parse(response);
         };
 
@@ -1000,11 +1001,11 @@ public:
             if (statusCode == HTTP_TOO_MANY_REQUESTS)
             {
                 needToRetry = true;
-                LOG_DEBUG2(m_logFn, "Too many requests, retrying in %zu second(s).", retryDelaySeconds);
+                LOGFN_DEBUG2(m_logFn, "Too many requests, retrying in %zu second(s).", retryDelaySeconds);
             }
             else
             {
-                LOG_ERROR(m_logFn, "Search query failed: %s, status code: %ld", error.c_str(), statusCode);
+                LOGFN_ERROR(m_logFn, "Search query failed: %s, status code: %ld", error.c_str(), statusCode);
                 throw IndexerConnectorException("Search query failed: " + error);
             }
         };
@@ -1024,7 +1025,7 @@ public:
             url += index;
             url += "/_search";
 
-            LOG_DEBUG2(m_logFn, "Executing search query on: %s", url.c_str());
+            LOGFN_DEBUG2(m_logFn, "Executing search query on: %s", url.c_str());
 
             m_httpRequest->post(RequestParameters {.url = HttpURL(url),
                                                    .data = searchQuery.dump(),
@@ -1064,14 +1065,14 @@ public:
             const auto itHits = searchResult.find("hits");
             if (itHits == searchResult.end())
             {
-                LOG_DEBUG2(m_logFn, "No 'hits' object in response, breaking pagination loop");
+                LOGFN_DEBUG2(m_logFn, "No 'hits' object in response, breaking pagination loop");
                 break;
             }
 
             const auto itInner = itHits->find("hits");
             if (itInner == itHits->end() || !itInner->is_array() || itInner->empty())
             {
-                LOG_DEBUG2(m_logFn, "No 'hits' array in response or it is empty, breaking pagination loop");
+                LOGFN_DEBUG2(m_logFn, "No 'hits' array in response or it is empty, breaking pagination loop");
                 break;
             }
 
@@ -1080,7 +1081,7 @@ public:
             // If we got less results than requested, this is the last page
             if (currentQuery.contains("size") && hits.size() < currentQuery["size"].template get<size_t>())
             {
-                LOG_DEBUG2(m_logFn, "Fewer results than page size, breaking pagination loop");
+                LOGFN_DEBUG2(m_logFn, "Fewer results than page size, breaking pagination loop");
                 break;
             }
 
@@ -1096,9 +1097,9 @@ public:
             }
             else
             {
-                LOG_DEBUG2(m_logFn,
-                           "Pagination loop finished: Last hit has no 'sort' field, it is not an array, or it is "
-                           "empty.");
+                LOGFN_DEBUG2(m_logFn,
+                             "Pagination loop finished: Last hit has no 'sort' field, it is not an array, or it is "
+                             "empty.");
                 break;
             }
         }
@@ -1175,20 +1176,20 @@ public:
                 creationTime = jsonResponse["creation_time"].get<uint64_t>();
                 success = true;
 
-                LOG_DEBUG2(
+                LOGFN_DEBUG2(
                     m_logFn, "PIT created successfully. PIT ID: %s, Creation time: %lu", pitId.c_str(), creationTime);
             }
             catch (const std::exception& e)
             {
                 errorMessage = std::string("Failed to parse PIT response: ") + e.what();
-                LOG_DEBUG1(m_logFn, "%s", errorMessage.c_str());
+                LOGFN_DEBUG1(m_logFn, "%s", errorMessage.c_str());
             }
         };
 
         const auto onError = [this, &errorMessage](const std::string& error, const long statusCode, const std::string&)
         {
             errorMessage = "Failed to create PIT. Error: " + error + ", Status code: " + std::to_string(statusCode);
-            LOG_DEBUG1(m_logFn, "%s", errorMessage.c_str());
+            LOGFN_DEBUG1(m_logFn, "%s", errorMessage.c_str());
         };
 
         m_httpRequest->post(RequestParameters {.url = HttpURL(url), .secureCommunication = m_secureCommunication},
@@ -1220,7 +1221,7 @@ public:
 
         const auto onSuccess = [this](const std::string& response)
         {
-            LOG_DEBUG2(m_logFn, "PIT successfully deleted. Response: %s", response.c_str());
+            LOGFN_DEBUG2(m_logFn, "PIT successfully deleted. Response: %s", response.c_str());
         };
 
         const auto onError = [&pitId](const std::string& error, const long statusCode, const std::string&)
@@ -1348,13 +1349,13 @@ public:
     {
         if (!isSafeIndexName(index))
         {
-            LOG_ERROR(m_logFn,
-                      "Refusing bulkDelete for unsafe index name '%.*s' (empty or contains characters outside "
-                      "[a-zA-Z0-9._*-]) on document '%.*s'",
-                      static_cast<int>(index.size()),
-                      index.data(),
-                      static_cast<int>(id.size()),
-                      id.data());
+            LOGFN_ERROR(m_logFn,
+                        "Refusing bulkDelete for unsafe index name '%.*s' (empty or contains characters outside "
+                        "[a-zA-Z0-9._*-]) on document '%.*s'",
+                        static_cast<int>(index.size()),
+                        index.data(),
+                        static_cast<int>(id.size()),
+                        id.data());
             throw IndexerConnectorException("Unsafe index name");
         }
 
@@ -1386,24 +1387,24 @@ public:
         // Validate input parameters
         if (!isSafeIndexName(index))
         {
-            LOG_ERROR(m_logFn,
-                      "Refusing bulkIndex for unsafe index name '%.*s' (empty or contains characters outside "
-                      "[a-zA-Z0-9._*-]) on document '%.*s'",
-                      static_cast<int>(index.size()),
-                      index.data(),
-                      static_cast<int>(id.size()),
-                      id.data());
+            LOGFN_ERROR(m_logFn,
+                        "Refusing bulkIndex for unsafe index name '%.*s' (empty or contains characters outside "
+                        "[a-zA-Z0-9._*-]) on document '%.*s'",
+                        static_cast<int>(index.size()),
+                        index.data(),
+                        static_cast<int>(id.size()),
+                        id.data());
             throw IndexerConnectorException("Unsafe index name");
         }
 
         if (data.empty())
         {
-            LOG_WARN(m_logFn,
-                     "Empty data provided for document %.*s in index %.*s",
-                     static_cast<int>(id.size()),
-                     id.data(),
-                     static_cast<int>(index.size()),
-                     index.data());
+            LOGFN_WARN(m_logFn,
+                       "Empty data provided for document %.*s in index %.*s",
+                       static_cast<int>(id.size()),
+                       id.data(),
+                       static_cast<int>(index.size()),
+                       index.data());
         }
 
         const auto totalSize =
@@ -1421,18 +1422,18 @@ public:
             // to check state.document_version instead of OpenSearch's internal _version.
             if (id.empty())
             {
-                LOG_ERROR(m_logFn, "Id must be provided if version value is provided");
+                LOGFN_ERROR(m_logFn, "Id must be provided if version value is provided");
                 throw IndexerConnectorException("Id must be provided if version value is provided");
             }
 
             appendScriptedUpdate(m_bulkData, index, id, version, data);
 
-            LOG_DEBUG2(m_logFn,
-                       "Using document version %.*s for document %.*s (checking state.document_version)",
-                       static_cast<int>(version.size()),
-                       version.data(),
-                       static_cast<int>(id.size()),
-                       id.data());
+            LOGFN_DEBUG2(m_logFn,
+                         "Using document version %.*s for document %.*s (checking state.document_version)",
+                         static_cast<int>(version.size()),
+                         version.data(),
+                         static_cast<int>(id.size()),
+                         id.data());
         }
         else
         {
@@ -1449,10 +1450,10 @@ public:
             m_bulkData.append(data);
             m_bulkData.append("\n");
 
-            LOG_DEBUG2(m_logFn,
-                       "No version specified for document %.*s, using default versioning",
-                       static_cast<int>(id.size()),
-                       id.data());
+            LOGFN_DEBUG2(m_logFn,
+                         "No version specified for document %.*s, using default versioning",
+                         static_cast<int>(id.size()),
+                         id.data());
         }
 
         m_boundaries.push_back(m_bulkData.size());
@@ -1528,15 +1529,15 @@ public:
         url += "/";
         url += indexPattern;
         url += "/_refresh";
-        LOG_DEBUG2(m_logFn, "Forcing index refresh: %s", url.c_str());
+        LOGFN_DEBUG2(m_logFn, "Forcing index refresh: %s", url.c_str());
 
         const auto onSuccess = [this](const std::string& response)
         {
-            LOG_DEBUG2(m_logFn, "Index refresh response: %s", response.c_str());
+            LOGFN_DEBUG2(m_logFn, "Index refresh response: %s", response.c_str());
         };
         const auto onError = [this](const std::string& error, const long statusCode, const std::string&)
         {
-            LOG_WARN(m_logFn, "Index refresh failed: %s, status code: %ld", error.c_str(), statusCode);
+            LOGFN_WARN(m_logFn, "Index refresh failed: %s, status code: %ld", error.c_str(), statusCode);
         };
 
         m_httpRequest->post(RequestParameters {.url = HttpURL(url), .secureCommunication = m_secureCommunication},

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -181,7 +181,7 @@ inline bool validateBulkResponse(const std::string& response, const char* tag)
         // Errors were reported, validate each item
         if (!responseJson.contains("items") || !responseJson["items"].is_array())
         {
-            logError(tag, "Bulk response has errors but missing 'items' array");
+            logWarn(tag, "Bulk response has errors but missing 'items' array");
             return false;
         }
 
@@ -208,7 +208,7 @@ inline bool validateBulkResponse(const std::string& response, const char* tag)
             // Check status code
             if (!result.contains("status"))
             {
-                logError(tag, "Item missing status field");
+                logDebug1(tag, "Item missing status field");
                 realFailureCount++;
                 continue;
             }
@@ -274,30 +274,40 @@ inline bool validateBulkResponse(const std::string& response, const char* tag)
                 }
             }
 
-            logError(
+            logWarn(
                 tag, "Indexing failure for %s operation (status %d): %s", operation.c_str(), status, errorMsg.c_str());
             realFailureCount++;
         }
 
-        // Log summary
-        logInfo(tag,
-                "Bulk operation summary: %zu total, %zu success, %zu acceptable version conflicts, %zu failures",
-                totalItems,
-                successCount,
-                versionConflictAcceptedCount,
-                realFailureCount);
+        if (realFailureCount > 0)
+        {
+            logWarn(tag,
+                    "Bulk operation summary: %zu total, %zu success, %zu acceptable version conflicts, %zu failures",
+                    totalItems,
+                    successCount,
+                    versionConflictAcceptedCount,
+                    realFailureCount);
+        }
+        else
+        {
+            logDebug2(tag,
+                      "Bulk operation summary: %zu total, %zu success, %zu acceptable version conflicts",
+                      totalItems,
+                      successCount,
+                      versionConflictAcceptedCount);
+        }
 
         // Return success only if no real failures occurred
         return realFailureCount == 0;
     }
     catch (const nlohmann::json::exception& e)
     {
-        logError(tag, "Failed to parse bulk response: %s", e.what());
+        logWarn(tag, "Failed to parse bulk response: %s", e.what());
         return false;
     }
     catch (const std::exception& e)
     {
-        logError(tag, "Error validating bulk response: %s", e.what());
+        logWarn(tag, "Error validating bulk response: %s", e.what());
         return false;
     }
 }
@@ -366,7 +376,7 @@ class IndexerConnectorSyncImpl final
             }
             else
             {
-                LOGFN_ERROR(m_logFn, "deleteByQuery error: %s, status code: %ld.", error.c_str(), statusCode);
+                LOGFN_WARN(m_logFn, "deleteByQuery error: %s, status code: %ld.", error.c_str(), statusCode);
                 m_bulkData.clear();
                 m_lastBulkTime = std::chrono::steady_clock::now();
                 throw IndexerConnectorException(error);
@@ -398,7 +408,6 @@ class IndexerConnectorSyncImpl final
             // Validate bulk response at document level
             if (!validateBulkResponse(response, m_logFn.c_str()))
             {
-                LOGFN_ERROR(m_logFn, "Bulk operation had indexing failures");
                 m_bulkData.clear();
                 m_boundaries.clear();
                 m_lastBulkTime = std::chrono::steady_clock::now();
@@ -413,17 +422,16 @@ class IndexerConnectorSyncImpl final
                                                                       const long statusCode,
                                                                       const std::string& responseBody) -> void
         {
-            LOGFN_ERROR(m_logFn, "%s, status code: %ld.", error.c_str(), statusCode);
             if (statusCode == HTTP_CONTENT_LENGTH)
             {
                 LOGFN_DEBUG2(m_logFn, "Received 413 error (Payload Too Large). Splitting bulk data.");
                 if (const size_t currentOperations = m_boundaries.size(); currentOperations <= 1)
                 {
-                    LOGFN_ERROR(m_logFn,
-                                "Unable to send data even with single operation. "
-                                "Consider increasing http.max_content_length in OpenSearch settings. "
-                                "Current data size: %zu bytes.",
-                                m_bulkData.size());
+                    LOGFN_WARN(m_logFn,
+                               "Unable to send data even with single operation. "
+                               "Consider increasing http.max_content_length in OpenSearch settings. "
+                               "Current data size: %zu bytes.",
+                               m_bulkData.size());
                     m_bulkData.clear();
                     m_boundaries.clear();
                     throw IndexerConnectorException("Single operation exceeds server payload limits");
@@ -447,7 +455,7 @@ class IndexerConnectorSyncImpl final
             }
             else
             {
-                LOGFN_ERROR(m_logFn, "%s, status code: %ld.", error.c_str(), statusCode);
+                LOGFN_WARN(m_logFn, "%s, status code: %ld.", error.c_str(), statusCode);
                 m_bulkData.clear();
                 m_boundaries.clear();
                 m_lastBulkTime = std::chrono::steady_clock::now();
@@ -524,7 +532,7 @@ class IndexerConnectorSyncImpl final
             }
             catch (const IndexerConnectorException& e)
             {
-                LOGFN_ERROR(m_logFn, "Failed to process first half: %s", e.what());
+                LOGFN_DEBUG1(m_logFn, "Failed to process first half: %s", e.what());
                 allProcessed = false;
                 throw;
             }
@@ -537,7 +545,7 @@ class IndexerConnectorSyncImpl final
             }
             catch (const IndexerConnectorException& e)
             {
-                LOGFN_ERROR(m_logFn, "Failed to process second half: %s", e.what());
+                LOGFN_DEBUG1(m_logFn, "Failed to process second half: %s", e.what());
                 allProcessed = false;
                 throw;
             }
@@ -566,14 +574,12 @@ class IndexerConnectorSyncImpl final
             // Validate bulk response at document level
             if (!validateBulkResponse(response, m_logFn.c_str()))
             {
-                LOGFN_ERROR(m_logFn, "Bulk chunk operation had indexing failures");
                 throw IndexerConnectorException("Bulk chunk operation had indexing failures");
             }
         };
         const auto onError = [this, &needToRetry, &retryDelaySeconds, boundaries](
                                  const std::string& error, const long statusCode, const std::string& responseBody)
         {
-            LOGFN_ERROR(m_logFn, "Chunk processing failed: %s, status code: %ld", error.c_str(), statusCode);
             if (statusCode == HTTP_CONTENT_LENGTH)
             {
                 if (boundaries.size() > 1)
@@ -592,7 +598,7 @@ class IndexerConnectorSyncImpl final
                     processBulkChunk(secondHalf, secondBoundaries);
                     return;
                 }
-                LOGFN_ERROR(m_logFn, "Single operation too large for server limits");
+                LOGFN_WARN(m_logFn, "Single operation too large for server limits");
                 throw IndexerConnectorException("Single operation exceeds server limits");
             }
             else if (statusCode == HTTP_VERSION_CONFLICT)
@@ -609,6 +615,7 @@ class IndexerConnectorSyncImpl final
             }
             else
             {
+                LOGFN_WARN(m_logFn, "Chunk processing failed: %s, status code: %ld", error.c_str(), statusCode);
                 throw IndexerConnectorException(error);
             }
         };
@@ -776,7 +783,7 @@ public:
                         }
                         catch (const IndexerConnectorException& e)
                         {
-                            LOGFN_ERROR(m_logFn, "Error processing bulk: %s", e.what());
+                            LOGFN_WARN(m_logFn, "Error processing bulk: %s", e.what());
                         }
                         catch (const std::exception& e)
                         {
@@ -876,13 +883,13 @@ public:
                 if (responseJson.contains("failures") && !responseJson["failures"].empty())
                 {
                     auto failures = responseJson["failures"];
-                    LOGFN_ERROR(m_logFn, "Update by query completed with %zu failures", failures.size());
+                    LOGFN_WARN(m_logFn, "Update by query completed with %zu failures", failures.size());
 
                     // Log first few failures for debugging
                     size_t logCount = std::min<size_t>(failures.size(), 3);
                     for (size_t i = 0; i < logCount; ++i)
                     {
-                        LOGFN_ERROR(m_logFn, "Failure %zu: %s", i + 1, failures[i].dump().c_str());
+                        LOGFN_DEBUG1(m_logFn, "Failure %zu: %s", i + 1, failures[i].dump().c_str());
                     }
                 }
 
@@ -940,7 +947,7 @@ public:
             }
             else
             {
-                LOGFN_ERROR(m_logFn, "Update by query failed: %s, status code: %ld.", error.c_str(), statusCode);
+                LOGFN_WARN(m_logFn, "Update by query failed: %s, status code: %ld.", error.c_str(), statusCode);
                 m_notify.clear();
                 throw IndexerConnectorException(error);
             }
@@ -1001,11 +1008,11 @@ public:
             if (statusCode == HTTP_TOO_MANY_REQUESTS)
             {
                 needToRetry = true;
-                LOGFN_DEBUG2(m_logFn, "Too many requests, retrying in %zu second(s).", retryDelaySeconds);
+                LOGFN_DEBUG1(m_logFn, "Search query rate-limited (429), retrying in %zu second(s).", retryDelaySeconds);
             }
             else
             {
-                LOGFN_ERROR(m_logFn, "Search query failed: %s, status code: %ld", error.c_str(), statusCode);
+                LOGFN_WARN(m_logFn, "Search query failed: %s, status code: %ld", error.c_str(), statusCode);
                 throw IndexerConnectorException("Search query failed: " + error);
             }
         };
@@ -1303,10 +1310,11 @@ public:
             if (statusCode == HTTP_TOO_MANY_REQUESTS)
             {
                 needToRetry = true;
-                LOG_DEBUG2(m_logFn, "Too many requests, retrying in %zu second(s).", retryDelaySeconds);
+                LOGFN_DEBUG2(m_logFn, "Too many requests, retrying in %zu second(s).", retryDelaySeconds);
             }
             else
             {
+                LOGFN_WARN(m_logFn, "Search request failed: %s, status code: %ld", error.c_str(), statusCode);
                 throw IndexerConnectorException("Search request failed with status " + std::to_string(statusCode) +
                                                 ": " + error);
             }

--- a/src/shared_modules/indexer_connector/tests/unit/main.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/main.cpp
@@ -9,10 +9,12 @@
  * Foundation.
  */
 
+#include "loggerHelper.h"
 #include <gtest/gtest.h>
 
 int main(int argc, char** argv)
 {
+    Log::assignLogFunction([](const int, const char*, const char*, const int, const char*, const char*, va_list) {});
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }

--- a/src/shared_modules/keystore/src/keyStore.cpp
+++ b/src/shared_modules/keystore/src/keyStore.cpp
@@ -49,12 +49,12 @@ static void upgrade(Utils::RocksDBWrapper& keystoreDB, const std::string& column
                 // Get the encrypted RSA value
                 if (keystoreDB.get(key, encryptedRSAValue, columnFamily))
                 {
-                    LOG_INFO(logFn, "Upgrading '%s' key pair.", key.c_str());
+                    LOGFN_INFO(logFn, "Upgrading '%s' key pair.", key.c_str());
                 }
 
                 // Decrypt the RSA value
                 RSAHelper().rsaDecrypt(PRIVATE_KEY_FILE, encryptedRSAValue, rawValue);
-                LOG_DEBUG2(logFn, "Decryption successful for key: '%s'", key.c_str());
+                LOGFN_DEBUG2(logFn, "Decryption successful for key: '%s'", key.c_str());
 
                 // Encrypt the value with AES 256
                 EVPHelper().encryptAES256(rawValue, encryptedValue);
@@ -62,16 +62,16 @@ static void upgrade(Utils::RocksDBWrapper& keystoreDB, const std::string& column
                 // Insert the key-value pair using AES encryption
                 keystoreDB.put(key, rocksdb::Slice(encryptedValue.data(), encryptedValue.size()), columnFamily);
 
-                LOG_INFO(logFn, "Key pair '%s' upgraded.", key.c_str());
+                LOGFN_INFO(logFn, "Key pair '%s' upgraded.", key.c_str());
             }
         }
         catch (const std::exception& exception)
         {
             // If the upgrade fails, delete all keys and log the error.
             keystoreDB.deleteAll(columnFamily);
-            LOG_WARN(logFn,
-                     "Keystore upgrade failed, re-run the tool again for all keys to save them. Error: %s",
-                     exception.what());
+            LOGFN_WARN(logFn,
+                       "Keystore upgrade failed, re-run the tool again for all keys to save them. Error: %s",
+                       exception.what());
         }
     }
 
@@ -87,8 +87,6 @@ static void upgrade(Utils::RocksDBWrapper& keystoreDB, const std::string& column
 
 void Keystore::put(const std::string& columnFamily, const std::string& key, const std::string& value)
 {
-    // Keystore methods are static so there is no instance to cache the LogFn on.
-    // Each call builds a fresh one — acceptable because put/get are low-frequency operations.
     const auto logFn = makeLibLogFn("keystore");
     std::vector<char> encryptedValue;
 

--- a/src/shared_modules/utils/asyncValueDispatcher.hpp
+++ b/src/shared_modules/utils/asyncValueDispatcher.hpp
@@ -205,7 +205,7 @@ namespace Utils
                 }
                 catch (const std::exception& ex)
                 {
-                    LOG_DEBUG1(m_logFn, "Dispatch handler error, %s", ex.what());
+                    LOGFN_DEBUG1(m_logFn, "Dispatch handler error, %s", ex.what());
                 }
             }
         }

--- a/src/shared_modules/utils/loggerHelper.h
+++ b/src/shared_modules/utils/loggerHelper.h
@@ -38,6 +38,14 @@ auto constexpr LOGGER_DEFAULT_TAG {"logger-helper"};
 #define logDebug2(X, Y, ...) Log::Logger::debugVerbose(X, LogEndl, Y, ##__VA_ARGS__)
 #define logError(X, Y, ...)  Log::Logger::error(X, LogEndl, Y, ##__VA_ARGS__)
 constexpr auto MAXLEN {65536};
+// clang-format off
+// Macros for Log::LogFn instances. Debug variants skip argument evaluation when debug is inactive.
+#define LOGFN_INFO(fn, fmt, ...)   do { if (Log::isInfoEnabled())   { (fn).info(  {__FILE__, __LINE__, __func__}, fmt, ##__VA_ARGS__); } } while (0)
+#define LOGFN_WARN(fn, fmt, ...)   do { if (Log::isWarnEnabled())   { (fn).warn(  {__FILE__, __LINE__, __func__}, fmt, ##__VA_ARGS__); } } while (0)
+#define LOGFN_DEBUG1(fn, fmt, ...) do { if (Log::isDebugEnabled())  { (fn).debug1({__FILE__, __LINE__, __func__}, fmt, ##__VA_ARGS__); } } while (0)
+#define LOGFN_DEBUG2(fn, fmt, ...) do { if (Log::isDebug2Enabled()) { (fn).debug2({__FILE__, __LINE__, __func__}, fmt, ##__VA_ARGS__); } } while (0)
+#define LOGFN_ERROR(fn, fmt, ...)  do { if (Log::isErrorEnabled())  { (fn).error( {__FILE__, __LINE__, __func__}, fmt, ##__VA_ARGS__); } } while (0)
+// clang-format on
 
 namespace Log
 {
@@ -58,7 +66,38 @@ namespace Log
 
     extern std::function<void(const int, const char*, const char*, const int, const char*, const char*, va_list)>
         GLOBAL_LOG_FUNCTION;
+
+    // Minimum level for LOGFN_* filtering. inline so each DSO gets its own copy.
+    inline int GLOBAL_LOG_LEVEL {LOGLEVEL_DEBUG};
 #pragma GCC visibility pop
+
+    inline bool isLevelEnabled(int level) noexcept
+    {
+        return GLOBAL_LOG_FUNCTION && level >= GLOBAL_LOG_LEVEL;
+    }
+
+    // Per-level helpers used by LOGFN_* macros. Defined inside the namespace so that
+    // LOGLEVEL_* identifiers resolve correctly whether or not defs.h is included.
+    inline bool isInfoEnabled() noexcept
+    {
+        return isLevelEnabled(LOGLEVEL_INFO);
+    }
+    inline bool isWarnEnabled() noexcept
+    {
+        return isLevelEnabled(LOGLEVEL_WARNING);
+    }
+    inline bool isDebugEnabled() noexcept
+    {
+        return isLevelEnabled(LOGLEVEL_DEBUG);
+    }
+    inline bool isDebug2Enabled() noexcept
+    {
+        return isLevelEnabled(LOGLEVEL_DEBUG_VERBOSE);
+    }
+    inline bool isErrorEnabled() noexcept
+    {
+        return isLevelEnabled(LOGLEVEL_ERROR);
+    }
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
@@ -76,6 +115,12 @@ namespace Log
         {
             GLOBAL_LOG_FUNCTION = logFunction;
         }
+    }
+
+    /** Sets the minimum log level. LOGFN_* macros skip messages below this level. */
+    static void setLogLevel(int level)
+    {
+        GLOBAL_LOG_LEVEL = level;
     }
 
     /**
@@ -229,149 +274,114 @@ namespace Log
             }
         }
     };
-} // namespace Log
-
-/**
- * @brief Pre-bound log wrapper — stores a tag and calls GLOBAL_LOG_FUNCTION with it.
- *
- * Each component receives a LogFn from its caller and calls compose("myname") to
- * build its own LogFn. The tag shown in every log line is always
- * "<process>(<current-library>)" — only the library currently executing, not the
- * full call chain.
- *
- * Use the LOG_WARN / LOG_INFO / LOG_DEBUG1 / LOG_DEBUG2 / LOG_ERROR macros so that
- * __FILE__ / __LINE__ / __func__ are captured at the actual call site.
- */
-struct LogFn
-{
-    std::string m_tag;
-
-    LogFn() : m_tag(LOGGER_DEFAULT_TAG) {}
-    LogFn(std::string_view tag) : m_tag(tag) {}  // NOLINT(google-explicit-constructor)
-    LogFn(std::string tag) : m_tag(std::move(tag)) {}  // NOLINT(google-explicit-constructor)
-    LogFn(const char* tag) : m_tag(tag ? tag : LOGGER_DEFAULT_TAG) {}  // NOLINT(google-explicit-constructor)
-
-    /**
-     * Returns a new LogFn for @p component within the same process.
-     * Replaces the library part of the tag — does NOT accumulate a chain.
-     *   LogFn{"proc"}.compose("rocksdb")          → "proc(rocksdb)"
-     *   LogFn{"proc(keystore)"}.compose("rocksdb") → "proc(rocksdb)"
-     */
-    LogFn compose(std::string_view component) const
+    // Pre-bound log wrapper. Holds a tag string and dispatches through GLOBAL_LOG_FUNCTION.
+    // Use via LOGFN_* macros so that source location is captured at the call site.
+    struct LogFn
     {
-        const auto open = m_tag.find('(');
-        const auto base = (open != std::string::npos) ? m_tag.substr(0, open) : m_tag;
-        if (base.empty())
-            return LogFn {std::string(component)};
-        return LogFn {base + "(" + std::string(component) + ")"};
-    }
+        std::string m_tag;
 
-    const char* c_str() const { return m_tag.c_str(); }
-
-    void info(Log::SourceFile src, const char* fmt, ...) const
-    {
-        if (Log::GLOBAL_LOG_FUNCTION)
+        LogFn()
+            : m_tag(LOGGER_DEFAULT_TAG)
         {
-            std::va_list args;
-            va_start(args, fmt);
-            Log::GLOBAL_LOG_FUNCTION(Log::LOGLEVEL_INFO, m_tag.c_str(), src.file, src.line, src.func, fmt, args);
-            va_end(args);
         }
-    }
-
-    void warn(Log::SourceFile src, const char* fmt, ...) const
-    {
-        if (Log::GLOBAL_LOG_FUNCTION)
+        LogFn(std::string_view tag)
+            : m_tag(tag)
         {
-            std::va_list args;
-            va_start(args, fmt);
-            Log::GLOBAL_LOG_FUNCTION(Log::LOGLEVEL_WARNING, m_tag.c_str(), src.file, src.line, src.func, fmt, args);
-            va_end(args);
-        }
-    }
-
-    void debug1(Log::SourceFile src, const char* fmt, ...) const
-    {
-        if (Log::GLOBAL_LOG_FUNCTION)
+        } // NOLINT(google-explicit-constructor)
+        LogFn(std::string tag)
+            : m_tag(std::move(tag))
         {
-            std::va_list args;
-            va_start(args, fmt);
-            Log::GLOBAL_LOG_FUNCTION(Log::LOGLEVEL_DEBUG, m_tag.c_str(), src.file, src.line, src.func, fmt, args);
-            va_end(args);
-        }
-    }
-
-    void debug2(Log::SourceFile src, const char* fmt, ...) const
-    {
-        if (Log::GLOBAL_LOG_FUNCTION)
+        } // NOLINT(google-explicit-constructor)
+        LogFn(const char* tag)
+            : m_tag(tag ? tag : LOGGER_DEFAULT_TAG)
         {
-            std::va_list args;
-            va_start(args, fmt);
-            Log::GLOBAL_LOG_FUNCTION(
-                Log::LOGLEVEL_DEBUG_VERBOSE, m_tag.c_str(), src.file, src.line, src.func, fmt, args);
-            va_end(args);
-        }
-    }
+        } // NOLINT(google-explicit-constructor)
 
-    void error(Log::SourceFile src, const char* fmt, ...) const
-    {
-        if (Log::GLOBAL_LOG_FUNCTION)
+        // Returns a new LogFn with the library part of the tag replaced by component.
+        LogFn compose(std::string_view component) const
         {
-            std::va_list args;
-            va_start(args, fmt);
-            Log::GLOBAL_LOG_FUNCTION(Log::LOGLEVEL_ERROR, m_tag.c_str(), src.file, src.line, src.func, fmt, args);
-            va_end(args);
+            const auto open = m_tag.find('(');
+            const auto base = (open != std::string::npos) ? m_tag.substr(0, open) : m_tag;
+            if (base.empty())
+                return LogFn {std::string(component)};
+            return LogFn {base + "(" + std::string(component) + ")"};
         }
-    }
-};
 
-// clang-format off
-#define LOG_INFO(fn, fmt, ...)   (fn).info( {__FILE__, __LINE__, __func__}, fmt, ##__VA_ARGS__)
-#define LOG_WARN(fn, fmt, ...)   (fn).warn( {__FILE__, __LINE__, __func__}, fmt, ##__VA_ARGS__)
-#define LOG_DEBUG1(fn, fmt, ...) (fn).debug1({__FILE__, __LINE__, __func__}, fmt, ##__VA_ARGS__)
-#define LOG_DEBUG2(fn, fmt, ...) (fn).debug2({__FILE__, __LINE__, __func__}, fmt, ##__VA_ARGS__)
-#define LOG_ERROR(fn, fmt, ...)  (fn).error( {__FILE__, __LINE__, __func__}, fmt, ##__VA_ARGS__)
-// clang-format on
+        const char* c_str() const
+        {
+            return m_tag.c_str();
+        }
 
-namespace Log
-{
-    /**
-     * @brief Returns the thread-local LogFn for the current module/process context.
-     *
-     * Each module thread sets this once via setModuleLogFn() so that shared
-     * libraries can read the right base tag without being explicitly passed one.
-     */
+        void info(SourceFile src, const char* fmt, ...) const
+        {
+            if (GLOBAL_LOG_FUNCTION)
+            {
+                std::va_list args;
+                va_start(args, fmt);
+                GLOBAL_LOG_FUNCTION(LOGLEVEL_INFO, m_tag.c_str(), src.file, src.line, src.func, fmt, args);
+                va_end(args);
+            }
+        }
+
+        void warn(SourceFile src, const char* fmt, ...) const
+        {
+            if (GLOBAL_LOG_FUNCTION)
+            {
+                std::va_list args;
+                va_start(args, fmt);
+                GLOBAL_LOG_FUNCTION(LOGLEVEL_WARNING, m_tag.c_str(), src.file, src.line, src.func, fmt, args);
+                va_end(args);
+            }
+        }
+
+        void debug1(SourceFile src, const char* fmt, ...) const
+        {
+            if (GLOBAL_LOG_FUNCTION)
+            {
+                std::va_list args;
+                va_start(args, fmt);
+                GLOBAL_LOG_FUNCTION(LOGLEVEL_DEBUG, m_tag.c_str(), src.file, src.line, src.func, fmt, args);
+                va_end(args);
+            }
+        }
+
+        void debug2(SourceFile src, const char* fmt, ...) const
+        {
+            if (GLOBAL_LOG_FUNCTION)
+            {
+                std::va_list args;
+                va_start(args, fmt);
+                GLOBAL_LOG_FUNCTION(LOGLEVEL_DEBUG_VERBOSE, m_tag.c_str(), src.file, src.line, src.func, fmt, args);
+                va_end(args);
+            }
+        }
+
+        void error(SourceFile src, const char* fmt, ...) const
+        {
+            if (GLOBAL_LOG_FUNCTION)
+            {
+                std::va_list args;
+                va_start(args, fmt);
+                GLOBAL_LOG_FUNCTION(LOGLEVEL_ERROR, m_tag.c_str(), src.file, src.line, src.func, fmt, args);
+                va_end(args);
+            }
+        }
+    }; // struct LogFn
+
+    // Returns the thread-local LogFn for the current module context.
     inline LogFn& currentModuleLogFn()
     {
         thread_local LogFn tl_logFn;
         return tl_logFn;
     }
 
-    /**
-     * @brief Sets the module log context for the calling thread.
-     *
-     * Call this once per module thread before creating any shared-library objects.
-     * Example: Log::setModuleLogFn(LogFn{WM_INVENTORY_SYNC_LOGTAG});
-     */
-    inline void setModuleLogFn(LogFn fn) { currentModuleLogFn() = std::move(fn); }
+    // Sets the module LogFn for the calling thread.
+    inline void setModuleLogFn(LogFn fn)
+    {
+        currentModuleLogFn() = std::move(fn);
+    }
 
-    /**
-     * @brief RAII guard that temporarily installs a module LogFn on the calling thread.
-     *
-     * Saves the current thread-local LogFn on construction, installs the provided one,
-     * and restores the saved value on destruction. Use before constructing objects that
-     * call makeLibLogFn() so they inherit the correct caller context rather than the
-     * default "logger-helper" fallback.
-     *
-     * The guard must not outlive the thread that created it — do not store it on the heap
-     * or pass it to another thread.
-     *
-     * Example:
-     *   {
-     *       const Log::ScopedModuleLogFn guard {LogFn {callerName}};
-     *       m_queue = std::make_unique<RocksDBQueue>(...);  // picks up callerName
-     *   }  // previous context restored here
-     */
+    // RAII guard that installs a LogFn on the calling thread and restores the previous one on destruction.
     class ScopedModuleLogFn
     {
         LogFn m_saved;
@@ -382,26 +392,21 @@ namespace Log
         {
             setModuleLogFn(std::move(fn));
         }
-        ~ScopedModuleLogFn() { setModuleLogFn(std::move(m_saved)); }
+        ~ScopedModuleLogFn()
+        {
+            setModuleLogFn(std::move(m_saved));
+        }
         ScopedModuleLogFn(const ScopedModuleLogFn&) = delete;
         ScopedModuleLogFn& operator=(const ScopedModuleLogFn&) = delete;
     };
+    // Returns a LogFn with the library name composed onto the calling thread's module LogFn.
+    inline LogFn makeLibLogFn(std::string_view libName)
+    {
+        return currentModuleLogFn().compose(libName);
+    }
 } // namespace Log
 
-/**
- * @brief Creates a LogFn for a shared library by composing the library name
- *        onto the current thread's module LogFn.
- *
- * Result: "<process>:<module>(<libName>)"  e.g. "wazuh-manager-modulesd:inventory-sync(rocksdb)"
- *         or "<process>(<libName>)"         e.g. "wazuh-manager-analysisd(indexer-connector)"
- *
- * The base context must have been set with Log::setModuleLogFn() on this thread before calling
- * this function. If it has not been set, the thread-local defaults to LogFn{"logger-helper"} and
- * the result will be "logger-helper(<libName>)" — a valid fallback, but without module context.
- */
-inline LogFn makeLibLogFn(std::string_view libName)
-{
-    return Log::currentModuleLogFn().compose(libName);
-}
+using LogFn = Log::LogFn;
+using Log::makeLibLogFn;
 
 #endif // LOGGER_HELPER_H

--- a/src/shared_modules/utils/rocksDBQueue.hpp
+++ b/src/shared_modules/utils/rocksDBQueue.hpp
@@ -91,7 +91,7 @@ public:
                         throw std::runtime_error("Failed to open RocksDB database after repairing. Reason: " +
                                                  std::string {status.getState()});
                     }
-                    LOG_WARN(m_logFn, "Database '%s' was repaired because it was corrupt.", connectorName.c_str());
+                    LOGFN_WARN(m_logFn, "Database '%s' was repaired because it was corrupt.", connectorName.c_str());
                 }
             }
             else

--- a/src/shared_modules/utils/rocksDBQueueCF.hpp
+++ b/src/shared_modules/utils/rocksDBQueueCF.hpp
@@ -129,7 +129,7 @@ public:
                         throw std::runtime_error("Failed to open RocksDB database after repairing. Reason: " +
                                                  std::string {status.getState()});
                     }
-                    LOG_WARN(m_logFn, "Database '%s' was repaired because it was corrupt.", path.c_str());
+                    LOGFN_WARN(m_logFn, "Database '%s' was repaired because it was corrupt.", path.c_str());
                 }
             }
             else

--- a/src/shared_modules/utils/rocksDBWrapper.hpp
+++ b/src/shared_modules/utils/rocksDBWrapper.hpp
@@ -787,7 +787,7 @@ namespace Utils
                     throw std::runtime_error("Failed to repair RocksDB database. Reason: " +
                                              std::string {repairStatus.getState()});
                 }
-                LOG_WARN(m_logFn, "Database '%s' was repaired because it was corrupt.", m_path.c_str());
+                LOGFN_WARN(m_logFn, "Database '%s' was repaired because it was corrupt.", m_path.c_str());
             }
             else
             {

--- a/src/shared_modules/utils/threadDispatcher.h
+++ b/src/shared_modules/utils/threadDispatcher.h
@@ -11,18 +11,18 @@
 
 #ifndef THREAD_DISPATCHER_H
 #define THREAD_DISPATCHER_H
-#include <vector>
-#include <thread>
 #include <atomic>
-#include <future>
 #include <functional>
+#include <future>
 #include <string>
+#include <thread>
+#include <vector>
 
-#include "loggerHelper.h"
-#include "threadSafeQueue.h"
-#include "promiseFactory.h"
 #include "commonDefs.h"
+#include "loggerHelper.h"
 #include "proc.hpp"
+#include "promiseFactory.h"
+#include "threadSafeQueue.h"
 
 namespace Utils
 {
@@ -63,177 +63,164 @@ namespace Utils
     //  void cancel();
     // };
 
-    template
-    <
-        typename Type,
-        typename Functor
-        >
+    template<typename Type, typename Functor>
     class AsyncDispatcher
     {
-        public:
-            AsyncDispatcher(Functor functor, const unsigned int numberOfThreads = cpp_get_nproc(), const size_t maxQueueSize = UNLIMITED_QUEUE_SIZE)
-                : m_functor{ functor }
-                , m_running{ true }
-                , m_numberOfThreads{ numberOfThreads ? numberOfThreads : 1 }
-                , m_maxQueueSize { maxQueueSize }
-                , m_logFn(makeLibLogFn("async-dispatcher"))
-            {
-                m_threads.reserve(m_numberOfThreads);
+    public:
+        AsyncDispatcher(Functor functor,
+                        const unsigned int numberOfThreads = cpp_get_nproc(),
+                        const size_t maxQueueSize = UNLIMITED_QUEUE_SIZE)
+            : m_functor {functor}
+            , m_running {true}
+            , m_numberOfThreads {numberOfThreads ? numberOfThreads : 1}
+            , m_maxQueueSize {maxQueueSize}
+            , m_logFn(makeLibLogFn("async-dispatcher"))
+        {
+            m_threads.reserve(m_numberOfThreads);
 
-                for (unsigned int i = 0; i < m_numberOfThreads; ++i)
+            for (unsigned int i = 0; i < m_numberOfThreads; ++i)
+            {
+                m_threads.push_back(std::thread {&AsyncDispatcher<Type, Functor>::dispatch, this});
+            }
+        }
+        AsyncDispatcher& operator=(const AsyncDispatcher&) = delete;
+        AsyncDispatcher(AsyncDispatcher& other) = delete;
+        ~AsyncDispatcher()
+        {
+            cancel();
+        }
+
+        void push(const Type& value)
+        {
+            if (m_running)
+            {
+                if (UNLIMITED_QUEUE_SIZE == m_maxQueueSize || m_queue.size() < m_maxQueueSize)
                 {
-                    m_threads.push_back(std::thread{ &AsyncDispatcher<Type, Functor>::dispatch, this });
+                    m_queue.push([value, this]() { this->m_functor(value); });
                 }
             }
-            AsyncDispatcher& operator=(const AsyncDispatcher&) = delete;
-            AsyncDispatcher(AsyncDispatcher& other) = delete;
-            ~AsyncDispatcher()
+        }
+
+        void rundown()
+        {
+            if (m_running)
             {
+                auto promise {PromiseFactory<PROMISE_TYPE>::getPromiseObject()};
+                m_queue.push([&promise]() { promise->set_value(); });
+                promise->wait();
                 cancel();
             }
+        }
+        void cancel()
+        {
+            m_running = false;
+            m_queue.cancel();
+            joinThreads();
+        }
 
-            void push(const Type& value)
+        bool cancelled() const
+        {
+            return !m_running;
+        }
+        unsigned int numberOfThreads() const
+        {
+            return m_numberOfThreads;
+        }
+        size_t size() const
+        {
+            return m_queue.size();
+        }
+
+    private:
+        void dispatch()
+        {
+            while (m_running)
             {
-                if (m_running)
+                try
                 {
-                    if (UNLIMITED_QUEUE_SIZE == m_maxQueueSize || m_queue.size() < m_maxQueueSize)
+                    std::function<void()> fnc;
+
+                    if (m_queue.pop(fnc))
                     {
-                        m_queue.push
-                        (
-                            [value, this]()
-                        {
-                            this->m_functor(value);
-                        }
-                        );
+                        fnc();
                     }
                 }
-            }
-
-            void rundown()
-            {
-                if (m_running)
+                catch (const std::exception& ex)
                 {
-                    auto promise { PromiseFactory<PROMISE_TYPE>::getPromiseObject() };
-                    m_queue.push
-                    (
-                        [&promise]()
-                    {
-                        promise->set_value();
-                    }
-                    );
-                    promise->wait();
-                    cancel();
+                    LOGFN_DEBUG1(m_logFn, "Dispatch handler error, %s", ex.what());
                 }
             }
-            void cancel()
+        }
+        void joinThreads()
+        {
+            for (auto& thread : m_threads)
             {
-                m_running = false;
-                m_queue.cancel();
-                joinThreads();
-            }
-
-            bool cancelled() const
-            {
-                return !m_running;
-            }
-            unsigned int numberOfThreads() const
-            {
-                return m_numberOfThreads;
-            }
-            size_t size() const
-            {
-                return m_queue.size();
-            }
-
-        private:
-            void dispatch()
-            {
-                while (m_running)
+                if (thread.joinable())
                 {
-                    try
-                    {
-                        std::function<void()> fnc;
-
-                        if (m_queue.pop(fnc))
-                        {
-                            fnc();
-                        }
-                    }
-                    catch (const std::exception& ex)
-                    {
-                        LOG_DEBUG1(m_logFn, "Dispatch handler error, %s", ex.what());
-                    }
+                    thread.join();
                 }
             }
-            void joinThreads()
-            {
-                for (auto& thread : m_threads)
-                {
-                    if (thread.joinable())
-                    {
-                        thread.join();
-                    }
-                }
-            }
+        }
 
-            Functor m_functor;
-            SafeQueue<std::function<void()>> m_queue;
-            std::vector<std::thread> m_threads;
-            std::atomic_bool m_running;
-            const unsigned int m_numberOfThreads;
-            const size_t m_maxQueueSize;
-            LogFn m_logFn;
+        Functor m_functor;
+        SafeQueue<std::function<void()>> m_queue;
+        std::vector<std::thread> m_threads;
+        std::atomic_bool m_running;
+        const unsigned int m_numberOfThreads;
+        const size_t m_maxQueueSize;
+        LogFn m_logFn;
     };
 
-    template <typename Input, typename Functor>
+    template<typename Input, typename Functor>
     class SyncDispatcher
     {
-        public:
-            SyncDispatcher(Functor functor,
-                           const unsigned int /*numberOfThreads = std::thread::hardware_concurrency()*/,
-                           const size_t /*maxQueueSize = UNLIMITED_QUEUE_SIZE*/)
-                : m_functor{functor}
-                , m_running{true}
-            {
-            }
+    public:
+        SyncDispatcher(Functor functor,
+                       const unsigned int /*numberOfThreads = std::thread::hardware_concurrency()*/,
+                       const size_t /*maxQueueSize = UNLIMITED_QUEUE_SIZE*/)
+            : m_functor {functor}
+            , m_running {true}
+        {
+        }
 
-            SyncDispatcher(Functor functor)
-                : m_functor{functor}
-                , m_running{true}
-            {
-            }
+        SyncDispatcher(Functor functor)
+            : m_functor {functor}
+            , m_running {true}
+        {
+        }
 
-            void push(const Input& data)
+        void push(const Input& data)
+        {
+            if (m_running)
             {
-                if (m_running)
-                {
-                    m_functor(data);
-                }
+                m_functor(data);
             }
-            size_t size() const
-            {
-                return 0;
-            }
-            void rundown()
-            {
-                cancel();
-            }
-            void cancel()
-            {
-                m_running = false;
-            }
-            bool cancelled() const
-            {
-                return !m_running;
-            }
-            unsigned int numberOfThreads() const
-            {
-                return 0;
-            }
-            ~SyncDispatcher() = default;
-        private:
-            Functor m_functor;
-            bool m_running;
+        }
+        size_t size() const
+        {
+            return 0;
+        }
+        void rundown()
+        {
+            cancel();
+        }
+        void cancel()
+        {
+            m_running = false;
+        }
+        bool cancelled() const
+        {
+            return !m_running;
+        }
+        unsigned int numberOfThreads() const
+        {
+            return 0;
+        }
+        ~SyncDispatcher() = default;
+
+    private:
+        Functor m_functor;
+        bool m_running;
     };
-}//namespace Utils
-#endif //THREAD_DISPATCHER_H
+} // namespace Utils
+#endif // THREAD_DISPATCHER_H

--- a/src/shared_modules/utils/threadEventDispatcher.hpp
+++ b/src/shared_modules/utils/threadEventDispatcher.hpp
@@ -87,9 +87,9 @@ public:
                 // If we were previously discarding, log that we're accepting again
                 if (m_discardedCount.load() > 0)
                 {
-                    LOG_INFO(m_logFn,
-                             "Queue size normalized. Resuming event acceptance after %zu discarded events.",
-                             m_discardedCount.load());
+                    LOGFN_INFO(m_logFn,
+                               "Queue size normalized. Resuming event acceptance after %zu discarded events.",
+                               m_discardedCount.load());
                     m_discardedCount = 0;
                     m_firstDiscardLogged = false;
                 }
@@ -104,12 +104,12 @@ public:
                 // Log the first discard immediately
                 if (!m_firstDiscardLogged.exchange(true))
                 {
-                    LOG_WARN(m_logFn,
-                             "Queue is full (size: %zu, max: %zu). Starting to discard events. "
-                             "Periodic summaries will be logged every %zu seconds.",
-                             m_queue->size(),
-                             m_maxQueueSize,
-                             m_summaryInterval);
+                    LOGFN_WARN(m_logFn,
+                               "Queue is full (size: %zu, max: %zu). Starting to discard events. "
+                               "Periodic summaries will be logged every %zu seconds.",
+                               m_queue->size(),
+                               m_maxQueueSize,
+                               m_summaryInterval);
                     m_lastSummaryLog = now;
                 }
                 // Log periodic summary
@@ -119,14 +119,14 @@ public:
                         std::chrono::duration_cast<std::chrono::seconds>(now - m_lastSummaryLog).count();
                     if (elapsed >= m_summaryInterval)
                     {
-                        LOG_WARN(m_logFn,
-                                 "Queue overflow continues: %zu events discarded in the last %lld seconds "
-                                 "(queue size: %zu, max: %zu, total discarded: %zu).",
-                                 discarded - m_lastDiscardedCount.load(),
-                                 elapsed,
-                                 m_queue->size(),
-                                 m_maxQueueSize,
-                                 discarded);
+                        LOGFN_WARN(m_logFn,
+                                   "Queue overflow continues: %zu events discarded in the last %lld seconds "
+                                   "(queue size: %zu, max: %zu, total discarded: %zu).",
+                                   discarded - m_lastDiscardedCount.load(),
+                                   elapsed,
+                                   m_queue->size(),
+                                   m_maxQueueSize,
+                                   discarded);
                         m_lastSummaryLog = now;
                         m_lastDiscardedCount = discarded;
                     }
@@ -151,11 +151,11 @@ public:
                 // If we were previously discarding, log that we're accepting again
                 if (m_discardedCount.load() > 0)
                 {
-                    LOG_INFO(m_logFn,
-                             "Queue '%.*s' size normalized. Resuming event acceptance after %zu discarded events.",
-                             static_cast<int>(prefix.size()),
-                             prefix.data(),
-                             m_discardedCount.load());
+                    LOGFN_INFO(m_logFn,
+                               "Queue '%.*s' size normalized. Resuming event acceptance after %zu discarded events.",
+                               static_cast<int>(prefix.size()),
+                               prefix.data(),
+                               m_discardedCount.load());
                     m_discardedCount = 0;
                     m_firstDiscardLogged = false;
                 }
@@ -170,14 +170,14 @@ public:
                 // Log the first discard immediately
                 if (!m_firstDiscardLogged.exchange(true))
                 {
-                    LOG_WARN(m_logFn,
-                             "Queue '%.*s' is full (size: %zu, max: %zu). Starting to discard events. "
-                             "Periodic summaries will be logged every %zu seconds.",
-                             static_cast<int>(prefix.size()),
-                             prefix.data(),
-                             m_queue->size(prefix),
-                             m_maxQueueSize,
-                             m_summaryInterval);
+                    LOGFN_WARN(m_logFn,
+                               "Queue '%.*s' is full (size: %zu, max: %zu). Starting to discard events. "
+                               "Periodic summaries will be logged every %zu seconds.",
+                               static_cast<int>(prefix.size()),
+                               prefix.data(),
+                               m_queue->size(prefix),
+                               m_maxQueueSize,
+                               m_summaryInterval);
                     m_lastSummaryLog = now;
                 }
                 // Log periodic summary
@@ -187,16 +187,16 @@ public:
                         std::chrono::duration_cast<std::chrono::seconds>(now - m_lastSummaryLog).count();
                     if (elapsed >= m_summaryInterval)
                     {
-                        LOG_WARN(m_logFn,
-                                 "Queue '%.*s' overflow continues: %zu events discarded in the last %lld seconds "
-                                 "(queue size: %zu, max: %zu, total discarded: %zu).",
-                                 static_cast<int>(prefix.size()),
-                                 prefix.data(),
-                                 discarded - m_lastDiscardedCount.load(),
-                                 elapsed,
-                                 m_queue->size(prefix),
-                                 m_maxQueueSize,
-                                 discarded);
+                        LOGFN_WARN(m_logFn,
+                                   "Queue '%.*s' overflow continues: %zu events discarded in the last %lld seconds "
+                                   "(queue size: %zu, max: %zu, total discarded: %zu).",
+                                   static_cast<int>(prefix.size()),
+                                   prefix.data(),
+                                   discarded - m_lastDiscardedCount.load(),
+                                   elapsed,
+                                   m_queue->size(prefix),
+                                   m_maxQueueSize,
+                                   discarded);
                         m_lastSummaryLog = now;
                         m_lastDiscardedCount = discarded;
                     }
@@ -335,11 +335,11 @@ private:
                 if (m_running)
                 {
                     std::this_thread::sleep_for(std::chrono::seconds(m_retryDelay));
-                    LOG_WARN(m_logFn, "Dispatch handler error, %s", ex.what());
+                    LOGFN_WARN(m_logFn, "Dispatch handler error, %s", ex.what());
                 }
                 else
                 {
-                    LOG_DEBUG1(m_logFn, "ThreadEventDispatcher dispatch end.");
+                    LOGFN_DEBUG1(m_logFn, "ThreadEventDispatcher dispatch end.");
                 }
             }
         }

--- a/src/wazuh_modules/inventory_sync/src/agentSession.hpp
+++ b/src/wazuh_modules/inventory_sync/src/agentSession.hpp
@@ -156,13 +156,13 @@ public:
                     auto entry = index->str();
                     if (!isAgentScopedStateIndex(entry))
                     {
-                        LOG_WARN(m_logFn,
-                                 "Start: ignoring index '%s' (does not belong to wazuh-states-* family) for "
-                                 "agent '%.*s' (session %llu).",
-                                 entry.c_str(),
-                                 static_cast<int>(agentId.size()),
-                                 agentId.data(),
-                                 sessionId);
+                        LOGFN_WARN(m_logFn,
+                                   "Start: ignoring index '%s' (does not belong to wazuh-states-* family) for "
+                                   "agent '%.*s' (session %llu).",
+                                   entry.c_str(),
+                                   static_cast<int>(agentId.size()),
+                                   agentId.data(),
+                                   sessionId);
                         continue;
                     }
                     indices.emplace_back(std::move(entry));
@@ -205,17 +205,17 @@ public:
                                                .clusterName = std::string(clusterName.data(), clusterName.size()),
                                                .clusterNode = std::string(clusterNode.data(), clusterNode.size())});
 
-        LOG_DEBUG2(m_logFn,
-                   "New session for module '%s' by agent '%s'. (Session %llu)",
-                   m_context->moduleName.c_str(),
-                   m_context->agentId.c_str(),
-                   m_context->sessionId);
+        LOGFN_DEBUG2(m_logFn,
+                     "New session for module '%s' by agent '%s'. (Session %llu)",
+                     m_context->moduleName.c_str(),
+                     m_context->agentId.c_str(),
+                     m_context->sessionId);
 
-        LOG_DEBUG2(m_logFn,
-                   "Session %llu cluster info - cluster_name: '%s', cluster_node: '%s'",
-                   m_context->sessionId,
-                   m_context->clusterName.c_str(),
-                   m_context->clusterNode.c_str());
+        LOGFN_DEBUG2(m_logFn,
+                     "Session %llu cluster info - cluster_name: '%s', cluster_node: '%s'",
+                     m_context->sessionId,
+                     m_context->clusterName.c_str(),
+                     m_context->clusterNode.c_str());
 
         responseDispatcher.sendStartAck(
             Wazuh::SyncSchema::Status_Ok, m_context->agentId, m_context->sessionId, m_context->moduleName);
@@ -253,21 +253,21 @@ public:
         const auto seq = data->seq();
         const auto session = data->session();
 
-        LOG_DEBUG2(m_logFn, "Handling sequence number '%llu' for session '%llu'", seq, session);
+        LOGFN_DEBUG2(m_logFn, "Handling sequence number '%llu' for session '%llu'", seq, session);
 
         // Avoid storing data if the sequence number is out of declared size bounds;
         // GapSet::observe will throw std::out_of_range below and the WorkersQueue
         // wrapper will absorb it, so m_store.put never runs and no orphan key is left.
         if (seq >= m_declaredSize)
         {
-            LOG_WARN(m_logFn,
-                     "Data sequence number '%llu' exceeds declared size '%llu' for session %llu "
-                     "(agent '%s', module '%s'); rejecting message.",
-                     seq,
-                     m_declaredSize,
-                     m_context->sessionId,
-                     m_context->agentId.c_str(),
-                     m_context->moduleName.c_str());
+            LOGFN_WARN(m_logFn,
+                       "Data sequence number '%llu' exceeds declared size '%llu' for session %llu "
+                       "(agent '%s', module '%s'); rejecting message.",
+                       seq,
+                       m_declaredSize,
+                       m_context->sessionId,
+                       m_context->agentId.c_str(),
+                       m_context->moduleName.c_str());
             throw std::out_of_range("Sequence number out of declared size bounds");
         }
 
@@ -278,12 +278,12 @@ public:
         // the observation should not throw, though if it does the data chunk is already stored.
         m_gapSet->observe(data->seq());
 
-        LOG_DEBUG2(m_logFn,
-                   "Data received: %s %llu %llu %s",
-                   std::format("{}_{}", session, seq).c_str(),
-                   m_context->sessionId,
-                   m_context->agentId,
-                   m_context->moduleName.c_str());
+        LOGFN_DEBUG2(m_logFn,
+                     "Data received: %s %llu %llu %s",
+                     std::format("{}_{}", session, seq).c_str(),
+                     m_context->sessionId,
+                     m_context->agentId,
+                     m_context->moduleName.c_str());
 
         if (m_endReceived && !m_endEnqueued)
         {
@@ -316,9 +316,9 @@ public:
         // ChecksumModule messages — they can no longer influence the in-flight bulk.
         if (m_endEnqueued)
         {
-            LOG_DEBUG2(m_logFn,
-                       "ChecksumModule arrived after End was enqueued for session %llu; ignoring",
-                       m_context->sessionId);
+            LOGFN_DEBUG2(m_logFn,
+                         "ChecksumModule arrived after End was enqueued for session %llu; ignoring",
+                         m_context->sessionId);
             return;
         }
 
@@ -332,11 +332,11 @@ public:
             auto candidate = data->index()->str();
             if (!isAgentScopedStateIndex(candidate))
             {
-                LOG_WARN(m_logFn,
-                         "ChecksumModule: ignoring index '%s' (does not belong to wazuh-states-* family) for "
-                         "session %llu.",
-                         candidate.c_str(),
-                         m_context->sessionId);
+                LOGFN_WARN(m_logFn,
+                           "ChecksumModule: ignoring index '%s' (does not belong to wazuh-states-* family) for "
+                           "session %llu.",
+                           candidate.c_str(),
+                           m_context->sessionId);
             }
             else
             {
@@ -344,11 +344,11 @@ public:
             }
         }
 
-        LOG_DEBUG2(m_logFn,
-                   "ChecksumModule received for session %llu, index: %s, checksum: %s",
-                   m_context->sessionId,
-                   m_context->checksumIndex.c_str(),
-                   m_context->checksum.c_str());
+        LOGFN_DEBUG2(m_logFn,
+                     "ChecksumModule received for session %llu, index: %s, checksum: %s",
+                     m_context->sessionId,
+                     m_context->checksumIndex.c_str(),
+                     m_context->checksum.c_str());
     }
 
     /**
@@ -374,21 +374,21 @@ public:
         const auto seq = data->seq();
         const auto session = data->session();
 
-        LOG_DEBUG2(m_logFn, "Handling DataContext sequence number '%llu' for session '%llu'", seq, session);
+        LOGFN_DEBUG2(m_logFn, "Handling DataContext sequence number '%llu' for session '%llu'", seq, session);
 
         // Avoid storing context if the sequence number is out of declared size bounds;
         // GapSet::observe will throw std::out_of_range below and the WorkersQueue
         // wrapper will absorb it, so m_store.put never runs and no orphan key is left.
         if (seq >= m_declaredSize)
         {
-            LOG_WARN(m_logFn,
-                     "DataContext sequence number '%llu' exceeds declared size '%llu' for session %llu "
-                     "(agent '%s', module '%s'); rejecting message.",
-                     seq,
-                     m_declaredSize,
-                     m_context->sessionId,
-                     m_context->agentId.c_str(),
-                     m_context->moduleName.c_str());
+            LOGFN_WARN(m_logFn,
+                       "DataContext sequence number '%llu' exceeds declared size '%llu' for session %llu "
+                       "(agent '%s', module '%s'); rejecting message.",
+                       seq,
+                       m_declaredSize,
+                       m_context->sessionId,
+                       m_context->agentId.c_str(),
+                       m_context->moduleName.c_str());
             throw std::out_of_range("Sequence number out of declared size bounds");
         }
 
@@ -400,12 +400,12 @@ public:
         // the observation should not throw, though if it does the data chunk is already stored.
         m_gapSet->observe(seq);
 
-        LOG_DEBUG2(m_logFn,
-                   "DataContext received: %s %llu %llu %s",
-                   std::format("{}_{}_context", session, seq).c_str(),
-                   m_context->sessionId,
-                   m_context->agentId,
-                   m_context->moduleName.c_str());
+        LOGFN_DEBUG2(m_logFn,
+                     "DataContext received: %s %llu %llu %s",
+                     std::format("{}_{}_context", session, seq).c_str(),
+                     m_context->sessionId,
+                     m_context->agentId,
+                     m_context->moduleName.c_str());
 
         if (m_endReceived && !m_endEnqueued)
         {
@@ -438,20 +438,20 @@ public:
         const auto seq = data->seq();
         const auto session = data->session();
 
-        LOG_DEBUG2(m_logFn, "Handling DataClean sequence number '%llu' for session '%llu'", seq, session);
+        LOGFN_DEBUG2(m_logFn, "Handling DataClean sequence number '%llu' for session '%llu'", seq, session);
 
         // Check if the sequence number is within declared size bounds; GapSet::observe will
         // throw std::out_of_range below and the WorkersQueue wrapper will absorb it.
         if (seq >= m_declaredSize)
         {
-            LOG_WARN(m_logFn,
-                     "DataClean sequence number '%llu' exceeds declared size '%llu' for session %llu "
-                     "(agent '%s', module '%s'); rejecting message.",
-                     seq,
-                     m_declaredSize,
-                     m_context->sessionId,
-                     m_context->agentId.c_str(),
-                     m_context->moduleName.c_str());
+            LOGFN_WARN(m_logFn,
+                       "DataClean sequence number '%llu' exceeds declared size '%llu' for session %llu "
+                       "(agent '%s', module '%s'); rejecting message.",
+                       seq,
+                       m_declaredSize,
+                       m_context->sessionId,
+                       m_context->agentId.c_str(),
+                       m_context->moduleName.c_str());
         }
         m_gapSet->observe(seq);
 
@@ -460,27 +460,27 @@ public:
             std::string index = data->index()->str();
             if (!isAgentScopedStateIndex(index))
             {
-                LOG_WARN(m_logFn,
-                         "DataClean: ignoring index '%s' (does not belong to wazuh-states-* family) for "
-                         "session %llu, seq %llu.",
-                         index.c_str(),
-                         m_context->sessionId,
-                         seq);
+                LOGFN_WARN(m_logFn,
+                           "DataClean: ignoring index '%s' (does not belong to wazuh-states-* family) for "
+                           "session %llu, seq %llu.",
+                           index.c_str(),
+                           m_context->sessionId,
+                           seq);
             }
             else
             {
                 m_context->dataCleanIndices.insert(index);
 
-                LOG_DEBUG2(m_logFn,
-                           "DataClean received for session %llu, seq %llu, index: %s",
-                           m_context->sessionId,
-                           seq,
-                           index.c_str());
+                LOGFN_DEBUG2(m_logFn,
+                             "DataClean received for session %llu, seq %llu, index: %s",
+                             m_context->sessionId,
+                             seq,
+                             index.c_str());
             }
         }
         else
         {
-            LOG_ERROR(
+            LOGFN_ERROR(
                 m_logFn, "DataClean received without index for session %llu, seq %llu", m_context->sessionId, seq);
         }
 
@@ -508,7 +508,7 @@ public:
 
         if (m_endEnqueued)
         {
-            LOG_DEBUG2(m_logFn, "End already enqueued for session %llu", m_context->sessionId);
+            LOGFN_DEBUG2(m_logFn, "End already enqueued for session %llu", m_context->sessionId);
             responseDispatcher.sendEndAck(
                 Wazuh::SyncSchema::Status_Processing, m_context->agentId, m_context->sessionId, m_context->moduleName);
             return;
@@ -516,7 +516,7 @@ public:
 
         if (m_gapSet->empty())
         {
-            LOG_DEBUG2(m_logFn, "All sequences received for session %llu", m_context->sessionId);
+            LOGFN_DEBUG2(m_logFn, "All sequences received for session %llu", m_context->sessionId);
             m_indexerQueue.push(Response({.status = ResponseStatus::Ok, .context = m_context}));
             m_endEnqueued = true;
             responseDispatcher.sendEndAck(

--- a/src/wazuh_modules/inventory_sync/src/inventorySync.cpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySync.cpp
@@ -60,7 +60,7 @@ extern "C"
         }
         catch (const std::exception& e)
         {
-            LOG_ERROR(LogFn {WM_INVENTORY_SYNC_LOGTAG}, "Error starting inventory sync: %s", e.what());
+            LOGFN_ERROR(LogFn {WM_INVENTORY_SYNC_LOGTAG}, "Error starting inventory sync: %s", e.what());
         }
     }
 

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -110,14 +110,14 @@ class InventorySyncFacadeImpl final
                     }
                     else
                     {
-                        LOG_ERROR(m_logFn, "Invalid delete_agent message: missing agent_id");
+                        LOGFN_ERROR(m_logFn, "Invalid delete_agent message: missing agent_id");
                     }
                     return;
                 }
             }
             catch (const std::exception& e)
             {
-                LOG_ERROR(m_logFn, "Failed to parse JSON message: %s", e.what());
+                LOGFN_ERROR(m_logFn, "Failed to parse JSON message: %s", e.what());
                 return;
             }
         }
@@ -136,13 +136,14 @@ class InventorySyncFacadeImpl final
             std::shared_lock lock(m_agentSessionsMutex);
             if (auto it = m_agentSessions.find(data->session()); it == m_agentSessions.end())
             {
-                LOG_DEBUG2(m_logFn, "InventorySyncFacade::start: Session not found, sessionId: %llu", data->session());
+                LOGFN_DEBUG2(
+                    m_logFn, "InventorySyncFacade::start: Session not found, sessionId: %llu", data->session());
             }
             else
             {
                 // Handle data - pass the raw flatbuffer bytes directly
                 it->second.handleData(data, reinterpret_cast<const uint8_t*>(dataRaw.data()), dataRaw.size());
-                LOG_DEBUG2(m_logFn, "InventorySyncFacade::start: Data handled for session %llu", data->session());
+                LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: Data handled for session %llu", data->session());
             }
         }
         else if (syncMessage->content_type() == Wazuh::SyncSchema::MessageType_DataClean)
@@ -157,15 +158,15 @@ class InventorySyncFacadeImpl final
             std::shared_lock lock(m_agentSessionsMutex);
             if (auto it = m_agentSessions.find(dataClean->session()); it == m_agentSessions.end())
             {
-                LOG_DEBUG2(m_logFn,
-                           "InventorySyncFacade::start: Session not found for DataClean, sessionId: %llu",
-                           dataClean->session());
+                LOGFN_DEBUG2(m_logFn,
+                             "InventorySyncFacade::start: Session not found for DataClean, sessionId: %llu",
+                             dataClean->session());
             }
             else
             {
                 // Handle DataClean - stores index and tracks seq number
                 it->second.handleDataClean(dataClean);
-                LOG_DEBUG2(
+                LOGFN_DEBUG2(
                     m_logFn, "InventorySyncFacade::start: DataClean handled for session %llu", dataClean->session());
             }
         }
@@ -181,18 +182,18 @@ class InventorySyncFacadeImpl final
             std::shared_lock lock(m_agentSessionsMutex);
             if (auto it = m_agentSessions.find(dataContext->session()); it == m_agentSessions.end())
             {
-                LOG_DEBUG2(m_logFn,
-                           "InventorySyncFacade::start: Session not found for DataContext, sessionId: %llu",
-                           dataContext->session());
+                LOGFN_DEBUG2(m_logFn,
+                             "InventorySyncFacade::start: Session not found for DataContext, sessionId: %llu",
+                             dataContext->session());
             }
             else
             {
                 // Handle DataContext - stores context in RocksDB and tracks seq number
                 it->second.handleDataContext(
                     dataContext, reinterpret_cast<const uint8_t*>(dataRaw.data()), dataRaw.size());
-                LOG_DEBUG2(m_logFn,
-                           "InventorySyncFacade::start: DataContext handled for session %llu",
-                           dataContext->session());
+                LOGFN_DEBUG2(m_logFn,
+                             "InventorySyncFacade::start: DataContext handled for session %llu",
+                             dataContext->session());
             }
         }
         else if (syncMessage->content_type() == Wazuh::SyncSchema::MessageType_DataBatch)
@@ -203,9 +204,9 @@ class InventorySyncFacadeImpl final
                 throw InventorySyncException("Invalid data batch message");
             }
 
-            LOG_DEBUG2(m_logFn,
-                       "InventorySyncFacade::start: Received DataBatch with %zu DataValues.",
-                       dataBatch->values()->size());
+            LOGFN_DEBUG2(m_logFn,
+                         "InventorySyncFacade::start: Received DataBatch with %zu DataValues.",
+                         dataBatch->values()->size());
 
             std::shared_lock lock(m_agentSessionsMutex);
             for (const auto* dataValue : *dataBatch->values())
@@ -217,9 +218,9 @@ class InventorySyncFacadeImpl final
 
                 if (auto it = m_agentSessions.find(dataValue->session()); it == m_agentSessions.end())
                 {
-                    LOG_DEBUG2(m_logFn,
-                               "InventorySyncFacade::start: Session not found, sessionId: %llu",
-                               dataValue->session());
+                    LOGFN_DEBUG2(m_logFn,
+                                 "InventorySyncFacade::start: Session not found, sessionId: %llu",
+                                 dataValue->session());
                 }
                 else
                 {
@@ -251,17 +252,17 @@ class InventorySyncFacadeImpl final
                         dvBuilder.Finish(msgOffset);
 
                         it->second.handleData(dataValue, dvBuilder.GetBufferPointer(), dvBuilder.GetSize());
-                        LOG_DEBUG2(m_logFn,
-                                   "InventorySyncFacade::start: DataBatch item handled for session %llu",
-                                   dataValue->session());
+                        LOGFN_DEBUG2(m_logFn,
+                                     "InventorySyncFacade::start: DataBatch item handled for session %llu",
+                                     dataValue->session());
                     }
                     catch (const std::exception& e)
                     {
-                        LOG_ERROR(m_logFn,
-                                  "InventorySyncFacade::start: DataBatch item failed for session %llu, seq %llu: %s",
-                                  dataValue->session(),
-                                  dataValue->seq(),
-                                  e.what());
+                        LOGFN_ERROR(m_logFn,
+                                    "InventorySyncFacade::start: DataBatch item failed for session %llu, seq %llu: %s",
+                                    dataValue->session(),
+                                    dataValue->seq(),
+                                    e.what());
                     }
                 }
             }
@@ -287,14 +288,14 @@ class InventorySyncFacadeImpl final
             const bool isVDModule = (moduleNameStr == "syscollector_vd");
             if (isAgentLocked(agentIdStr, isVDModule))
             {
-                LOG_DEBUG2(m_logFn,
-                           "InventorySyncFacade::start: Agent %s is locked, rejecting new session",
-                           agentIdStr.c_str());
+                LOGFN_DEBUG2(m_logFn,
+                             "InventorySyncFacade::start: Agent %s is locked, rejecting new session",
+                             agentIdStr.c_str());
                 m_responseDispatcher->sendStartAck(Wazuh::SyncSchema::Status_Error, agentId, -1, moduleName);
             }
             else if (!m_indexerConnector->isAvailable())
             {
-                LOG_DEBUG2(m_logFn, "InventorySyncFacade::start: No available server");
+                LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: No available server");
                 m_responseDispatcher->sendStartAck(Wazuh::SyncSchema::Status_Offline, agentId, -1, moduleName);
             }
             else
@@ -308,12 +309,12 @@ class InventorySyncFacadeImpl final
 
                 if (m_agentSessions.size() >= static_cast<size_t>(m_maxSessions))
                 {
-                    LOG_WARN(m_logFn,
-                             "InventorySyncFacade::start: Session limit reached (%zu/%d active sessions). "
-                             "Rejecting new session for agent %s - agent will retry later",
-                             m_agentSessions.size(),
-                             m_maxSessions,
-                             std::string(agentId).c_str());
+                    LOGFN_WARN(m_logFn,
+                               "InventorySyncFacade::start: Session limit reached (%zu/%d active sessions). "
+                               "Rejecting new session for agent %s - agent will retry later",
+                               m_agentSessions.size(),
+                               m_maxSessions,
+                               std::string(agentId).c_str());
                     m_responseDispatcher->sendStartAck(Wazuh::SyncSchema::Status_Offline, agentId, -1, moduleName);
                 }
                 else
@@ -333,12 +334,12 @@ class InventorySyncFacadeImpl final
                     }
                     if (!admitted)
                     {
-                        LOG_WARN(m_logFn,
-                                 "InventorySyncFacade::start: DataValue quota exhausted "
-                                 "(requested=%llu, remaining=%llu); rejecting session for agent %s",
-                                 static_cast<unsigned long long>(requestedSize),
-                                 static_cast<unsigned long long>(remaining),
-                                 std::string(agentId).c_str());
+                        LOGFN_WARN(m_logFn,
+                                   "InventorySyncFacade::start: DataValue quota exhausted "
+                                   "(requested=%llu, remaining=%llu); rejecting session for agent %s",
+                                   static_cast<unsigned long long>(requestedSize),
+                                   static_cast<unsigned long long>(remaining),
+                                   std::string(agentId).c_str());
                         m_responseDispatcher->sendStartAck(Wazuh::SyncSchema::Status_Offline, agentId, -1, moduleName);
                     }
                     else
@@ -373,7 +374,7 @@ class InventorySyncFacadeImpl final
                             restoreQuota(requestedSize);
                             throw;
                         }
-                        LOG_DEBUG2(m_logFn, "InventorySyncFacade::start: Session created %llu", sessionId);
+                        LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: Session created %llu", sessionId);
                     }
                 }
             }
@@ -390,17 +391,17 @@ class InventorySyncFacadeImpl final
             std::shared_lock lock(m_agentSessionsMutex);
             if (auto it = m_agentSessions.find(checksumModule->session()); it == m_agentSessions.end())
             {
-                LOG_DEBUG2(m_logFn,
-                           "InventorySyncFacade::start: Session not found, sessionId: %llu",
-                           checksumModule->session());
+                LOGFN_DEBUG2(m_logFn,
+                             "InventorySyncFacade::start: Session not found, sessionId: %llu",
+                             checksumModule->session());
             }
             else
             {
                 // Handle checksum module.
                 it->second.handleChecksumModule(checksumModule);
-                LOG_DEBUG2(m_logFn,
-                           "InventorySyncFacade::start: ChecksumModule handled for session %llu",
-                           checksumModule->session());
+                LOGFN_DEBUG2(m_logFn,
+                             "InventorySyncFacade::start: ChecksumModule handled for session %llu",
+                             checksumModule->session());
             }
         }
         else if (syncMessage->content_type() == Wazuh::SyncSchema::MessageType_End)
@@ -415,13 +416,13 @@ class InventorySyncFacadeImpl final
             std::shared_lock lock(m_agentSessionsMutex);
             if (auto it = m_agentSessions.find(end->session()); it == m_agentSessions.end())
             {
-                LOG_DEBUG2(m_logFn, "InventorySyncFacade::start: Session not found, sessionId: %llu", end->session());
+                LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: Session not found, sessionId: %llu", end->session());
             }
             else
             {
                 // Handle end.
                 it->second.handleEnd(*m_responseDispatcher);
-                LOG_DEBUG2(m_logFn, "InventorySyncFacade::start: End handled for session %llu", end->session());
+                LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: End handled for session %llu", end->session());
             }
         }
         else
@@ -437,7 +438,7 @@ class InventorySyncFacadeImpl final
         constexpr size_t BATCH_SIZE = 1000;
         size_t totalDocs = 0;
 
-        LOG_DEBUG2(m_logFn, "Querying indexer for checksums: agent=%s, index=%s", agentId.c_str(), index.c_str());
+        LOGFN_DEBUG2(m_logFn, "Querying indexer for checksums: agent=%s, index=%s", agentId.c_str(), index.c_str());
 
         while (true)
         {
@@ -453,16 +454,16 @@ class InventorySyncFacadeImpl final
                 searchQuery["search_after"] = nlohmann::json::array({searchAfter});
             }
 
-            LOG_DEBUG2(m_logFn, "Search query: %s", searchQuery.dump().c_str());
+            LOGFN_DEBUG2(m_logFn, "Search query: %s", searchQuery.dump().c_str());
 
             auto searchResult = m_indexerConnector->executeSearchQuery(index, searchQuery);
 
-            LOG_DEBUG2(m_logFn, "Search result: %s", searchResult.dump().c_str());
+            LOGFN_DEBUG2(m_logFn, "Search result: %s", searchResult.dump().c_str());
 
             if (!searchResult.contains("hits") || !searchResult["hits"].contains("hits") ||
                 searchResult["hits"]["hits"].empty())
             {
-                LOG_DEBUG2(m_logFn, "No more results, breaking pagination loop");
+                LOGFN_DEBUG2(m_logFn, "No more results, breaking pagination loop");
                 break;
             }
 
@@ -489,14 +490,14 @@ class InventorySyncFacadeImpl final
             }
         }
 
-        LOG_DEBUG2(m_logFn, "Retrieved %zu documents for checksum calculation", totalDocs);
+        LOGFN_DEBUG2(m_logFn, "Retrieved %zu documents for checksum calculation", totalDocs);
 
         Utils::HashData hash(Utils::HashType::Sha1);
         hash.update(concatenatedChecksums.c_str(), concatenatedChecksums.length());
         const std::vector<unsigned char> hashResult = hash.hash();
         std::string finalChecksum = Utils::asciiToHex(hashResult);
 
-        LOG_DEBUG2(m_logFn, "Calculated checksum of checksums: %s", finalChecksum.c_str());
+        LOGFN_DEBUG2(m_logFn, "Calculated checksum of checksums: %s", finalChecksum.c_str());
 
         return finalChecksum;
     }
@@ -599,12 +600,12 @@ public:
         std::filesystem::remove_all(INVENTORY_SYNC_PATH, errorCodeFS);
         if (errorCodeFS)
         {
-            LOG_WARN(m_logFn, "Error removing inventory_sync directory: %s", errorCodeFS.message().c_str());
+            LOGFN_WARN(m_logFn, "Error removing inventory_sync directory: %s", errorCodeFS.message().c_str());
         }
         m_dataStore = std::make_unique<TRocksDBWrapper>(INVENTORY_SYNC_PATH);
         m_responseDispatcher = std::make_unique<TResponseDispatcher>();
 
-        LOG_DEBUG2(m_logFn, "Configuration: %s", configuration.dump().c_str());
+        LOGFN_DEBUG2(m_logFn, "Configuration: %s", configuration.dump().c_str());
 
         nlohmann::json indexerConfig = configuration.contains("indexer") && configuration.at("indexer").is_object()
                                            ? configuration.at("indexer")
@@ -635,7 +636,7 @@ public:
         {
             m_maxSessions = configuration.at("maxSessions").get<int>();
         }
-        LOG_DEBUG1(m_logFn, "InventorySync session limit: %d", m_maxSessions);
+        LOGFN_DEBUG1(m_logFn, "InventorySync session limit: %d", m_maxSessions);
 
         // Get input queue size and DataValue quota from configuration
         if (configuration.contains("queueSize"))
@@ -647,12 +648,12 @@ public:
             m_dataValueQuotaRemaining.store(configuration.at("dataValueQuota").get<uint64_t>(),
                                             std::memory_order_relaxed);
         }
-        LOG_DEBUG1(m_logFn,
-                   "InventorySync queue size: %zu, DataValue quota: %llu",
-                   m_workersQueueSize,
-                   static_cast<unsigned long long>(m_dataValueQuotaRemaining.load()));
+        LOGFN_DEBUG1(m_logFn,
+                     "InventorySync queue size: %zu, DataValue quota: %llu",
+                     m_workersQueueSize,
+                     static_cast<unsigned long long>(m_dataValueQuotaRemaining.load()));
 
-        LOG_DEBUG2(m_logFn, "Cluster name to be used in indexer: %s", m_clusterName.c_str());
+        LOGFN_DEBUG2(m_logFn, "Cluster name to be used in indexer: %s", m_clusterName.c_str());
 
         logDebug1(LOGGER_DEFAULT_TAG, "InventorySync worker threads: %u", cpp_get_nproc());
         m_workersQueue = std::make_unique<WorkersQueue>(
@@ -663,7 +664,7 @@ public:
                     // Check if it's a JSON message (starts with '{')
                     if (!dataRaw.empty() && dataRaw[0] == '{')
                     {
-                        LOG_DEBUG2(m_logFn, "InventorySyncFacade::start: Processing JSON message...");
+                        LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: Processing JSON message...");
                         run(dataRaw);
                     }
                     else
@@ -673,7 +674,7 @@ public:
                                                        dataRaw.size());
                         if (Wazuh::SyncSchema::VerifyMessageBuffer(verifier))
                         {
-                            LOG_DEBUG2(m_logFn, "InventorySyncFacade::start: Processing FlatBuffer message...");
+                            LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: Processing FlatBuffer message...");
                             run(dataRaw);
                         }
                         else
@@ -684,7 +685,7 @@ public:
                 }
                 catch (const std::exception& e)
                 {
-                    LOG_ERROR(m_logFn, "InventorySyncFacade::start: %s", e.what());
+                    LOGFN_ERROR(m_logFn, "InventorySyncFacade::start: %s", e.what());
                 }
             },
             cpp_get_nproc(),
@@ -696,15 +697,15 @@ public:
             // coverity[copy_constructor_call]
             [this, queue = m_workersQueue.get()](const std::vector<char>& message)
             {
-                LOG_DEBUG2(m_logFn, "InventorySyncFacade::start: Received message from router");
+                LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: Received message from router");
                 // TODO: Temporal allocation, we need to use move semantics in router module.
                 if (!queue->push(std::move(const_cast<std::vector<char>&>(message))))
                 {
                     if (shouldLogThrottled(m_lastQueueDropLogNs))
                     {
-                        LOG_WARN(m_logFn,
-                                 "InventorySyncFacade: workers queue full (max=%zu); dropping inbound message",
-                                 m_workersQueueSize);
+                        LOGFN_WARN(m_logFn,
+                                   "InventorySyncFacade: workers queue full (max=%zu); dropping inbound message",
+                                   m_workersQueueSize);
                     }
                 }
             });
@@ -712,14 +713,14 @@ public:
         m_indexerQueue = std::make_unique<IndexerQueue>(
             [this](const Response& res)
             {
-                LOG_DEBUG2(m_logFn, "Indexer queue action...");
+                LOGFN_DEBUG2(m_logFn, "Indexer queue action...");
                 {
                     std::shared_lock sessionLock(m_agentSessionsMutex);
                     if (m_agentSessions.find(res.context->sessionId) == m_agentSessions.end())
                     {
-                        LOG_WARN(m_logFn,
-                                 "InventorySyncFacade::start: Session not found, sessionId: %llu",
-                                 res.context->sessionId);
+                        LOGFN_WARN(m_logFn,
+                                   "InventorySyncFacade::start: Session not found, sessionId: %llu",
+                                   res.context->sessionId);
                         return;
                     }
                 }
@@ -751,7 +752,7 @@ public:
                             // Timeout: sessions still active after 60s
                             // These are zombie sessions - agent already validated no active syncs on its side
                             // Manager-side validation failed because of orphaned sessions
-                            LOG_WARN(
+                            LOGFN_WARN(
                                 m_logFn,
                                 "Metadata/groups update for agent %s: %zu session(s) still active after 60s timeout. "
                                 "Detecting as zombie sessions (agent already validated no active syncs). "
@@ -762,11 +763,12 @@ public:
                             // Clean up zombie sessions
                             size_t cleanedCount = cleanupZombieSessions(res.context->agentId, res.context->sessionId);
 
-                            LOG_INFO(m_logFn,
-                                     "Cleaned up %zu zombie session(s) for agent %s - proceeding with metadata/groups "
-                                     "update",
-                                     cleanedCount,
-                                     res.context->agentId.c_str());
+                            LOGFN_INFO(
+                                m_logFn,
+                                "Cleaned up %zu zombie session(s) for agent %s - proceeding with metadata/groups "
+                                "update",
+                                cleanedCount,
+                                res.context->agentId.c_str());
                         }
 
                         // All sessions completed (or zombies cleaned) - safe to proceed with metadata/groups update
@@ -777,9 +779,9 @@ public:
 
                     if (res.context->mode == Wazuh::SyncSchema::Mode_MetadataDelta)
                     {
-                        LOG_DEBUG2(m_logFn,
-                                   "InventorySyncFacade::start: Updating agent metadata for agent %s...",
-                                   res.context->agentId.c_str());
+                        LOGFN_DEBUG2(m_logFn,
+                                     "InventorySyncFacade::start: Updating agent metadata for agent %s...",
+                                     res.context->agentId.c_str());
 
                         // Register notify callback BEFORE starting async operation to avoid race condition
                         m_indexerConnector->registerNotify(
@@ -795,9 +797,9 @@ public:
                                 // Delete Session.
                                 if (eraseSession(ctx->sessionId) == 0)
                                 {
-                                    LOG_DEBUG2(m_logFn,
-                                               "InventorySyncFacade::start: Session not found, sessionId: %llu",
-                                               ctx->sessionId);
+                                    LOGFN_DEBUG2(m_logFn,
+                                                 "InventorySyncFacade::start: Session not found, sessionId: %llu",
+                                                 ctx->sessionId);
                                 }
                             });
 
@@ -820,9 +822,9 @@ public:
                     }
                     else if (res.context->mode == Wazuh::SyncSchema::Mode_GroupDelta)
                     {
-                        LOG_DEBUG2(m_logFn,
-                                   "InventorySyncFacade::start: Updating agent groups for agent %s...",
-                                   res.context->agentId.c_str());
+                        LOGFN_DEBUG2(m_logFn,
+                                     "InventorySyncFacade::start: Updating agent groups for agent %s...",
+                                     res.context->agentId.c_str());
 
                         // Register notify callback BEFORE starting async operation to avoid race condition
                         m_indexerConnector->registerNotify(
@@ -838,9 +840,9 @@ public:
                                 // Delete Session.
                                 if (eraseSession(ctx->sessionId) == 0)
                                 {
-                                    LOG_DEBUG2(m_logFn,
-                                               "InventorySyncFacade::start: Session not found, sessionId: %llu",
-                                               ctx->sessionId);
+                                    LOGFN_DEBUG2(m_logFn,
+                                                 "InventorySyncFacade::start: Session not found, sessionId: %llu",
+                                                 ctx->sessionId);
                                 }
                             });
 
@@ -854,9 +856,10 @@ public:
                     }
                     else if (res.context->mode == Wazuh::SyncSchema::Mode_MetadataCheck)
                     {
-                        LOG_DEBUG2(m_logFn,
-                                   "InventorySyncFacade::start: Disaster recovery - checking metadata for agent %s...",
-                                   res.context->agentId.c_str());
+                        LOGFN_DEBUG2(
+                            m_logFn,
+                            "InventorySyncFacade::start: Disaster recovery - checking metadata for agent %s...",
+                            res.context->agentId.c_str());
 
                         // Register notify callback BEFORE starting async operation to avoid race condition
                         m_indexerConnector->registerNotify(
@@ -872,9 +875,9 @@ public:
                                 // Delete Session.
                                 if (eraseSession(ctx->sessionId) == 0)
                                 {
-                                    LOG_DEBUG2(m_logFn,
-                                               "InventorySyncFacade::start: Session not found, sessionId: %llu",
-                                               ctx->sessionId);
+                                    LOGFN_DEBUG2(m_logFn,
+                                                 "InventorySyncFacade::start: Session not found, sessionId: %llu",
+                                                 ctx->sessionId);
                                 }
                             });
 
@@ -891,20 +894,20 @@ public:
                                                                                res.context->osversion);
                         InventorySyncQueryBuilder::addClusterScope(metadataCheckQuery, m_clusterName);
 
-                        LOG_INFO(m_logFn,
-                                 "Disaster recovery: Checking and recovering metadata inconsistencies for agent %s "
-                                 "across %zu indices",
-                                 res.context->agentId.c_str(),
-                                 res.context->indices.size());
+                        LOGFN_INFO(m_logFn,
+                                   "Disaster recovery: Checking and recovering metadata inconsistencies for agent %s "
+                                   "across %zu indices",
+                                   res.context->agentId.c_str(),
+                                   res.context->indices.size());
 
                         // Execute the metadata check update
                         m_indexerConnector->executeUpdateByQuery(res.context->indices, metadataCheckQuery);
                     }
                     else if (res.context->mode == Wazuh::SyncSchema::Mode_GroupCheck)
                     {
-                        LOG_DEBUG2(m_logFn,
-                                   "InventorySyncFacade::start: Disaster recovery - checking groups for agent %s...",
-                                   res.context->agentId.c_str());
+                        LOGFN_DEBUG2(m_logFn,
+                                     "InventorySyncFacade::start: Disaster recovery - checking groups for agent %s...",
+                                     res.context->agentId.c_str());
 
                         // Register notify callback BEFORE starting async operation to avoid race condition
                         m_indexerConnector->registerNotify(
@@ -920,9 +923,9 @@ public:
                                 // Delete Session.
                                 if (eraseSession(ctx->sessionId) == 0)
                                 {
-                                    LOG_DEBUG2(m_logFn,
-                                               "InventorySyncFacade::start: Session not found, sessionId: %llu",
-                                               ctx->sessionId);
+                                    LOGFN_DEBUG2(m_logFn,
+                                                 "InventorySyncFacade::start: Session not found, sessionId: %llu",
+                                                 ctx->sessionId);
                                 }
                             });
 
@@ -931,7 +934,7 @@ public:
                             InventorySyncQueryBuilder::buildGroupsCheckQuery(res.context->agentId, res.context->groups);
                         InventorySyncQueryBuilder::addClusterScope(groupsCheckQuery, m_clusterName);
 
-                        LOG_INFO(
+                        LOGFN_INFO(
                             m_logFn,
                             "Disaster recovery: Checking and recovering groups inconsistencies for agent %s across "
                             "%zu indices",
@@ -943,18 +946,18 @@ public:
                     }
                     else if (res.context->mode == Wazuh::SyncSchema::Mode_ModuleCheck)
                     {
-                        LOG_DEBUG2(m_logFn,
-                                   "InventorySyncFacade::start: Processing ModuleCheck for agent %s, module %s",
-                                   res.context->agentId.c_str(),
-                                   res.context->moduleName.c_str());
+                        LOGFN_DEBUG2(m_logFn,
+                                     "InventorySyncFacade::start: Processing ModuleCheck for agent %s, module %s",
+                                     res.context->agentId.c_str(),
+                                     res.context->moduleName.c_str());
 
                         try
                         {
                             if (res.context->checksumIndex.empty())
                             {
-                                LOG_ERROR(m_logFn,
-                                          "ModuleCheck: No index specified for agent %s",
-                                          res.context->agentId.c_str());
+                                LOGFN_ERROR(m_logFn,
+                                            "ModuleCheck: No index specified for agent %s",
+                                            res.context->agentId.c_str());
                                 m_responseDispatcher->sendEndAck(Wazuh::SyncSchema::Status_Error,
                                                                  res.context->agentId,
                                                                  res.context->sessionId,
@@ -973,27 +976,27 @@ public:
                                 {
                                     if (attempt > 0)
                                     {
-                                        LOG_DEBUG2(m_logFn,
-                                                   "ModuleCheck: Retry attempt %d for agent %s after %ds delay",
-                                                   attempt,
-                                                   res.context->agentId.c_str(),
-                                                   RETRY_DELAY_SEC);
+                                        LOGFN_DEBUG2(m_logFn,
+                                                     "ModuleCheck: Retry attempt %d for agent %s after %ds delay",
+                                                     attempt,
+                                                     res.context->agentId.c_str(),
+                                                     RETRY_DELAY_SEC);
                                         std::this_thread::sleep_for(std::chrono::seconds(RETRY_DELAY_SEC));
                                     }
 
                                     managerChecksum =
                                         calculateChecksumOfChecksums(res.context->checksumIndex, res.context->agentId);
 
-                                    LOG_INFO(m_logFn,
-                                             "ModuleCheck (attempt %d/%d): agent=%s, module=%s, index=%s, "
-                                             "agent_checksum=%s, manager_checksum=%s",
-                                             attempt + 1,
-                                             MAX_RETRIES,
-                                             res.context->agentId.c_str(),
-                                             res.context->moduleName.c_str(),
-                                             res.context->checksumIndex.c_str(),
-                                             res.context->checksum.c_str(),
-                                             managerChecksum.c_str());
+                                    LOGFN_INFO(m_logFn,
+                                               "ModuleCheck (attempt %d/%d): agent=%s, module=%s, index=%s, "
+                                               "agent_checksum=%s, manager_checksum=%s",
+                                               attempt + 1,
+                                               MAX_RETRIES,
+                                               res.context->agentId.c_str(),
+                                               res.context->moduleName.c_str(),
+                                               res.context->checksumIndex.c_str(),
+                                               res.context->checksum.c_str(),
+                                               managerChecksum.c_str());
 
                                     if (managerChecksum == res.context->checksum)
                                     {
@@ -1004,9 +1007,9 @@ public:
 
                                 if (checksumMatch)
                                 {
-                                    LOG_INFO(m_logFn,
-                                             "ModuleCheck: Checksums match for agent %s - no full resync needed",
-                                             res.context->agentId.c_str());
+                                    LOGFN_INFO(m_logFn,
+                                               "ModuleCheck: Checksums match for agent %s - no full resync needed",
+                                               res.context->agentId.c_str());
                                     m_responseDispatcher->sendEndAck(Wazuh::SyncSchema::Status_Ok,
                                                                      res.context->agentId,
                                                                      res.context->sessionId,
@@ -1014,11 +1017,11 @@ public:
                                 }
                                 else
                                 {
-                                    LOG_INFO(m_logFn,
-                                             "ModuleCheck: Checksums DO NOT match for agent %s after %d attempts - "
-                                             "full resync required",
-                                             res.context->agentId.c_str(),
-                                             MAX_RETRIES);
+                                    LOGFN_INFO(m_logFn,
+                                               "ModuleCheck: Checksums DO NOT match for agent %s after %d attempts - "
+                                               "full resync required",
+                                               res.context->agentId.c_str(),
+                                               MAX_RETRIES);
                                     m_responseDispatcher->sendEndAck(Wazuh::SyncSchema::Status_ChecksumMismatch,
                                                                      res.context->agentId,
                                                                      res.context->sessionId,
@@ -1028,7 +1031,7 @@ public:
                         }
                         catch (const std::exception& e)
                         {
-                            LOG_ERROR(
+                            LOGFN_ERROR(
                                 m_logFn, "ModuleCheck failed for agent %s: %s", res.context->agentId.c_str(), e.what());
                             m_responseDispatcher->sendEndAck(Wazuh::SyncSchema::Status_Error,
                                                              res.context->agentId,
@@ -1038,9 +1041,9 @@ public:
 
                         if (eraseSession(res.context->sessionId) == 0)
                         {
-                            LOG_DEBUG2(m_logFn,
-                                       "InventorySyncFacade::start: Session not found, sessionId: %llu",
-                                       res.context->sessionId);
+                            LOGFN_DEBUG2(m_logFn,
+                                         "InventorySyncFacade::start: Session not found, sessionId: %llu",
+                                         res.context->sessionId);
                         }
                     }
                     else
@@ -1057,16 +1060,16 @@ public:
                         // Execute DataClean deletions if any were received during the session
                         if (!res.context->dataCleanIndices.empty())
                         {
-                            LOG_DEBUG2(m_logFn,
-                                       "InventorySyncFacade::start: Processing DataClean for %zu indices...",
-                                       res.context->dataCleanIndices.size());
+                            LOGFN_DEBUG2(m_logFn,
+                                         "InventorySyncFacade::start: Processing DataClean for %zu indices...",
+                                         res.context->dataCleanIndices.size());
                             // Delete from each index specified in DataClean messages
                             for (const auto& index : res.context->dataCleanIndices)
                             {
-                                LOG_DEBUG2(m_logFn,
-                                           "InventorySyncFacade::start: Deleting data from index '%s' for agent %s",
-                                           index.c_str(),
-                                           res.context->agentId.c_str());
+                                LOGFN_DEBUG2(m_logFn,
+                                             "InventorySyncFacade::start: Deleting data from index '%s' for agent %s",
+                                             index.c_str(),
+                                             res.context->agentId.c_str());
                                 try
                                 {
                                     m_indexerConnector->deleteByQuery(index, res.context->agentId, m_clusterName);
@@ -1074,12 +1077,12 @@ public:
                                 }
                                 catch (const std::exception& e)
                                 {
-                                    LOG_WARN(m_logFn,
-                                             "InventorySyncFacade::start: deleteByQuery rejected for index '%s' "
-                                             "(session %llu): %s",
-                                             index.c_str(),
-                                             res.context->sessionId,
-                                             e.what());
+                                    LOGFN_WARN(m_logFn,
+                                               "InventorySyncFacade::start: deleteByQuery rejected for index '%s' "
+                                               "(session %llu): %s",
+                                               index.c_str(),
+                                               res.context->sessionId,
+                                               e.what());
                                 }
                             }
                         }
@@ -1087,9 +1090,9 @@ public:
                         // Send delete by query to indexer if mode is full.
                         if (res.context->mode == Wazuh::SyncSchema::Mode_ModuleFull)
                         {
-                            LOG_DEBUG2(m_logFn,
-                                       "InventorySyncFacade::start: Deleting by query for %zu indices...",
-                                       res.context->indices.size());
+                            LOGFN_DEBUG2(m_logFn,
+                                         "InventorySyncFacade::start: Deleting by query for %zu indices...",
+                                         res.context->indices.size());
                             // Delete from all indices specified in the Start message
                             for (const auto& index : res.context->indices)
                             {
@@ -1100,12 +1103,12 @@ public:
                                 }
                                 catch (const std::exception& e)
                                 {
-                                    LOG_WARN(m_logFn,
-                                             "InventorySyncFacade::start: deleteByQuery rejected for index '%s' "
-                                             "(session %llu): %s",
-                                             index.c_str(),
-                                             res.context->sessionId,
-                                             e.what());
+                                    LOGFN_WARN(m_logFn,
+                                               "InventorySyncFacade::start: deleteByQuery rejected for index '%s' "
+                                               "(session %llu): %s",
+                                               index.c_str(),
+                                               res.context->sessionId,
+                                               e.what());
                                 }
                             }
                         }
@@ -1121,12 +1124,12 @@ public:
                             // Skip DataContext entries - they are stored with "_context" suffix and not sent to indexer
                             if (key.ends_with("_context"))
                             {
-                                LOG_DEBUG2(
+                                LOGFN_DEBUG2(
                                     m_logFn, "InventorySyncFacade::start: Skipping DataContext entry: %s", key.c_str());
                                 continue;
                             }
 
-                            LOG_DEBUG2(m_logFn, "InventorySyncFacade::start: Processing data...");
+                            LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: Processing data...");
                             flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(value.data()),
                                                            value.size());
                             if (Wazuh::SyncSchema::VerifyMessageBuffer(verifier))
@@ -1142,12 +1145,12 @@ public:
                                 const auto rawIndex = data->index() ? data->index()->string_view() : std::string_view();
                                 if (!isAgentScopedStateIndex(rawIndex))
                                 {
-                                    LOG_WARN(m_logFn,
-                                             "InventorySyncFacade::start: skipping bulk entry for session %llu - "
-                                             "index '%.*s' does not belong to wazuh-states-* family.",
-                                             res.context->sessionId,
-                                             static_cast<int>(rawIndex.size()),
-                                             rawIndex.data());
+                                    LOGFN_WARN(m_logFn,
+                                               "InventorySyncFacade::start: skipping bulk entry for session %llu - "
+                                               "index '%.*s' does not belong to wazuh-states-* family.",
+                                               res.context->sessionId,
+                                               static_cast<int>(rawIndex.size()),
+                                               rawIndex.data());
                                     continue;
                                 }
 
@@ -1164,10 +1167,10 @@ public:
                                 // Validate required FlatBuffer fields before dereferencing them
                                 if (!data->id() || data->id()->string_view().empty())
                                 {
-                                    LOG_WARN(m_logFn,
-                                             "InventorySyncFacade::start: skipping bulk entry for session %llu - "
-                                             "DataValue missing required 'id' field",
-                                             res.context->sessionId);
+                                    LOGFN_WARN(m_logFn,
+                                               "InventorySyncFacade::start: skipping bulk entry for session %llu - "
+                                               "DataValue missing required 'id' field",
+                                               res.context->sessionId);
                                     continue;
                                 }
 
@@ -1183,11 +1186,12 @@ public:
                                     // Validate that the data field is present for Upsert operations
                                     if (!data->data())
                                     {
-                                        LOG_WARN(m_logFn,
-                                                 "InventorySyncFacade::start: skipping bulk entry for session "
-                                                 "%llu (seq %llu) - DataValue missing required 'data' field for Upsert",
-                                                 res.context->sessionId,
-                                                 data->seq());
+                                        LOGFN_WARN(
+                                            m_logFn,
+                                            "InventorySyncFacade::start: skipping bulk entry for session "
+                                            "%llu (seq %llu) - DataValue missing required 'data' field for Upsert",
+                                            res.context->sessionId,
+                                            data->seq());
                                         continue;
                                     }
 
@@ -1198,21 +1202,21 @@ public:
                                     }
                                     catch (const nlohmann::json::parse_error& e)
                                     {
-                                        LOG_WARN(m_logFn,
-                                                 "InventorySyncFacade::start: skipping bulk entry for session "
-                                                 "%llu (seq %llu) - DataValue body is not valid JSON: %s",
-                                                 res.context->sessionId,
-                                                 data->seq(),
-                                                 e.what());
+                                        LOGFN_WARN(m_logFn,
+                                                   "InventorySyncFacade::start: skipping bulk entry for session "
+                                                   "%llu (seq %llu) - DataValue body is not valid JSON: %s",
+                                                   res.context->sessionId,
+                                                   data->seq(),
+                                                   e.what());
                                         continue;
                                     }
                                     if (!document.is_object())
                                     {
-                                        LOG_WARN(m_logFn,
-                                                 "InventorySyncFacade::start: skipping bulk entry for session "
-                                                 "%llu (seq %llu) - DataValue body is not a JSON object",
-                                                 res.context->sessionId,
-                                                 data->seq());
+                                        LOGFN_WARN(m_logFn,
+                                                   "InventorySyncFacade::start: skipping bulk entry for session "
+                                                   "%llu (seq %llu) - DataValue body is not a JSON object",
+                                                   res.context->sessionId,
+                                                   data->seq());
                                         continue;
                                     }
                                 }
@@ -1235,7 +1239,7 @@ public:
 
                                 if (isUpsert)
                                 {
-                                    LOG_DEBUG2(m_logFn, "InventorySyncFacade::start: Upserting data...");
+                                    LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: Upserting data...");
 
                                     // Overlay manager-controlled metadata on top of the agent payload.
                                     // Any field the agent tries to set under wazuh.* gets clobbered here,
@@ -1269,7 +1273,7 @@ public:
                                 }
                                 else
                                 {
-                                    LOG_DEBUG2(m_logFn, "InventorySyncFacade::start: Deleting data...");
+                                    LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: Deleting data...");
                                     m_indexerConnector->bulkDelete(elementId, rawIndex);
                                 }
                             }
@@ -1306,10 +1310,10 @@ public:
 
                                     if (skipScan)
                                     {
-                                        LOG_INFO(m_logFn,
-                                                 "InventorySyncFacade: Skipping VDSync scan for agent %s — "
-                                                 "feed-update full scan in progress, covers all packages.",
-                                                 res.context->agentId.c_str());
+                                        LOGFN_INFO(m_logFn,
+                                                   "InventorySyncFacade: Skipping VDSync scan for agent %s — "
+                                                   "feed-update full scan in progress, covers all packages.",
+                                                   res.context->agentId.c_str());
                                     }
                                     else
                                     {
@@ -1324,7 +1328,7 @@ public:
                                             auto [it, inserted] = m_activeVDFirstScans.insert(res.context->agentId);
                                             if (!inserted)
                                             {
-                                                LOG_WARN(
+                                                LOGFN_WARN(
                                                     m_logFn,
                                                     "InventorySyncFacade: Duplicate VDFirst scan detected for agent "
                                                     "%s - another VDFirst scan is already in progress. Skipping "
@@ -1360,11 +1364,11 @@ public:
                                                     m_activeVDFirstScans.erase(res.context->agentId);
                                                 }
 
-                                                LOG_ERROR(m_logFn,
-                                                          "InventorySyncFacade: Vulnerability scanner exception for "
-                                                          "agent %s: %s",
-                                                          res.context->agentId.c_str(),
-                                                          e.what());
+                                                LOGFN_ERROR(m_logFn,
+                                                            "InventorySyncFacade: Vulnerability scanner exception for "
+                                                            "agent %s: %s",
+                                                            res.context->agentId.c_str(),
+                                                            e.what());
                                                 m_responseDispatcher->sendEndAck(Wazuh::SyncSchema::Status_Error,
                                                                                  res.context->agentId,
                                                                                  res.context->sessionId,
@@ -1378,18 +1382,18 @@ public:
                                 }
                                 else
                                 {
-                                    LOG_DEBUG1(m_logFn,
-                                               "InventorySyncFacade: Scanner stopped while waiting for CVE feed — "
-                                               "skipping scan for agent %s.",
-                                               res.context->agentId.c_str());
+                                    LOGFN_DEBUG1(m_logFn,
+                                                 "InventorySyncFacade: Scanner stopped while waiting for CVE feed — "
+                                                 "skipping scan for agent %s.",
+                                                 res.context->agentId.c_str());
                                 }
                             }
                             else
                             {
-                                LOG_DEBUG1(m_logFn,
-                                           "InventorySyncFacade: Vulnerability scanner disabled — "
-                                           "skipping scan for agent %s.",
-                                           res.context->agentId.c_str());
+                                LOGFN_DEBUG1(m_logFn,
+                                             "InventorySyncFacade: Vulnerability scanner disabled — "
+                                             "skipping scan for agent %s.",
+                                             res.context->agentId.c_str());
                             }
                         }
 
@@ -1414,9 +1418,9 @@ public:
                                     // Delete Session.
                                     if (eraseSession(ctx->sessionId) == 0)
                                     {
-                                        LOG_DEBUG2(m_logFn,
-                                                   "InventorySyncFacade::start: Session not found, sessionId: %llu",
-                                                   ctx->sessionId);
+                                        LOGFN_DEBUG2(m_logFn,
+                                                     "InventorySyncFacade::start: Session not found, sessionId: %llu",
+                                                     ctx->sessionId);
                                     }
                                     m_sessionCompletedCV.notify_all();
                                 });
@@ -1425,10 +1429,10 @@ public:
                         {
                             // No bulk data and no deleteByQuery - send immediate response (e.g., DataContext-only
                             // session)
-                            LOG_DEBUG2(m_logFn,
-                                       "InventorySyncFacade::start: No bulk data or deleteByQuery, sending immediate "
-                                       "response for session %llu",
-                                       res.context->sessionId);
+                            LOGFN_DEBUG2(m_logFn,
+                                         "InventorySyncFacade::start: No bulk data or deleteByQuery, sending immediate "
+                                         "response for session %llu",
+                                         res.context->sessionId);
                             m_responseDispatcher->sendEndAck(Wazuh::SyncSchema::Status_Ok,
                                                              res.context->agentId,
                                                              res.context->sessionId,
@@ -1436,9 +1440,9 @@ public:
                             m_dataStore->deleteByPrefix(std::to_string(res.context->sessionId));
                             if (eraseSession(res.context->sessionId) == 0)
                             {
-                                LOG_DEBUG2(m_logFn,
-                                           "InventorySyncFacade::start: Session not found, sessionId: %llu",
-                                           res.context->sessionId);
+                                LOGFN_DEBUG2(m_logFn,
+                                             "InventorySyncFacade::start: Session not found, sessionId: %llu",
+                                             res.context->sessionId);
                             }
                             m_sessionCompletedCV.notify_all();
                         }
@@ -1451,7 +1455,7 @@ public:
                 }
                 catch (const InventorySyncException& e)
                 {
-                    LOG_ERROR(m_logFn, "InventorySyncFacade::start: %s", e.what());
+                    LOGFN_ERROR(m_logFn, "InventorySyncFacade::start: %s", e.what());
 
                     // Unlock agent if this session owns the lock
                     if (res.context->ownsAgentLock)
@@ -1470,9 +1474,9 @@ public:
                     // Delete Session.
                     if (eraseSession(res.context->sessionId) == 0)
                     {
-                        LOG_DEBUG2(m_logFn,
-                                   "InventorySyncFacade::start: Session not found, sessionId: %llu",
-                                   res.context->sessionId);
+                        LOGFN_DEBUG2(m_logFn,
+                                     "InventorySyncFacade::start: Session not found, sessionId: %llu",
+                                     res.context->sessionId);
                     }
                     m_sessionCompletedCV.notify_all();
 
@@ -1480,7 +1484,7 @@ public:
                 }
                 catch (const std::exception& e)
                 {
-                    LOG_ERROR(m_logFn, "InventorySyncFacade::start: %s", e.what());
+                    LOGFN_ERROR(m_logFn, "InventorySyncFacade::start: %s", e.what());
 
                     // Unlock agent if this session owns the lock
                     if (res.context->ownsAgentLock)
@@ -1499,9 +1503,9 @@ public:
                     // Delete Session.
                     if (eraseSession(res.context->sessionId) == 0)
                     {
-                        LOG_DEBUG2(m_logFn,
-                                   "InventorySyncFacade::start: Session not found, sessionId: %llu",
-                                   res.context->sessionId);
+                        LOGFN_DEBUG2(m_logFn,
+                                     "InventorySyncFacade::start: Session not found, sessionId: %llu",
+                                     res.context->sessionId);
                     }
                     m_sessionCompletedCV.notify_all();
 
@@ -1535,17 +1539,17 @@ public:
                     {
                         if (!it->second.isAlive(std::chrono::seconds(DEFAULT_TIME * 2)))
                         {
-                            LOG_DEBUG2(m_logFn, "Session %llu has timed out", it->first);
+                            LOGFN_DEBUG2(m_logFn, "Session %llu has timed out", it->first);
 
                             // Unlock agent if this session owns the lock
                             const auto& context = it->second.getContext();
                             if (context->ownsAgentLock)
                             {
                                 unlockAgent(context->agentId);
-                                LOG_DEBUG1(m_logFn,
-                                           "Session %llu for agent %s timed out - agent unlocked",
-                                           it->first,
-                                           context->agentId.c_str());
+                                LOGFN_DEBUG1(m_logFn,
+                                             "Session %llu for agent %s timed out - agent unlocked",
+                                             it->first,
+                                             context->agentId.c_str());
                             }
 
                             // Delete data from database.
@@ -1564,7 +1568,7 @@ public:
         // Init the socket server to attend keystore requests
         initializeKeystoreSocket();
 
-        LOG_DEBUG1(m_logFn, "InventorySyncFacade started.");
+        LOGFN_DEBUG1(m_logFn, "InventorySyncFacade started.");
     }
 
     /**
@@ -1581,14 +1585,14 @@ public:
         {
             if (m_allAgentsLocked.load())
             {
-                LOG_DEBUG2(m_logFn, "All agents already locked");
+                LOGFN_DEBUG2(m_logFn, "All agents already locked");
                 return false;
             }
             m_allAgentsLocked.store(true);
-            LOG_INFO(m_logFn,
-                     "Locked ALL agents from creating new sessions%s%s",
-                     reason.empty() ? "" : " - Reason: ",
-                     reason.c_str());
+            LOGFN_INFO(m_logFn,
+                       "Locked ALL agents from creating new sessions%s%s",
+                       reason.empty() ? "" : " - Reason: ",
+                       reason.c_str());
             return true;
         }
         else
@@ -1596,15 +1600,15 @@ public:
             auto [it, inserted] = m_blockedAgents.insert(agentId);
             if (inserted)
             {
-                LOG_INFO(m_logFn,
-                         "Locked agent %s from creating new sessions%s%s",
-                         agentId.c_str(),
-                         reason.empty() ? "" : " - Reason: ",
-                         reason.c_str());
+                LOGFN_INFO(m_logFn,
+                           "Locked agent %s from creating new sessions%s%s",
+                           agentId.c_str(),
+                           reason.empty() ? "" : " - Reason: ",
+                           reason.c_str());
             }
             else
             {
-                LOG_DEBUG2(m_logFn, "Agent %s already locked", agentId.c_str());
+                LOGFN_DEBUG2(m_logFn, "Agent %s already locked", agentId.c_str());
             }
             return inserted;
         }
@@ -1621,18 +1625,18 @@ public:
         if (agentId.empty())
         {
             m_allAgentsLocked.store(false);
-            LOG_INFO(m_logFn, "Unlocked ALL agents for new sessions");
+            LOGFN_INFO(m_logFn, "Unlocked ALL agents for new sessions");
         }
         else
         {
             size_t erased = m_blockedAgents.erase(agentId);
             if (erased > 0)
             {
-                LOG_INFO(m_logFn, "Unlocked agent %s for new sessions", agentId.c_str());
+                LOGFN_INFO(m_logFn, "Unlocked agent %s for new sessions", agentId.c_str());
             }
             else
             {
-                LOG_DEBUG2(m_logFn, "Agent %s was not locked", agentId.c_str());
+                LOGFN_DEBUG2(m_logFn, "Agent %s was not locked", agentId.c_str());
             }
         }
     }
@@ -1776,12 +1780,12 @@ public:
 
                 if (timeout > std::chrono::seconds(0))
                 {
-                    LOG_INFO(m_logFn,
-                             "Feed update scan waiting for VDSync session to complete for agent %s "
-                             "(timeout: %lds, max retries: %u).",
-                             agentId.c_str(),
-                             static_cast<long>(timeout.count()),
-                             maxRetries);
+                    LOGFN_INFO(m_logFn,
+                               "Feed update scan waiting for VDSync session to complete for agent %s "
+                               "(timeout: %lds, max retries: %u).",
+                               agentId.c_str(),
+                               static_cast<long>(timeout.count()),
+                               maxRetries);
 
                     const auto isSessionGone = [&]()
                     {
@@ -1808,20 +1812,20 @@ public:
 
                         if (attemptsLeft > 0)
                         {
-                            LOG_WARN(m_logFn,
-                                     "Feed update scan timeout waiting for VDSync session for agent %s (%lds). "
-                                     "Retrying (%u retries left).",
-                                     agentId.c_str(),
-                                     static_cast<long>(timeout.count()),
-                                     attemptsLeft);
+                            LOGFN_WARN(m_logFn,
+                                       "Feed update scan timeout waiting for VDSync session for agent %s (%lds). "
+                                       "Retrying (%u retries left).",
+                                       agentId.c_str(),
+                                       static_cast<long>(timeout.count()),
+                                       attemptsLeft);
                         }
                         else
                         {
-                            LOG_WARN(m_logFn,
-                                     "Feed update scan timeout waiting for VDSync session for agent %s (%lds). "
-                                     "Proceeding with current indexer data.",
-                                     agentId.c_str(),
-                                     static_cast<long>(timeout.count()));
+                            LOGFN_WARN(m_logFn,
+                                       "Feed update scan timeout waiting for VDSync session for agent %s (%lds). "
+                                       "Proceeding with current indexer data.",
+                                       agentId.c_str(),
+                                       static_cast<long>(timeout.count()));
                         }
                     }
                 }
@@ -1915,11 +1919,11 @@ public:
             {
                 const auto& context = it->second.getContext();
 
-                LOG_WARN(m_logFn,
-                         "Cleaning up zombie session %llu for agent %s (module: %s)",
-                         sessionId,
-                         context->agentId.c_str(),
-                         context->moduleName.c_str());
+                LOGFN_WARN(m_logFn,
+                           "Cleaning up zombie session %llu for agent %s (module: %s)",
+                           sessionId,
+                           context->agentId.c_str(),
+                           context->moduleName.c_str());
 
                 // Delete data from database
                 m_dataStore->deleteByPrefix(std::to_string(sessionId));
@@ -1933,10 +1937,10 @@ public:
         if (cleanedCount > 0)
         {
             m_sessionCompletedCV.notify_all();
-            LOG_INFO(m_logFn,
-                     "Cleaned up %zu zombie session(s) for agent %s",
-                     cleanedCount,
-                     agentId.empty() ? "ALL" : agentId.c_str());
+            LOGFN_INFO(m_logFn,
+                       "Cleaned up %zu zombie session(s) for agent %s",
+                       cleanedCount,
+                       agentId.empty() ? "ALL" : agentId.c_str());
         }
 
         return cleanedCount;
@@ -1958,15 +1962,15 @@ public:
 
         if (initialCount == 0)
         {
-            LOG_DEBUG2(m_logFn, "No active sessions for agent %s", agentId.empty() ? "ALL" : agentId.c_str());
+            LOGFN_DEBUG2(m_logFn, "No active sessions for agent %s", agentId.empty() ? "ALL" : agentId.c_str());
             return 0;
         }
 
-        LOG_INFO(m_logFn,
-                 "Waiting for %zu active session(s) of agent %s to complete (timeout: %llds)",
-                 initialCount,
-                 agentId.empty() ? "ALL" : agentId.c_str(),
-                 timeout.count());
+        LOGFN_INFO(m_logFn,
+                   "Waiting for %zu active session(s) of agent %s to complete (timeout: %llds)",
+                   initialCount,
+                   agentId.empty() ? "ALL" : agentId.c_str(),
+                   timeout.count());
 
         while (true)
         {
@@ -1976,21 +1980,21 @@ public:
             {
                 auto elapsed =
                     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - startTime);
-                LOG_INFO(m_logFn,
-                         "All %zu session(s) of agent %s completed after %lldms",
-                         initialCount,
-                         agentId.empty() ? "ALL" : agentId.c_str(),
-                         elapsed.count());
+                LOGFN_INFO(m_logFn,
+                           "All %zu session(s) of agent %s completed after %lldms",
+                           initialCount,
+                           agentId.empty() ? "ALL" : agentId.c_str(),
+                           elapsed.count());
                 return 0; // Success - no sessions remaining
             }
 
             auto elapsed = std::chrono::steady_clock::now() - startTime;
             if (elapsed >= timeout)
             {
-                LOG_DEBUG1(m_logFn,
-                           "Timeout waiting for agent %s sessions to complete. %zu session(s) still active",
-                           agentId.empty() ? "ALL" : agentId.c_str(),
-                           currentCount);
+                LOGFN_DEBUG1(m_logFn,
+                             "Timeout waiting for agent %s sessions to complete. %zu session(s) still active",
+                             agentId.empty() ? "ALL" : agentId.c_str(),
+                             currentCount);
                 return currentCount; // Timeout - return number of remaining sessions
             }
 
@@ -2005,7 +2009,7 @@ public:
      */
     void stop()
     {
-        LOG_INFO(m_logFn, "Stopping InventorySync module");
+        LOGFN_INFO(m_logFn, "Stopping InventorySync module");
 
         // Lock all agents to reject new sessions during shutdown (don't wait for existing sessions)
         lockAgent("", "Module shutdown");
@@ -2042,28 +2046,28 @@ private:
     {
         if (agentId.empty())
         {
-            LOG_WARN(m_logFn, "InventorySyncFacade::deleteAgent: Empty agent ID");
+            LOGFN_WARN(m_logFn, "InventorySyncFacade::deleteAgent: Empty agent ID");
             return;
         }
 
         if (!m_indexerConnector)
         {
-            LOG_ERROR(m_logFn, "InventorySyncFacade::deleteAgent: Indexer connector not initialized");
+            LOGFN_ERROR(m_logFn, "InventorySyncFacade::deleteAgent: Indexer connector not initialized");
             return;
         }
 
         if (!m_indexerConnector->isAvailable())
         {
-            LOG_WARN(m_logFn,
-                     "InventorySyncFacade::deleteAgent: Indexer not available, skipping deletion for agent '%s'",
-                     agentId.c_str());
+            LOGFN_WARN(m_logFn,
+                       "InventorySyncFacade::deleteAgent: Indexer not available, skipping deletion for agent '%s'",
+                       agentId.c_str());
             return;
         }
 
-        LOG_INFO(m_logFn,
-                 "InventorySyncFacade::deleteAgent: Deleting data for agent '%s' from %s indexes",
-                 agentId.c_str(),
-                 WAZUH_STATES_INDEX_PATTERN);
+        LOGFN_INFO(m_logFn,
+                   "InventorySyncFacade::deleteAgent: Deleting data for agent '%s' from %s indexes",
+                   agentId.c_str(),
+                   WAZUH_STATES_INDEX_PATTERN);
 
         try
         {
@@ -2071,15 +2075,15 @@ private:
             auto lock = m_indexerConnector->scopeLock();
             m_indexerConnector->deleteByQuery(WAZUH_STATES_INDEX_PATTERN, agentId, m_clusterName);
 
-            LOG_INFO(
+            LOGFN_INFO(
                 m_logFn, "InventorySyncFacade::deleteAgent: Successfully deleted data for agent '%s'", agentId.c_str());
         }
         catch (const std::exception& e)
         {
-            LOG_ERROR(m_logFn,
-                      "InventorySyncFacade::deleteAgent: Failed to delete data for agent '%s': %s",
-                      agentId.c_str(),
-                      e.what());
+            LOGFN_ERROR(m_logFn,
+                        "InventorySyncFacade::deleteAgent: Failed to delete data for agent '%s': %s",
+                        agentId.c_str(),
+                        e.what());
         }
     }
 
@@ -2104,12 +2108,12 @@ private:
             const auto& existingContext = existingSession.getContext();
             if (existingContext->agentId == agentId && existingContext->moduleName == moduleName)
             {
-                LOG_INFO(m_logFn,
-                         "Found existing session %llu for agent %s module %s - "
-                         "cleaning up stale session",
-                         existingSessionId,
-                         agentId.c_str(),
-                         moduleName.c_str());
+                LOGFN_INFO(m_logFn,
+                           "Found existing session %llu for agent %s module %s - "
+                           "cleaning up stale session",
+                           existingSessionId,
+                           agentId.c_str(),
+                           moduleName.c_str());
                 staleSessionsToRemove.push_back(existingSessionId);
             }
         }
@@ -2126,10 +2130,10 @@ private:
                 if (context->ownsAgentLock)
                 {
                     unlockAgent(agentId);
-                    LOG_INFO(m_logFn,
-                             "Stale session %llu owned agent lock - unlocked agent %s",
-                             staleSessionId,
-                             agentId.c_str());
+                    LOGFN_INFO(m_logFn,
+                               "Stale session %llu owned agent lock - unlocked agent %s",
+                               staleSessionId,
+                               agentId.c_str());
                 }
 
                 // Delete data from database

--- a/src/wazuh_modules/inventory_sync/src/responseDispatcher.hpp
+++ b/src/wazuh_modules/inventory_sync/src/responseDispatcher.hpp
@@ -62,12 +62,12 @@ public:
         responseSocketClient->connect(
             [logFn = m_logFn](const char*, uint32_t, const char*, uint32_t)
             {
-                LOG_DEBUG2(logFn, "OnRead to %s", ARQUEUE_PATH);
+                LOGFN_DEBUG2(logFn, "OnRead to %s", ARQUEUE_PATH);
                 // Not used
             },
             [logFn = m_logFn]()
             {
-                LOG_DEBUG2(logFn, "Connected to %s", ARQUEUE_PATH);
+                LOGFN_DEBUG2(logFn, "Connected to %s", ARQUEUE_PATH);
                 // Not used
             },
             SOCK_DGRAM);
@@ -76,10 +76,10 @@ public:
         m_responseDispatcher = std::make_unique<ResponseQueue>(
             [responseSocketClient, logFn = m_logFn](const ResponseMessage& data)
             {
-                LOG_DEBUG2(logFn,
-                           "ResponseDispatcher: Sending response to agent '%s', module '%s'",
-                           data.agentId.c_str(),
-                           data.moduleName.c_str());
+                LOGFN_DEBUG2(logFn,
+                             "ResponseDispatcher: Sending response to agent '%s', module '%s'",
+                             data.agentId.c_str(),
+                             data.moduleName.c_str());
 
                 // Send via ARQUEUE for all agents
                 thread_local std::vector<uint8_t> messageVector;


### PR DESCRIPTION
## Description

The `LOG_INFO/WARN/ERROR/DEBUG1/DEBUG2` macros in `loggerHelper.h` collide with identically-named macros in the engine's `logging.hpp`. Any translation unit that includes both headers fails to compile or silently uses the wrong macro. Additionally, log levels across the indexer connector were miscalibrated: recoverable HTTP errors (429, generic network failures, partial bulk failures) were reported at ERROR, generating false alarms and masking real issues.

Closes #37354

## Proposed Changes

**Macro rename and design (commit 1)**
- Rename `LOG_*` → `LOGFN_*` across all callers in `shared_modules/` and `wazuh_modules/`
- Wrap `LOGFN_DEBUG1/DEBUG2` in `do { if (isLevelEnabled(...)) { ... } } while (0)` to prevent dangling-else bugs and skip argument evaluation when the level is inactive
- Declare `GLOBAL_LOG_LEVEL` as `inline int` in the header so each DSO gets an independent copy without a per-TU `.cpp` definition
- Move per-level helpers (`isInfoEnabled()`, etc.) into `namespace Log` to prevent the preprocessor from expanding `LOGLEVEL_DEBUG → 0`, which would produce the invalid token `Log::0`

**Log level calibration (commit 2)**
- `processBulk` / `processBulkChunk` onError: remove the generic `LOGFN_ERROR` that fired unconditionally before per-status branching; 429 and 413 already had dedicated handling — they no longer produce a spurious ERROR line
- `executeSearchQuery` / PIT `search`: add per-status handling; 429 → DEBUG1 with retry count, other errors → WARN
- `validateBulkResponse`: per-document failures → WARN; summary → WARN only when `realFailureCount > 0`, otherwise DEBUG2; parse exceptions → WARN
- `deleteByQuery` / `updateByQuery` generic else-branch → WARN
- `splitAndProcessBulk` inner catch (re-throw) → DEBUG1 to avoid double logging
- Thread bulk-loop outer catch → WARN
- Single-operation-too-large (data dropped, config issue) → WARN
- Async bulk threshold exhausted (fires once via flag) → WARN
- Input validation errors (unsafe index name, missing id) → WARN
- `IndexerDownloader`: demote the duplicate "Starting sliced PIT download" log to DEBUG1; the outer "Starting initial full load" already covers the event

### Results and Evidence

Before — every 429 from the indexer produced a false ERROR:
```
2026/07/14 11:30:12 wazuh-manager-modulesd:content-updater(indexer-connector): ERROR: Search query failed: Client error, status code: 429
```

After — 429 is handled at the appropriate level with retry context:
```
2026/07/14 ...: DEBUG: Search query rate-limited (429), retrying in 1 second(s).
```

Before — initial full load printed two INFO lines for the same event:
```
INFO: IndexerDownloader: Starting initial full load (slices=2)
INFO: IndexerDownloader: Starting sliced PIT download with 2 slices, pageSize=100
```

After — single INFO line; implementation detail demoted to DEBUG:
```
INFO: IndexerDownloader: Starting initial full load (slices=2)
```

### Artifacts Affected

- `wazuh-manager` (all platforms)

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

`src/shared_modules/indexer_connector/tests/unit/main.cpp`: assigns a no-op log function so `LOGFN_*` macro bodies execute during unit tests (previously the log callbacks were uninitialized, silently skipping the bodies).

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)