### PR TITLE
Skip feed-update vulnerability scan for agents without package inventory

### DIFF
--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
@@ -415,6 +415,17 @@ private:
             logWarn(WM_VULNSCAN_LOGTAG, "Failed to retrieve packages for agent %s: %s.", agent.id.c_str(), e.what());
         }
 
+        // No package inventory means no completed baseline (VDFirst aborts on empty inventory):
+        // scanning here would alert on a silent baseline or wipe valid vulnerability state.
+        if (context->packageCount() == 0)
+        {
+            logInfo(WM_VULNSCAN_LOGTAG,
+                    "Skipping feed update scan for agent %s: no package inventory available "
+                    "(first scan not completed yet, VDFirst will cover the updated feed).",
+                    agent.id.c_str());
+            return;
+        }
+
         try
         {
             fetchInventoryDocuments(std::string(HOTFIX_INDEX),

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanAgentList_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanAgentList_test.cpp
@@ -108,10 +108,12 @@ TEST_F(ScanAgentListTest, ScanRunnerNotConfiguredDoesNotThrow)
     auto indexerConnector = std::make_shared<MockIndexerConnector>();
     TScanAgentList<ScanContext, MockIndexerConnector> scanAgents(indexerConnector, {});
 
+    const auto packageResponse = makeSearchResponse(nlohmann::json::array({makePackageHit("wazuh_003_4a08e5")}));
     const auto emptyResponse = makeSearchResponse(nlohmann::json::array());
 
     EXPECT_CALL(*indexerConnector, executeSearchQuery(_, _))
-        .WillRepeatedly(Invoke([&](const std::string&, const nlohmann::json&) { return emptyResponse; }));
+        .WillRepeatedly(Invoke([&](const std::string& index, const nlohmann::json&)
+                               { return index == std::string(PACKAGE_INDEX) ? packageResponse : emptyResponse; }));
 
     auto data = std::make_shared<ScanContext>();
     data->m_agents.emplace_back(makeAgent("003"));
@@ -130,10 +132,12 @@ TEST_F(ScanAgentListTest, ScanRunnerThrowsAddsAgentToRescanList)
     };
     TScanAgentList<ScanContext, MockIndexerConnector> scanAgents(indexerConnector, scanRunner);
 
+    const auto packageResponse = makeSearchResponse(nlohmann::json::array({makePackageHit("wazuh_003_4a08e5")}));
     const auto emptyResponse = makeSearchResponse(nlohmann::json::array());
 
     EXPECT_CALL(*indexerConnector, executeSearchQuery(_, _))
-        .WillRepeatedly(Invoke([&](const std::string&, const nlohmann::json&) { return emptyResponse; }));
+        .WillRepeatedly(Invoke([&](const std::string& index, const nlohmann::json&)
+                               { return index == std::string(PACKAGE_INDEX) ? packageResponse : emptyResponse; }));
 
     auto data = std::make_shared<ScanContext>();
     data->m_agents.emplace_back(makeAgent("003"));
@@ -206,10 +210,12 @@ TEST_F(ScanAgentListTest, UsesAgentOsWhenNoOsInventory)
     };
     TScanAgentList<ScanContext, MockIndexerConnector> scanAgents(indexerConnector, scanRunner);
 
+    const auto packageResponse = makeSearchResponse(nlohmann::json::array({makePackageHit("wazuh_003_4a08e5")}));
     const auto emptyResponse = makeSearchResponse(nlohmann::json::array());
 
     EXPECT_CALL(*indexerConnector, executeSearchQuery(_, _))
-        .WillRepeatedly(Invoke([&](const std::string&, const nlohmann::json&) { return emptyResponse; }));
+        .WillRepeatedly(Invoke([&](const std::string& index, const nlohmann::json&)
+                               { return index == std::string(PACKAGE_INDEX) ? packageResponse : emptyResponse; }));
 
     auto data = std::make_shared<ScanContext>();
     data->m_agents.emplace_back(makeAgent("003"));
