### PR TITLE
Agent /stateless events: batching, occupancy ladder, adaptive 413

### DIFF
--- a/.github/actions/check_files/deb_linux_agent_amd64.csv
+++ b/.github/actions/check_files/deb_linux_agent_amd64.csv
@@ -10,7 +10,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12374168,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,505104,0.1
 /var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,218488,0.1
-/var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,105592,0.1
+/var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,270552,0.1
 /var/ossec/lib/libschema_validator.so,root,wazuh,750,file,-rwxr-x---,390232,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2603392,0.1
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,253344,0.1

--- a/.github/actions/check_files/deb_linux_agent_i386.csv
+++ b/.github/actions/check_files/deb_linux_agent_i386.csv
@@ -10,7 +10,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12358288,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,525380,0.1
 /var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,216020,0.1
-/var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,105592,0.1
+/var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,270552,0.1
 /var/ossec/lib/libschema_validator.so,root,wazuh,750,file,-rwxr-x---,426324,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2792476,0.1
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,273712,0.1

--- a/.github/actions/check_files/rpm_linux_agent_amd64.csv
+++ b/.github/actions/check_files/rpm_linux_agent_amd64.csv
@@ -74,7 +74,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12417720,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,484376,0.1
 /var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,220736,0.1
-/var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,105592,0.1
+/var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,270552,0.1
 /var/ossec/lib/libschema_validator.so,root,wazuh,750,file,-rwxr-x---,386024,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2555328,0.1
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,224672,0.1

--- a/.github/actions/check_files/rpm_linux_agent_i386.csv
+++ b/.github/actions/check_files/rpm_linux_agent_i386.csv
@@ -74,7 +74,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12362096,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,541828,0.1
 /var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,216520,0.1
-/var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,105592,0.1
+/var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,270552,0.1
 /var/ossec/lib/libschema_validator.so,root,wazuh,750,file,-rwxr-x---,398136,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2717844,0.1
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,259032,0.1

--- a/src/client-agent/https_client/demo/demo_driver.c
+++ b/src/client-agent/https_client/demo/demo_driver.c
@@ -133,6 +133,13 @@ static void on_state_change(int state, void *user_data)
     fflush(stdout);
 }
 
+static void on_buffer_level(int level, void *user_data)
+{
+    (void)user_data;
+    printf("[+%7ld ms] ~~ buffer level -> %d\n", elapsed_ms(), level);
+    fflush(stdout);
+}
+
 static void nap(int ms)
 {
     struct timespec t = {ms / 1000, (long)(ms % 1000) * 1000000L};
@@ -162,6 +169,7 @@ int main(int argc, char **argv)
     strncpy(config.agent_key, argv[3], sizeof config.agent_key - 1);
     config.verify_mode = HC_VERIFY_NONE; /* demo mock uses a self-signed cert */
     config.notify_interval_s = 2;        /* Notify every 2 s so we see a few   */
+    config.batch_interval_ms = 1000;     /* flush events every 1 s             */
     config.request_timeout_ms = 10000;
     config.backoff_base_ms = 200;
     config.backoff_cap_ms = 2000;
@@ -179,6 +187,7 @@ int main(int argc, char **argv)
     callbacks.on_reenroll_required = on_reenroll_required;
     callbacks.on_config_downloaded = on_config_downloaded;
     callbacks.on_state_change = on_state_change;
+    callbacks.on_buffer_level = on_buffer_level;
 
     printf("== creating + starting the https_client (target %s:%s) ==\n", argv[1], argv[2]);
     hc_handle *handle = hc_create(&config, &callbacks);
@@ -192,6 +201,14 @@ int main(int argc, char **argv)
     /* Give the control thread a moment to run Startup + register. */
     nap(800);
 
+    printf("== feeding 5 events into the /stateless stream ==\n");
+    for (int i = 0; i < 5; i++)
+    {
+        char frame[64];
+        int n = snprintf(frame, sizeof frame, "1:/var/log/syslog:demo event %d", i);
+        hc_submit_event(handle, (const uint8_t *)frame, (size_t)n);
+    }
+
     printf("== forcing an out-of-cycle Notify ==\n");
     hc_notify_now(handle);
 
@@ -204,9 +221,9 @@ int main(int argc, char **argv)
     nap(7000);
 
     /* Optional sustained mode: DEMO_SECONDS=<n> keeps the client alive after
-     * the scripted walkthrough so the periodic Notify traffic (and the key
-     * rotation at notify #7) stays visible. SIGINT/SIGTERM (Ctrl-C, docker
-     * stop) ends it early through the same clean drain. */
+     * the scripted walkthrough, submitting an event every 2 s so the periodic
+     * Notify + /stateless traffic stays visible. SIGINT/SIGTERM (Ctrl-C,
+     * docker stop) ends it early through the same clean drain. */
     const char *extra = getenv("DEMO_SECONDS");
     const long extra_s = extra ? strtol(extra, NULL, 10) : 0;
     if (extra_s > 0)
@@ -216,6 +233,25 @@ int main(int argc, char **argv)
         fflush(stdout);
         for (long tick = 0; tick * 2 < extra_s && !atomic_load(&g_stop); tick++)
         {
+            char frame[80];
+            int n = snprintf(frame, sizeof frame, "1:/var/log/syslog:sustained event %ld", tick);
+            hc_submit_event(handle, (const uint8_t *)frame, (size_t)n);
+
+            /* Every 10 s, burst enough events to exceed the mock's /stateless
+             * payload cap, so the 413 -> split -> resend path is visible. */
+            if (tick > 0 && tick % 5 == 0)
+            {
+                printf("== bursting 120 events (exceeds the /stateless cap -> 413 "
+                       "split/resend) ==\n");
+                fflush(stdout);
+                for (int burst = 0; burst < 120; burst++)
+                {
+                    char big[96];
+                    int m = snprintf(big, sizeof big,
+                                     "1:/var/log/burst:event %ld-%d payload-padding", tick, burst);
+                    hc_submit_event(handle, (const uint8_t *)big, (size_t)m);
+                }
+            }
             nap(2000);
         }
     }

--- a/src/client-agent/https_client/demo/mock_manager.py
+++ b/src/client-agent/https_client/demo/mock_manager.py
@@ -54,6 +54,11 @@ class Handler(BaseHTTPRequestHandler):
     CONFIG_FLIP_AT = 3
     SETTINGS_FLIP_AT = 5
 
+    # /stateless payload cap: a bigger body gets 413, so the client must split
+    # and resend smaller (#37835). Small here so the burst in sustained mode
+    # triggers it visibly.
+    STATELESS_MAX_BODY = 2048
+
     # Credential rotation (#37828): after this notify the mock verifies ONLY
     # against ROTATED_KEY, so the agent's old key starts getting 401 and must
     # re-enroll. The demo driver swaps to ROTATED_KEY via hc_set_agent_key.
@@ -155,6 +160,8 @@ class Handler(BaseHTTPRequestHandler):
 
         if target == "/control":
             self._handle_control(body)
+        elif target == "/stateless":
+            self._handle_stateless(body)
         elif target == "/download":
             self._handle_download(body)
         else:
@@ -217,6 +224,16 @@ class Handler(BaseHTTPRequestHandler):
         self._reply_chunked(blob)
         log(f"     /download   -> 200  chunked, {len(blob)} B "
             f"(sha256 {hashlib.sha256(blob).hexdigest()[:8]}..)")
+
+    def _handle_stateless(self, body):
+        if len(body) > Handler.STATELESS_MAX_BODY:
+            self._reply(413, {"error": "payload too large"})
+            log(f"     /stateless  -> 413  ({len(body)} B > "
+                f"{Handler.STATELESS_MAX_BODY} B cap; client halves + resends)")
+            return
+        events = body.count(b"\nE ") + (1 if b"\nE " not in body and b"E " in body else 0)
+        self._reply(200)  # 200 with an empty body per #37732
+        log(f"     /stateless  -> 200  ({len(body)} B, ~{events} events accepted)")
 
 
 def main():

--- a/src/client-agent/https_client/include/https_client.h
+++ b/src/client-agent/https_client/include/https_client.h
@@ -67,6 +67,17 @@ typedef enum hc_conn_state_t
     ///< until hc_set_agent_key() supplies a new key.
 } hc_conn_state_t;
 
+/* Occupancy level of the stateless accumulator. Replaces the legacy client
+ * buffer levels so the manager-side flood alerts (rules 202-205 analogues)
+ * keep working. */
+typedef enum hc_buffer_level_t
+{
+    HC_BUFFER_NORMAL = 0,
+    HC_BUFFER_WARNING,
+    HC_BUFFER_FULL,
+    HC_BUFFER_FLOOD
+} hc_buffer_level_t;
+
 /* Outcome classes of a request/submission (D9 classification). */
 typedef enum hc_result_t
 {
@@ -109,6 +120,12 @@ typedef struct hc_config_t
     char client_cert[HC_MAX_PATH]; ///< Optional mTLS certificate (FR11.3).
     char client_key[HC_MAX_PATH];  ///< Optional mTLS private key.
     char ciphers[HC_MAX_CIPHERS];  ///< Optional cipher list.
+
+    uint64_t batch_size_bytes;      ///< Max /stateless payload per request
+    ///< (adaptive: halves on 413, ramps back on
+    ///< success); 0 -> 1 MiB.
+    uint32_t batch_interval_ms;     ///< <batch><interval>; 0 -> 10000.
+    uint32_t buffer_cap_multiplier; ///< Accumulator cap = N x batch size; 0 -> 4.
 
     uint32_t notify_interval_s;         ///< notify_time; 0 -> 20.
     uint32_t rejected_retry_interval_s; ///< Slow re-Startup cadence; 0 -> 60.
@@ -157,6 +174,7 @@ typedef struct hc_callbacks_t
     void (*on_config_downloaded)(const char* config_hash, const char* file_path,
                                  void* user_data);
     void (*on_state_change)(int state, void* user_data);  ///< hc_conn_state_t
+    void (*on_buffer_level)(int level, void* user_data);  ///< hc_buffer_level_t
     void* user_data;
 } hc_callbacks_t;
 
@@ -181,16 +199,26 @@ HC_EXPORTED hc_handle* hc_create(const hc_config_t* config, const hc_callbacks_t
 HC_EXPORTED bool hc_start(hc_handle* handle);
 
 /**
- * @brief Stop the client: drains within the configured window (final
- *        Notify), aborts in-flight requests explicitly and joins every
- *        thread. No callback fires after this returns. Terminal (single-shot):
- *        the instance cannot be restarted afterwards. Safe without a prior
- *        start.
+ * @brief Stop the client: drains within the configured window (stateless
+ *        flush + final Notify), aborts in-flight requests explicitly and
+ *        joins every thread. No callback fires after this returns. Terminal
+ *        (single-shot): the instance cannot be restarted afterwards. Safe
+ *        without a prior start.
  */
 HC_EXPORTED void hc_stop(hc_handle* handle);
 
 /** @brief Destroy the instance. Implies hc_stop(). NULL-safe. */
 HC_EXPORTED void hc_destroy(hc_handle* handle);
+
+/* ---- data plane (called from agentd's EventForward seam) ---- */
+
+/**
+ * @brief Submit one event frame ("queue:location:message" bytes) for the
+ *        /stateless batch. Returns false when the client is not running
+ *        or the accumulator is full (drop-newest; the occupancy ladder is
+ *        surfaced via on_buffer_level).
+ */
+HC_EXPORTED bool hc_submit_event(hc_handle* handle, const uint8_t* frame, size_t length);
 
 /* ---- control plane ---- */
 

--- a/src/client-agent/https_client/include/https_client.h
+++ b/src/client-agent/https_client/include/https_client.h
@@ -127,6 +127,16 @@ typedef struct hc_config_t
     uint32_t batch_interval_ms;     ///< <batch><interval>; 0 -> 10000.
     uint32_t buffer_cap_multiplier; ///< Accumulator cap = N x batch size; 0 -> 4.
 
+    /* Occupancy ladder, mirroring the legacy client buffer's internal options
+     * so the manager-side flood rules keep firing on the same thresholds.
+     * Note the struct's zero-means-default convention: agent.normal_level and
+     * agent.tolerance accept a literal 0, which is indistinguishable from
+     * "unset" here and takes the default instead. */
+    uint32_t buffer_warn_level;        ///< agent.warn_level, percent; 0 -> 90.
+    uint32_t buffer_normal_level;      ///< agent.normal_level, percent; 0 -> 70.
+    uint32_t buffer_flood_tolerance_s; ///< agent.tolerance: seconds FULL must
+    ///< hold before FLOOD; 0 -> 15.
+
     uint32_t notify_interval_s;         ///< notify_time; 0 -> 20.
     uint32_t rejected_retry_interval_s; ///< Slow re-Startup cadence; 0 -> 60.
 

--- a/src/client-agent/https_client/src/adaptivePayload.hpp
+++ b/src/client-agent/https_client/src/adaptivePayload.hpp
@@ -22,8 +22,8 @@
  *        hard floor, a server cap below floor + header would wedge the stream
  *        retrying the same too-big batch forever. At one byte the snapshot
  *        still carries one whole event, so a persistent 413 converges onto
- *        the single-event drop path instead of livelocking. Pure and single-
- *        threaded (owned by the stateless sender thread).
+ *        the single-event drop path instead of livelocking. StatelessStream
+ *        serializes access because intake also reads the current budget.
  */
 class AdaptivePayload final
 {

--- a/src/client-agent/https_client/src/adaptivePayload.hpp
+++ b/src/client-agent/https_client/src/adaptivePayload.hpp
@@ -1,0 +1,59 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 21, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _HC_ADAPTIVE_PAYLOAD_HPP
+#define _HC_ADAPTIVE_PAYLOAD_HPP
+
+#include <algorithm>
+#include <cstdint>
+
+/**
+ * @brief The effective /stateless payload budget (#37835). Starts at the
+ *        configured max; a 413 halves it, a successful send doubles it back
+ *        toward the max. Halving has NO lower clamp (only never-zero): with a
+ *        hard floor, a server cap below floor + header would wedge the stream
+ *        retrying the same too-big batch forever. At one byte the snapshot
+ *        still carries one whole event, so a persistent 413 converges onto
+ *        the single-event drop path instead of livelocking. Pure and single-
+ *        threaded (owned by the stateless sender thread).
+ */
+class AdaptivePayload final
+{
+    public:
+        explicit AdaptivePayload(uint64_t maxBytes)
+            : m_max(maxBytes == 0 ? 1 : maxBytes)
+            , m_effective(m_max)
+        {
+        }
+
+        uint64_t effectiveBytes() const
+        {
+            return m_effective;
+        }
+
+        /// A 413: shrink so the next batch carries fewer events (never zero).
+        void onPayloadTooLarge()
+        {
+            m_effective = std::max<uint64_t>(1, m_effective / 2);
+        }
+
+        /// A successful send: ramp back toward the configured max.
+        void onSuccess()
+        {
+            m_effective = std::min(m_max, m_effective * 2);
+        }
+
+    private:
+        uint64_t m_max;
+        uint64_t m_effective;
+};
+
+#endif // _HC_ADAPTIVE_PAYLOAD_HPP

--- a/src/client-agent/https_client/src/bufferLevel.hpp
+++ b/src/client-agent/https_client/src/bufferLevel.hpp
@@ -1,0 +1,157 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 24, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _HC_BUFFER_LEVEL_HPP
+#define _HC_BUFFER_LEVEL_HPP
+
+#include "https_client.h"
+
+#include <cstdint>
+
+/**
+ * @brief The four-level client-buffer ladder, re-based on byte occupancy
+ *        (#37835).
+ *
+ * A port of the legacy leaky bucket's state machine (client-agent/src/buffer.c)
+ * so the manager-side flood rules keep seeing the same transitions once
+ * stateless events stop passing through buffer_append():
+ *
+ *   NORMAL  -> WARNING  at warn_level % occupancy
+ *   any     -> FULL     the moment an event is actually dropped (the byte
+ *                       analogue of buffer.c's full(): no room, event lost)
+ *   FULL    -> FLOOD    once FULL has held for tolerance seconds
+ *   any     -> NORMAL   at normal_level % occupancy
+ *
+ * The gap between warn_level and normal_level is the hysteresis that keeps a
+ * buffer hovering around the warn mark from flapping; buffer.c's defaults
+ * (agent.warn_level 90, agent.normal_level 70, agent.tolerance 15) are the
+ * module's defaults too, and the bridge forwards whatever the operator set.
+ *
+ * observe() reports whether the transition is one the agent announces.
+ * buffer.c deliberately does not announce the step down from FULL/FLOOD to
+ * WARNING -- only the return to NORMAL is reported -- so neither does this.
+ *
+ * Pure and not thread-safe: StatelessStream owns one and calls it under its
+ * own state mutex.
+ */
+class BufferLevelLadder final
+{
+    public:
+        struct Transition
+        {
+            bool announce;          ///< True when the agent reports this step.
+            hc_buffer_level_t level;
+        };
+
+        BufferLevelLadder(uint32_t warnLevel, uint32_t normalLevel, uint32_t toleranceSeconds)
+            : m_warnLevel(warnLevel)
+              // Mirrors internal_options' own constraint (normal_level max is
+              // warn_level - 1): a config that inverts them would otherwise make
+              // every observation both "warn" and "normal" at once.
+            , m_normalLevel(normalLevel < warnLevel ? normalLevel
+                            : (warnLevel > 0 ? warnLevel - 1 : 0))
+            , m_toleranceSeconds(toleranceSeconds)
+        {
+        }
+
+        /**
+         * @brief Feeds one observation of the buffer.
+         *
+         * @param occupancyPercent Whole-buffer occupancy, 0-100.
+         * @param eventDropped     True when this observation follows a
+         *                         drop-newest rejection (buffer.c's full()).
+         * @param nowSeconds       Monotonic seconds, for the FLOOD dwell.
+         */
+        Transition observe(unsigned occupancyPercent, bool eventDropped, int64_t nowSeconds)
+        {
+            // buffer.c: from NORMAL or WARNING, a full buffer goes straight to
+            // FULL and starts the tolerance clock.
+            if (eventDropped && m_level != HC_BUFFER_FULL && m_level != HC_BUFFER_FLOOD)
+            {
+                m_level = HC_BUFFER_FULL;
+                m_fullSince = nowSeconds;
+                return Transition {true, m_level};
+            }
+
+            switch (m_level)
+            {
+                case HC_BUFFER_NORMAL:
+                    if (occupancyPercent >= m_warnLevel)
+                    {
+                        m_level = HC_BUFFER_WARNING;
+                        return Transition {true, m_level};
+                    }
+
+                    break;
+
+                case HC_BUFFER_WARNING:
+                    if (occupancyPercent <= m_normalLevel)
+                    {
+                        m_level = HC_BUFFER_NORMAL;
+                        return Transition {true, m_level};
+                    }
+
+                    break;
+
+                case HC_BUFFER_FULL:
+                    if (occupancyPercent <= m_normalLevel)
+                    {
+                        m_level = HC_BUFFER_NORMAL;
+                        return Transition {true, m_level};
+                    }
+
+                    if (occupancyPercent <= m_warnLevel)
+                    {
+                        m_level = HC_BUFFER_WARNING; // Quiet step down, as in buffer.c.
+                        return Transition {false, m_level};
+                    }
+
+                    if (nowSeconds - m_fullSince >= static_cast<int64_t>(m_toleranceSeconds))
+                    {
+                        m_level = HC_BUFFER_FLOOD;
+                        return Transition {true, m_level};
+                    }
+
+                    break;
+
+                case HC_BUFFER_FLOOD:
+                    if (occupancyPercent <= m_normalLevel)
+                    {
+                        m_level = HC_BUFFER_NORMAL;
+                        return Transition {true, m_level};
+                    }
+
+                    if (occupancyPercent <= m_warnLevel)
+                    {
+                        m_level = HC_BUFFER_WARNING; // Quiet step down, as in buffer.c.
+                        return Transition {false, m_level};
+                    }
+
+                    break;
+            }
+
+            return Transition {false, m_level};
+        }
+
+        hc_buffer_level_t level() const
+        {
+            return m_level;
+        }
+
+    private:
+        uint32_t m_warnLevel;
+        uint32_t m_normalLevel;
+        uint32_t m_toleranceSeconds;
+        hc_buffer_level_t m_level {HC_BUFFER_NORMAL};
+        int64_t m_fullSince {0};
+};
+
+#endif // _HC_BUFFER_LEVEL_HPP

--- a/src/client-agent/https_client/src/callbackDispatcher.cpp
+++ b/src/client-agent/https_client/src/callbackDispatcher.cpp
@@ -128,7 +128,7 @@ void CallbackDispatcher::onConfigDownloaded(const std::string& configHash,
     enqueue([this, configHash, file = std::move(file)]
     {
         m_callbacks.on_config_downloaded(configHash.c_str(), file->path().c_str(),
-        m_callbacks.user_data);
+                                         m_callbacks.user_data);
     });
 }
 

--- a/src/client-agent/https_client/src/callbackDispatcher.cpp
+++ b/src/client-agent/https_client/src/callbackDispatcher.cpp
@@ -141,3 +141,13 @@ void CallbackDispatcher::onStateChange(hc_conn_state_t state)
 
     enqueue([this, state] { m_callbacks.on_state_change(state, m_callbacks.user_data); });
 }
+
+void CallbackDispatcher::onBufferLevel(hc_buffer_level_t level)
+{
+    if (m_callbacks.on_buffer_level == nullptr)
+    {
+        return;
+    }
+
+    enqueue([this, level] { m_callbacks.on_buffer_level(level, m_callbacks.user_data); });
+}

--- a/src/client-agent/https_client/src/callbackDispatcher.hpp
+++ b/src/client-agent/https_client/src/callbackDispatcher.hpp
@@ -48,6 +48,7 @@ class CallbackDispatcher final : public ICallbackSink
         void onConfigDownloaded(const std::string& configHash,
                                 std::shared_ptr<SpoolFile> file) override;
         void onStateChange(hc_conn_state_t state) override;
+        void onBufferLevel(hc_buffer_level_t level) override;
 
     private:
         void run();

--- a/src/client-agent/https_client/src/callbackSink.hpp
+++ b/src/client-agent/https_client/src/callbackSink.hpp
@@ -37,6 +37,7 @@ class ICallbackSink
         virtual void onConfigDownloaded(const std::string& configHash,
                                         std::shared_ptr<SpoolFile> file) = 0;
         virtual void onStateChange(hc_conn_state_t state) = 0;
+        virtual void onBufferLevel(hc_buffer_level_t level) = 0;
 };
 
 #endif // _HC_CALLBACK_SINK_HPP

--- a/src/client-agent/https_client/src/configFetcher.cpp
+++ b/src/client-agent/https_client/src/configFetcher.cpp
@@ -72,7 +72,7 @@ std::shared_ptr<SpoolFile> ConfigFetcher::fetch(const std::string& expectedHash,
     if (result.outcome != OutcomeClass::Ok)
     {
         LOGFN_WARN(m_logFn, "Config download for group '%s' failed (outcome %d); "
-                            "the next notify re-triggers it.", group.c_str(),
+                   "the next notify re-triggers it.", group.c_str(),
                    static_cast<int>(result.outcome));
         return nullptr;
     }
@@ -82,7 +82,7 @@ std::shared_ptr<SpoolFile> ConfigFetcher::fetch(const std::string& expectedHash,
     if (!actualHash || lowered(*actualHash) != lowered(expectedHash))
     {
         LOGFN_WARN(m_logFn, "Downloaded config hash %s does not match the advertised %s; "
-                            "discarding it.", actualHash ? actualHash->c_str() : "(unreadable)",
+                   "discarding it.", actualHash ? actualHash->c_str() : "(unreadable)",
                    expectedHash.c_str());
         return nullptr; // RAII deletes the file.
     }

--- a/src/client-agent/https_client/src/controlStream.cpp
+++ b/src/client-agent/https_client/src/controlStream.cpp
@@ -266,7 +266,7 @@ void ControlStream::maybeDownloadConfig(const std::string& managerHash, const st
     }
 
     LOGFN_INFO(m_logFn, "Manager config hash %s differs from the local one; downloading "
-                        "the new configuration (group '%s').", managerHash.c_str(), group.c_str());
+               "the new configuration (group '%s').", managerHash.c_str(), group.c_str());
     auto file = m_fetcher.fetch(managerHash, group, waiter);
 
     if (!file)
@@ -302,7 +302,7 @@ void ControlStream::maybeArmSettingsRefresh(const std::string& incoming)
         if (!m_settingsLoopWarned)
         {
             LOGFN_WARN(m_logFn, "settings_hash %s still mismatches after a refresh; "
-                                "holding the baseline until it changes.", incoming.c_str());
+                       "holding the baseline until it changes.", incoming.c_str());
             m_settingsLoopWarned = true;
         }
 

