### PR TITLE
Fix flaky content manager component tests caused by a race in the fake server startup

### DIFF
--- a/src/shared_modules/content_manager/tests/component/fakes/fakeServer.hpp
+++ b/src/shared_modules/content_manager/tests/component/fakes/fakeServer.hpp
@@ -43,8 +43,11 @@ public:
      * @param host Host of the fake server.
      * @param port Port of the fake  server
      */
-    FakeServer(std::string host, int port) : m_thread(&FakeServer::run, this), m_host(std::move(host)), m_port(port)
+    FakeServer(std::string host, int port) : m_host(std::move(host)), m_port(port)
     {
+        // The thread is started once all the members it reads are initialized.
+        m_thread = std::thread(&FakeServer::run, this);
+
         // Wait until server is ready
         while (!m_server.is_running())
         {

--- a/src/shared_modules/content_manager/tests/unit/fakes/fakeServer.hpp
+++ b/src/shared_modules/content_manager/tests/unit/fakes/fakeServer.hpp
@@ -96,8 +96,11 @@ public:
      * @param host Host of the fake server.
      * @param port Port of the fake server
      */
-    FakeServer(std::string host, int port) : m_thread(&FakeServer::run, this), m_host(std::move(host)), m_port(port)
+    FakeServer(std::string host, int port) : m_host(std::move(host)), m_port(port)
     {
+        // The thread is started once all the members it reads are initialized.
+        m_thread = std::thread(&FakeServer::run, this);
+
         m_server.wait_until_ready();
     }
 

--- a/src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp
+++ b/src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp
@@ -51,14 +51,16 @@ public:
                          uint16_t forcedDelay = 0,
                          int code = 200,
                          std::string response = "")
-        : m_thread(&FakeOpenSearchServer::run, this)
-        , m_host(std::move(host))
+        : m_host(std::move(host))
         , m_health(std::move(health))
         , m_port(port)
         , m_statusCode(code)
         , m_response(std::move(response))
         , m_forcedDelay(forcedDelay)
     {
+        // The thread is started once all the members it reads are initialized.
+        m_thread = std::thread(&FakeOpenSearchServer::run, this);
+
         // Wait until server is ready
         while (!m_server.is_running())
         {


### PR DESCRIPTION
## Description

Closes #37690

The `content_manager_component_tests` suite fails sporadically in the `4_testcomponent_vulnerability-scanner` workflow. In the reported run (tag `v4.14.7-rc1`, job `vulnerability-scanner-modules-asan (ubuntu-22.04)`), ASAN aborts with a SEGV during `ActionOrchestratorTest::SetUpTestSuite`:

```
==7661==ERROR: AddressSanitizer: SEGV on unknown address (pc 0x7fe45afb217c ...)
    #1 __interceptor_strlen
    #2 std::char_traits<char>::length(char const*)
    #3 std::basic_string(char const*, ...)
    #4 FakeServer::run() .../content_manager/tests/component/fakes/fakeServer.hpp:223
Thread T1 created by T0 here:
    #2 FakeServer::FakeServer(...) .../fakes/fakeServer.hpp:46
    #4 ActionOrchestratorTest::SetUpTestSuite()
```

Root cause: the fake HTTP servers used by the tests start their worker thread from the constructor initialization list, before `m_host` and `m_port` are initialized. Class members are initialized in declaration order (`m_server`, `m_thread`, `m_host`, `m_port`), regardless of the order in the init list, so the thread can reach `m_server.listen(m_host.c_str(), m_port)` while `m_host` is still unconstructed and read garbage memory. The race is usually masked because the thread registers all the endpoints before calling `listen()`, which normally gives the main thread enough time to finish the constructor; under CI scheduling jitter it occasionally loses the race and crashes.

## Proposed Changes

Start the worker thread in the constructor body, after all the members it reads are initialized. Applied to the three fakes sharing the pattern:

- `src/shared_modules/content_manager/tests/component/fakes/fakeServer.hpp`
- `src/shared_modules/content_manager/tests/unit/fakes/fakeServer.hpp`
- `src/shared_modules/indexer_connector/tests/unit/fakeOpenSearchServer.hpp`

### Results and Evidence

**ThreadSanitizer confirms the RCA deterministically.** A minimal program that only constructs a `FakeServer` (built with `-fsanitize=thread` against `src/`) reports the exact race on the old code, matching the CI crash stack:

```
WARNING: ThreadSanitizer: data race
  Read of size 8 by thread T1:
    #0 strlen
    #2 std::char_traits<char>::length(char const*)
    #4 FakeServer::run() old/fakeServer.hpp:223
  Previous write of size 8 by main thread:
    #2 std::basic_string(std::basic_string&&)   <- m_host initialization
    #3 main
  Thread T1 created by main thread at:
    #2 FakeServer::FakeServer(...) old/fakeServer.hpp:46
```

A second identical report covers `m_port` (read of size 4 at `fakeServer.hpp:223`). With the fix applied, the same program reports **no races and exits 0**.

**Tests reproduce the CI job locally (ubuntu 22.04, gcc 11, ASAN flags `-fsanitize=address -fsanitize=undefined -fsanitize=leak`):**

`content_manager_component_tests` executed 20 consecutive times, 53/53 tests passing on every run:

```
$ for i in $(seq 1 20); do ./content_manager_component_tests > run_$i.log || exit 1; done
$ grep -h "PASSED" run_*.log | sort | uniq -c
     20 [  PASSED  ] 53 tests.
```

`content_manager_unit_tests`:

```
2/2 Test #2: content_manager_unit_tests ........   Passed
```

Indexer connector suites (its fake shared the same pattern):

```
[==========] 11 tests from 2 test suites ran. (10762 ms total)
[  PASSED  ] 11 tests.
[==========] 22 tests from 1 test suite ran. (124118 ms total)
[  PASSED  ] 22 tests.
```

Coding style validated with the pinned Wazuh clang-format (22.1.1): no violations.

**CI: repeated green runs of the flaky workflow.** The `4_testcomponent_vulnerability-scanner` workflow was run 5 times manually on this branch (`workflow_dispatch`), on top of the PR's own run, to confirm the flaky no longer reproduces. The job that crashed originally (`vulnerability-scanner-modules-asan (ubuntu-22.04)`, and its 24.04 counterpart) passed in every run:

| Run | Result | asan (ubuntu-22.04) | asan (ubuntu-24.04) |
|---|---|---|---|
| [29927762377](https://github.com/wazuh/wazuh/actions/runs/29927762377) | success | success | success |
| [29927765281](https://github.com/wazuh/wazuh/actions/runs/29927765281) | success | success | success |
| [29927767829](https://github.com/wazuh/wazuh/actions/runs/29927767829) | success | success | success |
| [29927770418](https://github.com/wazuh/wazuh/actions/runs/29927770418) | success | success | success |
| [29927773074](https://github.com/wazuh/wazuh/actions/runs/29927773074) | success | success | success |

6 green runs of the component suite in total (5 manual dispatches + the PR run), with the content manager component tests green in all of them.

### Artifacts Affected

None. Test-only change; no product code is modified.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None. Existing tests are stabilized.

## Review Checklist
- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)

