### PR TITLE
Fix version comparison in indexer documents updates

### DIFF
--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -111,6 +111,43 @@ inline void appendEscapedId(std::string& bulkData, std::string_view id)
 }
 
 /**
+ * @brief Builds an update operation with Painless script for version checking
+ * @param bulkData The string to append the update operation to
+ * @param index Index name
+ * @param id Document ID (will be escaped if needed)
+ * @param version Document version to check against state.document_version
+ * @param data Document data (JSON string)
+ *
+ * The script implements external_gte behavior on state.document_version:
+ * - Updates if state.document_version is null or <= provided version
+ * - No-op if state.document_version > provided version
+ */
+inline void appendScriptedUpdate(
+    std::string& bulkData, std::string_view index, std::string_view id, std::string_view version, std::string_view data)
+{
+    // Build update operation metadata
+    bulkData.append(R"({"update":{"_index":")");
+    bulkData.append(index);
+    bulkData.append(R"(","_id":")");
+    appendEscapedId(bulkData, id);
+    bulkData.append(R"("}})");
+    bulkData.append("\n");
+
+    // Build script that checks state.document_version field
+    bulkData.append(R"({"script":{"source":")");
+    bulkData.append(
+        R"(if (ctx._source?.state?.document_version == null || ctx._source.state.document_version <= params.doc_version) { ctx._source = params.doc } else { ctx.op = 'noop' })");
+    bulkData.append(R"(","lang":"painless","params":{"doc_version":)");
+    bulkData.append(version);
+    bulkData.append(R"(,"doc":)");
+    bulkData.append(data);
+    bulkData.append(R"(}},"upsert":)");
+    bulkData.append(data);
+    bulkData.append(R"(,"scripted_upsert":true})");
+    bulkData.append("\n");
+}
+
+/**
  * @brief Validates bulk API response at document level
  * @param response The bulk API response JSON string
  * @return true if all operations succeeded (or had acceptable version conflicts), false otherwise
@@ -1317,27 +1354,21 @@ public:
         {
             processBulk();
         }
-        m_bulkData.append(R"({"index":{"_index":")");
-        m_bulkData.append(index);
+
         if (!version.empty())
         {
-            // In case the version is provided, the id must be provided too
-            if (!id.empty())
-            {
-                m_bulkData.append(R"(","_id":")");
-                appendEscapedId(m_bulkData, id);
-            }
-            else
+            // When version is provided, use update operation with Painless script
+            // to check state.document_version instead of OpenSearch's internal _version.
+            if (id.empty())
             {
                 LOG_ERROR(m_logFn, "Id must be provided if version value is provided");
                 throw IndexerConnectorException("Id must be provided if version value is provided");
             }
 
-            m_bulkData.append(R"(","version":")");
-            m_bulkData.append(version);
-            m_bulkData.append(R"(","version_type":"external_gte)");
+            appendScriptedUpdate(m_bulkData, index, id, version, data);
+
             LOG_DEBUG2(m_logFn,
-                       "Using external version %.*s for document %.*s",
+                       "Using document version %.*s for document %.*s (checking state.document_version)",
                        static_cast<int>(version.size()),
                        version.data(),
                        static_cast<int>(id.size()),
@@ -1345,20 +1376,25 @@ public:
         }
         else
         {
+            // No version provided, use standard index operation
+            m_bulkData.append(R"({"index":{"_index":")");
+            m_bulkData.append(index);
             if (!id.empty())
             {
                 m_bulkData.append(R"(","_id":")");
                 appendEscapedId(m_bulkData, id);
             }
+            m_bulkData.append(R"("}})");
+            m_bulkData.append("\n");
+            m_bulkData.append(data);
+            m_bulkData.append("\n");
+
             LOG_DEBUG2(m_logFn,
                        "No version specified for document %.*s, using default versioning",
                        static_cast<int>(id.size()),
                        id.data());
         }
-        m_bulkData.append(R"("}})");
-        m_bulkData.append("\n");
-        m_bulkData.append(data);
-        m_bulkData.append("\n");
+
         m_boundaries.push_back(m_bulkData.size());
     }
 

--- a/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
+++ b/src/shared_modules/indexer_connector/tests/unit/indexerConnectorSync_test.cpp
@@ -1799,9 +1799,10 @@ TEST_F(IndexerConnectorSyncTest, BulkIndexWithVersionHandling)
     auto status = processingCompletedFuture.wait_for(std::chrono::seconds(5));
     EXPECT_EQ(status, std::future_status::ready) << "Timeout waiting for version test processing";
 
-    // Verify version is included in the bulk data for doc1
-    EXPECT_THAT(capturedBulkData, ::testing::HasSubstr(R"("version":"12345")"));
-    EXPECT_THAT(capturedBulkData, ::testing::HasSubstr(R"("version_type":"external_gte")"));
+    // Verify version is included in the bulk data for doc1 using update with script
+    EXPECT_THAT(capturedBulkData, ::testing::HasSubstr(R"("update")"));
+    EXPECT_THAT(capturedBulkData, ::testing::HasSubstr(R"("doc_version":12345)"));
+    EXPECT_THAT(capturedBulkData, ::testing::HasSubstr(R"(state.document_version)"));
 
     // Verify doc2 does not have version information
     std::size_t doc2_pos = capturedBulkData.find("doc2");


### PR DESCRIPTION
## Description

Fixed version conflict issues in inventory sync by changing bulk index operations to use application-level `state.document_version` instead of OpenSearch's internal `_version`. This prevents rejection of valid agent data updates when manager-side metadata changes (groups, cluster name) occur.

## Proposed Changes

Modified `IndexerConnectorSync::bulkIndex` to use scripted update operations that check `state.document_version` instead of `_version`:
- Before: Used index operation with version_type: `external_gte` (compares against `_version`)
- After: Uses update operation with Painless script (compares against `state.document_version`)

### Results and Evidence

SCA document after several group updates and stateful changes reflect the change immediately:

<details>
```
{
  "_index": "wazuh-states-sca",
  "_id": "wazuh_001_ef99b64d898d19c7d911b78b83b9b1d133b11732",
  "_score": null,
  "_source": {
    "checksum": {
      "hash": {
        "sha1": "b767510d83c07ded52e923528c188fa32c0f134f"
      }
    },
    "wazuh": {
      "cluster": {
        "name": "wazuh"
      },
      "agent": {
        "host": {
          "hostname": "tomas",
          "os": {
            "name": "Ubuntu",
            "type": "linux",
            "version": "24.04.2 LTS (Noble Numbat)",
            "platform": "ubuntu"
          },
          "architecture": "aarch64"
        },
        "name": "tomas",
        "groups": [
          "default",
          "test"
        ],
        "id": "001",
        "version": "v5.0.0"
      }
    },
    "check": {
      "result": "Failed",
      "remediation": "Create the file by running: touch /tmp/test_file",
      "condition": "all",
      "name": "Ensure the file /tmp/test_file exists.",
      "description": "Verifies the presence of the file /tmp/test_file on the system.",
      "rules": [
        "[\"f:/tmp/test_file\"]"
      ],
      "id": "90000",
      "rationale": "This is a demonstration check to confirm that a specific file is present under the /tmp directory."
    },
    "state": {
      "document_version": 4,
      "modified_at": "2026-07-07T15:06:23.902Z"
    },
    "policy": {
      "file": "cis_ubuntu24-04.yml",
      "references": [
        "[\"https://www.cisecurity.org/cis-benchmarks/\"]"
      ],
      "name": "CIS Ubuntu Linux 24.04 LTS Benchmark v1.0.0.",
      "description": "This document provides prescriptive guidance for establishing a secure configuration posture for Ubuntu Linux 24.04 LTS based on CIS benchmark for Ubuntu Linux 24.04 LTS.",
      "id": "cis_ubuntu24-04"
    }
  },
  "fields": {
    "state.modified_at": [
      "2026-07-07T15:06:23.902Z"
    ]
  },
  "sort": [
    "90000"
  ]
}
```
</details>

### Artifacts Affected

Manager

### Configuration Changes

N/A

### Tests Introduced

Updated existing unit test expectations in `indexerConnectorSync_test.cpp` to validate:
- Scripted update operation format
- `state.document_version` parameter presence
- Correct Painless script execution

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues