### PR TITLE
Cap engine unit-test build parallelism to prevent OOM

### DIFF
--- a/.github/actions/legacy_unit_tests.sh
+++ b/.github/actions/legacy_unit_tests.sh
@@ -14,7 +14,12 @@ build_wazuh_test_flags() {
     echo "Building Wazuh for target: $target"
     cd "$GITHUB_WORKSPACE"
     make deps -C src TARGET=${target} -j$(nproc)
-    make -C src TARGET=${target} TEST=1 -j$(nproc)
+    # Building the engine unit tests at -j$(nproc) runs many heavy compiles and links at
+    # once; their combined peak memory exhausts the runner and the OOM killer aborts the
+    # build (ld or cc1plus terminated with SIGKILL). Halve the job count to keep the peak
+    # in bounds while still using half the cores.
+    local jobs=$(( $(nproc) / 2 )); [ "$jobs" -lt 1 ] && jobs=1
+    make -C src TARGET=${target} TEST=1 -j"$jobs"
 }
 
 build_wazuh_unit_tests() {

--- a/.github/workflows/5_testunit_linux-win.yml
+++ b/.github/workflows/5_testunit_linux-win.yml
@@ -34,7 +34,9 @@ jobs:
           matrix:
               target: [agent, winagent, manager]
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
-    timeout-minutes: 90
+    # Halving the build parallelism to avoid OOM (see legacy_unit_tests.sh) roughly doubles the
+    # engine unit-test compile phase, which alone approaches the old 90-minute cap.
+    timeout-minutes: 130
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v5

--- a/.github/workflows/5_testunit_linux-win.yml
+++ b/.github/workflows/5_testunit_linux-win.yml
@@ -8,6 +8,7 @@ on:
         - ".github/workflows/5_testunit_linux-win.yml"
         - ".github/actions/build_test_flags/**"
         - ".github/actions/install_build_deps/**"
+        - ".github/actions/legacy_unit_tests.sh"
         - ".github/actions/legacy_unit_tests_build/**"
         - ".github/actions/legacy_unit_tests_run/**"
         - ".github/actions/reinstall_cmake/**"


### PR DESCRIPTION
## Description

Closes #37954

The `5.X - Wazuh - Legacy Unit tests` workflow (job `Unit-Tests (manager)`) fails intermittently during the "Build wazuh" step. The build runs `make -C src TARGET=manager TEST=1 -j$(nproc)`; with `TEST=1` the engine unit-test binaries are built, and at full `-j$(nproc)` many heavy engine translation units compile and link at the same time. Their combined peak memory exhausts the runner and the OOM killer aborts the build. It shows up either as a linker kill:

```
[100%] Linking CXX executable builder_utest
collect2: fatal error: ld terminated with signal 9 [Killed]
```

or a compiler kill:

```
c++: fatal error: Killed signal terminated program cc1plus
  ... engine/source/api/tester/.../handlers_test.cpp.o
```

Whether the peaks overlap depends on scheduling, hence the intermittency.

## Proposed Changes

`.github/actions/legacy_unit_tests.sh`: halve the job count for the engine unit-test build (`-j$(($(nproc)/2))`, floored at 1). Fewer concurrent heavy compiles/links keep the peak memory in bounds while still using half the cores. This covers both the linker and compiler OOM (unlike a linker-only tweak).

Also add `.github/actions/legacy_unit_tests.sh` to the workflow's trigger paths: the workflow watched the `build_test_flags`/`legacy_unit_tests_build`/`legacy_unit_tests_run` actions but not the shared script all three source, so changes to it did not run the workflow.

The change is confined to the CI build script; it does not touch product code and does not change any build output.

### Results and Evidence

Validated by running the `5.X - Wazuh - Legacy Unit tests` workflow (matrix `agent`/`winagent`/`manager`) manually on this branch (`workflow_dispatch`). The `manager` job — where the OOM occurred — builds and passes:

| Run | Result | manager job |
|---|---|---|
| [30355850908](https://github.com/wazuh/wazuh/actions/runs/30355850908) | success | success (~92 min) |
| [30355852785](https://github.com/wazuh/wazuh/actions/runs/30355852785) | success | success (~92 min) |
| [30355854523](https://github.com/wazuh/wazuh/actions/runs/30355854523) | success | success (~96 min) |
| [30355856255](https://github.com/wazuh/wazuh/actions/runs/30355856255) | success | success (~86 min) |
| [30355858949](https://github.com/wazuh/wazuh/actions/runs/30355858949) | success | success (~83 min) |
| [30355861067](https://github.com/wazuh/wazuh/actions/runs/30355861067) | success | success (~96 min) |

6/6 manual `workflow_dispatch` runs green: the `manager` job builds the engine unit tests without OOM and completes within the raised timeout.

### Artifacts Affected

None. CI build-script change only.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None. Stabilizes the existing legacy unit test build.

## Review Checklist
- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)

