### PR TITLE
Fix RestrictAnonymous registry checks in Windows CIS policies

### DIFF
--- a/ruleset/sca/windows/cis_win2012_non_r2.yml
+++ b/ruleset/sca/windows/cis_win2012_non_r2.yml
@@ -2228,7 +2228,7 @@ checks:
     condition: all
     rules:
       - 'r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa'
-      - 'r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa -> RestrictAnonymous '
+      - 'r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa -> RestrictAnonymous'
       - 'r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa -> RestrictAnonymous -> 1'
 
   # 2.3.10.4 (L2) Ensure 'Network access: Do not allow storage of passwords and credentials for network authentication' is set to 'Enabled'. (Automated)

--- a/ruleset/sca/windows/cis_win2016.yml
+++ b/ruleset/sca/windows/cis_win2016.yml
@@ -1798,7 +1798,7 @@ checks:
     condition: all
     rules:
       - 'r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa'
-      - 'r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa -> RestrictAnonymous '
+      - 'r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa -> RestrictAnonymous'
       - 'r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa -> RestrictAnonymous -> 1'
 
   # 2.3.10.4 (L2) Ensure 'Network access: Do not allow storage of passwords and credentials for network authentication' is set to 'Enabled'. (Automated)


### PR DESCRIPTION
## Description

The Windows Server 2016 CIS policy used `RestrictAnonymous `, including a trailing space inside the quoted registry value name. Wazuh therefore queried a non-existent value and could report a false negative for check 16036 even when `RestrictAnonymous` was correctly set to `1`.

Repository-wide validation found the identical typo in the Windows Server 2012 non-R2 policy, check 34546.

Closes #37763.

## Proposed Changes

- Remove the trailing space from the `RestrictAnonymous` registry value in `cis_win2016.yml`.
- Apply the same correction to `cis_win2012_non_r2.yml`.
- Leave the surrounding check conditions and expected DWORD value unchanged.

### Results and Evidence

Before the change, the parsed lookup rule ended with:

```text
'...\\Lsa -> RestrictAnonymous '
```

After the change, both affected checks resolve to:

```text
'...\\Lsa -> RestrictAnonymous'
```

Validation results:

- All 8 Windows CIS policy YAML files parsed successfully with PyYAML 6.0.3.
- Checks 16036 and 34546 both resolve to the exact `RestrictAnonymous` value name.
- A scan across the Windows policies found 0 remaining rules ending with `RestrictAnonymous `.
- `git diff --check` passed.
- The final diff contains only the two one-character corrections.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] N/A - this is a data-only SCA policy correction with no executable source changes.
- [x] Log syntax and correct language review - all Windows CIS YAML policies parsed successfully.
- Memory tests for Linux, Windows, and macOS
  - [x] N/A - no executable code or memory behavior changed.
- Decoder/Rule tests _(Wazuh v4.x)_
  - [x] N/A - no decoder or `.ini` rule test changed.
- Engine _(Wazuh v5.x and above)_
  - [x] N/A - no engine source changed.
- Wazuh server API/Framework
  - [x] N/A - no API or framework code changed.

A live Windows Server SCA scan was not run locally because it requires the corresponding Windows agent environment. The static validation confirms that the policy now queries the real registry value name.

### Artifacts Affected

- Default Windows Server 2016 CIS SCA policy.
- Default Windows Server 2012 non-R2 CIS SCA policy.

### Configuration Changes

No new configuration parameters are introduced. The existing checks now reference the correct registry value name; their expected value remains `1`.

### Tests Introduced

N/A - the repository does not provide a policy-file test hook for these shipped SCA YAML files. Focused YAML parsing and exact rule-value assertions were run locally.

## Review Checklist

- [x] Code changes reviewed.
- [x] Relevant before/after evidence provided.
- [x] Focused static validation covers both affected policy entries.
- [x] Configuration impact documented.
- [x] Developer documentation is unaffected.
- [x] Meets the issue requirements and keeps the change narrowly scoped.
- [x] No unresolved dependencies with other issues.
