### PR TITLE
Validate read path in CDB list file retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Fixed a deadlock in `wazuh-analysisd` that stopped alert generation when the Active Response queue filled up. ([#37764](https://github.com/wazuh/wazuh/pull/37764))
 - Restricted the upgrade commands accepted from the agent message channel in Analysisd. ([#37745](https://github.com/wazuh/wazuh/pull/37745))
 - Added destination path validation when deleting rule and decoder files. ([#37838](https://github.com/wazuh/wazuh/pull/37838))
+- Added source path validation when retrieving CDB list files. ([#37901](https://github.com/wazuh/wazuh/pull/37901))
 
 ### Agent
 

--- a/framework/wazuh/cdb_list.py
+++ b/framework/wazuh/cdb_list.py
@@ -98,7 +98,11 @@ def get_list_file(filename: list = None, raw: bool = None) -> AffectedItemsWazuh
 
     try:
         # Recursively search for filename inside {wazuh_path}/etc/lists/
-        content = get_list_from_file(get_filenames_paths(filename)[0], raw)
+        full_path = get_filenames_paths(filename)[0]
+        # Ensure the resolved path stays inside the lists directory.
+        if commonpath([realpath(full_path), realpath(common.USER_LISTS_PATH)]) != realpath(common.USER_LISTS_PATH):
+            raise WazuhError(1804, extra_message=f"{filename[0]} is outside the lists directory")
+        content = get_list_from_file(full_path, raw)
         if raw:
             result = content
         else:

--- a/framework/wazuh/tests/test_cdb_list.py
+++ b/framework/wazuh/tests/test_cdb_list.py
@@ -297,6 +297,7 @@ def test_get_path_lists_sort(iterate_mock):
     ('test_file', True, 'test-ossec-w:write\ntest-ossec-r:read\ntest-ossec-x:execute\n', 0),
     ('test_file', False, {'test-ossec-w': 'write', 'test-ossec-r': 'read', 'test-ossec-x': 'execute'}, 0),
 ])
+@patch('wazuh.cdb_list.common.USER_LISTS_PATH', new=DATA_PATH)
 def test_get_list_file(filename, raw, expected_result, total_failed_items):
     """Test that get_list_file calls functions with expected params and it searches filename recursively.
 
@@ -319,6 +320,16 @@ def test_get_list_file(filename, raw, expected_result, total_failed_items):
             isinstance(result, AffectedItemsWazuhResult)
             assert result.render()['data']['total_failed_items'] == total_failed_items
             assert result.render()['data']['affected_items'][0] == expected_result
+
+
+@patch('wazuh.cdb_list.common.USER_LISTS_PATH', new=DATA_PATH)
+def test_get_list_file_outside_lists_path():
+    """Check that a filename resolving outside the lists directory is rejected and not read."""
+    with patch('wazuh.cdb_list.get_list_from_file') as mock_get_list_from_file:
+        result = get_list_file(['../../outside/file'], raw=True)
+        assert isinstance(result, AffectedItemsWazuhResult)
+        assert result.render()['data']['failed_items'][0]['error']['code'] == 1804
+        mock_get_list_from_file.assert_not_called()
 
 
 @patch('wazuh.cdb_list.safe_move')


### PR DESCRIPTION
## Description
`get_list_file` (`lists:read`) resolved its `filename` argument through `get_filenames_paths()`, which could resolve outside `USER_LISTS_PATH` when the recursive search finds no match. The function is reachable via the cluster callable path (`as_wazuh_object` → `DistributedAPI.run_local`), which bypasses the REST controller's filename validators. The fix resolves the candidate path with `realpath` and rejects the request if it falls outside `USER_LISTS_PATH`, before the file is opened.

## Proposed Changes
- `framework/wazuh/cdb_list.py`: in `get_list_file`, resolve the path from `get_filenames_paths()` and raise `WazuhError(1804)` if `realpath(full_path)` is not contained within `realpath(USER_LISTS_PATH)`, before calling `get_list_from_file`.
- `framework/wazuh/tests/test_cdb_list.py`: added `test_get_list_file_outside_lists_path`, and pinned `USER_LISTS_PATH` to the fixture directory in the existing `test_get_list_file` so it keeps passing under the new check.

### Results and Evidence
Verified against a real manager installation (4.14.8) at `/var/ossec` with the fix applied, using the manager's own embedded Python environment (`/var/ossec/framework/python/bin/python3`):

- Direct call — `get_list_file(filename=['../../etc/hostname'], raw=True)` with RBAC context set to `{'rbac_mode': 'black'}` (the same default used when a cluster request omits `rbac_permissions`) returns a failed item with `WazuhError` code 1804 (`../../etc/hostname is outside the lists directory`); the file is never opened.
- Cluster-callable path — the same call issued through `DistributedAPI(f=get_list_file, f_kwargs={'filename': ['../../etc/hostname'], 'raw': True}, ...).distribute_function()`, without supplying `rbac_permissions` (so it falls back to the `{'rbac_mode': 'black'}` default), is rejected the same way with code 1804.
- Legitimate retrieval — `get_list_file(filename=['audit-keys'], raw=True)` against the manager's real `/var/ossec/etc/lists/audit-keys` file still returns its content unchanged.
- Full test suite in the development repo: `pytest wazuh/tests/test_cdb_list.py wazuh/core/tests/test_cdb_list.py` — 93 passed, 0 failed.
- New test `test_get_list_file_outside_lists_path` fails against the pre-fix code and passes after the fix.

### Artifacts Affected
- `wazuh-manager` (framework API/cluster code, `wazuh.cdb_list` module).

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
- `test_get_list_file_outside_lists_path` in `framework/wazuh/tests/test_cdb_list.py`: asserts a filename resolving outside the lists directory is rejected with error code 1804 and `get_list_from_file` is never invoked.
- Updated `test_get_list_file` in the same file to pin `common.USER_LISTS_PATH` to the fixture directory, keeping it valid under the new check.

## Credits
Thanks to @namd0ng for reporting this issue.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
