### PR TITLE
Downgrade benign syscollector shutdown-timeout log

### DIFF
--- a/src/wazuh_modules/src/wm_syscollector.c
+++ b/src/wazuh_modules/src/wm_syscollector.c
@@ -844,7 +844,9 @@ void wm_sys_stop(__attribute__((unused))wm_sys_t* data)
         {
             if (pthread_cond_timedwait(&sys_stop_condition, &sys_stop_mutex, &ts) == ETIMEDOUT)
             {
-                mtwarn(WM_SYS_LOGTAG, "Timeout waiting for Syscollector to complete shutdown.");
+                mtinfo(WM_SYS_LOGTAG,
+                       "Syscollector did not confirm shutdown within %ld seconds; releasing resources and continuing.",
+                       (long)SHUTDOWN_WAIT_SECONDS);
                 break;
             }
         }


### PR DESCRIPTION
## Description

Closes #37657

On a 5.0.0-beta agent (first seen on CentOS 7 in a nightly run) the shutdown log shows:

```sql
2026/07/14 04:38:43 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2026/07/14 04:38:53 wazuh-modulesd:syscollector: WARNING: Timeout waiting for Syscollector to complete shutdown.
```

`wm_sys_stop()` waits up to 10 seconds for syscollector to confirm its teardown, then releases resources and lets the agent continue. That wait is a deliberate, bounded fail-safe: it was added so a slow teardown could never hang the SIGTERM handler indefinitely.

It was investigated why the wait occasionally times out. Using `gdb` (with debug symbols) on a caught-hung `wazuh-modulesd`, the module main thread was inside `fork()` while syscollector and agent-info were parked in `malloc_atfork`. The chain is:

- An SCA policy "command" rule runs a subprocess via `wm_exec()`, which calls `fork()`.
- In a multithreaded process, `fork()` takes the glibc malloc arena lock. On old glibc (CentOS 7 ships 2.17) that contention can persist for the duration of the forked command, so any other thread that allocates (syscollector during teardown) blocks in `malloc_atfork`.
- If a stop arrives in that window, syscollector cannot finish within the 10-second budget, so the fail-safe fires.

So syscollector is a victim, not the cause. Most importantly, the event is **bounded and benign**: the agent always completes shutdown within the budget, releases resources, and restarts and reconnects cleanly. No data is lost.

## Proposed Changes

Downgrade the fail-safe log from `WARNING` to `INFO` and reword it to state what happened and that the agent continues.

- **`wm_syscollector.c`.** `Timeout waiting for Syscollector to complete shutdown.` (WARNING) becomes `Syscollector did not confirm shutdown within 10 seconds; releasing resources and continuing.` (INFO).

That is the whole change. Behavior is unchanged: the 10-second bounded wait and the resource release are exactly as before, only the severity and wording of the message differ.


> [!IMPORTANT]
> An earlier iteration reworked `wm_exec()` (fork -> posix_spawn), added a shutdown gate, and touched the syscollector scan-abort logic across four files, to remove the underlying fork/malloc-atfork contention. That was dropped for the stable branch:
    - The event it addresses is a bounded, benign shutdown delay, not a fault or a hang. It costs at most the 10-second wait, once, at stop time, and the agent recovers.
    - Changing subprocess launch affects every wodle that calls `wm_exec()` (SCA, wodle-command, aws, azure, gcp, docker). The shutdown-skip return value also collides with those callers' error handling (they treat the new `-1` as a real failure and would log `Internal error. Exiting...` on a normal shutdown race), which is a regression the log-only change avoids entirely.
    - The remaining contention is specific to glibc < 2.24; on every currently supported non-EOL platform (RHEL/Rocky/Alma 8+, Debian 10+, Ubuntu 18.04+) `posix_spawn` already uses `clone(CLONE_VM | CLONE_VFORK)` and never takes the malloc lock, so there is no runtime penalty to remove there.  
    The minimal change fixes the reported symptom (a scary WARNING for a normal, self-recovering event) without the blast radius.

### Results and Evidence

Validated on the reported platform, CentOS 7 (glibc 2.17), with the patched agent, over 100 forced-window stop cycles (start the agent, let a scan begin, cut the manager so a sync is in flight, then stop and time the teardown).

```sql
iterations      : 100   (stall 2s, bound 10s)
timeout events  : 1 / 100
teardown avg    : 3.54 s
teardown max    : 29.4 s   (late completion: no -> the bounded glibc-2.17 residual)
```

The one timeout now logs at INFO, as intended:

```sql
2026/07/27 16:55:33 wazuh-modulesd:syscollector: INFO: Syscollector did not confirm shutdown within 10 seconds; releasing resources and continuing.
```

Binary check on the installed agent:

```sql
"releasing resources and continuing"                     -> present
"Timeout waiting for Syscollector to complete shutdown"  -> absent (old WARNING removed)
```

Every cycle completed shutdown within the budget and the agent reconnected normally: bounded and benign, as expected.

### Artifacts Affected

- `wazuh-modulesd` (agent and manager; the log line lives in the shared syscollector module).
- No package, configuration, on-disk format, or behavior changes. Log severity and wording only.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None. The change is log severity + wording; existing syscollector tests are unaffected.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
