### PR TITLE
Exclude monotonic counters from syscollector dbsync diff/checksum

### DIFF
--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -1534,14 +1534,27 @@ bool SQLiteDBEngine::getRowDiff(const std::vector<std::string>& primaryKeyList,
         {
             auto haveDiffOnNonIgnored
             {
-                [&ignoredColumns, primaryKeyList](const nlohmann::json & rowToBeUpdated) -> bool
+                [&ignoredColumns, primaryKeyList, &data](const nlohmann::json & rowToBeUpdated) -> bool
                 {
                     bool haveDiff { false };
 
                     for (const auto& fieldToBeUpdated : rowToBeUpdated.items())
                     {
-                        if (std::find(ignoredColumns.begin(), ignoredColumns.end(),
-                                      fieldToBeUpdated.key()) == ignoredColumns.end())
+                        // "version"/"sync" are DB-managed bookkeeping fields normally always present
+                        // in oldData/updatedData regardless of whether any real column changed, so
+                        // they must be excluded here too or the ignore list can never suppress a diff.
+                        // But if the caller's own data explicitly set one of them (e.g. the
+                        // syscollector set_version command rewriting only "version"), that's a real,
+                        // intentional change and must still count.
+                        const bool isBookkeepingOnly
+                        {
+                            (fieldToBeUpdated.key() == "version" || fieldToBeUpdated.key() == "sync")
+                            && data.find(fieldToBeUpdated.key()) == data.end()
+                        };
+
+                        if (!isBookkeepingOnly
+                                && std::find(ignoredColumns.begin(), ignoredColumns.end(),
+                                             fieldToBeUpdated.key()) == ignoredColumns.end())
                         {
                             if (std::find(primaryKeyList.begin(), primaryKeyList.end(),
                                           fieldToBeUpdated.key()) == primaryKeyList.end())

--- a/src/shared_modules/dbsync/tests/interface/dbsync_test.cpp
+++ b/src/shared_modules/dbsync/tests/interface/dbsync_test.cpp
@@ -809,7 +809,81 @@ TEST_F(DBSyncTest, syncRowIgnoreFields)
     EXPECT_EQ(0, dbsync_sync_row(handle, jsUpdate3.get(), callbackData));  // Expect an update event
 }
 
+TEST_F(DBSyncTest, syncRowIgnoreFieldsWithVersionColumn)
+{
+    // Tables with a DB-managed "version" column must still suppress the diff/callback when
+    // only ignored fields changed - "version" itself must not count as a "non-ignored" change.
+    const auto sql
+    {
+        "CREATE TABLE processes(`pid` BIGINT, `name` TEXT, `tid` BIGINT, "
+        "`version` INTEGER NOT NULL DEFAULT 1, PRIMARY KEY (`pid`)) WITHOUT ROWID;"
+    };
+    const auto handle { dbsync_create(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, sql) };
+    ASSERT_NE(nullptr, handle);
 
+    auto insertionQuery = InsertQuery::builder().table("processes")
+                          .data(nlohmann::json::parse(R"({"pid":4,"name":"System", "tid":100})"));
+    // Only the ignored field ("tid") changes - must NOT trigger a MODIFIED callback,
+    // even though the row's "version" column is bumped internally on every write.
+    auto updateQuery1 = SyncRowQuery::builder().table("processes")
+                        .ignoreColumn("tid")
+                        .data(nlohmann::json::parse(R"({"pid":4,"name":"System", "tid":101})"));
+    // A non-ignored field ("name") also changes - MUST trigger a MODIFIED callback.
+    auto updateQuery2 = SyncRowQuery::builder().table("processes")
+                        .ignoreColumn("tid")
+                        .data(nlohmann::json::parse(R"({"pid":4,"name":"SystemIsDown", "tid":102})"));
+
+    const std::unique_ptr<cJSON, CJsonSmartDeleter> jsInsert1{ cJSON_Parse(insertionQuery.query().dump().c_str()) };
+    const std::unique_ptr<cJSON, CJsonSmartDeleter> jsUpdate1{ cJSON_Parse(updateQuery1.query().dump().c_str()) };
+    const std::unique_ptr<cJSON, CJsonSmartDeleter> jsUpdate2{ cJSON_Parse(updateQuery2.query().dump().c_str()) };
+
+    CallbackMock wrapper;
+    callback_data_t callbackData { callback, &wrapper };
+
+    EXPECT_CALL(wrapper, callbackMock(INSERTED, nlohmann::json::parse(R"({"pid":4,"name":"System","tid":100,"version":1})"))).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(MODIFIED, nlohmann::json::parse(R"({"pid":4,"name":"SystemIsDown","tid":102,"version":2})"))).Times(1);
+
+    EXPECT_EQ(0, dbsync_sync_row(handle, jsInsert1.get(), callbackData));  // Expect an insert event
+    EXPECT_EQ(0, dbsync_sync_row(handle, jsUpdate1.get(), callbackData));  // Ignored-only change: no callback
+    EXPECT_EQ(0, dbsync_sync_row(handle, jsUpdate2.get(), callbackData));  // Real change: expect an update event
+}
+
+TEST_F(DBSyncTest, syncRowIgnoreFieldsWithExplicitVersionChange)
+{
+    // Mirrors Syscollector::setVersion(): the caller reads back a full row and rewrites only
+    // "version", with some other column ignored (standing in for the real "sync" ignore-list
+    // entry). Because the caller supplied "version" itself, it is a real, intentional change
+    // and must still count as non-ignored - even though no other column changed - so a
+    // MODIFIED callback must still fire and the new version must still be persisted.
+    const auto sql
+    {
+        "CREATE TABLE processes(`pid` BIGINT, `name` TEXT, `tid` BIGINT, "
+        "`version` INTEGER NOT NULL DEFAULT 1, PRIMARY KEY (`pid`)) WITHOUT ROWID;"
+    };
+    const auto handle { dbsync_create(HostType::AGENT, DbEngineType::SQLITE3, DATABASE_TEMP, sql) };
+    ASSERT_NE(nullptr, handle);
+
+    auto insertionQuery = InsertQuery::builder().table("processes")
+                          .data(nlohmann::json::parse(R"({"pid":4,"name":"System", "tid":100})"));
+    // "tid" is ignored and unchanged, "name" is unchanged - "version" is the only field that
+    // differs, and it was explicitly supplied by the caller. Must still trigger a MODIFIED
+    // callback carrying the new version.
+    auto updateQuery1 = SyncRowQuery::builder().table("processes")
+                        .ignoreColumn("tid")
+                        .data(nlohmann::json::parse(R"({"pid":4,"name":"System", "tid":100, "version":9})"));
+
+    const std::unique_ptr<cJSON, CJsonSmartDeleter> jsInsert1{ cJSON_Parse(insertionQuery.query().dump().c_str()) };
+    const std::unique_ptr<cJSON, CJsonSmartDeleter> jsUpdate1{ cJSON_Parse(updateQuery1.query().dump().c_str()) };
+
+    CallbackMock wrapper;
+    callback_data_t callbackData { callback, &wrapper };
+
+    EXPECT_CALL(wrapper, callbackMock(INSERTED, nlohmann::json::parse(R"({"pid":4,"name":"System","tid":100,"version":1})"))).Times(1);
+    EXPECT_CALL(wrapper, callbackMock(MODIFIED, nlohmann::json::parse(R"({"pid":4,"name":"System","tid":100,"version":9})"))).Times(1);
+
+    EXPECT_EQ(0, dbsync_sync_row(handle, jsInsert1.get(), callbackData));  // Expect an insert event
+    EXPECT_EQ(0, dbsync_sync_row(handle, jsUpdate1.get(), callbackData));  // Explicit version-only change: still expect a MODIFIED event
+}
 
 TEST_F(DBSyncTest, syncRowInvalidData)
 {

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -186,6 +186,22 @@ static std::string getItemChecksum(const nlohmann::json& item)
     return Utils::asciiToHex(hash.hash());
 }
 
+// Monotonic counters excluded from dbsync's diff 
+// NOTE: dbsync's "ignore" only suppresses the diff/callback when ignored fields
+// are the *only* thing that changed; it also skips persisting their new value in
+// that case (see SQLiteDBEngine::syncTableRowData). These fields will hold whatever
+// value they had at the last scan that also changed a non-ignored field.
+static const std::vector<std::string> HW_IGNORED_FIELDS { "memory_free", "memory_used", "checksum" };
+static const std::vector<std::string> PROCESSES_IGNORED_FIELDS { "utime", "stime", "checksum" };
+static const std::vector<std::string> NET_IFACE_IGNORED_FIELDS
+{
+    "host_network_egress_packages", "host_network_ingress_packages",
+    "host_network_egress_errors",   "host_network_ingress_errors",
+    "host_network_egress_bytes",    "host_network_ingress_bytes",
+    "host_network_egress_drops",    "host_network_ingress_drops",
+    "checksum"
+};
+
 static std::string getItemId(const nlohmann::json& item, const std::vector<std::string>& idFields)
 {
     Utils::HashData hash;
@@ -370,6 +386,15 @@ void Syscollector::updateChanges(const std::string& table,
     input["table"] = table;
     input["data"] = values;
     input["options"]["return_old_data"] = true;
+
+    if (table == HW_TABLE)
+    {
+        input["options"]["ignore"] = HW_IGNORED_FIELDS;
+    }
+    else if (table == NET_IFACE_TABLE)
+    {
+        input["options"]["ignore"] = NET_IFACE_IGNORED_FIELDS;
+    }
 
     txn.syncTxnRow(input);
     txn.getDeletedRows(callback);
@@ -1355,7 +1380,11 @@ nlohmann::json Syscollector::getHardwareData()
     nlohmann::json ret;
     ret[0] = m_spInfo->hardware();
     sanitizeJsonValue(ret[0]);
-    ret[0]["checksum"] = getItemChecksum(ret[0]);
+
+    auto checksumInput = ret[0];
+    checksumInput.erase("memory_free");
+    checksumInput.erase("memory_used");
+    ret[0]["checksum"] = getItemChecksum(checksumInput);
     return ret;
 }
 
@@ -1431,7 +1460,13 @@ nlohmann::json Syscollector::getNetworkData()
                 ifaceTableData["host_network_ingress_bytes"]    = item.at("host_network_ingress_bytes");
                 ifaceTableData["host_network_egress_drops"]     = item.at("host_network_egress_drops");
                 ifaceTableData["host_network_ingress_drops"]    = item.at("host_network_ingress_drops");
-                ifaceTableData["checksum"]                      = getItemChecksum(ifaceTableData);
+
+                auto ifaceChecksumInput = ifaceTableData;
+                for (const auto& field : NET_IFACE_IGNORED_FIELDS)
+                {
+                    ifaceChecksumInput.erase(field);
+                }
+                ifaceTableData["checksum"] = getItemChecksum(ifaceChecksumInput);
                 ifaceTableDataList.push_back(std::move(ifaceTableData));
 
                 if (item.find("IPv4") != item.end())
@@ -1705,11 +1740,16 @@ void Syscollector::scanProcesses()
             nlohmann::json input;
 
             sanitizeJsonValue(rawData);
-            rawData["checksum"] = getItemChecksum(rawData);
+
+            auto checksumInput = rawData;
+            checksumInput.erase("utime");
+            checksumInput.erase("stime");
+            rawData["checksum"] = getItemChecksum(checksumInput);
 
             input["table"] = PROCESSES_TABLE;
             input["data"] = nlohmann::json::array( { rawData } );
             input["options"]["return_old_data"] = true;
+            input["options"]["ignore"] = PROCESSES_IGNORED_FIELDS;
 
             txn.syncTxnRow(input);
         });

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -186,7 +186,7 @@ static std::string getItemChecksum(const nlohmann::json& item)
     return Utils::asciiToHex(hash.hash());
 }
 
-// Monotonic counters excluded from dbsync's diff 
+// Monotonic counters excluded from dbsync's diff
 // NOTE: dbsync's "ignore" only suppresses the diff/callback when ignored fields
 // are the *only* thing that changed; it also skips persisting their new value in
 // that case (see SQLiteDBEngine::syncTableRowData). These fields will hold whatever
@@ -1462,10 +1462,12 @@ nlohmann::json Syscollector::getNetworkData()
                 ifaceTableData["host_network_ingress_drops"]    = item.at("host_network_ingress_drops");
 
                 auto ifaceChecksumInput = ifaceTableData;
+
                 for (const auto& field : NET_IFACE_IGNORED_FIELDS)
                 {
                     ifaceChecksumInput.erase(field);
                 }
+
                 ifaceTableData["checksum"] = getItemChecksum(ifaceChecksumInput);
                 ifaceTableDataList.push_back(std::move(ifaceTableData));
 

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -350,7 +350,7 @@ static bool waitUntil(const std::function<bool()>& predicate,
 // Expected results for persist callback - shared across all tests
 static const auto expectedPersistHW
 {
-    R"({"checksum":{"hash":{"sha1":"0288831cec1334e0d67eb2f7b83e0c96d2abb9be"}},"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":2904},"memory":{"free":2257872,"total":4972208,"used":54},"serial_number":"Intel Corporation"}})"
+    R"({"checksum":{"hash":{"sha1":"06e5046d8e8b1605f81b648e1289a2cb2ad6e7b3"}},"host":{"cpu":{"cores":2,"name":"Intel(R) Core(TM) i5-9400 CPU @ 2.90GHz","speed":2904},"memory":{"free":2257872,"total":4972208,"used":54},"serial_number":"Intel Corporation"}})"
 };
 static const auto expectedPersistOS
 {
@@ -358,7 +358,7 @@ static const auto expectedPersistOS
 };
 static const auto expectedPersistNetIface
 {
-    R"({"checksum":{"hash":{"sha1":"712c4c9e6d65a48bc8fb0e99f8ce9238d88bbca4"}},"host":{"mac":["d4:5d:64:51:07:5d"],"network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"alias":null,"mtu":1500,"name":"enp4s0","state":"up","type":"ethernet"}})"
+    R"({"checksum":{"hash":{"sha1":"81571a9a6ac1018501f851021ac837fd205bdc57"}},"host":{"mac":["d4:5d:64:51:07:5d"],"network":{"egress":{"bytes":0,"drops":0,"errors":0,"packets":0},"ingress":{"bytes":0,"drops":0,"errors":0,"packets":0}}},"interface":{"alias":null,"mtu":1500,"name":"enp4s0","state":"up","type":"ethernet"}})"
 };
 static const auto expectedPersistNetProtoIPv4
 {
@@ -386,7 +386,7 @@ static const auto expectedPersistPortsUdp
 };
 static const auto expectedPersistProcess
 {
-    R"({"checksum":{"hash":{"sha1":"78e4e090e42f88d949428eb56836287f99de9f4f"}},"process":{"args":null,"args_count":null,"command_line":null,"name":"kworker/u256:2-","parent":{"pid":2},"pid":431625,"start":9302261,"state":"I","stime":3,"utime":0}})"
+    R"({"checksum":{"hash":{"sha1":"e4f22515111f6059c067d8602289786e90855a1e"}},"process":{"args":null,"args_count":null,"command_line":null,"name":"kworker/u256:2-","parent":{"pid":2},"pid":431625,"start":9302261,"state":"I","stime":3,"utime":0}})"
 };
 static const auto expectedPersistPackage
 {
@@ -4951,6 +4951,117 @@ TEST_F(SyscollectorImpTest, hardwareCpuSpeedZeroIsReportedAsNull)
 
     // Reset factory after test
     SchemaValidator::SchemaValidatorFactory::getInstance().reset();
+}
+
+// End-to-end check that the per-table "ignore" lists (HW_IGNORED_FIELDS, PROCESSES_IGNORED_FIELDS,
+// NET_IFACE_IGNORED_FIELDS) actually suppress dbsync MODIFIED events across several scan cycles.
+// Hardware memory, process CPU times and network byte/packet counters change on every scan below
+// (as real monotonic counters do), while every other field stays constant: each collector must
+// still persist exactly once (the initial insert), never again on the following cycles.
+TEST_F(SyscollectorImpTest, ignoredCountersDoNotTriggerModifiedEventsAcrossScans)
+{
+    const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
+
+    int hwCallCount{0};
+    EXPECT_CALL(*spInfoWrapper, hardware()).WillRepeatedly(testing::Invoke(
+                                                               [&hwCallCount]()
+    {
+        auto data = nlohmann::json::parse(EXPECT_CALL_HARDWARE_JSON);
+        data["memory_free"] = 2257872 + (hwCallCount * 4096);
+        data["memory_used"] = 54 + hwCallCount;
+        // dbsync_hwinfo.cpu_speed is a DOUBLE column; the shared fixture's plain "2904"
+        // literal parses as a JSON integer, which permanently mismatches the DB-stored
+        // value on every diff comparison. Force it to the float type the column expects.
+        data["cpu_speed"] = data["cpu_speed"].get<double>();
+        ++hwCallCount;
+        return data;
+    }));
+
+    int procCallCount{0};
+    EXPECT_CALL(*spInfoWrapper, processes(_)).WillRepeatedly(testing::Invoke(
+                                                                 [&procCallCount](std::function<void(nlohmann::json&)> callback)
+    {
+        auto data = nlohmann::json::parse(EXPECT_CALL_PROCESSES_JSON);
+        data["utime"] = procCallCount;
+        data["stime"] = procCallCount + 1;
+        // dbsync_processes.start is a TEXT column (real providers always report an ISO8601
+        // string); the shared fixture's plain "9302261" literal parses as a JSON integer,
+        // which permanently mismatches the DB-stored value on every diff comparison.
+        data["start"] = std::to_string(data["start"].get<int64_t>());
+        ++procCallCount;
+        callback(data);
+    }));
+
+    int netCallCount{0};
+    const auto networksJsonTemplate
+    {
+        R"({"iface":[{"host_mac":"d4:5d:64:51:07:5d", "interface_mtu":1500, "interface_name":"eth0", )"
+        R"("interface_alias":" ", "interface_type":"ethernet", "interface_state":"up",)"
+        R"("host_network_ingress_bytes":0,"host_network_ingress_drops":0,"host_network_ingress_errors":0,)"
+        R"("host_network_ingress_packages":0,"host_network_egress_bytes":0,"host_network_egress_drops":0,)"
+        R"("host_network_egress_errors":0,"host_network_egress_packages":0}]})"
+    };
+    EXPECT_CALL(*spInfoWrapper, networks()).WillRepeatedly(testing::Invoke(
+                                                               [&netCallCount, networksJsonTemplate]()
+    {
+        auto data = nlohmann::json::parse(networksJsonTemplate);
+        data["iface"][0]["host_network_ingress_bytes"]    = 100000 + (netCallCount * 1024);
+        data["iface"][0]["host_network_egress_bytes"]     = 200000 + (netCallCount * 2048);
+        data["iface"][0]["host_network_ingress_packages"] = 1000 + netCallCount;
+        data["iface"][0]["host_network_egress_packages"]  = 2000 + netCallCount;
+        ++netCallCount;
+        return data;
+    }));
+
+    EXPECT_CALL(*spInfoWrapper, os()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, ports()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, packages(_)).Times(0);
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, groups()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, users()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, services()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, browserExtensions()).Times(0);
+
+    CallbackMockPersist wrapperPersist;
+    std::function<void(const std::string&, Operation_t, const std::string&, const std::string&, uint64_t)> callbackDataPersist
+    {
+        [&wrapperPersist](const std::string & id, Operation_t operation, const std::string & index, const std::string & data, uint64_t version)
+        {
+            wrapperPersist.callbackMock(id, operation, index, data, version);
+        }
+    };
+
+    // Exactly one persisted event per collector: the initial insert. None of the following
+    // scan cycles - which only ever change ignored fields - may produce a second (MODIFIED) event.
+    EXPECT_CALL(wrapperPersist, callbackMock(testing::_, testing::_, testing::Eq("wazuh-states-inventory-hardware"), testing::_, testing::_)).Times(1);
+    EXPECT_CALL(wrapperPersist, callbackMock(testing::_, testing::_, testing::Eq("wazuh-states-inventory-processes"), testing::_, testing::_)).Times(1);
+    EXPECT_CALL(wrapperPersist, callbackMock(testing::_, testing::_, testing::Eq("wazuh-states-inventory-interfaces"), testing::_, testing::_)).Times(1);
+
+    std::thread t
+    {
+        [&spInfoWrapper, &callbackDataPersist]()
+        {
+            Syscollector::instance().init(spInfoWrapper,
+                                          reportFunction,
+                                          callbackDataPersist,
+                                          logFunction,
+                                          SYSCOLLECTOR_DB_PATH,
+                                          "",
+                                          "",
+                                          1, true, true, false, true, false, false, false, true, false, false, false, false, false, false);
+
+            Syscollector::instance().start();
+        }
+    };
+
+    // interval=1s: initial scan at t=0, second (noise-only-change) scan at ~t=1s.
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+    Syscollector::instance().destroy();
+
+    if (t.joinable())
+    {
+        t.join();
+    }
 }
 
 // Windows reports interface_mtu as 4294967295 (UINT32_MAX) when the MTU is not available;