@@ -219,6 +225,32 @@ TEST_F(ScanAgentListTest, UsesAgentOsWhenNoOsInventory)
     ASSERT_EQ(scans.size(), 1u);
     EXPECT_EQ(std::string(scans.front()->osName()), "Ubuntu");
     EXPECT_EQ(std::string(scans.front()->osArchitecture()), "x86_64");
+}
+
+TEST_F(ScanAgentListTest, SkipsScanWhenNoPackageInventory)
+{
+    auto indexerConnector = std::make_shared<MockIndexerConnector>();
+    std::vector<std::shared_ptr<ScanContext>> scans;
+    auto scanRunner = [&](std::shared_ptr<ScanContext> ctx)
+    {
+        scans.push_back(std::move(ctx));
+    };
+    TScanAgentList<ScanContext, MockIndexerConnector> scanAgents(indexerConnector, scanRunner);
+
+    const auto osResponse = makeSearchResponse(nlohmann::json::array({makeOsHit()}));
+    const auto emptyResponse = makeSearchResponse(nlohmann::json::array());
+
+    EXPECT_CALL(*indexerConnector, executeSearchQuery(_, _))
+        .WillRepeatedly(Invoke([&](const std::string& index, const nlohmann::json&)
+                               { return index == std::string(OS_INDEX) ? osResponse : emptyResponse; }));
+
+    auto data = std::make_shared<ScanContext>();
+    data->m_agents.emplace_back(makeAgent("003"));
+
+    auto result = scanAgents.handleRequest(data);
+    ASSERT_NE(result, nullptr);
+    EXPECT_TRUE(scans.empty());
+    EXPECT_TRUE(result->m_agentsWithIncompletedScan.empty());
 }
 
 TEST_F(ScanAgentListTest, UsesInventoryDataEvenWhenIncomplete)
@@ -233,6 +265,7 @@ TEST_F(ScanAgentListTest, UsesInventoryDataEvenWhenIncomplete)
 
     nlohmann::json osHit = {{"_id", "os_001"}, {"_source", {{"host", {{"os", {{"name", "Debian"}}}}}}}};
     const auto osResponse = makeSearchResponse(nlohmann::json::array({osHit}));
+    const auto packageResponse = makeSearchResponse(nlohmann::json::array({makePackageHit("wazuh_003_4a08e5")}));
     const auto emptyResponse = makeSearchResponse(nlohmann::json::array());
 
     EXPECT_CALL(*indexerConnector, executeSearchQuery(_, _))
@@ -242,6 +275,10 @@ TEST_F(ScanAgentListTest, UsesInventoryDataEvenWhenIncomplete)
                 if (index == std::string(OS_INDEX))
                 {
                     return osResponse;
+                }
+                if (index == std::string(PACKAGE_INDEX))
+                {
+                    return packageResponse;
                 }
                 return emptyResponse;
             }));
@@ -277,6 +314,7 @@ TEST_F(ScanAgentListTest, PaginatesInventoryResultsWhenPageIsFull)
     }
     const auto osResponseFirst = makeSearchResponse(firstPage);
     const auto osResponseSecond = makeSearchResponse(nlohmann::json::array({makeOsHitWithId("os_last")}));
+    const auto packageResponse = makeSearchResponse(nlohmann::json::array({makePackageHit("wazuh_003_4a08e5")}));
     const auto emptyResponse = makeSearchResponse(nlohmann::json::array());
 
     size_t osCalls = 0;
@@ -288,6 +326,10 @@ TEST_F(ScanAgentListTest, PaginatesInventoryResultsWhenPageIsFull)
                 {
                     ++osCalls;
                     return osCalls == 1 ? osResponseFirst : osResponseSecond;
+                }
+                if (index == std::string(PACKAGE_INDEX))
+                {
+                    return packageResponse;
                 }
                 return emptyResponse;
             }));
@@ -314,6 +356,7 @@ TEST_F(ScanAgentListTest, SkipsHotfixWhenNameMissing)
 
     nlohmann::json hotfixHit = {{"_id", "hf_001"}, {"_source", {{"package", {{"hotfix", {{"name", ""}}}}}}}};
     const auto hotfixResponse = makeSearchResponse(nlohmann::json::array({hotfixHit}));
+    const auto packageResponse = makeSearchResponse(nlohmann::json::array({makePackageHit("wazuh_003_4a08e5")}));
     const auto emptyResponse = makeSearchResponse(nlohmann::json::array());
 
     EXPECT_CALL(*indexerConnector, executeSearchQuery(_, _))
@@ -323,6 +366,10 @@ TEST_F(ScanAgentListTest, SkipsHotfixWhenNameMissing)
                 if (index == std::string(HOTFIX_INDEX))
                 {
                     return hotfixResponse;
+                }
+                if (index == std::string(PACKAGE_INDEX))
+                {
+                    return packageResponse;
                 }
                 return emptyResponse;
             }));
@@ -346,6 +393,7 @@ TEST_F(ScanAgentListTest, HandlesOsQueryExceptionAndUsesAgentFallback)
     };
     TScanAgentList<ScanContext, MockIndexerConnector> scanAgents(indexerConnector, scanRunner);
 
+    const auto packageResponse = makeSearchResponse(nlohmann::json::array({makePackageHit("wazuh_003_4a08e5")}));
     const auto emptyResponse = makeSearchResponse(nlohmann::json::array());
 
     EXPECT_CALL(*indexerConnector, executeSearchQuery(_, _))
@@ -355,6 +403,10 @@ TEST_F(ScanAgentListTest, HandlesOsQueryExceptionAndUsesAgentFallback)
                 if (index == std::string(OS_INDEX))
                 {
                     throw std::runtime_error("os query failed");
+                }
+                if (index == std::string(PACKAGE_INDEX))
+                {
+                    return packageResponse;
                 }
                 return emptyResponse;
             }));
@@ -369,7 +421,7 @@ TEST_F(ScanAgentListTest, HandlesOsQueryExceptionAndUsesAgentFallback)
     EXPECT_EQ(std::string(scans.front()->osArchitecture()), "x86_64");
 }
 
-TEST_F(ScanAgentListTest, HandlesPackageQueryExceptionAndKeepsOsData)
+TEST_F(ScanAgentListTest, SkipsScanWhenPackageQueryFails)
 {
     auto indexerConnector = std::make_shared<MockIndexerConnector>();
     std::vector<std::shared_ptr<ScanContext>> scans;
@@ -402,9 +454,8 @@ TEST_F(ScanAgentListTest, HandlesPackageQueryExceptionAndKeepsOsData)
 
     auto result = scanAgents.handleRequest(data);
     ASSERT_NE(result, nullptr);
-    ASSERT_EQ(scans.size(), 1u);
-    EXPECT_EQ(std::string(scans.front()->osName()), "Ubuntu");
-    EXPECT_EQ(scans.front()->packageCount(), 0u);
+    EXPECT_TRUE(scans.empty());
+    EXPECT_TRUE(result->m_agentsWithIncompletedScan.empty());
 }
 
 TEST_F(ScanAgentListTest, HandlesHotfixQueryExceptionAndKeepsPackages)
@@ -474,6 +525,7 @@ TEST_F(ScanAgentListTest, ParsesOsDistributionAndKernelData)
                                   {"distribution", {{"release", "jammy"}}},
                                   {"kernel", {{"version", "5.15.0"}, {"release", "5.15.0-100"}}}}}}}}}};
     const auto osResponse = makeSearchResponse(nlohmann::json::array({osHit}));
+    const auto packageResponse = makeSearchResponse(nlohmann::json::array({makePackageHit("wazuh_003_4a08e5")}));
     const auto emptyResponse = makeSearchResponse(nlohmann::json::array());
 
     EXPECT_CALL(*indexerConnector, executeSearchQuery(_, _))
