### PR TITLE
Close the SCA DBSync connection on module stop

### DIFF
--- a/src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp
+++ b/src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp
@@ -69,6 +69,10 @@ class SecurityConfigurationAssessment
         /// @brief Releases owned resources after the sync worker thread has exited.
         /// Must be called only after all threads that may use those resources
         /// (in particular the sync worker thread) have been joined.
+        /// @note Every member that holds a copy of m_dBSync must be reset here (currently
+        /// m_syncManager). Missing one keeps the DBSync refcount above zero, so the SQLite
+        /// connection to sca.db is neither committed nor closed and the database stays locked
+        /// for the next process.
         void releaseResources();
 
         /// @copydoc IModule::Name
@@ -268,6 +272,8 @@ class SecurityConfigurationAssessment
         std::shared_ptr<IDBSync> m_dBSync;
 
         /// @brief SCA sync manager (document limits)
+        /// @note Co-owns m_dBSync (it is constructed with a copy of it), so it must be reset in
+        /// releaseResources() for the sca.db connection to actually be closed.
         std::shared_ptr<SCASyncManager> m_syncManager;
 
         /// @brief Function for pushing stateless event messages

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -376,10 +376,29 @@ void SecurityConfigurationAssessment::releaseResources()
 
     std::unique_lock<std::shared_mutex> lock(m_resourcesMutex);
 
+    // Release the sync manager first: it was constructed with a copy of m_dBSync (see the
+    // constructor), so it co-owns the DBSync handle. Resetting m_dBSync alone leaves that copy
+    // alive, ~SQLiteDBEngine never runs, and the standing write transaction on sca.db is never
+    // committed nor the connection closed -- so the file stays locked until the OS tears the
+    // process down and the next agent process fails with "database is locked" (issue #38069).
+    m_syncManager.reset();
+
     // Explicitly release DBSync before static destruction to avoid use-after-free
     // during shutdown when DBSyncImplementation singleton may be destroyed first.
+    // This must drop the last reference, otherwise the database is not closed here: every
+    // member holding a copy of m_dBSync has to be reset above (see releaseResources() in the
+    // header). It cannot be left to ~SecurityConfigurationAssessment, which never runs because
+    // SCA::~SCA releases the impl to avoid teardown races at process exit.
     // Must be called only after the sync worker thread has been joined, because
     // synchronizeDatabaseSnapshot() uses m_dBSync without holding any mutex.
+    if (m_dBSync && m_dBSync.use_count() > 1)
+    {
+        LoggingHelper::getInstance().log(
+            LOG_WARNING,
+            "SCA database is still referenced by " + std::to_string(m_dBSync.use_count() - 1) +
+            " other owner(s); it will not be closed until the process exits.");
+    }
+
     m_dBSync.reset();
 
     // Destroy the sync protocol so its SQLite connection to sca_sync.db is closed
@@ -389,7 +408,9 @@ void SecurityConfigurationAssessment::releaseResources()
     // thread and the SCA run loop have already exited (see wm_sca_start teardown),
     // mirroring Syscollector::releaseResources(); the entry points still reachable from
     // other threads (wcom queries and sync responses, agent-info's in-process
-    // coordination queries) are excluded by the lock, which they take shared.
+    // coordination queries) are excluded by the lock, which they take shared -- except
+    // setSyncLimit(), which takes no lock because it runs on the module thread before the
+    // run loop starts (its only caller is wm_sca_start).
     m_spSyncProtocol.reset();
 }
 

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp
@@ -778,3 +778,74 @@ TEST_F(ScaTest, ExecuteFlushSync_GenuineFailureKeepsError)
     EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("deferred")));
     EXPECT_THAT(m_logOutput, ::testing::Not(::testing::HasSubstr("times in a row")));
 }
+
+// releaseResources() must drop *every* owner of the DBSync handle held by the module, not just
+// m_dBSync: SCASyncManager is constructed with a copy of it, so a reset that misses the manager
+// leaves the refcount above zero, ~SQLiteDBEngine never runs and sca.db stays locked.
+// The module instance is deliberately kept alive across the assertion because in production it is
+// never destroyed (SCA::~SCA releases it), so releaseResources() is the only thing that can close
+// the database.
+TEST_F(ScaTest, ReleaseResources_DropsEveryDbSyncOwner)
+{
+    auto mockDBSync = std::make_shared<MockDBSync>();
+    const std::weak_ptr<IDBSync> dbSyncWatcher = mockDBSync;
+
+    SCAMock scaMock(mockDBSync, nullptr);
+    mockDBSync.reset();
+
+    ASSERT_FALSE(dbSyncWatcher.expired());
+
+    scaMock.releaseResources();
+
+    EXPECT_TRUE(dbSyncWatcher.expired());
+}
+
+// End-to-end form of the same bug, asserting on the symptom reported in #38069: DBSync writes go
+// into a long-lived transaction that only ~SQLiteDBEngine commits, so while any owner survives the
+// database file stays under a RESERVED lock and the next connection fails with
+// "sqlite: database is locked" -- which on Windows is the incoming agent process after a WPK upgrade.
+TEST_F(ScaTest, ReleaseResources_ReleasesSqliteWriteLock)
+{
+    const auto dbPath = makeTempPath();
+    auto dbSync = std::make_shared<DBSync>(
+                      HostType::AGENT,
+                      DbEngineType::SQLITE3,
+                      dbPath,
+                      kCreateStatement,
+                      DbManagement::PERSISTENT);
+
+    SCAMock scaMock(dbSync, nullptr);
+
+    // Writing inside DBSync's standing transaction takes the RESERVED lock on the database file.
+    insertRow(dbSync, "sca_policy",
+    {
+        {"id", "policy-1"},
+        {"name", "Policy 1"},
+        {"file", "policy.yml"},
+        {"description", "Policy description"},
+        {"refs", "https://example.com"}
+    });
+
+    dbSync.reset();
+    scaMock.releaseResources();
+
+    // A second connection stands in for the incoming agent process: it must be able to open the
+    // database and write to it immediately.
+    std::shared_ptr<DBSync> reopened;
+    ASSERT_NO_THROW(reopened = std::make_shared<DBSync>(
+                                   HostType::AGENT,
+                                   DbEngineType::SQLITE3,
+                                   dbPath,
+                                   kCreateStatement,
+                                   DbManagement::PERSISTENT));
+    EXPECT_NO_THROW(insertRow(reopened, "sca_policy",
+    {
+        {"id", "policy-2"},
+        {"name", "Policy 2"},
+        {"file", "policy2.yml"},
+        {"description", "Policy description"},
+        {"refs", "https://example.com"}
+    }));
+
+    reopened->closeAndDeleteDatabase();
+}


### PR DESCRIPTION
## Description

The 2026-07-29 nightly reported the following on a `windows_server-2012r2-amd64` agent running `5.0.0-rc1-c480ca9`, logged twice about two seconds after the departing process had already announced `Exit completed successfully`:

```
2026/07/29 04:20:14 wazuh-modulesd:sca: ERROR: Error synchronizing data with DBSync: sqlite: database is locked
```

`SecurityConfigurationAssessment::releaseResources()` resets `m_dBSync`, but `m_syncManager` is constructed with a copy of that `shared_ptr` (`m_syncManager(std::make_shared<SCASyncManager>(m_dBSync))`) and therefore co-owns the DBSync handle. Because `m_syncManager` was never reset, the reference count never reached zero and `~DBSync` never ran, so `~SQLiteDBEngine` never ran either — and that destructor is the only place the long-lived write transaction is committed and the `sqlite3` handle closed. `~SecurityConfigurationAssessment` does not cover the gap because it never runs: `SCA::~SCA()` deliberately releases the impl to avoid teardown races at process exit. The net effect is that `queue/sca/db/sca.db` stays under a `RESERVED` lock until the OS tears the process down.

On Windows every module is a thread inside a single `wazuh-agent.exe`, so a restart can put two agent processes side by side, and the departing one keeps the lock past the point where the SCM has already launched its replacement. The nightly logs show exactly that: at the failing restart the departing process was still writing to the log a second *after* the new `Started (pid: 2492)` line. No `sqlite3_busy_timeout` or busy handler is configured on the DBSync connection, so the incoming process's first write — the `UPDATE <table> SET db_status=0` issued while constructing the `DBSyncTxn` in `SCAPolicyLoader::SyncWithDBSync`, which lands about two seconds into startup once all policy YAML has been parsed — fails immediately rather than waiting. The exception is caught and logged, an empty delta map is returned, and `sca_policy`/`sca_check` are not refreshed, so no SCA stateful events reach the manager for that cycle. It self-heals on the next scan, which means the observable cost is one `<interval>` (12 hours by default) with no SCA state synchronized.

The failing restart is worth naming precisely, because it is not the one the issue title suggests. It is the plain `Restart-Service -Name wazuh` issued by `test_upgrade_processes_restarted` in `test_00_setup_upgrade.py`, about two and a half minutes after the WPK upgrade — not the upgrade restart itself, which shows an 8 second gap and is clean. Of the five restarts in that run only this one has the departing and incoming processes landing in the same second.

This is the residual half of #37629. The fix in #37841 made the sync-protocol database (`sca_sync.db`, via `PersistentQueueStorage`) close before `stop()` returns, and the attached nightly logs confirm that half is holding — no `PersistentQueueStorage` or `Failed to initialize persistent queue` errors appear on any Windows platform. Only the DBSync connection to `sca.db` was missed. `a479a4183d` (the #37841 merge) is an ancestor of the build under test, `c480ca93a0`, so this is an incomplete fix rather than a stale build.

The same class of bug does not exist in the sibling modules: Syscollector holds its handle in a `unique_ptr` and resets every holder in `releaseResources()`, FIM's `DBSyncHandler()` copies are all consumed as temporaries, and agent-info has a single owner reset under `m_dbSyncMutex`. No sweep is needed.

## Proposed Changes

- `src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp` — reset `m_syncManager` in `releaseResources()`, inside the existing exclusive `m_resourcesMutex` lock and before `m_dBSync.reset()`, so the reset drops the last owner and `~SQLiteDBEngine` commits the standing transaction and closes the connection while the process is still healthy. This also restores the ordering that `wm_sca_stop` already assumed: `wm_sca_release_and_signal` performs the release before signalling `sca_stop_condition`, so the module is now only reported as stopped once `sca.db` is actually closed.
- `src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp` — log a `WARNING` naming the number of remaining owners if `m_dBSync.use_count()` is still greater than one at the reset. In production the only owners are these two members (the `SCAPolicyLoader` and `SCAEventHandler` copies are stack-scoped locals and the run loop has already exited), so this can only fire on a genuine regression, surfacing a future hidden reference as a log line instead of as a Windows-only field failure. It did not fire in any of the ~30 shutdowns measured on Windows Server 2012 R2.
- `src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp` — correct the comment that claimed every other entry point takes `m_resourcesMutex` shared. `setSyncLimit()` takes no lock at all; the comment now records that and why it is safe (it runs on the module thread before the run loop starts, and its only caller is `wm_sca_start`).
- `src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp` — document the ownership invariant on `releaseResources()` (every member holding a copy of `m_dBSync` must be reset there) and annotate `m_syncManager` as a co-owner of `m_dBSync`. `SCASyncManager` and the `m_dBSync` reset were introduced by different changes, which is how the gap opened; recording the invariant is what keeps the next refactor from reintroducing it.

### Results and Evidence

#### Unit tests

Both new tests were written before the fix and verified red against it, by stashing only the two source files and keeping the tests, so the red/green transition is real and not an artifact of rebuilding.

| Test | Before the fix | After the fix |
|---|---|---|
| `ScaTest.ReleaseResources_DropsEveryDbSyncOwner` | FAILED — `dbSyncWatcher.expired()` actual `false`, expected `true` | OK |
| `ScaTest.ReleaseResources_ReleasesSqliteWriteLock` | FAILED — `throws SQLite::sqlite_error with description "sqlite: database is locked"` | OK (3 ms) |

The failure of the second test is byte-identical to the error reported in the issue, which is what makes it a direct regression guard rather than a proxy for one:

```
/workspaces/devcontainer-5x/wazuh/src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp:841: Failure
Expected: insertRow(reopened, "sca_policy", { ... }) doesn't throw an exception.
  Actual: it throws SQLite::sqlite_error with description "sqlite: database is locked".
```

Full SCA suite green after the fix, `TARGET=agent`, 16 test binaries and 335 tests. The two SCA targets not listed (`registry_rule_evaluator_unit_test`, `sca_win_helpers_unit_test`) are Windows-only and are not built for this target.

