### PR TITLE
Fix out-of-bounds read in logpar group end-token resolution (CID 558406)

### DIFF
--- a/src/engine/source/logpar/src/logpar.cpp
+++ b/src/engine/source/logpar/src/logpar.cpp
@@ -511,7 +511,7 @@ Logpar::Hlp Logpar::buildParsers(const std::list<parser::ParserInfo>& parserInfo
                     insideTokens.splice(insideTokens.end(), ref(std::get<parser::Group>(*it), ref));
                     it = std::next(it);
                 }
-                if (std::holds_alternative<parser::Literal>(*it))
+                if (it != group.children.cend() && std::holds_alternative<parser::Literal>(*it))
                 {
                     insideTokens.emplace_back(std::get<parser::Literal>(*it).value);
                 }

--- a/src/engine/source/logpar/test/src/unit/logpar_test.cpp
+++ b/src/engine/source/logpar/test/src/unit/logpar_test.cpp
@@ -94,6 +94,7 @@ INSTANTIATE_TEST_SUITE_P(Parses,
                                            ParseExprT("lit<~>(?<~>:)|", false),
                                            ParseExprT("lit(?lit)(?lit)", false), // Must build if limit >= 2
                                            ParseExprT("lit(?(?lit)lit)", false), // Must build if limit >= 2
+                                           ParseExprT("<~>(?(?a)(?b))", false),  // Children are groups with no trailing literal
                                            ParseExprT("<~opt>?lit", false),
                                            ParseExprT("lit(?lit", false),
                                            ParseExprT("literal<text><_custom/long><~>", false),


### PR DESCRIPTION
## Description

Closes #37959.

Coverity CID 558406 (`INVALIDATE_ITERATOR`) reported an out-of-bounds read in `hlp::logpar::Logpar::buildParsers`. In the `groupEndToken` lambda, a group whose children are all groups with no trailing literal leaves the iterator at `group.children.cend()`, and the next line dereferences that past-the-end `std::list` iterator (undefined behavior) before the intended "Group must be followed by a literal" error is raised.

## Proposed Changes

- Guard the trailing-literal check in `groupEndToken` with `it != group.children.cend()`, the same bound the surrounding loop already applies, so the all-groups-no-literal case falls through to the intended `runtime_error` instead of dereferencing past the end.
- Add a unit test in the `logpar_utest` `Parses` suite covering a group whose children are groups with no trailing literal (`<~>(?(?a)(?b))`).

### Results and Evidence

Built `logpar_utest` with AddressSanitizer (`ENGINE_ENABLE_ASAN=ON`, mirroring `5_testunit_engine.yml`) and ran it under ASAN.

Without the fix, the new case aborts with an out-of-bounds read; ASAN's stack-variable map pins it to the `buildParsers` frame and the `group` variable:

```
==XXXXX==ERROR: AddressSanitizer: stack-buffer-overflow ... READ of size 8 ...
This frame has 99 object(s):
    [32, 33) 'groupEndToken' (line 494)
    ...
    [2144, 2168) 'group' (line 587) <== Memory access at offset 2168 overflows this variable
    [2208, 2232) 'endTokens' (line 588)
SUMMARY: AddressSanitizer: stack-buffer-overflow
```

With the fix, the full suite passes clean under ASAN:

```
[==========] 122 tests from 11 test suites ran.
[  PASSED  ] 122 tests.
```

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer
- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [x] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

### Artifacts Affected

- `wazuh-manager` engine (`logpar`) — no configuration, package, or schema changes.
