### PR TITLE
Fixed error 1603 to allow the Windows agent to be uninstalled following the latest hotfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ All notable changes to this project will be documented in this file.
 
 - Fixed AES connection getting reset to blowfish on keystore rebuild. ([#37524](https://github.com/wazuh/wazuh/pull/37524))
 
+### Agent
+
+#### Fixed
+
+- Fixed Windows agent uninstallation failing with error 1603 on systems with the June 2026 Windows cumulative updates installed. ([#37719](https://github.com/wazuh/wazuh/pull/37719))
+
 ### Ruleset
 
 #### Fixed

--- a/src/win32/RemoveAllScript.vbs
+++ b/src/win32/RemoveAllScript.vbs
@@ -70,31 +70,15 @@ public function removeAll()
        Dim filesToKeep: filesToKeep = Array("ossec.conf.save", "client.keys.save", _
                                             "local_internal_options.conf.save", "installer.log.save")
 
-      ' Construct a simple dictionary to check out later whether a file is in
-      ' the list or not
-      Dim dicFiles: Set dicFiles = CreateObject("Scripting.Dictionary")
-      dicFiles.CompareMode = vbTextCompare
-      For Each x in filesToKeep
-         dicFiles.add x, x
-      Next
-
       ' Everything in the application's root folder will be deleted.
       ' *BUT*, the subfolders, and the files inside, specified here *will not* be deleted
       Dim subfoldersToKeep: subfoldersToKeep = Array("backup", "upgrade")
-
-      ' Construct a simple dictionary to check out later whether a subfolders is in
-      ' the list or not
-      Dim dicFolders: Set dicFolders = CreateObject("Scripting.Dictionary")
-      dicFolders.CompareMode = vbTextCompare
-      For Each x in subfoldersToKeep
-         dicFolders.add x, x
-      Next
 
       ' Delete the files in the root folder
       For Each f In folder.Files
          name = f.name
          ' Delete the file only if it is not in the list
-         If Not dicFiles.Exists(name) Then
+         If Not isNameInList(name, filesToKeep) Then
             On Error Resume Next
             f.Delete True
          End If
@@ -104,7 +88,7 @@ public function removeAll()
       For Each f In folder.SubFolders
          name = f.name
          ' Delete the file only if it is not in the list
-         If Not dicFolders.Exists(name) Then
+         If Not isNameInList(name, subfoldersToKeep) Then
             On Error Resume Next
             f.Delete True
          End If
@@ -115,3 +99,19 @@ public function removeAll()
    removeAll = 0
 
 End Function   'removeAll
+
+
+' Case-insensitive name lookup over a small array. Deliberately avoids
+' Scripting.Dictionary: the June 2026 Windows cumulative updates
+' (KB5094123 / KB5094128 and siblings) make Dictionary.Add raise a spurious
+' error 457 (0x800A01C9), which aborted the whole uninstall.
+private function isNameInList(strName, arrNames)
+   Dim item
+   isNameInList = False
+   For Each item In arrNames
+      If LCase(strName) = LCase(item) Then
+         isNameInList = True
+         Exit Function
+      End If
+   Next
+End Function


### PR DESCRIPTION
|Related issue|
|---|
|Closes #37634|

## Description

Windows agent uninstallation fails with error 1603 on systems that have installed the June 2026 Windows cumulative updates. The MSI verbose log points to `CustomAction_RemoveAllScript` (`src/win32/RemoveAllScript.vbs`) crashing with an unhandled VBScript runtime error 457 (`0x800A01C9`, "This key is already associated with an element of this collection") raised by `Scripting.Dictionary.Add`, even though the keys added are distinct string literals. Because this custom action runs at the `commit` phase (after the service and tracked files have already been removed), the failure also triggers Windows Installer's automatic rollback, which reinstalls the service and restores the removed files — so affected machines can end up unable to uninstall at all through Control Panel, `msiexec /x`, or the `RemoveExistingProducts` step of an in-place upgrade.

Closes #37634

## Proposed Changes

- Replaced both `Scripting.Dictionary`-based membership checks in `removeAll()` (`src/win32/RemoveAllScript.vbs`) with a new private helper, `isNameInList(strName, arrNames)`, that performs a simple case-insensitive linear scan (`LCase` comparison) over the existing keep-lists (`filesToKeep`, `subfoldersToKeep`).
- This removes the custom action's dependency on `CreateObject("Scripting.Dictionary")` / `.Add` entirely, so the OS-side regression in `Dictionary.Add` can no longer abort the uninstall.
- Behavior is unchanged for unaffected systems: the same files/subfolders continue to be preserved (`ossec.conf.save`, `client.keys.save`, `local_internal_options.conf.save`, `installer.log.save`, `backup/`, `upgrade/`), and everything else under the install root is still removed.
- Added a `CHANGELOG.md` entry under `Agent > Fixed`.

### Results and Evidence

- Reproduced the original failure on a Windows 11 VM (build 26200) with Wazuh Agent 4.14.4 installed, with the affected June 2026 updates applied:
  ```
  Error 1720. ... Custom action CustomAction_RemoveAllScript script error -2146827831,
  Microsoft VBScript runtime error: This key is already associated with an element of
  this collection Line 78, Column 10
  ...
  Product: Wazuh Agent -- Removal success or error status: 1603.
  ```
- Confirmed a temporary MSI transform that disables `CustomAction_RemoveAllScript` allows the uninstall to complete on the same VM, isolating the crash to this custom action.
- [ ] Pending: rebuild the MSI (WiX `candle`/`light`) with this change and attach the verbose log from a full uninstall on an affected/patched machine showing `Removal success or error status: 0`.

### Artifacts Affected

- `src/win32/RemoveAllScript.vbs` — VBScript compiled as a `Binary` stream into the Windows agent MSI (referenced from `wazuh-installer.wxs`), executed by `CustomAction_RemoveAllScript` on uninstall.
- Windows agent installer package (`wazuh-agent-*.msi`), built via `packages/windows/generate_wazuh_msi.ps1` — requires a rebuild to include this fix. No changes to the service, registry, or any other package artifact.

### Configuration Changes

None.

### Documentation Updates

- `CHANGELOG.md`: added an `Agent > Fixed` entry describing this fix (update the PR number placeholder once this PR is opened).

### Tests Introduced

- No automated test harness covers this VBScript custom action (it is compiled directly into the MSI via WiX, outside the existing C/Python unit test suites). Verification performed manually:
  - Reproduced the original failure on an affected Windows build.
  - Confirmed `isNameInList` preserves the original keep-list semantics for all six entries (`ossec.conf.save`, `client.keys.save`, `local_internal_options.conf.save`, `installer.log.save`, `backup`, `upgrade`), case-insensitively.
  - [ ] Pending: full install -> uninstall -> reinstall cycle on a rebuilt MSI, on a real patched Windows box.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided (original-failure log attached above)
- [ ] Tests cover the new functionality (manual only; rebuilt-MSI verification pending)
- [x] Configuration changes documented (none apply)
- [x] Developer documentation reflects the changes (CHANGELOG updated)
- [ ] Meets requirements and/or definition of done (pending rebuilt-MSI validation)
- [x] No unresolved dependencies with other issues
