### PR TITLE
Add new indexer API roles mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added new CVE 5.0 schema fields to the Vulnerability Detector content model. ([#36000](https://github.com/wazuh/wazuh/issues/36000))
 - Added manager watermarks. ([#35579](https://github.com/wazuh/wazuh/issues/35579))
 - Added byte-based capacity limits to wazuh-manager-remoted. ([#37052](https://github.com/wazuh/wazuh/issues/37052))
+- Added default API role mappings for the indexer users wazuh-admin, wazuh-readonly and wazuh-demo. ([#37706](https://github.com/wazuh/wazuh/issues/37706))
 
 #### Changed
 

--- a/api/test/integration/mapping/_test_mapping.py
+++ b/api/test/integration/mapping/_test_mapping.py
@@ -68,7 +68,7 @@ def get_file_and_test_info(test_name, test_mapping, module_name):
     if test_tag == 'test':
         # Integration tests themselves must be added. Unit tests must not
         related_tests = [test_name] if test_name.endswith('.yaml') else []
-    elif path.basename(module_name) == 'rbac':
+    elif module_name.startswith(path.join('framework', 'wazuh', 'rbac')):
         # Every file within the RBAC directory must be tagged as RBAC
         related_tests = test_mapping['rbac']
     elif test_tag in ['black', 'white']:
@@ -100,7 +100,7 @@ if __name__ == '__main__':
                 mappings['files'] = list()
                 for file in sorted(files):
                     if file.endswith(allowed_extensions):
-                        test_info = get_file_and_test_info(file, test_tags, module)
+                        test_info = get_file_and_test_info(file, test_tags, mappings['path'])
                         if test_info and test_info[2]:
                             mappings['files'].append({'name': test_info[0], 'tag': test_info[1], 'tests': test_info[2]})
 

--- a/api/test/integration/mapping/integration_test_api_endpoints.json
+++ b/api/test/integration/mapping/integration_test_api_endpoints.json
@@ -514,6 +514,17 @@
                 ]
             },
             {
+                "name": "engine_http.py",
+                "tag": "engine",
+                "tests": [
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml"
+                ]
+            },
+            {
                 "name": "exception.py",
                 "tag": "exception",
                 "tests": [
@@ -908,17 +919,6 @@
                 ]
             },
             {
-                "name": "max_version_components.py",
-                "tag": "max",
-                "tests": [
-                    "test_agent_DELETE_endpoints.tavern.yaml",
-                    "test_agent_GET_endpoints.tavern.yaml",
-                    "test_agent_POST_endpoints.tavern.yaml",
-                    "test_agent_PUT_endpoints.tavern.yaml",
-                    "test_cluster_endpoints.tavern.yaml"
-                ]
-            },
-            {
                 "name": "metrics.py",
                 "tag": "metrics",
                 "tests": [
@@ -932,6 +932,17 @@
             {
                 "name": "metrics_snapshot.py",
                 "tag": "metrics",
+                "tests": [
+                    "test_agent_DELETE_endpoints.tavern.yaml",
+                    "test_agent_GET_endpoints.tavern.yaml",
+                    "test_agent_POST_endpoints.tavern.yaml",
+                    "test_agent_PUT_endpoints.tavern.yaml",
+                    "test_cluster_endpoints.tavern.yaml"
+                ]
+            },
+            {
+                "name": "states_components.py",
+                "tag": "states",
                 "tests": [
                     "test_agent_DELETE_endpoints.tavern.yaml",
                     "test_agent_GET_endpoints.tavern.yaml",
@@ -965,55 +976,95 @@
                 "name": "auth_context.py",
                 "tag": "auth",
                 "tests": [
-                    "test_agent_DELETE_endpoints.tavern.yaml",
-                    "test_agent_GET_endpoints.tavern.yaml",
-                    "test_agent_POST_endpoints.tavern.yaml",
-                    "test_agent_PUT_endpoints.tavern.yaml",
-                    "test_cluster_endpoints.tavern.yaml"
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_white_all_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml"
                 ]
             },
             {
                 "name": "decorators.py",
                 "tag": "decorators",
                 "tests": [
-                    "test_agent_DELETE_endpoints.tavern.yaml",
-                    "test_agent_GET_endpoints.tavern.yaml",
-                    "test_agent_POST_endpoints.tavern.yaml",
-                    "test_agent_PUT_endpoints.tavern.yaml",
-                    "test_cluster_endpoints.tavern.yaml"
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_white_all_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml"
                 ]
             },
             {
                 "name": "orm.py",
                 "tag": "orm",
                 "tests": [
-                    "test_agent_DELETE_endpoints.tavern.yaml",
-                    "test_agent_GET_endpoints.tavern.yaml",
-                    "test_agent_POST_endpoints.tavern.yaml",
-                    "test_agent_PUT_endpoints.tavern.yaml",
-                    "test_cluster_endpoints.tavern.yaml"
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_white_all_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml"
                 ]
             },
             {
                 "name": "preprocessor.py",
                 "tag": "preprocessor",
                 "tests": [
-                    "test_agent_DELETE_endpoints.tavern.yaml",
-                    "test_agent_GET_endpoints.tavern.yaml",
-                    "test_agent_POST_endpoints.tavern.yaml",
-                    "test_agent_PUT_endpoints.tavern.yaml",
-                    "test_cluster_endpoints.tavern.yaml"
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_white_all_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml"
                 ]
             },
             {
                 "name": "utils.py",
                 "tag": "utils",
                 "tests": [
-                    "test_agent_DELETE_endpoints.tavern.yaml",
-                    "test_agent_GET_endpoints.tavern.yaml",
-                    "test_agent_POST_endpoints.tavern.yaml",
-                    "test_agent_PUT_endpoints.tavern.yaml",
-                    "test_cluster_endpoints.tavern.yaml"
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_white_all_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml"
                 ]
             }
         ]
@@ -1025,55 +1076,95 @@
                 "name": "policies.yaml",
                 "tag": "policies",
                 "tests": [
-                    "test_agent_DELETE_endpoints.tavern.yaml",
-                    "test_agent_GET_endpoints.tavern.yaml",
-                    "test_agent_POST_endpoints.tavern.yaml",
-                    "test_agent_PUT_endpoints.tavern.yaml",
-                    "test_cluster_endpoints.tavern.yaml"
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_white_all_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml"
                 ]
             },
             {
                 "name": "relationships.yaml",
                 "tag": "relationships",
                 "tests": [
-                    "test_agent_DELETE_endpoints.tavern.yaml",
-                    "test_agent_GET_endpoints.tavern.yaml",
-                    "test_agent_POST_endpoints.tavern.yaml",
-                    "test_agent_PUT_endpoints.tavern.yaml",
-                    "test_cluster_endpoints.tavern.yaml"
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_white_all_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml"
                 ]
             },
             {
                 "name": "roles.yaml",
                 "tag": "roles",
                 "tests": [
-                    "test_agent_DELETE_endpoints.tavern.yaml",
-                    "test_agent_GET_endpoints.tavern.yaml",
-                    "test_agent_POST_endpoints.tavern.yaml",
-                    "test_agent_PUT_endpoints.tavern.yaml",
-                    "test_cluster_endpoints.tavern.yaml"
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_white_all_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml"
                 ]
             },
             {
                 "name": "rules.yaml",
                 "tag": "rules",
                 "tests": [
-                    "test_agent_DELETE_endpoints.tavern.yaml",
-                    "test_agent_GET_endpoints.tavern.yaml",
-                    "test_agent_POST_endpoints.tavern.yaml",
-                    "test_agent_PUT_endpoints.tavern.yaml",
-                    "test_cluster_endpoints.tavern.yaml"
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_white_all_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml"
                 ]
             },
             {
                 "name": "users.yaml",
                 "tag": "users",
                 "tests": [
-                    "test_agent_DELETE_endpoints.tavern.yaml",
-                    "test_agent_GET_endpoints.tavern.yaml",
-                    "test_agent_POST_endpoints.tavern.yaml",
-                    "test_agent_PUT_endpoints.tavern.yaml",
-                    "test_cluster_endpoints.tavern.yaml"
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_white_all_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml"
                 ]
             }
         ]
@@ -1085,11 +1176,19 @@
                 "name": "utils.py",
                 "tag": "utils",
                 "tests": [
-                    "test_agent_DELETE_endpoints.tavern.yaml",
-                    "test_agent_GET_endpoints.tavern.yaml",
-                    "test_agent_POST_endpoints.tavern.yaml",
-                    "test_agent_PUT_endpoints.tavern.yaml",
-                    "test_cluster_endpoints.tavern.yaml"
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_white_all_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml"
                 ]
             }
         ]
@@ -1101,11 +1200,19 @@
                 "name": "schema_security_test.sql",
                 "tag": "schema",
                 "tests": [
-                    "test_agent_DELETE_endpoints.tavern.yaml",
-                    "test_agent_GET_endpoints.tavern.yaml",
-                    "test_agent_POST_endpoints.tavern.yaml",
-                    "test_agent_PUT_endpoints.tavern.yaml",
-                    "test_cluster_endpoints.tavern.yaml"
+                    "test_rbac_black_agent_endpoints.tavern.yaml",
+                    "test_rbac_black_cluster_endpoints.tavern.yaml",
+                    "test_rbac_black_mitre_endpoints.tavern.yaml",
+                    "test_rbac_black_overview_endpoints.tavern.yaml",
+                    "test_rbac_black_security_endpoints.tavern.yaml",
+                    "test_rbac_black_task_endpoints.tavern.yaml",
+                    "test_rbac_white_agent_endpoints.tavern.yaml",
+                    "test_rbac_white_all_endpoints.tavern.yaml",
+                    "test_rbac_white_cluster_endpoints.tavern.yaml",
+                    "test_rbac_white_mitre_endpoints.tavern.yaml",
+                    "test_rbac_white_overview_endpoints.tavern.yaml",
+                    "test_rbac_white_security_endpoints.tavern.yaml",
+                    "test_rbac_white_task_endpoints.tavern.yaml"
                 ]
             }
         ]
@@ -1273,39 +1380,6 @@
                 "tag": "default",
                 "tests": [
                     "test_default_endpoints.tavern.yaml"
-                ]
-            },
-            {
-                "name": "migration_policies.yml",
-                "tag": "migration",
-                "tests": [
-                    "test_agent_DELETE_endpoints.tavern.yaml",
-                    "test_agent_GET_endpoints.tavern.yaml",
-                    "test_agent_POST_endpoints.tavern.yaml",
-                    "test_agent_PUT_endpoints.tavern.yaml",
-                    "test_cluster_endpoints.tavern.yaml"
-                ]
-            },
-            {
-                "name": "mock_relationships.yml",
-                "tag": "mock",
-                "tests": [
-                    "test_agent_DELETE_endpoints.tavern.yaml",
-                    "test_agent_GET_endpoints.tavern.yaml",
-                    "test_agent_POST_endpoints.tavern.yaml",
-                    "test_agent_PUT_endpoints.tavern.yaml",
-                    "test_cluster_endpoints.tavern.yaml"
-                ]
-            },
-            {
-                "name": "new_default_policies.yml",
-                "tag": "new",
-                "tests": [
-                    "test_agent_DELETE_endpoints.tavern.yaml",
-                    "test_agent_GET_endpoints.tavern.yaml",
-                    "test_agent_POST_endpoints.tavern.yaml",
-                    "test_agent_PUT_endpoints.tavern.yaml",
-                    "test_cluster_endpoints.tavern.yaml"
                 ]
             }
         ]

