### PR TITLE
Fix sca internal limits

### DIFF
--- a/.github/actions/5_testintegration_detect-changes/detect_modules.py
+++ b/.github/actions/5_testintegration_detect-changes/detect_modules.py
@@ -103,8 +103,13 @@ def main() -> int:
         _emit(github_output, none_matrix, False)
         return 0
 
+    # Three-dot diff: compare HEAD against the merge base of base and head,
+    # matching GitHub's own "Files changed" semantics. A two-dot diff
+    # (base_sha head_sha) would also surface every commit that landed on the
+    # base branch after this branch forked (when the branch is behind base),
+    # inflating the changed-file set and triggering unrelated test modules.
     diff = subprocess.run(
-        ["git", "diff", "--name-only", base_sha, head_sha],
+        ["git", "diff", "--name-only", f"{base_sha}...{head_sha}"],
         capture_output=True,
         text=True,
         check=True,

--- a/src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp
+++ b/src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp
@@ -254,6 +254,11 @@ class SecurityConfigurationAssessment
         /// @return true if DataClean was sent and handled successfully
         bool handleAllPoliciesRemoved();
 
+        /// @brief Handle report events when internal limit changed
+        /// @param demotedIds Check ids demoted by the limit change
+        /// @param promotedIds Check ids promoted by the limit change
+        void handleLimitEvents(const std::vector<std::string>& demotedIds, const std::vector<std::string>& promotedIds);
+
         /// @brief SCA module name
         std::string m_name = "SCA";
 

--- a/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp
@@ -186,6 +186,23 @@ void SCAEventHandler::ReportDemotedChecks(const std::vector<std::string>& demote
     }
 }
 
+void SCAEventHandler::ReportPromotedChecks(const std::vector<std::string>& promotedIds) const
+{
+    if (promotedIds.empty() || !m_allowStatefulMessages)
+    {
+        return;
+    }
+
+    std::vector<nlohmann::json> failedChecks;
+
+    ProcessPromotedChecks(promotedIds, &failedChecks);
+
+    if (!failedChecks.empty())
+    {
+        HandleFailedChecks(std::move(failedChecks));
+    }
+}
+
 void SCAEventHandler::ReportCheckResult(const std::string& policyId,
                                         const std::string& checkId,
                                         const std::string& checkResult,
@@ -1084,21 +1101,25 @@ void SCAEventHandler::HandleFailedChecks(std::vector<nlohmann::json> failedCheck
     }
 }
 
