### PR TITLE
Fix invalid MTU value reported for Windows network interfaces

### DIFF
--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -1026,7 +1026,25 @@ nlohmann::json Syscollector::ecsNetworkInterfaceData(const nlohmann::json& origi
     setJsonField(ret, originalData, "/host/network/egress/errors", "host_network_egress_errors", createFields);
     setJsonField(ret, originalData, "/host/network/egress/packets", "host_network_egress_packages", createFields);
     setJsonField(ret, originalData, "/interface/alias", "interface_alias", createFields);
-    setJsonField(ret, originalData, "/interface/mtu", "interface_mtu", createFields);
+
+    // Discard invalid MTU values: 4294967295 (UINT32_MAX) is reported by Windows and 0 by UNIX
+    // when the MTU is not available
+    if (createFields || originalData.contains("interface_mtu"))
+    {
+        const nlohmann::json::json_pointer pointer("/interface/mtu");
+
+        if (originalData.contains("interface_mtu") && originalData["interface_mtu"].is_number() &&
+                originalData["interface_mtu"].get<int64_t>() != UINT32_MAX &&
+                originalData["interface_mtu"].get<int64_t>() != 0)
+        {
+            ret[pointer] = originalData["interface_mtu"];
+        }
+        else
+        {
+            ret[pointer] = nullptr;
+        }
+    }
+
     setJsonField(ret, originalData, "/interface/name", "interface_name", createFields);
     setJsonField(ret, originalData, "/interface/state", "interface_state", createFields);
     setJsonField(ret, originalData, "/interface/type", "interface_type", createFields);

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -4953,6 +4953,202 @@ TEST_F(SyscollectorImpTest, hardwareCpuSpeedZeroIsReportedAsNull)
     SchemaValidator::SchemaValidatorFactory::getInstance().reset();
 }
 
