### PR TITLE
fix(sca): correct 3 permission checks in cis_ubuntu22-04.yml

### DIFF
--- a/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
+++ b/ruleset/sca/ubuntu/cis_ubuntu22-04.yml
@@ -9479,7 +9479,7 @@ checks:
           - "Credentials In Files"
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/shadow -> r:0 root \d+ shadow|0 root 0 root && r: r:640|604|600|400|500'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/shadow -> r:0 root \d+ shadow|0 root 0 root && r:640|604|600|400|500'
 
   # 7.1.6 Ensure permissions on /etc/shadow- are configured. (Automated)
   - id: 28675
@@ -9528,7 +9528,7 @@ checks:
           - "Credentials In Files"
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/shadow- -> r:0 root \d+ shadow|0 root 0 root && r: r:640|604|600|400|500'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/shadow- -> r:0 root \d+ shadow|0 root 0 root && r:640|604|600|400|500'
 
   # 7.1.7 Ensure permissions on /etc/gshadow are configured. (Automated)
   - id: 28676
@@ -9577,7 +9577,7 @@ checks:
           - "Credentials In Files"
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/gshadow -> r:0 root \d+ shadow|0 root 0 root && r: r:640|604|600|400|500'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/gshadow -> r:0 root \d+ shadow|0 root 0 root && r:640|604|600|400|500'
 
   # 7.1.8 Ensure permissions on /etc/gshadow- are configured. (Automated)
   - id: 28677
@@ -9626,7 +9626,7 @@ checks:
           - "Credentials In Files"
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/gshadow- -> r:0 root \d+ shadow|0 root 0 root && r: r:640|604|600|400|500'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/gshadow- -> r:0 root \d+ shadow|0 root 0 root && r:640|604|600|400|500'
 
   # 7.1.9 Ensure permissions on /etc/shells are configured. (Automated)
   - id: 28750
@@ -9675,7 +9675,7 @@ checks:
           - "Credentials In Files"
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/shells- -> r:0 root 0 root && r:644|640|604|600|400|500'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/shells -> r:0 root 0 root && r:644|640|604|600|400|500'
 
   # 7.1.10 Ensure permissions on /etc/security/opasswd are configured. (Automated)
   - id: 28751
@@ -9724,7 +9724,7 @@ checks:
           - "Credentials In Files"
     condition: all
     rules:
-      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/security/opasswds -> r:0 root 0 root && r:600|400|500'
+      - 'c:stat -Lc "%n %a %u %U %g %G" /etc/security/opasswd -> r:0 root 0 root && r:600|400|500'
 
   # 7.1.11 Ensure world writable files and directories are secured. (Automated) - Not Implemented
   # 7.1.12 Ensure no files or directories without an owner and a group exist. (Automated) - Not Implemented


### PR DESCRIPTION
## Description

  Three checks in `ruleset/sca/ubuntu/cis_ubuntu22-04.yml` report **Failed** on compliant Ubuntu 22.04 systems due to typos in the rule text. These are false negatives: the target files are already at their CIS-recommended state, but the rules can never match. Verified on Ubuntu 22.04.5 (Wazuh agent/SCA 4.14.6) and
  confirmed still present on `main`.

  Closes #31835 (same shadow/gshadow bug; fix already proposed by @MiguelazoDS).
  Related: #34275 (closed as "completed" on 2026-07-03 as fixed-in-PR, but the fix is not present on `main` — last commit to this file is 2026-06-24), #20281 and #20310 (the `/etc/shells` and `/etc/security/opasswd` typos, previously fixed for Ubuntu 20.04 / Debian 10, are present again in this file).

  ## Proposed Changes

  Fixed three rule typos (6 lines total):

  1. **Checks 28674–28677** (`/etc/shadow`, `/etc/shadow-`, `/etc/gshadow`, `/etc/gshadow-`): removed a spurious `r: ` token. The rules read `... && r: r:640|604|600|400|500`; the extra `r: ` makes the octal-mode match impossible, so files at the correct `640 root:shadow` always fail. Changed to `... &&
  r:640|604|600|400|500` (the same form the sibling `/etc/security/opasswd` check already uses).
  2. **Check 28750** (`/etc/shells`): the rule ran `stat` on `/etc/shells-` (trailing dash — a backup that normally does not exist) instead of `/etc/shells`.
  3. **Check 28751** (`/etc/security/opasswd`): the rule ran `stat` on `/etc/security/opasswds` (trailing `s`) instead of `/etc/security/opasswd`.

  ### Results and Evidence

  On a compliant Ubuntu 22.04.5 host, all three targets are at their CIS-recommended permissions:
  $ stat -Lc "%n %a %u %U %g %G" /etc/shadow /etc/shells /etc/security/opasswd
  /etc/shadow 640 0 root 42 shadow
  /etc/shells 644 0 root 0 root
  /etc/security/opasswd 600 0 root 0 root
  Before this change checks 28674–28677, 28750 and 28751 report **Failed**; with the corrected rules they report **Passed**. The mode alternations already list 640/644/600, confirming these values are intended to pass.

  ### Manual tests with their corresponding evidence

  This change edits SCA policy content (YAML) only; it does not touch compiled code, so the compilation/memory/engine/API suites do not apply. Validated that the file remains well-formed YAML and that the corrected rules match the `stat` output above.

  - Compilation without warnings on every supported platform
    - [ ] Linux — N/A (no source code changed)
    - [ ] Windows — N/A
    - [ ] MAC OS X — N/A
  - [ ] Log syntax and correct language review — N/A
  - Memory tests for Linux
    - [ ] Coverity — N/A
    - [ ] Valgrind — N/A
    - [ ] AddressSanitizer — N/A
  - Memory tests for Windows
    - [ ] Coverity — N/A
    - [ ] UMDH — N/A
  - Memory tests for macOS
    - [ ] Leaks — N/A
    - [ ] AddressSanitizer — N/A
  - Decoder/Rule tests _(Wazuh v4.x)_
    - [ ] Added unit testing files ".ini" — N/A (SCA policy, not ruleset decoders/rules)
    - [ ] `runtests.py` executed without errors — N/A
  - Engine _(Wazuh v5.x and above)_
    - [ ] Test run in parallel — N/A
    - [ ] ASAN for test (utest/ctest) — N/A
    - [ ] TSAN for test and wazuh-engine — N/A
  - Wazuh server API/Framework
    - [ ] Run API Integration Tests — N/A

### Artifacts Affected

  `ruleset/sca/ubuntu/cis_ubuntu22-04.yml` (SCA policy content only). No executables, packages, or default configuration files are affected.

  ### Configuration Changes

  N/A — no new parameters, no default-value changes, no backward-compatibility impact. The corrected rules evaluate the same files against the same
  already-listed octal modes.

  ### Tests Introduced

  N/A — SCA policy content fix; no unit/integration tests added.

  ## Review Checklist

  - [ ] Code changes reviewed
  - [ ] Relevant evidence provided
  - [ ] Tests cover the new functionality
  - [ ] Configuration changes documented
  - [ ] Developer documentation reflects the changes
  - [ ] Meets requirements and/or definition of done
  - [ ] No unresolved dependencies with other issues
