### PR TITLE
ci: pass WAZUH_BRANCH through env and quote it in the compose build

### DIFF
--- a/.github/workflows/5_testintegration_api-endpoints.yml
+++ b/.github/workflows/5_testintegration_api-endpoints.yml
@@ -170,9 +170,11 @@ jobs:
 
       - name: Build and save Docker images
         if: steps.cache.outputs.cache-hit != 'true'
+        env:
+          WAZUH_BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
           cd api/test/integration/env
-          docker compose build --build-arg WAZUH_BRANCH=${{ github.head_ref || github.ref_name }} --no-cache
+          docker compose build --build-arg WAZUH_BRANCH="$WAZUH_BRANCH" --no-cache
           mkdir -p /tmp/docker-images
           readarray -t images < <(docker images | awk '/integration/ {print $1}')
           for image in "${images[@]}"; do


### PR DESCRIPTION
Hi, and thanks for Wazuh.

In `.github/workflows/5_testintegration_api-endpoints.yml`, the branch name is passed to the image build by interpolation, unquoted:

```yaml
run: |
  cd api/test/integration/env
  docker compose build --build-arg WAZUH_BRANCH=${{ github.head_ref || github.ref_name }} --no-cache
```

Actions expands `${{ ... }}` into the script text before bash runs, so the branch name lands as script rather than as an argument. Git allows `$`, `(`, `)`, backticks and spaces in branch names, and `$(...)` executes inside double quotes — and being unquoted, a name containing a space would also split into extra arguments to `docker compose build`.

Scope, so I do not overstate it: this is a `pull_request` trigger, so a fork PR gets a read-only token and no repository secrets. I am raising it as hardening rather than as a live exploit path.

The change passes the value through `env:` and quotes it at the use site:

```yaml
env:
  WAZUH_BRANCH: ${{ github.head_ref || github.ref_name }}
run: |
  cd api/test/integration/env
  docker compose build --build-arg WAZUH_BRANCH="$WAZUH_BRANCH" --no-cache
```

The `||` fallback is preserved by keeping the whole expression in the `env:` value, so the build argument receives exactly the same string as today, and `--no-cache` and everything downstream are untouched.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow and its trigger myself.
