### PR TITLE
Validate destination paths when deleting rule and decoder files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Fixed AES connection getting reset to blowfish on keystore rebuild. ([#37524](https://github.com/wazuh/wazuh/pull/37524))
 - Fixed a deadlock in `wazuh-analysisd` that stopped alert generation when the Active Response queue filled up. ([#37764](https://github.com/wazuh/wazuh/pull/37764))
 - Restricted the upgrade commands accepted from the agent message channel in Analysisd. ([#37745](https://github.com/wazuh/wazuh/pull/37745))
+- Added destination path validation when deleting rule and decoder files. ([#37838](https://github.com/wazuh/wazuh/pull/37838))
 
 ### Agent
 

--- a/framework/wazuh/decoder.py
+++ b/framework/wazuh/decoder.py
@@ -421,6 +421,10 @@ def delete_decoder_file(filename: Union[str, list], relative_dirname: str = None
         if wazuh_error:
             raise wazuh_error
 
+        base_path = join(common.WAZUH_PATH, relative_dirname)
+        if commonpath([realpath(full_path), realpath(base_path)]) != realpath(base_path):
+            raise WazuhError(1508)
+
         if exists(full_path):
             try:
                 remove(full_path)

--- a/framework/wazuh/rule.py
+++ b/framework/wazuh/rule.py
@@ -547,6 +547,10 @@ def delete_rule_file(filename: Union[str, list], relative_dirname: str = None) -
         if wazuh_error:
             raise wazuh_error
 
+        base_path = join(common.WAZUH_PATH, relative_dirname)
+        if commonpath([realpath(full_path), realpath(base_path)]) != realpath(base_path):
+            raise WazuhError(1212)
+
         if exists(full_path):
             try:
                 remove(full_path)

--- a/framework/wazuh/tests/test_decoder.py
+++ b/framework/wazuh/tests/test_decoder.py
@@ -374,6 +374,17 @@ def test_upload_decoder_file_path_traversal(mock_safe_move, mock_upload_file):
     mock_upload_file.assert_not_called()
 
 
+def test_delete_decoder_file_path_traversal():
+    """Test that a crafted filename resolving outside the decoders directory is rejected and the
+    file is not removed."""
+    with patch('wazuh.decoder.remove') as mock_remove:
+        result = decoder.delete_decoder_file(filename='../../../../../../tmp/poc_decoder_traversal')
+        assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
+        assert result.render()['data']['failed_items'][0]['error']['code'] == 1508, \
+            'Error code not expected.'
+        mock_remove.assert_not_called()
+
+
 @pytest.mark.parametrize('filename, relative_dirname', [
     ('test1_decoders.xml', None),
     ('test3_decoders.xml', None),

--- a/framework/wazuh/tests/test_rule.py
+++ b/framework/wazuh/tests/test_rule.py
@@ -440,6 +440,18 @@ def test_upload_rule_file_path_traversal(mock_safe_move, mock_upload_file):
         mock_upload_file.assert_not_called()
 
 
+def test_delete_rule_file_path_traversal():
+    """Test that a crafted filename resolving outside the rules directory is rejected and the
+    file is not removed."""
+    with patch('wazuh.core.configuration.get_ossec_conf', return_value=get_rule_file_ossec_conf):
+        with patch('wazuh.rule.remove') as mock_remove:
+            result = rule.delete_rule_file(filename='../../../../../../tmp/poc_rule_traversal')
+            assert isinstance(result, AffectedItemsWazuhResult), 'No expected result type'
+            assert result.render()['data']['failed_items'][0]['error']['code'] == 1212, \
+                'Error code not expected.'
+            mock_remove.assert_not_called()
+
+
 @pytest.mark.parametrize('file, relative_dirname', [
     ('test_rules.xml', None),
     ('test_rules.xml', 'tests/data/etc/rules'),


### PR DESCRIPTION
## Description
`delete_rule_file` and `delete_decoder_file` built their destination path from a caller-supplied `filename` without confirming it stayed inside the validated rules/decoders directory before removing it. This path is reachable through the cluster callable mechanism (`as_wazuh_object` -> `DistributedAPI.run_local`), which bypasses the REST controller's filename format validators, and mirrors the destination-path validation already applied to the upload functions in PR #37691. The fix resolves the final destination with `realpath` and rejects the request if it falls outside the intended base directory, before any file is removed — the same check already applied to `upload_rule_file`/`upload_decoder_file`.

## Proposed Changes
- `framework/wazuh/rule.py`: `delete_rule_file` now verifies `commonpath([realpath(full_path), realpath(base_path)]) == realpath(base_path)` before calling `remove()`; raises `WazuhError(1212)` otherwise.
- `framework/wazuh/decoder.py`: `delete_decoder_file` now applies the same check; raises `WazuhError(1508)` otherwise.
- `framework/wazuh/tests/test_rule.py`: added `test_delete_rule_file_path_traversal`.
- `framework/wazuh/tests/test_decoder.py`: added `test_delete_decoder_file_path_traversal`.

### Results and Evidence
- Verified against the patched, installed manager (`/var/ossec`) by driving the exact resolution/invocation flow the cluster protocol uses, rather than calling the function directly: the target function is serialized with `WazuhJSONEncoder` and resolved back with `as_wazuh_object` (the same call the master makes when deserializing a cluster request), then invoked as `f(**f_kwargs)` under the default RBAC context, exactly as `DistributedAPI.run_local` does.
  - `delete_rule_file`, invoked with `filename='../../../../../../tmp/poc_rule_traversal'`, is denied: `{'code': 1212, 'message': 'Invalid filename. It resolves outside of the expected rules directory.'}`, and `os.remove()` is confirmed not called.
  - `delete_decoder_file`, invoked the same way with an equivalent crafted `filename`, is denied: `{'code': 1508, 'message': 'Invalid filename. It resolves outside of the expected decoders directory.'}`, and `os.remove()` is confirmed not called.
- Before the fix, the same crafted requests fell through to the `exists()`/`remove()` block with no containment check (regression check: the new unit tests failed with error code `1906` instead of the expected `1212`/`1508`).
- Full suite: `pytest wazuh/tests/test_rule.py wazuh/tests/test_decoder.py` — 136 passed, no regressions.

### Artifacts Affected
`framework/wazuh` (manager Python framework/API).

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
- `framework/wazuh/tests/test_rule.py::test_delete_rule_file_path_traversal`
- `framework/wazuh/tests/test_decoder.py::test_delete_decoder_file_path_traversal`

## Credits
Thanks to @namd0ng for reporting this issue.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
