### PR TITLE
Agent /control task dispatch: four types, batch planning, interim dedup

### DIFF
--- a/.github/actions/check_files/deb_linux_agent_amd64.csv
+++ b/.github/actions/check_files/deb_linux_agent_amd64.csv
@@ -10,7 +10,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12374168,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,505104,0.1
 /var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,218488,0.1
-/var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,270552,0.1
+/var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,340472,0.1
 /var/ossec/lib/libschema_validator.so,root,wazuh,750,file,-rwxr-x---,390232,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2603392,0.1
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,253344,0.1

--- a/.github/actions/check_files/deb_linux_agent_i386.csv
+++ b/.github/actions/check_files/deb_linux_agent_i386.csv
@@ -10,7 +10,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12358288,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,525380,0.1
 /var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,216020,0.1
-/var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,270552,0.1
+/var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,340472,0.1
 /var/ossec/lib/libschema_validator.so,root,wazuh,750,file,-rwxr-x---,426324,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2792476,0.1
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,273712,0.1

--- a/.github/actions/check_files/rpm_linux_agent_amd64.csv
+++ b/.github/actions/check_files/rpm_linux_agent_amd64.csv
@@ -74,7 +74,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12417720,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,484376,0.1
 /var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,220736,0.1
-/var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,270552,0.1
+/var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,324096,0.1
 /var/ossec/lib/libschema_validator.so,root,wazuh,750,file,-rwxr-x---,386024,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2555328,0.1
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,224672,0.1

--- a/.github/actions/check_files/rpm_linux_agent_i386.csv
+++ b/.github/actions/check_files/rpm_linux_agent_i386.csv
@@ -74,7 +74,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12362096,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,541828,0.1
 /var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,216520,0.1
-/var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,270552,0.1
+/var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,324096,0.1
 /var/ossec/lib/libschema_validator.so,root,wazuh,750,file,-rwxr-x---,398136,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2717844,0.1
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,259032,0.1

--- a/src/client-agent/https_client/demo/demo_driver.c
+++ b/src/client-agent/https_client/demo/demo_driver.c
@@ -98,6 +98,17 @@ static void on_reenroll_required(void *user_data)
     fflush(stdout);
 }
 
+static void on_task(const char *task_id, const char *task_type, const char *payload_json,
+                    void *user_data)
+{
+    (void)user_data;
+    printf("[+%7ld ms] >> TASK received: id=%s type=%s payload=%s\n", elapsed_ms(), task_id,
+           task_type, payload_json);
+    fflush(stdout);
+    /* All four contract types are fire-and-forget (#37733): nothing is
+     * reported back; a real agent routes them to their handlers here. */
+}
+
 /* The new-config delivery: the file lives only until this returns, so a real
  * consumer copies it here, applies it (write merged.mg, unmerge, reload) and
  * corrects the module's hash view if the apply fails. */
@@ -185,6 +196,7 @@ int main(int argc, char **argv)
     callbacks.log = on_log;
     callbacks.on_startup_result = on_startup_result;
     callbacks.on_reenroll_required = on_reenroll_required;
+    callbacks.on_task = on_task;
     callbacks.on_config_downloaded = on_config_downloaded;
     callbacks.on_state_change = on_state_change;
     callbacks.on_buffer_level = on_buffer_level;
@@ -212,10 +224,11 @@ int main(int argc, char **argv)
     printf("== forcing an out-of-cycle Notify ==\n");
     hc_notify_now(handle);
 
-    /* Let the control loop run: the mock flips its config at notify #3
-     * (-> /download), its settings at notify #5 (-> the client refreshes
-     * startup in place) and rotates its key at #7 (-> 401, one re-enroll
-     * callback, hc_set_agent_key recovery). */
+    /* Let the control loop deliver the fire-and-forget task batch (notify
+     * #2); nothing is reported back (#37733: no response message). Then the
+     * mock flips its config at #3 (-> /download), its settings at #5 (-> an
+     * in-place startup refresh) and rotates its key at #7 (-> 401, one
+     * re-enroll callback, hc_set_agent_key recovery). */
     nap(3000);
     hc_notify_now(handle);
     nap(7000);

--- a/src/client-agent/https_client/demo/mock_manager.py
+++ b/src/client-agent/https_client/demo/mock_manager.py
@@ -199,6 +199,25 @@ class Handler(BaseHTTPRequestHandler):
         response = {"agent": {"groups": ["default"],
                               "config_hash": hashlib.sha256(blob).hexdigest()},
                     "settings_hash": hashlib.sha256(startup).hexdigest()}
+        if n == 2:
+            # Deliberately shuffled 4-type batch (#37733: all fire-and-forget):
+            # the client dispatches AR then upgrade; restart and reload are
+            # covered by the upgrade and dropped with a log line.
+            response["tasks"] = [
+                {"task_id": "018f9a-0003", "task_type": "agent_restart",
+                 "payload": {}},
+                {"task_id": "018f9a-0001", "task_type": "active_response",
+                 "payload": {"wazuh": {"active_response": {
+                     "name": "firewall-drop", "executable": "firewall-drop",
+                     "extra_arguments": "192.168.1.100"}},
+                     "rule": {"id": 5503}}},
+                {"task_id": "018f9a-0005", "task_type": "remote_upgrade",
+                 "payload": {"wpk_file": "wazuh_agent_v5.1.0_linux_x86_64.wpk",
+                             "wpk_sha1": "a1b2c3d4e5f6",
+                             "installer": "upgrade.sh"}},
+                {"task_id": "018f9a-0004", "task_type": "agent_reload",
+                 "payload": {}},
+            ]
         self._reply(200, response)
         markers = []
         if n == Handler.CONFIG_FLIP_AT:
@@ -207,10 +226,11 @@ class Handler(BaseHTTPRequestHandler):
             markers.append("SETTINGS FLIPPED (new settings_hash)")
         if n == Handler.ROTATE_KEY_AT:
             markers.append("KEY ROTATED - old key now 401s, agent must re-enroll")
+        tasks = [t["task_id"] for t in response.get("tasks", [])]
         marker = (" <- " + ", ".join(markers)) if markers else ""
         log(f"     /control    -> 200  NOTIFY #{n} "
             f"cfg={response['agent']['config_hash'][:8]}.. "
-            f"set={response['settings_hash'][:8]}..{marker}")
+            f"set={response['settings_hash'][:8]}.. tasks={tasks}{marker}")
 
     def _handle_download(self, body):
         # 5.2: signed request for a resource, chunked octet-stream back.

--- a/src/client-agent/https_client/include/https_client.h
+++ b/src/client-agent/https_client/include/https_client.h
@@ -192,6 +192,12 @@ typedef struct hc_callbacks_t
     /// hc_set_config_hash() with the hash actually on disk.
     void (*on_config_downloaded)(const char* config_hash, const char* file_path,
                                  void* user_data);
+    /// The config hash the manager reported on the last accepted Notify,
+    /// whether or not it differed from ours. Fired on every Notify so a
+    /// consumer holding a gate on the manager-validated configuration (the
+    /// agent's startup hash gate) can reconcile it even when nothing needs
+    /// downloading. Empty when the manager reported none.
+    void (*on_manager_config_hash)(const char* config_hash, void* user_data);
     void (*on_state_change)(int state, void* user_data);  ///< hc_conn_state_t
     void (*on_buffer_level)(int level, void* user_data);  ///< hc_buffer_level_t
     void* user_data;

--- a/src/client-agent/https_client/include/https_client.h
+++ b/src/client-agent/https_client/include/https_client.h
@@ -140,6 +140,13 @@ typedef struct hc_config_t
     uint32_t notify_interval_s;         ///< notify_time; 0 -> 20.
     uint32_t rejected_retry_interval_s; ///< Slow re-Startup cadence; 0 -> 60.
 
+    /// Interim task-dedup bounds (TODO #37833: replaced by the durable
+    /// agent-info task_id registry). Max ids kept; 0 -> 4096.
+    uint32_t task_dedup_max;
+    /// Interim task-dedup TTL in seconds; a duplicate re-delivered after this
+    /// is accepted again; 0 -> 3600 (TODO #37833).
+    uint32_t task_dedup_ttl_s;
+
     char version[HC_MAX_VERSION];       ///< Product version for Startup.
     char config_checksum[HC_MAX_CHECKSUM]; ///< Local merged.mg MD5 seed. Compared
     ///< against the manager-reported
@@ -174,6 +181,8 @@ typedef struct hc_callbacks_t
     /// band (the authd flow, caller-owned retries) and call hc_set_agent_key()
     /// with the new key to resume.
     void (*on_reenroll_required)(void* user_data);
+    void (*on_task)(const char* task_id, const char* task_type, const char* payload_json,
+                    void* user_data);
     /// A Notify reported a merged-config hash differing from the local one;
     /// the module fetched the new configuration via POST /download and
     /// verified its MD5. file_path is a module-owned temp file valid ONLY

--- a/src/client-agent/https_client/src/callbackDispatcher.cpp
+++ b/src/client-agent/https_client/src/callbackDispatcher.cpp
@@ -105,6 +105,21 @@ void CallbackDispatcher::onStartupResult(bool accepted, const std::string& hands
     { m_callbacks.on_startup_result(accepted, handshakeJson.c_str(), m_callbacks.user_data); });
 }
 
