### PR TITLE
Prevent race condition in Windows RSA key container initialization (randombytes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ All notable changes to this project will be documented in this file.
 
 - Fixed AES connection getting reset to blowfish on keystore rebuild. ([#37524](https://github.com/wazuh/wazuh/pull/37524))
 
+### Agent
+
+#### Fixed
+
+- Prevent a race condition in `randombytes` during the initialization of the Windows RSA key container ([#37701](https://github.com/wazuh/wazuh/pull/37701))
+
 ### Ruleset
 
 #### Fixed

--- a/src/shared/randombytes.c
+++ b/src/shared/randombytes.c
@@ -25,6 +25,15 @@ void randombytes(void *ptr, size_t length)
 
 #ifdef WIN32
     static HCRYPTPROV prov = 0;
+    static pthread_mutex_t prov_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+    /* Multiple agent threads (syscheck, logcollector, execd, wodles...) may reach
+     * this function concurrently on the first call. Without serializing access,
+     * two threads can race inside CryptAcquireContext: one creates the default
+     * key container while the other, having just observed NTE_BAD_KEYSET, tries
+     * to create it too and gets NTE_EXISTS, aborting the whole process.
+     */
+    w_mutex_lock(&prov_mutex);
 
     if (prov == 0) {
         if (!CryptAcquireContext(&prov, NULL, NULL, PROV_RSA_FULL, 0)) {
@@ -55,6 +64,8 @@ void randombytes(void *ptr, size_t length)
     if (!failed && !CryptGenRandom(prov, length, ptr)) {
         failed = 1;
     }
+
+    w_mutex_unlock(&prov_mutex);
 #else
     static int fh = -1;
     ssize_t ret;


### PR DESCRIPTION
## Description

On Windows, `wazuh-agent.exe` runs as a single process with multiple worker threads (syscheck, logcollector, execd, and one thread per configured wodle module), several of which call `randombytes()` during startup. The lazy initialization of the CryptoAPI key container handle (`static HCRYPTPROV prov`) in `src/shared/randombytes.c` was not protected by any synchronization primitive.

When two threads reached the initialization block concurrently — which is likely right after a fresh install/upgrade, before any default RSA key container exists for the running account — a classic CryptoAPI race could occur:

1. Thread A gets `NTE_BAD_KEYSET` from the first `CryptAcquireContext` call and successfully creates the default container via `CRYPT_NEWKEYSET`.
2. Thread B, having entered the same unguarded block a moment earlier, also gets `NTE_BAD_KEYSET`. By the time it attempts `CRYPT_NEWKEYSET`, the container has just been created by thread A, so it fails with `NTE_EXISTS` (`0x8009000f`).
3. Thread B logs `CryptAcquireContext Flag: NewKeySet (1): (8009000f)` and calls `merror_exit()`, which internally calls `exit(1)` — terminating the **entire agent process**, not just the failing thread.

This matches exactly the error reported in #37308 and its historical duplicates (#26067, #31343), which had previously been closed as "environment-related" because the race is timing-dependent and hard to reproduce on demand. It was reliably reproduced again during 5.0.0 nightly upgrade testing, which motivated this fix.

Closes #37308

## Proposed Changes

- Added a `pthread_mutex_t` (`prov_mutex`) guarding the lazy initialization and use of the Windows CryptoAPI provider handle in `randombytes()`, serializing concurrent calls from different agent threads so only one thread creates/repairs the key container while the others reuse the already-initialized handle.
- No change to the Unix/Linux code path (the `#else` branch), which was not affected by this issue.
- No change to the function's public API or return semantics.

### Results and Evidence

- Static analysis of the Windows agent startup path (`src/win32/win_utils.c::local_start()`) confirms multiple threads (syscheck, logcollector, execd, and each configured wodle module) are started concurrently, and several call `randombytes()` / `os_random()` early in their lifecycle — matching the conditions required to trigger the race.
- The reported error code `0x8009000f` (`NTE_EXISTS`) returned from the `CRYPT_NEWKEYSET` call is only reachable, per the Windows CryptoAPI semantics, when the key container was created by a concurrent caller between the failed plain `CryptAcquireContext` call and the `CRYPT_NEWKEYSET` retry — consistent with an unsynchronized race rather than an environment issue.
- The mingw-w64 Windows cross-compiler was not available in this environment, so the patched logic was validated by compiling a syntax-equivalent reproduction of the patched function (Windows API calls stubbed out) with `gcc -Wall -Wextra -Werror -pthread`; it compiled without warnings and executed as expected.
- No live reproduction of the original crash was performed against a QA Windows environment as part of this change. A `TARGET=winagent` CI build and a re-run of the nightly upgrade suite are recommended to fully confirm the fix.

### Artifacts Affected

- `wazuh-agent` (Windows) and any other Windows executable statically linking `shared/randombytes.c` (e.g. `agent-auth`, `manage_agents`) — behavior only changes under `WIN32` builds.
- No impact on Linux/Unix agent or manager binaries (code path untouched).

### Configuration Changes

- None.

### Documentation Updates

- None required — this is an internal implementation detail with no user-facing behavior or configuration change.

### Tests Introduced

- No new automated test added. There is no existing unit test target that links the real `src/shared/randombytes.c` (existing tests mock it via `randombytes_wrappers`), and deterministically unit-testing a Windows CryptoAPI thread race is impractical in the current test harness.
- Suggested manual/QA validation: re-run the 5.0.0 Windows upgrade test suite (internal-devel-requests#5354) across multiple iterations without environment destroy, to confirm the `randombytes failed for all possible methods for accessing random data` message no longer appears.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
- [ ] Validated on a real Windows (`TARGET=winagent`) build