### PR TITLE
Restore 5.x checkfiles baselines on main reverted by 4.14.7 merge

### DIFF
--- a/.github/actions/check_files/deb_linux_agent_amd64.csv
+++ b/.github/actions/check_files/deb_linux_agent_amd64.csv
@@ -15,10 +15,10 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,253344,0.1
 /var/ossec/lib/libbpf.so,root,wazuh,750,file,-rwxr-x---,526040,0.1
 /var/ossec/lib/libfimebpf.so,root,wazuh,750,file,-rwxr-x---,64168,0.1
-/var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,904720,0.1
+/var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,998504,0.1
 /var/ossec/lib/libstdc++.so.6,root,wazuh,750,file,-rwxr-x---,2599704,0.1
 /var/ossec/lib/libsyscollector.so,root,wazuh,750,file,-rwxr-x---,793656,0.1
-/var/ossec/lib/libsca.so,root,wazuh,750,file,-rwxr-x---,800872,0.1
+/var/ossec/lib/libsca.so,root,wazuh,750,file,-rwxr-x---,886544,0.1
 /var/ossec/lib/libagent_info.so,root,wazuh,750,file,-rwxr-x---,345184,0.1
 /var/ossec/lib/libagent_metadata.so,root,wazuh,750,file,-rwxr-x---,14448,0.1
 /var/ossec/lib/libgcc_s.so.1,root,wazuh,750,file,-rwxr-x---,183248,0.1

--- a/.github/actions/check_files/rpm_linux_agent_amd64.csv
+++ b/.github/actions/check_files/rpm_linux_agent_amd64.csv
@@ -73,13 +73,13 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/bin/wazuh-agentd,root,root,750,file,-rwxr-x---,624632,0.1
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12417720,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,484376,0.1
-/var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,200240,0.1
+/var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,220736,0.1
 /var/ossec/lib/libschema_validator.so,root,wazuh,750,file,-rwxr-x---,386024,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2555328,0.1
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,224672,0.1
 /var/ossec/lib/libbpf.so,root,wazuh,750,file,-rwxr-x---,526048,0.1
 /var/ossec/lib/libfimebpf.so,root,wazuh,750,file,-rwxr-x---,60080,0.1
-/var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,904720,0.1
+/var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,998504,0.1
 /var/ossec/lib/libstdc++.so.6,root,wazuh,750,file,-rwxr-x---,2530376,0.1
 /var/ossec/lib/libsyscollector.so,root,wazuh,750,file,-rwxr-x---,769128,0.1
 /var/ossec/lib/libsca.so,root,wazuh,750,file,-rwxr-x---,783864,0.1

--- a/.github/actions/check_files/rpm_linux_agent_i386.csv
+++ b/.github/actions/check_files/rpm_linux_agent_i386.csv
@@ -79,7 +79,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,259032,0.1
 /var/ossec/lib/libbpf.so,root,wazuh,750,file,-rwxr-x---,470152,0.1
 /var/ossec/lib/libfimebpf.so,root,wazuh,750,file,-rwxr-x---,52720,0.1
-/var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,904752,0.1
+/var/ossec/lib/modern.bpf.o,root,wazuh,750,file,-rwxr-x---,998504,0.1
 /var/ossec/lib/libstdc++.so.6,root,wazuh,750,file,-rwxr-x---,1984136,0.1
 /var/ossec/lib/libsyscollector.so,root,wazuh,750,file,-rwxr-x---,866104,0.1
 /var/ossec/lib/libsca.so,root,wazuh,750,file,-rwxr-x---,795908,0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## [v5.1.0]
 
+### Agent
+
+#### Fixed
+
+- Restored the 5.x package file-check baselines on `main` that were reverted to 4.x values by the 4.14.7 merge. ([#37704](https://github.com/wazuh/wazuh/issues/37704))
+
 ## [v5.0.1]
 
 ## [v5.0.0]


### PR DESCRIPTION
|Related issue|
|---|
|Closes #37704|

## Description

`Test DEB amd64 package` and `Test RPM amd64 package` fail on every `main`-based branch since the 5.1.0 version bump: the `Merge branch '4.14.7' into 5.0.0` merge (`c1a2980659`) reverted several 5.x size baselines in `.github/actions/check_files/*.csv` to 4.x values. This was fixed on the `5.0.0` branch by #37414 but never forwarded to `main`.

## Proposed Changes

Port the #37414 baseline values from the `5.0.0` branch to `main` (5 lines across 3 CSVs):

- `deb_linux_agent_amd64.csv`: `modern.bpf.o` 904720 → 998504, `libsca.so` 800872 → 886544
- `rpm_linux_agent_amd64.csv`: `modern.bpf.o` 904720 → 998504, `libagent_sync_protocol.so` 200240 → 220736
- `rpm_linux_agent_i386.csv`: `modern.bpf.o` 904752 → 998504

### Results and Evidence

Values verified against artifacts built from current `main` (sizes of stripped binaries):

| File | `main` CSV (stale, ±10%) | Actual from `main` build | New baseline (±10%) |
|---|---|---|---|
| `modern.bpf.o` | 904720 (max 995192) ✗ | **998504** (byte-exact match with 5.0.0 baseline) | 998504 ✓ |
| `libsca.so` | 800872 (max 881k) ✗ | 895200 | 886544 ✓ |
| `libagent_sync_protocol.so` | 200240 (max 220264) ✗ | 224880 | 220736 ✓ |

First failing occurrence (once builder images for 5.1.0 were available): `Test DEB amd64 package` / `Test RPM amd64 package` in https://github.com/wazuh/wazuh/actions/runs/29406719920 — `Failed: Results didn't match the expected output / Wazuh File Integrity Check`.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform: N/A (CI data files only)
- [ ] Log syntax and correct language review (N/A — no log changes)
- Memory tests: N/A (CI data files only)
- Decoder/Rule tests _(Wazuh v4.x)_: N/A
- Engine _(Wazuh v5.x and above)_: N/A
- Wazuh server API/Framework: N/A

### Artifacts Affected

N/A — CI expected-files baselines only.

### Configuration Changes

N/A

### Tests Introduced

N/A

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality (covered by the existing `Test * package` CI jobs)
- [ ] Configuration changes documented (N/A)
- [ ] Developer documentation reflects the changes (N/A)
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
