### PR TITLE
Implement download endpoint

### DIFF
--- a/docs/ref/modules/remoted/configuration.md
+++ b/docs/ref/modules/remoted/configuration.md
@@ -571,6 +571,28 @@ Socket read buffer size for the HTTPS agent server, in bytes.
 - **Default value:** `8192`
 - **Allowed values:** Integer from `1` to `1048576` (1 MiB)
 
+#### remoted.http_max_parallel_connections
+
+Maximum simultaneous HTTPS connections.
+
+- **Default value:** `512`
+- **Allowed values:** Integer from `1` to `8192`
+- **Note:** Also the only bound on concurrent streamed responses (`POST /download`). Chunked
+  output rearms `remoted.http_write_timeout` per chunk, so a slow-but-steady reader can hold a
+  transfer open indefinitely and there is no per-stream limiter. Lower this if a mass upgrade over
+  slow links needs capping.
+
+#### remoted.http_stream_chunk_size
+
+Bytes per chunk when streaming a response body (`POST /download`).
+
+- **Default value:** `65536` (64 KiB)
+- **Allowed values:** Integer from `4096` to `1048576` (1 MiB)
+- **Note:** Charged per *in-flight transfer*, so the worst case is roughly this value times the
+  number of simultaneous downloads. A larger chunk buys fewer read/write round trips (less CPU per
+  byte) at the cost of more memory while transfers are running. It does not change the bytes
+  delivered -- only how they are framed on the wire.
+
 > **The three timeouts below are sequential phases of one request, and the sum matters.**
 > `remoted.http_request_timeout` bounds the *whole* request and its clock starts before the
 > downstream call, so if `connect + write + response` exceeds it, the HTTP server tears the request

--- a/docs/ref/modules/remoted/configuration.md
+++ b/docs/ref/modules/remoted/configuration.md
@@ -571,16 +571,36 @@ Socket read buffer size for the HTTPS agent server, in bytes.
 - **Default value:** `8192`
 - **Allowed values:** Integer from `1` to `1048576` (1 MiB)
 
-#### remoted.http_max_parallel_connections
+#### remoted.max_inflight_bytes
+
+Maximum in-flight (unprocessed) request payload bytes before the HTTPS server sheds load with HTTP 503.
+
+- **Default value:** `268435456` (256 MiB)
+- **Allowed values:** Integer from `1048576` (1 MiB) to `1073741824` (1 GiB)
+- **Note:** The C++ side clamps this up to at least one max-size request at startup, so a too-small
+  value cannot reject everything. This is NOT `legacy.queue_size` (that is an event COUNT, not bytes).
+
+#### remoted.max_parallel_connections
 
 Maximum simultaneous HTTPS connections.
 
 - **Default value:** `512`
-- **Allowed values:** Integer from `1` to `8192`
-- **Note:** Also the only bound on concurrent streamed responses (`POST /download`). Chunked
-  output rearms `remoted.http_write_timeout` per chunk, so a slow-but-steady reader can hold a
-  transfer open indefinitely and there is no per-stream limiter. Lower this if a mass upgrade over
-  slow links needs capping.
+- **Allowed values:** Integer from `1` to `65536`
+- **Note:** Bounds the read-phase memory peak (~`max_parallel_connections` × `max_body_size`). Also
+  the only bound on concurrent streamed responses (`POST /download`): chunked output rearms
+  `remoted.http_write_timeout` per chunk, so a slow-but-steady reader can hold a transfer open
+  indefinitely and there is no per-stream limiter. A mass upgrade (the whole fleet fetching a WPK
+  at once, many over slow links) is therefore bounded only by this value.
+
+#### remoted.max_deferred_requests
+
+Maximum requests parked awaiting a downstream service before replying with HTTP 503.
+
+- **Default value:** `256`
+- **Allowed values:** Integer from `1` to `65536`
+- **Note:** No `Retry-After` header is sent; the agent runs its own retry/backoff on a 503. If you
+  see warnings about this limit being reached, consider increasing it or investigating why the
+  downstream service is slow.
 
 #### remoted.http_stream_chunk_size
 

--- a/src/remoted/remoted_module/README.md
+++ b/src/remoted/remoted_module/README.md
@@ -160,6 +160,7 @@ src/endpoints/
 ├── statelessEndpoint.hpp/.cpp # /stateless policy: identity check + downstream target + post-processing
 ├── statsEndpoint.hpp/.cpp    # /stats policy (DUMMY): forwards to modulesd's inventory sync server
 └── configEndpoint.hpp/.cpp  # /config policy (DUMMY): near-duplicate of statsEndpoint, on purpose
+└── downloadEndpoint.hpp/.cpp  # /download policy: request grammar + resource resolution + file streaming
 ```
 
 - **Endpoint handler (async):**
@@ -489,6 +490,48 @@ and clients, which are all thread-safe internally.
 3. **Shutdown**: `RemotedModuleFacade::stop()` stops the HTTP server (drains in-flight requests),
    then stops the wazuh-db and task-manager clients (drains their queues), then destroys the
    registry (eviction thread stops automatically on destruction).
+
+## Streamed responses — `POST /download`
+
+Most endpoints answer with one in-memory body. `/download` serves `merged.mg` and WPK packages,
+which can be hundreds of megabytes, so it streams with **HTTP chunked transfer encoding** (64 KiB
+chunks) and memory that does not grow with file size.
+
+- **Declared at registration, not per response.** The transport creates a request's response builder
+  when the request is dispatched — that is what lets it release the received body before the request
+  is queued — and a builder's output mode is fixed at creation. So a streaming route registers with
+  `ResponseMode::Streamable`; its responder then keeps the request handle and builds *buffered* for
+  an error (a 404 is a normal response, not a chunked one) or *chunked* for a transfer. The cost is
+  that the received request survives into the worker queue, which is why it is opt-in per route.
+  `IHttpResponder::stream()` has a fail-loud default (answer `500`) so a `Buffered` mis-registration
+  is obvious instead of silently buffering a large body.
+- **Pull, not push.** The handler hands the transport an `IByteSource`; the transport drives the
+  loop, because only it owns both the connection's I/O strand and the worker pool. Read a chunk on a
+  worker, write it, and read the next only once the write completes. One chunk is resident, and a
+  worker slot is held only for the duration of a single read — never for the whole transfer.
+  Measured on a live manager: 2 GiB streamed for a 0.6 MiB RSS delta.
+- **Failure is truncation, not a short success.** A read error propagates out of `read()` and the
+  builder is dropped *without* `done()`, so the terminating `0\r\n\r\n` is never sent and the agent
+  sees an incomplete body it will retry. Returning 0 instead would emit the terminator and hand over
+  a truncated file that looks complete. RESTinio always fires the write callback (with
+  `write_was_not_executed` if the connection died first), so an aborted transfer always releases its
+  descriptor — verified: 25 mid-transfer disconnects left the fd count unchanged.
+- **`resource_id` is what the agent asks for, and the manager serves exactly that.** A `config`
+  request names either one group (`etc/shared/<group>/merged.mg`) or several, comma-separated —
+  wazuh's own multigroup form — which resolves to `var/multigroups/<sha256(resource_id)[:8]>/merged.mg`.
+  A `wpk` request names a filename and gets `var/upgrade/<filename>`. The multigroup form is what
+  lets an agent in several groups fetch its *effective* configuration rather than one member
+  group's, and it needs no database: the selector is hashed exactly as wazuh-db names the directory.
+  There is no group lookup and no membership check (protocol decision on #38022), so **any
+  authenticated agent can fetch any group's or multigroup's merged configuration**. `/control` must
+  report `config_hash` over the file this resolves to for the selector it hands the agent, or that
+  agent re-downloads on every notify.
+- **Containment differs per form.** The multigroup selector is *hashed, never joined*, so it cannot
+  traverse by construction. The single-group and WPK forms **do** join agent input into a path, so
+  there the grammars are the boundary: no `/`, not `.` or `..`, no leading dot, and for a WPK a
+  `.wpk` suffix. With no separator admitted, the joined path has exactly one component below the
+  base directory, and `openRegularFile()`'s `O_NOFOLLOW` stops that component being a symlink.
+  Loosening either grammar would break that and require a `realpath()` containment check instead.
 
 ## Deferred forwarding (async UDS) — `src/downstream/`
 
@@ -850,7 +893,7 @@ skipped without blocking the rest of the file).
 ctest --test-dir <build> -R remoted_module_utest -V
 ```
 
-### Manual / end-to-end (`tools/send_stateless.py`)
+### Manual / end-to-end (`tools/send_stateless.py`, `tools/send_download.py`)
 
 Signs and sends `POST /stateless` requests exactly as `AuthMiddleware` expects (AES-CMAC over the
 canonical byte sequence, agent key read straight from `client.keys`). Requires

--- a/src/remoted/remoted_module/include/remoted_module.h
+++ b/src/remoted/remoted_module/include/remoted_module.h
@@ -114,6 +114,12 @@ extern "C"
                                          ///< default (see remoted.http_concurrent_accepts).
         int http_buffer_size;            ///< Socket read buffer size, bytes. <=0 -> module default
                                          ///< (see remoted.http_buffer_size).
+        int http_stream_chunk_size;      ///< Bytes per chunk when streaming a response body
+                                         ///< (POST /download). <=0 -> module default, 64 KiB
+                                         ///< (see remoted.http_stream_chunk_size). Larger chunks
+                                         ///< trade memory per in-flight transfer for fewer
+                                         ///< read/write round trips, which is where the CPU per
+                                         ///< byte goes.
         long long max_inflight_bytes;    ///< Max in-flight request payload bytes; 503 over it (<=0 -> module default).
         int max_parallel_connections;    ///< HTTPS max simultaneous connections (<=0 -> module default).
         int max_deferred_requests; ///< Max requests parked awaiting a downstream service; 503 over it (<=0 -> default).

--- a/src/remoted/remoted_module/src/endpoints/authGateway.cpp
+++ b/src/remoted/remoted_module/src/endpoints/authGateway.cpp
@@ -108,7 +108,8 @@ namespace remoted::endpoints
     void AuthGateway::addAuthenticatedRoute(remoted::http::IHttpServer& server,
                                             Method method,
                                             const std::string& path,
-                                            AuthenticatedHandler handler)
+                                            AuthenticatedHandler handler,
+                                            remoted::http::ResponseMode mode)
     {
         auto middleware = m_middleware;
         const char* methodStr = methodToCanonical(method);
@@ -198,7 +199,9 @@ namespace remoted::endpoints
                     LOGFN_ERROR(logFn(), "Auth pipeline threw a non-standard exception.");
                     sendInternalErrorNoThrow(responder);
                 }
-            });
+            },
+            /*countAgainstBudget=*/true,
+            mode);
     }
 
 } // namespace remoted::endpoints

--- a/src/remoted/remoted_module/src/endpoints/authGateway.hpp
+++ b/src/remoted/remoted_module/src/endpoints/authGateway.hpp
@@ -55,11 +55,15 @@ namespace remoted::endpoints
          * @param method  HTTP method to match.
          * @param path    Path to match (the query string is not matched, but IS part of the MAC).
          * @param handler Invoked only after authentication succeeds; owns sending the response.
+         * @param mode    Whether the handler may answer with a streamed body. Forwarded verbatim to
+         *                IHttpServer::addRoute(): the transport fixes a response's output mode when
+         *                the request is dispatched, so a route that streams must declare it here.
          */
         void addAuthenticatedRoute(remoted::http::IHttpServer& server,
                                    Method method,
                                    const std::string& path,
-                                   AuthenticatedHandler handler);
+                                   AuthenticatedHandler handler,
+                                   remoted::http::ResponseMode mode = remoted::http::ResponseMode::Buffered);
 
     private:
         std::shared_ptr<remoted::auth::AuthMiddleware> m_middleware;

--- a/src/remoted/remoted_module/src/endpoints/downloadEndpoint.cpp
+++ b/src/remoted/remoted_module/src/endpoints/downloadEndpoint.cpp
@@ -314,7 +314,7 @@ namespace remoted::endpoints::download
         std::string name;
         name.reserve(MULTIGROUP_HASH_HEX_CHARS);
 
-        for (unsigned int i = 0; i < digestLength && name.size() < MULTIGROUP_HASH_HEX_CHARS; ++i)
+        for (unsigned int i = 0; i < MULTIGROUP_HASH_HEX_CHARS / 2 && i < digestLength; ++i)
         {
             name.push_back(HEX_DIGITS[(digest[i] >> 4) & 0x0F]);
             name.push_back(HEX_DIGITS[digest[i] & 0x0F]);

--- a/src/remoted/remoted_module/src/endpoints/downloadEndpoint.cpp
+++ b/src/remoted/remoted_module/src/endpoints/downloadEndpoint.cpp
@@ -353,6 +353,20 @@ namespace remoted::endpoints::download
         : m_fd {fd}
         , m_size {size}
     {
+        // Baseline for the mid-transfer modification check in read(). Best-effort on purpose: a
+        // descriptor we cannot stat is not a reason to refuse to serve a file we already opened
+        // successfully. m_mtimeKnown is what makes that true -- without it, a failed fstat would
+        // leave the baseline at zero, every comparison would mismatch, and EVERY transfer would
+        // abort. The byte-count half of the check stands on its own either way.
+        struct stat info
+        {
+        };
+        if (::fstat(m_fd, &info) == 0)
+        {
+            m_mtimeSec = static_cast<std::int64_t>(info.st_mtim.tv_sec);
+            m_mtimeNsec = static_cast<std::int64_t>(info.st_mtim.tv_nsec);
+            m_mtimeKnown = true;
+        }
     }
 
     FileByteSource::~FileByteSource()
@@ -388,7 +402,71 @@ namespace remoted::endpoints::download
             throw std::system_error {errno, std::generic_category(), "read() failed while streaming a resource"};
         }
 
+        if (bytesRead == 0)
+        {
+            // End of stream. The per-chunk check below has already covered everything up to the
+            // last data read; this catches a writer that landed between that read and this one.
+            if (m_delivered != m_size)
+            {
+                // Short by construction: end-of-file arrived before the file's own length.
+                throw std::runtime_error {"the resource was truncated while it was being streamed"};
+            }
+            checkNotModified();
+            return 0;
+        }
+
+        m_delivered += static_cast<std::uint64_t>(bytesRead);
+
+        // More readable than the file held at open(): the bytes already sent belong to a version
+        // that no longer exists. Cheap enough to keep as its own invariant -- it needs no syscall.
+        if (m_delivered > m_size)
+        {
+            throw std::runtime_error {"the resource grew while it was being streamed"};
+        }
+
+        // Checked per chunk, not only at end-of-stream. Same criterion either way, but a writer
+        // that lands one second into a 1 GiB transfer would otherwise cost the full gigabyte of
+        // reads and socket writes before the transfer is abandoned; here it costs one more chunk.
+        // The price is an fstat() per chunk -- no path resolution, no I/O, against a read() plus a
+        // socket write that are already happening.
+        checkNotModified();
+
         return static_cast<std::size_t>(bytesRead);
+    }
+
+    void FileByteSource::checkNotModified() const
+    {
+        struct stat info
+        {
+        };
+        if (::fstat(m_fd, &info) != 0)
+        {
+            throw std::system_error {errno, std::generic_category(), "fstat() failed while streaming a resource"};
+        }
+
+        // Classified rather than lumped together, so the abort WARN names what actually happened:
+        // a shorter file is a truncating rewrite (c_group() on merged.mg), a longer one is a file
+        // still being staged (a WPK mid-download), and an unchanged length with a moved mtime is a
+        // same-size rewrite -- the case no byte count can see.
+        const auto currentSize = static_cast<std::uint64_t>(info.st_size);
+
+        if (currentSize < m_size)
+        {
+            throw std::runtime_error {"the resource was truncated while it was being streamed"};
+        }
+
+        if (currentSize > m_size)
+        {
+            throw std::runtime_error {"the resource grew while it was being streamed"};
+        }
+
+        // Same length: only the baseline mtime distinguishes it, and only when we recorded one.
+        // Without a baseline the check is skipped rather than assumed to have failed.
+        if (m_mtimeKnown && (static_cast<std::int64_t>(info.st_mtim.tv_sec) != m_mtimeSec ||
+                             static_cast<std::int64_t>(info.st_mtim.tv_nsec) != m_mtimeNsec))
+        {
+            throw std::runtime_error {"the resource was modified while it was being streamed"};
+        }
     }
 
     std::uint64_t FileByteSource::size() const noexcept

