### PR TITLE
Agent side https - Fix shutdown and log enhancement

### DIFF
--- a/src/client-agent/https_client/src/curlHandle.cpp
+++ b/src/client-agent/https_client/src/curlHandle.cpp
@@ -54,7 +54,8 @@ namespace
             {CurlOption::SslKey, CURLOPT_SSLKEY},
             {CurlOption::SslCiphers, CURLOPT_SSL_CIPHER_LIST},
             {CurlOption::FollowLocation, CURLOPT_FOLLOWLOCATION},
-            {CurlOption::NoSignal, CURLOPT_NOSIGNAL}};
+            {CurlOption::NoSignal, CURLOPT_NOSIGNAL}
+        };
         return *map;
     }
 

--- a/src/client-agent/https_client/src/curlHandle.cpp
+++ b/src/client-agent/https_client/src/curlHandle.cpp
@@ -36,7 +36,11 @@ namespace
 
     const std::map<CurlOption, CURLoption>& optionMap()
     {
-        static const std::map<CurlOption, CURLoption> map
+        // Never destroyed, like the global curl init above: the shutdown drain reads
+        // this from an atexit handler registered before the lazy init, so LIFO
+        // teardown would free the tree first and the drain would fault.
+        static const std::map<CurlOption, CURLoption>* const map =
+            new const std::map<CurlOption, CURLoption>
         {
             {CurlOption::Url, CURLOPT_URL},
             {CurlOption::Post, CURLOPT_POST},
@@ -51,7 +55,7 @@ namespace
             {CurlOption::SslCiphers, CURLOPT_SSL_CIPHER_LIST},
             {CurlOption::FollowLocation, CURLOPT_FOLLOWLOCATION},
             {CurlOption::NoSignal, CURLOPT_NOSIGNAL}};
-        return map;
+        return *map;
     }
 
     // curl callbacks are C: nothing may throw across them.

--- a/src/client-agent/src/agentd.c
+++ b/src/client-agent/src/agentd.c
@@ -135,6 +135,10 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
      * independently of the legacy TCP path below until that is retired
      * (later workstream). See client-agent/https_client and the bridge. */
     w_https_client_start();
+
+    /* Note: Whatever the drain touches must outlive this: exit() unwinds atexit LIFO, so
+     * a C++ static lazily initialized on a module thread registers after this line
+     * and dies before the drain runs. */
     atexit(w_https_client_stop);
 
     start_agent(1);

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -673,10 +673,30 @@ static void bridge_on_sync_response(const char *session_id, int result, const ch
             (int)module_len, module);
 }
 
+/* Names the module's connection states for the log The numeric
+ * value is kept alongside the name by the caller. */
+static const char *bridge_str_conn_state(int hc_state)
+{
+    switch (hc_state) {
+    case HC_STATE_STOPPED:
+        return "stopped";
+    case HC_STATE_STARTING:
+        return "starting";
+    case HC_STATE_REGISTERED:
+        return "registered";
+    case HC_STATE_REJECTED:
+        return "rejected";
+    case HC_STATE_AUTH_ERROR:
+        return "auth_error";
+    default:
+        return "unknown";
+    }
+}
+
 static void bridge_on_state_change(int state, void *user_data)
 {
     (void)user_data;
-    mdebug1("https_client connection state -> %d", state);
+    mdebug1("https_client connection state -> %s (%d)", bridge_str_conn_state(state), state);
     w_agentd_state_update(UPDATE_STATUS, (void *)bridge_map_agent_status(state));
 
     /* Interim fix for the WAIT_FILE/os_setwait() producer lock (armed

--- a/src/unit_tests/client-agent/test_https_client_bridge.c
+++ b/src/unit_tests/client-agent/test_https_client_bridge.c
@@ -686,7 +686,7 @@ static void test_registered_state_maps_to_active(void **state)
     (void)state;
     start_client_successfully();
 
-    expect_string(__wrap__mdebug1, formatted_msg, "https_client connection state -> 2");
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client connection state -> registered (2)");
     expect_value(__wrap_w_agentd_state_update, type, UPDATE_STATUS);
     expect_value(__wrap_w_agentd_state_update, data, GA_STATUS_ACTIVE);
     expect_function_call(__wrap_os_delwait);
@@ -725,7 +725,7 @@ static void test_starting_state_maps_to_pending(void **state)
     (void)state;
     start_client_successfully();
 
-    expect_string(__wrap__mdebug1, formatted_msg, "https_client connection state -> 1");
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client connection state -> starting (1)");
     expect_value(__wrap_w_agentd_state_update, type, UPDATE_STATUS);
     expect_value(__wrap_w_agentd_state_update, data, GA_STATUS_PENDING);
 
@@ -740,7 +740,7 @@ static void test_stopped_state_maps_to_nactive(void **state)
     (void)state;
     start_client_successfully();
 
-    expect_string(__wrap__mdebug1, formatted_msg, "https_client connection state -> 0");
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client connection state -> stopped (0)");
     expect_value(__wrap_w_agentd_state_update, type, UPDATE_STATUS);
     expect_value(__wrap_w_agentd_state_update, data, GA_STATUS_NACTIVE);
 
@@ -755,7 +755,7 @@ static void test_rejected_state_maps_to_nactive(void **state)
     (void)state;
     start_client_successfully();
 
-    expect_string(__wrap__mdebug1, formatted_msg, "https_client connection state -> 3");
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client connection state -> rejected (3)");
     expect_value(__wrap_w_agentd_state_update, type, UPDATE_STATUS);
     expect_value(__wrap_w_agentd_state_update, data, GA_STATUS_NACTIVE);
 
@@ -843,7 +843,7 @@ static void test_auth_error_state_maps_to_nactive(void **state)
     (void)state;
     start_client_successfully();
 
-    expect_string(__wrap__mdebug1, formatted_msg, "https_client connection state -> 4");
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client connection state -> auth_error (4)");
     expect_value(__wrap_w_agentd_state_update, type, UPDATE_STATUS);
     expect_value(__wrap_w_agentd_state_update, data, GA_STATUS_NACTIVE);
 

--- a/src/unit_tests/client-agent/test_https_client_bridge.c
+++ b/src/unit_tests/client-agent/test_https_client_bridge.c
@@ -704,13 +704,13 @@ static void test_registered_state_twice_clears_wait_file_each_time(void **state)
     (void)state;
     start_client_successfully();
 
-    expect_string(__wrap__mdebug1, formatted_msg, "https_client connection state -> 2");
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client connection state -> registered (2)");
     expect_value(__wrap_w_agentd_state_update, type, UPDATE_STATUS);
     expect_value(__wrap_w_agentd_state_update, data, GA_STATUS_ACTIVE);
     expect_function_call(__wrap_os_delwait);
     g_captured_callbacks.on_state_change(HC_STATE_REGISTERED, g_captured_callbacks.user_data);
 
-    expect_string(__wrap__mdebug1, formatted_msg, "https_client connection state -> 2");
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client connection state -> registered (2)");
     expect_value(__wrap_w_agentd_state_update, type, UPDATE_STATUS);
     expect_value(__wrap_w_agentd_state_update, data, GA_STATUS_ACTIVE);
     expect_function_call(__wrap_os_delwait);


### PR DESCRIPTION
## Description

Two independent problems on the agent's HTTPS control path, both found while investigating the missing shutdown notification.

**1. A graceful stop never delivered the shutdown notification to the manager.**

Stopping `wazuh-agentd` never sent the graceful `POST /control {"type":"shutdown"}`, so the manager only noticed the agent was gone once the keepalive timed out.

The signal handling and the stop path were both fine — the agent *crashed* partway through the stop, before the request went out. The teardown is registered with `atexit()`, and `exit()` runs those handlers in reverse registration order. A C++ lookup table the drain needs is created lazily on one of the module's own threads, so it registered *after* the teardown and was therefore destroyed *before* it, leaving the drain walking freed memory..

**2. The connection-state log line was unreadable, and silently wrong over time.**

The line reported only the raw enum value, so `state -> 2` required opening a header to interpret.

Related to #37831.

## Proposed Changes

- A graceful stop now delivers the shutdown notification to the manager, so it marks the agent disconnected immediately instead of waiting out the keepalive timeout. The agent also exits cleanly within the stop grace period instead of dying mid-teardown.
- The connection-state log line now names the state and keeps the numeric value alongside it, so an unrecognised value is still reported rather than hidden.
- Added a note where the teardown is registered, recording the ordering constraint that caused the first problem, so it is visible to whoever adds the next dependency.

### Results and Evidence

**Before — the stop, captured.** The agent logs that it received the signal and began stopping, and then simply stops logging; nothing further is written and no shutdown request reaches the manager:

```sql
2026/07/28 13:43:48 wazuh-agentd[58720] sig_op.c:39 at HandleSIG(): INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/07/28 13:43:48 wazuh-agentd:https-client[58720] httpsClientFacade.cpp:85 at stop(): INFO: Stopping https_client.
2026/07/28 13:43:48 wazuh-execd: INFO: (1314): Shutdown received. Deleting responses.
2026/07/28 13:43:48 wazuh-execd: INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
```

The reason is only visible outside the Wazuh logs, in the kernel log:

```sql
traps: wazuh-agentd[58722] general protection fault ip:7e178fbac74b sp:7ffcb34f70b0 error:0 in libhttps_client.so[3b74b,7e178fb85000+34000]
```

**After — the manager side, captured.** Real `wazuh-agentd` against the HTTPS `RemotedSimulator` with CMAC verification enabled, stopped gracefully. Trimmed to the start and end of the run:

```sql
[+] RemotedSimulator on https://127.0.0.1:1514 (verify_auth=True, agent 001)
[+] Waiting for agent traffic (Ctrl+C to stop)...
    POST /control    id=001 (37 B) {"type":"startup","version":"v5.0.0"}
    POST /control    id=001 (17 B) {"type":"notify"}
    POST /download   id=001 (50 B) {"resource_type":"config","resource_id":"default"}
    POST /control    id=001 (17 B) {"type":"notify"}
    ... (notify keepalives) ...
    POST /control    id=001 (17 B) {"type":"notify"}
    POST /control    id=001 (19 B) {"type":"shutdown"}
```

The final `{"type":"shutdown"}` is the line that was missing before. The agent now also exits within the stop grace period rather than being escalated to `SIGKILL`, and the kernel reports no fault from the module on stop.

**After — the agent side, illustrating the new state log format.** The excerpt below shows the format the second change produces across a full start-to-stop cycle at `agent.debug=2`:

```sql
2026/07/28 19:10:22 wazuh-agentd[135513] https_client_bridge.c:823 at w_https_client_start(): INFO: https_client: starting.
2026/07/28 19:10:22 wazuh-agentd:https-client[135513] httpsClientFacade.cpp:60 at start(): INFO: Starting https_client (server=127.0.0.1:1514, agent=001).
2026/07/28 19:10:22 wazuh-agentd[135513] https_client_bridge.c:604 at bridge_on_state_change(): DEBUG: https_client connection state -> starting (1)
2026/07/28 19:10:22 wazuh-agentd[135513] https_client_bridge.c:604 at bridge_on_state_change(): DEBUG: https_client connection state -> registered (2)
2026/07/28 19:12:04 wazuh-agentd[135513] sig_op.c:39 at HandleSIG(): INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
2026/07/28 19:12:04 wazuh-agentd:https-client[135513] httpsClientFacade.cpp:85 at stop(): INFO: Stopping https_client.
2026/07/28 19:12:04 wazuh-agentd[135513] https_client_bridge.c:604 at bridge_on_state_change(): DEBUG: https_client connection state -> stopped (0)
```

Two things to read out of it. The states are now legible without a header to hand — `starting (1)`, `registered (2)`, `stopped (0)`. And the final `stopped (0)` line is itself a marker for the first fix: it is emitted at the very end of the stop path, after the drain has run, so before the fix it never appeared at all.

### Artifacts Affected

- `wazuh-agentd` and `libhttps_client.so` (Linux agent).
- The lookup table behind the first fix is shared code, so the Windows agent picks that change up as well.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

- Existing bridge unit-test assertions updated for the new connection-state log format, plus a case covering an unrecognised state value, which the previous format had no path to exercise.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
