### PR TITLE
Restore legacy 5.0 deprecation notes and update wm_control migration

### DIFF
--- a/docs/ref/modules/control/architecture.md
+++ b/docs/ref/modules/control/architecture.md
@@ -463,17 +463,17 @@ No dedicated thread. `control_dispatch()` is called synchronously from the reque
 
 ### Changes
 
-| Feature               | v4.x (execd)   | v5.0 (wm_control) | Notes                               |
-| --------------------- | -------------- | ----------------- | ----------------------------------- |
-| Manager restart       | ✓ wcom socket  | ✓ control socket  | Migrated                            |
-| Manager reload        | ✓ wcom socket  | ✓ control socket  | Migrated                            |
-| Get primary IP        | ✓ wcom socket  | ✗ Removed         | No longer handled by control socket |
-| Configuration serving | ✓ wcom socket  | ✗ File-based      | Changed approach                    |
-| Config validation     | ✓ wcom socket  | ✗ File-based      | Changed approach                    |
-| File unmerge          | ✓ wcom socket  | ✗ Removed         | Deprecated                          |
-| File uncompress       | ✓ wcom socket  | ✗ Removed         | Deprecated                          |
-| Restart locking       | ✓ wcom socket  | ✗ Not migrated    | TBD                                 |
-| Active Response       | ✓ execd daemon | ✗ Agents only     | Intentional removal                 |
+| Feature               | v4.x (execd)   | v5.0 (wm_control) | Notes                                                                              |
+| --------------------- | -------------- | ----------------- | ----------------------------------------------------------------------------------- |
+| Manager restart       | ✓ wcom socket  | ✓ control socket  | Migrated                                                                           |
+| Manager reload        | ✓ wcom socket  | ✓ control socket  | Migrated                                                                           |
+| Get primary IP        | ✓ wcom socket  | ✗ Removed         | No longer handled by control socket                                                |
+| Configuration serving | ✓ wcom socket  | ✗ Not migrated    | Manager: file-based (`get_ossec_conf`); Agent: still via `com` socket (`os_execd`, agent-only) |
+| Config validation     | ✓ wcom socket  | ✗ Not migrated    | Not available on manager — `os_execd` no longer builds/runs there                 |
+| File unmerge          | ✓ wcom socket  | ✗ Not migrated    | Unchanged, agent-only (`os_execd`/`wcom.c`)                                        |
+| File uncompress       | ✓ wcom socket  | ✗ Not migrated    | Unchanged, agent-only (`os_execd`/`wcom.c`)                                        |
+| Restart locking       | ✓ wcom socket  | ✗ Not migrated    | TBD                                                                                |
+| Active Response       | ✓ execd daemon | ✗ Agents only     | Intentional removal                                                                |
 
 ## Performance Characteristics
 

--- a/docs/ref/modules/rootcheck/README.md
+++ b/docs/ref/modules/rootcheck/README.md
@@ -107,6 +107,16 @@ Scans network interfaces for promiscuous mode, which allows capturing all networ
 | [Architecture](architecture.md) | Technical architecture and detection methods |
 | [Output Samples](output-samples.md) | Alert formats and examples |
 
+## Migration from Deprecated Features
+
+If you were using rootcheck features removed in Wazuh 5.0, here are the recommended alternatives:
+
+| Removed Feature | Alternative Solution |
+|----------------|---------------------|
+| **File check** (rootkit_files.txt) | Use [FIM](../fim/README.md) with threat intelligence integration |
+| **Trojan scan** (rootkit_trojans.txt) | Use [FIM](../fim/README.md) with YARA rules |
+| **Policy check** (system_audit_*.txt) | Use [SCA](../sca/README.md) module with YAML policies |
+
 ## Related Modules
 
 - **[Security Configuration Assessment (SCA)](../sca/index.html)**: Policy and configuration compliance checking

--- a/docs/ref/modules/rootcheck/architecture.md
+++ b/docs/ref/modules/rootcheck/architecture.md
@@ -411,6 +411,7 @@ Rootcheck alerts are processed by rules in the 510-550 range:
 
 - Existing rootcheck queries against API return limited data
 - Historical rootcheck data not migrated
+- Configuration remains compatible (deprecated options ignored)
 
 ## Internal Options
 


### PR DESCRIPTION
## Description

Commit af06bbeb1ac6a9eac082d5be91cc38baca3cdd24 ("docs: remove legacy 5.0 references") removed the explanations of why several rootcheck and control-module features were deprecated in 5.0, along with the recommended alternatives and the wazuh-execd to wm_control migration context. This information is still valuable for users migrating from 4.x, so this PR reverts that commit and refreshes the restored content to match the current codebase.



## Proposed Changes

- Revert af06bbeb1ac6a9eac082d5be91cc38baca3cdd24, restoring the deprecated rootcheck options section (`scanall`, `readall`), the rootcheck "Migration from Deprecated Features" table, and the wazuh-execd/wm_control architecture comparison in `docs/ref/modules/control/architecture.md`.
- Resolved conflicts against docs that were restructured after af06bbeb1a (e.g. the new "Internal Options" section in `rootcheck/configuration.md` and the expanded manager/agent Unix/Windows description in `control/README.md`), keeping the newer, more accurate wording instead of reintroducing stale duplicates.
- Removed the VirusTotal mention from the rootcheck migration table, since the VirusTotal integration itself was removed in 5.0 (integratord was deprecated) and pointing to it as an alternative is no longer accurate.
- Verified the wm_control migration status against the current source and corrected the "Changes" table in `control/architecture.md`: configuration serving, config validation, file unmerge and file uncompress are not file-based as previously documented, they are still served over the legacy `com` socket by `os_execd`/`wcom.c` and were never migrated to `wm_control`. Restart locking remains correctly documented as not migrated (TBD).

### Results and Evidence

N/A (documentation-only change)

### Manual tests with their corresponding evidence

N/A (documentation-only change, no compiled artifacts affected)

### Artifacts Affected

- `docs/ref/modules/control/architecture.md`
- `docs/ref/modules/rootcheck/README.md`
- `docs/ref/modules/rootcheck/architecture.md`
- `docs/ref/modules/rootcheck/configuration.md`

### Configuration Changes

N/A

### Tests Introduced

N/A


- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
