### PR TITLE
Fix analysisd deadlock on AR send when the queue is not drained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 #### Fixed
 
 - Fixed AES connection getting reset to blowfish on keystore rebuild. ([#37524](https://github.com/wazuh/wazuh/pull/37524))
+- Fixed a deadlock in `wazuh-analysisd` that stopped alert generation when the Active Response queue filled up. ([#37764](https://github.com/wazuh/wazuh/pull/37764))
 
 ### Agent
 

--- a/src/analysisd/alerts/exec.c
+++ b/src/analysisd/alerts/exec.c
@@ -379,6 +379,31 @@ void get_exec_msg(const active_response *ar, char *agent_id, const char *msg, ch
 }
 
 /**
+ * @brief Connect to an active response queue.
+ *
+ * The socket is given a send timeout: a reader that stops draining the queue must never
+ * block the rule matching threads, so it is never left without one.
+ *
+ * @param queue_path Queue to connect to.
+ * @return Socket descriptor on success, OS_INVALID on error.
+ */
+int connect_exec_queue(const char *queue_path) {
+    int sock = StartMQ(queue_path, WRITE, 1);
+
+    if (sock < 0) {
+        return OS_INVALID;
+    }
+
+    if (OS_SetSendTimeout(sock, EXEC_SEND_TIMEOUT_S) < 0) {
+        merror(EXEC_QUEUE_SET_TIMEOUT_ERROR, queue_path, strerror(errno), errno);
+        OS_CloseSocket(sock);
+        return OS_INVALID;
+    }
+
+    return sock;
+}
+
+/**
  * @brief Send the message to the socket. Tries to reconnect one time if the socket is not valid.
  *
  * @param socket Socket where the message will be sent.
@@ -388,14 +413,20 @@ void get_exec_msg(const active_response *ar, char *agent_id, const char *msg, ch
  */
 void send_exec_msg(int *socket, const char *queue_path, const char *exec_msg) {
     static int conn_error_sent = 0;
+    /* Serializes the socket shared by the rule matching threads: without it a thread may
+     * close and replace the descriptor while another one is still sending through it */
+    static pthread_mutex_t exec_sock_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+    w_mutex_lock(&exec_sock_mutex);
 
     if (*socket < 0) {
-        if ((*socket = StartMQ(queue_path, WRITE, 1)) < 0) {
+        if ((*socket = connect_exec_queue(queue_path)) < 0) {
             if (conn_error_sent == 0){
                 merror(QUEUE_ERROR, queue_path, strerror(errno));
                 conn_error_sent = 1;
             }
 
+            w_mutex_unlock(&exec_sock_mutex);
             return;
         } else {
             conn_error_sent = 0;
@@ -411,4 +442,6 @@ void send_exec_msg(int *socket, const char *queue_path, const char *exec_msg) {
         *socket = -1;
         merror(EXEC_QUEUE_CONNECTION_ERROR, queue_path);
     }
+
+    w_mutex_unlock(&exec_sock_mutex);
 }

--- a/src/analysisd/alerts/exec.h
+++ b/src/analysisd/alerts/exec.h
@@ -14,6 +14,9 @@
 #include "eventinfo.h"
 #include "active-response.h"
 
+/* Max time in seconds waiting for the active response queue reader to drain the queue */
+#define EXEC_SEND_TIMEOUT_S 1
+
 void OS_Exec(int *execq, int *arq, int *sock, const Eventinfo *lf, const active_response *ar);
 void getActiveResponseInString(const Eventinfo *lf,
                                const active_response *ar,
@@ -24,5 +27,6 @@ void getActiveResponseInString(const Eventinfo *lf,
                                char *temp_msg);
 void get_exec_msg(const active_response *ar, char *agent_id, const char *temp_msg, char *exec_msg);
 void send_exec_msg(int *socket, const char *queue_path, const char *exec_msg);
+int connect_exec_queue(const char *queue_path);
 
 #endif /* EXEC_H */

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -912,7 +912,7 @@ void OS_ReadMSG_analysisd(int m_queue)
 
 #ifndef LOCAL
         if (Config.ar & REMOTE_AR) {
-            if ((arq = StartMQ(ARQUEUE, WRITE, 1)) < 0) {
+            if ((arq = connect_exec_queue(ARQUEUE)) < 0) {
                 merror(ARQ_ERROR);
             } else {
                 minfo(CONN_TO, ARQUEUE, "active-response");
@@ -921,7 +921,7 @@ void OS_ReadMSG_analysisd(int m_queue)
 #endif
 
         if (Config.ar & LOCAL_AR) {
-            if ((execdq = StartMQ(EXECQUEUE, WRITE, 1)) < 0) {
+            if ((execdq = connect_exec_queue(EXECQUEUE)) < 0) {
                 merror(ARQ_ERROR);
             } else {
                 minfo(CONN_TO, EXECQUEUE, "exec");

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -202,6 +202,7 @@
 #define AR_NOAGENT_ERROR                "(1320): Agent '%s' not found."
 #define EXEC_QUEUE_CONNECTION_ERROR     "(1321): Error communicating with queue '%s'."
 #define EXEC_QUEUE_BUSY                 "(1322): Socket busy."
+#define EXEC_QUEUE_SET_TIMEOUT_ERROR    "(1323): Cannot set send timeout on queue '%s': %s (%d)"
 
 /* List operations */
 #define LIST_ERROR      "(1290): Unable to create a new list (calloc)."

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -48,6 +48,7 @@ list(APPEND analysisd_flags "-Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendS
 
 list(APPEND analysisd_names "test_exec")
 list(APPEND analysisd_flags "-Wl,--wrap,OS_SendUnix -Wl,--wrap,wdb_get_agent_info -Wl,--wrap,Eventinfo_to_jsonstr \
+                             -Wl,--wrap,OS_SetSendTimeout \
                              -Wl,--wrap,OS_ReadXML -Wl,--wrap,OS_GetOneContentforElement -Wl,--wrap,OS_ClearXML -Wl,--wrap,StartMQ \
                              -Wl,--wrap,wdb_get_agents_by_connection_status -Wl,--wrap,labels_find -Wl,--wrap,labels_get -Wl,--wrap,labels_free \
                              -Wl,--wrap,OS_IPFoundList \

--- a/src/unit_tests/analysisd/test_exec.c
+++ b/src/unit_tests/analysisd/test_exec.c
@@ -827,6 +827,7 @@ void test_send_exec_msg_reconnect_socket(void **state){
     char *exec_msg = "Message";
 
     expect_StartMQ_call(queue_path, WRITE, new_socket);
+    will_return(__wrap_OS_SetSendTimeout, 0);
     expect_OS_SendUnix_call(new_socket, exec_msg, 0, 0);
 
     send_exec_msg(&socket, queue_path, exec_msg);
@@ -856,15 +857,48 @@ void test_send_exec_msg_OS_SOCKBUSY(void **state){
     send_exec_msg(&socket, queue_path, exec_msg);
 }
 
-void test_send_exec_msg_OS_TIMEOUT(void **state){
+/* A send that times out must drop the message and invalidate the socket, never block */
+void test_send_exec_msg_send_timeout_drops_message(void **state){
     int socket = 10;
     char *queue_path = "/path/to/queue";
     char *exec_msg = "Message";
 
-    expect_OS_SendUnix_call(socket, exec_msg, 0, OS_TIMEOUT);
+    expect_OS_SendUnix_call(socket, exec_msg, 0, OS_SOCKTERR);
     expect_string(__wrap__merror, formatted_msg, "(1321): Error communicating with queue '/path/to/queue'.");
 
     send_exec_msg(&socket, queue_path, exec_msg);
+
+    assert_int_equal(socket, -1);
+}
+
+void test_connect_exec_queue(void **state){
+    char *queue_path = "/path/to/queue";
+
+    expect_StartMQ_call(queue_path, WRITE, 5);
+    will_return(__wrap_OS_SetSendTimeout, 0);
+
+    assert_int_equal(connect_exec_queue(queue_path), 5);
+}
+
+void test_connect_exec_queue_fail(void **state){
+    char *queue_path = "/path/to/queue";
+
+    expect_StartMQ_call(queue_path, WRITE, -1);
+
+    assert_int_equal(connect_exec_queue(queue_path), OS_INVALID);
+}
+
+/* A socket that cannot be given a send timeout must not be used */
+void test_connect_exec_queue_set_timeout_fail(void **state){
+    char *queue_path = "/path/to/queue";
+    errno = 1;
+
+    expect_StartMQ_call(queue_path, WRITE, 999);
+    will_return(__wrap_OS_SetSendTimeout, -1);
+    expect_string(__wrap__merror, formatted_msg,
+                  "(1323): Cannot set send timeout on queue '/path/to/queue': Operation not permitted (1)");
+
+    assert_int_equal(connect_exec_queue(queue_path), OS_INVALID);
 }
 
 void test_get_ip_success(void **state)
@@ -925,7 +959,12 @@ int main(void)
         cmocka_unit_test(test_send_exec_msg_reconnect_socket),
         cmocka_unit_test(test_send_exec_msg_reconnect_socket_fail),
         cmocka_unit_test(test_send_exec_msg_OS_SOCKBUSY),
-        cmocka_unit_test(test_send_exec_msg_OS_TIMEOUT),
+        cmocka_unit_test(test_send_exec_msg_send_timeout_drops_message),
+
+        // connect_exec_queue
+        cmocka_unit_test(test_connect_exec_queue),
+        cmocka_unit_test(test_connect_exec_queue_fail),
+        cmocka_unit_test(test_connect_exec_queue_set_timeout_fail),
         };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION

| Related issue |
| ------------- |
| #37683        |

## Description

**Symptom.** analysisd keeps running but stops generating alerts (`alerts.json` / `alerts.log` stop growing), and can trigger the `Bad file descriptor` cascade tracked in #29245.

**Root cause.** When a rule triggers an Active Response, the rule-matching threads send the order through a *shared, blocking* Unix `SOCK_DGRAM` socket (the execd/AR queue). Two defects live on that path:

1. **No send timeout.** If the consumer (execd or remoted) stops draining the queue, the socket buffer fills and `send()` blocks forever, freezing the threads that should be processing events. The consumer can stall for ordinary reasons: execd blocked reading a hung AR script's stdout, or remoted's forwarder blocked sending to a slow or disconnected agent. Without a timeout that stall freezes the rule-matching threads one by one, until analysisd stops producing alerts.
2. **Unsynchronized shared descriptor.** On error, the code closes and reconnects the shared `fd` without a lock, so concurrent threads race on the same descriptor and produce the `Bad file descriptor` cascade.


**Fix.**

- Add a 1s send timeout (`SO_SNDTIMEO`) to the queue socket through a new `connect_exec_queue()`, applied at every open point (`analysisd.c` initial connect and the reconnect inside `send_exec_msg`). A stuck `send()` now returns instead of blocking: the AR message is dropped and the thread keeps processing events, so the deadlock can't form.
- Serialize `send_exec_msg()` with a mutex, so the check/send/close/reconnect of the shared descriptor is atomic across threads and the fd-reuse race is gone.
**Trade-off.** Under saturation an AR order may be dropped, acceptable versus freezing the whole daemon.


## Configuration options

None.

## Logs/Alerts example

GDB backtrace from the affected manager (issue #37683): four rule-matching threads blocked at the same time in `send()` on the same queue fd (`fd=10`), with ~950 byte messages and identical return addresses. The binary is stripped, so the deeper frames show as `??`; the message sizes, the shared fd and the four concurrent identical stacks are consistent with the Active Response send path `OS_Exec -> send_exec_msg -> OS_SendUnix -> send()`:

```
Thread 15 "wazuh-analysisd": #0 __libc_send (fd=10, len=973, flags=0)
Thread 14 "wazuh-analysisd": #0 __libc_send (fd=10, len=943, flags=0)
Thread 13 "wazuh-analysisd": #0 __libc_send (fd=10, len=973, flags=0)
Thread 12 "wazuh-analysisd": #0 __libc_send (fd=10, len=971, flags=0)
```

Unit tests (`server` target) on Linux pass with the fix, including the new `test_exec` cases for `connect_exec_queue` and the send-timeout drop:

```

100% tests passed, 0 tests failed out of 191

Total Test time (real) =   7.81 sec

```

Local before/after on a single-node manager (local AR rule under load with its queue reader `wazuh-execd` stopped, so the AR socket fills; ~24s window):

| metric | pre-fix (package) | post-fix (this branch) |
|---|---|---|
| new alerts written | +13 (frozen) | +399 (flowing) |
| threads blocked in `__libc_send()` | 8 (permanent) | 2 (transient) |
| `(1321)` queue errors | 0 | 24 |
| outcome | deadlock | alive |

Pre-fix reproduces the reported deadlock (threads permanently stuck in the AR send, alert output frozen); post-fix the 1s send timeout drops the AR order instead of blocking, so alerting keeps running.

## Tests

- Compilation without warnings in every supported platform
- [x] Added unit tests (for new features)