### PR DESCRIPTION
## Description

Monotonic runtime counters — accumulated CPU time, free/used memory, and interface byte/packet totals — were being compared as if they were regular inventory attributes. As a result, every syscollector scan produced a `modified` event for every process, every NIC, and the hardware record, even when nothing about the host actually changed. In one example deployment this accounted for 947 events, 24.8% of all IT Hygiene volume, across all five agents/platforms.

Closes #38017

## Proposed Changes

The fix has two parts, both required together:

1. **`wazuh_modules/syscollector/src/syscollectorImp.cpp`** — define per-table ignore lists (`HW_IGNORED_FIELDS`, `PROCESSES_IGNORED_FIELDS`, `NET_IFACE_IGNORED_FIELDS`) and pass them via dbsync's existing `input["options"]["ignore"]` mechanism in the hardware, process, and network-interface scan paths (this mechanism already existed in dbsync and was already used elsewhere in this same file, just never in these three scan paths). The same fields are also excluded from each item's checksum computation, so the checksum itself stays stable across scans where only these counters moved.
2. **`shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp`** (`SQLiteDBEngine::getRowDiff`) — dbsync's own `version`/`sync` bookkeeping columns are always present in the row diff regardless of what changed, so they were still counted as "non-ignored changes" and defeated the ignore list added in part 1. This change excludes `version`/`sync` from that check as well.

