### PR TITLE
Initialize primitive members in parsec::Trace and base::result::Result

### DIFF
--- a/src/engine/source/base/include/base/result.hpp
+++ b/src/engine/source/base/include/base/result.hpp
@@ -18,9 +18,9 @@ class Result
 private:
     inline static const std::string EMPTY_TRACE {}; ///< Shared empty string for cases where no trace is present
 
-    Event m_payload;                    ///< The event payload
+    Event m_payload {};                 ///< The event payload
     std::optional<std::string> m_trace; ///< Optional trace message
-    bool m_success;                     ///< Status of the result, true for success, false for failure
+    bool m_success {false};             ///< Status of the result, true for success, false for failure
 
 public:
     /**

--- a/src/engine/source/parsec/interface/parsec/parsec.hpp
+++ b/src/engine/source/parsec/interface/parsec/parsec.hpp
@@ -34,8 +34,8 @@ public:
     using nestedTracesT = std::optional<std::vector<Trace>>;
 
 private:
-    bool m_success;
-    size_t m_index;
+    bool m_success {false};
+    size_t m_index {0};
     messageT m_message;
     nestedTracesT m_innerTraces;
 


### PR DESCRIPTION
## Description

Coverity reported uninitialized scalar members in the default-constructed `parsec::Trace` and `base::result::Result` engine types. `Trace() = default;` and `Result() {}` left `m_success`, `m_index` and `m_payload` indeterminate, so reading `success()`, `index()` or `payload()` on a default-constructed object was undefined behavior.

This is reachable at runtime: `Tokenizer::parser` default-constructs a `Result<Token>` and, on whitespace-only input, breaks out of its loop before ever assigning it, then reads `partial.failure()` on that uninitialized object.

Closes #37972

## Proposed Changes

- Added default member initializers `bool m_success{false}` and `size_t m_index{0}` in `parsec::Trace` (`parsec.hpp`).
- Added default member initializers `Event m_payload{}` and `bool m_success{false}` in `base::result::Result` (`result.hpp`).

No change to `Tokenizer::parser`: once the default constructors leave a valid state (`m_success == false`), the whitespace-only input path resolves deterministically through the existing error branch.

## Results and Evidence

Diff of the two files:

```diff
--- a/src/engine/source/parsec/interface/parsec/parsec.hpp
+++ b/src/engine/source/parsec/interface/parsec/parsec.hpp
@@ -34,8 +34,8 @@ public:
     using nestedTracesT = std::optional<std::vector<Trace>>;
 
 private:
-    bool m_success;
-    size_t m_index;
+    bool m_success {false};
+    size_t m_index {0};
     messageT m_message;
     nestedTracesT m_innerTraces;

--- a/src/engine/source/base/include/base/result.hpp
+++ b/src/engine/source/base/include/base/result.hpp
@@ -18,9 +18,9 @@ class Result
 private:
     inline static const std::string EMPTY_TRACE {}; ///< Shared empty string for cases where no trace is present
 
-    Event m_payload;                    ///< The event payload
+    Event m_payload {};                 ///< The event payload
     std::optional<std::string> m_trace; ///< Optional trace message
-    bool m_success;                     ///< Status of the result, true for success, false for failure
+    bool m_success {false};             ///< Status of the result, true for success, false for failure
```

Verified that every concrete instantiation of `base::result::Result<Event>` in the engine tree (`json::Json`, `base::Event`, `bool`, `int`) is default-constructible, so `Event m_payload{}` compiles at every use site.

## Checklist

- [ ] Add default member initializers in `parsec.hpp` and `result.hpp`.
- [ ] Add a unit test covering a default-constructed `Result`/`Trace` and the whitespace-only `Tokenizer::parser` path.
- [ ] Re-run Coverity to confirm CIDs 558151, 557994 and 558176 are resolved.