### PR TITLE
fix(rootcheck): stop rule 510 false positives on uutils coreutils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 - Fixed the LLMNR SCA check expected value on Windows Server 2016 and 2012. ([#37765](https://github.com/wazuh/wazuh/pull/37765))
 - Fixed typo in `/etc/shells` permission check on Debian 10, Ubuntu 20.04 and Ubuntu 22.04 SCA rules. ([#37770](https://github.com/wazuh/wazuh/pull/37770))
 - Fixed MITRE ATT&CK tactic IDs being used instead of technique IDs in Microsoft Graph rules. ([#37950](https://github.com/wazuh/wazuh/pull/37950))
+- Updated rootcheck trojan signatures to avoid false positives on distributions shipping uutils coreutils (Ubuntu 25.10 and later). ([#32142](https://github.com/wazuh/wazuh/issues/32142))
 
 ## [v4.14.7]
 

--- a/ruleset/rootcheck/db/rootkit_trojans.txt
+++ b/ruleset/rootcheck/db/rootkit_trojans.txt
@@ -16,17 +16,17 @@
 # file_name !string_to_search!Description
 
 # Common binaries and public trojan entries
-ls          !bash|^/bin/sh|dev/[^clu]|\.tmp/lsfile|duarawkz|/prof|/security|file\.h!
-env         !bash|^/bin/sh|file\.h|proc\.h|/dev/|^/bin/.*sh!
-echo        !bash|^/bin/sh|file\.h|proc\.h|/dev/[^cl]|^/bin/.*sh!
-chown       !bash|^/bin/sh|file\.h|proc\.h|/dev/[^cl]|^/bin/.*sh!
-chmod       !bash|^/bin/sh|file\.h|proc\.h|/dev/[^cl]|^/bin/.*sh!
-chgrp       !bash|^/bin/sh|file\.h|proc\.h|/dev/[^cl]|^/bin/.*sh!
-cat         !bash|^/bin/sh|file\.h|proc\.h|/dev/[^cl]|^/bin/.*sh!
+ls          !/bin/bash|^/bin/sh|dev/[^cfhlnrstuw]|\.tmp/lsfile|duarawkz|/prof|/security|file\.h!
+env         !/bin/bash|^/bin/sh|file\.h|proc\.h|/dev/[^cfhlnrstuw]|^/bin/.*sh!
+echo        !/bin/bash|^/bin/sh|file\.h|proc\.h|/dev/[^cfhlnrstuw]|^/bin/.*sh!
+chown       !/bin/bash|^/bin/sh|file\.h|proc\.h|/dev/[^cfhlnrstuw]|^/bin/.*sh!
+chmod       !/bin/bash|^/bin/sh|file\.h|proc\.h|/dev/[^cfhlnrstuw]|^/bin/.*sh!
+chgrp       !/bin/bash|^/bin/sh|file\.h|proc\.h|/dev/[^cfhlnrstuw]|^/bin/.*sh!
+cat         !/bin/bash|^/bin/sh|file\.h|proc\.h|/dev/[^cfhlnrstuw]|^/bin/.*sh!
 bash        !proc\.h|/dev/[0-9]|/dev/[hijkz]!
 sh          !proc\.h|/dev/[0-9]|/dev/[hijkz]!
-uname       !bash|^/bin/sh|file\.h|proc\.h|^/bin/.*sh!
-date        !bash|^/bin/sh|file\.h|proc\.h|/dev/[^cfhlnrstuw]|^/bin/.*sh!
+uname       !/bin/bash|^/bin/sh|file\.h|proc\.h|^/bin/.*sh!
+date        !/bin/bash|^/bin/sh|file\.h|proc\.h|/dev/[^cfhlnrstuw]|^/bin/.*sh!
 du          !w0rm|/prof|file\.h!
 df          !bash|^/bin/sh|file\.h|proc\.h|/dev/[^clurdv]|^/bin/.*sh!
 login       !elite|SucKIT|xlogin|vejeta|porcao|lets_log|sukasuk!
@@ -41,7 +41,7 @@ crond       !/dev/[^nt]|bash!
 gpm         !bash|mingetty!
 ifconfig    !bash|^/bin/sh|/dev/tux|session.null|/dev/[^cludisopt]!
 diff        !bash|^/bin/sh|file\.h|proc\.h|(/dev/($|[^nf]|n($|[^u])|nu($|[^l])|nul($|[^l])|null.+|f($|[^u])|fu($|[^l])|ful($|[^l])|full.+))|^/bin/.*sh!
-md5sum      !bash|^/bin/sh|file\.h|proc\.h|/dev/[^cfhlnrstuw]|^/bin/.*sh!
+md5sum      !/bin/bash|^/bin/sh|file\.h|proc\.h|/dev/[^cfhlnrstuw]|^/bin/.*sh!
 hdparm      !bash|/dev/ida!
 ldd         !/dev/[^n]|proc\.h|libshow.so|libproc.a!
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes #<issue_number>
-->

Rootcheck reports _"Trojaned version of file detected."_ (rule **510**) against stock, package-verified coreutils binaries on distributions that ship the Rust **uutils** rewrite as the default coreutils — Ubuntu 25.10 and later, including Ubuntu 26.04.

This completes the fix started in #35927. That PR addressed `chsh`, `chfn`, `passwd`, `date` and `md5sum`, and closed #32142. Eight further binaries were never in scope — and `date` and `md5sum` still false-positive today, because only one of the two responsible clauses on those lines was corrected (detail below).

Related: #32142, #35927.

## Proposed Changes

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

`rootkit_trojans.txt` signatures are string heuristics that assume a GNU per-command build.
uutils breaks two of those assumptions:

1. **All commands are a single multicall binary.** 
  Every name in `/usr/bin` is a symlink to one ~11 MB `/usr/lib/cargo/bin/coreutils` binary — 115 hardlinks on Ubuntu 26.04. Every command therefore presents an *identical*, much larger string surface, so a signature that trips for one command trips for all of them.
2. **Rust merges adjacent string literals with no separator.**   
  `strings`-style extraction smears unrelated literals into substrings no GNU build ever contained.

Two clauses false-positive as a result:

| Clause | What it actually matches in the stock binary |
|---|---|
| bare `bash` | the Coptic month name **"Bashans"** in embedded locale data, e.g. the run `toutbabahatourkiahktoubaamshirbaramhatbaramoudabashansba` |
| `/dev/`, `/dev/[^cl]`, `dev/[^clu]` | `/dev/fd`, `/dev/hda`, `/dev/null`, `/dev/random`, `/dev/stdin`, `/dev/stdout`, `/dev/tty`, `/dev/urandom` |

**Why `date` and `md5sum` are still affected.** #35927 introduced the `/dev/[^cfhlnrstuw]` class for those two lines. That class is correct and this PR reuses it verbatim. But both lines kept the bare `bash` clause, which matches the Coptic month data above — so the alert never went away.

Minimal signature adjustments in `ruleset/rootcheck/db/rootkit_trojans.txt`, 10 lines:

| Binary | Distro | Root cause | Change |
|---|---|---|---|
| `ls`, `env`, `echo`, `cat`, `chgrp`, `chmod`, `chown`, `uname`, `date`, `md5sum` | Ubuntu 25.10+ | uutils multicall binary embeds Coptic month names in locale data; `…baramoudabashansba…` matches bare `bash` | `bash` → `/bin/bash` |
| `cat`, `echo`, `chgrp`, `chmod`, `chown` | Ubuntu 25.10+ | Legitimately embedded device paths | `/dev/[^cl]` → `/dev/[^cfhlnrstuw]` |
| `env` | Ubuntu 25.10+ | Same, against a bare `/dev/` clause | `/dev/` → `/dev/[^cfhlnrstuw]` |
| `ls` | Ubuntu 25.10+ | Same, against `dev/[^clu]` | `dev/[^clu]` → `dev/[^cfhlnrstuw]` |

`uname` has no `/dev/` clause; bare `bash` was its only matching token.

#35927 took two different approaches: it *narrowed* the `/dev/` character classes, but *deleted* the bare `bash` clause outright for `chfn`/`chsh` (while keeping it on `passwd`). This PR narrows in both cases rather than deleting, so a genuinely suspicious reference still matches.
`/bin/bash` is an unanchored substring, so it still catches `/usr/bin/bash` and `/usr/local/bin/bash`. Real trojan indicators (`/dev/kmem`, `/dev/mem`, `/dev/ptyXX`, `/dev/ttyo`, `duarawkz`, `.tmp/lsfile`, `proc.h`) remain unaffected — their leading characters are not in the excluded set.

> **Note for reviewers:** narrowing `bash` → `/bin/bash` rather than removing it is a deliberate choice, and I'm happy to switch to removal for consistency with the `chfn`/`chsh` treatment in #35927. The argument for narrowing: it preserves detection of a binary that references the bash interpreter by path, at no false-positive cost. Across all 748 binaries in `/usr/bin` on a stock Ubuntu 26.04 host, bare `bash` appears in 164 (22%) — too common to discriminate — while `/bin/bash` appears in 15 (2%). The pathless form (`bash -c`) is the one case narrowing gives up; in practice `system()` shells out via `/bin/sh`, which the existing `^/bin/sh` clause on these lines already covers.

Known trade-off, inherited from #35927's character class: excluding `h` means `/dev/hd*` indicators no longer match on these lines. This is unavoidable — the uutils multicall binary embeds `/dev/hda` in `dd`'s own help text.

### Results and Evidence

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

Before, on a clean Ubuntu 26.04 host — one alert per affected name, per path (`/bin` and `/usr/bin`):

```
Trojaned version of file '/usr/bin/cat' detected. Signature used:
'bash|^/bin/sh|file\.h|proc\.h|/dev/[^cl]|^/bin/.*sh' (Generic).

Trojaned version of file '/usr/bin/uname' detected. Signature used:
'bash|^/bin/sh|file\.h|proc\.h|^/bin/.*sh' (Generic).
```

After:

```
No binaries with any trojan detected. Analyzed 76 files.
```

Running the whole signature file against the live filesystem, iterating `bin`, `sbin`, `usr/bin`, `usr/sbin` exactly as `check_rc_trojans()` does:

| Signature file | Rule 510 hits |
|---|---|
| `4.14.8` baseline | **20** (10 binaries × 2 paths) |
| This PR | **0** |

All 76 signatures in the file still compile as POSIX ERE.

**Detection is preserved.** A synthetic binary embedding `/bin/bash`, `/dev/ptyr`, `/dev/kmem`, `proc.h`, `duarawkz` and `.tmp/lsfile` is still matched by **all 10** modified signatures:

```
ls=MATCH env=MATCH echo=MATCH chown=MATCH chmod=MATCH
chgrp=MATCH cat=MATCH uname=MATCH date=MATCH md5sum=MATCH
```

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

Tested on Ubuntu 26.04 LTS (Resolute Raccoon), `rust-coreutils 0.8.0-0ubuntu3`.
`debsums rust-coreutils` reports every file `OK`, confirming stock, unmodified packages — i.e. these are false positives, not tampering.

*Methodology:* rootcheck matches with **POSIX ERE**, not PCRE — `check_rc_trojans()` calls `os_string()` (`src/rootcheck/os_string.c`), which extracts runs of printable ASCII ≥ 4 chars and feeds each run to `OS_PRegex()` (`src/shared/regex_op.c`, `regcomp`/`regexec` with `REG_EXTENDED | REG_NOSUB`). `strings -a | grep -E` is therefore an exact stand-in, and `^` anchors to the start of a printable run. Empty results indicate no match → no alert. The end-to-end figures in the previous section come from replaying `os_string()` and `OS_PRegex()` directly over the real binaries.

#### The uutils multicall binary

```
$ cat --version | head -1
cat (uutils coreutils) 0.8.0

$ ls -li /usr/lib/cargo/bin/coreutils/{cat,ls,uname}
9223372036854779607 -rwxr-xr-x 115 root root 11352352 ... /usr/lib/cargo/bin/coreutils/cat
9223372036854779607 -rwxr-xr-x 115 root root 11352352 ... /usr/lib/cargo/bin/coreutils/ls
9223372036854779607 -rwxr-xr-x 115 root root 11352352 ... /usr/lib/cargo/bin/coreutils/uname
```

Same inode, 115 links — one binary serving every coreutils name, which is why a single string surface explains every alert.

#### The `bash` clause — all 10 binaries, including `date` and `md5sum`

```
# Old signature — MATCH (false positive): Coptic month names in embedded locale data
$ strings -a /usr/lib/cargo/bin/coreutils/cat | grep -a "bash" | head -3
toutbabahatourkiahktoubaamshirbaramhatbaramoudabashansba
tutbabahhaturkiyahktubahamshirbaramhatbaramundahbashansba
toutbabahatorkiahktobaamshirbaramhatbaramoudabashanspaonaepepmesranasie

# New signature — NO MATCH ✅
$ strings -a /usr/lib/cargo/bin/coreutils/cat | grep -aE "/bin/bash"
(no output)
```

#### The `/dev/` clauses — `ls`, `env`, `echo`, `cat`, `chgrp`, `chmod`, `chown`

```
# Legitimately embedded device paths
$ strings -a /usr/lib/cargo/bin/coreutils/cat | grep -aoE "/dev/[A-Za-z][A-Za-z0-9]*" | sort -u
/dev/fd
/dev/hda
/dev/null
/dev/random
/dev/stdin
/dev/stdout
/dev/tty
/dev/urandom
/dev/who

# Old signature — MATCH (false positive)
$ strings -a /usr/lib/cargo/bin/coreutils/cat | grep -aoE "/dev/[^cl]" | sort -u
/dev/f
/dev/h
/dev/n
/dev/r
/dev/s
/dev/t
/dev/u
/dev/w

# New signature — NO MATCH ✅
$ strings -a /usr/lib/cargo/bin/coreutils/cat | grep -aoE "/dev/[^cfhlnrstuw]" | sort -u
(no output)
```

The complete set of characters following `/dev/` in the binary is exactly `f h n r s t u w`, all of which the `[^cfhlnrstuw]` class introduced by #35927 already excludes.

#### Checks

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux — N/A, no code changes; data file only
  - [x] Windows — N/A, no code changes; data file only
  - [x] MAC OS X — N/A, no code changes; data file only
- [x] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [x] Coverity — N/A, no code changes
  - [x] Valgrind (memcheck and descriptor leaks check) — N/A, no code changes
  - [x] AddressSanitizer — N/A, no code changes
- Memory tests for Windows
  - [x] Coverity — N/A, no code changes
  - [x] UMDH — N/A, no code changes
- Memory tests for macOS
  - [x] Leaks — N/A, no code changes
  - [x] AddressSanitizer — N/A, no code changes

- Decoder/Rule tests _(Wazuh v4.x)_
  - [x] Added unit testing files ".ini" — N/A, see **Tests Introduced**; `runtests.py` covers decoders and rules only, not rootcheck signatures
  - [x] `runtests.py` executed without errors — N/A, no decoder or rule is changed

- Engine _(Wazuh v5.x and above)_
  - [x] Test run in parallel — N/A, this targets `4.14.8`; `ruleset/rootcheck/db/` does not exist on 5.x
  - [x] ASAN for test (utest/ctest) — N/A
  - [x] TSAN for test and wazuh-engine. — N/A

- Wazuh server API/Framework
  - [x] Run API Integration Tests — N/A, no API or framework code is changed

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

No executables, packages or default configuration files change. One ruleset data file:

- `ruleset/rootcheck/db/rootkit_trojans.txt`

It is installed by `src/init/inst-functions.sh` to:

- `${INSTALLDIR}/etc/shared/` — `InstallAgent()`
- `${INSTALLDIR}/etc/shared/default/` — `InstallServer()`, from where it is distributed to agent groups
- `${INSTALLDIR}/etc/rootcheck/` — `InstallLocal()`

`CHANGELOG.md` is also updated.

Note that agents which already carry a locally edited `/var/ossec/etc/shared/rootkit_trojans.txt` will keep their copy; the corrected signatures reach them the same way any other shared-configuration update does.

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

N/A. No configuration parameters are added, removed or changed, and no default values are affected. The modified file is signature data, not configuration.

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

**None.** No automated test covers these signatures, and this PR adds none. To be explicit about what exists today:

- There is no `src/unit_tests/rootcheck/` — rootcheck has no unit-test suite, so neither `check_rc_trojans()` nor `os_string()` is covered.
- `ruleset/testing/runtests.py` drives `wazuh-logtest` and covers decoders and rules only, so there is no `.ini` case to add for a rootcheck signature.
- `framework/wazuh/core/tests/test_configuration.py::test_rootkit_trojans2json` tests the *parser* against a synthetic fixture, not the shipped ruleset file. It is unaffected by this change and does not validate signature behaviour.

All validation reported above is therefore manual, plus the end-to-end replay of `os_string()` and `OS_PRegex()` described in the methodology note.

If you would like coverage added, `os_string()` is straightforward to test in isolation — its only dependencies are `OS_PRegex` and file I/O, and `librootcheck.a` is already a build artifact — so a `src/unit_tests/rootcheck/test_os_string.c` suite could pin this regression (legitimate uutils strings must not match; `/dev/ptyr`, `/dev/kmem`, `/bin/bash`, `duarawkz` and `proc.h` must still match). Happy to add it here or as a follow-up, whichever you prefer.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality — **no automated tests added**; rootcheck has no
      unit-test harness and its signatures are not covered by the ruleset test suite. Validated
      manually on Ubuntu 26.04 plus an end-to-end replay of the matcher, see above
- [x] Configuration changes documented — N/A, no configuration changes
- [x] Developer documentation reflects the changes — N/A, no documented behaviour changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->

---

Disclosure: Claude Code (Opus 5) was used to generate the code changes and the PR description. Everything was reviewed by myself before submitting.