### PR TITLE
Fix Azure Storage bookmarks to be keyed per container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## [v5.0.1]
 
+### Manager
+
+#### Fixed
+
+- Fixed Azure Storage integration bookmarks to be keyed per container instead of per storage account, preventing low-volume containers from being skipped when several containers share the same account. ([#37391](https://github.com/wazuh/wazuh/issues/37391))
+
 ## [v5.0.0]
 
 ### Manager

--- a/wodles/azure/azure_services/storage.py
+++ b/wodles/azure/azure_services/storage.py
@@ -8,7 +8,6 @@
 import logging
 import sys
 from datetime import datetime
-from hashlib import md5
 from json import JSONDecodeError, dumps, loads
 from os.path import abspath, dirname
 
@@ -79,17 +78,20 @@ def start_storage(args):
 
     # Get the blobs
     for container in containers:
-        md5_hash = md5(name.encode()).hexdigest()
+        # Include the container name in the primary key so each container keeps its own bookmark.
+        # Using only the account name would make every container in the same storage account share
+        # a single bookmark row, causing low-volume containers to be skipped as "already processed"
+        md5_hash = orm.create_pk(account=name, container=container)
         offset = args.storage_time_offset
         try:
             item = orm.get_row(orm.Storage, md5=md5_hash)
             if item is None:
                 item = create_new_row(
-                    table=orm.Storage, query=name, md5_hash=md5_hash, offset=offset
+                    table=orm.Storage, query=container, md5_hash=md5_hash, offset=offset
                 )
         except orm.AzureORMError as e:
             logging.error(
-                f'Error trying to obtain row object from "{orm.Storage.__tablename__}" using md5="{md5}": {e}'
+                f'Error trying to obtain row object from "{orm.Storage.__tablename__}" using md5="{md5_hash}": {e}'
             )
             sys.exit(1)
 

--- a/wodles/azure/tests/azure_services/test_storage.py
+++ b/wodles/azure/tests/azure_services/test_storage.py
@@ -8,7 +8,6 @@
 import json
 import sys
 from datetime import datetime
-from hashlib import md5
 from os.path import abspath, dirname, join, realpath
 from typing import Optional
 from unittest.mock import MagicMock, PropertyMock, call, patch
@@ -96,14 +95,64 @@ def test_start_storage(
 
     mock_auth.assert_called_with(auth_path=auth_path, fields=('account_name', 'account_key'))
 
-    md5_hash = md5(name.encode()).hexdigest()
+    md5_hash = orm.create_pk(account=name, container=container_name)
     mock_blob.assert_called_with(
         account_url=f'https://{name}.blob.core.windows.net/',
         credential={'account_name': name, 'account_key': key}
     )
     mock_get_row.assert_called_with(orm.Storage, md5=md5_hash)
-    mock_create.assert_called_with(table=orm.Storage, query=name, md5_hash=md5_hash, offset=offset)
+    mock_create.assert_called_with(table=orm.Storage, query=container_name, md5_hash=md5_hash, offset=offset)
     mock_get_blobs.assert_called_once()
+
+
+@patch('azure_services.storage.get_blobs')
+@patch('azure_services.storage.create_new_row')
+@patch('azure_services.storage.orm.get_row', return_value=None)
+@patch('azure_services.storage.BlobServiceClient')
+@patch('azure_services.storage.read_auth_file')
+def test_start_storage_multiple_containers_have_distinct_bookmarks(
+    mock_auth,
+    mock_blob,
+    mock_get_row,
+    mock_create,
+    mock_get_blobs,
+):
+    """Test each container in the same storage account gets its own bookmark row."""
+    name = 'name'
+    key = 'key'
+    offset = '1d'
+    container_names = ['container1', 'container2']
+    args = MagicMock(
+        storage_auth_path='auth_path',
+        account_name=name,
+        account_key=key,
+        container='*',
+        storage_time_offset=offset,
+    )
+    mock_create.return_value = MagicMock(min_processed_date=PRESENT_DATE, max_processed_date=PRESENT_DATE)
+    mock_auth.return_value = (name, key)
+    m = MagicMock()
+    mocked_containers = []
+    for container_name in container_names:
+        container = MagicMock()
+        container.name = container_name
+        mocked_containers.append(container)
+    m.list_containers.return_value = mocked_containers
+    mock_blob.return_value = m
+    start_storage(args)
+
+    expected_hashes = [
+        orm.create_pk(account=name, container=container_name) for container_name in container_names
+    ]
+    assert len(set(expected_hashes)) == len(container_names)
+    mock_get_row.assert_has_calls([call(orm.Storage, md5=md5_hash) for md5_hash in expected_hashes])
+    mock_create.assert_has_calls(
+        [
+            call(table=orm.Storage, query=container_name, md5_hash=md5_hash, offset=offset)
+            for container_name, md5_hash in zip(container_names, expected_hashes)
+        ]
+    )
+    assert mock_get_blobs.call_count == len(container_names)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Closes #37391.

The Azure Storage integration computes the bookmark primary key (`md5`) from the storage account name only:

```python
md5_hash = md5(name.encode()).hexdigest()   # 'name' is the storage account name
```

Because of this, every container in the same storage account maps to the **same row** in the `storage` table of `azure.db`. A high-volume container keeps advancing the shared `max_processed_date`, and lower-volume containers in the same account are treated as "already processed" and silently stop being collected.

This is a common layout: Azure Application Gateway diagnostic settings send Access and WAF logs to two different containers in the same storage account (`insights-logs-applicationgatewayaccesslog` / `insights-logs-applicationgatewayfirewalllog`), and the account cannot be split per log category.

## Changes

- Build the bookmark key with `orm.create_pk(account=..., container=...)`, following the approach already used by the Log Analytics integration (`create_pk(workspace=..., query=...)`), so each container keeps its own bookmark row.
- Store the container name in the `query` column so each `storage` row is identifiable.
- Fix the error log in `start_storage` that interpolated the `md5` function object instead of the computed hash.
- Update the existing `test_start_storage` expectations and add a regression test asserting that multiple containers in the same account get distinct bookmark rows.
- Add CHANGELOG entry.

## Upgrade note

Existing deployments have a single row keyed by the account-name hash. After this change, new per-container rows are created on the next run and their initial window is derived from `time_offset` (same as a fresh install), so blobs within one offset window may be re-ingested once. The legacy row is left in place and simply no longer used. If a data migration of the legacy bookmark is preferred, I am happy to add it.

## Tests

- `wodles/azure/tests/azure_services/test_storage.py`: 35/35 pass.
- Full `wodles/azure/tests` suite: 174 pass; the 5 failures in `test_azure_utils.py::test_send_message*` are environment-only (tests open a real `AF_UNIX` socket, unavailable on the Windows dev machine) and unrelated to this change.

| Test | Result |
|------|--------|
| `pytest wodles/azure/tests/azure_services/test_storage.py` | ✅ 35 passed |
| New: `test_start_storage_multiple_containers_have_distinct_bookmarks` | ✅ passed |
