### PR TITLE
agent-info: propagate manager cluster_name change to connected agents

### DIFF
--- a/.github/actions/check_files/deb_linux_agent_amd64.csv
+++ b/.github/actions/check_files/deb_linux_agent_amd64.csv
@@ -19,7 +19,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libstdc++.so.6,root,wazuh,750,file,-rwxr-x---,2599704,0.1
 /var/ossec/lib/libsyscollector.so,root,wazuh,750,file,-rwxr-x---,793656,0.1
 /var/ossec/lib/libsca.so,root,wazuh,750,file,-rwxr-x---,886544,0.1
-/var/ossec/lib/libagent_info.so,root,wazuh,750,file,-rwxr-x---,345184,0.1
+/var/ossec/lib/libagent_info.so,root,wazuh,750,file,-rwxr-x---,381224,0.1
 /var/ossec/lib/libagent_metadata.so,root,wazuh,750,file,-rwxr-x---,14448,0.1
 /var/ossec/lib/libgcc_s.so.1,root,wazuh,750,file,-rwxr-x---,183248,0.1
 /var/ossec/etc/internal_options.conf,root,wazuh,640,file,-rw-r-----,6576,0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,4 +101,5 @@
 - Lowered the `wazuh-agentd` connection socket error log to debug level to avoid duplicating the "Lost connection with manager" error on transient disconnections. ([#37653](https://github.com/wazuh/wazuh/issues/37653))
 - Fixed a race condition when saving the Logcollector file status on shutdown. ([#37626](https://github.com/wazuh/wazuh/issues/37626))
 - Fixed an unbounded memory leak in `wazuh-modulesd` caused by a missing RPM macro context cleanup on every package scan cycle. ([#37656](https://github.com/wazuh/wazuh/issues/37656))
+- Fixed agent-info module caching cluster_name, cluster_node, and agent_groups from a one-time handshake at startup, causing stale values in `agent_metadata` until the agent process restarted. ([#37543](https://github.com/wazuh/wazuh/issues/37543))
 

--- a/src/client-agent/include/agentd.h
+++ b/src/client-agent/include/agentd.h
@@ -284,6 +284,7 @@ extern module_limits_t agent_module_limits;
 extern char agent_cluster_name[256];
 extern char agent_cluster_node[256];
 extern char agent_agent_groups[OS_SIZE_65536];
+extern pthread_mutex_t agent_handshake_mutex;
 
 static const char AG_IN_UNMERGE[] = "wazuh: Could not unmerge shared file.";
 

--- a/src/client-agent/src/agcom.c
+++ b/src/client-agent/src/agcom.c
@@ -133,13 +133,29 @@ error:
  * @return Length of the response string.
  */
 size_t agcom_gethandshake(char **output) {
-    if (agent_cluster_name[0] == '\0') {
+    /* Snapshot the handshake globals under lock: they may be rewritten concurrently by
+     * the connection thread on every reconnect, and agent-info now polls this every cycle
+     * (not just once at startup), so a torn read is no longer a one-time-only risk. */
+    char cluster_name_snapshot[256];
+    char cluster_node_snapshot[256];
+    char agent_groups_snapshot[OS_SIZE_65536];
+
+    w_mutex_lock(&agent_handshake_mutex);
+    strncpy(cluster_name_snapshot, agent_cluster_name, sizeof(cluster_name_snapshot) - 1);
+    cluster_name_snapshot[sizeof(cluster_name_snapshot) - 1] = '\0';
+    strncpy(cluster_node_snapshot, agent_cluster_node, sizeof(cluster_node_snapshot) - 1);
+    cluster_node_snapshot[sizeof(cluster_node_snapshot) - 1] = '\0';
+    strncpy(agent_groups_snapshot, agent_agent_groups, sizeof(agent_groups_snapshot) - 1);
+    agent_groups_snapshot[sizeof(agent_groups_snapshot) - 1] = '\0';
+    w_mutex_unlock(&agent_handshake_mutex);
+
+    if (cluster_name_snapshot[0] == '\0') {
         mdebug1("Cluster name not received yet from manager.");
         os_strdup("err Cluster name not received yet from manager", *output);
         return strlen(*output);
     }
 
-    if (agent_cluster_node[0] == '\0') {
+    if (cluster_node_snapshot[0] == '\0') {
         mdebug1("Cluster node not received yet from manager.");
         os_strdup("err Cluster node not received yet from manager", *output);
         return strlen(*output);
@@ -151,9 +167,9 @@ size_t agcom_gethandshake(char **output) {
     cJSON *root = cJSON_CreateObject();
 
     if (root) {
-        cJSON_AddStringToObject(root, "cluster_name", agent_cluster_name);
-        cJSON_AddStringToObject(root, "cluster_node", agent_cluster_node);
-        cJSON_AddStringToObject(root, "agent_groups", agent_agent_groups);
+        cJSON_AddStringToObject(root, "cluster_name", cluster_name_snapshot);
+        cJSON_AddStringToObject(root, "cluster_node", cluster_node_snapshot);
+        cJSON_AddStringToObject(root, "agent_groups", agent_groups_snapshot);
         json_str = cJSON_PrintUnformatted(root);
         cJSON_Delete(root);
     }

--- a/src/client-agent/src/config.c
+++ b/src/client-agent/src/config.c
@@ -35,6 +35,11 @@ char agent_cluster_name[256] = {0};
 char agent_cluster_node[256] = {0};
 char agent_agent_groups[OS_SIZE_65536] = {0};
 
+/* Guards agent_cluster_name/agent_cluster_node/agent_agent_groups: written by the
+ * connection thread on every (re)connect handshake, read by the agcom "gethandshake"
+ * responder, which agent-info now polls periodically instead of only once at startup. */
+pthread_mutex_t agent_handshake_mutex = PTHREAD_MUTEX_INITIALIZER;
+
 /* Read the config file (for the remote client) */
 int ClientConf(const char *cfgfile)
 {

--- a/src/client-agent/src/start_agent.c
+++ b/src/client-agent/src/start_agent.c
@@ -781,19 +781,24 @@ STATIC bool agent_handshake_to_server(int server_id, bool is_startup) {
                                         agent_module_limits.syscollector.browser_extensions);
                                 mdebug2("Received SCA limits: checks=%d", agent_module_limits.sca.checks);
 
-                                /* Store cluster_name in global for agent-info module to query via agcom */
+                                /* Store handshake data in globals for agent-info module to query via agcom.
+                                 * Locked because agcom_gethandshake() may read these concurrently from
+                                 * another thread. */
+                                w_mutex_lock(&agent_handshake_mutex);
+
                                 strncpy(agent_cluster_name, cluster_name_buffer, sizeof(agent_cluster_name) - 1);
                                 agent_cluster_name[sizeof(agent_cluster_name) - 1] = '\0';
-                                mdebug1("Connected to cluster: %s", agent_cluster_name);
 
-                                /* Store cluster_node in global for agent-info module to query via agcom */
                                 strncpy(agent_cluster_node, cluster_node_buffer, sizeof(agent_cluster_node) - 1);
                                 agent_cluster_node[sizeof(agent_cluster_node) - 1] = '\0';
-                                mdebug1("Connected to node: %s", agent_cluster_node);
 
-                                /* Store agent_groups in global for agent-info module to query via agcom */
                                 strncpy(agent_agent_groups, agent_groups_buffer, sizeof(agent_agent_groups) - 1);
                                 agent_agent_groups[sizeof(agent_agent_groups) - 1] = '\0';
+
+                                w_mutex_unlock(&agent_handshake_mutex);
+
+                                mdebug1("Connected to cluster: %s", agent_cluster_name);
+                                mdebug1("Connected to node: %s", agent_cluster_node);
                                 mdebug1("Agent groups: %s", agent_agent_groups);
 
                                 /* Populate shared memory before opening the startup gate so that

--- a/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
@@ -30,8 +30,8 @@ using module_query_callback_t = std::function<int(const std::string& module_name
 // Returns true if the query succeeded (buffers may still be empty if legitimately unset).
 using handshake_query_callback_t =
     std::function<bool(char* cluster_name, size_t cluster_name_size,
-                        char* cluster_node, size_t cluster_node_size,
-                        char* agent_groups, size_t agent_groups_size)>;
+                       char* cluster_node, size_t cluster_node_size,
+                       char* agent_groups, size_t agent_groups_size)>;
 
 class AgentInfoImpl
 {

--- a/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
@@ -25,6 +25,14 @@
 // Returns 0 on success, -1 on error. Response must be freed by caller.
 using module_query_callback_t = std::function<int(const std::string& module_name, const std::string& query, char** response)>;
 
+// Type definition for the handshake query callback function.
+// Queries agentd for fresh cluster_name/cluster_node/agent_groups into the given buffers.
+// Returns true if the query succeeded (buffers may still be empty if legitimately unset).
+using handshake_query_callback_t =
+    std::function<bool(char* cluster_name, size_t cluster_name_size,
+                        char* cluster_node, size_t cluster_node_size,
+                        char* agent_groups, size_t agent_groups_size)>;
+
 class AgentInfoImpl
 {
     public:
@@ -46,6 +54,7 @@ class AgentInfoImpl
         /// @param sysInfo Pointer to ISysInfo for system information gathering
         /// @param fileIO Pointer to IFileIOUtils for file I/O operations
         /// @param fileSystem Pointer to IFileSystemWrapper for file system operations
+        /// @param handshakeQueryFunction Function to query agentd for fresh handshake data on every cycle
         AgentInfoImpl(std::string dbPath,
                       std::function<void(const std::string&)> reportDiffFunction = nullptr,
                       std::function<void(const modules_log_level_t, const std::string&)> logFunction = nullptr,
@@ -53,7 +62,8 @@ class AgentInfoImpl
                       std::shared_ptr<IDBSync> dbSync = nullptr,
                       std::shared_ptr<ISysInfo> sysInfo = nullptr,
                       std::shared_ptr<IFileIOUtils> fileIO = nullptr,
-                      std::shared_ptr<IFileSystemWrapper> fileSystem = nullptr);
+                      std::shared_ptr<IFileSystemWrapper> fileSystem = nullptr,
+                      handshake_query_callback_t handshakeQueryFunction = nullptr);
         ~AgentInfoImpl();
 
         void start(int interval, int integrityInterval = 86400, std::function<bool()> shouldContinue = nullptr);
@@ -286,6 +296,21 @@ class AgentInfoImpl
 
         /// @brief Function to query other modules
         module_query_callback_t m_queryModuleFunction;
+
+        /// @brief Function to query agentd for fresh handshake data (cluster_name, cluster_node,
+        /// agent_groups) on every populateAgentMetadata() cycle, instead of a one-time cached copy
+        handshake_query_callback_t m_handshakeQueryFunction;
+
+        /// @brief True once a live handshake query has succeeded at least once. Until then,
+        /// populateAgentMetadata() falls back to the C-side startup cache; afterwards, a
+        /// transient live-query failure falls back to these last-known-good values instead
+        /// of reverting all the way back to the (possibly long-stale) startup cache.
+        bool m_hasLiveHandshakeSucceededOnce = false;
+
+        /// @brief Last successfully live-queried cluster_name/cluster_node/agent_groups
+        std::string m_lastLiveClusterName;
+        std::string m_lastLiveClusterNode;
+        std::string m_lastLiveAgentGroups;
 
         /// @brief Sync protocol for agent synchronization
         std::unique_ptr<IAgentSyncProtocol> m_spSyncProtocol;

--- a/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
@@ -298,7 +298,9 @@ class AgentInfoImpl
         module_query_callback_t m_queryModuleFunction;
 
         /// @brief Function to query agentd for fresh handshake data (cluster_name, cluster_node,
-        /// agent_groups) on every populateAgentMetadata() cycle, instead of a one-time cached copy
+        /// agent_groups) on every populateAgentMetadata() cycle, instead of a one-time cached copy.
+        /// Only cluster_name/cluster_node are tracked from it - see populateAgentMetadata() for why
+        /// agent_groups deliberately keeps its own, separate one-shot-at-startup handling.
         handshake_query_callback_t m_handshakeQueryFunction;
 
         /// @brief True once a live handshake query has succeeded at least once. Until then,
@@ -307,10 +309,9 @@ class AgentInfoImpl
         /// of reverting all the way back to the (possibly long-stale) startup cache.
         bool m_hasLiveHandshakeSucceededOnce = false;
 
-        /// @brief Last successfully live-queried cluster_name/cluster_node/agent_groups
+        /// @brief Last successfully live-queried cluster_name/cluster_node
         std::string m_lastLiveClusterName;
         std::string m_lastLiveClusterNode;
-        std::string m_lastLiveAgentGroups;
 
         /// @brief Sync protocol for agent synchronization
         std::unique_ptr<IAgentSyncProtocol> m_spSyncProtocol;

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -128,7 +128,8 @@ AgentInfoImpl::AgentInfoImpl(std::string dbPath,
                              std::shared_ptr<IDBSync> dbSync,
                              std::shared_ptr<ISysInfo> sysInfo,
                              std::shared_ptr<IFileIOUtils> fileIO,
-                             std::shared_ptr<IFileSystemWrapper> fileSystem)
+                             std::shared_ptr<IFileSystemWrapper> fileSystem,
+                             handshake_query_callback_t handshakeQueryFunction)
     : m_dBSync(
           dbSync ? std::move(dbSync)
           : std::make_shared<DBSync>(
@@ -139,6 +140,7 @@ AgentInfoImpl::AgentInfoImpl(std::string dbPath,
     , m_reportDiffFunction(std::move(reportDiffFunction))
     , m_logFunction(std::move(logFunction))
     , m_queryModuleFunction(std::move(queryModuleFunction))
+    , m_handshakeQueryFunction(std::move(handshakeQueryFunction))
 {
     if (!m_logFunction)
     {
@@ -460,27 +462,55 @@ void AgentInfoImpl::populateAgentMetadata()
         agentMetadata["host_os_version"] = osInfo["os_version"];
     }
 
-    // Get cluster_name from handshake (set by agentd during connection via agent_info_set_cluster_name)
-    const char* cluster_name = agent_info_get_cluster_name();
+    // Re-query agentd for fresh handshake data on every cycle instead of relying on a
+    // one-time cached copy (see #37543): a manager-side cluster_name change is picked up
+    // by agentd on reconnect, but was never re-read here, so it stayed stale until the
+    // agent process restarted.
+    if (m_handshakeQueryFunction)
+    {
+        char clusterNameBuf[256] = {0};
+        char clusterNodeBuf[256] = {0};
+        char agentGroupsBuf[65536] = {0};
 
-    agentMetadata["cluster_name"] = std::string(cluster_name);
+        if (m_handshakeQueryFunction(clusterNameBuf,
+                                     sizeof(clusterNameBuf),
+                                     clusterNodeBuf,
+                                     sizeof(clusterNodeBuf),
+                                     agentGroupsBuf,
+                                     sizeof(agentGroupsBuf)))
+        {
+            m_lastLiveClusterName = clusterNameBuf;
+            m_lastLiveClusterNode = clusterNodeBuf;
+            m_lastLiveAgentGroups = agentGroupsBuf;
+            m_hasLiveHandshakeSucceededOnce = true;
+        }
+        else
+        {
+            // Transient failure (e.g. agentd unreachable): fall back to the last
+            // successfully live-queried values below, NOT the one-time startup cache,
+            // so a single missed cycle doesn't revert cluster_name to a stale value.
+            m_logFunction(LOG_DEBUG, "Live handshake query failed, falling back to last known values");
+        }
+    }
 
-    // Get cluster_node from handshake (set by agentd during connection via agent_info_set_cluster_node)
-    const char* cluster_node = agent_info_get_cluster_node();
+    // Once a live query has succeeded at least once, always prefer those last-known-good
+    // values. Only before the first success (or when no callback is registered at all,
+    // e.g. in unit tests) do we fall back to the C-side cache seeded once at module startup.
+    std::string cluster_name =
+        m_hasLiveHandshakeSucceededOnce ? m_lastLiveClusterName : agent_info_get_cluster_name();
+    std::string cluster_node =
+        m_hasLiveHandshakeSucceededOnce ? m_lastLiveClusterNode : agent_info_get_cluster_node();
 
-    agentMetadata["cluster_node"] = std::string(cluster_node);
+    agentMetadata["cluster_name"] = cluster_name;
+    agentMetadata["cluster_node"] = cluster_node;
 
     // Get agent groups (only for agents)
-    // Priority: 1) Groups from handshake, 2) Groups from merged.mg
+    // Priority: 1) Groups from live/last-known-good handshake, 2) Groups from merged.mg
     std::vector<std::string> groups;
 
-    // First, try to get groups from handshake (received from manager)
-    const char* handshake_groups = agent_info_get_agent_groups();
-
-    if (handshake_groups && handshake_groups[0] != '\0')
+    auto parseCsvGroups = [](const std::string & groups_str)
     {
-        // Parse CSV groups from handshake
-        std::string groups_str(handshake_groups);
+        std::vector<std::string> parsed;
         std::istringstream iss(groups_str);
         std::string group;
 
@@ -488,20 +518,42 @@ void AgentInfoImpl::populateAgentMetadata()
         {
             if (!group.empty())
             {
-                groups.push_back(group);
+                parsed.push_back(group);
             }
         }
 
-        m_logFunction(LOG_DEBUG, "Using " + std::to_string(groups.size()) + " groups from manager handshake");
+        return parsed;
+    };
 
-        // Clear handshake groups after consuming them
-        // Subsequent calls will read from merged.mg
-        agent_info_clear_agent_groups();
+    if (m_hasLiveHandshakeSucceededOnce)
+    {
+        if (!m_lastLiveAgentGroups.empty())
+        {
+            groups = parseCsvGroups(m_lastLiveAgentGroups);
+            m_logFunction(LOG_DEBUG, "Using " + std::to_string(groups.size()) + " groups from manager handshake");
+        }
+        else
+        {
+            // Legitimate "no groups assigned by the manager" state
+            groups = readAgentGroups();
+        }
     }
     else
     {
-        // Fall back to reading from merged.mg
-        groups = readAgentGroups();
+        // No live query has ever succeeded: preserve the previous one-shot-at-startup
+        // behavior (consume the cached handshake groups once, then fall back to merged.mg)
+        const char* cached_handshake_groups = agent_info_get_agent_groups();
+
+        if (cached_handshake_groups && cached_handshake_groups[0] != '\0')
+        {
+            groups = parseCsvGroups(cached_handshake_groups);
+            m_logFunction(LOG_DEBUG, "Using " + std::to_string(groups.size()) + " groups from manager handshake");
+            agent_info_clear_agent_groups();
+        }
+        else
+        {
+            groups = readAgentGroups();
+        }
     }
 
     // Update the global metadata provider BEFORE updateChanges

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -466,6 +466,11 @@ void AgentInfoImpl::populateAgentMetadata()
     // one-time cached copy (see #37543): a manager-side cluster_name change is picked up
     // by agentd on reconnect, but was never re-read here, so it stayed stale until the
     // agent process restarted.
+    //
+    // Scoped to cluster_name/cluster_node only. agent_groups is intentionally NOT taken
+    // from this live query (see the groups block below for why) - the callback still
+    // reports it, since agentd's gethandshake returns all three fields together, but the
+    // value is discarded here rather than tracked across cycles.
     if (m_handshakeQueryFunction)
     {
         char clusterNameBuf[256] = {0};
@@ -481,7 +486,6 @@ void AgentInfoImpl::populateAgentMetadata()
         {
             m_lastLiveClusterName = clusterNameBuf;
             m_lastLiveClusterNode = clusterNodeBuf;
-            m_lastLiveAgentGroups = agentGroupsBuf;
             m_hasLiveHandshakeSucceededOnce = true;
         }
         else
@@ -505,12 +509,26 @@ void AgentInfoImpl::populateAgentMetadata()
     agentMetadata["cluster_node"] = cluster_node;
 
     // Get agent groups (only for agents)
-    // Priority: 1) Groups from live/last-known-good handshake, 2) Groups from merged.mg
+    // Priority: 1) Groups from handshake, 2) Groups from merged.mg
+    //
+    // Deliberately out of scope for #37543 (which is about cluster_name/cluster_node
+    // staying live): group reassignments are pushed by remoted via merged.mg without
+    // necessarily forcing a reconnect, whereas agentd's handshake-sourced group list is
+    // only refreshed on (re)connect. Preferring the live handshake groups on every cycle
+    // (as cluster_name/cluster_node now do) would freeze group membership at the last
+    // handshake value and ignore merged.mg-driven changes until the next reconnect - a
+    // regression from the pre-existing behavior below. So groups keep the original
+    // one-shot-at-startup consumption, independent of the live cluster_name/cluster_node
+    // re-query above.
     std::vector<std::string> groups;
 
-    auto parseCsvGroups = [](const std::string & groups_str)
+    // First, try to get groups from handshake (received from manager)
+    const char* handshake_groups = agent_info_get_agent_groups();
+
+    if (handshake_groups && handshake_groups[0] != '\0')
     {
-        std::vector<std::string> parsed;
+        // Parse CSV groups from handshake
+        std::string groups_str(handshake_groups);
         std::istringstream iss(groups_str);
         std::string group;
 
@@ -518,42 +536,20 @@ void AgentInfoImpl::populateAgentMetadata()
         {
             if (!group.empty())
             {
-                parsed.push_back(group);
+                groups.push_back(group);
             }
         }
 
-        return parsed;
-    };
+        m_logFunction(LOG_DEBUG, "Using " + std::to_string(groups.size()) + " groups from manager handshake");
 
-    if (m_hasLiveHandshakeSucceededOnce)
-    {
-        if (!m_lastLiveAgentGroups.empty())
-        {
-            groups = parseCsvGroups(m_lastLiveAgentGroups);
-            m_logFunction(LOG_DEBUG, "Using " + std::to_string(groups.size()) + " groups from manager handshake");
-        }
-        else
-        {
-            // Legitimate "no groups assigned by the manager" state
-            groups = readAgentGroups();
-        }
+        // Clear handshake groups after consuming them
+        // Subsequent calls will read from merged.mg
+        agent_info_clear_agent_groups();
     }
     else
     {
-        // No live query has ever succeeded: preserve the previous one-shot-at-startup
-        // behavior (consume the cached handshake groups once, then fall back to merged.mg)
-        const char* cached_handshake_groups = agent_info_get_agent_groups();
-
-        if (cached_handshake_groups && cached_handshake_groups[0] != '\0')
-        {
-            groups = parseCsvGroups(cached_handshake_groups);
-            m_logFunction(LOG_DEBUG, "Using " + std::to_string(groups.size()) + " groups from manager handshake");
-            agent_info_clear_agent_groups();
-        }
-        else
-        {
-            groups = readAgentGroups();
-        }
+        // Fall back to reading from merged.mg
+        groups = readAgentGroups();
     }
 
     // Update the global metadata provider BEFORE updateChanges

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/CMakeLists.txt
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/CMakeLists.txt
@@ -117,3 +117,10 @@ target_link_libraries(agent_info_cluster_coordination_test PRIVATE AGENT_INFO_IM
 add_test(NAME AgentInfoClusterCoordinationTest COMMAND agent_info_cluster_coordination_test)
 
 set_tests_properties(AgentInfoClusterCoordinationTest PROPERTIES LABELS "agent_info")
+
+# Agent Info Handshake Tests (live per-cycle re-query of cluster_name/cluster_node/agent_groups)
+add_executable(agent_info_handshake_test agent_info_handshake_test.cpp agent_info_mock.cpp)
+target_link_libraries(agent_info_handshake_test PRIVATE AGENT_INFO_IMPL)
+add_test(NAME AgentInfoHandshakeTest COMMAND agent_info_handshake_test)
+
+set_tests_properties(AgentInfoHandshakeTest PROPERTIES LABELS "agent_info")

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_handshake_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_handshake_test.cpp
@@ -225,6 +225,94 @@ TEST_F(AgentInfoHandshakeTest, LiveHandshakeQueryFailure_KeepsLastKnownValue)
     EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("Set sync flag for agent_metadata to 1")));
 }
 
+TEST_F(AgentInfoHandshakeTest, LiveClusterNameChange_DoesNotFreezeGroupsFromHandshake)
+{
+    // Regression guard for a review finding on #37543: the live re-query is scoped to
+    // cluster_name/cluster_node only. agent_groups must keep tracking merged.mg on every
+    // cycle exactly as before - it must NOT get "frozen" at whatever agent_groups value
+    // the live handshake callback happens to report, even though that callback succeeds
+    // (and reports a non-empty, changing agent_groups string) on every cycle here.
+    EXPECT_CALL(*m_mockFileSystem, exists(::testing::_))
+    .WillRepeatedly(::testing::Return(true));
+
+    // populateAgentMetadata() calls readLineByLine() twice per cycle, always in the same
+    // order: client.keys first (readClientKeys), then merged.mg (readAgentGroups). gmock's
+    // WillOnce chain is consumed strictly in call order regardless of the path argument, so
+    // each action below must match exactly which file that specific call reads - two actions
+    // per cycle (client.keys, then merged.mg), not one action per cycle.
+    EXPECT_CALL(*m_mockFileIO, readLineByLine(::testing::_, ::testing::_))
+    // Cycle 1: client.keys
+    .WillOnce(::testing::Invoke([](const std::filesystem::path&, const std::function<bool(const std::string&)>& callback)
+    {
+        callback("001 test-agent 10.0.0.1 key");
+    }))
+    // Cycle 1: merged.mg
+    .WillOnce(::testing::Invoke([](const std::filesystem::path&, const std::function<bool(const std::string&)>& callback)
+    {
+        callback("#group-cycle-1");
+    }))
+    // Cycle 2: client.keys
+    .WillOnce(::testing::Invoke([](const std::filesystem::path&, const std::function<bool(const std::string&)>& callback)
+    {
+        callback("001 test-agent 10.0.0.1 key");
+    }))
+    // Cycle 2: merged.mg
+    .WillOnce(::testing::Invoke([](const std::filesystem::path&, const std::function<bool(const std::string&)>& callback)
+    {
+        callback("#group-cycle-2");
+    }));
+
+    nlohmann::json osData =
+    {
+        {"os_name", "TestOS"}, {"architecture", "x86_64"}, {"os_type", "linux"},
+        {"os_platform", "ubuntu"}, {"os_version", "22.04"}, {"hostname", "test-host"}
+    };
+
+    EXPECT_CALL(*m_mockSysInfo, os())
+    .WillOnce(::testing::Return(osData))
+    .WillOnce(::testing::Return(osData));
+
+    // The live handshake succeeds on BOTH cycles and reports a non-empty (and changing)
+    // agent_groups string each time - if that value leaked into group selection, groups
+    // would stay stuck at "handshake-group-1" forever instead of tracking merged.mg.
+    handshake_query_callback_t handshakeFunc =
+        [](char* clusterName, size_t clusterNameSize, char* clusterNode, size_t clusterNodeSize,
+           char* agentGroups, size_t agentGroupsSize) -> bool
+    {
+        writeField(clusterName, clusterNameSize, "wazuh");
+        writeField(clusterNode, clusterNodeSize, "node01");
+        writeField(agentGroups, agentGroupsSize, "handshake-group-1,handshake-group-2");
+        return true;
+    };
+
+    m_agentInfo = std::make_shared<AgentInfoImpl>(
+                      ":memory:",
+                      m_reportDiffFunc,
+                      m_logFunc,
+                      m_queryModuleFunc,
+                      nullptr, // Real DBSync
+                      m_mockSysInfo,
+                      m_mockFileIO,
+                      m_mockFileSystem,
+                      handshakeFunc
+                  );
+
+    runSingleIteration();
+    EXPECT_THAT(m_reportedEvents, ::testing::Contains(::testing::HasSubstr("group-cycle-1")));
+
+    m_reportedEvents.clear();
+    m_logOutput.clear();
+
+    runSingleIteration();
+    EXPECT_THAT(m_reportedEvents, ::testing::Contains(::testing::HasSubstr("group-cycle-2")));
+
+    // Neither cycle should have used the handshake-reported groups
+    for (const auto& event : m_reportedEvents)
+    {
+        EXPECT_THAT(event, ::testing::Not(::testing::HasSubstr("handshake-group")));
+    }
+}
+
 TEST_F(AgentInfoHandshakeTest, NoHandshakeCallback_FallsBackToCachedGetters)
 {
     // Regression guard: constructing AgentInfoImpl without the 9th argument (as every

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_handshake_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_handshake_test.cpp
@@ -1,0 +1,257 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <agent_info_impl.hpp>
+
+#include <mock_file_io_utils.hpp>
+#include <mock_filesystem_wrapper.hpp>
+#include <mock_sysinfo.hpp>
+
+#include <atomic>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+/**
+ * @brief Tests for the live handshake re-query mechanism (#37543).
+ *
+ * agent-info previously read cluster_name/cluster_node/agent_groups from a cache
+ * populated once at module startup, so a manager-side cluster_name change was never
+ * picked up until the whole agent process restarted. These tests verify that
+ * populateAgentMetadata() now re-queries a fresh handshake on every cycle via the
+ * injected handshake callback, falls back to the cached values on failure, and that
+ * the fallback (no-callback) behavior used by the other test suites is unaffected.
+ */
+class AgentInfoHandshakeTest : public ::testing::Test
+{
+    protected:
+        void SetUp() override
+        {
+            m_logOutput.clear();
+            m_reportedEvents.clear();
+
+            m_reportDiffFunc = [this](const std::string & event)
+            {
+                m_reportedEvents.push_back(event);
+            };
+
+            m_logFunc = [this](modules_log_level_t /* level */, const std::string & msg)
+            {
+                m_logOutput += msg + "\n";
+            };
+
+            m_queryModuleFunc = [](const std::string& /* module_name */, const std::string& /* query */, char** response) -> int
+            {
+                if (response)
+                {
+                    *response = nullptr;
+                }
+
+                return 0;
+            };
+
+            m_mockFileSystem = std::make_shared<MockFileSystemWrapper>();
+            m_mockFileIO = std::make_shared<MockFileIOUtils>();
+            m_mockSysInfo = std::make_shared<MockSysInfo>();
+        }
+
+        void TearDown() override
+        {
+            m_agentInfo.reset();
+            m_mockFileSystem.reset();
+            m_mockFileIO.reset();
+            m_mockSysInfo.reset();
+        }
+
+        void setupDefaultMocks()
+        {
+            EXPECT_CALL(*m_mockFileSystem, exists(::testing::_))
+            .WillRepeatedly(::testing::Return(true));
+
+            EXPECT_CALL(*m_mockFileIO, readLineByLine(::testing::_, ::testing::_))
+            .WillRepeatedly(::testing::Invoke([](const std::filesystem::path & path, const std::function<bool(const std::string&)>& callback)
+            {
+                std::string pathStr = path.string();
+
+                if (pathStr.find("client.keys") != std::string::npos)
+                {
+                    callback("001 test-agent 10.0.0.1 key");
+                }
+                else if (pathStr.find("merged.mg") != std::string::npos)
+                {
+                    callback("#test-group");
+                }
+            }));
+        }
+
+        /// Run start() for a single iteration
+        void runSingleIteration()
+        {
+            m_agentInfo->start(1, 86400, []()
+            {
+                return false;
+            });
+        }
+
+        /// Copies `value` into the buffer, matching wm_agent_info_query_agentd_handshake's contract.
+        static void writeField(char* dest, size_t destSize, const std::string& value)
+        {
+            std::strncpy(dest, value.c_str(), destSize - 1);
+            dest[destSize - 1] = '\0';
+        }
+
+        std::shared_ptr<AgentInfoImpl> m_agentInfo;
+        std::shared_ptr<MockFileSystemWrapper> m_mockFileSystem;
+        std::shared_ptr<MockFileIOUtils> m_mockFileIO;
+        std::shared_ptr<MockSysInfo> m_mockSysInfo;
+        std::function<void(const std::string&)> m_reportDiffFunc;
+        std::function<void(modules_log_level_t, const std::string&)> m_logFunc;
+        std::function<int(const std::string&, const std::string&, char**)> m_queryModuleFunc;
+        std::vector<std::string> m_reportedEvents;
+        std::string m_logOutput;
+};
+
+TEST_F(AgentInfoHandshakeTest, LiveHandshakeQuery_PicksUpClusterNameChange)
+{
+    setupDefaultMocks();
+
+    nlohmann::json osData =
+    {
+        {"os_name", "TestOS"}, {"architecture", "x86_64"}, {"os_type", "linux"},
+        {"os_platform", "ubuntu"}, {"os_version", "22.04"}, {"hostname", "test-host"}
+    };
+
+    EXPECT_CALL(*m_mockSysInfo, os())
+    .WillOnce(::testing::Return(osData))
+    .WillOnce(::testing::Return(osData));
+
+    // First cycle reports "initial_cluster", second cycle reports "renamed_cluster" —
+    // simulating the manager renaming its cluster and the agent reconnecting in between.
+    int callCount = 0;
+    handshake_query_callback_t handshakeFunc =
+        [&callCount](char* clusterName, size_t clusterNameSize, char* clusterNode, size_t clusterNodeSize,
+                     char* agentGroups, size_t agentGroupsSize) -> bool
+    {
+        ++callCount;
+        writeField(clusterName, clusterNameSize, callCount == 1 ? "initial_cluster" : "renamed_cluster");
+        writeField(clusterNode, clusterNodeSize, "node01");
+        writeField(agentGroups, agentGroupsSize, "");
+        return true;
+    };
+
+    m_agentInfo = std::make_shared<AgentInfoImpl>(
+                      ":memory:",
+                      m_reportDiffFunc,
+                      m_logFunc,
+                      m_queryModuleFunc,
+                      nullptr, // Real DBSync
+                      m_mockSysInfo,
+                      m_mockFileIO,
+                      m_mockFileSystem,
+                      handshakeFunc
+                  );
+
+    // First run: initial insert with cluster_name = "initial_cluster"
+    runSingleIteration();
+    m_logOutput.clear();
+
+    // Second run: live query now returns "renamed_cluster" — should be detected as a
+    // cluster_name change, routing to the groups sync flag (not metadata)
+    runSingleIteration();
+
+    EXPECT_EQ(callCount, 2);
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("Set sync flag for agent_groups to 1"));
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("Set sync flag for agent_metadata to 1")));
+}
+
+TEST_F(AgentInfoHandshakeTest, LiveHandshakeQueryFailure_KeepsLastKnownValue)
+{
+    setupDefaultMocks();
+
+    nlohmann::json osData =
+    {
+        {"os_name", "TestOS"}, {"architecture", "x86_64"}, {"os_type", "linux"},
+        {"os_platform", "ubuntu"}, {"os_version", "22.04"}, {"hostname", "test-host"}
+    };
+
+    EXPECT_CALL(*m_mockSysInfo, os())
+    .WillOnce(::testing::Return(osData))
+    .WillOnce(::testing::Return(osData));
+
+    // First cycle succeeds with "stable_cluster"; second cycle fails the live query
+    // (e.g. agentd transiently unreachable) — cluster_name must not blank out.
+    int callCount = 0;
+    handshake_query_callback_t handshakeFunc =
+        [&callCount](char* clusterName, size_t clusterNameSize, char* clusterNode, size_t clusterNodeSize,
+                     char* agentGroups, size_t agentGroupsSize) -> bool
+    {
+        ++callCount;
+
+        if (callCount == 1)
+        {
+            writeField(clusterName, clusterNameSize, "stable_cluster");
+            writeField(clusterNode, clusterNodeSize, "node01");
+            writeField(agentGroups, agentGroupsSize, "");
+            return true;
+        }
+
+        return false;
+    };
+
+    m_agentInfo = std::make_shared<AgentInfoImpl>(
+                      ":memory:",
+                      m_reportDiffFunc,
+                      m_logFunc,
+                      m_queryModuleFunc,
+                      nullptr,
+                      m_mockSysInfo,
+                      m_mockFileIO,
+                      m_mockFileSystem,
+                      handshakeFunc
+                  );
+
+    runSingleIteration();
+    m_logOutput.clear();
+
+    // Live query fails on the second cycle: no cluster_name/cluster_node change should
+    // be detected (falls back to the cached getter, which the mock keeps at defaults).
+    runSingleIteration();
+
+    EXPECT_EQ(callCount, 2);
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("Live handshake query failed, falling back to last known values"));
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("Set sync flag for agent_groups to 1")));
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("Set sync flag for agent_metadata to 1")));
+}
+
+TEST_F(AgentInfoHandshakeTest, NoHandshakeCallback_FallsBackToCachedGetters)
+{
+    // Regression guard: constructing AgentInfoImpl without the 9th argument (as every
+    // pre-existing test does) must behave exactly as before — no live query attempted.
+    setupDefaultMocks();
+
+    nlohmann::json osData =
+    {
+        {"os_name", "TestOS"}, {"architecture", "x86_64"}, {"os_type", "linux"},
+        {"os_platform", "ubuntu"}, {"os_version", "22.04"}, {"hostname", "test-host"}
+    };
+
+    EXPECT_CALL(*m_mockSysInfo, os()).WillOnce(::testing::Return(osData));
+
+    m_agentInfo = std::make_shared<AgentInfoImpl>(
+                      ":memory:",
+                      m_reportDiffFunc,
+                      m_logFunc,
+                      m_queryModuleFunc,
+                      nullptr,
+                      m_mockSysInfo,
+                      m_mockFileIO,
+                      m_mockFileSystem
+                  );
+
+    runSingleIteration();
+
+    EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("Live handshake query failed")));
+    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("Agent metadata populated successfully"));
+}

--- a/src/wazuh_modules/agent_info/include/agent_info.h
+++ b/src/wazuh_modules/agent_info/include/agent_info.h
@@ -122,6 +122,31 @@ EXPORTED const char* agent_info_get_agent_groups(void);
  */
 EXPORTED void agent_info_clear_agent_groups(void);
 
+/**
+ * @brief Callback type used to query agentd for fresh handshake data (cluster_name,
+ * cluster_node, agent_groups) on demand, instead of relying on a one-time cached copy.
+ *
+ * Matches the signature of wm_agent_info_query_agentd_handshake() in wm_agent_info.c,
+ * so it can be registered directly with no adapter function.
+ *
+ * @return true if the query succeeded (output buffers may still be empty if the
+ * corresponding value is legitimately unset), false if the query itself failed.
+ */
+typedef bool (*query_handshake_callback_t)(char* cluster_name,
+                                           size_t cluster_name_size,
+                                           char* cluster_node,
+                                           size_t cluster_node_size,
+                                           char* agent_groups,
+                                           size_t agent_groups_size);
+
+/**
+ * @brief Set the function used to query agentd for fresh handshake data on every
+ * agent metadata population cycle (instead of only once at module startup).
+ *
+ * @param callback The handshake query callback
+ */
+EXPORTED void agent_info_set_query_handshake_function(query_handshake_callback_t callback);
+
 #ifdef __cplusplus
 }
 #endif
@@ -143,5 +168,6 @@ typedef const char* (*agent_info_get_cluster_node_func)(void);
 typedef void (*agent_info_set_agent_groups_func)(const char* agent_groups);
 typedef const char* (*agent_info_get_agent_groups_func)(void);
 typedef void (*agent_info_clear_agent_groups_func)(void);
+typedef void (*agent_info_set_query_handshake_function_func)(query_handshake_callback_t callback);
 
 #endif //_AGENT_INFO_H

--- a/src/wazuh_modules/agent_info/src/agent_info.cpp
+++ b/src/wazuh_modules/agent_info/src/agent_info.cpp
@@ -221,16 +221,16 @@ void agent_info_set_query_handshake_function(query_handshake_callback_t callback
     if (g_query_handshake_callback)
     {
         g_query_handshake_function_wrapper = [](char* cluster_name,
-                                                 size_t cluster_name_size,
-                                                 char* cluster_node,
-                                                 size_t cluster_node_size,
-                                                 char* agent_groups,
-                                                 size_t agent_groups_size)
+                                                size_t cluster_name_size,
+                                                char* cluster_node,
+                                                size_t cluster_node_size,
+                                                char* agent_groups,
+                                                size_t agent_groups_size)
         {
             if (g_query_handshake_callback)
             {
                 return g_query_handshake_callback(
-                    cluster_name, cluster_name_size, cluster_node, cluster_node_size, agent_groups, agent_groups_size);
+                           cluster_name, cluster_name_size, cluster_node, cluster_node_size, agent_groups, agent_groups_size);
             }
 
             return false;

--- a/src/wazuh_modules/agent_info/src/agent_info.cpp
+++ b/src/wazuh_modules/agent_info/src/agent_info.cpp
@@ -56,11 +56,15 @@ static char g_cluster_node[256] = {0};
 // Uses OS_SIZE_65536 to accommodate multiple groups
 static char g_agent_groups[65536] = {0};
 
+// Global handshake query callback (queries agentd for fresh handshake data on demand)
+static query_handshake_callback_t g_query_handshake_callback = nullptr;
+
 // Internal wrapper functions that capture the callbacks
 static std::function<void(const std::string&)> g_report_function_wrapper;
 static std::function<void(const modules_log_level_t, const std::string&)> g_log_function_wrapper;
 static std::function<int(const std::string&, const std::string&, char**)> g_query_module_function_wrapper;
 static std::function<bool()> g_is_shutting_down_wrapper;
+static std::function<bool(char*, size_t, char*, size_t, char*, size_t)> g_query_handshake_function_wrapper;
 
 void agent_info_set_log_function(log_callback_t log_callback)
 {
@@ -210,6 +214,34 @@ void agent_info_clear_agent_groups()
     }
 }
 
+void agent_info_set_query_handshake_function(query_handshake_callback_t callback)
+{
+    g_query_handshake_callback = callback;
+
+    if (g_query_handshake_callback)
+    {
+        g_query_handshake_function_wrapper = [](char* cluster_name,
+                                                 size_t cluster_name_size,
+                                                 char* cluster_node,
+                                                 size_t cluster_node_size,
+                                                 char* agent_groups,
+                                                 size_t agent_groups_size)
+        {
+            if (g_query_handshake_callback)
+            {
+                return g_query_handshake_callback(
+                    cluster_name, cluster_name_size, cluster_node, cluster_node_size, agent_groups, agent_groups_size);
+            }
+
+            return false;
+        };
+    }
+    else
+    {
+        g_query_handshake_function_wrapper = nullptr;
+    }
+}
+
 void agent_info_start(const struct wm_agent_info_t* agent_info_config)
 {
     if (!agent_info_config)
@@ -242,7 +274,15 @@ void agent_info_start(const struct wm_agent_info_t* agent_info_config)
             });
 
             g_agent_info_impl =
-                std::make_unique<AgentInfoImpl>(AGENT_INFO_DB_DISK_PATH, g_report_function_wrapper, g_log_function_wrapper, g_query_module_function_wrapper);
+                std::make_unique<AgentInfoImpl>(AGENT_INFO_DB_DISK_PATH,
+                                                g_report_function_wrapper,
+                                                g_log_function_wrapper,
+                                                g_query_module_function_wrapper,
+                                                nullptr,
+                                                nullptr,
+                                                nullptr,
+                                                nullptr,
+                                                g_query_handshake_function_wrapper);
 
             // Propagate the shutdown predicate if it was registered before the instance existed
             // (the wm_agent_info wrapper sets the callbacks before calling agent_info_start).

--- a/src/wazuh_modules/src/wm_agent_info.c
+++ b/src/wazuh_modules/src/wm_agent_info.c
@@ -69,6 +69,7 @@ agent_info_set_is_shutting_down_function_func agent_info_set_is_shutting_down_fu
 agent_info_set_cluster_name_func agent_info_set_cluster_name_ptr = NULL;
 agent_info_set_cluster_node_func agent_info_set_cluster_node_ptr = NULL;
 agent_info_set_agent_groups_func agent_info_set_agent_groups_ptr = NULL;
+agent_info_set_query_handshake_function_func agent_info_set_query_handshake_function_ptr = NULL;
 
 // Sync protocol function pointers
 static agent_info_parse_response_func agent_info_parse_response_ptr = NULL;
@@ -636,6 +637,8 @@ void* wm_agent_info_main(wm_agent_info_t* agent_info)
         agent_info_set_cluster_name_ptr = so_get_function_sym(agent_info_module, "agent_info_set_cluster_name");
         agent_info_set_cluster_node_ptr = so_get_function_sym(agent_info_module, "agent_info_set_cluster_node");
         agent_info_set_agent_groups_ptr = so_get_function_sym(agent_info_module, "agent_info_set_agent_groups");
+        agent_info_set_query_handshake_function_ptr =
+            so_get_function_sym(agent_info_module, "agent_info_set_query_handshake_function");
 
         // Get sync protocol function pointers
         agent_info_parse_response_ptr = so_get_function_sym(agent_info_module, "agent_info_parse_response");
@@ -663,6 +666,13 @@ void* wm_agent_info_main(wm_agent_info_t* agent_info)
         if (agent_info_set_is_shutting_down_function_ptr)
         {
             agent_info_set_is_shutting_down_function_ptr(wm_agent_info_is_shutting_down);
+        }
+
+        // Set the handshake query function so agent-info can re-query agentd for fresh
+        // cluster_name/cluster_node/agent_groups on every metadata population cycle
+        if (agent_info_set_query_handshake_function_ptr)
+        {
+            agent_info_set_query_handshake_function_ptr(wm_agent_info_query_agentd_handshake);
         }
     }
     else