@@ -483,6 +535,10 @@ TEST_F(ScanAgentListTest, ParsesOsDistributionAndKernelData)
                 if (index == std::string(OS_INDEX))
                 {
                     return osResponse;
+                }
+                if (index == std::string(PACKAGE_INDEX))
+                {
+                    return packageResponse;
                 }
                 return emptyResponse;
             }));
@@ -544,8 +600,8 @@ TEST_F(ScanAgentListTest, SkipsPackageWhenDocIdMissingOrEmptySuffix)
     TScanAgentList<ScanContext, MockIndexerConnector> scanAgents(indexerConnector, scanRunner);
 
     nlohmann::json missingIdHit = {{"_source", {{"package", {{"name", "pkg"}}}}}};
-    const auto packageResponse =
-        makeSearchResponse(nlohmann::json::array({missingIdHit, makePackageHit("wazuh_003_")}));
+    const auto packageResponse = makeSearchResponse(
+        nlohmann::json::array({missingIdHit, makePackageHit("wazuh_003_"), makePackageHit("wazuh_003_4a08e5")}));
     const auto emptyResponse = makeSearchResponse(nlohmann::json::array());
 
     EXPECT_CALL(*indexerConnector, executeSearchQuery(_, _))
@@ -565,7 +621,8 @@ TEST_F(ScanAgentListTest, SkipsPackageWhenDocIdMissingOrEmptySuffix)
     auto result = scanAgents.handleRequest(data);
     ASSERT_NE(result, nullptr);
     ASSERT_EQ(scans.size(), 1u);
-    EXPECT_EQ(scans.front()->packageCount(), 0u);
+    EXPECT_EQ(scans.front()->packageCount(), 1u);
+    EXPECT_NE(scans.front()->findPackageByDetectionBase("003_4a08e5"), nullptr);
 }
 
 TEST_F(ScanAgentListTest, SkipsMalformedInventoryResponses)
@@ -579,7 +636,7 @@ TEST_F(ScanAgentListTest, SkipsMalformedInventoryResponses)
     TScanAgentList<ScanContext, MockIndexerConnector> scanAgents(indexerConnector, scanRunner);
 
     const auto missingHitsArray = nlohmann::json {{"hits", nlohmann::json::object()}};
