### PR TITLE
Limit node expansion in yaml2json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this project will be documented in this file.
 
 ### Agent
 
+#### Changed
+
+- Improved SCA policy YAML parsing to bound memory usage on deeply nested policies. ([#37725](https://github.com/wazuh/wazuh/pull/37725))
+
 #### Fixed
 
 - Prevent a race condition in `randombytes` during the initialization of the Windows RSA key container ([#37701](https://github.com/wazuh/wazuh/pull/37701))

--- a/src/shared/yaml2json.c
+++ b/src/shared/yaml2json.c
@@ -14,7 +14,12 @@
 #include <errno.h>
 #include "shared.h"
 
-static cJSON * yaml2json_node(yaml_document_t * document, yaml_node_t * node, int quoted_float_as_string);
+/* Maximum number of JSON nodes a single YAML document may expand into.
+ * The largest bundled SCA policy expands to about 18000 nodes, so this leaves
+ * ample headroom for legitimate documents. */
+#define YAML2JSON_MAX_NODES 100000
+
+static cJSON * yaml2json_node(yaml_document_t * document, yaml_node_t * node, int quoted_float_as_string, unsigned int * node_count);
 
 int yaml_parse_stdin(yaml_document_t * document) {
     yaml_parser_t parser;
@@ -61,16 +66,17 @@ int yaml_parse_file(const char * path, yaml_document_t * document) {
 
 cJSON * yaml2json(yaml_document_t * document, int single_quote_float_as_string) {
     yaml_node_t * node;
+    unsigned int node_count = 0;
 
     if (node = yaml_document_get_root_node(document), !node) {
         mwarn("No document defined.");
         return NULL;
     }
 
-    return yaml2json_node(document, node, single_quote_float_as_string);
+    return yaml2json_node(document, node, single_quote_float_as_string, &node_count);
 }
 
-cJSON * yaml2json_node(yaml_document_t * document, yaml_node_t * node,int quoted_float_as_string) {
+cJSON * yaml2json_node(yaml_document_t * document, yaml_node_t * node, int quoted_float_as_string, unsigned int * node_count) {
     yaml_node_t * key;
     yaml_node_t * value;
     yaml_node_item_t * item_i;
@@ -79,6 +85,12 @@ cJSON * yaml2json_node(yaml_document_t * document, yaml_node_t * node,int quoted
     char * scalar;
     char * end;
     cJSON * object;
+    cJSON * item;
+
+    if (++(*node_count) > YAML2JSON_MAX_NODES) {
+        mwarn("YAML document exceeds the maximum number of nodes (%d). Possible alias expansion abuse.", YAML2JSON_MAX_NODES);
+        return NULL;
+    }
 
     switch (node->type) {
     case YAML_NO_NODE:
@@ -101,7 +113,12 @@ cJSON * yaml2json_node(yaml_document_t * document, yaml_node_t * node,int quoted
         object = cJSON_CreateArray();
 
         for (item_i = node->data.sequence.items.start; item_i < node->data.sequence.items.top; ++item_i) {
-            cJSON_AddItemToArray(object, yaml2json_node(document, yaml_document_get_node(document, *item_i),quoted_float_as_string));
+            if (item = yaml2json_node(document, yaml_document_get_node(document, *item_i), quoted_float_as_string, node_count), !item) {
+                cJSON_Delete(object);
+                return NULL;
+            }
+
+            cJSON_AddItemToArray(object, item);
         }
 
         break;
@@ -118,7 +135,12 @@ cJSON * yaml2json_node(yaml_document_t * document, yaml_node_t * node,int quoted
                 continue;
             }
 
-            cJSON_AddItemToObject(object, (char *)key->data.scalar.value, yaml2json_node(document, value,quoted_float_as_string));
+            if (item = yaml2json_node(document, value, quoted_float_as_string, node_count), !item) {
+                cJSON_Delete(object);
+                return NULL;
+            }
+
+            cJSON_AddItemToObject(object, (char *)key->data.scalar.value, item);
         }
 
         break;

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -305,6 +305,9 @@ list(APPEND shared_tests_flags "-Wl,--wrap,OS_BindUnixDomainWithPerms -Wl,--wrap
 list(APPEND shared_tests_names "test_remoted_op")
 list(APPEND shared_tests_flags "${DEBUG_OP_WRAPPERS}")
 
+list(APPEND shared_tests_names "test_yaml2json_op")
+list(APPEND shared_tests_flags "${DEBUG_OP_WRAPPERS}")
+
 endif()
 
 if(${TARGET} STREQUAL "server")

--- a/src/unit_tests/shared/test_yaml2json_op.c
+++ b/src/unit_tests/shared/test_yaml2json_op.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "../../headers/shared.h"
+#include "../../headers/yaml2json.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+
+static char * write_temp_yaml(const char * content) {
+    char * path;
+    os_strdup("/tmp/test_yaml2json_XXXXXX", path);
+
+    int fd = mkstemp(path);
+    assert_true(fd >= 0);
+
+    FILE * fp = fdopen(fd, "w");
+    assert_non_null(fp);
+    fputs(content, fp);
+    fclose(fp);
+
+    return path;
+}
+
+static int teardown_temp_file(void ** state) {
+    char * path = *state;
+    unlink(path);
+    os_free(path);
+    return 0;
+}
+
+/* A normal, small SCA-like policy must still convert successfully. */
+static void test_yaml2json_valid_policy(void ** state) {
+    char * path = write_temp_yaml(
+        "policy:\n"
+        "  id: test_policy\n"
+        "  file: 'test_policy.yml'\n"
+        "  name: Test policy\n"
+        "checks:\n"
+        "  - id: 1\n"
+        "    title: \"Test check\"\n"
+        "    condition: all\n"
+        "    rules:\n"
+        "      - 'f:/etc/passwd'\n"
+    );
+    *state = path;
+
+    yaml_document_t document;
+    assert_int_equal(yaml_parse_file(path, &document), 0);
+
+    cJSON * object = yaml2json(&document, 1);
+    assert_non_null(object);
+
+    cJSON * policy = cJSON_GetObjectItem(object, "policy");
+    assert_non_null(policy);
+    assert_string_equal(cJSON_GetObjectItem(policy, "id")->valuestring, "test_policy");
+
+    cJSON * checks = cJSON_GetObjectItem(object, "checks");
+    assert_int_equal(cJSON_GetArraySize(checks), 1);
+
+    cJSON_Delete(object);
+    yaml_document_delete(&document);
+}
+
+/* Nested anchors/aliases must not be allowed to expand into an
+ * unbounded number of JSON nodes. */
+static void test_yaml2json_alias_expansion_rejected(void ** state) {
+    char * path = write_temp_yaml(
+        "policy:\n"
+        "  id: expansion_test\n"
+        "checks:\n"
+        "  - id: 1\n"
+        "    rules: &a [\"f:/etc/passwd\"]\n"
+        "  - id: 2\n"
+        "    rules: &b [*a, *a, *a, *a, *a, *a, *a, *a, *a, *a]\n"
+        "  - id: 3\n"
+        "    rules: &c [*b, *b, *b, *b, *b, *b, *b, *b, *b, *b]\n"
+        "  - id: 4\n"
+        "    rules: &d [*c, *c, *c, *c, *c, *c, *c, *c, *c, *c]\n"
+        "  - id: 5\n"
+        "    rules: &e [*d, *d, *d, *d, *d, *d, *d, *d, *d, *d]\n"
+        "  - id: 6\n"
+        "    rules: &f [*e, *e, *e, *e, *e, *e, *e, *e, *e, *e]\n"
+    );
+    *state = path;
+
+    yaml_document_t document;
+    assert_int_equal(yaml_parse_file(path, &document), 0);
+
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "YAML document exceeds the maximum number of nodes (100000). Possible alias expansion abuse.");
+
+    cJSON * object = yaml2json(&document, 1);
+    assert_null(object);
+
+    yaml_document_delete(&document);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_teardown(test_yaml2json_valid_policy, teardown_temp_file),
+        cmocka_unit_test_teardown(test_yaml2json_alias_expansion_rejected, teardown_temp_file),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## Description
`yaml2json_node()` (src/shared/yaml2json.c) converts a parsed YAML document into a `cJSON` tree recursively, with no cap on alias expansion, recursion depth, or resulting node count. Because libyaml resolves an alias to the same underlying node as its anchor rather than cloning it, a document with deeply nested anchors/aliases can produce a very large number of `cJSON` allocations from a small input. This is reachable unconditionally from the SCA module (`wm_sca_read_files()`) on every scan cycle, using policy files delivered by the manager, and can exhaust agent memory (GHSA-x8v7-g49q-ff7j). The fix caps the total number of nodes a single document may expand into and aborts the conversion, freeing partial results, once the cap is exceeded.

## Proposed Changes
- `src/shared/yaml2json.c`: added a `YAML2JSON_MAX_NODES` (100000) cap. `yaml2json_node()` now takes a `node_count` accumulator, incremented on every node visited; once the cap is exceeded, the function logs a warning and returns `NULL` instead of allocating further `cJSON` nodes. The sequence/mapping recursion cases now check each child's result and, on `NULL`, delete the partially built object and propagate `NULL` upward so `yaml2json()` returns `NULL` for the whole document (existing callers already treat a `NULL` return as "skip this policy").
- `src/unit_tests/shared/CMakeLists.txt`: registered the new `test_yaml2json_op` test (no link-wrap flags needed; it exercises real file I/O and the real YAML/cJSON pipeline).
- `src/unit_tests/shared/test_yaml2json_op.c` (new): cmocka tests for the fix.

### Results and Evidence
- Standalone reproduction (real `yaml2json.c` logic + this repo's built `libyaml.a` + `cJSON.c`) against a 394-byte document with nested aliases:
  - Before the fix: 234,583 `cJSON` nodes allocated.
  - After the fix: `yaml2json()` returns `NULL` once the 100000-node cap is exceeded; peak RSS for the same input drops to ~11 MB.
- The largest bundled SCA policy in this repo (`ruleset/sca/windows/cis_win11_enterprise.yml`, ~10,000 lines / ~18,300 nodes) still converts successfully, confirming the cap does not affect legitimate policies (which top out around 18-26K nodes for the largest bundled files).
- New unit tests `test_yaml2json_valid_policy` (must still succeed) and `test_yaml2json_alias_expansion_rejected` (must return `NULL`) added; the latter fails before the fix and passes after.

### Artifacts Affected
- `wazuh-agentd` / `wazuh-modulesd` (agent): consumes `yaml2json()` via the SCA module (`wm_sca.c`), the only caller of this function in this codebase.

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
- `src/unit_tests/shared/test_yaml2json_op.c`:
  - `test_yaml2json_valid_policy` — a small, valid SCA-like policy still converts to the expected `cJSON` structure.
  - `test_yaml2json_alias_expansion_rejected` — a document with nested aliases is rejected (`yaml2json()` returns `NULL`).

## Credits
Reported by @karasu-hakira (Hakira, https://github.com/hakiraio).

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
