### PR TITLE
Fix RBAC permission bypass in GET /security/actions and /security/resources

### DIFF
--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -1146,7 +1146,8 @@ async def get_rbac_resources(resource: str = None, pretty: bool = False) -> Conn
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=True,
-                          logger=logger
+                          logger=logger,
+                          rbac_permissions=request.context['token_info']['rbac_policies']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 
@@ -1175,7 +1176,8 @@ async def get_rbac_actions(pretty: bool = False, endpoint: str = None) -> Connex
                           request_type='local_any',
                           is_async=False,
                           wait_for_complete=True,
-                          logger=logger
+                          logger=logger,
+                          rbac_permissions=request.context['token_info']['rbac_policies']
                           )
     data = raise_if_exc(await dapi.distribute_function())
 

--- a/api/api/controllers/test/test_security_controller.py
+++ b/api/api/controllers/test/test_security_controller.py
@@ -849,7 +849,7 @@ async def test_remove_role_rule(mock_exc, mock_dapi, mock_remove, mock_dfunc, mo
 @patch('api.controllers.security_controller.remove_nones_to_dict')
 @patch('api.controllers.security_controller.DistributedAPI.__init__', return_value=None)
 @patch('api.controllers.security_controller.raise_if_exc', return_value=CustomAffectedItems())
-async def test_get_rbac_resources(mock_exc, mock_dapi, mock_remove, mock_dfunc):
+async def test_get_rbac_resources(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request):
     """Verify 'get_rbac_resources' endpoint is working as expected."""
     result = await get_rbac_resources()
     f_kwargs = {'resource': None
@@ -859,7 +859,8 @@ async def test_get_rbac_resources(mock_exc, mock_dapi, mock_remove, mock_dfunc):
                                       request_type='local_any',
                                       is_async=False,
                                       logger=ANY,
-                                      wait_for_complete=True
+                                      wait_for_complete=True,
+                                      rbac_permissions=mock_request.context['token_info']['rbac_policies']
                                       )
     mock_exc.assert_called_once_with(mock_dfunc.return_value)
     mock_remove.assert_called_once_with(f_kwargs)
@@ -871,7 +872,7 @@ async def test_get_rbac_resources(mock_exc, mock_dapi, mock_remove, mock_dfunc):
 @patch('api.controllers.security_controller.remove_nones_to_dict')
 @patch('api.controllers.security_controller.DistributedAPI.__init__', return_value=None)
 @patch('api.controllers.security_controller.raise_if_exc', return_value=CustomAffectedItems())
-async def test_get_rbac_actions(mock_exc, mock_dapi, mock_remove, mock_dfunc):
+async def test_get_rbac_actions(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_request):
     """Verify 'get_rbac_actions' endpoint is working as expected."""
     result = await get_rbac_actions()
     f_kwargs = {'endpoint': None
@@ -881,7 +882,8 @@ async def test_get_rbac_actions(mock_exc, mock_dapi, mock_remove, mock_dfunc):
                                       request_type='local_any',
                                       is_async=False,
                                       logger=ANY,
-                                      wait_for_complete=True
+                                      wait_for_complete=True,
+                                      rbac_permissions=mock_request.context['token_info']['rbac_policies']
                                       )
     mock_exc.assert_called_once_with(mock_dfunc.return_value)
     mock_remove.assert_called_once_with(f_kwargs)


### PR DESCRIPTION
## Description
`GET /security/actions` and `GET /security/resources` built their `DistributedAPI` instance without passing the caller's `rbac_policies`, so the RBAC decorator's black-mode expansion always resolved to allow, bypassing the intended `security:read_config` check. The fix passes `rbac_permissions=request.context['token_info']['rbac_policies']` to both `DistributedAPI` calls, matching the pattern used by every other security endpoint (e.g. `get_security_config`).

## Proposed Changes
- `api/api/controllers/security_controller.py`: added `rbac_permissions=request.context['token_info']['rbac_policies']` to the `DistributedAPI` constructor calls in `get_rbac_resources` and `get_rbac_actions`.
- `api/api/controllers/test/test_security_controller.py`: updated `test_get_rbac_resources` and `test_get_rbac_actions` to use the `mock_request` fixture and assert `rbac_permissions` is forwarded to `DistributedAPI`.

### Results and Evidence
Ran `api/api/controllers/test/test_security_controller.py` with pytest:
- Before the fix: `test_get_rbac_resources` and `test_get_rbac_actions` fail (`AssertionError: expected call not found` — missing `rbac_permissions` kwarg).
- After the fix: all 51 tests in the file pass.

Manual verification against a running deployment, using a test user restricted to the `agents_readonly` role (`agent:read` on `agent:id:*`, no `security:*` permissions):

| Endpoint | Before | After |
|---|---|---|
| `GET /agents?limit=1` | 200 | 200 |
| `GET /security/config` | 403 | 403 |
| `GET /security/actions` | 200 | 403 |
| `GET /security/resources` | 200 | 403 |

After the fix, all three `/security/*` endpoints behave consistently for the same restricted user, matching the existing `/agents` and `/security/config` behavior.

### Artifacts Affected
Wazuh API (`api/api/controllers/security_controller.py`).

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
Updated `test_get_rbac_resources` and `test_get_rbac_actions` in `api/api/controllers/test/test_security_controller.py`.

## Credits

Kudos to @Voilater for reporting this issue.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)