### PR TITLE
Reduce authd enrollment log severity for expected rejections

### DIFF
--- a/src/os_auth/include/auth.h
+++ b/src/os_auth/include/auth.h
@@ -152,11 +152,13 @@ w_err_t w_auth_validate_data(char *response,
  * @param hash_key Hash of the key on the agent
  * @param force_options Force configuration structure to define how the agent replacement must be handled.
  * @param str_result A message related to the result of the agent replacement. Must be freed by the caller.
+ * @param warn Set to true when the rejection reflects a live identity conflict (the existing agent is still connected and does not self-heal); false for transient or expected rejections. May be NULL.
  * */
 w_err_t w_auth_replace_agent(keyentry *key,
                              const char *key_hash,
                              authd_force_options_t *force_options,
-                             char** str_result);
+                             char** str_result,
+                             bool *warn);
 
 /**
  * @brief Adds new agent with provided enrollment data.

--- a/src/os_auth/src/auth.c
+++ b/src/os_auth/src/auth.c
@@ -100,7 +100,7 @@ w_err_t w_auth_parse_data(const char* buf,
         }
 
         if (parseok == 0) {
-            merror("Invalid password provided by %s. Closing connection.", ip);
+            minfo("Invalid password provided by %s. Closing connection.", ip);
             snprintf(response, OS_SIZE_2048, "ERROR: Invalid password");
             return OS_INVALID;
         }
@@ -248,7 +248,8 @@ w_err_t w_auth_parse_data(const char* buf,
 w_err_t w_auth_replace_agent(keyentry *key,
                              const char *key_hash,
                              authd_force_options_t *force_options,
-                             char** str_result) {
+                             char** str_result,
+                             bool *warn) {
 
     cJSON *j_agent_info = NULL;
     cJSON *j_date_add = NULL;
@@ -256,6 +257,10 @@ w_err_t w_auth_replace_agent(keyentry *key,
     cJSON *j_connection_status = NULL;
     bool replace_agent = true;
     char message[OS_SIZE_128] = {0};
+
+    if (warn) {
+        *warn = false;
+    }
 
     /* Check if the agent replacement is allowed */
     if (!force_options->enabled) {
@@ -290,6 +295,9 @@ w_err_t w_auth_replace_agent(keyentry *key,
                 snprintf(message, OS_SIZE_128, "Agent '%s' can't be replaced since it is not disconnected.", key->id);
                 os_strdup(message, *str_result);
                 replace_agent = false;
+                if (warn) {
+                    *warn = true;
+                }
             }
         }
     }
@@ -336,6 +344,7 @@ w_err_t w_auth_validate_data(char *response,
     int index = 0;
     char* str_result = NULL;
     w_err_t result = OS_SUCCESS;
+    bool warn = false;
 
     /* Validate the group(s) name(s) */
     if (groups) {
@@ -344,10 +353,14 @@ w_err_t w_auth_validate_data(char *response,
 
     /* Check for duplicate IP */
     if (result != OS_INVALID && strcmp(ip, "any") != 0 && (index = OS_IsAllowedIP(&keys, ip), index >= 0)) {
-        if(OS_SUCCESS == w_auth_replace_agent(keys.keyentries[index], key_hash, &config.force_options, &str_result)) {
+        if(OS_SUCCESS == w_auth_replace_agent(keys.keyentries[index], key_hash, &config.force_options, &str_result, &warn)) {
             minfo("Duplicate IP '%s'. %s", ip, str_result);
         } else {
-            mwarn("Duplicate IP '%s', rejecting enrollment. %s", ip, str_result);
+            if (warn) {
+                mwarn("Duplicate IP '%s', rejecting enrollment. %s", ip, str_result);
+            } else {
+                minfo("Duplicate IP '%s', rejecting enrollment. %s", ip, str_result);
+            }
             snprintf(response, OS_SIZE_2048, "ERROR: Duplicate IP: %s", ip);
             result = OS_INVALID;
         }
@@ -355,10 +368,14 @@ w_err_t w_auth_validate_data(char *response,
 
     /* Check for duplicate name */
     if (result != OS_INVALID && (index = OS_IsAllowedName(&keys, agentname), index >= 0)) {
-        if(OS_SUCCESS == w_auth_replace_agent(keys.keyentries[index], key_hash, &config.force_options, &str_result)) {
+        if(OS_SUCCESS == w_auth_replace_agent(keys.keyentries[index], key_hash, &config.force_options, &str_result, &warn)) {
             minfo("Duplicate name. %s", str_result);
         } else {
-            mwarn("Duplicate name '%s', rejecting enrollment. %s", agentname, str_result);
+            if (warn) {
+                mwarn("Duplicate name '%s', rejecting enrollment. %s", agentname, str_result);
+            } else {
+                minfo("Duplicate name '%s', rejecting enrollment. %s", agentname, str_result);
+            }
             snprintf(response, OS_SIZE_2048, "ERROR: Duplicate agent name: %s", agentname);
             result = OS_INVALID;
         }

--- a/src/os_auth/src/local-server.c
+++ b/src/os_auth/src/local-server.c
@@ -354,6 +354,7 @@ cJSON* local_add(const char *id,
     int ierror;
     char* str_result = NULL;
     char _ip[IPSIZE + 1] = {0};
+    bool warn = false;
 
     mdebug2("add(%s)", name);
     w_mutex_lock(&mutex_keys);
@@ -368,10 +369,14 @@ cJSON* local_add(const char *id,
 
     // Check for duplicate ID
     if (id && (index = OS_IsAllowedID(&keys, id), index >= 0)) {
-        if(OS_SUCCESS == w_auth_replace_agent(keys.keyentries[index], key_hash, force_options, &str_result)) {
+        if(OS_SUCCESS == w_auth_replace_agent(keys.keyentries[index], key_hash, force_options, &str_result, &warn)) {
             minfo("Duplicate ID. %s", str_result);
         } else {
-            mwarn("Duplicate ID, rejecting enrollment. %s", str_result);
+            if (warn) {
+                mwarn("Duplicate ID, rejecting enrollment. %s", str_result);
+            } else {
+                minfo("Duplicate ID, rejecting enrollment. %s", str_result);
+            }
             ierror = EDUPID;
             goto fail;
         }
@@ -393,10 +398,14 @@ cJSON* local_add(const char *id,
         w_free_os_ip(aux_ip);
 
         if (index = OS_IsAllowedIP(&keys, _ip), index >= 0) {
-            if (OS_SUCCESS == w_auth_replace_agent(keys.keyentries[index], key_hash, force_options, &str_result)) {
+            if (OS_SUCCESS == w_auth_replace_agent(keys.keyentries[index], key_hash, force_options, &str_result, &warn)) {
                 minfo("Duplicate IP '%s'. %s", _ip, str_result);
             } else {
-                mwarn("Duplicate IP '%s', rejecting enrollment. %s", _ip, str_result);
+                if (warn) {
+                    mwarn("Duplicate IP '%s', rejecting enrollment. %s", _ip, str_result);
+                } else {
+                    minfo("Duplicate IP '%s', rejecting enrollment. %s", _ip, str_result);
+                }
                 ierror = EDUPIP;
                 goto fail;
             }
@@ -413,10 +422,14 @@ cJSON* local_add(const char *id,
 
     /* Check for duplicate names */
     if (index = OS_IsAllowedName(&keys, name), index >= 0) {
-        if(OS_SUCCESS == w_auth_replace_agent(keys.keyentries[index], key_hash, force_options, &str_result)) {
+        if(OS_SUCCESS == w_auth_replace_agent(keys.keyentries[index], key_hash, force_options, &str_result, &warn)) {
             minfo("Duplicate name. %s", str_result);
         } else {
-            mwarn("Duplicate name '%s', rejecting enrollment. %s", name, str_result);
+            if (warn) {
+                mwarn("Duplicate name '%s', rejecting enrollment. %s", name, str_result);
+            } else {
+                minfo("Duplicate name '%s', rejecting enrollment. %s", name, str_result);
+            }
             ierror = EDUPNAME;
             goto fail;
         }

--- a/src/unit_tests/os_auth/test_auth_parse.c
+++ b/src/unit_tests/os_auth/test_auth_parse.c
@@ -24,7 +24,8 @@ typedef struct _mocked_log {
     char* merror;
     char* mwarn;
     char* minfo;
-    char* mdebug;
+    char* mdebug1;
+    char* mdebug1_2;
 } mocked_log;
 
 //Sets all the expected log messages
@@ -36,10 +37,13 @@ void set_expected_log (mocked_log* log) {
             expect_string(__wrap__mwarn, formatted_msg, log->mwarn);
     }
     if (log->minfo) {
-            expect_string(__wrap__mdebug1, formatted_msg, log->minfo);
+            expect_string(__wrap__minfo, formatted_msg, log->minfo);
     }
-    if (log->mdebug) {
-            expect_string(__wrap__mdebug1, formatted_msg, log->mdebug);
+    if (log->mdebug1) {
+            expect_string(__wrap__mdebug1, formatted_msg, log->mdebug1);
+    }
+    if (log->mdebug1_2) {
+            expect_string(__wrap__mdebug1, formatted_msg, log->mdebug1_2);
     }
 }
 
@@ -68,35 +72,35 @@ typedef struct _parse_evaluator {
 } parse_evaluator;
 
 parse_evaluator parse_values_default_cfg [] = {
-    { "OSSEC A:'agent1'", "192.0.0.1", NULL,                                                      {"192.0.0.1", "agent1", NULL, NULL},                          {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent1) from: 192.0.0.1", NULL} },
-    { "OSSEC A:'agent2' G:'Group1'", "192.0.0.1", NULL,                                           {"192.0.0.1", "agent2", "Group1", NULL},                      {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent2) from: 192.0.0.1", "Group(s) is: Group1"} },
-    { "OSSEC A:'agent3' G:'Group1,Group2'", "192.0.0.1", NULL,                                    {"192.0.0.1", "agent3", "Group1,Group2", NULL},               {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent3) from: 192.0.0.1", "Group(s) is: Group1,Group2"} },
-    { "OSSEC A:'agent4' G:'Group1,Group2,Group1'", "192.0.0.1", NULL,                             {"192.0.0.1", "agent4", "Group1,Group2", NULL},               {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent4) from: 192.0.0.1", "Group(s) is: Group1,Group2"} },
-    { "OSSEC PASS: pass123 OSSEC A:'agent5'", "192.0.0.1", "pass123",                             {"192.0.0.1", "agent5", NULL, NULL},                          {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent5) from: 192.0.0.1", NULL} },
-    { "OSSEC A:'agent6' IP:'192.0.0.2'", "192.0.0.1", NULL,                                       {"192.0.0.2", "agent6", NULL, NULL},                          {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent6) from: 192.0.0.1", NULL} },
-    { "OSSEC A:'agent7' K:'07f05add1049244e7e71ad0f54f24d8094cd8f8b'", "192.0.0.1", NULL,         {"192.0.0.1", "agent7", NULL, "07f05add1049244e7e71ad0f54f24d8094cd8f8b"},     {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent7) from: 192.0.0.1", NULL} },
-    { "OSSEC A:'agent8' IP:'192.0.0.3' K:'ABC123'", "192.0.0.1", NULL,                            {"192.0.0.3", "agent8", NULL, "ABC123"},                      {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent8) from: 192.0.0.1", NULL} },
-    { "OSSEC PASS: pass123 OSSEC A:'agent9' IP:'192.0.0.3' K:'ABC123'", "192.0.0.1", "pass123",   {"192.0.0.3", "agent9", NULL, "ABC123"},                      {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent9) from: 192.0.0.1", NULL} },
-    { "OSSEC A:'agent10' G:'Group1,Group2' IP:'192.0.0.3' K:'ABC123'", "192.0.0.1", NULL,         {"192.0.0.3", "agent10", "Group1,Group2", "ABC123"},          {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent10) from: 192.0.0.1", "Group(s) is: Group1,Group2"} },
-    { "OSSEC A:'agent11' V:'v4.5.0'", "192.0.0.1", NULL,                                          {"192.0.0.1", "agent11", NULL, NULL},                         {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent11) from: 192.0.0.1", NULL} },
+    { "OSSEC A:'agent1'", "192.0.0.1", NULL,                                                      {"192.0.0.1", "agent1", NULL, NULL},                          {OS_SUCCESS,""}, {NULL, NULL, NULL, "Received request for a new agent (agent1) from: 192.0.0.1", NULL} },
+    { "OSSEC A:'agent2' G:'Group1'", "192.0.0.1", NULL,                                           {"192.0.0.1", "agent2", "Group1", NULL},                      {OS_SUCCESS,""}, {NULL, NULL, NULL, "Received request for a new agent (agent2) from: 192.0.0.1", "Group(s) is: Group1"} },
+    { "OSSEC A:'agent3' G:'Group1,Group2'", "192.0.0.1", NULL,                                    {"192.0.0.1", "agent3", "Group1,Group2", NULL},               {OS_SUCCESS,""}, {NULL, NULL, NULL, "Received request for a new agent (agent3) from: 192.0.0.1", "Group(s) is: Group1,Group2"} },
+    { "OSSEC A:'agent4' G:'Group1,Group2,Group1'", "192.0.0.1", NULL,                             {"192.0.0.1", "agent4", "Group1,Group2", NULL},               {OS_SUCCESS,""}, {NULL, NULL, NULL, "Received request for a new agent (agent4) from: 192.0.0.1", "Group(s) is: Group1,Group2"} },
+    { "OSSEC PASS: pass123 OSSEC A:'agent5'", "192.0.0.1", "pass123",                             {"192.0.0.1", "agent5", NULL, NULL},                          {OS_SUCCESS,""}, {NULL, NULL, NULL, "Received request for a new agent (agent5) from: 192.0.0.1", NULL} },
+    { "OSSEC A:'agent6' IP:'192.0.0.2'", "192.0.0.1", NULL,                                       {"192.0.0.2", "agent6", NULL, NULL},                          {OS_SUCCESS,""}, {NULL, NULL, NULL, "Received request for a new agent (agent6) from: 192.0.0.1", NULL} },
+    { "OSSEC A:'agent7' K:'07f05add1049244e7e71ad0f54f24d8094cd8f8b'", "192.0.0.1", NULL,         {"192.0.0.1", "agent7", NULL, "07f05add1049244e7e71ad0f54f24d8094cd8f8b"},     {OS_SUCCESS,""}, {NULL, NULL, NULL, "Received request for a new agent (agent7) from: 192.0.0.1", NULL} },
+    { "OSSEC A:'agent8' IP:'192.0.0.3' K:'ABC123'", "192.0.0.1", NULL,                            {"192.0.0.3", "agent8", NULL, "ABC123"},                      {OS_SUCCESS,""}, {NULL, NULL, NULL, "Received request for a new agent (agent8) from: 192.0.0.1", NULL} },
+    { "OSSEC PASS: pass123 OSSEC A:'agent9' IP:'192.0.0.3' K:'ABC123'", "192.0.0.1", "pass123",   {"192.0.0.3", "agent9", NULL, "ABC123"},                      {OS_SUCCESS,""}, {NULL, NULL, NULL, "Received request for a new agent (agent9) from: 192.0.0.1", NULL} },
+    { "OSSEC A:'agent10' G:'Group1,Group2' IP:'192.0.0.3' K:'ABC123'", "192.0.0.1", NULL,         {"192.0.0.3", "agent10", "Group1,Group2", "ABC123"},          {OS_SUCCESS,""}, {NULL, NULL, NULL, "Received request for a new agent (agent10) from: 192.0.0.1", "Group(s) is: Group1,Group2"} },
+    { "OSSEC A:'agent11' V:'v4.5.0'", "192.0.0.1", NULL,                                          {"192.0.0.1", "agent11", NULL, NULL},                         {OS_SUCCESS,""}, {NULL, NULL, NULL, "Received request for a new agent (agent11) from: 192.0.0.1", NULL} },
 
-    { "OSSEC A:'agent0'", "192.0.0.1", "pass123",                       {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid password"},              {"Invalid password provided by 192.0.0.1. Closing connection.", NULL, NULL, NULL} },
-    { "OSSEC PASS: pass124 OSSEC A:'agent0'", "192.0.0.1", "pass123",   {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid password"},              {"Invalid password provided by 192.0.0.1. Closing connection.", NULL, NULL, NULL} },
-    { "OSSEC PASS: pass124 OSSEC A:'agent0'", "192.0.0.1", NULL,        {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid request for new agent"}, {"Invalid request for new agent from: 192.0.0.1", NULL, NULL, NULL} },
-    { "OSSEC A:''", "192.0.0.1", NULL,                                  {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid agent name: "},          {"Invalid agent name:  from 192.0.0.1", NULL, "Received request for a new agent () from: 192.0.0.1", NULL} },
-    { "OSSEC A:'inv;agent'", "192.0.0.1", NULL,                         {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid agent name: inv;agent"}, {"Invalid agent name: inv;agent from 192.0.0.1", NULL, "Received request for a new agent (inv;agent) from: 192.0.0.1", NULL} },
-    { "OSSEC A:'agent3' G:'Group1,Group2", "192.0.0.1", NULL,           {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Unterminated group field"}, {"Unterminated group field", NULL, "Received request for a new agent (agent3) from: 192.0.0.1", NULL} },
-    { "OSSEC A:'agent3' G:'Group1,Group2' IP:'192.0.0.3 K:'ABC123'", "192.0.0.1", NULL,           {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Unterminated IP field"}, {"Unterminated IP field", NULL, "Received request for a new agent (agent3) from: 192.0.0.1", "Group(s) is: Group1,Group2"} },
-    { "OSSEC A:'agent3' G:'Group1,Group2' IP:'192.0.0.3' K:'ABC123", "192.0.0.1", NULL,           {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Unterminated key field"}, {"Unterminated key field", NULL, "Received request for a new agent (agent3) from: 192.0.0.1", "Group(s) is: Group1,Group2"} },
-    { "OSSEC A:'agent3' V:'v4.5.0", "192.0.0.1", NULL,                  {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Unterminated version field"},    {"Unterminated version field", NULL, "Received request for a new agent (agent3) from: 192.0.0.1", NULL} },
-    { "OSSEC A:'agent4' V:'v5.6.0'", "192.0.0.1", NULL,                 {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Agent version must be lower or equal to manager version"},          {"Incompatible version for new agent from: 192.0.0.1", NULL, "Received request for a new agent (agent4) from: 192.0.0.1", NULL} },
+    { "OSSEC A:'agent0'", "192.0.0.1", "pass123",                       {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid password"},              {NULL, NULL, "Invalid password provided by 192.0.0.1. Closing connection.", NULL, NULL} },
+    { "OSSEC PASS: pass124 OSSEC A:'agent0'", "192.0.0.1", "pass123",   {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid password"},              {NULL, NULL, "Invalid password provided by 192.0.0.1. Closing connection.", NULL, NULL} },
+    { "OSSEC PASS: pass124 OSSEC A:'agent0'", "192.0.0.1", NULL,        {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid request for new agent"}, {"Invalid request for new agent from: 192.0.0.1", NULL, NULL, NULL, NULL} },
+    { "OSSEC A:''", "192.0.0.1", NULL,                                  {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid agent name: "},          {"Invalid agent name:  from 192.0.0.1", NULL, NULL, "Received request for a new agent () from: 192.0.0.1", NULL} },
+    { "OSSEC A:'inv;agent'", "192.0.0.1", NULL,                         {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Invalid agent name: inv;agent"}, {"Invalid agent name: inv;agent from 192.0.0.1", NULL, NULL, "Received request for a new agent (inv;agent) from: 192.0.0.1", NULL} },
+    { "OSSEC A:'agent3' G:'Group1,Group2", "192.0.0.1", NULL,           {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Unterminated group field"}, {"Unterminated group field", NULL, NULL, "Received request for a new agent (agent3) from: 192.0.0.1", NULL} },
+    { "OSSEC A:'agent3' G:'Group1,Group2' IP:'192.0.0.3 K:'ABC123'", "192.0.0.1", NULL,           {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Unterminated IP field"}, {"Unterminated IP field", NULL, NULL, "Received request for a new agent (agent3) from: 192.0.0.1", "Group(s) is: Group1,Group2"} },
+    { "OSSEC A:'agent3' G:'Group1,Group2' IP:'192.0.0.3' K:'ABC123", "192.0.0.1", NULL,           {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Unterminated key field"}, {"Unterminated key field", NULL, NULL, "Received request for a new agent (agent3) from: 192.0.0.1", "Group(s) is: Group1,Group2"} },
+    { "OSSEC A:'agent3' V:'v4.5.0", "192.0.0.1", NULL,                  {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Unterminated version field"},    {"Unterminated version field", NULL, NULL, "Received request for a new agent (agent3) from: 192.0.0.1", NULL} },
+    { "OSSEC A:'agent4' V:'v5.6.0'", "192.0.0.1", NULL,                 {NULL, NULL, NULL, NULL}, {OS_INVALID,"ERROR: Agent version must be lower or equal to manager version"},          {"Incompatible version for new agent from: 192.0.0.1", NULL, NULL, "Received request for a new agent (agent4) from: 192.0.0.1", NULL} },
 
     {0}
 };
 
 parse_evaluator parse_values_without_use_src_ip_cfg [] = {
-    {"OSSEC A:'agent1'", "192.0.0.1", NULL,                             {"any", "agent1", NULL, NULL},                    {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent1) from: 192.0.0.1", NULL} },
-    {"OSSEC A:'agent2' IP:'192.0.0.2'", "192.0.0.1", NULL,              {"192.0.0.2", "agent2", NULL, NULL},              {OS_SUCCESS,""}, {NULL, NULL, "Received request for a new agent (agent2) from: 192.0.0.1", NULL} },
+    {"OSSEC A:'agent1'", "192.0.0.1", NULL,                             {"any", "agent1", NULL, NULL},                    {OS_SUCCESS,""}, {NULL, NULL, NULL, "Received request for a new agent (agent1) from: 192.0.0.1", NULL} },
+    {"OSSEC A:'agent2' IP:'192.0.0.2'", "192.0.0.1", NULL,              {"192.0.0.2", "agent2", NULL, NULL},              {OS_SUCCESS,""}, {NULL, NULL, NULL, "Received request for a new agent (agent2) from: 192.0.0.1", NULL} },
 
     {0}
 };

--- a/src/unit_tests/os_auth/test_auth_validate.c
+++ b/src/unit_tests/os_auth/test_auth_validate.c
@@ -173,7 +173,7 @@ static void test_w_auth_validate_data(void **state) {
 
     /* Existent IP */
     response[0] = '\0';
-    expect_string(__wrap__mwarn, formatted_msg, "Duplicate IP '"EXISTENT_IP1"', rejecting enrollment. "
+    expect_string(__wrap__minfo, formatted_msg, "Duplicate IP '"EXISTENT_IP1"', rejecting enrollment. "
                                                 "Agent '001' won't be removed because the force option is disabled.");
     err = w_auth_validate_data(response, EXISTENT_IP1, NEW_AGENT1, NULL, NULL);
     assert_int_equal(err, OS_INVALID);
@@ -181,7 +181,7 @@ static void test_w_auth_validate_data(void **state) {
 
     /* Existent Agent Name */
     response[0] = '\0';
-    expect_string(__wrap__mwarn, formatted_msg, "Duplicate name '"EXISTENT_AGENT1"', rejecting enrollment. "
+    expect_string(__wrap__minfo, formatted_msg, "Duplicate name '"EXISTENT_AGENT1"', rejecting enrollment. "
                                                 "Agent '001' won't be removed because the force option is disabled.");
     err = w_auth_validate_data(response, NEW_IP1, EXISTENT_AGENT1, NULL, NULL);
     assert_int_equal(err, OS_INVALID);
@@ -371,7 +371,7 @@ static void test_w_auth_replace_agent_force_disabled(void **state) {
     keyentry_init(&key, NEW_AGENT1, AGENT1_ID, NEW_IP1, NULL);
     char* str_result = NULL;
 
-    err = w_auth_replace_agent(&key, NULL, &config.force_options, &str_result);
+    err = w_auth_replace_agent(&key, NULL, &config.force_options, &str_result, NULL);
 
     assert_int_equal(err, OS_INVALID);
     assert_string_equal(str_result, "Agent '001' won't be removed because the force option is disabled.");
@@ -389,7 +389,7 @@ static void test_w_auth_replace_agent_agent_info_failed(void **state) {
     expect_value(__wrap_wdb_get_agent_info, id, 1);
     will_return(__wrap_wdb_get_agent_info, NULL);
 
-    err = w_auth_replace_agent(&key, NULL, &config.force_options, &str_result);
+    err = w_auth_replace_agent(&key, NULL, &config.force_options, &str_result, NULL);
 
     config.force_options.enabled = 0;
     assert_int_equal(err, OS_INVALID);
@@ -400,6 +400,7 @@ static void test_w_auth_replace_agent_agent_info_failed(void **state) {
 
 static void test_w_auth_replace_agent_not_disconnected(void **state) {
     w_err_t err;
+    bool warn = false;
     keyentry key;
     keyentry_init(&key, NEW_AGENT1, AGENT1_ID, NEW_IP1, NULL);
     char *connection_status = "active";
@@ -425,9 +426,10 @@ static void test_w_auth_replace_agent_not_disconnected(void **state) {
     config.force_options.disconnected_time_enabled = true;
     config.force_options.disconnected_time = 100;
 
-    err = w_auth_replace_agent(&key, NULL, &config.force_options, &str_result);
+    err = w_auth_replace_agent(&key, NULL, &config.force_options, &str_result, &warn);
 
     assert_int_equal(err, OS_INVALID);
+    assert_true(warn);
     assert_string_equal(str_result, "Agent '001' can't be replaced since it is not disconnected.");
     free_keyentry(&key);
     os_free(str_result);
@@ -460,7 +462,7 @@ static void test_w_auth_replace_agent_not_disconnected_long_enough(void **state)
     config.force_options.disconnected_time_enabled = true;
     config.force_options.disconnected_time = 100;
 
-    err = w_auth_replace_agent(&key, NULL, &config.force_options, &str_result);
+    err = w_auth_replace_agent(&key, NULL, &config.force_options, &str_result, NULL);
 
     config.force_options.disconnected_time_enabled = false;
     config.force_options.disconnected_time = 0;
@@ -499,7 +501,7 @@ static void test_w_auth_replace_agent_not_old_enough(void **state) {
 
     config.force_options.after_registration_time = 100;
 
-    err = w_auth_replace_agent(&key, NULL, &config.force_options, &str_result);
+    err = w_auth_replace_agent(&key, NULL, &config.force_options, &str_result, NULL);
 
     config.force_options.after_registration_time = 0;
 
@@ -536,7 +538,7 @@ static void test_w_auth_replace_agent_existent_key_hash(void **state) {
     config.force_options.after_registration_time = 0;
     config.force_options.key_mismatch = true;
 
-    err = w_auth_replace_agent(&key, key_hash, &config.force_options, &str_result);
+    err = w_auth_replace_agent(&key, key_hash, &config.force_options, &str_result, NULL);
 
     config.force_options.key_mismatch = false;
 
@@ -572,7 +574,7 @@ static void test_w_auth_replace_agent_success(void **state) {
     config.force_options.disconnected_time_enabled = false;
     config.force_options.after_registration_time = 1;
 
-    err = w_auth_replace_agent(&key, NULL, &config.force_options, &str_result);
+    err = w_auth_replace_agent(&key, NULL, &config.force_options, &str_result, NULL);
 
     config.force_options.after_registration_time = 0;
 


### PR DESCRIPTION
## Description

During Wazuh 5.0.0 Beta 3 testing the manager logged `WARNING`/`ERROR` lines for
enrollment events that are expected and self-healing, which read like manager
faults:

```
wazuh-manager-authd: WARNING: Duplicate name 'ubuntu24-agent', rejecting enrollment. Agent '003' has not been disconnected long enough to be replaced.
wazuh-manager-authd: ERROR: Invalid password provided by 127.0.0.1. Closing connection.
```

None of these is a manager fault: a wrong enrollment password is just a rejected
client, and a duplicate that cannot be replaced is `authd` enforcing its own
force-replace policy. `WARNING` should be reserved for problems the operator must
actually attend to, so a single agent failing to enroll should not raise one.

Ref #37514

## Proposed Changes

- **Invalid enrollment password** (`auth.c`): `ERROR` -> `INFO`. The connection is
  still rejected; only the severity changes.

- **Duplicate name / IP / ID rejection** (`auth.c`, `local-server.c`): logged at
  `INFO` by default, escalated to `WARNING` only when the rejection reflects a
  **live identity conflict** the manager should attend to, i.e. the existing agent
  is still connected (`disconnection_time == 0`) so the conflict does not
  self-heal. The transient cases (recently disconnected, too new to replace, same
  key, force disabled) stay at `INFO` because they clear on their own once the
  force window elapses.

This mirrors the persistence-based approach used for the duplicate-connection
warning in `remoted` (#37408 / #37493): warn only when the condition persists,
not on the transient case that resolves itself. Here the persistence signal is
already in the existing agent's connection state, so no extra timestamp is
needed.

`w_auth_replace_agent` reports the live-conflict case via a nullable `warn`
out-parameter, consumed by every rejection site in both enrollment paths (network
`authd` and the local socket) so behavior is identical regardless of how the
agent enrolls.

### Results and Evidence

Same agent re-enrolling within its force window (transient, self-heals):
```
wazuh-manager-authd: INFO: Duplicate name 'ubuntu24-agent', rejecting enrollment. Agent '003' has not been disconnected long enough to be replaced.
```
Wrong enrollment password:
```
wazuh-manager-authd: INFO: Invalid password provided by 127.0.0.1. Closing connection.
```
A different, live agent already holding the name (persistent conflict, still a warning):
```
wazuh-manager-authd: WARNING: Duplicate name 'ubuntu24-agent', rejecting enrollment. Agent '003' can't be replaced since it is not disconnected.
```

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

### Artifacts Affected

- `wazuh-authd` enrollment logging (integrated into `wazuh-manager`), both the
  network enrollment service and the local socket.

### Configuration Changes

N/A

### Tests Introduced

Existing `os_auth` unit tests updated:
- `test_auth_validate.c`: `w_auth_replace_agent` live-conflict case asserts the
  new `warn` flag; force-disabled `w_auth_validate_data` rejections now expect
  `info`.
- `test_auth_parse.c`: invalid-password case expects `info`; the mocked-log helper
  exposes a real `minfo` slot plus a second `mdebug1` slot.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
