### PR TITLE
Add retry logic to indexer templates download

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -401,6 +401,15 @@ ifneq (,$(shell curl --help all 2>/dev/null | grep -F -- '--retry-all-errors'))
 	TZDATA_CURL_FLAGS += --retry-all-errors
 endif
 TZDATA_CURL := curl $(TZDATA_CURL_FLAGS) -o
+# Curl flags for indexer templates and WCS flat files with retry logic
+INDEXER_CURL_FLAGS := -fsS --retry 5 --retry-delay 2 --connect-timeout 20 --max-time 300
+ifneq (,$(shell curl --help all 2>/dev/null | grep -F -- '--retry-connrefused'))
+	INDEXER_CURL_FLAGS += --retry-connrefused
+endif
+ifneq (,$(shell curl --help all 2>/dev/null | grep -F -- '--retry-all-errors'))
+	INDEXER_CURL_FLAGS += --retry-all-errors
+endif
+INDEXER_CURL := curl $(INDEXER_CURL_FLAGS) -o
 DEPS_VERSION = 99-37361
 RESOURCES_URL_BASE := https://packages.wazuh.com/deps/
 RESOURCES_URL := $(RESOURCES_URL_BASE)$(DEPS_VERSION)
@@ -670,8 +679,8 @@ $(INDEXER_TEMPLATES_SERVER_STREAMS:%=$(INDEXER_PLUGINS_DIR)/%): | $(INDEXER_PLUG
 	@success=0; \
 	for ref in $(INDEXER_PLUGIN_REFS_LIST); do \
 		url="$(INDEXER_PLUGINS_BASE_URL)/$$ref/$(INDEXER_PLUGINS_STREAMS_PATH)/$(notdir $@)"; \
-		echo "$(CURL) $@ $(CACERT_OPT) -f $$url"; \
-		if $(CURL) $@ $(CACERT_OPT) -f "$$url" 2>/dev/null; then \
+		echo "$(INDEXER_CURL) $@ $(CACERT_OPT) -f $$url"; \
+		if $(INDEXER_CURL) $@ $(CACERT_OPT) -f "$$url"; then \
 			success=1; \
 			break; \
 		fi; \
@@ -687,8 +696,8 @@ $(INDEXER_PLUGINS_DIR)/%.json: | $(INDEXER_PLUGINS_DIR)
 	 @success=0; \
 	for ref in $(INDEXER_PLUGIN_REFS_LIST); do \
 		url="$(INDEXER_PLUGINS_BASE_URL)/$$ref/$(INDEXER_PLUGINS_STATES_PATH)/$(notdir $@)"; \
-		echo "$(CURL) $@ $(CACERT_OPT) -f $$url"; \
-		if $(CURL) $@ $(CACERT_OPT) -f "$$url" 2>/dev/null; then \
+		echo "$(INDEXER_CURL) $@ $(CACERT_OPT) -f $$url"; \
+		if $(INDEXER_CURL) $@ $(CACERT_OPT) -f "$$url"; then \
 			success=1; \
 			break; \
 		fi; \
@@ -709,8 +718,8 @@ $(WCS_FLAT_DIR)/wcs_flat.yml: | $(WCS_FLAT_DIR)
 	 @success=0; \
 	for ref in $(INDEXER_PLUGIN_REFS_LIST); do \
 		url="$(INDEXER_PLUGINS_BASE_URL)/$$ref/$(WCS_FLAT_STATELESS_PATH)/$(notdir $@)"; \
-		echo "$(CURL) $@ $(CACERT_OPT) -f $$url"; \
-		if $(CURL) $@ $(CACERT_OPT) -f "$$url" 2>/dev/null; then \
+		echo "$(INDEXER_CURL) $@ $(CACERT_OPT) -f $$url"; \
+		if $(INDEXER_CURL) $@ $(CACERT_OPT) -f "$$url"; then \
 			success=1; \
 			break; \
 		fi; \


### PR DESCRIPTION
## Description
Fixes transient network failures during the download of indexer templates, metrics, and WCS flat files that cause package builds to fail intermittently. This addresses issues reported by the QA team where downloads from the wazuh-indexer-plugins repository fail sporadically, particularly during nightly builds.

Related to #37537

## Proposed Changes
- Add `INDEXER_CURL` variable with retry flags matching the existing `TZDATA_CURL` pattern
- Configure automatic retry with 5 attempts, 2-second delays between retries
- Set connection timeout (20s) and max time (300s) for downloads
- Enable `--retry-connrefused` and `--retry-all-errors` flags when supported by curl
- Update all indexer template download rules (states, streams, WCS flat files) to use the new retry-enabled curl
- Remove stderr suppression (`2>/dev/null`) to make retry messages visible for debugging

### Results and Evidence
The retry logic follows the same proven pattern already used for tzdata downloads in the Makefile (lines 396-403). This will automatically handle transient failures like:
- Temporary connection issues
- DNS resolution delays
- SSL/TLS handshake failures
- Network timeouts

Example error that will be mitigated:
```
ERROR: Failed to download fim-files.json from any reference
```

### Artifacts Affected
- Manager packages (DEB, RPM) for all platforms
- Build process for Wazuh manager that requires indexer templates

### Configuration Changes
N/A

### Tests Introduced
N/A - This change improves reliability of existing download mechanism without changing functionality

## Review Checklist
- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues