### PR TITLE
Notify pause() waiters on Syscollector shutdown

### DIFF
--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -691,9 +691,17 @@ bool Syscollector::handleNotifyDataClean()
 
 void Syscollector::quiesce()
 {
-    m_stopping = true;
+    {
+        // m_pauseMutex must be held here: pause() checks m_stopping and waits on m_pauseCv
+        // under this same mutex, so setting the flag and notifying without it would leave a
+        // window where pause() reads m_stopping as false and starts waiting right after this
+        // notify_all() fires, missing it (lost wakeup) until some other, unrelated notify
+        // (e.g. a scan/sync finishing on its own) happens to wake it instead.
+        std::lock_guard<std::mutex> lock(m_pauseMutex);
+        m_stopping = true;
+        m_pauseCv.notify_all();
+    }
     m_cv.notify_all();
-    m_pauseCv.notify_all();
 
     if (m_spSyncProtocol)
     {

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -693,6 +693,7 @@ void Syscollector::quiesce()
 {
     m_stopping = true;
     m_cv.notify_all();
+    m_pauseCv.notify_all();
 
     if (m_spSyncProtocol)
     {


### PR DESCRIPTION
## Description

Syscollector bug (confirmed, fixed): Syscollector::quiesce() (syscollectorImp.cpp:692-697) set m_stopping = true and called m_cv.notify_all(), but never notified m_pauseCv — the condition variable pause() actually waits on.
m_cv and m_pauseCv are two distinct condition variables (syscollector.hpp:444,446); the only other place m_pauseCv gets notified is the ScanGuard/RAII destructor when a scan/sync naturally completes (lines 1851, 2266). So on shutdown, pause() could not wake up in response to the stop signal at all — only when the in-flight scan/sync happened to finish on its own. SCA's equivalent quiesce() (sca_impl.cpp:329-336) already notified m_pauseCv correctly, so SCA did not have this specific defect.

Sequencing issue (identified, not yet fixed): main.c's SIGTERM handler (wm_handler, lines 281-285) calls every module's .stop() sequentially and blocking, one at a time, in wmodules list order (i.e., ossec.conf module order). If agent-info precedes
sca/syscollector in that order, agent-info's stop() can block inside pauseCoordinationModules() before the sibling module's own .stop()/quiesce() has even been invoked — so even with the m_pauseCv notify fix in place, nothing has told SCA/Syscollector to stop yett.

## Proposed Changes
`Syscollector::quiesce()` set `m_stopping = true` and notified `m_cv`, but never notified `m_pauseCv` — the condition variable `pause()` actually waits on. `m_cv` and `m_pauseCv` are distinct condition variables; `m_pauseCv` was only otherwise notified by the `ScanGuard` RAII destructor when an in-flight scan/sync finishes on its own.

As a result, a `pause()` call blocked on an active scan could not react to shutdown at all 
it stayed blocked until that scan finished naturally, which can take minutes if the manager is unreachable (sync retries default to 4 attempts x 30s timeout).

This change adds `m_pauseCv.notify_all()` to `quiesce()`, mirroring SCA's existing `quiesce()`.
`pause()`'s wait predicate (`(scanDone && syncDone) || m_stopping`) now gets re-evaluated immediately on shutdown instead of only on scan completion, so it unblocks right away.

### Results and Evidence

### Method
Wrote a temporary gtest (`SyscollectorImpTest.EVIDENCE_QuiesceUnblocksPauseWaiterDuringScan`, not committed) that:
1. Mocks `ISysInfo::os()` to sleep 5s, holding a real scan (`m_scanning = true`) in flight.
2. Blocks a `pause()` call on a separate thread while the scan is running.
3. Calls `destroy()` (which invokes `quiesce()`) and measures whether `pause()` unblocks
   within ~500ms — well before the 5s mocked scan can finish on its own.

## Result — WITHOUT the fix (`m_pauseCv.notify_all()` stashed out)
[ RUN      ] SyscollectorImpTest.EVIDENCE_QuiesceUnblocksPauseWaiterDuringScan
.../syscollectorImp_test.cpp:6185: Failure
Value of: returnedInTime
Actual: false
Expected: true
pause() did not unblock promptly after quiesce()/destroy() - m_pauseCv was not notified on shutdown
[  FAILED  ] SyscollectorImpTest.EVIDENCE_QuiesceUnblocksPauseWaiterDuringScan (5004 ms)


`pause()` only returns once the mocked scan's full 5s sleep elapses — confirming `quiesce()` does not wake a thread blocked in `pause()`.

### Result — WITH the fix (`m_pauseCv.notify_all()` applied)
[ RUN      ] SyscollectorImpTest.EVIDENCE_QuiesceUnblocksPauseWaiterDuringScan
[       OK ] SyscollectorImpTest.EVIDENCE_QuiesceUnblocksPauseWaiterDuringScan (5008 ms)
[  PASSED  ] 1 test.


(Total wall time is still ~5s because the test waits for the background scan thread to join before exiting — but the `pause()` unblock itself, checked within the first 500ms after `destroy()`, succeeded promptly, which is what the assertion measures.)

### Conclusion
Toggling only the one-line fix (`git stash`) flips this test from FAILED to PASSED, with no other code change involved — direct, reproducible evidence that `m_pauseCv.notify_all()` in `Syscollector::quiesce()` is both necessary and sufficient to unblock a `pause()` waiter on shutdown, instead of leaving it dependent on the in-flight scan/sync finishing naturally.

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [x] Windows 
  - [x] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected
N-A

### Configuration Changes
N-A

### Tests Introduced
N-A

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
