### PR TITLE
Backport: Lower DBSync-not-available shutdown messages to DEBUG to 5.0.0

### DIFF
--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -1838,7 +1838,7 @@ AgentInfoImpl::CoordinationResult AgentInfoImpl::coordinateModules(const std::st
 
             if (!syncResult.success)
             {
-                m_logFunction(LOG_WARNING, "Failed to synchronize " + table +
+                m_logFunction(m_stopped ? LOG_DEBUG : LOG_WARNING, "Failed to synchronize " + table +
                               (syncResult.failureReason.empty() ? "." : ": " + syncResult.failureReason));
                 return CoordinationResult::Failed;
             }
@@ -2274,7 +2274,7 @@ bool AgentInfoImpl::performIntegritySync(const std::string& table)
         }
         else
         {
-            m_logFunction(LOG_WARNING, "Failed integrity check for " + table +
+            m_logFunction(m_stopped ? LOG_DEBUG : LOG_WARNING, "Failed integrity check for " + table +
                           (syncResult.failureReason.empty() ? "." : ": " + syncResult.failureReason));
         }
 

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -752,7 +752,7 @@ bool AgentInfoImpl::updateChanges(const std::string& table, const nlohmann::json
 
         if (!m_dBSync)
         {
-            m_logFunction(LOG_WARNING, "DBSync not available for table " + table);
+            m_logFunction(LOG_DEBUG, "DBSync not available for table " + table);
             return false;
         }
 
@@ -1937,7 +1937,7 @@ void AgentInfoImpl::setSyncFlag(const std::string& table, bool value)
 
             if (!m_dBSync)
             {
-                m_logFunction(LOG_WARNING, "Cannot set sync flag: DBSync not available");
+                m_logFunction(LOG_DEBUG, "Cannot set sync flag: DBSync not available");
                 return;
             }
         }
@@ -1974,7 +1974,7 @@ void AgentInfoImpl::loadSyncFlags()
 
             if (!m_dBSync)
             {
-                m_logFunction(LOG_WARNING, "Cannot load sync flags: DBSync not available");
+                m_logFunction(LOG_DEBUG, "Cannot load sync flags: DBSync not available");
                 return;
             }
 
@@ -2154,7 +2154,7 @@ void AgentInfoImpl::updateLastIntegrityTime(const std::string& table)
 
             if (!m_dBSync)
             {
-                m_logFunction(LOG_WARNING, "Cannot update last integrity time: DBSync not available");
+                m_logFunction(LOG_DEBUG, "Cannot update last integrity time: DBSync not available");
                 return;
             }
         }

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -752,7 +752,7 @@ bool AgentInfoImpl::updateChanges(const std::string& table, const nlohmann::json
 
         if (!m_dBSync)
         {
-            m_logFunction(LOG_DEBUG, "DBSync not available for table " + table);
+            m_logFunction(m_stopped ? LOG_DEBUG : LOG_WARNING, "DBSync not available for table " + table);
             return false;
         }
 
@@ -1937,7 +1937,7 @@ void AgentInfoImpl::setSyncFlag(const std::string& table, bool value)
 
             if (!m_dBSync)
             {
-                m_logFunction(LOG_DEBUG, "Cannot set sync flag: DBSync not available");
+                m_logFunction(m_stopped ? LOG_DEBUG : LOG_WARNING, "Cannot set sync flag: DBSync not available");
                 return;
             }
         }
@@ -1974,7 +1974,7 @@ void AgentInfoImpl::loadSyncFlags()
 
             if (!m_dBSync)
             {
-                m_logFunction(LOG_DEBUG, "Cannot load sync flags: DBSync not available");
+                m_logFunction(m_stopped ? LOG_DEBUG : LOG_WARNING, "Cannot load sync flags: DBSync not available");
                 return;
             }
 
@@ -2154,7 +2154,7 @@ void AgentInfoImpl::updateLastIntegrityTime(const std::string& table)
 
             if (!m_dBSync)
             {
-                m_logFunction(LOG_DEBUG, "Cannot update last integrity time: DBSync not available");
+                m_logFunction(m_stopped ? LOG_DEBUG : LOG_WARNING, "Cannot update last integrity time: DBSync not available");
                 return;
             }
         }


### PR DESCRIPTION
## Description

Closes #37302

Backport of #37325 to the `5.0.0` branch. The original fix was merged into `main` (5.0.1), but the issue belongs to the 5.0.0 release project and the log messages still appear in the 5.0.0 nightly, so the change must ship in 5.0.0.

The fix gates six `wazuh-modulesd:agent-info` messages on the module's `m_stopped` flag: they are logged at `DEBUG` during shutdown and remain `WARNING` during normal operation. These messages report a benign shutdown/restart race (`stop()` sets `m_stopped = true`, then releases the DBSync handle, then stops the sync protocol), so when any guard fires during teardown `m_stopped` is already `true`. This silences the expected shutdown noise at the default log level while keeping a genuine runtime fault visible. 

Full rationale is in #37325 and issue #37302.

## Proposed Changes

- Cherry-picked the three commits from #37325 onto `5.0.0`.
- Gate severity on `m_stopped` (`DEBUG` during shutdown, `WARNING` otherwise) for these `agent-info` messages:
  - `DBSync not available for table <table>`
  - `Cannot set sync flag: DBSync not available`
  - `Cannot load sync flags: DBSync not available`
  - `Cannot update last integrity time: DBSync not available`
  - `Failed to synchronize <table>`
  - `Failed integrity check for <table>`

### Results and Evidence




### Artifacts Affected

- `src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp` (Agent, `wazuh-modulesd`).

### Configuration Changes

- None.

### Documentation Updates

- None.

### Tests Introduced

- None. 

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
