### PR TITLE
Maintain crypto_method on keystore rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## [v4.14.8]
 
+### Manager
+
+#### Fixed
+
+- Fixed AES connection getting reset to blowfish on keystore rebuild. ([#37524](https://github.com/wazuh/wazuh/pull/37524))
+
 ### Ruleset
 
 #### Fixed

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -39,6 +39,7 @@ static void move_netdata(keystore *keys, const keystore *old_keys)
         if (keyid >= 0 && !strcmp(keys->keyentries[keyid]->ip->ip, old_keys->keyentries[i]->ip->ip)) {
             keys->keyentries[keyid]->rcvd = old_keys->keyentries[i]->rcvd;
             keys->keyentries[keyid]->sock = old_keys->keyentries[i]->sock;
+            keys->keyentries[keyid]->crypto_method = old_keys->keyentries[i]->crypto_method;
             memcpy(&keys->keyentries[keyid]->peer_info, &old_keys->keyentries[i]->peer_info, sizeof(struct sockaddr_storage));
 
             snprintf(strsock, sizeof(strsock), "%d", keys->keyentries[keyid]->sock);
@@ -695,6 +696,7 @@ keyentry * OS_DupKeyEntry(const keyentry * key) {
     copy->time_added = key->time_added;
     w_mutex_init(&copy->mutex, NULL);
     copy->peer_info = key->peer_info;
+    copy->crypto_method = key->crypto_method;
 
     return copy;
 }


### PR DESCRIPTION
## Description
Closes https://github.com/wazuh/wazuh/issues/37336

Fixes a problem in the manager where the `crypto_method` property of a key is reset to the default (`blowfish`) when re-creating the keystore.
This causes AES connections to be reset to blowfish and, if the manager manages to send a message to the agent, before they send one, these warnings would be logged:
```
2026/07/08 15:08:55 wazuh-agentd: WARNING: (1404): Authentication error. Wrong key or corrupt payload. Message received from agent '002' at 'any'.
2026/07/08 15:08:55 wazuh-agentd: WARNING: (1214): Problem receiving message from '192.168.56.10'.
```

## Proposed Changes
Copy `crypto_method` in both `move_netdata()` and `OS_DupKeyEntry()` so that it is maintained accross keystore rebuilds.

## Results and Evidence

Tested by following the next series of steps before and after the changes proposed in this PR:

0. Agent + Manager setup. With the default AES and TCP connection.
1. Disabled syscheck, rootcheck, sca ans syscollector on the agent's ossec.conf so that they don't send messages to the manager that can interfere with our test and re-set AES
2. Manager: set remoted.keyupdate_interval=1. in `local_internal_options.conf`
3. Agent: `notify_time` bumped up to `120` to widen the quiet window.
4. Manager: touch `client.keys` → forces `crypto_method` reset to Blowfish for all tracked agents.
5. Manager: `curl -u wazuh:wazuh -k -X PUT "https://IP:55000/agents/restart?agents_list=002"     -H "Authorization: Bearer $TOKEN"` → independent send while the reset is still in effect.

Before the changes in this PR we saw the warnings:
```
2026/07/08 15:08:55 wazuh-agentd: WARNING: (1404): Authentication error. Wrong key or corrupt payload. Message received from agent '002' at 'any'.
2026/07/08 15:08:55 wazuh-agentd: WARNING: (1214): Problem receiving message from '192.168.56.10'.
```

After the changes in this PR, the warnings are gone.

### Manual tests with their corresponding evidence

N/A

### Artifacts Affected

N/A

### Configuration Changes

N/A

### Tests Introduced

N/A

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->


