### PR TITLE
Fix macos drain autoreleased OD objects in genAccountPolicyData

### DIFF
--- a/src/data_provider/src/extended_sources/wrappers/unix/darwin/od_wrapper.mm
+++ b/src/data_provider/src/extended_sources/wrappers/unix/darwin/od_wrapper.mm
@@ -71,9 +71,6 @@ namespace od
 
     void genAccountPolicyData(const std::string& uid, nlohmann::json& policyData)
     {
-        ODSession* s = [ODSession defaultSession];
-        NSError* err = nullptr;
-
         policyData =
         {
             {"creation_time", 0.0},
@@ -82,127 +79,139 @@ namespace od
             {"password_last_set_time", 0.0}
         };
 
-        ODNode* root = [ODNode nodeWithSession:s name:@"/Local/Default" error:&err];
-
-        if (err != nullptr)
+        // Every autoreleased OpenDirectory/Foundation object created below (ODNode, ODQuery,
+        // NSArray results, the plist NSDictionary tree, etc.) must be drained by an explicit
+        // pool: this runs on the syscollector scan thread, which has no Cocoa run loop to do
+        // it implicitly. Without this, called once per local user on every inventory cycle,
+        // these objects accumulate for the life of the process (see genEntries() above, which
+        // already does this correctly).
+        @autoreleasepool
         {
-            return;
-        }
+            ODSession* s = [ODSession defaultSession];
+            NSError* err = nullptr;
 
-        ODQuery* q =
-            [ODQuery queryWithNode:root
-                     forRecordTypes:kODRecordTypeUsers
-                     attribute:kODAttributeTypeUniqueID
-                     matchType:kODMatchEqualTo
-                     queryValues:[NSString stringWithFormat:@"%s", uid.c_str()]
-                     returnAttributes:@"dsAttrTypeNative:accountPolicyData"
-                     maximumResults:0
-                     error:&err];
+            ODNode* root = [ODNode nodeWithSession:s name:@"/Local/Default" error:&err];
 
-        if (err != nullptr)
-        {
-            return;
-        }
-
-        NSArray* od_results = [q resultsAllowingPartial:NO error:&err];
-
-        if (err != nullptr)
-        {
-            // std::cout << "Error with OpenDirectory results: "
-            //  << std::string([[err localizedDescription] UTF8String])
-            //  << std::endl;
-            return;
-        }
-
-        for (ODRecord * re in od_results)
-        {
-
-            NSError* attrErr = nullptr;
-            NSArray* userPolicyDataValues =
-                [re valuesForAttribute:@"dsAttrTypeNative:accountPolicyData"
-                    error:&attrErr];
-
-            if (attrErr != nullptr || ![userPolicyDataValues count])
-            {
-                // std::cout << "No accountPolicyData found for UID: "
-                // << uid.c_str() << std::endl;
-                return;
-            }
-
-            NSData* plistData = userPolicyDataValues[0];
-            NSPropertyListFormat format;
-            NSError* plistError = nil;
-
-            id plistDict = [NSPropertyListSerialization propertyListWithData:plistData
-                                                        options:NSPropertyListMutableContainersAndLeaves
-                                                        format:&format
-                                                        error:&plistError];
-
-            if (plistError != nil || ![plistDict isKindOfClass:[NSDictionary class]])
+            if (err != nullptr)
             {
                 return;
             }
 
-            NSDictionary* dict = (NSDictionary*)plistDict;
-            nlohmann::json tree;
+            ODQuery* q =
+                [ODQuery queryWithNode:root
+                         forRecordTypes:kODRecordTypeUsers
+                         attribute:kODAttributeTypeUniqueID
+                         matchType:kODMatchEqualTo
+                         queryValues:[NSString stringWithFormat:@"%s", uid.c_str()]
+                         returnAttributes:@"dsAttrTypeNative:accountPolicyData"
+                         maximumResults:0
+                         error:&err];
 
-            for (NSString * key in dict)
+            if (err != nullptr)
             {
-                id value = [dict objectForKey:key];
-                std::string k = [key UTF8String];
-
-                if ([value isKindOfClass:[NSNumber class]])
-                {
-                    tree[k] = [value doubleValue];
-                }
-                else if ([value isKindOfClass:[NSString class]])
-                {
-                    tree[k] = std::string([value UTF8String]);
-                }
+                return;
             }
 
-            auto assign_safe = [&](const char* plistKey, const char* jsonKey, bool isInteger)
+            NSArray* od_results = [q resultsAllowingPartial:NO error:&err];
+
+            if (err != nullptr)
             {
-                if (!tree.contains(plistKey)) return;
+                // std::cout << "Error with OpenDirectory results: "
+                //  << std::string([[err localizedDescription] UTF8String])
+                //  << std::endl;
+                return;
+            }
 
-                const auto& val = tree[plistKey];
+            for (ODRecord * re in od_results)
+            {
 
-                try
+                NSError* attrErr = nullptr;
+                NSArray* userPolicyDataValues =
+                    [re valuesForAttribute:@"dsAttrTypeNative:accountPolicyData"
+                        error:&attrErr];
+
+                if (attrErr != nullptr || ![userPolicyDataValues count])
                 {
-                    if (val.is_number())
+                    // std::cout << "No accountPolicyData found for UID: "
+                    // << uid.c_str() << std::endl;
+                    return;
+                }
+
+                NSData* plistData = userPolicyDataValues[0];
+                NSPropertyListFormat format;
+                NSError* plistError = nil;
+
+                id plistDict = [NSPropertyListSerialization propertyListWithData:plistData
+                                                            options:NSPropertyListMutableContainersAndLeaves
+                                                            format:&format
+                                                            error:&plistError];
+
+                if (plistError != nil || ![plistDict isKindOfClass:[NSDictionary class]])
+                {
+                    return;
+                }
+
+                NSDictionary* dict = (NSDictionary*)plistDict;
+                nlohmann::json tree;
+
+                for (NSString * key in dict)
+                {
+                    id value = [dict objectForKey:key];
+                    std::string k = [key UTF8String];
+
+                    if ([value isKindOfClass:[NSNumber class]])
                     {
-                        if (isInteger)
-                        {
-                            policyData[jsonKey] = static_cast<int64_t>(val.get<double>());
-                        }
-                        else
-                        {
-                            policyData[jsonKey] = val.get<double>();
-                        }
+                        tree[k] = [value doubleValue];
                     }
-                    else if (val.is_string())
+                    else if ([value isKindOfClass:[NSString class]])
                     {
-                        if (isInteger)
-                        {
-                            policyData[jsonKey] = std::stoll(val.get<std::string>());
-                        }
-                        else
-                        {
-                            policyData[jsonKey] = std::stod(val.get<std::string>());
-                        }
+                        tree[k] = std::string([value UTF8String]);
                     }
                 }
-                catch (...)
-                {
-                    // Keep value in null if it fails
-                }
-            };
 
-            // Assign values if present and valid
-            assign_safe("creationTime", "creation_time", false);
-            assign_safe("failedLoginCount", "failed_login_count", true);
-            assign_safe("failedLoginTimestamp", "failed_login_timestamp", false);
-            assign_safe("passwordLastSetTime", "password_last_set_time", false);
+                auto assign_safe = [&](const char* plistKey, const char* jsonKey, bool isInteger)
+                {
+                    if (!tree.contains(plistKey)) return;
+
+                    const auto& val = tree[plistKey];
+
+                    try
+                    {
+                        if (val.is_number())
+                        {
+                            if (isInteger)
+                            {
+                                policyData[jsonKey] = static_cast<int64_t>(val.get<double>());
+                            }
+                            else
+                            {
+                                policyData[jsonKey] = val.get<double>();
+                            }
+                        }
+                        else if (val.is_string())
+                        {
+                            if (isInteger)
+                            {
+                                policyData[jsonKey] = std::stoll(val.get<std::string>());
+                            }
+                            else
+                            {
+                                policyData[jsonKey] = std::stod(val.get<std::string>());
+                            }
+                        }
+                    }
+                    catch (...)
+                    {
+                        // Keep value in null if it fails
+                    }
+                };
+
+                // Assign values if present and valid
+                assign_safe("creationTime", "creation_time", false);
+                assign_safe("failedLoginCount", "failed_login_count", true);
+                assign_safe("failedLoginTimestamp", "failed_login_timestamp", false);
+                assign_safe("passwordLastSetTime", "password_last_set_time", false);
+            }
         }
     }
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

