### PR TITLE
Keep the sync queue in memory and persist only on shutdown

### DIFF
--- a/.github/actions/check_files/deb_linux_agent_amd64.csv
+++ b/.github/actions/check_files/deb_linux_agent_amd64.csv
@@ -9,7 +9,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/bin/wazuh-agentd,root,root,750,file,-rwxr-x---,661568,0.1
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12374168,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,505104,0.1
-/var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,241184,0.1
+/var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,257720,0.1
 /var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,1153344,0.1
 /var/ossec/lib/libschema_validator.so,root,wazuh,750,file,-rwxr-x---,390232,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2603392,0.1

--- a/.github/actions/check_files/deb_linux_agent_amd64.csv
+++ b/.github/actions/check_files/deb_linux_agent_amd64.csv
@@ -9,7 +9,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/bin/wazuh-agentd,root,root,750,file,-rwxr-x---,661568,0.1
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12374168,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,505104,0.1
-/var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,218488,0.1
+/var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,257720,0.1
 /var/ossec/lib/libschema_validator.so,root,wazuh,750,file,-rwxr-x---,390232,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2603392,0.1
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,253344,0.1

--- a/.github/actions/check_files/deb_linux_agent_amd64.csv
+++ b/.github/actions/check_files/deb_linux_agent_amd64.csv
@@ -9,7 +9,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/bin/wazuh-agentd,root,root,750,file,-rwxr-x---,661568,0.1
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12374168,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,505104,0.1
-/var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,257720,0.1
+/var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,315064,0.1
 /var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,1153344,0.1
 /var/ossec/lib/libschema_validator.so,root,wazuh,750,file,-rwxr-x---,390232,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2603392,0.1

--- a/.github/actions/check_files/rpm_linux_agent_amd64.csv
+++ b/.github/actions/check_files/rpm_linux_agent_amd64.csv
@@ -73,7 +73,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/bin/wazuh-agentd,root,root,750,file,-rwxr-x---,624632,0.1
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12417720,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,484376,0.1
-/var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,220736,0.1
+/var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,249528,0.1
 /var/ossec/lib/libschema_validator.so,root,wazuh,750,file,-rwxr-x---,386024,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2555328,0.1
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,224672,0.1

--- a/.github/actions/check_files/rpm_linux_agent_amd64.csv
+++ b/.github/actions/check_files/rpm_linux_agent_amd64.csv
@@ -73,7 +73,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/bin/wazuh-agentd,root,root,750,file,-rwxr-x---,624632,0.1
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12417720,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,484376,0.1
-/var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,249528,0.1
+/var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,306872,0.1
 /var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,1132872,0.1
 /var/ossec/lib/libschema_validator.so,root,wazuh,750,file,-rwxr-x---,386024,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2555328,0.1

--- a/.github/actions/check_files/rpm_linux_agent_amd64.csv
+++ b/.github/actions/check_files/rpm_linux_agent_amd64.csv
@@ -73,7 +73,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/bin/wazuh-agentd,root,root,750,file,-rwxr-x---,624632,0.1
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12417720,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,484376,0.1
-/var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,249336,0.1
+/var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,249528,0.1
 /var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,1132872,0.1
 /var/ossec/lib/libschema_validator.so,root,wazuh,750,file,-rwxr-x---,386024,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2555328,0.1

--- a/src/shared_modules/sync_protocol/CMakeLists.txt
+++ b/src/shared_modules/sync_protocol/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(
   src/agent_sync_protocol.cpp
   src/persistent_queue.cpp
   src/persistent_queue_storage.cpp
+  src/in_memory_queue_storage.cpp
   ${GENERATED_HEADER}
   src/agent_sync_protocol_c_interface.cpp
   src/sync_socket_transport.cpp

--- a/src/shared_modules/sync_protocol/CMakeLists.txt
+++ b/src/shared_modules/sync_protocol/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(
   src/agent_sync_protocol.cpp
   src/persistent_queue.cpp
   src/persistent_queue_storage.cpp
+  src/in_memory_queue_storage.cpp
   ${GENERATED_HEADER}
   src/agent_sync_protocol_c_interface.cpp
   src/mqueue_transport.cpp

--- a/src/shared_modules/sync_protocol/src/in_memory_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/src/in_memory_queue_storage.cpp
@@ -11,6 +11,34 @@
 #include "persistent_queue_storage.hpp"
 #include "filesystem_wrapper.hpp"
 
+#include <chrono>
+#include <thread>
+
+namespace
+{
+    // Mirrors PersistentQueueStorage's own byte-budget constants exactly, so the two
+    // backends behave identically from AgentSyncProtocol's point of view.
+    constexpr size_t SYNC_BLOCK_ESTIMATED_OVERHEAD_BYTES = 8U * 1024U;
+    constexpr size_t SYNC_ITEM_ESTIMATED_OVERHEAD_BYTES = 512U;
+    constexpr unsigned int MAX_OVERSIZED_ATTEMPTS = 5U;
+
+    /// @brief Maximum number of distinct (never-seen-before) ids this queue will hold at
+    ///        once. Bounds RSS growth if the sync peer is unreachable for an extended
+    ///        period: once full, a brand-new id is rejected (logged, not silently dropped)
+    ///        rather than evicting already-queued state. This value is a starting point,
+    ///        not an authoritative figure -- there is no official sizing guidance for this
+    ///        queue, so it should be revisited against real operational data.
+    constexpr size_t MAX_QUEUE_ROWS = 10000U;
+
+    size_t estimateSerializedItemBytes(const PersistedData& data)
+    {
+        return data.id.size()
+               + data.index.size()
+               + data.data.size()
+               + SYNC_ITEM_ESTIMATED_OVERHEAD_BYTES;
+    }
+} // namespace
+
 InMemoryQueueStorage::InMemoryQueueStorage(const std::string& dbPath, LoggerFunc logger, std::shared_ptr<IFileSystemWrapper> fileSystemWrapper)
     : m_dbPath(dbPath),
       m_logger(std::move(logger)),
@@ -78,15 +106,58 @@ void InMemoryQueueStorage::saveToDisk()
         return;
     }
 
-    PersistentQueueStorage snapshot(m_dbPath, m_logger, m_fileSystemWrapper);
-    snapshot.saveAll(std::vector<QueueRow>(m_rows.begin(), m_rows.end()));
+    // This is the ONLY point where the entire in-memory backlog gets persisted -- a single
+    // failed write here loses everything accumulated since the last graceful shutdown. A
+    // short bounded retry covers transient failures (e.g. a momentary I/O hiccup) without
+    // reintroducing continuous disk writes; a persistent failure (disk full, read-only
+    // mount) still surfaces to the caller after the last attempt, as before.
+    constexpr int MAX_SAVE_ATTEMPTS = 3;
+    constexpr std::chrono::milliseconds RETRY_DELAY{100};
+
+    for (int attempt = 1; attempt <= MAX_SAVE_ATTEMPTS; ++attempt)
+    {
+        try
+        {
+            PersistentQueueStorage snapshot(m_dbPath, m_logger, m_fileSystemWrapper);
+            snapshot.saveAll(std::vector<QueueRow>(m_rows.begin(), m_rows.end()));
+            return;
+        }
+        catch (const std::exception& ex)
+        {
+            if (attempt == MAX_SAVE_ATTEMPTS)
+            {
+                throw;
+            }
+
+            m_logger(LOG_WARNING,
+                     "InMemoryQueueStorage: Attempt " + std::to_string(attempt) + "/" +
+                     std::to_string(MAX_SAVE_ATTEMPTS) +
+                     " to save the shutdown snapshot failed, retrying: " + ex.what());
+            std::this_thread::sleep_for(RETRY_DELAY);
+        }
+    }
 }
 
 void InMemoryQueueStorage::addRow(QueueRow row)
 {
     row.rowId = m_nextRowId++;
+
+    // Capture the id before the move below invalidates row's own copy.
+    const std::string id = row.data.id;
     m_rows.push_back(std::move(row));
-    m_index[m_rows.back().data.id] = std::prev(m_rows.end());
+
+    try
+    {
+        m_index[id] = std::prev(m_rows.end());
+    }
+    catch (...)
+    {
+        // The index insert failed (e.g. bad_alloc growing the hash table) after the row
+        // was already appended -- roll back the append so m_rows and m_index cannot
+        // desync into a state where the same id could be inserted twice.
+        m_rows.pop_back();
+        throw;
+    }
 }
 
 void InMemoryQueueStorage::applyCoalesceLogic(const PersistedData& newData)
@@ -95,6 +166,15 @@ void InMemoryQueueStorage::applyCoalesceLogic(const PersistedData& newData)
 
     if (it == m_index.end())
     {
+        if (m_rows.size() >= MAX_QUEUE_ROWS)
+        {
+            m_logger(LOG_ERROR,
+                     "InMemoryQueueStorage: Queue is at capacity (" + std::to_string(MAX_QUEUE_ROWS) +
+                     " rows); rejecting new item id=" + newData.id +
+                     ". The sync peer may be unreachable for an extended period.");
+            return;
+        }
+
         QueueRow row;
         row.data = newData;
         row.syncStatus = SyncStatus::PENDING;
@@ -119,39 +199,32 @@ void InMemoryQueueStorage::applyCoalesceLogic(const PersistedData& newData)
 
     const SyncStatus newSyncStatus = (oldSyncStatus == SyncStatus::PENDING) ? SyncStatus::PENDING : SyncStatus::SYNCING_UPDATED;
 
+    if (newData.operation == Operation::DELETE_ && oldCreateStatus == CreateStatus::NEW && oldSyncStatus == SyncStatus::PENDING)
+    {
+        m_rows.erase(it->second);
+        m_index.erase(it);
+        return;
+    }
+
+    CreateStatus newCreateStatus = oldCreateStatus;
+
     if (newData.operation == Operation::DELETE_)
     {
-        if (oldCreateStatus == CreateStatus::NEW && oldSyncStatus == SyncStatus::PENDING)
-        {
-            m_rows.erase(it->second);
-            m_index.erase(it);
-            return;
-        }
-
-        const CreateStatus newCreateStatus = (oldCreateStatus == CreateStatus::NEW) ? CreateStatus::NEW_DELETED : oldCreateStatus;
-
-        oldRow.data.index = newData.index;
-        oldRow.data.data = newData.data;
-        oldRow.data.operation = Operation::DELETE_;
-        oldRow.data.version = newData.version;
-        oldRow.data.is_data_context = newData.is_data_context;
-        oldRow.syncStatus = newSyncStatus;
-        oldRow.createStatus = newCreateStatus;
-        oldRow.operationSyncing = newOperationSyncing;
+        newCreateStatus = (oldCreateStatus == CreateStatus::NEW) ? CreateStatus::NEW_DELETED : oldCreateStatus;
     }
-    else
+    else if (oldCreateStatus == CreateStatus::NEW_DELETED)
     {
-        const CreateStatus newCreateStatus = (oldCreateStatus == CreateStatus::NEW_DELETED) ? CreateStatus::NEW : oldCreateStatus;
-
-        oldRow.data.index = newData.index;
-        oldRow.data.data = newData.data;
-        oldRow.data.operation = newData.operation;
-        oldRow.data.version = newData.version;
-        oldRow.data.is_data_context = newData.is_data_context;
-        oldRow.syncStatus = newSyncStatus;
-        oldRow.createStatus = newCreateStatus;
-        oldRow.operationSyncing = newOperationSyncing;
+        newCreateStatus = CreateStatus::NEW;
     }
+
+    oldRow.data.index = newData.index;
+    oldRow.data.data = newData.data;
+    oldRow.data.operation = newData.operation;
+    oldRow.data.version = newData.version;
+    oldRow.data.is_data_context = newData.is_data_context;
+    oldRow.syncStatus = newSyncStatus;
+    oldRow.createStatus = newCreateStatus;
+    oldRow.operationSyncing = newOperationSyncing;
 }
 
 void InMemoryQueueStorage::submitOrCoalesce(const PersistedData& data)
@@ -167,17 +240,80 @@ void InMemoryQueueStorage::submitBatch(const std::vector<PersistedData>& batch)
     }
 }
 
-std::vector<PersistedData> InMemoryQueueStorage::fetchAndMarkForSync()
+std::vector<PersistedData> InMemoryQueueStorage::fetchAndMarkForSync(size_t maxBytes)
 {
     std::vector<PersistedData> result;
+    size_t estimatedBytes = SYNC_BLOCK_ESTIMATED_OVERHEAD_BYTES;
 
-    for (auto& row : m_rows)
+    for (auto it = m_rows.begin(); it != m_rows.end();)
     {
-        if (row.syncStatus == SyncStatus::PENDING)
+        if (it->syncStatus != SyncStatus::PENDING)
         {
-            result.push_back(row.data);
-            row.syncStatus = SyncStatus::SYNCING;
+            ++it;
+            continue;
         }
+
+        const size_t estimatedItemBytes = estimateSerializedItemBytes(it->data);
+
+        if (maxBytes > 0 && estimatedBytes + estimatedItemBytes > maxBytes)
+        {
+            if (!result.empty())
+            {
+                // Normal budget exhaustion: stop before adding this item.
+                break;
+            }
+
+            if (it->data.id == m_oversizedItemId)
+            {
+                ++m_oversizedItemAttempts;
+            }
+            else
+            {
+                m_oversizedItemId = it->data.id;
+                m_oversizedItemAttempts = 1;
+            }
+
+            if (m_oversizedItemAttempts > MAX_OVERSIZED_ATTEMPTS)
+            {
+                // This item alone has exceeded the cap for MAX_OVERSIZED_ATTEMPTS
+                // consecutive cycles: drop it instead of resending it forever, so it
+                // cannot starve every item behind it.
+                m_logger(LOG_ERROR,
+                         "InMemoryQueueStorage: Dropping pending item (~" +
+                         std::to_string(estimatedItemBytes) +
+                         " B) after " + std::to_string(m_oversizedItemAttempts) +
+                         " consecutive cycles alone over the byte cap (" +
+                         std::to_string(maxBytes) + " B); it was blocking every item behind it.");
+                m_index.erase(it->data.id);
+                it = m_rows.erase(it);
+                m_oversizedItemId.clear();
+                m_oversizedItemAttempts = 0;
+                continue;
+            }
+
+            // First item already exceeds the cap. Enforcing the limit here would leave
+            // it stuck in PENDING forever, so accept it once but warn.
+            m_logger(LOG_WARNING,
+                     "InMemoryQueueStorage: A single pending item (~" +
+                     std::to_string(estimatedItemBytes) +
+                     " B) exceeds the byte cap (" +
+                     std::to_string(maxBytes) +
+                     " B); sending it alone (attempt " +
+                     std::to_string(m_oversizedItemAttempts) + "/" +
+                     std::to_string(MAX_OVERSIZED_ATTEMPTS) +
+                     "). Consider reducing individual item size.");
+        }
+        else if (it->data.id == m_oversizedItemId)
+        {
+            // No longer alone over the cap (e.g. coalesced smaller): clear its streak.
+            m_oversizedItemId.clear();
+            m_oversizedItemAttempts = 0;
+        }
+
+        estimatedBytes += estimatedItemBytes;
+        result.push_back(it->data);
+        it->syncStatus = SyncStatus::SYNCING;
+        ++it;
     }
 
     return result;

--- a/src/shared_modules/sync_protocol/src/in_memory_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/src/in_memory_queue_storage.cpp
@@ -269,7 +269,21 @@ void InMemoryQueueStorage::applyCoalesceLogic(const PersistedData& newData)
         newCreateStatus = CreateStatus::NEW;
     }
 
-    m_totalEstimatedBytes -= estimateSerializedItemBytes(oldRow.data);
+    const size_t oldBytes = estimateSerializedItemBytes(oldRow.data);
+    const size_t newBytes = estimateSerializedItemBytes(newData);
+
+    // Only a growing update can breach the cap; check before mutating oldRow so a rejection
+    // leaves it untouched, like a rejected brand-new id above.
+    if (newBytes > oldBytes && m_totalEstimatedBytes - oldBytes + newBytes > MAX_QUEUE_BYTES)
+    {
+        std::string message = "InMemoryQueueStorage: Queue is at capacity (~" + std::to_string(m_totalEstimatedBytes);
+        message += " of " + std::to_string(MAX_QUEUE_BYTES) + " B); rejecting update that would grow tracked item id=" + newData.id;
+        message += ". The sync peer may be unreachable for an extended period.";
+        m_logger(LOG_ERROR, message);
+        throw std::runtime_error(message);
+    }
+
+    m_totalEstimatedBytes -= oldBytes;
 
     oldRow.data.index = newData.index;
     oldRow.data.data = newData.data;
@@ -280,7 +294,7 @@ void InMemoryQueueStorage::applyCoalesceLogic(const PersistedData& newData)
     oldRow.createStatus = newCreateStatus;
     oldRow.operationSyncing = newOperationSyncing;
 
-    m_totalEstimatedBytes += estimateSerializedItemBytes(oldRow.data);
+    m_totalEstimatedBytes += newBytes;
 }
 
 void InMemoryQueueStorage::submitOrCoalesce(const PersistedData& data)

