### PR TITLE
Fix Windows block-ip firewall-enabled check misfire and ineffective route fallback

### DIFF
--- a/.github/actions/check_files/deb_linux_agent_amd64.csv
+++ b/.github/actions/check_files/deb_linux_agent_amd64.csv
@@ -28,7 +28,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/etc/client.keys,root,wazuh,640,file,-rw-r-----,0,0.1
 /var/ossec/etc/ossec.conf,root,wazuh,640,file,-rw-r-----,4566,0.1
 /var/ossec/etc/local_internal_options.conf,root,wazuh,640,file,-rw-r-----,320,0.1
-/var/ossec/active-response/bin/block-ip,root,wazuh,750,file,-rwxr-x---,111968,0.1
+/var/ossec/active-response/bin/block-ip,root,wazuh,750,file,-rwxr-x---,126144,0.1
 /var/ossec/active-response/bin/disable-account,root,wazuh,750,file,-rwxr-x---,114512,0.1
 /var/ossec/logs/active-responses.log,wazuh,wazuh,660,file,-rw-rw----,0,0.1
 /var/ossec/logs/ossec.log,root,wazuh,660,file,-rw-rw----,0,0.1

--- a/docs/ref/modules/active-response/executables.md
+++ b/docs/ref/modules/active-response/executables.md
@@ -145,12 +145,14 @@ block in quick from <wazuh_fwtable>
 
 **Type**: Stateful (supports timeout-based reversion)
 
-**Firewall Methods** (tried in order):
+**Firewall Methods** (ENABLE tries them in order; DISABLE removes **both** — see Removal below):
 
 | Priority | Method | Tool | Command Example |
 |----------|--------|------|-----------------|
-| 1 | netsh | `netsh.exe` | `netsh advfirewall firewall add rule name="Wazuh AR: 192.168.1.100" dir=in action=block remoteip=192.168.1.100` |
-| 2 | route | `route.exe` | `route add 192.168.1.100 mask 255.255.255.255 <gateway> metric 1` |
+| 1 | netsh | `netsh.exe` | `netsh advfirewall firewall add rule name="WAZUH ACTIVE RESPONSE BLOCKED IP" interface=any dir=in action=block remoteip=192.168.1.100/32` (plus a matching `dir=out` rule) |
+| 2 | route | `route.exe` | `route -p ADD 192.168.1.100 MASK 255.255.255.255 127.0.0.1` (null-route to loopback) |
+
+The `remoteip` prefix matches the address family: `/32` for IPv4 and `/128` for IPv6.
 
 **Input Fields**:
 ```json
@@ -170,16 +172,24 @@ block in quick from <wazuh_fwtable>
 ```
 
 **Windows-Specific Details**:
-- **Firewall Rules**: Creates named rules: `"Wazuh AR: <IP>"`
-- **Rule Direction**: Inbound blocking only (`dir=in`)
-- **Route Fallback**: Adds blackhole route if netsh fails
-- **Gateway Detection**: Uses `ipconfig` to find default gateway for route method
-- **IPv6 Support**: Automatically detects IPv6 addresses and uses appropriate commands
+- **Firewall Rules**: Creates rules named `"WAZUH ACTIVE RESPONSE BLOCKED IP"` — one inbound (`dir=in`) and one outbound (`dir=out`) for bidirectional blocking.
+- **Effective firewall-state detection**: On **ENABLE only**, netsh is used only if the Windows Firewall is *effectively* enabled. The state is read directly from the registry `EnableFirewall` DWORD (locale-independent), evaluated per profile (Domain/Standard/Public):
+  - The GPO policy value (`HKLM\SOFTWARE\Policies\Microsoft\WindowsFirewall\<profile>`) wins if present;
+  - otherwise the local SharedAccess value (`HKLM\SYSTEM\CurrentControlSet\Services\SharedAccess\Parameters\FirewallPolicy\<profile>`);
+  - otherwise, an **absent** value defaults to **enabled** (the Windows default).
+
+  If any profile is effectively enabled, netsh is used; if the firewall is effectively off, netsh is skipped and the chain defers to the `route` fallback (adding a rule that would sit dormant is avoided). This check is **not** applied on DISABLE, so an unblock always attempts to remove the rule.
+- **Route Fallback (best-effort)**: When netsh is unavailable, or the firewall is effectively off, the target is **null-routed to loopback** (`route -p ADD <IP> MASK 255.255.255.255 127.0.0.1`) so the host discards packets destined to it. This is **best-effort**: it can break routed/remote attackers but does **not** block a host on a directly-connected subnet (on-link traffic is delivered via ARP, which the loopback route does not redirect). The `route add` exit code is checked, so the method no longer reports a false success. **Windows Firewall (netsh) remains the only comprehensive blocking mechanism.**
+- **IPv4-only fallback**: The `route` fallback applies to **IPv4 targets only**; IPv6 targets are skipped (netsh already covers IPv6).
 - **Permissions**: Requires Administrator privileges
 
 **Removal**:
-- Enable: `netsh advfirewall firewall delete rule name="Wazuh AR: 192.168.1.100"`
-- Route: `route delete 192.168.1.100`
+
+DISABLE is **not** a fallback chain — because a block may have been applied by *either* netsh (firewall on) *or* the null-route (firewall off), unblock unconditionally attempts to remove **both**, each best-effort (a missing rule/route is the expected, non-failure case):
+- netsh: `netsh advfirewall firewall delete rule name="WAZUH ACTIVE RESPONSE BLOCKED IP" remoteip=192.168.1.100/32`
+- route: `route DELETE 192.168.1.100`
+
+The unblock is reported successful if **either** removal actually took effect; if nothing matched, a warning is logged (the IP may already be unblocked).
 
 **Return Codes**:
 - `0`: Success (IP blocked/unblocked)
@@ -739,7 +749,7 @@ pfctl -t wazuh_fwtable -T show
 
 **Windows (netsh)**:
 ```powershell
-netsh advfirewall firewall show rule name="Wazuh AR: 192.168.1.100"
+netsh advfirewall firewall show rule name="WAZUH ACTIVE RESPONSE BLOCKED IP"
 ```
 
 ### Check Logs