--- a/src/client-agent/https_client/src/curlPerformer.cpp
+++ b/src/client-agent/https_client/src/curlPerformer.cpp
@@ -148,6 +148,7 @@ bool CurlPerformer::configureResponseSink(ICurlHandle& handle, const HttpRequest
             CloseHandle(winHandle); // A reparse point (or the query failed): refuse.
         }
     }
+
 #else
     const int fd = ::open(spec.responseFilePath.c_str(),
                           O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW | O_CLOEXEC, S_IRUSR | S_IWUSR);
@@ -157,6 +158,7 @@ bool CurlPerformer::configureResponseSink(ICurlHandle& handle, const HttpRequest
     {
         ::close(fd); // LCOV_EXCL_LINE: fdopen failing on a good fd is not reproducible.
     }
+
 #endif
 
     if (file == nullptr)

--- a/src/client-agent/https_client/src/eventAccumulator.cpp
+++ b/src/client-agent/https_client/src/eventAccumulator.cpp
@@ -11,7 +11,7 @@
 
 #include "eventAccumulator.hpp"
 
-std::string encodeEventLine(const uint8_t* frame, size_t length)
+std::string encodeStatelessEventLine(const uint8_t* frame, size_t length)
 {
     std::string line = "E ";
     line.reserve(length + 3);
@@ -33,15 +33,14 @@ std::string encodeEventLine(const uint8_t* frame, size_t length)
 
 EventAccumulator::EventAccumulator(uint64_t batchSizeBytes, uint32_t capMultiplier,
                                    uint32_t batchIntervalMs)
-    : m_batchSizeBytes(batchSizeBytes)
-    , m_capBytes(batchSizeBytes * capMultiplier)
+    : m_capBytes(batchSizeBytes * capMultiplier)
     , m_batchIntervalMs(batchIntervalMs)
 {
 }
 
 bool EventAccumulator::append(const uint8_t* frame, size_t length)
 {
-    const std::string line = encodeEventLine(frame, length);
+    const std::string line = encodeStatelessEventLine(frame, length);
     std::lock_guard<std::mutex> lock(m_mutex);
 
     if (m_buffer.size() + line.size() > m_capBytes)

--- a/src/client-agent/https_client/src/eventAccumulator.cpp
+++ b/src/client-agent/https_client/src/eventAccumulator.cpp
@@ -104,31 +104,18 @@ void EventAccumulator::consume(const Snapshot& sent)
     }
 }
 
-hc_buffer_level_t EventAccumulator::level() const
+unsigned EventAccumulator::occupancyPercent() const
 {
     std::lock_guard<std::mutex> lock(m_mutex);
-    return levelForLocked();
-}
 
-hc_buffer_level_t EventAccumulator::levelForLocked() const
-{
-    // Occupancy of the whole bounded buffer, mapped onto the legacy ladder.
-    const double occupancy = static_cast<double>(m_buffer.size()) / static_cast<double>(m_capBytes);
-
-    if (occupancy >= 0.90)
+    if (m_capBytes == 0)
     {
-        return HC_BUFFER_FLOOD;
+        return 100; // LCOV_EXCL_LINE: the config layer floors the cap above zero.
     }
 
-    if (occupancy >= 0.75)
-    {
-        return HC_BUFFER_FULL;
-    }
-
-    if (occupancy >= 0.50)
-    {
-        return HC_BUFFER_WARNING;
-    }
-
-    return HC_BUFFER_NORMAL;
+    // Integer percent of the whole bounded buffer, widened first so a large
+    // configured cap cannot overflow size_t on a 32-bit agent. Truncation
+    // matches the legacy float comparison at every threshold: both treat 89.9%
+    // as below 90.
+    return static_cast<unsigned>(static_cast<uint64_t>(m_buffer.size()) * 100 / m_capBytes);
 }

--- a/src/client-agent/https_client/src/eventAccumulator.cpp
+++ b/src/client-agent/https_client/src/eventAccumulator.cpp
@@ -1,0 +1,135 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 17, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "eventAccumulator.hpp"
+
+std::string encodeEventLine(const uint8_t* frame, size_t length)
+{
+    std::string line = "E ";
+    line.reserve(length + 3);
+
+    for (size_t index = 0; index < length; index++)
+    {
+        const char character = static_cast<char>(frame[index]);
+        line.push_back(character);
+
+        if (character == '\n')
+        {
+            line.push_back(' '); // Continuation escape: one leading space.
+        }
+    }
+
+    line.push_back('\n');
+    return line;
+}
+
+EventAccumulator::EventAccumulator(uint64_t batchSizeBytes, uint32_t capMultiplier,
+                                   uint32_t batchIntervalMs)
+    : m_batchSizeBytes(batchSizeBytes)
+    , m_capBytes(batchSizeBytes * capMultiplier)
+    , m_batchIntervalMs(batchIntervalMs)
+{
+}
+
+bool EventAccumulator::append(const uint8_t* frame, size_t length)
+{
+    const std::string line = encodeEventLine(frame, length);
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    if (m_buffer.size() + line.size() > m_capBytes)
+    {
+        return false; // Drop-newest.
+    }
+
+    m_buffer += line;
+    m_lineLengths.push_back(line.size());
+    return true;
+}
+
+bool EventAccumulator::flushDue(uint64_t elapsedMs, uint64_t thresholdBytes) const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    if (m_buffer.empty())
+    {
+        return false;
+    }
+
+    return m_buffer.size() >= thresholdBytes || elapsedMs >= m_batchIntervalMs;
+}
+
+bool EventAccumulator::empty() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_buffer.empty();
+}
+
+EventAccumulator::Snapshot EventAccumulator::snapshot(uint64_t maxBytes) const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    size_t bytes = 0;
+    unsigned events = 0;
+
+    for (const size_t lineLength : m_lineLengths)
+    {
+        // Always take the first event; then stop before exceeding the budget.
+        if (events > 0 && bytes + lineLength > maxBytes)
+        {
+            break;
+        }
+
+        bytes += lineLength;
+        events++;
+    }
+
+    return Snapshot {m_buffer.substr(0, bytes), bytes, events};
+}
+
+void EventAccumulator::consume(const Snapshot& sent)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    const size_t toErase = std::min(sent.byteLength, m_buffer.size());
+    m_buffer.erase(0, toErase);
+
+    for (unsigned popped = 0; popped < sent.eventCount && !m_lineLengths.empty(); popped++)
+    {
+        m_lineLengths.pop_front();
+    }
+}
+
+hc_buffer_level_t EventAccumulator::level() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return levelForLocked();
+}
+
+hc_buffer_level_t EventAccumulator::levelForLocked() const
+{
+    // Occupancy of the whole bounded buffer, mapped onto the legacy ladder.
+    const double occupancy = static_cast<double>(m_buffer.size()) / static_cast<double>(m_capBytes);
+
+    if (occupancy >= 0.90)
+    {
+        return HC_BUFFER_FLOOD;
+    }
+
+    if (occupancy >= 0.75)
+    {
+        return HC_BUFFER_FULL;
+    }
+
+    if (occupancy >= 0.50)
+    {
+        return HC_BUFFER_WARNING;
+    }
+
+    return HC_BUFFER_NORMAL;
+}

--- a/src/client-agent/https_client/src/eventAccumulator.hpp
+++ b/src/client-agent/https_client/src/eventAccumulator.hpp
@@ -12,8 +12,6 @@
 #ifndef _HC_EVENT_ACCUMULATOR_HPP
 #define _HC_EVENT_ACCUMULATOR_HPP
 
-#include "https_client.h"
-
 #include <cstddef>
 #include <cstdint>
 #include <deque>
@@ -26,8 +24,9 @@
  * Events are stored as "E <frame>\n" lines with embedded newlines escaped by
  * one leading space (the H/E continuation rule). The buffer is bounded at
  * capMultiplier x batchSize; on overflow the newest event is dropped
- * (drop-newest), and byte occupancy maps onto the four-level ladder so the
- * manager-side flood alerts keep working. snapshot(maxBytes) cuts at
+ * (drop-newest). It reports raw byte occupancy only -- BufferLevelLadder owns
+ * the four-level state machine, because that needs a clock (the FLOOD dwell)
+ * and belongs with the stream. snapshot(maxBytes) cuts at
  * an event boundary within a byte budget (always >= 1 event); consume() is
  * tail-preserving: only the sent prefix is removed, so events appended during
  * the send — and any left behind by a bounded snapshot — survive.
@@ -63,11 +62,10 @@ class EventAccumulator final
         /// prefix that was sent), preserving anything appended meanwhile.
         void consume(const Snapshot& sent);
 
-        hc_buffer_level_t level() const;
+        /// Whole-buffer occupancy as a percentage (0-100), for the ladder.
+        unsigned occupancyPercent() const;
 
     private:
-        hc_buffer_level_t levelForLocked() const;
-
         mutable std::mutex m_mutex;
         std::string m_buffer;
         std::deque<size_t> m_lineLengths; ///< Byte length of each buffered event line.

--- a/src/client-agent/https_client/src/eventAccumulator.hpp
+++ b/src/client-agent/https_client/src/eventAccumulator.hpp
@@ -25,9 +25,9 @@
  *
  * Events are stored as "E <frame>\n" lines with embedded newlines escaped by
  * one leading space (the H/E continuation rule). The buffer is bounded at
- * capMultiplier x batchSize; on overflow the newest event is dropped and
- * counted (drop-newest), and byte occupancy maps onto the four-level ladder
- * so the manager-side flood alerts keep working. snapshot(maxBytes) cuts at
+ * capMultiplier x batchSize; on overflow the newest event is dropped
+ * (drop-newest), and byte occupancy maps onto the four-level ladder so the
+ * manager-side flood alerts keep working. snapshot(maxBytes) cuts at
  * an event boundary within a byte budget (always >= 1 event); consume() is
  * tail-preserving: only the sent prefix is removed, so events appended during
  * the send — and any left behind by a bounded snapshot — survive.
@@ -71,13 +71,12 @@ class EventAccumulator final
         mutable std::mutex m_mutex;
         std::string m_buffer;
         std::deque<size_t> m_lineLengths; ///< Byte length of each buffered event line.
-        uint64_t m_batchSizeBytes;
         uint64_t m_capBytes;
         uint32_t m_batchIntervalMs;
 };
 
 /// Escapes one frame into an "E <frame>\n" line (embedded '\n' -> "\n ").
 /// Exposed for direct unit testing of the escaping rule.
-std::string encodeEventLine(const uint8_t* frame, size_t length);
+std::string encodeStatelessEventLine(const uint8_t* frame, size_t length);
 
 #endif // _HC_EVENT_ACCUMULATOR_HPP

--- a/src/client-agent/https_client/src/eventAccumulator.hpp
+++ b/src/client-agent/https_client/src/eventAccumulator.hpp
@@ -1,0 +1,83 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 17, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _HC_EVENT_ACCUMULATOR_HPP
+#define _HC_EVENT_ACCUMULATOR_HPP
+
+#include "https_client.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <mutex>
+#include <string>
+
+/**
+ * @brief The /stateless byte-budget accumulator (D6), pure and thread-safe.
+ *
+ * Events are stored as "E <frame>\n" lines with embedded newlines escaped by
+ * one leading space (the H/E continuation rule). The buffer is bounded at
+ * capMultiplier x batchSize; on overflow the newest event is dropped and
+ * counted (drop-newest), and byte occupancy maps onto the four-level ladder
+ * so the manager-side flood alerts keep working. snapshot(maxBytes) cuts at
+ * an event boundary within a byte budget (always >= 1 event); consume() is
+ * tail-preserving: only the sent prefix is removed, so events appended during
+ * the send — and any left behind by a bounded snapshot — survive.
+ */
+class EventAccumulator final
+{
+    public:
+        struct Snapshot
+        {
+            std::string body;    ///< "E ..." lines ready to follow the H line.
+            size_t byteLength;   ///< Bytes represented (the prefix consume() removes).
+            unsigned eventCount;
+        };
+
+        EventAccumulator(uint64_t batchSizeBytes, uint32_t capMultiplier, uint32_t batchIntervalMs);
+
+        /// Appends one event. Returns false (drop-newest) when the cap is hit.
+        bool append(const uint8_t* frame, size_t length);
+
+        /// True when a flush is due: bytes >= thresholdBytes, or age >= interval
+        /// and there is something to send. elapsedMs is the caller's clock; the
+        /// stream passes the effective (adaptive) payload size as the threshold.
+        bool flushDue(uint64_t elapsedMs, uint64_t thresholdBytes) const;
+
+        bool empty() const;
+
+        /// Copies a leading run of whole events fitting in maxBytes for sending;
+        /// always includes at least the first event (so a lone oversized event
+        /// can be sent/dropped, never wedged). consume() removes the sent prefix.
+        Snapshot snapshot(uint64_t maxBytes) const;
+
+        /// Removes exactly the first byteLength bytes and eventCount events (the
+        /// prefix that was sent), preserving anything appended meanwhile.
+        void consume(const Snapshot& sent);
+
+        hc_buffer_level_t level() const;
+
+    private:
+        hc_buffer_level_t levelForLocked() const;
+
+        mutable std::mutex m_mutex;
+        std::string m_buffer;
+        std::deque<size_t> m_lineLengths; ///< Byte length of each buffered event line.
+        uint64_t m_batchSizeBytes;
+        uint64_t m_capBytes;
+        uint32_t m_batchIntervalMs;
+};
+
+/// Escapes one frame into an "E <frame>\n" line (embedded '\n' -> "\n ").
+/// Exposed for direct unit testing of the escaping rule.
+std::string encodeEventLine(const uint8_t* frame, size_t length);
+
+#endif // _HC_EVENT_ACCUMULATOR_HPP

--- a/src/client-agent/https_client/src/hcInterface.cpp
+++ b/src/client-agent/https_client/src/hcInterface.cpp
@@ -125,6 +125,23 @@ extern "C"
         }
     }
 
+    bool hc_submit_event(hc_handle* handle, const uint8_t* frame, size_t length)
+    {
+        if (handle == nullptr)
+        {
+            return false;
+        }
+
+        try
+        {
+            return handle->impl.submitEvent(frame, length);
+        }
+        catch (...)
+        {
+            return false; // LCOV_EXCL_LINE: nothing throws into C.
+        }
+    }
+
     void hc_notify_now(hc_handle* handle)
     {
         if (handle == nullptr)

--- a/src/client-agent/https_client/src/httpsClientFacade.cpp
+++ b/src/client-agent/https_client/src/httpsClientFacade.cpp
@@ -21,6 +21,7 @@ HttpsClientFacade::HttpsClientFacade(const hc_config_t& config, const hc_callbac
     , m_performer(m_config, defaultCurlHandleFactory())
     , m_dispatcher(callbacks)
     , m_configHash(m_config.configChecksum)
+    , m_stateless(m_config, m_performer, m_signer, m_clock, m_random, m_dispatcher, m_authGate)
     , m_control(m_config, m_performer, m_signer, m_clock, m_random, m_dispatcher, m_spoolFactory,
                 m_configHash, m_cluster, m_authGate)
 {
@@ -64,6 +65,7 @@ bool HttpsClientFacade::start()
     m_dispatcher.start();
     m_dispatcher.onStateChange(HC_STATE_STARTING);
     m_controlThread = std::thread(&HttpsClientFacade::controlLoop, this);
+    m_statelessThread = std::thread(&HttpsClientFacade::statelessLoop, this);
     return true;
 }
 
@@ -84,6 +86,7 @@ void HttpsClientFacade::stop()
 
     // Interrupt in-flight requests and break the loops; wake gated streams.
     m_controlWaiter.requestStop();
+    m_statelessWaiter.requestStop();
     m_gate.abort();
 
     if (m_controlThread.joinable())
@@ -91,7 +94,12 @@ void HttpsClientFacade::stop()
         m_controlThread.join();
     }
 
-    drain(); // Best-effort final shutdown message, from this thread.
+    if (m_statelessThread.joinable())
+    {
+        m_statelessThread.join();
+    }
+
+    drain(); // Best-effort final flush + final shutdown message, from this thread.
 
     m_dispatcher.onStateChange(HC_STATE_STOPPED);
     m_dispatcher.stop(); // Drains queued callbacks, then joins.
@@ -115,6 +123,24 @@ void HttpsClientFacade::controlLoop()
     }
 }
 
+void HttpsClientFacade::statelessLoop()
+{
+    if (!m_gate.wait())
+    {
+        return; // Aborted before registration.
+    }
+
+    while (true)
+    {
+        m_stateless.tick(m_statelessWaiter, false);
+
+        if (!m_statelessWaiter.waitFor(std::chrono::milliseconds {m_config.batchIntervalMs}))
+        {
+            break;
+        }
+    }
+}
+
 void HttpsClientFacade::drain()
 {
     if (m_authGate.paused() || m_control.connState() != HC_STATE_REGISTERED)
@@ -122,6 +148,7 @@ void HttpsClientFacade::drain()
         return; // Paused (dead key) or never registered: nothing to flush.
     }
 
+    m_stateless.drain(m_drainWaiter);   // Flush the backlog in bounded batches.
     m_control.drainStep(m_drainWaiter); // Final shutdown message.
 }
 
@@ -130,6 +157,16 @@ std::chrono::milliseconds HttpsClientFacade::controlInterval() const
     const uint32_t seconds =
         m_control.useSlowCadence() ? m_config.rejectedRetryIntervalS : m_config.notifyIntervalS;
     return std::chrono::seconds {seconds};
+}
+
+bool HttpsClientFacade::submitEvent(const uint8_t* frame, size_t length)
+{
+    if (!m_started || frame == nullptr || length == 0)
+    {
+        return false;
+    }
+
+    return m_stateless.submit(frame, length);
 }
 
 void HttpsClientFacade::notifyNow()