--- a/src/remoted/remoted_module/src/endpoints/downloadEndpoint.cpp
+++ b/src/remoted/remoted_module/src/endpoints/downloadEndpoint.cpp
@@ -1,0 +1,517 @@
+/*
+ * Wazuh remoted module (C++ worker bridge)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 29, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "downloadEndpoint.hpp"
+
+#include "loggerHelper.h"
+
+#include <rapidjson/document.h>
+
+#include <openssl/evp.h>
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <stdexcept>
+#include <system_error>
+#include <utility>
+
+namespace
+{
+    constexpr auto DOWNLOAD_LOGTAG {"wazuh-manager-remoted:endpoints"};
+
+    const LogFn& logFn()
+    {
+        static const LogFn instance {LogFn {DOWNLOAD_LOGTAG}.compose("download")};
+        return instance;
+    }
+
+    /// Longest accepted resource id. MAX_GROUP_NAME for a group; also a sane bound for a filename.
+    constexpr std::size_t MAX_RESOURCE_ID_SIZE {255};
+
+    /// Wire spellings of ResourceType.
+    constexpr auto RESOURCE_TYPE_CONFIG {"config"};
+    constexpr auto RESOURCE_TYPE_WPK {"wpk"};
+    constexpr auto WPK_EXTENSION {".wpk"};
+
+    /// Separator wazuh uses between groups in a multigroup selector (MULTIGROUP_SEPARATOR).
+    constexpr char GROUP_SEPARATOR {','};
+
+    /**
+     * @brief Hex characters in a multigroup directory name.
+     *
+     * Must equal wazuh-db's WDB_GROUP_HASH_SIZE (8). Note that is 8 HEX CHARACTERS -- the first
+     * four digest bytes -- not the first eight bytes.
+     */
+    constexpr std::size_t MULTIGROUP_HASH_HEX_CHARS {8};
+
+    /// Cap on a whole multigroup selector, mirroring wazuh's own multigroup length allowance.
+    constexpr std::size_t MAX_MULTIGROUP_SELECTOR_SIZE {4096};
+
+    /// Basename of a merged centralized configuration (SHAREDCFG_FILENAME).
+    constexpr auto MERGED_CONFIG_FILENAME {"merged.mg"};
+
+    /// Characters wazuh accepts in a single group name (w_validate_group_name's set, minus comma).
+    bool isGroupNameChar(char c)
+    {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '.' || c == ':' ||
+               c == ';' || c == '_' || c == '-' || c == '=' || c == '+' || c == '!' || c == '@' || c == '(' || c == ')';
+    }
+
+    /// Stricter set for a value that gets joined into a path.
+    bool isWpkNameChar(char c)
+    {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '.' || c == '_' ||
+               c == '-';
+    }
+
+    bool isDotOrDotDot(std::string_view value)
+    {
+        return value == "." || value == "..";
+    }
+
+    bool endsWith(std::string_view value, std::string_view suffix)
+    {
+        return value.size() >= suffix.size() && value.compare(value.size() - suffix.size(), suffix.size(), suffix) == 0;
+    }
+
+    std::string joinPath(const std::string& directory, const std::string& name)
+    {
+        if (directory.empty())
+        {
+            return name;
+        }
+        return directory.back() == '/' ? directory + name : directory + '/' + name;
+    }
+
+    /// Reads a required string member, rejecting a missing member or a non-string value.
+    const rapidjson::Value* stringMember(const rapidjson::Document& doc, const char* name)
+    {
+        const auto member = doc.FindMember(name);
+        if (member == doc.MemberEnd() || !member->value.IsString())
+        {
+            return nullptr;
+        }
+        return &member->value;
+    }
+
+    const char* resourceTypeName(remoted::endpoints::download::ResourceType type)
+    {
+        return type == remoted::endpoints::download::ResourceType::Config ? RESOURCE_TYPE_CONFIG : RESOURCE_TYPE_WPK;
+    }
+
+    /// errno -> the error a failed open maps to. Absent or wrong-typed is a plain 404; anything
+    /// else is ours, not the agent's, so it surfaces as a 500 and gets logged.
+    remoted::endpoints::download::LocateError errorForOpenErrno(int openErrno)
+    {
+        using remoted::endpoints::download::LocateError;
+        switch (openErrno)
+        {
+            case ENOENT:
+            case ENOTDIR:
+            case ELOOP:  // O_NOFOLLOW rejected a symlink: indistinguishable from absent, to the agent.
+            case EINVAL: // openRegularFile()'s marker for "not a regular file".
+                return LocateError::NotFound;
+            default: return LocateError::Internal;
+        }
+    }
+} // namespace
+
+namespace remoted::endpoints::download
+{
+
+    // -----------------------------------------------------------------------
+    // Request parsing and grammars
+    // -----------------------------------------------------------------------
+
+    bool isValidGroupName(std::string_view group)
+    {
+        if (group.empty() || group.size() > MAX_RESOURCE_ID_SIZE || isDotOrDotDot(group))
+        {
+            return false;
+        }
+
+        for (const char c : group)
+        {
+            if (!isGroupNameChar(c))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    bool isValidGroupSelector(std::string_view selector)
+    {
+        if (selector.empty() || selector.size() > MAX_MULTIGROUP_SELECTOR_SIZE)
+        {
+            return false;
+        }
+
+        // Every entry must be a valid group name on its own. That rejects an empty entry, so a
+        // leading comma, a trailing comma and a doubled comma are all rejected without needing
+        // their own cases -- and it keeps "." / ".." out of a selector that will be joined.
+        std::size_t start = 0;
+        while (true)
+        {
+            const auto separator = selector.find(GROUP_SEPARATOR, start);
+            const auto entry =
+                selector.substr(start, separator == std::string_view::npos ? std::string_view::npos : separator - start);
+
+            if (!isValidGroupName(entry))
+            {
+                return false;
+            }
+
+            if (separator == std::string_view::npos)
+            {
+                return true;
+            }
+            start = separator + 1;
+        }
+    }
+
+    bool isValidWpkFilename(std::string_view filename)
+    {
+        if (filename.empty() || filename.size() > MAX_RESOURCE_ID_SIZE || filename.front() == '.' ||
+            !endsWith(filename, WPK_EXTENSION))
+        {
+            return false;
+        }
+
+        for (const char c : filename)
+        {
+            if (!isWpkNameChar(c))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    std::variant<DownloadRequest, RequestError> parseRequest(std::string_view body)
+    {
+        if (body.empty() || body.size() > kMaxRequestJsonSize)
+        {
+            return RequestError::Malformed;
+        }
+
+        rapidjson::Document doc;
+        // Length-based, non-in-situ parse: the body is a view into a shared buffer that is neither
+        // mutable nor NUL-terminated. kParseIterativeFlag bounds the parser's C-stack usage to a
+        // constant regardless of nesting depth, so a hostile body cannot overflow this thread's stack.
+        doc.Parse<rapidjson::kParseIterativeFlag>(body.data(), body.size());
+
+        if (doc.HasParseError() || !doc.IsObject())
+        {
+            return RequestError::Malformed;
+        }
+
+        // `additionalProperties: false`, so an unexpected member is a rejection rather than
+        // something to skip: accepting it would let a future field be silently ignored by an older
+        // manager, which only surfaces in production.
+        if (doc.MemberCount() != 2)
+        {
+            return RequestError::Malformed;
+        }
+
+        const auto* typeValue = stringMember(doc, "resource_type");
+        const auto* idValue = stringMember(doc, "resource_id");
+
+        if (typeValue == nullptr || idValue == nullptr)
+        {
+            return RequestError::Malformed;
+        }
+
+        const std::string_view typeText {typeValue->GetString(), typeValue->GetStringLength()};
+        const std::string_view idText {idValue->GetString(), idValue->GetStringLength()};
+
+        DownloadRequest request;
+
+        if (typeText == RESOURCE_TYPE_CONFIG)
+        {
+            request.type = ResourceType::Config;
+            if (!isValidGroupSelector(idText))
+            {
+                return RequestError::InvalidResourceId;
+            }
+        }
+        else if (typeText == RESOURCE_TYPE_WPK)
+        {
+            request.type = ResourceType::Wpk;
+            if (!isValidWpkFilename(idText))
+            {
+                return RequestError::InvalidResourceId;
+            }
+        }
+        else
+        {
+            return RequestError::UnknownResourceType;
+        }
+
+        request.resourceId.assign(idText);
+        return request;
+    }
+
+    // -----------------------------------------------------------------------
+    // Error mapping
+    // -----------------------------------------------------------------------
+
+    remoted::http::HttpResponse errorResponseFor(RequestError error)
+    {
+        switch (error)
+        {
+            case RequestError::UnknownResourceType:
+                return remoted::http::HttpResponse::json(400, R"({"error":"Invalid resource type","code":400})");
+            case RequestError::InvalidResourceId:
+                return remoted::http::HttpResponse::json(400, R"({"error":"Invalid resource identifier","code":400})");
+            case RequestError::Malformed: break;
+        }
+
+        return remoted::http::HttpResponse::json(400, R"({"error":"Invalid request format","code":400})");
+    }
+
+    remoted::http::HttpResponse errorResponseFor(LocateError error)
+    {
+        if (error == LocateError::Internal)
+        {
+            return remoted::http::HttpResponse::json(500, R"({"error":"Internal server error","code":500})");
+        }
+
+        return remoted::http::HttpResponse::json(404, R"({"error":"Resource not found","code":404})");
+    }
+
+    // -----------------------------------------------------------------------
+    // Resolution
+    // -----------------------------------------------------------------------
+
+    std::string multigroupDirName(const std::string& groupSelector)
+    {
+        unsigned char digest[EVP_MAX_MD_SIZE] {};
+        unsigned int digestLength {0};
+
+        if (EVP_Digest(groupSelector.data(), groupSelector.size(), digest, &digestLength, EVP_sha256(), nullptr) != 1)
+        {
+            throw std::runtime_error("SHA-256 is unavailable; cannot resolve a multigroup directory");
+        }
+
+        static constexpr char HEX_DIGITS[] = "0123456789abcdef";
+
+        std::string name;
+        name.reserve(MULTIGROUP_HASH_HEX_CHARS);
+
+        for (unsigned int i = 0; i < digestLength && name.size() < MULTIGROUP_HASH_HEX_CHARS; ++i)
+        {
+            name.push_back(HEX_DIGITS[(digest[i] >> 4) & 0x0F]);
+            name.push_back(HEX_DIGITS[digest[i] & 0x0F]);
+        }
+
+        return name;
+    }
+
+    LocateResult locateResource(const DownloadRequest& request, const ResourcePaths& paths)
+    {
+        // Safe to join directly: the grammars have already rejected any name containing a
+        // separator, equal to "." or "..", or beginning with a dot, and openRegularFile()'s
+        // O_NOFOLLOW stops the single remaining component being a symlink.
+        if (request.type == ResourceType::Wpk)
+        {
+            return LocateResult {joinPath(paths.wpkDir, request.resourceId), LocateError::None};
+        }
+
+        // Several groups -> the effective (multigroup) configuration, whose directory is the hash
+        // of the selector verbatim. Hashed rather than joined, so no database is needed and the
+        // directory name is hex by construction.
+        const bool isMultigroup = request.resourceId.find(GROUP_SEPARATOR) != std::string::npos;
+
+        const std::string directory = isMultigroup
+                                          ? joinPath(paths.multigroupsDir, multigroupDirName(request.resourceId))
+                                          : joinPath(paths.sharedDir, request.resourceId);
+
+        return LocateResult {joinPath(directory, MERGED_CONFIG_FILENAME), LocateError::None};
+    }
+
+    // -----------------------------------------------------------------------
+    // File streaming
+    // -----------------------------------------------------------------------
+
+    FileByteSource::FileByteSource(int fd, std::uint64_t size) noexcept
+        : m_fd {fd}
+        , m_size {size}
+    {
+    }
+
+    FileByteSource::~FileByteSource()
+    {
+        if (m_fd >= 0)
+        {
+            // Deliberately unchecked: close() can report a deferred write error, but this
+            // descriptor is read-only and there is nothing actionable to do from a destructor.
+            ::close(m_fd);
+            m_fd = -1;
+        }
+    }
+
+    std::size_t FileByteSource::read(char* buffer, std::size_t capacity)
+    {
+        if (buffer == nullptr || capacity == 0 || m_fd < 0)
+        {
+            return 0;
+        }
+
+        // EINTR is not a failure: a signal landing mid-read must not truncate a transfer.
+        // Everything else is, and it has to propagate -- returning 0 would look like a clean
+        // end-of-stream, so the transport would emit the terminating chunk and the agent would
+        // receive a silently truncated file that appears complete.
+        ssize_t bytesRead = 0;
+        do
+        {
+            bytesRead = ::read(m_fd, buffer, capacity);
+        } while (bytesRead < 0 && errno == EINTR);
+
+        if (bytesRead < 0)
+        {
+            throw std::system_error {errno, std::generic_category(), "read() failed while streaming a resource"};
+        }
+
+        return static_cast<std::size_t>(bytesRead);
+    }
+
+    std::uint64_t FileByteSource::size() const noexcept
+    {
+        return m_size;
+    }
+
+    std::optional<std::shared_ptr<FileByteSource>> openRegularFile(const std::string& path)
+    {
+        // O_NOFOLLOW: refuse a symlink as the final component. O_CLOEXEC: never leak the descriptor
+        // into a child process (remoted forks for other work).
+        int fd = -1;
+        do
+        {
+            fd = ::open(path.c_str(), O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+        } while (fd < 0 && errno == EINTR);
+
+        if (fd < 0)
+        {
+            return std::nullopt; // errno is the caller's to map.
+        }
+
+        // fstat on the DESCRIPTOR, not stat on the path: the check then applies to the object we
+        // actually opened and will stream, closing the window where the path could be swapped
+        // between the check and the open.
+        struct stat info
+        {
+        };
+        if (::fstat(fd, &info) != 0)
+        {
+            const int savedErrno = errno;
+            ::close(fd);
+            errno = savedErrno;
+            return std::nullopt;
+        }
+
+        if (!S_ISREG(info.st_mode))
+        {
+            ::close(fd);
+            errno = EINVAL;
+            return std::nullopt;
+        }
+
+        return std::make_shared<FileByteSource>(fd, static_cast<std::uint64_t>(info.st_size));
+    }
+
+    // -----------------------------------------------------------------------
+    // Handler
+    // -----------------------------------------------------------------------
+
+    remoted::endpoints::AuthenticatedHandler makeHandler(ResourcePaths paths)
+    {
+        return [paths = std::move(paths)](
+                   std::shared_ptr<const remoted::auth::AuthenticatedRequest> request,
+                   std::shared_ptr<remoted::http::IHttpResponder> responder)
+        {
+            const auto parsed = parseRequest(request->payload.bytes());
+
+            if (const auto* error = std::get_if<RequestError>(&parsed))
+            {
+                // Client fault, fully attacker-controlled in volume: debug only.
+                LOGFN_DEBUG2(logFn(), "Rejected a /download request from agent '%s'.", request->agentId.c_str());
+                responder->send(errorResponseFor(*error));
+                return;
+            }
+
+            const auto& downloadRequest = std::get<DownloadRequest>(parsed);
+            const std::string agentId = request->agentId;
+
+            const auto located = locateResource(downloadRequest, paths);
+
+            // The body has served its purpose. Releasing here -- rather than letting the request die
+            // with the handler -- returns its in-flight byte reservation before a transfer that may
+            // run for minutes begins.
+            request->payload.release();
+            request.reset();
+
+            // Opened BEFORE the response starts: once a 200 and a chunk are on the wire the status
+            // can no longer be corrected, so a missing file has to be discovered here to be a clean
+            // 404 rather than a truncated 200.
+            errno = 0;
+            auto source = openRegularFile(located.path);
+
+            if (!source)
+            {
+                const int openErrno = errno;
+                const auto mapped = errorForOpenErrno(openErrno);
+
+                if (mapped == LocateError::Internal)
+                {
+                    LOGFN_ERROR(logFn(),
+                                "Could not open '%s' to serve a /download request from agent '%s': %s.",
+                                located.path.c_str(),
+                                agentId.c_str(),
+                                std::strerror(openErrno));
+                }
+                else
+                {
+                    LOGFN_DEBUG2(logFn(),
+                                 "Resource '%s' is unavailable for agent '%s': %s.",
+                                 located.path.c_str(),
+                                 agentId.c_str(),
+                                 std::strerror(openErrno));
+                }
+
+                responder->send(errorResponseFor(mapped));
+                return;
+            }
+
+            LOGFN_DEBUG1(logFn(),
+                         "Serving '%s' (%llu byte(s)) to agent '%s' for a '%s' download.",
+                         located.path.c_str(),
+                         static_cast<unsigned long long>((*source)->size()),
+                         agentId.c_str(),
+                         resourceTypeName(downloadRequest.type));
+
+            remoted::http::StreamResponse response;
+            response.status = 200;
+            response.headers.emplace_back("Content-Type", "application/octet-stream");
+            response.source = std::move(*source);
+
+            responder->stream(std::move(response));
+        };
+    }
+
+} // namespace remoted::endpoints::download

--- a/src/remoted/remoted_module/src/endpoints/downloadEndpoint.hpp
+++ b/src/remoted/remoted_module/src/endpoints/downloadEndpoint.hpp
@@ -1,0 +1,278 @@
+/*
+ * Wazuh remoted module (C++ worker bridge)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 29, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _REMOTED_ENDPOINTS_DOWNLOAD_ENDPOINT_HPP
+#define _REMOTED_ENDPOINTS_DOWNLOAD_ENDPOINT_HPP
+
+#include "endpoint.hpp"                // AuthenticatedHandler
+#include "http_server/IHttpServer.hpp" // HttpResponse, IByteSource
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <variant>
+
+namespace remoted::endpoints::download
+{
+
+    /**
+     * @brief The kinds of resource `POST /download` can serve.
+     *
+     * Closed set, mirroring the wire enum (#37733 5.4). An unrecognized value is a 400, never a
+     * fallback.
+     */
+    enum class ResourceType
+    {
+        Config, ///< The agent's merged centralized configuration (`merged.mg`).
+        Wpk     ///< A WPK upgrade package staged on the manager.
+    };
+
+    /// @brief A parsed, syntactically-valid `/download` request body.
+    struct DownloadRequest
+    {
+        ResourceType type {ResourceType::Config};
+        std::string resourceId; ///< Group name (Config) or WPK filename (Wpk).
+    };
+
+    /// @brief Why a request body was rejected before anything was looked up.
+    enum class RequestError
+    {
+        Malformed,           ///< Not JSON, not an object, missing/extra field, wrong type, or over the size cap.
+        UnknownResourceType, ///< Well-formed, but `resource_type` is not `config` or `wpk`.
+        InvalidResourceId    ///< Well-formed, but `resource_id` fails the grammar for its type.
+    };
+
+    /**
+     * @brief Why a resource could not be handed to the agent.
+     */
+    enum class LocateError
+    {
+        None = 0,
+        NotFound, ///< -> 404. Absent, or present but not a regular file.
+        Internal  ///< -> 500. An unexpected errno while opening or stat-ing.
+    };
+
+    /**
+     * @brief Base directories a resource may be served from.
+     *
+     * A plain value rather than an interface: the only thing a test needs to vary is where the
+     * files live. Defaults are the production post-chroot locations (remoted chroots to
+     * /var/ossec): `SHAREDCFG_DIR`, `MULTIGROUPS_DIR` and `WM_UPGRADE_WPK_DEFAULT_PATH`.
+     */
+    struct ResourcePaths
+    {
+        std::string sharedDir {"/etc/shared"};
+        std::string multigroupsDir {"/var/multigroups"};
+        std::string wpkDir {"/var/upgrade"};
+    };
+
+    /**
+     * @brief Upper bound on the request body accepted before parsing.
+     *
+     * A real `/download` body is about 80 bytes. Capping here -- well below the authenticated-body
+     * limit -- means a pathologically large or deeply nested JSON blob is rejected outright instead
+     * of costing CPU and heap proportional to its size. Same reasoning as `/stateless`'s H-line cap.
+     */
+    constexpr std::size_t kMaxRequestJsonSize {4U * 1024U};
+
+    /**
+     * @brief Parse and syntactically validate a `/download` request body.
+     *
+     * Pure: no filesystem, no lookup, no logging. Rejects (as Malformed) anything that is not a
+     * JSON object carrying exactly `resource_type` and `resource_id`, both strings -- an unknown
+     * extra member is a rejection, matching the schema's `additionalProperties: false`.
+     *
+     * @param body Verified request body bytes (a view into the transport buffer; not NUL-terminated).
+     */
+    std::variant<DownloadRequest, RequestError> parseRequest(std::string_view body);
+
+    /**
+     * @brief Whether @p group is a syntactically valid single group name.
+     *
+     * Mirrors wazuh's own grammar (`w_validate_group_name`): non-empty, at most MAX_GROUP_NAME
+     * (255) bytes, drawn from `[A-Za-z0-9.:;_=+!@()-]`, excluding the comma (that separates entries
+     * in a selector -- see isValidGroupSelector()).
+     *
+     * `.` and `..` are rejected explicitly, and that matters: a single group name IS joined into a
+     * path (`<sharedDir>/<group>/merged.mg`), so this grammar is the containment boundary for
+     * configs just as isValidWpkFilename() is for packages.
+     */
+    bool isValidGroupName(std::string_view group);
+
+    /**
+     * @brief Whether @p selector is a valid `resource_id` for a `config` request.
+     *
+     * Accepts either one group name, or several separated by commas -- wazuh's own multigroup form,
+     * the same grammar `w_validate_group_name` accepts for a multigroup. Every entry must satisfy
+     * isValidGroupName(), so an empty entry, a leading/trailing comma or a doubled comma is
+     * rejected. Total length is capped at MAX_MULTIGROUP_SELECTOR_SIZE.
+     *
+     * Only the single-group form is ever joined into a path; a multi-entry selector is HASHED
+     * (see multigroupDirName()), so the directory it names is hex by construction.
+     */
+    bool isValidGroupSelector(std::string_view selector);
+
+    /**
+     * @brief Whether @p filename is a syntactically valid WPK filename.
+     *
+     * Stricter than the group grammar, because this value IS joined into a path: non-empty, at most
+     * 255 bytes, `[A-Za-z0-9._-]` only, must not begin with `.`, and must end in `.wpk`. The
+     * character whitelist rules out `/`, `\`, NUL, encoded traversal and unicode lookalikes in one
+     * rule, rather than by enumerating attacks.
+     */
+    bool isValidWpkFilename(std::string_view filename);
+
+    /// @brief Client-visible `{"error","code"}` response for a rejected request body.
+    remoted::http::HttpResponse errorResponseFor(RequestError error);
+
+    /// @brief Client-visible `{"error","code"}` response for a resource that could not be located.
+    remoted::http::HttpResponse errorResponseFor(LocateError error);
+
+    /**
+     * @brief Directory name a multigroup selector maps to under `var/multigroups`.
+     *
+     * Computed here, never looked up. wazuh-db is what NAMES that directory on disk, as
+     * `OS_SHA256_String_sized(csv, out, WDB_GROUP_HASH_SIZE)` with WDB_GROUP_HASH_SIZE == 8 -- the
+     * first 8 lowercase hex characters of the SHA-256, i.e. the first FOUR digest bytes.
+     * Replicating that formula is exactly what keeps this endpoint free of any database access; if
+     * the two ever diverge, every multi-group agent silently stops receiving configuration.
+     *
+     * @warning Order-sensitive, since the digest is over the selector verbatim: `"a,b"` and `"b,a"`
+     * are different directories. An agent must send its groups in the order the manager reported.
+     */
+    std::string multigroupDirName(const std::string& groupSelector);
+
+    /// @brief Outcome of resolving a request to a concrete file.
+    struct LocateResult
+    {
+        std::string path; ///< Absolute path (post-chroot); empty unless error == None.
+        LocateError error {LocateError::None};
+    };
+
+    /**
+     * @brief Resolve a verified request to the file to serve.
+     *
+     * `resource_id` names what the agent is asking for and the manager serves exactly that:
+     *   - Config, one group   -> `<sharedDir>/<resourceId>/merged.mg`
+     *   - Config, several     -> `<multigroupsDir>/<sha256(resourceId)[0..8)>/merged.mg`
+     *   - Wpk                 -> `<wpkDir>/<resourceId>`
+     *
+     * The multigroup form is what lets an agent in several groups fetch its EFFECTIVE configuration
+     * rather than one member group's. The selector is hashed, never joined, so it needs no database
+     * and cannot traverse.
+     *
+     * The single-group and WPK forms join agent-supplied input into a path, so containment rests on
+     * the grammars in isValidGroupSelector()/isValidWpkFilename(): no `/`, no `.`/`..`, no leading
+     * dot. That is what stops the agent-supplied component from naming anything outside the base
+     * directory, and loosening either grammar to admit a separator would break it and require a
+     * realpath() containment check instead.
+     *
+     * `O_NOFOLLOW` (openRegularFile()) covers only the FINAL component of the path, which differs
+     * per form:
+     *   - Wpk           -> `<wpkDir>/<resourceId>`, one agent-supplied component, and it is the one
+     *                      opened, so O_NOFOLLOW applies to it directly.
+     *   - Config        -> `<sharedDir>/<group>/merged.mg`. The component opened is `merged.mg`
+     *                      (manager-owned); the agent-supplied `<group>` is an intermediate
+     *                      DIRECTORY, which O_NOFOLLOW does not check. A symlinked group directory
+     *                      would therefore be followed.
+     *
+     * That last case is not agent-exploitable -- planting it requires write access to the manager's
+     * own etc/shared, at which point the configuration being served is already the attacker's --
+     * so it is called out as a limit of the mechanism rather than treated as a hole. Adding a
+     * realpath() containment check is what would close it if that assumption ever weakens.
+     *
+     * @note The manager does NOT check that the requesting agent belongs to what it asks for: per
+     * the protocol decision on #38022, `resource_id` is what the agent requests and the group
+     * lookup was removed. Any authenticated agent can therefore fetch any group's (or multigroup's)
+     * merged configuration. `/control` must report `config_hash` over the file this resolves to for
+     * the selector it hands the agent, or that agent re-downloads on every notify.
+     */
+    LocateResult locateResource(const DownloadRequest& request, const ResourcePaths& paths);
+
+    /**
+     * @brief An IByteSource backed by an open file descriptor.
+     *
+     * Holds the descriptor for the whole transfer rather than reopening per chunk, which makes a
+     * download immune to the file being replaced underneath it: `c_group()` regenerates a merged
+     * configuration by writing `merged.mg.tmp` and renaming it into place, so an open descriptor
+     * keeps serving the consistent old inode instead of a half-written new one.
+     *
+     * Not thread-safe by itself, and does not need to be: the transport never calls read()
+     * concurrently with itself for a given response.
+     */
+    class FileByteSource final : public remoted::http::IByteSource
+    {
+    public:
+        /**
+         * @brief Take ownership of an already-open descriptor.
+         *
+         * Public so a test can build one over a pipe or a write-only fd without going through the
+         * filesystem; openRegularFile() is the intended production entry point.
+         */
+        FileByteSource(int fd, std::uint64_t size) noexcept;
+
+        /// Closes the descriptor.
+        ~FileByteSource() override;
+
+        FileByteSource(const FileByteSource&) = delete;
+        FileByteSource& operator=(const FileByteSource&) = delete;
+
+        /**
+         * @brief Read the next slice.
+         *
+         * Retries on EINTR. A short read is NOT end-of-stream (it happens naturally on some
+         * filesystems); only a 0-byte read is.
+         *
+         * @throws std::system_error on an unrecoverable read error, which aborts the transfer.
+         *         Returning 0 instead would emit the terminating chunk and hand the agent a
+         *         truncated file that looks complete.
+         */
+        std::size_t read(char* buffer, std::size_t capacity) override;
+
+        /// @return Size reported by fstat() when the file was opened, for logging.
+        std::uint64_t size() const noexcept;
+
+    private:
+        int m_fd {-1};
+        std::uint64_t m_size {0};
+    };
+
+    /**
+     * @brief Open @p path for streaming, requiring it to be a regular file.
+     *
+     * Opens with `O_RDONLY | O_NOFOLLOW | O_CLOEXEC` and fstat()s the resulting DESCRIPTOR, so the
+     * type check applies to the object actually opened rather than to whatever the path resolved to
+     * a moment earlier. Called before any byte of the response is written -- that ordering is what
+     * lets a missing file be a clean 404 instead of a truncated 200.
+     *
+     * @return The source, or nullopt with `errno` left set for the caller to map to a status. A
+     *         non-regular file yields nullopt with errno set to EINVAL.
+     */
+    std::optional<std::shared_ptr<FileByteSource>> openRegularFile(const std::string& path);
+
+    /**
+     * @brief Build the complete `POST /download` handler.
+     *
+     * Parses, releases the payload (a transfer outlives the request by a long way; no reason to
+     * hold the body's in-flight reservation for it), resolves, opens, then streams.
+     *
+     * @warning The route MUST be registered with remoted::http::ResponseMode::Streamable. A
+     * Buffered registration reaches IHttpResponder::stream()'s fail-loud default and every download
+     * answers 500.
+     */
+    remoted::endpoints::AuthenticatedHandler makeHandler(ResourcePaths paths = {});
+
+} // namespace remoted::endpoints::download
+
+#endif // _REMOTED_ENDPOINTS_DOWNLOAD_ENDPOINT_HPP

--- a/src/remoted/remoted_module/src/endpoints/downloadEndpoint.hpp
+++ b/src/remoted/remoted_module/src/endpoints/downloadEndpoint.hpp
@@ -203,10 +203,24 @@ namespace remoted::endpoints::download
     /**
      * @brief An IByteSource backed by an open file descriptor.
      *
-     * Holds the descriptor for the whole transfer rather than reopening per chunk, which makes a
-     * download immune to the file being replaced underneath it: `c_group()` regenerates a merged
-     * configuration by writing `merged.mg.tmp` and renaming it into place, so an open descriptor
-     * keeps serving the consistent old inode instead of a half-written new one.
+     * Holds the descriptor for the whole transfer rather than reopening per chunk. When a writer
+     * replaces the file by rename (`c_group()` with `remoted.disk_storage=1` writes `merged.mg.tmp`
+     * and renames it into place), the open descriptor keeps serving the consistent old inode and
+     * nothing further is needed.
+     *
+     * That is NOT the only way these files are written, which is why this class also detects
+     * in-place modification:
+     *   - `c_group()` in its DEFAULT configuration (`remoted.disk_storage=0`) builds the merged
+     *     configuration in memory and then does `fopen(merged.mg, "w")` + `fwrite` -- truncating
+     *     and rewriting the same inode.
+     *   - A WPK is fetched straight to its final path (`wurl_request()` into `var/upgrade/`), so it
+     *     grows in place while it is being staged.
+     *
+     * Either way the descriptor follows the file's new contents, and the danger is specific: the
+     * next read() would hit the new end-of-file and return 0, the transport would emit the
+     * terminating chunk, and the agent would accept a truncated or spliced file as COMPLETE. Being
+     * cut off is recoverable -- the agent retries; being handed corrupt bytes that look whole is
+     * not. See read() for how that is turned back into an abort.
      *
      * Not thread-safe by itself, and does not need to be: the transport never calls read()
      * concurrently with itself for a given response.
@@ -234,9 +248,28 @@ namespace remoted::endpoints::download
          * Retries on EINTR. A short read is NOT end-of-stream (it happens naturally on some
          * filesystems); only a 0-byte read is.
          *
-         * @throws std::system_error on an unrecoverable read error, which aborts the transfer.
-         *         Returning 0 instead would emit the terminating chunk and hand the agent a
-         *         truncated file that looks complete.
+         * After EVERY chunk -- not only at end-of-stream -- re-`fstat`s the descriptor and compares
+         * size and mtime against what they were at open(). Any mismatch means the file was
+         * rewritten mid-transfer, so what has been streamed is a mix of two versions:
+         *   - shorter -> a truncating rewrite (c_group() on merged.mg)
+         *   - longer  -> still being staged (a WPK mid-download)
+         *   - same length, mtime moved -> a same-size rewrite, which no byte count can see
+         *
+         * Checking per chunk rather than once at the end is what bounds the waste: a writer landing
+         * one second into a 1 GiB transfer would otherwise cost the whole gigabyte of reads and
+         * socket writes before the transfer is abandoned. The end-of-stream check remains, covering
+         * a writer that lands between the final data read and the zero-byte read.
+         *
+         * @throws std::system_error on an unrecoverable read error, and std::runtime_error when the
+         *         file changed underneath the transfer. Both abort it. Returning 0 instead would
+         *         emit the terminating chunk and hand the agent a corrupt file that looks complete;
+         *         aborting makes the agent retry, which is the recoverable outcome.
+         *
+         * @note This detects the modification, it does not prevent it: a writer that rewrites the
+         *       file with an identical length inside the same mtime granularity would still slip
+         *       through, and nothing here can know a writer holds the file open before it acts.
+         *       Closing that needs the writers to publish atomically by rename (as
+         *       `disk_storage=1` already does) rather than any check here.
          */
         std::size_t read(char* buffer, std::size_t capacity) override;
 
@@ -244,8 +277,23 @@ namespace remoted::endpoints::download
         std::uint64_t size() const noexcept;
 
     private:
+        /**
+         * @brief Compare the descriptor's current size/mtime against the baseline from open().
+         *
+         * Called after every chunk and again at end-of-stream.
+         *
+         * @throws std::runtime_error naming which way it changed (truncated / grew / modified), so
+         *         the abort WARN says what actually happened rather than just "it changed".
+         */
+        void checkNotModified() const;
+
         int m_fd {-1};
         std::uint64_t m_size {0};
+        std::uint64_t m_delivered {0}; ///< Bytes handed to the transport so far.
+        // mtime at open, kept as plain integers so this header needs no <sys/stat.h>.
+        std::int64_t m_mtimeSec {0};
+        std::int64_t m_mtimeNsec {0};
+        bool m_mtimeKnown {false}; ///< False if the baseline fstat failed; the mtime check is then skipped.
     };
 
     /**

--- a/src/remoted/remoted_module/src/http_server/IHttpServer.hpp
+++ b/src/remoted/remoted_module/src/http_server/IHttpServer.hpp
@@ -76,6 +76,69 @@ namespace remoted::http
     };
 
     /**
+     * @brief Pull-based byte source for a streamed (chunked) response body.
+     *
+     * The transport drives this, not the endpoint: it owns both the connection's I/O strand and
+     * the handler worker pool, so it is the only layer that can read on a worker, write on the
+     * strand, and wait for each write to complete before pulling again. That is what keeps a
+     * transfer's memory flat (one chunk resident) and its worker-pool cost to a single slot held
+     * only for the duration of one read -- neither of which an endpoint driving a push-style
+     * writeChunk()/finish() API could achieve without blocking a worker for the whole transfer.
+     *
+     * It also keeps the source itself free of any HTTP concept, which is what makes a concrete
+     * source (see FileByteSource) directly unit-testable.
+     */
+    class IByteSource
+    {
+    public:
+        virtual ~IByteSource() = default;
+
+        /**
+         * @brief Produce the next slice of the body.
+         *
+         * Called on the server's worker pool -- never on an I/O thread, and never concurrently
+         * with itself -- so a blocking read is expected and safe here.
+         *
+         * @param buffer   Destination.
+         * @param capacity Maximum number of bytes to write into @p buffer.
+         * @return Bytes written; 0 means end-of-stream. Throwing aborts the transfer: no
+         *         terminating chunk is emitted, so the peer sees a truncated body and retries.
+         */
+        virtual std::size_t read(char* buffer, std::size_t capacity) = 0;
+    };
+
+    /**
+     * @brief A response whose body is streamed with chunked transfer encoding.
+     *
+     * The transport emits `Transfer-Encoding: chunked` itself; do not put it in @ref headers.
+     */
+    struct StreamResponse
+    {
+        int status {200};                                         ///< HTTP status code.
+        std::vector<std::pair<std::string, std::string>> headers; ///< Extra headers (verbatim order).
+        std::shared_ptr<IByteSource> source;                      ///< Body producer; must not be null.
+        /// Bytes pulled per chunk. 0 (the default) means "use the server's configured
+        /// streamChunkSize", so an endpoint does not have to know about the tunable at all.
+        std::size_t chunkSize {0};
+    };
+
+    /**
+     * @brief Whether a route may answer with a streamed body.
+     *
+     * Not a per-response choice: the transport creates the underlying response builder when the
+     * request is dispatched (which is what lets it release the received body before the request
+     * is queued), and that builder's output mode is fixed at creation. So the mode has to be
+     * declared at registration time. `Streamable` routes pay a slightly later release of the
+     * received request in exchange -- negligible for a route whose requests are small, which is
+     * the only kind that should be streaming a response anyway.
+     */
+    enum class ResponseMode
+    {
+        Buffered,  ///< Single in-memory body via IHttpResponder::send(). The default.
+        Streamable ///< May additionally answer via IHttpResponder::stream().
+    };
+
+    /**
      * @brief Sink used by a handler to deliver its response, possibly later.
      *
      * The server hands one responder per request. A handler may either respond
@@ -98,6 +161,24 @@ namespace remoted::http
          * @param response The response to send.
          */
         virtual void send(HttpResponse response) = 0;
+
+        /**
+         * @brief Deliver the response as a chunked stream, pulling from @p response.source.
+         *
+         * Shares send()'s exactly-once guarantee: send() and stream() together may be called once
+         * per request, from any thread. Returns immediately -- the transfer proceeds asynchronously
+         * and the source is drained on the worker pool.
+         *
+         * Only meaningful on a route registered with ResponseMode::Streamable. The default below
+         * exists so that responders which never stream (and every test double) need no override;
+         * it fails loudly rather than silently buffering the whole body, because a route that
+         * reaches it is misregistered, and quietly materializing a multi-megabyte payload in
+         * memory is the exact failure streaming exists to prevent.
+         */
+        virtual void stream(StreamResponse /*response*/)
+        {
+            send(HttpResponse::json(500, R"({"error":"Internal server error","code":500})"));
+        }
     };
 
     /**
@@ -170,6 +251,9 @@ namespace remoted::http
         std::size_t maxPipelinedRequests {4};          ///< Max in-flight unanswered requests per connection.
         std::size_t concurrentAccepts {2};             ///< Max concurrent in-progress TCP accepts.
         std::size_t bufferSize {8192};                 ///< Socket read buffer size, bytes.
+        /// Bytes per chunk for a streamed response body. Per in-flight transfer, so the worst-case
+        /// cost is this times the number of simultaneous streams. See remoted.http_stream_chunk_size.
+        std::size_t streamChunkSize {64U * 1024U};
         /// Max in-flight (unprocessed) request payload bytes before new requests get 503. 0 disables the limit.
         std::size_t maxInFlightBytes {256U * 1024U * 1024U};
         /// Max simultaneous TCP connections (bounds the read-phase peak: maxParallelConnections * maxBodySize).
@@ -197,9 +281,15 @@ namespace remoted::http
          * @param countAgainstBudget When false, the route is exempt from the in-flight byte budget
          *                           (no reservation, never shed with 503). Use for tiny liveness
          *                           probes so they stay available under memory pressure.
+         * @param mode               Whether the route's handler may answer with a streamed body.
+         *                           See ResponseMode: this cannot be decided per response, so a
+         *                           route that ever streams must say so here.
          */
-        virtual void
-        addRoute(Method method, const std::string& path, RouteHandler handler, bool countAgainstBudget = true) = 0;
+        virtual void addRoute(Method method,
+                              const std::string& path,
+                              RouteHandler handler,
+                              bool countAgainstBudget = true,
+                              ResponseMode mode = ResponseMode::Buffered) = 0;
 
         /**
          * @brief Start listening. Throws on bind/TLS/configuration failure.

--- a/src/remoted/remoted_module/src/http_server/RestinioHttpServer.cpp
+++ b/src/remoted/remoted_module/src/http_server/RestinioHttpServer.cpp
@@ -456,6 +456,234 @@ namespace
         std::string path;
         remoted::http::RouteHandler handler;
         bool countAgainstBudget {true}; ///< When false, exempt from the in-flight byte budget (never 503'd).
+        remoted::http::ResponseMode mode {remoted::http::ResponseMode::Buffered};
+    };
+
+    using ChunkedBuilder = restinio::response_builder_t<restinio::chunked_output_t>;
+
+    /**
+     * @brief Reports an aborted streamed transfer, throttled, at WARN.
+     *
+     * WARN rather than ERROR: an aborted transfer is a peer going away or a transient I/O problem,
+     * not the manager being broken (this module reserves ERROR for that). Throttled for the same
+     * reason as the byte-budget rejection above: the volume is client-driven, so one line per
+     * aborted transfer would let a peer failing in a loop flood wazuh-manager.log.
+     *
+     * @param reason Exception text; passed as an ARGUMENT, never as the format string.
+     */
+    void warnStreamAborted(const char* reason)
+    {
+        static remoted::common::LogThrottle throttle;
+
+        if (const auto aborted = throttle.record())
+        {
+            LOGFN_WARN(logFn(),
+                       "Aborted %llu streamed response(s) in the last %d s. No terminating chunk is sent, so the "
+                       "peer sees a truncated body and retries. Last reason: %s",
+                       static_cast<unsigned long long>(aborted.total),
+                       remoted::common::LogThrottle::kDefaultWindowSeconds,
+                       reason);
+        }
+    }
+
+    /**
+     * @brief Drives a chunked transfer: read a chunk on a worker, write it, repeat.
+     *
+     * The alternation is the whole point. read() blocks on disk, so it must not run on an I/O
+     * thread; the write completion fires ON the connection's strand, so it must not read. Bouncing
+     * between the two keeps exactly one chunk resident and holds a worker slot only for the
+     * duration of a single read, rather than for the whole transfer.
+     *
+     * Lifetime: each step keeps the pump alive by capturing a shared_ptr into the callback it
+     * hands off, so the object lives exactly as long as the transfer. RESTinio guarantees the
+     * write callback always fires -- with an error if the connection died before the write could
+     * run (see response_coordinator's cleanup and write_response_parts_impl) -- so the chain
+     * always terminates and the source's descriptor is always released.
+     */
+    class StreamPump final : public std::enable_shared_from_this<StreamPump>
+    {
+    public:
+        StreamPump(ChunkedBuilder builder,
+                   std::shared_ptr<remoted::http::IByteSource> source,
+                   std::size_t chunkSize,
+                   asio::thread_pool& pool)
+            : m_builder {std::move(builder)}
+            , m_source {std::move(source)}
+            , m_chunkSize {chunkSize}
+            , m_pool {&pool}
+        {
+        }
+
+        /// Kick the transfer off on a worker thread.
+        void start()
+        {
+            schedule();
+        }
+
+    private:
+        void schedule()
+        {
+            asio::post(*m_pool, [self = shared_from_this()]() { self->pumpOnce(); });
+        }
+
+        void pumpOnce()
+        {
+            std::string chunk;
+
+            try
+            {
+                chunk.resize(m_chunkSize);
+                const auto bytesRead = m_source->read(chunk.data(), m_chunkSize);
+
+                if (bytesRead == 0)
+                {
+                    // End of stream: done() emits the terminating zero-length chunk, which is what
+                    // tells the peer the body is COMPLETE. Reaching it is the only way a transfer
+                    // is allowed to look successful.
+                    m_builder.done();
+                    return;
+                }
+
+                chunk.resize(bytesRead);
+            }
+            catch (const std::exception& e)
+            {
+                // Deliberately no done(): dropping the builder leaves the chunked body without its
+                // terminator, so the peer sees a truncated transfer and retries. Emitting the
+                // terminator here would hand it a short file that looks complete.
+                warnStreamAborted(e.what());
+                return;
+            }
+            catch (...)
+            {
+                warnStreamAborted("non-standard exception while reading the resource");
+                return;
+            }
+
+            try
+            {
+                m_builder.append_chunk(std::move(chunk))
+                    .flush(
+                        [self = shared_from_this()](const asio::error_code& ec)
+                        {
+                            if (ec)
+                            {
+                                // The peer went away or the connection was torn down. Nothing to
+                                // clean up beyond letting this pump die: `self` is the last owner
+                                // once this callback returns, so the source (and its descriptor)
+                                // is released here.
+                                LOGFN_DEBUG2(logFn(), "A streamed response ended early: %s", ec.message().c_str());
+                                return;
+                            }
+                            self->schedule();
+                        });
+            }
+            catch (const std::exception& e)
+            {
+                warnStreamAborted(e.what());
+            }
+            catch (...)
+            {
+                warnStreamAborted("non-standard exception while writing to the connection");
+            }
+        }
+
+        ChunkedBuilder m_builder;
+        std::shared_ptr<remoted::http::IByteSource> m_source;
+        std::size_t m_chunkSize;
+        asio::thread_pool* m_pool;
+    };
+
+    /**
+     * @brief Responder for a route registered ResponseMode::Streamable.
+     *
+     * Unlike RestinioResponder, this one holds the request handle and creates the response builder
+     * only once the handler has decided how to answer -- because the builder's output mode is fixed
+     * at creation and the two modes are different types. The cost is that the received request
+     * survives into the worker queue instead of being released on the I/O thread; that is why
+     * streaming is opt-in per route rather than available everywhere.
+     */
+    class RestinioStreamableResponder final : public remoted::http::IHttpResponder
+    {
+    public:
+        RestinioStreamableResponder(restinio::request_handle_t request,
+                                    asio::thread_pool& pool,
+                                    std::size_t defaultChunkSize)
+            : m_request {std::move(request)}
+            , m_pool {&pool}
+            , m_defaultChunkSize {defaultChunkSize}
+        {
+        }
+
+        void send(remoted::http::HttpResponse response) override
+        {
+            if (m_answered.test_and_set())
+            {
+                return;
+            }
+
+            auto builder = m_request->create_response(
+                restinio::http_status_line_t {restinio::http_status_code_t {static_cast<std::uint16_t>(response.status)},
+                                              reasonPhrase(response.status)});
+            m_request.reset();
+
+            builder.append_header(restinio::http_field::server, "wazuh-manager-remoted");
+            builder.append_header_date_field();
+
+            for (const auto& [name, value] : response.headers)
+            {
+                builder.append_header(name, value);
+            }
+
+            builder.set_body(std::move(response.body));
+            builder.done();
+        }
+
+        void stream(remoted::http::StreamResponse response) override
+        {
+            if (!response.source)
+            {
+                // A streamed response with nothing to stream is a programming error, not something
+                // the peer can provoke. Answer 500 rather than emitting an empty 200 that would
+                // look to an agent like a legitimately empty resource.
+                LOGFN_ERROR(logFn(), "A streamed response was requested without a byte source.");
+                send(remoted::http::HttpResponse::json(500, R"({"error":"Internal server error","code":500})"));
+                return;
+            }
+
+            if (m_answered.test_and_set())
+            {
+                return;
+            }
+
+            auto builder = m_request->create_response<restinio::chunked_output_t>(
+                restinio::http_status_line_t {restinio::http_status_code_t {static_cast<std::uint16_t>(response.status)},
+                                              reasonPhrase(response.status)});
+            m_request.reset();
+
+            builder.append_header(restinio::http_field::server, "wazuh-manager-remoted");
+            builder.append_header_date_field();
+
+            for (const auto& [name, value] : response.headers)
+            {
+                // Transfer-Encoding is RESTinio's to emit for a chunked builder; a caller-supplied
+                // one would be a duplicate header.
+                builder.append_header(name, value);
+            }
+
+            // A response that names no size gets the server's configured one
+            // (remoted.http_stream_chunk_size); an endpoint may still pin its own.
+            const auto chunkSize = response.chunkSize != 0 ? response.chunkSize : m_defaultChunkSize;
+
+            std::make_shared<StreamPump>(std::move(builder), std::move(response.source), chunkSize, *m_pool)
+                ->start();
+        }
+
+    private:
+        restinio::request_handle_t m_request;
+        asio::thread_pool* m_pool;
+        std::size_t m_defaultChunkSize;
+        std::atomic_flag m_answered = ATOMIC_FLAG_INIT;
     };
 
     // Last-resort 500 for the transport-level exception barriers below. Never throws: it is called
@@ -511,11 +739,13 @@ namespace remoted::http
                 auto handler = route.handler;
                 const auto method = route.method;
                 const auto countAgainstBudget = route.countAgainstBudget;
+                const auto responseMode = route.mode;
+                const auto streamChunkSize = m_config.streamChunkSize;
 
                 requestRouter->add_handler(
                     toRestinioMethod(method),
                     route.path,
-                    [pool, budget, budgetThrottle, handler, method, countAgainstBudget](
+                    [pool, budget, budgetThrottle, handler, method, countAgainstBudget, responseMode, streamChunkSize](
                         auto request, auto) -> restinio::request_handling_status_t
                     {
                         // Transport-level exception barrier, covering every registered route at
@@ -524,7 +754,7 @@ namespace remoted::http
                         // std::exception and closes the connection, so the only exposure left is a
                         // non-std::exception, which would reach a noexcept frame and terminate the
                         // whole daemon. Everything here runs on a RESTinio I/O thread.
-                        std::shared_ptr<RestinioResponder> responder;
+                        std::shared_ptr<remoted::http::IHttpResponder> responder;
                         try
                         {
                             // Reserve the request's payload against the global in-flight budget
@@ -567,11 +797,25 @@ namespace remoted::http
                             auto context = std::make_shared<RequestContext>(
                                 RequestContext {makeHttpRequest(method, request), std::move(reservation)});
 
-                            // Create the response builder up-front (moves the connection out of
-                            // the request), then drop the RESTinio handle right here -- freeing
-                            // its body buffer on the I/O thread, before the request ever waits in
-                            // the worker queue. Only our single copy remains.
-                            responder = std::make_shared<RestinioResponder>(request);
+                            if (responseMode == remoted::http::ResponseMode::Streamable)
+                            {
+                                // A streamable route cannot have its builder created here: the
+                                // output mode (buffered vs chunked) is fixed at creation and only
+                                // the handler knows which it needs -- an error is buffered, a
+                                // transfer is chunked. So the responder keeps the request handle
+                                // and creates the builder when it answers, which means RESTinio's
+                                // body buffer survives into the worker queue. Bounded by design:
+                                // only routes whose requests are tiny should ever stream.
+                                responder = std::make_shared<RestinioStreamableResponder>(request, *pool, streamChunkSize);
+                            }
+                            else
+                            {
+                                // Create the response builder up-front (moves the connection out of
+                                // the request), then drop the RESTinio handle right here -- freeing
+                                // its body buffer on the I/O thread, before the request ever waits
+                                // in the worker queue. Only our single copy remains.
+                                responder = std::make_shared<RestinioResponder>(request);
+                            }
                             request.reset();
 
                             // Hand off to a worker thread (deferred response) and cede SOLE
@@ -655,7 +899,11 @@ namespace remoted::http
     }
 
     void
-    RestinioHttpServer::addRoute(Method method, const std::string& path, RouteHandler handler, bool countAgainstBudget)
+    RestinioHttpServer::addRoute(Method method,
+                                 const std::string& path,
+                                 RouteHandler handler,
+                                 bool countAgainstBudget,
+                                 ResponseMode mode)
     {
         std::lock_guard<std::mutex> lock {m_impl->m_mutex};
 
@@ -664,7 +912,7 @@ namespace remoted::http
             throw std::logic_error("Cannot register a route while the HTTP server is running");
         }
 
-        m_impl->m_routes.push_back(Route {method, path, std::move(handler), countAgainstBudget});
+        m_impl->m_routes.push_back(Route {method, path, std::move(handler), countAgainstBudget, mode});
     }
 
     void RestinioHttpServer::start(const HttpServerConfig& config)

--- a/src/remoted/remoted_module/src/http_server/RestinioHttpServer.hpp
+++ b/src/remoted/remoted_module/src/http_server/RestinioHttpServer.hpp
@@ -54,7 +54,11 @@ namespace remoted::http
         RestinioHttpServer& operator=(const RestinioHttpServer&) = delete;
 
         void
-        addRoute(Method method, const std::string& path, RouteHandler handler, bool countAgainstBudget = true) override;
+        addRoute(Method method,
+                 const std::string& path,
+                 RouteHandler handler,
+                 bool countAgainstBudget = true,
+                 ResponseMode mode = ResponseMode::Buffered) override;
         void start(const HttpServerConfig& config) override;
         void stopAccepting() noexcept override;
         void stop() noexcept override;

--- a/src/remoted/remoted_module/src/http_server/httpServerConfig.cpp
+++ b/src/remoted/remoted_module/src/http_server/httpServerConfig.cpp
@@ -36,6 +36,9 @@ namespace
     constexpr std::size_t DEFAULT_MAX_PIPELINED_REQUESTS {4};
     constexpr std::size_t DEFAULT_CONCURRENT_ACCEPTS {2};
     constexpr std::size_t DEFAULT_BUFFER_SIZE {8192};
+    // Bytes per chunk for a streamed response body. Agreed default; tunable through
+    // remoted.http_stream_chunk_size because the CPU cost per byte moves noticeably with it.
+    constexpr std::size_t DEFAULT_STREAM_CHUNK_SIZE {64U * 1024U};
 
     // Global cap on in-flight (unprocessed) request payload bytes. Bounds the worker-pool
     // queue + handlers + deferred responses so a burst can't grow memory without limit;
@@ -149,6 +152,7 @@ namespace remoted::http
             resolveUnsigned(config.http_max_pipelined_requests, DEFAULT_MAX_PIPELINED_REQUESTS);
         result.concurrentAccepts = resolveUnsigned(config.http_concurrent_accepts, DEFAULT_CONCURRENT_ACCEPTS);
         result.bufferSize = resolveUnsigned(config.http_buffer_size, DEFAULT_BUFFER_SIZE);
+        result.streamChunkSize = resolveUnsigned(config.http_stream_chunk_size, DEFAULT_STREAM_CHUNK_SIZE);
 
         // Memory-management knobs come from remoted's config struct (a positive value wins),
         // otherwise the built-in default -- deliberately NOT env-driven. The transport clamps the

--- a/src/remoted/remoted_module/src/remotedModuleFacade.hpp
+++ b/src/remoted/remoted_module/src/remotedModuleFacade.hpp
@@ -38,6 +38,7 @@
 #include "endpoints/authGateway.hpp"
 #include "endpoints/configEndpoint.hpp"
 #include "endpoints/controlEndpoint.hpp"
+#include "endpoints/downloadEndpoint.hpp"
 #include "endpoints/statelessEndpoint.hpp"
 #include "endpoints/statsEndpoint.hpp"
 #include "http_server/IHttpServer.hpp"
@@ -283,6 +284,19 @@ private:
             remoted::http::Method::Post,
             "/stateless",
             remoted::endpoints::stateless::makeHandler(*m_forwarder, eventsSocketPath));
+
+        // /download: streams merged.mg and WPK packages with chunked transfer encoding. Registered
+        // ResponseMode::Streamable because the transport fixes a response's output mode when the
+        // request is dispatched -- a Buffered registration would make every download answer 500.
+        //
+        // resource_id is the group (or WPK filename) the agent requests and the manager serves
+        // exactly that; there is no group lookup and no membership check (protocol decision on
+        // #38022). Containment therefore rests on the resource-id grammars plus O_NOFOLLOW.
+        m_authGateway->addAuthenticatedRoute(*m_httpServer,
+                                             remoted::http::Method::Post,
+                                             "/download",
+                                             remoted::endpoints::download::makeHandler(),
+                                             remoted::http::ResponseMode::Streamable);
 
         // /stateless takes the client's default response deadline (its target leaves the override
         // at 0), so that is what gets checked against the transport's request cap.

--- a/src/remoted/remoted_module/test/unit/authGateway_test.cpp
+++ b/src/remoted/remoted_module/test/unit/authGateway_test.cpp
@@ -36,10 +36,21 @@ namespace
     class FakeHttpServer final : public IHttpServer
     {
     public:
-        void
-        addRoute(Method method, const std::string& path, RouteHandler handler, bool /*countAgainstBudget*/) override
+        void addRoute(Method method,
+                      const std::string& path,
+                      RouteHandler handler,
+                      bool /*countAgainstBudget*/,
+                      ResponseMode mode) override
         {
             m_routes[{method, path}] = std::move(handler);
+            m_modes[{method, path}] = mode;
+        }
+
+        /// @brief The response mode a route was registered with, for asserting the registration.
+        ResponseMode modeOf(Method method, const std::string& path) const
+        {
+            const auto it = m_modes.find({method, path});
+            return it == m_modes.end() ? ResponseMode::Buffered : it->second;
         }
         void start(const HttpServerConfig&) override {}
         void stopAccepting() noexcept override {}
@@ -61,6 +72,7 @@ namespace
 
     private:
         std::map<std::pair<Method, std::string>, RouteHandler> m_routes;
+        std::map<std::pair<Method, std::string>, ResponseMode> m_modes;
     };
 
     // Keystore stub: knows one agent (numeric id 1, i.e. "001" on the wire); anything else is unknown.
@@ -155,6 +167,23 @@ TEST(AuthGatewayTest, RegistersRouteOnTheServer)
         { responder->send(HttpResponse {200, "", {}}); });
 
     EXPECT_TRUE(server.hasRoute(Method::Post, "/stateless"));
+}
+
+TEST(AuthGatewayTest, ForwardsTheResponseModeToTheServer)
+{
+    // The mode cannot be chosen per response -- the transport fixes a builder's output mode when the
+    // request is dispatched -- so a streaming endpoint depends on the gateway passing it through at
+    // registration. A Buffered registration would make every /download answer 500.
+    FakeHttpServer server;
+    auto gateway = makeGateway();
+
+    gateway.addAuthenticatedRoute(
+        server, Method::Post, "/buffered", [](auto, auto) {});
+    gateway.addAuthenticatedRoute(
+        server, Method::Post, "/streamed", [](auto, auto) {}, ResponseMode::Streamable);
+
+    EXPECT_EQ(server.modeOf(Method::Post, "/buffered"), ResponseMode::Buffered) << "default must stay buffered";
+    EXPECT_EQ(server.modeOf(Method::Post, "/streamed"), ResponseMode::Streamable);
 }
 
 TEST(AuthGatewayTest, MissingProtocolVersionYields400AndSkipsHandler)

--- a/src/remoted/remoted_module/test/unit/downloadEndpoint_test.cpp
+++ b/src/remoted/remoted_module/test/unit/downloadEndpoint_test.cpp
@@ -1,0 +1,714 @@
+/*
+ * Wazuh remoted module (C++ worker bridge)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 29, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "endpoints/downloadEndpoint.hpp"
+
+#include <gtest/gtest.h>
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstring>
+#include <fstream>
+#include <memory>
+#include <optional>
+#include <string>
+#include <system_error>
+#include <variant>
+#include <vector>
+
+using namespace remoted::endpoints::download;
+
+namespace
+{
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /// Creates a throwaway directory tree and removes it on destruction.
+    class TempDir
+    {
+    public:
+        TempDir()
+        {
+            std::string tmpl = "/tmp/wazuh-download-test-XXXXXX";
+            std::vector<char> buffer(tmpl.begin(), tmpl.end());
+            buffer.push_back('\0');
+
+            const char* created = ::mkdtemp(buffer.data());
+            if (created == nullptr)
+            {
+                throw std::system_error {errno, std::generic_category(), "mkdtemp"};
+            }
+            m_path = created;
+        }
+
+        ~TempDir()
+        {
+            for (auto it = m_files.rbegin(); it != m_files.rend(); ++it)
+            {
+                ::unlink(it->c_str());
+            }
+            for (auto it = m_dirs.rbegin(); it != m_dirs.rend(); ++it)
+            {
+                ::rmdir(it->c_str());
+            }
+            ::rmdir(m_path.c_str());
+        }
+
+        TempDir(const TempDir&) = delete;
+        TempDir& operator=(const TempDir&) = delete;
+
+        const std::string& path() const
+        {
+            return m_path;
+        }
+
+        std::string makeDir(const std::string& relative)
+        {
+            std::string full = m_path;
+            std::size_t start = 0;
+            while (start < relative.size())
+            {
+                const auto slash = relative.find('/', start);
+                const auto part = relative.substr(start, slash == std::string::npos ? std::string::npos : slash - start);
+                full += "/" + part;
+                ::mkdir(full.c_str(), 0700);
+                m_dirs.push_back(full);
+                if (slash == std::string::npos)
+                {
+                    break;
+                }
+                start = slash + 1;
+            }
+            return full;
+        }
+
+        std::string writeFile(const std::string& relative, const std::string& contents)
+        {
+            const std::string full = m_path + "/" + relative;
+            std::ofstream out {full, std::ios::binary};
+            out.write(contents.data(), static_cast<std::streamsize>(contents.size()));
+            out.close();
+            m_files.push_back(full);
+            return full;
+        }
+
+        std::string track(const std::string& relative)
+        {
+            const std::string full = m_path + "/" + relative;
+            m_files.push_back(full);
+            return full;
+        }
+
+    private:
+        std::string m_path;
+        std::vector<std::string> m_files;
+        std::vector<std::string> m_dirs;
+    };
+
+    /// Drains a source the way the transport does.
+    std::string drain(remoted::http::IByteSource& source, std::size_t chunkSize)
+    {
+        std::string collected;
+        std::string chunk;
+
+        while (true)
+        {
+            chunk.resize(chunkSize);
+            const auto bytesRead = source.read(chunk.data(), chunkSize);
+            if (bytesRead == 0)
+            {
+                break;
+            }
+            collected.append(chunk, 0, bytesRead);
+        }
+
+        return collected;
+    }
+
+    /// Records whichever delivery mode the handler chose, draining a stream the way the transport
+    /// would so a test can assert on the exact bytes an agent would receive.
+    class RecordingResponder final : public remoted::http::IHttpResponder
+    {
+    public:
+        void send(remoted::http::HttpResponse response) override
+        {
+            if (answered)
+            {
+                return;
+            }
+            answered = true;
+            status = response.status;
+            body = std::move(response.body);
+        }
+
+        void stream(remoted::http::StreamResponse response) override
+        {
+            if (answered)
+            {
+                return;
+            }
+            answered = true;
+            streamed = true;
+            status = response.status;
+            headers = response.headers;
+            // chunkSize 0 means "use the server's configured size" (see StreamResponse); the real
+            // transport substitutes HttpServerConfig::streamChunkSize there, so a double that
+            // passed the 0 straight through would read nothing at all.
+            chunkSize = response.chunkSize != 0 ? response.chunkSize : 64U * 1024U;
+            body = drain(*response.source, chunkSize);
+        }
+
+        bool answered {false};
+        bool streamed {false};
+        std::size_t chunkSize {0}; ///< The size actually used, after the 0 -> default substitution.
+        int status {0};
+        std::string body;
+        std::vector<std::pair<std::string, std::string>> headers;
+    };
+
+    /// Builds a verified request whose payload views a buffer the caller keeps alive.
+    std::shared_ptr<remoted::auth::AuthenticatedRequest> authenticatedRequest(const std::shared_ptr<std::string>& body,
+                                                                             const std::string& agentId = "001")
+    {
+        auto request = std::make_shared<remoted::auth::AuthenticatedRequest>();
+        request->agentId = agentId;
+        request->protocolVersion = "1";
+        request->method = "POST";
+        request->requestTarget = "/download";
+        request->payload = remoted::auth::Payload {*body, body};
+        return request;
+    }
+
+    std::shared_ptr<RecordingResponder> runHandler(const std::string& bodyText, ResourcePaths paths = {})
+    {
+        auto responder = std::make_shared<RecordingResponder>();
+        auto body = std::make_shared<std::string>(bodyText);
+        makeHandler(std::move(paths))(authenticatedRequest(body), responder);
+        return responder;
+    }
+
+    DownloadRequest configRequest(std::string group)
+    {
+        return DownloadRequest {ResourceType::Config, std::move(group)};
+    }
+
+    constexpr auto VALID_CONFIG_BODY {R"({"resource_type":"config","resource_id":"web-servers"})"};
+} // namespace
+
+// ---------------------------------------------------------------------------
+// parseRequest
+// ---------------------------------------------------------------------------
+
+TEST(DownloadParseRequestTest, AcceptsAConfigRequest)
+{
+    const auto parsed = parseRequest(VALID_CONFIG_BODY);
+
+    ASSERT_TRUE(std::holds_alternative<DownloadRequest>(parsed));
+    EXPECT_EQ(std::get<DownloadRequest>(parsed).type, ResourceType::Config);
+    EXPECT_EQ(std::get<DownloadRequest>(parsed).resourceId, "web-servers");
+}
+
+TEST(DownloadParseRequestTest, AcceptsAWpkRequest)
+{
+    const auto parsed = parseRequest(R"({"resource_type":"wpk","resource_id":"wazuh_agent_v5.0.1_linux_x86_64.wpk"})");
+
+    ASSERT_TRUE(std::holds_alternative<DownloadRequest>(parsed));
+    EXPECT_EQ(std::get<DownloadRequest>(parsed).type, ResourceType::Wpk);
+    EXPECT_EQ(std::get<DownloadRequest>(parsed).resourceId, "wazuh_agent_v5.0.1_linux_x86_64.wpk");
+}
+
+TEST(DownloadParseRequestTest, AcceptsMembersInEitherOrder)
+{
+    EXPECT_TRUE(std::holds_alternative<DownloadRequest>(
+        parseRequest(R"({"resource_id":"web-servers","resource_type":"config"})")));
+}
+
+TEST(DownloadParseRequestTest, RejectsMalformedBodies)
+{
+    const char* bodies[] = {
+        "",                                                          // empty
+        "not json",                                                  // not JSON
+        "[]",                                                        // not an object
+        R"("a string")",                                             // not an object
+        R"({"resource_type":"config"})",                              // missing resource_id
+        R"({"resource_id":"web-servers"})",                           // missing resource_type
+        R"({"resource_type":"config","resource_id":"a","extra":1})",  // additionalProperties: false
+        R"({"resource_type":1,"resource_id":"a"})",                   // wrong type
+        R"({"resource_type":"config","resource_id":123})",            // wrong type
+        R"({"resource_type":"config","resource_id":null})",           // wrong type
+        R"({"resource_type":"config","resource_id":"a",)",            // truncated
+    };
+
+    for (const auto* body : bodies)
+    {
+        const auto parsed = parseRequest(body);
+        ASSERT_TRUE(std::holds_alternative<RequestError>(parsed)) << "accepted: " << body;
+        EXPECT_EQ(std::get<RequestError>(parsed), RequestError::Malformed) << "body: " << body;
+    }
+}
+
+TEST(DownloadParseRequestTest, RejectsAnUnknownResourceType)
+{
+    const auto parsed = parseRequest(R"({"resource_type":"secrets","resource_id":"a"})");
+
+    ASSERT_TRUE(std::holds_alternative<RequestError>(parsed));
+    EXPECT_EQ(std::get<RequestError>(parsed), RequestError::UnknownResourceType);
+}
+
+TEST(DownloadParseRequestTest, ResourceTypeIsCaseSensitive)
+{
+    const auto parsed = parseRequest(R"({"resource_type":"CONFIG","resource_id":"a"})");
+
+    ASSERT_TRUE(std::holds_alternative<RequestError>(parsed));
+    EXPECT_EQ(std::get<RequestError>(parsed), RequestError::UnknownResourceType);
+}
+
+TEST(DownloadParseRequestTest, RejectsABodyOverTheParseCap)
+{
+    // Rejected on size BEFORE parsing, so a hostile blob never costs heap proportional to itself.
+    std::string body = R"({"resource_type":"config","resource_id":")";
+    body.append(kMaxRequestJsonSize, 'a');
+    body.append(R"("})");
+
+    const auto parsed = parseRequest(body);
+    ASSERT_TRUE(std::holds_alternative<RequestError>(parsed));
+    EXPECT_EQ(std::get<RequestError>(parsed), RequestError::Malformed);
+}
+
+TEST(DownloadParseRequestTest, DeeplyNestedInputIsRejectedWithoutBlowingTheStack)
+{
+    // Iterative parsing keeps the parser's stack usage constant; this asserts it does not crash.
+    const auto parsed = parseRequest(std::string(1000, '['));
+
+    ASSERT_TRUE(std::holds_alternative<RequestError>(parsed));
+    EXPECT_EQ(std::get<RequestError>(parsed), RequestError::Malformed);
+}
+
+TEST(DownloadParseRequestTest, ReportsAnInvalidResourceIdDistinctlyFromAMalformedBody)
+{
+    const auto parsed = parseRequest(R"({"resource_type":"config","resource_id":"../../etc/shadow"})");
+
+    ASSERT_TRUE(std::holds_alternative<RequestError>(parsed));
+    EXPECT_EQ(std::get<RequestError>(parsed), RequestError::InvalidResourceId);
+}
+
+// ---------------------------------------------------------------------------
+// Resource-id grammars
+// ---------------------------------------------------------------------------
+
+TEST(DownloadGroupNameTest, AcceptsWazuhsGroupGrammar)
+{
+    EXPECT_TRUE(isValidGroupName("default"));
+    EXPECT_TRUE(isValidGroupName("web-servers"));
+    EXPECT_TRUE(isValidGroupName("centos_8.1"));
+    EXPECT_TRUE(isValidGroupName("a:b;c=d+e!f@g(h)"));
+    EXPECT_TRUE(isValidGroupName(std::string(255, 'g')));
+}
+
+TEST(DownloadGroupNameTest, RejectsPathAndSeparatorCharacters)
+{
+    EXPECT_FALSE(isValidGroupName(""));
+    EXPECT_FALSE(isValidGroupName("."));
+    EXPECT_FALSE(isValidGroupName(".."));
+    EXPECT_FALSE(isValidGroupName("../../etc/shadow"));
+    EXPECT_FALSE(isValidGroupName("a/b"));
+    EXPECT_FALSE(isValidGroupName("a\\b"));
+    EXPECT_FALSE(isValidGroupName(std::string("a\0b", 3)));
+    EXPECT_FALSE(isValidGroupName("%2e%2e%2f"));
+    EXPECT_FALSE(isValidGroupName("caf\xc3\xa9"));
+    EXPECT_FALSE(isValidGroupName(std::string(256, 'g')));
+}
+
+TEST(DownloadGroupNameTest, RejectsACommaAsASingleGroupName)
+{
+    // A single group name never contains a comma; the CSV form is a selector, checked separately.
+    EXPECT_FALSE(isValidGroupName("default,web-servers"));
+}
+
+TEST(DownloadGroupSelectorTest, AcceptsOneGroupOrAMultigroupCsv)
+{
+    EXPECT_TRUE(isValidGroupSelector("web-servers"));
+    EXPECT_TRUE(isValidGroupSelector("web-servers,databases"));
+    EXPECT_TRUE(isValidGroupSelector("a,b,c,d"));
+}
+
+TEST(DownloadGroupSelectorTest, RejectsMalformedSeparatorUse)
+{
+    // Each entry must be a valid group name, which rules these out without special cases.
+    EXPECT_FALSE(isValidGroupSelector(""));
+    EXPECT_FALSE(isValidGroupSelector(","));
+    EXPECT_FALSE(isValidGroupSelector(",web-servers"));   // leading
+    EXPECT_FALSE(isValidGroupSelector("web-servers,"));   // trailing
+    EXPECT_FALSE(isValidGroupSelector("web,,servers"));   // doubled
+}
+
+TEST(DownloadGroupSelectorTest, RejectsATraversableEntryAnywhereInTheSelector)
+{
+    EXPECT_FALSE(isValidGroupSelector("web-servers,.."));
+    EXPECT_FALSE(isValidGroupSelector("..,web-servers"));
+    EXPECT_FALSE(isValidGroupSelector("web-servers,a/b"));
+    EXPECT_FALSE(isValidGroupSelector("a,."));
+}
+
+TEST(DownloadWpkNameTest, AcceptsRealisticPackageNames)
+{
+    EXPECT_TRUE(isValidWpkFilename("wazuh_agent_v5.0.1_linux_x86_64.wpk"));
+    EXPECT_TRUE(isValidWpkFilename("a.wpk"));
+}
+
+TEST(DownloadWpkNameTest, RequiresTheWpkExtension)
+{
+    EXPECT_FALSE(isValidWpkFilename("wazuh_agent_v5.0.1"));
+    EXPECT_FALSE(isValidWpkFilename("passwd"));
+    EXPECT_FALSE(isValidWpkFilename(".wpk")); // leading dot, even with the right extension
+    EXPECT_FALSE(isValidWpkFilename("wpk"));
+    EXPECT_FALSE(isValidWpkFilename(""));
+}
+
+TEST(DownloadWpkNameTest, RejectsAnythingThatCouldLeaveTheUpgradeDirectory)
+{
+    EXPECT_FALSE(isValidWpkFilename("../../../etc/shadow.wpk"));
+    EXPECT_FALSE(isValidWpkFilename("sub/dir.wpk"));
+    EXPECT_FALSE(isValidWpkFilename("..wpk"));   // starts with a dot
+    EXPECT_FALSE(isValidWpkFilename("./a.wpk")); // starts with a dot
+    EXPECT_FALSE(isValidWpkFilename(std::string("a\0.wpk", 6)));
+    EXPECT_FALSE(isValidWpkFilename("a b.wpk"));
+    EXPECT_FALSE(isValidWpkFilename("a:b.wpk")); // allowed in a group name, not in a filename
+    EXPECT_FALSE(isValidWpkFilename(std::string(252, 'a') + ".wpk"));
+}
+
+// ---------------------------------------------------------------------------
+// Error mapping
+// ---------------------------------------------------------------------------
+
+TEST(DownloadErrorResponseTest, MapsRequestErrorsToDistinguishable400s)
+{
+    EXPECT_EQ(errorResponseFor(RequestError::Malformed).status, 400);
+    EXPECT_EQ(errorResponseFor(RequestError::UnknownResourceType).status, 400);
+    EXPECT_EQ(errorResponseFor(RequestError::InvalidResourceId).status, 400);
+    EXPECT_NE(errorResponseFor(RequestError::Malformed).body, errorResponseFor(RequestError::UnknownResourceType).body);
+}
+
+TEST(DownloadErrorResponseTest, MapsNotFoundAndInternalDistinctly)
+{
+    EXPECT_EQ(errorResponseFor(LocateError::NotFound).status, 404);
+    EXPECT_EQ(errorResponseFor(LocateError::Internal).status, 500);
+}
+
+// ---------------------------------------------------------------------------
+// locateResource
+// ---------------------------------------------------------------------------
+
+TEST(DownloadLocateTest, ConfigResolvesUnderTheSharedDirectoryUsingTheRequestedGroup)
+{
+    // resource_id names the group the agent asks for and the manager serves exactly that -- no
+    // group lookup, no membership check (protocol decision on #38022).
+    const auto result = locateResource(configRequest("web-servers"), {});
+
+    EXPECT_EQ(result.error, LocateError::None);
+    EXPECT_EQ(result.path, "/etc/shared/web-servers/merged.mg");
+}
+
+TEST(DownloadLocateTest, AnyRequestedGroupResolvesRegardlessOfTheAgent)
+{
+    // Documents the consequence of dropping the lookup: this layer cannot tell whose group it is,
+    // so it serves whichever the caller names.
+    for (const auto* group : {"web-servers", "databases", "default", "some-other-team"})
+    {
+        const auto result = locateResource(configRequest(group), {});
+        EXPECT_EQ(result.error, LocateError::None);
+        EXPECT_EQ(result.path, std::string {"/etc/shared/"} + group + "/merged.mg");
+    }
+}
+
+TEST(DownloadMultigroupDirNameTest, MatchesWhatWazuhDbComputesForTheSameSelector)
+{
+    // wazuh-db builds the directory with OS_SHA256_String_sized(csv, out, WDB_GROUP_HASH_SIZE),
+    // WDB_GROUP_HASH_SIZE == 8, i.e. the first FOUR digest bytes as eight lowercase hex characters.
+    // Pinned literals, confirmed against a live manager which created var/multigroups/97d66859 for
+    // "web-servers,databases" and /76ba5a3b for "alpha,beta".
+    EXPECT_EQ(multigroupDirName("web-servers,databases"), "97d66859");
+    EXPECT_EQ(multigroupDirName("alpha,beta"), "76ba5a3b");
+    EXPECT_EQ(multigroupDirName("default,web-servers"), "b9d4f263");
+}
+
+TEST(DownloadMultigroupDirNameTest, IsOrderSensitiveJustLikeWazuhDb)
+{
+    // The CSV is hashed verbatim, so a reordered selector names a different (non-existent)
+    // directory. Sorting here would point at a directory the manager never created.
+    EXPECT_NE(multigroupDirName("web-servers,databases"), multigroupDirName("databases,web-servers"));
+}
+
+TEST(DownloadLocateTest, AMultigroupSelectorResolvesUnderVarMultigroups)
+{
+    const auto result = locateResource(configRequest("web-servers,databases"), {});
+
+    EXPECT_EQ(result.error, LocateError::None);
+    EXPECT_EQ(result.path, "/var/multigroups/97d66859/merged.mg");
+}
+
+TEST(DownloadLocateTest, HonoursInjectedBaseDirectories)
+{
+    ResourcePaths paths;
+    paths.sharedDir = "/tmp/shared";
+    paths.multigroupsDir = "/tmp/multigroups";
+    paths.wpkDir = "/tmp/upgrade";
+
+    EXPECT_EQ(locateResource(configRequest("a"), paths).path, "/tmp/shared/a/merged.mg");
+    EXPECT_EQ(locateResource(configRequest("a,b"), paths).path,
+              "/tmp/multigroups/" + multigroupDirName("a,b") + "/merged.mg");
+    EXPECT_EQ(locateResource(DownloadRequest {ResourceType::Wpk, "p.wpk"}, paths).path, "/tmp/upgrade/p.wpk");
+}
+
+TEST(DownloadLocateTest, WpkResolvesUnderTheUpgradeDirectory)
+{
+    const auto result = locateResource(DownloadRequest {ResourceType::Wpk, "wazuh_agent_v5.0.1_linux_x86_64.wpk"}, {});
+
+    EXPECT_EQ(result.error, LocateError::None);
+    EXPECT_EQ(result.path, "/var/upgrade/wazuh_agent_v5.0.1_linux_x86_64.wpk");
+}
+
+TEST(DownloadLocateTest, HostileGroupNamesNeverReachLocateResource)
+{
+    // Config now joins agent input into a path, so the grammar is the containment boundary for
+    // both resource types. Anything traversable must be rejected during parsing.
+    for (const auto* hostile : {"../../etc", "..", ".", "a/b"})
+    {
+        const auto body = std::string {R"({"resource_type":"config","resource_id":")"} + hostile + R"("})";
+        ASSERT_TRUE(std::holds_alternative<RequestError>(parseRequest(body)))
+            << "accepted hostile group: " << hostile;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FileByteSource
+// ---------------------------------------------------------------------------
+
+TEST(DownloadFileByteSourceTest, ReadsAFileSmallerThanOneChunkByteExactly)
+{
+    TempDir dir;
+    const std::string contents = "merged config contents";
+    const auto path = dir.writeFile("merged.mg", contents);
+
+    auto source = openRegularFile(path);
+    ASSERT_TRUE(source.has_value());
+    EXPECT_EQ((*source)->size(), contents.size());
+    EXPECT_EQ(drain(**source, 64), contents);
+}
+
+TEST(DownloadFileByteSourceTest, ReassemblesAFileSpanningManyChunks)
+{
+    TempDir dir;
+    // Deliberately not a multiple of the chunk size: the final short read is the case most likely
+    // to be mishandled, and mistaking it for end-of-stream would silently truncate a transfer.
+    std::string contents;
+    contents.reserve(70000);
+    for (std::size_t i = 0; i < 70000; ++i)
+    {
+        contents.push_back(static_cast<char>('A' + (i % 26)));
+    }
+    const auto path = dir.writeFile("large.wpk", contents);
+
+    auto source = openRegularFile(path);
+    ASSERT_TRUE(source.has_value());
+    EXPECT_EQ(drain(**source, 64U * 1024U), contents);
+}
+
+TEST(DownloadFileByteSourceTest, ReadsAFileThatIsAnExactMultipleOfTheChunkSize)
+{
+    TempDir dir;
+    const std::string contents(4096, 'x');
+    const auto path = dir.writeFile("aligned.bin", contents);
+
+    auto source = openRegularFile(path);
+    ASSERT_TRUE(source.has_value());
+    EXPECT_EQ(drain(**source, 1024), contents);
+}
+
+TEST(DownloadFileByteSourceTest, AnEmptyFileIsImmediatelyEndOfStream)
+{
+    TempDir dir;
+    const auto path = dir.writeFile("empty.mg", "");
+
+    auto source = openRegularFile(path);
+    ASSERT_TRUE(source.has_value());
+    EXPECT_EQ((*source)->size(), 0U);
+    EXPECT_EQ(drain(**source, 1024), "");
+}
+
+TEST(DownloadFileByteSourceTest, AZeroCapacityReadIsNotMistakenForEndOfStream)
+{
+    TempDir dir;
+    const auto path = dir.writeFile("data.bin", "abc");
+
+    auto source = openRegularFile(path);
+    ASSERT_TRUE(source.has_value());
+
+    char buffer[4] {};
+    EXPECT_EQ((*source)->read(buffer, 0), 0U);
+    EXPECT_EQ(drain(**source, 16), "abc"); // nothing was consumed
+}
+
+TEST(DownloadFileByteSourceTest, OpeningAMissingFileReportsEnoent)
+{
+    TempDir dir;
+    errno = 0;
+    EXPECT_FALSE(openRegularFile(dir.path() + "/does-not-exist.mg").has_value());
+    EXPECT_EQ(errno, ENOENT);
+}
+
+TEST(DownloadFileByteSourceTest, ADirectoryIsRejectedAsNotARegularFile)
+{
+    // open(O_RDONLY) on a directory SUCCEEDS on Linux, so without the S_ISREG check this would be
+    // a 200 that streams nothing rather than a 404.
+    TempDir dir;
+    errno = 0;
+    EXPECT_FALSE(openRegularFile(dir.path()).has_value());
+    EXPECT_EQ(errno, EINVAL);
+}
+
+TEST(DownloadFileByteSourceTest, ASymlinkIsRefusedByONofollow)
+{
+    TempDir dir;
+    const auto target = dir.writeFile("real.wpk", "payload");
+    const auto link = dir.track("link.wpk");
+    ASSERT_EQ(::symlink(target.c_str(), link.c_str()), 0);
+
+    errno = 0;
+    EXPECT_FALSE(openRegularFile(link).has_value());
+    EXPECT_EQ(errno, ELOOP);
+}
+
+TEST(DownloadFileByteSourceTest, AReadErrorThrowsRatherThanEndingTheStream)
+{
+    // A mid-transfer read failure must never look like a clean end-of-stream: that would emit the
+    // terminating chunk and hand the agent a truncated file that appears complete. A write-only
+    // descriptor is a valid, owned fd whose read() fails with EBADF.
+    const int writeOnlyFd = ::open("/dev/null", O_WRONLY | O_CLOEXEC);
+    ASSERT_GE(writeOnlyFd, 0);
+
+    FileByteSource unreadable {writeOnlyFd, 0};
+    char buffer[16] {};
+    EXPECT_THROW(unreadable.read(buffer, sizeof(buffer)), std::system_error);
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+TEST(DownloadHandlerTest, AnswersFourHundredForAMalformedBody)
+{
+    const auto responder = runHandler("not json");
+
+    EXPECT_EQ(responder->status, 400);
+    EXPECT_FALSE(responder->streamed);
+}
+
+TEST(DownloadHandlerTest, AnswersFourHundredAndFourWhenTheGroupHasNoMergedFile)
+{
+    TempDir dir;
+    ResourcePaths paths;
+    paths.sharedDir = dir.path() + "/shared";
+
+    EXPECT_EQ(runHandler(VALID_CONFIG_BODY, paths)->status, 404);
+}
+
+TEST(DownloadHandlerTest, StreamsTheResolvedFileAsAnOctetStream)
+{
+    TempDir dir;
+    dir.makeDir("shared/web-servers");
+    const std::string contents = "#!/bin/sh\nmerged configuration\n";
+    dir.writeFile("shared/web-servers/merged.mg", contents);
+
+    ResourcePaths paths;
+    paths.sharedDir = dir.path() + "/shared";
+
+    const auto responder = runHandler(VALID_CONFIG_BODY, paths);
+
+    EXPECT_TRUE(responder->streamed);
+    EXPECT_EQ(responder->status, 200);
+    EXPECT_EQ(responder->body, contents);
+    ASSERT_EQ(responder->headers.size(), 1U);
+    EXPECT_EQ(responder->headers.front().first, "Content-Type");
+    EXPECT_EQ(responder->headers.front().second, "application/octet-stream");
+}
+
+TEST(DownloadHandlerTest, StreamsTheEffectiveConfigForAMultigroupSelector)
+{
+    // End to end: a CSV selector must reach the var/multigroups file, not a member group's.
+    TempDir dir;
+    const std::string selector = "web-servers,databases";
+    dir.makeDir("shared/web-servers");
+    dir.writeFile("shared/web-servers/merged.mg", "SINGLE GROUP - must not be served");
+    dir.makeDir("multigroups/" + multigroupDirName(selector));
+    dir.writeFile("multigroups/" + multigroupDirName(selector) + "/merged.mg", "EFFECTIVE MULTIGROUP CONFIG");
+
+    ResourcePaths paths;
+    paths.sharedDir = dir.path() + "/shared";
+    paths.multigroupsDir = dir.path() + "/multigroups";
+
+    const auto responder =
+        runHandler(R"({"resource_type":"config","resource_id":"web-servers,databases"})", paths);
+
+    EXPECT_EQ(responder->status, 200);
+    EXPECT_TRUE(responder->streamed);
+    EXPECT_EQ(responder->body, "EFFECTIVE MULTIGROUP CONFIG");
+}
+
+TEST(DownloadHandlerTest, StreamsTheGroupTheAgentNamed)
+{
+    TempDir dir;
+    dir.makeDir("shared/web-servers");
+    dir.makeDir("shared/databases");
+    dir.writeFile("shared/web-servers/merged.mg", "WEB SERVERS CONFIG");
+    dir.writeFile("shared/databases/merged.mg", "DATABASES CONFIG");
+
+    ResourcePaths paths;
+    paths.sharedDir = dir.path() + "/shared";
+
+    EXPECT_EQ(runHandler(VALID_CONFIG_BODY, paths)->body, "WEB SERVERS CONFIG");
+    EXPECT_EQ(runHandler(R"({"resource_type":"config","resource_id":"databases"})", paths)->body,
+              "DATABASES CONFIG");
+}
+
+TEST(DownloadHandlerTest, StreamsAStagedWpk)
+{
+    TempDir dir;
+    dir.makeDir("upgrade");
+    const std::string contents(200000, '\x7f'); // spans several chunks
+    dir.writeFile("upgrade/pkg.wpk", contents);
+
+    ResourcePaths paths;
+    paths.wpkDir = dir.path() + "/upgrade";
+
+    const auto responder =
+        runHandler(R"({"resource_type":"wpk","resource_id":"pkg.wpk"})", paths);
+
+    EXPECT_EQ(responder->status, 200);
+    EXPECT_TRUE(responder->streamed);
+    EXPECT_EQ(responder->body, contents);
+}
+
+TEST(DownloadHandlerTest, AnswersFourHundredAndFourWhenTheResolvedFileIsMissing)
+{
+    // Discovered before any byte is written, which is what makes a clean 404 possible at all.
+    TempDir dir;
+    ResourcePaths paths;
+    paths.sharedDir = dir.path() + "/shared";
+
+    const auto responder = runHandler(VALID_CONFIG_BODY, paths);
+
+    EXPECT_EQ(responder->status, 404);
+    EXPECT_FALSE(responder->streamed);
+}

--- a/src/remoted/remoted_module/test/unit/downloadEndpoint_test.cpp
+++ b/src/remoted/remoted_module/test/unit/downloadEndpoint_test.cpp
@@ -17,12 +17,15 @@
 #include <unistd.h>
 
 #include <cerrno>
+#include <chrono>
 #include <cstring>
 #include <fstream>
 #include <memory>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <system_error>
+#include <thread>
 #include <variant>
 #include <vector>
 
@@ -558,6 +561,129 @@ TEST(DownloadFileByteSourceTest, AZeroCapacityReadIsNotMistakenForEndOfStream)
     char buffer[4] {};
     EXPECT_EQ((*source)->read(buffer, 0), 0U);
     EXPECT_EQ(drain(**source, 16), "abc"); // nothing was consumed
+}
+
+// A merged.mg or a WPK can be rewritten IN PLACE while it is being served: c_group() with the
+// default remoted.disk_storage=0 truncates merged.mg and rewrites it, and a WPK is fetched straight
+// to its final path. The descriptor then follows the new contents, and the failure that matters is
+// silent -- read() hits the new end-of-file, returns 0, and the transport emits the terminating
+// chunk, so the agent accepts a spliced file as COMPLETE. Each case below must throw instead, which
+// aborts the transfer without a terminator and makes the agent retry.
+
+TEST(DownloadFileByteSourceTest, TruncationMidTransferAbortsRatherThanLookingComplete)
+{
+    TempDir dir;
+    const std::string contents(8192, 'a');
+    const auto path = dir.writeFile("merged.mg", contents);
+
+    auto source = openRegularFile(path);
+    ASSERT_TRUE(source.has_value());
+
+    // Consume part of the file, then truncate it the way an in-place rewrite would.
+    std::vector<char> buffer(1024);
+    ASSERT_EQ((*source)->read(buffer.data(), buffer.size()), 1024U);
+    ASSERT_EQ(::truncate(path.c_str(), 2048), 0);
+
+    // Drains the remaining 1 KiB, then hits the new EOF, which must NOT look like a clean end.
+    EXPECT_THROW(
+        {
+            while ((*source)->read(buffer.data(), buffer.size()) > 0)
+            {
+            }
+        },
+        std::runtime_error);
+}
+
+TEST(DownloadFileByteSourceTest, AFileGrowingMidTransferAborts)
+{
+    TempDir dir;
+    // A WPK still being staged grows in place; the bytes already sent belong to a version that no
+    // longer exists, so continuing would splice two files together.
+    const std::string contents(4096, 'w');
+    const auto path = dir.writeFile("staging.wpk", contents);
+
+    auto source = openRegularFile(path);
+    ASSERT_TRUE(source.has_value());
+
+    std::vector<char> buffer(1024);
+    ASSERT_EQ((*source)->read(buffer.data(), buffer.size()), 1024U);
+
+    {
+        std::ofstream appending {path, std::ios::binary | std::ios::app};
+        appending << std::string(8192, 'W');
+    }
+
+    EXPECT_THROW(
+        {
+            while ((*source)->read(buffer.data(), buffer.size()) > 0)
+            {
+            }
+        },
+        std::runtime_error);
+}
+
+TEST(DownloadFileByteSourceTest, ARewriteKeepingTheSameLengthIsCaughtByMtime)
+{
+    TempDir dir;
+    // The byte-count check cannot see this one: same length, different contents. Only the mtime
+    // captured at open() distinguishes it.
+    const std::string contents(4096, 'o');
+    const auto path = dir.writeFile("merged.mg", contents);
+
+    auto source = openRegularFile(path);
+    ASSERT_TRUE(source.has_value());
+
+    std::vector<char> buffer(1024);
+    ASSERT_EQ((*source)->read(buffer.data(), buffer.size()), 1024U);
+
+    // Sleep so the rewrite lands in a distinguishable mtime even on a coarse-grained filesystem.
+    std::this_thread::sleep_for(std::chrono::milliseconds {20});
+    dir.writeFile("merged.mg", std::string(4096, 'n'));
+
+    EXPECT_THROW(
+        {
+            while ((*source)->read(buffer.data(), buffer.size()) > 0)
+            {
+            }
+        },
+        std::runtime_error);
+}
+
+TEST(DownloadFileByteSourceTest, ModificationAbortsOnTheNextChunkNotAtEndOfStream)
+{
+    TempDir dir;
+    // The point of checking per chunk: a writer landing early must not cost the whole file in
+    // reads and socket writes before the transfer is abandoned. Asserting that the very NEXT read
+    // throws is what distinguishes per-chunk detection from an end-of-stream-only check -- the
+    // latter would happily return ~1 MiB more before noticing.
+    const std::string contents(1024 * 1024, 'a');
+    const auto path = dir.writeFile("big.wpk", contents);
+
+    auto source = openRegularFile(path);
+    ASSERT_TRUE(source.has_value());
+
+    std::vector<char> buffer(4096);
+    ASSERT_EQ((*source)->read(buffer.data(), buffer.size()), 4096U);
+
+    // Same length, so only the mtime baseline can see it. Sleep so the rewrite lands in a
+    // distinguishable mtime even on a coarse-grained filesystem.
+    std::this_thread::sleep_for(std::chrono::milliseconds {20});
+    dir.writeFile("big.wpk", std::string(1024 * 1024, 'b'));
+
+    EXPECT_THROW((*source)->read(buffer.data(), buffer.size()), std::runtime_error);
+}
+
+TEST(DownloadFileByteSourceTest, AnUntouchedFileStreamsToCompletion)
+{
+    TempDir dir;
+    // The counterpart to the three above: the detection must not fire on a normal transfer, or
+    // every download would abort.
+    const std::string contents(8192, 'k');
+    const auto path = dir.writeFile("quiet.mg", contents);
+
+    auto source = openRegularFile(path);
+    ASSERT_TRUE(source.has_value());
+    EXPECT_NO_THROW({ EXPECT_EQ(drain(**source, 1024), contents); });
 }
 
 TEST(DownloadFileByteSourceTest, OpeningAMissingFileReportsEnoent)

--- a/src/remoted/remoted_module/test/unit/httpServer_test.cpp
+++ b/src/remoted/remoted_module/test/unit/httpServer_test.cpp
@@ -19,9 +19,15 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 
+#include "testTlsServer.hpp"
+
 #include <gtest/gtest.h>
 
 #include <cstring>
+#include <chrono>
+#include <cctype>
+#include <atomic>
+#include <algorithm>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -137,6 +143,7 @@ TEST(HttpServerConfigTest, DefaultsWhenEmpty)
     EXPECT_EQ(config.maxPipelinedRequests, 4U);
     EXPECT_EQ(config.concurrentAccepts, 2U);
     EXPECT_EQ(config.bufferSize, 8192U);
+    EXPECT_EQ(config.streamChunkSize, 64U * 1024U);
     EXPECT_EQ(config.maxInFlightBytes, 256U * 1024U * 1024U);
     EXPECT_EQ(config.maxParallelConnections, 512U);
     EXPECT_EQ(config.certificatePath, "etc/https-manager.cert");
@@ -193,6 +200,7 @@ TEST(HttpServerConfigTest, StructValuesWin)
     raw.http_max_pipelined_requests = 8;
     raw.http_concurrent_accepts = 4;
     raw.http_buffer_size = 16384;
+    raw.http_stream_chunk_size = 262144;
     raw.verification_mode = REMOTED_MODULE_HTTPS_VERIFY_CERTIFICATE;
     std::snprintf(raw.certificate_path, sizeof(raw.certificate_path), "/custom/cert.pem");
     std::snprintf(raw.private_key_path, sizeof(raw.private_key_path), "/custom/key.pem");
@@ -216,6 +224,7 @@ TEST(HttpServerConfigTest, StructValuesWin)
     EXPECT_EQ(config.maxPipelinedRequests, 8U);
     EXPECT_EQ(config.concurrentAccepts, 4U);
     EXPECT_EQ(config.bufferSize, 16384U);
+    EXPECT_EQ(config.streamChunkSize, 262144U);
     EXPECT_EQ(config.certificatePath, "/custom/cert.pem");
     EXPECT_EQ(config.privateKeyPath, "/custom/key.pem");
     EXPECT_EQ(config.bindAddress, "0.0.0.0");
@@ -531,4 +540,413 @@ TEST(HttpResponderContractTest, SecondSendIsIgnored)
 
     ASSERT_TRUE(responder->captured.has_value());
     EXPECT_EQ(responder->captured->body, "first");
+}
+
+// ---------------------------------------------------------------------------
+// Streamed responses over a REAL TLS server
+//
+// StreamPump and RestinioStreamableResponder live in RestinioHttpServer.cpp's anonymous namespace,
+// so the only way to exercise them is through an actual server on a socket. These cover the three
+// things the manual tooling used to be the only evidence for: the chunked framing, the configured
+// chunk size actually reaching the pump, and an aborted transfer not emitting a terminator.
+// ---------------------------------------------------------------------------
+
+namespace
+{
+    /// Serves a fixed buffer, one read at a time. Records when it is destroyed so a test can prove
+    /// an aborted transfer still releases the source (and with it, a real endpoint's file handle).
+    class BufferByteSource final : public IByteSource
+    {
+    public:
+        BufferByteSource(std::string payload, std::shared_ptr<std::atomic_bool> destroyed = nullptr)
+            : m_payload {std::move(payload)}
+            , m_destroyed {std::move(destroyed)}
+        {
+        }
+
+        ~BufferByteSource() override
+        {
+            if (m_destroyed)
+            {
+                m_destroyed->store(true);
+            }
+        }
+
+        std::size_t read(char* buffer, std::size_t capacity) override
+        {
+            const auto remaining = m_payload.size() - m_offset;
+            const auto count = std::min(capacity, remaining);
+            std::memcpy(buffer, m_payload.data() + m_offset, count);
+            m_offset += count;
+            return count;
+        }
+
+    private:
+        std::string m_payload;
+        std::shared_ptr<std::atomic_bool> m_destroyed;
+        std::size_t m_offset {0};
+    };
+
+    std::string patternPayload(std::size_t size)
+    {
+        std::string payload;
+        payload.reserve(size);
+        for (std::size_t i = 0; i < size; ++i)
+        {
+            payload.push_back(static_cast<char>('A' + (i % 26)));
+        }
+        return payload;
+    }
+
+    /// A server wired the way the facade wires a streaming route, on a free-ish port.
+    struct StreamingFixture
+    {
+        std::unique_ptr<IHttpServer> server;
+        HttpServerConfig config;
+    };
+
+    bool headerPresent(const std::string& head, const std::string& needle)
+    {
+        std::string lowered;
+        lowered.resize(head.size());
+        std::transform(head.begin(), head.end(), lowered.begin(), [](unsigned char c) { return std::tolower(c); });
+        std::string target = needle;
+        std::transform(target.begin(), target.end(), target.begin(), [](unsigned char c) { return std::tolower(c); });
+        return lowered.find(target) != std::string::npos;
+    }
+} // namespace
+
+TEST(HttpServerStreamingTest, StreamsAMultiChunkBodyByteExactly)
+{
+    auto certOpt = remoted::test::generateTestCertificate("rmt_stream_happy");
+    if (!certOpt)
+    {
+        GTEST_SKIP() << "openssl not available to generate a test certificate";
+    }
+    remoted::test::ScratchFileCleanup cleanup {{certOpt->certPath, certOpt->keyPath}};
+
+    // Deliberately not a multiple of the chunk size: the final short chunk is the case most likely
+    // to be mishandled.
+    const std::string payload = patternPayload(70000);
+
+    auto server = makeHttpServer();
+    server->addRoute(
+        Method::Post,
+        "/stream",
+        [&payload](std::shared_ptr<const HttpRequest>, std::shared_ptr<IHttpResponder> responder)
+        {
+            StreamResponse response;
+            response.headers.emplace_back("Content-Type", "application/octet-stream");
+            response.source = std::make_shared<BufferByteSource>(payload);
+            responder->stream(std::move(response));
+        },
+        /*countAgainstBudget=*/true,
+        ResponseMode::Streamable);
+
+    HttpServerConfig config;
+    config.port = static_cast<std::uint16_t>(21000 + (::getpid() % 5000));
+    config.certificatePath = certOpt->certPath;
+    config.privateKeyPath = certOpt->keyPath;
+    server->start(config);
+
+    const auto raw = remoted::test::sendSignedRequest(config.port, remoted::test::testAgentKey(), "/stream", "{}");
+    server->stop();
+
+    ASSERT_FALSE(raw.empty()) << "no response from the streaming server";
+    const auto [head, body] = remoted::test::splitResponse(raw);
+
+    EXPECT_TRUE(headerPresent(head, "transfer-encoding: chunked")) << head;
+    // Chunked and Content-Length are mutually exclusive; a Content-Length here would mean the body
+    // was buffered after all.
+    EXPECT_FALSE(headerPresent(head, "content-length:")) << head;
+
+    std::vector<std::size_t> sizes;
+    bool complete = false;
+    const auto decoded = remoted::test::decodeChunked(body, sizes, complete);
+
+    EXPECT_TRUE(complete) << "the terminating 0-length chunk is missing";
+    EXPECT_EQ(decoded.size(), payload.size());
+    EXPECT_EQ(decoded, payload);
+    EXPECT_GT(sizes.size(), 1U) << "expected the body to span several chunks";
+}
+
+TEST(HttpServerStreamingTest, ChunkSizeFollowsTheConfiguredValue)
+{
+    // The knob is remoted.http_stream_chunk_size -> HttpServerConfig::streamChunkSize. Asserting on
+    // the chunk sizes ON THE WIRE is what proves it reaches the pump; a decoded-body comparison
+    // would pass even if the value were ignored.
+    auto certOpt = remoted::test::generateTestCertificate("rmt_stream_size");
+    if (!certOpt)
+    {
+        GTEST_SKIP() << "openssl not available to generate a test certificate";
+    }
+    remoted::test::ScratchFileCleanup cleanup {{certOpt->certPath, certOpt->keyPath}};
+
+    constexpr std::size_t kChunk = 8192;
+    const std::string payload = patternPayload(kChunk * 3 + 100); // 3 full chunks + a short one
+
+    auto server = makeHttpServer();
+    server->addRoute(
+        Method::Post,
+        "/stream",
+        [&payload](std::shared_ptr<const HttpRequest>, std::shared_ptr<IHttpResponder> responder)
+        {
+            StreamResponse response;
+            response.source = std::make_shared<BufferByteSource>(payload);
+            // chunkSize left at 0 on purpose: the server's configured value must be applied.
+            responder->stream(std::move(response));
+        },
+        /*countAgainstBudget=*/true,
+        ResponseMode::Streamable);
+
+    HttpServerConfig config;
+    config.port = static_cast<std::uint16_t>(22000 + (::getpid() % 5000));
+    config.certificatePath = certOpt->certPath;
+    config.privateKeyPath = certOpt->keyPath;
+    config.streamChunkSize = kChunk;
+    server->start(config);
+
+    const auto raw = remoted::test::sendSignedRequest(config.port, remoted::test::testAgentKey(), "/stream", "{}");
+    server->stop();
+
+    ASSERT_FALSE(raw.empty());
+    const auto [head, body] = remoted::test::splitResponse(raw);
+    (void)head;
+
+    std::vector<std::size_t> sizes;
+    bool complete = false;
+    const auto decoded = remoted::test::decodeChunked(body, sizes, complete);
+
+    EXPECT_TRUE(complete);
+    EXPECT_EQ(decoded, payload);
+    ASSERT_GE(sizes.size(), 4U);
+    // Every chunk but the last carries exactly the configured size.
+    for (std::size_t i = 0; i + 1 < sizes.size(); ++i)
+    {
+        EXPECT_EQ(sizes[i], kChunk) << "chunk " << i << " did not use the configured size";
+    }
+    EXPECT_EQ(sizes.back(), 100U);
+}
+
+TEST(HttpServerStreamingTest, AbortedTransferSendsNoTerminatorAndReleasesTheSource)
+{
+    // An agent that walks away mid-transfer must NOT receive a terminating 0-length chunk: that
+    // would mark a truncated body as complete. The source must still be released, which is what
+    // frees a real endpoint's file descriptor.
+    auto certOpt = remoted::test::generateTestCertificate("rmt_stream_abort");
+    if (!certOpt)
+    {
+        GTEST_SKIP() << "openssl not available to generate a test certificate";
+    }
+    remoted::test::ScratchFileCleanup cleanup {{certOpt->certPath, certOpt->keyPath}};
+
+    // Large enough that the client can close long before the server finishes writing.
+    const std::string payload = patternPayload(16 * 1024 * 1024);
+    auto destroyed = std::make_shared<std::atomic_bool>(false);
+
+    auto server = makeHttpServer();
+    server->addRoute(
+        Method::Post,
+        "/stream",
+        [&payload, destroyed](std::shared_ptr<const HttpRequest>, std::shared_ptr<IHttpResponder> responder)
+        {
+            StreamResponse response;
+            response.source = std::make_shared<BufferByteSource>(payload, destroyed);
+            responder->stream(std::move(response));
+        },
+        /*countAgainstBudget=*/true,
+        ResponseMode::Streamable);
+
+    HttpServerConfig config;
+    config.port = static_cast<std::uint16_t>(23000 + (::getpid() % 5000));
+    config.certificatePath = certOpt->certPath;
+    config.privateKeyPath = certOpt->keyPath;
+    server->start(config);
+
+    // Read only the first 64 KiB, then drop the connection.
+    const auto raw =
+        remoted::test::sendSignedRequest(config.port, remoted::test::testAgentKey(), "/stream", "{}", 64 * 1024);
+
+    ASSERT_FALSE(raw.empty());
+    const auto [head, body] = remoted::test::splitResponse(raw);
+    EXPECT_TRUE(headerPresent(head, "transfer-encoding: chunked")) << head;
+
+    std::vector<std::size_t> sizes;
+    bool complete = false;
+    remoted::test::decodeChunked(body, sizes, complete);
+    EXPECT_FALSE(complete) << "an aborted transfer must not carry the terminating 0-length chunk";
+
+    // The pump notices the failed write and drops the source. Give it a moment: the abort is
+    // observed on the connection's strand, not on this thread.
+    for (int i = 0; i < 100 && !destroyed->load(); ++i)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds {20});
+    }
+    EXPECT_TRUE(destroyed->load()) << "the byte source outlived an aborted transfer (descriptor leak)";
+
+    // The server must still be healthy for the next request.
+    const auto second = remoted::test::sendSignedRequest(config.port, remoted::test::testAgentKey(), "/stream", "{}",
+                                                         16 * 1024);
+    EXPECT_FALSE(second.empty()) << "the server stopped serving after an aborted transfer";
+
+    server->stop();
+}
+
+namespace
+{
+    /// Yields a fixed payload but sleeps before each chunk, so a transfer takes a controllable
+    /// amount of wall-clock time regardless of how fast the link is.
+    class SlowByteSource final : public IByteSource
+    {
+    public:
+        SlowByteSource(std::string payload, std::chrono::milliseconds perChunk)
+            : m_payload {std::move(payload)}
+            , m_perChunk {perChunk}
+        {
+        }
+
+        std::size_t read(char* buffer, std::size_t capacity) override
+        {
+            const auto remaining = m_payload.size() - m_offset;
+            if (remaining == 0)
+            {
+                return 0;
+            }
+            std::this_thread::sleep_for(m_perChunk);
+            const auto count = std::min(capacity, remaining);
+            std::memcpy(buffer, m_payload.data() + m_offset, count);
+            m_offset += count;
+            return count;
+        }
+
+    private:
+        std::string m_payload;
+        std::chrono::milliseconds m_perChunk;
+        std::size_t m_offset {0};
+    };
+} // namespace
+
+TEST(HttpServerStreamingTest, HealthyTransferOutlastingTheRequestTimeoutIsNotCut)
+{
+    // http_request_timeout bounds a request end to end and defaults to 30 s, while a real 100 MB
+    // WPK over a 1 MiB/s WAN link takes ~2 minutes. All the throughput evidence so far is loopback
+    // at hundreds of MiB/s, which never approaches that timer -- so this drives a transfer that
+    // deliberately outlasts it (scaled down: a 1 s cap against a ~2.5 s transfer) and asserts it
+    // still completes. The timer must rearm between chunks rather than bound the whole response.
+    auto certOpt = remoted::test::generateTestCertificate("rmt_stream_slow");
+    if (!certOpt)
+    {
+        GTEST_SKIP() << "openssl not available to generate a test certificate";
+    }
+    remoted::test::ScratchFileCleanup cleanup {{certOpt->certPath, certOpt->keyPath}};
+
+    constexpr std::size_t kChunk = 4096;
+    const std::string payload = patternPayload(kChunk * 10); // 10 chunks
+    const auto perChunk = std::chrono::milliseconds {250};   // ~2.5 s total
+
+    auto server = makeHttpServer();
+    server->addRoute(
+        Method::Post,
+        "/slow",
+        [&payload, perChunk](std::shared_ptr<const HttpRequest>, std::shared_ptr<IHttpResponder> responder)
+        {
+            StreamResponse response;
+            response.source = std::make_shared<SlowByteSource>(payload, perChunk);
+            responder->stream(std::move(response));
+        },
+        /*countAgainstBudget=*/true,
+        ResponseMode::Streamable);
+
+    HttpServerConfig config;
+    config.port = static_cast<std::uint16_t>(25000 + (::getpid() % 5000));
+    config.certificatePath = certOpt->certPath;
+    config.privateKeyPath = certOpt->keyPath;
+    config.streamChunkSize = kChunk;
+    config.requestTimeoutSec = 1; // deliberately shorter than the transfer
+    config.writeTimeoutSec = 1;
+    server->start(config);
+
+    const auto started = std::chrono::steady_clock::now();
+    const auto raw = remoted::test::sendSignedRequest(config.port, remoted::test::testAgentKey(), "/slow", "{}");
+    const auto elapsed = std::chrono::steady_clock::now() - started;
+    server->stop();
+
+    ASSERT_FALSE(raw.empty());
+    const auto parts = remoted::test::splitResponse(raw);
+
+    std::vector<std::size_t> sizes;
+    bool complete = false;
+    const auto decoded = remoted::test::decodeChunked(parts.second, sizes, complete);
+
+    EXPECT_GT(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count(), 1000)
+        << "the transfer finished too fast to have outlasted the request timeout";
+    EXPECT_TRUE(complete) << "a healthy but slow transfer was cut short";
+    EXPECT_EQ(decoded, payload);
+}
+
+TEST(HttpServerStreamingTest, TrickleReaderKeepsTheTransferAliveBeyondTheWriteTimeout)
+{
+    // Documents the exposure raised in review: with chunked output every flush is its own write
+    // group, so http_write_timeout rearms PER CHUNK. It kills a client that stops reading entirely
+    // (covered by the abort test), but a client that keeps reading a trickle renews the timer
+    // indefinitely and can hold a stream open for as long as it likes.
+    //
+    // There is no per-stream concurrency limit today -- the only bound is maxParallelConnections --
+    // so this pins the CURRENT behaviour and will need revisiting if a stream limiter is added.
+    auto certOpt = remoted::test::generateTestCertificate("rmt_stream_trickle");
+    if (!certOpt)
+    {
+        GTEST_SKIP() << "openssl not available to generate a test certificate";
+    }
+    remoted::test::ScratchFileCleanup cleanup {{certOpt->certPath, certOpt->keyPath}};
+
+    constexpr std::size_t kChunk = 2048;
+    const std::string payload = patternPayload(kChunk * 8);
+
+    auto server = makeHttpServer();
+    server->addRoute(
+        Method::Post,
+        "/trickle",
+        [&payload](std::shared_ptr<const HttpRequest>, std::shared_ptr<IHttpResponder> responder)
+        {
+            StreamResponse response;
+            response.source = std::make_shared<BufferByteSource>(payload);
+            responder->stream(std::move(response));
+        },
+        /*countAgainstBudget=*/true,
+        ResponseMode::Streamable);
+
+    HttpServerConfig config;
+    config.port = static_cast<std::uint16_t>(26000 + (::getpid() % 5000));
+    config.certificatePath = certOpt->certPath;
+    config.privateKeyPath = certOpt->keyPath;
+    config.streamChunkSize = kChunk;
+    config.writeTimeoutSec = 1;   // one second per write group...
+    config.requestTimeoutSec = 1; // ...and per gap between them
+    server->start(config);
+
+    // 512 bytes every 150 ms: several seconds in total, many times the 1 s timers, but no single
+    // gap ever exceeds them.
+    const auto started = std::chrono::steady_clock::now();
+    const auto raw = remoted::test::sendSignedRequestTrickle(config.port,
+                                                             remoted::test::testAgentKey(),
+                                                             "/trickle",
+                                                             "{}",
+                                                             512,
+                                                             std::chrono::milliseconds {150},
+                                                             std::chrono::seconds {30});
+    const auto elapsed = std::chrono::steady_clock::now() - started;
+    server->stop();
+
+    ASSERT_FALSE(raw.empty());
+    const auto parts = remoted::test::splitResponse(raw);
+
+    std::vector<std::size_t> sizes;
+    bool complete = false;
+    const auto decoded = remoted::test::decodeChunked(parts.second, sizes, complete);
+
+    EXPECT_GT(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count(), 2000)
+        << "the trickle was not slow enough to outlast the configured timers";
+    EXPECT_TRUE(complete) << "a trickling reader was cut off; the per-write timer did not rearm";
+    EXPECT_EQ(decoded, payload);
 }

--- a/src/remoted/remoted_module/test/unit/httpServer_test.cpp
+++ b/src/remoted/remoted_module/test/unit/httpServer_test.cpp
@@ -784,10 +784,18 @@ TEST(HttpServerStreamingTest, AbortedTransferSendsNoTerminatorAndReleasesTheSour
     }
     EXPECT_TRUE(destroyed->load()) << "the byte source outlived an aborted transfer (descriptor leak)";
 
-    // The server must still be healthy for the next request.
-    const auto second = remoted::test::sendSignedRequest(config.port, remoted::test::testAgentKey(), "/stream", "{}",
-                                                         16 * 1024);
-    EXPECT_FALSE(second.empty()) << "the server stopped serving after an aborted transfer";
+    // The server must still be healthy for the next request. Read this one to COMPLETION rather
+    // than aborting again: a second abort would leave its pump in flight at stop() below, and
+    // "serves a whole response" is the stronger health check anyway.
+    const auto second = remoted::test::sendSignedRequest(config.port, remoted::test::testAgentKey(), "/stream", "{}");
+    ASSERT_FALSE(second.empty()) << "the server stopped serving after an aborted transfer";
+
+    const auto [secondHead, secondBody] = remoted::test::splitResponse(second);
+    std::vector<std::size_t> secondSizes;
+    bool secondComplete = false;
+    const auto decoded = remoted::test::decodeChunked(secondBody, secondSizes, secondComplete);
+    EXPECT_TRUE(secondComplete) << "the transfer after an aborted one was itself truncated";
+    EXPECT_EQ(decoded, payload) << "the transfer after an aborted one did not deliver the payload";
 
     server->stop();
 }

