### PR TITLE
Free rpm macro context to stop unbounded growth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,4 +100,5 @@
 - Dropped orphan paths before promoting on agent startup to fix FIM. ([#36134](https://github.com/wazuh/wazuh/issues/36134))
 - Lowered the `wazuh-agentd` connection socket error log to debug level to avoid duplicating the "Lost connection with manager" error on transient disconnections. ([#37653](https://github.com/wazuh/wazuh/issues/37653))
 - Fixed a race condition when saving the Logcollector file status on shutdown. ([#37626](https://github.com/wazuh/wazuh/issues/37626))
+- Fixed an unbounded memory leak in `wazuh-modulesd` caused by a missing RPM macro context cleanup on every package scan cycle. ([#37656](https://github.com/wazuh/wazuh/issues/37656))
 

--- a/src/data_provider/src/packages/rpmPackageManager.cpp
+++ b/src/data_provider/src/packages/rpmPackageManager.cpp
@@ -40,6 +40,11 @@ RpmPackageManager::RpmPackageManager(std::shared_ptr<IRpmLibWrapper>&& wrapper)
 
 RpmPackageManager::~RpmPackageManager()
 {
+    // the constructor's rpmReadConfigFiles() call loads macros into rpm's
+    // process-global macro context (rpmInitMacros()), which is never cleared automatically.
+    // rpmFreeRpmrc() alone does not free it (different subsystem) — without this, every
+    // construct/destruct cycle of RpmPackageManager permanently grows that global table.
+    m_rpmlib->rpmFreeMacros();
     m_rpmlib->rpmFreeRpmrc();
     ms_instantiated = false;
 }

--- a/src/data_provider/src/packages/rpmlib.h
+++ b/src/data_provider/src/packages/rpmlib.h
@@ -27,6 +27,19 @@ class RpmLib final : public IRpmLibWrapper
             ::rpmFreeRpmrc();
         }
 
+        void rpmFreeMacros() override
+        {
+            // rpmReadConfigFiles() (called from RpmPackageManager's constructor,
+            // once per scanPackages() cycle) calls rpmInitMacros() internally, which PUSHES
+            // built-in + config-file macros onto rpm's process-global macro context every time,
+            // without clearing it first (confirmed in rpm/rpmio/macro.c). rpmFreeRpmrc() alone
+            // does not undo this — it's a different subsystem (platform/arch tables). Only
+            // rpmFreeMacros() empties the macro table; rpm's own reference CLI (poptALL.c) calls
+            // both together on exit. Without this, every scan cycle permanently grows rpm's
+            // global macro table — a genuine accumulating leak in third-party library state.
+            ::rpmFreeMacros(nullptr);
+        }
+
         rpmtd rpmtdNew() override
         {
             return ::rpmtdNew();

--- a/src/data_provider/src/packages/rpmlibWrapper.h
+++ b/src/data_provider/src/packages/rpmlibWrapper.h
@@ -15,6 +15,7 @@
 #include <rpm/header.h>
 #include <rpm/rpmdb.h>
 #include <rpm/rpmlib.h>
+#include <rpm/rpmmacro.h>
 #include <rpm/rpmts.h>
 
 class IRpmLibWrapper
@@ -25,6 +26,7 @@ class IRpmLibWrapper
         // LCOV_EXCL_STOP
         virtual int rpmReadConfigFiles(const char* file, const char* target) = 0;
         virtual void rpmFreeRpmrc() = 0;
+        virtual void rpmFreeMacros() = 0;
         virtual rpmtd rpmtdNew() = 0;
         virtual void rpmtdFree(rpmtd td) = 0;
         virtual rpmts rpmtsCreate() = 0;

--- a/src/data_provider/tests/sysInfoPackageLinuxParserRpm/sysInfoPackageLinuxParserRPM_test.cpp
+++ b/src/data_provider/tests/sysInfoPackageLinuxParserRpm/sysInfoPackageLinuxParserRPM_test.cpp
@@ -16,6 +16,7 @@
 #include <rpm/rpmdb.h>
 #include <rpm/rpmlib.h>
 #include <rpm/rpmts.h>
+#include <rpm/rpmmacro.h>
 #include <db.h>
 
 
@@ -48,6 +49,7 @@ class RpmLibMock
     public:
         MOCK_METHOD(int, rpmReadConfigFiles, (const char* file, const char* target));
         MOCK_METHOD(void, rpmFreeRpmrc, ());
+        MOCK_METHOD(void, rpmFreeMacros, ());
         MOCK_METHOD(rpmtd, rpmtdNew, ());
         MOCK_METHOD(rpmtd, rpmtdFree, (rpmtd td));
         MOCK_METHOD(rpmts, rpmtsCreate, ());
@@ -78,6 +80,11 @@ int rpmReadConfigFiles(const char* file, const char* target)
 void rpmFreeRpmrc()
 {
     gs_rpm_mock->rpmFreeRpmrc();
+}
+void rpmFreeMacros(rpmMacroContext mc)
+{
+    (void)mc;
+    gs_rpm_mock->rpmFreeMacros();
 }
 rpmtd rpmtdNew()
 {
@@ -402,6 +409,7 @@ TEST(SysInfoPackageLinuxParserRPM_test, rpmFromLibRPM)
     EXPECT_CALL(*rpm_mock, rpmtdFree(_)).Times(1).WillOnce(Return(nullptr));
     EXPECT_CALL(*rpm_mock, rpmdbFreeIterator(_)).Times(1).WillOnce(Return(nullptr));
     EXPECT_CALL(*rpm_mock, rpmFreeRpmrc());
+    EXPECT_CALL(*rpm_mock, rpmFreeMacros());
 
     EXPECT_CALL(*rpm_mock, headerGet(_, _, _, _)).Times(AnyNumber()).WillRepeatedly(Return(1));
 

--- a/src/data_provider/tests/sysInfoRpmPackageManager/RpmPackageManager_test.cpp
+++ b/src/data_provider/tests/sysInfoRpmPackageManager/RpmPackageManager_test.cpp
@@ -34,6 +34,7 @@ class RpmLibMock : public IRpmLibWrapper
         virtual ~RpmLibMock() override {};
         MOCK_METHOD(int, rpmReadConfigFiles, (const char* file, const char* target), (override));
         MOCK_METHOD(void, rpmFreeRpmrc, (), (override));
+        MOCK_METHOD(void, rpmFreeMacros, (), (override));
         MOCK_METHOD(rpmtd, rpmtdNew, (), (override));
         MOCK_METHOD(void, rpmtdFree, (rpmtd td), (override));
         MOCK_METHOD(rpmts, rpmtsCreate, (), (override));
@@ -96,6 +97,7 @@ TEST(RpmLibTest, RAII)
 {
     auto mock {std::make_shared<NiceMock<RpmLibMock>>()};
     EXPECT_CALL(*mock, rpmReadConfigFiles(_, _)).WillOnce(Return(0));
+    EXPECT_CALL(*mock, rpmFreeMacros());
     EXPECT_CALL(*mock, rpmFreeRpmrc());
     {
         RpmPackageManager rpm{mock};


### PR DESCRIPTION
<!-- PR draft for issue #37656 — Possible modulesd memory leak for linux agents in soak test (https://github.com/wazuh/wazuh/issues/37656). Branch: fix/37656-possible-modulesd-memory-leak-for-linux-agents-in (base origin/5.0.0 @ 1c8d7c1e85). -->

## Description

On Linux agents, `wazuh-modulesd` RSS grows linearly and without bound over the lifetime of the
process under continuous system inventory churn (packages/users/groups/processes changing), as
reported by the `5.0.0/Performance_Testing` soak test (Jenkins #235): ~1.9–2.9 MB/h over ~25 hours,
resetting only on daemon restart, Linux-only (macOS/Windows unaffected), all other daemons flat.

Root cause: `RpmPackageManager`'s constructor (`src/data_provider/src/packages/rpmPackageManager.cpp`)
calls `rpmReadConfigFiles()`, which internally calls rpm's own `rpmInitMacros()` — this pushes every
built-in macro plus every macro from rpm's config files onto **rpm's process-global macro context**,
every single `scanPackages()` cycle, with no clearing first (confirmed by reading the vendored
`rpm/rpmio/macro.c`). The only function that empties that table is `rpmFreeMacros()`. The destructor
called `rpmFreeRpmrc()` only — a different, unrelated subsystem (platform/arch compatibility tables,
`rpm/lib/rpmrc.c`) — never `rpmFreeMacros()`. rpm's own reference CLI (`rpm/lib/poptALL.c`) calls both
together on exit; this code was missing the macro-table cleanup. Since `RpmPackageManager` is
constructed and destroyed fresh on every scan cycle, this permanently grew rpm's global macro table,
unbounded, for the lifetime of the process — a genuine leak in third-party library global state,
invisible to any allocator-level mitigation (arena tuning, `malloc_trim`, tcache) because the memory
was never actually free.

This was root-caused via `massif` live-heap profiling (not RSS/allocator-level guessing) under a real
IT-Hygiene churn reproduction that matches the reported production rate (~250–272 KB/scan).

Closes #37656

## Proposed Changes

- **`src/data_provider/src/packages/rpmPackageManager.cpp`**: `RpmPackageManager::~RpmPackageManager()`
  now calls `m_rpmlib->rpmFreeMacros()` before the existing `m_rpmlib->rpmFreeRpmrc()`, so every
  scan cycle's macro-context growth is released when the object is destroyed.
- **`src/data_provider/src/packages/rpmlibWrapper.h`**: added `virtual void rpmFreeMacros() = 0;` to
  `IRpmLibWrapper`, plus the `<rpm/rpmmacro.h>` include needed for the declaration.
- **`src/data_provider/src/packages/rpmlib.h`**: implemented `RpmLib::rpmFreeMacros()` as a thin
  wrapper over the real `::rpmFreeMacros(nullptr)` (frees the global/default macro context).
- **`src/data_provider/tests/sysInfoRpmPackageManager/RpmPackageManager_test.cpp`**: added the new
  mock method (`RpmLibMock::rpmFreeMacros`) and an `EXPECT_CALL` in the existing `RpmLibTest.RAII`
  test asserting the destructor now calls it.

No behavior change to package inventory data or scan semantics — this only releases memory that was
never supposed to accumulate; nothing is skipped or gated.

### Results and Evidence

**Root-cause identification** — `massif` on the pre-fix binary under a 700s real
`wazuh-saturation` IT-Hygiene churn run (`packages:4/users:100/groups:100/processes:100/services:10`,
`syscollector` interval 30s, sync 5m, SCA off) showed the live heap (not just RSS) genuinely growing,
and call-stack attribution at the peak snapshot pinned **21.24%** of retained memory to
`RpmPackageManager::RpmPackageManager()` → `rpmReadConfigFiles()` → `rpmInitMacros()`
(`refs/massif_testE_msprint.txt`, `refs/massif_testF_msprint.txt`).

**Massif A/B (live-heap growth slope, same churn/config each run):**

| Build | live-heap slope | Δ over ~17.4 min |
|---|---|---|
| Before (unfixed) | +1.948 KB/s | +1.63 MB |
| **+ this fix (`rpmFreeMacros`)** | **−0.008 KB/s** | **flat** |

~99.6% reduction in the live-heap growth rate; the `rpmInitMacros`/`RpmPackageManager` allocation path
is entirely gone from the post-fix peak snapshot. Chart: `refs/massif_CEF_liveheap_37656.png`.

**Isolation A/B** (this fix alone, everything else at the pre-existing baseline, native RSS sampling,
same churn/config, 900s): fast warm-up (~6 min) then a **complete plateau** (2,268 KB total, then flat)
— a fundamentally different shape from the unfixed build's sustained linear ratchet (212.5 KB/scan).
Chart: `refs/rss_ABCG_native_37656.png`.

**Capstone verification — this exact commit, built and installed on a real agent enrolled to a real
manager, running the issue's reproduction methodology for a full 1-hour soak** (the longest single run
in this investigation): RSS 28,180 → 29,932 KB (+1,752 KB total over 62.2 min), of which **78% (+1,372
KB) was a ~5-minute warm-up; the remaining 57 minutes added only +380 KB (~3.3 KB/scan-equivalent,
~98.4% reduction** vs. the unfixed baseline's steady 212.5 KB/scan). Before/after comparison, same
elapsed-minutes axis:

<img width="1251" height="685" alt="image" src="https://github.com/user-attachments/assets/b151ffbf-2f6d-4319-ad94-39220ff10fa8" />


Supporting data: `refs/rss_finalfix_soak_37656.csv` (this fix, 1h real-agent run),
`refs/rss_ab_unfixed_37656.csv` (before, 17.3 min), `refs/massif_testF.out` /
`refs/massif_testF_msprint.txt` (raw massif trace for the fixed build).

Full investigation history, all intermediate A/B rounds, and file:line evidence for every hypothesis
tested (and ruled out) are in this workspace's `analysis.md`.

### Artifacts Affected

- `libsysinfo.so` (agent, all platforms — the change is in `data_provider`/`sysinfo`, Linux-specific
  code path via `#ifdef`-free RPM package manager code, but the shared library itself is built for
  every platform `sysinfo` targets). No Windows/macOS behavior change: the affected code
  (`RpmPackageManager`) is only exercised on Linux hosts with RPM-based package managers present.

### Configuration Changes

None. No new configuration parameters, no default value changes, no backward-compatibility impact.

### Documentation Updates

N/A — no user-facing behavior or configuration changed; this is an internal resource-cleanup fix.

### Tests Introduced

- Extended the existing `RpmLibTest.RAII` unit test (`RpmPackageManager_test.cpp`) to assert
  `rpmFreeMacros()` is called during `RpmPackageManager` destruction, alongside the pre-existing
  `rpmFreeRpmrc()` assertion.
- No new integration/soak test was added to the automated suite in this PR — verification was done
  manually via the real `wazuh-saturation` IT-Hygiene reproduction and `massif` profiling described
  above. (Consider whether a longer-running soak check belongs in CI as a follow-up; out of scope here.)

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided (massif profiling, isolation A/B, 1-hour real-agent soak capture)
- [x] Tests cover the new functionality (RAII destructor test updated)
- [x] Configuration changes documented (none)
- [ ] Developer documentation reflects the changes (N/A — no doc changes needed, not verified against a docs checklist)
- [x] Meets requirements and/or definition of done (root cause fixed, verified on a real agent)
- [x] No unresolved dependencies with other issues
