### PR TITLE
Reject upgrade commands from the agent channel in wazuh-analysisd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 - Fixed AES connection getting reset to blowfish on keystore rebuild. ([#37524](https://github.com/wazuh/wazuh/pull/37524))
 - Fixed a deadlock in `wazuh-analysisd` that stopped alert generation when the Active Response queue filled up. ([#37764](https://github.com/wazuh/wazuh/pull/37764))
+- Restricted the upgrade commands accepted from the agent message channel in Analysisd. ([#37745](https://github.com/wazuh/wazuh/pull/37745))
 
 ### Agent
 

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1962,9 +1962,16 @@ void DispatchUpgradeModule(Eventinfo * lf) {
     cJSON *message_obj = cJSON_Parse(lf->log);
 
     if (message_obj) {
+        cJSON *message_command = cJSON_GetObjectItem(message_obj, "command");
         cJSON *message_params = cJSON_GetObjectItem(message_obj, "parameters");
 
-        if (message_params) {
+        // Agents may only report their own upgrade status; any other command
+        // (e.g. "upgrade", "upgrade_custom") must come from the management API,
+        // never from the agent-message channel.
+        if (!message_command || message_command->type != cJSON_String ||
+            strcmp(message_command->valuestring, "upgrade_update_status") != 0) {
+            mdebug1("Agent '%s' is not allowed to request the upgrade command received on the agent channel", lf->agent_id);
+        } else if (message_params) {
             int sock = OS_ConnectUnixDomain(WM_UPGRADE_SOCK, SOCK_STREAM, OS_MAXSTR);
 
             if (sock == OS_SOCKTERR) {

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -66,6 +66,7 @@ int DecodeCiscat(Eventinfo *lf, int *socket);
 int DecodeWinevt(Eventinfo *lf);
 int DecodeSCA(Eventinfo *lf, int *socket);
 void DispatchDBSync(dbsync_context_t * ctx, Eventinfo * lf);
+void DispatchUpgradeModule(Eventinfo * lf);
 
 // Init sdb and decoder struct
 void sdb_init(_sdb *localsdb, OSDecoderInfo *fim_decoder);
@@ -1947,41 +1948,45 @@ void * w_dispatch_upgrade_module_thread(__attribute__((unused)) void * args) {
 
             w_inc_modules_upgrade_decoded_events(lf->agent_id);
 
-            // Inserts agent id into incomming message and sends it to upgrade module
-            cJSON *message_obj = cJSON_Parse(lf->log);
-
-            if (message_obj) {
-                cJSON *message_params = cJSON_GetObjectItem(message_obj, "parameters");
-
-                if (message_params) {
-                    int sock = OS_ConnectUnixDomain(WM_UPGRADE_SOCK, SOCK_STREAM, OS_MAXSTR);
-
-                    if (sock == OS_SOCKTERR) {
-                        merror("Could not connect to upgrade module socket at '%s'. Error: %s", WM_UPGRADE_SOCK, strerror(errno));
-                    } else {
-                        int agent = atoi(lf->agent_id);
-                        cJSON* agents = cJSON_CreateIntArray(&agent, 1);
-                        cJSON_AddItemToObject(message_params, "agents", agents);
-
-                        char *message = cJSON_PrintUnformatted(message_obj);
-                        OS_SendSecureTCP(sock, strlen(message), message);
-                        os_free(message);
-
-                        close(sock);
-                    }
-                } else {
-                    merror("Could not get parameters from upgrade message: %s", lf->log);
-                }
-                cJSON_Delete(message_obj);
-            } else {
-                merror("Could not parse upgrade message: %s", lf->log);
-            }
+            DispatchUpgradeModule(lf);
 
             Free_Eventinfo(lf);
         }
     }
 
     return NULL;
+}
+
+// Inserts agent id into incomming message and sends it to upgrade module
+void DispatchUpgradeModule(Eventinfo * lf) {
+    cJSON *message_obj = cJSON_Parse(lf->log);
+
+    if (message_obj) {
+        cJSON *message_params = cJSON_GetObjectItem(message_obj, "parameters");
+
+        if (message_params) {
+            int sock = OS_ConnectUnixDomain(WM_UPGRADE_SOCK, SOCK_STREAM, OS_MAXSTR);
+
+            if (sock == OS_SOCKTERR) {
+                merror("Could not connect to upgrade module socket at '%s'. Error: %s", WM_UPGRADE_SOCK, strerror(errno));
+            } else {
+                int agent = atoi(lf->agent_id);
+                cJSON* agents = cJSON_CreateIntArray(&agent, 1);
+                cJSON_AddItemToObject(message_params, "agents", agents);
+
+                char *message = cJSON_PrintUnformatted(message_obj);
+                OS_SendSecureTCP(sock, strlen(message), message);
+                os_free(message);
+
+                close(sock);
+            }
+        } else {
+            merror("Could not get parameters from upgrade message: %s", lf->log);
+        }
+        cJSON_Delete(message_obj);
+    } else {
+        merror("Could not parse upgrade message: %s", lf->log);
+    }
 }
 
 void * w_process_event_thread(__attribute__((unused)) void * id){

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -189,6 +189,9 @@ LIST(APPEND analysisd_flags "-Wl,--wrap,_minfo -Wl,--wrap,_mwarn")
 list(APPEND analysisd_names "test_json_extended")
 list(APPEND analysisd_flags "${DEBUG_OP_WRAPPERS}")
 
+list(APPEND analysisd_names "test_analysisd_upgrade_module")
+list(APPEND analysisd_flags "-Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP ${DEBUG_OP_WRAPPERS}")
+
 list(LENGTH analysisd_names count)
 math(EXPR count "${count} - 1")
 foreach(counter RANGE ${count})

--- a/src/unit_tests/analysisd/test_analysisd_upgrade_module.c
+++ b/src/unit_tests/analysisd/test_analysisd_upgrade_module.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+#include "../wrappers/wazuh/os_net/os_net_wrappers.h"
+
+#include "../analysisd/eventinfo.h"
+#include "../headers/defs.h"
+
+void DispatchUpgradeModule(Eventinfo * lf);
+
+/* setup/teardown */
+
+static int setup_upgrade_event(void **state) {
+    Eventinfo *lf;
+
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_calloc(OS_SIZE_16, sizeof(char), lf->agent_id);
+    snprintf(lf->agent_id, OS_SIZE_16, "001");
+
+    *state = lf;
+
+    return 0;
+}
+
+static int teardown_upgrade_event(void **state) {
+    Eventinfo *lf = *state;
+
+    os_free(lf->agent_id);
+    os_free(lf->log);
+    os_free(lf);
+
+    return 0;
+}
+
+/* tests */
+
+static void test_DispatchUpgradeModule_blocks_upgrade_custom_from_agent(void **state) {
+    Eventinfo *lf = *state;
+
+    os_strdup(
+        "{\"command\":\"upgrade_custom\",\"parameters\":{\"file_path\":\"/etc/shadow\",\"installer\":\"upgrade.sh\"}}",
+        lf->log);
+
+    expect_string(__wrap__mdebug1, formatted_msg,
+                  "Agent '001' is not allowed to request the upgrade command received on the agent channel");
+
+    DispatchUpgradeModule(lf);
+}
+
+static void test_DispatchUpgradeModule_blocks_upgrade_from_agent(void **state) {
+    Eventinfo *lf = *state;
+
+    os_strdup(
+        "{\"command\":\"upgrade\",\"parameters\":{\"wpk_repository\":\"http://x/\",\"wpk_file\":\"a.wpk\",\"wpk_sha1\":\"abc\"}}",
+        lf->log);
+
+    expect_string(__wrap__mdebug1, formatted_msg,
+                  "Agent '001' is not allowed to request the upgrade command received on the agent channel");
+
+    DispatchUpgradeModule(lf);
+}
+
+static void test_DispatchUpgradeModule_allows_status_update(void **state) {
+    Eventinfo *lf = *state;
+
+    os_strdup("{\"command\":\"upgrade_update_status\",\"parameters\":{\"status\":\"Done\"}}", lf->log);
+
+    expect_string(__wrap_OS_ConnectUnixDomain, path, WM_UPGRADE_SOCK);
+    expect_value(__wrap_OS_ConnectUnixDomain, type, SOCK_STREAM);
+    expect_value(__wrap_OS_ConnectUnixDomain, max_msg_size, OS_MAXSTR);
+    will_return(__wrap_OS_ConnectUnixDomain, 44);
+
+    expect_value(__wrap_OS_SendSecureTCP, sock, 44);
+    expect_any(__wrap_OS_SendSecureTCP, size);
+    expect_any(__wrap_OS_SendSecureTCP, msg);
+    will_return(__wrap_OS_SendSecureTCP, 0);
+
+    DispatchUpgradeModule(lf);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_DispatchUpgradeModule_blocks_upgrade_custom_from_agent,
+                                         setup_upgrade_event, teardown_upgrade_event),
+        cmocka_unit_test_setup_teardown(test_DispatchUpgradeModule_blocks_upgrade_from_agent,
+                                         setup_upgrade_event, teardown_upgrade_event),
+        cmocka_unit_test_setup_teardown(test_DispatchUpgradeModule_allows_status_update,
+                                         setup_upgrade_event, teardown_upgrade_event),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## Description
`wazuh-analysisd` forwarded any agent-originated message received on the `UPGRADE_MQ` queue verbatim to the `wm_agent_upgrade` manager module's socket, with no check on the `command` field. Since that module applies no origin check either, an agent could inject an `upgrade_custom` command with an attacker-chosen `file_path`, causing the manager (running as root) to read and stream back any file on its filesystem — or inject a plain `upgrade` command to force upgrade/downgrade/reinstall of an agent. The fix makes `wazuh-analysisd` only forward the one command an agent may legitimately send on this channel (`upgrade_update_status`); any other command is rejected and logged before it ever reaches the upgrade module's socket.

## Proposed Changes
- `wazuh-analysisd` used to forward any agent-originated message on the upgrade channel straight to the upgrade module's socket, with no check on what command it was actually requesting. This PR adds that missing check: analysisd now looks at the command name before forwarding, and only lets through `upgrade_update_status` — the one message an agent legitimately needs to send here, to report progress on an upgrade already in flight. Any other command (in particular `upgrade` and `upgrade_custom`, which only the management API should ever be able to trigger) is dropped and logged at debug level, so it can't be abused to flood the manager's log at default verbosity either.
- To make this check testable on its own, the per-message forwarding logic that used to live inline inside the dispatch thread was pulled out into its own function, `DispatchUpgradeModule`, following the same pattern already used for `DispatchDBSync` elsewhere in the file. This part is a pure structural change, with no behavior difference — it just gives the new check something to be unit-tested against.

### Results and Evidence
Unit tests run automatically in CI (see Tests Introduced below); the evidence here is from manual verification against a running manager.

Built the fix (`wazuh-analysisd` v4.14.8) and installed it on a manager with a real registered agent (id `001`). Injected the same agent-channel message described in the GHSA reproduction directly onto `wazuh-analysisd`'s local queue socket, impersonating that agent:
```
u:[001] (fbb1635f5a97) any->upgrade_module:{"command":"upgrade_custom","parameters":{"file_path":"/var/ossec/tmp/agent.wpk","installer":"upgrade.sh"}}
```
`ossec.log` confirms the message is rejected inside `DispatchUpgradeModule`, before it ever reaches `WM_UPGRADE_SOCK` — so the vulnerable file read is never attempted:
```
2026/07/17 12:48:49 wazuh-analysisd[103309] analysisd.c:1973 at DispatchUpgradeModule(): DEBUG: Agent '001' is not allowed to request the upgrade command received on the agent channel
```

### Artifacts Affected
- `wazuh-analysisd` (manager component).

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
- `src/unit_tests/analysisd/test_analysisd_upgrade_module.c`:
  - `test_DispatchUpgradeModule_blocks_upgrade_custom_from_agent` — an agent-forged `upgrade_custom` message (with `file_path` set to `/etc/shadow`) is rejected and never reaches `OS_ConnectUnixDomain`/`OS_SendSecureTCP`.
  - `test_DispatchUpgradeModule_blocks_upgrade_from_agent` — an agent-forged plain `upgrade` message is rejected the same way.
  - `test_DispatchUpgradeModule_allows_status_update` — the legitimate `upgrade_update_status` message an agent sends is still forwarded to `WM_UPGRADE_SOCK` unchanged, confirming the fix does not break normal upgrade-status reporting.

## Credits

Thanks to @kah-ja, [turingpoint](https://www.turingpoint.de) for reporting this issue.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
