### PR TITLE
Fix daemon stats for analysisd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ All notable changes to this project will be documented in this file.
 - Fixed `wazuh-db` error assigning groups by avoiding the keyentries counter as index. ([#34082](https://github.com/wazuh/wazuh/issues/34082))
 - Fixed token validation race condition after revoke. ([#35043](https://github.com/wazuh/wazuh/issues/35043))
 - Handled the stop signal during vulnerability feed download. ([#35638](https://github.com/wazuh/wazuh/issues/35638))
+- Fixed `GET /cluster/{node_id}/daemons/stats` always returning error 1014 for `wazuh-manager-analysisd` due to a protocol mismatch between `WazuhSocketJSON` and the engine's HTTP API socket. ([#36721](https://github.com/wazuh/wazuh/issues/37521))
 
 ### Agent
 

--- a/api/test/integration/test_cluster_endpoints.tavern.yaml
+++ b/api/test/integration/test_cluster_endpoints.tavern.yaml
@@ -1227,15 +1227,15 @@ stages:
     response:
       status_code: 200
       json:
-        error: 2
+        error: 0
         data:
           affected_items:
             - name: wazuh-manager-remoted
+            - name: wazuh-manager-analysisd
             - name: wazuh-manager-db
-          total_affected_items: 2
-          failed_items:
-            - id: [ wazuh-manager-analysisd ]
-          total_failed_items: 1
+          total_affected_items: 3
+          failed_items: []
+          total_failed_items: 0
 
   # GET /cluster/{node_id}/daemons/stats?daemons_list=wazuh-manager-remoted
   - name: Get statistics from a single daemon from {node_id}

--- a/framework/wazuh/stats.py
+++ b/framework/wazuh/stats.py
@@ -135,7 +135,7 @@ def get_daemons_stats(daemons_list: list = None) -> AffectedItemsWazuhResult:
         Dictionary with the stats of the input file.
     """
     daemon_socket_mapping = {'wazuh-manager-remoted': common.REMOTED_SOCKET,
-                             'wazuh-manager-analysisd': common.ANALYSISD_SOCKET,
+                             'wazuh-manager-analysisd': None,
                              'wazuh-manager-db': common.WDB_SOCKET}
     result = AffectedItemsWazuhResult(all_msg='Statistical information for each daemon was successfully read',
                                       some_msg='Could not read statistical information for some daemons',
@@ -143,7 +143,14 @@ def get_daemons_stats(daemons_list: list = None) -> AffectedItemsWazuhResult:
 
     for daemon in daemons_list or daemon_socket_mapping.keys():
         try:
-            result.affected_items.append(get_daemons_stats_socket(daemon_socket_mapping[daemon]))
+            if daemon == 'wazuh-manager-analysisd':
+                client = EngineHTTPClient()
+                try:
+                    result.affected_items.append(client.get_metrics_dump())
+                finally:
+                    client.close()
+            else:
+                result.affected_items.append(get_daemons_stats_socket(daemon_socket_mapping[daemon]))
         except WazuhException as e:
             result.add_failed_item(id_=daemon, error=e)
 

--- a/framework/wazuh/tests/test_stats.py
+++ b/framework/wazuh/tests/test_stats.py
@@ -37,16 +37,22 @@ def send_msg_to_wdb(msg, raw=False):
 
 
 @patch('wazuh.core.common.REMOTED_SOCKET', '/var/wazuh-manager/queue/sockets/remote')
-@patch('wazuh.core.common.ANALYSISD_SOCKET', '/var/wazuh-manager/queue/sockets/analysis')
 @patch('wazuh.core.common.WDB_SOCKET', '/var/wazuh-manager/queue/db/wdb')
+@patch('wazuh.stats.EngineHTTPClient')
 @patch('wazuh.stats.get_daemons_stats_socket')
-def test_get_daemons_stats(mock_get_daemons_stats_socket):
+def test_get_daemons_stats(mock_get_daemons_stats_socket, mock_engine_client_cls):
     """Makes sure get_daemons_stats() fit with the expected."""
+    mock_engine_client = MagicMock()
+    mock_engine_client.get_metrics_dump.return_value = METRICS_DUMP_DATA
+    mock_engine_client_cls.return_value = mock_engine_client
+
     response = stats.get_daemons_stats(['wazuh-manager-remoted', 'wazuh-manager-analysisd', 'wazuh-manager-db'])
 
-    calls = [call('/var/wazuh-manager/queue/sockets/remote'), call('/var/wazuh-manager/queue/sockets/analysis'),
-             call('/var/wazuh-manager/queue/db/wdb')]
+    # remoted and db still use the socket; analysisd goes through EngineHTTPClient
+    calls = [call('/var/wazuh-manager/queue/sockets/remote'), call('/var/wazuh-manager/queue/db/wdb')]
     mock_get_daemons_stats_socket.assert_has_calls(calls)
+    mock_engine_client.get_metrics_dump.assert_called_once()
+    mock_engine_client.close.assert_called_once()
     assert isinstance(response, AffectedItemsWazuhResult), 'The result is not AffectedItemsWazuhResult type'
     assert response.total_affected_items == len(response.affected_items)
 


### PR DESCRIPTION
## Description

GET /cluster/{node_id}/daemons/stats always returned error 1014 for wazuh-manager-analysisd even when the daemon was running. queue/sockets/analysis is the engine's HTTP API socket, not a JSON stats socket. The framework was sending a 4-byte length-prefixed JSON message that the engine does not understand, causing the connection to close immediately.


## Proposed Changes

- EngineHTTPClient().get_metrics_dump() instead of get_daemons_stats_socket().
- framework/wazuh/tests/test_stats.py — Update test_get_daemons_stats to mock EngineHTTPClient and assert it is called for analysisd.

### Results and Evidence

```
(venv) ╭─root@89ebd703d7af /workspaces/devContainer/wazuh ‹enhancement/36720-memory-imprements-part-2●›
╰─# service wazuh-manager start
Starting Wazuh v5.0.0...
Started wazuh-manager-apid...
Started wazuh-manager-authd...
Started wazuh-manager-db...
Started wazuh-manager-analysisd...
Started wazuh-manager-remoted...
Started wazuh-manager-monitord...
Started wazuh-manager-modulesd...
Started wazuh-manager-clusterd...
Completed.
(venv) ╭─root@89ebd703d7af /workspaces/devContainer/wazuh ‹enhancement/36720-memory-imprements-part-2●›
╰─# TOKEN=$(curl -u wazuh:wazuh -k -X POST "https://localhost:55000/security/user/authenticate?raw=true")
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   429  100   429    0     0   3565      0 --:--:-- --:--:-- --:--:--  3575
(venv) ╭─root@89ebd703d7af /workspaces/devContainer/wazuh ‹enhancement/36720-memory-imprements-part-2●›
╰─# echo ${TOKEN}
eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNzgzNTM4MzQ0LCJuYmZfbXMiOjE3ODM1MzgzNDQ5MzMsImV4cCI6MTc4MzUzOTI0NCwic3ViIjoid2F6dWgiLCJydW5fYXMiOmZhbHNlLCJyYmFjX3JvbGVzIjpbMV0sInJiYWNfbW9kZSI6IndoaXRlIn0.ALLsQFGb1ml50orB2Dx2JtUMhULHCHZvxfnNN2ZxGrQSIm0ke-BFyzUDNdlqwRCsu2MQKrnXFBjMIrbn9VCsURIKAH09ujgbxPdvIsACdksDop5roBhRFR6QrUpoBp6zwUCSSlc5UTmniuEqraS6DR787TEt6BMYD2MX1zHMs3xuiUEb
(venv) ╭─root@89ebd703d7af /workspaces/devContainer/wazuh ‹bug/37521-request--daemons-stats-fails› 
╰─# curl -s -k -H "Authorization: Bearer $TOKEN" \
  "https://localhost:55000/cluster/node01/daemons/stats?daemons_list=wazuh-manager-analysisd&pretty=true"
{
   "data": {
      "affected_items": [
         {
            "status": "OK",
            "global": [
               {
                  "name": "server.events.received",
                  "type": "counter",
                  "enabled": true,
                  "value": 5000
               },
               {
                  "name": "server.bytes.received",
                  "type": "counter",
                  "enabled": true,
                  "value": 526359
               },
               {
                  "name": "router.events.processed",
                  "type": "counter",
                  "enabled": true,
                  "value": 5000
               },
               {
                  "name": "indexer.queue.usage.percent",
                  "type": "pull",
                  "enabled": true,
                  "value": 9.215867519378662
               },
               {
                  "name": "router.queue.size",
                  "type": "pull",
                  "enabled": true,
                  "value": 0
               },
               {
                  "name": "router.eps.30m",
                  "type": "pull",
                  "enabled": true,
                  "value": 2.7777777777777777
               },
               {
                  "name": "router.queue.usage.percent",
                  "type": "pull",
                  "enabled": true,
                  "value": 0
               },
               {
                  "name": "router.queue.bytes.usage.percent",
                  "type": "pull",
                  "enabled": true,
                  "value": 0
               },
               {
                  "name": "router.queue.bytes.used",
                  "type": "pull",
                  "enabled": true,
                  "value": 0
               },
               {
                  "name": "router.events.dropped",
                  "type": "counter",
                  "enabled": true,
                  "value": 0
               },
               {
                  "name": "router.eps.1m",
                  "type": "pull",
                  "enabled": true,
                  "value": 83.33333333333333
               },
               {
                  "name": "router.eps.5m",
                  "type": "pull",
                  "enabled": true,
                  "value": 16.666666666666668
               },
               {
                  "name": "indexer.queue.size",
                  "type": "pull",
                  "enabled": true,
                  "value": 6184664
               },
               {
                  "name": "indexer.events.dropped",
                  "type": "pull",
                  "enabled": true,
                  "value": 0
               }
            ],
            "spaces": [
               {
                  "name": "standard",
                  "metrics": [
                     {
                        "name": "events.unclassified",
                        "type": "counter",
                        "enabled": true,
                        "value": 0
                     },
                     {
                        "name": "events.discarded.postfilter",
                        "type": "counter",
                        "enabled": true,
                        "value": 0
                     },
                     {
                        "name": "events.discarded",
                        "type": "counter",
                        "enabled": true,
                        "value": 0
                     },
                     {
                        "name": "events.discarded.prefilter",
                        "type": "counter",
                        "enabled": true,
                        "value": 0
                     }
                  ]
               }
            ],
            "name": "wazuh-manager-analysisd",
            "uptime": "2026-07-08T19:30:19.695Z",
            "timestamp": "2026-07-08T19:32:59.665Z"
         }
      ],
      "total_affected_items": 1,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "Statistical information for each daemon was successfully read",
   "error": 0
}

```

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
