### PR TITLE
Fix AWS discard_regex values containing spaces

### DIFF
--- a/src/unit_tests/wazuh_modules/aws/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/aws/CMakeLists.txt
@@ -9,7 +9,7 @@
 list(APPEND tests_names "test_wm_aws")
 list(APPEND tests_flags "-Wl,--wrap=time,--wrap=w_time_delay,--wrap=w_sleep_until,--wrap=_mwarn,--wrap=_minfo,--wrap=_merror \
                          -Wl,--wrap=_mtwarn,--wrap=_mtinfo,--wrap=_mterror,--wrap=wm_aws_run_s3,--wrap=StartMQ,--wrap=FOREVER,--wrap=wm_sleep_until_interruptible \
-                         -Wl,--wrap=atexit -Wl,--wrap=wm_state_io -Wl,--wrap=w_query_agentd")
+                         -Wl,--wrap=atexit -Wl,--wrap=wm_state_io -Wl,--wrap=wm_exec -Wl,--wrap=w_query_agentd")
 list(APPEND use_shared_libs 1)
 
 list(APPEND shared_libs "../scheduling/wmodules_scheduling_helpers.h")

--- a/src/unit_tests/wazuh_modules/aws/test_wm_aws.c
+++ b/src/unit_tests/wazuh_modules/aws/test_wm_aws.c
@@ -23,6 +23,7 @@
 #include "../../wrappers/libc/stdlib_wrappers.h"
 #include "../../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../../wrappers/wazuh/wazuh_modules/wmodules_wrappers.h"
+#include "../../wrappers/wazuh/wazuh_modules/wm_exec_wrappers.h"
 #include "../../wrappers/wazuh/shared/mq_op_wrappers.h"
 
 #define TEST_MAX_DATES 5
@@ -34,6 +35,7 @@ static OS_XML *lxml;
 extern int test_mode;
 
 extern void wm_aws_run_s3(wm_aws_bucket *bucket);
+extern void wm_aws_run_subscriber(wm_aws *aws_config, wm_aws_subscriber *exec_subscriber);
 
 void wm_aws_run_s3(wm_aws_bucket *exec_bucket) {
     // Will wrap this function to check running times in order to check scheduling
@@ -268,6 +270,34 @@ void test_read_scheduling_interval_configuration(void **state) {
     assert_int_equal(module_data->scan_config.scan_wday, -1);
 }
 
+void test_subscriber_discard_regex_with_spaces(void **state) {
+    wm_aws config = {0};
+    wm_aws_subscriber subscriber = {0};
+
+    config.queue_fd = 1;
+    subscriber.type = "security_hub";
+    subscriber.sqs_name = "security-hub-queue";
+    subscriber.discard_field = "detail-type";
+    subscriber.discard_regex = "Security Hub Insight Results";
+
+    expect_string(__wrap_wm_state_io, tag, "aws-s3");
+    expect_value(__wrap_wm_state_io, op, WM_IO_READ);
+    expect_value(__wrap_wm_state_io, state, &config.state);
+    expect_value(__wrap_wm_state_io, size, sizeof(config.state));
+    will_return(__wrap_wm_state_io, 1);
+
+    expect_wm_exec(
+        "wodles/aws/aws-s3 --subscriber security_hub --queue security-hub-queue --discard-field detail-type --discard-regex \"Security Hub Insight Results\"",
+        0,
+        NULL,
+        "",
+        0,
+        0
+    );
+
+    wm_aws_run_subscriber(&config, &subscriber);
+}
+
 int main(void) {
     const struct CMUnitTest tests_with_startup[] = {
         cmocka_unit_test_setup_teardown(test_interval_execution, setup_test_executions, teardown_test_executions)
@@ -277,7 +307,8 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_read_scheduling_monthday_configuration, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_read_scheduling_weekday_configuration, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_read_scheduling_daytime_configuration, setup_test_read, teardown_test_read),
-        cmocka_unit_test_setup_teardown(test_read_scheduling_interval_configuration, setup_test_read, teardown_test_read)
+        cmocka_unit_test_setup_teardown(test_read_scheduling_interval_configuration, setup_test_read, teardown_test_read),
+        cmocka_unit_test(test_subscriber_discard_regex_with_spaces)
     };
     int result;
     result = cmocka_run_group_tests(tests_with_startup, setup_module, teardown_module);

--- a/src/wazuh_modules/src/wm_aws.c
+++ b/src/wazuh_modules/src/wm_aws.c
@@ -30,6 +30,7 @@ static void wm_aws_check();                             // Check configuration, 
 static void wm_aws_run_s3(wm_aws *aws_config, wm_aws_bucket *bucket);       // Run a s3 bucket
 static void wm_aws_run_service(wm_aws *aws_config, wm_aws_service *service);// Run a AWS service such as Inspector
 static void wm_aws_run_subscriber(wm_aws *aws_config, wm_aws_subscriber *subscriber); //Run an AWS subscriber
+static void wm_aws_append_quoted_argument(char **command, const char *argument);
 cJSON *wm_aws_dump(const wm_aws *aws_config);
 
 // Command module context definition
@@ -365,6 +366,24 @@ void wm_aws_check() {
 
 }
 
+void wm_aws_append_quoted_argument(char **command, const char *argument) {
+    char *quoted_argument = NULL;
+
+    wm_strcat(&quoted_argument, "\"", '\0');
+    for (const char *character = argument; *character; ++character) {
+        if (*character == '\\' || *character == '"') {
+            wm_strcat(&quoted_argument, "\\\\", '\0');
+        }
+
+        char value[] = {*character, '\0'};
+        wm_strcat(&quoted_argument, value, '\0');
+    }
+    wm_strcat(&quoted_argument, "\"", '\0');
+
+    wm_strcat(command, quoted_argument, ' ');
+    os_free(quoted_argument);
+}
+
 // Run a bucket parsing
 #ifdef WAZUH_UNIT_TESTING
 __attribute__((weak))
@@ -451,7 +470,7 @@ void wm_aws_run_s3(wm_aws *aws_config, wm_aws_bucket *exec_bucket) {
     }
     if (exec_bucket->discard_regex) {
         wm_strcat(&command, "--discard-regex", ' ');
-        wm_strcat(&command, exec_bucket->discard_regex, ' ');
+        wm_aws_append_quoted_argument(&command, exec_bucket->discard_regex);
     }
     if (exec_bucket->sts_endpoint) {
         wm_strcat(&command, "--sts_endpoint", ' ');
@@ -622,7 +641,7 @@ void wm_aws_run_service(wm_aws *aws_config, wm_aws_service *exec_service) {
     }
     if (exec_service->discard_regex) {
         wm_strcat(&command, "--discard-regex", ' ');
-        wm_strcat(&command, exec_service->discard_regex, ' ');
+        wm_aws_append_quoted_argument(&command, exec_service->discard_regex);
     }
     if (exec_service->sts_endpoint) {
         wm_strcat(&command, "--sts_endpoint", ' ');
@@ -776,7 +795,7 @@ void wm_aws_run_subscriber(wm_aws *aws_config, wm_aws_subscriber *exec_subscribe
     }
     if (exec_subscriber->discard_regex) {
         wm_strcat(&command, "--discard-regex", ' ');
-        wm_strcat(&command, exec_subscriber->discard_regex, ' ');
+        wm_aws_append_quoted_argument(&command, exec_subscriber->discard_regex);
     }
 
     if (isDebug()) {


### PR DESCRIPTION
## Description

Fixes #37709.

`aws-s3` built the `--discard-regex` value as an unquoted part of its command string. `wm_exec()` tokenizes that string before starting the Python collector, so a valid Security Hub value such as `Security Hub Insight Results` was split into separate arguments and rejected by `argparse`.

## Proposed changes

- Encode `discard_regex` as one quoted argument, escaping embedded double quotes and backslashes for `w_strtok()`.
- Apply the encoding consistently to AWS bucket, service, and subscriber command construction.
- Add a regression test covering the reported Security Hub value containing spaces.

### Results and evidence

The new unit test asserts that the subscriber command contains:

```text
--discard-regex "Security Hub Insight Results"
```

This preserves the supplied value as one token when `wm_exec()` calls `w_strtok()`.

### Manual tests with their corresponding evidence

- [x] `make -j4 TARGET=agent TEST=1` (macOS development environment)
- [x] `git diff --check`
- [ ] Targeted AWS C unit test: `test_wm_aws` (Linux build in progress)
- [ ] Compilation without warnings on every supported platform (maintainer CI)
- [ ] Log syntax and correct language review

### Artifacts affected

- AWS S3 wodle command construction in the Wazuh agent/manager module.

### Configuration changes

None. Existing `discard_regex` configuration values containing spaces, backslashes, or double quotes are passed to the collector without losing token boundaries.

### Tests introduced

Adds a unit test for a Security Hub subscriber whose `detail-type` discard regex is `Security Hub Insight Results`.

## Review checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the regression
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] No unresolved dependencies with other issues
