### PR TITLE
Avoid holding remoted key lock across blocking send

### DIFF
--- a/src/remoted/src/sendmsg.c
+++ b/src/remoted/src/sendmsg.c
@@ -116,13 +116,29 @@ int send_msg_with_key_control(const char* agent_id, const char* msg, ssize_t msg
         error = errno;
         retval = bytes_sent == msg_size ? OS_SUCCESS : OS_INVALID;
     } else if (keys.keyentries[key_id]->sock >= 0) {
-        /* TCP mode, enqueue the message in the send buffer */
-        retval = nb_queue(&netbuffer_send, keys.keyentries[key_id]->sock, crypt_msg, msg_size, keys.keyentries[key_id]->id);
+        /* TCP mode, enqueue the message in the send buffer.
+         *
+         * nb_queue() may sleep(send_timeout_to_retry) while the agent's send buffer is full
+         * (netbuffer.c). Doing that while holding key_lock_read() lets a single slow/stuck
+         * agent block the key reloader's key_lock_write(), which -- because the rwlock takes a
+         * front mutex before the write lock (rwlock_op.c) -- then blocks every other worker's
+         * key_lock_read(), stalling all message processing until remoted is restarted (#37750).
+         *
+         * The keystore only needs to be locked to resolve the socket fd. nb_queue() protects the
+         * netbuffer with its own mutex and re-checks the per-socket buffer after sleeping, so it
+         * is safe to call after releasing the key lock: if the socket is closed meanwhile, the
+         * buffer is gone and nb_queue() returns an error instead of touching a stale fd.
+         */
+        const int sock = keys.keyentries[key_id]->sock;
+        char id_snapshot[KEYSIZE + 1] = {0};
+        strncpy(id_snapshot, keys.keyentries[key_id]->id, KEYSIZE);
+
         w_mutex_unlock(&keys.keyentries[key_id]->mutex);
         if (!skip_key_lock) {
             key_unlock();
         }
-        return retval;
+
+        return nb_queue(&netbuffer_send, sock, crypt_msg, msg_size, id_snapshot);
     } else {
         w_mutex_unlock(&keys.keyentries[key_id]->mutex);
         if (!skip_key_lock) {


### PR DESCRIPTION
## Description

Closes #37750

State synchronization could stop for every agent connected to a manager. FIM, IT Hygiene, and SCA all timed out waiting for the manager to acknowledge their `Start` messages:

| Module | Synchronization started | Timeout reported | Result |
|---|---:|---:|---|
| IT Hygiene (`syscollector`) | 14:17:13 | 14:21:13 | Timed out waiting for the manager response |
| FIM (`syscheckd`) | 14:17:14 | 14:21:14 | Timed out waiting for the manager response |
| SCA | 14:17:15 | 14:21:15 | Timed out waiting for the manager response |

The manager produced no logs during these timeouts, and synchronization resumed only after `wazuh-remoted` was restarted. This places the stall in `wazuh-remoted`, before the messages reach the module that generates the acknowledgements.

## Root cause

`wazuh-remoted` uses one read/write lock to protect the agent keystore. `send_msg_with_key_control()` held its read lock while calling `nb_queue()`.

When an agent's TCP send buffer is full, `nb_queue()` waits before retrying. During that wait:

1. The sending worker keeps the keystore read lock.
2. The periodic key reload waits for the write lock.
3. New readers wait behind the pending reload.
4. Message processing stops for all agents.

This explains why several synchronization modules and agent platforms failed together, the manager stopped processing the messages, and restarting `wazuh-remoted` cleared the condition.

## Proposed changes

The TCP path in `send_msg_with_key_control()` now copies the socket descriptor and agent ID while holding the keystore lock, then releases both the agent-entry mutex and keystore read lock before calling `nb_queue()`.

The potentially blocking retry therefore no longer holds the keystore lock and cannot stop the key reload or other workers.

This does not change the send logic or network protocol. `nb_queue()` protects the network buffer with its own mutex and checks the socket buffer again after waiting. If the socket was closed meanwhile, it returns an error instead of accessing a removed buffer.

## Validation

The lock paths before and after the change were verified through code analysis.

<details><summary>Details</summary>
<p>

### Before

```mermaid
sequenceDiagram
    participant Worker
    participant Keystore
    participant Queue as TCP send queue
    participant Reload as Key reload

    Worker->>Keystore: Acquire read lock
    Worker->>Queue: Send message
    Queue-->>Worker: Send buffer is full
    Worker->>Worker: Wait before retrying
    Reload->>Keystore: Request write lock
    Note over Worker,Keystore: Read lock remains held during the wait
    Keystore-->>Reload: Write lock blocked
    Worker->>Keystore: Release read lock
```

### After

```mermaid
sequenceDiagram
    participant Worker
    participant Keystore
    participant Queue as TCP send queue
    participant Reload as Key reload

    Worker->>Keystore: Acquire read lock
    Worker->>Worker: Copy socket descriptor and agent ID
    Worker->>Keystore: Release read lock
    Worker->>Queue: Send message
    Queue-->>Worker: Send buffer is full
    Worker->>Worker: Wait before retrying
    Reload->>Keystore: Request write lock
    Keystore-->>Reload: Grant write lock
```

</p>
</details> 


ThreadSanitizer builds before and after the change were run for 120 seconds under concurrent key reloads and sends to a frozen agent. The test used a one-entry send buffer, a one-second send retry, repeated key-file changes, and an Active Response flood.

| Build | Peak futex-blocked threads | Result |
|---|---:|---|
| Before | 14 | Survived 120 seconds |
| After | 14 | Survived 120 seconds |

ThreadSanitizer reported no keystore data race in either run. This is consistent with a lock-hold problem rather than an unsynchronized memory access.

The test environment did not reproduce the reported generalized stall. The stall requires three conditions to hold at the same instant: an agent whose TCP send buffer stays full, the manager actively sending to that agent, and a key reload landing during that send. On a single-manager box with one idle agent there is almost no outbound traffic to keep a send buffer full, so the window never opened even when forced. The original report was itself a one-time occurrence that cleared on restart, which is consistent with a rare timing race that a small test setup cannot reproduce on demand.

Given that, the change is accepted on static analysis rather than a live before/after:

- The failure mechanism is a lock-hold, not a data race, so it is fully determined by reading the code: the read lock is provably held across `nb_queue()`'s wait, and the fix provably removes that operation from the locked region. Nothing about the mechanism depends on runtime timing that only a reproduction could reveal.
- The incident symptoms (all agents and modules failing together, manager silent, cleared only by restarting `wazuh-remoted`) match this mechanism and no other.
- ThreadSanitizer confirmed the paths are otherwise correctly synchronized, so the change does not trade a liveness fix for a new data race.
- The change is small and local, does not alter send logic or the protocol, and is safe against a socket closing during the unlocked window.


### Soak test

Following the suggestion to let the fix run for a while with a few agents, I built a clean release remoted with the patch, installed it on the manager, and left it running for 3 hours with 3 enrolled agents (Docker), sampling remoted continuously.

| Metric | Result |
|---|---|
| Runtime | 3 hours, no restart (same PID throughout) |
| Memory (RSS) | ~18-22 MB, flat, no growth |
| Peak lock-blocked threads | 14 (baseline; no lock-hold spike) |
| Sync-failure log lines | 0 |

#### Linux agents
Across all 3 agents:

- `Timed out waiting for manager response to Start message` (the reported symptom): **0 occurrences.**
- FIM synchronization finished successfully: **12 times per agent.**
- SCA synchronization: succeeded repeatedly.

The exact modules that failed in the report synchronize cleanly and repeatedly on the patched build, and the stall symptom never appeared.

The patched remoted was stable for 3 hours with 3 connected agents: no crash, no restart, no memory growth, no lock-hold spike, and no synchronization timeouts, with FIM and SCA synchronizing repeatedly. This is direct runtime evidence that the change does not regress remoted and that the synchronization path works under the fix.

#### Windows agent

The soak was repeated with a real Windows agent driving the patched manager. The fix is manager-side only (`wazuh-manager-remoted`), so no patched agent is needed: a stock nightly Windows agent was enrolled and left connected to the patched manager for ~2 hours while remoted was sampled continuously.

remoted stability (server-side, 254 samples over ~2 hours):

| Metric | Result |
|---|---|
| Runtime | ~2 hours, no restart (same PID throughout) |
| Threads | 27, constant |
| Peak lock-blocked threads | 14 (baseline; no lock-hold spike) |
| Memory (RSS) | ~18-19 MB, flat, no growth |
| Sync-failure log lines | 0 |

Windows agent (agent-side, 95 samples):

- Service running and connection status `connected`: **every sample.**
- `Timed out waiting for manager response to Start` (the reported symptom): **0 occurrences.**
- The connection remained established on 1514 with an active keepalive through the end of the run.

The patched remoted ran for ~2 hours with a Windows agent continuously connected: no crash, no restart, no memory growth, constant thread count, no lock-hold spike, and no synchronization timeouts. This is direct runtime evidence on Windows that the change does not regress remoted and does not reintroduce the stall.

> [!NOTE]
> In this lab the Windows agent's module synchronization did not complete, because its sync HTTPS client was rejected for a missing CA (`verify_mode requires a readable CA file, certificate_authorities=''`). This is an environment gap on the sync HTTPS channel, unrelated to the fix: it is an instant configuration rejection, not the 4-minute `Start`-ack timeout over remoted that characterizes this issue, and it comes from a newer agent feature that is not part of this change. FIM and SCA synchronization completion was demonstrated on the Docker Linux soak above.


> [!NOTE]
> One control-message acknowledgement path enters `send_msg_with_key_control()` while its caller already holds the keystore read lock. That outer lock can still span an `nb_queue()` wait and requires a separate restructuring. This path handles occasional keepalive acknowledgements and is outside the scope of this change.

### Artifacts Affected

- `wazuh-manager-remoted`. Manager-side only; no change to agent behavior or the wire protocol.

### Configuration Changes

- N/A

### Documentation Updates

- N/A

### Tests Introduced

- N/A


## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
