### PR TITLE
Agent periodic /stats and /config push

### DIFF
--- a/src/client-agent/https_client/demo/demo_driver.c
+++ b/src/client-agent/https_client/demo/demo_driver.c
@@ -167,6 +167,25 @@ static void nap(int ms)
     nanosleep(&t, NULL);
 }
 
+/* Reporter collectors (#37843): run on the module's reporter thread, return a
+ * malloc'd JSON object the module owns (frees) after stamping identity. A real
+ * agent aggregates every module's stats/config here. */
+static char *collect_stats(void *user_data)
+{
+    (void)user_data;
+    printf("[+%7ld ms] >> COLLECT stats\n", elapsed_ms());
+    fflush(stdout);
+    return strdup("{\"uptime\":86400,\"events_received\":12543,\"queue_usage\":15.2}");
+}
+
+static char *collect_config(void *user_data)
+{
+    (void)user_data;
+    printf("[+%7ld ms] >> COLLECT config\n", elapsed_ms());
+    fflush(stdout);
+    return strdup("{\"client\":{\"notify_time\":2,\"config-profile\":\"demo\"}}");
+}
+
 /* Deterministic hex filler (xorshift-style) for the fake file hashes. */
 static void fake_hex(char *dst, size_t hex_chars, uint64_t seed)
 {
@@ -247,6 +266,10 @@ int main(int argc, char **argv)
     config.request_timeout_ms = 10000;   /* a multi-MB /stateful takes a moment */
     config.backoff_base_ms = 200;
     config.backoff_cap_ms = 2000;
+    config.stats_enabled = true;          /* push /stats every few seconds     */
+    config.stats_interval_s = 3;
+    config.config_report_enabled = true;  /* push /config on its own cadence    */
+    config.config_report_interval_s = 5;
     strncpy(config.version, "5.1.0", sizeof config.version - 1);
     /* SHA-256 of the empty merged.mg the mock starts with: in sync at boot,
      * so the scripted config flip is a real transition. */
@@ -268,6 +291,8 @@ int main(int argc, char **argv)
     callbacks.on_sync_response = on_sync_response;
     callbacks.on_state_change = on_state_change;
     callbacks.on_buffer_level = on_buffer_level;
+    callbacks.collect_stats = collect_stats;
+    callbacks.collect_config = collect_config;
 
     printf("== creating + starting the https_client (target %s:%s) ==\n", argv[1], argv[2]);
     hc_handle *handle = hc_create(&config, &callbacks);

--- a/src/client-agent/https_client/demo/mock_manager.py
+++ b/src/client-agent/https_client/demo/mock_manager.py
@@ -183,6 +183,8 @@ class Handler(BaseHTTPRequestHandler):
             self._handle_stateful(body)
         elif target == "/download":
             self._handle_download(body)
+        elif target in ("/stats", "/config"):
+            self._handle_report(target, body)
         else:
             self._reply(404)
 
@@ -273,6 +275,18 @@ class Handler(BaseHTTPRequestHandler):
         events = body.count(b"\nE ") + (1 if b"\nE " not in body and b"E " in body else 0)
         self._reply(200)  # 200 with an empty body per #37732
         log(f"     /stateless  -> 200  ({len(body)} B, ~{events} events accepted)")
+
+    def _handle_report(self, target, body):
+        # /stats and /config (#37843): the agent pushes a full snapshot the
+        # module stamped with agent_id + cluster; the manager stores it.
+        try:
+            doc = json.loads(body.decode())
+        except (ValueError, UnicodeDecodeError):
+            doc = {}
+        self._reply(200, {})
+        cluster = doc.get("cluster", {})
+        log(f"     {target:<11} -> 200  stored: agent_id={doc.get('agent_id')} "
+            f"cluster={cluster.get('name')}/{cluster.get('node')} keys={sorted(doc.keys())}")
 
     def _handle_stateful(self, body):
         session = self.headers.get("X-Session-Id", "?")

--- a/src/client-agent/https_client/demo/mock_manager.py
+++ b/src/client-agent/https_client/demo/mock_manager.py
@@ -84,13 +84,34 @@ class Handler(BaseHTTPRequestHandler):
 
     # Exact startup-response bytes, kept verbatim: settings_hash is the SHA256
     # of precisely what goes on the wire (#37733 5.1.1).
+    #
+    # Every field the bridge's parser marks required has to be here: it takes
+    # the limits all-or-nothing, and a partial block is silently discarded.
+    # syscheckd then waits on limits that never arrive (fim_initialize()'s
+    # fetch_document_limits_from_agentd() loop) and never finishes starting.
     STARTUP_V1 = json.dumps(
-        {"limits": {"fim": {"file": 100000}, "syscollector": {"packages": 50000},
+        {"limits": {"fim": {"file": 100000, "registry_key": 100000,
+                            "registry_value": 100000},
+                    "syscollector": {"hotfixes": 10000, "packages": 50000,
+                                     "processes": 10000, "ports": 10000,
+                                     "network_iface": 10000, "network_protocol": 10000,
+                                     "network_address": 10000, "hardware": 10000,
+                                     "os_info": 10000, "users": 10000,
+                                     "groups": 10000, "services": 10000,
+                                     "browser_extensions": 10000},
                     "sca": {"checks": 10000}},
          "cluster": {"name": "demo", "node": "node01"},
          "agent": {"groups": ["default"]}}).encode()
     STARTUP_V2 = json.dumps(
-        {"limits": {"fim": {"file": 200000}, "syscollector": {"packages": 50000},
+        {"limits": {"fim": {"file": 200000, "registry_key": 100000,
+                            "registry_value": 100000},
+                    "syscollector": {"hotfixes": 10000, "packages": 50000,
+                                     "processes": 10000, "ports": 10000,
+                                     "network_iface": 10000, "network_protocol": 10000,
+                                     "network_address": 10000, "hardware": 10000,
+                                     "os_info": 10000, "users": 10000,
+                                     "groups": 10000, "services": 10000,
+                                     "browser_extensions": 10000},
                     "sca": {"checks": 20000}},
          "cluster": {"name": "demo", "node": "node01"},
          "agent": {"groups": ["default"]}}).encode()

--- a/src/client-agent/https_client/include/https_client.h
+++ b/src/client-agent/https_client/include/https_client.h
@@ -159,6 +159,15 @@ typedef struct hc_config_t
     /// Local STREAM socket for the stateful sync intake (large sessions bypass
     /// the 64 KB DGRAM event queue). Empty -> the intake is not started.
     char sync_socket_path[HC_MAX_PATH];
+
+    /// Periodic reporters (#37843), both OFF by default. When on, the module
+    /// collects the corresponding snapshot on its interval, stamps agent_id +
+    /// the manager-authoritative cluster, signs and POSTs to /stats resp.
+    /// /config.
+    bool stats_enabled;
+    uint32_t stats_interval_s;         ///< 0 -> 60.
+    bool config_report_enabled;
+    uint32_t config_report_interval_s; ///< 0 -> 3600.
 } hc_config_t;
 
 /**
@@ -242,6 +251,17 @@ typedef struct hc_callbacks_t
                              size_t body_len, void* user_data);
     void (*on_state_change)(int state, void* user_data);  ///< hc_conn_state_t
     void (*on_buffer_level)(int level, void* user_data);  ///< hc_buffer_level_t
+    /// Periodic collectors for the /stats and /config reporters (#37843).
+    /// Unlike every other callback these run on the module's REPORTER thread
+    /// (not the dispatcher): they must return promptly and must NOT call hc_*
+    /// functions. Return either NULL (skip this cycle) or a NUL-terminated
+    /// JSON OBJECT allocated with malloc() from the module's C runtime; the
+    /// module takes ownership and frees it. Before sending, the module stamps
+    /// "agent_id" and the manager-authoritative "cluster" {"name","node"} into
+    /// the object (overwriting same-named members). A non-object return is
+    /// logged and the cycle skipped.
+    char* (*collect_stats)(void* user_data);
+    char* (*collect_config)(void* user_data);
     void* user_data;
 } hc_callbacks_t;
 

--- a/src/client-agent/https_client/src/collectorSource.hpp
+++ b/src/client-agent/https_client/src/collectorSource.hpp
@@ -1,0 +1,79 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 21, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _HC_COLLECTOR_SOURCE_HPP
+#define _HC_COLLECTOR_SOURCE_HPP
+
+#include "https_client.h"
+
+#include <cstdlib>
+#include <optional>
+#include <string>
+
+/**
+ * @brief Where the reporter pulls the /stats and /config snapshots. Injected
+ *        so the reporter can be unit-tested without C callbacks.
+ */
+class ICollectorSource
+{
+    public:
+        virtual ~ICollectorSource() = default;
+        virtual std::optional<std::string> collectStats() = 0;
+        virtual std::optional<std::string> collectConfig() = 0;
+};
+
+/**
+ * @brief Production source: calls the C collect_* callbacks directly (NOT via
+ *        the dispatcher — they return a value synchronously) and adopts the
+ *        malloc'd string they return, freeing it after copying.
+ */
+class CallbackCollectorSource final : public ICollectorSource
+{
+    public:
+        explicit CallbackCollectorSource(const hc_callbacks_t& callbacks)
+            : m_callbacks(callbacks)
+        {
+        }
+
+        std::optional<std::string> collectStats() override
+        {
+            return invoke(m_callbacks.collect_stats);
+        }
+
+        std::optional<std::string> collectConfig() override
+        {
+            return invoke(m_callbacks.collect_config);
+        }
+
+    private:
+        std::optional<std::string> invoke(char* (*collector)(void*)) const
+        {
+            if (collector == nullptr)
+            {
+                return std::nullopt;
+            }
+
+            char* raw = collector(m_callbacks.user_data);
+
+            if (raw == nullptr)
+            {
+                return std::nullopt; // The collector chose to skip this cycle.
+            }
+
+            std::string document {raw};
+            std::free(raw); // Module owns the buffer; free after copying.
+            return document;
+        }
+
+        hc_callbacks_t m_callbacks;
+};
+
+#endif // _HC_COLLECTOR_SOURCE_HPP

--- a/src/client-agent/https_client/src/httpsClientFacade.cpp
+++ b/src/client-agent/https_client/src/httpsClientFacade.cpp
@@ -22,11 +22,14 @@ HttpsClientFacade::HttpsClientFacade(const hc_config_t& config, const hc_callbac
     , m_dispatcher(callbacks)
     , m_configHash(m_config.configChecksum)
     , m_taskStore(callbacks.check_and_record_task, callbacks.user_data)
+    , m_collectors(callbacks)
     , m_stateless(m_config, m_performer, m_signer, m_clock, m_random, m_dispatcher, m_authGate)
     , m_stateful(m_config, m_performer, m_signer, m_clock, m_random, m_spoolFactory, m_dispatcher,
                  m_authGate)
     , m_control(m_config, m_performer, m_signer, m_clock, m_random, m_dispatcher, m_spoolFactory,
                 m_configHash, m_cluster, m_authGate, m_taskStore)
+    , m_reporter(m_config, m_performer, m_signer, m_clock, m_random, m_authGate, m_cluster,
+                 m_collectors)
 {
 }
 
@@ -70,6 +73,12 @@ bool HttpsClientFacade::start()
     m_controlThread = std::thread(&HttpsClientFacade::controlLoop, this);
     m_statelessThread = std::thread(&HttpsClientFacade::statelessLoop, this);
     m_statefulThread = std::thread(&HttpsClientFacade::statefulLoop, this);
+
+    if (m_reporter.anyEnabled())
+    {
+        m_reporterThread = std::thread(&HttpsClientFacade::reporterLoop, this);
+    }
+
     startSyncIntake();
     return true;
 }
@@ -144,6 +153,7 @@ void HttpsClientFacade::stop()
     m_controlWaiter.requestStop();
     m_statelessWaiter.requestStop();
     m_statefulWaiter.requestStop();
+    m_reporterWaiter.requestStop();
     m_gate.abort();
 
     if (m_controlThread.joinable())
@@ -165,6 +175,11 @@ void HttpsClientFacade::stop()
     if (m_statefulThread.joinable())
     {
         m_statefulThread.join();
+    }
+
+    if (m_reporterThread.joinable())
+    {
+        m_reporterThread.join(); // Joined before drain: the drain skips the reporter.
     }
 
     drain(); // Best-effort final flush + final shutdown message, from this thread.
@@ -227,6 +242,24 @@ void HttpsClientFacade::statefulLoop()
         }
 
         if (!m_statefulWaiter.waitFor(std::chrono::milliseconds {m_config.batchIntervalMs}))
+        {
+            break;
+        }
+    }
+}
+
+void HttpsClientFacade::reporterLoop()
+{
+    if (!m_gate.wait())
+    {
+        return; // Aborted before registration.
+    }
+
+    while (true)
+    {
+        const auto delay = m_reporter.tick(m_reporterWaiter, m_control.isRegistered());
+
+        if (!m_reporterWaiter.waitFor(delay))
         {
             break;
         }

--- a/src/client-agent/https_client/src/httpsClientFacade.hpp
+++ b/src/client-agent/https_client/src/httpsClientFacade.hpp
@@ -16,8 +16,10 @@
 #include "callbackDispatcher.hpp"
 #include "clusterIdentity.hpp"
 #include "cmacSigner.hpp"
+#include "collectorSource.hpp"
 #include "configHashState.hpp"
 #include "controlStream.hpp"
+#include "reporterStream.hpp"
 #include "curlPerformer.hpp"
 #include "https_client.h"
 #include "keyProvider.hpp"
@@ -74,6 +76,7 @@ class HttpsClientFacade final
         void controlLoop();
         void statelessLoop();
         void statefulLoop();
+        void reporterLoop();
         void startSyncIntake();
         void drain();
         std::chrono::milliseconds controlInterval() const;
@@ -98,9 +101,11 @@ class HttpsClientFacade final
         // below) is safe.
         AuthGate m_authGate {m_dispatcher, [this] { m_controlWaiter.notify(); }};
 
+        CallbackCollectorSource m_collectors;
         StatelessStream m_stateless;
         StatefulStream m_stateful;
         ControlStream m_control;
+        ReporterStream m_reporter;
 
         // One waiter per stream thread; the stop flag doubles as the abort flag.
         Waiter m_controlWaiter;
@@ -109,9 +114,12 @@ class HttpsClientFacade final
         Waiter m_drainWaiter; ///< Fresh (never stopped) so the final drain can run.
         RegistrationGate m_gate;
 
+        Waiter m_reporterWaiter;
+
         std::thread m_controlThread;
         std::thread m_statelessThread;
         std::thread m_statefulThread;
+        std::thread m_reporterThread;
 
         // Optional stateful sync intake (large sessions off a local STREAM
         // socket). Constructed only when a socket path is configured; its sink

--- a/src/client-agent/https_client/src/moduleConfig.cpp
+++ b/src/client-agent/https_client/src/moduleConfig.cpp
@@ -50,6 +50,10 @@ ModuleConfig ModuleConfig::fromC(const hc_config_t& config)
     typed.notifyIntervalS = orDefault<uint32_t>(config.notify_interval_s, 20);
     typed.rejectedRetryIntervalS = orDefault<uint32_t>(config.rejected_retry_interval_s, 60);
     typed.wpkMaxDownloadBytes = orDefault<uint64_t>(config.wpk_max_download_bytes, 200ULL * 1024 * 1024);
+    typed.statsEnabled = config.stats_enabled;
+    typed.statsIntervalS = orDefault<uint32_t>(config.stats_interval_s, 60);
+    typed.configReportEnabled = config.config_report_enabled;
+    typed.configReportIntervalS = orDefault<uint32_t>(config.config_report_interval_s, 3600);
     typed.version = boundedString(config.version, sizeof(config.version));
     typed.configChecksum = boundedString(config.config_checksum, sizeof(config.config_checksum));
     typed.requestTimeoutMs = orDefault<uint32_t>(config.request_timeout_ms, 10000);

--- a/src/client-agent/https_client/src/moduleConfig.hpp
+++ b/src/client-agent/https_client/src/moduleConfig.hpp
@@ -66,6 +66,12 @@ struct ModuleConfig
         uint32_t drainTimeoutMs {5000};
 
         std::string spoolDir;
+
+        // #37843 periodic reporters (both off by default).
+        bool statsEnabled {false};
+        uint32_t statsIntervalS {60};
+        bool configReportEnabled {false};
+        uint32_t configReportIntervalS {3600};
         std::string syncSocketPath; ///< Stateful sync-intake STREAM socket; empty = disabled.
 
         // Always "https" in production (fromC never changes it); the component

--- a/src/client-agent/https_client/src/reporterStream.cpp
+++ b/src/client-agent/https_client/src/reporterStream.cpp
@@ -1,0 +1,166 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 21, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "reporterStream.hpp"
+
+#include "external/nlohmann/json.hpp"
+
+#include <algorithm>
+
+namespace
+{
+    // Reporters never retry in the loop: a fresh snapshot is collected next
+    // cycle, so a failed send just reschedules.
+    constexpr uint32_t REPORTER_MAX_ATTEMPTS = 1;
+    constexpr auto MIN_SLEEP = std::chrono::milliseconds
+    {
+        100
+    };
+    constexpr auto MAX_SLEEP = std::chrono::milliseconds
+    {
+        60000
+    };
+}
+
+ReporterStream::ReporterStream(const ModuleConfig& config, IHttpPerformer& performer,
+                               const ISigner& signer, IClock& clock, IRandom& random,
+                               AuthGate& authGate, ClusterIdentity& cluster,
+                               ICollectorSource& collectors)
+    : m_config(config)
+    , m_sendBackoff(config.backoffBaseMs, config.backoffCapMs, random)
+    , m_sender(performer, signer, clock, m_sendBackoff, &authGate)
+    , m_clock(clock)
+    , m_authGate(authGate)
+    , m_cluster(cluster)
+    , m_collectors(collectors)
+    , m_statsBackoff(config.backoffBaseMs, config.backoffCapMs, random)
+    , m_configBackoff(config.backoffBaseMs, config.backoffCapMs, random)
+{
+    // Set in the body (not the init list) to keep the brace-nested aggregate
+    // init from confusing astyle's indentation for the rest of the file.
+    m_stats.target = "/stats";
+    m_stats.enabled = config.statsEnabled;
+    m_stats.interval = std::chrono::seconds {config.statsIntervalS};
+    m_config_.target = "/config";
+    m_config_.enabled = config.configReportEnabled;
+    m_config_.interval = std::chrono::seconds {config.configReportIntervalS};
+}
+
+bool ReporterStream::anyEnabled() const
+{
+    return m_stats.enabled || m_config_.enabled;
+}
+
+std::chrono::milliseconds ReporterStream::tick(Waiter& waiter, bool registered)
+{
+    // Skip entirely (without advancing nextDue) when not registered or paused,
+    // so the first tick after recovery fires immediately. Poll on the batch
+    // cadence until the control loop re-registers / the gate releases.
+    if (!registered || m_authGate.paused())
+    {
+        return std::chrono::milliseconds {m_config.batchIntervalMs};
+    }
+
+    const auto now = m_clock.steadyNow();
+
+    if (m_stats.enabled && now >= m_stats.nextDue)
+    {
+        runPath(m_stats, m_statsBackoff, waiter, m_collectors.collectStats());
+    }
+
+    if (m_config_.enabled && now >= m_config_.nextDue)
+    {
+        runPath(m_config_, m_configBackoff, waiter, m_collectors.collectConfig());
+    }
+
+    return sleepHint();
+}
+
+void ReporterStream::runPath(Path& path, Backoff& backoff, Waiter& waiter,
+                             std::optional<std::string> collected)
+{
+    const auto now = m_clock.steadyNow();
+    const auto document = stampedDocument(std::move(collected));
+
+    if (!document)
+    {
+        path.nextDue = now + path.interval; // Nothing to send this cycle.
+        return;
+    }
+
+    HttpRequestSpec spec;
+    spec.target = path.target;
+    spec.body = reinterpret_cast<const uint8_t*>(document->data());
+    spec.bodyLength = document->size();
+    spec.timeoutMs = m_config.requestTimeoutMs;
+
+    const auto result = m_sender.send(spec, waiter, REPORTER_MAX_ATTEMPTS);
+
+    if (result.outcome == OutcomeClass::Ok)
+    {
+        backoff.reset();
+        path.nextDue = now + path.interval;
+    }
+    else if (result.outcome == OutcomeClass::BackPressure)
+    {
+        const auto serverDelay = std::chrono::milliseconds {result.response.retryAfterSeconds * 1000};
+        path.nextDue = now + std::max(std::chrono::duration_cast<std::chrono::milliseconds>(
+                                          serverDelay),
+                                      backoff.next());
+    }
+    else
+    {
+        // Retryable / auth-paused (the gate is engaged by RetrySender) / other:
+        // back off and try a fresh snapshot later.
+        path.nextDue = now + backoff.next();
+    }
+}
+
+std::optional<std::string> ReporterStream::stampedDocument(std::optional<std::string> collected) const
+{
+    if (!collected)
+    {
+        return std::nullopt; // The collector skipped this cycle.
+    }
+
+    auto document = nlohmann::json::parse(*collected, nullptr, false);
+
+    if (document.is_discarded() || !document.is_object())
+    {
+        LOGFN_WARN(m_logFn, "Collector returned a non-object document; skipping.");
+        return std::nullopt;
+    }
+
+    const auto cluster = m_cluster.get();
+    document["agent_id"] = m_config.agentId;
+    document["cluster"] = {{"name", cluster.name}, {"node", cluster.node}};
+    return document.dump();
+}
+
+std::chrono::milliseconds ReporterStream::sleepHint() const
+{
+    const auto now = m_clock.steadyNow();
+    auto soonest = MAX_SLEEP;
+
+    if (m_stats.enabled)
+    {
+        soonest = std::min(soonest, std::chrono::duration_cast<std::chrono::milliseconds>(
+                               m_stats.nextDue - now));
+    }
+
+    if (m_config_.enabled)
+    {
+        soonest = std::min(soonest, std::chrono::duration_cast<std::chrono::milliseconds>(
+                               m_config_.nextDue - now));
+    }
+
+    return std::clamp(soonest, MIN_SLEEP, MAX_SLEEP);
+}

--- a/src/client-agent/https_client/src/reporterStream.hpp
+++ b/src/client-agent/https_client/src/reporterStream.hpp
@@ -1,0 +1,79 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 21, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _HC_REPORTER_STREAM_HPP
+#define _HC_REPORTER_STREAM_HPP
+
+#include "authGate.hpp"
+#include "backoff.hpp"
+#include "clusterIdentity.hpp"
+#include "collectorSource.hpp"
+#include "iHttpPerformer.hpp"
+#include "moduleConfig.hpp"
+#include "moduleLog.hpp"
+#include "retrySender.hpp"
+#include "stopToken.hpp"
+#include "sysSeams.hpp"
+
+#include <chrono>
+#include <optional>
+#include <string>
+
+/**
+ * @brief The periodic /stats and /config reporter (#37843). One worker thread
+ *        drives two independent cadences: each due path collects a snapshot,
+ *        stamps agent_id + the manager-authoritative cluster, signs and POSTs.
+ *        Only runs while Registered and not auth-paused; the drain skips it.
+ */
+class ReporterStream final
+{
+    public:
+        ReporterStream(const ModuleConfig& config, IHttpPerformer& performer, const ISigner& signer,
+                       IClock& clock, IRandom& random, AuthGate& authGate, ClusterIdentity& cluster,
+                       ICollectorSource& collectors);
+
+        /// True when at least one reporter is enabled (the facade only starts
+        /// the worker then).
+        bool anyEnabled() const;
+
+        /// One iteration: run every due path when registered and not paused.
+        /// Returns the delay until the next tick should run.
+        std::chrono::milliseconds tick(Waiter& waiter, bool registered);
+
+    private:
+        struct Path
+        {
+            std::string target;
+            bool enabled {false};
+            std::chrono::seconds interval {0};
+            std::chrono::steady_clock::time_point nextDue; // epoch => due immediately.
+        };
+
+        void runPath(Path& path, Backoff& backoff, Waiter& waiter,
+                     std::optional<std::string> collected);
+        std::optional<std::string> stampedDocument(std::optional<std::string> collected) const;
+        std::chrono::milliseconds sleepHint() const;
+
+        const ModuleConfig& m_config;
+        Backoff m_sendBackoff;
+        RetrySender m_sender;
+        IClock& m_clock;
+        AuthGate& m_authGate;
+        ClusterIdentity& m_cluster;
+        ICollectorSource& m_collectors;
+        const LogFn m_logFn {HTTPS_CLIENT_LOGTAG};
+        Backoff m_statsBackoff;
+        Backoff m_configBackoff;
+        Path m_stats;
+        Path m_config_; ///< Trailing underscore: m_config is the ModuleConfig ref.
+};
+
+#endif // _HC_REPORTER_STREAM_HPP

--- a/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
+++ b/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
@@ -23,18 +23,17 @@
 
 #include <gtest/gtest.h>
 
-#include <cstdio>
-#include <unistd.h>
-
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <mutex>
 #include <string>
 #include <thread>
+#include <unistd.h>
 #include <vector>
 
 namespace
@@ -635,6 +634,76 @@ TEST_F(FacadeE2eTest, OversizedBatchIsSplitAndResentWithoutLoss)
     }
 }
 
+namespace
+{
+    char* collectStatsStub(void*)
+    {
+        return strdup(R"({"uptime":123,"events":7})");
+    }
+
+    char* collectConfigStub(void*)
+    {
+        return strdup(R"({"client":{"notify_time":10}})");
+    }
+} // namespace
+
+TEST_F(FacadeE2eTest, ReporterPostsStampedStatsAndConfig)
+{
+    // With both reporters on, the module POSTs the collected snapshots to
+    // /stats and /config, stamped with agent_id and the manager-authoritative
+    // cluster (proving the commit-4 plumbing end to end). #37843.
+    const uint16_t port = TLS_PORT + 5;
+    FakeManager manager {port, KEY_HEX, /*tls=*/true};
+
+    Recorder recorder;
+    hc_config_t config = tlsConfig();
+    config.server_port = port;
+    config.stats_enabled = true;
+    config.stats_interval_s = 1;
+    config.config_report_enabled = true;
+    config.config_report_interval_s = 1;
+    hc_callbacks_t callbacks {};
+    callbacks.on_startup_result = onStartup;
+    callbacks.on_state_change = onState;
+    callbacks.collect_stats = collectStatsStub;
+    callbacks.collect_config = collectConfigStub;
+    callbacks.user_data = &recorder;
+
+    hc_handle* handle = hc_create(&config, &callbacks);
+    ASSERT_NE(nullptr, handle);
+    ASSERT_TRUE(hc_start(handle));
+    ASSERT_TRUE(waitFor(recorder.startupCount, 1, 3000));
+
+    httplib::Client peek {std::string {"https://127.0.0.1:"} + std::to_string(port)};
+    peek.enable_server_certificate_verification(false);
+    std::string stats;
+    std::string cfg;
+
+    for (int attempt = 0; attempt < 300; attempt++)
+    {
+        auto s = peek.Get("/peek/stats");
+        auto c = peek.Get("/peek/config");
+
+        if (s && s->status == 200 && c && c->status == 200)
+        {
+            stats = s->body;
+            cfg = c->body;
+            break;
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds {20});
+    }
+
+    hc_destroy(handle);
+
+    // The manager sees the module's own snapshot, stamped with identity.
+    EXPECT_NE(std::string::npos, stats.find(R"("uptime":123)"));
+    EXPECT_NE(std::string::npos, stats.find(R"("agent_id":"001")"));
+    EXPECT_NE(std::string::npos, stats.find(R"("cluster":{"name":"fake","node":"node01"})"));
+    EXPECT_NE(std::string::npos, cfg.find(R"("notify_time":10)"));
+    EXPECT_NE(std::string::npos, cfg.find(R"("agent_id":"001")"));
+}
+
 TEST_F(FacadeE2eTest, SettingsChangeRefreshesStartupWithoutLeavingRegistered)
 {
     // A dedicated manager that flips its settings after 2 notifies: the
@@ -667,4 +736,37 @@ TEST_F(FacadeE2eTest, SettingsChangeRefreshesStartupWithoutLeavingRegistered)
     EXPECT_EQ(0, std::count(recorder.states.begin(), recorder.states.end(),
                             HC_STATE_REJECTED));
     EXPECT_EQ(HC_STATE_STOPPED, recorder.states.back());
+}
+
+TEST_F(FacadeE2eTest, RegistersAndRunsTheDataStreams)
+{
+    Recorder recorder;
+    hc_config_t config = tlsConfig();
+    hc_callbacks_t callbacks {};
+    callbacks.log = nullptr;
+    callbacks.on_startup_result = onStartup;
+    callbacks.on_sync_response = onSync;
+    callbacks.on_state_change = onState;
+    callbacks.user_data = &recorder;
+
+    hc_handle* handle = hc_create(&config, &callbacks);
+    ASSERT_NE(nullptr, handle);
+    ASSERT_TRUE(hc_start(handle));
+
+    // The control loop reaches REGISTERED (Startup accepted over real TLS).
+    ASSERT_TRUE(waitFor(recorder.startupCount, 1, 3000));
+    EXPECT_EQ(HC_STATE_REGISTERED, hc_get_state(handle));
+
+    // The gate is open: the stateless sender flushes submitted events, and the
+    // stateful sender ships a submitted session (answered via on_sync_response).
+    const uint8_t frame[] = "1:/var/log/syslog:e2e";
+    EXPECT_TRUE(hc_submit_event(handle, frame, sizeof(frame) - 1));
+    const uint8_t session[] = "FULLSESSION:syscollector:body";
+    EXPECT_TRUE(hc_submit_sync_session(handle, "sess-e2e", session, sizeof(session) - 1));
+    EXPECT_TRUE(waitFor(recorder.syncCount, 1, 3000));
+
+    hc_destroy(handle); // Drains (final flush + Notify) and joins.
+    EXPECT_EQ(HC_STATE_STOPPED, recorder.states.back());
+    EXPECT_NE(recorder.states.end(),
+              std::find(recorder.states.begin(), recorder.states.end(), HC_STATE_REGISTERED));
 }

--- a/src/client-agent/https_client/tests/component/fakeManager.hpp
+++ b/src/client-agent/https_client/tests/component/fakeManager.hpp
@@ -165,7 +165,6 @@ class FakeManager final
                     rotateAfter > 0 && !rotatedKey.empty() && notifyCount->load() >= rotateAfter;
                 return verifyCmac(rotated ? rotatedKey : keyHex, target, request);
             };
-
             // Accumulates accepted /stateless bodies so the fork parent can
             // read them back via GET /peek/stateless (fork servers share no
             // memory; a peek endpoint is the observability channel).
@@ -220,6 +219,44 @@ class FakeManager final
                 response.status = 200;
                 response.set_content(std::to_string(notifyCount->load()), "text/plain");
             });
+
+            // /stats and /config: verify + store the last body so the fork
+            // parent can assert on it via GET /peek/{stats,config}.
+            auto lastStats = std::make_shared<std::string>();
+            auto lastConfig = std::make_shared<std::string>();
+
+            for (const auto& kind :
+                    {
+                        std::string {"stats"}, std::string {"config"}
+                    })
+            {
+                auto store = kind == "stats" ? lastStats : lastConfig;
+                server.Post("/" + kind,
+                            [verify, kind, store, acceptedMutex](const httplib::Request & request,
+                                                                 httplib::Response & response)
+                {
+                    if (!verify("/" + kind, request))
+                    {
+                        response.status = 401;
+                        return;
+                    }
+
+                    {
+                        std::lock_guard<std::mutex> lock(*acceptedMutex);
+                        *store = request.body;
+                    }
+
+                    response.set_content("{}", "application/json");
+                });
+
+                server.Get("/peek/" + kind,
+                           [store, acceptedMutex](const httplib::Request&, httplib::Response & response)
+                {
+                    std::lock_guard<std::mutex> lock(*acceptedMutex);
+                    response.status = store->empty() ? 204 : 200;
+                    response.set_content(*store, "text/plain");
+                });
+            }
 
             server.Post("/stateful",
                         [verify, lastSession, holdFile](const httplib::Request & request,
@@ -343,7 +380,8 @@ class FakeManager final
 
                 // #37733 5.1: startup answers the handshake metadata (v1 or
                 // v2 after the settings flip); notify reports agent.groups
-                // and the settings_hash of the CURRENT startup body.
+                // and the settings_hash of the CURRENT startup body; response
+                // answers a plain ok.
                 static const std::string startupV1 =
                     R"({"limits":{"eps":0},"cluster":{"name":"fake","node":"node01"},)"
                     R"("agent":{"groups":["default"]}})";
@@ -382,7 +420,7 @@ class FakeManager final
                     return;
                 }
 
-                // Unknown /control type: 400.
+                // Unknown /control type (the response leg is gone): 400.
                 response.status = 400;
                 response.set_content(R"({"error":"unknown control type"})", "application/json");
             });

--- a/src/client-agent/https_client/tests/component/httpsClient_component_test.cpp
+++ b/src/client-agent/https_client/tests/component/httpsClient_component_test.cpp
@@ -229,6 +229,27 @@ TEST_F(ComponentTest, AuthorizationHeaderMatchesTheContractFormat)
     EXPECT_TRUE(std::regex_match(headers->authorization, expected));
 }
 
+TEST_F(ComponentTest, BackPressureIsHonoredAndEachRetryReSigns)
+{
+    SystemClock clock;
+    Mt19937Random random;
+    Backoff backoff {10, 50, random};
+    RetrySender sender {m_performer, m_signer, clock, backoff};
+    Waiter waiter;
+
+    const std::string body = "H {}\nE 1:l:bp\n";
+    HttpRequestSpec spec;
+    spec.target = "/stateless";
+    spec.body = reinterpret_cast<const uint8_t*>(body.data());
+    spec.bodyLength = body.size();
+    spec.timeoutMs = 3000;
+    spec.headers = {"X-Arm-Backpressure: 1"}; // Server 503s once, then 200s.
+
+    const auto result = sender.send(spec, waiter, 4);
+    EXPECT_EQ(OutcomeClass::Ok, result.outcome);
+    EXPECT_EQ(200, result.response.httpCode);
+}
+
 TEST_F(ComponentTest, StatefulSessionStreamsFromSpoolAndDedupsOnReplay)
 {
     TempSpoolFactory factory {::testing::TempDir()};
@@ -278,25 +299,4 @@ TEST_F(ComponentTest, VersionRejectionSurfacesAs426)
                                      R"({"type":"startup"})", {"X-Reject-Version: 1"});
     EXPECT_EQ(426, response.httpCode);
     EXPECT_EQ(OutcomeClass::VersionRejected, classifyOutcome(response));
-}
-
-TEST_F(ComponentTest, BackPressureIsHonoredAndEachRetryReSigns)
-{
-    SystemClock clock;
-    Mt19937Random random;
-    Backoff backoff {10, 50, random};
-    RetrySender sender {m_performer, m_signer, clock, backoff};
-    Waiter waiter;
-
-    const std::string body = "H {}\nE 1:l:bp\n";
-    HttpRequestSpec spec;
-    spec.target = "/stateless";
-    spec.body = reinterpret_cast<const uint8_t*>(body.data());
-    spec.bodyLength = body.size();
-    spec.timeoutMs = 3000;
-    spec.headers = {"X-Arm-Backpressure: 1"}; // Server 503s once, then 200s.
-
-    const auto result = sender.send(spec, waiter, 4);
-    EXPECT_EQ(OutcomeClass::Ok, result.outcome);
-    EXPECT_EQ(200, result.response.httpCode);
 }

--- a/src/client-agent/https_client/tests/unit/controlStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/controlStream_test.cpp
@@ -22,7 +22,6 @@
 #include <cstring>
 #include <fstream>
 #include <memory>
-#include <vector>
 
 using ::testing::_;
 using ::testing::Invoke;
