### PR TITLE
Re-enable AWS Inspector integration tests in 5.0.0

### DIFF
--- a/.github/test_modules_linux.json
+++ b/.github/test_modules_linux.json
@@ -20,7 +20,6 @@
     {
       "name": "aws",
       "pytest_target": "test_aws/",
-      "pytest_extra_args": "-k \"not inspector\"",
       "tiers": ["0 1"],
       "timeout_minutes": 120,
       "setup_aws_credentials": true,
@@ -34,6 +33,18 @@
         "src/Makefile",
         "tests/integration/conftest.py",
         "tests/integration/test_aws/**"
+      ]
+    },
+    {
+      "name": "aws_inspector",
+      "pytest_target": "test_aws/",
+      "pytest_extra_args": "-k inspector",
+      "tiers": ["0 1"],
+      "timeout_minutes": 60,
+      "setup_aws_credentials": true,
+      "paths": [
+        "wodles/aws/services/inspector.py",
+        "wodles/aws/services/aws_service.py"
       ]
     },
     {

--- a/wodles/aws/services/inspector.py
+++ b/wodles/aws/services/inspector.py
@@ -205,3 +205,4 @@ class AWSInspector(aws_service.AWSService):
     def check_region(region: str) -> None:
         if region not in INSPECTOR_V2_REGIONS:
             raise ValueError(f"Unsupported region '{region}'")
+


### PR DESCRIPTION
## Description

AWS Inspector integration tests were temporarily disabled in 5.0.0 via commit `7f2e8a280a` (`ci(workflows): exclude FIM whodata tests on CodeBuild Windows and AWS inspector tests on Codebuild Linux`), which excluded inspector tests from the `aws` module and removed the dedicated `aws_inspector` module. This was done because Inspector Classic (V1) had reached end of life, breaking the existing tests while the fix was being developed.

The fix was merged via #37194 into `4.14.7` and has since been propagated into `5.0.0` and `main`, removing Inspector V1 support and migrating the integration tests to use only the Inspector V2 API (`wodles/aws/services/inspector.py`). This PR reverts the CI exclusion now that the Inspector V2 tests are functional.

Closes #37316

## Proposed Changes

- Removed the `-k "not inspector"` exclusion filter from the `aws` module in `.github/test_modules_linux.json`.
- Re-added a dedicated `aws_inspector` module referencing only `wodles/aws/services/inspector.py` (V2) and `wodles/aws/services/aws_service.py`.

### Results and Evidence

<!-- Add CI run link showing the aws_inspector module passing -->

### Artifacts Affected

- N/A

### Configuration Changes

- N/A

### Documentation Updates

- N/A

### Tests Introduced

- No new tests; re-enables existing AWS Inspector V2 integration tests (`test_aws/`) in the CI pipeline.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
