### PR TITLE
Reorder revoke-token from API integration test

### DIFF
--- a/api/test/integration/test_security_PUT_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_PUT_endpoints.tavern.yaml
@@ -466,31 +466,6 @@ stages:
           total_failed_items: 1
 
 ---
-test_name: PUT /security/user/revoke
-
-stages:
-
-  - name: Revoke all tokens
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/user/revoke"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      method: PUT
-    response:
-      status_code: 200
-
-  - name: Revoke all tokens (Invalid token after previous call)
-    request:
-      verify: False
-      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/user/revoke"
-      headers:
-        Authorization: "Bearer {test_login_token}"
-      method: PUT
-    response:
-      status_code: 401
-
----
 test_name: DELETE /security/user/authenticate
 
 stages:
@@ -730,3 +705,28 @@ stages:
         data:
           auth_token_exp_timeout: 3000
           rbac_mode: !anystr
+
+---
+test_name: PUT /security/user/revoke
+
+stages:
+
+  - name: Revoke all tokens
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/user/revoke"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+    response:
+      status_code: 200
+
+  - name: Revoke all tokens (Invalid token after previous call)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/user/revoke"
+      headers:
+        Authorization: "Bearer {test_login_token}"
+      method: PUT
+    response:
+      status_code: 401


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

`test_security_PUT_endpoints.tavern.yaml` runs `PUT /security/user/revoke` as the 4th of 9 test blocks. Revoking invalidates the shared `test_login_token`, so every stage that reuses it afterwards (`DELETE /security/user/authenticate`, `PUT /security/users/{user_id}`, `.../run_as`, `PUT /security/config`, `PUT /security/config` Check) fails with `401 Invalid token` once strict auth validation landed in 4.14.7 (#37034). The equivalent fix was applied on main/5.0.0 in #35040 (move revoke to the end) but was never backported to 4.14.x.


## Proposed Changes

- Move the `PUT /security/user/revoke` block to the end of `api/test/integration/test_security_PUT_endpoints.tavern.yaml`, after `PUT /security/config (Check)`, matching the ordering already in place on main/5.0.0 since #35040.
- No URLs, headers or assertions changed, only block order.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->

Closes #37677
Closes #37676
