### PR TITLE
Disable OpenSSL runtime CPU probing in Python daemon wrappers

### DIFF
--- a/api/wrappers/generic_wrapper.sh
+++ b/api/wrappers/generic_wrapper.sh
@@ -5,6 +5,13 @@
 
 WPYTHON_BIN="framework/python/bin/python3"
 
+# Skip OpenSSL runtime CPU feature probing. Some hypervisors (e.g. VMware
+# Fusion on Apple Silicon) advertise SVE in the guest CPU flags without
+# implementing it, so the probe dies with SIGILL when importing cryptography.
+# No effect on non-ARM platforms.
+OPENSSL_armcap=0
+export OPENSSL_armcap
+
 SCRIPT_PATH_NAME="$0"
 
 DIR_NAME="$(cd $(dirname ${SCRIPT_PATH_NAME}); pwd -P)"

--- a/framework/wrappers/generic_wrapper.sh
+++ b/framework/wrappers/generic_wrapper.sh
@@ -5,6 +5,13 @@
 
 WPYTHON_BIN="framework/python/bin/python3"
 
+# Skip OpenSSL runtime CPU feature probing. Some hypervisors (e.g. VMware
+# Fusion on Apple Silicon) advertise SVE in the guest CPU flags without
+# implementing it, so the probe dies with SIGILL when importing cryptography.
+# No effect on non-ARM platforms.
+OPENSSL_armcap=0
+export OPENSSL_armcap
+
 SCRIPT_PATH_NAME="$0"
 
 DIR_NAME="$(cd $(dirname ${SCRIPT_PATH_NAME}); pwd -P)"


### PR DESCRIPTION
## Description

Closes #37749

`wazuh-manager-apid` crashes with SIGILL on arm64 guests running under VMware Fusion on Apple Silicon since cryptography was bumped to 48.0.1 (#37361). The hypervisor advertises SVE2 in the guest CPU flags without implementing it, and the OpenSSL bundled in the cryptography wheel probes SVE at import time with the `cntb` instruction, which crashes before the daemon starts. Upstream closed it as a hypervisor bug (pyca/cryptography#14733), so the workaround belongs on our side.

## Proposed Changes

Set `OPENSSL_armcap=0` in the Python daemon wrappers (`api/wrappers/generic_wrapper.sh` and `framework/wrappers/generic_wrapper.sh`). With this variable set, OpenSSL skips runtime CPU feature probing entirely and uses its portable implementations.

The issue proposed setting the variable in the systemd unit instead. The wrapper placement was chosen because it:

- covers every start path: systemd, SysV init scripts, containers and direct CLI invocations such as `wazuh-manager-apid -t` and the framework tools (`cluster_control`, `rbac_control`, ...), which crash the same way,
- scopes the effect to the embedded Python processes, leaving hardware crypto acceleration of the C daemons (remoted, authd) untouched on native arm64.

The variable has no effect on x86_64, where OpenSSL uses `OPENSSL_ia32cap`.

### Results and Evidence

Wrapper environment propagation and argument forwarding, verified with a stub Python binary:

```
$ bin/wazuh-manager-apid -t -f
OPENSSL_armcap=0 script=<root>/api/scripts/wazuh_manager_apid.py args=-t -f
$ bin/wazuh-manager-clusterd -V
OPENSSL_armcap=0 script=<root>/framework/scripts/wazuh_manager_clusterd.py args=-V
```

Functional check of cryptography 48.0.1 with the variable set, on linux/arm64 with Python 3.12 (same interpreter version as the embedded framework Python):

```
--- default env ---
import OK
--- OPENSSL_armcap=0 ---
AES-GCM + SHA256 round-trip OK with OPENSSL_armcap=0
```

End-to-end reproduction and fix verification on a VMware Fusion arm64 guest (Ubuntu 24.04, VMware20,1). Fusion 13.6.4 does not expose the bogus SVE flags (the reporter's 25.x does), so the condition was reproduced with an `LD_PRELOAD` shim that adds the SVE/SVE2 bits to `getauxval()`, the same interface OpenSSL reads and Fusion 25.x misreports. Manager layout replicated with a Python 3.12 venv at `framework/python` and cryptography 48.0.1, the same manylinux arm64 wheel the package bundles.

| Scenario | Result |
|---|---|
| Import, real hwcaps | OK |
| Import, spoofed SVE | SIGILL, exit 132 |
| Import, spoofed SVE + `OPENSSL_armcap=0` | OK, AES-GCM round-trip passes |
| `wazuh-manager-apid` / `wazuh-manager-clusterd` through unpatched wrappers, spoofed SVE | Both SIGILL, exit 132 |
| Same through patched wrappers, spoofed SVE | Both start, cryptography 48.0.1 loaded |

gdb shows the same crash site reported in #37749:

```
Program received signal SIGILL, Illegal instruction.
0x0000fffff71db5f8 in _armv8_sve_get_vl_bytes () from .../cryptography/hazmat/bindings/_rust.abi3.so
=> 0xfffff71db5f8 <_armv8_sve_get_vl_bytes>:	cntb	x0
#1  0x0000fffff6de0728 in OPENSSL_cpuid_setup ()
```


### Artifacts Affected

- Manager packages (DEB, RPM) for all platforms: `bin/wazuh-manager-apid`, `bin/wazuh-manager-clusterd` and the framework CLI tools are installed from these wrappers.

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

N/A

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)

