### PR TITLE
Compilation error in HP-UX arch

### DIFF
--- a/src/shared/time_op.c
+++ b/src/shared/time_op.c
@@ -89,10 +89,13 @@ time_t w_get_monotonic_time(void) {
     clock_get_time(cclock, &mts);
     mach_port_deallocate(mach_task_self(), cclock);
     return (time_t)mts.tv_sec;
-#else
+#elif defined(CLOCK_MONOTONIC)
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
     return ts.tv_sec;
+#else
+    // Platforms without CLOCK_MONOTONIC (e.g. HP-UX 11.31): use the native monotonic high-resolution timer.
+    return (time_t)(gethrtime() / 1000000000LL);
 #endif
 }
 


### PR DESCRIPTION
## Description

The Wazuh agent fails to compile on HP-UX 11.31, breaking package generation for that platform starting in v4.14.7-rc1.

PR #36338 ("Fix agent keepalive scheduling after system clock rollback") added `w_get_monotonic_time()` in `src/shared/time_op.c`. Its non-Windows/non-macOS branch uses the POSIX `CLOCK_MONOTONIC` constant, which is not defined on HP-UX 11.31 with gcc 4.2.3:

```text
CC shared/time_op.o
<command-line>: warning: ISO C99 requires whitespace after the macro name
shared/time_op.c: In function 'w_get_monotonic_time':
shared/time_op.c:94:19: error: 'CLOCK_MONOTONIC' undeclared (first use in this function)
   94 |     clock_gettime(CLOCK_MONOTONIC, &ts);
      |                   ^~~~~~~~~~~~~~~
shared/time_op.c:94:19: note: each undeclared identifier is reported only once for each function it appears in
gmake[1]: *** [Makefile:1728: shared/time_op.o] Error 1
gmake[1]: Leaving directory '/var/wazuh-sources/src'
gmake: *** [Makefile:776: agent] Error 2
```

The compile failure leaves wazuh-execd (and other binaries) unbuilt, so the HP-UX package install/verify step then reports `wazuh-execd: not found` and rejects the package.

## Proposed Changes

- `src/shared/time_op.c`: guard the `clock_gettime(CLOCK_MONOTONIC, ...)` path with a compile-time capability check (`#elif defined(CLOCK_MONOTONIC)`) and add a fallback to the platform's native monotonic timer `gethrtime()` (nanoseconds) for systems lacking `CLOCK_MONOTONIC`, such as HP-UX 11.31.

  The guard is deliberately a capability check, not a platform check (`defined(CLOCK_MONOTONIC)` rather than `defined(__hpux)`): any OS exposing `CLOCK_MONOTONIC` keeps the exact previous code path; only true fallbacks use `gethrtime()`. Monotonic semantics (and therefore the clock-rollback fix intent of #36338) are preserved.

### Results and Evidence

Package generation before fix:
🔴 https://github.com/wazuh/wazuh-agent-packages/actions/runs/29026955852/job/86149111289

Package generation after fix:
🟢 https://github.com/wazuh/wazuh-agent-packages/actions/runs/29049832950/job/86227453899

### Artifacts Affected

- `src/shared/time_op.c`
- HP-UX agent package.

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

N/A

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
