### PR TITLE
Preserve original scan_day/scan_time strings in syscheck config

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -79,6 +79,8 @@ int initialize_syscheck_configuration(syscheck_config *syscheck) {
     syscheck->nodiff_regex                    = NULL;
     syscheck->scan_day                        = NULL;
     syscheck->scan_time                       = NULL;
+    syscheck->scan_day_str                    = NULL;
+    syscheck->scan_time_str                   = NULL;
     syscheck->file_limit_enabled              = true;
     syscheck->file_entry_limit                = 100000;
     syscheck->directories                     = OSList_Create();
@@ -1763,6 +1765,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
+            os_strdup(node[i]->content, syscheck->scan_time_str);
         }
 
         /* Get scan day */
@@ -1773,6 +1776,7 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *configp, __attribute__
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
+            os_strdup(node[i]->content, syscheck->scan_day_str);
         }
 
         /* Get file limit */
@@ -2369,8 +2373,14 @@ void Free_Syscheck(syscheck_config * config) {
         if (config->scan_day) {
             free(config->scan_day);
         }
+        if (config->scan_day_str) {
+            free(config->scan_day_str);
+        }
         if (config->scan_time) {
             free(config->scan_time);
+        }
+        if (config->scan_time_str) {
+            free(config->scan_time_str);
         }
         if (config->ignore) {
             for (i=0; config->ignore[i] != NULL; i++) {

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -386,6 +386,8 @@ typedef struct _config {
 
     char *scan_day;                                    /* run syscheck on this day */
     char *scan_time;                                   /* run syscheck at this time */
+    char *scan_day_str;                                /* original scan_day string from config */
+    char *scan_time_str;                               /* original scan_time string from config */
 
     unsigned int file_limit_enabled;                   /* Enable FIM file entry max limits */
     int file_entry_limit;                              /* maximum number of files to monitor */

--- a/src/syscheckd/src/config.c
+++ b/src/syscheckd/src/config.c
@@ -141,8 +141,8 @@ cJSON *getSyscheckConfig(void) {
     cJSON_AddStringToObject(syscfg, "skip_sys", syscheck.skip_fs.sys ? "yes" : "no");
     cJSON_AddStringToObject(syscfg, "skip_proc", syscheck.skip_fs.proc ? "yes" : "no");
     if (syscheck.scan_on_start) cJSON_AddStringToObject(syscfg,"scan_on_start","yes"); else cJSON_AddStringToObject(syscfg,"scan_on_start","no");
-    if (syscheck.scan_day) cJSON_AddStringToObject(syscfg,"scan_day",syscheck.scan_day);
-    if (syscheck.scan_time) cJSON_AddStringToObject(syscfg,"scan_time",syscheck.scan_time);
+    if (syscheck.scan_day_str) cJSON_AddStringToObject(syscfg,"scan_day",syscheck.scan_day_str);
+    if (syscheck.scan_time_str) cJSON_AddStringToObject(syscfg,"scan_time",syscheck.scan_time_str);
     cJSON_AddNumberToObject(syscfg, "max_files_per_second", syscheck.max_files_per_second);
 
     cJSON * file_limit = cJSON_CreateObject();


### PR DESCRIPTION
# Description

`GET /agents/{id}/config/syscheck/syscheck` returns garbled values for `scan_day` and `scan_time` instead of the human-readable strings configured in `ossec.conf`. `getSyscheckConfig()` was serializing the internal, encoded runtime representations of these fields (a day-of-week bitmask and a converted/duplicated time string, produced by `OS_IsValidDay()` / `OS_IsValidUniqueTime()` for scheduling purposes) directly into the JSON response instead of the original config values. This change keeps the original strings around and reports those instead. 

Resolves #37181.

## Proposed Changes

- Added `scan_day_str` and `scan_time_str` fields to `syscheck_config` (`src/config/syscheck-config.h`) to hold the original, human-readable `<scan_day>` / `<scan_time>` values from `ossec.conf`, separate from the encoded fields used internally for scheduling.
- `Read_Syscheck_Config` (`src/config/syscheck-config.c`) now duplicates the raw XML content of `<scan_time>` and `<scan_day>` into `scan_time_str` / `scan_day_str` via `os_strdup`, and `Free_Syscheck` releases both new fields.
- `getSyscheckConfig()` (`src/syscheckd/src/config.c`) now populates the `scan_day` / `scan_time` JSON fields from `scan_day_str` / `scan_time_str` instead of from the internal `scan_day` (bitmask) / `scan_time` (encoded schedule) fields.

### Results and Evidence

Two Ubuntu 26.04 agents enrolled to the same manager: `stable-agent-37181` (ID `002`, latest stable release, unpatched) and `pr-agent-37181` (ID `003`, this fix, 4.14.7). Each agent was configured in turn with two `<syscheck>` variants, then queried via `GET /agents/{id}/config/syscheck/syscheck`.

#### Before the fix — unpatched stable agent (`002`)

**Variant A** — configure the agent, then query the API:

```console
$ grep -A2 '<syscheck>' /var/ossec/etc/ossec.conf
<syscheck>
  <scan_time>01:00</scan_time>
  <scan_day>sunday</scan_day>

$ curl -sk -H "Authorization: Bearer $TOKEN" \
    'https://localhost:55000/agents/002/config/syscheck/syscheck' \
    | jq -c '.data.syscheck | {scan_day, scan_time}'
{"scan_day":"","scan_time":".01:0001:00"}
```

**Variant B**:

```console
$ grep -A2 '<syscheck>' /var/ossec/etc/ossec.conf
<syscheck>
  <scan_time>3pm</scan_time>
  <scan_day>weekdays</scan_day>

$ curl -sk -H "Authorization: Bearer $TOKEN" \
    'https://localhost:55000/agents/002/config/syscheck/syscheck' \
    | jq -c '.data.syscheck | {scan_day, scan_time}'
{"scan_day":"","scan_time":".15:0015:00"}
```

`scan_day` comes back as a non-printable byte (``) or empty, and `scan_time` as a dot-prefixed duplicate — the encoded internal representations, not the configured strings.

#### After the fix — patched PR build agent (`003`)

**Variant A**:

```console
$ grep -A2 '<syscheck>' /var/ossec/etc/ossec.conf
<syscheck>
  <scan_time>01:00</scan_time>
  <scan_day>sunday</scan_day>

$ curl -sk -H "Authorization: Bearer $TOKEN" \
    'https://localhost:55000/agents/003/config/syscheck/syscheck' \
    | jq -c '.data.syscheck | {scan_day, scan_time}'
{"scan_day":"sunday","scan_time":"01:00"}
```

**Variant B**:

```console
$ grep -A2 '<syscheck>' /var/ossec/etc/ossec.conf
<syscheck>
  <scan_time>3pm</scan_time>
  <scan_day>weekdays</scan_day>

$ curl -sk -H "Authorization: Bearer $TOKEN" \
    'https://localhost:55000/agents/003/config/syscheck/syscheck' \
    | jq -c '.data.syscheck | {scan_day, scan_time}'
{"scan_day":"weekdays","scan_time":"3pm"}
```

The API now returns the original human-readable strings exactly as configured in `ossec.conf`.
<details><summary>Full unabridged API responses — grouped by variant (before vs. after)</summary>

```json
// ===== Variant A: scan_day=sunday scan_time=01:00 =====

// BEFORE fix — stable-agent-37181 (002)  ->  scan_day="", scan_time=".01:0001:00"
{"data": {"syscheck": {"disabled": "no", "frequency": 604800, "skip_nfs": "yes", "skip_dev": "yes", "skip_sys": "yes", "skip_proc": "yes", "scan_on_start": "no", "scan_day": "", "scan_time": ".01:0001:00", "max_files_per_second": 0, "file_limit": {"enabled": "yes", "entries": 100000}, "diff": {"disk_quota": {"enabled": "yes", "limit": 1048576}, "file_size": {"enabled": "yes", "limit": 51200}}, "directories": [{"opts": ["check_md5sum", "check_sha1sum", "check_perm", "check_size", "check_owner", "check_group", "check_mtime", "check_inode", "check_sha256sum"], "dir": "/etc", "recursion_level": 256, "diff_size_limit": 51200}], "whodata": {"restart_audit": "yes", "startup_healthcheck": "yes", "queue_size": 16384, "provider": "audit"}, "allow_remote_prefilter_cmd": "no", "synchronization": {"enabled": "yes", "queue_size": 16384, "interval": 300, "max_eps": 10, "response_timeout": 30, "max_interval": 3600, "thread_pool": 1}, "max_eps": 50, "process_priority": 10, "database": "disk"}}, "error": 0}

// AFTER fix — pr-agent-37181 (003)  ->  scan_day="sunday", scan_time="01:00"
{"data": {"syscheck": {"disabled": "no", "frequency": 604800, "skip_nfs": "yes", "skip_dev": "yes", "skip_sys": "yes", "skip_proc": "yes", "scan_on_start": "no", "scan_day": "sunday", "scan_time": "01:00", "max_files_per_second": 0, "file_limit": {"enabled": "yes", "entries": 100000}, "diff": {"disk_quota": {"enabled": "yes", "limit": 1048576}, "file_size": {"enabled": "yes", "limit": 51200}}, "directories": [{"opts": ["check_md5sum", "check_sha1sum", "check_perm", "check_size", "check_owner", "check_group", "check_mtime", "check_inode", "check_sha256sum"], "dir": "/etc", "recursion_level": 256, "diff_size_limit": 51200}], "whodata": {"restart_audit": "yes", "startup_healthcheck": "yes", "queue_size": 16384, "provider": "audit"}, "allow_remote_prefilter_cmd": "no", "synchronization": {"enabled": "yes", "queue_size": 16384, "interval": 300, "max_eps": 10, "response_timeout": 30, "max_interval": 3600, "thread_pool": 1}, "max_eps": 50, "process_priority": 10, "database": "disk"}}, "error": 0}


// ===== Variant B: scan_day=weekdays scan_time=3pm =====

// BEFORE fix — stable-agent-37181 (002)  ->  scan_day="", scan_time=".15:0015:00"
{"data": {"syscheck": {"disabled": "no", "frequency": 604800, "skip_nfs": "yes", "skip_dev": "yes", "skip_sys": "yes", "skip_proc": "yes", "scan_on_start": "no", "scan_day": "", "scan_time": ".15:0015:00", "max_files_per_second": 0, "file_limit": {"enabled": "yes", "entries": 100000}, "diff": {"disk_quota": {"enabled": "yes", "limit": 1048576}, "file_size": {"enabled": "yes", "limit": 51200}}, "directories": [{"opts": ["check_md5sum", "check_sha1sum", "check_perm", "check_size", "check_owner", "check_group", "check_mtime", "check_inode", "check_sha256sum"], "dir": "/etc", "recursion_level": 256, "diff_size_limit": 51200}], "whodata": {"restart_audit": "yes", "startup_healthcheck": "yes", "queue_size": 16384, "provider": "audit"}, "allow_remote_prefilter_cmd": "no", "synchronization": {"enabled": "yes", "queue_size": 16384, "interval": 300, "max_eps": 10, "response_timeout": 30, "max_interval": 3600, "thread_pool": 1}, "max_eps": 50, "process_priority": 10, "database": "disk"}}, "error": 0}

// AFTER fix — pr-agent-37181 (003)  ->  scan_day="weekdays", scan_time="3pm"
{"data": {"syscheck": {"disabled": "no", "frequency": 604800, "skip_nfs": "yes", "skip_dev": "yes", "skip_sys": "yes", "skip_proc": "yes", "scan_on_start": "no", "scan_day": "weekdays", "scan_time": "3pm", "max_files_per_second": 0, "file_limit": {"enabled": "yes", "entries": 100000}, "diff": {"disk_quota": {"enabled": "yes", "limit": 1048576}, "file_size": {"enabled": "yes", "limit": 51200}}, "directories": [{"opts": ["check_md5sum", "check_sha1sum", "check_perm", "check_size", "check_owner", "check_group", "check_mtime", "check_inode", "check_sha256sum"], "dir": "/etc", "recursion_level": 256, "diff_size_limit": 51200}], "whodata": {"restart_audit": "yes", "startup_healthcheck": "yes", "queue_size": 16384, "provider": "audit"}, "allow_remote_prefilter_cmd": "no", "synchronization": {"enabled": "yes", "queue_size": 16384, "interval": 300, "max_eps": 10, "response_timeout": 30, "max_interval": 3600, "thread_pool": 1}, "max_eps": 50, "process_priority": 10, "database": "disk"}}, "error": 0}
```

</details>

### Artifacts Affected

- `wazuh-syscheckd` (agent FIM daemon) — reports the fixed `scan_day` / `scan_time` values in response to `getconfig syscheck` requests.
- `src/config/syscheck-config.c`, `src/config/syscheck-config.h` — shared syscheck config struct/parsing, linked into both the agent and manager syscheck config code paths.
- `GET /agents/{id}/config/syscheck/syscheck` REST API response — consumers of this endpoint (API clients, dashboard) now see the original human-readable values.

### Configuration Changes

_No configuration changes._

### Documentation Updates

_No documentation changes required._

### Tests Introduced

_No new tests introduced._

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
