### PR TITLE
Reject undersized legacy-format agent messages in wazuh-remoted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Fixed the `aws-s3` wodle failing to parse configuration values that contain spaces, such as `discard_regex`, `discard_field`, `aws_profile`, `aws_account_alias`, `path` and `path_suffix`. ([#37929](https://github.com/wazuh/wazuh/pull/37929))
 - Fixed wazuh-db exiting the worker thread instead of closing the peer socket when an oversized message is received. ([#37850](https://github.com/wazuh/wazuh/pull/37850))
 - Improved SCA policy source validation to correctly enforce the `sca.remote_commands` restriction. ([#37953](https://github.com/wazuh/wazuh/pull/37953))
+- Added a minimum length check for legacy-format agent messages in `wazuh-remoted`. ([#38099](https://github.com/wazuh/wazuh/pull/38099))
 
 ### Agent
 

--- a/src/os_crypto/shared/msgs.c
+++ b/src/os_crypto/shared/msgs.c
@@ -484,6 +484,11 @@ int ReadSecMSG(keystore *keys, char *buffer, char *cleartext, int id, unsigned i
         unsigned int msg_count;
         unsigned int msg_time;
 
+        if (buffer_size < MSG_OVERHEAD) {
+            mwarn("Message too short from agent '%s'", keys->keyentries[id]->id);
+            return KS_CORRUPT;
+        }
+
         /* Close string */
         cleartext[buffer_size] = '\0';
 

--- a/src/unit_tests/os_crypto/shared/test_msgs.c
+++ b/src/unit_tests/os_crypto/shared/test_msgs.c
@@ -389,6 +389,50 @@ void test_ReadSecMSG_final_size_validation(void **state){
     free(keys);
 }
 
+void test_ReadSecMSG_legacy_format_length_validation(void **state){
+    keystore *keys;
+
+    os_calloc(1, sizeof(keystore), keys);
+    os_calloc(1, sizeof(keyentry *), keys->keyentries);
+    keys->keysize = 1;
+    keys->flags.key_mode = W_ENCRYPTION_KEY;
+
+    os_calloc(1, sizeof(keyentry), keys->keyentries[0]);
+    keys->keyentries[0]->keyid = 0;
+    keys->keyentries[0]->id = "001";
+    keys->keyentries[0]->name = "agent1";
+    keys->keyentries[0]->encryption_key =
+        "778823d0b0886be37049bdf01cc703f72fa8dc7bb499303";
+    keys->keyentries[0]->crypto_method = W_METH_BLOWFISH;
+    w_mutex_init(&keys->keyentries[0]->mutex, NULL);
+
+    /* Plaintext for the legacy ("Old format") branch: starts with ':' and is
+     * far shorter than MSG_OVERHEAD, matching the undersized-message case
+     * the missing length guard was supposed to reject. */
+    const char plaintext[] = ":123456789";
+    const size_t plain_len = sizeof(plaintext) - 1;
+
+    char msg_buf[1 + sizeof(plaintext) - 1];
+    msg_buf[0] = ':';
+    assert_int_equal(doEncryptByMethod(plaintext, msg_buf + 1,
+                      keys->keyentries[0]->encryption_key, (long)plain_len,
+                      OS_ENCRYPT, W_METH_BLOWFISH), 1);
+
+    char cleartext[1024];
+    size_t final_size = 0;
+    char *output = NULL;
+
+    expect_string(__wrap__mwarn, formatted_msg, "Message too short from agent '001'");
+
+    assert_int_equal(ReadSecMSG(keys, msg_buf, cleartext, 0,
+                                sizeof(msg_buf) - 1, &final_size, "127.0.0.1", &output), KS_CORRUPT);
+
+    w_mutex_destroy(&keys->keyentries[0]->mutex);
+    free(keys->keyentries[0]);
+    free(keys->keyentries);
+    free(keys);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -401,7 +445,8 @@ int main(void)
         cmocka_unit_test(test_encrypt_by_method_aes),
         cmocka_unit_test(test_encrypt_by_method_default),
         cmocka_unit_test(test_set_agent_crypto_method),
-        cmocka_unit_test(test_ReadSecMSG_final_size_validation)
+        cmocka_unit_test(test_ReadSecMSG_final_size_validation),
+        cmocka_unit_test(test_ReadSecMSG_legacy_format_length_validation)
         };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
## Description
`ReadSecMSG()`'s legacy/uncompressed ("Old format") branch in `src/os_crypto/shared/msgs.c` called `CheckSum()` on the decrypted buffer with no minimum-length check, unlike the sibling compressed branch, which already validates against `MSG_OVERHEAD`. The fix adds the same `MSG_OVERHEAD` guard to the legacy branch, closing the inconsistency between the two branches before `CheckSum()` is reached.

## Proposed Changes
- `src/os_crypto/shared/msgs.c`: added a `buffer_size < MSG_OVERHEAD` check at the start of the `else if (cleartext[0] == ':')` branch in `ReadSecMSG()`, returning `KS_CORRUPT` with a warning if the decrypted message is too short — mirroring the existing guard in the compressed branch.
- `src/unit_tests/os_crypto/shared/test_msgs.c`: added `test_ReadSecMSG_legacy_format_length_validation`, covering the new guard, and registered it in the test suite.

### Results and Evidence
The added test builds a real Blowfish-encrypted legacy-format message (plaintext `:123456789`, 10 bytes) and asserts that `ReadSecMSG()` returns `KS_CORRUPT` with the warning `Message too short from agent '001'`. Traced by code review:
- Before the fix: execution falls through to `CheckSum()`, which reads/copies data from the buffer independently of `buffer_size`; the checksum computed over the undersized content does not match the attacker-supplied checksum bytes, so the function returns via the unrelated `ENCSUM_ERROR` path — the new guard's warning is never emitted, so the test's expectation is not satisfied.
- After the fix: the new guard is reached first and returns `KS_CORRUPT` with the expected warning, satisfying the test.

This test was authored following the project's existing CMocka conventions (mirroring `test_ReadSecMSG_final_size_validation`) but could not be executed in the sandbox used for this change, because the full CMake build requires downloading and building several third-party dependencies not available offline. It should be run through the project's normal CI/build before merge.

### Artifacts Affected
`wazuh-remoted` (manager) and `wazuh-agentd` (agent), both of which link `src/os_crypto/shared/msgs.c`.

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
`test_ReadSecMSG_legacy_format_length_validation` in `src/unit_tests/os_crypto/shared/test_msgs.c`.

## Credits
Reported by @mohammad228.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
