### PR TITLE
Resolve Coverity findings for 5.0.0 Beta 4 - Agent

### DIFF
--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -326,7 +326,7 @@ SyncModuleResult AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
     const bool managerNotReady = m_syncState.lastSyncManagerNotReady;
     const unsigned int consecutiveFailures = trackSyncOutcome(success, stopped);
     clearSyncState();
-    return {success, failureReason, stopped, managerNotReady, consecutiveFailures};
+    return {success, std::move(failureReason), stopped, managerNotReady, consecutiveFailures};
 }
 
 unsigned int AgentSyncProtocol::trackSyncOutcome(bool success, bool stopped)
@@ -469,7 +469,7 @@ SyncModuleResult AgentSyncProtocol::synchronizeMetadataOrGroups(Mode mode,
     const bool managerNotReady = m_syncState.lastSyncManagerNotReady;
     const unsigned int consecutiveFailures = trackSyncOutcome(success, stopped);
     clearSyncState();
-    return {success, failureReason, stopped, managerNotReady, consecutiveFailures};
+    return {success, std::move(failureReason), stopped, managerNotReady, consecutiveFailures};
 }
 
 bool AgentSyncProtocol::notifyDataClean(const std::vector<std::string>& indices,

--- a/src/syscheckd/src/main.c
+++ b/src/syscheckd/src/main.c
@@ -108,6 +108,9 @@ static void *fim_shutdown_waiter(__attribute__((unused)) void *arg)
      * second, so the join below still completes. */
     fim_sync_module_running = 0;
     bool join_sync_thread = fim_sync_thread_initialized;
+    /* Read the thread handle under the same lock its writer (start_daemon) holds, so the
+     * join below never races the creation store. */
+    pthread_t sync_thread = fim_sync_thread;
     fim_sync_thread_initialized = false;
     w_rwlock_unlock(&fim_sync_handle_rwlock);
 
@@ -127,7 +130,7 @@ static void *fim_shutdown_waiter(__attribute__((unused)) void *arg)
 
         if (poll_ret > 0)
         {
-            pthread_join(fim_sync_thread, NULL);
+            pthread_join(sync_thread, NULL);
         }
         else
         {
@@ -318,11 +321,16 @@ int main(int argc, char **argv)
         merror_exit("Could not create the shutdown pipes: %s (%d)", strerror(errno), errno);
     }
 
-    /* Keep the pipes out of child processes (e.g. prefilter_cmd) */
-    fcntl(fim_shutdown_pipe[0], F_SETFD, FD_CLOEXEC);
-    fcntl(fim_shutdown_pipe[1], F_SETFD, FD_CLOEXEC);
-    fcntl(fim_sync_exit_pipe[0], F_SETFD, FD_CLOEXEC);
-    fcntl(fim_sync_exit_pipe[1], F_SETFD, FD_CLOEXEC);
+    /* Keep the pipes out of child processes (e.g. prefilter_cmd). A failure here is not fatal
+     * (it would only mean the pipe fds could leak into a child), so log and continue. */
+    int cloexec_ret = 0;
+    cloexec_ret |= fcntl(fim_shutdown_pipe[0], F_SETFD, FD_CLOEXEC);
+    cloexec_ret |= fcntl(fim_shutdown_pipe[1], F_SETFD, FD_CLOEXEC);
+    cloexec_ret |= fcntl(fim_sync_exit_pipe[0], F_SETFD, FD_CLOEXEC);
+    cloexec_ret |= fcntl(fim_sync_exit_pipe[1], F_SETFD, FD_CLOEXEC);
+    if (cloexec_ret < 0) {
+        mwarn("Could not set FD_CLOEXEC on the shutdown pipes: %s (%d)", strerror(errno), errno);
+    }
 
     w_create_thread(fim_shutdown_waiter, NULL);
 

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -2382,7 +2382,7 @@ SyncModuleResult Syscollector::syncModule(Mode mode)
         m_logFunction(LOG_INFO, "Syscollector synchronization process finished successfully.");
     }
 
-    return {overallSuccess, failureReason};
+    return {overallSuccess, std::move(failureReason)};
 }
 // LCOV_EXCL_STOP
 


### PR DESCRIPTION
## Description

The Coverity analysis run as part of the [5.0.0 Beta 4 validation](https://github.com/wazuh/wazuh/issues/37920) reported five new defects in the Wazuh agent (tracked in #37984): two Medium-impact and three Low-impact. This PR reviews and fixes all five.

The root causes, per finding:

- **CID 562055 — Data race (MISSING_LOCK), `src/syscheckd/src/main.c`, `fim_shutdown_waiter()`.** The `pthread_join(fim_sync_thread, ...)` read the global `fim_sync_thread` handle after releasing `fim_sync_handle_rwlock`, while its writer in `start_daemon()` (`run_check.c`) stores it under that same lock. Although the read is ordered in practice by the `fim_sync_thread_initialized` flag (which is read under the lock), the handle itself was accessed outside the lock, which is what Coverity flags.
- **CID 562056 — Unchecked return value (CHECKED_RETURN), `src/syscheckd/src/main.c`, `main()`.** The four `fcntl(..., F_SETFD, FD_CLOEXEC)` calls that keep the shutdown/sync pipe descriptors out of forked children (e.g. `prefilter_cmd`) ignored their return value.
- **CID 562054 / 562058 / 562057 — Variable copied when it could be moved (COPY_INSTEAD_OF_MOVE).** The local `failureReason` string was copied (not moved) into the returned `SyncModuleResult` aggregate in `AgentSyncProtocol::synchronizeModule` and `AgentSyncProtocol::synchronizeMetadataOrGroups` (`agent_sync_protocol.cpp`) and in `Syscollector::syncModule` (`syscollectorImp.cpp`).

## Proposed Changes

- **`src/syscheckd/src/main.c` (CID 562055):** copy `fim_sync_thread` into a local `pthread_t sync_thread` inside the `fim_sync_handle_rwlock` critical section (next to the existing `join_sync_thread` capture) and join the local copy, so the handle is never read outside the lock its writer holds.
- **`src/syscheckd/src/main.c` (CID 562056):** check the return value of the four `fcntl(F_SETFD, FD_CLOEXEC)` calls and emit an `mwarn` on failure. The calls run unconditionally and their return values are OR-ed together, so an early failure does not short-circuit the remaining descriptors (a failure is non-fatal — it would only mean a pipe fd could leak into a child — so the daemon logs and continues).
- **`src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp` (CID 562054, 562058):** `std::move(failureReason)` into the returned `SyncModuleResult` in `synchronizeModule` and `synchronizeMetadataOrGroups`.
- **`src/wazuh_modules/syscollector/src/syscollectorImp.cpp` (CID 562057):** `std::move(failureReason)` into the returned `SyncModuleResult` in `syncModule`.

### Results and Evidence

<img width="836" height="670" alt="image" src="https://github.com/user-attachments/assets/53489459-0515-49bc-9b58-dc811d020b04" />

<img width="1354" height="225" alt="image" src="https://github.com/user-attachments/assets/151764a5-5ff5-4608-a30f-905edc0908c8" />


### Artifacts Affected

- `wazuh-syscheckd` (FIM daemon) — `main.c` changes.
- `wazuh-modulesd` — `syscollector` module (`syscollectorImp.cpp`) and the agent sync protocol (`shared_modules/sync_protocol`).

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None.
## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