```
sca_unit_test                    -> [  PASSED  ] 28 tests.
sca_event_handler_unit_test      -> [  PASSED  ] 61 tests.
directory_rule_evaluator_unit_test -> [  PASSED  ] 34 tests.
sca_recovery_utils_unit_test     -> [  PASSED  ] 32 tests.
sca_utils_unit_test              -> [  PASSED  ] 28 tests.
sca_recovery_unit_test           -> [  PASSED  ] 20 tests.
file_rule_evaluator_unit_test    -> [  PASSED  ] 18 tests.
sca_checksum_unit_test           -> [  PASSED  ] 17 tests.
sca_policy_loader_unit_test      -> [  PASSED  ] 16 tests.
rule_creation_unit_test          -> [  PASSED  ] 16 tests.
sca_policy_parser_unit_test      -> [  PASSED  ] 15 tests.
command_rule_evaluator_unit_test -> [  PASSED  ] 14 tests.
check_condition_evaluator_unit_test -> [  PASSED  ] 9 tests.
process_rule_evaluator_unit_test -> [  PASSED  ] 9 tests.
sca_dataclean_unit_test          -> [  PASSED  ] 9 tests.
sca_sync_manager_unit_test       -> [  PASSED  ] 9 tests.
```

#### On the failing platform: Windows Server 2012 R2, signed CI packages

Measured on the platform that failed in the nightly, driving `Restart-Service -Name wazuh` under CPU and disk load, with the stock 4.x agent configuration a WPK upgrade preserves. The metric is when `sca.db` actually becomes writable again, sampled with `PRAGMA busy_timeout=0; BEGIN IMMEDIATE;` (an ordinary file open is useless — SQLite uses advisory byte-range locks, so opening the file for write succeeds while it is locked). Five restarts per build:

| | pre-fix `5.0.0-rc1 090eaf0` | post-fix `5.0.0-rc1 a5b23f0` |
|---|---|---|
| release, ms after the restart is issued | mean **1747**, range 1076–2436 | mean **854**, range 639–998 |
| release relative to `SCA module stopped` | mean +1919 ms | mean +1142 ms |
| release relative to `Exit completed successfully` | **after it in 5 of 5** (+197 to +714 ms) | after it in only 2 of 5 (−882 to +809 ms) |

The two release-time ranges are fully disjoint: the earliest pre-fix release, 1076 ms, is later than the latest post-fix one, 998 ms. An all-or-nothing split like that between two groups of five arises from ordering alone with probability 1/252. The one confound we could identify runs against the effect rather than for it — `a5b23f0` happens to ship a slightly larger CIS policy, 983810 bytes against 970052.

The qualitative change is the row that matters for this issue: pre-fix the database is released *after* the process has announced `Exit completed successfully`, i.e. at teardown, which is what leaves it locked while a replacement is already running. Post-fix it is released during the module stop.

An earlier A/B on Windows 11 was reported as negative in the issue and that verdict was wrong. It used "was the database free while the service was still `StopPending`" as the discriminator, which is binary and answers no on both builds for reasons unrelated to this change.

#### Instrumented confirmation that `releaseResources()` is what closes the file

A throwaway build (`diag/38069-release-resources-timing`, not for merge) added unconditional log lines around the reset plus a `weak_ptr` to observe whether `~DBSync` actually ran. Ten shutdowns on 2012 R2, identical every time:

```
16:45:45  SCA module stopped.
16:45:46  DIAG releaseResources: entered
16:45:46  DIAG releaseResources: flush controller released
16:45:46  DIAG releaseResources: about to reset m_dBSync, use_count=1
16:45:46  DIAG releaseResources: m_dBSync reset, dbsync destroyed=yes
16:45:46  DIAG releaseResources: done
16:45:46  Exit completed successfully.          (lock sampled free at 16:45:46.500)
```

`use_count=1` in 10 of 10 confirms no owner survives, so the reset added here really is the last one. `destroyed=yes` in 10 of 10 confirms `~DBSync` and `~SQLiteDBEngine` run at that point rather than being skipped. And the lock is observed free inside the same second, which pins the close to this function rather than to process teardown.

That run also settled two incidental questions: a real Windows service stop never enters `SecurityConfigurationAssessment::Stop()` — `releaseResources()` is called directly from `wm_sca_release_and_signal()` — and the ~1 s that still elapses between `SCA module stopped.` and the release is spent *before* this function is entered, in `wm_sca_main`'s join of the SCA sync worker (see notes for reviewers).

#### What is not evidenced

We did not reproduce the reported message on a VM, on either build, across 33 soak cycles plus four instrumented configurations. Two agent processes coexisted in 33 of 33 cycles, for up to 4228 ms, and we twice sampled two processes alive with `sca.db` locked — but the incoming process's first write never landed inside the window, closest approach 89 ms. The reason is quantitative: our departing process exits about half a second after `Exit completed successfully`, where the nightly's lingered one to two seconds. Full detail is in the issue.

### Artifacts Affected

