### PR TITLE
Fix flaky Windows syscollector test

### DIFF
--- a/src/os_execd/src/execd.c
+++ b/src/os_execd/src/execd.c
@@ -18,6 +18,7 @@
 #include "active_responses.h"
 #include "startup_gate_op.h"
 
+
 #ifdef WAZUH_UNIT_TESTING
 // Remove static qualifier when unit testing
 #define STATIC

--- a/src/os_execd/src/execd.c
+++ b/src/os_execd/src/execd.c
@@ -18,7 +18,6 @@
 #include "active_responses.h"
 #include "startup_gate_op.h"
 
-
 #ifdef WAZUH_UNIT_TESTING
 // Remove static qualifier when unit testing
 #define STATIC

--- a/tests/integration/test_syscollector/conftest.py
+++ b/tests/integration/test_syscollector/conftest.py
@@ -8,6 +8,7 @@ import sys
 import subprocess
 import os
 import sqlite3
+import time
 from pathlib import Path
 
 from wazuh_testing.tools.monitors import file_monitor
@@ -457,6 +458,17 @@ def custom_daemons_handler(request: pytest.FixtureRequest) -> None:
         if not ignore_errors:
             raise called_process_error
 
+    # `control_service('stop')` only waits for the OS to acknowledge the stop request
+    # (e.g. Windows SCM confirming "net stop"), not for the process to have actually
+    # exited and released its handles. `populate_syscollector_db()` below opens the same
+    # local.db the daemon was just using, and the restart further down can then race a
+    # still-shutting-down previous process for that file and for the sync protocol's
+    # persistent queue/socket. Wait for the process to actually be gone first.
+    try:
+        services.wait_expected_daemon_status(running_condition=False, timeout=30)
+    except TimeoutError as timeout_error:
+        logger.warning(str(timeout_error))
+
     # Ensures at least one entry in each syscollector table
     populate_syscollector_db()
 
@@ -477,6 +489,17 @@ def custom_daemons_handler(request: pytest.FixtureRequest) -> None:
         logger.error(f"{str(called_process_error)}")
         if not ignore_errors:
             raise called_process_error
+
+    # Same rationale as the fix already applied to the generic `daemons_handler_implementation`
+    # (tests/integration/conftest.py): on a restart the service can report running before the
+    # logger has (re)created ossec.log, and monitors built right after this fixture require the
+    # file to exist. Wait for it instead of racing the first log write.
+    for _ in range(30):
+        if os.path.isfile(WAZUH_LOG_PATH):
+            break
+        time.sleep(1)
+    else:
+        logger.warning(f"{WAZUH_LOG_PATH} was not created after starting the daemons")
 
     yield
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Closes [#37515](https://github.com/wazuh/wazuh/issues/37515)

`test_syscollector_collectors_disabled` (`tests/integration/test_syscollector/test_configuration/test_syscollector_configuration.py`) fails intermittently on Windows CI waiting on the "DataClean notification should be started for disabled collectors with data" assertion. A prior fix ([`bfbd5a77e0`](https://github.com/wazuh/wazuh/commit/bfbd5a77e0194da50b9628c55fcbee081287cd37)) bumped that monitor's timeout from 60s to 180s, but the failures continued.

Across 6 recent Windows CI runs, the failure pattern was not random: the 1st and 3rd of the test's 4 parametrized cases (`packages_disabled`, `network_disabled`) failed in 6/6 and 5/6 runs respectively, while the 2nd and 4th (`packages_processes_disabled`, `all_collectors_disabled`) passed every time — a position-dependent signature pointing at the daemon restart cycle between consecutive cases, not a per-collector bug. In `syscollectorImp.cpp`, the log line the test waits for is emitted unconditionally on the very first retry attempt, so a longer timeout could never have helped if the module never got that far.

`custom_daemons_handler` (`tests/integration/test_syscollector/conftest.py`), used only by this test, stops the agent, immediately reopens the same `local.db` the daemon was just using (`populate_syscollector_db()`), and immediately restarts it — with no readiness wait anywhere in that cycle. This differs from the generic `daemons_handler` fixture (`tests/integration/conftest.py`), which already waits for `ossec.log` to reappear after a restart (fix [`8b2c802c1d`](https://github.com/wazuh/wazuh/commit/8b2c802c1d1e1776ee5c6c16284bc9f0fffd2574), already merged into `5.0.0` — this closes the other flaky symptom originally reported in [#37515](https://github.com/wazuh/wazuh/issues/37515), the `test_syscollector_deactivation` / "ossec.log does not exist" failure). `custom_daemons_handler` never received the equivalent treatment.

On Windows, `control_service('stop')` only waits for `net stop` to be acknowledged by the SCM, not for the process to actually exit and release its handles, so the immediately-following DB write and restart can race a still-shutting-down previous process.

## Proposed Changes

- `tests/integration/test_syscollector/conftest.py` (`custom_daemons_handler`):
  - After stopping the daemon, wait for the process to actually be gone (`services.wait_expected_daemon_status(running_condition=False, timeout=30)`) before touching `local.db` and restarting.
  - After starting the daemon, wait up to 30s for `ossec.log` to reappear before yielding to the test, mirroring the fix already proven in the generic `daemons_handler` fixture.
- `src/os_execd/src/execd.c`: a single blank-line, no-op edit included only to get `src/**` paths to trigger the Windows build/IT pipeline on this PR for verification. **Not a functional change — should be dropped before merge.**

### Results and Evidence

Historical evidence (6 Windows CI runs, `2026-07-17` to `2026-07-20`, all on `test_syscollector_collectors_disabled`):

| Run | `packages_disabled` | `packages_processes_disabled` | `network_disabled` | `all_collectors_disabled` |
|---|---|---|---|---|
| [88464568951](https://github.com/wazuh/wazuh/actions/runs/29770352816/job/88464568951) | FAIL | pass | FAIL | pass |
| [88443074364](https://github.com/wazuh/wazuh/actions/runs/29767725202/job/88443074364) | FAIL | pass | FAIL | pass |
| [88424688022](https://github.com/wazuh/wazuh/actions/runs/29762605572/job/88424688022) | FAIL | pass | FAIL | pass |
| [88405476020](https://github.com/wazuh/wazuh/actions/runs/29756613093/job/88405476020) | FAIL | pass | pass | pass |
| [88388451522](https://github.com/wazuh/wazuh/actions/runs/29751674063/job/88388451522) | FAIL | pass | FAIL | pass |
| [88351905812](https://github.com/wazuh/wazuh/actions/runs/29628719982/job/88351905812) | FAIL | pass | FAIL | pass |

Successful runs after applying this fix:
- https://github.com/wazuh/wazuh/actions/runs/29854951563/job/88716844341
- https://github.com/wazuh/wazuh/actions/runs/29857168587/job/88729049061

### Artifacts Affected

- Test-only change: `wazuh-agent` integration test suite (Windows and Linux, `custom_daemons_handler` is platform-agnostic). No production agent or manager binaries affected.
- The `src/os_execd/src/execd.c` edit is a no-op (blank line) and does not affect the `execd` binary's behavior; it will be reverted before merge.

### Configuration Changes

N/A

### Tests Introduced

No new tests. Hardens the existing `custom_daemons_handler` fixture used by `test_syscollector_collectors_disabled` so its daemon-restart cycle doesn't race itself between parametrized cases.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
