### PR TITLE
fix: three non-security reliability bugs (rocksDB queue error msg, AWS Config sort crash, AWS discard filter)

### DIFF
--- a/src/shared_modules/utils/rocksDBQueue.hpp
+++ b/src/shared_modules/utils/rocksDBQueue.hpp
@@ -269,7 +269,7 @@ public:
             {
                 if (status != rocksdb::Status::NotFound())
                 {
-                    throw std::runtime_error("Failed to get elements, error: " + status.code());
+                    throw std::runtime_error("Failed to get elements, error: " + std::to_string(status.code()));
                 }
             }
             ++index;

--- a/wodles/aws/buckets_s3/config.py
+++ b/wodles/aws/buckets_s3/config.py
@@ -154,7 +154,11 @@ class AWSConfigBucket(aws_bucket.AWSLogsBucket):
 
         filtered_files = super()._filter_bucket_files(bucket_files, **kwargs)
 
-        sorted_files = sorted(filtered_files, key=lambda x: extract_date_from_key(x['Key']))
+        # extract_date_from_key returns None for keys without a /YYYY/M/D/ segment
+        # (e.g. AWS Config writability-check objects). Fall back to datetime.min so the
+        # sort key is totally ordered; comparing datetime to None raises TypeError and
+        # aborts the whole Config ingestion run.
+        sorted_files = sorted(filtered_files, key=lambda x: extract_date_from_key(x['Key']) or datetime.min)
 
         if self.only_logs_after is None:
             for sorted_file in sorted_files:

--- a/wodles/aws/wazuh_integration.py
+++ b/wodles/aws/wazuh_integration.py
@@ -76,7 +76,11 @@ class WazuhIntegration:
                                       )
 
         self.discard_field = discard_field
-        self.discard_regex = re.compile(fr'{discard_regex}')
+        # When no discard regex is configured, compile a pattern that never matches
+        # so no event is filtered. Interpolating a None value with fr'{discard_regex}'
+        # compiles the literal 'None', which silently discards any event whose text
+        # begins with "None".
+        self.discard_regex = re.compile(discard_regex if discard_regex is not None else r'(?!)')
         # to fetch logs using this date if no only_logs_after value was provided on the first execution
         self.default_date = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
 


### PR DESCRIPTION
## Description

This pull request fixes three independent, non-security reliability bugs found while auditing the codebase. None of them are security vulnerabilities; each is a small, self-contained correctness fix. They are grouped here for convenience and can be split on request.

## Proposed Changes

**Bugs fixed**

1. **`src/shared_modules/utils/rocksDBQueue.hpp` — garbled error message (undefined behavior).**
   In `front()`, the error path built its message with `"Failed to get elements, error: " + status.code()`. Because `status.code()` is an unscoped enum that promotes to `int`, this is `const char* + int` (pointer arithmetic on the string literal), not string concatenation — it offsets into/past the literal instead of appending the code. The sibling call site (`getElements`, line 241) already does it correctly. Fixed to `+ std::to_string(status.code())`.

2. **`wodles/aws/buckets_s3/config.py` — AWS Config ingestion aborts with `TypeError`.**
   `_filter_bucket_files` sorts objects by a date extracted from the key, but `extract_date_from_key` returns `None` for keys without a `/YYYY/M/D/` segment (e.g. AWS Config `ConfigWritabilityCheckFile` objects). `sorted()` then compares `datetime` to `None`, raising `TypeError: '<' not supported between instances of 'datetime.datetime' and 'NoneType'`, which aborts the whole Config run. Note the sibling filter loop already guards for `None` (`if file_date and ...`) but the sort key did not. Fixed by making the sort key total (`... or datetime.min`).

3. **`wodles/aws/wazuh_integration.py` — events silently discarded when no discard regex is configured.**
   `self.discard_regex = re.compile(fr'{discard_regex}')` compiles the literal string `'None'` when `discard_regex` is `None` (the default). The subscriber plaintext path then applies it unconditionally, so any event whose text begins with `None` is silently dropped even though the operator never enabled discard filtering — real event loss. Fixed by compiling a never-matching pattern (`r'(?!)'`) when unconfigured, preserving the "always a compiled Pattern" invariant the rest of the module relies on (e.g. `.pattern` accesses in debug messages).

### Results and Evidence

- Bug 3 behavior was confirmed in isolation: `re.compile('None')` matches `"None"`, `"Nothing"`, etc.; `re.compile(r'(?!)')` matches nothing. So the fix stops the spurious discard while leaving a genuinely configured regex unchanged.
- Bug 2: `extract_date_from_key` returns `None` for a key such as `AWSLogs/<account>/Config/<region>/ConfigWritabilityCheckFile/...`; the added `or datetime.min` fallback makes the sort total-ordered, and such files remain correctly filtered by the existing `if file_date` guard in the `only_logs_after` branch.
- Bug 1: matches the already-correct sibling call site in the same file.

### Manual tests with their corresponding evidence

I do not have access to the full multi-platform build/test infrastructure, so the checks below are left unchecked and were **not** run locally. They should be validated by CI / reviewers.

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] N/A

- Engine _(Wazuh v5.x and above)_
  - [ ] N/A (no engine code changed)

- Wazuh server API/Framework
  - [ ] N/A (no API/Framework code changed)

### Artifacts Affected

- `wazuh-db` shared_modules RocksDB queue utility (header-only; affects any component using `RocksDBQueue::front()` error path).
- AWS integration wodle (`wodles/aws`): the `aws-s3` module (Config bucket type and the S3 subscriber plaintext path).

### Configuration Changes

N/A — no new configuration parameters and no changes to default values. Behavior only changes on previously-broken paths (crash avoided; events no longer wrongly discarded when no `discard_regex` is set).

### Tests Introduced

N/A in this PR. The fixes are minimal; I can add unit tests for the AWS wodle paths (Config sort with a non-dated key; subscriber discard with an unconfigured regex) if the maintainers would like them.

## Review Checklist

- [x] Code changes reviewed (self-review)
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented (N/A)
- [ ] Developer documentation reflects the changes (N/A)
- [ ] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