`wazuh-modulesd` RSS grows steadily on macOS agents during load testing (~61-104% growth over ~1h run), failing the baseline `modulesd_macos_memory_growth_pct` check. Every other daemon/platform combination in the same run showed 0% or negative growth — macOS `wazuh-modulesd` was the only outlier.

Root cause: `genAccountPolicyData()` (`src/data_provider/src/extended_sources/wrappers/unix/darwin/od_wrapper.mm`) creates several autoreleased OpenDirectory/Foundation objects (`ODNode`, `ODQuery`, `NSArray` results, and a full `NSDictionary` tree built from the user's `accountPolicyData` plist via `NSPropertyListSerialization`) without wrapping them in an `@autoreleasepool`. `genEntries()`, in the same file, already does this correctly.

This function is called once per local user, on every syscollector full inventory scan cycle (`scanUsers()` runs each cycle per `syscollectorImp.cpp`). Since the syscollector scan thread has no Cocoa run loop to implicitly drain autoreleased objects, every call leaked its OpenDirectory/plist object graph for the life of the process — explaining why RSS only dropped back down on daemon restart, and why the growth was macOS-specific (Objective-C/OpenDirectory doesn't exist on Linux/Windows).

Closes #38081

## Proposed Changes

- `src/data_provider/src/extended_sources/wrappers/unix/darwin/od_wrapper.mm`: wrapped the body of `genAccountPolicyData()` in `@autoreleasepool { ... }`, matching the existing pattern already used in `genEntries()`. No behavior or data changes — this only ensures the autoreleased objects created per call are drained instead of accumulating.

### Results and Evidence

Static code-review finding, not yet validated with a live macOS profiling run. Confirmed via code inspection that:
- `genEntries()` (line 22) already wraps its OpenDirectory calls in `@autoreleasepool`.
- `genAccountPolicyData()` did not, and is the only other place in the file creating Objective-C objects.
- `grep -rn "autoreleasepool"` across the whole repository returned a single match (inside `genEntries()`), confirming no outer-level pool exists anywhere on the syscollector scan thread to drain these objects otherwise.
- `collectAccountPolicyData()` (`users_darwin.cpp`) confirms `genAccountPolicyData()` is called once per local user, and `scanUsers()` runs on every syscollector inventory cycle (`syscollectorImp.cpp`), matching the reported growth cadence.

Recommended before merge: re-run the macOS load test (or `leaks --atExit -- wazuh-modulesd` / Instruments Allocations trace) with this fix to confirm RSS growth is resolved.

### Manual tests with their corresponding evidence

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - N/A

- Engine _(Wazuh v5.x and above)_
  - N/A

- Wazuh server API/Framework
  - N/A

### Artifacts Affected

- `wazuh-modulesd` (agent, macOS only) — no other executables, configuration files, or packages affected.

### Configuration Changes

N/A — no new configuration parameters, default value changes, or backward-compatibility impact.

### Tests Introduced

None added. `genAccountPolicyData()` is implementation code behind `IODUtilsWrapper`, exercised through the real OpenDirectory framework rather than through the existing mocked unit tests for `users_darwin`/`groups_darwin`, so this change isn't covered by a new unit test — verification is via macOS-side memory profiling (see Results and Evidence).

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
