### PR TITLE
Remove startup deprecation warning from agent_upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Fixed wazuh-db exiting the worker thread instead of closing the peer socket when an oversized message is received. ([#37850](https://github.com/wazuh/wazuh/pull/37850))
 - Improved SCA policy source validation to correctly enforce the `sca.remote_commands` restriction. ([#37953](https://github.com/wazuh/wazuh/pull/37953))
 - Added a minimum length check for legacy-format agent messages in `wazuh-remoted`. ([#38099](https://github.com/wazuh/wazuh/pull/38099))
+- Fixed a spurious `StarletteDeprecationWarning` printed by `agent_upgrade` at startup. ([#38085](https://github.com/wazuh/wazuh/pull/38085))
 
 ### Agent
 

--- a/framework/scripts/agent_upgrade.py
+++ b/framework/scripts/agent_upgrade.py
@@ -5,11 +5,22 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import argparse
+import warnings
 from asyncio import run
 from os.path import dirname
 from signal import signal, SIGINT
 from sys import exit, path, argv
 from time import sleep
+
+from starlette.exceptions import StarletteDeprecationWarning
+
+# Importing connexion pulls in `starlette.testclient`, which warns when `httpx2` is not
+# installed. Starlette attributes the warning to the importer, so filter by message, not module.
+warnings.filterwarnings(
+    'ignore', category=StarletteDeprecationWarning,
+    message=r'Using `httpx` with `starlette\.testclient` is deprecated',
+)
+
 from connexion import ProblemException
 
 # Set framework path


### PR DESCRIPTION
## Description

Closes #38084.

Running `agent_upgrade` on a 4.14.x manager prints a `StarletteDeprecationWarning` before the command output. `agent_upgrade` imports `connexion` at startup, `connexion` imports `starlette.testclient` on package import, and starlette warns because the manager ships `httpx` but not `httpx2`. This is the 4.x counterpart of #37501, fixed in 5.0.0 by #37509.

## Proposed Changes

- Register a `warnings` filter for that specific message in `framework/scripts/agent_upgrade.py` before importing `connexion`. Same approach as #37509; in 4.x the filter lives in the script itself because the `agent_upgrade` import chain never loads the `api` package where the 5.0.0 filter is registered. `cluster_control` is not affected in 4.x for the same reason.
- Changelog entry for v4.14.8.

### Results and Evidence

Observed on a live v4.14.7 manager (see #38084). Reproduction below runs the actual script with the framework pinned dependencies (`connexion==3.1.0`, `httpx==0.26.0`, `starlette==1.3.1`) in a clean virtualenv; the `wazuh` package is not installed, so the script exits right after the import block, which is where the warning triggers.

Before (script as shipped in 4.14.8):

```
$ python3.11 agent_upgrade_before.py
.../site-packages/connexion/apps/abstract.py:9: StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.
  from starlette.testclient import TestClient
Error importing 'Wazuh' package.

No module named 'wazuh'
```

After (this PR):

```
$ python3.11 framework/scripts/agent_upgrade.py
Error importing 'Wazuh' package.

No module named 'wazuh'
```

### Artifacts Affected

- `framework/scripts/agent_upgrade.py` (wazuh-manager packages)

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None. The change only registers a warnings filter at CLI startup.

## Review Checklist
- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
