### PR TITLE
Multi SCA, Decoder and Rule fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## [v4.14.8]
 
+### Ruleset
+
+#### Fixed
+
+- Fixed Fortigate Decoder and malicious ioc rule. ([#37434](https://github.com/wazuh/wazuh/pull/37434))
+
 ## [v4.14.7]
 
 ### Ruleset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 #### Fixed
 
-- Fixed Fortigate Decoder and malicious ioc rule. ([#37434](https://github.com/wazuh/wazuh/pull/37434))
+- Fixed Fortigate Decoder, malicious ioc rule and RHEL 8,9,10 incorrect rpm check. ([#37434](https://github.com/wazuh/wazuh/pull/37434))
 
 ## [v4.14.7]
 

--- a/ruleset/decoders/0100-fortigate_decoders.xml
+++ b/ruleset/decoders/0100-fortigate_decoders.xml
@@ -238,7 +238,7 @@
 
 <decoder name="fortigate-firewall-v5">
   <type>syslog</type>
-  <prematch>date=\S+\.+time=\.+devname=\S+\.+devid=\p*FG\S+\.+logid=</prematch>
+  <prematch>date=\S+\.+time=\.+devname=\S+\.+devid=\p*FG</prematch>
 </decoder>
 
 <decoder name="fortigate-firewall-v5">

--- a/ruleset/rules/0999-malicious-ioc-rules.xml
+++ b/ruleset/rules/0999-malicious-ioc-rules.xml
@@ -37,14 +37,14 @@
     <if_sid>5715</if_sid>
     <list field="srcip" lookup="match_key">etc/lists/malicious-ioc/malicious-ip</list>
     <description>sshd: Authentication succeeded from a malicious IP address $(srcip).</description>
-    <group>authentication_failed,authentication_success,pci_dss_10.2.4,pci_dss_10.2.5,</group>
+    <group>authentication_success,pci_dss_10.2.4,pci_dss_10.2.5,</group>
   </rule>
 
   <rule id="99904" level="9">
     <if_sid>5716</if_sid>
   <list field="srcip" lookup="match_key">etc/lists/malicious-ioc/malicious-ip</list>
     <description>sshd: Authentication failed from a malicious IP address $(srcip).</description>
-    <group>authentication_failed,authentication_success,pci_dss_10.2.4,pci_dss_10.2.5,</group>
+    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
   </rule>
 </group>
 

--- a/ruleset/sca/centos/10/cis_centos10_linux.yml
+++ b/ruleset/sca/centos/10/cis_centos10_linux.yml
@@ -1227,7 +1227,7 @@ checks:
       - soc_2: ["CC6.3", "CC6.6"]
     condition: all
     rules:
-      - "f:rpm -q gdm -> r:is not installed"
+      - "c:rpm -q gdm -> r:package gdm is not installed"
 
   # 1.8.2 Ensure GDM login banner is configured. (Automated)
   - id: 37557

--- a/ruleset/sca/centos/8/cis_centos8_linux.yml
+++ b/ruleset/sca/centos/8/cis_centos8_linux.yml
@@ -1227,7 +1227,7 @@ checks:
       - soc_2: ["CC6.3", "CC6.6"]
     condition: all
     rules:
-      - "f:rpm -q gdm -> r:is not installed"
+      - "c:rpm -q gdm -> r:package gdm is not installed"
 
   # 1.8.2 Ensure GDM login banner is configured. (Automated)
   - id: 6557

--- a/ruleset/sca/centos/9/cis_centos9_linux.yml
+++ b/ruleset/sca/centos/9/cis_centos9_linux.yml
@@ -1227,7 +1227,7 @@ checks:
       - soc_2: ["CC6.3", "CC6.6"]
     condition: all
     rules:
-      - "f:rpm -q gdm -> r:is not installed"
+      - "c:rpm -q gdm -> r:package gdm is not installed"
 
   # 1.8.2 Ensure GDM login banner is configured. (Automated)
   - id: 39057


### PR DESCRIPTION
|Wazuh version| Component | Action type |
|---| --- | --- |
| 4.13.0 - 4.14.5 | Rules | Improve |

## Description
Default rules `99903` and `99904` in `0999-malicious-ioc-rules.xml` are assigned to both the `authentication_success` and `authentication_failed` rule groups.

This mapping is incorrect because:
- Rule `99903` detects a successful SSH authentication from a malicious IP address and should only belong to `authentication_success`.
- Rule `99904` detects a failed SSH authentication from a malicious IP address and should only belong to `authentication_failed`.

The incorrect group assignments affect rule analysis and dashboard visualizations. For example, rule `99904` can appear in the Authentication success visualization because it contains the `authentication_success` group, even though the rule represents a failed authentication attempt.

The issue appears to have been present since Wazuh `4.13.0` and is still present in `4.14.5`.

### Current results
Both rules are assigned to both authentication groups:
```bash
<group name="syslog,sshd,">

  <rule id="99903" level="14">
    <if_sid>5715</if_sid>
    <list field="srcip" lookup="match_key">etc/lists/malicious-ioc/malicious-ip</list>
    <description>sshd: Authentication succeeded from a malicious IP address $(srcip).</description>
    <group>authentication_failed,authentication_success,pci_dss_10.2.4,pci_dss_10.2.5,</group>
  </rule>

  <rule id="99904" level="9">
    <if_sid>5716</if_sid>
  <list field="srcip" lookup="match_key">etc/lists/malicious-ioc/malicious-ip</list>
    <description>sshd: Authentication failed from a malicious IP address $(srcip).</description>
    <group>authentication_failed,authentication_success,pci_dss_10.2.4,pci_dss_10.2.5,</group>
  </rule>
</group>
```

### Expected results
Each rule should be assigned only to the authentication group that matches the event it detects:
```bash
<group name="syslog,sshd,">

  <rule id="99903" level="14">
    <if_sid>5715</if_sid>
    <list field="srcip" lookup="match_key">etc/lists/malicious-ioc/malicious-ip</list>
    <description>sshd: Authentication succeeded from a malicious IP address $(srcip).</description>
    <group>authentication_success,pci_dss_10.2.4,pci_dss_10.2.5,</group>
  </rule>

  <rule id="99904" level="9">
    <if_sid>5716</if_sid>
  <list field="srcip" lookup="match_key">etc/lists/malicious-ioc/malicious-ip</list>
    <description>sshd: Authentication failed from a malicious IP address $(srcip).</description>
    <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
  </rule>
</group>
```

# Description 
A FortiGate traffic log that should decode as `fortigate-firewall-v5` instead decodes as `fortigate-firewall-v6` whenever a free-text field before `logid=` (such as the device serial in `devid="..."`) contains the letter **L** or **l**. The trigger is the greedy quantifier `\.+` immediately before the literal `logid=` in the v5 prematch, combined with how the Wazuh regex engine (`os_regex`) handles greedy matching.

### Component
- Product: Wazuh Manager 4.14.5
- File: `ruleset/decoders/0100-fortigate_decoders.xml`
- Decoder: `fortigate-firewall-v5` (the `<prematch>`)
- Engine: `src/os_regex` (`os_regex_execute.c`, `os_regex_maps.c`)

### Current v5 prematch
```
date=\S+\.+time=\.+devname=\S+\.+devid=\p*FG\S+\.+logid=
```
 
# Symptom
A valid FortiOS 5.x traffic log is decoded as `fortigate-firewall-v6` instead of `fortigate-firewall-v5` when the `devid` serial (or any free-text field that the trailing `\.+` has to traverse before `logid=`) contains an `L` or `l`.
 
Reproduction with `wazuh-logtest -v`, identical logs differing by one character in the serial:
- `devid="123123123HaV"` --> decoder `fortigate-firewall-v5` (correct)
- `devid="123123123HLV"` --> decoder `fortigate-firewall-v6` (incorrect)
Sweeping that serial position through A–Z (and a–z) against the v5 prematch: **only `L` and `l` fail.** All 24 other letters match v5.
 
# Root cause
The failure is in the trailing `\.+logid=`, not in any character class. `os_regex` greedy quantifiers (`\.+`, `\S+`, `*`) do not do PCRE-style maximal munch with full backtracking. In `os_regex_execute.c`, while matching a quantified token the engine peeks at the *next* pattern token and stops the quantifier as soon as that next token can match the current input character. When the next token is a literal, the comparison is done
through the **case-insensitive** map:
 
```c
} else if (*next_pt == charmap[(uchar)*st]) {   // charmap folds upper->lower
    _regex_matched = 0;
    ok_here = 1;
}
```
 
So the `\.+` that is meant to bridge from the serial to `logid=` treats any `L`/`l` as a candidate stop point for `logid`'s leading `l`. The engine has only a small, fixed set of saved backtrack positions (`pt_error[4]` / `st_error`), not unlimited backtracking. A single stray early stop is recoverable in isolation, but across the chain of greedy segments in this prematch (`\S+\.+ … \S+\.+ … \S+\.+logid=`) the extra false stop introduced by the `L` derails the alignment beyond what the limited backtracking can repair, and the trailing `logid=` no longer matches. v5's prematch returns no-match, v6 is evaluated next, v6's prematch also matches the log, and v6 wins on order.
 
### Why it matters / scope
- FortiGate serials and other free-text fields routinely contain `L`/`l`, so this is not an edge case, a meaningful share of real devices will be silently misrouted v5 for v6.
- The same class of bug can bite any prematch of the form `…\.+<literal>` or `…\S+<literal>` where `<literal>` begins with a letter that can legitimately appear in the free text being skipped. The colliding letter is always the first character of the literal that follows the greedy quantifier (here `l` of `logid`).

### Suggested fix

I would suggest replacing the existing regex for the following and this into account for future decoder creation:
 
```
date=\S+\.+time=\.+devname=\S+\.+devid=\p*FG
```

# Approved by

DRI name:
- [X] Kasim Mustapha.