### Results and Evidence

**Bug side — pre-fix nightly build (`wazuh-agent1`)**

The issue's own "How to verify" section asks to confirm that `state.document_version` for hardware/interfaces keeps incrementing every scan, and that `dbsync_processes` only emits `modified` for `stime`/`utime`. Five sampling cycles (20s interval) confirmed exactly that mechanism on all three collectors:

- `processes` (`process.name=wazuh-modulesd`): 7 `Delta sent` occurrences across 5 cycles, every one naming only the two fields the fix now ignores:
  ```json
  {"changed_fields": ["process.stime", "process.utime"], "event_type": "modified"}
  ```
- `hardware` (singleton): 7 occurrences, always exactly:
  ```json
  {"collector":"dbsync_hwinfo","data":{"event":{"changed_fields":["host.memory.free","host.memory.used"],"created":"2026-07-30T01:05:38.741Z","type":"modified"},"host":{"cpu":{"cores":10,"name":"12th Gen Intel(R) Core(TM) i7-12650H","speed":2688},"memory":{"free":12328865792,"total":24454692864,"used":12125827072},"previous":{"memory":{"free":12319621120,"used":12135071744}},"serial_number":"0"}},"module":"inventory"}
  ```
  `free` moved by ~8.8 MB — routine fluctuation, nothing else in the record changed.
- `interfaces` (`interface.name=eth0`): 7 occurrences, always exactly the 4 active byte/packet counters:
  ```json
  {"collector":"dbsync_network_iface","data":{"event":{"changed_fields":["host.network.ingress.bytes","host.network.ingress.packets","host.network.egress.bytes","host.network.egress.packets"],"created":"2026-07-30T01:05:38.889Z","type":"modified"},"host":{"mac":["e2:aa:5e:b7:54:6f"],"network":{"egress":{"bytes":800335,"drops":0,"errors":0,"packets":1521},"ingress":{"bytes":793883,"packets":1504}}},"interface":{"alias":null,"mtu":1500,"name":"eth0","state":"up","type":"ethernet"}},"module":"inventory"}
  ```

Confirmed directly against the indexer too, not just the log — same query re-run once per sampling cycle (5 cycles, ~20s apart), shape identical for all 3 collectors (only the index and the entity `term` filter change):

```
curl -sk -u <user>:<pass> -X POST \
  "https://<indexer-host>:9200/wazuh-states-inventory-hardware/_search" \
  -H 'Content-Type: application/json' \
  -d '{"size":1,"sort":[{"state.modified_at":{"order":"desc"}}],"query":{"bool":{"must":[{"term":{"wazuh.agent.name":"wazuh-agent1"}}]}}}'
```

`document_version` and the checksum change every single cycle, for all three collectors:

```
hardware:
{"cycle": 1, "checksum": "a0fe87c98d...", "document_version": 1553, "modified_at": "2026-07-30T19:07:34.303Z"}
{"cycle": 2, "checksum": "a0fe87c98d...", "document_version": 1553, "modified_at": "2026-07-30T19:07:34.303Z"}
{"cycle": 3, "checksum": "944e62caa5...", "document_version": 1555, "modified_at": "2026-07-30T19:08:14.753Z"}
{"cycle": 4, "checksum": "093d85b8d1...", "document_version": 1557, "modified_at": "2026-07-30T19:08:55.248Z"}
{"cycle": 5, "checksum": "ca0e2d6b28...", "document_version": 1559, "modified_at": "2026-07-30T19:09:35.716Z"}

processes (wazuh-modulesd):
{"cycle": 1, "checksum": "827bc4f86a...", "document_version": 342, "modified_at": "2026-07-30T19:04:03.957Z"}
{"cycle": 2, "checksum": "2eddf92e04...", "document_version": 1, "modified_at": "2026-07-30T19:04:46.671Z"}
{"cycle": 3, "checksum": "1314152bb2...", "document_version": 3, "modified_at": "2026-07-30T19:05:27.143Z"}
{"cycle": 4, "checksum": "781e3edbcf...", "document_version": 5, "modified_at": "2026-07-30T19:06:07.612Z"}
{"cycle": 5, "checksum": "0d1fe5fae4...", "document_version": 7, "modified_at": "2026-07-30T19:06:48.090Z"}
(cycle 1's higher document_version, 342, is the pre-restart process's stale document — a new PID starts its own document at a low version, then climbs; see the restart-artifact note in the verification report for detail)

interfaces (eth0):
{"cycle": 1, "checksum": "9125daba9f...", "document_version": 1563, "modified_at": "2026-07-30T19:10:19.196Z"}
{"cycle": 2, "checksum": "9125daba9f...", "document_version": 1563, "modified_at": "2026-07-30T19:10:19.196Z"}
{"cycle": 3, "checksum": "897528705522...", "document_version": 1565, "modified_at": "2026-07-30T19:10:59.718Z"}
{"cycle": 4, "checksum": "7f0fa10a87...", "document_version": 1567, "modified_at": "2026-07-30T19:11:40.203Z"}
{"cycle": 5, "checksum": "b2b6eed8c4...", "document_version": 1569, "modified_at": "2026-07-30T19:12:20.680Z"}
```

**Fixed side — `wazuh-agent2`**

The identical 5-cycle/20s-interval verification was re-run against all three collectors:

| Collector | Delta occurrences (5 cycles) | Distinct checksums | `document_version` movement | Verdict |
|---|---|---|---|---|
| processes | 0 | 1 | 1 → 1 (stable) | `FIXED-LIKE` |
| hardware | 0 | 1 | 312 → 312 (stable) | `FIXED-LIKE` |
| interfaces | 0 | 1 | 312 → 312 (stable) | `FIXED-LIKE` |

Zero `Delta sent` log occurrences matching any of these collectors/entities across all 5 cycles for all three, versus 7 each on the bug-side run — a direct before/after comparison confirming the fix. The counters keep being sampled and stored on every scan (confirmed via the raw `Persisting Inventory event` log lines, where `host.memory.free`/`used` and process `stime`/`utime` continue to differ scan-to-scan) — they simply no longer participate in the diff/checksum that triggers a `modified` event, exactly as intended by the fix.

The same indexer query as above (`wazuh.agent.name: wazuh-agent2`) confirms it directly — one raw response:

<details>
<summary>Raw response, hardware (click to expand)</summary>

```json
{
  "took": 1,
  "timed_out": false,
  "_shards": { "total": 1, "successful": 1, "skipped": 0, "failed": 0 },
  "hits": {
    "total": { "value": 1, "relation": "eq" },
    "max_score": null,
    "hits": [
      {
        "_index": "wazuh-states-inventory-hardware",
        "_id": "wazuh_002_3d8f8efa51fe80ff83e14adaa8eb8c9cbae808c8",
        "_score": null,
        "_source": {
          "checksum": { "hash": { "sha1": "286d5453c11621e1ed7121436635a24b5e47b104" } },
          "host": {
            "memory": { "total": 24454692864, "used": 13086941184, "free": 11367751680 },
            "cpu": { "cores": 10, "name": "12th Gen Intel(R) Core(TM) i7-12650H", "speed": 2688 },
            "serial_number": "0"
          },
          "wazuh": {
            "cluster": { "name": "wazuh" },
            "agent": {
              "host": { "hostname": "wazuh-agent2", "os": { "name": "Ubuntu", "type": "linux", "version": "22.04.5 LTS (Jammy Jellyfish)", "platform": "ubuntu" }, "architecture": "x86_64" },
              "name": "wazuh-agent2",
              "groups": ["default"],
              "id": "002",
              "version": "v5.0.0"
            }
          },
          "state": { "document_version": 312, "modified_at": "2026-07-30T18:32:09.068Z" }
        },
        "sort": [1785436329068]
      }
    ]
  }
}
```

</details>

Re-run 5 times, ~20s apart: every collector's `document_version`, checksum, and `modified_at` come back byte-identical across all 5 samples (hardware/interfaces pinned at `document_version: 312`, processes at `1`) — the one sync that happened right after the fixed agent's install/restart, never rewritten again during the sampling window, versus the bug-side result above where every collector changes every cycle.

No dashboard/UI screenshots are used anywhere in this report — every claim above is backed by log lines and/or direct indexer queries, both reproducible by a reviewer without this test environment's dashboard.


**Fixed side — same indexer evidence for `processes` and `interfaces`**

`wazuh-agent2`'s `wazuh-modulesd` process (PID 7516) and its `eth0` interface happened to have been running continuously, unrestarted, for over 2 real days at the time of this check — giving a far longer soak than the 5×20s cycles above, with thousands of real scan cycles in between. Same query shape as the hardware one, pointed at the `processes` and `interfaces` indices instead:

```
curl -sk -u <user>:<pass> -X POST \
  "https://<indexer-host>:9200/wazuh-states-inventory-processes/_search" \
  -H 'Content-Type: application/json' \
  -d '{"size":1,"query":{"bool":{"must":[{"term":{"wazuh.agent.name":"wazuh-agent2"}},{"match":{"process.name":"wazuh-modulesd"}}]}}}'
```

<details>
<summary>Raw response, processes / wazuh-modulesd (click to expand)</summary>

```json
{
  "took": 1,
  "timed_out": false,
  "_shards": { "total": 1, "successful": 1, "skipped": 0, "failed": 0 },
  "hits": {
    "total": { "value": 1, "relation": "eq" },
    "max_score": 2.0,
    "hits": [
      {
        "_index": "wazuh-states-inventory-processes",
        "_id": "wazuh_002_71ea6ac894a43a5711bc297009a117b3208f362f",
        "_score": 2.0,
        "_source": {
          "process": {
            "args": null,
            "parent": { "pid": 1 },
            "utime": 12,
            "name": "wazuh-modulesd",
            "start": "2026-08-01T04:16:39.000Z",
            "pid": 7516,
            "stime": 13,
            "args_count": 0,
            "state": "S",
            "command_line": "/var/ossec/bin/wazuh-modulesd"
          },
          "checksum": { "hash": { "sha1": "0e698b437f8dbdb03bf27ca3afdc46fd4528ccfa" } },
          "wazuh": {
            "cluster": { "name": "wazuh" },
            "agent": {
              "host": { "hostname": "wazuh-agent2", "os": { "name": "Ubuntu", "type": "linux", "version": "22.04.5 LTS (Jammy Jellyfish)", "platform": "ubuntu" }, "architecture": "x86_64" },
              "name": "wazuh-agent2",
              "groups": ["default"],
              "id": "002",
              "version": "v5.0.0"
            }
          },
          "state": { "document_version": 1, "modified_at": "2026-08-01T04:16:39.772Z" }
        }
      }
    ]
  }
}
```

</details>

```
curl -sk -u <user>:<pass> -X POST \
  "https://<indexer-host>:9200/wazuh-states-inventory-interfaces/_search" \
  -H 'Content-Type: application/json' \
  -d '{"size":1,"query":{"bool":{"must":[{"term":{"wazuh.agent.name":"wazuh-agent2"}},{"match":{"interface.name":"eth0"}}]}}}'
```

<details>
<summary>Raw response, interfaces / eth0 (click to expand)</summary>

```json
{
  "took": 1,
  "timed_out": false,
  "_shards": { "total": 1, "successful": 1, "skipped": 0, "failed": 0 },
  "hits": {
    "total": { "value": 1, "relation": "eq" },
    "max_score": 1.0,
    "hits": [
      {
        "_index": "wazuh-states-inventory-interfaces",
        "_id": "wazuh_002_2a17861fe751d2d6d2ba037afe120e4a222df8f2",
        "_score": 1.0,
        "_source": {
          "checksum": { "hash": { "sha1": "25cd70c72eb6c3fa55212ed8efdc04473b9ac09c" } },
          "host": {
            "mac": ["e2:c3:62:a7:0c:41"],
            "network": {
              "ingress": { "drops": 0, "bytes": 12997, "errors": 0, "packets": 84 },
              "egress": { "drops": 0, "bytes": 4143, "errors": 0, "packets": 23 }
            }
          },
          "wazuh": {
            "cluster": { "name": "wazuh" },
            "agent": {
              "host": { "hostname": "wazuh-agent2", "os": { "name": "Ubuntu", "type": "linux", "version": "22.04.5 LTS (Jammy Jellyfish)", "platform": "ubuntu" }, "architecture": "x86_64" },
              "name": "wazuh-agent2",
              "groups": ["default"],
              "id": "002",
              "version": "v5.0.0"
            }
          },
          "state": { "document_version": 1, "modified_at": "2026-08-01T01:52:40.019Z" },
          "interface": { "name": "eth0", "alias": null, "state": "up", "type": "ethernet", "mtu": 1500 }
        }
      }
    ]
  }
}
```

</details>

Both queries were re-run 3 times, ~20s apart: `document_version`, checksum, and every field (including `utime`/`stime` and the four byte/packet counters) came back byte-identical on all 3 samples for both collectors — no drift at all, because dbsync only rewrites a row when a non-ignored field changes.

That last point is also worth sanity-checking directly: the counters *are* still sampled every scan, they just don't get written back to the row once they stop being the reason for a diff. Direct proof from the live host, at the same moment as the queries above:

- `/proc/7516/stat` (the same PID as above) reports `utime=99 stime=153` in raw ticks — far higher than the `utime:12`/`stime:13` frozen in the indexed document — confirming the process really has kept accumulating CPU time for 2+ days, it just isn't reflected in the persisted state anymore.
- `/proc/net/dev` for `eth0` reports `rx_bytes=166554 rx_packets=1525 tx_bytes=792923 tx_packets=1920` at the same moment — again far above the `ingress.bytes:12997`/`egress.bytes:4143` frozen in the indexed document.
- Across the full 2+ day log window: `grep -c "dbsync_network_iface"` on the agent log returns **0** — not one insert/modified/deleted delta was ever emitted for the interface after the initial sync. All `Delta sent` lines for `dbsync_processes` in that same window show `"changed_fields":[]` (process-exit events) — zero occurrences of `utime`/`stime` ever appearing as a changed field.


**`wazuh-agent1` upgraded in place to the fixed package — before/after on the same host, plus a "nothing breaks" pass**

`wazuh-agent1` is the same host used for the bug-side evidence above (pre-fix nightly build). To get a direct before/after on identical hardware, it was upgraded in place to the package built from this PR's head commit (`wazuh-agent_5.0.0-0_amd64_7df7cde.deb`, commit `7df7cde`) via this repo's install helper:

```
./install_wazuh.sh --target wazuh-agent1 --agent-package ./wazuh-agent_5.0.0-0_amd64_7df7cde.deb --manager manager
```

`dpkg` confirmed the version swap (`5.0.0-latest` → `5.0.0-0`), the agent re-enrolled cleanly, and `wazuh-control status` showed all 5 daemons running immediately after.

*Note on method:* to sample several scan cycles quickly, the syscollector `<interval>` was temporarily dropped from `1h` to `20s` (same as the `wazuh-agent2` methodology earlier in this report) and `wazuh_modules.debug=2` was set to get `Delta sent`/`Persisting Inventory event` debug lines. Both were reverted and the agent restarted back to defaults once evidence was collected. 

*Log-level evidence, patched build, ~20 scan cycles at 20s each:*

```
Delta sent, by collector (grep -o '"collector":"[a-z_]*"' | sort | uniq -c):
      4 "collector":"dbsync_processes"
(all 4 have "changed_fields":[] — process-exit events, not counter-triggered)

dbsync_hwinfo Delta sent occurrences: 0
dbsync_network_iface Delta sent occurrences: 0
```

Zero `modified` deltas attributable to `stime`/`utime`/memory/byte-packet counters — matching the `wazuh-agent2` result, now confirmed from the actual `.deb` build rather than a locally-compiled binary.

*Indexer evidence, same host, before vs. after the fix took effect:*

The hardware and `eth0` interface documents both carry `document_version: 73`, last written at `2026-08-03T12:24:1x`, i.e. from the last hourly scan under the **old, pre-fix build** (consistent with roughly one genuine version bump per hour over the ~2.5 days this agent ran the buggy build). From the moment the fixed package took over, that counter never moved again — re-queried 3 times, ~20s apart, well after the reinstall:

```
hw     cycle 1-3: document_version=73, checksum=c65b147aa2..., modified_at=2026-08-03T12:24:10.396Z  (unchanged across all 3)
eth0   cycle 1-3: document_version=73, checksum=3d17c47a14..., modified_at=2026-08-03T12:24:10.432Z  (unchanged across all 3)
```

...while the real, live counters on the same host kept climbing the whole time:

```
free -b (live):          used: 10355195904 → 10406408192   (~50MB more used, ~20 min apart)
/proc/net/dev eth0:       rx_bytes: 265808 → 266583, tx_bytes: 1164933 → 1167183
```

The sync pipeline itself was confirmed healthy in the same window (ruling out "nothing arrived because the pipe is broken" as an alternative explanation): the `processes` index picked up fresh `document_version: 1` inserts for every wazuh daemon's new PID immediately after the restart (`wazuh-modulesd` PID `13097`: `utime:23, stime:15, document_version:1` at `2026-08-03T13:10:23.551Z`), and re-querying that same PID 3 times ~20s apart returned that identical frozen snapshot — while `/proc/13097/stat` at the same moments showed the real counters had already moved on to `utime=275 stime=631`. Same frozen-document/live-counter pattern as `wazuh-agent2`, now on the upgraded host.

*Nothing else broke:* agent status stayed `active` throughout (API: `status: active`, `group_config_status: synced`, `lastKeepAlive` current), no `ERROR`/`CRITICAL` log lines appeared after the install, and every other syscollector table unrelated to this PR kept populating normally on the same agent: `packages` (239 docs), `users` (22), `groups` (43), `ports` (3), `networks` (3), `protocols` (3), `system` (1). None of those tables use an ignore list, so their continuing to sync as expected rules out any collateral damage from the fix.

**Does the upgrade itself trigger a one-time transition event? No — confirmed on `wazuh-agent1`.**

The upgrade path is worth calling out on its own, because it looks like it should force one event that has nothing to do with a "real" host change: the checksum formula changes with this fix (the old build hashes `memory_free`/`memory_used` etc. into the checksum; the new build excludes them). So the very first scan under the new binary computes a checksum that is virtually guaranteed to differ from whatever is already stored in the agent's local DB from the old binary — a genuine, unavoidable value change on that field.

That does **not** produce a `modified` event, because `"checksum"` is itself part of every affected table's ignore list (`HW_IGNORED_FIELDS`, `PROCESSES_IGNORED_FIELDS`, `NET_IFACE_IGNORED_FIELDS`). A change in the checksum alone — whether from an ignored counter moving or from the hashing formula itself changing — never counts as a qualifying diff in `getRowDiff`. Combined with the counters themselves being ignored, there is nothing left on the row to trigger a diff, *provided nothing else on that row genuinely changed at the same time*.

This is exactly what the `wazuh-agent1` upgrade showed: `document_version: 73` for both hardware and `eth0` is the version from the **last hourly scan under the old, pre-fix build** (`modified_at: 2026-08-03T12:24:10.x`) — it did not tick to `74` at any point during or after the reinstall, despite the checksum formula changing underneath it on the very next scan.

Two things worth separating from this, so the "no event on upgrade" claim isn't overstated:

- **PID churn on the agent's own daemons is expected and unrelated to this fix.** Upgrading restarts `wazuh-modulesd`/`wazuh-agentd`/etc., so their PIDs change — the `processes` table correctly showed ordinary insert (new PID) + delete (old PID gone) events for those daemons right after the restart (e.g. `wazuh-modulesd` PID `13097` got a fresh `document_version: 1` insert at `2026-08-03T13:10:23.551Z`). That's normal process-lifecycle churn any restart produces, with or without this PR — not something the ignore list is meant to (or does) suppress.
- **The locally stored checksum keeps the old formula's value for a while.** Because the diff is suppressed, `getDataToUpdate` never rewrites the row, so the agent's local DB (and the indexed document) keeps showing the checksum computed by the **old** build until some other genuinely-changed field forces a real rewrite of that row. Not a bug — the same "ignored fields don't get persisted on a suppressed diff" behavior discussed earlier in this report, now also applying to the checksum's own transition across the upgrade.

### Manual tests with their corresponding evidence

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux — a Linux amd64 `.deb` package containing this fix was built, installed, and run successfully in this verification; no explicit compiler-warning log was captured, so left unchecked
  - [ ] Windows — not exercised
  - [ ] MAC OS X — not exercised
- [ ] Log syntax and correct language review — not exercised

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity — not exercised
  - [ ] Valgrind (memcheck and descriptor leaks check) — not exercised
  - [ ] AddressSanitizer — not exercised
- Memory tests for Windows — N/A (not exercised on this platform)
- Memory tests for macOS — N/A (not exercised on this platform)

- Decoder/Rule tests _(Wazuh v4.x)_ — N/A, this change is agent-side C++ (dbsync/syscollector), not decoder/rule content
- Engine _(Wazuh v5.x and above)_ — N/A, no wazuh-engine changes in this PR
- Wazuh server API/Framework — N/A, no manager API/Framework changes in this PR

### Artifacts Affected

- `wazuh-agent` package (all supported platforms — the changed code, `shared_modules/dbsync` and `wazuh_modules/syscollector`, is shared/cross-platform; only the Linux amd64 build was actually compiled and verified here).

### Configuration Changes

N/A — no new configuration parameters and no changes to default values.

### Tests Introduced

- `shared_modules/dbsync/tests/interface/dbsync_test.cpp`: `DBSyncTest.syncRowIgnoreFieldsWithVersionColumn` — verifies that a table with a DB-managed `version` column still suppresses the `MODIFIED` callback when only an ignored field changes, and still fires it when a real field changes.
- `wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp`: `SyscollectorImpTest.ignoredCountersDoNotTriggerModifiedEventsAcrossScans` — end-to-end test across several simulated scan cycles where hardware memory, process CPU times, and network byte/packet counters change every cycle (as real monotonic counters do) while nothing else changes; asserts each of the three collectors persists exactly once (the initial insert) and never again.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...
