### PR TITLE
Standardize CHANGELOG format and keep prior versions in the bumper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,8 +97,3 @@
 - Adjusted DockerListener messages as log entries to fix event categorization. ([#36126](https://github.com/wazuh/wazuh/issues/36126))
 - Dropped orphan paths before promoting on agent startup to fix FIM. ([#36134](https://github.com/wazuh/wazuh/issues/36134))
 
-## Prior versions
-
-- [v4.14.5](https://github.com/wazuh/wazuh/blob/v4.14.5/CHANGELOG.md)
-- [v4.13.1](https://github.com/wazuh/wazuh/blob/v4.13.1/CHANGELOG.md)
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
-# Change Log
-All notable changes to this project will be documented in this file.
-
 ## [v5.0.0]
 
 ### Manager
@@ -14,8 +11,6 @@ All notable changes to this project will be documented in this file.
 - Added CVSS v4.0 support to the Vulnerability Scanner. ([#35623](https://github.com/wazuh/wazuh/issues/35623))
 - Added Engine metrics collection, normalization, and indexing pipeline. ([#35771](https://github.com/wazuh/wazuh/issues/35771))
 - Added new CVE 5.0 schema fields to the Vulnerability Detector content model. ([#36000](https://github.com/wazuh/wazuh/issues/36000))
-- Added Engine content management. ([#2445](https://github.com/wazuh/internal-devel-requests/issues/2445))
-- Added Engine content management tier 2. ([#3166](https://github.com/wazuh/internal-devel-requests/issues/3166))
 - Added manager watermarks. ([#35579](https://github.com/wazuh/wazuh/issues/35579))
 - Added byte-based capacity limits to wazuh-manager-remoted. ([#37052](https://github.com/wazuh/wazuh/issues/37052))
 
@@ -36,7 +31,6 @@ All notable changes to this project will be documented in this file.
 - Changed the default Indexer user used by the Manager from `admin` to the restricted `wazuh-server` user, aligning with the Indexer RBAC least-privilege model. ([#36311](https://github.com/wazuh/wazuh/issues/36311))
 - Enabled shared-password agent enrollment by default, persisting the auto-generated `authd.pass` and synchronizing it to worker nodes, with fail-closed password validation. ([#36705](https://github.com/wazuh/wazuh/issues/36705))
 - Adapted API integration tests. ([#32698](https://github.com/wazuh/wazuh/issues/32698))
-- Migrated the remaining CI GitHub Actions artifacts (agent package builders, toolchain, and engine build/test workflows) to the internal S3 bucket, so no workflow uses `actions/upload-artifact`/`download-artifact`. ([#3502](https://github.com/wazuh/wazuh-automation/issues/3502))
 
 #### Removed
 
@@ -106,11 +100,5 @@ All notable changes to this project will be documented in this file.
 ## Prior versions
 
 - [v4.14.5](https://github.com/wazuh/wazuh/blob/v4.14.5/CHANGELOG.md)
-- [v4.14.4](https://github.com/wazuh/wazuh/blob/v4.14.4/CHANGELOG.md)
-- [v4.14.3](https://github.com/wazuh/wazuh/blob/v4.14.3/CHANGELOG.md)
-- [v4.14.2](https://github.com/wazuh/wazuh/blob/v4.14.2/CHANGELOG.md)
-- [v4.14.1](https://github.com/wazuh/wazuh/blob/v4.14.1/CHANGELOG.md)
-- [v4.14.0](https://github.com/wazuh/wazuh/blob/v4.14.0/CHANGELOG.md)
 - [v4.13.1](https://github.com/wazuh/wazuh/blob/v4.13.1/CHANGELOG.md)
-- [v4.13.0](https://github.com/wazuh/wazuh/blob/v4.13.0/CHANGELOG.md)
 

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -527,11 +527,12 @@ update_root_changelog() {
         } | sort -Vr
     )
 
-    # Keep the highest patch per minor series, drop the new release's own series,
-    # and take only the two latest minor series.
+    # Keep the highest patch per minor series, ignore versions older than 5.0.0,
+    # drop the new release's own series, and take only the two latest minor series.
     local prior_tags
-    prior_tags=$(awk -F. -v skip="$new_mm" '
+    prior_tags=$(awk -F. -v skip="$new_mm" -v min_major=5 '
         NF < 3 { next }
+        $1 < min_major { next }
         { mm = $1 "." $2 }
         mm == skip { next }
         !seen[mm]++ { print }' <<< "$candidates" | head -n2)

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -494,44 +494,62 @@ update_file_packages() {
 update_root_changelog() {
     local new_version="$1"
     local changelog_file="$DIR_ROOT/CHANGELOG.md"
+    local repo_url="https://github.com/wazuh/wazuh"
 
     if [[ -z "$new_version" ]]; then
         return
     fi
 
     if [[ ! -f "$changelog_file" ]]; then
-        echo -e "# Change Log\nAll notable changes to this project will be documented in this file.\n" > "$changelog_file"
+        echo "## [v$new_version]" > "$changelog_file"
+        log_action "Created $changelog_file with new version: $new_version"
+        return
     fi
 
-    if grep -q "\[$new_version\]" "$changelog_file"; then
+    if grep -q "\[v\?$new_version\]" "$changelog_file"; then
         log_action "Version $new_version already exists in changelog."
         return
     fi
 
-    local inserted=0
-    local temp_file
-    temp_file=$(mktemp)
+    # Minor series (MAJOR.MINOR) of the version being released.
+    local new_mm="${new_version%.*}"
 
-    while IFS= read -r line; do
-        if [[ "$line" =~ ^##\ \[v?([0-9]+\.[0-9]+\.[0-9]+)\] ]]; then
-            existing_version="${BASH_REMATCH[1]}"
-            if [[ "$existing_version" == "$new_version" ]]; then
-                log_action "Duplicate version $new_version found, skipping."
-                return
-            fi
-            if [[ $inserted -eq 0 ]] && [[ "$(printf "%s\n%s" "$new_version" "$existing_version" | sort -Vr | head -n1)" == "$new_version" ]]; then
-                echo -e "## [v$new_version]\n" >> "$temp_file"
-                inserted=1
-            fi
-        fi
-        echo "$line" >> "$temp_file"
-    done < "$changelog_file"
+    # Candidate prior versions: the current top version (whose full changelog is
+    # replaced by a link) plus every version already listed under
+    # "## Prior versions", newest first.
+    local candidates
+    candidates=$(
+        {
+            grep -m1 -E '^## \[v?[0-9]+\.[0-9]+\.[0-9]+\]' "$changelog_file" \
+                | sed -E 's/^## \[v?([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/'
+            sed -n '/^## Prior versions/,$p' "$changelog_file" \
+                | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^v//'
+        } | sort -Vr
+    )
 
-    if [[ $inserted -eq 0 ]]; then
-        echo -e "## [v$new_version]\n" >> "$temp_file"
+    # Keep the highest patch per minor series, drop the new release's own series,
+    # and take only the two latest minor series.
+    local prior_tags
+    prior_tags=$(awk -F. -v skip="$new_mm" '
+        NF < 3 { next }
+        { mm = $1 "." $2 }
+        mm == skip { next }
+        !seen[mm]++ { print }' <<< "$candidates" | head -n2)
+
+    # Rebuild the changelog: the new version section plus the prior-version links.
+    local new_content="## [v${new_version}]"
+    if [[ -n "$prior_tags" ]]; then
+        new_content+=$'\n\n'"## Prior versions"$'\n'
+        local tag
+        while IFS= read -r tag; do
+            [[ -z "$tag" ]] && continue
+            new_content+=$'\n'"- [v${tag}](${repo_url}/blob/v${tag}/CHANGELOG.md)"
+        done <<< "$prior_tags"
     fi
 
-    mv "$temp_file" "$changelog_file"
+    local current
+    current=$(<"$changelog_file")
+    add_command "$changelog_file" "$current" "$new_content"
     log_action "Modified $changelog_file with new version: $new_version"
 }
 

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -173,7 +173,7 @@ update_file_sources() {
 
     # Update defs.h
     if [[ -n "$new_version" ]]; then
-        local defs_file="$DIR_SRC/headers/defs.h"
+        local defs_file="$DIR_SRC/shared/include/defs.h"
         local current_defs_version
         current_defs_version=$(grep -E '^#define __wazuh_version' "$defs_file" \
             | sed -E 's/^#define __wazuh_version\s+"v([0-9]+\.[0-9]+\.[0-9]+)".*/\1/')
@@ -187,8 +187,7 @@ update_file_sources() {
     # Update wazuh-*.sh scripts
     for script in \
         "$DIR_SRC/init/wazuh-server.sh" \
-        "$DIR_SRC/init/wazuh-client.sh" \
-        "$DIR_SRC/init/wazuh-local.sh"
+        "$DIR_SRC/init/wazuh-client.sh"
     do
         if [[ -n "$new_version" ]]; then
             local current_script_version


### PR DESCRIPTION
## Description

Aligns `CHANGELOG.md` with the format defined in the PRs revamp epic and makes `tools/repository_bumper.sh` preserve that format across bumps. It also fixes stale target paths in the bumper that broke a full run against the 5.0 source layout.

Closes #37512

## Proposed Changes

- Drop the top `# Change Log` title so the file starts at the version heading, matching the epic format.
- Remove CHANGELOG references to private repositories (`internal-devel-requests`, `wazuh-automation`).
- `update_root_changelog`: on a new version, replace the previous version content with a link and rebuild the `Prior versions` section, keeping only the two latest minor changelogs and excluding anything older than 5.0.0.
- Fix stale bumper target paths: point the `defs.h` update to `src/shared/include/defs.h` and drop the removed `wazuh-local.sh` from the init scripts loop.

### Results and Evidence

Verified end-to-end in a Linux container (bash 5.1, GNU sed/sort) against the exact PR branch code.

- Test A: the real `update_root_changelog` function across 7 scenarios (minor bump, chained bumps, patch bump, idempotency, empty repo, major bump), asserting 4.x and the release's own minor are excluded and only the two latest minors are kept.
- Test B: a full `repository_bumper.sh` run with no workarounds (`--version 5.1.0 --stage rc1 --date 2026-07-09`), checking every touched file.

Resulting `CHANGELOG.md` after the full bump:

```
## [v5.1.0]

## Prior versions

- [v5.0.0](https://github.com/wazuh/wazuh/blob/v5.0.0/CHANGELOG.md)
```

<details><summary>Full test output — 16 passed, 0 failed</summary>

```
### environment
GNU bash, version 5.1.16(1)-release (aarch64-unknown-linux-gnu)
sed (GNU sed) 4.8
sort (GNU coreutils) 8.32
mawk 1.3.4 20200120

==========================================================
 TEST A - update_root_changelog (REAL functions from script)
==========================================================
PASS: A1 minor 5.0.0->5.1.0 (4.x excluded)
PASS: A2 chained 5.1.0->5.2.0 (two latest minors)
PASS: A3 patch 5.0.0->5.0.1 (own minor & 4.x excluded -> no priors)
PASS: A4 patch 5.1.0->5.1.1 (own minor excluded, keeps v5.0.0)
PASS: A5 idempotent re-bump 5.1.1 (unchanged)
PASS: A6 fresh repo -> bare header
PASS: A7 major 5.2.0->6.0.0 (two latest minors)

==========================================================
 TEST B - FULL real bumper run (end-to-end)
==========================================================
BEFORE:
{
    "version": "5.0.0",
    "stage": "beta4"
}

--- running: repository_bumper.sh --version 5.1.0 --stage rc1 --date 2026-07-09 ---
exit code: 0

AFTER VERSION.json:
{
    "version": "5.1.0",
    "stage": "rc1"
}

AFTER CHANGELOG.md:
-----
## [v5.1.0]

## Prior versions

- [v5.0.0](https://github.com/wazuh/wazuh/blob/v5.0.0/CHANGELOG.md)
-----
PASS: B full-run exit code 0
PASS: B CHANGELOG has new version header
PASS: B CHANGELOG prior versions = v5.0.0 only
PASS: B no 4.x leaked into changelog
PASS: B VERSION.json bumped to 5.1.0
PASS: B defs.h (fixed path) bumped to v5.1.0
PASS: B wazuh-server.sh bumped to v5.1.0
PASS: B wazuh-server.sh revision -> rc1
PASS: B no stale src/headers/defs.h created

==========================================================
 RESULT: 16 passed, 0 failed
==========================================================
```
</details>

### Artifacts Affected

- `CHANGELOG.md`
- `tools/repository_bumper.sh` (release tooling; no runtime artifact)

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

No automated tests added; the bumper has no existing test suite. Verification was done with the end-to-end harness whose output is shown above.

## Review Checklist
- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