--- a/api/test/integration/test_rbac_black_security_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_black_security_endpoints.tavern.yaml
@@ -228,13 +228,16 @@ stages:
           affected_items:
             - id: 1
             - id: 2
+            - id: 3
+            - id: 4
+            - id: 5
             - id: 100
             - id: 101
             - id: 102
             - id: 104
             - id: 105
           failed_items: []
-          total_affected_items: 7
+          total_affected_items: 10
           total_failed_items: 0
 
   - name: Get a specified rule by its id (Deny)

--- a/api/test/integration/test_rbac_white_security_endpoints.tavern.yaml
+++ b/api/test/integration/test_rbac_white_security_endpoints.tavern.yaml
@@ -202,6 +202,8 @@ stages:
               name: cluster_readonly
             - id: 7
               name: cluster_admin
+            - id: 8
+              name: wazuh_indexer_admin
             - id: 99
               name: testing
             - id: 100
@@ -216,7 +218,7 @@ stages:
               name: normalUser
             - id: 105
               name: ossec
-          total_affected_items: 14
+          total_affected_items: 15
           total_failed_items: 0
           failed_items: []
 
@@ -311,6 +313,9 @@ stages:
           affected_items:
             - id: 1
             - id: 2
+            - id: 3
+            - id: 4
+            - id: 5
             - id: 100
             - id: 101
             - id: 102
@@ -318,7 +323,7 @@ stages:
             - id: 104
             - id: 105
           failed_items: []
-          total_affected_items: 8
+          total_affected_items: 11
           total_failed_items: 0
 
 ---

--- a/api/test/integration/test_security_POST_endpoints.tavern.yaml
+++ b/api/test/integration/test_security_POST_endpoints.tavern.yaml
@@ -1087,6 +1087,54 @@ stages:
         extra_kwargs:
           expected_roles: [1]
 
+  - name: Log in with wazuh-wui and default rules and expect readonly permissions (wazuh-demo)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/user/authenticate/run_as"
+      headers:
+        Authorization: "Basic {basic_auth_context:s}"
+      method: POST
+      json:
+        user_name: "wazuh-demo" # Indexer default user
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_validate_auth_context
+        extra_kwargs:
+          expected_roles: [2]
+
+  - name: Log in with wazuh-wui and default rules and expect readonly permissions (wazuh-readonly)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/user/authenticate/run_as"
+      headers:
+        Authorization: "Basic {basic_auth_context:s}"
+      method: POST
+      json:
+        user_name: "wazuh-readonly" # Indexer default user
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_validate_auth_context
+        extra_kwargs:
+          expected_roles: [2]
+
+  - name: Log in with wazuh-wui and default rules and expect wazuh_indexer_admin permissions (wazuh-admin)
+    request:
+      verify: False
+      url: "{protocol:s}://{host:s}:{balanced_port:d}/security/user/authenticate/run_as"
+      headers:
+        Authorization: "Basic {basic_auth_context:s}"
+      method: POST
+      json:
+        user_name: "wazuh-admin" # Indexer default user
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tavern_utils:test_validate_auth_context
+        extra_kwargs:
+          expected_roles: [8]
+
   - name: Log in with wazuh-wui and no matching rule
     request:
       verify: False

--- a/framework/wazuh/rbac/default/policies.yaml
+++ b/framework/wazuh/rbac/default/policies.yaml
@@ -167,3 +167,22 @@ default_policies:
         resources:
           - '*:*:*'
         effect: allow
+
+  security_read:
+    description: Provide read-only access to all security related functionalities.
+    policies:
+      resourceless:
+        actions:
+          - security:read_config
+        resources:
+          - '*:*:*'
+        effect: allow
+      security:
+        actions:
+          - security:read
+        resources:
+          - role:id:*
+          - policy:id:*
+          - user:id:*
+          - rule:id:*
+        effect: allow

--- a/framework/wazuh/rbac/default/relationships.yaml
+++ b/framework/wazuh/rbac/default/relationships.yaml
@@ -27,7 +27,19 @@ relationships:
         - agents_read
         - cluster_read
         - mitre_read
-      rule_ids: []
+      rule_ids:
+        - wazuh_indexer_readonly
+        - wazuh_indexer_demo
+
+    wazuh_indexer_admin:
+      policy_ids:
+        - agents_all
+        - security_read
+        - cluster_all
+        - mitre_read
+        - task_status
+      rule_ids:
+        - wazuh_indexer_admin
 
     users_admin:
       policy_ids:

--- a/framework/wazuh/rbac/default/roles.yaml
+++ b/framework/wazuh/rbac/default/roles.yaml
@@ -21,3 +21,6 @@ default_roles:
 
   cluster_admin:
     description: Manager administrator of the system, this role have full access to all manager related functionalities.
+
+  wazuh_indexer_admin:
+    description: Indexer administrator, this role can only read security configurations, not change them.

--- a/framework/wazuh/rbac/default/rules.yaml
+++ b/framework/wazuh/rbac/default/rules.yaml
@@ -12,3 +12,21 @@ default_rules:
     rule:
       FIND:
         user_name: "admin"
+
+  wazuh_indexer_demo:
+    description: "Read-only permissions for the indexer's wazuh-demo user."
+    rule:
+      FIND:
+        user_name: "wazuh-demo"
+
+  wazuh_indexer_readonly:
+    description: "Read-only permissions for the indexer's wazuh-readonly user."
+    rule:
+      FIND:
+        user_name: "wazuh-readonly"
+
+  wazuh_indexer_admin:
+    description: "Administrator permissions with read-only access to security resources for the indexer's wazuh-admin user."
+    rule:
+      FIND:
+        user_name: "wazuh-admin"


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

The Wazuh indexer ships with default `wazuh-readonly`, `wazuh-demo`, and `wazuh-admin` users, but there was no RBAC role mapping associating these users with a role in the Wazuh API. This PR adds the missing default role mappings so these indexer users are granted the appropriate Wazuh API permissions when they authenticate through the `run_as` flow.

Closes #37706

## Proposed Changes

- Added `FIND` rules in `rules.yaml` matching each indexer user by `user_name`: `wazuh_indexer_demo`, `wazuh_indexer_readonly`, `wazuh_indexer_admin`.
- Attached `wazuh_indexer_demo` and `wazuh_indexer_readonly` to the existing `readonly` role, so both `wazuh-demo` and `wazuh-readonly` are granted read-only access.
- Added a new `security_read` policy (`security:read`, `security:read_config`), since the existing `security_all` policy bundles read and write security actions together and could not be reused as-is. It is appended at the end of `policies.yaml` so the IDs of the pre-existing default policies remain unchanged.
- Added a new `wazuh_indexer_admin` role, with the same policies as `administrator` (`agents_all`, `cluster_all`, `mitre_read`, `task_status`) but `security_read` instead of `security_all`, so `wazuh-admin` can read but not modify the security configuration. Attached to the `wazuh_indexer_admin` rule.

### Results and Evidence

<details>
<summary>New role, policies and rules in dashboard</summary>

<img width="1920" height="1085" alt="image" src="https://github.com/user-attachments/assets/0017bd2f-f829-41d5-9f8a-5db230c8148e" />


<img width="1920" height="1085" alt="image" src="https://github.com/user-attachments/assets/8902bc5e-bf20-4052-a6bb-45557d59be1f" />

<img width="958" height="1035" alt="image" src="https://github.com/user-attachments/assets/7aada926-5533-4a5c-8724-b212e878832d" />

<img width="958" height="1035" alt="image" src="https://github.com/user-attachments/assets/9545d60f-e8dc-416d-a962-c670987bc705" />

<img width="958" height="1035" alt="image" src="https://github.com/user-attachments/assets/b8fca0c6-9fd5-493d-9982-1f83d3a7177e" />

</details>

<details>
<summary>wazuh-demo</summary>

<img width="1920" height="1085" alt="image" src="https://github.com/user-attachments/assets/1f33a105-0609-4b5c-96cd-3d2bf58fa610" />

<img width="472" height="298" alt="image" src="https://github.com/user-attachments/assets/8d797d50-12c4-4011-9b8d-889d631de718" />

<img width="1920" height="1084" alt="image" src="https://github.com/user-attachments/assets/75cc9045-8c9b-401f-9a64-b683732f99c4" />

<img width="1920" height="1084" alt="image" src="https://github.com/user-attachments/assets/91d5d308-adc2-4068-959d-9bdfb878b625" />

<img width="1920" height="1084" alt="image" src="https://github.com/user-attachments/assets/2086624f-942e-4944-ab0e-98e86b530f1f" />

<img width="1920" height="1084" alt="image" src="https://github.com/user-attachments/assets/a43480b6-72a0-454c-b476-173c21c95785" />

<img width="1920" height="1084" alt="image" src="https://github.com/user-attachments/assets/da8f9669-6273-443a-927b-1754d8f944da" />

</details>

<details>
<summary>wazuh-readonly</summary>

<img width="1920" height="1084" alt="image" src="https://github.com/user-attachments/assets/21307001-13cd-43a3-8945-64953452d6f6" />

<img width="473" height="297" alt="image" src="https://github.com/user-attachments/assets/bb182022-8e21-4c24-bbea-6f2c71bac90f" />

<img width="1920" height="1083" alt="image" src="https://github.com/user-attachments/assets/dd5e1132-5f16-4ed1-85fa-2fbe505f0b54" />

<img width="1920" height="1083" alt="image" src="https://github.com/user-attachments/assets/19f759f2-75bb-4560-a04a-def136a6a3d3" />

<img width="1920" height="1083" alt="image" src="https://github.com/user-attachments/assets/436e73ea-de86-4eed-87c0-9e3df9b5f032" />

</details>

<details>
<summary>wazuh-admin</summary>

