### PR TITLE
Improve access control on the agent active-configuration endpoint

### DIFF
--- a/framework/wazuh/core/agent.py
+++ b/framework/wazuh/core/agent.py
@@ -1151,6 +1151,8 @@ class Agent:
 
         Raises
         ------
+        WazuhError(1703)
+            Action not available for manager (000).
         WazuhError(1735)
             The agent version is older than the minimum required version.
 
@@ -1159,6 +1161,9 @@ class Agent:
         dict
             Agent's active configuration.
         """
+        if self.id == '000':
+            raise WazuhError(1703)
+
         if WazuhVersion(agent_version) < WazuhVersion(common.ACTIVE_CONFIG_VERSION):
             raise WazuhInternalError(1735, extra_message=f"Minimum required version is {common.ACTIVE_CONFIG_VERSION}")
 

--- a/framework/wazuh/core/tests/test_agent.py
+++ b/framework/wazuh/core/tests/test_agent.py
@@ -1222,6 +1222,11 @@ def test_agent_get_config_ko(socket_mock, send_mock, mock_wazuh_socket):
     with pytest.raises(WazuhInternalError, match=".* 1735 .*"):
         agent.get_config('com', 'active-response', 'Wazuh v3.6.0')
 
+    # Action not available for manager (000)
+    agent = Agent('000')
+    with pytest.raises(WazuhError, match=".* 1703 .*"):
+        agent.get_config('auth', 'auth', 'Wazuh v4.0.0')
+
 
 @patch('wazuh.core.wazuh_socket.WazuhSocket')
 @patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)

--- a/framework/wazuh/tests/test_agent.py
+++ b/framework/wazuh/tests/test_agent.py
@@ -1326,6 +1326,17 @@ def test_agent_get_agent_config_exceptions(socket_mock, send_mock, agent_list):
         assert error == WazuhError(1740)
 
 
+@patch('wazuh.core.wdb.WazuhDBConnection._send', side_effect=send_msg_to_wdb)
+@patch('socket.socket.connect')
+def test_agent_get_agent_config_manager_forbidden(socket_mock, send_mock):
+    """Test `get_agent_config` function from agent module raises WazuhError(1703) for agent id '000'."""
+    try:
+        get_agent_config(agent_list=['000'], component='auth', config='auth')
+        pytest.fail('An exception should be raised.')
+    except WazuhError as error:
+        assert error == WazuhError(1703)
+
+
 @pytest.mark.parametrize('agent_list', [
     full_agent_list[1:]
 ])


### PR DESCRIPTION
## Description
`GET /agents/000/config/{component}/{configuration}` allowed any user with `agent:read` (including the stock `readonly` role) to read the manager's active configuration for agent ID `000`, the reserved pseudo-agent representing the manager itself. When `auth.use_password` is `yes`, this returned the contents of `etc/authd.pass` in plaintext, unlike the equivalent `GET /manager/configuration/...` endpoint, which masks it. The fix adds the same `id == '000'` guard already used in `Agent.get_key()` and `Agent.remove_agent_from_group()` to `Agent.get_config()`, rejecting the manager pseudo-agent with `WazuhError(1703)`.

## Proposed Changes
- `framework/wazuh/core/agent.py`: `Agent.get_config()` now raises `WazuhError(1703)` when `self.id == '000'`, before querying the active configuration.
- `framework/wazuh/core/tests/test_agent.py`: added a case to `test_agent_get_config_ko` asserting `Agent('000').get_config(...)` raises `WazuhError(1703)`.
- `framework/wazuh/tests/test_agent.py`: added `test_agent_get_agent_config_manager_forbidden`, an end-to-end test asserting `get_agent_config(agent_list=['000'], ...)` raises `WazuhError(1703)`.

### Results and Evidence
- Live reproduction against a local Wazuh manager (4.14.6-based, `use_password: yes`, `authd.pass` present) confirmed the leak pre-fix: an API user holding only the stock `readonly` role received `"authd.pass": "helloWorld"` in plaintext from `GET /agents/000/config/auth/auth`, while `GET /manager/configuration/auth/auth` correctly returned `"authd.pass": "*****"`.
- Post-fix, the same request to `GET /agents/000/config/auth/auth` returns `WazuhError(1703)` ("Action not available for Manager (agent 000)"), while `GET /manager/configuration/auth/auth` continues to work unaffected.
- A real enrolled agent (agent 003) was also tested for comparison and does not expose the `auth` component locally, confirming the leak is specific to ID `000`.
- New/updated unit tests were confirmed to fail before the fix and pass after it.
- Full `wazuh/core/tests/test_agent.py` (147 tests), `wazuh/tests/test_agent.py` (132 tests), and the active-response test suites (29 tests) pass with no regressions.

### Artifacts Affected
- `framework/wazuh/core/agent.py` (Wazuh Python framework, `wazuh-apid` component).

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
- `test_agent_get_config_ko` (updated) in `framework/wazuh/core/tests/test_agent.py`.
- `test_agent_get_agent_config_manager_forbidden` (new) in `framework/wazuh/tests/test_agent.py`.

## Credits

Reported by @5kr1pt.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