--- a/src/shared_modules/sync_protocol/src/in_memory_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/src/in_memory_queue_storage.cpp
@@ -1,0 +1,335 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "in_memory_queue_storage.hpp"
+#include "persistent_queue_storage.hpp"
+#include "filesystem_wrapper.hpp"
+
+InMemoryQueueStorage::InMemoryQueueStorage(const std::string& dbPath, LoggerFunc logger, std::shared_ptr<IFileSystemWrapper> fileSystemWrapper)
+    : m_dbPath(dbPath),
+      m_logger(std::move(logger)),
+      m_fileSystemWrapper(fileSystemWrapper ? std::move(fileSystemWrapper) : std::make_shared<file_system::FileSystemWrapper>())
+{
+    if (!m_logger)
+    {
+        throw std::invalid_argument("Logger provided to InMemoryQueueStorage cannot be null.");
+    }
+
+    loadFromDisk();
+}
+
+InMemoryQueueStorage::~InMemoryQueueStorage()
+{
+    try
+    {
+        saveToDisk();
+    }
+    // LCOV_EXCL_START
+    catch (const std::exception& ex)
+    {
+        m_logger(LOG_ERROR, std::string("InMemoryQueueStorage: Failed to save snapshot to disk: ") + ex.what());
+    }
+
+    // LCOV_EXCL_STOP
+}
+
+void InMemoryQueueStorage::loadFromDisk()
+{
+    if (!m_fileSystemWrapper->exists(m_dbPath))
+    {
+        return;
+    }
+
+    try
+    {
+        PersistentQueueStorage onDiskSnapshot(m_dbPath, m_logger, m_fileSystemWrapper);
+
+        for (auto& row : onDiskSnapshot.fetchAll())
+        {
+            addRow(std::move(row));
+        }
+
+        // The snapshot has been fully loaded into memory; remove it so a crash before the
+        // next graceful shutdown correctly yields "no snapshot" rather than a stale one.
+        onDiskSnapshot.deleteDatabase();
+    }
+    // LCOV_EXCL_START
+    catch (const std::exception& ex)
+    {
+        m_logger(LOG_ERROR, std::string("InMemoryQueueStorage: Failed to load snapshot from disk, starting empty: ") + ex.what());
+    }
+
+    // LCOV_EXCL_STOP
+}
+
+void InMemoryQueueStorage::saveToDisk()
+{
+    // Nothing pending: skip writing a snapshot altogether (there is also nothing to clean up,
+    // since loadFromDisk()/deleteDatabase() already remove any on-disk file as soon as its
+    // contents are absorbed into m_rows or discarded).
+    if (m_rows.empty())
+    {
+        return;
+    }
+
+    PersistentQueueStorage snapshot(m_dbPath, m_logger, m_fileSystemWrapper);
+    snapshot.saveAll(std::vector<QueueRow>(m_rows.begin(), m_rows.end()));
+}
+
+void InMemoryQueueStorage::addRow(QueueRow row)
+{
+    row.rowId = m_nextRowId++;
+    m_rows.push_back(std::move(row));
+    m_index[m_rows.back().data.id] = std::prev(m_rows.end());
+}
+
+void InMemoryQueueStorage::applyCoalesceLogic(const PersistedData& newData)
+{
+    auto it = m_index.find(newData.id);
+
+    if (it == m_index.end())
+    {
+        QueueRow row;
+        row.data = newData;
+        row.syncStatus = SyncStatus::PENDING;
+        row.createStatus = (newData.operation == Operation::CREATE) ? CreateStatus::NEW : CreateStatus::EXISTING;
+        row.operationSyncing = Operation::NO_OP;
+        addRow(std::move(row));
+        return;
+    }
+
+    QueueRow& oldRow = *it->second;
+    const Operation oldOperation = oldRow.data.operation;
+    const SyncStatus oldSyncStatus = oldRow.syncStatus;
+    const CreateStatus oldCreateStatus = oldRow.createStatus;
+    const Operation oldOperationSyncing = oldRow.operationSyncing;
+
+    Operation newOperationSyncing = Operation::NO_OP;
+
+    if (oldSyncStatus != SyncStatus::PENDING)
+    {
+        newOperationSyncing = (oldOperationSyncing == Operation::NO_OP) ? oldOperation : oldOperationSyncing;
+    }
+
+    const SyncStatus newSyncStatus = (oldSyncStatus == SyncStatus::PENDING) ? SyncStatus::PENDING : SyncStatus::SYNCING_UPDATED;
+
+    if (newData.operation == Operation::DELETE_)
+    {
+        if (oldCreateStatus == CreateStatus::NEW && oldSyncStatus == SyncStatus::PENDING)
+        {
+            m_rows.erase(it->second);
+            m_index.erase(it);
+            return;
+        }
+
+        const CreateStatus newCreateStatus = (oldCreateStatus == CreateStatus::NEW) ? CreateStatus::NEW_DELETED : oldCreateStatus;
+
+        oldRow.data.index = newData.index;
+        oldRow.data.data = newData.data;
+        oldRow.data.operation = Operation::DELETE_;
+        oldRow.data.version = newData.version;
+        oldRow.data.is_data_context = newData.is_data_context;
+        oldRow.syncStatus = newSyncStatus;
+        oldRow.createStatus = newCreateStatus;
+        oldRow.operationSyncing = newOperationSyncing;
+    }
+    else
+    {
+        const CreateStatus newCreateStatus = (oldCreateStatus == CreateStatus::NEW_DELETED) ? CreateStatus::NEW : oldCreateStatus;
+
+        oldRow.data.index = newData.index;
+        oldRow.data.data = newData.data;
+        oldRow.data.operation = newData.operation;
+        oldRow.data.version = newData.version;
+        oldRow.data.is_data_context = newData.is_data_context;
+        oldRow.syncStatus = newSyncStatus;
+        oldRow.createStatus = newCreateStatus;
+        oldRow.operationSyncing = newOperationSyncing;
+    }
+}
+
+void InMemoryQueueStorage::submitOrCoalesce(const PersistedData& data)
+{
+    applyCoalesceLogic(data);
+}
+
+void InMemoryQueueStorage::submitBatch(const std::vector<PersistedData>& batch)
+{
+    for (const auto& item : batch)
+    {
+        applyCoalesceLogic(item);
+    }
+}
+
+std::vector<PersistedData> InMemoryQueueStorage::fetchAndMarkForSync()
+{
+    std::vector<PersistedData> result;
+
+    for (auto& row : m_rows)
+    {
+        if (row.syncStatus == SyncStatus::PENDING)
+        {
+            result.push_back(row.data);
+            row.syncStatus = SyncStatus::SYNCING;
+        }
+    }
+
+    return result;
+}
+
+std::vector<PersistedData> InMemoryQueueStorage::fetchPending(bool onlyDataValues)
+{
+    std::vector<PersistedData> result;
+
+    for (const auto& row : m_rows)
+    {
+        if (row.syncStatus == SyncStatus::PENDING && (!onlyDataValues || !row.data.is_data_context))
+        {
+            PersistedData data = row.data;
+            data.seq = row.rowId;
+            result.push_back(std::move(data));
+        }
+    }
+
+    if (m_logger)
+    {
+        m_logger(LOG_DEBUG, "InMemoryQueueStorage: Fetcheing " + std::to_string(result.size()) +
+                 " pending datavalues items");
+    }
+
+    return result;
+}
+
+void InMemoryQueueStorage::removeAllSynced()
+{
+    for (auto it = m_rows.begin(); it != m_rows.end();)
+    {
+        const bool shouldDelete = (it->syncStatus == SyncStatus::SYNCING) ||
+                                  (it->createStatus == CreateStatus::NEW_DELETED &&
+                                   (it->operationSyncing == Operation::NO_OP || it->operationSyncing == Operation::DELETE_));
+
+        if (shouldDelete)
+        {
+            m_index.erase(it->data.id);
+            it = m_rows.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    for (auto& row : m_rows)
+    {
+        if (row.syncStatus == SyncStatus::SYNCING || row.syncStatus == SyncStatus::SYNCING_UPDATED)
+        {
+            row.syncStatus = SyncStatus::PENDING;
+            row.createStatus = CreateStatus::EXISTING;
+            row.operationSyncing = Operation::NO_OP;
+        }
+    }
+}
+
+void InMemoryQueueStorage::resetAllSyncing()
+{
+    for (auto& row : m_rows)
+    {
+        if (row.syncStatus == SyncStatus::SYNCING || row.syncStatus == SyncStatus::SYNCING_UPDATED)
+        {
+            row.syncStatus = SyncStatus::PENDING;
+            row.operationSyncing = Operation::NO_OP;
+        }
+    }
+
+    for (auto it = m_rows.begin(); it != m_rows.end();)
+    {
+        if (it->data.operation == Operation::DELETE_ && it->createStatus == CreateStatus::NEW_DELETED)
+        {
+            m_index.erase(it->data.id);
+            it = m_rows.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+}
+
+void InMemoryQueueStorage::removeByIndex(const std::string& index)
+{
+    for (auto it = m_rows.begin(); it != m_rows.end();)
+    {
+        if (it->data.index == index)
+        {
+            m_index.erase(it->data.id);
+            it = m_rows.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+}
+
+void InMemoryQueueStorage::removeAllDataContext()
+{
+    for (auto it = m_rows.begin(); it != m_rows.end();)
+    {
+        if (it->data.is_data_context)
+        {
+            m_index.erase(it->data.id);
+            it = m_rows.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    if (m_logger)
+    {
+        m_logger(LOG_DEBUG, "InMemoryQueueStorage: Removed all DataContext items");
+    }
+}
+
+void InMemoryQueueStorage::deleteDatabase()
+{
+    m_rows.clear();
+    m_index.clear();
+
+    try
+    {
+        if (m_fileSystemWrapper->exists(m_dbPath))
+        {
+            m_fileSystemWrapper->remove(m_dbPath);
+            m_logger(LOG_DEBUG, std::string("InMemoryQueueStorage: Database file deleted: ") + m_dbPath);
+        }
+    }
+    catch (const std::exception& ex)
+    {
+        m_logger(LOG_ERROR, std::string("InMemoryQueueStorage: Error deleting database: ") + ex.what());
+        throw;
+    }
+}
+
+std::vector<QueueRow> InMemoryQueueStorage::fetchAll()
+{
+    return std::vector<QueueRow>(m_rows.begin(), m_rows.end());
+}
+
+void InMemoryQueueStorage::saveAll(const std::vector<QueueRow>& rows)
+{
+    m_rows.clear();
+    m_index.clear();
+
+    for (const auto& row : rows)
+    {
+        addRow(row);
+    }
+}

--- a/src/shared_modules/sync_protocol/src/in_memory_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/src/in_memory_queue_storage.cpp
@@ -94,6 +94,12 @@ void InMemoryQueueStorage::loadFromDisk()
     {
         try
         {
+            // Discard any partial rows from a previous failed attempt before re-reading the
+            // same on-disk snapshot, otherwise they end up duplicated (addRow() has no guard).
+            m_rows.clear();
+            m_index.clear();
+            m_totalEstimatedBytes = 0;
+
             PersistentQueueStorage onDiskSnapshot(m_dbPath, m_logger, m_fileSystemWrapper);
 
             for (auto& row : onDiskSnapshot.fetchAll())
@@ -213,10 +219,9 @@ void InMemoryQueueStorage::applyCoalesceLogic(const PersistedData& newData)
             // the moment the cap is hit -- turning "silently dropped forever" into "retried
             // until the queue has room," which is not a full fix (the caller still gets no
             // synchronous success/failure signal) but is a materially better failure mode.
-            const std::string message = "InMemoryQueueStorage: Queue is at capacity (~" +
-                                         std::to_string(m_totalEstimatedBytes) + " of " +
-                                         std::to_string(MAX_QUEUE_BYTES) + " B); rejecting new item id=" +
-                                         newData.id + ". The sync peer may be unreachable for an extended period.";
+            std::string message = "InMemoryQueueStorage: Queue is at capacity (~" + std::to_string(m_totalEstimatedBytes);
+            message += " of " + std::to_string(MAX_QUEUE_BYTES) + " B); rejecting new item id=" + newData.id;
+            message += ". The sync peer may be unreachable for an extended period.";
             m_logger(LOG_ERROR, message);
             throw std::runtime_error(message);
         }
@@ -285,9 +290,20 @@ void InMemoryQueueStorage::submitOrCoalesce(const PersistedData& data)
 
 void InMemoryQueueStorage::submitBatch(const std::vector<PersistedData>& batch)
 {
-    for (const auto& item : batch)
+    // Snapshot and restore on failure so a mid-batch throw can't leave a partial batch applied.
+    const std::vector<QueueRow> rowsBeforeBatch(m_rows.begin(), m_rows.end());
+
+    try
     {
-        applyCoalesceLogic(item);
+        for (const auto& item : batch)
+        {
+            applyCoalesceLogic(item);
+        }
+    }
+    catch (...)
+    {
+        saveAll(rowsBeforeBatch);
+        throw;
     }
 }
 

--- a/src/shared_modules/sync_protocol/src/in_memory_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/src/in_memory_queue_storage.cpp
@@ -22,13 +22,18 @@ namespace
     constexpr size_t SYNC_ITEM_ESTIMATED_OVERHEAD_BYTES = 512U;
     constexpr unsigned int MAX_OVERSIZED_ATTEMPTS = 5U;
 
-    /// @brief Maximum number of distinct (never-seen-before) ids this queue will hold at
-    ///        once. Bounds RSS growth if the sync peer is unreachable for an extended
-    ///        period: once full, a brand-new id is rejected (logged, not silently dropped)
+    /// @brief Maximum estimated total size (in bytes, using the same per-item estimate as
+    ///        the sync byte budget above) of distinct (never-seen-before) ids this queue
+    ///        will hold at once. Bounds RSS growth if the sync peer is unreachable for an
+    ///        extended period: once full, a brand-new id is rejected (throws -- see the
+    ///        throw site in applyCoalesceLogic below for why it must not silently no-op)
     ///        rather than evicting already-queued state. This value is a starting point,
     ///        not an authoritative figure -- there is no official sizing guidance for this
-    ///        queue, so it should be revisited against real operational data.
-    constexpr size_t MAX_QUEUE_ROWS = 10000U;
+    ///        queue, so it should be revisited against real operational data. Tracking the
+    ///        cap in bytes rather than row count avoids the previous mismatch where 10000
+    ///        rows of small FIM checksums was negligible RSS but the same row count of
+    ///        larger SCA/inventory payloads could be tens of MB.
+    constexpr size_t MAX_QUEUE_BYTES = 8U * 1024U * 1024U;
 
     size_t estimateSerializedItemBytes(const PersistedData& data)
     {
@@ -74,26 +79,53 @@ void InMemoryQueueStorage::loadFromDisk()
         return;
     }
 
-    try
-    {
-        PersistentQueueStorage onDiskSnapshot(m_dbPath, m_logger, m_fileSystemWrapper);
+    // A transient failure here is far more dangerous than it looks: giving up immediately
+    // leaves the on-disk snapshot file untouched (deleteDatabase() below is only reached on
+    // success), but m_rows starts empty regardless -- and the NEXT graceful shutdown's
+    // saveToDisk() unconditionally overwrites that same on-disk file with whatever is in
+    // m_rows at that point (PersistentQueueStorage::saveAll() deletes the old rows first),
+    // permanently destroying the never-loaded backlog. Retrying here, mirroring saveToDisk()'s
+    // own bounded retry, closes most of that window; a persistent failure still falls back to
+    // "start empty" exactly as before, since there is nothing else this constructor can do.
+    constexpr int MAX_LOAD_ATTEMPTS = 3;
+    constexpr std::chrono::milliseconds RETRY_DELAY{100};
 
-        for (auto& row : onDiskSnapshot.fetchAll())
+    for (int attempt = 1; attempt <= MAX_LOAD_ATTEMPTS; ++attempt)
+    {
+        try
         {
-            addRow(std::move(row));
+            PersistentQueueStorage onDiskSnapshot(m_dbPath, m_logger, m_fileSystemWrapper);
+
+            for (auto& row : onDiskSnapshot.fetchAll())
+            {
+                addRow(std::move(row));
+            }
+
+            // The snapshot has been fully loaded into memory; remove it so a crash before
+            // the next graceful shutdown correctly yields "no snapshot" rather than a stale
+            // one.
+            onDiskSnapshot.deleteDatabase();
+            return;
+        }
+        // LCOV_EXCL_START
+        catch (const std::exception& ex)
+        {
+            if (attempt == MAX_LOAD_ATTEMPTS)
+            {
+                m_logger(LOG_ERROR, std::string("InMemoryQueueStorage: Failed to load snapshot from disk after ") +
+                         std::to_string(MAX_LOAD_ATTEMPTS) + " attempts, starting empty: " + ex.what());
+                return;
+            }
+
+            m_logger(LOG_WARNING,
+                     "InMemoryQueueStorage: Attempt " + std::to_string(attempt) + "/" +
+                     std::to_string(MAX_LOAD_ATTEMPTS) +
+                     " to load the on-disk snapshot failed, retrying: " + ex.what());
+            std::this_thread::sleep_for(RETRY_DELAY);
         }
 
-        // The snapshot has been fully loaded into memory; remove it so a crash before the
-        // next graceful shutdown correctly yields "no snapshot" rather than a stale one.
-        onDiskSnapshot.deleteDatabase();
+        // LCOV_EXCL_STOP
     }
-    // LCOV_EXCL_START
-    catch (const std::exception& ex)
-    {
-        m_logger(LOG_ERROR, std::string("InMemoryQueueStorage: Failed to load snapshot from disk, starting empty: ") + ex.what());
-    }
-
-    // LCOV_EXCL_STOP
 }
 
 void InMemoryQueueStorage::saveToDisk()
@@ -142,8 +174,9 @@ void InMemoryQueueStorage::addRow(QueueRow row)
 {
     row.rowId = m_nextRowId++;
 
-    // Capture the id before the move below invalidates row's own copy.
+    // Capture the id and estimated size before the move below invalidates row's own copy.
     const std::string id = row.data.id;
+    const size_t rowBytes = estimateSerializedItemBytes(row.data);
     m_rows.push_back(std::move(row));
 
     try
@@ -158,6 +191,8 @@ void InMemoryQueueStorage::addRow(QueueRow row)
         m_rows.pop_back();
         throw;
     }
+
+    m_totalEstimatedBytes += rowBytes;
 }
 
 void InMemoryQueueStorage::applyCoalesceLogic(const PersistedData& newData)
@@ -166,13 +201,24 @@ void InMemoryQueueStorage::applyCoalesceLogic(const PersistedData& newData)
 
     if (it == m_index.end())
     {
-        if (m_rows.size() >= MAX_QUEUE_ROWS)
+        const size_t incomingBytes = estimateSerializedItemBytes(newData);
+
+        if (m_totalEstimatedBytes + incomingBytes > MAX_QUEUE_BYTES)
         {
-            m_logger(LOG_ERROR,
-                     "InMemoryQueueStorage: Queue is at capacity (" + std::to_string(MAX_QUEUE_ROWS) +
-                     " rows); rejecting new item id=" + newData.id +
-                     ". The sync peer may be unreachable for an extended period.");
-            return;
+            // Throw rather than silently returning: a caller like syscheckd's full-table
+            // recovery path (which clears the manager's index first, then re-persists every
+            // row in a loop with no capacity check of its own) cannot tell a silent no-op
+            // apart from success. Throwing lets PersistentQueue::submit() retain this item in
+            // m_pendingRetry and retry it once room frees up, instead of permanently losing it
+            // the moment the cap is hit -- turning "silently dropped forever" into "retried
+            // until the queue has room," which is not a full fix (the caller still gets no
+            // synchronous success/failure signal) but is a materially better failure mode.
+            const std::string message = "InMemoryQueueStorage: Queue is at capacity (~" +
+                                         std::to_string(m_totalEstimatedBytes) + " of " +
+                                         std::to_string(MAX_QUEUE_BYTES) + " B); rejecting new item id=" +
+                                         newData.id + ". The sync peer may be unreachable for an extended period.";
+            m_logger(LOG_ERROR, message);
+            throw std::runtime_error(message);
         }
 
         QueueRow row;
@@ -201,6 +247,7 @@ void InMemoryQueueStorage::applyCoalesceLogic(const PersistedData& newData)
 
     if (newData.operation == Operation::DELETE_ && oldCreateStatus == CreateStatus::NEW && oldSyncStatus == SyncStatus::PENDING)
     {
+        m_totalEstimatedBytes -= estimateSerializedItemBytes(oldRow.data);
         m_rows.erase(it->second);
         m_index.erase(it);
         return;
@@ -217,6 +264,8 @@ void InMemoryQueueStorage::applyCoalesceLogic(const PersistedData& newData)
         newCreateStatus = CreateStatus::NEW;
     }
 
+    m_totalEstimatedBytes -= estimateSerializedItemBytes(oldRow.data);
+
     oldRow.data.index = newData.index;
     oldRow.data.data = newData.data;
     oldRow.data.operation = newData.operation;
@@ -225,6 +274,8 @@ void InMemoryQueueStorage::applyCoalesceLogic(const PersistedData& newData)
     oldRow.syncStatus = newSyncStatus;
     oldRow.createStatus = newCreateStatus;
     oldRow.operationSyncing = newOperationSyncing;
+
+    m_totalEstimatedBytes += estimateSerializedItemBytes(oldRow.data);
 }
 
 void InMemoryQueueStorage::submitOrCoalesce(const PersistedData& data)
@@ -284,6 +335,7 @@ std::vector<PersistedData> InMemoryQueueStorage::fetchAndMarkForSync(size_t maxB
                          " B) after " + std::to_string(m_oversizedItemAttempts) +
                          " consecutive cycles alone over the byte cap (" +
                          std::to_string(maxBytes) + " B); it was blocking every item behind it.");
+                m_totalEstimatedBytes -= estimateSerializedItemBytes(it->data);
                 m_index.erase(it->data.id);
                 it = m_rows.erase(it);
                 m_oversizedItemId.clear();
@@ -328,6 +380,14 @@ std::vector<PersistedData> InMemoryQueueStorage::fetchPending(bool onlyDataValue
         if (row.syncStatus == SyncStatus::PENDING && (!onlyDataValues || !row.data.is_data_context))
         {
             PersistedData data = row.data;
+            // NOTE: unlike PersistentQueueStorage (whose seq is the durable SQLite rowid,
+            // stable across restarts), row.rowId here comes from m_nextRowId, which restarts
+            // at 1 every process start -- including for rows just reloaded from a prior
+            // snapshot in loadFromDisk(). No current caller relies on seq being stable across
+            // restarts (fetchAndMarkForSync()'s own callers overwrite it per-batch anyway),
+            // but this is a real, disclosed drift from the field's documented semantics that
+            // a future or external consumer comparing seq values across restarts would need
+            // to be aware of.
             data.seq = row.rowId;
             result.push_back(std::move(data));
         }
@@ -352,6 +412,7 @@ void InMemoryQueueStorage::removeAllSynced()
 
         if (shouldDelete)
         {
+            m_totalEstimatedBytes -= estimateSerializedItemBytes(it->data);
             m_index.erase(it->data.id);
             it = m_rows.erase(it);
         }
@@ -387,6 +448,7 @@ void InMemoryQueueStorage::resetAllSyncing()
     {
         if (it->data.operation == Operation::DELETE_ && it->createStatus == CreateStatus::NEW_DELETED)
         {
+            m_totalEstimatedBytes -= estimateSerializedItemBytes(it->data);
             m_index.erase(it->data.id);
             it = m_rows.erase(it);
         }
@@ -403,6 +465,7 @@ void InMemoryQueueStorage::removeByIndex(const std::string& index)
     {
         if (it->data.index == index)
         {
+            m_totalEstimatedBytes -= estimateSerializedItemBytes(it->data);
             m_index.erase(it->data.id);
             it = m_rows.erase(it);
         }
@@ -419,6 +482,7 @@ void InMemoryQueueStorage::removeAllDataContext()
     {
         if (it->data.is_data_context)
         {
+            m_totalEstimatedBytes -= estimateSerializedItemBytes(it->data);
             m_index.erase(it->data.id);
             it = m_rows.erase(it);
         }
@@ -438,6 +502,7 @@ void InMemoryQueueStorage::deleteDatabase()
 {
     m_rows.clear();
     m_index.clear();
+    m_totalEstimatedBytes = 0;
 
     try
     {
@@ -463,6 +528,7 @@ void InMemoryQueueStorage::saveAll(const std::vector<QueueRow>& rows)
 {
     m_rows.clear();
     m_index.clear();
+    m_totalEstimatedBytes = 0;
 
     for (const auto& row : rows)
     {

--- a/src/shared_modules/sync_protocol/src/in_memory_queue_storage.hpp
+++ b/src/shared_modules/sync_protocol/src/in_memory_queue_storage.hpp
@@ -61,6 +61,11 @@ class InMemoryQueueStorage : public IPersistentQueueStorage
         /// @brief Monotonically increasing counter assigned to each row on insertion.
         uint64_t m_nextRowId{1};
 
+        /// @brief Running total of estimated serialized bytes across all rows in m_rows,
+        ///        kept in sync with every insert/update/erase so the capacity check in
+        ///        applyCoalesceLogic() never has to rescan the whole queue.
+        size_t m_totalEstimatedBytes{0};
+
         /// @brief Id of the pending item currently stuck as a lone oversized block, if any.
         /// Mirrors PersistentQueueStorage's own oversized-item tracking.
         std::string m_oversizedItemId;

--- a/src/shared_modules/sync_protocol/src/in_memory_queue_storage.hpp
+++ b/src/shared_modules/sync_protocol/src/in_memory_queue_storage.hpp
@@ -1,0 +1,85 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#pragma once
+
+#include "ipersistent_queue_storage.hpp"
+#include "agent_sync_protocol_types.hpp"
+#include "ifilesystem_wrapper.hpp"
+
+#include <list>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+/// @brief In-memory implementation of IPersistentQueueStorage.
+///
+/// Holds the full queue state in memory for the lifetime of the process; no disk I/O
+/// happens on submit/fetch/clear. The on-disk file (in the SQLite format produced by
+/// PersistentQueueStorage) is only touched at the two lifecycle boundaries: it is loaded
+/// once at construction (if present, from a previous graceful shutdown) and written once
+/// at destruction. An ungraceful termination (crash, SIGKILL) skips the destructor, so no
+/// snapshot is written — the queue reverts to its last gracefully-saved state on the next
+/// run, which is the accepted trade-off for removing continuous disk I/O from this queue.
+class InMemoryQueueStorage : public IPersistentQueueStorage
+{
+    public:
+        /// @brief Constructs the storage, loading any existing on-disk snapshot at dbPath.
+        /// @param dbPath Path to the on-disk snapshot file (SQLite format).
+        /// @param logger Logger function.
+        /// @param fileSystemWrapper Filesystem wrapper for operations (for testing). If nullptr, uses default implementation.
+        explicit InMemoryQueueStorage(const std::string& dbPath, LoggerFunc logger, std::shared_ptr<IFileSystemWrapper> fileSystemWrapper = nullptr);
+
+        /// @brief Destructor. Writes the full in-memory state back to dbPath.
+        ~InMemoryQueueStorage() override;
+
+        void submitOrCoalesce(const PersistedData& data) override;
+        void submitBatch(const std::vector<PersistedData>& batch) override;
+        std::vector<PersistedData> fetchAndMarkForSync() override;
+        std::vector<PersistedData> fetchPending(bool onlyDataValues = true) override;
+        void removeAllSynced() override;
+        void resetAllSyncing() override;
+        void removeByIndex(const std::string& index) override;
+        void removeAllDataContext() override;
+        void deleteDatabase() override;
+        std::vector<QueueRow> fetchAll() override;
+        void saveAll(const std::vector<QueueRow>& rows) override;
+
+    private:
+        /// @brief Rows in insertion order.
+        std::list<QueueRow> m_rows;
+
+        /// @brief Index from message id to its position in m_rows, for O(1) lookup.
+        std::unordered_map<std::string, std::list<QueueRow>::iterator> m_index;
+
+        /// @brief Monotonically increasing counter assigned to each row on insertion.
+        uint64_t m_nextRowId{1};
+
+        /// @brief Path to the on-disk snapshot file.
+        std::string m_dbPath;
+
+        /// @brief Logger function.
+        LoggerFunc m_logger;
+
+        /// @brief Filesystem wrapper for operations.
+        std::shared_ptr<IFileSystemWrapper> m_fileSystemWrapper;
+
+        /// @brief Applies coalescing logic for a single item against the in-memory rows.
+        /// Mirrors PersistentQueueStorage::applyCoalesceLogic's SQL semantics exactly.
+        void applyCoalesceLogic(const PersistedData& newData);
+
+        /// @brief Appends a fully-formed row, assigning it the next row id.
+        void addRow(QueueRow row);
+
+        /// @brief Loads a previously-saved snapshot from m_dbPath, if it exists.
+        void loadFromDisk();
+
+        /// @brief Writes the current in-memory rows to m_dbPath.
+        void saveToDisk();
+};

--- a/src/shared_modules/sync_protocol/src/in_memory_queue_storage.hpp
+++ b/src/shared_modules/sync_protocol/src/in_memory_queue_storage.hpp
@@ -41,7 +41,7 @@ class InMemoryQueueStorage : public IPersistentQueueStorage
 
         void submitOrCoalesce(const PersistedData& data) override;
         void submitBatch(const std::vector<PersistedData>& batch) override;
-        std::vector<PersistedData> fetchAndMarkForSync() override;
+        std::vector<PersistedData> fetchAndMarkForSync(size_t maxBytes = 0) override;
         std::vector<PersistedData> fetchPending(bool onlyDataValues = true) override;
         void removeAllSynced() override;
         void resetAllSyncing() override;
@@ -60,6 +60,14 @@ class InMemoryQueueStorage : public IPersistentQueueStorage
 
         /// @brief Monotonically increasing counter assigned to each row on insertion.
         uint64_t m_nextRowId{1};
+
+        /// @brief Id of the pending item currently stuck as a lone oversized block, if any.
+        /// Mirrors PersistentQueueStorage's own oversized-item tracking.
+        std::string m_oversizedItemId;
+
+        /// @brief Consecutive fetchAndMarkForSync() calls in which m_oversizedItemId was
+        ///        resent alone because it exceeds the byte cap on its own.
+        unsigned int m_oversizedItemAttempts = 0;
 
         /// @brief Path to the on-disk snapshot file.
         std::string m_dbPath;

--- a/src/shared_modules/sync_protocol/src/ipersistent_queue_storage.hpp
+++ b/src/shared_modules/sync_protocol/src/ipersistent_queue_storage.hpp
@@ -12,6 +12,45 @@
 #include <vector>
 #include "ipersistent_queue.hpp"
 
+/// @brief Defines the synchronization status of a persisted message.
+enum class SyncStatus : int
+{
+    PENDING = 0,        ///< The message is waiting to be synchronized.
+    SYNCING = 1,        ///< The message is currently being synchronized.
+    SYNCING_UPDATED = 2 ///< The message is being synchronized and its contents have been updated.
+};
+
+/// @brief Tracks the creation state of a persisted message, particularly for newly created items.
+enum class CreateStatus : int
+{
+    EXISTING = 0,     ///< The message existed prior to the current session; it was not newly created.
+    NEW = 1,          ///< The message was newly created during the current session.
+    NEW_DELETED = 2   ///< The message was newly created, but then deleted before it could be synchronized.
+};
+
+/// @brief A single stored row, including the internal coalescing state.
+///
+/// Used to move the full queue state between the runtime backend (in-memory) and the
+/// on-disk snapshot format (SQLite) via fetchAll()/saveAll() — the two boundaries where
+/// the queue is persisted (agent startup / graceful shutdown).
+struct QueueRow
+{
+    /// @brief Row insertion order, used to preserve FIFO ordering across a save/load round trip.
+    uint64_t rowId{};
+
+    /// @brief The message payload.
+    PersistedData data;
+
+    /// @brief Current synchronization status.
+    SyncStatus syncStatus{SyncStatus::PENDING};
+
+    /// @brief Current creation status.
+    CreateStatus createStatus{CreateStatus::EXISTING};
+
+    /// @brief Operation captured while the previous version of this row was mid-sync.
+    Operation operationSyncing{Operation::NO_OP};
+};
+
 /// @brief Interface for persistent storage backend used by PersistentQueue.
 ///
 /// Implementations of this interface are responsible for saving, retrieving,
@@ -60,4 +99,14 @@ class IPersistentQueueStorage
         /// @brief Deletes the database file.
         /// This method closes the database connection and removes the database file from disk.
         virtual void deleteDatabase() = 0;
+
+        /// @brief Fetches every row regardless of status, including internal coalescing state.
+        /// Used to load a full snapshot (e.g. from disk into memory at startup).
+        /// @return All rows in insertion order.
+        virtual std::vector<QueueRow> fetchAll() = 0;
+
+        /// @brief Replaces the entire contents of the store with the given rows, in one
+        /// transaction. Used to persist a full snapshot (e.g. from memory to disk at shutdown).
+        /// @param rows The complete set of rows to persist, in insertion order.
+        virtual void saveAll(const std::vector<QueueRow>& rows) = 0;
 };

--- a/src/shared_modules/sync_protocol/src/ipersistent_queue_storage.hpp
+++ b/src/shared_modules/sync_protocol/src/ipersistent_queue_storage.hpp
@@ -13,6 +13,45 @@
 #include <vector>
 #include "ipersistent_queue.hpp"
 
+/// @brief Defines the synchronization status of a persisted message.
+enum class SyncStatus : int
+{
+    PENDING = 0,        ///< The message is waiting to be synchronized.
+    SYNCING = 1,        ///< The message is currently being synchronized.
+    SYNCING_UPDATED = 2 ///< The message is being synchronized and its contents have been updated.
+};
+
+/// @brief Tracks the creation state of a persisted message, particularly for newly created items.
+enum class CreateStatus : int
+{
+    EXISTING = 0,     ///< The message existed prior to the current session; it was not newly created.
+    NEW = 1,          ///< The message was newly created during the current session.
+    NEW_DELETED = 2   ///< The message was newly created, but then deleted before it could be synchronized.
+};
+
+/// @brief A single stored row, including the internal coalescing state.
+///
+/// Used to move the full queue state between the runtime backend (in-memory) and the
+/// on-disk snapshot format (SQLite) via fetchAll()/saveAll() — the two boundaries where
+/// the queue is persisted (agent startup / graceful shutdown).
+struct QueueRow
+{
+    /// @brief Row insertion order, used to preserve FIFO ordering across a save/load round trip.
+    uint64_t rowId{};
+
+    /// @brief The message payload.
+    PersistedData data;
+
+    /// @brief Current synchronization status.
+    SyncStatus syncStatus{SyncStatus::PENDING};
+
+    /// @brief Current creation status.
+    CreateStatus createStatus{CreateStatus::EXISTING};
+
+    /// @brief Operation captured while the previous version of this row was mid-sync.
+    Operation operationSyncing{Operation::NO_OP};
+};
+
 /// @brief Interface for persistent storage backend used by PersistentQueue.
 ///
 /// Implementations of this interface are responsible for saving, retrieving,
@@ -62,4 +101,14 @@ class IPersistentQueueStorage
         /// @brief Deletes the database file.
         /// This method closes the database connection and removes the database file from disk.
         virtual void deleteDatabase() = 0;
+
+        /// @brief Fetches every row regardless of status, including internal coalescing state.
+        /// Used to load a full snapshot (e.g. from disk into memory at startup).
+        /// @return All rows in insertion order.
+        virtual std::vector<QueueRow> fetchAll() = 0;
+
+        /// @brief Replaces the entire contents of the store with the given rows, in one
+        /// transaction. Used to persist a full snapshot (e.g. from memory to disk at shutdown).
+        /// @param rows The complete set of rows to persist, in insertion order.
+        virtual void saveAll(const std::vector<QueueRow>& rows) = 0;
 };

--- a/src/shared_modules/sync_protocol/src/persistent_queue.cpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue.cpp
@@ -116,9 +116,28 @@ void PersistentQueue::submit(const std::string& id,
     {
         m_logger(LOG_ERROR, std::string("PersistentQueue: Error submitting item to storage: ") + ex.what() + " (will retry on next call)");
 
-        // An id already pending retry is always updated in place (never grows the map);
-        // only a brand-new failing id is subject to the capacity check below.
-        if (m_pendingRetry.find(id) == m_pendingRetry.end() && m_pendingRetry.size() >= MAX_PENDING_RETRY_ITEMS)
+        auto pending = m_pendingRetry.find(id);
+
+        // Coalesce with an id already pending retry instead of raw-overwriting it: since
+        // storage never received this id, a CREATE later canceled by a DELETE_ must be
+        // dropped entirely rather than replayed as a lone DELETE_ once storage recovers.
+        if (pending != m_pendingRetry.end())
+        {
+            if (pending->second.operation == Operation::CREATE && newItem.operation == Operation::DELETE_)
+            {
+                m_pendingRetry.erase(pending);
+                return;
+            }
+
+            // Keep CREATE if that's what it started as, so storage still sees it as one.
+            const Operation mergedOperation = (pending->second.operation == Operation::CREATE) ? Operation::CREATE : newItem.operation;
+            newItem.operation = mergedOperation;
+            pending->second = std::move(newItem);
+            return;
+        }
+
+        // A brand-new failing id is subject to the capacity check.
+        if (m_pendingRetry.size() >= MAX_PENDING_RETRY_ITEMS)
         {
             m_logger(LOG_ERROR,
                      "PersistentQueue: Retry list is at capacity (" + std::to_string(MAX_PENDING_RETRY_ITEMS) +

--- a/src/shared_modules/sync_protocol/src/persistent_queue.cpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue.cpp
@@ -51,6 +51,9 @@ PersistentQueue::~PersistentQueue()
     // on a clean, graceful shutdown, not just a crash. Any failure here is logged and swallowed
     // (there is no later point left to retry from), which is an accepted, disclosed loss on top
     // of the already-accepted "ungraceful termination loses unsaved state" trade-off.
+    // Locked for consistency with every other m_storage access.
+    std::lock_guard<std::mutex> storageLock(m_storageMutex);
+
     for (auto& [id, pending] : m_pendingRetry)
     {
         try

--- a/src/shared_modules/sync_protocol/src/persistent_queue.cpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue.cpp
@@ -8,12 +8,10 @@
  */
 
 #include "persistent_queue.hpp"
-#include "persistent_queue_storage.hpp"
-
-#include <algorithm>
+#include "in_memory_queue_storage.hpp"
 
 PersistentQueue::PersistentQueue(const std::string& dbPath, LoggerFunc logger, std::shared_ptr<IPersistentQueueStorage> storage)
-    : m_storage(storage ? std::move(storage) : std::make_shared<PersistentQueueStorage>(dbPath, logger)),
+    : m_storage(storage ? std::move(storage) : std::make_shared<InMemoryQueueStorage>(dbPath, logger)),
       m_logger(std::move(logger))
 {
     if (!m_logger)
@@ -30,25 +28,9 @@ PersistentQueue::PersistentQueue(const std::string& dbPath, LoggerFunc logger, s
         m_logger(LOG_ERROR, std::string("PersistentQueue: Error on DB: ") + ex.what());
         throw;
     }
-
-    m_buffers[0].reserve(FLUSH_BATCH_SIZE);
-    m_buffers[1].reserve(FLUSH_BATCH_SIZE);
-    m_flushThread = std::thread(&PersistentQueue::flushLoop, this);
 }
 
-PersistentQueue::~PersistentQueue()
-{
-    {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        m_stop = true;
-    }
-    m_cv.notify_one();
-
-    if (m_flushThread.joinable())
-    {
-        m_flushThread.join();
-    }
-}
+PersistentQueue::~PersistentQueue() = default;
 
 void PersistentQueue::submit(const std::string& id,
                              const std::string& index,
@@ -57,96 +39,19 @@ void PersistentQueue::submit(const std::string& id,
                              uint64_t version,
                              bool isDataContext)
 {
-    bool shouldNotify = false;
-    {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        m_buffers[m_currentIdx].push_back(PersistedData{0, id, index, data, operation, version, isDataContext});
-        shouldNotify = (m_buffers[m_currentIdx].size() >= FLUSH_BATCH_SIZE);
-    }
-
-    if (shouldNotify)
-    {
-        m_cv.notify_one();
-    }
-}
-
-void PersistentQueue::flushLoop()
-{
-    while (true)
-    {
-        std::size_t flushIdx = 0;
-        bool shouldFlush = false;
-
-        {
-            std::unique_lock<std::mutex> lock(m_mutex);
-            m_cv.wait_for(lock, FLUSH_INTERVAL, [this]
-            {
-                return m_buffers[m_currentIdx].size() >= FLUSH_BATCH_SIZE || m_stop.load();
-            });
-
-            if (!m_buffers[m_currentIdx].empty())
-            {
-                flushIdx = m_currentIdx;
-                shouldFlush = true;
-                m_currentIdx ^= 1;
-            }
-
-            if (m_stop.load() && !shouldFlush)
-            {
-                break;
-            }
-        }
-
-        if (shouldFlush)
-        {
-            if (flushBuffer(m_buffers[flushIdx]))
-            {
-                m_buffers[flushIdx].clear();
-            }
-        }
-    }
-}
-
-bool PersistentQueue::flushBuffer(const std::vector<PersistedData>& batch)
-{
     try
     {
         std::lock_guard<std::mutex> storageLock(m_storageMutex);
-        m_storage->submitBatch(batch);
-        return true;
+        m_storage->submitOrCoalesce(PersistedData{0, id, index, data, operation, version, isDataContext});
     }
     catch (const std::exception& ex)
     {
-        m_logger(LOG_ERROR, std::string("PersistentQueue: Error flushing batch to storage: ") + ex.what());
-        return false;
-    }
-}
-
-void PersistentQueue::flushPendingBuffer()
-{
-    std::size_t flushIdx;
-    {
-        std::lock_guard<std::mutex> lock(m_mutex);
-
-        if (m_buffers[m_currentIdx].empty())
-        {
-            return;
-        }
-
-        flushIdx = m_currentIdx;
-        m_currentIdx ^= 1;
-    }
-
-    if (flushBuffer(m_buffers[flushIdx]))
-    {
-        m_buffers[flushIdx].clear();
+        m_logger(LOG_ERROR, std::string("PersistentQueue: Error submitting item to storage: ") + ex.what());
     }
 }
 
 std::vector<PersistedData> PersistentQueue::fetchAndMarkForSync(size_t maxBytes)
 {
-    flushPendingBuffer();
-
     try
     {
         std::lock_guard<std::mutex> storageLock(m_storageMutex);
@@ -161,8 +66,6 @@ std::vector<PersistedData> PersistentQueue::fetchAndMarkForSync(size_t maxBytes)
 
 std::vector<PersistedData> PersistentQueue::fetchPendingItems(bool onlyDataValues)
 {
-    flushPendingBuffer();
-
     try
     {
         std::lock_guard<std::mutex> storageLock(m_storageMutex);

--- a/src/shared_modules/sync_protocol/src/persistent_queue.cpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue.cpp
@@ -39,14 +39,44 @@ void PersistentQueue::submit(const std::string& id,
                              uint64_t version,
                              bool isDataContext)
 {
+    std::lock_guard<std::mutex> storageLock(m_storageMutex);
+
+    // Opportunistically retry anything that failed on a previous submit() before handling
+    // the new item, so a transient storage failure does not silently and permanently lose
+    // an event. This replaces the old buffer/flush-thread-based retry that existed when
+    // submitBatch() on a background thread was the only write path -- with submit() now
+    // writing synchronously, retrying on the next call is the equivalent, simpler guarantee.
+    if (!m_pendingRetry.empty())
+    {
+        std::vector<PersistedData> stillPending;
+        stillPending.reserve(m_pendingRetry.size());
+
+        for (auto& pending : m_pendingRetry)
+        {
+            try
+            {
+                m_storage->submitOrCoalesce(pending);
+            }
+            catch (const std::exception& ex)
+            {
+                m_logger(LOG_WARNING, std::string("PersistentQueue: Retry of a previously failed item is still failing: ") + ex.what());
+                stillPending.push_back(std::move(pending));
+            }
+        }
+
+        m_pendingRetry = std::move(stillPending);
+    }
+
+    PersistedData newItem{0, id, index, data, operation, version, isDataContext};
+
     try
     {
-        std::lock_guard<std::mutex> storageLock(m_storageMutex);
-        m_storage->submitOrCoalesce(PersistedData{0, id, index, data, operation, version, isDataContext});
+        m_storage->submitOrCoalesce(newItem);
     }
     catch (const std::exception& ex)
     {
-        m_logger(LOG_ERROR, std::string("PersistentQueue: Error submitting item to storage: ") + ex.what());
+        m_logger(LOG_ERROR, std::string("PersistentQueue: Error submitting item to storage: ") + ex.what() + " (will retry on next submit())");
+        m_pendingRetry.push_back(std::move(newItem));
     }
 }
 

--- a/src/shared_modules/sync_protocol/src/persistent_queue.cpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue.cpp
@@ -8,12 +8,10 @@
  */
 
 #include "persistent_queue.hpp"
-#include "persistent_queue_storage.hpp"
-
-#include <algorithm>
+#include "in_memory_queue_storage.hpp"
 
 PersistentQueue::PersistentQueue(const std::string& dbPath, LoggerFunc logger, std::shared_ptr<IPersistentQueueStorage> storage)
-    : m_storage(storage ? std::move(storage) : std::make_shared<PersistentQueueStorage>(dbPath, logger)),
+    : m_storage(storage ? std::move(storage) : std::make_shared<InMemoryQueueStorage>(dbPath, logger)),
       m_logger(std::move(logger))
 {
     if (!m_logger)
@@ -30,25 +28,9 @@ PersistentQueue::PersistentQueue(const std::string& dbPath, LoggerFunc logger, s
         m_logger(LOG_ERROR, std::string("PersistentQueue: Error on DB: ") + ex.what());
         throw;
     }
-
-    m_buffers[0].reserve(FLUSH_BATCH_SIZE);
-    m_buffers[1].reserve(FLUSH_BATCH_SIZE);
-    m_flushThread = std::thread(&PersistentQueue::flushLoop, this);
 }
 
-PersistentQueue::~PersistentQueue()
-{
-    {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        m_stop = true;
-    }
-    m_cv.notify_one();
-
-    if (m_flushThread.joinable())
-    {
-        m_flushThread.join();
-    }
-}
+PersistentQueue::~PersistentQueue() = default;
 
 void PersistentQueue::submit(const std::string& id,
                              const std::string& index,
@@ -57,96 +39,19 @@ void PersistentQueue::submit(const std::string& id,
                              uint64_t version,
                              bool isDataContext)
 {
-    bool shouldNotify = false;
-    {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        m_buffers[m_currentIdx].push_back(PersistedData{0, id, index, data, operation, version, isDataContext});
-        shouldNotify = (m_buffers[m_currentIdx].size() >= FLUSH_BATCH_SIZE);
-    }
-
-    if (shouldNotify)
-    {
-        m_cv.notify_one();
-    }
-}
-
-void PersistentQueue::flushLoop()
-{
-    while (true)
-    {
-        std::size_t flushIdx = 0;
-        bool shouldFlush = false;
-
-        {
-            std::unique_lock<std::mutex> lock(m_mutex);
-            m_cv.wait_for(lock, FLUSH_INTERVAL, [this]
-            {
-                return m_buffers[m_currentIdx].size() >= FLUSH_BATCH_SIZE || m_stop.load();
-            });
-
-            if (!m_buffers[m_currentIdx].empty())
-            {
-                flushIdx = m_currentIdx;
-                shouldFlush = true;
-                m_currentIdx ^= 1;
-            }
-
-            if (m_stop.load() && !shouldFlush)
-            {
-                break;
-            }
-        }
-
-        if (shouldFlush)
-        {
-            if (flushBuffer(m_buffers[flushIdx]))
-            {
-                m_buffers[flushIdx].clear();
-            }
-        }
-    }
-}
-
-bool PersistentQueue::flushBuffer(const std::vector<PersistedData>& batch)
-{
     try
     {
         std::lock_guard<std::mutex> storageLock(m_storageMutex);
-        m_storage->submitBatch(batch);
-        return true;
+        m_storage->submitOrCoalesce(PersistedData{0, id, index, data, operation, version, isDataContext});
     }
     catch (const std::exception& ex)
     {
-        m_logger(LOG_ERROR, std::string("PersistentQueue: Error flushing batch to storage: ") + ex.what());
-        return false;
-    }
-}
-
-void PersistentQueue::flushPendingBuffer()
-{
-    std::size_t flushIdx;
-    {
-        std::lock_guard<std::mutex> lock(m_mutex);
-
-        if (m_buffers[m_currentIdx].empty())
-        {
-            return;
-        }
-
-        flushIdx = m_currentIdx;
-        m_currentIdx ^= 1;
-    }
-
-    if (flushBuffer(m_buffers[flushIdx]))
-    {
-        m_buffers[flushIdx].clear();
+        m_logger(LOG_ERROR, std::string("PersistentQueue: Error submitting item to storage: ") + ex.what());
     }
 }
 
 std::vector<PersistedData> PersistentQueue::fetchAndMarkForSync()
 {
-    flushPendingBuffer();
-
     try
     {
         std::lock_guard<std::mutex> storageLock(m_storageMutex);
@@ -161,8 +66,6 @@ std::vector<PersistedData> PersistentQueue::fetchAndMarkForSync()
 
 std::vector<PersistedData> PersistentQueue::fetchPendingItems(bool onlyDataValues)
 {
-    flushPendingBuffer();
-
     try
     {
         std::lock_guard<std::mutex> storageLock(m_storageMutex);

--- a/src/shared_modules/sync_protocol/src/persistent_queue.cpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue.cpp
@@ -10,6 +10,18 @@
 #include "persistent_queue.hpp"
 #include "in_memory_queue_storage.hpp"
 
+namespace
+{
+    /// @brief Maximum number of distinct ids this queue will hold in the failed-item retry
+    ///        list at once. Bounds memory growth if the storage backend keeps failing (e.g.
+    ///        sustained memory pressure) -- once full, a brand-new failing id is dropped
+    ///        (logged) rather than retained, since retaining more under exactly the condition
+    ///        that is already causing failures would make things worse, not better. An id
+    ///        already present is always updated in place regardless of this cap, since that
+    ///        never grows the map.
+    constexpr size_t MAX_PENDING_RETRY_ITEMS = 1000U;
+} // namespace
+
 PersistentQueue::PersistentQueue(const std::string& dbPath, LoggerFunc logger, std::shared_ptr<IPersistentQueueStorage> storage)
     : m_storage(storage ? std::move(storage) : std::make_shared<InMemoryQueueStorage>(dbPath, logger)),
       m_logger(std::move(logger))
@@ -30,7 +42,53 @@ PersistentQueue::PersistentQueue(const std::string& dbPath, LoggerFunc logger, s
     }
 }
 
-PersistentQueue::~PersistentQueue() = default;
+PersistentQueue::~PersistentQueue()
+{
+    // Best-effort final drain: give anything still stuck in m_pendingRetry one last chance
+    // to actually land in m_storage before it's destroyed. Without this, an item that failed
+    // and was never retried again by a later submit()/fetchAndMarkForSync()/fetchPendingItems()
+    // call would be silently absent from InMemoryQueueStorage's shutdown snapshot -- lost even
+    // on a clean, graceful shutdown, not just a crash. Any failure here is logged and swallowed
+    // (there is no later point left to retry from), which is an accepted, disclosed loss on top
+    // of the already-accepted "ungraceful termination loses unsaved state" trade-off.
+    for (auto& [id, pending] : m_pendingRetry)
+    {
+        try
+        {
+            m_storage->submitOrCoalesce(pending);
+        }
+        // LCOV_EXCL_START
+        catch (const std::exception& ex)
+        {
+            m_logger(LOG_ERROR, std::string("PersistentQueue: A previously failed item is still failing on final shutdown drain, it will be lost: ") + ex.what());
+        }
+
+        // LCOV_EXCL_STOP
+    }
+}
+
+void PersistentQueue::drainPendingRetryLocked()
+{
+    // Caller must already hold m_storageMutex.
+    if (m_pendingRetry.empty())
+    {
+        return;
+    }
+
+    for (auto it = m_pendingRetry.begin(); it != m_pendingRetry.end();)
+    {
+        try
+        {
+            m_storage->submitOrCoalesce(it->second);
+            it = m_pendingRetry.erase(it);
+        }
+        catch (const std::exception& ex)
+        {
+            m_logger(LOG_WARNING, std::string("PersistentQueue: Retry of a previously failed item is still failing: ") + ex.what());
+            ++it;
+        }
+    }
+}
 
 void PersistentQueue::submit(const std::string& id,
                              const std::string& index,
@@ -41,31 +99,12 @@ void PersistentQueue::submit(const std::string& id,
 {
     std::lock_guard<std::mutex> storageLock(m_storageMutex);
 
-    // Opportunistically retry anything that failed on a previous submit() before handling
-    // the new item, so a transient storage failure does not silently and permanently lose
-    // an event. This replaces the old buffer/flush-thread-based retry that existed when
-    // submitBatch() on a background thread was the only write path -- with submit() now
-    // writing synchronously, retrying on the next call is the equivalent, simpler guarantee.
-    if (!m_pendingRetry.empty())
-    {
-        std::vector<PersistedData> stillPending;
-        stillPending.reserve(m_pendingRetry.size());
-
-        for (auto& pending : m_pendingRetry)
-        {
-            try
-            {
-                m_storage->submitOrCoalesce(pending);
-            }
-            catch (const std::exception& ex)
-            {
-                m_logger(LOG_WARNING, std::string("PersistentQueue: Retry of a previously failed item is still failing: ") + ex.what());
-                stillPending.push_back(std::move(pending));
-            }
-        }
-
-        m_pendingRetry = std::move(stillPending);
-    }
+    // Opportunistically retry anything that failed previously before handling the new item,
+    // so a transient storage failure does not silently and permanently lose an event. This
+    // replaces the old buffer/flush-thread-based retry that existed when submitBatch() on a
+    // background thread was the only write path -- with submit() now writing synchronously,
+    // retrying on the next call is the equivalent, simpler guarantee.
+    drainPendingRetryLocked();
 
     PersistedData newItem{0, id, index, data, operation, version, isDataContext};
 
@@ -75,8 +114,19 @@ void PersistentQueue::submit(const std::string& id,
     }
     catch (const std::exception& ex)
     {
-        m_logger(LOG_ERROR, std::string("PersistentQueue: Error submitting item to storage: ") + ex.what() + " (will retry on next submit())");
-        m_pendingRetry.push_back(std::move(newItem));
+        m_logger(LOG_ERROR, std::string("PersistentQueue: Error submitting item to storage: ") + ex.what() + " (will retry on next call)");
+
+        // An id already pending retry is always updated in place (never grows the map);
+        // only a brand-new failing id is subject to the capacity check below.
+        if (m_pendingRetry.find(id) == m_pendingRetry.end() && m_pendingRetry.size() >= MAX_PENDING_RETRY_ITEMS)
+        {
+            m_logger(LOG_ERROR,
+                     "PersistentQueue: Retry list is at capacity (" + std::to_string(MAX_PENDING_RETRY_ITEMS) +
+                     " ids); dropping failed item id=" + id + " instead of retaining it for retry.");
+            return;
+        }
+
+        m_pendingRetry[id] = std::move(newItem);
     }
 }
 
@@ -85,6 +135,13 @@ std::vector<PersistedData> PersistentQueue::fetchAndMarkForSync(size_t maxBytes)
     try
     {
         std::lock_guard<std::mutex> storageLock(m_storageMutex);
+
+        // Also drain here: AgentSyncProtocol's periodic sync cycle calls this on its own
+        // timer, independently of submit() -- without this, an item that failed and was
+        // never followed by another submit() call would sit in m_pendingRetry forever,
+        // invisible to every sync cycle even though the queue is otherwise being read
+        // regularly.
+        drainPendingRetryLocked();
         return m_storage->fetchAndMarkForSync(maxBytes);
     }
     catch (const std::exception& ex)
@@ -99,6 +156,7 @@ std::vector<PersistedData> PersistentQueue::fetchPendingItems(bool onlyDataValue
     try
     {
         std::lock_guard<std::mutex> storageLock(m_storageMutex);
+        drainPendingRetryLocked();
         return m_storage->fetchPending(onlyDataValues);
     }
     catch (const std::exception& ex)

--- a/src/shared_modules/sync_protocol/src/persistent_queue.hpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue.hpp
@@ -93,8 +93,10 @@ class PersistentQueue : public IPersistentQueue
 
         /// @brief Items that failed to persist on a previous call, keyed by id so repeated
         ///        failures (or a newer submit() for the same id arriving before the older
-        ///        failed attempt is retried) coalesce to just the latest attempt instead of
-        ///        accumulating stale duplicates. Retried opportunistically at the start of
+        ///        failed attempt is retried) coalesce instead of accumulating stale
+        ///        duplicates or being raw-overwritten -- a CREATE canceled by a later
+        ///        DELETE_ is dropped entirely rather than replayed as a lone DELETE_.
+        ///        Retried opportunistically at the start of
         ///        submit(), fetchAndMarkForSync(), and fetchPendingItems() -- i.e. every entry
         ///        point that touches m_storage, not just submit() -- so a transient storage
         ///        failure does not silently and permanently lose the event even if no further

--- a/src/shared_modules/sync_protocol/src/persistent_queue.hpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue.hpp
@@ -14,22 +14,16 @@
 #include "agent_sync_protocol_types.hpp"
 
 #include <string>
-#include <array>
-#include <map>
 #include <vector>
-#include <optional>
 #include <mutex>
-#include <condition_variable>
-#include <thread>
-#include <chrono>
 #include <memory>
-#include <atomic>
 
 /// @brief Implementation of IPersistentQueue with persistent storage backend.
 ///
 /// This class provides a module-scoped message queue.
 /// Messages are held in memory and synchronized with a storage backend
-/// implementing IPersistentQueueStorage (e.g., SQLite).
+/// implementing IPersistentQueueStorage — by default InMemoryQueueStorage, which itself
+/// only touches disk at construction (load) and destruction (save).
 ///
 /// Each module has its own queue and sequence counter, ensuring isolation and ordering.
 class PersistentQueue : public IPersistentQueue
@@ -87,47 +81,12 @@ class PersistentQueue : public IPersistentQueue
         void deleteDatabase() override;
 
     private:
-        /// @brief Maximum number of buffered events before triggering an immediate flush.
-        static constexpr std::size_t FLUSH_BATCH_SIZE = 100;
-
-        /// @brief Maximum time to wait before flushing a non-full buffer.
-        static constexpr std::chrono::milliseconds FLUSH_INTERVAL{500};
-
-        /// @brief Mutex protecting m_buffers.
-        std::mutex m_mutex;
-
         /// @brief Mutex serializing all m_storage access across threads.
         std::mutex m_storageMutex;
-
-        /// @brief Condition variable signalling the flush thread.
-        std::condition_variable m_cv;
-
-        /// @brief Double buffer (ping-pong): producers write to m_buffers[m_currentIdx],
-        ///        the flush thread swaps the index and drains the old slot.
-        std::array<std::vector<PersistedData>, 2> m_buffers;
-
-        /// @brief Index (0 or 1) of the buffer currently accepting new events.
-        std::size_t m_currentIdx{0};
-
-        /// @brief Background thread that drains m_buffers into storage.
-        std::thread m_flushThread;
-
-        /// @brief Set to true to request flush thread shutdown.
-        std::atomic<bool> m_stop{false};
 
         /// @brief Storage backend to persist and restore messages.
         std::shared_ptr<IPersistentQueueStorage> m_storage;
 
         /// @brief Logger function
         LoggerFunc m_logger;
-
-        /// @brief Main loop executed by m_flushThread.
-        void flushLoop();
-
-        /// @brief Writes a batch to storage in a single transaction.
-        /// @return true if the batch was persisted successfully, false otherwise.
-        bool flushBuffer(const std::vector<PersistedData>& batch);
-
-        /// @brief Steals any items currently in m_buffers and flushes them to storage.
-        void flushPendingBuffer();
 };

--- a/src/shared_modules/sync_protocol/src/persistent_queue.hpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue.hpp
@@ -33,7 +33,7 @@ class PersistentQueue : public IPersistentQueue
         /// @param dbPath Path to the SQLite database file for this protocol instance.
         /// @param logger Logger function
         /// @param storage Optional shared pointer to a custom storage backend.
-        ///                If null, a default PersistentQueueStorage is used.
+        ///                If null, a default InMemoryQueueStorage is used.
         explicit PersistentQueue(const std::string& dbPath, LoggerFunc logger, std::shared_ptr<IPersistentQueueStorage> storage = nullptr);
 
         /// @brief Destructor.
@@ -89,4 +89,10 @@ class PersistentQueue : public IPersistentQueue
 
         /// @brief Logger function
         LoggerFunc m_logger;
+
+        /// @brief Items that failed to persist on a previous submit() call. Retried
+        ///        opportunistically at the start of the next submit() before the new
+        ///        item is processed, so a transient storage failure does not silently
+        ///        and permanently lose the event.
+        std::vector<PersistedData> m_pendingRetry;
 };

--- a/src/shared_modules/sync_protocol/src/persistent_queue.hpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue.hpp
@@ -14,22 +14,16 @@
 #include "agent_sync_protocol_types.hpp"
 
 #include <string>
-#include <array>
-#include <map>
 #include <vector>
-#include <optional>
 #include <mutex>
-#include <condition_variable>
-#include <thread>
-#include <chrono>
 #include <memory>
-#include <atomic>
 
 /// @brief Implementation of IPersistentQueue with persistent storage backend.
 ///
 /// This class provides a module-scoped message queue.
 /// Messages are held in memory and synchronized with a storage backend
-/// implementing IPersistentQueueStorage (e.g., SQLite).
+/// implementing IPersistentQueueStorage — by default InMemoryQueueStorage, which itself
+/// only touches disk at construction (load) and destruction (save).
 ///
 /// Each module has its own queue and sequence counter, ensuring isolation and ordering.
 class PersistentQueue : public IPersistentQueue
@@ -86,47 +80,12 @@ class PersistentQueue : public IPersistentQueue
         void deleteDatabase() override;
 
     private:
-        /// @brief Maximum number of buffered events before triggering an immediate flush.
-        static constexpr std::size_t FLUSH_BATCH_SIZE = 100;
-
-        /// @brief Maximum time to wait before flushing a non-full buffer.
-        static constexpr std::chrono::milliseconds FLUSH_INTERVAL{500};
-
-        /// @brief Mutex protecting m_buffers.
-        std::mutex m_mutex;
-
         /// @brief Mutex serializing all m_storage access across threads.
         std::mutex m_storageMutex;
-
-        /// @brief Condition variable signalling the flush thread.
-        std::condition_variable m_cv;
-
-        /// @brief Double buffer (ping-pong): producers write to m_buffers[m_currentIdx],
-        ///        the flush thread swaps the index and drains the old slot.
-        std::array<std::vector<PersistedData>, 2> m_buffers;
-
-        /// @brief Index (0 or 1) of the buffer currently accepting new events.
-        std::size_t m_currentIdx{0};
-
-        /// @brief Background thread that drains m_buffers into storage.
-        std::thread m_flushThread;
-
-        /// @brief Set to true to request flush thread shutdown.
-        std::atomic<bool> m_stop{false};
 
         /// @brief Storage backend to persist and restore messages.
         std::shared_ptr<IPersistentQueueStorage> m_storage;
 
         /// @brief Logger function
         LoggerFunc m_logger;
-
-        /// @brief Main loop executed by m_flushThread.
-        void flushLoop();
-
-        /// @brief Writes a batch to storage in a single transaction.
-        /// @return true if the batch was persisted successfully, false otherwise.
-        bool flushBuffer(const std::vector<PersistedData>& batch);
-
-        /// @brief Steals any items currently in m_buffers and flushes them to storage.
-        void flushPendingBuffer();
 };

--- a/src/shared_modules/sync_protocol/src/persistent_queue.hpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue.hpp
@@ -17,6 +17,7 @@
 #include <vector>
 #include <mutex>
 #include <memory>
+#include <unordered_map>
 
 /// @brief Implementation of IPersistentQueue with persistent storage backend.
 ///
@@ -90,9 +91,19 @@ class PersistentQueue : public IPersistentQueue
         /// @brief Logger function
         LoggerFunc m_logger;
 
-        /// @brief Items that failed to persist on a previous submit() call. Retried
-        ///        opportunistically at the start of the next submit() before the new
-        ///        item is processed, so a transient storage failure does not silently
-        ///        and permanently lose the event.
-        std::vector<PersistedData> m_pendingRetry;
+        /// @brief Items that failed to persist on a previous call, keyed by id so repeated
+        ///        failures (or a newer submit() for the same id arriving before the older
+        ///        failed attempt is retried) coalesce to just the latest attempt instead of
+        ///        accumulating stale duplicates. Retried opportunistically at the start of
+        ///        submit(), fetchAndMarkForSync(), and fetchPendingItems() -- i.e. every entry
+        ///        point that touches m_storage, not just submit() -- so a transient storage
+        ///        failure does not silently and permanently lose the event even if no further
+        ///        submit() call for a different id ever happens. Also given one last
+        ///        best-effort drain attempt in the destructor, so a failed item that was never
+        ///        retried again is not additionally lost on an otherwise graceful shutdown.
+        std::unordered_map<std::string, PersistedData> m_pendingRetry;
+
+        /// @brief Retries every item in m_pendingRetry against m_storage, keeping only the
+        ///        ones that still fail. Caller must already hold m_storageMutex.
+        void drainPendingRetryLocked();
 };

--- a/src/shared_modules/sync_protocol/src/persistent_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue_storage.cpp
@@ -479,6 +479,88 @@ void PersistentQueueStorage::removeAllDataContext()
     // LCOV_EXCL_STOP
 }
 
+std::vector<QueueRow> PersistentQueueStorage::fetchAll()
+{
+    std::vector<QueueRow> result;
+
+    try
+    {
+        const std::string selectQuery =
+            "SELECT rowid, id, idx, data, operation, version, is_data_context, sync_status, create_status, operation_syncing "
+            "FROM persistent_queue "
+            "ORDER BY rowid ASC;";
+
+        SQLite3Wrapper::Statement selectStmt(m_connection, selectQuery);
+
+        while (selectStmt.step() == SQLITE_ROW)
+        {
+            QueueRow row;
+            row.rowId = static_cast<uint64_t>(selectStmt.value<int64_t>(0));
+            row.data.id = selectStmt.value<std::string>(1);
+            row.data.index = selectStmt.value<std::string>(2);
+            row.data.data = selectStmt.value<std::string>(3);
+            row.data.operation = static_cast<Operation>(selectStmt.value<int>(4));
+            row.data.version = static_cast<uint64_t>(selectStmt.value<int64_t>(5));
+            row.data.is_data_context = selectStmt.value<int>(6) != 0;
+            row.syncStatus = static_cast<SyncStatus>(selectStmt.value<int>(7));
+            row.createStatus = static_cast<CreateStatus>(selectStmt.value<int>(8));
+            row.operationSyncing = static_cast<Operation>(selectStmt.value<int>(9));
+
+            result.emplace_back(std::move(row));
+        }
+    }
+    // LCOV_EXCL_START
+    catch (const std::exception& e)
+    {
+        m_logger(LOG_ERROR, std::string("PersistentQueueStorage: Failed to fetch all items: ") + e.what());
+        throw;
+    }
+
+    // LCOV_EXCL_STOP
+
+    return result;
+}
+
+void PersistentQueueStorage::saveAll(const std::vector<QueueRow>& rows)
+{
+    m_connection.execute("BEGIN IMMEDIATE TRANSACTION;");
+
+    try
+    {
+        m_connection.execute("DELETE FROM persistent_queue;");
+
+        const std::string insertQuery =
+            "INSERT INTO persistent_queue (id, idx, data, operation, version, sync_status, create_status, operation_syncing, is_data_context) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);";
+
+        for (const auto& row : rows)
+        {
+            SQLite3Wrapper::Statement insertStmt(m_connection, insertQuery);
+            insertStmt.bind(1, row.data.id);
+            insertStmt.bind(2, row.data.index);
+            insertStmt.bind(3, row.data.data);
+            insertStmt.bind(4, static_cast<int>(row.data.operation));
+            insertStmt.bind(5, static_cast<int64_t>(row.data.version));
+            insertStmt.bind(6, static_cast<int>(row.syncStatus));
+            insertStmt.bind(7, static_cast<int>(row.createStatus));
+            insertStmt.bind(8, static_cast<int>(row.operationSyncing));
+            insertStmt.bind(9, row.data.is_data_context ? 1 : 0);
+            insertStmt.step();
+        }
+
+        m_connection.execute("COMMIT;");
+    }
+    // LCOV_EXCL_START
+    catch (const std::exception& e)
+    {
+        m_logger(LOG_ERROR, std::string("PersistentQueueStorage: Transaction failed in saveAll: ") + e.what());
+        m_connection.execute("ROLLBACK;");
+        throw;
+    }
+
+    // LCOV_EXCL_STOP
+}
+
 void PersistentQueueStorage::deleteDatabase()
 {
     try

--- a/src/shared_modules/sync_protocol/src/persistent_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue_storage.cpp
@@ -579,6 +579,88 @@ void PersistentQueueStorage::removeAllDataContext()
     // LCOV_EXCL_STOP
 }
 
+std::vector<QueueRow> PersistentQueueStorage::fetchAll()
+{
+    std::vector<QueueRow> result;
+
+    try
+    {
+        const std::string selectQuery =
+            "SELECT rowid, id, idx, data, operation, version, is_data_context, sync_status, create_status, operation_syncing "
+            "FROM persistent_queue "
+            "ORDER BY rowid ASC;";
+
+        SQLite3Wrapper::Statement selectStmt(m_connection, selectQuery);
+
+        while (selectStmt.step() == SQLITE_ROW)
+        {
+            QueueRow row;
+            row.rowId = static_cast<uint64_t>(selectStmt.value<int64_t>(0));
+            row.data.id = selectStmt.value<std::string>(1);
+            row.data.index = selectStmt.value<std::string>(2);
+            row.data.data = selectStmt.value<std::string>(3);
+            row.data.operation = static_cast<Operation>(selectStmt.value<int>(4));
+            row.data.version = static_cast<uint64_t>(selectStmt.value<int64_t>(5));
+            row.data.is_data_context = selectStmt.value<int>(6) != 0;
+            row.syncStatus = static_cast<SyncStatus>(selectStmt.value<int>(7));
+            row.createStatus = static_cast<CreateStatus>(selectStmt.value<int>(8));
+            row.operationSyncing = static_cast<Operation>(selectStmt.value<int>(9));
+
+            result.emplace_back(std::move(row));
+        }
+    }
+    // LCOV_EXCL_START
+    catch (const std::exception& e)
+    {
+        m_logger(LOG_ERROR, std::string("PersistentQueueStorage: Failed to fetch all items: ") + e.what());
+        throw;
+    }
+
+    // LCOV_EXCL_STOP
+
+    return result;
+}
+
+void PersistentQueueStorage::saveAll(const std::vector<QueueRow>& rows)
+{
+    m_connection.execute("BEGIN IMMEDIATE TRANSACTION;");
+
+    try
+    {
+        m_connection.execute("DELETE FROM persistent_queue;");
+
+        const std::string insertQuery =
+            "INSERT INTO persistent_queue (id, idx, data, operation, version, sync_status, create_status, operation_syncing, is_data_context) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);";
+
+        for (const auto& row : rows)
+        {
+            SQLite3Wrapper::Statement insertStmt(m_connection, insertQuery);
+            insertStmt.bind(1, row.data.id);
+            insertStmt.bind(2, row.data.index);
+            insertStmt.bind(3, row.data.data);
+            insertStmt.bind(4, static_cast<int>(row.data.operation));
+            insertStmt.bind(5, static_cast<int64_t>(row.data.version));
+            insertStmt.bind(6, static_cast<int>(row.syncStatus));
+            insertStmt.bind(7, static_cast<int>(row.createStatus));
+            insertStmt.bind(8, static_cast<int>(row.operationSyncing));
+            insertStmt.bind(9, row.data.is_data_context ? 1 : 0);
+            insertStmt.step();
+        }
+
+        m_connection.execute("COMMIT;");
+    }
+    // LCOV_EXCL_START
+    catch (const std::exception& e)
+    {
+        m_logger(LOG_ERROR, std::string("PersistentQueueStorage: Transaction failed in saveAll: ") + e.what());
+        m_connection.execute("ROLLBACK;");
+        throw;
+    }
+
+    // LCOV_EXCL_STOP
+}
+
 void PersistentQueueStorage::deleteDatabase()
 {
     try

--- a/src/shared_modules/sync_protocol/src/persistent_queue_storage.hpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue_storage.hpp
@@ -14,22 +14,6 @@
 #include "agent_sync_protocol_types.hpp"
 #include "ifilesystem_wrapper.hpp"
 
-/// @brief Defines the synchronization status of a persisted message.
-enum class SyncStatus : int
-{
-    PENDING = 0,        ///< The message is waiting to be synchronized.
-    SYNCING = 1,        ///< The message is currently being synchronized.
-    SYNCING_UPDATED = 2 ///< The message is being synchronized and its contents have been updated.
-};
-
-/// @brief Tracks the creation state of a persisted message, particularly for newly created items.
-enum class CreateStatus : int
-{
-    EXISTING = 0,     ///< The message existed prior to the current session; it was not newly created.
-    NEW = 1,          ///< The message was newly created during the current session.
-    NEW_DELETED = 2   ///< The message was newly created, but then deleted before it could be synchronized.
-};
-
 /// @brief SQLite-backed implementation of IPersistentQueueStorage.
 ///
 /// Persists module messages into a local SQLite database file.
@@ -83,6 +67,14 @@ class PersistentQueueStorage : public IPersistentQueueStorage
         /// @brief Deletes the database file.
         /// This method closes the database connection and removes the database file from disk.
         void deleteDatabase() override;
+
+        /// @brief Fetches every row regardless of status, including internal coalescing state.
+        /// @return All rows in insertion (rowid) order.
+        std::vector<QueueRow> fetchAll() override;
+
+        /// @brief Replaces the entire contents of the table with the given rows, in one transaction.
+        /// @param rows The complete set of rows to persist, in insertion order.
+        void saveAll(const std::vector<QueueRow>& rows) override;
 
     private:
         /// @brief Active SQLite database connection.

--- a/src/shared_modules/sync_protocol/src/persistent_queue_storage.hpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue_storage.hpp
@@ -14,22 +14,6 @@
 #include "agent_sync_protocol_types.hpp"
 #include "ifilesystem_wrapper.hpp"
 
-/// @brief Defines the synchronization status of a persisted message.
-enum class SyncStatus : int
-{
-    PENDING = 0,        ///< The message is waiting to be synchronized.
-    SYNCING = 1,        ///< The message is currently being synchronized.
-    SYNCING_UPDATED = 2 ///< The message is being synchronized and its contents have been updated.
-};
-
-/// @brief Tracks the creation state of a persisted message, particularly for newly created items.
-enum class CreateStatus : int
-{
-    EXISTING = 0,     ///< The message existed prior to the current session; it was not newly created.
-    NEW = 1,          ///< The message was newly created during the current session.
-    NEW_DELETED = 2   ///< The message was newly created, but then deleted before it could be synchronized.
-};
-
 /// @brief SQLite-backed implementation of IPersistentQueueStorage.
 ///
 /// Persists module messages into a local SQLite database file.
@@ -84,6 +68,14 @@ class PersistentQueueStorage : public IPersistentQueueStorage
         /// @brief Deletes the database file.
         /// This method closes the database connection and removes the database file from disk.
         void deleteDatabase() override;
+
+        /// @brief Fetches every row regardless of status, including internal coalescing state.
+        /// @return All rows in insertion (rowid) order.
+        std::vector<QueueRow> fetchAll() override;
+
+        /// @brief Replaces the entire contents of the table with the given rows, in one transaction.
+        /// @param rows The complete set of rows to persist, in insertion order.
+        void saveAll(const std::vector<QueueRow>& rows) override;
 
     private:
         /// @brief Active SQLite database connection.

--- a/src/shared_modules/sync_protocol/tests/CMakeLists.txt
+++ b/src/shared_modules/sync_protocol/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ link_directories(${CMAKE_BINARY_DIR}/lib/)
 set(TEST_SOURCES
     main.cpp
     test_persistent_queue_storage.cpp
+    test_in_memory_queue_storage.cpp
     test_persistent_queue.cpp
     test_agent_sync_protocol_datacontext.cpp
     test_sync_protocol_integration.cpp

--- a/src/shared_modules/sync_protocol/tests/test_in_memory_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_in_memory_queue_storage.cpp
@@ -695,3 +695,26 @@ TEST(InMemoryQueueStorageCapacityTest, CoalescedUpdatesDoNotLeakIntoTheByteBudge
     EXPECT_TRUE(sameIdPresent);
     EXPECT_TRUE(newIdPresent);
 }
+
+TEST(InMemoryQueueStorageCapacityTest, SubmitBatchRollsBackFullyOnMidBatchFailure)
+{
+    // submitBatch() must persist atomically: a mid-batch failure must not leave earlier
+    // items in the batch applied.
+    InMemoryQueueStorage storage(":memory:", silentLogger());
+
+    // Bigger than the whole queue byte cap alone, so it's rejected no matter how much room
+    // the first two items left.
+    const std::string oversizedPayload(9 * 1024 * 1024, 'x');
+
+    const std::vector<PersistedData> batch =
+    {
+        PersistedData{0, "id1", "idx", "{}", Operation::CREATE, 1},
+        PersistedData{0, "id2", "idx", "{}", Operation::CREATE, 1},
+        PersistedData{0, "id3", "idx", oversizedPayload, Operation::CREATE, 1},
+    };
+
+    EXPECT_THROW(storage.submitBatch(batch), std::runtime_error);
+
+    // Nothing remains -- not even "id1"/"id2", applied before "id3" triggered the rejection.
+    EXPECT_TRUE(storage.fetchAll().empty());
+}

--- a/src/shared_modules/sync_protocol/tests/test_in_memory_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_in_memory_queue_storage.cpp
@@ -696,6 +696,59 @@ TEST(InMemoryQueueStorageCapacityTest, CoalescedUpdatesDoNotLeakIntoTheByteBudge
     EXPECT_TRUE(newIdPresent);
 }
 
+TEST(InMemoryQueueStorageCapacityTest, RejectsCoalescedUpdateThatWouldGrowTrackedItemPastCapacity)
+{
+    // The cap must also apply when an already-tracked id grows, not just to brand-new ids.
+    InMemoryQueueStorage storage(":memory:", silentLogger());
+
+    const std::string largePayload(4096, 'x');
+
+    // Fill the queue with distinct ids up to just under the cap.
+    int lastAcceptedIndex = -1;
+
+    for (int i = 0; i < 3000; ++i)
+    {
+        try
+        {
+            storage.submitOrCoalesce(PersistedData{0, "id" + std::to_string(i), "idx", largePayload, Operation::CREATE, 1});
+            lastAcceptedIndex = i;
+        }
+        catch (const std::exception&)
+        {
+            break;
+        }
+    }
+
+    ASSERT_GE(lastAcceptedIndex, 0) << "Test setup expected at least one item to fit before the cap";
+
+    const std::string trackedId = "id" + std::to_string(lastAcceptedIndex);
+    const auto rowsBeforeGrowth = storage.fetchAll();
+    const auto originalRow = std::find_if(rowsBeforeGrowth.begin(), rowsBeforeGrowth.end(),
+                                          [&](const QueueRow & row)
+    {
+        return row.data.id == trackedId;
+    });
+    ASSERT_NE(originalRow, rowsBeforeGrowth.end());
+
+    // Re-submit that same, already-tracked id with a much bigger payload: this must be
+    // rejected exactly like a brand-new id would be once the cap is reached.
+    const std::string oversizedPayload(2 * 1024 * 1024, 'y');
+    EXPECT_THROW(
+        storage.submitOrCoalesce(PersistedData{0, trackedId, "idx", oversizedPayload, Operation::MODIFY, 2}),
+        std::runtime_error);
+
+    // The rejected update must leave the tracked item exactly as it was, not partially applied.
+    const auto rowsAfterRejection = storage.fetchAll();
+    const auto rowAfterRejection = std::find_if(rowsAfterRejection.begin(), rowsAfterRejection.end(),
+                                                [&](const QueueRow & row)
+    {
+        return row.data.id == trackedId;
+    });
+    ASSERT_NE(rowAfterRejection, rowsAfterRejection.end());
+    EXPECT_EQ(rowAfterRejection->data.data, originalRow->data.data);
+    EXPECT_EQ(rowAfterRejection->data.version, originalRow->data.version);
+}
+
 TEST(InMemoryQueueStorageCapacityTest, SubmitBatchRollsBackFullyOnMidBatchFailure)
 {
     // submitBatch() must persist atomically: a mid-batch failure must not leave earlier

--- a/src/shared_modules/sync_protocol/tests/test_in_memory_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_in_memory_queue_storage.cpp
@@ -620,29 +620,78 @@ TEST_F(InMemoryQueueStorageRoundTripTest, LoadsASnapshotWrittenDirectlyByPersist
     EXPECT_EQ(pending[0].id, "id1");
 }
 
-TEST(InMemoryQueueStorageCapacityTest, RejectsNewItemsPastQueueCapacityWithoutEvictingExisting)
+TEST(InMemoryQueueStorageCapacityTest, RejectsNewItemsPastQueueByteCapacityWithoutEvictingExisting)
 {
-    // Bounds RSS growth when the sync peer is unreachable for an extended period: once at
-    // capacity, a brand-new (never-seen) id is rejected rather than evicting already-queued
-    // state. The exact cap is an internal implementation detail (not exposed via the
-    // header), so this only checks the boundary behavior, not the specific limit value.
+    // Bounds RSS growth when the sync peer is unreachable for an extended period: once the
+    // estimated total size of the queue is at capacity, a brand-new (never-seen) id is
+    // rejected -- by throwing, not silently returning, so a caller (e.g.
+    // PersistentQueue::submit()) can tell the difference from success and retain the item
+    // for retry -- rather than evicting already-queued state. The exact byte cap is an
+    // internal implementation detail (not exposed via the header), so this only checks the
+    // boundary behavior, not the specific limit value -- each item carries a large enough
+    // payload, and enough of them are submitted, to comfortably exceed any plausible cap.
     InMemoryQueueStorage storage(":memory:", silentLogger());
 
-    // Fill well past any plausible cap.
-    for (int i = 0; i < 10001; ++i)
+    const std::string largePayload(4096, 'x');
+
+    // Fill up to well past any plausible cap, expecting the first throw to mark where the
+    // real limit was hit. 3000 items * (~4096 payload + ~512 overhead) bytes is well past
+    // any plausible byte cap.
+    size_t acceptedCount = 0;
+    bool threwOnce = false;
+
+    for (int i = 0; i < 3000; ++i)
     {
-        storage.submitOrCoalesce(PersistedData{0, "id" + std::to_string(i), "idx", "{}", Operation::CREATE, 1});
+        try
+        {
+            storage.submitOrCoalesce(PersistedData{0, "id" + std::to_string(i), "idx", largePayload, Operation::CREATE, 1});
+            ++acceptedCount;
+        }
+        catch (const std::exception&)
+        {
+            threwOnce = true;
+        }
     }
+
+    EXPECT_TRUE(threwOnce) << "Expected at least one rejection once the cap was reached";
 
     const auto rows = storage.fetchAll();
 
-    // The row count must have actually been capped -- not every one of the 10001 submitted
-    // items made it in.
-    EXPECT_LT(rows.size(), static_cast<size_t>(10001));
+    // The row count must match exactly how many submissions were actually accepted -- not
+    // every one of the 3000 attempted submissions made it in.
+    EXPECT_LT(rows.size(), static_cast<size_t>(3000));
+    EXPECT_EQ(rows.size(), acceptedCount);
 
     // The very first item submitted must still be present: capacity enforcement rejects
     // new arrivals once full, it does not evict already-queued state to make room.
     const bool firstItemStillPresent = std::any_of(rows.begin(), rows.end(),
                                                     [](const QueueRow & row) { return row.data.id == "id0"; });
     EXPECT_TRUE(firstItemStillPresent);
+}
+
+TEST(InMemoryQueueStorageCapacityTest, CoalescedUpdatesDoNotLeakIntoTheByteBudget)
+{
+    // Repeated updates to the SAME id must not each add to the running byte total -- only
+    // net queue content should count against the cap, otherwise a single hot id could
+    // eventually exhaust the whole budget on its own via in-place updates.
+    InMemoryQueueStorage storage(":memory:", silentLogger());
+
+    const std::string largePayload(4096, 'x');
+
+    for (int i = 0; i < 5000; ++i)
+    {
+        storage.submitOrCoalesce(PersistedData{0, "same-id", "idx", largePayload, Operation::MODIFY, static_cast<uint64_t>(i)});
+    }
+
+    // A single coalesced id, however many times it was updated, must never itself be
+    // rejected by the capacity check, and a fresh, distinct id must still fit right after.
+    storage.submitOrCoalesce(PersistedData{0, "brand-new-id", "idx", "{}", Operation::CREATE, 1});
+
+    const auto rows = storage.fetchAll();
+    const bool sameIdPresent = std::any_of(rows.begin(), rows.end(),
+                                            [](const QueueRow & row) { return row.data.id == "same-id"; });
+    const bool newIdPresent = std::any_of(rows.begin(), rows.end(),
+                                           [](const QueueRow & row) { return row.data.id == "brand-new-id"; });
+    EXPECT_TRUE(sameIdPresent);
+    EXPECT_TRUE(newIdPresent);
 }

--- a/src/shared_modules/sync_protocol/tests/test_in_memory_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_in_memory_queue_storage.cpp
@@ -619,3 +619,30 @@ TEST_F(InMemoryQueueStorageRoundTripTest, LoadsASnapshotWrittenDirectlyByPersist
     ASSERT_EQ(pending.size(), static_cast<size_t>(1));
     EXPECT_EQ(pending[0].id, "id1");
 }
+
+TEST(InMemoryQueueStorageCapacityTest, RejectsNewItemsPastQueueCapacityWithoutEvictingExisting)
+{
+    // Bounds RSS growth when the sync peer is unreachable for an extended period: once at
+    // capacity, a brand-new (never-seen) id is rejected rather than evicting already-queued
+    // state. The exact cap is an internal implementation detail (not exposed via the
+    // header), so this only checks the boundary behavior, not the specific limit value.
+    InMemoryQueueStorage storage(":memory:", silentLogger());
+
+    // Fill well past any plausible cap.
+    for (int i = 0; i < 10001; ++i)
+    {
+        storage.submitOrCoalesce(PersistedData{0, "id" + std::to_string(i), "idx", "{}", Operation::CREATE, 1});
+    }
+
+    const auto rows = storage.fetchAll();
+
+    // The row count must have actually been capped -- not every one of the 10001 submitted
+    // items made it in.
+    EXPECT_LT(rows.size(), static_cast<size_t>(10001));
+
+    // The very first item submitted must still be present: capacity enforcement rejects
+    // new arrivals once full, it does not evict already-queued state to make room.
+    const bool firstItemStillPresent = std::any_of(rows.begin(), rows.end(),
+                                                    [](const QueueRow & row) { return row.data.id == "id0"; });
+    EXPECT_TRUE(firstItemStillPresent);
+}

--- a/src/shared_modules/sync_protocol/tests/test_in_memory_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_in_memory_queue_storage.cpp
@@ -1,0 +1,621 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "in_memory_queue_storage.hpp"
+#include "persistent_queue_storage.hpp"
+#include "mock_filesystem_wrapper.hpp"
+#include <memory>
+#include <filesystem>
+#include <algorithm>
+
+namespace
+{
+    LoggerFunc silentLogger()
+    {
+        return [](modules_log_level_t /*level*/, const std::string& /*msg*/) {};
+    }
+
+    // Unique per-test path (keyed by the running test's name) so that InMemoryQueueStorage's
+    // save-on-destruct behavior in one test can never leak a snapshot into the next test
+    // that happens to reuse the same literal path.
+    std::string tempDbPath(const std::string& name)
+    {
+        const auto* testInfo = ::testing::UnitTest::GetInstance()->current_test_info();
+        const std::string suffix = testInfo ? std::string(testInfo->test_suite_name()) + "_" + testInfo->name() : "";
+        return (std::filesystem::temp_directory_path() / (suffix + "_" + name)).string();
+    }
+}
+
+// ========================================
+// Coalescing logic: same scenarios as PersistentQueueStorage, since both backends
+// must implement identical semantics.
+// ========================================
+
+struct QueueScenario
+{
+    std::string name;
+    std::vector<PersistedData> initial;
+    bool doFetchAndSync;
+    std::vector<PersistedData> eventsInSync;
+    bool removeSynced;
+    bool resetSyncing;
+    size_t expectedRows;
+    Operation expectedOp;
+};
+
+inline void PrintTo(const QueueScenario& q, std::ostream* os)
+{
+    *os << q.name;
+}
+
+class InMemoryQueueFullParamTest : public ::testing::TestWithParam<QueueScenario>
+{
+    protected:
+        std::string dbPath;
+        std::unique_ptr<InMemoryQueueStorage> storage;
+
+        void SetUp() override
+        {
+            dbPath = tempDbPath("in_memory_queue_param_test.db");
+            std::filesystem::remove(dbPath);
+            storage = std::make_unique<InMemoryQueueStorage>(dbPath, silentLogger());
+        }
+
+        void TearDown() override
+        {
+            storage.reset();
+            std::filesystem::remove(dbPath);
+        }
+};
+
+TEST_P(InMemoryQueueFullParamTest, HandlesSubmitFetchRemoveResetCorrectly)
+{
+    auto param = GetParam();
+
+    for (auto& ev : param.initial)
+    {
+        storage->submitOrCoalesce(ev);
+    }
+
+    if (param.doFetchAndSync)
+    {
+        storage->fetchAndMarkForSync();
+
+        for (auto& evs : param.eventsInSync)
+        {
+            storage->submitOrCoalesce(evs);
+        }
+    }
+
+    if (param.removeSynced)
+    {
+        storage->removeAllSynced();
+    }
+
+    if (param.resetSyncing)
+    {
+        storage->resetAllSyncing();
+    }
+
+    auto rows = storage->fetchAndMarkForSync();
+    EXPECT_EQ(rows.size(), param.expectedRows);
+
+    if (!rows.empty())
+    {
+        EXPECT_EQ(rows[0].operation, param.expectedOp);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    FullQueueCases,
+    InMemoryQueueFullParamTest,
+    ::testing::Values(
+        QueueScenario
+{
+    "Case 1", { PersistedData{0, "id1", "idx", "{}", Operation::CREATE, 0} },
+    false, {}, false, false, 1, Operation::CREATE
+},
+QueueScenario
+{
+    "Case 2",
+    {
+        PersistedData{0, "id1", "idx", "{}", Operation::CREATE, 0},
+        PersistedData{0, "id1", "idx2", "{}", Operation::MODIFY, 0}
+    },
+    false, {}, false, false, 1, Operation::MODIFY
+},
+QueueScenario
+{
+    "Case 3",
+    {
+        PersistedData{0, "id1", "idx", "{}", Operation::CREATE, 0},
+        PersistedData{0, "id1", "idx", "{}", Operation::DELETE_, 0}
+    },
+    false, {}, false, false, 0, Operation::CREATE
+},
+QueueScenario
+{
+    "Case 4",
+    {
+        PersistedData{0, "id1", "idx", "{}", Operation::MODIFY, 0},
+        PersistedData{0, "id1", "idx", "{}", Operation::DELETE_, 0}
+    },
+    false, {}, false, false, 1, Operation::DELETE_
+},
+QueueScenario
+{
+    "Case 5", { PersistedData{0, "id1", "idx", "{}", Operation::DELETE_, 0} },
+    false, {}, false, false, 1, Operation::DELETE_
+},
+QueueScenario
+{
+    "Case 6",
+    { PersistedData{0, "id1", "idx", "{}", Operation::CREATE, 0} },
+    true,
+    { PersistedData{0, "id1", "idx2", "{}", Operation::MODIFY, 0} },
+    true, false, 1, Operation::MODIFY
+},
+QueueScenario
+{
+    "Case 7",
+    { PersistedData{0, "id1", "idx", "{}", Operation::CREATE, 0} },
+    true,
+    { PersistedData{0, "id1", "idx", "{}", Operation::DELETE_, 0} },
+    true, false, 1, Operation::DELETE_
+},
+QueueScenario
+{
+    "Case 8",
+    { PersistedData{0, "id1", "idx", "{}", Operation::CREATE, 0} },
+    true,
+    { PersistedData{0, "id1", "idx", "{}", Operation::DELETE_, 0} },
+    false, true, 0, Operation::DELETE_
+},
+QueueScenario
+{
+    "Case 9",
+    { PersistedData{0, "id1", "idx", "{}", Operation::CREATE, 0} },
+    true,
+    { PersistedData{0, "id1", "idx2", "{}", Operation::MODIFY, 0} },
+    false, true, 1, Operation::MODIFY
+},
+QueueScenario
+{
+    "Case 10",
+    {
+        PersistedData{0, "id1", "idx", "{}", Operation::DELETE_, 0},
+        PersistedData{0, "id1", "idx2", "{}", Operation::MODIFY, 0}
+    },
+    false, {}, false, false, 1, Operation::MODIFY
+},
+QueueScenario
+{
+    "Case 11",
+    { PersistedData{0, "id1", "idx", "{}", Operation::CREATE, 0} },
+    true, {}, true, false, 0, Operation::CREATE
+},
+QueueScenario
+{
+    "Case 12",
+    {
+        PersistedData{0, "id1", "idx", "{}", Operation::MODIFY, 0},
+        PersistedData{0, "id1", "idx2", "{}", Operation::MODIFY, 0},
+    },
+    false, {}, false, false, 1, Operation::MODIFY
+},
+QueueScenario
+{
+    "Case 13",
+    {
+        PersistedData{0, "id1", "idx", "{}", Operation::CREATE, 0},
+        PersistedData{0, "id2", "idx", "{}", Operation::MODIFY, 0}
+    },
+    false, {}, false, false, 2, Operation::CREATE
+},
+QueueScenario
+{
+    "Case 14",
+    { PersistedData{0, "id1", "idx", "{}", Operation::MODIFY, 0} },
+    true,
+    {
+        PersistedData{0, "id1", "idx", "{}", Operation::DELETE_, 0},
+        PersistedData{0, "id1", "idx", "{}", Operation::CREATE, 0},
+        PersistedData{0, "id1", "idx", "{}", Operation::DELETE_, 0}
+    },
+    false, true, 1, Operation::DELETE_
+},
+QueueScenario
+{
+    "Case 15",
+    {
+        PersistedData{0, "id1", "idx", "{}", Operation::CREATE, 0},
+        PersistedData{0, "id1", "idx", "{}", Operation::DELETE_, 0},
+        PersistedData{0, "id1", "idx2", "{}", Operation::CREATE, 0}
+    },
+    false, {}, false, false, 1, Operation::CREATE
+},
+QueueScenario
+{
+    "Case 16",
+    { PersistedData{0, "id1", "idx", "{}", Operation::CREATE, 0} },
+    true,
+    {
+        PersistedData{0, "id1", "idx2", "{}", Operation::MODIFY, 0},
+        PersistedData{0, "id1", "idx", "{}", Operation::DELETE_, 0},
+        PersistedData{0, "id1", "idx3", "{}", Operation::MODIFY, 0}
+    },
+    true, false, 1, Operation::MODIFY
+},
+QueueScenario
+{
+    "Case 17",
+    { PersistedData{0, "id1", "idx", "{}", Operation::CREATE, 0} },
+    true,
+    {
+        PersistedData{0, "id1", "idx", "{}", Operation::DELETE_, 0},
+        PersistedData{0, "id1", "idx2", "{}", Operation::CREATE, 0}
+    },
+    false, true, 1, Operation::CREATE
+}
+    )
+);
+
+// ========================================
+// removeByIndex
+// ========================================
+
+class InMemoryQueueStorageTest : public ::testing::Test
+{
+    protected:
+        std::string dbPath;
+        std::unique_ptr<InMemoryQueueStorage> storage;
+
+        void SetUp() override
+        {
+            dbPath = tempDbPath("in_memory_queue_basic_test.db");
+            std::filesystem::remove(dbPath);
+            storage = std::make_unique<InMemoryQueueStorage>(dbPath, silentLogger());
+        }
+
+        void TearDown() override
+        {
+            storage.reset();
+            std::filesystem::remove(dbPath);
+        }
+};
+
+TEST_F(InMemoryQueueStorageTest, RemoveByIndexDeletesOnlySpecifiedIndex)
+{
+    storage->submitOrCoalesce(PersistedData{0, "id1", "index1", "{}", Operation::CREATE, 0});
+    storage->submitOrCoalesce(PersistedData{0, "id2", "index2", "{}", Operation::CREATE, 0});
+    storage->submitOrCoalesce(PersistedData{0, "id3", "index1", "{}", Operation::MODIFY, 0});
+    storage->submitOrCoalesce(PersistedData{0, "id4", "index3", "{}", Operation::CREATE, 0});
+
+    auto allItems = storage->fetchAndMarkForSync();
+    EXPECT_EQ(allItems.size(), static_cast<size_t>(4));
+
+    storage->resetAllSyncing();
+    storage->removeByIndex("index1");
+
+    auto remainingItems = storage->fetchAndMarkForSync();
+    EXPECT_EQ(remainingItems.size(), static_cast<size_t>(2));
+
+    for (const auto& item : remainingItems)
+    {
+        EXPECT_NE(item.index, "index1");
+    }
+}
+
+TEST_F(InMemoryQueueStorageTest, RemoveByIndexHandlesNonExistentIndex)
+{
+    storage->submitOrCoalesce(PersistedData{0, "id1", "index1", "{}", Operation::CREATE, 1});
+    storage->submitOrCoalesce(PersistedData{0, "id2", "index2", "{}", Operation::CREATE, 1});
+
+    EXPECT_NO_THROW(storage->removeByIndex("non_existent_index"));
+
+    auto allItems = storage->fetchAndMarkForSync();
+    EXPECT_EQ(allItems.size(), static_cast<size_t>(2));
+}
+
+TEST_F(InMemoryQueueStorageTest, RemoveByIndexHandlesEmptyStorage)
+{
+    EXPECT_NO_THROW(storage->removeByIndex("any_index"));
+
+    auto allItems = storage->fetchAndMarkForSync();
+    EXPECT_EQ(allItems.size(), static_cast<size_t>(0));
+}
+
+TEST_F(InMemoryQueueStorageTest, RemoveAllDataContextRemovesOnlyDataContextItems)
+{
+    storage->submitOrCoalesce(PersistedData{0, "id1", "idx", "{}", Operation::CREATE, 0, false});
+    storage->submitOrCoalesce(PersistedData{0, "id2", "idx", "{}", Operation::CREATE, 0, true});
+
+    storage->removeAllDataContext();
+
+    auto remaining = storage->fetchPending(false);
+    ASSERT_EQ(remaining.size(), static_cast<size_t>(1));
+    EXPECT_EQ(remaining[0].id, "id1");
+}
+
+TEST_F(InMemoryQueueStorageTest, FetchPendingOnlyDataValuesFiltersDataContext)
+{
+    storage->submitOrCoalesce(PersistedData{0, "value1", "idx", "{}", Operation::CREATE, 0, false});
+    storage->submitOrCoalesce(PersistedData{0, "context1", "idx", "{}", Operation::CREATE, 0, true});
+
+    auto onlyValues = storage->fetchPending(true);
+    ASSERT_EQ(onlyValues.size(), static_cast<size_t>(1));
+    EXPECT_EQ(onlyValues[0].id, "value1");
+
+    auto everything = storage->fetchPending(false);
+    EXPECT_EQ(everything.size(), static_cast<size_t>(2));
+}
+
+TEST_F(InMemoryQueueStorageTest, FetchAndMarkForSyncMarksRowsSyncing)
+{
+    storage->submitOrCoalesce(PersistedData{0, "id1", "idx", "{}", Operation::CREATE, 0});
+
+    auto firstFetch = storage->fetchAndMarkForSync();
+    ASSERT_EQ(firstFetch.size(), static_cast<size_t>(1));
+
+    // Rows already marked SYNCING must not appear again until reset/cleared.
+    auto secondFetch = storage->fetchAndMarkForSync();
+    EXPECT_TRUE(secondFetch.empty());
+}
+
+TEST_F(InMemoryQueueStorageTest, SubmitBatchAppliesCoalesceLogicForEachItem)
+{
+    std::vector<PersistedData> batch =
+    {
+        PersistedData{0, "id1", "idx1", "{}", Operation::CREATE, 1},
+        PersistedData{0, "id2", "idx2", "{}", Operation::CREATE, 1},
+        PersistedData{0, "id1", "idx1", "{updated}", Operation::MODIFY, 2}
+    };
+
+    storage->submitBatch(batch);
+
+    auto rows = storage->fetchAndMarkForSync();
+    ASSERT_EQ(rows.size(), static_cast<size_t>(2));
+
+    const auto id1 = std::find_if(rows.begin(), rows.end(), [](const PersistedData& d) { return d.id == "id1"; });
+    ASSERT_NE(id1, rows.end());
+    EXPECT_EQ(id1->operation, Operation::MODIFY);
+}
+
+TEST_F(InMemoryQueueStorageTest, SubmitBatchWithEmptyBatchIsANoOp)
+{
+    EXPECT_NO_THROW(storage->submitBatch({}));
+
+    auto rows = storage->fetchAndMarkForSync();
+    EXPECT_TRUE(rows.empty());
+}
+
+TEST_F(InMemoryQueueStorageTest, FetchAllReturnsEveryRowRegardlessOfStatus)
+{
+    storage->submitOrCoalesce(PersistedData{0, "id1", "idx", "{}", Operation::CREATE, 1});
+    storage->submitOrCoalesce(PersistedData{0, "id2", "idx", "{}", Operation::CREATE, 1});
+    storage->fetchAndMarkForSync(); // marks both SYNCING
+
+    auto rows = storage->fetchAll();
+    ASSERT_EQ(rows.size(), static_cast<size_t>(2));
+
+    for (const auto& row : rows)
+    {
+        EXPECT_EQ(row.syncStatus, SyncStatus::SYNCING);
+    }
+}
+
+TEST_F(InMemoryQueueStorageTest, SaveAllReplacesExistingRowsWithGivenSet)
+{
+    storage->submitOrCoalesce(PersistedData{0, "old", "idx", "{}", Operation::CREATE, 1});
+
+    QueueRow replacement;
+    replacement.data = PersistedData{0, "new", "idx", "{}", Operation::CREATE, 1};
+    replacement.syncStatus = SyncStatus::PENDING;
+    storage->saveAll({replacement});
+
+    auto rows = storage->fetchPending(false);
+    ASSERT_EQ(rows.size(), static_cast<size_t>(1));
+    EXPECT_EQ(rows[0].id, "new");
+}
+
+TEST(InMemoryQueueStorageConstructorTest, ThrowsWhenLoggerIsNull)
+{
+    LoggerFunc nullLogger = nullptr;
+    EXPECT_THROW(InMemoryQueueStorage("fake_path_for_null_logger_test.db", nullLogger), std::invalid_argument);
+}
+
+// ========================================
+// deleteDatabase
+// ========================================
+
+class InMemoryQueueStorageDeleteDatabaseTest : public ::testing::Test
+{
+    protected:
+        std::shared_ptr<MockFileSystemWrapper> mockFileSystemWrapper;
+        std::unique_ptr<InMemoryQueueStorage> storage;
+
+        void SetUp() override
+        {
+            mockFileSystemWrapper = std::make_shared<MockFileSystemWrapper>();
+            // Constructor-time loadFromDisk() checks existence once; default to "no snapshot"
+            // for tests that don't care about the load path, then set explicit expectations
+            // for deleteDatabase() itself below.
+            EXPECT_CALL(*mockFileSystemWrapper, exists(::testing::_)).WillOnce(::testing::Return(false));
+            storage = std::make_unique<InMemoryQueueStorage>("fake_path.db", silentLogger(), mockFileSystemWrapper);
+        }
+
+        void TearDown() override
+        {
+            storage.reset();
+            mockFileSystemWrapper.reset();
+        }
+};
+
+TEST_F(InMemoryQueueStorageDeleteDatabaseTest, DeleteDatabaseWhenFileExists)
+{
+    using ::testing::Return;
+    using ::testing::_;
+
+    EXPECT_CALL(*mockFileSystemWrapper, exists(_)).WillOnce(Return(true));
+    EXPECT_CALL(*mockFileSystemWrapper, remove(_)).WillOnce(Return(true));
+
+    EXPECT_NO_THROW(storage->deleteDatabase());
+}
+
+TEST_F(InMemoryQueueStorageDeleteDatabaseTest, DeleteDatabaseWhenFileDoesNotExist)
+{
+    using ::testing::Return;
+    using ::testing::_;
+
+    EXPECT_CALL(*mockFileSystemWrapper, exists(_)).WillOnce(Return(false));
+    EXPECT_CALL(*mockFileSystemWrapper, remove(_)).Times(0);
+
+    EXPECT_NO_THROW(storage->deleteDatabase());
+}
+
+TEST_F(InMemoryQueueStorageDeleteDatabaseTest, DeleteDatabaseClearsInMemoryRows)
+{
+    using ::testing::Return;
+    using ::testing::_;
+
+    storage->submitOrCoalesce(PersistedData{0, "id1", "idx", "{}", Operation::CREATE, 0});
+
+    EXPECT_CALL(*mockFileSystemWrapper, exists(_)).WillOnce(Return(false));
+    EXPECT_CALL(*mockFileSystemWrapper, remove(_)).Times(0);
+
+    storage->deleteDatabase();
+
+    auto remaining = storage->fetchPending(false);
+    EXPECT_TRUE(remaining.empty());
+}
+
+TEST_F(InMemoryQueueStorageDeleteDatabaseTest, DeleteDatabaseWhenRemoveFails)
+{
+    using ::testing::Return;
+    using ::testing::Throw;
+    using ::testing::_;
+
+    EXPECT_CALL(*mockFileSystemWrapper, exists(_)).WillOnce(Return(true));
+    EXPECT_CALL(*mockFileSystemWrapper, remove(_))
+    .WillOnce(Throw(std::filesystem::filesystem_error("Remove failed", std::error_code())));
+
+    EXPECT_THROW(storage->deleteDatabase(), std::filesystem::filesystem_error);
+}
+
+TEST_F(InMemoryQueueStorageDeleteDatabaseTest, DeleteDatabaseWhenExistsThrows)
+{
+    using ::testing::Throw;
+    using ::testing::_;
+
+    EXPECT_CALL(*mockFileSystemWrapper, exists(_)).WillOnce(Throw(std::runtime_error("Filesystem access error")));
+    EXPECT_CALL(*mockFileSystemWrapper, remove(_)).Times(0);
+
+    EXPECT_THROW(storage->deleteDatabase(), std::runtime_error);
+}
+
+// ========================================
+// Disk round trip: this is the behavior this class exists for — no disk I/O during
+// normal operation, snapshot only at construction (load) and destruction (save).
+// ========================================
+
+class InMemoryQueueStorageRoundTripTest : public ::testing::Test
+{
+    protected:
+        std::string dbPath;
+
+        void SetUp() override
+        {
+            dbPath = tempDbPath("in_memory_queue_roundtrip_test.db");
+            std::filesystem::remove(dbPath);
+        }
+
+        void TearDown() override
+        {
+            std::filesystem::remove(dbPath);
+        }
+};
+
+TEST_F(InMemoryQueueStorageRoundTripTest, SavesSnapshotOnDestructionAndLoadsItOnNextConstruction)
+{
+    {
+        InMemoryQueueStorage storage(dbPath, silentLogger());
+        storage.submitOrCoalesce(PersistedData{0, "id1", "idx", "{}", Operation::CREATE, 1});
+        storage.submitOrCoalesce(PersistedData{0, "id2", "idx2", "{}", Operation::MODIFY, 2});
+    } // destructor saves both rows to dbPath
+
+    ASSERT_TRUE(std::filesystem::exists(dbPath));
+
+    {
+        InMemoryQueueStorage storage(dbPath, silentLogger());
+        // Loading absorbs the on-disk file into memory and removes it.
+        EXPECT_FALSE(std::filesystem::exists(dbPath));
+
+        auto pending = storage.fetchPending(false);
+        ASSERT_EQ(pending.size(), static_cast<size_t>(2));
+        EXPECT_EQ(pending[0].id, "id1");
+        EXPECT_EQ(pending[1].id, "id2");
+    }
+}
+
+TEST_F(InMemoryQueueStorageRoundTripTest, DoesNotWriteASnapshotWhenQueueIsEmpty)
+{
+    {
+        InMemoryQueueStorage storage(dbPath, silentLogger());
+        // Nothing submitted.
+    }
+
+    EXPECT_FALSE(std::filesystem::exists(dbPath));
+}
+
+TEST_F(InMemoryQueueStorageRoundTripTest, PreservesSyncStatusAcrossRestartAfterResetAllSyncing)
+{
+    {
+        InMemoryQueueStorage storage(dbPath, silentLogger());
+        storage.submitOrCoalesce(PersistedData{0, "id1", "idx", "{}", Operation::CREATE, 1});
+        // Mark it SYNCING (as if a sync round were in flight) without an ack.
+        storage.fetchAndMarkForSync();
+    } // destructor saves the row while it is still SYNCING
+
+    {
+        InMemoryQueueStorage storage(dbPath, silentLogger());
+        // PersistentQueue::resetAllSyncing() is normally called right after construction;
+        // this class doesn't call it itself, so the row loads back as SYNCING...
+        auto beforeReset = storage.fetchPending(false);
+        EXPECT_TRUE(beforeReset.empty());
+
+        // ...and becomes visible again once the caller normalizes leftover sync state,
+        // exactly as PersistentQueue's constructor does today.
+        storage.resetAllSyncing();
+        auto afterReset = storage.fetchPending(false);
+        ASSERT_EQ(afterReset.size(), static_cast<size_t>(1));
+        EXPECT_EQ(afterReset[0].id, "id1");
+    }
+}
+
+TEST_F(InMemoryQueueStorageRoundTripTest, LoadsASnapshotWrittenDirectlyByPersistentQueueStorage)
+{
+    // Simulate a snapshot left behind before this feature existed (or written by another
+    // process using the SQLite format directly) to confirm the two backends' on-disk
+    // format is compatible.
+    {
+        PersistentQueueStorage onDiskStorage(dbPath, silentLogger());
+        onDiskStorage.submitOrCoalesce(PersistedData{0, "id1", "idx", "{}", Operation::CREATE, 1});
+    }
+
+    ASSERT_TRUE(std::filesystem::exists(dbPath));
+
+    InMemoryQueueStorage storage(dbPath, silentLogger());
+    EXPECT_FALSE(std::filesystem::exists(dbPath));
+
+    auto pending = storage.fetchPending(false);
+    ASSERT_EQ(pending.size(), static_cast<size_t>(1));
+    EXPECT_EQ(pending[0].id, "id1");
+}

--- a/src/shared_modules/sync_protocol/tests/test_persistent_queue.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_persistent_queue.cpp
@@ -13,6 +13,8 @@
 #include "ipersistent_queue_storage.hpp"
 #include "persistent_queue.hpp"
 
+#include <filesystem>
+
 using ::testing::_;
 using ::testing::Return;
 using ::testing::SaveArg;
@@ -29,6 +31,8 @@ class MockPersistentQueueStorage : public IPersistentQueueStorage
         MOCK_METHOD(void, removeByIndex, (const std::string& index), (override));
         MOCK_METHOD(void, removeAllDataContext, (), (override));
         MOCK_METHOD(void, deleteDatabase, (), (override));
+        MOCK_METHOD(std::vector<QueueRow>, fetchAll, (), (override));
+        MOCK_METHOD(void, saveAll, (const std::vector<QueueRow>& rows), (override));
 };
 
 TEST(PersistentQueueTest, ConstructorCallsLoadAllForEachModule)
@@ -68,32 +72,29 @@ TEST(PersistentQueueTest, ConstructorThrowsWhenResetAllSyncingFails)
     }, std::runtime_error);
 }
 
-TEST(PersistentQueueTest, SubmitStoresInMemoryAndStorage)
+TEST(PersistentQueueTest, SubmitCallsStorageSubmitOrCoalesce)
 {
     auto mockStorage = std::make_shared<MockPersistentQueueStorage>();
 
-    std::vector<PersistedData> flushedBatch;
-    EXPECT_CALL(*mockStorage, submitBatch(_))
+    PersistedData captured;
+    EXPECT_CALL(*mockStorage, submitOrCoalesce(_))
     .Times(1)
-    .WillOnce(SaveArg<0>(&flushedBatch));
+    .WillOnce(SaveArg<0>(&captured));
 
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    {
-        PersistentQueue queue(":memory:", testLogger, mockStorage);
-        queue.submit("id1", "index1", "{}", Operation::CREATE, 1);
-    } // destructor joins flush thread, ensuring submitBatch has been called
+    PersistentQueue queue(":memory:", testLogger, mockStorage);
+    queue.submit("id1", "index1", "{}", Operation::CREATE, 1);
 
-    ASSERT_EQ(flushedBatch.size(), 1u);
-    EXPECT_EQ(flushedBatch[0].id, "id1");
+    EXPECT_EQ(captured.id, "id1");
 }
 
-TEST(PersistentQueueTest, SubmitRollbackSequenceOnPersistError)
+TEST(PersistentQueueTest, SubmitDoesNotThrowOnPersistError)
 {
     auto mockStorage = std::make_shared<MockPersistentQueueStorage>();
 
-    // With double-buffer design, submitBatch errors are caught in flushBuffer().
-    // submit() itself never throws — events are buffered and flushed asynchronously.
-    EXPECT_CALL(*mockStorage, submitBatch(_))
+    // submitOrCoalesce() now runs synchronously on the caller's thread; submit()
+    // must still never throw — a failed item is logged and dropped, not surfaced.
+    EXPECT_CALL(*mockStorage, submitOrCoalesce(_))
     .WillOnce(testing::Throw(std::runtime_error("Simulated DB error")))
     .WillRepeatedly(testing::Return());
 
@@ -108,7 +109,7 @@ TEST(PersistentQueueTest, SubmitLogsErrorWhenPersistingFails)
 {
     auto mockStorage = std::make_shared<MockPersistentQueueStorage>();
 
-    EXPECT_CALL(*mockStorage, submitBatch(_))
+    EXPECT_CALL(*mockStorage, submitOrCoalesce(_))
     .WillOnce(testing::Throw(std::runtime_error("Simulated persistence error")));
 
     // Capture the log message
@@ -120,58 +121,13 @@ TEST(PersistentQueueTest, SubmitLogsErrorWhenPersistingFails)
         capturedLogMessage = message;
     };
 
-    {
-        PersistentQueue queue(":memory:", testLogger, mockStorage);
-        queue.submit("id1", "idx1", "{}", Operation::CREATE, 0);
-    } // destructor joins flush thread — guarantees log was written before assertions
+    PersistentQueue queue(":memory:", testLogger, mockStorage);
+    queue.submit("id1", "idx1", "{}", Operation::CREATE, 0);
 
     // Verify that the specific error message was logged
     EXPECT_EQ(capturedLogLevel, LOG_ERROR);
-    EXPECT_TRUE(capturedLogMessage.find("PersistentQueue: Error flushing batch to storage:") != std::string::npos);
+    EXPECT_TRUE(capturedLogMessage.find("PersistentQueue: Error submitting item to storage:") != std::string::npos);
     EXPECT_TRUE(capturedLogMessage.find("Simulated persistence error") != std::string::npos);
-}
-
-TEST(PersistentQueueTest, FailedBatchIsRetainedAndRetriedOnNextFlushCycle)
-{
-    // Verifies the fix: a transient submitBatch() failure must not drop the batch.
-    // The failed events stay in their buffer slot and are merged with newly
-    // submitted events on the next flush of that slot.
-    //
-    // Drives every flush explicitly via fetchAndMarkForSync() (which calls the
-    // synchronous flushPendingBuffer()) so the sequence is deterministic and
-    // never depends on the background flush thread's timing.
-    auto mockStorage = std::make_shared<MockPersistentQueueStorage>();
-    LoggerFunc logger = [](modules_log_level_t, const std::string&) {};
-
-    std::vector<PersistedData> retryBatch;
-
-    EXPECT_CALL(*mockStorage, submitBatch(_))
-    .WillOnce(::testing::Throw(std::runtime_error("Simulated transient storage error")))
-    .WillOnce(Return())
-    .WillOnce(SaveArg<0>(&retryBatch));
-
-    EXPECT_CALL(*mockStorage, fetchAndMarkForSync())
-    .WillRepeatedly(Return(std::vector<PersistedData> {}));
-
-    {
-        PersistentQueue queue(":memory:", logger, mockStorage);
-
-        // Buffer A gets "id1" and its flush fails -- the event must stay buffered.
-        queue.submit("id1", "idx", "{}", Operation::CREATE, 1);
-        queue.fetchAndMarkForSync();
-
-        // Buffer B gets "id2" and its flush succeeds, flipping back to buffer A.
-        queue.submit("id2", "idx", "{}", Operation::CREATE, 2);
-        queue.fetchAndMarkForSync();
-
-        // Buffer A now holds the still-unflushed "id1" plus this new "id3".
-        queue.submit("id3", "idx", "{}", Operation::CREATE, 3);
-        queue.fetchAndMarkForSync();
-    }
-
-    ASSERT_EQ(retryBatch.size(), 2u);
-    EXPECT_EQ(retryBatch[0].id, "id1");
-    EXPECT_EQ(retryBatch[1].id, "id3");
 }
 
 TEST(PersistentQueueTest, FetchAllReturnsAllMessages)
@@ -494,45 +450,35 @@ TEST(PersistentQueueTest, clearAllDataContext_ExceptionHandling)
 }
 
 // ========================================
-// Tests for graceful shutdown / destructor
+// Tests for graceful shutdown / disk persistence
 // ========================================
+//
+// PersistentQueue itself no longer owns any disk-persistence logic — with no storage
+// injected, it defaults to InMemoryQueueStorage, which loads from disk on construction
+// and saves to disk on destruction (see test_in_memory_queue_storage.cpp for the
+// coalescing-state round trip). This is an end-to-end check that PersistentQueue really
+// wires up that default and that the save/load boundary works through the public API.
 
-TEST(PersistentQueueTest, DestructorFlushesBufferedEventsOnGracefulShutdown)
+TEST(PersistentQueueTest, DefaultStorageRoundTripsThroughDiskAcrossRestarts)
 {
-    auto mockStorage = std::make_shared<MockPersistentQueueStorage>();
+    const auto dbPath = (std::filesystem::temp_directory_path() / "persistent_queue_roundtrip_test.db").string();
+    std::filesystem::remove(dbPath);
+
     LoggerFunc logger = [](modules_log_level_t, const std::string&) {};
 
-    std::vector<PersistedData> flushedBatch;
-    EXPECT_CALL(*mockStorage, submitBatch(_))
-    .Times(1)
-    .WillOnce(SaveArg<0>(&flushedBatch));
-
     {
-        PersistentQueue queue(":memory:", logger, mockStorage);
+        PersistentQueue queue(dbPath, logger); // no storage injected -> InMemoryQueueStorage
         queue.submit("id1", "idx", R"({"k":1})", Operation::CREATE, 1);
-        queue.submit("id2", "idx", R"({"k":2})", Operation::MODIFY, 2);
-        queue.submit("id3", "idx", R"({"k":3})", Operation::DELETE_, 3);
-        // Destructor: sets m_stop=true, notifies flush thread, joins.
-        // Flush thread wakes up, sees m_stop, swaps buffer, calls submitBatch.
-    }
+    } // destructor: InMemoryQueueStorage saves the pending item to dbPath
 
-    // join() in destructor guarantees submitBatch has returned before we assert.
-    ASSERT_EQ(flushedBatch.size(), 3u);
-    EXPECT_EQ(flushedBatch[0].id, "id1");
-    EXPECT_EQ(flushedBatch[1].id, "id2");
-    EXPECT_EQ(flushedBatch[2].id, "id3");
-}
-
-TEST(PersistentQueueTest, DestructorWithEmptyBufferDoesNotCallSubmitBatch)
-{
-    // Verify that no spurious write happens when the buffer is empty at shutdown.
-    auto mockStorage = std::make_shared<MockPersistentQueueStorage>();
-    LoggerFunc logger = [](modules_log_level_t, const std::string&) {};
-
-    EXPECT_CALL(*mockStorage, submitBatch(_)).Times(0);
+    ASSERT_TRUE(std::filesystem::exists(dbPath));
 
     {
-        PersistentQueue queue(":memory:", logger, mockStorage);
-        // No events submitted — destructor must not call submitBatch.
+        PersistentQueue queue(dbPath, logger); // loads the snapshot saved above
+        auto pending = queue.fetchPendingItems(false);
+        ASSERT_EQ(pending.size(), 1u);
+        EXPECT_EQ(pending[0].id, "id1");
     }
+
+    std::filesystem::remove(dbPath);
 }

--- a/src/shared_modules/sync_protocol/tests/test_persistent_queue.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_persistent_queue.cpp
@@ -109,8 +109,13 @@ TEST(PersistentQueueTest, SubmitLogsErrorWhenPersistingFails)
 {
     auto mockStorage = std::make_shared<MockPersistentQueueStorage>();
 
+    // The failed item also gets one final drain attempt from the destructor (see
+    // SubmitRetriesPreviouslyFailedItemOnNextCall for the next-submit() retry path, and the
+    // destructor's own best-effort drain) -- let that second attempt succeed so this test
+    // stays focused on submit()'s own error log, not on the destructor's.
     EXPECT_CALL(*mockStorage, submitOrCoalesce(_))
-    .WillOnce(testing::Throw(std::runtime_error("Simulated persistence error")));
+    .WillOnce(testing::Throw(std::runtime_error("Simulated persistence error")))
+    .WillOnce(Return());
 
     // Capture the log message
     std::string capturedLogMessage;
@@ -167,6 +172,54 @@ TEST(PersistentQueueTest, SubmitRetriesPreviouslyFailedItemOnNextCall)
     EXPECT_EQ(submittedIds[0], "id1");
     EXPECT_EQ(submittedIds[1], "id1");
     EXPECT_EQ(submittedIds[2], "id2");
+}
+
+TEST(PersistentQueueTest, FetchAndMarkForSyncDrainsPreviouslyFailedItemEvenWithoutAnotherSubmit)
+{
+    // A failed item must not require a NEW submit() call for a different id to ever get
+    // retried -- AgentSyncProtocol's periodic sync cycle calls fetchAndMarkForSync() on its
+    // own timer, independently of submit(), so that call path must drain m_pendingRetry too.
+    auto mockStorage = std::make_shared<MockPersistentQueueStorage>();
+    LoggerFunc logger = [](modules_log_level_t, const std::string&) {};
+
+    EXPECT_CALL(*mockStorage, submitOrCoalesce(_))
+    .WillOnce(::testing::Throw(std::runtime_error("Simulated transient storage error")))
+    .WillOnce(Return());
+    EXPECT_CALL(*mockStorage, fetchAndMarkForSync(_))
+    .WillOnce(Return(std::vector<PersistedData> {}));
+
+    PersistentQueue queue(":memory:", logger, mockStorage);
+
+    queue.submit("id1", "idx", "{}", Operation::CREATE, 1);
+    // No further submit() call -- only a sync-cycle-style read.
+    queue.fetchAndMarkForSync();
+
+    // Both mock expectations above are satisfied only if fetchAndMarkForSync() actually
+    // retried "id1" (the second submitOrCoalesce WillOnce) before delegating to storage.
+}
+
+TEST(PersistentQueueTest, DestructorMakesFinalDrainAttemptForPendingRetryItems)
+{
+    // A failed item that was never retried again by a later call must still get one last
+    // chance to be persisted before the queue (and the storage snapshot it triggers on
+    // destruction) is gone -- otherwise it is lost even on an otherwise graceful shutdown.
+    auto mockStorage = std::make_shared<MockPersistentQueueStorage>();
+    LoggerFunc logger = [](modules_log_level_t, const std::string&) {};
+
+    bool finalDrainSucceeded = false;
+
+    EXPECT_CALL(*mockStorage, submitOrCoalesce(_))
+    .WillOnce(::testing::Throw(std::runtime_error("Simulated transient storage error")))
+    .WillOnce(::testing::DoAll(::testing::Invoke([&finalDrainSucceeded](const PersistedData&) { finalDrainSucceeded = true; }),
+                                ::testing::Return()));
+
+    {
+        PersistentQueue queue(":memory:", logger, mockStorage);
+        queue.submit("id1", "idx", "{}", Operation::CREATE, 1);
+        EXPECT_FALSE(finalDrainSucceeded);
+    } // destructor runs here, making the second (successful) submitOrCoalesce call
+
+    EXPECT_TRUE(finalDrainSucceeded);
 }
 
 TEST(PersistentQueueTest, FetchAllReturnsAllMessages)

--- a/src/shared_modules/sync_protocol/tests/test_persistent_queue.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_persistent_queue.cpp
@@ -222,6 +222,68 @@ TEST(PersistentQueueTest, DestructorMakesFinalDrainAttemptForPendingRetryItems)
     EXPECT_TRUE(finalDrainSucceeded);
 }
 
+TEST(PersistentQueueTest, PendingRetryCoalescesCreateThenDeleteIntoNoOp)
+{
+    // A CREATE then a DELETE_ for the same id, both failing, must cancel out entirely once
+    // storage recovers -- not replay as a lone DELETE_ for an id storage never saw created.
+    auto mockStorage = std::make_shared<MockPersistentQueueStorage>();
+    LoggerFunc logger = [](modules_log_level_t, const std::string&) {};
+
+    std::vector<std::pair<std::string, Operation>> submitted;
+
+    EXPECT_CALL(*mockStorage, submitOrCoalesce(_))
+    .WillRepeatedly(::testing::Invoke([&submitted](const PersistedData & d) { submitted.emplace_back(d.id, d.operation); throw std::runtime_error("Simulated transient storage error"); }));
+
+    PersistentQueue queue(":memory:", logger, mockStorage);
+
+    queue.submit("id1", "idx", "{}", Operation::CREATE, 1);
+    queue.submit("id1", "idx", "{}", Operation::DELETE_, 2);
+
+    // 3 failed attempts so far: initial CREATE, its retry-drain, and the DELETE_.
+    ASSERT_EQ(submitted.size(), 3u);
+
+    // Storage "recovers": further calls succeed.
+    testing::Mock::VerifyAndClearExpectations(mockStorage.get());
+    EXPECT_CALL(*mockStorage, submitOrCoalesce(_))
+    .WillRepeatedly(::testing::Invoke([&submitted](const PersistedData & d) { submitted.emplace_back(d.id, d.operation); }));
+
+    queue.submit("id2", "idx2", "{}", Operation::CREATE, 3);
+
+    // Only "id2" gets submitted -- the canceled CREATE+DELETE_ pair never resurfaces.
+    ASSERT_EQ(submitted.size(), 4u);
+    EXPECT_EQ(submitted[3].first, "id2");
+}
+
+TEST(PersistentQueueTest, PendingRetryCoalescesCreateThenModifyKeepingCreateOperation)
+{
+    // CREATE then MODIFY, both failing, must still persist as CREATE -- storage never saw
+    // this id, so sending MODIFY instead would desync its createStatus tracking.
+    auto mockStorage = std::make_shared<MockPersistentQueueStorage>();
+    LoggerFunc logger = [](modules_log_level_t, const std::string&) {};
+
+    std::vector<PersistedData> submitted;
+
+    EXPECT_CALL(*mockStorage, submitOrCoalesce(_))
+    .WillOnce(::testing::Throw(std::runtime_error("Simulated transient storage error"))) // initial CREATE
+    .WillOnce(::testing::Throw(std::runtime_error("Simulated transient storage error"))) // retry-drain of the CREATE
+    .WillOnce(::testing::Throw(std::runtime_error("Simulated transient storage error"))) // the MODIFY itself
+    .WillRepeatedly(::testing::Invoke([&submitted](const PersistedData & d) { submitted.push_back(d); }));
+
+    PersistentQueue queue(":memory:", logger, mockStorage);
+
+    queue.submit("id1", "idx", "{}", Operation::CREATE, 1);
+    queue.submit("id1", "idx2", "{updated}", Operation::MODIFY, 2);
+    queue.submit("id2", "idx3", "{}", Operation::CREATE, 3); // drains id1 successfully this time, then submits id2
+
+    ASSERT_EQ(submitted.size(), 2u);
+    EXPECT_EQ(submitted[0].id, "id1");
+    EXPECT_EQ(submitted[0].operation, Operation::CREATE);
+    EXPECT_EQ(submitted[0].index, "idx2");
+    EXPECT_EQ(submitted[0].data, "{updated}");
+    EXPECT_EQ(submitted[0].version, 2u);
+    EXPECT_EQ(submitted[1].id, "id2");
+}
+
 TEST(PersistentQueueTest, FetchAllReturnsAllMessages)
 {
     auto mockStorage = std::make_shared<MockPersistentQueueStorage>();

--- a/src/shared_modules/sync_protocol/tests/test_persistent_queue.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_persistent_queue.cpp
@@ -130,6 +130,45 @@ TEST(PersistentQueueTest, SubmitLogsErrorWhenPersistingFails)
     EXPECT_TRUE(capturedLogMessage.find("Simulated persistence error") != std::string::npos);
 }
 
+TEST(PersistentQueueTest, SubmitRetriesPreviouslyFailedItemOnNextCall)
+{
+    // Replaces the old buffer/flush-thread-based retry test (removed along with the
+    // background flush thread submitBatch() used to run on): submit() now writes
+    // synchronously, so a failed item is retried at the start of the NEXT submit() call
+    // instead of on a scheduled flush cycle. This is the guarantee finding #2 of the
+    // #37844 review asked for: a transient storage failure must not silently and
+    // permanently lose the event.
+    auto mockStorage = std::make_shared<MockPersistentQueueStorage>();
+    LoggerFunc logger = [](modules_log_level_t, const std::string&) {};
+
+    std::vector<std::string> submittedIds;
+
+    EXPECT_CALL(*mockStorage, submitOrCoalesce(_))
+    .WillOnce(::testing::DoAll(
+                  ::testing::Invoke([&submittedIds](const PersistedData & d) { submittedIds.push_back(d.id); }),
+                  ::testing::Throw(std::runtime_error("Simulated transient storage error"))))
+    .WillOnce(::testing::DoAll(
+                  ::testing::Invoke([&submittedIds](const PersistedData & d) { submittedIds.push_back(d.id); }),
+                  ::testing::Return()))
+    .WillOnce(::testing::DoAll(
+                  ::testing::Invoke([&submittedIds](const PersistedData & d) { submittedIds.push_back(d.id); }),
+                  ::testing::Return()));
+
+    PersistentQueue queue(":memory:", logger, mockStorage);
+
+    // "id1" fails on this first attempt and is retained for retry.
+    queue.submit("id1", "idx", "{}", Operation::CREATE, 1);
+
+    // The next submit() call drains the retry first ("id1" succeeds this time), then
+    // submits the new item ("id2").
+    queue.submit("id2", "idx", "{}", Operation::CREATE, 2);
+
+    ASSERT_EQ(submittedIds.size(), 3u);
+    EXPECT_EQ(submittedIds[0], "id1");
+    EXPECT_EQ(submittedIds[1], "id1");
+    EXPECT_EQ(submittedIds[2], "id2");
+}
+
 TEST(PersistentQueueTest, FetchAllReturnsAllMessages)
 {
     auto mockStorage = std::make_shared<MockPersistentQueueStorage>();

--- a/src/shared_modules/sync_protocol/tests/test_persistent_queue.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_persistent_queue.cpp
@@ -13,6 +13,8 @@
 #include "ipersistent_queue_storage.hpp"
 #include "persistent_queue.hpp"
 
+#include <filesystem>
+
 using ::testing::_;
 using ::testing::Return;
 using ::testing::SaveArg;
@@ -29,6 +31,8 @@ class MockPersistentQueueStorage : public IPersistentQueueStorage
         MOCK_METHOD(void, removeByIndex, (const std::string& index), (override));
         MOCK_METHOD(void, removeAllDataContext, (), (override));
         MOCK_METHOD(void, deleteDatabase, (), (override));
+        MOCK_METHOD(std::vector<QueueRow>, fetchAll, (), (override));
+        MOCK_METHOD(void, saveAll, (const std::vector<QueueRow>& rows), (override));
 };
 
 TEST(PersistentQueueTest, ConstructorCallsLoadAllForEachModule)
@@ -68,32 +72,29 @@ TEST(PersistentQueueTest, ConstructorThrowsWhenResetAllSyncingFails)
     }, std::runtime_error);
 }
 
-TEST(PersistentQueueTest, SubmitStoresInMemoryAndStorage)
+TEST(PersistentQueueTest, SubmitCallsStorageSubmitOrCoalesce)
 {
     auto mockStorage = std::make_shared<MockPersistentQueueStorage>();
 
-    std::vector<PersistedData> flushedBatch;
-    EXPECT_CALL(*mockStorage, submitBatch(_))
+    PersistedData captured;
+    EXPECT_CALL(*mockStorage, submitOrCoalesce(_))
     .Times(1)
-    .WillOnce(SaveArg<0>(&flushedBatch));
+    .WillOnce(SaveArg<0>(&captured));
 
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    {
-        PersistentQueue queue(":memory:", testLogger, mockStorage);
-        queue.submit("id1", "index1", "{}", Operation::CREATE, 1);
-    } // destructor joins flush thread, ensuring submitBatch has been called
+    PersistentQueue queue(":memory:", testLogger, mockStorage);
+    queue.submit("id1", "index1", "{}", Operation::CREATE, 1);
 
-    ASSERT_EQ(flushedBatch.size(), 1u);
-    EXPECT_EQ(flushedBatch[0].id, "id1");
+    EXPECT_EQ(captured.id, "id1");
 }
 
-TEST(PersistentQueueTest, SubmitRollbackSequenceOnPersistError)
+TEST(PersistentQueueTest, SubmitDoesNotThrowOnPersistError)
 {
     auto mockStorage = std::make_shared<MockPersistentQueueStorage>();
 
-    // With double-buffer design, submitBatch errors are caught in flushBuffer().
-    // submit() itself never throws — events are buffered and flushed asynchronously.
-    EXPECT_CALL(*mockStorage, submitBatch(_))
+    // submitOrCoalesce() now runs synchronously on the caller's thread; submit()
+    // must still never throw — a failed item is logged and dropped, not surfaced.
+    EXPECT_CALL(*mockStorage, submitOrCoalesce(_))
     .WillOnce(testing::Throw(std::runtime_error("Simulated DB error")))
     .WillRepeatedly(testing::Return());
 
@@ -108,7 +109,7 @@ TEST(PersistentQueueTest, SubmitLogsErrorWhenPersistingFails)
 {
     auto mockStorage = std::make_shared<MockPersistentQueueStorage>();
 
-    EXPECT_CALL(*mockStorage, submitBatch(_))
+    EXPECT_CALL(*mockStorage, submitOrCoalesce(_))
     .WillOnce(testing::Throw(std::runtime_error("Simulated persistence error")));
 
     // Capture the log message
@@ -120,58 +121,13 @@ TEST(PersistentQueueTest, SubmitLogsErrorWhenPersistingFails)
         capturedLogMessage = message;
     };
 
-    {
-        PersistentQueue queue(":memory:", testLogger, mockStorage);
-        queue.submit("id1", "idx1", "{}", Operation::CREATE, 0);
-    } // destructor joins flush thread — guarantees log was written before assertions
+    PersistentQueue queue(":memory:", testLogger, mockStorage);
+    queue.submit("id1", "idx1", "{}", Operation::CREATE, 0);
 
     // Verify that the specific error message was logged
     EXPECT_EQ(capturedLogLevel, LOG_ERROR);
-    EXPECT_TRUE(capturedLogMessage.find("PersistentQueue: Error flushing batch to storage:") != std::string::npos);
+    EXPECT_TRUE(capturedLogMessage.find("PersistentQueue: Error submitting item to storage:") != std::string::npos);
     EXPECT_TRUE(capturedLogMessage.find("Simulated persistence error") != std::string::npos);
-}
-
-TEST(PersistentQueueTest, FailedBatchIsRetainedAndRetriedOnNextFlushCycle)
-{
-    // Verifies the fix: a transient submitBatch() failure must not drop the batch.
-    // The failed events stay in their buffer slot and are merged with newly
-    // submitted events on the next flush of that slot.
-    //
-    // Drives every flush explicitly via fetchAndMarkForSync() (which calls the
-    // synchronous flushPendingBuffer()) so the sequence is deterministic and
-    // never depends on the background flush thread's timing.
-    auto mockStorage = std::make_shared<MockPersistentQueueStorage>();
-    LoggerFunc logger = [](modules_log_level_t, const std::string&) {};
-
-    std::vector<PersistedData> retryBatch;
-
-    EXPECT_CALL(*mockStorage, submitBatch(_))
-    .WillOnce(::testing::Throw(std::runtime_error("Simulated transient storage error")))
-    .WillOnce(Return())
-    .WillOnce(SaveArg<0>(&retryBatch));
-
-    EXPECT_CALL(*mockStorage, fetchAndMarkForSync(_) )
-    .WillRepeatedly(Return(std::vector<PersistedData> {}));
-
-    {
-        PersistentQueue queue(":memory:", logger, mockStorage);
-
-        // Buffer A gets "id1" and its flush fails -- the event must stay buffered.
-        queue.submit("id1", "idx", "{}", Operation::CREATE, 1);
-        queue.fetchAndMarkForSync();
-
-        // Buffer B gets "id2" and its flush succeeds, flipping back to buffer A.
-        queue.submit("id2", "idx", "{}", Operation::CREATE, 2);
-        queue.fetchAndMarkForSync();
-
-        // Buffer A now holds the still-unflushed "id1" plus this new "id3".
-        queue.submit("id3", "idx", "{}", Operation::CREATE, 3);
-        queue.fetchAndMarkForSync();
-    }
-
-    ASSERT_EQ(retryBatch.size(), 2u);
-    EXPECT_EQ(retryBatch[0].id, "id1");
-    EXPECT_EQ(retryBatch[1].id, "id3");
 }
 
 TEST(PersistentQueueTest, FetchAllReturnsAllMessages)
@@ -494,45 +450,35 @@ TEST(PersistentQueueTest, clearAllDataContext_ExceptionHandling)
 }
 
 // ========================================
-// Tests for graceful shutdown / destructor
+// Tests for graceful shutdown / disk persistence
 // ========================================
+//
+// PersistentQueue itself no longer owns any disk-persistence logic — with no storage
+// injected, it defaults to InMemoryQueueStorage, which loads from disk on construction
+// and saves to disk on destruction (see test_in_memory_queue_storage.cpp for the
+// coalescing-state round trip). This is an end-to-end check that PersistentQueue really
+// wires up that default and that the save/load boundary works through the public API.
 
-TEST(PersistentQueueTest, DestructorFlushesBufferedEventsOnGracefulShutdown)
+TEST(PersistentQueueTest, DefaultStorageRoundTripsThroughDiskAcrossRestarts)
 {
-    auto mockStorage = std::make_shared<MockPersistentQueueStorage>();
+    const auto dbPath = (std::filesystem::temp_directory_path() / "persistent_queue_roundtrip_test.db").string();
+    std::filesystem::remove(dbPath);
+
     LoggerFunc logger = [](modules_log_level_t, const std::string&) {};
 
-    std::vector<PersistedData> flushedBatch;
-    EXPECT_CALL(*mockStorage, submitBatch(_))
-    .Times(1)
-    .WillOnce(SaveArg<0>(&flushedBatch));
-
     {
-        PersistentQueue queue(":memory:", logger, mockStorage);
+        PersistentQueue queue(dbPath, logger); // no storage injected -> InMemoryQueueStorage
         queue.submit("id1", "idx", R"({"k":1})", Operation::CREATE, 1);
-        queue.submit("id2", "idx", R"({"k":2})", Operation::MODIFY, 2);
-        queue.submit("id3", "idx", R"({"k":3})", Operation::DELETE_, 3);
-        // Destructor: sets m_stop=true, notifies flush thread, joins.
-        // Flush thread wakes up, sees m_stop, swaps buffer, calls submitBatch.
-    }
+    } // destructor: InMemoryQueueStorage saves the pending item to dbPath
 
-    // join() in destructor guarantees submitBatch has returned before we assert.
-    ASSERT_EQ(flushedBatch.size(), 3u);
-    EXPECT_EQ(flushedBatch[0].id, "id1");
-    EXPECT_EQ(flushedBatch[1].id, "id2");
-    EXPECT_EQ(flushedBatch[2].id, "id3");
-}
-
-TEST(PersistentQueueTest, DestructorWithEmptyBufferDoesNotCallSubmitBatch)
-{
-    // Verify that no spurious write happens when the buffer is empty at shutdown.
-    auto mockStorage = std::make_shared<MockPersistentQueueStorage>();
-    LoggerFunc logger = [](modules_log_level_t, const std::string&) {};
-
-    EXPECT_CALL(*mockStorage, submitBatch(_)).Times(0);
+    ASSERT_TRUE(std::filesystem::exists(dbPath));
 
     {
-        PersistentQueue queue(":memory:", logger, mockStorage);
-        // No events submitted — destructor must not call submitBatch.
+        PersistentQueue queue(dbPath, logger); // loads the snapshot saved above
+        auto pending = queue.fetchPendingItems(false);
+        ASSERT_EQ(pending.size(), 1u);
+        EXPECT_EQ(pending[0].id, "id1");
     }
+
+    std::filesystem::remove(dbPath);
 }

--- a/src/shared_modules/sync_protocol/tests/test_persistent_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_persistent_queue_storage.cpp
@@ -16,6 +16,7 @@
 #include <filesystem>
 #include <thread>
 #include <chrono>
+#include <algorithm>
 
 struct QueueScenario
 {
@@ -489,6 +490,64 @@ TEST_F(PersistentQueueStorageTest, FetchAndMarkForSyncWithoutByteBudgetReturnsAl
     EXPECT_EQ(rows[0].id, "id1");
     EXPECT_EQ(rows[1].id, "id2");
     EXPECT_EQ(rows[2].id, "id3");
+}
+
+TEST_F(PersistentQueueStorageTest, SubmitBatchAppliesCoalesceLogicForEachItem)
+{
+    std::vector<PersistedData> batch =
+    {
+        PersistedData{0, "id1", "idx1", "{}", Operation::CREATE, 1},
+        PersistedData{0, "id2", "idx2", "{}", Operation::CREATE, 1},
+        PersistedData{0, "id1", "idx1", "{updated}", Operation::MODIFY, 2}
+    };
+
+    storage->submitBatch(batch);
+
+    auto rows = storage->fetchAndMarkForSync();
+    ASSERT_EQ(rows.size(), static_cast<size_t>(2));
+
+    const auto id1 = std::find_if(rows.begin(), rows.end(), [](const PersistedData& d) { return d.id == "id1"; });
+    ASSERT_NE(id1, rows.end());
+    EXPECT_EQ(id1->operation, Operation::MODIFY);
+}
+
+TEST_F(PersistentQueueStorageTest, SubmitBatchWithEmptyBatchIsANoOp)
+{
+    EXPECT_NO_THROW(storage->submitBatch({}));
+
+    auto rows = storage->fetchAndMarkForSync();
+    EXPECT_TRUE(rows.empty());
+}
+
+TEST_F(PersistentQueueStorageTest, FetchPendingFiltersDataContextWhenRequested)
+{
+    storage->submitOrCoalesce(PersistedData{0, "value1", "idx", "{}", Operation::CREATE, 0, false});
+    storage->submitOrCoalesce(PersistedData{0, "context1", "idx", "{}", Operation::CREATE, 0, true});
+
+    auto onlyValues = storage->fetchPending(true);
+    ASSERT_EQ(onlyValues.size(), static_cast<size_t>(1));
+    EXPECT_EQ(onlyValues[0].id, "value1");
+
+    auto everything = storage->fetchPending(false);
+    EXPECT_EQ(everything.size(), static_cast<size_t>(2));
+}
+
+TEST_F(PersistentQueueStorageTest, RemoveAllDataContextRemovesOnlyDataContextItems)
+{
+    storage->submitOrCoalesce(PersistedData{0, "id1", "idx", "{}", Operation::CREATE, 0, false});
+    storage->submitOrCoalesce(PersistedData{0, "id2", "idx", "{}", Operation::CREATE, 0, true});
+
+    storage->removeAllDataContext();
+
+    auto remaining = storage->fetchPending(false);
+    ASSERT_EQ(remaining.size(), static_cast<size_t>(1));
+    EXPECT_EQ(remaining[0].id, "id1");
+}
+
+TEST(PersistentQueueStorageConstructorTest, ThrowsWhenLoggerIsNull)
+{
+    LoggerFunc nullLogger = nullptr;
+    EXPECT_THROW(PersistentQueueStorage(":memory:", nullLogger), std::invalid_argument);
 }
 
 // Test class for testing deleteDatabase method with mock filesystem wrapper

--- a/src/shared_modules/sync_protocol/tests/test_persistent_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_persistent_queue_storage.cpp
@@ -13,6 +13,7 @@
 #include "mock_filesystem_wrapper.hpp"
 #include <memory>
 #include <filesystem>
+#include <algorithm>
 
 struct QueueScenario
 {
@@ -384,6 +385,64 @@ TEST_F(PersistentQueueStorageTest, RemoveByIndexDeletesItemsInAnyStatus)
     EXPECT_EQ(remainingItems.size(), static_cast<size_t>(1));
     EXPECT_EQ(remainingItems[0].id, "id3");
     EXPECT_EQ(remainingItems[0].index, "index2");
+}
+
+TEST_F(PersistentQueueStorageTest, SubmitBatchAppliesCoalesceLogicForEachItem)
+{
+    std::vector<PersistedData> batch =
+    {
+        PersistedData{0, "id1", "idx1", "{}", Operation::CREATE, 1},
+        PersistedData{0, "id2", "idx2", "{}", Operation::CREATE, 1},
+        PersistedData{0, "id1", "idx1", "{updated}", Operation::MODIFY, 2}
+    };
+
+    storage->submitBatch(batch);
+
+    auto rows = storage->fetchAndMarkForSync();
+    ASSERT_EQ(rows.size(), static_cast<size_t>(2));
+
+    const auto id1 = std::find_if(rows.begin(), rows.end(), [](const PersistedData& d) { return d.id == "id1"; });
+    ASSERT_NE(id1, rows.end());
+    EXPECT_EQ(id1->operation, Operation::MODIFY);
+}
+
+TEST_F(PersistentQueueStorageTest, SubmitBatchWithEmptyBatchIsANoOp)
+{
+    EXPECT_NO_THROW(storage->submitBatch({}));
+
+    auto rows = storage->fetchAndMarkForSync();
+    EXPECT_TRUE(rows.empty());
+}
+
+TEST_F(PersistentQueueStorageTest, FetchPendingFiltersDataContextWhenRequested)
+{
+    storage->submitOrCoalesce(PersistedData{0, "value1", "idx", "{}", Operation::CREATE, 0, false});
+    storage->submitOrCoalesce(PersistedData{0, "context1", "idx", "{}", Operation::CREATE, 0, true});
+
+    auto onlyValues = storage->fetchPending(true);
+    ASSERT_EQ(onlyValues.size(), static_cast<size_t>(1));
+    EXPECT_EQ(onlyValues[0].id, "value1");
+
+    auto everything = storage->fetchPending(false);
+    EXPECT_EQ(everything.size(), static_cast<size_t>(2));
+}
+
+TEST_F(PersistentQueueStorageTest, RemoveAllDataContextRemovesOnlyDataContextItems)
+{
+    storage->submitOrCoalesce(PersistedData{0, "id1", "idx", "{}", Operation::CREATE, 0, false});
+    storage->submitOrCoalesce(PersistedData{0, "id2", "idx", "{}", Operation::CREATE, 0, true});
+
+    storage->removeAllDataContext();
+
+    auto remaining = storage->fetchPending(false);
+    ASSERT_EQ(remaining.size(), static_cast<size_t>(1));
+    EXPECT_EQ(remaining[0].id, "id1");
+}
+
+TEST(PersistentQueueStorageConstructorTest, ThrowsWhenLoggerIsNull)
+{
+    LoggerFunc nullLogger = nullptr;
+    EXPECT_THROW(PersistentQueueStorage(":memory:", nullLogger), std::invalid_argument);
 }
 
 // Test class for testing deleteDatabase method with mock filesystem wrapper


### PR DESCRIPTION

## Description

Under the FIM saturation load profile used in #37153 (1000 files, 100 EPS, realtime monitoring), `wazuh-syscheckd` on 5.x agents shows a significantly higher memory footprint than on 4.x. This PR addresses the `fim_sync.db` connection/buffering component of that gap: the sync queue backing AgentSyncProtocol no longer keeps a live SQLite connection (its own page cache and WAL buffers) open for the life of the process. It now lives purely in memory at runtime, loading a prior snapshot from disk on startup and writing one back only at graceful shutdown.

Closes #37844

## Proposed Changes

- Added `InMemoryQueueStorage`, a new in-memory backend for the sync queue, used by default in place of the always-open SQLite-backed `PersistentQueueStorage`.
- `PersistentQueueStorage` is now used only as the on-disk snapshot format: `fetchAll()` loads a prior snapshot into memory on startup, `saveAll()` writes the current in-memory state back to disk on shutdown.
- Capacity handling hardened in a follow-up commit: the queue's capacity is now tracked as an estimated byte budget (rather than a raw row count) so the cap actually reflects the RSS it's meant to bound. A submission that would exceed capacity now throws and is retried once room frees up, instead of being silently dropped. Retries are drained on the next successful fetch/mark-for-sync cycle and given one last attempt in the destructor, so a failed item can no longer sit un-synced indefinitely or be lost on an otherwise graceful shutdown.
- Fixed a stale CI packaging check: the expected installed size of `libagent_sync_protocol.so` in the `deb`/`rpm` amd64 `check_files` CSVs had been updated against an earlier commit and no longer matched the library's actual size after the capacity/retry hardening added more code to it.

## Results and Evidence

### Memory footprint — three-way comparison (4.x release / 5.x nightly / this PR)

To separate what this PR itself changes from what's already true of unmodified 5.x, three agents were run concurrently against the same load profile from #37153 (1000 realtime-monitored files, target 100 EPS file-churn) for 60 minutes each (90s idle baseline + 3600s under load, `wazuh-syscheckd` RSS sampled every 60s via `/proc/<pid>/status`), all enrolled against the same manager at the same time so none of the three see a materially different environment:

| Build | Idle RSS avg | Load RSS avg | Idle vs 4.x | Load vs 4.x | Churn applied |
|---|---:|---:|---:|---:|---:|
| 4.x release | 13.36 MiB | 13.82 MiB | — | — | 161,989 events / 3665s |
| 5.x nightly (no PR changes) | 16.03 MiB | 17.89 MiB | +20.0% | +29.4% | 168,860 events / 3621s |
| **This PR** | **14.46 MiB** | **18.08 MiB** | **+8.2%** | **+30.8%** | 168,922 events / 3634s |

Representative raw samples (full runs: 63 rows each, 2 idle + 60 load samples at 60s intervals; the omitted rows in between are the same shape as the ones shown — steady values interspersed with step changes):

<details><summary>This PR (agent enrolled against the manager, `wazuh-syscheckd` RSS)</summary>

```
timestamp,phase,process_name,pid,rss_kb
2026-09-01T15:24:51Z,idle,wazuh-syscheckd,248919,14748
2026-09-01T15:26:05Z,idle,wazuh-syscheckd,248919,14872
2026-09-01T15:27:47Z,load,wazuh-syscheckd,248919,15732
[... 57 more load-phase rows omitted, same 60s-interval shape ...]
2026-09-01T16:35:09Z,load,wazuh-syscheckd,248919,18720
2026-09-01T16:36:09Z,load,wazuh-syscheckd,248919,18720
2026-09-01T16:37:09Z,load,wazuh-syscheckd,248919,18720
```
</details>

<details><summary>5.x nightly, no PR changes</summary>

```
timestamp,phase,process_name,pid,rss_kb
2026-09-01T15:25:01Z,idle,wazuh-syscheckd,3458,16356
2026-09-01T15:26:16Z,idle,wazuh-syscheckd,3458,16480
2026-09-01T15:28:02Z,load,wazuh-syscheckd,3458,16480
[... 57 more load-phase rows omitted, same 60s-interval shape ...]
2026-09-01T16:36:10Z,load,wazuh-syscheckd,3458,18352
2026-09-01T16:37:11Z,load,wazuh-syscheckd,3458,18352
```
</details>

<details><summary>4.x release baseline</summary>

```
timestamp,phase,process_name,pid,rss_kb
2026-09-01T15:24:30Z,idle,wazuh-syscheckd,204794,13676
2026-09-01T15:25:40Z,idle,wazuh-syscheckd,204794,13676
2026-09-01T15:27:18Z,load,wazuh-syscheckd,204794,13676
[... 57 more load-phase rows omitted, same 60s-interval shape ...]
2026-09-01T16:35:10Z,load,wazuh-syscheckd,204794,14200
2026-09-01T16:36:10Z,load,wazuh-syscheckd,204794,14200
```
</details>

**Reading of these numbers:** at idle, this PR measurably helps — 14.46 MiB vs. nightly's 16.03 MiB, a real -9.8% reduction, bringing 5.x to +8.2% over the 4.x baseline (inside the issue's 10% target). This matches the change's mechanism: no persistent SQLite connection/page-cache/WAL overhead sitting around at idle. Under load, however, this PR does not move the needle — 18.08 MiB vs. nightly's 17.89 MiB is statistically the same (+1%, within run-to-run noise), and both are roughly +30% over the 4.x baseline. Under active churn the in-memory queue holds essentially the same volume of pending data the SQLite-backed version would have; the footprint shifts from "connection overhead" to "queue contents in memory" without a net reduction once real data is flowing. The load-phase gap — which is what the issue's own load profile is scoped to measure — is a pre-existing 5.x characteristic present in both the unmodified nightly and this PR; this PR does not introduce it and does not close it.

One caveat worth flagging for whoever reviews this: an earlier, longer-running investigation into this same issue found `wazuh-syscheckd` RSS never reaches a stable plateau on either 4.x or 5.x even at durations up to an hour, with swings of up to ~400x between runs of the same build taken hours apart. The comparison above is duration-matched and fully concurrent (all three builds under the same load, same manager, same moment), which is the strongest single-run methodology available, but a single 60-minute sample per build should still be read with that instability in mind rather than as a fully converged number.

## Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_: N/A
- Engine _(Wazuh v5.x and above)_: N/A
- Wazuh server API/Framework: N/A

### Artifacts Affected

`libagent_sync_protocol.so` (Linux agent, all packaged architectures)

### Configuration Changes

N/A — no new configuration parameters and no changes to existing defaults.

### Tests Introduced

- A new coalescing-behavior test suite for `InMemoryQueueStorage`, mirroring the existing suite already in place for `PersistentQueueStorage`, run against the new backend instead of SQLite. Also covers item-removal, pending-fetch, and mark-for-sync behavior, `deleteDatabase` against a mocked filesystem, and disk round-trip behavior (save-on-destruct, load-on-construct, cross-format compatibility with the SQLite-backed snapshot format, and that an empty queue skips the disk write entirely).
- The existing queue test suite was updated to replace its former buffer/flush-thread-specific tests (no longer applicable to the new default backend) with direct submit/coalesce tests and an end-to-end round-trip test through the public API against the default storage.

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented (N/A, none)
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

Flagging explicitly for the reviewer: "Relevant evidence provided" is left unchecked on purpose. The idle-phase improvement is real and evidenced above, but the load-phase footprint — the actual target this issue set (≤ ~15.1 MiB, within 10% of the 4.x baseline, under the #37153 load profile) — is not met by this PR as it stands (+30.8% over 4.x under load, essentially unchanged from unmodified nightly). Whether that's acceptable to merge as a partial improvement, or whether it should stay open until the load-phase gap is addressed too, is a call for whoever reviews this rather than something to decide unilaterally in the description.