<img width="1920" height="1084" alt="image" src="https://github.com/user-attachments/assets/e6e3a1b0-5081-4fc0-bfb4-b7988a3f86af" />

<img width="470" height="291" alt="image" src="https://github.com/user-attachments/assets/484fa473-d290-42a2-9d58-3eeecfd0a1da" />

<img width="1920" height="1084" alt="image" src="https://github.com/user-attachments/assets/7d80a826-92b6-4e22-b395-9d66c99dd5ec" />

<img width="1920" height="1084" alt="image" src="https://github.com/user-attachments/assets/9392b8dd-6dde-4893-9ae7-176135168fce" />

<img width="1920" height="1084" alt="image" src="https://github.com/user-attachments/assets/329e5c78-d8d4-4850-8480-96f8401ffde9" />

<img width="1920" height="1084" alt="image" src="https://github.com/user-attachments/assets/9ef54054-4ad0-4b94-979c-33b8045a5cfc" />

<img width="1920" height="1084" alt="image" src="https://github.com/user-attachments/assets/5725ce2d-5025-46d0-8e35-3299c50f930e" />

<img width="1920" height="1084" alt="image" src="https://github.com/user-attachments/assets/8c1c3040-7685-4c63-b080-3bfdbcb2311e" />

<img width="1920" height="1084" alt="image" src="https://github.com/user-attachments/assets/56841b0e-ef3e-4765-93b4-5e2855a78993" />

<img width="1920" height="1084" alt="image" src="https://github.com/user-attachments/assets/dd0fc739-48bd-48b9-9078-2bbcdbd798ea" />

</details>

Additionally, `framework/wazuh/rbac/tests/test_default_configuration.py` (which parametrizes directly off these YAML files) passes with the new role, rule, and policy entries, confirming they load correctly into the RBAC database:

