### PR TITLE
Git refs and makefile changes for GHA

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -581,7 +581,7 @@ external/$(CPYTHON).tar.gz: external-precompiled/$(CPYTHON).tar.gz
 	($(CURL) $@ $(RESOURCES_URL)/libraries/sources/$(CPYTHON_ARCHIVE).tar.gz &&\
 	cd external && $(GUNZIP) $(patsubst external/%,%,$@) && $(TAR) $(patsubst external/%.gz,%,$@) && rm $(patsubst external/%.gz,%,$@))
 	@test -d $(patsubst %.tar.gz,%,$@) || (cd external && $(GZIP) $(patsubst external/%.gz,%,$@))
-	 @echo "[+] Dependency $(notdir $(patsubst %.tar.gz,%,$@)) installed successfully"
+	@printf "\033[32m[+] Dependency %s installed successfully\033[0m\n" "$(notdir $(patsubst %.tar.gz,%,$@))"
 
 external-precompiled/$(CPYTHON).tar.gz:
 	-@$(CURL) external/$(patsubst external-precompiled/%,%,$@) $(RESOURCES_URL)/libraries/$(PRECOMPILED_RES)/$(patsubst external-precompiled/%,%,$@) || true
@@ -589,20 +589,20 @@ external-precompiled/$(CPYTHON).tar.gz:
 else
 external/$(CPYTHON).tar.gz:
 	 @echo "[-] Downloading dependency $(notdir $(patsubst %.tar.gz,%,$@)) ..."
-	@$(CURL) $@ $(RESOURCES_URL)/libraries/sources/$(CPYTHON_ARCHIVE).tar.gz || { echo "[-] Dependency $(notdir $(patsubst %.tar.gz,%,$@)) failed installation"; exit 1; }
+	@$(CURL) $@ $(RESOURCES_URL)/libraries/sources/$(CPYTHON_ARCHIVE).tar.gz || { printf "\033[31m[-] Dependency %s failed installation\033[0m\n" "$(notdir $(patsubst %.tar.gz,%,$@))"; exit 1; }
 	 @cd external && $(GUNZIP) $(patsubst external/%,%,$@)
 	 @cd external && $(TAR) $(patsubst external/%.gz,%,$@)
 	 @rm $(patsubst %.gz,%,$@)
-	 @echo "[+] Dependency $(notdir $(patsubst %.tar.gz,%,$@)) installed successfully"
+	@printf "\033[32m[+] Dependency %s installed successfully\033[0m\n" "$(notdir $(patsubst %.tar.gz,%,$@))"
 endif
 else
 external/$(CPYTHON).tar.gz:
 	 @echo "[-] Downloading dependency $(notdir $(patsubst %.tar.gz,%,$@)) ..."
-	@$(CURL) $@ $(RESOURCES_URL)/libraries/sources/$(CPYTHON_ARCHIVE).tar.gz || { echo "[-] Dependency $(notdir $(patsubst %.tar.gz,%,$@)) failed installation"; exit 1; }
+	@$(CURL) $@ $(RESOURCES_URL)/libraries/sources/$(CPYTHON_ARCHIVE).tar.gz || { printf "\033[31m[-] Dependency %s failed installation\033[0m\n" "$(notdir $(patsubst %.tar.gz,%,$@))"; exit 1; }
 	 @cd external && $(GUNZIP) $(patsubst external/%,%,$@)
 	 @cd external && $(TAR) $(patsubst external/%.gz,%,$@)
 	 @rm $(patsubst %.gz,%,$@)
-	 @echo "[+] Dependency $(notdir $(patsubst %.tar.gz,%,$@)) installed successfully"
+	@printf "\033[32m[+] Dependency %s installed successfully\033[0m\n" "$(notdir $(patsubst %.tar.gz,%,$@))"
 endif
 
 # Explicit rule for tzdata - always download from sources URL
@@ -619,15 +619,15 @@ external/%.tar.gz: external-precompiled/%.tar.gz
 	@test -d $(patsubst %.tar.gz,%,$@) ||\
 	($(CURL) $@ $(RESOURCES_URL)/libraries/sources/$(patsubst external/%,%,$@) &&\
 	cd external && $(GUNZIP) $(patsubst external/%,%,$@) && $(TAR) $(patsubst external/%.gz,%,$@) && rm $(patsubst external/%.gz,%,$@))
