### PR TITLE
Classify SCA policy remoteness by activation source, not file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Added source path validation when retrieving CDB list files. ([#37901](https://github.com/wazuh/wazuh/pull/37901))
 - Fixed the `aws-s3` wodle failing to parse configuration values that contain spaces, such as `discard_regex`, `discard_field`, `aws_profile`, `aws_account_alias`, `path` and `path_suffix`. ([#37929](https://github.com/wazuh/wazuh/pull/37929))
 - Fixed wazuh-db exiting the worker thread instead of closing the peer socket when an oversized message is received. ([#37850](https://github.com/wazuh/wazuh/pull/37850))
+- Improved SCA policy source validation to correctly enforce the `sca.remote_commands` restriction. ([#37953](https://github.com/wazuh/wazuh/pull/37953))
 
 ### Agent
 

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -186,7 +186,7 @@ static int read_main_elements(const OS_XML *xml, int modules,
             }
 #endif
         } else if (strcmp(node[i]->element, ossca) == 0) {
-            if ((modules & CWMODULE) && (Read_SCA(xml, node[i], d1) < 0)) {
+            if ((modules & CWMODULE) && (Read_SCA(xml, node[i], d1, d2) < 0)) {
                 goto fail;
             }
         } else if (strcmp(node[i]->element, osvulndetection) == 0) {

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -83,7 +83,7 @@ int ReadActiveResponses(XML_NODE node, void *d1, void *d2);
 int ReadActiveCommands(XML_NODE node, void *d1, void *d2);
 int Read_CReports(XML_NODE node, void *config1, void *config2);
 int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2);
-int Read_SCA(const OS_XML *xml, xml_node *node, void *d1);
+int Read_SCA(const OS_XML *xml, xml_node *node, void *d1, void *d2);
 
 /**
  * @brief Read the configuration for client section with centralized configuration

--- a/src/config/wmodules-config.c
+++ b/src/config/wmodules-config.c
@@ -157,9 +157,10 @@ int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2)
     return 0;
 }
 
-int Read_SCA(const OS_XML *xml, xml_node *node, void *d1)
+int Read_SCA(const OS_XML *xml, xml_node *node, void *d1, void *d2)
 {
     wmodule **wmodules = (wmodule**)d1;
+    int agent_cfg = d2 ? *(int *)d2 : 0;
     wmodule *cur_wmodule;
     xml_node **children = NULL;
     wmodule *cur_wmodule_exists;
@@ -202,7 +203,7 @@ int Read_SCA(const OS_XML *xml, xml_node *node, void *d1)
 
     //Policy Monitoring Module
     if (!strcmp(node->element, WM_SCA_CONTEXT.name)) {
-        if (wm_sca_read(xml,children, cur_wmodule) < 0) {
+        if (wm_sca_read(xml,children, cur_wmodule, agent_cfg) < 0) {
             OS_ClearNode(children);
             return OS_INVALID;
         }

--- a/src/config/wmodules-sca.c
+++ b/src/config/wmodules-sca.c
@@ -79,7 +79,7 @@ static short eval_bool(const char *str)
 }
 
 // Reading function
-int wm_sca_read(const OS_XML *xml,xml_node **nodes, wmodule *module)
+int wm_sca_read(const OS_XML *xml,xml_node **nodes, wmodule *module, int agent_cfg)
 {
     unsigned int i;
     wm_sca_t *sca;
@@ -104,10 +104,17 @@ int wm_sca_read(const OS_XML *xml,xml_node **nodes, wmodule *module)
     /* By default, load all every ruleset present */
 
     char ruleset_path[PATH_MAX] = {0};
+    char ruleset_realpath[PATH_MAX] = {0};
     #ifdef WIN32
     sprintf(ruleset_path, "%s\\", SECURITY_CONFIGURATION_ASSESSMENT_DIR_WIN);
+    if (!GetFullPathName(SECURITY_CONFIGURATION_ASSESSMENT_DIR_WIN, PATH_MAX, ruleset_realpath, NULL)) {
+        ruleset_realpath[0] = '\0';
+    }
     #else
     sprintf(ruleset_path, "%s/", SECURITY_CONFIGURATION_ASSESSMENT_DIR);
+    if (!realpath(SECURITY_CONFIGURATION_ASSESSMENT_DIR, ruleset_realpath)) {
+        ruleset_realpath[0] = '\0';
+    }
     #endif
 
     DIR *ruleset_dir = wopendir(ruleset_path);
@@ -305,11 +312,18 @@ int wm_sca_read(const OS_XML *xml,xml_node **nodes, wmodule *module)
                         os_calloc(1,sizeof(wm_sca_policy_t), policy);
                         policy->enabled = enabled;
                         policy->policy_id = NULL;
-                        #ifdef WIN32
-                        policy->remote = strstr(realpath_buffer, "shared\\") != NULL;
-                        #else
-                        policy->remote = strstr(realpath_buffer, "etc/shared/") != NULL;
-                        #endif
+                        {
+                            size_t ruleset_len = strlen(ruleset_realpath);
+                            #ifdef WIN32
+                            const char ruleset_sep = '\\';
+                            #else
+                            const char ruleset_sep = '/';
+                            #endif
+                            /* Only a path actually anchored at the resolved ruleset directory counts as local. */
+                            int under_ruleset = ruleset_len && !strncmp(realpath_buffer, ruleset_realpath, ruleset_len) &&
+                                                (realpath_buffer[ruleset_len] == ruleset_sep || realpath_buffer[ruleset_len] == '\0');
+                            policy->remote = agent_cfg && !under_ruleset;
+                        }
                         os_strdup(realpath_buffer, policy->policy_path);
                         sca->policies[policies_count] = policy;
                         sca->policies[policies_count + 1] = NULL;

--- a/src/unit_tests/wazuh_modules/sca/test_wm_sca.c
+++ b/src/unit_tests/wazuh_modules/sca/test_wm_sca.c
@@ -82,6 +82,8 @@ static int setup_module() {
         "</policies>\n";
     lxml = malloc(sizeof(OS_XML));
 
+    expect_string(__wrap_realpath, path, "ruleset/sca");
+    will_return(__wrap_realpath, "/var/ossec/ruleset/sca");
     will_return(__wrap_opendir, 0);
     expect_string(__wrap__mtinfo, tag, "sca");
     expect_any(__wrap__mtinfo, formatted_msg);
@@ -91,7 +93,7 @@ static int setup_module() {
     will_return(__wrap_IsFile, 0);
 
     XML_NODE nodes = string_to_xml_node(string, lxml);
-    int ret = wm_sca_read(lxml, nodes, sca_module);
+    int ret = wm_sca_read(lxml, nodes, sca_module, 0);
     OS_ClearNode(nodes);
     test_mode = 0;
 
@@ -184,6 +186,8 @@ void test_fake_tag(void **state) {
 
     expect_string(__wrap__mterror, tag, "sca");
     expect_string(__wrap__mterror, formatted_msg, "No such tag 'fake' at module 'sca'.");
+    expect_string(__wrap_realpath, path, "ruleset/sca");
+    will_return(__wrap_realpath, "/var/ossec/ruleset/sca");
     will_return(__wrap_opendir, 0);
     expect_string(__wrap__mtinfo, tag, "sca");
     expect_any(__wrap__mtinfo, formatted_msg);
@@ -192,7 +196,7 @@ void test_fake_tag(void **state) {
     expect_string(__wrap_IsFile, file, "/var/ossec/etc/shared/your_policy_file.yml");
     will_return(__wrap_IsFile, 0);
 
-    assert_int_equal(wm_sca_read(&(test->xml), test->nodes, test->module),-1);
+    assert_int_equal(wm_sca_read(&(test->xml), test->nodes, test->module, 0),-1);
 }
 
 void test_read_scheduling_monthday_configuration(void **state) {
@@ -207,6 +211,8 @@ void test_read_scheduling_monthday_configuration(void **state) {
     test_structure *test = *state;
 
     expect_string(__wrap__mwarn, formatted_msg, "Interval must be a multiple of one month. New interval value: 1M");
+    expect_string(__wrap_realpath, path, "ruleset/sca");
+    will_return(__wrap_realpath, "/var/ossec/ruleset/sca");
     will_return(__wrap_opendir, 0);
     expect_string(__wrap__mtinfo, tag, "sca");
     expect_any(__wrap__mtinfo, formatted_msg);
@@ -216,7 +222,7 @@ void test_read_scheduling_monthday_configuration(void **state) {
     will_return(__wrap_IsFile, 0);
 
     test->nodes = string_to_xml_node(string, &(test->xml));
-    assert_int_equal(wm_sca_read(&(test->xml), test->nodes, test->module),0);
+    assert_int_equal(wm_sca_read(&(test->xml), test->nodes, test->module, 0),0);
     wm_sca_t* module_data = (wm_sca_t *)test->module->data;
     assert_int_equal(module_data->scan_config.scan_day, 7);
     assert_int_equal(module_data->scan_config.interval, 1);
@@ -237,6 +243,8 @@ void test_read_scheduling_weekday_configuration(void **state) {
     test_structure *test = *state;
 
     expect_string(__wrap__mwarn, formatted_msg, "Interval must be a multiple of one week. New interval value: 1w");
+    expect_string(__wrap_realpath, path, "ruleset/sca");
+    will_return(__wrap_realpath, "/var/ossec/ruleset/sca");
     will_return(__wrap_opendir, 0);
     expect_string(__wrap__mtinfo, tag, "sca");
     expect_any(__wrap__mtinfo, formatted_msg);
@@ -246,7 +254,7 @@ void test_read_scheduling_weekday_configuration(void **state) {
     will_return(__wrap_IsFile, 0);
 
     test->nodes = string_to_xml_node(string, &(test->xml));
-    assert_int_equal(wm_sca_read(&(test->xml), test->nodes, test->module),0);
+    assert_int_equal(wm_sca_read(&(test->xml), test->nodes, test->module, 0),0);
     wm_sca_t* module_data = (wm_sca_t *)test->module->data;
     assert_int_equal(module_data->scan_config.scan_day, 0);
     assert_int_equal(module_data->scan_config.interval, 604800);
@@ -265,6 +273,8 @@ void test_read_scheduling_daytime_configuration(void **state) {
         "</policies>\n";
     test_structure *test = *state;
 
+    expect_string(__wrap_realpath, path, "ruleset/sca");
+    will_return(__wrap_realpath, "/var/ossec/ruleset/sca");
     will_return(__wrap_opendir, 0);
     expect_string(__wrap__mtinfo, tag, "sca");
     expect_any(__wrap__mtinfo, formatted_msg);
@@ -274,7 +284,7 @@ void test_read_scheduling_daytime_configuration(void **state) {
     will_return(__wrap_IsFile, 0);
 
     test->nodes = string_to_xml_node(string, &(test->xml));
-    assert_int_equal(wm_sca_read(&(test->xml), test->nodes, test->module),0);
+    assert_int_equal(wm_sca_read(&(test->xml), test->nodes, test->module, 0),0);
     wm_sca_t* module_data = (wm_sca_t *)test->module->data;
     assert_int_equal(module_data->scan_config.scan_day, 0);
     assert_int_equal(module_data->scan_config.interval, WM_DEF_INTERVAL);
@@ -293,6 +303,8 @@ void test_read_scheduling_interval_configuration(void **state) {
         "</policies>\n";
     test_structure *test = *state;
 
+    expect_string(__wrap_realpath, path, "ruleset/sca");
+    will_return(__wrap_realpath, "/var/ossec/ruleset/sca");
     will_return(__wrap_opendir, 0);
     expect_string(__wrap__mtinfo, tag, "sca");
     expect_any(__wrap__mtinfo, formatted_msg);
@@ -302,12 +314,119 @@ void test_read_scheduling_interval_configuration(void **state) {
     will_return(__wrap_IsFile, 0);
 
     test->nodes = string_to_xml_node(string, &(test->xml));
-    assert_int_equal(wm_sca_read(&(test->xml), test->nodes, test->module),0);
+    assert_int_equal(wm_sca_read(&(test->xml), test->nodes, test->module, 0),0);
     wm_sca_t* module_data = (wm_sca_t *)test->module->data;
     assert_int_equal(module_data->scan_config.scan_day, 0);
     assert_int_equal(module_data->scan_config.interval, 7200);
     assert_int_equal(module_data->scan_config.month_interval, false);
     assert_int_equal(module_data->scan_config.scan_wday, -1);
+}
+
+/* policy->remote classification tests (GHSA-qmhg-366r-jjfp) */
+
+void test_wm_sca_policy_remote_agent_conf_outside_ruleset(void **state) {
+    const char *string =
+        "<enabled>yes</enabled>\n"
+        "<scan_on_start>no</scan_on_start>\n"
+        "<policies>\n"
+        "    <policy>/var/ossec/var/incoming/evil.yml</policy>\n"
+        "</policies>\n";
+    test_structure *test = *state;
+
+    expect_string(__wrap_realpath, path, "ruleset/sca");
+    will_return(__wrap_realpath, "/var/ossec/ruleset/sca");
+    will_return(__wrap_opendir, 0);
+    expect_string(__wrap__mtinfo, tag, "sca");
+    expect_any(__wrap__mtinfo, formatted_msg);
+    expect_string(__wrap_realpath, path, "/var/ossec/var/incoming/evil.yml");
+    will_return(__wrap_realpath, "/var/ossec/var/incoming/evil.yml");
+    expect_string(__wrap_IsFile, file, "/var/ossec/var/incoming/evil.yml");
+    will_return(__wrap_IsFile, 0);
+
+    test->nodes = string_to_xml_node(string, &(test->xml));
+    /* Policy activated from agent.conf (agent_cfg = 1), pointing outside ruleset/sca: must be remote */
+    assert_int_equal(wm_sca_read(&(test->xml), test->nodes, test->module, 1), 0);
+    wm_sca_t* module_data = (wm_sca_t *)test->module->data;
+    assert_int_equal(module_data->policies[0]->remote, 1);
+}
+
+void test_wm_sca_policy_remote_agent_conf_path_contains_ruleset_substring(void **state) {
+    const char *string =
+        "<enabled>yes</enabled>\n"
+        "<scan_on_start>no</scan_on_start>\n"
+        "<policies>\n"
+        "    <policy>/root/ruleset/sca/cis_ubuntu24-04.yml</policy>\n"
+        "</policies>\n";
+    test_structure *test = *state;
+
+    expect_string(__wrap_realpath, path, "ruleset/sca");
+    will_return(__wrap_realpath, "/var/ossec/ruleset/sca");
+    will_return(__wrap_opendir, 0);
+    expect_string(__wrap__mtinfo, tag, "sca");
+    expect_any(__wrap__mtinfo, formatted_msg);
+    expect_string(__wrap_realpath, path, "/root/ruleset/sca/cis_ubuntu24-04.yml");
+    will_return(__wrap_realpath, "/root/ruleset/sca/cis_ubuntu24-04.yml");
+    expect_string(__wrap_IsFile, file, "/root/ruleset/sca/cis_ubuntu24-04.yml");
+    will_return(__wrap_IsFile, 0);
+
+    test->nodes = string_to_xml_node(string, &(test->xml));
+    /* Path contains the "ruleset/sca" substring but is NOT under the actual resolved
+     * ruleset directory ("/var/ossec/ruleset/sca"): must still be remote. */
+    assert_int_equal(wm_sca_read(&(test->xml), test->nodes, test->module, 1), 0);
+    wm_sca_t* module_data = (wm_sca_t *)test->module->data;
+    assert_int_equal(module_data->policies[0]->remote, 1);
+}
+
+void test_wm_sca_policy_local_agent_conf_inside_ruleset(void **state) {
+    const char *string =
+        "<enabled>yes</enabled>\n"
+        "<scan_on_start>no</scan_on_start>\n"
+        "<policies>\n"
+        "    <policy>/var/ossec/ruleset/sca/my_policy.yml</policy>\n"
+        "</policies>\n";
+    test_structure *test = *state;
+
+    expect_string(__wrap_realpath, path, "ruleset/sca");
+    will_return(__wrap_realpath, "/var/ossec/ruleset/sca");
+    will_return(__wrap_opendir, 0);
+    expect_string(__wrap__mtinfo, tag, "sca");
+    expect_any(__wrap__mtinfo, formatted_msg);
+    expect_string(__wrap_realpath, path, "/var/ossec/ruleset/sca/my_policy.yml");
+    will_return(__wrap_realpath, "/var/ossec/ruleset/sca/my_policy.yml");
+    expect_string(__wrap_IsFile, file, "/var/ossec/ruleset/sca/my_policy.yml");
+    will_return(__wrap_IsFile, 0);
+
+    test->nodes = string_to_xml_node(string, &(test->xml));
+    /* Policy activated from agent.conf (agent_cfg = 1), but inside ruleset/sca: must stay local */
+    assert_int_equal(wm_sca_read(&(test->xml), test->nodes, test->module, 1), 0);
+    wm_sca_t* module_data = (wm_sca_t *)test->module->data;
+    assert_int_equal(module_data->policies[0]->remote, 0);
+}
+
+void test_wm_sca_policy_local_ossec_conf_outside_ruleset(void **state) {
+    const char *string =
+        "<enabled>yes</enabled>\n"
+        "<scan_on_start>no</scan_on_start>\n"
+        "<policies>\n"
+        "    <policy>/var/ossec/etc/shared/your_policy_file.yml</policy>\n"
+        "</policies>\n";
+    test_structure *test = *state;
+
+    expect_string(__wrap_realpath, path, "ruleset/sca");
+    will_return(__wrap_realpath, "/var/ossec/ruleset/sca");
+    will_return(__wrap_opendir, 0);
+    expect_string(__wrap__mtinfo, tag, "sca");
+    expect_any(__wrap__mtinfo, formatted_msg);
+    expect_string(__wrap_realpath, path, "/var/ossec/etc/shared/your_policy_file.yml");
+    will_return(__wrap_realpath, "/var/ossec/etc/shared/your_policy_file.yml");
+    expect_string(__wrap_IsFile, file, "/var/ossec/etc/shared/your_policy_file.yml");
+    will_return(__wrap_IsFile, 0);
+
+    test->nodes = string_to_xml_node(string, &(test->xml));
+    /* Policy activated from local ossec.conf (agent_cfg = 0), outside ruleset/sca: must stay local */
+    assert_int_equal(wm_sca_read(&(test->xml), test->nodes, test->module, 0), 0);
+    wm_sca_t* module_data = (wm_sca_t *)test->module->data;
+    assert_int_equal(module_data->policies[0]->remote, 0);
 }
 
 /* wm_sort_variables tests */
@@ -786,6 +905,10 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_read_scheduling_weekday_configuration, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_read_scheduling_daytime_configuration, setup_test_read, teardown_test_read),
         cmocka_unit_test_setup_teardown(test_read_scheduling_interval_configuration, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_wm_sca_policy_remote_agent_conf_outside_ruleset, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_wm_sca_policy_remote_agent_conf_path_contains_ruleset_substring, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_wm_sca_policy_local_agent_conf_inside_ruleset, setup_test_read, teardown_test_read),
+        cmocka_unit_test_setup_teardown(test_wm_sca_policy_local_ossec_conf_outside_ruleset, setup_test_read, teardown_test_read),
         cmocka_unit_test(test_wm_sort_variables_null),
         cmocka_unit_test(test_wm_sort_variables_duplicated),
         cmocka_unit_test(test_wm_sort_variables),

--- a/src/wazuh_modules/wm_sca.h
+++ b/src/wazuh_modules/wm_sca.h
@@ -66,7 +66,7 @@ typedef struct cis_db_hash_info_t {
 extern const wm_context WM_SCA_CONTEXT;
 
 // Read configuration and return a module (if enabled) or NULL (if disabled)
-int wm_sca_read(const OS_XML *xml,xml_node **nodes, wmodule *module);
+int wm_sca_read(const OS_XML *xml,xml_node **nodes, wmodule *module, int agent_cfg);
 char *wm_sca_hash_integrity_file(const char *file);
 char **wm_sort_variables(const cJSON * const variables);
 #ifdef WIN32


### PR DESCRIPTION
## Description
`sca.remote_commands=0` was meant to stop the manager from running arbitrary commands on agents via SCA `c:` checks, but `policy->remote` was computed only from whether the resolved policy path contained `etc/shared/`. A policy referenced from the manager's shared `agent.conf` but pointing at a file outside `etc/shared/` (e.g. one dropped unsigned into `var/incoming/` via the agent-upgrade `open`/`write`/`close` commands) was misclassified as local, so its command checks ran as root regardless of `sca.remote_commands` (GHSA-qmhg-366r-jjfp). The fix tracks whether the `<policy>` entry was read from `agent.conf` (mirroring the existing `wm_command`/`agent_cfg` pattern) and only treats it as remote when it was configured that way **and** resolves outside the pre-installed `ruleset/sca/` directory.

## Proposed Changes
- `src/config/config.c`, `src/config/config.h`, `src/config/wmodules-config.c`: the SCA module is now told whether it is being configured from the agent's own local settings or from configuration pushed by the manager — the same information already passed to other modules (e.g. the `command` wodle), just wired up for SCA too.
- `src/wazuh_modules/wm_sca.h`, `src/config/wmodules-sca.c`: a policy is now treated as "remote" (subject to `sca.remote_commands`) only when it was configured by the manager **and** its file does not genuinely live inside the agent's built-in policy directory (`ruleset/sca/`). That directory is resolved to its real path and compared properly, instead of just checking whether a piece of text appears somewhere in the file path — which is what allowed the bypass.
- `src/unit_tests/wazuh_modules/sca/test_wm_sca.c`: added tests covering these classification scenarios (local vs. manager-pushed, built-in policy vs. other locations, and a decoy path crafted to look like the built-in directory).

### Results and Evidence
Manual functional testing on a live agent, on both Linux and Windows, with `sca.remote_commands=0` (default). Full logs in `tests.md`. A policy is blocked when the agent logs `WARNING: Ignoring check for policy '...'. The internal option 'sca.remote_commands' is disabled.`; otherwise its checks run.

**Linux:**

| Policy path | Activated from | Result |
|---|---|---|
| `/var/ossec/ruleset/sca/cis_ubuntu24-04.yml` (default install path) | auto-discovered | Runs (local) |
| `/root/ruleset/sca/cis_ubuntu24-04.yml` | `ossec.conf` | Runs (local) |
| `/var/ossec/tmp/cis_ubuntu24-04.yml` | `agent.conf` | Blocked (remote) |
| `/var/ossec/etc/shared/cis_ubuntu24-04.yml` | `agent.conf` | Blocked (remote) |
| `/root/ruleset/sca/cis_ubuntu24-04.yml` (contains the `ruleset/sca` substring, not the real install path) | `agent.conf` | Blocked (remote) |

**Windows:**

| Policy path | Activated from | Result |
|---|---|---|
| `C:\Program Files (x86)\ossec-agent\ruleset\sca\cis_win11_enterprise.yml` (default install path) | auto-discovered | Runs (local) |
| `C:\Program Files (x86)\ossec-agent\tmp\cis_win11_enterprise.yml` | `ossec.conf` | Runs (local) |
| `C:\Program Files (x86)\ossec-agent\tmp\cis_win11_enterprise.yml` | `agent.conf` | Blocked (remote) |
| `C:\Program Files (x86)\ossec-agent\shared\cis_win11_enterprise.yml` | `agent.conf` | Blocked (remote) |
| `D:\Test\ruleset\sca\cis_win11_enterprise.yml` (contains the `ruleset\sca` substring, not the real install path) | `agent.conf` | Blocked (remote) |

This confirms, on both platforms: policies under the real installed ruleset directory always run regardless of activation source; any other policy configured locally in `ossec.conf` still runs (no regression for local admin use); and any other policy activated remotely from `agent.conf` — including one crafted to merely contain the `ruleset/sca` substring — is correctly blocked.

Additionally:
- Full manual trace of the changed code paths against the triage report (`triage-report.md`).
- Confirmed the `d2`/`agent_cfg` plumbing added to `Read_SCA()`/`wm_sca_read()` is structurally identical to the existing, already-shipping `Read_WModule()` → `wm_command_read()` → `command->agent_cfg` path used by the `command` wodle (`src/config/wmodules-config.c`, `src/wazuh_modules/wm_command.c:59`).
- Grepped every call site of `wm_sca_read()` and `Read_SCA()` to confirm all were updated consistently.
- The vendored third-party build dependencies (`cJSON`, OpenSSL, etc. under `src/external/`) are not checked out in this environment and there is no network access to fetch them, so the added unit test suite itself could not be compiled and run here; the table above is direct evidence from a live agent instead.

### Artifacts Affected
`wazuh-modulesd` (agent and manager builds) — SCA module configuration parsing. `wazuh-agent.exe` on Windows.

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
`src/unit_tests/wazuh_modules/sca/test_wm_sca.c`:
- `test_wm_sca_policy_remote_agent_conf_outside_ruleset`
- `test_wm_sca_policy_remote_agent_conf_path_contains_ruleset_substring`
- `test_wm_sca_policy_local_agent_conf_inside_ruleset`
- `test_wm_sca_policy_local_ossec_conf_outside_ruleset`

## Credits
Thanks to @YuvalMil for raising this issue to our attention.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
