### PR TITLE
fix date schema validation error in scheduled metrics

### DIFF
--- a/framework/wazuh/core/indexer/metrics_snapshot.py
+++ b/framework/wazuh/core/indexer/metrics_snapshot.py
@@ -344,7 +344,9 @@ class MetricsSnapshotTasks:
                         "last_seen": MetricsSnapshotTasks._to_iso(
                             doc.get("lastKeepAlive")
                         ),
-                        "disconnected_at": doc.get("disconnection_time") or None,
+                        "disconnected_at": MetricsSnapshotTasks._to_iso(
+                            doc.get("disconnection_time")
+                        ),
                         "register": {"ip": register_ip},
                         "host": {
                             "ip": [ip] if ip else [],

--- a/framework/wazuh/core/indexer/tests/test_metrics_snapshot.py
+++ b/framework/wazuh/core/indexer/tests/test_metrics_snapshot.py
@@ -12,6 +12,8 @@ TestAgentFieldMapping                        – all normalized agent fields pre
 TestMetadataInjection                        – @timestamp, wazuh.cluster.node, wazuh.cluster.name in every document
 TestRunMetricsSnapshot                       – frequency=0 early-exit; frequency<600 clamped to 600
 TestDisconnectionTimeOmission                – wazuh.agent.disconnected_at absent when disconnection_time is 0
+TestDatetimeFieldsSerialization              – datetime date fields normalized to ISO strings
+TestDisconnectedAgentPassesSchemaValidation  – disconnected agent doc passes schema validation
 TestBulkActionShape                          – _op_type: create on every action sent to async_bulk
 TestBuildJsonschemaProperties                – nested property schema building
 TestOpensearchTemplateToJsonschema           – OpenSearch template to JSON Schema conversion
@@ -22,7 +24,7 @@ TestValidateDocuments                        – per-document validation and inv
 import asyncio
 import json
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 
 import pytest
@@ -419,12 +421,14 @@ AGENT_DOC_FULL = {
     },
     "version": "Wazuh v4.9.0",
     "manager": "node01",
-    "dateAdd": "2026-01-01T00:00:00Z",
+    # WazuhDBQueryAgents returns dateAdd, lastKeepAlive and disconnection_time
+    # as tz-aware datetime objects.
+    "dateAdd": datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
     "group": ["default"],
     "mergedSum": "abcdef1234567890",
     "node_name": "node01",
-    "lastKeepAlive": "2026-03-17T10:00:00Z",
-    "disconnection_time": 12345,
+    "lastKeepAlive": datetime(2026, 3, 17, 10, 0, 0, tzinfo=timezone.utc),
+    "disconnection_time": datetime(2026, 3, 17, 10, 5, 0, tzinfo=timezone.utc),
     "registerIP": "10.0.1.5",
     "group_config_status": "synced",
     "status_code": 0,
@@ -919,14 +923,16 @@ class TestDisconnectionTimeOmission:
     async def test_nonzero_disconnection_time_is_preserved(
         self, mock_wazuh_db_query_agents
     ):
-        """A non-zero disconnection_time maps to wazuh.agent.disconnected_at."""
+        """A non-zero disconnection_time maps to wazuh.agent.disconnected_at as ISO 8601."""
         mock_wazuh_db_query_agents.return_value.run.return_value = {
             "items": [
                 {
                     "id": "002",
                     "name": "agent-disconnected",
                     "status": "disconnected",
-                    "disconnection_time": 19345809,
+                    "disconnection_time": datetime(
+                        1970, 8, 12, 21, 50, 9, tzinfo=timezone.utc
+                    ),
                 }
             ]
         }
@@ -934,7 +940,7 @@ class TestDisconnectionTimeOmission:
         tasks = _make_tasks()
         docs = await tasks._collect_agents(TIMESTAMP)
 
-        assert docs[0]["wazuh"]["agent"]["disconnected_at"] == 19345809
+        assert docs[0]["wazuh"]["agent"]["disconnected_at"] == "1970-08-12T21:50:09Z"
 
     @pytest.mark.asyncio
     @patch("wazuh.core.indexer.metrics_snapshot.WazuhDBQueryAgents")
@@ -945,7 +951,13 @@ class TestDisconnectionTimeOmission:
         mock_wazuh_db_query_agents.return_value.run.return_value = {
             "items": [
                 {"id": "001", "status": "active"},
-                {"id": "002", "status": "disconnected", "disconnection_time": 5000},
+                {
+                    "id": "002",
+                    "status": "disconnected",
+                    "disconnection_time": datetime(
+                        1970, 1, 1, 1, 23, 20, tzinfo=timezone.utc
+                    ),
+                },
             ]
         }
 
@@ -960,7 +972,118 @@ class TestDisconnectionTimeOmission:
         )
 
         assert "disconnected_at" not in active_doc.get("wazuh", {}).get("agent", {})
-        assert disconnected_doc["wazuh"]["agent"]["disconnected_at"] == 5000
+        assert disconnected_doc["wazuh"]["agent"]["disconnected_at"] == "1970-01-01T01:23:20Z"
+
+
+# ---------------------------------------------------------------------------
+# datetime serialization of agent date fields
+# ---------------------------------------------------------------------------
+
+
+class TestDatetimeFieldsSerialization:
+    """Regression – datetime objects from WazuhDBQueryAgents must never leak
+    into the normalized document (they fail schema validation and are not
+    JSON-serializable)."""
+
+    @pytest.mark.asyncio
+    @patch("wazuh.core.indexer.metrics_snapshot.WazuhDBQueryAgents")
+    async def test_datetime_inputs_become_iso_strings(self, mock_wazuh_db_query_agents):
+        """dateAdd, lastKeepAlive and disconnection_time datetimes map to ISO strings."""
+        mock_wazuh_db_query_agents.return_value.run.return_value = {
+            "items": [
+                {
+                    "id": "003",
+                    "name": "agent-disconnected",
+                    "status": "disconnected",
+                    "dateAdd": datetime(2026, 7, 1, 10, 0, 0, tzinfo=timezone.utc),
+                    "lastKeepAlive": datetime(
+                        2026, 7, 14, 15, 13, 36, tzinfo=timezone.utc
+                    ),
+                    "disconnection_time": datetime(
+                        2026, 7, 14, 15, 13, 46, tzinfo=timezone.utc
+                    ),
+                }
+            ]
+        }
+
+        tasks = _make_tasks()
+        docs = await tasks._collect_agents(TIMESTAMP)
+        agent = docs[0]["wazuh"]["agent"]
+
+        assert agent["registered_at"] == "2026-07-01T10:00:00Z"
+        assert agent["last_seen"] == "2026-07-14T15:13:36Z"
+        assert agent["disconnected_at"] == "2026-07-14T15:13:46Z"
+        # The whole document must survive JSON round-tripping (bulk indexing).
+        json.dumps(docs[0])
+
+
+# ---------------------------------------------------------------------------
+# disconnected agent passes schema validation
+# ---------------------------------------------------------------------------
+
+
+class TestDisconnectedAgentPassesSchemaValidation:
+    """Regression – a disconnected agent's document must not be dropped by
+    schema validation (it previously failed with
+    'datetime.datetime(...) is not valid under any of the given schemas')."""
+
+    MINIMAL_TEMPLATE = {
+        "template": {
+            "mappings": {
+                "dynamic": "strict",
+                "properties": {
+                    "@timestamp": {"type": "date"},
+                    "wazuh": {
+                        "properties": {
+                            "agent": {
+                                "properties": {
+                                    "id": {"type": "keyword"},
+                                    "name": {"type": "keyword"},
+                                    "status": {"type": "keyword"},
+                                    "disconnected_at": {"type": "date"},
+                                }
+                            },
+                            "cluster": {
+                                "properties": {
+                                    "name": {"type": "keyword"},
+                                    "node": {"type": "keyword"},
+                                }
+                            },
+                            "schema": {
+                                "properties": {"version": {"type": "keyword"}}
+                            },
+                        }
+                    },
+                },
+            }
+        }
+    }
+
+    @pytest.mark.asyncio
+    @patch("wazuh.core.indexer.metrics_snapshot.WazuhDBQueryAgents")
+    async def test_disconnected_agent_doc_is_valid(self, mock_wazuh_db_query_agents):
+        """A document with a datetime disconnection_time survives _validate_documents."""
+        mock_wazuh_db_query_agents.return_value.run.return_value = {
+            "items": [
+                {
+                    "id": "003",
+                    "name": "agent-disconnected",
+                    "status": "disconnected",
+                    "disconnection_time": datetime(
+                        2026, 7, 14, 15, 13, 46, tzinfo=timezone.utc
+                    ),
+                }
+            ]
+        }
+
+        tasks = _make_tasks()
+        docs = await tasks._collect_agents(TIMESTAMP)
+        schema = _opensearch_template_to_jsonschema(self.MINIMAL_TEMPLATE)
+
+        valid = tasks._validate_documents(docs, schema, "wazuh-metrics-agents")
+
+        assert len(valid) == 1  # was 0 before the fix
+        tasks.logger.error.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

Closes #37681

On the master node, every metrics snapshot cycle (default: every 10 min) logs one error
per **disconnected** agent in `logs/cluster.log`, and silently drops that agent's
document from the `wazuh-metrics-agents` index:

```
2026/07/14 15:22:48 ERROR: [Master] [metrics_snapshot] Document failed schema validation for index 'wazuh-metrics-agents': datetime.datetime(2026, 7, 14, 15, 13, 46, tzinfo=datetime.timezone.utc) is not valid under any of the given schemas
```

The rejected value is the agent's disconnection time. Active agents are unaffected
(their `disconnection_time` is `0` and is deleted before formatting,
`framework/wazuh/core/agent.py:231-232`).

## Root cause

1. `WazuhDBQueryAgents` formats the three date fields `dateAdd`, `lastKeepAlive` and
   `disconnection_time` from epoch integers into **tz-aware `datetime` objects**
   (`format_fields`, `framework/wazuh/core/agent.py:1414-1415`, via
   `get_date_from_timestamp`).
2. `MetricsSnapshotTasks._normalize_agent_doc`
   (`framework/wazuh/core/indexer/metrics_snapshot.py`) converts `dateAdd` and
   `lastKeepAlive` to strings with `_to_iso()`, but forwards `disconnection_time`
   **raw** (line 347):

   ```python
   "disconnected_at": doc.get("disconnection_time") or None,
   ```

3. The JSON Schema generated from the `metrics-agents.json` index template maps the
   OpenSearch `date` type to `anyOf [string, array-of-string, null]`. A Python
   `datetime` instance matches none of those, so `jsonschema.validate` raises and
   `_validate_documents` drops the document.


## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

## Issue replication

* Configuration

Manager / dashboard / indexer and Agent all installed on the same host.

Wait for sever status to synch with indexer and the agent enrollment to finish succesfully. 

After that stop the agent and wait 10 minutes


## Before fix

* Agent

Stop agent

```console
╰─# date ; /var/ossec/bin/wazuh-control stop                                          130 ↵
Wed Jul 15 12:28:21 PM UTC 2026
```

* Manager

10 minutes after

`# tail -f /var/wazuh-manager/logs/cluster.log`

```console
2026/07/15 12:35:35 INFO: [Master] [Active Response] Starting
2026/07/15 12:35:35 INFO: [Master] [Active Response] Finished in 0.072s.
2026/07/15 12:36:03 INFO: [Master] [Main] Checking if the indexer is available to initiate indexer tasks.
2026/07/15 12:36:03 ERROR: [Master] [metrics_snapshot] Document failed schema validation for index 'wazuh-metrics-agents': datetime.datetime(2026, 7, 15, 12, 28, 21, tzinfo=datetime.timezone.utc) is not valid under any of the given schemas
2026/07/15 12:36:04 INFO: [Master] [disconnected_agent_sync_task] Retrieved 0 non-active agents from WazuhDB meeting minimum disconnection time
2026/07/15 12:36:04 INFO: [Master] [disconnected_agent_sync_task] No disconnected agents found
2026/07/15 12:36:05 INFO: [Master] [Active Response] Starting
2026/07/15 12:36:05 INFO: [Master] [Active Response] Finished in 0.069s.
```

Request

```console

╰─# curl -XGET "https://localhost:9200/wazuh-metrics-agents/_search" -H 'Content-Type: application/json' -u admin:admin -k -d '{ "query": { "term": { "wazuh.agent.status": "disconnected" } }, 
     "sort": [ { "@timestamp": "desc" } ], "size": 1 }' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   279  100   160  100   119  25090  18660 --:--:-- --:--:-- --:--:-- 46500
{
  "took": 0,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 0,
      "relation": "eq"
    },
    "max_score": null,
    "hits": []
  }
}
(venv) ╭─root@9fac3eeb828e /workspaces/devContainer/testttts 
╰─# curl -sk -u admin:admin "https://localhost:9200/wazuh-metrics-agents/_count" | jq

{
  "count": 0,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  }

```

## After fix

* Agent

```console
(venv) ╭─root@9fac3eeb828e /workspaces/devContainer/testttts 
╰─# /var/ossec/bin/wazuh-control stop                             130 ↵
Killing wazuh-modulesd... 
Killing wazuh-logcollector... 
Killing wazuh-syscheckd... 
Killing wazuh-agentd... 
Killing wazuh-execd... 
dateWazuh v5.0.0 Stopped
(venv) ╭─root@9fac3eeb828e /workspaces/devContainer/testttts 
╰─# date
Tue Jul 14 07:34:09 PM UTC 2026
```

* Manager

`# tail -f /var/wazuh-manager/logs/cluster.log`

```console
2026/07/14 19:46:13 INFO: [Master] [Main] Checking if the indexer is available to initiate indexer tasks.
2026/07/14 19:46:13 INFO: [Master] [disconnected_agent_sync_task] Retrieved 1 non-active agents from WazuhDB meeting minimum disconnection time
2026/07/14 19:46:13 INFO: [Master] [disconnected_agent_sync_task] Found 1 disconnected agents to synchronize
2026/07/14 19:46:13 INFO: [Master] [disconnected_agent_sync_task] Synchronizing groups for agent 001 with groups=['default']
2026/07/14 19:46:13 INFO: [Master] [disconnected_agent_sync_task] Starting group synchronization for 1 disconnected agents
2026/07/14 19:46:13 INFO: [Master] [Main] Summary: {'index': ['wazuh-states-fim-files', 'wazuh-states-fim-registry-keys', 'wazuh-states-fim-registry-values'], 'updated_documents': 0, 'module': 'fim'}
2026/07/14 19:46:13 INFO: [Master] [Main] Summary: {'index': ['wazuh-states-sca'], 'updated_documents': 0, 'module': 'sca'}
2026/07/14 19:46:13 INFO: [Master] [Main] Summary: {'index': ['wazuh-states-inventory-system', 'wazuh-states-inventory-hardware', 'wazuh-states-inventory-hotfixes', 'wazuh-states-inventory-packages', 'wazuh-states-inventory-processes', 'wazuh-states-inventory-ports', 'wazuh-states-inventory-interfaces', 'wazuh-states-inventory-protocols', 'wazuh-states-inventory-networks', 'wazuh-states-inventory-users', 'wazuh-states-inventory-groups', 'wazuh-states-inventory-services', 'wazuh-states-inventory-browser-extensions', 'wazuh-states-vulnerabilities'], 'updated_documents': 0, 'module': 'syscollector'}
2026/07/14 19:46:13 INFO: [Master] [disconnected_agent_sync_task] Successfully synchronized agent 001 with groups ['default']
2026/07/14 19:46:13 INFO: [Master] [disconnected_agent_sync_task] Group synchronization completed: 1 succeeded, 0 failed
2026/07/14 19:46:13 INFO: [Master] [disconnected_agent_sync_task] Finished group synchronization task. Processed 1/1 agents in 0.19 seconds. 0 agents failed.
2026/07/14 19:46:16 INFO: [Master] [Active Response] Starting
2026/07/14 19:46:16 INFO: [Master] [Active Response] Finished in 0.071s.
```

Requests

```console
╰─# curl -sk -u admin:admin "https://localhost:9200/wazuh-metrics-agents/_count" | jq

{
  "count": 2,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  }
}
(venv) ╭─root@9fac3eeb828e /workspaces/devContainer/testttts 
╰─# curl -XGET "https://localhost:9200/wazuh-metrics-agents/_search" -H 'Content-Type: application/json' -u admin:admin -k -d '{ "query": { "term": { "wazuh.agent.status": "disconnected" } },
     "sort": [ { "@timestamp": "desc" } ], "size": 1 }' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1000  100   881  100   119   135k  18808 --:--:-- --:--:-- --:--:--  162k
{
  "took": 0,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 2,
      "relation": "eq"
    },
    "max_score": null,
    "hits": [
      {
        "_index": ".ds-wazuh-metrics-agents-000001",
        "_id": "8o31ZZ8BmeFGZNjuCrPT",
        "_score": null,
        "_source": {
          "@timestamp": "2026-07-15T13:26:25Z",
          "wazuh": {
            "agent": {
              "id": "001",
              "name": "9fac3eeb828e",
              "version": "v5.0.0",
              "groups": [
                "default"
              ],
              "status": "disconnected",
              "status_code": 3,
              "registered_at": "2026-07-15T12:26:13Z",
              "last_seen": "2026-07-15T13:10:04Z",
              "disconnected_at": "2026-07-15T13:10:10Z",
              "register": {
                "ip": "0.0.0.0"
              },
              "host": {
                "ip": [
                  "127.0.0.1"
                ],
                "architecture": "x86_64",
                "os": {
                  "name": "Ubuntu",
                  "version": "24.04.3 LTS (Noble Numbat)",
                  "platform": "ubuntu"
                }
              },
              "config": {
                "group": {
                  "synced": true,
                  "hash": {
                    "md5": "c8a763498900b3dbd056a9b1a2c2593a"
                  }
                }
              }
            },
            "cluster": {
              "name": "wazuh",
              "node": "node01"
            },
            "schema": {
              "version": "1"
            }
          }
        },
        "sort": [
          1784121985000
        ]
      }
    ]
  }
}
```

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