- `wazuh-modulesd` (agent) — SCA module. Agent-side only; no manager artifact is touched, and `shared_modules/dbsync` is unchanged.

### Configuration Changes

None.

### Documentation Updates

None. The changes to the header are in-code documentation of the ownership invariant.

### Tests Introduced

Two unit tests in `src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp`, extending the existing `ScaTest` fixture. No CMake change was needed; `sca_unit_test` already compiles this file. There was previously no coverage of `releaseResources()` anywhere in the SCA, Syscollector or agent-info test suites, which is how this survived the review of #37841.

Both tests deliberately keep the module instance alive across the assertion. In production the impl is never destroyed, so `releaseResources()` alone has to be what closes the database; letting `~SCAMock` run first would make both tests pass vacuously by destroying `m_syncManager` as a member.

- `ReleaseResources_DropsEveryDbSyncOwner` — captures a `weak_ptr` to the DBSync mock, drops the test's own strong reference, and asserts the pointer is expired after `releaseResources()` returns. Beyond guarding the specific missed reset, this asserts the general invariant that no owner survives the call, so it would also catch a third owner added later.
- `ReleaseResources_ReleasesSqliteWriteLock` — the end-to-end form. It writes through a real `DBSync` to dirty the standing transaction and take the `RESERVED` lock, calls `releaseResources()`, then opens a second connection to the same file and writes to it, standing in for the incoming agent process. SQLite arbitrates two connections within one process the same way it arbitrates two processes, so this is deterministic and needs no second process, no sleeps and no Windows host.

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

## Notes for reviewers

Four related items were deliberately left out, each of which needs its own issue.

**`wm_sca.c:747` — `WaitForSingleObject(sca_sync_worker_thread, INFINITE)`.** `releaseResources()` is not reached until `wm_sca_main` has joined the SCA sync worker, so `sca.db` stays locked for the whole join. With an idle worker that is bounded at one second by its `sleep(1)` poll (`wm_sca.c:953`), which is the ~1 s still visible after this fix. But if the stop arrives while the worker is inside `sca_sync_module_ptr(MODE_DELTA)`, the join waits for that entire synchronization — bounded only by `sca_sync_response_timeout` (60 s) × `SCA_SYNC_RETRIES` (3) — and reopens the same window this PR closes. Not the cause of #38069 (the nightly's worker was asleep: its previous sync finished at 04:17:28 and `sync_interval` defaults to 300 s), but the same failure class and arguably the more dangerous one.

**`sqlite3_busy_timeout` on the DBSync connection.** We implemented `PRAGMA busy_timeout = 5000` and it is provably ineffective, so it should not be proposed as a substitute for this fix. DBSync holds a long-lived deferred `BEGIN` and reads through it, so a write must promote SHARED to RESERVED, and SQLite deliberately skips the busy handler for a promotion that could deadlock. Measured against plain SQLite with a holder on RESERVED: deferred + `SELECT` + write (what DBSync does) fails in **0 ms**; write as the first statement waits the full **5003 ms**; `BEGIN IMMEDIATE` + timeout succeeds in **328 ms**; WAL + deferred + `SELECT` + write fails in **0 ms** with `SQLITE_BUSY_SNAPSHOT`. Surviving a conflict needs a transaction-strategy change across all four agent consumers (FIM, syscollector, SCA, agent-info).

**PRAGMAs on the persistent open-existing path in `SQLiteDBEngine::initialize`.** `journal_mode` and `synchronous` are applied only on the create path, so `sca.db`, `fim.db`, `local.db` and `agent_info.db` run on default rollback-journal locking with `synchronous=FULL`. `sca_sync.db` already gets WAL, which is part of why the `sca_sync.db` half of #37841 is holding.

**`~SQLiteDBEngine` calls `m_transaction->commit()` with no `try`/`catch`** (`sqlite_dbengine.cpp:34-43`), so a failing commit throws out of a destructor and calls `std::terminate`. Reproduced with two DBSync instances on one file: `terminate called after throwing 'SQLite::sqlite_error': sqlite: COMMIT TRANSACTION. database is locked`. On an agent that is a hard crash of `wazuh-agent.exe` rather than a logged error. Unrelated to this PR but found while testing it.

One further observation, bounded and logged rather than silent, so not a new defect but the same failure class: `AgentInfoImpl::stop()` skips its teardown if the run loop has not exited within its 10 second budget, which leaves `agent_info.db` locked in exactly the way `sca.db` was here.

