### PR TITLE
Calibrate log levels in router and vulnerability_scanner

### DIFF
--- a/src/shared_modules/router/src/router.cpp
+++ b/src/shared_modules/router/src/router.cpp
@@ -293,7 +293,7 @@ extern "C"
         }
         catch (const std::exception& e)
         {
-            logMessage(modules_log_level_t::LOG_ERROR, std::string("Error sending message to provider: ") + e.what());
+            logMessage(modules_log_level_t::LOG_WARNING, std::string("Error sending message to provider: ") + e.what());
         }
         return retVal;
     }
@@ -420,7 +420,8 @@ extern "C"
         }
         catch (const std::exception& e)
         {
-            logMessage(modules_log_level_t::LOG_ERROR, std::string("Error in router_provider_send_sync: ") + e.what());
+            logMessage(modules_log_level_t::LOG_WARNING,
+                       std::string("Error in router_provider_send_sync: ") + e.what());
             return -1;
         }
     }
@@ -582,7 +583,7 @@ extern "C"
     {
         if (!socketPath)
         {
-            logMessage(modules_log_level_t::LOG_ERROR, "Error stopping API. Invalid socket path");
+            logMessage(modules_log_level_t::LOG_WARNING, "Error stopping API. Invalid socket path");
             return;
         }
 
@@ -645,7 +646,7 @@ extern "C"
         }
         catch (const std::exception& e)
         {
-            logMessage(modules_log_level_t::LOG_ERROR, std::string("Error subscribing: ") + e.what());
+            logMessage(modules_log_level_t::LOG_WARNING, std::string("Error subscribing: ") + e.what());
         }
         return retVal;
     }
@@ -659,7 +660,7 @@ extern "C"
         }
         catch (const std::exception& e)
         {
-            logMessage(modules_log_level_t::LOG_ERROR, std::string("Error unsubscribing: ") + e.what());
+            logMessage(modules_log_level_t::LOG_WARNING, std::string("Error unsubscribing: ") + e.what());
         }
     }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVERemediations.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/databaseFeedManager/updateCVERemediations.hpp
@@ -68,7 +68,7 @@ public:
 
         if (!remediations)
         {
-            logError(WM_VULNSCAN_LOGTAG, "Remediations database is empty.");
+            logDebug1(WM_VULNSCAN_LOGTAG, "Remediations database is empty.");
             return;
         }
 
@@ -81,7 +81,7 @@ public:
                           auto updatesCve5 = remediation->anyOf();
                           if (!updatesCve5)
                           {
-                              logError(WM_VULNSCAN_LOGTAG, "No updates available.");
+                              logDebug1(WM_VULNSCAN_LOGTAG, "No updates available.");
                               return;
                           }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/eventDetailsBuilder.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/eventDetailsBuilder.hpp
@@ -551,11 +551,11 @@ public:
             }
             catch (const std::exception& e)
             {
-                logError(WM_VULNSCAN_LOGTAG,
-                         "Failed to build ECS event for detection '%s' (CVE %s): %s",
-                         detectionId.c_str(),
-                         cveId.c_str(),
-                         e.what());
+                logWarn(WM_VULNSCAN_LOGTAG,
+                        "Failed to build ECS event for detection '%s' (CVE %s): %s",
+                        detectionId.c_str(),
+                        cveId.c_str(),
+                        e.what());
             }
         }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/eventGetContext.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/eventGetContext.hpp
@@ -463,9 +463,9 @@ public:
         }
         catch (const std::exception& e)
         {
-            logError(WM_VULNSCAN_LOGTAG,
-                     "TEventGetContext - Failed to execute vulnerabilities reconciliation query: %s",
-                     e.what());
+            logWarn(WM_VULNSCAN_LOGTAG,
+                    "TEventGetContext - Failed to execute vulnerabilities reconciliation query: %s",
+                    e.what());
             // Continue with the chain even if the query fails.
         }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/eventGetCve.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/eventGetCve.hpp
@@ -233,7 +233,7 @@ public:
         }
         catch (const std::exception& e)
         {
-            logError(WM_VULNSCAN_LOGTAG, "TEventGetCve - Failed to execute GET CVE queries: %s", e.what());
+            logWarn(WM_VULNSCAN_LOGTAG, "TEventGetCve - Failed to execute GET CVE queries: %s", e.what());
             // We continue the chain even if this step fails.
         }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/packageScanner.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/packageScanner.hpp
@@ -904,11 +904,11 @@ private:
             }
             catch (const std::exception& e)
             {
-                logError(WM_VULNSCAN_LOGTAG,
-                         "Exception scanning CVE for package '%s' (CNA: '%s'): %s",
-                         pkg.name.c_str(),
-                         cnaName.c_str(),
-                         e.what());
+                logWarn(WM_VULNSCAN_LOGTAG,
+                        "Exception scanning CVE for package '%s' (CNA: '%s'): %s",
+                        pkg.name.c_str(),
+                        cnaName.c_str(),
+                        e.what());
                 return false;
             }
         };
@@ -949,7 +949,7 @@ private:
         }
         catch (const std::exception& e)
         {
-            logError(WM_VULNSCAN_LOGTAG, "Failed to scan package '%s': %s", package.name.c_str(), e.what());
+            logWarn(WM_VULNSCAN_LOGTAG, "Failed to scan package '%s': %s", package.name.c_str(), e.what());
         }
     }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/resultIndexer.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/factory/resultIndexer.hpp
@@ -104,8 +104,8 @@ public:
                             errorMsg += "  - " + error;
                         }
 
-                        logError(WM_VULNSCAN_LOGTAG, "%s", errorMsg.c_str());
-                        logError(WM_VULNSCAN_LOGTAG, "Raw event that failed validation: %s", ecsJson->c_str());
+                        logWarn(WM_VULNSCAN_LOGTAG, "%s", errorMsg.c_str());
+                        logDebug1(WM_VULNSCAN_LOGTAG, "Raw event that failed validation: %s", ecsJson->c_str());
                         continue;
                     }
                 }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
@@ -357,7 +357,7 @@ private:
         }
         catch (const std::exception& e)
         {
-            logError(WM_VULNSCAN_LOGTAG, "Failed to retrieve OS data for agent %s: %s.", agent.id.c_str(), e.what());
+            logWarn(WM_VULNSCAN_LOGTAG, "Failed to retrieve OS data for agent %s: %s.", agent.id.c_str(), e.what());
         }
 
         auto context = std::make_shared<TScanContext>(buildContextFromAgent(agent, osData));
@@ -412,7 +412,7 @@ private:
         }
         catch (const std::exception& e)
         {
-            logError(WM_VULNSCAN_LOGTAG, "Failed to retrieve packages for agent %s: %s.", agent.id.c_str(), e.what());
+            logWarn(WM_VULNSCAN_LOGTAG, "Failed to retrieve packages for agent %s: %s.", agent.id.c_str(), e.what());
         }
 
         try
@@ -437,7 +437,7 @@ private:
         }
         catch (const std::exception& e)
         {
-            logError(WM_VULNSCAN_LOGTAG, "Failed to retrieve hotfixes for agent %s: %s.", agent.id.c_str(), e.what());
+            logWarn(WM_VULNSCAN_LOGTAG, "Failed to retrieve hotfixes for agent %s: %s.", agent.id.c_str(), e.what());
         }
 
         if (m_scanRunner)
@@ -446,7 +446,7 @@ private:
         }
         else
         {
-            logError(WM_VULNSCAN_LOGTAG, "Scan runner not configured for agent %s.", agent.id.c_str());
+            logWarn(WM_VULNSCAN_LOGTAG, "Scan runner not configured for agent %s.", agent.id.c_str());
         }
     }
 
@@ -497,7 +497,7 @@ public:
             }
             catch (const std::exception& e)
             {
-                logError(WM_VULNSCAN_LOGTAG, "Error executing scan for agent %s: %s.", agent.id.c_str(), e.what());
+                logWarn(WM_VULNSCAN_LOGTAG, "Error executing scan for agent %s: %s.", agent.id.c_str(), e.what());
                 data->m_agentsWithIncompletedScan.push_back(agent);
             }
         }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
@@ -787,7 +787,7 @@ private:
         }
         catch (const simdjson::simdjson_error& e)
         {
-            logError(
+            logWarn(
                 WM_VULNSCAN_LOGTAG, "Error extracting OS from host document: %s", simdjson::error_message(e.error()));
         }
 
@@ -974,7 +974,7 @@ private:
         }
         catch (const simdjson::simdjson_error& e)
         {
-            logError(WM_VULNSCAN_LOGTAG, "Error extracting package info: %s", simdjson::error_message(e.error()));
+            logWarn(WM_VULNSCAN_LOGTAG, "Error extracting package info: %s", simdjson::error_message(e.error()));
         }
 
         return info;
@@ -1056,7 +1056,7 @@ private:
         }
         catch (const simdjson::simdjson_error& e)
         {
-            logError(WM_VULNSCAN_LOGTAG, "Error extracting hotfix info: %s", simdjson::error_message(e.error()));
+            logWarn(WM_VULNSCAN_LOGTAG, "Error extracting hotfix info: %s", simdjson::error_message(e.error()));
         }
 
         return hotfix;


### PR DESCRIPTION
## Description

Closes #37700

Per-agent and per-event failures in the vulnerability scanner were logged at ERROR even though the overall scan cycle continues after each one. In an environment with many agents or packages, this produces constant false-positive ERROR noise that masks real blocking failures. Two data-absence conditions in `updateCVERemediations` fire at ERROR for every CVE that has no Windows remediation entry, which is the normal case for most CVEs. Five per-message and shutdown-context failures in the router were also at ERROR level.

## Proposed Changes

Applies the following calibration across `shared_modules/router` and `wazuh_modules/vulnerability_scanner`:

**ERROR → WARN** — per-agent/per-event/per-operation failures where processing continues:
- `router.cpp`: per-message send failure, sync send failure, subscribe/unsubscribe failures, null socketPath on stop
- `scanAgentList.hpp`: OS/packages/hotfixes retrieval per-agent, scan runner not configured per-agent, scan execution failure per-agent
- `scanOrchestrator.hpp`: OS/package/hotfix extraction from simdjson document
- `factory/packageScanner.hpp`: CVE scan exception per package, package scan failure catch-all
- `factory/eventDetailsBuilder.hpp`: ECS event build failure per detection
- `factory/resultIndexer.hpp`: event schema validation failure (summary line)
- `factory/eventGetContext.hpp`: reconciliation query failure (chain continues)
- `factory/eventGetCve.hpp`: GET CVE query failure (chain continues)

**ERROR → DEBUG1** — expected data-absence conditions, not errors:
- `updateCVERemediations.hpp`: "Remediations database is empty" and "No updates available" — fire per CVE entry; most CVEs have no Windows remediation data

**DEBUG1** (raw event body on validation failure in `resultIndexer.hpp`) — diagnostic context, potentially large payload.

Blocking failures remain at ERROR: module startup, global agent list unavailable, indexer connector absent, feed database open failure, feed update failure.

### Results and Evidence

Diff is purely severity changes — no functional behavior modified.

```
src/shared_modules/router/src/router.cpp                     | 10 +++++-----
vulnerability_scanner/src/databaseFeedManager/updateCVERemediations.hpp |  4 ++--
vulnerability_scanner/src/scanOrchestrator/factory/eventDetailsBuilder.hpp | 10 +++++-----
vulnerability_scanner/src/scanOrchestrator/factory/eventGetContext.hpp |  6 +++---
vulnerability_scanner/src/scanOrchestrator/factory/eventGetCve.hpp |  2 +-
vulnerability_scanner/src/scanOrchestrator/factory/packageScanner.hpp | 12 ++++++------
vulnerability_scanner/src/scanOrchestrator/factory/resultIndexer.hpp |  4 ++--
vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp | 10 +++++-----
vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp |  6 +++---
9 files changed, 32 insertions(+), 32 deletions(-)
```

### Artifacts Affected

- `wazuh-manager` binary (log output only)

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None — log level changes do not alter product behavior.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)