### PR TITLE
Adds AR Windows binary extension fallback

### DIFF
--- a/src/os_execd/src/execd.c
+++ b/src/os_execd/src/execd.c
@@ -260,7 +260,13 @@ void ExecdRun(char *exec_msg, int *childcount)
 
     /* Build full command path */
     static char cmd_path[OS_FLSIZE];
+#ifdef WIN32
+    size_t name_len = strlen(name);
+    const char *exe_suffix = (name_len >= 4 && strcasecmp(name + name_len - 4, ".exe") == 0) ? "" : ".exe";
+    if (snprintf(cmd_path, sizeof(cmd_path), "%s/%s%s", AR_BINDIR, name, exe_suffix) >= (int)sizeof(cmd_path)) {
+#else
     if (snprintf(cmd_path, sizeof(cmd_path), "%s/%s", AR_BINDIR, name) >= (int)sizeof(cmd_path)) {
+#endif
         merror("Active response command path too long for '%s'. Ignoring.", name);
         cJSON_Delete(json_root);
         return;

--- a/src/os_execd/src/execd.c
+++ b/src/os_execd/src/execd.c
@@ -261,8 +261,7 @@ void ExecdRun(char *exec_msg, int *childcount)
     /* Build full command path */
     static char cmd_path[OS_FLSIZE];
 #ifdef WIN32
-    size_t name_len = strlen(name);
-    const char *exe_suffix = (name_len >= 4 && strcasecmp(name + name_len - 4, ".exe") == 0) ? "" : ".exe";
+    const char *exe_suffix = strchr(name, '.') ? "" : ".exe";
     if (snprintf(cmd_path, sizeof(cmd_path), "%s/%s%s", AR_BINDIR, name, exe_suffix) >= (int)sizeof(cmd_path)) {
 #else
     if (snprintf(cmd_path, sizeof(cmd_path), "%s/%s", AR_BINDIR, name) >= (int)sizeof(cmd_path)) {

--- a/src/os_execd/src/execd.c
+++ b/src/os_execd/src/execd.c
@@ -262,10 +262,10 @@ void ExecdRun(char *exec_msg, int *childcount)
     static char cmd_path[OS_FLSIZE];
 #ifdef WIN32
     const char *exe_suffix = strchr(name, '.') ? "" : ".exe";
-    if (snprintf(cmd_path, sizeof(cmd_path), "%s/%s%s", AR_BINDIR, name, exe_suffix) >= (int)sizeof(cmd_path)) {
 #else
-    if (snprintf(cmd_path, sizeof(cmd_path), "%s/%s", AR_BINDIR, name) >= (int)sizeof(cmd_path)) {
+    const char *exe_suffix = "";
 #endif
+    if (snprintf(cmd_path, sizeof(cmd_path), "%s/%s%s", AR_BINDIR, name, exe_suffix) >= (int)sizeof(cmd_path)) {
         merror("Active response command path too long for '%s'. Ignoring.", name);
         cJSON_Delete(json_root);
         return;

--- a/src/unit_tests/os_execd/test_win_execd.c
+++ b/src/unit_tests/os_execd/test_win_execd.c
@@ -61,9 +61,9 @@ static int test_setup_file_timeout(void **state) {
     timeout_data *timeout_entry;
     os_calloc(1, sizeof(timeout_data), timeout_entry);
     os_calloc(2, sizeof(char *), timeout_entry->command);
-    os_strdup(AR_BINDIR "/block-ip", timeout_entry->command[0]);
+    os_strdup(AR_BINDIR "/block-ip.exe", timeout_entry->command[0]);
     timeout_entry->command[1] = NULL;
-    os_strdup("block-ip-10.0.0.1-root", timeout_entry->rkey);
+    os_strdup("block-ip.exe-10.0.0.1-root", timeout_entry->rkey);
     timeout_entry->time_of_addition = 123456789;
     timeout_entry->time_to_block = 10;
     OSList_AddData(timeout_list, timeout_entry);
@@ -106,10 +106,10 @@ static void test_WinExecdRun_ok(void **state) {
                         "}"
                     "}";
 
-    expect_wfopen(AR_BINDIR "/block-ip", "r", (FILE *)1);
+    expect_wfopen(AR_BINDIR "/block-ip.exe", "r", (FILE *)1);
     expect_fclose((FILE *)1, 0);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Executing command '" AR_BINDIR "/block-ip {"
+    expect_string(__wrap__mdebug1, formatted_msg, "Executing command '" AR_BINDIR "/block-ip.exe {"
                                                                                         "\"wazuh\":{"
                                                                                             "\"active_response\":{"
                                                                                                 "\"name\":\"block-ip\","
@@ -229,10 +229,10 @@ static void test_WinExecdRun_timeout_not_repeated(void **state) {
                         "}"
                     "}";
 
-    expect_wfopen(AR_BINDIR "/block-ip", "r", (FILE *)1);
+    expect_wfopen(AR_BINDIR "/block-ip.exe", "r", (FILE *)1);
     expect_fclose((FILE *)1, 0);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Executing command '" AR_BINDIR "/block-ip {"
+    expect_string(__wrap__mdebug1, formatted_msg, "Executing command '" AR_BINDIR "/block-ip.exe {"
                                                                                         "\"wazuh\":{"
                                                                                             "\"active_response\":{"
                                                                                                 "\"name\":\"block-ip\","
@@ -325,7 +325,7 @@ static void test_WinExecdRun_timeout_not_repeated(void **state) {
 
     will_return(__wrap_wpclose, 0);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Adding command '" AR_BINDIR "/block-ip {"
+    expect_string(__wrap__mdebug1, formatted_msg, "Adding command '" AR_BINDIR "/block-ip.exe {"
                                                                                         "\"wazuh\":{"
                                                                                             "\"active_response\":{"
                                                                                                 "\"name\":\"block-ip\","
@@ -379,10 +379,10 @@ static void test_WinExecdRun_timeout_repeated(void **state) {
                         "}"
                     "}";
 
-    expect_wfopen(AR_BINDIR "/block-ip", "r", (FILE *)1);
+    expect_wfopen(AR_BINDIR "/block-ip.exe", "r", (FILE *)1);
     expect_fclose((FILE *)1, 0);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Executing command '" AR_BINDIR "/block-ip {"
+    expect_string(__wrap__mdebug1, formatted_msg, "Executing command '" AR_BINDIR "/block-ip.exe {"
                                                                                         "\"wazuh\":{"
                                                                                             "\"active_response\":{"
                                                                                                 "\"name\":\"block-ip\","
@@ -506,10 +506,10 @@ static void test_WinExecdRun_wpopenv_err(void **state) {
                         "}"
                     "}";
 
-    expect_wfopen(AR_BINDIR "/block-ip", "r", (FILE *)1);
+    expect_wfopen(AR_BINDIR "/block-ip.exe", "r", (FILE *)1);
     expect_fclose((FILE *)1, 0);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Executing command '" AR_BINDIR "/block-ip {"
+    expect_string(__wrap__mdebug1, formatted_msg, "Executing command '" AR_BINDIR "/block-ip.exe {"
                                                                                             "\"wazuh\":{"
                                                                                                 "\"active_response\":{"
                                                                                                     "\"name\":\"block-ip\","
@@ -565,10 +565,10 @@ static void test_WinExecdRun_fgets_err(void **state) {
                         "}"
                     "}";
 
-    expect_wfopen(AR_BINDIR "/block-ip", "r", (FILE *)1);
+    expect_wfopen(AR_BINDIR "/block-ip.exe", "r", (FILE *)1);
     expect_fclose((FILE *)1, 0);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Executing command '" AR_BINDIR "/block-ip {"
+    expect_string(__wrap__mdebug1, formatted_msg, "Executing command '" AR_BINDIR "/block-ip.exe {"
                                                                                         "\"wazuh\":{"
                                                                                             "\"active_response\":{"
                                                                                                 "\"name\":\"block-ip\","
@@ -621,7 +621,7 @@ static void test_WinExecdRun_fgets_err(void **state) {
     expect_value(wrap_fgets, __stream, wfd->file_out);
     will_return(wrap_fgets, NULL);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "Active response won't be added to timeout list. Message not received with alert keys from script '" AR_BINDIR "/block-ip'");
+    expect_string(__wrap__mdebug1, formatted_msg, "Active response won't be added to timeout list. Message not received with alert keys from script '" AR_BINDIR "/block-ip.exe'");
 
     will_return(__wrap_wpclose, 0);
 
@@ -654,7 +654,7 @@ static void test_WinExecdRun_get_command_err(void **state) {
                         "}"
                     "}";
 
-    expect_wfopen(AR_BINDIR "/block-ip", "r", NULL);
+    expect_wfopen(AR_BINDIR "/block-ip.exe", "r", NULL);
 
     expect_string(__wrap__merror, formatted_msg, "(1311): Invalid command name 'block-ip' provided.");
 

--- a/src/unit_tests/os_execd/test_win_execd.c
+++ b/src/unit_tests/os_execd/test_win_execd.c
@@ -661,6 +661,74 @@ static void test_WinExecdRun_get_command_err(void **state) {
     ExecdRun(message);
 }
 
+static void test_WinExecdRun_custom_ar_no_extension_appends_exe(void **state) {
+    wfd_t * wfd = *state;
+    int queue = 1;
+    int now = 123456789;
+    char *message = "{"
+                        "\"wazuh\":{"
+                            "\"active_response\":{"
+                                "\"name\":\"custom-ar\","
+                                "\"executable\":\"custom-ar\","
+                                "\"type\":\"stateless\","
+                                "\"location\":\"agent\","
+                                "\"agent_id\":\"001\""
+                            "}"
+                        "},"
+                        "\"event\":{"
+                            "\"original\":\"Test event\","
+                            "\"kind\":\"event\""
+                        "},"
+                        "\"source\":{"
+                            "\"ip\":\"10.0.0.1\""
+                        "},"
+                        "\"user\":{"
+                            "\"name\":\"root\""
+                        "}"
+                    "}";
+
+    /* A custom AR name with no extension should still get '.exe' appended, just like block-ip */
+    expect_wfopen(AR_BINDIR "/custom-ar.exe", "r", NULL);
+
+    expect_string(__wrap__merror, formatted_msg, "(1311): Invalid command name 'custom-ar' provided.");
+
+    ExecdRun(message);
+}
+
+static void test_WinExecdRun_custom_ar_with_extension_not_duplicated(void **state) {
+    wfd_t * wfd = *state;
+    int queue = 1;
+    int now = 123456789;
+    char *message = "{"
+                        "\"wazuh\":{"
+                            "\"active_response\":{"
+                                "\"name\":\"custom-ar\","
+                                "\"executable\":\"custom-ar.bat\","
+                                "\"type\":\"stateless\","
+                                "\"location\":\"agent\","
+                                "\"agent_id\":\"001\""
+                            "}"
+                        "},"
+                        "\"event\":{"
+                            "\"original\":\"Test event\","
+                            "\"kind\":\"event\""
+                        "},"
+                        "\"source\":{"
+                            "\"ip\":\"10.0.0.1\""
+                        "},"
+                        "\"user\":{"
+                            "\"name\":\"root\""
+                        "}"
+                    "}";
+
+    /* A custom AR name that already has a non-.exe extension must not be suffixed again */
+    expect_wfopen(AR_BINDIR "/custom-ar.bat", "r", NULL);
+
+    expect_string(__wrap__merror, formatted_msg, "(1311): Invalid command name 'custom-ar.bat' provided.");
+
+    ExecdRun(message);
+}
+
 static void test_WinExecdRun_get_name_err(void **state) {
     wfd_t * wfd = *state;
     int queue = 1;
@@ -693,6 +761,8 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_WinExecdRun_wpopenv_err, test_setup_file, test_teardown_file),
         cmocka_unit_test_setup_teardown(test_WinExecdRun_fgets_err, test_setup_file, test_teardown_file),
         cmocka_unit_test_setup_teardown(test_WinExecdRun_get_command_err, test_setup_file, test_teardown_file),
+        cmocka_unit_test_setup_teardown(test_WinExecdRun_custom_ar_no_extension_appends_exe, test_setup_file, test_teardown_file),
+        cmocka_unit_test_setup_teardown(test_WinExecdRun_custom_ar_with_extension_not_duplicated, test_setup_file, test_teardown_file),
         cmocka_unit_test_setup_teardown(test_WinExecdRun_get_name_err, test_setup_file, test_teardown_file),
         cmocka_unit_test_setup_teardown(test_WinExecdRun_json_err, test_setup_file, test_teardown_file),
     };


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

Closes #37387

On Windows, the block-ip active response runs but never actually blocks the IP, and active-responses.log stays empty. execd resolves the AR executable path by joining the binaries folder with the executable name taken from the manager JSON (e.g. block-ip). On Linux/macOS the installed binary matches that name exactly, but on Windows the installed file is block-ip.exe. Since execd opens the path directly with wfopen (plain file I/O, no PATHEXT resolution like cmd.exe does), the lookup fails, execd logs EXEC_INV_NAME and never starts the binary.

## Proposed Changes

- In `ExecdRun` (`src/os_execd/src/execd.c`), when building `cmd_path` from `AR_BINDIR` and the AR executable name, append a `.exe` suffix on Windows builds **only when the executable name has no extension** — i.e. it contains no `.` (checked with `strchr(name, '.')`). If the name already carries an extension (`.exe`, `.cmd`, `.bat`, `.ps1`, …) it is used as-is, so `.exe` is never duplicated and non-`.exe` executables/scripts are respected. Non-Windows builds are unaffected — the path is built exactly as before.
- The fix is applied where the path is constructed, so the existing single `wfopen` existence check and error handling are unchanged.

### Results and Evidence

#### Before fix

<details><summary>ossec.log</summary>

```log
2026/07/14 20:30:04 wazuh-agent[4828] execd.c:643 at win_exec_main(): DEBUG: Received message: '{"@timestamp": "2026-07-14T20:27:54.274Z", "event": {"original": "<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Security-Auditing' Guid='{54849625-5478-4994-a5ba-3e3b0328c30d}'/><EventID>4624</EventID><Version>2</Version><Level>0</Level><Task>12544</Task><Opcode>0</Opcode><Keywords>0x8020000000000000</Keywords><TimeCreated SystemTime='2026-07-14T20:27:52.3111157Z'/><EventRecordID>1028534</EventRecordID><Correlation ActivityID='{285fc1ef-13cb-0002-0fc2-5f28cb13dd01}'/><Execution ProcessID='736' ThreadID='784'/><Channel>Security</Channel><Computer>vm-win2022</Computer><Security/></System><EventData><Data Name='SubjectUserSid'>S-1-0-0</Data><Data Name='SubjectUserName'>-</Data><Data Name='SubjectDomainName'>-</Data><Data Name='SubjectLogonId'>0x0</Data><Data Name='TargetUserSid'>S-1-5-21-1673099515-2324581457-255951991-1000</Data><Data Name='TargetUserName'>vagrant</Data><Data Name='TargetDomainName'>VM-WIN2022</Data><Data Name='TargetLogonId'>0x760537</Data><Data Name='LogonType'>3</Data><Data Name='LogonProcessName'>NtLmSsp </Data><Data Name='AuthenticationPackageName'>NTLM</Data><Data Name='WorkstationName'>VM-WIN2025</Data><Data Name='LogonGuid'>{00000000-0000-0000-0000-000000000000}</Data><Data Name='TransmittedServices'>-</Data><Data Name='LmPackageName'>NTLM V2</Data><Data Name='KeyLength'>128</Data><Data Name='ProcessId'>0x0</Data><Data Name='ProcessName'>-</Data><Data Name='IpAddress'>192.168.56.80</Data><Data Name='IpPort'>57083</Data><Data Name='ImpersonationLevel'>%%1833</Data><Data Name='RestrictedAdminMode'>-</Data><Data Name='TargetOutboundUserName'>-</Data><Data Name='TargetOutboundDomainName'>-</Data><Data Name='VirtualAccount'>%%1843</Data><Data Name='TargetLinkedLogonId'>0x0</Data><Data Name='ElevatedToken'>%%1842</Data></EventData></Event>", "code": "4624", "kind": "event", "start": "2026-07-14T20:27:52.3111157Z", "action": "logged-in", "index": ".ds-wazuh-events-v5-system-activity-000001", "type": ["start"], "category": ["authentication"], "dataset": "security", "doc_id": "1eVQYp8B4U2O_vadlcCG", "outcome": "success"}, "wazuh": {"cluster": {"node": "node01", "name": "wazuh"}, "protocol": {"location": "EventChannel", "queue": 102}, "agent": {"host": {"hostname": "VM-WIN2022", "os": {"name": "Microsoft Windows Server 2022 Standard", "type": "windows", "version": "10.0.20348.1906", "platform": "windows"}, "architecture": "x86_64"}, "name": "vm-win2022", "groups": ["default"], "id": "001", "version": "v5.0.0"}, "integration": {"name": "windows", "decoders": ["decoder/core-wazuh-message/0", "decoder/windows-event/0", "decoder/windows-security/0"], "category": "system-activity"}, "rule": {"sigma_id": "3519cfd5-c5e6-445e-860d-cf1dd42703a6", "level": "informational", "compliance": {"iso_27001": ["A.9.2.1", "A.12.4.1"], "hipaa": ["164.308.a.1.ii.D", "164.312.a.2.i", "164.312.b"], "pci_dss": ["8.2", "10.2"], "tsc": ["CC6.1", "CC7.2"], "nis2": ["21.2.a"], "nist_800_171": ["3.1.1", "3.3.1"], "fedramp": ["AC-2", "AU-2"], "nist_800_53": ["AC-2", "AU-2"], "cmmc": ["AC.L2-3.1.1", "AU.L2-3.3.1"], "gdpr": ["IV_32.1.a", "IV_33.1", "IV_34.1", "V_5.1.f"]}, "mitre": {"technique": {"name": ["Valid Accounts"], "id": ["T1078"]}, "tactic": {"name": ["Initial Access"], "id": ["TA0001"]}}, "id": "3519cfd5-c5e6-445e-860d-cf1dd42703a6", "title": "Successful user authentication - vagrant", "tags": ["informational", "wazuh-generic", "attack.initial-access", "attack.t1078"], "status": "stable"}, "event": {"id": "0776c63c-fad9-4317-96f1-ef7e9a9fd8a6"}, "space": {"name": "standard"}, "active_response": {"name": "Block-IP-stateful-response", "type": "stateful", "stateful_timeout": 120, "executable": "block-ip", "extra_arguments": null, "location": "local", "agent_id": null}}, "process": {"name": "-", "pid": 0, "executable": "-"}, "related": {"ip": ["192.168.56.80"], "user": ["vagrant"]}, "log": {"level": "information"}, "host": {"name": "vm-win2022"}, "source": {"ip": "192.168.56.80", "domain": "VM-WIN2025"}, "message": "An account was successfully logged on", "user": {"domain": "-", "name": "vagrant", "id": "S-1-0-0", "target": {"domain": "VM-WIN2022", "name": "vagrant", "id": "S-1-5-21-1673099515-2324581457-255951991-1000"}}}'
2026/07/14 20:30:04 wazuh-agent[4828] execd.c:273 at ExecdRun(): ERROR: (1311): Invalid command name 'block-ip' provided.
```

</details> 

#### After fix

<details><summary>ossec.log</summary>

```log
2026/07/14 20:50:10 wazuh-agent[4744] execd.c:648 at win_exec_main(): DEBUG: Received message: '{"@timestamp": "2026-07-14T20:48:00.127Z", "event": {"original": "<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Security-Auditing' Guid='{54849625-5478-4994-a5ba-3e3b0328c30d}'/><EventID>4624</EventID><Version>2</Version><Level>0</Level><Task>12544</Task><Opcode>0</Opcode><Keywords>0x8020000000000000</Keywords><TimeCreated SystemTime='2026-07-14T20:47:57.6125733Z'/><EventRecordID>1033340</EventRecordID><Correlation ActivityID='{285fc1ef-13cb-0002-0fc2-5f28cb13dd01}'/><Execution ProcessID='736' ThreadID='3024'/><Channel>Security</Channel><Computer>vm-win2022</Computer><Security/></System><EventData><Data Name='SubjectUserSid'>S-1-0-0</Data><Data Name='SubjectUserName'>-</Data><Data Name='SubjectDomainName'>-</Data><Data Name='SubjectLogonId'>0x0</Data><Data Name='TargetUserSid'>S-1-5-21-1673099515-2324581457-255951991-1000</Data><Data Name='TargetUserName'>vagrant</Data><Data Name='TargetDomainName'>VM-WIN2022</Data><Data Name='TargetLogonId'>0x8eb8f3</Data><Data Name='LogonType'>3</Data><Data Name='LogonProcessName'>NtLmSsp </Data><Data Name='AuthenticationPackageName'>NTLM</Data><Data Name='WorkstationName'>VM-WIN2025</Data><Data Name='LogonGuid'>{00000000-0000-0000-0000-000000000000}</Data><Data Name='TransmittedServices'>-</Data><Data Name='LmPackageName'>NTLM V2</Data><Data Name='KeyLength'>128</Data><Data Name='ProcessId'>0x0</Data><Data Name='ProcessName'>-</Data><Data Name='IpAddress'>192.168.56.80</Data><Data Name='IpPort'>57170</Data><Data Name='ImpersonationLevel'>%%1833</Data><Data Name='RestrictedAdminMode'>-</Data><Data Name='TargetOutboundUserName'>-</Data><Data Name='TargetOutboundDomainName'>-</Data><Data Name='VirtualAccount'>%%1843</Data><Data Name='TargetLinkedLogonId'>0x0</Data><Data Name='ElevatedToken'>%%1842</Data></EventData></Event>", "code": "4624", "kind": "event", "start": "2026-07-14T20:47:57.6125733Z", "action": "logged-in", "index": ".ds-wazuh-events-v5-system-activity-000001", "type": ["start"], "category": ["authentication"], "dataset": "security", "doc_id": "n-VjYp8B4U2O_vadNcHR", "outcome": "success"}, "wazuh": {"cluster": {"node": "node01", "name": "wazuh"}, "protocol": {"location": "EventChannel", "queue": 102}, "agent": {"host": {"hostname": "VM-WIN2022", "os": {"name": "Microsoft Windows Server 2022 Standard", "type": "windows", "version": "10.0.20348.1906", "platform": "windows"}, "architecture": "x86_64"}, "name": "vm-win2022", "groups": ["default"], "id": "002", "version": "v5.0.0"}, "integration": {"name": "windows", "decoders": ["decoder/core-wazuh-message/0", "decoder/windows-event/0", "decoder/windows-security/0"], "category": "system-activity"}, "rule": {"sigma_id": "3519cfd5-c5e6-445e-860d-cf1dd42703a6", "level": "informational", "compliance": {"iso_27001": ["A.9.2.1", "A.12.4.1"], "hipaa": ["164.308.a.1.ii.D", "164.312.a.2.i", "164.312.b"], "pci_dss": ["8.2", "10.2"], "tsc": ["CC6.1", "CC7.2"], "nis2": ["21.2.a"], "nist_800_171": ["3.1.1", "3.3.1"], "fedramp": ["AC-2", "AU-2"], "nist_800_53": ["AC-2", "AU-2"], "cmmc": ["AC.L2-3.1.1", "AU.L2-3.3.1"], "gdpr": ["IV_32.1.a", "IV_33.1", "IV_34.1", "V_5.1.f"]}, "mitre": {"technique": {"name": ["Valid Accounts"], "id": ["T1078"]}, "tactic": {"name": ["Initial Access"], "id": ["TA0001"]}}, "id": "3519cfd5-c5e6-445e-860d-cf1dd42703a6", "title": "Successful user authentication - vagrant", "tags": ["informational", "wazuh-generic", "attack.initial-access", "attack.t1078"], "status": "stable"}, "event": {"id": "ee9ca859-5002-4ba8-84bf-a021365630d2"}, "space": {"name": "standard"}, "active_response": {"name": "Block-IP-stateful-response", "type": "stateful", "stateful_timeout": 120, "executable": "block-ip", "extra_arguments": null, "location": "local", "agent_id": null}}, "process": {"name": "-", "pid": 0, "executable": "-"}, "related": {"ip": ["192.168.56.80"], "user": ["vagrant"]}, "log": {"level": "information"}, "host": {"name": "vm-win2022"}, "source": {"ip": "192.168.56.80", "domain": "VM-WIN2025"}, "message": "An account was successfully logged on", "user": {"domain": "-", "name": "vagrant", "id": "S-1-0-0", "target": {"domain": "VM-WIN2022", "name": "vagrant", "id": "S-1-5-21-1673099515-2324581457-255951991-1000"}}}'
2026/07/14 20:50:10 wazuh-agent[4744] execd.c:303 at ExecdRun(): DEBUG: Executing command 'active-response/bin/block-ip.exe {"@timestamp":"2026-07-14T20:48:00.127Z","event":{"original":"<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Security-Auditing' Guid='{54849625-5478-4994-a5ba-3e3b0328c30d}'/><EventID>4624</EventID><Version>2</Version><Level>0</Level><Task>12544</Task><Opcode>0</Opcode><Keywords>0x8020000000000000</Keywords><TimeCreated SystemTime='2026-07-14T20:47:57.6125733Z'/><EventRecordID>1033340</EventRecordID><Correlation ActivityID='{285fc1ef-13cb-0002-0fc2-5f28cb13dd01}'/><Execution ProcessID='736' ThreadID='3024'/><Channel>Security</Channel><Computer>vm-win2022</Computer><Security/></System><EventData><Data Name='SubjectUserSid'>S-1-0-0</Data><Data Name='SubjectUserName'>-</Data><Data Name='SubjectDomainName'>-</Data><Data Name='SubjectLogonId'>0x0</Data><Data Name='TargetUserSid'>S-1-5-21-1673099515-2324581457-255951991-1000</Data><Data Name='TargetUserName'>vagrant</Data><Data Name='TargetDomainName'>VM-WIN2022</Data><Data Name='TargetLogonId'>0x8eb8f3</Data><Data Name='LogonType'>3</Data><Data Name='LogonProcessName'>NtLmSsp </Data><Data Name='AuthenticationPackageName'>NTLM</Data><Data Name='WorkstationName'>VM-WIN2025</Data><Data Name='LogonGuid'>{00000000-0000-0000-0000-000000000000}</Data><Data Name='TransmittedServices'>-</Data><Data Name='LmPackageName'>NTLM V2</Data><Data Name='KeyLength'>128</Data><Data Name='ProcessId'>0x0</Data><Data Name='ProcessName'>-</Data><Data Name='IpAddress'>192.168.56.80</Data><Data Name='IpPort'>57170</Data><Data Name='ImpersonationLevel'>%%1833</Data><Data Name='RestrictedAdminMode'>-</Data><Data Name='TargetOutboundUserName'>-</Data><Data Name='TargetOutboundDomainName'>-</Data><Data Name='VirtualAccount'>%%1843</Data><Data Name='TargetLinkedLogonId'>0x0</Data><Data Name='ElevatedToken'>%%1842</Data></EventData></Event>","code":"4624","kind":"event","start":"2026-07-14T20:47:57.6125733Z","action":"logged-in","index":".ds-wazuh-events-v5-system-activity-000001","type":["start"],"category":["authentication"],"dataset":"security","doc_id":"n-VjYp8B4U2O_vadNcHR","outcome":"success"},"wazuh":{"cluster":{"node":"node01","name":"wazuh"},"protocol":{"location":"EventChannel","queue":102},"agent":{"host":{"hostname":"VM-WIN2022","os":{"name":"Microsoft Windows Server 2022 Standard","type":"windows","version":"10.0.20348.1906","platform":"windows"},"architecture":"x86_64"},"name":"vm-win2022","groups":["default"],"id":"002","version":"v5.0.0"},"integration":{"name":"windows","decoders":["decoder/core-wazuh-message/0","decoder/windows-event/0","decoder/windows-security/0"],"category":"system-activity"},"rule":{"sigma_id":"3519cfd5-c5e6-445e-860d-cf1dd42703a6","level":"informational","compliance":{"iso_27001":["A.9.2.1","A.12.4.1"],"hipaa":["164.308.a.1.ii.D","164.312.a.2.i","164.312.b"],"pci_dss":["8.2","10.2"],"tsc":["CC6.1","CC7.2"],"nis2":["21.2.a"],"nist_800_171":["3.1.1","3.3.1"],"fedramp":["AC-2","AU-2"],"nist_800_53":["AC-2","AU-2"],"cmmc":["AC.L2-3.1.1","AU.L2-3.3.1"],"gdpr":["IV_32.1.a","IV_33.1","IV_34.1","V_5.1.f"]},"mitre":{"technique":{"name":["Valid Accounts"],"id":["T1078"]},"tactic":{"name":["Initial Access"],"id":["TA0001"]}},"id":"3519cfd5-c5e6-445e-860d-cf1dd42703a6","title":"Successful user authentication - vagrant","tags":["informational","wazuh-generic","attack.initial-access","attack.t1078"],"status":"stable"},"event":{"id":"ee9ca859-5002-4ba8-84bf-a021365630d2"},"space":{"name":"standard"},"active_response":{"name":"Block-IP-stateful-response","type":"stateful","stateful_timeout":120,"executable":"block-ip","extra_arguments":null,"location":"local","agent_id":null}},"process":{"name":"-","pid":0,"executable":"-"},"related":{"ip":["192.168.56.80"],"user":["vagrant"]},"log":{"level":"information"},"host":{"name":"vm-win2022"},"source":{"ip":"192.168.56.80","domain":"VM-WIN2025"},"message":"An account was successfully logged on","user":{"domain":"-","name":"vagrant","id":"S-1-0-0","target":{"domain":"VM-WIN2022","name":"vagrant","id":"S-1-5-21-1673099515-2324581457-255951991-1000"}},"command":"enable"}'

2026/07/14 20:52:12 wazuh-agent[4744] execd.c:169 at ExecdTimeoutRun(): DEBUG: Executing command 'active-response/bin/block-ip.exe {"@timestamp":"2026-07-14T20:48:00.127Z","event":{"original":"<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Security-Auditing' Guid='{54849625-5478-4994-a5ba-3e3b0328c30d}'/><EventID>4624</EventID><Version>2</Version><Level>0</Level><Task>12544</Task><Opcode>0</Opcode><Keywords>0x8020000000000000</Keywords><TimeCreated SystemTime='2026-07-14T20:47:57.6125733Z'/><EventRecordID>1033340</EventRecordID><Correlation ActivityID='{285fc1ef-13cb-0002-0fc2-5f28cb13dd01}'/><Execution ProcessID='736' ThreadID='3024'/><Channel>Security</Channel><Computer>vm-win2022</Computer><Security/></System><EventData><Data Name='SubjectUserSid'>S-1-0-0</Data><Data Name='SubjectUserName'>-</Data><Data Name='SubjectDomainName'>-</Data><Data Name='SubjectLogonId'>0x0</Data><Data Name='TargetUserSid'>S-1-5-21-1673099515-2324581457-255951991-1000</Data><Data Name='TargetUserName'>vagrant</Data><Data Name='TargetDomainName'>VM-WIN2022</Data><Data Name='TargetLogonId'>0x8eb8f3</Data><Data Name='LogonType'>3</Data><Data Name='LogonProcessName'>NtLmSsp </Data><Data Name='AuthenticationPackageName'>NTLM</Data><Data Name='WorkstationName'>VM-WIN2025</Data><Data Name='LogonGuid'>{00000000-0000-0000-0000-000000000000}</Data><Data Name='TransmittedServices'>-</Data><Data Name='LmPackageName'>NTLM V2</Data><Data Name='KeyLength'>128</Data><Data Name='ProcessId'>0x0</Data><Data Name='ProcessName'>-</Data><Data Name='IpAddress'>192.168.56.80</Data><Data Name='IpPort'>57170</Data><Data Name='ImpersonationLevel'>%%1833</Data><Data Name='RestrictedAdminMode'>-</Data><Data Name='TargetOutboundUserName'>-</Data><Data Name='TargetOutboundDomainName'>-</Data><Data Name='VirtualAccount'>%%1843</Data><Data Name='TargetLinkedLogonId'>0x0</Data><Data Name='ElevatedToken'>%%1842</Data></EventData></Event>","code":"4624","kind":"event","start":"2026-07-14T20:47:57.6125733Z","action":"logged-in","index":".ds-wazuh-events-v5-system-activity-000001","type":["start"],"category":["authentication"],"dataset":"security","doc_id":"n-VjYp8B4U2O_vadNcHR","outcome":"success"},"wazuh":{"cluster":{"node":"node01","name":"wazuh"},"protocol":{"location":"EventChannel","queue":102},"agent":{"host":{"hostname":"VM-WIN2022","os":{"name":"Microsoft Windows Server 2022 Standard","type":"windows","version":"10.0.20348.1906","platform":"windows"},"architecture":"x86_64"},"name":"vm-win2022","groups":["default"],"id":"002","version":"v5.0.0"},"integration":{"name":"windows","decoders":["decoder/core-wazuh-message/0","decoder/windows-event/0","decoder/windows-security/0"],"category":"system-activity"},"rule":{"sigma_id":"3519cfd5-c5e6-445e-860d-cf1dd42703a6","level":"informational","compliance":{"iso_27001":["A.9.2.1","A.12.4.1"],"hipaa":["164.308.a.1.ii.D","164.312.a.2.i","164.312.b"],"pci_dss":["8.2","10.2"],"tsc":["CC6.1","CC7.2"],"nis2":["21.2.a"],"nist_800_171":["3.1.1","3.3.1"],"fedramp":["AC-2","AU-2"],"nist_800_53":["AC-2","AU-2"],"cmmc":["AC.L2-3.1.1","AU.L2-3.3.1"],"gdpr":["IV_32.1.a","IV_33.1","IV_34.1","V_5.1.f"]},"mitre":{"technique":{"name":["Valid Accounts"],"id":["T1078"]},"tactic":{"name":["Initial Access"],"id":["TA0001"]}},"id":"3519cfd5-c5e6-445e-860d-cf1dd42703a6","title":"Successful user authentication - vagrant","tags":["informational","wazuh-generic","attack.initial-access","attack.t1078"],"status":"stable"},"event":{"id":"ee9ca859-5002-4ba8-84bf-a021365630d2"},"space":{"name":"standard"},"active_response":{"name":"Block-IP-stateful-response","type":"stateful","stateful_timeout":120,"executable":"block-ip","extra_arguments":null,"location":"local","agent_id":null}},"process":{"name":"-","pid":0,"executable":"-"},"related":{"ip":["192.168.56.80"],"user":["vagrant"]},"log":{"level":"information"},"host":{"name":"vm-win2022"},"source":{"ip":"192.168.56.80","domain":"VM-WIN2025"},"message":"An account was successfully logged on","user":{"domain":"-","name":"vagrant","id":"S-1-0-0","target":{"domain":"VM-WIN2022","name":"vagrant","id":"S-1-5-21-1673099515-2324581457-255951991-1000"}},"command":"disable"}' after a timeout of '120s'
2026/07/14 20:52:12 wazuh-agent[4744] exec_op.c:137 at wpopenv(): DEBUG: path = 'active-response/bin/block-ip.exe', command = '"active-response/bin/block-ip.exe"'
```

</details> 

<details><summary>active-responses.log</summary>

```log
2026/07/14 20:50:10 active-response/bin/block-ip.exe: Starting
2026/07/14 20:50:10 active-response/bin/block-ip.exe: {"@timestamp":"2026-07-14T20:48:00.127Z","event":{"original":"<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Security-Auditing' Guid='{54849625-5478-4994-a5ba-3e3b0328c30d}'/><EventID>4624</EventID><Version>2</Version><Level>0</Level><Task>12544</Task><Opcode>0</Opcode><Keywords>0x8020000000000000</Keywords><TimeCreated SystemTime='2026-07-14T20:47:57.6125733Z'/><EventRecordID>1033340</EventRecordID><Correlation ActivityID='{285fc1ef-13cb-0002-0fc2-5f28cb13dd01}'/><Execution ProcessID='736' ThreadID='3024'/><Channel>Security</Channel><Computer>vm-win2022</Computer><Security/></System><EventData><Data Name='SubjectUserSid'>S-1-0-0</Data><Data Name='SubjectUserName'>-</Data><Data Name='SubjectDomainName'>-</Data><Data Name='SubjectLogonId'>0x0</Data><Data Name='TargetUserSid'>S-1-5-21-1673099515-2324581457-255951991-1000</Data><Data Name='TargetUserName'>vagrant</Data><Data Name='TargetDomainName'>VM-WIN2022</Data><Data Name='TargetLogonId'>0x8eb8f3</Data><Data Name='LogonType'>3</Data><Data Name='LogonProcessName'>NtLmSsp </Data><Data Name='AuthenticationPackageName'>NTLM</Data><Data Name='WorkstationName'>VM-WIN2025</Data><Data Name='LogonGuid'>{00000000-0000-0000-0000-000000000000}</Data><Data Name='TransmittedServices'>-</Data><Data Name='LmPackageName'>NTLM V2</Data><Data Name='KeyLength'>128</Data><Data Name='ProcessId'>0x0</Data><Data Name='ProcessName'>-</Data><Data Name='IpAddress'>192.168.56.80</Data><Data Name='IpPort'>57170</Data><Data Name='ImpersonationLevel'>%%1833</Data><Data Name='RestrictedAdminMode'>-</Data><Data Name='TargetOutboundUserName'>-</Data><Data Name='TargetOutboundDomainName'>-</Data><Data Name='VirtualAccount'>%%1843</Data><Data Name='TargetLinkedLogonId'>0x0</Data><Data Name='ElevatedToken'>%%1842</Data></EventData></Event>","code":"4624","kind":"event","start":"2026-07-14T20:47:57.6125733Z","action":"logged-in","index":".ds-wazuh-events-v5-system-activity-000001","type":["start"],"category":["authentication"],"dataset":"security","doc_id":"n-VjYp8B4U2O_vadNcHR","outcome":"success"},"wazuh":{"cluster":{"node":"node01","name":"wazuh"},"protocol":{"location":"EventChannel","queue":102},"agent":{"host":{"hostname":"VM-WIN2022","os":{"name":"Microsoft Windows Server 2022 Standard","type":"windows","version":"10.0.20348.1906","platform":"windows"},"architecture":"x86_64"},"name":"vm-win2022","groups":["default"],"id":"002","version":"v5.0.0"},"integration":{"name":"windows","decoders":["decoder/core-wazuh-message/0","decoder/windows-event/0","decoder/windows-security/0"],"category":"system-activity"},"rule":{"sigma_id":"3519cfd5-c5e6-445e-860d-cf1dd42703a6","level":"informational","compliance":{"iso_27001":["A.9.2.1","A.12.4.1"],"hipaa":["164.308.a.1.ii.D","164.312.a.2.i","164.312.b"],"pci_dss":["8.2","10.2"],"tsc":["CC6.1","CC7.2"],"nis2":["21.2.a"],"nist_800_171":["3.1.1","3.3.1"],"fedramp":["AC-2","AU-2"],"nist_800_53":["AC-2","AU-2"],"cmmc":["AC.L2-3.1.1","AU.L2-3.3.1"],"gdpr":["IV_32.1.a","IV_33.1","IV_34.1","V_5.1.f"]},"mitre":{"technique":{"name":["Valid Accounts"],"id":["T1078"]},"tactic":{"name":["Initial Access"],"id":["TA0001"]}},"id":"3519cfd5-c5e6-445e-860d-cf1dd42703a6","title":"Successful user authentication - vagrant","tags":["informational","wazuh-generic","attack.initial-access","attack.t1078"],"status":"stable"},"event":{"id":"ee9ca859-5002-4ba8-84bf-a021365630d2"},"space":{"name":"standard"},"active_response":{"name":"Block-IP-stateful-response","type":"stateful","stateful_timeout":120,"executable":"block-ip","extra_arguments":null,"location":"local","agent_id":null}},"process":{"name":"-","pid":0,"executable":"-"},"related":{"ip":["192.168.56.80"],"user":["vagrant"]},"log":{"level":"information"},"host":{"name":"vm-win2022"},"source":{"ip":"192.168.56.80","domain":"VM-WIN2025"},"message":"An account was successfully logged on","user":{"domain":"-","name":"vagrant","id":"S-1-0-0","target":{"domain":"VM-WIN2022","name":"vagrant","id":"S-1-5-21-1673099515-2324581457-255951991-1000"}},"command":"enable"}

2026/07/14 20:50:10 active-response/bin/block-ip.exe: {"version":1,"origin":{"name":"block-ip.exe","module":"active-response"},"command":"check_keys","parameters":{"keys":["192.168.56.80"]}}
2026/07/14 20:50:10 active-response/bin/block-ip.exe: {"@timestamp":"2026-07-14T20:48:00.127Z","event":{"original":"<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Security-Auditing' Guid='{54849625-5478-4994-a5ba-3e3b0328c30d}'/><EventID>4624</EventID><Version>2</Version><Level>0</Level><Task>12544</Task><Opcode>0</Opcode><Keywords>0x8020000000000000</Keywords><TimeCreated SystemTime='2026-07-14T20:47:57.6125733Z'/><EventRecordID>1033340</EventRecordID><Correlation ActivityID='{285fc1ef-13cb-0002-0fc2-5f28cb13dd01}'/><Execution ProcessID='736' ThreadID='3024'/><Channel>Security</Channel><Computer>vm-win2022</Computer><Security/></System><EventData><Data Name='SubjectUserSid'>S-1-0-0</Data><Data Name='SubjectUserName'>-</Data><Data Name='SubjectDomainName'>-</Data><Data Name='SubjectLogonId'>0x0</Data><Data Name='TargetUserSid'>S-1-5-21-1673099515-2324581457-255951991-1000</Data><Data Name='TargetUserName'>vagrant</Data><Data Name='TargetDomainName'>VM-WIN2022</Data><Data Name='TargetLogonId'>0x8eb8f3</Data><Data Name='LogonType'>3</Data><Data Name='LogonProcessName'>NtLmSsp </Data><Data Name='AuthenticationPackageName'>NTLM</Data><Data Name='WorkstationName'>VM-WIN2025</Data><Data Name='LogonGuid'>{00000000-0000-0000-0000-000000000000}</Data><Data Name='TransmittedServices'>-</Data><Data Name='LmPackageName'>NTLM V2</Data><Data Name='KeyLength'>128</Data><Data Name='ProcessId'>0x0</Data><Data Name='ProcessName'>-</Data><Data Name='IpAddress'>192.168.56.80</Data><Data Name='IpPort'>57170</Data><Data Name='ImpersonationLevel'>%%1833</Data><Data Name='RestrictedAdminMode'>-</Data><Data Name='TargetOutboundUserName'>-</Data><Data Name='TargetOutboundDomainName'>-</Data><Data Name='VirtualAccount'>%%1843</Data><Data Name='TargetLinkedLogonId'>0x0</Data><Data Name='ElevatedToken'>%%1842</Data></EventData></Event>","code":"4624","kind":"event","start":"2026-07-14T20:47:57.6125733Z","action":"logged-in","index":".ds-wazuh-events-v5-system-activity-000001","type":["start"],"category":["authentication"],"dataset":"security","doc_id":"n-VjYp8B4U2O_vadNcHR","outcome":"success"},"wazuh":{"cluster":{"node":"node01","name":"wazuh"},"protocol":{"location":"EventChannel","queue":102},"agent":{"host":{"hostname":"VM-WIN2022","os":{"name":"Microsoft Windows Server 2022 Standard","type":"windows","version":"10.0.20348.1906","platform":"windows"},"architecture":"x86_64"},"name":"vm-win2022","groups":["default"],"id":"002","version":"v5.0.0"},"integration":{"name":"windows","decoders":["decoder/core-wazuh-message/0","decoder/windows-event/0","decoder/windows-security/0"],"category":"system-activity"},"rule":{"sigma_id":"3519cfd5-c5e6-445e-860d-cf1dd42703a6","level":"informational","compliance":{"iso_27001":["A.9.2.1","A.12.4.1"],"hipaa":["164.308.a.1.ii.D","164.312.a.2.i","164.312.b"],"pci_dss":["8.2","10.2"],"tsc":["CC6.1","CC7.2"],"nis2":["21.2.a"],"nist_800_171":["3.1.1","3.3.1"],"fedramp":["AC-2","AU-2"],"nist_800_53":["AC-2","AU-2"],"cmmc":["AC.L2-3.1.1","AU.L2-3.3.1"],"gdpr":["IV_32.1.a","IV_33.1","IV_34.1","V_5.1.f"]},"mitre":{"technique":{"name":["Valid Accounts"],"id":["T1078"]},"tactic":{"name":["Initial Access"],"id":["TA0001"]}},"id":"3519cfd5-c5e6-445e-860d-cf1dd42703a6","title":"Successful user authentication - vagrant","tags":["informational","wazuh-generic","attack.initial-access","attack.t1078"],"status":"stable"},"event":{"id":"ee9ca859-5002-4ba8-84bf-a021365630d2"},"space":{"name":"standard"},"active_response":{"name":"Block-IP-stateful-response","type":"stateful","stateful_timeout":120,"executable":"block-ip","extra_arguments":null,"location":"local","agent_id":null}},"process":{"name":"-","pid":0,"executable":"-"},"related":{"ip":["192.168.56.80"],"user":["vagrant"]},"log":{"level":"information"},"host":{"name":"vm-win2022"},"source":{"ip":"192.168.56.80","domain":"VM-WIN2025"},"message":"An account was successfully logged on","user":{"domain":"-","name":"vagrant","id":"S-1-0-0","target":{"domain":"VM-WIN2022","name":"vagrant","id":"S-1-5-21-1673099515-2324581457-255951991-1000"}},"command":"continue"}

2026/07/14 20:50:10 active-response/bin/block-ip.exe: [INFO] Method=netsh Action=start Details=Attempting method: netsh (lock=no)
2026/07/14 20:50:10 active-response/bin/block-ip.exe: Windows Firewall Domain profile: Enabled
2026/07/14 20:50:10 active-response/bin/block-ip.exe: Windows Firewall Private profile: Enabled
2026/07/14 20:50:10 active-response/bin/block-ip.exe: Windows Firewall Public profile: Enabled
2026/07/14 20:50:10 active-response/bin/block-ip.exe: [INFO] Method=netsh Action=success Details=IP 192.168.56.80 successfully blocked
2026/07/14 20:50:10 active-response/bin/block-ip.exe: Ended

2026/07/14 20:52:12 active-response/bin/block-ip.exe: Starting
2026/07/14 20:52:12 active-response/bin/block-ip.exe: {"@timestamp":"2026-07-14T20:48:00.127Z","event":{"original":"<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Security-Auditing' Guid='{54849625-5478-4994-a5ba-3e3b0328c30d}'/><EventID>4624</EventID><Version>2</Version><Level>0</Level><Task>12544</Task><Opcode>0</Opcode><Keywords>0x8020000000000000</Keywords><TimeCreated SystemTime='2026-07-14T20:47:57.6125733Z'/><EventRecordID>1033340</EventRecordID><Correlation ActivityID='{285fc1ef-13cb-0002-0fc2-5f28cb13dd01}'/><Execution ProcessID='736' ThreadID='3024'/><Channel>Security</Channel><Computer>vm-win2022</Computer><Security/></System><EventData><Data Name='SubjectUserSid'>S-1-0-0</Data><Data Name='SubjectUserName'>-</Data><Data Name='SubjectDomainName'>-</Data><Data Name='SubjectLogonId'>0x0</Data><Data Name='TargetUserSid'>S-1-5-21-1673099515-2324581457-255951991-1000</Data><Data Name='TargetUserName'>vagrant</Data><Data Name='TargetDomainName'>VM-WIN2022</Data><Data Name='TargetLogonId'>0x8eb8f3</Data><Data Name='LogonType'>3</Data><Data Name='LogonProcessName'>NtLmSsp </Data><Data Name='AuthenticationPackageName'>NTLM</Data><Data Name='WorkstationName'>VM-WIN2025</Data><Data Name='LogonGuid'>{00000000-0000-0000-0000-000000000000}</Data><Data Name='TransmittedServices'>-</Data><Data Name='LmPackageName'>NTLM V2</Data><Data Name='KeyLength'>128</Data><Data Name='ProcessId'>0x0</Data><Data Name='ProcessName'>-</Data><Data Name='IpAddress'>192.168.56.80</Data><Data Name='IpPort'>57170</Data><Data Name='ImpersonationLevel'>%%1833</Data><Data Name='RestrictedAdminMode'>-</Data><Data Name='TargetOutboundUserName'>-</Data><Data Name='TargetOutboundDomainName'>-</Data><Data Name='VirtualAccount'>%%1843</Data><Data Name='TargetLinkedLogonId'>0x0</Data><Data Name='ElevatedToken'>%%1842</Data></EventData></Event>","code":"4624","kind":"event","start":"2026-07-14T20:47:57.6125733Z","action":"logged-in","index":".ds-wazuh-events-v5-system-activity-000001","type":["start"],"category":["authentication"],"dataset":"security","doc_id":"n-VjYp8B4U2O_vadNcHR","outcome":"success"},"wazuh":{"cluster":{"node":"node01","name":"wazuh"},"protocol":{"location":"EventChannel","queue":102},"agent":{"host":{"hostname":"VM-WIN2022","os":{"name":"Microsoft Windows Server 2022 Standard","type":"windows","version":"10.0.20348.1906","platform":"windows"},"architecture":"x86_64"},"name":"vm-win2022","groups":["default"],"id":"002","version":"v5.0.0"},"integration":{"name":"windows","decoders":["decoder/core-wazuh-message/0","decoder/windows-event/0","decoder/windows-security/0"],"category":"system-activity"},"rule":{"sigma_id":"3519cfd5-c5e6-445e-860d-cf1dd42703a6","level":"informational","compliance":{"iso_27001":["A.9.2.1","A.12.4.1"],"hipaa":["164.308.a.1.ii.D","164.312.a.2.i","164.312.b"],"pci_dss":["8.2","10.2"],"tsc":["CC6.1","CC7.2"],"nis2":["21.2.a"],"nist_800_171":["3.1.1","3.3.1"],"fedramp":["AC-2","AU-2"],"nist_800_53":["AC-2","AU-2"],"cmmc":["AC.L2-3.1.1","AU.L2-3.3.1"],"gdpr":["IV_32.1.a","IV_33.1","IV_34.1","V_5.1.f"]},"mitre":{"technique":{"name":["Valid Accounts"],"id":["T1078"]},"tactic":{"name":["Initial Access"],"id":["TA0001"]}},"id":"3519cfd5-c5e6-445e-860d-cf1dd42703a6","title":"Successful user authentication - vagrant","tags":["informational","wazuh-generic","attack.initial-access","attack.t1078"],"status":"stable"},"event":{"id":"ee9ca859-5002-4ba8-84bf-a021365630d2"},"space":{"name":"standard"},"active_response":{"name":"Block-IP-stateful-response","type":"stateful","stateful_timeout":120,"executable":"block-ip","extra_arguments":null,"location":"local","agent_id":null}},"process":{"name":"-","pid":0,"executable":"-"},"related":{"ip":["192.168.56.80"],"user":["vagrant"]},"log":{"level":"information"},"host":{"name":"vm-win2022"},"source":{"ip":"192.168.56.80","domain":"VM-WIN2025"},"message":"An account was successfully logged on","user":{"domain":"-","name":"vagrant","id":"S-1-0-0","target":{"domain":"VM-WIN2022","name":"vagrant","id":"S-1-5-21-1673099515-2324581457-255951991-1000"}},"command":"disable"}

2026/07/14 20:52:12 active-response/bin/block-ip.exe: [INFO] Method=netsh Action=start Details=Attempting method: netsh (lock=no)
2026/07/14 20:52:12 active-response/bin/block-ip.exe: Windows Firewall Domain profile: Enabled
2026/07/14 20:52:12 active-response/bin/block-ip.exe: Windows Firewall Private profile: Enabled
2026/07/14 20:52:12 active-response/bin/block-ip.exe: Windows Firewall Public profile: Enabled
2026/07/14 20:52:12 active-response/bin/block-ip.exe: [INFO] Method=netsh Action=success Details=IP 192.168.56.80 successfully unblocked
2026/07/14 20:52:12 active-response/bin/block-ip.exe: Ended

```

</details> 

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->
 - wazuh-execd (Windows agent only). No changes to Linux/macOS behavior or binaries.
 
### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->
 - N/A
### Tests Introduced

- Added unit tests in `src/unit_tests/os_execd/test_win_execd.c`:
  - `test_WinExecdRun_custom_ar_no_extension_appends_exe` — an AR name with no extension gets `.exe` appended (`custom-ar` → `custom-ar.exe`).
  - `test_WinExecdRun_custom_ar_with_extension_not_duplicated` — an AR name that already has an extension is used as-is (`custom-ar.bat` stays `custom-ar.bat`, no `.exe` appended).
- Updated the existing Windows execd tests to expect the `.exe`-resolved path (`block-ip` → `block-ip.exe`), including the timeout-list setup and the derived `rkey`.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
