### PR TITLE
Fix Windows agent Event-handle leak from per-cycle COM init in syscollector hotfixes collector

### DIFF
--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -976,16 +976,78 @@ void SysInfo::getPackages(std::function<void(nlohmann::json&)> callback) const
     ModernFactoryPackagesCreator::getPackages(searchPaths, callback);
 }
 
+namespace
+{
+    /// @brief RAII per-thread COM initializer for the syscollector hotfixes collector.
+    ///
+    /// getHotfixes() runs on syscollector's single long-lived scan thread, so COM is
+    /// initialized once per thread (issue #37655) instead of on every scan cycle: a
+    /// per-cycle CoInitializeEx/CoUninitialize churns the COM/RPC infrastructure (notably
+    /// the Windows Update Agent) and leaks ~1 anonymous Event handle per cycle. The
+    /// destructor runs when the thread exits (thread_local storage), balancing the
+    /// CoInitializeEx we own.
+    class ThreadComContext final
+    {
+        public:
+            ThreadComContext() = default;
+            ThreadComContext(const ThreadComContext&) = delete;
+            ThreadComContext& operator=(const ThreadComContext&) = delete;
+
+            /// @brief Ensures COM is usable on this thread; retries on transient failure.
+            /// @return true when COM can be used for the hotfix queries.
+            bool ensureInitialized()
+            {
+                if (!m_usable)
+                {
+                    const HRESULT hres = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+
+                    if (SUCCEEDED(hres))
+                    {
+                        // We added the reference, so we must balance it on thread exit.
+                        m_usable = true;
+                        m_ownsInit = true;
+                    }
+                    else if (hres == RPC_E_CHANGED_MODE)
+                    {
+                        // COM is already initialized on this thread in another apartment
+                        // model; it is still usable, but we did not add a reference, so we
+                        // must not call CoUninitialize.
+                        m_usable = true;
+                    }
+
+                    // Any other failure leaves m_usable false so the next cycle retries.
+                }
+
+                return m_usable;
+            }
+
+            ~ThreadComContext()
+            {
+                if (m_ownsInit)
+                {
+                    CoUninitialize();
+                }
+            }
+
+        private:
+            bool m_usable {false};
+            bool m_ownsInit {false};
+    };
+} // namespace
+
 nlohmann::json SysInfo::getHotfixes() const
 {
     std::set<std::string> hotfixes;
     std::ostringstream oss;
     ComHelper comHelper;
 
-    // Initialize COM
-    HRESULT hres = CoInitializeEx(0, COINIT_MULTITHREADED);
+    // Initialize COM once per thread instead of per scan cycle (issue #37655). The RAII
+    // guard initializes COM once, retries on transient failure, tolerates COM already
+    // being initialized in another apartment, and balances CoUninitialize when the
+    // collection thread exits.
+    static thread_local ThreadComContext comContext;
 
-    if (SUCCEEDED(hres))
+    if (comContext.ensureInitialized())
     {
         try
         {
@@ -997,7 +1059,6 @@ nlohmann::json SysInfo::getHotfixes() const
             // Ignore the error. The OS does not support WMI API.
         }
 
-
         try
         {
             // Query hotfixes using Windows Update API
@@ -1007,9 +1068,6 @@ nlohmann::json SysInfo::getHotfixes() const
         {
             // Ignore the error. The OS does not support WUA API.
         }
-
-        // Uninitialize COM
-        CoUninitialize();
     }
 
     PackageWindowsHelper::getHotFixFromReg(HKEY_LOCAL_MACHINE, PackageWindowsHelper::WIN_REG_HOTFIX, hotfixes);

--- a/src/data_provider/src/utilsWrapperWin.cpp
+++ b/src/data_provider/src/utilsWrapperWin.cpp
@@ -140,7 +140,7 @@ void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper)
     {
         if (pLoc) pLoc->Release();
 
-        if (pLoc) pSvc->Release();
+        if (pSvc) pSvc->Release();
 
         oss << "WMI: query error. Code: " << std::hex << hres;
         throw std::runtime_error(oss.str());
@@ -178,7 +178,13 @@ void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper)
 
     pSvc->Release();
     pLoc->Release();
-    pEnumerator->Release();
+
+    // ExecuteWmiQuery may report success yet leave a NULL enumerator; guard the release
+    // to avoid dereferencing NULL on the syscollector scan thread.
+    if (pEnumerator)
+    {
+        pEnumerator->Release();
+    }
 }
 
 ProcessCmdLine parseProcessCommandLine(const std::wstring& fullCmdLineW)


