### PR TITLE
Fix benchmark test_cluster_error_logs test

### DIFF
--- a/framework/scripts/tests/test_wazuh_clusterd.py
+++ b/framework/scripts/tests/test_wazuh_clusterd.py
@@ -4,7 +4,7 @@
 
 import asyncio
 import sys
-from unittest.mock import call, patch
+from unittest.mock import ANY, Mock, call, patch
 
 import pytest
 import scripts.wazuh_clusterd as wazuh_clusterd
@@ -148,16 +148,84 @@ async def test_master_main(helper_disabled: bool):
 
     wazuh_clusterd.cluster_utils = cluster_utils
     args = Arguments(performance_test='test_performance', concurrency_test='concurrency_test')
-    with patch('scripts.wazuh_clusterd.asyncio.gather', gather):
+    loop = asyncio.get_event_loop()
+    with patch.object(loop, 'add_signal_handler') as add_signal_handler_mock:
+        with patch('scripts.wazuh_clusterd.asyncio.gather', gather):
+            with patch('wazuh.core.cluster.master.Master', MasterMock):
+                with patch('wazuh.core.cluster.local_server.LocalServerMaster', LocalServerMasterMock):
+                    with patch('wazuh.core.cluster.hap_helper.hap_helper.HAPHelper', HAPHElperMock):
+                        await wazuh_clusterd.master_main(
+                            args=args,
+                            cluster_config=cluster_config,
+                            cluster_items={'node': 'item'},
+                            logger='test_logger'
+                        )
+        add_signal_handler_mock.assert_called_once_with(wazuh_clusterd.signal.SIGTERM, ANY)
+
+
+@pytest.mark.asyncio
+async def test_master_main_sigterm_closes_connections_gracefully():
+    """Check that master_main closes cluster connections instead of letting the process die on SIGTERM."""
+    import wazuh.core.cluster.utils as cluster_utils
+    cluster_config = {'test': 'config', HAPROXY_HELPER: {HAPROXY_DISABLED: True}}
+
+    class Arguments:
+        def __init__(self, performance_test, concurrency_test):
+            self.performance_test = performance_test
+            self.concurrency_test = concurrency_test
+
+    class ClientMock:
+        def __init__(self):
+            self.transport = Mock()
+
+    worker_client = ClientMock()
+    local_client = ClientMock()
+
+    class MasterMock:
+        def __init__(self, performance_test, concurrency_test, configuration, logger, cluster_items):
+            self.task_pool = None
+            self.clients = {'worker_1': worker_client}
+
+        async def start(self):
+            await asyncio.sleep(3600)
+
+    class LocalServerMasterMock:
+        def __init__(self, performance_test, logger, concurrency_test, node, configuration, cluster_items):
+            self.clients = {'local_1': local_client}
+
+        async def start(self):
+            await asyncio.sleep(3600)
+
+    wazuh_clusterd.cluster_utils = cluster_utils
+    args = Arguments(performance_test=None, concurrency_test=None)
+    logger = Mock()
+    loop = asyncio.get_event_loop()
+    sigterm_callback = None
+
+    def fake_add_signal_handler(sig, callback):
+        nonlocal sigterm_callback
+        sigterm_callback = callback
+
+    with patch.object(loop, 'add_signal_handler', side_effect=fake_add_signal_handler):
         with patch('wazuh.core.cluster.master.Master', MasterMock):
             with patch('wazuh.core.cluster.local_server.LocalServerMaster', LocalServerMasterMock):
-                with patch('wazuh.core.cluster.hap_helper.hap_helper.HAPHelper', HAPHElperMock):
-                    await wazuh_clusterd.master_main(
-                        args=args,
-                        cluster_config=cluster_config,
-                        cluster_items={'node': 'item'},
-                        logger='test_logger'
-                    )
+                master_main_task = asyncio.ensure_future(wazuh_clusterd.master_main(
+                    args=args,
+                    cluster_config=cluster_config,
+                    cluster_items={'node': 'item'},
+                    logger=logger
+                ))
+                # Give master_main a chance to register the signal handler and start the server tasks.
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+                assert sigterm_callback is not None
+
+                # Simulate the arrival of SIGTERM instead of sending a real signal to the test process.
+                sigterm_callback()
+                await asyncio.wait_for(master_main_task, timeout=5)
+
+    worker_client.transport.close.assert_called_once()
+    local_client.transport.close.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/framework/scripts/wazuh_clusterd.py
+++ b/framework/scripts/wazuh_clusterd.py
@@ -6,6 +6,7 @@
 
 import argparse
 import asyncio
+import contextlib
 import logging
 import os
 import signal
@@ -99,7 +100,30 @@ async def master_main(args: argparse.Namespace, cluster_config: dict, cluster_it
     tasks = [my_server, my_local_server]
     if not cluster_config.get(cluster_utils.HAPROXY_HELPER, {}).get(cluster_utils.HAPROXY_DISABLED, True):
         tasks.append(HAPHelper)
-    await asyncio.gather(*[task.start() for task in tasks])
+
+    # Handle SIGTERM within the loop so cluster connections can be closed gracefully before the process exits.
+    # This replaces the process-wide handler installed in `signal.signal(signal.SIGTERM, exit_handler)` for the
+    # remainder of the master's lifetime, letting the workers see a clean EOF instead of a connection reset.
+    loop = asyncio.get_running_loop()
+    shutdown_event = asyncio.Event()
+    loop.add_signal_handler(signal.SIGTERM, shutdown_event.set)
+
+    server_task = asyncio.ensure_future(asyncio.gather(*[task.start() for task in tasks]))
+    shutdown_task = asyncio.ensure_future(shutdown_event.wait())
+    done, _ = await asyncio.wait([server_task, shutdown_task], return_when=asyncio.FIRST_COMPLETED)
+
+    if shutdown_task in done:
+        logger.info("SIGNAL [(15)-(SIGTERM)] received. Closing cluster connections gracefully. Exit...")
+        for client in list(my_server.clients.values()) + list(my_local_server.clients.values()):
+            client.transport.close()
+        server_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await server_task
+    else:
+        shutdown_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await shutdown_task
+        await server_task
 
 
 #

--- a/framework/wazuh/core/cluster/client.py
+++ b/framework/wazuh/core/cluster/client.py
@@ -201,6 +201,11 @@ class AbstractClient(common.Handler):
         self._cancel_payload_deadline()
         if exc is None:
             self.logger.info('The master closed the connection')
+        elif isinstance(exc, (ConnectionResetError, ConnectionAbortedError)):
+            # The peer forcibly closed the connection (e.g. a TCP reset while the master was shutting down).
+            # This is transient and recoverable: the client automatically retries the connection, so it is
+            # logged as a warning instead of an error.
+            self.logger.warning(f"Connection closed by the peer: {exc}. Reconnecting...")
         else:
             self.logger.error(f"Connection closed due to an unhandled error: {exc}\n"
                               f"{''.join(traceback.format_tb(exc.__traceback__))}", exc_info=False)
@@ -208,6 +213,9 @@ class AbstractClient(common.Handler):
         if not self.on_con_lost.done():
             self.on_con_lost.set_result(True)
         self._cancel_all_tasks()
+
+        if self.server is not None and self.server.client is self:
+            self.server.client = None
 
     def _cancel_all_tasks(self):
         """Cancel all asyncio tasks and clients."""

--- a/framework/wazuh/core/cluster/common.py
+++ b/framework/wazuh/core/cluster/common.py
@@ -1603,8 +1603,10 @@ class SyncFiles(SyncTask):
                 # Remove local file.
                 os.unlink(compressed_data)
             except FileNotFoundError:
-                self.logger.error(f"File {compressed_data} could not be removed/not found. "
-                                  f"May be due to a lost connection.")
+                # Expected when a connection reset triggers connection_lost's cluster.clean_up(),
+                # which wipes this same file while this task is still in flight.
+                self.logger.warning(f"File {compressed_data} could not be removed/not found. "
+                                    f"May be due to a lost connection.")
 
 
 class SyncWazuhdb(SyncTask):

--- a/framework/wazuh/core/cluster/local_server.py
+++ b/framework/wazuh/core/cluster/local_server.py
@@ -359,6 +359,29 @@ class LocalServerHandlerWorker(LocalServerHandler):
     The local server handler instance that runs in worker nodes.
     """
 
+    def not_connected_response(self, command: bytes) -> Tuple[bytes, bytes]:
+        """Answer a request with error 3023 when the worker is not connected to the master.
+
+        Being disconnected from the master is a transient, recoverable situation (the worker
+        periodically retries the connection), so it is logged as a warning instead of letting
+        the exception reach the generic handler, which would log it at ERROR level.
+
+        Parameters
+        ----------
+        command : bytes
+            Received command from client.
+
+        Returns
+        -------
+        bytes
+            Result.
+        bytes
+            Response message.
+        """
+        self.logger.warning(f"Request '{command.decode()}' could not be forwarded, "
+                            f"worker is not connected to the master yet. It was answered with code 3023.")
+        return b'err', json.dumps(WazuhClusterError(3023), cls=c_common.WazuhJSONEncoder).encode()
+
     def process_request(self, command: bytes, data: bytes):
         """Define available requests in the local server.
 
@@ -382,25 +405,25 @@ class LocalServerHandlerWorker(LocalServerHandler):
         self.logger.debug2(f"Command received: {command}")
         if command == b'dapi':
             if self.server.node.client is None:
-                raise WazuhClusterError(3023)
+                return self.not_connected_response(command)
             asyncio.create_task(self.log_exceptions(
                 self.server.node.client.send_request(b'dapi', self.name.encode() + b' ' + data)))
             return b'ok', b'Added request to API requests queue'
         elif command == b'sendsync':
             if self.server.node.client is None:
-                raise WazuhClusterError(3023)
+                return self.not_connected_response(command)
             asyncio.create_task(self.log_exceptions(
                 self.server.node.client.send_request(b'sendsync', self.name.encode() + b' ' + data)))
             return None, None
         elif command == b'sendasync':
             if self.server.node.client is None:
-                raise WazuhClusterError(3023)
+                return self.not_connected_response(command)
             asyncio.create_task(self.log_exceptions(
                 self.server.node.client.send_request(b'sendsync', self.name.encode() + b' ' + data)))
             return b'ok', b'Added request to sendsync requests queue'
         elif command == b'sendrreload':
             if self.server.node.client is None:
-                raise WazuhClusterError(3023)
+                return self.not_connected_response(command)
             asyncio.create_task(self.log_exceptions(self.set_reload_ruleset_flag()))
             return b'ok', json.dumps({'success': True}).encode()
         else:

--- a/framework/wazuh/core/cluster/tests/test_client.py
+++ b/framework/wazuh/core/cluster/tests/test_client.py
@@ -281,6 +281,15 @@ def test_ac_connection_lost(cancel_tasks_mock):
         logger_mock.assert_called_once_with(f"Connection closed due to an unhandled error: {WazuhException(1001)}\n",
                                             exc_info=False)
 
+    # Test that a connection reset/aborted by the peer is logged as a warning, not an error
+    for reset_exc in (ConnectionResetError('[Errno 104] Connection reset by peer'), ConnectionAbortedError()):
+        with patch.object(logging.getLogger('wazuh'), "warning") as warning_logger_mock:
+            with patch.object(logging.getLogger('wazuh'), "error") as error_logger_mock:
+                abstract_client.connection_lost(exc=reset_exc)
+                warning_logger_mock.assert_called_once_with(f"Connection closed by the peer: {reset_exc}. "
+                                                            f"Reconnecting...")
+                error_logger_mock.assert_not_called()
+
 def test_ac_cancel_all_tasks():
     """Check whether all tasks and connections are being properly closed."""
 

--- a/framework/wazuh/core/cluster/tests/test_common.py
+++ b/framework/wazuh/core/cluster/tests/test_common.py
@@ -2270,7 +2270,7 @@ async def test_sync_files_sync_ko(send_request_mock):
         with patch("wazuh.core.cluster.cluster.compress_files", return_value=(compressed_data, {})):
             send_request_mock.side_effect = None
             logger = logging.getLogger('wazuh')
-            with patch.object(logger, "error") as logger_mock:
+            with patch.object(logger, "warning") as logger_mock:
                 await sync_files.sync(files_to_sync, files_metadata, 1, task_pool=None)
                 logger_mock.assert_called_with(f"File {compressed_data} could not be removed/not found. "
                                                f"May be due to a lost connection.")

--- a/framework/wazuh/core/cluster/tests/test_local_server.py
+++ b/framework/wazuh/core/cluster/tests/test_local_server.py
@@ -396,6 +396,9 @@ async def test_LocalServerHandlerWorker_process_request(process_request_mock, ev
         def debug2(self, msg):
             pass
 
+        def warning(self, msg):
+            pass
+
     class ClientMock:
         async def send_request(self, request):
             pass
@@ -418,17 +421,9 @@ async def test_LocalServerHandlerWorker_process_request(process_request_mock, ev
         assert mock_contextvar.get() == f"Local {lshw.name}"
         process_request_mock.assert_called_with(b"hello", b"bye")
 
-    with pytest.raises(WazuhClusterError, match=".* 3023 .*"):
-        lshw.process_request(command=b"dapi", data=b"bye")
-
-    with pytest.raises(WazuhClusterError, match=".* 3023 .*"):
-        lshw.process_request(command=b"sendsync", data=b"bye")
-
-    with pytest.raises(WazuhClusterError, match=".* 3023 .*"):
-        lshw.process_request(command=b"sendasync", data=b"bye")
-
-    with pytest.raises(WazuhClusterError, match=".* 3023 .*"):
-        lshw.process_request(command=b"sendrreload", data=b"bye")
+    expected_err = b'err', json.dumps(WazuhClusterError(3023), cls=c_common.WazuhJSONEncoder).encode()
+    for not_connected_command in (b"dapi", b"sendsync", b"sendasync", b"sendrreload"):
+        assert lshw.process_request(command=not_connected_command, data=b"bye") == expected_err
 
     server_mock.node.client = ClientMock()
     with patch.object(server_mock.node.client, "send_request", return_value='') as send_request_mock:


### PR DESCRIPTION
## Description

Related issue: https://github.com/wazuh/wazuh/issues/37321

The cluster reliability tests for the Workload benchmarks metrics scenario were failing in `test_cluster_error_logs` and `test_check_logs_order_workers`. The root cause is that some expected, recoverable events around master/worker disconnections were logged at ERROR level, and that stopping the master killed the process without closing the cluster connections:

- On SIGTERM, the master exited abruptly, so every connected worker saw a TCP reset and logged it as an unhandled ERROR.
- A temporarily disconnected worker logged ERROR both when the connection dropped and when local `dapi`/`sendsync` requests arrived before reconnecting, even though the worker retries the connection on its own and the requester already receives the proper 3023 error response.

## Proposed Changes

- `wazuh_clusterd.py`: handle SIGTERM inside the master's event loop. On shutdown the master logs `SIGNAL [(15)-(SIGTERM)] received. Closing cluster connections gracefully. Exit...`, closes all worker and local server transports and cancels the server tasks, so workers see a clean EOF and log `The master closed the connection` at INFO level. PID file and child process cleanup still runs in `main()`.
- `client.py`: `ConnectionResetError`/`ConnectionAbortedError` in `connection_lost` are logged as a warning instead of an error, since the client reconnects on its own. The handler also clears `self.server.client` when its own connection is the one that dropped, so the rest of the code no longer treats a stale handler as an established connection.
- `local_server.py`: when a worker receives `dapi`/`sendsync`/`sendasync`/`sendrreload` while not connected to the master, it answers directly with the 3023 error and logs a warning, instead of raising and letting the generic handler log it as an error. The response sent to local clients is byte-identical to the previous one.
- `common.py`: the `FileNotFoundError` raised while removing the compressed file in `SyncFiles.sync()` is logged as a warning; it is an expected race with the cleanup performed by `connection_lost` when the connection drops mid-sync.

### Results and Evidence

Jenkins `4.14.8/CLUSTER-Workload_benchmarks_metrics` build 4, with manager packages built from `73dd1a4` (this PR's head) and the QA tests from wazuh/wazuh-qa-automation#8010: SUCCESS, reliability suite 6/6 passed in-pipeline.

https://jenkins-staging.qa.wazuh.info/job/4.14.8/job/CLUSTER-Workload_benchmarks_metrics/4/

```
legacy/reliability/test_cluster/test_cluster_logs/test_cluster_connection/test_cluster_connection.py . [ 16%]
legacy/reliability/test_cluster/test_cluster_logs/test_cluster_error_logs/test_cluster_error_logs.py . [ 33%]
legacy/reliability/test_cluster/test_cluster_logs/test_cluster_master_logs_order/test_cluster_master_logs_order.py . [ 50%]
legacy/reliability/test_cluster/test_cluster_logs/test_cluster_sync/test_cluster_sync.py . [ 66%]
legacy/reliability/test_cluster/test_cluster_logs/test_cluster_task_order/test_cluster_task_order.py . [ 83%]
legacy/reliability/test_cluster/test_cluster_logs/test_cluster_worker_logs_order/test_cluster_worker_logs_order.py . [100%]
======================== 6 passed in 379.07s (0:06:19) =========================
```

Build 5 is a re-run with the same parameters and the final QA automation branch: https://jenkins-staging.qa.wazuh.info/job/4.14.8/job/CLUSTER-Workload_benchmarks_metrics/5/

Verified on a live two-node cluster (master + worker, packages with this branch's framework):

- `systemctl stop wazuh-manager` on the master: new SIGTERM log line on the master, PID file and child processes cleaned up, worker logs `The master closed the connection` at INFO and reconnects when the master returns. No ERROR lines on either node.
- Forced TCP reset of the established connection (`ss -K` on the master): worker logs `WARNING: Connection closed by the peer: [Errno 104] Connection reset by peer. Reconnecting...` and reconnects 10 seconds later, resuming sync tasks.
- `dapi` request through the local socket while disconnected: requester receives the same 3023 error payload as before, worker logs a single WARNING.

### Manual tests with their corresponding evidence

N/A (Python-only change, no compilation involved).

### Artifacts Affected

N/A

### Configuration Changes

N/A

### Tests Introduced

- `test_client.py`: a connection reset/abort logs a warning instead of an error in `connection_lost`.
- `test_common.py`: the zip cleanup `FileNotFoundError` is expected to log as a warning.
- `test_local_server.py`: `dapi`/`sendsync`/`sendasync`/`sendrreload` return the 3023 error response directly instead of raising when the worker is not connected.
- `test_wazuh_clusterd.py`: `master_main` registers the SIGTERM handler and closes cluster connections gracefully on shutdown.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
