### PR TITLE
Validate destination paths when uploading list, rule, and decoder files

### DIFF
--- a/framework/wazuh/cdb_list.py
+++ b/framework/wazuh/cdb_list.py
@@ -3,7 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from os import remove
-from os.path import join, split, exists, isfile, dirname as path_dirname
+from os.path import join, split, exists, isfile, dirname as path_dirname, realpath, commonpath
 
 from wazuh.core import common
 from wazuh.core.cdb_list import iterate_lists, get_list_from_file, REQUIRED_FIELDS, SORT_FIELDS, delete_list, \
@@ -140,6 +140,9 @@ def upload_list_file(filename: str = None, content: str = None, overwrite: bool 
         # If file already exists and overwrite is False, raise exception.
         if not overwrite and exists(full_path):
             raise WazuhError(1905)
+        # If filename resolves outside the lists directory (path traversal).
+        elif commonpath([realpath(full_path), realpath(common.USER_LISTS_PATH)]) != realpath(common.USER_LISTS_PATH):
+            raise WazuhError(1805)
         # If file with same name already exists in subdirectory.
         elif get_filenames_paths([filename])[0] != full_path:
             raise WazuhError(1805)

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -179,6 +179,9 @@ class WazuhException(Exception):
                               f'{DOCU_VERSION}/user-manual/reference/ossec-conf/ruleset.html)'
                               ' to get more information about the rules'
                },
+        1212: {'message': 'Invalid filename. It resolves outside of the expected rules directory.',
+               'remediation': 'Please, do not use path traversal sequences in the filename'
+               },
 
         # Stats: 1300 - 1399
         1307: {'message': 'Invalid parameters',
@@ -259,6 +262,9 @@ class WazuhException(Exception):
                                '(https://documentation.wazuh.com/'
                               f'{DOCU_VERSION}/user-manual/reference/ossec-conf/ruleset.html)'
                               ' to get more information about the decoders'
+               },
+        1508: {'message': 'Invalid filename. It resolves outside of the expected decoders directory.',
+               'remediation': 'Please, do not use path traversal sequences in the filename'
                },
 
         # Syscheck/AR: 1600 - 1699

--- a/framework/wazuh/decoder.py
+++ b/framework/wazuh/decoder.py
@@ -3,7 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from os import remove
-from os.path import join, exists, normpath, commonpath
+from os.path import join, exists, normpath, commonpath, realpath
 from typing import Union, Tuple
 from xml.parsers.expat import ExpatError
 
