### PR TITLE
Report modulesSync failure as debug during agent shutdown

### DIFF
--- a/src/unit_tests/wazuh_modules/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/CMakeLists.txt
@@ -16,6 +16,7 @@ if(${TARGET} STREQUAL "manager")
 endif()
 
 if(${TARGET} STREQUAL "agent")
+  add_subdirectory(wmodules)
   add_subdirectory(aws)
   add_subdirectory(azure)
   add_subdirectory(command)

--- a/src/unit_tests/wazuh_modules/wmodules/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/wmodules/CMakeLists.txt
@@ -32,7 +32,7 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 
 # Generate wmodules tests
 list(APPEND wmodules_names "test_wmodules")
-list(APPEND wmodules_flags "-Wl,--wrap,w_query_agentd")
+list(APPEND wmodules_flags "-Wl,--wrap,w_query_agentd -Wl,--wrap,_merror -Wl,--wrap,_mdebug1")
 
 # Compilig tests
 list(LENGTH wmodules_names count)

--- a/src/unit_tests/wazuh_modules/wmodules/test_wmodules.c
+++ b/src/unit_tests/wazuh_modules/wmodules/test_wmodules.c
@@ -23,16 +23,29 @@ static size_t echo(void * module, char * query, char ** output) {
     return strlen(query);
 }
 
