### PR TITLE
Warn on duplicate agent connection only when it persists

### DIFF
--- a/src/remoted/src/secure.c
+++ b/src/remoted/src/secure.c
@@ -691,8 +691,19 @@ STATIC void HandleSecureMessage(const message_t *message, w_indexed_queue_t * co
                     mdebug2("Idle socket [%d] from agent ID '%s' will be closed.", sock_idle, keys.keyentries[agentid]->id);
 
                     keys.keyentries[agentid]->rcvd = current_ts;
+                    keys.keyentries[agentid]->conflict_ts = 0;
                 } else {
-                    mwarn("Agent key already in use: agent ID '%s' (source IP: %s)", keys.keyentries[agentid]->id, srcip);
+                    // Warn only if the conflict outlives the overtake window: a reconnect self-heals,
+                    // a shared key does not.
+                    if (keys.keyentries[agentid]->conflict_ts == 0) {
+                        keys.keyentries[agentid]->conflict_ts = current_ts;
+                    }
+
+                    if ((logr.connection_overtake_time <= 0) || (current_ts - keys.keyentries[agentid]->conflict_ts) > logr.connection_overtake_time) {
+                        mwarn("Agent key already in use: agent ID '%s' (source IP: %s)", keys.keyentries[agentid]->id, srcip);
+                    } else {
+                        mdebug2("Agent ID '%s' reconnected from '%s' before its previous session was closed.", keys.keyentries[agentid]->id, srcip);
+                    }
 
                     w_mutex_unlock(&keys.keyentries[agentid]->mutex);
                     key_unlock();
@@ -748,8 +759,19 @@ STATIC void HandleSecureMessage(const message_t *message, w_indexed_queue_t * co
                     mdebug2("Idle socket [%d] from agent ID '%s' will be closed.", sock_idle, keys.keyentries[agentid]->id);
 
                     keys.keyentries[agentid]->rcvd = current_ts;
+                    keys.keyentries[agentid]->conflict_ts = 0;
                 } else {
-                    mwarn("Agent key already in use: agent ID '%s' (source IP: %s)", keys.keyentries[agentid]->id, srcip);
+                    // Warn only if the conflict outlives the overtake window: a reconnect self-heals,
+                    // a shared key does not.
+                    if (keys.keyentries[agentid]->conflict_ts == 0) {
+                        keys.keyentries[agentid]->conflict_ts = current_ts;
+                    }
+
+                    if ((logr.connection_overtake_time <= 0) || (current_ts - keys.keyentries[agentid]->conflict_ts) > logr.connection_overtake_time) {
+                        mwarn("Agent key already in use: agent ID '%s' (source IP: %s)", keys.keyentries[agentid]->id, srcip);
+                    } else {
+                        mdebug2("Agent ID '%s' reconnected from '%s' before its previous session was closed.", keys.keyentries[agentid]->id, srcip);
+                    }
 
                     w_mutex_unlock(&keys.keyentries[agentid]->mutex);
                     key_unlock();

--- a/src/shared/include/sec.h
+++ b/src/shared/include/sec.h
@@ -59,6 +59,7 @@ typedef struct _keyentry {
     int sock;                           ///< File descriptor of client's TCP socket
     _Atomic (int) net_protocol;         ///< Client current protocol
     time_t time_added;
+    time_t conflict_ts;                 ///< Start of a duplicate-connection conflict (0 if none)
     pthread_mutex_t mutex;
     struct sockaddr_storage peer_info;
     FILE *fp;

--- a/src/shared/os_crypto/shared/keys.c
+++ b/src/shared/os_crypto/shared/keys.c
@@ -728,6 +728,7 @@ int OS_DeleteSocket(keystore * keys, int sock) {
 
         if (sock == entry->sock) {
             entry->sock = -1;
+            entry->conflict_ts = 0; // Connection closed: clear conflict
         }
 
         w_mutex_unlock(&entry->mutex);

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -1084,10 +1084,13 @@ void test_HandleSecureMessage_different_sock(void** state)
     key->id = strdup("001");
     key->sock = 4;
     key->keyid = 1;
+    key->rcvd = 200;         // not idle, no overtake
+    key->conflict_ts = 100;  // conflict older than the window -> warn
 
     keys.keyentries[0] = key;
 
     global_counter = 0;
+    current_ts = 200;
 
     peer_info.sin_family = AF_INET;
     peer_info.sin_addr.s_addr = inet_addr("127.0.0.1");
@@ -1157,6 +1160,84 @@ void test_HandleSecureMessage_different_sock_2(void** state)
     key->id = strdup("001");
     key->sock = 4;
     key->keyid = 1;
+    key->rcvd = 200;         // not idle, no overtake
+    key->conflict_ts = 100;  // conflict older than the window -> warn
+
+    keys.keyentries[0] = key;
+
+    global_counter = 0;
+    current_ts = 200;
+
+    peer_info.sin_family = AF_INET;
+    peer_info.sin_addr.s_addr = inet_addr("127.0.0.1");
+    memcpy(&message.addr, &peer_info, sizeof(peer_info));
+
+    expect_function_call(__wrap_key_lock_read);
+
+    // OS_IsAllowedDynamicID
+    expect_string(__wrap_OS_IsAllowedIP, srcip, "127.0.0.1");
+    will_return(__wrap_OS_IsAllowedIP, 0);
+
+    expect_function_call(__wrap_key_unlock);
+
+    expect_string(__wrap__mwarn, formatted_msg, "Agent key already in use: agent ID '001' (source IP: 127.0.0.1)");
+
+    expect_function_call(__wrap_key_lock_read);
+
+    // OS_DeleteSocket
+    expect_value(__wrap_OS_DeleteSocket, sock, message.sock);
+    will_return(__wrap_OS_DeleteSocket, 0);
+
+    expect_function_call(__wrap_key_unlock);
+
+    will_return(__wrap_close, 0);
+
+    // nb_close
+    expect_value(__wrap_nb_close, sock, message.sock);
+    expect_value(__wrap_nb_close, sock, message.sock);
+    expect_function_call(__wrap_rem_dec_tcp);
+
+    // rem_setCounter
+    expect_value(__wrap_rem_setCounter, fd, 1);
+    expect_value(__wrap_rem_setCounter, counter, 0);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "TCP peer disconnected [1]");
+
+    expect_function_call(__wrap_rem_inc_recv_unknown);
+
+    HandleSecureMessage(&message, control_msg_queue, events_queue);
+
+    os_free(key->id);
+    os_free(key);
+    os_free(keyentries);
+    indexed_queue_free(control_msg_queue);
+    batch_queue_free(events_queue);
+}
+
+void test_HandleSecureMessage_conflict_first_seen(void** state)
+{
+    char buffer[OS_MAXSTR + 1] = "!12!";
+    message_t message = {.buffer = buffer, .size = 4, .sock = 1};
+    struct sockaddr_in peer_info;
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
+    w_rr_queue_t * events_queue = batch_queue_init(10);
+    batch_queue_set_dispose(events_queue, (void (*)(void *))dispose_evt_item);
+
+    logr.connection_overtake_time = 60;
+    current_ts = 100;
+
+    keyentry** keyentries;
+    os_calloc(1, sizeof(keyentry*), keyentries);
+    keys.keyentries = keyentries;
+
+    keyentry* key = NULL;
+    os_calloc(1, sizeof(keyentry), key);
+
+    key->id = strdup("001");
+    key->sock = 4;
+    key->keyid = 1;
+    key->rcvd = 100;        // not idle, no overtake
+    key->conflict_ts = 0;   // first conflict
 
     keys.keyentries[0] = key;
 
@@ -1169,8 +1250,87 @@ void test_HandleSecureMessage_different_sock_2(void** state)
     expect_function_call(__wrap_key_lock_read);
 
     // OS_IsAllowedDynamicID
-    expect_string(__wrap_OS_IsAllowedIP, srcip, "127.0.0.1");
-    will_return(__wrap_OS_IsAllowedIP, 0);
+    expect_string(__wrap_OS_IsAllowedDynamicID, id, "12");
+    expect_string(__wrap_OS_IsAllowedDynamicID, srcip, "127.0.0.1");
+    will_return(__wrap_OS_IsAllowedDynamicID, 0);
+
+    expect_function_call(__wrap_key_unlock);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Agent ID '001' reconnected from '127.0.0.1' before its previous session was closed.");
+
+    expect_function_call(__wrap_key_lock_read);
+
+    // OS_DeleteSocket
+    expect_value(__wrap_OS_DeleteSocket, sock, message.sock);
+    will_return(__wrap_OS_DeleteSocket, 0);
+
+    expect_function_call(__wrap_key_unlock);
+
+    will_return(__wrap_close, 0);
+
+    // nb_close
+    expect_value(__wrap_nb_close, sock, message.sock);
+    expect_value(__wrap_nb_close, sock, message.sock);
+    expect_function_call(__wrap_rem_dec_tcp);
+
+    // rem_setCounter
+    expect_value(__wrap_rem_setCounter, fd, 1);
+    expect_value(__wrap_rem_setCounter, counter, 0);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "TCP peer disconnected [1]");
+
+    expect_function_call(__wrap_rem_inc_recv_unknown);
+
+    HandleSecureMessage(&message, control_msg_queue, events_queue);
+
+    assert_int_equal(key->conflict_ts, 100); // conflict recorded
+
+    os_free(key->id);
+    os_free(key);
+    os_free(keyentries);
+    indexed_queue_free(control_msg_queue);
+    batch_queue_free(events_queue);
+}
+
+void test_HandleSecureMessage_conflict_persists(void** state)
+{
+    char buffer[OS_MAXSTR + 1] = "!12!";
+    message_t message = {.buffer = buffer, .size = 4, .sock = 1};
+    struct sockaddr_in peer_info;
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
+    w_rr_queue_t * events_queue = batch_queue_init(10);
+    batch_queue_set_dispose(events_queue, (void (*)(void *))dispose_evt_item);
+
+    logr.connection_overtake_time = 60;
+    current_ts = 200;
+
+    keyentry** keyentries;
+    os_calloc(1, sizeof(keyentry*), keyentries);
+    keys.keyentries = keyentries;
+
+    keyentry* key = NULL;
+    os_calloc(1, sizeof(keyentry), key);
+
+    key->id = strdup("001");
+    key->sock = 4;
+    key->keyid = 1;
+    key->rcvd = 200;         // not idle, no overtake
+    key->conflict_ts = 100;  // conflict older than the window -> warn
+
+    keys.keyentries[0] = key;
+
+    global_counter = 0;
+
+    peer_info.sin_family = AF_INET;
+    peer_info.sin_addr.s_addr = inet_addr("127.0.0.1");
+    memcpy(&message.addr, &peer_info, sizeof(peer_info));
+
+    expect_function_call(__wrap_key_lock_read);
+
+    // OS_IsAllowedDynamicID
+    expect_string(__wrap_OS_IsAllowedDynamicID, id, "12");
+    expect_string(__wrap_OS_IsAllowedDynamicID, srcip, "127.0.0.1");
+    will_return(__wrap_OS_IsAllowedDynamicID, 0);
 
     expect_function_call(__wrap_key_unlock);
 
@@ -3343,6 +3503,8 @@ int main(void)
         cmocka_unit_test(test_HandleSecureMessage_OldMessage_NoShutdownMessage),
         cmocka_unit_test(test_HandleSecureMessage_different_sock),
         cmocka_unit_test(test_HandleSecureMessage_different_sock_2),
+        cmocka_unit_test(test_HandleSecureMessage_conflict_first_seen),
+        cmocka_unit_test(test_HandleSecureMessage_conflict_persists),
         cmocka_unit_test(test_HandleSecureMessage_close_idle_sock),
         cmocka_unit_test(test_HandleSecureMessage_close_idle_sock_2),
         cmocka_unit_test(test_HandleSecureMessage_close_idle_sock_disabled),


### PR DESCRIPTION
## Description

In a fresh single-agent environment `wazuh-remoted` logs:

```
wazuh-remoted: WARNING: Agent key already in use: agent ID '001' (source IP: 192.168.1.4)
```

even though only one agent exists. Resolves #37408.

### Root cause

The warning is emitted in `HandleSecureMessage` (`src/remoted/src/secure.c`) when an agent presents a **second TCP connection** while the manager still holds the previous one (`keyentries[agentid]->sock >= 0`, different from the incoming socket) and the previous session has been active within `connection_overtake_time` (default 60s), so the idle-socket overtake path does not trigger.

This is hit on any **ungraceful reconnect** where the old socket has not been reaped yet: agent restart, VM/container stop, or a network drop that swallows the FIN/RST. It is common right after deployment. The condition self-heals within `connection_overtake_time`, but the warning reads like a shared-key / security incident when it is just the same agent reconnecting.

### Why not compare the source IP

Comparing the new connection's IP against the previous session's IP does **not** prove "same agent": two different hosts sharing the same key behind the same NAT egress present the same visible IP (and ephemeral source ports differ for a legit reconnect too). There is no reliable per-connection identity available before decryption. Keying the decision on IP would silence a genuine shared-key warning in the NAT case.

### Fix

Use the one reliable discriminator: **behavior over time**.

- A same-agent reconnect self-heals: the dead socket goes idle and is reaped by the overtake path, so the conflict clears within `connection_overtake_time`.
- A genuinely shared key keeps the previous socket alive (its `rcvd` stays fresh), so the conflict **never** clears.

Track when the duplicate-connection episode started (`conflict_ts`, new field in `keyentry`):

- While the conflict has lasted `<= connection_overtake_time` → log at **debug** (a reconnect that will self-heal).
- Once it outlives that window → **warning** (the previous session is still active = real key reuse).
- With `connection_overtake_time = 0` (overtake disabled) the previous behavior is kept: warn immediately.

`conflict_ts` is reset when the socket is overtaken (`secure.c`) or closed (`OS_DeleteSocket`). Connection handling is unchanged: the new socket is still closed and the overtake mechanism still reaps the old one. This is IP-independent, so it preserves the shared-key warning behind NAT.

### Tests

- `test_HandleSecureMessage_conflict_first_seen`: first conflict within the window → debug, no warning; asserts the episode is recorded.
- `test_HandleSecureMessage_conflict_persists`: conflict older than the window → warning.
- `test_HandleSecureMessage_different_sock` / `_2`: updated to exercise the persistent (warning) path.
- The `connection_overtake_time = 0` cases keep asserting the immediate warning.