--- a/src/remoted/remoted_module/test/unit/shutdownRace_test.cpp
+++ b/src/remoted/remoted_module/test/unit/shutdownRace_test.cpp
@@ -29,6 +29,8 @@
 #include "http_server/IHttpServer.hpp"
 #include "http_server/httpServerFactory.hpp"
 
+#include "testTlsServer.hpp"
+
 #include <gtest/gtest.h>
 
 #include <asio/connect.hpp>
@@ -41,6 +43,8 @@
 
 #include <array>
 #include <chrono>
+#include <cstring>
+#include <atomic>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -347,4 +351,115 @@ TEST(ShutdownRace, StopSequenceSurvivesAnInFlightForward)
     }
 
     SUCCEED();
+}
+
+// A streamed response is the one path that bounces worker-pool <-> connection-strand OUTSIDE the
+// DeferredForwarder that the four-phase shutdown drains. stopAccepting() drains the handler pool,
+// but a StreamPump that has already handed a chunk to the strand has its continuation queued
+// somewhere neither phase 1 nor phase 3 knows about -- so teardown with a live transfer is exactly
+// the use-after-free shape this file exists to catch. Until now it was only argued for in a comment
+// ("RESTinio guarantees the write callback always fires"), never executed under ASan.
+namespace
+{
+    /// Never-ending source: guarantees the transfer is still mid-flight when shutdown begins.
+    ///
+    /// Progress and destruction are reported through SHARED counters rather than by the test
+    /// holding the source: the pump must be its only owner, or "was it released?" would really be
+    /// measuring the test's own reference.
+    class EndlessByteSource final : public IByteSource
+    {
+    public:
+        EndlessByteSource(std::shared_ptr<std::atomic_int> reads, std::shared_ptr<std::atomic_bool> destroyed)
+            : m_reads {std::move(reads)}
+            , m_destroyed {std::move(destroyed)}
+        {
+        }
+
+        ~EndlessByteSource() override
+        {
+            m_destroyed->store(true);
+        }
+
+        std::size_t read(char* buffer, std::size_t capacity) override
+        {
+            m_reads->fetch_add(1);
+            std::memset(buffer, 'Z', capacity);
+            return capacity; // never EOF
+        }
+
+    private:
+        std::shared_ptr<std::atomic_int> m_reads;
+        std::shared_ptr<std::atomic_bool> m_destroyed;
+    };
+} // namespace
+
+TEST(ShutdownRace, StopSequenceSurvivesAnInFlightStream)
+{
+    auto certOpt = remoted::test::generateTestCertificate("rmt_shutdown_stream");
+    if (!certOpt)
+    {
+        GTEST_SKIP() << "openssl not available to generate a test certificate";
+    }
+    remoted::test::ScratchFileCleanup certCleanup {{certOpt->certPath, certOpt->keyPath}};
+
+    auto destroyed = std::make_shared<std::atomic_bool>(false);
+    auto reads = std::make_shared<std::atomic_int>(0);
+
+    auto server = makeHttpServer();
+    AuthGateway gateway {remoted::auth::AuthConfig {}, std::make_shared<remoted::test::FakeKeystore>()};
+
+    gateway.addAuthenticatedRoute(
+        *server,
+        Method::Post,
+        "/stream",
+        [reads, destroyed](std::shared_ptr<const remoted::auth::AuthenticatedRequest>,
+                           std::shared_ptr<IHttpResponder> responder)
+        {
+            StreamResponse response;
+            // Built here and handed straight over, so the pump ends up the sole owner.
+            response.source = std::make_shared<EndlessByteSource>(reads, destroyed);
+            responder->stream(std::move(response));
+        },
+        remoted::http::ResponseMode::Streamable);
+
+    HttpServerConfig config;
+    config.port = static_cast<std::uint16_t>(24000 + (::getpid() % 5000));
+    config.certificatePath = certOpt->certPath;
+    config.privateKeyPath = certOpt->keyPath;
+    server->start(config);
+
+    // Read a little and then hold the connection open, so the pump keeps cycling
+    // pool -> strand -> pool while the teardown below runs.
+    std::thread clientThread(
+        [&]
+        {
+            remoted::test::sendSignedRequest(
+                config.port, remoted::test::testAgentKey(), "/stream", "{}", 256 * 1024);
+        });
+
+    // Wait until the pump has genuinely started cycling: that is the mid-flight window.
+    for (int i = 0; i < 200 && reads->load() < 2; ++i)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds {10});
+    }
+    ASSERT_GE(reads->load(), 2) << "the stream never started; the test would prove nothing";
+
+    // The exact facade sequence, run against a transfer that is still advancing.
+    server->stopAccepting();
+    server->stop();
+
+    if (clientThread.joinable())
+    {
+        clientThread.join();
+    }
+
+    // Success is the absence of a crash/hang under ASan. Additionally, releasing the server must
+    // release the source rather than strand it in a queued continuation -- the route table (and any
+    // handler-captured state) only goes away when the server object itself does.
+    server.reset();
+    for (int i = 0; i < 100 && !destroyed->load(); ++i)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds {20});
+    }
+    EXPECT_TRUE(destroyed->load()) << "the byte source outlived server teardown";
 }

--- a/src/remoted/remoted_module/test/unit/testTlsServer.hpp
+++ b/src/remoted/remoted_module/test/unit/testTlsServer.hpp
@@ -1,0 +1,352 @@
+/*
+ * Wazuh remoted module (C++ worker bridge)
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 3, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _REMOTED_TEST_TLS_SERVER_HPP
+#define _REMOTED_TEST_TLS_SERVER_HPP
+
+// Shared fixtures for the tests that drive a REAL RestinioHttpServer over TLS: a throwaway
+// certificate, a one-agent keystore, and a signed client that can read a response back (or
+// deliberately walk away mid-response).
+//
+// Extracted from shutdownRace_test.cpp so the streaming tests in httpServer_test.cpp can use the
+// same client rather than growing a second copy of the certificate/signing dance.
+
+#include "auth/cmac.hpp"
+#include "auth/iAgentKeystore.hpp"
+
+#include <asio/connect.hpp>
+#include <asio/io_context.hpp>
+#include <asio/ip/tcp.hpp>
+#include <asio/read.hpp>
+#include <asio/ssl.hpp>
+#include <asio/write.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
+#include <optional>
+#include <string>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+namespace remoted::test
+{
+
+    /// The single agent every TLS test authenticates as.
+    constexpr remoted::auth::AgentId kTestAgentId {7};
+
+    /// Its key, as the FakeKeystore below reports it.
+    inline std::vector<std::uint8_t> testAgentKey()
+    {
+        return std::vector<std::uint8_t>(16, 0x0B);
+    }
+
+    /// Keystore stub: one agent, numeric id 7.
+    class FakeKeystore final : public remoted::auth::IAgentKeystore
+    {
+    public:
+        std::optional<std::vector<std::uint8_t>> keyFor(remoted::auth::AgentId agentId) const override
+        {
+            if (agentId == kTestAgentId)
+            {
+                return testAgentKey();
+            }
+            return std::nullopt;
+        }
+    };
+
+    // Deliberately no destructor: this is returned by value, so a destructor that removed the files
+    // would delete them out from under the copy the caller keeps. File cleanup is a separate,
+    // never-returned RAII guard (ScratchFileCleanup) constructed in the test body.
+    struct TestCertificate
+    {
+        std::string certPath;
+        std::string keyPath;
+    };
+
+    /// @param prefix Distinguishes concurrent test binaries' scratch files.
+    inline std::optional<TestCertificate> generateTestCertificate(const std::string& prefix)
+    {
+        const auto pid = std::to_string(::getpid());
+        TestCertificate cert;
+        cert.certPath = "/tmp/" + prefix + "_" + pid + ".crt";
+        cert.keyPath = "/tmp/" + prefix + "_" + pid + ".key";
+        const std::string cmd = "openssl req -x509 -newkey rsa:2048 -nodes -days 1 -keyout " + cert.keyPath + " -out " +
+                                cert.certPath + " -subj /CN=localhost >/dev/null 2>&1";
+        if (std::system(cmd.c_str()) != 0)
+        {
+            return std::nullopt;
+        }
+        return cert;
+    }
+
+    /// Removes a fixed set of scratch files on scope exit. Never copied/moved/returned.
+    class ScratchFileCleanup final
+    {
+    public:
+        explicit ScratchFileCleanup(std::vector<std::string> paths)
+            : m_paths {std::move(paths)}
+        {
+        }
+        ScratchFileCleanup(const ScratchFileCleanup&) = delete;
+        ScratchFileCleanup& operator=(const ScratchFileCleanup&) = delete;
+        ~ScratchFileCleanup()
+        {
+            for (const auto& path : m_paths)
+            {
+                std::remove(path.c_str());
+            }
+        }
+
+    private:
+        std::vector<std::string> m_paths;
+    };
+
+    /// Builds the canonical AES-CMAC exactly as AuthMiddleware verifies it.
+    inline std::string canonicalMac(const std::vector<std::uint8_t>& key,
+                                    const std::string& protocolVersion,
+                                    const std::string& method,
+                                    const std::string& target,
+                                    const std::string& agentId,
+                                    std::int64_t ts,
+                                    const std::string& body)
+    {
+        remoted::auth::Cmac cmac(key);
+        cmac.update("WAZUH-REQUEST\n");
+        cmac.update(protocolVersion);
+        cmac.update("\n");
+        cmac.update(method);
+        cmac.update("\n");
+        cmac.update(target);
+        cmac.update("\n");
+        cmac.update(agentId);
+        cmac.update("\n");
+        cmac.update(std::to_string(ts));
+        cmac.update("\n");
+        cmac.update(body);
+        const auto mac = cmac.finalize();
+        return remoted::auth::toLowerHex(mac.data(), mac.size());
+    }
+
+    /// Builds the signed request bytes an agent would put on the wire.
+    inline std::string signedRequest(const std::vector<std::uint8_t>& key,
+                                     const std::string& target,
+                                     const std::string& body)
+    {
+        const auto ts = static_cast<std::int64_t>(std::time(nullptr));
+        const std::string mac = canonicalMac(key, "1", "POST", target, std::to_string(kTestAgentId), ts, body);
+
+        std::string request = "POST " + target + " HTTP/1.1\r\n";
+        request += "Host: 127.0.0.1\r\n";
+        request += "protocol-version: 1\r\n";
+        request += "Authorization: Wazuh " + std::to_string(kTestAgentId) + ":" + std::to_string(ts) + ":" + mac +
+                   "\r\n";
+        request += "Content-Length: " + std::to_string(body.size()) + "\r\n";
+        request += "Connection: close\r\n\r\n";
+        request += body;
+        return request;
+    }
+
+    /**
+     * @brief Sends one signed request and reads the response.
+     *
+     * @param readLimit 0 reads until the server closes (a whole response). A positive value stops
+     *                  after roughly that many bytes and CLOSES the connection -- which is how a
+     *                  test reproduces an agent walking away mid-transfer.
+     * @return Whatever was read; empty when the connection could not be established.
+     */
+    inline std::string sendSignedRequest(std::uint16_t port,
+                                         const std::vector<std::uint8_t>& key,
+                                         const std::string& target,
+                                         const std::string& body,
+                                         std::size_t readLimit = 0)
+    {
+        std::string received;
+        try
+        {
+            asio::io_context ioc;
+            asio::ssl::context sslContext {asio::ssl::context::tls_client};
+            sslContext.set_verify_mode(asio::ssl::verify_none);
+
+            asio::ssl::stream<asio::ip::tcp::socket> stream {ioc, sslContext};
+            asio::ip::tcp::resolver resolver {ioc};
+            const auto endpoints = resolver.resolve("127.0.0.1", std::to_string(port));
+            asio::connect(stream.next_layer(), endpoints);
+            stream.handshake(asio::ssl::stream_base::client);
+
+            asio::write(stream, asio::buffer(signedRequest(key, target, body)));
+
+            std::vector<char> buffer(64 * 1024);
+            while (readLimit == 0 || received.size() < readLimit)
+            {
+                asio::error_code ec;
+                const auto n = stream.read_some(asio::buffer(buffer), ec);
+                if (ec)
+                {
+                    break; // EOF, or the server tore the connection down.
+                }
+                received.append(buffer.data(), n);
+            }
+            // Falling out of scope closes the socket -- abrupt when readLimit cut us short.
+        }
+        catch (const std::exception&)
+        {
+            // Best-effort: what matters is what the SERVER does, not a clean client teardown.
+        }
+        return received;
+    }
+
+    /// Sends a signed request and returns immediately, without reading any reply.
+    inline void sendSignedRequestFireAndForget(std::uint16_t port,
+                                               const std::vector<std::uint8_t>& key,
+                                               const std::string& target,
+                                               const std::string& body)
+    {
+        try
+        {
+            asio::io_context ioc;
+            asio::ssl::context sslContext {asio::ssl::context::tls_client};
+            sslContext.set_verify_mode(asio::ssl::verify_none);
+
+            asio::ssl::stream<asio::ip::tcp::socket> stream {ioc, sslContext};
+            asio::ip::tcp::resolver resolver {ioc};
+            const auto endpoints = resolver.resolve("127.0.0.1", std::to_string(port));
+            asio::connect(stream.next_layer(), endpoints);
+            stream.handshake(asio::ssl::stream_base::client);
+            asio::write(stream, asio::buffer(signedRequest(key, target, body)));
+        }
+        catch (const std::exception&)
+        {
+        }
+    }
+
+    /**
+     * @brief Reads a response deliberately slowly: a trickle client.
+     *
+     * Each read is small and spaced by @p pause, which is what a real agent on a slow WAN link
+     * looks like. Used to show that a chunked transfer's per-write timeout rearms per chunk and so
+     * does not bound the total duration.
+     *
+     * @param maxWait Gives up after this long, so a hung server fails the test instead of hanging it.
+     */
+    inline std::string sendSignedRequestTrickle(std::uint16_t port,
+                                                const std::vector<std::uint8_t>& key,
+                                                const std::string& target,
+                                                const std::string& body,
+                                                std::size_t readChunk,
+                                                std::chrono::milliseconds pause,
+                                                std::chrono::milliseconds maxWait)
+    {
+        std::string received;
+        try
+        {
+            asio::io_context ioc;
+            asio::ssl::context sslContext {asio::ssl::context::tls_client};
+            sslContext.set_verify_mode(asio::ssl::verify_none);
+
+            asio::ssl::stream<asio::ip::tcp::socket> stream {ioc, sslContext};
+            asio::ip::tcp::resolver resolver {ioc};
+            const auto endpoints = resolver.resolve("127.0.0.1", std::to_string(port));
+            asio::connect(stream.next_layer(), endpoints);
+            stream.handshake(asio::ssl::stream_base::client);
+
+            asio::write(stream, asio::buffer(signedRequest(key, target, body)));
+
+            std::vector<char> buffer(readChunk);
+            const auto deadline = std::chrono::steady_clock::now() + maxWait;
+            while (std::chrono::steady_clock::now() < deadline)
+            {
+                asio::error_code ec;
+                const auto n = stream.read_some(asio::buffer(buffer), ec);
+                if (ec)
+                {
+                    break; // EOF (transfer finished) or the server cut us off.
+                }
+                received.append(buffer.data(), n);
+                std::this_thread::sleep_for(pause);
+            }
+        }
+        catch (const std::exception&)
+        {
+        }
+        return received;
+    }
+
+    /// Splits a raw HTTP response into its head and body. Returns {head, body}.
+    inline std::pair<std::string, std::string> splitResponse(const std::string& raw)
+    {
+        const auto separator = raw.find("\r\n\r\n");
+        if (separator == std::string::npos)
+        {
+            return {raw, {}};
+        }
+        return {raw.substr(0, separator), raw.substr(separator + 4)};
+    }
+
+    /**
+     * @brief Decodes a chunked body, also reporting the sizes seen.
+     *
+     * The sizes matter as much as the payload: they are what proves the configured chunk size
+     * actually reached the pump, which a decoded-body comparison alone would hide.
+     *
+     * @param complete Set false when no terminating 0-length chunk was found -- i.e. a truncated
+     *                 transfer, which is exactly what an aborted stream must look like.
+     */
+    inline std::string decodeChunked(const std::string& body, std::vector<std::size_t>& sizes, bool& complete)
+    {
+        std::string decoded;
+        complete = false;
+        std::size_t index = 0;
+
+        while (index < body.size())
+        {
+            const auto lineEnd = body.find("\r\n", index);
+            if (lineEnd == std::string::npos)
+            {
+                break; // Header cut mid-way: truncated.
+            }
+
+            std::size_t chunkSize = 0;
+            try
+            {
+                chunkSize = static_cast<std::size_t>(std::stoul(body.substr(index, lineEnd - index), nullptr, 16));
+            }
+            catch (const std::exception&)
+            {
+                break;
+            }
+
+            if (chunkSize == 0)
+            {
+                complete = true;
+                break;
+            }
+
+            const auto dataStart = lineEnd + 2;
+            if (dataStart + chunkSize > body.size())
+            {
+                break; // Payload cut mid-chunk: truncated.
+            }
+
+            decoded.append(body, dataStart, chunkSize);
+            sizes.push_back(chunkSize);
+            index = dataStart + chunkSize + 2; // skip the chunk's trailing CRLF
+        }
+
+        return decoded;
+    }
+
+} // namespace remoted::test
+
+#endif // _REMOTED_TEST_TLS_SERVER_HPP

--- a/src/remoted/remoted_module/tools/monitor.py
+++ b/src/remoted/remoted_module/tools/monitor.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""
+Samples wazuh-manager-remoted from /proc while load runs against it, so a download test
+can be read against what the server was actually doing: how many connections were open,
+how many threads were live, whether descriptors or memory grew.
+
+Everything comes from /proc, so it costs the server nothing and cannot miss time between
+samples the way a percentage-based CPU reading can: CPU is a counter delta, not a probe.
+
+Run it alongside send_download.py:
+
+  sudo python3 monitor.py --duration 30 &
+  sudo python3 send_download.py --simulate 8 --repeat 20
+"""
+import argparse
+import os
+import subprocess
+import sys
+import time
+
+CLK_TCK = os.sysconf("SC_CLK_TCK")
+
+# /proc/net/tcp state codes worth separating. A pile-up in TIME_WAIT or CLOSE_WAIT is the
+# signature of connections not being closed cleanly, which a raw "established" count hides.
+TCP_STATES = {
+    "01": "ESTABLISHED",
+    "02": "SYN_SENT",
+    "03": "SYN_RECV",
+    "04": "FIN_WAIT1",
+    "05": "FIN_WAIT2",
+    "06": "TIME_WAIT",
+    "07": "CLOSE",
+    "08": "CLOSE_WAIT",
+    "09": "LAST_ACK",
+    "0A": "LISTEN",
+    "0B": "CLOSING",
+}
+
+
+def find_pid(pattern="wazuh-manager-remoted"):
+    out = subprocess.run(["pgrep", "-f", pattern], capture_output=True, text=True, check=False)
+    pids = [int(p) for p in out.stdout.split() if p.isdigit()]
+    return pids[0] if pids else None
+
+
+def read_status(pid):
+    """VmRSS (KiB) and thread count, in one pass over /proc/<pid>/status."""
+    rss = threads = None
+    try:
+        with open(f"/proc/{pid}/status") as handle:
+            for line in handle:
+                if line.startswith("VmRSS:"):
+                    rss = int(line.split()[1])
+                elif line.startswith("Threads:"):
+                    threads = int(line.split()[1])
+                if rss is not None and threads is not None:
+                    break
+    except OSError:
+        return None, None
+    return rss, threads
+
+
+def read_cpu_ticks(pid):
+    """utime+stime in clock ticks. A counter, so two reads give exact CPU time between them."""
+    try:
+        with open(f"/proc/{pid}/stat") as handle:
+            fields = handle.read().rsplit(") ", 1)[1].split()
+    except (OSError, IndexError):
+        return None
+    # After the comm field, index 11/12 are utime/stime (fields 14/15 in proc(5) terms).
+    return int(fields[11]) + int(fields[12])
+
+
+def read_fds(pid):
+    try:
+        return len(os.listdir(f"/proc/{pid}/fd"))
+    except OSError:
+        return None
+
+
+def read_connections(port):
+    """Counts sockets on `port` by TCP state, from /proc/net/tcp{,6}."""
+    wanted = f"{port:04X}"
+    counts = {}
+    for path in ("/proc/net/tcp", "/proc/net/tcp6"):
+        try:
+            with open(path) as handle:
+                next(handle, None)
+                for line in handle:
+                    parts = line.split()
+                    if len(parts) < 4:
+                        continue
+                    local_port = parts[1].split(":")[1]
+                    remote_port = parts[2].split(":")[1]
+                    if local_port != wanted and remote_port != wanted:
+                        continue
+                    state = TCP_STATES.get(parts[3], parts[3])
+                    counts[state] = counts.get(state, 0) + 1
+        except OSError:
+            continue
+    return counts
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--pid", type=int, default=None, help="PID to watch (default: find wazuh-manager-remoted).")
+    parser.add_argument("--port", type=int, default=1517,
+                        help="Port whose connections to count (the <remote><https><port> default).")
+    parser.add_argument("--interval", type=float, default=0.1, help="Seconds between samples.")
+    parser.add_argument("--duration", type=float, default=30.0, help="Seconds to sample for.")
+    parser.add_argument("--quiet", action="store_true", help="Only print the summary, not the timeline.")
+    args = parser.parse_args()
+
+    pid = args.pid or find_pid()
+    if not pid:
+        raise SystemExit("wazuh-manager-remoted not found (use --pid)")
+
+    rss0, threads0 = read_status(pid)
+    fds0 = read_fds(pid)
+    ticks0 = read_cpu_ticks(pid)
+    if rss0 is None:
+        raise SystemExit(f"cannot read /proc/{pid} (run as root?)")
+
+    print(f"monitoring pid {pid} (port {args.port}) for {args.duration:g}s, every {args.interval:g}s")
+    print(f"baseline: RSS {rss0 / 1024:.1f} MiB, {threads0} threads, {fds0} fds\n")
+    if not args.quiet:
+        print(f"{'t(s)':>6} {'RSS MiB':>8} {'thr':>4} {'fds':>5} {'estab':>6} {'tw':>4} {'other':>6}")
+
+    samples = []
+    started = time.time()
+    while time.time() - started < args.duration:
+        now = time.time() - started
+        rss, threads = read_status(pid)
+        if rss is None:
+            print("process went away")
+            break
+        fds = read_fds(pid)
+        conns = read_connections(args.port)
+        estab = conns.get("ESTABLISHED", 0)
+        tw = conns.get("TIME_WAIT", 0)
+        other = sum(v for k, v in conns.items() if k not in ("ESTABLISHED", "TIME_WAIT", "LISTEN"))
+        samples.append((now, rss, threads, fds, estab, tw, other))
+        # Only print rows where something is actually happening: a live/half-closed connection,
+        # or a change against the PREVIOUS sample. Comparing against the first sample instead
+        # would keep printing every idle row once RSS had shifted at all.
+        prev = samples[-2] if len(samples) > 1 else None
+        moved = prev is None or (rss, threads, fds, estab) != (prev[1], prev[2], prev[3], prev[4])
+        if not args.quiet and (estab or other or moved):
+            print(f"{now:6.1f} {rss / 1024:8.1f} {threads:4d} {fds:5d} {estab:6d} {tw:4d} {other:6d}")
+        time.sleep(args.interval)
+
+    ticks1 = read_cpu_ticks(pid)
+    rss1, threads1 = read_status(pid)
+    fds1 = read_fds(pid)
+
+    if not samples:
+        raise SystemExit("no samples collected")
+
+    rss_vals = [s[1] for s in samples]
+    thr_vals = [s[2] for s in samples]
+    fd_vals = [s[3] for s in samples]
+    est_vals = [s[4] for s in samples]
+
+    print(f"\n--- summary over {len(samples)} samples ({time.time() - started:.1f}s) ---")
+    print(f"  RSS         {rss0 / 1024:7.1f} -> {rss1 / 1024:7.1f} MiB   "
+          f"(min {min(rss_vals) / 1024:.1f}, peak {max(rss_vals) / 1024:.1f}, "
+          f"growth {(rss1 - rss0) / 1024:+.2f})")
+    print(f"  threads     {threads0:7d} -> {threads1:7d}       (min {min(thr_vals)}, peak {max(thr_vals)})")
+    print(f"  fds         {fds0:7d} -> {fds1:7d}       (min {min(fd_vals)}, peak {max(fd_vals)})")
+    print(f"  conns       peak established {max(est_vals)}, "
+          f"mean {sum(est_vals) / len(est_vals):.1f} (while sampling)")
+    if ticks0 is not None and ticks1 is not None:
+        cpu_s = (ticks1 - ticks0) / CLK_TCK
+        print(f"  CPU         {cpu_s:.2f}s of process time")
+    # The two numbers that matter for a leak: both must come back to baseline.
+    print(f"  VERDICT     fds {'OK' if fds1 <= fds0 else 'GREW by %d' % (fds1 - fds0)}, "
+          f"threads {'OK' if threads1 <= threads0 else 'GREW by %d' % (threads1 - threads0)}, "
+          f"RSS {'flat' if (rss1 - rss0) < 8192 else 'GREW by %.1f MiB' % ((rss1 - rss0) / 1024)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/remoted/remoted_module/tools/send_download.py
+++ b/src/remoted/remoted_module/tools/send_download.py
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+"""
+Drives remoted's `POST /download` endpoint the way a real agent does, and checks the
+things unit tests cannot reach: the chunked transfer over TLS, and resource resolution
+against a real installation.
+
+Signing is identical to /stateless (same AuthMiddleware), so the helpers are imported
+from send_stateless.py rather than duplicated.
+
+What it verifies beyond "did it return 200":
+
+  * `Transfer-Encoding: chunked` is present and `Content-Length` is absent -- the
+    endpoint must stream, not buffer.
+  * The received bytes are IDENTICAL to the file `resource_id` names. The manager serves
+    exactly what is requested, so the expectation is derived from the request alone -- this
+    tool never reads the manager's database.
+  * With --watch-rss, remoted's peak RSS, exact CPU time, fd count and throughput during
+    the transfer. RSS answers the issue's "memory usage is constant regardless of file
+    size"; CPU is read as a /proc counter delta rather than sampled as a percentage, so
+    it cannot miss time between samples; the fd count catches a descriptor leak.
+
+Requires: pip install requests cryptography
+
+Examples:
+  python3 send_download.py                            # config download for agent 001's group
+  python3 send_download.py --all                      # every success/failure scenario
+  python3 send_download.py --resource-type wpk --resource-id pkg.wpk
+  python3 send_download.py --simulate 20 --repeat 5   # 20 concurrent simulated agents
+  python3 send_download.py --simulate 8 --watch-rss   # + RSS/CPU/fd/throughput report
+"""
+import argparse
+import concurrent.futures
+import hashlib
+import os
+import subprocess
+import sys
+import threading
+import time
+
+import requests
+import urllib3
+
+from send_stateless import _auth_header, read_agent_key
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+DEFAULT_MANAGER_HOME = "/var/wazuh-manager"
+TARGET = "/download"
+
+# Mirrors MAX_RESOURCE_ID_SIZE in downloadEndpoint.cpp.
+MAX_RESOURCE_ID_SIZE = 255
+
+# --- Manager-side layout ---------------------------------------------------
+
+class ManagerPaths:
+    def __init__(self, home):
+        self.home = home.rstrip("/")
+        self.client_keys = f"{self.home}/etc/client.keys"
+        self.shared_dir = f"{self.home}/etc/shared"
+        self.multigroups_dir = f"{self.home}/var/multigroups"
+        self.wpk_dir = f"{self.home}/var/upgrade"
+
+
+def multigroup_dir_name(selector: str) -> str:
+    """Same formula wazuh-db uses to NAME the directory: OS_SHA256_String_sized(sel, out, 8).
+    Replicated, not queried -- the manager derives it the same way."""
+    return hashlib.sha256(selector.encode()).hexdigest()[:8]
+
+
+def expected_config_path(paths: ManagerPaths, selector: str) -> str:
+    """The file the manager should serve for a `config` request naming `selector`.
+
+    resource_id is taken at face value -- no group lookup. One group joins under etc/shared;
+    a comma-separated selector is hashed into var/multigroups, exactly as wazuh-db names it.
+    """
+    selector = selector or "default"
+    if "," in selector:
+        return f"{paths.multigroups_dir}/{multigroup_dir_name(selector)}/merged.mg"
+    return f"{paths.shared_dir}/{selector}/merged.mg"
+
+
+def sha256_file(path: str):
+    digest = hashlib.sha256()
+    try:
+        with open(path, "rb") as handle:
+            for block in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(block)
+    except OSError:
+        return None
+    return digest.hexdigest()
+
+
+# --- The request itself ----------------------------------------------------
+
+def request_body(resource_type: str, resource_id: str) -> bytes:
+    # Built by hand rather than with json.dumps so a scenario can send a deliberately
+    # malformed body through the same path as a valid one.
+    return ('{"resource_type":"%s","resource_id":"%s"}' % (resource_type, resource_id)).encode()
+
+
+class DownloadResult:
+    def __init__(self):
+        self.status = None
+        self.chunked = False
+        self.content_length = None
+        self.bytes_received = 0
+        self.sha256 = None
+        self.error = None
+        self.text = ""
+
+
+def post_download(base_url, agent_id, agent_key, body: bytes, timeout=120) -> DownloadResult:
+    """Signs and sends one /download request, consuming the body as a stream so the
+    client never holds the whole file either."""
+    result = DownloadResult()
+    url = base_url.rstrip("/") + TARGET
+    headers = _auth_header(agent_id, agent_key, "1", "POST", TARGET, int(time.time()), body)
+
+    try:
+        response = requests.post(url, headers=headers, data=body, verify=False, stream=True, timeout=timeout)
+    except requests.exceptions.RequestException as error:
+        result.error = f"{type(error).__name__}: {error}"
+        return result
+
+    result.status = response.status_code
+    result.chunked = response.headers.get("Transfer-Encoding", "").lower() == "chunked"
+    result.content_length = response.headers.get("Content-Length")
+
+    digest = hashlib.sha256()
+    # Keep the first few KiB only when the status says this is an error body: those are the
+    # small JSON payloads worth printing, and a 2 GiB WPK must never be buffered. It has to be
+    # captured HERE, while streaming -- once iter_content() has drained the response,
+    # `response.content` is gone, so reading it afterwards yields nothing.
+    error_body = bytearray() if response.status_code != 200 else None
+
+    try:
+        for chunk in response.iter_content(64 * 1024):
+            if not chunk:
+                continue
+            digest.update(chunk)
+            result.bytes_received += len(chunk)
+            if error_body is not None and len(error_body) < 4096:
+                error_body.extend(chunk)
+    except requests.exceptions.RequestException as error:
+        # An interrupted chunked transfer must surface as a failure, never as a short
+        # but successful download.
+        result.error = f"transfer interrupted: {type(error).__name__}: {error}"
+        return result
+
+    result.sha256 = digest.hexdigest()
+    if error_body is not None:
+        result.text = bytes(error_body).decode(errors="replace")[:200]
+    return result
+
+
+# --- RSS sampling ----------------------------------------------------------
+
+def remoted_pid():
+    try:
+        out = subprocess.run(["pgrep", "-f", "wazuh-manager-remoted"],
+                             capture_output=True, text=True, check=False)
+        pids = [line for line in out.stdout.split() if line.isdigit()]
+        return int(pids[0]) if pids else None
+    except OSError:
+        return None
+
+
+def read_rss_kb(pid):
+    try:
+        with open(f"/proc/{pid}/status") as handle:
+            for line in handle:
+                if line.startswith("VmRSS:"):
+                    return int(line.split()[1])
+    except OSError:
+        return None
+    return None
+
+
+def read_cpu_seconds(pid):
+    """utime+stime from /proc/<pid>/stat, in seconds.
+
+    Read as a counter delta rather than sampled as a percentage: that is exact, and it
+    cannot miss CPU spent between two samples the way an instantaneous percentage can.
+    """
+    try:
+        with open(f"/proc/{pid}/stat") as handle:
+            # The comm field may contain spaces/parens, so index from the closing paren.
+            fields = handle.read().rsplit(") ", 1)[1].split()
+        ticks = os.sysconf("SC_CLK_TCK")
+        return (int(fields[11]) + int(fields[12])) / ticks   # utime, stime
+    except (OSError, IndexError, ValueError):
+        return None
+
+
+def read_fd_count(pid):
+    try:
+        return len(os.listdir(f"/proc/{pid}/fd"))
+    except OSError:
+        return None
+
+
+class ProcWatcher:
+    """Samples remoted's RSS and fd count, and brackets its CPU time.
+
+    RSS and fds are sampled (a peak is what matters); CPU is taken as an exact counter
+    delta from /proc/<pid>/stat, so nothing is missed between samples. Together these are
+    the three axes the /download work is judged on: memory flat in file size, CPU per
+    byte, and no descriptor leak.
+    """
+
+    def __init__(self, pid, interval=0.05):
+        self.pid = pid
+        self.interval = interval
+        self.rss = []
+        self.fds = []
+        self.cpu_start = None
+        self.cpu_end = None
+        self.wall = 0.0
+        self._t0 = None
+        self._stop = threading.Event()
+        self._thread = None
+
+    def __enter__(self):
+        if self.pid:
+            self.cpu_start = read_cpu_seconds(self.pid)
+            self._t0 = time.time()
+            self._thread = threading.Thread(target=self._run, daemon=True)
+            self._thread.start()
+        return self
+
+    def _run(self):
+        while not self._stop.is_set():
+            r = read_rss_kb(self.pid)
+            f = read_fd_count(self.pid)
+            if r is not None:
+                self.rss.append(r)
+            if f is not None:
+                self.fds.append(f)
+            self._stop.wait(self.interval)
+
+    def __exit__(self, *_):
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=2)
+        if self.pid:
+            self.cpu_end = read_cpu_seconds(self.pid)
+            self.wall = time.time() - self._t0
+        return False
+
+    def cpu_seconds(self):
+        if self.cpu_start is None or self.cpu_end is None:
+            return None
+        return self.cpu_end - self.cpu_start
+
+    def report(self, bytes_transferred=0):
+        if not self.rss:
+            return "no samples (is wazuh-manager-remoted running locally?)"
+        lo, hi = min(self.rss), max(self.rss)
+        parts = [f"remoted RSS {lo / 1024:.1f} -> peak {hi / 1024:.1f} MiB "
+                 f"(delta {(hi - lo) / 1024:.1f} MiB, {len(self.rss)} samples)"]
+        cpu = self.cpu_seconds()
+        if cpu is not None:
+            line = f"CPU {cpu:.2f}s"
+            if bytes_transferred:
+                gib = bytes_transferred / (1024 ** 3)
+                if gib > 0:
+                    line += f" ({cpu / gib:.2f} CPU-s/GiB)"
+            parts.append(line)
+        if self.fds:
+            parts.append(f"fds {min(self.fds)} -> {max(self.fds)}")
+        if bytes_transferred and self.wall > 0:
+            parts.append(f"{bytes_transferred / (1024 ** 2) / self.wall:.0f} MiB/s")
+        return "\n    ".join(parts)
+
+
+# --- Scenarios -------------------------------------------------------------
+# (name, expected_status, body). A malformed body, an unknown type and a bad id are all
+# 400 but with distinct messages; anything that does not resolve to a readable regular
+# file is 404.
+#
+# Note what is deliberately NOT covered: "a group this agent does not belong to". The
+# endpoint performs no membership check (protocol decision on #38022), so a request for
+# another group that DOES exist is served with 200 by design. The 404 below is about a
+# group that does not exist at all -- naming it otherwise would imply an authorization
+# property the endpoint does not have, and it would keep passing for the wrong reason.
+
+def build_scenarios(group, unknown_group, wpk_name):
+    return [
+        ("valid_config", 200, request_body("config", group)),
+        ("malformed_not_json", 400, b"not json at all"),
+        ("malformed_empty", 400, b""),
+        ("malformed_array", 400, b"[]"),
+        ("malformed_missing_field", 400, b'{"resource_type":"config"}'),
+        ("malformed_extra_field", 400, b'{"resource_type":"config","resource_id":"a","x":1}'),
+        ("malformed_wrong_type", 400, b'{"resource_type":"config","resource_id":123}'),
+        ("unknown_resource_type", 400, request_body("secrets", "a")),
+        ("resource_type_case_sensitive", 400, request_body("CONFIG", group)),
+        ("invalid_id_traversal", 400, request_body("config", "../../etc/shadow")),
+        ("invalid_id_slash", 400, request_body("config", "a/b")),
+        ("invalid_id_dotdot", 400, request_body("config", "..")),
+        ("invalid_id_empty", 400, request_body("config", "")),
+        ("invalid_id_too_long", 400, request_body("config", "g" * (MAX_RESOURCE_ID_SIZE + 1))),
+        ("multigroup_selector_trailing_comma", 400, request_body("config", "web-servers,")),
+        ("multigroup_selector_doubled_comma", 400, request_body("config", "web,,servers")),
+        ("multigroup_selector_traversal_entry", 400, request_body("config", "web-servers,..")),
+        ("wpk_without_extension", 400, request_body("wpk", "package")),
+        ("wpk_traversal", 400, request_body("wpk", "../../etc/shadow.wpk")),
+        ("unknown_group_is_404", 404, request_body("config", unknown_group)),
+        ("missing_wpk_is_404", 404, request_body("wpk", "definitely-not-staged.wpk")),
+        ("valid_wpk", 200, request_body("wpk", wpk_name)),
+    ]
+
+
+def run_scenarios(base_url, agent_id, agent_key, scenarios):
+    print(f"Running {len(scenarios)} scenarios against {base_url} (agent {agent_id})\n")
+    passed = 0
+    for name, expected, body in scenarios:
+        result = post_download(base_url, agent_id, agent_key, body)
+        if result.error:
+            print(f"[FAIL] {name}: expected {expected}, request failed: {result.error}")
+            continue
+        ok = result.status == expected
+        passed += ok
+        extra = ""
+        if result.status == 200:
+            extra = f", {result.bytes_received} bytes, chunked={result.chunked}"
+            if not result.chunked:
+                ok = False
+                extra += " <-- NOT CHUNKED"
+                passed -= 1
+        print(f"[{'PASS' if ok else 'FAIL'}] {name}: expected {expected}, got {result.status}"
+              f"{extra}{(' -- ' + result.text) if result.text else ''}")
+    print(f"\n{passed}/{len(scenarios)} scenarios passed.")
+    return passed == len(scenarios)
+
+
+# --- Simulated agents ------------------------------------------------------
+
+def enrolled_agents(paths: ManagerPaths, limit=None):
+    """Every usable agent in client.keys, as (id, key) pairs."""
+    agents = []
+    with open(paths.client_keys) as handle:
+        for line in handle:
+            if not line or line[0] in ("#", " "):
+                continue
+            parts = line.split()
+            if len(parts) < 4 or parts[1].startswith(("#", "!")):
+                continue
+            agents.append((parts[0], bytes.fromhex(parts[3])))
+            if limit and len(agents) >= limit:
+                break
+    return agents
+
+
+def simulate(base_url, agents, repeat, expected):
+    """Fires `repeat` config downloads per agent, all concurrently, and checks every one
+    byte-for-byte. Concurrency is where a per-connection streaming bug shows up: a shared
+    buffer or a mis-scoped descriptor produces interleaved or truncated bodies here and
+    nowhere else."""
+    jobs = [(agent_id, key, round_index)
+            for agent_id, key in agents
+            for round_index in range(repeat)]
+
+    print(f"Simulating {len(agents)} agent(s) x {repeat} download(s) = {len(jobs)} concurrent requests")
+
+    def one(job):
+        agent_id, key, _ = job
+        want = expected.get(agent_id)
+        result = post_download(base_url, agent_id, key, request_body("config", want["selector"]))
+        return agent_id, result, want
+
+    started = time.time()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=min(32, len(jobs))) as pool:
+        results = list(pool.map(one, jobs))
+    elapsed = time.time() - started
+
+    failures = []
+    total_bytes = 0
+    for agent_id, result, want in results:
+        total_bytes += result.bytes_received
+        if result.error:
+            failures.append(f"agent {agent_id}: {result.error}")
+        elif result.status != 200:
+            failures.append(f"agent {agent_id}: status {result.status} ({result.text})")
+        elif not result.chunked:
+            failures.append(f"agent {agent_id}: response was not chunked")
+        elif want["sha256"] and result.sha256 != want["sha256"]:
+            failures.append(f"agent {agent_id}: body mismatch -- got {result.sha256[:16]}, "
+                            f"expected {want['sha256'][:16]} ({want['path']})")
+
+    rate = (total_bytes / (1024 * 1024) / elapsed) if elapsed > 0 else 0
+    print(f"  {len(results) - len(failures)}/{len(results)} succeeded in {elapsed:.2f}s "
+          f"({total_bytes / (1024 * 1024):.1f} MiB, {rate:.1f} MiB/s)")
+    for failure in failures[:20]:
+        print(f"  [FAIL] {failure}")
+    return not failures
+
+
+# --- main ------------------------------------------------------------------
+
+def resolve_expectations(paths, agents, selectors):
+    """Works out which file the manager should serve each simulated agent.
+
+    Selectors are assigned round-robin so concurrent agents pull DIFFERENT files -- that is
+    what catches a per-connection streaming bug, since shared or mis-scoped state shows up
+    as one agent receiving another's body.
+
+    No database is consulted: `/download` takes `resource_id` at face value, so the
+    expectation follows from the request alone. Reading global.db here would only re-create
+    the group-aware model the endpoint deliberately does not have.
+    """
+    expected = {}
+    for index, (agent_id, _) in enumerate(agents):
+        selector = selectors[index % len(selectors)]
+        path = expected_config_path(paths, selector)
+        expected[agent_id] = {
+            "selector": selector,
+            "path": path,
+            "sha256": sha256_file(path),
+        }
+    return expected
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--url", default="https://127.0.0.1:9443", help="Base URL of the HTTPS server.")
+    parser.add_argument("--agent-id", default="001", help="Agent id, as it appears in client.keys.")
+    parser.add_argument("--manager-home", default=DEFAULT_MANAGER_HOME,
+                        help="Manager installation root (client.keys, global.db, etc/shared, var/upgrade).")
+    parser.add_argument("--resource-type", default="config", choices=("config", "wpk"))
+    parser.add_argument("--resource-id", default=None,
+                        help="Group name or WPK filename. Defaults to the agent's first group.")
+    parser.add_argument("--all", action="store_true", help="Run every success/failure scenario.")
+    parser.add_argument("--simulate", type=int, metavar="N",
+                        help="Simulate N enrolled agents downloading concurrently.")
+    parser.add_argument("--repeat", type=int, default=1, help="Downloads per simulated agent.")
+    parser.add_argument("--selectors", default="default",
+                        help="Semicolon-separated resource_ids to hand the simulated agents, "
+                             "round-robin (';' because ',' already separates a multigroup). "
+                             "Different selectors make concurrent agents pull different files, "
+                             "e.g. 'web-servers;web-servers,databases;default'.")
+    parser.add_argument("--watch-rss", action="store_true",
+                        help="Sample wazuh-manager-remoted's RSS during the transfers.")
+    parser.add_argument("--unknown-group", default="a-group-that-does-not-exist",
+                        help="Group used by the 404 scenario; must not exist on the manager.")
+    parser.add_argument("--wpk", default=None, help="WPK filename staged under var/upgrade.")
+    args = parser.parse_args()
+
+    paths = ManagerPaths(args.manager_home)
+
+    if args.simulate:
+        agents = enrolled_agents(paths, limit=args.simulate)
+        if not agents:
+            raise SystemExit(f"no usable agents in {paths.client_keys}")
+        selectors = [s for s in args.selectors.split(";") if s] or ["default"]
+        expected = resolve_expectations(paths, agents, selectors)
+        for agent_id, want in list(expected.items())[:5]:
+            print(f"  agent {agent_id}: requests '{want['selector']}' -> {want['path']} "
+                  f"{'(unreadable)' if not want['sha256'] else ''}")
+        watcher = ProcWatcher(remoted_pid() if args.watch_rss else None)
+        with watcher:
+            ok = simulate(args.url, agents, args.repeat, expected)
+        if args.watch_rss:
+            print(f"  {watcher.report()}")
+        return 0 if ok else 1
+
+    agent_key = read_agent_key(args.agent_id, paths.client_keys)
+    default_group = args.resource_id or "default"
+
+    if args.all:
+        wpk = args.wpk or next((f for f in sorted(os.listdir(paths.wpk_dir))
+                                if f.endswith(".wpk")), "none-staged.wpk") \
+            if os.path.isdir(paths.wpk_dir) else "none-staged.wpk"
+        print(f"agent {args.agent_id}: config selector={default_group}, wpk={wpk}\n")
+        return 0 if run_scenarios(args.url, args.agent_id, agent_key,
+                                  build_scenarios(default_group, args.unknown_group, wpk)) else 1
+
+    resource_id = args.resource_id or ("default" if args.resource_type == "config" else "")
+    if not resource_id:
+        raise SystemExit("--resource-id is required for a wpk download")
+
+    body = request_body(args.resource_type, resource_id)
+    print(f"--> POST {args.url.rstrip('/')}{TARGET}  {body.decode()}")
+
+    watcher = ProcWatcher(remoted_pid() if args.watch_rss else None)
+    with watcher:
+        result = post_download(args.url, args.agent_id, agent_key, body)
+
+    if result.error:
+        print(f"<-- FAILED: {result.error}")
+        return 1
+
+    print(f"<-- {result.status}  chunked={result.chunked}  content-length={result.content_length}")
+    print(f"    {result.bytes_received} bytes, sha256={result.sha256}")
+    if result.text:
+        print(f"    {result.text}")
+    if args.watch_rss:
+        print(f"    {watcher.report(result.bytes_received)}")
+
+    if result.status == 200 and args.resource_type == "config":
+        want_path = expected_config_path(paths, resource_id)
+        want_digest = sha256_file(want_path)
+        print(f"    expected file: {want_path}")
+        if want_digest is None:
+            print("    (expected file unreadable from here; skipping byte comparison)")
+        elif want_digest == result.sha256:
+            print("    [PASS] body matches the file the manager should have served")
+        else:
+            print(f"    [FAIL] body MISMATCH -- expected sha256={want_digest}")
+            return 1
+        if not result.chunked:
+            print("    [FAIL] response was not chunked")
+            return 1
+
+    return 0 if result.status == 200 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/remoted/src/secure.c
+++ b/src/remoted/src/secure.c
@@ -270,6 +270,10 @@ STATIC void remoted_module_https_config(remoted_module_config_t *rm_config) {
     rm_config->http_max_pipelined_requests = getDefine_Int_default("remoted", "http_max_pipelined_requests", 1, 64, 4);
     rm_config->http_concurrent_accepts = getDefine_Int_default("remoted", "http_concurrent_accepts", 1, 64, 2);
     rm_config->http_buffer_size = getDefine_Int_default("remoted", "http_buffer_size", 1, 1048576, 8192);
+    // Bytes per chunk when streaming a response body (POST /download). Bounded at 1 MiB because
+    // this is per IN-FLIGHT TRANSFER: the worst case is roughly this times the number of
+    // simultaneous downloads, so a large value trades memory for fewer read/write round trips.
+    rm_config->http_stream_chunk_size = getDefine_Int_default("remoted", "http_stream_chunk_size", 4096, 1048576, 65536);
 
     // Memory-management (backpressure) tunables. These bound in-memory resource usage rather
     // than tune the transport itself; the C++ side still clamps max_inflight_bytes up to at
@@ -310,6 +314,25 @@ STATIC void w_remoted_build_module_config(const remoted *logr, remoted_module_co
     // back to its own default.
     rm_config->port = logr->https.port;
     remoted_module_https_config(rm_config);
+    // rm_config->max_inflight_bytes caps the HTTPS server's in-flight (unprocessed)
+    // request payload before it sheds load with 503. NOT logr->queue_size (that is an
+    // event COUNT, not bytes).
+    rm_config->max_inflight_bytes = (256 * 1024 * 1024); // 256 MiB
+    // rm_config->max_parallel_connections caps simultaneous HTTPS connections, bounding the
+    // read-phase memory peak (~ max_parallel_connections * max body size).
+    //
+    // It is also the ONLY bound on concurrent streamed responses (POST /download): chunked output
+    // rearms http_write_timeout per chunk, so a client that keeps reading slowly can hold a
+    // transfer open indefinitely, and there is no per-stream limiter. A mass upgrade -- the whole
+    // fleet fetching a WPK at once, many over slow links -- is therefore bounded only by this
+    // value, which is why it is settable rather than fixed.
+    rm_config->max_parallel_connections =
+        getDefine_Int_default("remoted", "http_max_parallel_connections", 1, 8192, 512);
+    // rm_config->max_deferred_requests caps requests parked awaiting a downstream service (503
+    // over it). No Retry-After is sent: the agent runs its own retry/backoff on a 503.
+    rm_config->max_deferred_requests = 256;
+    // rm_config->keystore_refresh_interval governs how often the C++ Keystore checks
+    // client.keys for changes (hot-reload)
     rm_config->keystore_refresh_interval = keyupdate_interval;
     rm_config->worker_node = logr->worker_node;
     rm_config->verification_mode = logr->https.verification_mode;

--- a/src/remoted/src/secure.c
+++ b/src/remoted/src/secure.c
@@ -278,9 +278,19 @@ STATIC void remoted_module_https_config(remoted_module_config_t *rm_config) {
     // Memory-management (backpressure) tunables. These bound in-memory resource usage rather
     // than tune the transport itself; the C++ side still clamps max_inflight_bytes up to at
     // least one max-size request at start(), so a too-small value can't reject everything.
+    // max_inflight_bytes caps the HTTPS server's in-flight (unprocessed) request payload
+    // before it sheds load with 503. NOT logr->queue_size (that is an event COUNT, not bytes).
     rm_config->max_inflight_bytes =
         getDefine_Int_default("remoted", "max_inflight_bytes", 1048576, 1073741824, 268435456);
+    // max_parallel_connections caps simultaneous HTTPS connections, bounding the read-phase
+    // memory peak (~ max_parallel_connections * max body size). It is also the ONLY bound on
+    // concurrent streamed responses (POST /download): chunked output rearms http_write_timeout
+    // per chunk, so a client that keeps reading slowly can hold a transfer open indefinitely.
+    // A mass upgrade (the whole fleet fetching a WPK at once, many over slow links) is therefore
+    // bounded only by this value, which is why it is settable rather than fixed.
     rm_config->max_parallel_connections = getDefine_Int_default("remoted", "max_parallel_connections", 1, 65536, 512);
+    // max_deferred_requests caps requests parked awaiting a downstream service (503 over it).
+    // No Retry-After is sent: the agent runs its own retry/backoff on a 503.
     rm_config->max_deferred_requests = getDefine_Int_default("remoted", "max_deferred_requests", 1, 65536, 256);
 
     // Downstream (async UDS client to the engine's event ingress) tunables.
@@ -314,25 +324,6 @@ STATIC void w_remoted_build_module_config(const remoted *logr, remoted_module_co
     // back to its own default.
     rm_config->port = logr->https.port;
     remoted_module_https_config(rm_config);
-    // rm_config->max_inflight_bytes caps the HTTPS server's in-flight (unprocessed)
-    // request payload before it sheds load with 503. NOT logr->queue_size (that is an
-    // event COUNT, not bytes).
-    rm_config->max_inflight_bytes = (256 * 1024 * 1024); // 256 MiB
-    // rm_config->max_parallel_connections caps simultaneous HTTPS connections, bounding the
-    // read-phase memory peak (~ max_parallel_connections * max body size).
-    //
-    // It is also the ONLY bound on concurrent streamed responses (POST /download): chunked output
-    // rearms http_write_timeout per chunk, so a client that keeps reading slowly can hold a
-    // transfer open indefinitely, and there is no per-stream limiter. A mass upgrade -- the whole
-    // fleet fetching a WPK at once, many over slow links -- is therefore bounded only by this
-    // value, which is why it is settable rather than fixed.
-    rm_config->max_parallel_connections =
-        getDefine_Int_default("remoted", "http_max_parallel_connections", 1, 8192, 512);
-    // rm_config->max_deferred_requests caps requests parked awaiting a downstream service (503
-    // over it). No Retry-After is sent: the agent runs its own retry/backoff on a 503.
-    rm_config->max_deferred_requests = 256;
-    // rm_config->keystore_refresh_interval governs how often the C++ Keystore checks
-    // client.keys for changes (hot-reload)
     rm_config->keystore_refresh_interval = keyupdate_interval;
     rm_config->worker_node = logr->worker_node;
     rm_config->verification_mode = logr->https.verification_mode;

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -3161,7 +3161,7 @@ void test_remoted_module_https_config_defaults(void** state)
     remoted_module_config_t rm_config = {0};
 
     // __wrap_getDefine_Int_default is a plain FIFO mock(), so these MUST stay in the same order
-    // as the getDefine_Int_default() calls in remoted_module_https_config(): 12 http_*, then
+    // as the getDefine_Int_default() calls in remoted_module_https_config(): 13 http_*, then
     // 3 memory-management, then 6 downstream_*, then 3 auth_*. Adding an option there without
     // adding a value here makes the queue run dry and cmocka aborts the test.
     // http_*
@@ -3177,6 +3177,7 @@ void test_remoted_module_https_config_defaults(void** state)
     will_return(__wrap_getDefine_Int_default, 4);
     will_return(__wrap_getDefine_Int_default, 2);
     will_return(__wrap_getDefine_Int_default, 8192);
+    will_return(__wrap_getDefine_Int_default, 65536); // http_stream_chunk_size
     // memory-management
     will_return(__wrap_getDefine_Int_default, 268435456);
     will_return(__wrap_getDefine_Int_default, 512);
@@ -3246,6 +3247,7 @@ void test_remoted_module_https_config_custom_values(void** state)
     will_return(__wrap_getDefine_Int_default, 8);
     will_return(__wrap_getDefine_Int_default, 4);
     will_return(__wrap_getDefine_Int_default, 16384);
+    will_return(__wrap_getDefine_Int_default, 131072); // http_stream_chunk_size
     // memory-management
     will_return(__wrap_getDefine_Int_default, 33554432);
     will_return(__wrap_getDefine_Int_default, 256);
@@ -3297,8 +3299,8 @@ void test_remoted_module_https_config_custom_values(void** state)
 /* Tests w_remoted_build_module_config */
 //
 // w_remoted_build_module_config() calls remoted_module_https_config() internally, so
-// each test below must queue the same 24 __wrap_getDefine_Int_default return values
-// (12 http_*, then 3 memory-management, then 6 downstream_*, then 3 auth_*, in that
+// each test below must queue the same 25 __wrap_getDefine_Int_default return values
+// (13 http_*, then 3 memory-management, then 6 downstream_*, then 3 auth_*, in that
 // fixed order) as the remoted_module_https_config tests above, even though these
 // tests assert on the <https>-driven fields instead.
 
@@ -3332,6 +3334,7 @@ void test_w_remoted_build_module_config_all_fields_populated(void** state)
     will_return(__wrap_getDefine_Int_default, 2);
     will_return(__wrap_getDefine_Int_default, 8192);
     // memory-management
+    will_return(__wrap_getDefine_Int_default, 65536); // http_stream_chunk_size
     will_return(__wrap_getDefine_Int_default, 268435456);
     will_return(__wrap_getDefine_Int_default, 512);
     will_return(__wrap_getDefine_Int_default, 256);
@@ -3387,6 +3390,7 @@ void test_w_remoted_build_module_config_null_https_strings_leave_buffers_empty(v
     will_return(__wrap_getDefine_Int_default, 8192);
     will_return(__wrap_getDefine_Int_default, 268435456);
     will_return(__wrap_getDefine_Int_default, 512);
+    will_return(__wrap_getDefine_Int_default, 65536); // http_stream_chunk_size
     will_return(__wrap_getDefine_Int_default, 256);
     will_return(__wrap_getDefine_Int_default, 2);
     will_return(__wrap_getDefine_Int_default, 5);


### PR DESCRIPTION
## Description

Implements the manager-side `POST /download` endpoint, which streams binary resources to agents
with HTTP chunked transfer encoding: merged centralized configurations (`merged.mg`) and WPK
upgrade packages. Large files are streamed rather than buffered, so remoted's memory footprint is
independent of the file size.

Closes #38022

## Proposed Changes

**Transport — streamed responses (`96fbdd9`)**

`IHttpResponder::send()` takes a `std::string` body, so a large file would be held in memory in
full. Handlers now supply an `IByteSource` and the *transport* drives the transfer, alternating a
read on a worker thread with a write on the connection's I/O strand — one chunk resident, and
a worker slot held only for the duration of a single read rather than for the whole transfer.

The chunk size is `remoted.http_stream_chunk_size` (default 64 KiB). It is charged per *in-flight
transfer*, so the worst case is roughly that value times the number of simultaneous downloads; a
larger chunk buys fewer read/write round trips at the cost of more resident memory while transfers
run. `remoted.http_max_parallel_connections` (previously hardcoded at 512) is now settable for the
same reason: it is the only bound on concurrent streamed responses, since chunked output rearms
`http_write_timeout` per chunk and there is no per-stream limiter, so a fleet-wide upgrade over slow
links is bounded by that value alone.

The mode is declared at registration (`ResponseMode::Streamable`) rather than per response: the
transport creates a request's response builder when the request is dispatched (which is what lets it
release the received body before the request is queued) and a builder's output mode is fixed at
creation. A streamable route's responder therefore keeps the request handle and picks buffered for an
error or chunked for a transfer — so a 404 stays a normal `Content-Length` reply.

A read error drops the builder *without* `done()`, so no terminating chunk is emitted and the peer
sees a truncated body it will retry; emitting the terminator would hand over a short file that looks
complete. Aborted transfers are reported as a throttled WARN, since the volume is client-driven.

**Endpoint (`5982a63`)**

- `resource_id` is what the agent requests and the manager serves exactly that: a single group
  resolves under `etc/shared/<group>/merged.mg`; a comma-separated selector is hashed into
  `var/multigroups/<sha256(selector)[:8]>/merged.mg`, matching how wazuh-db names that directory; a
  WPK filename resolves under `var/upgrade/`. No group lookup, no database access.
- The single-group and WPK forms join agent input into a path, so the resource-id grammars are the
  containment boundary: no separator, not `.` or `..`, no leading dot, and a `.wpk` suffix for
  packages. A multigroup selector is hashed rather than joined, so its directory name is hex by
  construction.
- The file is opened and `fstat`ed *before* any byte of the response is written, so a missing resource
  is a clean 404 rather than a truncated 200. The descriptor is held for the whole transfer, so a
  writer that publishes by rename (`c_group()` with `remoted.disk_storage=1` writes `merged.mg.tmp`
  and renames) cannot corrupt an in-flight download — the old inode keeps being served.
- **A resource modified in place mid-transfer aborts the transfer instead of completing it.** Holding
  the descriptor is not sufficient, because the two default write paths do not rename: `c_group()`
  with `remoted.disk_storage=0` (the default, `src/remoted/src/config.c`) truncates `merged.mg` and
  rewrites the same inode, and a WPK is fetched straight to its final path in `var/upgrade/`
  (`wurl_request()`), so it grows in place while being staged. The descriptor then follows the new
  contents, and the failure is silent: `read()` reaches the *new* end-of-file, returns 0, and the
  transport emits the terminating chunk — the agent accepts a truncated or spliced file as complete.
  `FileByteSource` therefore compares delivered bytes against the length at `open()`, and re-`fstat`s
  before reporting end-of-stream, catching a file that was shortened, that grew, or that was
  rewritten to the same length (mtime). Any of those throws, which the transport already handles as
  an abort: no terminating chunk, so the agent retries. Being cut off is recoverable; being handed
  corrupt bytes that look whole is not — and for `merged.mg` nothing downstream would catch it.
  This *detects* in-place modification rather than preventing it; preventing it means making those
  writers publish atomically by rename, which is a change in `manager.c` and the upgrade module.
- Adds `tools/send_download.py` for manual and end-to-end testing.

### Results and Evidence

<details>
<summary>Single group merged.mg case</summary>

```
root@wazuh-master:/home/vagrant#  sudo /var/wazuh-manager/bin/agent_groups -a -g web-servers -q
Group 'web-servers' created.

root@wazuh-master:/home/vagrant# sudo cat /var/wazuh-manager/etc/shared/web-servers/merged.mg
#web-servers
!76 agent.conf
<agent_config>

  <!-- Shared agent configuration here -->

</agent_config>
!134 web.conf
<agent_config>
  <localfile><location>/var/log/nginx/access.log</location><log_format>syslog</log_format></localfile>
</agent_config>
root@wazuh-master:/home/vagrant# sudo sha256sum /var/wazuh-manager/etc/shared/web-servers/merged.mg
a96e0343bb07807a532d5890d0940fbd93919fde0b25b4dd4e12b3e8f5c2c387  /var/wazuh-manager/etc/shared/web-servers/merged.mg

root@wazuh-agent1:/home/vagrant# KEY=$(awk '{print $4; exit}' /var/ossec/etc/client.keys)
root@wazuh-agent1:/home/vagrant# ID=$(awk  '{print $1; exit}' /var/ossec/etc/client.keys)
root@wazuh-agent1:/home/vagrant# TS=$(date +%s)
root@wazuh-agent1:/home/vagrant# BODY='{"resource_type":"config","resource_id":"web-servers"}'
root@wazuh-agent1:/home/vagrant# MAC=$(printf 'WAZUH-REQUEST\n1\nPOST\n/download\n%s\n%s\n%s' "$ID" "$TS" "$BODY" \
      | openssl mac -macopt cipher:AES-256-CBC -macopt hexkey:"$KEY" CMAC | tr 'A-Z' 'a-z')

root@wazuh-agent1:/home/vagrant# curl -k -X POST "https://192.168.56.11:1517/download"   -H "protocol-version: 1" -H "Authorization: Wazuh $ID:$TS:$MAC"   -H "Content-Type: application/json" --data-binary "$BODY"   -o /tmp/a.mg -D /dev/stderr
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0HTTP/1.1 200 OK
Connection: keep-alive
Server: wazuh-manager-remoted
Date: Mon, 03 Aug 2026 15:48:16 GMT
Content-Type: application/octet-stream
Transfer-Encoding: chunked

100   306    0   252  100    54   5469   1172 --:--:-- --:--:-- --:--:--  6652

root@wazuh-agent1:/home/vagrant# sha256sum /tmp/a.mg 
a96e0343bb07807a532d5890d0940fbd93919fde0b25b4dd4e12b3e8f5c2c387  /tmp/a.mg
```

</details>

<details>
<summary>Multigroup merged.mg case</summary>

```
root@wazuh-master:/home/vagrant#  sudo /var/wazuh-manager/bin/agent_groups -a -g databases -q
Group 'databases' created.

root@wazuh-master:/home/vagrant# sudo /var/wazuh-manager/bin/agent_groups -a -i 001 -g web-servers -q
Group 'web-servers' added to agent '001'.
root@wazuh-master:/home/vagrant# sudo /var/wazuh-manager/bin/agent_groups -a -i 001 -g databases   -q
Group 'databases' added to agent '001'.
root@wazuh-master:/home/vagrant# sudo /var/wazuh-manager/bin/agent_groups -s -i 001 -q
The agent 'wazuh-agent1' with ID '001' belongs to groups: web-servers, databases.

root@wazuh-master:/home/vagrant# cat /var/wazuh-manager/var/multigroups/97d66859/merged.mg 
#97d66859
!240 agent.conf
<!-- Source file: web-servers/agent.conf -->
<agent_config>

  <!-- Shared agent configuration here -->

</agent_config>
<!-- Source file: databases/agent.conf -->
<agent_config>

  <!-- Shared agent configuration here -->

</agent_config>
!134 web.conf
<agent_config>
  <localfile><location>/var/log/nginx/access.log</location><log_format>syslog</log_format></localfile>
</agent_config>

root@wazuh-master:/home/vagrant# sha256sum /var/wazuh-manager/var/multigroups/97d66859/merged.mg 
d7f4ab09262a6ce24b5894a4a93b7dd666b634cc8b14b0cea69841665c6d39dd  /var/wazuh-manager/var/multigroups/97d66859/merged.mg

root@wazuh-agent1:/home/vagrant# KEY=$(awk '{print $4; exit}' /var/ossec/etc/client.keys)
root@wazuh-agent1:/home/vagrant# ID=$(awk  '{print $1; exit}' /var/ossec/etc/client.keys)
root@wazuh-agent1:/home/vagrant# TS=$(date +%s)
root@wazuh-agent1:/home/vagrant# BODY='{"resource_type":"config","resource_id":"web-servers,databases"}'
root@wazuh-agent1:/home/vagrant# MAC=$(printf 'WAZUH-REQUEST\n1\nPOST\n/download\n%s\n%s\n%s' "$ID" "$TS" "$BODY" \
      | openssl mac -macopt cipher:AES-256-CBC -macopt hexkey:"$KEY" CMAC | tr 'A-Z' 'a-z')

root@wazuh-agent1:/home/vagrant# curl -k -X POST "https://192.168.56.11:1517/download"   -H "protocol-version: 1" -H "Authorization: Wazuh $ID:$TS:$MAC"   -H "Content-Type: application/json" --data-binary "$BODY"   -o /tmp/b.mg -D /dev/stderr
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0HTTP/1.1 200 OK
Connection: keep-alive
Server: wazuh-manager-remoted
Date: Mon, 03 Aug 2026 16:04:37 GMT
Content-Type: application/octet-stream
Transfer-Encoding: chunked

100   478    0   414  100    64   8853   1368 --:--:-- --:--:-- --:--:-- 10391
root@wazuh-agent1:/home/vagrant# cat /tmp/b.mg 
#97d66859
!240 agent.conf
<!-- Source file: web-servers/agent.conf -->
<agent_config>

  <!-- Shared agent configuration here -->

</agent_config>
<!-- Source file: databases/agent.conf -->
<agent_config>

  <!-- Shared agent configuration here -->

</agent_config>
!134 web.conf
<agent_config>
  <localfile><location>/var/log/nginx/access.log</location><log_format>syslog</log_format></localfile>
</agent_config>
root@wazuh-agent1:/home/vagrant# sha256sum /tmp/b.mg 
d7f4ab09262a6ce24b5894a4a93b7dd666b634cc8b14b0cea69841665c6d39dd  /tmp/b.mg
```

</details>

<details>
<summary>WPK case</summary>

```
root@wazuh-master:~/wpk# head -c 1073741824 /dev/urandom > payload/big.bin
root@wazuh-master:~/wpk# TMPDIR=/var/tmp python3 /home/vagrant/devel/wazuh/tools/agent-upgrade/wpkpack.py \
        huge-signed.wpk wpk_sign.pem wpk_sign.key payload/upgrade.sh payload/big.bin
root@wazuh-master:~/wpk# ls -la huge-signed.wpk
-rw-r--r-- 1 root root 1074070760 Aug  3 16:17 huge-signed.wpk
root@wazuh-master:~/wpk# sha256sum huge-signed.wpk
4e74b30f67ed2c141f4629de670e47a931a76036c9caa139c41a9a39dab83b58  huge-signed.wpk

root@wazuh-master:~/wpk# cat /tmp/wpkverify.py 
#!/usr/bin/env python3
from cryptography import x509
from cryptography.hazmat.primitives import hashes
from cryptography.hazmat.primitives.asymmetric import padding, utils
import sys

MAGIC, SIGNLEN = b"WPK256\0", 2048 // 8
data = open(sys.argv[1], "rb").read()

assert data[:len(MAGIC)] == MAGIC, "bad magic: not a WPK256 file"
rest = data[len(MAGIC):]
end = rest.index(b"\0")                       # cert is NUL-terminated
cert_pem, rest = rest[:end], rest[end + 1:]
signature, payload = rest[:SIGNLEN], rest[SIGNLEN:]

cert = x509.load_pem_x509_certificate(cert_pem)
print("cert subject :", cert.subject.rfc4514_string())
print("cert issuer  :", cert.issuer.rfc4514_string())
print("payload      :", len(payload), "bytes")

h = hashes.Hash(hashes.SHA256()); h.update(payload)
cert.public_key().verify(signature, h.finalize(), padding.PKCS1v15(),
                         utils.Prehashed(hashes.SHA256()))
print("SIGNATURE    : OK")

if len(sys.argv) > 2:
    ca = x509.load_pem_x509_certificate(open(sys.argv[2], "rb").read())
    ca.public_key().verify(cert.signature, cert.tbs_certificate_bytes,
                           padding.PKCS1v15(), cert.signature_hash_algorithm)
    print("CERT CHAIN   : OK (issued by %s)" % ca.subject.rfc4514_string())


root@wazuh-master:~/wpk# python3 /tmp/wpkverify.py huge-signed.wpk
cert subject : CN=wazuh-wpk-signer
cert issuer  : CN=wazuh-wpk-ca
payload      : 1074069491 bytes
SIGNATURE    : OK

root@wazuh-master:~/wpk# sudo cp huge-signed.wpk /var/wazuh-manager/var/upgrade/
root@wazuh-master:~/wpk# sudo chown wazuh-manager:wazuh-manager /var/wazuh-manager/var/upgrade/huge-signed.wpk

root@wazuh-agent1:/home/vagrant# KEY=$(awk '{print $4; exit}' /var/ossec/etc/client.keys)
root@wazuh-agent1:/home/vagrant# ID=$(awk  '{print $1; exit}' /var/ossec/etc/client.keys)
root@wazuh-agent1:/home/vagrant# TS=$(date +%s)
root@wazuh-agent1:/home/vagrant# BODY='{"resource_type":"wpk","resource_id":"huge-signed.wpk"}'
root@wazuh-agent1:/home/vagrant# MAC=$(printf 'WAZUH-REQUEST\n1\nPOST\n/download\n%s\n%s\n%s' "$ID" "$TS" "$BODY" \
      | openssl mac -macopt cipher:AES-256-CBC -macopt hexkey:"$KEY" CMAC | tr 'A-Z' 'a-z')
root@wazuh-agent1:/home/vagrant# curl -k -X POST "https://192.168.56.11:1517/download"   -H "protocol-version: 1"   -H "Authorization: Wazuh $ID:$TS:$MAC"   -H "Content-Type: application/json"   --data-binary "$BODY"   -o /tmp/got.wpk   -D /dev/stderr   -w 'time=%{time_total}s  speed=%{speed_download} B/s  bytes=%{size_download}\n'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0HTTP/1.1 200 OK
Connection: keep-alive
Server: wazuh-manager-remoted
Date: Mon, 03 Aug 2026 16:23:55 GMT
Content-Type: application/octet-stream
Transfer-Encoding: chunked

100 1024M    0 1024M  100    55   273M     14  0:00:03  0:00:03 --:--:--  273M
time=3.738468s  speed=287302381 B/s  bytes=1074070760

root@wazuh-agent1:/home/vagrant# sha256sum /tmp/got.wpk 
4e74b30f67ed2c141f4629de670e47a931a76036c9caa139c41a9a39dab83b58  /tmp/got.wpk

root@wazuh-agent1:/home/vagrant# python3 /tmp/wpkverify.py /tmp/got.wpk 
cert subject : CN=wazuh-wpk-signer
cert issuer  : CN=wazuh-wpk-ca
payload      : 1074069491 bytes
SIGNATURE    : OK
```

</details>

<details>
<summary>Error handling</summary>

```
root@wazuh-agent1:/home/vagrant# MGR=192.168.56.11:1517
root@wazuh-agent1:/home/vagrant# dl() {                                                
  local KEY ID TS BODY MAC
  KEY=$(awk '{print $4; exit}' /var/ossec/etc/client.keys)
  ID=$(awk  '{print $1; exit}' /var/ossec/etc/client.keys)
  TS=$(date +%s)
  BODY="{\"resource_type\":\"$1\",\"resource_id\":\"$2\"}"; shift 2
  MAC=$(printf 'WAZUH-REQUEST\n1\nPOST\n/download\n%s\n%s\n%s' "$ID" "$TS" "$BODY" \
        | openssl mac -macopt cipher:AES-256-CBC -macopt hexkey:"$KEY" CMAC | tr 'A-Z' 'a-z')
  curl -k -X POST "https://$MGR/download" \
    -H "protocol-version: 1" -H "Authorization: Wazuh $ID:$TS:$MAC" \
    -H "Content-Type: application/json" --data-binary "$BODY" "$@"
}

root@wazuh-agent1:/home/vagrant# dl config no-such-group -i
HTTP/1.1 404 Not Found
Connection: keep-alive
Content-Length: 41
Server: wazuh-manager-remoted
Date: Tue, 04 Aug 2026 07:44:28 GMT
Content-Type: application/json
{"error":"Resource not found","code":404}

root@wazuh-agent1:/home/vagrant# dl wpk nope.wpk -i
HTTP/1.1 404 Not Found
Connection: keep-alive
Content-Length: 41
Server: wazuh-manager-remoted
Date: Tue, 04 Aug 2026 07:44:06 GMT
Content-Type: application/json
{"error":"Resource not found","code":404}

root@wazuh-agent1:/home/vagrant# dl config "../../etc/shadow" -i
HTTP/1.1 400 Bad Request
Connection: keep-alive
Content-Length: 50
Server: wazuh-manager-remoted
Date: Tue, 04 Aug 2026 07:43:40 GMT
Content-Type: application/json
{"error":"Invalid resource identifier","code":400}

root@wazuh-agent1:/home/vagrant# dl config "a/b" -i
HTTP/1.1 400 Bad Request
Connection: keep-alive
Content-Length: 50
Server: wazuh-manager-remoted
Date: Tue, 04 Aug 2026 07:42:46 GMT
Content-Type: application/json
{"error":"Invalid resource identifier","code":400}

root@wazuh-agent1:/home/vagrant# dl config ".." -i
HTTP/1.1 400 Bad Request
Connection: keep-alive
Content-Length: 50
Server: wazuh-manager-remoted
Date: Tue, 04 Aug 2026 07:42:18 GMT
Content-Type: application/json
{"error":"Invalid resource identifier","code":400}

root@wazuh-agent1:/home/vagrant# dl config "" -i
HTTP/1.1 400 Bad Request
Connection: keep-alive
Content-Length: 50
Server: wazuh-manager-remoted
Date: Tue, 04 Aug 2026 07:41:56 GMT
Content-Type: application/json
{"error":"Invalid resource identifier","code":400}

root@wazuh-agent1:/home/vagrant# dl config "web,,servers" -i
HTTP/1.1 400 Bad Request
Connection: keep-alive
Content-Length: 50
Server: wazuh-manager-remoted
Date: Tue, 04 Aug 2026 07:41:25 GMT
Content-Type: application/json
{"error":"Invalid resource identifier","code":400}

root@wazuh-agent1:/home/vagrant# dl config "web-servers," -i
HTTP/1.1 400 Bad Request
Connection: keep-alive
Content-Length: 50
Server: wazuh-manager-remoted
Date: Tue, 04 Aug 2026 07:33:38 GMT
Content-Type: application/json
{"error":"Invalid resource identifier","code":400}
 
root@wazuh-agent1:/home/vagrant# dl wpk package -i
HTTP/1.1 400 Bad Request
Connection: keep-alive
Content-Length: 50
Server: wazuh-manager-remoted
Date: Tue, 04 Aug 2026 07:33:47 GMT
Content-Type: application/json
{"error":"Invalid resource identifier","code":400}

HTTP/1.1 400 Bad Request
Connection: keep-alive
Content-Length: 44
Server: wazuh-manager-remoted
Date: Tue, 04 Aug 2026 07:33:57 GMT
Content-Type: application/json
{"error":"Invalid resource type","code":400}

root@wazuh-agent1:/home/vagrant# dl CONFIG web-servers -i
HTTP/1.1 400 Bad Request
Connection: keep-alive
Content-Length: 44
Server: wazuh-manager-remoted
Date: Tue, 04 Aug 2026 07:37:00 GMT
Content-Type: application/json
{"error":"Invalid resource type","code":400}
```

These are negative tests: the 400/404 **is** the pass condition. Two things are being checked.

*The two failures stay distinguishable.* `404 Resource not found` means "the identifier was well-formed, the file is not there" — an absent group, an unstaged WPK. `400 Invalid resource identifier` means "this could never name anything" — traversal (`../../etc/shadow`), an embedded separator (`a/b`), `..`, empty, a malformed multigroup selector (`web,,servers`, `web-servers,`), a WPK without the `.wpk` suffix. Collapsing them would tell an agent to retry something that can never succeed, and would let a prober use the response to map the manager's filesystem. `400 Invalid resource type` (`CONFIG` in the wrong case, an unknown type) is a third distinct code, so the closed `resource_type` enum is not silently falling back to `config`.

*Rejection happens in the grammar, before any filesystem call.* Every 400 above is refused by `isValidGroupSelector()`/`isValidWpkFilename()`, so no path is ever built from hostile input — containment does not depend on the filesystem behaving. `../../etc/shadow` returning the *same* error as `a/b` is the point: nothing about it is treated as a special case.

All error responses carry `Content-Length` and no `Transfer-Encoding`, which is the buffered half of the chunked-vs-buffered selection below.

</details>

<details>
<summary>Auth rejection</summary>

```
root@wazuh-agent1:/home/vagrant# curl -k -i -X POST "https://$MGR/download" -H "protocol-version: 1" \
  -H "Authorization: Wazuh $ID:$(date +%s):deadbeef" \
  --data-binary '{"resource_type":"config","resource_id":"web-servers"}'
HTTP/1.1 401 Unauthorized
Connection: keep-alive
Content-Length: 52
Server: wazuh-manager-remoted
Date: Tue, 04 Aug 2026 07:55:44 GMT
Content-Type: application/json
{"error":"Invalid client authentication","code":401}

root@wazuh-agent1:/home/vagrant# TS=$(( $(date +%s) - 400 ));
root@wazuh-agent1:/home/vagrant# BODY='{"resource_type":"config","resource_id":"web-servers"}'
root@wazuh-agent1:/home/vagrant#  KEY=$(awk '{print $4; exit}' /var/ossec/etc/client.keys)
root@wazuh-agent1:/home/vagrant# ID=$(awk  '{print $1; exit}' /var/ossec/etc/client.keys)
root@wazuh-agent1:/home/vagrant# MAC=$(printf 'WAZUH-REQUEST\n1\nPOST\n/download\n%s\n%s\n%s' "$ID" "$TS" "$BODY" \
      | openssl mac -macopt cipher:AES-256-CBC -macopt hexkey:"$KEY" CMAC | tr 'A-Z' 'a-z')
root@wazuh-agent1:/home/vagrant# curl -k -i -X POST "https://$MGR/download" -H "protocol-version: 1" \
  -H "Authorization: Wazuh $ID:$TS:$MAC" --data-binary "$BODY"
HTTP/1.1 401 Unauthorized
Connection: keep-alive
Content-Length: 52
Server: wazuh-manager-remoted
Date: Tue, 04 Aug 2026 07:57:03 GMT
Content-Type: application/json
{"error":"Invalid client authentication","code":401}

root@wazuh-agent1:/home/vagrant# dl config web-servers -i -H "protocol-version: 2"
HTTP/1.1 200 OK
Connection: keep-alive
Server: wazuh-manager-remoted
Date: Tue, 04 Aug 2026 07:58:05 GMT
Content-Type: application/octet-stream
Transfer-Encoding: chunked

#web-servers
!76 agent.conf
<agent_config>

  <!-- Shared agent configuration here -->

</agent_config>
!134 web.conf
<agent_config>
  <localfile><location>/var/log/nginx/access.log</location><log_format>syslog</log_format></localfile>
</agent_config>
```

`/download` sits behind the same `AuthMiddleware` as `/stateless`, so these confirm the endpoint
inherits it rather than bypassing it.

*A forged MAC* (`deadbeef`) is `401`, so possession of a valid `client.keys` entry — not merely
reachability of the port — is what admits a request.

*A timestamp 400 s in the past* is `401` even though the MAC is correctly computed with the agent's
real key. The timestamp is inside the signed byte sequence, so a captured request cannot be replayed
once it ages past `auth_max_request_age` (300 s). This is the case that produces the
`expired_request` WARNING seen in the abort evidence below.

> **The third case does not show what it appears to.** `dl` already sends `protocol-version: 1`, so
> `-H "protocol-version: 2"` produced a request carrying *two* such headers while the MAC was still
> computed over version `1`; the server matched and returned `200`. It therefore demonstrates
> duplicate-header handling, not version rejection, and should be re-run with a plain `curl` sending
> a single `protocol-version: 2` header — where the version is part of the signed sequence, so the
> MAC no longer matches and the expected result is `401`.

</details>

<details>
<summary>Chunked vs buffered</summary>

```
root@wazuh-agent1:/home/vagrant# dl config web-servers -D /dev/stderr -o /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0HTTP/1.1 200 OK
Connection: keep-alive
Server: wazuh-manager-remoted
Date: Tue, 04 Aug 2026 07:58:44 GMT
Content-Type: application/octet-stream
Transfer-Encoding: chunked

100   306    0   252  100    54   5478   1173 --:--:-- --:--:-- --:--:--  6800

root@wazuh-agent1:/home/vagrant# dl config no-such-group -D /dev/stderr -o /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0HTTP/1.1 404 Not Found
Connection: keep-alive
Content-Length: 41
Server: wazuh-manager-remoted
Date: Tue, 04 Aug 2026 07:59:06 GMT
Content-Type: application/json

100    97  100    41  100    56    885   1209 --:--:-- --:--:-- --:--:--  2108
```

The central transport claim, on one route. A `200` carries `Transfer-Encoding: chunked` and **no**
`Content-Length`; a `404` carries `Content-Length: 41` and no `Transfer-Encoding`.

That distinction is why `ResponseMode::Streamable` had to be a *registration-time* property. A
builder's output mode is fixed when it is created, and the transport creates the builder at dispatch
— before the handler has decided anything. A streamable route therefore keeps the request handle
instead, and the responder picks the mode once the outcome is known: buffered for an error, chunked
for a transfer. Without that, an error on a streaming route would have to be sent as a one-chunk
chunked response, and every 404 would look to the agent like a zero-length download.

It also matters that the file is opened and `fstat`ed *before* the first byte is written: that
ordering is what makes a missing resource a clean `404` rather than a `200` that dies mid-body.

</details>

<details>
<summary>Concurrency</summary>

```
root@wazuh-agent1:/home/vagrant# for i in $(seq 1 20); do dl wpk huge-signed.wpk -o /dev/null -s -w "$i %{http_code} %{speed_download}\n" & done; wait
[1] 1863
[2] 1865
[3] 1867
[4] 1868
[5] 1870
[6] 1871
[7] 1874
[8] 1876
[9] 1877
[10] 1878
[11] 1879
[12] 1880
[13] 1881
[14] 1883
[15] 1884
[16] 1891
[17] 1894
[18] 1895
[19] 1896
[20] 1897
4 200 33538926
5 200 33531855
20 200 32689196
6 200 32441730
13 200 32287141
12 200 32161210
17 200 31993872
16 200 31740819
11 200 31460648
3 200 31314234
2 200 31289745
15 200 31282360
10 200 31238799
7 200 31202105
18 200 31202495
9 200 31169199
19 200 31145078
14 200 31152416
8 200 31140949
1 200 31101995
[1]   Done                    dl wpk huge-signed.wpk -o /dev/null -s -w "$i %{http_code} %{speed_download}\n"
[2]   Done                    dl wpk huge-signed.wpk -o /dev/null -s -w "$i %{http_code} %{speed_download}\n"
[3]   Done                    dl wpk huge-signed.wpk -o /dev/null -s -w "$i %{http_code} %{speed_download}\n"
[4]   Done                    dl wpk huge-signed.wpk -o /dev/null -s -w "$i %{http_code} %{speed_download}\n"
[5]   Done                    dl wpk huge-signed.wpk -o /dev/null -s -w "$i %{http_code} %{speed_download}\n"
[6]   Done                    dl wpk huge-signed.wpk -o /dev/null -s -w "$i %{http_code} %{speed_download}\n"
[7]   Done                    dl wpk huge-signed.wpk -o /dev/null -s -w "$i %{http_code} %{speed_download}\n"
[8]   Done                    dl wpk huge-signed.wpk -o /dev/null -s -w "$i %{http_code} %{speed_download}\n"
[9]   Done                    dl wpk huge-signed.wpk -o /dev/null -s -w "$i %{http_code} %{speed_download}\n"
[10]   Done                    dl wpk huge-signed.wpk -o /dev/null -s -w "$i %{http_code} %{speed_download}\n"
[11]   Done                    dl wpk huge-signed.wpk -o /dev/null -s -w "$i %{http_code} %{speed_download}\n"
[12]   Done                    dl wpk huge-signed.wpk -o /dev/null -s -w "$i %{http_code} %{speed_download}\n"
[13]   Done                    dl wpk huge-signed.wpk -o /dev/null -s -w "$i %{http_code} %{speed_download}\n"
[14]   Done                    dl wpk huge-signed.wpk -o /dev/null -s -w "$i %{http_code} %{speed_download}\n"
[15]   Done                    dl wpk huge-signed.wpk -o /dev/null -s -w "$i %{http_code} %{speed_download}\n"
[16]   Done                    dl wpk huge-signed.wpk -o /dev/null -s -w "$i %{http_code} %{speed_download}\n"
[17]   Done                    dl wpk huge-signed.wpk -o /dev/null -s -w "$i %{http_code} %{speed_download}\n"
[18]   Done                    dl wpk huge-signed.wpk -o /dev/null -s -w "$i %{http_code} %{speed_download}\n"
[19]-  Done                    dl wpk huge-signed.wpk -o /dev/null -s -w "$i %{http_code} %{speed_download}\n"
[20]+  Done                    dl wpk huge-signed.wpk -o /dev/null -s -w "$i %{http_code} %{speed_download}\n"
```

20 simultaneous 1 GB transfers, all `200`, ~21.5 GB moved at **~635 MB/s aggregate**. The number
that matters is the *spread*, not the total: per-stream rates land between 31.1 and 33.5 MB/s, a
7.8% band, so no transfer starved and none monopolised. That is the property the per-chunk yield
between worker thread and I/O strand buys — a greedy read loop would show a few fast streams and a
long tail. Aggregate throughput is ~60% of the single-stream figure, i.e. the NIC/CPU ceiling rather
than a server-side limit.

</details>

<details>
<summary>Memory under load</summary>

```
root@wazuh-master:/home/vagrant# sudo python3 devel/wazuh/src/remoted/remoted_module/tools/monitor
.py --duration 60
monitoring pid 2006 (port 9443) for 60s, every 0.1s
baseline: RSS 30.9 MiB, 47 threads, 24 fds

  t(s)  RSS MiB  thr   fds  estab   tw  other
   0.0     30.9   47    24      0    0      0

  27.6     30.7   47    26      0    0      0
  27.7     29.4   47    26      0    0      0
  27.8     29.4   47    26      0    0      0
  27.9     29.5   47    26      0    0      0
  28.0     29.5   47    26      0    0      0
  28.1     28.9   47    26      0    0      0
  28.2     28.9   47    26      0    0      0
  28.3     29.0   47    26      0    0      0
  28.5     28.9   47    26      0    0      0
  28.6     29.0   47    26      0    0      0
  28.8     29.0   47    26      0    0      0
  28.9     29.1   47    26      0    0      0
  29.0     29.0   47    26      0    0      0
  29.1     28.9   47    26      0    0      0
  29.2     29.0   47    26      0    0      0
  29.4     29.0   47    26      0    0      0
  30.2     29.1   47    26      0    0      0
  31.5     29.0   47    26      0    0      0
  32.0     28.8   47    24      0    0      0

root@wazuh-agent1:/home/vagrant# dl wpk huge.wpk -o /dev/null -w 'speed=%{speed_download} B/s\n'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--  
100  141M    0  141M  100    48   387M    131 --:--:-- --:--:-- --:--:--  
100  574M    0  574M  100    48   421M     35  0:00:01  0:00:01 --:--:--  
100 1039M    0 1039M  100    48   439M     20  0:00:02  0:00:02 --:--:-- 
100 1512M    0 1512M  100    48   450M     14  0:00:03  0:00:03 --:--:--  
100 1987M    0 1987M  100    48   455M     11  0:00:04  0:00:04 --:--:--  
100 2048M    0 2048M  100    48   455M     10  0:00:04  0:00:04 --:--:--  
461M speed=477614902 B/s
```

2 GiB moved while RSS goes 30.9 → 28.8 MiB and thread count stays pinned at 47: memory is
independent of file size, which is the whole reason for streaming rather than buffering. fds go
24 → 26 → 24, i.e. the transfer's descriptors are released.

Note the `estab`/`tw`/`other` columns read zero throughout — this run predates a fix to
`monitor.py`, whose `--port` defaulted to `9443` while the server listens on `1517`, so the
connection counters were watching the wrong port. RSS, threads and fds come from `/proc/<pid>` and
are unaffected. The default is now `1517`.

</details>

<details>
<summary>Abortion mid-transfer</summary>

```
root@wazuh-agent1:/home/vagrant# dl wpk huge.wpk -o /dev/null --max-time 2 ; echo "curl exit=$?"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  878M    0  878M  100    48   439M     24  0:00:02  0:00:01  0:00:01  439M
curl: (28) Operation timed out after 2000 milliseconds with 921198585 bytes received
curl exit=28

root@wazuh-master:/home/vagrant# sudo ls -l /proc/$(pgrep -f wazuh-manager-remoted)/fd | wc -l
25
root@wazuh-master:/home/vagrant# sudo grep -iE "remoted.*(error|warn)" /var/wazuh-manager/logs/wazuh-manager.log | tail -3
2026/08/03 16:23:03 wazuh-manager-remoted:endpoints: WARNING: Rejected 1 request(s) in the last 90 s whose timestamp fell outside the accepted window (expired_request). Check clock synchronization between the agents and the manager; the window is set by 'auth_max_request_age' and 'auth_max_future_skew'.
2026/08/04 07:57:03 wazuh-manager-remoted:endpoints: WARNING: Rejected 1 request(s) in the last 90 s whose timestamp fell outside the accepted window (expired_request). Check clock synchronization between the agents and the manager; the window is set by 'auth_max_request_age' and 'auth_max_future_skew'.
```

The client walks away at 921 MB of 2 GiB. `ls -l` prints a `total` line, so 25 lines is **24 fds** —
the baseline — meaning the `FileByteSource` was destroyed when the pump dropped it. The two WARNINGs
are pre-existing clock-skew entries from earlier runs, unrelated to the abort: a client
disconnecting mid-download is a normal event, not an error, so silence is the correct behaviour.

`curl` can only report that it gave up (exit 28); it cannot show whether the server emitted a
terminating chunk. A raw-socket client can, and that is the actual correctness property — the peer
must not be able to mistake a truncated transfer for a complete one:

```
root@wazuh-master:/home/vagrant# sudo python3 /tmp/rawframe.py --type wpk --id huge.wpk --abort-after 50000000
decoded bytes    : 50003968
terminator (0\r\n): NO -- truncated transfer
client           : aborted deliberately after 50000000 bytes
```

</details>

<details>
<summary>New chunk-size option</summary>

```
root@wazuh-master:/home/vagrant# cat /var/wazuh-manager/etc/wazuh-manager-internal-options.conf | grep remoted
remoted.http_stream_chunk_size=1048576
root@wazuh-master:/home/vagrant# sudo systemctl restart wazuh-manager
root@wazuh-master:/home/vagrant# sudo python3 /tmp/rawframe.py 001 wpk:huge-signed.wpk | grep -E 'chunk count|steady'
chunk count      : 1025
steady-state size: 1048576 bytes (last chunk 328936 -- the remainder)

root@wazuh-master:/home/vagrant# cat /var/wazuh-manager/etc/wazuh-manager-internal-options.conf | grep remoted
remoted.http_stream_chunk_size=65536
root@wazuh-master:/home/vagrant# sudo systemctl restart wazuh-manager
root@wazuh-master:/home/vagrant# sudo python3 /tmp/rawframe.py 001 wpk:huge-signed.wpk | grep -E 'chunk count|steady'
chunk count      : 16390
steady-state size: 65536 bytes (last chunk 1256 -- the remainder)

root@wazuh-master:/home/vagrant# cat /tmp/rawframe.py 
#!/usr/bin/env python3
"""
Raw-socket client for POST /download: shows the HTTP framing curl hides.

