### PR TITLE
Windows agent: lift the 2 GB memory limit that crashes the FIM engine on large file servers [4.14.8]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Prevent a race condition in `randombytes` during the initialization of the Windows RSA key container ([#37701](https://github.com/wazuh/wazuh/pull/37701))
 - Fixed missing macOS SSH authentication logs by adding the `sshd-session` and `sshd-auth` processes to the default Unified Logging query. ([#37769](https://github.com/wazuh/wazuh/pull/37769))
 - Fixed the name, version and PyPI packages reported for Microsoft Store Python installations. ([#37441](https://github.com/wazuh/wazuh/pull/37441))
+- Fixed Windows agent out-of-memory crashes in the FIM engine on large file servers. ([#38061](https://github.com/wazuh/wazuh/pull/38061))
 
 #### Added
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -335,6 +335,8 @@ else
 		OSSEC_CFLAGS+=-Wl,-L,win32/ -Wl,-Bstatic,--whole-archive -lwinpthreadpatched -Wl,--no-whole-archive -Wl,-Bdynamic -ldelayimp -pthread -DBUILDING_LIBCURL="" -DPCRE2_EXP_DECL=""
 		OSSEC_LDFLAGS+=-Wl,-L,win32/ -Wl,-Bstatic,--whole-archive -lwinpthreadpatched -Wl,--no-whole-archive -Wl,-Bdynamic -ldelayimp -pthread -DBUILDING_LIBCURL="" -DPCRE2_EXP_DECL=""
 		AR_LDFLAGS+=-Wl,-L,win32/ -Wl,-Bstatic,--whole-archive -lwinpthreadpatched -Wl,--no-whole-archive -Wl,-Bdynamic -ldelayimp -pthread -DBUILDING_LIBCURL="" -DPCRE2_EXP_DECL=""
+		# Lift the 32-bit 2 GB user-space limit to ~4 GB on 64-bit Windows (issue #6800).
+		OSSEC_LDFLAGS+=-Wl,--large-address-aware
 		PRECOMPILED_OS:=windows
 endif # winagent
 


### PR DESCRIPTION
## Description

This PR fixes intermittent crashes of the Windows agent inside the FIM engine on busy file servers. The agent is a 32-bit process built **without** the Large-Address-Aware flag, so it is capped at ~2 GB of user virtual address space on 64-bit Windows regardless of server RAM. Under heavy FIM load the address space is exhausted and an uncaught `std::bad_alloc` aborts the process (`0x40000015` in `libstdc++-6.dll`). Marking the agent executables Large-Address-Aware lifts the limit to ~4 GB.

**Proposed Release:** v4.14.8

## Proposed Changes

- Updated `src/Makefile`: added `-Wl,--large-address-aware` to the `winagent` `OSSEC_LDFLAGS`, so `wazuh-agent.exe` and `wazuh-agent-eventchannel.exe` link Large-Address-Aware. (5.x forward-port lands the same flag via `add_link_options` in `src/win32/CMakeLists.txt`.)
- Added a `CHANGELOG.md` entry under Agent → Fixed.

### Results and Evidence

**Compile-time — the flag sets the bit.** Building a minimal 32-bit program with the same MinGW toolchain the agent uses (`i686-w64-mingw32-g++`), with and without the flag:

```bash
$ i686-w64-mingw32-g++ -O2 alloc.c -o nolaa.exe
$ i686-w64-mingw32-g++ -O2 -Wl,--large-address-aware alloc.c -o laa.exe
$ i686-w64-mingw32-objdump -x nolaa.exe | grep Characteristics
Characteristics 0x106
$ i686-w64-mingw32-objdump -x laa.exe | grep -A1 Characteristics
Characteristics 0x126
	large address aware
```

Same source, same toolchain — the only difference is the flag, which flips exactly the `0x20` (`IMAGE_FILE_LARGE_ADDRESS_AWARE`) bit. Running both on 64-bit Windows and reserving virtual address space until exhaustion shows the ceiling roughly doubles:

```
nolaa.exe (0x106, no LAA):  reserved_MB=1920   # ~2 GB
laa.exe   (0x126, LAA):     reserved_MB=3904   # ~4 GB
```

**Runtime — the bit lifts the ceiling.** Validated on a Windows 11 x64 VM with the official **4.14.4** agent (binaries byte-identical to the reporter's: agent PE TimeStamp `0x69B3E753`, `libwazuhext.dll` `0x69B3E63B`).

**Before — 32-bit, not Large-Address-Aware (2 GB ceiling):**

```bash
# PE header of the shipped agent
wazuh-agent.exe   arch=x86(32-bit)  LargeAddressAware=False  Characteristics=0x0106
```

Driving the in-memory FIM DB, the process dies at the 2 GB wall with the reporter's `Report (5)` signature:

```sql
PM=1921 MB  Virt=2040 MB   <-- 2 GB wall, process gone

Faulting application name: wazuh-agent.exe, version: 4.14.4.0, time stamp: 0x69b3e753
Faulting module name: libstdc++-6.dll, version: 0.0.0.0, time stamp: 0x00000000
Exception code: 0x40000015
Fault offset: 0x000ed794
```

When the failing allocation is a checked one, the same exhaustion is also seen on the affected host as:

```sql
CRITICAL: (1102): Could not acquire memory due to [(12)-(Not enough space)].
```

**After — Large-Address-Aware (the flag sets `IMAGE_FILE_LARGE_ADDRESS_AWARE`, `0x0106 -> 0x0126`):**

```bash
wazuh-agent.exe   Characteristics=0x0126  LargeAddressAware=True
```

Same load, same dataset — the process now sails past the old 2 GB death point and keeps running (private bytes above 2 GB is impossible for a non-LAA 32-bit process):

```bash
MEM svc=Running PM_MB=1910 Virt_MB=2033   # old crash point, still alive
MEM svc=Running PM_MB=1968 Virt_MB=2096
MEM svc=Running PM_MB=2025 Virt_MB=2157
MEM svc=Running PM_MB=2088 Virt_MB=2223   # >2 GB, still Running
```

The flag was verified with the agent's own MinGW toolchain (compile-time proof above); the full agent cross-build runs in CI.

### Artifacts Affected

- `src/Makefile`
- `CHANGELOG.md`

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Manual verification on Windows.
- **Details:** Reproduced the OOM crash 1:1 on customer-identical 4.14.4 binaries (WER matches `Report (5)`), applied the Large-Address-Aware bit, and confirmed the agent runs past the previous 2 GB crash point (reached ~2.2 GB and still running) under the same FIM load.

## Review Checklist

**Manual tests with their corresponding evidence:**

- Compilation without warnings on every supported platform
    - [ ] Linux
    - [ ] Windows
    - [ ] MAC OS X
- [ ] Log syntax and correct language review
- Memory tests for Linux
    - [ ] Coverity
    - [ ] Valgrind (memcheck and descriptor leaks check)
    - [ ] AddressSanitizer

**General Checklist:**

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