--- a/src/active-response/include/active_responses.h
+++ b/src/active-response/include/active_responses.h
@@ -128,6 +128,22 @@ void splitStrFromCharDelimiter(const char * output_buf, const char delimiter, ch
 */
 int isEnabledFromPattern(const char * output_buf, const char * str_pattern_1, const char * str_pattern_2);
 
+/**
+ * Validate that a string is a bare numeric IP address and return its version.
+ *
+ * Unlike get_ip_version(), this performs a strict character-whitelist check and does NOT
+ * rely on getaddrinfo/DNS, so it is available on every platform (get_ip_version is compiled
+ * out on Windows). Besides classifying the family it rejects any value that is not a plain
+ * numeric IP - no CIDR prefix, whitespace or shell metacharacters - which is required before
+ * a source IP is placed on a command line (e.g. the Windows netsh/route invocations, where
+ * arguments are not quoted).
+ * @param srcip IP string to validate
+ * @retval 4 If srcip is a bare IPv4 address
+ * @retval 6 If srcip is a bare IPv6 address
+ * @retval OS_INVALID If srcip is NULL, empty, out of range or contains any other character
+ * */
+int validate_srcip(const char *srcip);
+
 #ifndef WIN32
 
 /**

--- a/src/active-response/src/active_responses.c
+++ b/src/active-response/src/active_responses.c
@@ -388,6 +388,39 @@ int isEnabledFromPattern(const char * output_buf, const char * str_pattern_1, co
     return retVal;
 }
 
+int validate_srcip(const char *srcip) {
+    if (!srcip || srcip[0] == '\0') {
+        return OS_INVALID;
+    }
+
+    size_t len = strlen(srcip);
+    // "::" is the shortest valid literal; 45 is the longest possible IPv6 text form.
+    if (len < 2 || len > 45) {
+        return OS_INVALID;
+    }
+
+    const bool is_ipv6 = (strchr(srcip, ':') != NULL);
+
+    for (size_t i = 0; i < len; i++) {
+        const char c = srcip[i];
+        const bool is_digit = (c >= '0' && c <= '9');
+        if (is_ipv6) {
+            // IPv6: hex digits, ':' and '.' (the latter for IPv4-mapped forms like ::ffff:1.2.3.4)
+            const bool is_hex = is_digit || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+            if (!is_hex && c != ':' && c != '.') {
+                return OS_INVALID;
+            }
+        } else {
+            // IPv4: decimal digits and '.' only
+            if (!is_digit && c != '.') {
+                return OS_INVALID;
+            }
+        }
+    }
+
+    return is_ipv6 ? 6 : 4;
+}
+
 #ifndef WIN32
 
 int lock(const char *lock_path, const char *lock_pid_path, const char *log_path, const char *proc_name) {

--- a/src/active-response/src/block-ip-windows.c
+++ b/src/active-response/src/block-ip-windows.c
@@ -27,7 +27,7 @@
 
 firewall_result_t try_netsh(const char *srcip, int action, int ip_version, const char *argv0);
 firewall_result_t try_route_windows(const char *srcip, int action, int ip_version, const char *argv0);
-static bool firewall_is_effectively_on(const char *netsh_path, const char *argv0);
+static bool firewall_is_effectively_on(const char *argv0);
 
 int main(int argc, char **argv) {
     // This must always be the first instruction on Windows
@@ -93,41 +93,57 @@ int main(int argc, char **argv) {
 // WINDOWS: effective firewall-state detection
 // ============================================================================
 
-// Returns true if ANY firewall profile is effectively enabled (enforcing), read from
-// `netsh advfirewall show allprofiles state`. This reports the effective state and, in
-// particular, correctly returns ON when the local EnableFirewall value is ABSENT (the
-// Windows default).
-// On any failure to determine the state (or when the "ON" token is not recognized, e.g.
-// on a localized Windows) we return false, so try_netsh conservatively defers to the
-// route fallback rather than adding a rule that might never be enforced.
-static bool firewall_is_effectively_on(const char *netsh_path, const char *argv0) {
-    char *exec_cmd[] = {(char *)netsh_path, "advfirewall", "show", "allprofiles", "state", NULL};
-    wfd_t *wfd = wpopenv(netsh_path, exec_cmd, W_BIND_STDOUT);
-    if (!wfd) {
-        write_debug_file(argv0, "Unable to query firewall state via netsh - assuming disabled");
-        return false;
+// Reads the EnableFirewall DWORD under HKLM\<subkey>. Returns 1 (enabled), 0 (disabled),
+// or -1 (key/value absent). Forces the 64-bit view (KEY_WOW64_64KEY) because block-ip may
+// run as a 32-bit process and these keys live in the native hive.
+static int read_enable_firewall(const char *subkey) {
+    HKEY hkey;
+    if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, subkey, 0, KEY_READ | KEY_WOW64_64KEY, &hkey) != ERROR_SUCCESS) {
+        return -1;
     }
 
-    char output_buf[OS_MAXSTR];
+    DWORD value = 0;
+    DWORD size = sizeof(value);
+    DWORD type = 0;
+    LONG rc = RegQueryValueEx(hkey, "EnableFirewall", NULL, &type, (LPBYTE)&value, &size);
+    RegCloseKey(hkey);
+
+    if (rc != ERROR_SUCCESS || type != REG_DWORD) {
+        return -1;
+    }
+    return value != 0 ? 1 : 0;
+}
+
+// Returns true if ANY firewall profile is effectively enabled (enforcing). Reads the
+// EnableFirewall DWORD directly from the registry.
+// Per profile: the GPO policy value wins if present, else the local SharedAccess value,
+// else it defaults to ENABLED (the Windows default). Defaulting an ABSENT value to enabled
+// is the fix for the #37388 misfire (the old check treated absent as "disabled").
+static bool firewall_is_effectively_on(const char *argv0) {
+    static const char *profiles[] = {"DomainProfile", "StandardProfile", "PublicProfile"};
+    char gpo_key[OS_MAXSTR];
+    char local_key[OS_MAXSTR];
     bool any_on = false;
 
-    while (fgets(output_buf, OS_MAXSTR, wfd->file_out)) {
-        char *p = strstr(output_buf, "State");
-        if (!p) {
-            continue;
-        }
-        p += 5;  // strlen("State")
-        while (*p == ' ' || *p == '\t') {
-            p++;
-        }
-        if ((p[0] == 'O' || p[0] == 'o') && (p[1] == 'N' || p[1] == 'n') &&
-            (p[2] == '\0' || p[2] == '\r' || p[2] == '\n' || p[2] == ' ' || p[2] == '\t')) {
+    for (int i = 0; i < 3; i++) {
+        snprintf(gpo_key, OS_MAXSTR - 1,
+                 "SOFTWARE\\Policies\\Microsoft\\WindowsFirewall\\%s", profiles[i]);
+        snprintf(local_key, OS_MAXSTR - 1,
+                 "SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Parameters\\FirewallPolicy\\%s",
+                 profiles[i]);
+
+        int gpo = read_enable_firewall(gpo_key);
+        int state = (gpo != -1) ? gpo : read_enable_firewall(local_key);
+        bool enabled = (state == -1) ? true : (state == 1);  // both absent -> Windows default ON
+        if (enabled) {
             any_on = true;
             break;
         }
     }
 
-    wpclose(wfd);
+    if (!any_on) {
+        write_debug_file(argv0, "No firewall profile is effectively enabled (registry check)");
+    }
     return any_on;
 }
 
@@ -147,11 +163,11 @@ firewall_result_t try_netsh(const char *srcip, int action, int ip_version, const
 
     // A netsh block rule is only enforced while a firewall profile is enabled. On ENABLE,
     // if the firewall is effectively OFF, defer to the route fallback instead of adding a
-    // dormant rule. We read the EFFECTIVE state via netsh (which reports ON even when the
-    // local EnableFirewall value is absent). This is ENABLE-only: on DISABLE we must
-    // always try to remove the rule, which may have been added while the firewall was
-    // enabled.
-    if (action == ENABLE_COMMAND && !firewall_is_effectively_on(netsh_path, argv0)) {
+    // dormant rule. The effective state is read from the registry (see
+    // firewall_is_effectively_on), which is locale-independent. This is ENABLE-only: on
+    // DISABLE we must always try to remove the rule, which may have been added while the
+    // firewall was enabled.
+    if (action == ENABLE_COMMAND && !firewall_is_effectively_on(argv0)) {
         log_firewall_action(argv0, LOG_LEVEL_WARNING, "netsh", "check",
                           "Windows Firewall is effectively disabled - deferring to route fallback");
         os_free(netsh_path);

--- a/src/active-response/src/block-ip-windows.c
+++ b/src/active-response/src/block-ip-windows.c
@@ -27,7 +27,7 @@
 
 firewall_result_t try_netsh(const char *srcip, int action, int ip_version, const char *argv0);
 firewall_result_t try_route_windows(const char *srcip, int action, int ip_version, const char *argv0);
-static bool firewall_is_effectively_on(const char *argv0);
+static bool firewall_is_effectively_on(const char *netsh_path, const char *argv0);
 
 int main(int argc, char **argv) {
     // This must always be the first instruction on Windows
@@ -80,8 +80,10 @@ int main(int argc, char **argv) {
         {NULL, NULL, false}  // Sentinel
     };
 
+    int ip_version = (strchr(srcip, ':') != NULL) ? 6 : 4;
+
     // Execute firewall chain with fallback
-    int result = execute_firewall_chain(methods, srcip, action, 0, argv[0]);
+    int result = execute_firewall_chain(methods, srcip, action, ip_version, argv[0]);
 
     cJSON_Delete(input_json);
     return result;
@@ -98,20 +100,11 @@ int main(int argc, char **argv) {
 // On any failure to determine the state (or when the "ON" token is not recognized, e.g.
 // on a localized Windows) we return false, so try_netsh conservatively defers to the
 // route fallback rather than adding a rule that might never be enforced.
-static bool firewall_is_effectively_on(const char *argv0) {
-    char *netsh_path = NULL;
-
-    if (get_binary_path("netsh.exe", &netsh_path) < 0) {
-        write_debug_file(argv0, "Unable to locate netsh.exe to query firewall state - assuming disabled");
-        os_free(netsh_path);
-        return false;
-    }
-
-    char *exec_cmd[] = {netsh_path, "advfirewall", "show", "allprofiles", "state", NULL};
+static bool firewall_is_effectively_on(const char *netsh_path, const char *argv0) {
+    char *exec_cmd[] = {(char *)netsh_path, "advfirewall", "show", "allprofiles", "state", NULL};
     wfd_t *wfd = wpopenv(netsh_path, exec_cmd, W_BIND_STDOUT);
     if (!wfd) {
         write_debug_file(argv0, "Unable to query firewall state via netsh - assuming disabled");
-        os_free(netsh_path);
         return false;
     }
 
@@ -135,7 +128,6 @@ static bool firewall_is_effectively_on(const char *argv0) {
     }
 
     wpclose(wfd);
-    os_free(netsh_path);
     return any_on;
 }
 
@@ -144,7 +136,6 @@ static bool firewall_is_effectively_on(const char *argv0) {
 // ============================================================================
 
 firewall_result_t try_netsh(const char *srcip, int action, int ip_version, const char *argv0) {
-    (void)ip_version;  // netsh handles both IPv4 and IPv6
     static const char rule_name[] = "name=\"WAZUH ACTIVE RESPONSE BLOCKED IP\"";
     char log_msg[OS_MAXSTR];
     char *netsh_path = NULL;
@@ -160,7 +151,7 @@ firewall_result_t try_netsh(const char *srcip, int action, int ip_version, const
     // local EnableFirewall value is absent). This is ENABLE-only: on DISABLE we must
     // always try to remove the rule, which may have been added while the firewall was
     // enabled.
-    if (action == ENABLE_COMMAND && !firewall_is_effectively_on(argv0)) {
+    if (action == ENABLE_COMMAND && !firewall_is_effectively_on(netsh_path, argv0)) {
         log_firewall_action(argv0, LOG_LEVEL_WARNING, "netsh", "check",
                           "Windows Firewall is effectively disabled - deferring to route fallback");
         os_free(netsh_path);
@@ -168,7 +159,7 @@ firewall_result_t try_netsh(const char *srcip, int action, int ip_version, const
     }
 
     // Single-host prefix for netsh remoteip: /32 for IPv4, /128 for IPv6.
-    const char *host_prefix = (strchr(srcip, ':') != NULL) ? "128" : "32";
+    const char *host_prefix = (ip_version == 6) ? "128" : "32";
 
     // Build netsh command
     wfd_t *wfd = NULL;
@@ -287,7 +278,6 @@ firewall_result_t try_netsh(const char *srcip, int action, int ip_version, const
 // ============================================================================
 
 firewall_result_t try_route_windows(const char *srcip, int action, int ip_version, const char *argv0) {
-    (void)ip_version;
     char log_msg[OS_MAXSTR];
     char *route_path = NULL;
 
@@ -301,7 +291,7 @@ firewall_result_t try_route_windows(const char *srcip, int action, int ip_versio
     // netsh (Windows Firewall) remains the only comprehensive blocking mechanism.
 
     // The IPv4 mask below only applies to IPv4 targets; netsh already covers IPv6.
-    if (strchr(srcip, ':') != NULL) {
+    if (ip_version == 6) {
         log_firewall_action(argv0, LOG_LEVEL_WARNING, "route", "check",
                           "route fallback supports IPv4 only - skipping IPv6 target");
         return FIREWALL_NOT_AVAILABLE;

--- a/src/active-response/src/block-ip-windows.c
+++ b/src/active-response/src/block-ip-windows.c
@@ -92,8 +92,9 @@ int main(int argc, char **argv) {
 // ============================================================================
 
 // Returns true if ANY firewall profile is effectively enabled (enforcing), read from
-// `netsh advfirewall show allprofiles state` - the merged GPO + local state, unlike the
-// SharedAccess EnableFirewall value that produced the false negative in #37388.
+// `netsh advfirewall show allprofiles state`. This reports the effective state and, in
+// particular, correctly returns ON when the local EnableFirewall value is ABSENT (the
+// Windows default).
 // On any failure to determine the state (or when the "ON" token is not recognized, e.g.
 // on a localized Windows) we return false, so try_netsh conservatively defers to the
 // route fallback rather than adding a rule that might never be enforced.
@@ -155,9 +156,10 @@ firewall_result_t try_netsh(const char *srcip, int action, int ip_version, const
 
     // A netsh block rule is only enforced while a firewall profile is enabled. On ENABLE,
     // if the firewall is effectively OFF, defer to the route fallback instead of adding a
-    // dormant rule. We read the EFFECTIVE state (merged GPO + local). This is
-    // ENABLE-only: on DISABLE we must always try to remove the rule, which may have been
-    // added while the firewall was enabled.
+    // dormant rule. We read the EFFECTIVE state via netsh (which reports ON even when the
+    // local EnableFirewall value is absent). This is ENABLE-only: on DISABLE we must
+    // always try to remove the rule, which may have been added while the firewall was
+    // enabled.
     if (action == ENABLE_COMMAND && !firewall_is_effectively_on(argv0)) {
         log_firewall_action(argv0, LOG_LEVEL_WARNING, "netsh", "check",
                           "Windows Firewall is effectively disabled - deferring to route fallback");
@@ -165,14 +167,17 @@ firewall_result_t try_netsh(const char *srcip, int action, int ip_version, const
         return FIREWALL_INVALID_STATE;
     }
 
+    // Single-host prefix for netsh remoteip: /32 for IPv4, /128 for IPv6.
+    const char *host_prefix = (strchr(srcip, ':') != NULL) ? "128" : "32";
+
     // Build netsh command
     wfd_t *wfd = NULL;
 
     if (action == ENABLE_COMMAND) {
-        // netsh advfirewall firewall add rule name="..." interface=any dir=in action=block remoteip=<IP>/32
+        // netsh advfirewall firewall add rule name="..." interface=any dir=in action=block remoteip=<IP>/<prefix>
         char remote_ip_arg[OS_MAXSTR];
         memset(remote_ip_arg, '\0', OS_MAXSTR);
-        snprintf(remote_ip_arg, OS_MAXSTR - 1, "remoteip=%s/32", srcip);
+        snprintf(remote_ip_arg, OS_MAXSTR - 1, "remoteip=%s/%s", srcip, host_prefix);
 
         char *exec_cmd_in[] = {
             netsh_path,
@@ -210,7 +215,7 @@ firewall_result_t try_netsh(const char *srcip, int action, int ip_version, const
         // Add outbound rule (from PR #34675 fix for bidirectional blocking)
         char remote_ip_arg_out[OS_MAXSTR];
         memset(remote_ip_arg_out, '\0', OS_MAXSTR);
-        snprintf(remote_ip_arg_out, OS_MAXSTR - 1, "remoteip=%s/32", srcip);
+        snprintf(remote_ip_arg_out, OS_MAXSTR - 1, "remoteip=%s/%s", srcip, host_prefix);
 
         char *exec_cmd_out[] = {
             netsh_path,
@@ -241,7 +246,7 @@ firewall_result_t try_netsh(const char *srcip, int action, int ip_version, const
         // DELETE: netsh advfirewall firewall delete rule name="..." remoteip=<IP>/32
         char remote_ip_arg_del[OS_MAXSTR];
         memset(remote_ip_arg_del, '\0', OS_MAXSTR);
-        snprintf(remote_ip_arg_del, OS_MAXSTR - 1, "remoteip=%s/32", srcip);
+        snprintf(remote_ip_arg_del, OS_MAXSTR - 1, "remoteip=%s/%s", srcip, host_prefix);
 
         char *exec_cmd[] = {
             netsh_path,
@@ -288,10 +293,11 @@ firewall_result_t try_route_windows(const char *srcip, int action, int ip_versio
 
     // Reached when netsh is unavailable, or (via try_netsh) when the firewall is
     // effectively OFF. BEST-EFFORT: null-routes the target to loopback so the host drops
-    // packets destined to it, which also breaks the reverse path of inbound TCP sessions.
-    // LIMITATION: this does NOT block a target on a directly-connected subnet - on-link
-    // hosts are reached via ARP and the /32-via-loopback route does not redirect that
-    // egress (verified on WS2022). It is effective for remote/routed attackers only.
+    // packets destined to it, which in principle also breaks the reverse path of inbound
+    // TCP sessions to a routed/remote attacker.
+    // LIMITATION: this does NOT block a target on a directly-connected
+    // subnet - on-link hosts are reached via ARP and the /32-via-loopback route does not
+    // redirect that egress. Effectiveness against routed/remote attackers was not verified.
     // netsh (Windows Firewall) remains the only comprehensive blocking mechanism.
 
     // The IPv4 mask below only applies to IPv4 targets; netsh already covers IPv6.

--- a/src/active-response/src/block-ip-windows.c
+++ b/src/active-response/src/block-ip-windows.c
@@ -77,7 +77,16 @@ int main(int argc, char **argv) {
         }
     }
 
-    int ip_version = (strchr(srcip, ':') != NULL) ? 6 : 4;
+    // Validate IP and get version (mirrors block-ip-unix.c / block-ip-macos.c)
+    int ip_version = validate_srcip(srcip);
+    if (ip_version == OS_INVALID) {
+        char log_msg[OS_MAXSTR];
+        memset(log_msg, '\0', OS_MAXSTR);
+        snprintf(log_msg, OS_MAXSTR - 1, "Invalid IP address: '%s'", srcip);
+        write_debug_file(argv[0], log_msg);
+        cJSON_Delete(input_json);
+        return OS_INVALID;
+    }
 
     int result;
     if (action == DISABLE_COMMAND) {

--- a/src/active-response/src/block-ip-windows.c
+++ b/src/active-response/src/block-ip-windows.c
@@ -17,12 +17,16 @@
 /**
  * Windows-specific block-ip implementation
  *
- * Method chain (first success wins): netsh (Windows Firewall) -> route (null-route).
+ * ENABLE: method chain (first success wins) netsh (Windows Firewall) -> route (null-route).
  * netsh provides true bidirectional (inbound + outbound) blocking, but its rules are only
- * enforced while a firewall profile is enabled. On ENABLE, try_netsh checks the EFFECTIVE
- * firewall state; when the firewall is off it defers to the route fallback, which
- * null-routes the target to loopback (dropping the attacker's reverse path). netsh.exe
- * being unavailable also falls through to route.
+ * enforced while a firewall profile is enabled. try_netsh checks the EFFECTIVE firewall
+ * state; when the firewall is off it defers to the route fallback, which null-routes the
+ * target to loopback (dropping the attacker's reverse path). netsh.exe being unavailable
+ * also falls through to route.
+ *
+ * DISABLE: not a fallback chain - the netsh rule AND any null-route are removed
+ * unconditionally (best-effort), since either may exist depending on how the block was
+ * applied.
  */
 
 firewall_result_t try_netsh(const char *srcip, int action, int ip_version, const char *argv0);
@@ -73,17 +77,42 @@ int main(int argc, char **argv) {
         }
     }
 
-    // Define Windows method chain
-    const firewall_method_t methods[] = {
-        {"netsh", try_netsh, false},
-        {"route", try_route_windows, false},
-        {NULL, NULL, false}  // Sentinel
-    };
-
     int ip_version = (strchr(srcip, ':') != NULL) ? 6 : 4;
 
-    // Execute firewall chain with fallback
-    int result = execute_firewall_chain(methods, srcip, action, ip_version, argv[0]);
+    int result;
+    if (action == DISABLE_COMMAND) {
+        // Removal is NOT a fallback chain: the block may have been applied by netsh
+        // (firewall enabled) OR by the null-route (firewall off) - or, across re-blocks with
+        // a firewall state change, BOTH - so we unconditionally attempt to remove BOTH.
+        // Each is best-effort: a missing rule/route is the expected case (not a failure), so
+        // cleanup never depends on netsh's (undocumented) exit code for "no rule matched".
+        // The unblock counts as successful if EITHER removal actually took effect.
+        firewall_result_t netsh_res = try_netsh(srcip, DISABLE_COMMAND, ip_version, argv[0]);
+        firewall_result_t route_res = try_route_windows(srcip, DISABLE_COMMAND, ip_version, argv[0]);
+        if (netsh_res == FIREWALL_SUCCESS || route_res == FIREWALL_SUCCESS) {
+            char unblock_msg[OS_MAXSTR];
+            memset(unblock_msg, '\0', OS_MAXSTR);
+            snprintf(unblock_msg, OS_MAXSTR - 1, "IP %s successfully unblocked", srcip);
+            log_firewall_action(argv[0], LOG_LEVEL_INFO, "block-ip", "unblock", unblock_msg);
+        } else {
+            // Neither a rule nor a route was actually removed. Usually benign (the IP was
+            // not blocked, or was blocked by the artifact that is now gone), but surface it
+            // so a genuine removal failure is not silent.
+            log_firewall_action(argv[0], LOG_LEVEL_WARNING, "block-ip", "unblock",
+                              "Nothing was removed (no matching firewall rule or null-route) - "
+                              "the IP may already be unblocked, or removal failed");
+        }
+        write_debug_file(argv[0], "Ended");
+        result = OS_SUCCESS;
+    } else {
+        // ENABLE: netsh -> route fallback (first success wins).
+        const firewall_method_t methods[] = {
+            {"netsh", try_netsh, false},
+            {"route", try_route_windows, false},
+            {NULL, NULL, false}  // Sentinel
+        };
+        result = execute_firewall_chain(methods, srcip, action, ip_version, argv[0]);
+    }
 
     cJSON_Delete(input_json);
     return result;
@@ -250,7 +279,10 @@ firewall_result_t try_netsh(const char *srcip, int action, int ip_version, const
         }
 
     } else {
-        // DELETE: netsh advfirewall firewall delete rule name="..." remoteip=<IP>/32
+        // DELETE (best-effort): the rule may not exist - e.g. the block was applied via the
+        // route fallback while the firewall was off - so a non-zero "no rule matched" exit
+        // is expected and is NOT treated as a failure. The caller removes the null-route
+        // unconditionally, independently of this result.
         char remote_ip_arg_del[OS_MAXSTR];
         memset(remote_ip_arg_del, '\0', OS_MAXSTR);
         snprintf(remote_ip_arg_del, OS_MAXSTR - 1, "remoteip=%s/%s", srcip, host_prefix);
@@ -266,23 +298,24 @@ firewall_result_t try_netsh(const char *srcip, int action, int ip_version, const
             NULL
         };
 
+        firewall_result_t del_res = FIREWALL_EXECUTION_FAILED;
         wfd = wpopenv(netsh_path, exec_cmd, W_BIND_STDERR);
-        if (!wfd) {
-            memset(log_msg, '\0', OS_MAXSTR);
-            snprintf(log_msg, OS_MAXSTR - 1, "Unable to execute netsh delete rule");
-            write_debug_file(argv0, log_msg);
-            os_free(netsh_path);
-            return FIREWALL_EXECUTION_FAILED;
+        if (wfd) {
+            int result_del = wpclose(wfd);
+            if (result_del == 0) {
+                del_res = FIREWALL_SUCCESS;  // a matching rule was actually removed
+            } else {
+                memset(log_msg, '\0', OS_MAXSTR);
+                snprintf(log_msg, OS_MAXSTR - 1,
+                         "netsh delete rule returned %d (no matching rule is expected if the block used the route fallback)",
+                         result_del);
+                write_debug_file(argv0, log_msg);
+            }
+        } else {
+            write_debug_file(argv0, "Unable to execute netsh delete rule");
         }
-
-        int result_del = wpclose(wfd);
-        if (result_del != 0) {
-            memset(log_msg, '\0', OS_MAXSTR);
-            snprintf(log_msg, OS_MAXSTR - 1, "netsh delete rule failed with exit code %d", result_del);
-            write_debug_file(argv0, log_msg);
-            os_free(netsh_path);
-            return FIREWALL_EXECUTION_FAILED;
-        }
+        os_free(netsh_path);
+        return del_res;
     }
 
     os_free(netsh_path);
@@ -323,29 +356,43 @@ firewall_result_t try_route_windows(const char *srcip, int action, int ip_versio
                           "Applying best-effort null-route (firewall off or netsh unavailable): "
                           "blocks routed/remote attackers but NOT same-subnet hosts - enable "
                           "Windows Firewall for comprehensive blocking");
-    }
 