+// Sync callback that always fails, to exercise the modulesSync() failure path.
+static int sync_fail(const char * args, size_t length) {
+    (void)args;
+    (void)length;
+    return -1;
+}
+
 static int setup_modules(void ** state) {
     static wm_context CONTEXTS[] = {
         { .name = "A", .query = echo },
         { .name = "B", .query = NULL },
+        { .name = "sca", .sync = sync_fail },
     };
 
     wmodules = calloc(1, sizeof(wmodule));
     wmodules->context = &CONTEXTS[0];
     wmodules->next = calloc(1, sizeof(wmodule));
     wmodules->next->context = &CONTEXTS[1];
+    wmodules->next->next = calloc(1, sizeof(wmodule));
+    wmodules->next->next->context = &CONTEXTS[2];
+    wmodules->next->next->tag = "sca";
+
+    wm_shutdown_requested = 0;
 
     *state = NULL;
     return 0;
@@ -40,8 +53,11 @@ static int setup_modules(void ** state) {
 
 static int teardown_modules(void ** state) {
     free(*state);
+    free(wmodules->next->next);
     free(wmodules->next);
     free(wmodules);
+
+    wm_shutdown_requested = 0;
 
     return 0;
 }
@@ -107,6 +123,39 @@ static void test_module_query_echo(void ** state) {
     assert_int_equal(n, 4);
 }
 
+// A sync command that keeps failing while the agent is running is a real error: after exhausting
+// the retries, modulesSync() must log it at ERROR level.
+static void test_modules_sync_failure_while_running(void ** state) {
+    (void)state;
+    char input[] = "sca_sync payload";
+
+    // One "not ready" debug per retry (WM_MAX_ATTEMPTS attempts after the first one).
+    expect_string(__wrap__mdebug1, formatted_msg, "WModules is not ready. Retry 1");
+    expect_string(__wrap__mdebug1, formatted_msg, "WModules is not ready. Retry 2");
+    expect_string(__wrap__mdebug1, formatted_msg, "WModules is not ready. Retry 3");
+    expect_string(__wrap__merror, formatted_msg, "At modulesSync(): Unable to sync module 'sca': (-1)");
+
+    int ret = modulesSync(input, sizeof(input));
+
+    assert_int_equal(ret, -1);
+}
+
+// The same failure during agent shutdown is expected (the module was already stopped on purpose):
+// modulesSync() must not retry and must report it at DEBUG level, not ERROR.
+static void test_modules_sync_failure_during_shutdown(void ** state) {
+    (void)state;
+    char input[] = "sca_sync payload";
+
+    wm_shutdown_requested = 1;
+
+    expect_string(__wrap__mdebug1, formatted_msg,
+                  "At modulesSync(): skipping sync for module 'sca' (-1): the agent is shutting down.");
+
+    int ret = modulesSync(input, sizeof(input));
+
+    assert_int_equal(ret, -1);
+}
+
 int main() {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown(test_find_module_found, setup_modules, teardown_modules),
@@ -115,6 +164,8 @@ int main() {
         cmocka_unit_test_setup_teardown(test_module_query_no_module, setup_modules, teardown_modules),
         cmocka_unit_test_setup_teardown(test_module_query_no_queries, setup_modules, teardown_modules),
         cmocka_unit_test_setup_teardown(test_module_query_echo, setup_modules, teardown_modules),
+        cmocka_unit_test_setup_teardown(test_modules_sync_failure_while_running, setup_modules, teardown_modules),
+        cmocka_unit_test_setup_teardown(test_modules_sync_failure_during_shutdown, setup_modules, teardown_modules),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/wazuh_modules/src/wmodules.c
+++ b/src/wazuh_modules/src/wmodules.c
@@ -365,13 +365,22 @@ int modulesSync(char* args, size_t length) {
 
         ++retry;
 
-        if (retry > WM_MAX_ATTEMPTS) {
+        // Stop retrying if the agent is shutting down: the target module is being torn down on
+        // purpose, so further attempts would only delay shutdown while always failing.
+        if (retry > WM_MAX_ATTEMPTS || wm_shutdown_requested) {
             break;
         }
     } while (ret != 0);
 
     if (ret) {
-        merror("At modulesSync(): Unable to sync module '%s': (%d)", cur_module ? cur_module->tag : "",  ret);
+        if (wm_shutdown_requested) {
+            // Expected during agent shutdown/restart: a sync command reached a module that was already
+            // stopping. Report it as a debug breadcrumb instead of an error.
+            mdebug1("At modulesSync(): skipping sync for module '%s' (%d): the agent is shutting down.",
+                    cur_module ? cur_module->tag : "", ret);
+        } else {
+            merror("At modulesSync(): Unable to sync module '%s': (%d)", cur_module ? cur_module->tag : "",  ret);
+        }
     }
     return ret;
 }

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -104,6 +104,11 @@ void *win_module_thread(void *arg)
 
 void stop_wmodules()
 {
+    // Signal the agent-wide shutdown so dispatchers (e.g. modulesSync) skip work
+    // that targets modules already being torn down. On POSIX the modulesd SIGTERM
+    // handler sets this; on Windows shutdown flows through here instead.
+    wm_shutdown_requested = 1;
+
     wmodule * cur_module;
     for (cur_module = wmodules; cur_module; cur_module = cur_module->next) {
         if (cur_module->context->stop) {


### PR DESCRIPTION
## Description

Closes #37554

During a normal agent upgrade or restart, `wazuh-modulesd` logged an `ERROR` for an expected shutdown-time condition:

```sql
wazuh-modulesd:sca: INFO: SCA module stopped.
wazuh-agent: ERROR: At modulesSync(): Unable to sync module 'sca': (-1)
```

The manager can push a synchronization command for a module a moment after the agent has already begun stopping that module. The module is no longer running, so its `sync()` returns `-1`; the `modulesSync()` dispatcher retries `WM_MAX_ATTEMPTS` times and, since the module stays stopped, logs a hard `ERROR`. This is transient, the agent recovers, and no data is lost, but it surfaced as an unknown `ERROR` in the nightly upgrade tests.

>Note: While reviewing the dispatcher, a second, pre-existing bug turned up in the same retry loop: `usleep(retry * WM_MAX_WAIT)` treats a millisecond constant as microseconds, so the backoff between attempts never really waits (all three retries fire within ~3 ms instead of the intended ~3 s). That bug predates this PR and is unrelated to the shutdown race fixed here, so it's left out of scope and tracked separately (see [review comment](https://github.com/wazuh/wazuh/pull/37689#discussion_r3598525992)).

## Proposed Changes

### 1. Do not report an expected shutdown-time failure as an error

The dispatcher is gated on the agent-wide shutdown flag (`wm_shutdown_requested`) in `modulesSync()`:

- Stop retrying once a shutdown is in progress. The target module is being torn down on purpose, so further attempts only delay shutdown while always failing.
- When the failure happens during shutdown, log it at `DEBUG` (worded as an expected skip) instead of `ERROR`. A genuine failure while the agent is running keeps the `ERROR` level so real problems remain visible.

This mirrors the already-merged sibling #37345 ("Lower log level of transient queue send failures in modulesd") and the approach used in #37325 (gate the log level on the stopping condition).

### 2. Set the shutdown flag on the Windows shutdown path

As raised in review, the gate above was unreachable on the platform the issue is about: `wm_shutdown_requested` was only ever set by the POSIX writers (the standalone `wazuh-modulesd` `SIGTERM` handler in `main.c`, and `wm_control_stop()`, whose module is only compiled on Linux/macOS/BSD). On a Windows agent the modules run as threads inside `wazuh-agent.exe`, shutdown flows through `OssecServiceCtrlHandler(SERVICE_CONTROL_STOP)` -> `stop_wmodules()`, and neither path touched the flag, so the `ERROR` would have kept appearing exactly as reported in #37554.

`stop_wmodules()` (`src/win32/win_utils.c`) now sets `wm_shutdown_requested = 1` before iterating the modules' `stop()` callbacks, mirroring what the POSIX `SIGTERM` handler does. This is what actually engages the fix on Windows.

### 3. Retry backoff timing bug (out of scope)

`WM_MAX_WAIT` is documented as milliseconds, but its value is passed straight to `usleep()`, which takes microseconds:

```c
usleep(retry * WM_MAX_WAIT);    // 500 us, not 500 ms
```

The loop is therefore sleeping 500 us / 1 ms / 1.5 ms between attempts instead of the intended 500 ms / 1000 ms / 1500 ms, so all three retries fire within ~3 ms. A module that needs a moment to become ready gets no real grace period, which defeats the point of retrying at all. This was flagged in review ([discussion](https://github.com/wazuh/wazuh/pull/37689#discussion_r3598525992)).

This bug predates this PR and is independent of the shutdown race it fixes, so it is **not** addressed here. It will be tracked and fixed in a separate issue/PR.

### Results and Evidence

`wazuh-modulesd` dispatcher behavior after the change:

```sql
# During agent shutdown/restart (expected corner case) - was ERROR, now DEBUG
wazuh-modulesd: DEBUG: At modulesSync(): skipping sync for module 'sca' (-1): the agent is shutting down.

# Genuine failure while the agent is running - unchanged, still ERROR
wazuh-agent: ERROR: At modulesSync(): Unable to sync module 'sca': (-1)
```

The exact race (the manager pushing an `sca_sync` right after the SCA module stopped during an upgrade restart) is timing-dependent and hard to force on demand. Unit tests were added to exercise both branches of the log-level decision directly (see Tests Introduced).

### Artifacts Affected

- `wazuh-modulesd` (agent) — the `modulesSync()` dispatcher in `src/wazuh_modules/src/wmodules.c`.
- `wazuh-agent.exe` (Windows agent) — `stop_wmodules()` in `src/win32/win_utils.c` now raises the shutdown flag.
- Unit test build — `src/unit_tests/wazuh_modules/CMakeLists.txt` now registers the `wmodules` suite for the agent target (see Tests Introduced).

Agent-only components. No manager artifacts, no configuration files, no packages changed.

### Configuration Changes

- None.

### Documentation Updates

- None.

### Tests Introduced

Added to the `wmodules` unit test suite (`src/unit_tests/wazuh_modules/wmodules/test_wmodules.c`):

- `test_modules_sync_failure_while_running`: a sync command that keeps failing while the agent is running must log at `ERROR` after exhausting the retries. The test also asserts one `"WModules is not ready. Retry N"` debug per attempt, so the full retry sequence is exercised.
- `test_modules_sync_failure_during_shutdown`: the same failure with `wm_shutdown_requested = 1` must not retry (no `Retry` debug is expected) and must log the single expected-skip `DEBUG` line, not `ERROR`.

The test file wraps `_merror` and `_mdebug1` to assert the exact level and message per case, which is also what pins down the retry-vs-no-retry difference between the two branches.

The `wmodules` suite was previously only registered for `TARGET=manager`, so these tests never ran for the component they cover. `src/unit_tests/wazuh_modules/CMakeLists.txt` now adds the suite to the agent target as well, where it builds and passes.

The suite is not wired for `winagent`: verifying that requires the full MinGW cross-build plus wine, and an unverified build-system change seemed worse than a scoped one. The Windows behavior itself (change 2) is validated on a live Windows agent instead (restart/upgrade flow of #37554).

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented (none)
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
