### PR TITLE
Prevent exiting Wazuh-DB worker when oversized message arrives.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Added destination path validation when deleting rule and decoder files. ([#37838](https://github.com/wazuh/wazuh/pull/37838))
 - Added source path validation when retrieving CDB list files. ([#37901](https://github.com/wazuh/wazuh/pull/37901))
 - Fixed the `aws-s3` wodle failing to parse configuration values that contain spaces, such as `discard_regex`, `discard_field`, `aws_profile`, `aws_account_alias`, `path` and `path_suffix`. ([#37929](https://github.com/wazuh/wazuh/pull/37929))
+- Fixed wazuh-db exiting the worker thread instead of closing the peer socket when an oversized message is received. ([#37850](https://github.com/wazuh/wazuh/pull/37850))
 
 ### Agent
 

--- a/src/wazuh_db/main.c
+++ b/src/wazuh_db/main.c
@@ -413,7 +413,8 @@ void * run_worker(__attribute__((unused)) void * args) {
         if(count == OS_SOCKTERR){
             mwarn("at run_worker(): received string size is bigger than %d bytes",
                     OS_MAXSTR);
-            break;
+            close(peer);
+            continue;
         }
         length+=count;
 

--- a/tests/integration/test_wazuh_db/test_databases/test_wazuh_db_oversized_message.py
+++ b/tests/integration/test_wazuh_db/test_databases/test_wazuh_db_oversized_message.py
@@ -1,0 +1,82 @@
+'''
+copyright: Copyright (C) 2015-2024, Wazuh Inc.
+
+           Created by Wazuh, Inc. <info@wazuh.com>.
+
+           This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+type: integration
+
+brief: Wazuh-db is the daemon in charge of the databases with all the Wazuh persistent information, exposing a
+       socket to receive requests and provide information. When a client sends a message bigger than the maximum
+       allowed size (OS_MAXSTR, 65536 bytes), wazuh-db must close that connection instead of leaving it open and
+       unanswered, otherwise the client is left waiting forever for a response that will never arrive.
+
+components:
+    - wazuh_db
+
+targets:
+    - manager
+
+daemons:
+    - wazuh-db
+
+os_platform:
+    - linux
+
+references:
+    - https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-db.html
+
+tags:
+    - wazuh_db
+'''
+import socket
+import pytest
+
+from wazuh_testing.constants.paths.sockets import WAZUH_DB_SOCKET_PATH
+
+# Marks
+pytestmark = [pytest.mark.server, pytest.mark.tier(level=0)]
+
+# Variables
+receiver_sockets_params = [(WAZUH_DB_SOCKET_PATH, 'AF_UNIX', 'TCP')]
+
+receiver_sockets, monitored_sockets, log_monitors = None, None, None  # Set in the fixtures
+
+# Test daemons to restart.
+daemons_handler_configuration = {'all_daemons': True}
+
+OS_MAXSTR = 65536
+RECEIVE_TIMEOUT = 10
+
+def build_oversized_global_query(pairs=900):
+    """Build a 'global sql select ...' wazuh-db query whose payload exceeds OS_MAXSTR bytes."""
+    condition = "(version != 'Wazuh v4.14.2' collate nocase) and (name = 'agent{:06x}' collate nocase)"
+    conditions = ' or '.join(condition.format(i) for i in range(pairs))
+    sql = f"select count(*) from agent where (id != '000' collate nocase) and ({conditions})   order by id asc"
+    query = f"global sql {sql}"
+
+    assert len(query) > OS_MAXSTR, f"Generated query ({len(query)} bytes) does not exceed OS_MAXSTR, increase `pairs`"
+
+    return query
+
+
+def test_wazuh_db_closes_peer_on_oversized_message(daemons_handler_module, connect_to_sockets_module):
+    """Check wazuh-db closes the connection after receiving a message bigger than OS_MAXSTR."""
+    receiver_sockets[0].sock.settimeout(RECEIVE_TIMEOUT)
+    receiver_sockets[0].send(build_oversized_global_query(), size=True)
+
+    try:
+        response = receiver_sockets[0].receive(size=True)
+    except socket.timeout:
+        pytest.fail(
+            f"wazuh-db did not close the connection within {RECEIVE_TIMEOUT}s of receiving an oversized message. "
+            "The worker thread handling it most likely exited without closing the peer socket (see the "
+            "OS_SOCKTERR branch of run_worker() in src/wazuh_db/src/main.c)."
+        )
+    except ConnectionResetError:
+        # wazuh-db closes the peer without ever draining the oversized payload still sitting in the socket's
+        # receive buffer, so the kernel sends a RST instead of a graceful FIN. That is still a closed connection.
+        return
+
+    assert response == b'', f"Expected the connection to be closed (empty read), got: {response!r}"


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Wazuh-DB didn't handle well a message bigger than "65536" characters. Instead of closing the connection it terminates the thread by breaking the look. Now the connection is successfully closed and the worker thread is still active. 

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

## Results and Evidence

Prevent the thread to exit when an oversized message arrives. The thread closes the connection but it does ends the loop. 

### Testing 

Before the fix

```console
(integration_tests) root@noble:/home/vagrant/wazuh/tests/integration# python -m pytest -x --tier 0 --tier 1 test_wazuh_db/
===================================================================== test session starts ======================================================================
platform linux -- Python 3.12.3, pytest-7.3.1, pluggy-1.6.0
rootdir: /home/vagrant/wazuh/tests/integration
configfile: pytest.ini
plugins: metadata-3.1.1, cov-4.1.0, html-3.1.1
collected 130 items

test_wazuh_db/test_backup/test_db_backup.py ...........                                                                                                  [  8%]
test_wazuh_db/test_backup/test_wdb_backup_configs.py ........                                                                                            [ 14%]
test_wazuh_db/test_configuration/test_wazuhdb_getconfig.py ......                                                                                        [ 19%]
test_wazuh_db/test_databases/test_agent_database_version.py .                                                                                            [ 20%]
test_wazuh_db/test_databases/test_wazuh_db.py ......................................s.                                                                   [ 50%]
test_wazuh_db/test_databases/test_wazuh_db_oversized_message.py F

=========================================================================== FAILURES ===========================================================================
________________________________________________________ test_wazuh_db_closes_peer_on_oversized_message ________________________________________________________
test_wazuh_db/test_databases/test_wazuh_db_oversized_message.py:86: in test_wazuh_db_closes_peer_on_oversized_message
    ???
integration_tests/lib/python3.12/site-packages/wazuh_testing/tools/socket_controller.py:132: in receive
    data = self.sock.recv(4, socket.MSG_WAITALL)
E   TimeoutError: timed out

During handling of the above exception, another exception occurred:
test_wazuh_db/test_databases/test_wazuh_db_oversized_message.py:88: in test_wazuh_db_closes_peer_on_oversized_message
    ???
E   Failed: wazuh-db did not close the connection within 10s of receiving an oversized message. The worker thread handling it most likely exited without closing the peer socket (see the OS_SOCKTERR branch of run_worker() in src/wazuh_db/src/main.c).
```

After the fix 

```console
(integration_tests) root@noble:/home/vagrant/wazuh/tests/integration# python -m pytest -x --tier 0 --tier 1 test_wazuh_db/test_databases/test_wazuh_db_oversized_message.py
===================================================================== test session starts ======================================================================
platform linux -- Python 3.12.3, pytest-7.3.1, pluggy-1.6.0
rootdir: /home/vagrant/wazuh/tests/integration
configfile: pytest.ini
plugins: metadata-3.1.1, cov-4.1.0, html-3.1.1
collected 1 item

test_wazuh_db/test_databases/test_wazuh_db_oversized_message.py .                                                                                        [100%]

====================================================================== 1 passed in 39.30s ======================================================================
(integration_tests) root@noble:/home/vagrant/wazuh/tests/integration#
```

### Manual testing 

- Query used
[wql.txt](https://github.com/user-attachments/files/30270111/wql.txt)

- Before the fix 

<img width="885" height="241" alt="image" src="https://github.com/user-attachments/assets/5ce63f6a-1c21-4bb6-acf6-262944717235" />
<img width="1435" height="128" alt="image" src="https://github.com/user-attachments/assets/febb51ca-ef91-43aa-a447-eca90612aea1" />

- After the fix 

<img width="1879" height="309" alt="image" src="https://github.com/user-attachments/assets/88d86292-2856-4990-9cdd-f33d8b097168" />

We can see the warning message, but the worker thread keeps active. 
<img width="1920" height="425" alt="image" src="https://github.com/user-attachments/assets/9a5d2baf-52e4-47e9-a326-3b63c2eabe78" />
