### PR TITLE
Report manager-not-ready sync failures as deferred

### DIFF
--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
@@ -132,6 +132,14 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         /// @brief Default maximum events per second for synchronization operations
         size_t m_maxEps;
 
+        /// @brief Updates the consecutive-failure streak with the outcome of a synchronization.
+        /// @param success Whether the synchronization succeeded.
+        /// @param stopped Whether it was aborted because a stop was requested.
+        /// @return Consecutive failed synchronizations including this one, or 0 on success.
+        ///
+        /// A stop-induced abort leaves the streak untouched: it reports nothing about the manager.
+        unsigned int trackSyncOutcome(bool success, bool stopped);
+
         /// @brief Sends a start message to the server
         /// @param mode Sync mode
         /// @param dataSize Size of data to send
@@ -264,6 +272,12 @@ class AgentSyncProtocol : public IAgentSyncProtocol
             /// @brief Last sync operation result for detailed error reporting.
             SyncResult lastSyncResult = SyncResult::SUCCESS;
 
+            /// @brief True when the manager did not answer the handshake or reported itself Offline.
+            /// Set only where that condition is known, since a SyncResult value alone does not identify
+            /// it (COMMUNICATION_ERROR is also used for a local send failure in the middle of an
+            /// established session).
+            bool lastSyncManagerNotReady = false;
+
             /// @brief Destructor ensures all waiting threads are woken up before destruction.
             ///
             /// This prevents deadlocks when the condition variable is destroyed while threads are still waiting.
@@ -288,6 +302,7 @@ class AgentSyncProtocol : public IAgentSyncProtocol
                 phase = SyncPhase::Idle;
                 session = 0;
                 lastSyncResult = SyncResult::SUCCESS;
+                lastSyncManagerNotReady = false;
             }
         };
 
@@ -301,6 +316,14 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         /// in progress the second caller skips its cycle — the in-flight sync drains the
         /// shared queue, making the concurrent call redundant.
         std::atomic<bool> m_syncInProgress{false};
+
+        /// @brief Consecutive failed synchronizations for this module, reset on the first success.
+        ///
+        /// Lives on the instance, not in SyncState, because SyncState is cleared at the start of every
+        /// cycle. It is what tells a brief post-restart hiccup (the count stays at one and clears on the
+        /// next cycle) apart from a lasting condition such as the manager having no indexer available
+        /// (the count keeps growing), which the modules must keep reporting at WARNING.
+        std::atomic<unsigned int> m_consecutiveSyncFailures{0};
 };
 
 #endif // AGENT_SYNC_PROTOCOL_HPP

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
@@ -323,6 +323,17 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         /// cycle. It is what tells a brief post-restart hiccup (the count stays at one and clears on the
         /// next cycle) apart from a lasting condition such as the manager having no indexer available
         /// (the count keeps growing), which the modules must keep reporting at WARNING.
+        ///
+        /// The streak is counted in sync ATTEMPTS that reach the handshake, not in cycles, and it is
+        /// per protocol instance. When several sync flows share one instance (agent-info: metadata,
+        /// groups and the integrity check; FIM: the periodic and the agent-info-requested syncs;
+        /// SCA/Syscollector: the periodic sync and the flush), each of them bumps this same counter,
+        /// so the SYNC_MANAGER_NOT_READY_TOLERANCE threshold can be reached in fewer real cycles for
+        /// those modules than for a single-flow one. Only outcomes that reach the handshake move the
+        /// counter: early returns (queue-open failure, nothing-to-sync success, invalid mode) leave it
+        /// untouched, so "consecutive" is not strictly "consecutive cycles". This is acceptable because
+        /// managerNotReady is a manager-wide condition: a real success means the manager is ready, and
+        /// resetting the streak on it is correct regardless of which flow observed it.
         std::atomic<unsigned int> m_consecutiveSyncFailures{0};
 };
 

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface_types.h
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface_types.h
@@ -15,6 +15,14 @@
 
 #define SYNC_FAILURE_REASON_MAX_LEN 2048
 
+/// @brief Consecutive failed synchronizations tolerated before a module escalates a
+/// manager-not-ready failure from INFO to WARNING.
+///
+/// The first failures are expected while the manager is still not ready for this agent (mostly right
+/// after an agent restart) and clear on the next cycle. Beyond this many in a row the condition is not
+/// clearing on its own (for example the manager has no indexer available), so it must stay visible.
+#define SYNC_MANAGER_NOT_READY_TOLERANCE 3U
+
 #include "logging_helper.h"
 
 #ifdef __cplusplus
@@ -28,11 +36,18 @@ extern "C" {
 /// @var failure_reason Human-readable reason string when available; may be empty if no specific reason was recorded.
 /// @var stopped        true if the operation was aborted because a stop/shutdown was requested; lets the
 ///                     caller demote an expected shutdown-time failure from WARNING to INFO/DEBUG.
+/// @var manager_not_ready true if the manager did not answer the handshake, or answered that it cannot
+///                     serve this agent yet (Offline). Describes what happened, not whether it is
+///                     harmless: use it together with consecutive_failures to decide the log level.
+/// @var consecutive_failures number of consecutive failed synchronizations for this module, including
+///                     this one; reset to zero on the first success.
 typedef struct SyncModuleResult_t
 {
     bool success;
     char failure_reason[SYNC_FAILURE_REASON_MAX_LEN];
     bool stopped;
+    bool manager_not_ready;
+    unsigned int consecutive_failures;
 } SyncModuleResult_t;
 
 /// @brief Defines the type of modification operation.

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_types.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_types.hpp
@@ -36,4 +36,14 @@ struct SyncModuleResult
     /// Lets the calling module demote an expected shutdown-time failure from WARNING to
     /// INFO/DEBUG.
     bool stopped{false};
+    /// @brief True when the manager did not answer the handshake, or answered that it cannot serve
+    /// this agent yet (Offline). This describes what happened, not whether it is harmless: the same
+    /// condition covers a brief window after an agent restart and a lasting outage (for example the
+    /// manager having no indexer available). Use it together with @ref consecutiveFailures to decide
+    /// the log level.
+    bool managerNotReady{false};
+    /// @brief Number of consecutive failed synchronizations for this module, including this one.
+    /// Reset to zero on the first success. A single failure that recovers on the next cycle is an
+    /// expected hiccup; a growing count means the condition is not clearing and deserves a WARNING.
+    unsigned int consecutiveFailures{0};
 };

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -323,8 +323,28 @@ SyncModuleResult AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
     // shutdown-time failure from WARNING to INFO/DEBUG.
     // (shouldStop() reads m_stopRequested, which clearSyncState() does not touch.)
     const bool stopped = shouldStop();
+    const bool managerNotReady = m_syncState.lastSyncManagerNotReady;
+    const unsigned int consecutiveFailures = trackSyncOutcome(success, stopped);
     clearSyncState();
