### PR TITLE
Fix WM_MAX_WAITunit comment modified (milliseconds -> microseconds)

### DIFF
--- a/src/wazuh_modules/include/wmodules.h
+++ b/src/wazuh_modules/include/wmodules.h
@@ -23,7 +23,7 @@
 #define WM_BUFFER_MAX   1024                        // Max. static buffer size.
 #define WM_BUFFER_MIN   1024                        // Starting JSON buffer length.
 #define WM_MAX_ATTEMPTS 3                           // Max. number of attempts.
-#define WM_MAX_WAIT     500                           // Max. wait between attempts in milliseconds.
+#define WM_MAX_WAIT     500                         // Max. wait between attempts in microseconds.
 #define WM_IO_WRITE     0
 #define WM_IO_READ      1
 #define WM_ERROR_TIMEOUT 1                          // Error code for timeout.


### PR DESCRIPTION

## Description

The tempting fix looks like: convert WM_MAX_WAIT to milliseconds properly (e.g. usleep(retry * WM_MAX_WAIT * 1000)), so the backoff actually waits 500ms/1s/1.5s as originally documented. We deliberately did not do that, because it introduces a real regression risk on Windows:

modulesSync() is reached via wmcom_send(), which behaves very differently per platform:
Linux/macOS: wmcom_send() just opens a Unix domain socket to wazuh-modulesd (a separate process) and returns immediately. The actual retry loop runs on a dedicated thread inside that other process, completely decoupled from the agent's manager-communication path.
Windows: there is no separate wazuh-modulesd process — everything runs in one process, in threads. wmcom_send() calls wmcom_dispatch() → modulesSync() directly, inline, on the same thread that reads incoming messages from the manager (client-agent/receiver.c).
Correcting the unit conversion would make that thread block for up to ~3 seconds (worst case: 3 failed attempts × real ms/s sleeps) every time a sync message hits this retry path on Windows. During that window the agent would stop reading ACKs, keepalives, and config updates from the manager — i.e. it could appear unresponsive/disconnected.
Additionally, usleep() has a POSIX limit of 1,000,000 microseconds; a correctly-converted third attempt (3 * 500ms = 1500ms = 1,500,000µs) would exceed it, requiring a different sleep primitive anyway.
Even with correct timing, the retry loop itself doesn't distinguish why a sync attempt failed (module not yet initialized vs. module not configured at all vs. a genuinely invalid payload) — only the first case can plausibly benefit from waiting, so a longer sleep wouldn't reliably fix the race it's meant to address, while still carrying the Windows blocking risk.


### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected
N-A


### Configuration Changes
N-A

### Tests Introduced
N-A

## Review Checklist


- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
