### PR TITLE
Add internal options to remoted-https

### DIFF
--- a/docs/ref/modules/remoted/configuration.md
+++ b/docs/ref/modules/remoted/configuration.md
@@ -375,6 +375,101 @@ Event count threshold for logging compression statistics.
 - **Allowed values:** Integer from `10` to `999999` (event count)
 - **Note:** Compression stats logged after this many events processed
 
+### HTTPS Agent Server (`remoted_module`)
+
+Advanced tuning for the experimental HTTPS agent server (see
+[HTTPS Events API](https-events-api.md)). These are RESTinio transport settings, not part
+of the regular `<remote>` configuration -- bind address, port and max body size are
+regular `<remote>` settings instead (see [HTTPS Events API](https-events-api.md#configuration)).
+An option present in `wazuh-manager-internal-options.conf` but out of its allowed range (or
+non-numeric) prevents `remoted` from starting, same as every other internal option.
+
+#### remoted.http_io_threads
+
+Number of I/O threads (accept + read/write) for the HTTPS agent server.
+
+- **Default value:** `2`
+- **Allowed values:** Integer from `1` to `64`
+
+#### remoted.http_worker_threads
+
+Number of worker threads that run endpoint handlers (auth + business logic), off the I/O threads.
+
+- **Default value:** `4`
+- **Allowed values:** Integer from `1` to `256`
+
+#### remoted.http_read_timeout
+
+Seconds to wait for a full request to arrive on a connection.
+
+- **Default value:** `10`
+- **Allowed values:** Integer from `1` to `300`
+- **Note:** The clock starts as soon as the connection is established, so this also bounds a
+  stalled TLS handshake -- there is no separate handshake timeout
+
+#### remoted.http_write_timeout
+
+Seconds to wait for a response write to complete.
+
+- **Default value:** `10`
+- **Allowed values:** Integer from `1` to `300`
+
+#### remoted.http_request_timeout
+
+Seconds a request may take to be handled end-to-end.
+
+- **Default value:** `30`
+- **Allowed values:** Integer from `1` to `600`
+
+#### remoted.http_max_url_size
+
+Maximum accepted URL size, in bytes.
+
+- **Default value:** `2048`
+- **Allowed values:** Integer from `1` to `65536`
+
+#### remoted.http_max_header_name_size
+
+Maximum accepted HTTP header name size, in bytes.
+
+- **Default value:** `256`
+- **Allowed values:** Integer from `1` to `8192`
+
+#### remoted.http_max_header_value_size
+
+Maximum accepted HTTP header value size, in bytes.
+
+- **Default value:** `8192`
+- **Allowed values:** Integer from `1` to `65536`
+
+#### remoted.http_max_header_count
+
+Maximum number of HTTP headers accepted per request.
+
+- **Default value:** `64`
+- **Allowed values:** Integer from `1` to `1024`
+
+#### remoted.http_max_pipelined_requests
+
+Maximum in-flight unanswered requests per connection (HTTP pipelining depth).
+
+- **Default value:** `4`
+- **Allowed values:** Integer from `1` to `64`
+
+#### remoted.http_concurrent_accepts
+
+Maximum concurrent in-progress TCP accepts for the HTTPS agent server.
+
+- **Default value:** `2`
+- **Allowed values:** Integer from `1` to `64`
+
+#### remoted.http_buffer_size
+
+Socket read buffer size for the HTTPS agent server, in bytes.
+
+- **Default value:** `8192`
+- **Allowed values:** Integer from `1` to `1048576` (1 MiB)
+
 ---
 
 ## Configuration Examples

--- a/docs/ref/modules/remoted/https-events-api.md
+++ b/docs/ref/modules/remoted/https-events-api.md
@@ -31,9 +31,10 @@ per-agent **AES-CMAC** signature derived from the agent's pre-shared key.
   `/etc/remoted-https/server.crt` and `/etc/remoted-https/server.key` — i.e. host paths
   `/var/wazuh-manager/etc/remoted-https/server.{crt,key}`. The private key must be readable by the
   `wazuh` user that `remoted` runs as.
-- **Message limits (fixed):** max URL 2048 B, max header name 256 B, max header value 8192 B, max
-  64 header fields, and a transport body cap of 16 MiB. Handshake/read timeouts are 10 s, request
-  timeout 30 s.
+- **Message limits and timeouts:** max URL 2048 B, max header name 256 B, max header value 8192 B,
+  max 64 header fields, and a transport body cap of 16 MiB by default; read/handshake timeout 10 s,
+  write timeout 10 s, request timeout 30 s. All tunable via `remoted.http_*` internal options -- see
+  [Configuration](#configuration) below.
 
 Generate a self-signed certificate for testing:
 
@@ -109,22 +110,47 @@ The machine-readable contract is published as OpenAPI — see the
 
 ## Configuration
 
-All settings resolve as **caller value (C-ABI struct) → environment variable → built-in default**.
-`remoted` currently leaves the C-ABI fields unset, so in practice values come from the environment
-or the defaults below.
+Advanced RESTinio settings resolve as **caller value → built-in default**. `remoted` populates the
+caller value by reading the `remoted.http_*` internal options
+(`etc/wazuh-manager-internal-options.conf`) in `secure.c` and passing the result to
+`remoted_module` through its C-ABI struct; an option present in the file but out of range (or
+non-numeric) prevents `remoted` from starting, same as every other internal option. See
+[Internal Options](configuration.md#internal-options) for the full reference (allowed ranges,
+notes).
 
-| Setting | Default | Environment override |
+| Setting | Default | Internal option |
 |---|---|---|
-| Bind address | `127.0.0.1` | `WAZUH_REMOTED_HTTPS_ADDRESS` |
-| Port | `9443` | `WAZUH_REMOTED_HTTPS_PORT` |
-| I/O threads | `2` | `WAZUH_REMOTED_HTTPS_IO_THREADS` |
-| Handler worker threads | `4` | `WAZUH_REMOTED_HTTPS_WORKER_THREADS` |
-| Transport max body size | `16 MiB` | `WAZUH_REMOTED_HTTPS_MAX_BODY_SIZE` |
-| TLS certificate chain | `/etc/remoted-https/server.crt` | `WAZUH_REMOTED_HTTPS_CERTIFICATE` |
-| TLS private key | `/etc/remoted-https/server.key` | `WAZUH_REMOTED_HTTPS_PRIVATE_KEY` |
+| I/O threads | `2` | `remoted.http_io_threads` |
+| Handler worker threads | `4` | `remoted.http_worker_threads` |
+| Read / handshake timeout | `10 s` | `remoted.http_read_timeout` |
+| Write timeout | `10 s` | `remoted.http_write_timeout` |
+| Request timeout | `30 s` | `remoted.http_request_timeout` |
+| Max URL size | `2048 B` | `remoted.http_max_url_size` |
+| Max header name size | `256 B` | `remoted.http_max_header_name_size` |
+| Max header value size | `8192 B` | `remoted.http_max_header_value_size` |
+| Max header count | `64` | `remoted.http_max_header_count` |
+| Max pipelined requests per connection | `4` | `remoted.http_max_pipelined_requests` |
+| Concurrent TCP accepts | `2` | `remoted.http_concurrent_accepts` |
+| Socket read buffer size | `8192 B` | `remoted.http_buffer_size` |
+
+Bind address, port, max body size and the certificate/private key paths are **not** internal
+options -- these belong in the regular `<remote>` configuration (`wazuh-manager.conf`), not
+`wazuh-manager-internal-options.conf` (bind address/port/max body size are regular, user-facing
+settings; the certificate/private key paths have no string-valued internal-option mechanism to use
+even if they were advanced tuning). That `<remote>` wiring doesn't exist yet, so all five resolve as
+**caller value (C-ABI struct) → built-in default**, and `remoted` currently leaves those C-ABI
+fields unset -- in practice the built-in defaults below apply.
+
+| Setting | Default |
+|---|---|
+| Bind address | `127.0.0.1` |
+| Port | `9443` |
+| Transport max body size | `16 MiB` |
+| TLS certificate chain | `/etc/remoted-https/server.crt` |
+| TLS private key | `/etc/remoted-https/server.key` |
 
 > There is no `ossec.conf` (`<remote>`) setting for the HTTPS listener yet; configuration is
-> limited to the environment variables above and the certificate files on disk.
+> limited to the internal options above and the certificate files on disk.
 
 ## Testing
 

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -204,4 +204,45 @@ agent.debug=0
 
 wazuh_modules.debug=0
 
+# Remoted HTTPS agent server (remoted_module) - advanced RESTinio tuning.
+# For fine-tuning only. Bind address, port and max body size are NOT here --
+# they belong in the regular <remote> configuration (wazuh-manager.conf).
+
+# Number of I/O threads (accept + read/write) for the HTTPS agent server [1..64]
+remoted.http_io_threads=2
+
+# Number of worker threads that run endpoint handlers for the HTTPS agent server [1..256]
+remoted.http_worker_threads=4
+
+# Seconds to wait for a full request on a connection; also bounds the TLS
+# handshake window, since the clock starts as soon as the connection opens [1..300]
+remoted.http_read_timeout=10
+
+# Seconds to wait for a response write to complete [1..300]
+remoted.http_write_timeout=10
+
+# Seconds a request may take to be handled end-to-end [1..600]
+remoted.http_request_timeout=30
+
+# Maximum accepted URL size, in bytes [1..65536]
+remoted.http_max_url_size=2048
+
+# Maximum accepted HTTP header name size, in bytes [1..8192]
+remoted.http_max_header_name_size=256
+
+# Maximum accepted HTTP header value size, in bytes [1..65536]
+remoted.http_max_header_value_size=8192
+
+# Maximum number of HTTP headers accepted per request [1..1024]
+remoted.http_max_header_count=64
+
+# Maximum in-flight unanswered requests per connection (HTTP pipelining depth) [1..64]
+remoted.http_max_pipelined_requests=4
+
+# Maximum concurrent in-progress TCP accepts for the HTTPS agent server [1..64]
+remoted.http_concurrent_accepts=2
+
+# Socket read buffer size for the HTTPS agent server, in bytes [1..1048576]
+remoted.http_buffer_size=8192
+
 # EOF

--- a/src/remoted/remoted_module/README.md
+++ b/src/remoted/remoted_module/README.md
@@ -53,10 +53,16 @@ src/http_server/
   bounded worker pool with a **deferred response**, so RESTinio's I/O threads never block on
   slow handler work (disk, calls to other APIs). A handler may respond inline or capture the
   responder, offload the blocking work, and call `responder->send(...)` later from any thread.
-- **Configuration** (via the C-ABI struct, each with env/default fallback when empty/0):
-  `port`, `certificate_path`, `private_key_path`, `io_threads`, `http_worker_threads`.
-  Environment overrides: `WAZUH_REMOTED_HTTPS_{ADDRESS,PORT,IO_THREADS,WORKER_THREADS,
-  MAX_BODY_SIZE,CERTIFICATE,PRIVATE_KEY}`.
+- **Configuration** (via the C-ABI struct, each field falling back to a built-in default when
+  <=0/empty): `port`, `certificate_path`, `private_key_path`, `io_threads`, `http_worker_threads`,
+  `http_max_body_size`, `http_read_timeout`, `http_write_timeout`, `http_request_timeout`,
+  `http_max_url_size`, `http_max_header_name_size`, `http_max_header_value_size`,
+  `http_max_header_count`, `http_max_pipelined_requests`, `http_concurrent_accepts`,
+  `http_buffer_size`. `remoted` populates the RESTinio tuning fields (`io_threads`,
+  `http_worker_threads`, the timeouts, and the header/URL/pipelining/accept/buffer limits) from the
+  `remoted.http_*` internal options in `secure.c`. `port`, `http_max_body_size` and the two paths are
+  regular `<remote>` settings instead (not wired yet -- built-in defaults apply) -- see
+  [HTTPS Events API](../../../docs/ref/modules/remoted/https-events-api.md#configuration).
 - **Restart-friendly bind:** the RESTinio acceptor sets `SO_REUSEADDR`
   (`acceptor_options_setter`), so a manager restart rebinds the port immediately instead of
   failing with `EADDRINUSE` while the previous socket lingers in `TIME_WAIT`.

--- a/src/remoted/remoted_module/include/remoted_module.h
+++ b/src/remoted/remoted_module/include/remoted_module.h
@@ -47,16 +47,41 @@ extern "C"
      */
     typedef struct remoted_module_config_t
     {
-        int worker_threads;         ///< Number of worker threads the module should run.
-        int queue_size;             ///< Input queue capacity.
-        int port;                   ///< HTTPS listening port (<=0 -> module default/env).
-        bool worker_node;           ///< true if this manager is a cluster worker node.
-        char cluster_name[256];     ///< Cluster name.
-        char node_name[256];        ///< Cluster node name.
-        char certificate_path[512]; ///< TLS certificate chain (PEM) path (empty -> default/env).
-        char private_key_path[512]; ///< TLS private key (PEM) path (empty -> default/env).
-        int io_threads;             ///< HTTPS I/O threads (<=0 -> module default/env).
-        int http_worker_threads;    ///< HTTPS handler worker-pool size (<=0 -> worker_threads/default/env).
+        int worker_threads;              ///< Number of worker threads the module should run.
+        int queue_size;                  ///< Input queue capacity.
+        int port;                        ///< HTTPS listening port. Regular <remote> setting (wazuh-manager.conf),
+                                         ///< not an internal option. <=0 -> module default.
+        bool worker_node;                ///< true if this manager is a cluster worker node.
+        char cluster_name[256];          ///< Cluster name.
+        char node_name[256];             ///< Cluster node name.
+        char certificate_path[512];      ///< TLS certificate chain (PEM) path (empty -> module default).
+        char private_key_path[512];      ///< TLS private key (PEM) path (empty -> module default).
+        int io_threads;                  ///< HTTPS I/O threads. <=0 -> module default (see remoted.http_io_threads).
+        int http_worker_threads;         ///< HTTPS handler worker-pool size. <=0 -> module default
+                                         ///< (see remoted.http_worker_threads).
+        int http_max_body_size;          ///< Transport body cap, bytes. Regular <remote> setting
+                                         ///< (wazuh-manager.conf), not an internal option. <=0 -> module default.
+        int http_read_timeout;           ///< Seconds to wait for a full request on a connection (also covers
+                                         ///< the TLS handshake window). <=0 -> module default
+                                         ///< (see remoted.http_read_timeout).
+        int http_write_timeout;          ///< Seconds to wait for a response write to complete. <=0 -> module
+                                         ///< default (see remoted.http_write_timeout).
+        int http_request_timeout;        ///< Seconds a request may take to be handled end-to-end. <=0 ->
+                                         ///< module default (see remoted.http_request_timeout).
+        int http_max_url_size;           ///< Max URL size, bytes. <=0 -> module default
+                                         ///< (see remoted.http_max_url_size).
+        int http_max_header_name_size;   ///< Max HTTP header name size, bytes. <=0 -> module default
+                                         ///< (see remoted.http_max_header_name_size).
+        int http_max_header_value_size;  ///< Max HTTP header value size, bytes. <=0 -> module default
+                                         ///< (see remoted.http_max_header_value_size).
+        int http_max_header_count;       ///< Max number of HTTP headers per request. <=0 -> module default
+                                         ///< (see remoted.http_max_header_count).
+        int http_max_pipelined_requests; ///< Max in-flight unanswered requests per connection. <=0 ->
+                                         ///< module default (see remoted.http_max_pipelined_requests).
+        int http_concurrent_accepts;     ///< Max concurrent in-progress TCP accepts. <=0 -> module
+                                         ///< default (see remoted.http_concurrent_accepts).
+        int http_buffer_size;            ///< Socket read buffer size, bytes. <=0 -> module default
+                                         ///< (see remoted.http_buffer_size).
     } remoted_module_config_t;
 
     /**

--- a/src/remoted/remoted_module/src/http_server/IHttpServer.hpp
+++ b/src/remoted/remoted_module/src/http_server/IHttpServer.hpp
@@ -117,6 +117,17 @@ namespace remoted::http
         std::size_t ioThreads {2};                     ///< RESTinio/asio I/O threads (accept + read/write).
         std::size_t workerThreads {4};                 ///< Handler worker-pool size (blocking work offload).
         std::size_t maxBodySize {16U * 1024U * 1024U}; ///< Transport hard cap (backstop above the auth body limit).
+        std::size_t readTimeoutSec {10};               ///< Time to receive a full request on a connection (also covers
+                                                       ///< the TLS handshake window).
+        std::size_t writeTimeoutSec {10};              ///< Time allowed to write a response.
+        std::size_t requestTimeoutSec {30};            ///< Time allowed to handle a request end-to-end.
+        std::size_t maxUrlSize {2048};                 ///< Max URL size, bytes.
+        std::size_t maxHeaderNameSize {256};           ///< Max HTTP header name size, bytes.
+        std::size_t maxHeaderValueSize {8192};         ///< Max HTTP header value size, bytes.
+        std::size_t maxHeaderCount {64};               ///< Max number of HTTP headers per request.
+        std::size_t maxPipelinedRequests {4};          ///< Max in-flight unanswered requests per connection.
+        std::size_t concurrentAccepts {2};             ///< Max concurrent in-progress TCP accepts.
+        std::size_t bufferSize {8192};                 ///< Socket read buffer size, bytes.
     };
 
     /**

--- a/src/remoted/remoted_module/src/http_server/RestinioHttpServer.cpp
+++ b/src/remoted/remoted_module/src/http_server/RestinioHttpServer.cpp
@@ -280,18 +280,21 @@ namespace remoted::http
                                      { options.set_option(asio::ip::tcp::acceptor::reuse_address(true)); })
             .request_handler(std::move(requestRouter))
             .tls_context(std::move(tlsContext))
-            .buffer_size(8192)
-            .read_next_http_message_timelimit(std::chrono::seconds {10})
-            .write_http_response_timelimit(std::chrono::seconds {10})
-            .handle_request_timeout(std::chrono::seconds {30})
-            .max_pipelined_requests(4)
-            .concurrent_accepts_count(std::min<std::size_t>(config.ioThreads, 8))
+            .buffer_size(config.bufferSize)
+            // read_next_http_message_timelimit also stands in for a TLS handshake timeout:
+            // it starts counting as soon as the connection is established, before anything
+            // has been read, so it already bounds a stalled/never-completed handshake.
+            .read_next_http_message_timelimit(std::chrono::seconds {config.readTimeoutSec})
+            .write_http_response_timelimit(std::chrono::seconds {config.writeTimeoutSec})
+            .handle_request_timeout(std::chrono::seconds {config.requestTimeoutSec})
+            .max_pipelined_requests(config.maxPipelinedRequests)
+            .concurrent_accepts_count(config.concurrentAccepts)
             .separate_accept_and_create_connect(true)
             .incoming_http_msg_limits(restinio::incoming_http_msg_limits_t {}
-                                          .max_url_size(2048)
-                                          .max_field_name_size(256)
-                                          .max_field_value_size(8192)
-                                          .max_field_count(64)
+                                          .max_url_size(config.maxUrlSize)
+                                          .max_field_name_size(config.maxHeaderNameSize)
+                                          .max_field_value_size(config.maxHeaderValueSize)
+                                          .max_field_count(config.maxHeaderCount)
                                           .max_body_size(config.maxBodySize));
 
         try

--- a/src/remoted/remoted_module/src/http_server/httpServerConfig.cpp
+++ b/src/remoted/remoted_module/src/http_server/httpServerConfig.cpp
@@ -11,11 +11,7 @@
 
 #include "httpServerConfig.hpp"
 
-#include <charconv>
-#include <cstdlib>
-#include <stdexcept>
 #include <string>
-#include <string_view>
 
 namespace
 {
@@ -27,64 +23,27 @@ namespace
     // 10 MiB) so an oversized batch reaches the middleware and gets a clean 413 there, while this
     // still bounds memory as a backstop.
     constexpr std::size_t DEFAULT_MAX_BODY_SIZE {16U * 1024U * 1024U};
+    constexpr std::size_t DEFAULT_READ_TIMEOUT_SEC {10};
+    constexpr std::size_t DEFAULT_WRITE_TIMEOUT_SEC {10};
+    constexpr std::size_t DEFAULT_REQUEST_TIMEOUT_SEC {30};
+    constexpr std::size_t DEFAULT_MAX_URL_SIZE {2048};
+    constexpr std::size_t DEFAULT_MAX_HEADER_NAME_SIZE {256};
+    constexpr std::size_t DEFAULT_MAX_HEADER_VALUE_SIZE {8192};
+    constexpr std::size_t DEFAULT_MAX_HEADER_COUNT {64};
+    constexpr std::size_t DEFAULT_MAX_PIPELINED_REQUESTS {4};
+    constexpr std::size_t DEFAULT_CONCURRENT_ACCEPTS {2};
+    constexpr std::size_t DEFAULT_BUFFER_SIZE {8192};
 
     // These paths are evaluated after remoted has entered its chroot.
     // Host paths: /var/ossec/etc/remoted-https/server.{crt,key}
     constexpr auto DEFAULT_CERTIFICATE_PATH {"/etc/remoted-https/server.crt"};
     constexpr auto DEFAULT_PRIVATE_KEY_PATH {"/etc/remoted-https/server.key"};
 
-    std::string readStringEnvironment(const char* name, std::string defaultValue)
+    // A positive caller value wins; otherwise the built-in default. remoted is expected to
+    // always pass an already-validated value read from the `remoted.http_*` internal options.
+    std::size_t resolveUnsigned(const int configValue, const std::size_t defaultValue)
     {
-        const auto* value = std::getenv(name);
-
-        if (value == nullptr || *value == '\0')
-        {
-            return defaultValue;
-        }
-
-        return value;
-    }
-
-    std::size_t readUnsignedEnvironment(const char* name,
-                                        const std::size_t defaultValue,
-                                        const std::size_t minimum,
-                                        const std::size_t maximum)
-    {
-        const auto* rawValue = std::getenv(name);
-
-        if (rawValue == nullptr || *rawValue == '\0')
-        {
-            return defaultValue;
-        }
-
-        const std::string_view value {rawValue};
-
-        std::size_t parsedValue {};
-        const auto result = std::from_chars(value.data(), value.data() + value.size(), parsedValue);
-
-        if (result.ec != std::errc {} || result.ptr != value.data() + value.size() || parsedValue < minimum ||
-            parsedValue > maximum)
-        {
-            throw std::invalid_argument(std::string {name} + " must be an integer between " + std::to_string(minimum) +
-                                        " and " + std::to_string(maximum));
-        }
-
-        return parsedValue;
-    }
-
-    // Positive C-ABI int wins; otherwise fall back to env (which itself defaults).
-    std::size_t resolveUnsigned(const int configValue,
-                                const char* envName,
-                                const std::size_t defaultValue,
-                                const std::size_t minimum,
-                                const std::size_t maximum)
-    {
-        if (configValue > 0)
-        {
-            return static_cast<std::size_t>(configValue);
-        }
-
-        return readUnsignedEnvironment(envName, defaultValue, minimum, maximum);
+        return configValue > 0 ? static_cast<std::size_t>(configValue) : defaultValue;
     }
 } // namespace
 
@@ -95,31 +54,29 @@ namespace remoted::http
     {
         HttpServerConfig result;
 
-        result.bindAddress = readStringEnvironment("WAZUH_REMOTED_HTTPS_ADDRESS", DEFAULT_BIND_ADDRESS);
+        result.bindAddress = DEFAULT_BIND_ADDRESS;
 
-        result.port = static_cast<std::uint16_t>(
-            resolveUnsigned(config.port, "WAZUH_REMOTED_HTTPS_PORT", DEFAULT_HTTPS_PORT, 1, 65535));
-
-        result.ioThreads =
-            resolveUnsigned(config.io_threads, "WAZUH_REMOTED_HTTPS_IO_THREADS", DEFAULT_IO_THREADS, 1, 64);
-
-        // Worker pool: dedicated field first, then the module's generic worker_threads, then env/default.
-        const int workerHint = config.http_worker_threads > 0 ? config.http_worker_threads : config.worker_threads;
-        result.workerThreads =
-            resolveUnsigned(workerHint, "WAZUH_REMOTED_HTTPS_WORKER_THREADS", DEFAULT_WORKER_THREADS, 1, 256);
-
-        result.maxBodySize =
-            readUnsignedEnvironment("WAZUH_REMOTED_HTTPS_MAX_BODY_SIZE", DEFAULT_MAX_BODY_SIZE, 1, 64U * 1024U * 1024U);
+        result.port = static_cast<std::uint16_t>(resolveUnsigned(config.port, DEFAULT_HTTPS_PORT));
+        result.ioThreads = resolveUnsigned(config.io_threads, DEFAULT_IO_THREADS);
+        result.workerThreads = resolveUnsigned(config.http_worker_threads, DEFAULT_WORKER_THREADS);
+        result.maxBodySize = resolveUnsigned(config.http_max_body_size, DEFAULT_MAX_BODY_SIZE);
+        result.readTimeoutSec = resolveUnsigned(config.http_read_timeout, DEFAULT_READ_TIMEOUT_SEC);
+        result.writeTimeoutSec = resolveUnsigned(config.http_write_timeout, DEFAULT_WRITE_TIMEOUT_SEC);
+        result.requestTimeoutSec = resolveUnsigned(config.http_request_timeout, DEFAULT_REQUEST_TIMEOUT_SEC);
+        result.maxUrlSize = resolveUnsigned(config.http_max_url_size, DEFAULT_MAX_URL_SIZE);
+        result.maxHeaderNameSize = resolveUnsigned(config.http_max_header_name_size, DEFAULT_MAX_HEADER_NAME_SIZE);
+        result.maxHeaderValueSize = resolveUnsigned(config.http_max_header_value_size, DEFAULT_MAX_HEADER_VALUE_SIZE);
+        result.maxHeaderCount = resolveUnsigned(config.http_max_header_count, DEFAULT_MAX_HEADER_COUNT);
+        result.maxPipelinedRequests =
+            resolveUnsigned(config.http_max_pipelined_requests, DEFAULT_MAX_PIPELINED_REQUESTS);
+        result.concurrentAccepts = resolveUnsigned(config.http_concurrent_accepts, DEFAULT_CONCURRENT_ACCEPTS);
+        result.bufferSize = resolveUnsigned(config.http_buffer_size, DEFAULT_BUFFER_SIZE);
 
         result.certificatePath =
-            config.certificate_path[0] != '\0'
-                ? std::string {config.certificate_path}
-                : readStringEnvironment("WAZUH_REMOTED_HTTPS_CERTIFICATE", DEFAULT_CERTIFICATE_PATH);
+            config.certificate_path[0] != '\0' ? std::string {config.certificate_path} : DEFAULT_CERTIFICATE_PATH;
 
         result.privateKeyPath =
-            config.private_key_path[0] != '\0'
-                ? std::string {config.private_key_path}
-                : readStringEnvironment("WAZUH_REMOTED_HTTPS_PRIVATE_KEY", DEFAULT_PRIVATE_KEY_PATH);
+            config.private_key_path[0] != '\0' ? std::string {config.private_key_path} : DEFAULT_PRIVATE_KEY_PATH;
 
         return result;
     }

--- a/src/remoted/remoted_module/src/http_server/httpServerConfig.hpp
+++ b/src/remoted/remoted_module/src/http_server/httpServerConfig.hpp
@@ -21,21 +21,8 @@ namespace remoted::http
     /**
      * @brief Translate the module's C-ABI config into an HttpServerConfig.
      *
-     * Fields left empty/zero by the caller (remoted fills the struct with {0}) fall
-     * back to environment variables and then to built-in defaults, so the server is
-     * usable today without wiring every value from the C side:
-     *   - port          <- config.port  | WAZUH_REMOTED_HTTPS_PORT          | 9443
-     *   - ioThreads     <- config.io_threads | WAZUH_REMOTED_HTTPS_IO_THREADS | 2
-     *   - workerThreads <- config.http_worker_threads | config.worker_threads
-     *                        | WAZUH_REMOTED_HTTPS_WORKER_THREADS | 4
-     *   - certificate   <- config.certificate_path | WAZUH_REMOTED_HTTPS_CERTIFICATE  | default
-     *   - private key   <- config.private_key_path | WAZUH_REMOTED_HTTPS_PRIVATE_KEY  | default
-     *   - bind address  <- WAZUH_REMOTED_HTTPS_ADDRESS | 127.0.0.1
-     *   - max body size <- WAZUH_REMOTED_HTTPS_MAX_BODY_SIZE | 2 MiB
-     *
      * @param config Configuration handed by remoted.
      * @return Resolved HttpServerConfig.
-     * @throws std::invalid_argument if an environment override is not a valid integer in range.
      */
     HttpServerConfig buildHttpServerConfig(const remoted_module_config_t& config);
 

--- a/src/remoted/remoted_module/test/unit/httpServer_test.cpp
+++ b/src/remoted/remoted_module/test/unit/httpServer_test.cpp
@@ -15,7 +15,6 @@
 
 #include <gtest/gtest.h>
 
-#include <cstdlib>
 #include <cstring>
 #include <memory>
 #include <optional>
@@ -48,20 +47,6 @@ namespace
         std::memset(&config, 0, sizeof(config));
         return config;
     }
-
-    void clearHttpEnvironment()
-    {
-        for (const auto* name : {"WAZUH_REMOTED_HTTPS_ADDRESS",
-                                 "WAZUH_REMOTED_HTTPS_PORT",
-                                 "WAZUH_REMOTED_HTTPS_IO_THREADS",
-                                 "WAZUH_REMOTED_HTTPS_WORKER_THREADS",
-                                 "WAZUH_REMOTED_HTTPS_MAX_BODY_SIZE",
-                                 "WAZUH_REMOTED_HTTPS_CERTIFICATE",
-                                 "WAZUH_REMOTED_HTTPS_PRIVATE_KEY"})
-        {
-            unsetenv(name);
-        }
-    }
 } // namespace
 
 // ---------------------------------------------------------------------------
@@ -70,26 +55,44 @@ namespace
 
 TEST(HttpServerConfigTest, DefaultsWhenEmpty)
 {
-    clearHttpEnvironment();
-
     const auto config = buildHttpServerConfig(zeroedConfig());
 
     EXPECT_EQ(config.bindAddress, "127.0.0.1");
     EXPECT_EQ(config.port, 9443);
     EXPECT_EQ(config.ioThreads, 2U);
     EXPECT_EQ(config.workerThreads, 4U);
+    EXPECT_EQ(config.maxBodySize, 16U * 1024U * 1024U);
+    EXPECT_EQ(config.readTimeoutSec, 10U);
+    EXPECT_EQ(config.writeTimeoutSec, 10U);
+    EXPECT_EQ(config.requestTimeoutSec, 30U);
+    EXPECT_EQ(config.maxUrlSize, 2048U);
+    EXPECT_EQ(config.maxHeaderNameSize, 256U);
+    EXPECT_EQ(config.maxHeaderValueSize, 8192U);
+    EXPECT_EQ(config.maxHeaderCount, 64U);
+    EXPECT_EQ(config.maxPipelinedRequests, 4U);
+    EXPECT_EQ(config.concurrentAccepts, 2U);
+    EXPECT_EQ(config.bufferSize, 8192U);
     EXPECT_EQ(config.certificatePath, "/etc/remoted-https/server.crt");
     EXPECT_EQ(config.privateKeyPath, "/etc/remoted-https/server.key");
 }
 
 TEST(HttpServerConfigTest, StructValuesWin)
 {
-    clearHttpEnvironment();
-
     auto raw = zeroedConfig();
     raw.port = 12345;
     raw.io_threads = 3;
     raw.http_worker_threads = 7;
+    raw.http_max_body_size = 1048576;
+    raw.http_read_timeout = 20;
+    raw.http_write_timeout = 15;
+    raw.http_request_timeout = 45;
+    raw.http_max_url_size = 4096;
+    raw.http_max_header_name_size = 512;
+    raw.http_max_header_value_size = 16384;
+    raw.http_max_header_count = 128;
+    raw.http_max_pipelined_requests = 8;
+    raw.http_concurrent_accepts = 4;
+    raw.http_buffer_size = 16384;
     std::snprintf(raw.certificate_path, sizeof(raw.certificate_path), "/custom/cert.pem");
     std::snprintf(raw.private_key_path, sizeof(raw.private_key_path), "/custom/key.pem");
 
@@ -98,19 +101,37 @@ TEST(HttpServerConfigTest, StructValuesWin)
     EXPECT_EQ(config.port, 12345);
     EXPECT_EQ(config.ioThreads, 3U);
     EXPECT_EQ(config.workerThreads, 7U);
+    EXPECT_EQ(config.maxBodySize, 1048576U);
+    EXPECT_EQ(config.readTimeoutSec, 20U);
+    EXPECT_EQ(config.writeTimeoutSec, 15U);
+    EXPECT_EQ(config.requestTimeoutSec, 45U);
+    EXPECT_EQ(config.maxUrlSize, 4096U);
+    EXPECT_EQ(config.maxHeaderNameSize, 512U);
+    EXPECT_EQ(config.maxHeaderValueSize, 16384U);
+    EXPECT_EQ(config.maxHeaderCount, 128U);
+    EXPECT_EQ(config.maxPipelinedRequests, 8U);
+    EXPECT_EQ(config.concurrentAccepts, 4U);
+    EXPECT_EQ(config.bufferSize, 16384U);
     EXPECT_EQ(config.certificatePath, "/custom/cert.pem");
     EXPECT_EQ(config.privateKeyPath, "/custom/key.pem");
 }
 
-TEST(HttpServerConfigTest, WorkerThreadsFallBackToGenericWorkerThreads)
+// Negative values can't come from remoted (getDefine_Int_default's own min bound
+// keeps them out), but buildHttpServerConfig() only trusts "positive", so a
+// leftover/garbage negative must fall back to the default like 0 does, not
+// underflow when cast to the unsigned HttpServerConfig fields.
+TEST(HttpServerConfigTest, NegativeValuesFallBackToDefaults)
 {
-    clearHttpEnvironment();
-
     auto raw = zeroedConfig();
-    raw.worker_threads = 9;      // generic
-    raw.http_worker_threads = 0; // not set -> use generic
+    raw.port = -1;
+    raw.io_threads = -5;
+    raw.http_max_url_size = -2048;
 
-    EXPECT_EQ(buildHttpServerConfig(raw).workerThreads, 9U);
+    const auto config = buildHttpServerConfig(raw);
+
+    EXPECT_EQ(config.port, 9443);
+    EXPECT_EQ(config.ioThreads, 2U);
+    EXPECT_EQ(config.maxUrlSize, 2048U);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/remoted/src/secure.c
+++ b/src/remoted/src/secure.c
@@ -75,6 +75,9 @@ STATIC void handle_incoming_data_from_tcp_socket(int sock_client);
 STATIC void handle_incoming_data_from_udp_socket(struct sockaddr_storage * peer_info);
 STATIC void handle_new_tcp_connection(wnotify_t * notify, struct sockaddr_storage * peer_info);
 
+// Read the remoted.http_* internal options into the C++ module's config struct
+STATIC void remoted_module_https_config(remoted_module_config_t *rm_config);
+
 // Headers for messages
 #define UPGRADE_ACK_HEADER "u:upgrade_module:"
 #define UPGRADE_ACK_HEADER_SIZE 17
@@ -205,6 +208,25 @@ typedef struct {
     w_rr_queue_t      *events_queue;      // round robbin event ring
 } rem_handler_args_t;
 
+/**
+ * @brief Read the HTTPS agent server's advanced settings (`remoted.http_*` internal
+ *        options) into the config struct passed to remoted_module_start().
+ */
+STATIC void remoted_module_https_config(remoted_module_config_t *rm_config) {
+    rm_config->io_threads = getDefine_Int_default("remoted", "http_io_threads", 1, 64, 2);
+    rm_config->http_worker_threads = getDefine_Int_default("remoted", "http_worker_threads", 1, 256, 4);
+    rm_config->http_read_timeout = getDefine_Int_default("remoted", "http_read_timeout", 1, 300, 10);
+    rm_config->http_write_timeout = getDefine_Int_default("remoted", "http_write_timeout", 1, 300, 10);
+    rm_config->http_request_timeout = getDefine_Int_default("remoted", "http_request_timeout", 1, 600, 30);
+    rm_config->http_max_url_size = getDefine_Int_default("remoted", "http_max_url_size", 1, 65536, 2048);
+    rm_config->http_max_header_name_size = getDefine_Int_default("remoted", "http_max_header_name_size", 1, 8192, 256);
+    rm_config->http_max_header_value_size = getDefine_Int_default("remoted", "http_max_header_value_size", 1, 65536, 8192);
+    rm_config->http_max_header_count = getDefine_Int_default("remoted", "http_max_header_count", 1, 1024, 64);
+    rm_config->http_max_pipelined_requests = getDefine_Int_default("remoted", "http_max_pipelined_requests", 1, 64, 4);
+    rm_config->http_concurrent_accepts = getDefine_Int_default("remoted", "http_concurrent_accepts", 1, 64, 2);
+    rm_config->http_buffer_size = getDefine_Int_default("remoted", "http_buffer_size", 1, 1048576, 8192);
+}
+
 /* Handle secure connections */
 void HandleSecure()
 {
@@ -299,9 +321,9 @@ void HandleSecure()
         remoted_module_config_t rm_config = {0};
         rm_config.worker_threads = worker_pool;
         rm_config.queue_size = (int)logr.queue_size;
-        // rm_config.port is the HTTPS listening port, unrelated to logr.port (remoted's
-        // own classic TCP/UDP port, already bound by the time we get here). Left at 0
-        // so the module falls back to WAZUH_REMOTED_HTTPS_PORT/its own default.
+        // rm_config.port is the HTTPS listening port -- unrelated to logr.port (remoted's
+        // own classic TCP/UDP port, already bound by the time we get here).
+        remoted_module_https_config(&rm_config);
         rm_config.worker_node = logr.worker_node;
 
         char *rm_cluster_name = get_cluster_name();

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -3479,6 +3479,91 @@ void test_handle_outgoing_data_to_tcp_socket_success(void** state)
     handle_outgoing_data_to_tcp_socket(sock_client);
 }
 
+// Tests remoted_module_https_config
+//
+// getDefine_Int_default() is wrapped as a plain FIFO mock (see
+// validate_op_wrappers.c), so these tests only verify that each internal option's
+// value lands in the right remoted_module_config_t field, in the fixed call order
+// remoted_module_https_config() uses. The "invalid value -> process exits" behavior
+// itself lives entirely in the real (unwrapped) getDefine_Int_default()/
+// parse_define_int_value() and is not reachable through this mock.
+
+void test_remoted_module_https_config_defaults(void** state)
+{
+    (void) state;
+    remoted_module_config_t rm_config = {0};
+
+    will_return(__wrap_getDefine_Int_default, 2);
+    will_return(__wrap_getDefine_Int_default, 4);
+    will_return(__wrap_getDefine_Int_default, 10);
+    will_return(__wrap_getDefine_Int_default, 10);
+    will_return(__wrap_getDefine_Int_default, 30);
+    will_return(__wrap_getDefine_Int_default, 2048);
+    will_return(__wrap_getDefine_Int_default, 256);
+    will_return(__wrap_getDefine_Int_default, 8192);
+    will_return(__wrap_getDefine_Int_default, 64);
+    will_return(__wrap_getDefine_Int_default, 4);
+    will_return(__wrap_getDefine_Int_default, 2);
+    will_return(__wrap_getDefine_Int_default, 8192);
+
+    remoted_module_https_config(&rm_config);
+
+    // port and http_max_body_size are not read here -- they come from
+    // wazuh-manager.conf (<remote>), not internal options; untouched means 0.
+    assert_int_equal(rm_config.port, 0);
+    assert_int_equal(rm_config.io_threads, 2);
+    assert_int_equal(rm_config.http_worker_threads, 4);
+    assert_int_equal(rm_config.http_max_body_size, 0);
+    assert_int_equal(rm_config.http_read_timeout, 10);
+    assert_int_equal(rm_config.http_write_timeout, 10);
+    assert_int_equal(rm_config.http_request_timeout, 30);
+    assert_int_equal(rm_config.http_max_url_size, 2048);
+    assert_int_equal(rm_config.http_max_header_name_size, 256);
+    assert_int_equal(rm_config.http_max_header_value_size, 8192);
+    assert_int_equal(rm_config.http_max_header_count, 64);
+    assert_int_equal(rm_config.http_max_pipelined_requests, 4);
+    assert_int_equal(rm_config.http_concurrent_accepts, 2);
+    assert_int_equal(rm_config.http_buffer_size, 8192);
+}
+
+void test_remoted_module_https_config_custom_values(void** state)
+{
+    (void) state;
+    remoted_module_config_t rm_config = {0};
+
+    will_return(__wrap_getDefine_Int_default, 8);
+    will_return(__wrap_getDefine_Int_default, 16);
+    will_return(__wrap_getDefine_Int_default, 20);
+    will_return(__wrap_getDefine_Int_default, 15);
+    will_return(__wrap_getDefine_Int_default, 60);
+    will_return(__wrap_getDefine_Int_default, 4096);
+    will_return(__wrap_getDefine_Int_default, 512);
+    will_return(__wrap_getDefine_Int_default, 16384);
+    will_return(__wrap_getDefine_Int_default, 128);
+    will_return(__wrap_getDefine_Int_default, 8);
+    will_return(__wrap_getDefine_Int_default, 4);
+    will_return(__wrap_getDefine_Int_default, 16384);
+
+    remoted_module_https_config(&rm_config);
+
+    // port and http_max_body_size are not read here -- they come from
+    // wazuh-manager.conf (<remote>), not internal options; untouched means 0.
+    assert_int_equal(rm_config.port, 0);
+    assert_int_equal(rm_config.io_threads, 8);
+    assert_int_equal(rm_config.http_worker_threads, 16);
+    assert_int_equal(rm_config.http_max_body_size, 0);
+    assert_int_equal(rm_config.http_read_timeout, 20);
+    assert_int_equal(rm_config.http_write_timeout, 15);
+    assert_int_equal(rm_config.http_request_timeout, 60);
+    assert_int_equal(rm_config.http_max_url_size, 4096);
+    assert_int_equal(rm_config.http_max_header_name_size, 512);
+    assert_int_equal(rm_config.http_max_header_value_size, 16384);
+    assert_int_equal(rm_config.http_max_header_count, 128);
+    assert_int_equal(rm_config.http_max_pipelined_requests, 8);
+    assert_int_equal(rm_config.http_concurrent_accepts, 4);
+    assert_int_equal(rm_config.http_buffer_size, 16384);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -3542,6 +3627,9 @@ int main(void)
         // Tests handle_outgoing_data_to_tcp_socket
         cmocka_unit_test(test_handle_outgoing_data_to_tcp_socket_case_1_EAGAIN),
         cmocka_unit_test(test_handle_outgoing_data_to_tcp_socket_case_1_EPIPE),
-        cmocka_unit_test(test_handle_outgoing_data_to_tcp_socket_success)};
+        cmocka_unit_test(test_handle_outgoing_data_to_tcp_socket_success),
+        // Tests remoted_module_https_config
+        cmocka_unit_test(test_remoted_module_https_config_defaults),
+        cmocka_unit_test(test_remoted_module_https_config_custom_values)};
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
## Description

The HTTPS agent server introduced in #37821 (`remoted_module`) currently uses hardcoded
defaults and environment variables (`WAZUH_REMOTED_HTTPS_*`) for its RESTinio settings. There is
no way to tune I/O threads, worker threads, timeouts, or transport limits without recompiling.

This PR exposes the relevant advanced RESTinio settings through
`etc/wazuh-manager-internal-options.conf`, following the exact mechanism every other Wazuh
daemon already uses for advanced tuning (`getDefine_Int_default()`), and removes the
environment-variable configuration path entirely.

Closes #37925.

## Proposed Changes

- Added 12 new `remoted.http_*` internal options for the HTTPS agent server, read in
  `remoted/src/secure.c` and passed to `remoted_module` through its existing C-ABI struct
  (`remoted_module_config_t`):
  - `remoted.http_io_threads` — I/O threads (accept + read/write). Default `2`, range `[1..64]`.
  - `remoted.http_worker_threads` — endpoint-handler worker pool size. Default `4`, range `[1..256]`.
  - `remoted.http_read_timeout` — seconds to receive a full request on a connection; also stands
    in for a TLS handshake timeout (the clock starts as soon as the connection opens, before the
    handshake completes — RESTinio has no dedicated handshake timeout). Default `10`, range `[1..300]`.
  - `remoted.http_write_timeout` — seconds to write a response. Default `10`, range `[1..300]`.
  - `remoted.http_request_timeout` — seconds to handle a request end-to-end. Default `30`, range `[1..600]`.
  - `remoted.http_max_url_size` — max URL size, bytes. Default `2048`, range `[1..65536]`.
  - `remoted.http_max_header_name_size` — max HTTP header name size, bytes. Default `256`, range `[1..8192]`.
  - `remoted.http_max_header_value_size` — max HTTP header value size, bytes. Default `8192`, range `[1..65536]`.
  - `remoted.http_max_header_count` — max HTTP headers per request. Default `64`, range `[1..1024]`.
  - `remoted.http_max_pipelined_requests` — max in-flight unanswered requests per connection
    (HTTP pipelining depth). Default `4`, range `[1..64]`.
  - `remoted.http_concurrent_accepts` — max concurrent in-progress TCP accepts. Default `2`, range `[1..64]`.
  - `remoted.http_buffer_size` — socket read buffer size, bytes. Default `8192`, range `[1..1048576]`.
- Validation is delegated entirely to `getDefine_Int_default()`: an option absent from the file
  falls back to its built-in default; an option present but out of range or non-numeric makes
  `remoted` exit at startup with a clear error, exactly like every other internal option in the
  codebase (`validate_op.c`'s `parse_define_int_value()`/`merror_exit()`) — no custom validation
  logic was added.
- Removed all `WAZUH_REMOTED_HTTPS_{ADDRESS,PORT,IO_THREADS,WORKER_THREADS,MAX_BODY_SIZE,
  CERTIFICATE,PRIVATE_KEY}` environment-variable overrides from `httpServerConfig.cpp`. This is a
  **breaking change** for anyone currently configuring the HTTPS server via these env vars.
- `remoted_module_config_t` (the C-ABI struct shared between `remoted` and `remoted_module`) grew
  9 new `int` fields for the settings above (`io_threads` and `http_worker_threads` already
  existed and are now populated from internal options too).
- `RestinioHttpServer.cpp` no longer hardcodes `buffer_size`, `read_next_http_message_timelimit`,
  `write_http_response_timelimit`, `handle_request_timeout`, `max_pipelined_requests`,
  `concurrent_accepts_count`, or the `incoming_http_msg_limits` group — all now come from the
  resolved `HttpServerConfig`.
- **Deliberately excluded from internal options** (left as before — C-ABI struct value or
  built-in default, `<=0`/empty falls back): bind address, listening port, and transport max body
  size. These are regular, user-facing `<remote>` settings (`wazuh-manager.conf`), not advanced
  tuning, and belong there once that XML wiring is added (tracked separately, not in scope here).
  The certificate/private key paths stay the same way for a different reason: there is no
  string-valued internal-option mechanism in this codebase (`getDefine_Int`/`getDefine_Int_default`
  are integer-only).

### Results and Evidence

### Install
```
- System is Debian (Ubuntu or derivative).
 - Init script modified to start Wazuh during boot.
Starting Wazuh...
manager
Starting Wazuh v5.0.0...
Started wazuh-manager-apid...
Started wazuh-manager-authd...
Started wazuh-manager-db...
Started wazuh-manager-analysisd...
Started wazuh-manager-remoted...
Started wazuh-manager-monitord...
Started wazuh-manager-modulesd...
Started wazuh-manager-clusterd...
Completed.

 - Configuration finished properly.

 - To start Wazuh:
      /var/wazuh-manager/bin/wazuh-manager-control start

 - To stop Wazuh:
      /var/wazuh-manager/bin/wazuh-manager-control stop

 - The configuration can be viewed or modified at /var/wazuh-manager/etc/wazuh-manager.conf


 - In order to connect agent and manager, you need to add each agent to the manager.

   More information at:
   https://documentation.wazuh.com/
```

### Default options (port 0 because the block in wazuh-manager.conf is not implemented. This variable take the default value got in remoted-http module)

```
2026/07/23 20:05:10 wazuh-manager-remoted:communication: INFO: Starting remoted module (workerThreads=4, queueSize=131072, port=0, cluster='wazuh', node='node01', workerNode=false).
2026/07/23 20:05:10 wazuh-manager-remoted:communication: INFO: remoted module worker thread running.
2026/07/23 20:05:10 wazuh-manager-remoted: INFO: Started (pid: 220633). Listening on port 1514/TCP (secure).
2026/07/23 20:05:10 wazuh-manager-monitord: INFO: Started (pid: 220654).
2026/07/23 20:05:10 wazuh-manager-remoted:communication: WARNING: remoted HTTP server not started yet, will retry: use_certificate_chain_file: No such file or directory
```

### Start succeful when the certificates are setting

```
2026/07/23 20:09:10 wazuh-manager-remoted:http-server: INFO: HTTP server listening on https://127.0.0.1:9443 (2 I/O thread(s), 4 worker thread(s), max body 16777216 bytes).
2026/07/23 20:09:10 wazuh-manager-remoted:communication: INFO: remoted HTTP server started.
```

### Change some internal option. The log shows this change

```
╭─root@89ebd703d7af /var/wazuh-manager/etc/remoted-https
╰─# cat /var/wazuh-manager/etc/wazuh-manager-internal-options.conf | grep remoted
remoted.http_worker_threads=8

2026/07/23 20:12:27 wazuh-manager-remoted:http-server: INFO: HTTP server listening on https://127.0.0.1:9443 (2 I/O thread(s), 8 worker thread(s), max body 16777216 bytes).
2026/07/23 20:12:27 wazuh-manager-remoted:communication: INFO: remoted HTTP server started.
```

### Bad option provocates tha remoted stopping
```
╭─root@89ebd703d7af /var/wazuh-manager/etc/remoted-https
╰─# cat /var/wazuh-manager/etc/wazuh-manager-internal-options.conf | grep remoted                                          1 ↵
remoted.http_worker_threads=8
remoted.http_io_threads=9999
╭─root@89ebd703d7af /var/wazuh-manager/etc/remoted-https
╰─# service wazuh-manager status
wazuh-manager-clusterd is running...
wazuh-manager-modulesd is running...
wazuh-manager-monitord is running...
wazuh-manager-remoted not running...
wazuh-manager-analysisd is running...
wazuh-manager-db is running...
wazuh-manager-authd is running...
wazuh-manager-apid is running...
```

### This confirms that the override works: a target of ~300 bytes with the default (2048) should have passed with 200, but here the connection was cut off, exactly the expected behavior when the actual limit is 64.

```
╭─root@89ebd703d7af /workspaces/devContainer
╰─# cat /var/wazuh-manager/etc/wazuh-manager-internal-options.conf | grep remoted                                        130 ↵
remoted.http_max_url_size=64
╭─root@89ebd703d7af /workspaces/devContainer
╰─# python3 - <<'EOF'
import requests, sys
sys.path.insert(0, "wazuh/src/remoted/remoted_module/tools")
from send_stateless import sign_request, read_agent_key
import time

agent_id = "1001"
key = read_agent_key(agent_id, "/var/wazuh-manager/etc/client.keys")
target = "/stateless?pad=" + "a" * 300
body = b""
ts = int(time.time())
mac = sign_request(key, "1", "POST", target, agent_id, ts, body)
headers = {"protocol-version": "1", "Authorization": f"Wazuh {agent_id}:{ts}:{mac}"}
try:
    r = requests.post("https://127.0.0.1:9443" + target, data=body, headers=headers, verify=False, timeout=5)
    print("status:", r.status_code, r.text)
except requests.exceptions.RequestException as e:
    print("connection dropped:", e)
EOF

connection dropped: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
```
 
```
╭─root@89ebd703d7af /workspaces/devContainer
╰─# cat /var/wazuh-manager/etc/wazuh-manager-internal-options.conf | grep remoted
remoted.http_max_url_size=2048
╭─root@89ebd703d7af /workspaces/devContainer
╰─# python3 - <<'EOF'
import requests, sys
sys.path.insert(0, "wazuh/src/remoted/remoted_module/tools")
from send_stateless import sign_request, read_agent_key
import time

agent_id = "1001"
key = read_agent_key(agent_id, "/var/wazuh-manager/etc/client.keys")
target = "/stateless?pad=" + "a" * 300
body = b""
ts = int(time.time())
mac = sign_request(key, "1", "POST", target, agent_id, ts, body)
headers = {"protocol-version": "1", "Authorization": f"Wazuh {agent_id}:{ts}:{mac}"}
try:
    r = requests.post("https://127.0.0.1:9443" + target, data=body, headers=headers, verify=False, timeout=5)
    print("status:", r.status_code, r.text)
except requests.exceptions.RequestException as e:
    print("connection dropped:", e)
EOF

status: 200
```



### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
