### PR TITLE
Enable authd in manager source-install integration test step

### DIFF
--- a/.github/workflows/5_testintegration_manager.yml
+++ b/.github/workflows/5_testintegration_manager.yml
@@ -191,7 +191,7 @@ jobs:
           USER_LANGUAGE="en"
           USER_INSTALL_TYPE="manager"
           USER_DIR="/var/wazuh-manager"
-          USER_ENABLE_AUTHD="n"
+          USER_ENABLE_AUTHD="y"
           USER_AUTO_START="n"
           EOF
           sudo sh install.sh


### PR DESCRIPTION
## Description

`authd-tier-0-1` and `remoted-tier-0-1` fail reproducibly when `5_testintegration_manager.yml` runs from source (empty `build_run_id`), while they pass on the package path.

The source-install step set `USER_ENABLE_AUTHD="n"`, which makes the installer write `<auth><disabled>yes</disabled>`. authd then closes on start (`Daemon is disabled. Closing.`) and enrollment-dependent tests error at setup. The package path passes because the `.deb` ships the enabled auth default introduced in #37151.

Closes #37566

## Proposed Changes

Set `USER_ENABLE_AUTHD="y"` in the source-install step. The installer then applies `etc/templates/config/generic/auth.template`, which writes `<auth><disabled>no</disabled><use_password>yes</use_password>`, matching the package default.

### Results and Evidence

Installer mapping confirming the resulting config:

- `USER_ENABLE_AUTHD="y"` -> `AUTHD=yes` -> `inst-functions.sh` applies `auth.template`:

```xml
  <auth>
    <disabled>no</disabled>
    <port>1515</port>
    <use_source_ip>no</use_source_ip>
    <purge>yes</purge>
    <use_password>yes</use_password>
    ...
  </auth>
```

- Previously `USER_ENABLE_AUTHD="n"` -> `DisableAuthd()` -> `<disabled>yes</disabled>`, causing the failures reported in #37566 (authd: 119 passed, 31 errors; remoted: 66 passed, 21 errors).

### Artifacts Affected

- `.github/workflows/5_testintegration_manager.yml` (CI only, no product artifacts).
- Manual execution success: https://github.com/wazuh/wazuh/actions/runs/29404228118 

### Configuration Changes

None to the product. Only the test workflow's source-install preloaded vars change.

### Documentation Updates

None.

### Tests Introduced

None. This unblocks the existing authd and remoted integration tests on the source-install path.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
