### PR TITLE
Clarify security policy for pre-release versions and disclosure timeline

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,13 +25,15 @@ Upon receiving such a report, we will determine whether the vulnerability:
 ## Vulnerability Disclosure Policy
 Upon receiving a report of a potential vulnerability, our team will initiate an investigation. If the reported issue is confirmed as a vulnerability, we will take the following steps:
 
-1. Acknowledgment: We will acknowledge the receipt of your vulnerability report and begin our investigation.
-2. Validation: We will validate the issue and work on reproducing it in our environment.
-3. Remediation: We will work on a fix and thoroughly test it
-4. Release & Disclosure: After 90 days from the discovery of the vulnerability, or as soon as a fix is ready and thoroughly tested (whichever comes first), we will release a security update for the affected project. We will also publicly disclose the vulnerability by publishing a CVE (Common Vulnerabilities and Exposures) and acknowledging the discovering party.
-5. Exceptions: In order to preserve the security of the Wazuh community at large, we might extend the disclosure period to allow users to patch their deployments.
+1. **Acknowledgment**: We will acknowledge the receipt of your vulnerability report and begin our investigation.
+2. **Validation**: We will validate the issue and work on reproducing it in our environment.
+3. **Remediation**: We will develop a fix, have it reviewed, and merge it once thoroughly tested.
+4. **Release**: We will publish a security release for the affected project that includes the fix.
+5. **Rollout**: We will confirm that the fix has been applied to environments managed by Wazuh before proceeding with disclosure.
+6. **Disclosure**: Once the fix has been released and confirmed in managed environments, we will publicly disclose the vulnerability by publishing a CVE (Common Vulnerabilities and Exposures), where applicable, and acknowledging the discovering party.
+7. **Exceptions**: In order to preserve the security of the Wazuh community at large, we might extend the disclosure period to allow users to patch their deployments.
 
-This 90-day period allows for end-users to update their systems and minimizes the risk of widespread exploitation of the vulnerability.
+Steps 1 through 6 will be completed within 90 days from the report of the vulnerability. This period allows for end-users to update their systems and minimizes the risk of widespread exploitation of the vulnerability.
 
 ## Automatic Scanning
 We leverage GitHub Actions to perform automated scans of our supply chain. These scans assist us in identifying vulnerabilities and outdated dependencies in a proactive and timely manner.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Wazuh Open Source Project Security Policy
 
-Version: 2023-06-12
+Version: 2026-07-06
 
 ## Introduction
 This document outlines the Security Policy for Wazuh's open source projects. It emphasizes our commitment to maintain a secure environment for our users and contributors, and reflects our belief in the power of collaboration to identify and resolve security vulnerabilities.
@@ -12,6 +12,15 @@ This policy applies to all open source projects developed, maintained, or hosted
 If you believe you've discovered a potential security vulnerability in one of our open source projects, we strongly encourage you to report it to us responsibly.
 
 Please submit your findings as security advisories under the "Security" tab in the relevant GitHub repository. Alternatively, you may send the details of your findings to [security@wazuh.com](mailto:security@wazuh.com).
+
+## Reporting Vulnerabilities in Non-GA Versions
+
+Wazuh publishes pre-release versions (Alphas, Betas, and Release Candidates) of its open source projects ahead of General Availability (GA) to gather community feedback. If you discover a potential security vulnerability in one of these non-GA versions, please report it following the process described above.
+
+Upon receiving such a report, we will determine whether the vulnerability:
+
+- **Affects only non-GA version(s)**: We will manage the report privately by opening a GitHub Security Advisory (GHSA). Since the affected code has not been part of a GA release, the vulnerability is not eligible for a CVE ID, consistent with the [CNA Operational Rules](https://www.cve.org/ResourcesSupport/AllResources/CNARules). Once resolved, the GHSA will be converted into a public issue instead of a security advisory.
+- **Also affects a previously released GA version**: We will continue managing the report as a GHSA and evaluate requesting a CVE ID for the GA-affected versions, in accordance with the eligibility criteria in the CNA Operational Rules.
 
 ## Vulnerability Disclosure Policy
 Upon receiving a report of a potential vulnerability, our team will initiate an investigation. If the reported issue is confirmed as a vulnerability, we will take the following steps:


### PR DESCRIPTION
## Description

This PR updates `SECURITY.md` to clarify two points in our security policy:

1. How reports affecting non-GA versions (Alphas, Betas, and Release Candidates) are handled, and their eligibility for a CVE ID.
2. The sequence of steps that take place before public disclosure, making explicit that a fix must be released and rolled out to environments managed by Wazuh before a report is disclosed, all within the existing 90-day window.

## Proposed Changes

- Added a new section describing how reports affecting only non-GA versions are handled privately via a GitHub Security Advisory (GHSA) and are not eligible for a CVE ID, referencing the CNA Operational Rules. Reports that also affect a previously released GA version continue to be evaluated for a CVE ID.
- Split the former "Release & Disclosure" step into four explicit steps: Remediation, Release, Rollout, and Disclosure — clarifying that disclosure only happens once the fix has been released and confirmed in managed environments.
- Clarified that all steps prior to disclosure must be completed within the existing 90-day period.
- Bumped the policy `Version` date to reflect the update.

### Results and Evidence

N/A — documentation-only change; see the diff on `SECURITY.md` for the full before/after.

### Artifacts Affected

N/A

### Configuration Changes

N/A

### Documentation Updates

- `SECURITY.md`: added the non-GA reporting section, restructured the disclosure timeline, and updated the policy version date.

### Tests Introduced

N/A — documentation-only change.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
