### PR TITLE
Render each changelog block as a table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,103 +4,119 @@
 
 #### Added
 
-- Added cluster-by-default deployment model: all Wazuh Server installations now run as a cluster node, removing the distinction between clustered and non-clustered deployments. The `cluster.disabled` configuration option has been removed. ([#31295](https://github.com/wazuh/wazuh/issues/31295))
-- Added stateless metadata enrichment in `remoted`, centralizing event metadata handling for stateless messages and removing the dependency on `wazuh-db` for that ingestion path. ([#33269](https://github.com/wazuh/wazuh/issues/33269))
-- Added Engine enrichment support: IOC matching, GeoIP lookup, and event filters. ([#33493](https://github.com/wazuh/wazuh/issues/33493))
-- Added Engine adaptation tier 2: raw archives handling, uncategorized event routing, input-level throttling, and internal metrics exposure. ([#34477](https://github.com/wazuh/wazuh/issues/34477))
-- Added CVSS v4.0 support to the Vulnerability Scanner. ([#35623](https://github.com/wazuh/wazuh/issues/35623))
-- Added Engine metrics collection, normalization, and indexing pipeline. ([#35771](https://github.com/wazuh/wazuh/issues/35771))
-- Added new CVE 5.0 schema fields to the Vulnerability Detector content model. ([#36000](https://github.com/wazuh/wazuh/issues/36000))
-- Added manager watermarks. ([#35579](https://github.com/wazuh/wazuh/issues/35579))
-- Added byte-based capacity limits to wazuh-manager-remoted. ([#37052](https://github.com/wazuh/wazuh/issues/37052))
-- Added default API role mappings for the indexer users wazuh-admin, wazuh-readonly and wazuh-demo. ([#37706](https://github.com/wazuh/wazuh/issues/37706))
+| Issue | Comment |
+|-------|---------|
+| [#31295](https://github.com/wazuh/wazuh/issues/31295) | Added cluster-by-default deployment model: all Wazuh Server installations now run as a cluster node, removing the distinction between clustered and non-clustered deployments. The `cluster.disabled` configuration option has been removed. |
+| [#33269](https://github.com/wazuh/wazuh/issues/33269) | Added stateless metadata enrichment in `remoted`, centralizing event metadata handling for stateless messages and removing the dependency on `wazuh-db` for that ingestion path. |
+| [#33493](https://github.com/wazuh/wazuh/issues/33493) | Added Engine enrichment support: IOC matching, GeoIP lookup, and event filters. |
+| [#34477](https://github.com/wazuh/wazuh/issues/34477) | Added Engine adaptation tier 2: raw archives handling, uncategorized event routing, input-level throttling, and internal metrics exposure. |
+| [#35623](https://github.com/wazuh/wazuh/issues/35623) | Added CVSS v4.0 support to the Vulnerability Scanner. |
+| [#35771](https://github.com/wazuh/wazuh/issues/35771) | Added Engine metrics collection, normalization, and indexing pipeline. |
+| [#36000](https://github.com/wazuh/wazuh/issues/36000) | Added new CVE 5.0 schema fields to the Vulnerability Detector content model. |
+| [#35579](https://github.com/wazuh/wazuh/issues/35579) | Added manager watermarks. |
+| [#37052](https://github.com/wazuh/wazuh/issues/37052) | Added byte-based capacity limits to wazuh-manager-remoted. |
+| [#37706](https://github.com/wazuh/wazuh/issues/37706) | Added default API role mappings for the indexer users wazuh-admin, wazuh-readonly and wazuh-demo. |
 
 #### Changed
 
-- Upgraded embedded Python interpreter from 3.10 to 3.12. ([#33377](https://github.com/wazuh/wazuh/issues/33377)) ([#33570](https://github.com/wazuh/wazuh/issues/33570))
-- Adapted Vulnerability Detector input pipeline to the new Wazuh 5.0 synchronization algorithm, covering first-scan, inventory-change, and feed-update scenarios. ([#30535](https://github.com/wazuh/wazuh/issues/30535))
-- Removed legacy configuration surfaces, database schemas, build targets, and compatibility layers in the second server cleanup phase. ([#34608](https://github.com/wazuh/wazuh/issues/34608))
-- Reduced `wazuh-manager` Debian package dependencies, removed `adduser`, `lsb-release`, `debconf`, and `libc6`. ([#35881](https://github.com/wazuh/wazuh/issues/35881))
-- Upgraded external dependencies: `curl`, `sqlite`, `xz`, and `libarchive`. ([#29734](https://github.com/wazuh/wazuh/issues/29734))
-- Implemented cooperative-cancellation graceful termination for `wmodules`. ([#34479](https://github.com/wazuh/wazuh/issues/34479))
-- Included source IP in `wazuh-remoted` log messages. ([#35358](https://github.com/wazuh/wazuh/pull/35358))
-- Preserved manager configuration files during package upgrades. ([#35478](https://github.com/wazuh/wazuh/issues/35478))
-- Improved Wazuh server directory layout. ([#35479](https://github.com/wazuh/wazuh/issues/35479))
-- Updated manager index names to align with the new sync model. ([#35525](https://github.com/wazuh/wazuh/issues/35525))
-- Added caller module context to indexer-connector logs. ([#35905](https://github.com/wazuh/wazuh/issues/35905))
-- Randomized the cluster key generated during manager installation instead of using a hardcoded default. ([#36805](https://github.com/wazuh/wazuh/issues/36805))
-- Changed the default Indexer user used by the Manager from `admin` to the restricted `wazuh-server` user, aligning with the Indexer RBAC least-privilege model. ([#36311](https://github.com/wazuh/wazuh/issues/36311))
-- Enabled shared-password agent enrollment by default, persisting the auto-generated `authd.pass` and synchronizing it to worker nodes, with fail-closed password validation. ([#36705](https://github.com/wazuh/wazuh/issues/36705))
-- Adapted API integration tests. ([#32698](https://github.com/wazuh/wazuh/issues/32698))
+| Issue | Comment |
+|-------|---------|
+| [#33377](https://github.com/wazuh/wazuh/issues/33377) [#33570](https://github.com/wazuh/wazuh/issues/33570) | Upgraded embedded Python interpreter from 3.10 to 3.12. |
+| [#30535](https://github.com/wazuh/wazuh/issues/30535) | Adapted Vulnerability Detector input pipeline to the new Wazuh 5.0 synchronization algorithm, covering first-scan, inventory-change, and feed-update scenarios. |
+| [#34608](https://github.com/wazuh/wazuh/issues/34608) | Removed legacy configuration surfaces, database schemas, build targets, and compatibility layers in the second server cleanup phase. |
+| [#35881](https://github.com/wazuh/wazuh/issues/35881) | Reduced `wazuh-manager` Debian package dependencies, removed `adduser`, `lsb-release`, `debconf`, and `libc6`. |
+| [#29734](https://github.com/wazuh/wazuh/issues/29734) | Upgraded external dependencies: `curl`, `sqlite`, `xz`, and `libarchive`. |
+| [#34479](https://github.com/wazuh/wazuh/issues/34479) | Implemented cooperative-cancellation graceful termination for `wmodules`. |
+| [#35358](https://github.com/wazuh/wazuh/pull/35358) | Included source IP in `wazuh-remoted` log messages. |
+| [#35478](https://github.com/wazuh/wazuh/issues/35478) | Preserved manager configuration files during package upgrades. |
+| [#35479](https://github.com/wazuh/wazuh/issues/35479) | Improved Wazuh server directory layout. |
+| [#35525](https://github.com/wazuh/wazuh/issues/35525) | Updated manager index names to align with the new sync model. |
+| [#35905](https://github.com/wazuh/wazuh/issues/35905) | Added caller module context to indexer-connector logs. |
+| [#36805](https://github.com/wazuh/wazuh/issues/36805) | Randomized the cluster key generated during manager installation instead of using a hardcoded default. |
+| [#36311](https://github.com/wazuh/wazuh/issues/36311) | Changed the default Indexer user used by the Manager from `admin` to the restricted `wazuh-server` user, aligning with the Indexer RBAC least-privilege model. |
+| [#36705](https://github.com/wazuh/wazuh/issues/36705) | Enabled shared-password agent enrollment by default, persisting the auto-generated `authd.pass` and synchronizing it to worker nodes, with fail-closed password validation. |
+| [#32698](https://github.com/wazuh/wazuh/issues/32698) | Adapted API integration tests. |
 
 #### Removed
 
-- Removed Filebeat as the log-shipping component; event forwarding now uses native Wazuh server connectivity to the Wazuh Indexer via `indexer-connector`. ([#33124](https://github.com/wazuh/wazuh/pull/33124))
-- Removed deprecated manager daemons: `ossec-authd`, `wazuh-agentlessd`, `wazuh-maild`, `wazuh-dbd`. ([#30922](https://github.com/wazuh/wazuh/issues/30922))
-- Removed deprecated C CLI tools: `manage_agents`, `agent-auth`. ([#30924](https://github.com/wazuh/wazuh/issues/30924))
-- Removed OpenSCAP server-side module. ([#31028](https://github.com/wazuh/wazuh/issues/31028))
-- Removed inventory-related API endpoints. ([#31299](https://github.com/wazuh/wazuh/issues/31299))
-- Removed legacy API security configuration endpoints. ([#28425](https://github.com/wazuh/wazuh/issues/28425))
-- Removed SELinux integration from the manager. ([#35908](https://github.com/wazuh/wazuh/issues/35908))
+| Issue | Comment |
+|-------|---------|
+| [#33124](https://github.com/wazuh/wazuh/pull/33124) | Removed Filebeat as the log-shipping component; event forwarding now uses native Wazuh server connectivity to the Wazuh Indexer via `indexer-connector`. |
+| [#30922](https://github.com/wazuh/wazuh/issues/30922) | Removed deprecated manager daemons: `ossec-authd`, `wazuh-agentlessd`, `wazuh-maild`, `wazuh-dbd`. |
+| [#30924](https://github.com/wazuh/wazuh/issues/30924) | Removed deprecated C CLI tools: `manage_agents`, `agent-auth`. |
+| [#31028](https://github.com/wazuh/wazuh/issues/31028) | Removed OpenSCAP server-side module. |
+| [#31299](https://github.com/wazuh/wazuh/issues/31299) | Removed inventory-related API endpoints. |
+| [#28425](https://github.com/wazuh/wazuh/issues/28425) | Removed legacy API security configuration endpoints. |
+| [#35908](https://github.com/wazuh/wazuh/issues/35908) | Removed SELinux integration from the manager. |
 
 #### Fixed
 
-- Fixed Vulnerability Detector version matcher logic for improved detection accuracy. ([#31746](https://github.com/wazuh/wazuh/issues/31746))
-- Fixed Cloudtrail log ingestion parsing errors. ([#33108](https://github.com/wazuh/wazuh/issues/33108))
-- Fixed `wazuh-db` error assigning groups by avoiding the keyentries counter as index. ([#34082](https://github.com/wazuh/wazuh/issues/34082))
-- Fixed token validation race condition after revoke. ([#35043](https://github.com/wazuh/wazuh/issues/35043))
-- Handled the stop signal during vulnerability feed download. ([#35638](https://github.com/wazuh/wazuh/issues/35638))
-- Fixed `GET /cluster/{node_id}/daemons/stats` always returning error 1014 for `wazuh-manager-analysisd` due to a protocol mismatch between `WazuhSocketJSON` and the engine's HTTP API socket. ([#37521](https://github.com/wazuh/wazuh/issues/37521))
+| Issue | Comment |
+|-------|---------|
+| [#31746](https://github.com/wazuh/wazuh/issues/31746) | Fixed Vulnerability Detector version matcher logic for improved detection accuracy. |
+| [#33108](https://github.com/wazuh/wazuh/issues/33108) | Fixed Cloudtrail log ingestion parsing errors. |
+| [#34082](https://github.com/wazuh/wazuh/issues/34082) | Fixed `wazuh-db` error assigning groups by avoiding the keyentries counter as index. |
+| [#35043](https://github.com/wazuh/wazuh/issues/35043) | Fixed token validation race condition after revoke. |
+| [#35638](https://github.com/wazuh/wazuh/issues/35638) | Handled the stop signal during vulnerability feed download. |
+| [#37521](https://github.com/wazuh/wazuh/issues/37521) | Fixed `GET /cluster/{node_id}/daemons/stats` always returning error 1014 for `wazuh-manager-analysisd` due to a protocol mismatch between `WazuhSocketJSON` and the engine's HTTP API socket. |
 
 ### Agent
 
 #### Added
 
-- Added local state persistence for agent modules (FIM, System Inventory, SCA), removing the dependency on `rsync` with the Wazuh Server and reducing network traffic and server-side processing overhead. ([#29533](https://github.com/wazuh/wazuh/issues/29533)) ([#31838](https://github.com/wazuh/wazuh/issues/31838))
+| Issue | Comment |
+|-------|---------|
+| [#29533](https://github.com/wazuh/wazuh/issues/29533) [#31838](https://github.com/wazuh/wazuh/issues/31838) | Added local state persistence for agent modules (FIM, System Inventory, SCA), removing the dependency on `rsync` with the Wazuh Server and reducing network traffic and server-side processing overhead. |
 
 #### Changed
 
-- Changed the Wazuh Manager installation path to `/var/wazuh-manager` (replacing `/var/ossec`) and removed agent ID `000`, fully decoupling agent and manager processes on shared hosts. ([#33378](https://github.com/wazuh/wazuh/issues/33378))
-- Changed Vulnerability Detection to use the Wazuh Indexer as the sole authoritative CVE data source, removing direct CTI network access from the agent-side Vulnerability Detector. ([#34849](https://github.com/wazuh/wazuh/issues/34849))
-- Adjusted agent-side Vulnerability Detector inventory emission and synchronization (OS, packages, hotfixes) to align with the updated VD behavior in Wazuh 5.0. ([#33199](https://github.com/wazuh/wazuh/issues/33199))
-- Simplified rootcheck: removed the server-side database, sync path, and API surface; findings are now indexed through the standard alert pipeline. ([#31478](https://github.com/wazuh/wazuh/issues/31478))
-- Updated logcollector file-tailing initial read strategy for more consistent behavior across log rotation scenarios. ([#33382](https://github.com/wazuh/wazuh/issues/33382))
-- Updated Windows Event Channel log collection to emit native XML from `EvtRender()` without an XML declaration header. ([#34462](https://github.com/wazuh/wazuh/issues/34462))
-- Increased default limits for agent event throughput and inventory message sizes. ([#35330](https://github.com/wazuh/wazuh/issues/35330))
-- Reduced `wazuh-agent` Debian package dependencies, removed `adduser`, `lsb-release`, and `debconf`. ([#35880](https://github.com/wazuh/wazuh/issues/35880))
-- Standardized agent-start and buffer-status events to a WCS-aligned JSON format. ([#35471](https://github.com/wazuh/wazuh/issues/35471))
+| Issue | Comment |
+|-------|---------|
+| [#33378](https://github.com/wazuh/wazuh/issues/33378) | Changed the Wazuh Manager installation path to `/var/wazuh-manager` (replacing `/var/ossec`) and removed agent ID `000`, fully decoupling agent and manager processes on shared hosts. |
+| [#34849](https://github.com/wazuh/wazuh/issues/34849) | Changed Vulnerability Detection to use the Wazuh Indexer as the sole authoritative CVE data source, removing direct CTI network access from the agent-side Vulnerability Detector. |
+| [#33199](https://github.com/wazuh/wazuh/issues/33199) | Adjusted agent-side Vulnerability Detector inventory emission and synchronization (OS, packages, hotfixes) to align with the updated VD behavior in Wazuh 5.0. |
+| [#31478](https://github.com/wazuh/wazuh/issues/31478) | Simplified rootcheck: removed the server-side database, sync path, and API surface; findings are now indexed through the standard alert pipeline. |
+| [#33382](https://github.com/wazuh/wazuh/issues/33382) | Updated logcollector file-tailing initial read strategy for more consistent behavior across log rotation scenarios. |
+| [#34462](https://github.com/wazuh/wazuh/issues/34462) | Updated Windows Event Channel log collection to emit native XML from `EvtRender()` without an XML declaration header. |
+| [#35330](https://github.com/wazuh/wazuh/issues/35330) | Increased default limits for agent event throughput and inventory message sizes. |
+| [#35880](https://github.com/wazuh/wazuh/issues/35880) | Reduced `wazuh-agent` Debian package dependencies, removed `adduser`, `lsb-release`, and `debconf`. |
+| [#35471](https://github.com/wazuh/wazuh/issues/35471) | Standardized agent-start and buffer-status events to a WCS-aligned JSON format. |
 
 #### Removed
 
-- Removed deprecated agent binaries and legacy modules as part of the Wazuh 5.0 agent cleanup. ([#30435](https://github.com/wazuh/wazuh/issues/30435))
-- Removed NSIS-based Windows agent installer; Windows agent now ships exclusively as an MSI package. ([#31582](https://github.com/wazuh/wazuh/issues/31582))
+| Issue | Comment |
+|-------|---------|
+| [#30435](https://github.com/wazuh/wazuh/issues/30435) | Removed deprecated agent binaries and legacy modules as part of the Wazuh 5.0 agent cleanup. |
+| [#31582](https://github.com/wazuh/wazuh/issues/31582) | Removed NSIS-based Windows agent installer; Windows agent now ships exclusively as an MSI package. |
 
 #### Fixed
 
-- Fixed FIM checksum calculation that was incorrectly ignoring some file fields. ([#29668](https://github.com/wazuh/wazuh/issues/29668))
-- Fixed syscollector reporting duplicate and bogus packages on macOS arm64. ([#30513](https://github.com/wazuh/wazuh/issues/30513))
-- Fixed `agent_control` not displaying agent status information. ([#32915](https://github.com/wazuh/wazuh/issues/32915))
-- Fixed SCA handling of invalid operators and missing values in regex patterns. ([#35071](https://github.com/wazuh/wazuh/issues/35071))
-- Fixed agent modules initializing before agent metadata was fully ready. ([#35156](https://github.com/wazuh/wazuh/issues/35156))
-- Fixed FIM inventory reporting file modification time as 1970-01-01. ([#35162](https://github.com/wazuh/wazuh/issues/35162))
-- Fixed agent automatic reload failing after receiving centralized configuration. ([#35169](https://github.com/wazuh/wazuh/issues/35169))
-- Fixed syscollector false positive package detection on macOS. ([#35248](https://github.com/wazuh/wazuh/issues/35248))
-- Fixed agent uninstall on Windows after a WPK upgrade. ([#35329](https://github.com/wazuh/wazuh/issues/35329))
-- Fixed agent 5.x sending a trailing null byte in messages. ([#35474](https://github.com/wazuh/wazuh/issues/35474))
-- Fixed WUA hotfix collection regression in Windows agent v5.0.0. ([#35636](https://github.com/wazuh/wazuh/issues/35636))
-- Fixed wodle command argument construction for Windows paths. ([#35955](https://github.com/wazuh/wazuh/issues/35955))
-- Prevented Windows agent restart abort when the service is already stopping. ([#35960](https://github.com/wazuh/wazuh/issues/35960))
-- Fixed timeout message displayed after a 4.13-to-5.0 upgrade on Windows. ([#35978](https://github.com/wazuh/wazuh/issues/35978))
-- Fixed agent disconnection on direct 4.13-to-5.0 custom WPK upgrade. ([#35979](https://github.com/wazuh/wazuh/issues/35979))
-- Excluded `/bin` and `/sbin` from FIM monitored directories on usrmerge distributions. ([#35988](https://github.com/wazuh/wazuh/issues/35988))
-- Expanded Windows environment variables in SCA rule inputs. ([#36002](https://github.com/wazuh/wazuh/issues/36002))
-- Made `sync_end_delay` interruptible to remove stale `modulesd.pid` after agent stop. ([#36061](https://github.com/wazuh/wazuh/issues/36061))
-- Honored the shutdown signal in `agent-upgrade` `StartMQ` to avoid timeout warning on agent stop. ([#36092](https://github.com/wazuh/wazuh/issues/36092))
-- Adjusted DockerListener messages as log entries to fix event categorization. ([#36126](https://github.com/wazuh/wazuh/issues/36126))
-- Dropped orphan paths before promoting on agent startup to fix FIM. ([#36134](https://github.com/wazuh/wazuh/issues/36134))
-- Lowered the `wazuh-agentd` connection socket error log to debug level to avoid duplicating the "Lost connection with manager" error on transient disconnections. ([#37653](https://github.com/wazuh/wazuh/issues/37653))
-- Fixed a race condition when saving the Logcollector file status on shutdown. ([#37626](https://github.com/wazuh/wazuh/issues/37626))
-- Fixed an unbounded memory leak in `wazuh-modulesd` caused by a missing RPM macro context cleanup on every package scan cycle. ([#37656](https://github.com/wazuh/wazuh/issues/37656))
-- Fixed agent-info module caching cluster_name, cluster_node, and agent_groups from a one-time handshake at startup, causing stale values in `agent_metadata` until the agent process restarted. ([#37543](https://github.com/wazuh/wazuh/issues/37543))
-- Fixed `wazuh-syscheckd` failing the `file_entry.checksum` NOT NULL constraint when the deferred sync-flag update ran for an entry deleted during the scan. ([#37993](https://github.com/wazuh/wazuh/issues/37993))
+| Issue | Comment |
+|-------|---------|
+| [#29668](https://github.com/wazuh/wazuh/issues/29668) | Fixed FIM checksum calculation that was incorrectly ignoring some file fields. |
+| [#30513](https://github.com/wazuh/wazuh/issues/30513) | Fixed syscollector reporting duplicate and bogus packages on macOS arm64. |
+| [#32915](https://github.com/wazuh/wazuh/issues/32915) | Fixed `agent_control` not displaying agent status information. |
+| [#35071](https://github.com/wazuh/wazuh/issues/35071) | Fixed SCA handling of invalid operators and missing values in regex patterns. |
+| [#35156](https://github.com/wazuh/wazuh/issues/35156) | Fixed agent modules initializing before agent metadata was fully ready. |
+| [#35162](https://github.com/wazuh/wazuh/issues/35162) | Fixed FIM inventory reporting file modification time as 1970-01-01. |
+| [#35169](https://github.com/wazuh/wazuh/issues/35169) | Fixed agent automatic reload failing after receiving centralized configuration. |
+| [#35248](https://github.com/wazuh/wazuh/issues/35248) | Fixed syscollector false positive package detection on macOS. |
+| [#35329](https://github.com/wazuh/wazuh/issues/35329) | Fixed agent uninstall on Windows after a WPK upgrade. |
+| [#35474](https://github.com/wazuh/wazuh/issues/35474) | Fixed agent 5.x sending a trailing null byte in messages. |
+| [#35636](https://github.com/wazuh/wazuh/issues/35636) | Fixed WUA hotfix collection regression in Windows agent v5.0.0. |
+| [#35955](https://github.com/wazuh/wazuh/issues/35955) | Fixed wodle command argument construction for Windows paths. |
+| [#35960](https://github.com/wazuh/wazuh/issues/35960) | Prevented Windows agent restart abort when the service is already stopping. |
+| [#35978](https://github.com/wazuh/wazuh/issues/35978) | Fixed timeout message displayed after a 4.13-to-5.0 upgrade on Windows. |
+| [#35979](https://github.com/wazuh/wazuh/issues/35979) | Fixed agent disconnection on direct 4.13-to-5.0 custom WPK upgrade. |
+| [#35988](https://github.com/wazuh/wazuh/issues/35988) | Excluded `/bin` and `/sbin` from FIM monitored directories on usrmerge distributions. |
+| [#36002](https://github.com/wazuh/wazuh/issues/36002) | Expanded Windows environment variables in SCA rule inputs. |
+| [#36061](https://github.com/wazuh/wazuh/issues/36061) | Made `sync_end_delay` interruptible to remove stale `modulesd.pid` after agent stop. |
+| [#36092](https://github.com/wazuh/wazuh/issues/36092) | Honored the shutdown signal in `agent-upgrade` `StartMQ` to avoid timeout warning on agent stop. |
+| [#36126](https://github.com/wazuh/wazuh/issues/36126) | Adjusted DockerListener messages as log entries to fix event categorization. |
+| [#36134](https://github.com/wazuh/wazuh/issues/36134) | Dropped orphan paths before promoting on agent startup to fix FIM. |
+| [#37653](https://github.com/wazuh/wazuh/issues/37653) | Lowered the `wazuh-agentd` connection socket error log to debug level to avoid duplicating the "Lost connection with manager" error on transient disconnections. |
+| [#37626](https://github.com/wazuh/wazuh/issues/37626) | Fixed a race condition when saving the Logcollector file status on shutdown. |
+| [#37656](https://github.com/wazuh/wazuh/issues/37656) | Fixed an unbounded memory leak in `wazuh-modulesd` caused by a missing RPM macro context cleanup on every package scan cycle. |
+| [#37543](https://github.com/wazuh/wazuh/issues/37543) | Fixed agent-info module caching cluster_name, cluster_node, and agent_groups from a one-time handshake at startup, causing stale values in `agent_metadata` until the agent process restarted. |
+| [#37993](https://github.com/wazuh/wazuh/issues/37993) | Fixed `wazuh-syscheckd` failing the `file_entry.checksum` NOT NULL constraint when the deferred sync-flag update ran for an entry deleted during the scan. |
 

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -499,45 +499,57 @@ update_root_changelog() {
         return
     fi
 
+    # Skeleton for the new version: every section and block heading with an
+    # empty table ready to receive entries.
+    local table_header=$'| Issue | Comment |\n|-------|---------|'
+    local skeleton="## [v${new_version}]"
+    local section block
+    for section in Manager Agent; do
+        skeleton+=$'\n\n'"### ${section}"
+        for block in Added Changed Removed Fixed; do
+            skeleton+=$'\n\n'"#### ${block}"$'\n\n'"${table_header}"
+        done
+    done
+
     if [[ ! -f "$changelog_file" ]]; then
-        echo "## [v$new_version]" > "$changelog_file"
+        echo "$skeleton" > "$changelog_file"
         log_action "Created $changelog_file with new version: $new_version"
         return
     fi
 
-    if grep -q "\[v\?$new_version\]" "$changelog_file"; then
+    local version_escaped="${new_version//./\\.}"
+    if grep -qE "^## \[v?${version_escaped}\]" "$changelog_file"; then
         log_action "Version $new_version already exists in changelog."
         return
     fi
 
-    # Minor series (MAJOR.MINOR) of the version being released.
-    local new_mm="${new_version%.*}"
-
-    # Candidate prior versions: the current top version (whose full changelog is
-    # replaced by a link) plus every version already listed under
-    # "## Prior versions", newest first.
+    # Candidate prior versions: every version section being replaced by a link
+    # plus the versions already listed under "## Prior versions", newest first.
     local candidates
     candidates=$(
         {
-            grep -m1 -E '^## \[v?[0-9]+\.[0-9]+\.[0-9]+\]' "$changelog_file" \
+            grep -E '^## \[v?[0-9]+\.[0-9]+\.[0-9]+\]' "$changelog_file" \
                 | sed -E 's/^## \[v?([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/'
             sed -n '/^## Prior versions/,$p' "$changelog_file" \
                 | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^v//'
-        } | sort -Vr
+        } | sort -Vru
     )
 
-    # Keep the highest patch per minor series, ignore versions older than 5.0.0,
-    # drop the new release's own series, and take only the two latest minor series.
+    # Ignore versions older than 5.0.0 and keep every version belonging to the
+    # two latest minor series.
     local prior_tags
-    prior_tags=$(awk -F. -v skip="$new_mm" -v min_major=5 '
+    prior_tags=$(awk -F. -v min_major=5 '
         NF < 3 { next }
         $1 < min_major { next }
         { mm = $1 "." $2 }
-        mm == skip { next }
-        !seen[mm]++ { print }' <<< "$candidates" | head -n2)
+        !(mm in minors) {
+            if (nminors == 2) next
+            minors[mm]; nminors++
+        }
+        { print }' <<< "$candidates")
 
-    # Rebuild the changelog: the new version section plus the prior-version links.
-    local new_content="## [v${new_version}]"
+    # Rebuild the changelog: the new version skeleton plus the prior-version links.
+    local new_content="$skeleton"
     if [[ -n "$prior_tags" ]]; then
         new_content+=$'\n\n'"## Prior versions"$'\n'
         local tag


### PR DESCRIPTION
## Description

The changelog blocks were rendered as bullet lists with the issue reference at the end of each entry. The agreed format renders each block as a table, with the issue reference in the first column and the entry description in the second one, so references stay aligned and are easier to scan. The repository bumper is adapted so that bumping to a new version produces a changelog that follows this format.

Closes #38075

## Proposed Changes

- Converted every `Added`/`Changed`/`Removed`/`Fixed` block of the v5.0.0 changelog (Manager and Agent sections) into a table with `Issue` and `Comment` columns. Entries referencing more than one issue keep all their links in the `Issue` column. No entry was added, removed, or reworded: the 75 existing entries were converted in place, plus the entry added on the base branch afterwards (#37993, integrated as a table row while rebasing).
- Adapted `update_root_changelog` in `tools/repository_bumper.sh`. When bumping to a new version it now:
  - Rebuilds the changelog with the full skeleton for the new version: `### Manager` and `### Agent` sections, each with its `#### Added/Changed/Removed/Fixed` blocks and an empty `| Issue | Comment |` table ready to receive entries (before, it left a bare `## [vX.Y.Z]` heading with no structure).
  - Collects every `## [vX.Y.Z]` section as a prior-version candidate instead of only the first one, so intermediate version sections are turned into `Prior versions` links rather than silently dropped.
  - Keeps every version belonging to the two latest minor series in `Prior versions` and removes the older ones (e.g. bumping to 5.3.0 keeps the 5.2.x and 5.1.x links and drops 5.0.x), instead of keeping only the highest patch of each series.
  - Anchors the "version already exists" check to the `## [vX.Y.Z]` heading so a bracketed token inside an entry cannot trigger a false positive.

### Results and Evidence

**Changelog conversion**

Rendered result: [CHANGELOG.md on the branch](https://github.com/wazuh/wazuh/blob/enhancement/38075-changelog-table-format/CHANGELOG.md)

```
$ grep -c '^| \[#' CHANGELOG.md   # table rows
76
$ grep -c '^- ' CHANGELOG.md      # remaining bullet entries
0
```

The original file contained 75 bullet entries across 8 blocks (76 after rebasing on the current base); the converted file contains 76 table rows and 8 table headers.

**Bumper test suite**

The script was executed end to end (`bash tools/repository_bumper.sh --version <v> --stage <s> --date 2026-07-29`, exercising all the bump steps, not only the changelog one) against a copy of the repository files in an Ubuntu 24.04 container with GNU tools, the same environment class as the release workflows. Seven scenarios, 29 checks, all passing:

| Scenario | Expected result |
|----------|-----------------|
| W1: minor bump 5.0.0 → 5.1.0 | Skeleton with Manager/Agent, 8 blocks, 8 empty tables; `Prior versions` references v5.0.0; version files (VERSION.json, defs.h, ...) updated |
| W2: re-run with the same version | Changelog untouched, "already exists" logged |
| W3: patch bump 5.0.0 → 5.0.1 | Previous version v5.0.0 referenced in `Prior versions` |
| W4: bump to 5.3.0 with priors 5.2.1, 5.2.0, 5.1.1, 5.1.0, 5.0.2, 5.0.1, 5.0.0, 4.14.0 | Keeps all 5.2.x and 5.1.x links; drops 5.0.x and 4.x |
| W5: file with several version sections in the old bullet format (current `main` layout) bumped to 5.2.0 | v5.1.0, v5.0.1 and v5.0.0 all linked; nothing silently lost |
| W6: missing CHANGELOG.md | Created with the new version skeleton |
| W7: entry containing a bracketed `[5.1.0]` token, bump to 5.1.0 | Rebuild happens anyway (no false "already exists") |

<details>
<summary>Full test run output</summary>

```
== Environment: Ubuntu 24.04.4 LTS, bash 5.2.21(1)-release, grep (GNU grep) 3.11, sed (GNU sed) 4.9, sort (GNU coreutils) 9.4

=== wazuh/wazuh: tools/repository_bumper.sh ===
-- W1: full run, minor bump 5.0.0 -> 5.1.0
  exit=0
  [PASS] VERSION.json updated
  [PASS] defs.h updated
  [PASS] changelog: new heading
  [PASS] changelog: Manager section
  [PASS] changelog: Agent section
  [PASS] changelog: 8 blocks
  [PASS] changelog: 8 empty tables
  [PASS] changelog: prior v5.0.0 link
  [PASS] changelog: old entries gone
  changelog line count: 49
-- W2: re-run with same version (idempotence)
  exit=0
  [PASS] changelog untouched
  [PASS] log says already exists
-- W3: patch bump 5.0.0 -> 5.0.1 (previous version must be referenced)
  [PASS] prior v5.0.0 link
  [PASS] new heading v5.0.1
-- W4: bump to 5.3.0 prunes to the two latest minor series
  [PASS] keeps v5.2.1
  [PASS] keeps v5.2.0
  [PASS] keeps v5.1.1
  [PASS] keeps v5.1.0
  [PASS] drops 5.0.x
  [PASS] drops 4.x
-- W5: file with several version sections in old bullet format (main-like), bump to 5.2.0
  [PASS] links v5.1.0
  [PASS] links v5.0.1
  [PASS] links v5.0.0
  [PASS] drops 4.x
  [PASS] old bullets gone
-- W6: missing CHANGELOG.md is created with the skeleton
  [PASS] file created
  [PASS] skeleton heading
  [PASS] 8 empty tables
-- W7: bracketed token in a table row must not fake 'version exists'
  [PASS] rebuild happened anyway
  [PASS] prior v5.0.0 link
```

</details>

<details>
<summary>CHANGELOG.md produced by the bumper after W1 (bump to 5.1.0)</summary>

```markdown
## [v5.1.0]

### Manager

#### Added

| Issue | Comment |
|-------|---------|

#### Changed

| Issue | Comment |
|-------|---------|

#### Removed

| Issue | Comment |
|-------|---------|

#### Fixed

| Issue | Comment |
|-------|---------|

### Agent

#### Added

| Issue | Comment |
|-------|---------|

#### Changed

| Issue | Comment |
|-------|---------|

#### Removed

| Issue | Comment |
|-------|---------|

#### Fixed

| Issue | Comment |
|-------|---------|

## Prior versions

- [v5.0.0](https://github.com/wazuh/wazuh/blob/v5.0.0/CHANGELOG.md)
```

</details>

`bash -n tools/repository_bumper.sh` passes.

### Artifacts Affected

None. Only `CHANGELOG.md` and `tools/repository_bumper.sh` change.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None.

## Review Checklist
- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)

