### PR TITLE
Update docs (agent) for the new password in manager

### DIFF
--- a/docs/dev/run-sources.md
+++ b/docs/dev/run-sources.md
@@ -120,13 +120,13 @@ This will generate the MSI installer package.
 
 ### Installation
 
-Once the package is generated, install it using the command line with the server address:
+Once the package is generated, install it using the command line with the server address and the required registration password:
 
 ```batch
-wazuh-agent-*.msi /q WAZUH_MANAGER="10.0.0.2"
+wazuh-agent-*.msi /q WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_PASSWORD="<PASSWORD>"
 ```
 
-**Important**: Replace `10.0.0.2` with the correct server IP address.
+**Important**: Replace `10.0.0.2` with the correct server IP address, and `<PASSWORD>` with the registration password retrieved from the manager (e.g., from `/var/wazuh-manager/etc/authd.pass`).
 
 For more installation options, see the [Installation](../ref/getting-started/installation.md#windows) guide.
 

--- a/docs/guide/migration/upgrade-4x-to-5x.md
+++ b/docs/guide/migration/upgrade-4x-to-5x.md
@@ -181,6 +181,7 @@ Workaround checklist:
 - Confirm manager has been migrated to a compatible 5.0 deployment.
 - Confirm firewall/network rules allow `1514/tcp` and `1515/tcp`.
 - Confirm the agent points to the correct manager address in `<client><manager>`.
+- Confirm enrollment credentials: if enrollment fails with `Invalid password (from manager)`, verify that the password in `/var/ossec/etc/authd.pass` on the agent matches `/var/wazuh-manager/etc/authd.pass` on the manager.
 
 ## Validation checklist
 

--- a/docs/ref/getting-started/installation.md
+++ b/docs/ref/getting-started/installation.md
@@ -197,6 +197,15 @@ Whether the node is hidden from the cluster. Default: `no`.
 
 ## Agent
 
+> [!IMPORTANT]
+> Enrollment password protection is enabled by default in Wazuh 5.0. Before enrolling agents, you must retrieve the auto-generated password from the manager using:
+> 
+> ```bash
+> sudo cat /var/wazuh-manager/etc/authd.pass
+> ```
+> 
+> Pass this password to the installer using the `WAZUH_REGISTRATION_PASSWORD` environment variable (or `/tmp/wazuh_envs` on macOS, or the installer arguments on Windows) as shown in the examples below.
+
 ### Download package
 
 Download the Wazuh agent package for your platform and version. See the [Package Download](packages.md#package-download) section for available repositories and download instructions.
@@ -209,10 +218,10 @@ Download the Wazuh agent package for your platform and version. See the [Package
 sudo dpkg -i wazuh-agent_*.deb
 ```
 
-You can optionally specify configuration parameters:
+You can optionally specify configuration parameters (such as the manager IP and the required registration password):
 
 ```bash
-sudo WAZUH_MANAGER='10.0.0.2' WAZUH_AGENT_NAME='web-server-01' dpkg -i wazuh-agent_*.deb
+sudo WAZUH_MANAGER='10.0.0.2' WAZUH_REGISTRATION_PASSWORD='<PASSWORD>' WAZUH_AGENT_NAME='web-server-01' dpkg -i wazuh-agent_*.deb
 ```
 
 #### Red Hat-based platforms
@@ -224,7 +233,7 @@ sudo rpm -ivh wazuh-agent-*.rpm
 You can optionally specify configuration parameters:
 
 ```bash
-sudo WAZUH_MANAGER='10.0.0.2' WAZUH_AGENT_NAME='web-server-01' rpm -ivh wazuh-agent-*.rpm
+sudo WAZUH_MANAGER='10.0.0.2' WAZUH_REGISTRATION_PASSWORD='<PASSWORD>' WAZUH_AGENT_NAME='web-server-01' rpm -ivh wazuh-agent-*.rpm
 ```
 
 #### SUSE-based platforms
@@ -236,7 +245,7 @@ sudo rpm -ivh wazuh-agent-*.rpm
 You can optionally specify configuration parameters:
 
 ```bash
-sudo WAZUH_MANAGER='10.0.0.2' WAZUH_AGENT_NAME='web-server-01' rpm -ivh wazuh-agent-*.rpm
+sudo WAZUH_MANAGER='10.0.0.2' WAZUH_REGISTRATION_PASSWORD='<PASSWORD>' WAZUH_AGENT_NAME='web-server-01' rpm -ivh wazuh-agent-*.rpm
 ```
 
 #### Starting the agent
@@ -266,7 +275,7 @@ sudo installer -pkg wazuh-agent-*.pkg -target /
 You can optionally specify configuration parameters by writing them to `/tmp/wazuh_envs` before running the installer:
 
 ```bash
-echo "WAZUH_MANAGER='10.0.0.2'" > /tmp/wazuh_envs && echo "WAZUH_AGENT_NAME='macbook-01'" >> /tmp/wazuh_envs && sudo installer -pkg wazuh-agent-*.pkg -target /
+echo "WAZUH_MANAGER='10.0.0.2'" > /tmp/wazuh_envs && echo "WAZUH_REGISTRATION_PASSWORD='<PASSWORD>'" >> /tmp/wazuh_envs && echo "WAZUH_AGENT_NAME='macbook-01'" >> /tmp/wazuh_envs && sudo installer -pkg wazuh-agent-*.pkg -target /
 ```
 
 Start the agent service:
@@ -292,7 +301,7 @@ wazuh-agent-*.msi /q
 You can optionally specify configuration parameters:
 
 ```powershell
-wazuh-agent-*.msi /q WAZUH_MANAGER="10.0.0.2" WAZUH_AGENT_NAME="windows-server-01"
+wazuh-agent-*.msi /q WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_PASSWORD="<PASSWORD>" WAZUH_AGENT_NAME="windows-server-01"
 ```
 
 For interactive installation, double-click the MSI file and follow the installation wizard.

--- a/docs/ref/upgrade.md
+++ b/docs/ref/upgrade.md
@@ -301,6 +301,7 @@ Before upgrading agents:
 2. Plan upgrades in batches to avoid upgrading all agents simultaneously
 3. Test on non-production agents first
 4. Verify manager compatibility with the new agent version
+5. **Password Authentication:** Wazuh 5.0 enables password protection for agent enrollment by default. If you need to re-enroll agents during or after the upgrade, you must use the registration password. If the 5.0 manager was freshly installed, retrieve the new password using `sudo cat /var/wazuh-manager/etc/authd.pass` on the manager and apply it on the agents, or restore the old `authd.pass` file to the new manager.
 
 **Note:** Wazuh agents version 4.x and later support upgrades to version 5.x.
 
@@ -626,6 +627,11 @@ telnet <manager_ip> 1514
 
 # Verify client.keys matches manager
 # Compare key on agent with manager's client.keys entry
+
+# Check for enrollment password verification issues:
+# If you see "ERROR: Invalid password (from manager)" in /var/ossec/logs/ossec.log,
+# verify that the password in the agent's `/var/ossec/etc/authd.pass` matches
+# the manager's `/var/wazuh-manager/etc/authd.pass`.
 
 # Restart agent
 sudo systemctl restart wazuh-agent


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

This pull request updates the installation, upgrade, and developer guides for Wazuh 5.0 to document the mandatory registration password feature (`WAZUH_REGISTRATION_PASSWORD`), which is enabled by default in Wazuh 5.0.

Closes #37341

## Proposed Changes

- Added information blocks detailing the requirement of registration password authentication for Wazuh 5.0 agent enrollment.
- Updated installation syntax examples (DEB, RPM, macOS, Windows) in `docs/ref/getting-started/installation.md` to include the `WAZUH_REGISTRATION_PASSWORD` parameter.
- Added password verification reminders to agent upgrade checklists and troubleshooting steps in `docs/ref/upgrade.md` and `docs/guide/migration/upgrade-4x-to-5x.md`.
- Updated developer documentation in `docs/dev/run-sources.md` to include the password parameter for Windows MSI agent installations.

### Results and Evidence

Manual validation confirms the registration password setup works end-to-end:

1. **Failure without password:** When the manager has `use_password` enabled, attempts to enroll without the password fail:
   ```log
   2026/07/06 05:37:11 wazuh-agentd: INFO: Requesting a key from server: 192.168.56.10
   2026/07/06 05:37:11 wazuh-agentd: INFO: No authentication password provided
   2026/07/06 05:37:11 wazuh-agentd: ERROR: Invalid password. Unable to add agent (from manager)
   ```

2. **Success with password parameter:** Installing the agent with `WAZUH_REGISTRATION_PASSWORD` correctly creates the file with the expected permissions and ownership:
   ```bash
   # ls -l /var/ossec/etc/authd.pass
   -rw-r----- 1 root wazuh 25 Jul  6 05:37 /var/ossec/etc/authd.pass
   ```
   The agent successfully authenticates using the password and registers:
   ```log
   2026/07/06 05:37:41 wazuh-agentd: INFO: Using password specified on file: etc/authd.pass
   2026/07/06 05:37:41 wazuh-agentd: INFO: Valid key received
   ```

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform: N/A (Documentation changes only)
- Log syntax and correct language review: N/A

### Artifacts Affected

None.

### Configuration Changes

None.

### Tests Introduced

None.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