-	 @echo "[+] Dependency $(notdir $(patsubst %.tar.gz,%,$@)) installed successfully"
+	@printf "\033[32m[+] Dependency %s installed successfully\033[0m\n" "$(notdir $(patsubst %.tar.gz,%,$@))"
 else
 external/%.tar.gz:
 	 @echo "[-] Downloading dependency $(notdir $(patsubst %.tar.gz,%,$@)) ..."
-	@$(CURL) $@ $(RESOURCES_URL)/libraries/sources/$(patsubst external/%,%,$@) || { echo "[-] Dependency $(notdir $(patsubst %.tar.gz,%,$@)) failed installation"; exit 1; }
+	@$(CURL) $@ $(RESOURCES_URL)/libraries/sources/$(patsubst external/%,%,$@) || { printf "\033[31m[-] Dependency %s failed installation\033[0m\n" "$(notdir $(patsubst %.tar.gz,%,$@))"; exit 1; }
 	 @cd external && $(GUNZIP) $(patsubst external/%,%,$@)
 	 @cd external && $(TAR) $(patsubst external/%.gz,%,$@)
 	 @rm $(patsubst %.gz,%,$@)
-	 @echo "[+] Dependency $(notdir $(patsubst %.tar.gz,%,$@)) installed successfully"
+	@printf "\033[32m[+] Dependency %s installed successfully\033[0m\n" "$(notdir $(patsubst %.tar.gz,%,$@))"
 endif
 
 ifneq (,$(PRECOMPILED_RES))
@@ -649,10 +649,10 @@ shared_modules/http-request.tar.gz:
 	 @echo "[-] Downloading dependency $(notdir $(patsubst %.tar.gz,%,$@)) ..."
 	@find $(patsubst %.tar.gz,%,$@) -type f -exec false {} + &&\
 	((test -e $(patsubst %.gz,%,$@) || $(CURL) $@ $(CACERT_OPT) -L $(HTTP_REQUEST_URL)) &&\
-	($(GUNZIP) $@ || (rm -f $@ && echo "[-] Error decompressing $@, maybe wrong branch was supplied" && false)) &&\
+	($(GUNZIP) $@ || (rm -f $@ && printf "\033[31m[-] Error decompressing %s, maybe wrong branch was supplied\033[0m\n" "$@" && false)) &&\
 	$(TAR) $(patsubst %.gz,%,$@) --strip-components=1 -C $(patsubst %.tar.gz,%,$@) &&\
 	rm $(patsubst %.gz,%,$@)) || true
-	 @echo "[+] Dependency $(notdir $(patsubst %.tar.gz,%,$@)) installed successfully"
+	@printf "\033[32m[+] Dependency %s installed successfully\033[0m\n" "$(notdir $(patsubst %.tar.gz,%,$@))"
 
 # Indexer plugin templates download
 # Get refs from get_git_refs.sh if INDEXER_PLUGINS_REFS is not set
