### PR TITLE
Prevent empty string version from being stored for agents

### DIFF
--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -1164,12 +1164,12 @@ int mkstemp_ex(char *tmp_path)
 const char *getuname()
 {
     struct utsname uts_buf;
-    static char muname[512] = "";
+    static char muname[2048] = "";
     os_info *read_version;
 
     if (!muname[0]){
         if (read_version = get_unix_version(), read_version){
-            snprintf(muname, 512, "%s |%s |%s |%s |%s [%s|%s: %s] - %s %s",
+            snprintf(muname, 2048, "%s |%s |%s |%s |%s [%s|%s: %s] - %s %s",
                     read_version->sysname,
                     read_version->nodename,
                     read_version->release,
@@ -1183,7 +1183,7 @@ const char *getuname()
             free_osinfo(read_version);
         }
         else if (uname(&uts_buf) >= 0) {
-            snprintf(muname, 512, "%s %s %s %s %s - %s %s",
+            snprintf(muname, 2048, "%s %s %s %s %s - %s %s",
                      uts_buf.sysname,
                      uts_buf.nodename,
                      uts_buf.release,
@@ -1191,7 +1191,7 @@ const char *getuname()
                      uts_buf.machine,
                      __ossec_name, __ossec_version);
         } else {
-            snprintf(muname, 512, "No system info available - %s %s",
+            snprintf(muname, 2048, "No system info available - %s %s",
                      __ossec_name, __ossec_version);
         }
     }

--- a/src/shared/remoted_op.c
+++ b/src/shared/remoted_op.c
@@ -224,8 +224,12 @@ int parse_agent_update_msg (char *msg,
                 if (str_tmp = strstr(line, " / "), str_tmp) {
                     *str_tmp = '\0';
                     str_tmp += 3;
-                    os_strdup(line, agent_data->version);
-                    os_strdup(str_tmp, agent_data->config_sum);
+                    if (*line) {
+                        os_strdup(line, agent_data->version);
+                    }
+                    if (*str_tmp) {
+                        os_strdup(str_tmp, agent_data->config_sum);
+                    }
                 }
                 else if (str_tmp = strstr(line, __ossec_name), str_tmp) {
                     // If for some reason the separator between Wazuh version and config sum is

--- a/src/wazuh_db/wdb_global.c
+++ b/src/wazuh_db/wdb_global.c
@@ -211,9 +211,16 @@ int wdb_global_update_agent_version(wdb_t *wdb,
         merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
         return OS_INVALID;
     }
-    if (sqlite3_bind_text(stmt, index++, version, -1, NULL) != SQLITE_OK) {
-        merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
-        return OS_INVALID;
+    if (version && version[0]) {
+        if (sqlite3_bind_text(stmt, index++, version, -1, NULL) != SQLITE_OK) {
+            merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+            return OS_INVALID;
+        }
+    } else {
+        if (sqlite3_bind_null(stmt, index++) != SQLITE_OK) {
+            merror("DB(%s) sqlite3_bind_null(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+            return OS_INVALID;
+        }
     }
     if (sqlite3_bind_text(stmt, index++, config_sum, -1, NULL) != SQLITE_OK) {
         merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));


### PR DESCRIPTION
## Description

Agents in production databases were found with `version = ''` instead of `NULL`, which breaks API sorting by version. The keep-alive parser stored an empty string when the version or config sum was missing around the `" / "` separator, instead of leaving the field unset, and the database write path did not guard against that empty value either.

Closes #37324

## Proposed Changes

- `parse_agent_update_msg` (`src/shared/remoted_op.c`) now only duplicates `version`/`config_sum` into `agent_data` when the corresponding substring is non-empty, leaving the field `NULL` instead of `""` otherwise.
- `wdb_global_update_agent_version` (`src/wazuh_db/wdb_global.c`) binds `NULL` instead of an empty string to the `version` column when the incoming value is empty, as a second safeguard at the database write path.
- `getuname` (`src/shared/file_op.c`) had its static `muname` buffer increased from 512 to 2048 bytes to avoid truncating the OS info string built from these same fields.

### Results and Evidence

For testing purposes, I set up a manager and an agent on Vagrant and modified the contents of the agent's `/etc/os-release` file so that the buffer would fill up.

```
root@agent:/home/vagrant/git/empty_string/wazuh# printf 'VERSION="%s"\n' "$(python3 -c "print('bookworm extended LTS build with backports enabled for the finance compliance hardened stack, kernel patch level 21, ' + 'x'*40)")" >> /etc/os-release
```

#### Before changes

- agent logs

```
2026/07/23 14:55:15 wazuh-agentd: INFO: Version detected -> Linux |agent |6.8.0-86-generic |#87-Ubuntu SMP PREEMPT_DYNAMIC Mon Sep 22 18:03:36 UTC 2025 |x86_64 [Ubuntu Enterprise Custom Build xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx|ubuntu: 24.04.3 LTS extended build finance compliance xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx] - 
```

- Manager global.db

```bash
$ sqlite3 -header -column /var/ossec/queue/db/global.db \
    "SELECT id, name, quote(version), version IS NULL AS is_null, version = '' AS is_empty, \
            last_keepalive, os_uname, config_sum FROM agent WHERE id=1;"

id  name   quote(version)  is_null  is_empty  last_keepalive  os_uname                                                                                             config_sum
--  -----  --------------  -------  --------  --------------  ---------------------------------------------------------------------------------------------------  --------------------------------
1   agent  ''              0        1         1784818526      Linux |agent |6.8.0-86-generic |#87-Ubuntu SMP PREEMPT_DYNAMIC Mon Sep 22 18:03:36 UTC 2025 |x86_64  ab73af41699f13fdd81903b5f23d8d00
```



* after

- agent logs

```
2026/07/23 15:12:42 wazuh-agentd: INFO: Version detected -> Linux |agent |6.8.0-86-generic |#87-Ubuntu SMP PREEMPT_DYNAMIC Mon Sep 22 18:03:36 UTC 2025 |x86_64 [Ubuntu Enterprise Custom Build xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx|ubuntu: 24.04.3 LTS extended build finance compliance xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx] - Wazuh v4.14.8
```
- Manager global.db

```bash
$ sqlite3 -header -column /var/ossec/queue/db/global.db \
    "SELECT id, name, quote(version), version IS NULL AS is_null, version = '' AS is_empty, \
            last_keepalive, os_uname, config_sum FROM agent WHERE id=1;"

id  name   quote(version)   is_null  is_empty  last_keepalive  os_uname                                                                                             config_sum
--  -----  ---------------  -------  --------  --------------  ---------------------------------------------------------------------------------------------------  --------------------------------
1   agent  'Wazuh v4.14.8'  0        0         1784819592      Linux |agent |6.8.0-86-generic |#87-Ubuntu SMP PREEMPT_DYNAMIC Mon Sep 22 18:03:36 UTC 2025 |x86_64  ab73af41699f13fdd81903b5f23d8d00
```


## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

<!--
Include any additional information relevant to the review process.
-->
