### PR TITLE
Fix issue reference in the daemons stats changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 - Fixed `wazuh-db` error assigning groups by avoiding the keyentries counter as index. ([#34082](https://github.com/wazuh/wazuh/issues/34082))
 - Fixed token validation race condition after revoke. ([#35043](https://github.com/wazuh/wazuh/issues/35043))
 - Handled the stop signal during vulnerability feed download. ([#35638](https://github.com/wazuh/wazuh/issues/35638))
-- Fixed `GET /cluster/{node_id}/daemons/stats` always returning error 1014 for `wazuh-manager-analysisd` due to a protocol mismatch between `WazuhSocketJSON` and the engine's HTTP API socket. ([#36721](https://github.com/wazuh/wazuh/issues/37521))
+- Fixed `GET /cluster/{node_id}/daemons/stats` always returning error 1014 for `wazuh-manager-analysisd` due to a protocol mismatch between `WazuhSocketJSON` and the engine's HTTP API socket. ([#37521](https://github.com/wazuh/wazuh/issues/37521))
 
 ### Agent
 


### PR DESCRIPTION
## Description

Changelog review for the 5.0.0 Beta 4 stage. The `[v5.0.0]` section is complete: every PR merged into `5.0.0` since the Beta 3 review either has its entry or carries the `no-changelog` label. The review found one defect: the entry for the `GET /cluster/{node_id}/daemons/stats` fix links to issue #37521 but its link text reads `#36721`, an unrelated issue.

Closes #37825.

## Proposed Changes

- Correct the link text of the daemons stats changelog entry from `#36721` to `#37521`, matching the URL it already points to.

### Results and Evidence

Diff of the only change:

```diff
-- Fixed `GET /cluster/{node_id}/daemons/stats` always returning error 1014 for `wazuh-manager-analysisd` due to a protocol mismatch between `WazuhSocketJSON` and the engine's HTTP API socket. ([#36721](https://github.com/wazuh/wazuh/issues/37521))
+- Fixed `GET /cluster/{node_id}/daemons/stats` always returning error 1014 for `wazuh-manager-analysisd` due to a protocol mismatch between `WazuhSocketJSON` and the engine's HTTP API socket. ([#37521](https://github.com/wazuh/wazuh/issues/37521))
```

Consistency check of link text vs URL over the whole file, before and after the fix:

```
$ python3 check_links.py CHANGELOG.md   # before
CHANGELOG.md:53 text #36721 -> issues/37521
$ python3 check_links.py CHANGELOG.md   # after
(no mismatches)
```

Coverage check: PRs merged into `5.0.0` after the Beta 3 changelog review (#37369) with a changelog entry: #37695 (issue #37626), #37746 (issue #37706), #37758 (issue #37656). All remaining merges (#37430, #37433, #37439, #37496, #37703, #37720, #37724, #37731, #37751, #37756) carry the `no-changelog` label.

### Artifacts Affected

None.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None.

## Review Checklist
- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
