### PR TITLE
Fix spurious ERROR/WARNING logs during agent shutdown

### DIFF
--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface_types.h
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface_types.h
@@ -26,10 +26,13 @@ extern "C" {
 /// Returned by sync entry points to report both outcome and failure detail.
 /// @var success        true if synchronization completed successfully; false otherwise.
 /// @var failure_reason Human-readable reason string when available; may be empty if no specific reason was recorded.
+/// @var stopped        true if the operation was aborted because a stop/shutdown was requested; lets the
+///                     caller demote an expected shutdown-time failure from WARNING to INFO/DEBUG.
 typedef struct SyncModuleResult_t
 {
     bool success;
     char failure_reason[SYNC_FAILURE_REASON_MAX_LEN];
+    bool stopped;
 } SyncModuleResult_t;
 
 /// @brief Defines the type of modification operation.

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_types.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_types.hpp
@@ -32,4 +32,8 @@ struct SyncModuleResult
 {
     bool success{false};
     std::string failureReason;
+    /// @brief True when the operation was aborted because a stop/shutdown was requested.
+    /// Lets the calling module demote an expected shutdown-time failure from WARNING to
+    /// INFO/DEBUG.
+    bool stopped{false};
 };

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -166,7 +166,10 @@ SyncModuleResult AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
 
     if (!m_transport->checkStatus())
     {
-        return {false, {}};
+        // Propagate the reason so the calling module emits a single, informative message at the
+        // right level (WARNING on a real failure, INFO "aborted" during shutdown). The transport
+        // itself only logs the low-level detail at debug.
+        return {false, "Failed to open the local message queue.", shouldStop()};
     }
 
     // Guard against concurrent calls. The timer thread and the AsyncFlushController
@@ -316,8 +319,11 @@ SyncModuleResult AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
     }
 
     std::string failureReason = determineSyncFailureReasonBasedOnSyncResult(m_syncState.lastSyncResult);
+    // Capture the stop state before clearing it so the caller can demote an expected
+    // shutdown-time failure from WARNING to INFO/DEBUG.
+    const bool stopped = shouldStop();
     clearSyncState();
-    return {success, failureReason};
+    return {success, failureReason, stopped};
 }
 
 bool AgentSyncProtocol::requiresFullSync(const std::string& index,
@@ -396,7 +402,10 @@ SyncModuleResult AgentSyncProtocol::synchronizeMetadataOrGroups(Mode mode,
 
     if (!m_transport->checkStatus())
     {
-        return {false, {}};
+        // Propagate the reason so the calling module emits a single, informative message at the
+        // right level (WARNING on a real failure, INFO "aborted" during shutdown). The transport
+        // itself only logs the low-level detail at debug.
+        return {false, "Failed to open the local message queue.", shouldStop()};
     }
 
     clearSyncState();
@@ -432,8 +441,11 @@ SyncModuleResult AgentSyncProtocol::synchronizeMetadataOrGroups(Mode mode,
     }
 
     std::string failureReason = determineSyncFailureReasonBasedOnSyncResult(m_syncState.lastSyncResult);
+    // Capture the stop state before clearing it so the caller can demote an expected
+    // shutdown-time failure from WARNING to INFO/DEBUG.
+    const bool stopped = shouldStop();
     clearSyncState();
-    return {success, failureReason};
+    return {success, failureReason, stopped};
 }
 
 bool AgentSyncProtocol::notifyDataClean(const std::vector<std::string>& indices,

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -319,8 +319,9 @@ SyncModuleResult AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
     }
 
     std::string failureReason = determineSyncFailureReasonBasedOnSyncResult(m_syncState.lastSyncResult);
-    // Capture the stop state before clearing it so the caller can demote an expected
+    // Report whether a stop was requested so the caller can demote an expected
     // shutdown-time failure from WARNING to INFO/DEBUG.
+    // (shouldStop() reads m_stopRequested, which clearSyncState() does not touch.)
     const bool stopped = shouldStop();
     clearSyncState();
     return {success, failureReason, stopped};
@@ -441,8 +442,9 @@ SyncModuleResult AgentSyncProtocol::synchronizeMetadataOrGroups(Mode mode,
     }
 
     std::string failureReason = determineSyncFailureReasonBasedOnSyncResult(m_syncState.lastSyncResult);
-    // Capture the stop state before clearing it so the caller can demote an expected
+    // Report whether a stop was requested so the caller can demote an expected
     // shutdown-time failure from WARNING to INFO/DEBUG.
+    // (shouldStop() reads m_stopRequested, which clearSyncState() does not touch.)
     const bool stopped = shouldStop();
     clearSyncState();
     return {success, failureReason, stopped};

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol_c_interface.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol_c_interface.cpp
@@ -112,7 +112,7 @@ extern "C" {
     {
         try
         {
-            if (!handle) return {false, {}};
+            if (!handle) return {false, {}, false};
 
             auto* wrapper = reinterpret_cast<AgentSyncProtocolWrapper*>(handle);
 
@@ -126,15 +126,17 @@ extern "C" {
 
             cResult.failure_reason[SYNC_FAILURE_REASON_MAX_LEN - 1] = '\0';
 
+            cResult.stopped = cppResult.stopped;
+
             return cResult;
         }
         catch (const std::exception& ex)
         {
-            return {false, {}};
+            return {false, {}, false};
         }
         catch (...)
         {
-            return {false, {}};
+            return {false, {}, false};
         }
     }
 
@@ -205,7 +207,7 @@ extern "C" {
     {
         try
         {
-            if (!handle || !indices || indices_count == 0) return {false, {}};
+            if (!handle || !indices || indices_count == 0) return {false, {}, false};
 
             // Convert C array of strings to C++ vector
             std::vector<std::string> indices_vec;
@@ -220,7 +222,7 @@ extern "C" {
                 }
             }
 
-            if (indices_vec.empty()) return {false, {}};
+            if (indices_vec.empty()) return {false, {}, false};
 
             auto* wrapper = reinterpret_cast<AgentSyncProtocolWrapper*>(handle);
 
@@ -236,15 +238,17 @@ extern "C" {
 
             cResult.failure_reason[SYNC_FAILURE_REASON_MAX_LEN - 1] = '\0';
 
+            cResult.stopped = cppResult.stopped;
+
             return cResult;
         }
         catch (const std::exception& ex)
         {
-            return {false, {}};
+            return {false, {}, false};
         }
         catch (...)
         {
-            return {false, {}};
+            return {false, {}, false};
         }
     }
 

--- a/src/shared_modules/sync_protocol/src/mqueue_transport.cpp
+++ b/src/shared_modules/sync_protocol/src/mqueue_transport.cpp
@@ -24,7 +24,11 @@ bool MQueueTransport::checkStatus()
 {
     if (!ensureQueueAvailable())
     {
-        m_logger(LOG_WARNING, "Failed to open queue: " + std::string(DEFAULTQUEUE));
+        // Internal transport detail: the failure is returned to the caller, which reports the
+        // contextualized outcome (e.g. "... synchronization aborted: the module is stopping" during
+        // shutdown, or a WARNING on a genuine failure). Keep this at debug to avoid duplicate noise,
+        // consistent with sendMessage() below.
+        m_logger(LOG_DEBUG, "Failed to open queue: " + std::string(DEFAULTQUEUE));
         return false;
     }
 

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -204,7 +204,37 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleNoQueueAvailable)
                   );
 
     EXPECT_FALSE(result.success);
-    EXPECT_EQ(result.failureReason, "");
+    EXPECT_EQ(result.failureReason, "Failed to open the local message queue.");
+    // No stop was requested, so the failure must not be flagged as shutdown-induced.
+    EXPECT_FALSE(result.stopped);
+}
+
+TEST_F(AgentSyncProtocolTest, SynchronizeModuleReportsStoppedWhenStopRequested)
+{
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    MQ_Functions failingStartMqFuncs =
+    {
+        .start = [](const char*, short int, short int) { return -1; }, // Fail to start queue
+        .send_binary = [](int, const void*, size_t, const char*, char)
+        {
+            return 0;
+        }
+    };
+
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", failingStartMqFuncs, testLogger, std::chrono::seconds(syncEndDelay), std::chrono::seconds(min_timeout), retries, maxEps,
+                                                   mockQueue);
+
+    // Simulate a shutdown/stop being requested before the sync runs.
+    protocol->stop();
+
+    SyncModuleResult result = protocol->synchronizeModule(
+                      Mode::DELTA
+                  );
+
+    EXPECT_FALSE(result.success);
+    // The failure happened while a stop was in progress: the module can demote its log.
+    EXPECT_TRUE(result.stopped);
 }
 
 TEST_F(AgentSyncProtocolTest, SynchronizeModuleFetchAndMarkForSyncThrowsException)
@@ -3220,7 +3250,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithFailedQueueStart)
                   );
 
     EXPECT_FALSE(result.success);
