### PR TITLE
Lower connection socket error log to debug level in wazuh-agentd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,4 +96,5 @@
 - Honored the shutdown signal in `agent-upgrade` `StartMQ` to avoid timeout warning on agent stop. ([#36092](https://github.com/wazuh/wazuh/issues/36092))
 - Adjusted DockerListener messages as log entries to fix event categorization. ([#36126](https://github.com/wazuh/wazuh/issues/36126))
 - Dropped orphan paths before promoting on agent startup to fix FIM. ([#36134](https://github.com/wazuh/wazuh/issues/36134))
+- Lowered the `wazuh-agentd` connection socket error log to debug level to avoid duplicating the "Lost connection with manager" error on transient disconnections. ([#37653](https://github.com/wazuh/wazuh/issues/37653))
 

--- a/src/client-agent/src/receiver.c
+++ b/src/client-agent/src/receiver.c
@@ -67,10 +67,10 @@ int receive_msg()
                 if (errno == ENOTCONN) {
                     mdebug1("Manager disconnected (ENOTCONN).");
                 } else {
-                    merror("Connection socket: %s (%d)", strerror(errno), errno);
+                    mdebug1("Connection socket: %s (%d)", strerror(errno), errno);
                 }
 #else
-                merror("Connection socket: %s (%d)", win_strerror(WSAGetLastError()), WSAGetLastError());
+                mdebug1("Connection socket: %s (%d)", win_strerror(WSAGetLastError()), WSAGetLastError());
 #endif
                 break;
 


### PR DESCRIPTION
## Description

`wazuh-agentd` was logging the same manager disconnection event as **two** `ERROR` lines:

```
2026/07/14 04:33:47 wazuh-agentd: ERROR: Connection socket: Connection reset by peer (104)
2026/07/14 04:33:47 wazuh-agentd: ERROR: (1137): Lost connection with manager. Setting lock.
```

`receiver.c` logs the low-level socket error (`recv()` failure, e.g. `ECONNRESET`) and then its caller in `agentd.c` immediately logs the generic `(1137): Lost connection with manager` error for the same event — a transient, expected condition on network reconnects, not an actionable failure. This was flagged as an unexpected log during nightly testing on SLES 16 ARM.

Closes #37653

## Proposed Changes

- Lowered the `Connection socket: %s (%d)` log in `receiver.c` (`receive_msg()`) from `merror` to `mdebug1`, for both the POSIX and Windows branches.
- This matches the existing precedent in `start_agent.c`, where the identical message is already logged at `mdebug1`.
- The `(1137): Lost connection with manager. Setting lock.` `ERROR` is unchanged and remains the single, user-facing signal for a lost connection.
- The socket-level detail (errno/description) is still available for troubleshooting when debug logging is enabled (`-d` / `agent.conf` `debug` option).

### Results and Evidence

Reproduced the exact logging call from `receiver.c::receive_msg()` (`errno = ECONNRESET`, i.e. "Connection reset by peer (104)", as seen in the reported nightly log) against the real Wazuh logging backend (`libwazuhshared.so`), before and after the change:

**Before the fix** — default log level (no debug enabled): two `ERROR` lines for one event.
```
2026/07/09 08:58:33 wazuh-agentd: ERROR: Connection socket: Connection reset by peer (104)
2026/07/09 08:58:33 wazuh-agentd: ERROR: (1137): Lost connection with manager. Setting lock.
```

**After the fix** — default log level (no debug enabled): only the actionable `ERROR` remains.
```
2026/07/09 08:58:33 wazuh-agentd: ERROR: (1137): Lost connection with manager. Setting lock.
```

**After the fix** — debug enabled (`-d` / `agent.conf` `debug=1`): socket-level detail is still available, now correctly tagged `DEBUG`.
```
2026/07/09 08:58:33 wazuh-agentd[320776] before_after.c:30 at after_fix_path(): DEBUG: Connection socket: Connection reset by peer (104)
2026/07/09 08:58:33 wazuh-agentd[320776] before_after.c:31 at after_fix_path(): ERROR: (1137): Lost connection with manager. Setting lock.
```

_(captured by driving the real `libwazuhshared.so` logging backend with the exact `merror`/`mdebug1` call signatures used in `receiver.c::receive_msg()` — file/line above are the harness's, not `receiver.c`'s, since it's a standalone repro rather than the full agent binary; log format, tag, and gating behavior are identical to what the compiled agent produces.)_

This confirms `merror` is unconditional while `mdebug1` is gated by the daemon's debug level (`dbg_flag`, `src/shared/src/debug_op.c`), so the change removes the duplicate `ERROR` in the default/production case while preserving the detail for debugging.

### Artifacts Affected

- `wazuh-agentd` binary (`src/client-agent/src/receiver.c`) — Linux and Windows agent.
- No configuration, package, or default-value changes.

### Configuration Changes

None. No new parameters; no default values changed. Behavior only changes for the verbosity/level at which the `Connection socket: ...` message is logged.

### Documentation Updates

None required — this is an internal log-level adjustment, not a documented message or behavior change.

### Tests Introduced

None added. Existing `tests/integration/test_agentd` suite (reconnection/state tests) covers the surrounding disconnect/reconnect flow and passed except for one unrelated flake (`test_agentd_state[Successful_connection_with_remoted]`, waiting on an unrelated `Sending keep alive` debug2 message from `notify.c`, not touched by this change) on the Windows IT job — see CI run for details.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
