### PR TITLE
Fix typo in SCA rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 #### Fixed
 
 - Fixed Fortigate Decoder, malicious ioc rule and RHEL 8,9,10 incorrect rpm check. ([#37434](https://github.com/wazuh/wazuh/pull/37434))
+- Fixed typo in `/etc/security/opasswd` permission check on Debian 10, Ubuntu 20.04 and Ubuntu 22.04 SCA rules. ([#37652](https://github.com/wazuh/wazuh/pull/37652))
 
 ## [v4.14.7]
 

--- a/ruleset/sca/debian/cis_debian10.yml
+++ b/ruleset/sca/debian/cis_debian10.yml
@@ -5130,9 +5130,9 @@ checks:
     rules:
       - 'c:stat -Lc "%n %a %u %U %g %G" /etc/shells- -> r:0 root 0 root && r:644|640|604|600|400|500'
 
-  # 6.1.10 Ensure permissions on /etc/opasswd are configured. (Automated)
+  # 6.1.10 Ensure permissions on /etc/security/opasswd are configured. (Automated)
   - id: 2712
-    title: "Ensure permissions on /etc/opasswd are configured."
+    title: "Ensure permissions on /etc/security/opasswd are configured."
     description: "/etc/security/opasswd and it's backup /etc/security/opasswd.old hold user's previous passwords if pam_unix or pam_pwhistory is in use on the system."
     rationale: "It is critical to ensure that /etc/security/opasswd is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
     remediation: 'Run the following commands to remove excess permissions, set owner, and set group on /etc/security/opasswd and /etc/security/opasswd.old is they exist: # [ -e "/etc/security/opasswd" ] && chmod u-x,go-rwx /etc/security/opasswd # [ -e "/etc/security/opasswd" ] && chown root:root /etc/security/opasswd # [ -e "/etc/security/opasswd.old" ] && chmod u-x,go-rwx /etc/security/opasswd.old # [ -e "/etc/security/opasswd.old" ] && chown root:root /etc/security/opasswd.old.'
@@ -5152,7 +5152,8 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/security/opasswds -> r:0 root 0 root && r:644|640|604|600|400|500'
+      - 'c:sh -c "[ ! -e /etc/security/opasswd ] || stat -Lc ''%n %a %u %U %g %G'' /etc/security/opasswd" -> r:^$|0 root 0 root && r:^$|600|400|500'
+      - 'c:sh -c "[ ! -e /etc/security/opasswd.old ] || stat -Lc ''%n %a %u %U %g %G'' /etc/security/opasswd.old" -> r:^$|0 root 0 root && r:^$|600|400|500'
 
   # 6.1.11 Ensure world writable files and directories are secured. (Automated) - Not Implemented
   # 6.1.12 Ensure no unowned or ungrouped files or directories exist. (Automated) - Not Implemented

--- a/ruleset/sca/debian/cis_debian10.yml
+++ b/ruleset/sca/debian/cis_debian10.yml
@@ -5152,8 +5152,8 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:sh -c "[ ! -e /etc/security/opasswd ] || stat -Lc ''%n %a %u %U %g %G'' /etc/security/opasswd" -> r:^$|0 root 0 root && r:^$|600|400|500'
-      - 'c:sh -c "[ ! -e /etc/security/opasswd.old ] || stat -Lc ''%n %a %u %U %g %G'' /etc/security/opasswd.old" -> r:^$|0 root 0 root && r:^$|600|400|500'
+      - 'c:stat -c "%a %U %G" /etc/security/opasswd -> r:^600\s+root\s+root$'
+      - 'c:stat -c "%a %U %G" /etc/security/opasswd.old -> r:^600\s+root\s+root$'
 
   # 6.1.11 Ensure world writable files and directories are secured. (Automated) - Not Implemented
   # 6.1.12 Ensure no unowned or ungrouped files or directories exist. (Automated) - Not Implemented

--- a/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
@@ -5006,9 +5006,9 @@ checks:
     rules:
       - 'c:stat -Lc "%n %a %u %U %g %G" /etc/shells- -> r:0 root 0 root && r:644|640|604|600|400|500'
 
-  # 6.1.10 Ensure permissions on /etc/opasswd are configured. (Automated)
+  # 6.1.10 Ensure permissions on /etc/security/opasswd are configured. (Automated)
   - id: 19205
-    title: "Ensure permissions on /etc/opasswd are configured."
+    title: "Ensure permissions on /etc/security/opasswd are configured."
     description: "/etc/security/opasswd and it's backup /etc/security/opasswd.old hold user's previous passwords if pam_unix or pam_pwhistory is in use on the system."
     rationale: "It is critical to ensure that /etc/security/opasswd is protected from unauthorized access. Although it is protected by default, the file permissions could be changed either inadvertently or through malicious actions."
     remediation: 'Run the following commands to remove excess permissions, set owner, and set group on /etc/security/opasswd and /etc/security/opasswd.old is they exist: # [ -e "/etc/security/opasswd" ] && chmod u-x,go-rwx /etc/security/opasswd # [ -e "/etc/security/opasswd" ] && chown root:root /etc/security/opasswd # [ -e "/etc/security/opasswd.old" ] && chmod u-x,go-rwx /etc/security/opasswd.old # [ -e "/etc/security/opasswd.old" ] && chown root:root /etc/security/opasswd.old.'
@@ -5028,7 +5028,8 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/security/opasswds -> r:0 root 0 root && r:644|640|604|600|400|500'
+      - 'c:sh -c "[ ! -e /etc/security/opasswd ] || stat -Lc ''%n %a %u %U %g %G'' /etc/security/opasswd" -> r:^$|0 root 0 root && r:^$|600|400|500'
+      - 'c:sh -c "[ ! -e /etc/security/opasswd.old ] || stat -Lc ''%n %a %u %U %g %G'' /etc/security/opasswd.old" -> r:^$|0 root 0 root && r:^$|600|400|500'
 
   # 6.1.11 Ensure world writable files and directories are secured. (Automated) - Not Implemented
   # 6.1.12 Ensure no unowned or ungrouped files or directories exist. (Automated) - Not Implemented

--- a/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
@@ -5028,8 +5028,8 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:sh -c "[ ! -e /etc/security/opasswd ] || stat -Lc ''%n %a %u %U %g %G'' /etc/security/opasswd" -> r:^$|0 root 0 root && r:^$|600|400|500'
-      - 'c:sh -c "[ ! -e /etc/security/opasswd.old ] || stat -Lc ''%n %a %u %U %g %G'' /etc/security/opasswd.old" -> r:^$|0 root 0 root && r:^$|600|400|500'
+      - 'c:stat -c "%a %U %G" /etc/security/opasswd -> r:^600\s+root\s+root$'
+      - 'c:stat -c "%a %U %G" /etc/security/opasswd.old -> r:^600\s+root\s+root$'
 
   # 6.1.11 Ensure world writable files and directories are secured. (Automated) - Not Implemented
   # 6.1.12 Ensure no unowned or ungrouped files or directories exist. (Automated) - Not Implemented

--- a/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
@@ -4998,7 +4998,8 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/security/opasswds -> r:0 root 0 root && r:600|400|500'
+      - 'c:sh -c "[ ! -e /etc/security/opasswd ] || stat -Lc ''%n %a %u %U %g %G'' /etc/security/opasswd" -> r:^$|0 root 0 root && r:^$|600|400|500'
+      - 'c:sh -c "[ ! -e /etc/security/opasswd.old ] || stat -Lc ''%n %a %u %U %g %G'' /etc/security/opasswd.old" -> r:^$|0 root 0 root && r:^$|600|400|500'
 
   # 7.1.11 Ensure world writable files and directories are secured. (Automated) - Not Implemented
   # 7.1.12 Ensure no files or directories without an owner and a group exist. (Automated) - Not Implemented

--- a/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
@@ -4998,8 +4998,8 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:sh -c "[ ! -e /etc/security/opasswd ] || stat -Lc ''%n %a %u %U %g %G'' /etc/security/opasswd" -> r:^$|0 root 0 root && r:^$|600|400|500'
-      - 'c:sh -c "[ ! -e /etc/security/opasswd.old ] || stat -Lc ''%n %a %u %U %g %G'' /etc/security/opasswd.old" -> r:^$|0 root 0 root && r:^$|600|400|500'
+      - 'c:stat -c "%a %U %G" /etc/security/opasswd -> r:^600\s+root\s+root$'
+      - 'c:stat -c "%a %U %G" /etc/security/opasswd.old -> r:^600\s+root\s+root$'
 
   # 7.1.11 Ensure world writable files and directories are secured. (Automated) - Not Implemented
   # 7.1.12 Ensure no files or directories without an owner and a group exist. (Automated) - Not Implemented


### PR DESCRIPTION
|Related issue|
|---|
| #20310 |

## Description

Fixed a typo in the permissions check for the `/etc/security/opasswd` file (which was looking for the non-existent `/etc/security/opasswds`) in the Debian 10, Ubuntu 20.04, and Ubuntu 22.04 SCA rules.

Additionally:
- Added a check for `/etc/security/opasswd.old`.
- Standardized the permitted permissions to `600 root root`.
- Aligned the rule with the one already shipped in Ubuntu 24.04's policy (`cis_ubuntu24-04.yml`, id 35770) and Debian 12/13, instead of introducing a bespoke existence-guard variant, so the check stays consistent across the whole ruleset. As a consequence the check fails (rather than passing trivially) when `opasswd`/`opasswd.old` don't exist yet — same behavior already accepted in the newer policies.

We verified the underlying mechanism behaves identically on Ubuntu 22.04 and Ubuntu 24.04: neither creates `/etc/security/opasswd`/`.old` by default (no `remember=N` configured out of the box), and once password-history tracking is enabled (`pam_pwhistory.so remember=N`), both versions create `opasswd` on the first password change and `opasswd.old` on the second, with identical permissions (`600 root:root`) and identical file size in our test. No behavioral difference between the two OS versions.

## Configuration options

No new configuration options.

## Logs/Alerts example

No logs/alerts changes.

## Tests

Verified with a real `wazuh-agent` (4.14.6) SCA scan against a minimal test policy mirroring the fixed rule:
- `opasswd` present (600 root:root), `opasswd.old` missing → check reports `failed` (score 0), as expected for `condition: all` without an existence guard.
- Both `opasswd` and `opasswd.old` present with `600 root:root` → check reports `passed` (score 100).

Also confirmed on real Ubuntu 22.04 and Ubuntu 24.04 containers that pam_unix/pam_pwhistory create and rotate `opasswd`/`opasswd.old` identically when password history is enabled.