### PR TITLE
Lower httpsrv C++ standard from 20 to 17

### DIFF
--- a/src/shared_modules/httpsrv/CMakeLists.txt
+++ b/src/shared_modules/httpsrv/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12.4)
 
 project(httpsrv)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(NOT DEFINED WAZUH_MAIN_PROJECT)


### PR DESCRIPTION
## Description

Closes #36989

The `shared_modules/httpsrv` module was introduced in #37213 with `CMAKE_CXX_STANDARD 20`, following the convention of its primary consumer (`vulnerability_scanner`). The module itself uses no C++20 features and compiles cleanly under C++17, so the standard is lowered to match the rest of `shared_modules`.

## Proposed Changes

Set `CMAKE_CXX_STANDARD 17` in `src/shared_modules/httpsrv/CMakeLists.txt`.

### Results and Evidence

No functional change. The module uses only C++17-compatible headers (`<algorithm>`, `<memory>`, `<thread>`, `<filesystem>`, `<functional>`, `<string_view>`).

### Artifacts Affected

None.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)