### PR TITLE
Change indexer username and password to wazuh-manager

### DIFF
--- a/api/tools/env/wazuh-manager/entrypoint.sh
+++ b/api/tools/env/wazuh-manager/entrypoint.sh
@@ -15,9 +15,9 @@ while [ ! -f "${WAZUH_CERTS_DIR}/root-ca.pem" ]; do
 done
 echo "Certificates found."
 
-# Set indexer credentials (default: wazuh-server/wazuh-server)
-echo 'wazuh-server' | /var/wazuh-manager/bin/wazuh-manager-keystore -f indexer -k username
-echo 'wazuh-server' | /var/wazuh-manager/bin/wazuh-manager-keystore -f indexer -k password
+# Set indexer credentials (default: wazuh-manager/wazuh-manager)
+echo 'wazuh-manager' | /var/wazuh-manager/bin/wazuh-manager-keystore -f indexer -k username
+echo 'wazuh-manager' | /var/wazuh-manager/bin/wazuh-manager-keystore -f indexer -k password
 
 # Configure wazuh configuration file and api.yaml based on the Master role
 if [ "$ROLE" == "master" ]; then

--- a/docs/ref/getting-started/installation.md
+++ b/docs/ref/getting-started/installation.md
@@ -56,9 +56,9 @@ sudo chown -R wazuh-manager:wazuh-manager /var/wazuh-manager/etc/certs
 Configure the Wazuh server to connect to the Wazuh indexer using the secure keystore:
 
 ```bash
-# Set indexer credentials (default: wazuh-server/wazuh-server)
-sudo /var/wazuh-manager/bin/wazuh-manager-keystore -f indexer -k username -v wazuh-server
-sudo /var/wazuh-manager/bin/wazuh-manager-keystore -f indexer -k password -v wazuh-server
+# Set indexer credentials (default: wazuh-manager/wazuh-manager)
+sudo /var/wazuh-manager/bin/wazuh-manager-keystore -f indexer -k username -v wazuh-manager
+sudo /var/wazuh-manager/bin/wazuh-manager-keystore -f indexer -k password -v wazuh-manager
 ```
 
 Update the indexer configuration in `/var/wazuh-manager/etc/wazuh-manager.conf` to specify the indexer IP address:

--- a/framework/wazuh/core/indexer/tests/test_indexer.py
+++ b/framework/wazuh/core/indexer/tests/test_indexer.py
@@ -29,8 +29,8 @@ async def test_get_indexer_client_resolves_relative_certificate_paths():
     client.close = AsyncMock()
     keystore_client = MagicMock()
     keystore_client.__enter__.return_value.get.side_effect = [
-        {"value": "wazuh-server"},
-        {"value": "wazuh-server"},
+        {"value": "wazuh-manager"},
+        {"value": "wazuh-manager"},
     ]
 
     wazuh_config = {
@@ -64,8 +64,8 @@ async def test_get_indexer_client_resolves_relative_certificate_paths():
     create_indexer.assert_awaited_once_with(
         hosts=["localhost"],
         ports=[9200],
-        user="wazuh-server",
-        password="wazuh-server",
+        user="wazuh-manager",
+        password="wazuh-manager",
         use_ssl=True,
         verify_certs=True,
         client_cert_path="/var/wazuh-manager/etc/certs/manager.pem",

--- a/src/engine/source/conf/src/conf.cpp
+++ b/src/engine/source/conf/src/conf.cpp
@@ -58,8 +58,8 @@ Conf::Conf(std::shared_ptr<IFileLoader> fileLoader)
 
     // Indexer connector
     addUnit<std::vector<std::string>>(key::INDEXER_HOST, "WAZUH_INDEXER_HOSTS", {"http://localhost:9200"});
-    addUnit<std::string>(key::INDEXER_USER, "WAZUH_INDEXER_USER", "wazuh-server");
-    addUnit<std::string>(key::INDEXER_PASSWORD, "WAZUH_INDEXER_PASSWORD", "wazuh-server");
+    addUnit<std::string>(key::INDEXER_USER, "WAZUH_INDEXER_USER", "wazuh-manager");
+    addUnit<std::string>(key::INDEXER_PASSWORD, "WAZUH_INDEXER_PASSWORD", "wazuh-manager");
     addUnit<std::vector<std::string>>(key::INDEXER_SSL_CA_BUNDLE, "WAZUH_INDEXER_SSL_CA_BUNDLE", {});
     addUnit<std::string>(key::INDEXER_SSL_CERTIFICATE, "WAZUH_INDEXER_SSL_CERTIFICATE", "");
     addUnit<std::string>(key::INDEXER_SSL_KEY, "WAZUH_INDEXER_SSL_KEY", "");

--- a/src/shared_modules/content_manager/README.md
+++ b/src/shared_modules/content_manager/README.md
@@ -53,8 +53,8 @@ After all pages are processed, the downloader signals completion via `indexer_co
         "databasePath": "queue/vd/vd_updater/rocksdb",
         "indexer": {
             "hosts": ["https://localhost:9200"],
-            "username": "wazuh-server",
-            "password": "wazuh-server",
+            "username": "wazuh-manager",
+            "password": "wazuh-manager",
             "ssl": {
                 "certificate_authorities": ["/etc/wazuh-indexer/certs/root-ca.pem"],
                 "certificate": "",

--- a/src/shared_modules/content_manager/doc/components/INDEXER_DOWNLOADER.md
+++ b/src/shared_modules/content_manager/doc/components/INDEXER_DOWNLOADER.md
@@ -129,8 +129,8 @@ Example:
         "offset": 0,
         "indexer": {
             "hosts": ["https://localhost:9200"],
-            "username": "wazuh-server",
-            "password": "wazuh-server",
+            "username": "wazuh-manager",
+            "password": "wazuh-manager",
             "ssl": {
                 "certificate_authorities": ["/etc/wazuh-indexer/certs/root-ca.pem"],
                 "certificate": "",

--- a/src/shared_modules/indexer_connector/src/indexerConnectorAsyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorAsyncImpl.hpp
@@ -188,13 +188,13 @@ public:
         static auto password = Keystore::get(INDEXER_COLUMN, PASSWORD_KEY);
         if (username.empty() && password.empty())
         {
-            username = "wazuh-server";
-            password = "wazuh-server";
+            username = "wazuh-manager";
+            password = "wazuh-manager";
             LOG_WARN(m_logFn, "No username and password found in the keystore, using default values.");
         }
         if (username.empty())
         {
-            username = "wazuh-server";
+            username = "wazuh-manager";
             LOG_WARN(m_logFn, "No username found in the keystore, using default value.");
         }
         m_secureCommunication = SecureCommunication::builder();

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -672,13 +672,13 @@ public:
         static auto password = Keystore::get(INDEXER_COLUMN, PASSWORD_KEY);
         if (username.empty() && password.empty())
         {
-            username = "wazuh-server";
-            password = "wazuh-server";
+            username = "wazuh-manager";
+            password = "wazuh-manager";
             LOG_WARN(m_logFn, "No username and password found in the keystore, using default values.");
         }
         if (username.empty())
         {
-            username = "wazuh-server";
+            username = "wazuh-manager";
             LOG_WARN(m_logFn, "No username found in the keystore, using default value.");
         }
         m_secureCommunication = SecureCommunication::builder();

--- a/src/shared_modules/keystore/src/argsParser.hpp
+++ b/src/shared_modules/keystore/src/argsParser.hpp
@@ -103,7 +103,7 @@ public:
                   << "\t-vp VALUE_PATH\t\tPath to a file containing the value to read (single line). Only use one value option at the time.\n"
                   << "\tNOTE: if both value parameters are empty, stdin will be read.\n"
                   << "\nExample:"
-                  << "\n\t./wazuh-manager-keystore -f indexer -k username -v wazuh-server\n"
+                  << "\n\t./wazuh-manager-keystore -f indexer -k username -v wazuh-manager\n"
                   << "\n\t./wazuh-manager-keystore -f indexer -k password -vp /path/to/file.txt\n"
                   << "\n\t./wazuh-manager-keystore -f indexer -k password < /path/to/file.txt\n"
                   << "\n\techo 'pass' | ./wazuh-manager-keystore -f indexer -k password\n"

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -544,7 +544,7 @@ class InventorySyncFacadeImpl final
                         }
                         else
                         {
-                            result["value"] = "wazuh-server";
+                            result["value"] = "wazuh-manager";
                         }
                     }
                     else if (queryOp == "PUT")


### PR DESCRIPTION
## Description

Change default credentials to connect to the Wazuh indexer to `wazuh-manager`.

## Proposed Changes

- Change username to `wazuh-manager`.
- Change password to `wazuh-manager`.

### Results and Evidence

<img width="1498" height="772" alt="image" src="https://github.com/user-attachments/assets/6d904e52-6372-4350-adea-31b03b5e7700" />

### Configuration Changes

N/A

### Tests Introduced

N/A

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided