### PR TITLE
Explicit use of jemalloc on daemons

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,7 @@ set(WAZUH_MAIN_PROJECT
 # Shared CMake helpers
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include(WazuhRpath)
+include(WazuhJemalloc)
 
 # Define CLIENT for agent builds
 if("${TARGET}" STREQUAL "winagent" OR "${TARGET}" STREQUAL "agent")

--- a/src/cmake/WazuhJemalloc.cmake
+++ b/src/cmake/WazuhJemalloc.cmake
@@ -1,0 +1,45 @@
+# Links jemalloc onto a server-only daemon target, explicitly and per-target.
+#
+# jemalloc is only built for server (non-agent, non-Windows) targets — see
+# the jemalloc section in external/CMakeLists.txt — and can be turned off
+# entirely with -DDISABLE_JEMALLOC=ON.
+#
+# Each daemon that wants jemalloc's allocator must call this itself. It is
+# intentionally NOT linked onto any shared static library (e.g. `config` or
+# `wazuh_modulesd_lib`): a static library can't hide a dependency from its
+# consumers, so linking jemalloc there would silently drag it into every
+# daemon that happens to link that library, whether or not it actually
+# wants it. This function makes the choice visible at each call site instead.
+#
+# Usage: wazuh_link_jemalloc(<target> [PLAIN])
+#   PLAIN: use the plain (non-keyword) target_link_libraries() signature.
+#   CMake forbids mixing plain and keyword calls on the same target, so pass
+#   PLAIN for a target (e.g. wazuh-engine) that already links itself with
+#   the plain signature elsewhere. Defaults to the keyword PRIVATE signature.
+
+function(wazuh_link_jemalloc target)
+  if(IS_AGENT OR CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    return()
+  endif()
+
+  if(DEFINED DISABLE_JEMALLOC AND DISABLE_JEMALLOC)
+    return()
+  endif()
+
+  find_library(
+    JEMALLOC_LIB jemalloc
+    PATHS ${CMAKE_SOURCE_DIR}/external/jemalloc/lib
+    NO_DEFAULT_PATH)
+
+  if(NOT JEMALLOC_LIB)
+    message(WARNING "jemalloc not found in ${CMAKE_SOURCE_DIR}/external/jemalloc/lib, ${target} will use the default allocator")
+    return()
+  endif()
+
+  if("${ARGV1}" STREQUAL "PLAIN")
+    target_link_libraries(${target} ${JEMALLOC_LIB})
+  else()
+    target_link_libraries(${target} PRIVATE ${JEMALLOC_LIB})
+  endif()
+  message(STATUS "Linking ${target} with jemalloc: ${JEMALLOC_LIB}")
+endfunction()

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -368,18 +368,7 @@ if(NOT ENGINE_SANITIZER_OPTIONS AND NOT CMAKE_CXX_FLAGS MATCHES "-fsanitize=.*")
 endif()
 
 # Link jemalloc for reduced memory fragmentation (unless explicitly disabled)
-if(NOT DEFINED DISABLE_JEMALLOC OR NOT DISABLE_JEMALLOC)
-  find_library(
-    JEMALLOC_LIB jemalloc
-    PATHS ${CMAKE_SOURCE_DIR}/external/jemalloc/lib
-    NO_DEFAULT_PATH)
-  if(JEMALLOC_LIB)
-    target_link_libraries(wazuh-engine ${JEMALLOC_LIB})
-    message(STATUS "Linking wazuh-engine with jemalloc: ${JEMALLOC_LIB}")
-  else()
-    message(WARNING "jemalloc not found in ${CMAKE_SOURCE_DIR}/external/jemalloc/lib")
-  endif()
-endif()
+wazuh_link_jemalloc(wazuh-engine PLAIN)
 
 # Print LD anc CXX flags
 message(STATUS "engine CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")

--- a/src/monitord/CMakeLists.txt
+++ b/src/monitord/CMakeLists.txt
@@ -88,6 +88,7 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows" AND NOT UNIT_TEST)
     wazuh-manager-monitord PROPERTIES LINKER_LANGUAGE C RUNTIME_OUTPUT_DIRECTORY
                                                         ${SRC_FOLDER}/build/bin)
   target_link_libraries(wazuh-manager-monitord PRIVATE monitord_lib)
+  wazuh_link_jemalloc(wazuh-manager-monitord)
 
   wazuh_set_runtime_rpath(wazuh-manager-monitord)
 endif()

--- a/src/os_auth/CMakeLists.txt
+++ b/src/os_auth/CMakeLists.txt
@@ -85,6 +85,7 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows" AND NOT UNIT_TEST)
     wazuh-manager-authd PROPERTIES LINKER_LANGUAGE C RUNTIME_OUTPUT_DIRECTORY
                                                      ${SRC_FOLDER}/build/bin)
   target_link_libraries(wazuh-manager-authd PRIVATE authd_lib)
+  wazuh_link_jemalloc(wazuh-manager-authd)
 
   wazuh_set_runtime_rpath(wazuh-manager-authd)
 endif()

--- a/src/remoted/CMakeLists.txt
+++ b/src/remoted/CMakeLists.txt
@@ -91,6 +91,7 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows" AND NOT UNIT_TEST)
     wazuh-manager-remoted PROPERTIES LINKER_LANGUAGE C RUNTIME_OUTPUT_DIRECTORY
                                                        ${SRC_FOLDER}/build/bin)
   target_link_libraries(wazuh-manager-remoted PRIVATE remoted_lib)
+  wazuh_link_jemalloc(wazuh-manager-remoted)
 
   wazuh_set_runtime_rpath(wazuh-manager-remoted)
 endif()

--- a/src/wazuh_db/CMakeLists.txt
+++ b/src/wazuh_db/CMakeLists.txt
@@ -104,6 +104,7 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows" AND NOT UNIT_TEST)
     wazuh-manager-db PROPERTIES LINKER_LANGUAGE C RUNTIME_OUTPUT_DIRECTORY
                                                   ${SRC_FOLDER}/build/bin)
   target_link_libraries(wazuh-manager-db PRIVATE wdb_lib)
+  wazuh_link_jemalloc(wazuh-manager-db)
 
   wazuh_set_runtime_rpath(wazuh-manager-db)
 endif()

--- a/src/wazuh_modules/CMakeLists.txt
+++ b/src/wazuh_modules/CMakeLists.txt
@@ -136,15 +136,17 @@ if(NOT "${TARGET}" STREQUAL "winagent" AND NOT "${TARGET}" STREQUAL "agent")
            wazuh
            schema_validator)
 
-  # Link jemalloc for server builds (unless explicitly disabled)
+  # Locate jemalloc for server builds (unless explicitly disabled). Linked
+  # onto the modulesd executable target below, not onto wazuh_modulesd_lib
+  # itself — this is a static library, so a PUBLIC/PRIVATE dependency here
+  # would still be forwarded to the final link command of every daemon
+  # that pulls in wazuh_modulesd_lib transitively via `config` (remoted,
+  # monitord, wazuh_db, authd), none of which are meant to use jemalloc.
   if(NOT DEFINED DISABLE_JEMALLOC OR NOT DISABLE_JEMALLOC)
     find_library(
       JEMALLOC_LIB jemalloc
       PATHS ${SRC_FOLDER}/external/jemalloc/lib
       NO_DEFAULT_PATH)
-    if(JEMALLOC_LIB)
-      target_link_libraries(wazuh_modulesd_lib PUBLIC ${JEMALLOC_LIB})
-    endif()
   endif()
 else()
   # Agent build
@@ -200,6 +202,9 @@ elseif(NOT UNIT_TEST)
                                  ${SRC_FOLDER}/build/bin)
   target_link_libraries(${WAZUH_MODULESD_DAEMON_NAME}
                         PRIVATE wazuh_modulesd_lib)
+  if(JEMALLOC_LIB)
+    target_link_libraries(${WAZUH_MODULESD_DAEMON_NAME} PRIVATE ${JEMALLOC_LIB})
+  endif()
 
   wazuh_set_runtime_rpath(${WAZUH_MODULESD_DAEMON_NAME})
 endif()

--- a/src/wazuh_modules/CMakeLists.txt
+++ b/src/wazuh_modules/CMakeLists.txt
@@ -136,18 +136,6 @@ if(NOT "${TARGET}" STREQUAL "winagent" AND NOT "${TARGET}" STREQUAL "agent")
            wazuh
            schema_validator)
 
-  # Locate jemalloc for server builds (unless explicitly disabled). Linked
-  # onto the modulesd executable target below, not onto wazuh_modulesd_lib
-  # itself — this is a static library, so a PUBLIC/PRIVATE dependency here
-  # would still be forwarded to the final link command of every daemon
-  # that pulls in wazuh_modulesd_lib transitively via `config` (remoted,
-  # monitord, wazuh_db, authd), none of which are meant to use jemalloc.
-  if(NOT DEFINED DISABLE_JEMALLOC OR NOT DISABLE_JEMALLOC)
-    find_library(
-      JEMALLOC_LIB jemalloc
-      PATHS ${SRC_FOLDER}/external/jemalloc/lib
-      NO_DEFAULT_PATH)
-  endif()
 else()
   # Agent build
   target_link_libraries(
@@ -202,9 +190,7 @@ elseif(NOT UNIT_TEST)
                                  ${SRC_FOLDER}/build/bin)
   target_link_libraries(${WAZUH_MODULESD_DAEMON_NAME}
                         PRIVATE wazuh_modulesd_lib)
-  if(JEMALLOC_LIB)
-    target_link_libraries(${WAZUH_MODULESD_DAEMON_NAME} PRIVATE ${JEMALLOC_LIB})
-  endif()
+  wazuh_link_jemalloc(${WAZUH_MODULESD_DAEMON_NAME})
 
   wazuh_set_runtime_rpath(${WAZUH_MODULESD_DAEMON_NAME})
 endif()


### PR DESCRIPTION
## Description

Jemalloc was unintentionally linked to `wazuh-manager-remoted`, `wazuh-manager-monitord`, `wazuh-manager-authd`, and `wazuh-manager-db` as a direct runtime dependency (`DT_NEEDED libjemalloc.so.2`), even though none of these daemons reference jemalloc in their own `CMakeLists.txt`. Only `wazuh-manager-modulesd` and `wazuh-engine` (analysisd) are designed to use it.

This pull request aims to explicitly include JEMALLOC in the above daemons, avoiding the implicit pull of the current implementation.

## Proposed Changes

The proposal is to create a centralized JEMALLOC inclusion target so that all daemons that need it only call this function, avoiding duplication and potential errors.


### Results and Evidence

#### Install

```
Done building manager

Wait for success...
success
mkdir -p /var/wazuh-manager/framework/python
cp external/cpython.tar.gz /var/wazuh-manager/framework/python/cpython.tar.gz && tar -xf /var/wazuh-manager/framework/python/cpython.tar.gz-C /var/wazuh-manager/framework/python && rm -rf /var/wazuh-manager/framework/python/cpython.tar.gz
find /var/wazuh-manager/framework/python -name "*libpython3.12.so.1.0" -exec ln -f {} /var/wazuh-manager/lib/libpython3.12.so.1.0 \;
cd ../framework && /var/wazuh-manager/framework/python/bin/python3 -m pip install . --use-pep517 --prefix=/var/wazuh-manager/framework/python && rm -rf build/
Processing ./.
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: wazuh
  Building wheel for wazuh (pyproject.toml) ... done
  Created wheel for wazuh: filename=wazuh-5.0.0-py3-none-any.whl size=289030 sha256=6921ced12afccbbc0c8ee089cd1b6117c9f197ec918e9043c4c0800aff6398e0
  Stored in directory: /tmp/pip-ephem-wheel-cache-_yv4evw2/wheels/d0/a0/5b/ec6d654f16af27945f6196843277c1333ef1f7d7cbee0944d6
Successfully built wazuh
Installing collected packages: wazuh
Successfully installed wazuh-5.0.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.

[notice] A new release of pip is available: 26.1 -> 26.1.2
[notice] To update, run: /var/wazuh-manager/framework/python/bin/python3 -m pip install --upgrade pip
chown -R root:wazuh-manager /var/wazuh-manager/framework/python
chmod -R o=- /var/wazuh-manager/framework/python
cd ../api && /var/wazuh-manager/framework/python/bin/python3 -m pip install . --use-pep517 --prefix=/var/wazuh-manager/framework/python && rm -rf build/
Processing ./.
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: api
  Building wheel for api (pyproject.toml) ... done
  Created wheel for api: filename=api-5.0.0-py3-none-any.whl size=102474 sha256=00ff8ad79ab7b252fabfe0ee29cc198e5411b496f03d35ea76c08a6969db7d2d
  Stored in directory: /tmp/pip-ephem-wheel-cache-3h5lrptu/wheels/26/26/02/106c76a98f584faf72026c08b574a73b643c428c8fc38f1dbc
Successfully built api
Installing collected packages: api
Successfully installed api-5.0.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.

[notice] A new release of pip is available: 26.1 -> 26.1.2
[notice] To update, run: /var/wazuh-manager/framework/python/bin/python3 -m pip install --upgrade pip
cd ../tools/mitre && /var/wazuh-manager/framework/python/bin/python3 mitredb.py -d /var/wazuh-manager/var/db/mitre.db
Generating schema files...
Loading resources...
Loading WCS files from directory external/wcs-flat-files/...
Found 1 YAML files to merge: ['wcs_flat.yml']
Loading wcs_flat.yml...
Successfully merged 1 files into temporary file: /tmp/merged_wcs_rjyjdwpp.yml
Loading schema template...
Loading logpar overrides template...
Generating geo/as enrichment map...
Success.
Generating enrichment sources config...
Success.
Building field tree from WCS definition...
Success.
Generating engine schema...
Generating fields schema properties...
Success.
Generating clean properties mapping...
Success.
Generating logpar configuration...
Success.
Cleaned up temporary file: /tmp/merged_wcs_rjyjdwpp.yml
Saving files to "engine/ruleset/schemas/"...
Generated wazuh-decoders.json
Success.
Schema files generated successfully.
Copying store files...
Engine store installed successfully.
Engine output configuration files installed successfully.
Installing GeoIP databases...
GeoIP databases installed successfully.
Installing timezone database...
Timezone database installed successfully.
Generating self-signed certificate for wazuh-manager-authd...


 - System is Debian (Ubuntu or derivative).
 - Init script modified to start Wazuh during boot.
Starting Wazuh...
manager
Starting Wazuh v5.0.0...
Started wazuh-manager-apid...
Started wazuh-manager-authd...
Started wazuh-manager-db...
Started wazuh-manager-analysisd...
Started wazuh-manager-remoted...
Started wazuh-manager-monitord...
Started wazuh-manager-modulesd...
Started wazuh-manager-clusterd...
Completed.

 - Configuration finished properly.

 - To start Wazuh:
      /var/wazuh-manager/bin/wazuh-manager-control start

 - To stop Wazuh:
      /var/wazuh-manager/bin/wazuh-manager-control stop

 - The configuration can be viewed or modified at /var/wazuh-manager/etc/wazuh-manager.conf


 - In order to connect agent and manager, you need to add each agent to the manager.

   More information at: 
   https://documentation.wazuh.com/
```



#### Check jemalloc 
```
(venv) ╭─root@89ebd703d7af /workspaces/devContainer/wazuh ‹bug/37682-jemalloc-leaks-into-too-much-daemons› 
╰─# for f in /var/wazuh-manager/bin/*; do
    [ -x "$f" ] || continue
    echo "==> $f"
    ldd "$f" | grep jemalloc
done
==> /var/wazuh-manager/bin/agent_groups
        not a dynamic executable
==> /var/wazuh-manager/bin/agent_upgrade
        not a dynamic executable
==> /var/wazuh-manager/bin/cluster_control
        not a dynamic executable
==> /var/wazuh-manager/bin/rbac_control
        not a dynamic executable
==> /var/wazuh-manager/bin/verify-agent-conf
==> /var/wazuh-manager/bin/wazuh-manager-analysisd
        libjemalloc.so.2 => /workspaces/devContainer/wazuh/src/external/jemalloc/lib/libjemalloc.so.2 (0x00007fe7dd800000)
==> /var/wazuh-manager/bin/wazuh-manager-apid
        not a dynamic executable
==> /var/wazuh-manager/bin/wazuh-manager-authd
        libjemalloc.so.2 => /workspaces/devContainer/wazuh/src/external/jemalloc/lib/libjemalloc.so.2 (0x00007f066b600000)
==> /var/wazuh-manager/bin/wazuh-manager-clusterd
        not a dynamic executable
==> /var/wazuh-manager/bin/wazuh-manager-control
        not a dynamic executable
==> /var/wazuh-manager/bin/wazuh-manager-db
        libjemalloc.so.2 => /workspaces/devContainer/wazuh/src/external/jemalloc/lib/libjemalloc.so.2 (0x00007f710bc00000)
==> /var/wazuh-manager/bin/wazuh-manager-keystore
==> /var/wazuh-manager/bin/wazuh-manager-modulesd
        libjemalloc.so.2 => /workspaces/devContainer/wazuh/src/external/jemalloc/lib/libjemalloc.so.2 (0x00007f5d92c00000)
==> /var/wazuh-manager/bin/wazuh-manager-monitord
        libjemalloc.so.2 => /workspaces/devContainer/wazuh/src/external/jemalloc/lib/libjemalloc.so.2 (0x00007fc217400000)
==> /var/wazuh-manager/bin/wazuh-manager-remoted
        libjemalloc.so.2 => /workspaces/devContainer/wazuh/src/external/jemalloc/lib/libjemalloc.so.2 (0x00007f511ce00000)

```



### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
