### PR TITLE
Fix compilation with newer GCC: missing cstdint includes in versionMatcher headers

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectCalVer.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectCalVer.hpp
@@ -13,6 +13,7 @@
 #define _VERSION_OBJECT_CALVER_HPP
 
 #include "iVersionObjectInterface.hpp"
+#include <cstdint>
 #include <iostream>
 #include <memory>
 #include <regex>

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectDpkg.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectDpkg.hpp
@@ -16,6 +16,7 @@
 #include "stringHelper.h"
 #include "vulnerabilityScannerDefs.hpp"
 #include <cctype>
+#include <cstdint>
 #include <cstring>
 #include <iostream>
 #include <limits.h>

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectMajorMinor.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectMajorMinor.hpp
@@ -13,6 +13,7 @@
 #define _VERSION_OBJECT_MAJORMINOR_HPP
 
 #include "iVersionObjectInterface.hpp"
+#include <cstdint>
 #include <iostream>
 #include <memory>
 #include <regex>

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectPEP440.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectPEP440.hpp
@@ -16,6 +16,7 @@
 #include "stringHelper.h"
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
 #include <regex>
 #include <string>
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectRpm.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectRpm.hpp
@@ -14,6 +14,7 @@
 
 #include "iVersionObjectInterface.hpp"
 #include <cctype>
+#include <cstdint>
 #include <cstring>
 #include <iostream>
 #include <memory>

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectSemVer.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/versionObjectSemVer.hpp
@@ -13,6 +13,7 @@
 #define _VERSION_OBJECT_SEMVER_HPP
 
 #include "iVersionObjectInterface.hpp"
+#include <cstdint>
 #include <iostream>
 #include <memory>
 #include <regex>


### PR DESCRIPTION
## Description

Compilation fails on Arch Linux (GCC 16.1.1) and may fail on other recent GCC versions because `<cstdint>` is no longer transitively included through `<regex>` or `<iostream>`. Three headers in `src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/versionMatcher/` use `uint8_t`/`uint16_t`/`uint32_t` without including `<cstdint>` directly, relying on that transitive include from older libstdc++ versions.

Closes #37822

## Proposed changes

Add `#include <cstdint>` to the three affected headers:

- `versionObjectMajorMinor.hpp`
- `versionObjectCalVer.hpp`
- `versionObjectSemVer.hpp`

## Results and evidence

Reproduced on a fresh Arch Linux VM (rolling, GCC 16.1.1) and verified the fix resolves it.

Environment:
```
$ gcc --version
gcc (GCC) 16.1.1 20260625
$ cat /etc/os-release | grep BUILD_ID
BUILD_ID=rolling
```

Without the fix, `make TARGET=server -j4` fails with 82 errors starting at `versionObjectCalVer.hpp`:
```
In file included from .../versionMatcher/versionObjectCalVer.cpp:12:
.../versionMatcher/versionObjectCalVer.hpp:27:5: error: 'uint16_t' does not name a type
   27 |     uint16_t year;  ///< Year.
      |     ^~~~~~~~
.../versionMatcher/versionObjectCalVer.hpp:19:1: note: 'uint16_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
.../versionMatcher/versionObjectCalVer.hpp:28:5: error: 'uint8_t' does not name a type
.../versionMatcher/versionObjectCalVer.hpp:30:5: error: 'uint32_t' does not name a type
...
make: *** [Makefile:330: manager] Error 2
```

Full rebuild of the `server` target with the fix applied:
```
$ make TARGET=server -j4
...
Done building manager
$ echo $?
0
```
- 0 errors in the build log.
- Binaries and libraries generated correctly, including the affected module: `build/lib/libvulnerability_scanner.so`, `build/bin/wazuh-manager-modulesd`, `build/bin/wazuh-manager-authd`, `wazuh-manager-db`, `wazuh-manager-remoted`, `wazuh-manager-monitord`, `wazuh-manager-keystore`, `wazuh-keystore-testtool`, `build/engine/wazuh-engine`.

## Checklist

- [x] Compiles cleanly on GCC 16.1.1 (previously failed)
- [x] Full `server` target build succeeds after the fix
- [ ] Pending reviewer sign-off