+// Windows reports interface_mtu as 4294967295 (UINT32_MAX) when the MTU is not available;
+// this correction must discard that placeholder and report interface.mtu as null.
+TEST_F(SyscollectorImpTest, schemaValidationDiscardsInvalidMtuValueOnWindows)
+{
+    const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
+
+    // No "IPv4"/"IPv6" sub-arrays are included on purpose, so that only the
+    // "dbsync_network_iface" table (and its "wazuh-states-inventory-interfaces" index)
+    // is generated, keeping this test focused on the MTU normalization.
+    const std::string networksJson =
+        R"({"iface":[{"host_mac":"d4:5d:64:51:07:5d", "interface_mtu":4294967295, "interface_name":"enp4s0", "interface_alias":" ", "interface_type":"ethernet", "interface_state":"up","host_network_ingress_bytes":0,"host_network_ingress_drops":0,"host_network_ingress_errors":0,"host_network_ingress_packages":0,"host_network_egress_bytes":0,"host_network_egress_drops":0,"host_network_egress_errors":0,"host_network_egress_packages":0}]})";
+
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(networksJson)));
+    EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, packages(_)).Times(0);
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, processes(_)).Times(0);
+    EXPECT_CALL(*spInfoWrapper, groups()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, users()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, services()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, browserExtensions()).WillRepeatedly(Return(nlohmann::json{}));
+
+    CallbackMock wrapperDelta;
+    std::function<void(const std::string&)> callbackDataDelta
+    {
+        [&wrapperDelta](const std::string & data)
+        {
+            wrapperDelta.callbackMock(data);
+        }
+    };
+
+    CallbackMockPersist wrapperPersist;
+    std::function<void(const std::string&, Operation_t, const std::string&, const std::string&, uint64_t)> callbackDataPersist
+    {
+        [&wrapperPersist](const std::string & id, Operation_t operation, const std::string & index, const std::string & data, uint64_t version)
+        {
+            auto jsonData = nlohmann::json::parse(data);
+
+            if (index == "wazuh-states-inventory-interfaces")
+            {
+                // interface.mtu should be null instead of the raw 4294967295 placeholder
+                EXPECT_TRUE(jsonData["interface"]["mtu"].is_null());
+            }
+
+            wrapperPersist.callbackMock(id, operation, index, data, version);
+        }
+    };
+
+    EXPECT_CALL(wrapperPersist, callbackMock(testing::_, testing::_, testing::Eq("wazuh-states-inventory-interfaces"), testing::_, testing::_)).Times(1);
+
+    std::thread t
+    {
+        [&spInfoWrapper, &callbackDataDelta, &callbackDataPersist]()
+        {
+            Syscollector::instance().init(spInfoWrapper,
+                                          callbackDataDelta,
+                                          callbackDataPersist,
+                                          logFunction,
+                                          SYSCOLLECTOR_DB_PATH,
+                                          "",
+                                          "",
+                                          5, true, false, false, true, false, false, false, false, false, false, false, false, false, false);
+
+            // Initialize sync protocol to enable schema validation
+            MQ_Functions mqFuncs;
+            mqFuncs.start = [](const char*, short, short) -> int { return 0; };
+            mqFuncs.send_binary = [](int, const void*, size_t, const char*, char) -> int { return 0; };
+
+            Syscollector::instance().initSyncProtocol(
+                "syscollector",
+                ":memory:",
+                ":memory:",
+                mqFuncs,
+                std::chrono::seconds(10),
+                std::chrono::seconds(5),
+                3,
+                100,
+                86400
+            );
+
+            Syscollector::instance().start();
+        }
+    };
+
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+    Syscollector::instance().destroy();
+
+    if (t.joinable())
+    {
+        t.join();
+    }
+
+    // Reset factory after test
+    SchemaValidator::SchemaValidatorFactory::getInstance().reset();
+}
+
+// UNIX (Linux/BSD) reports interface_mtu as 0 when the MTU is not available;
+// this correction must discard that placeholder and report interface.mtu as null.
+TEST_F(SyscollectorImpTest, schemaValidationDiscardsInvalidMtuValueOnUnix)
+{
+    const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
+
+    // No "IPv4"/"IPv6" sub-arrays are included on purpose, so that only the
+    // "dbsync_network_iface" table (and its "wazuh-states-inventory-interfaces" index)
+    // is generated, keeping this test focused on the MTU normalization.
+    const std::string networksJson =
+        R"({"iface":[{"host_mac":"d4:5d:64:51:07:5d", "interface_mtu":0, "interface_name":"enp4s0", "interface_alias":" ", "interface_type":"ethernet", "interface_state":"up","host_network_ingress_bytes":0,"host_network_ingress_drops":0,"host_network_ingress_errors":0,"host_network_ingress_packages":0,"host_network_egress_bytes":0,"host_network_egress_drops":0,"host_network_egress_errors":0,"host_network_egress_packages":0}]})";
+
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, os()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(Return(nlohmann::json::parse(networksJson)));
+    EXPECT_CALL(*spInfoWrapper, ports()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, packages(_)).Times(0);
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, processes(_)).Times(0);
+    EXPECT_CALL(*spInfoWrapper, groups()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, users()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, services()).WillRepeatedly(Return(nlohmann::json{}));
+    EXPECT_CALL(*spInfoWrapper, browserExtensions()).WillRepeatedly(Return(nlohmann::json{}));
+
+    CallbackMock wrapperDelta;
+    std::function<void(const std::string&)> callbackDataDelta
+    {
+        [&wrapperDelta](const std::string & data)
+        {
+            wrapperDelta.callbackMock(data);
+        }
+    };
+
+    CallbackMockPersist wrapperPersist;
+    std::function<void(const std::string&, Operation_t, const std::string&, const std::string&, uint64_t)> callbackDataPersist
+    {
+        [&wrapperPersist](const std::string & id, Operation_t operation, const std::string & index, const std::string & data, uint64_t version)
+        {
+            auto jsonData = nlohmann::json::parse(data);
+
+            if (index == "wazuh-states-inventory-interfaces")
+            {
+                // interface.mtu should be null instead of the raw 0 placeholder
+                EXPECT_TRUE(jsonData["interface"]["mtu"].is_null());
+            }
+
+            wrapperPersist.callbackMock(id, operation, index, data, version);
+        }
+    };
+
+    EXPECT_CALL(wrapperPersist, callbackMock(testing::_, testing::_, testing::Eq("wazuh-states-inventory-interfaces"), testing::_, testing::_)).Times(1);
+
+    std::thread t
+    {
+        [&spInfoWrapper, &callbackDataDelta, &callbackDataPersist]()
+        {
+            Syscollector::instance().init(spInfoWrapper,
+                                          callbackDataDelta,
+                                          callbackDataPersist,
+                                          logFunction,
+                                          SYSCOLLECTOR_DB_PATH,
+                                          "",
+                                          "",
+                                          5, true, false, false, true, false, false, false, false, false, false, false, false, false, false);
+
+            // Initialize sync protocol to enable schema validation
+            MQ_Functions mqFuncs;
+            mqFuncs.start = [](const char*, short, short) -> int { return 0; };
+            mqFuncs.send_binary = [](int, const void*, size_t, const char*, char) -> int { return 0; };
+
+            Syscollector::instance().initSyncProtocol(
+                "syscollector",
+                ":memory:",
+                ":memory:",
+                mqFuncs,
+                std::chrono::seconds(10),
+                std::chrono::seconds(5),
+                3,
+                100,
+                86400
+            );
+
+            Syscollector::instance().start();
+        }
+    };
+
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+    Syscollector::instance().destroy();
+
+    if (t.joinable())
+    {
+        t.join();
+    }
+
+    // Reset factory after test
+    SchemaValidator::SchemaValidatorFactory::getInstance().reset();
+}
+
 // Schema validation test using mock to force rejection
 TEST_F(SyscollectorImpTest, schemaValidationRejectsInvalidDataWithMock)
 {


### PR DESCRIPTION
## Description

Some network adapters report a placeholder MTU value when the actual MTU cannot be determined: `4294967295` (`UINT32_MAX`) on Windows, and `0` on UNIX (Linux/BSD). This raw value was being forwarded as-is into the `interface.mtu` field of the network interface inventory, showing up as a nonsensical value instead of a meaningful one.

This change discards both placeholders and reports `interface.mtu` as `null` when either is detected, following the same normalization approach already used for other numeric fields (e.g. `cpu_speed`).

Closes #37319.

## Proposed Changes

- Updated `Syscollector::ecsNetworkInterfaceData` (`syscollectorImp.cpp`) to detect an `interface_mtu` value of `4294967295` (`UINT32_MAX`, Windows) or `0` (UNIX) and map it to `null` instead of passing it through, matching the existing convention used for `cpu_speed`.

### Results and Evidence

**Before** — Loopback interface reporting `interface.mtu = 4294967295`:

<img width="1714" height="998" alt="Screenshot 2026-07-03 101033" src="https://github.com/user-attachments/assets/47719c45-3402-4813-9653-9a4959f0a106" />

**After** — Loopback interface reporting `interface.mtu = null`:

<img width="1394" height="937" alt="Screenshot 2026-07-03 124010" src="https://github.com/user-attachments/assets/237d4f43-6356-4602-bffc-a38c97ea6875" />

**Sample state document (JSON)** — `interface.mtu` normalized to `null`:

```json
{
  "_index": "wazuh-states-inventory-interfaces",
  "_id": "wazuh_003_f91f4f60835cea3e8555c0dba7b3a29e6ade8ae7",
  "_score": 0,
  "_source": {
    "checksum": {
      "hash": {
        "sha1": "e0c587989b207e396f9d15ac40ad731b40185b20"
      }
    },
    "host": {
      "mac": [
        "00:00:00:00:00:00"
      ],
      "network": {
        "egress": {
          "bytes": 0,
          "drops": 0,
          "errors": 0,
          "packets": 0
        },
        "ingress": {
          "bytes": 0,
          "drops": 0,
          "errors": 0,
          "packets": 0
        }
      }
    },
    "interface": {
      "alias": "Software Loopback Interface 1",
      "mtu": null,
      "name": "Loopback Pseudo-Interface 1",
      "state": "up",
      "type": null
    },
    "state": {
      "document_version": 1,
      "modified_at": "2026-07-03T10:39:39.169Z"
    },
    "wazuh": {
      "agent": {
        "groups": [
          "default"
        ],
        "host": {
          "architecture": "x86_64",
          "hostname": "ROCKET",
          "os": {
            "name": "Microsoft Windows 11 Pro",
            "platform": "",
            "type": "windows",
            "version": "10.0.26200.8655"
          }
        },
        "id": "003",
        "name": "Rocket",
        "version": "v5.0.0"
      },
      "cluster": {
        "name": "wazuh"
      }
    }
  },
  "fields": {
    "state.modified_at": [
      "2026-07-03T10:39:39.169Z"
    ]
  }
}
```

### Artifacts Affected

- `syscollector.dll` (Windows)
- `libsyscollector.so` (UNIX)

### Configuration Changes

- None.

### Documentation Updates

- None.

### Tests Introduced

- `schemaValidationDiscardsInvalidMtuValueOnWindows` (`syscollectorImp_test.cpp`): simulates a network interface reporting `interface_mtu: 4294967295` and verifies that the resulting `wazuh-states-inventory-interfaces` document contains `interface.mtu: null`.
- `schemaValidationDiscardsInvalidMtuValueOnUnix` (`syscollectorImp_test.cpp`): simulates a network interface reporting `interface_mtu: 0` and verifies that the resulting `wazuh-states-inventory-interfaces` document contains `interface.mtu: null`.

```
[ RUN      ] [mSyscollectorImpTest.schemaValidationDiscardsInvalidMtuValueOnWindows
[       OK ] [mSyscollectorImpTest.schemaValidationDiscardsInvalidMtuValueOnWindows (2003 ms)
[ RUN      ] [mSyscollectorImpTest.schemaValidationDiscardsInvalidMtuValueOnUnix
[       OK ] [mSyscollectorImpTest.schemaValidationDiscardsInvalidMtuValueOnUnix (2003 ms)
```

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
