### PR TITLE
Throttle centralized configuration distribution in remoted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added new CVE 5.0 schema fields to the Vulnerability Detector content model. ([#36000](https://github.com/wazuh/wazuh/issues/36000))
 - Added manager watermarks. ([#35579](https://github.com/wazuh/wazuh/issues/35579))
 - Added byte-based capacity limits to wazuh-manager-remoted. ([#37052](https://github.com/wazuh/wazuh/issues/37052))
+- Added configurable throttling for centralized configuration distribution in wazuh-manager-remoted, staggering config downloads and agent restarts to avoid load spikes in large deployments. ([#37527](https://github.com/wazuh/wazuh/issues/37527))
 - Added default API role mappings for the indexer users wazuh-admin, wazuh-readonly and wazuh-demo. ([#37706](https://github.com/wazuh/wazuh/issues/37706))
 
 #### Changed

--- a/docs/ref/modules/remoted/README.md
+++ b/docs/ref/modules/remoted/README.md
@@ -16,6 +16,7 @@ The `remoted` module is responsible for managing secure communication between Wa
 - [Stateless Metadata](stateless-metadata.md) - Agent metadata enrichment for stateless events
 - [Configuration](configuration.md) - Configuration options and tuning parameters
 - [Event Protocol](event-protocol.md) - Event framing and message format specification
+- [Config Distribution Throttling](config-distribution-throttling.md) - Progressive distribution of centralized configuration updates and staggered agent restarts
 
 ## Overview
 

--- a/docs/ref/modules/remoted/config-distribution-throttling.md
+++ b/docs/ref/modules/remoted/config-distribution-throttling.md
@@ -1,0 +1,58 @@
+# Centralized Configuration Distribution Throttling
+
+This document describes the investigation and design behind the mechanism that paces the distribution of centralized (group) configuration updates in `wazuh-manager-remoted`, and the associated staggering of agent restarts. It addresses [issue #37527](https://github.com/wazuh/wazuh/issues/37527).
+
+## Problem
+
+When the centralized configuration of a group changes, every agent in that group must download the new configuration and reload/restart. In large deployments (thousands of agents per group), this happens within a very narrow time window, producing load spikes on the manager:
+
+- Simultaneous downloads of the updated `merged.mg`.
+- Simultaneous agent restarts.
+- Simultaneous reconnections and bursts of synchronization and event traffic afterwards.
+
+## Current workflow
+
+The relevant code lives in `src/remoted/src/manager.c`:
+
+1. `update_shared_files()` rebuilds each group's `merged.mg` every `shared_reload_interval` seconds (10 by default) and stores its MD5 checksum.
+2. On every agent keep-alive, `save_controlmsg()` compares the group's checksum against the checksum the agent reports. On mismatch it pushes the agent ID onto `pending_queue` and marks the agent as *not synced*.
+3. A pool of `sender_pool` (8 by default) `wait_for_msgs()` threads pop `pending_queue` and call `send_file_toagent()`, sending the file **as fast as they can**.
+4. On the agent side (`src/client-agent/src/receiver.c`), once the new `merged.mg` is received and its checksum verified, the agent triggers a reload/restart.
+
+Because the restart is driven by the *reception* of the configuration, throttling the distribution on the manager side is sufficient to stagger both the downloads and the restarts. No agent-side change is required, which keeps older agents fully compatible.
+
+## Evaluated strategies
+
+| Strategy | Pros | Cons |
+|----------|------|------|
+| **Rate limiting / batched distribution** (chosen) | Single manager-side change at the natural chokepoint (`wait_for_msgs`); staggers downloads *and* restarts at once; cluster-friendly (each node paces its own agents); fully backward compatible | Restart timing is indirect (a consequence of paced delivery) rather than explicitly scheduled |
+| Randomized restart delay (jitter) on the agent | Directly spreads restarts | Requires an agent-side protocol change; breaks compatibility with existing agents; does not spread the configuration downloads |
+| Dedicated distribution queue with workers | Flexible scheduling | `pending_queue` already exists; adding a second queue duplicates state for little gain |
+| Cluster-aware global balancing | Global optimum across the cluster | High complexity; needs cross-node coordination; each node already only serves the agents connected to it |
+
+## Chosen solution
+
+A **token-bucket rate limiter** shared by the sender threads, applied right before `send_file_toagent()` in `wait_for_msgs()`.
+
+- Capacity (burst) and refill amount: `shared_config_batch_size` agents.
+- Refill window: `shared_config_interval` seconds.
+- Effective steady-state rate: `shared_config_batch_size / shared_config_interval` agents per
+  second, after an initial burst of one full batch.
+
+The pacing math is isolated in the pure helper `shared_config_bucket_update()` (no clock, no sleep) so it can be unit-tested deterministically; `throttle_shared_config_distribution()` wraps it with the shared mutex, the monotonic-style clock and the sleep.
+
+### Configuration
+
+Two options in the `<remote>` block of `ossec.conf` (see [configuration.md](configuration.md) for details):
+
+- `shared_config_batch_size` — default `0`, which **disables** throttling and preserves the legacy "send as fast as possible" behavior. Backward compatible by default.
+- `shared_config_interval` — default `5` seconds; only used when `shared_config_batch_size > 0`.
+
+### Cluster behavior
+
+Each cluster node runs its own `remoted` and only serves the agents connected to it. The limiter is therefore applied per node with no cross-node coordination required, which keeps the design simple and compatible with clustered environments. The effective cluster-wide rate is the sum of the per-node rates.
+
+## Testing
+
+- **Unit tests** (`src/unit_tests/remoted/`): `test_remote-config.c` covers parsing and validation of both options; `test_manager.c` covers the token-bucket math (`shared_config_bucket_update`): granting, refilling, capping at the batch size, and reporting the wait time when empty.
+- **Integration tests** (`tests/integration/test_remoted/`): validation of valid/invalid option values, and a staggered-distribution test that simulates several agents in a group and asserts the configuration pushes are spread over time.

--- a/docs/ref/modules/remoted/configuration.md
+++ b/docs/ref/modules/remoted/configuration.md
@@ -85,6 +85,23 @@ Time in seconds before allowing a new connection to overtake an existing agent c
 - **Allowed values:** Integer from `0` to `3600` (seconds)
 - **Note:** Set to `0` to disable overtake protection (allows immediate reconnection); higher values provide more protection against connection hijacking while requiring longer wait for legitimate agent restarts
 
+### shared_config_batch_size
+
+Maximum number of agents that are served an updated group (centralized) configuration during each `shared_config_interval` window. This paces the distribution of `merged.mg` after a group configuration changes, which in turn staggers the restarts agents perform when they receive the new configuration. It prevents load spikes in large deployments where thousands of agents would otherwise download the configuration and restart within the same few seconds.
+
+- **Default value:** `0` (throttling disabled: the configuration is served as fast as possible, preserving the legacy behavior)
+- **Allowed values:** Integer from `0` to `100000` (agents)
+- **Note:** The rate limiter is applied independently by each cluster node to the agents connected to it. The first window allows a burst of up to `shared_config_batch_size` agents; afterwards agents are served at a rate of `shared_config_batch_size` per `shared_config_interval` seconds.
+- **Note:** Throttling parks the serving `sender_pool` threads while they wait for their turn. Very restrictive settings (a small batch size over a long interval) can therefore keep all sender threads waiting for the duration of a window, delaying every `merged.mg` push accordingly. Size `shared_config_batch_size`/`shared_config_interval` with `remoted.sender_pool` in mind.
+
+### shared_config_interval
+
+Length, in seconds, of the window used by `shared_config_batch_size` to pace the distribution of updated group configuration.
+
+- **Default value:** `5`
+- **Allowed values:** Integer from `1` to `3600` (seconds)
+- **Note:** Only takes effect when `shared_config_batch_size` is greater than `0`. For example, `shared_config_batch_size` = `100` with `shared_config_interval` = `5` distributes the configuration to at most 100 agents every 5 seconds (20 agents per second).
+
 ---
 
 ## Internal Options

--- a/src/config/include/remote-config.h
+++ b/src/config/include/remote-config.h
@@ -25,6 +25,11 @@
 
 #define REMOTED_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT false  ///< Default allow_higher_versions value (false)
 
+#define REMOTED_SHARED_CONFIG_BATCH_SIZE_DEFAULT 0   ///< Default shared_config_batch_size (0 = throttling disabled)
+#define REMOTED_SHARED_CONFIG_BATCH_SIZE_MAX     100000 ///< Maximum agents served per shared config window
+#define REMOTED_SHARED_CONFIG_INTERVAL_DEFAULT   5   ///< Default shared_config_interval in seconds
+#define REMOTED_SHARED_CONFIG_INTERVAL_MAX       3600 ///< Maximum shared_config_interval in seconds
+
 #include "shared.h"
 #include "global-config.h"
 
@@ -45,6 +50,8 @@ typedef struct _remoted {
     bool worker_node;
     int rids_closing_time;
     int connection_overtake_time;
+    int shared_config_batch_size;   ///< Max agents served an updated shared config per window (0 = throttling disabled)
+    int shared_config_interval;     ///< Length of the shared config distribution window, in seconds
     _Config global;
 } remoted;
 

--- a/src/config/src/remote-config.c
+++ b/src/config/src/remote-config.c
@@ -51,6 +51,8 @@ int Read_Remote(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
     const char *xml_queue_size = "queue_size";
     const char *xml_rids_closing_time = "rids_closing_time";
     const char *xml_connection_overtake_time = "connection_overtake_time";
+    const char *xml_shared_config_batch_size = "shared_config_batch_size";
+    const char *xml_shared_config_interval = "shared_config_interval";
 
     logr = (remoted *)d1;
 
@@ -132,6 +134,28 @@ int Read_Remote(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
                     mwarn("Invalid value for element '%s':'%s'. Setting to default value: '%d'.", node[i]->element, node[i]->content, logr->connection_overtake_time);
                 } else {
                     logr->connection_overtake_time = connection_overtake_time;
+                }
+            }
+        } else if (strcmp(node[i]->element, xml_shared_config_batch_size) == 0) {
+            if (!OS_StrIsNum(node[i]->content)) {
+                mwarn("Invalid value for element '%s':'%s'. Setting to default value: '%d'.", node[i]->element, node[i]->content, logr->shared_config_batch_size);
+            } else {
+                int shared_config_batch_size = atoi(node[i]->content);
+                if (shared_config_batch_size < 0 || shared_config_batch_size > REMOTED_SHARED_CONFIG_BATCH_SIZE_MAX) {
+                    mwarn("Invalid value for element '%s':'%s'. Setting to default value: '%d'.", node[i]->element, node[i]->content, logr->shared_config_batch_size);
+                } else {
+                    logr->shared_config_batch_size = shared_config_batch_size;
+                }
+            }
+        } else if (strcmp(node[i]->element, xml_shared_config_interval) == 0) {
+            if (!OS_StrIsNum(node[i]->content)) {
+                mwarn("Invalid value for element '%s':'%s'. Setting to default value: '%d'.", node[i]->element, node[i]->content, logr->shared_config_interval);
+            } else {
+                int shared_config_interval = atoi(node[i]->content);
+                if (shared_config_interval < 1 || shared_config_interval > REMOTED_SHARED_CONFIG_INTERVAL_MAX) {
+                    mwarn("Invalid value for element '%s':'%s'. Setting to default value: '%d'.", node[i]->element, node[i]->content, logr->shared_config_interval);
+                } else {
+                    logr->shared_config_interval = shared_config_interval;
                 }
             }
         } else if (strcasecmp(node[i]->element, xml_remote_agents) == 0) {

--- a/src/remoted/src/config.c
+++ b/src/remoted/src/config.c
@@ -91,6 +91,8 @@ int RemotedConfig(const char *cfgfile, remoted *cfg)
     cfg->queue_size = 131072;
     cfg->allow_higher_versions = REMOTED_ALLOW_AGENTS_HIGHER_VERSIONS_DEFAULT;
     cfg->connection_overtake_time = 60;
+    cfg->shared_config_batch_size = REMOTED_SHARED_CONFIG_BATCH_SIZE_DEFAULT;
+    cfg->shared_config_interval = REMOTED_SHARED_CONFIG_INTERVAL_DEFAULT;
 
     // Initialize all internal options
     receive_chunk = (unsigned)getDefine_Int_default("remoted", "receive_chunk", 1024, 16384, 4096);
@@ -205,6 +207,8 @@ cJSON *getRemoteConfig(void) {
     }
 
     cJSON_AddNumberToObject(conn, "connection_overtake_time", logr.connection_overtake_time);
+    cJSON_AddNumberToObject(conn, "shared_config_batch_size", logr.shared_config_batch_size);
+    cJSON_AddNumberToObject(conn, "shared_config_interval", logr.shared_config_interval);
 
     cJSON_AddItemToArray(rem,conn);
 

--- a/src/remoted/src/manager.c
+++ b/src/remoted/src/manager.c
@@ -160,6 +160,33 @@ STATIC cJSON *assign_group_to_agent_worker(const char *agent_id, const char *md5
 static int send_file_toagent(const char *agent_id, const char *group, const char *name, const char *sum, char *sharedcfg_dir);
 
 /**
+ * @brief Update a token-bucket state for shared configuration distribution.
+ *
+ * Pure helper (no clock, no sleep) so the pacing math can be unit-tested
+ * deterministically. Refills the bucket according to the elapsed time and, when
+ * a token is available, grants it (returning the count already decremented by
+ * one). Otherwise it reports how long the caller must wait for the next token.
+ *
+ * @param tokens Current available tokens.
+ * @param elapsed Seconds elapsed since the last refill.
+ * @param batch_size Bucket capacity and refill amount per interval (agents).
+ * @param interval Refill window, in seconds.
+ * @param[out] wait_seconds Seconds to wait before a token is available (0 when granted).
+ * @return Updated token count (decremented by one when a token is granted).
+ */
+static double shared_config_bucket_update(double tokens, double elapsed, int batch_size, int interval, double *wait_seconds);
+
+/**
+ * @brief Block the calling sender thread until a shared configuration distribution slot is free.
+ *
+ * Paces how fast agents are served an updated merged.mg using a token bucket
+ * shared across all sender threads. When throttling is disabled
+ * (shared_config_batch_size <= 0) it returns immediately, preserving the legacy
+ * "send as fast as possible" behavior.
+ */
+static void throttle_shared_config_distribution(void);
+
+/**
  * @brief Validate files to be shared with agents, update invalid file hash table
  * @param src_path Source path of the files to validate
  * @param finalfp Handler of temporal file
@@ -202,6 +229,14 @@ OSHash *pending_data;
 /* pthread mutex variables */
 static pthread_mutex_t lastmsg_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t files_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+/* Shared configuration distribution rate limiter (token bucket).
+ * Shared across all sender threads to progressively distribute updated group
+ * configuration and, in turn, stagger the restarts agents perform on receipt. */
+static pthread_mutex_t shared_config_throttle_mutex = PTHREAD_MUTEX_INITIALIZER;
+static double shared_config_tokens = 0;
+static struct timespec shared_config_last_refill;
+static bool shared_config_throttle_initialized = false;
 
 /* Hash table for multigroups */
 OSHash *m_hash;
@@ -1784,6 +1819,72 @@ static int send_file_toagent(const char *agent_id, const char *group, const char
     return OS_SUCCESS;
 }
 
+static double shared_config_bucket_update(double tokens, double elapsed, int batch_size, int interval, double *wait_seconds)
+{
+    double rate = (double)batch_size / (double)interval;
+
+    if (elapsed > 0) {
+        tokens += elapsed * rate;
+        if (tokens > batch_size) {
+            tokens = batch_size;
+        }
+    }
+
+    if (tokens >= 1.0) {
+        *wait_seconds = 0;
+        return tokens - 1.0;
+    }
+
+    *wait_seconds = (1.0 - tokens) / rate;
+    return tokens;
+}
+
+static void throttle_shared_config_distribution(void)
+{
+    int batch_size = logr.shared_config_batch_size;
+    int interval = logr.shared_config_interval;
+
+    /* Throttling disabled: keep the legacy behavior */
+    if (batch_size <= 0 || interval <= 0) {
+        return;
+    }
+
+    w_mutex_lock(&shared_config_throttle_mutex);
+
+    if (!shared_config_throttle_initialized) {
+        clock_gettime(CLOCK_MONOTONIC, &shared_config_last_refill);
+        /* Allow an initial burst of a full batch */
+        shared_config_tokens = batch_size;
+        shared_config_throttle_initialized = true;
+    }
+
+    while (1) {
+        struct timespec now;
+        clock_gettime(CLOCK_MONOTONIC, &now);
+
+        double elapsed = time_diff(&shared_config_last_refill, &now);
+        shared_config_last_refill = now;
+
+        double wait_seconds = 0;
+        shared_config_tokens = shared_config_bucket_update(shared_config_tokens, elapsed, batch_size, interval, &wait_seconds);
+
+        if (wait_seconds <= 0) {
+            break;
+        }
+
+        w_mutex_unlock(&shared_config_throttle_mutex);
+
+        struct timespec ts;
+        ts.tv_sec = (time_t)wait_seconds;
+        ts.tv_nsec = (long)((wait_seconds - (double)ts.tv_sec) * 1e9);
+        nanosleep(&ts, NULL);
+
+        w_mutex_lock(&shared_config_throttle_mutex);
+    }
+
+    w_mutex_unlock(&shared_config_throttle_mutex);
+}
+
 /* Wait for new messages to read */
 void *wait_for_msgs(__attribute__((unused)) void *none)
 {
@@ -1798,6 +1899,10 @@ void *wait_for_msgs(__attribute__((unused)) void *none)
 
         /* Pop data from queue */
         char *agent_id = linked_queue_pop_ex(pending_queue);
+
+        /* Pace the distribution to avoid load spikes on large groups. This also
+        * staggers the restarts agents trigger when they receive the new config. */
+        throttle_shared_config_distribution();
 
         w_mutex_lock(&lastmsg_mutex);
 
@@ -1883,6 +1988,7 @@ void manager_init()
     _stime = time(0);
     m_hash = OSHash_Create();
     invalid_files = OSHash_Create();
+    shared_config_throttle_initialized = false;
 
     mdebug1("Running manager_init");
 

--- a/src/unit_tests/remoted/test_manager.c
+++ b/src/unit_tests/remoted/test_manager.c
@@ -5339,6 +5339,54 @@ static void test_build_handshake_json_with_empty_agent_groups(void **state) {
     os_free(json_str);
 }
 
+/* Tests shared_config_bucket_update (token-bucket pacing math) */
+
+static void test_shared_config_bucket_grant_when_tokens_available(void **state) {
+    (void) state;
+    double wait_seconds = -1;
+
+    // 5 tokens available, no time elapsed -> a token is granted immediately
+    double tokens = shared_config_bucket_update(5.0, 0.0, 100, 5, &wait_seconds);
+
+    assert_int_equal((int)(wait_seconds * 1000), 0);
+    assert_int_equal((int)(tokens * 1000), 4000);
+}
+
+static void test_shared_config_bucket_refills_over_time(void **state) {
+    (void) state;
+    double wait_seconds = -1;
+
+    // batch_size=100, interval=5 -> 20 tokens/s. 2s elapsed adds 40 tokens.
+    double tokens = shared_config_bucket_update(0.0, 2.0, 100, 5, &wait_seconds);
+
+    assert_int_equal((int)(wait_seconds * 1000), 0);
+    // 40 refilled, 1 consumed -> 39
+    assert_int_equal((int)(tokens * 1000), 39000);
+}
+
+static void test_shared_config_bucket_caps_at_batch_size(void **state) {
+    (void) state;
+    double wait_seconds = -1;
+
+    // Long idle period must not accumulate more than batch_size tokens
+    double tokens = shared_config_bucket_update(0.0, 3600.0, 50, 5, &wait_seconds);
+
+    assert_int_equal((int)(wait_seconds * 1000), 0);
+    // Capped at 50, minus 1 consumed -> 49
+    assert_int_equal((int)(tokens * 1000), 49000);
+}
+
+static void test_shared_config_bucket_waits_when_empty(void **state) {
+    (void) state;
+    double wait_seconds = -1;
+
+    // No tokens and no elapsed time: must report how long to wait for one token.
+    // rate = 100/5 = 20 tokens/s -> 1 token in 0.05s. Tokens unchanged (not granted).
+    double tokens = shared_config_bucket_update(0.0, 0.0, 100, 5, &wait_seconds);
+
+    assert_int_equal((int)(wait_seconds * 1000), 50);
+    assert_int_equal((int)(tokens * 1000), 0);
+}
 
 int main(void)
 {
@@ -5479,6 +5527,11 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_build_handshake_json_with_single_agent_group, setup_cluster_globals, teardown_cluster_globals),
         cmocka_unit_test_setup_teardown(test_build_handshake_json_with_no_agent_groups, setup_cluster_globals, teardown_cluster_globals),
         cmocka_unit_test_setup_teardown(test_build_handshake_json_with_empty_agent_groups, setup_cluster_globals, teardown_cluster_globals),
+        // Tests shared_config_bucket_update
+        cmocka_unit_test(test_shared_config_bucket_grant_when_tokens_available),
+        cmocka_unit_test(test_shared_config_bucket_refills_over_time),
+        cmocka_unit_test(test_shared_config_bucket_caps_at_batch_size),
+        cmocka_unit_test(test_shared_config_bucket_waits_when_empty),
     };
     return cmocka_run_group_tests(tests, test_setup_group, test_teardown_group);
 }

--- a/src/unit_tests/remoted/test_remote-config.c
+++ b/src/unit_tests/remoted/test_remote-config.c
@@ -76,6 +76,8 @@ static remoted *create_remoted() {
     logr->queue_size = 0;
     logr->rids_closing_time = 0;
     logr->connection_overtake_time = 60;
+    logr->shared_config_batch_size = REMOTED_SHARED_CONFIG_BATCH_SIZE_DEFAULT;
+    logr->shared_config_interval = REMOTED_SHARED_CONFIG_INTERVAL_DEFAULT;
     logr->lip = NULL;
     return logr;
 }
@@ -487,6 +489,72 @@ static void test_read_remote_denied_ips_section(void **state) {
     free_node_array(nodes);
 }
 
+static void test_read_remote_valid_shared_config_batch_size(void **state) {
+    test_state *ts = *state;
+
+    xml_node **nodes = create_node_array(1,
+        create_xml_node("shared_config_batch_size", "200")
+    );
+
+    int result = Read_Remote(&ts->xml, nodes, ts->logr, NULL);
+
+    assert_int_equal(result, OS_SUCCESS);
+    assert_int_equal(ts->logr->shared_config_batch_size, 200);
+
+    free_node_array(nodes);
+}
+
+static void test_read_remote_invalid_shared_config_batch_size(void **state) {
+    test_state *ts = *state;
+
+    xml_node **nodes = create_node_array(1,
+        create_xml_node("shared_config_batch_size", "-5")
+    );
+
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "Invalid value for element 'shared_config_batch_size':'-5'. Setting to default value: '0'.");
+
+    int result = Read_Remote(&ts->xml, nodes, ts->logr, NULL);
+
+    assert_int_equal(result, OS_SUCCESS);
+    assert_int_equal(ts->logr->shared_config_batch_size, REMOTED_SHARED_CONFIG_BATCH_SIZE_DEFAULT);
+
+    free_node_array(nodes);
+}
+
+static void test_read_remote_valid_shared_config_interval(void **state) {
+    test_state *ts = *state;
+
+    xml_node **nodes = create_node_array(1,
+        create_xml_node("shared_config_interval", "10")
+    );
+
+    int result = Read_Remote(&ts->xml, nodes, ts->logr, NULL);
+
+    assert_int_equal(result, OS_SUCCESS);
+    assert_int_equal(ts->logr->shared_config_interval, 10);
+
+    free_node_array(nodes);
+}
+
+static void test_read_remote_invalid_shared_config_interval(void **state) {
+    test_state *ts = *state;
+
+    xml_node **nodes = create_node_array(1,
+        create_xml_node("shared_config_interval", "0")
+    );
+
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "Invalid value for element 'shared_config_interval':'0'. Setting to default value: '5'.");
+
+    int result = Read_Remote(&ts->xml, nodes, ts->logr, NULL);
+
+    assert_int_equal(result, OS_SUCCESS);
+    assert_int_equal(ts->logr->shared_config_interval, REMOTED_SHARED_CONFIG_INTERVAL_DEFAULT);
+
+    free_node_array(nodes);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -509,6 +577,10 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_read_remote_connection_section, setup, teardown),
         cmocka_unit_test_setup_teardown(test_read_remote_allowed_ips_section, setup, teardown),
         cmocka_unit_test_setup_teardown(test_read_remote_denied_ips_section, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_read_remote_valid_shared_config_batch_size, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_read_remote_invalid_shared_config_batch_size, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_read_remote_valid_shared_config_interval, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_read_remote_invalid_shared_config_interval, setup, teardown),
 
     };
 

--- a/tests/integration/test_remoted/test_agent_communication/data/configuration_templates/config_shared_config_staggered.yaml
+++ b/tests/integration/test_remoted/test_agent_communication/data/configuration_templates/config_shared_config_staggered.yaml
@@ -1,0 +1,11 @@
+- sections:
+    - section: remote
+      elements:
+        - port:
+            value: '1514'
+        - protocol:
+            value: PROTOCOL
+        - shared_config_batch_size:
+            value: SHARED_CONFIG_BATCH_SIZE
+        - shared_config_interval:
+            value: SHARED_CONFIG_INTERVAL

--- a/tests/integration/test_remoted/test_agent_communication/data/test_cases/cases_shared_config_staggered.yaml
+++ b/tests/integration/test_remoted/test_agent_communication/data/test_cases/cases_shared_config_staggered.yaml
@@ -1,0 +1,13 @@
+- name: Staggered shared configuration distribution
+  description: With a batch size of 1 agent every 3 seconds, the config pushes to a group of agents must be spread over time
+  configuration_parameters:
+    PROTOCOL: 'TCP'
+    SHARED_CONFIG_BATCH_SIZE: '1'
+    SHARED_CONFIG_INTERVAL: '3'
+  metadata:
+    protocol: 'TCP'
+    agents_number: 4
+    shared_config_batch_size: 1
+    shared_config_interval: 3
+    # Initial burst equals batch_size (1), so the remaining agents are paced one per interval.
+    min_distribution_span: 5

--- a/tests/integration/test_remoted/test_agent_communication/test_shared_config_staggered_distribution.py
+++ b/tests/integration/test_remoted/test_agent_communication/test_shared_config_staggered_distribution.py
@@ -1,0 +1,158 @@
+"""
+ Copyright (C) 2015-2024, Wazuh Inc.
+ Created by Wazuh, Inc. <info@wazuh.com>.
+ This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+"""
+
+import re
+import time
+import pytest
+
+from datetime import datetime
+from pathlib import Path
+from wazuh_testing.tools.simulators.agent_simulator import connect
+from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
+from wazuh_testing.modules.remoted.configuration import REMOTED_DEBUG
+from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
+from wazuh_testing.tools.monitors.file_monitor import FileMonitor
+from wazuh_testing.utils.callbacks import generate_callback
+from wazuh_testing.modules.remoted import patterns
+from wazuh_testing.utils.agent_groups import create_group, delete_group, add_agent_to_group
+
+from . import CONFIGS_PATH, TEST_CASES_PATH
+
+
+# Set pytest marks.
+pytestmark = [pytest.mark.server, pytest.mark.tier(level=2)]
+
+# Cases metadata and its ids.
+cases_path = Path(TEST_CASES_PATH, 'cases_shared_config_staggered.yaml')
+config_path = Path(CONFIGS_PATH, 'config_shared_config_staggered.yaml')
+test_configuration, test_metadata, cases_ids = get_test_cases_data(cases_path)
+test_configuration = load_configuration_template(config_path, test_configuration, test_metadata)
+
+daemons_handler_configuration = {'all_daemons': True}
+
+local_internal_options = {REMOTED_DEBUG: '2'}
+
+# Leading timestamp of a Wazuh log line, e.g. "2024/07/23 15:04:05 ...".
+LOG_TIMESTAMP_REGEX = re.compile(r'^(\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2})')
+# Matches "End sending file '.../merged.mg' to agent 'ID'."
+END_SEND_REGEX = re.compile(r'End sending file.*to agent')
+
+
+def get_distribution_timestamps():
+    """Return the timestamps of every 'End sending file to agent' log line."""
+    timestamps = []
+    with open(WAZUH_LOG_PATH, 'r') as log_file:
+        for line in log_file:
+            if END_SEND_REGEX.search(line):
+                match = LOG_TIMESTAMP_REGEX.match(line)
+                if match:
+                    timestamps.append(datetime.strptime(match.group(1), '%Y/%m/%d %H:%M:%S'))
+    return timestamps
+
+
+# Test function.
+@pytest.mark.parametrize('test_configuration, test_metadata', zip(test_configuration, test_metadata), ids=cases_ids)
+def test_shared_config_staggered_distribution(test_configuration, test_metadata, configure_local_internal_options,
+                                              truncate_monitored_files, set_wazuh_configuration, daemons_handler,
+                                              simulate_agents):
+    '''
+    description: Check that the manager progressively distributes an updated group configuration when
+                 'shared_config_batch_size'/'shared_config_interval' throttling is enabled, instead of pushing it
+                 to every agent of the group at once. This also staggers the restarts agents perform on receipt.
+
+                 The test simulates several agents, adds them to a group and then modifies the group configuration.
+                 It asserts that the "End sending file to agent" events recorded in the log are spread over a time
+                 window consistent with the configured rate, rather than happening simultaneously.
+
+    parameters:
+        - test_configuration:
+            type: dict
+            brief: Configuration applied to ossec.conf.
+        - test_metadata:
+            type: dict
+            brief: Test case metadata.
+        - configure_local_internal_options:
+            type: fixture
+            brief: Configure the Wazuh local internal options using the values from `local_internal_options`.
+        - truncate_monitored_files:
+            type: fixture
+            brief: Truncate all the log files and json alerts files before and after the test execution.
+        - set_wazuh_configuration:
+            type: fixture
+            brief: Apply changes to the ossec.conf configuration.
+        - daemons_handler:
+            type: fixture
+            brief: Restart service once the test finishes stops the daemons.
+        - simulate_agents:
+            type: fixture
+            brief: Create the simulated agents.
+
+    assertions:
+        - Verify that the manager pushes the updated configuration to every agent of the group.
+        - Verify that the distribution is spread over at least 'min_distribution_span' seconds.
+    '''
+    agents = simulate_agents
+    agents_number = test_metadata['agents_number']
+    protocol = test_metadata['protocol']
+    group = 'staggered_group'
+
+    injectors = []
+
+    wazuh_log_monitor = FileMonitor(WAZUH_LOG_PATH)
+
+    # Connect every agent and complete its handshake with a start-up and a keep-alive message.
+    for agent in agents:
+        sender, injector = connect(agent=agent, protocol=protocol)
+        injectors.append(injector)
+
+        sender.send_event(agent.startup_msg)
+        wazuh_log_monitor.start(callback=generate_callback(regex=patterns.START_UP,
+                                                           replacement={"agent_name": agent.name,
+                                                                        "agent_ip": '127.0.0.1'}))
+        assert wazuh_log_monitor.callback_result, f"Agent {agent.id} did not complete its start-up."
+
+        sender.send_event(agent.keep_alive_event)
+
+    # Let the agents settle as 'synced' before the group configuration changes.
+    time.sleep(5)
+
+    # Modify the group configuration: this marks every agent of the group as out of sync.
+    create_group(group)
+    for agent in agents:
+        add_agent_to_group(group, agent.id)
+
+    try:
+        # Truncate so we only count the pushes triggered by the group change from now on.
+        with open(WAZUH_LOG_PATH, 'w'):
+            pass
+
+        # Trigger the re-sync: every agent reports its now stale merged.mg checksum.
+        senders = [connect(agent=agent, protocol=protocol) for agent in agents]
+        injectors.extend(injector for _, injector in senders)
+        for (sender, _), agent in zip(senders, agents):
+            sender.send_event(agent.keep_alive_event)
+
+        # Wait long enough for the paced distribution to complete for every agent.
+        max_wait = test_metadata['min_distribution_span'] + test_metadata['shared_config_interval'] * agents_number + 30
+        deadline = time.time() + max_wait
+        timestamps = []
+        while time.time() < deadline:
+            timestamps = get_distribution_timestamps()
+            if len(timestamps) >= agents_number:
+                break
+            time.sleep(1)
+
+        assert len(timestamps) >= agents_number, \
+            f"Expected the config pushed to {agents_number} agents, but only saw {len(timestamps)} pushes."
+
+        distribution_span = (max(timestamps) - min(timestamps)).total_seconds()
+        assert distribution_span >= test_metadata['min_distribution_span'], \
+            f"Distribution span {distribution_span}s is below the expected minimum " \
+            f"{test_metadata['min_distribution_span']}s; the throttling did not stagger the pushes."
+    finally:
+        delete_group(group)
+        for injector in injectors:
+            injector.stop_receive()

--- a/tests/integration/test_remoted/test_configurations/data/configuration_templates/config_shared_config_distribution.yaml
+++ b/tests/integration/test_remoted/test_configurations/data/configuration_templates/config_shared_config_distribution.yaml
@@ -1,0 +1,11 @@
+- sections:
+    - section: remote
+      elements:
+        - port:
+            value: PORT
+        - protocol:
+            value: PROTOCOL
+        - shared_config_batch_size:
+            value: SHARED_CONFIG_BATCH_SIZE
+        - shared_config_interval:
+            value: SHARED_CONFIG_INTERVAL

--- a/tests/integration/test_remoted/test_configurations/data/test_cases/cases_shared_config_invalid.yaml
+++ b/tests/integration/test_remoted/test_configurations/data/test_cases/cases_shared_config_invalid.yaml
@@ -1,0 +1,39 @@
+- name: Negative shared_config_batch_size
+  description: A negative batch size must be rejected and fall back to the default
+  configuration_parameters:
+    PORT: '1514'
+    PROTOCOL: 'TCP'
+    SHARED_CONFIG_BATCH_SIZE: '-1'
+    SHARED_CONFIG_INTERVAL: '5'
+  metadata:
+    invalid_element: 'shared_config_batch_size'
+
+- name: Non numeric shared_config_batch_size
+  description: A non numeric batch size must be rejected and fall back to the default
+  configuration_parameters:
+    PORT: '1514'
+    PROTOCOL: 'TCP'
+    SHARED_CONFIG_BATCH_SIZE: 'abc'
+    SHARED_CONFIG_INTERVAL: '5'
+  metadata:
+    invalid_element: 'shared_config_batch_size'
+
+- name: Zero shared_config_interval
+  description: An interval below the minimum must be rejected and fall back to the default
+  configuration_parameters:
+    PORT: '1514'
+    PROTOCOL: 'TCP'
+    SHARED_CONFIG_BATCH_SIZE: '10'
+    SHARED_CONFIG_INTERVAL: '0'
+  metadata:
+    invalid_element: 'shared_config_interval'
+
+- name: Out of range shared_config_interval
+  description: An interval above the maximum must be rejected and fall back to the default
+  configuration_parameters:
+    PORT: '1514'
+    PROTOCOL: 'TCP'
+    SHARED_CONFIG_BATCH_SIZE: '10'
+    SHARED_CONFIG_INTERVAL: '99999'
+  metadata:
+    invalid_element: 'shared_config_interval'

--- a/tests/integration/test_remoted/test_configurations/data/test_cases/cases_shared_config_valid.yaml
+++ b/tests/integration/test_remoted/test_configurations/data/test_cases/cases_shared_config_valid.yaml
@@ -1,0 +1,32 @@
+- name: Shared config distribution disabled (default)
+  description: Throttling disabled with batch size 0
+  configuration_parameters:
+    PORT: '1514'
+    PROTOCOL: 'TCP'
+    SHARED_CONFIG_BATCH_SIZE: '0'
+    SHARED_CONFIG_INTERVAL: '5'
+  metadata:
+    shared_config_batch_size: 0
+    shared_config_interval: 5
+
+- name: Shared config distribution with small batch
+  description: Progressive distribution of 10 agents every 2 seconds
+  configuration_parameters:
+    PORT: '1514'
+    PROTOCOL: 'TCP'
+    SHARED_CONFIG_BATCH_SIZE: '10'
+    SHARED_CONFIG_INTERVAL: '2'
+  metadata:
+    shared_config_batch_size: 10
+    shared_config_interval: 2
+
+- name: Shared config distribution with large batch
+  description: Progressive distribution of 500 agents every 30 seconds
+  configuration_parameters:
+    PORT: '1514'
+    PROTOCOL: 'TCP'
+    SHARED_CONFIG_BATCH_SIZE: '500'
+    SHARED_CONFIG_INTERVAL: '30'
+  metadata:
+    shared_config_batch_size: 500
+    shared_config_interval: 30

--- a/tests/integration/test_remoted/test_configurations/test_shared_config_distribution_invalid.py
+++ b/tests/integration/test_remoted/test_configurations/test_shared_config_distribution_invalid.py
@@ -1,0 +1,71 @@
+"""
+ Copyright (C) 2015-2024, Wazuh Inc.
+ Created by Wazuh, Inc. <info@wazuh.com>.
+ This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+"""
+
+import pytest
+
+from pathlib import Path
+from wazuh_testing.tools.monitors.file_monitor import FileMonitor
+from wazuh_testing.utils.callbacks import generate_callback
+from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
+from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
+
+from . import CONFIGS_PATH, TEST_CASES_PATH
+
+from wazuh_testing.modules.remoted.configuration import REMOTED_DEBUG
+from wazuh_testing.modules.remoted import patterns
+
+# Set pytest marks.
+pytestmark = [pytest.mark.server, pytest.mark.tier(level=1)]
+
+# Cases metadata and its ids.
+cases_path = Path(TEST_CASES_PATH, 'cases_shared_config_invalid.yaml')
+config_path = Path(CONFIGS_PATH, 'config_shared_config_distribution.yaml')
+test_configuration, test_metadata, cases_ids = get_test_cases_data(cases_path)
+test_configuration = load_configuration_template(config_path, test_configuration, test_metadata)
+
+daemons_handler_configuration = {'all_daemons': True}
+
+local_internal_options = {REMOTED_DEBUG: '2'}
+
+
+# Test function.
+@pytest.mark.parametrize('test_configuration, test_metadata', zip(test_configuration, test_metadata), ids=cases_ids)
+def test_shared_config_distribution_invalid(test_configuration, test_metadata, configure_local_internal_options,
+                                            truncate_monitored_files, set_wazuh_configuration,
+                                            restart_wazuh_expect_error):
+    '''
+    description: Check that invalid 'shared_config_batch_size' and 'shared_config_interval' values are rejected
+                 by 'wazuh-manager-remoted', which logs a warning and falls back to the default value without
+                 aborting the startup (the option is not fatal).
+
+    parameters:
+        - test_configuration:
+            type: dict
+            brief: Configuration applied to ossec.conf.
+        - test_metadata:
+            type: dict
+            brief: Test case metadata.
+        - configure_local_internal_options:
+            type: fixture
+            brief: Configure the Wazuh local internal options using the values from `local_internal_options`.
+        - truncate_monitored_files:
+            type: fixture
+            brief: Truncate all the log files and json alerts files before and after the test execution.
+        - set_wazuh_configuration:
+            type: fixture
+            brief: Apply changes to the ossec.conf configuration.
+        - restart_wazuh_expect_error:
+            type: fixture
+            brief: Restart service when expected error is None, once the test finishes stops the daemons.
+
+    assertions:
+        - Verify that a warning about the invalid element is logged.
+    '''
+    log_monitor = FileMonitor(WAZUH_LOG_PATH)
+
+    log_monitor.start(callback=generate_callback(patterns.INVALID_VALUE_FOR_ELEMENT))
+    assert log_monitor.callback_result, \
+        f"Expected warning for invalid '{test_metadata['invalid_element']}' was not found."

--- a/tests/integration/test_remoted/test_configurations/test_shared_config_distribution_valid.py
+++ b/tests/integration/test_remoted/test_configurations/test_shared_config_distribution_valid.py
@@ -1,0 +1,71 @@
+"""
+ Copyright (C) 2015-2024, Wazuh Inc.
+ Created by Wazuh, Inc. <info@wazuh.com>.
+ This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+"""
+
+import pytest
+
+from pathlib import Path
+from wazuh_testing.utils.configuration import get_test_cases_data, load_configuration_template
+
+from . import CONFIGS_PATH, TEST_CASES_PATH
+
+from wazuh_testing.modules.remoted.configuration import REMOTED_DEBUG
+from wazuh_testing.modules.api import utils
+
+# Set pytest marks.
+pytestmark = [pytest.mark.server, pytest.mark.tier(level=1)]
+
+# Cases metadata and its ids.
+cases_path = Path(TEST_CASES_PATH, 'cases_shared_config_valid.yaml')
+config_path = Path(CONFIGS_PATH, 'config_shared_config_distribution.yaml')
+test_configuration, test_metadata, cases_ids = get_test_cases_data(cases_path)
+test_configuration = load_configuration_template(config_path, test_configuration, test_metadata)
+
+daemons_handler_configuration = {'all_daemons': True}
+
+local_internal_options = {REMOTED_DEBUG: '2'}
+
+
+# Test function.
+@pytest.mark.parametrize('test_configuration, test_metadata', zip(test_configuration, test_metadata), ids=cases_ids)
+def test_shared_config_distribution_valid(test_configuration, test_metadata, configure_local_internal_options,
+                                          truncate_monitored_files, set_wazuh_configuration,
+                                          restart_wazuh_expect_error):
+    '''
+    description: Check that valid 'shared_config_batch_size' and 'shared_config_interval' values are accepted
+                 by 'wazuh-manager-remoted' and reported back unchanged through the API configuration endpoint.
+
+    parameters:
+        - test_configuration:
+            type: dict
+            brief: Configuration applied to ossec.conf.
+        - test_metadata:
+            type: dict
+            brief: Test case metadata.
+        - configure_local_internal_options:
+            type: fixture
+            brief: Configure the Wazuh local internal options using the values from `local_internal_options`.
+        - truncate_monitored_files:
+            type: fixture
+            brief: Truncate all the log files and json alerts files before and after the test execution.
+        - set_wazuh_configuration:
+            type: fixture
+            brief: Apply changes to the ossec.conf configuration.
+        - restart_wazuh_expect_error:
+            type: fixture
+            brief: Restart service when expected error is None, once the test finishes stops the daemons.
+
+    assertions:
+        - Verify that the API reports the configured shared_config_batch_size.
+        - Verify that the API reports the configured shared_config_interval.
+    '''
+    remote_config = utils.get_manager_configuration(section='remote')
+
+    # 'remote' section is returned as a list of connection objects.
+    assert isinstance(remote_config, list)
+    connection = remote_config[0]
+
+    assert int(connection['shared_config_batch_size']) == test_metadata['shared_config_batch_size']
+    assert int(connection['shared_config_interval']) == test_metadata['shared_config_interval']


### PR DESCRIPTION
## Description

When the centralized configuration of a group changes, every agent in that group downloads the updated `merged.mg` and reloads/restarts on its next keep-alive. In large deployments (thousands of agents per group) this happens within a very narrow window, producing load spikes on the manager: simultaneous downloads, restarts, reconnections and bursts of sync/event traffic.

This PR adds a manager-side mechanism to progressively distribute those configuration updates and, as a consequence, stagger the restarts, without affecting existing behavior by default.

Closes #37527

## Proposed Changes

The natural chokepoint for group configuration is the sender path in `remoted` (`wait_for_msgs` → `send_file_toagent` in `src/remoted/src/manager.c`). A token-bucket rate limiter is applied there, shared across all sender threads:

- Bucket capacity / refill amount: `shared_config_batch_size` agents.
- Refill window: `shared_config_interval` seconds.
- Steady-state rate: `shared_config_batch_size / shared_config_interval` agents per second, after an initial burst of one full batch.

Because agents restart on config *receipt*, pacing the distribution staggers the restarts too, so no agent-side change is needed (older agents stay compatible). The limiter is applied per node, so it works transparently in a cluster (the cluster-wide rate is the sum of the per-node rates).

The pacing math is isolated in a pure helper (`shared_config_bucket_update`) so it can be unit-tested without a clock, while `throttle_shared_config_distribution` wraps it with the mutex, clock and sleep.

### Results and Evidence

The rationale, evaluated alternatives and chosen design are documented in `docs/ref/modules/remoted/config-distribution-throttling.md`.

Verified live on a manager built from this branch (Ubuntu 24.04). The manager ran `wazuh-manager-db` + `wazuh-manager-authd` + this `wazuh-manager-remoted`, with `remoted.debug=2`. Agents were simulated with the QA framework, enrolled, assigned to the `default` group and made to report a stale `merged.mg` checksum at the same time, so `remoted` queues all of them at once. The distribution was observed in `logs/wazuh-manager.log`.

Simulator (per run):

```python
from wazuh_testing.tools.simulators.agent_simulator import create_agents, connect
from wazuh_testing.utils.db_queries.global_db import set_agent_group

agents = create_agents(N, "localhost", authd_password=AUTHD_PASS)
conns = [(a, *connect(agent=a, wait_status='')) for a in agents]
for a in agents:
    set_agent_group(mode='override', sync_status='synced', source='remote', id=int(a.id), group='default')
for a, sender, _ in conns:            # trigger all agents at t0
    sender.send_event(a.startup_msg)
for a, sender, _ in conns:
    sender.send_event(a.keep_alive_event)
```

Observed:

```console
$ sudo grep 'End sending file' logs/wazuh-manager.log
```

**1. Throttling disabled (`shared_config_batch_size=0`, current/default behavior)** — the load spike, all 6 pushes land in the same second:

```
11:36:48  End sending file 'default/merged.mg' to agent '002'
11:36:48  End sending file 'default/merged.mg' to agent '004'
11:36:48  End sending file 'default/merged.mg' to agent '001'
11:36:48  End sending file 'default/merged.mg' to agent '005'
11:36:48  End sending file 'default/merged.mg' to agent '006'
11:36:48  End sending file 'default/merged.mg' to agent '003'
```

**2. Throttling enabled (`shared_config_batch_size=1`, `shared_config_interval=3`)** — one agent every 3 s, exactly as configured:

```
11:39:04  End sending file 'default/merged.mg' to agent '012'
11:39:07  End sending file 'default/merged.mg' to agent '011'   (+3s)
11:39:10  End sending file 'default/merged.mg' to agent '009'   (+3s)
11:39:13  End sending file 'default/merged.mg' to agent '010'   (+3s)
11:39:16  End sending file 'default/merged.mg' to agent '007'   (+3s)
11:39:19  End sending file 'default/merged.mg' to agent '008'   (+3s)
```

**3. Monotonic clock: pacing is immune to wall-clock jumps.** The limiter uses `CLOCK_MONOTONIC`, so NTP steps or manual clock changes cannot corrupt the refill delta. With 12 agents at `batch_size=1`/`interval=3`, the wall clock was stepped **−45 min** (t≈14 s) and **+3 h** (t≈23 s), both mid-distribution. Each push was stamped with a monotonic timer, independent of the wall clock:

```
monotonic t=+  2.12s  agent 033
monotonic t=+  5.14s  agent 032
monotonic t=+  8.12s  agent 037
monotonic t=+ 11.10s  agent 042
monotonic t=+ 14.12s  agent 031   <-- wall clock stepped -45 min here
monotonic t=+ 17.14s  agent 041
monotonic t=+ 20.11s  agent 039
monotonic t=+ 23.13s  agent 038   <-- wall clock stepped +3 h here
monotonic t=+ 26.11s  agent 036
monotonic t=+ 29.13s  agent 035
monotonic t=+ 32.11s  agent 038
monotonic t=+ 35.14s  agent 034
monotonic t=+ 38.11s  agent 040

real-time gaps: [3.02, 2.98, 2.98, 3.02, 3.02, 2.97, 3.02, 2.98, 3.03, 2.98, 3.02, 2.97]
min=2.97s  max=3.03s  span=35.99s
```

Every interval stays within 3 s ± 30 ms across both jumps — no burst and no stall. (The wall-clock timestamps in `wazuh-manager.log` do jump, since the logger uses wall time; the pacing does not.)

The staggering is also asserted automatically by the new `test_shared_config_staggered_distribution` integration test.
### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

> Note: the changed translation units compile cleanly (`-Wall -Wextra`, objects generated) on Linux. The cmocka unit suite and pytest integration suite are expected to run in CI, where the full build/test environment is available.

### Artifacts Affected

- `wazuh-manager-remoted` (Linux manager executable).
- Default configuration reference documentation for the `<remote>` section.

### Configuration Changes

Two new optional parameters in the `<remote>` block of `ossec.conf`:

- `shared_config_batch_size` — max agents served the updated group config per window. **Default `0`, which disables throttling and preserves the previous behavior.** Range `0`–`100000`.
- `shared_config_interval` — length of the throttling window in seconds. Default `5`. Range `1`–`3600`. Only used when `shared_config_batch_size > 0`.

Invalid values are non-fatal: a warning is logged and the default is used. Backward compatible: with the defaults, distribution behaves exactly as before.

### Tests Introduced

- Unit tests (`src/unit_tests/remoted/`):
  - `test_remote-config.c`: parsing and validation of both options (valid and out-of-range/non-numeric).
  - `test_manager.c`: token-bucket math (`shared_config_bucket_update`) — grant, refill over time, cap at batch size, and wait-time computation when empty.
- Integration tests (`tests/integration/test_remoted/`):
  - `test_configurations/`: valid values reported back through the API and invalid values rejected with a warning.
  - `test_agent_communication/`: staggered distribution over a group of simulated agents, asserting the pushes are spread over time.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues


