### PR TITLE
Correct EnableMulticast expected value in Windows LLMNR checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 
 - Fixed Fortigate Decoder, malicious ioc rule and RHEL 8,9,10 incorrect rpm check. ([#37434](https://github.com/wazuh/wazuh/pull/37434))
 - Fixed typo in `/etc/security/opasswd` permission check on Debian 10, Ubuntu 20.04 and Ubuntu 22.04 SCA rules. ([#37652](https://github.com/wazuh/wazuh/pull/37652))
+- Fixed the LLMNR SCA check expected value on Windows Server 2016 and 2012. ([#37765](https://github.com/wazuh/wazuh/pull/37765))
 
 ## [v4.14.7]
 

--- a/ruleset/sca/windows/cis_win2012_non_r2.yml
+++ b/ruleset/sca/windows/cis_win2012_non_r2.yml
@@ -3395,7 +3395,7 @@ checks:
     rules:
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient'
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient -> EnableMulticast'
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient -> EnableMulticast -> 1'
+      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient -> EnableMulticast -> 0'
 
   # 18.6.9.1 (L2) Ensure 'Turn on Mapper I/O (LLTDIO) driver' is set to 'Disabled'. (Automated)
   - id: 34666

--- a/ruleset/sca/windows/cis_win2016.yml
+++ b/ruleset/sca/windows/cis_win2016.yml
@@ -3381,7 +3381,7 @@ checks:
     rules:
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient'
       - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient -> EnableMulticast'
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient -> EnableMulticast -> 1'
+      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient -> EnableMulticast -> 0'
 
   # 18.6.5.1 (L2) Ensure 'Enable Font Providers' is set to 'Disabled'. (Automated)
   - id: 16161


### PR DESCRIPTION
## Description

This PR fixes the SCA LLMNR check "Ensure 'Turn off multicast name resolution' is set to 'Enabled'" which was validating `EnableMulticast -> 1` (LLMNR enabled/insecure) instead of `EnableMulticast -> 0` (LLMNR disabled/secure). With `condition: all`, the check was reporting PASS on vulnerable hosts and FAIL on hardened ones — inverted logic.

**Proposed Release:** v4.14.8
**Issue:** wazuh/wazuh#32349
**Internal Reference:** N/A

## Proposed Changes

- Updated `ruleset/sca/windows/cis_win2016.yml` — check 16160 (CIS 18.6.4.2): changed `EnableMulticast -> 1` to `EnableMulticast -> 0`.
- Updated `ruleset/sca/windows/cis_win2012_non_r2.yml` — check 34665 (CIS 18.6.4.2): changed `EnableMulticast -> 1` to `EnableMulticast -> 0`.

### Results and Evidence

**Cross-reference validation:** The remaining 6 CIS Windows policies in the repo already use the correct value `EnableMulticast -> 0` for the same check (CIS 18.6.4.2):

| File | Check ID | Line | Expected value |
|---|---|---|---|
| `cis_win10_enterprise.yml` | 15703 | 4069 | `EnableMulticast -> 0` |
| `cis_win11_enterprise.yml` | 26193 | 4268 | `EnableMulticast -> 0` |
| `cis_win2012r2.yml` | 15156 | 3217 | `EnableMulticast -> 0` |
| `cis_win2019.yml` | 16667 | 3430 | `EnableMulticast -> 0` |
| `cis_win2022.yml` | 27171 | 3491 | `EnableMulticast -> 0` |
| `cis_win2025.yml` | 36666 | 3510 | `EnableMulticast -> 0` |

**In-repo authoritative reference:** `ruleset/mitre/enterprise-attack.json` states:
> A value of "0" indicates LLMNR is disabled. (Citation: Sternsecurity LLMNR-NBTNS)

**Semantic contradiction in the check metadata:** The title, description, and rationale all describe disabling LLMNR as the secure state, yet the old rule required `EnableMulticast = 1` (LLMNR enabled).

```diff
# cis_win2016.yml (line 3384)
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient -> EnableMulticast -> 1'
+      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient -> EnableMulticast -> 0'

# cis_win2012_non_r2.yml (line 3398)
-      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient -> EnableMulticast -> 1'
+      - 'r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient -> EnableMulticast -> 0'
```

### Artifacts Affected

- `ruleset/sca/windows/cis_win2016.yml`
- `ruleset/sca/windows/cis_win2012_non_r2.yml`

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Static Ruleset Validation
- **Details:** Cross-referenced against the 6 sibling CIS Windows policies (all using `EnableMulticast -> 0`) and the in-repo MITRE ATT&CK dataset (`ruleset/mitre/enterprise-attack.json`: "A value of '0' indicates LLMNR is disabled"). No functional test environment with an enrolled Windows agent was available at the time of submission. The fix is a data-only change (expected registry value in a YAML policy); no code logic is modified.

## Review Checklist

**Manual tests with their corresponding evidence:**

- Compilation without warnings on every supported platform
    - [ ] Linux
    - [ ] Windows
    - [ ] MAC OS X
- [ ] Log syntax and correct language review
- Memory tests for Linux
    - [ ] Coverity
    - [ ] Valgrind (memcheck and descriptor leaks check)
    - [ ] AddressSanitizer

**General Checklist:**

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues