### PR TITLE
Close HTTPS control-path gaps blocking module startup,  event transmission, and shutdown visibility

### DIFF
--- a/src/client-agent/https_client/include/https_client.h
+++ b/src/client-agent/https_client/include/https_client.h
@@ -148,7 +148,7 @@ typedef struct hc_config_t
     uint32_t task_dedup_ttl_s;
 
     char version[HC_MAX_VERSION];       ///< Product version for Startup.
-    char config_checksum[HC_MAX_CHECKSUM]; ///< Local merged.mg MD5 seed. Compared
+    char config_checksum[HC_MAX_CHECKSUM]; ///< Local merged.mg SHA-256 seed. Compared
     ///< against the manager-reported
     ///< agent.config_hash on every Notify;
     ///< a mismatch triggers /download.
@@ -185,7 +185,7 @@ typedef struct hc_callbacks_t
                     void* user_data);
     /// A Notify reported a merged-config hash differing from the local one;
     /// the module fetched the new configuration via POST /download and
-    /// verified its MD5. file_path is a module-owned temp file valid ONLY
+    /// verified its SHA-256. file_path is a module-owned temp file valid ONLY
     /// until this callback returns (the module deletes it afterwards):
     /// read/copy it inside the callback. Writing merged.mg, unmerging and
     /// reloading is the consumer's job. If applying fails, call

--- a/src/client-agent/https_client/src/configFetcher.cpp
+++ b/src/client-agent/https_client/src/configFetcher.cpp
@@ -67,6 +67,14 @@ std::shared_ptr<SpoolFile> ConfigFetcher::fetch(const std::string& expectedHash,
     spec.maxResponseBytes = CONFIG_MAX_DOWNLOAD_BYTES;
     spec.timeoutMs = m_config.statefulTimeoutMs; // The large-transfer class.
 
+    // Operational visibility (send-time debug log, mirroring controlStream.cpp's
+    // sendStartup()/sendNotify()/sendShutdown()): confirms the download was
+    // actually attempted and for which resource, so a log reader can tell
+    // "never attempted" from "attempted and failed" without source-level
+    // reasoning.
+    LOGFN_DEBUG2(m_logFn, "Sending /download (resource_type=config, resource_id='%s').",
+                 group.c_str());
+
     const auto result = m_sender.send(spec, waiter, DOWNLOAD_MAX_ATTEMPTS);
 
     if (result.outcome != OutcomeClass::Ok)
@@ -76,6 +84,9 @@ std::shared_ptr<SpoolFile> ConfigFetcher::fetch(const std::string& expectedHash,
                    static_cast<int>(result.outcome));
         return nullptr;
     }
+
+    LOGFN_DEBUG2(m_logFn, "Config download (resource_id='%s') delivered by the manager.",
+                 group.c_str());
 
     const auto actualHash = sha256FileHex(spool->path());
 

--- a/src/client-agent/https_client/src/controlStream.cpp
+++ b/src/client-agent/https_client/src/controlStream.cpp
@@ -171,6 +171,12 @@ void ControlStream::drainStep(Waiter& waiter)
 void ControlStream::sendShutdown(Waiter& waiter)
 {
     const std::string body = R"({"type":"shutdown"})";
+    // Operational visibility (send-time debug log, mirroring sendStartup()/
+    // sendNotify() below): confirms the send was actually attempted, so a log
+    // reader can tell "never attempted" from "attempted and failed" without
+    // needing source-level reasoning (finding 3, #37831 QA round).
+    LOGFN_DEBUG2(m_logFn, "Sending /control shutdown.");
+
     // Best-effort within the drain window (drain_timeout_ms): a single attempt,
     // NOT the normal 4x retry/backoff, so an unreachable manager cannot stall
     // shutdown for minutes. The manager marks the agent disconnected on the next
@@ -181,6 +187,10 @@ void ControlStream::sendShutdown(Waiter& waiter)
     {
         LOGFN_WARN(m_logFn, "Shutdown notification to the manager failed (outcome %d).",
                    static_cast<int>(result.outcome));
+    }
+    else
+    {
+        LOGFN_DEBUG2(m_logFn, "Shutdown notification delivered to the manager.");
     }
 }
 
@@ -202,6 +212,8 @@ OutcomeClass ControlStream::sendStartup(Waiter& waiter)
     request["type"] = "startup";
     request["version"] = m_config.version;
     const std::string body = request.dump();
+
+    LOGFN_DEBUG2(m_logFn, "Sending /control startup.");
 
     const auto result = m_sender.send(controlSpec(body, m_config.requestTimeoutMs), waiter,
                                       CONTROL_MAX_ATTEMPTS);
@@ -238,6 +250,8 @@ OutcomeClass ControlStream::sendNotify(Waiter& waiter)
     // 5.1.2 (#37733): the keepalive request is bare; the manager reports the
     // hashes and tasks in the response.
     const std::string body = R"({"type":"notify"})";
+
+    LOGFN_DEBUG2(m_logFn, "Sending /control notify.");
 
     const auto result = m_sender.send(controlSpec(body, m_config.requestTimeoutMs), waiter,
                                       CONTROL_MAX_ATTEMPTS);

--- a/src/client-agent/https_client/src/httpsClientFacade.cpp
+++ b/src/client-agent/https_client/src/httpsClientFacade.cpp
@@ -143,11 +143,25 @@ void HttpsClientFacade::statelessLoop()
 
 void HttpsClientFacade::drain()
 {
+    // Finding 3 (#37831 QA round): the manager was observed never receiving
+    // the /control shutdown message, with no failure log either -- pointing
+    // at this guard silently skipping the send. Neither branch had a log
+    // statement at any verbosity before this, so raising debug logging could
+    // not distinguish "guard tripped" from "never reached this code at all".
+    // These two lines make that observable; see controlStream.cpp's
+    // sendShutdown() for the send-attempt/outcome logs on the other side of
+    // the guard.
     if (m_authGate.paused() || m_control.connState() != HC_STATE_REGISTERED)
     {
+        LOGFN_DEBUG2(m_logFn,
+                     "Skipping drain/shutdown notification (auth paused=%d, connState=%d): "
+                     "paused or never registered, nothing to flush.",
+                     static_cast<int>(m_authGate.paused()),
+                     static_cast<int>(m_control.connState()));
         return; // Paused (dead key) or never registered: nothing to flush.
     }
 
+    LOGFN_DEBUG2(m_logFn, "Draining (stateless flush + /control shutdown) before stopping.");
     m_stateless.drain(m_drainWaiter);   // Flush the backlog in bounded batches.
     m_control.drainStep(m_drainWaiter); // Final shutdown message.
 }

--- a/src/client-agent/https_client/src/statelessStream.cpp
+++ b/src/client-agent/https_client/src/statelessStream.cpp
@@ -142,8 +142,21 @@ bool StatelessStream::flushOnce(Waiter& waiter, uint32_t timeoutMs, uint32_t max
     spec.bodyLength = body.size();
     spec.timeoutMs = timeoutMs;
 
+    // Operational visibility (send-time debug log, mirroring controlStream.cpp's
+    // sendStartup()/sendNotify()/sendShutdown() and configFetcher.cpp's fetch()):
+    // confirms the flush was actually attempted, with the batch size that made
+    // it observable without source-level reasoning.
+    LOGFN_DEBUG2(m_logFn, "Sending /stateless batch (%llu events, %zu bytes).",
+                 static_cast<unsigned long long>(snapshot.eventCount), body.size());
+
     const auto result = m_sender.send(spec, waiter, maxAttempts);
     m_lastFlush = m_clock.steadyNow();
+
+    if (result.outcome == OutcomeClass::Ok)
+    {
+        LOGFN_DEBUG2(m_logFn, "Stateless batch delivered to the manager.");
+    }
+
     handleOutcome(result.outcome, snapshot);
     return result.outcome == OutcomeClass::Ok;
 }

--- a/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
+++ b/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
@@ -132,6 +132,52 @@ namespace
     FakeManager* FacadeE2eTest::s_manager = nullptr;
 } // namespace
 
+TEST_F(FacadeE2eTest, GracefulStopSendsControlShutdown)
+{
+    // Finding 3 (#37831 QA round): the manager was observed never receiving
+    // {"type":"shutdown"} on a graceful stop, with HttpsClientFacade::drain()'s
+    // guard (paused-or-not-registered) suspected as the likely (but, per that
+    // round's own report, unconfirmed) cause. This is the direct, live
+    // repro the report asked for: register for real over TLS, destroy the
+    // client the same way the real agent's atexit(w_https_client_stop) does,
+    // and check the manager's own record of what it received.
+    const uint16_t port = TLS_PORT + 6;
+    FakeManager manager {port, KEY_HEX, /*tls=*/true};
+
+    Recorder recorder;
+    hc_config_t config = tlsConfig();
+    config.server_port = port;
+    hc_callbacks_t callbacks {};
+    callbacks.on_startup_result = onStartup;
+    callbacks.user_data = &recorder;
+
+    hc_handle* handle = hc_create(&config, &callbacks);
+    ASSERT_NE(nullptr, handle);
+    ASSERT_TRUE(hc_start(handle));
+    ASSERT_TRUE(waitFor(recorder.startupCount, 1, 3000)); // Registered.
+
+    hc_destroy(handle); // The same call the real agent's atexit hook makes.
+
+    httplib::Client peek {std::string {"https://127.0.0.1:"} + std::to_string(port)};
+    peek.enable_server_certificate_verification(false);
+    std::string seenTypes;
+
+    if (auto result = peek.Get("/peek/control"))
+    {
+        seenTypes = result->body;
+    }
+
+    // If this fails, finding 3 is confirmed live (not just suspected from
+    // reading the source) and HttpsClientFacade::drain()'s guard (or
+    // something upstream of it) needs an actual behavior fix, not just the
+    // logging this same change adds. If it passes, the guard is NOT the
+    // problem in this exact lifecycle (start -> register -> destroy), and
+    // whatever the QA round observed must come from a path this test does
+    // not cover (e.g. the real daemon's signal-handler-driven shutdown).
+    EXPECT_NE(std::string::npos, seenTypes.find("shutdown"))
+            << "manager's /control record was: " << seenTypes;
+}
+
 TEST_F(FacadeE2eTest, RegistersOverTlsAndStopsCleanly)
 {
     // The full lifecycle against a real TLS listener: STARTING -> REGISTERED

--- a/src/client-agent/https_client/tests/component/fakeManager.hpp
+++ b/src/client-agent/https_client/tests/component/fakeManager.hpp
@@ -248,8 +248,18 @@ class FakeManager final
                 });
             });
 
+            // Records every /control request TYPE the fork child actually saw
+            // (not the full body -- just "startup"/"notify"/"shutdown"/
+            // "unknown"), so the fork parent can assert on the conversation
+            // shape via GET /peek/control (fork servers share no memory; this
+            // is the same observability idiom as acceptedEvents/peek/stateless
+            // above). Used to directly (not just by source reading) confirm
+            // whether a graceful stop actually sends {"type":"shutdown"}.
+            auto controlTypes = std::make_shared<std::string>();
+            auto controlMutex = std::make_shared<std::mutex>();
+
             server.Post("/control",
-                        [verify, settingsFlipAfter, notifyCount, configHash](
+                        [verify, settingsFlipAfter, notifyCount, configHash, controlTypes, controlMutex](
                             const httplib::Request & request, httplib::Response & response)
             {
                 if (!verify("/control", request))
@@ -262,6 +272,27 @@ class FakeManager final
                 {
                     response.status = 426;
                     return;
+                }
+
+                {
+                    std::lock_guard<std::mutex> lock(*controlMutex);
+                    const char* type = "unknown";
+
+                    if (request.body.find("\"type\":\"startup\"") != std::string::npos)
+                    {
+                        type = "startup";
+                    }
+                    else if (request.body.find("\"type\":\"notify\"") != std::string::npos)
+                    {
+                        type = "notify";
+                    }
+                    else if (request.body.find("\"type\":\"shutdown\"") != std::string::npos)
+                    {
+                        type = "shutdown";
+                    }
+
+                    *controlTypes += type;
+                    *controlTypes += ";";
                 }
 
                 // #37733 5.1: startup answers the handshake metadata (v1 or
@@ -308,6 +339,15 @@ class FakeManager final
                 // Unknown /control type: 400.
                 response.status = 400;
                 response.set_content(R"({"error":"unknown control type"})", "application/json");
+            });
+
+            server.Get("/peek/control",
+                       [controlTypes, controlMutex](const httplib::Request&,
+                                                    httplib::Response & response)
+            {
+                std::lock_guard<std::mutex> lock(*controlMutex);
+                response.status = 200;
+                response.set_content(*controlTypes, "text/plain");
             });
         }
 

--- a/src/client-agent/include/agentd.h
+++ b/src/client-agent/include/agentd.h
@@ -237,6 +237,20 @@ void startup_gate_process_handshake(bool is_startup, const char *merged_sum);
 // Re-check startup gate state after merged.mg updates.
 void startup_gate_refresh_from_local_hash(void);
 
+// Release the startup gate from the HTTPS /control apply chain
+// (bridge_on_config_downloaded, once a downloaded config has been verified
+// and applied). There is no merged_sum handshake field to key a hash
+// comparison off over HTTPS (#37733), so this opens the gate directly on the
+// strength of the module's own SHA-256 verification, rather than routing
+// through startup_gate_refresh_from_local_hash()'s (legacy-only, MD5-based)
+// comparison machinery.
+void startup_gate_release_from_https_apply(void);
+
+// Release the startup gate from the manager's per-Notify config_hash (SHA-256
+// over merged.mg), independent of any download/reload having happened -- this
+// is what covers an agent that boots already in sync with the manager.
+void startup_gate_check_manager_config_hash(const char *manager_sha256);
+
 // Read current startup gate state.
 void startup_gate_get_status(bool *ready, char *reason, size_t reason_size);
 

--- a/src/client-agent/src/agentd.c
+++ b/src/client-agent/src/agentd.c
@@ -167,37 +167,27 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
     /* Monitor loop */
     while (1) {
 
-        /* Reconnect if the socket was invalidated (either carried over from
-         * the previous iteration or by a sender/dispatcher thread via SO_SNDTIMEO).
-         * Using continue ensures run_notify() always runs on a valid descriptor. */
-        if (agt->sock < 0) {
-            w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_NACTIVE);
-            merror(LOST_ERROR);
-            os_setwait();
-            start_agent(0);
-            minfo(SERVER_UP);
-            os_delwait();
-            w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_ACTIVE);
-            continue;
-        }
-
         /* Continuously send notifications */
         run_notify();
 
-        /* If run_notify() invalidated the socket, restart the loop to reconnect
-         * before FD_SET(), which requires a valid descriptor. */
+        /* agt->sock is permanently -1: the legacy TCP path has been retired
+         * (start_agent() no longer attempts it, see its own comment), so there
+         * is no descriptor to reconnect. Everything below that used to depend
+         * on a valid sock -- needs_config_reload handling, execdq, the queue
+         * forwarder -- must run every iteration regardless, gated only by the
+         * select() timeout below; sock-specific operations are individually
+         * guarded instead of short-circuiting the whole loop body. */
         const int sock = agt->sock;
-        if (sock < 0) {
-            continue;
-        }
 
-        if (sock > maxfd - 1) {
+        if (sock >= 0 && sock > maxfd - 1) {
             maxfd = sock + 1;
         }
 
         /* Monitor all available sockets from here */
         FD_ZERO(&fdset);
-        FD_SET(sock, &fdset);
+        if (sock >= 0) {
+            FD_SET(sock, &fdset);
+        }
         FD_SET(agt->m_queue, &fdset);
 
         fdtimeout.tv_sec = 1;
@@ -210,8 +200,8 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
 
         if (rc == -1) {
             /* EBADF can occur if a non-main thread closed agt->sock while we
-             * were inside select(). Treat it as a lost connection and let the
-             * reconnect block at the top of the loop handle recovery. */
+             * were inside select(). Nothing reconnects it (legacy is retired),
+             * so just make sure the next iteration's FD_SET() skips it too. */
             if (errno == EBADF) {
                 agt->sock = -1;
                 continue;
@@ -262,6 +252,20 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
             // Release the startup gate now so modules blocked in
             // startup_gate_wait_for_ready() can proceed with the new config.
             startup_gate_refresh_from_local_hash();
+
+            // Same signal, HTTPS-side release (#37831): startup_gate_refresh_from_local_hash()
+            // above is a no-op for a pure-HTTPS agent (it only ever does anything once the
+            // legacy handshake's startup_gate_process_handshake() has populated
+            // startup_gate_expected_sum, which never happens without a legacy handshake).
+            // bridge_on_config_downloaded() (https_client_bridge.c) deliberately does NOT
+            // release the gate inline when reloadAgent() succeeds, to avoid the same
+            // start-then-killed race this file's own reload chain is designed to avoid
+            // (a module blocked in startup_gate_wait_for_ready() unblocking and starting a
+            // moment before this SIGUSR1 restarts it anyway). This is the other half of that
+            // deferral: release once the restart this SIGUSR1 represents has actually
+            // happened. A no-op when already released (own guard) or when nothing was ever
+            // pending via the HTTPS apply chain.
+            startup_gate_release_from_https_apply();
         }
 
         /* Connect to the execd queue */
@@ -272,8 +276,8 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
             }
         }
 
