### PR TITLE
Fix resource leaks when upgrade command params carry duplicate keys

### DIFF
--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_parsing.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_parsing.c
@@ -566,11 +566,15 @@ void test_wm_agent_upgrade_parse_upgrade_command_success(void **state)
     char *ver = "v4.0.0";
     char *package_type = "rpm";
 
+    /* Each key is added twice: cJSON keeps duplicates, so the parser must end up with the last one */
     cJSON *params = cJSON_CreateObject();
+    cJSON_AddStringToObject(params, "wpk_repo", "duplicate");
     cJSON_AddStringToObject(params, "wpk_repo", repo);
+    cJSON_AddStringToObject(params, "version", "duplicate");
     cJSON_AddStringToObject(params, "version", ver);
     cJSON_AddTrueToObject(params, "use_http");
     cJSON_AddTrueToObject(params, "force_upgrade");
+    cJSON_AddStringToObject(params, "package_type", "deb");
     cJSON_AddStringToObject(params, "package_type", package_type);
 
     wm_upgrade_task* upgrade_task = wm_agent_upgrade_parse_upgrade_command(params, &error);
@@ -790,8 +794,11 @@ void test_wm_agent_upgrade_parse_upgrade_custom_command_success(void **state)
     char *file = "wazuh.wpk";
     char *exe = "install.sh";
 
+    /* Each key is added twice: cJSON keeps duplicates, so the parser must end up with the last one */
     cJSON *params = cJSON_CreateObject();
+    cJSON_AddStringToObject(params, "file_path", "duplicate");
     cJSON_AddStringToObject(params, "file_path", file);
+    cJSON_AddStringToObject(params, "installer", "duplicate");
     cJSON_AddStringToObject(params, "installer", exe);
 
     wm_upgrade_custom_task* upgrade_custom_task = wm_agent_upgrade_parse_upgrade_custom_command(params, &error);
@@ -905,9 +912,12 @@ void test_wm_agent_upgrade_parse_upgrade_agent_status_success(void **state)
     char *data = "Success";
     char *status = "Done";
 
+    /* Each key is added twice: cJSON keeps duplicates, so the parser must end up with the last one */
     cJSON *params = cJSON_CreateObject();
     cJSON_AddNumberToObject(params, "error", error_code);
+    cJSON_AddStringToObject(params, "message", "duplicate");
     cJSON_AddStringToObject(params, "message", data);
+    cJSON_AddStringToObject(params, "status", "duplicate");
     cJSON_AddStringToObject(params, "status", status);
 
     wm_upgrade_agent_status_task* agent_status_task = wm_agent_upgrade_parse_upgrade_agent_status(params, &error);

