### PR TITLE
Make sure dbs are fully closed before stop() returns (sca, syscollector, agent-info)

### DIFF
--- a/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
@@ -367,6 +367,16 @@ class AgentInfoImpl
         /// @brief Mutex for synchronizing access to m_dBSync (prevents race conditions during cleanup/transactions)
         std::mutex m_dbSyncMutex;
 
+        /// @brief Serializes destruction of m_spSyncProtocol in stop()
+        std::mutex m_syncProtocolMutex;
+
+        /// @brief Clean-stop handshake: stop() blocks until the run loop (start()) has
+        /// exited, so the sync-protocol connection can be closed with no other thread
+        /// using it.
+        std::mutex m_shutdownMutex;
+        std::condition_variable m_shutdownCv;
+        bool m_runLoopActive = false;
+
         /// @brief Flag set during updateChanges callback when cluster_name changed
         bool m_clusterNameChanged = false;
 };

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -295,13 +295,21 @@ void AgentInfoImpl::stop()
     // Wait for the run loop to exit before freeing shared resources, so we don't
     // free m_dBSync / the sync protocol while synchronizeMetadataOrGroups() is
     // still using them. Time-bounded so a stuck loop can't hang shutdown.
+    constexpr auto SHUTDOWN_WAIT_SECONDS = std::chrono::seconds(10);  // max wait for the run loop to finish teardown
+    bool runLoopExited = false;
     {
         std::unique_lock<std::mutex> lock(m_shutdownMutex);
+        runLoopExited = m_shutdownCv.wait_for(lock, SHUTDOWN_WAIT_SECONDS, [this] { return !m_runLoopActive; });
+    }
 
-        if (!m_shutdownCv.wait_for(lock, std::chrono::seconds(10), [this] { return !m_runLoopActive; }))
-        {
-            m_logFunction(LOG_WARNING, "Timeout waiting for AgentInfo run loop to exit.");
-        }
+    if (!runLoopExited)
+    {
+        // The run loop is still active. Freeing m_dBSync / the sync protocol now
+        // would be a use-after-free (the loop can still call synchronizeMetadataOrGroups()),
+        // so skip the teardown and let process exit reclaim the handles instead.
+        m_logFunction(LOG_WARNING, "Timeout waiting for AgentInfo run loop to exit; skipping database teardown.");
+        m_logFunction(LOG_INFO, "AgentInfo module stopped.");
+        return;
     }
 
     // Close the main DB connection.

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -165,6 +165,11 @@ void AgentInfoImpl::start(int interval, int integrityInterval, std::function<boo
                   "AgentInfo module started with interval: " + std::to_string(interval) +
                   " seconds, integrity interval: " + std::to_string(integrityInterval) + " seconds.");
 
+    {
+        std::lock_guard<std::mutex> lock(m_shutdownMutex);
+        m_runLoopActive = true;
+    }
+
     // Load sync flags from database at startup
     loadSyncFlags();
 
@@ -252,6 +257,14 @@ void AgentInfoImpl::start(int interval, int integrityInterval, std::function<boo
     while (!m_stopped && (shouldContinue ? shouldContinue() : true));
 
     m_logFunction(LOG_INFO, "AgentInfo module loop ended.");
+
+    // Publish that the run loop has fully exited so stop() can tear down the sync
+    // protocol without racing synchronizeMetadataOrGroups().
+    {
+        std::lock_guard<std::mutex> shutdownLock(m_shutdownMutex);
+        m_runLoopActive = false;
+    }
+    m_shutdownCv.notify_all();
 }
 
 void AgentInfoImpl::stop()
@@ -269,6 +282,29 @@ void AgentInfoImpl::stop()
 
     m_cv.notify_one(); // Wake up the sleeping thread immediately
 
+    // Unblock any in-flight synchronizeModule() so the run loop returns promptly.
+    {
+        std::lock_guard<std::mutex> lock(m_syncProtocolMutex);
+
+        if (m_spSyncProtocol)
+        {
+            m_spSyncProtocol->stop();
+        }
+    }
+
+    // Wait for the run loop to exit before freeing shared resources, so we don't
+    // free m_dBSync / the sync protocol while synchronizeMetadataOrGroups() is
+    // still using them. Time-bounded so a stuck loop can't hang shutdown.
+    {
+        std::unique_lock<std::mutex> lock(m_shutdownMutex);
+
+        if (!m_shutdownCv.wait_for(lock, std::chrono::seconds(10), [this] { return !m_runLoopActive; }))
+        {
+            m_logFunction(LOG_WARNING, "Timeout waiting for AgentInfo run loop to exit.");
+        }
+    }
+
+    // Close the main DB connection.
     {
         std::lock_guard<std::mutex> dbLock(m_dbSyncMutex);
 
@@ -280,11 +316,12 @@ void AgentInfoImpl::stop()
         }
     }
 
-    // Signal sync protocol to stop any ongoing operations AFTER DBSync is cleaned up
-    // This ensures no new sync operations are started from DBSync callbacks
-    if (m_spSyncProtocol)
+    // Destroy the sync protocol so its SQLite connection to the persistent-queue
+    // db is closed BEFORE stop() returns. Guarded against parseResponseBuffer(),
+    // which runs on another thread.
     {
-        m_spSyncProtocol->stop();
+        std::lock_guard<std::mutex> lock(m_syncProtocolMutex);
+        m_spSyncProtocol.reset();
     }
 
     m_logFunction(LOG_INFO, "AgentInfo module stopped.");
@@ -338,12 +375,16 @@ void AgentInfoImpl::setIsShuttingDownFunction(std::function<bool()> isShuttingDo
 
 bool AgentInfoImpl::parseResponseBuffer(const uint8_t* data, size_t length)
 {
+    std::lock_guard<std::mutex> lock(m_syncProtocolMutex);
+
     if (m_spSyncProtocol && data)
     {
         return m_spSyncProtocol->parseResponseBuffer(data, length);
     }
 
-    m_logFunction(LOG_WARNING, "Sync protocol not initialized or invalid data");
+    // A late manager response can arrive after stop() has torn the sync protocol
+    // down; that is expected during shutdown, so don't raise it to WARNING then.
+    m_logFunction(m_stopped ? LOG_DEBUG : LOG_WARNING, "Sync protocol not initialized or invalid data");
     return false;
 }
 

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_basic_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_basic_test.cpp
@@ -347,12 +347,26 @@ TEST_F(AgentInfoImplTest, StopWaitsForRunLoopToExit)
 
 // After stop() tears down the sync protocol, the asynchronous MQ response path
 // (parseResponseBuffer, called on the dispatch thread) must fail gracefully
-// instead of dereferencing a freed sync protocol.
+// instead of dereferencing the freed sync protocol.
 TEST_F(AgentInfoImplTest, ParseResponseBufferAfterStopIsSafe)
 {
-    m_agentInfo->stop();
+    // Initialize a real (in-memory, no DB file) sync protocol so that stop()
+    // genuinely destroys it and the call below exercises the m_syncProtocolMutex
+    // guard, not the trivial "was never initialized" path.
+    const MQ_Functions mqFuncs
+    {
+        [](const char*, short, short) -> int { return 0; },
+        [](int, const void*, size_t, const char*, char) -> int { return 0; }
+    };
+    m_agentInfo->initSyncProtocol("agent_info", mqFuncs);
 
     const uint8_t data[] = {0x01, 0x02, 0x03};
+
+    // stop() destroys the sync protocol under m_syncProtocolMutex.
+    m_agentInfo->stop();
+
+    // The now-torn-down protocol must be rejected safely (no use-after-free).
+    clearLogOutput();
     EXPECT_FALSE(m_agentInfo->parseResponseBuffer(data, sizeof(data)));
     EXPECT_THAT(getLogOutput(), ::testing::HasSubstr("Sync protocol not initialized"));
 }

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_basic_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_basic_test.cpp
@@ -290,3 +290,69 @@ TEST_F(AgentInfoImplTest, ConstructorThrowsWhenQueryModuleFunctionIsNull)
     },
     std::invalid_argument);
 }
+
+// Regression test for the clean-stop ordering fix (issues #37629 / #37714).
+//
+// stop() must not return until the run loop has exited, so that shared resources
+// (the main DBSync connection and the sync-protocol SQLite connection) are only
+// torn down once no other thread is using them.
+//
+// The run loop calls ISysInfo::os() near the top of populateAgentMetadata(). We
+// hold it there for a fixed window so the loop is provably still active when
+// stop() is called: stop() blocks for that window; before it, stop()
+// returned immediately.
+TEST_F(AgentInfoImplTest, StopWaitsForRunLoopToExit)
+{
+    constexpr auto HOLD = std::chrono::milliseconds(300);
+
+    auto mockSysInfo = std::make_shared<MockSysInfo>();
+    std::atomic<bool> loopInBody{false};
+
+    EXPECT_CALL(*mockSysInfo, os())
+    .WillRepeatedly(::testing::Invoke([&]() -> nlohmann::json
+    {
+        loopInBody.store(true, std::memory_order_release);
+        std::this_thread::sleep_for(HOLD);
+        return nlohmann::json::object();
+    }));
+
+    auto agentInfo =
+        std::make_shared<AgentInfoImpl>("test_path", nullptr, m_logFunction, m_queryModuleFunction, m_mockDBSync, mockSysInfo);
+
+    // start() blocks until stopped, so it runs on its own thread. It has a fixed
+    // 5s initial delay before the first iteration.
+    std::thread loopThread([&]()
+    {
+        agentInfo->start(3600, 86400, []()
+        {
+            return true;
+        });
+    });
+
+    while (!loopInBody.load(std::memory_order_acquire))
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    const auto start = std::chrono::steady_clock::now();
+    agentInfo->stop();
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    // AFTER the fix stop() blocks until the in-flight run-loop iteration finishes;
+    // BEFORE the fix it returned immediately (< 1 ms).
+    EXPECT_GE(elapsed, HOLD / 2) << "stop() returned before the run loop had exited";
+
+    loopThread.join();
+}
+
+// After stop() tears down the sync protocol, the asynchronous MQ response path
+// (parseResponseBuffer, called on the dispatch thread) must fail gracefully
+// instead of dereferencing a freed sync protocol.
+TEST_F(AgentInfoImplTest, ParseResponseBufferAfterStopIsSafe)
+{
+    m_agentInfo->stop();
+
+    const uint8_t data[] = {0x01, 0x02, 0x03};
+    EXPECT_FALSE(m_agentInfo->parseResponseBuffer(data, sizeof(data)));
+    EXPECT_THAT(getLogOutput(), ::testing::HasSubstr("Sync protocol not initialized"));
+}

--- a/src/wazuh_modules/src/wm_sca.c
+++ b/src/wazuh_modules/src/wm_sca.c
@@ -98,6 +98,7 @@ static void * wm_sca_sync_module(__attribute__((unused)) void * args);
 static void wm_sca_destroy(wm_sca_t * data);  // Destroy data
 static int wm_sca_start(wm_sca_t * data);  // Start
 static void wm_sca_stop(wm_sca_t* data);   // Stop
+static void wm_sca_release_and_signal(void);  // Release resources and wake wm_sca_stop()
 
 cJSON *wm_sca_dump(const wm_sca_t * data);     // Read config
 
@@ -607,6 +608,13 @@ void * wm_sca_main(wm_sca_t * data) {
     data->commands_timeout = getDefine_Int_default("sca", "commands_timeout", 1, 300, 30);
     data->remote_commands = getDefine_Int_default("sca", "remote_commands", 0, 1, 0);
 
+    // Arm the shutdown wait before sca_init() opens the databases, so that a
+    // concurrent wm_sca_stop() blocks until they are released on every exit path
+    // below (not only the normal wm_sca_start() teardown).
+    w_mutex_lock(&sca_stop_mutex);
+    sca_need_shutdown_wait = true;
+    w_mutex_unlock(&sca_stop_mutex);
+
     if (sca_init_ptr) {
         sca_init_ptr();
     }
@@ -626,6 +634,10 @@ void * wm_sca_main(wm_sca_t * data) {
 
         if (wm_sca_is_shutting_down())
         {
+            // sca_init() already opened the databases; release them and wake any
+            // waiting wm_sca_stop() before returning, so the next process does not
+            // find them locked.
+            wm_sca_release_and_signal();
 #ifdef WIN32
             return 0;
 #else
@@ -637,9 +649,6 @@ void * wm_sca_main(wm_sca_t * data) {
     }
 
     mdebug1("Starting module.");
-    w_mutex_lock(&sca_stop_mutex);
-    sca_need_shutdown_wait = true;
-    w_mutex_unlock(&sca_stop_mutex);
     wm_sca_start(data);
 
 #ifdef WIN32
@@ -649,20 +658,32 @@ void * wm_sca_main(wm_sca_t * data) {
 #endif
 }
 
+// Release SCA resources and wake any wm_sca_stop() blocked on the shutdown
+// condition.
+static void wm_sca_release_and_signal(void)
+{
+    w_mutex_lock(&sca_stop_mutex);
+    sca_need_shutdown_wait = false;
+    sca_main_thread_initialized = false;
+    if (sca_release_resources_ptr)
+    {
+        sca_release_resources_ptr();
+        sca_release_resources_ptr = NULL;
+    }
+    w_cond_signal(&sca_stop_condition);
+    w_mutex_unlock(&sca_stop_mutex);
+}
+
 static int wm_sca_start(wm_sca_t *sca) {
     // Initialize message queue
     g_sca_queue = StartMQPredicated(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS, wm_sca_is_shutting_down);
     if (g_sca_queue < 0) {
         merror("Cannot initialize SCA message queue.");
-        // StartMQPredicated only gives up when shutdown started mid-startup, so a
-        // wm_sca_stop() is already waiting on the condition. Clear the flag and
-        // signal it here (there are no resources to release yet) instead of leaving
-        // it to block for the full timeout.
-        w_mutex_lock(&sca_stop_mutex);
-        sca_need_shutdown_wait = false;
-        sca_main_thread_initialized = false;
-        w_cond_signal(&sca_stop_condition);
-        w_mutex_unlock(&sca_stop_mutex);
+        // sca_init() already opened the databases, and StartMQPredicated only
+        // gives up when shutdown started mid-startup (a wm_sca_stop() is already
+        // waiting). Release the connections and signal, instead of leaking them
+        // and blocking the waiter for the full timeout.
+        wm_sca_release_and_signal();
         return -1;
     }
 
@@ -729,18 +750,9 @@ static int wm_sca_start(wm_sca_t *sca) {
     }
 #endif
 
-    w_mutex_lock(&sca_stop_mutex);
-    sca_need_shutdown_wait = false;
-    sca_main_thread_initialized = false;
     // Safe to release resources now that both the sync worker and the main SCA
     // run loop have exited.  m_dBSync is no longer referenced by any thread.
-    if (sca_release_resources_ptr)
-    {
-        sca_release_resources_ptr();
-        sca_release_resources_ptr = NULL;
-    }
-    w_cond_signal(&sca_stop_condition);
-    w_mutex_unlock(&sca_stop_mutex);
+    wm_sca_release_and_signal();
 
     return 0;
 }

--- a/src/wazuh_modules/src/wm_sca.c
+++ b/src/wazuh_modules/src/wm_sca.c
@@ -44,6 +44,13 @@ static HANDLE sca_sync_worker_thread = NULL;
 #endif
 static bool sca_sync_worker_thread_initialized = false;
 
+// Clean stop mechanism variables
+static pthread_cond_t sca_stop_condition = PTHREAD_COND_INITIALIZER;
+static pthread_mutex_t sca_stop_mutex = PTHREAD_MUTEX_INITIALIZER;
+static bool sca_need_shutdown_wait = false;
+static pthread_t sca_main_thread;
+static bool sca_main_thread_initialized = false;
+
 // SCA message queue variables
 static int g_shutting_down = 0;
 static int g_sca_queue = 0;
@@ -518,6 +525,11 @@ DWORD WINAPI wm_sca_main(void *arg) {
 #else
 void * wm_sca_main(wm_sca_t * data) {
 #endif
+    w_mutex_lock(&sca_stop_mutex);
+    sca_main_thread = pthread_self();
+    sca_main_thread_initialized = true;
+    w_mutex_unlock(&sca_stop_mutex);
+
     // If module is disabled, exit
     if (data->enabled) {
         mdebug1("Module enabled.");
@@ -625,7 +637,9 @@ void * wm_sca_main(wm_sca_t * data) {
     }
 
     mdebug1("Starting module.");
-
+    w_mutex_lock(&sca_stop_mutex);
+    sca_need_shutdown_wait = true;
+    w_mutex_unlock(&sca_stop_mutex);
     wm_sca_start(data);
 
 #ifdef WIN32
@@ -706,6 +720,9 @@ static int wm_sca_start(wm_sca_t *sca) {
     }
 #endif
 
+    w_mutex_lock(&sca_stop_mutex);
+    sca_need_shutdown_wait = false;
+    sca_main_thread_initialized = false;
     // Safe to release resources now that both the sync worker and the main SCA
     // run loop have exited.  m_dBSync is no longer referenced by any thread.
     if (sca_release_resources_ptr)
@@ -713,6 +730,8 @@ static int wm_sca_start(wm_sca_t *sca) {
         sca_release_resources_ptr();
         sca_release_resources_ptr = NULL;
     }
+    w_cond_signal(&sca_stop_condition);
+    w_mutex_unlock(&sca_stop_mutex);
 
     return 0;
 }
@@ -730,13 +749,41 @@ void wm_sca_stop(__attribute__((unused)) wm_sca_t* data)
     g_shutting_down = 1;
     sca_sync_module_running = 0;
 
-    // Quiesce the sync protocol and the main SCA loop.  Resource teardown
-    // (join + releaseResources) is deferred to wm_sca_start() after
-    // sca_start_ptr() returns, so that we do not free m_dBSync while the
-    // SCA run loop is still using it.
+    // Quiesce the sync protocol and the main SCA loop, then block until
+    // wm_sca_start()'s teardown (join + releaseResources(), deferred until
+    // after sca_start_ptr() returns so we don't free m_dBSync while the SCA
+    // run loop is still using it) has actually finished, so the caller can't
+    // observe "stopped" before the sync-protocol SQLite connection is closed.
+
     if (sca_stop_ptr) {
         sca_stop_ptr();
     }
+
+    w_mutex_lock(&sca_stop_mutex);
+    const bool called_from_sca_main_thread = sca_main_thread_initialized && pthread_equal(pthread_self(), sca_main_thread);
+
+    if (called_from_sca_main_thread)
+    {
+        mdebug1("Stop called from SCA worker thread. Skipping synchronous shutdown wait.");
+    }
+
+    if (sca_need_shutdown_wait && !called_from_sca_main_thread)
+    {
+        struct timespec ts;
+        clock_gettime(CLOCK_REALTIME, &ts);
+        ts.tv_sec += 10;
+
+        while (sca_need_shutdown_wait)
+        {
+            if (pthread_cond_timedwait(&sca_stop_condition, &sca_stop_mutex, &ts) == ETIMEDOUT)
+            {
+                mwarn("Timeout waiting for SCA to complete shutdown.");
+                break;
+            }
+        }
+    }
+
+    w_mutex_unlock(&sca_stop_mutex);
 }
 
 cJSON *wm_sca_dump(const wm_sca_t * data) {

--- a/src/wazuh_modules/src/wm_sca.c
+++ b/src/wazuh_modules/src/wm_sca.c
@@ -654,6 +654,15 @@ static int wm_sca_start(wm_sca_t *sca) {
     g_sca_queue = StartMQPredicated(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS, wm_sca_is_shutting_down);
     if (g_sca_queue < 0) {
         merror("Cannot initialize SCA message queue.");
+        // StartMQPredicated only gives up when shutdown started mid-startup, so a
+        // wm_sca_stop() is already waiting on the condition. Clear the flag and
+        // signal it here (there are no resources to release yet) instead of leaving
+        // it to block for the full timeout.
+        w_mutex_lock(&sca_stop_mutex);
+        sca_need_shutdown_wait = false;
+        sca_main_thread_initialized = false;
+        w_cond_signal(&sca_stop_condition);
+        w_mutex_unlock(&sca_stop_mutex);
         return -1;
     }
 
@@ -769,9 +778,10 @@ void wm_sca_stop(__attribute__((unused)) wm_sca_t* data)
 
     if (sca_need_shutdown_wait && !called_from_sca_main_thread)
     {
+        const time_t SHUTDOWN_WAIT_SECONDS = 10;  // max wait for the run loop to finish teardown
         struct timespec ts;
         clock_gettime(CLOCK_REALTIME, &ts);
-        ts.tv_sec += 10;
+        ts.tv_sec += SHUTDOWN_WAIT_SECONDS;
 
         while (sca_need_shutdown_wait)
         {

--- a/src/wazuh_modules/src/wm_syscollector.c
+++ b/src/wazuh_modules/src/wm_syscollector.c
@@ -835,9 +835,10 @@ void wm_sys_stop(__attribute__((unused))wm_sys_t* data)
 
     if (need_shutdown_wait && !called_from_sys_main_thread)
     {
+        const time_t SHUTDOWN_WAIT_SECONDS = 10;  // max wait for the run loop to finish teardown
         struct timespec ts;
         clock_gettime(CLOCK_REALTIME, &ts);
-        ts.tv_sec += 10;
+        ts.tv_sec += SHUTDOWN_WAIT_SECONDS;
 
         while (need_shutdown_wait)
         {

--- a/src/wazuh_modules/src/wm_syscollector.c
+++ b/src/wazuh_modules/src/wm_syscollector.c
@@ -48,9 +48,9 @@ static void wm_sys_stop(wm_sys_t* sys);         // Module stopper
 const char* WM_SYS_LOCATION = "syscollector";   // Location field for event sending
 cJSON* wm_sys_dump(const wm_sys_t* sys);
 int wm_sync_message(const char* command, size_t command_len);
-pthread_cond_t sys_stop_condition = PTHREAD_COND_INITIALIZER;
-pthread_mutex_t sys_stop_mutex = PTHREAD_MUTEX_INITIALIZER;
-bool need_shutdown_wait = false;
+static pthread_cond_t sys_stop_condition = PTHREAD_COND_INITIALIZER;
+static pthread_mutex_t sys_stop_mutex = PTHREAD_MUTEX_INITIALIZER;
+static bool need_shutdown_wait = false;
 static pthread_t sys_main_thread;
 static bool sys_main_thread_initialized = false;
 #ifndef WIN32
@@ -787,15 +787,14 @@ void* wm_sys_main(wm_sys_t* sys)
     w_mutex_lock(&sys_stop_mutex);
     need_shutdown_wait = false;
     sys_main_thread_initialized = false;
-    w_cond_signal(&sys_stop_condition);
-    w_mutex_unlock(&sys_stop_mutex);
-
     // Safe to release resources now that the sync worker has exited.
     if (syscollector_release_resources_ptr)
     {
         syscollector_release_resources_ptr();
         syscollector_release_resources_ptr = NULL;
     }
+    w_cond_signal(&sys_stop_condition);
+    w_mutex_unlock(&sys_stop_mutex);
 
     return 0;
 }


### PR DESCRIPTION
## Description

On Windows the agent runs all its modules as threads inside a single process (`wazuh-agent.exe`). During shutdown the service could report itself stopped — and the process could exit and a new one start (agent upgrade/restart),before a module had actually finished closing its synchronization database. The next process then failed to open the database.

This surfaced as `database is locked` / `Failed to initialize persistent queue` errors after a restart, intermittently and only on Windows.

Closes #37629 #37742
Related: #37714 (same root cause, observed as leftover locked DB files on uninstall)

## Proposed Changes

The SCA, Syscollector and Agent-info modules now block their stop path until their database resources have actually been released, so a module is only considered stopped once its SQLite connections are closed. Previously the stop call could return while a module's synchronization database was still open, leaving it locked for the next process.

### Results and Evidence

Reproduced on a Windows Server 2025 agent, simulating long db close times by adding delays in the code and performing the scenario where the issue arose in the original report: Stopping the agent, de-registering it, removing `client.keys` and re-registering it with a DNS name instead of the IP address.  Before the fix, the incoming process reported the databases as locked:

```sql
2026/07/17 18:43:32 wazuh-modulesd:syscollector: ERROR: sqlite: COMMIT TRANSACTION. database is locked
2026/07/17 18:43:32 wazuh-modulesd:syscollector: ERROR: sqlite: COMMIT TRANSACTION. database is locked
2026/07/17 18:43:32 wazuh-modulesd:syscollector: ERROR: sqlite: COMMIT TRANSACTION. database is locked

2026/07/17 18:43:47 wazuh-modulesd:sca: ERROR: Error setting version: sqlite: COMMIT TRANSACTION. cannot commit transaction - SQL statements in progress
2026/07/17 18:43:48 wazuh-modulesd:sca: ERROR: Error setting version: sqlite: COMMIT TRANSACTION. cannot commit transaction - SQL statements in progress
2026/07/17 18:43:49 wazuh-modulesd:sca: ERROR: Error setting version: sqlite: COMMIT TRANSACTION. cannot commit transaction - SQL statements in progress
```

After the fix, the same stop/start cycles no longer produce these errors for SCA and Syscollector, and each module re-initializes its database cleanly on the next start.

Agent-info has the same shutdown-ordering gap, but it did not reproduce in the original issue's scenarios. Rather than force a manual reproduction, its fix is covered by a unit test that verifies the stop path blocks until the module's run loop has fully torn down.

### Artifacts Affected

- Wazuh agent (Windows) — SCA, Syscollector and Agent-info modules.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

- Unit test for Agent-info verifying that `stop()` does not return until the module's run loop has exited (and its database resources are released).
- SCA and Syscollector shutdown behavior was validated through the manual Windows stop/start reproduction described above; the shared clean-stop pattern is additionally exercised end-to-end by the Windows agent upgrade QA system test.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