-    char **exec_cmd = NULL;
-    // Null-route to the loopback so outbound packets to the target are discarded.
-    char *add_cmd[] = {route_path, "-p", "ADD", (char *)srcip,
-                       "MASK", "255.255.255.255", "127.0.0.1", NULL};
-    char *del_cmd[] = {route_path, "DELETE", (char *)srcip, NULL};
-    exec_cmd = (action == ENABLE_COMMAND) ? add_cmd : del_cmd;
-
-    wfd_t *wfd = wpopenv(route_path, exec_cmd, W_BIND_STDERR);
-    if (!wfd) {
+        // Null-route to the loopback so packets to the target are discarded.
+        char *add_cmd[] = {route_path, "-p", "ADD", (char *)srcip,
+                           "MASK", "255.255.255.255", "127.0.0.1", NULL};
+        wfd_t *wfd = wpopenv(route_path, add_cmd, W_BIND_STDERR);
+        if (!wfd) {
+            os_free(route_path);
+            return FIREWALL_EXECUTION_FAILED;
+        }
+        int rc = wpclose(wfd);
+        if (rc != 0) {
+            memset(log_msg, '\0', OS_MAXSTR);
+            snprintf(log_msg, OS_MAXSTR - 1, "route add failed with exit code %d", rc);
+            write_debug_file(argv0, log_msg);
+            os_free(route_path);
+            return FIREWALL_EXECUTION_FAILED;
+        }
+    } else {
+        // DELETE (best-effort): a null-route may not exist - e.g. the block was applied via
+        // netsh while the firewall was on - so a non-zero "element not found" is expected
+        // and is NOT treated as a failure.
+        char *del_cmd[] = {route_path, "DELETE", (char *)srcip, NULL};
+        wfd_t *wfd = wpopenv(route_path, del_cmd, W_BIND_STDERR);
+        firewall_result_t del_res = FIREWALL_EXECUTION_FAILED;
+        if (wfd) {
+            int rc = wpclose(wfd);
+            if (rc == 0) {
+                del_res = FIREWALL_SUCCESS;  // a route was actually removed
+            } else {
+                memset(log_msg, '\0', OS_MAXSTR);
+                snprintf(log_msg, OS_MAXSTR - 1,
+                         "route delete returned %d (no route is expected if the block used netsh)", rc);
+                write_debug_file(argv0, log_msg);
+            }
+        }
         os_free(route_path);
-        return FIREWALL_EXECUTION_FAILED;
-    }
-
-    int rc = wpclose(wfd);
-    if (rc != 0) {
-        memset(log_msg, '\0', OS_MAXSTR);
-        snprintf(log_msg, OS_MAXSTR - 1, "route %s failed with exit code %d",
-                 action == ENABLE_COMMAND ? "add" : "delete", rc);
-        write_debug_file(argv0, log_msg);
-        os_free(route_path);
-        return FIREWALL_EXECUTION_FAILED;
+        return del_res;
     }
 
     os_free(route_path);

