### PR TITLE
Restore modern.bpf.o checkfiles baseline reverted by 4.14.7 merge

### DIFF
--- a/.github/actions/check_files/deb_linux_agent_amd64.csv
+++ b/.github/actions/check_files/deb_linux_agent_amd64.csv
@@ -15,7 +15,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,253344,0.1
 /var/ossec/lib/libbpf.so,root,wazuh,750,file,-rwxr-x---,526040,0.1
 /var/ossec/lib/libfimebpf.so,root,wazuh,750,file,-rwxr-x---,64168,0.1
-/var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,904720,0.1
+/var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,998504,0.1
 /var/ossec/lib/libstdc++.so.6,root,wazuh,750,file,-rwxr-x---,2599704,0.1
 /var/ossec/lib/libsyscollector.so,root,wazuh,750,file,-rwxr-x---,793656,0.1
 /var/ossec/lib/libsca.so,root,wazuh,750,file,-rwxr-x---,800872,0.1

--- a/.github/actions/check_files/deb_linux_agent_i386.csv
+++ b/.github/actions/check_files/deb_linux_agent_i386.csv
@@ -15,7 +15,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,273712,0.1
 /var/ossec/lib/libbpf.so,root,wazuh,750,file,-rwxr-x---,470148,0.1
 /var/ossec/lib/libfimebpf.so,root,wazuh,750,file,-rwxr-x---,57476,0.1
-/var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,904752,0.1
+/var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,998504,0.1
 /var/ossec/lib/libstdc++.so.6,root,wazuh,750,file,-rwxr-x---,2123404,0.1
 /var/ossec/lib/libsyscollector.so,root,wazuh,750,file,-rwxr-x---,911196,0.1
 /var/ossec/lib/libsca.so,root,wazuh,750,file,-rwxr-x---,836900,0.1

--- a/.github/actions/check_files/rpm_linux_agent_amd64.csv
+++ b/.github/actions/check_files/rpm_linux_agent_amd64.csv
@@ -79,7 +79,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,224672,0.1
 /var/ossec/lib/libbpf.so,root,wazuh,750,file,-rwxr-x---,526048,0.1
 /var/ossec/lib/libfimebpf.so,root,wazuh,750,file,-rwxr-x---,60080,0.1
-/var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,904720,0.1
+/var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,998504,0.1
 /var/ossec/lib/libstdc++.so.6,root,wazuh,750,file,-rwxr-x---,2530376,0.1
 /var/ossec/lib/libsyscollector.so,root,wazuh,750,file,-rwxr-x---,769128,0.1
 /var/ossec/lib/libsca.so,root,wazuh,750,file,-rwxr-x---,783864,0.1

--- a/.github/actions/check_files/rpm_linux_agent_i386.csv
+++ b/.github/actions/check_files/rpm_linux_agent_i386.csv
@@ -79,7 +79,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,259032,0.1
 /var/ossec/lib/libbpf.so,root,wazuh,750,file,-rwxr-x---,470152,0.1
 /var/ossec/lib/libfimebpf.so,root,wazuh,750,file,-rwxr-x---,52720,0.1
-/var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,904752,0.1
+/var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,998504,0.1
 /var/ossec/lib/libstdc++.so.6,root,wazuh,750,file,-rwxr-x---,1984136,0.1
 /var/ossec/lib/libsyscollector.so,root,wazuh,750,file,-rwxr-x---,866104,0.1
 /var/ossec/lib/libsca.so,root,wazuh,750,file,-rwxr-x---,795908,0.1


### PR DESCRIPTION
# Description

The "Check installed files" step was failing on every DEB/RPM Linux agent package build on `5.0.0`, regardless of what a given PR changed, with `Failed: Results didn't match the expected output`. The regression was introduced when merging the long-lived `4.14.7` branch into `5.0.0`: a conflict on the checkfiles baseline CSVs was resolved by keeping the `4.14.7` side, which silently reverted the expected size of `/var/ossec/lib/modern.bpf.o` back to its pre-fix value from just before the eBPF FIM whodata fix for Amazon Linux was merged. Since that fix legitimately grew `modern.bpf.c`, every subsequent build produces a `modern.bpf.o` around 10.4% larger than the reverted baseline, which exceeds the file's 10% size tolerance and fails the check. This PR restores the correct expected size in the four affected baselines. Resolves #37413.

## Proposed Changes

- `.github/actions/check_files/deb_linux_agent_amd64.csv`: restored expected size of `/var/ossec/lib/modern.bpf.o` from `904720` back to `998504` bytes.
- `.github/actions/check_files/deb_linux_agent_i386.csv`: restored expected size of `/var/ossec/lib/modern.bpf.o` from `904752` back to `998504` bytes.
- `.github/actions/check_files/rpm_linux_agent_amd64.csv`: restored expected size of `/var/ossec/lib/modern.bpf.o` from `904720` back to `998504` bytes.
- `.github/actions/check_files/rpm_linux_agent_i386.csv`: restored expected size of `/var/ossec/lib/modern.bpf.o` from `904752` back to `998504` bytes.

### Results and Evidence

<!--
_Pending — attach a CI re-run log of the "Test DEB amd64 package" / "Test RPM amd64 package" jobs' "Check installed files" step showing it now passes._
-->

- https://github.com/wazuh/wazuh/actions/runs/28693878428?pr=37414 - :green_circle:

### Artifacts Affected

- CI-only change: `.github/actions/check_files/{deb,rpm}_linux_agent_{amd64,i386}.csv` baselines used by the "Check installed files" job in `5_builderpackage_agent-linux.yml`.
- No runtime daemon, library, or package content is changed — `/var/ossec/lib/modern.bpf.o` itself is unaffected; only the expected-size baseline used for CI validation is corrected.

### Configuration Changes

_No configuration changes._

### Documentation Updates

_No documentation changes required._

### Tests Introduced

_No new tests introduced._

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