-        /* For the receiver */
-        if (FD_ISSET(sock, &fdset)) {
+        /* For the receiver (legacy only -- sock is never valid without it) */
+        if (sock >= 0 && FD_ISSET(sock, &fdset)) {
             if (receive_msg() < 0) {
                 w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_NACTIVE);
                 merror(LOST_ERROR);

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -1,5 +1,5 @@
 /*
- * Wazuh agent HTTPS client bridge (development scaffold)
+ * Wazuh agent HTTPS client bridge
  * Copyright (C) 2015, Wazuh Inc.
  * July 17, 2026.
  *
@@ -23,8 +23,16 @@
  * real verify_mode/CA/cert/key/ciphers instead of a forced HC_VERIFY_NONE.
  * on_reenroll_required is wired to the existing authd flow (try_enroll_to_server,
  * start_agent.c) and hc_set_agent_key(); on_state_change feeds the .state file
- * (client-agent/include/state.h). Still pending (later integration workstreams
- * of #37702): retiring the legacy TCP data path this module runs alongside.
+ * (client-agent/include/state.h) and, since a QA round against #37831 found
+ * WAIT_FILE/os_setwait() had no HTTPS release path either, also clears that
+ * producer lock on REGISTERED. on_startup_result applies module limits and
+ * cluster-name authority (#37830's own scope), and on_config_downloaded
+ * writes/applies merged.mg and releases the startup_gate (#37832's own
+ * scope) -- both were previously dev-scaffold stubs despite their issues
+ * being merged and closed; see startup_gate_release_from_https_apply()'s own
+ * comment for why that release cannot reuse the legacy MD5-based gate
+ * machinery. Still pending (later integration workstreams of #37702):
+ * retiring the legacy TCP data path this module runs alongside.
  */
 
 #include "https_client_bridge.h"
@@ -36,6 +44,8 @@
 
 #include "agentd.h" /* pulls defs.h (__wazuh_version), sec.h (keys), client-config.h (agt) */
 #include "https_client.h"
+#include "sendmsg.h" /* send_msg(): the AG_IN_UNMERGE manager-visible report on unmerge failure */
+#include "sha256_op.h" /* OS_SHA256_File(): config_checksum seed, matching the module's own hash space */
 
 static hc_handle *g_https_client = NULL;
 
@@ -166,11 +176,205 @@ static DWORD WINAPI bridge_reenroll_thread_win(LPVOID arg)
 /* Received-work callbacks. The production hookups still pending (later
  * integration workstreams): execd/module-com routing for on_task-equivalent
  * work. */
+
+/* Startup-response parsing (#37830's own "In scope" text: apply module limits
+ * and cluster-name authority from the handshake). Deliberately separate,
+ * local copies of client-agent/src/start_agent.c's parse_fim_limits()/
+ * parse_syscollector_limits()/parse_sca_limits()/parse_limits() logic rather
+ * than calling those functions directly: they are file-static in start_agent.c
+ * (legacy handshake code, out of this change's scope per finding 4), and
+ * strict-required-field parsing is genuinely what the "limits" sub-object
+ * needs (unlike cluster/groups below). Field names/nesting confirmed against
+ * the current #37733 contract and the https_client module's own demo mock
+ * manager (https_client/demo/mock_manager.py): {"limits":{"fim":{...},
+ * "syscollector":{...},"sca":{...}},"cluster":{"name":...,"node":...},
+ * "agent":{"groups":[...]}}. */
+
+static bool bridge_get_required_int(const cJSON *parent, const char *name, int *value)
+{
+    cJSON *field = cJSON_GetObjectItem(parent, name);
+    if (!field || !cJSON_IsNumber(field)) {
+        return false;
+    }
+    *value = field->valueint;
+    return true;
+}
+
+static bool bridge_parse_fim_limits(const cJSON *limits_obj, fim_limits_t *fim)
+{
+    cJSON *module = cJSON_GetObjectItem(limits_obj, "fim");
+    if (!module || !cJSON_IsObject(module)) {
+        return false;
+    }
+
+    return bridge_get_required_int(module, "file", &fim->file) &&
+           bridge_get_required_int(module, "registry_key", &fim->registry_key) &&
+           bridge_get_required_int(module, "registry_value", &fim->registry_value);
+}
+
+static bool bridge_parse_syscollector_limits(const cJSON *limits_obj, syscollector_limits_t *syscollector)
+{
+    cJSON *module = cJSON_GetObjectItem(limits_obj, "syscollector");
+    if (!module || !cJSON_IsObject(module)) {
+        return false;
+    }
+
+    return bridge_get_required_int(module, "hotfixes", &syscollector->hotfixes) &&
+           bridge_get_required_int(module, "packages", &syscollector->packages) &&
+           bridge_get_required_int(module, "processes", &syscollector->processes) &&
+           bridge_get_required_int(module, "ports", &syscollector->ports) &&
+           bridge_get_required_int(module, "network_iface", &syscollector->network_iface) &&
+           bridge_get_required_int(module, "network_protocol", &syscollector->network_protocol) &&
+           bridge_get_required_int(module, "network_address", &syscollector->network_address) &&
+           bridge_get_required_int(module, "hardware", &syscollector->hardware) &&
+           bridge_get_required_int(module, "os_info", &syscollector->os_info) &&
+           bridge_get_required_int(module, "users", &syscollector->users) &&
+           bridge_get_required_int(module, "groups", &syscollector->groups) &&
+           bridge_get_required_int(module, "services", &syscollector->services) &&
+           bridge_get_required_int(module, "browser_extensions", &syscollector->browser_extensions);
+}
+
+static bool bridge_parse_sca_limits(const cJSON *limits_obj, sca_limits_t *sca)
+{
+    cJSON *module = cJSON_GetObjectItem(limits_obj, "sca");
+    if (!module || !cJSON_IsObject(module)) {
+        return false;
+    }
+
+    return bridge_get_required_int(module, "checks", &sca->checks);
+}
+
+static bool bridge_parse_limits(const cJSON *root, module_limits_t *limits)
+{
+    cJSON *limits_obj = cJSON_GetObjectItem(root, "limits");
+    if (!limits_obj || !cJSON_IsObject(limits_obj)) {
+        return false;
+    }
+
+    if (!bridge_parse_fim_limits(limits_obj, &limits->fim) ||
+        !bridge_parse_syscollector_limits(limits_obj, &limits->syscollector) ||
+        !bridge_parse_sca_limits(limits_obj, &limits->sca)) {
+        return false;
+    }
+
+    limits->limits_received = true;
+    return true;
+}
+
+/* Cluster-name authority (#37830): unlike start_agent.c's parse_cluster_name()/
+ * parse_cluster_node() -- which are flat top-level fields and REFUSE an empty
+ * value -- the HTTPS contract nests them under "cluster":{"name","node"}, and
+ * #37830's own scope explicitly wants an unconditional overwrite, even to
+ * empty/unknown, so a manager that stops reporting identity doesn't leave a
+ * stale value behind. Mirrors ControlStream::applyClusterIdentity() (the
+ * module's own internal, HTTPS-side copy of this same rule) so the C side's
+ * globals (which agent-info/agcom and the shutdown message already read)
+ * agree with what the module itself believes. */
+static void bridge_apply_cluster_identity(const cJSON *root)
+{
+    const cJSON *cluster = cJSON_GetObjectItem(root, "cluster");
+    const char *name = NULL;
+    const char *node = NULL;
+
+    if (cluster && cJSON_IsObject(cluster)) {
+        cJSON *name_field = cJSON_GetObjectItem(cluster, "name");
+        cJSON *node_field = cJSON_GetObjectItem(cluster, "node");
+
+        if (name_field && cJSON_IsString(name_field) && name_field->valuestring) {
+            name = name_field->valuestring;
+        }
+        if (node_field && cJSON_IsString(node_field) && node_field->valuestring) {
+            node = node_field->valuestring;
+        }
+    }
+
+    snprintf(agent_cluster_name, sizeof(agent_cluster_name), "%s", name ? name : "");
+    snprintf(agent_cluster_node, sizeof(agent_cluster_node), "%s", node ? node : "");
+    mdebug1("https_client: cluster identity -> name='%s', node='%s'.", agent_cluster_name, agent_cluster_node);
+}
+
+/* agent_groups: HTTPS nests the array under "agent":{"groups":[...]} (see
+ * ControlStream's firstGroup(), which reads the same object for /download's
+ * group parameter) rather than start_agent.c's flat "agent_groups" array.
+ * Builds the same CSV shape agent_agent_groups already holds for legacy. */
+static void bridge_apply_agent_groups(const cJSON *root)
+{
+    const cJSON *agent = cJSON_GetObjectItem(root, "agent");
+    const cJSON *groups_array = agent ? cJSON_GetObjectItem(agent, "groups") : NULL;
+    cJSON *group_item = NULL;
+    size_t offset = 0;
+
+    agent_agent_groups[0] = '\0';
+
+    if (!groups_array || !cJSON_IsArray(groups_array)) {
+        return;
+    }
+
+    cJSON_ArrayForEach(group_item, groups_array) {
+        if (cJSON_IsString(group_item) && group_item->valuestring && group_item->valuestring[0] != '\0') {
+            size_t group_len = strlen(group_item->valuestring);
+            /* Space check: group + comma + null terminator. */
+            if (offset + group_len + 2 < sizeof(agent_agent_groups)) {
+                if (offset > 0) {
+                    agent_agent_groups[offset++] = ',';
+                }
+                strcpy(agent_agent_groups + offset, group_item->valuestring);
+                offset += group_len;
+            }
+        }
+    }
+    agent_agent_groups[offset] = '\0';
+
+    if (agent_agent_groups[0]) {
+        mdebug1("https_client: agent groups -> %s.", agent_agent_groups);
+    }
+}
+
 static void bridge_on_startup_result(bool accepted, const char *metadata_json, void *user_data)
 {
     (void)user_data;
     mdebug1("https_client startup %s: %s", accepted ? "accepted" : "rejected",
             metadata_json ? metadata_json : "(no metadata)");
+
+    if (!accepted || !metadata_json) {
+        return;
+    }
+
+    cJSON *root = cJSON_Parse(metadata_json);
+    if (!root) {
+        mdebug2("https_client: startup metadata is not valid JSON; module limits and "
+                "cluster identity are unchanged.");
+        return;
+    }
+
+    /* #37830 "In scope": apply module limits into the existing exposure paths
+     * (agent_module_limits, read by FIM/syscollector/SCA the same way the
+     * legacy handshake feeds them) and reload under <auto_restart> only when
+     * the limits actually changed -- mirrors start_agent.c's
+     * agent_handshake_to_server() (previous_limits snapshot + module_limits_changed()),
+     * not an unconditional reload on every accepted startup. */
+    module_limits_t previous_limits = agent_module_limits;
+
+    if (bridge_parse_limits(root, &agent_module_limits)) {
+        mdebug1("https_client: module limits received from manager.");
+
+        if (previous_limits.limits_received && module_limits_changed(&previous_limits, &agent_module_limits)) {
+            if (agt->flags.auto_restart) {
+                minfo("https_client: reloading due to module limits changes.");
+                reloadAgent();
+            } else {
+                mdebug1("https_client: module limits have been updated.");
+            }
+        }
+    } else {
+        mdebug2("https_client: no valid 'limits' object in the startup response; "
+                "module limits are unchanged.");
+    }
+
+    bridge_apply_cluster_identity(root);
+    bridge_apply_agent_groups(root);
+
+    cJSON_Delete(root);
 }
 
 static void bridge_on_reenroll_required(void *user_data)
@@ -223,56 +427,155 @@ static void bridge_on_task(const char *task_id, const char *task_type, const cha
 }
 
 /* The startup hash gate (client-agent/src/startup_gate.c) holds syscheckd and
- * the other modules until the manager-validated configuration is in place. Its
- * only feed was the legacy TCP handshake (start_agent.c calls
- * startup_gate_process_handshake with the merged_sum the manager pushes there),
- * so an agent whose transport is HTTPS never got an expected hash and the gate
- * stayed at "waiting_handshake" forever, blocking module startup on Linux and
- * Windows alike.
- *
- * The module reports the manager's hash on every Notify, matching or not, which
- * covers both cases through the gate's existing logic: an agent already in sync
- * releases immediately on the hash match, and one that diverges keeps waiting
- * until /download lands the new configuration and the apply path refreshes it. */
+ * the other modules until the manager-validated configuration is in place.
+ * Fired on every accepted Notify (whether or not it triggers a download), so
+ * an agent that boots already in sync with the manager -- no download, no
+ * reload, nothing else to hook a release off -- still releases the gate via
+ * a direct SHA-256 comparison against the local merged.mg
+ * (startup_gate_check_manager_config_hash(), which owns the real digest math;
+ * this callback only forwards). */
 static void bridge_on_manager_config_hash(const char *config_hash, void *user_data)
 {
     (void)user_data;
-
-    /* Only an MD5-shaped hash may reach the gate. It validates against
-     * getsharedfiles(), which is OS_MD5_File over merged.mg, and it reacts to
-     * anything else by latching itself blocked on "invalid_handshake_hash",
-     * which its own comment says needs an agentd restart to clear. The module
-     * verifies downloaded configs with sha256 instead, so until the manager
-     * side settles which digest /control reports (no endpoint exists yet), a
-     * mismatched shape must leave the gate exactly as it was rather than
-     * wedge it. */
-    if (config_hash == NULL || strlen(config_hash) != 32) {
-        mdebug2("https_client: manager config hash '%s' is not the MD5 shape the startup "
-                "gate validates; leaving the gate untouched.",
-                config_hash && config_hash[0] ? config_hash : "(none)");
-        return;
-    }
-
-    startup_gate_process_handshake(true, config_hash);
+    startup_gate_check_manager_config_hash(config_hash);
 }
 
+/* Applies a downloaded merged configuration and releases the startup gate.
+ *
+ * file_path is a module-owned temp file valid ONLY until the callback that
+ * received it returns (the module deletes it right after) -- so the very
+ * first thing this does is copy it into SHAREDCFG_FILE.
+ *
+ * Mirrors the legacy apply chain (client-agent/src/receiver.c's FILE_CLOSE_HEADER
+ * handling: UnmergeFiles -> cldir_ex_ignore -> verifyRemoteConf -> reloadAgent),
+ * reusing the exact same shared-code calls, including receiver.c's own
+ * anti-race sequencing between reloadAgent() and the gate release (see its
+ * "the reload chain ... is the normal release path" comment): if
+ * reloadAgent() actually dispatches, the gate is deliberately NOT released
+ * here -- releasing it unconditionally could let a module still blocked in
+ * startup_gate_wait_for_ready() unblock and start a moment before the reload
+ * chain (modulesd CONTROL_SOCK -> wazuh-control reload -> SIGUSR1) restarts
+ * it anyway. client-agent/src/agentd.c's own SIGUSR1 handling
+ * (needs_config_reload) calls startup_gate_release_from_https_apply()
+ * once that restart has actually happened -- this is the transport-agnostic
+ * release path for the common case.
+ *
+ * The one deliberate difference from receiver.c: the HTTPS /control contract
+ * has no merged_sum handshake field (#37733), so there is no later handshake
+ * retry to lean on if reloadAgent() cannot even dispatch (control socket
+ * unreachable). receiver.c's own fallback ("release inline only if
+ * reloadAgent() fails") is mirrored exactly below for that case -- see the
+ * reload/gate block near the end of this function, and
+ * startup_gate_release_from_https_apply()'s own comment for why that inline
+ * release is safe even without the legacy MD5 comparison.
+ */
 static void bridge_on_config_downloaded(const char *config_hash, const char *file_path,
                                         void *user_data)
 {
-    /* Production hookup (later integration workstream): copy the file inside
-     * this callback (the module deletes it right after), then run the legacy
-     * apply chain -- write SHAREDCFG_DIR/merged.mg, UnmergeFiles(), verify
-     * with getsharedfiles(), reloadAgent() under auto_restart (receiver.c /
-     * reload_agent.c) -- and call hc_set_config_hash() if the applied hash
-     * diverges. The dev scaffold only logs the delivery. */
     (void)user_data;
+
+    /* Callback-safe per https_client.h's own doc; read without the lock like
+     * bridge_on_reenroll_required's w_create_thread(..., g_https_client, ...)
+     * already does -- a callback cannot be running concurrently with the
+     * hc_destroy() that would invalidate this pointer. */
+    hc_handle *handle = g_https_client;
+
     mdebug1("https_client config downloaded (hash=%s, file=%s)",
             config_hash ? config_hash : "?", file_path ? file_path : "?");
 
-    /* Re-check the gate once the configuration has been applied. Harmless
-     * today, when the apply chain above is still a scaffold and the local hash
-     * has not moved: the gate simply stays blocked until it has. */
-    startup_gate_refresh_from_local_hash();
+    if (!file_path || !file_path[0]) {
+        merror("https_client: config downloaded callback fired without a file path; nothing to apply.");
+        return;
+    }
+
+    /* Binary mode ('b'): the module already SHA-256-verified these exact
+     * bytes against the manager's config_hash before this callback fired
+     * (configFetcher.cpp). A text-mode copy on Windows would silently
+     * rewrite '\n' as '\r\n', corrupting the file relative to what the hash
+     * was computed over -- the SHA-256 recomputed from SHAREDCFG_FILE on the
+     * next fresh instance (bridge_build_config()) would then never match the
+     * manager's hash, forcing an endless re-download/reload loop (observed
+     * as a real, Windows-only regression during #37831 real-package
+     * validation, 2026-07-28). */
+    if (w_copy_file(file_path, SHAREDCFG_FILE, 'b', NULL, 0) != 0) {
+        merror("https_client: could not copy the downloaded configuration into '%s'; "
+               "keeping the previously applied one.", SHAREDCFG_FILE);
+        if (handle) {
+            /* What's actually on disk is still the old config, not config_hash:
+             * correct the module's optimistic view so the next Notify mismatch
+             * re-triggers the download instead of assuming we are in sync. */
+            hc_set_config_hash(handle, "");
+        }
+        return;
+    }
+
+    char **ignore_list;
+    os_calloc(2, sizeof(char *), ignore_list);
+    os_strdup(SHAREDCFG_FILENAME, *ignore_list);
+
+    if (!UnmergeFiles(SHAREDCFG_FILE, SHAREDCFG_DIR, OS_TEXT, &ignore_list)) {
+        merror("https_client: failed to unmerge the downloaded configuration "
+               "('%s'); keeping the previously applied files.", SHAREDCFG_FILE);
+        /* Manager-visible report, mirroring receiver.c's own AG_IN_UNMERGE event
+         * on the same failure. */
+        char unmerge_fail_msg[OS_MAXSTR];
+        snprintf(unmerge_fail_msg, OS_MAXSTR, "%c:%s:%s", LOCALFILE_MQ, "wazuh-agent", AG_IN_UNMERGE);
+        send_msg(unmerge_fail_msg, -1);
+        free_strarray(ignore_list);
+        if (handle) {
+            hc_set_config_hash(handle, "");
+        }
+        return;
+    }
+
+    if (cldir_ex_ignore(SHAREDCFG_DIR, (const char **)ignore_list)) {
+        mwarn("https_client: could not clean up the shared configuration directory.");
+    }
+    free_strarray(ignore_list);
+
+    if (!agt->flags.remote_conf) {
+        /* Mirrors receiver.c: the files are staged either way, but nothing
+         * reloads or gates on remote configuration when the agent has opted
+         * out of it. */
+        return;
+    }
+
+    if (verifyRemoteConf()) {
+        /* Invalid remote configuration: verifyRemoteConf() already reported it
+         * to the manager (AG_IN_RCON). Do not reload or release the gate with
+         * a configuration known to be broken -- mirrors receiver.c, which
+         * skips its own reload/gate block on the same check. */
+        merror("https_client: downloaded configuration failed validation; not reloading.");
+        return;
+    }
+
+    minfo("https_client: applying configuration downloaded over HTTPS (hash=%s).",
+          config_hash ? config_hash : "?");
+
+    /* Anti-race sequencing, mirroring receiver.c's own FILE_CLOSE_HEADER
+     * handling (see its "the reload chain ... is the normal release path"
+     * comment): if reloadAgent() actually dispatches, do NOT release the gate
+     * here. Doing so unconditionally could let a module still blocked in
+     * startup_gate_wait_for_ready() unblock and start a moment before the
+     * reload chain (modulesd CONTROL_SOCK -> wazuh-control reload -> SIGUSR1)
+     * restarts it anyway -- the exact "briefly start with the new config and
+     * then get killed" race receiver.c was written to avoid. agentd.c's own
+     * SIGUSR1 handling (needs_config_reload) already calls
+     * startup_gate_release_from_https_apply() once that restart has actually
+     * happened.
+     *
+     * Only release inline here as a fallback when reloadAgent() itself could
+     * not even dispatch (control socket unreachable) -- no SIGUSR1 will ever
+     * arrive to do it later in that case, so the gate would otherwise stay
+     * stuck. This is also, concretely, the fresh-install/first-boot case:
+     * modulesd/monitoring processes are still blocked in their very first
+     * startup_gate_wait_for_ready() call and have no prior instance to
+     * restart, so there is nothing to race against. */
+    if (!reloadAgent()) {
+        mdebug1("https_client: could not dispatch the reload chain; releasing "
+                "the startup gate directly instead (no restart will arrive to do it).");
+        startup_gate_release_from_https_apply();
+    }
 }
 
 static void bridge_on_state_change(int state, void *user_data)
@@ -280,6 +583,21 @@ static void bridge_on_state_change(int state, void *user_data)
     (void)user_data;
     mdebug1("https_client connection state -> %d", state);
     w_agentd_state_update(UPDATE_STATUS, (void *)bridge_map_agent_status(state));
+
+    /* Interim fix for the WAIT_FILE/os_setwait() producer lock (armed
+     * unconditionally at agent startup, see agentd.c's AgentdStart()): it is
+     * otherwise only ever cleared by a successful LEGACY plaintext handshake,
+     * which permanently blocks every module's SendMSG/SendBinaryMSG against a
+     * pure-HTTPS manager even though /control is fully connected and healthy.
+     * A successful HTTPS registration is the equivalent "the manager
+     * acknowledged us" signal, so clear the lock here too. os_delwait() is
+     * idempotent (unlink() on an already-absent WAIT_FILE is a harmless
+     * no-op, and __wait_lock is just reset to 0), so it is safe to call
+     * unconditionally on every REGISTERED transition, including a later one
+     * after a reconnect. */
+    if (state == HC_STATE_REGISTERED) {
+        os_delwait();
+    }
 }
 
 /* Occupancy thresholds the module reports against, kept so the log lines can
@@ -295,9 +613,7 @@ static int g_buffer_normal_level = 70;
  *
  * The state event bypasses the accumulator -- send_buffer_status_event() writes
  * straight to send_msg() -- exactly as buffer.c bypassed the ring it reports
- * on. A flood report must not queue behind the flood it is reporting. That
- * keeps it on the legacy socket for now; it moves with every other stateless
- * producer when the TCP path is retired. */
+ * on. A flood report must not queue behind the flood it is reporting. */
 static void bridge_on_buffer_level(int level, void *user_data)
 {
     (void)user_data;
@@ -438,10 +754,39 @@ static bool bridge_build_config(hc_config_t *config)
     config->buffer_normal_level = (uint32_t)g_buffer_normal_level;
     config->buffer_flood_tolerance_s = (uint32_t)getDefine_Int("agent", "tolerance", 0, 600);
 
-    char *checksum = getsharedfiles();
-    if (checksum) {
-        strncpy(config->config_checksum, checksum, sizeof(config->config_checksum) - 1);
-        os_free(checksum);
+    /* Bug found during real-package validation of #37831 (2026-07-28): this used to be
+     * getsharedfiles() (client-agent/src/notify.c), which is an MD5 (OS_MD5_File) -- the legacy
+     * merged_sum format. config->config_checksum seeds ConfigHashState's initial value
+     * (httpsClientFacade.cpp: m_configHash(m_config.configChecksum)), which is compared
+     * byte-for-byte against the manager-reported agent.config_hash on every Notify
+     * (controlStream.cpp's maybeDownloadConfig()) -- and that value is a SHA-256 ("SHA256 hash
+     * of group configuration", #37733 OpenAPI; confirmed against configFetcher.cpp/digest.hpp,
+     * which verify downloads the same way). An MD5 hex string can never equal a SHA-256 hex
+     * string, so seeding this from the MD5 guaranteed a mismatch on literally every comparison
+     * against this seed, not just the first one -- and while the module's own optimistic
+     * ConfigHashState::set() after a successful download corrects this in memory for the
+     * lifetime of one https_client instance, this seed is what a FRESH instance starts from
+     * every time one is created. On a platform where a config-triggered reload actually restarts
+     * the whole agent process (observed as a real, repeated infinite-restart regression on
+     * Windows during validation -- Linux's wazuh-control reload explicitly excludes wazuh-agentd
+     * from the daemons it restarts, but that exclusion is not guaranteed on every platform/path),
+     * every fresh instance reseeds from this same permanently-mismatching MD5 value, so every
+     * Notify after every restart looks like "config changed" again, forever, even though the
+     * on-disk config never actually changed after the first real download.
+     *
+     * Fixed by seeding from a SHA-256 of the same file instead, computed the same way the module
+     * itself verifies a download (raw bytes, no text-mode newline translation -- OS_BINARY, not
+     * OS_TEXT, matching digest.cpp's std::fopen(path, "rb")): once a real download has actually
+     * landed the correct bytes on disk, a freshly (re)computed local hash now compares in the
+     * SAME hash space the manager uses, so it can actually match and stop forcing a redundant
+     * re-download/reload every Notify cycle. A missing/unreadable local merged.mg still seeds an
+     * empty checksum (OS_SHA256_File's own failure path; config_checksum was already
+     * zero-filled by this function's memset above), which still can never equal a real
+     * manager-advertised hash -- preserving the original, correct first-boot behavior (force
+     * exactly one bootstrap download when there is nothing meaningful on disk yet). */
+    os_sha256 config_sha256;
+    if (OS_SHA256_File(SHAREDCFG_FILE, config_sha256, OS_BINARY) == 0) {
+        strncpy(config->config_checksum, config_sha256, sizeof(config->config_checksum) - 1);
     }
 
     return true;

--- a/src/client-agent/src/start_agent.c
+++ b/src/client-agent/src/start_agent.c
@@ -437,6 +437,7 @@ void start_agent(int is_startup)
         w_agentd_keys_init();
     }
 
+    /* legacy tcp connection removed
     int current_server_id = agt->rip_id;
     while (1) {
         // (max_retries - 1) attempts
@@ -467,10 +468,10 @@ void start_agent(int is_startup)
 
         sleep(agt->server[current_server_id].retry_interval);
 
-        /* Wait for server reply */
+        // Wait for server reply
         mwarn(AG_WAIT_SERVER, agt->server[current_server_id].rip, __wazuh_version);
 
-        /* If there is a next server, try it */
+        // If there is a next server, try it
         if (agt->server[current_server_id + 1].rip) {
             current_server_id++;
             mdebug1("Trying next server ip in the line: '%s'.", agt->server[current_server_id].rip);
@@ -479,6 +480,8 @@ void start_agent(int is_startup)
             mwarn("Unable to connect to any server.");
         }
     }
+    */
+   return;
 }
 
 /**

--- a/src/client-agent/src/startup_gate.c
+++ b/src/client-agent/src/startup_gate.c
@@ -11,6 +11,7 @@
 #include "shared.h"
 #include "agentd.h"
 #include "../os_crypto/md5/md5_op.h"
+#include "sha256_op.h"
 #include <ctype.h>
 
 static pthread_mutex_t startup_gate_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -151,6 +152,69 @@ void startup_gate_refresh_from_local_hash(void) {
         w_mutex_lock(&startup_gate_mutex);
         startup_gate_set_locked(true, "hash_match");
         w_mutex_unlock(&startup_gate_mutex);
+    }
+}
+
+void startup_gate_release_from_https_apply(void) {
+    // The HTTPS /control contract (#37733) has no merged_sum handshake field
+    // to seed startup_gate_expected_sum with (unlike the legacy handshake), so
+    // startup_gate_refresh_from_local_hash()'s MD5-comparison machinery is
+    // structurally unusable here: it only ever does anything once
+    // startup_gate_process_handshake() has already set an expected value, and
+    // that function is legacy-only. Worse, the two sides would compare
+    // different hash algorithms anyway -- the HTTPS config_hash is a SHA-256
+    // ("SHA256 hash of group configuration", #37733 OpenAPI), while
+    // getsharedfiles()/startup_gate_expected_sum are MD5 -- so even seeding
+    // expected_sum with config_hash could never produce a real match.
+    //
+    // The HTTPS /download client (configFetcher.cpp) already verifies the
+    // downloaded bytes' SHA-256 against the manager-advertised config_hash
+    // BEFORE handing the file to the C side at all (see hc_callbacks_t's
+    // on_config_downloaded doc). By the time bridge_on_config_downloaded()
+    // calls this function, it has itself written those exact verified bytes
+    // to SHAREDCFG_FILE and applied them (UnmergeFiles + verifyRemoteConf).
+    // That is the same real-world invariant the legacy MD5 comparison exists
+    // to establish ("the config on disk is the one the manager just gave
+    // us"), just reached via a different, HTTPS-native verification path --
+    // so it is safe to open the gate directly here instead of going through
+    // the (inapplicable) MD5 matching helpers.
+    w_mutex_lock(&startup_gate_mutex);
+
+    if (startup_gate_enabled && !startup_gate_ready) {
+        startup_gate_set_locked(true, "https_config_applied");
+        w_mutex_unlock(&startup_gate_mutex);
+        mdebug1("Startup hash gate released via HTTPS configuration apply (https_config_applied).");
+        return;
+    }
+
+    w_mutex_unlock(&startup_gate_mutex);
+}
+
+void startup_gate_check_manager_config_hash(const char *manager_sha256) {
+    bool should_check = false;
+    os_sha256 local_sha256;
+
+    if (!manager_sha256 || !manager_sha256[0]) {
+        return;
+    }
+
+    w_mutex_lock(&startup_gate_mutex);
+    should_check = startup_gate_enabled && !startup_gate_ready;
+    w_mutex_unlock(&startup_gate_mutex);
+
+    if (!should_check) {
+        return;
+    }
+
+    if (OS_SHA256_File(SHAREDCFG_FILE, local_sha256, OS_BINARY) != 0) {
+        return; // No local merged.mg yet (nothing downloaded so far): nothing to compare.
+    }
+
+    if (strcmp(local_sha256, manager_sha256) == 0) {
+        w_mutex_lock(&startup_gate_mutex);
+        startup_gate_set_locked(true, "https_hash_match");
+        w_mutex_unlock(&startup_gate_mutex);
+        mdebug1("Startup hash gate: manager config hash (SHA-256) matches local, gate released.");
     }
 }
 

--- a/src/shared/include/file_op.h
+++ b/src/shared/include/file_op.h
@@ -324,7 +324,10 @@ int OS_MoveFile(const char *src, const char *dst);
  *
  * @param src Source path.
  * @param dst Destination path.
- * @param mode Mode: `a` to append, `w` to write.
+ * @param mode Mode: `a` to append (text), `w` to write (text), `b` to write in
+ * binary mode (exact byte copy -- required on Windows whenever the copied
+ * content's exact bytes matter downstream, e.g. a hash computed over it;
+ * text mode there silently rewrites `\n` as `\r\n`).
  * @param message Write message to the destination file.
  * @param silent Do not show errors.
  * @return 0 on success and -1 on error.

--- a/src/shared/src/file_op.c
+++ b/src/shared/src/file_op.c
@@ -2085,7 +2085,13 @@ int w_copy_file(const char *src, const char *dst, char mode, char * message, int
     char buffer[4096];
     int status = 0;
 
-    fp_src = wfopen(src, "r");
+    /* 'b': exact binary copy -- wfopen() defaults to _O_TEXT on Windows unless
+     * 'b' is in the mode string, which silently rewrites every bare '\n' as
+     * '\r\n' on write (and the reverse on read). A caller copying content
+     * whose exact bytes matter downstream (e.g. a hash computed over it) must
+     * request binary mode explicitly; text mode and binary mode are
+     * equivalent on non-Windows, so this only changes Windows behavior. */
+    fp_src = wfopen(src, mode == 'b' ? "rb" : "r");
 
     if (!fp_src) {
         if(!silent) {
@@ -2097,6 +2103,9 @@ int w_copy_file(const char *src, const char *dst, char mode, char * message, int
     /* Append to file */
     if (mode == 'a') {
         fp_dst = wfopen(dst, "a");
+    }
+    else if (mode == 'b') {
+        fp_dst = wfopen(dst, "wb");
     }
     else {
         fp_dst = wfopen(dst, "w");

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -133,9 +133,15 @@ list(APPEND client-agent_names "test_https_client_bridge")
 list(APPEND client-agent_flags "-Wl,--wrap,wurl_free_response -Wl,--wrap,wurl_http_request \
                                 -Wl,--wrap,hc_create -Wl,--wrap,hc_start -Wl,--wrap,hc_destroy \
                                 -Wl,--wrap,hc_set_agent_key -Wl,--wrap,hc_submit_event \
+                                -Wl,--wrap,hc_set_config_hash \
                                 -Wl,--wrap,try_enroll_to_server \
                                 -Wl,--wrap,CreateThread -Wl,--wrap,sleep -Wl,--wrap,getpid \
                                 -Wl,--wrap,w_agentd_state_update -Wl,--wrap,getDefine_Int \
+                                -Wl,--wrap,w_copy_file -Wl,--wrap,UnmergeFiles -Wl,--wrap,cldir_ex_ignore \
+                                -Wl,--wrap,wfopen \
+                                -Wl,--wrap,verifyRemoteConf -Wl,--wrap,reloadAgent -Wl,--wrap,send_msg \
+                                -Wl,--wrap,startup_gate_release_from_https_apply -Wl,--wrap,os_delwait \
+                                -Wl,--wrap,OS_SHA256_File \
                                 ${DEBUG_OP_WRAPPERS}")
 endif()
 

--- a/src/unit_tests/client-agent/test_https_client_bridge.c
+++ b/src/unit_tests/client-agent/test_https_client_bridge.c
@@ -18,6 +18,8 @@
 #include "https_client_bridge.h"
 #include "https_client.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+#include "../wrappers/wazuh/shared/file_op_wrappers.h"
+#include "sha256_op.h"
 
 /* hc_create/hc_start/hc_destroy mocks (no pre-existing wrapper for this ABI):
  * hc_create captures both the config and the callback table it was given, so
@@ -58,6 +60,13 @@ bool __wrap_hc_set_agent_key(hc_handle *handle, const char *key_hex)
     return mock();
 }
 
+bool __wrap_hc_set_config_hash(hc_handle *handle, const char *config_hash)
+{
+    check_expected_ptr(handle);
+    check_expected(config_hash);
+    return mock();
+}
+
 bool __wrap_hc_submit_event(hc_handle *handle, const uint8_t *frame, size_t length)
 {
     check_expected_ptr(handle);
@@ -77,6 +86,60 @@ void __wrap_w_agentd_state_update(w_agentd_state_update_t type, void *data)
 {
     check_expected(type);
     check_expected(data);
+}
+
+/* bridge_on_config_downloaded's apply chain (M1/finding 1): no pre-existing
+ * wrapper for these two ABIs either (unlike w_copy_file/UnmergeFiles/
+ * cldir_ex_ignore below, which reuse the shared wrappers already used by
+ * remoted/test_manager.c and wazuh_modules/agent_upgrade). */
+int __wrap_verifyRemoteConf(void)
+{
+    return mock();
+}
+
+bool __wrap_reloadAgent(void)
+{
+    return mock();
+}
+
+void __wrap_startup_gate_release_from_https_apply(void)
+{
+    function_called();
+}
+
+/* Finding 2 (WAIT_FILE/os_setwait): no pre-existing wrapper for this ABI. */
+void __wrap_os_delwait(void)
+{
+    function_called();
+}
+
+/* Bug 2 fix (real-package validation, 2026-07-28): config_checksum's seed must be a SHA-256 of
+ * SHAREDCFG_FILE (matching the module's own ConfigHashState/manager config_hash comparison
+ * space), not the legacy MD5 getsharedfiles() used to seed it with. No pre-existing wrapper for
+ * this ABI either. */
+int __wrap_OS_SHA256_File(const char *fname, os_sha256 output, int mode)
+{
+    check_expected(fname);
+    check_expected(mode);
+
+    const char *hash = mock_ptr_type(const char *);
+    if (!hash) {
+        return -1;
+    }
+
+    strncpy(output, hash, sizeof(os_sha256) - 1);
+    output[sizeof(os_sha256) - 1] = '\0';
+    return 0;
+}
+
+/* AG_IN_UNMERGE manager-visible report on unmerge failure: no shared wrapper
+ * for this ABI either (test_start_agent.c/test_manager.c each define their
+ * own local one the same way, since send_msg lives in client-agent/src/sendmsg.c). */
+int __wrap_send_msg(const char *msg, ssize_t msg_length)
+{
+    check_expected(msg);
+    (void)msg_length;
+    return 0;
 }
 
 /* bridge_build_config() reads the client-buffer occupancy options exactly as
@@ -161,6 +224,13 @@ static int setup_test(void **state)
      * individual tests override this to exercise the rejection paths. */
     set_agent_key("001", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
 
+    /* Process-wide globals bridge_on_startup_result writes into (finding 1b,
+     * config.c): reset every test so none leaks state into the next one. */
+    memset(&agent_module_limits, 0, sizeof(agent_module_limits));
+    agent_cluster_name[0] = '\0';
+    agent_cluster_node[0] = '\0';
+    agent_agent_groups[0] = '\0';
+
     return 0;
 }
 
@@ -210,6 +280,9 @@ static void test_full_verify_mode_and_ca_reach_the_module(void **state)
     agt->ssl.verification_mode = AGENT_VERIFY_FULL;
 
     expect_string(__wrap__minfo, formatted_msg, "https_client: starting.");
+    expect_string(__wrap_OS_SHA256_File, fname, SHAREDCFG_FILE);
+    expect_value(__wrap_OS_SHA256_File, mode, OS_BINARY);
+    will_return(__wrap_OS_SHA256_File, NULL);
     expect_any(__wrap_hc_create, callbacks);
     will_return(__wrap_hc_create, FAKE_HANDLE);
     expect_value(__wrap_hc_start, handle, FAKE_HANDLE);
@@ -234,6 +307,9 @@ static void test_certificate_verify_mode_maps_to_hc_verify_cert(void **state)
     agt->ssl.verification_mode = AGENT_VERIFY_CERT;
 
     expect_string(__wrap__minfo, formatted_msg, "https_client: starting.");
+    expect_string(__wrap_OS_SHA256_File, fname, SHAREDCFG_FILE);
+    expect_value(__wrap_OS_SHA256_File, mode, OS_BINARY);
+    will_return(__wrap_OS_SHA256_File, NULL);
     expect_any(__wrap_hc_create, callbacks);
     will_return(__wrap_hc_create, FAKE_HANDLE);
     expect_value(__wrap_hc_start, handle, FAKE_HANDLE);
@@ -253,6 +329,9 @@ static void test_none_verify_mode_maps_to_hc_verify_none(void **state)
     agt->ssl.verification_mode = AGENT_VERIFY_NONE;
 
     expect_string(__wrap__minfo, formatted_msg, "https_client: starting.");
+    expect_string(__wrap_OS_SHA256_File, fname, SHAREDCFG_FILE);
+    expect_value(__wrap_OS_SHA256_File, mode, OS_BINARY);
+    will_return(__wrap_OS_SHA256_File, NULL);
     expect_any(__wrap_hc_create, callbacks);
     will_return(__wrap_hc_create, FAKE_HANDLE);
     expect_value(__wrap_hc_start, handle, FAKE_HANDLE);
@@ -274,6 +353,9 @@ static void test_client_cert_key_and_ciphers_are_copied(void **state)
     os_strdup("HIGH:!aNULL", agt->ssl.ciphers);
 
     expect_string(__wrap__minfo, formatted_msg, "https_client: starting.");
+    expect_string(__wrap_OS_SHA256_File, fname, SHAREDCFG_FILE);
+    expect_value(__wrap_OS_SHA256_File, mode, OS_BINARY);
+    will_return(__wrap_OS_SHA256_File, NULL);
     expect_any(__wrap_hc_create, callbacks);
     will_return(__wrap_hc_create, FAKE_HANDLE);
     expect_value(__wrap_hc_start, handle, FAKE_HANDLE);
@@ -285,6 +367,50 @@ static void test_client_cert_key_and_ciphers_are_copied(void **state)
     assert_string_equal(g_captured_config.client_cert, "/etc/wazuh/agent.pem");
     assert_string_equal(g_captured_config.client_key, "/etc/wazuh/agent.key");
     assert_string_equal(g_captured_config.ciphers, "HIGH:!aNULL");
+
+    w_https_client_stop();
+}
+
+static void test_config_checksum_is_sha256_of_local_merged_file(void **state)
+{
+    (void)state;
+    static const char *const SOME_SHA256 =
+        "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08";
+
+    expect_string(__wrap__minfo, formatted_msg, "https_client: starting.");
+    expect_string(__wrap_OS_SHA256_File, fname, SHAREDCFG_FILE);
+    expect_value(__wrap_OS_SHA256_File, mode, OS_BINARY);
+    will_return(__wrap_OS_SHA256_File, SOME_SHA256);
+    expect_any(__wrap_hc_create, callbacks);
+    will_return(__wrap_hc_create, FAKE_HANDLE);
+    expect_value(__wrap_hc_start, handle, FAKE_HANDLE);
+    will_return(__wrap_hc_start, true);
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+
+    w_https_client_start();
+
+    assert_string_equal(g_captured_config.config_checksum, SOME_SHA256);
+
+    w_https_client_stop();
+}
+
+static void test_config_checksum_is_empty_when_local_file_unreadable(void **state)
+{
+    (void)state;
+
+    expect_string(__wrap__minfo, formatted_msg, "https_client: starting.");
+    expect_string(__wrap_OS_SHA256_File, fname, SHAREDCFG_FILE);
+    expect_value(__wrap_OS_SHA256_File, mode, OS_BINARY);
+    will_return(__wrap_OS_SHA256_File, NULL); /* Simulates OS_SHA256_File's -1 (unreadable). */
+    expect_any(__wrap_hc_create, callbacks);
+    will_return(__wrap_hc_create, FAKE_HANDLE);
+    expect_value(__wrap_hc_start, handle, FAKE_HANDLE);
+    will_return(__wrap_hc_start, true);
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+
+    w_https_client_start();
+
+    assert_string_equal(g_captured_config.config_checksum, "");
 
     w_https_client_stop();
 }
@@ -343,6 +469,9 @@ static void test_valid_48_char_key_is_accepted(void **state)
     os_strdup("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", keys.keyentries[0]->raw_key); /* 48 hex chars */
 
     expect_string(__wrap__minfo, formatted_msg, "https_client: starting.");
+    expect_string(__wrap_OS_SHA256_File, fname, SHAREDCFG_FILE);
+    expect_value(__wrap_OS_SHA256_File, mode, OS_BINARY);
+    will_return(__wrap_OS_SHA256_File, NULL);
     expect_any(__wrap_hc_create, callbacks);
     will_return(__wrap_hc_create, FAKE_HANDLE);
     expect_value(__wrap_hc_start, handle, FAKE_HANDLE);
@@ -363,6 +492,9 @@ static void test_hc_create_failure_is_logged(void **state)
 {
     (void)state;
     expect_string(__wrap__minfo, formatted_msg, "https_client: starting.");
+    expect_string(__wrap_OS_SHA256_File, fname, SHAREDCFG_FILE);
+    expect_value(__wrap_OS_SHA256_File, mode, OS_BINARY);
+    will_return(__wrap_OS_SHA256_File, NULL);
     expect_any(__wrap_hc_create, callbacks);
     will_return(__wrap_hc_create, NULL);
     expect_string(__wrap__merror, formatted_msg, "https_client: failed to create the client instance.");
@@ -375,6 +507,9 @@ static void test_hc_start_failure_destroys_and_logs(void **state)
 {
     (void)state;
     expect_string(__wrap__minfo, formatted_msg, "https_client: starting.");
+    expect_string(__wrap_OS_SHA256_File, fname, SHAREDCFG_FILE);
+    expect_value(__wrap_OS_SHA256_File, mode, OS_BINARY);
+    will_return(__wrap_OS_SHA256_File, NULL);
     expect_any(__wrap_hc_create, callbacks);
     will_return(__wrap_hc_create, FAKE_HANDLE);
     expect_value(__wrap_hc_start, handle, FAKE_HANDLE);
@@ -392,6 +527,9 @@ static void test_hc_start_failure_destroys_and_logs(void **state)
 static void start_client_successfully(void)
 {
     expect_string(__wrap__minfo, formatted_msg, "https_client: starting.");
+    expect_string(__wrap_OS_SHA256_File, fname, SHAREDCFG_FILE);
+    expect_value(__wrap_OS_SHA256_File, mode, OS_BINARY);
+    will_return(__wrap_OS_SHA256_File, NULL);
     expect_any(__wrap_hc_create, callbacks);
     will_return(__wrap_hc_create, FAKE_HANDLE);
     expect_value(__wrap_hc_start, handle, FAKE_HANDLE);
@@ -541,6 +679,8 @@ static void test_reenroll_thread_logs_error_when_new_key_fails_validation(void *
 /* on_state_change -> .state (M7 partial): exercised through the real
  * callback, like the reenroll spawn-decision tests above. */
 
+/* Finding 2: a REGISTERED transition must clear the WAIT_FILE/os_setwait()
+ * producer lock too (the interim fix for it never releasing over HTTPS). */
 static void test_registered_state_maps_to_active(void **state)
 {
     (void)state;
@@ -549,7 +689,31 @@ static void test_registered_state_maps_to_active(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "https_client connection state -> 2");
     expect_value(__wrap_w_agentd_state_update, type, UPDATE_STATUS);
     expect_value(__wrap_w_agentd_state_update, data, GA_STATUS_ACTIVE);
+    expect_function_call(__wrap_os_delwait);
 
+    g_captured_callbacks.on_state_change(HC_STATE_REGISTERED, g_captured_callbacks.user_data);
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+/* A REGISTERED transition after a reconnect must clear the lock again:
+ * os_delwait() is idempotent, so this is wired unconditionally, not once. */
+static void test_registered_state_twice_clears_wait_file_each_time(void **state)
+{
+    (void)state;
+    start_client_successfully();
+
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client connection state -> 2");
+    expect_value(__wrap_w_agentd_state_update, type, UPDATE_STATUS);
+    expect_value(__wrap_w_agentd_state_update, data, GA_STATUS_ACTIVE);
+    expect_function_call(__wrap_os_delwait);
+    g_captured_callbacks.on_state_change(HC_STATE_REGISTERED, g_captured_callbacks.user_data);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client connection state -> 2");
+    expect_value(__wrap_w_agentd_state_update, type, UPDATE_STATUS);
+    expect_value(__wrap_w_agentd_state_update, data, GA_STATUS_ACTIVE);
+    expect_function_call(__wrap_os_delwait);
     g_captured_callbacks.on_state_change(HC_STATE_REGISTERED, g_captured_callbacks.user_data);
 
     expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
@@ -689,6 +853,436 @@ static void test_auth_error_state_maps_to_nactive(void **state)
     w_https_client_stop();
 }
 
+/* bridge_on_config_downloaded: the /download apply chain + startup_gate
+ * release (finding 1, #37832's unmet scope). */
+
+static const char *const DOWNLOAD_HASH = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b85";
+static const char *const DOWNLOAD_FILE = "/tmp/https-client-spool/download-xyz";
+
+static void expect_config_downloaded_log(const char *hash, const char *file)
+{
+    /* expect_string() keeps a reference to this buffer rather than copying
+     * it (confirmed the hard way: a local/automatic buffer here caused a
+     * stack-use-after-return once bridge_on_config_downloaded() actually ran
+     * and check_expected() dereferenced it) -- static so it outlives this
+     * call, matching the lifetime expect_string() actually needs. */
+    static char expected[256];
+    snprintf(expected, sizeof(expected), "https_client config downloaded (hash=%s, file=%s)",
+             hash ? hash : "?", file ? file : "?");
+    expect_string(__wrap__mdebug1, formatted_msg, expected);
+}
+
+static void expect_copy_unmerge_cleanup_ok(void)
+{
+    expect_string(__wrap_w_copy_file, src, DOWNLOAD_FILE);
+    expect_string(__wrap_w_copy_file, dst, SHAREDCFG_FILE);
+    expect_value(__wrap_w_copy_file, mode, 'b');
+    expect_value(__wrap_w_copy_file, silent, 0);
+    will_return(__wrap_w_copy_file, 0);
+
+    expect_string(__wrap_UnmergeFiles, finalpath, SHAREDCFG_FILE);
+    expect_string(__wrap_UnmergeFiles, optdir, SHAREDCFG_DIR);
+    expect_value(__wrap_UnmergeFiles, mode, OS_TEXT);
+    will_return(__wrap_UnmergeFiles, 1); /* UnmergeFiles: 1 = success, 0 = failure. */
+
+    expect_string(__wrap_cldir_ex_ignore, name, SHAREDCFG_DIR);
+    will_return(__wrap_cldir_ex_ignore, 0);
+}
+
+/* Anti-race sequencing (per receiver.c's own "the reload chain ... is the
+ * normal release path" comment): when reloadAgent() actually dispatches, the
+ * gate must NOT be released here -- agentd.c's own SIGUSR1 handling
+ * (needs_config_reload) releases it once the restart that reload triggers
+ * has actually happened, exactly mirroring how it already does this for the
+ * legacy path via startup_gate_refresh_from_local_hash(). Releasing inline
+ * regardless of reloadAgent()'s outcome would let a module still blocked in
+ * startup_gate_wait_for_ready() unblock and start a moment before the reload
+ * chain restarts it anyway. */
+static void test_config_downloaded_happy_path_reload_dispatched_defers_gate_to_sigusr1(void **state)
+{
+    (void)state;
+    agt->flags.remote_conf = 1;
+    start_client_successfully();
+
+    expect_config_downloaded_log(DOWNLOAD_HASH, DOWNLOAD_FILE);
+    expect_copy_unmerge_cleanup_ok();
+    will_return(__wrap_verifyRemoteConf, 0); /* valid */
+    expect_string(__wrap__minfo, formatted_msg,
+                  "https_client: applying configuration downloaded over HTTPS (hash="
+                  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b85).");
+    will_return(__wrap_reloadAgent, true);
+    /* No expect_function_call(__wrap_startup_gate_release_from_https_apply):
+     * must NOT be reached when the reload chain actually dispatched. */
+
+    g_captured_callbacks.on_config_downloaded(DOWNLOAD_HASH, DOWNLOAD_FILE, g_captured_callbacks.user_data);
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+/* Fallback: reloadAgent() could not even dispatch (control socket
+ * unreachable -- concretely, the fresh-install/first-boot case, where
+ * modulesd/monitoring processes are still blocked in their very first
+ * startup_gate_wait_for_ready() call and have no prior instance to restart).
+ * No SIGUSR1 will ever arrive to release the gate later, so this is the only
+ * release path such an agent will ever get -- release inline. */
+static void test_config_downloaded_releases_gate_when_reload_chain_unreachable(void **state)
+{
+    (void)state;
+    agt->flags.remote_conf = 1;
+    start_client_successfully();
+
+    expect_config_downloaded_log(DOWNLOAD_HASH, DOWNLOAD_FILE);
+    expect_copy_unmerge_cleanup_ok();
+    will_return(__wrap_verifyRemoteConf, 0);
+    expect_string(__wrap__minfo, formatted_msg,
+                  "https_client: applying configuration downloaded over HTTPS (hash="
+                  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b85).");
+    will_return(__wrap_reloadAgent, false); /* Control socket unreachable (e.g. first boot). */
+    expect_string(__wrap__mdebug1, formatted_msg,
+                  "https_client: could not dispatch the reload chain; releasing "
+                  "the startup gate directly instead (no restart will arrive to do it).");
+    expect_function_call(__wrap_startup_gate_release_from_https_apply);
+
+    g_captured_callbacks.on_config_downloaded(DOWNLOAD_HASH, DOWNLOAD_FILE, g_captured_callbacks.user_data);
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+static void test_config_downloaded_invalid_config_skips_reload_and_gate(void **state)
+{
+    (void)state;
+    agt->flags.remote_conf = 1;
+    start_client_successfully();
+
+    expect_config_downloaded_log(DOWNLOAD_HASH, DOWNLOAD_FILE);
+    expect_copy_unmerge_cleanup_ok();
+    will_return(__wrap_verifyRemoteConf, -1); /* invalid */
+    expect_string(__wrap__merror, formatted_msg,
+                  "https_client: downloaded configuration failed validation; not reloading.");
+    /* No reloadAgent/gate-release expectation: must not be reached. */
+
+    g_captured_callbacks.on_config_downloaded(DOWNLOAD_HASH, DOWNLOAD_FILE, g_captured_callbacks.user_data);
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+static void test_config_downloaded_remote_conf_disabled_stages_files_only(void **state)
+{
+    (void)state;
+    agt->flags.remote_conf = 0;
+    start_client_successfully();
+
+    expect_config_downloaded_log(DOWNLOAD_HASH, DOWNLOAD_FILE);
+    expect_copy_unmerge_cleanup_ok();
+    /* No verifyRemoteConf/reloadAgent/gate-release expectation: remote_conf is
+     * off, mirrors receiver.c's own guard. */
+
+    g_captured_callbacks.on_config_downloaded(DOWNLOAD_HASH, DOWNLOAD_FILE, g_captured_callbacks.user_data);
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+static void test_config_downloaded_copy_failure_corrects_module_hash(void **state)
+{
+    (void)state;
+    agt->flags.remote_conf = 1;
+    start_client_successfully();
+
+    expect_config_downloaded_log(DOWNLOAD_HASH, DOWNLOAD_FILE);
+
+    expect_string(__wrap_w_copy_file, src, DOWNLOAD_FILE);
+    expect_string(__wrap_w_copy_file, dst, SHAREDCFG_FILE);
+    expect_value(__wrap_w_copy_file, mode, 'b');
+    expect_value(__wrap_w_copy_file, silent, 0);
+    will_return(__wrap_w_copy_file, -1); /* I/O error */
+
+    expect_string(__wrap__merror, formatted_msg,
+                  "https_client: could not copy the downloaded configuration into "
+                  "'" SHAREDCFG_FILE "'; keeping the previously applied one.");
+    expect_value(__wrap_hc_set_config_hash, handle, FAKE_HANDLE);
+    expect_string(__wrap_hc_set_config_hash, config_hash, "");
+    will_return(__wrap_hc_set_config_hash, true);
+    /* No UnmergeFiles/verifyRemoteConf/reloadAgent/gate-release expectation:
+     * nothing was actually applied. */
+
+    g_captured_callbacks.on_config_downloaded(DOWNLOAD_HASH, DOWNLOAD_FILE, g_captured_callbacks.user_data);
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+static void test_config_downloaded_unmerge_failure_corrects_module_hash(void **state)
+{
+    (void)state;
+    agt->flags.remote_conf = 1;
+    start_client_successfully();
+
+    expect_config_downloaded_log(DOWNLOAD_HASH, DOWNLOAD_FILE);
+
+    expect_string(__wrap_w_copy_file, src, DOWNLOAD_FILE);
+    expect_string(__wrap_w_copy_file, dst, SHAREDCFG_FILE);
+    expect_value(__wrap_w_copy_file, mode, 'b');
+    expect_value(__wrap_w_copy_file, silent, 0);
+    will_return(__wrap_w_copy_file, 0);
+
+    expect_string(__wrap_UnmergeFiles, finalpath, SHAREDCFG_FILE);
+    expect_string(__wrap_UnmergeFiles, optdir, SHAREDCFG_DIR);
+    expect_value(__wrap_UnmergeFiles, mode, OS_TEXT);
+    will_return(__wrap_UnmergeFiles, 0); /* failure */
+
+    expect_string(__wrap__merror, formatted_msg,
+                  "https_client: failed to unmerge the downloaded configuration "
+                  "('" SHAREDCFG_FILE "'); keeping the previously applied files.");
+    /* AG_IN_UNMERGE-equivalent manager-visible report (mirrors receiver.c's
+     * own send_msg() on this exact failure). */
+    expect_string(__wrap_send_msg, msg, "1:wazuh-agent:wazuh: Could not unmerge shared file.");
+    expect_value(__wrap_hc_set_config_hash, handle, FAKE_HANDLE);
+    expect_string(__wrap_hc_set_config_hash, config_hash, "");
+    will_return(__wrap_hc_set_config_hash, true);
+    /* No cldir_ex_ignore/verifyRemoteConf/reloadAgent/gate-release expectation. */
+
+    g_captured_callbacks.on_config_downloaded(DOWNLOAD_HASH, DOWNLOAD_FILE, g_captured_callbacks.user_data);
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+static void test_config_downloaded_null_file_path_is_a_noop(void **state)
+{
+    (void)state;
+    agt->flags.remote_conf = 1;
+    start_client_successfully();
+
+    expect_config_downloaded_log(DOWNLOAD_HASH, NULL);
+    expect_string(__wrap__merror, formatted_msg,
+                  "https_client: config downloaded callback fired without a file path; nothing to apply.");
+    /* No w_copy_file expectation: must not be reached. */
+
+    g_captured_callbacks.on_config_downloaded(DOWNLOAD_HASH, NULL, g_captured_callbacks.user_data);
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+/* bridge_on_startup_result: module limits + cluster-name authority + agent
+ * groups (finding 1b, #37830's unmet "In scope" text). */
+
+#define FULL_LIMITS_JSON_FMT \
+    "{\"limits\":{\"fim\":{\"file\":%d,\"registry_key\":2,\"registry_value\":3}," \
+    "\"syscollector\":{\"hotfixes\":4,\"packages\":5,\"processes\":6,\"ports\":7," \
+    "\"network_iface\":8,\"network_protocol\":9,\"network_address\":10,\"hardware\":11," \
+    "\"os_info\":12,\"users\":13,\"groups\":14,\"services\":15,\"browser_extensions\":16}," \
+    "\"sca\":{\"checks\":17}}," \
+    "\"cluster\":{\"name\":\"demo-cluster\",\"node\":\"node01\"}," \
+    "\"agent\":{\"groups\":[\"default\",\"linux\"]}}"
+
+static void test_startup_result_rejected_does_not_touch_globals(void **state)
+{
+    (void)state;
+    strcpy(agent_cluster_name, "sentinel");
+    start_client_successfully();
+
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client startup rejected: (no metadata)");
+
+    g_captured_callbacks.on_startup_result(false, NULL, g_captured_callbacks.user_data);
+
+    assert_string_equal(agent_cluster_name, "sentinel"); /* Untouched: not accepted. */
+    assert_false(agent_module_limits.limits_received);
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+static void test_startup_result_invalid_json_logs_and_returns(void **state)
+{
+    (void)state;
+    strcpy(agent_cluster_name, "sentinel");
+    start_client_successfully();
+
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client startup accepted: not-json{");
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "https_client: startup metadata is not valid JSON; module limits and "
+                  "cluster identity are unchanged.");
+
+    g_captured_callbacks.on_startup_result(true, "not-json{", g_captured_callbacks.user_data);
+
+    assert_string_equal(agent_cluster_name, "sentinel");
+    assert_false(agent_module_limits.limits_received);
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+static void test_startup_result_first_time_applies_without_reload(void **state)
+{
+    (void)state;
+    char body[1024];
+    snprintf(body, sizeof(body), FULL_LIMITS_JSON_FMT, 100);
+    start_client_successfully();
+
+    /* Loosen the first log's exact-match: use expect_any since the raw JSON
+     * body is long and not the point of this test. */
+    expect_any(__wrap__mdebug1, formatted_msg); /* "https_client startup accepted: <json>" */
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: module limits received from manager.");
+    /* limits_received was false (fresh global): no changed-check, no reload. */
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: cluster identity -> name='demo-cluster', node='node01'.");
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: agent groups -> default,linux.");
+
+    g_captured_callbacks.on_startup_result(true, body, g_captured_callbacks.user_data);
+
+    assert_true(agent_module_limits.limits_received);
+    assert_int_equal(agent_module_limits.fim.file, 100);
+    assert_string_equal(agent_cluster_name, "demo-cluster");
+    assert_string_equal(agent_cluster_node, "node01");
+    assert_string_equal(agent_agent_groups, "default,linux");
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+static void test_startup_result_limits_changed_reloads_under_auto_restart(void **state)
+{
+    (void)state;
+    char body_v1[1024];
+    char body_v2[1024];
+    snprintf(body_v1, sizeof(body_v1), FULL_LIMITS_JSON_FMT, 100);
+    snprintf(body_v2, sizeof(body_v2), FULL_LIMITS_JSON_FMT, 200);
+    agt->flags.auto_restart = 1;
+    start_client_successfully();
+
+    expect_any(__wrap__mdebug1, formatted_msg);
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: module limits received from manager.");
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: cluster identity -> name='demo-cluster', node='node01'.");
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: agent groups -> default,linux.");
+    g_captured_callbacks.on_startup_result(true, body_v1, g_captured_callbacks.user_data); /* Establishes previous_limits. */
+
+    expect_any(__wrap__mdebug1, formatted_msg);
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: module limits received from manager.");
+    expect_string(__wrap__minfo, formatted_msg, "https_client: reloading due to module limits changes.");
+    will_return(__wrap_reloadAgent, true);
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: cluster identity -> name='demo-cluster', node='node01'.");
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: agent groups -> default,linux.");
+
+    g_captured_callbacks.on_startup_result(true, body_v2, g_captured_callbacks.user_data);
+
+    assert_int_equal(agent_module_limits.fim.file, 200);
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+static void test_startup_result_limits_changed_no_reload_without_auto_restart(void **state)
+{
+    (void)state;
+    char body_v1[1024];
+    char body_v2[1024];
+    snprintf(body_v1, sizeof(body_v1), FULL_LIMITS_JSON_FMT, 100);
+    snprintf(body_v2, sizeof(body_v2), FULL_LIMITS_JSON_FMT, 200);
+    agt->flags.auto_restart = 0;
+    start_client_successfully();
+
+    expect_any(__wrap__mdebug1, formatted_msg);
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: module limits received from manager.");
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: cluster identity -> name='demo-cluster', node='node01'.");
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: agent groups -> default,linux.");
+    g_captured_callbacks.on_startup_result(true, body_v1, g_captured_callbacks.user_data);
+
+    expect_any(__wrap__mdebug1, formatted_msg);
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: module limits received from manager.");
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: module limits have been updated.");
+    /* No reloadAgent expectation: must not be reached. */
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: cluster identity -> name='demo-cluster', node='node01'.");
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: agent groups -> default,linux.");
+
+    g_captured_callbacks.on_startup_result(true, body_v2, g_captured_callbacks.user_data);
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+static void test_startup_result_limits_unchanged_no_reload(void **state)
+{
+    (void)state;
+    char body[1024];
+    snprintf(body, sizeof(body), FULL_LIMITS_JSON_FMT, 100);
+    agt->flags.auto_restart = 1;
+    start_client_successfully();
+
+    expect_any(__wrap__mdebug1, formatted_msg);
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: module limits received from manager.");
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: cluster identity -> name='demo-cluster', node='node01'.");
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: agent groups -> default,linux.");
+    g_captured_callbacks.on_startup_result(true, body, g_captured_callbacks.user_data);
+
+    /* Same body again: module_limits_changed() must see no difference. */
+    expect_any(__wrap__mdebug1, formatted_msg);
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: module limits received from manager.");
+    /* No reload/"updated" log: unchanged skips the whole changed-branch. */
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: cluster identity -> name='demo-cluster', node='node01'.");
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: agent groups -> default,linux.");
+
+    g_captured_callbacks.on_startup_result(true, body, g_captured_callbacks.user_data);
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+static void test_startup_result_missing_limits_object_leaves_limits_unchanged(void **state)
+{
+    (void)state;
+    const char *body = "{\"cluster\":{\"name\":\"demo-cluster\",\"node\":\"node01\"},"
+                       "\"agent\":{\"groups\":[\"default\"]}}";
+    start_client_successfully();
+
+    expect_any(__wrap__mdebug1, formatted_msg);
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "https_client: no valid 'limits' object in the startup response; "
+                  "module limits are unchanged.");
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: cluster identity -> name='demo-cluster', node='node01'.");
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: agent groups -> default.");
+
+    g_captured_callbacks.on_startup_result(true, body, g_captured_callbacks.user_data);
+
+    assert_false(agent_module_limits.limits_received);
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+/* #37830's own scope: overwrite cluster/groups unconditionally, even to
+ * empty, rather than leaving a stale value when the manager omits them. */
+static void test_startup_result_cluster_and_groups_cleared_when_absent(void **state)
+{
+    (void)state;
+    strcpy(agent_cluster_name, "stale-cluster");
+    strcpy(agent_cluster_node, "stale-node");
+    strcpy(agent_agent_groups, "stale,groups");
+    start_client_successfully();
+
+    const char *body = "{}";
+
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client startup accepted: {}");
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "https_client: no valid 'limits' object in the startup response; "
+                  "module limits are unchanged.");
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: cluster identity -> name='', node=''.");
+    /* No "agent groups ->" log: bridge_apply_agent_groups only logs when
+     * the resulting CSV is non-empty. */
+
+    g_captured_callbacks.on_startup_result(true, body, g_captured_callbacks.user_data);
+
+    assert_string_equal(agent_cluster_name, "");
+    assert_string_equal(agent_cluster_node, "");
+    assert_string_equal(agent_agent_groups, "");
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -696,6 +1290,8 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_certificate_verify_mode_maps_to_hc_verify_cert, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_none_verify_mode_maps_to_hc_verify_none, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_client_cert_key_and_ciphers_are_copied, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_config_checksum_is_sha256_of_local_merged_file, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_config_checksum_is_empty_when_local_file_unreadable, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_missing_key_refuses_to_start, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_wrong_length_key_refuses_to_start, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_non_hex_key_refuses_to_start, setup_test, teardown_test),
@@ -710,6 +1306,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_reenroll_thread_aborts_when_stopping_flag_already_set, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_reenroll_thread_logs_error_when_new_key_fails_validation, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_registered_state_maps_to_active, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_registered_state_twice_clears_wait_file_each_time, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_starting_state_maps_to_pending, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_stopped_state_maps_to_nactive, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_rejected_state_maps_to_nactive, setup_test, teardown_test),
@@ -719,6 +1316,21 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_submit_event_rejects_an_empty_frame, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_submit_event_is_a_noop_before_start, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_submit_event_is_a_noop_once_stopping, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_config_downloaded_happy_path_reload_dispatched_defers_gate_to_sigusr1, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_config_downloaded_releases_gate_when_reload_chain_unreachable, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_config_downloaded_invalid_config_skips_reload_and_gate, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_config_downloaded_remote_conf_disabled_stages_files_only, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_config_downloaded_copy_failure_corrects_module_hash, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_config_downloaded_unmerge_failure_corrects_module_hash, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_config_downloaded_null_file_path_is_a_noop, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_startup_result_rejected_does_not_touch_globals, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_startup_result_invalid_json_logs_and_returns, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_startup_result_first_time_applies_without_reload, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_startup_result_limits_changed_reloads_under_auto_restart, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_startup_result_limits_changed_no_reload_without_auto_restart, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_startup_result_limits_unchanged_no_reload, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_startup_result_missing_limits_object_leaves_limits_unchanged, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_startup_result_cluster_and_groups_cleared_when_absent, setup_test, teardown_test),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/unit_tests/client-agent/test_startup_gate.c
+++ b/src/unit_tests/client-agent/test_startup_gate.c
@@ -226,6 +226,48 @@ static void test_check_hash_match_false_when_not_blocked(void **state) {
     assert_false(startup_gate_check_hash_match());
 }
 
+/* --- startup_gate_release_from_https_apply (finding 1, #37831) ---------- */
+
+/* Blocked + remote_conf enabled: releases directly, no MD5 comparison at all
+ * (no will_return(__wrap_getsharedfiles, ...) queued -- if the implementation
+ * routed through the legacy hash-matching helpers instead, cmocka would fail
+ * on a missing mock return). */
+static void test_release_from_https_apply_releases_blocked_gate(void **state) {
+    (void)state;
+    expect_string(__wrap__mdebug1, formatted_msg,
+                  "Startup hash gate released via HTTPS configuration apply (https_config_applied).");
+
+    startup_gate_release_from_https_apply();
+
+    assert_gate_state(true, "https_config_applied");
+}
+
+/* remote_conf disabled: the gate is already released (by initialize()); this
+ * must be a silent no-op, not re-log a release. */
+static void test_release_from_https_apply_is_noop_when_disabled(void **state) {
+    (void)state;
+    /* No expect_any(__wrap__mdebug1, ...): must not log anything. */
+    startup_gate_release_from_https_apply();
+
+    assert_gate_state(true, "disabled");
+}
+
+/* Idempotent: calling it again once already released (e.g. a later config
+ * download after the gate is already open) must not re-log or change state. */
+static void test_release_from_https_apply_is_noop_once_already_released(void **state) {
+    (void)state;
+    expect_string(__wrap__mdebug1, formatted_msg,
+                  "Startup hash gate released via HTTPS configuration apply (https_config_applied).");
+    startup_gate_release_from_https_apply();
+    assert_gate_state(true, "https_config_applied");
+
+    /* Second call: already ready, so the enabled-and-not-ready guard skips the
+     * log/reason-update entirely -- no expect_any queued means cmocka fails
+     * this test if it logs again. */
+    startup_gate_release_from_https_apply();
+    assert_gate_state(true, "https_config_applied");
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown(test_initialize_remote_conf_disabled_releases_gate,
@@ -257,6 +299,12 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_check_hash_match_true_when_blocked_and_matches,
                                         setup_remote_conf_enabled, teardown_gate),
         cmocka_unit_test_setup_teardown(test_check_hash_match_false_when_not_blocked,
+                                        setup_remote_conf_enabled, teardown_gate),
+        cmocka_unit_test_setup_teardown(test_release_from_https_apply_releases_blocked_gate,
+                                        setup_remote_conf_enabled, teardown_gate),
+        cmocka_unit_test_setup_teardown(test_release_from_https_apply_is_noop_when_disabled,
+                                        setup_remote_conf_disabled, teardown_gate),
+        cmocka_unit_test_setup_teardown(test_release_from_https_apply_is_noop_once_already_released,
                                         setup_remote_conf_enabled, teardown_gate),
     };
 


### PR DESCRIPTION
## Description

This pull request closes critical HTTPS control-path gaps that were preventing normal agent behavior in HTTPS-only deployments.

It completes the missing behavior expected in #37832 and #37830 and fixes additional regressions discovered during real-package validation.

Closes #37832.
Closes #37830.

## Proposed Changes

- Implemented `bridge_on_config_downloaded()` in the HTTPS bridge to apply downloaded `merged.mg`, validate with `verifyRemoteConf()`, and release `startup_gate` with correct sequencing.
- Implemented `bridge_on_startup_result()` to apply startup limits and identity data (module limits, cluster name/node, agent groups).
- Released `WAIT_FILE` on HTTPS registration (`HC_STATE_REGISTERED`) via `os_delwait()`.
- Removed blocking legacy handshake behavior from `start_agent()` and decoupled `AgentdStart()` loop progression from legacy socket availability.
- Added an HTTPS-native gate release path using SHA-256 manager/local config hash comparison.
- Fixed hash seed mismatch by moving `config_checksum` seed from MD5 to SHA-256.
- Added binary copy mode in `w_copy_file()` and used it in config apply path to prevent Windows CRLF corruption and reload loops.
- Added consistent send/success debug logs for `/control`, `/download`, and `/stateless`.
- Added component-test support to verify graceful-stop `/control` shutdown delivery.

### Results and Evidence

- Real-package QA validation (10 scenarios) was executed on Linux and Windows for this branch state.
- Startup gate and event-flow blocking issues are resolved in HTTPS scenarios.
- Reload-loop regressions were fixed, including the Windows-only corruption path.
- Graceful-stop component test verifies `shutdown` reaches the manager in the tested lifecycle.
- Unit/component tests were expanded around HTTPS bridge and startup gate behavior.

### Artifacts Affected

- `wazuh-agentd` behavior and control flow:
  - `src/client-agent/src/https_client_bridge.c`
  - `src/client-agent/src/startup_gate.c`
  - `src/client-agent/src/agentd.c`
  - `src/client-agent/src/start_agent.c`
  - `src/client-agent/include/agentd.h`
- HTTPS client library behavior/logging:
  - `src/client-agent/https_client/src/controlStream.cpp`
  - `src/client-agent/https_client/src/configFetcher.cpp`
  - `src/client-agent/https_client/src/statelessStream.cpp`
  - `src/client-agent/https_client/src/httpsClientFacade.cpp`
  - `src/client-agent/https_client/include/https_client.h`
- Shared file-copy utility:
  - `src/shared/src/file_op.c`
  - `src/shared/include/file_op.h`
- Test artifacts:
  - `src/client-agent/https_client/tests/component/fakeManager.hpp`
  - `src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp`
  - `src/unit_tests/client-agent/test_https_client_bridge.c`
  - `src/unit_tests/client-agent/test_startup_gate.c`
  - `src/unit_tests/client-agent/CMakeLists.txt`

### Configuration Changes

N/A. No new configuration parameters and no default-value changes.

### Documentation Updates

N/A.

### Tests Introduced

- New and extended tests in `test_https_client_bridge` covering:
  - config download apply/reload/gate-release paths
  - startup result limits/identity application
  - wait-file release on HTTPS registration
  - SHA-256 seed behavior
- New tests in `test_startup_gate` for HTTPS startup-gate release behavior.
- New component test path for graceful-stop `/control` shutdown observation.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [~] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->