### PR TITLE
Discard_regex values containing a space break argument parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Restricted the upgrade commands accepted from the agent message channel in Analysisd. ([#37745](https://github.com/wazuh/wazuh/pull/37745))
 - Added destination path validation when deleting rule and decoder files. ([#37838](https://github.com/wazuh/wazuh/pull/37838))
 - Added source path validation when retrieving CDB list files. ([#37901](https://github.com/wazuh/wazuh/pull/37901))
+- Fixed the `aws-s3` wodle failing to parse configuration values that contain spaces, such as `discard_regex`, `discard_field`, `aws_profile`, `aws_account_alias`, `path` and `path_suffix`. ([#37929](https://github.com/wazuh/wazuh/pull/37929))
 
 ### Agent
 

--- a/src/unit_tests/wazuh_modules/aws/test_wm_aws.c
+++ b/src/unit_tests/wazuh_modules/aws/test_wm_aws.c
@@ -33,6 +33,9 @@ extern int test_mode;
 
 extern void wm_aws_run_s3(wm_aws_bucket *bucket);
 
+// Static in wm_aws.c, but visible here because WAZUH_UNIT_TESTING drops the qualifier.
+extern void wm_aws_add_quoted_arg(char **command, const char *value);
+
 void wm_aws_run_s3(wm_aws_bucket *exec_bucket) {
     // Will wrap this function to check running times in order to check scheduling
     return;
@@ -266,6 +269,82 @@ void test_read_scheduling_interval_configuration(void **state) {
     assert_int_equal(module_data->scan_config.scan_wday, -1);
 }
 
+/* Tests for wm_aws_add_quoted_arg (quoting of the command-line values that may contain
+   spaces: discard_regex, discard_field, aws_profile, aws_account_alias, trail_prefix
+   and trail_suffix) */
+
+// A value with spaces should end up quoted and, once w_strtok splits the command line
+// the way wm_exec does, come back out as a single argument.
+void test_add_quoted_arg_value_with_spaces(void **state) {
+    char *command = NULL;
+    wm_strcat(&command, "--discard-regex", ' ');
+    wm_aws_add_quoted_arg(&command, "Security Hub Insight Results");
+
+    assert_string_equal(command, "--discard-regex \"Security Hub Insight Results\"");
+
+    char **argv = w_strtok(command);
+    assert_string_equal(argv[0], "--discard-regex");
+    assert_string_equal(argv[1], "Security Hub Insight Results");
+    assert_null(argv[2]);
+
+    free_strarray(argv);
+    os_free(command);
+}
+
+// A value without spaces gets quoted too, and still comes back unchanged.
+void test_add_quoted_arg_value_without_spaces(void **state) {
+    char *command = NULL;
+    wm_aws_add_quoted_arg(&command, "detail-type");
+
+    assert_string_equal(command, "\"detail-type\"");
+
+    char **argv = w_strtok(command);
+    assert_string_equal(argv[0], "detail-type");
+    assert_null(argv[1]);
+
+    free_strarray(argv);
+    os_free(command);
+}
+
+// Quotes and backslashes inside the value (think regexes like \d+ "value") have to be
+// escaped so w_strtok hands the exact same string back.
+void test_add_quoted_arg_value_with_special_chars(void **state) {
+    char *command = NULL;
+    wm_aws_add_quoted_arg(&command, "a\\d+ \"b\"");
+
+    assert_string_equal(command, "\"a\\\\d+ \\\"b\\\"\"");
+
+    char **argv = w_strtok(command);
+    assert_string_equal(argv[0], "a\\d+ \"b\"");
+    assert_null(argv[1]);
+
+    free_strarray(argv);
+    os_free(command);
+}
+
+// S3 object keys accept spaces, so a path prefix has to survive the split as one argument
+// too. Same for the free-form account alias taken from the configuration.
+void test_add_quoted_arg_bucket_values_with_spaces(void **state) {
+    char *command = NULL;
+    wm_strcat(&command, "--trail_prefix", ' ');
+    wm_aws_add_quoted_arg(&command, "AWSLogs/my folder/");
+    wm_strcat(&command, "--aws_account_alias", ' ');
+    wm_aws_add_quoted_arg(&command, "Production Account");
+
+    assert_string_equal(command,
+        "--trail_prefix \"AWSLogs/my folder/\" --aws_account_alias \"Production Account\"");
+
+    char **argv = w_strtok(command);
+    assert_string_equal(argv[0], "--trail_prefix");
+    assert_string_equal(argv[1], "AWSLogs/my folder/");
+    assert_string_equal(argv[2], "--aws_account_alias");
+    assert_string_equal(argv[3], "Production Account");
+    assert_null(argv[4]);
+
+    free_strarray(argv);
+    os_free(command);
+}
+
 int main(void) {
     const struct CMUnitTest tests_with_startup[] = {
         cmocka_unit_test_setup_teardown(test_interval_execution, setup_test_executions, teardown_test_executions)
@@ -275,7 +354,11 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_read_scheduling_monthday_configuration, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_read_scheduling_weekday_configuration, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_read_scheduling_daytime_configuration, setup_test_read, teardown_test_read),
-        cmocka_unit_test_setup_teardown(test_read_scheduling_interval_configuration, setup_test_read, teardown_test_read)
+        cmocka_unit_test_setup_teardown(test_read_scheduling_interval_configuration, setup_test_read, teardown_test_read),
+        cmocka_unit_test(test_add_quoted_arg_value_with_spaces),
+        cmocka_unit_test(test_add_quoted_arg_value_without_spaces),
+        cmocka_unit_test(test_add_quoted_arg_value_with_special_chars),
+        cmocka_unit_test(test_add_quoted_arg_bucket_values_with_spaces)
     };
     int result;
     result = cmocka_run_group_tests(tests_with_startup, setup_module, teardown_module);

--- a/src/wazuh_modules/wm_aws.c
+++ b/src/wazuh_modules/wm_aws.c
@@ -363,6 +363,33 @@ void wm_aws_check() {
 
 }
 
+// Quote a value before appending it to the command line so it survives the
+// word-splitting that wm_exec() performs through w_strtok(). Otherwise a value with
+// spaces (for example a discard_regex like "Security Hub Insight Results") is broken
+// into several tokens and the AWS script rejects it with "unrecognized arguments".
+// Embedded quotes and backslashes are escaped so the value reaches the script intact.
+static void wm_aws_add_quoted_arg(char **command, const char *value) {
+    char *quoted = NULL;
+    const size_t len = strlen(value);
+    size_t j = 0;
+
+    // Room for the surrounding quotes, a backslash before every character and the '\0'.
+    os_calloc(len * 2 + 3, sizeof(char), quoted);
+
+    quoted[j++] = '"';
+    for (size_t i = 0; i < len; i++) {
+        if (value[i] == '"' || value[i] == '\\') {
+            quoted[j++] = '\\';
+        }
+        quoted[j++] = value[i];
+    }
+    quoted[j++] = '"';
+    quoted[j] = '\0';
+
+    wm_strcat(command, quoted, ' ');
+    os_free(quoted);
+}
+
 // Run a bucket parsing
 #ifdef WAZUH_UNIT_TESTING
 __attribute__((weak))
@@ -405,7 +432,7 @@ void wm_aws_run_s3(wm_aws *aws_config, wm_aws_bucket *exec_bucket) {
     }
     if (exec_bucket->aws_profile) {
         wm_strcat(&command, "--aws_profile", ' ');
-        wm_strcat(&command, exec_bucket->aws_profile, ' ');
+        wm_aws_add_quoted_arg(&command, exec_bucket->aws_profile);
     }
     if (exec_bucket->iam_role_arn) {
         wm_strcat(&command, "--iam_role_arn", ' ');
@@ -425,15 +452,15 @@ void wm_aws_run_s3(wm_aws *aws_config, wm_aws_bucket *exec_bucket) {
     }
     if (exec_bucket->aws_account_alias) {
         wm_strcat(&command, "--aws_account_alias", ' ');
-        wm_strcat(&command, exec_bucket->aws_account_alias, ' ');
+        wm_aws_add_quoted_arg(&command, exec_bucket->aws_account_alias);
     }
     if (exec_bucket->trail_prefix) {
         wm_strcat(&command, "--trail_prefix", ' ');
-        wm_strcat(&command, exec_bucket->trail_prefix, ' ');
+        wm_aws_add_quoted_arg(&command, exec_bucket->trail_prefix);
     }
     if (exec_bucket->trail_suffix) {
         wm_strcat(&command, "--trail_suffix", ' ');
-        wm_strcat(&command, exec_bucket->trail_suffix, ' ');
+        wm_aws_add_quoted_arg(&command, exec_bucket->trail_suffix);
     }
     if (exec_bucket->only_logs_after) {
         wm_strcat(&command, "--only_logs_after", ' ');
@@ -445,11 +472,11 @@ void wm_aws_run_s3(wm_aws *aws_config, wm_aws_bucket *exec_bucket) {
     }
     if (exec_bucket->discard_field) {
         wm_strcat(&command, "--discard-field", ' ');
-        wm_strcat(&command, exec_bucket->discard_field, ' ');
+        wm_aws_add_quoted_arg(&command, exec_bucket->discard_field);
     }
     if (exec_bucket->discard_regex) {
         wm_strcat(&command, "--discard-regex", ' ');
-        wm_strcat(&command, exec_bucket->discard_regex, ' ');
+        wm_aws_add_quoted_arg(&command, exec_bucket->discard_regex);
     }
     if (exec_bucket->sts_endpoint) {
         wm_strcat(&command, "--sts_endpoint", ' ');
@@ -581,7 +608,7 @@ void wm_aws_run_service(wm_aws *aws_config, wm_aws_service *exec_service) {
     }
     if (exec_service->aws_profile) {
         wm_strcat(&command, "--aws_profile", ' ');
-        wm_strcat(&command, exec_service->aws_profile, ' ');
+        wm_aws_add_quoted_arg(&command, exec_service->aws_profile);
     }
     if (exec_service->iam_role_arn) {
         wm_strcat(&command, "--iam_role_arn", ' ');
@@ -597,7 +624,7 @@ void wm_aws_run_service(wm_aws *aws_config, wm_aws_service *exec_service) {
     }
     if (exec_service->aws_account_alias) {
         wm_strcat(&command, "--aws_account_alias", ' ');
-        wm_strcat(&command, exec_service->aws_account_alias, ' ');
+        wm_aws_add_quoted_arg(&command, exec_service->aws_account_alias);
     }
     if (exec_service->only_logs_after) {
         wm_strcat(&command, "--only_logs_after", ' ');
@@ -616,11 +643,11 @@ void wm_aws_run_service(wm_aws *aws_config, wm_aws_service *exec_service) {
     }
     if (exec_service->discard_field) {
         wm_strcat(&command, "--discard-field", ' ');
-        wm_strcat(&command, exec_service->discard_field, ' ');
+        wm_aws_add_quoted_arg(&command, exec_service->discard_field);
     }
     if (exec_service->discard_regex) {
         wm_strcat(&command, "--discard-regex", ' ');
-        wm_strcat(&command, exec_service->discard_regex, ' ');
+        wm_aws_add_quoted_arg(&command, exec_service->discard_regex);
     }
     if (exec_service->sts_endpoint) {
         wm_strcat(&command, "--sts_endpoint", ' ');
@@ -757,7 +784,7 @@ void wm_aws_run_subscriber(wm_aws *aws_config, wm_aws_subscriber *exec_subscribe
     }
     if (exec_subscriber->aws_profile) {
         wm_strcat(&command, "--aws_profile", ' ');
-        wm_strcat(&command, exec_subscriber->aws_profile, ' ');
+        wm_aws_add_quoted_arg(&command, exec_subscriber->aws_profile);
     }
     if (exec_subscriber->sts_endpoint){
         wm_strcat(&command, "--sts_endpoint", ' ');
@@ -770,11 +797,11 @@ void wm_aws_run_subscriber(wm_aws *aws_config, wm_aws_subscriber *exec_subscribe
 
     if (exec_subscriber->discard_field) {
         wm_strcat(&command, "--discard-field", ' ');
-        wm_strcat(&command, exec_subscriber->discard_field, ' ');
+        wm_aws_add_quoted_arg(&command, exec_subscriber->discard_field);
     }
     if (exec_subscriber->discard_regex) {
         wm_strcat(&command, "--discard-regex", ' ');
-        wm_strcat(&command, exec_subscriber->discard_regex, ' ');
+        wm_aws_add_quoted_arg(&command, exec_subscriber->discard_regex);
     }
 
     if (isDebug()) {


### PR DESCRIPTION
## Description

The `aws-s3` wodle's `discard_regex` option failed whenever the configured value contained a space. This is the common case for human-readable fields: every AWS Security Hub `detail-type` value has spaces (`Security Hub Findings - Imported`, `Security Hub Insight Results`, ...).

The root cause is in `wm_aws.c`. The wodle builds the whole command as a single flat string, and `wm_exec()` splits it back into the `argv` array with `w_strtok()`, which word-splits on spaces. Because the `discard_regex` and `discard_field` values were interpolated **unquoted**, a value like `Security Hub Insight Results` was chopped into four separate arguments, so the AWS script aborted while parsing arguments:

```
WARNING: Subscriber: security_hub <queue>  -  Returned exit code 2
WARNING: Subscriber: security_hub <queue>  -  Error parsing arguments.
```
```
aws-s3.py: error: unrecognized arguments: Hub Insight Results
```

At the default log level this failure is nearly invisible (the warning gives no hint that the `discard_regex` value is the problem), and the primary use case for `discard_regex` on `detail-type` is completely broken.

Closes #37709

## Proposed Changes

- Added a helper `wm_aws_add_quoted_arg()` in `wm_aws.c` that wraps a value in double quotes and escapes any embedded `"` or `\` before appending it to the command line. `w_strtok()` then reconstructs the exact original value as a single argument.
- Applied the helper in the three run paths that build the command (`wm_aws_run_s3`, `wm_aws_run_service` and `wm_aws_run_subscriber`) to every value that can legitimately contain a space, not only the reported one: `discard_regex`, `discard_field`, `aws_profile` (`[profile My Dev]` is valid in `~/.aws/config`), `aws_account_alias` (free-form label from `ossec.conf`) and `path` / `path_suffix` (S3 object keys accept spaces). The bug affects buckets and services too, not only subscribers.
- The remaining values are left unquoted because AWS constrains their charset to exclude spaces: `bucket`, `aws_account_id`, `aws_organization_id`, `iam_role_arn`, `iam_role_duration`, `external_id`, `sqs_name`, `type`, `only_logs_after`, `sts_endpoint`, `service_endpoint`, `access_key` and `secret_key`. `regions` and `aws_log_groups` were deliberately left out as well: quoting them would not fix a `us-east-1, us-west-2` style value, because `arg_valid_regions()` applies its anchored regex before stripping, and `cloudwatchlogs.py` splits on `,` with no stripping at all.
- As a side effect, backslashes (for example a regex `\.`, or an S3 prefix containing `\`) are now preserved instead of being silently stripped by the tokenizer.

### Results and evidences

Tested on the `master` Vagrant VM (Ubuntu 24.04), with `libwazuh.a` built via `make TARGET=server DEBUG=1 TEST=1` and AddressSanitizer + UndefinedBehaviorSanitizer enabled, as `unit_tests/server.cmake` does. No sanitizer reports.

**1. Unit tests** — the whole `test_wm_aws` suite passes:

```
[==========] tests_with_startup: Running 1 test(s).
[ RUN      ] test_interval_execution
[       OK ] test_interval_execution
[  PASSED  ] 1 test(s).
[==========] tests_without_startup: Running 9 test(s).
[ RUN      ] test_fake_tag
[       OK ] test_fake_tag
[ RUN      ] test_read_scheduling_monthday_configuration
[       OK ] test_read_scheduling_monthday_configuration
[ RUN      ] test_read_scheduling_weekday_configuration
[       OK ] test_read_scheduling_weekday_configuration
[ RUN      ] test_read_scheduling_daytime_configuration
[       OK ] test_read_scheduling_daytime_configuration
[ RUN      ] test_read_scheduling_interval_configuration
[       OK ] test_read_scheduling_interval_configuration
[ RUN      ] test_add_quoted_arg_value_with_spaces
[       OK ] test_add_quoted_arg_value_with_spaces
[ RUN      ] test_add_quoted_arg_value_without_spaces
[       OK ] test_add_quoted_arg_value_without_spaces
[ RUN      ] test_add_quoted_arg_value_with_special_chars
[       OK ] test_add_quoted_arg_value_with_special_chars
[ RUN      ] test_add_quoted_arg_bucket_values_with_spaces
[       OK ] test_add_quoted_arg_bucket_values_with_spaces
[==========] tests_without_startup: 9 test(s) run.
[  PASSED  ] 9 test(s).
```

**2. Real `execvp` round-trip** — the unit tests exercise the helper in isolation, so the whole path was also driven for real: `wm_aws_run_s3` / `wm_aws_run_service` / `wm_aws_run_subscriber` → `wm_strcat` → `wm_exec` → `w_strtok` → `execvp`, with a stand-in `wodles/aws/aws-s3` that records the `argv` it actually receives. Configuration used spaces in `aws_profile`, `aws_account_alias`, `path`, `path_suffix` and `discard_regex`.

`argv` received for a bucket, **before** the fix (28 arguments, every value shredded):

```
[00] --bucket              [14] --trail_suffix
[01] wazuh-aws-wodle       [15] my
[02] --aws_profile         [16] suffix
[03] My                    [17] --regions
[04] Dev                   [18] us-east-1
[05] Profile               [19] --discard-field
[06] --aws_account_id      [20] detail-type
[07] 123456789012          [21] --discard-regex
[08] --aws_account_alias   [22] Security
[09] Production            [23] Hub
[10] Account               [24] Insight
[11] --trail_prefix        [25] Results
[12] AWSLogs/my            [26] --type
[13] folder/               [27] cloudtrail
```

**After** the fix (20 arguments, every value intact):

```
[00] --bucket              [10] --trail_suffix
[01] wazuh-aws-wodle       [11] my suffix
[02] --aws_profile         [12] --regions
[03] My Dev Profile        [13] us-east-1
[04] --aws_account_id      [14] --discard-field
[05] 123456789012          [15] detail-type
[06] --aws_account_alias   [16] --discard-regex
[07] Production Account    [17] Security Hub Insight Results
[08] --trail_prefix        [18] --type
[09] AWSLogs/my folder/    [19] cloudtrail
```

The service and subscriber paths behave the same way, delivering 12 and 10 arguments respectively with `My Dev Profile`, `Production Account` and `Security Hub Insight Results` each arriving as a single argument.

**3. The user-visible symptom** — both `argv` sets fed into the wodle's real argument parser (`aws_tools.get_script_arguments()`):

```
=== after the fix ===
  ACCEPTED (20 argv) -> discard_regex='Security Hub Insight Results' aws_profile='My Dev Profile' trail_prefix='AWSLogs/my folder/'
  ACCEPTED (12 argv) -> discard_regex='Security Hub Insight Results' aws_profile='My Dev Profile'
  ACCEPTED (10 argv) -> discard_regex='Security Hub Insight Results' aws_profile='My Dev Profile'

=== before the fix ===
  REJECTED (28 argv) -> argparse exited with code 2
  aws-s3: error: unrecognized arguments: Dev Profile Account folder/ suffix Hub Insight Results
```

That reproduces the exact failure reported in #37709 on the old code and confirms it is gone on the new one. Exit code 2 is what `wm_aws_run_s3` surfaces as `Error parsing arguments`.

## Tests Introduced

Added unit tests in `test_wm_aws.c` for `wm_aws_add_quoted_arg`:

- a value with spaces (`Security Hub Insight Results`),
- a value without spaces,
- a value with embedded quotes and backslashes (`a\d+ "b"`),
- an S3 path prefix and a free-form account alias with spaces (`AWSLogs/my folder/`, `Production Account`), covering the newly quoted bucket fields.

Each case runs the resulting command line back through `w_strtok` (the same tokenizer `wm_exec` uses) and asserts the value comes out as a single, unchanged argument.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
