### PR TITLE
Remove WMI dependency in GetVersion

### DIFF
--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -346,12 +346,24 @@ public function config()
 End Function
 
 Private Function GetVersion()
-	Set objWMIService = GetObject("winmgmts:\\.\root\cimv2")
-	Set colItems = objWMIService.ExecQuery("Select * from Win32_OperatingSystem",,48)
+	On Error Resume Next
 
-	For Each objItem in colItems
-		GetVersion = Split(objItem.Version,".")(0)
-	Next
+	Set WshShell = CreateObject("WScript.Shell")
+
+	majorVersion = WshShell.RegRead("HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentMajorVersionNumber")
+	If Err.Number = 0 And IsNumeric(majorVersion) Then
+		GetVersion = CStr(majorVersion)
+	Else
+		Err.Clear
+		currentVersion = WshShell.RegRead("HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentVersion")
+		If Err.Number = 0 And Len(currentVersion) > 0 Then
+			GetVersion = Split(currentVersion, ".")(0)
+		Else
+			GetVersion = "0"
+		End If
+	End If
+
+	On Error GoTo 0
 End Function
 
 Public Function CheckSvcRunning()


### PR DESCRIPTION
## Description

Closes #37526

The Windows MSI installer can fail with `Error 1720` / `Error 1603` on hosts where WMI cannot service a query (e.g. insufficient paging file, `ERROR_COMMITMENT_LIMIT`, or a corrupted WMI repository). PR #34543 already migrated the `CheckSvcRunning` custom action off WMI (`Win32_Service` → `sc.exe`), but `GetVersion()`, invoked from `SetWazuhPermissions()` during `CustomAction_InstallerScripts`, still depended on WMI (`Win32_OperatingSystem`). On affected hosts the `For Each` enumeration over the WMI query result throws, the custom action returns a failure HRESULT, and MSI rolls back the entire installation.

## Proposed Changes

- Replaced the WMI query (`GetObject("winmgmts:\\.\root\cimv2")` + `Win32_OperatingSystem`) in `GetVersion()` (`src/win32/InstallerScripts.vbs`) with a registry read via `WScript.Shell.RegRead`, removing the last remaining WMI dependency from the installer scripts.
- Reads `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentMajorVersionNumber` (available on Windows 10+ / Server 2016+), with a fallback to parsing the `CurrentVersion` string value for older systems (e.g. `6.1`, `6.3`).
- Wrapped the reads in `On Error Resume Next` / `On Error GoTo 0`, matching the pattern used in `CheckSvcRunning`, so a registry read failure falls back to `"0"` instead of aborting the install. Callers comparing `GetVersion() >= 6` are unaffected since VBScript coerces the numeric string.

### Results and Evidence

N/A — no environment with a reproducible WMI failure was available for this change; see manual tests below for the healthy-WMI regression check. Reviewer input welcome on validating against a host that reproduces the original failure.

### Manual tests with their corresponding evidence

<!-- Depending on the affected components by this PR, the following checks should be selected and marked. -->

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

N/A — this change only affects the Windows MSI installer custom action script (`InstallerScripts.vbs`), not compiled agent/manager code, decoders/rules, the Engine, or the server API/Framework.

### Artifacts Affected

- `src/win32/InstallerScripts.vbs` — Windows MSI installer custom action script.
- Windows MSI installer package (`.msi`).

### Configuration Changes

N/A

### Tests Introduced

N/A — no automated test harness exists for the MSI custom action scripts in this repository. Verification requires manual installation testing on Windows (ideally including a host/VM with WMI put into a failing state, as described in #37526).

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
