### PR TITLE
Stop `verify-agent-conf` from falsely warning on agent-only wodle blocks, without breaking their validation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -863,7 +863,12 @@ ifneq ($(wildcard external/cpython/*),)
 endif
 
 clean-deps:
-	rm -rf $(EXTERNAL_DIR) $(EXTERNAL_TAR) shared_modules/http-request/* shared_modules/http-request/.??* $(INDEXER_PLUGINS_DIR) $(WCS_FLAT_DIR)
+# EXTERNAL_RES/EXTERNAL_DIR are filtered by TARGET, so removing only those
+# paths leaves other targets' fetched deps behind. Wipe everything under
+# external/ instead, except the two files tracked by git (CMakeLists.txt
+# and .gitignore), regardless of which TARGET this is invoked with.
+	find external -mindepth 1 -maxdepth 1 ! -name 'CMakeLists.txt' ! -name '.gitignore' -exec rm -rf {} +
+	rm -rf shared_modules/http-request/* shared_modules/http-request/.??* $(WCS_FLAT_DIR)
 
 clean-internals:
 # Wazuh binaries and libraries

--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -42,13 +42,6 @@ endif()
 # Collect config source files
 file(GLOB CONFIG_CORE_SRC "${CMAKE_CURRENT_SOURCE_DIR}/src/*.c")
 
-# Remove agent-only config modules from server builds
-if(NOT "${TARGET}" STREQUAL "winagent" AND NOT "${TARGET}" STREQUAL "agent")
-  list(REMOVE_ITEM CONFIG_CORE_SRC
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/wmodules-sca.c"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/wmodules-syscollector.c")
-endif()
-
 # Remove manager-only config parsers from agent builds
 if("${TARGET}" STREQUAL "agent" OR "${TARGET}" STREQUAL "winagent")
   list(REMOVE_ITEM CONFIG_CORE_SRC

--- a/src/config/include/config.h
+++ b/src/config/include/config.h
@@ -53,7 +53,7 @@ int Read_Remote(const OS_XML *xml,XML_NODE node, void *d1, void *d2);
 int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, void *d2);
 int Read_ClientBuffer(XML_NODE node, void *d1, void *d2);
 int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2);
-int Read_SCA(const OS_XML *xml, xml_node *node, void *d1);
+int Read_SCA(const OS_XML *xml, xml_node *node, void *d1, void *d2);
 int Read_AGENT_INFO(const OS_XML* xml, xml_node* node, void* d1);
 
 /**
@@ -68,16 +68,18 @@ int Read_Client_Shared(XML_NODE node, void *d1);
  * @param xml XML object
  * @param node XML node to analyze
  * @param d1 Pub/Sub configuration structure
+ * @param d2 Agent configuration validation flag
  */
-int Read_GCP_pubsub(const OS_XML *xml, xml_node *node, void *d1);
+int Read_GCP_pubsub(const OS_XML *xml, xml_node *node, void *d1, void *d2);
 
 /**
  * @brief Read the configuration for a Google Cloud bucket
  * @param xml XML object
  * @param node XML node to analyze
  * @param d1 Bucket configuration structure
+ * @param d2 Agent configuration validation flag
  */
-int Read_GCP_bucket(const OS_XML *xml, xml_node *node, void *d1);
+int Read_GCP_bucket(const OS_XML *xml, xml_node *node, void *d1, void *d2);
 
 #ifndef WIN32
 int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, void *d2);
@@ -94,24 +96,27 @@ int Read_TaskManager(const OS_XML *xml, xml_node *node, void *d1);
  * @param xml XML object
  * @param node XML node to analyze
  * @param d1 github configuration structure
+ * @param d2 Agent configuration validation flag
  */
-int Read_Github(const OS_XML *xml, xml_node *node, void *d1);
+int Read_Github(const OS_XML *xml, xml_node *node, void *d1, void *d2);
 
 /**
  * @brief Read the configuration for Office365 module
  * @param xml XML object
  * @param node XML node to analyze
  * @param d1 office365 configuration structure
+ * @param d2 Agent configuration validation flag
  */
-int Read_Office365(const OS_XML *xml, xml_node *node, void *d1);
+int Read_Office365(const OS_XML *xml, xml_node *node, void *d1, void *d2);
 
 /**
  * @brief Read the configuration for MS Graph module
  * @param xml XML object
  * @param node XML node to analyze
  * @param d1 ms_graph configuration structure
+ * @param d2 Agent configuration validation flag
  */
-int Read_MS_Graph(const OS_XML *xml, xml_node *node, void *d1);
+int Read_MS_Graph(const OS_XML *xml, xml_node *node, void *d1, void *d2);
 #endif
 
 /* Verifies that the configuration for Syscheck is correct. Return 0 on success or -1 on error.  */

--- a/src/config/src/config.c
+++ b/src/config/src/config.c
@@ -113,7 +113,7 @@ static int read_main_elements(const OS_XML *xml, int modules,
                 goto fail;
             }
         } else if (strcmp(node[i]->element, ossca) == 0) {
-            if ((modules & CWMODULE) && (Read_SCA(xml, node[i], d1) < 0)) {
+            if ((modules & CWMODULE) && (Read_SCA(xml, node[i], d1, d2) < 0)) {
                 goto fail;
             }
         }
@@ -162,12 +162,12 @@ static int read_main_elements(const OS_XML *xml, int modules,
             mwarn("%s configuration is only set in the manager.", node[i]->element);
 #endif
         } else if (strcmp(node[i]->element, osgcp_pub) == 0) {
-            if ((modules & CWMODULE) && (Read_GCP_pubsub(xml, node[i], d1) < 0)) {
+            if ((modules & CWMODULE) && (Read_GCP_pubsub(xml, node[i], d1, d2) < 0)) {
                 goto fail;
             }
 
         } else if (strcmp(node[i]->element, osgcp_bucket) == 0) {
-            if ((modules & CWMODULE) && (Read_GCP_bucket(xml, node[i], d1) < 0)) {
+            if ((modules & CWMODULE) && (Read_GCP_bucket(xml, node[i], d1, d2) < 0)) {
                 goto fail;
             }
 #ifndef WIN32
@@ -205,15 +205,15 @@ static int read_main_elements(const OS_XML *xml, int modules,
         }
 #if defined(WIN32) || defined(__linux__) || defined(__MACH__)
         else if (chld_node && (strcmp(node[i]->element, github) == 0)) {
-            if ((modules & CWMODULE) && (Read_Github(xml, node[i], d1) < 0)) {
+            if ((modules & CWMODULE) && (Read_Github(xml, node[i], d1, d2) < 0)) {
                 goto fail;
             }
         } else if (chld_node && (strcmp(node[i]->element, office365) == 0)) {
-            if ((modules & CWMODULE) && (Read_Office365(xml, node[i], d1) < 0)) {
+            if ((modules & CWMODULE) && (Read_Office365(xml, node[i], d1, d2) < 0)) {
                 goto fail;
             }
         } else if (chld_node && (strcmp(node[i]->element, ms_graph) == 0)) {
-            if ((modules & CWMODULE) && (Read_MS_Graph(xml, node[i], d1) < 0)) {
+            if ((modules & CWMODULE) && (Read_MS_Graph(xml, node[i], d1, d2) < 0)) {
                 goto fail;
             }
         }

--- a/src/config/src/wmodules-config.c
+++ b/src/config/src/wmodules-config.c
@@ -256,13 +256,13 @@ int Read_SCA(const OS_XML *xml, xml_node *node, void *d1, void *d2)
     //Policy Monitoring Module
     if (!strcmp(node->element, WM_SCA_CONTEXT.name)) {
 #ifdef CLIENT
-        if (wm_sca_read(xml,children, cur_wmodule) < 0) {
+        if (wm_sca_read(xml,children, cur_wmodule, 0) < 0) {
             OS_ClearNode(children);
             return OS_INVALID;
         }
 #else
         if (agent_cfg) {
-            if (wm_sca_read(xml,children, cur_wmodule) < 0) {
+            if (wm_sca_read(xml,children, cur_wmodule, 1) < 0) {
                 OS_ClearNode(children);
                 return OS_INVALID;
             }

--- a/src/config/src/wmodules-config.c
+++ b/src/config/src/wmodules-config.c
@@ -31,9 +31,6 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
 {
     wmodule **wmodules = (wmodule**)d1;
     int agent_cfg = d2 ? *(int *)d2 : 0;
-#ifndef CLIENT
-    (void)agent_cfg;
-#endif
     wmodule *cur_wmodule;
     xml_node **children = NULL;
     wmodule *cur_wmodule_exists;
@@ -92,7 +89,14 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
             return OS_INVALID;
         }
 #else
-        mwarn("The '%s' module only works for the agent", node->values[0]);
+        if (agent_cfg) {
+            if (wm_syscollector_read(xml, children, cur_wmodule) < 0) {
+                OS_ClearNode(children);
+                return OS_INVALID;
+            }
+        } else {
+            mwarn("The '%s' module only works for the agent", node->values[0]);
+        }
 #endif
     }
 #ifdef CLIENT
@@ -104,7 +108,14 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
     }
 #else
     else if (!strcmp(node->values[0], WM_COMMAND_CONTEXT.name)) {
-        mwarn("The '%s' module only works for the agent", node->values[0]);
+        if (agent_cfg) {
+            if (wm_command_read(children, cur_wmodule, agent_cfg) < 0) {
+                OS_ClearNode(children);
+                return OS_INVALID;
+            }
+        } else {
+            mwarn("The '%s' module only works for the agent", node->values[0]);
+        }
     }
 #endif
     else if (!strcmp(node->values[0], WM_AWS_CONTEXT.name) || !strcmp(node->values[0], "aws-cloudtrail")) {
@@ -116,7 +127,14 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
             return OS_INVALID;
         }
 #else
-        mwarn("The '%s' module only works for the agent", node->values[0]);
+        if (agent_cfg) {
+            if (wm_aws_read(xml, children, cur_wmodule) < 0) {
+                OS_ClearNode(children);
+                return OS_INVALID;
+            }
+        } else {
+            mwarn("The '%s' module only works for the agent", node->values[0]);
+        }
 #endif
 #else
         mwarn("The '%s' module is not available on Windows systems. Ignoring.", node->values[0]);
@@ -129,7 +147,14 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
             return OS_INVALID;
         }
 #else
-        mwarn("The '%s' module only works for the agent", node->values[0]);
+        if (agent_cfg) {
+            if (wm_docker_read(children, cur_wmodule) < 0) {
+                OS_ClearNode(children);
+                return OS_INVALID;
+            }
+        } else {
+            mwarn("The '%s' module only works for the agent", node->values[0]);
+        }
 #endif
 #else
         mwarn("The '%s' module is not available on Windows systems. Ignoring it.", node->values[0]);
@@ -145,7 +170,14 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
     }
 #else
     else if (!strcmp(node->values[0], WM_AZURE_CONTEXT.name)) {
-        mwarn("The '%s' module only works for the agent", node->values[0]);
+        if (agent_cfg) {
+            if (wm_azure_read(xml, children, cur_wmodule) < 0) {
+                OS_ClearNode(children);
+                return OS_INVALID;
+            }
+        } else {
+            mwarn("The '%s' module only works for the agent", node->values[0]);
+        }
     }
 #endif
 #endif
@@ -174,9 +206,13 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
     return 0;
 }
 
-int Read_SCA(const OS_XML *xml, xml_node *node, void *d1)
+int Read_SCA(const OS_XML *xml, xml_node *node, void *d1, void *d2)
 {
     wmodule **wmodules = (wmodule**)d1;
+    int agent_cfg = d2 ? *(int *)d2 : 0;
+#ifdef CLIENT
+    (void)agent_cfg;
+#endif
     wmodule *cur_wmodule;
     xml_node **children = NULL;
     wmodule *cur_wmodule_exists;
@@ -218,14 +254,21 @@ int Read_SCA(const OS_XML *xml, xml_node *node, void *d1)
     }
 
     //Policy Monitoring Module
-#ifdef CLIENT
     if (!strcmp(node->element, WM_SCA_CONTEXT.name)) {
+#ifdef CLIENT
         if (wm_sca_read(xml,children, cur_wmodule) < 0) {
             OS_ClearNode(children);
             return OS_INVALID;
         }
-    }
+#else
+        if (agent_cfg) {
+            if (wm_sca_read(xml,children, cur_wmodule) < 0) {
+                OS_ClearNode(children);
+                return OS_INVALID;
+            }
+        }
 #endif
+    }
     OS_ClearNode(children);
     return 0;
 }
@@ -312,8 +355,12 @@ int Read_AGENT_INFO(const OS_XML* xml, xml_node* node, void* d1)
     return 0;
 }
 
-int Read_GCP_pubsub(const OS_XML *xml, xml_node *node, void *d1) {
+int Read_GCP_pubsub(const OS_XML *xml, xml_node *node, void *d1, void *d2) {
     wmodule **wmodules = (wmodule**)d1;
+    int agent_cfg = d2 ? *(int *)d2 : 0;
+#ifdef CLIENT
+    (void)agent_cfg;
+#endif
     wmodule *cur_wmodule;
     xml_node **children = NULL;
     wmodule *cur_wmodule_exists;
@@ -367,7 +414,14 @@ int Read_GCP_pubsub(const OS_XML *xml, xml_node *node, void *d1) {
         mwarn("The '%s' module is not available on Windows systems. Ignoring it.", node->element);
 #endif
 #else
-        mwarn("The '%s' module only works for the agent", node->element);
+        if (agent_cfg) {
+            if (wm_gcp_pubsub_read(children, cur_wmodule) < 0) {
+                OS_ClearNode(children);
+                return OS_INVALID;
+            }
+        } else {
+            mwarn("The '%s' module only works for the agent", node->element);
+        }
 #endif
     }
 
@@ -375,8 +429,12 @@ int Read_GCP_pubsub(const OS_XML *xml, xml_node *node, void *d1) {
     return 0;
 }
 
-int Read_GCP_bucket(const OS_XML *xml, xml_node *node, void *d1) {
+int Read_GCP_bucket(const OS_XML *xml, xml_node *node, void *d1, void *d2) {
     wmodule **wmodules = (wmodule**)d1;
+    int agent_cfg = d2 ? *(int *)d2 : 0;
+#ifdef CLIENT
+    (void)agent_cfg;
+#endif
     wmodule *cur_wmodule;
     xml_node **children = NULL;
     wmodule *cur_wmodule_exists;
@@ -430,7 +488,14 @@ int Read_GCP_bucket(const OS_XML *xml, xml_node *node, void *d1) {
         mwarn("The '%s' module is not available on Windows systems. Ignoring it.", node->element);
 #endif
 #else
-        mwarn("The '%s' module only works for the agent", node->element);
+        if (agent_cfg) {
+            if (wm_gcp_bucket_read(xml, children, cur_wmodule) < 0) {
+                OS_ClearNode(children);
+                return OS_INVALID;
+            }
+        } else {
+            mwarn("The '%s' module only works for the agent", node->element);
+        }
 #endif
     }
 
@@ -551,8 +616,12 @@ int Read_TaskManager(const OS_XML *xml, xml_node *node, void *d1) {
 #endif
 
 #if defined(WIN32) || defined(__linux__) || defined(__MACH__)
-int Read_Github(const OS_XML *xml, xml_node *node, void *d1) {
+int Read_Github(const OS_XML *xml, xml_node *node, void *d1, void *d2) {
     wmodule **wmodules = (wmodule**)d1;
+    int agent_cfg = d2 ? *(int *)d2 : 0;
+#ifdef CLIENT
+    (void)agent_cfg;
+#endif
     wmodule *cur_wmodule;
     xml_node **children = NULL;
     wmodule *cur_wmodule_exists;
@@ -602,7 +671,14 @@ int Read_Github(const OS_XML *xml, xml_node *node, void *d1) {
             return OS_INVALID;
         }
 #else
-        mwarn("The '%s' module only works for the agent", node->element);
+        if (agent_cfg) {
+            if (wm_github_read(xml, children, cur_wmodule) < 0) {
+                OS_ClearNode(children);
+                return OS_INVALID;
+            }
+        } else {
+            mwarn("The '%s' module only works for the agent", node->element);
+        }
 #endif
     }
 
@@ -610,8 +686,12 @@ int Read_Github(const OS_XML *xml, xml_node *node, void *d1) {
     return 0;
 }
 
-int Read_Office365(const OS_XML *xml, xml_node *node, void *d1) {
+int Read_Office365(const OS_XML *xml, xml_node *node, void *d1, void *d2) {
     wmodule **wmodules = (wmodule**)d1;
+    int agent_cfg = d2 ? *(int *)d2 : 0;
+#ifdef CLIENT
+    (void)agent_cfg;
+#endif
     wmodule *cur_wmodule;
     xml_node **children = NULL;
     wmodule *cur_wmodule_exists;
@@ -661,7 +741,14 @@ int Read_Office365(const OS_XML *xml, xml_node *node, void *d1) {
             return OS_INVALID;
         }
 #else
-        mwarn("The '%s' module only works for the agent", node->element);
+        if (agent_cfg) {
+            if (wm_office365_read(xml, children, cur_wmodule) < 0) {
+                OS_ClearNode(children);
+                return OS_INVALID;
+            }
+        } else {
+            mwarn("The '%s' module only works for the agent", node->element);
+        }
 #endif
     }
 
@@ -669,8 +756,12 @@ int Read_Office365(const OS_XML *xml, xml_node *node, void *d1) {
     return 0;
 }
 
-int Read_MS_Graph(const OS_XML *xml, xml_node *node, void *d1) {
+int Read_MS_Graph(const OS_XML *xml, xml_node *node, void *d1, void *d2) {
     wmodule **wmodules = (wmodule**)d1;
+    int agent_cfg = d2 ? *(int *)d2 : 0;
+#ifdef CLIENT
+    (void)agent_cfg;
+#endif
     wmodule *cur_wmodule;
     xml_node **children = NULL;
     wmodule *cur_wmodule_exists;
@@ -720,7 +811,14 @@ int Read_MS_Graph(const OS_XML *xml, xml_node *node, void *d1) {
             return OS_INVALID;
         }
 #else
-        mwarn("The '%s' module only works for the agent", node->element);
+        if (agent_cfg) {
+            if (wm_ms_graph_read(xml, children, cur_wmodule) < 0) {
+                OS_ClearNode(children);
+                return OS_INVALID;
+            }
+        } else {
+            mwarn("The '%s' module only works for the agent", node->element);
+        }
 #endif
     }
 
@@ -731,10 +829,11 @@ int Read_MS_Graph(const OS_XML *xml, xml_node *node, void *d1) {
 
 int Test_WModule(const char * path) {
     int fail = 0;
+    int agent_cfg = 1;
     wmodule *test_wmodule;
     os_calloc(1, sizeof(wmodule), test_wmodule);
 
-    if (ReadConfig(CAGENT_CONFIG | CWMODULE, path, &test_wmodule, NULL) < 0) {
+    if (ReadConfig(CAGENT_CONFIG | CWMODULE, path, &test_wmodule, &agent_cfg) < 0) {
         merror(RCONFIG_ERROR,"WModule", path);
         fail = 1;
     }

--- a/src/config/src/wmodules-sca.c
+++ b/src/config/src/wmodules-sca.c
@@ -143,7 +143,7 @@ static void parse_synchronization_section(wm_sca_t * sca, XML_NODE node)
 }
 
 // Reading function
-int wm_sca_read(const OS_XML *xml,xml_node **nodes, wmodule *module)
+int wm_sca_read(const OS_XML *xml,xml_node **nodes, wmodule *module, int skip_ruleset_load)
 {
     unsigned int i;
     wm_sca_t *sca;
@@ -173,82 +173,84 @@ int wm_sca_read(const OS_XML *xml,xml_node **nodes, wmodule *module)
 
     /* By default, load all every ruleset present */
 
-    char ruleset_path[PATH_MAX] = {0};
-    #ifdef WIN32
-    sprintf(ruleset_path, "%s\\", SECURITY_CONFIGURATION_ASSESSMENT_DIR_WIN);
-    #else
-    sprintf(ruleset_path, "%s/", SECURITY_CONFIGURATION_ASSESSMENT_DIR);
-    #endif
+    if (!skip_ruleset_load) {
+        char ruleset_path[PATH_MAX] = {0};
+        #ifdef WIN32
+        sprintf(ruleset_path, "%s\\", SECURITY_CONFIGURATION_ASSESSMENT_DIR_WIN);
+        #else
+        sprintf(ruleset_path, "%s/", SECURITY_CONFIGURATION_ASSESSMENT_DIR);
+        #endif
 
-    DIR *ruleset_dir = wopendir(ruleset_path);
-    const int open_dir_errno = errno;
-    if (ruleset_dir) {
-        struct dirent *dir_entry;
-        while ((dir_entry = readdir(ruleset_dir)) != NULL) {
-            if (strcmp(dir_entry->d_name, ".") == 0 || strcmp(dir_entry->d_name, "..") == 0) {
-                continue;
-            }
+        DIR *ruleset_dir = wopendir(ruleset_path);
+        const int open_dir_errno = errno;
+        if (ruleset_dir) {
+            struct dirent *dir_entry;
+            while ((dir_entry = readdir(ruleset_dir)) != NULL) {
+                if (strcmp(dir_entry->d_name, ".") == 0 || strcmp(dir_entry->d_name, "..") == 0) {
+                    continue;
+                }
 
-            const char * const file_extension = strrchr(dir_entry->d_name, '.');
-            if (!file_extension || (strcmp(file_extension, ".yml") != 0 && strcmp(file_extension, ".yaml") != 0)) {
-                continue;
-            }
+                const char * const file_extension = strrchr(dir_entry->d_name, '.');
+                if (!file_extension || (strcmp(file_extension, ".yml") != 0 && strcmp(file_extension, ".yaml") != 0)) {
+                    continue;
+                }
 
-            /* get the full path of the policy file */
-            char relative_path[PATH_MAX] = {0};
-            const int ruleset_path_len = sprintf(relative_path, "%s", ruleset_path);
-            strncat(relative_path, dir_entry->d_name, PATH_MAX - ruleset_path_len);
+                /* get the full path of the policy file */
+                char relative_path[PATH_MAX] = {0};
+                const int ruleset_path_len = sprintf(relative_path, "%s", ruleset_path);
+                strncat(relative_path, dir_entry->d_name, PATH_MAX - ruleset_path_len);
 
-            char realpath_buffer[PATH_MAX] = {0};
-            #ifdef WIN32
-            const int path_length = GetFullPathName(relative_path, PATH_MAX, realpath_buffer, NULL);
-            if (!path_length) {
-                mwarn("File '%s' not found.", dir_entry->d_name);
-                continue;
-            }
-            #else
-            const char * const realpath_buffer_ref = realpath(relative_path, realpath_buffer);
-            if (!realpath_buffer_ref) {
-                mwarn("File '%s' not found.", dir_entry->d_name);
-                continue;
-            }
-            #endif
+                char realpath_buffer[PATH_MAX] = {0};
+                #ifdef WIN32
+                const int path_length = GetFullPathName(relative_path, PATH_MAX, realpath_buffer, NULL);
+                if (!path_length) {
+                    mwarn("File '%s' not found.", dir_entry->d_name);
+                    continue;
+                }
+                #else
+                const char * const realpath_buffer_ref = realpath(relative_path, realpath_buffer);
+                if (!realpath_buffer_ref) {
+                    mwarn("File '%s' not found.", dir_entry->d_name);
+                    continue;
+                }
+                #endif
 
-            int policy_found = 0;
+                int policy_found = 0;
 
-            if (sca->policies) {
-                int i;
-                for(i = 0; sca->policies[i]; i++) {
-                    if(sca->policies[i]->policy_path && !strcmp(sca->policies[i]->policy_path, realpath_buffer)) {
-                        /* Avoid adding policies by default for each xml configuration block.
-                        This happens because wm_sca_read function is called once for each xml
-                        configuration block */
-                        policy_found = 1;
-                        break;
+                if (sca->policies) {
+                    int i;
+                    for(i = 0; sca->policies[i]; i++) {
+                        if(sca->policies[i]->policy_path && !strcmp(sca->policies[i]->policy_path, realpath_buffer)) {
+                            /* Avoid adding policies by default for each xml configuration block.
+                            This happens because wm_sca_read function is called once for each xml
+                            configuration block */
+                            policy_found = 1;
+                            break;
+                        }
                     }
                 }
+
+                if (policy_found) {
+                    continue;
+                }
+
+                os_realloc(sca->policies, (policies_count + 2) * sizeof(wm_sca_policy_t *), sca->policies);
+                wm_sca_policy_t *policy;
+                os_calloc(1,sizeof(wm_sca_policy_t),policy);
+
+                policy->enabled = 1;
+                policy->policy_id = NULL;
+                policy->remote = 0;
+                os_strdup(realpath_buffer, policy->policy_path);
+                sca->policies[policies_count] = policy;
+                sca->policies[policies_count + 1] = NULL;
+                policies_count++;
             }
 
-            if (policy_found) {
-                continue;
-            }
-
-            os_realloc(sca->policies, (policies_count + 2) * sizeof(wm_sca_policy_t *), sca->policies);
-            wm_sca_policy_t *policy;
-            os_calloc(1,sizeof(wm_sca_policy_t),policy);
-
-            policy->enabled = 1;
-            policy->policy_id = NULL;
-            policy->remote = 0;
-            os_strdup(realpath_buffer, policy->policy_path);
-            sca->policies[policies_count] = policy;
-            sca->policies[policies_count + 1] = NULL;
-            policies_count++;
+            closedir(ruleset_dir);
+        } else {
+            minfo("Could not open the default SCA ruleset folder '%s': %s", ruleset_path, strerror(open_dir_errno));
         }
-
-        closedir(ruleset_dir);
-    } else {
-        minfo("Could not open the default SCA ruleset folder '%s': %s", ruleset_path, strerror(open_dir_errno));
     }
 
     if (!nodes) {

--- a/src/unit_tests/config/CMakeLists.txt
+++ b/src/unit_tests/config/CMakeLists.txt
@@ -40,6 +40,9 @@ list(APPEND config_flags "-Wl,--wrap,OS_GetHost -Wl,--wrap=Start_win32_Syscheck 
 if(${TARGET} STREQUAL "manager")
     list(APPEND config_names "test_indexer")
     list(APPEND config_flags "-Wl,--wrap,Read_Indexer -Wl,--wrap,get_indexer_cnf ${DEBUG_OP_WRAPPERS}")
+
+    list(APPEND config_names "test_wmodules-config")
+    list(APPEND config_flags "${DEBUG_OP_WRAPPERS}")
 endif()
 
 # Compiling tests

--- a/src/unit_tests/config/test_wmodules-config.c
+++ b/src/unit_tests/config/test_wmodules-config.c
@@ -89,11 +89,6 @@ static void test_Test_WModule_github_no_warning(void **state) {
         fail();
     }
 
-    /* wm_free() destroys the successfully parsed github module, which logs
-     * an informational message unrelated to what this test checks. */
-    expect_any(__wrap__mtinfo, tag);
-    expect_string(__wrap__mtinfo, formatted_msg, "Module GitHub finished.");
-
     assert_int_equal(Test_WModule(TEST_CONF_PATH), 0);
 }
 
@@ -112,11 +107,6 @@ static void test_Test_WModule_github_invalid_content_is_reported(void **state) {
     expect_string(__wrap__merror, formatted_msg, "Invalid content for tag 'enabled' at module 'github'.");
     expect_string(__wrap__merror, formatted_msg, "(1202): Configuration error at 'test_wmodules-config.conf'.");
     expect_string(__wrap__merror, formatted_msg, "(1207): WModule remote configuration in 'test_wmodules-config.conf' is corrupted.");
-
-    /* module->data was already allocated before the invalid tag was hit, so
-     * wm_free() still destroys a (partially initialized) github module. */
-    expect_any(__wrap__mtinfo, tag);
-    expect_string(__wrap__mtinfo, formatted_msg, "Module GitHub finished.");
 
     assert_int_equal(Test_WModule(TEST_CONF_PATH), -1);
 }

--- a/src/unit_tests/config/test_wmodules-config.c
+++ b/src/unit_tests/config/test_wmodules-config.c
@@ -1,0 +1,203 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "shared.h"
+#include "os_xml.h"
+#include "config.h"
+#include "wmodules.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+
+static const char *TEST_CONF_PATH = "test_wmodules-config.conf";
+
+static int write_conf(const char *content) {
+    FILE *fp = fopen(TEST_CONF_PATH, "w");
+
+    if (!fp) {
+        return -1;
+    }
+
+    fputs(content, fp);
+    fclose(fp);
+
+    return 0;
+}
+
+static int teardown_conf_file(void **state) {
+    unlink(TEST_CONF_PATH);
+    return 0;
+}
+
+/* Test_WModule() is what verify-agent-conf uses to validate an agent group's
+ * agent.conf. Agent-only modules must not raise the "only works for the
+ * agent" warning in that context. */
+static void test_Test_WModule_syscollector_no_warning(void **state) {
+    if (write_conf("<agent_config>"
+                    "<wodle name=\"syscollector\">"
+                    "<disabled>no</disabled>"
+                    "</wodle>"
+                    "</agent_config>") != 0) {
+        fail();
+    }
+
+    assert_int_equal(Test_WModule(TEST_CONF_PATH), 0);
+}
+
+/* Suppressing the false-positive warning must not turn validation off:
+ * genuinely invalid content inside a <wodle name="syscollector"> block
+ * still has to be reported by verify-agent-conf. */
+static void test_Test_WModule_syscollector_invalid_content_is_reported(void **state) {
+    if (write_conf("<agent_config>"
+                    "<wodle name=\"syscollector\">"
+                    "<disabled>notabool</disabled>"
+                    "</wodle>"
+                    "</agent_config>") != 0) {
+        fail();
+    }
+
+    expect_string(__wrap__merror, formatted_msg, "Invalid content for tag 'disabled' at module 'syscollector'.");
+    expect_string(__wrap__merror, formatted_msg, "(1202): Configuration error at 'test_wmodules-config.conf'.");
+    expect_string(__wrap__merror, formatted_msg, "(1207): WModule remote configuration in 'test_wmodules-config.conf' is corrupted.");
+
+    assert_int_equal(Test_WModule(TEST_CONF_PATH), -1);
+}
+
+/* Same false-positive check for a standalone reader (Read_Github) that
+ * received the same agent_cfg plumbing as Read_WModule, this time with a
+ * complete, valid config so wm_github_read() actually runs and succeeds. */
+static void test_Test_WModule_github_no_warning(void **state) {
+    if (write_conf("<agent_config>"
+                    "<github>"
+                    "<enabled>yes</enabled>"
+                    "<api_auth>"
+                    "<org_name>test-org</org_name>"
+                    "<api_token>test-token</api_token>"
+                    "</api_auth>"
+                    "</github>"
+                    "</agent_config>") != 0) {
+        fail();
+    }
+
+    /* wm_free() destroys the successfully parsed github module, which logs
+     * an informational message unrelated to what this test checks. */
+    expect_any(__wrap__mtinfo, tag);
+    expect_string(__wrap__mtinfo, formatted_msg, "Module GitHub finished.");
+
+    assert_int_equal(Test_WModule(TEST_CONF_PATH), 0);
+}
+
+/* Suppressing the false-positive warning must not turn validation off:
+ * genuinely invalid content inside an agent-only module block still has to
+ * be reported by verify-agent-conf. */
+static void test_Test_WModule_github_invalid_content_is_reported(void **state) {
+    if (write_conf("<agent_config>"
+                    "<github>"
+                    "<enabled>invalid</enabled>"
+                    "</github>"
+                    "</agent_config>") != 0) {
+        fail();
+    }
+
+    expect_string(__wrap__merror, formatted_msg, "Invalid content for tag 'enabled' at module 'github'.");
+    expect_string(__wrap__merror, formatted_msg, "(1202): Configuration error at 'test_wmodules-config.conf'.");
+    expect_string(__wrap__merror, formatted_msg, "(1207): WModule remote configuration in 'test_wmodules-config.conf' is corrupted.");
+
+    /* module->data was already allocated before the invalid tag was hit, so
+     * wm_free() still destroys a (partially initialized) github module. */
+    expect_any(__wrap__mtinfo, tag);
+    expect_string(__wrap__mtinfo, formatted_msg, "Module GitHub finished.");
+
+    assert_int_equal(Test_WModule(TEST_CONF_PATH), -1);
+}
+
+/* Read_SCA never warned on the manager (it silently skipped <sca> blocks
+ * both for the manager's own config and while validating agent config), so
+ * there is no false-positive warning to check here — only that validation
+ * now actually happens for agent-only SCA blocks too. */
+static void test_Test_WModule_sca_valid_content_is_accepted(void **state) {
+    if (write_conf("<agent_config>"
+                    "<sca>"
+                    "<enabled>yes</enabled>"
+                    "</sca>"
+                    "</agent_config>") != 0) {
+        fail();
+    }
+
+    /* wm_sca_read() always scans the default ruleset folder, which does not
+     * exist relative to the test binary's working directory. */
+    expect_any(__wrap__mtinfo, tag);
+    expect_any(__wrap__mtinfo, formatted_msg);
+
+    assert_int_equal(Test_WModule(TEST_CONF_PATH), 0);
+}
+
+static void test_Test_WModule_sca_invalid_content_is_reported(void **state) {
+    if (write_conf("<agent_config>"
+                    "<sca>"
+                    "<enabled>invalid</enabled>"
+                    "</sca>"
+                    "</agent_config>") != 0) {
+        fail();
+    }
+
+    expect_any(__wrap__mtinfo, tag);
+    expect_any(__wrap__mtinfo, formatted_msg);
+
+    expect_any(__wrap__mterror, tag);
+    expect_string(__wrap__mterror, formatted_msg, "Invalid content for tag 'enabled'");
+    expect_string(__wrap__merror, formatted_msg, "(1202): Configuration error at 'test_wmodules-config.conf'.");
+    expect_string(__wrap__merror, formatted_msg, "(1207): WModule remote configuration in 'test_wmodules-config.conf' is corrupted.");
+
+    assert_int_equal(Test_WModule(TEST_CONF_PATH), -1);
+}
+
+/* When the manager parses its own configuration (agent_cfg = 0), the warning
+ * must still be raised: syscollector genuinely does not belong there. */
+static void test_Read_WModule_syscollector_warns_without_agent_cfg(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    wmodule *wmodules = NULL;
+    int ret;
+
+    if (OS_ReadXMLString("<wodle name=\"syscollector\"><disabled>no</disabled></wodle>", &xml) != 0) {
+        fail();
+    }
+
+    if (nodes = OS_GetElementsbyNode(&xml, NULL), nodes == NULL) {
+        fail();
+    }
+
+    expect_string(__wrap__mwarn, formatted_msg, "The 'syscollector' module only works for the agent");
+
+    ret = Read_WModule(&xml, nodes[0], &wmodules, NULL);
+
+    assert_int_equal(ret, 0);
+
+    os_free(wmodules);
+    OS_ClearNode(nodes);
+    OS_ClearXML(&xml);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_teardown(test_Test_WModule_syscollector_no_warning, teardown_conf_file),
+        cmocka_unit_test_teardown(test_Test_WModule_syscollector_invalid_content_is_reported, teardown_conf_file),
+        cmocka_unit_test_teardown(test_Test_WModule_github_no_warning, teardown_conf_file),
+        cmocka_unit_test_teardown(test_Test_WModule_github_invalid_content_is_reported, teardown_conf_file),
+        cmocka_unit_test_teardown(test_Test_WModule_sca_valid_content_is_accepted, teardown_conf_file),
+        cmocka_unit_test_teardown(test_Test_WModule_sca_invalid_content_is_reported, teardown_conf_file),
+        cmocka_unit_test(test_Read_WModule_syscollector_warns_without_agent_cfg),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/config/test_wmodules-config.c
+++ b/src/unit_tests/config/test_wmodules-config.c
@@ -124,11 +124,6 @@ static void test_Test_WModule_sca_valid_content_is_accepted(void **state) {
         fail();
     }
 
-    /* wm_sca_read() always scans the default ruleset folder, which does not
-     * exist relative to the test binary's working directory. */
-    expect_any(__wrap__mtinfo, tag);
-    expect_any(__wrap__mtinfo, formatted_msg);
-
     assert_int_equal(Test_WModule(TEST_CONF_PATH), 0);
 }
 
@@ -140,9 +135,6 @@ static void test_Test_WModule_sca_invalid_content_is_reported(void **state) {
                     "</agent_config>") != 0) {
         fail();
     }
-
-    expect_any(__wrap__mtinfo, tag);
-    expect_any(__wrap__mtinfo, formatted_msg);
 
     expect_any(__wrap__mterror, tag);
     expect_string(__wrap__mterror, formatted_msg, "Invalid content for tag 'enabled'");

--- a/src/unit_tests/wazuh_modules/github/test_wm_github.c
+++ b/src/unit_tests/wazuh_modules/github/test_wm_github.c
@@ -63,8 +63,6 @@ static int setup_conf(void **state) {
 static int teardown_conf(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     test_mode = 0;
-    expect_string(__wrap__mtinfo, tag, "wazuh-modulesd:github");
-    expect_string(__wrap__mtinfo, formatted_msg, "Module GitHub finished.");
     wm_github_destroy(data->github_config);
     os_free(data->root_c);
     os_free(data);
@@ -113,6 +111,9 @@ void test_github_main_enable(void **state) {
 
     expect_value_count(__wrap_sleep, __seconds, 1, 2);
     will_return_count(__wrap_sleep, 0, 2);
+
+    expect_string(__wrap__mtinfo, tag, "wazuh-modulesd:github");
+    expect_string(__wrap__mtinfo, formatted_msg, "Module GitHub finished.");
 
     wm_github_main(data->github_config);
 }

--- a/src/unit_tests/wazuh_modules/office365/test_wm_office365.c
+++ b/src/unit_tests/wazuh_modules/office365/test_wm_office365.c
@@ -71,8 +71,6 @@ static int setup_conf(void **state) {
 static int teardown_conf(void **state) {
     test_struct_t *data  = (test_struct_t *)*state;
     test_mode = 0;
-    expect_string(__wrap__mtinfo, tag, "wazuh-modulesd:office365");
-    expect_string(__wrap__mtinfo, formatted_msg, "Module Office365 finished.");
 
     wm_office365_destroy(data->office365_config);
     os_free(data->root_c);
@@ -1258,6 +1256,9 @@ void test_wm_office365_main_enable(void **state) {
     expect_any(__wrap__mtdebug1, formatted_msg);
     expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:office365");
     expect_string(__wrap__mtdebug1, formatted_msg, "Unknown error while getting access token.");
+
+    expect_string(__wrap__mtinfo, tag, "wazuh-modulesd:office365");
+    expect_string(__wrap__mtinfo, formatted_msg, "Module Office365 finished.");
 
     wm_office365_main(data->office365_config);
 }

--- a/src/wazuh_modules/CMakeLists.txt
+++ b/src/wazuh_modules/CMakeLists.txt
@@ -114,11 +114,6 @@ else()
        "${SRC_FOLDER}/wazuh_modules/src/agent_upgrade/agent/*.c")
 endif()
 
-# Remove agent-only modules from server build
-if(NOT "${TARGET}" STREQUAL "winagent" AND NOT "${TARGET}" STREQUAL "agent")
-  list(REMOVE_ITEM WAZUH_MODULES_SRC "${SRC_FOLDER}/wazuh_modules/src/wm_sca.c")
-endif()
-
 # Build static library (without main.c)
 list(REMOVE_ITEM WAZUH_MODULES_SRC "${SRC_FOLDER}/wazuh_modules/src/main.c")
 add_library(wazuh_modulesd_lib STATIC ${WAZUH_MODULES_SRC})

--- a/src/wazuh_modules/src/wm_github.c
+++ b/src/wazuh_modules/src/wm_github.c
@@ -115,6 +115,8 @@ void * wm_github_main(wm_github* github_config) {
                 break;
             #endif
         }
+
+        mtinfo(WM_GITHUB_LOGTAG, "Module GitHub finished.");
     } else {
         mtinfo(WM_GITHUB_LOGTAG, "Module GitHub disabled.");
     }
@@ -127,7 +129,6 @@ void * wm_github_main(wm_github* github_config) {
 }
 
 void wm_github_destroy(wm_github* github_config) {
-    mtinfo(WM_GITHUB_LOGTAG, "Module GitHub finished.");
     wm_github_auth_destroy(github_config->auth);
     wm_github_fail_destroy(github_config->fails);
     os_free(github_config->event_type);

--- a/src/wazuh_modules/src/wm_office365.c
+++ b/src/wazuh_modules/src/wm_office365.c
@@ -152,6 +152,8 @@ void * wm_office365_main(wm_office365* office365_config) {
                 break;
             #endif
         }
+
+        mtinfo(WM_OFFICE365_LOGTAG, "Module Office365 finished.");
     } else {
         mtinfo(WM_OFFICE365_LOGTAG, "Module Office365 disabled.");
     }
@@ -164,7 +166,6 @@ void * wm_office365_main(wm_office365* office365_config) {
 }
 
 void wm_office365_destroy(wm_office365* office365_config) {
-    mtinfo(WM_OFFICE365_LOGTAG, "Module Office365 finished.");
     wm_office365_auth_destroy(office365_config->auth);
     wm_office365_subscription_destroy(office365_config->subscription);
     wm_office365_fail_destroy(office365_config->fails);

--- a/src/wazuh_modules/src/wm_sca.h
+++ b/src/wazuh_modules/src/wm_sca.h
@@ -48,7 +48,17 @@ typedef struct wm_sca_t {
 
 extern const wm_context WM_SCA_CONTEXT;
 
-// Read configuration and return a module (if enabled) or NULL (if disabled)
-int wm_sca_read(const OS_XML* xml, xml_node** nodes, wmodule* module);
+/**
+ * @brief Read configuration and return a module (if enabled) or NULL (if disabled)
+ * @param xml XML object
+ * @param nodes XML nodes to analyze
+ * @param module SCA configuration structure
+ * @param skip_ruleset_load When set, skips scanning the default SCA ruleset
+ *        folder on disk. Used when only validating the XML content (e.g. on
+ *        the manager, which never runs the SCA module itself) so validation
+ *        does not depend on, or report on, filesystem state that is
+ *        irrelevant to it.
+ */
+int wm_sca_read(const OS_XML* xml, xml_node** nodes, wmodule* module, int skip_ruleset_load);
 
 #endif // WM_SCA_H


### PR DESCRIPTION
## Description
`verify-agent-conf` validates an agent group's `agent.conf` by parsing it on the manager. For agent-only wodles (`syscollector`, `command`, `aws`, `docker-listener`, `azure`, `gcp-pubsub`, `gcp-bucket`, `github`, `office365`, `ms-graph`) and for `sca`, it either logged a false "only works for the agent" warning or silently skipped the block — either way, it never checked the block's content.

The fix makes the manager parse these blocks with the same reader functions the agent uses whenever it's validating agent configuration, instead of just warning (or, for `sca`, doing nothing at all). This removes the false warning and makes real content errors inside those blocks visible again. When these modules appear in the manager's own `ossec.conf`, the warning is still raised, unchanged (SCA never warned there either, and still doesn't). `wmodules-syscollector.c` and `wmodules-sca.c` had to be re-added to the manager build (both were previously excluded there), and `wazuh_modules/src/wm_sca.c` (the file defining `WM_SCA_CONTEXT`) had to be included for the manager too, so `wm_syscollector_read`/`wm_sca_read` are available for this.

Along the way, this also surfaced and fixed a pre-existing, unrelated bug: `wm_github_destroy`/`wm_office365_destroy` logged "Module ... finished." on data teardown rather than on actual module shutdown. Left unfixed, every `verify-agent-conf` run would now log a misleading "finished" line for these two modules.

While rebuilding both the `manager` and `agent` targets to verify this fix, `make clean-deps` was found to only remove the fetched `external/` dependencies belonging to whichever `TARGET` it was last invoked with, leaving the other target's dependencies behind. That's fixed too, since it got in the way of testing both targets cleanly.

## Proposed Changes
- `src/config/CMakeLists.txt`: stopped excluding `wmodules-syscollector.c` and `wmodules-sca.c` from manager builds, so `wm_syscollector_read`/`wm_sca_read` link into the manager binary.
- `src/wazuh_modules/CMakeLists.txt`: stopped excluding `wm_sca.c` from the manager's `wazuh_modulesd_lib`, so `WM_SCA_CONTEXT` (referenced by `Read_SCA`) is available. `wm_sca_destroy()` is a trivial `free()`, so none of the module's dynamically-loaded scan engine (`sym_load`/`so_get_module_handle`) is ever exercised during config validation.
- `src/config/src/wmodules-config.c`: for all ten agent-only wodle branches plus `Read_SCA`, the manager now calls the real reader (`wm_syscollector_read`, `wm_command_read`, `wm_aws_read`, `wm_docker_read`, `wm_azure_read`, `wm_gcp_pubsub_read`, `wm_gcp_bucket_read`, `wm_github_read`, `wm_office365_read`, `wm_ms_graph_read`, `wm_sca_read`) when `agent_cfg` is set, instead of only warning (or doing nothing, for SCA). The ten wodle branches fall back to the bare warning when `agent_cfg` is unset (manager's own configuration); `Read_SCA` keeps its original no-op behavior in that case, since it never warned to begin with. `Test_WModule` now passes `agent_cfg = 1` instead of `NULL`.
- `src/config/include/config.h` / `src/config/src/config.c`: threaded the `d2` (`agent_cfg`) parameter through `Read_SCA`, `Read_GCP_pubsub`, `Read_GCP_bucket`, `Read_Github`, `Read_Office365`, `Read_MS_Graph` and their call sites.
- `src/wazuh_modules/src/wm_github.c` / `src/wazuh_modules/src/wm_office365.c`: moved the "Module ... finished." log from `destroy()` (data teardown — runs during config validation too) to the end of the module's main loop (actual shutdown).
- `src/unit_tests/config/test_wmodules-config.c` (new): cmocka tests for the fix.
- `src/unit_tests/config/CMakeLists.txt`: registered the new test for the `manager` target.
- `src/unit_tests/wazuh_modules/github/test_wm_github.c` / `src/unit_tests/wazuh_modules/office365/test_wm_office365.c`: updated the pre-existing tests for the "Module ... finished." log move — dropped the now-stale expectation from the `destroy()` teardown helper, added it where the log now actually fires (end of the enabled-module run in `wm_github_main`/`wm_office365_main`).
- `src/Makefile`: `clean-deps` now wipes everything under `external/` (except the two files tracked by git, `CMakeLists.txt` and `.gitignore`) instead of only the `TARGET`-filtered subset it removed before. Unrelated to the config-validation fix itself, but needed to reliably rebuild both `manager` and `agent` from a clean `external/` while testing this change.

### Results and Evidence
Manual run of `verify-agent-conf` against a group's `agent.conf` containing both a genuinely invalid tag and agent-only wodle blocks:
```xml
<agent_config>
  <syscheck>
    <synchronization>
    </synchronization>
  </syscheck>

  <sca>
    <synchronization>
      <no-op />
    </synchronization>
  </sca>

  <wodle name="syscollector">
    <synchronization>
      <unknown>any</unknown>
    </synchronization>
  </wodle>

  <office365>
    <enabled>yes</enabled>
    <api_auth>any</api_auth>
    <subscriptions>
    </subscriptions>
  </office365>
</agent_config>
```

The `<sca>` block's content is valid (an empty `<synchronization>` is accepted), so it produces neither a warning nor an error in either run below — its presence here just confirms it no longer causes a crash or a spurious message now that `wm_sca_read` runs on the manager too. The `test_Test_WModule_sca_*` unit tests are what specifically exercise SCA's invalid-content path.

**Before the fix** — false-positive warnings for `syscollector`/`office365`, and the actual error (`<unknown>` is not a valid tag under `<synchronization>`, `<subscriptions>` is empty) went completely unnoticed; `verify-agent-conf` reported `OK`:
```
verify-agent-conf: Verifying [etc/shared/default/agent.conf]
2026/07/10 10:38:24 verify-agent-conf: WARNING: The 'syscollector' module only works for the agent
2026/07/10 10:38:24 verify-agent-conf: WARNING: The 'office365' module only works for the agent
verify-agent-conf: OK
```

**After the fix** — no false-positive warning, and the genuine content errors are now caught and reported:
```
verify-agent-conf: Verifying [etc/shared/default/agent.conf]
2026/07/14 19:21:33 wazuh-modulesd:sca: INFO: Could not open the default SCA ruleset folder 'ruleset/sca/': No such file or directory
2026/07/14 19:21:33 wazuh-modulesd:sca: WARNING: (1230): Invalid element in the configuration: 'no-op'.
2026/07/14 19:21:33 verify-agent-conf: WARNING: (1230): Invalid element in the configuration: 'unknown'.
2026/07/14 19:21:33 verify-agent-conf: ERROR: Empty content for tag 'subscriptions' at module 'office365'.
2026/07/14 19:21:33 verify-agent-conf: ERROR: (1202): Configuration error at 'etc/shared/default/agent.conf'.
2026/07/14 19:21:33 verify-agent-conf: ERROR: (1207): WModule remote configuration in 'etc/shared/default/agent.conf' is corrupted
```

**After the fix, with the same blocks but valid content** — no warning, no error, and no misleading "Module ... finished." line (the module never actually ran on the manager):
```
verify-agent-conf: Verifying [etc/shared/default/agent.conf]
verify-agent-conf: OK
```

`make clean-deps`, before/after the `src/Makefile` fix, run against an `external/` populated for both `manager` and `agent`:
```
$ make clean-deps
find external -mindepth 1 -maxdepth 1 ! -name 'CMakeLists.txt' ! -name '.gitignore' -exec rm -rf {} +
rm -rf shared_modules/http-request/* shared_modules/http-request/.??* external/wcs-flat-files

$ ls -la external/
total 68
-rw-r--r--  1 root root    30 external/.gitignore
-rw-r--r--  1 root root 53602 external/CMakeLists.txt
```
Only the two git-tracked files remain, regardless of which `TARGET` the removed dependencies had originally been fetched for.

### Artifacts Affected
`wazuh-manager` package (`libconfig.a`, `wazuh-modulesd_lib` / `wazuh-modulesd`, `verify-agent-conf`). The `clean-deps` change affects build tooling only, not any shipped binary or package.

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
`src/unit_tests/config/test_wmodules-config.c` (new):
- `test_Test_WModule_syscollector_no_warning`
- `test_Test_WModule_syscollector_invalid_content_is_reported`
- `test_Test_WModule_github_no_warning`
- `test_Test_WModule_github_invalid_content_is_reported`
- `test_Test_WModule_sca_valid_content_is_accepted`
- `test_Test_WModule_sca_invalid_content_is_reported`
- `test_Read_WModule_syscollector_warns_without_agent_cfg`

Updated to match the log move (see Proposed Changes):
- `src/unit_tests/wazuh_modules/github/test_wm_github.c`
- `src/unit_tests/wazuh_modules/office365/test_wm_office365.c`

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
