### PR TITLE
Remove startup deprecation warning from cluster_control and agent_upgrade

### DIFF
--- a/api/api/__init__.py
+++ b/api/api/__init__.py
@@ -1,3 +1,16 @@
 # Copyright (C) 2015, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import warnings
+
+from starlette.exceptions import StarletteDeprecationWarning
+
+# Connexion unconditionally imports `starlette.testclient` to offer a test helper we never use,
+# which warns when only `httpx` (and not `httpx2`) is installed. Not fixed as of connexion 3.3.0.
+# Starlette raises this with stacklevel=2, so it is attributed to the importing module rather
+# than to starlette.testclient itself; match on the message instead of `module`.
+warnings.filterwarnings(
+    'ignore', category=StarletteDeprecationWarning,
+    message=r'Using `httpx` with `starlette\.testclient` is deprecated',
+)

--- a/api/api/test/test_signals.py
+++ b/api/api/test/test_signals.py
@@ -5,8 +5,6 @@ from unittest.mock import AsyncMock, patch
 
 from asyncinotify import Mask
 import pytest
-from starlette.applications import Starlette
-from starlette.testclient import TestClient
 
 from api.constants import SECURITY_PATH
 from api.signals import (
@@ -38,7 +36,7 @@ async def test_register_background_tasks(clean_auth_keys_cache_mock):
         create_task_mock.create_task.return_value = AwaitableMock(spec=asyncio.Task)
         create_task_mock.create_task.return_value.cancel = AsyncMock()
 
-        with TestClient(Starlette(lifespan=lifespan_handler)):
+        async with lifespan_handler(None):
             assert create_task_mock.create_task.call_count == 1
 
         assert create_task_mock.create_task.return_value.cancel.call_count == 1

--- a/framework/scripts/agent_upgrade.py
+++ b/framework/scripts/agent_upgrade.py
@@ -10,7 +10,6 @@ from os.path import dirname
 from signal import signal, SIGINT
 from sys import exit, path, argv
 from time import sleep
-from connexion import ProblemException
 
 # Set framework path
 path.append(dirname(argv[0]) + '/../framework')  # It is necessary to import Wazuh package
@@ -25,6 +24,8 @@ try:
 except Exception as e:
     print("Error importing 'Wazuh' package.\n\n{0}\n".format(e))
     exit()
+
+from connexion import ProblemException
 
 
 # Functions


### PR DESCRIPTION
## Description

Running `cluster_control -a` (and `agent_upgrade.py`) printed a `StarletteDeprecationWarning` about `httpx`/`starlette.testclient` on every invocation:

```
/var/wazuh-manager/framework/python/lib/python3.12/site-packages/connexion/apps/abstract.py:9: StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.
  from starlette.testclient import TestClient
```

The warning originates inside `connexion` (pinned to `3.1.0`), which unconditionally imports `starlette.testclient` for a test helper we never use. This is confirmed to still be present in the latest `connexion` release (`3.3.0`), so it cannot be resolved by upgrading the dependency.

Closes #37501

## Proposed Changes

- Suppress this specific, unfixable upstream warning at the `api` package entry point, so it no longer surfaces for any tool that imports it (CLI scripts, the API server, tests).
- Reorder the `connexion` import in `agent_upgrade.py` so it happens after the `wazuh`/`api` packages are loaded, letting the new filter take effect for this script as well (it previously imported `connexion` directly, before anything else).
- Remove the equivalent deprecated pattern from our own test suite, where `starlette.testclient.TestClient` was used only to trigger startup/shutdown events, not to make HTTP requests.

### Results and Evidence

**Before / after for `cluster_control`:**
```diff
$ /var/wazuh-manager/bin/cluster_control -a
- /var/wazuh-manager/framework/python/lib/python3.12/site-packages/connexion/apps/abstract.py:9: StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.
-   from starlette.testclient import TestClient
ID   NAME                       IP           STATUS        VERSION  NODE NAME
001  ubuntu                     127.0.0.1    active        v5.0.0   node01
```

**Before / after for `agent_upgrade`:**
```diff
- /var/wazuh-manager/framework/python/lib/python3.12/site-packages/connexion/apps/abstract.py:9: StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.
-  from starlette.testclient import TestClient
usage: agent_upgrade.py [-h] [-a AGENTS [AGENTS ...]] [-r REPOSITORY] [-v VERSION] [-F] [-s] [-l] [-f FILE] [-d] [-x EXECUTE] [--http] [--package_type PACKAGE_TYPE]
```

Additionally verified in this session (using the manager's own Python interpreter against the patched source):
- Importing `wazuh.core.cluster.control` (the `cluster_control` import chain) no longer emits `StarletteDeprecationWarning`.
- Importing `agent_upgrade.py`'s module chain no longer emits `StarletteDeprecationWarning`.
- `api/api/test/` suite: 297 passed.
- `framework/wazuh/core/cluster/tests/` suite: 447 passed, 1 skipped (pre-existing, unrelated).

### Artifacts Affected

- `cluster_control` CLI tool
- `agent_upgrade` CLI tool

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

No new tests were added. `api/api/test/test_signals.py::test_register_background_tasks` was adapted to drop the `starlette.testclient.TestClient` dependency: the test now enters the `lifespan_handler` async context manager directly instead of wrapping it in a `Starlette` app and `TestClient`, keeping the same coverage (background task creation/cancellation on startup/shutdown) without the deprecated import path.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
