### PR TITLE
Fix typo in SCA rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 
 - Fixed Fortigate Decoder, malicious ioc rule and RHEL 8,9,10 incorrect rpm check. ([#37434](https://github.com/wazuh/wazuh/pull/37434))
 - Fixed typo in `/etc/security/opasswd` permission check on Debian 10, Ubuntu 20.04 and Ubuntu 22.04 SCA rules. ([#37652](https://github.com/wazuh/wazuh/pull/37652))
+- Fixed typo in `/etc/shells` permission check on Debian 10, Ubuntu 20.04 and Ubuntu 22.04 SCA rules. ([#37770](https://github.com/wazuh/wazuh/pull/37770))
 
 ## [v4.14.7]
 

--- a/ruleset/sca/debian/cis_debian10.yml
+++ b/ruleset/sca/debian/cis_debian10.yml
@@ -5128,7 +5128,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/shells- -> r:0 root 0 root && r:644|640|604|600|400|500'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/shells -> r:0 root 0 root && r:644|640|604|600|400|500'
 
   # 6.1.10 Ensure permissions on /etc/security/opasswd are configured. (Automated)
   - id: 2712

--- a/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu20-04.yml
@@ -5004,7 +5004,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/shells- -> r:0 root 0 root && r:644|640|604|600|400|500'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/shells -> r:0 root 0 root && r:644|640|604|600|400|500'
 
   # 6.1.10 Ensure permissions on /etc/security/opasswd are configured. (Automated)
   - id: 19205

--- a/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
@@ -4974,7 +4974,7 @@ checks:
       - soc_2: ["CC5.2", "CC6.1"]
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/shells- -> r:0 root 0 root && r:644|640|604|600|400|500'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/shells -> r:0 root 0 root && r:644|640|604|600|400|500'
 
   # 7.1.10 Ensure permissions on /etc/security/opasswd are configured. (Automated)
   - id: 28751


### PR DESCRIPTION
|Related issue|
|---|
| #20281 |

## Description

Fixed a typo in the permissions check for the `/etc/shells` file (which was looking for the non-existent `/etc/shells-`) in the Debian 10, Ubuntu 20.04, and Ubuntu 22.04 SCA rules (CIS 6.1.9 / 7.1.9).

The extra trailing `-` made `stat` fail with `No such file or directory` on every system, so the check was always reported as `failed`, even when `/etc/shells` had the correct permissions (`644 root:root`).

## Configuration options

No new configuration options.

## Logs/Alerts example

No logs/alerts changes.

## Tests

Reproduced the root cause and verified the fix on real Debian 10, Ubuntu 20.04 and Ubuntu 22.04 containers by running the exact `stat` command used by the SCA rule, before and after the fix:

```sh
$ docker run --rm --network none debian:10 bash -c 'stat -Lc "%n %a %u %U %g %G" /etc/shells; stat -Lc "%n %a %u %U %g %G" /etc/shells-'
/etc/shells 644 0 root 0 root
stat: cannot stat '/etc/shells-': No such file or directory

$ docker run --rm --network none ubuntu:20.04 bash -c 'stat -Lc "%n %a %u %U %g %G" /etc/shells; stat -Lc "%n %a %u %U %g %G" /etc/shells-'
/etc/shells 644 0 root 0 root
stat: cannot stat '/etc/shells-': No such file or directory

$ docker run --rm --network none ubuntu:22.04 bash -c 'stat -Lc "%n %a %u %U %g %G" /etc/shells; stat -Lc "%n %a %u %U %g %G" /etc/shells-'
/etc/shells 644 0 root 0 root
stat: cannot statx '/etc/shells-': No such file or directory
```


On all three OS versions, `/etc/shells` exists by default with `644 root:root`, which matches the expected values in the rule (`r:0 root 0 root && r:644|640|604|600|400|500`). The old check against `/etc/shells-` fails with exit code 1 on every case, confirming it reported `failed` on correctly configured systems as described in the issue. With the fix, the same stat command now targets the real file and reports `passed` on a default, unmodified system.