@@ -663,7 +663,7 @@ INDEXER_PLUGIN_REFS_LIST := $(shell $(ROUTE_PATH)/../tools/get_git_refs.sh 2>/de
 endif
 
 $(INDEXER_PLUGINS_DIR):
-	mkdir -p $(INDEXER_PLUGINS_DIR)
+	@mkdir -p $(INDEXER_PLUGINS_DIR)
 
 $(INDEXER_TEMPLATES_SERVER_STREAMS:%=$(INDEXER_PLUGINS_DIR)/%): | $(INDEXER_PLUGINS_DIR)
 	@success=0; \
@@ -676,7 +676,7 @@ $(INDEXER_TEMPLATES_SERVER_STREAMS:%=$(INDEXER_PLUGINS_DIR)/%): | $(INDEXER_PLUG
 		fi; \
 	done; \
 	if [ $$success -eq 0 ]; then \
-		echo "ERROR: Failed to download $(notdir $@) from any reference" >&2; \
+		printf "\033[31mERROR: Failed to download %s from any reference\033[0m\n" "$(notdir $@)" >&2; \
 		exit 1; \
 	fi
 
@@ -693,14 +693,14 @@ $(INDEXER_PLUGINS_DIR)/%.json: | $(INDEXER_PLUGINS_DIR)
 		fi; \
 	done; \
 	if [ $$success -eq 0 ]; then \
-		echo "ERROR: Failed to download $(notdir $@) from any reference" >&2; \
+		printf "\033[31mERROR: Failed to download %s from any reference\033[0m\n" "$(notdir $@)" >&2; \
 		exit 1; \
 	fi
-	 @echo "[+] Dependency $(notdir $@) installed successfully"
+	@printf "\033[32m[+] Dependency %s installed successfully\033[0m\n" "$(notdir $@)"
 
 # WCS flat files directory
 $(WCS_FLAT_DIR):
-	mkdir -p $(WCS_FLAT_DIR)
+	@mkdir -p $(WCS_FLAT_DIR)
 
 # Rule for WCS flat consolidated YAML file
 $(WCS_FLAT_DIR)/wcs_flat.yml: | $(WCS_FLAT_DIR)
@@ -715,10 +715,10 @@ $(WCS_FLAT_DIR)/wcs_flat.yml: | $(WCS_FLAT_DIR)
 		fi; \
 	done; \
 	if [ $$success -eq 0 ]; then \
-		echo "ERROR: Failed to download $(notdir $@) from any reference" >&2; \
+		printf "\033[31mERROR: Failed to download %s from any reference\033[0m\n" "$(notdir $@)" >&2; \
 		exit 1; \
 	fi
-	 @echo "[+] Dependency $(notdir $@) installed successfully"
+	@printf "\033[32m[+] Dependency %s installed successfully\033[0m\n" "$(notdir $@)"
 
 ####################
 #### Python ########

--- a/tools/get_git_refs.sh
+++ b/tools/get_git_refs.sh
@@ -64,6 +64,18 @@ try_git_command() {
 
     local has_output=0
 
+    # Try to detect branch from GitHub Actions environment if present
+    if [ -n "$GITHUB_REF" ]; then
+        if [[ "$GITHUB_REF" == refs/heads/* ]] || [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "$GITHUB_REF"
+            has_output=1
+        fi
+        if [ -n "$GITHUB_HEAD_REF" ]; then
+            echo "refs/heads/$GITHUB_HEAD_REF"
+            has_output=1
+        fi
+    fi
+
     # Try to get the current branch
     local branch
     branch=$(git -C "$REPO_ROOT" symbolic-ref --short HEAD 2>/dev/null || true)


### PR DESCRIPTION
## Description

`make deps` (src/Makefile) relies on `tools/get_git_refs.sh` to resolve the current Git branch when downloading indexer plugin templates. In GitHub Actions, `actions/checkout` leaves the repository in a detached HEAD state, so `git symbolic-ref --short HEAD` returns nothing and the script falls back straight to `VERSION.json`, ignoring the actual branch the workflow is running on. This breaks branch-based template resolution for both Agent and Manager workflows.

Closes #35909

## Proposed Changes

- `tools/get_git_refs.sh`: `try_git_command()` now checks GitHub Actions environment variables (`GITHUB_REF`, `GITHUB_HEAD_REF`) before falling through to `git symbolic-ref`. `GITHUB_HEAD_REF` in particular resolves the branch on `pull_request` events, where `GITHUB_REF` itself points to the synthetic `refs/pull/<n>/merge` ref rather than a real branch. Outside of GitHub Actions (local dev, other CI) these variables are unset, so behavior is unchanged.
- `src/Makefile`: minor output cleanup (colored `printf` instead of plain `echo`, quieter `mkdir -p`) for the dependency-download targets that call into `get_git_refs.sh`.

### Results and Evidence

- Verified `get_git_refs.sh` output changes with `GITHUB_REF`/`GITHUB_HEAD_REF` set/unset locally, both on a detached HEAD checkout and on a normal branch checkout.

### Artifacts Affected

- `tools/get_git_refs.sh`
- `src/Makefile`

### Configuration Changes

N/A

### Tests Introduced

N/A 

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues