### PR TITLE
initializeContext thread-safe with std::call_once

### DIFF
--- a/src/shared_modules/utils/hashHelper.h
+++ b/src/shared_modules/utils/hashHelper.h
@@ -12,13 +12,14 @@
 #ifndef _HASH_HELPER_H
 #define _HASH_HELPER_H
 
-#include <memory>
-#include <vector>
-#include <stdexcept>
 #include "openssl/evp.h"
-#include <fstream>
 #include <array>
+#include <fstream>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
 #include <string>
+#include <vector>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
@@ -107,13 +108,20 @@ namespace Utils
             }
             static void initializeContext(const HashType hashType, std::unique_ptr<EVP_MD_CTX, EvpContextDeleter>& spCtx)
             {
-                static auto cryptoInitialized { false };
-
-                if (!cryptoInitialized)
-                {
-                    OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS | OPENSSL_INIT_ADD_ALL_DIGESTS | OPENSSL_INIT_LOAD_CONFIG | OPENSSL_INIT_NO_ATEXIT, nullptr);
-                    cryptoInitialized = true;
-                }
+                // std::call_once guarantees OPENSSL_init_crypto runs exactly once process-wide
+                // and that every concurrent caller blocks until it's done — a plain static bool
+                // guard here previously let multiple threads race past the check before either
+                // set it, so EVP_DigestInit below could transiently fail on the first-ever
+                // HashData construction (e.g. syscollector fanning out several RSync-backed
+                // checksum computations across its thread pool on its first evaluation cycle).
+                static std::once_flag cryptoInitFlag;
+                std::call_once(cryptoInitFlag,
+                               []()
+                               {
+                                   OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS | OPENSSL_INIT_ADD_ALL_DIGESTS |
+                                                           OPENSSL_INIT_LOAD_CONFIG | OPENSSL_INIT_NO_ATEXIT,
+                                                       nullptr);
+                               });
 
                 auto ret{0};
 