@@ -347,6 +347,11 @@ def upload_decoder_file(filename: str, content: str, relative_dirname: str = Non
         full_path = join(common.WAZUH_PATH, relative_dirname, filename)
         if wazuh_error:
             raise wazuh_error
+
+        # If filename resolves outside the validated decoders directory (path traversal).
+        base_path = join(common.WAZUH_PATH, relative_dirname)
+        if commonpath([realpath(full_path), realpath(base_path)]) != realpath(base_path):
+            raise WazuhError(1508)
 
         if len(content) == 0:
             raise WazuhError(1112)

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -3,7 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 from os import remove
-from os.path import exists, join, normpath, commonpath
+from os.path import exists, join, normpath, commonpath, realpath
 from typing import Union, Tuple
 from xml.parsers.expat import ExpatError
 
@@ -476,6 +476,10 @@ def upload_rule_file(filename: str, content: str, relative_dirname: str = None,
         full_path = join(common.WAZUH_PATH, relative_dirname, filename)
         if wazuh_error:
             raise wazuh_error
+        # If filename resolves outside the validated rules directory (path traversal).
+        base_path = join(common.WAZUH_PATH, relative_dirname)
+        if commonpath([realpath(full_path), realpath(base_path)]) != realpath(base_path):
+            raise WazuhError(1212)
         if len(content) == 0:
             raise WazuhError(1112)
 

--- a/framework/wazuh/tests/test_cdb_list.py
+++ b/framework/wazuh/tests/test_cdb_list.py
@@ -373,6 +373,18 @@ def test_upload_list_file_ko(mock_remove, mock_lists_path):
                         upload_list_file(filename='test', content='test:content', overwrite=False)
 
 
+@patch('wazuh.cdb_list.upload_file')
+@patch('wazuh.cdb_list.safe_move')
+@patch('wazuh.cdb_list.exists', return_value=False)
+def test_upload_list_file_path_traversal(mock_exists, mock_safe_move, mock_upload_file):
+    """Check that a filename with path traversal sequences is rejected and the file is not written."""
+    result = upload_list_file(filename='../../../../../../tmp/poc_cdb_traversal',
+                              content='test_key:test_value\n', overwrite=True)
+    assert isinstance(result, AffectedItemsWazuhResult)
+    assert result.render()['data']['failed_items'][0]['error']['code'] == 1805
+    mock_upload_file.assert_not_called()
+
+
 @patch('wazuh.core.cdb_list.delete_wazuh_file')
 def test_delete_list_file(mock_delete_file):
     """Check that expected result is returned when the file is deleted."""

--- a/framework/wazuh/tests/test_decoder.py
+++ b/framework/wazuh/tests/test_decoder.py
@@ -362,6 +362,18 @@ def test_upload_file_ko(*_):
         os.remove(bkp)
 
 
+@patch('wazuh.decoder.upload_file')
+@patch('wazuh.decoder.safe_move')
+def test_upload_decoder_file_path_traversal(mock_safe_move, mock_upload_file):
+    """Test that a filename with path traversal sequences is rejected and the file is not written
+    outside the decoders directory."""
+    result = decoder.upload_decoder_file(filename='../../../../../../tmp/poc_decoder_traversal', content='test')
+    assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
+    assert result.render()['data']['failed_items'][0]['error']['code'] == 1508, \
+        'Error code not expected.'
+    mock_upload_file.assert_not_called()
+
+
 @pytest.mark.parametrize('filename, relative_dirname', [
     ('test1_decoders.xml', None),
     ('test3_decoders.xml', None),

--- a/framework/wazuh/tests/test_rule.py
+++ b/framework/wazuh/tests/test_rule.py
@@ -426,6 +426,20 @@ def test_upload_file_ko(*args):
             os.remove(bkp)
 
 
+@patch('wazuh.rule.upload_file')
+@patch('wazuh.rule.safe_move')
+def test_upload_rule_file_path_traversal(mock_safe_move, mock_upload_file):
+    """Test that a filename with path traversal sequences is rejected and the file is not written
+    outside the rules directory."""
+    with patch('wazuh.core.configuration.get_ossec_conf', return_value=get_rule_file_ossec_conf):
+        result = rule.upload_rule_file(filename='../../../../../../tmp/poc_rule_traversal',
+                                        content='<group name="poc"></group>')
+        assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
+        assert result.render()['data']['failed_items'][0]['error']['code'] == 1212, \
+            'Error code not expected.'
+        mock_upload_file.assert_not_called()
+
+
 @pytest.mark.parametrize('file, relative_dirname', [
     ('test_rules.xml', None),
     ('test_rules.xml', 'tests/data/etc/rules'),


### PR DESCRIPTION
## Description
`upload_list_file`, `upload_rule_file`, and `upload_decoder_file` built their destination path from a caller-supplied `filename` without confirming it stayed inside the intended directory, allowing a file to be written to an unexpected location as the `wazuh` user when these functions are reached through the cluster callable path (`as_wazuh_object` → `DistributedAPI.run_local`), which bypasses the REST controller's filename format validators. The fix resolves the final destination with `realpath` and rejects the request if it falls outside the intended base directory, before any file is written.

## Proposed Changes
- `framework/wazuh/cdb_list.py`: in `upload_list_file`, added a `commonpath`/`realpath` check that the resolved destination stays under `common.USER_LISTS_PATH`; raises the existing `WazuhError(1805)` otherwise.
- `framework/wazuh/rule.py`: in `upload_rule_file`, added the same check against the validated `relative_dirname` under `common.WAZUH_PATH`; raises a new `WazuhError(1212)`.
- `framework/wazuh/decoder.py`: in `upload_decoder_file`, added the same check against the validated `relative_dirname` under `common.WAZUH_PATH`; raises a new `WazuhError(1508)`.
- `framework/wazuh/core/exception.py`: registered new error codes `1212` (Rule block) and `1508` (Decoders block) for the invalid-filename case.

### Results and Evidence
- Reproduced the out-of-bounds write with the reporter's payloads (`filename="../../../tmp/..."`) prior to the fix; the guard now raises before `upload_file`/`safe_move` is called.
- New tests fail on the pre-fix code (they reach past the intended guard into unmocked code, e.g. `validate_dummy_logtest` attempting a real socket connection) and pass after the fix, with `upload_file` asserted as never called.
- Full existing suites pass unmodified: `wazuh/tests/test_cdb_list.py`, `wazuh/tests/test_rule.py`, `wazuh/tests/test_decoder.py` (188 passed), `wazuh/core/tests/test_cdb_list.py`, `wazuh/core/tests/test_rule.py`, `wazuh/core/tests/test_decoder.py`, `wazuh/core/tests/test_utils.py` (398 passed), `wazuh/core/tests/test_exception.py` (10 passed).

### Artifacts Affected
`wazuh-manager` framework (Python API/framework layer): `wazuh.cdb_list`, `wazuh.rule`, `wazuh.decoder`, `wazuh.core.exception`.

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
- `framework/wazuh/tests/test_cdb_list.py::test_upload_list_file_path_traversal`
- `framework/wazuh/tests/test_rule.py::test_upload_rule_file_path_traversal`
- `framework/wazuh/tests/test_decoder.py::test_upload_decoder_file_path_traversal`

## Credit

Kudos to @namd0ng for reporting this bug.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