@@ -102,7 +101,7 @@ TEST_F(ControlStreamTest, StartupBodyCarriesTypeAndVersionOnly)
     EXPECT_TRUE(m_stream.step(m_waiter));
     EXPECT_NE(std::string::npos, sent.find("\"type\":\"startup\""));
     EXPECT_NE(std::string::npos, sent.find("\"version\":\"5.1.0\""));
-    // 5.1.1: hashes travel in the Notify response, never in the startup request.
+    // C.1: the config hash travels in Notify, never in the startup request.
     EXPECT_EQ(std::string::npos, sent.find("config_hash"));
     EXPECT_EQ(std::string::npos, sent.find("config_checksum"));
 }

--- a/src/client-agent/https_client/tests/unit/hcInterface_test.cpp
+++ b/src/client-agent/https_client/tests/unit/hcInterface_test.cpp
@@ -53,6 +53,8 @@ namespace
         recorder->states.push_back(state);
     }
 
+    // Points at a closed localhost port with tiny timeouts and backoff so the
+    // control loop churns quickly and stop is near-instant.
     hc_config_t makeConfig()
     {
         hc_config_t config {};
@@ -164,30 +166,6 @@ TEST_F(HcInterfaceTest, DrainReturnsWithinDeadlineAgainstADeadServer)
     hc_destroy(handle);
 }
 
-TEST_F(HcInterfaceTest, StartRejectsMissingMandatoryFields)
-{
-    hc_config_t badConfig = m_config;
-    badConfig.server_host[0] = '\0';
-    hc_handle* handle = hc_create(&badConfig, &m_callbacks);
-    ASSERT_NE(nullptr, handle);
-    EXPECT_FALSE(hc_start(handle));
-    EXPECT_EQ(HC_STATE_STOPPED, hc_get_state(handle));
-    EXPECT_TRUE(m_recorder.states.empty());
-    hc_destroy(handle);
-}
-
-TEST_F(HcInterfaceTest, StartFailsClosedWithoutCaInFullMode)
-{
-    hc_config_t failClosed = m_config;
-    failClosed.verify_mode = HC_VERIFY_FULL; // No CA -> must refuse to start.
-    hc_handle* handle = hc_create(&failClosed, &m_callbacks);
-    ASSERT_NE(nullptr, handle);
-    EXPECT_FALSE(hc_start(handle));
-    EXPECT_EQ(HC_STATE_STOPPED, hc_get_state(handle));
-    EXPECT_TRUE(m_recorder.states.empty());
-    hc_destroy(handle);
-}
-
 TEST_F(HcInterfaceTest, SubmitBeforeStartIsRejected)
 {
     hc_handle* handle = hc_create(&m_config, &m_callbacks);
@@ -238,6 +216,30 @@ TEST_F(HcInterfaceTest, SubmitNullArgumentsAreRejected)
     EXPECT_FALSE(hc_submit_event(handle, frame, 0));
     EXPECT_FALSE(hc_submit_sync_session(handle, nullptr, frame, 1));
     EXPECT_FALSE(hc_submit_sync_session(handle, "sess", nullptr, 1));
+    hc_destroy(handle);
+}
+
+TEST_F(HcInterfaceTest, StartRejectsMissingMandatoryFields)
+{
+    hc_config_t badConfig = m_config;
+    badConfig.server_host[0] = '\0';
+    hc_handle* handle = hc_create(&badConfig, &m_callbacks);
+    ASSERT_NE(nullptr, handle);
+    EXPECT_FALSE(hc_start(handle));
+    EXPECT_EQ(HC_STATE_STOPPED, hc_get_state(handle));
+    EXPECT_TRUE(m_recorder.states.empty());
+    hc_destroy(handle);
+}
+
+TEST_F(HcInterfaceTest, StartFailsClosedWithoutCaInFullMode)
+{
+    hc_config_t failClosed = m_config;
+    failClosed.verify_mode = HC_VERIFY_FULL; // No CA -> must refuse to start.
+    hc_handle* handle = hc_create(&failClosed, &m_callbacks);
+    ASSERT_NE(nullptr, handle);
+    EXPECT_FALSE(hc_start(handle));
+    EXPECT_EQ(HC_STATE_STOPPED, hc_get_state(handle));
+    EXPECT_TRUE(m_recorder.states.empty());
     hc_destroy(handle);
 }
 
@@ -305,7 +307,6 @@ TEST_F(HcInterfaceTest, NullHandleIsSafeEverywhere)
     EXPECT_FALSE(hc_submit_sync_session(nullptr, "s", frame, 1));
     hc_notify_now(nullptr);
     EXPECT_FALSE(hc_set_config_hash(nullptr, "abc"));
-    EXPECT_FALSE(hc_set_agent_key(nullptr, "000102030405060708090a0b0c0d0e0f"));
     EXPECT_EQ(HC_STATE_STOPPED, hc_get_state(nullptr));
 }
 
@@ -325,5 +326,6 @@ TEST_F(HcInterfaceTest, SetAgentKeyValidatesTheMaterial)
     EXPECT_TRUE(hc_set_agent_key(handle, "000102030405060708090a0b0c0d0e0f")); // 16 bytes.
     EXPECT_FALSE(hc_set_agent_key(handle, "abcd")); // 2 bytes: not an AES length.
     EXPECT_FALSE(hc_set_agent_key(handle, nullptr));
+    EXPECT_FALSE(hc_set_agent_key(nullptr, "000102030405060708090a0b0c0d0e0f"));
     hc_destroy(handle);
 }

--- a/src/client-agent/https_client/tests/unit/moduleConfig_test.cpp
+++ b/src/client-agent/https_client/tests/unit/moduleConfig_test.cpp
@@ -49,6 +49,10 @@ TEST(ModuleConfigTest, DefaultsAppliedOnZeroFields)
     EXPECT_EQ(60000u, typed.backoffCapMs);
     EXPECT_EQ(5000u, typed.drainTimeoutMs);
     EXPECT_EQ(200ULL * 1024 * 1024, typed.wpkMaxDownloadBytes);
+    EXPECT_FALSE(typed.statsEnabled);
+    EXPECT_EQ(60u, typed.statsIntervalS);
+    EXPECT_FALSE(typed.configReportEnabled);
+    EXPECT_EQ(3600u, typed.configReportIntervalS);
 }
 
 TEST(ModuleConfigTest, ZeroedVerifyModeIsFullFailClosed)

--- a/src/client-agent/https_client/tests/unit/reporterStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/reporterStream_test.cpp
@@ -1,0 +1,220 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 21, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "fakeSysSeams.hpp"
+#include "mockCallbackSink.hpp"
+#include "mockHttpPerformer.hpp"
+#include "reporterStream.hpp"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+namespace
+{
+    HttpResponse response(TransportStatus status, long code, long retryAfter = 0)
+    {
+        HttpResponse value;
+        value.status = status;
+        value.httpCode = code;
+        value.retryAfterSeconds = retryAfter;
+        return value;
+    }
+
+    /// Hands out scripted snapshots; records how many times each was pulled.
+    class FakeCollectorSource final : public ICollectorSource
+    {
+        public:
+            std::optional<std::string> collectStats() override
+            {
+                m_statsCalls++;
+                return m_stats;
+            }
+
+            std::optional<std::string> collectConfig() override
+            {
+                m_configCalls++;
+                return m_config;
+            }
+
+            std::optional<std::string> m_stats {R"({"uptime":10})"};
+            std::optional<std::string> m_config {R"({"client":{"notify_time":10}})"};
+            int m_statsCalls {0};
+            int m_configCalls {0};
+    };
+
+    class ReporterStreamTest : public ::testing::Test
+    {
+        protected:
+            ReporterStreamTest()
+                : m_signer("001", m_keyProvider)
+                , m_authGate(m_sink, [] {})
+            {
+            }
+
+            ModuleConfig makeConfig(bool stats, bool config)
+            {
+                hc_config_t raw {};
+                std::strncpy(raw.server_host, "127.0.0.1", sizeof(raw.server_host) - 1);
+                std::strncpy(raw.agent_id, "001", sizeof(raw.agent_id) - 1);
+                raw.verify_mode = HC_VERIFY_NONE;
+                raw.stats_enabled = stats;
+                raw.stats_interval_s = 60;
+                raw.config_report_enabled = config;
+                raw.config_report_interval_s = 3600;
+                return ModuleConfig::fromC(raw);
+            }
+
+            ConfigKeyProvider m_keyProvider {"000102030405060708090a0b0c0d0e0f"};
+            CmacSigner m_signer;
+            FakeClock m_clock;
+            ScriptedRandom m_random {{0.0}};
+            NiceMock<MockCallbackSink> m_sink;
+            AuthGate m_authGate;
+            ClusterIdentity m_cluster;
+            FakeCollectorSource m_collectors;
+            MockHttpPerformer m_performer;
+            FakeWaiter m_waiter;
+    };
+} // namespace
+
+TEST_F(ReporterStreamTest, DisabledReportersNeverCollectOrSend)
+{
+    const auto config = makeConfig(false, false);
+    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate,
+                             m_cluster, m_collectors};
+    EXPECT_FALSE(reporter.anyEnabled());
+    EXPECT_CALL(m_performer, perform(_)).Times(0);
+    reporter.tick(m_waiter, true);
+    EXPECT_EQ(0, m_collectors.m_statsCalls);
+    EXPECT_EQ(0, m_collectors.m_configCalls);
+}
+
+TEST_F(ReporterStreamTest, StampsAgentIdAndClusterAndPostsToStats)
+{
+    m_cluster.set("prod", "node01");
+    const auto config = makeConfig(true, false);
+    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate,
+                             m_cluster, m_collectors};
+
+    std::string body;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & spec)
+    {
+        EXPECT_EQ("/stats", spec.target);
+        body.assign(reinterpret_cast<const char*>(spec.body), spec.bodyLength);
+        return response(TransportStatus::Ok, 200);
+    }));
+
+    reporter.tick(m_waiter, true); // Due immediately at epoch.
+    EXPECT_NE(std::string::npos, body.find(R"("agent_id":"001")"));
+    EXPECT_NE(std::string::npos, body.find(R"("cluster":{"name":"prod","node":"node01"})"));
+    EXPECT_NE(std::string::npos, body.find(R"("uptime":10)"));
+}
+
+TEST_F(ReporterStreamTest, StampOverwritesCollectorSuppliedIdentityFields)
+{
+    m_cluster.set("authoritative", "n1");
+    m_collectors.m_stats = R"({"agent_id":"WRONG","cluster":"WRONG","x":1})";
+    const auto config = makeConfig(true, false);
+    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate,
+                             m_cluster, m_collectors};
+
+    std::string body;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Invoke([&](const HttpRequestSpec & spec)
+    {
+        body.assign(reinterpret_cast<const char*>(spec.body), spec.bodyLength);
+        return response(TransportStatus::Ok, 200);
+    }));
+
+    reporter.tick(m_waiter, true);
+    EXPECT_NE(std::string::npos, body.find(R"("agent_id":"001")"));
+    EXPECT_EQ(std::string::npos, body.find("WRONG"));
+    EXPECT_NE(std::string::npos, body.find(R"("cluster":{"name":"authoritative")"));
+}
+
+TEST_F(ReporterStreamTest, NullCollectorReturnSkipsWithoutSending)
+{
+    m_collectors.m_stats = std::nullopt;
+    const auto config = makeConfig(true, false);
+    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate,
+                             m_cluster, m_collectors};
+    EXPECT_CALL(m_performer, perform(_)).Times(0);
+    reporter.tick(m_waiter, true);
+    EXPECT_EQ(1, m_collectors.m_statsCalls); // Collected, then skipped.
+}
+
+TEST_F(ReporterStreamTest, NonObjectCollectorReturnIsSkipped)
+{
+    m_collectors.m_stats = R"(["not","an","object"])";
+    const auto config = makeConfig(true, false);
+    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate,
+                             m_cluster, m_collectors};
+    EXPECT_CALL(m_performer, perform(_)).Times(0);
+    reporter.tick(m_waiter, true);
+}
+
+TEST_F(ReporterStreamTest, UnregisteredOrPausedSkipsAndKeepsDueness)
+{
+    const auto config = makeConfig(true, false);
+    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate,
+                             m_cluster, m_collectors};
+    EXPECT_CALL(m_performer, perform(_)).Times(0);
+    reporter.tick(m_waiter, false); // Not registered.
+    m_authGate.reportAuthFailure();
+    reporter.tick(m_waiter, true); // Registered but paused.
+    EXPECT_EQ(0, m_collectors.m_statsCalls);
+}
+
+TEST_F(ReporterStreamTest, IntervalGovernsTheNextSend)
+{
+    const auto config = makeConfig(true, false);
+    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate,
+                             m_cluster, m_collectors};
+    EXPECT_CALL(m_performer, perform(_)).WillRepeatedly(Return(response(TransportStatus::Ok, 200)));
+
+    reporter.tick(m_waiter, true);             // Sends (due at epoch).
+    EXPECT_EQ(1, m_collectors.m_statsCalls);
+    reporter.tick(m_waiter, true);             // Too soon: not due.
+    EXPECT_EQ(1, m_collectors.m_statsCalls);
+    m_clock.advance(std::chrono::seconds {60}); // Reach the interval.
+    reporter.tick(m_waiter, true);
+    EXPECT_EQ(2, m_collectors.m_statsCalls);
+}
+
+TEST_F(ReporterStreamTest, BackPressureDefersOnlyThatPath)
+{
+    const auto config = makeConfig(true, true);
+    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate,
+                             m_cluster, m_collectors};
+    // Both due at epoch: stats 503 (Retry-After 5), config 200.
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 503, 5)))  // /stats first.
+    .WillOnce(Return(response(TransportStatus::Ok, 200)));    // /config.
+    reporter.tick(m_waiter, true);
+    EXPECT_EQ(1, m_collectors.m_statsCalls);
+    EXPECT_EQ(1, m_collectors.m_configCalls);
+
+    // Immediately after, neither is due (config on its 3600 s interval, stats
+    // deferred by the Retry-After) -> no send.
+    EXPECT_CALL(m_performer, perform(_)).Times(0);
+    reporter.tick(m_waiter, true);
+}

--- a/src/client-agent/include/agentd.h
+++ b/src/client-agent/include/agentd.h
@@ -268,6 +268,26 @@ bool startup_gate_check_hash_match(void);
 
 size_t agcom_dispatch(char * command, char ** output);
 size_t agcom_getconfig(const char * section, char ** output);
+size_t agcom_getallconfig(char ** output);
+size_t agcom_getallstats(char ** output);
+
+/**
+ * @brief Collect every module's configuration into one /config document.
+ *
+ * Queries each agent daemon once and concatenates what they report.
+ *
+ * @return Allocated JSON document the caller frees, or NULL when no component
+ *         answered and the cycle should be skipped.
+ */
+char *w_agent_collect_config(void);
+
+/**
+ * @brief Collect every module's statistics into one /stats document.
+ *
+ * @return Allocated JSON document the caller frees, or NULL when no component
+ *         answered and the cycle should be skipped.
+ */
+char *w_agent_collect_stats(void);
 
 #ifdef WIN32
 size_t control_dispatch(char *command, char **output);

--- a/src/client-agent/src/agcom.c
+++ b/src/client-agent/src/agcom.c
@@ -10,8 +10,12 @@
 
 #include <shared.h>
 #include "agentd.h"
+#include "module_report.h"
 #include "os_net.h"
 #include "wmodules.h"
+
+/* Name this daemon reports itself under in the /config and /stats documents. */
+#define AGCOM_MODULE_NAME "agent"
 
 
 size_t agcom_dispatch(char * command, char ** output){
@@ -32,6 +36,12 @@ size_t agcom_dispatch(char * command, char ** output){
             return strlen(*output);
         }
         return agcom_getconfig(rcv_args, output);
+
+    } else if (strcmp(rcv_comm, "getallconfig") == 0) {
+        return agcom_getallconfig(output);
+
+    } else if (strcmp(rcv_comm, "getallstats") == 0) {
+        return agcom_getallstats(output);
 
     } else if (strcmp(rcv_comm, "getstate") == 0) {
         *output = w_agentd_state_get();
@@ -125,6 +135,34 @@ error:
     mdebug1("At AGCOM getconfig: Could not get '%s' section", section);
     os_strdup("err Could not get requested section", *output);
     return strlen(*output);
+}
+
+size_t agcom_getallconfig(char ** output) {
+
+    cJSON *report = cJSON_CreateArray();
+    cJSON *body = cJSON_CreateObject();
+
+    module_report_merge(body, getClientConfig());
+    module_report_merge(body, getBufferConfig());
+    module_report_merge(body, getAgentInternalOptions());
+#ifndef WIN32
+    module_report_merge(body, getAntiTamperingConfig());
+#endif
+
+    module_report_add_config(report, AGCOM_MODULE_NAME, body);
+    return module_report_reply(report, output);
+}
+
+size_t agcom_getallstats(char ** output) {
+
+    cJSON *report = cJSON_CreateArray();
+    char *state = w_agentd_state_get();
+
+    /* w_agentd_state_get() hands back a serialized document; parse it so the
+     * report carries the object rather than a string holding JSON. */
+    module_report_add_stats(report, AGCOM_MODULE_NAME, state ? cJSON_Parse(state) : NULL);
+    os_free(state);
+    return module_report_reply(report, output);
 }
 
 /**

--- a/src/client-agent/src/agent_report.c
+++ b/src/client-agent/src/agent_report.c
@@ -1,0 +1,231 @@
+/* Agent-wide config and stats reports
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 29, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <shared.h>
+#include "agentd.h"
+#include "os_net.h"
+
+#ifdef WIN32
+#include "execd.h"
+#include "logcollector.h"
+#include "syscheck.h"
+#include "wmodules.h"
+#endif
+
+/* The agent's modules live in separate daemons, so a full picture costs one
+ * query per daemon. Each answers with the report for the modules it hosts, and
+ * the arrays below are concatenated into the document pushed to /config and
+ * /stats. A daemon that is disabled or not answering is left out rather than
+ * reported empty, so the manager can tell "not running" from "nothing set". */
+
+typedef struct report_source_t {
+    const char *target;     ///< Component socket name under queue/sockets.
+    const char *command;    ///< Command that yields that component's report.
+} report_source_t;
+
+static const report_source_t CONFIG_SOURCES[] = {
+    {"agent", "getallconfig"},
+    {"syscheck", "getallconfig"},
+    {"logcollector", "getallconfig"},
+    {"wmodules", "getallconfig"},
+    {"com", "getallconfig"},
+};
+
+/* Only these two produce statistics today; the rest have no getstate handler. */
+static const report_source_t STATS_SOURCES[] = {
+    {"agent", "getallstats"},
+    {"logcollector", "getallstats"},
+};
+
+#ifdef WIN32
+
+/**
+ * @brief Dispatch a command in-process, the way request.c does on Windows.
+ * @param target Component name.
+ * @param command Command to run. Modified in place by the dispatchers.
+ * @param output Receives the allocated reply.
+ * @return Length of *output, or 0 when the target is unknown.
+ */
+static size_t report_dispatch(const char *target, char *command, char **output) {
+    const size_t length = strlen(command);
+
+    if (strcmp(target, "agent") == 0) {
+        return agcom_dispatch(command, output);
+    } else if (strcmp(target, "syscheck") == 0) {
+        return syscom_dispatch(command, length, output);
+    } else if (strcmp(target, "logcollector") == 0) {
+        return lccom_dispatch(command, output);
+    } else if (strcmp(target, "wmodules") == 0) {
+        return wmcom_dispatch(command, length, output);
+    } else if (strcmp(target, "com") == 0) {
+        return wcom_dispatch(command, output);
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Ask one component for its report. Windows runs every daemon inside a
+ *        single process, so this is a direct call instead of a socket round trip.
+ */
+static char *report_query(const char *target, const char *command) {
+    char request[OS_SIZE_128] = {0};
+    char *response = NULL;
+
+    snprintf(request, sizeof(request), "%s", command);
+
+    if (report_dispatch(target, request, &response) == 0) {
+        os_free(response);
+        return NULL;
+    }
+
+    return response;
+}
+
+#else
+
+/**
+ * @brief Send a command to a component socket and read the whole reply back.
+ * @param sock Connected socket. Closed by this call.
+ * @param command Command to send.
+ * @return Allocated reply, or NULL when the exchange failed.
+ */
+static char *report_exchange(int sock, const char *command) {
+    char *response = NULL;
+    ssize_t length;
+
+    if (OS_SendSecureTCP(sock, strlen(command), command) != 0) {
+        mdebug1("Could not send '%s' to a component socket: %s", command, strerror(errno));
+        close(sock);
+        return NULL;
+    }
+
+    /* One byte short of the buffer, so the terminator below always has room. */
+    os_calloc(OS_MAXSTR, sizeof(char), response);
+    length = OS_RecvSecureTCP(sock, response, OS_MAXSTR - 1);
+    close(sock);
+
+    if (length <= 0) {
+        /* OS_SOCKTERR here means the component's report did not fit in the
+         * socket's buffer, which is the one failure worth naming. */
+        mdebug1("No usable answer to '%s': %s", command,
+                length == OS_SOCKTERR ? "the report is larger than the socket allows"
+                                      : strerror(errno));
+        os_free(response);
+        return NULL;
+    }
+
+    response[length] = '\0';
+    return response;
+}
+
+/**
+ * @brief Ask one component for its report over its local socket.
+ */
+static char *report_query(const char *target, const char *command) {
+    char sockname[PATH_MAX + 1] = {0};
+    int sock;
+
+    snprintf(sockname, sizeof(sockname), "queue/sockets/%s", target);
+
+    if (sock = OS_ConnectUnixDomain(sockname, SOCK_STREAM, OS_MAXSTR), sock < 0) {
+        mdebug1("Component '%s' is not answering, leaving it out of the report.", target);
+        return NULL;
+    }
+
+    return report_exchange(sock, command);
+}
+
+#endif /* WIN32 */
+
+/**
+ * @brief Parse one component's reply into the array of entries it carries.
+ * @param target Component name, for logging.
+ * @param reply Component reply, "ok <json>" on success. Freed by this call.
+ * @return Parsed array, or NULL when the component reported an error.
+ */
+static cJSON *report_entries(const char *target, char *reply) {
+    cJSON *entries = NULL;
+
+    if (!reply) {
+        return NULL;
+    }
+
+    if (strncmp(reply, "ok ", 3) != 0) {
+        mdebug1("Component '%s' refused to report: %s", target, reply);
+        os_free(reply);
+        return NULL;
+    }
+
+    if (entries = cJSON_Parse(reply + 3), !entries || !cJSON_IsArray(entries)) {
+        mdebug1("Component '%s' answered with something other than a report.", target);
+        cJSON_Delete(entries);
+        entries = NULL;
+    }
+
+    os_free(reply);
+    return entries;
+}
+
+/**
+ * @brief Move every entry of a component's array into the combined report.
+ * @param report Destination array.
+ * @param entries Source array. Consumed by this call.
+ */
+static void report_absorb(cJSON *report, cJSON *entries) {
+    cJSON *entry = NULL;
+
+    while (entries && (entry = entries->child)) {
+        cJSON_DetachItemViaPointer(entries, entry);
+        cJSON_AddItemToArray(report, entry);
+    }
+
+    cJSON_Delete(entries);
+}
+
+/**
+ * @brief Query every source and serialize the modules they reported.
+ * @param sources Component/command pairs to query.
+ * @param count Number of sources.
+ * @return Allocated JSON document, or NULL when no component answered.
+ */
+static char *report_collect(const report_source_t *sources, size_t count) {
+    cJSON *root = cJSON_CreateObject();
+    cJSON *report = cJSON_CreateArray();
+    char *document = NULL;
+    size_t i;
+
+    for (i = 0; i < count; i++) {
+        report_absorb(report, report_entries(sources[i].target,
+                                             report_query(sources[i].target,
+                                                          sources[i].command)));
+    }
+
+    if (!report->child) {
+        /* Nothing answered. Skip the cycle instead of pushing an empty
+         * document that would overwrite a good one in the manager's index. */
+        cJSON_Delete(report);
+        cJSON_Delete(root);
+        return NULL;
+    }
+
+    cJSON_AddItemToObject(root, "modules", report);
+    document = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    return document;
+}
+
+char *w_agent_collect_config(void) {
+    return report_collect(CONFIG_SOURCES, sizeof(CONFIG_SOURCES) / sizeof(CONFIG_SOURCES[0]));
+}
+
+char *w_agent_collect_stats(void) {
+    return report_collect(STATS_SOURCES, sizeof(STATS_SOURCES) / sizeof(STATS_SOURCES[0]));
+}

--- a/src/client-agent/src/agent_report.c
+++ b/src/client-agent/src/agent_report.c
@@ -216,6 +216,12 @@ static char *report_collect(const report_source_t *sources, size_t count) {
     char *document = NULL;
     size_t i;
 
+    if (!root || !report) {
+        cJSON_Delete(root);
+        cJSON_Delete(report);
+        return NULL; /* Out of memory: skip the cycle, same as nothing answering. */
+    }
+
     for (i = 0; i < count; i++) {
         report_absorb(report, report_entries(sources[i].target,
                                              report_query(sources[i].target,

--- a/src/client-agent/src/agent_report.c
+++ b/src/client-agent/src/agent_report.c
@@ -96,6 +96,11 @@ static char *report_query(const char *target, const char *command) {
     snprintf(request, sizeof(request), "%s", command);
 
     if (report_dispatch(target, request, &response) == 0) {
+        /* Same line, and the same reason, as the POSIX connect failure below:
+         * the component produced nothing, so it is left out of the report.
+         * Worth saying on both platforms -- a module missing from /config is
+         * otherwise silent here, with no socket error to point at. */
+        mdebug1("Component '%s' is not answering, leaving it out of the report.", target);
         os_free(response);
         return NULL;
     }

--- a/src/client-agent/src/agent_report.c
+++ b/src/client-agent/src/agent_report.c
@@ -79,6 +79,20 @@ static char *report_query(const char *target, const char *command) {
     char request[OS_SIZE_128] = {0};
     char *response = NULL;
 
+    /* On POSIX, a component that has not finished starting up simply is not
+     * listening on its socket yet, so report_query() below fails the connect
+     * and skips it cleanly. In-process there is no socket to refuse the call:
+     * dispatching straight into e.g. syscheckd before its own thread has run
+     * past the startup gate touches state it has not initialized yet (its
+     * directories_lock is a prime example) instead of getting turned away.
+     * The startup gate is the only cross-module readiness signal this process
+     * has, so until it opens, every target is treated the same way a POSIX
+     * daemon that is not answering yet would be. */
+    if (!startup_gate_is_ready()) {
+        mdebug1("Component '%s' is not answering, leaving it out of the report.", target);
+        return NULL;
+    }
+
     snprintf(request, sizeof(request), "%s", command);
 
     if (report_dispatch(target, request, &response) == 0) {

--- a/src/client-agent/src/config.c
+++ b/src/client-agent/src/config.c
@@ -159,6 +159,18 @@ cJSON *getClientConfig(void) {
         cJSON_AddStringToObject(enrollment_cfg,"auto_method",agt->enrollment_cfg->cert_cfg->auto_method ? "yes": "no");
         cJSON_AddItemToObject(client,"enrollment",enrollment_cfg);
     }
+    /* The two periodic report pushes (#37843). Reported so the /config document
+     * says whether the agent is reporting, and on what cadence. */
+    cJSON *stats_report = cJSON_CreateObject();
+    cJSON_AddStringToObject(stats_report, "enabled", agt->stats_report.enabled ? "yes" : "no");
+    cJSON_AddNumberToObject(stats_report, "interval", agt->stats_report.interval);
+    cJSON_AddItemToObject(client, "stats_report", stats_report);
+
+    cJSON *config_report = cJSON_CreateObject();
+    cJSON_AddStringToObject(config_report, "enabled", agt->config_report.enabled ? "yes" : "no");
+    cJSON_AddNumberToObject(config_report, "interval", agt->config_report.interval);
+    cJSON_AddItemToObject(client, "config_report", config_report);
+
     cJSON_AddItemToObject(root,"client",client);
 
     return root;

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -1141,6 +1141,23 @@ static void bridge_on_state_change(int state, void *user_data)
     }
 }
 
+/* The reporters call these straight through (not via the task dispatcher): they
+ * return a value, and the module frees the buffer after copying it. Collecting
+ * is a fan-out over the component sockets, so it runs on the reporter's own
+ * thread and cannot stall the other endpoints. */
+
+static char *bridge_collect_config(void *user_data)
+{
+    (void)user_data;
+    return w_agent_collect_config();
+}
+
+static char *bridge_collect_stats(void *user_data)
+{
+    (void)user_data;
+    return w_agent_collect_stats();
+}
+
 /* Occupancy thresholds the module reports against, kept so the log lines can
  * quote them exactly as buffer.c does. Filled by bridge_build_config() from the
  * same internal options buffer_init() reads. */
@@ -1407,6 +1424,8 @@ void w_https_client_start(void)
     callbacks.on_sync_response = bridge_on_sync_response;
     callbacks.on_state_change = bridge_on_state_change;
     callbacks.on_buffer_level = bridge_on_buffer_level;
+    callbacks.collect_stats = bridge_collect_stats;
+    callbacks.collect_config = bridge_collect_config;
 
     g_https_client = hc_create(&config, &callbacks);
     if (!g_https_client) {

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -1301,6 +1301,14 @@ static bool bridge_build_config(hc_config_t *config)
     config->batch_size_bytes = (uint64_t)agt->batch.size;
     config->batch_interval_ms = (uint32_t)(agt->batch.interval * 1000);
 
+    /* <client><stats_report>/<config_report>: the two periodic pushes (#37843),
+     * independent of each other and off unless configured. A zero interval
+     * leaves the module on its own default (60 s / 3600 s). */
+    config->stats_enabled = agt->stats_report.enabled;
+    config->stats_interval_s = (uint32_t)agt->stats_report.interval;
+    config->config_report_enabled = agt->config_report.enabled;
+    config->config_report_interval_s = (uint32_t)agt->config_report.interval;
+
     /* Occupancy ladder: the same internal options buffer_init() reads, so an
      * operator who tuned the legacy client buffer keeps their thresholds now
      * that the accumulator is what fills up. Read here rather than through

--- a/src/config/include/client-config.h
+++ b/src/config/include/client-config.h
@@ -57,6 +57,19 @@ typedef struct agent_batch {
     long interval;  ///< <interval>: longest an event waits before a flush, seconds.
 } agent_batch;
 
+/**
+ * @brief <client><stats_report> / <client><config_report>: the periodic push of
+ *        a whole-agent snapshot to /stats and /config (#37843).
+ *
+ * The two are independent and both stay off until <enabled> says otherwise.
+ * Zero interval means "unset": the transport module applies its own default
+ * (60 s for stats, 3600 s for config).
+ */
+typedef struct agent_report {
+    unsigned char enabled; ///< <enabled>: whether to push at all.
+    long interval;         ///< <interval>: seconds between pushes.
+} agent_report;
+
 /* Configuration structure */
 typedef struct _agent {
     agent_server * server;
@@ -76,6 +89,8 @@ typedef struct _agent {
     agent_flags_t flags;
     agent_ssl ssl;     ///< HTTPS transport TLS settings (<client><ssl>).
     agent_batch batch; ///< /stateless batching limits (<client><batch>).
+    agent_report stats_report;  ///< Periodic /stats push (<client><stats_report>).
+    agent_report config_report; ///< Periodic /config push (<client><config_report>).
     w_enrollment_ctx *enrollment_cfg;
 } agent;
 

--- a/src/config/include/syscheck-config.h
+++ b/src/config/include/syscheck-config.h
@@ -445,7 +445,6 @@ typedef struct _config {
     int sym_checker_interval;
 
     pthread_rwlock_t directories_lock;
-    atomic_int_t directories_lock_ready;                /* Flag (0=false, 1=true): directories_lock has been pthread_rwlock_init'd. On Windows, getSyscheckConfig() can be reached in-process (agent_report.c) from another thread before Start_Syscheck() gets here; this lets it decline instead of locking uninitialized memory. */
     pthread_mutex_t fim_scan_mutex;
     pthread_mutex_t fim_realtime_mutex;
 #ifdef WIN32
@@ -467,6 +466,21 @@ typedef struct _config {
     int registry_key_limit;
     int registry_value_limit;
 } syscheck_config;
+
+/**
+ * @brief Whether directories_lock has been pthread_rwlock_init'd yet.
+ *
+ * Deliberately NOT a syscheck_config member. Windows dispatches the /config
+ * report in-process (agent_report.c), so getSyscheckConfig() can be reached
+ * from another thread before fim_initialize() has run at all -- and the whole
+ * `syscheck` struct is zero-initialized until then. On winpthreads
+ * PTHREAD_MUTEX_INITIALIZER is a non-zero sentinel, so an atomic_int_t here
+ * would need its OWN mutex initialized to be read -- trading the uninitialized
+ * rwlock for an uninitialized mutex. A plain flag needs nothing initialized,
+ * which is the only property that holds this early. It is written once, after
+ * the rwlock is real, and only ever read afterwards.
+ */
+extern volatile int syscheck_directories_lock_ready;
 
 
 /**

--- a/src/config/include/syscheck-config.h
+++ b/src/config/include/syscheck-config.h
@@ -476,11 +476,41 @@ typedef struct _config {
  * `syscheck` struct is zero-initialized until then. On winpthreads
  * PTHREAD_MUTEX_INITIALIZER is a non-zero sentinel, so an atomic_int_t here
  * would need its OWN mutex initialized to be read -- trading the uninitialized
- * rwlock for an uninitialized mutex. A plain flag needs nothing initialized,
- * which is the only property that holds this early. It is written once, after
- * the rwlock is real, and only ever read afterwards.
+ * rwlock for an uninitialized mutex. A bare int needs nothing initialized,
+ * which is the only property that holds this early.
+ *
+ * Access it only through the two accessors below, never directly: the flag
+ * carries the rwlock's initialization to the reader, so it needs real
+ * release/acquire ordering and not just `volatile`, which orders nothing
+ * between threads. Without the pairing a weakly-ordered CPU may show a reader
+ * the flag set while pthread_rwlock_init()'s own writes are still invisible,
+ * which is the exact crash this flag exists to prevent. The __atomic builtins
+ * are lock-free for an int on every toolchain that builds the agent, need no
+ * initialization, and are not the <stdatomic.h> generics mingw lacks.
  */
-extern volatile int syscheck_directories_lock_ready;
+extern int syscheck_directories_lock_ready;
+
+/**
+ * @brief Publish that directories_lock is initialized and safe to take.
+ *
+ * Release: everything fim_initialize() wrote beforehand, the rwlock included,
+ * is visible to any thread that then observes the flag set.
+ */
+static inline void syscheck_set_directories_lock_ready(void)
+{
+    __atomic_store_n(&syscheck_directories_lock_ready, 1, __ATOMIC_RELEASE);
+}
+
+/**
+ * @brief Whether directories_lock may be taken yet.
+ *
+ * Acquire: pairs with the release above, so a true answer means the rwlock's
+ * initialization is visible to this thread too.
+ */
+static inline int syscheck_directories_lock_is_ready(void)
+{
+    return __atomic_load_n(&syscheck_directories_lock_ready, __ATOMIC_ACQUIRE);
+}
 
 
 /**

--- a/src/config/include/syscheck-config.h
+++ b/src/config/include/syscheck-config.h
@@ -445,6 +445,7 @@ typedef struct _config {
     int sym_checker_interval;
 
     pthread_rwlock_t directories_lock;
+    atomic_int_t directories_lock_ready;                /* Flag (0=false, 1=true): directories_lock has been pthread_rwlock_init'd. On Windows, getSyscheckConfig() can be reached in-process (agent_report.c) from another thread before Start_Syscheck() gets here; this lets it decline instead of locking uninitialized memory. */
     pthread_mutex_t fim_scan_mutex;
     pthread_mutex_t fim_realtime_mutex;
 #ifdef WIN32

--- a/src/config/src/client-config.c
+++ b/src/config/src/client-config.c
@@ -17,6 +17,7 @@
 int Read_Client_Server(XML_NODE node, agent *logr);
 int Read_Client_SSL(XML_NODE node, agent *logr);
 int Read_Client_Batch(XML_NODE node, agent *logr);
+int Read_Client_Report(XML_NODE node, agent_report *report);
 int Read_Client_Enrollment(XML_NODE node, agent *logr);
 
 int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused)) void *d2)
@@ -31,6 +32,8 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
     const char *xml_client_server = "server";
     const char *xml_client_ssl = "ssl";
     const char *xml_client_batch = "batch";
+    const char *xml_client_stats_report = "stats_report";
+    const char *xml_client_config_report = "config_report";
     const char *xml_local_ip = "local_ip";
     const char *xml_ar_disabled = "disable-active-response";
     const char *xml_notify_time = "notify_time";
@@ -125,6 +128,24 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
              * replaces the leaky bucket's pacing (#37835). */
             if ((chld_node = OS_GetElementsbyNode(xml, node[i]))) {
                 if (Read_Client_Batch(chld_node, logr) < 0) {
+                    OS_ClearNode(chld_node);
+                    return (OS_INVALID);
+                }
+                OS_ClearNode(chld_node);
+            }
+        } else if (strcmp(node[i]->element, xml_client_stats_report) == 0) {
+            /* <stats_report>/<config_report>: the two independent periodic
+             * pushes to /stats and /config (#37843). Both off by default. */
+            if ((chld_node = OS_GetElementsbyNode(xml, node[i]))) {
+                if (Read_Client_Report(chld_node, &logr->stats_report) < 0) {
+                    OS_ClearNode(chld_node);
+                    return (OS_INVALID);
+                }
+                OS_ClearNode(chld_node);
+            }
+        } else if (strcmp(node[i]->element, xml_client_config_report) == 0) {
+            if ((chld_node = OS_GetElementsbyNode(xml, node[i]))) {
+                if (Read_Client_Report(chld_node, &logr->config_report) < 0) {
                     OS_ClearNode(chld_node);
                     return (OS_INVALID);
                 }
@@ -391,6 +412,51 @@ int Read_Client_SSL(XML_NODE node, agent * logr)
         } else if (strcmp(node[j]->element, xml_ciphers) == 0) {
             os_free(logr->ssl.ciphers);
             os_strdup(node[j]->content, logr->ssl.ciphers);
+        } else {
+            merror(XML_INVELEM, node[j]->element);
+            return (OS_INVALID);
+        }
+    }
+
+    return (0);
+}
+
+int Read_Client_Report(XML_NODE node, agent_report * report)
+{
+    /* XML definitions - shared by <stats_report> and <config_report> (#37843);
+     * <interval> takes the usual suffixes: <interval>1h</interval>. */
+    const char *xml_enabled = "enabled";
+    const char *xml_interval = "interval";
+
+    /* Same ceiling as <batch>: a day between snapshots is already past useless,
+     * and it keeps the value the module wants inside 32 bits. */
+    const long max_interval = 86400;
+
+    for (int j = 0; node[j]; j++) {
+        if (!node[j]->element) {
+            merror(XML_ELEMNULL);
+            return (OS_INVALID);
+        } else if (!node[j]->content) {
+            merror(XML_VALUENULL, node[j]->element);
+            return (OS_INVALID);
+        } else if (strcmp(node[j]->element, xml_enabled) == 0) {
+            if (strcmp(node[j]->content, "yes") == 0) {
+                report->enabled = 1;
+            } else if (strcmp(node[j]->content, "no") == 0) {
+                report->enabled = 0;
+            } else {
+                merror(XML_VALUEERR, node[j]->element, node[j]->content);
+                return (OS_INVALID);
+            }
+        } else if (strcmp(node[j]->element, xml_interval) == 0) {
+            const long interval = w_parse_time(node[j]->content);
+
+            if (interval <= 0 || interval > max_interval) {
+                merror(XML_VALUEERR, node[j]->element, node[j]->content);
+                return (OS_INVALID);
+            }
+
+            report->interval = interval;
         } else {
             merror(XML_INVELEM, node[j]->element);
             return (OS_INVALID);

--- a/src/logcollector/include/logcollector.h
+++ b/src/logcollector/include/logcollector.h
@@ -203,6 +203,22 @@ void* lccom_main(void* arg);
 #endif
 size_t lccom_dispatch(char* command, char** output);
 size_t lccom_getconfig(const char* section, char** output);
+
+/**
+ * @brief Build this daemon's entry for the agent's /config document.
+ *
+ * @param output Receives the allocated "ok <json>" reply.
+ * @return Length of *output.
+ */
+size_t lccom_getallconfig(char** output);
+
+/**
+ * @brief Build this daemon's entry for the agent's /stats document.
+ *
+ * @param output Receives the allocated "ok <json>" reply.
+ * @return Length of *output.
+ */
+size_t lccom_getallstats(char** output);
 size_t lccom_getstate(char** output, bool getNextPage);
 
 /*** Global variables ***/

--- a/src/logcollector/src/lccom.c
+++ b/src/logcollector/src/lccom.c
@@ -10,9 +10,13 @@
 
 #include <shared.h>
 #include "logcollector.h"
+#include "module_report.h"
 #include "wmodules.h"
 #include "os_net.h"
 #include "state.h"
+
+/* Name this daemon reports itself under in the /config and /stats documents. */
+#define LCCOM_MODULE_NAME "logcollector"
 
 #define LEN_LOCATION        (10)    /*!< length of "location"*/
 #define LEN_BOOL_STR        (5)     /*!< length of "false"*/
@@ -56,6 +60,12 @@ size_t lccom_dispatch(char * command, char ** output){
             return strlen(*output);
         }
         return lccom_getconfig(rcv_args, output);
+
+    } else if (strcmp(rcv_comm, "getallconfig") == 0) {
+        return lccom_getallconfig(output);
+
+    } else if (strcmp(rcv_comm, "getallstats") == 0) {
+        return lccom_getallstats(output);
 
     } else if (strcmp(rcv_comm, "getstate") == 0) {
         if (rcv_args && !strncmp(rcv_args, "next", 4)){
@@ -449,6 +459,30 @@ size_t lccom_getstate(char ** output, bool getNextPage) {
         retval = strlen(*output);
     }
     return retval;
+}
+
+size_t lccom_getallconfig(char ** output) {
+
+    cJSON *report = cJSON_CreateArray();
+    cJSON *body = cJSON_CreateObject();
+
+    module_report_merge(body, getLocalfileConfig());
+    module_report_merge(body, getSocketConfig());
+    module_report_merge(body, getLogcollectorInternalOptions());
+
+    module_report_add_config(report, LCCOM_MODULE_NAME, body);
+    return module_report_reply(report, output);
+}
+
+size_t lccom_getallstats(char ** output) {
+
+    cJSON *report = cJSON_CreateArray();
+
+    /* Straight from the state rather than through lccom_getstate(): the report
+     * wants the statistics themselves, without that path's error envelope or
+     * its 64k paging, which a single reply cannot carry anyway. */
+    module_report_add_stats(report, LCCOM_MODULE_NAME, w_logcollector_state_get());
+    return module_report_reply(report, output);
 }
 
 size_t lccom_getconfig(const char * section, char ** output) {

--- a/src/os_execd/include/execd.h
+++ b/src/os_execd/include/execd.h
@@ -66,6 +66,14 @@ size_t wcom_uncompress(const char * source, const char * target, char ** output)
 size_t wcom_dispatch(char *command, char **output);
 size_t lock_restart(int timeout);
 size_t wcom_getconfig(const char * section, char ** output);
+
+/**
+ * @brief Build this daemon's entry for the agent's /config document.
+ *
+ * @param output Receives the allocated "ok <json>" reply.
+ * @return Length of *output.
+ */
+size_t wcom_getallconfig(char ** output);
 size_t wcom_check_manager_config(char **output);
 
 #ifndef WIN32

--- a/src/os_execd/src/wcom.c
+++ b/src/os_execd/src/wcom.c
@@ -19,6 +19,11 @@
 #include "agentd.h"
 #include "logcollector.h"
 #include "rootcheck.h"
+#include "module_report.h"
+
+/* Name this daemon reports itself under in the /config document. It owns the
+ * active-response, logging and internal sections. */
+#define WCOM_MODULE_NAME "execd"
 
 static int _jailfile(char finalpath[PATH_MAX + 1], const char * basedir, const char * filename);
 int req_timeout;
@@ -97,6 +102,9 @@ size_t wcom_dispatch(char *command, char ** output) {
             return strlen(*output);
         }
         return wcom_getconfig(rcv_args, output);
+
+    } else if (strcmp(rcv_comm, "getallconfig") == 0) {
+        return wcom_getallconfig(output);
 
     } else if (strcmp(rcv_comm, "check-manager-configuration") == 0) {
         return wcom_check_manager_config(output);
@@ -181,6 +189,21 @@ size_t wcom_uncompress(const char * source, const char * target, char ** output)
     gzclose(fsource);
     fclose(ftarget);
     return strlen(*output);
+}
+
+size_t wcom_getallconfig(char ** output) {
+
+    cJSON *report = cJSON_CreateArray();
+    cJSON *body = cJSON_CreateObject();
+
+    /* No "cluster" section here: it is manager-only and reaching it depends on
+     * a socket an agent never has. */
+    module_report_merge(body, getARConfig());
+    module_report_merge(body, getLoggingConfig());
+    module_report_merge(body, getExecdInternalOptions());
+
+    module_report_add_config(report, WCOM_MODULE_NAME, body);
+    return module_report_reply(report, output);
 }
 
 size_t wcom_getconfig(const char * section, char ** output) {

--- a/src/shared/include/module_report.h
+++ b/src/shared/include/module_report.h
@@ -1,0 +1,69 @@
+/*
+ * Module-tagged config and stats reports
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#ifndef MODULE_REPORT_H
+#define MODULE_REPORT_H
+
+#include <stddef.h>
+#include "cJSON.h"
+
+/* A report is a JSON array where each entry names one module and carries its
+ * body:
+ *
+ *   [{"module": "fim", "config": {...}}, {"module": "logcollector", ...}]
+ *
+ * Every agent daemon answers "getallconfig" / "getallstats" with the report for
+ * the modules it hosts, so the HTTPS client needs one query per daemon instead
+ * of one per configuration section. The client concatenates the arrays into the
+ * document it pushes to /config and /stats. */
+
+/**
+ * @brief Move every member of a section into a module body.
+ *
+ * The per-section getters return a one-key wrapper such as {"syscheck": {...}}.
+ * A module that spans several sections merges them into a single body. Does
+ * nothing when section is NULL, so a getter result can be passed straight in.
+ *
+ * @param body Destination object.
+ * @param section Source object. Consumed by this call.
+ */
+void module_report_merge(cJSON *body, cJSON *section);
+
+/**
+ * @brief Append a {"module": name, "config": body} entry to a report.
+ *
+ * A module that produced nothing is left out rather than reported empty, so the
+ * manager can tell "not configured" from "configured with no options".
+ *
+ * @param report Destination array.
+ * @param module Module name as the manager knows it, e.g. "fim".
+ * @param body Module body. Consumed by this call.
+ */
+void module_report_add_config(cJSON *report, const char *module, cJSON *body);
+
+/**
+ * @brief Append a {"module": name, "stats": body} entry to a report.
+ *
+ * @param report Destination array.
+ * @param module Module name as the manager knows it, e.g. "logcollector".
+ * @param body Module body. Consumed by this call.
+ */
+void module_report_add_stats(cJSON *report, const char *module, cJSON *body);
+
+/**
+ * @brief Serialize a report into the "ok <json>" reply a dispatcher returns.
+ *
+ * @param report Report array. Consumed by this call.
+ * @param output Receives the allocated reply.
+ * @return Length of *output.
+ */
+size_t module_report_reply(cJSON *report, char **output);
+
+#endif /* MODULE_REPORT_H */

--- a/src/shared/src/module_report.c
+++ b/src/shared/src/module_report.c
@@ -1,0 +1,93 @@
+/*
+ * Module-tagged config and stats reports
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include "shared.h"
+#include "module_report.h"
+
+void module_report_merge(cJSON *body, cJSON *section) {
+    cJSON *member = NULL;
+
+    if (!section) {
+        return;
+    }
+
+    if (!body) {
+        cJSON_Delete(section); /* Still consumed, as the contract promises. */
+        return;
+    }
+
+    while (member = section->child, member) {
+        /* cJSON_AddItemToObject copies the key before releasing the item's own
+         * name, so handing it member->string is safe. */
+        cJSON_DetachItemViaPointer(section, member);
+        cJSON_AddItemToObject(body, member->string, member);
+    }
+
+    cJSON_Delete(section);
+}
+
+/**
+ * @brief Append a {"module": name, <key>: body} entry, dropping empty bodies.
+ * @param report Destination array.
+ * @param module Module name.
+ * @param key Name under which the body is stored.
+ * @param body Module body. Consumed by this call.
+ */
+static void module_report_add(cJSON *report, const char *module, const char *key, cJSON *body) {
+    cJSON *entry = NULL;
+
+    if (!report || !module || !body) {
+        cJSON_Delete(body);
+        return;
+    }
+
+    if (!body->child) {
+        cJSON_Delete(body);
+        return;
+    }
+
+    if (entry = cJSON_CreateObject(), !entry) {
+        cJSON_Delete(body);
+        return;
+    }
+
+    cJSON_AddStringToObject(entry, "module", module);
+    cJSON_AddItemToObject(entry, key, body);
+    cJSON_AddItemToArray(report, entry);
+}
+
+void module_report_add_config(cJSON *report, const char *module, cJSON *body) {
+    module_report_add(report, module, "config", body);
+}
+
+void module_report_add_stats(cJSON *report, const char *module, cJSON *body) {
+    module_report_add(report, module, "stats", body);
+}
+
+size_t module_report_reply(cJSON *report, char **output) {
+    char *json_str = NULL;
+
+    if (!output) {
+        cJSON_Delete(report);
+        return 0;
+    }
+
+    if (json_str = cJSON_PrintUnformatted(report), !json_str) {
+        cJSON_Delete(report);
+        os_strdup("err Could not serialize the module report", *output);
+        return strlen(*output);
+    }
+
+    os_strdup("ok", *output);
+    wm_strcat(output, json_str, ' ');
+    os_free(json_str);
+    cJSON_Delete(report);
+    return strlen(*output);
+}

--- a/src/syscheckd/include/syscheck.h
+++ b/src/syscheckd/include/syscheck.h
@@ -715,6 +715,14 @@ size_t syscom_dispatch(char* command, size_t command_len, char** output);
  */
 size_t syscom_getconfig(const char* section, char** output);
 
+/**
+ * @brief Build this daemon's entry for the agent's /config document.
+ *
+ * @param output Receives the allocated "ok <json>" reply.
+ * @return Length of *output.
+ */
+size_t syscom_getallconfig(char** output);
+
 // Flush on-demand synchronization variables (thread-safe with atomic operations)
 extern atomic_int_t fim_flush_in_progress;  // 0 = idle, 1 = flush active
 extern atomic_int_t fim_flush_result;       // 0 = success, -1 = error (valid only when in_progress=0)

--- a/src/syscheckd/src/config.c
+++ b/src/syscheckd/src/config.c
@@ -121,7 +121,7 @@ void free_whodata_event(whodata_evt *w_evt) {
 /* Valid from program start: getSyscheckConfig() can run on another thread
  * before fim_initialize() has touched anything (see the declaration in
  * syscheck-config.h for why it cannot live in the zero-initialized struct). */
-volatile int syscheck_directories_lock_ready = 0;
+int syscheck_directories_lock_ready = 0;
 
 cJSON *getSyscheckConfig(void) {
     /* directories_lock is only pthread_rwlock_init'd partway through
@@ -129,7 +129,7 @@ cJSON *getSyscheckConfig(void) {
      * in-process report dispatch (agent_report.c), which runs on its own
      * thread with no socket to make it wait its turn -- would otherwise lock
      * memory nothing has initialized yet. */
-    if (!syscheck_directories_lock_ready) {
+    if (!syscheck_directories_lock_is_ready()) {
         return NULL;
     }
 

--- a/src/syscheckd/src/config.c
+++ b/src/syscheckd/src/config.c
@@ -118,13 +118,18 @@ void free_whodata_event(whodata_evt *w_evt) {
     free(w_evt);
 }
 
+/* Valid from program start: getSyscheckConfig() can run on another thread
+ * before fim_initialize() has touched anything (see the declaration in
+ * syscheck-config.h for why it cannot live in the zero-initialized struct). */
+volatile int syscheck_directories_lock_ready = 0;
+
 cJSON *getSyscheckConfig(void) {
     /* directories_lock is only pthread_rwlock_init'd partway through
      * Start_Syscheck(). A caller reaching here first -- e.g. the Windows
      * in-process report dispatch (agent_report.c), which runs on its own
      * thread with no socket to make it wait its turn -- would otherwise lock
      * memory nothing has initialized yet. */
-    if (!atomic_int_get(&syscheck.directories_lock_ready)) {
+    if (!syscheck_directories_lock_ready) {
         return NULL;
     }
 

--- a/src/syscheckd/src/config.c
+++ b/src/syscheckd/src/config.c
@@ -119,6 +119,15 @@ void free_whodata_event(whodata_evt *w_evt) {
 }
 
 cJSON *getSyscheckConfig(void) {
+    /* directories_lock is only pthread_rwlock_init'd partway through
+     * Start_Syscheck(). A caller reaching here first -- e.g. the Windows
+     * in-process report dispatch (agent_report.c), which runs on its own
+     * thread with no socket to make it wait its turn -- would otherwise lock
+     * memory nothing has initialized yet. */
+    if (!atomic_int_get(&syscheck.directories_lock_ready)) {
+        return NULL;
+    }
+
 #ifndef WIN32
     w_rwlock_rdlock(&syscheck.directories_lock);
     if (OSList_GetFirstNode(syscheck.directories) == NULL) {

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -476,7 +476,7 @@ void fim_initialize() {
 
     // Initialize locks before sync handle creation
     w_rwlock_init(&syscheck.directories_lock, NULL);
-    syscheck_directories_lock_ready = 1;
+    syscheck_set_directories_lock_ready();
     w_mutex_init(&syscheck.fim_scan_mutex, NULL);
     w_mutex_init(&syscheck.fim_realtime_mutex, NULL);
 #ifdef WIN32

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -476,7 +476,7 @@ void fim_initialize() {
 
     // Initialize locks before sync handle creation
     w_rwlock_init(&syscheck.directories_lock, NULL);
-    atomic_int_set(&syscheck.directories_lock_ready, 1);
+    syscheck_directories_lock_ready = 1;
     w_mutex_init(&syscheck.fim_scan_mutex, NULL);
     w_mutex_init(&syscheck.fim_realtime_mutex, NULL);
 #ifdef WIN32

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -476,6 +476,7 @@ void fim_initialize() {
 
     // Initialize locks before sync handle creation
     w_rwlock_init(&syscheck.directories_lock, NULL);
+    atomic_int_set(&syscheck.directories_lock_ready, 1);
     w_mutex_init(&syscheck.fim_scan_mutex, NULL);
     w_mutex_init(&syscheck.fim_realtime_mutex, NULL);
 #ifdef WIN32

--- a/src/syscheckd/src/syscom.c
+++ b/src/syscheckd/src/syscom.c
@@ -13,9 +13,13 @@
 #include "rootcheck.h"
 #include "os_net.h"
 #include "wmodules.h"
+#include "module_report.h"
 #include "module_query_errors.h"
 #include "db.h"
 #include "agent_sync_protocol_c_interface.h"
+
+/* Name this daemon reports itself under in the /config document. */
+#define SYSCOM_MODULE_NAME "fim"
 
 #ifdef WAZUH_UNIT_TESTING
 /* Replace assert with mock_assert */
@@ -260,6 +264,22 @@ error:
     mdebug1(FIM_SYSCOM_FAIL_GETCONFIG, section);
     os_strdup("err Could not get requested section", *output);
     return strlen(*output);
+}
+
+size_t syscom_getallconfig(char ** output) {
+    assert(output != NULL);
+
+    cJSON *report = cJSON_CreateArray();
+    cJSON *body = cJSON_CreateObject();
+
+    /* rootcheck ships inside this daemon, so it rides along in fim's body
+     * under its own section key rather than as a separate module entry. */
+    module_report_merge(body, getSyscheckConfig());
+    module_report_merge(body, getRootcheckConfig());
+    module_report_merge(body, getSyscheckInternalOptions());
+
+    module_report_add_config(report, SYSCOM_MODULE_NAME, body);
+    return module_report_reply(report, output);
 }
 
 size_t syscom_handle_agent_info_query(char * json_command, char ** output) {
@@ -621,6 +641,8 @@ size_t syscom_dispatch(char * command, size_t command_len, char ** output){
                 return strlen(*output);
             }
             return syscom_getconfig(rcv_args, output);
+        } else if (strcmp(rcv_comm, "getallconfig") == 0) {
+            return syscom_getallconfig(output);
         }
     } else if (strncmp(command, FIM_SYNC_HEADER, strlen(FIM_SYNC_HEADER)) == 0) {
         if (syscheck.enable_synchronization) {

--- a/src/syscheckd/src/syscom.c
+++ b/src/syscheckd/src/syscom.c
@@ -21,6 +21,9 @@
 /* Name this daemon reports itself under in the /config document. */
 #define SYSCOM_MODULE_NAME "fim"
 
+/* The whole-daemon config request (#37843). */
+#define SYSCOM_GETALLCONFIG "getallconfig"
+
 #ifdef WAZUH_UNIT_TESTING
 /* Replace assert with mock_assert */
 extern void mock_assert(const int result, const char* const expression,
@@ -617,8 +620,11 @@ size_t syscom_dispatch(char * command, size_t command_len, char ** output){
         return syscom_handle_json_query(command, output);
     }
 
+    /* HC_GETCONFIG is a prefix match, and "getallconfig" does not start with
+     * it, so it needs naming here or it never reaches the branch below. */
     if (strncmp(command, HC_SK, strlen(HC_SK)) == 0 ||
-               strncmp(command, HC_GETCONFIG, strlen(HC_GETCONFIG)) == 0) {
+               strncmp(command, HC_GETCONFIG, strlen(HC_GETCONFIG)) == 0 ||
+               strcmp(command, SYSCOM_GETALLCONFIG) == 0) {
         char *rcv_comm = NULL;
         char *rcv_args = NULL;
 
@@ -641,7 +647,7 @@ size_t syscom_dispatch(char * command, size_t command_len, char ** output){
                 return strlen(*output);
             }
             return syscom_getconfig(rcv_args, output);
-        } else if (strcmp(rcv_comm, "getallconfig") == 0) {
+        } else if (strcmp(rcv_comm, SYSCOM_GETALLCONFIG) == 0) {
             return syscom_getallconfig(output);
         }
     } else if (strncmp(command, FIM_SYNC_HEADER, strlen(FIM_SYNC_HEADER)) == 0) {

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -150,6 +150,14 @@ list(APPEND client-agent_flags "-Wl,--wrap,wurl_free_response -Wl,--wrap,wurl_ht
                                 ${DEBUG_OP_WRAPPERS}")
 endif()
 
+# Unix only: on Windows the aggregator dispatches in-process instead of going
+# through the component sockets these wrappers stand in for.
+if(NOT ${TARGET} STREQUAL "winagent")
+list(APPEND client-agent_names "test_agent_report")
+list(APPEND client-agent_flags "-Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP \
+                                -Wl,--wrap,OS_RecvSecureTCP ${DEBUG_OP_WRAPPERS}")
+endif()
+
 list(LENGTH client-agent_names count)
 math(EXPR count "${count} - 1")
 foreach(counter RANGE ${count})

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -150,10 +150,18 @@ list(APPEND client-agent_flags "-Wl,--wrap,wurl_free_response -Wl,--wrap,wurl_ht
                                 ${DEBUG_OP_WRAPPERS}")
 endif()
 
-# Unix only: on Windows the aggregator dispatches in-process instead of going
-# through the component sockets these wrappers stand in for.
-if(NOT ${TARGET} STREQUAL "winagent")
+# The aggregator reaches the daemons differently per platform, so each side
+# wraps what it actually calls: sockets on POSIX, the dispatchers in-process on
+# Windows. The assertions in the test are shared.
 list(APPEND client-agent_names "test_agent_report")
+if(${TARGET} STREQUAL "winagent")
+list(APPEND client-agent_flags "-Wl,--wrap,agcom_dispatch -Wl,--wrap,syscom_dispatch \
+                                -Wl,--wrap,lccom_dispatch -Wl,--wrap,wmcom_dispatch \
+                                -Wl,--wrap,wcom_dispatch \
+                                -Wl,--wrap=Start_win32_Syscheck -Wl,--wrap=is_fim_shutdown \
+                                -Wl,--wrap=fim_db_teardown -Wl,--wrap=_imp__dbsync_initialize \
+                                -Wl,--wrap=_imp__rsync_initialize ${DEBUG_OP_WRAPPERS}")
+else()
 list(APPEND client-agent_flags "-Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP \
                                 -Wl,--wrap,OS_RecvSecureTCP ${DEBUG_OP_WRAPPERS}")
 endif()

--- a/src/unit_tests/client-agent/https_client_stubs.c
+++ b/src/unit_tests/client-agent/https_client_stubs.c
@@ -52,6 +52,19 @@ bool hc_submit_event(void *handle, const uint8_t *frame, size_t length)
     return false;
 }
 
+/* Windows delivers /stateful sessions in-process, so the bridge calls this
+ * one only there -- which is why its absence broke the winagent test link
+ * while the POSIX build, whose sessions arrive over the sync socket, was fine. */
+bool hc_submit_sync_session(void *handle, const char *session_id, const uint8_t *buffer,
+                            size_t length)
+{
+    (void)handle;
+    (void)session_id;
+    (void)buffer;
+    (void)length;
+    return false;
+}
+
 void hc_notify_now(void *handle)
 {
     (void)handle;

--- a/src/unit_tests/client-agent/test_agcom.c
+++ b/src/unit_tests/client-agent/test_agcom.c
@@ -232,6 +232,110 @@ static void test_agcom_getconfig_unknown_section(void** state)
     free(output);
 }
 
+static void test_agcom_getallconfig_reports_every_section_as_one_module(void** state)
+{
+    (void)state;
+    char command[] = "getallconfig";
+    char* output = NULL;
+
+    g_client_cfg = make_simple_json("client", "ok");
+    g_buffer_cfg = make_simple_json("buffer", "ok");
+    g_internal_cfg = make_simple_json("internal", "ok");
+#ifndef WIN32
+    g_anti_tampering_cfg = make_simple_json("anti_tampering", "ok");
+#endif
+
+    size_t len = agcom_dispatch(command, &output);
+
+    assert_non_null(output);
+    assert_true(strncmp(output, "ok ", 3) == 0);
+    assert_int_equal((int)len, (int)strlen(output));
+
+    cJSON* report = cJSON_Parse(output + 3);
+    assert_non_null(report);
+    /* One entry for the whole daemon, with every section inside it: this is
+     * what saves the caller a query per section. */
+    assert_int_equal(cJSON_GetArraySize(report), 1);
+
+    cJSON* entry = cJSON_GetArrayItem(report, 0);
+    assert_string_equal(cJSON_GetObjectItem(entry, "module")->valuestring, "agent");
+
+    cJSON* config = cJSON_GetObjectItem(entry, "config");
+    assert_non_null(cJSON_GetObjectItem(config, "client"));
+    assert_non_null(cJSON_GetObjectItem(config, "buffer"));
+    assert_non_null(cJSON_GetObjectItem(config, "internal"));
+#ifndef WIN32
+    assert_non_null(cJSON_GetObjectItem(config, "anti_tampering"));
+#endif
+
+    cJSON_Delete(report);
+    free(output);
+}
+
+static void test_agcom_getallconfig_omits_sections_that_are_unset(void** state)
+{
+    (void)state;
+    char command[] = "getallconfig";
+    char* output = NULL;
+
+    /* Only the client section is configured; the rest return NULL. */
+    g_client_cfg = make_simple_json("client", "ok");
+
+    size_t len = agcom_dispatch(command, &output);
+
+    assert_int_equal((int)len, (int)strlen(output));
+
+    cJSON* report = cJSON_Parse(output + 3);
+    cJSON* config = cJSON_GetObjectItem(cJSON_GetArrayItem(report, 0), "config");
+    assert_non_null(cJSON_GetObjectItem(config, "client"));
+    assert_null(cJSON_GetObjectItem(config, "buffer"));
+
+    cJSON_Delete(report);
+    free(output);
+}
+
+static void test_agcom_getallstats_carries_the_state_as_an_object(void** state)
+{
+    (void)state;
+    char command[] = "getallstats";
+    char* output = NULL;
+    const char* previous = g_state_output;
+
+    g_state_output = "{\"status\":\"connected\"}";
+
+    size_t len = agcom_dispatch(command, &output);
+
+    assert_int_equal((int)len, (int)strlen(output));
+
+    cJSON* report = cJSON_Parse(output + 3);
+    cJSON* entry = cJSON_GetArrayItem(report, 0);
+    assert_string_equal(cJSON_GetObjectItem(entry, "module")->valuestring, "agent");
+    /* Parsed, not embedded as a string holding JSON. */
+    assert_string_equal(
+        cJSON_GetObjectItem(cJSON_GetObjectItem(entry, "stats"), "status")->valuestring,
+        "connected");
+
+    cJSON_Delete(report);
+    free(output);
+    g_state_output = previous;
+}
+
+static void test_agcom_getallstats_drops_state_that_is_not_json(void** state)
+{
+    (void)state;
+    char command[] = "getallstats";
+    char* output = NULL;
+
+    /* g_state_output is the default "ok state", which is not a document. The
+     * entry must be left out rather than reported as a broken one. */
+    size_t len = agcom_dispatch(command, &output);
+
+    assert_int_equal((int)len, (int)strlen(output));
+    assert_string_equal(output, "ok []");
+
+    free(output);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -246,6 +350,10 @@ int main(void)
 #endif
         cmocka_unit_test(test_agcom_getconfig_client_error),
         cmocka_unit_test(test_agcom_getconfig_unknown_section),
+        cmocka_unit_test(test_agcom_getallconfig_reports_every_section_as_one_module),
+        cmocka_unit_test(test_agcom_getallconfig_omits_sections_that_are_unset),
+        cmocka_unit_test(test_agcom_getallstats_carries_the_state_as_an_object),
+        cmocka_unit_test(test_agcom_getallstats_drops_state_that_is_not_json),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/client-agent/test_agent_report.c
+++ b/src/unit_tests/client-agent/test_agent_report.c
@@ -1,0 +1,266 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <cJSON.h>
+
+#include "agentd.h"
+#include "../wrappers/wazuh/os_net/os_net_wrappers.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+
+/* The aggregator asks each daemon in turn. These stubs stand in for the
+ * component sockets so a test can decide, per component, whether it answers,
+ * refuses, or is not there at all. */
+
+typedef struct answer_t {
+    const char* target;     ///< Component the answer belongs to.
+    const char* reply;      ///< Reply to hand back, NULL when unreachable.
+} answer_t;
+
+static const answer_t* g_answers = NULL;
+static size_t g_answer_count = 0;
+static const char* g_connected_target = NULL;
+static int g_connect_calls = 0;
+
+/* --- Stub implementations --- */
+static const answer_t* answer_for(const char* target)
+{
+    size_t i;
+
+    for (i = 0; i < g_answer_count; i++) {
+        if (strcmp(g_answers[i].target, target) == 0) {
+            return &g_answers[i];
+        }
+    }
+
+    return NULL;
+}
+
+int __wrap_OS_ConnectUnixDomain(const char* path, __attribute__((unused)) int type,
+                                __attribute__((unused)) int max_msg_size)
+{
+    /* The path is "queue/sockets/<target>"; keep the target so the recv stub
+     * knows which component this socket belongs to. */
+    const char* target = strrchr(path, '/');
+    const answer_t* answer = answer_for(target ? target + 1 : path);
+
+    g_connect_calls++;
+
+    if (!answer || !answer->reply) {
+        return -1;
+    }
+
+    g_connected_target = answer->target;
+    return 42;
+}
+
+int __wrap_OS_SendSecureTCP(__attribute__((unused)) int sock,
+                            __attribute__((unused)) uint32_t size,
+                            __attribute__((unused)) const void* msg)
+{
+    return 0;
+}
+
+int __wrap_OS_RecvSecureTCP(__attribute__((unused)) int sock, char* ret,
+                            __attribute__((unused)) uint32_t size)
+{
+    const answer_t* answer = g_connected_target ? answer_for(g_connected_target) : NULL;
+
+    if (!answer || !answer->reply) {
+        return -1;
+    }
+
+    strcpy(ret, answer->reply);
+    return (int)strlen(answer->reply);
+}
+
+/* --- Helpers --- */
+static void given(const answer_t* answers, size_t count)
+{
+    g_answers = answers;
+    g_answer_count = count;
+    g_connected_target = NULL;
+    g_connect_calls = 0;
+}
+
+/// @brief Allow the debug lines a component that is down or refusing produces.
+///        Only the tests that exercise those paths may declare this: cmocka
+///        fails a test that leaves the expectation unused.
+static void expecting_debug_logs(void)
+{
+    expect_any_always(__wrap__mdebug1, formatted_msg);
+}
+
+static cJSON* module_named(cJSON* document, const char* name)
+{
+    cJSON* modules = cJSON_GetObjectItem(document, "modules");
+    cJSON* entry = NULL;
+
+    cJSON_ArrayForEach(entry, modules) {
+        cJSON* module = cJSON_GetObjectItem(entry, "module");
+
+        if (module && strcmp(module->valuestring, name) == 0) {
+            return entry;
+        }
+    }
+
+    return NULL;
+}
+
+/* --- Tests --- */
+static void test_collect_config_merges_every_daemon_into_one_document(void** state)
+{
+    (void)state;
+    const answer_t answers[] = {
+        {"agent", "ok [{\"module\":\"agent\",\"config\":{\"client\":{}}}]"},
+        {"syscheck", "ok [{\"module\":\"fim\",\"config\":{\"syscheck\":{}}}]"},
+        {"logcollector", "ok [{\"module\":\"logcollector\",\"config\":{\"localfile\":[]}}]"},
+        /* One daemon, two modules: modulesd reports each wodle separately. */
+        {"wmodules", "ok [{\"module\":\"syscollector\",\"config\":{}},"
+                     "{\"module\":\"sca\",\"config\":{}}]"},
+        {"com", "ok [{\"module\":\"execd\",\"config\":{\"active-response\":[]}}]"},
+    };
+
+    given(answers, 5);
+
+    char* document = w_agent_collect_config();
+
+    assert_non_null(document);
+
+    cJSON* parsed = cJSON_Parse(document);
+    assert_non_null(parsed);
+
+    /* One query per daemon, and every module they named is present. */
+    assert_int_equal(g_connect_calls, 5);
+    assert_int_equal(cJSON_GetArraySize(cJSON_GetObjectItem(parsed, "modules")), 6);
+    assert_non_null(module_named(parsed, "agent"));
+    assert_non_null(module_named(parsed, "fim"));
+    assert_non_null(module_named(parsed, "logcollector"));
+    assert_non_null(module_named(parsed, "syscollector"));
+    assert_non_null(module_named(parsed, "sca"));
+    assert_non_null(module_named(parsed, "execd"));
+
+    cJSON_Delete(parsed);
+    free(document);
+}
+
+static void test_collect_config_reports_the_daemons_that_are_up(void** state)
+{
+    (void)state;
+    const answer_t answers[] = {
+        {"agent", "ok [{\"module\":\"agent\",\"config\":{\"client\":{}}}]"},
+        {"syscheck", NULL},         /* not running */
+        {"logcollector", "err Could not get requested section"},
+        {"wmodules", "ok [{\"module\":\"sca\",\"config\":{}}]"},
+        {"com", NULL},
+    };
+
+    given(answers, 5);
+    expecting_debug_logs();
+
+    char* document = w_agent_collect_config();
+
+    assert_non_null(document);
+
+    cJSON* parsed = cJSON_Parse(document);
+    /* A daemon that is down or refuses is left out; the rest still report, so
+     * one sick component does not cost the manager the whole document. */
+    assert_int_equal(cJSON_GetArraySize(cJSON_GetObjectItem(parsed, "modules")), 2);
+    assert_non_null(module_named(parsed, "agent"));
+    assert_non_null(module_named(parsed, "sca"));
+    assert_null(module_named(parsed, "fim"));
+
+    cJSON_Delete(parsed);
+    free(document);
+}
+
+static void test_collect_config_skips_the_cycle_when_nothing_answers(void** state)
+{
+    (void)state;
+    const answer_t answers[] = {
+        {"agent", NULL},
+        {"syscheck", NULL},
+        {"logcollector", NULL},
+        {"wmodules", NULL},
+        {"com", NULL},
+    };
+
+    given(answers, 5);
+    expecting_debug_logs();
+
+    /* Pushing {"modules":[]} here would overwrite a good document in the
+     * manager's index with an empty one, so the cycle is skipped instead. */
+    assert_null(w_agent_collect_config());
+}
+
+static void test_collect_config_ignores_a_reply_that_is_not_a_report(void** state)
+{
+    (void)state;
+    const answer_t answers[] = {
+        {"agent", "ok {\"module\":\"agent\"}"},   /* an object, not an array */
+        {"syscheck", "ok not json at all"},
+        {"logcollector", "ok [{\"module\":\"logcollector\",\"config\":{}}]"},
+        {"wmodules", NULL},
+        {"com", NULL},
+    };
+
+    given(answers, 5);
+    expecting_debug_logs();
+
+    char* document = w_agent_collect_config();
+    cJSON* parsed = cJSON_Parse(document);
+
+    assert_int_equal(cJSON_GetArraySize(cJSON_GetObjectItem(parsed, "modules")), 1);
+    assert_non_null(module_named(parsed, "logcollector"));
+
+    cJSON_Delete(parsed);
+    free(document);
+}
+
+static void test_collect_stats_only_asks_the_daemons_that_produce_them(void** state)
+{
+    (void)state;
+    const answer_t answers[] = {
+        {"agent", "ok [{\"module\":\"agent\",\"stats\":{\"status\":\"connected\"}}]"},
+        {"logcollector", "ok [{\"module\":\"logcollector\",\"stats\":{}}]"},
+    };
+
+    given(answers, 2);
+
+    char* document = w_agent_collect_stats();
+
+    assert_non_null(document);
+
+    cJSON* parsed = cJSON_Parse(document);
+    /* Only two daemons have a getstate handler, so only two are queried. */
+    assert_int_equal(g_connect_calls, 2);
+    assert_int_equal(cJSON_GetArraySize(cJSON_GetObjectItem(parsed, "modules")), 2);
+
+    cJSON_Delete(parsed);
+    free(document);
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_collect_config_merges_every_daemon_into_one_document),
+        cmocka_unit_test(test_collect_config_reports_the_daemons_that_are_up),
+        cmocka_unit_test(test_collect_config_skips_the_cycle_when_nothing_answers),
+        cmocka_unit_test(test_collect_config_ignores_a_reply_that_is_not_a_report),
+        cmocka_unit_test(test_collect_stats_only_asks_the_daemons_that_produce_them),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/client-agent/test_agent_report.c
+++ b/src/unit_tests/client-agent/test_agent_report.c
@@ -17,12 +17,19 @@
 #include <cJSON.h>
 
 #include "agentd.h"
-#include "../wrappers/wazuh/os_net/os_net_wrappers.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+#ifndef TEST_WINAGENT
+#include "../wrappers/wazuh/os_net/os_net_wrappers.h"
+#endif
 
-/* The aggregator asks each daemon in turn. These stubs stand in for the
- * component sockets so a test can decide, per component, whether it answers,
- * refuses, or is not there at all. */
+/* The aggregator asks each daemon in turn. These stubs stand in for whatever it
+ * asks THROUGH, so a test can decide, per component, whether it answers,
+ * refuses, or is not there at all.
+ *
+ * The two platforms reach the daemons differently and both need covering: on
+ * POSIX each one is a separate process behind a socket, while a Windows agent
+ * runs them all in-process and calls their dispatchers directly. The stubs
+ * below switch; every assertion further down is shared. */
 
 typedef struct answer_t {
     const char* target;     ///< Component the answer belongs to.
@@ -47,6 +54,8 @@ static const answer_t* answer_for(const char* target)
 
     return NULL;
 }
+
+#ifndef TEST_WINAGENT
 
 int __wrap_OS_ConnectUnixDomain(const char* path, __attribute__((unused)) int type,
                                 __attribute__((unused)) int max_msg_size)
@@ -85,6 +94,58 @@ int __wrap_OS_RecvSecureTCP(__attribute__((unused)) int sock, char* ret,
     strcpy(ret, answer->reply);
     return (int)strlen(answer->reply);
 }
+
+#else /* TEST_WINAGENT */
+
+/**
+ * @brief Stand in for one component's dispatcher.
+ *
+ * A component that is "not there" answers 0 with no output, which is what a
+ * dispatcher that does not recognise the command does; the aggregator has to
+ * treat that the same way it treats an unreachable socket on POSIX.
+ */
+static size_t dispatch_as(const char* target, char** output)
+{
+    const answer_t* answer = answer_for(target);
+
+    g_connect_calls++;
+
+    if (!answer || !answer->reply) {
+        return 0;
+    }
+
+    os_strdup(answer->reply, *output);
+    return strlen(*output);
+}
+
+size_t __wrap_agcom_dispatch(__attribute__((unused)) char* command, char** output)
+{
+    return dispatch_as("agent", output);
+}
+
+size_t __wrap_syscom_dispatch(__attribute__((unused)) char* command,
+                              __attribute__((unused)) size_t command_len, char** output)
+{
+    return dispatch_as("syscheck", output);
+}
+
+size_t __wrap_lccom_dispatch(__attribute__((unused)) char* command, char** output)
+{
+    return dispatch_as("logcollector", output);
+}
+
+size_t __wrap_wmcom_dispatch(__attribute__((unused)) char* command,
+                             __attribute__((unused)) size_t command_len, char** output)
+{
+    return dispatch_as("wmodules", output);
+}
+
+size_t __wrap_wcom_dispatch(__attribute__((unused)) char* command, char** output)
+{
+    return dispatch_as("com", output);
+}
+
+#endif /* TEST_WINAGENT */
 
 /* --- Helpers --- */
 static void given(const answer_t* answers, size_t count)

--- a/src/unit_tests/client-agent/test_task_registry_ipc_component.cpp
+++ b/src/unit_tests/client-agent/test_task_registry_ipc_component.cpp
@@ -176,6 +176,29 @@ namespace
         return std::string(buffer);
     }
 
+    /// agent-info logs through a C callback; without one its own failures are
+    /// silent, which is what hid this test's missing setup. Route it to stderr so
+    /// a future breakage says why.
+    void testLogCallback(modules_log_level_t level, const char* msg, const char* tag)
+    {
+        if (level == LOG_ERROR || level == LOG_WARNING)
+        {
+            fprintf(stderr, "[%s] %s\n", tag ? tag : "agent-info", msg ? msg : "");
+        }
+    }
+
+    /// agent-info can query sibling modules; nothing in this test's path does, but
+    /// the constructor requires the function to be present.
+    int testQueryModuleCallback(const char*, const char*, char** response)
+    {
+        if (response)
+        {
+            *response = nullptr;
+        }
+
+        return -1;
+    }
+
     class TaskRegistryIpcComponentTest : public ::testing::Test
     {
         protected:
@@ -199,6 +222,16 @@ namespace
                 m_module.data = nullptr;
                 m_module.next = nullptr;
                 wmodules = &m_module;
+
+                // AgentInfoImpl's constructor requires both a log and a query-module
+                // function and throws std::invalid_argument without them. It builds its
+                // DBSync member first, so agent_info.db and its schema appear on disk
+                // either way; the throw then leaves g_agent_info_impl null and
+                // agent_info_ensure_database() reports it through the log callback that
+                // is not set yet, so skipping these two reads as "the database is there
+                // but every task query answers MQ_ERR_INTERNAL".
+                agent_info_set_log_function(testLogCallback);
+                agent_info_set_query_module_function(testQueryModuleCallback);
 
                 // agent_info_task_registry_init() constructs agent_info.db as a side effect
                 // (see its own comment) -- no separate agent_info_start()/blocking sync loop

--- a/src/unit_tests/config/test_client-config_https.c
+++ b/src/unit_tests/config/test_client-config_https.c
@@ -391,6 +391,120 @@ static void test_retry_interval_is_deprecated(void **state) {
     cleanup(&xml, nodes, &cfg);
 }
 
+
+/* <stats_report> / <config_report> blocks (#37843) */
+
+static void test_reports_are_off_when_absent(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    /* Both pushes must default to off: the manager's config/stats indices have
+     * a single writer, and nobody asked for it yet. */
+    const char *xml_str = "<server><address>10.0.0.1</address></server>";
+
+    expect_valid_ip("10.0.0.1");
+
+    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(cfg.stats_report.enabled, 0);
+    assert_int_equal(cfg.config_report.enabled, 0);
+    assert_int_equal(cfg.stats_report.interval, 0);
+    assert_int_equal(cfg.config_report.interval, 0);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_reports_are_independent_of_each_other(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    /* The issue requires two separate toggles: enabling stats must leave the
+     * config push alone. */
+    const char *xml_str =
+        "<server><address>10.0.0.1</address></server>"
+        "<stats_report><enabled>yes</enabled><interval>30s</interval></stats_report>";
+
+    expect_valid_ip("10.0.0.1");
+
+    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(cfg.stats_report.enabled, 1);
+    assert_int_equal(cfg.stats_report.interval, 30);
+    assert_int_equal(cfg.config_report.enabled, 0);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_reports_accept_time_suffixes(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str =
+        "<server><address>10.0.0.1</address></server>"
+        "<stats_report><enabled>yes</enabled><interval>2m</interval></stats_report>"
+        "<config_report><enabled>yes</enabled><interval>1h</interval></config_report>";
+
+    expect_valid_ip("10.0.0.1");
+
+    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(cfg.stats_report.interval, 120);
+    assert_int_equal(cfg.config_report.interval, 3600);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_report_enabled_rejects_a_non_boolean(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str =
+        "<server><address>10.0.0.1</address></server>"
+        "<config_report><enabled>maybe</enabled></config_report>";
+
+    expect_valid_ip("10.0.0.1");
+    expect_any(__wrap__merror, formatted_msg);
+
+    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_report_interval_beyond_a_day_is_rejected(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str =
+        "<server><address>10.0.0.1</address></server>"
+        "<stats_report><interval>2d</interval></stats_report>";
+
+    expect_valid_ip("10.0.0.1");
+    expect_any(__wrap__merror, formatted_msg);
+
+    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_report_invalid_tag_is_rejected(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str =
+        "<server><address>10.0.0.1</address></server>"
+        "<stats_report><cadence>30s</cadence></stats_report>";
+
+    expect_valid_ip("10.0.0.1");
+    expect_any(__wrap__merror, formatted_msg);
+
+    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_ssl_full_verification_mode),
@@ -408,6 +522,12 @@ int main(void) {
         cmocka_unit_test(test_batch_zero_size_is_rejected),
         cmocka_unit_test(test_batch_interval_beyond_a_day_is_rejected),
         cmocka_unit_test(test_batch_invalid_tag_is_rejected),
+        cmocka_unit_test(test_reports_are_off_when_absent),
+        cmocka_unit_test(test_reports_are_independent_of_each_other),
+        cmocka_unit_test(test_reports_accept_time_suffixes),
+        cmocka_unit_test(test_report_enabled_rejects_a_non_boolean),
+        cmocka_unit_test(test_report_interval_beyond_a_day_is_rejected),
+        cmocka_unit_test(test_report_invalid_tag_is_rejected),
         cmocka_unit_test(test_time_reconnect_is_deprecated),
         cmocka_unit_test(test_max_retries_is_deprecated),
         cmocka_unit_test(test_retry_interval_is_deprecated),

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -390,6 +390,9 @@ endif()
 list(APPEND shared_tests_names "test_hash_op")
 list(APPEND shared_tests_flags "${DEBUG_OP_WRAPPERS}")
 
+list(APPEND shared_tests_names "test_module_report")
+list(APPEND shared_tests_flags "${DEBUG_OP_WRAPPERS}")
+
 # Compiling tests
 list(LENGTH shared_tests_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/shared/test_module_report.c
+++ b/src/unit_tests/shared/test_module_report.c
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <cJSON.h>
+
+#include "module_report.h"
+
+/* --- Helpers --- */
+static cJSON* wrapped_section(const char* name, const char* key, const char* value)
+{
+    cJSON* section = cJSON_CreateObject();
+    cJSON* inner = cJSON_CreateObject();
+
+    cJSON_AddStringToObject(inner, key, value);
+    cJSON_AddItemToObject(section, name, inner);
+
+    return section;
+}
+
+/* --- module_report_merge --- */
+static void test_merge_moves_every_section_under_one_body(void** state)
+{
+    (void)state;
+    cJSON* body = cJSON_CreateObject();
+
+    module_report_merge(body, wrapped_section("syscheck", "frequency", "43200"));
+    module_report_merge(body, wrapped_section("rootcheck", "disabled", "no"));
+
+    /* Both sections keep their own key, side by side in the same body. */
+    assert_non_null(cJSON_GetObjectItem(body, "syscheck"));
+    assert_non_null(cJSON_GetObjectItem(body, "rootcheck"));
+    assert_string_equal(
+        cJSON_GetObjectItem(cJSON_GetObjectItem(body, "syscheck"), "frequency")->valuestring,
+        "43200");
+
+    cJSON_Delete(body);
+}
+
+static void test_merge_ignores_a_getter_that_returned_nothing(void** state)
+{
+    (void)state;
+    cJSON* body = cJSON_CreateObject();
+
+    /* A disabled component's getter returns NULL; passing it straight in must
+     * be harmless so call sites need no guard. */
+    module_report_merge(body, NULL);
+
+    assert_null(body->child);
+
+    cJSON_Delete(body);
+}
+
+static void test_merge_consumes_the_section_even_without_a_body(void** state)
+{
+    (void)state;
+
+    /* The contract is that merge always takes the section. Leak checkers in CI
+     * are what actually enforce this; the call must simply not crash. */
+    module_report_merge(NULL, wrapped_section("syscheck", "frequency", "43200"));
+}
+
+/* --- module_report_add_config / _add_stats --- */
+static void test_add_config_names_the_module_and_nests_its_body(void** state)
+{
+    (void)state;
+    cJSON* report = cJSON_CreateArray();
+    cJSON* body = cJSON_CreateObject();
+
+    cJSON_AddStringToObject(body, "disabled", "no");
+    module_report_add_config(report, "fim", body);
+
+    assert_int_equal(cJSON_GetArraySize(report), 1);
+    cJSON* entry = cJSON_GetArrayItem(report, 0);
+    assert_string_equal(cJSON_GetObjectItem(entry, "module")->valuestring, "fim");
+    assert_string_equal(
+        cJSON_GetObjectItem(cJSON_GetObjectItem(entry, "config"), "disabled")->valuestring, "no");
+
+    cJSON_Delete(report);
+}
+
+static void test_add_stats_files_the_body_under_stats(void** state)
+{
+    (void)state;
+    cJSON* report = cJSON_CreateArray();
+    cJSON* body = cJSON_CreateObject();
+
+    cJSON_AddNumberToObject(body, "events", 12);
+    module_report_add_stats(report, "logcollector", body);
+
+    cJSON* entry = cJSON_GetArrayItem(report, 0);
+    assert_null(cJSON_GetObjectItem(entry, "config"));
+    assert_non_null(cJSON_GetObjectItem(entry, "stats"));
+
+    cJSON_Delete(report);
+}
+
+static void test_add_leaves_out_a_module_that_reported_nothing(void** state)
+{
+    (void)state;
+    cJSON* report = cJSON_CreateArray();
+
+    /* An empty body and a missing one both mean "this module said nothing", so
+     * neither may appear: absent and empty must stay distinguishable. */
+    module_report_add_config(report, "fim", cJSON_CreateObject());
+    module_report_add_config(report, "logcollector", NULL);
+
+    assert_int_equal(cJSON_GetArraySize(report), 0);
+
+    cJSON_Delete(report);
+}
+
+/* --- module_report_reply --- */
+static void test_reply_prefixes_the_serialized_report_with_ok(void** state)
+{
+    (void)state;
+    cJSON* report = cJSON_CreateArray();
+    cJSON* body = cJSON_CreateObject();
+    char* output = NULL;
+
+    cJSON_AddStringToObject(body, "disabled", "no");
+    module_report_add_config(report, "fim", body);
+
+    size_t length = module_report_reply(report, &output);
+
+    assert_non_null(output);
+    assert_string_equal(output, "ok [{\"module\":\"fim\",\"config\":{\"disabled\":\"no\"}}]");
+    assert_int_equal((int)length, (int)strlen(output));
+
+    free(output);
+}
+
+static void test_reply_still_answers_when_no_module_reported(void** state)
+{
+    (void)state;
+    char* output = NULL;
+
+    /* An empty array is a valid answer: the daemon is up and hosts nothing
+     * worth reporting. The caller must not read that as a failure. */
+    size_t length = module_report_reply(cJSON_CreateArray(), &output);
+
+    assert_string_equal(output, "ok []");
+    assert_int_equal((int)length, (int)strlen(output));
+
+    free(output);
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_merge_moves_every_section_under_one_body),
+        cmocka_unit_test(test_merge_ignores_a_getter_that_returned_nothing),
+        cmocka_unit_test(test_merge_consumes_the_section_even_without_a_body),
+        cmocka_unit_test(test_add_config_names_the_module_and_nests_its_body),
+        cmocka_unit_test(test_add_stats_files_the_body_under_stats),
+        cmocka_unit_test(test_add_leaves_out_a_module_that_reported_nothing),
+        cmocka_unit_test(test_reply_prefixes_the_serialized_report_with_ok),
+        cmocka_unit_test(test_reply_still_answers_when_no_module_reported),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/syscheckd/test_config.c
+++ b/src/unit_tests/syscheckd/test_config.c
@@ -632,11 +632,11 @@ void test_getSyscheckConfig_lock_not_ready(void **state)
 
     /* Windows reaches this in-process and can beat fim_initialize() to it.
      * Declining is what keeps it off an rwlock nothing has initialized. */
-    syscheck_directories_lock_ready = 0;
+    __atomic_store_n(&syscheck_directories_lock_ready, 0, __ATOMIC_RELEASE);
 
     assert_null(getSyscheckConfig());
 
-    syscheck_directories_lock_ready = 1;
+    syscheck_set_directories_lock_ready();
 }
 
 void test_getSyscheckInternalOptions(void **state)
@@ -879,7 +879,7 @@ void test_fim_adjust_path_convert_system32 (void **state) {
 int main(void) {
     /* getSyscheckConfig() declines until fim_initialize() publishes this.
      * fim_initialize() does this once directories_lock is real. */
-    syscheck_directories_lock_ready = 1;
+    syscheck_set_directories_lock_ready();
 
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown(test_Read_Syscheck_Config_success, setup_read_config, restart_syscheck),

--- a/src/unit_tests/syscheckd/test_config.c
+++ b/src/unit_tests/syscheckd/test_config.c
@@ -626,6 +626,19 @@ void test_SyscheckConf_DirectoriesWithCommas(void **state) {
     #endif
 }
 
+void test_getSyscheckConfig_lock_not_ready(void **state)
+{
+    (void) state;
+
+    /* Windows reaches this in-process and can beat fim_initialize() to it.
+     * Declining is what keeps it off an rwlock nothing has initialized. */
+    syscheck_directories_lock_ready = 0;
+
+    assert_null(getSyscheckConfig());
+
+    syscheck_directories_lock_ready = 1;
+}
+
 void test_getSyscheckInternalOptions(void **state)
 {
     (void) state;
@@ -864,6 +877,10 @@ void test_fim_adjust_path_convert_system32 (void **state) {
 }
 
 int main(void) {
+    /* getSyscheckConfig() declines until fim_initialize() publishes this.
+     * fim_initialize() does this once directories_lock is real. */
+    syscheck_directories_lock_ready = 1;
+
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown(test_Read_Syscheck_Config_success, setup_read_config, restart_syscheck),
         cmocka_unit_test_setup_teardown(test_Read_Syscheck_Config_invalid, setup_read_config, restart_syscheck),
@@ -872,6 +889,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_getSyscheckConfig, setup_read_config, restart_syscheck),
         cmocka_unit_test_setup_teardown(test_getSyscheckConfig_no_audit, setup_read_config, restart_syscheck),
         cmocka_unit_test_setup_teardown(test_getSyscheckConfig_no_directories, setup_read_config, restart_syscheck),
+        cmocka_unit_test(test_getSyscheckConfig_lock_not_ready),
         cmocka_unit_test_setup_teardown(test_getSyscheckInternalOptions, setup_read_config, restart_syscheck),
         cmocka_unit_test_setup_teardown(test_SyscheckConf_DirectoriesWithCommas, setup_read_config, restart_syscheck),
         cmocka_unit_test_setup_teardown(test_fim_create_directory_add_new_entry, setup_entry, teardown_entry),

--- a/src/unit_tests/syscheckd/test_syscom.c
+++ b/src/unit_tests/syscheckd/test_syscom.c
@@ -333,6 +333,32 @@ void test_syscom_getconfig_null_output(void **state)
 }
 
 
+
+void test_syscom_dispatch_getallconfig(void **state)
+{
+    (void) state;
+    size_t ret;
+
+    /* "getallconfig" does not start with HC_GETCONFIG, so the outer prefix
+     * guard in syscom_dispatch has to name it explicitly. When it did not, the
+     * whole daemon answered "err Unrecognized command" and fim went missing
+     * from every /config document the agent pushed (#37843). */
+    char command[] = "getallconfig";
+    char * output = NULL;
+
+    will_return(__wrap_getSyscheckConfig, NULL);
+    will_return(__wrap_getRootcheckConfig, NULL);
+    will_return(__wrap_getSyscheckInternalOptions, NULL);
+
+    ret = syscom_dispatch(command, strlen(command), &output);
+    *state = output;
+
+    /* Every getter empty still has to be a report, not a rejection: the caller
+     * tells "this daemon reported nothing" from "this daemon is unreachable". */
+    assert_string_equal(output, "ok []");
+    assert_int_equal(ret, strlen(output));
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_teardown(test_syscom_dispatch_getconfig_agent, delete_string),
@@ -351,6 +377,7 @@ int main(void) {
         cmocka_unit_test_teardown(test_syscom_getconfig_rootcheck_failure, delete_string),
         cmocka_unit_test_teardown(test_syscom_getconfig_internal, delete_string),
         cmocka_unit_test_teardown(test_syscom_getconfig_internal_failure, delete_string),
+        cmocka_unit_test_teardown(test_syscom_dispatch_getallconfig, delete_string),
         cmocka_unit_test(test_syscom_getconfig_null_section),
         cmocka_unit_test(test_syscom_getconfig_null_output),
     };

--- a/src/unit_tests/wazuh_modules/wmodules/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/wmodules/CMakeLists.txt
@@ -34,6 +34,10 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 list(APPEND wmodules_names "test_wmodules")
 list(APPEND wmodules_flags "-Wl,--wrap,w_query_agentd -Wl,--wrap,_merror -Wl,--wrap,_mdebug1")
 
+list(APPEND wmodules_names "test_wmcom")
+list(APPEND wmodules_flags "-Wl,--wrap,getModulesConfig -Wl,--wrap,getModulesInternalOptions \
+                            -Wl,--wrap,w_query_agentd -Wl,--wrap,_merror -Wl,--wrap,_mdebug1")
+
 # Compilig tests
 list(LENGTH wmodules_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/wazuh_modules/wmodules/test_wmcom.c
+++ b/src/unit_tests/wazuh_modules/wmodules/test_wmcom.c
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <cJSON.h>
+
+#include "wmodules.h"
+
+/* --- Stub controls --- */
+static cJSON* g_modules_cfg = NULL;
+static cJSON* g_internal_cfg = NULL;
+
+/* --- Stub implementations --- */
+cJSON* __wrap_getModulesConfig(void)
+{
+    cJSON* ret = g_modules_cfg;
+    g_modules_cfg = NULL;
+
+    return ret;
+}
+
+cJSON* __wrap_getModulesInternalOptions(void)
+{
+    cJSON* ret = g_internal_cfg;
+    g_internal_cfg = NULL;
+
+    return ret;
+}
+
+/* --- Helpers --- */
+
+/// @brief Build what getModulesConfig() returns: {"wmodules": [{"<name>": {...}}, ...]}.
+static cJSON* dumped_wodles(const char** names, size_t count)
+{
+    cJSON* root = cJSON_CreateObject();
+    cJSON* array = cJSON_CreateArray();
+    size_t i;
+
+    for (i = 0; i < count; i++) {
+        cJSON* wodle = cJSON_CreateObject();
+        cJSON* body = cJSON_CreateObject();
+
+        cJSON_AddStringToObject(body, "disabled", "no");
+        cJSON_AddItemToObject(wodle, names[i], body);
+        cJSON_AddItemToArray(array, wodle);
+    }
+
+    cJSON_AddItemToObject(root, "wmodules", array);
+    return root;
+}
+
+static cJSON* entry_named(cJSON* report, const char* name)
+{
+    cJSON* entry = NULL;
+
+    cJSON_ArrayForEach(entry, report) {
+        if (strcmp(cJSON_GetObjectItem(entry, "module")->valuestring, name) == 0) {
+            return entry;
+        }
+    }
+
+    return NULL;
+}
+
+/* --- Tests --- */
+static void test_getallconfig_gives_each_wodle_its_own_entry(void** state)
+{
+    (void)state;
+    const char* names[] = {"syscollector", "sca"};
+    char command[] = "getallconfig";
+    char* output = NULL;
+
+    g_modules_cfg = dumped_wodles(names, 2);
+
+    size_t len = wmcom_dispatch(command, strlen(command), &output);
+
+    assert_non_null(output);
+    assert_true(strncmp(output, "ok ", 3) == 0);
+    assert_int_equal((int)len, (int)strlen(output));
+
+    cJSON* report = cJSON_Parse(output + 3);
+    assert_non_null(report);
+
+    /* One daemon, but the modules it hosts stay individually addressable
+     * instead of being buried in a single "wmodules" blob. */
+    assert_int_equal(cJSON_GetArraySize(report), 2);
+    assert_non_null(entry_named(report, "syscollector"));
+    assert_non_null(entry_named(report, "sca"));
+    assert_string_equal(
+        cJSON_GetObjectItem(cJSON_GetObjectItem(entry_named(report, "sca"), "config"),
+                            "disabled")->valuestring,
+        "no");
+
+    cJSON_Delete(report);
+    free(output);
+}
+
+static void test_getallconfig_reports_internal_options_separately(void** state)
+{
+    (void)state;
+    const char* names[] = {"syscollector"};
+    char command[] = "getallconfig";
+    char* output = NULL;
+
+    g_modules_cfg = dumped_wodles(names, 1);
+    g_internal_cfg = cJSON_CreateObject();
+    cJSON_AddNumberToObject(g_internal_cfg, "wazuh_modules.debug", 2);
+
+    wmcom_dispatch(command, strlen(command), &output);
+
+    cJSON* report = cJSON_Parse(output + 3);
+
+    /* Internal options belong to modulesd itself, not to any one wodle. */
+    assert_int_equal(cJSON_GetArraySize(report), 2);
+    assert_non_null(entry_named(report, "wmodules"));
+
+    cJSON_Delete(report);
+    free(output);
+}
+
+static void test_getallconfig_answers_even_with_no_wodles_loaded(void** state)
+{
+    (void)state;
+    char command[] = "getallconfig";
+    char* output = NULL;
+
+    /* Nothing configured: both getters return NULL. The daemon still has to
+     * answer, so the caller can tell it apart from an unreachable socket. */
+    size_t len = wmcom_dispatch(command, strlen(command), &output);
+
+    assert_string_equal(output, "ok []");
+    assert_int_equal((int)len, (int)strlen(output));
+
+    free(output);
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_getallconfig_gives_each_wodle_its_own_entry),
+        cmocka_unit_test(test_getallconfig_reports_internal_options_separately),
+        cmocka_unit_test(test_getallconfig_answers_even_with_no_wodles_loaded),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/wazuh_modules/include/wmodules.h
+++ b/src/wazuh_modules/include/wmodules.h
@@ -196,6 +196,16 @@ void * wmcom_main(void * arg);
 void wmcom_send(char * message, size_t length);
 size_t wmcom_dispatch(char * command, size_t length, char ** output);
 size_t wmcom_getconfig(const char * section, char ** output);
+
+/**
+ * @brief Build this daemon's entries for the agent's /config document.
+ *
+ * One entry per hosted wodle, plus one for modulesd's internal options.
+ *
+ * @param output Receives the allocated "ok <json>" reply.
+ * @return Length of *output.
+ */
+size_t wmcom_getallconfig(char ** output);
 int wmcom_sync(char * buffer, size_t length);
 
 /**

--- a/src/wazuh_modules/src/wmcom.c
+++ b/src/wazuh_modules/src/wmcom.c
@@ -10,7 +10,12 @@
 
 #include <shared.h>
 #include "wmodules.h"
+#include "module_report.h"
 #include "os_net.h"
+
+/* Name modulesd's own internal options are reported under. The wodles it hosts
+ * each get their own entry, named after the wodle. */
+#define WMCOM_MODULE_NAME "wmodules"
 
 
 size_t wmcom_dispatch(char * command, size_t length, char ** output){
@@ -34,6 +39,8 @@ size_t wmcom_dispatch(char * command, size_t length, char ** output){
             return strlen(*output);
         }
         return wmcom_getconfig(rcv_args, output);
+    } else if (strcmp(command, "getallconfig") == 0) {
+        return wmcom_getallconfig(output);
     } else if (strncmp(command, "query ", 6) == 0) {
         return wm_module_query(command + 6, output);
     } else if (wmcom_sync(command, length) == 0) {
@@ -47,6 +54,42 @@ size_t wmcom_dispatch(char * command, size_t length, char ** output){
         os_strdup("err Unrecognized command", *output);
         return strlen(*output);
     }
+}
+
+/**
+ * @brief Turn getModulesConfig()'s array into one report entry per wodle.
+ *
+ * Every wodle dumps itself as a one-key object, so the key names the module and
+ * the value is its body.
+ *
+ * @param report Destination array.
+ * @param modules Result of getModulesConfig(). Left untouched.
+ */
+static void wmcom_report_wodles(cJSON * report, const cJSON * modules) {
+
+    const cJSON *wodles = modules ? cJSON_GetObjectItem(modules, "wmodules") : NULL;
+    const cJSON *wodle = NULL;
+
+    cJSON_ArrayForEach(wodle, wodles) {
+        if (wodle->child) {
+            module_report_add_config(report, wodle->child->string,
+                                     cJSON_Duplicate(wodle->child, true));
+        }
+    }
+}
+
+size_t wmcom_getallconfig(char ** output) {
+
+    cJSON *report = cJSON_CreateArray();
+    cJSON *modules = getModulesConfig();
+    cJSON *internal = cJSON_CreateObject();
+
+    wmcom_report_wodles(report, modules);
+    cJSON_Delete(modules);
+
+    module_report_merge(internal, getModulesInternalOptions());
+    module_report_add_config(report, WMCOM_MODULE_NAME, internal);
+    return module_report_reply(report, output);
 }
 
 size_t wmcom_getconfig(const char * section, char ** output) {


### PR DESCRIPTION
Part of #37843.

**Stack (7/7)** — last one. #37856 (/stateful) is merged, so this now sits directly on the integration branch and all four commits are its own.

The agent-push replacement for the removed `info_request` task: two independent reporters, both OFF by default, with their own intervals (stats 60 s, config 3600 s).

- A dedicated worker thread runs them behind the registration gate and the auth pause; the drain skips them (upsert semantics: a failed cycle's snapshot is simply superseded next time).
- The consumer supplies snapshots through two new `collect_stats` / `collect_config` callbacks. These run on the reporter thread (not the dispatcher) and return a malloc'd JSON object the module frees.
- Before sending, the module stamps `agent_id` and the **manager-authoritative cluster identity** from the startup response — overwriting anything the collector put there — so the indexed documents (doc id = agent id) are always coherent.
- Back-pressure honors Retry-After per path; other failures back off per path without touching the sibling's cadence.

## Aggregation: one query per daemon, one document

The reporters now have producers behind them. The agent's modules live in
separate daemons, so a complete picture costs one query per daemon — that is
the floor, and this is at it. Previously the same information took one query
per configuration section (15 across the five sockets).

Each daemon gained `getallconfig` (and `getallstats` where a stats producer
already exists) and answers with the modules it hosts:

```json
{"modules": [
  {"module": "fim",          "config": {"syscheck": {...}, "rootcheck": {...}}},
  {"module": "logcollector", "config": {"localfile": [...], "socket": [...]}},
  {"module": "syscollector", "config": {...}},
  {"module": "sca",          "config": {...}}
]}
```

`agent_id` and `cluster` are stamped on top by the reporter, so the document is
a complete snapshot ready to upsert by agent id.

Mapping, one entry per module:

| daemon | reports as | sections |
|---|---|---|
| agentd | `agent` | client, buffer, internal, anti_tampering |
| syscheckd | `fim` | syscheck, rootcheck, internal |
| logcollector | `logcollector` | localfile, socket, internal |
| modulesd | one entry per wodle, plus `wmodules` | each wodle's own dump; internal_options |
| execd | `execd` | active-response, logging, internal |

modulesd splits its wodles apart, taking each module's name from its own
`dump()`, so `syscollector` and `sca` stay individually addressable rather than
buried in one blob.

Failure behaviour is deliberate: a daemon that is down or refuses is left out
and the rest still report, so one sick component does not cost the manager the
whole document. When **nothing** answers the cycle is skipped rather than
pushing `{"modules": []}`, which would overwrite a good document in the index
with an empty one.

## Open points for the manager side (#38023 / #38024)

1. **Shape differs from the issue's example.** #38023 sketches a flat map
   (`{"client": {...}, "syscheck": {...}}`). This is an array of tagged
   entries, per the module-oriented shape asked for on the agent side, and
   because a flat map cannot express two modules living in one daemon.
   #37843 makes defining the JSON an agent-side deliverable, so this is the
   proposal — happy to converge.
2. **`internal` sections are included.** They bulk up the document, but
   `GET /agents/{id}/config` can currently be asked for `internal`, and #38023
   wants that endpoint served from the index. Dropping them would break it.
3. **Size ceiling.** A daemon's reply travels over its local socket, capped at
   `OS_MAXSTR` (64 KiB). A logcollector with a very large state exceeds that;
   today it is logged and the module is left out rather than truncated. Worth
   confirming what the manager wants for that case.
4. **`/stats` is thin.** Only agentd and logcollector have a `getstate`
   producer, so those are the only two modules with statistics. The rest need
   producers before they can report.

## Verification

- Unit: 107/107 in the agent suite (104 before; three new suites added).
  `test_module_report` (8), `test_agent_report` (5), `test_wmcom` (3),
  plus 4 new cases in `test_agcom`. ASAN-clean — it caught a leak in
  `module_report_merge` that is fixed here.
- `make TARGET=agent` clean; every changed C file also passes
  `i686-w64-mingw32-gcc -fsyntax-only`, which is the only path that compiles
  the Windows in-process dispatch branch.
- 245 unit + 23 component for the module itself; e2e: the fake manager
  receives both documents with the stamped identity over TLS + CMAC.

