### PR TITLE
Prevent spurious CRITICAL (1211) queue error during rootcheck/FIM shutdown on WPK upgrade

### DIFF
--- a/src/rootcheck/run_rk_check.c
+++ b/src/rootcheck/run_rk_check.c
@@ -45,10 +45,21 @@ int notify_rk(int rk_type, const char *msg)
         mtdebug1(ARGV0, QUEUE_SEND);
 
         if ((rootcheck.queue = StartMQPredicated(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS, fim_shutdown_process_on)) < 0) {
+            /* StartMQPredicated aborts the reconnection when a shutdown is in
+             * progress: the queue being unavailable is expected in that case,
+             * so exit quietly instead of reporting a fatal error (1211). */
+            if (fim_shutdown_process_on()) {
+                mtdebug1(ARGV0, "Rootcheck queue unavailable during shutdown. Skipping notification.");
+                return (0);
+            }
             mterror_exit(ARGV0, QUEUE_FATAL, DEFAULTQUEUE);
         }
 
         if (SendMSG(rootcheck.queue, msg, ROOTCHECK, ROOTCHECK_MQ) < 0) {
+            if (fim_shutdown_process_on()) {
+                mtdebug1(ARGV0, "Rootcheck queue unavailable during shutdown. Skipping notification.");
+                return (0);
+            }
             mterror_exit(ARGV0, QUEUE_FATAL, DEFAULTQUEUE);
         }
     }

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -83,6 +83,13 @@ STATIC void fim_send_msg(char mq, const char * location, const char * msg) {
         mdebug1(QUEUE_SEND);
 
         if ((syscheck.queue = StartMQPredicated(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS, fim_shutdown_process_on)) < 0) {
+            /* StartMQPredicated aborts the reconnection when a shutdown is in
+             * progress: the queue being unavailable is expected in that case,
+             * so return quietly instead of reporting a fatal error (1211). */
+            if (fim_shutdown_process_on()) {
+                mdebug1("FIM queue unavailable during shutdown. Skipping message.");
+                return;
+            }
             merror_exit(QUEUE_FATAL, DEFAULTQUEUE);
         }
 

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -254,7 +254,8 @@ set(RUN_CHECK_BASE_FLAGS "-Wl,--wrap,sleep -Wl,--wrap,SendMSGPredicated -Wl,--wr
 
 list(APPEND syscheckd_tests_names "run_check")
 if(${TARGET} STREQUAL "agent")
-  list(APPEND syscheckd_tests_flags "${RUN_CHECK_BASE_FLAGS} -Wl,--wrap=sleep -Wl,--wrap,time")
+  list(APPEND syscheckd_tests_flags "${RUN_CHECK_BASE_FLAGS} -Wl,--wrap=sleep -Wl,--wrap,time \
+                                     -Wl,--wrap,StartMQPredicated -Wl,--wrap,SendMSG")
 elseif(${TARGET} STREQUAL "winagent")
   list(APPEND syscheckd_tests_flags "${RUN_CHECK_BASE_FLAGS} -Wl,--wrap=realtime_start \
                                      -Wl,--wrap,WaitForSingleObjectEx -Wl,--wrap,pthread_rwlock_rdlock \

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -284,7 +284,8 @@ elseif(${TARGET} STREQUAL "winagent")
                                                                    -Wl,--wrap=_imp__rsync_initialize \
                                                                    -Wl,--wrap=fim_db_teardown")
 else()
-  list(APPEND syscheckd_tests_flags "${RUN_CHECK_BASE_FLAGS} -Wl,--wrap=sleep,--wrap,time")
+  list(APPEND syscheckd_tests_flags "${RUN_CHECK_BASE_FLAGS} -Wl,--wrap=sleep,--wrap,time \
+                                     -Wl,--wrap,StartMQPredicated -Wl,--wrap,SendMSG")
 endif()
 
 # Compiling tests

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -1115,6 +1115,10 @@ void test_fim_db_remove_validated_path(void **state){
 void test_fim_send_msg_shutdown_skips_fatal(void **state) {
     (void) state;
 
+    /* tolerate any incidental mutex traffic in the exercised path */
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
+
     is_fim_shutdown = false;                 /* passes the early shutdown check */
 
     /* The send fails, so the reconnection branch is taken. */
@@ -1136,6 +1140,10 @@ void test_fim_send_msg_shutdown_skips_fatal(void **state) {
 
 void test_notify_rk_shutdown_skips_fatal(void **state) {
     (void) state;
+
+    /* tolerate any incidental mutex traffic in the exercised path */
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
 
     rootcheck.notify = QUEUE;
     rootcheck.queue = 1;

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -40,6 +40,8 @@ void set_whodata_mode_changes();
 
 /* External 'static' functions prototypes */
 void fim_send_msg(char mq, const char * location, const char * msg);
+/* rootcheck notification, compiled into the same binary through ROOTCHECK_O */
+int notify_rk(int rk_type, const char *msg);
 #ifdef WIN32
 DWORD WINAPI fim_run_realtime(__attribute__((unused)) void * args);
 
@@ -78,6 +80,21 @@ time_t __wrap_time(time_t *timer) {
 
 
 extern bool fim_shutdown_process_on();
+extern bool is_fim_shutdown;
+
+#ifndef TEST_WINAGENT
+/* Local wrap of StartMQPredicated used by the issue #37646 regression tests.
+ * It models the shutdown race: the shutdown flag flips to true while the queue
+ * reconnection is being attempted, then the (mocked) result is returned. */
+int __wrap_StartMQPredicated(__attribute__((unused)) const char *path,
+                             __attribute__((unused)) short int type,
+                             __attribute__((unused)) short int n_attempts,
+                             __attribute__((unused)) bool (*fn_ptr)(void)) {
+    is_fim_shutdown = true;
+    return mock_type(int);
+}
+#endif
+
 /* Setup/Teardown */
 
 static int setup_group(void ** state) {
@@ -1090,6 +1107,58 @@ void test_fim_db_remove_validated_path(void **state){
     fim_db_remove_validated_path(path, &mock_data);
 }
 
+#ifndef TEST_WINAGENT
+/* Regression tests for issue #37646: a queue that is unreachable because the
+ * agent is shutting down must be handled as expected (debug + clean return),
+ * not as a fatal error (CRITICAL 1211 + *_exit). */
+void test_fim_send_msg_shutdown_skips_fatal(void **state) {
+    (void) state;
+
+    is_fim_shutdown = false;                 /* passes the early shutdown check */
+
+    /* The send fails, so the reconnection branch is taken. */
+    expect_SendMSGPredicated_call("test message", "test location", 'a', fim_shutdown_process_on, -1);
+    expect_string(__wrap__mdebug1, formatted_msg, QUEUE_SEND);
+
+    /* StartMQPredicated aborts the reconnection because a shutdown is in progress
+     * (our wrap flips is_fim_shutdown to true) and returns OS_INVALID. */
+    will_return(__wrap_StartMQPredicated, -1);
+
+    /* The guard must log at debug and return WITHOUT calling merror_exit
+     * (no expect for __wrap__merror_exit -> the test aborts if it is called). */
+    expect_string(__wrap__mdebug1, formatted_msg, "FIM queue unavailable during shutdown. Skipping message.");
+
+    fim_send_msg('a', "test location", "test message");
+
+    is_fim_shutdown = false;
+}
+
+void test_notify_rk_shutdown_skips_fatal(void **state) {
+    (void) state;
+
+    rootcheck.notify = QUEUE;
+    rootcheck.queue = 1;
+    is_fim_shutdown = false;
+
+    /* First send fails -> reconnection branch. */
+    expect_SendMSG_call("test message", ROOTCHECK, ROOTCHECK_MQ, -1);
+    expect_string(__wrap__mtdebug1, tag, "rootcheck");
+    expect_string(__wrap__mtdebug1, formatted_msg, QUEUE_SEND);
+
+    /* StartMQPredicated aborts because of the shutdown -> OS_INVALID. */
+    will_return(__wrap_StartMQPredicated, -1);
+
+    /* The guard must log at debug and return 0 WITHOUT calling mterror_exit. */
+    expect_string(__wrap__mtdebug1, tag, "rootcheck");
+    expect_string(__wrap__mtdebug1, formatted_msg, "Rootcheck queue unavailable during shutdown. Skipping notification.");
+
+    int ret = notify_rk(ALERT_ROOTKIT_FOUND, "test message");
+    assert_int_equal(ret, 0);
+
+    is_fim_shutdown = false;
+}
+#endif
+
 int main(void) {
 #ifndef WIN_WHODATA
     const struct CMUnitTest tests[] = {
@@ -1124,6 +1193,9 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_fim_link_silent_scan, setup_symbolic_links, teardown_symbolic_links),
         cmocka_unit_test_setup_teardown(test_fim_link_reload_broken_link_already_monitored, setup_symbolic_links, teardown_symbolic_links),
         cmocka_unit_test_setup_teardown(test_fim_link_reload_broken_link_reload_broken, setup_symbolic_links, teardown_symbolic_links),
+        /* issue #37646: shutdown-skip guard must avoid the fatal QUEUE (1211) path */
+        cmocka_unit_test(test_fim_send_msg_shutdown_skips_fatal),
+        cmocka_unit_test(test_notify_rk_shutdown_skips_fatal),
 #else
         cmocka_unit_test_setup_teardown(test_fim_run_realtime_w_first_timeout, setup_hash, teardown_hash),
         cmocka_unit_test_setup_teardown(test_fim_run_realtime_w_wait_success, setup_hash, teardown_hash),

--- a/src/unit_tests/syscheckd/test_run_check.c
+++ b/src/unit_tests/syscheckd/test_run_check.c
@@ -30,6 +30,7 @@
 #include "../syscheckd/include/syscheck.h"
 #include "../syscheckd/src/db/include/db.h"
 #include "../config/syscheck-config.h"
+#include "../rootcheck/rootcheck.h"   /* rootcheck global, QUEUE, ROOTCHECK, ALERT_* for notify_rk test (#37646) */
 
 #ifdef TEST_WINAGENT
 #include "../wrappers/windows/processthreadsapi_wrappers.h"


### PR DESCRIPTION
## Description

This PR fixes a spurious `rootcheck: CRITICAL: (1211): Unable to access queue` error that is logged when the agent shuts down (e.g. during a WPK upgrade) while a rootcheck/FIM scan is still sending. The upgrade succeeds, but the CRITICAL pollutes `ossec.log`. Root cause is pre-existing since v4.14.1 (commit `d1e6574d50`), not a 4.14.7/4.14.8 regression.

**Proposed Release:** v4.14.8
**Issue:** wazuh/wazuh#37646
**Internal Reference:** N/A

## Proposed Changes

- Updated `src/rootcheck/run_rk_check.c` (`notify_rk`) and `src/syscheckd/src/run_check.c` (`fim_send_msg`).
- Fixed: `StartMQPredicated()` already aborts the queue reconnect when `fim_shutdown_process_on()` is true, but the callers still treated its `OS_INVALID` return as fatal, calling `*_exit(QUEUE_FATAL)` and logging `CRITICAL (1211)`. The fix guards those exits: if a shutdown is in progress, log at debug and return cleanly instead of exiting fatally.
- Completes the intent of `d1e6574d50` ("fixed syscheckd shutdown when disconnected"), which introduced the predicated reconnect in v4.14.1 but left the fatal-exit path reachable during shutdown.

### Results and Evidence

Validated on an Ubuntu 26.04 (amd64) agent (systemd-managed) against Wazuh Manager v4.14.6.

**(A) Deterministic A/B on the `wazuh-syscheckd` binary**, same harness that forces the exact shutdown interleaving the WPK double-restart produces (kill `wazuh-agentd` mid rootcheck/FIM scan, then `SIGTERM wazuh-syscheckd`), run against the original vs the patched binary:

```bash
# CONTROL: original binary (md5 19d18860...): bug reproduces at the guarded line
2026/07/15 07:05:32 wazuh-syscheckd[9702] run_check.c:86 at fim_send_msg(): CRITICAL: (1211): Unable to access queue: 'queue/sockets/queue'. Giving up.

# TREATMENT: patched binary (md5 d2afb9c7...): 0 CRITICAL over 12 rounds; the guard
# executes instead (both FIM and rootcheck paths) and the daemon shuts down cleanly:
2026/07/15 07:12:24 rootcheck[12412] run_rk_check.c:52 at notify_rk(): DEBUG: Rootcheck queue unavailable during shutdown. Skipping notification.
2026/07/15 07:12:28 wazuh-syscheckd[12412] run_check.c:90 at fim_send_msg(): DEBUG: FIM queue unavailable during shutdown. Skipping message.
```

Control: 1 CRITICAL (round 1). Treatment: **0 / 12 rounds**, guard fired 5x.

**(B) Real `agent_upgrade` before/after**: the fix was also validated through genuine WPK upgrades (no forced kills). The upgrade itself performs a **double restart** (the `.deb` postinst `systemctl restart` + `pkg_installer.sh`'s `wazuh-control restart`, ~20s apart); the 2nd restart kills the rootcheck/FIM scan the 1st started:

```bash
# BEFORE (stock binary): natural agent_upgrade reproduces the issue's rootcheck-tagged CRITICAL:
2026/07/15 09:38:59 rootcheck: CRITICAL: (1211): Unable to access queue: 'queue/sockets/queue'. Giving up.

# AFTER (patched binary, delivered via a patched WPK): 3 consecutive real agent_upgrade -f runs:
CRITICAL (1211) count = 0
```

The upgrade completes successfully and the agent reconnects normally in every case; the fix only removes the spurious CRITICAL.

### Artifacts Affected

- `src/rootcheck/run_rk_check.c`
- `src/syscheckd/src/run_check.c`
- `src/unit_tests/syscheckd/test_run_check.c`
- `src/unit_tests/syscheckd/CMakeLists.txt`

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Unit tests + manual reproduction (real `agent_upgrade` and forced-interleaving A/B).
- **Details:** Added two cmocka unit tests in `test_run_check.c` covering the shutdown-skip guard:
  - `test_fim_send_msg_shutdown_skips_fatal` (`fim_send_msg()`)
  - `test_notify_rk_shutdown_skips_fatal` (`notify_rk()`)

  Each drives the reconnection-failure branch with the shutdown flag set (a local `__wrap_StartMQPredicated` flips `is_fim_shutdown` mid-reconnect, modeling the race) and asserts the function logs at debug and returns without calling `merror_exit`/`mterror_exit`. Manually validated end-to-end via real WPK `agent_upgrade` (before/after) and a deterministic binary A/B (see Results and Evidence).

## Review Checklist

**Manual tests with their corresponding evidence:**

- Compilation without warnings on every supported platform

    - [ ] Linux
    - [ ] Windows
    - [ ] MAC OS X

- [ ] Log syntax and correct language review

- Memory tests for Linux

    - [ ] Coverity
    - [ ] Valgrind (memcheck and descriptor leaks check)
    - [ ] AddressSanitizer

**General Checklist:**

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues