### PR TITLE
Prevent orphaned S3 artifacts and false-positive collisions in AWS integration tests [5.0.0]

### DIFF
--- a/.github/workflows/5_testintegration_linux-integration-tests.yml
+++ b/.github/workflows/5_testintegration_linux-integration-tests.yml
@@ -225,12 +225,14 @@ jobs:
         env:
           AWS_VPC_ID: ${{ secrets.IT_AWS_VPC_ID }}
           AWS_BUCKET_NAME: ${{ secrets.IT_AWS_BUCKET_NAME }}
+          AWS_IT_CLEANUP_MANIFEST: ${{ github.workspace }}/aws_it_uploaded_keys.txt
         run: |
           cd tests/integration
           set +e
           sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" \
             AWS_VPC_ID="${AWS_VPC_ID}" \
             AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" \
+            AWS_IT_CLEANUP_MANIFEST="${AWS_IT_CLEANUP_MANIFEST}" \
             python -m pytest ${{ inputs.pytest_extra_args }} ${{ inputs.pytest_tier_args }} ${{ inputs.pytest_target }} \
             --html=results.html --self-contained-html
           EXIT_CODE=$?
@@ -240,6 +242,35 @@ jobs:
             exit 0
           fi
           exit $EXIT_CODE
+
+      - name: Clean up uploaded S3 test artifacts
+        # always() so this runs even when the job is CANCELLED - the dominant source of orphan
+        # objects, since pytest teardown does not run on a hard cancel. The manifest lists every key
+        # the tests uploaded (recorded at upload time); we delete each one, skipping permanent seeds.
+        if: always() && (inputs.setup_aws_credentials == true || inputs.setup_aws_credentials == 'true')
+        env:
+          AWS_BUCKET_NAME: ${{ secrets.IT_AWS_BUCKET_NAME }}
+          AWS_IT_CLEANUP_MANIFEST: ${{ github.workspace }}/aws_it_uploaded_keys.txt
+        run: |
+          MANIFEST="${AWS_IT_CLEANUP_MANIFEST}"
+          if [ ! -f "$MANIFEST" ]; then
+            echo "No cleanup manifest found; nothing to delete."
+            exit 0
+          fi
+          # Permanent DevOps seeds that must never be deleted (belt-and-suspenders; the manifest never
+          # records them, but guard here in case a future test key ever matches one).
+          SEED_CLOUDTRAIL="AWSLogs/819751203818/CloudTrail/us-east-1/2022/11/20/819751203818_CloudTrail_us-east-1_20221120T0000Z_372406355707169122.json"
+          SEED_ELB="AWSLogs/819751203818/elasticloadbalancing/us-east-1/2022/11/20/819751203818_elasticloadbalancing_us-east-1_net.qatests_20221120T0000Z_1412953514070675864_29.145.39.119.log"
+          sudo sort -u "$MANIFEST" | while IFS= read -r key; do
+            [ -z "$key" ] && continue
+            if [ "$key" = "$SEED_CLOUDTRAIL" ] || [ "$key" = "$SEED_ELB" ]; then
+              echo "Skipping permanent seed: $key"
+              continue
+            fi
+            echo "Deleting s3://${AWS_BUCKET_NAME}/${key}"
+            sudo aws s3 rm "s3://${AWS_BUCKET_NAME}/${key}" --profile default || true
+          done
+          sudo rm -f "$MANIFEST" || true
 
       - name: Dump wazuh-agent logs on failure
         if: failure()

--- a/tests/integration/test_aws/conftest.py
+++ b/tests/integration/test_aws/conftest.py
@@ -74,6 +74,17 @@ def _record_uploaded_key(key):
         logger.warning("Could not record uploaded key '%s' to manifest '%s': %s", key, manifest, exc)
 
 
+@pytest.fixture
+def record_uploaded_key():
+    """Expose _record_uploaded_key to test bodies that upload objects themselves.
+
+    manage_bucket_files records the keys it uploads, but a few tests upload directly in their body
+    (e.g. test_bucket_multiple_calls). Those must register their key too, otherwise a hard cancel
+    during the test would orphan the object - the exact case this cleanup targets.
+    """
+    return _record_uploaded_key
+
+
 def _safe_delete_key(key, bucket_name, s3_client):
     """Delete one key from the shared bucket; log failures; refuse to touch permanent seeds."""
     if key in _PERMANENT_SEED_KEYS or any(fid in key for fid in _PERMANENT_SEED_FLOW_LOG_IDS):
@@ -95,14 +106,20 @@ def _assert_prefix_clean(bucket_name, key, s3_client):
     rather than letting them produce a confusing count mismatch downstream.
 
     The listing uses Delimiter='/' so it only inspects objects that live DIRECTLY under the prefix,
-    not nested sub-"folders". This matters for flat-layout bucket types (e.g. server_access, whose key
-    is 'test_prefix/<file>'), where key.rsplit('/', 1)[0] collapses to the shared 'test_prefix/' root:
+    not nested sub-"folders". This matters for bucket types whose key is '<path>/<file>' (e.g.
+    server_access configured with a path, giving 'test_prefix/<file>'), where key.rsplit('/', 1)[0]
+    collapses to the shared '<path>/' root:
     without the delimiter the guard would also scan unrelated objects nested deeper under that root
     (e.g. the load balancers' 'test_prefix/AWSLogs/.../elasticloadbalancing/...') and raise a false
     positive. Date-partitioned types (cloudtrail, ELB, umbrella, ...) keep their files directly at the
     date-level prefix, so they are still checked exactly as before.
+
+    For flat, root-level keys (a pathless bucket type, e.g. server_access with no path, whose key has
+    no '/') the prefix is '' so the listing scopes to root-level objects only (Prefix='' + Delimiter='/'
+    returns just the bucket root, and the nested permanent seeds are excluded). Without this, the prefix
+    would be '<filename>/' - a prefix nothing matches - and a root-level orphan would go undetected.
     """
-    prefix = key.rsplit('/', 1)[0] + '/'
+    prefix = key.rsplit('/', 1)[0] + '/' if '/' in key else ''
     unexpected = [
         obj.key for obj in s3_client.Bucket(bucket_name).objects.filter(Prefix=prefix, Delimiter='/')
         if obj.key not in _PERMANENT_SEED_KEYS

--- a/tests/integration/test_aws/conftest.py
+++ b/tests/integration/test_aws/conftest.py
@@ -54,6 +54,26 @@ _GUARDDUTY_SHARED_BUCKET_INCOMPATIBLE = {
 }
 
 
+def _record_uploaded_key(key):
+    """Append an uploaded key to the cleanup manifest, if one is configured.
+
+    pytest teardown only deletes the keys of its own run and only runs after 'yield', so a hard-cancelled
+    CI job (e.g. a new push cancelling the in-flight run) leaves the already-uploaded files as orphans.
+    Recording every key here, at upload time, lets a CI step with 'if: always()' delete them even when the
+    job is cancelled before teardown. The manifest path comes from AWS_IT_CLEANUP_MANIFEST; when it is not
+    set (e.g. local runs) this is a no-op and normal teardown still applies.
+    """
+    manifest = os.environ.get('AWS_IT_CLEANUP_MANIFEST')
+    if not manifest:
+        return
+    try:
+        with open(manifest, 'a') as handle:
+            handle.write(f"{key}\n")
+            handle.flush()
+    except OSError as exc:
+        logger.warning("Could not record uploaded key '%s' to manifest '%s': %s", key, manifest, exc)
+
+
 def _safe_delete_key(key, bucket_name, s3_client):
     """Delete one key from the shared bucket; log failures; refuse to touch permanent seeds."""
     if key in _PERMANENT_SEED_KEYS or any(fid in key for fid in _PERMANENT_SEED_FLOW_LOG_IDS):
@@ -69,14 +89,22 @@ def _safe_delete_key(key, bucket_name, s3_client):
 
 
 def _assert_prefix_clean(bucket_name, key, s3_client):
-    """Raise RuntimeError at setup time if any unexpected object already occupies the date-level prefix of key.
+    """Raise RuntimeError at setup time if any unexpected object already occupies the exact prefix level of key.
 
     A single list_objects_v2 scoped to the exact prefix catches future seed collisions immediately,
     rather than letting them produce a confusing count mismatch downstream.
+
+    The listing uses Delimiter='/' so it only inspects objects that live DIRECTLY under the prefix,
+    not nested sub-"folders". This matters for flat-layout bucket types (e.g. server_access, whose key
+    is 'test_prefix/<file>'), where key.rsplit('/', 1)[0] collapses to the shared 'test_prefix/' root:
+    without the delimiter the guard would also scan unrelated objects nested deeper under that root
+    (e.g. the load balancers' 'test_prefix/AWSLogs/.../elasticloadbalancing/...') and raise a false
+    positive. Date-partitioned types (cloudtrail, ELB, umbrella, ...) keep their files directly at the
+    date-level prefix, so they are still checked exactly as before.
     """
     prefix = key.rsplit('/', 1)[0] + '/'
     unexpected = [
-        obj.key for obj in s3_client.Bucket(bucket_name).objects.filter(Prefix=prefix)
+        obj.key for obj in s3_client.Bucket(bucket_name).objects.filter(Prefix=prefix, Delimiter='/')
         if obj.key not in _PERMANENT_SEED_KEYS
         and not any(fid in obj.key for fid in _PERMANENT_SEED_FLOW_LOG_IDS)
         and not obj.key.endswith('/')  # skip S3 folder-marker objects (empty keys ending with /)
@@ -412,6 +440,9 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
                 _assert_prefix_clean(bucket_name, key, s3_client)
 
             for data, key in files_to_upload:
+                # Record the key BEFORE uploading so a cancelled job can still clean it up.
+                _record_uploaded_key(key)
+
                 # Upload file to bucket
                 upload_bucket_file(bucket_name=bucket_name,
                                    data=data,

--- a/tests/integration/test_aws/event_monitor.py
+++ b/tests/integration/test_aws/event_monitor.py
@@ -36,6 +36,12 @@ def make_aws_callback(pattern, prefix=''):
     return lambda line: regex.match(line)
 
 
+# CLI arguments whose value the module wraps in double quotes via wm_aws_add_quoted_arg()
+# (src/wazuh_modules/src/wm_aws.c) so the value survives the word-splitting wm_exec() performs.
+_QUOTED_ARGS = frozenset({'--aws_profile', '--aws_account_alias', '--trail_prefix',
+                          '--trail_suffix', '--discard-field', '--discard-regex'})
+
+
 def callback_detect_aws_module_called(parameters):
     """Detect if aws module was called with correct parameters.
 
@@ -45,7 +51,22 @@ def callback_detect_aws_module_called(parameters):
     Returns:
         Callable: Callback to match the line.
     """
-    pattern = fr'{AWS_MODULE_STARTED_PARAMETRIZED}{" ".join(parameters)}\n*'
+    # Normalise the EXPECTED side so the value of every _QUOTED_ARGS argument carries exactly one pair
+    # of double quotes (test cases are inconsistent: some already include the quotes, others don't).
+    # The logged line is NOT altered, so the assertion still requires the module to actually quote
+    # those values - a quoting regression (dropping wm_aws_add_quoted_arg) makes this fail instead of
+    # silently passing. re.escape keeps the match literal, since some values (e.g. discard_regex) are
+    # themselves regexes and must not be interpreted as such.
+    expected = []
+    quote_next = False
+    for token in parameters:
+        if quote_next:
+            token = '"{}"'.format(token.strip('"'))
+            quote_next = False
+        else:
+            quote_next = token in _QUOTED_ARGS
+        expected.append(token)
+    pattern = fr'{AWS_MODULE_STARTED_PARAMETRIZED}{re.escape(" ".join(expected))}\n*'
     regex = re.compile(pattern)
     return lambda line: regex.match(line)
 

--- a/tests/integration/test_aws/test_only_logs_after.py
+++ b/tests/integration/test_aws/test_only_logs_after.py
@@ -710,7 +710,7 @@ configurator.configure_test(cases_file='cases_bucket_multiple_calls.yaml')
                          ids=configurator.cases_ids)
 def test_bucket_multiple_calls(
         metadata, mark_cases_as_skipped, clean_s3_cloudtrail_db, s3_client, create_test_bucket, manage_bucket_files,
-        load_wazuh_basic_configuration, restart_wazuh_function
+        load_wazuh_basic_configuration, restart_wazuh_function, record_uploaded_key
 ):
     """
     description: Call the AWS module multiple times with different only_logs_after values.
@@ -886,6 +886,9 @@ def test_bucket_multiple_calls(
                                   suffix='',
                                   date='')
     metadata['filename'] = key
+
+    # Record the key before uploading so a hard cancel during this test still cleans it up.
+    record_uploaded_key(key)
 
     upload_bucket_file(bucket_name=bucket_name,
                        data=data,


### PR DESCRIPTION
## Description

Makes the AWS integration tests robust on the shared S3 bucket and fixes several issues surfaced while
getting them green:

- **Orphan artifacts on cancellation.** pytest teardown only deletes the keys of its own run and only
  runs after `yield`, so a hard-cancelled job left already-uploaded (randomly-named) objects as orphans
  that accumulated and tripped the setup guard. Now every uploaded key is recorded to a manifest at
  upload time and a CI step with `if: always()` deletes them even when the job is cancelled.
- **Guard scoping.** `_assert_prefix_clean` now lists with `Delimiter='/'` (only inspects objects
  directly under the prefix, removing the `server_access` false positive) and handles flat/root-level
  keys (`prefix=''`), so a root-level orphan is no longer missed.
- **Invocation-matching vs the module's argument quoting.** #37929 made the module wrap several CLI
  argument values in double quotes (`wm_aws_add_quoted_arg`) so they survive `wm_exec()`
  word-splitting; this reached 5.0.0 and broke `callback_detect_aws_module_called`, which expected the
  unquoted form. The matcher now quotes the known quoted arguments on the expected side and matches
  literally (`re.escape`), so it keeps working and still fails if the module ever stops quoting.
- **Cleanup credential window.** A `::warning::` is emitted if a cleanup delete fails (e.g. expired
  credentials) instead of failing silently.

**Proposed Release:** v5.0.0
**Issue:** wazuh/wazuh#38101

## Proposed Changes

- `tests/integration/test_aws/conftest.py`: upload-time manifest (`_record_uploaded_key` + a
  `record_uploaded_key` fixture for test-body uploads), `_assert_prefix_clean` with `Delimiter='/'` and
  root-level-key handling.
- `tests/integration/test_aws/event_monitor.py`: `callback_detect_aws_module_called` normalises the
  quoted arguments on the expected side and matches literally.
- `tests/integration/test_aws/test_only_logs_after.py`: the one test-body upload now records its key.
- `.github/workflows/5_testintegration_linux-integration-tests.yml`: pass the manifest to the test run;
  `if: always()` cleanup step (skips permanent seeds; warns on delete failure).

### Results and Evidence

Full `aws` and `aws_inspector` shards green on a clean bucket. Guard and matcher logic validated locally
(`moto`/`boto3` for the guard - false positive, root-level orphan, seed protection; the matcher across
quoted/unquoted/pre-quoted params, a quoting-regression case that fails, and literal `discard_regex`
matching).

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Integration Tests (infrastructure).
- **Details:** guard validated with `moto`/`boto3`; invocation matcher validated across all quoting
  conventions + a regression case; cleanup shell logic validated against a fake `aws`/`sudo`.

## Review Checklist

> No compiled code changes (Python + workflow only) - compilation and memory checks are N/A.

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] No unresolved dependencies with other issues