--- a/src/client-agent/https_client/src/httpsClientFacade.cpp
+++ b/src/client-agent/https_client/src/httpsClientFacade.cpp
@@ -132,9 +132,9 @@ void HttpsClientFacade::statelessLoop()
 
     while (true)
     {
-        m_stateless.tick(m_statelessWaiter, false);
+        const auto delay = m_stateless.tick(m_statelessWaiter, false);
 
-        if (!m_statelessWaiter.waitFor(std::chrono::milliseconds {m_config.batchIntervalMs}))
+        if (!m_statelessWaiter.waitFor(delay))
         {
             break;
         }
@@ -161,16 +161,27 @@ std::chrono::milliseconds HttpsClientFacade::controlInterval() const
 
 bool HttpsClientFacade::submitEvent(const uint8_t* frame, size_t length)
 {
+    std::lock_guard<std::mutex> lock(m_lifecycleMutex);
+
     if (!m_started || frame == nullptr || length == 0)
     {
         return false;
     }
 
-    return m_stateless.submit(frame, length);
+    const auto result = m_stateless.submit(frame, length);
+
+    if (result.shouldWakeSender)
+    {
+        m_statelessWaiter.notify();
+    }
+
+    return result.accepted;
 }
 
 void HttpsClientFacade::notifyNow()
 {
+    std::lock_guard<std::mutex> lock(m_lifecycleMutex);
+
     if (m_started)
     {
         m_controlWaiter.notify(); // Break the Notify cadence for one out-of-cycle send.

--- a/src/client-agent/https_client/src/httpsClientFacade.hpp
+++ b/src/client-agent/https_client/src/httpsClientFacade.hpp
@@ -25,10 +25,13 @@
 #include "moduleLog.hpp"
 #include "registrationGate.hpp"
 #include "spoolFile.hpp"
+#include "statelessStream.hpp"
 #include "stopToken.hpp"
 #include "sysSeams.hpp"
 
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <mutex>
 #include <thread>
 
@@ -36,12 +39,12 @@
  * @brief Composition root of the agent HTTPS client behind the C ABI.
  *
  * Builds every seam (curl performer, signer, dispatcher) and owns the
- * module's threads: the control loop and the dispatcher. The data streams
- * (#37835, #37836) will idle behind the registration gate until Startup is
- * accepted. Shutdown is cooperative: interrupt in-flight requests, join the
- * loops, drain (final shutdown message), then stop the dispatcher — no
- * callback outlives stop(). The lifecycle skeleton mirrors the manager-side
- * RemotedModuleFacade.
+ * module's threads: the control loop, the stateless sender and the
+ * dispatcher. The data streams idle behind a registration gate until Startup
+ * is accepted. Shutdown is cooperative: interrupt in-flight requests, join
+ * the loops, drain (final flush + final shutdown message), then stop the
+ * dispatcher — no callback outlives stop(). The lifecycle skeleton mirrors
+ * the manager-side RemotedModuleFacade.
  */
 class HttpsClientFacade final
 {
@@ -55,6 +58,7 @@ class HttpsClientFacade final
         bool start();
         void stop();
 
+        bool submitEvent(const uint8_t* frame, size_t length);
         void notifyNow();
         void setConfigHash(const char* configHash);
         bool setAgentKey(const char* keyHex);
@@ -62,6 +66,7 @@ class HttpsClientFacade final
 
     private:
         void controlLoop();
+        void statelessLoop();
         void drain();
         std::chrono::milliseconds controlInterval() const;
 
@@ -84,14 +89,17 @@ class HttpsClientFacade final
         // below) is safe.
         AuthGate m_authGate {m_dispatcher, [this] { m_controlWaiter.notify(); }};
 
+        StatelessStream m_stateless;
         ControlStream m_control;
 
         // One waiter per stream thread; the stop flag doubles as the abort flag.
         Waiter m_controlWaiter;
+        Waiter m_statelessWaiter;
         Waiter m_drainWaiter; ///< Fresh (never stopped) so the final drain can run.
         RegistrationGate m_gate;
 
         std::thread m_controlThread;
+        std::thread m_statelessThread;
 
         mutable std::mutex m_lifecycleMutex;
         bool m_started {false};

--- a/src/client-agent/https_client/src/moduleConfig.cpp
+++ b/src/client-agent/https_client/src/moduleConfig.cpp
@@ -44,6 +44,9 @@ ModuleConfig ModuleConfig::fromC(const hc_config_t& config)
     typed.batchSizeBytes = orDefault<uint64_t>(config.batch_size_bytes, 1024 * 1024);
     typed.batchIntervalMs = orDefault<uint32_t>(config.batch_interval_ms, 10000);
     typed.bufferCapMultiplier = orDefault<uint32_t>(config.buffer_cap_multiplier, 4);
+    typed.bufferWarnLevel = orDefault<uint32_t>(config.buffer_warn_level, 90);
+    typed.bufferNormalLevel = orDefault<uint32_t>(config.buffer_normal_level, 70);
+    typed.bufferFloodToleranceS = orDefault<uint32_t>(config.buffer_flood_tolerance_s, 15);
     typed.notifyIntervalS = orDefault<uint32_t>(config.notify_interval_s, 20);
     typed.rejectedRetryIntervalS = orDefault<uint32_t>(config.rejected_retry_interval_s, 60);
     typed.version = boundedString(config.version, sizeof(config.version));

--- a/src/client-agent/https_client/src/moduleConfig.cpp
+++ b/src/client-agent/https_client/src/moduleConfig.cpp
@@ -41,6 +41,9 @@ ModuleConfig ModuleConfig::fromC(const hc_config_t& config)
     typed.clientCert = boundedString(config.client_cert, sizeof(config.client_cert));
     typed.clientKey = boundedString(config.client_key, sizeof(config.client_key));
     typed.ciphers = boundedString(config.ciphers, sizeof(config.ciphers));
+    typed.batchSizeBytes = orDefault<uint64_t>(config.batch_size_bytes, 1024 * 1024);
+    typed.batchIntervalMs = orDefault<uint32_t>(config.batch_interval_ms, 10000);
+    typed.bufferCapMultiplier = orDefault<uint32_t>(config.buffer_cap_multiplier, 4);
     typed.notifyIntervalS = orDefault<uint32_t>(config.notify_interval_s, 20);
     typed.rejectedRetryIntervalS = orDefault<uint32_t>(config.rejected_retry_interval_s, 60);
     typed.version = boundedString(config.version, sizeof(config.version));

--- a/src/client-agent/https_client/src/moduleConfig.hpp
+++ b/src/client-agent/https_client/src/moduleConfig.hpp
@@ -43,6 +43,11 @@ struct ModuleConfig
         uint32_t batchIntervalMs {10000};
         uint32_t bufferCapMultiplier {4};
 
+        // Legacy client-buffer ladder defaults (etc/internal_options.conf).
+        uint32_t bufferWarnLevel {90};
+        uint32_t bufferNormalLevel {70};
+        uint32_t bufferFloodToleranceS {15};
+
         uint32_t notifyIntervalS {20};
         uint32_t rejectedRetryIntervalS {60};
 

--- a/src/client-agent/https_client/src/moduleConfig.hpp
+++ b/src/client-agent/https_client/src/moduleConfig.hpp
@@ -39,6 +39,10 @@ struct ModuleConfig
         std::string clientKey;
         std::string ciphers;
 
+        uint64_t batchSizeBytes {1024 * 1024};
+        uint32_t batchIntervalMs {10000};
+        uint32_t bufferCapMultiplier {4};
+
         uint32_t notifyIntervalS {20};
         uint32_t rejectedRetryIntervalS {60};
 

--- a/src/client-agent/https_client/src/statelessStream.cpp
+++ b/src/client-agent/https_client/src/statelessStream.cpp
@@ -28,6 +28,7 @@ StatelessStream::StatelessStream(const ModuleConfig& config, IHttpPerformer& per
     , m_sender(performer, signer, clock, m_backoff, &authGate)
     , m_sink(sink)
     , m_lastFlush(clock.steadyNow())
+    , m_ladder(config.bufferWarnLevel, config.bufferNormalLevel, config.bufferFloodToleranceS)
 {
 }
 
@@ -44,7 +45,7 @@ StatelessStream::SubmissionResult StatelessStream::submit(const uint8_t* frame, 
     }
 
     const bool isFlushDue = m_accumulator.flushDue(0, eventBudget);
-    publishLevelLocked();
+    publishLevelLocked(!accepted);
     return SubmissionResult {accepted, accepted&& !wasFlushDue&& isFlushDue};
 }
 
@@ -62,9 +63,17 @@ std::chrono::milliseconds StatelessStream::tick(Waiter& waiter, bool force)
     // waits and retries on this stream's own thread; the next flush is thus
     // naturally deferred while the accumulator (fed by the intake thread) keeps
     // absorbing (D5/D6).
-    if (flushDue(force))
+    if (flushDue(force) && flushOnce(waiter, m_config.requestTimeoutMs, STATELESS_MAX_ATTEMPTS)
+            && flushDue(false))
     {
-        flushOnce(waiter);
+        // Keep draining back-to-back while a backlog stays above the threshold.
+        // The size condition is edge-triggered in submit() (it fires once, as
+        // the buffer crosses the mark), so without this a buffer that stays
+        // above the threshold would give up a whole batch interval per request
+        // and cap throughput at one payload per interval regardless of load.
+        // Gated on the flush having succeeded: any failure falls through to the
+        // interval, so a rejecting or back-pressuring manager is never hammered.
+        return std::chrono::milliseconds::zero();
     }
 
     return std::chrono::milliseconds {m_config.batchIntervalMs};
@@ -72,7 +81,8 @@ std::chrono::milliseconds StatelessStream::tick(Waiter& waiter, bool force)
 
 hc_buffer_level_t StatelessStream::level() const
 {
-    return m_accumulator.level();
+    std::lock_guard<std::mutex> lock(m_stateMutex);
+    return m_ladder.level();
 }
 
 uint64_t StatelessStream::droppedEvents() const
@@ -100,7 +110,7 @@ bool StatelessStream::flushDue(bool force) const
     return m_accumulator.flushDue(static_cast<uint64_t>(elapsed), eventBytesBudgetLocked());
 }
 
-bool StatelessStream::flushOnce(Waiter& waiter)
+bool StatelessStream::flushOnce(Waiter& waiter, uint32_t timeoutMs, uint32_t maxAttempts)
 {
     uint64_t eventBudget;
     {
@@ -114,9 +124,9 @@ bool StatelessStream::flushOnce(Waiter& waiter)
     const std::string body = buildHeaderLine() + snapshot.body;
     spec.body = reinterpret_cast<const uint8_t*>(body.data());
     spec.bodyLength = body.size();
-    spec.timeoutMs = m_config.requestTimeoutMs;
+    spec.timeoutMs = timeoutMs;
 
-    const auto result = m_sender.send(spec, waiter, STATELESS_MAX_ATTEMPTS);
+    const auto result = m_sender.send(spec, waiter, maxAttempts);
     m_lastFlush = m_clock.steadyNow();
     handleOutcome(result.outcome, snapshot);
     return result.outcome == OutcomeClass::Ok;
@@ -131,7 +141,8 @@ void StatelessStream::handleOutcome(OutcomeClass outcome,
     {
         m_accumulator.consume(snapshot);
         m_payload.onSuccess(); // Ramp the effective payload back toward the max.
-        publishLevelLocked();
+        m_oversizedWarned = false; // The manager accepts again: re-arm the warning.
+        publishLevelLocked(false);
         return;
     }
 
@@ -143,10 +154,30 @@ void StatelessStream::handleOutcome(OutcomeClass outcome,
         {
             m_accumulator.consume(snapshot);
             m_droppedEvents++;
-            LOGFN_WARN(m_logFn, "Dropped a single oversized /stateless event the "
-                       "manager rejected with 413 (total dropped: %llu).",
-                       static_cast<unsigned long long>(m_droppedEvents));
-            publishLevelLocked();
+
+            // Warn once per incident, then stay at debug. A manager cap below
+            // one event rejects every request, so an unconditional warning here
+            // would log once per dropped event at full intake rate.
+            if (!m_oversizedWarned)
+            {
+                m_oversizedWarned = true;
+                LOGFN_WARN(m_logFn, "Dropped a single oversized /stateless event the manager "
+                           "rejected with 413 (total dropped: %llu). Further unsplittable "
+                           "drops are logged at debug level until a batch is accepted.",
+                           static_cast<unsigned long long>(m_droppedEvents));
+            }
+            else
+            {
+                LOGFN_DEBUG2(m_logFn, "Dropped a single oversized /stateless event the "
+                             "manager rejected with 413 (total dropped: %llu).",
+                             static_cast<unsigned long long>(m_droppedEvents));
+            }
+
+            // The batch size was not the cause -- this one event is simply too
+            // big for the manager. Halving the budget again would only cost a
+            // round trip before the next event is tried.
+            publishLevelLocked(false);
+            return;
         }
 
         m_payload.onPayloadTooLarge(); // A multi-event batch stays for a smaller retry.
@@ -157,7 +188,7 @@ void StatelessStream::handleOutcome(OutcomeClass outcome,
     {
         m_accumulator.consume(snapshot); // Non-413 4xx: retrying identical bytes cannot help.
         m_droppedEvents += snapshot.eventCount;
-        publishLevelLocked();
+        publishLevelLocked(false);
         return;
     }
 
@@ -166,27 +197,37 @@ void StatelessStream::handleOutcome(OutcomeClass outcome,
 
 void StatelessStream::drain(Waiter& waiter)
 {
-    // Bounded best-effort: bufferCapMultiplier + 1 iterations covers a full
-    // buffer at the configured (max) payload. If 413s shrank the effective
-    // size, part of the backlog may remain unsent at shutdown - a bounded
-    // drain beats stalling the stop path against a rejecting server.
+    // Bounded in two directions. Iterations: bufferCapMultiplier + 1 covers a
+    // full buffer at the configured (max) payload; if 413s shrank the effective
+    // size, part of the backlog stays unsent rather than stalling the stop
+    // path. Per flush: the drain window and a single attempt, exactly like
+    // ControlStream::drainStep. This runs on the stop path with a waiter that
+    // is deliberately never stopped, so the full retry ladder (5 attempts,
+    // per-request timeout, back-off up to the cap) would hold process exit for
+    // minutes against a slow or back-pressuring manager -- on Windows from an
+    // atexit handler.
     for (uint32_t iteration = 0; iteration <= m_config.bufferCapMultiplier; iteration++)
     {
-        if (m_accumulator.empty() || !flushOnce(waiter))
+        if (m_accumulator.empty() || !flushOnce(waiter, m_config.drainTimeoutMs, 1))
         {
             return;
         }
     }
 }
 
-void StatelessStream::publishLevelLocked()
+void StatelessStream::publishLevelLocked(bool eventDropped)
 {
-    const auto level = m_accumulator.level();
+    // Steady seconds: the FLOOD dwell must not be perturbed by wall-clock jumps
+    // (buffer.c uses time(0) only because it has no steady clock to hand).
+    const auto nowSeconds = std::chrono::duration_cast<std::chrono::seconds>(
+                                m_clock.steadyNow().time_since_epoch())
+                            .count();
+    const auto transition =
+        m_ladder.observe(m_accumulator.occupancyPercent(), eventDropped, nowSeconds);
 
-    if (level != m_lastLevel)
+    if (transition.announce)
     {
-        m_lastLevel = level;
-        m_sink.onBufferLevel(level);
+        m_sink.onBufferLevel(transition.level);
     }
 }
 

--- a/src/client-agent/https_client/src/statelessStream.cpp
+++ b/src/client-agent/https_client/src/statelessStream.cpp
@@ -11,9 +11,24 @@
 
 #include "statelessStream.hpp"
 
+#include "external/nlohmann/json.hpp"
+
 namespace
 {
     constexpr uint32_t STATELESS_MAX_ATTEMPTS = 5;
+
+    /// The H metadata line that opens every /stateless body (#37732). Built
+    /// through the JSON library rather than concatenated, so an agent id
+    /// carrying a quote, a backslash or a newline cannot escape the string it
+    /// sits in -- controlStream.cpp builds its payloads the same way. The line
+    /// is fixed for the life of the stream and is built once: its length is
+    /// needed on every submitted event, not just on every flush.
+    std::string headerLineFor(const std::string& agentId)
+    {
+        nlohmann::json header;
+        header["wazuh"]["agent"]["id"] = agentId;
+        return "H " + header.dump() + "\n";
+    }
 }
 
 StatelessStream::StatelessStream(const ModuleConfig& config, IHttpPerformer& performer,
@@ -27,6 +42,7 @@ StatelessStream::StatelessStream(const ModuleConfig& config, IHttpPerformer& per
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
     , m_sender(performer, signer, clock, m_backoff, &authGate)
     , m_sink(sink)
+    , m_headerLine(headerLineFor(config.agentId))
     , m_lastFlush(clock.steadyNow())
     , m_ladder(config.bufferWarnLevel, config.bufferNormalLevel, config.bufferFloodToleranceS)
 {
@@ -121,7 +137,7 @@ bool StatelessStream::flushOnce(Waiter& waiter, uint32_t timeoutMs, uint32_t max
 
     HttpRequestSpec spec;
     spec.target = "/stateless";
-    const std::string body = buildHeaderLine() + snapshot.body;
+    const std::string body = m_headerLine + snapshot.body;
     spec.body = reinterpret_cast<const uint8_t*>(body.data());
     spec.bodyLength = body.size();
     spec.timeoutMs = timeoutMs;
@@ -234,11 +250,6 @@ void StatelessStream::publishLevelLocked(bool eventDropped)
 uint64_t StatelessStream::eventBytesBudgetLocked() const
 {
     const uint64_t requestBudget = m_payload.effectiveBytes();
-    const size_t headerBytes = buildHeaderLine().size();
+    const size_t headerBytes = m_headerLine.size();
     return requestBudget > headerBytes ? requestBudget - headerBytes : 0;
-}
-
-std::string StatelessStream::buildHeaderLine() const
-{
-    return R"(H {"wazuh":{"agent":{"id":")" + m_config.agentId + R"("}}})" + "\n";
 }

--- a/src/client-agent/https_client/src/statelessStream.cpp
+++ b/src/client-agent/https_client/src/statelessStream.cpp
@@ -31,11 +31,21 @@ StatelessStream::StatelessStream(const ModuleConfig& config, IHttpPerformer& per
 {
 }
 
-bool StatelessStream::submit(const uint8_t* frame, size_t length)
+StatelessStream::SubmissionResult StatelessStream::submit(const uint8_t* frame, size_t length)
 {
+    std::lock_guard<std::mutex> lock(m_stateMutex);
+    const auto eventBudget = eventBytesBudgetLocked();
+    const bool wasFlushDue = m_accumulator.flushDue(0, eventBudget);
     const bool accepted = m_accumulator.append(frame, length);
-    publishLevel();
-    return accepted;
+
+    if (!accepted)
+    {
+        m_droppedEvents++;
+    }
+
+    const bool isFlushDue = m_accumulator.flushDue(0, eventBudget);
+    publishLevelLocked();
+    return SubmissionResult {accepted, accepted && !wasFlushDue && isFlushDue};
 }
 
 std::chrono::milliseconds StatelessStream::tick(Waiter& waiter, bool force)
@@ -65,6 +75,12 @@ hc_buffer_level_t StatelessStream::level() const
     return m_accumulator.level();
 }
 
+uint64_t StatelessStream::droppedEvents() const
+{
+    std::lock_guard<std::mutex> lock(m_stateMutex);
+    return m_droppedEvents;
+}
+
 bool StatelessStream::flushDue(bool force) const
 {
     if (m_accumulator.empty())
@@ -80,12 +96,18 @@ bool StatelessStream::flushDue(bool force) const
     const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
                              m_clock.steadyNow() - m_lastFlush)
                          .count();
-    return m_accumulator.flushDue(static_cast<uint64_t>(elapsed), m_payload.effectiveBytes());
+    std::lock_guard<std::mutex> lock(m_stateMutex);
+    return m_accumulator.flushDue(static_cast<uint64_t>(elapsed), eventBytesBudgetLocked());
 }
 
 bool StatelessStream::flushOnce(Waiter& waiter)
 {
-    const auto snapshot = m_accumulator.snapshot(m_payload.effectiveBytes());
+    uint64_t eventBudget;
+    {
+        std::lock_guard<std::mutex> lock(m_stateMutex);
+        eventBudget = eventBytesBudgetLocked();
+    }
+    const auto snapshot = m_accumulator.snapshot(eventBudget);
 
     HttpRequestSpec spec;
     spec.target = "/stateless";
@@ -103,11 +125,13 @@ bool StatelessStream::flushOnce(Waiter& waiter)
 void StatelessStream::handleOutcome(OutcomeClass outcome,
                                     const EventAccumulator::Snapshot& snapshot)
 {
+    std::lock_guard<std::mutex> lock(m_stateMutex);
+
     if (outcome == OutcomeClass::Ok)
     {
         m_accumulator.consume(snapshot);
         m_payload.onSuccess(); // Ramp the effective payload back toward the max.
-        publishLevel();
+        publishLevelLocked();
         return;
     }
 
@@ -118,11 +142,11 @@ void StatelessStream::handleOutcome(OutcomeClass outcome,
         if (snapshot.eventCount == 1)
         {
             m_accumulator.consume(snapshot);
-            m_oversizedDropped++;
+            m_droppedEvents++;
             LOGFN_WARN(m_logFn, "Dropped a single oversized /stateless event the "
                                 "manager rejected with 413 (total dropped: %llu).",
-                       static_cast<unsigned long long>(m_oversizedDropped));
-            publishLevel();
+                       static_cast<unsigned long long>(m_droppedEvents));
+            publishLevelLocked();
         }
 
         m_payload.onPayloadTooLarge(); // A multi-event batch stays for a smaller retry.
@@ -132,7 +156,8 @@ void StatelessStream::handleOutcome(OutcomeClass outcome,
     if (outcome == OutcomeClass::Permanent)
     {
         m_accumulator.consume(snapshot); // Non-413 4xx: retrying identical bytes cannot help.
-        publishLevel();
+        m_droppedEvents += snapshot.eventCount;
+        publishLevelLocked();
         return;
     }
 
@@ -154,7 +179,7 @@ void StatelessStream::drain(Waiter& waiter)
     }
 }
 
-void StatelessStream::publishLevel()
+void StatelessStream::publishLevelLocked()
 {
     const auto level = m_accumulator.level();
 
@@ -163,6 +188,13 @@ void StatelessStream::publishLevel()
         m_lastLevel = level;
         m_sink.onBufferLevel(level);
     }
+}
+
+uint64_t StatelessStream::eventBytesBudgetLocked() const
+{
+    const uint64_t requestBudget = m_payload.effectiveBytes();
+    const size_t headerBytes = buildHeaderLine().size();
+    return requestBudget > headerBytes ? requestBudget - headerBytes : 0;
 }
 
 std::string StatelessStream::buildHeaderLine() const

--- a/src/client-agent/https_client/src/statelessStream.cpp
+++ b/src/client-agent/https_client/src/statelessStream.cpp
@@ -45,7 +45,7 @@ StatelessStream::SubmissionResult StatelessStream::submit(const uint8_t* frame, 
 
     const bool isFlushDue = m_accumulator.flushDue(0, eventBudget);
     publishLevelLocked();
-    return SubmissionResult {accepted, accepted && !wasFlushDue && isFlushDue};
+    return SubmissionResult {accepted, accepted&& !wasFlushDue&& isFlushDue};
 }
 
 std::chrono::milliseconds StatelessStream::tick(Waiter& waiter, bool force)
@@ -144,7 +144,7 @@ void StatelessStream::handleOutcome(OutcomeClass outcome,
             m_accumulator.consume(snapshot);
             m_droppedEvents++;
             LOGFN_WARN(m_logFn, "Dropped a single oversized /stateless event the "
-                                "manager rejected with 413 (total dropped: %llu).",
+                       "manager rejected with 413 (total dropped: %llu).",
                        static_cast<unsigned long long>(m_droppedEvents));
             publishLevelLocked();
         }

--- a/src/client-agent/https_client/src/statelessStream.cpp
+++ b/src/client-agent/https_client/src/statelessStream.cpp
@@ -1,0 +1,171 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 17, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "statelessStream.hpp"
+
+namespace
+{
+    constexpr uint32_t STATELESS_MAX_ATTEMPTS = 5;
+}
+
+StatelessStream::StatelessStream(const ModuleConfig& config, IHttpPerformer& performer,
+                                 const ISigner& signer, IClock& clock, IRandom& random,
+                                 ICallbackSink& sink, AuthGate& authGate)
+    : m_config(config)
+    , m_clock(clock)
+    , m_authGate(authGate)
+    , m_accumulator(config.batchSizeBytes, config.bufferCapMultiplier, config.batchIntervalMs)
+    , m_payload(config.batchSizeBytes)
+    , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
+    , m_sender(performer, signer, clock, m_backoff, &authGate)
+    , m_sink(sink)
+    , m_lastFlush(clock.steadyNow())
+{
+}
+
+bool StatelessStream::submit(const uint8_t* frame, size_t length)
+{
+    const bool accepted = m_accumulator.append(frame, length);
+    publishLevel();
+    return accepted;
+}
+
+std::chrono::milliseconds StatelessStream::tick(Waiter& waiter, bool force)
+{
+    // Paused on a dead credential (401): the accumulator keeps filling (the
+    // drop-newest ladder still applies) but nothing is sent until a new key
+    // clears the pause (#37828).
+    if (m_authGate.paused())
+    {
+        return std::chrono::milliseconds {m_config.batchIntervalMs};
+    }
+
+    // Back-pressure (503/Retry-After) is honored inside RetrySender, which
+    // waits and retries on this stream's own thread; the next flush is thus
+    // naturally deferred while the accumulator (fed by the intake thread) keeps
+    // absorbing (D5/D6).
+    if (flushDue(force))
+    {
+        flushOnce(waiter);
+    }
+
+    return std::chrono::milliseconds {m_config.batchIntervalMs};
+}
+
+hc_buffer_level_t StatelessStream::level() const
+{
+    return m_accumulator.level();
+}
+
+bool StatelessStream::flushDue(bool force) const
+{
+    if (m_accumulator.empty())
+    {
+        return false;
+    }
+
+    if (force)
+    {
+        return true;
+    }
+
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                             m_clock.steadyNow() - m_lastFlush)
+                         .count();
+    return m_accumulator.flushDue(static_cast<uint64_t>(elapsed), m_payload.effectiveBytes());
+}
+
+bool StatelessStream::flushOnce(Waiter& waiter)
+{
+    const auto snapshot = m_accumulator.snapshot(m_payload.effectiveBytes());
+
+    HttpRequestSpec spec;
+    spec.target = "/stateless";
+    const std::string body = buildHeaderLine() + snapshot.body;
+    spec.body = reinterpret_cast<const uint8_t*>(body.data());
+    spec.bodyLength = body.size();
+    spec.timeoutMs = m_config.requestTimeoutMs;
+
+    const auto result = m_sender.send(spec, waiter, STATELESS_MAX_ATTEMPTS);
+    m_lastFlush = m_clock.steadyNow();
+    handleOutcome(result.outcome, snapshot);
+    return result.outcome == OutcomeClass::Ok;
+}
+
+void StatelessStream::handleOutcome(OutcomeClass outcome,
+                                    const EventAccumulator::Snapshot& snapshot)
+{
+    if (outcome == OutcomeClass::Ok)
+    {
+        m_accumulator.consume(snapshot);
+        m_payload.onSuccess(); // Ramp the effective payload back toward the max.
+        publishLevel();
+        return;
+    }
+
+    if (outcome == OutcomeClass::PayloadTooLarge)
+    {
+        // Split + resend smaller, never drop (#37835). The only exception: a
+        // lone event that already 413s cannot be split, so drop and count it.
+        if (snapshot.eventCount == 1)
+        {
+            m_accumulator.consume(snapshot);
+            m_oversizedDropped++;
+            LOGFN_WARN(m_logFn, "Dropped a single oversized /stateless event the "
+                                "manager rejected with 413 (total dropped: %llu).",
+                       static_cast<unsigned long long>(m_oversizedDropped));
+            publishLevel();
+        }
+
+        m_payload.onPayloadTooLarge(); // A multi-event batch stays for a smaller retry.
+        return;
+    }
+
+    if (outcome == OutcomeClass::Permanent)
+    {
+        m_accumulator.consume(snapshot); // Non-413 4xx: retrying identical bytes cannot help.
+        publishLevel();
+        return;
+    }
+
+    // BackPressure/Retryable/AuthFail/Interrupted: keep the batch for the next tick.
+}
+
+void StatelessStream::drain(Waiter& waiter)
+{
+    // Bounded best-effort: bufferCapMultiplier + 1 iterations covers a full
+    // buffer at the configured (max) payload. If 413s shrank the effective
+    // size, part of the backlog may remain unsent at shutdown - a bounded
+    // drain beats stalling the stop path against a rejecting server.
+    for (uint32_t iteration = 0; iteration <= m_config.bufferCapMultiplier; iteration++)
+    {
+        if (m_accumulator.empty() || !flushOnce(waiter))
+        {
+            return;
+        }
+    }
+}
+
+void StatelessStream::publishLevel()
+{
+    const auto level = m_accumulator.level();
+
+    if (level != m_lastLevel)
+    {
+        m_lastLevel = level;
+        m_sink.onBufferLevel(level);
+    }
+}
+
+std::string StatelessStream::buildHeaderLine() const
+{
+    return R"(H {"wazuh":{"agent":{"id":")" + m_config.agentId + R"("}}})" + "\n";
+}

--- a/src/client-agent/https_client/src/statelessStream.hpp
+++ b/src/client-agent/https_client/src/statelessStream.hpp
@@ -13,6 +13,7 @@
 #define _HC_STATELESS_STREAM_HPP
 
 #include "adaptivePayload.hpp"
+#include "bufferLevel.hpp"
 #include "callbackSink.hpp"
 #include "eventAccumulator.hpp"
 #include "moduleConfig.hpp"
@@ -30,8 +31,9 @@
  *        sender thread flushes on the size/age/forced conditions. Each flush
  *        prepends the H metadata line, signs (via RetrySender), and on success
  *        consumes the sent prefix. Back-pressure defers only this stream's
- *        next flush. The occupancy ladder is surfaced through the sink on
- *        every change.
+ *        next flush. Occupancy is surfaced through the sink whenever
+ *        BufferLevelLadder says the legacy client buffer would have reported
+ *        the step.
  */
 class StatelessStream final
 {
@@ -55,8 +57,8 @@ class StatelessStream final
         std::chrono::milliseconds tick(Waiter& waiter, bool force);
 
         /// Shutdown drain: flush repeatedly until the buffer empties or nothing
-        /// more can be sent (bounded, since one flush now sends <= effective
-        /// bytes rather than the whole buffer).
+        /// more can be sent. Bounded in both directions -- a fixed iteration
+        /// count and, per flush, the drain window with a single attempt.
         void drain(Waiter& waiter);
 
         hc_buffer_level_t level() const;
@@ -64,9 +66,9 @@ class StatelessStream final
 
     private:
         bool flushDue(bool force) const;
-        bool flushOnce(Waiter& waiter);
+        bool flushOnce(Waiter& waiter, uint32_t timeoutMs, uint32_t maxAttempts);
         void handleOutcome(OutcomeClass outcome, const EventAccumulator::Snapshot& snapshot);
-        void publishLevelLocked();
+        void publishLevelLocked(bool eventDropped);
         uint64_t eventBytesBudgetLocked() const;
         std::string buildHeaderLine() const;
 
@@ -81,8 +83,9 @@ class StatelessStream final
         const LogFn m_logFn {HTTPS_CLIENT_LOGTAG};
         std::chrono::steady_clock::time_point m_lastFlush;
         mutable std::mutex m_stateMutex;
-        hc_buffer_level_t m_lastLevel {HC_BUFFER_NORMAL};
+        BufferLevelLadder m_ladder;
         uint64_t m_droppedEvents {0};
+        bool m_oversizedWarned {false}; ///< Warn-once latch for unsplittable 413s.
 };
 
 #endif // _HC_STATELESS_STREAM_HPP

--- a/src/client-agent/https_client/src/statelessStream.hpp
+++ b/src/client-agent/https_client/src/statelessStream.hpp
@@ -70,7 +70,6 @@ class StatelessStream final
         void handleOutcome(OutcomeClass outcome, const EventAccumulator::Snapshot& snapshot);
         void publishLevelLocked(bool eventDropped);
         uint64_t eventBytesBudgetLocked() const;
-        std::string buildHeaderLine() const;
 
         const ModuleConfig& m_config;
         IClock& m_clock;
@@ -80,6 +79,7 @@ class StatelessStream final
         Backoff m_backoff;
         RetrySender m_sender;
         ICallbackSink& m_sink;
+        const std::string m_headerLine; ///< Fixed H line prefixed to every batch.
         const LogFn m_logFn {HTTPS_CLIENT_LOGTAG};
         std::chrono::steady_clock::time_point m_lastFlush;
         mutable std::mutex m_stateMutex;

--- a/src/client-agent/https_client/src/statelessStream.hpp
+++ b/src/client-agent/https_client/src/statelessStream.hpp
@@ -1,0 +1,77 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 17, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _HC_STATELESS_STREAM_HPP
+#define _HC_STATELESS_STREAM_HPP
+
+#include "adaptivePayload.hpp"
+#include "callbackSink.hpp"
+#include "eventAccumulator.hpp"
+#include "moduleConfig.hpp"
+#include "moduleLog.hpp"
+#include "retrySender.hpp"
+#include "stopToken.hpp"
+#include "sysSeams.hpp"
+
+#include <chrono>
+#include <string>
+
+/**
+ * @brief The /stateless sender (D6). Intake appends to the accumulator; the
+ *        sender thread flushes on the size/age/forced conditions. Each flush
+ *        prepends the H metadata line, signs (via RetrySender), and on success
+ *        consumes the sent prefix. Back-pressure defers only this stream's
+ *        next flush. The occupancy ladder is surfaced through the sink on
+ *        every change.
+ */
+class StatelessStream final
+{
+    public:
+        StatelessStream(const ModuleConfig& config, IHttpPerformer& performer, const ISigner& signer,
+                        IClock& clock, IRandom& random, ICallbackSink& sink, AuthGate& authGate);
+
+        /// Intake entry point (from agentd's EventForward seam). Emits a buffer
+        /// level change if the append crosses a ladder threshold.
+        bool submit(const uint8_t* frame, size_t length);
+
+        /// One sender iteration. force = shutdown/notify-now drain. Returns the
+        /// delay until the next tick should run.
+        std::chrono::milliseconds tick(Waiter& waiter, bool force);
+
+        /// Shutdown drain: flush repeatedly until the buffer empties or nothing
+        /// more can be sent (bounded, since one flush now sends <= effective
+        /// bytes rather than the whole buffer).
+        void drain(Waiter& waiter);
+
+        hc_buffer_level_t level() const;
+
+    private:
+        bool flushDue(bool force) const;
+        bool flushOnce(Waiter& waiter);
+        void handleOutcome(OutcomeClass outcome, const EventAccumulator::Snapshot& snapshot);
+        void publishLevel();
+        std::string buildHeaderLine() const;
+
+        const ModuleConfig& m_config;
+        IClock& m_clock;
+        AuthGate& m_authGate;
+        EventAccumulator m_accumulator;
+        AdaptivePayload m_payload;
+        Backoff m_backoff;
+        RetrySender m_sender;
+        ICallbackSink& m_sink;
+        const LogFn m_logFn {HTTPS_CLIENT_LOGTAG};
+        std::chrono::steady_clock::time_point m_lastFlush;
+        hc_buffer_level_t m_lastLevel {HC_BUFFER_NORMAL};
+        uint64_t m_oversizedDropped {0}; ///< Single events too large to ever fit.
+};
+
+#endif // _HC_STATELESS_STREAM_HPP

--- a/src/client-agent/https_client/src/statelessStream.hpp
+++ b/src/client-agent/https_client/src/statelessStream.hpp
@@ -22,6 +22,7 @@
 #include "sysSeams.hpp"
 
 #include <chrono>
+#include <mutex>
 #include <string>
 
 /**
@@ -35,12 +36,19 @@
 class StatelessStream final
 {
     public:
+        struct SubmissionResult
+        {
+            bool accepted;
+            bool shouldWakeSender;
+        };
+
         StatelessStream(const ModuleConfig& config, IHttpPerformer& performer, const ISigner& signer,
                         IClock& clock, IRandom& random, ICallbackSink& sink, AuthGate& authGate);
 
         /// Intake entry point (from agentd's EventForward seam). Emits a buffer
-        /// level change if the append crosses a ladder threshold.
-        bool submit(const uint8_t* frame, size_t length);
+        /// level change if the append crosses a ladder threshold and tells the
+        /// facade when the size threshold has just been reached.
+        SubmissionResult submit(const uint8_t* frame, size_t length);
 
         /// One sender iteration. force = shutdown/notify-now drain. Returns the
         /// delay until the next tick should run.
@@ -52,12 +60,14 @@ class StatelessStream final
         void drain(Waiter& waiter);
 
         hc_buffer_level_t level() const;
+        uint64_t droppedEvents() const;
 
     private:
         bool flushDue(bool force) const;
         bool flushOnce(Waiter& waiter);
         void handleOutcome(OutcomeClass outcome, const EventAccumulator::Snapshot& snapshot);
-        void publishLevel();
+        void publishLevelLocked();
+        uint64_t eventBytesBudgetLocked() const;
         std::string buildHeaderLine() const;
 
         const ModuleConfig& m_config;
@@ -70,8 +80,9 @@ class StatelessStream final
         ICallbackSink& m_sink;
         const LogFn m_logFn {HTTPS_CLIENT_LOGTAG};
         std::chrono::steady_clock::time_point m_lastFlush;
+        mutable std::mutex m_stateMutex;
         hc_buffer_level_t m_lastLevel {HC_BUFFER_NORMAL};
-        uint64_t m_oversizedDropped {0}; ///< Single events too large to ever fit.
+        uint64_t m_droppedEvents {0};
 };
 
 #endif // _HC_STATELESS_STREAM_HPP

--- a/src/client-agent/https_client/src/sysSeams.cpp
+++ b/src/client-agent/https_client/src/sysSeams.cpp
@@ -30,6 +30,7 @@ Mt19937Random::Mt19937Random()
 
 double Mt19937Random::uniform01()
 {
+    std::lock_guard<std::mutex> lock(m_mutex);
     return std::uniform_real_distribution<double> {0.0, 1.0}(m_engine);
 }
 

--- a/src/client-agent/https_client/src/sysSeams.hpp
+++ b/src/client-agent/https_client/src/sysSeams.hpp
@@ -14,6 +14,7 @@
 
 #include <chrono>
 #include <ctime>
+#include <mutex>
 #include <random>
 #include <string>
 
@@ -57,6 +58,7 @@ class Mt19937Random final : public IRandom
         double uniform01() override;
 
     private:
+        std::mutex m_mutex;
         std::mt19937_64 m_engine;
 };
 

--- a/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
+++ b/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
@@ -349,6 +349,7 @@ TEST_F(FacadeE2eTest, OversizedBatchIsSplitAndResentWithoutLoss)
     // 40 distinctly-numbered events; each "E evt-NN:payload...\n" ~30 bytes,
     // so the full batch (~1200 B) exceeds the 600-byte limit and must split.
     constexpr int total = 40;
+
     for (int index = 0; index < total; index++)
     {
         char frame[64];
@@ -361,25 +362,30 @@ TEST_F(FacadeE2eTest, OversizedBatchIsSplitAndResentWithoutLoss)
     httplib::Client peek {std::string {"https://127.0.0.1:"} + std::to_string(port)};
     peek.enable_server_certificate_verification(false);
     std::string received;
+
     for (int attempt = 0; attempt < 300; attempt++)
     {
         if (auto result = peek.Get("/peek/stateless"))
         {
             received = result->body;
             int seen = 0;
+
             for (int index = 0; index < total; index++)
             {
                 char needle[32];
                 std::snprintf(needle, sizeof needle, "evt-%02d-", index);
                 seen += received.find(needle) != std::string::npos ? 1 : 0;
             }
+
             if (seen == total)
             {
                 break;
             }
         }
+
         std::this_thread::sleep_for(std::chrono::milliseconds {20});
     }
+
     hc_destroy(handle);
 
     // Every event delivered exactly once, none dropped despite the 413s.

--- a/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
+++ b/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
@@ -255,13 +255,13 @@ namespace
 
     // A key-rotating manager stored in a global so the C callback can reach it.
     hc_handle* g_keyRotationHandle = nullptr;
-    const char* g_rotatedKey = nullptr;
+    std::string g_rotatedKey;
 
     void onReenroll(void* userData)
     {
         static_cast<ReenrollRecorder*>(userData)->reenrollCount++;
         // The consumer's re-enrollment: swap in the new key (callback-safe).
-        hc_set_agent_key(g_keyRotationHandle, g_rotatedKey);
+        hc_set_agent_key(g_keyRotationHandle, g_rotatedKey.c_str());
     }
 
     void onReenrollStartup(bool accepted, const char*, void* userData)
@@ -303,7 +303,7 @@ TEST_F(FacadeE2eTest, KeyRotationFiresReenrollAndHcSetAgentKeyRecovers)
     hc_handle* handle = hc_create(&config, &callbacks);
     ASSERT_NE(nullptr, handle);
     g_keyRotationHandle = handle;
-    g_rotatedKey = newKey.c_str();
+    g_rotatedKey = newKey;
 
     ASSERT_TRUE(hc_start(handle));
     ASSERT_TRUE(waitFor(recorder.startups, 1, 3000)); // First registration (old key).

--- a/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
+++ b/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
@@ -134,6 +134,57 @@ TEST_F(FacadeE2eTest, RegistersOverTlsAndStopsCleanly)
     EXPECT_EQ(HC_STATE_STOPPED, recorder.states.back());
 }
 
+TEST_F(FacadeE2eTest, SizeThresholdFlushesBeforeTheBatchInterval)
+{
+    // A long interval makes the size-threshold wake observable. The 80-byte
+    // request budget leaves 45 bytes after the H line, so two events cross it.
+    const uint16_t port = TLS_PORT + 5;
+    FakeManager manager {port, KEY_HEX, /*tls=*/true};
+
+    Recorder recorder;
+    hc_config_t config = tlsConfig();
+    config.server_port = port;
+    config.batch_size_bytes = 80;
+    config.batch_interval_ms = 5000;
+    hc_callbacks_t callbacks {};
+    callbacks.on_startup_result = onStartup;
+    callbacks.user_data = &recorder;
+
+    hc_handle* handle = hc_create(&config, &callbacks);
+    ASSERT_NE(nullptr, handle);
+    ASSERT_TRUE(hc_start(handle));
+    ASSERT_TRUE(waitFor(recorder.startupCount, 1, 3000));
+
+    const std::string first = "1:/loc:size-wakeup-first";
+    const std::string second = "1:/loc:size-wakeup-second";
+    ASSERT_TRUE(hc_submit_event(handle, reinterpret_cast<const uint8_t*>(first.data()),
+                                first.size()));
+    ASSERT_TRUE(hc_submit_event(handle, reinterpret_cast<const uint8_t*>(second.data()),
+                                second.size()));
+
+    httplib::Client peek {std::string {"https://127.0.0.1:"} + std::to_string(port)};
+    peek.enable_server_certificate_verification(false);
+    std::string received;
+
+    for (int attempt = 0; attempt < 150; attempt++)
+    {
+        if (auto result = peek.Get("/peek/stateless"))
+        {
+            received = result->body;
+
+            if (received.find("size-wakeup-first") != std::string::npos)
+            {
+                break;
+            }
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds {10});
+    }
+
+    hc_destroy(handle);
+    EXPECT_NE(std::string::npos, received.find("size-wakeup-first"));
+}
+
 namespace
 {
     struct ConfigRecorder

--- a/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
+++ b/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
@@ -21,6 +21,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdio>
+
 #include <algorithm>
 #include <atomic>
 #include <chrono>
@@ -70,6 +72,7 @@ namespace
         config.backoff_base_ms = 10;
         config.backoff_cap_ms = 50;
         config.notify_interval_s = 1;
+        config.batch_interval_ms = 200;
         config.drain_timeout_ms = 1000;
         std::strncpy(config.version, "5.1.0", sizeof(config.version) - 1);
         return config;
@@ -234,7 +237,7 @@ TEST_F(FacadeE2eTest, KeyRotationFiresReenrollAndHcSetAgentKeyRecovers)
     const uint16_t port = TLS_PORT + 4;
     const std::string oldKey = KEY_HEX;
     const std::string newKey = "0f0e0d0c0b0a09080706050403020100";
-    FakeManager manager {port, oldKey, /*tls=*/true, 0, {}, /*rotateKeyAfterNotifies=*/2, newKey};
+    FakeManager manager {port, oldKey, /*tls=*/true, 0, {}, 0, /*rotateKeyAfterNotifies=*/2, newKey};
 
     ReenrollRecorder recorder;
     hc_config_t config = tlsConfig();
@@ -267,6 +270,77 @@ TEST_F(FacadeE2eTest, KeyRotationFiresReenrollAndHcSetAgentKeyRecovers)
               std::find(recorder.states.begin(), recorder.states.end(), HC_STATE_AUTH_ERROR));
     EXPECT_NE(recorder.states.end(),
               std::find(recorder.states.begin(), recorder.states.end(), HC_STATE_REGISTERED));
+}
+
+TEST_F(FacadeE2eTest, OversizedBatchIsSplitAndResentWithoutLoss)
+{
+    // The manager 413s any /stateless body over ~600 bytes; the client must
+    // split and resend smaller so every event lands exactly once (#37835).
+    const uint16_t port = TLS_PORT + 3;
+    FakeManager manager {port, KEY_HEX, /*tls=*/true, 0, {}, /*statelessMaxBody=*/600};
+
+    Recorder recorder;
+    hc_config_t config = tlsConfig();
+    config.server_port = port;
+    // Max payload 1024 straddles the 600-byte manager limit, so a 413 halves
+    // the effective size down under it and the split succeeds.
+    config.batch_size_bytes = 1024;
+    hc_callbacks_t callbacks {};
+    callbacks.on_startup_result = onStartup;
+    callbacks.on_state_change = onState;
+    callbacks.user_data = &recorder;
+
+    hc_handle* handle = hc_create(&config, &callbacks);
+    ASSERT_NE(nullptr, handle);
+    ASSERT_TRUE(hc_start(handle));
+    ASSERT_TRUE(waitFor(recorder.startupCount, 1, 3000));
+
+    // 40 distinctly-numbered events; each "E evt-NN:payload...\n" ~30 bytes,
+    // so the full batch (~1200 B) exceeds the 600-byte limit and must split.
+    constexpr int total = 40;
+    for (int index = 0; index < total; index++)
+    {
+        char frame[64];
+        const int n = std::snprintf(frame, sizeof frame, "1:/loc:evt-%02d-payload", index);
+        EXPECT_TRUE(hc_submit_event(handle, reinterpret_cast<const uint8_t*>(frame),
+                                    static_cast<size_t>(n)));
+    }
+
+    // Poll the manager's accumulated view until all events land (or time out).
+    httplib::Client peek {std::string {"https://127.0.0.1:"} + std::to_string(port)};
+    peek.enable_server_certificate_verification(false);
+    std::string received;
+    for (int attempt = 0; attempt < 300; attempt++)
+    {
+        if (auto result = peek.Get("/peek/stateless"))
+        {
+            received = result->body;
+            int seen = 0;
+            for (int index = 0; index < total; index++)
+            {
+                char needle[32];
+                std::snprintf(needle, sizeof needle, "evt-%02d-", index);
+                seen += received.find(needle) != std::string::npos ? 1 : 0;
+            }
+            if (seen == total)
+            {
+                break;
+            }
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds {20});
+    }
+    hc_destroy(handle);
+
+    // Every event delivered exactly once, none dropped despite the 413s.
+    for (int index = 0; index < total; index++)
+    {
+        char needle[32];
+        std::snprintf(needle, sizeof needle, "evt-%02d-", index);
+        const size_t first = received.find(needle);
+        ASSERT_NE(std::string::npos, first) << "missing event " << index;
+        EXPECT_EQ(std::string::npos, received.find(needle, first + 1))
+                << "duplicated event " << index;
+    }
 }
 
 TEST_F(FacadeE2eTest, SettingsChangeRefreshesStartupWithoutLeavingRegistered)

--- a/src/client-agent/https_client/tests/component/fakeManager.hpp
+++ b/src/client-agent/https_client/tests/component/fakeManager.hpp
@@ -25,6 +25,7 @@
 #include <csignal>
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -48,17 +49,21 @@ class FakeManager final
         /// configBlob non-empty: /download serves it (chunked octet-stream)
         /// and every notify reports agent.config_hash = MD5(configBlob), so a
         /// client whose local hash differs downloads it.
+        /// statelessMaxBody > 0: a /stateless POST whose body exceeds it gets
+        /// 413, so the client must split and resend smaller (#37835).
         /// rotateKeyAfterNotifies > 0 with rotatedKeyHex set: after that many
         /// notifies the server verifies ONLY against rotatedKeyHex, so the old
         /// key starts getting 401 (#37828 re-enrollment).
         FakeManager(uint16_t port, const std::string& keyHex, bool tls = false,
                     int settingsFlipAfter = 0, std::string configBlob = {},
-                    int rotateKeyAfterNotifies = 0, std::string rotatedKeyHex = {})
+                    size_t statelessMaxBody = 0, int rotateKeyAfterNotifies = 0,
+                    std::string rotatedKeyHex = {})
             : m_port(port)
             , m_keyHex(keyHex)
             , m_tls(tls)
             , m_settingsFlipAfter(settingsFlipAfter)
             , m_configBlob(std::move(configBlob))
+            , m_statelessMaxBody(statelessMaxBody)
             , m_rotateKeyAfterNotifies(rotateKeyAfterNotifies)
             , m_rotatedKeyHex(std::move(rotatedKeyHex))
         {
@@ -133,6 +138,7 @@ class FakeManager final
             const std::string keyHex = m_keyHex;
             const int settingsFlipAfter = m_settingsFlipAfter;
             const std::string configBlob = m_configBlob;
+            const size_t statelessMaxBody = m_statelessMaxBody;
             const std::string configHash =
                 configBlob.empty() ? std::string {}
                 :
@@ -153,9 +159,15 @@ class FakeManager final
                 return verifyCmac(rotated ? rotatedKey : keyHex, target, request);
             };
 
+            // Accumulates accepted /stateless bodies so the fork parent can
+            // read them back via GET /peek/stateless (fork servers share no
+            // memory; a peek endpoint is the observability channel).
+            auto acceptedEvents = std::make_shared<std::string>();
+            auto acceptedMutex = std::make_shared<std::mutex>();
+
             server.Post("/stateless",
-                        [verify, backpressureArmed](const httplib::Request & request,
-                                                    httplib::Response & response)
+                        [verify, backpressureArmed, statelessMaxBody, acceptedEvents, acceptedMutex](
+                            const httplib::Request & request, httplib::Response & response)
             {
                 if (!verify("/stateless", request))
                 {
@@ -170,8 +182,28 @@ class FakeManager final
                     return;
                 }
 
+                if (statelessMaxBody > 0 && request.body.size() > statelessMaxBody)
+                {
+                    response.status = 413; // Payload too large: the client must split + resend.
+                    return;
+                }
+
+                {
+                    std::lock_guard<std::mutex> lock(*acceptedMutex);
+                    *acceptedEvents += request.body; // Record the accepted batch.
+                }
+
                 response.status = 200;
                 response.set_content(request.body, "text/plain"); // Echo for body assertions.
+            });
+
+            server.Get("/peek/stateless",
+                       [acceptedEvents, acceptedMutex](const httplib::Request&,
+                                                       httplib::Response & response)
+            {
+                std::lock_guard<std::mutex> lock(*acceptedMutex);
+                response.status = 200;
+                response.set_content(*acceptedEvents, "text/plain");
             });
 
             server.Post("/download",
@@ -342,6 +374,7 @@ class FakeManager final
         bool m_tls {false};
         int m_settingsFlipAfter {0};
         std::string m_configBlob;
+        size_t m_statelessMaxBody {0};
         int m_rotateKeyAfterNotifies {0};
         std::string m_rotatedKeyHex;
 };

--- a/src/client-agent/https_client/tests/unit/adaptivePayload_test.cpp
+++ b/src/client-agent/https_client/tests/unit/adaptivePayload_test.cpp
@@ -1,0 +1,66 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 21, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "adaptivePayload.hpp"
+
+#include <gtest/gtest.h>
+
+TEST(AdaptivePayloadTest, StartsAtTheConfiguredMax)
+{
+    AdaptivePayload payload {1024 * 1024};
+    EXPECT_EQ(1024u * 1024u, payload.effectiveBytes());
+}
+
+TEST(AdaptivePayloadTest, PayloadTooLargeHalvesWithoutAHardFloor)
+{
+    // No lower clamp: a server cap smaller than any fixed floor must still be
+    // reachable, or the stream would retry the same too-big batch forever.
+    AdaptivePayload payload {1000};
+    payload.onPayloadTooLarge();
+    EXPECT_EQ(500u, payload.effectiveBytes());
+    payload.onPayloadTooLarge();
+    EXPECT_EQ(250u, payload.effectiveBytes());
+
+    for (int halvings = 0; halvings < 20; halvings++)
+    {
+        payload.onPayloadTooLarge();
+    }
+
+    EXPECT_EQ(1u, payload.effectiveBytes()); // Converges to one byte, never zero.
+    payload.onPayloadTooLarge();
+    EXPECT_EQ(1u, payload.effectiveBytes());
+}
+
+TEST(AdaptivePayloadTest, SuccessDoublesBackTowardTheMax)
+{
+    AdaptivePayload payload {1000};
+    payload.onPayloadTooLarge();
+    payload.onPayloadTooLarge();
+    payload.onPayloadTooLarge(); // 125.
+    payload.onSuccess();
+    EXPECT_EQ(250u, payload.effectiveBytes());
+    payload.onSuccess();
+    EXPECT_EQ(500u, payload.effectiveBytes());
+    payload.onSuccess();
+    EXPECT_EQ(1000u, payload.effectiveBytes()); // Clamped at the max.
+    payload.onSuccess();
+    EXPECT_EQ(1000u, payload.effectiveBytes());
+}
+
+TEST(AdaptivePayloadTest, ZeroMaxIsTreatedAsOneByte)
+{
+    AdaptivePayload payload {0};
+    EXPECT_EQ(1u, payload.effectiveBytes());
+    payload.onPayloadTooLarge();
+    EXPECT_EQ(1u, payload.effectiveBytes());
+    payload.onSuccess();
+    EXPECT_EQ(1u, payload.effectiveBytes());
+}

--- a/src/client-agent/https_client/tests/unit/bufferLevel_test.cpp
+++ b/src/client-agent/https_client/tests/unit/bufferLevel_test.cpp
@@ -1,0 +1,146 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 24, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "bufferLevel.hpp"
+
+#include <gtest/gtest.h>
+
+namespace
+{
+    // The legacy defaults: agent.warn_level, agent.normal_level, agent.tolerance.
+    BufferLevelLadder defaultLadder()
+    {
+        return BufferLevelLadder {90, 70, 15};
+    }
+} // namespace
+
+TEST(BufferLevelLadderTest, StartsNormalAndStaysQuietBelowTheWarnMark)
+{
+    auto ladder = defaultLadder();
+    EXPECT_EQ(HC_BUFFER_NORMAL, ladder.level());
+
+    const auto transition = ladder.observe(89, false, 0);
+    EXPECT_FALSE(transition.announce);
+    EXPECT_EQ(HC_BUFFER_NORMAL, ladder.level());
+}
+
+TEST(BufferLevelLadderTest, AnnouncesWarningAtTheWarnMark)
+{
+    auto ladder = defaultLadder();
+    const auto transition = ladder.observe(90, false, 0);
+    EXPECT_TRUE(transition.announce);
+    EXPECT_EQ(HC_BUFFER_WARNING, transition.level);
+
+    // Already there: no repeat announcement while it stays above the mark.
+    EXPECT_FALSE(ladder.observe(95, false, 0).announce);
+}
+
+TEST(BufferLevelLadderTest, HysteresisHoldsWarningBetweenNormalAndWarnLevels)
+{
+    auto ladder = defaultLadder();
+    ladder.observe(90, false, 0);
+
+    // Back under the warn mark but above normal_level: the legacy ladder stays
+    // in WARNING, which is exactly what stops a buffer hovering around the mark
+    // from flapping an event per crossing.
+    EXPECT_FALSE(ladder.observe(80, false, 0).announce);
+    EXPECT_EQ(HC_BUFFER_WARNING, ladder.level());
+
+    const auto backToNormal = ladder.observe(70, false, 0);
+    EXPECT_TRUE(backToNormal.announce);
+    EXPECT_EQ(HC_BUFFER_NORMAL, backToNormal.level);
+}
+
+TEST(BufferLevelLadderTest, ADroppedEventGoesStraightToFull)
+{
+    auto ladder = defaultLadder();
+
+    // buffer.c enters FULL on full(), not on a percentage: the byte analogue is
+    // the drop-newest rejection, whatever the occupancy reads.
+    const auto transition = ladder.observe(99, true, 100);
+    EXPECT_TRUE(transition.announce);
+    EXPECT_EQ(HC_BUFFER_FULL, transition.level);
+}
+
+TEST(BufferLevelLadderTest, FloodOnlyAfterFullHoldsForTolerance)
+{
+    auto ladder = defaultLadder();
+    ladder.observe(99, true, 1000); // Enters FULL, starts the dwell.
+
+    EXPECT_FALSE(ladder.observe(99, true, 1010).announce); // 10 s: too soon.
+    EXPECT_EQ(HC_BUFFER_FULL, ladder.level());
+
+    const auto flooded = ladder.observe(99, true, 1015); // 15 s: tolerance met.
+    EXPECT_TRUE(flooded.announce);
+    EXPECT_EQ(HC_BUFFER_FLOOD, flooded.level);
+
+    // FLOOD is terminal until the buffer actually drains.
+    EXPECT_FALSE(ladder.observe(99, true, 2000).announce);
+}
+
+TEST(BufferLevelLadderTest, ZeroToleranceFloodsOnTheNextObservation)
+{
+    BufferLevelLadder ladder {90, 70, 0};
+    ladder.observe(99, true, 500);
+    EXPECT_EQ(HC_BUFFER_FLOOD, ladder.observe(99, true, 500).level);
+}
+
+TEST(BufferLevelLadderTest, StepDownFromFullToWarningIsSilent)
+{
+    auto ladder = defaultLadder();
+    ladder.observe(99, true, 0);
+
+    // buffer.c drops FULL/FLOOD back to WARNING without emitting anything --
+    // only the return to NORMAL is reported. Announcing here would invent an
+    // event the manager never used to see.
+    const auto stepDown = ladder.observe(85, false, 0);
+    EXPECT_FALSE(stepDown.announce);
+    EXPECT_EQ(HC_BUFFER_WARNING, ladder.level());
+}
+
+TEST(BufferLevelLadderTest, DrainingFromFloodAnnouncesNormal)
+{
+    auto ladder = defaultLadder();
+    ladder.observe(99, true, 0);
+    ladder.observe(99, true, 60); // FLOOD.
+
+    const auto recovered = ladder.observe(10, false, 61);
+    EXPECT_TRUE(recovered.announce);
+    EXPECT_EQ(HC_BUFFER_NORMAL, recovered.level);
+}
+
+TEST(BufferLevelLadderTest, RefillAfterRecoveryRestartsTheDwell)
+{
+    auto ladder = defaultLadder();
+    ladder.observe(99, true, 0);
+    ladder.observe(10, false, 5); // Back to NORMAL.
+
+    ladder.observe(99, true, 100);                          // FULL again, dwell restarts at 100.
+    EXPECT_FALSE(ladder.observe(99, true, 110).announce);   // Not 15 s yet.
+    EXPECT_EQ(HC_BUFFER_FLOOD, ladder.observe(99, true, 115).level);
+}
+
+TEST(BufferLevelLadderTest, InvertedThresholdsAreClampedLikeInternalOptions)
+{
+    // internal_options caps normal_level at warn_level - 1; a config that
+    // inverts them would otherwise make every observation both warn and normal.
+    BufferLevelLadder ladder {50, 80, 15}; // normal_level clamps to 49.
+    EXPECT_TRUE(ladder.observe(50, false, 0).announce);
+    EXPECT_EQ(HC_BUFFER_WARNING, ladder.level());
+
+    // Still above the clamped normal mark: WARNING holds rather than resolving
+    // on the same observation that raised it.
+    EXPECT_FALSE(ladder.observe(50, false, 0).announce);
+    EXPECT_EQ(HC_BUFFER_WARNING, ladder.level());
+
+    EXPECT_TRUE(ladder.observe(49, false, 0).announce);
+    EXPECT_EQ(HC_BUFFER_NORMAL, ladder.level());
+}

--- a/src/client-agent/https_client/tests/unit/callbackDispatcher_test.cpp
+++ b/src/client-agent/https_client/tests/unit/callbackDispatcher_test.cpp
@@ -52,6 +52,14 @@ namespace
         record->count++;
     }
 
+    void recordBuffer(int level, void* userData)
+    {
+        auto* record = static_cast<Record*>(userData);
+        std::lock_guard<std::mutex> lock(record->mutex);
+        record->order.push_back("buffer:" + std::to_string(level));
+        record->count++;
+    }
+
     void recordStartup(bool accepted, const char*, void* userData)
     {
         auto* record = static_cast<Record*>(userData);
@@ -67,6 +75,7 @@ namespace
         callbacks.on_startup_result = recordStartup;
         callbacks.on_reenroll_required = recordReenroll;
         callbacks.on_state_change = recordState;
+        callbacks.on_buffer_level = recordBuffer;
         callbacks.user_data = record;
         return callbacks;
     }
@@ -145,6 +154,7 @@ TEST(CallbackDispatcherTest, NullCallbacksAreSafe)
     dispatcher.onStateChange(HC_STATE_STARTING);
     dispatcher.onReenrollRequired();
     dispatcher.onStartupResult(true, "{}");
+    dispatcher.onBufferLevel(HC_BUFFER_NORMAL);
     dispatcher.stop(); // No crash despite null handlers.
 }
 
@@ -156,7 +166,8 @@ TEST(CallbackDispatcherTest, EveryCallbackKindIsForwarded)
     dispatcher.onStartupResult(true, R"({"limits":{}})");
     dispatcher.onReenrollRequired();
     dispatcher.onStateChange(HC_STATE_REGISTERED);
-    waitForCount(record, 3);
+    dispatcher.onBufferLevel(HC_BUFFER_WARNING);
+    waitForCount(record, 4);
     dispatcher.stop();
 
     EXPECT_NE(record.order.end(),
@@ -166,6 +177,9 @@ TEST(CallbackDispatcherTest, EveryCallbackKindIsForwarded)
     EXPECT_NE(record.order.end(),
               std::find(record.order.begin(), record.order.end(),
                         "state:" + std::to_string(HC_STATE_REGISTERED)));
+    EXPECT_NE(record.order.end(),
+              std::find(record.order.begin(), record.order.end(),
+                        "buffer:" + std::to_string(HC_BUFFER_WARNING)));
 }
 
 namespace

--- a/src/client-agent/https_client/tests/unit/controlStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/controlStream_test.cpp
@@ -53,8 +53,8 @@ namespace
                 , m_spoolFactory(::testing::TempDir())
                 , m_configHash("abc")
                 , m_authGate(m_sink, [] {})
-                , m_stream(m_config, m_performer, m_signer, m_clock, m_random, m_sink,
-                           m_spoolFactory, m_configHash, m_cluster, m_authGate)
+            , m_stream(m_config, m_performer, m_signer, m_clock, m_random, m_sink,
+                       m_spoolFactory, m_configHash, m_cluster, m_authGate)
             {
             }
 

--- a/src/client-agent/https_client/tests/unit/eventAccumulator_test.cpp
+++ b/src/client-agent/https_client/tests/unit/eventAccumulator_test.cpp
@@ -24,17 +24,19 @@ namespace
     }
 } // namespace
 
-TEST(EncodeEventLineTest, WrapsFrameAsEeLine)
+TEST(EncodeStatelessEventLineTest, WrapsFrameAsEeLine)
 {
     const std::string frame = "1:/var/log/syslog:hello";
-    const auto line = encodeEventLine(reinterpret_cast<const uint8_t*>(frame.data()), frame.size());
+    const auto line =
+        encodeStatelessEventLine(reinterpret_cast<const uint8_t*>(frame.data()), frame.size());
     EXPECT_EQ("E 1:/var/log/syslog:hello\n", line);
 }
 
-TEST(EncodeEventLineTest, EscapesEmbeddedNewlinesWithLeadingSpace)
+TEST(EncodeStatelessEventLineTest, EscapesEmbeddedNewlinesWithLeadingSpace)
 {
     const std::string frame = "line1\nline2\nline3";
-    const auto line = encodeEventLine(reinterpret_cast<const uint8_t*>(frame.data()), frame.size());
+    const auto line =
+        encodeStatelessEventLine(reinterpret_cast<const uint8_t*>(frame.data()), frame.size());
     EXPECT_EQ("E line1\n line2\n line3\n", line);
 }
 

--- a/src/client-agent/https_client/tests/unit/eventAccumulator_test.cpp
+++ b/src/client-agent/https_client/tests/unit/eventAccumulator_test.cpp
@@ -101,37 +101,35 @@ TEST(EventAccumulatorTest, ConsumeIsTailPreserving)
     EXPECT_EQ(1u, remaining.eventCount);
 }
 
-TEST(EventAccumulatorTest, LadderThresholdsBothDirections)
+TEST(EventAccumulatorTest, OccupancyTracksBytesBothDirections)
 {
-    // cap = 100 bytes. Each "E " + 8 chars + "\n" = 11 bytes.
+    // cap = 100 bytes. Each "E " + 8 chars + "\n" = 11 bytes, so occupancy is
+    // 11% per event. BufferLevelLadder turns this into the four-level ladder.
     EventAccumulator accumulator {25, 4, 100000};
-    const std::string frame(8, 'x'); // 11-byte line.
+    const std::string frame(8, 'x');
 
-    EXPECT_EQ(HC_BUFFER_NORMAL, accumulator.level());
+    EXPECT_EQ(0u, accumulator.occupancyPercent());
 
-    for (int index = 0; index < 5; index++) // 55 bytes -> 55% -> WARNING.
+    for (int index = 0; index < 5; index++)
     {
         append(accumulator, frame);
     }
 
-    EXPECT_EQ(HC_BUFFER_WARNING, accumulator.level());
+    EXPECT_EQ(55u, accumulator.occupancyPercent());
 
-    for (int index = 0; index < 2; index++) // 77 bytes -> 77% -> FULL.
+    for (int index = 0; index < 4; index++)
     {
         append(accumulator, frame);
     }
 
-    EXPECT_EQ(HC_BUFFER_FULL, accumulator.level());
-    append(accumulator, frame); // 88 bytes.
-    append(accumulator, frame); // 99 bytes -> 99% -> FLOOD.
-    EXPECT_EQ(HC_BUFFER_FLOOD, accumulator.level());
+    EXPECT_EQ(99u, accumulator.occupancyPercent());
 
-    // Draining most of the buffer walks the ladder back down.
+    // Draining most of the buffer walks occupancy back down.
     EventAccumulator::Snapshot partial;
     partial.byteLength = 88;
     partial.eventCount = 8;
     accumulator.consume(partial);
-    EXPECT_EQ(HC_BUFFER_NORMAL, accumulator.level());
+    EXPECT_EQ(11u, accumulator.occupancyPercent());
 }
 
 TEST(EventAccumulatorTest, ConsumeNeverUnderflowsCounts)

--- a/src/client-agent/https_client/tests/unit/eventAccumulator_test.cpp
+++ b/src/client-agent/https_client/tests/unit/eventAccumulator_test.cpp
@@ -1,0 +1,183 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 17, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "eventAccumulator.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <string>
+
+namespace
+{
+    bool append(EventAccumulator& accumulator, const std::string& frame)
+    {
+        return accumulator.append(reinterpret_cast<const uint8_t*>(frame.data()), frame.size());
+    }
+} // namespace
+
+TEST(EncodeEventLineTest, WrapsFrameAsEeLine)
+{
+    const std::string frame = "1:/var/log/syslog:hello";
+    const auto line = encodeEventLine(reinterpret_cast<const uint8_t*>(frame.data()), frame.size());
+    EXPECT_EQ("E 1:/var/log/syslog:hello\n", line);
+}
+
+TEST(EncodeEventLineTest, EscapesEmbeddedNewlinesWithLeadingSpace)
+{
+    const std::string frame = "line1\nline2\nline3";
+    const auto line = encodeEventLine(reinterpret_cast<const uint8_t*>(frame.data()), frame.size());
+    EXPECT_EQ("E line1\n line2\n line3\n", line);
+}
+
+TEST(EventAccumulatorTest, AppendAndSnapshotProducesEeLines)
+{
+    EventAccumulator accumulator {1024, 4, 10000};
+    EXPECT_TRUE(append(accumulator, "a"));
+    EXPECT_TRUE(append(accumulator, "b"));
+    const auto snapshot = accumulator.snapshot(SIZE_MAX);
+    EXPECT_EQ("E a\nE b\n", snapshot.body);
+    EXPECT_EQ(2u, snapshot.eventCount);
+    EXPECT_EQ(snapshot.body.size(), snapshot.byteLength);
+}
+
+TEST(EventAccumulatorTest, FlushDueOnSizeThreshold)
+{
+    EventAccumulator accumulator {8, 4, 10000}; // batch size 8 bytes.
+    EXPECT_FALSE(accumulator.flushDue(0, 8));
+    append(accumulator, "abc"); // "E abc\n" = 6 bytes < 8.
+    EXPECT_FALSE(accumulator.flushDue(0, 8));
+    append(accumulator, "d"); // + "E d\n" = 10 bytes >= 8.
+    EXPECT_TRUE(accumulator.flushDue(0, 8));
+}
+
+TEST(EventAccumulatorTest, FlushDueOnAgeThreshold)
+{
+    EventAccumulator accumulator {1024, 4, 5000};
+    append(accumulator, "a");
+    EXPECT_FALSE(accumulator.flushDue(4999, 1024));
+    EXPECT_TRUE(accumulator.flushDue(5000, 1024));
+}
+
+TEST(EventAccumulatorTest, EmptyBufferIsNeverFlushDue)
+{
+    EventAccumulator accumulator {1024, 4, 1};
+    EXPECT_FALSE(accumulator.flushDue(1000000, 1024));
+    EXPECT_TRUE(accumulator.empty());
+}
+
+TEST(EventAccumulatorTest, DropNewestWhenCapExceeded)
+{
+    // batch 8, multiplier 1 -> cap 8 bytes. "E aaaa\n" = 7 bytes fits; the
+    // next 7-byte line would exceed 8 and is dropped.
+    EventAccumulator accumulator {8, 1, 10000};
+    EXPECT_TRUE(append(accumulator, "aaaa"));
+    EXPECT_FALSE(append(accumulator, "bbbb"));
+    const auto snapshot = accumulator.snapshot(SIZE_MAX);
+    EXPECT_EQ("E aaaa\n", snapshot.body);
+    EXPECT_EQ(1u, snapshot.eventCount);
+}
+
+TEST(EventAccumulatorTest, ConsumeIsTailPreserving)
+{
+    EventAccumulator accumulator {1024, 4, 10000};
+    append(accumulator, "first");
+    const auto snapshot = accumulator.snapshot(SIZE_MAX);
+    // An event arrives AFTER the snapshot but BEFORE consume().
+    append(accumulator, "second");
+    accumulator.consume(snapshot);
+    const auto remaining = accumulator.snapshot(SIZE_MAX);
+    EXPECT_EQ("E second\n", remaining.body);
+    EXPECT_EQ(1u, remaining.eventCount);
+}
+
+TEST(EventAccumulatorTest, LadderThresholdsBothDirections)
+{
+    // cap = 100 bytes. Each "E " + 8 chars + "\n" = 11 bytes.
+    EventAccumulator accumulator {25, 4, 100000};
+    const std::string frame(8, 'x'); // 11-byte line.
+
+    EXPECT_EQ(HC_BUFFER_NORMAL, accumulator.level());
+
+    for (int index = 0; index < 5; index++) // 55 bytes -> 55% -> WARNING.
+    {
+        append(accumulator, frame);
+    }
+
+    EXPECT_EQ(HC_BUFFER_WARNING, accumulator.level());
+
+    for (int index = 0; index < 2; index++) // 77 bytes -> 77% -> FULL.
+    {
+        append(accumulator, frame);
+    }
+
+    EXPECT_EQ(HC_BUFFER_FULL, accumulator.level());
+    append(accumulator, frame); // 88 bytes.
+    append(accumulator, frame); // 99 bytes -> 99% -> FLOOD.
+    EXPECT_EQ(HC_BUFFER_FLOOD, accumulator.level());
+
+    // Draining most of the buffer walks the ladder back down.
+    EventAccumulator::Snapshot partial;
+    partial.byteLength = 88;
+    partial.eventCount = 8;
+    accumulator.consume(partial);
+    EXPECT_EQ(HC_BUFFER_NORMAL, accumulator.level());
+}
+
+TEST(EventAccumulatorTest, ConsumeNeverUnderflowsCounts)
+{
+    EventAccumulator accumulator {1024, 4, 10000};
+    append(accumulator, "one");
+    EventAccumulator::Snapshot oversized;
+    oversized.byteLength = 100000; // More than present.
+    oversized.eventCount = 100;
+    accumulator.consume(oversized);
+    EXPECT_TRUE(accumulator.empty());
+    EXPECT_EQ(0u, accumulator.snapshot(SIZE_MAX).eventCount);
+}
+
+TEST(EventAccumulatorTest, BoundedSnapshotCutsAtEventBoundary)
+{
+    // Each "E xx\n" line is 5 bytes. A 12-byte budget fits two whole lines
+    // (10 bytes); the third would push to 15 and is left behind.
+    EventAccumulator accumulator {1024, 4, 10000};
+    append(accumulator, "aa");
+    append(accumulator, "bb");
+    append(accumulator, "cc");
+    const auto snapshot = accumulator.snapshot(12);
+    EXPECT_EQ("E aa\nE bb\n", snapshot.body);
+    EXPECT_EQ(2u, snapshot.eventCount);
+    EXPECT_EQ(10u, snapshot.byteLength);
+}
+
+TEST(EventAccumulatorTest, BoundedSnapshotAlwaysReturnsAtLeastOneEvent)
+{
+    // A budget smaller than the first line still returns that one event, so a
+    // lone oversized event can be sent (or dropped) rather than wedging.
+    EventAccumulator accumulator {1024, 4, 10000};
+    append(accumulator, "a-long-single-event-frame");
+    const auto snapshot = accumulator.snapshot(4); // Below the line length.
+    EXPECT_EQ(1u, snapshot.eventCount);
+    EXPECT_EQ("E a-long-single-event-frame\n", snapshot.body);
+}
+
+TEST(EventAccumulatorTest, ConsumeAfterBoundedSnapshotPreservesRemainderAndTail)
+{
+    EventAccumulator accumulator {1024, 4, 10000};
+    append(accumulator, "aa");
+    append(accumulator, "bb");
+    const auto snapshot = accumulator.snapshot(5); // Just the first line.
+    append(accumulator, "cc"); // Arrives before consume.
+    accumulator.consume(snapshot);
+    const auto remaining = accumulator.snapshot(SIZE_MAX);
+    EXPECT_EQ("E bb\nE cc\n", remaining.body);
+    EXPECT_EQ(2u, remaining.eventCount);
+}

--- a/src/client-agent/https_client/tests/unit/hcInterface_test.cpp
+++ b/src/client-agent/https_client/tests/unit/hcInterface_test.cpp
@@ -243,9 +243,9 @@ TEST_F(HcInterfaceTest, LifecycleChurn)
             }
         });
         std::this_thread::sleep_for(std::chrono::milliseconds {2});
+        hc_stop(handle);
         submitting = false;
         producer.join();
-        hc_stop(handle);
         hc_destroy(handle);
     }
 }

--- a/src/client-agent/https_client/tests/unit/hcInterface_test.cpp
+++ b/src/client-agent/https_client/tests/unit/hcInterface_test.cpp
@@ -27,6 +27,7 @@
 #include <chrono>
 #include <cstring>
 #include <mutex>
+#include <thread>
 #include <vector>
 
 namespace
@@ -187,17 +188,63 @@ TEST_F(HcInterfaceTest, StartFailsClosedWithoutCaInFullMode)
     hc_destroy(handle);
 }
 
+TEST_F(HcInterfaceTest, SubmitBeforeStartIsRejected)
+{
+    hc_handle* handle = hc_create(&m_config, &m_callbacks);
+    ASSERT_NE(nullptr, handle);
+    const uint8_t frame[] = "1:/var/log/syslog:hello";
+    EXPECT_FALSE(hc_submit_event(handle, frame, sizeof(frame) - 1));
+    hc_notify_now(handle);
+    EXPECT_EQ(HC_STATE_STOPPED, hc_get_state(handle));
+    hc_destroy(handle);
+}
+
+TEST_F(HcInterfaceTest, SubmitAfterStartAcceptsIntoQueues)
+{
+    hc_handle* handle = hc_create(&m_config, &m_callbacks);
+    ASSERT_NE(nullptr, handle);
+    ASSERT_TRUE(hc_start(handle));
+    const uint8_t frame[] = "1:/var/log/syslog:hello";
+    EXPECT_TRUE(hc_submit_event(handle, frame, sizeof(frame) - 1));
+    hc_notify_now(handle);
+    hc_destroy(handle);
+}
+
+TEST_F(HcInterfaceTest, SubmitNullArgumentsAreRejected)
+{
+    hc_handle* handle = hc_create(&m_config, &m_callbacks);
+    ASSERT_NE(nullptr, handle);
+    ASSERT_TRUE(hc_start(handle));
+    const uint8_t frame[] = "x";
+    EXPECT_FALSE(hc_submit_event(handle, nullptr, 1));
+    EXPECT_FALSE(hc_submit_event(handle, frame, 0));
+    hc_destroy(handle);
+}
+
 TEST_F(HcInterfaceTest, LifecycleChurn)
 {
-    // The designated ThreadSanitizer workload: a fresh handle each cycle
-    // exercises the full create/start/stop/destroy race surface. The client is
-    // single-shot (start-after-stop is rejected), so restarting one handle is
-    // not a valid workload.
+    // The designated ThreadSanitizer workload: a fresh handle each cycle (the
+    // client is single-shot) with concurrent submits from another thread,
+    // exercising the full create/start/stop/destroy race surface.
     for (int cycle = 0; cycle < 20; cycle++)
     {
         hc_handle* handle = hc_create(&m_config, &m_callbacks);
         ASSERT_NE(nullptr, handle);
         ASSERT_TRUE(hc_start(handle));
+        std::atomic<bool> submitting {true};
+        std::thread producer(
+            [&]
+        {
+            const uint8_t frame[] = "1:/var/log/syslog:churn";
+
+            while (submitting.load())
+            {
+                hc_submit_event(handle, frame, sizeof(frame) - 1);
+            }
+        });
+        std::this_thread::sleep_for(std::chrono::milliseconds {2});
+        submitting = false;
+        producer.join();
         hc_stop(handle);
         hc_destroy(handle);
     }
@@ -220,6 +267,8 @@ TEST_F(HcInterfaceTest, NullHandleIsSafeEverywhere)
     EXPECT_FALSE(hc_start(nullptr));
     hc_stop(nullptr);
     hc_destroy(nullptr);
+    const uint8_t frame[] = "x";
+    EXPECT_FALSE(hc_submit_event(nullptr, frame, 1));
     hc_notify_now(nullptr);
     EXPECT_FALSE(hc_set_config_hash(nullptr, "abc"));
     EXPECT_FALSE(hc_set_agent_key(nullptr, "000102030405060708090a0b0c0d0e0f"));

--- a/src/client-agent/https_client/tests/unit/mocks/mockCallbackSink.hpp
+++ b/src/client-agent/https_client/tests/unit/mocks/mockCallbackSink.hpp
@@ -24,6 +24,7 @@ class MockCallbackSink : public ICallbackSink
         MOCK_METHOD(void, onConfigDownloaded,
                     (const std::string& configHash, std::shared_ptr<SpoolFile> file), (override));
         MOCK_METHOD(void, onStateChange, (hc_conn_state_t state), (override));
+        MOCK_METHOD(void, onBufferLevel, (hc_buffer_level_t level), (override));
 };
 
 #endif // _HC_MOCK_CALLBACK_SINK_HPP

--- a/src/client-agent/https_client/tests/unit/moduleConfig_test.cpp
+++ b/src/client-agent/https_client/tests/unit/moduleConfig_test.cpp
@@ -38,6 +38,9 @@ TEST(ModuleConfigTest, DefaultsAppliedOnZeroFields)
 {
     const auto typed = ModuleConfig::fromC(minimalConfig());
     EXPECT_EQ(443, typed.serverPort);
+    EXPECT_EQ(1024u * 1024u, typed.batchSizeBytes);
+    EXPECT_EQ(10000u, typed.batchIntervalMs);
+    EXPECT_EQ(4u, typed.bufferCapMultiplier);
     EXPECT_EQ(20u, typed.notifyIntervalS);
     EXPECT_EQ(60u, typed.rejectedRetryIntervalS);
     EXPECT_EQ(10000u, typed.requestTimeoutMs);
@@ -57,12 +60,12 @@ TEST(ModuleConfigTest, ExplicitValuesAreKept)
 {
     auto config = minimalConfig();
     config.server_port = 27840;
+    config.batch_size_bytes = 2048;
     config.notify_interval_s = 5;
-    config.request_timeout_ms = 5000;
     const auto typed = ModuleConfig::fromC(config);
     EXPECT_EQ(27840, typed.serverPort);
+    EXPECT_EQ(2048u, typed.batchSizeBytes);
     EXPECT_EQ(5u, typed.notifyIntervalS);
-    EXPECT_EQ(5000u, typed.requestTimeoutMs);
 }
 
 TEST(ModuleConfigTest, UnterminatedFixedFieldIsBounded)

--- a/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
@@ -1,0 +1,294 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 17, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "fakeSysSeams.hpp"
+#include "mockCallbackSink.hpp"
+#include "mockHttpPerformer.hpp"
+#include "statelessStream.hpp"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <vector>
+
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+namespace
+{
+    HttpResponse response(TransportStatus status, long code, long retryAfter = 0)
+    {
+        HttpResponse value;
+        value.status = status;
+        value.httpCode = code;
+        value.retryAfterSeconds = retryAfter;
+        return value;
+    }
+
+    class StatelessStreamTest : public ::testing::Test
+    {
+        protected:
+            StatelessStreamTest()
+                : m_signer("001", m_keyProvider)
+                , m_config(makeConfig())
+                , m_authGate(m_sink, [] {})
+            , m_stream(m_config, m_performer, m_signer, m_clock, m_random, m_sink, m_authGate)
+            {
+            }
+
+            static ModuleConfig makeConfig()
+            {
+                hc_config_t config {};
+                std::strncpy(config.server_host, "127.0.0.1", sizeof(config.server_host) - 1);
+                std::strncpy(config.agent_id, "001", sizeof(config.agent_id) - 1);
+                config.verify_mode = HC_VERIFY_NONE;
+                config.batch_size_bytes = 16; // Small so a couple of events trigger a flush.
+                config.batch_interval_ms = 5000;
+                config.buffer_cap_multiplier = 4;
+                return ModuleConfig::fromC(config);
+            }
+
+            bool submit(const std::string& frame)
+            {
+                return m_stream.submit(reinterpret_cast<const uint8_t*>(frame.data()), frame.size());
+            }
+
+            ConfigKeyProvider m_keyProvider {"000102030405060708090a0b0c0d0e0f"};
+            CmacSigner m_signer;
+            ModuleConfig m_config;
+            FakeClock m_clock;
+            ScriptedRandom m_random {{0.0}}; // Zero jitter keeps deferrals deterministic.
+            NiceMock<MockCallbackSink> m_sink;
+            MockHttpPerformer m_performer;
+            AuthGate m_authGate;
+            FakeWaiter m_waiter;
+            StatelessStream m_stream;
+    };
+} // namespace
+
+TEST_F(StatelessStreamTest, NoFlushWhenEmpty)
+{
+    EXPECT_CALL(m_performer, perform(_)).Times(0);
+    m_stream.tick(m_waiter, false);
+}
+
+TEST_F(StatelessStreamTest, FlushOnSizeThresholdSendsHeaderAndEvents)
+{
+    std::string sentBody;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & spec)
+    {
+        sentBody.assign(reinterpret_cast<const char*>(spec.body), spec.bodyLength);
+        EXPECT_EQ("/stateless", spec.target);
+        return response(TransportStatus::Ok, 200);
+    }));
+
+    submit("event-aaaa");
+    submit("event-bbbb"); // Pushes the buffer past the 16-byte max payload.
+    m_stream.tick(m_waiter, false);
+
+    // The 16-byte max payload caps one POST to the first whole event; the
+    // second follows in the next flush.
+    EXPECT_EQ(0u, sentBody.find("H {\"wazuh\":{\"agent\":{\"id\":\"001\"}}}\n"));
+    EXPECT_NE(std::string::npos, sentBody.find("E event-aaaa\n"));
+    EXPECT_EQ(std::string::npos, sentBody.find("E event-bbbb\n"));
+}
+
+TEST_F(StatelessStreamTest, SuccessConsumesTheBatch)
+{
+    EXPECT_CALL(m_performer, perform(_)).WillOnce(Return(response(TransportStatus::Ok, 200)));
+    submit("event-aaaa");
+    submit("event-bbbb");
+    m_stream.tick(m_waiter, false);
+    // Nothing left: a second tick sends nothing.
+    EXPECT_CALL(m_performer, perform(_)).Times(0);
+    m_stream.tick(m_waiter, false);
+}
+
+TEST_F(StatelessStreamTest, ForceFlushesEvenBelowThreshold)
+{
+    EXPECT_CALL(m_performer, perform(_)).WillOnce(Return(response(TransportStatus::Ok, 200)));
+    submit("tiny"); // Well under 16 bytes.
+    m_stream.tick(m_waiter, true);
+}
+
+TEST_F(StatelessStreamTest, PayloadTooLargeKeepsEventsInOrderAndHalves)
+{
+    // 413 must NOT drop a multi-event batch (#37835): the events stay, in
+    // order, and the effective payload halves so the next flush is smaller.
+    std::vector<std::string> bodies;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillRepeatedly(Invoke(
+                        [&](const HttpRequestSpec & spec)
+    {
+        bodies.emplace_back(reinterpret_cast<const char*>(spec.body), spec.bodyLength);
+        // First send (full 16-byte budget) 413s; smaller retries succeed.
+        return response(TransportStatus::Ok, bodies.size() == 1 ? 413 : 200);
+    }));
+
+    submit("aaaa"); // "E aaaa\n" = 7 bytes.
+    submit("bbbb"); // + 7 = 14 bytes; two events in the batch.
+    m_stream.tick(m_waiter, true); // 413: batch retained, payload halves to 8.
+    m_stream.tick(m_waiter, true); // Smaller batch (fits 8): first event.
+    m_stream.tick(m_waiter, true); // Remaining event.
+
+    ASSERT_GE(bodies.size(), 3u);
+    // Nothing lost, order preserved across the split sends.
+    EXPECT_NE(std::string::npos, bodies[1].find("E aaaa\n"));
+    EXPECT_NE(std::string::npos, bodies[2].find("E bbbb\n"));
+
+    // All delivered: a further tick sends nothing.
+    EXPECT_CALL(m_performer, perform(_)).Times(0);
+    m_stream.tick(m_waiter, true);
+}
+
+TEST_F(StatelessStreamTest, SuccessRampsThePayloadBackUp)
+{
+    // After a 413 halves the payload, successful sends double it back, so the
+    // batch grows again toward the configured max.
+    int calls = 0;
+    std::vector<size_t> bodySizes;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillRepeatedly(Invoke(
+                        [&](const HttpRequestSpec & spec)
+    {
+        bodySizes.push_back(spec.bodyLength);
+        return response(TransportStatus::Ok, ++calls == 1 ? 413 : 200);
+    }));
+
+    for (int index = 0; index < 6; index++)
+    {
+        submit("cccc");
+    }
+
+    for (int tick = 0; tick < 6; tick++)
+    {
+        m_stream.tick(m_waiter, true);
+    }
+
+    // The post-413 batches start small and grow as the payload ramps back.
+    ASSERT_GE(bodySizes.size(), 3u);
+    EXPECT_LT(bodySizes[1], bodySizes[2]); // Second success carries more than the first.
+}
+
+TEST_F(StatelessStreamTest, SingleOversizedEventIs413DroppedAndCounted)
+{
+    // A lone event that 413s cannot be split: drop it (only unsalvageable
+    // case) so the stream is not wedged.
+    EXPECT_CALL(m_performer, perform(_)).WillOnce(Return(response(TransportStatus::Ok, 413)));
+    submit("only-one-event");
+    m_stream.tick(m_waiter, true); // 413 on a single-event batch: dropped.
+
+    EXPECT_CALL(m_performer, perform(_)).Times(0);
+    m_stream.tick(m_waiter, true); // Nothing left.
+}
+
+TEST_F(StatelessStreamTest, PausedGateHoldsEventsWithoutSending)
+{
+    m_authGate.reportAuthFailure(); // 401 elsewhere: pause.
+    submit("event-aaaa");
+    submit("event-bbbb");
+    EXPECT_CALL(m_performer, perform(_)).Times(0); // No send while paused.
+    m_stream.tick(m_waiter, true);
+
+    // Once released, the retained events flush.
+    m_authGate.release();
+    EXPECT_CALL(m_performer, perform(_)).WillRepeatedly(Return(response(TransportStatus::Ok, 200)));
+    m_stream.tick(m_waiter, true);
+    m_stream.tick(m_waiter, true);
+}
+
+TEST_F(StatelessStreamTest, Non413PermanentStillDropsTheBatch)
+{
+    EXPECT_CALL(m_performer, perform(_)).WillOnce(Return(response(TransportStatus::Ok, 400)));
+    submit("event-aaaa");
+    submit("event-bbbb");
+    m_stream.tick(m_waiter, false);
+    // 400: retrying identical bytes cannot help, so the batch is dropped.
+    EXPECT_CALL(m_performer, perform(_)).Times(0);
+    m_stream.tick(m_waiter, false);
+}
+
+TEST_F(StatelessStreamTest, RetryableKeepsTheBatch)
+{
+    EXPECT_CALL(m_performer, perform(_))
+    .WillRepeatedly(Return(response(TransportStatus::Timeout, 0)));
+    submit("event-aaaa");
+    submit("event-bbbb");
+    m_stream.tick(m_waiter, true); // force; the batch stays after failure.
+
+    // A later forced tick still has the batch to send.
+    EXPECT_CALL(m_performer, perform(_)).WillOnce(Return(response(TransportStatus::Ok, 200)));
+    m_stream.tick(m_waiter, true);
+}
+
+TEST_F(StatelessStreamTest, BackPressureKeepsTheBatchForALaterTick)
+{
+    // RetrySender owns the Retry-After wait; with the waiter unscripted the
+    // send returns without success, so the batch survives for a later flush.
+    EXPECT_CALL(m_performer, perform(_)).WillOnce(Return(response(TransportStatus::Ok, 503, 2)));
+    submit("event-aaaa");
+    submit("event-bbbb");
+    m_stream.tick(m_waiter, false);
+
+    // The batch is still present: a later tick can send it successfully.
+    EXPECT_CALL(m_performer, perform(_)).WillOnce(Return(response(TransportStatus::Ok, 200)));
+    m_stream.tick(m_waiter, true);
+}
+
+TEST_F(StatelessStreamTest, BackPressureIsRetriedInsideOneFlushWhenWaiterAllows)
+{
+    // With the waiter scripted to keep running, one flush waits out the
+    // Retry-After and retries within the same tick.
+    m_waiter.script({true});
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 503, 2)))
+    .WillOnce(Return(response(TransportStatus::Ok, 200)));
+    submit("event-aaaa");
+    submit("event-bbbb");
+    m_stream.tick(m_waiter, false);
+
+    // Consumed on success: nothing left to send.
+    EXPECT_CALL(m_performer, perform(_)).Times(0);
+    m_stream.tick(m_waiter, false);
+}
+
+TEST_F(StatelessStreamTest, BufferLevelEmittedOnlyOnChange)
+{
+    // cap = 16 * 4 = 64 bytes. Cross 50% (32 bytes) to reach WARNING.
+    ::testing::InSequence sequence;
+    EXPECT_CALL(m_sink, onBufferLevel(HC_BUFFER_WARNING)).Times(1);
+
+    for (int index = 0; index < 3; index++) // 3 x 13-byte lines = 39 bytes.
+    {
+        submit("event-1234"); // "E event-1234\n" = 13 bytes.
+    }
+}
+
+TEST_F(StatelessStreamTest, DropNewestReturnsFalseAtCap)
+{
+    // cap = 64 bytes; fill it, then the next append is dropped.
+    bool anyDropped = false;
+
+    for (int index = 0; index < 20; index++)
+    {
+        if (!submit("event-1234"))
+        {
+            anyDropped = true;
+        }
+    }
+
+    EXPECT_TRUE(anyDropped);
+}

--- a/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
@@ -17,7 +17,10 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <chrono>
 #include <cstring>
+#include <string>
 #include <vector>
 
 using ::testing::_;
@@ -204,6 +207,52 @@ TEST_F(StatelessStreamTest, SingleOversizedEventIs413DroppedAndCounted)
     m_stream.tick(m_waiter, true); // Nothing left.
 }
 
+TEST_F(StatelessStreamTest, ASingleOversized413DoesNotShrinkTheBudget)
+{
+    // The batch size was not what the manager rejected -- one event was simply
+    // too big. Halving here would only cost a round trip before the next event
+    // is tried, so the budget must survive the drop.
+    hc_config_t raw {};
+    std::strncpy(raw.server_host, "127.0.0.1", sizeof(raw.server_host) - 1);
+    std::strncpy(raw.agent_id, "001", sizeof(raw.agent_id) - 1);
+    raw.verify_mode = HC_VERIFY_NONE;
+    raw.batch_size_bytes = 200; // 35-byte H line + 165 bytes of E lines.
+    raw.batch_interval_ms = 5000;
+    raw.buffer_cap_multiplier = 4;
+    const ModuleConfig config = ModuleConfig::fromC(raw);
+    StatelessStream stream {config,   m_performer, m_signer, m_clock,
+                            m_random, m_sink,      m_authGate};
+
+    const auto push = [&stream](const std::string & frame)
+    {
+        stream.submit(reinterpret_cast<const uint8_t*>(frame.data()), frame.size());
+    };
+
+    EXPECT_CALL(m_performer, perform(_)).WillOnce(Return(response(TransportStatus::Ok, 413)));
+    push("only-one-event");
+    stream.tick(m_waiter, true);
+    EXPECT_EQ(1u, stream.droppedEvents());
+
+    // 12 x 13 bytes = 156, inside the untouched 165-byte event budget. A halved
+    // budget (100 - 35 = 65) would have cut this to five events.
+    std::string sentBody;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & spec)
+    {
+        sentBody.assign(reinterpret_cast<const char*>(spec.body), spec.bodyLength);
+        return response(TransportStatus::Ok, 200);
+    }));
+
+    for (int index = 0; index < 12; index++)
+    {
+        push("event-1234");
+    }
+
+    stream.tick(m_waiter, true);
+    EXPECT_EQ(12u, std::count(sentBody.begin(), sentBody.end(), '\n') - 1); // Minus the H line.
+}
+
 TEST_F(StatelessStreamTest, PausedGateHoldsEventsWithoutSending)
 {
     m_authGate.reportAuthFailure(); // 401 elsewhere: pause.
@@ -274,16 +323,140 @@ TEST_F(StatelessStreamTest, BackPressureIsRetriedInsideOneFlushWhenWaiterAllows)
     m_stream.tick(m_waiter, false);
 }
 
-TEST_F(StatelessStreamTest, BufferLevelEmittedOnlyOnChange)
+TEST_F(StatelessStreamTest, BufferLevelWalksTheLegacyLadder)
 {
-    // cap = 51 * 4 = 204 bytes. Cross 50% (102 bytes) to reach WARNING.
+    // cap = 51 * 4 = 204 bytes; "E event-1234\n" is 13 bytes, so each event is
+    // ~6%. The default ladder warns at 90% (184 bytes = the 15th event) and
+    // reports FULL on the first drop-newest rejection (the 16th would need 208).
     ::testing::InSequence sequence;
     EXPECT_CALL(m_sink, onBufferLevel(HC_BUFFER_WARNING)).Times(1);
+    EXPECT_CALL(m_sink, onBufferLevel(HC_BUFFER_FULL)).Times(1);
 
-    for (int index = 0; index < 8; index++) // 8 x 13-byte lines = 104 bytes.
+    for (int index = 0; index < 16; index++)
     {
-        submit("event-1234"); // "E event-1234\n" = 13 bytes.
+        submit("event-1234");
     }
+
+    EXPECT_EQ(HC_BUFFER_FULL, m_stream.level());
+}
+
+TEST_F(StatelessStreamTest, BufferLevelHoldsWarningUntilTheNormalMark)
+{
+    // 15 events = 195 bytes = 95% -> WARNING. Draining to 12 events (156 bytes,
+    // 76%) is under the warn mark but above normal_level (70%), so the legacy
+    // ladder stays in WARNING without announcing anything.
+    EXPECT_CALL(m_sink, onBufferLevel(HC_BUFFER_WARNING)).Times(1);
+    EXPECT_CALL(m_sink, onBufferLevel(HC_BUFFER_NORMAL)).Times(0);
+
+    for (int index = 0; index < 15; index++)
+    {
+        submit("event-1234");
+    }
+
+    EXPECT_CALL(m_performer, perform(_)).WillOnce(Return(response(TransportStatus::Ok, 200)));
+    m_stream.tick(m_waiter, true); // Sends one event: 14 left = 182 bytes = 89%.
+    EXPECT_EQ(HC_BUFFER_WARNING, m_stream.level());
+}
+
+TEST_F(StatelessStreamTest, FloodOnlyAfterFullHoldsForTheTolerance)
+{
+    ::testing::InSequence sequence;
+    EXPECT_CALL(m_sink, onBufferLevel(HC_BUFFER_WARNING)).Times(1);
+    EXPECT_CALL(m_sink, onBufferLevel(HC_BUFFER_FULL)).Times(1);
+    EXPECT_CALL(m_sink, onBufferLevel(HC_BUFFER_FLOOD)).Times(1);
+
+    for (int index = 0; index < 16; index++) // Fills, then the first drop.
+    {
+        submit("event-1234");
+    }
+
+    submit("event-1234"); // Still dropping, but inside the tolerance window.
+    m_clock.advance(std::chrono::seconds {15});
+    submit("event-1234"); // Full for 15 s: flooded.
+    EXPECT_EQ(HC_BUFFER_FLOOD, m_stream.level());
+}
+
+TEST_F(StatelessStreamTest, KeepsDrainingWhileTheBacklogStaysAboveTheThreshold)
+{
+    // The size condition is edge-triggered at submit(), so a tick that leaves
+    // the buffer above the threshold must ask to run again immediately --
+    // otherwise a full buffer gives up a whole interval per request.
+    EXPECT_CALL(m_performer, perform(_)).WillRepeatedly(Return(response(TransportStatus::Ok, 200)));
+
+    for (int index = 0; index < 6; index++)
+    {
+        submit("event-1234");
+    }
+
+    EXPECT_EQ(std::chrono::milliseconds::zero(), m_stream.tick(m_waiter, false));
+
+    // Drain the rest; the last flush empties the buffer, so the stream goes
+    // back to waiting out the batch interval.
+    std::chrono::milliseconds delay {0};
+
+    for (int index = 0; index < 6 && delay == std::chrono::milliseconds::zero(); index++)
+    {
+        delay = m_stream.tick(m_waiter, false);
+    }
+
+    EXPECT_EQ(std::chrono::milliseconds {m_config.batchIntervalMs}, delay);
+}
+
+TEST_F(StatelessStreamTest, AFailedFlushFallsBackToTheBatchInterval)
+{
+    // Never loop back-to-back on failure: that would hammer a manager that is
+    // rejecting or backing off.
+    EXPECT_CALL(m_performer, perform(_))
+    .WillRepeatedly(Return(response(TransportStatus::Timeout, 0)));
+
+    for (int index = 0; index < 6; index++)
+    {
+        submit("event-1234");
+    }
+
+    EXPECT_EQ(std::chrono::milliseconds {m_config.batchIntervalMs}, m_stream.tick(m_waiter, false));
+}
+
+TEST_F(StatelessStreamTest, DrainUsesASingleAttemptWithinTheDrainWindow)
+{
+    // The drain runs on the stop path with a waiter that is never stopped, so
+    // it must not walk the retry ladder: one attempt per batch, bounded by the
+    // drain window, exactly like ControlStream::drainStep.
+    uint32_t attempts = 0;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillRepeatedly(Invoke(
+                        [&](const HttpRequestSpec & spec)
+    {
+        attempts++;
+        EXPECT_EQ(m_config.drainTimeoutMs, spec.timeoutMs);
+        return response(TransportStatus::Timeout, 0);
+    }));
+
+    m_waiter.script({true, true, true, true, true}); // Would allow retries.
+    submit("event-aaaa");
+    m_stream.drain(m_waiter);
+    EXPECT_EQ(1u, attempts);
+}
+
+TEST_F(StatelessStreamTest, DrainStopsAtTheIterationBound)
+{
+    // A manager that keeps accepting must not let the drain run forever either.
+    uint32_t attempts = 0;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillRepeatedly(Invoke(
+                        [&](const HttpRequestSpec&)
+    {
+        attempts++;
+        return response(TransportStatus::Ok, 200);
+    }));
+
+    for (int index = 0; index < 15; index++)
+    {
+        submit("event-1234");
+    }
+
+    m_stream.drain(m_waiter);
+    EXPECT_EQ(m_config.bufferCapMultiplier + 1, attempts);
 }
 
 TEST_F(StatelessStreamTest, DropNewestReturnsFalseAtCap)

--- a/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
@@ -53,15 +53,21 @@ namespace
                 std::strncpy(config.server_host, "127.0.0.1", sizeof(config.server_host) - 1);
                 std::strncpy(config.agent_id, "001", sizeof(config.agent_id) - 1);
                 config.verify_mode = HC_VERIFY_NONE;
-                config.batch_size_bytes = 16; // Small so a couple of events trigger a flush.
+                // 35-byte H line + 16 bytes available for E lines.
+                config.batch_size_bytes = 51;
                 config.batch_interval_ms = 5000;
                 config.buffer_cap_multiplier = 4;
                 return ModuleConfig::fromC(config);
             }
 
-            bool submit(const std::string& frame)
+            StatelessStream::SubmissionResult submitResult(const std::string& frame)
             {
                 return m_stream.submit(reinterpret_cast<const uint8_t*>(frame.data()), frame.size());
+            }
+
+            bool submit(const std::string& frame)
+            {
+                return submitResult(frame).accepted;
             }
 
             ConfigKeyProvider m_keyProvider {"000102030405060708090a0b0c0d0e0f"};
@@ -95,24 +101,26 @@ TEST_F(StatelessStreamTest, FlushOnSizeThresholdSendsHeaderAndEvents)
         return response(TransportStatus::Ok, 200);
     }));
 
-    submit("event-aaaa");
-    submit("event-bbbb"); // Pushes the buffer past the 16-byte max payload.
+    EXPECT_FALSE(submitResult("event-aaaa").shouldWakeSender);
+    EXPECT_TRUE(submitResult("event-bbbb").shouldWakeSender);
     m_stream.tick(m_waiter, false);
 