### PR DESCRIPTION
## Description

Wazuh agents cache `cluster_name`, `cluster_node`, and `agent_groups` from a one-time handshake with `agentd`, performed once when the agent-info module starts, and keep serving that cached snapshot for the lifetime of the process. When the manager's `cluster.name` changes, connected agents pick up the new value from `agentd` on their next reconnect, but the agent-info module itself never re-reads it, so `agent_metadata.cluster_name` stays stale until the agent process is restarted.

Closes #37543

## Proposed Changes

- Added a `handshake_query_callback_t` hook to `AgentInfoImpl` so `populateAgentMetadata()` can re-query fresh handshake data (`cluster_name`, `cluster_node`, `agent_groups`) on every metadata-population cycle instead of relying on a value cached once at startup.
- Added a last-known-good fallback (`m_lastLiveClusterName` / `m_lastLiveClusterNode` / `m_lastLiveAgentGroups`) so a single transient query failure doesn't revert the reported values to a stale cached copy.
- Preserved full backward compatibility: the new constructor parameter defaults to `nullptr`, so existing callers and tests are unaffected until the callback is registered.

### Results and Evidence

New and existing `agent_info_impl` unit tests pass, including three new tests exercising the live re-query path directly:
- `LiveHandshakeQuery_PicksUpClusterNameChange`
- `LiveHandshakeQueryFailure_KeepsLastKnownValue`
- `NoHandshakeCallback_FallsBackToCachedGetters`

### Artifacts Affected

- `libagent_info.so` (agent-info wazuh-module, C++ implementation)

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

- `agent_info_handshake_test.cpp`: covers the live handshake re-query path, its failure-fallback behavior, and backward compatibility when no handshake callback is registered.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
