### PR TITLE
Fix analysisd flaky test

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,7 +12,7 @@ import sys
 from wazuh_testing import session_parameters
 from wazuh_testing.constants import platforms
 from wazuh_testing.constants.platforms import WINDOWS
-from wazuh_testing.constants.daemons import WAZUH_MANAGER, API_DAEMONS_REQUIREMENTS
+from wazuh_testing.constants.daemons import WAZUH_MANAGER, API_DAEMONS_REQUIREMENTS, ANALYSISD_DAEMON
 from wazuh_testing.constants.paths import ROOT_PREFIX
 from wazuh_testing.constants.paths.api import RBAC_DATABASE_PATH
 from wazuh_testing.constants.paths.logs import (
@@ -332,6 +332,8 @@ def daemons_handler_implementation(request: pytest.FixtureRequest) -> None:
         all_daemons (boolean): Configure to restart all wazuh services. Default `False`.
         ignore_errors (boolean): Configure if errors in daemon handling should be ignored. This option is available
         in order to use this fixture along with invalid configuration. Default `False`
+        extra_sockets (list, optional): Additional wazuh-analysisd sockets (e.g. LOGTEST_SOCKET_PATH) that are not
+            part of its default socket set but that the module needs ready before proceeding. Default `[]`
 
     Args:
         request (pytest.FixtureRequest): Provide information about the current test function which made the request.
@@ -339,6 +341,7 @@ def daemons_handler_implementation(request: pytest.FixtureRequest) -> None:
     daemons = []
     ignore_errors = False
     all_daemons = False
+    extra_sockets = []
 
     if config := getattr(request.module, "daemons_handler_configuration", None):
         if "daemons" in config:
@@ -354,6 +357,9 @@ def daemons_handler_implementation(request: pytest.FixtureRequest) -> None:
         if "ignore_errors" in config:
             logger.debug(f"Ignore error set to {config['ignore_errors']}")
             ignore_errors = config["ignore_errors"]
+
+        if "extra_sockets" in config:
+            extra_sockets = config["extra_sockets"]
     else:
         logger.debug("Wazuh control set to 'all_daemons'")
         all_daemons = True
@@ -362,11 +368,16 @@ def daemons_handler_implementation(request: pytest.FixtureRequest) -> None:
         if all_daemons:
             logger.debug("Restarting wazuh using wazuh-control")
             services.control_service("restart")
+            services.wait_expected_daemon_status(target_daemon="wazuh-analysisd", running_condition=True,
+                                                extra_sockets=extra_sockets)
         else:
             for daemon in daemons:
                 logger.debug(f"Restarting {daemon}")
                 # Restart daemon instead of starting due to legacy used fixture in the test suite.
                 services.control_service("restart", daemon=daemon)
+                daemon_extra_sockets = extra_sockets if daemon == ANALYSISD_DAEMON else []
+                services.wait_expected_daemon_status(target_daemon=daemon, running_condition=True,
+                                                        extra_sockets=daemon_extra_sockets)
 
     except ValueError as value_error:
         logger.error(f"{str(value_error)}")
@@ -376,6 +387,10 @@ def daemons_handler_implementation(request: pytest.FixtureRequest) -> None:
         logger.error(f"{str(called_process_error)}")
         if not ignore_errors:
             raise called_process_error
+    except TimeoutError as timeout_error:
+        logger.error(f"{str(timeout_error)}")
+        if not ignore_errors:
+            raise timeout_error
 
     yield
 

--- a/tests/integration/test_analysisd/test_predecoder_stage/test_predecoder_stage.py
+++ b/tests/integration/test_analysisd/test_predecoder_stage/test_predecoder_stage.py
@@ -61,7 +61,7 @@ test_cases_path = Path(TEST_CASES_PATH, 'cases_syslog_socket_input.yaml')
 _, test_metadata, test_cases_ids = configuration.get_test_cases_data(test_cases_path)
 
 # Test daemons to restart.
-daemons_handler_configuration = {'all_daemons': True}
+daemons_handler_configuration = {'all_daemons': True, 'extra_sockets': [LOGTEST_SOCKET_PATH]}
 
 # Test variables.
 receiver_sockets_params = [(LOGTEST_SOCKET_PATH, 'AF_UNIX', 'TCP')]

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_decoder_syntax.py
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_decoder_syntax.py
@@ -69,7 +69,7 @@ receiver_sockets_params = [(LOGTEST_SOCKET_PATH, 'AF_UNIX', 'TCP')]
 receiver_sockets = []
 
 # Test daemons to restart.
-daemons_handler_configuration = {'daemons': [ANALYSISD_DAEMON, WAZUH_DB_DAEMON]}
+daemons_handler_configuration = {'daemons': [ANALYSISD_DAEMON, WAZUH_DB_DAEMON], 'extra_sockets': [LOGTEST_SOCKET_PATH]}
 
 # Tests
 @pytest.mark.parametrize('test_metadata', t_config_metadata, ids=t_case_ids)

--- a/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_rules_syntax.py
+++ b/tests/integration/test_logtest/test_invalid_rule_decoders_syntax/test_invalid_rules_syntax.py
@@ -69,7 +69,7 @@ receiver_sockets_params = [(LOGTEST_SOCKET_PATH, 'AF_UNIX', 'TCP')]
 receiver_sockets = []
 
 # Test daemons to restart.
-daemons_handler_configuration = {'daemons': [ANALYSISD_DAEMON, WAZUH_DB_DAEMON]}
+daemons_handler_configuration = {'daemons': [ANALYSISD_DAEMON, WAZUH_DB_DAEMON], 'extra_sockets': [LOGTEST_SOCKET_PATH]}
 
 # Tests
 @pytest.mark.parametrize('test_metadata', t_config_metadata, ids=t_case_ids)

--- a/tests/integration/test_logtest/test_invalid_socket_input/test_invalid_socket_input.py
+++ b/tests/integration/test_logtest/test_invalid_socket_input/test_invalid_socket_input.py
@@ -68,7 +68,7 @@ receiver_sockets_params = [(LOGTEST_SOCKET_PATH, 'AF_UNIX', 'TCP')]
 receiver_sockets = None  # Set in the fixtures
 
 # Test daemons to restart.
-daemons_handler_configuration = {'daemons': [ANALYSISD_DAEMON, WAZUH_DB_DAEMON]}
+daemons_handler_configuration = {'daemons': [ANALYSISD_DAEMON, WAZUH_DB_DAEMON], 'extra_sockets': [LOGTEST_SOCKET_PATH]}
 
 
 # Tests

--- a/tests/integration/test_logtest/test_invalid_token/test_invalid_session_token.py
+++ b/tests/integration/test_logtest/test_invalid_token/test_invalid_session_token.py
@@ -68,7 +68,7 @@ t_cases_path = Path(TEST_CASES_FOLDER_PATH, 'cases_invalid_session_token.yaml')
 t_config_parameters, t_config_metadata, t_case_ids = configuration.get_test_cases_data(t_cases_path)
 
 # Test daemons to restart.
-daemons_handler_configuration = {'daemons': [ANALYSISD_DAEMON, WAZUH_DB_DAEMON]}
+daemons_handler_configuration = {'daemons': [ANALYSISD_DAEMON, WAZUH_DB_DAEMON], 'extra_sockets': [LOGTEST_SOCKET_PATH]}
 
 
 # Tests

--- a/tests/integration/test_logtest/test_log_process_options/test_rules_verbose.py
+++ b/tests/integration/test_logtest/test_log_process_options/test_rules_verbose.py
@@ -70,7 +70,7 @@ receiver_sockets_params = [(LOGTEST_SOCKET_PATH, 'AF_UNIX', 'TCP')]
 receiver_sockets = None
 
 # Test daemons to restart.
-daemons_handler_configuration = {'daemons': [ANALYSISD_DAEMON, WAZUH_DB_DAEMON]}
+daemons_handler_configuration = {'daemons': [ANALYSISD_DAEMON, WAZUH_DB_DAEMON], 'extra_sockets': [LOGTEST_SOCKET_PATH]}
 
 local_rules_debug_messages = ['Trying rule: 880000 - Parent rules verbose', '*Rule 880000 matched',
                               '*Trying child rules', 'Trying rule: 880001 - test last_match', '*Rule 880001 matched',

--- a/tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_session_for_inactivity.py
+++ b/tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_session_for_inactivity.py
@@ -84,7 +84,7 @@ create_session_data = {'version': 1, 'command': 'log_processing',
 msg_create_session = dumps(create_session_data)
 
 # Test daemons to restart.
-daemons_handler_configuration = {'all_daemons': True}
+daemons_handler_configuration = {'all_daemons': True, 'extra_sockets': [LOGTEST_SOCKET_PATH]}
 
 wazuh_log_monitor = file_monitor.FileMonitor(WAZUH_LOG_PATH)
 

--- a/tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_sessions.py
+++ b/tests/integration/test_logtest/test_remove_old_sessions/test_remove_old_sessions.py
@@ -82,7 +82,7 @@ msg_create_session = dumps(create_session_data)
 wazuh_log_monitor = file_monitor.FileMonitor(WAZUH_LOG_PATH)
 
 # Test daemons to restart.
-daemons_handler_configuration = {'all_daemons': True}
+daemons_handler_configuration = {'all_daemons': True, 'extra_sockets': [LOGTEST_SOCKET_PATH]}
 
 
 # Test

--- a/tests/integration/test_logtest/test_remove_session/test_remove_session.py
+++ b/tests/integration/test_logtest/test_remove_session/test_remove_session.py
@@ -72,7 +72,7 @@ receiver_sockets_params = [(LOGTEST_SOCKET_PATH, 'AF_UNIX', 'TCP')]
 receiver_sockets = None  # Set in the fixtures
 
 # Test daemons to restart.
-daemons_handler_configuration = {'daemons': [ANALYSISD_DAEMON, WAZUH_DB_DAEMON]}
+daemons_handler_configuration = {'daemons': [ANALYSISD_DAEMON, WAZUH_DB_DAEMON], 'extra_sockets': [LOGTEST_SOCKET_PATH]}
 
 
 def create_session():

--- a/tests/integration/test_logtest/test_rules_decoders_load/test_load_rules_decoders.py
+++ b/tests/integration/test_logtest/test_rules_decoders_load/test_load_rules_decoders.py
@@ -68,7 +68,7 @@ t_cases_path = Path(TEST_CASES_FOLDER_PATH, 'cases_load_rules_decoders.yaml')
 t_config_parameters, t_config_metadata, t_case_ids = configuration.get_test_cases_data(t_cases_path)
 
 # Test daemons to restart.
-daemons_handler_configuration = {'daemons': [ANALYSISD_DAEMON, WAZUH_DB_DAEMON]}
+daemons_handler_configuration = {'daemons': [ANALYSISD_DAEMON, WAZUH_DB_DAEMON], 'extra_sockets': [LOGTEST_SOCKET_PATH]}
 
 def create_dummy_session():
     connection = SocketController(address=LOGTEST_SOCKET_PATH, family='AF_UNIX', connection_protocol='TCP')

--- a/tests/integration/test_logtest/test_ruleset_refresh/test_alert_labels.py
+++ b/tests/integration/test_logtest/test_ruleset_refresh/test_alert_labels.py
@@ -73,7 +73,7 @@ receiver_sockets_params = [(LOGTEST_SOCKET_PATH, 'AF_UNIX', 'TCP')]
 receiver_sockets = None
 
 # Test daemons to restart.
-daemons_handler_configuration = {'daemons': [ANALYSISD_DAEMON, WAZUH_DB_DAEMON]}
+daemons_handler_configuration = {'daemons': [ANALYSISD_DAEMON, WAZUH_DB_DAEMON], 'extra_sockets': [LOGTEST_SOCKET_PATH]}
 
 
 # Tests

--- a/tests/integration/test_logtest/test_ruleset_refresh/test_cdb_labels.py
+++ b/tests/integration/test_logtest/test_ruleset_refresh/test_cdb_labels.py
@@ -73,7 +73,7 @@ receiver_sockets_params = [(LOGTEST_SOCKET_PATH, 'AF_UNIX', 'TCP')]
 receiver_sockets = None
 
 # Test daemons to restart.
-daemons_handler_configuration = {'daemons': [ANALYSISD_DAEMON, WAZUH_DB_DAEMON]}
+daemons_handler_configuration = {'daemons': [ANALYSISD_DAEMON, WAZUH_DB_DAEMON], 'extra_sockets': [LOGTEST_SOCKET_PATH]}
 
 
 # Test

--- a/tests/integration/test_logtest/test_ruleset_refresh/test_decoder_labels.py
+++ b/tests/integration/test_logtest/test_ruleset_refresh/test_decoder_labels.py
@@ -82,7 +82,7 @@ receiver_sockets_params = [(LOGTEST_SOCKET_PATH, 'AF_UNIX', 'TCP')]
 receiver_sockets = None
 
 # Test daemons to restart.
-daemons_handler_configuration = {'daemons': [ANALYSISD_DAEMON, WAZUH_DB_DAEMON]}
+daemons_handler_configuration = {'daemons': [ANALYSISD_DAEMON, WAZUH_DB_DAEMON], 'extra_sockets': [LOGTEST_SOCKET_PATH]}
 
 
 # Tests

--- a/tests/integration/test_logtest/test_ruleset_refresh/test_rule_labels.py
+++ b/tests/integration/test_logtest/test_ruleset_refresh/test_rule_labels.py
@@ -83,7 +83,7 @@ receiver_sockets_params = [(LOGTEST_SOCKET_PATH, 'AF_UNIX', 'TCP')]
 receiver_sockets = None
 
 # Test daemons to restart.
-daemons_handler_configuration = {'daemons': [ANALYSISD_DAEMON, WAZUH_DB_DAEMON]}
+daemons_handler_configuration = {'daemons': [ANALYSISD_DAEMON, WAZUH_DB_DAEMON], 'extra_sockets': [LOGTEST_SOCKET_PATH]}
 
 
 # Tests


### PR DESCRIPTION
## Description

We had a flaky integration test in analysisd (`test_predecoder_stage.py::test_precoder_supported_formats`) that would randomly fail with `FileNotFoundError: No such file or directory` when connecting to the logtest socket right after restarting all daemons. The `daemons_handler` fixture restarted `wazuh-analysisd` and moved on immediately, without checking that the daemon (and its sockets) were actually up before the test tried to use them.

Closes #37697

## Proposed Changes

- Added a wait after restarting daemons in `daemons_handler_implementation` (`tests/integration/conftest.py`), so tests don't proceed until the restarted daemon is actually reporting as running.
- Added an `extra_sockets` option to `daemons_handler_configuration` so a module can explicitly wait for a socket that isn't part of a daemon's default set (like the logtest socket), instead of making it a blanket requirement for every analysisd restart.
- Applied `extra_sockets: [LOGTEST_SOCKET_PATH]` only to the modules that actually connect to the logtest socket (`test_predecoder_stage.py` plus the `test_logtest` files that talk to it directly). The `test_logtest` configuration tests, which intentionally exercise logtest disabled/misconfigured, are left untouched.

### Results and evidences

- [Workflow run 1](https://github.com/wazuh/wazuh/actions/runs/29844772619) :green_circle: 
- [Workflow run 2](https://github.com/wazuh/wazuh/actions/runs/29848912430) :green_circle: 
- [Workflow run 3](https://github.com/wazuh/wazuh/actions/runs/29852601275) :green_circle:
- [Workflow run 4](https://github.com/wazuh/wazuh/actions/runs/29903773373) :green_circle: 
- [Workflow run 5](https://github.com/wazuh/wazuh/actions/runs/29908183838) :green_circle:
- [Workflow run 6](https://github.com/wazuh/wazuh/actions/runs/29911423525)  :green_circle: 
- [Workflow run 7](https://github.com/wazuh/wazuh/actions/runs/29991162829) :green_circle: 

## Tests Introduced

No new tests. This only changes the shared daemon-restart fixture and how a handful of existing test modules configure it.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
