### PR TITLE
Fix cross-DSO ABI mismatch in LogFn visibility causing inventory_sync_testtool SIGSEGV

### DIFF
--- a/src/shared_modules/utils/loggerHelper.h
+++ b/src/shared_modules/utils/loggerHelper.h
@@ -279,7 +279,13 @@ namespace Log
     };
     // Pre-bound log wrapper. Holds a tag string and dispatches through GLOBAL_LOG_FUNCTION.
     // Use via LOGFN_* macros so that source location is captured at the call site.
-    struct LogFn
+    //
+    // The type keeps default visibility even though the surrounding block is hidden: LogFn is
+    // embedded as a member (m_logFn) in default-visibility classes (TRocksDBWrapper, dispatchers,
+    // ...) that are ODR-merged across shared objects. A hidden member type in a visible, merged
+    // class is an ODR/ABI mismatch that corrupts m_tag. The dispatch methods below stay hidden so
+    // each DSO still reads its own GLOBAL_LOG_FUNCTION (see the block comment above).
+    struct __attribute__((visibility("default"))) LogFn
     {
         std::string m_tag;
 
@@ -315,7 +321,7 @@ namespace Log
             return m_tag.c_str();
         }
 
-        void info(SourceFile src, const char* fmt, ...) const
+        __attribute__((visibility("hidden"))) void info(SourceFile src, const char* fmt, ...) const
         {
             if (GLOBAL_LOG_FUNCTION)
             {
@@ -326,7 +332,7 @@ namespace Log
             }
         }
 
-        void warn(SourceFile src, const char* fmt, ...) const
+        __attribute__((visibility("hidden"))) void warn(SourceFile src, const char* fmt, ...) const
         {
             if (GLOBAL_LOG_FUNCTION)
             {
@@ -337,7 +343,7 @@ namespace Log
             }
         }
 
-        void debug1(SourceFile src, const char* fmt, ...) const
+        __attribute__((visibility("hidden"))) void debug1(SourceFile src, const char* fmt, ...) const
         {
             if (GLOBAL_LOG_FUNCTION)
             {
@@ -348,7 +354,7 @@ namespace Log
             }
         }
 
-        void debug2(SourceFile src, const char* fmt, ...) const
+        __attribute__((visibility("hidden"))) void debug2(SourceFile src, const char* fmt, ...) const
         {
             if (GLOBAL_LOG_FUNCTION)
             {
@@ -359,7 +365,7 @@ namespace Log
             }
         }
 
-        void error(SourceFile src, const char* fmt, ...) const
+        __attribute__((visibility("hidden"))) void error(SourceFile src, const char* fmt, ...) const
         {
             if (GLOBAL_LOG_FUNCTION)
             {


### PR DESCRIPTION
## Description

The `5.X - Vulnerability Scanner - Integration tests` job (`vulnerability-scanner-integration`, `test_efficacy_log.py`) fails on `5.0.0-https`: `inventory_sync_testtool` segfaults during module initialization, right after the first log line, so every expected log line is reported missing (11/12 cases fail, all with `Process exit code: -11`).

This is a regression introduced by the logger visibility change in #37821 (HTTPS base server). It is confined to `5.0.0-https`; mainline `5.0.0` is unaffected.

### Root cause

`loggerHelper.h` wraps the whole `Log` namespace, including the `LogFn` **type**, in `#pragma GCC visibility push(hidden)`. `LogFn` is embedded as a member (`m_logFn`) in default-visibility classes that are ODR-merged across shared objects: `TRocksDBWrapper`, `threadEventDispatcher`, `asyncValueDispatcher`, `rocksDBQueue`/`rocksDBQueueCF`, the indexer connector impls, and the inventory_sync `agentSession`/`facade`/`responseDispatcher`.

A hidden member type inside a visible, cross-DSO-merged class is an ABI mismatch: the class is emitted once for all DSOs, but the operations on its `LogFn m_logFn` member (the `std::string m_tag`) are not, so `m_tag` gets corrupted. The `tag` pointer passed to the log callback then dangles, and the consumer dereferences it. The build already flags this:

```
rocksDBWrapper.hpp:72: warning: 'Utils::TRocksDBWrapper<>' declared with greater
visibility than the type of its field 'm_logFn' [-Wattributes]
```

Backtrace of the crash (reproduced locally on the merge commit, `-g -O0`):

```
InventorySync::start()
  -> InventorySyncFacadeImpl<...>::start()
    -> std::function::operator()            (the log callback)
      -> testtool log lambda  main.cpp:1027  ->  strcmp(tag, WM_VULNSCAN_LOGTAG)
        -> __strcmp_avx2  ->  SIGSEGV        (tag is dangling; message is intact)
```

## Proposed Changes

`src/shared_modules/utils/loggerHelper.h`:
- Give `LogFn` **default** visibility (`struct __attribute__((visibility("default"))) LogFn`) so the type is consistent everywhere it is embedded as a member across DSOs. This removes the ABI mismatch.
- Keep only its dispatch methods (`info`/`warn`/`debug1`/`debug2`/`error`) `hidden`, since those are the members that read `GLOBAL_LOG_FUNCTION`. Each DSO keeps its own copy, so the per-DSO log-function isolation the `#pragma` was added for is preserved.

Everything else (the state, `isLevelEnabled`, `currentModuleLogFn`, `Logger`, ...) stays as-is.

### Results and Evidence

Reproduced and verified locally (Ubuntu 24.04, prebuilt deps DEPS_VERSION 99-37702, `inventory_sync_testtool` built from this branch's tree).

Before the change: `inventory_sync_testtool <input> --config <config>` → SIGSEGV right after `[IS] Configuration`, and the build emits the `-Wattributes` warning on `m_logFn`.

After the change:
- The `-Wattributes` warning is gone (0 occurrences across the build).
- The tool runs to completion:
  ```
  [IS] Stopping InventorySync module
  [INFO] Test completed successfully!
  EXIT=0
  ```
- Per-DSO log routing preserved, verified at the symbol level: the dispatch methods are local (not exported), while the type is now a normal default-visibility symbol:
  ```
  $ nm -CD libinventory_sync.so | grep 'LogFn::info'      # exported? -> none
  $ nm -C  libinventory_sync.so | grep 'LogFn::info'
  00000000000868f0 t Log::LogFn::info(Log::SourceFile, char const*, ...) const   # 't' = local/hidden, per-DSO
  $ nm -CD libinventory_sync.so | grep 'LogFn'
  ... W Log::LogFn::~LogFn() ...  W Log::LogFn::compose(...)                       # type exported, consistent across DSOs
  ```

### Artifacts Affected

None beyond the logging helper header. The change only adjusts symbol visibility; generated code behaviour is unchanged in the single-log-function case used in production.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None. Restores the existing `vulnerability-scanner-integration` efficacy tests.

## Review Checklist
- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)  <!-- pending: link to the HTTPS-server issue/epic per team policy -->
- [x] Correct labels applied (e.g., `no-changelog`)
