### PR TITLE
fix(ci): grant OIDC to Coverity S3 jobs

### DIFF
--- a/.github/workflows/4_codeanalysis_coverity.yml
+++ b/.github/workflows/4_codeanalysis_coverity.yml
@@ -65,6 +65,7 @@ jobs:
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     needs: prepare
     permissions:
+      id-token: write
       contents: read
       packages: read
     steps:
@@ -110,6 +111,9 @@ jobs:
   upload:
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     needs: [prepare, build]
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Grant `id-token: write` to the Coverity build job, which uploads the Coverity artifact to S3.
- Add explicit OIDC permissions to the Coverity upload job, which downloads the artifact from S3.
- Keep `packages: read` on the build job for the GHCR login.

## Problem
The build job had a job-level `permissions:` block without `id-token: write`, which overrode the workflow-level OIDC permission. As a result, `aws-actions/configure-aws-credentials` could not use OIDC and fell back to the CodeBuild runner credentials, failing with `sts:TagSession` authorization errors.

## Validation
- Parsed `.github/workflows/4_codeanalysis_coverity.yml` with PyYAML.
- Verified the jobs using `upload_s3_artifact` / `download_s3_artifact` have `id-token: write`.