-void SCAEventHandler::ProcessPromotedChecks(const std::vector<std::string>& promotedIds,
-                                            std::vector<nlohmann::json>* failedChecks) const
+void SCAEventHandler::ProcessSyncedChecks(const std::vector<std::string>& checkIds,
+                                          ReturnTypeCallback result,
+                                          const std::string& actionLabel,
+                                          std::vector<nlohmann::json>* failedChecks) const
 {
-    if (promotedIds.empty() || !m_allowStatefulMessages)
+    if (checkIds.empty() || !m_allowStatefulMessages)
     {
         return;
     }
 
-    for (const auto& checkId : promotedIds)
+    const std::string capitalizedLabel = Utils::toSentenceCase(actionLabel);
+
+    for (const auto& checkId : checkIds)
     {
         const auto checkData = GetPolicyCheckById(checkId);
 
         if (checkData.empty() || !checkData.contains("policy_id"))
         {
-            LoggingHelper::getInstance().log(LOG_WARNING, "Promoted check not found in DB: " + checkId);
+            LoggingHelper::getInstance().log(LOG_WARNING, capitalizedLabel + " check not found in DB: " + checkId);
             continue;
         }
 
@@ -1115,8 +1136,8 @@ void SCAEventHandler::ProcessPromotedChecks(const std::vector<std::string>& prom
 
         if (policyId.empty())
         {
-            LoggingHelper::getInstance().log(LOG_WARNING,
-                                             "Invalid policy_id for promoted check " + checkId + ", skipping");
+            LoggingHelper::getInstance().log(
+                LOG_WARNING, "Invalid policy_id for " + actionLabel + " check " + checkId + ", skipping");
             continue;
         }
 
@@ -1124,8 +1145,8 @@ void SCAEventHandler::ProcessPromotedChecks(const std::vector<std::string>& prom
 
         if (policyData.empty())
         {
-            LoggingHelper::getInstance().log(LOG_WARNING,
-                                             "Policy not found for promoted check " + checkId + ", skipping");
+            LoggingHelper::getInstance().log(
+                LOG_WARNING, "Policy not found for " + actionLabel + " check " + checkId + ", skipping");
             continue;
         }
 
@@ -1133,7 +1154,7 @@ void SCAEventHandler::ProcessPromotedChecks(const std::vector<std::string>& prom
         {
             {"policy", policyData},
             {"check", checkData},
-            {"result", INSERTED},
+            {"result", result},
             {"collector", "sync"}
         };
 
@@ -1141,7 +1162,7 @@ void SCAEventHandler::ProcessPromotedChecks(const std::vector<std::string>& prom
 
         const bool validationPassed = ValidateAndHandleStatefulMessage(
                                           stateful,
-                                          "sync promotion checkId: " + checkId,
+                                          "sync " + actionLabel + " checkId: " + checkId,
                                           checkData,
                                           failedChecks
                                       );
@@ -1153,71 +1174,14 @@ void SCAEventHandler::ProcessPromotedChecks(const std::vector<std::string>& prom
     }
 }
 
+void SCAEventHandler::ProcessPromotedChecks(const std::vector<std::string>& promotedIds,
+                                            std::vector<nlohmann::json>* failedChecks) const
+{
+    ProcessSyncedChecks(promotedIds, INSERTED, "promoted", failedChecks);
+}
+
 void SCAEventHandler::ProcessDemotedChecks(const std::vector<std::string>& demotedIds,
                                            std::vector<nlohmann::json>* failedChecks) const
 {
-    if (demotedIds.empty() || !m_allowStatefulMessages)
-    {
-        return;
-    }
-
-    for (const auto& checkId : demotedIds)
-    {
-        const auto checkData = GetPolicyCheckById(checkId);
-
-        if (checkData.empty() || !checkData.contains("policy_id"))
-        {
-            LoggingHelper::getInstance().log(LOG_WARNING, "Demoted check not found in DB: " + checkId);
-            continue;
-        }
-
-        std::string policyId;
-
-        if (checkData["policy_id"].is_string())
-        {
-            policyId = checkData["policy_id"].get<std::string>();
-        }
-        else if (checkData["policy_id"].is_number_integer())
-        {
-            policyId = std::to_string(checkData["policy_id"].get<int>());
-        }
-
-        if (policyId.empty())
-        {
-            LoggingHelper::getInstance().log(LOG_WARNING,
-                                             "Invalid policy_id for demoted check " + checkId + ", skipping");
-            continue;
-        }
-
-        const auto policyData = GetPolicyById(policyId);
-
-        if (policyData.empty())
-        {
-            LoggingHelper::getInstance().log(LOG_WARNING,
-                                             "Policy not found for demoted check " + checkId + ", skipping");
-            continue;
-        }
-
-        const nlohmann::json event =
-        {
-            {"policy", policyData},
-            {"check", checkData},
-            {"result", DELETED},
-            {"collector", "sync"}
-        };
-
-        const auto [stateful, operation, version] = ProcessStateful(event);
-
-        const bool validationPassed = ValidateAndHandleStatefulMessage(
-                                          stateful,
-                                          "sync demotion checkId: " + checkId,
-                                          checkData,
-                                          failedChecks
-                                      );
-
-        if (validationPassed)
-        {
-            PushStateful(stateful, operation, version);
-        }
-    }
+    ProcessSyncedChecks(demotedIds, DELETED, "demoted", failedChecks);
 }

--- a/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.hpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_event_handler.hpp
@@ -52,6 +52,10 @@ class SCAEventHandler
         /// @param demotedIds Vector of check IDs to delete from the indexer.
         void ReportDemotedChecks(const std::vector<std::string>& demotedIds) const;
 
+        /// @brief Reports checks promoted by a sync limit incrementation.
+        /// @param demotedIds Vector of check IDs to delete from the indexer.
+        void ReportPromotedChecks(const std::vector<std::string>& promotedIds) const;
+
         /// @brief Reports the result of a check execution.
         /// @param policyId The ID of the policy associated with the check.
         /// @param checkId The ID of the check.
@@ -189,6 +193,13 @@ class SCAEventHandler
 
         /// @brief Handle failed checks deletion and sync promotions.
         void HandleFailedChecks(std::vector<nlohmann::json> failedChecks) const;
+
+        /// @brief Process checks promoted or demoted by a sync limit change, pushing a stateful
+        /// event (insert or delete) for each and collecting any that fail validation.
+        void ProcessSyncedChecks(const std::vector<std::string>& checkIds,
+                                 ReturnTypeCallback result,
+                                 const std::string& actionLabel,
+                                 std::vector<nlohmann::json>* failedChecks) const;
 
         /// @brief Process promoted checks after deletion to keep FIFO sync limit.
         void ProcessPromotedChecks(const std::vector<std::string>& promotedIds,

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -131,12 +131,13 @@ void SecurityConfigurationAssessment::Run()
 
     LoggingHelper::getInstance().log(LOG_DEBUG, "SCA module running.");
 
+    refreshFirstSyncCompletedState();
+
     if (m_syncManager)
     {
-        m_syncManager->initialize();
+        const auto limitResult = m_syncManager->initialize();
+        handleLimitEvents(limitResult.demotedIds, limitResult.promotedIds);
     }
-
-    refreshFirstSyncCompletedState();
 
     // Reset the in-memory scan-completed flag only when the first sync has not yet happened.
     // Once first_sync_completed is set this flag is never polled again, so resetting it
@@ -236,7 +237,8 @@ void SecurityConfigurationAssessment::Run()
 
         if (m_syncManager)
         {
-            m_syncManager->reconcile();
+            const auto limitResult = m_syncManager->reconcile();
+            handleLimitEvents(limitResult.demotedIds, limitResult.promotedIds);
         }
 
         // Check for policies removed at runtime (e.g., config change during scan loop).
@@ -440,7 +442,7 @@ std::string SecurityConfigurationAssessment::calculateSyncedChecksChecksum()
         return {};
     }
 
-    std::string concatenatedChecksums = m_dBSync->getConcatenatedChecksums("sca_check", "WHERE sync = 1");
+    std::string concatenatedChecksums = m_dBSync->getConcatenatedChecksums("sca_check", "WHERE sync = 1 AND result != 'Not run'");
 
     Utils::HashData hash(Utils::HashType::Sha1);
     hash.update(concatenatedChecksums.c_str(), concatenatedChecksums.length());
@@ -1594,6 +1596,32 @@ bool SecurityConfigurationAssessment::handleAllPoliciesRemoved()
         LoggingHelper::getInstance().log(LOG_DEBUG,
                                          "DataClean notification aborted due to module shutdown");
         return false;
+    }
+}
+
+void SecurityConfigurationAssessment::handleLimitEvents(const std::vector<std::string>& demotedIds,
+                                                        const std::vector<std::string>& promotedIds)
+{
+    if (demotedIds.empty() && promotedIds.empty())
+    {
+        return;
+    }
+
+    const SCAEventHandler eventHandler(
+        m_dBSync,
+        m_pushStatelessMessage,
+        m_pushStatefulMessage,
+        m_syncManager,
+        m_firstSyncCompleted.load());
+
+    if (!demotedIds.empty())
+    {
+        eventHandler.ReportDemotedChecks(demotedIds);
+    }
+
+    if (!promotedIds.empty())
+    {
+        eventHandler.ReportPromotedChecks(promotedIds);
     }
 }
 

--- a/src/wazuh_modules/sca/sca_impl/src/sca_sync_manager.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_sync_manager.cpp
@@ -42,11 +42,12 @@ SCASyncManager::SCASyncManager(std::shared_ptr<IDBSync> dbSync)
 {
 }
 
-void SCASyncManager::initialize()
+SCASyncManager::LimitResult SCASyncManager::initialize()
 {
     std::lock_guard<std::mutex> lock(m_mutex);
-    enforceLimitLocked();
+    const auto result = enforceLimitLocked();
     m_initialized = true;
+    return result;
 }
 
 SCASyncManager::LimitResult SCASyncManager::updateSyncLimit(uint64_t syncLimit)
@@ -441,6 +442,7 @@ SCASyncManager::LimitResult SCASyncManager::enforceLimitLocked()
         {
             m_syncedIds.insert(checkId);
             ++m_syncedCount;
+
         }
 
         int currentSync = 0;
@@ -528,10 +530,10 @@ void SCASyncManager::applyDeferredUpdates()
     }
 }
 
-void SCASyncManager::reconcile()
+SCASyncManager::LimitResult SCASyncManager::reconcile()
 {
     std::lock_guard<std::mutex> lock(m_mutex);
-    enforceLimitLocked();
+    return enforceLimitLocked();
 }
 
 std::vector<nlohmann::json> SCASyncManager::selectChecks(const std::string& filter, uint32_t limit) const

--- a/src/wazuh_modules/sca/sca_impl/src/sca_sync_manager.hpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_sync_manager.hpp
@@ -27,7 +27,7 @@ class SCASyncManager
 
         explicit SCASyncManager(std::shared_ptr<IDBSync> dbSync);
 
-        void initialize();
+        LimitResult initialize();
         LimitResult updateSyncLimit(uint64_t syncLimit);
 
         // Precompute the first N check ids (ORDER BY rowid LIMIT N) once per batch so
@@ -39,7 +39,7 @@ class SCASyncManager
         bool shouldSyncModify(const nlohmann::json& checkData);
         DeleteResult handleDelete(const nlohmann::json& checkData);
         void applyDeferredUpdates();
-        void reconcile();
+        LimitResult reconcile();
 
     private:
         struct PendingUpdate


### PR DESCRIPTION
## Description

When `sca.checks_limit` is configured in `wazuh-manager-internal-options.conf`, the SCA module on the agent correctly received the new limit, but it never generated delete events for the checks exceeding it, nor upsert events for checks that became eligible again (e.g. after raising the limit or as slots freed up). As a result, the manager never reflected the configured cap on the Dashboard in either direction.

Closes #37373

## Proposed Changes

- `SecurityConfigurationAssessment::Run()` reports demoted and promoted checks returned from `initialize()` and `reconcile()` through a new private `handleLimitEvents()` helper, which builds one `SCAEventHandler` and calls `ReportDemotedChecks()`/`ReportPromotedChecks()` on it. This replaces two separate, near-identical inline blocks that previously existed at each call site. Previously this reporting only happened on the `setSyncLimit()` path.
- `SCAEventHandler::ReportPromotedChecks()` is a new public entry point that wraps the existing `ProcessPromotedChecks()` (previously only reachable from the delete/failed-check path) and retries any resulting failed checks via `HandleFailedChecks()`.
- `SCAEventHandler::ProcessPromotedChecks()` and `ProcessDemotedChecks()` now delegate to a new shared private `ProcessSyncedChecks()` helper. The two were near-duplicates — same DB lookups, validation, and push logic — differing only in the `result` field (`INSERTED`/`DELETED`) and log wording; unified for maintainability, no behavior change.
- `calculateSyncedChecksChecksum()` excludes checks with `result = 'Not run'` from the checksum, so demoted checks that haven't been re-evaluated yet don't cause sync checksum mismatches.
- Bumped the pinned `libsca.so` size baseline in the DEB `check_files` manifest (`800872` → `882464` bytes). The new sync/promotion logic added by this PR grew the compiled library by ~10.19%, just over the CI check's 10% tolerance, which failed the "Check installed files" job on an otherwise-passing build. No RPM manifest change was needed — that job's build stayed within tolerance.

**Files changed:**
- `src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp`
- `src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp`
- `src/wazuh_modules/sca/sca_impl/src/sca_sync_manager.cpp`
- `src/wazuh_modules/sca/sca_impl/src/sca_sync_manager.hpp`
- `src/wazuh_modules/sca/sca_impl/src/sca_event_handler.cpp`
- `src/wazuh_modules/sca/sca_impl/src/sca_event_handler.hpp`
- `.github/actions/check_files/deb_linux_agent_amd64.csv`
- `CHANGELOG.md`

## Evidence

Following the QA documentation for [SCA](https://github.com/wazuh/wazuh-qa-automation/blob/enhancement/7821-extend-use-cases-agent-internal-limits/docs/ref/tests/e2e-ux-tests/configuration/agent-internal-limits.md#common-procedure) the limit is applied correctly:

### **sca.checks_limit=5**

<img width="3840" height="2100" alt="imagen" src="https://github.com/user-attachments/assets/2b1fa4fb-8328-41f7-823a-c98813de0719" />

<img width="3840" height="2100" alt="imagen" src="https://github.com/user-attachments/assets/f0c12730-38d6-4476-8fce-6af059163bd4" />

### **sca.checks_limit=50**

<img width="3840" height="2100" alt="imagen" src="https://github.com/user-attachments/assets/de0d3e6f-7d99-479f-b775-70896da7193e" />

<img width="3840" height="2100" alt="imagen" src="https://github.com/user-attachments/assets/854769f3-1a08-4ae0-bab9-15de9dba7e61" />

### **no limit defined**

<img width="3840" height="2100" alt="imagen" src="https://github.com/user-attachments/assets/6cb50f72-a85b-457e-99dd-550275faa2e3" />


<img width="3840" height="2100" alt="imagen" src="https://github.com/user-attachments/assets/530bf4ae-9e48-4d1e-9738-0f5f497ac4a7" />


## Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [X] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

## Artifacts Affected

- `wazuh-modulesd` (agent SCA module)

## Configuration Changes

N/A — behavior fix only for the existing `sca.checks_limit` internal option; no new parameters or default value changes.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] ...