+void CallbackDispatcher::onTask(const std::string& taskId, const std::string& taskType,
+                                const std::string& payloadJson)
+{
+    if (m_callbacks.on_task == nullptr)
+    {
+        return;
+    }
+
+    enqueue([this, taskId, taskType, payloadJson]
+    {
+        m_callbacks.on_task(taskId.c_str(), taskType.c_str(), payloadJson.c_str(),
+                            m_callbacks.user_data);
+    });
+}
+
 void CallbackDispatcher::onReenrollRequired()
 {
     if (m_callbacks.on_reenroll_required == nullptr)

--- a/src/client-agent/https_client/src/callbackDispatcher.cpp
+++ b/src/client-agent/https_client/src/callbackDispatcher.cpp
@@ -147,6 +147,19 @@ void CallbackDispatcher::onConfigDownloaded(const std::string& configHash,
     });
 }
 
+void CallbackDispatcher::onManagerConfigHash(const std::string& configHash)
+{
+    if (m_callbacks.on_manager_config_hash == nullptr)
+    {
+        return;
+    }
+
+    enqueue([this, configHash]
+    {
+        m_callbacks.on_manager_config_hash(configHash.c_str(), m_callbacks.user_data);
+    });
+}
+
 void CallbackDispatcher::onStateChange(hc_conn_state_t state)
 {
     if (m_callbacks.on_state_change == nullptr)

--- a/src/client-agent/https_client/src/callbackDispatcher.hpp
+++ b/src/client-agent/https_client/src/callbackDispatcher.hpp
@@ -45,6 +45,8 @@ class CallbackDispatcher final : public ICallbackSink
 
         void onStartupResult(bool accepted, const std::string& handshakeJson) override;
         void onReenrollRequired() override;
+        void onTask(const std::string& taskId, const std::string& taskType,
+                    const std::string& payloadJson) override;
         void onConfigDownloaded(const std::string& configHash,
                                 std::shared_ptr<SpoolFile> file) override;
         void onStateChange(hc_conn_state_t state) override;

--- a/src/client-agent/https_client/src/callbackDispatcher.hpp
+++ b/src/client-agent/https_client/src/callbackDispatcher.hpp
@@ -49,6 +49,7 @@ class CallbackDispatcher final : public ICallbackSink
                     const std::string& payloadJson) override;
         void onConfigDownloaded(const std::string& configHash,
                                 std::shared_ptr<SpoolFile> file) override;
+        void onManagerConfigHash(const std::string& configHash) override;
         void onStateChange(hc_conn_state_t state) override;
         void onBufferLevel(hc_buffer_level_t level) override;
 

--- a/src/client-agent/https_client/src/callbackSink.hpp
+++ b/src/client-agent/https_client/src/callbackSink.hpp
@@ -32,6 +32,8 @@ class ICallbackSink
         /// The signing credential was rejected (401); the module has paused all
         /// traffic. Fired once per incident until the key is replaced.
         virtual void onReenrollRequired() = 0;
+        virtual void onTask(const std::string& taskId, const std::string& taskType,
+                            const std::string& payloadJson) = 0;
         /// The file lives while the callback chain holds the shared_ptr; the
         /// production sink drops it right after the C callback returns.
         virtual void onConfigDownloaded(const std::string& configHash,

--- a/src/client-agent/https_client/src/callbackSink.hpp
+++ b/src/client-agent/https_client/src/callbackSink.hpp
@@ -38,6 +38,7 @@ class ICallbackSink
         /// production sink drops it right after the C callback returns.
         virtual void onConfigDownloaded(const std::string& configHash,
                                         std::shared_ptr<SpoolFile> file) = 0;
+        virtual void onManagerConfigHash(const std::string& configHash) = 0;
         virtual void onStateChange(hc_conn_state_t state) = 0;
         virtual void onBufferLevel(hc_buffer_level_t level) = 0;
 };

--- a/src/client-agent/https_client/src/controlStream.cpp
+++ b/src/client-agent/https_client/src/controlStream.cpp
@@ -12,6 +12,7 @@
 #include "controlStream.hpp"
 
 #include "digest.hpp"
+#include "taskBatch.hpp"
 
 #include "external/nlohmann/json.hpp"
 
@@ -56,6 +57,37 @@ namespace
 
         return "default";
     }
+
+    /// The Notify batch after dedup: fresh, identifiable tasks only.
+    /// Deliberately deduped BEFORE planning, so a task dropped as redundant is
+    /// still marked seen and an at-least-once redelivery stays dropped (a
+    /// restart landing after its subsuming upgrade would be harmful).
+    std::vector<NotifyTask> collectFreshTasks(const nlohmann::json& parsed, TaskDeduper& deduper,
+                                              std::chrono::steady_clock::time_point now)
+    {
+        std::vector<NotifyTask> batch;
+        const auto tasks = parsed.find("tasks");
+
+        if (tasks == parsed.end() || !tasks->is_array())
+        {
+            return batch;
+        }
+
+        for (const auto& task : *tasks)
+        {
+            std::string taskId = jsonField(task, "task_id");
+
+            if (taskId.empty() || !deduper.markIfNew(taskId, now))
+            {
+                continue; // Duplicate (at-least-once) or unidentifiable.
+            }
+
+            batch.push_back({std::move(taskId), jsonField(task, "task_type"),
+                             jsonField(task, "payload")});
+        }
+
+        return batch;
+    }
 } // namespace
 
 ControlStream::ControlStream(const ModuleConfig& config, IHttpPerformer& performer,
@@ -66,11 +98,13 @@ ControlStream::ControlStream(const ModuleConfig& config, IHttpPerformer& perform
     : m_config(config)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
     , m_sender(performer, signer, clock, m_backoff, &authGate)
+    , m_clock(clock)
     , m_sink(sink)
     , m_fetcher(config, performer, signer, clock, random, spoolFactory, authGate)
     , m_configHash(configHash)
     , m_cluster(cluster)
     , m_authGate(authGate)
+    , m_deduper(config.taskDedupMax, std::chrono::seconds {config.taskDedupTtlS})
 {
 }
 
@@ -247,6 +281,9 @@ void ControlStream::handleNotifyBody(const std::string& body, Waiter& waiter)
         return; // Tolerant: a malformed Notify body is ignored, never fatal.
     }
 
+    // Tasks first, then the hash checks: a slow config download must never
+    // delay task delivery.
+    dispatchPlannedTasks(collectFreshTasks(parsed, m_deduper, m_clock.steadyNow()));
     maybeArmSettingsRefresh(jsonField(parsed, "settings_hash"));
 
     const auto agent = parsed.find("agent");
@@ -313,6 +350,22 @@ void ControlStream::maybeArmSettingsRefresh(const std::string& incoming)
     m_refreshedForSettingsHash = incoming;
     m_settingsLoopWarned = false;
     m_machine.onEvent(ControlStateMachine::Event::SettingsChanged);
+}
+
+void ControlStream::dispatchPlannedTasks(std::vector<NotifyTask> batch)
+{
+    auto plan = planTaskBatch(std::move(batch));
+
+    for (const auto& [task, subsumer] : plan.dropped)
+    {
+        LOGFN_INFO(m_logFn, "Task %s (%s) dropped: covered by a %s in the same batch.",
+                   task.id.c_str(), task.type.c_str(), subsumer.c_str());
+    }
+
+    for (const auto& task : plan.ordered)
+    {
+        m_sink.onTask(task.id, task.type, task.payloadJson);
+    }
 }
 
 ControlStateMachine::Event ControlStream::eventFor(OutcomeClass outcome) const

--- a/src/client-agent/https_client/src/controlStream.cpp
+++ b/src/client-agent/https_client/src/controlStream.cpp
@@ -308,7 +308,12 @@ void ControlStream::handleNotifyBody(const std::string& body, Waiter& waiter)
 
     if (agent != parsed.end() && agent->is_object())
     {
-        maybeDownloadConfig(jsonField(*agent, "config_hash"), firstGroup(*agent), waiter);
+        const std::string managerHash = jsonField(*agent, "config_hash");
+        // Reported on every notify, matching or not: the agent's startup hash
+        // gate waits on the manager-validated configuration and, when the
+        // hashes already agree, no download fires to tell it so (#37854).
+        m_sink.onManagerConfigHash(managerHash);
+        maybeDownloadConfig(managerHash, firstGroup(*agent), waiter);
     }
 }
 

--- a/src/client-agent/https_client/src/controlStream.cpp
+++ b/src/client-agent/https_client/src/controlStream.cpp
@@ -63,7 +63,8 @@ namespace
     /// still marked seen and an at-least-once redelivery stays dropped (a
     /// restart landing after its subsuming upgrade would be harmful).
     std::vector<NotifyTask> collectFreshTasks(const nlohmann::json& parsed, TaskDeduper& deduper,
-                                              std::chrono::steady_clock::time_point now)
+                                              std::chrono::steady_clock::time_point now,
+                                              const LogFn& logFn)
     {
         std::vector<NotifyTask> batch;
         const auto tasks = parsed.find("tasks");
@@ -76,14 +77,31 @@ namespace
         for (const auto& task : *tasks)
         {
             std::string taskId = jsonField(task, "task_id");
+            std::string taskType = jsonField(task, "task_type");
 
-            if (taskId.empty() || !deduper.markIfNew(taskId, now))
+            // Two very different reasons to skip, so trace them separately.
+            // Both stay at debug: a drop is expected traffic, not an operator
+            // problem, which is the level buffer.c uses for the same thing.
+            if (taskId.empty())
             {
-                continue; // Duplicate (at-least-once) or unidentifiable.
+                // Every task carries a task_id (#37733 5.1.2), so one without
+                // is a manager-side defect: it can be neither deduped nor
+                // acknowledged, and dropping it silently would leave a future
+                // reader with no way to tell it ever arrived.
+                LOGFN_DEBUG1(logFn, "Ignoring a /control task with no task_id (type '%s').",
+                             taskType.empty() ? "(none)" : taskType.c_str());
+                continue;
             }
 
-            batch.push_back({std::move(taskId), jsonField(task, "task_type"),
-                             jsonField(task, "payload")});
+            if (!deduper.markIfNew(taskId, now))
+            {
+                // Routine: delivery is at-least-once, so a redelivery inside
+                // the dedup TTL is the mechanism working.
+                LOGFN_DEBUG2(logFn, "Dropping /control task %s: already seen.", taskId.c_str());
+                continue;
+            }
+
+            batch.push_back({std::move(taskId), std::move(taskType), jsonField(task, "payload")});
         }
 
         return batch;
@@ -283,7 +301,7 @@ void ControlStream::handleNotifyBody(const std::string& body, Waiter& waiter)
 
     // Tasks first, then the hash checks: a slow config download must never
     // delay task delivery.
-    dispatchPlannedTasks(collectFreshTasks(parsed, m_deduper, m_clock.steadyNow()));
+    dispatchPlannedTasks(collectFreshTasks(parsed, m_deduper, m_clock.steadyNow(), m_logFn));
     maybeArmSettingsRefresh(jsonField(parsed, "settings_hash"));
 
     const auto agent = parsed.find("agent");

--- a/src/client-agent/https_client/src/controlStream.hpp
+++ b/src/client-agent/https_client/src/controlStream.hpp
@@ -23,8 +23,11 @@
 #include "retrySender.hpp"
 #include "stopToken.hpp"
 #include "sysSeams.hpp"
+#include "taskBatch.hpp"
+#include "taskDeduper.hpp"
 
 #include <string>
+#include <vector>
 
 /**
  * @brief The /control client: Startup, Notify and shutdown, speaking the
@@ -32,10 +35,9 @@
  *
  * Drives the pure ControlStateMachine: nextAction() decides the request,
  * step() performs it and feeds the result back as an event. Startup applies
- * the handshake JSON and releases the producer gate; Notify compares the
- * manager-reported hashes (config_hash -> /download, settings_hash ->
- * startup refresh). Task dispatch (#37833) mounts on the Notify response in
- * its own workstream.
+ * the handshake JSON and releases the producer gate; Notify dispatches the
+ * planned task batch and compares the manager-reported hashes (config_hash
+ * -> /download, settings_hash -> startup refresh).
  */
 class ControlStream final
 {
@@ -69,6 +71,7 @@ class ControlStream final
         void applyEffects(const ControlStateMachine::Effects& effects, const std::string& handshake);
         void applyClusterIdentity(const std::string& startupBody);
         void handleNotifyBody(const std::string& body, Waiter& waiter);
+        void dispatchPlannedTasks(std::vector<NotifyTask> batch);
         void maybeArmSettingsRefresh(const std::string& incoming);
         void maybeDownloadConfig(const std::string& managerHash, const std::string& group,
                                  Waiter& waiter);
@@ -77,12 +80,14 @@ class ControlStream final
         const ModuleConfig& m_config;
         Backoff m_backoff;
         RetrySender m_sender;
+        IClock& m_clock;
         ICallbackSink& m_sink;
         ConfigFetcher m_fetcher;
         ConfigHashState& m_configHash;
         ClusterIdentity& m_cluster;
         AuthGate& m_authGate;
         ControlStateMachine m_machine;
+        TaskDeduper m_deduper;
         const LogFn m_logFn {HTTPS_CLIENT_LOGTAG};
 
         /// SHA-256 of the exact startup-response bytes (the local settings

--- a/src/client-agent/https_client/src/moduleConfig.cpp
+++ b/src/client-agent/https_client/src/moduleConfig.cpp
@@ -49,6 +49,8 @@ ModuleConfig ModuleConfig::fromC(const hc_config_t& config)
     typed.bufferFloodToleranceS = orDefault<uint32_t>(config.buffer_flood_tolerance_s, 15);
     typed.notifyIntervalS = orDefault<uint32_t>(config.notify_interval_s, 20);
     typed.rejectedRetryIntervalS = orDefault<uint32_t>(config.rejected_retry_interval_s, 60);
+    typed.taskDedupMax = orDefault<uint32_t>(config.task_dedup_max, 4096);
+    typed.taskDedupTtlS = orDefault<uint32_t>(config.task_dedup_ttl_s, 3600);
     typed.version = boundedString(config.version, sizeof(config.version));
     typed.configChecksum = boundedString(config.config_checksum, sizeof(config.config_checksum));
     typed.requestTimeoutMs = orDefault<uint32_t>(config.request_timeout_ms, 10000);

--- a/src/client-agent/https_client/src/moduleConfig.hpp
+++ b/src/client-agent/https_client/src/moduleConfig.hpp
@@ -51,6 +51,11 @@ struct ModuleConfig
         uint32_t notifyIntervalS {20};
         uint32_t rejectedRetryIntervalS {60};
 
+        // TODO(#37833): interim in-memory dedup bounds; retired by the durable
+        // agent-info task_id registry.
+        uint32_t taskDedupMax {4096};
+        uint32_t taskDedupTtlS {3600};
+
         std::string version;
         std::string configChecksum;
 

--- a/src/client-agent/https_client/src/taskBatch.hpp
+++ b/src/client-agent/https_client/src/taskBatch.hpp
@@ -1,0 +1,141 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 21, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _HC_TASK_BATCH_HPP
+#define _HC_TASK_BATCH_HPP
+
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
+
+/// One task as parsed from a Notify response (#37733 5.1.2).
+struct NotifyTask
+{
+    std::string id;
+    std::string type;
+    std::string payloadJson;
+};
+
+/// The dispatch plan for one Notify batch: tasks in dispatch order, plus the
+/// tasks dropped as redundant (paired with the type that covers them).
+struct TaskBatchPlan
+{
+    std::vector<NotifyTask> ordered;
+    std::vector<std::pair<NotifyTask, std::string>> dropped;
+};
+
+namespace taskBatchDetail
+{
+    /// Dispatch rank over the four contract types (#37733 §2: all
+    /// fire-and-forget). Terminal tasks (upgrade/restart end the process)
+    /// rank last so quick work is never lost behind them; unknown types
+    /// (including the removed agent_reconnect/info_request, tolerated from
+    /// older managers) rank after everything, in arrival order.
+    inline int rankOf(const std::string& type)
+    {
+        if (type == "active_response")
+        {
+            return 0;
+        }
+
+        if (type == "agent_reload")
+        {
+            return 1;
+        }
+
+        if (type == "remote_upgrade")
+        {
+            return 2;
+        }
+
+        if (type == "agent_restart")
+        {
+            return 3;
+        }
+
+        return 4;
+    }
+
+    /// The batch-mate type that makes this task redundant, or empty. All
+    /// tasks are fire-and-forget, so dropping owes nothing: an upgrade ends
+    /// in a restart (which reloads), and a restart reloads by itself.
+    inline std::string subsumerOf(const std::string& type, bool hasUpgrade, bool hasRestart)
+    {
+        if (type == "agent_restart" && hasUpgrade)
+        {
+            return "remote_upgrade";
+        }
+
+        if (type == "agent_reload")
+        {
+            if (hasUpgrade)
+            {
+                return "remote_upgrade";
+            }
+
+            if (hasRestart)
+            {
+                return "agent_restart";
+            }
+        }
+
+        return {};
+    }
+} // namespace taskBatchDetail
+
+/**
+ * @brief Plans one Notify batch: priority order + redundancy collapse.
+ *
+ * Presence for subsumption is evaluated on the batch as delivered (pre-drop),
+ * so a restart that is itself dropped by an upgrade still covers a reload in
+ * the same batch. The relative order of same-rank tasks is preserved.
+ */
+inline TaskBatchPlan planTaskBatch(std::vector<NotifyTask> batch)
+{
+    const bool hasUpgrade =
+        std::any_of(batch.begin(), batch.end(),
+                    [](const NotifyTask & task)
+    {
+        return task.type == "remote_upgrade";
+    });
+    const bool hasRestart =
+        std::any_of(batch.begin(), batch.end(),
+                    [](const NotifyTask & task)
+    {
+        return task.type == "agent_restart";
+    });
+
+    TaskBatchPlan plan;
+
+    for (auto& task : batch)
+    {
+        const auto subsumer = taskBatchDetail::subsumerOf(task.type, hasUpgrade, hasRestart);
+
+        if (subsumer.empty())
+        {
+            plan.ordered.push_back(std::move(task));
+        }
+        else
+        {
+            plan.dropped.emplace_back(std::move(task), subsumer);
+        }
+    }
+
+    std::stable_sort(plan.ordered.begin(), plan.ordered.end(),
+                     [](const NotifyTask & a, const NotifyTask & b)
+    {
+        return taskBatchDetail::rankOf(a.type) < taskBatchDetail::rankOf(b.type);
+    });
+    return plan;
+}
+
+#endif // _HC_TASK_BATCH_HPP

--- a/src/client-agent/https_client/src/taskBatch.hpp
+++ b/src/client-agent/https_client/src/taskBatch.hpp
@@ -68,6 +68,20 @@ namespace taskBatchDetail
     /// The batch-mate type that makes this task redundant, or empty. All
     /// tasks are fire-and-forget, so dropping owes nothing: an upgrade ends
     /// in a restart (which reloads), and a restart reloads by itself.
+    ///
+    /// Collapsing is deliberately ACROSS types only; two tasks of the same
+    /// type both survive. That is not an oversight:
+    ///
+    ///  - active_response tasks carry per-task payloads, so two of them are
+    ///    two different actions (block 10.0.0.1 and block 10.0.0.2). Folding
+    ///    them together would silently discard real work.
+    ///  - for remote_upgrade, which of two differing payloads should win is a
+    ///    contract question (#37733), not something this planner can decide.
+    ///
+    /// The manager is the trusted source of the batch and assigns
+    /// deterministic task ids (#37944), so a batch carrying two upgrades is a
+    /// manager-side defect. Worth knowing that it would dispatch twice, which
+    /// once #37834 wires execution means two installer runs.
     inline std::string subsumerOf(const std::string& type, bool hasUpgrade, bool hasRestart)
     {
         if (type == "agent_restart" && hasUpgrade)

--- a/src/client-agent/https_client/src/taskDeduper.hpp
+++ b/src/client-agent/https_client/src/taskDeduper.hpp
@@ -1,0 +1,90 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 17, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _HC_TASK_DEDUPER_HPP
+#define _HC_TASK_DEDUPER_HPP
+
+#include <chrono>
+#include <cstddef>
+#include <deque>
+#include <string>
+#include <unordered_set>
+
+/**
+ * @brief Bounded, TTL-aged set of seen task ids. Task delivery is
+ *        at-least-once (#37733), so the client ignores duplicates; the bound
+ *        keeps memory flat and the TTL lets a much-later re-delivery through
+ *        (acceptable under at-least-once).
+ *
+ * TODO(#37833): INTERIM. This in-memory record is lost on restart, so a
+ *        duplicate that straddles a restart (notably a remote_upgrade, which
+ *        restarts the agent) can re-execute. Issue #37833 replaces it with a
+ *        durable, restart-surviving task_id table owned by the agent-info
+ *        module, reached over IPC; this class is retired then.
+ */
+class TaskDeduper final
+{
+    public:
+        explicit TaskDeduper(size_t capacity = 4096,
+                             std::chrono::seconds ttl = std::chrono::seconds {3600})
+            : m_capacity(capacity == 0 ? 1 : capacity)
+            , m_ttl(ttl)
+        {
+        }
+
+        /// Records the id at time `now`. Returns true if it is new (dispatch),
+        /// false if already seen and unexpired (drop). Insertion-time TTL: an
+        /// id re-delivered after the TTL is treated as new.
+        bool markIfNew(const std::string& taskId, std::chrono::steady_clock::time_point now)
+        {
+            pruneExpired(now);
+
+            if (m_seen.count(taskId) != 0)
+            {
+                return false;
+            }
+
+            if (m_order.size() >= m_capacity)
+            {
+                m_seen.erase(m_order.front().id);
+                m_order.pop_front();
+            }
+
+            m_seen.insert(taskId);
+            m_order.push_back({taskId, now});
+            return true;
+        }
+
+    private:
+        struct Entry
+        {
+            std::string id;
+            std::chrono::steady_clock::time_point seenAt;
+        };
+
+        /// Insertion-time TTL means m_order is sorted by seenAt, so expired
+        /// entries are always a front prefix: pop them, amortized O(expired).
+        void pruneExpired(std::chrono::steady_clock::time_point now)
+        {
+            while (!m_order.empty() && now - m_order.front().seenAt >= m_ttl)
+            {
+                m_seen.erase(m_order.front().id);
+                m_order.pop_front();
+            }
+        }
+
+        size_t m_capacity;
+        std::chrono::seconds m_ttl;
+        std::unordered_set<std::string> m_seen;
+        std::deque<Entry> m_order;
+};
+
+#endif // _HC_TASK_DEDUPER_HPP

--- a/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
+++ b/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <mutex>
@@ -78,9 +79,29 @@ namespace
         return config;
     }
 
+    /// Valgrind runs this binary about six times slower (the RTR stage reports
+    /// ~86 s for what takes ~14 s natively), which is enough to miss the
+    /// deadlines below. A missed deadline costs more than one failed
+    /// assertion: ASSERT_TRUE returns from the test body before its
+    /// hc_destroy(), so the handle's threads, curl handles and OpenSSL state
+    /// are never released and valgrind reports them as definitely lost. Stretch
+    /// the bound when running under valgrind rather than loosening it for
+    /// everyone, so a genuine hang still fails fast in a normal run.
+    int scaledTimeout(int timeoutMs)
+    {
+        static const int factor = []
+        {
+            const char* preload = std::getenv("LD_PRELOAD");
+            return preload != nullptr && std::strstr(preload, "valgrind") != nullptr ? 10 : 1;
+        }();
+        return timeoutMs * factor;
+    }
+
     bool waitFor(const std::atomic<int>& counter, int target, int timeoutMs)
     {
-        for (int elapsed = 0; elapsed < timeoutMs; elapsed += 10)
+        const int deadline = scaledTimeout(timeoutMs);
+
+        for (int elapsed = 0; elapsed < deadline; elapsed += 10)
         {
             if (counter.load() >= target)
             {

--- a/src/client-agent/https_client/tests/unit/callbackDispatcher_test.cpp
+++ b/src/client-agent/https_client/tests/unit/callbackDispatcher_test.cpp
@@ -34,6 +34,15 @@ namespace
         std::atomic<int> count {0};
     };
 
+    void recordTask(const char* taskId, const char*, const char*, void* userData)
+    {
+        auto* record = static_cast<Record*>(userData);
+        std::lock_guard<std::mutex> lock(record->mutex);
+        record->order.emplace_back(taskId);
+        record->threads.push_back(std::this_thread::get_id());
+        record->count++;
+    }
+
     void recordState(int state, void* userData)
     {
         auto* record = static_cast<Record*>(userData);
@@ -73,6 +82,7 @@ namespace
     {
         hc_callbacks_t callbacks {};
         callbacks.on_startup_result = recordStartup;
+        callbacks.on_task = recordTask;
         callbacks.on_reenroll_required = recordReenroll;
         callbacks.on_state_change = recordState;
         callbacks.on_buffer_level = recordBuffer;
@@ -95,10 +105,9 @@ TEST(CallbackDispatcherTest, DeliversInSubmissionOrderOnOneThread)
     CallbackDispatcher dispatcher {makeCallbacks(&record)};
     dispatcher.start();
 
-    // A cycling state sequence: any reorder breaks the expected labels below.
     for (int index = 0; index < 20; index++)
     {
-        dispatcher.onStateChange(static_cast<hc_conn_state_t>(index % 5));
+        dispatcher.onTask("task-" + std::to_string(index), "ar", "{}");
     }
 
     waitForCount(record, 20);
@@ -108,7 +117,7 @@ TEST(CallbackDispatcherTest, DeliversInSubmissionOrderOnOneThread)
 
     for (int index = 0; index < 20; index++)
     {
-        EXPECT_EQ("state:" + std::to_string(index % 5), record.order[index]); // FIFO.
+        EXPECT_EQ("task-" + std::to_string(index), record.order[index]); // FIFO.
     }
 
     // Every callback ran on the same (single) dispatcher thread.
@@ -129,7 +138,7 @@ TEST(CallbackDispatcherTest, StopDrainsQueuedCallbacks)
     for (int index = 0; index < 50; index++)
     {
         dispatcher.onStateChange(HC_STATE_REGISTERED);
-        dispatcher.onReenrollRequired();
+        dispatcher.onTask("t" + std::to_string(index), "ar", "{}");
     }
 
     dispatcher.stop(); // Must run everything already queued before joining.
@@ -142,7 +151,7 @@ TEST(CallbackDispatcherTest, PostAfterStopIsRejected)
     CallbackDispatcher dispatcher {makeCallbacks(&record)};
     dispatcher.start();
     dispatcher.stop();
-    dispatcher.onStateChange(HC_STATE_STARTING);
+    dispatcher.onTask("late", "ar", "{}");
     EXPECT_EQ(0, record.count.load());
 }
 
@@ -151,6 +160,7 @@ TEST(CallbackDispatcherTest, NullCallbacksAreSafe)
     hc_callbacks_t callbacks {}; // All function pointers null.
     CallbackDispatcher dispatcher {callbacks};
     dispatcher.start();
+    dispatcher.onTask("x", "ar", "{}");
     dispatcher.onStateChange(HC_STATE_STARTING);
     dispatcher.onReenrollRequired();
     dispatcher.onStartupResult(true, "{}");
@@ -164,14 +174,16 @@ TEST(CallbackDispatcherTest, EveryCallbackKindIsForwarded)
     CallbackDispatcher dispatcher {makeCallbacks(&record)};
     dispatcher.start();
     dispatcher.onStartupResult(true, R"({"limits":{}})");
+    dispatcher.onTask("t1", "active_response", "{}");
     dispatcher.onReenrollRequired();
     dispatcher.onStateChange(HC_STATE_REGISTERED);
     dispatcher.onBufferLevel(HC_BUFFER_WARNING);
-    waitForCount(record, 4);
+    waitForCount(record, 5);
     dispatcher.stop();
 
     EXPECT_NE(record.order.end(),
               std::find(record.order.begin(), record.order.end(), "startup:ok"));
+    EXPECT_NE(record.order.end(), std::find(record.order.begin(), record.order.end(), "t1"));
     EXPECT_NE(record.order.end(),
               std::find(record.order.begin(), record.order.end(), "reenroll"));
     EXPECT_NE(record.order.end(),
@@ -258,7 +270,7 @@ TEST(CallbackDispatcherTest, DoubleStartAndDoubleStopAreSafe)
     CallbackDispatcher dispatcher {makeCallbacks(&record)};
     dispatcher.start();
     dispatcher.start(); // Ignored.
-    dispatcher.onReenrollRequired();
+    dispatcher.onTask("one", "ar", "{}");
     waitForCount(record, 1);
     dispatcher.stop();
     dispatcher.stop(); // Ignored.

--- a/src/client-agent/https_client/tests/unit/controlStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/controlStream_test.cpp
@@ -572,6 +572,23 @@ TEST_F(ControlStreamTest, TaskMissingOptionalFieldsStillDispatches)
     m_stream.step(m_waiter);
 }
 
+TEST_F(ControlStreamTest, TaskWithoutATaskIdIsSkippedAndTheRestOfTheBatchSurvives)
+{
+    // A task with no task_id cannot be deduped or identified, so it is
+    // dropped (traced at debug). It must not take its batch-mates with it.
+    const std::string body =
+        R"({"tasks":[)"
+        R"({"task_type":"active_response","payload":{}},)"
+        R"({"task_id":"good","task_type":"active_response","payload":{}}]})";
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, body)));
+    EXPECT_CALL(m_sink, onTask("good", "active_response", "{}"));
+
+    m_stream.step(m_waiter);
+    m_stream.step(m_waiter);
+}
+
 TEST_F(ControlStreamTest, MalformedNotifyBodyIsIgnored)
 {
     EXPECT_CALL(m_performer, perform(_))

--- a/src/client-agent/https_client/tests/unit/controlStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/controlStream_test.cpp
@@ -365,6 +365,41 @@ TEST_F(ControlStreamTest, MatchingConfigHashDoesNotDownload)
     m_stream.step(m_waiter); // Still in sync.
 }
 
+TEST_F(ControlStreamTest, ManagerConfigHashIsReportedEvenWhenItMatches)
+{
+    // The agent's startup hash gate waits on the manager-validated config, and
+    // an agent already in sync never downloads, so the hash has to reach the
+    // consumer on the notify itself or the gate never releases (#37854).
+    const std::string notify =
+        R"({"status":"ok","agent":{"groups":["default"],"config_hash":"abc"}})";
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, notify)));
+    EXPECT_CALL(m_sink, onConfigDownloaded(_, _)).Times(0);
+    EXPECT_CALL(m_sink, onManagerConfigHash("abc")).Times(1);
+
+    m_stream.step(m_waiter); // Startup.
+    m_stream.step(m_waiter); // Notify: in sync, still reported.
+}
+
+TEST_F(ControlStreamTest, ManagerConfigHashIsReportedBeforeADownload)
+{
+    // The diverging case reports too, so the gate can record what it is
+    // waiting for before /download lands it.
+    const std::string blob = "new-config-bytes";
+    const std::string blobHash = sha256Hex(blob.data(), blob.size());
+    const std::string notify =
+        R"({"status":"ok","agent":{"groups":["default"],"config_hash":")" + blobHash + R"("}})";
+    EXPECT_CALL(m_sink, onManagerConfigHash(blobHash)).Times(1);
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, notify)))
+    .WillRepeatedly(Return(response(TransportStatus::Ok, 500)));
+
+    m_stream.step(m_waiter); // Startup.
+    m_stream.step(m_waiter); // Notify: reports, then attempts the download.
+}
+
 TEST_F(ControlStreamTest, HashMismatchOnTheDownloadedFileDiscardsIt)
 {
     // The downloaded bytes do not match the advertised MD5: no delivery, no

--- a/src/client-agent/https_client/tests/unit/controlStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/controlStream_test.cpp
@@ -442,11 +442,13 @@ TEST_F(ControlStreamTest, FailedDownloadRetriesOnTheNextNotify)
 
 TEST_F(ControlStreamTest, DrainStepSendsBareShutdown)
 {
-    // Even with a settings refresh armed and a content-bearing response, the
-    // drain sends exactly {"type":"shutdown"} and handles no body.
+    // Even with a settings refresh armed and a task-bearing response, the
+    // drain sends exactly {"type":"shutdown"}, dispatches nothing and
+    // downloads nothing.
     const std::string armingNotify = R"({"status":"ok","settings_hash":"different"})";
     const std::string shutdownResponse =
-        R"({"agent":{"groups":["default"]},"settings_hash":"even-more-different"})";
+        R"({"agent":{"groups":["default"],"config_hash":"drain-mismatch"},"tasks":[)"
+        R"({"task_id":"late","task_type":"active_response","payload":{}}]})";
 
     EXPECT_CALL(m_performer, perform(_))
     .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))            // Startup.
@@ -458,10 +460,92 @@ TEST_F(ControlStreamTest, DrainStepSendsBareShutdown)
         EXPECT_EQ(m_config.drainTimeoutMs, spec.timeoutMs); // Shutdown uses the drain window, not the request timeout.
         return response(TransportStatus::Ok, 200, shutdownResponse);
     }));
+    EXPECT_CALL(m_sink, onTask(_, _, _)).Times(0);
+    EXPECT_CALL(m_sink, onConfigDownloaded(_, _)).Times(0);
 
     m_stream.step(m_waiter);      // Startup.
     m_stream.step(m_waiter);      // Notify arms the refresh.
     m_stream.drainStep(m_waiter); // Drain: bare shutdown, no side actions.
+}
+
+TEST_F(ControlStreamTest, NotifyTasksAreDispatchedAndDeduped)
+{
+    const std::string notifyResponse =
+        R"({"status":"ok","tasks":[)"
+        R"({"task_id":"t1","task_type":"active_response","payload":{"cmd":"x"}},)"
+        R"({"task_id":"t2","task_type":"agent_restart","payload":{}}]})";
+    const std::string repeatResponse =
+        R"({"status":"ok","tasks":[)"
+        R"({"task_id":"t1","task_type":"active_response","payload":{"cmd":"x"}}]})";
+
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))  // Startup.
+    .WillOnce(Return(response(TransportStatus::Ok, 200, notifyResponse)))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, repeatResponse)));
+
+    // t1 and t2 dispatched once; the repeated t1 is dropped (at-least-once).
+    EXPECT_CALL(m_sink, onTask("t1", "active_response", R"({"cmd":"x"})"));
+    EXPECT_CALL(m_sink, onTask("t2", "agent_restart", "{}"));
+
+    m_stream.step(m_waiter); // Startup.
+    m_stream.step(m_waiter); // Notify -> t1, t2.
+    m_stream.step(m_waiter); // Notify -> t1 duplicate dropped.
+}
+
+TEST_F(ControlStreamTest, NotifyBatchIsPrioritizedAndCollapsedBeforeDispatch)
+{
+    // A shuffled batch: dispatch order is AR -> reload -> upgrade; the restart
+    // is dropped (covered by the upgrade). Because dedup runs before the
+    // planner, the dropped restart is marked seen and its at-least-once
+    // redelivery on the next Notify stays dropped.
+    const std::string batch =
+        R"({"status":"ok","tasks":[)"
+        R"({"task_id":"t-restart","task_type":"agent_restart","payload":{}},)"
+        R"({"task_id":"t-reload","task_type":"agent_reload","payload":{}},)"
+        R"({"task_id":"t-up","task_type":"remote_upgrade","payload":{}},)"
+        R"({"task_id":"t-ar","task_type":"active_response","payload":{}}]})";
+    const std::string redelivery =
+        R"({"status":"ok","tasks":[)"
+        R"({"task_id":"t-restart","task_type":"agent_restart","payload":{}}]})";
+
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))  // Startup.
+    .WillOnce(Return(response(TransportStatus::Ok, 200, batch)))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, redelivery)));
+
+    // restart + reload dropped (both covered by the upgrade).
+    EXPECT_CALL(m_sink, onTask("t-restart", _, _)).Times(0);
+    EXPECT_CALL(m_sink, onTask("t-reload", _, _)).Times(0);
+    {
+        ::testing::InSequence ordered;
+        EXPECT_CALL(m_sink, onTask("t-ar", "active_response", "{}"));
+        EXPECT_CALL(m_sink, onTask("t-up", "remote_upgrade", "{}"));
+    }
+
+    m_stream.step(m_waiter); // Startup.
+    m_stream.step(m_waiter); // Notify: planned dispatch in priority order.
+    m_stream.step(m_waiter); // Redelivered restart: still dropped.
+}
+
+TEST_F(ControlStreamTest, DuplicateTaskIsReDeliveredAfterTheDedupTtl)
+{
+    // The default fixture config carries the 3600 s dedup TTL; advancing the
+    // FakeClock past it lets the same task_id through again (at-least-once).
+    const std::string body =
+        R"({"status":"ok","tasks":[)"
+        R"({"task_id":"t-ttl","task_type":"active_response","payload":{}}]})";
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))  // Startup.
+    .WillOnce(Return(response(TransportStatus::Ok, 200, body)))  // First delivery.
+    .WillOnce(Return(response(TransportStatus::Ok, 200, body)))  // Within TTL: dropped.
+    .WillOnce(Return(response(TransportStatus::Ok, 200, body))); // After TTL: re-dispatched.
+    EXPECT_CALL(m_sink, onTask("t-ttl", "active_response", "{}")).Times(2);
+
+    m_stream.step(m_waiter); // Startup.
+    m_stream.step(m_waiter); // Dispatch #1.
+    m_stream.step(m_waiter); // Duplicate within TTL: no dispatch.
+    m_clock.advance(std::chrono::seconds {3601});
+    m_stream.step(m_waiter); // Past TTL: dispatch #2.
 }
 
 TEST_F(ControlStreamTest, EmptyNotifyBodyIsIgnored)
@@ -469,9 +553,23 @@ TEST_F(ControlStreamTest, EmptyNotifyBodyIsIgnored)
     EXPECT_CALL(m_performer, perform(_))
     .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
     .WillOnce(Return(response(TransportStatus::Ok, 200, ""))); // Empty body.
+    EXPECT_CALL(m_sink, onTask(_, _, _)).Times(0);
 
     m_stream.step(m_waiter);
-    m_stream.step(m_waiter); // No crash.
+    m_stream.step(m_waiter); // No dispatch, no crash.
+}
+
+TEST_F(ControlStreamTest, TaskMissingOptionalFieldsStillDispatches)
+{
+    // A task with only task_id: type/payload resolve to empty strings.
+    const std::string body = R"({"tasks":[{"task_id":"only-id"}]})";
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, body)));
+    EXPECT_CALL(m_sink, onTask("only-id", "", ""));
+
+    m_stream.step(m_waiter);
+    m_stream.step(m_waiter);
 }
 
 TEST_F(ControlStreamTest, MalformedNotifyBodyIsIgnored)
@@ -479,7 +577,9 @@ TEST_F(ControlStreamTest, MalformedNotifyBodyIsIgnored)
     EXPECT_CALL(m_performer, perform(_))
     .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
     .WillOnce(Return(response(TransportStatus::Ok, 200, "not-json{{")));
+    EXPECT_CALL(m_sink, onTask(_, _, _)).Times(0);
 
     m_stream.step(m_waiter);
-    m_stream.step(m_waiter); // No crash.
+    m_stream.step(m_waiter); // No crash, no dispatch.
 }
+

--- a/src/client-agent/https_client/tests/unit/mocks/mockCallbackSink.hpp
+++ b/src/client-agent/https_client/tests/unit/mocks/mockCallbackSink.hpp
@@ -27,6 +27,7 @@ class MockCallbackSink : public ICallbackSink
                     (override));
         MOCK_METHOD(void, onConfigDownloaded,
                     (const std::string& configHash, std::shared_ptr<SpoolFile> file), (override));
+        MOCK_METHOD(void, onManagerConfigHash, (const std::string& configHash), (override));
         MOCK_METHOD(void, onStateChange, (hc_conn_state_t state), (override));
         MOCK_METHOD(void, onBufferLevel, (hc_buffer_level_t level), (override));
 };

--- a/src/client-agent/https_client/tests/unit/mocks/mockCallbackSink.hpp
+++ b/src/client-agent/https_client/tests/unit/mocks/mockCallbackSink.hpp
@@ -21,6 +21,10 @@ class MockCallbackSink : public ICallbackSink
     public:
         MOCK_METHOD(void, onStartupResult, (bool accepted, const std::string& handshakeJson), (override));
         MOCK_METHOD(void, onReenrollRequired, (), (override));
+        MOCK_METHOD(void, onTask,
+                    (const std::string& taskId, const std::string& taskType,
+                     const std::string& payloadJson),
+                    (override));
         MOCK_METHOD(void, onConfigDownloaded,
                     (const std::string& configHash, std::shared_ptr<SpoolFile> file), (override));
         MOCK_METHOD(void, onStateChange, (hc_conn_state_t state), (override));

--- a/src/client-agent/https_client/tests/unit/moduleConfig_test.cpp
+++ b/src/client-agent/https_client/tests/unit/moduleConfig_test.cpp
@@ -48,6 +48,8 @@ TEST(ModuleConfigTest, DefaultsAppliedOnZeroFields)
     EXPECT_EQ(1000u, typed.backoffBaseMs);
     EXPECT_EQ(60000u, typed.backoffCapMs);
     EXPECT_EQ(5000u, typed.drainTimeoutMs);
+    EXPECT_EQ(4096u, typed.taskDedupMax);
+    EXPECT_EQ(3600u, typed.taskDedupTtlS);
 }
 
 TEST(ModuleConfigTest, ZeroedVerifyModeIsFullFailClosed)

--- a/src/client-agent/https_client/tests/unit/outcomeClassifier_test.cpp
+++ b/src/client-agent/https_client/tests/unit/outcomeClassifier_test.cpp
@@ -13,6 +13,8 @@
 
 #include <gtest/gtest.h>
 
+#include <ostream>
+
 namespace
 {
     HttpResponse makeResponse(TransportStatus status, long code)
@@ -30,6 +32,17 @@ struct ClassifierCase
     long httpCode;
     OutcomeClass expected;
 };
+
+/// Without a printer gtest falls back to hex-dumping the raw object when it
+/// names a case, and this aggregate carries padding (4 bytes after the enum,
+/// 4 at the end, hence the 24-byte object) that no initializer writes. Reading
+/// it is what valgrind reports under the RTR. A printer removes the fallback,
+/// and a failure now names the case instead of dumping bytes.
+inline void PrintTo(const ClassifierCase& value, std::ostream* stream)
+{
+    *stream << "transport=" << static_cast<int>(value.status) << " http=" << value.httpCode
+            << " expected=" << static_cast<int>(value.expected);
+}
 
 class OutcomeClassifierTable : public ::testing::TestWithParam<ClassifierCase>
 {

--- a/src/client-agent/https_client/tests/unit/taskBatch_test.cpp
+++ b/src/client-agent/https_client/tests/unit/taskBatch_test.cpp
@@ -74,6 +74,22 @@ TEST(TaskBatchTest, SameTypeKeepsArrivalOrder)
     EXPECT_EQ((std::vector<std::string> {"ar-1", "ar-2", "ar-3"}), idsOf(plan.ordered));
 }
 
