### PR TITLE
Reliably start workload daemons on install and shared-config reload

### DIFF
--- a/src/client-agent/src/receiver.c
+++ b/src/client-agent/src/receiver.c
@@ -263,15 +263,30 @@ int receive_msg()
                                                 minfo("Agent is reloading due to shared configuration changes.");
                                             }
                                             // The reload chain (modulesd CONTROL_SOCK -> wazuh-control
-                                            // reload -> SIGUSR1) is the normal release path; doing it
-                                            // there ensures modules don't briefly start with the new
-                                            // config and then get killed when the chain restarts them.
-                                            // Only release the gate inline if reloadAgent() reports the
-                                            // control socket is unreachable, in which case the chain
-                                            // will never fire and the gate would otherwise stay stuck.
+                                            // reload -> SIGUSR1) restarts the modules to apply the new
+                                            // config and is the normal gate-release path.
+#ifdef Darwin
+                                            // On macOS that chain runs out-of-process via the Wazuh-launcher
+                                            // (launchd anchor polling a request flag), so reloadAgent() only
+                                            // confirms the request reached modulesd, not that the reload ran
+                                            // nor that agentd was signalled to release the gate. Relying on
+                                            // it alone left blocked modules (logcollector, syscheck, ...)
+                                            // stuck in startup_gate_wait_for_ready() forever when it did not
+                                            // complete (#37565). The gate precondition (local hash ==
+                                            // manager's expected hash) already holds here, so release the
+                                            // gate directly, then request the reload to restart the modules
+                                            // best-effort (one harmless extra restart).
+                                            if (gate_would_release) {
+                                                startup_gate_refresh_from_local_hash();
+                                            }
+                                            reloadAgent();
+#else
+                                            // On Linux/Windows the chain is in-process and observable;
+                                            // release inline only if the request could not be delivered.
                                             if (!reloadAgent() && gate_would_release) {
                                                 startup_gate_refresh_from_local_hash();
                                             }
+#endif
                                         } else {
                                             startup_gate_refresh_from_local_hash();
                                             if (!config_changed) {


### PR DESCRIPTION
## Description

This PR fixes the macOS agent leaving its workload daemons (logcollector, syscheck, modulesd, execd) blocked at the 5.0 startup hash gate after a fresh install or a shared-configuration reload, so `wazuh-logcollector` never starts its ULS `log stream` and no logs are collected until a manual `wazuh-control restart`.

On macOS the reload that releases the startup gate runs out-of-process through the `Wazuh-launcher` (the launchd anchor that polls a request flag) and only releases the gate via `wazuh-control reload -> kill -USR1 agentd`. Because `reloadAgent()` returns success as soon as the request reaches modulesd — not when the reload actually runs — the gate release depends entirely on that launcher/SIGUSR1 chain completing in time. When it does not (timing/environment dependent, e.g. a remote or clustered manager), the daemons stay blocked in `startup_gate_wait_for_ready()` indefinitely. This PR releases the gate inline in agentd the moment the local `merged.mg` hash matches the manager's expected hash, removing the dependency on that chain.

**Proposed Release:** [v5.0.0]
**Issue:** wazuh/wazuh#37565
**Internal Reference:** N/A

## Proposed Changes

- Updated `src/client-agent/src/receiver.c`.
- Fixed the startup hash gate release on macOS: when its precondition (local `merged.mg` hash == manager's expected `merged_sum`) is already satisfied, release the gate inline via `startup_gate_refresh_from_local_hash()` instead of relying solely on the out-of-process `Wazuh-launcher -> wazuh-control reload -> SIGUSR1` chain.
- Gated to `#ifdef __APPLE__`; Linux/Windows keep the existing in-process reload chain as the single start path (no behavior change).

### Results and Evidence

Validated on a real macOS 15.3.2 (arm64) agent enrolled against a Wazuh v5.0.0 manager. The agent binary was built from this branch. The gate's own debug lines (`logcollector.debug=2`, `agent.debug=2`) make the otherwise-silent gate visible.

**Before (clean 5.0.0):** the gate is released only ~21 s later, after the launcher `SIGUSR1` — the fragile link:

```sql
03:00:28 wazuh-agentd: Received message: '#!-up file 2898... merged.mg'
03:00:28 wazuh-modulesd:control: INFO: Requested 'reload' via Wazuh-launcher (flag 'var/run/wazuh-control.request')
03:00:39 wazuh-agentd: reload_handler(): SIGNAL [(30)-(User defined signal 1)] Received. Reload agentd.
03:00:49 wazuh-logcollector: Startup hash gate released for 'wazuh-logcollector' (hash_match)
```

After (this fix): the gate is released inline the same second merged.mg matches, 13 s before the SIGUSR1 (now irrelevant); logcollector starts the ULS reader immediately:

```sql
05:32:28 wazuh-agentd: Received message: '#!-up file 2898... merged.mg'
05:32:28 wazuh-logcollector: Startup hash gate released for 'wazuh-logcollector' stream --style syslog ...
05:32:41 wazuh-agentd: reload_handler(): SIGNAL [(30)-(User defined signal 1)] Received. Reload agentd.
```

Repeatability — 5 consecutive fresh install + enroll cycles with the fixed package, checking that log stream comes up and the gate is released:
```
run 1: PASS (log stream up) | client.keys=1 | gate_released=1 | Monitoring_lines=2
run 2: PASS (log stream up) | client.keys=1 | gate_released=1 | Monitoring_lines=1
run 3: PASS (log stream up) | client.keys=1 | gate_released=1 | Monitoring_lines=2
run 4: PASS (log stream up) | client.keys=1 | gate_released=1 | Monitoring_lines=2
run 5: PASS (log stream up) | client.keys=1 | gate_released=1 | Monitoring_lines=2
```


Artifacts Affected

- src/client-agent/src/receiver.c

Configuration Changes

N/A

Documentation Updates

N/A

Tests Introduced

- Scope: Manual validation on real macOS 15.3.2 arm64 (agent 5.0.0, manager 5.0.0).
- Details: Confirmed the gate is released inline (same second as the merged.mg download, before the launcher SIGUSR1), that wazuh-logcollector starts its /usr/bin/log stream ULS reader, and that 5/5 fresh install + enroll cycles start correctly with no regression on the Linux/Windows path (unchanged, #ifdef __APPLE__).

Review Checklist

Manual tests with their corresponding evidence:

- Compilation without warnings on every supported platform

  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review
- Memory tests for Linux

  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

General Checklist:

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done  
- [ ] No unresolved dependencies with other issues