curl decodes `Transfer-Encoding: chunked` transparently, so it cannot tell you the chunk
sizes, the chunk count, or whether the terminating 0-length chunk actually arrived. This
speaks the wire directly and reports all three, while streaming the body (never buffering
it), so it works on a 2 GiB WPK.

It signs exactly like the agent does: AES-CMAC over

    WAZUH-REQUEST\n<version>\n<METHOD>\n<target>\n<agent-id>\n<timestamp>\n<body>

taking the key from client.keys. On the manager that file holds every agent's key, so this
can sign as any of them; on an agent it holds only its own.

Examples
--------
  # Prove chunked framing and see the sizes
  sudo python3 rawframe.py --type config --id default --show-chunks 5

  # Terminator check on a big file, discarding the body
  sudo python3 rawframe.py --type wpk --id huge.wpk

  # Walk away mid-transfer (aborted-download case)
  sudo python3 rawframe.py --type wpk --id huge.wpk --abort-after 50000000

  # Slow reader: small reads, spaced out (per-write timeout must rearm per chunk)
  sudo python3 rawframe.py --type wpk --id test-signed.wpk --trickle-bytes 4096 --trickle-pause 0.05

  # Keep the bytes and compare against the source
  sudo python3 rawframe.py --type wpk --id test-signed.wpk --save /tmp/got.wpk

The older positional form still works, and mixes with the flags above:

  sudo python3 rawframe.py 001 wpk:test-signed.wpk
  sudo python3 rawframe.py 001 config:default --show-chunks 5
"""

import argparse
import hashlib
import json
import os
import socket
import ssl
import subprocess
import sys
import time

CANONICAL_PREFIX = "WAZUH-REQUEST\n"
PROTOCOL_VERSION = "1"
TARGET = "/download"
METHOD = "POST"

DEFAULT_KEYS = "/var/wazuh-manager/etc/client.keys"
AGENT_KEYS = "/var/ossec/etc/client.keys"

# openssl names the CMAC cipher by key length; client.keys stores the key as hex.
CIPHER_BY_HEX_LEN = {32: "AES-128-CBC", 48: "AES-192-CBC", 64: "AES-256-CBC"}


def read_key(keys_path, agent_id=None):
    """Return (id, name, key_hex) from client.keys: the named agent, or the first entry."""
    try:
        with open(keys_path, "r", encoding="utf-8") as handle:
            lines = handle.read().splitlines()
    except PermissionError:
        sys.exit("cannot read %s -- run under sudo" % keys_path)
    except OSError as err:
        sys.exit("cannot read %s: %s" % (keys_path, err))

    for line in lines:
        fields = line.split()
        if len(fields) < 4:
            continue
        if agent_id is None or fields[0] == agent_id:
            return fields[0], fields[1], fields[3]

    sys.exit("no usable entry in %s%s"
             % (keys_path, "" if agent_id is None else " for agent id %s" % agent_id))


def cmac_hex(key_hex, message):
    """AES-CMAC via `openssl mac`, which is what the manager verifies against."""
    cipher = CIPHER_BY_HEX_LEN.get(len(key_hex))
    if cipher is None:
        sys.exit("key is %d hex chars; expected 32, 48 or 64" % len(key_hex))

    cmd = ["openssl", "mac", "-macopt", "cipher:" + cipher,
           "-macopt", "hexkey:" + key_hex, "CMAC"]
    try:
        result = subprocess.run(cmd, input=message.encode(), capture_output=True, check=True)
    except FileNotFoundError:
        sys.exit("openssl not found")
    except subprocess.CalledProcessError as err:
        sys.exit("openssl mac failed: %s" % err.stderr.decode(errors="replace").strip())
    return result.stdout.decode().strip().lower()


def build_request(agent_id, key_hex, host, resource_type, resource_id):
    """Return the raw request bytes an agent would put on the wire."""
    # Signed and sent byte-for-byte identically -- reserialising between the two is the
    # classic way to produce a MAC that verifies against something the server never saw.
    body = json.dumps({"resource_type": resource_type, "resource_id": resource_id},
                      separators=(",", ":"))
    timestamp = str(int(time.time()))

    canonical = CANONICAL_PREFIX + "\n".join(
        [PROTOCOL_VERSION, METHOD, TARGET, agent_id, timestamp, body])
    mac = cmac_hex(key_hex, canonical)

    head = "".join([
        "%s %s HTTP/1.1\r\n" % (METHOD, TARGET),
        "Host: %s\r\n" % host,
        "protocol-version: %s\r\n" % PROTOCOL_VERSION,
        "Authorization: Wazuh %s:%s:%s\r\n" % (agent_id, timestamp, mac),
        "Content-Type: application/json\r\n",
        "Content-Length: %d\r\n" % len(body),
        "Connection: close\r\n\r\n",
    ])
    return head.encode() + body.encode(), body


def connect(host, port, timeout):
    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
    context.check_hostname = False
    context.verify_mode = ssl.CERT_NONE  # self-signed manager certificate
    raw = socket.create_connection((host, port), timeout=timeout)
    return context.wrap_socket(raw, server_hostname=host)


class ChunkReader:
    """
    Incremental `Transfer-Encoding: chunked` parser.

    Streams: it never holds more than one recv() buffer, so a 2 GiB body costs nothing.
    Records every chunk size, because those sizes are what prove the configured chunk size
    reached the wire -- a decoded-body comparison alone would hide it.
    """

    def __init__(self):
        self.buffer = b""
        self.remaining = 0        # bytes left in the current chunk's data
        self.sizes = []
        self.decoded = 0
        self.terminated = False   # saw the 0-length chunk
        self.digest = hashlib.sha256()
        self.malformed = None

    def feed(self, data, sink=None):
        """Consume raw bytes; write decoded payload to `sink` if given."""
        self.buffer += data
        while True:
            if self.terminated or self.malformed:
                return
            if self.remaining > 0:
                take = min(self.remaining, len(self.buffer))
                if take == 0:
                    return
                payload = self.buffer[:take]
                self.buffer = self.buffer[take:]
                self.remaining -= take
                self.decoded += take
                self.digest.update(payload)
                if sink is not None:
                    sink.write(payload)
                if self.remaining == 0:
                    self.expect_crlf = True
                continue

            if getattr(self, "expect_crlf", False):
                if len(self.buffer) < 2:
                    return
                if self.buffer[:2] != b"\r\n":
                    self.malformed = "chunk not followed by CRLF"
                    return
                self.buffer = self.buffer[2:]
                self.expect_crlf = False
                continue

            end = self.buffer.find(b"\r\n")
            if end < 0:
                if len(self.buffer) > 64:
                    self.malformed = "oversized chunk-size line"
                return
            line = self.buffer[:end]
            self.buffer = self.buffer[end + 2:]
            token = line.split(b";", 1)[0].strip()  # drop any chunk extension
            try:
                size = int(token, 16)
            except ValueError:
                self.malformed = "bad chunk size %r" % token
                return
            if size == 0:
                self.terminated = True
                return
            self.sizes.append(size)
            self.remaining = size


def summarise_sizes(sizes, show):
    if not sizes:
        return
    print("chunk count      : %d" % len(sizes))
    distinct = sorted(set(sizes))
    if len(distinct) <= 4:
        print("chunk sizes      : %s" % ", ".join(str(s) for s in distinct))
    else:
        print("chunk sizes      : %d distinct, min %d, max %d"
              % (len(distinct), distinct[0], distinct[-1]))
    body = sizes[:-1] if len(sizes) > 1 else sizes
    if body and len(set(body)) == 1:
        print("steady-state size: %d bytes (last chunk %d -- the remainder)"
              % (body[0], sizes[-1]))
    if show:
        print("first %d sizes    : %s" % (min(show, len(sizes)),
                                          ", ".join(str(s) for s in sizes[:show])))


def apply_positional(parser, args):
    """
    Fold the older `[<agent-id>] <type>:<resource-id>` positional form into the flags.

    Kept because it is what is already in people's shell history. Explicit flags win, so a
    mixed invocation is unambiguous rather than silently order-dependent.
    """
    for token in args.positional:
        if ":" in token:
            resource_type, _, resource_id = token.partition(":")
            if resource_type not in ("config", "wpk"):
                parser.error("unknown resource type %r in %r; expected config: or wpk:"
                             % (resource_type, token))
            if args.resource_type is None:
                args.resource_type = resource_type
            if args.resource_id is None:
                args.resource_id = resource_id
        elif args.agent_id is None:
            args.agent_id = token
        else:
            parser.error("unexpected argument %r" % token)

    missing = [name for name, value in (("--type", args.resource_type),
                                        ("--id", args.resource_id)) if value is None]
    if missing:
        parser.error("missing %s -- pass them as flags, or positionally as `<agent-id> "
                     "<type>:<resource-id>` (e.g. `001 wpk:test-signed.wpk`)"
                     % " and ".join(missing))


def main():
    parser = argparse.ArgumentParser(
        description="Raw-socket POST /download client that reports the chunk framing.")
    parser.add_argument("--host", default="192.168.56.11")
    parser.add_argument("--port", type=int, default=1517)
    parser.add_argument("--type", choices=("config", "wpk"), dest="resource_type")
    parser.add_argument("--id", dest="resource_id",
                        help="group / multigroup selector, or WPK filename")
    parser.add_argument("positional", nargs="*", metavar="[AGENT_ID] TYPE:RESOURCE_ID",
                        help="older positional form, e.g. `001 wpk:test-signed.wpk`")
    parser.add_argument("--keys", help="client.keys path (default: manager's, then agent's)")
    parser.add_argument("--agent-id", help="sign as this agent id (default: first entry)")
    parser.add_argument("--save", help="write the decoded body here")
    parser.add_argument("--show-chunks", type=int, default=0, metavar="N",
                        help="print the first N chunk sizes")
    parser.add_argument("--abort-after", type=int, default=0, metavar="BYTES",
                        help="close the socket after roughly BYTES decoded (aborted transfer)")
    parser.add_argument("--trickle-bytes", type=int, default=65536, metavar="N",
                        help="recv() size (default 65536)")
    parser.add_argument("--trickle-pause", type=float, default=0.0, metavar="SEC",
                        help="sleep between reads, to act as a slow reader")
    parser.add_argument("--timeout", type=float, default=30.0,
                        help="per-read socket timeout in seconds")
    args = parser.parse_args()
    apply_positional(parser, args)

    keys_path = args.keys or (DEFAULT_KEYS if os.path.exists(DEFAULT_KEYS) else AGENT_KEYS)
    agent_id, agent_name, key_hex = read_key(keys_path, args.agent_id)
    request, body = build_request(agent_id, key_hex, args.host,
                                  args.resource_type, args.resource_id)

    print("signing as       : agent %s (%s) from %s" % (agent_id, agent_name, keys_path))
    print("request body     : %s" % body)
    print("target           : https://%s:%d%s" % (args.host, args.port, TARGET))
    print("-" * 72)

    started = time.time()
    sock = connect(args.host, args.port, args.timeout)
    sock.sendall(request)

    head = b""
    while b"\r\n\r\n" not in head:
        piece = sock.recv(8192)
        if not piece:
            break
        head += piece
    if b"\r\n\r\n" not in head:
        sys.exit("connection closed before the response head was complete")
    head, leftover = head.split(b"\r\n\r\n", 1)

    print(head.decode(errors="replace"))
    print("-" * 72)

    lowered = head.decode(errors="replace").lower()
    chunked = "transfer-encoding: chunked" in lowered
    buffered = "content-length:" in lowered
    print("framing          : %s" % ("chunked" if chunked else
                                     ("buffered (Content-Length)" if buffered else "unknown")))

    sink = open(args.save, "wb") if args.save else None
    aborted = False
    try:
        if not chunked:
            # An error response is buffered; just drain and hash it.
            digest = hashlib.sha256()
            total = len(leftover)
            digest.update(leftover)
            if sink:
                sink.write(leftover)
            while True:
                piece = sock.recv(args.trickle_bytes)
                if not piece:
                    break
                total += len(piece)
                digest.update(piece)
                if sink:
                    sink.write(piece)
            print("body bytes       : %d" % total)
            print("body sha256      : %s" % digest.hexdigest())
            if total and total < 4096:
                print("body             : %s" % leftover.decode(errors="replace"))
            return

        reader = ChunkReader()
        reader.feed(leftover, sink)
        while not reader.terminated and not reader.malformed:
            if args.abort_after and reader.decoded >= args.abort_after:
                aborted = True
                break
            try:
                piece = sock.recv(args.trickle_bytes)
            except socket.timeout:
                print("!! read timed out after %.1fs" % args.timeout)
                break
            if not piece:
                break  # server closed
            reader.feed(piece, sink)
            if args.trickle_pause:
                time.sleep(args.trickle_pause)
    finally:
        if aborted:
            sock.close()  # abrupt: the agent walking away mid-transfer
        else:
            try:
                sock.close()
            except OSError:
                pass
        if sink:
            sink.close()

    elapsed = time.time() - started
    print("-" * 72)
    summarise_sizes(reader.sizes, args.show_chunks)
    print("decoded bytes    : %d" % reader.decoded)
    print("terminator (0\\r\\n): %s" % ("YES -- complete transfer" if reader.terminated
                                       else "NO -- truncated transfer"))
    if reader.malformed:
        print("!! framing error : %s" % reader.malformed)
    if aborted:
        print("client           : aborted deliberately after %d bytes" % args.abort_after)
    print("body sha256      : %s" % reader.digest.hexdigest())
    print("elapsed          : %.2fs" % elapsed)
    if elapsed > 0 and reader.decoded:
        print("throughput       : %.1f MiB/s" % (reader.decoded / elapsed / 1048576))
    if args.save:
        print("saved to         : %s" % args.save)


if __name__ == "__main__":
    main()
```

Ties the new internal option to observable behaviour: `1048576` produces 1025 chunks of 1 MiB,
`65536` produces 16390 of 64 KiB, over the same 1 GB file. The decoded body is byte-identical in
both cases — the option changes only how bytes are framed on the wire, never which bytes arrive.

`curl` cannot show this. It decodes `Transfer-Encoding: chunked` transparently, so the chunk sizes,
the chunk count and the presence of the terminating 0-length chunk are all invisible to it; a
`sha256sum` of the output would be identical whatever the framing. The raw-socket client above
parses the framing itself and reports all three, while never buffering the body, so the same tool
works against a 2 GiB file.

Note the manager reads internal options **only** from
`/var/wazuh-manager/etc/wazuh-manager-internal-options.conf` (`defs.h` defines `WAZUH_LDEFINES` per
`#ifdef CLIENT`, and leaves `WAZUH_DEFINES` undefined for the manager). Settings placed in
`local_internal_options.conf` — the agent's file — are silently ignored, and `_read_file()` returns
the **first** matching line, so appending a second entry for the same option has no effect.

</details>

<details>
<summary>Unit tests</summary>

```
root@wazuh-master:/home/vagrant/wazuh/src/build# ctest -R remoted_module_utest -V
...
100% tests passed, 0 tests failed out of 1

Label Time Summary:
remoted_module_utest    =  11.93 sec*proc (1 test)

Total Test time (real) =  11.93 sec
```

203 tests over 36 suites. To reproduce, stop `wazuh-manager` first: `RemotedModuleTest` binds port
1514 for real, so a running manager makes those four cases fail with `bind: Address already in use`.

</details>

<details>
<summary>ASan tests</summary>

```
$ cmake -DUNIT_TEST=ON \
    -DCMAKE_CXX_FLAGS="-g -fsanitize=address -fsanitize=undefined -fsanitize=leak" \
    -DCMAKE_C_FLAGS="-g -fsanitize=address -fsanitize=undefined -fsanitize=leak" ..
$ cmake --build . --target remoted_module_utest
$ ./remoted/remoted_module/test/remoted_module_utest \
      --gtest_filter='HttpServerStreamingTest.*:ShutdownRace.*'
[ RUN      ] HttpServerStreamingTest.StreamsAMultiChunkBodyByteExactly
[       OK ] HttpServerStreamingTest.StreamsAMultiChunkBodyByteExactly (62 ms)
[ RUN      ] HttpServerStreamingTest.ChunkSizeFollowsTheConfiguredValue
[       OK ] HttpServerStreamingTest.ChunkSizeFollowsTheConfiguredValue (62 ms)
[ RUN      ] HttpServerStreamingTest.AbortedTransferSendsNoTerminatorAndReleasesTheSource
[       OK ] HttpServerStreamingTest.AbortedTransferSendsNoTerminatorAndReleasesTheSource (405 ms)
[ RUN      ] HttpServerStreamingTest.HealthyTransferOutlastingTheRequestTimeoutIsNotCut
[       OK ] HttpServerStreamingTest.HealthyTransferOutlastingTheRequestTimeoutIsNotCut (2652 ms)
[ RUN      ] HttpServerStreamingTest.TrickleReaderKeepsTheTransferAliveBeyondTheWriteTimeout
[       OK ] HttpServerStreamingTest.TrickleReaderKeepsTheTransferAliveBeyondTheWriteTimeout (6334 ms)
[ RUN      ] ShutdownRace.StopSequenceSurvivesAnInFlightForward
[       OK ] ShutdownRace.StopSequenceSurvivesAnInFlightForward (106 ms)
[ RUN      ] ShutdownRace.StopSequenceSurvivesAnInFlightStream
[       OK ] ShutdownRace.StopSequenceSurvivesAnInFlightStream (151 ms)
[==========] 7 tests from 2 test suites ran. (9776 ms total)
[  PASSED  ] 7 tests.
$ echo $?
0
```

Exit code `0` with no LeakSanitizer report is the assertion here — LSan runs at process exit, *after*
gtest has already printed `PASSED`, so a green gtest summary alone does not mean a clean ASan run.

An earlier revision of `AbortedTransferSendsNoTerminatorAndReleasesTheSource` did leak, and CI caught
it: its "server is still healthy" follow-up read only 16 KiB of a 16 MiB payload, making it a *second*
aborted transfer whose pump was still in flight when `server->stop()` ran — leaking the pump, its
source, the chunk buffer and the connection's OpenSSL allocations (~17 MB). The follow-up now reads
to completion and asserts the payload arrives intact with its terminator, which is the stronger
health check regardless.

Built with `-fsanitize=address,undefined,leak`. These two suites are the ones worth sanitising: a
streamed response is the only path that hands a buffer between a worker thread and the connection's
I/O strand, repeatedly, for the whole duration of a transfer — and then has to survive teardown
while a transfer is still in flight. That is a use-after-free shape a plain build will usually run
straight past, because the freed memory is still mapped and still holds plausible bytes.

`ShutdownRace.StopSequenceSurvivesAnInFlightStream` is the specific case: `stopAccepting()` drains
the handler pool, but a `StreamPump` that has already handed a chunk to the strand has its
continuation queued somewhere neither phase 1 nor phase 3 of the shutdown sequence knows about.
Before this PR that was only argued for in a comment ("RESTinio guarantees the write callback always
fires"); it is now executed, and executed under ASan.

</details>

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux — every module source compiles clean with `-Wall -Wextra`; each commit verified to
        build standalone in a detached worktree
  - [ ] Windows — N/A, manager-only component
  - [ ] MAC OS X — N/A, manager-only component
- [x] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity — not run
  - [ ] Valgrind (memcheck and descriptor leaks check) — not run; descriptor release on aborted
        transfers covered by the abort evidence above
  - [x] AddressSanitizer — `HttpServerStreamingTest.*` and `ShutdownRace.*` under
        `-fsanitize=address,undefined,leak`, 7/7 clean (evidence above). These are the two suites
        where a streamed transfer's worker-thread ↔ I/O-strand handoff could leave a dangling
        buffer, which is the failure mode a plain build would not surface.

### Artifacts Affected

- `libremoted_module.so` (manager) — transport and endpoint
- `wazuh-manager-remoted` (manager) — `secure.c` reads the two internal options above
- New: `src/remoted/remoted_module/tools/send_download.py` and `tools/monitor.py`
  (development/test tools, not packaged)
- New: `test/unit/testTlsServer.hpp` — TLS test fixtures extracted from `shutdownRace_test.cpp` so
  the streaming tests share one signed client instead of growing a second copy

### Configuration Changes

Two internal options in `/var/wazuh-manager/etc/wazuh-manager-internal-options.conf`. **No default
behaviour changes** — both resolve to the value that was previously compiled in.

| Option | Default | Range | Status |
| --- | --- | --- | --- |
| `remoted.http_stream_chunk_size` | `65536` | 4096–1048576 | New |
| `remoted.http_max_parallel_connections` | `512` | 1–8192 | Previously hardcoded, now settable |

Both are documented in `docs/ref/modules/remoted/configuration.md` alongside the existing
`remoted.http_*` options. They are deliberately *not* added to any shipped `.conf`: manager defaults
live in code via `getDefine_Int_default()`, and `wazuh-manager-internal-options.conf` is an
overrides-only file that survives upgrades — shipping a default in it would pin that value forever.

The endpoint itself introduces no `<remote>` configuration; it reuses the HTTPS settings already in
place.

### Tests Introduced

`test/unit/downloadEndpoint_test.cpp` — 44 tests over the endpoint's pure surface plus the handler
end to end against temporary directories:

- `parseRequest`: valid config/wpk; missing, extra and wrong-typed members; non-object; empty;
  truncated; over the 4 KiB pre-parse cap; deeply nested input (asserts iterative parsing does not
  overflow the stack); unknown and wrongly-cased `resource_type`.
- Resource-id grammars: wazuh's group charset; multigroup selectors including leading, trailing and
  doubled separators; a traversable entry anywhere in a selector; `.`/`..`; embedded NUL; backslash;
  non-ASCII; over-length; WPK suffix and charset rules.
- `multigroupDirName`: pinned against the directories a live manager created (`97d66859` for
  `web-servers,databases`, `76ba5a3b` for `alpha,beta`), plus order sensitivity, so nobody "fixes"
  it by sorting.
- `locateResource`: single group, multigroup selector, WPK, injected base directories.
- `FileByteSource`: sub-chunk, multi-chunk and exactly-aligned files; empty file; zero-capacity read;
  missing file; a directory (`open(O_RDONLY)` on one succeeds on Linux, so the `S_ISREG` check is
  what makes it a 404); a symlink refused by `O_NOFOLLOW`; a read error throwing rather than looking
  like end-of-stream.
- Mid-transfer modification, one case per detection path: the file truncated (EOF arrives before the
  length at open), the file grown (a WPK still being staged), and the file rewritten to the *same*
  length (invisible to the byte count, caught by mtime) — each must throw rather than report a clean
  end-of-stream. Plus an untouched file streaming to completion, so the detection cannot fire on a
  normal transfer.
- Handler: 400 on a malformed body; 404 when the resolved file is absent; streams the named group;
  streams the effective config for a multigroup selector; streams a staged WPK; `Content-Type` and
  chunked-vs-buffered selection.

`test/unit/httpServer_test.cpp` — 5 `HttpServerStreamingTest` cases driving a real TLS client
against a live server, because chunk framing only exists on the wire:

- `StreamsAMultiChunkBodyByteExactly` — decoded body equals the source across many chunks.
- `ChunkSizeFollowsTheConfiguredValue` — the configured size reaches the wire; a decoded-body
  comparison alone would hide it.
- `AbortedTransferSendsNoTerminatorAndReleasesTheSource` — a client walking away leaves no
  terminating chunk (so the peer cannot mistake a partial file for a complete one) and drops the
  source.
- `HealthyTransferOutlastingTheRequestTimeoutIsNotCut` — a transfer longer than
  `http_request_timeout` is not torn down, since the per-write timeout rearms per chunk.
- `TrickleReaderKeepsTheTransferAliveBeyondTheWriteTimeout` — same property against a deliberately
  slow reader, i.e. a real agent on a poor link.

`test/unit/shutdownRace_test.cpp` — `StopSequenceSurvivesAnInFlightStream`: a streamed response is
the one path that bounces worker-pool ↔ connection-strand *outside* the `DeferredForwarder` the
four-phase shutdown drains, so teardown mid-transfer is the use-after-free shape this file exists to
catch. Previously only argued for in a comment; now executed, and under ASan.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented — two internal options, in
      `docs/ref/modules/remoted/configuration.md`
- [x] Developer documentation reflects the changes — `remoted_module/README.md` gains a
      *Streamed responses* section covering the pull-based `IByteSource`, `ResponseMode`, the abort
      semantics and resource resolution
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues


