### PR TITLE
Checkout wazuh/wazuh explicitly in the engine standalone test job

### DIFF
--- a/.github/workflows/5_builderpackage_engine-standalone.yml
+++ b/.github/workflows/5_builderpackage_engine-standalone.yml
@@ -160,8 +160,15 @@ jobs:
             ;;
         esac
 
+    # Explicit repository/ref (same as the build job): this workflow is also
+    # invoked cross-repo (e.g. from wazuh-indexer), where a bare checkout would
+    # clone the caller's repo and the local download_s3_artifact action would
+    # not be on disk.
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        repository: wazuh/wazuh
+        ref: ${{ env.WAZUH_BRANCH }}
 
     - name: Download compressed tar.gz file
       uses: ./.github/actions/download_s3_artifact


### PR DESCRIPTION
## Description

Follow-up to #37350 (wazuh-automation#3502).

`5_builderpackage_engine-standalone.yml` is a reusable workflow that is also invoked cross-repo: wazuh-indexer calls it to build and test the engine. The `check_standalone_engine` job used a bare `actions/checkout@v4`, which checks out the caller's repository. When the caller is wazuh-indexer, the workspace is wazuh-indexer's tree, so the local `download_s3_artifact` action introduced by #37350 is not on disk and the job fails at the `Download compressed tar.gz file` step:

```
Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '.../wazuh-indexer/wazuh-indexer/.github/actions/download_s3_artifact'. Did you forget to run actions/checkout before running your local action?
```

The build job in the same workflow already handles this by checking out `wazuh/wazuh` at `WAZUH_BRANCH` explicitly. This PR makes the test job do the same.

Runs triggered from within wazuh/wazuh are unaffected: for them the explicit checkout resolves to the same repository as before.

CI-only change, no changelog entry (`skip-changelog`).

## Tests

- [x] actionlint / YAML parse clean (remaining shellcheck notes are pre-existing in untouched run scripts)
- [ ] wazuh-indexer engine build run against this branch
