### PR TITLE
Fix remoted agent state cleanup data race

### DIFF
--- a/src/remoted/src/main.c
+++ b/src/remoted/src/main.c
@@ -10,6 +10,7 @@
 
 #include "shared.h"
 #include "remoted.h"
+#include <openssl/crypto.h>
 #include <unistd.h>
 
 /* Prototypes */
@@ -49,6 +50,10 @@ int main(int argc, char **argv)
 
     /* Set the name */
     OS_SetName(ARGV0);
+
+    if (OPENSSL_init_crypto(OPENSSL_INIT_NO_ATEXIT, NULL) != 1) {
+        merror_exit("Could not initialize OpenSSL");
+    }
 
     // Define current working directory
     char * home_path = w_homedir(argv[0]);

--- a/src/remoted/src/state.c
+++ b/src/remoted/src/state.c
@@ -13,6 +13,7 @@
 #include "remoted.h"
 #include "state.h"
 #include <pthread.h>
+#include <stdlib.h>
 
 #ifdef WAZUH_UNIT_TESTING
 // Remove STATIC qualifier from tests
@@ -32,6 +33,14 @@ extern OSHash *remoted_agents_state;
  * @return remoted_agent_state_t node
  */
 STATIC remoted_agent_state_t * get_node(const char *agent_id);
+
+/**
+ * @brief Compare agent IDs for qsort/bsearch
+ * @param a First agent ID
+ * @param b Second agent ID
+ * @return Negative, zero or positive depending on comparison result
+ */
+STATIC int cmp_agent_id(const void *a, const void *b);
 
 /**
  * @brief Clean non active agents from agents state
@@ -151,14 +160,28 @@ STATIC remoted_agent_state_t * get_node(const char *agent_id) {
     }
 }
 
+STATIC int cmp_agent_id(const void *a, const void *b) {
+    int agent_a = *(const int *)a;
+    int agent_b = *(const int *)b;
+
+    return (agent_a > agent_b) - (agent_a < agent_b);
+}
+
 STATIC void w_remoted_clean_agents_state(int *sock) {
     int *active_agents = NULL;
     OSHashNode *hash_node;
     unsigned int inode_it = 0;
+    size_t active_agents_count = 0;
 
     if (active_agents = wdb_get_agents_ids_of_current_node(AGENT_CS_ACTIVE, sock, 0, -1), active_agents == NULL) {
         return;
     }
+
+    while (active_agents[active_agents_count] != -1) {
+        active_agents_count++;
+    }
+
+    qsort(active_agents, active_agents_count, sizeof(int), cmp_agent_id);
 
     char *agent_id = NULL;
     remoted_agent_state_t * agent_state = NULL;
@@ -172,13 +195,8 @@ STATIC void w_remoted_clean_agents_state(int *sock) {
 
         hash_node = OSHash_Next(remoted_agents_state, &inode_it, hash_node);
 
-        int exist = 0;
-        for (size_t i = 0; active_agents[i] != -1; i++) {
-            if (atoi(agent_id) == active_agents[i] ) {
-                exist = 1;
-                break;
-            }
-        }
+        int id = atoi(agent_id);
+        int exist = bsearch(&id, active_agents, active_agents_count, sizeof(int), cmp_agent_id) != NULL;
 
         if (exist == 0) {
             agent_state = (remoted_agent_state_t *)OSHash_Delete_ex(remoted_agents_state, agent_id);

--- a/src/remoted/src/state.c
+++ b/src/remoted/src/state.c
@@ -156,18 +156,16 @@ STATIC void w_remoted_clean_agents_state(int *sock) {
     OSHashNode *hash_node;
     unsigned int inode_it = 0;
 
-    hash_node = OSHash_Begin_ex(remoted_agents_state, &inode_it);
-
-    if (hash_node == NULL) {
-        return;
-    }
-
     if (active_agents = wdb_get_agents_ids_of_current_node(AGENT_CS_ACTIVE, sock, 0, -1), active_agents == NULL) {
         return;
     }
 
     char *agent_id = NULL;
     remoted_agent_state_t * agent_state = NULL;
+
+    w_mutex_lock(&agents_state_mutex);
+
+    hash_node = OSHash_Begin_ex(remoted_agents_state, &inode_it);
 
     while (hash_node) {
         agent_id = hash_node->key;
@@ -187,6 +185,8 @@ STATIC void w_remoted_clean_agents_state(int *sock) {
             os_free(agent_state);
         }
     }
+
+    w_mutex_unlock(&agents_state_mutex);
 
     os_free(active_agents);
     return;

--- a/src/shared/src/http_op.c
+++ b/src/shared/src/http_op.c
@@ -9,13 +9,8 @@
 #include <strings.h> // strncasecmp
 
 /* ------------------------------- Global state ------------------------------- */
-/* Thread-safe, one-time libcurl initialization using pthread_once. */
+/* Thread-safe, one-time libcurl initialization using atomics. */
 static _Atomic int g_curl_state = UHTTP_UNINIT;
-
-static void uhttp_atexit_cleanup(void)
-{
-    curl_global_cleanup();
-}
 
 /**
  * @brief Initialize libcurl globally (idempotent, thread-safe).
@@ -34,7 +29,6 @@ int uhttp_global_init(void)
         CURLcode rc = curl_global_init(CURL_GLOBAL_DEFAULT);
         if (rc == CURLE_OK)
         {
-            atexit(uhttp_atexit_cleanup); // Cleanup only once per process
             atomic_store_explicit(&g_curl_state, UHTTP_INITED, memory_order_release);
             return 0;
         }
@@ -57,13 +51,15 @@ int uhttp_global_init(void)
     }
 }
 
-/**
- * @brief No-op; global cleanup is registered via atexit().
- * Provided for API symmetry only.
- */
 void uhttp_global_cleanup(void)
 {
-    /* no-op */
+    int expected = UHTTP_INITED;
+
+    if (atomic_compare_exchange_strong_explicit(
+            &g_curl_state, &expected, UHTTP_UNINIT, memory_order_acq_rel, memory_order_acquire))
+    {
+        curl_global_cleanup();
+    }
 }
 
 /* ---------------------------- Per-client state ---------------------------- */

--- a/src/unit_tests/remoted/test_remote-state.c
+++ b/src/unit_tests/remoted/test_remote-state.c
@@ -341,6 +341,15 @@ void test_rem_get_node_existing_node(void ** state) {
 }
 
 void test_w_remoted_clean_agents_state_empty_table(void ** state) {
+    int *connected_agents = NULL;
+    os_calloc(1, sizeof(int), connected_agents);
+    connected_agents[0] = OS_INVALID;
+
+    expect_string(__wrap_wdb_get_agents_ids_of_current_node, status, AGENT_CS_ACTIVE);
+    expect_value(__wrap_wdb_get_agents_ids_of_current_node, last_id, 0);
+    expect_value(__wrap_wdb_get_agents_ids_of_current_node, limit, -1);
+    will_return(__wrap_wdb_get_agents_ids_of_current_node, connected_agents);
+
     expect_value(__wrap_OSHash_Begin_ex, self, remoted_agents_state);
     will_return(__wrap_OSHash_Begin_ex, NULL);
 
@@ -403,9 +412,6 @@ void test_w_remoted_clean_agents_state_completed_without_delete(void ** state) {
 
 void test_w_remoted_clean_agents_state_query_fail(void ** state) {
     test_struct_t *test_data  = (test_struct_t *)*state;
-
-    expect_value(__wrap_OSHash_Begin_ex, self, remoted_agents_state);
-    will_return(__wrap_OSHash_Begin_ex, test_data->hash_node);
 
     int *connected_agents = NULL;
 

--- a/src/unit_tests/remoted/test_remote-state.c
+++ b/src/unit_tests/remoted/test_remote-state.c
@@ -392,8 +392,9 @@ void test_w_remoted_clean_agents_state_completed_without_delete(void ** state) {
     will_return(__wrap_OSHash_Begin_ex, test_data->hash_node);
 
     int *connected_agents = NULL;
-    os_calloc(1, sizeof(int), connected_agents);
+    os_calloc(2, sizeof(int), connected_agents);
     connected_agents[0] = 1;
+    connected_agents[1] = OS_INVALID;
 
     expect_string(__wrap_wdb_get_agents_ids_of_current_node, status, AGENT_CS_ACTIVE);
     expect_value(__wrap_wdb_get_agents_ids_of_current_node, last_id, 0);
@@ -408,6 +409,49 @@ void test_w_remoted_clean_agents_state_completed_without_delete(void ** state) {
     w_remoted_clean_agents_state(&sock);
 
     os_free(test_data->agent_state);
+}
+
+void test_w_remoted_clean_agents_state_bsearch_multiple_active(void ** state) {
+    test_struct_t *test_data  = (test_struct_t *)*state;
+
+    OSHashNode *inactive_node = NULL;
+    remoted_agent_state_t *inactive_state = NULL;
+    os_calloc(1, sizeof(OSHashNode), inactive_node);
+    os_calloc(1, sizeof(remoted_agent_state_t), inactive_state);
+    inactive_node->key = "005";
+    inactive_node->data = inactive_state;
+
+    int *connected_agents = NULL;
+    os_calloc(4, sizeof(int), connected_agents);
+    connected_agents[0] = 7;
+    connected_agents[1] = 1;
+    connected_agents[2] = 3;
+    connected_agents[3] = OS_INVALID;
+
+    expect_string(__wrap_wdb_get_agents_ids_of_current_node, status, AGENT_CS_ACTIVE);
+    expect_value(__wrap_wdb_get_agents_ids_of_current_node, last_id, 0);
+    expect_value(__wrap_wdb_get_agents_ids_of_current_node, limit, -1);
+    will_return(__wrap_wdb_get_agents_ids_of_current_node, connected_agents);
+
+    expect_value(__wrap_OSHash_Begin_ex, self, remoted_agents_state);
+    will_return(__wrap_OSHash_Begin_ex, test_data->hash_node);
+
+    expect_value(__wrap_OSHash_Next, self, remoted_agents_state);
+    will_return(__wrap_OSHash_Next, inactive_node);
+
+    expect_value(__wrap_OSHash_Next, self, remoted_agents_state);
+    will_return(__wrap_OSHash_Next, NULL);
+
+    expect_value(__wrap_OSHash_Delete_ex, self, remoted_agents_state);
+    expect_value(__wrap_OSHash_Delete_ex, key, "005");
+    will_return(__wrap_OSHash_Delete_ex, inactive_state);
+
+    int sock = 1;
+
+    w_remoted_clean_agents_state(&sock);
+
+    os_free(test_data->agent_state);
+    os_free(inactive_node);
 }
 
 void test_w_remoted_clean_agents_state_query_fail(void ** state) {
@@ -440,6 +484,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_w_remoted_clean_agents_state_empty_table, test_setup_empty_hash_table, test_teardown_empty_hash_table),
         cmocka_unit_test_setup_teardown(test_w_remoted_clean_agents_state_completed, test_setup_agent, test_teardown_agent),
         cmocka_unit_test_setup_teardown(test_w_remoted_clean_agents_state_completed_without_delete, test_setup_agent, test_teardown_agent),
+        cmocka_unit_test_setup_teardown(test_w_remoted_clean_agents_state_bsearch_multiple_active, test_setup_agent, test_teardown_agent),
         cmocka_unit_test_setup_teardown(test_w_remoted_clean_agents_state_query_fail, test_setup_agent, test_teardown_agent),
     };
 


### PR DESCRIPTION
## Description

This PR fixes a data race in `wazuh-remoted` agent state cleanup.

The issue was reproduced with ThreadSanitizer under concurrent agent traffic. Worker threads update `remoted_agents_state` while holding `agents_state_mutex`, but the cleanup path iterated and removed entries from the same hash table without using that mutex. This could race with per-agent statistics updates and lead to unsafe access to freed agent state.

The fix makes the cleanup path use the same synchronization model as the worker paths, protecting hash iteration, deletion, and state lifetime with `agents_state_mutex`.

Closes #29415 

## Proposed Changes

- Move `OSHash_Begin_ex()` in `w_remoted_clean_agents_state()` so the iterator is created after the Wazuh DB active-agent query.
- Protect the cleanup hash traversal with `agents_state_mutex`.
- Keep inactive-agent deletion and `remoted_agent_state_t` freeing inside the same mutex-protected section.
- Keep the Wazuh DB active-agent query outside `agents_state_mutex` to avoid blocking the message-processing hot path on I/O.
- Sort the active-agent ID list once and use `bsearch()` during cleanup instead of a linear scan for each hash entry.
- Initialize OpenSSL in `wazuh-remoted` with `OPENSSL_INIT_NO_ATEXIT` before any implicit crypto initialization.
- Stop registering libcurl global cleanup through `atexit`; keep `uhttp_global_cleanup()` as an explicit cleanup path for controlled contexts.

## Results and Evidence

 #### Build & install
 
 ```bash
 
 General settings:
    TARGET:             manager
    V:                  
    DEBUG:              yes
    INSTALLDIR:         
    RESOURCES_URL:      https://packages.wazuh.com/deps/99-37361
    EXTERNAL_SRC_ONLY:  
    HTTP_REQUEST_BRANCH:ebf9d2f82533ff2f84c3304ab29db01fcfb6735e
User settings:
    WAZUH_GROUP:        wazuh-manager
    WAZUH_USER:         wazuh-manager
USE settings:
    USE_INOTIFY:        no
    USE_BIG_ENDIAN:     no
    USE_SELINUX:        no
    USE_AUDIT:          no
    IMAGE_TRUST_CHECKS: 1
    CA_NAME:            DigiCert Assured ID Root CA
Compiler:
    CC                cc
    MAKE              /usr/bin/make
make[1]: Leaving directory '/workspaces/Wazuh_5x/wazuh/src'

Done building manager


(venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/29415-remoted-tsan-data-races●› 
╰─# service wazuh-manager status
wazuh-manager-clusterd is running...
wazuh-manager-modulesd is running...
wazuh-manager-monitord is running...
wazuh-manager-remoted is running...
wazuh-manager-analysisd is running...
wazuh-manager-db is running...
wazuh-manager-authd is running...
wazuh-manager-apid is running...
 
 (venv) ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/29415-remoted-tsan-data-races●› 
╰─# engine-private ns list
engine-router list

- cmsync_standard_9260

- entry_status: ENABLED
  name: cmsync_standard
  namespaceId: cmsync_standard_9260
  priority: 1
  uptime: 3
 
 
 ╭─root@wazuh5x-dev /workspaces/Wazuh_5x/wazuh ‹bug/29415-remoted-tsan-data-races●› 
╰─# ctest --test-dir src/build --output-on-failure

 100% tests passed, 0 tests failed out of 9807

Total Test time (real) = 704.16 sec
 
 ```
 
  ```console
  
2026/07/11 07:19:48 wazuh-manager-analysisd: INFO: IOC Sync Service initialized
2026/07/11 07:19:48 wazuh-manager-analysisd: INFO: Dumper Events initialized
2026/07/11 07:19:48 wazuh-manager-analysisd: INFO: Remote engine's server initialized and started
2026/07/11 07:19:48 wazuh-manager-analysisd: INFO: Engine started
2026/07/11 07:19:48 wazuh-manager-analysisd: INFO: Scheduler started
2026/07/11 07:19:58 wazuh-manager-monitord: INFO: wazuh: Manager started.
 ```

####  Before the Fix

<details><summary>extract of report - benchmark workload</summary>

```TSAN
==================
WARNING: ThreadSanitizer: data race (pid=114963)
  Write of size 8 at 0x7218000164a8 by thread T5:
    #0 <null> <null> (libtsan.so.2+0x57c71) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (wazuh-manager-remoted+0x19108) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0x18e09) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (libtsan.so.2+0x4edee) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)

  Previous write of size 8 at 0x7218000164a8 by thread T21 (mutexes: write M0):
    #0 <null> <null> (wazuh-manager-remoted+0x1920c) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #1 <null> <null> (wazuh-manager-remoted+0x1a31a) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0x15e84) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (wazuh-manager-remoted+0x125aa) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #4 <null> <null> (libtsan.so.2+0x4edee) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)

  Mutex M0 (0x5555556dbd60) created at:
    #0 <null> <null> (libtsan.so.2+0x59a13) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (wazuh-manager-remoted+0x196df) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0x1ad32) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (wazuh-manager-remoted+0x2275e) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #4 <null> <null> (wazuh-manager-remoted+0x14b0e) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #5 <null> <null> (wazuh-manager-remoted+0x125aa) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #6 <null> <null> (libtsan.so.2+0x4edee) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)

  Thread T5 (tid=114987, running) created by main thread at:
    #0 <null> <null> (libtsan.so.2+0x5ac1a) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (wazuh-manager-remoted+0xd0fca) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0xd1093) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (wazuh-manager-remoted+0x11218) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #4 <null> <null> (wazuh-manager-remoted+0x106b8) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #5 <null> <null> (wazuh-manager-remoted+0xdba6) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #6 <null> <null> (libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)

  Thread T21 (tid=115003, running) created by main thread at:
    #0 <null> <null> (libtsan.so.2+0x5ac1a) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (wazuh-manager-remoted+0xd0fca) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0xd1093) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (wazuh-manager-remoted+0x1167e) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #4 <null> <null> (wazuh-manager-remoted+0x106b8) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #5 <null> <null> (wazuh-manager-remoted+0xdba6) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #6 <null> <null> (libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)

SUMMARY: ThreadSanitizer: data race (/lib/x86_64-linux-gnu/libtsan.so.2+0x57c71) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738) 
==================
```

</details>

```TSAN
WARNING: ThreadSanitizer: data race (pid=114963)

Write:
  w_remoted_clean_agents_state
  /workspaces/Wazuh_5x/wazuh/src/remoted/src/state.c:187

Previous write:
  rem_inc_agents_recv_events
  /workspaces/Wazuh_5x/wazuh/src/remoted/src/state.c:198

Call path:
  rem_inc_recv_events
  /workspaces/Wazuh_5x/wazuh/src/remoted/src/state.c:310
  HandleSecureMessage
  /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:1072
  rem_handler_main
  /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:530

SUMMARY: ThreadSanitizer: data race
```

<details><summary>extract of report - simulate-agents workload</summary>

```TSAN
==================
WARNING: ThreadSanitizer: data race (pid=10006)
  Write of size 8 at 0x72a400008610 by thread T22 (mutexes: read M0, write M1, write M2):
    #0 <null> <null> (wazuh-manager-remoted+0xc0844) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #1 <null> <null> (wazuh-manager-remoted+0xc055d) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0xc0a6a) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (wazuh-manager-remoted+0x18f33) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #4 <null> <null> (wazuh-manager-remoted+0x1972e) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #5 <null> <null> (wazuh-manager-remoted+0x1ad32) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #6 <null> <null> (wazuh-manager-remoted+0x2275e) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #7 <null> <null> (wazuh-manager-remoted+0x14b0e) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #8 <null> <null> (wazuh-manager-remoted+0x125aa) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #9 <null> <null> (libtsan.so.2+0x4edee) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)

  Previous read of size 8 at 0x72a400008610 by thread T5:
    #0 <null> <null> (wazuh-manager-remoted+0xc1e40) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #1 <null> <null> (wazuh-manager-remoted+0x1904e) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0x18e09) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (libtsan.so.2+0x4edee) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)

  Location is heap block of size 16432 at 0x72a400005000 allocated by main thread:
    #0 <null> <null> (libtsan.so.2+0x56f52) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (wazuh-manager-remoted+0xbff60) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0x11063) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (wazuh-manager-remoted+0x106b8) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #4 <null> <null> (wazuh-manager-remoted+0xdba6) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #5 <null> <null> (libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)

  Mutex M0 (0x5555556dbc48) created at:
    #0 <null> <null> (libtsan.so.2+0x5633d) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (wazuh-manager-remoted+0xda763) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0x17e72) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (wazuh-manager-remoted+0x110e6) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #4 <null> <null> (wazuh-manager-remoted+0x106b8) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #5 <null> <null> (wazuh-manager-remoted+0xdba6) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #6 <null> <null> (libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)

  Mutex M1 (0x5555556dbd60) created at:
    #0 <null> <null> (libtsan.so.2+0x59a13) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (wazuh-manager-remoted+0x196df) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0x1ad32) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (wazuh-manager-remoted+0x2275e) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #4 <null> <null> (wazuh-manager-remoted+0x14b0e) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #5 <null> <null> (wazuh-manager-remoted+0x125aa) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #6 <null> <null> (libtsan.so.2+0x4edee) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)

  Mutex M2 (0x721800000130) created at:
    #0 <null> <null> (libtsan.so.2+0x5633d) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (wazuh-manager-remoted+0xbfb7d) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0x10fdf) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (wazuh-manager-remoted+0x106b8) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #4 <null> <null> (wazuh-manager-remoted+0xdba6) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #5 <null> <null> (libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)

  Thread T22 (tid=10030, running) created by main thread at:
    #0 <null> <null> (libtsan.so.2+0x5ac1a) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (wazuh-manager-remoted+0xd0fca) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0xd1093) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (wazuh-manager-remoted+0x1167e) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #4 <null> <null> (wazuh-manager-remoted+0x106b8) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #5 <null> <null> (wazuh-manager-remoted+0xdba6) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #6 <null> <null> (libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)

  Thread T5 (tid=10013, running) created by main thread at:
    #0 <null> <null> (libtsan.so.2+0x5ac1a) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (wazuh-manager-remoted+0xd0fca) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0xd1093) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (wazuh-manager-remoted+0x11218) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #4 <null> <null> (wazuh-manager-remoted+0x106b8) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #5 <null> <null> (wazuh-manager-remoted+0xdba6) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #6 <null> <null> (libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)

SUMMARY: ThreadSanitizer: data race (/var/wazuh-manager/bin/wazuh-manager-remoted+0xc0844) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea) 
==================
==================
WARNING: ThreadSanitizer: data race (pid=10006)
  Write of size 8 at 0x72a400008618 by thread T23 (mutexes: read M0, write M1, write M2):
    #0 <null> <null> (wazuh-manager-remoted+0xc0844) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #1 <null> <null> (wazuh-manager-remoted+0xc055d) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0xc0a6a) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (wazuh-manager-remoted+0x18f33) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #4 <null> <null> (wazuh-manager-remoted+0x1961d) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #5 <null> <null> (wazuh-manager-remoted+0x1ac25) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #6 <null> <null> (wazuh-manager-remoted+0x22a73) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #7 <null> <null> (wazuh-manager-remoted+0x14b0e) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #8 <null> <null> (wazuh-manager-remoted+0x125aa) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #9 <null> <null> (libtsan.so.2+0x4edee) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)

  Previous read of size 8 at 0x72a400008618 by thread T5:
    #0 <null> <null> (wazuh-manager-remoted+0xc1e40) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #1 <null> <null> (wazuh-manager-remoted+0x1904e) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0x18e09) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (libtsan.so.2+0x4edee) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)

  Location is heap block of size 16432 at 0x72a400005000 allocated by main thread:
    #0 <null> <null> (libtsan.so.2+0x56f52) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (wazuh-manager-remoted+0xbff60) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0x11063) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (wazuh-manager-remoted+0x106b8) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #4 <null> <null> (wazuh-manager-remoted+0xdba6) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #5 <null> <null> (libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)

  Mutex M0 (0x5555556dbc48) created at:
    #0 <null> <null> (libtsan.so.2+0x5633d) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (wazuh-manager-remoted+0xda763) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0x17e72) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (wazuh-manager-remoted+0x110e6) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #4 <null> <null> (wazuh-manager-remoted+0x106b8) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #5 <null> <null> (wazuh-manager-remoted+0xdba6) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #6 <null> <null> (libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)

  Mutex M1 (0x5555556dbd60) created at:
    #0 <null> <null> (libtsan.so.2+0x59a13) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (wazuh-manager-remoted+0x196df) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0x1ad32) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (wazuh-manager-remoted+0x2275e) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #4 <null> <null> (wazuh-manager-remoted+0x14b0e) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #5 <null> <null> (wazuh-manager-remoted+0x125aa) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #6 <null> <null> (libtsan.so.2+0x4edee) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)

  Mutex M2 (0x721800000130) created at:
    #0 <null> <null> (libtsan.so.2+0x5633d) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (wazuh-manager-remoted+0xbfb7d) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0x10fdf) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (wazuh-manager-remoted+0x106b8) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #4 <null> <null> (wazuh-manager-remoted+0xdba6) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #5 <null> <null> (libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)

  Thread T23 (tid=10031, running) created by main thread at:
    #0 <null> <null> (libtsan.so.2+0x5ac1a) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (wazuh-manager-remoted+0xd0fca) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0xd1093) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (wazuh-manager-remoted+0x1167e) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #4 <null> <null> (wazuh-manager-remoted+0x106b8) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #5 <null> <null> (wazuh-manager-remoted+0xdba6) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #6 <null> <null> (libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)

  Thread T5 (tid=10013, running) created by main thread at:
    #0 <null> <null> (libtsan.so.2+0x5ac1a) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (wazuh-manager-remoted+0xd0fca) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0xd1093) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (wazuh-manager-remoted+0x11218) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #4 <null> <null> (wazuh-manager-remoted+0x106b8) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #5 <null> <null> (wazuh-manager-remoted+0xdba6) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #6 <null> <null> (libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)

SUMMARY: ThreadSanitizer: data race (/var/wazuh-manager/bin/wazuh-manager-remoted+0xc0844) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea) 
==================
==================
WARNING: ThreadSanitizer: data race (pid=10006)
  Write of size 8 at 0x72a400008638 by thread T22 (mutexes: write M0, write M1):
    #0 <null> <null> (wazuh-manager-remoted+0xc0844) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #1 <null> <null> (wazuh-manager-remoted+0xc055d) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0xc0a6a) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (wazuh-manager-remoted+0x18f33) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #4 <null> <null> (wazuh-manager-remoted+0x191dc) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #5 <null> <null> (wazuh-manager-remoted+0x1a31a) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #6 <null> <null> (wazuh-manager-remoted+0x15e84) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #7 <null> <null> (wazuh-manager-remoted+0x125aa) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #8 <null> <null> (libtsan.so.2+0x4edee) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)

  Previous read of size 8 at 0x72a400008638 by thread T5:
    #0 <null> <null> (wazuh-manager-remoted+0xc1e40) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #1 <null> <null> (wazuh-manager-remoted+0x1904e) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0x18e09) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (libtsan.so.2+0x4edee) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)

  Location is heap block of size 16432 at 0x72a400005000 allocated by main thread:
    #0 <null> <null> (libtsan.so.2+0x56f52) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (wazuh-manager-remoted+0xbff60) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0x11063) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (wazuh-manager-remoted+0x106b8) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #4 <null> <null> (wazuh-manager-remoted+0xdba6) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #5 <null> <null> (libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)

  Mutex M0 (0x5555556dbd60) created at:
    #0 <null> <null> (libtsan.so.2+0x59a13) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (wazuh-manager-remoted+0x196df) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0x1ad32) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (wazuh-manager-remoted+0x2275e) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #4 <null> <null> (wazuh-manager-remoted+0x14b0e) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #5 <null> <null> (wazuh-manager-remoted+0x125aa) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #6 <null> <null> (libtsan.so.2+0x4edee) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)

  Mutex M1 (0x721800000130) created at:
    #0 <null> <null> (libtsan.so.2+0x5633d) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (wazuh-manager-remoted+0xbfb7d) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0x10fdf) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (wazuh-manager-remoted+0x106b8) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #4 <null> <null> (wazuh-manager-remoted+0xdba6) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #5 <null> <null> (libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)

  Thread T22 (tid=10030, running) created by main thread at:
    #0 <null> <null> (libtsan.so.2+0x5ac1a) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (wazuh-manager-remoted+0xd0fca) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0xd1093) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (wazuh-manager-remoted+0x1167e) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #4 <null> <null> (wazuh-manager-remoted+0x106b8) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #5 <null> <null> (wazuh-manager-remoted+0xdba6) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #6 <null> <null> (libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)

  Thread T5 (tid=10013, running) created by main thread at:
    #0 <null> <null> (libtsan.so.2+0x5ac1a) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (wazuh-manager-remoted+0xd0fca) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #2 <null> <null> (wazuh-manager-remoted+0xd1093) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #3 <null> <null> (wazuh-manager-remoted+0x11218) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #4 <null> <null> (wazuh-manager-remoted+0x106b8) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #5 <null> <null> (wazuh-manager-remoted+0xdba6) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea)
    #6 <null> <null> (libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)

SUMMARY: ThreadSanitizer: data race (/var/wazuh-manager/bin/wazuh-manager-remoted+0xc0844) (BuildId: 41dd0785067d47cf361afba4c08d1afe86bd5eea) 
==================
```

</details>

```TSAN
WARNING: ThreadSanitizer: data race (pid=10006)

Write:
  _OSHash_Add
  /workspaces/Wazuh_5x/wazuh/src/shared/src/hash_op.c:291

Previous read:
  OSHash_Next
  /workspaces/Wazuh_5x/wazuh/src/shared/src/hash_op.c:624

Call path for write:
  OSHash_Add_ex
  get_node
  /workspaces/Wazuh_5x/wazuh/src/remoted/src/state.c:149
  rem_inc_agents_recv_ctrl_startup / rem_inc_agents_recv_ctrl_keepalive / rem_inc_agents_recv_events

Call path for previous read:
  w_remoted_clean_agents_state
  /workspaces/Wazuh_5x/wazuh/src/remoted/src/state.c:175
  rem_state_main
  /workspaces/Wazuh_5x/wazuh/src/remoted/src/state.c:133

SUMMARY: ThreadSanitizer: data race
```

<details><summary>extract of report - shutdown crypto cleanup</summary>

```TSAN
==================
WARNING: ThreadSanitizer: data race (pid=132494)
  Write of size 8 at 0x720c000e9188 by main thread:
    #0 <null> <null> (libtsan.so.2+0x57c71) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (libwazuhext.so+0x3b4d4f) (BuildId: 343807b8a7beb3aba431d4bfd003ea659ca1f467)
    #2 <null> <null> (libwazuhext.so+0x3b9ebf) (BuildId: 343807b8a7beb3aba431d4bfd003ea659ca1f467)
    #3 <null> <null> (libtsan.so.2+0x517d5) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #4 wnotify_wait /workspaces/Wazuh_5x/wazuh/src/shared/src/notify_op.c:54 (wazuh-manager-remoted+0xcf91f) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 HandleSecure /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:375 (wazuh-manager-remoted+0x11be7) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #6 HandleRemote /workspaces/Wazuh_5x/wazuh/src/remoted/src/remoted.c:80 (wazuh-manager-remoted+0x106d8) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #7 main /workspaces/Wazuh_5x/wazuh/src/remoted/src/main.c:207 (wazuh-manager-remoted+0xdbc6) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)

  Previous read of size 1 at 0x720c000e9188 by thread T23 (mutexes: read M0, write M1, read M2):
    #0 <null> <null> (libtsan.so.2+0x5c5bf) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (libwazuhext.so+0x4b59f8) (BuildId: 343807b8a7beb3aba431d4bfd003ea659ca1f467)
    #2 OS_AES_Str /workspaces/Wazuh_5x/wazuh/src/shared/os_crypto/aes/aes_op.c:34 (wazuh-manager-remoted+0x116be9) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #3 ReadSecMSG /workspaces/Wazuh_5x/wazuh/src/shared/os_crypto/shared/msgs.c:353 (wazuh-manager-remoted+0x102533) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #4 HandleSecureMessage /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:788 (wazuh-manager-remoted+0x140a1) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 rem_handler_main /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:530 (wazuh-manager-remoted+0x125ca) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #6 <null> <null> (libtsan.so.2+0x4edee) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)

  Mutex M0 (0x55b4ceeb8c48) created at:
    #0 <null> <null> (libtsan.so.2+0x5633d) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 rwlock_init /workspaces/Wazuh_5x/wazuh/src/shared/src/rwlock_op.c:26 (wazuh-manager-remoted+0xda8ae) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #2 key_lock_init /workspaces/Wazuh_5x/wazuh/src/remoted/src/sendmsg.c:24 (wazuh-manager-remoted+0x17e92) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #3 HandleSecure /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:250 (wazuh-manager-remoted+0x11106) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #4 HandleRemote /workspaces/Wazuh_5x/wazuh/src/remoted/src/remoted.c:80 (wazuh-manager-remoted+0x106d8) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 main /workspaces/Wazuh_5x/wazuh/src/remoted/src/main.c:207 (wazuh-manager-remoted+0xdbc6) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)

  Mutex M1 (0x724400177ba8) created at:
    #0 <null> <null> (libtsan.so.2+0x594cd) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 OS_AddKey /workspaces/Wazuh_5x/wazuh/src/shared/os_crypto/shared/keys.c:110 (wazuh-manager-remoted+0xfb49e) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #2 OS_ReadKeys /workspaces/Wazuh_5x/wazuh/src/shared/os_crypto/shared/keys.c:319 (wazuh-manager-remoted+0xfc6e1) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #3 OS_UpdateKeys /workspaces/Wazuh_5x/wazuh/src/shared/os_crypto/shared/keys.c:444 (wazuh-manager-remoted+0xfd1ed) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #4 check_keyupdate /workspaces/Wazuh_5x/wazuh/src/remoted/src/sendmsg.c:52 (wazuh-manager-remoted+0x17f8f) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 rem_keyupdate_main /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:543 (wazuh-manager-remoted+0x12654) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #6 <null> <null> (libtsan.so.2+0x4edee) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)

  Mutex M2 (0x721000001cc0) created at:
    #0 <null> <null> (libtsan.so.2+0x5633d) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (libwazuhext.so+0x3cc161) (BuildId: 343807b8a7beb3aba431d4bfd003ea659ca1f467)
    #2 <null> <null> (libwazuhext.so+0x3cc228) (BuildId: 343807b8a7beb3aba431d4bfd003ea659ca1f467)
    #3 <null> <null> (libwazuhext.so+0x3cc228) (BuildId: 343807b8a7beb3aba431d4bfd003ea659ca1f467)
    #4 HandleSecure /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:225 (wazuh-manager-remoted+0x10fbe) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 HandleRemote /workspaces/Wazuh_5x/wazuh/src/remoted/src/remoted.c:80 (wazuh-manager-remoted+0x106d8) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #6 main /workspaces/Wazuh_5x/wazuh/src/remoted/src/main.c:207 (wazuh-manager-remoted+0xdbc6) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)

  Thread T23 (tid=132519, running) created by main thread at:
    #0 <null> <null> (libtsan.so.2+0x5ac1a) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 CreateThreadJoinable /workspaces/Wazuh_5x/wazuh/src/shared/src/pthreads_op.c:51 (wazuh-manager-remoted+0xd1115) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #2 CreateThread /workspaces/Wazuh_5x/wazuh/src/shared/src/pthreads_op.c:66 (wazuh-manager-remoted+0xd11de) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #3 HandleSecure /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:315 (wazuh-manager-remoted+0x1169e) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #4 HandleRemote /workspaces/Wazuh_5x/wazuh/src/remoted/src/remoted.c:80 (wazuh-manager-remoted+0x106d8) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 main /workspaces/Wazuh_5x/wazuh/src/remoted/src/main.c:207 (wazuh-manager-remoted+0xdbc6) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)

SUMMARY: ThreadSanitizer: data race (/lib/x86_64-linux-gnu/libtsan.so.2+0x57c71) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738) 
==================
==================
WARNING: ThreadSanitizer: data race (pid=132494)
  Write of size 8 at 0x720c00007618 by main thread:
    #0 <null> <null> (libtsan.so.2+0x57c71) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (libwazuhext.so+0x3b4d4f) (BuildId: 343807b8a7beb3aba431d4bfd003ea659ca1f467)
    #2 <null> <null> (libwazuhext.so+0x3b9ebf) (BuildId: 343807b8a7beb3aba431d4bfd003ea659ca1f467)
    #3 <null> <null> (libtsan.so.2+0x517d5) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #4 wnotify_wait /workspaces/Wazuh_5x/wazuh/src/shared/src/notify_op.c:54 (wazuh-manager-remoted+0xcf91f) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 HandleSecure /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:375 (wazuh-manager-remoted+0x11be7) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #6 HandleRemote /workspaces/Wazuh_5x/wazuh/src/remoted/src/remoted.c:80 (wazuh-manager-remoted+0x106d8) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #7 main /workspaces/Wazuh_5x/wazuh/src/remoted/src/main.c:207 (wazuh-manager-remoted+0xdbc6) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)

  Previous read of size 1 at 0x720c00007618 by thread T2 (mutexes: write M0, read M1):
    #0 <null> <null> (libtsan.so.2+0x5c5bf) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (libwazuhext.so+0x4b59f8) (BuildId: 343807b8a7beb3aba431d4bfd003ea659ca1f467)
    #2 c_group /workspaces/Wazuh_5x/wazuh/src/remoted/src/manager.c:902 (wazuh-manager-remoted+0x2579a) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #3 process_groups /workspaces/Wazuh_5x/wazuh/src/remoted/src/manager.c:1047 (wazuh-manager-remoted+0x26271) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #4 c_files /workspaces/Wazuh_5x/wazuh/src/remoted/src/manager.c:982 (wazuh-manager-remoted+0x25cf8) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 update_shared_files /workspaces/Wazuh_5x/wazuh/src/remoted/src/manager.c:1863 (wazuh-manager-remoted+0x2a7f8) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #6 <null> <null> (libtsan.so.2+0x4edee) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)

  Mutex M0 (0x55b4ceeb8e80) created at:
    #0 <null> <null> (libtsan.so.2+0x59a13) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 c_files /workspaces/Wazuh_5x/wazuh/src/remoted/src/manager.c:979 (wazuh-manager-remoted+0x25cab) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #2 manager_init /workspaces/Wazuh_5x/wazuh/src/remoted/src/manager.c:1895 (wazuh-manager-remoted+0x2aa16) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #3 HandleSecure /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:243 (wazuh-manager-remoted+0x110c5) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #4 HandleRemote /workspaces/Wazuh_5x/wazuh/src/remoted/src/remoted.c:80 (wazuh-manager-remoted+0x106d8) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 main /workspaces/Wazuh_5x/wazuh/src/remoted/src/main.c:207 (wazuh-manager-remoted+0xdbc6) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)

  Mutex M1 (0x721000001cc0) created at:
    #0 <null> <null> (libtsan.so.2+0x5633d) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (libwazuhext.so+0x3cc161) (BuildId: 343807b8a7beb3aba431d4bfd003ea659ca1f467)
    #2 <null> <null> (libwazuhext.so+0x3cc228) (BuildId: 343807b8a7beb3aba431d4bfd003ea659ca1f467)
    #3 <null> <null> (libwazuhext.so+0x3cc228) (BuildId: 343807b8a7beb3aba431d4bfd003ea659ca1f467)
    #4 HandleSecure /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:225 (wazuh-manager-remoted+0x10fbe) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 HandleRemote /workspaces/Wazuh_5x/wazuh/src/remoted/src/remoted.c:80 (wazuh-manager-remoted+0x106d8) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #6 main /workspaces/Wazuh_5x/wazuh/src/remoted/src/main.c:207 (wazuh-manager-remoted+0xdbc6) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)

  Thread T2 (tid=132498, running) created by main thread at:
    #0 <null> <null> (libtsan.so.2+0x5ac1a) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 CreateThreadJoinable /workspaces/Wazuh_5x/wazuh/src/shared/src/pthreads_op.c:51 (wazuh-manager-remoted+0xd1115) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #2 CreateThread /workspaces/Wazuh_5x/wazuh/src/shared/src/pthreads_op.c:66 (wazuh-manager-remoted+0xd11de) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #3 HandleSecure /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:256 (wazuh-manager-remoted+0x1115f) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #4 HandleRemote /workspaces/Wazuh_5x/wazuh/src/remoted/src/remoted.c:80 (wazuh-manager-remoted+0x106d8) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 main /workspaces/Wazuh_5x/wazuh/src/remoted/src/main.c:207 (wazuh-manager-remoted+0xdbc6) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)

SUMMARY: ThreadSanitizer: data race (/lib/x86_64-linux-gnu/libtsan.so.2+0x57c71) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738) 
==================
==================
WARNING: ThreadSanitizer: data race (pid=132494)
  Write of size 1 at 0x721000001cc0 by main thread:
    #0 <null> <null> (libtsan.so.2+0x5589a) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (libwazuhext.so+0x3cc1fd) (BuildId: 343807b8a7beb3aba431d4bfd003ea659ca1f467)
    #2 <null> <null> (libwazuhext.so+0x3b9ebf) (BuildId: 343807b8a7beb3aba431d4bfd003ea659ca1f467)
    #3 <null> <null> (libtsan.so.2+0x517d5) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #4 wnotify_wait /workspaces/Wazuh_5x/wazuh/src/shared/src/notify_op.c:54 (wazuh-manager-remoted+0xcf91f) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 HandleSecure /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:375 (wazuh-manager-remoted+0x11be7) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #6 HandleRemote /workspaces/Wazuh_5x/wazuh/src/remoted/src/remoted.c:80 (wazuh-manager-remoted+0x106d8) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #7 main /workspaces/Wazuh_5x/wazuh/src/remoted/src/main.c:207 (wazuh-manager-remoted+0xdbc6) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)

  Previous atomic read of size 1 at 0x721000001cc0 by thread T21 (mutexes: read M0):
    #0 <null> <null> (libtsan.so.2+0x57473) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (libwazuhext.so+0x3cc198) (BuildId: 343807b8a7beb3aba431d4bfd003ea659ca1f467)
    #2 CheckSum /workspaces/Wazuh_5x/wazuh/src/shared/os_crypto/shared/msgs.c:300 (wazuh-manager-remoted+0x101e46) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #3 ReadSecMSG /workspaces/Wazuh_5x/wazuh/src/shared/os_crypto/shared/msgs.c:398 (wazuh-manager-remoted+0x1029ab) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #4 HandleSecureMessage /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:788 (wazuh-manager-remoted+0x140a1) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 rem_handler_main /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:530 (wazuh-manager-remoted+0x125ca) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #6 <null> <null> (libtsan.so.2+0x4edee) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)

  Location is heap block of size 56 at 0x721000001cc0 allocated by main thread:
    #0 <null> <null> (libtsan.so.2+0x54b3f) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (libwazuhext.so+0x3bafe0) (BuildId: 343807b8a7beb3aba431d4bfd003ea659ca1f467)
    #2 <null> <null> (libwazuhext.so+0x3cc228) (BuildId: 343807b8a7beb3aba431d4bfd003ea659ca1f467)
    #3 <null> <null> (libwazuhext.so+0x3cc228) (BuildId: 343807b8a7beb3aba431d4bfd003ea659ca1f467)
    #4 HandleSecure /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:225 (wazuh-manager-remoted+0x10fbe) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 HandleRemote /workspaces/Wazuh_5x/wazuh/src/remoted/src/remoted.c:80 (wazuh-manager-remoted+0x106d8) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #6 main /workspaces/Wazuh_5x/wazuh/src/remoted/src/main.c:207 (wazuh-manager-remoted+0xdbc6) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)

  Mutex M0 (0x55b4ceeb8c48) created at:
    #0 <null> <null> (libtsan.so.2+0x5633d) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 rwlock_init /workspaces/Wazuh_5x/wazuh/src/shared/src/rwlock_op.c:26 (wazuh-manager-remoted+0xda8ae) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #2 key_lock_init /workspaces/Wazuh_5x/wazuh/src/remoted/src/sendmsg.c:24 (wazuh-manager-remoted+0x17e92) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #3 HandleSecure /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:250 (wazuh-manager-remoted+0x11106) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #4 HandleRemote /workspaces/Wazuh_5x/wazuh/src/remoted/src/remoted.c:80 (wazuh-manager-remoted+0x106d8) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 main /workspaces/Wazuh_5x/wazuh/src/remoted/src/main.c:207 (wazuh-manager-remoted+0xdbc6) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)

  Thread T21 (tid=132517, running) created by main thread at:
    #0 <null> <null> (libtsan.so.2+0x5ac1a) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 CreateThreadJoinable /workspaces/Wazuh_5x/wazuh/src/shared/src/pthreads_op.c:51 (wazuh-manager-remoted+0xd1115) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #2 CreateThread /workspaces/Wazuh_5x/wazuh/src/shared/src/pthreads_op.c:66 (wazuh-manager-remoted+0xd11de) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #3 HandleSecure /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:315 (wazuh-manager-remoted+0x1169e) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #4 HandleRemote /workspaces/Wazuh_5x/wazuh/src/remoted/src/remoted.c:80 (wazuh-manager-remoted+0x106d8) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 main /workspaces/Wazuh_5x/wazuh/src/remoted/src/main.c:207 (wazuh-manager-remoted+0xdbc6) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)

SUMMARY: ThreadSanitizer: data race (/lib/x86_64-linux-gnu/libtsan.so.2+0x5589a) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738) 
==================
==================
WARNING: ThreadSanitizer: data race (pid=132494)
  Write of size 8 at 0x721c000037b8 by main thread:
    #0 <null> <null> (libtsan.so.2+0x57c71) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (libwazuhext.so+0x3a81cb) (BuildId: 343807b8a7beb3aba431d4bfd003ea659ca1f467)
    #2 <null> <null> (libwazuhext.so+0x3b9ebf) (BuildId: 343807b8a7beb3aba431d4bfd003ea659ca1f467)
    #3 <null> <null> (libtsan.so.2+0x517d5) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #4 wnotify_wait /workspaces/Wazuh_5x/wazuh/src/shared/src/notify_op.c:54 (wazuh-manager-remoted+0xcf91f) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 HandleSecure /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:375 (wazuh-manager-remoted+0x11be7) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #6 HandleRemote /workspaces/Wazuh_5x/wazuh/src/remoted/src/remoted.c:80 (wazuh-manager-remoted+0x106d8) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #7 main /workspaces/Wazuh_5x/wazuh/src/remoted/src/main.c:207 (wazuh-manager-remoted+0xdbc6) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)

  Previous read of size 8 at 0x721c000037b8 by thread T23 (mutexes: read M0, write M1):
    #0 <null> <null> (libtsan.so.2+0x5e1f0) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (libwazuhext.so+0x3a9379) (BuildId: 343807b8a7beb3aba431d4bfd003ea659ca1f467)
    #2 OS_AES_Str /workspaces/Wazuh_5x/wazuh/src/shared/os_crypto/aes/aes_op.c:34 (wazuh-manager-remoted+0x116be9) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #3 ReadSecMSG /workspaces/Wazuh_5x/wazuh/src/shared/os_crypto/shared/msgs.c:353 (wazuh-manager-remoted+0x102533) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #4 HandleSecureMessage /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:788 (wazuh-manager-remoted+0x140a1) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 rem_handler_main /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:530 (wazuh-manager-remoted+0x125ca) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #6 <null> <null> (libtsan.so.2+0x4edee) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)

  Mutex M0 (0x55b4ceeb8c48) created at:
    #0 <null> <null> (libtsan.so.2+0x5633d) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 rwlock_init /workspaces/Wazuh_5x/wazuh/src/shared/src/rwlock_op.c:26 (wazuh-manager-remoted+0xda8ae) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #2 key_lock_init /workspaces/Wazuh_5x/wazuh/src/remoted/src/sendmsg.c:24 (wazuh-manager-remoted+0x17e92) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #3 HandleSecure /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:250 (wazuh-manager-remoted+0x11106) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #4 HandleRemote /workspaces/Wazuh_5x/wazuh/src/remoted/src/remoted.c:80 (wazuh-manager-remoted+0x106d8) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 main /workspaces/Wazuh_5x/wazuh/src/remoted/src/main.c:207 (wazuh-manager-remoted+0xdbc6) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)

  Mutex M1 (0x724400177ba8) created at:
    #0 <null> <null> (libtsan.so.2+0x594cd) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 OS_AddKey /workspaces/Wazuh_5x/wazuh/src/shared/os_crypto/shared/keys.c:110 (wazuh-manager-remoted+0xfb49e) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #2 OS_ReadKeys /workspaces/Wazuh_5x/wazuh/src/shared/os_crypto/shared/keys.c:319 (wazuh-manager-remoted+0xfc6e1) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #3 OS_UpdateKeys /workspaces/Wazuh_5x/wazuh/src/shared/os_crypto/shared/keys.c:444 (wazuh-manager-remoted+0xfd1ed) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #4 check_keyupdate /workspaces/Wazuh_5x/wazuh/src/remoted/src/sendmsg.c:52 (wazuh-manager-remoted+0x17f8f) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 rem_keyupdate_main /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:543 (wazuh-manager-remoted+0x12654) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #6 <null> <null> (libtsan.so.2+0x4edee) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)

  Thread T23 (tid=132519, running) created by main thread at:
    #0 <null> <null> (libtsan.so.2+0x5ac1a) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 CreateThreadJoinable /workspaces/Wazuh_5x/wazuh/src/shared/src/pthreads_op.c:51 (wazuh-manager-remoted+0xd1115) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #2 CreateThread /workspaces/Wazuh_5x/wazuh/src/shared/src/pthreads_op.c:66 (wazuh-manager-remoted+0xd11de) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #3 HandleSecure /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:315 (wazuh-manager-remoted+0x1169e) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #4 HandleRemote /workspaces/Wazuh_5x/wazuh/src/remoted/src/remoted.c:80 (wazuh-manager-remoted+0x106d8) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 main /workspaces/Wazuh_5x/wazuh/src/remoted/src/main.c:207 (wazuh-manager-remoted+0xdbc6) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)

SUMMARY: ThreadSanitizer: data race (/lib/x86_64-linux-gnu/libtsan.so.2+0x57c71) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738) 
==================
==================
WARNING: ThreadSanitizer: data race (pid=132494)
  Write of size 8 at 0x721c000086e8 by main thread:
    #0 <null> <null> (libtsan.so.2+0x57c71) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (libwazuhext.so+0x3a81cb) (BuildId: 343807b8a7beb3aba431d4bfd003ea659ca1f467)
    #2 <null> <null> (libwazuhext.so+0x3b9ebf) (BuildId: 343807b8a7beb3aba431d4bfd003ea659ca1f467)
    #3 <null> <null> (libtsan.so.2+0x517d5) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #4 wnotify_wait /workspaces/Wazuh_5x/wazuh/src/shared/src/notify_op.c:54 (wazuh-manager-remoted+0xcf91f) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 HandleSecure /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:375 (wazuh-manager-remoted+0x11be7) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #6 HandleRemote /workspaces/Wazuh_5x/wazuh/src/remoted/src/remoted.c:80 (wazuh-manager-remoted+0x106d8) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #7 main /workspaces/Wazuh_5x/wazuh/src/remoted/src/main.c:207 (wazuh-manager-remoted+0xdbc6) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)

  Previous read of size 8 at 0x721c000086e8 by thread T2 (mutexes: write M0):
    #0 <null> <null> (libtsan.so.2+0x5e1f0) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 <null> <null> (libwazuhext.so+0x3a9379) (BuildId: 343807b8a7beb3aba431d4bfd003ea659ca1f467)
    #2 c_group /workspaces/Wazuh_5x/wazuh/src/remoted/src/manager.c:902 (wazuh-manager-remoted+0x2579a) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #3 process_groups /workspaces/Wazuh_5x/wazuh/src/remoted/src/manager.c:1047 (wazuh-manager-remoted+0x26271) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #4 c_files /workspaces/Wazuh_5x/wazuh/src/remoted/src/manager.c:982 (wazuh-manager-remoted+0x25cf8) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 update_shared_files /workspaces/Wazuh_5x/wazuh/src/remoted/src/manager.c:1863 (wazuh-manager-remoted+0x2a7f8) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #6 <null> <null> (libtsan.so.2+0x4edee) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)

  Mutex M0 (0x55b4ceeb8e80) created at:
    #0 <null> <null> (libtsan.so.2+0x59a13) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 c_files /workspaces/Wazuh_5x/wazuh/src/remoted/src/manager.c:979 (wazuh-manager-remoted+0x25cab) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #2 manager_init /workspaces/Wazuh_5x/wazuh/src/remoted/src/manager.c:1895 (wazuh-manager-remoted+0x2aa16) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #3 HandleSecure /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:243 (wazuh-manager-remoted+0x110c5) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #4 HandleRemote /workspaces/Wazuh_5x/wazuh/src/remoted/src/remoted.c:80 (wazuh-manager-remoted+0x106d8) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 main /workspaces/Wazuh_5x/wazuh/src/remoted/src/main.c:207 (wazuh-manager-remoted+0xdbc6) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)

  Thread T2 (tid=132498, running) created by main thread at:
    #0 <null> <null> (libtsan.so.2+0x5ac1a) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 CreateThreadJoinable /workspaces/Wazuh_5x/wazuh/src/shared/src/pthreads_op.c:51 (wazuh-manager-remoted+0xd1115) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #2 CreateThread /workspaces/Wazuh_5x/wazuh/src/shared/src/pthreads_op.c:66 (wazuh-manager-remoted+0xd11de) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #3 HandleSecure /workspaces/Wazuh_5x/wazuh/src/remoted/src/secure.c:256 (wazuh-manager-remoted+0x1115f) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #4 HandleRemote /workspaces/Wazuh_5x/wazuh/src/remoted/src/remoted.c:80 (wazuh-manager-remoted+0x106d8) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)
    #5 main /workspaces/Wazuh_5x/wazuh/src/remoted/src/main.c:207 (wazuh-manager-remoted+0xdbc6) (BuildId: 364e49ff15fdb6b0a23b61ad68dfa654b46332a3)

SUMMARY: ThreadSanitizer: data race (/lib/x86_64-linux-gnu/libtsan.so.2+0x57c71) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738) 
==================
ThreadSanitizer: reported 5 warnings
```

</details>

```TSAN
WARNING: ThreadSanitizer: data race (pid=132494)

Write:
  wnotify_wait
  /workspaces/Wazuh_5x/wazuh/src/shared/src/notify_op.c:54

Previous reads:
  OS_AES_Str
  /workspaces/Wazuh_5x/wazuh/src/shared/os_crypto/aes/aes_op.c:34

  ReadSecMSG
  /workspaces/Wazuh_5x/wazuh/src/shared/os_crypto/shared/msgs.c:353

  c_group
  /workspaces/Wazuh_5x/wazuh/src/remoted/src/manager.c:902

  process_groups
  /workspaces/Wazuh_5x/wazuh/src/remoted/src/manager.c:1047

Result:
  5 TSAN data race warnings reproduced in the shutdown crypto-cleanup family.

SUMMARY: ThreadSanitizer: data race
```




#### After the Fix


```TSAN
Result:
  No ThreadSanitizer report was generated after the fix.

Validation:
  tsan_log_count=0
  tsan_stdout_matches=0
  peak_tcp_1514_rows=200

SUMMARY: fixed workload completed without TSAN data race reports
```

<img width="1834" height="936" alt="Captura desde 2026-07-14 15-08-00" src="https://github.com/user-attachments/assets/35223ca6-74cb-41f8-9108-972fbe4e4709" />


<img width="1834" height="936" alt="Captura desde 2026-07-14 15-07-38" src="https://github.com/user-attachments/assets/7e58ad14-7c76-4e68-adac-0b7e92cf5af4" />


<img width="1834" height="936" alt="Captura desde 2026-07-14 15-06-44" src="https://github.com/user-attachments/assets/8b32effb-e762-4516-a5fc-5356595a961e" />


### Cleanup contention

The synchronization fix makes the cleaner hold `agents_state_mutex` while iterating and deleting stale agent-state entries. To avoid introducing excessive contention in that critical section, the active-agent lookup was changed from a linear scan to `qsort()` + `bsearch()`.

<img width="867" height="478" alt="highlight" src="https://github.com/user-attachments/assets/ba16d02e-a145-4577-94b4-a66bb3930de5" />


| Agents | Before avg `lock_held_us` | After avg `lock_held_us` | Improvement |
|---:|---:|---:|---:|
| 100 | 335 | 122 | 2.7x |
| 300 | 1709 | 196 | 8.7x |
| 500 | 3654 | 325 | 11.2x |
| 1000 | 10630 | 500 | 21.3x |



## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