-    const auto hitsNotArray = nlohmann::json {{"hits", {{"hits", nlohmann::json::object()}}}};
+    const auto packageResponse = makeSearchResponse(nlohmann::json::array({makePackageHit("wazuh_003_4a08e5")}));
 
     EXPECT_CALL(*indexerConnector, executeSearchQuery(_, _))
         .WillRepeatedly(Invoke(
@@ -591,7 +648,7 @@ TEST_F(ScanAgentListTest, SkipsMalformedInventoryResponses)
                 }
                 if (index == std::string(PACKAGE_INDEX))
                 {
-                    return hitsNotArray;
+                    return packageResponse;
                 }
                 if (index == std::string(HOTFIX_INDEX))
                 {
@@ -606,7 +663,7 @@ TEST_F(ScanAgentListTest, SkipsMalformedInventoryResponses)
     auto result = scanAgents.handleRequest(data);
     ASSERT_NE(result, nullptr);
     ASSERT_EQ(scans.size(), 1u);
-    EXPECT_EQ(scans.front()->packageCount(), 0u);
+    EXPECT_EQ(scans.front()->packageCount(), 1u);
     EXPECT_EQ(scans.front()->hotfixCount(), 0u);
     EXPECT_EQ(std::string(scans.front()->osName()), "Ubuntu");
     EXPECT_EQ(std::string(scans.front()->osArchitecture()), "x86_64");
@@ -623,7 +680,8 @@ TEST_F(ScanAgentListTest, SkipsPackageWhenNameMissing)
     TScanAgentList<ScanContext, MockIndexerConnector> scanAgents(indexerConnector, scanRunner);
 
     nlohmann::json noNameHit = {{"_id", "wazuh_003_noname"}, {"_source", {{"package", {{"version", "1.0"}}}}}};
-    const auto packageResponse = makeSearchResponse(nlohmann::json::array({noNameHit}));
+    const auto packageResponse =
+        makeSearchResponse(nlohmann::json::array({noNameHit, makePackageHit("wazuh_003_4a08e5")}));
     const auto emptyResponse = makeSearchResponse(nlohmann::json::array());
 
     EXPECT_CALL(*indexerConnector, executeSearchQuery(_, _))
@@ -643,7 +701,7 @@ TEST_F(ScanAgentListTest, SkipsPackageWhenNameMissing)
     auto result = scanAgents.handleRequest(data);
     ASSERT_NE(result, nullptr);
     ASSERT_EQ(scans.size(), 1u);
-    EXPECT_EQ(scans.front()->packageCount(), 0u);
+    EXPECT_EQ(scans.front()->packageCount(), 1u);
     EXPECT_EQ(scans.front()->findPackageByDetectionBase("003_noname"), nullptr);
 }
 


### PR DESCRIPTION
## Description

On a cold-start manager, the post-feed-update scan (SAFU) can reach an agent before that agent's first scan (`VDFirst`). The SAFU path uses the `FullScan` chain, which emits alerts unconditionally, so the agent's baseline is alerted instead of silently indexed. Measured on a fresh 5.0.0-rc1 AIO: 251 `vulnerability-detected` events for a macOS agent at feed-load time, all OS-category CVEs evaluated from the global.db enrollment data alone (`0 packages scanned, 251 new`).

Closes #38072

## Proposed Changes

`TScanAgentList::scanAgent` now skips the feed-update scan when the agent has no package inventory in the indexer. An agent without synced package inventory has not completed `VDFirst`, so its pending `VDFirst` session owns the full scan with the updated feed (in the reported case it arrived 2 seconds later). The same guard protects the opposite direction: running the `FullScan` chain with an empty inventory against an already-scanned agent would resolve and delete all its package vulnerability state (e.g. after a transient indexer query failure). This mirrors the existing `VDFirst` empty-inventory guard in `runScan`.

The skip is logged explicitly:

```
Skipping feed update scan for agent 002: no package inventory available (first scan not completed yet, VDFirst will cover the updated feed).
```

### Results and Evidence

Bug evidence (fresh 5.0.0-rc1 AIO, agents enrolled during the initial CVE feed download — full detail in #38072):

```
2026/07/29 10:37:56 vulnerability-scanner: INFO: Vulnerability scan start: agent='002' (v5.0.0) type=full reason=feed_update
2026/07/29 10:37:56 vulnerability-scanner: INFO: Agent '002' - Packages scan completed in 0 ms: 0 packages scanned, 0 skipped, 0 vulnerable packages
2026/07/29 10:37:56 vulnerability-scanner: INFO: Agent '002' - Vulnerability scan completed: 251 new, 0 solved
```

251 `vulnerability-detected` events indexed in `.ds-wazuh-events-v5-*` at `10:37:56.86x`, all for agent 002, before its `VDFirst` at `10:37:58` (which logged the expected alert suppression).

Unit test run (to be added, run in progress):

```
pending
```

### Artifacts Affected

- `libvulnerability_scanner.so` (wazuh-manager, Linux)

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

- `ScanAgentListTest.SkipsScanWhenNoPackageInventory`: agent with OS inventory but no packages is not scanned and is not added to the rescan list.
- `ScanAgentListTest.SkipsScanWhenPackageQueryFails` (repurposed from `HandlesPackageQueryExceptionAndKeepsOsData`): a failed package query no longer produces an empty-inventory scan.
- Existing `ScanAgentList` tests that asserted scanning with an empty package inventory now provide a package document, preserving their original intent (OS fallback, pagination, malformed responses, invalid package documents).

## Review Checklist
- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
