### PR TITLE
Decouple authd use_password invalid test from the manager restart return code

### DIFF
--- a/tests/integration/test_authd/test_use_password/test_authd_use_password_invalid.py
+++ b/tests/integration/test_authd/test_use_password/test_authd_use_password_invalid.py
@@ -118,9 +118,12 @@ def test_authd_use_password_invalid(test_configuration, test_metadata, set_wazuh
     if log == 'Invalid password provided.':
         pytest.xfail(reason="No password validation in authd.pass - Issue wazuh/wazuh#16282.")
 
-    # Verify wazuh-manager fails at restart.
-    with pytest.raises(ValueError):
+    # wazuh-authd exits on the invalid password; depending on the service manager the
+    # restart may report failure or succeed, so tolerate both outcomes.
+    try:
         control_service('restart')
+    except ValueError:
+        pass
 
     # Verify the error log is raised.
 


### PR DESCRIPTION
|Related issue|
|---|
|#37707|

## Description

`test_authd_use_password_invalid[Use empty password file.]` fails intermittently in `4_testintegration_authd-tier-0-1` (seen while reviewing 4.14.8 in #37687), always with `DID NOT RAISE <class 'ValueError'>` at the `pytest.raises(ValueError)` wrapping `control_service('restart')`.

The root cause is a timing race, not a product bug:

- `control_service('restart')` raises `ValueError` only when `service wazuh-manager restart` returns non-zero. That exit code is decided by `wazuh-control`'s start loop, which polls `pstatus` per daemon (`src/init/wazuh-server.sh`).
- On an empty `authd.pass`, `wazuh-authd` daemonizes, writes its pidfile (`CreatePID`, `src/os_auth/main-server.c:496`), and only later reads the password, logs `Empty password provided.` and `exit(1)` (`main-server.c:574-575`).
- If a `pstatus` poll lands while authd is still alive in that window, `wazuh-control` reports the daemon as started and the restart returns 0. No `ValueError` is raised, so the assertion fails.

The test coupled on that timing-dependent return code. The deterministic signal (the error log) is already asserted right after with a polling `FileMonitor`. This change stops asserting on the restart outcome and tolerates both cases, keeping the error-log assertion as the real check. The `#16282` xfail and the 4.14.x expected logs are unchanged. The same decoupling is already merged on 5.x (59162721a0).

## Tests

Validated on a source install (Ubuntu 24.04) running the case in a loop with the machine saturated (`stress-ng`, load ~15 on 6 cores):

Before (old assertion), intermittent failures matching CI:

```
=== run 2 ===
test_authd/test_use_password/test_authd_use_password_invalid.py:122: in test_authd_use_password_invalid
    with pytest.raises(ValueError):
E   Failed: DID NOT RAISE <class 'ValueError'>
1 failed, 1 deselected, 1 warning in 33.37s
```

After (this change), under the same load: the loop completes with 0 failures (`1 passed` every run). Without load the full file is green as well (`1 passed, 1 xfailed`).

QA-only change; no product code touched.

- [x] Source installation