--- a/src/shared_modules/utils/tests/CMakeLists.txt
+++ b/src/shared_modules/utils/tests/CMakeLists.txt
@@ -38,6 +38,11 @@ file(GLOB UTIL_CXX_UNITTEST_COMMON_SRC
     "byteArrayHelper_test.cpp"
     "cmdHelper_test.cpp"
     "cacheLRU_test.cpp"
+    # hashHelper_test.cpp's ConcurrentFirstInitializationIsThreadSafe test relies on being the
+    # first test in the utils_unit_test binary to construct Utils::HashData, so it can exercise
+    # HashData::initializeContext()'s one-time OpenSSL init guard under real concurrency. Keep
+    # this entry ahead of any other test file that constructs Utils::HashData (currently
+    # zlibHelper_test.cpp, in UTIL_CXX_UNITTEST_LINUX_SRC below, linked after this list).
     "hashHelper_test.cpp"
     "mapWrapperSafe_test.cpp"
     "msgDispatcher_test.cpp"

--- a/src/shared_modules/utils/tests/hashHelper_test.cpp
+++ b/src/shared_modules/utils/tests/hashHelper_test.cpp
@@ -29,6 +29,55 @@ const std::filesystem::path INPUT_FILES_DIR {std::filesystem::current_path() / "
 // Test file used for hashing.
 const std::filesystem::path TEST_FILE {INPUT_FILES_DIR / "test_file.xyz"};
 
+// Regression test for a race in HashData::initializeContext(): the OpenSSL crypto init guard
+// was a plain, process-wide `static bool` read/written with no synchronization, so concurrent
+// *first-time* construction of HashData from multiple threads could make EVP_DigestInit()
+// transiently fail ("Error initializing EVP_MD_CTX."). Syscollector hits exactly this pattern on
+// its first evaluation cycle, fanning out several RSync-backed checksum computations across its
+// thread pool. MUST be the first HashData-constructing test in this binary: the guard being
+// exercised here only ever runs once per process, so any earlier construction elsewhere in this
+// binary would silently defeat this test. Run under ThreadSanitizer for a deterministic result —
+// without it, the actual EVP_DigestInit failure is timing-dependent and may not reproduce on
+// every run even with the bug present.
+TEST_F(HashHelperTest, ConcurrentFirstInitializationIsThreadSafe)
+{
+    constexpr auto THREAD_COUNT {16u};
+    std::vector<std::thread> threads;
+    std::vector<std::exception_ptr> exceptions(THREAD_COUNT);
+
+    for (auto i {0u}; i < THREAD_COUNT; ++i)
+    {
+        threads.emplace_back(
+            [i, &exceptions]()
+            {
+                try
+                {
+                    HashData hash;
+                    const std::string data {"HASH"};
+                    hash.update(data.c_str(), data.size());
+                    hash.hash();
+                }
+                catch (...)
+                {
+                    exceptions[i] = std::current_exception();
+                }
+            });
+    }
+
+    for (auto& thread : threads)
+    {
+        thread.join();
+    }
+
+    for (const auto& exceptionPtr : exceptions)
+    {
+        if (exceptionPtr)
+        {
+            EXPECT_NO_THROW(std::rethrow_exception(exceptionPtr));
+        }
+    }
+}
+
 TEST_F(HashHelperTest, UnsupportedHashType)
 {
     EXPECT_THROW(HashData hash{static_cast<HashType>(15)}, std::runtime_error);
@@ -90,55 +139,6 @@ TEST_F(HashHelperTest, HashHelperHashIterativeSha256)
     const auto result{ hash.hash() };
     EXPECT_EQ(sizeof(expected), result.size());
     EXPECT_TRUE(!memcmp(expected, result.data(), result.size()));
-}
-
-// Regression test for a race in HashData::initializeContext(): the OpenSSL crypto init guard
-// was a plain, process-wide `static bool` read/written with no synchronization, so concurrent
-// *first-time* construction of HashData from multiple threads could make EVP_DigestInit()
-// transiently fail ("Error initializing EVP_MD_CTX."). Syscollector hits exactly this pattern on
-// its first evaluation cycle, fanning out several RSync-backed checksum computations across its
-// thread pool. MUST be the first HashData-constructing test in this binary: the guard being
-// exercised here only ever runs once per process, so any earlier construction elsewhere in this
-// binary would silently defeat this test. Run under ThreadSanitizer for a deterministic result —
-// without it, the actual EVP_DigestInit failure is timing-dependent and may not reproduce on
-// every run even with the bug present.
-TEST_F(HashHelperTest, ConcurrentFirstInitializationIsThreadSafe)
-{
-    constexpr auto THREAD_COUNT {16u};
-    std::vector<std::thread> threads;
-    std::vector<std::exception_ptr> exceptions(THREAD_COUNT);
-
-    for (auto i {0u}; i < THREAD_COUNT; ++i)
-    {
-        threads.emplace_back(
-            [i, &exceptions]()
-            {
-                try
-                {
-                    HashData hash;
-                    const std::string data {"HASH"};
-                    hash.update(data.c_str(), data.size());
-                    hash.hash();
-                }
-                catch (...)
-                {
-                    exceptions[i] = std::current_exception();
-                }
-            });
-    }
-
-    for (auto& thread : threads)
-    {
-        thread.join();
-    }
-
-    for (const auto& exceptionPtr : exceptions)
-    {
-        if (exceptionPtr)
-        {
-            EXPECT_NO_THROW(std::rethrow_exception(exceptionPtr));
-        }
-    }
 }
 
 /**

--- a/src/shared_modules/utils/tests/hashHelper_test.cpp
+++ b/src/shared_modules/utils/tests/hashHelper_test.cpp
@@ -12,6 +12,8 @@
 #include "hashHelper_test.h"
 #include "hashHelper.h"
 #include <filesystem>
+#include <thread>
+#include <vector>
 
 void HashHelperTest::SetUp() {};
 
@@ -88,6 +90,55 @@ TEST_F(HashHelperTest, HashHelperHashIterativeSha256)
     const auto result{ hash.hash() };
     EXPECT_EQ(sizeof(expected), result.size());
     EXPECT_TRUE(!memcmp(expected, result.data(), result.size()));
+}
+
+// Regression test for a race in HashData::initializeContext(): the OpenSSL crypto init guard
+// was a plain, process-wide `static bool` read/written with no synchronization, so concurrent
+// *first-time* construction of HashData from multiple threads could make EVP_DigestInit()
+// transiently fail ("Error initializing EVP_MD_CTX."). Syscollector hits exactly this pattern on
+// its first evaluation cycle, fanning out several RSync-backed checksum computations across its
+// thread pool. MUST be the first HashData-constructing test in this binary: the guard being
+// exercised here only ever runs once per process, so any earlier construction elsewhere in this
+// binary would silently defeat this test. Run under ThreadSanitizer for a deterministic result —
+// without it, the actual EVP_DigestInit failure is timing-dependent and may not reproduce on
+// every run even with the bug present.
+TEST_F(HashHelperTest, ConcurrentFirstInitializationIsThreadSafe)
+{
+    constexpr auto THREAD_COUNT {16u};
+    std::vector<std::thread> threads;
+    std::vector<std::exception_ptr> exceptions(THREAD_COUNT);
+
+    for (auto i {0u}; i < THREAD_COUNT; ++i)
+    {
+        threads.emplace_back(
+            [i, &exceptions]()
+            {
+                try
+                {
+                    HashData hash;
+                    const std::string data {"HASH"};
+                    hash.update(data.c_str(), data.size());
+                    hash.hash();
+                }
+                catch (...)
+                {
+                    exceptions[i] = std::current_exception();
+                }
+            });
+    }
+
+    for (auto& thread : threads)
+    {
+        thread.join();
+    }
+
+    for (const auto& exceptionPtr : exceptions)
+    {
+        if (exceptionPtr)
+        {
+            EXPECT_NO_THROW(std::rethrow_exception(exceptionPtr));
+        }
+    }
 }
 
 /**


### PR DESCRIPTION

## Description
HashData::initializeContext() guarded the one-time call to OPENSSL_init_crypto() with a plain static bool cryptoInitialized flag, read and written with no synchronization. When multiple threads constructed HashData for the first time concurrently, more than one could observe cryptoInitialized == false and race past the check before either thread set it, letting EVP_DigestInit() run against a not-yet-initialized OpenSSL state. This surfaced as an intermittent Error initializing EVP_MD_CTX. — most visibly in syscollector, which fans out several RSync-backed checksum computations across its thread pool on its first evaluation cycle (#37743).

## Proposed Changes

Replace the unsynchronized boolean guard with std::once_flag + std::call_once, which guarantees OPENSSL_init_crypto runs exactly once process-wide and that every concurrent caller blocks until it complete
### Results and Evidence
#### Setup

Isolated `hashHelper.h` in two variants and compiled the *same* repro harness against each:

- `buggy/hashHelper.h` — original code, `static bool cryptoInitialized` guard.
- `fixed/hashHelper.h` — this PR's code, `static std::once_flag` + `std::call_once`.

Harness (`repro.cpp`): 50 rounds of 32 threads each, all constructing `Utils::HashData` for the first time concurrently and hashing `"HASH"` — the same pattern syscollector hits fanning out RSync-backed checksum computations across its thread pool on its first evaluation cycle.

```
g++ -std=c++17 -I<buggy|fixed> repro.cpp -o repro -lssl -lcrypto -lpthread [-fsanitize=thread -g -O1 | -O2]
```

#### 1. ThreadSanitizer — buggy version: race detected

```
$ setarch "$(uname -m)" -R ./repro_buggy_tsan
==================
WARNING: ThreadSanitizer: data race (pid=32288)
  Write of size 1 at 0x55555555a029 by thread T2:
    #0 Utils::HashData::initializeContext(...) buggy/hashHelper.h:115
    #1 Utils::HashData::HashData(Utils::HashType) buggy/hashHelper.h:39
    ...
  Previous read of size 1 at 0x55555555a029 by thread T12:
    #0 Utils::HashData::initializeContext(...) buggy/hashHelper.h:112
    ...
  Location is global 'Utils::HashData::initializeContext(...)::cryptoInitialized' of size 1
SUMMARY: ThreadSanitizer: data race buggy/hashHelper.h:115 in Utils::HashData::initializeContext(...)
==================
[... second, similar report ...]
Rounds: 50, threads/round: 32, total failures: 0
ThreadSanitizer: reported 2 warnings
```

TSan pinpoints the exact unsynchronized read/write on `cryptoInitialized` (the old `static bool` guard) at `hashHelper.h:112` (read) and `:115` (write) — confirming the race independently of whether it happened to produce an observable `EVP_DigestInit` failure in this particular run. Exit code: 66 (TSan error).

#### 2. ThreadSanitizer — fixed version: clean

```
$ setarch "$(uname -m)" -R ./repro_fixed_tsan
Rounds: 50, threads/round: 32, total failures: 0
```

No warnings, exit code: 0. `std::call_once` gives the initializer a proper happens-before
edge, so TSan sees no race.

#### 3. Plain runs (no instrumentation) — why this bug was intermittent in production

```
100 fresh-process runs of repro_buggy_plain (no TSan): 0/100 hit an observable EVP_DigestInit failure 20  fresh-process runs of repro_fixed_plain (no TSan): 0/20 failures (sanity check)
```

Without ThreadSanitizer's instrumentation (which slows/serializes memory accesses enough to expose the race), the functional failure is timing-dependent and didn't manifest in 100 runs on this machine — consistent with the original report being an intermittent, hard-to-repro "Error initializing EVP_MD_CTX." rather than a deterministic crash. This is exactly why the regression test added in this PR (`ConcurrentFirstInitializationIsThreadSafe`) is meant to be run under ThreadSanitizer in CI for a deterministic signal, rather than relied on bare.

#### Conclusion

- **Buggy** (`static bool`): TSan confirms a real data race on the init guard.
- **Fixed** (`std::call_once`): same workload, same thread count, zero races.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

N-A
### Configuration Changes

N-A

### Tests Introduced
HashHelperTest, ConcurrentFirstInitializationIsThreadSafe

## Review Checklist
N-A

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

