### PR TITLE
Remove unnused assignment for bpf object

### DIFF
--- a/src/syscheckd/src/ebpf/src/ebpf_whodata.cpp
+++ b/src/syscheckd/src/ebpf/src/ebpf_whodata.cpp
@@ -531,7 +531,6 @@ int init_bpfobj() {
         }
 
         bpf_helpers->bpf_object_close(obj);
-        obj = nullptr;
 
         if (g_bpf_lsm_active && prefer_dpath) {
             logFn(LOG_INFO, FIM_EBPF_LSM_DPATH_FALLBACK);


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/37409 |

## Description

Removed an unused assignment (`obj = nullptr;`) in `init_bpfobj()` after closing the BPF object, resolving Coverity defect CID 1672677.

## Configuration options

N/A

## Logs/Alerts example

N/A

## Tests

- Compilation without warnings in every supported platform
  - [ x] Linux
  - [ ] Windows
  - [ ] MAC OS X