--- a/src/active-response/src/block-ip-windows.c
+++ b/src/active-response/src/block-ip-windows.c
@@ -292,36 +292,49 @@ firewall_result_t try_netsh(const char *srcip, int action, int ip_version, const
         // route fallback while the firewall was off - so a non-zero "no rule matched" exit
         // is expected and is NOT treated as a failure. The caller removes the null-route
         // unconditionally, independently of this result.
-        char remote_ip_arg_del[OS_MAXSTR];
-        memset(remote_ip_arg_del, '\0', OS_MAXSTR);
-        snprintf(remote_ip_arg_del, OS_MAXSTR - 1, "remoteip=%s/%s", srcip, host_prefix);
-
-        char *exec_cmd[] = {
-            netsh_path,
-            "advfirewall",
-            "firewall",
-            "delete",
-            "rule",
-            (char *)rule_name,
-            remote_ip_arg_del,
-            NULL
-        };
+        //
+        // netsh matches the rule by its exact remoteip prefix. For IPv6 we also try the
+        // legacy "/32" prefix: an agent upgraded from a version that wrote every rule as
+        // remoteip=<ip>/32 may still carry such a rule, which a "/128" delete would not match.
+        const char *del_prefixes[2];
+        int del_prefix_count = 0;
+        del_prefixes[del_prefix_count++] = host_prefix;
+        if (ip_version == 6) {
+            del_prefixes[del_prefix_count++] = "32";  // pre-upgrade IPv6 rules used /32
+        }
 
         firewall_result_t del_res = FIREWALL_EXECUTION_FAILED;
-        wfd = wpopenv(netsh_path, exec_cmd, W_BIND_STDERR);
-        if (wfd) {
-            int result_del = wpclose(wfd);
-            if (result_del == 0) {
-                del_res = FIREWALL_SUCCESS;  // a matching rule was actually removed
+        for (int p = 0; p < del_prefix_count; p++) {
+            char remote_ip_arg_del[OS_MAXSTR];
+            memset(remote_ip_arg_del, '\0', OS_MAXSTR);
+            snprintf(remote_ip_arg_del, OS_MAXSTR - 1, "remoteip=%s/%s", srcip, del_prefixes[p]);
+
+            char *exec_cmd[] = {
+                netsh_path,
+                "advfirewall",
+                "firewall",
+                "delete",
+                "rule",
+                (char *)rule_name,
+                remote_ip_arg_del,
+                NULL
+            };
+
+            wfd = wpopenv(netsh_path, exec_cmd, W_BIND_STDERR);
+            if (wfd) {
+                int result_del = wpclose(wfd);
+                if (result_del == 0) {
+                    del_res = FIREWALL_SUCCESS;  // a matching rule was actually removed
+                } else {
+                    memset(log_msg, '\0', OS_MAXSTR);
+                    snprintf(log_msg, OS_MAXSTR - 1,
+                             "netsh delete rule (remoteip=%s/%s) returned %d (no matching rule is expected if the block used the route fallback)",
+                             srcip, del_prefixes[p], result_del);
+                    write_debug_file(argv0, log_msg);
+                }
             } else {
-                memset(log_msg, '\0', OS_MAXSTR);
-                snprintf(log_msg, OS_MAXSTR - 1,
-                         "netsh delete rule returned %d (no matching rule is expected if the block used the route fallback)",
-                         result_del);
-                write_debug_file(argv0, log_msg);
+                write_debug_file(argv0, "Unable to execute netsh delete rule");
             }
-        } else {
-            write_debug_file(argv0, "Unable to execute netsh delete rule");
         }
         os_free(netsh_path);
         return del_res;
@@ -350,8 +363,16 @@ firewall_result_t try_route_windows(const char *srcip, int action, int ip_versio
 
     // The IPv4 mask below only applies to IPv4 targets; netsh already covers IPv6.
     if (ip_version == 6) {
-        log_firewall_action(argv0, LOG_LEVEL_WARNING, "route", "check",
-                          "route fallback supports IPv4 only - skipping IPv6 target");
+        // On ENABLE this is a genuine limitation worth flagging. On DISABLE, skipping IPv6
+        // here is the expected path (the route fallback never creates an IPv6 null-route, so
+        // there is nothing to remove), so keep it at debug to avoid a warning on every
+        // routine IPv6 unblock.
+        if (action == ENABLE_COMMAND) {
+            log_firewall_action(argv0, LOG_LEVEL_WARNING, "route", "check",
+                              "route fallback supports IPv4 only - skipping IPv6 target");
+        } else {
+            write_debug_file(argv0, "route fallback is IPv4-only - no null-route to remove for IPv6 target");
+        }
         return FIREWALL_NOT_AVAILABLE;
     }
 

--- a/src/active-response/src/block-ip-windows.c
+++ b/src/active-response/src/block-ip-windows.c
@@ -16,11 +16,18 @@
 
 /**
  * Windows-specific block-ip implementation
- * Fallback chain: netsh → route
+ *
+ * Method chain (first success wins): netsh (Windows Firewall) -> route (null-route).
+ * netsh provides true bidirectional (inbound + outbound) blocking, but its rules are only
+ * enforced while a firewall profile is enabled. On ENABLE, try_netsh checks the EFFECTIVE
+ * firewall state; when the firewall is off it defers to the route fallback, which
+ * null-routes the target to loopback (dropping the attacker's reverse path). netsh.exe
+ * being unavailable also falls through to route.
  */
 
 firewall_result_t try_netsh(const char *srcip, int action, int ip_version, const char *argv0);
 firewall_result_t try_route_windows(const char *srcip, int action, int ip_version, const char *argv0);
+static bool firewall_is_effectively_on(const char *argv0);
 
 int main(int argc, char **argv) {
     // This must always be the first instruction on Windows
@@ -81,6 +88,57 @@ int main(int argc, char **argv) {
 }
 
 // ============================================================================
+// WINDOWS: effective firewall-state detection
+// ============================================================================
+
+// Returns true if ANY firewall profile is effectively enabled (enforcing), read from
+// `netsh advfirewall show allprofiles state` - the merged GPO + local state, unlike the
+// SharedAccess EnableFirewall value that produced the false negative in #37388.
+// On any failure to determine the state (or when the "ON" token is not recognized, e.g.
+// on a localized Windows) we return false, so try_netsh conservatively defers to the
+// route fallback rather than adding a rule that might never be enforced.
+static bool firewall_is_effectively_on(const char *argv0) {
+    char *netsh_path = NULL;
+
+    if (get_binary_path("netsh.exe", &netsh_path) < 0) {
+        write_debug_file(argv0, "Unable to locate netsh.exe to query firewall state - assuming disabled");
+        os_free(netsh_path);
+        return false;
+    }
+
+    char *exec_cmd[] = {netsh_path, "advfirewall", "show", "allprofiles", "state", NULL};
+    wfd_t *wfd = wpopenv(netsh_path, exec_cmd, W_BIND_STDOUT);
+    if (!wfd) {
+        write_debug_file(argv0, "Unable to query firewall state via netsh - assuming disabled");
+        os_free(netsh_path);
+        return false;
+    }
+
+    char output_buf[OS_MAXSTR];
+    bool any_on = false;
+
+    while (fgets(output_buf, OS_MAXSTR, wfd->file_out)) {
+        char *p = strstr(output_buf, "State");
+        if (!p) {
+            continue;
+        }
+        p += 5;  // strlen("State")
+        while (*p == ' ' || *p == '\t') {
+            p++;
+        }
+        if ((p[0] == 'O' || p[0] == 'o') && (p[1] == 'N' || p[1] == 'n') &&
+            (p[2] == '\0' || p[2] == '\r' || p[2] == '\n' || p[2] == ' ' || p[2] == '\t')) {
+            any_on = true;
+            break;
+        }
+    }
+
+    wpclose(wfd);
+    os_free(netsh_path);
+    return any_on;
+}
+
+// ============================================================================
 // WINDOWS: netsh (Windows Firewall) implementation
 // ============================================================================
 
@@ -89,58 +147,22 @@ firewall_result_t try_netsh(const char *srcip, int action, int ip_version, const
     static const char rule_name[] = "name=\"WAZUH ACTIVE RESPONSE BLOCKED IP\"";
     char log_msg[OS_MAXSTR];
     char *netsh_path = NULL;
-    char *reg_path = NULL;
 
     // Check if netsh.exe is available
     if (check_binary_available("netsh.exe", &netsh_path, argv0) != FIREWALL_SUCCESS) {
         return FIREWALL_NOT_AVAILABLE;
     }
 
-    // Check if reg.exe is available (for profile checking)
-    if (get_binary_path("reg.exe", &reg_path) < 0) {
-        memset(log_msg, '\0', OS_MAXSTR);
-        snprintf(log_msg, OS_MAXSTR - 1, "Binary 'reg.exe' not found - skipping firewall profile check");
-        write_debug_file(argv0, log_msg);
-        // Continue without profile check
-    }
-
-    // Check Windows Firewall profiles if reg.exe is available
-    if (reg_path) {
-        const char *profiles[] = {
-            "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Parameters\\FirewallPolicy\\DomainProfile",
-            "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Parameters\\FirewallPolicy\\StandardProfile",
-            "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Parameters\\FirewallPolicy\\PublicProfile"
-        };
-        const char *profile_names[] = {"Domain", "Private", "Public"};
-        bool any_enabled = false;
-
-        for (int i = 0; i < 3; i++) {
-            char *exec_cmd[] = {reg_path, "query", (char *)profiles[i], "/v", "EnableFirewall", NULL};
-            wfd_t *wfd = wpopenv(reg_path, exec_cmd, W_BIND_STDOUT);
-
-            if (wfd) {
-                char output_buf[OS_MAXSTR];
-                while (fgets(output_buf, OS_MAXSTR, wfd->file_out)) {
-                    if (strstr(output_buf, "0x1") != NULL) {
-                        any_enabled = true;
-                        memset(log_msg, '\0', OS_MAXSTR);
-                        snprintf(log_msg, OS_MAXSTR - 1, "Windows Firewall %s profile: Enabled", profile_names[i]);
-                        write_debug_file(argv0, log_msg);
-                        break;
-                    }
-                }
-                wpclose(wfd);
-            }
-        }
-
-        os_free(reg_path);
-
-        if (!any_enabled) {
-            log_firewall_action(argv0, LOG_LEVEL_WARNING, "netsh", "check",
-                              "No Windows Firewall profiles are enabled");
-            os_free(netsh_path);
-            return FIREWALL_INVALID_STATE;
-        }
+    // A netsh block rule is only enforced while a firewall profile is enabled. On ENABLE,
+    // if the firewall is effectively OFF, defer to the route fallback instead of adding a
+    // dormant rule. We read the EFFECTIVE state (merged GPO + local). This is
+    // ENABLE-only: on DISABLE we must always try to remove the rule, which may have been
+    // added while the firewall was enabled.
+    if (action == ENABLE_COMMAND && !firewall_is_effectively_on(argv0)) {
+        log_firewall_action(argv0, LOG_LEVEL_WARNING, "netsh", "check",
+                          "Windows Firewall is effectively disabled - deferring to route fallback");
+        os_free(netsh_path);
+        return FIREWALL_INVALID_STATE;
     }
 
     // Build netsh command
@@ -260,11 +282,24 @@ firewall_result_t try_netsh(const char *srcip, int action, int ip_version, const
 // ============================================================================
 
 firewall_result_t try_route_windows(const char *srcip, int action, int ip_version, const char *argv0) {
-    (void)ip_version;  // route works for both IPv4 and IPv6
+    (void)ip_version;
     char log_msg[OS_MAXSTR];
     char *route_path = NULL;
-    char *ipconfig_path = NULL;
-    char gateway[OS_MAXSTR] = {0};
+
+    // Reached when netsh is unavailable, or (via try_netsh) when the firewall is
+    // effectively OFF. BEST-EFFORT: null-routes the target to loopback so the host drops
+    // packets destined to it, which also breaks the reverse path of inbound TCP sessions.
+    // LIMITATION: this does NOT block a target on a directly-connected subnet - on-link
+    // hosts are reached via ARP and the /32-via-loopback route does not redirect that
+    // egress (verified on WS2022). It is effective for remote/routed attackers only.
+    // netsh (Windows Firewall) remains the only comprehensive blocking mechanism.
+
+    // The IPv4 mask below only applies to IPv4 targets; netsh already covers IPv6.
+    if (strchr(srcip, ':') != NULL) {
+        log_firewall_action(argv0, LOG_LEVEL_WARNING, "route", "check",
+                          "route fallback supports IPv4 only - skipping IPv6 target");
+        return FIREWALL_NOT_AVAILABLE;
+    }
 
     // Check if route.exe is available
     if (check_binary_available("route.exe", &route_path, argv0) != FIREWALL_SUCCESS) {
@@ -272,96 +307,33 @@ firewall_result_t try_route_windows(const char *srcip, int action, int ip_versio
     }
 
     if (action == ENABLE_COMMAND) {
-        // Need to find default gateway using ipconfig
-        if (check_binary_available("ipconfig.exe", &ipconfig_path, argv0) != FIREWALL_SUCCESS) {
-            log_firewall_action(argv0, LOG_LEVEL_WARNING, "route", "check",
-                              "ipconfig.exe not found - cannot determine gateway");
-            os_free(route_path);
-            return FIREWALL_NOT_AVAILABLE;
-        }
+        log_firewall_action(argv0, LOG_LEVEL_WARNING, "route", "best_effort",
+                          "Applying best-effort null-route (firewall off or netsh unavailable): "
+                          "blocks routed/remote attackers but NOT same-subnet hosts - enable "
+                          "Windows Firewall for comprehensive blocking");
+    }
 
-        // Query default gateway
-        char *ipconfig_cmd[] = {ipconfig_path, NULL};
-        wfd_t *wfd = wpopenv(ipconfig_path, ipconfig_cmd, W_BIND_STDOUT);
+    char **exec_cmd = NULL;
+    // Null-route to the loopback so outbound packets to the target are discarded.
+    char *add_cmd[] = {route_path, "-p", "ADD", (char *)srcip,
+                       "MASK", "255.255.255.255", "127.0.0.1", NULL};
+    char *del_cmd[] = {route_path, "DELETE", (char *)srcip, NULL};
+    exec_cmd = (action == ENABLE_COMMAND) ? add_cmd : del_cmd;
 
-        if (!wfd) {
-            os_free(ipconfig_path);
-            os_free(route_path);
-            return FIREWALL_EXECUTION_FAILED;
-        }
+    wfd_t *wfd = wpopenv(route_path, exec_cmd, W_BIND_STDERR);
+    if (!wfd) {
+        os_free(route_path);
+        return FIREWALL_EXECUTION_FAILED;
+    }
 
-        // Parse ipconfig output to find default gateway
-        char output_buf[OS_MAXSTR];
-        bool found_gateway = false;
-
-        while (fgets(output_buf, OS_MAXSTR, wfd->file_out)) {
-            if (strstr(output_buf, "Default Gateway") != NULL ||
-                strstr(output_buf, "Puerta de enlace predeterminada") != NULL) {
-                // Extract IP address from line
-                char *ip_start = strchr(output_buf, ':');
-                if (ip_start) {
-                    ip_start++;
-                    // Skip whitespace
-                    while (*ip_start == ' ' || *ip_start == '\t') ip_start++;
-
-                    // Copy IP address
-                    int i = 0;
-                    while (ip_start[i] != '\0' && ip_start[i] != '\n' && ip_start[i] != '\r' && i < OS_MAXSTR - 1) {
-                        gateway[i] = ip_start[i];
-                        i++;
-                    }
-                    gateway[i] = '\0';
-
-                    if (strlen(gateway) > 0) {
-                        found_gateway = true;
-                        break;
-                    }
-                }
-            }
-        }
-        wpclose(wfd);
-        os_free(ipconfig_path);
-
-        if (!found_gateway) {
-            log_firewall_action(argv0, LOG_LEVEL_WARNING, "route", "gateway",
-                              "Unable to determine default gateway");
-            os_free(route_path);
-            return FIREWALL_EXECUTION_FAILED;
-        }
-
+    int rc = wpclose(wfd);
+    if (rc != 0) {
         memset(log_msg, '\0', OS_MAXSTR);
-        snprintf(log_msg, OS_MAXSTR - 1, "Using gateway: %s", gateway);
+        snprintf(log_msg, OS_MAXSTR - 1, "route %s failed with exit code %d",
+                 action == ENABLE_COMMAND ? "add" : "delete", rc);
         write_debug_file(argv0, log_msg);
-
-        // Add persistent route: route -p ADD <IP> MASK 255.255.255.255 <gateway>
-        char *exec_cmd[] = {
-            route_path,
-            "-p",
-            "ADD",
-            (char *)srcip,
-            "MASK",
-            "255.255.255.255",
-            gateway,
-            NULL
-        };
-
-        wfd = wpopenv(route_path, exec_cmd, W_BIND_STDERR);
-        if (!wfd) {
-            os_free(route_path);
-            return FIREWALL_EXECUTION_FAILED;
-        }
-        wpclose(wfd);
-
-    } else {
-        // DELETE: route DELETE <IP>
-        char *exec_cmd[] = {route_path, "DELETE", (char *)srcip, NULL};
-
-        wfd_t *wfd = wpopenv(route_path, exec_cmd, W_BIND_STDERR);
-        if (!wfd) {
-            os_free(route_path);
-            return FIREWALL_EXECUTION_FAILED;
-        }
-        wpclose(wfd);
+        os_free(route_path);
+        return FIREWALL_EXECUTION_FAILED;
     }
 
     os_free(route_path);

--- a/src/unit_tests/active-response/test_active-response.c
+++ b/src/unit_tests/active-response/test_active-response.c
@@ -112,12 +112,71 @@ void test_get_ip_version_success_invalid_ip(void **state) {
     assert_int_equal(ret, -1);    //OS_INVALID
 }
 
+// validate_srcip: strict numeric-IP whitelist
+
+void test_validate_srcip_ipv4(void **state) {
+    (void)state;
+    assert_int_equal(validate_srcip("192.168.1.100"), 4);
+    assert_int_equal(validate_srcip("10.0.0.1"), 4);
+}
+
+void test_validate_srcip_ipv6(void **state) {
+    (void)state;
+    assert_int_equal(validate_srcip("2001:db8::1"), 6);
+    assert_int_equal(validate_srcip("::1"), 6);
+    assert_int_equal(validate_srcip("fe80::a1b2:c3d4"), 6);
+}
+
+void test_validate_srcip_ipv4_mapped_ipv6(void **state) {
+    (void)state;
+    // IPv4-mapped IPv6 contains both ':' and '.', classified as IPv6
+    assert_int_equal(validate_srcip("::ffff:1.2.3.4"), 6);
+}
+
+void test_validate_srcip_null_and_empty(void **state) {
+    (void)state;
+    assert_int_equal(validate_srcip(NULL), OS_INVALID);
+    assert_int_equal(validate_srcip(""), OS_INVALID);
+    assert_int_equal(validate_srcip("a"), OS_INVALID);    // shorter than minimum length
+}
+
+void test_validate_srcip_rejects_cidr(void **state) {
+    (void)state;
+    // A '/' would let a CIDR prefix (or extra path) reach the command line
+    assert_int_equal(validate_srcip("192.168.1.100/32"), OS_INVALID);
+    assert_int_equal(validate_srcip("2001:db8::1/128"), OS_INVALID);
+}
+
+void test_validate_srcip_rejects_argument_injection(void **state) {
+    (void)state;
+    // wpopenv does not quote arguments on Windows; whitespace/metacharacters must be rejected
+    // so a crafted source.ip cannot inject extra tokens into the netsh/route command line.
+    assert_int_equal(validate_srcip("1.2.3.4 action=allow"), OS_INVALID);
+    assert_int_equal(validate_srcip("1.2.3.4 enable=no"), OS_INVALID);
+    assert_int_equal(validate_srcip("::1 remoteip=any"), OS_INVALID);
+    assert_int_equal(validate_srcip("1.2.3.4&calc"), OS_INVALID);
+    assert_int_equal(validate_srcip("1.2.3.4;rm"), OS_INVALID);
+    assert_int_equal(validate_srcip("1.2.3.4\""), OS_INVALID);
+}
+
+void test_validate_srcip_rejects_hostname(void **state) {
+    (void)state;
+    assert_int_equal(validate_srcip("google.com"), OS_INVALID);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown(test_get_ip_version_success_ipv4, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_get_ip_version_success_ipv6, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_get_ip_version_no_success, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_get_ip_version_success_invalid_ip, test_setup, test_teardown),
+        cmocka_unit_test(test_validate_srcip_ipv4),
+        cmocka_unit_test(test_validate_srcip_ipv6),
+        cmocka_unit_test(test_validate_srcip_ipv4_mapped_ipv6),
+        cmocka_unit_test(test_validate_srcip_null_and_empty),
+        cmocka_unit_test(test_validate_srcip_rejects_cidr),
+        cmocka_unit_test(test_validate_srcip_rejects_argument_injection),
+        cmocka_unit_test(test_validate_srcip_rejects_hostname),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/os_execd/test_win_execd.c
+++ b/src/unit_tests/os_execd/test_win_execd.c
@@ -226,10 +226,10 @@ static void test_WinExecdRun_ar_reports_failure(void **state) {
                         "}"
                     "}";
 
-    expect_wfopen(AR_BINDIR "/block-ip", "r", (FILE *)1);
+    expect_wfopen(AR_BINDIR "/block-ip.exe", "r", (FILE *)1);
     expect_fclose((FILE *)1, 0);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Executing command '" AR_BINDIR "/block-ip {"
+    expect_string(__wrap__mdebug1, formatted_msg, "Executing command '" AR_BINDIR "/block-ip.exe {"
                                                                                         "\"wazuh\":{"
                                                                                             "\"active_response\":{"
                                                                                                 "\"name\":\"block-ip\","
@@ -318,7 +318,7 @@ static void test_WinExecdRun_ar_reports_failure(void **state) {
     will_return(wrap_fprintf, 0);
 
     /* On Windows, wpclose() returns the exit code directly; any nonzero value is a failure */
-    expect_string(__wrap__mwarn, formatted_msg, "Active response command '" AR_BINDIR "/block-ip' reported failure (exit code 3).");
+    expect_string(__wrap__mwarn, formatted_msg, "Active response command '" AR_BINDIR "/block-ip.exe' reported failure (exit code 3).");
     will_return(__wrap_wpclose, 3);
 
     ExecdRun(message);


### PR DESCRIPTION
## Description

On Windows, the `block-ip` active response failed to block IPs: the executable ran and reported success, but the target IP stayed reachable (e.g. WinRM/RDP logins kept working).

`try_netsh` pre-checked whether the firewall was "enabled" by running `reg query` against the local SharedAccess store:

```
HKLM\SYSTEM\CurrentControlSet\Services\SharedAccess\Parameters\FirewallPolicy\{Domain,Standard,Public}Profile\EnableFirewall
```

and looked for `0x1` in the output. This misfires whenever the value is **not present** while the firewall is running: the reg query returns no data, so the check concludes "no profile enabled", returns `FIREWALL_INVALID_STATE`, and **skips `netsh` entirely** — even though `netsh` is fully functional — falling back to the `route` method. This is not a rare edge: with `EnableFirewall` **absent**, the firewall is effectively **ON** (Windows default), yet the check reads it as disabled. The local SharedAccess value is also not authoritative on hosts where the firewall is managed elsewhere. (Confirmed empirically below.)

The `route` fallback could never provide the intended protection:

- It routed the target through the host's **real default gateway**, which does not blackhole anything.
- It parsed `ipconfig` and took the first `Default Gateway` line, which on a dual-stack host is the **IPv6 link-local** address (`fe80::…`); the resulting `route add <IPv4> MASK 255.255.255.255 <IPv6-gw>` is invalid and `route.exe` rejects it.
- The `route add` exit code was never checked, so the method returned `FIREWALL_SUCCESS` while adding nothing — a **silent false success**.

Closes #37388

## Proposed Changes

**`src/active-response/src/block-ip-windows.c`**

- **Firewall-state detection (`firewall_is_effectively_on`, new)** — Read the `EnableFirewall` DWORD directly from the registry via the Win32 API (`RegOpenKeyEx`/`RegQueryValueEx`, 64-bit view). Per profile: the GPO policy value (`SOFTWARE\Policies\Microsoft\WindowsFirewall\<profile>`) wins if present, else the local SharedAccess value, else it defaults to **ENABLED** (the Windows default). Defaulting an **absent** value to enabled is the actual misfire fix — the old check treated absent as "disabled". 
- **`try_netsh`** — On **ENABLE** only, if the firewall is effectively off, return `FIREWALL_INVALID_STATE` so the chain defers to `route` instead of adding a rule that would sit dormant. The check is deliberately **not** applied on DISABLE, so an unblock always removes the rule (which may have been added while the firewall was enabled). This keeps the "one method or the other" chain semantics while fixing the misfire (correct signal source). Also fixed the `remoteip` prefix to match the address family — `/32` for IPv4, `/128` for IPv6 — instead of a hardcoded `/32` that malformed the rule for IPv6 targets.
- **`try_route_windows`** — Rework the fallback into a null-route:
  - Null-route the target to the loopback (`route -p ADD <ip> MASK 255.255.255.255 127.0.0.1`) instead of routing via the host's real default gateway.
  - Remove the `ipconfig` parsing entirely (eliminates the IPv6-link-local gateway bug and the locale-dependent string matching).
  - Skip IPv6 targets (`FIREWALL_NOT_AVAILABLE`) rather than emit an invalid route; `netsh` already covers IPv6.
  - On ENABLE, check the `route add` exit code and return `FIREWALL_EXECUTION_FAILED` on error (ending the silent false-success). The DELETE path is **best-effort** — a missing route is the expected case on cleanup.
  - Log an explicit **best-effort** warning documenting the limitation (below).
- **DISABLE cleanup (semantics fix)** — Unblock is no longer routed through the fallback chain. The block may have been applied by *either* netsh (firewall on) *or* the null-route (firewall off), so DISABLE now removes **both** unconditionally, each best-effort. Previously the chain only reached `route delete` if `netsh delete rule` returned non-zero, which relied on netsh's **undocumented** "errorlevel 1 on no rule matched" — had it ever returned 0, the null-route would have been orphaned while the log reported "unblocked" (raised in review). The delete helpers now return `SUCCESS` only when they actually removed something; if **neither** removed anything, a `WARNING` is logged so a genuine removal failure is not silent. The command still returns `OS_SUCCESS` for consistency with the ENABLE chain — execd ignores the AR exit code (it never reads `wpclose`'s return), so failures are surfaced via the log, not the return code.

**ENABLE** uses the `netsh → route` chain (mutually exclusive: one method or the other). `netsh` (Windows Firewall) is the comprehensive, bidirectional mechanism, used whenever the firewall is effectively enabled. `route` is reached only when the firewall is off (or `netsh.exe` is missing) and is **best-effort**: a loopback null-route breaks the attacker's reverse path (which also disrupts inbound TCP sessions) for **routed/remote** attackers, but does **not** block a target on a **directly-connected subnet** (on-link hosts are reached via ARP and the `/32`-via-loopback route does not redirect that egress — verified on WS2022). This is documented in-code and surfaced as a warning in `active-responses.log`. **DISABLE** removes both artifacts unconditionally (above).


### Results and Evidence

Reproduced on a standalone **Windows Server 2022** agent (5.0.0) by driving `block-ip.exe` directly via stdin, as `execd` does.

**Root cause.** Setting the local `EnableFirewall` value to each state and comparing what the old reg-query check saw against the effective firewall state:

| SharedAccess `EnableFirewall` | Effective firewall (`netsh advfirewall show allprofiles state`) | Old check finds `0x1`? |
|---|---|---|
| `0x1` | ON | yes → uses netsh (correct) |
| `0x0` | OFF | no → firewall genuinely off |
| **absent** | **ON** | **no → MISFIRE** |

The `absent` row is the bug: the firewall is effectively **on** (Windows default) but the old check finds no `0x1`, reports "disabled", and skips `netsh`. This is a common state on managed/unconfigured hosts. The fix reads the `EnableFirewall` DWORD from the registry and **defaults an absent value to enabled**, which matches the effective state in every row above and is locale-independent. (The `netsh ... state` column here is just how the effective state was *measured*; parsing that text was tried as the signal but dropped — see the detection bullet — because it is localized. `Get-NetFirewallProfile ActiveStore` was also rejected — it reported `Enabled=True` even when the firewall was effectively OFF.)

**Misfire — before vs after (firewall on, `EnableFirewall` absent):**

- **Old binary:** `[WARNING] Method=netsh Action=check Details=No Windows Firewall profiles are enabled` → skips netsh → `route`, which reported success while adding nothing (IPv6 gateway + unchecked exit code).

<img width="1843" height="545" alt="Captura desde 2026-07-13 15-44-34" src="https://github.com/user-attachments/assets/da0325a9-c6ce-4acf-bc3e-3efd24676be4" />

- **Fixed binary:** reads the effective state (ON) → `[INFO] Method=netsh Action=success` → inbound + outbound rules created. Misfire gone.

<img width="1843" height="479" alt="Captura desde 2026-07-13 15-40-08" src="https://github.com/user-attachments/assets/929ae165-e955-480b-abc9-6ba276cfc0ef" />

**Blocking actually works — end-to-end connectivity test (two machines).** The agent blocked/unblocked a second machine's IP while that machine continuously probed an open TCP port (22), mimicking a stateful response (block → hold → unblock):

- **Firewall ON (netsh):** probe went `REACHABLE → BLOCKED` ~2 s after `enable`, and `BLOCKED → REACHABLE` ~2 s after `disable`. The connection is genuinely blocked and restored. ✅
- **Firewall OFF (route fallback):** the null-route did **not** block a same-subnet probe (on-link ARP delivery is not redirected by the loopback route). netsh is the only comprehensive method; the route fallback is best-effort for routed/remote attackers only — documented in-code and logged as a warning.


### Artifacts Affected

- `block-ip.exe` (Windows active-response executable)

### Configuration Changes

N/A

### Documentation Updates

Updated the Active Response executables reference (`docs/ref/modules/active-response/executables.md`), **block-ip (Windows)** section, to match the reworked behavior:
- netsh: corrected rule name (`WAZUH ACTIVE RESPONSE BLOCKED IP`), in/out bidirectional rules, and the family-aware `remoteip` prefix (`/32` IPv4, `/128` IPv6).
- Documented effective firewall-state detection (`EnableFirewall` DWORD read from the registry: GPO > SharedAccess > absent defaults to enabled), ENABLE-only.
- route fallback rewritten as a best-effort loopback null-route; removed the obsolete `ipconfig`/gateway detection; noted the same-subnet (on-link ARP) limitation, the checked exit code, and IPv4-only scope.
- DISABLE now documented as unconditional dual cleanup (removes both the netsh rule and the null-route, best-effort) instead of a fallback chain.
- Fixed the stale rule name in the netsh verification example.

### Tests Introduced

No new automated tests.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