-    EXPECT_EQ(result.failureReason, "");
+    EXPECT_EQ(result.failureReason, "Failed to open the local message queue.");
 }
 
 TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsStartAckTimeout)

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -237,6 +237,39 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleReportsStoppedWhenStopRequested)
     EXPECT_TRUE(result.stopped);
 }
 
+// Exercises the C interface (asp_sync_module -> SyncModuleResult_t.stopped): this is the path
+// FIM depends on to distinguish a shutdown-aborted sync from a genuine failure.
+TEST_F(AgentSyncProtocolTest, CInterfacePropagatesStoppedFlag)
+{
+    // A queue that always fails to open, so synchronizeModule() returns at the checkStatus early
+    // out (no persistent-queue data needed).
+    MQ_Functions failingStartMq
+    {
+        [](const char*, short, short) { return -1; },
+        [](int, const void*, size_t, const char*, char) { return 0; }
+    };
+
+    auto* handle = asp_create("test_module",
+                              ":memory:",
+                              &failingStartMq,
+                              +[](modules_log_level_t, const char*) {},
+                              syncEndDelay, max_timeout, retries, maxEps);
+    ASSERT_NE(handle, nullptr);
+
+    // No stop requested: a real failure must not be flagged as shutdown-induced.
+    SyncModuleResult_t noStop = asp_sync_module(handle, MODE_DELTA);
+    EXPECT_FALSE(noStop.success);
+    EXPECT_FALSE(noStop.stopped);
+
+    // Stop requested: the C result must propagate stopped = true.
+    asp_stop(handle);
+    SyncModuleResult_t afterStop = asp_sync_module(handle, MODE_DELTA);
+    EXPECT_FALSE(afterStop.success);
+    EXPECT_TRUE(afterStop.stopped);
+
+    asp_destroy(handle);
+}
+
 TEST_F(AgentSyncProtocolTest, SynchronizeModuleFetchAndMarkForSyncThrowsException)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
@@ -896,7 +929,11 @@ TEST_F(AgentSyncProtocolTest, SendEndAbortedOnStopDuringSyncEndDelay)
                << "cv.wait_for may not be interruptible";
     }
 
-    EXPECT_FALSE(syncFuture.get().success);
+    const SyncModuleResult endResult = syncFuture.get();
+    EXPECT_FALSE(endResult.success);
+    // stop() was requested during the sync-end wait, so the final return must flag the failure
+    // as shutdown-induced (exercises the end-of-sync `stopped = shouldStop()` capture path).
+    EXPECT_TRUE(endResult.stopped);
 }
 
 TEST_F(AgentSyncProtocolTest, SynchronizeModuleEndFailDueToManager)
@@ -3251,6 +3288,8 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithFailedQueueStart)
 
     EXPECT_FALSE(result.success);
     EXPECT_EQ(result.failureReason, "Failed to open the local message queue.");
+    // No stop was requested, so the failure must not be flagged as shutdown-induced.
+    EXPECT_FALSE(result.stopped);
 }
 
 TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsStartAckTimeout)

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -1028,6 +1028,10 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
 
             if (sync_result.success) {
                 minfo("FIM synchronization requested by agent-info finished successfully.");
+            } else if (sync_result.stopped || fim_shutdown_process_on()) {
+                // Not a real failure: the sync was aborted because FIM is stopping.
+                // Report it as an expected event, not a WARNING.
+                minfo("FIM synchronization requested by agent-info aborted: FIM is stopping.");
             } else {
                 mwarn("FIM synchronization requested by agent-info failed%s%s",
                       sync_result.failure_reason[0] != '\0' ? ": " : "",
@@ -1069,6 +1073,10 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
                     first_sync_completed = true;
                     atomic_int_set(&syscheck.fim_first_sync_completed, 1);
                 }
+            } else if (sync_result.stopped || fim_shutdown_process_on()) {
+                // Not a real failure: the sync was aborted because FIM is stopping.
+                // Report it as an expected event, not a WARNING.
+                minfo("FIM synchronization aborted: FIM is stopping.");
             } else {
                 mwarn("FIM synchronization failed%s%s", sync_result.failure_reason[0] != '\0' ? ": " : "", sync_result.failure_reason);
             }

--- a/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
@@ -87,8 +87,8 @@ class AgentInfoImpl
 
         /// @brief Set the predicate used to detect that a shutdown is in progress.
         /// It complements the module's own stop flag so that failures caused by the global agent
-        /// shutdown (which happens before this module receives its own stop) are logged at DEBUG
-        /// instead of WARNING.
+        /// shutdown (which happens before this module receives its own stop) are logged at a lower
+        /// level (DEBUG or INFO, depending on the message) instead of WARNING.
         /// @param isShuttingDown Predicate returning true while a shutdown is requested
         void setIsShuttingDownFunction(std::function<bool()> isShuttingDown);
 

--- a/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
@@ -85,6 +85,13 @@ class AgentInfoImpl
         /// @param maxEps Maximum events per second
         void setSyncParameters(uint32_t syncEndDelay, uint32_t timeout, uint32_t retries, long maxEps);
 
+        /// @brief Set the predicate used to detect that a shutdown is in progress.
+        /// It complements the module's own stop flag so that failures caused by the global agent
+        /// shutdown (which happens before this module receives its own stop) are logged at DEBUG
+        /// instead of WARNING.
+        /// @param isShuttingDown Predicate returning true while a shutdown is requested
+        void setIsShuttingDownFunction(std::function<bool()> isShuttingDown);
+
         /// @brief Parse sync protocol response buffer
         /// @param data Pointer to the response data buffer
         /// @param length Size of the response data buffer
@@ -299,6 +306,18 @@ class AgentInfoImpl
         /// Atomic so the poll loops can read it without holding m_mutex while
         /// stop() writes it from another thread (avoids a data race).
         std::atomic<bool> m_stopped{false};
+
+        /// @brief Predicate reporting whether a shutdown is in progress (may be null).
+        /// Injected from the module wrapper; reports the *global* agent shutdown, which is
+        /// signaled before this module's own stop() runs.
+        std::function<bool()> m_isShuttingDown;
+
+        /// @brief True when this module is stopping OR a global shutdown is in progress.
+        /// Used to demote expected shutdown-time failures from WARNING to DEBUG.
+        bool isShutdownInProgress() const
+        {
+            return m_stopped || (m_isShuttingDown && m_isShuttingDown());
+        }
 
         /// @brief Delay in milliseconds between flush completion polls (10 seconds in production).
         /// Overridable in unit tests to avoid real sleeps.

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -331,6 +331,11 @@ void AgentInfoImpl::setSyncParameters(uint32_t syncEndDelay, uint32_t timeout, u
                   ", maxEps=" + std::to_string(maxEps));
 }
 
+void AgentInfoImpl::setIsShuttingDownFunction(std::function<bool()> isShuttingDown)
+{
+    m_isShuttingDown = std::move(isShuttingDown);
+}
+
 bool AgentInfoImpl::parseResponseBuffer(const uint8_t* data, size_t length)
 {
     if (m_spSyncProtocol && data)
@@ -752,7 +757,7 @@ bool AgentInfoImpl::updateChanges(const std::string& table, const nlohmann::json
 
         if (!m_dBSync)
         {
-            m_logFunction(m_stopped ? LOG_DEBUG : LOG_WARNING, "DBSync not available for table " + table);
+            m_logFunction(isShutdownInProgress() ? LOG_DEBUG : LOG_WARNING, "DBSync not available for table " + table);
             return false;
         }
 
@@ -1838,7 +1843,7 @@ AgentInfoImpl::CoordinationResult AgentInfoImpl::coordinateModules(const std::st
 
             if (!syncResult.success)
             {
-                m_logFunction(m_stopped ? LOG_DEBUG : LOG_WARNING, "Failed to synchronize " + table +
+                m_logFunction(isShutdownInProgress() ? LOG_DEBUG : LOG_WARNING, "Failed to synchronize " + table +
                               (syncResult.failureReason.empty() ? "." : ": " + syncResult.failureReason));
                 return CoordinationResult::Failed;
             }
@@ -1937,7 +1942,7 @@ void AgentInfoImpl::setSyncFlag(const std::string& table, bool value)
 
             if (!m_dBSync)
             {
-                m_logFunction(m_stopped ? LOG_DEBUG : LOG_WARNING, "Cannot set sync flag: DBSync not available");
+                m_logFunction(isShutdownInProgress() ? LOG_DEBUG : LOG_WARNING, "Cannot set sync flag: DBSync not available");
                 return;
             }
         }
@@ -1974,7 +1979,7 @@ void AgentInfoImpl::loadSyncFlags()
 
             if (!m_dBSync)
             {
-                m_logFunction(m_stopped ? LOG_DEBUG : LOG_WARNING, "Cannot load sync flags: DBSync not available");
+                m_logFunction(isShutdownInProgress() ? LOG_DEBUG : LOG_WARNING, "Cannot load sync flags: DBSync not available");
                 return;
             }
 
@@ -2154,7 +2159,7 @@ void AgentInfoImpl::updateLastIntegrityTime(const std::string& table)
 
             if (!m_dBSync)
             {
-                m_logFunction(m_stopped ? LOG_DEBUG : LOG_WARNING, "Cannot update last integrity time: DBSync not available");
+                m_logFunction(isShutdownInProgress() ? LOG_DEBUG : LOG_WARNING, "Cannot update last integrity time: DBSync not available");
                 return;
             }
         }
@@ -2274,7 +2279,7 @@ bool AgentInfoImpl::performIntegritySync(const std::string& table)
         }
         else
         {
-            m_logFunction(m_stopped ? LOG_DEBUG : LOG_WARNING, "Failed integrity check for " + table +
+            m_logFunction(isShutdownInProgress() ? LOG_DEBUG : LOG_WARNING, "Failed integrity check for " + table +
                           (syncResult.failureReason.empty() ? "." : ": " + syncResult.failureReason));
         }
 

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -1815,9 +1815,19 @@ AgentInfoImpl::CoordinationResult AgentInfoImpl::coordinateModules(const std::st
         // documents that have not yet arrived at the indexer.
         if (!pollFlushCompletion(pausedModules))
         {
-            m_logFunction(LOG_INFO,
-                          "One or more module flushes did not complete; aborting version sync to avoid "
-                          "indexer inconsistency — coordination will be retried in the next cycle");
+            if (isShutdownInProgress())
+            {
+                // No "next cycle": the module is stopping, so version sync is simply not handed over.
+                m_logFunction(LOG_INFO,
+                              "Module flush aborted: the module is stopping.");
+            }
+            else
+            {
+                m_logFunction(LOG_INFO,
+                              "One or more module flushes did not complete; aborting version sync to avoid "
+                              "indexer inconsistency — coordination will be retried in the next cycle");
+            }
+
             return CoordinationResult::Failed;
         }
 
@@ -2228,6 +2238,12 @@ bool AgentInfoImpl::performDeltaSync(const std::string& table)
         else if (result == CoordinationResult::Deferred)
         {
             m_logFunction(LOG_DEBUG, "Coordination of " + table + " deferred, sync flag retained for retry");
+            return false;
+        }
+        else if (isShutdownInProgress())
+        {
+            // Not a real failure and there is no "next cycle": the module is stopping.
+            m_logFunction(LOG_INFO, "Coordination of " + table + " aborted: the module is stopping.");
             return false;
         }
         else

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -1843,8 +1843,17 @@ AgentInfoImpl::CoordinationResult AgentInfoImpl::coordinateModules(const std::st
 
             if (!syncResult.success)
             {
-                m_logFunction(isShutdownInProgress() ? LOG_DEBUG : LOG_WARNING, "Failed to synchronize " + table +
-                              (syncResult.failureReason.empty() ? "." : ": " + syncResult.failureReason));
+                if (isShutdownInProgress() || syncResult.stopped)
+                {
+                    // Not a real failure: the sync was aborted because the module is stopping.
+                    m_logFunction(LOG_DEBUG, "Synchronization of " + table + " aborted: the module is stopping.");
+                }
+                else
+                {
+                    m_logFunction(LOG_WARNING, "Failed to synchronize " + table +
+                                  (syncResult.failureReason.empty() ? "." : ": " + syncResult.failureReason));
+                }
+
                 return CoordinationResult::Failed;
             }
 
@@ -2277,9 +2286,14 @@ bool AgentInfoImpl::performIntegritySync(const std::string& table)
         {
             m_logFunction(LOG_INFO, "Successfully completed integrity check for " + table);
         }
+        else if (isShutdownInProgress() || syncResult.stopped)
+        {
+            // Not a real failure: the integrity check was aborted because the module is stopping.
+            m_logFunction(LOG_DEBUG, "Integrity check for " + table + " aborted: the module is stopping.");
+        }
         else
         {
-            m_logFunction(isShutdownInProgress() ? LOG_DEBUG : LOG_WARNING, "Failed integrity check for " + table +
+            m_logFunction(LOG_WARNING, "Failed integrity check for " + table +
                           (syncResult.failureReason.empty() ? "." : ": " + syncResult.failureReason));
         }
 

--- a/src/wazuh_modules/agent_info/include/agent_info.h
+++ b/src/wazuh_modules/agent_info/include/agent_info.h
@@ -29,6 +29,7 @@ struct wm_agent_info_t;
 typedef void (*log_callback_t)(const modules_log_level_t level, const char* log, const char* tag);
 typedef int (*report_callback_t)(const char* message);
 typedef int (*query_module_callback_t)(const char* module_name, const char* query, char** response);
+typedef bool (*is_shutting_down_callback_t)(void);
 
 EXPORTED void agent_info_start(const struct wm_agent_info_t* agent_info_config);
 
@@ -46,6 +47,16 @@ agent_info_init_sync_protocol(const char* module_name, const MQ_Functions* mq_fu
 EXPORTED bool agent_info_parse_response(const uint8_t* data, size_t data_len);
 
 EXPORTED void agent_info_set_query_module_function(query_module_callback_t query_module_callback);
+
+/**
+ * @brief Set the predicate used to detect that a shutdown is in progress
+ *
+ * The implementation uses it to log expected shutdown-time synchronization/coordination
+ * failures at DEBUG instead of WARNING/ERROR.
+ *
+ * @param is_shutting_down_callback Predicate returning true while a shutdown is requested
+ */
+EXPORTED void agent_info_set_is_shutting_down_function(is_shutting_down_callback_t is_shutting_down_callback);
 
 /**
  * @brief Set the cluster name received from the manager during handshake
@@ -123,6 +134,7 @@ typedef void (*agent_info_init_sync_protocol_func)(const char* module_name,
                                                    const MQ_Functions* mq_funcs);
 typedef bool (*agent_info_parse_response_func)(const uint8_t* data, size_t data_len);
 typedef void (*agent_info_set_query_module_function_func)(query_module_callback_t query_module_callback);
+typedef void (*agent_info_set_is_shutting_down_function_func)(is_shutting_down_callback_t is_shutting_down_callback);
 typedef void (*agent_info_set_cluster_name_func)(const char* cluster_name);
 typedef const char* (*agent_info_get_cluster_name_func)(void);
 typedef void (*agent_info_set_cluster_node_func)(const char* cluster_node);

--- a/src/wazuh_modules/agent_info/include/agent_info.h
+++ b/src/wazuh_modules/agent_info/include/agent_info.h
@@ -52,7 +52,8 @@ EXPORTED void agent_info_set_query_module_function(query_module_callback_t query
  * @brief Set the predicate used to detect that a shutdown is in progress
  *
  * The implementation uses it to log expected shutdown-time synchronization/coordination
- * failures at DEBUG instead of WARNING/ERROR.
+ * failures at a lower level (DEBUG or INFO, depending on the message) instead of
+ * WARNING/ERROR.
  *
  * @param is_shutting_down_callback Predicate returning true while a shutdown is requested
  */

--- a/src/wazuh_modules/agent_info/src/agent_info.cpp
+++ b/src/wazuh_modules/agent_info/src/agent_info.cpp
@@ -39,6 +39,7 @@ static std::unique_ptr<AgentInfoImpl> g_agent_info_impl;
 static report_callback_t g_report_callback = nullptr;
 static log_callback_t g_log_callback = nullptr;
 static query_module_callback_t g_query_module_callback = nullptr;
+static is_shutting_down_callback_t g_is_shutting_down_callback = nullptr;
 
 // Global sync protocol parameters
 static const char* g_module_name = nullptr;
@@ -59,6 +60,7 @@ static char g_agent_groups[65536] = {0};
 static std::function<void(const std::string&)> g_report_function_wrapper;
 static std::function<void(const modules_log_level_t, const std::string&)> g_log_function_wrapper;
 static std::function<int(const std::string&, const std::string&, char**)> g_query_module_function_wrapper;
+static std::function<bool()> g_is_shutting_down_wrapper;
 
 void agent_info_set_log_function(log_callback_t log_callback)
 {
@@ -109,6 +111,24 @@ void agent_info_set_query_module_function(query_module_callback_t query_module_c
         };
     }
 
+}
+
+void agent_info_set_is_shutting_down_function(is_shutting_down_callback_t is_shutting_down_callback)
+{
+    g_is_shutting_down_callback = is_shutting_down_callback;
+
+    if (g_is_shutting_down_callback)
+    {
+        g_is_shutting_down_wrapper = []()
+        {
+            return g_is_shutting_down_callback ? g_is_shutting_down_callback() : false;
+        };
+    }
+
+    if (g_agent_info_impl)
+    {
+        g_agent_info_impl->setIsShuttingDownFunction(g_is_shutting_down_wrapper);
+    }
 }
 
 void agent_info_set_cluster_name(const char* cluster_name)
@@ -223,6 +243,10 @@ void agent_info_start(const struct wm_agent_info_t* agent_info_config)
 
             g_agent_info_impl =
                 std::make_unique<AgentInfoImpl>(AGENT_INFO_DB_DISK_PATH, g_report_function_wrapper, g_log_function_wrapper, g_query_module_function_wrapper);
+
+            // Propagate the shutdown predicate if it was registered before the instance existed
+            // (the wm_agent_info wrapper sets the callbacks before calling agent_info_start).
+            g_agent_info_impl->setIsShuttingDownFunction(g_is_shutting_down_wrapper);
 
             // Set sync parameters from configuration
             g_agent_info_impl->setSyncParameters(agent_info_config->sync.sync_end_delay,

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -567,7 +567,16 @@ bool SecurityConfigurationAssessment::syncModule(Mode mode)
     }
     else
     {
-        LoggingHelper::getInstance().log(LOG_WARNING, "SCA synchronization failed" + (result.failureReason.empty() ? "." : ": " + result.failureReason));
+        if (result.stopped || !m_keepRunning.load())
+        {
+            // Not a real failure: the sync was aborted because the module is stopping.
+            // Report it as an expected event, not a WARNING.
+            LoggingHelper::getInstance().log(LOG_INFO, "SCA synchronization aborted: the module is stopping.");
+        }
+        else
+        {
+            LoggingHelper::getInstance().log(LOG_WARNING, "SCA synchronization failed" + (result.failureReason.empty() ? "." : ": " + result.failureReason));
+        }
     }
 
     return result.success;
@@ -807,6 +816,12 @@ int SecurityConfigurationAssessment::executeFlushSync()
     {
         LoggingHelper::getInstance().log(LOG_DEBUG, "SCA flush completed successfully");
         return 0;
+    }
+    else if (result.stopped || !m_keepRunning.load())
+    {
+        // Not a real failure: the flush sync was aborted because the module is stopping.
+        LoggingHelper::getInstance().log(LOG_INFO, "SCA flush aborted: the module is stopping.");
+        return -1;
     }
     else
     {

--- a/src/wazuh_modules/src/wm_agent_info.c
+++ b/src/wazuh_modules/src/wm_agent_info.c
@@ -65,6 +65,7 @@ agent_info_set_log_function_func agent_info_set_log_function_ptr = NULL;
 agent_info_set_report_function_func agent_info_set_report_function_ptr = NULL;
 agent_info_init_sync_protocol_func agent_info_init_sync_protocol_ptr = NULL;
 agent_info_set_query_module_function_func agent_info_set_query_module_function_ptr = NULL;
+agent_info_set_is_shutting_down_function_func agent_info_set_is_shutting_down_function_ptr = NULL;
 agent_info_set_cluster_name_func agent_info_set_cluster_name_ptr = NULL;
 agent_info_set_cluster_node_func agent_info_set_cluster_node_ptr = NULL;
 agent_info_set_agent_groups_func agent_info_set_agent_groups_ptr = NULL;
@@ -198,7 +199,7 @@ agent_info_log_callback(const modules_log_level_t level, const char* log, __attr
 
 // True once a shutdown is requested. Checks both flags: wm_shutdown_requested
 // is set first, g_shutting_down later.
-static bool wm_agent_info_is_shutting_down()
+static bool wm_agent_info_is_shutting_down(void)
 {
     return g_shutting_down || wm_shutdown_requested;
 }
@@ -630,6 +631,8 @@ void* wm_agent_info_main(wm_agent_info_t* agent_info)
         agent_info_init_sync_protocol_ptr = so_get_function_sym(agent_info_module, "agent_info_init_sync_protocol");
         agent_info_set_query_module_function_ptr =
             so_get_function_sym(agent_info_module, "agent_info_set_query_module_function");
+        agent_info_set_is_shutting_down_function_ptr =
+            so_get_function_sym(agent_info_module, "agent_info_set_is_shutting_down_function");
         agent_info_set_cluster_name_ptr = so_get_function_sym(agent_info_module, "agent_info_set_cluster_name");
         agent_info_set_cluster_node_ptr = so_get_function_sym(agent_info_module, "agent_info_set_cluster_node");
         agent_info_set_agent_groups_ptr = so_get_function_sym(agent_info_module, "agent_info_set_agent_groups");
@@ -653,6 +656,13 @@ void* wm_agent_info_main(wm_agent_info_t* agent_info)
         if (agent_info_set_query_module_function_ptr)
         {
             agent_info_set_query_module_function_ptr(wm_agent_info_query_module_wrapper);
+        }
+
+        // Let the implementation know when a shutdown is in progress so it can demote
+        // expected shutdown-time sync/coordination failures from WARNING to DEBUG.
+        if (agent_info_set_is_shutting_down_function_ptr)
+        {
+            agent_info_set_is_shutting_down_function_ptr(wm_agent_info_is_shutting_down);
         }
     }
     else

--- a/src/wazuh_modules/src/wmodules.c
+++ b/src/wazuh_modules/src/wmodules.c
@@ -502,9 +502,14 @@ size_t wm_fim_query_json(const char* command, char** response) {
         // This is a transport helper: the connection failure is returned to the caller as a
         // structured JSON error (see the switch below), and the caller (agent-info) is the one
         // that contextualizes it (e.g. FIM unavailable during shutdown -> ECONNREFUSED/errno 111).
-        // Keep this at debug so an expected condition -such as syscheck being stopped first during
-        // shutdown- does not surface as a spurious ERROR.
-        mdebug1("WM_FIM_QUERY_JSON: Failed to connect to socket, errno=%d", errno);
+        // During shutdown syscheck is stopped first, so this is expected and kept at debug to avoid
+        // a spurious ERROR; during normal operation a dead syscheck is a genuine fault worth ERROR.
+        if (wm_shutdown_requested) {
+            mdebug1("WM_FIM_QUERY_JSON: Failed to connect to socket, errno=%d", errno);
+        } else {
+            merror("WM_FIM_QUERY_JSON: Failed to connect to socket, errno=%d", errno);
+        }
+
         switch (errno) {
             case ECONNREFUSED:
                 snprintf(error_msg, sizeof(error_msg), "{\"error\":%d,\"message\":\"Syscheck module refused connection. The component might be disabled\"}",
@@ -527,9 +532,13 @@ size_t wm_fim_query_json(const char* command, char** response) {
 
     // Send the JSON query to syscheck
     if (OS_SendSecureTCP(sock, strlen(json_string), json_string) < 0) {
-        // Transport-level failure returned to the caller as a JSON error; keep at debug to avoid
-        // spurious ERROR noise on expected shutdown races.
-        mdebug1("WM_FIM_QUERY_JSON: Failed to send command");
+        // Transport-level failure returned to the caller as a JSON error; debug during shutdown
+        // (expected race), ERROR otherwise (genuine fault).
+        if (wm_shutdown_requested) {
+            mdebug1("WM_FIM_QUERY_JSON: Failed to send command");
+        } else {
+            merror("WM_FIM_QUERY_JSON: Failed to send command");
+        }
         close(sock);
         snprintf(error_msg, sizeof(error_msg), "{\"error\":%d,\"message\":\"Could not send query to syscheck\"}",
                  MQ_ERR_INTERNAL);

--- a/src/wazuh_modules/src/wmodules.c
+++ b/src/wazuh_modules/src/wmodules.c
@@ -499,7 +499,12 @@ size_t wm_fim_query_json(const char* command, char** response) {
     // Connect to syscheck syscom socket
     mdebug1("WM_FIM_QUERY_JSON: Attempting to connect to socket: %s", SYS_LOCAL_SOCK);
     if ((sock = OS_ConnectUnixDomain(SYS_LOCAL_SOCK, SOCK_STREAM, OS_MAXSTR)) < 0) {
-        merror("WM_FIM_QUERY_JSON: Failed to connect to socket, errno=%d", errno);
+        // This is a transport helper: the connection failure is returned to the caller as a
+        // structured JSON error (see the switch below), and the caller (agent-info) is the one
+        // that contextualizes it (e.g. FIM unavailable during shutdown -> ECONNREFUSED/errno 111).
+        // Keep this at debug so an expected condition -such as syscheck being stopped first during
+        // shutdown- does not surface as a spurious ERROR.
+        mdebug1("WM_FIM_QUERY_JSON: Failed to connect to socket, errno=%d", errno);
         switch (errno) {
             case ECONNREFUSED:
                 snprintf(error_msg, sizeof(error_msg), "{\"error\":%d,\"message\":\"Syscheck module refused connection. The component might be disabled\"}",
@@ -522,7 +527,9 @@ size_t wm_fim_query_json(const char* command, char** response) {
 
     // Send the JSON query to syscheck
     if (OS_SendSecureTCP(sock, strlen(json_string), json_string) < 0) {
-        merror("WM_FIM_QUERY_JSON: Failed to send command");
+        // Transport-level failure returned to the caller as a JSON error; keep at debug to avoid
+        // spurious ERROR noise on expected shutdown races.
+        mdebug1("WM_FIM_QUERY_JSON: Failed to send command");
         close(sock);
         snprintf(error_msg, sizeof(error_msg), "{\"error\":%d,\"message\":\"Could not send query to syscheck\"}",
                  MQ_ERR_INTERNAL);

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -2285,8 +2285,18 @@ SyncModuleResult Syscollector::syncModule(Mode mode)
         {
             overallSuccess = false;
             failureReason = result.failureReason;
-            m_logFunction(LOG_WARNING, "Syscollector synchronization failed" +
-                          (result.failureReason.empty() ? "." : ": " + result.failureReason));
+
+            if (result.stopped || m_stopping.load())
+            {
+                // Not a real failure: the sync was aborted because the module is stopping.
+                // Report it as an expected event, not a WARNING.
+                m_logFunction(LOG_INFO, "Syscollector synchronization aborted: the module is stopping.");
+            }
+            else
+            {
+                m_logFunction(LOG_WARNING, "Syscollector synchronization failed" +
+                              (result.failureReason.empty() ? "." : ": " + result.failureReason));
+            }
         }
     }
 
@@ -2328,8 +2338,16 @@ SyncModuleResult Syscollector::syncModule(Mode mode)
                 failureReason = vdResult.failureReason;
             }
 
-            m_logFunction(LOG_WARNING, "Syscollector VD synchronization failed" +
-                          (vdResult.failureReason.empty() ? "." : ": " + vdResult.failureReason));
+            if (vdResult.stopped || m_stopping.load())
+            {
+                // Not a real failure: the VD sync was aborted because the module is stopping
+                m_logFunction(LOG_INFO, "Syscollector VD synchronization aborted: the module is stopping.");
+            }
+            else
+            {
+                m_logFunction(LOG_WARNING, "Syscollector VD synchronization failed" +
+                              (vdResult.failureReason.empty() ? "." : ": " + vdResult.failureReason));
+            }
         }
     }
 


### PR DESCRIPTION
## Description

During a normal agent shutdown or restart, `wazuh-modulesd` and `wazuh-syscheckd` emitted `ERROR`/`WARNING` messages for conditions that are expected corner cases (transient, no functional impact, the agent never failed). They were reported by the nightly install tests as unknown messages.

The root cause is a mismatch between **which flag causes the failure** and **which flag decides the log level**:

- The agent-wide shutdown is signaled early (the modulesd `SIGTERM` handler sets `wm_shutdown_requested`), which immediately tears down the transport used to reach the manager. The synchronization transport already honors that early flag and aborts.
- The log-level decision, however, relied on each module's **own** stop flag (`m_stopped`), which is set **later**, when modulesd stops that specific module. In the window between the two, an in-flight sync fails because of the shutdown, but the module does not yet "know" it is stopping, so it logged a `WARNING`.

In addition, a low-level transport helper (`wm_fim_query_json`, `MQueueTransport::checkStatus`) logged the failure itself, duplicating a signal the calling module already reports.

Closes #37555
Closes #37557

## Proposed Changes

Two complementary mechanisms so that expected shutdown-time aborts are reported at `INFO`/`DEBUG` (and worded as *aborted*, not *failed*), while genuine failures keep their `WARNING`/`ERROR` level.

**1. Make the agent-info module aware of the early global shutdown**
- Inject an `is_shutting_down` predicate (bound to `wm_agent_info_is_shutting_down` = `g_shutting_down || wm_shutdown_requested`) into `AgentInfoImpl`.
- Route the log-level guards through a new `isShutdownInProgress()` helper (`m_stopped || predicate`) so failures caused by the global shutdown — before agent-info receives its own stop — are demoted.
- Reword the shutdown cases so they read as expected aborts instead of failures/retries (there is no "next cycle" during shutdown):
  - *"Failed to synchronize \<table\>"* → *"Synchronization of \<table\> aborted: the module is stopping."*
  - *"Failed integrity check for \<table\>"* → *"Integrity check for \<table\> aborted: the module is stopping."*
  - *"Failed to coordinate \<table\>, will retry in next cycle"* → *"Coordination of \<table\> aborted: the module is stopping."*
  - *"One or more module flushes did not complete; aborting version sync … coordination will be retried in the next cycle"* → *"Module flush aborted: the module is stopping."*
  - The original wording (with *"will retry in next cycle"*) is kept for genuine, non-shutdown failures.

**2. Propagate the stop condition from the sync protocol to every module**
- Add a `stopped` flag to `SyncModuleResult` (C++) and `SyncModuleResult_t` (C interface). `synchronizeModule()` / `synchronizeMetadataOrGroups()` set it from `shouldStop()` at return and on the transport `checkStatus()` early-out.
- On `checkStatus()` failure, propagate a `failureReason` (`"Failed to open the local message queue."`) so the module emits a single informative message instead of a bare *"synchronization failed"*.
- `MQueueTransport::checkStatus()`: log the queue-open failure at `DEBUG` instead of `WARNING` (internal detail; consistent with `sendMessage()`, which already logs at `DEBUG`).
- Consumers (`syscollector`, `SCA`, `FIM`, `agent-info`) now log an `INFO`/`DEBUG` *"... synchronization aborted: the module is stopping."* when the abort was stop-induced (`result.stopped` combined with the module's own stopping flag: `m_stopping` / `!m_keepRunning` / `fim_shutdown_process_on()`), instead of a `WARNING`/`ERROR` *"... synchronization failed"*. Notably, `SCA executeFlushSync()` was previously an `ERROR`.

**3. Demote the FIM query transport error**
- `wm_fim_query_json()` logged an `ERROR` (`"Failed to connect to socket, errno=111"`) when syscheck's socket was already gone during shutdown. It already returns a structured JSON error to the caller, so the connect/send failures are demoted to `DEBUG`.

### Results and Evidence

Logs extracted from `/var/ossec/logs/ossec.log`.

**Before** (from the reported issues, agent shutdown):

```
wazuh-modulesd: ERROR: WM_FIM_QUERY_JSON: Failed to connect to socket, errno=111
wazuh-modulesd:agent-info: WARNING: Failed to synchronize agent_groups.
wazuh-modulesd:agent-info: WARNING: Failed to synchronize agent_metadata.
wazuh-modulesd:syscollector: WARNING: Syscollector VD synchronization failed.
wazuh-modulesd:syscollector: WARNING: syscollector_vd: Failed to open queue: queue/sockets/queue
```

**After** (repeated `start/stop` cycles with this branch built, captured from `/var/ossec/logs/ossec.log`).

Across all start/stop cycles in the captured window (2026-07-14 10:03 → 10:14) there were **0 `WARNING` and 0 `ERROR`** messages. A representative stop shows only expected `INFO` events, worded as *aborted* rather than *failed*:

```
2026/07/14 10:12:16 wazuh-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/07/14 10:12:17 wazuh-agentd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/07/14 10:12:17 wazuh-syscheckd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/07/14 10:12:17 wazuh-modulesd:agent-info: INFO: AgentInfo module stopped.
2026/07/14 10:12:17 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2026/07/14 10:12:17 wazuh-modulesd:agent-info: INFO: Module stopping, aborting pending flush monitoring
2026/07/14 10:12:17 wazuh-modulesd:agent-info: INFO: Module flush aborted: the module is stopping.
2026/07/14 10:12:17 wazuh-modulesd:agent-info: INFO: Coordination of agent_groups aborted: the module is stopping.
2026/07/14 10:12:17 wazuh-modulesd:agent-info: INFO: AgentInfo module loop ended.
2026/07/14 10:12:17 wazuh-modulesd:syscollector: INFO: Syscollector flush skipped: module is stopping
2026/07/14 10:12:18 wazuh-modulesd:sca: INFO: SCA module stopped.
```

- The `WM_FIM_QUERY_JSON ... ERROR` no longer appears.
- No `WARNING: Failed to synchronize ...` / `Failed to coordinate ...`; shutdown is reported at `INFO`, worded as *aborted*.
- The `syscollector_vd: Failed to open queue` `WARNING` is demoted to `DEBUG` and no longer surfaces in the default log.

Normal operation is unaffected — successful syncs/flushes still complete on running cycles:

```
2026/07/14 10:12:52 wazuh-syscheckd: INFO: FIM synchronization finished successfully.
2026/07/14 10:12:58 wazuh-modulesd:syscollector: INFO: Syscollector flush completed successfully
2026/07/14 10:13:43 wazuh-modulesd:agent-info: INFO: Successfully coordinated agent_groups
```

> Note: the *"... aborted: the module is stopping."* wording is emitted only when a stop/restart interrupts an in-flight sync/coordination; genuine failures still log at `WARNING` with the failure reason (see e.g. the retained `SteadyStateGenuineTimeoutStillLogsError` unit test).

### Artifacts Affected

- `wazuh-modulesd` (agent) — modules `agent-info`, `syscollector`, `sca`, and the FIM query helper (`wmodules.c`).
- `wazuh-syscheckd` (agent) — FIM synchronization loop.
- Shared library `agent_sync_protocol` (used by the modules above).

Agent-only components. No changes to manager artifacts.

### Configuration Changes

None. No new parameters, no default-value changes, no backward-compatibility impact. The changes only adjust log severities/messages and add an internal result field.

### Documentation Updates

None required. Recommendation: add the new expected shutdown messages to the known-messages list of the epic (#37410).

### Tests Introduced

- `test_agent_sync_protocol.cpp`: new `SynchronizeModuleReportsStoppedWhenStopRequested` asserting `SyncModuleResult.stopped` is set when a stop was requested and clear otherwise.
- Updated the `checkStatus`-failure tests (`SynchronizeModuleNoQueueAvailable`, `SynchronizeMetadataOrGroupsWithFailedQueueStart`) to assert the newly propagated `failureReason`.
- Existing module unit tests remain valid: they do not assert on the affected log levels, and the new predicate/`stopped` field default to the previous behavior when unset.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented (none)
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