### PR DESCRIPTION
## Description

The Windows agent (`wazuh-agent.exe`) leaked OS **handles** over long soak/performance runs while memory (RSS/VMS) stayed flat — a handle leak, not a memory leak (issue #37655).

The leaking objects are **anonymous Windows `Event` kernel objects**. Root cause: `SysInfo::getHotfixes()` (syscollector's Windows hotfixes collector) called `CoInitializeEx` / `CoUninitialize` on **every scan cycle**. Because the Windows agent is built with the mingw `-posix` (winpthreads) runtime, this per-cycle COM/RPC lifecycle churn — driven notably by the Windows Update Agent used in that path — leaks roughly **one anonymous Event handle per scan cycle**. At the performance `interval` of 1 minute this matches the observed ~+60 handles/h growth.

The cause was reproduced on Windows 11, isolated by module bisection (only syscollector leaks; FIM and SCA are flat even though SCA shares the same dbsync/sync stack), and **confirmed by A/B**: toggling `<hotfixes>` off flattens the leak, and the fix drops the slope from **+59 handles/h to flat**.

## Proposed Changes

- **`src/data_provider/src/sysInfoWin.cpp` — `getHotfixes()`**: initialize COM **once per thread** (via a new RAII `ThreadComContext` `thread_local` guard) instead of on every scan cycle. The guard initializes COM on first use and retries on transient failure, tolerates COM already being initialized in another apartment (`RPC_E_CHANGED_MODE`), and balances `CoUninitialize` in its destructor when the long-lived syscollector scan thread exits.
- **`src/data_provider/src/utilsWrapperWin.cpp` — `QueryWMIHotFixes()`**: fix a wrong-pointer guard on the query-failure path (`if (pLoc) pSvc->Release();` → `if (pSvc) ...`), and guard `pEnumerator->Release()` against a NULL enumerator returned with a success `HRESULT`.

### Results and Evidence

A/B on the reproducing Windows 11 VM (syscollector-only config, saturator load, agent connected and syscollector confirmed evaluating), Event-handle slope:

| Build / config | Event slope |
|---|---|
| original, `<hotfixes>` on | **+59 /h (leak)** |
| original, `<hotfixes>` off | +6 /h (flat) |
| **fixed package, `<hotfixes>` on** | **+9 /h (flat)** |

<!-- paste VM evidence here: handle-count graph/CSV over the soak window for the fixed build, and the ossec.log lines showing syscollector evaluating while connected -->

<img width="1323" height="790" alt="image" src="https://github.com/user-attachments/assets/5998d08e-a295-492f-b0a4-6889108f9692" />

```sql
2026/07/24 10:15:11 wazuh-agent: INFO: (4102): Connected to the server ([192.168.56.30]:1514/tcp).
2026/07/24 10:15:21 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/07/24 10:15:24 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2026/07/24 10:16:24 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/07/24 10:16:26 wazuh-modulesd:syscollector: INFO: Evaluation finished.
   ... (syscollector evaluates once per minute for the whole 20-min window) ...
2026/07/24 10:38:52 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/07/24 10:38:53 wazuh-modulesd:syscollector: INFO: Evaluation finished.
2026/07/24 10:39:53 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/07/24 10:39:54 wazuh-modulesd:syscollector: INFO: Evaluation finished.
```

### Artifacts Affected

Windows agent syscollector inventory collection (`sysinfo.dll` / `syscollector.dll`, i.e. the `wazuh-modulesd` syscollector module on Windows). No change to the hotfix data collected — only the COM lifecycle around it.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided 
- [ ] Tests cover the new functionality 
- [x] Configuration changes documented 
- [x] Developer documentation reflects the changes 
- [x] Meets requirements and/or definition of done 
- [x] No unresolved dependencies with other issues