--- a/src/wazuh_modules/src/agent_upgrade/manager/wm_agent_upgrade_parsing.c
+++ b/src/wazuh_modules/src/agent_upgrade/manager/wm_agent_upgrade_parsing.c
@@ -216,6 +216,7 @@ STATIC wm_upgrade_task* wm_agent_upgrade_parse_upgrade_command(const cJSON* para
             if(strcmp(item->string, "wpk_repo") == 0) {
                 /* wpk_repo */
                 if (item->type == cJSON_String) {
+                    os_free(task->wpk_repository);
                     os_strdup(item->valuestring, task->wpk_repository);
                 } else {
                     sprintf(output, "Parameter \"%s\" should be a string", item->string);
@@ -224,6 +225,7 @@ STATIC wm_upgrade_task* wm_agent_upgrade_parse_upgrade_command(const cJSON* para
             } else if(strcmp(item->string, "version") == 0) {
                 /* version */
                 if (item->type == cJSON_String) {
+                    os_free(task->custom_version);
                     os_strdup(item->valuestring, task->custom_version);
                 } else {
                     sprintf(output, "Parameter \"%s\" should be a string", item->string);
@@ -253,6 +255,7 @@ STATIC wm_upgrade_task* wm_agent_upgrade_parse_upgrade_command(const cJSON* para
                 /* package_type */
                 if (item->type == cJSON_String) {
                     if (!strcmp(item->valuestring, "rpm") || !strcmp(item->valuestring, "deb")) {
+                        os_free(task->package_type);
                         os_strdup(item->valuestring, task->package_type);
                     } else {
                         sprintf(output, "Invalid parameter \"%s\", value should be \"rpm\" or \"deb\"", item->string);
@@ -298,6 +301,7 @@ STATIC wm_upgrade_custom_task* wm_agent_upgrade_parse_upgrade_custom_command(con
             if (strcmp(item->string, "file_path") == 0) {
                 /* file_path */
                 if (item->type == cJSON_String) {
+                    os_free(task->custom_file_path);
                     os_strdup(item->valuestring, task->custom_file_path);
                 } else {
                     sprintf(output, "Parameter \"%s\" should be a string", item->string);
@@ -306,6 +310,7 @@ STATIC wm_upgrade_custom_task* wm_agent_upgrade_parse_upgrade_custom_command(con
             } else if(strcmp(item->string, "installer") == 0) {
                 /* installer */
                 if (item->type == cJSON_String) {
+                    os_free(task->custom_installer);
                     os_strdup(item->valuestring, task->custom_installer);
                 } else {
                     sprintf(output, "Parameter \"%s\" should be a string", item->string);
@@ -353,6 +358,7 @@ STATIC wm_upgrade_agent_status_task* wm_agent_upgrade_parse_upgrade_agent_status
                 }
             } else if(strcmp(item->string, task_manager_json_keys[WM_TASK_ERROR_MESSAGE]) == 0) {
                 if (item->type == cJSON_String) {
+                    os_free(task->message);
                     os_strdup(item->valuestring, task->message);
                 } else {
                     sprintf(output, "Parameter \"%s\" should be a string", item->string);
@@ -360,6 +366,7 @@ STATIC wm_upgrade_agent_status_task* wm_agent_upgrade_parse_upgrade_agent_status
                 }
             } else if(strcmp(item->string, task_manager_json_keys[WM_TASK_STATUS]) == 0) {
                 if (item->type == cJSON_String) {
+                    os_free(task->status);
                     os_strdup(item->valuestring, task->status);
                 } else {
                     sprintf(output, "Parameter \"%s\" should be a string", item->string);


### PR DESCRIPTION
## Description

`os_strdup` expands to a bare `y = strdup(x)` and does not free the previous value. The upgrade command parse functions iterate `params` item by item, and cJSON preserves duplicate object keys, so a repeated key reaches the same `os_strdup` twice and the second assignment leaks the first allocation. Coverity reports it as seven `RESOURCE_LEAK` CIDs with one root cause. Impact is Low: authenticated socket, one small buffer per duplicate key.

Closes #37960

## Proposed Changes

`os_free` before each of the seven `os_strdup` calls that write a task field: lines 219, 227, 256 (`parse_upgrade_command`), 301, 309 (`parse_upgrade_custom_command`), 356, 363 (`parse_upgrade_agent_status`). `os_free` is NULL-safe, so the first occurrence is unaffected and the last key wins, matching current behavior. Rejecting duplicates instead would reject payloads accepted today.

### Results and Evidence

`TARGET=manager`, gcc 14.3. `test_wm_agent_upgrade_parsing` passes (59 tests), no compilation warnings, and LeakSanitizer reports nothing.

The assertions can only prove the last key wins: this suite has no `test_malloc` and `ctest` no memcheck, so a leaking build still passes. Reverting only the seven `os_free` lines is what shows the defect, one `strdup` leak per line:

```
$ ASAN_OPTIONS=detect_leaks=1 ./test_wm_agent_upgrade_parsing
SUMMARY: AddressSanitizer: 64 byte(s) leaked in 7 allocation(s).

$ grep -o 'wm_agent_upgrade_parsing.c:[0-9]*' before.txt | sort -t: -k2 -n | uniq -c
      1 wm_agent_upgrade_parsing.c:219
      1 wm_agent_upgrade_parsing.c:227
      1 wm_agent_upgrade_parsing.c:256
      1 wm_agent_upgrade_parsing.c:301
      1 wm_agent_upgrade_parsing.c:309
      1 wm_agent_upgrade_parsing.c:356
      1 wm_agent_upgrade_parsing.c:363
```

Valgrind is not usable: the build tree is ASan-instrumented, so the binary aborts before `main` and reports `0 allocs, 0 frees`, which reads as clean but never ran. Coverity re-run is a CI-side step.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer

Manager-only code, so no Windows or macOS check: `test_wm_agent_upgrade_parsing` is only built for `TARGET=manager`. No log message changed.

### Artifacts Affected

`wazuh-modulesd` (manager).

### Configuration Changes

N/A

### Tests Introduced

No new test functions. The three existing `*_success` cases already assert every field against a local variable, so adding a prior occurrence of each key makes them verify that the last one wins: seven lines for all seven assignments. 

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