-    return {success, failureReason, stopped};
+    return {success, failureReason, stopped, managerNotReady, consecutiveFailures};
+}
+
+unsigned int AgentSyncProtocol::trackSyncOutcome(bool success, bool stopped)
+{
+    if (success)
+    {
+        m_consecutiveSyncFailures.store(0, std::memory_order_relaxed);
+        return 0;
+    }
+
+    // A sync aborted because the module is stopping says nothing about the manager, so it must not
+    // count towards the streak: the module is torn down on purpose and will start over on restart.
+    if (stopped)
+    {
+        return m_consecutiveSyncFailures.load(std::memory_order_relaxed);
+    }
+
+    return m_consecutiveSyncFailures.fetch_add(1, std::memory_order_relaxed) + 1;
 }
 
 bool AgentSyncProtocol::requiresFullSync(const std::string& index,
@@ -446,8 +466,10 @@ SyncModuleResult AgentSyncProtocol::synchronizeMetadataOrGroups(Mode mode,
     // shutdown-time failure from WARNING to INFO/DEBUG.
     // (shouldStop() reads m_stopRequested, which clearSyncState() does not touch.)
     const bool stopped = shouldStop();
+    const bool managerNotReady = m_syncState.lastSyncManagerNotReady;
+    const unsigned int consecutiveFailures = trackSyncOutcome(success, stopped);
     clearSyncState();
-    return {success, failureReason, stopped};
+    return {success, failureReason, stopped, managerNotReady, consecutiveFailures};
 }
 
 bool AgentSyncProtocol::notifyDataClean(const std::vector<std::string>& indices,
@@ -719,6 +741,9 @@ bool AgentSyncProtocol::sendStartAndWaitAck(Mode mode,
         {
             m_logger(LOG_DEBUG, "Exceeded maximum retries for Start message.");
             m_syncState.lastSyncResult = SyncResult::START_TIMEOUT_ERROR;
+            // The manager never acknowledged the handshake: expected while it is not ready for this
+            // agent yet (mostly right after a restart). The module retries on its next cycle.
+            m_syncState.lastSyncManagerNotReady = true;
         }
 
         return false;
@@ -1120,6 +1145,9 @@ bool AgentSyncProtocol::sendEndAndWaitAck(uint64_t session,
         {
             m_logger(LOG_DEBUG, "Exceeded maximum retries for End message.");
             m_syncState.lastSyncResult = SyncResult::END_TIMEOUT_ERROR;
+            // The manager never acknowledged the End message: same expected, self-recovering condition
+            // as the Start timeout above.
+            m_syncState.lastSyncManagerNotReady = true;
         }
 
         return false;
@@ -1175,6 +1203,9 @@ bool AgentSyncProtocol::parseResponseBuffer(const uint8_t* data, size_t length)
                             m_syncState.lastSyncResult = (startAck->status() == Wazuh::SyncSchema::Status::Offline)
                                                          ? SyncResult::COMMUNICATION_ERROR
                                                          : SyncResult::PROTOCOL_ERROR;
+                            // An Offline status means the manager itself reports it cannot serve this
+                            // agent yet: expected and self-recovering. An Error status is not.
+                            m_syncState.lastSyncManagerNotReady = (startAck->status() == Wazuh::SyncSchema::Status::Offline);
                             m_syncState.syncFailed = true;
                             m_syncState.cv.notify_all();
                             break;
@@ -1214,6 +1245,9 @@ bool AgentSyncProtocol::parseResponseBuffer(const uint8_t* data, size_t length)
                         if (endAck->status() == Wazuh::SyncSchema::Status::Offline)
                         {
                             m_syncState.lastSyncResult = SyncResult::COMMUNICATION_ERROR;
+                            // The manager reports it cannot serve this agent: same condition as the
+                            // Offline StartAck above.
+                            m_syncState.lastSyncManagerNotReady = true;
                             m_logger(LOG_DEBUG, "Received EndAck with Offline status. Aborting synchronization.");
                         }
                         else if (endAck->status() == Wazuh::SyncSchema::Status::ChecksumMismatch)

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol_c_interface.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol_c_interface.cpp
@@ -112,7 +112,7 @@ extern "C" {
     {
         try
         {
-            if (!handle) return {false, {}, false};
+            if (!handle) return {false, {}, false, false, 0};
 
             auto* wrapper = reinterpret_cast<AgentSyncProtocolWrapper*>(handle);
 
@@ -128,15 +128,19 @@ extern "C" {
 
             cResult.stopped = cppResult.stopped;
 
+            cResult.manager_not_ready = cppResult.managerNotReady;
+
+            cResult.consecutive_failures = cppResult.consecutiveFailures;
+
             return cResult;
         }
         catch (const std::exception& ex)
         {
-            return {false, {}, false};
+            return {false, {}, false, false, 0};
         }
         catch (...)
         {
-            return {false, {}, false};
+            return {false, {}, false, false, 0};
         }
     }
 
@@ -207,7 +211,7 @@ extern "C" {
     {
         try
         {
-            if (!handle || !indices || indices_count == 0) return {false, {}, false};
+            if (!handle || !indices || indices_count == 0) return {false, {}, false, false, 0};
 
             // Convert C array of strings to C++ vector
             std::vector<std::string> indices_vec;
@@ -222,7 +226,7 @@ extern "C" {
                 }
             }
 
-            if (indices_vec.empty()) return {false, {}, false};
+            if (indices_vec.empty()) return {false, {}, false, false, 0};
 
             auto* wrapper = reinterpret_cast<AgentSyncProtocolWrapper*>(handle);
 
@@ -240,15 +244,19 @@ extern "C" {
 
             cResult.stopped = cppResult.stopped;
 
+            cResult.manager_not_ready = cppResult.managerNotReady;
+
+            cResult.consecutive_failures = cppResult.consecutiveFailures;
+
             return cResult;
         }
         catch (const std::exception& ex)
         {
-            return {false, {}, false};
+            return {false, {}, false, false, 0};
         }
         catch (...)
         {
-            return {false, {}, false};
+            return {false, {}, false, false, 0};
         }
     }
 

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -535,6 +535,272 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleCountsConsecutiveFailures)
     EXPECT_GT(previous, SYNC_MANAGER_NOT_READY_TOLERANCE);
 }
 
+// An Offline StartAck means the manager itself reports it cannot serve this agent yet. That is the
+// manager-not-ready condition modules demote to INFO for the first few cycles, so it must be surfaced
+// in the result (not just the Start timeout case).
+TEST_F(AgentSyncProtocolTest, SynchronizeModuleOfflineStartAckReportsManagerNotReady)
+{
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    MQ_Functions mqFuncs =
+    {
+        .start = [](const char*, short int, short int) { return 0; },
+        .send_binary = [](int, const void*, size_t, const char*, char)
+        {
+            return 0;
+        }
+    };
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", mqFuncs, testLogger, std::chrono::seconds(syncEndDelay), std::chrono::seconds(max_timeout), retries, maxEps, mockQueue);
+
+    SyncModuleResult result;
+    std::thread syncThread([this, &result]()
+    {
+        std::vector<PersistedData> testData =
+        {
+            {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
+        };
+        EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+        .WillOnce(Return(testData));
+
+        result = protocol->synchronizeModule(Mode::DELTA);
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+
+    // StartAck with Offline status
+    flatbuffers::FlatBufferBuilder builder;
+    Wazuh::SyncSchema::StartAckBuilder startAckBuilder(builder);
+    startAckBuilder.add_status(Wazuh::SyncSchema::Status::Offline);
+    startAckBuilder.add_session(session);
+    auto startAckOffset = startAckBuilder.Finish();
+    auto message = Wazuh::SyncSchema::CreateMessage(
+                       builder,
+                       Wazuh::SyncSchema::MessageType::StartAck,
+                       startAckOffset.Union());
+    builder.Finish(message);
+    protocol->parseResponseBuffer(builder.GetBufferPointer(), builder.GetSize());
+
+    syncThread.join();
+
+    EXPECT_FALSE(result.success);
+    EXPECT_TRUE(result.managerNotReady);
+    EXPECT_EQ(result.consecutiveFailures, 1u);
+}
+
+// An Offline EndAck reports the same manager-not-ready condition once the session is already open.
+TEST_F(AgentSyncProtocolTest, SynchronizeModuleOfflineEndAckReportsManagerNotReady)
+{
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    MQ_Functions mqFuncs =
+    {
+        .start = [](const char*, short int, short int) { return 0; },
+        .send_binary = [](int, const void*, size_t, const char*, char)
+        {
+            return 0;
+        }
+    };
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", mqFuncs, testLogger, std::chrono::seconds(syncEndDelay), std::chrono::seconds(max_timeout), retries, maxEps, mockQueue);
+
+    SyncModuleResult result;
+    std::thread syncThread([this, &result]()
+    {
+        std::vector<PersistedData> testData =
+        {
+            {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
+        };
+        EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+        .WillOnce(Return(testData));
+
+        result = protocol->synchronizeModule(Mode::DELTA);
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+
+    // StartAck Ok to open the session
+    flatbuffers::FlatBufferBuilder startBuilder;
+    Wazuh::SyncSchema::StartAckBuilder startAckBuilder(startBuilder);
+    startAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
+    startAckBuilder.add_session(session);
+    auto startAckOffset = startAckBuilder.Finish();
+    auto startMessage = Wazuh::SyncSchema::CreateMessage(
+                            startBuilder,
+                            Wazuh::SyncSchema::MessageType::StartAck,
+                            startAckOffset.Union());
+    startBuilder.Finish(startMessage);
+    protocol->parseResponseBuffer(startBuilder.GetBufferPointer(), startBuilder.GetSize());
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+
+    // EndAck with Offline status
+    flatbuffers::FlatBufferBuilder endBuilder;
+    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
+    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Offline);
+    endAckBuilder.add_session(session);
+    auto endAckOffset = endAckBuilder.Finish();
+    auto endMessage = Wazuh::SyncSchema::CreateMessage(
+                          endBuilder,
+                          Wazuh::SyncSchema::MessageType::EndAck,
+                          endAckOffset.Union());
+    endBuilder.Finish(endMessage);
+    protocol->parseResponseBuffer(endBuilder.GetBufferPointer(), endBuilder.GetSize());
+
+    syncThread.join();
+
+    EXPECT_FALSE(result.success);
+    EXPECT_TRUE(result.managerNotReady);
+    EXPECT_EQ(result.consecutiveFailures, 1u);
+}
+
+// A timeout waiting for the EndAck (session opened, but the manager never acknowledges the End) is
+// the same self-recovering manager-not-ready condition as a Start timeout.
+TEST_F(AgentSyncProtocolTest, SynchronizeModuleEndTimeoutReportsManagerNotReady)
+{
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    MQ_Functions mqFuncs =
+    {
+        .start = [](const char*, short int, short int) { return 0; },
+        .send_binary = [](int, const void*, size_t, const char*, char)
+        {
+            return 0;
+        }
+    };
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", mqFuncs, testLogger, std::chrono::seconds(syncEndDelay), std::chrono::seconds(min_timeout), retries, maxEps, mockQueue);
+
+    SyncModuleResult result;
+    std::thread syncThread([this, &result]()
+    {
+        std::vector<PersistedData> testData =
+        {
+            {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
+        };
+        EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+        .WillOnce(Return(testData));
+
+        result = protocol->synchronizeModule(Mode::DELTA);
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+
+    // StartAck Ok to open the session, then never send the EndAck so the End wait times out.
+    flatbuffers::FlatBufferBuilder startBuilder;
+    Wazuh::SyncSchema::StartAckBuilder startAckBuilder(startBuilder);
+    startAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
+    startAckBuilder.add_session(session);
+    auto startAckOffset = startAckBuilder.Finish();
+    auto startMessage = Wazuh::SyncSchema::CreateMessage(
+                            startBuilder,
+                            Wazuh::SyncSchema::MessageType::StartAck,
+                            startAckOffset.Union());
+    startBuilder.Finish(startMessage);
+    protocol->parseResponseBuffer(startBuilder.GetBufferPointer(), startBuilder.GetSize());
+
+    syncThread.join();
+
+    EXPECT_FALSE(result.success);
+    EXPECT_TRUE(result.managerNotReady);
+    EXPECT_EQ(result.consecutiveFailures, 1u);
+}
+
+// A sync aborted because a stop was requested says nothing about the manager, so it must not add to
+// the consecutive-failure streak.
+TEST_F(AgentSyncProtocolTest, SynchronizeModuleStoppedDoesNotCountTowardsStreak)
+{
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    MQ_Functions mqFuncs =
+    {
+        .start = [](const char*, short int, short int) { return 0; },
+        .send_binary = [](int, const void*, size_t, const char*, char)
+        {
+            return 0;
+        }
+    };
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", mqFuncs, testLogger, std::chrono::seconds(syncEndDelay), std::chrono::seconds(min_timeout), retries, maxEps, mockQueue);
+
+    // First failure (Start timeout) puts the streak at 1.
+    protocol->persistDifferenceInMemory("memory_id_1", Operation::CREATE, "memory_index_1", "memory_data_1", 1);
+    SyncModuleResult firstFailure = protocol->synchronizeModule(Mode::FULL);
+    EXPECT_FALSE(firstFailure.success);
+    EXPECT_EQ(firstFailure.consecutiveFailures, 1u);
+
+    // A stop-aborted sync must leave the streak where it was.
+    protocol->stop();
+    protocol->persistDifferenceInMemory("memory_id_2", Operation::MODIFY, "memory_index_2", "memory_data_2", 2);
+    SyncModuleResult stoppedResult = protocol->synchronizeModule(Mode::FULL);
+    EXPECT_FALSE(stoppedResult.success);
+    EXPECT_TRUE(stoppedResult.stopped);
+    EXPECT_EQ(stoppedResult.consecutiveFailures, 1u);
+}
+
+// The first successful sync clears the streak, so a later manager-not-ready failure starts again at 1
+// and modules go back to reporting it at INFO instead of staying escalated.
+TEST_F(AgentSyncProtocolTest, SynchronizeModuleSuccessResetsConsecutiveFailures)
+{
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    MQ_Functions mqFuncs =
+    {
+        .start = [](const char*, short int, short int) { return 0; },
+        .send_binary = [](int, const void*, size_t, const char*, char)
+        {
+            return 0;
+        }
+    };
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", mqFuncs, testLogger, std::chrono::seconds(syncEndDelay), std::chrono::seconds(min_timeout), retries, maxEps, mockQueue);
+
+    // First failure (Start timeout) puts the streak at 1.
+    protocol->persistDifferenceInMemory("memory_id_1", Operation::CREATE, "memory_index_1", "memory_data_1", 1);
+    SyncModuleResult firstFailure = protocol->synchronizeModule(Mode::FULL);
+    EXPECT_FALSE(firstFailure.success);
+    EXPECT_EQ(firstFailure.consecutiveFailures, 1u);
+
+    // Second sync: drive a full successful handshake, which must reset the streak to 0.
+    protocol->persistDifferenceInMemory("memory_id_2", Operation::MODIFY, "memory_index_2", "memory_data_2", 2);
+
+    SyncModuleResult successResult;
+    std::thread syncThread([this, &successResult]()
+    {
+        successResult = protocol->synchronizeModule(Mode::FULL);
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+
+    // StartAck Ok
+    flatbuffers::FlatBufferBuilder startBuilder;
+    Wazuh::SyncSchema::StartAckBuilder startAckBuilder(startBuilder);
+    startAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
+    startAckBuilder.add_session(session);
+    auto startAckOffset = startAckBuilder.Finish();
+    auto startMessage = Wazuh::SyncSchema::CreateMessage(
+                            startBuilder,
+                            Wazuh::SyncSchema::MessageType::StartAck,
+                            startAckOffset.Union());
+    startBuilder.Finish(startMessage);
+    protocol->parseResponseBuffer(startBuilder.GetBufferPointer(), startBuilder.GetSize());
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+
+    // EndAck Ok
+    flatbuffers::FlatBufferBuilder endBuilder;
+    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
+    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
+    endAckBuilder.add_session(session);
+    auto endAckOffset = endAckBuilder.Finish();
+    auto endMessage = Wazuh::SyncSchema::CreateMessage(
+                          endBuilder,
+                          Wazuh::SyncSchema::MessageType::EndAck,
+                          endAckOffset.Union());
+    endBuilder.Finish(endMessage);
+    protocol->parseResponseBuffer(endBuilder.GetBufferPointer(), endBuilder.GetSize());
+
+    syncThread.join();
+
+    EXPECT_TRUE(successResult.success);
+    EXPECT_EQ(successResult.consecutiveFailures, 0u);
+}
+
 TEST_F(AgentSyncProtocolTest, SynchronizeModuleInvalidModeValidation)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -237,6 +237,32 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleReportsStoppedWhenStopRequested)
     EXPECT_TRUE(result.stopped);
 }
 
+// A local queue-open failure is not a "manager not ready yet" condition, so it must not be reported as
+// manager-not-ready: the calling module keeps it at WARNING.
+TEST_F(AgentSyncProtocolTest, SynchronizeModuleDoesNotReportTransientOnQueueFailure)
+{
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    MQ_Functions failingStartMqFuncs =
+    {
+        .start = [](const char*, short int, short int) { return -1; }, // Fail to start queue
+        .send_binary = [](int, const void*, size_t, const char*, char)
+        {
+            return 0;
+        }
+    };
+
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", failingStartMqFuncs, testLogger, std::chrono::seconds(syncEndDelay), std::chrono::seconds(min_timeout), retries, maxEps,
+                                                   mockQueue);
+
+    SyncModuleResult result = protocol->synchronizeModule(
+                      Mode::DELTA
+                  );
+
+    EXPECT_FALSE(result.success);
+    EXPECT_FALSE(result.managerNotReady);
+}
+
 // Exercises the C interface (asp_sync_module -> SyncModuleResult_t.stopped): this is the path
 // FIM depends on to distinguish a shutdown-aborted sync from a genuine failure.
 TEST_F(AgentSyncProtocolTest, CInterfacePropagatesStoppedFlag)
@@ -452,9 +478,61 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleFullModeFailureKeepsInMemoryData)
 
     EXPECT_FALSE(result.success);  // Should fail due to timeout
     EXPECT_EQ(result.failureReason, "Timed out waiting for manager response to Start message.");
+    // The manager did not answer the handshake.
+    EXPECT_TRUE(result.managerNotReady);
+    // First failure of the streak: the module reports it at INFO and retries.
+    EXPECT_EQ(result.consecutiveFailures, 1u);
 
     // In-memory data should be kept for potential retry, so we can add more data
     EXPECT_NO_THROW(protocol->persistDifferenceInMemory("memory_id_2", Operation::MODIFY, "memory_index_2", "memory_data_2", 2));
+}
+
+// The consecutive-failure streak is what tells a brief post-restart hiccup apart from a lasting
+// condition (for example the manager having no indexer available, which also answers "not ready").
+// Without it the modules would demote a permanent sync outage to INFO forever.
+TEST_F(AgentSyncProtocolTest, SynchronizeModuleCountsConsecutiveFailures)
+{
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    // The queue opens fine and messages are sent, but no StartAck is ever parsed, so every attempt
+    // ends in a Start timeout: the manager is never ready. A queue-open failure would not do, since
+    // it returns before the streak is tracked.
+    MQ_Functions mqFuncs =
+    {
+        .start = [](const char*, short int, short int) { return 0; },
+        .send_binary = [](int, const void*, size_t, const char*, char)
+        {
+            return 0;
+        }
+    };
+
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", mqFuncs, testLogger, std::chrono::seconds(syncEndDelay), std::chrono::seconds(min_timeout), retries, maxEps,
+                                                   mockQueue);
+
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+    .Times(0);
+    EXPECT_CALL(*mockQueue, resetSyncingItems())
+    .Times(0);
+
+    unsigned int previous = 0;
+
+    for (unsigned int attempt = 1; attempt <= SYNC_MANAGER_NOT_READY_TOLERANCE + 1; ++attempt)
+    {
+        // There must be something to synchronize on every attempt, otherwise the sync short-circuits
+        // as a success and never reaches the handshake.
+        protocol->clearInMemoryData();
+        protocol->persistDifferenceInMemory("memory_id_1", Operation::CREATE, "memory_index_1", "memory_data_1", 1);
+
+        SyncModuleResult result = protocol->synchronizeModule(Mode::FULL);
+        EXPECT_FALSE(result.success);
+        EXPECT_TRUE(result.managerNotReady);
+        // The count grows while the condition does not clear, so the module escalates to WARNING once
+        // it goes past SYNC_MANAGER_NOT_READY_TOLERANCE.
+        EXPECT_EQ(result.consecutiveFailures, attempt);
+        previous = result.consecutiveFailures;
+    }
+
+    EXPECT_GT(previous, SYNC_MANAGER_NOT_READY_TOLERANCE);
 }
 
 TEST_F(AgentSyncProtocolTest, SynchronizeModuleInvalidModeValidation)
@@ -1230,6 +1308,9 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleWithReqRetAndDataResendFails)
                       );
         EXPECT_FALSE(result.success);
         EXPECT_EQ(result.failureReason, "Failed to communicate with the manager.");
+        // Failing to resend data in an established session is a real send failure, not the
+        // "manager is not ready yet" case: it must not be reported as such.
+        EXPECT_FALSE(result.managerNotReady);
     });
 
     // Wait for start

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -1049,6 +1049,16 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
                 // Not a real failure: the sync was aborted because FIM is stopping.
                 // Report it as an expected event, not a WARNING.
                 minfo("FIM synchronization requested by agent-info aborted: FIM is stopping.");
+            } else if (sync_result.manager_not_ready
+                       && sync_result.consecutive_failures <= SYNC_MANAGER_NOT_READY_TOLERANCE) {
+                // The manager is not ready for this agent yet, mostly right after a restart, and the
+                // sync has not failed enough times in a row to suspect it will not clear.
+                minfo("FIM synchronization requested by agent-info deferred: %s Will retry next cycle.",
+                      sync_result.failure_reason);
+            } else if (sync_result.manager_not_ready) {
+                // Not a restart hiccup any more: the manager has not been ready for several cycles.
+                mwarn("FIM synchronization requested by agent-info failed %u times in a row: %s",
+                      sync_result.consecutive_failures, sync_result.failure_reason);
             } else {
                 mwarn("FIM synchronization requested by agent-info failed%s%s",
                       sync_result.failure_reason[0] != '\0' ? ": " : "",
@@ -1094,6 +1104,15 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
                 // Not a real failure: the sync was aborted because FIM is stopping.
                 // Report it as an expected event, not a WARNING.
                 minfo("FIM synchronization aborted: FIM is stopping.");
+            } else if (sync_result.manager_not_ready
+                       && sync_result.consecutive_failures <= SYNC_MANAGER_NOT_READY_TOLERANCE) {
+                // The manager is not ready for this agent yet, mostly right after a restart, and the
+                // sync has not failed enough times in a row to suspect it will not clear.
+                minfo("FIM synchronization deferred: %s Will retry next cycle.", sync_result.failure_reason);
+            } else if (sync_result.manager_not_ready) {
+                // Not a restart hiccup any more: the manager has not been ready for several cycles.
+                mwarn("FIM synchronization failed %u times in a row: %s",
+                      sync_result.consecutive_failures, sync_result.failure_reason);
             } else {
                 mwarn("FIM synchronization failed%s%s", sync_result.failure_reason[0] != '\0' ? ": " : "", sync_result.failure_reason);
             }

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -1858,6 +1858,22 @@ AgentInfoImpl::CoordinationResult AgentInfoImpl::coordinateModules(const std::st
                     // Not a real failure: the sync was aborted because the module is stopping.
                     m_logFunction(LOG_DEBUG, "Synchronization of " + table + " aborted: the module is stopping.");
                 }
+                else if (syncResult.managerNotReady
+                         && syncResult.consecutiveFailures <= SYNC_MANAGER_NOT_READY_TOLERANCE)
+                {
+                    // The manager is not ready for this agent yet, mostly right after a restart, and the
+                    // sync has not failed enough times in a row to suspect it will not clear. Agent-info
+                    // retries this table on the next coordination cycle.
+                    m_logFunction(LOG_INFO, "Synchronization of " + table + " deferred: " +
+                                  syncResult.failureReason + " Will retry next cycle.");
+                }
+                else if (syncResult.managerNotReady)
+                {
+                    // Not a restart hiccup any more: the manager has not been ready for several cycles.
+                    m_logFunction(LOG_WARNING, "Failed to synchronize " + table + " " +
+                                  std::to_string(syncResult.consecutiveFailures) + " times in a row: " +
+                                  syncResult.failureReason);
+                }
                 else
                 {
                     m_logFunction(LOG_WARNING, "Failed to synchronize " + table +

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -2323,6 +2323,22 @@ bool AgentInfoImpl::performIntegritySync(const std::string& table)
             // Not a real failure: the integrity check was aborted because the module is stopping.
             m_logFunction(LOG_DEBUG, "Integrity check for " + table + " aborted: the module is stopping.");
         }
+        else if (syncResult.managerNotReady
+                 && syncResult.consecutiveFailures <= SYNC_MANAGER_NOT_READY_TOLERANCE)
+        {
+            // The manager is not ready for this agent yet, mostly right after a restart, and the
+            // sync has not failed enough times in a row to suspect it will not clear. Agent-info
+            // retries this table on the next integrity cycle.
+            m_logFunction(LOG_INFO, "Integrity check for " + table + " deferred: " +
+                          syncResult.failureReason + " Will retry next cycle.");
+        }
+        else if (syncResult.managerNotReady)
+        {
+            // Not a restart hiccup any more: the manager has not been ready for several cycles.
+            m_logFunction(LOG_WARNING, "Integrity check for " + table + " failed " +
+                          std::to_string(syncResult.consecutiveFailures) + " times in a row: " +
+                          syncResult.failureReason);
+        }
         else
         {
             m_logFunction(LOG_WARNING, "Failed integrity check for " + table +

--- a/src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp
+++ b/src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp
@@ -183,6 +183,12 @@ class SecurityConfigurationAssessment
         /// @brief Mutex for pause/resume coordination
         std::mutex m_pauseMutex;
 
+        /// @brief Execute the blocking flush work for the module.
+        /// @return 0 on success, -1 on error.
+        /// @note Protected (rather than private) so test subclasses can drive the flush path
+        ///       deterministically without spinning the asynchronous flush controller.
+        int executeFlushSync();
+
     private:
         /// @brief Get the create statement for the database
         std::string GetCreateStatement() const;
@@ -239,10 +245,6 @@ class SecurityConfigurationAssessment
         /// @brief Check if DB has data (policies or checks)
         /// @return true if DB contains any policies or checks
         bool hasDataInDatabase();
-
-        /// @brief Execute the blocking flush work for the module.
-        /// @return 0 on success, -1 on error.
-        int executeFlushSync();
 
         /// @brief Handle the case when no policies are available (either at startup or runtime).
         /// If the database has existing data, triggers DataClean to notify the manager and clears DB.

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -573,6 +573,21 @@ bool SecurityConfigurationAssessment::syncModule(Mode mode)
             // Report it as an expected event, not a WARNING.
             LoggingHelper::getInstance().log(LOG_INFO, "SCA synchronization aborted: the module is stopping.");
         }
+        else if (result.managerNotReady && result.consecutiveFailures <= SYNC_MANAGER_NOT_READY_TOLERANCE)
+        {
+            // The manager is not ready for this agent yet, mostly right after a restart, and the sync
+            // has not failed enough times in a row to suspect it will not clear. Not a WARNING yet.
+            LoggingHelper::getInstance().log(LOG_INFO, "SCA synchronization deferred: " + result.failureReason +
+                                             " Will retry next cycle.");
+        }
+        else if (result.managerNotReady)
+        {
+            // The manager has not been ready for several cycles in a row: this is no longer a restart
+            // hiccup, so it must stay visible.
+            LoggingHelper::getInstance().log(LOG_WARNING, "SCA synchronization failed " +
+                                             std::to_string(result.consecutiveFailures) + " times in a row: " +
+                                             result.failureReason);
+        }
         else
         {
             LoggingHelper::getInstance().log(LOG_WARNING, "SCA synchronization failed" + (result.failureReason.empty() ? "." : ": " + result.failureReason));

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -838,6 +838,23 @@ int SecurityConfigurationAssessment::executeFlushSync()
         LoggingHelper::getInstance().log(LOG_INFO, "SCA flush aborted: the module is stopping.");
         return -1;
     }
+    else if (result.managerNotReady && result.consecutiveFailures <= SYNC_MANAGER_NOT_READY_TOLERANCE)
+    {
+        // The manager is not ready for this agent yet, mostly right after a restart, and the sync
+        // has not failed enough times in a row to suspect it will not clear. Not an error yet.
+        LoggingHelper::getInstance().log(LOG_INFO, "SCA flush deferred: " + result.failureReason +
+                                         " Will retry next cycle.");
+        return -1;
+    }
+    else if (result.managerNotReady)
+    {
+        // The manager has not been ready for several cycles in a row: this is no longer a restart
+        // hiccup, so it must stay visible.
+        LoggingHelper::getInstance().log(LOG_WARNING, "SCA flush failed " +
+                                         std::to_string(result.consecutiveFailures) + " times in a row: " +
+                                         result.failureReason);
+        return -1;
+    }
     else
     {
         LoggingHelper::getInstance().log(LOG_ERROR, "SCA flush failed");

--- a/src/wazuh_modules/sca/sca_impl/tests/mocks/sca_sca_mock.hpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/mocks/sca_sca_mock.hpp
@@ -52,4 +52,11 @@ class SCAMock : public SecurityConfigurationAssessment
         {
             m_pauseMutex.unlock();
         }
+
+        /// @brief Testing helper to drive the flush path synchronously (bypasses the async controller).
+        /// @return 0 on success, -1 on error.
+        int callExecuteFlushSync()
+        {
+            return executeFlushSync();
+        }
 };

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp
@@ -657,3 +657,124 @@ TEST_F(ScaTest, SyncModule_UsesDeltaAfterFirstSyncCompleted)
 
     dbSync->closeAndDeleteDatabase();
 }
+
+// --- Manager-not-ready log-level decision (issue #37553) ------------------------------------------
+// These use MockDBSync so the log-level decision is exercised in isolation from real DB/transport.
+
+namespace
+{
+    // Makes selectRows report that the first synchronization already completed, so syncModule() takes
+    // the periodic (DELTA) path instead of the initial full snapshot.
+    void expectFirstSyncCompleted(std::shared_ptr<MockDBSync>& mockDBSync)
+    {
+        EXPECT_CALL(*mockDBSync, selectRows(::testing::_, ::testing::_))
+        .WillRepeatedly(::testing::Invoke([](const nlohmann::json&,
+                                             std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
+        {
+            callback(SELECTED, nlohmann::json{{"key", "first_sync_completed"}, {"value", 123456}});
+        }));
+    }
+}
+
+// While the manager is briefly not ready (streak within tolerance), the periodic sync is reported at
+// INFO as deferred, not as a WARNING.
+TEST_F(ScaTest, SyncModule_ManagerNotReadyWithinToleranceLogsDeferred)
+{
+    auto mockDBSync = std::make_shared<MockDBSync>();
+    auto mockSyncProtocol = std::make_shared<MockAgentSyncProtocol>();
+    SCAMock scaMock(mockDBSync, nullptr);
+    scaMock.setSyncProtocol(mockSyncProtocol);
+    scaMock.pause();
+    expectFirstSyncCompleted(mockDBSync);
+
+    EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
+    .WillOnce(testing::Return(SyncModuleResult{false, "Failed to communicate with the manager.", false, true, 1u}));
+
+    m_logOutput.clear();
+    EXPECT_FALSE(scaMock.syncModule(Mode::DELTA));
+
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr(
+                    "SCA synchronization deferred: Failed to communicate with the manager. Will retry next cycle."));
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("SCA synchronization failed")));
+}
+
+// Past the tolerance the periodic sync escalates to a WARNING that names the streak.
+TEST_F(ScaTest, SyncModule_ManagerNotReadyPastToleranceLogsWarning)
+{
+    auto mockDBSync = std::make_shared<MockDBSync>();
+    auto mockSyncProtocol = std::make_shared<MockAgentSyncProtocol>();
+    SCAMock scaMock(mockDBSync, nullptr);
+    scaMock.setSyncProtocol(mockSyncProtocol);
+    scaMock.pause();
+    expectFirstSyncCompleted(mockDBSync);
+
+    const unsigned int streak = SYNC_MANAGER_NOT_READY_TOLERANCE + 1;
+    EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
+    .WillOnce(testing::Return(SyncModuleResult{false, "Failed to communicate with the manager.", false, true, streak}));
+
+    m_logOutput.clear();
+    EXPECT_FALSE(scaMock.syncModule(Mode::DELTA));
+
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr(
+                    "SCA synchronization failed " + std::to_string(streak) +
+                    " times in a row: Failed to communicate with the manager."));
+}
+
+// A flush that fails while the manager is briefly not ready is reported at INFO as deferred, not as
+// the ERROR it used to be.
+TEST_F(ScaTest, ExecuteFlushSync_ManagerNotReadyWithinToleranceLogsDeferred)
+{
+    auto mockDBSync = std::make_shared<MockDBSync>();
+    auto mockSyncProtocol = std::make_shared<MockAgentSyncProtocol>();
+    SCAMock scaMock(mockDBSync, nullptr);
+    scaMock.setSyncProtocol(mockSyncProtocol);
+
+    EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
+    .WillOnce(testing::Return(SyncModuleResult{false, "Failed to communicate with the manager.", false, true, 1u}));
+
+    m_logOutput.clear();
+    EXPECT_EQ(scaMock.callExecuteFlushSync(), -1);
+
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr(
+                    "SCA flush deferred: Failed to communicate with the manager. Will retry next cycle."));
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("SCA flush failed")));
+}
+
+// A flush that keeps failing past the tolerance escalates to a WARNING naming the streak.
+TEST_F(ScaTest, ExecuteFlushSync_ManagerNotReadyPastToleranceLogsWarning)
+{
+    auto mockDBSync = std::make_shared<MockDBSync>();
+    auto mockSyncProtocol = std::make_shared<MockAgentSyncProtocol>();
+    SCAMock scaMock(mockDBSync, nullptr);
+    scaMock.setSyncProtocol(mockSyncProtocol);
+
+    const unsigned int streak = SYNC_MANAGER_NOT_READY_TOLERANCE + 1;
+    EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
+    .WillOnce(testing::Return(SyncModuleResult{false, "Failed to communicate with the manager.", false, true, streak}));
+
+    m_logOutput.clear();
+    EXPECT_EQ(scaMock.callExecuteFlushSync(), -1);
+
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr(
+                    "SCA flush failed " + std::to_string(streak) +
+                    " times in a row: Failed to communicate with the manager."));
+}
+
+// A flush failure that is not a manager-not-ready condition keeps the original ERROR.
+TEST_F(ScaTest, ExecuteFlushSync_GenuineFailureKeepsError)
+{
+    auto mockDBSync = std::make_shared<MockDBSync>();
+    auto mockSyncProtocol = std::make_shared<MockAgentSyncProtocol>();
+    SCAMock scaMock(mockDBSync, nullptr);
+    scaMock.setSyncProtocol(mockSyncProtocol);
+
+    EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
+    .WillOnce(testing::Return(SyncModuleResult{false, "Manager sent an unexpected or invalid response.", false, false, 0u}));
+
+    m_logOutput.clear();
+    EXPECT_EQ(scaMock.callExecuteFlushSync(), -1);
+
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("SCA flush failed"));
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("deferred")));
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("times in a row")));
+}

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -2292,6 +2292,19 @@ SyncModuleResult Syscollector::syncModule(Mode mode)
                 // Report it as an expected event, not a WARNING.
                 m_logFunction(LOG_INFO, "Syscollector synchronization aborted: the module is stopping.");
             }
+            else if (result.managerNotReady && result.consecutiveFailures <= SYNC_MANAGER_NOT_READY_TOLERANCE)
+            {
+                // The manager is not ready for this agent yet, mostly right after a restart, and the
+                // sync has not failed enough times in a row to suspect it will not clear.
+                m_logFunction(LOG_INFO, "Syscollector synchronization deferred: " + result.failureReason +
+                              " Will retry next cycle.");
+            }
+            else if (result.managerNotReady)
+            {
+                // Not a restart hiccup any more: the manager has not been ready for several cycles.
+                m_logFunction(LOG_WARNING, "Syscollector synchronization failed " +
+                              std::to_string(result.consecutiveFailures) + " times in a row: " + result.failureReason);
+            }
             else
             {
                 m_logFunction(LOG_WARNING, "Syscollector synchronization failed" +
@@ -2342,6 +2355,19 @@ SyncModuleResult Syscollector::syncModule(Mode mode)
             {
                 // Not a real failure: the VD sync was aborted because the module is stopping
                 m_logFunction(LOG_INFO, "Syscollector VD synchronization aborted: the module is stopping.");
+            }
+            else if (vdResult.managerNotReady && vdResult.consecutiveFailures <= SYNC_MANAGER_NOT_READY_TOLERANCE)
+            {
+                // The manager is not ready for this agent yet, mostly right after a restart, and the
+                // sync has not failed enough times in a row to suspect it will not clear.
+                m_logFunction(LOG_INFO, "Syscollector VD synchronization deferred: " + vdResult.failureReason +
+                              " Will retry next cycle.");
+            }
+            else if (vdResult.managerNotReady)
+            {
+                // Not a restart hiccup any more: the manager has not been ready for several cycles.
+                m_logFunction(LOG_WARNING, "Syscollector VD synchronization failed " +
+                              std::to_string(vdResult.consecutiveFailures) + " times in a row: " + vdResult.failureReason);
             }
             else
             {

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -2955,7 +2955,40 @@ int Syscollector::executeFlushSync()
             if (!vdResult.success && !vdResult.failureReason.empty())
                 reason += (reason.empty() ? "" : "; VD: ") + vdResult.failureReason;
 
-            m_logFunction(LOG_WARNING, "Syscollector flush failed: " + failedQueues + (reason.empty() ? "" : ": " + reason));
+            const std::string reasonSuffix = reason.empty() ? "" : ": " + reason;
+
+            // A queue that failed counts as "manager not ready" only if that specific sync said so;
+            // a queue that succeeded does not veto the deferral.
+            const bool allFailuresManagerNotReady =
+                (result.success   || result.managerNotReady) &&
+                (vdResult.success || vdResult.managerNotReady);
+
+            // Longest manager-not-ready streak among the queues that actually failed.
+            unsigned int streak = 0;
+
+            if (!result.success && result.managerNotReady && result.consecutiveFailures > streak)
+                streak = result.consecutiveFailures;
+
+            if (!vdResult.success && vdResult.managerNotReady && vdResult.consecutiveFailures > streak)
+                streak = vdResult.consecutiveFailures;
+
+            if (allFailuresManagerNotReady && streak <= SYNC_MANAGER_NOT_READY_TOLERANCE)
+            {
+                // The manager is not ready for this agent yet, mostly right after a restart, and the
+                // sync has not failed enough times in a row to suspect it will not clear.
+                m_logFunction(LOG_INFO, "Syscollector flush deferred: " + failedQueues + reasonSuffix +
+                              " Will retry next cycle.");
+            }
+            else if (allFailuresManagerNotReady)
+            {
+                // Not a restart hiccup any more: the manager has not been ready for several cycles.
+                m_logFunction(LOG_WARNING, "Syscollector flush failed " + std::to_string(streak) +
+                              " times in a row: " + failedQueues + reasonSuffix);
+            }
+            else
+            {
+                m_logFunction(LOG_WARNING, "Syscollector flush failed: " + failedQueues + reasonSuffix);
+            }
         }
     }
 


### PR DESCRIPTION
## Description

Closes #37553

After an agent install or upgrade, `wazuh-modulesd` and `wazuh-syscheckd` reported synchronization warnings for expected, self-recovering conditions:

```sql
2026/07/09 22:30:43 wazuh-modulesd:syscollector: WARNING: Syscollector synchronization failed: Failed to communicate with the manager.
2026/07/09 22:30:43 wazuh-modulesd:syscollector: WARNING: Syscollector VD synchronization failed: Failed to communicate with the manager.
2026/07/09 22:30:43 wazuh-syscheckd: WARNING: FIM synchronization failed: Failed to communicate with the manager.
2026/07/14 04:42:38 wazuh-modulesd:sca: WARNING: SCA synchronization failed: Timed out waiting for manager response to Start message.
```

The reported messages fall into two situations:

1. A synchronization aborted because the agent was stopping. This was already addressed by #37673, which reports it at `INFO` as `"... synchronization aborted: the module is stopping."`.
2. The first synchronization right after the agent restarts, while the manager is not ready to answer the handshake for this agent yet. `wazuh-agentd` already reports `Connected to the server`, but the manager side of the sync path is not wired up for a second or two, so the first attempt fails and the next cycle succeeds.

This PR covers the second situation. The agent recovers on its own and no data is lost, but the message read as a generic failure, with no indication that it is transient and will be retried.

## Proposed Changes

- Add `managerNotReady` to `SyncModuleResult` (C twin `manager_not_ready`): the manager did not answer the handshake, or answered that it cannot serve this agent yet (`Offline`). It is set only at the sites where that condition is known, not derived from the `SyncResult` value, because `SyncResult` does not carry the intent: `COMMUNICATION_ERROR` is also used when `sendDataMessages()` fails while resending data for a `ReqRet` in an already established session, which is a real send failure and must stay visible.
- Add `consecutiveFailures` (C twin `consecutive_failures`): consecutive failed synchronizations for that module, reset on the first success. A stop-induced abort does not count, since it says nothing about the manager.
- Modules demote to `INFO` only while both hold: the manager was not ready and the streak is within `SYNC_MANAGER_NOT_READY_TOLERANCE` (3). Past that the message escalates to `WARNING` and names the streak.

This second condition matters: `managerNotReady` alone describes a failure kind, not whether it is harmless. The manager answers `StartAck{Offline}` not only right after an agent restart, but also when it has **no indexer available**, when the session limit is reached, or when the DataValue quota is exhausted (it logs the last two at `WARN` itself). Demoting on the condition alone would report a lasting, fleet-wide sync outage as `INFO: will retry next cycle` forever, invisible at the default log level. Counting consecutive failures is what separates a restart hiccup, which clears on the next cycle, from a condition that is not clearing, and it needs no restart-awareness in the agent.

`PROTOCOL_ERROR` (unexpected or invalid manager response) and `CHECKSUM_ERROR` are unaffected and keep their `WARNING`.

Consumers updated: `SCA`, `Syscollector` (module and VD sync) and `FIM`.

The resulting decision in every module keeps the shape introduced by #37673:

```
success                                  -> INFO    "... synchronization finished successfully."
stopped / module stopping                -> INFO    "... synchronization aborted: the module is stopping."
managerNotReady && streak <= tolerance   -> INFO    "... synchronization deferred: <reason> Will retry next cycle."
managerNotReady && streak >  tolerance   -> WARNING "... synchronization failed N times in a row: <reason>"
otherwise                                -> WARNING "... synchronization failed[: <reason>]"
```

### Results and Evidence

Message changes:

- Before:
```sql
WARNING: Syscollector synchronization failed: Failed to communicate with the manager.
WARNING: SCA synchronization failed: Timed out waiting for manager response to Start message.
WARNING: FIM synchronization failed: Failed to communicate with the manager.
```
- After
```sql
# Option 1: while the manager is briefly not ready (the reported case): recovers on the next cycle
INFO: Syscollector synchronization deferred: Failed to communicate with the manager. Will retry next cycle.
INFO: SCA synchronization deferred: Timed out waiting for manager response to Start message. Will retry next cycle.
INFO: FIM synchronization deferred: Failed to communicate with the manager. Will retry next cycle.

# Option 2: if it does not clear (for example the manager has no indexer available): stays visible
WARNING: Syscollector synchronization failed 4 times in a row: Failed to communicate with the manager.

# Unchanged: an unexpected manager response is still a WARNING
WARNING: Syscollector VD synchronization failed: Manager sent an unexpected or invalid response.
```

The reported race (the first sync landing while the manager is still not ready after a restart) is timing-dependent and hard to force on demand, so the classification is covered by unit tests instead.

### Artifacts Affected

- Shared library `agent_sync_protocol` (new `transient` field in the C++ and C result structures).
- `wazuh-modulesd` (agent): modules `syscollector` (including VD sync) and `sca`.
- `wazuh-syscheckd` (agent): FIM synchronization.

Agent-only components. No manager artifacts changed.

### Configuration Changes

- None.

### Documentation Updates

- None.

### Tests Introduced

In `src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp`:

- New `SynchronizeModuleCountsConsecutiveFailures`: drives four consecutive Start-handshake timeouts and asserts the streak is exactly 1, 2, 3, 4, crossing the tolerance. This is the test that covers the escalation, and therefore the protection against reporting a lasting outage as `INFO`.
- The existing Start-timeout test now also asserts `managerNotReady == true` and `consecutiveFailures == 1`.
- The existing ReqRet-resend-failure test now asserts `managerNotReady == false`: it produces the same `COMMUNICATION_ERROR` value as the Offline cases but must keep its `WARNING`, which is why the flag is set per condition instead of being derived from the enum.
- `SynchronizeModuleDoesNotReportTransientOnQueueFailure`: a local queue-open failure is not a "manager not ready" condition either.
- The existing `PROTOCOL_ERROR` reason tests remain valid and unchanged.
- `SynchronizeModuleOfflineStartAckReportsManagerNotReady` / `SynchronizeModuleOfflineEndAckReportsManagerNotReady` / `SynchronizeModuleEndTimeoutReportsManagerNotReady`: assert `managerNotReady`/`consecutiveFailures` directly for the Offline `StartAck`, Offline `EndAck`, and End-timeout paths (previously only the Start-timeout case had direct coverage).
- `SynchronizeModuleStoppedDoesNotCountTowardsStreak`: a stop-aborted sync leaves the streak where it was.
- `SynchronizeModuleSuccessResetsConsecutiveFailures`: a successful synchronization resets the streak to 0.

In `src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp`:

- `SyncModule_ManagerNotReadyWithinToleranceLogsDeferred` / `SyncModule_ManagerNotReadyPastToleranceLogsWarning`: assert the periodic sync logs `INFO` "deferred" while within tolerance and escalates to `WARNING` naming the streak past it.
- `ExecuteFlushSync_ManagerNotReadyWithinToleranceLogsDeferred` / `ExecuteFlushSync_ManagerNotReadyPastToleranceLogsWarning`: same decision asserted for the flush path.
- `ExecuteFlushSync_GenuineFailureKeepsError`: a non-manager-not-ready flush failure keeps its original `ERROR` log, unaffected by this change.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

