### PR TITLE
Remove multiple warning messages for each unathorized shared policy

### DIFF
--- a/src/wazuh_modules/wm_sca.c
+++ b/src/wazuh_modules/wm_sca.c
@@ -962,6 +962,7 @@ static int wm_sca_do_scan(cJSON * checks,
 
     int ret_val = 0;
     OSList *p_list = NULL;
+    bool remote_commands_warned = false;
 
     /* Initialize variables */
     memset(buf, '\0', sizeof(buf));
@@ -1155,13 +1156,15 @@ static int wm_sca_do_scan(cJSON * checks,
                 os_strdup(value, rule_location);
 
                 if (!data->remote_commands && remote_policy) {
-                    mwarn("Ignoring check for policy '%s'. The internal option 'sca.remote_commands' is disabled.", cJSON_GetObjectItem(policy, "name")->valuestring);
+                    if (!remote_commands_warned) {
+                        mwarn("Ignoring check for policy '%s'. The internal option 'sca.remote_commands' is disabled.", cJSON_GetObjectItem(policy, "name")->valuestring);
+                        remote_commands_warned = true;
+                    }
                     if (reason == NULL) {
                         os_malloc(snprintf(NULL, 0, "Ignoring check for running command '%s'. The internal option 'sca.remote_commands' is disabled", rule_location) + 1, reason);
                         sprintf(reason, "Ignoring check for running command '%s'. The internal option 'sca.remote_commands' is disabled", rule_location);
                     }
                     found = RETURN_INVALID;
-
                 } else {
                     /* If any, replace the variables by their respective values */
                     if (sorted_variables) {


### PR DESCRIPTION
|Closes|
|---|
| #15053 |

## Description

This PR addresses the issue of log flooding in the Wazuh Agent when `sca.remote_commands` is disabled and a shared policy contains multiple command checks. Previously, a warning was logged for every single check/rule of type `WM_SCA_TYPE_COMMAND` that was skipped, producing verbose logs.

With this fix, a tracking boolean `remote_commands_warned` is introduced inside the scan execution scope of `wm_sca_do_scan()`. This limits the warning message to be output at most once per policy scan. The individual checks/rules are still safely skipped and marked as `RETURN_INVALID` with their respective detailed `reason` strings.

## Logs/Alerts example

Before the fix, a policy scan with multiple command checks and remote commands disabled produced:
```log
2022/09/30 09:57:59 sca: WARNING: Ignoring check for policy 'Testing policy - Unix'. The internal option 'sca.remote_commands' is disabled.
2022/09/30 09:57:59 sca: WARNING: Ignoring check for policy 'Testing policy - Unix'. The internal option 'sca.remote_commands' is disabled.
2022/09/30 09:57:59 sca: WARNING: Ignoring check for policy 'Testing policy - Unix'. The internal option 'sca.remote_commands' is disabled.
```

After the fix, only a single warning is logged:
```log
2026/07/16 18:28:45 sca: WARNING: Ignoring check for policy 'Testing policy - Unix'. The internal option 'sca.remote_commands' is disabled.
```

## Tests

- Compilation without warnings in every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Review logs syntax and correct language
