### PR TITLE
Windows agent: lift the 2 GB memory limit that crashes the FIM engine on large file servers [5.0.0]

### DIFF
--- a/src/win32/CMakeLists.txt
+++ b/src/win32/CMakeLists.txt
@@ -17,6 +17,9 @@ endif()
 
 add_definitions(-DWIN32=1 -DCLIENT -D_POSIX_C_SOURCE -DPSAPI_VERSION=1)
 
+# Lift the 32-bit 2 GB user-space limit to ~4 GB on 64-bit Windows (issue #6800).
+add_link_options(-Wl,--large-address-aware)
+
 include_directories(
   ${SRC_FOLDER}/
   ${SRC_FOLDER}/shared/include/


### PR DESCRIPTION
## Description

This PR fixes intermittent crashes of the Windows agent inside the FIM engine on busy file servers. The agent is a 32-bit process built **without** the Large-Address-Aware flag, so it is capped at ~2 GB of user virtual address space on 64-bit Windows regardless of server RAM. Under heavy FIM load the address space is exhausted and an uncaught `std::bad_alloc` aborts the process (`0x40000015` in `libstdc++-6.dll`). Marking the agent executables Large-Address-Aware lifts the limit to ~4 GB.

This is the 5.0.0 counterpart of the 4.14.8 fix; on 5.x the Windows agent is built with CMake, so the flag is added via `add_link_options` instead of the Makefile.

**Proposed Release:** v5.0.0

## Proposed Changes

- Updated `src/win32/CMakeLists.txt`: added `add_link_options(-Wl,--large-address-aware)` so the Windows agent executables (`wazuh-agent.exe`, `wazuh-agent-eventchannel.exe`, …) link Large-Address-Aware.

### Results and Evidence

**Compile-time — the CMake directive sets the bit.** A minimal CMake project cross-compiled with the agent's MinGW toolchain (`i686-w64-mingw32`), built with and without the exact directive this PR adds:

```bash
# CMakeLists.txt: if(LAA) add_link_options(-Wl,--large-address-aware) endif()
$ cmake -B b_OFF -DLAA=OFF && cmake --build b_OFF
$ cmake -B b_ON  -DLAA=ON  && cmake --build b_ON
$ i686-w64-mingw32-objdump -x b_OFF/probe.exe | grep -iE 'Characteristics|large address'
Characteristics 0x106
$ i686-w64-mingw32-objdump -x b_ON/probe.exe  | grep -iE 'Characteristics|large address'
Characteristics 0x126
	large address aware
```

Only difference is the directive, which flips exactly the `0x20` (`IMAGE_FILE_LARGE_ADDRESS_AWARE`) bit.

**Runtime — the bit lifts the ceiling.** Running both CMake-built binaries on 64-bit Windows and reserving virtual address space until exhaustion:

```
probe (0x106, no LAA):  reserved_MB=1920   # ~2 GB
probe (0x126, LAA):     reserved_MB=3904   # ~4 GB
```

The end-to-end crash and its fix were reproduced on the shipped 32-bit agent (same 32-bit, non-LAA build as 5.x). Without LAA the FIM engine dies at the 2 GB wall with the reporter's `Report (5)` signature:

```sql
PM=1921 MB  Virt=2040 MB   <-- 2 GB wall, process gone

Faulting application name: wazuh-agent.exe
Faulting module name: libstdc++-6.dll
Exception code: 0x40000015
Fault offset: 0x000ed794
```

With the Large-Address-Aware bit set, the same load runs past that point and keeps going (private bytes above 2 GB is impossible for a non-LAA 32-bit process):

```bash
MEM svc=Running PM_MB=1910 Virt_MB=2033   # old crash point, still alive
MEM svc=Running PM_MB=2088 Virt_MB=2223   # >2 GB, still Running
```

The directive was verified with the agent's own MinGW toolchain (compile-time proof above); the full agent cross-build runs in CI.

### Artifacts Affected

- `src/win32/CMakeLists.txt`

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Manual verification on Windows.
- **Details:** Verified the `add_link_options` directive sets `IMAGE_FILE_LARGE_ADDRESS_AWARE` (CMake + MinGW), that the resulting binary reserves ~3.9 GB vs ~1.9 GB of virtual address space, and reproduced the OOM crash and its resolution on the shipped 32-bit agent.

## Review Checklist

**Manual tests with their corresponding evidence:**

- Compilation without warnings on every supported platform
    - [ ] Linux
    - [ ] Windows
    - [ ] MAC OS X
- [ ] Log syntax and correct language review
- Memory tests for Linux
    - [ ] Coverity
    - [ ] Valgrind (memcheck and descriptor leaks check)
    - [ ] AddressSanitizer

**General Checklist:**

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
