### PR TITLE
Fix rename race on logcollector file status during shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,4 +98,5 @@
 - Adjusted DockerListener messages as log entries to fix event categorization. ([#36126](https://github.com/wazuh/wazuh/issues/36126))
 - Dropped orphan paths before promoting on agent startup to fix FIM. ([#36134](https://github.com/wazuh/wazuh/issues/36134))
 - Lowered the `wazuh-agentd` connection socket error log to debug level to avoid duplicating the "Lost connection with manager" error on transient disconnections. ([#37653](https://github.com/wazuh/wazuh/issues/37653))
+- Fixed a race condition when saving the Logcollector file status on shutdown. ([#37626](https://github.com/wazuh/wazuh/issues/37626))
 

--- a/src/logcollector/src/logcollector.c
+++ b/src/logcollector/src/logcollector.c
@@ -2607,10 +2607,16 @@ STATIC void w_initialize_file_status() {
 }
 
 STATIC void w_save_file_status() {
+    static pthread_mutex_t save_status_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+    if (pthread_mutex_trylock(&save_status_mutex) != 0) {
+        return;
+    }
 
     char * str = w_save_files_status_to_cJSON();
 
     if (str == NULL) {
+        w_mutex_unlock(&save_status_mutex);
         return;
     }
 
@@ -2641,8 +2647,11 @@ STATIC void w_save_file_status() {
 #endif
         }
     } else {
+        w_mutex_unlock(&save_status_mutex);
         merror_exit(FOPEN_ERROR, tmp_path, errno, strerror(errno));
     }
+
+    w_mutex_unlock(&save_status_mutex);
 
     os_free(str);
 }


### PR DESCRIPTION
|Related issue|
|---|
|Closes #37626|

## Description

The nightly Windows upgrade tests reported the following transient error during agent stop:

```
2026/07/11 04:25:01 wazuh-agent: ERROR: Could not rename 'queue\logcollector\file_status.json.tmp' to 'queue\logcollector\file_status.json' (error 2)
```

`w_save_file_status()` persists the logcollector read state with a write-then-rename pattern (introduced in #36615) using a **fixed temporary path** (`file_status.json.tmp`). The function is called from two unsynchronized places:

- The periodic save in the logcollector main loop (`logcollector.c:945`).
- An `atexit` handler registered at startup (`logcollector.c:212`), executed on process exit.

On Windows the logcollector runs as a thread inside `wazuh-agent`, and the service stop path never stops that thread, so during shutdown both callers can run concurrently. When they interleave, one caller renames the shared `.tmp` away and the other caller's rename fails with `ERROR_FILE_NOT_FOUND` (error 2). The same race exists on POSIX (`ENOENT`). There is no functional impact — one of the renames always wins, so `file_status.json` is always left complete — but the error pollutes the log and fails the nightly known-messages check.

## Proposed Changes

Serialize the save with a static mutex, using **`pthread_mutex_trylock` + skip** instead of a blocking lock:

- If another save is already in flight, the new call simply returns: the in-flight save carries equally fresh state, and the atomic rename guarantees the previous complete file remains in place if a save is interrupted.
- A blocking lock is not an option: on POSIX, `SIGTERM` → `HandleSIG()` → `exit(1)` runs the `atexit` handler *inside the signal handler*, potentially on the same thread that already holds the mutex mid-save. A blocking lock would self-deadlock there, hanging the agent shutdown until SIGKILL (verified experimentally).

### Results and Evidence

Reproduction on a real agent built from source and installed via `install.sh` (Ubuntu 24.04, incus): real `wazuh-logcollector` daemon with `logcollector.vcheck_files=2`, an `LD_PRELOAD` shim adding 300 ms latency to `rename()` of `file_status.json*` (emulating the slow nightly-VM disks where the race reproduces), and inotify-timed `SIGTERM` delivered to a non-main thread at the exact moment the periodic save creates the `.tmp` file. 30 stop cycles per build:

| Build | Stop cycles | `Could not rename` errors | Hangs | Corrupt `file_status.json` |
|---|---|---|---|---|
| Base (`631afacfc2`) | 30 | **30** | 0 | 0 |
| This PR (`a4035c4485`) | 30 | **0** | 0 | 0 |

<details>
<summary>Before — base build, first stop cycle (error reproduced, same pattern as the nightly report)</summary>

```console
2026/07/15 09:24:37 wazuh-logcollector: INFO: Started (pid: 1975).
2026/07/15 09:24:37 wazuh-logcollector: INFO: Startup completed. Runtime-discovered files will be read from beginning.
2026/07/15 09:24:39 wazuh-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/07/15 09:24:40 wazuh-logcollector: ERROR: Could not rename 'queue/logcollector/file_status.json.tmp' to 'queue/logcollector/file_status.json': No such file or directory
```

</details>

<details>
<summary>After — patched build, identical stop cycle (clean exit, no error)</summary>

```console
2026/07/15 09:26:37 wazuh-logcollector: INFO: Started (pid: 7099).
2026/07/15 09:26:37 wazuh-logcollector: INFO: Startup completed. Runtime-discovered files will be read from beginning.
2026/07/15 09:26:39 wazuh-logcollector: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
```

</details>

Additionally, 30 stop cycles delivering `SIGTERM` to the saving thread itself (the exit-from-signal re-entry case) on the patched build: 0 errors, 0 hangs, `file_status.json` valid JSON after every cycle — confirming the trylock choice does not deadlock where a blocking lock would.

`file_status.json` was validated as complete JSON after every one of the stop cycles in all runs.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Log syntax and correct language review (no log messages added or modified)

- Decoder/Rule tests _(Wazuh v4.x)_: N/A
- Engine _(Wazuh v5.x and above)_: N/A
- Wazuh server API/Framework: N/A

Unit tests: `test_logcollector` suite (79 tests, including the five `w_save_file_status` cases) passes without modifications — the test binary does not wrap `pthread_mutex_*`, so the real (uncontended) mutex runs transparently.

### Artifacts Affected

- `wazuh-agent` (Windows monolithic binary) and `wazuh-logcollector` (UNIX daemon).

### Configuration Changes

N/A

### Tests Introduced

N/A — existing `test_logcollector` unit tests cover all `w_save_file_status` paths and pass unchanged.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented (N/A)
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
