### PR TITLE
Disable OpenSSL runtime CPU probing in Python daemon wrappers

### DIFF
--- a/api/wrappers/generic_wrapper.sh
+++ b/api/wrappers/generic_wrapper.sh
@@ -5,6 +5,13 @@
 
 WPYTHON_BIN="framework/python/bin/python3"
 
+# Skip OpenSSL runtime CPU feature probing. Some hypervisors (e.g. VMware
+# Fusion on Apple Silicon) advertise SVE in the guest CPU flags without
+# implementing it, so the probe dies with SIGILL when importing cryptography.
+# No effect on non-ARM platforms.
+OPENSSL_armcap=0
+export OPENSSL_armcap
+
 SCRIPT_PATH_NAME="$0"
 
 DIR_NAME="$(cd $(dirname ${SCRIPT_PATH_NAME}); pwd -P)"

--- a/framework/wrappers/generic_wrapper.sh
+++ b/framework/wrappers/generic_wrapper.sh
@@ -5,6 +5,13 @@
 
 WPYTHON_BIN="framework/python/bin/python3"
 
+# Skip OpenSSL runtime CPU feature probing. Some hypervisors (e.g. VMware
+# Fusion on Apple Silicon) advertise SVE in the guest CPU flags without
+# implementing it, so the probe dies with SIGILL when importing cryptography.
+# No effect on non-ARM platforms.
+OPENSSL_armcap=0
+export OPENSSL_armcap
+
 SCRIPT_PATH_NAME="$0"
 
 DIR_NAME="$(cd $(dirname ${SCRIPT_PATH_NAME}); pwd -P)"


### PR DESCRIPTION
## Description

Related to #37749. Backport of #37773 to 4.14.8.

The Python dependency update that landed in 4.14 on 2026-07-07 (`76ae32f84f`) bumped cryptography to 48.0.1, which bundles OpenSSL 4. On arm64 guests whose hypervisor advertises SVE without implementing it (VMware Fusion 25.x on Apple Silicon), the SVE probe run at import time crashes `wazuh-apid` and `wazuh-clusterd` with SIGILL. The last GA release (4.14.6) ships cryptography 46.0.7 and is not affected; 4.14.7 (pre-release) and 4.14.8 are.

## Proposed Changes

Set `OPENSSL_armcap=0` in `api/wrappers/generic_wrapper.sh` and `framework/wrappers/generic_wrapper.sh`, so OpenSSL skips runtime CPU feature probing in the embedded Python processes. Clean cherry-pick of the 5.0.0 commit; rationale for the wrapper placement over the systemd unit is in #37773.

### Results and Evidence

The published `wazuh-manager_4.14.7-1_arm64.deb` (pre-release) bundles the affected code:

```
$ nm _rust.abi3.so | grep -i sve
00000000004cdf18 t _armv8_sve_get_vl_bytes
...
```

Reproduction and fix verification on a VMware Fusion arm64 Ubuntu 24.04 guest, using that exact `_rust.abi3.so` extracted from the deb, with an `LD_PRELOAD` shim that adds the SVE/SVE2 bits to `getauxval()` (the interface Fusion 25.x misreports; the local Fusion 13.6.4 does not expose the bogus flags by itself):

```
=== UNPATCHED wrappers (origin/4.14.8) + spoofed SVE hwcaps
apid exit=132
Illegal instruction (core dumped)
Illegal instruction (core dumped)
clusterd exit=132

=== PATCHED wrappers (4.14.8 backport) + spoofed SVE hwcaps
wazuh_apid.py: cryptography 48.0.1 native bindings loaded, args=['-t']
apid exit=0
wazuh_clusterd.py: cryptography 48.0.1 native bindings loaded, args=['-V']
clusterd exit=0
```

The crash site is the same one reported in #37749 (`cntb` in `_armv8_sve_get_vl_bytes`, called from `OPENSSL_cpuid_setup`); full gdb trace in #37773.

Not verified on a genuine Fusion 25.x host; none is available here.

### Artifacts Affected

- Manager packages (DEB, RPM): `bin/wazuh-apid`, `bin/wazuh-clusterd` and the framework CLI tools are installed from these wrappers.

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

N/A

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