+TEST(TaskBatchTest, SameTypeIsNeverCollapsed)
+{
+    // Redundancy collapse is across types only, by design. Two active
+    // responses are two different actions (their payloads differ), so folding
+    // them would discard real work; and for two upgrades, picking a winner is
+    // a contract question rather than a planner one. The manager is expected
+    // not to send a batch like this, but if it does, both are dispatched.
+    auto responses = planTaskBatch({task("ar-1", "active_response"), task("ar-2", "active_response")});
+    EXPECT_TRUE(responses.dropped.empty());
+    EXPECT_EQ((std::vector<std::string> {"ar-1", "ar-2"}), idsOf(responses.ordered));
+
+    auto upgrades = planTaskBatch({task("up-1", "remote_upgrade"), task("up-2", "remote_upgrade")});
+    EXPECT_TRUE(upgrades.dropped.empty());
+    EXPECT_EQ((std::vector<std::string> {"up-1", "up-2"}), idsOf(upgrades.ordered));
+}
+
 TEST(TaskBatchTest, UpgradeSubsumesRestart)
 {
     auto plan = planTaskBatch({task("t1", "agent_restart"), task("t2", "remote_upgrade")});

--- a/src/client-agent/https_client/tests/unit/taskBatch_test.cpp
+++ b/src/client-agent/https_client/tests/unit/taskBatch_test.cpp
@@ -1,0 +1,153 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 21, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "taskBatch.hpp"
+
+#include <gtest/gtest.h>
+
+namespace
+{
+    NotifyTask task(const std::string& id, const std::string& type)
+    {
+        return {id, type, "{}"};
+    }
+
+    std::vector<std::string> typesOf(const std::vector<NotifyTask>& tasks)
+    {
+        std::vector<std::string> types;
+
+        for (const auto& entry : tasks)
+        {
+            types.push_back(entry.type);
+        }
+
+        return types;
+    }
+
+    std::vector<std::string> idsOf(const std::vector<NotifyTask>& tasks)
+    {
+        std::vector<std::string> ids;
+
+        for (const auto& entry : tasks)
+        {
+            ids.push_back(entry.id);
+        }
+
+        return ids;
+    }
+} // namespace
+
+TEST(TaskBatchTest, AllFourTypesShuffledComeOutInCanonicalOrder)
+{
+    // Terminal-last over the four contract types: quick work first, then the
+    // tasks that end the process. No upgrade/restart interplay here beyond
+    // the reload subsumption, so use distinct batches.
+    auto plan = planTaskBatch({task("t1", "agent_restart"), task("t2", "active_response"),
+                               task("t3", "remote_upgrade"), task("t4", "agent_reload")});
+    // upgrade present: restart and reload are covered.
+    EXPECT_EQ((std::vector<std::string> {"active_response", "remote_upgrade"}),
+              typesOf(plan.ordered));
+    ASSERT_EQ(2u, plan.dropped.size());
+}
+
+TEST(TaskBatchTest, FullOrderWithoutSubsumers)
+{
+    // Without upgrade/restart present, reload survives and slots into rank.
+    auto plan = planTaskBatch({task("t1", "agent_reload"), task("t2", "active_response")});
+    EXPECT_EQ((std::vector<std::string> {"active_response", "agent_reload"}),
+              typesOf(plan.ordered));
+    EXPECT_TRUE(plan.dropped.empty());
+}
+
+TEST(TaskBatchTest, SameTypeKeepsArrivalOrder)
+{
+    auto plan = planTaskBatch({task("ar-1", "active_response"), task("ar-2", "active_response"),
+                               task("ar-3", "active_response")});
+    EXPECT_EQ((std::vector<std::string> {"ar-1", "ar-2", "ar-3"}), idsOf(plan.ordered));
+}
+
+TEST(TaskBatchTest, UpgradeSubsumesRestart)
+{
+    auto plan = planTaskBatch({task("t1", "agent_restart"), task("t2", "remote_upgrade")});
+    EXPECT_EQ((std::vector<std::string> {"remote_upgrade"}), typesOf(plan.ordered));
+    ASSERT_EQ(1u, plan.dropped.size());
+    EXPECT_EQ("agent_restart", plan.dropped[0].first.type);
+    EXPECT_EQ("remote_upgrade", plan.dropped[0].second);
+}
+
+TEST(TaskBatchTest, RestartSubsumesReload)
+{
+    auto plan = planTaskBatch({task("t1", "agent_reload"), task("t2", "agent_restart")});
+    EXPECT_EQ((std::vector<std::string> {"agent_restart"}), typesOf(plan.ordered));
+    ASSERT_EQ(1u, plan.dropped.size());
+    EXPECT_EQ("agent_reload", plan.dropped[0].first.type);
+    EXPECT_EQ("agent_restart", plan.dropped[0].second);
+}
+
+TEST(TaskBatchTest, PresenceIsEvaluatedPreDrop)
+{
+    // The restart is itself dropped by the upgrade, but it was present in the
+    // delivered batch, so the reload is still covered (attributed to the
+    // upgrade, the stronger subsumer).
+    auto plan = planTaskBatch({task("t1", "agent_reload"), task("t2", "agent_restart"),
+                               task("t3", "remote_upgrade")});
+    EXPECT_EQ((std::vector<std::string> {"remote_upgrade"}), typesOf(plan.ordered));
+    ASSERT_EQ(2u, plan.dropped.size());
+    EXPECT_EQ("agent_reload", plan.dropped[0].first.type);
+    EXPECT_EQ("remote_upgrade", plan.dropped[0].second);
+    EXPECT_EQ("agent_restart", plan.dropped[1].first.type);
+    EXPECT_EQ("remote_upgrade", plan.dropped[1].second);
+}
+
+TEST(TaskBatchTest, TheUserScenarioRestartPlusUpgrade)
+{
+    // "If there's a restart and an upgrade, just the upgrade would do."
+    auto plan = planTaskBatch({task("t1", "active_response"), task("t2", "agent_restart"),
+                               task("t3", "remote_upgrade")});
+    EXPECT_EQ((std::vector<std::string> {"active_response", "remote_upgrade"}),
+              typesOf(plan.ordered));
+    ASSERT_EQ(1u, plan.dropped.size());
+    EXPECT_EQ("agent_restart", plan.dropped[0].first.type);
+}
+
+TEST(TaskBatchTest, LegacyReconnectAndInfoRequestRankLastAndStillDispatch)
+{
+    // Removed from the contract (#37733 2026-07-21): they are unknown types
+    // now -- tolerated, dispatched last in arrival order, never subsumed.
+    auto plan = planTaskBatch({task("t1", "agent_reconnect"), task("t2", "info_request"),
+                               task("t3", "active_response"), task("t4", "remote_upgrade")});
+    EXPECT_EQ((std::vector<std::string> {"active_response", "remote_upgrade",
+                                         "agent_reconnect", "info_request"
+                                        }),
+              typesOf(plan.ordered));
+    EXPECT_TRUE(plan.dropped.empty());
+}
+
+TEST(TaskBatchTest, UnknownTypesRankLastInArrivalOrderAndNeverInteract)
+{
+    // Forward compatibility: an unknown type is dispatched (the consumer
+    // decides what to do), after everything known, and no subsumption rule
+    // touches it.
+    auto plan = planTaskBatch({task("t1", "future_thing"), task("t2", "another_future"),
+                               task("t3", "active_response"), task("t4", "remote_upgrade")});
+    EXPECT_EQ((std::vector<std::string> {"active_response", "remote_upgrade", "future_thing",
+                                         "another_future"
+                                        }),
+              typesOf(plan.ordered));
+    EXPECT_TRUE(plan.dropped.empty());
+}
+
+TEST(TaskBatchTest, EmptyBatchYieldsEmptyPlan)
+{
+    const auto plan = planTaskBatch({});
+    EXPECT_TRUE(plan.ordered.empty());
+    EXPECT_TRUE(plan.dropped.empty());
+}

--- a/src/client-agent/https_client/tests/unit/taskDeduper_test.cpp
+++ b/src/client-agent/https_client/tests/unit/taskDeduper_test.cpp
@@ -1,0 +1,95 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 17, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "taskDeduper.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+namespace
+{
+    // A fixed "now" for the tests that do not exercise the TTL; a long default
+    // TTL keeps every id live.
+    const std::chrono::steady_clock::time_point T0 {};
+}
+
+TEST(TaskDeduperTest, NewIdsAreAcceptedOnce)
+{
+    TaskDeduper deduper;
+    EXPECT_TRUE(deduper.markIfNew("task-1", T0));
+    EXPECT_FALSE(deduper.markIfNew("task-1", T0)); // Duplicate.
+    EXPECT_TRUE(deduper.markIfNew("task-2", T0));
+}
+
+TEST(TaskDeduperTest, RecentIdsStayDeduped)
+{
+    TaskDeduper deduper {3};
+    EXPECT_TRUE(deduper.markIfNew("a", T0));
+    EXPECT_TRUE(deduper.markIfNew("b", T0));
+    EXPECT_TRUE(deduper.markIfNew("c", T0));
+    // All three still within capacity and TTL: every repeat is a duplicate.
+    EXPECT_FALSE(deduper.markIfNew("a", T0));
+    EXPECT_FALSE(deduper.markIfNew("b", T0));
+    EXPECT_FALSE(deduper.markIfNew("c", T0));
+}
+
+TEST(TaskDeduperTest, LruEvictionAllowsReDeliveryAfterAgingOut)
+{
+    TaskDeduper deduper {2}; // Capacity 2; oldest ages out first.
+    EXPECT_TRUE(deduper.markIfNew("a", T0));
+    EXPECT_TRUE(deduper.markIfNew("b", T0));
+    // "c" evicts the oldest ("a"); remembered set is now {b, c}.
+    EXPECT_TRUE(deduper.markIfNew("c", T0));
+    EXPECT_FALSE(deduper.markIfNew("c", T0)); // Still a duplicate.
+    // "a" aged out, so a re-delivery is accepted again (at-least-once); this
+    // in turn evicts "b".
+    EXPECT_TRUE(deduper.markIfNew("a", T0));
+    EXPECT_TRUE(deduper.markIfNew("b", T0));
+}
+
+TEST(TaskDeduperTest, ZeroCapacityIsClampedToOne)
+{
+    TaskDeduper deduper {0};
+    EXPECT_TRUE(deduper.markIfNew("only", T0));
+    EXPECT_FALSE(deduper.markIfNew("only", T0));
+}
+
+TEST(TaskDeduperTest, ExpiredIdIsAcceptedAgainAfterTtl)
+{
+    TaskDeduper deduper {4096, std::chrono::seconds {60}};
+    EXPECT_TRUE(deduper.markIfNew("t", T0));
+    EXPECT_FALSE(deduper.markIfNew("t", T0 + std::chrono::seconds {59})); // Within TTL.
+    // At/after the TTL the id has expired: a re-delivery is accepted.
+    EXPECT_TRUE(deduper.markIfNew("t", T0 + std::chrono::seconds {60}));
+}
+
+TEST(TaskDeduperTest, PruneEvictsOnlyTheExpiredPrefix)
+{
+    TaskDeduper deduper {4096, std::chrono::seconds {100}};
+    deduper.markIfNew("old", T0);
+    deduper.markIfNew("mid", T0 + std::chrono::seconds {50});
+    // At t=120 "old" (age 120) has expired but "mid" (age 70) has not: "old"
+    // is re-acceptable, "mid" is still a duplicate.
+    const auto later = T0 + std::chrono::seconds {120};
+    EXPECT_FALSE(deduper.markIfNew("mid", later));
+    EXPECT_TRUE(deduper.markIfNew("old", later));
+}
+
+TEST(TaskDeduperTest, CapacityStillEnforcedWithinTheTtl)
+{
+    TaskDeduper deduper {2, std::chrono::seconds {3600}};
+    EXPECT_TRUE(deduper.markIfNew("a", T0));
+    EXPECT_TRUE(deduper.markIfNew("b", T0));
+    EXPECT_TRUE(deduper.markIfNew("c", T0)); // Evicts "a" by capacity, not TTL.
+    EXPECT_TRUE(deduper.markIfNew("a", T0));  // "a" was evicted: accepted again.
+    EXPECT_FALSE(deduper.markIfNew("c", T0)); // "c" still remembered.
+}

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -222,6 +222,40 @@ static void bridge_on_task(const char *task_id, const char *task_type, const cha
             task_type ? task_type : "?");
 }
 
+/* The startup hash gate (client-agent/src/startup_gate.c) holds syscheckd and
+ * the other modules until the manager-validated configuration is in place. Its
+ * only feed was the legacy TCP handshake (start_agent.c calls
+ * startup_gate_process_handshake with the merged_sum the manager pushes there),
+ * so an agent whose transport is HTTPS never got an expected hash and the gate
+ * stayed at "waiting_handshake" forever, blocking module startup on Linux and
+ * Windows alike.
+ *
+ * The module reports the manager's hash on every Notify, matching or not, which
+ * covers both cases through the gate's existing logic: an agent already in sync
+ * releases immediately on the hash match, and one that diverges keeps waiting
+ * until /download lands the new configuration and the apply path refreshes it. */
+static void bridge_on_manager_config_hash(const char *config_hash, void *user_data)
+{
+    (void)user_data;
+
+    /* Only an MD5-shaped hash may reach the gate. It validates against
+     * getsharedfiles(), which is OS_MD5_File over merged.mg, and it reacts to
+     * anything else by latching itself blocked on "invalid_handshake_hash",
+     * which its own comment says needs an agentd restart to clear. The module
+     * verifies downloaded configs with sha256 instead, so until the manager
+     * side settles which digest /control reports (no endpoint exists yet), a
+     * mismatched shape must leave the gate exactly as it was rather than
+     * wedge it. */
+    if (config_hash == NULL || strlen(config_hash) != 32) {
+        mdebug2("https_client: manager config hash '%s' is not the MD5 shape the startup "
+                "gate validates; leaving the gate untouched.",
+                config_hash && config_hash[0] ? config_hash : "(none)");
+        return;
+    }
+
+    startup_gate_process_handshake(true, config_hash);
+}
+
 static void bridge_on_config_downloaded(const char *config_hash, const char *file_path,
                                         void *user_data)
 {
@@ -234,6 +268,11 @@ static void bridge_on_config_downloaded(const char *config_hash, const char *fil
     (void)user_data;
     mdebug1("https_client config downloaded (hash=%s, file=%s)",
             config_hash ? config_hash : "?", file_path ? file_path : "?");
+
+    /* Re-check the gate once the configuration has been applied. Harmless
+     * today, when the apply chain above is still a scaffold and the local hash
+     * has not moved: the gate simply stays blocked until it has. */
+    startup_gate_refresh_from_local_hash();
 }
 
 static void bridge_on_state_change(int state, void *user_data)
@@ -433,6 +472,7 @@ void w_https_client_start(void)
     callbacks.on_startup_result = bridge_on_startup_result;
     callbacks.on_reenroll_required = bridge_on_reenroll_required;
     callbacks.on_task = bridge_on_task;
+    callbacks.on_manager_config_hash = bridge_on_manager_config_hash;
     callbacks.on_config_downloaded = bridge_on_config_downloaded;
     callbacks.on_state_change = bridge_on_state_change;
     callbacks.on_buffer_level = bridge_on_buffer_level;

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -349,7 +349,12 @@ static bool bridge_build_config(hc_config_t *config)
     }
 
     const char *raw_key = (keys.keyentries && keys.keyentries[0]) ? keys.keyentries[0]->raw_key : NULL;
-    if (!bridge_key_is_valid(raw_key)) {
+    /* The NULL test is redundant with bridge_key_is_valid()'s own, and is here
+     * so it is visible at the point of use: the static analyzer does not inline
+     * the validator (its hex loop exhausts the inlining budget), so without a
+     * local test it explores a path where the key is NULL and reports the
+     * strncpy() below, plus the keys.keyentries[0]->id read above it. */
+    if (raw_key == NULL || !bridge_key_is_valid(raw_key)) {
         merror("https_client: agent key is missing or has an invalid length for AES-CMAC "
                "(expected 32, 48 or 64 hex characters); refusing to start.");
         return false;

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -213,6 +213,15 @@ static agent_status_t bridge_map_agent_status(int hc_state)
     }
 }
 
+static void bridge_on_task(const char *task_id, const char *task_type, const char *payload_json,
+                           void *user_data)
+{
+    (void)payload_json;
+    (void)user_data;
+    mdebug1("https_client task received: id=%s type=%s", task_id ? task_id : "?",
+            task_type ? task_type : "?");
+}
+
 static void bridge_on_config_downloaded(const char *config_hash, const char *file_path,
                                         void *user_data)
 {
@@ -418,6 +427,7 @@ void w_https_client_start(void)
     callbacks.log = mtLoggingFunctionsWrapper;
     callbacks.on_startup_result = bridge_on_startup_result;
     callbacks.on_reenroll_required = bridge_on_reenroll_required;
+    callbacks.on_task = bridge_on_task;
     callbacks.on_config_downloaded = bridge_on_config_downloaded;
     callbacks.on_state_change = bridge_on_state_change;
     callbacks.on_buffer_level = bridge_on_buffer_level;

--- a/src/unit_tests/config/CMakeLists.txt
+++ b/src/unit_tests/config/CMakeLists.txt
@@ -38,7 +38,13 @@ list(APPEND config_flags "-Wl,--wrap,OS_GetHost -Wl,--wrap=Start_win32_Syscheck 
                           -Wl,--wrap=fim_db_teardown -Wl,--wrap,w_query_agentd ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND config_names "test_client-config_https")
-list(APPEND config_flags "-Wl,--wrap,OS_IsValidIP ${DEBUG_OP_WRAPPERS}")
+# The syscheck/dbsync wraps mirror the sibling test above: on winagent this
+# binary pulls win_utils.obj and win_service.obj out of DEPENDENCIES_O, and
+# they reference symbols that live in the syscheckd DLL the tests do not link.
+list(APPEND config_flags "-Wl,--wrap,OS_IsValidIP -Wl,--wrap=Start_win32_Syscheck \
+                          -Wl,--wrap,syscom_dispatch -Wl,--wrap=is_fim_shutdown \
+                          -Wl,--wrap=_imp__dbsync_initialize -Wl,--wrap=fim_db_teardown \
+                          -Wl,--wrap,w_query_agentd ${DEBUG_OP_WRAPPERS}")
 
 if(${TARGET} STREQUAL "manager")
     list(APPEND config_names "test_indexer")

--- a/src/unit_tests/winagent.cmake
+++ b/src/unit_tests/winagent.cmake
@@ -70,7 +70,14 @@ file(GLOB win32_files
   ${SRC_FOLDER}/build/win32/CMakeFiles/win32_common.dir/win_utils.c.obj)
 list(APPEND obj_files ${win32_files})
 
-add_library(DEPENDENCIES_O STATIC ${obj_files})
+# client_agent_lib above carries https_client_bridge.obj, whose hc_* references
+# resolve against libhttps_client, a DLL no unit test links. Every winagent test
+# links DEPENDENCIES_O, so without these stubs the whole winagent unit-test build
+# fails, syscheckd and the rest included. The other targets get the same file
+# through the CLIENT-AGENT library, which winagent deliberately does not build
+# (it would duplicate globals such as agent_state).
+add_library(DEPENDENCIES_O STATIC ${obj_files}
+            ${SRC_FOLDER}/unit_tests/client-agent/https_client_stubs.c)
 set_source_files_properties(
   ${obj_files}
   PROPERTIES


### PR DESCRIPTION
Part of #37833.

**Stack (4/7)** — based on #37853 (/download). Only the last commit is this PR's.

The notify response's task array becomes agent work. Four fire-and-forget types (#37733: no response leg, nothing reported back): `active_response`, `agent_reload`, `remote_upgrade`, `agent_restart`.

- **Per-batch planning**: dispatch ordered by priority (AR first, terminal actions last); redundancy collapsed — an upgrade covers a restart and a reload, a restart covers a reload — with a log line per drop. Unknown types rank last but still dispatch (forward compatibility).
- **Interim dedup**: an in-memory registry of seen task_ids with configurable bounds (`task_dedup_max`, default 4096, FIFO eviction; `task_dedup_ttl_s`, default 3600). Dedup runs **before** planning so a task dropped as redundant is still marked seen and its at-least-once redelivery stays dropped.
- This registry is explicitly interim (TODO #37833 in the code): the durable agent-info task_id table replaces it so dedup survives restarts — the manager no longer dedups cluster-wide, making the agent's registry the sole guarantee against double execution.
- Tasks reach the consumer through the new `on_task` callback, serialized on the dispatcher thread; payloads cross opaquely.

Verification: 185 unit + 14 component; the demo shows a deliberately shuffled 4-type batch dispatched AR → upgrade with restart+reload dropped.



---

### Additionally fixed here

**The startup hash gate no longer blocks module startup over HTTPS.** `syscheckd` and the other modules
wait on `startup_gate_wait_for_ready()`, and the gate's only feed was the legacy TCP handshake:
`start_agent.c` hands it the `merged_sum` the manager pushes on that channel. An agent whose transport is
HTTPS never received an expected hash, so the gate stayed at `waiting_handshake` and module startup hung on
Linux and Windows alike.

The module already knew the manager's config hash on every Notify but only surfaced it when a download
happened, which is precisely the case that does *not* occur when the agent is already in sync. It is now
reported every time through a new `on_manager_config_hash` callback, and the gate's existing logic handles
both paths: a matching hash releases it immediately, a diverging one records what it is waiting for until
`/download` lands the configuration.

One guard worth calling out: the bridge only forwards an **MD5-shaped** hash. The gate validates against
`getsharedfiles()` (`OS_MD5_File` over `merged.mg`) and latches itself blocked on `invalid_handshake_hash`
for anything else, which its own comment says needs an agentd restart to clear. The module verifies
downloaded configs with `sha256FileHex`, and no manager `/control` endpoint exists yet to settle which
digest it will report, so anything that is not 32 hex characters leaves the gate untouched rather than
wedging it. That inconsistency between the MD5 seed and the sha256 verification is pre-existing and worth
resolving once the manager contract is real.

**Also fixed while getting CI green** (all pre-existing, none introduced by this PR): the winagent `hc_*`
link break, moved into `DEPENDENCIES_O` so every winagent test resolves it including syscheckd's; the
`test_client-config_https` syscheck wraps; the `libhttps_client.so` size drift; a scan-build null-pointer
report; and two valgrind findings — the `ClassifierCase` raw-byte dump and the component-test deadlines,
which were failing under valgrind and skipping `hc_destroy`, producing the "definitely lost" blocks.

Verification on this head: 243 unit + 17 component; `test_https_client_bridge` 27, `test_startup_gate` 15,
`test_agentd` 15, `test_client-config_https` 18. astyle 3.1 and cppcheck 2.20 clean.