```
(.venv) root@wazuh-master:/home/vagrant/wazuh# PYTHONPATH="/home/vagrant/wazuh/framework:/home/vagrant/wazuh/api" python3 -m pytest framework/
wazuh/rbac/tests/test_default_configuration.py -v
/home/vagrant/wazuh/.venv/lib/python3.12/site-packages/pytest_html/__init__.py:1: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import get_distribution, DistributionNotFound
============================================================ test session starts =============================================================
platform linux -- Python 3.12.3, pytest-7.3.1, pluggy-1.6.0 -- /home/vagrant/wazuh/.venv/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.12.3', 'Platform': 'Linux-6.8.0-86-generic-x86_64-with-glibc2.39', 'Packages': {'pytest': '7.3.1', 'pluggy': '1.6.0'}, 'Plugins': {'tavern': '1.23.5', 'rerunfailures': '13.0', 'cov': '4.1.0', 'anyio': '4.1.0', 'trio': '0.8.0', 'asyncio': '0.18.1', 'html': '2.1.1', 'metadata': '3.1.1'}}
rootdir: /home/vagrant/wazuh/framework
configfile: pytest.ini
plugins: tavern-1.23.5, rerunfailures-13.0, cov-4.1.0, anyio-4.1.0, trio-0.8.0, asyncio-0.18.1, html-2.1.1, metadata-3.1.1
asyncio: mode=Mode.AUTO
collected 43 items                                                                                                                           

framework/wazuh/rbac/tests/test_default_configuration.py::test_roles_default[administrator-Administrator role of the system, this role have full access to the system.] PASSED [  2%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_roles_default[readonly-Read only role, this role can read all the information of the system.] PASSED [  4%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_roles_default[users_admin-Users administrator of the system, this role have full access to all users related functionalities.] PASSED [  6%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_roles_default[agents_readonly-Read only role for agents related functionalities.] PASSED [  9%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_roles_default[agents_admin-Agents administrator of the system, this role have full access to all agents related functionalities.] PASSED [ 11%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_roles_default[cluster_readonly-Read only role for manager related functionalities.] PASSED [ 13%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_roles_default[cluster_admin-Manager administrator of the system, this role have full access to all manager related functionalities.] PASSED [ 16%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_roles_default[wazuh_indexer_admin-Indexer administrator, this role can only read security configurations, not change them.] PASSED [ 18%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_rules_default[wui_elastic_admin-rule_info0] PASSED                      [ 20%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_rules_default[wui_opensearch_admin-rule_info1] PASSED                   [ 23%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_rules_default[wazuh_indexer_demo-rule_info2] PASSED                     [ 25%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_rules_default[wazuh_indexer_readonly-rule_info3] PASSED                 [ 27%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_rules_default[wazuh_indexer_admin-rule_info4] PASSED                    [ 30%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_policies_default[agents_all_resourceless-policy_policy0] PASSED         [ 32%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_policies_default[agents_all_agents-policy_policy1] PASSED               [ 34%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_policies_default[agents_all_groups-policy_policy2] PASSED               [ 37%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_policies_default[agents_read_agents-policy_policy3] PASSED              [ 39%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_policies_default[agents_read_groups-policy_policy4] PASSED              [ 41%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_policies_default[security_all_resourceless-policy_policy5] PASSED       [ 44%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_policies_default[security_all_security-policy_policy6] PASSED           [ 46%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_policies_default[security_read_resourceless-policy_policy7] PASSED      [ 48%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_policies_default[security_read_security-policy_policy8] PASSED          [ 51%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_policies_default[users_all_resourceless-policy_policy9] PASSED          [ 53%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_policies_default[users_all_users-policy_policy10] PASSED                [ 55%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_policies_default[users_modify_run_as_flag-policy_policy11] PASSED       [ 58%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_policies_default[mitre_read_mitre-policy_policy12] PASSED               [ 60%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_policies_default[cluster_all_resourceless-policy_policy13] PASSED       [ 62%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_policies_default[cluster_all_nodes-policy_policy14] PASSED              [ 65%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_policies_default[cluster_read_resourceless-policy_policy15] PASSED      [ 67%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_policies_default[cluster_read_nodes-policy_policy16] PASSED             [ 69%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_policies_default[task_status_task-policy_policy17] PASSED               [ 72%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_users_default[wazuh-True] PASSED                                        [ 74%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_users_default[wazuh-wui-True] PASSED                                    [ 76%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_user_roles_default[wazuh-role_ids0] PASSED                              [ 79%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_user_roles_default[wazuh-wui-role_ids1] PASSED                          [ 81%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_role_policies_default[administrator-policy_names0] PASSED               [ 83%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_role_policies_default[readonly-policy_names1] PASSED                    [ 86%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_role_policies_default[wazuh_indexer_admin-policy_names2] PASSED         [ 88%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_role_policies_default[users_admin-policy_names3] PASSED                 [ 90%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_role_policies_default[agents_readonly-policy_names4] PASSED             [ 93%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_role_policies_default[agents_admin-policy_names5] PASSED                [ 95%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_role_policies_default[cluster_readonly-policy_names6] PASSED            [ 97%]
framework/wazuh/rbac/tests/test_default_configuration.py::test_role_policies_default[cluster_admin-policy_names7] PASSED               [100%]

============================================================== warnings summary ==============================================================
.venv/lib/python3.12/site-packages/dateutil/tz/tz.py:37
  /home/vagrant/wazuh/.venv/lib/python3.12/site-packages/dateutil/tz/tz.py:37: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    EPOCH = datetime.datetime.utcfromtimestamp(0)

.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:683
  /home/vagrant/wazuh/.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:683: DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
    and isinstance(item.value, ast.Str)

.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:685
  /home/vagrant/wazuh/.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:685: DeprecationWarning: Attribute s is deprecated and will be removed in Python 3.14; use value instead
    doc = item.value.s

.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:965: 15 warnings
  /home/vagrant/wazuh/.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:965: DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
    inlocs = ast.Compare(ast.Str(name.id), [ast.In()], [locs])

.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:968: 15 warnings
  /home/vagrant/wazuh/.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:968: DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
    expr = ast.IfExp(test, self.display(name), ast.Str(name.id))

.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1102
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1102
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1102
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1102
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1102
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1102
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1102
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1102
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1102
  /home/vagrant/wazuh/.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1102: DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
    syms.append(ast.Str(sym))

.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1104
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1104
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1104
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1104
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1104
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1104
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1104
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1104
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1104
  /home/vagrant/wazuh/.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:1104: DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
    expls.append(ast.Str(expl))

.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:817: 34 warnings
  /home/vagrant/wazuh/.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:817: DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
    keys = [ast.Str(key) for key in current.keys()]

.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:927
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:927
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:927
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:927
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:927
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:927
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:927
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:927
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:927
  /home/vagrant/wazuh/.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:927: DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
    assertmsg = ast.Str("")

.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:929
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:929
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:929
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:929
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:929
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:929
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:929
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:929
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:929
  /home/vagrant/wazuh/.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:929: DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
    template = ast.BinOp(assertmsg, ast.Add(), ast.Str(explanation))

.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:941
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:941
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:941
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:941
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:941
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:941
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:941
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:941
.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:941
  /home/vagrant/wazuh/.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:941: DeprecationWarning: ast.NameConstant is deprecated and will be removed in Python 3.14; use ast.Constant instead
    clear = ast.Assign(variables, ast.NameConstant(None))

wazuh/rbac/tests/test_default_configuration.py::test_roles_default[administrator-Administrator role of the system, this role have full access to the system.]
  /home/vagrant/wazuh/.venv/lib/python3.12/site-packages/connexion/lifecycle.py:8: PendingDeprecationWarning: Please use `import python_multipart` instead.
    from multipart.multipart import parse_options_header

wazuh/rbac/tests/test_default_configuration.py::test_roles_default[administrator-Administrator role of the system, this role have full access to the system.]
wazuh/rbac/tests/test_default_configuration.py::test_roles_default[administrator-Administrator role of the system, this role have full access to the system.]
  /home/vagrant/wazuh/.venv/lib/python3.12/site-packages/connexion/json_schema.py:16: DeprecationWarning: jsonschema.RefResolver is deprecated as of v4.18.0, in favor of the https://github.com/python-jsonschema/referencing library, which provides more compliant referencing behavior as well as more flexible APIs for customization. A future release will remove RefResolver. Please file a feature request (on referencing) if you are missing an API for the kind of customization you need.
    from jsonschema import Draft4Validator, RefResolver

wazuh/rbac/tests/test_default_configuration.py::test_roles_default[administrator-Administrator role of the system, this role have full access to the system.]
  /home/vagrant/wazuh/.venv/lib/python3.12/site-packages/connexion/json_schema.py:17: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
    from jsonschema.exceptions import RefResolutionError, ValidationError  # noqa

wazuh/rbac/tests/test_default_configuration.py::test_roles_default[administrator-Administrator role of the system, this role have full access to the system.]
wazuh/rbac/tests/test_default_configuration.py::test_roles_default[administrator-Administrator role of the system, this role have full access to the system.]
  /home/vagrant/wazuh/.venv/lib/python3.12/site-packages/connexion/validators/form_data.py:4: DeprecationWarning: Accessing jsonschema.draft4_format_checker is deprecated and will be removed in a future release. Instead, use the FORMAT_CHECKER attribute on the corresponding Validator.
    from jsonschema import ValidationError, draft4_format_checker

wazuh/rbac/tests/test_default_configuration.py::test_roles_default[administrator-Administrator role of the system, this role have full access to the system.]
wazuh/rbac/tests/test_default_configuration.py::test_roles_default[administrator-Administrator role of the system, this role have full access to the system.]
  /home/vagrant/wazuh/.venv/lib/python3.12/site-packages/connexion/validators/json.py:6: DeprecationWarning: Accessing jsonschema.draft4_format_checker is deprecated and will be removed in a future release. Instead, use the FORMAT_CHECKER attribute on the corresponding Validator.
    from jsonschema import Draft4Validator, ValidationError, draft4_format_checker

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================== 43 passed, 120 warnings in 13.69s ======================================================
```

### Artifacts Affected

- Default RBAC security configuration files:
  - `framework/wazuh/rbac/default/roles.yaml`
  - `framework/wazuh/rbac/default/rules.yaml`
  - `framework/wazuh/rbac/default/policies.yaml`
  - `framework/wazuh/rbac/default/relationships.yaml`

### Configuration Changes

- New default role: `wazuh_indexer_admin`.
- New default policy: `security_read`, appended after the existing defaults so their IDs keep the same values as in 4.x.
- New default rules: `wazuh_indexer_demo`, `wazuh_indexer_readonly`, `wazuh_indexer_admin`.
- Purely additive changes to the default RBAC configuration; no existing role, policy, or rule was removed or renamed.
- These defaults are only loaded on a fresh installation (`insert_default_resources`, gated by `CURRENT_ORM_VERSION` in `framework/wazuh/rbac/orm.py`). No version bump was needed since this targets 5.0.0, which requires a fresh install rather than an in-place upgrade.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