-    // The 16-byte max payload caps one POST to the first whole event; the
-    // second follows in the next flush.
+    // The configured limit includes the 35-byte H line. The remaining
+    // 16-byte event budget caps this POST to the first whole event.
     EXPECT_EQ(0u, sentBody.find("H {\"wazuh\":{\"agent\":{\"id\":\"001\"}}}\n"));
     EXPECT_NE(std::string::npos, sentBody.find("E event-aaaa\n"));
     EXPECT_EQ(std::string::npos, sentBody.find("E event-bbbb\n"));
+    EXPECT_LE(sentBody.size(), m_config.batchSizeBytes);
 }
 
-TEST_F(StatelessStreamTest, SuccessConsumesTheBatch)
+TEST_F(StatelessStreamTest, SuccessConsumesTheSentPrefix)
 {
     EXPECT_CALL(m_performer, perform(_)).WillOnce(Return(response(TransportStatus::Ok, 200)));
     submit("event-aaaa");
     submit("event-bbbb");
     m_stream.tick(m_waiter, false);
-    // Nothing left: a second tick sends nothing.
+    // The remaining event is below the threshold, so a second immediate tick
+    // does not resend the consumed prefix or flush the retained tail early.
     EXPECT_CALL(m_performer, perform(_)).Times(0);
     m_stream.tick(m_waiter, false);
 }
@@ -120,7 +128,7 @@ TEST_F(StatelessStreamTest, SuccessConsumesTheBatch)
 TEST_F(StatelessStreamTest, ForceFlushesEvenBelowThreshold)
 {
     EXPECT_CALL(m_performer, perform(_)).WillOnce(Return(response(TransportStatus::Ok, 200)));
-    submit("tiny"); // Well under 16 bytes.
+    submit("tiny"); // Well under the 16-byte event budget.
     m_stream.tick(m_waiter, true);
 }
 
@@ -134,7 +142,7 @@ TEST_F(StatelessStreamTest, PayloadTooLargeKeepsEventsInOrderAndHalves)
                         [&](const HttpRequestSpec & spec)
     {
         bodies.emplace_back(reinterpret_cast<const char*>(spec.body), spec.bodyLength);
-        // First send (full 16-byte budget) 413s; smaller retries succeed.
+        // First send (full 16-byte event budget) 413s; smaller retries succeed.
         return response(TransportStatus::Ok, bodies.size() == 1 ? 413 : 200);
     }));
 
@@ -191,6 +199,7 @@ TEST_F(StatelessStreamTest, SingleOversizedEventIs413DroppedAndCounted)
     submit("only-one-event");
     m_stream.tick(m_waiter, true); // 413 on a single-event batch: dropped.
 
+    EXPECT_EQ(1u, m_stream.droppedEvents());
     EXPECT_CALL(m_performer, perform(_)).Times(0);
     m_stream.tick(m_waiter, true); // Nothing left.
 }
@@ -267,11 +276,11 @@ TEST_F(StatelessStreamTest, BackPressureIsRetriedInsideOneFlushWhenWaiterAllows)
 
 TEST_F(StatelessStreamTest, BufferLevelEmittedOnlyOnChange)
 {
-    // cap = 16 * 4 = 64 bytes. Cross 50% (32 bytes) to reach WARNING.
+    // cap = 51 * 4 = 204 bytes. Cross 50% (102 bytes) to reach WARNING.
     ::testing::InSequence sequence;
     EXPECT_CALL(m_sink, onBufferLevel(HC_BUFFER_WARNING)).Times(1);
 
-    for (int index = 0; index < 3; index++) // 3 x 13-byte lines = 39 bytes.
+    for (int index = 0; index < 8; index++) // 8 x 13-byte lines = 104 bytes.
     {
         submit("event-1234"); // "E event-1234\n" = 13 bytes.
     }
@@ -279,16 +288,17 @@ TEST_F(StatelessStreamTest, BufferLevelEmittedOnlyOnChange)
 
 TEST_F(StatelessStreamTest, DropNewestReturnsFalseAtCap)
 {
-    // cap = 64 bytes; fill it, then the next append is dropped.
-    bool anyDropped = false;
+    // cap = 204 bytes; fill it, then later appends are dropped and counted.
+    uint64_t dropped = 0;
 
     for (int index = 0; index < 20; index++)
     {
         if (!submit("event-1234"))
         {
-            anyDropped = true;
+            dropped++;
         }
     }
 
-    EXPECT_TRUE(anyDropped);
+    EXPECT_GT(dropped, 0u);
+    EXPECT_EQ(dropped, m_stream.droppedEvents());
 }

--- a/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
@@ -116,6 +116,34 @@ TEST_F(StatelessStreamTest, FlushOnSizeThresholdSendsHeaderAndEvents)
     EXPECT_LE(sentBody.size(), m_config.batchSizeBytes);
 }
 
+TEST_F(StatelessStreamTest, TheHeaderLineEscapesTheAgentId)
+{
+    // The H line is JSON: an id carrying a quote must not be able to close the
+    // string it sits in and rewrite the rest of the object.
+    hc_config_t raw {};
+    std::strncpy(raw.server_host, "127.0.0.1", sizeof(raw.server_host) - 1);
+    std::strncpy(raw.agent_id, R"(0"01)", sizeof(raw.agent_id) - 1);
+    raw.verify_mode = HC_VERIFY_NONE;
+    const ModuleConfig config = ModuleConfig::fromC(raw);
+    StatelessStream stream {config,   m_performer, m_signer, m_clock,
+                            m_random, m_sink,      m_authGate};
+
+    std::string sentBody;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & spec)
+    {
+        sentBody.assign(reinterpret_cast<const char*>(spec.body), spec.bodyLength);
+        return response(TransportStatus::Ok, 200);
+    }));
+
+    const std::string frame = "1:/loc:escaped";
+    stream.submit(reinterpret_cast<const uint8_t*>(frame.data()), frame.size());
+    stream.tick(m_waiter, true);
+
+    EXPECT_EQ(0u, sentBody.find(R"(H {"wazuh":{"agent":{"id":"0\"01"}}})"));
+}
+
 TEST_F(StatelessStreamTest, SuccessConsumesTheSentPrefix)
 {
     EXPECT_CALL(m_performer, perform(_)).WillOnce(Return(response(TransportStatus::Ok, 200)));

--- a/src/client-agent/https_client/tests/unit/sysSeams_test.cpp
+++ b/src/client-agent/https_client/tests/unit/sysSeams_test.cpp
@@ -16,8 +16,11 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <cstdio>
 #include <fstream>
+#include <thread>
+#include <vector>
 
 TEST(SystemClockTest, WallAndSteadyAdvanceMonotonically)
 {
@@ -53,6 +56,37 @@ TEST(Mt19937RandomTest, ProducesVariation)
     }
 
     EXPECT_TRUE(differs); // Astronomically unlikely to be constant.
+}
+
+TEST(Mt19937RandomTest, ConcurrentCallsRemainInUnitInterval)
+{
+    Mt19937Random random;
+    std::atomic<bool> valid {true};
+    std::vector<std::thread> workers;
+
+    for (int worker = 0; worker < 8; worker++)
+    {
+        workers.emplace_back(
+            [&]
+        {
+            for (int sample = 0; sample < 10000; sample++)
+            {
+                const double value = random.uniform01();
+
+                if (value < 0.0 || value >= 1.0)
+                {
+                    valid = false;
+                }
+            }
+        });
+    }
+
+    for (auto& worker : workers)
+    {
+        worker.join();
+    }
+
+    EXPECT_TRUE(valid);
 }
 
 TEST(FsProbeTest, ReadableFileIsDetected)

--- a/src/client-agent/include/agentd.h
+++ b/src/client-agent/include/agentd.h
@@ -81,6 +81,19 @@ void buffer_init();
 int buffer_append(const char *msg, ssize_t msg_len);
 
 /**
+ * @brief Sends the wazuh-agent.buffer occupancy state event (manager flood
+ *        rules 202-205).
+ *
+ * Writes straight to send_msg(), bypassing every buffer, so a flood report
+ * never queues behind the flood it reports. Called by the legacy leaky bucket
+ * and by the https_client bridge for the /stateless accumulator (#37835).
+ *
+ * @param action One of "normal", "warning", "full", "flooded".
+ * @param severity Matching severity, 0 to 3.
+ */
+void send_buffer_status_event(const char *action, int severity);
+
+/**
  * @brief Resizes the internal circular buffer to a desired capacity.
  *
  * @param current_capacity The current allocated capacity of the buffer before resizing.

--- a/src/client-agent/src/buffer.c
+++ b/src/client-agent/src/buffer.c
@@ -156,7 +156,10 @@ int buffer_append(const char *msg, ssize_t msg_len) {
     }
 }
 
-STATIC void send_buffer_status_event(const char *action, int severity) {
+/* Not static: the https_client bridge reports the accumulator's occupancy
+ * through this same emitter, so the manager sees one event shape whichever
+ * buffer filled up (#37835). */
+void send_buffer_status_event(const char *action, int severity) {
     char msg[OS_MAXSTR];
     cJSON *event = cJSON_CreateObject();
     cJSON_AddStringToObject(event, "event.module", "wazuh-agent");

--- a/src/client-agent/src/event-forward.c
+++ b/src/client-agent/src/event-forward.c
@@ -14,6 +14,7 @@
 #include "state.h"
 #include "os_net.h"
 #include "sec.h"
+#include "https_client_bridge.h"
 
 
 /* Receive a message locally on the agent and forward it to the manager */
@@ -28,28 +29,26 @@ void *EventForward()
     msg[OS_MAXSTR] = '\0';
 
     while ((recv_b = recv(agt->m_queue, msg, OS_MAXSTR, MSG_DONTWAIT)) > 0) {
-        if (agt->buffer){
-            if (msg[0] == 's') {
+        if (msg[0] == 's') {
+            /* Stateful sync frames keep the legacy path until #37836 wires
+             * /stateful; only the stateless egress moves to HTTPS here (#37835). */
+            if (agt->buffer) {
                 if (buffer_append(msg, recv_b) < 0) {
                     break;
                 }
             } else {
-                msg[recv_b] = '\0';
-                if (buffer_append(msg, -1) < 0) {
+                w_agentd_state_update(INCREMENT_MSG_COUNT, NULL);
+                if (send_msg(msg, recv_b) < 0) {
                     break;
                 }
             }
-        }else{
+        } else {
+            /* Stateless events -> HTTPS /stateless accumulator (#37835). The
+             * accumulator owns buffering and back-pressure (drop-newest), so a
+             * full accumulator drops this frame without breaking the intake loop. */
             w_agentd_state_update(INCREMENT_MSG_COUNT, NULL);
-
-            if (msg[0] == 's') {
-                if (send_msg(msg, recv_b) < 0) break;
-            } else {
-                msg[recv_b] = '\0';
-                if (send_msg(msg, -1) < 0) break;
-            }
+            w_https_client_submit_event(msg, recv_b);
         }
-
     }
 
     return (NULL);

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -214,6 +214,12 @@ static void bridge_on_state_change(int state, void *user_data)
     w_agentd_state_update(UPDATE_STATUS, (void *)bridge_map_agent_status(state));
 }
 
+static void bridge_on_buffer_level(int level, void *user_data)
+{
+    (void)user_data;
+    mdebug2("https_client buffer level -> %d", level);
+}
+
 /* Maps the agent config parser's verification_mode enum onto the module
  * ABI's hc_verify_mode_t. The two are defined in independent headers with
  * matching values by convention (both documented "FULL is 0, fails closed");
@@ -332,6 +338,7 @@ void w_https_client_start(void)
     callbacks.on_reenroll_required = bridge_on_reenroll_required;
     callbacks.on_config_downloaded = bridge_on_config_downloaded;
     callbacks.on_state_change = bridge_on_state_change;
+    callbacks.on_buffer_level = bridge_on_buffer_level;
 
     g_https_client = hc_create(&config, &callbacks);
     if (!g_https_client) {

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -31,7 +31,7 @@
 
 #include <ctype.h>
 #include <pthread.h>
-#include <stdatomic.h>
+#include <stdbool.h>
 #include <unistd.h>
 
 #include "agentd.h" /* pulls defs.h (__wazuh_version), sec.h (keys), client-config.h (agt) */
@@ -44,10 +44,18 @@ static hc_handle *g_https_client = NULL;
  * before ever touching the handle, since hc_destroy() may run concurrently
  * with a retry loop that can take minutes against a down manager.
  *
+ * Guarded by g_https_client_lock, NOT a C11 _Atomic: mingw's <stdatomic.h>
+ * does not declare the generic atomic_load()/atomic_store() macros, so on
+ * winagent they compiled as implicit declarations and left undefined
+ * references that broke the wazuh-agent.exe link as soon as anything
+ * referenced this object. Every access already needed the lock for the handle
+ * it guards, so the mutex is the cheaper of the two fixes.
+ *
  * Not static: unit tests call bridge_reenroll_thread() directly (bypassing
  * w_https_client_start(), which is what normally resets this) and need to
- * reset it themselves between cases. */
-_Atomic bool g_https_client_stopping = false;
+ * reset it themselves between cases; they run single-threaded, so they assign
+ * it without the lock. */
+bool g_https_client_stopping = false;
 
 /* Serializes the re-enroll thread's key reload against shutdown's teardown.
  * The thread's hc_set_agent_key() touches the handle; w_https_client_stop()
@@ -59,6 +67,18 @@ _Atomic bool g_https_client_stopping = false;
  * not touched. NOT held across hc_destroy() (which joins module threads and
  * could run long / re-enter). */
 static pthread_mutex_t g_https_client_lock = PTHREAD_MUTEX_INITIALIZER;
+
+/* Reads the stopping flag for callers that are not already holding the lock
+ * (the re-enroll retry loop polls it between attempts). Callers that go on to
+ * touch the handle must instead read it inside their own critical section --
+ * checking here and acting later would reopen the check-then-act race. */
+static bool bridge_stopping(void)
+{
+    w_mutex_lock(&g_https_client_lock);
+    const bool stopping = g_https_client_stopping;
+    w_mutex_unlock(&g_https_client_lock);
+    return stopping;
+}
 
 /* Mirrors the incremental back-off already used for the initial-enrollment
  * loop (start_agent.c's w_agentd_keys_init: 5s steps up to a 60s cap). Not
@@ -87,7 +107,7 @@ void *bridge_reenroll_thread(void *arg)
     int delay_sleep = 0;
 
     while (enroll_result != 0) {
-        if (atomic_load(&g_https_client_stopping)) {
+        if (bridge_stopping()) {
             mdebug1("https_client: agent shutting down; abandoning re-enrollment.");
             return NULL;
         }
@@ -117,7 +137,7 @@ void *bridge_reenroll_thread(void *arg)
      * hc_destroy(), until we release. */
     w_mutex_lock(&g_https_client_lock);
 
-    if (atomic_load(&g_https_client_stopping)) {
+    if (g_https_client_stopping) {
         w_mutex_unlock(&g_https_client_lock);
         mdebug1("https_client: agent shutting down; not reloading the signing key.");
         return NULL;
@@ -324,7 +344,10 @@ static bool bridge_build_config(hc_config_t *config)
 void w_https_client_start(void)
 {
     minfo("https_client: starting.");
-    atomic_store(&g_https_client_stopping, false);
+
+    w_mutex_lock(&g_https_client_lock);
+    g_https_client_stopping = false;
+    w_mutex_unlock(&g_https_client_lock);
 
     hc_config_t config;
     if (!bridge_build_config(&config)) {
@@ -360,7 +383,7 @@ void w_https_client_stop(void)
      * continue) or set the flag before the thread checks it (so it abandons
      * without touching the handle). Only then is it safe to destroy. */
     w_mutex_lock(&g_https_client_lock);
-    atomic_store(&g_https_client_stopping, true);
+    g_https_client_stopping = true;
     w_mutex_unlock(&g_https_client_lock);
 
     if (g_https_client) {
@@ -383,7 +406,7 @@ int w_https_client_submit_event(const char *frame, size_t length)
      * hc_submit_event() only appends to the accumulator, so the section is short. */
     w_mutex_lock(&g_https_client_lock);
 
-    if (g_https_client != NULL && !atomic_load(&g_https_client_stopping)) {
+    if (g_https_client != NULL && !g_https_client_stopping) {
         retval = hc_submit_event(g_https_client, (const uint8_t *)frame, length) ? 0 : -1;
     }
 

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -367,6 +367,13 @@ static bool bridge_build_config(hc_config_t *config)
     config->notify_interval_s = (uint32_t)agt->notify_time;
     strncpy(config->version, __wazuh_version, sizeof(config->version) - 1);
 
+    /* <client><batch>: the /stateless payload limit and flush window. Left at
+     * zero when unset, which the module reads as "use the default" (1 MiB,
+     * 10 s). buffer_cap_multiplier has no configuration surface yet, so the
+     * accumulator keeps its own 4x default. */
+    config->batch_size_bytes = (uint64_t)agt->batch.size;
+    config->batch_interval_ms = (uint32_t)(agt->batch.interval * 1000);
+
     /* Occupancy ladder: the same internal options buffer_init() reads, so an
      * operator who tuned the legacy client buffer keeps their thresholds now
      * that the accumulator is what fills up. Read here rather than through

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -234,10 +234,51 @@ static void bridge_on_state_change(int state, void *user_data)
     w_agentd_state_update(UPDATE_STATUS, (void *)bridge_map_agent_status(state));
 }
 
+/* Occupancy thresholds the module reports against, kept so the log lines can
+ * quote them exactly as buffer.c does. Filled by bridge_build_config() from the
+ * same internal options buffer_init() reads. */
+static int g_buffer_warn_level = 90;
+static int g_buffer_normal_level = 70;
+
+/* Reports the accumulator's occupancy exactly as the legacy leaky bucket
+ * reported the ring it replaced (client-agent/src/buffer.c): the same log lines
+ * and the same wazuh-agent.buffer state event, so the manager-side flood rules
+ * keep firing now that stateless events no longer pass through buffer_append().
+ *
+ * The state event bypasses the accumulator -- send_buffer_status_event() writes
+ * straight to send_msg() -- exactly as buffer.c bypassed the ring it reports
+ * on. A flood report must not queue behind the flood it is reporting. That
+ * keeps it on the legacy socket for now; it moves with every other stateless
+ * producer when the TCP path is retired. */
 static void bridge_on_buffer_level(int level, void *user_data)
 {
     (void)user_data;
-    mdebug2("https_client buffer level -> %d", level);
+
+    switch (level) {
+    case HC_BUFFER_WARNING:
+        mwarn(WARN_BUFFER, g_buffer_warn_level);
+        send_buffer_status_event("warning", 1);
+        break;
+
+    case HC_BUFFER_FULL:
+        mwarn(FULL_BUFFER);
+        send_buffer_status_event("full", 2);
+        break;
+
+    case HC_BUFFER_FLOOD:
+        mwarn(FLOODED_BUFFER);
+        send_buffer_status_event("flooded", 3);
+        break;
+
+    case HC_BUFFER_NORMAL:
+        mdebug1(NORMAL_BUFFER, g_buffer_normal_level);
+        send_buffer_status_event("normal", 0);
+        break;
+
+    default:
+        mdebug2("https_client: unknown buffer level %d.", level);
+        break;
+    }
 }
 
 /* Maps the agent config parser's verification_mode enum onto the module
@@ -326,6 +367,17 @@ static bool bridge_build_config(hc_config_t *config)
     config->notify_interval_s = (uint32_t)agt->notify_time;
     strncpy(config->version, __wazuh_version, sizeof(config->version) - 1);
 
+    /* Occupancy ladder: the same internal options buffer_init() reads, so an
+     * operator who tuned the legacy client buffer keeps their thresholds now
+     * that the accumulator is what fills up. Read here rather than through
+     * buffer.c's globals because those are only set when the legacy buffer is
+     * enabled, and the accumulator applies either way. */
+    g_buffer_warn_level = getDefine_Int("agent", "warn_level", 1, 100);
+    g_buffer_normal_level = getDefine_Int("agent", "normal_level", 0, g_buffer_warn_level - 1);
+    config->buffer_warn_level = (uint32_t)g_buffer_warn_level;
+    config->buffer_normal_level = (uint32_t)g_buffer_normal_level;
+    config->buffer_flood_tolerance_s = (uint32_t)getDefine_Int("agent", "tolerance", 0, 600);
+
     char *checksum = getsharedfiles();
     if (checksum) {
         strncpy(config->config_checksum, checksum, sizeof(config->config_checksum) - 1);
@@ -406,10 +458,19 @@ int w_https_client_submit_event(const char *frame, size_t length)
      * hc_submit_event() only appends to the accumulator, so the section is short. */
     w_mutex_lock(&g_https_client_lock);
 
-    if (g_https_client != NULL && !g_https_client_stopping) {
+    const bool running = g_https_client != NULL && !g_https_client_stopping;
+
+    if (running) {
         retval = hc_submit_event(g_https_client, (const uint8_t *)frame, length) ? 0 : -1;
     }
 
     w_mutex_unlock(&g_https_client_lock);
+
+    /* Mirrors buffer.c's own drop trace, outside the lock: the accumulator is
+     * full and applied drop-newest, exactly as the leaky bucket used to. */
+    if (running && retval != 0) {
+        mdebug2("https_client: unable to store new packet: buffer is full.");
+    }
+
     return retval;
 }

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -368,3 +368,25 @@ void w_https_client_stop(void)
         g_https_client = NULL;
     }
 }
+
+int w_https_client_submit_event(const char *frame, size_t length)
+{
+    if (frame == NULL || length == 0) {
+        return -1;
+    }
+
+    int retval = -1;
+
+    /* Hold the lock across the submit so the handle cannot be destroyed under
+     * us: w_https_client_stop() must take this same lock to flag stopping
+     * before it calls hc_destroy(), so while we hold it the handle stays valid.
+     * hc_submit_event() only appends to the accumulator, so the section is short. */
+    w_mutex_lock(&g_https_client_lock);
+
+    if (g_https_client != NULL && !atomic_load(&g_https_client_stopping)) {
+        retval = hc_submit_event(g_https_client, (const uint8_t *)frame, length) ? 0 : -1;
+    }
+
+    w_mutex_unlock(&g_https_client_lock);
+    return retval;
+}

--- a/src/client-agent/src/https_client_bridge.h
+++ b/src/client-agent/src/https_client_bridge.h
@@ -12,6 +12,8 @@
 #ifndef _HTTPS_CLIENT_BRIDGE_H
 #define _HTTPS_CLIENT_BRIDGE_H
 
+#include <stddef.h> // size_t
+
 /**
  * @brief Start the HTTPS client module unconditionally. Relies on
  *        client-agent/src/main.c having already refused to start the agent
@@ -21,5 +23,13 @@ void w_https_client_start(void);
 
 /** @brief Stop and destroy the HTTPS client module if it was started. */
 void w_https_client_stop(void);
+
+/**
+ * @brief Submit one stateless event frame ("queue:location:message" bytes) into
+ *        the HTTPS /stateless accumulator. Non-blocking: appends and returns.
+ *        Returns 0 if accepted, -1 if dropped (accumulator full) or the client
+ *        is stopping / not started.
+ */
+int w_https_client_submit_event(const char *frame, size_t length);
 
 #endif // _HTTPS_CLIENT_BRIDGE_H

--- a/src/config/include/client-config.h
+++ b/src/config/include/client-config.h
@@ -45,6 +45,18 @@ typedef struct agent_ssl {
     char * ciphers;                 ///< <ciphers>: optional cipher list.
 } agent_ssl;
 
+/**
+ * @brief <client><batch>: the /stateless send-rate model (#37835).
+ *
+ * Replaces the leaky bucket's <client_buffer><events_per_second> pacing for
+ * stateless traffic. Zero means "unset": the transport module applies its own
+ * default (1 MiB, 10 s).
+ */
+typedef struct agent_batch {
+    long long size; ///< <size>: max /stateless request payload, in bytes.
+    long interval;  ///< <interval>: longest an event waits before a flush, seconds.
+} agent_batch;
+
 /* Configuration structure */
 typedef struct _agent {
     agent_server * server;
@@ -62,7 +74,8 @@ typedef struct _agent {
     int events_persec;
     int package_uninstallation;
     agent_flags_t flags;
-    agent_ssl ssl; ///< HTTPS transport TLS settings (<client><ssl>).
+    agent_ssl ssl;     ///< HTTPS transport TLS settings (<client><ssl>).
+    agent_batch batch; ///< /stateless batching limits (<client><batch>).
     w_enrollment_ctx *enrollment_cfg;
 } agent;
 

--- a/src/config/src/client-config.c
+++ b/src/config/src/client-config.c
@@ -16,6 +16,7 @@
 
 int Read_Client_Server(XML_NODE node, agent *logr);
 int Read_Client_SSL(XML_NODE node, agent *logr);
+int Read_Client_Batch(XML_NODE node, agent *logr);
 int Read_Client_Enrollment(XML_NODE node, agent *logr);
 
 int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused)) void *d2)
@@ -120,10 +121,15 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
                 OS_ClearNode(chld_node);
             }
         } else if (strcmp(node[i]->element, xml_client_batch) == 0) {
-            /* <batch><size>/<interval>: the send-rate model is owned by the
-             * stateless events module (#37835 / issue 06). Accepted here so an
-             * ossec.conf carrying it does not fail; parsed there, not here. */
-            mdebug1("The <%s> options are handled by the events module; ignored by the client parser.", xml_client_batch);
+            /* <batch><size>/<interval>: the /stateless send-rate model that
+             * replaces the leaky bucket's pacing (#37835). */
+            if ((chld_node = OS_GetElementsbyNode(xml, node[i]))) {
+                if (Read_Client_Batch(chld_node, logr) < 0) {
+                    OS_ClearNode(chld_node);
+                    return (OS_INVALID);
+                }
+                OS_ClearNode(chld_node);
+            }
         } else if (strcmp(node[i]->element, xml_client_enrollment) == 0) {
             if ((chld_node = OS_GetElementsbyNode(xml, node[i]))) {
                 if (Read_Client_Enrollment(chld_node, logr) < 0) {
@@ -385,6 +391,51 @@ int Read_Client_SSL(XML_NODE node, agent * logr)
         } else if (strcmp(node[j]->element, xml_ciphers) == 0) {
             os_free(logr->ssl.ciphers);
             os_strdup(node[j]->content, logr->ssl.ciphers);
+        } else {
+            merror(XML_INVELEM, node[j]->element);
+            return (OS_INVALID);
+        }
+    }
+
+    return (0);
+}
+
+int Read_Client_Batch(XML_NODE node, agent * logr)
+{
+    /* XML definitions - the <client><batch> block (#37835). Both accept the
+     * usual suffixes: <size>1MB</size>, <interval>10s</interval>. */
+    const char *xml_size = "size";
+    const char *xml_interval = "interval";
+
+    /* An interval this long already dwarfs any sane batching window, and it
+     * keeps the milliseconds the module wants inside 32 bits. */
+    const long max_interval = 86400;
+
+    for (int j = 0; node[j]; j++) {
+        if (!node[j]->element) {
+            merror(XML_ELEMNULL);
+            return (OS_INVALID);
+        } else if (!node[j]->content) {
+            merror(XML_VALUENULL, node[j]->element);
+            return (OS_INVALID);
+        } else if (strcmp(node[j]->element, xml_size) == 0) {
+            const long long size = w_validate_bytes(node[j]->content);
+
+            if (size <= 0) {
+                merror(XML_VALUEERR, node[j]->element, node[j]->content);
+                return (OS_INVALID);
+            }
+
+            logr->batch.size = size;
+        } else if (strcmp(node[j]->element, xml_interval) == 0) {
+            const long interval = w_parse_time(node[j]->content);
+
+            if (interval <= 0 || interval > max_interval) {
+                merror(XML_VALUEERR, node[j]->element, node[j]->content);
+                return (OS_INVALID);
+            }
+
+            logr->batch.interval = interval;
         } else {
             merror(XML_INVELEM, node[j]->element);
             return (OS_INVALID);

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -134,7 +134,7 @@ list(APPEND client-agent_flags "-Wl,--wrap,wurl_free_response -Wl,--wrap,wurl_ht
                                 -Wl,--wrap,hc_create -Wl,--wrap,hc_start -Wl,--wrap,hc_destroy \
                                 -Wl,--wrap,hc_set_agent_key -Wl,--wrap,try_enroll_to_server \
                                 -Wl,--wrap,CreateThread -Wl,--wrap,sleep -Wl,--wrap,getpid \
-                                -Wl,--wrap,w_agentd_state_update \
+                                -Wl,--wrap,w_agentd_state_update -Wl,--wrap,getDefine_Int \
                                 ${DEBUG_OP_WRAPPERS}")
 endif()
 

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -132,7 +132,8 @@ list(APPEND client-agent_flags "${DEBUG_OP_WRAPPERS} \
 list(APPEND client-agent_names "test_https_client_bridge")
 list(APPEND client-agent_flags "-Wl,--wrap,wurl_free_response -Wl,--wrap,wurl_http_request \
                                 -Wl,--wrap,hc_create -Wl,--wrap,hc_start -Wl,--wrap,hc_destroy \
-                                -Wl,--wrap,hc_set_agent_key -Wl,--wrap,try_enroll_to_server \
+                                -Wl,--wrap,hc_set_agent_key -Wl,--wrap,hc_submit_event \
+                                -Wl,--wrap,try_enroll_to_server \
                                 -Wl,--wrap,CreateThread -Wl,--wrap,sleep -Wl,--wrap,getpid \
                                 -Wl,--wrap,w_agentd_state_update -Wl,--wrap,getDefine_Int \
                                 ${DEBUG_OP_WRAPPERS}")

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 if(NOT ${TARGET} STREQUAL "winagent")
 list(REMOVE_ITEM client-agent_files ${SRC_FOLDER}/client-agent/main.o)
 
-add_library(CLIENT-AGENT STATIC ${client-agent_files})
+add_library(CLIENT-AGENT STATIC ${client-agent_files} ${CMAKE_CURRENT_SOURCE_DIR}/https_client_stubs.c)
 
 set_source_files_properties(
     ${client-agent_files}

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -117,7 +117,8 @@ endif()
 
 if(${TARGET} STREQUAL "agent")
 list(APPEND client-agent_names "test_agentd")
-list(APPEND client-agent_flags "-Wl,--wrap,wurl_free_response -Wl,--wrap,wurl_http_request ${DEBUG_OP_WRAPPERS}")
+list(APPEND client-agent_flags "-Wl,--wrap,wurl_free_response -Wl,--wrap,wurl_http_request \
+                                -Wl,--wrap,w_https_client_start -Wl,--wrap,w_https_client_stop ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND client-agent_names "test_startup_gate")
 list(APPEND client-agent_flags "-Wl,--wrap,getsharedfiles ${DEBUG_OP_WRAPPERS}")

--- a/src/unit_tests/client-agent/https_client_stubs.c
+++ b/src/unit_tests/client-agent/https_client_stubs.c
@@ -1,0 +1,78 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+/*
+ * Stubs for the https_client module C-ABI (client-agent/https_client/include/
+ * https_client.h). The agentd bridge (https_client_bridge.c) calls these, but
+ * the client-agent unit test binaries do not link the real libhttps_client, so
+ * without these stubs any test that pulls the bridge object fails to link.
+ *
+ * These are never meaningfully exercised: tests that assert on the bridge's use
+ * of the module intercept the calls with --wrap (so the real symbol is unused).
+ * Handles are opaque here; the linker resolves by name.
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+void *hc_create(const void *config, const void *callbacks)
+{
+    (void)config;
+    (void)callbacks;
+    return NULL;
+}
+
+bool hc_start(void *handle)
+{
+    (void)handle;
+    return false;
+}
+
+void hc_stop(void *handle)
+{
+    (void)handle;
+}
+
+void hc_destroy(void *handle)
+{
+    (void)handle;
+}
+
+bool hc_submit_event(void *handle, const uint8_t *frame, size_t length)
+{
+    (void)handle;
+    (void)frame;
+    (void)length;
+    return false;
+}
+
+void hc_notify_now(void *handle)
+{
+    (void)handle;
+}
+
+bool hc_set_config_hash(void *handle, const char *config_hash)
+{
+    (void)handle;
+    (void)config_hash;
+    return false;
+}
+
+bool hc_set_agent_key(void *handle, const char *key_hex)
+{
+    (void)handle;
+    (void)key_hex;
+    return false;
+}
+
+int hc_get_state(const void *handle)
+{
+    (void)handle;
+    return 0;
+}

--- a/src/unit_tests/client-agent/test_agentd.c
+++ b/src/unit_tests/client-agent/test_agentd.c
@@ -18,6 +18,12 @@
 
 #ifdef TEST_AGENT
 
+/* agentd.c calls w_https_client_start()/w_https_client_stop(), which would drag
+ * https_client_bridge.o (and its hc_* module references) into this test binary.
+ * test_agentd does not exercise the client, so stub the two entry points. */
+void __wrap_w_https_client_start(void) {}
+void __wrap_w_https_client_stop(void) {}
+
 static int setup_group(void **state) {
     curl_response *response;
     os_calloc(1, sizeof(curl_response), response);

--- a/src/unit_tests/client-agent/test_https_client_bridge.c
+++ b/src/unit_tests/client-agent/test_https_client_bridge.c
@@ -12,7 +12,6 @@
 #include <setjmp.h>
 #include <cmocka.h>
 #include <stdio.h>
-#include <stdatomic.h>
 
 #include "shared.h"
 #include "agentd.h"
@@ -78,7 +77,7 @@ void __wrap_w_agentd_state_update(w_agentd_state_update_t type, void *data)
  * it every test, since w_https_client_start() (the normal reset point) isn't
  * called by the tests that invoke bridge_reenroll_thread directly. */
 extern void *bridge_reenroll_thread(void *arg);
-extern _Atomic bool g_https_client_stopping;
+extern bool g_https_client_stopping;
 
 /* A fake, never-dereferenced handle: the bridge only compares it against
  * NULL and passes it back to hc_start/hc_destroy, both mocked here. */
@@ -123,7 +122,7 @@ static int setup_test(void **state)
     agt = (agent *)calloc(1, sizeof(agent));
     memset(&keys, 0, sizeof(keys));
     g_captured_config_valid = false;
-    atomic_store(&g_https_client_stopping, false);
+    g_https_client_stopping = false;
 
     add_server_config("10.0.0.1", 8443);
     /* A syntactically valid 64-hex-char (32-byte, AES-256) key by default;

--- a/src/unit_tests/client-agent/test_https_client_bridge.c
+++ b/src/unit_tests/client-agent/test_https_client_bridge.c
@@ -58,6 +58,14 @@ bool __wrap_hc_set_agent_key(hc_handle *handle, const char *key_hex)
     return mock();
 }
 
+bool __wrap_hc_submit_event(hc_handle *handle, const uint8_t *frame, size_t length)
+{
+    check_expected_ptr(handle);
+    check_expected(frame);
+    check_expected(length);
+    return mock();
+}
+
 int __wrap_try_enroll_to_server(const char *server_rip, uint32_t network_interface)
 {
     check_expected(server_rip);
@@ -593,6 +601,79 @@ static void test_rejected_state_maps_to_nactive(void **state)
     w_https_client_stop();
 }
 
+/* w_https_client_submit_event: the stateless intake seam (#37835) */
+
+static void test_submit_event_forwards_the_frame_to_the_module(void **state)
+{
+    (void)state;
+    const char *frame = "1:/var/log/syslog:hello";
+    start_client_successfully();
+
+    expect_value(__wrap_hc_submit_event, handle, FAKE_HANDLE);
+    expect_string(__wrap_hc_submit_event, frame, frame);
+    expect_value(__wrap_hc_submit_event, length, strlen(frame));
+    will_return(__wrap_hc_submit_event, true);
+
+    assert_int_equal(w_https_client_submit_event(frame, strlen(frame)), 0);
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+static void test_submit_event_reports_a_dropped_frame(void **state)
+{
+    (void)state;
+    const char *frame = "1:/var/log/syslog:dropped";
+    start_client_successfully();
+
+    /* The accumulator is full: drop-newest, traced like the leaky bucket did. */
+    expect_value(__wrap_hc_submit_event, handle, FAKE_HANDLE);
+    expect_string(__wrap_hc_submit_event, frame, frame);
+    expect_value(__wrap_hc_submit_event, length, strlen(frame));
+    will_return(__wrap_hc_submit_event, false);
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "https_client: unable to store new packet: buffer is full.");
+
+    assert_int_equal(w_https_client_submit_event(frame, strlen(frame)), -1);
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+static void test_submit_event_rejects_an_empty_frame(void **state)
+{
+    (void)state;
+    start_client_successfully();
+
+    /* Guarded before the module is ever reached: no hc_submit_event expectation
+     * is queued, so cmocka fails the test if one is made. */
+    assert_int_equal(w_https_client_submit_event(NULL, 8), -1);
+    assert_int_equal(w_https_client_submit_event("frame", 0), -1);
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+static void test_submit_event_is_a_noop_before_start(void **state)
+{
+    (void)state;
+    /* No client yet: the handle is NULL, so nothing may be called through it. */
+    assert_int_equal(w_https_client_submit_event("1:/loc:early", 12), -1);
+}
+
+static void test_submit_event_is_a_noop_once_stopping(void **state)
+{
+    (void)state;
+    start_client_successfully();
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+
+    /* After stop() the handle is destroyed; the stopping flag is what keeps a
+     * late intake frame from reaching freed memory. */
+    assert_int_equal(w_https_client_submit_event("1:/loc:late", 11), -1);
+}
+
 static void test_auth_error_state_maps_to_nactive(void **state)
 {
     (void)state;
@@ -633,6 +714,11 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_stopped_state_maps_to_nactive, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_rejected_state_maps_to_nactive, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_auth_error_state_maps_to_nactive, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_submit_event_forwards_the_frame_to_the_module, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_submit_event_reports_a_dropped_frame, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_submit_event_rejects_an_empty_frame, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_submit_event_is_a_noop_before_start, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_submit_event_is_a_noop_once_stopping, setup_test, teardown_test),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/client-agent/test_https_client_bridge.c
+++ b/src/unit_tests/client-agent/test_https_client_bridge.c
@@ -71,6 +71,30 @@ void __wrap_w_agentd_state_update(w_agentd_state_update_t type, void *data)
     check_expected(data);
 }
 
+/* bridge_build_config() reads the client-buffer occupancy options exactly as
+ * buffer_init() does, and the real getDefine_Int() merror_exit()s when a name
+ * is not in internal_options.conf. No case here exercises those values, so
+ * answer with the shipped defaults instead of scripting three returns into
+ * every test that starts the client. */
+int __wrap_getDefine_Int(const char *high_name, const char *low_name, int min, int max)
+{
+    (void)high_name;
+    (void)min;
+    (void)max;
+
+    if (strcmp(low_name, "warn_level") == 0) {
+        return 90;
+    }
+    if (strcmp(low_name, "normal_level") == 0) {
+        return 70;
+    }
+    if (strcmp(low_name, "tolerance") == 0) {
+        return 15;
+    }
+
+    return 0;
+}
+
 /* bridge_reenroll_thread is not static (see its own comment) precisely so it
  * can be called directly here, synchronously, bypassing w_create_thread.
  * g_https_client_stopping is likewise not static: setup_test() below resets

--- a/src/unit_tests/config/test_client-config_https.c
+++ b/src/unit_tests/config/test_client-config_https.c
@@ -232,7 +232,7 @@ static void test_second_server_block_prevails_with_warning(void **state) {
 
 /* <batch>: accepted, ignored here (owned by the events module, issue 06) */
 
-static void test_batch_block_is_accepted_and_ignored(void **state) {
+static void test_batch_size_and_interval_are_parsed(void **state) {
     OS_XML xml = {0};
     xml_node **nodes;
     agent cfg;
@@ -242,10 +242,99 @@ static void test_batch_block_is_accepted_and_ignored(void **state) {
         "<batch><size>1MB</size><interval>10s</interval></batch>";
 
     expect_valid_ip("10.0.0.1");
-    expect_string(__wrap__mdebug1, formatted_msg,
-                  "The <batch> options are handled by the events module; ignored by the client parser.");
 
     assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(cfg.batch.size, 1024 * 1024);
+    assert_int_equal(cfg.batch.interval, 10);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_batch_is_unset_when_absent(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    /* Zero is what the transport module reads as "apply your own default". */
+    const char *xml_str = "<server><address>10.0.0.1</address></server>";
+
+    expect_valid_ip("10.0.0.1");
+
+    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(cfg.batch.size, 0);
+    assert_int_equal(cfg.batch.interval, 0);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_batch_size_without_a_suffix_is_bytes(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str =
+        "<server><address>10.0.0.1</address></server>"
+        "<batch><size>2048</size></batch>";
+
+    expect_valid_ip("10.0.0.1");
+
+    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(cfg.batch.size, 2048);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_batch_zero_size_is_rejected(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    /* A zero payload can never carry an event; refuse it rather than let it
+     * read as "unset" and silently fall back to the default. */
+    const char *xml_str =
+        "<server><address>10.0.0.1</address></server>"
+        "<batch><size>0</size></batch>";
+
+    expect_valid_ip("10.0.0.1");
+    expect_string(__wrap__merror, formatted_msg,
+                  "(1235): Invalid value for element 'size': 0.");
+
+    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_batch_interval_beyond_a_day_is_rejected(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str =
+        "<server><address>10.0.0.1</address></server>"
+        "<batch><interval>2d</interval></batch>";
+
+    expect_valid_ip("10.0.0.1");
+    expect_string(__wrap__merror, formatted_msg,
+                  "(1235): Invalid value for element 'interval': 2d.");
+
+    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_batch_invalid_tag_is_rejected(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str =
+        "<server><address>10.0.0.1</address></server>"
+        "<batch><nonsense>1</nonsense></batch>";
+
+    expect_valid_ip("10.0.0.1");
+    expect_string(__wrap__merror, formatted_msg, "(1230): Invalid element in the configuration: 'nonsense'.");
+
+    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -313,7 +402,12 @@ int main(void) {
         cmocka_unit_test(test_server_tag_is_canonical_no_warning),
         cmocka_unit_test(test_manager_tag_is_deprecated_but_works),
         cmocka_unit_test(test_second_server_block_prevails_with_warning),
-        cmocka_unit_test(test_batch_block_is_accepted_and_ignored),
+        cmocka_unit_test(test_batch_size_and_interval_are_parsed),
+        cmocka_unit_test(test_batch_is_unset_when_absent),
+        cmocka_unit_test(test_batch_size_without_a_suffix_is_bytes),
+        cmocka_unit_test(test_batch_zero_size_is_rejected),
+        cmocka_unit_test(test_batch_interval_beyond_a_day_is_rejected),
+        cmocka_unit_test(test_batch_invalid_tag_is_rejected),
         cmocka_unit_test(test_time_reconnect_is_deprecated),
         cmocka_unit_test(test_max_retries_is_deprecated),
         cmocka_unit_test(test_retry_interval_is_deprecated),

--- a/src/win32/CMakeLists.txt
+++ b/src/win32/CMakeLists.txt
@@ -32,6 +32,7 @@ include_directories(
   ${SRC_FOLDER}/shared/os_xml/
   ${SRC_FOLDER}/config/include/
   ${SRC_FOLDER}/client-agent/include/
+  ${SRC_FOLDER}/client-agent/src/
   ${SRC_FOLDER}/client-agent/https_client/include/
   ${SRC_FOLDER}/logcollector/include/
   ${SRC_FOLDER}/os_execd/include/

--- a/src/win32/qa/test_win_upgrade.py
+++ b/src/win32/qa/test_win_upgrade.py
@@ -19,7 +19,7 @@ def populate_dict(dict, files_list):
 
         # It's required to normalize the name because the installation process changes it
         dict[file.name.lower().replace('-', '_').replace('c++', 'cpp').replace(
-            '_dll', '.dll').replace('wazuh_agent_eventchannel.exe', 'wazuh_agent.exe').replace('libfimdb.dll', 'fimdb.dll').replace('libagent_sync_protocol.dll', 'agent_sync_protocol.dll').replace('libagent_metadata.dll', 'agent_metadata.dll')] = file_hash
+            '_dll', '.dll').replace('wazuh_agent_eventchannel.exe', 'wazuh_agent.exe').replace('libfimdb.dll', 'fimdb.dll').replace('libagent_sync_protocol.dll', 'agent_sync_protocol.dll').replace('libagent_metadata.dll', 'agent_metadata.dll').replace('libhttps_client.dll', 'https_client.dll')] = file_hash
 
 
 def test_win_upgrade():

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -431,14 +431,22 @@ int SendMSGAction(__attribute__((unused)) int queue, const char *message, const 
 
     snprintf(tmpstr, OS_MAXSTR, "%c:%s:%s", loc, loc_buff, message);
 
-    /* Send events to the manager across the buffer */
-    if (!agt->buffer){
-        w_agentd_state_update(INCREMENT_MSG_COUNT, NULL);
-        if (send_msg(tmpstr, -1) >= 0) {
+    /* Stateless events -> HTTPS /stateless accumulator (#37835). Stateful ('s')
+     * frames keep the legacy buffer/send_msg path until #37836 wires /stateful.
+     * (Windows has no DGRAM queue; SendMSGAction is the in-process EventForward.) */
+    if (loc == 's') {
+        if (!agt->buffer){
+            w_agentd_state_update(INCREMENT_MSG_COUNT, NULL);
+            if (send_msg(tmpstr, -1) >= 0) {
+                retval = 0;
+            }
+        } else {
+            buffer_append(tmpstr, -1);
             retval = 0;
         }
     } else {
-        buffer_append(tmpstr, -1);
+        w_agentd_state_update(INCREMENT_MSG_COUNT, NULL);
+        w_https_client_submit_event(tmpstr, strlen(tmpstr));
         retval = 0;
     }
 

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -235,6 +235,16 @@ int local_start()
         minfo(DISABLED_BUFFER);
     }
 
+    /* HTTPS client: the agent's transport, unconditionally (mirrors AgentdStart
+     * on POSIX; the Windows startup path is separate). Started here, with the
+     * legacy buffer and before any producer thread, for the same reason that
+     * one is: on Windows the modules call SendMSG in-process, so an event
+     * emitted before the accumulator exists is dropped outright rather than
+     * waiting in a queue as it would on POSIX. The server address and the keys
+     * are both already validated by this point (see above). */
+    w_https_client_start();
+    atexit(w_https_client_stop);
+
     /* Start syscheck thread */
     w_create_thread(NULL,
                      0,
@@ -355,11 +365,6 @@ int local_start()
                      NULL,
                      0,
                      (LPDWORD)&threadID);
-
-    /* HTTPS client: the agent's transport, unconditionally (mirrors
-     * AgentdStart on POSIX; the Windows startup path is separate). */
-    w_https_client_start();
-    atexit(w_https_client_stop);
 
     start_agent(1);
 

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -11,6 +11,7 @@
 #ifdef WIN32
 #include "shared.h"
 #include "agentd.h"
+#include "https_client_bridge.h"
 #include "logcollector.h"
 #include "execd.h"
 #include "wmodules.h"
@@ -354,6 +355,11 @@ int local_start()
                      NULL,
                      0,
                      (LPDWORD)&threadID);
+
+    /* HTTPS client: the agent's transport, unconditionally (mirrors
+     * AgentdStart on POSIX; the Windows startup path is separate). */
+    w_https_client_start();
+    atexit(w_https_client_stop);
 
     start_agent(1);
 


### PR DESCRIPTION
Part of #37835.

Reopened after the stack reorder: stateless now bases on the integration branch so it can merge next (ahead of tasks/stateful/stats). Supersedes #37855, which GitHub auto-closed when the base swap briefly made its commits a subset of its old base.

This slice implements the HTTPS client module side of `/stateless` delivery:

- H/E framing with continuation escaping and bounded, tail-preserving batching.
- Size, age, and forced flushes; reaching the size threshold wakes the sender immediately.
- A drop-newest buffer cap with ordered occupancy-level callbacks and drop accounting.
- Adaptive 413 handling that splits multi-event batches without loss and drops only an unsplittable event rejected on its own.
- Request-size budgeting that includes the H metadata line.
- Thread-safe shared lifecycle, buffer-level, adaptive-payload, and jitter-RNG state.

It also carries the review fixes inherited through its integration base (drain bound, single-shot lifecycle, download size cap, and Windows symlink handling).

Scope: this PR is the module-side stateless transport slice, not the complete agentd integration for #37835. EventForward routing, production buffer-level handling, legacy-buffer retirement, and agent configuration wiring remain follow-up work.

Validation for the latest review update: all nine modified production/test translation units compile cleanly against the existing build configuration. The local test suites were not rerun.