### PR TITLE
Cap stateful DELTA sync with byte-prefiltered blocks

### DIFF
--- a/.github/actions/check_files/deb_linux_agent_amd64.csv
+++ b/.github/actions/check_files/deb_linux_agent_amd64.csv
@@ -9,7 +9,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/bin/wazuh-agentd,root,root,750,file,-rwxr-x---,661568,0.1
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12374168,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,505104,0.1
-/var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,218488,0.1
+/var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,241184,0.1
 /var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,426880,0.1
 /var/ossec/lib/libschema_validator.so,root,wazuh,750,file,-rwxr-x---,390232,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2603392,0.1

--- a/.github/actions/check_files/rpm_linux_agent_amd64.csv
+++ b/.github/actions/check_files/rpm_linux_agent_amd64.csv
@@ -73,7 +73,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/bin/wazuh-agentd,root,root,750,file,-rwxr-x---,624632,0.1
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12417720,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,484376,0.1
-/var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,220736,0.1
+/var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,249336,0.1
 /var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,406408,0.1
 /var/ossec/lib/libschema_validator.so,root,wazuh,750,file,-rwxr-x---,386024,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2555328,0.1

--- a/docs/ref/modules/fim/architecture.md
+++ b/docs/ref/modules/fim/architecture.md
@@ -702,13 +702,16 @@ Run Delta Sync ──► asp_sync_module(MODE_DELTA)
                                             └─► Mismatch? ──► Trigger Recovery
                                                                  │
                                                                  ▼
-                                                         Load Entire Table into Memory
+                                                         Load Entire Table
                                                                      │
                                                                      ▼
-                                                         Persist All Entries (MODE_FULL)
+                                                         Clear Manager Index (DataClean)
                                                                      │
                                                                      ▼
-                                                         Full Sync with Manager
+                                                         Persist All Entries (MODE_DELTA)
+                                                                     │
+                                                                     ▼
+                                                         Delta Sync with Manager
     ```
 
 ---
@@ -914,13 +917,13 @@ if (schema_validator_is_initialized())
 
 if (validation_passed)
 {
-    // Persist for recovery
-    asp_persist_diff_in_memory(sync_handle, id, operation, index, data, version);
+    // Persist for recovery (into the sync protocol's persistent queue, same as any other delta item)
+    asp_persist_diff(sync_handle, id, operation, index, data, version);
 }
 ```
 
 **Key characteristics:**
-- Validation before in-memory persistence
+- Validation before persistence
 - Invalid items are skipped (not persisted)
 - Prevents synchronizing invalid recovery data
 

--- a/docs/ref/modules/fim/configuration.md
+++ b/docs/ref/modules/fim/configuration.md
@@ -408,7 +408,6 @@ Controls how the agent synchronizes its local FIM database with the manager to e
 <synchronization>
   <enabled>yes</enabled>
   <interval>300</interval>
-  <response_timeout>60</response_timeout>
   <max_eps>75</max_eps>
   <integrity_interval>86400</integrity_interval>
 </synchronization>
@@ -420,11 +419,10 @@ Controls how the agent synchronizes its local FIM database with the manager to e
 |---|---|---|---|
 | `enabled` | `yes` | `yes`, `no` | Enable or disable FIM synchronization persistence. When disabled, FIM only generates stateless events. |
 | `interval` | `300` (5 minutes) | Any integer ≥ 1, with optional suffix `s`, `m`, `h`, `d` | How often the agent initiates a sync with the manager. |
-| `response_timeout` | `60` | Any integer ≥ 1, with optional suffix `s`, `m`, `h`, `d` | Seconds to wait for a manager response before marking the synchronization attempt as failed or timed out. A value that is too low causes unnecessary retries; a value that is too high delays failure detection. |
 | `max_eps` | `75` | Integer `0`–`1000000` (`0` = unlimited) | Maximum synchronization messages per second. |
 | `integrity_interval` | `86400` (24h)| Any integer ≥ 1, with optional suffix `s`, `m`, `h`, `d` | How often the agent performs a full integrity validation by comparing checksums with the manager. |
 
-**Note:** The retry logic automatically retries failed sync operations up to **3 times** before giving up. Database files are stored at fixed paths: `queue/fim/db/fim.db` and `queue/fim/db/fim_sync.db`.
+**Note:** Database files are stored at fixed paths: `queue/fim/db/fim.db` and `queue/fim/db/fim_sync.db`.
 
 ---
 
@@ -633,7 +631,6 @@ For systems with high file change rates (CI/CD nodes, busy web servers):
   <synchronization>
     <enabled>yes</enabled>
     <interval>60</interval>
-    <response_timeout>60</response_timeout>
     <max_eps>500</max_eps>
     <integrity_interval>43200</integrity_interval>  <!-- Integrity check every 12 hours -->
   </synchronization>
@@ -678,7 +675,6 @@ For environments that require full audit trails on critical configuration files:
   <synchronization>
     <enabled>yes</enabled>
     <interval>5m</interval>
-    <response_timeout>60</response_timeout>
     <max_eps>75</max_eps>
     <integrity_interval>86400</integrity_interval>
   </synchronization>
@@ -903,7 +899,6 @@ The following use cases describe concrete end-to-end test scenarios for verifyin
 <synchronization>
   <enabled>yes</enabled>
   <interval>60</interval>
-  <response_timeout>30</response_timeout>
   <integrity_interval>3600</integrity_interval>
 </synchronization>
 ```

--- a/docs/ref/modules/inventory-sync/api-reference.md
+++ b/docs/ref/modules/inventory-sync/api-reference.md
@@ -38,18 +38,14 @@ The FlatBuffer protocol accepted by Inventory Sync includes:
 
 - `Start`
 - `DataValue`
-- `DataBatch`
 - `DataContext`
 - `DataClean`
 - `ChecksumModule`
 - `End`
-- `ReqRet`
 
 Responses produced by the manager include:
 
-- `StartAck`
 - `EndAck`
-- `ReqRet`
 
 See the FlatBuffers page for the full schema details.
 

--- a/docs/ref/modules/inventory-sync/architecture.md
+++ b/docs/ref/modules/inventory-sync/architecture.md
@@ -12,7 +12,7 @@ Responsibilities:
 
 - Creates and clears the local RocksDB session store in `inventory_sync/`.
 - Subscribes to the Router topic `inventory-states` with subscriber id `inventory-sync-module`.
-- Validates and dispatches `Start`, `DataValue`, `DataBatch`, `DataContext`, `DataClean`, `ChecksumModule`, `End`, and `ReqRet` protocol messages.
+- Validates and dispatches `Start`, `DataValue`, `DataContext`, `DataClean`, `ChecksumModule`, and `End` protocol messages.
 - Owns the worker queue for inbound messages and the queue that serializes indexer-side completion work.
 - Executes bulk indexing, delete-by-query, update-by-query, checksum verification, stale-session cleanup, and agent deletion.
 - Triggers the Vulnerability Scanner for sessions marked with `VDFirst` or `VDSync`.
@@ -45,7 +45,7 @@ Responsibilities:
 
 ### `src/wazuh_modules/inventory_sync/src/responseDispatcher.hpp`
 
-This component sends `StartAck`, `EndAck`, and retransmission requests back to the agent through the Router/response path.
+This component sends `EndAck` back to the agent through the Router/response path.
 
 ### `src/wazuh_modules/inventory_sync/src/inventorySyncQueryBuilder.hpp`
 
@@ -88,13 +88,12 @@ The protocol is organized around three phases:
 1. **Start**
 
 - The agent opens a session with module name, mode, option, message count, target indices, agent identity, groups, and cluster fields.
-- The manager assigns a 64-bit session id and replies with `StartAck`.
+- The manager assigns a 64-bit session id. No acknowledgment is sent back for session establishment.
 - The session is rejected if the indexer is unavailable, the agent is locked for metadata or group maintenance, or the configured session limit is reached.
 
 2. **Data**
 
 - `DataValue` carries upsert or delete operations for indexable state documents.
-- `DataBatch` carries multiple `DataValue` entries in one protocol message; Inventory Sync unwraps them and stores them as individual session entries.
 - `DataContext` carries auxiliary context data. Inventory Sync stores it in RocksDB and tracks its sequence number, but does not index it directly.
 - `DataClean` requests `deleteByQuery` against one or more indices for the current agent.
 - `ChecksumModule` provides the agent checksum used by `ModuleCheck`.
@@ -110,13 +109,14 @@ The protocol is organized around three phases:
 
 Inventory Sync supports these synchronization modes:
 
-- `ModuleFull`: delete all documents for the agent in the Start indices, then index the session payload.
 - `ModuleDelta`: apply only the `DataValue` upserts and deletes received in the session.
 - `ModuleCheck`: compare the agent checksum with the manager checksum for the target index.
 - `MetadataDelta`: update agent metadata fields on existing state documents.
 - `MetadataCheck`: repair stale or inconsistent metadata through update-by-query.
 - `GroupDelta`: update `wazuh.agent.groups` on existing state documents.
 - `GroupCheck`: repair stale or inconsistent groups through update-by-query.
+
+There is no full/replace mode (`ModuleFull` was removed): it used to `deleteByQuery` every index in `Start` unconditionally, which was unsafe once the agent started byte-capping its payloads — a truncated session would still trigger the full delete, permanently losing whatever did not fit. A full resync is now a `DataClean` (explicit, scoped delete of the target index) followed by an ordinary `ModuleDelta` sync of the fresh snapshot, which the agent can safely split across as many sessions as needed.
 
 ## Message handling details
 
@@ -126,17 +126,10 @@ Inventory Sync supports these synchronization modes:
 - Replayed at End time into `bulkIndex` or `bulkDelete` calls.
 - Enriched by the manager with `wazuh.agent.*` and `wazuh.cluster.name` metadata before indexing.
 
-### `DataBatch`
-
-- Supported by the current schema and implementation.
-- Used to ship many `DataValue` entries in one message.
-- Inventory Sync unpacks the batch and stores each item as an individual session record so the rest of the pipeline remains unchanged.
-
 ### `DataContext`
 
 - Stored in RocksDB as `{session}_{seq}_context`.
 - Excluded from indexer replay.
-- Participates in gap tracking and retransmission.
 - Can still be consumed by downstream session logic, including vulnerability-scanner flows that use the session RocksDB contents.
 
 ### `DataClean`
@@ -168,7 +161,6 @@ This prevents race conditions where inventory data would be indexed with stale m
 
 Inventory Sync includes several consistency mechanisms:
 
-- **Gap detection and retransmission** through `GapSet` and `ReqRet`.
 - **Stale-session cleanup** for sessions inactive for **20 minutes**.
 - **Periodic cleanup sweep** every **10 minutes**.
 - **Checksum validation** with retry logic for `ModuleCheck` to tolerate indexer propagation delays.

--- a/docs/ref/modules/inventory-sync/configuration.md
+++ b/docs/ref/modules/inventory-sync/configuration.md
@@ -302,7 +302,7 @@ The module subscribes to the Router and expects FlatBuffer messages on the `inve
 **Requirements:**
 - Router must be active on the manager
 - Agents must emit the synchronization protocol
-- Response path must be available for `StartAck`, `EndAck`, and retransmission messages
+- Response path must be available for `EndAck` messages
 
 ### Indexer Dependency
 

--- a/docs/ref/modules/inventory-sync/flatbuffers.md
+++ b/docs/ref/modules/inventory-sync/flatbuffers.md
@@ -16,12 +16,9 @@ union MessageType {
     DataClean,
     ChecksumModule,
     Start,
-    StartAck,
     End,
     EndAck,
-    ReqRet,
     DataContext,
-    DataBatch,
     FullSession
 }
 
@@ -34,7 +31,6 @@ root_type Message;
 
 ```flatbuffers
 enum Mode: byte {
-    ModuleFull,
     ModuleDelta,
     ModuleCheck,
     MetadataDelta,
@@ -105,7 +101,7 @@ table Start {
 Important fields:
 
 - `module`: currently `syscollector`, `fim`, or `sca` for indexed module flows.
-- `mode`: full, delta, integrity-check, metadata, or group mode.
+- `mode`: delta, integrity-check, metadata, or group mode. There is no full/replace mode: a full resync is a `DataClean` followed by a delta sync of the fresh snapshot (see [architecture.md](architecture.md)).
 - `size`: number of expected sequence-tracked messages.
 - `index`: target indices for the current session.
 - `option`: vulnerability-scanner integration behavior.
@@ -129,28 +125,16 @@ table DataValue {
 
 This is the main indexable payload type.
 
-- `seq`: sequence number used by `GapSet`.
 - `operation`: `Upsert` or `Delete`.
 - `id`: logical document id fragment.
 - `index`: target state index.
 - `version`: optional document version propagated to the indexer.
 - `data`: JSON payload bytes.
 
-### `DataBatch`
-
-```flatbuffers
-table DataBatch {
-    values: [DataValue];
-}
-```
-
-`DataBatch` allows multiple `DataValue` items to be sent inside one message. Inventory Sync expands the batch internally and stores each contained item as an individual session record. This is the standalone, per-message form used by the chunked protocol below; inside a `FullSession` the same `DataValue` items travel directly in `SyncData.values` instead (see [`FullSession`](#fullsession-one-message-per-session)), without the `DataBatch` wrapper.
-
 ### `DataContext`
 
 ```flatbuffers
 table DataContext {
-    seq: ulong;
     id: string;
     index: string;
     data: [byte];
@@ -160,7 +144,7 @@ table DataContext {
 Current behavior:
 
 - stored in RocksDB with a `_context` suffix,
-- tracked for retransmission and end-of-session completeness,
+- tracked for end-of-session completeness,
 - not indexed directly by Inventory Sync,
 - available to downstream processing that reads the session store.
 
@@ -168,7 +152,6 @@ Current behavior:
 
 ```flatbuffers
 table DataClean {
-    seq: ulong;
     index: string;
 }
 ```
@@ -197,16 +180,6 @@ table End {
 
 ## Acknowledgments
 
-### `StartAck`
-
-```flatbuffers
-table StartAck {
-    status: Status;
-}
-```
-
-Acknowledges that the manager accepted the `Start` request.
-
 ### `EndAck`
 
 ```flatbuffers
@@ -216,21 +189,6 @@ table EndAck {
 ```
 
 The manager returns the final outcome of the session in `EndAck`.
-
-## Retransmission support
-
-```flatbuffers
-table Pair {
-    begin: ulong;
-    end: ulong;
-}
-
-table ReqRet {
-    seq: [Pair];
-}
-```
-
-`ReqRet` is used to request retransmission of missing sequence ranges detected by the manager.
 
 ## `FullSession` (one message per session)
 
@@ -246,14 +204,10 @@ table Cleans {
     items: [DataClean];
 }
 
-table Checksums {
-    items: [ChecksumModule];
-}
-
 union SessionPayload {
     SyncData,
     Cleans,
-    Checksums
+    ChecksumModule
 }
 
 table FullSession {
@@ -265,7 +219,7 @@ table FullSession {
 
 The chunked `Start` → `StartAck` → `DataBatch`/`DataClean`/`ChecksumModule`[…] → `End` → `EndAck` exchange documented above exists because the module→agentd transport used to be a DGRAM socket bounded by `OS_MAXSTR` (65536), which forced sessions to be split into ~60 KB messages. Over the STREAM sync socket that bound is gone, so the agent now sends the whole session as **one** `FullSession` message and the manager answers it with a single `EndAck` — no `StartAck`, no per-item messages, no `ReqRet` round trip.
 
-- `payload` carries exactly one of `SyncData`, `Cleans`, or `Checksums` — a session is either a data sync, a clean notification, or an integrity check, never a combination. The union makes that mutual exclusion structural instead of relying on sender discipline.
+- `payload` carries exactly one of `SyncData`, `Cleans`, or `ChecksumModule` — a session is either a data sync, a clean notification, or an integrity check, never a combination. The union makes that mutual exclusion structural instead of relying on sender discipline. `ChecksumModule` is referenced directly (no wrapper array table) because an integrity check always covers a single index/module; `Cleans` stays an array because a session can clean several indices at once.
 - `SyncData.values` and `SyncData.contexts` *can* both be non-empty in the same session: regular module deltas (`DataValue`) and vulnerability-detection context items (`DataContext`) are pulled from the same producer queue and travel together.
 - `payload` can be entirely absent (a session with just `start`/`end`, no `SessionPayload` set at all) for metadata/group syncs that carry no data items.
 
@@ -273,5 +227,4 @@ The chunked `Start` → `StartAck` → `DataBatch`/`DataClean`/`ChecksumModule`[
 
 - `size` in `Start` can be zero for `MetadataDelta`, `MetadataCheck`, `GroupDelta`, `GroupCheck`, and `ModuleCheck` sessions.
 - `DataContext` is part of the live protocol even though it is not replayed into the indexer.
-- `DataBatch` is part of the live protocol and should be supported by tools that generate or validate Inventory Sync traffic.
 - The agent-side `sync_protocol` module (`src/shared_modules/sync_protocol`) only ever sends `FullSession` messages; the chunked, per-message protocol documented above is what Inventory Sync's manager-side receiver currently implements. Tools that need to interoperate with the agent as it actually behaves today should target `FullSession`.

--- a/docs/ref/modules/inventory-sync/flatbuffers.md
+++ b/docs/ref/modules/inventory-sync/flatbuffers.md
@@ -21,7 +21,8 @@ union MessageType {
     EndAck,
     ReqRet,
     DataContext,
-    DataBatch
+    DataBatch,
+    FullSession
 }
 
 root_type Message;
@@ -118,7 +119,6 @@ Important fields:
 ```flatbuffers
 table DataValue {
     seq: ulong;
-    session: ulong;
     operation: Operation;
     id: string;
     index: string;
@@ -130,7 +130,6 @@ table DataValue {
 This is the main indexable payload type.
 
 - `seq`: sequence number used by `GapSet`.
-- `session`: session identifier assigned in `StartAck`.
 - `operation`: `Upsert` or `Delete`.
 - `id`: logical document id fragment.
 - `index`: target state index.
@@ -145,14 +144,13 @@ table DataBatch {
 }
 ```
 
-`DataBatch` allows multiple `DataValue` items to be sent inside one message. Inventory Sync expands the batch internally and stores each contained item as an individual session record.
+`DataBatch` allows multiple `DataValue` items to be sent inside one message. Inventory Sync expands the batch internally and stores each contained item as an individual session record. This is the standalone, per-message form used by the chunked protocol below; inside a `FullSession` the same `DataValue` items travel directly in `SyncData.values` instead (see [`FullSession`](#fullsession-one-message-per-session)), without the `DataBatch` wrapper.
 
 ### `DataContext`
 
 ```flatbuffers
 table DataContext {
     seq: ulong;
-    session: ulong;
     id: string;
     index: string;
     data: [byte];
@@ -171,7 +169,6 @@ Current behavior:
 ```flatbuffers
 table DataClean {
     seq: ulong;
-    session: ulong;
     index: string;
 }
 ```
@@ -182,7 +179,6 @@ table DataClean {
 
 ```flatbuffers
 table ChecksumModule {
-    session: ulong;
     index: string;
     checksum: string;
 }
@@ -194,7 +190,6 @@ Used by `ModuleCheck` to compare the agent-side checksum with the manager-side c
 
 ```flatbuffers
 table End {
-    session: ulong;
 }
 ```
 
@@ -207,18 +202,16 @@ table End {
 ```flatbuffers
 table StartAck {
     status: Status;
-    session: ulong;
 }
 ```
 
-The manager returns the assigned session id here when the Start request succeeds.
+Acknowledges that the manager accepted the `Start` request.
 
 ### `EndAck`
 
 ```flatbuffers
 table EndAck {
     status: Status;
-    session: ulong;
 }
 ```
 
@@ -234,14 +227,51 @@ table Pair {
 
 table ReqRet {
     seq: [Pair];
-    session: ulong;
 }
 ```
 
 `ReqRet` is used to request retransmission of missing sequence ranges detected by the manager.
+
+## `FullSession` (one message per session)
+
+None of the tables above carry a `session` field anymore. The session id is chosen by the **agent**, not handed back by a `StartAck`, and it is not part of any FlatBuffer table at all — it travels as a parameter of the transport call that sends the session (e.g. as an HTTP header, when the transport is the HTTPS client), so a retried session keeps the same id and the manager can dedupe on it independently of the message body.
+
+```flatbuffers
+table SyncData {
+    values: [DataValue];
+    contexts: [DataContext];
+}
+
+table Cleans {
+    items: [DataClean];
+}
+
+table Checksums {
+    items: [ChecksumModule];
+}
+
+union SessionPayload {
+    SyncData,
+    Cleans,
+    Checksums
+}
+
+table FullSession {
+    start: Start;
+    payload: SessionPayload;
+    end: End;
+}
+```
+
+The chunked `Start` → `StartAck` → `DataBatch`/`DataClean`/`ChecksumModule`[…] → `End` → `EndAck` exchange documented above exists because the module→agentd transport used to be a DGRAM socket bounded by `OS_MAXSTR` (65536), which forced sessions to be split into ~60 KB messages. Over the STREAM sync socket that bound is gone, so the agent now sends the whole session as **one** `FullSession` message and the manager answers it with a single `EndAck` — no `StartAck`, no per-item messages, no `ReqRet` round trip.
+
+- `payload` carries exactly one of `SyncData`, `Cleans`, or `Checksums` — a session is either a data sync, a clean notification, or an integrity check, never a combination. The union makes that mutual exclusion structural instead of relying on sender discipline.
+- `SyncData.values` and `SyncData.contexts` *can* both be non-empty in the same session: regular module deltas (`DataValue`) and vulnerability-detection context items (`DataContext`) are pulled from the same producer queue and travel together.
+- `payload` can be entirely absent (a session with just `start`/`end`, no `SessionPayload` set at all) for metadata/group syncs that carry no data items.
 
 ## Practical notes
 
 - `size` in `Start` can be zero for `MetadataDelta`, `MetadataCheck`, `GroupDelta`, `GroupCheck`, and `ModuleCheck` sessions.
 - `DataContext` is part of the live protocol even though it is not replayed into the indexer.
 - `DataBatch` is part of the live protocol and should be supported by tools that generate or validate Inventory Sync traffic.
+- The agent-side `sync_protocol` module (`src/shared_modules/sync_protocol`) only ever sends `FullSession` messages; the chunked, per-message protocol documented above is what Inventory Sync's manager-side receiver currently implements. Tools that need to interoperate with the agent as it actually behaves today should target `FullSession`.

--- a/docs/ref/modules/inventory-sync/test-tools.md
+++ b/docs/ref/modules/inventory-sync/test-tools.md
@@ -17,9 +17,8 @@ They cover components such as:
 - `AgentSession`
 - `GapSet`
 - `ResponseDispatcher`
-- `DataBatch` handling behavior
 
-These tests validate session lifecycle, chunk tracking, checksum handling, retransmission behavior, and response dispatch without requiring a full manager deployment.
+These tests validate session lifecycle, chunk tracking, checksum handling, and response dispatch without requiring a full manager deployment.
 
 ## Protocol integration tests
 
@@ -33,7 +32,6 @@ Current test coverage includes flows such as:
 
 - basic start/data/end synchronization,
 - sessions with no data,
-- `ReqRet` retransmission handling,
 - `DataClean` processing,
 - `DataContext`-only sessions,
 - checksum match and mismatch flows,

--- a/docs/ref/modules/sca/configuration.md
+++ b/docs/ref/modules/sca/configuration.md
@@ -92,14 +92,6 @@ Time interval between database synchronization cycles.
 - **Allowed values:** Time format strings in seconds (e.g., `300s`, `600s`)
 - **Note:** Controls how frequently the agent synchronizes SCA state with the manager
 
-### synchronization/response_timeout
-
-Maximum time to wait for manager response during synchronization.
-
-- **Default value:** `60s`
-- **Allowed values:** Time format strings in seconds
-- **Note:** If timeout is exceeded, synchronization is retried in the next cycle
-
 ### synchronization/max_eps
 
 Maximum events per second for synchronization operations.
@@ -211,7 +203,6 @@ Complete configuration including synchronization settings:
   <synchronization>
     <enabled>yes</enabled>
     <interval>300</interval>
-    <response_timeout>60</response_timeout>
     <max_eps>75</max_eps>
     <integrity_interval>86400</integrity_interval>
   </synchronization>

--- a/docs/ref/modules/syscollector/architecture.md
+++ b/docs/ref/modules/syscollector/architecture.md
@@ -383,14 +383,17 @@ When a checksum mismatch is detected for a table:
 1. **Version Increment**: All entries in the table have their version incremented by 1
    - Uses DBSync's `increaseEachEntryVersion()` method
 2. **Data Extraction**: All elements are retrieved from the affected table
-3. **Memory Preparation**: In-memory sync data is cleared via `clearInMemoryData()`
+3. **Index Clear**: The manager's index for this table is cleared via `notifyDataClean()` — there
+   is no full-replace mode; recovery is a `DataClean` followed by an ordinary delta sync of the
+   fresh snapshot (a byte-capped `Mode::FULL` used to make the manager unconditionally
+   `deleteByQuery` the whole index, which could permanently drop whatever didn't fit in one
+   session)
 4. **Stateful Message Rebuild**: Each inventory item is:
    - Converted to ECS format
    - Wrapped in stateful message structure
-   - Persisted to sync protocol memory with CREATE operation
-5. **Full Synchronization**: A FULL mode synchronization is triggered
-   - Sends all data for the affected table to manager
-   - Manager replaces its entire state for that index
+   - Persisted to the sync protocol's queue with CREATE operation via `persistDifference()`
+5. **Delta Synchronization**: A `Mode::DELTA` synchronization is triggered
+   - Sends all data for the affected table to the manager, safely split across sessions if needed
 6. **Timestamp Update**: `last_sync_time` is updated to current timestamp
 
 ### Recovery Flow Diagram
@@ -903,7 +906,7 @@ if (!validationPassed)
 
 if (shouldPersist)
 {
-    m_spSyncProtocol->persistDifferenceInMemory(
+    m_spSyncProtocol->persistDifference(
         calculateHashId(item, tableName),
         Operation::CREATE,
         index,
@@ -914,7 +917,7 @@ if (shouldPersist)
 ```
 
 **Key characteristics:**
-- Validation before in-memory persistence
+- Validation before persistence to the sync protocol's persistent queue
 - Invalid items are skipped (not persisted)
 - Prevents synchronizing invalid recovery data
 

--- a/docs/ref/modules/syscollector/configuration.md
+++ b/docs/ref/modules/syscollector/configuration.md
@@ -172,14 +172,6 @@ How often to trigger synchronization with the manager.
 - **Allowed values:** `1` to unlimited (seconds)
 - **Note:** Lower values provide faster synchronization but increase manager load. Higher values reduce network traffic but delay inventory delivery.
 
-### response_timeout
-
-Timeout for waiting manager responses during synchronization.
-
-- **Default value:** `60` (1 minute)
-- **Allowed values:** `1` to unlimited (seconds)
-- **Note:** Should be adjusted based on network latency. Inventory payloads can be larger than FIM events, may need higher timeouts than other modules.
-
 ### max_eps
 
 Maximum events per second for synchronization messages.
@@ -241,7 +233,6 @@ Standard configuration for most deployments:
     <synchronization>
         <enabled>yes</enabled>
         <interval>300</interval>
-        <response_timeout>60</response_timeout>
         <max_eps>75</max_eps>
         <integrity_interval>86400</integrity_interval>
     </synchronization>
@@ -376,7 +367,6 @@ Optimized for large-scale deployments with fast networks:
     <synchronization>
         <enabled>yes</enabled>
         <interval>120</interval>
-        <response_timeout>90</response_timeout>
         <max_eps>200</max_eps>
         <integrity_interval>43200</integrity_interval>  <!-- 12 hours -->
     </synchronization>
@@ -541,13 +531,6 @@ grep -i "sync.*error" /var/ossec/logs/ossec.log
 ```xml
 <synchronization>
     <integrity_interval>172800</integrity_interval>  <!-- 48 hours -->
-</synchronization>
-```
-
-**Increase response timeout for slow networks:**
-```xml
-<synchronization>
-    <response_timeout>120</response_timeout>  <!-- 2 minutes -->
 </synchronization>
 ```
 

--- a/docs/ref/modules/utils/flatbuffers/README.md
+++ b/docs/ref/modules/utils/flatbuffers/README.md
@@ -9,8 +9,9 @@ FlatBuffers is a high-performance serialization library used throughout Wazuh fo
 The Inventory Sync module uses FlatBuffers as its primary communication protocol for synchronizing inventory data between agents and the manager. The protocol supports multiple synchronization modes:
 
 **Module Synchronization** (agent-side inventory modules):
-- `ModuleFull`: Complete inventory replacement for a module (syscollector, FIM, SCA)
-- `ModuleDelta`: Incremental updates for inventory changes
+- `ModuleDelta`: Incremental updates for inventory changes. A full-replace resync (e.g. after a
+  checksum mismatch) is a `DataClean` followed by an ordinary `ModuleDelta` sync of the fresh
+  snapshot — there is no separate full-replacement mode.
 - `ModuleCheck`: Integrity verification using checksums
 
 **Agent Context Synchronization** (agent-info module):
@@ -56,7 +57,7 @@ These schemas are compiled into C++ headers during the build process.
 
 ### `inventorySync.fbs` — Status Enum
 
-The `Status` enum is used in acknowledgment messages (`StartAck`, `EndAck`) to convey the outcome of a protocol phase:
+The `Status` enum is used in the `EndAck` acknowledgment message to convey the outcome of a protocol phase:
 
 | Value | Meaning |
 |-------|---------|

--- a/docs/ref/modules/utils/sync-protocol/README.md
+++ b/docs/ref/modules/utils/sync-protocol/README.md
@@ -82,9 +82,7 @@ To integrate the Agent Sync Protocol in your module:
 
 2. Create a protocol instance with your module name and database path
 
-3. Persist differences using:
-   - `persistDifference()` / `asp_persist_diff()` for database storage
-   - `persistDifferenceInMemory()` / `asp_persist_diff_in_memory()` for in-memory recovery
+3. Persist differences using `persistDifference()` / `asp_persist_diff()`
 
 4. Process manager responses with `parseResponseBuffer()` or `asp_parse_response_buffer()`
 
@@ -95,7 +93,9 @@ To integrate the Agent Sync Protocol in your module:
    - `synchronizeModule()` / `asp_sync_module()` for module data
    - `synchronizeMetadataOrGroups()` / `asp_sync_metadata_or_groups()` for metadata/groups
 
-7. Clean up in-memory data (if used):
-   - `clearInMemoryData()` / `asp_clear_in_memory_data()` before recovery
+7. For a full-replace resync (e.g. after a checksum mismatch), call `notifyDataClean()` /
+   `asp_notify_data_clean()` on the affected indices first, then re-persist the fresh snapshot
+   and synchronize with `Mode::DELTA` — there is no in-memory recovery API or `Mode::FULL`
+   anymore (see [Protocol Lifecycle](lifecycle.md#full-replace-recovery-dataclean-then-delta)).
 
 See the [Integration Guide](integration-guide.md) for detailed examples.

--- a/docs/ref/modules/utils/sync-protocol/README.md
+++ b/docs/ref/modules/utils/sync-protocol/README.md
@@ -4,14 +4,20 @@
 
 The **Agent Sync Protocol** is a shared module that provides a standardized interface for internal Wazuh modules (FIM, SCA, Inventory) to synchronize data with the Wazuh Manager. It implements a reliable, session-based synchronization mechanism that ensures data consistency and handles errors gracefully.
 
-The protocol supports both **full** and **delta synchronization modes**, enabling efficient data transfer while maintaining state consistency. It uses a persistent queue backed by SQLite for durability and implements retry mechanisms with timeout controls to handle failures.
+The protocol supports both **full** and **delta synchronization modes**, enabling efficient data transfer
+while maintaining state consistency. It uses a persistent queue backed by SQLite for durability.
+Timeout and retry behaviour for the HTTP layer are owned exclusively by the HTTPS transport module;
+the sync protocol itself waits indefinitely for the transport callback and relies on the module's own
+periodic cycle to retry after failures.
 
 ## Key Features
 
 - **Unified API**: Single interface for all modules to interact with the synchronization protocol
 - **Persistent Storage**: SQLite-based queue ensures data durability across agent restarts
-- **Session Management**: Unique session IDs track synchronization state between agent and manager
-- **Retry Mechanism**: Configurable retry attempts with exponential backoff for network resilience
+- **Session Management**: Unique session IDs track synchronization state and guard against stale responses
+- **Transport-Owned Retry**: HTTP-level retries and per-request timeouts are managed by the HTTPS
+  transport layer (`STATEFUL_MAX_ATTEMPTS`, `statefulTimeoutMs`); the protocol layer does not impose
+  a separate response-wait timeout
 - **EPS Control**: Rate limiting to prevent overwhelming the manager with data
 - **Multiple Sync Modes**: Support for full, delta, integrity check, metadata, and groups synchronization
 

--- a/docs/ref/modules/utils/sync-protocol/README.md
+++ b/docs/ref/modules/utils/sync-protocol/README.md
@@ -27,27 +27,33 @@ Each internal module maintains its own instance of the Agent Sync Protocol with 
 
 ```
 ┌─────────────┐   ┌─────────────┐   ┌─────────────┐
-│     FIM     │   │     SCA     │   │  Inventory  │
+│     FIM     │   │     SCA     │   │ Syscollector│
 └──────┬──────┘   └──────┬──────┘   └──────┬──────┘
        │                 │                 │
 ┌──────▼──────┐   ┌──────▼──────┐   ┌──────▼──────┐
 │ Agent Sync  │   │ Agent Sync  │   │ Agent Sync  │
 │ Protocol    │   │ Protocol    │   │ Protocol    │
-│ (FIM)       │   │ (SCA)       │   │ (Inventory) │
+│ (FIM)       │   │ (SCA)       │   │(Syscollector│
 └──────┬──────┘   └──────┬──────┘   └──────┬──────┘
        │                 │                 │
 ┌──────▼──────┐   ┌──────▼──────┐   ┌──────▼──────┐
 │   SQLite    │   │   SQLite    │   │   SQLite    │
-│ fim_sync.db │   │ sca_sync.db │   │ inv_sync.db │
+│ fim_sync.db │   │ sca_sync.db │   │ sys_sync.db │
 └──────┬──────┘   └──────┬──────┘   └──────┬──────┘
        │                 │                 │
        └────────────┬────┴─────────────────┘
+                    │  one FullSession message per session
+                    ▼
+        ┌───────────────────────┐
+        │   queue-sync socket   │  (local AF_UNIX STREAM,
+        │  (SyncSocketTransport)│   no size bound)
+        └───────────┬───────────┘
                     │
-           ┌────────▼────────┐
-           │  Message Queue  │
-           │    (MQueue)     │
-           └────────┬────────┘
-                    │
+                    ▼
+        ┌───────────────────────┐
+        │  agentd / https_client │
+        └───────────┬───────────┘
+                    │  HTTPS POST /stateful
                     ▼
              Wazuh Manager
 ```

--- a/docs/ref/modules/utils/sync-protocol/api-reference.md
+++ b/docs/ref/modules/utils/sync-protocol/api-reference.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Agent Sync Protocol exposes APIs through both C++ and C interfaces, allowing modules written in different languages to integrate seamlessly. The protocol manages the complete synchronization lifecycle, from persisting differences to handling manager responses.
+The Agent Sync Protocol exposes APIs through both C++ and C interfaces, allowing modules written in different languages to integrate seamlessly. The protocol manages the complete synchronization lifecycle, from persisting differences to handling manager responses. On the wire, a whole session (data and all) crosses as one `FullSession` FlatBuffer message and the manager answers with one `EndAck` — see [Protocol Lifecycle](lifecycle.md) for the message-level detail.
 
 ## C++ Interface
 
@@ -22,18 +22,20 @@ Implements the `IAgentSyncProtocol` interface for synchronization operations.
 
 ```cpp
 AgentSyncProtocol(const std::string& moduleName,
-                   const std::string& dbPath,
-                   MQ_Functions mqFuncs,
-                   LoggerFunc logger,
-                   std::shared_ptr<IPersistentQueue> queue = nullptr)
+                  std::optional<std::string> dbPath,
+                  LoggerFunc logger,
+                  std::shared_ptr<IPersistentQueue> queue = nullptr,
+                  std::shared_ptr<ISyncSessionTransport> syncTransport = nullptr)
 ```
 
 **Parameters:**
-- `moduleName`: Unique identifier for the module (e.g., "FIM", "SCA", "Inventory")
-- `dbPath`: Full path to the SQLite database file for persistent storage
-- `mqFuncs`: Structure containing message queue function pointers
+- `moduleName`: Unique identifier for the module (e.g., "fim", "sca", "syscollector")
+- `dbPath`: Full path to the SQLite database file for persistent storage, or `std::nullopt` for in-memory-only synchronization
 - `logger`: Callback function for logging messages
-- `queue`: Optional custom persistent queue implementation
+- `queue`: Optional custom persistent queue implementation (mainly for testing)
+- `syncTransport`: Optional custom carrier for whole sessions (mainly for testing); defaults to `SyncSocketTransport`, which streams the session over the agent's local `queue-sync` socket
+
+There is no `timeout`/`retries` constructor parameter: HTTP-level timeout and retry are owned exclusively by the HTTPS transport layer (`statefulTimeoutMs`, `STATEFUL_MAX_ATTEMPTS`). See [Transport-Level Timeout and Retry](lifecycle.md#transport-level-timeout-and-retry).
 
 #### Public Methods
 
@@ -41,26 +43,31 @@ AgentSyncProtocol(const std::string& moduleName,
 
 ```cpp
 void persistDifference(const std::string& id,
-                      Operation operation,
-                      const std::string& index,
-                      const std::string& data)
+                       Operation operation,
+                       const std::string& index,
+                       const std::string& data,
+                       uint64_t version,
+                       bool isDataContext = false)
 ```
 
-Persists a data to the internal queue for later synchronization.
+Persists a data item to the internal SQLite-backed queue for later synchronization.
 
 **Parameters:**
 - `id`: Unique identifier for the data source (typically a hash of primary keys, e.g., file-path)
-- `operation`: Type of operation (`Operation::CREATE`, `Operation::UPDATE`, `Operation::DELETE`)
+- `operation`: Type of operation (`Operation::CREATE`, `Operation::MODIFY`, `Operation::DELETE_`)
 - `index`: Target index or destination for the data
 - `data`: JSON string containing the difference data
+- `version`: Version of the data
+- `isDataContext`: `true` marks the item as a `DataContext` item (vulnerability-detection data, no operation/version semantics on the wire) instead of a regular `DataValue` item. Regular `DataValue` and `DataContext` items can be mixed in the same queue and end up in the same `SyncData` payload of one session.
 
 **Example:**
 ```cpp
 protocol.persistDifference(
     "abc123def456",
     Operation::CREATE,
-    "fim_events",
-    "{\"path\": \"/etc/passwd\", \"hash\": \"...\", \"timestamp\": 1234567890}"
+    "fim_files",
+    "{\"path\": \"/etc/passwd\", \"hash\": \"...\", \"timestamp\": 1234567890}",
+    1
 );
 ```
 
@@ -70,16 +77,18 @@ protocol.persistDifference(
 void persistDifferenceInMemory(const std::string& id,
                                Operation operation,
                                const std::string& index,
-                               const std::string& data)
+                               const std::string& data,
+                               uint64_t version)
 ```
 
-Persists a difference to in-memory vector instead of database. This method is used for recovery scenarios where data should be kept in memory.
+Persists a difference to an in-memory vector instead of the database. Used for recovery scenarios where data should be kept in memory rather than written to disk; consumed by a subsequent `synchronizeModule(Mode::FULL, ...)` call instead of the persistent queue.
 
 **Parameters:**
 - `id`: Unique identifier for the data item
-- `operation`: Type of operation (`Operation::CREATE`, `Operation::UPDATE`, `Operation::DELETE`)
+- `operation`: Type of operation (`Operation::CREATE`, `Operation::MODIFY`, `Operation::DELETE_`)
 - `index`: Logical index for the data item
 - `data`: Serialized content of the message
+- `version`: Version of the data
 
 ##### `synchronizeModule()`
 
@@ -87,12 +96,11 @@ Persists a difference to in-memory vector instead of database. This method is us
 SyncModuleResult synchronizeModule(Mode mode, Option option = Option::SYNC)
 ```
 
-Initiates a synchronization session with the manager.
+Synchronizes a module's pending data with the manager. `Mode::FULL` reads from the in-memory vector (see `persistDifferenceInMemory()`); `Mode::DELTA` reads from the persistent queue, split into as many `FullSession` messages as needed to stay under the byte cap (`Option::VDFIRST`/`Option::VDSYNC` are exempt from that cap); `Mode::CHECK` is handled by `requiresFullSync()` instead.
 
 **Parameters:**
 - `mode`: Synchronization mode (`Mode::FULL` or `Mode::DELTA`)
-- `option`: Sync option (default `Option::SYNC`; use `Option::VDFIRST` / `Option::VDSYNC` for
-  VD flows that are exempt from the byte-cap)
+- `option`: Sync option (default `Option::SYNC`; use `Option::VDFIRST` / `Option::VDSYNC` for VD flows)
 
 **Returns:** `SyncModuleResult` with success flag, optional failure reason, stop and manager-not-ready flags, and consecutive failure count
 
@@ -108,22 +116,16 @@ if (!result.success) {
 
 ```cpp
 bool requiresFullSync(const std::string& index,
-                     const std::string& checksum,
-                     std::chrono::seconds timeout,
-                     unsigned int retries,
-                     size_t maxEps)
+                      const std::string& checksum)
 ```
 
-Checks if a module index requires full synchronization by verifying the checksum with the manager.
+Checks if a module index requires full synchronization by sending one `FullSession` carrying a `Checksums` payload and waiting for the manager's `EndAck`.
 
 **Parameters:**
 - `index`: The index/table to check
 - `checksum`: The calculated checksum for the index
-- `timeout`: Maximum time to wait for each response
-- `retries`: Number of retry attempts
-- `maxEps`: Maximum events per second (0 = unlimited)
 
-**Returns:** `true` if full sync is required (checksum mismatch); `false` if integrity is valid or connection error.
+**Returns:** `true` if full sync is required (checksum mismatch, i.e. `EndAck.status != Ok`); `false` if integrity is valid or the transport is not currently reachable
 
 ##### `clearInMemoryData()`
 
@@ -136,53 +138,60 @@ Clears the in-memory data queue. This method removes all entries from the in-mem
 ##### `synchronizeMetadataOrGroups()`
 
 ```cpp
-bool synchronizeMetadataOrGroups(Mode mode,
-                                std::chrono::seconds timeout,
-                                unsigned int retries,
-                                size_t maxEps,
-                                uint64_t globalVersion)
+SyncModuleResult synchronizeMetadataOrGroups(Mode mode,
+                                             const std::vector<std::string>& indices,
+                                             uint64_t globalVersion)
 ```
 
-Synchronizes metadata or groups with the server without sending data. This method handles the following modes: MetadataDelta, MetadataCheck, GroupDelta, GroupCheck. The sequence is: Start → StartAck → End → EndAck (no Data messages).
+Synchronizes metadata or groups with the manager without sending any data items. Sent as one `FullSession` carrying `Start` and `End` only — `payload` is absent.
 
 **Parameters:**
-- `mode`: Synchronization mode (must be `Mode::MetadataDelta`, `Mode::MetadataCheck`, `Mode::GroupDelta`, or `Mode::GroupCheck`)
-- `timeout`: Timeout duration for waiting for server responses
-- `retries`: Number of retry attempts for each message
-- `maxEps`: Maximum events per second (0 = unlimited)
-- `globalVersion`: Global version to include in the Start message.
+- `mode`: Synchronization mode (must be `Mode::METADATA_DELTA`, `Mode::METADATA_CHECK`, `Mode::GROUP_DELTA`, or `Mode::GROUP_CHECK`)
+- `indices`: Index names that will be updated by the manager
+- `globalVersion`: Global version to include in the `Start` message
 
-**Returns:** `true` if synchronization completed successfully, `false` otherwise
+**Returns:** `SyncModuleResult` with success flag and failure reason if unsuccessful
 
 ##### `notifyDataClean()`
 
 ```cpp
-bool notifyDataClean(const std::vector<std::string>& indices,
-                     std::chrono::seconds timeout,
-                     unsigned int retries,
-                     size_t maxEps)
+bool notifyDataClean(const std::vector<std::string>& indices, Option option = Option::SYNC)
 ```
 
-Notifies the manager about data cleaning for specified indices. This method sends DataClean messages for each index in the provided vector. The sequence is: Start → StartAck → DataClean (for each index) → End → EndAck. Upon receiving Ok, it clears the local database and returns true.
+Notifies the manager about data cleaning for specified indices. Sent as one `FullSession` carrying a `Cleans` payload (one `DataClean` per index). Upon receiving `Ok`, it clears the local database and returns true.
 
 **Parameters:**
-- `indices`: Vector of index names to clean
-- `timeout`: Timeout duration for waiting for server responses
-- `retries`: Number of retry attempts for each message
-- `maxEps`: Maximum events per second (0 = unlimited)
+- `indices`: Index names to clean
+- `option`: Synchronization option (default `Option::SYNC`)
 
 **Returns:** `true` if notification completed successfully and database was cleared, `false` otherwise
 
 **Example:**
 ```cpp
 std::vector<std::string> indices = {"fim_files", "fim_registry"};
-bool success = protocol.notifyDataClean(
-    indices,
-    std::chrono::seconds(30),
-    3,
-    1000
-);
+bool success = protocol.notifyDataClean(indices);
 ```
+
+##### `fetchPendingItems()`
+
+```cpp
+std::vector<PersistedData> fetchPendingItems(bool onlyDataValues = true)
+```
+
+Fetches pending items from the persistent queue without marking them as syncing.
+
+**Parameters:**
+- `onlyDataValues`: If `true`, only returns items with `is_data_context = false`
+
+**Returns:** Vector of pending items
+
+##### `clearAllDataContext()`
+
+```cpp
+void clearAllDataContext()
+```
+
+Clears all `DataContext` items (vulnerability-detection data) from the persistent queue. Should be called before adding new `DataContext` items to prevent inconsistencies.
 
 ##### `deleteDatabase()`
 
@@ -197,19 +206,29 @@ Deletes the database file. This method closes the database connection and remove
 protocol.deleteDatabase();
 ```
 
+##### `stop()` / `reset()` / `shouldStop()`
+
+```cpp
+void stop()
+void reset()
+bool shouldStop() const
+```
+
+`stop()` signals the protocol to abort any ongoing or pending synchronization; call it when the module is shutting down. `reset()` clears the stop flag so the module can restart operations. `shouldStop()` reports whether a stop is currently in effect.
+
 ##### `parseResponseBuffer()`
 
 ```cpp
 bool parseResponseBuffer(const uint8_t* data, size_t length)
 ```
 
-Processes FlatBuffer-encoded responses from the manager.
+Processes a response from the manager. Accepts either a FlatBuffer-encoded `Message` wrapping an `EndAck` (the response format used by `SyncSocketTransport`/the on-disk sync path), or the newer `"HCRESULT:<session>:<code>"` string format the HTTPS transport uses to route an HTTP status code back to the originating session (`"HCRESULT:<code>"`, without a session number, is accepted for backward compatibility and skips the session-correlation check).
 
 **Parameters:**
-- `data`: Pointer to the FlatBuffer message
-- `length`: Size of the message in bytes
+- `data`: Pointer to the response buffer
+- `length`: Size of the buffer in bytes
 
-**Returns:** `true` if message was successfully parsed and processed
+**Returns:** `true` if the message was successfully parsed and processed
 
 ## C Interface
 
@@ -227,9 +246,7 @@ Processes FlatBuffer-encoded responses from the manager.
 ```c
 AgentSyncProtocolHandle* asp_create(const char* module,
                                    const char* db_path,
-                                   asp_logger_t logger,
-                                   unsigned int timeout,
-                                   unsigned int retries)
+                                   asp_logger_t logger)
 ```
 
 Creates a new Agent Sync Protocol instance.
@@ -238,10 +255,6 @@ Creates a new Agent Sync Protocol instance.
 - `module`: Module name string (e.g. `"fim"`, `"syscollector"`)
 - `db_path`: SQLite database file path for the persistent queue (`NULL` for in-memory only)
 - `logger`: Logging callback function
-- `timeout`: Accepted for ABI compatibility but **no longer used**. The response-wait timeout
-  is owned by the HTTPS transport layer (`statefulTimeoutMs`).
-- `retries`: Number of times to retry the local sync-socket hand-off when the intake socket is
-  temporarily unavailable (e.g. during an agentd restart). Does **not** affect HTTP-level retries.
 
 **Returns:** Opaque handle to the protocol instance, or NULL on failure
 
@@ -263,10 +276,11 @@ void asp_persist_diff(AgentSyncProtocolHandle* handle,
                      const char* id,
                      Operation_t operation,
                      const char* index,
-                     const char* data)
+                     const char* data,
+                     uint64_t version)
 ```
 
-C wrapper for `persistDifference()`.
+C wrapper for `persistDifference()`, always with `isDataContext = false`.
 
 **Parameters:**
 - `handle`: Protocol handle
@@ -274,6 +288,7 @@ C wrapper for `persistDifference()`.
 - `operation`: Operation type (`OPERATION_CREATE`, `OPERATION_MODIFY`, `OPERATION_DELETE`, `OPERATION_NO_OP`)
 - `index`: Target index
 - `data`: JSON data string
+- `version`: Version of the data
 
 #### `asp_persist_diff_in_memory()`
 
@@ -282,10 +297,11 @@ void asp_persist_diff_in_memory(AgentSyncProtocolHandle* handle,
                                 const char* id,
                                 Operation_t operation,
                                 const char* index,
-                                const char* data)
+                                const char* data,
+                                uint64_t version)
 ```
 
-C wrapper for `persistDifferenceInMemory()`. Persists a difference to in-memory vector instead of database.
+C wrapper for `persistDifferenceInMemory()`. Persists a difference to an in-memory vector instead of the database.
 
 **Parameters:**
 - `handle`: Protocol handle
@@ -293,6 +309,7 @@ C wrapper for `persistDifferenceInMemory()`. Persists a difference to in-memory 
 - `operation`: Operation type (`OPERATION_CREATE`, `OPERATION_MODIFY`, `OPERATION_DELETE`, `OPERATION_NO_OP`)
 - `index`: Logical index for the data item
 - `data`: Serialized content of the message
+- `version`: Version of the data
 
 #### `asp_sync_module()`
 
@@ -300,7 +317,7 @@ C wrapper for `persistDifferenceInMemory()`. Persists a difference to in-memory 
 SyncModuleResult_t asp_sync_module(AgentSyncProtocolHandle* handle, Mode_t mode)
 ```
 
-C wrapper for `synchronizeModule()`.
+C wrapper for `synchronizeModule()` with the default `Option_t` (`OPTION_SYNC`).
 
 **Parameters:**
 - `handle`: Protocol handle
@@ -346,14 +363,14 @@ SyncModuleResult_t asp_sync_metadata_or_groups(AgentSyncProtocolHandle* handle,
                                                uint64_t global_version)
 ```
 
-C wrapper for `synchronizeMetadataOrGroups()`. Synchronizes metadata or groups with the server without sending data.
+C wrapper for `synchronizeMetadataOrGroups()`. Synchronizes metadata or groups with the manager without sending data.
 
 **Parameters:**
 - `handle`: Protocol handle
 - `mode`: Sync mode (`MODE_METADATA_DELTA`, `MODE_METADATA_CHECK`, `MODE_GROUP_DELTA`, or `MODE_GROUP_CHECK`)
 - `indices`: Array of index name strings that will be updated by the manager
 - `indices_count`: Number of indices in the array
-- `global_version`: Global version to include in the Start message
+- `global_version`: Global version to include in the `Start` message
 
 **Returns:** `SyncModuleResult_t` with success flag and failure reason if unsuccessful
 
@@ -365,7 +382,7 @@ bool asp_notify_data_clean(AgentSyncProtocolHandle* handle,
                            size_t indices_count)
 ```
 
-C wrapper for `notifyDataClean()`. Notifies the manager about data cleaning for specified indices.
+C wrapper for `notifyDataClean()` with the default `Option_t` (`OPTION_SYNC`). Notifies the manager about data cleaning for specified indices.
 
 **Parameters:**
 - `handle`: Protocol handle
@@ -377,14 +394,7 @@ C wrapper for `notifyDataClean()`. Notifies the manager about data cleaning for 
 **Example:**
 ```c
 const char* indices[] = {"fim_files", "fim_registry"};
-bool success = asp_notify_data_clean(
-    handle,
-    indices,
-    2,
-    30,
-    3,
-    1000
-);
+bool success = asp_notify_data_clean(handle, indices, 2);
 ```
 
 #### `asp_delete_database()`
@@ -393,7 +403,7 @@ bool success = asp_notify_data_clean(
 void asp_delete_database(AgentSyncProtocolHandle* handle)
 ```
 
-C wrapper for `deleteDatabase()`. Deletes the database file. This function closes the database connection and removes the database file from disk.
+C wrapper for `deleteDatabase()`. Closes the database connection and removes the database file from disk.
 
 **Parameters:**
 - `handle`: Protocol handle
@@ -402,6 +412,16 @@ C wrapper for `deleteDatabase()`. Deletes the database file. This function close
 ```c
 asp_delete_database(handle);
 ```
+
+#### `asp_stop()` / `asp_reset()` / `asp_should_stop()`
+
+```c
+void asp_stop(AgentSyncProtocolHandle* handle);
+void asp_reset(AgentSyncProtocolHandle* handle);
+bool asp_should_stop(const AgentSyncProtocolHandle* handle);
+```
+
+C wrappers for `stop()`, `reset()`, and `shouldStop()`.
 
 #### `asp_parse_response_buffer()`
 
@@ -413,6 +433,17 @@ bool asp_parse_response_buffer(AgentSyncProtocolHandle* handle,
 
 C wrapper for `parseResponseBuffer()`.
 
+#### `asp_set_session_sender()`
+
+```c
+void asp_set_session_sender(asp_sync_session_sender_fn sender);
+```
+
+Registers the in-process sender that the Windows build of `SyncSocketTransport` uses to hand a session directly to `https_client`, since Windows agents run modules in-process and have no local socket to connect to. A no-op on POSIX, where the real `queue-sync` socket is used instead. Process-global — there is one `sync_protocol` instance per process regardless of how many modules use it. Call with `NULL` to deregister (e.g. when `https_client` is stopping).
+
+**Parameters:**
+- `sender`: Function to call for each session, or `NULL` to deregister
+
 ## Type Definitions
 
 ### Enumerations
@@ -420,10 +451,11 @@ C wrapper for `parseResponseBuffer()`.
 #### `Operation` / `Operation_t`
 
 ```cpp
-enum class Operation {
-    CREATE,
-    UPDATE,
-    DELETE
+enum class Operation : int {
+    CREATE = OPERATION_CREATE,
+    MODIFY = OPERATION_MODIFY,
+    DELETE_ = OPERATION_DELETE, // trailing underscore: DELETE collides with a macro/keyword
+    NO_OP = OPERATION_NO_OP     // neutral state, not a synchronized operation
 };
 ```
 
@@ -439,97 +471,132 @@ typedef enum {
 #### `Mode` / `Mode_t`
 
 ```cpp
-enum class Mode {
-    FULL,               // Full synchronization mode
-    DELTA,              // Delta synchronization mode
-    CHECK,              // Integrity check mode
-    METADATA_DELTA,     // Metadata delta synchronization mode
-    METADATA_CHECK,     // Metadata integrity check mode
-    GROUP_DELTA,        // Group delta synchronization mode
-    GROUP_CHECK         // Group integrity check mode
+enum class Mode : int {
+    FULL           = MODE_FULL,           // Full synchronization mode
+    DELTA          = MODE_DELTA,          // Delta synchronization mode
+    CHECK          = MODE_CHECK,          // Integrity check mode
+    METADATA_DELTA = MODE_METADATA_DELTA, // Metadata delta synchronization mode
+    METADATA_CHECK = MODE_METADATA_CHECK, // Metadata integrity check mode
+    GROUP_DELTA    = MODE_GROUP_DELTA,    // Group delta synchronization mode
+    GROUP_CHECK    = MODE_GROUP_CHECK     // Group integrity check mode
 };
 ```
 
 ```c
 typedef enum {
-    MODE_FULL,
-    MODE_DELTA,
-    MODE_CHECK,
-    MODE_METADATA_DELTA,
-    MODE_METADATA_CHECK,
-    MODE_GROUP_DELTA,
-    MODE_GROUP_CHECK
+    MODE_FULL = 0,
+    MODE_DELTA = 1,
+    MODE_CHECK = 2,
+    MODE_METADATA_DELTA = 3,
+    MODE_METADATA_CHECK = 4,
+    MODE_GROUP_DELTA = 5,
+    MODE_GROUP_CHECK = 6
 } Mode_t;
 ```
+
+#### `Option` / `Option_t`
+
+```cpp
+enum class Option : int {
+    SYNC    = OPTION_SYNC,     // Standard synchronization option
+    VDFIRST = OPTION_VD_FIRST, // Vulnerability-detection-first synchronization option
+    VDSYNC  = OPTION_VD_SYNC   // Vulnerability-detection synchronization option
+};
+```
+
+```c
+typedef enum {
+    OPTION_SYNC     = 0,
+    OPTION_VD_FIRST = 1,
+    OPTION_VD_SYNC  = 2,
+    OPTION_VD_CLEAN = 3 // not currently mapped on the C++ Option enum
+} Option_t;
+```
+
+### Result Type
+
+#### `SyncModuleResult` / `SyncModuleResult_t`
+
+```cpp
+struct SyncModuleResult {
+    bool success{false};
+    std::string failureReason;
+    bool stopped{false};
+    bool managerNotReady{false};
+    unsigned int consecutiveFailures{0};
+};
+```
+
+```c
+typedef struct SyncModuleResult_t {
+    bool success;
+    char failure_reason[SYNC_FAILURE_REASON_MAX_LEN];
+    bool stopped;
+    bool manager_not_ready;
+    unsigned int consecutive_failures;
+} SyncModuleResult_t;
+```
+
+- `success`: whether the synchronization completed successfully.
+- `failureReason`/`failure_reason`: human-readable reason, may be empty.
+- `stopped`: `true` if the operation was aborted because `stop()` was called — lets the caller demote an expected shutdown-time failure to INFO/DEBUG instead of WARNING.
+- `managerNotReady`/`manager_not_ready`: `true` if the manager did not answer the handshake, or answered `Offline`. Describes what happened, not how serious it is — use it together with `consecutiveFailures` (see `SYNC_MANAGER_NOT_READY_TOLERANCE`) to decide the log level.
+- `consecutiveFailures`/`consecutive_failures`: consecutive failed synchronizations for this module, including this one; reset to zero on the first success.
 
 ### Callback Types
 
 #### Logger Function
 
 ```cpp
-using LoggerFunc = std::function<void(int level, const std::string& message)>;
+using LoggerFunc = std::function<void(modules_log_level_t level, const std::string& message)>;
 ```
 
 ```c
 typedef void (*asp_logger_t)(modules_log_level_t level, const char* message);
 ```
 
-Where `modules_log_level_t` is an enumeration for logging levels (typically defined in `logging_helper.h`).
+Where `modules_log_level_t` is defined in `logging_helper.h`.
 
-#### Message Queue Functions
-
-```c
-typedef struct MQ_Functions {
-    mq_start_fn start;
-    mq_send_binary_fn send_binary;
-} MQ_Functions;
-```
-
-Where the function pointers are defined as:
+#### Session Sender Function (Windows in-process transport)
 
 ```c
-typedef int (*mq_start_fn)(const char* key, short type, short attempts);
-typedef int (*mq_send_binary_fn)(int queue, const void* message, size_t message_len,
-                                 const char* locmsg, char loc);
+typedef bool (*asp_sync_session_sender_fn)(const char* session_id, const uint8_t* buffer, size_t length);
 ```
 
-**Function Parameters:**
+Registered via `asp_set_session_sender()` — see above.
 
-`mq_start_fn`:
-- `key`: The identifier key for the message queue
-- `type`: The type of queue or message
-- `attempts`: The number of connection attempts
-- Returns: 0 on success, non-zero on failure
+### Transport Abstraction
 
-`mq_send_binary_fn`:
-- `queue`: The queue identifier
-- `message`: The message payload to send
-- `message_len`: The length of the message payload in bytes
-- `locmsg`: Additional location/context message (optional)
-- `loc`: A character representing the message location or type
-- Returns: 0 on success, non-zero on failure
+Modules do not usually need to touch this: `AgentSyncProtocol`'s default constructor argument already wires up the real transport. It exists mainly so tests can drive a session without a socket.
+
+```cpp
+class ISyncSessionTransport
+{
+public:
+    virtual bool checkStatus() = 0;
+    virtual bool sendSession(uint64_t session, const std::vector<uint8_t>& message) = 0;
+};
+```
+
+`SyncSocketTransport` is the real implementation: it streams one whole `FullSession` message over the agent's local `queue-sync` `AF_UNIX` STREAM socket, which `agentd`'s HTTPS-client intake binds. `sendSession()` reports whether the **agent** took the session, not whether the **manager** accepted it — the manager's verdict arrives asynchronously over the HTTPS response and is routed back through `parseResponseBuffer()`/`applyHttpResultCode()`.
+
+`MQ_Functions`/`mq_start_fn`/`mq_send_binary_fn` are still declared in `agent_sync_protocol_c_interface_types.h` for ABI reasons but are not used by any current code path — the message-queue-based transport they described predates `SyncSocketTransport`/`FullSession`.
 
 ## Error Handling
 
 The protocol uses logging callbacks to report errors. Common error scenarios include:
 
 - **Database errors**: Failed to open/write to SQLite database
-- **Queue errors**: Message queue unavailable or full
-- **Network errors**: Timeout waiting for manager response
+- **Queue errors**: Persistent queue unavailable
+- **Transport errors**: `queue-sync` socket unreachable, or the HTTPS transport reporting a non-OK result
 - **Protocol errors**: Invalid message format or unexpected response
-
-Errors are logged with appropriate severity levels:
-- `0`: Debug
-- `1`: Info
-- `2`: Warning
-- `3`: Error
 
 ## Thread Safety
 
 The Agent Sync Protocol is designed to be thread-safe:
 
 - Multiple threads can call `persistDifference()` concurrently
-- Only one synchronization session (`synchronizeModule()`) should be active at a time
+- Only one synchronization session (`synchronizeModule()`) should be active at a time per instance — a concurrent caller is expected to skip its cycle, since the in-flight sync already drains the shared queue
 - Response parsing (`parseResponseBuffer()`) is synchronized internally
 
 ## Memory Management

--- a/docs/ref/modules/utils/sync-protocol/api-reference.md
+++ b/docs/ref/modules/utils/sync-protocol/api-reference.md
@@ -71,35 +71,16 @@ protocol.persistDifference(
 );
 ```
 
-##### `persistDifferenceInMemory()`
-
-```cpp
-void persistDifferenceInMemory(const std::string& id,
-                               Operation operation,
-                               const std::string& index,
-                               const std::string& data,
-                               uint64_t version)
-```
-
-Persists a difference to an in-memory vector instead of the database. Used for recovery scenarios where data should be kept in memory rather than written to disk; consumed by a subsequent `synchronizeModule(Mode::FULL, ...)` call instead of the persistent queue.
-
-**Parameters:**
-- `id`: Unique identifier for the data item
-- `operation`: Type of operation (`Operation::CREATE`, `Operation::MODIFY`, `Operation::DELETE_`)
-- `index`: Logical index for the data item
-- `data`: Serialized content of the message
-- `version`: Version of the data
-
 ##### `synchronizeModule()`
 
 ```cpp
 SyncModuleResult synchronizeModule(Mode mode, Option option = Option::SYNC)
 ```
 
-Synchronizes a module's pending data with the manager. `Mode::FULL` reads from the in-memory vector (see `persistDifferenceInMemory()`); `Mode::DELTA` reads from the persistent queue, split into as many `FullSession` messages as needed to stay under the byte cap (`Option::VDFIRST`/`Option::VDSYNC` are exempt from that cap); `Mode::CHECK` is handled by `requiresFullSync()` instead.
+Synchronizes a module's pending data with the manager. `Mode::DELTA` reads from the persistent queue, split into as many `FullSession` messages as needed to stay under the byte cap (`Option::VDFIRST`/`Option::VDSYNC` are exempt from that cap); `Mode::CHECK` is handled by `requiresFullSync()` instead. There is no `Mode::FULL`: a full-replace resync is `notifyDataClean()` followed by an ordinary `Mode::DELTA` sync of the freshly re-persisted snapshot — see [Protocol Lifecycle](lifecycle.md#full-replace-recovery-dataclean-then-delta) for why.
 
 **Parameters:**
-- `mode`: Synchronization mode (`Mode::FULL` or `Mode::DELTA`)
+- `mode`: Synchronization mode (only `Mode::DELTA` is valid here)
 - `option`: Sync option (default `Option::SYNC`; use `Option::VDFIRST` / `Option::VDSYNC` for VD flows)
 
 **Returns:** `SyncModuleResult` with success flag, optional failure reason, stop and manager-not-ready flags, and consecutive failure count
@@ -119,21 +100,13 @@ bool requiresFullSync(const std::string& index,
                       const std::string& checksum)
 ```
 
-Checks if a module index requires full synchronization by sending one `FullSession` carrying a `Checksums` payload and waiting for the manager's `EndAck`.
+Checks if a module index requires full synchronization by sending one `FullSession` carrying a `ChecksumModule` payload and waiting for the manager's `EndAck`.
 
 **Parameters:**
 - `index`: The index/table to check
 - `checksum`: The calculated checksum for the index
 
 **Returns:** `true` if full sync is required (checksum mismatch, i.e. `EndAck.status != Ok`); `false` if integrity is valid or the transport is not currently reachable
-
-##### `clearInMemoryData()`
-
-```cpp
-void clearInMemoryData()
-```
-
-Clears the in-memory data queue. This method removes all entries from the in-memory vector used for recovery scenarios.
 
 ##### `synchronizeMetadataOrGroups()`
 
@@ -290,27 +263,6 @@ C wrapper for `persistDifference()`, always with `isDataContext = false`.
 - `data`: JSON data string
 - `version`: Version of the data
 
-#### `asp_persist_diff_in_memory()`
-
-```c
-void asp_persist_diff_in_memory(AgentSyncProtocolHandle* handle,
-                                const char* id,
-                                Operation_t operation,
-                                const char* index,
-                                const char* data,
-                                uint64_t version)
-```
-
-C wrapper for `persistDifferenceInMemory()`. Persists a difference to an in-memory vector instead of the database.
-
-**Parameters:**
-- `handle`: Protocol handle
-- `id`: Unique identifier for the data item
-- `operation`: Operation type (`OPERATION_CREATE`, `OPERATION_MODIFY`, `OPERATION_DELETE`, `OPERATION_NO_OP`)
-- `index`: Logical index for the data item
-- `data`: Serialized content of the message
-- `version`: Version of the data
-
 #### `asp_sync_module()`
 
 ```c
@@ -321,7 +273,7 @@ C wrapper for `synchronizeModule()` with the default `Option_t` (`OPTION_SYNC`).
 
 **Parameters:**
 - `handle`: Protocol handle
-- `mode`: Sync mode (`MODE_FULL` or `MODE_DELTA`)
+- `mode`: Sync mode (only `MODE_DELTA` is valid here)
 
 **Returns:** `SyncModuleResult_t` with success flag and optional failure reason string
 
@@ -341,17 +293,6 @@ C wrapper for `requiresFullSync()`. Checks if a module index requires full synch
 - `checksum`: The calculated checksum for the index
 
 **Returns:** `true` if full sync is required (checksum mismatch); `false` if integrity is valid
-
-#### `asp_clear_in_memory_data()`
-
-```c
-void asp_clear_in_memory_data(AgentSyncProtocolHandle* handle)
-```
-
-C wrapper for `clearInMemoryData()`. Clears the in-memory data queue.
-
-**Parameters:**
-- `handle`: Protocol handle
 
 #### `asp_sync_metadata_or_groups()`
 
@@ -472,7 +413,6 @@ typedef enum {
 
 ```cpp
 enum class Mode : int {
-    FULL           = MODE_FULL,           // Full synchronization mode
     DELTA          = MODE_DELTA,          // Delta synchronization mode
     CHECK          = MODE_CHECK,          // Integrity check mode
     METADATA_DELTA = MODE_METADATA_DELTA, // Metadata delta synchronization mode
@@ -484,15 +424,16 @@ enum class Mode : int {
 
 ```c
 typedef enum {
-    MODE_FULL = 0,
-    MODE_DELTA = 1,
-    MODE_CHECK = 2,
-    MODE_METADATA_DELTA = 3,
-    MODE_METADATA_CHECK = 4,
-    MODE_GROUP_DELTA = 5,
-    MODE_GROUP_CHECK = 6
+    MODE_DELTA = 0,
+    MODE_CHECK = 1,
+    MODE_METADATA_DELTA = 2,
+    MODE_METADATA_CHECK = 3,
+    MODE_GROUP_DELTA = 4,
+    MODE_GROUP_CHECK = 5
 } Mode_t;
 ```
+
+There is no `FULL`/`MODE_FULL`: a full-replace resync is `notifyDataClean()` followed by an ordinary `Mode::DELTA` sync — see [Protocol Lifecycle](lifecycle.md#full-replace-recovery-dataclean-then-delta).
 
 #### `Option` / `Option_t`
 

--- a/docs/ref/modules/utils/sync-protocol/api-reference.md
+++ b/docs/ref/modules/utils/sync-protocol/api-reference.md
@@ -84,30 +84,24 @@ Persists a difference to in-memory vector instead of database. This method is us
 ##### `synchronizeModule()`
 
 ```cpp
-bool synchronizeModule(Mode mode,
-                      std::chrono::seconds timeout,
-                      unsigned int retries,
-                      size_t maxEps)
+SyncModuleResult synchronizeModule(Mode mode, Option option = Option::SYNC)
 ```
 
 Initiates a synchronization session with the manager.
 
 **Parameters:**
-- `mode`: Synchronization mode (`Mode::Full` or `Mode::Delta`)
-- `timeout`: Maximum time to wait for each response
-- `retries`: Number of retry attempts for Start and End messages
-- `maxEps`: Maximum events per second (0 = unlimited)
+- `mode`: Synchronization mode (`Mode::FULL` or `Mode::DELTA`)
+- `option`: Sync option (default `Option::SYNC`; use `Option::VDFIRST` / `Option::VDSYNC` for
+  VD flows that are exempt from the byte-cap)
 
-**Returns:** `true` if synchronization completed successfully, `false` otherwise
+**Returns:** `SyncModuleResult` with success flag, optional failure reason, stop and manager-not-ready flags, and consecutive failure count
 
 **Example:**
 ```cpp
-bool success = protocol.synchronizeModule(
-    Mode::Delta,
-    std::chrono::seconds(30),
-    3,
-    1000
-);
+SyncModuleResult result = protocol.synchronizeModule(Mode::DELTA);
+if (!result.success) {
+    // items reset to PENDING; next periodic cycle will retry
+}
 ```
 
 ##### `requiresFullSync()`
@@ -233,17 +227,21 @@ Processes FlatBuffer-encoded responses from the manager.
 ```c
 AgentSyncProtocolHandle* asp_create(const char* module,
                                    const char* db_path,
-                                   const MQ_Functions* mq_funcs,
-                                   asp_logger_t logger)
+                                   asp_logger_t logger,
+                                   unsigned int timeout,
+                                   unsigned int retries)
 ```
 
 Creates a new Agent Sync Protocol instance.
 
 **Parameters:**
-- `module`: Module name string
-- `db_path`: Database file path
-- `mq_funcs`: Pointer to message queue functions structure
+- `module`: Module name string (e.g. `"fim"`, `"syscollector"`)
+- `db_path`: SQLite database file path for the persistent queue (`NULL` for in-memory only)
 - `logger`: Logging callback function
+- `timeout`: Accepted for ABI compatibility but **no longer used**. The response-wait timeout
+  is owned by the HTTPS transport layer (`statefulTimeoutMs`).
+- `retries`: Number of times to retry the local sync-socket hand-off when the intake socket is
+  temporarily unavailable (e.g. during an agentd restart). Does **not** affect HTTP-level retries.
 
 **Returns:** Opaque handle to the protocol instance, or NULL on failure
 
@@ -299,11 +297,7 @@ C wrapper for `persistDifferenceInMemory()`. Persists a difference to in-memory 
 #### `asp_sync_module()`
 
 ```c
-bool asp_sync_module(AgentSyncProtocolHandle* handle,
-                    Mode_t mode,
-                    unsigned int sync_timeout,
-                    unsigned int sync_retries,
-                    size_t max_eps)
+SyncModuleResult_t asp_sync_module(AgentSyncProtocolHandle* handle, Mode_t mode)
 ```
 
 C wrapper for `synchronizeModule()`.
@@ -311,21 +305,15 @@ C wrapper for `synchronizeModule()`.
 **Parameters:**
 - `handle`: Protocol handle
 - `mode`: Sync mode (`MODE_FULL` or `MODE_DELTA`)
-- `sync_timeout`: Timeout in seconds
-- `sync_retries`: Number of retries
-- `max_eps`: Maximum events per second
 
-**Returns:** `true` on success, `false` on failure
+**Returns:** `SyncModuleResult_t` with success flag and optional failure reason string
 
 #### `asp_requires_full_sync()`
 
 ```c
 bool asp_requires_full_sync(AgentSyncProtocolHandle* handle,
                             const char* index,
-                            const char* checksum,
-                            unsigned int sync_timeout,
-                            unsigned int sync_retries,
-                            size_t max_eps)
+                            const char* checksum)
 ```
 
 C wrapper for `requiresFullSync()`. Checks if a module index requires full synchronization.
@@ -334,9 +322,6 @@ C wrapper for `requiresFullSync()`. Checks if a module index requires full synch
 - `handle`: Protocol handle
 - `index`: The index/table to check
 - `checksum`: The calculated checksum for the index
-- `sync_timeout`: Timeout in seconds
-- `sync_retries`: Number of retries
-- `max_eps`: Maximum events per second
 
 **Returns:** `true` if full sync is required (checksum mismatch); `false` if integrity is valid
 
@@ -354,12 +339,11 @@ C wrapper for `clearInMemoryData()`. Clears the in-memory data queue.
 #### `asp_sync_metadata_or_groups()`
 
 ```c
-bool asp_sync_metadata_or_groups(AgentSyncProtocolHandle* handle,
-                                 Mode_t mode,
-                                 unsigned int sync_timeout,
-                                 unsigned int sync_retries,
-                                 size_t max_eps,
-                                 uint64_t global_version)
+SyncModuleResult_t asp_sync_metadata_or_groups(AgentSyncProtocolHandle* handle,
+                                               Mode_t mode,
+                                               const char** indices,
+                                               size_t indices_count,
+                                               uint64_t global_version)
 ```
 
 C wrapper for `synchronizeMetadataOrGroups()`. Synchronizes metadata or groups with the server without sending data.
@@ -367,33 +351,26 @@ C wrapper for `synchronizeMetadataOrGroups()`. Synchronizes metadata or groups w
 **Parameters:**
 - `handle`: Protocol handle
 - `mode`: Sync mode (`MODE_METADATA_DELTA`, `MODE_METADATA_CHECK`, `MODE_GROUP_DELTA`, or `MODE_GROUP_CHECK`)
-- `sync_timeout`: Timeout in seconds
-- `sync_retries`: Number of retries
-- `max_eps`: Maximum events per second
-- `global_version`: Global version to include in the Start message.
+- `indices`: Array of index name strings that will be updated by the manager
+- `indices_count`: Number of indices in the array
+- `global_version`: Global version to include in the Start message
 
-**Returns:** `true` on success, `false` on failure
+**Returns:** `SyncModuleResult_t` with success flag and failure reason if unsuccessful
 
 #### `asp_notify_data_clean()`
 
 ```c
 bool asp_notify_data_clean(AgentSyncProtocolHandle* handle,
                            const char** indices,
-                           size_t indices_count,
-                           unsigned int sync_timeout,
-                           unsigned int sync_retries,
-                           size_t max_eps)
+                           size_t indices_count)
 ```
 
-C wrapper for `notifyDataClean()`. Notifies the manager about data cleaning for specified indices. This function sends DataClean messages for each index in the provided array. The sequence is: Start → StartAck → DataClean (for each index) → End → EndAck. Upon receiving Ok, it clears the local database and returns true.
+C wrapper for `notifyDataClean()`. Notifies the manager about data cleaning for specified indices.
 
 **Parameters:**
 - `handle`: Protocol handle
 - `indices`: Array of index name strings to clean
 - `indices_count`: Number of indices in the array
-- `sync_timeout`: Timeout in seconds
-- `sync_retries`: Number of retries
-- `max_eps`: Maximum events per second
 
 **Returns:** `true` if notification completed successfully and database was cleared, `false` otherwise
 

--- a/docs/ref/modules/utils/sync-protocol/integration-guide.md
+++ b/docs/ref/modules/utils/sync-protocol/integration-guide.md
@@ -1,6 +1,6 @@
 # Integration Guide
 
-This guide provides step-by-step examples for integrating the Agent Sync Protocol into internal Wazuh modules such as FIM, SCA, and Inventory.
+This guide provides step-by-step examples for integrating the Agent Sync Protocol into internal Wazuh modules such as FIM, SCA, and Syscollector.
 
 ## Prerequisites
 
@@ -8,8 +8,9 @@ Before integrating the Agent Sync Protocol, ensure you have:
 
 1. Access to the protocol headers in `src/shared_modules/sync_protocol/include/`
 2. A unique module name identifier
-3. A dedicated SQLite database path for persistent storage
-4. Message queue functions configured for your environment
+3. A dedicated SQLite database path for persistent storage (or `std::nullopt`/`NULL` for in-memory-only use)
+
+There is no message-queue setup to wire in: the protocol carries a whole session over its own local `queue-sync` socket by default (see [API Reference](api-reference.md#transport-abstraction)); nothing needs to be passed in for that.
 
 ## Basic Integration Steps
 
@@ -20,7 +21,7 @@ Before integrating the Agent Sync Protocol, ensure you have:
 #include "agent_sync_protocol.hpp"
 #include "agent_sync_protocol_types.hpp"
 
-// For custom queue implementations (optional)
+// For custom queue implementations (optional, mainly for testing)
 #include "ipersistent_queue.hpp"
 ```
 
@@ -35,26 +36,21 @@ Before integrating the Agent Sync Protocol, ensure you have:
 #### C++ Example
 ```cpp
 // Define logger function
-auto logger = [](int level, const std::string& message) {
-    switch(level) {
-        case 0: debug("%s", message.c_str()); break;
-        case 1: info("%s", message.c_str()); break;
-        case 2: warning("%s", message.c_str()); break;
-        case 3: error("%s", message.c_str()); break;
+LoggerFunc logger = [](modules_log_level_t level, const std::string& message) {
+    switch (level) {
+        case LOG_DEBUG:   mdebug1("%s", message.c_str()); break;
+        case LOG_INFO:    minfo("%s", message.c_str());   break;
+        case LOG_WARNING: mwarn("%s", message.c_str());   break;
+        case LOG_ERROR:   merror("%s", message.c_str());  break;
+        default: break;
     }
 };
 
-// Setup message queue functions
-MQ_Functions mqFuncs = {
-    .start = mq_start_wrapper,       // Your mq_start_fn implementation
-    .send_binary = mq_send_wrapper   // Your mq_send_binary_fn implementation
-};
-
-// Create protocol instance
+// Create protocol instance. queue and syncTransport are left at their
+// defaults (real SQLite queue, real queue-sync socket transport).
 auto protocol = std::make_unique<AgentSyncProtocol>(
-    "FIM",                              // Module name
+    "fim",                              // Module name
     "/var/ossec/queue/fim/fim_sync.db", // Database path
-    mqFuncs,                            // MQ functions
     logger                              // Logger callback
 );
 ```
@@ -63,30 +59,24 @@ auto protocol = std::make_unique<AgentSyncProtocol>(
 ```c
 // Define logger function
 void module_logger(modules_log_level_t level, const char* message) {
-    switch(level) {
-        case 0: debug("%s", message); break;
-        case 1: info("%s", message); break;
-        case 2: warning("%s", message); break;
-        case 3: error("%s", message); break;
+    switch (level) {
+        case LOG_DEBUG:   mdebug1("%s", message); break;
+        case LOG_INFO:    minfo("%s", message);   break;
+        case LOG_WARNING: mwarn("%s", message);   break;
+        case LOG_ERROR:   merror("%s", message);  break;
+        default: break;
     }
 }
 
-// Setup message queue functions
-MQ_Functions mq_funcs = {
-    .start = mq_start_wrapper,       // Your mq_start_fn implementation
-    .send_binary = mq_send_wrapper   // Your mq_send_binary_fn implementation
-};
-
 // Create protocol handle
 AgentSyncProtocolHandle* handle = asp_create(
-    "SCA",
+    "sca",
     "/var/ossec/queue/sca/sca_sync.db",
-    &mq_funcs,
     module_logger
 );
 
 if (!handle) {
-    error("Failed to create sync protocol instance");
+    merror("Failed to create sync protocol instance");
     return -1;
 }
 ```
@@ -97,10 +87,8 @@ if (!handle) {
 ```cpp
 // File creation event
 void onFileCreated(const std::string& filepath, const FileInfo& info) {
-    // Generate unique ID (hash of filepath)
     std::string id = generateHash(filepath);
 
-    // Build JSON data
     nlohmann::json data = {
         {"path", filepath},
         {"size", info.size},
@@ -112,12 +100,12 @@ void onFileCreated(const std::string& filepath, const FileInfo& info) {
         {"hash_sha256", info.hash_sha256}
     };
 
-    // Persist the difference
     protocol->persistDifference(
         id,
         Operation::CREATE,
-        "fim_events",
-        data.dump()
+        "fim_files",
+        data.dump(),
+        info.version
     );
 }
 
@@ -128,21 +116,23 @@ void onFileModified(const std::string& filepath, const FileInfo& info) {
 
     protocol->persistDifference(
         id,
-        Operation::UPDATE,
-        "fim_events",
-        data.dump()
+        Operation::MODIFY,
+        "fim_files",
+        data.dump(),
+        info.version
     );
 }
 
 // File deletion event
-void onFileDeleted(const std::string& filepath) {
+void onFileDeleted(const std::string& filepath, uint64_t version) {
     std::string id = generateHash(filepath);
 
     protocol->persistDifference(
         id,
-        Operation::DELETE,
-        "fim_events",
-        "{\"path\": \"" + filepath + "\"}"
+        Operation::DELETE_,
+        "fim_files",
+        "{\"path\": \"" + filepath + "\"}",
+        version
     );
 }
 ```
@@ -150,126 +140,112 @@ void onFileDeleted(const std::string& filepath) {
 #### C Example - SCA Policy Check
 ```c
 // Policy check result
-void persist_policy_check(const char* policy_id, CheckResult* result) {
-    // Build JSON data
+void persist_policy_check(const char* policy_id, CheckResult* result, uint64_t version) {
     char json_data[4096];
     snprintf(json_data, sizeof(json_data),
         "{\"policy_id\": \"%s\", \"status\": \"%s\", \"score\": %d, \"timestamp\": %ld}",
-        policy_id,
-        result->status,
-        result->score,
-        result->timestamp
-    );
+        policy_id, result->status, result->score, result->timestamp);
 
-    // Persist the check result
     asp_persist_diff(
         handle,
         policy_id,
         OPERATION_MODIFY,
         "sca_checks",
-        json_data
+        json_data,
+        version
     );
 }
 ```
 
+#### C++ Example - Vulnerability-Detection Context Data
+
+Items that carry vulnerability-detection context (no upsert/delete semantics, stored but not indexed) are persisted with `isDataContext = true`. They can be mixed freely with regular items — both end up in the same session's `SyncData` payload:
+
+```cpp
+protocol->persistDifference(
+    "pkg_ctx_" + pkg.name,
+    Operation::CREATE,
+    "vd_packages",
+    contextData.dump(),
+    1,
+    /* isDataContext = */ true
+);
+```
+
 #### C++ Example - Recovery Using In-Memory Storage
 ```cpp
-// Module recovery scenario
 void recoverModuleData() {
-    info("Starting module recovery process");
+    minfo("Starting module recovery process");
 
-    // Clear in-memory data before sync attempt
+    // Clear in-memory data before persisting recovery items
     protocol->clearInMemoryData();
 
-    // Read recovery data from backup source
     std::vector<RecoveryItem> recoveryItems = loadRecoveryData();
 
-    // Persist all recovery data in memory
     for (const auto& item : recoveryItems) {
         protocol->persistDifferenceInMemory(
             item.id,
             Operation::CREATE,
             item.index,
-            item.data
+            item.data,
+            item.version
         );
     }
 
-    info("Persisted %zu recovery items in memory", recoveryItems.size());
+    minfo("Persisted %zu recovery items in memory", recoveryItems.size());
 
-    // Synchronize the in-memory data with the manager
-    bool success = protocol->synchronizeModule(
-        Mode::FULL,
-        std::chrono::seconds(60),
-        5,
-        2000
-    );
+    // Mode::FULL reads from the in-memory vector, not the persistent queue
+    SyncModuleResult result = protocol->synchronizeModule(Mode::FULL);
 
-    if (success) {
-        info("Recovery completed successfully");
+    if (result.success) {
+        minfo("Recovery completed successfully");
     } else {
-        error("Recovery synchronization failed, will retry later");
+        merror("Recovery synchronization failed: %s", result.failureReason.c_str());
     }
 }
 ```
 
 #### C Example - Integrity Check Before Sync
 ```c
-// Check if full sync is needed before synchronization
 bool should_perform_full_sync(const char* index) {
-    // Calculate checksum for the index
     char checksum[65];
     calculate_index_checksum(index, checksum);
 
-    // Check with manager if full sync is required
-    bool needs_full_sync = asp_requires_full_sync(
-        handle,
-        index,
-        checksum,
-        30,   // timeout in seconds
-        3,    // retries
-        1000  // max EPS
-    );
+    // Sends one FullSession carrying a Checksums payload and waits for the EndAck
+    bool needs_full_sync = asp_requires_full_sync(handle, index, checksum);
 
     if (needs_full_sync) {
-        info("Checksum mismatch detected for index %s, full sync required", index);
-        return true;
+        minfo("Checksum mismatch detected for index %s, full sync required", index);
     } else {
-        info("Checksum valid for index %s, delta sync sufficient", index);
-        return false;
+        minfo("Checksum valid for index %s, delta sync sufficient", index);
     }
+
+    return needs_full_sync;
 }
 ```
 
 ### Step 4: Process Manager Responses
 
-When the manager sends responses, you need to parse them using the protocol:
+The manager's answer (an `EndAck`, or the HTTPS transport's own result code) needs to reach `parseResponseBuffer()` for the in-flight `synchronizeModule()`/`notifyDataClean()`/`requiresFullSync()`/`synchronizeMetadataOrGroups()` call to unblock. In practice, this is wired up once by the transport that delivers the manager's HTTPS response back to the module, not called ad hoc by each module.
 
 #### C++ Example
 ```cpp
-// Message receive callback
-void onMessageReceived(const uint8_t* buffer, size_t length) {
-    // Parse the FlatBuffer response from manager
+void onManagerResponse(const uint8_t* buffer, size_t length) {
     bool parsed = protocol->parseResponseBuffer(buffer, length);
 
-    if (parsed) {
-        info("Successfully processed manager response");
-    } else {
-        error("Failed to parse manager response");
+    if (!parsed) {
+        merror("Failed to parse manager response");
     }
 }
 ```
 
 #### C Example
 ```c
-// Message receive callback
-void on_message_received(const uint8_t* buffer, size_t length) {
-    // Parse the FlatBuffer response from manager
-    bool parsed = asp_parse_response(handle, buffer, length);
+void on_manager_response(const uint8_t* buffer, size_t length) {
+    bool parsed = asp_parse_response_buffer(handle, buffer, length);
 
-    if (parsed) {
-        info("Successfully processed manager response");
-    } else {
-        error("Failed to parse manager response");
+    if (!parsed) {
+        merror("Failed to parse manager response");
     }
 }
 ```
@@ -279,18 +255,18 @@ void on_message_received(const uint8_t* buffer, size_t length) {
 #### C++ Example - Periodic Sync
 ```cpp
 void performPeriodicSync() {
-    // Delta sync with 30-second timeout, 3 retries, 1000 EPS limit
-    bool success = protocol->synchronizeModule(
-        Mode::DELTA,
-        std::chrono::seconds(30),
-        3,
-        1000
-    );
+    SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
 
-    if (success) {
-        info("Synchronization completed successfully");
+    if (result.success) {
+        minfo("Synchronization completed successfully");
+    } else if (result.stopped) {
+        mdebug1("Synchronization aborted by shutdown");
+    } else if (result.managerNotReady) {
+        // Escalate to WARNING only once consecutiveFailures crosses
+        // SYNC_MANAGER_NOT_READY_TOLERANCE; see the API reference.
+        mdebug1("Manager not ready yet (%u consecutive)", result.consecutiveFailures);
     } else {
-        error("Synchronization failed");
+        merror("Synchronization failed: %s", result.failureReason.c_str());
     }
 }
 
@@ -305,21 +281,14 @@ std::thread syncThread([&protocol]() {
 
 #### C Example - Event-Driven Sync
 ```c
-// Trigger sync when buffer reaches threshold
 void check_and_sync(size_t buffer_size) {
     const size_t SYNC_THRESHOLD = 1000;
 
     if (buffer_size >= SYNC_THRESHOLD) {
-        bool success = asp_sync_module(
-            handle,
-            MODE_DELTA,
-            30,    // timeout in seconds
-            3,     // retries
-            500    // max EPS
-        );
+        SyncModuleResult_t result = asp_sync_module(handle, MODE_DELTA);
 
-        if (!success) {
-            error("Failed to synchronize module data");
+        if (!result.success) {
+            merror("Failed to synchronize module data: %s", result.failure_reason);
         }
     }
 }
@@ -328,74 +297,73 @@ void check_and_sync(size_t buffer_size) {
 #### C Example - Metadata Synchronization
 ```c
 // Synchronize metadata at agent startup
-void sync_agent_metadata() {
-    info("Synchronizing agent metadata");
+void sync_agent_metadata(uint64_t global_version) {
+    minfo("Synchronizing agent metadata");
 
-    bool success = asp_sync_metadata_or_groups(
+    const char* indices[] = {"agent_metadata"};
+    SyncModuleResult_t result = asp_sync_metadata_or_groups(
         handle,
         MODE_METADATA_DELTA,
-        30,  // timeout in seconds
-        3,   // retries
-        0,   // no EPS limit
-        0
+        indices,
+        1,
+        global_version
     );
 
-    if (success) {
-        info("Agent metadata synchronized successfully");
+    if (result.success) {
+        minfo("Agent metadata synchronized successfully");
     } else {
-        error("Failed to synchronize agent metadata");
+        merror("Failed to synchronize agent metadata: %s", result.failure_reason);
     }
 }
 ```
 
 ## Complete Module Integration Example
 
-### Inventory Module Integration
+### Syscollector-Style Module Integration
 
 ```cpp
-class InventorySync {
-private:
-    std::unique_ptr<AgentSyncProtocol> m_protocol;
-    std::atomic<bool> m_running{true};
-    std::thread m_syncThread;
-
+class InventorySync
+{
 public:
-    InventorySync(const std::string& dbPath, const MQ_Functions& mqFuncs) {
-        // Initialize protocol
+    InventorySync(const std::string& dbPath)
+    {
         m_protocol = std::make_unique<AgentSyncProtocol>(
-            "Inventory",
+            "syscollector",
             dbPath,
-            mqFuncs,
-            [](int level, const std::string& msg) {
+            [](modules_log_level_t level, const std::string& msg)
+            {
                 log_message(level, "InventorySync", msg.c_str());
-            }
-        );
+            });
 
-        // Start sync thread
         m_syncThread = std::thread(&InventorySync::syncWorker, this);
     }
 
-    ~InventorySync() {
+    ~InventorySync()
+    {
+        m_protocol->stop();
         m_running = false;
-        if (m_syncThread.joinable()) {
+        if (m_syncThread.joinable())
+        {
             m_syncThread.join();
         }
     }
 
     // Called when system inventory changes
-    void onInventoryChange(const std::string& category, const nlohmann::json& data) {
+    void onInventoryChange(const std::string& category, const nlohmann::json& data, uint64_t version)
+    {
         std::string id = generateInventoryId(category, data);
 
         m_protocol->persistDifference(
             id,
-            Operation::UPDATE,
+            Operation::MODIFY,
             "inventory_" + category,
-            data.dump()
-        );
+            data.dump(),
+            version);
     }
 
-    // Called when new package is installed
-    void onPackageInstalled(const PackageInfo& pkg) {
+    // Called when a new package is installed
+    void onPackageInstalled(const PackageInfo& pkg)
+    {
         nlohmann::json data = {
             {"name", pkg.name},
             {"version", pkg.version},
@@ -408,55 +376,61 @@ public:
             pkg.name + "_" + pkg.version,
             Operation::CREATE,
             "inventory_packages",
-            data.dump()
-        );
+            data.dump(),
+            1);
     }
 
-    // Called when package is removed
-    void onPackageRemoved(const std::string& pkgName) {
+    // Called when a package is removed
+    void onPackageRemoved(const std::string& pkgName, uint64_t version)
+    {
         m_protocol->persistDifference(
             pkgName,
-            Operation::DELETE,
+            Operation::DELETE_,
             "inventory_packages",
-            "{\"name\": \"" + pkgName + "\"}"
-        );
+            "{\"name\": \"" + pkgName + "\"}",
+            version);
     }
 
 private:
-    void syncWorker() {
-        while (m_running) {
-            // Wait for sync interval
+    void syncWorker()
+    {
+        int syncCount = 0;
+
+        while (m_running)
+        {
             std::this_thread::sleep_for(std::chrono::minutes(15));
 
-            // Perform full sync every 4 hours, delta sync otherwise
-            static int syncCount = 0;
-            Mode mode = (++syncCount % 16 == 0) ? Mode::Full : Mode::Delta;
+            // Full sync every 4 hours (16 * 15 min), delta sync otherwise
+            const Mode mode = (++syncCount % 16 == 0) ? Mode::FULL : Mode::DELTA;
+            const auto result = m_protocol->synchronizeModule(mode);
 
-            bool success = m_protocol->synchronizeModule(
-                mode,
-                std::chrono::seconds(60),  // 1 minute timeout
-                5,                         // 5 retries
-                2000                       // 2000 EPS limit
-            );
-
-            if (!success) {
-                error("Inventory sync failed, will retry in next interval");
+            if (!result.success)
+            {
+                merror("Inventory sync failed: %s", result.failureReason.c_str());
             }
         }
     }
 
-    std::string generateInventoryId(const std::string& category,
-                                   const nlohmann::json& data) {
-        // Generate unique ID based on category and key fields
+    std::string generateInventoryId(const std::string& category, const nlohmann::json& data)
+    {
         std::string keyData = category;
-        if (data.contains("name")) {
+
+        if (data.contains("name"))
+        {
             keyData += "_" + data["name"].get<std::string>();
         }
-        if (data.contains("id")) {
+
+        if (data.contains("id"))
+        {
             keyData += "_" + data["id"].get<std::string>();
         }
+
         return sha256(keyData);
     }
+
+    std::unique_ptr<AgentSyncProtocol> m_protocol;
+    std::atomic<bool> m_running{true};
+    std::thread m_syncThread;
 };
 ```
 
@@ -464,15 +438,27 @@ private:
 
 ### 1. Error Handling
 
-Always check return values and handle failures gracefully:
+Always check `SyncModuleResult`/`SyncModuleResult_t` and use its fields to decide how loudly to log, rather than treating every failure the same way:
 
 ```cpp
-if (!protocol->synchronizeModule(Mode::DELTA, timeout, retries, maxEps)) {
-    // Log error
-    error("Sync failed, scheduling retry");
+const auto result = protocol->synchronizeModule(Mode::DELTA);
 
-    // Schedule retry with exponential backoff
-    scheduleRetry(calculateBackoff(attemptNumber));
+if (!result.success)
+{
+    if (result.stopped)
+    {
+        mdebug1("Sync aborted by shutdown");
+    }
+    else if (result.managerNotReady && result.consecutiveFailures < SYNC_MANAGER_NOT_READY_TOLERANCE)
+    {
+        mdebug1("Manager not ready yet, will retry next cycle");
+    }
+    else
+    {
+        mwarn("Sync failed: %s", result.failureReason.c_str());
+    }
+    // No explicit retry scheduling needed: the module's own periodic
+    // cycle is what retries. The protocol itself does not re-attempt.
 }
 ```
 
@@ -493,28 +479,30 @@ AgentSyncProtocolHandle* handle = asp_create(...);
 asp_destroy(handle);  // Required cleanup
 ```
 
-### 3. Logging Integration
+### 3. Shutdown
 
-Provide detailed logging for debugging:
+Call `stop()`/`asp_stop()` before tearing down a module so any in-flight `synchronizeModule()`/`notifyDataClean()`/`requiresFullSync()` call unblocks instead of waiting indefinitely for a transport callback that will never arrive. `reset()`/`asp_reset()` clears the stop flag if the module restarts in the same process.
+
+### 4. Logging Integration
 
 ```cpp
-auto logger = [](int level, const std::string& message) {
-    std::string prefix = "[SyncProtocol] ";
+LoggerFunc logger = [](modules_log_level_t level, const std::string& message) {
+    const std::string prefix = "[SyncProtocol] ";
 
-    switch(level) {
-        case 0: // Debug
-            if (debug_enabled) {
-                mdebug1("%s%s", prefix.c_str(), message.c_str());
-            }
+    switch (level) {
+        case LOG_DEBUG:
+            mdebug1("%s%s", prefix.c_str(), message.c_str());
             break;
-        case 1: // Info
+        case LOG_INFO:
             minfo("%s%s", prefix.c_str(), message.c_str());
             break;
-        case 2: // Warning
+        case LOG_WARNING:
             mwarn("%s%s", prefix.c_str(), message.c_str());
             break;
-        case 3: // Error
+        case LOG_ERROR:
             merror("%s%s", prefix.c_str(), message.c_str());
+            break;
+        default:
             break;
     }
 };
@@ -524,41 +512,52 @@ auto logger = [](int level, const std::string& message) {
 
 ### Unit Testing
 
-Mock the protocol interface for unit tests:
+Mock the `IAgentSyncProtocol` interface for unit tests:
 
 ```cpp
-class MockAgentSyncProtocol : public IAgentSyncProtocol {
+class MockAgentSyncProtocol : public IAgentSyncProtocol
+{
 public:
     MOCK_METHOD(void, persistDifference,
-                (const std::string&, Operation, const std::string&, const std::string&),
+                (const std::string&, Operation, const std::string&, const std::string&, uint64_t, bool),
                 (override));
-    MOCK_METHOD(bool, synchronizeModule,
-                (Mode, std::chrono::seconds, unsigned int, size_t),
-                (override));
-    MOCK_METHOD(bool, parseResponseBuffer,
-                (const uint8_t*, size_t),
-                (override));
+    MOCK_METHOD(SyncModuleResult, synchronizeModule, (Mode, Option), (override));
+    MOCK_METHOD(bool, requiresFullSync, (const std::string&, const std::string&), (override));
+    MOCK_METHOD(bool, notifyDataClean, (const std::vector<std::string>&, Option), (override));
+    MOCK_METHOD(bool, parseResponseBuffer, (const uint8_t*, size_t), (override));
+    // ... plus the remaining IAgentSyncProtocol methods as needed by the test.
 };
 ```
 
 ### Integration Testing
 
-Test with a real protocol instance but mock message queue:
+Test with a real `AgentSyncProtocol` instance but a fake transport, so the test controls the manager's answer without a real socket or HTTPS round trip — this is the same `ISyncSessionTransport` seam `agent_sync_protocol_tests` itself uses (`tests/mocks/mock_sync_transport.hpp`):
 
 ```cpp
-MQ_Functions testMqFuncs = {
-    .open = [](const char*, int) { return 1; },
-    .send = [](int, const char*, const char*, const char*) { return 0; },
-    .recv = [](int, char*, unsigned int, unsigned int*) { return 0; },
-    .close = [](int) {}
+class FakeSyncTransport : public ISyncSessionTransport
+{
+public:
+    bool checkStatus() override { return true; }
+
+    bool sendSession(uint64_t /*session*/, const std::vector<uint8_t>& message) override
+    {
+        lastMessage = message;
+        return true; // pretend the local hand-off succeeded
+    }
+
+    std::vector<uint8_t> lastMessage;
 };
 
+auto transport = std::make_shared<FakeSyncTransport>();
 auto protocol = std::make_unique<AgentSyncProtocol>(
-    "TestModule",
-    ":memory:",  // In-memory SQLite for testing
-    testMqFuncs,
-    testLogger
-);
+    "test_module",
+    ":memory:",  // in-memory SQLite for testing
+    testLogger,
+    nullptr,     // default persistent queue
+    transport);
+
+// ... trigger a sync on another thread, then feed a synthetic EndAck back in:
+protocol->parseResponseBuffer(endAckBytes, endAckLength);
 ```
 
 ## Troubleshooting
@@ -569,26 +568,25 @@ auto protocol = std::make_unique<AgentSyncProtocol>(
    - Ensure only one process accesses the database file
    - Check file permissions and disk space
 
-2. **Message Queue Failures**
-   - Verify queue path and permissions
-   - Check queue size limits
+2. **`queue-sync` Socket Failures**
+   - Verify the socket path and permissions
+   - Check that `agentd`/`https_client` is running and bound to the intake socket
+   - `SYNC_HANDOFF_RETRIES` (fixed at 3) only covers a transiently-unavailable local socket; it does not retry HTTP-level failures
 
-3. **Synchronization Timeouts**
-   - Increase timeout values for slow networks
-   - Check network connectivity to manager
-   - Verify manager is processing messages
+3. **Synchronization Never Returns**
+   - The protocol waits indefinitely for the manager's answer once the local hand-off succeeds; a hang here usually means the HTTPS transport's own timeout (`statefulTimeoutMs`) hasn't fired yet, or `stop()` was never called during shutdown
+   - Check `agentd`/`https_client` logs and network connectivity to the manager
 
 4. **Memory Issues**
-   - Monitor queue size and implement flow control
-   - Use EPS limiting to control memory usage
-   - Implement periodic cleanup of old data
+   - Monitor persistent-queue size
+   - `Option::VDFIRST`/`Option::VDSYNC` bypass the `FullSession` byte cap — make sure that is intentional for the flow using it
 
 5. **Checksum Mismatch Issues**
    - Ensure consistent checksum calculation algorithm
-   - Verify checksum is calculated for the correct index/table
+   - Verify the checksum is calculated for the correct index/table
    - Check for data corruption in persistent storage
 
 6. **Metadata/Groups Sync Failures**
-   - Verify correct mode is used (METADATA_DELTA, METADATA_CHECK, GROUP_DELTA, GROUP_CHECK)
-   - Ensure no data messages are sent during metadata/groups sync
+   - Verify the correct mode is used (`METADATA_DELTA`, `METADATA_CHECK`, `GROUP_DELTA`, `GROUP_CHECK`)
+   - These modes never populate a `SessionPayload` — only `Start`/`End` are sent
    - Check manager logs for additional error details

--- a/docs/ref/modules/utils/sync-protocol/integration-guide.md
+++ b/docs/ref/modules/utils/sync-protocol/integration-guide.md
@@ -172,18 +172,27 @@ protocol->persistDifference(
 );
 ```
 
-#### C++ Example - Recovery Using In-Memory Storage
+#### C++ Example - Full-Replace Recovery (DataClean + DELTA)
+
+There is no in-memory recovery API or `Mode::FULL`: a full-replace resync clears the target
+index first, then streams the fresh snapshot through the normal persistent-queue DELTA path
+(which safely splits into as many sessions as needed) — see
+[Protocol Lifecycle](lifecycle.md#full-replace-recovery-dataclean-then-delta) for why.
+
 ```cpp
-void recoverModuleData() {
+void recoverModuleData(const std::string& index) {
     minfo("Starting module recovery process");
 
-    // Clear in-memory data before persisting recovery items
-    protocol->clearInMemoryData();
+    // Clear the manager's index before resending the fresh snapshot.
+    if (!protocol->notifyDataClean({index})) {
+        merror("Failed to clear index %s before recovery; will retry later", index.c_str());
+        return;
+    }
 
     std::vector<RecoveryItem> recoveryItems = loadRecoveryData();
 
     for (const auto& item : recoveryItems) {
-        protocol->persistDifferenceInMemory(
+        protocol->persistDifference(
             item.id,
             Operation::CREATE,
             item.index,
@@ -192,10 +201,9 @@ void recoverModuleData() {
         );
     }
 
-    minfo("Persisted %zu recovery items in memory", recoveryItems.size());
+    minfo("Persisted %zu recovery items", recoveryItems.size());
 
-    // Mode::FULL reads from the in-memory vector, not the persistent queue
-    SyncModuleResult result = protocol->synchronizeModule(Mode::FULL);
+    SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
 
     if (result.success) {
         minfo("Recovery completed successfully");
@@ -211,7 +219,7 @@ bool should_perform_full_sync(const char* index) {
     char checksum[65];
     calculate_index_checksum(index, checksum);
 
-    // Sends one FullSession carrying a Checksums payload and waits for the EndAck
+    // Sends one FullSession carrying a ChecksumModule payload and waits for the EndAck
     bool needs_full_sync = asp_requires_full_sync(handle, index, checksum);
 
     if (needs_full_sync) {
@@ -400,9 +408,27 @@ private:
         {
             std::this_thread::sleep_for(std::chrono::minutes(15));
 
-            // Full sync every 4 hours (16 * 15 min), delta sync otherwise
-            const Mode mode = (++syncCount % 16 == 0) ? Mode::FULL : Mode::DELTA;
-            const auto result = m_protocol->synchronizeModule(mode);
+            SyncModuleResult result;
+
+            // Full-replace resync every 4 hours (16 * 15 min): clear the index, re-persist a
+            // fresh snapshot, then sync via DELTA. Every other cycle is a plain delta sync of
+            // whatever is already pending. See the recovery example above for why there is no
+            // Mode::FULL to reach for here.
+            if (++syncCount % 16 == 0)
+            {
+                if (!m_protocol->notifyDataClean({"inventory_packages"}))
+                {
+                    merror("Failed to clear inventory_packages before full-replace resync");
+                    continue;
+                }
+
+                for (const auto& pkg : loadAllInstalledPackages())
+                {
+                    onPackageInstalled(pkg);
+                }
+            }
+
+            result = m_protocol->synchronizeModule(Mode::DELTA);
 
             if (!result.success)
             {

--- a/docs/ref/modules/utils/sync-protocol/lifecycle.md
+++ b/docs/ref/modules/utils/sync-protocol/lifecycle.md
@@ -1,416 +1,131 @@
 # Protocol Lifecycle
 
-The Agent Sync Protocol implements a session-based synchronization mechanism with well-defined phases and message types. This document details the complete lifecycle of a synchronization session, including all message types and state transitions.
+The Agent Sync Protocol sends a whole synchronization session as **one** FlatBuffer message (`FullSession`) and gets back **one** answer (`EndAck`). There is no `StartAck` round-trip, no per-item message exchange, and no retransmission-of-missing-ranges (`ReqRet`) — those existed only because the transport used to be a DGRAM socket bounded by `OS_MAXSTR` (65536 bytes), which forced a session to be split into many small messages. Over the agent's local `queue-sync` STREAM socket that bound is gone, so the session crosses whole.
 
 ## Synchronization Phases
 
-The protocol operates through three main phases:
+The protocol operates through two phases, tracked in `AgentSyncProtocol::SyncPhase`:
 
-1. **Idle Phase**: No active synchronization
-2. **Session Establishment**: Start message and StartAck response
-3. **Data Transfer**: Sending differences and handling retransmissions
-4. **Session Completion**: End message and EndAck response
+1. **Idle**: no active synchronization.
+2. **WaitingResponse**: the `FullSession` message has been handed to the transport; the calling thread blocks on a condition variable until `parseResponseBuffer()` (or the HTTPS transport's own result-code callback) reports a terminal outcome, or `stop()` is called.
 
-## Message Types
+There is no intermediate "waiting for StartAck" phase and no "processing, wait again" state: the manager's answer is terminal the moment it arrives.
 
-### 1. Start Message
+## The `FullSession` Message
 
-Initiates a synchronization session.
-
-**Direction**: Agent → Manager
-
-**Content**:
-- Synchronization mode (Full/Delta)
-- Total number of differences to send
-
-**FlatBuffer Schema**:
-```
+```flatbuffers
 table Start {
+    module: string;
     mode: Mode;
-    size: uint64;
+    size: ulong;
+    index: [string];
+    option: Option;
+    architecture: string;
+    hostname: string;
+    osname: string;
+    osplatform: string;
+    ostype: string;
+    osversion: string;
+    agentversion: string;
+    agentname: string;
+    agentid: string;
+    groups: [string];
+    global_version: ulong;
+    cluster_name: string;
+    cluster_node: string;
 }
-```
 
-**State Transition**: `Idle` → `WaitingStartAck`
-
-### 2. StartAck Message
-
-Acknowledges session establishment and provides session ID.
-
-**Direction**: Manager → Agent
-
-**Content**:
-- Acknowledgment status
-- Session ID (unique identifier for this sync session)
-
-**FlatBuffer Schema**:
-```
-table StartAck {
-    status: Status;
-    session: uint64;
-}
-```
-
-**State Transition**: `WaitingStartAck` → `DataTransfer`
-
-### 3. DataValue Message
-
-Transmits individual differences to the manager.
-
-**Direction**: Agent → Manager
-
-**Content**:
-- Sequence number
-- Session ID
-- Operation type (Upsert/Delete)
-- Data identifier
-- Target index
-- Version number
-- Data payload
-
-**FlatBuffer Schema**:
-```
 table DataValue {
     seq: ulong;
-    session: ulong;
     operation: Operation;
     id: string;
     index: string;
     version: ulong;
     data: [byte];
 }
-```
 
-**State**: Remains in `DataTransfer`
+table DataContext {
+    seq: ulong;
+    id: string;
+    index: string;
+    data: [byte];
+}
 
-### 4. DataClean Message
-
-Notifies the manager that specific indices should be cleaned.
-
-**Direction**: Agent → Manager
-
-**Content**:
-- Sequence number
-- Session ID
-- Index name to clean
-
-**FlatBuffer Schema**:
-```
 table DataClean {
     seq: ulong;
-    session: ulong;
     index: string;
 }
-```
 
-**State**: Remains in `DataTransfer`
-
-**Usage**: Sent during data cleaning synchronization mode when notifying the manager that specific indices have been disabled or should be cleared.
-
-### 5. End Message
-
-Signals completion of data transmission.
-
-**Direction**: Agent → Manager
-
-**Content**:
-- Session ID
-
-**FlatBuffer Schema**:
-```
-table End {
-    session: ulong;
-}
-```
-
-**State Transition**: `DataTransfer` → `WaitingEndAck`
-
-### 6. ReqRet Message (Request Retransmission)
-
-Manager requests retransmission of specific data ranges.
-
-**Direction**: Manager → Agent
-
-**Content**:
-- List of sequence number ranges to retransmit
-- Session ID
-
-**FlatBuffer Schema**:
-```
-table ReqRet {
-    seq: [Pair];
-    session: ulong;
-}
-
-table Pair {
-    begin: ulong;
-    end: ulong;
-}
-```
-
-**State**: Remains in `DataTransfer`
-
-**Agent Response**: Retransmits requested DataValue messages
-
-### 7. EndAck Message
-
-Acknowledges an `End` message. May be sent multiple times for the same session with different statuses.
-
-**Direction**: Manager → Agent
-
-**Content**:
-- Status (see below)
-- Session ID
-
-**FlatBuffer Schema**:
-```
-table EndAck {
-    status: Status;
-    session: ulong;
-}
-```
-
-**Status Values**:
-- `Ok`: Session completed successfully; agent deletes the synced data from the persistent queue.
-- `Error`: Session failed (e.g. checksum mismatch); agent does not delete data.
-- `Processing`: Manager received the `End` message but the session is still being processed (e.g. queued for indexing). The agent must wait again **without** resending `End` and **without** consuming a retry attempt.
-
-**State Transitions**:
-- `WaitingEndAck` → `Idle` on `Ok` or `Error`
-- `WaitingEndAck` → `WaitingEndAck` on `Processing` (reset wait, no retry consumed)
-
-### 8. ChecksumModule Message
-
-Transmits checksum information for integrity verification.
-
-**Direction**: Agent → Manager
-
-**Content**:
-- Session ID
-- Index identifier
-- Checksum value
-
-**FlatBuffer Schema**:
-```
 table ChecksumModule {
-    session: ulong;
     index: string;
     checksum: string;
 }
+
+table SyncData {
+    values: [DataValue];
+    contexts: [DataContext];
+}
+
+table Cleans {
+    items: [DataClean];
+}
+
+table Checksums {
+    items: [ChecksumModule];
+}
+
+union SessionPayload {
+    SyncData,
+    Cleans,
+    Checksums
+}
+
+table End {
+}
+
+table FullSession {
+    start: Start;
+    payload: SessionPayload;
+    end: End;
+}
 ```
 
-**State**: Used during integrity check mode, sent between StartAck and End
+None of these tables carry a `session` field. The session id is chosen by the **agent** (`AgentSyncProtocol::nextSessionId()`) and is not part of any FlatBuffer table at all — it travels as a parameter of the transport call (`ISyncSessionTransport::sendSession(uint64_t session, ...)`), so a retried session keeps the same id and the manager can dedupe on it independently of the message body.
 
-## Special Synchronization Modes
+`payload` carries exactly one of three shapes, depending on what the session is for:
 
-### Integrity Check Mode (requiresFullSync)
+- **`SyncData`** — a module/metadata sync. `values` (`DataValue`, from `persistDifference(..., isDataContext=false)`) and `contexts` (`DataContext`, from `persistDifference(..., isDataContext=true)`) can both be populated in the same session: they are pulled from the same producer queue and travel together.
+- **`Cleans`** — one `DataClean` per index, from `notifyDataClean()`.
+- **`Checksums`** — one `ChecksumModule`, from `requiresFullSync()`.
+- **absent** — `synchronizeMetadataOrGroups()` sends `Start` and `End` with no payload at all.
 
-The `requiresFullSync` method implements a specialized synchronization flow for checksum verification:
+A session is always exactly one of these — never a combination — which is why they are a `union` rather than four independent optional fields.
 
-```
-Agent                                   Manager
-  |                                        |
-  |-------------- Start ---------------->  |
-  |    (mode=CHECK, checksum)              |
-  |                                        |
-  |<------------ StartAck ---------------- |
-  |            (session_id)                |
-  |                                        |
-  |---------- ChecksumModule ----------->  |
-  |          (index, checksum)             |
-  |                                        |
-  |--------------- End ------------------> |
-  |             (session_id)               |
-  |                                        |
-  |<------------- EndAck ----------------- |
-  |       (status: match/mismatch)         |
-  |                                        |
-```
+## The Response: `EndAck`
 
-**Process:**
-1. Agent sends Start message with CHECK mode
-2. Agent sends checksum message
-3. Agent sends End message
-4. Manager responds with EndAck indicating if checksums match
-5. Return `Error` if mismatch (full sync needed), `Ok` if valid
+```flatbuffers
+enum Status: byte {
+    Ok,
+    Error,
+    Offline,
+    ChecksumMismatch,
+    Processing
+}
 
-### Metadata/Groups Synchronization Mode
-
-The `synchronizeMetadataOrGroups` method implements a simplified flow without data transfer:
-
-```
-Agent                                   Manager
-  |                                        |
-  |-------------- Start ---------------->  |
-  |  (mode=METADATA_DELTA/GROUP_DELTA)     |
-  |                                        |
-  |<------------ StartAck ---------------- |
-  |            (session_id)                |
-  |                                        |
-  |--------------- End ------------------> |
-  |             (session_id)               |
-  |                                        |
-  |<------------- EndAck ----------------- |
-  |              (success)                 |
-  |                                        |
+table EndAck {
+    status: Status;
+}
 ```
 
-**Supported Modes:**
-- `METADATA_DELTA`: Metadata delta synchronization
-- `METADATA_CHECK`: Metadata integrity check
-- `GROUP_DELTA`: Group delta synchronization
-- `GROUP_CHECK`: Group integrity check
+`parseResponseBuffer()` only recognizes one message type: `Message` wrapping an `EndAck`. Handling (see `AgentSyncProtocol::parseResponseBuffer()`):
 
-**Process:**
-1. Agent sends Start message with metadata/group mode
-2. No DataValue messages are sent
-3. Agent immediately sends End message
-4. Manager processes metadata/group information and responds with EndAck
+- **`Ok`**: success. `synchronizeModule()`/`notifyDataClean()` delete the synced items from the persistent queue; `requiresFullSync()` returns `false` (integrity valid).
+- **`Error`**: generic protocol failure (`SyncResult::PROTOCOL_ERROR`). Items are reset to `PENDING` for the next cycle.
+- **`Offline`**: the manager cannot serve this agent right now (`SyncResult::COMMUNICATION_ERROR`, `managerNotReady = true` on the result). Covers both a brief post-restart window and a lasting outage; see `SyncModuleResult::managerNotReady` / `consecutiveFailures` in the [API Reference](api-reference.md#result-type) for how callers tell them apart.
+- **`ChecksumMismatch`**: only meaningful as the answer to a `Checksums` session — `requiresFullSync()` returns `true` (full sync needed).
+- **`Processing`**: defined in the schema's `Status` enum but not currently handled as an intermediate/"keep waiting" state by `AgentSyncProtocol` — there is no longer a separate `End` message to withhold, since `end` is part of the same `FullSession` the manager already received in full.
 
-### Data Clean Synchronization Mode (notifyDataClean)
-
-The `notifyDataClean` method implements a specialized flow for notifying the manager about data cleaning when modules are disabled:
-
-```
-Agent                                   Manager
-  |                                        |
-  |-------------- Start ---------------->  |
-  |   (mode=DELTA, size=N, indices=[...])  |
-  |                                        |
-  |<------------ StartAck ---------------- |
-  |            (session_id)                |
-  |                                        |
-  |---------- DataClean[0] -------------->  |
-  |    (seq=0, session, index="fim_files") |
-  |                                        |
-  |---------- DataClean[1] -------------->  |
-  |  (seq=1, session, index="fim_registry")|
-  |                                        |
-  |              ...                       |
-  |                                        |
-  |---------- DataClean[N-1] ------------>  |
-  |    (seq=N-1, session, index=...)       |
-  |                                        |
-  |--------------- End ------------------> |
-  |             (session_id)               |
-  |                                        |
-  |<------------- EndAck ----------------- |
-  |         (status: Ok)                   |
-  |                                        |
-  | clearItemsByIndex() for each index     |
-  | (cleanup local database entries)       |
-  |                                        |
-```
-
-### In-Memory Recovery Mode
-
-When using `persistDifferenceInMemory` for recovery scenarios:
-
-```
-Agent (Recovery)                       Manager
-  |                                        |
-  | clearInMemoryData()                    |
-  | (cleanup before sync)                  |
-  |                                        |
-  | persistDifferenceInMemory() × N        |
-  | (storing recovery data in memory)      |
-  |                                        |
-  |-------------- Start ---------------->  |
-  |          (mode=FULL)                   |
-  |                                        |
-  |<------------ StartAck ---------------- |
-  |                                        |
-  |------- DataValue (from memory) ------> |
-  |------- DataValue (from memory) ------> |
-  |              ...                       |
-  |                                        |
-  |--------------- End ------------------> |
-  |                                        |
-  |<------------- EndAck ----------------- |
-  |                                        |
-```
-
-**Process:**
-1. Before a sync attempt, agent calls `clearInMemoryData()` to make sure memory is clean before persisting
-2. Agent persists recovery data in memory using `persistDifferenceInMemory()`
-3. Agent triggers full synchronization
-4. DataValue messages are sent from in-memory vector (not from database)
-
-## Complete Synchronization Flow
-
-### Successful Synchronization
-
-```
-Agent                                   Manager
-  |                                        |
-  |-------------- Start ---------------->  |
-  |            (mode, count)               |
-  |                                        |
-  |<------------ StartAck ---------------- |
-  |            (session_id)                |
-  |                                        |
-  |----------- DataValue[0] -------------> |
-  |----------- DataValue[1] -------------> |
-  |----------- DataValue[2] -------------> |
-  |              ...                       |
-  |----------- DataValue[N] -------------> |
-  |                                        |
-  |--------------- End ------------------> |
-  |             (session_id)               |
-  |                                        |
-  |<------------- EndAck ----------------- |
-  |              (success)                 |
-  |                                        |
-```
-
-### Synchronization with EndAck(Processing)
-
-When the manager receives `End` and immediately enqueues the session for indexing, it sends `EndAck(Processing)` to keep the agent waiting. The agent must not resend `End` and must not count this as a failed attempt.
-
-```
-Agent                                   Manager
-  |                                        |
-  |-------------- Start ---------------->  |
-  |                                        |
-  |<------------ StartAck ---------------- |
-  |                                        |
-  |----------- DataValue[0..N] ----------> |
-  |                                        |
-  |--------------- End ------------------> |
-  |                                        |
-  |<------- EndAck(Processing) ----------- |  (session queued, not yet indexed)
-  |   (wait again, no retry consumed,      |
-  |    End NOT resent)                     |
-  |                                        |
-  |<------------- EndAck(Ok) ------------- |  (indexing complete)
-  |                                        |
-```
-
-### Synchronization with Retransmission
-
-```
-Agent                                   Manager
-  |                                        |
-  |-------------- Start ---------------->  |
-  |                                        |
-  |<------------ StartAck ---------------- |
-  |                                        |
-  |----------- DataValue[0] -------------> |
-  |----------- DataValue[1] -------------> |
-  |----------- DataValue[2] -----X (lost)  |
-  |----------- DataValue[3] -------------> |
-  |----------- DataValue[4] -------------> |
-  |                                        |
-  |--------------- End ------------------> |
-  |                                        |
-  |<------------- ReqRet ----------------- |
-  |           (ranges: [[2,2]])            |
-  |                                        |
-  |----------- DataValue[2] -------------> | (retransmission)
-  |                                        |
-  |<------------- EndAck ----------------- |
-  |                                        |
-```
+`parseResponseBuffer()` is one of two ways a result reaches the protocol. The other is `applyHttpResultCode(int resultCode, uint64_t expectedSession)`, used by the HTTPS transport path: it accepts a `"HCRESULT:<session>:<code>"` string (or the legacy `"HCRESULT:<code>"`, which skips session correlation) carrying the HTTP status code directly, without a FlatBuffer body at all. Either path ends in the same terminal `SyncResult`.
 
 ## State Machine
 
@@ -418,53 +133,101 @@ Agent                                   Manager
 stateDiagram-v2
     [*] --> Idle
 
-    Idle --> WaitingStartAck: Send Start
-
-    WaitingStartAck --> DataTransfer: Receive StartAck
-    WaitingStartAck --> Idle: Timeout/Error
-
-    DataTransfer --> DataTransfer: Send DataValue/DataClean
-    DataTransfer --> WaitingEndAck: Send End
-
-    WaitingEndAck --> Idle: Receive EndAck(Ok/Error)
-    WaitingEndAck --> WaitingEndAck: Receive EndAck(Processing)
-    WaitingEndAck --> DataTransfer: Receive ReqRet
-    WaitingEndAck --> Idle: Timeout/Error
+    Idle --> WaitingResponse: Send FullSession
+    WaitingResponse --> Idle: Receive EndAck (Ok/Error/Offline/ChecksumMismatch)
+    WaitingResponse --> Idle: HCRESULT result code
+    WaitingResponse --> Idle: stop() requested
 ```
+
+## Special Synchronization Flows
+
+### Integrity Check (`requiresFullSync`)
+
+```
+Agent                                   Manager
+  |                                        |
+  |------------- FullSession ------------> |
+  |   Start(mode=ModuleCheck)               |
+  |   payload = Checksums{[index, sum]}     |
+  |   End                                  |
+  |                                        |
+  |<-------------- EndAck ----------------- |
+  |     status: Ok | ChecksumMismatch       |
+```
+
+Returns `true` (full sync required) on `ChecksumMismatch`, `false` (integrity valid) on `Ok`.
+
+### Metadata/Groups Sync (`synchronizeMetadataOrGroups`)
+
+```
+Agent                                   Manager
+  |                                        |
+  |------------- FullSession ------------> |
+  |   Start(mode=MetadataDelta/            |
+  |         MetadataCheck/GroupDelta/      |
+  |         GroupCheck, global_version)    |
+  |   (no payload)                         |
+  |   End                                  |
+  |                                        |
+  |<-------------- EndAck ----------------- |
+  |              status: Ok                |
+```
+
+### Data Clean Notification (`notifyDataClean`)
+
+```
+Agent                                   Manager
+  |                                        |
+  |------------- FullSession ------------> |
+  |   Start(mode=DELTA, index=[...])       |
+  |   payload = Cleans{                    |
+  |     DataClean(index="fim_files"),      |
+  |     DataClean(index="fim_registry")}   |
+  |   End                                  |
+  |                                        |
+  |<-------------- EndAck ----------------- |
+  |              status: Ok                |
+  |                                        |
+  | clearItemsByIndex() for each index     |
+  | (local database cleanup)               |
+```
+
+### In-Memory Recovery (`persistDifferenceInMemory` + `synchronizeModule(Mode::FULL, ...)`)
+
+```
+Agent (recovery)                        Manager
+  |                                        |
+  | clearInMemoryData()                    |
+  | persistDifferenceInMemory() x N        |
+  |                                        |
+  |------------- FullSession ------------> |
+  |   Start(mode=ModuleFull, size=N)       |
+  |   payload = SyncData{values: [...]}    |
+  |   End                                  |
+  |                                        |
+  |<-------------- EndAck ----------------- |
+  |              status: Ok                |
+```
+
+### Delta Sync Split Into Multiple Sessions
+
+`Mode::DELTA` reads from the persistent queue in blocks (`AgentSyncProtocol::synchronizeDeltaByBlocks()`), sending one `FullSession` per block until the queue is drained or `FULLSESSION_MAX_BLOCKS_PER_SYNC` is reached, each block capped at `FULLSESSION_MAX_BYTES` (`Option::VDFIRST`/`Option::VDSYNC` are exempt from the cap). Each block is its own independent `FullSession`/`EndAck` exchange with its own session id — a failure in one block does not roll back the others.
 
 ## Transport-Level Timeout and Retry
 
-The sync protocol module does **not** impose a module-level response-wait timeout. Once a session is
-successfully submitted to the HTTPS transport's intake socket, the module waits indefinitely for the
-transport callback. The transport layer owns:
+The sync protocol module does **not** impose a module-level response-wait timeout. Once a session is successfully submitted to the HTTPS transport's intake socket, the module waits indefinitely for the transport callback. The transport layer owns:
 
-- **Per-request timeout** — `statefulTimeoutMs` (default 120 s per attempt, configurable via the
-  HTTPS client configuration).
+- **Per-request timeout** — `statefulTimeoutMs` (default 120 s per attempt, configurable via the HTTPS client configuration).
 - **HTTP-level retries** — `STATEFUL_MAX_ATTEMPTS` (default 5 attempts with backoff).
 
-The only module-level parameter that remains active is **`retries`**, which controls how many times
-`runSession()` re-submits the session to the intake socket if that socket is temporarily unavailable
-(e.g. during an agentd restart between attempts). This is a local hand-off concern, not an HTTP-level
-one.
+The only retry that remains at the `sync_protocol` level is the fixed `SYNC_HANDOFF_RETRIES` constant (currently 3): how many times `runSession()` re-submits the same session to the local `queue-sync` intake socket if that socket is transiently unavailable (e.g. during an `agentd` restart between attempts). This is not caller-configurable and is a local hand-off concern, not an HTTP-level one.
 
-When all transport attempts are exhausted the callback fires with a non-OK result code, the sync cycle
-fails, items are reset to `PENDING`, and the module's own periodic timer triggers the next attempt.
+When all transport attempts are exhausted, the callback fires with a non-OK result, the sync cycle fails, items are reset to `PENDING`, and the module's own periodic timer triggers the next attempt.
 
 ## Error Handling
 
 ### Protocol Errors
 
-1. **Invalid Session ID**
-   - Manager sends message with wrong session ID
-   - Agent logs error and continues waiting
-   - Does not affect current synchronization
-
-2. **Unexpected Message Type**
-   - Receiving message out of sequence
-   - Logged as warning
-   - Current phase maintained
-
-3. **Malformed Messages**
-   - FlatBuffer parsing failures
-   - Logged as error
-   - Message ignored
+1. **Stale response**: `parseResponseBuffer()`/`applyHttpResultCode()` discard any response that arrives while the protocol is not in `WaitingResponse` phase, or (for `applyHttpResultCode`) whose session id does not match the in-flight one — logged at DEBUG, does not affect the current synchronization.
+2. **Unknown message type**: logged at DEBUG, `parseResponseBuffer()` returns `false`.
+3. **Malformed messages**: FlatBuffer verification failure or parse exception — logged as an error, message ignored.

--- a/docs/ref/modules/utils/sync-protocol/lifecycle.md
+++ b/docs/ref/modules/utils/sync-protocol/lifecycle.md
@@ -70,14 +70,10 @@ table Cleans {
     items: [DataClean];
 }
 
-table Checksums {
-    items: [ChecksumModule];
-}
-
 union SessionPayload {
     SyncData,
     Cleans,
-    Checksums
+    ChecksumModule
 }
 
 table End {
@@ -95,8 +91,8 @@ None of these tables carry a `session` field. The session id is chosen by the **
 `payload` carries exactly one of three shapes, depending on what the session is for:
 
 - **`SyncData`** — a module/metadata sync. `values` (`DataValue`, from `persistDifference(..., isDataContext=false)`) and `contexts` (`DataContext`, from `persistDifference(..., isDataContext=true)`) can both be populated in the same session: they are pulled from the same producer queue and travel together.
-- **`Cleans`** — one `DataClean` per index, from `notifyDataClean()`.
-- **`Checksums`** — one `ChecksumModule`, from `requiresFullSync()`.
+- **`Cleans`** — one `DataClean` per index, from `notifyDataClean()`. This is a real array: a session can clean several indices at once (e.g. FIM clearing files, registry keys, and registry values together).
+- **`ChecksumModule`** — from `requiresFullSync()`. Referenced directly rather than wrapped in an array table, since an integrity check always covers exactly one index/module.
 - **absent** — `synchronizeMetadataOrGroups()` sends `Start` and `End` with no payload at all.
 
 A session is always exactly one of these — never a combination — which is why they are a `union` rather than four independent optional fields.
@@ -122,7 +118,7 @@ table EndAck {
 - **`Ok`**: success. `synchronizeModule()`/`notifyDataClean()` delete the synced items from the persistent queue; `requiresFullSync()` returns `false` (integrity valid).
 - **`Error`**: generic protocol failure (`SyncResult::PROTOCOL_ERROR`). Items are reset to `PENDING` for the next cycle.
 - **`Offline`**: the manager cannot serve this agent right now (`SyncResult::COMMUNICATION_ERROR`, `managerNotReady = true` on the result). Covers both a brief post-restart window and a lasting outage; see `SyncModuleResult::managerNotReady` / `consecutiveFailures` in the [API Reference](api-reference.md#result-type) for how callers tell them apart.
-- **`ChecksumMismatch`**: only meaningful as the answer to a `Checksums` session — `requiresFullSync()` returns `true` (full sync needed).
+- **`ChecksumMismatch`**: only meaningful as the answer to a `ChecksumModule` session — `requiresFullSync()` returns `true` (full sync needed).
 - **`Processing`**: defined in the schema's `Status` enum but not currently handled as an intermediate/"keep waiting" state by `AgentSyncProtocol` — there is no longer a separate `End` message to withhold, since `end` is part of the same `FullSession` the manager already received in full.
 
 `parseResponseBuffer()` is one of two ways a result reaches the protocol. The other is `applyHttpResultCode(int resultCode, uint64_t expectedSession)`, used by the HTTPS transport path: it accepts a `"HCRESULT:<session>:<code>"` string (or the legacy `"HCRESULT:<code>"`, which skips session correlation) carrying the HTTP status code directly, without a FlatBuffer body at all. Either path ends in the same terminal `SyncResult`.
@@ -148,7 +144,7 @@ Agent                                   Manager
   |                                        |
   |------------- FullSession ------------> |
   |   Start(mode=ModuleCheck)               |
-  |   payload = Checksums{[index, sum]}     |
+  |   payload = ChecksumModule{index, sum}  |
   |   End                                  |
   |                                        |
   |<-------------- EndAck ----------------- |
@@ -192,16 +188,37 @@ Agent                                   Manager
   | (local database cleanup)               |
 ```
 
-### In-Memory Recovery (`persistDifferenceInMemory` + `synchronizeModule(Mode::FULL, ...)`)
+### Full-Replace Recovery: DataClean Then DELTA
+
+There is no `Mode::FULL`/in-memory recovery API anymore. `Mode::FULL` used to make the manager
+`deleteByQuery` every index in `Start` unconditionally and then index whatever the agent sent in
+that one session — safe only as long as the payload always went whole. Once DELTA sessions
+started being byte-capped and split into blocks, stamping a byte-capped payload as `Mode::FULL`
+would still trigger the unconditional delete, permanently losing whatever did not fit in that one
+session (see the change that removed it).
+
+A full-replace resync (recovery after a checksum mismatch, or a module's first sync) is instead
+two ordinary operations already described above: a `Cleans` session to explicitly and scopedly
+clear the target index, followed by a `Mode::DELTA` sync — itself already safely
+block-splittable — of the freshly rebuilt snapshot, persisted through the normal
+`persistDifference()`/persistent-queue path like any other delta.
 
 ```
 Agent (recovery)                        Manager
   |                                        |
-  | clearInMemoryData()                    |
-  | persistDifferenceInMemory() x N        |
+  |------------- FullSession ------------> |
+  |   Start(mode=ModuleDelta, index=[idx]) |
+  |   payload = Cleans{DataClean(index)}   |
+  |   End                                  |
+  |                                        |
+  |<-------------- EndAck ----------------- |
+  |              status: Ok                |
+  |                                        |
+  | persistDifference() x N                |
+  | (fresh snapshot, persistent queue)     |
   |                                        |
   |------------- FullSession ------------> |
-  |   Start(mode=ModuleFull, size=N)       |
+  |   Start(mode=ModuleDelta, size=N)      |
   |   payload = SyncData{values: [...]}    |
   |   End                                  |
   |                                        |

--- a/docs/ref/modules/utils/sync-protocol/lifecycle.md
+++ b/docs/ref/modules/utils/sync-protocol/lifecycle.md
@@ -432,30 +432,23 @@ stateDiagram-v2
     WaitingEndAck --> Idle: Timeout/Error
 ```
 
-## Timeout and Retry Mechanism
+## Transport-Level Timeout and Retry
 
-### Timeout Handling
+The sync protocol module does **not** impose a module-level response-wait timeout. Once a session is
+successfully submitted to the HTTPS transport's intake socket, the module waits indefinitely for the
+transport callback. The transport layer owns:
 
-Each phase has specific timeout behaviors:
+- **Per-request timeout** — `statefulTimeoutMs` (default 120 s per attempt, configurable via the
+  HTTPS client configuration).
+- **HTTP-level retries** — `STATEFUL_MAX_ATTEMPTS` (default 5 attempts with backoff).
 
-1. **WaitingStartAck**
-   - Default timeout: 30 seconds
-   - On timeout: Retry sending Start message
-   - Max retries: Configurable (default 3)
-   - After max retries: Abort synchronization
+The only module-level parameter that remains active is **`retries`**, which controls how many times
+`runSession()` re-submits the session to the intake socket if that socket is temporarily unavailable
+(e.g. during an agentd restart between attempts). This is a local hand-off concern, not an HTTP-level
+one.
 
-2. **DataTransfer**
-   - No timeout for data sending
-   - Flow control via EPS limiting
-
-3. **WaitingEndAck**
-   - Default timeout: 30 seconds
-   - On `EndAck(Ok/Error)`: Session completes or fails immediately
-   - On `EndAck(Processing)`: Manager is still processing; agent resets the wait timer and continues waiting **without** resending `End` and **without** consuming a retry
-   - On `ReqRet`: Agent retransmits missing sequences; retrying does **not** consume a retry
-   - On timeout after sending `End`: Retry sending End message, consuming one retry
-   - Max retries: Configurable (default 3)
-   - After max retries: Abort synchronization
+When all transport attempts are exhausted the callback fires with a non-OK result code, the sync cycle
+fails, items are reset to `PENDING`, and the module's own periodic timer triggers the next attempt.
 
 ## Error Handling
 

--- a/docs/ref/modules/utils/sync-protocol/sequence-diagrams.md
+++ b/docs/ref/modules/utils/sync-protocol/sequence-diagrams.md
@@ -121,7 +121,7 @@ sequenceDiagram
     Module->>Module: Calculate checksum for index
     Module->>ASP: requiresFullSync(index, checksum)
 
-    ASP->>ASP: Build ONE FullSession<br/>Start(mode=ModuleCheck) + Checksums{[index, checksum]} + End
+    ASP->>ASP: Build ONE FullSession<br/>Start(mode=ModuleCheck) + ChecksumModule{index, checksum} + End
     ASP->>Transport: sendSession(session_id, bytes)
     Transport->>AD: Write over queue-sync socket
     AD->>Manager: POST /stateful
@@ -193,32 +193,39 @@ sequenceDiagram
     ASP-->>Module: true (success)
 ```
 
-### In-Memory Recovery Flow
+### Full-Replace Recovery Flow (DataClean + DELTA)
+
+There is no in-memory recovery API or `Mode::FULL` anymore (see [Protocol Lifecycle](lifecycle.md#full-replace-recovery-dataclean-then-delta) for why). Recovery is a `notifyDataClean()` call followed by an ordinary persisted-queue `Mode::DELTA` sync of the fresh snapshot:
 
 ```mermaid
 sequenceDiagram
     participant Module as Internal Module
     participant ASP as Agent Sync Protocol
-    participant Memory as In-Memory Vector
+    participant Queue as Persistent Queue
     participant Transport as SyncSocketTransport
     participant Manager as Wazuh Manager
 
-    Note over Module: Module recovery initiated
+    Note over Module: Recovery initiated (e.g. checksum mismatch)
 
-    Module->>ASP: clearInMemoryData()
-    ASP->>Memory: Clear
-
-    loop For each recovery item
-        Module->>ASP: persistDifferenceInMemory(id, operation, index, data, version)
-        ASP->>Memory: Store in memory vector
-    end
-
-    Module->>ASP: synchronizeModule(FULL)
-    ASP->>Memory: Read all items
-    ASP->>ASP: Build ONE FullSession<br/>Start(mode=ModuleFull, size=N) + SyncData{values} + End
+    Module->>ASP: notifyDataClean({index})
+    ASP->>ASP: Build FullSession<br/>Start(mode=ModuleDelta, index=[index]) + Cleans{DataClean(index)} + End
     ASP->>Transport: sendSession(session_id, bytes)
     Transport-->>Manager: (via agentd/https_client)
     Manager-->>ASP: EndAck(status=Ok)
+    ASP-->>Module: true
+
+    loop For each item in the fresh snapshot
+        Module->>ASP: persistDifference(id, operation, index, data, version)
+        ASP->>Queue: Store in SQLite
+    end
+
+    Module->>ASP: synchronizeModule(DELTA)
+    ASP->>Queue: fetchAndMarkForSync(byteCap)
+    ASP->>ASP: Build FullSession<br/>Start(mode=ModuleDelta, size=N) + SyncData{values} + End
+    ASP->>Transport: sendSession(session_id, bytes)
+    Transport-->>Manager: (via agentd/https_client)
+    Manager-->>ASP: EndAck(status=Ok)
+    ASP->>Queue: clearSyncedItems()
 
     ASP-->>Module: SyncModuleResult{success=true}
 ```

--- a/docs/ref/modules/utils/sync-protocol/sequence-diagrams.md
+++ b/docs/ref/modules/utils/sync-protocol/sequence-diagrams.md
@@ -1,22 +1,31 @@
 # Sequence Diagrams
 
-This document provides visual representations of the interactions between modules and the Agent Sync Protocol during various synchronization scenarios.
+This document provides visual representations of the interactions between modules and the Agent Sync Protocol during various synchronization scenarios. Every scenario below sends **one** `FullSession` message and gets back **one** terminal answer — see [Protocol Lifecycle](lifecycle.md) for the message-level detail behind these diagrams.
+
+Participants used throughout:
+
+- **Module** — the internal module (FIM/SCA/Syscollector/agent-info) driving the protocol.
+- **ASP** — `AgentSyncProtocol`.
+- **Queue** — the SQLite-backed persistent queue.
+- **Transport** — `SyncSocketTransport`, which streams the session over the agent's local `queue-sync` socket.
+- **AD** — `agentd`'s intake process, which hands the session to `https_client` and relays its HTTPS response back.
+- **Manager** — the Wazuh Manager, reached over HTTPS.
 
 ## Module Integration Flow
 
-### Initial Setup and Registration
+### Initial Setup
 
 ```mermaid
 sequenceDiagram
-    participant Module as Internal Module<br/>(FIM/SCA/Inventory)
+    participant Module as Internal Module<br/>(FIM/SCA/Syscollector)
     participant ASP as Agent Sync Protocol
     participant Queue as Persistent Queue<br/>(SQLite)
-    participant MQ as Message Queue
+    participant Transport as SyncSocketTransport
 
-    Module->>ASP: Create instance<br/>(module_name, db_path, mq_funcs)
-    ASP->>Queue: Initialize database
+    Module->>ASP: Create instance<br/>(moduleName, dbPath, logger)
+    ASP->>Queue: Open/initialize database
     Queue-->>ASP: Database ready
-    ASP->>MQ: Setup connection functions
+    ASP->>Transport: Default-constructed<br/>(queue-sync socket path)
     ASP-->>Module: Instance created
 ```
 
@@ -30,403 +39,105 @@ sequenceDiagram
 
     Note over Module: Detect change<br/>(file modified, check completed, etc.)
 
-    Module->>ASP: persistDifference(id, operation, index, data)
-    ASP->>ASP: Validate parameters
+    Module->>ASP: persistDifference(id, operation, index, data, version, isDataContext)
     ASP->>Queue: Store in SQLite
     Queue-->>ASP: Success
     ASP-->>Module: Return
 
-    Note over Queue: Data persisted<br/>Ready for sync
+    Note over Queue: Item persisted,<br/>ready for the next sync cycle
 ```
 
 ## Synchronization Flows
 
-### Successful Delta Synchronization
+### Successful Delta Synchronization (mixed `DataValue` + `DataContext`)
 
 ```mermaid
 sequenceDiagram
     participant Module as Internal Module
     participant ASP as Agent Sync Protocol
     participant Queue as Persistent Queue
-    participant MQ as Message Queue
-    participant AD as Wazuh agentd
+    participant Transport as SyncSocketTransport
+    participant AD as agentd (https_client)
     participant Manager as Wazuh Manager
 
-    Module->>ASP: synchronizeModule(DELTA, timeout, retries, maxEps)
-    ASP->>Queue: Get pending differences
-    Queue-->>ASP: Return data array
+    Module->>ASP: synchronizeModule(DELTA)
+    ASP->>Queue: fetchAndMarkForSync(byteCap)
+    Queue-->>ASP: PersistedData[] (DataValue + DataContext mixed)
 
-    Note over ASP,Manager: Session Establishment Phase
-    ASP->>ASP: Build Start message
-    ASP->>MQ: Send Start message
-    MQ->>AD: Forward Start
-    AD->>Manager: Forward Start
-    Manager->>Manager: Create session
-    Manager->>AD: Send StartAck(session_id)
-    AD->>ASP: Forward StartAck
-    ASP->>ASP: Store session_id
+    ASP->>ASP: Build ONE FullSession<br/>Start + SyncData{values, contexts} + End
+    ASP->>Transport: sendSession(session_id, bytes)
+    Transport->>AD: Write over queue-sync socket
+    AD-->>Transport: Queued (status byte)
+    Transport-->>ASP: true
 
-    Note over ASP,Manager: Data Transfer Phase
-    loop For each difference
-        ASP->>ASP: Apply EPS throttling
-        ASP->>ASP: Build Data message
-        ASP->>MQ: Send Data[seq_num]
-        MQ->>AD: Forward Data
-        AD->>Manager: Forward Data
-        Manager->>Manager: Process & store
-    end
+    Note over ASP: Phase = WaitingResponse<br/>Block on condition variable
 
-    Note over ASP,Manager: Session Completion Phase
-    ASP->>ASP: Build End message
-    ASP->>MQ: Send End(session_id)
-    MQ->>AD: Forward End
-    AD->>Manager: Forward End
-    Manager->>Manager: Validate received data
-    Manager->>AD: Send EndAck(success)
-    AD->>ASP: Forward EndAck
-    ASP->>Queue: Delete data
+    AD->>Manager: POST /stateful<br/>(X-Session-Id header, FullSession body)
+    Manager->>Manager: Decode SyncData:<br/>values -> upsert/delete indexer docs<br/>contexts -> store, not indexed
+    Manager-->>AD: 200 OK, EndAck(status=Ok)
+    AD->>ASP: parseResponseBuffer(EndAck)
+    ASP->>Queue: Delete synced items
     Queue-->>ASP: Success
 
-    ASP-->>Module: Return true (success)
+    ASP-->>Module: SyncModuleResult{success=true}
 ```
 
-### Synchronization with EndAck(Processing)
+### Delta Sync Split Into Multiple Blocks
 
-When the manager receives `End` and immediately enqueues the session for indexing, it responds with `EndAck(Processing)` as an intermediate acknowledgment. The agent continues waiting without resending `End` and without consuming a retry attempt.
+`Mode::DELTA` splits the queue into as many `FullSession`s as needed to stay under `FULLSESSION_MAX_BYTES`; each block is its own independent session with its own session id.
 
 ```mermaid
 sequenceDiagram
     participant Module as Internal Module
     participant ASP as Agent Sync Protocol
     participant Queue as Persistent Queue
-    participant MQ as Message Queue
-    participant AD as Wazuh agentd
+    participant Transport as SyncSocketTransport
     participant Manager as Wazuh Manager
 
-    Module->>ASP: synchronizeModule(DELTA, timeout, retries, maxEps)
-    ASP->>Queue: Get pending differences
-    Queue-->>ASP: Return data array
+    Module->>ASP: synchronizeModule(DELTA)
 
-    Note over ASP,Manager: Session Establishment Phase
-    ASP->>MQ: Send Start
-    MQ->>AD: Forward Start
-    AD->>Manager: Forward Start
-    Manager->>AD: Send StartAck(session_id)
-    AD->>ASP: Forward StartAck
-
-    Note over ASP,Manager: Data Transfer Phase
-    loop For each difference
-        ASP->>MQ: Send Data[seq_num]
-        MQ->>AD: Forward Data
-        AD->>Manager: Forward Data
-        Manager->>Manager: Process & store
+    loop Until queue drained or FULLSESSION_MAX_BLOCKS_PER_SYNC reached
+        ASP->>Queue: fetchAndMarkForSync(byteCap)
+        Queue-->>ASP: Next block of PersistedData
+        ASP->>Transport: sendSession(session_id_N, FullSession)
+        Transport-->>Manager: (via agentd/https_client)
+        Manager-->>ASP: EndAck(status=Ok)
+        ASP->>Queue: clearSyncedItems() for this block
     end
 
-    Note over ASP,Manager: Session Completion Phase
-    ASP->>MQ: Send End(session_id)
-    MQ->>AD: Forward End
-    AD->>Manager: Forward End
-
-    Note over Manager: All sequences received.<br/>Enqueue session for indexing.<br/>Send Processing ack immediately.
-    Manager->>AD: Send EndAck(Processing)
-    AD->>ASP: Forward EndAck(Processing)
-
-    Note over ASP: processingAckReceived = true<br/>Reset wait timer.<br/>Do NOT resend End.<br/>Do NOT increment retry counter.
-
-    Note over Manager: Indexing complete.
-    Manager->>AD: Send EndAck(Ok)
-    AD->>ASP: Forward EndAck(Ok)
-
-    ASP->>Queue: Delete synced data
-    Queue-->>ASP: Success
-    ASP-->>Module: Return true (success)
+    ASP-->>Module: SyncModuleResult{success=true}
 ```
 
-### Synchronization with Retransmission Request
+### Integrity Check Flow (`requiresFullSync`)
 
 ```mermaid
 sequenceDiagram
     participant Module as Internal Module
     participant ASP as Agent Sync Protocol
-    participant Queue as Persistent Queue
-    participant MQ as Message Queue
-    participant AD as Wazuh agentd
-    participant Manager as Wazuh Manager
-
-    Module->>ASP: synchronizeModule(DELTA, timeout, retries, maxEps)
-    ASP->>Queue: Get pending differences
-    Queue-->>ASP: Return data array[1..100]
-
-    Note over ASP,Manager: Session Establishment
-    ASP->>MQ: Send Start
-    MQ->>AD: Forward Start
-    AD->>Manager: Forward Start
-    Manager->>AD: Send StartAck(session_id=123)
-    AD->>ASP: Forward StartAck
-
-    Note over ASP,Manager: Data Transfer with Loss
-    ASP->>MQ: Send Data[1..30]
-    MQ->>AD: Forward Data[1..30]
-    AD->>Manager: Forward Data[1..30]
-
-    Note over MQ,Manager: Network issue:<br/>Data[31..35] lost
-    ASP->>MQ: Send Data[31..35]
-    MQ->>AD: Send Data[31..35]
-    AD--xManager: Lost in transit
-
-    ASP->>MQ: Send Data[36..100]
-    MQ->>AD: Send Data[36..100]
-    AD->>Manager: Forward Data[36..100]
-
-    Note over ASP,Manager: Session Completion Phase
-    ASP->>MQ: Send End
-    MQ->>AD: Forward End
-    AD->>Manager: Forward End
-
-    Note over Manager: Detect missing<br/>sequences 31-35
-    Manager->>AD: Send ReqRet(ranges=[[31,35]])
-    AD->>ASP: Forward ReqRet
-
-    Note over ASP,Manager: Retransmission
-    ASP->>ASP: Filter data by ranges
-    ASP->>MQ: Resend Data[31..35]
-    MQ->>AD: Forward Data[31..35]
-    AD->>Manager: Forward Data[31..35]
-    Manager->>Manager: Fill gaps
-
-    Manager->>AD: Send EndAck(success)
-    AD->>ASP: Forward EndAck
-    ASP-->>Module: Return true
-```
-
-### Failed Synchronization with Retry
-
-```mermaid
-sequenceDiagram
-    participant Module as Internal Module
-    participant ASP as Agent Sync Protocol
-    participant MQ as Message Queue
-    participant AD as Wazuh agentd
-    participant Manager as Wazuh Manager
-
-    Module->>ASP: synchronizeModule(FULL, timeout=30s, retries=3, maxEps=1000)
-
-    Note over ASP,Manager: Attempt 1
-    ASP->>MQ: Send Start
-    MQ->>AD: Forward Start
-    AD->>Manager: Forward Start
-    Note over ASP: Wait 30s
-    ASP->>ASP: Timeout waiting for StartAck
-
-    Note over ASP,Manager: Attempt 2
-    ASP->>MQ: Send Start
-    MQ->>AD: Forward Start
-    AD->>Manager: Forward Start
-    Note over Manager: Manager busy/overloaded
-    Note over ASP: Wait 30s
-    ASP->>ASP: Timeout waiting for StartAck
-
-    Note over ASP,Manager: Attempt 3
-    ASP->>MQ: Send Start
-    MQ->>AD: Forward Start
-    AD->>Manager: Forward Start
-    Manager->>AD: Send StartAck(session_id=456)
-    AD->>ASP: Forward StartAck
-
-    Note over ASP,Manager: Continue with sync...
-    ASP->>MQ: Send Data messages
-    MQ->>AD: Forward Data
-    AD->>Manager: Forward Data
-    ASP->>MQ: Send End
-    MQ->>AD: Forward End
-    AD->>Manager: Forward End
-    Manager->>AD: Send EndAck
-    AD->>ASP: Forward EndAck
-
-    ASP-->>Module: Return true (success after retries)
-```
-
-## Error Handling Scenarios
-
-### Manager Error Response
-
-```mermaid
-sequenceDiagram
-    participant Module as Internal Module
-    participant ASP as Agent Sync Protocol
-    participant MQ as Message Queue
-    participant AD as Wazuh agentd
-    participant Manager as Wazuh Manager
-
-    Module->>ASP: synchronizeModule()
-    ASP->>MQ: Send Start
-    MQ->>AD: Forward Start
-    AD->>Manager: Forward Start
-
-    Note over Manager: Detect invalid<br/>protocol version
-
-    Manager->>AD: Send Error(INVALID_VERSION)
-    AD->>ASP: Forward Error
-
-    ASP->>ASP: Set syncFailed flag
-    ASP->>ASP: Clear sync state
-    ASP-->>Module: Return false (sync failed)
-
-    Note over Module: Handle failure<br/>(log, retry later, etc.)
-```
-
-## Response Handling Flow
-
-### Asynchronous Response Processing
-
-```mermaid
-sequenceDiagram
-    participant Thread1 as Sync Thread
-    participant Thread2 as Response Thread
-    participant ASP as Agent Sync Protocol
-    participant State as Sync State
-    participant MQ as Message Queue
-    participant AD as Wazuh agentd
-    participant Manager as Wazuh Manager
-
-    Thread1->>ASP: synchronizeModule()
-    ASP->>State: Set phase = WaitingStartAck
-    ASP->>MQ: Send Start
-    MQ->>AD: Forward Start
-    AD->>Manager: Forward Start
-
-    Thread1->>State: Wait on condition variable
-
-    Note over Thread2: agend Receive Loop
-    Manager->>AD: Send StartAck
-    AD->>Thread2: Receive StartAck
-    Thread2->>ASP: parseResponseBuffer(data)
-    ASP->>State: Validate session & phase
-    ASP->>State: Set startAckReceived = true
-    ASP->>State: Notify condition variable
-
-    State->>Thread1: Wake up
-    Thread1->>State: Check startAckReceived
-    Thread1->>ASP: Continue with data send
-    ASP->>MQ: Send Data
-    MQ->>AD: Forward Data
-    AD->>Manager: Forward Data
-    ASP->>State: Set phase = WaitingEndAck
-
-    Thread1->>State: Wait on condition variable
-
-    Note over Thread2: agend Receive Loop
-    Manager->>AD: Send EndtAck
-    AD->>Thread2: Receive EndtAck
-    Thread2->>ASP: parseResponseBuffer(data)
-    ASP->>State: Validate session & phase
-    ASP->>State: Set endAckReceived = true
-    ASP->>State: Notify condition variable
-
-    State->>Thread1: Wake up
-    Thread1->>State: Check endAckReceived
-    Thread1->>ASP: Delete sent data
-```
-
-### Integrity Check Flow (requiresFullSync)
-
-```mermaid
-sequenceDiagram
-    participant Module as Internal Module
-    participant ASP as Agent Sync Protocol
-    participant MQ as Message Queue
-    participant AD as Wazuh agentd
+    participant Transport as SyncSocketTransport
+    participant AD as agentd (https_client)
     participant Manager as Wazuh Manager
 
     Module->>Module: Calculate checksum for index
-    Module->>ASP: requiresFullSync(index, checksum, timeout, retries, maxEps)
+    Module->>ASP: requiresFullSync(index, checksum)
 
-    Note over ASP,Manager: Session Establishment
-    ASP->>MQ: Send Start(mode=CHECK)
-    MQ->>AD: Forward Start
-    AD->>Manager: Forward Start
-    Manager->>AD: Send StartAck(session_id)
-    AD->>ASP: Forward StartAck
+    ASP->>ASP: Build ONE FullSession<br/>Start(mode=ModuleCheck) + Checksums{[index, checksum]} + End
+    ASP->>Transport: sendSession(session_id, bytes)
+    Transport->>AD: Write over queue-sync socket
+    AD->>Manager: POST /stateful
 
-    Note over ASP,Manager: Send Checksum Only
-    ASP->>MQ: Send ChecksumModule
-    MQ->>AD: Forward ChecksumModule
-    AD->>Manager: Forward ChecksumModule
+    Manager->>Manager: Compare agent checksum<br/>against indexed documents
 
-    Note over Manager: Compare checksums
-
-    Note over ASP,Manager: Session Completion
-    ASP->>MQ: Send End(session_id)
-    MQ->>AD: Forward End
-    AD->>Manager: Forward End
-    Manager->>Manager: Determine if mismatch
-
-    alt Checksum Mismatch
-        Manager->>AD: Send EndAck(status=Error)
-        AD->>ASP: Forward EndAck
-        ASP-->>Module: Return true (full sync needed)
+    alt Checksum mismatch
+        Manager-->>AD: EndAck(status=ChecksumMismatch)
+        AD->>ASP: parseResponseBuffer(EndAck)
+        ASP-->>Module: true (full sync needed)
         Module->>Module: Schedule full synchronization
-    else Checksum Match
-        Manager->>AD: Send EndAck(status=Ok)
-        AD->>ASP: Forward EndAck
-        ASP-->>Module: Return false (integrity valid)
-        Module->>Module: Continue with delta sync
+    else Checksum match
+        Manager-->>AD: EndAck(status=Ok)
+        AD->>ASP: parseResponseBuffer(EndAck)
+        ASP-->>Module: false (integrity valid)
     end
-```
-
-### In-Memory Recovery Flow
-
-```mermaid
-sequenceDiagram
-    participant Module as Internal Module
-    participant ASP as Agent Sync Protocol
-    participant Memory as In-Memory Vector
-    participant MQ as Message Queue
-    participant AD as Wazuh agentd
-    participant Manager as Wazuh Manager
-
-    Note over Module: Module recovery initiated
-
-    loop For each recovery item
-        Module->>ASP: persistDifferenceInMemory(id, operation, index, data)
-        ASP->>Memory: Store in memory vector
-        Memory-->>ASP: Success
-    end
-
-    Note over Module: All recovery data in memory
-
-    Module->>ASP: synchronizeModule(FULL, timeout, retries, maxEps)
-
-    Note over ASP,Manager: Session Establishment
-    ASP->>MQ: Send Start(mode=FULL, size=N)
-    MQ->>AD: Forward Start
-    AD->>Manager: Forward Start
-    Manager->>AD: Send StartAck(session_id)
-    AD->>ASP: Forward StartAck
-
-    Note over ASP,Manager: Data Transfer from Memory
-    loop For each in-memory item
-        ASP->>Memory: Get next item
-        Memory-->>ASP: Return data
-        ASP->>ASP: Build Data message
-        ASP->>MQ: Send Data
-        MQ->>AD: Forward Data
-        AD->>Manager: Forward Data
-    end
-
-    Note over ASP,Manager: Session Completion
-    ASP->>MQ: Send End(session_id)
-    MQ->>AD: Forward End
-    AD->>Manager: Forward End
-    Manager->>AD: Send EndAck(success)
-    AD->>ASP: Forward EndAck
-
-    ASP-->>Module: Return true (success)
-    Module->>ASP: clearInMemoryData()
-    ASP->>Memory: Clear all entries
-    Memory-->>ASP: Cleared
-
-    Note over Module: Recovery complete
 ```
 
 ### Metadata/Groups Synchronization Flow
@@ -435,36 +146,22 @@ sequenceDiagram
 sequenceDiagram
     participant Module as Internal Module
     participant ASP as Agent Sync Protocol
-    participant MQ as Message Queue
-    participant AD as Wazuh agentd
+    participant Transport as SyncSocketTransport
+    participant AD as agentd (https_client)
     participant Manager as Wazuh Manager
 
-    Module->>ASP: synchronizeMetadataOrGroups(METADATA_DELTA, timeout, retries, maxEps, globalVersion)
+    Module->>ASP: synchronizeMetadataOrGroups(MetadataDelta, indices, globalVersion)
 
-    Note over ASP,Manager: Session Establishment
-    ASP->>ASP: Validate mode (METADATA/GROUP)
-    ASP->>MQ: Send Start(mode=METADATA_DELTA)
-    MQ->>AD: Forward Start
-    AD->>Manager: Forward Start
-    Manager->>Manager: Prepare to receive metadata
-    Manager->>AD: Send StartAck(session_id)
-    AD->>ASP: Forward StartAck
+    ASP->>ASP: Build ONE FullSession<br/>Start(mode=MetadataDelta, global_version) + End<br/>(no SessionPayload set)
+    ASP->>Transport: sendSession(session_id, bytes)
+    Transport->>AD: Write over queue-sync socket
+    AD->>Manager: POST /stateful
 
-    Note over ASP,Manager: No Data Messages Sent
+    Manager->>Manager: Apply metadata/group update
 
-    Note over ASP,Manager: Immediate Session Completion
-    ASP->>MQ: Send End(session_id)
-    MQ->>AD: Forward End
-    AD->>Manager: Forward End
-
-    Note over Manager: Process metadata<br/>based on mode
-
-    Manager->>AD: Send EndAck(success)
-    AD->>ASP: Forward EndAck
-
-    ASP-->>Module: Return true (success)
-
-    Note over Module: Metadata synchronized<br/>without data transfer
+    Manager-->>AD: EndAck(status=Ok)
+    AD->>ASP: parseResponseBuffer(EndAck)
+    ASP-->>Module: SyncModuleResult{success=true}
 ```
 
 ### Data Clean Notification Flow
@@ -474,49 +171,153 @@ sequenceDiagram
     participant Module as Internal Module
     participant ASP as Agent Sync Protocol
     participant Queue as Persistent Queue
-    participant MQ as Message Queue
-    participant AD as Wazuh agentd
+    participant Transport as SyncSocketTransport
+    participant AD as agentd (https_client)
     participant Manager as Wazuh Manager
 
     Note over Module: Module disabled or<br/>specific indices removed
 
-    Module->>ASP: notifyDataClean(indices, timeout, retries, maxEps)
-    ASP->>ASP: Validate indices (non-empty)
+    Module->>ASP: notifyDataClean(indices)
 
-    Note over ASP: Create PersistedData<br/>for each index
+    ASP->>ASP: Build ONE FullSession<br/>Start(mode=DELTA, index=[...]) +<br/>Cleans{DataClean per index} + End
+    ASP->>Transport: sendSession(session_id, bytes)
+    Transport->>AD: Write over queue-sync socket
+    AD->>Manager: POST /stateful
 
-    Note over ASP,Manager: Session Establishment
-    ASP->>MQ: Send Start(mode=DELTA, size=N, indices)
-    MQ->>AD: Forward Start
-    AD->>Manager: Forward Start
-    Manager->>Manager: Create session
-    Manager->>AD: Send StartAck(session_id)
-    AD->>ASP: Forward StartAck
-    ASP->>ASP: Store session_id
+    Manager->>Manager: deleteByQuery for each index
 
-    Note over ASP,Manager: DataClean Messages Transfer
-    loop For each index
-        ASP->>ASP: Build DataClean message
-        ASP->>MQ: Send DataClean[seq, session, index]
-        MQ->>AD: Forward DataClean
-        AD->>Manager: Forward DataClean
-        Manager->>Manager: Mark index for cleanup
+    Manager-->>AD: EndAck(status=Ok)
+    AD->>ASP: parseResponseBuffer(EndAck)
+    ASP->>Queue: clearItemsByIndex() for each index
+
+    ASP-->>Module: true (success)
+```
+
+### In-Memory Recovery Flow
+
+```mermaid
+sequenceDiagram
+    participant Module as Internal Module
+    participant ASP as Agent Sync Protocol
+    participant Memory as In-Memory Vector
+    participant Transport as SyncSocketTransport
+    participant Manager as Wazuh Manager
+
+    Note over Module: Module recovery initiated
+
+    Module->>ASP: clearInMemoryData()
+    ASP->>Memory: Clear
+
+    loop For each recovery item
+        Module->>ASP: persistDifferenceInMemory(id, operation, index, data, version)
+        ASP->>Memory: Store in memory vector
     end
 
-    Note over ASP,Manager: Session Completion
-    ASP->>MQ: Send End(session_id)
-    MQ->>AD: Forward End
-    AD->>Manager: Forward End
-    Manager->>Manager: Clean marked indices
-    Manager->>AD: Send EndAck(success)
-    AD->>ASP: Forward EndAck
+    Module->>ASP: synchronizeModule(FULL)
+    ASP->>Memory: Read all items
+    ASP->>ASP: Build ONE FullSession<br/>Start(mode=ModuleFull, size=N) + SyncData{values} + End
+    ASP->>Transport: sendSession(session_id, bytes)
+    Transport-->>Manager: (via agentd/https_client)
+    Manager-->>ASP: EndAck(status=Ok)
 
-    Note over ASP: Success confirmed
+    ASP-->>Module: SyncModuleResult{success=true}
+```
 
-    ASP->>Queue: clearItemsByIndex(index) for each
-    Queue-->>ASP: Local data cleared
+## Error Handling Scenarios
 
-    ASP-->>Module: Return true (success)
+### Manager Reports Offline / Not Ready
 
-    Note over Module: Data clean notification<br/>completed successfully
+```mermaid
+sequenceDiagram
+    participant Module as Internal Module
+    participant ASP as Agent Sync Protocol
+    participant Transport as SyncSocketTransport
+    participant Manager as Wazuh Manager
+
+    Module->>ASP: synchronizeModule(DELTA)
+    ASP->>Transport: sendSession(session_id, FullSession)
+    Transport-->>Manager: (via agentd/https_client)
+
+    Note over Manager: Cannot serve this agent yet<br/>(e.g. right after enrollment)
+
+    Manager-->>ASP: EndAck(status=Offline)
+    Note over ASP: lastSyncResult = COMMUNICATION_ERROR<br/>managerNotReady = true
+
+    ASP-->>Module: SyncModuleResult{success=false, managerNotReady=true,<br/>consecutiveFailures=N}
+    Note over Module: N below SYNC_MANAGER_NOT_READY_TOLERANCE:<br/>log at INFO/DEBUG.<br/>N at or above it: log at WARNING.
+```
+
+### Manager Error Response
+
+```mermaid
+sequenceDiagram
+    participant Module as Internal Module
+    participant ASP as Agent Sync Protocol
+    participant Transport as SyncSocketTransport
+    participant Manager as Wazuh Manager
+
+    Module->>ASP: synchronizeModule(DELTA)
+    ASP->>Transport: sendSession(session_id, FullSession)
+    Transport-->>Manager: (via agentd/https_client)
+
+    Manager-->>ASP: EndAck(status=Error)
+    Note over ASP: lastSyncResult = PROTOCOL_ERROR<br/>syncFailed = true
+
+    ASP-->>Module: SyncModuleResult{success=false}
+    Note over Module: Items stay/return to PENDING;<br/>next periodic cycle retries.
+```
+
+### Stop Requested While Waiting for a Response
+
+```mermaid
+sequenceDiagram
+    participant Module as Internal Module
+    participant ASP as Agent Sync Protocol
+    participant Transport as SyncSocketTransport
+
+    Module->>ASP: synchronizeModule(DELTA)
+    ASP->>Transport: sendSession(session_id, FullSession)
+    Note over ASP: Phase = WaitingResponse<br/>Block on condition variable
+
+    Module->>ASP: stop() (called from shutdown path)
+    Note over ASP: shouldStop() becomes true<br/>cv notified, wait unblocks
+
+    ASP-->>Module: SyncModuleResult{success=false, stopped=true}
+    Note over Module: stopped=true demotes this to<br/>INFO/DEBUG instead of WARNING
+```
+
+## Response Handling Flow
+
+### Two Response Paths Into `AgentSyncProtocol`
+
+The manager's verdict can reach the protocol through either of two independent paths, both terminal:
+
+```mermaid
+sequenceDiagram
+    participant SyncThread as Sync Thread
+    participant ResponseThread as Response Thread
+    participant ASP as Agent Sync Protocol
+    participant AD as agentd (https_client)
+    participant Manager as Wazuh Manager
+
+    SyncThread->>ASP: synchronizeModule(DELTA)
+    ASP->>ASP: Phase = WaitingResponse
+    ASP->>AD: sendSession(session_id, FullSession)
+    SyncThread->>ASP: Block on condition variable
+
+    alt FlatBuffer EndAck path
+        Manager->>AD: 200 OK, Message{EndAck}
+        AD->>ResponseThread: Deliver body
+        ResponseThread->>ASP: parseResponseBuffer(data, length)
+        ASP->>ASP: Validate phase, apply status
+    else HTTPS result-code path
+        Manager->>AD: HTTP status code for this request
+        AD->>ResponseThread: "HCRESULT:<session>:<code>"
+        ResponseThread->>ASP: applyHttpResultCode(code, session)
+        ASP->>ASP: Validate phase + session id, apply code
+    end
+
+    ASP->>ASP: Set responseReceived/syncFailed,<br/>notify condition variable
+    ASP-->>SyncThread: Wake up, read result
+    SyncThread->>SyncThread: Delete synced items on success
 ```

--- a/docs/ref/modules/vulnerability-scanner/flatbuffers.md
+++ b/docs/ref/modules/vulnerability-scanner/flatbuffers.md
@@ -13,13 +13,13 @@ The schema is defined in `src/shared_modules/utils/flatbuffers/schemas/inventory
 
 InventorySync sessions follow this pattern:
 
-`Start -> StartAck -> DataValue/DataContext -> End -> EndAck`
+`Start -> DataValue/DataContext -> End -> EndAck`
 
 `DataClean` and `ChecksumModule` exist in the schema for other synchronization modes, but VD only consumes Start/DataValue/DataContext/End.
 
 ### Enums
 
-- `Mode`: ModuleFull, ModuleDelta, ModuleCheck, MetadataDelta, MetadataCheck, GroupDelta, GroupCheck
+- `Mode`: ModuleDelta, ModuleCheck, MetadataDelta, MetadataCheck, GroupDelta, GroupCheck
 - `Option`: Sync, VDFirst, VDSync
 - `Operation`: Upsert, Delete
 - `Status`: Ok, Error, Offline, ChecksumMismatch
@@ -48,8 +48,6 @@ Represents inventory deltas and carries the inventory document as JSON.
 
 | Field | Description |
 | --- | --- |
-| seq | Sequence number within the session. |
-| session | Session identifier (from StartAck). |
 | operation | Upsert or Delete. |
 | id | Inventory document identifier (used by VD as item id / detection base). |
 | index | Inventory index name. |
@@ -62,8 +60,6 @@ Represents inventory context for deltas. It uses the same `data` JSON schema as 
 
 | Field | Description |
 | --- | --- |
-| seq | Sequence number within the session. |
-| session | Session identifier (from StartAck). |
 | id | Inventory document identifier. |
 | index | Inventory index name. |
 | data | JSON inventory document (host/package schema). |

--- a/src/client-agent/https_client/include/https_client.h
+++ b/src/client-agent/https_client/include/https_client.h
@@ -77,8 +77,11 @@ typedef enum hc_buffer_level_t
     HC_BUFFER_FLOOD
 } hc_buffer_level_t;
 
-/* Outcome classes of a request/submission (D9 classification). Crosses the
- * ABI in the on_sync_response callback. */
+/* Outcome classes of a request/submission (D9 classification), part of the
+ * stable ABI surface. on_sync_response no longer carries this type (see its
+ * own doc comment): the /stateful contract needs the real HTTP status code,
+ * not this coarser classification, so retry/backoff decisions inside the
+ * transport layer use the internal (C++-only) OutcomeClass instead. */
 typedef enum hc_result_t
 {
     HC_RESULT_OK = 0,
@@ -243,8 +246,15 @@ typedef struct hc_callbacks_t
     /// agent's startup hash gate) can reconcile it even when nothing needs
     /// downloading. Empty when the manager reported none.
     void (*on_manager_config_hash)(const char* config_hash, void* user_data);
-    /// The HTTP outcome for a /stateful session. `result` carries the verdict
-    /// (200 path => HC_RESULT_OK, non-200 path => non-zero). `body` may be empty.
+    /// The HTTP outcome for a /stateful session. Unlike every other outcome in this
+    /// header, `result` here is the RAW HTTP status code the manager answered with
+    /// (200, 400, 403, 409, 413, 500, 503...), not an hc_result_t - the /stateful
+    /// contract's numeric-code meanings are its own (a 409 means checksum mismatch,
+    /// not the version-rejection a control-plane 409 would mean) and are interpreted
+    /// by the sync protocol module, not by this transport layer. `result == 0` means
+    /// no HTTP response was received at all (timeout/connect/TLS failure/abort);
+    /// treat it like a 503. `body` carries the raw JSON response body and may be
+    /// empty.
     void (*on_sync_response)(const char* session_id, int result, const char* body,
                              size_t body_len, void* user_data);
     void (*on_state_change)(int state, void* user_data);  ///< hc_conn_state_t

--- a/src/client-agent/https_client/include/https_client.h
+++ b/src/client-agent/https_client/include/https_client.h
@@ -243,10 +243,8 @@ typedef struct hc_callbacks_t
     /// agent's startup hash gate) can reconcile it even when nothing needs
     /// downloading. Empty when the manager reported none.
     void (*on_manager_config_hash)(const char* config_hash, void* user_data);
-    /// The manager's verdict for a /stateful session. `body` is the response
-    /// payload and is NOT a C string: a session is answered with an EndAck
-    /// FlatBuffer, which is binary and contains NUL bytes, so `body_len` is the
-    /// only reliable length.
+    /// The HTTP outcome for a /stateful session. `result` carries the verdict
+    /// (200 path => HC_RESULT_OK, non-200 path => non-zero). `body` may be empty.
     void (*on_sync_response)(const char* session_id, int result, const char* body,
                              size_t body_len, void* user_data);
     void (*on_state_change)(int state, void* user_data);  ///< hc_conn_state_t

--- a/src/client-agent/https_client/src/callbackDispatcher.cpp
+++ b/src/client-agent/https_client/src/callbackDispatcher.cpp
@@ -203,8 +203,8 @@ void CallbackDispatcher::onSyncResponse(const std::string& sessionId, int result
 
     enqueue([this, sessionId, result, body]
     {
-        // Length-carrying: the body is an EndAck FlatBuffer, so it is binary and
-        // c_str() alone would truncate it at the first NUL.
+        // Length-carrying: the body is the manager's raw /stateful JSON response, and
+        // c_str() alone would truncate it at the first embedded NUL, if any.
         m_callbacks.on_sync_response(
             sessionId.c_str(), result, body.data(), body.size(), m_callbacks.user_data);
     });

--- a/src/client-agent/https_client/src/httpsClientFacade.cpp
+++ b/src/client-agent/https_client/src/httpsClientFacade.cpp
@@ -130,7 +130,10 @@ void HttpsClientFacade::startSyncIntake()
             // reaches this agent through on_sync_response.
             LOGFN_WARN(m_logFn, "Refused sync session %s: the /stateful queue is full.",
                        sessionId.c_str());
-            m_dispatcher.onSyncResponse(sessionId, HC_RESULT_BACKPRESSURE, "");
+            // 503: the manager-not-ready code the sync protocol already knows how to
+            // handle (retry next cycle) - this is local backpressure, never a real HTTP
+            // response, but the semantics match.
+            m_dispatcher.onSyncResponse(sessionId, 503, "");
             return false;
         }
 

--- a/src/client-agent/https_client/src/statefulStream.cpp
+++ b/src/client-agent/https_client/src/statefulStream.cpp
@@ -112,7 +112,7 @@ bool StatefulStream::step(Waiter& waiter)
     }
 
     const auto result = sendSession(session, waiter);
-    m_sink.onSyncResponse(session.id, result.code, result.body);
+    m_sink.onSyncResponse(session.id, static_cast<int>(result.httpCode), result.body);
     return true;
 }
 
@@ -155,5 +155,9 @@ StatefulStream::SendResult StatefulStream::sendSession(const Session& session, W
                  static_cast<unsigned long long>(session.size));
 
     const auto result = m_sender.send(spec, waiter, STATEFUL_MAX_ATTEMPTS);
-    return {toHcResult(result.outcome), result.response.body};
+    // The /stateful contract is interpreted from the raw HTTP status code and body by
+    // agent_sync_protocol, not from the shared D9 OutcomeClass (see SendResult::httpCode).
+    // result.response.httpCode is 0 when no HTTP response was received (m_sender's retry
+    // loop already exhausted its attempts via the OutcomeClass-driven retry decision).
+    return {result.response.httpCode, result.response.body};
 }

--- a/src/client-agent/https_client/src/statefulStream.hpp
+++ b/src/client-agent/https_client/src/statefulStream.hpp
@@ -68,7 +68,12 @@ class StatefulStream final
 
         struct SendResult
         {
-            int code {HC_RESULT_ERROR};
+            /// Raw HTTP status code the manager answered with (the /stateful contract
+            /// interprets these directly - it does not go through the shared D9
+            /// classifier, whose numeric-code meanings are specific to /stateless).
+            /// 0 means no HTTP response was received at all (timeout/connect/TLS
+            /// failure/abort) - the sync protocol treats that like a 503.
+            long httpCode {0};
             std::string body;
         };
 

--- a/src/client-agent/https_client/tests/unit/callbackDispatcher_test.cpp
+++ b/src/client-agent/https_client/tests/unit/callbackDispatcher_test.cpp
@@ -318,12 +318,13 @@ TEST(CallbackDispatcherBinaryTest, ASyncResponseBodyKeepsItsNulBytes)
     };
     callbacks.user_data = &captured;
 
-    // Shaped like a FlatBuffer root: a leading offset with high NUL bytes.
-    const std::string endAck {"\x0c\x00\x00\x00WZ\x00\x01\x00\x00\x00\x00", 12};
+    // A body with an embedded NUL partway through, to prove c_str()-style truncation
+    // never happens on the way through.
+    const std::string binaryBody {"\x0c\x00\x00\x00WZ\x00\x01\x00\x00\x00\x00", 12};
 
     CallbackDispatcher dispatcher {callbacks};
     dispatcher.start();
-    dispatcher.onSyncResponse("fim-42", HC_RESULT_OK, endAck);
+    dispatcher.onSyncResponse("fim-42", 200, binaryBody);
 
     {
         std::unique_lock<std::mutex> lock(captured.mutex);
@@ -331,6 +332,6 @@ TEST(CallbackDispatcherBinaryTest, ASyncResponseBodyKeepsItsNulBytes)
     }
 
     dispatcher.stop();
-    EXPECT_EQ(endAck, captured.body);
+    EXPECT_EQ(binaryBody, captured.body);
     EXPECT_EQ(12u, captured.body.size()); // Not 4, which is where the first NUL sits.
 }

--- a/src/client-agent/https_client/tests/unit/statefulStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/statefulStream_test.cpp
@@ -144,7 +144,7 @@ TEST_F(StatefulStreamTest, SessionIsSpooledAtSubmitAndStreamedWithSessionHeader)
         EXPECT_EQ(8u, spec.bodyFileSize);
         return response(TransportStatus::Ok, 200, R"({"itemsProcessed":42})");
     }));
-    EXPECT_CALL(m_sink, onSyncResponse("sess-1", HC_RESULT_OK, R"({"itemsProcessed":42})"));
+    EXPECT_CALL(m_sink, onSyncResponse("sess-1", 200, R"({"itemsProcessed":42})"));
 
     ASSERT_TRUE(submit("sess-1", "12345678"));
     EXPECT_TRUE(m_stream.step(m_waiter));
@@ -174,7 +174,7 @@ TEST_F(StatefulStreamTest, SubmitFileAdoptsAnAlreadySpooledSessionAndDeletesIt)
         EXPECT_EQ(200000u, spec.bodyFileSize); // The full session, well past the 64 KB cap.
         return response(TransportStatus::Ok, 200, R"({"itemsProcessed":199975})");
     }));
-    EXPECT_CALL(m_sink, onSyncResponse("intake-1", HC_RESULT_OK, _));
+    EXPECT_CALL(m_sink, onSyncResponse("intake-1", 200, _));
 
     ASSERT_TRUE(m_stream.submitFile("intake-1", path, 200000));
     EXPECT_TRUE(m_stream.step(m_waiter));
@@ -239,7 +239,7 @@ TEST_F(StatefulStreamTest, FailureOutcomeCrossesTheSink)
     const std::string path = ::testing::TempDir() + "hc_stateful_fail.tmp";
     EXPECT_CALL(m_spoolFactory, spool(_, _)).WillOnce(Return(ByMove(makeSpoolAt(path, "body"))));
     EXPECT_CALL(m_performer, perform(_)).WillOnce(Return(response(TransportStatus::Ok, 413)));
-    EXPECT_CALL(m_sink, onSyncResponse("sess-perm", HC_RESULT_PERMANENT, _));
+    EXPECT_CALL(m_sink, onSyncResponse("sess-perm", 413, _));
 
     submit("sess-perm", "body");
     EXPECT_TRUE(m_stream.step(m_waiter));
@@ -250,8 +250,8 @@ TEST_F(StatefulStreamTest, QueueIsFifo)
     EXPECT_CALL(m_performer, perform(_)).WillRepeatedly(Return(response(TransportStatus::Ok, 200)));
 
     ::testing::InSequence sequence;
-    EXPECT_CALL(m_sink, onSyncResponse("first", HC_RESULT_OK, _));
-    EXPECT_CALL(m_sink, onSyncResponse("second", HC_RESULT_OK, _));
+    EXPECT_CALL(m_sink, onSyncResponse("first", 200, _));
+    EXPECT_CALL(m_sink, onSyncResponse("second", 200, _));
 
     submit("first", "a");
     submit("second", "bb");

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -1075,11 +1075,18 @@ static void bridge_on_sync_response(const char *session_id, int result, const ch
             continue;
         }
 
-        /* ACK-less flow: route the HTTP outcome code. The receiving module maps
-         * "HCRESULT:0" to success (200 path) and non-zero values to failure. */
+        /* ACK-less flow: route the HTTP outcome code with the session's numeric
+         * ID so the receiving module can discard stale callbacks (responses for
+         * a previous timed-out session that arrives while a newer one is active).
+         * Format: HCRESULT:<session_number>:<result_code>
+         *
+         * session_id format is "<module>-<decimal_uint64>" so the numeric part
+         * is everything after module_len + 1 (the '-'). */
         const size_t header_len = strlen(SYNC_ROUTES[i].header);
-        char payload[64];
-        int payload_len = snprintf(payload, sizeof(payload), "HCRESULT:%d", result);
+        const char *session_num = module + module_len + 1; /* points to numeric suffix */
+        char payload[128];
+        int payload_len = snprintf(payload, sizeof(payload), "HCRESULT:%s:%d",
+                                   session_num, result);
 
         if (payload_len <= 0 || (size_t)payload_len >= sizeof(payload)) {
             mdebug2("https_client: could not encode sync result for session '%s'; dropping it.",

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -1055,12 +1055,10 @@ static void bridge_on_sync_response(const char *session_id, int result, const ch
                                     size_t body_len, void *user_data)
 {
     (void)user_data;
+    (void)body;
+    (void)body_len;
     mdebug1("https_client /stateful session=%s result=%d (%zu byte answer)",
             session_id ? session_id : "?", result, body_len);
-
-    if (body == NULL || body_len == 0) {
-        return;
-    }
 
     size_t module_len = 0;
     const char *module = bridge_module_of_session(session_id, &module_len);
@@ -1077,27 +1075,28 @@ static void bridge_on_sync_response(const char *session_id, int result, const ch
             continue;
         }
 
-        /* Hand it back exactly as the legacy path does: the manager answers a
-         * session with the same EndAck it always has, so the module parses it
-         * unchanged - only the transport that carried it here is different. */
+        /* ACK-less flow: route the HTTP outcome code. The receiving module maps
+         * "HCRESULT:0" to success (200 path) and non-zero values to failure. */
         const size_t header_len = strlen(SYNC_ROUTES[i].header);
+        char payload[64];
+        int payload_len = snprintf(payload, sizeof(payload), "HCRESULT:%d", result);
 
-        if (body_len > SIZE_MAX - header_len - 1) {
-            mdebug2("https_client: sync answer for session '%s' is too large to frame; dropping it.",
-                    session_id);
+        if (payload_len <= 0 || (size_t)payload_len >= sizeof(payload)) {
+            mdebug2("https_client: could not encode sync result for session '%s'; dropping it.",
+                    session_id ? session_id : "?");
             return;
         }
 
         char *framed = NULL;
-        os_malloc(header_len + body_len + 1, framed);
+        os_malloc(header_len + (size_t)payload_len + 1, framed);
         memcpy(framed, SYNC_ROUTES[i].header, header_len);
-        memcpy(framed + header_len, body, body_len);
-        framed[header_len + body_len] = '\0';
+        memcpy(framed + header_len, payload, (size_t)payload_len);
+        framed[header_len + (size_t)payload_len] = '\0';
 
         if (SYNC_ROUTES[i].syscheck) {
-            ag_send_syscheck(framed, header_len + body_len);
+            ag_send_syscheck(framed, header_len + (size_t)payload_len);
         } else {
-            wmcom_send(framed, header_len + body_len);
+            wmcom_send(framed, header_len + (size_t)payload_len);
         }
 
         os_free(framed);

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -1055,8 +1055,6 @@ static void bridge_on_sync_response(const char *session_id, int result, const ch
                                     size_t body_len, void *user_data)
 {
     (void)user_data;
-    (void)body;
-    (void)body_len;
     mdebug1("https_client /stateful session=%s result=%d (%zu byte answer)",
             session_id ? session_id : "?", result, body_len);
 
@@ -1075,35 +1073,44 @@ static void bridge_on_sync_response(const char *session_id, int result, const ch
             continue;
         }
 
-        /* ACK-less flow: route the HTTP outcome code with the session's numeric
-         * ID so the receiving module can discard stale callbacks (responses for
-         * a previous timed-out session that arrives while a newer one is active).
-         * Format: HCRESULT:<session_number>:<result_code>
+        /* ACK-less flow: route the raw HTTP status code and body with the session's
+         * numeric ID so the receiving module can discard stale callbacks (responses
+         * for a previous timed-out session that arrives while a newer one is active)
+         * and interpret the /stateful contract itself (a 409 means checksum mismatch,
+         * a 200 body may carry {"noop":true}, etc - see agent_sync_protocol's HTTP
+         * result handling; this bridge does not interpret the body, only carries it).
+         * Format: HCRESULT:<session_number>:<result_code>:<body>
          *
-         * session_id format is "<module>-<decimal_uint64>" so the numeric part
-         * is everything after module_len + 1 (the '-'). */
+         * session_id format is "<module>-<decimal_uint64>" so the numeric part is
+         * everything after module_len + 1 (the '-'). The body is copied verbatim
+         * after the second colon: the receiving parser only looks for the first two
+         * colons, so a JSON body containing its own colons is never misread. */
         const size_t header_len = strlen(SYNC_ROUTES[i].header);
         const char *session_num = module + module_len + 1; /* points to numeric suffix */
-        char payload[128];
-        int payload_len = snprintf(payload, sizeof(payload), "HCRESULT:%s:%d",
-                                   session_num, result);
 
-        if (payload_len <= 0 || (size_t)payload_len >= sizeof(payload)) {
+        char prefix[64];
+        int prefix_len = snprintf(prefix, sizeof(prefix), "HCRESULT:%s:%d:", session_num, result);
+
+        if (prefix_len <= 0 || (size_t)prefix_len >= sizeof(prefix)) {
             mdebug2("https_client: could not encode sync result for session '%s'; dropping it.",
                     session_id ? session_id : "?");
             return;
         }
 
+        const size_t payload_len = (size_t)prefix_len + body_len;
         char *framed = NULL;
-        os_malloc(header_len + (size_t)payload_len + 1, framed);
+        os_malloc(header_len + payload_len + 1, framed);
         memcpy(framed, SYNC_ROUTES[i].header, header_len);
-        memcpy(framed + header_len, payload, (size_t)payload_len);
-        framed[header_len + (size_t)payload_len] = '\0';
+        memcpy(framed + header_len, prefix, (size_t)prefix_len);
+        if (body_len > 0) {
+            memcpy(framed + header_len + (size_t)prefix_len, body, body_len);
+        }
+        framed[header_len + payload_len] = '\0';
 
         if (SYNC_ROUTES[i].syscheck) {
-            ag_send_syscheck(framed, header_len + (size_t)payload_len);
+            ag_send_syscheck(framed, header_len + payload_len);
         } else {
-            wmcom_send(framed, header_len + (size_t)payload_len);
+            wmcom_send(framed, header_len + payload_len);
         }
 
         os_free(framed);

--- a/src/config/include/syscheck-config.h
+++ b/src/config/include/syscheck-config.h
@@ -421,7 +421,6 @@ typedef struct _config {
 
     uint32_t sync_interval;                            /* Synchronization interval */
     uint32_t sync_end_delay;                           /* Delay for synchronization end message in seconds */
-    uint32_t sync_response_timeout;                    /* Minimum interval for the synchronization process */
     long sync_max_eps;                                 /* Maximum events per second for synchronization messages. */
     uint32_t integrity_interval;                       /* Integrity check interval */
     int max_eps;                                       /* Maximum events per second. */

--- a/src/config/src/syscheck-config.c
+++ b/src/config/src/syscheck-config.c
@@ -115,7 +115,6 @@ int initialize_syscheck_configuration(syscheck_config *syscheck) {
 #endif
     syscheck->sync_interval                   = 300;
     syscheck->sync_end_delay                  = 1;
-    syscheck->sync_response_timeout           = 60;
     syscheck->sync_max_eps                    = 75;
     syscheck->integrity_interval              = 24 * 60 * 60;  // 24 hours
     syscheck->max_eps                         = 50;
@@ -1254,7 +1253,6 @@ static void parse_synchronization(syscheck_config * syscheck, XML_NODE node) {
      const char *xml_enabled = "enabled";
      const char *xml_sync_interval = "interval";
      const char *xml_sync_end_delay = "sync_end_delay";
-     const char *xml_response_timeout = "response_timeout";
      const char *xml_max_eps = "max_eps";
      const char *xml_integrity_interval = "integrity_interval";
 
@@ -1282,14 +1280,6 @@ static void parse_synchronization(syscheck_config * syscheck, XML_NODE node) {
                  mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
              } else {
                  syscheck->sync_end_delay = (uint32_t) sync_end_delay;
-             }
-         } else if (strcmp(node[i]->element, xml_response_timeout) == 0) {
-             long response_timeout = w_parse_time(node[i]->content);
-
-             if (response_timeout < 0) {
-                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
-             } else {
-                 syscheck->sync_response_timeout = (uint32_t) response_timeout;
              }
          } else if (strcmp(node[i]->element, xml_max_eps) == 0) {
              char * end;

--- a/src/config/src/wmodules-sca.c
+++ b/src/config/src/wmodules-sca.c
@@ -82,7 +82,6 @@ static void parse_synchronization_section(wm_sca_t * sca, XML_NODE node)
     const char *XML_DB_SYNC_ENABLED = "enabled";
     const char *XML_DB_SYNC_INTERVAL = "interval";
     const char *XML_DB_SYNC_END_DELAY = "sync_end_delay";
-    const char *XML_DB_SYNC_RESPONSE_TIMEOUT = "response_timeout";
     const char *XML_DB_SYNC_MAX_EPS = "max_eps";
     const char *XML_DB_SYNC_INTEGRITY_INTERVAL = "integrity_interval";
 
@@ -110,14 +109,6 @@ static void parse_synchronization_section(wm_sca_t * sca, XML_NODE node)
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
                 sca->sync.sync_end_delay = (uint32_t) sync_end_delay;
-            }
-        } else if (strcmp(node[i]->element, XML_DB_SYNC_RESPONSE_TIMEOUT) == 0) {
-            long response_timeout = w_parse_time(node[i]->content);
-
-            if (response_timeout < 0 || (unsigned long)response_timeout > UINT32_MAX) {
-                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
-            } else {
-                sca->sync.sync_response_timeout = (uint32_t) response_timeout;
             }
         } else if (strcmp(node[i]->element, XML_DB_SYNC_MAX_EPS) == 0) {
             char * end;
@@ -164,7 +155,6 @@ int wm_sca_read(const OS_XML *xml,xml_node **nodes, wmodule *module, int skip_ru
         sca->sync.enable_synchronization = 1;
         sca->sync.sync_interval = 300;
         sca->sync.sync_end_delay = 1;
-        sca->sync.sync_response_timeout = 60;
         sca->sync.sync_max_eps = 75;
         sca->sync.integrity_interval = 86400;
     }

--- a/src/config/src/wmodules-syscollector.c
+++ b/src/config/src/wmodules-syscollector.c
@@ -33,7 +33,6 @@ static void parse_synchronization_section(wm_sys_t * syscollector, XML_NODE node
     const char *XML_DB_SYNC_ENABLED = "enabled";
     const char *XML_DB_SYNC_INTERVAL = "interval";
     const char *XML_DB_SYNC_END_DELAY = "sync_end_delay";
-    const char *XML_DB_SYNC_RESPONSE_TIMEOUT = "response_timeout";
     const char *XML_DB_SYNC_MAX_EPS = "max_eps";
     const char *XML_INTEGRITY_INTERVAL = "integrity_interval";
 
@@ -61,14 +60,6 @@ static void parse_synchronization_section(wm_sys_t * syscollector, XML_NODE node
                 mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
             } else {
                 syscollector->sync.sync_end_delay = (uint32_t) sync_end_delay;
-            }
-        } else if (strcmp(node[i]->element, XML_DB_SYNC_RESPONSE_TIMEOUT) == 0) {
-            long response_timeout = w_parse_time(node[i]->content);
-
-            if (response_timeout < 0 || (unsigned long)response_timeout > UINT32_MAX) {
-                mwarn(XML_VALUEERR, node[i]->element, node[i]->content);
-            } else {
-                syscollector->sync.sync_response_timeout = (uint32_t) response_timeout;
             }
         } else if (strcmp(node[i]->element, XML_DB_SYNC_MAX_EPS) == 0) {
             char * end;
@@ -123,7 +114,6 @@ int wm_syscollector_read(const OS_XML *xml, XML_NODE node, wmodule *module) {
         syscollector->sync.enable_synchronization = 1;
         syscollector->sync.sync_interval = 300;
         syscollector->sync.sync_end_delay = 1;
-        syscollector->sync.sync_response_timeout = 60;
         syscollector->sync.sync_max_eps = 75;
         syscollector->sync.integrity_interval = 86400;  // Integrity check every 24 hours (86400 seconds)
 

--- a/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
+++ b/src/shared_modules/indexer_connector/src/indexerConnectorSyncImpl.hpp
@@ -837,8 +837,8 @@ public:
             LOGFN_WARN(m_logFn,
                        "Update by query skipped: no valid indices after filtering (input had %zu entries)",
                        indices.size());
-            // No HTTP request needed, but pending notify callbacks (e.g. unlockAgent +
-            // sendEndAck) must still fire so the session terminates cleanly. Treat the
+            // No HTTP request needed, but pending notify callbacks (e.g. unlockAgent)
+            // must still fire so the session terminates cleanly. Treat the
             // missing/filtered indices as a no-op success.
             m_shouldNotifyAfterBulk = true;
             return;

--- a/src/shared_modules/router/tests/unit/routerApi_test.cpp
+++ b/src/shared_modules/router/tests/unit/routerApi_test.cpp
@@ -660,23 +660,23 @@ static std::vector<uint8_t> createStartMessage(const std::string& agentId, const
     auto clusterNameOffset = clusterName.empty() ? 0 : builder.CreateString(clusterName);
 
     auto startMsg = Wazuh::SyncSchema::CreateStart(builder,
-                                                   moduleOffset,                       // module
-                                                   Wazuh::SyncSchema::Mode_ModuleFull, // mode
-                                                   100,                                // size
-                                                   0,                                  // index
-                                                   Wazuh::SyncSchema::Option_Sync,     // option
-                                                   0,                                  // architecture
-                                                   0,                                  // hostname
-                                                   0,                                  // osname
-                                                   0,                                  // osplatform
-                                                   0,                                  // ostype
-                                                   0,                                  // osversion
-                                                   0,                                  // agentversion
-                                                   0,                                  // agentname
-                                                   agentIdOffset,                      // agentid
-                                                   0,                                  // groups
-                                                   0,                                  // global_version
-                                                   clusterNameOffset);                 // cluster_name
+                                                   moduleOffset,                        // module
+                                                   Wazuh::SyncSchema::Mode_ModuleDelta, // mode
+                                                   100,                                 // size
+                                                   0,                                   // index
+                                                   Wazuh::SyncSchema::Option_Sync,      // option
+                                                   0,                                   // architecture
+                                                   0,                                   // hostname
+                                                   0,                                   // osname
+                                                   0,                                   // osplatform
+                                                   0,                                   // ostype
+                                                   0,                                   // osversion
+                                                   0,                                   // agentversion
+                                                   0,                                   // agentname
+                                                   agentIdOffset,                       // agentid
+                                                   0,                                   // groups
+                                                   0,                                   // global_version
+                                                   clusterNameOffset);                  // cluster_name
 
     auto msg = Wazuh::SyncSchema::CreateMessage(builder, Wazuh::SyncSchema::MessageType_Start, startMsg.Union());
 

--- a/src/shared_modules/sync_protocol/CMakeLists.txt
+++ b/src/shared_modules/sync_protocol/CMakeLists.txt
@@ -134,6 +134,7 @@ endif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 if(UNIT_TEST)
   enable_testing()
   add_coverage_libraries(agent_sync_protocol)
+  target_compile_definitions(agent_sync_protocol PRIVATE WAZUH_UNIT_TESTING)
   add_subdirectory(tests)
 endif()
 

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
@@ -35,8 +35,8 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         /// @param retries Default number of retries for synchronization operations.
         /// @param queue Optional persistent queue to use for message storage and retrieval.
         /// @param syncTransport Optional carrier for whole sessions; defaults to the queue-sync socket.
-        explicit AgentSyncProtocol(const std::string& moduleName, std::optional<std::string> dbPath, LoggerFunc logger, std::chrono::seconds timeout,
-                                   unsigned int retries, std::shared_ptr<IPersistentQueue> queue = nullptr,
+        explicit AgentSyncProtocol(const std::string& moduleName, std::optional<std::string> dbPath, LoggerFunc logger,
+                                   std::shared_ptr<IPersistentQueue> queue = nullptr,
                                    std::shared_ptr<ISyncSessionTransport> syncTransport = nullptr);
 
         /// @copydoc IAgentSyncProtocol::persistDifference
@@ -116,11 +116,12 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         /// @brief In-memory vector to store PersistedData for recovery scenarios
         std::vector<PersistedData> m_inMemoryData;
 
-        /// @brief Default timeout for synchronization operations
-        std::chrono::seconds m_timeout;
-
-        /// @brief Default number of retries for synchronization operations
-        unsigned int m_retries;
+        /// @brief Retries for the local sync-socket hand-off.
+        ///
+        /// How many times runSession() re-submits to the HTTPS transport's intake
+        /// socket when that socket is transiently unavailable (e.g. agentd restart).
+        /// Fixed; the HTTP-level retry count lives in the transport layer.
+        static constexpr unsigned int SYNC_HANDOFF_RETRIES = 3;
 
         /// @brief Updates the consecutive-failure streak with the outcome of a synchronization.
         /// @param success Whether the synchronization succeeded.
@@ -188,7 +189,11 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         SyncModuleResult synchronizeDeltaByBlocks(Option option);
 
         /// @brief Applies HTTP-result outcomes received from https_client callback routing.
-        bool applyHttpResultCode(int resultCode);
+        /// @param resultCode HTTP status code (0 = success).
+        /// @param expectedSession Session that this result belongs to; 0 skips validation
+        ///        (legacy path). The check is performed under m_syncState.mtx so it is
+        ///        race-free with a concurrent session start.
+        bool applyHttpResultCode(int resultCode, uint64_t expectedSession = 0);
 
         /// @brief Picks the id for a new session. The agent chooses it because the
         ///        single-message exchange has no StartAck to carry one back; a retry
@@ -258,6 +263,14 @@ class AgentSyncProtocol : public IAgentSyncProtocol
             /// @brief True when the in-flight session is an integrity check; non-200 means checksum mismatch.
             bool expectingChecksumResult = false;
 
+            /// @brief Numeric session ID of the current in-flight session.
+            ///
+            /// Set by runSession() before the first send attempt and cleared on reset().
+            /// applyHttpResultCode() validates incoming HCRESULT payloads against this
+            /// value so that a stale response from a previous (timed-out) session cannot
+            /// satisfy a newer one.
+            uint64_t currentSession = 0;
+
             /// @brief Destructor ensures all waiting threads are woken up before destruction.
             ///
             /// This prevents deadlocks when the condition variable is destroyed while threads are still waiting.
@@ -279,6 +292,7 @@ class AgentSyncProtocol : public IAgentSyncProtocol
                 lastSyncResult = SyncResult::SUCCESS;
                 lastSyncManagerNotReady = false;
                 expectingChecksumResult = false;
+                currentSession = 0;
             }
         };
 

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
@@ -110,6 +110,17 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         /// Fixed; the HTTP-level retry count lives in the transport layer.
         static constexpr unsigned int SYNC_HANDOFF_RETRIES = 3;
 
+        /// @brief Total attempts for a module integrity check (requiresFullSync()) before
+        ///        trusting a checksum mismatch (409) as genuine.
+        ///
+        /// A bulk write to the indexer may not be visible yet when the manager checks it,
+        /// which used to make the manager retry internally against the indexer up to 5
+        /// times before answering. That loop moved here (2026-08-04, #38117/#38128) so the
+        /// manager stops holding the connection for the whole retry budget: on a 409 the
+        /// agent itself re-sends the same integrity check, spaced by CHECKSUM_RETRY_DELAY,
+        /// and only reports a real mismatch once every attempt in this budget agrees.
+        static constexpr unsigned int CHECKSUM_MISMATCH_MAX_ATTEMPTS = 5;
+
         /// @brief Updates the consecutive-failure streak with the outcome of a synchronization.
         /// @param success Whether the synchronization succeeded.
         /// @param stopped Whether it was aborted because a stop was requested.
@@ -124,7 +135,6 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         ///        to end.
         /// @param builder Builder to emit the table into.
         /// @param mode Sync mode
-        /// @param dataSize Size of data to send
         /// @param uniqueIndices Vector of unique indices to be synchronized
         /// @param option Synchronization option.
         /// @param globalVersion Optional global version to include in the Start message
@@ -133,7 +143,6 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         flatbuffers::Offset<Wazuh::SyncSchema::Start> waitMetadataAndBuildStart(
             flatbuffers::FlatBufferBuilder& builder,
             Mode mode,
-            size_t dataSize,
             const std::vector<std::string>& uniqueIndices,
             Option option = Option::SYNC,
             std::optional<uint64_t> globalVersion = std::nullopt);
@@ -148,8 +157,7 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         /// @brief Everything a session carries. All four flows (module sync,
         ///        metadata/groups, integrity check, data clean) differ only in
         ///        which of these are populated, so they all go through
-        ///        runSession() and produce one FullSession message. The size
-        ///        announced in Start is derived from the item vectors.
+        ///        runSession() and produce one FullSession message.
         struct SessionContent
         {
             Mode mode {Mode::DELTA};

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
@@ -47,22 +47,12 @@ class AgentSyncProtocol : public IAgentSyncProtocol
                                uint64_t version,
                                bool isDataContext = false) override;
 
-        /// @copydoc IAgentSyncProtocol::persistDifferenceInMemory
-        void persistDifferenceInMemory(const std::string& id,
-                                       Operation operation,
-                                       const std::string& index,
-                                       const std::string& data,
-                                       uint64_t version) override;
-
         /// @copydoc IAgentSyncProtocol::synchronizeModule
         SyncModuleResult synchronizeModule(Mode mode, Option option = Option::SYNC) override;
 
         /// @copydoc IAgentSyncProtocol::requiresFullSync
         bool requiresFullSync(const std::string& index,
                               const std::string& checksum) override;
-
-        /// @copydoc IAgentSyncProtocol::clearInMemoryData
-        void clearInMemoryData() override;
 
         /// @copydoc IAgentSyncProtocol::synchronizeMetadataOrGroups
         SyncModuleResult synchronizeMetadataOrGroups(Mode mode, const std::vector<std::string>& indices, uint64_t globalVersion) override;
@@ -112,9 +102,6 @@ class AgentSyncProtocol : public IAgentSyncProtocol
 
         /// @brief Stop flag to abort ongoing operations
         std::atomic<bool> m_stopRequested{false};
-
-        /// @brief In-memory vector to store PersistedData for recovery scenarios
-        std::vector<PersistedData> m_inMemoryData;
 
         /// @brief Retries for the local sync-socket hand-off.
         ///

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
@@ -20,6 +20,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -180,6 +181,15 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         /// @return True when the manager accepted it.
         bool runSession(const SessionContent& content);
 
+        /// @brief Whether this synchronization option must bypass FullSession size capping.
+        bool isUncappedSyncOption(Option option) const;
+
+        /// @brief Splits DELTA sync into capped FullSessions by fetching blocks from the queue.
+        SyncModuleResult synchronizeDeltaByBlocks(Option option);
+
+        /// @brief Applies HTTP-result outcomes received from https_client callback routing.
+        bool applyHttpResultCode(int resultCode);
+
         /// @brief Picks the id for a new session. The agent chooses it because the
         ///        single-message exchange has no StartAck to carry one back; a retry
         ///        reuses the same value so the manager can dedup on it.
@@ -187,10 +197,9 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         static uint64_t nextSessionId();
 
         /// @brief Serializes a whole session as one FullSession message.
-        /// @param session Session id, stamped on the message and on every item.
         /// @param content What the session carries.
         /// @return The serialized message, or an empty vector on failure.
-        std::vector<uint8_t> buildFullSessionMessage(uint64_t session, const SessionContent& content);
+        std::vector<uint8_t> buildFullSessionMessage(const SessionContent& content);
 
         /// @brief Defines the possible phases of a synchronization process.
         enum class SyncPhase
@@ -198,14 +207,8 @@ class AgentSyncProtocol : public IAgentSyncProtocol
             /// @brief The protocol is not in an active synchronization process.
             Idle,
             /// @brief The session has been sent, waiting for the manager's answer.
-            WaitingEndAck
+            WaitingResponse
         };
-
-        /// @brief Validate phase and session
-        /// @param receivedPhase Received synchronization phase
-        /// @param incomingSession Session received in message
-        /// @return True if current phase and session match the expected ones
-        bool validatePhaseAndSession(const SyncPhase receivedPhase, const uint64_t incomingSession);
 
         /// @brief Safely resets the synchronization state by acquiring a lock.
         void clearSyncState();
@@ -234,17 +237,14 @@ class AgentSyncProtocol : public IAgentSyncProtocol
             /// @brief Condition variable used to signal waiting threads.
             std::condition_variable cv;
 
-            /// @brief Indicates whether an EndAck response has been received.
-            bool endAckReceived = false;
+            /// @brief Indicates whether a terminal response has been received.
+            bool responseReceived = false;
 
             /// @brief Indicates that the manager reported a error, forcing the sync to fail.
             bool syncFailed = false;
 
             /// @brief Current phase of the synchronization process.
             SyncPhase phase = SyncPhase::Idle;
-
-            /// @brief Unique identifier for the current synchronization session, chosen by this agent.
-            uint64_t session = 0;
 
             /// @brief Last sync operation result for detailed error reporting.
             SyncResult lastSyncResult = SyncResult::SUCCESS;
@@ -254,6 +254,9 @@ class AgentSyncProtocol : public IAgentSyncProtocol
             /// it (COMMUNICATION_ERROR is also used for a local send failure in the middle of an
             /// established session).
             bool lastSyncManagerNotReady = false;
+
+            /// @brief True when the in-flight session is an integrity check; non-200 means checksum mismatch.
+            bool expectingChecksumResult = false;
 
             /// @brief Destructor ensures all waiting threads are woken up before destruction.
             ///
@@ -270,12 +273,12 @@ class AgentSyncProtocol : public IAgentSyncProtocol
             /// This should be called before starting a new synchronization cycle.
             void reset()
             {
-                endAckReceived = false;
+                responseReceived = false;
                 syncFailed = false;
                 phase = SyncPhase::Idle;
-                session = 0;
                 lastSyncResult = SyncResult::SUCCESS;
                 lastSyncManagerNotReady = false;
+                expectingChecksumResult = false;
             }
         };
 
@@ -308,6 +311,11 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         /// managerNotReady is a manager-wide condition: a real success means the manager is ready, and
         /// resetting the streak on it is correct regardless of which flow observed it.
         std::atomic<unsigned int> m_consecutiveSyncFailures{0};
+
+        static constexpr size_t FULLSESSION_MAX_BYTES = 5U * 1024U * 1024U;
+        static constexpr size_t FULLSESSION_PREFILTER_GRACE_BYTES = 64U * 1024U;
+        static constexpr size_t FULLSESSION_MAX_BLOCKS_PER_SYNC = 10U;
+        static constexpr std::string_view HTTP_RESULT_PREFIX = "HCRESULT:";
 };
 
 #endif // AGENT_SYNC_PROTOCOL_HPP

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
@@ -110,6 +110,18 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         /// Fixed; the HTTP-level retry count lives in the transport layer.
         static constexpr unsigned int SYNC_HANDOFF_RETRIES = 3;
 
+        /// @brief Safety-net ceiling on how long runSession() waits for on_sync_response.
+        ///
+        /// The HTTPS client fires on_sync_response for every outcome WITHIN wazuh-agentd,
+        /// but the result still has to cross the bridge (https_client_bridge.c) and a
+        /// module-local socket to reach this wait - a hop that can silently drop it (no
+        /// route for the session, a full module socket, a send() failure). Without a
+        /// ceiling here that drop wedges this module's sync forever. The value is set well
+        /// above https_client's own worst case for one /stateful session (5 attempts *
+        /// 120s statefulTimeoutMs + 4 backoff gaps capped at 60s, ~14 minutes) so it only
+        /// fires on an actual delivery failure, never on a slow-but-alive manager.
+        static constexpr auto SESSION_RESPONSE_TIMEOUT = std::chrono::minutes(15);
+
         /// @brief Total attempts for a module integrity check (requiresFullSync()) before
         ///        trusting a checksum mismatch (409) as genuine.
         ///

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
@@ -175,12 +175,19 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         /// @brief Splits DELTA sync into capped FullSessions by fetching blocks from the queue.
         SyncModuleResult synchronizeDeltaByBlocks(Option option);
 
-        /// @brief Applies HTTP-result outcomes received from https_client callback routing.
-        /// @param resultCode HTTP status code (0 = success).
+        /// @brief Applies the /stateful HTTP result received from https_client callback
+        ///        routing. This IS the sync protocol's response path: there is no EndAck
+        ///        FlatBuffer message anymore, so every outcome (success or failure) arrives
+        ///        this way.
+        /// @param httpCode Raw HTTP status code the manager answered with (200, 400, 403,
+        ///        409, 413, 500, 503...). 0 means no HTTP response was received at all
+        ///        (timeout/connect/TLS failure/abort), handled like a 503.
+        /// @param body Raw JSON response body (may be empty); used only for logging - the
+        ///        HTTP code alone fully determines the outcome.
         /// @param expectedSession Session that this result belongs to; 0 skips validation
         ///        (legacy path). The check is performed under m_syncState.mtx so it is
         ///        race-free with a concurrent session start.
-        bool applyHttpResultCode(int resultCode, uint64_t expectedSession = 0);
+        bool applyHttpResult(int httpCode, std::string_view body, uint64_t expectedSession = 0);
 
         /// @brief Picks the id for a new session. The agent chooses it because the
         ///        single-message exchange has no StartAck to carry one back; a retry
@@ -247,13 +254,10 @@ class AgentSyncProtocol : public IAgentSyncProtocol
             /// established session).
             bool lastSyncManagerNotReady = false;
 
-            /// @brief True when the in-flight session is an integrity check; non-200 means checksum mismatch.
-            bool expectingChecksumResult = false;
-
             /// @brief Numeric session ID of the current in-flight session.
             ///
             /// Set by runSession() before the first send attempt and cleared on reset().
-            /// applyHttpResultCode() validates incoming HCRESULT payloads against this
+            /// applyHttpResult() validates incoming HCRESULT payloads against this
             /// value so that a stale response from a previous (timed-out) session cannot
             /// satisfy a newer one.
             uint64_t currentSession = 0;
@@ -278,7 +282,6 @@ class AgentSyncProtocol : public IAgentSyncProtocol
                 phase = SyncPhase::Idle;
                 lastSyncResult = SyncResult::SUCCESS;
                 lastSyncManagerNotReady = false;
-                expectingChecksumResult = false;
                 currentSession = 0;
             }
         };

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface.h
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface.h
@@ -47,22 +47,6 @@ void asp_persist_diff(AgentSyncProtocolHandle* handle,
                       const char* data,
                       uint64_t version);
 
-/// @brief Persists a difference to in-memory vector instead of database.
-///
-/// This method is used for recovery scenarios where data should be kept in memory.
-/// @param handle Pointer to the AgentSyncProtocol handle.
-/// @param id Unique identifier for the data item.
-/// @param operation Type of operation (create, modify, delete).
-/// @param index Logical index for the data item.
-/// @param data Serialized content of the message.
-/// @param version Version of the data (64-bit unsigned integer).
-void asp_persist_diff_in_memory(AgentSyncProtocolHandle* handle,
-                                const char* id,
-                                Operation_t operation,
-                                const char* index,
-                                const char* data,
-                                uint64_t version);
-
 /// @brief Triggers synchronization of a module.
 ///
 /// @param handle Pointer to the AgentSyncProtocol handle.
@@ -87,10 +71,6 @@ bool asp_requires_full_sync(AgentSyncProtocolHandle* handle,
 /// @param length Size of the FlatBuffer message in bytes.
 /// @return true if parsed successfully, false on error.
 bool asp_parse_response_buffer(AgentSyncProtocolHandle* handle, const uint8_t* data, size_t length);
-
-/// @brief Clears the in-memory data queue.
-/// @param handle Protocol handle.
-void asp_clear_in_memory_data(AgentSyncProtocolHandle* handle);
 
 /// @brief Synchronizes metadata or groups with the server without sending data.
 ///

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface.h
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface.h
@@ -22,12 +22,10 @@ extern "C" {
 /// @brief Creates an instance of AgentSyncProtocol.
 ///
 /// @param module Name of the module associated with this instance.
-/// @param db_path Optional full path to the SQLite database file to be used (nullptr for in-memory only).
+/// @param db_path Optional full path to the SQLite database file (nullptr for in-memory only).
 /// @param logger Callback function used for logging messages.
-/// @param timeout Default timeout for synchronization operations in seconds.
-/// @param retries Default number of retries for synchronization operations.
 /// @return A pointer to an opaque AgentSyncProtocol handle, or NULL on failure.
-AgentSyncProtocolHandle* asp_create(const char* module, const char* db_path, asp_logger_t logger, unsigned int timeout, unsigned int retries);
+AgentSyncProtocolHandle* asp_create(const char* module, const char* db_path, asp_logger_t logger);
 
 /// @brief Destroys an AgentSyncProtocol instance.
 ///

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface.h
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface.h
@@ -53,7 +53,7 @@ void asp_persist_diff(AgentSyncProtocolHandle* handle,
 /// @param mode Synchronization mode (e.g., full, delta).
 /// @return SyncModuleResult_t with success flag and an optional failure reason string.
 SyncModuleResult_t asp_sync_module(AgentSyncProtocolHandle* handle,
-                     Mode_t mode);
+                                   Mode_t mode);
 
 /// @brief Checks if a module index requires full synchronization.
 ///

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface_types.h
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface_types.h
@@ -62,13 +62,12 @@ typedef enum
 /// @brief Defines the type of mode synchronization.
 typedef enum
 {
-    MODE_FULL  = 0,         ///< Full synchronization
-    MODE_DELTA = 1,         ///< Delta synchronization
-    MODE_CHECK = 2,         ///< Integrity check mode
-    MODE_METADATA_DELTA = 3, ///< Metadata delta synchronization
-    MODE_METADATA_CHECK = 4, ///< Metadata integrity check
-    MODE_GROUP_DELTA = 5,    ///< Group delta synchronization
-    MODE_GROUP_CHECK = 6     ///< Group integrity check
+    MODE_DELTA = 0,         ///< Delta synchronization
+    MODE_CHECK = 1,         ///< Integrity check mode
+    MODE_METADATA_DELTA = 2, ///< Metadata delta synchronization
+    MODE_METADATA_CHECK = 3, ///< Metadata integrity check
+    MODE_GROUP_DELTA = 4,    ///< Group delta synchronization
+    MODE_GROUP_CHECK = 5     ///< Group integrity check
 } Mode_t;
 
 /// @brief Defines additional synchronization options.

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_wrapper.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_wrapper.hpp
@@ -14,13 +14,9 @@ struct AgentSyncProtocolWrapper
     /// @brief Constructs the wrapper and initializes the AgentSyncProtocol instance.
     ///
     /// @param module Name of the module associated with this instance.
-    /// @param db_path Optional path to the SQLite database file for this protocol instance. If not provided, only in-memory synchronization is available.
+    /// @param db_path Optional path to the SQLite database file. If not provided, only in-memory synchronization is available.
     /// @param logger Logger function
-    /// @param timeout Default timeout for synchronization operations.
-    /// @param retries Default number of retries for synchronization operations.
-    AgentSyncProtocolWrapper(const std::string& module, std::optional<std::string> db_path, LoggerFunc logger,
-                             std::chrono::seconds timeout,
-                             unsigned int retries)
-        : impl(std::make_unique<AgentSyncProtocol>(module, db_path, std::move(logger), timeout, retries)) {}
+    AgentSyncProtocolWrapper(const std::string& module, std::optional<std::string> db_path, LoggerFunc logger)
+        : impl(std::make_unique<AgentSyncProtocol>(module, db_path, std::move(logger))) {}
 };
 

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_types.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_types.hpp
@@ -26,6 +26,8 @@ enum class SyncResult
     END_TIMEOUT_ERROR,       ///< Exceeded maximum retries waiting for a response for the End message
     PROTOCOL_ERROR,       ///< Manager sent an unexpected or invalid response
     NO_GROUPS_ERROR,     ///< No groups available in metadata.
+    PAYLOAD_TOO_LARGE,   ///< Manager rejected the session as larger than its total in-flight
+    ///< budget (HTTP 413); the session must be split and resent smaller.
 };
 
 struct SyncModuleResult

--- a/src/shared_modules/sync_protocol/include/iagent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/include/iagent_sync_protocol.hpp
@@ -33,19 +33,6 @@ class IAgentSyncProtocol
                                        uint64_t version,
                                        bool isDataContext = false) = 0;
 
-        /// @brief Persist a difference to in-memory vector instead of database.
-        /// This method is used for recovery scenarios where data should be kept in memory.
-        /// @param id Unique identifier for the data item.
-        /// @param operation Type of operation (CREATE, MODIFY, DELETE).
-        /// @param index Logical index for the data item.
-        /// @param data Serialized content of the message.
-        /// @param version Version of the data.
-        virtual void persistDifferenceInMemory(const std::string& id,
-                                               Operation operation,
-                                               const std::string& index,
-                                               const std::string& data,
-                                               uint64_t version) = 0;
-
         /// @brief Synchronize a module with the server
         /// @param mode Sync mode
         /// @param option Synchronization option.
@@ -58,11 +45,6 @@ class IAgentSyncProtocol
         /// @return true if full sync is required (checksum mismatch); false if integrity is valid.
         virtual bool requiresFullSync(const std::string& index,
                                       const std::string& checksum) = 0;
-
-        /// @brief Clears the in-memory data queue.
-        ///
-        /// This method removes all entries from the in-memory vector used for recovery scenarios.
-        virtual void clearInMemoryData() = 0;
 
         /// @brief Synchronizes metadata or groups with the server without sending data.
         ///

--- a/src/shared_modules/sync_protocol/include/iagent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/include/iagent_sync_protocol.hpp
@@ -40,6 +40,12 @@ class IAgentSyncProtocol
         virtual SyncModuleResult synchronizeModule(Mode mode, Option option = Option::SYNC) = 0;
 
         /// @brief Checks if a module index requires full synchronization
+        ///
+        /// A 409 (checksum mismatch) is retried against the manager up to
+        /// CHECKSUM_MISMATCH_MAX_ATTEMPTS times, spaced out, before being trusted as a
+        /// genuine mismatch -- a recent bulk write may not be visible in the indexer yet.
+        /// Any other failure (communication error, manager offline) returns false
+        /// immediately without spending this retry budget.
         /// @param index The index/table to check
         /// @param checksum The calculated checksum for the index
         /// @return true if full sync is required (checksum mismatch); false if integrity is valid.

--- a/src/shared_modules/sync_protocol/include/ipersistent_queue.hpp
+++ b/src/shared_modules/sync_protocol/include/ipersistent_queue.hpp
@@ -29,7 +29,6 @@ enum class Operation : int
 /// @brief Defines the type of synchronization mode.
 enum class Mode : int
 {
-    FULL  = MODE_FULL,               ///< Full synchronization mode.
     DELTA = MODE_DELTA,              ///< Delta synchronization mode.
     CHECK = MODE_CHECK,              ///< Integrity check mode.
     METADATA_DELTA = MODE_METADATA_DELTA, ///< Metadata delta synchronization mode.

--- a/src/shared_modules/sync_protocol/include/ipersistent_queue.hpp
+++ b/src/shared_modules/sync_protocol/include/ipersistent_queue.hpp
@@ -11,6 +11,7 @@
 
 #include "agent_sync_protocol_c_interface_types.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <optional>
@@ -100,9 +101,10 @@ class IPersistentQueue
                             uint64_t version,
                             bool isDataContext = false) = 0;
 
-        /// @brief Fetches a batch of pending messages and marks them for synchronization.
+        /// @brief Fetches a batch of pending messages up to a byte budget and marks them for synchronization.
+        /// @param maxBytes Maximum estimated payload size to collect. 0 means no byte cap.
         /// @return A vector of messages now marked as SYNCING.
-        virtual std::vector<PersistedData> fetchAndMarkForSync() = 0;
+        virtual std::vector<PersistedData> fetchAndMarkForSync(size_t maxBytes = 0) = 0;
 
         /// @brief Fetches pending DataValue items without marking them for sync.
         /// @param onlyDataValues If true, only returns items with is_data_context=false

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -881,29 +881,31 @@ bool AgentSyncProtocol::runSession(const SessionContent& content)
 
         // Session successfully handed off to the transport. The HTTPS client now
         // owns the send and will fire on_sync_response for EVERY outcome (200,
-        // error, timeout, abort). The module therefore waits indefinitely here —
-        // no module-level response timeout exists. Only shouldStop() (agent
-        // shutdown) interrupts the wait early; items are reset to PENDING and
-        // the next periodic cycle retries them.
+        // error, timeout, abort) WITHIN wazuh-agentd, but that result still has to
+        // cross the bridge and a module-local socket to reach this wait, and that
+        // hop can silently drop it. SESSION_RESPONSE_TIMEOUT is a safety net for
+        // that case, not a normal-path timeout. shouldStop() (agent shutdown)
+        // still interrupts the wait early; either way, items are reset to PENDING
+        // and the next periodic cycle retries them.
         std::unique_lock<std::mutex> lock(m_syncState.mtx);
 #ifdef WAZUH_UNIT_TESTING
-        const bool conditionMet = m_syncState.cv.wait_for(lock, std::chrono::seconds(2), [&]
+        const auto waitTimeout = std::chrono::seconds(2);
+#else
+        const auto waitTimeout = SESSION_RESPONSE_TIMEOUT;
+#endif
+        const bool conditionMet = m_syncState.cv.wait_for(lock, waitTimeout, [&]
         {
             return m_syncState.responseReceived || m_syncState.syncFailed || shouldStop();
         });
 
         if (!conditionMet)
         {
+            m_logger(LOG_WARNING, "Session " + std::to_string(session) + " got no response within " +
+                     std::to_string(std::chrono::duration_cast<std::chrono::seconds>(waitTimeout).count()) +
+                     "s; treating as failed so the next cycle can retry.");
             m_syncState.lastSyncResult = SyncResult::END_TIMEOUT_ERROR;
             m_syncState.lastSyncManagerNotReady = true;
         }
-
-#else
-        m_syncState.cv.wait(lock, [&]
-        {
-            return m_syncState.responseReceived || m_syncState.syncFailed || shouldStop();
-        });
-#endif
 
         if (m_syncState.syncFailed)
         {
@@ -916,7 +918,7 @@ bool AgentSyncProtocol::runSession(const SessionContent& content)
             return true;
         }
 
-        return false; // Woken by stop().
+        return false; // Woken by stop(), or by the SESSION_RESPONSE_TIMEOUT safety net.
     }
 
     // All hand-off attempts failed: the local sync intake is unavailable.
@@ -999,7 +1001,11 @@ bool AgentSyncProtocol::applyHttpResult(int httpCode, std::string_view body, uin
 
     // The HTTP status code alone fully determines the outcome; the body (already
     // valid JSON text from the manager) is only ever used here for logging context.
-    if (httpCode == 200)
+    // Any 2xx is success, not just 200: the /stateful contract already documents a
+    // future 202 (queued-processing endpoint) as a deliberate accepted-but-not-200
+    // answer (see syncEndpoint.cpp), and this must not fall into the default
+    // protocol-error branch below when the manager starts sending it.
+    if (httpCode >= 200 && httpCode < 300)
     {
         m_syncState.lastSyncResult = SyncResult::SUCCESS;
         m_syncState.responseReceived = true;

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -48,6 +48,10 @@ static std::string determineSyncFailureReasonBasedOnSyncResult(SyncResult result
             failureReason = "No groups available in metadata. Waiting for the server to synchronize the groups. Cannot proceed with synchronization.";
             break;
 
+        case SyncResult::PAYLOAD_TOO_LARGE:
+            failureReason = "Manager rejected the session as too large (413); it must be split and resent.";
+            break;
+
         // SyncResult::CHECKSUM_ERROR is not returned by either synchronizeModule() or synchronizeMetadataOrGroups()
 
         default:
@@ -743,9 +747,6 @@ std::vector<uint8_t> AgentSyncProtocol::buildFullSessionMessage(const SessionCon
             hasChecksum = true;
         }
 
-        Wazuh::SyncSchema::EndBuilder endBuilder(builder);
-        const auto endOffset = endBuilder.Finish();
-
         // A session carries exactly one of these: a data sync (values and/or
         // contexts), a clean notification, or a checksum check - never a mix,
         // so the three go through one union instead of three optional fields.
@@ -785,7 +786,6 @@ std::vector<uint8_t> AgentSyncProtocol::buildFullSessionMessage(const SessionCon
             fullSessionBuilder.add_payload(payloadOffset);
         }
 
-        fullSessionBuilder.add_end(endOffset);
         const auto fullSessionOffset = fullSessionBuilder.Finish();
 
         auto message = Wazuh::SyncSchema::CreateMessage(
@@ -812,8 +812,7 @@ bool AgentSyncProtocol::runSession(const SessionContent& content)
         m_syncState.phase = SyncPhase::WaitingResponse;
         m_syncState.responseReceived = false;
         m_syncState.syncFailed = false;
-        m_syncState.expectingChecksumResult = !content.checksums.empty();
-        // Record the session ID so applyHttpResultCode() can reject stale HCRESULT
+        // Record the session ID so applyHttpResult() can reject stale HCRESULT
         // callbacks that arrive after a timeout and a subsequent session start.
         m_syncState.currentSession = session;
     }
@@ -908,97 +907,35 @@ bool AgentSyncProtocol::parseResponseBuffer(const uint8_t* data, size_t length)
 
     try
     {
-        if (length >= HTTP_RESULT_PREFIX.size() &&
-                std::memcmp(data, HTTP_RESULT_PREFIX.data(), HTTP_RESULT_PREFIX.size()) == 0)
+        // Every sync outcome (success or failure) arrives this way now - there is no
+        // FlatBuffer response message anymore (no EndAck, no per-item acks): the manager
+        // answers a /stateful session with a single HTTP response, routed here as
+        // "HCRESULT:<session>:<http_code>:<body>". The body is the manager's raw JSON
+        // response (may be empty) and may itself contain colons, so only the first two
+        // colons are parsed as delimiters.
+        if (length < HTTP_RESULT_PREFIX.size() ||
+                std::memcmp(data, HTTP_RESULT_PREFIX.data(), HTTP_RESULT_PREFIX.size()) != 0)
         {
-            // HCRESULT format: "HCRESULT:<session>:<code>" (new, session-correlated)
-            //               or "HCRESULT:<code>"           (legacy, no session check)
-            const std::string remainder(reinterpret_cast<const char*>(data) + HTTP_RESULT_PREFIX.size(),
-                                        length - HTTP_RESULT_PREFIX.size());
-            const auto colon = remainder.find(':');
-
-            if (colon != std::string::npos)
-            {
-                const uint64_t receivedSession = std::stoull(remainder.substr(0, colon));
-                const int resultCode = std::stoi(remainder.substr(colon + 1));
-                return applyHttpResultCode(resultCode, receivedSession);
-            }
-
-            // Legacy format (no session number) — skip correlation check.
-            const int resultCode = std::stoi(remainder);
-            return applyHttpResultCode(resultCode, 0);
-        }
-
-        flatbuffers::Verifier verifier(data, length);
-
-        if (!Wazuh::SyncSchema::VerifyMessageBuffer(verifier))
-        {
-            m_logger(LOG_ERROR, "Invalid FlatBuffer message");
+            m_logger(LOG_ERROR, "Response buffer is not an HCRESULT payload.");
             return false;
         }
 
-        const auto* message = Wazuh::SyncSchema::GetMessage(data);
-        const auto messageType = message->content_type();
+        const std::string remainder(reinterpret_cast<const char*>(data) + HTTP_RESULT_PREFIX.size(),
+                                    length - HTTP_RESULT_PREFIX.size());
+        const auto firstColon = remainder.find(':');
+        const auto secondColon =
+            (firstColon == std::string::npos) ? std::string::npos : remainder.find(':', firstColon + 1);
 
-        std::unique_lock<std::mutex> lock(m_syncState.mtx);
-
-        switch (messageType)
+        if (firstColon == std::string::npos || secondColon == std::string::npos)
         {
-            case Wazuh::SyncSchema::MessageType::EndAck:
-                {
-                    const auto* endAck = message->content_as_EndAck();
-
-                    if (m_syncState.phase != SyncPhase::WaitingResponse)
-                    {
-                        m_logger(LOG_DEBUG, "Discarded response: protocol is not waiting for a sync answer.");
-                        return true;
-                    }
-
-                    if (endAck->status() == Wazuh::SyncSchema::Status::Error ||
-                            endAck->status() == Wazuh::SyncSchema::Status::Offline ||
-                            endAck->status() == Wazuh::SyncSchema::Status::ChecksumMismatch)
-                    {
-                        // Store the specific error type for detailed reporting
-                        if (endAck->status() == Wazuh::SyncSchema::Status::Offline)
-                        {
-                            m_syncState.lastSyncResult = SyncResult::COMMUNICATION_ERROR;
-                            // The manager reports it cannot serve this agent: same condition as the
-                            // manager reporting it cannot serve this agent yet.
-                            m_syncState.lastSyncManagerNotReady = true;
-                            m_logger(LOG_DEBUG, "Received EndAck with Offline status. Aborting synchronization.");
-                        }
-                        else if (endAck->status() == Wazuh::SyncSchema::Status::ChecksumMismatch)
-                        {
-                            m_syncState.lastSyncResult = SyncResult::CHECKSUM_ERROR;
-                            m_logger(LOG_DEBUG, "Checksum mismatch detected by manager, full resync will be triggered.");
-                        }
-                        else if (endAck->status() == Wazuh::SyncSchema::Status::Error)
-                        {
-                            m_syncState.lastSyncResult = SyncResult::PROTOCOL_ERROR;
-                            m_logger(LOG_DEBUG, "Received EndAck with Error status. Aborting synchronization.");
-                        }
-
-                        m_syncState.syncFailed = true;
-                        m_syncState.cv.notify_all();
-                        break;
-                    }
-
-                    m_syncState.lastSyncResult = SyncResult::SUCCESS;
-                    m_syncState.responseReceived = true;
-                    m_syncState.cv.notify_all();
-
-                    m_logger(LOG_DEBUG, "Sync response received with success status.");
-                    break;
-                }
-
-            default:
-                {
-                    m_logger(LOG_DEBUG, "Unknown message type: " + std::to_string(static_cast<int>(messageType)));
-                    return false;
-                }
+            m_logger(LOG_ERROR, "Malformed HCRESULT payload.");
+            return false;
         }
 
-        return true;
+        const uint64_t receivedSession = std::stoull(remainder.substr(0, firstColon));
+        const int httpCode = std::stoi(remainder.substr(firstColon + 1, secondColon - firstColon - 1));
+        const std::string_view body(remainder.data() + secondColon + 1, remainder.size() - secondColon - 1);
+        return applyHttpResult(httpCode, body, receivedSession);
     }
     catch (const std::exception& e)
     {
@@ -1007,14 +944,17 @@ bool AgentSyncProtocol::parseResponseBuffer(const uint8_t* data, size_t length)
     }
 }
 
-bool AgentSyncProtocol::applyHttpResultCode(int resultCode, uint64_t expectedSession)
+bool AgentSyncProtocol::applyHttpResult(int httpCode, std::string_view body, uint64_t expectedSession)
 {
     std::lock_guard<std::mutex> lock(m_syncState.mtx);
 
+    // A response that no longer applies (nothing in flight, or it belongs to a
+    // previous/timed-out session) is an expected race, not a parse failure: return
+    // true so the C-level receiver (wm_sca.c et al.) does not log it as an error.
     if (m_syncState.phase != SyncPhase::WaitingResponse)
     {
         m_logger(LOG_DEBUG, "Discarded response code: protocol is not waiting for a sync answer.");
-        return false;
+        return true;
     }
 
     // Transport-level session correlation: reject responses that belong to a
@@ -1028,26 +968,54 @@ bool AgentSyncProtocol::applyHttpResultCode(int resultCode, uint64_t expectedSes
                  std::to_string(expectedSession) +
                  " does not match current session " +
                  std::to_string(m_syncState.currentSession) + ".");
-        return false;
+        return true;
     }
 
-    if (resultCode == 0)
+    // The HTTP status code alone fully determines the outcome; the body (already
+    // valid JSON text from the manager) is only ever used here for logging context.
+    if (httpCode == 200)
     {
         m_syncState.lastSyncResult = SyncResult::SUCCESS;
         m_syncState.responseReceived = true;
         m_syncState.cv.notify_all();
+        m_logger(LOG_DEBUG, "Sync response received with success status: " + std::string(body));
         return true;
     }
 
     m_syncState.syncFailed = true;
 
-    if (m_syncState.expectingChecksumResult)
+    switch (httpCode)
     {
-        m_syncState.lastSyncResult = SyncResult::CHECKSUM_ERROR;
-    }
-    else
-    {
-        m_syncState.lastSyncResult = SyncResult::PROTOCOL_ERROR;
+        case 409: // checksum_mismatch: full resync will be triggered by the caller.
+            m_syncState.lastSyncResult = SyncResult::CHECKSUM_ERROR;
+            m_logger(LOG_DEBUG, "Checksum mismatch detected by manager (409): " + std::string(body));
+            break;
+
+        case 413: // Session larger than the manager's total in-flight budget; must be split.
+            m_syncState.lastSyncResult = SyncResult::PAYLOAD_TOO_LARGE;
+            m_logger(LOG_WARNING, "Session rejected as too large by the manager (413): " + std::string(body));
+            break;
+
+        case 503: // Manager not ready (indexer down, at capacity, shutting down, or a VD
+            // feed still downloading): retried on the next cycle either way.
+            m_syncState.lastSyncResult = SyncResult::COMMUNICATION_ERROR;
+            m_syncState.lastSyncManagerNotReady = true;
+            m_logger(LOG_DEBUG, "Manager reported not ready (503): " + std::string(body));
+            break;
+
+        case 0: // No HTTP response at all (timeout/connect/TLS failure/abort).
+            m_syncState.lastSyncResult = SyncResult::COMMUNICATION_ERROR;
+            m_syncState.lastSyncManagerNotReady = true;
+            m_logger(LOG_DEBUG, "No HTTP response received for the sync session.");
+            break;
+
+        default: // 400/403/500 and anything else: a protocol-level failure the caller
+            // does not blindly retry with identical bytes.
+            m_syncState.lastSyncResult = SyncResult::PROTOCOL_ERROR;
+            m_logger(LOG_DEBUG,
+                     "Manager reported a protocol error (" + std::to_string(httpCode) + "): " +
+                     std::string(body));
+            break;
     }
 
     m_syncState.cv.notify_all();

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -58,14 +58,11 @@ static std::string determineSyncFailureReasonBasedOnSyncResult(SyncResult result
 }
 
 AgentSyncProtocol::AgentSyncProtocol(const std::string& moduleName, std::optional<std::string> dbPath, LoggerFunc logger,
-                                     std::chrono::seconds timeout,
-                                     unsigned int retries, std::shared_ptr<IPersistentQueue> queue,
+                                     std::shared_ptr<IPersistentQueue> queue,
                                      std::shared_ptr<ISyncSessionTransport> syncTransport)
     : m_moduleName(moduleName),
       m_persistentQueue(nullptr), // Ensure initialized to nullptr
-      m_logger(std::move(logger)),
-      m_timeout(timeout),
-      m_retries(retries)
+      m_logger(std::move(logger))
 {
     if (!m_logger)
     {
@@ -196,14 +193,67 @@ SyncModuleResult AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
         return synchronizeDeltaByBlocks(option);
     }
 
-    // For FULL mode, use in-memory data for recovery scenarios
-    std::vector<PersistedData> dataToSync = m_inMemoryData;
+    // For FULL mode, use in-memory data for recovery scenarios.
+    // Non-VD flows are byte-capped so the HTTP transport receives a bounded payload.
+    // VD flows (VDFIRST / VDSYNC) are deliberately uncapped.
+    std::vector<PersistedData> dataToSync;
+    {
+        const bool uncapped = isUncappedSyncOption(option);
+        const size_t fetchMaxBytes =
+            uncapped
+            ? 0
+            : (FULLSESSION_MAX_BYTES > FULLSESSION_PREFILTER_GRACE_BYTES
+               ? FULLSESSION_MAX_BYTES - FULLSESSION_PREFILTER_GRACE_BYTES
+               : FULLSESSION_MAX_BYTES);
+
+        if (uncapped || fetchMaxBytes == 0)
+        {
+            dataToSync = m_inMemoryData;
+        }
+        else
+        {
+            size_t estimatedBytes = 0;
+
+            for (const auto& item : m_inMemoryData)
+            {
+                const size_t est = item.id.size() + item.index.size() + item.data.size() + 512U;
+
+                if (!dataToSync.empty() && estimatedBytes + est > fetchMaxBytes)
+                {
+                    break;
+                }
+
+                if (dataToSync.empty() && estimatedBytes + est > fetchMaxBytes)
+                {
+                    m_logger(LOG_WARNING,
+                             "FULL mode: single item (~" + std::to_string(est) +
+                             " B) exceeds byte cap (" + std::to_string(fetchMaxBytes) +
+                             " B); sending it alone.");
+                }
+
+                estimatedBytes += est;
+                dataToSync.push_back(item);
+            }
+
+            if (dataToSync.size() < m_inMemoryData.size())
+            {
+                m_logger(LOG_WARNING,
+                         "FULL mode: payload truncated from " +
+                         std::to_string(m_inMemoryData.size()) + " to " +
+                         std::to_string(dataToSync.size()) +
+                         " items to stay within byte cap.");
+            }
+        }
+    }
 
     if (dataToSync.empty())
     {
         m_logger(LOG_DEBUG, "No items to synchronize in FULL mode");
         return {true, {}};
     }
+
+    // Remember how many items are included so we can trim m_inMemoryData on success.
+    const size_t sentCount = dataToSync.size();
 
     for (size_t i = 0; i < dataToSync.size(); ++i)
     {
@@ -243,7 +293,18 @@ SyncModuleResult AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
     if (success)
     {
         m_logger(LOG_DEBUG_VERBOSE, "Synchronization completed successfully.");
-        m_inMemoryData.clear();
+
+        // Erase only the items that were part of this session; any unsent tail
+        // (due to byte-cap truncation) stays in m_inMemoryData for the next cycle.
+        if (sentCount >= m_inMemoryData.size())
+        {
+            m_inMemoryData.clear();
+        }
+        else
+        {
+            m_inMemoryData.erase(m_inMemoryData.begin(),
+                                 m_inMemoryData.begin() + static_cast<ptrdiff_t>(sentCount));
+        }
     }
 
     std::string failureReason = determineSyncFailureReasonBasedOnSyncResult(m_syncState.lastSyncResult);
@@ -367,6 +428,15 @@ SyncModuleResult AgentSyncProtocol::synchronizeDeltaByBlocks(Option option)
         catch (const std::exception& e)
         {
             m_logger(LOG_ERROR, std::string("Failed to finalize DELTA sync block: ") + e.what());
+
+            // The upload succeeded but the post-sync DB update failed; rows remain in SYNCING.
+            // Reset them back to PENDING so they are retried on the next cycle.
+            try
+            {
+                m_persistentQueue->resetSyncingItems();
+            }
+            catch (...) {}
+
             success = false;
             break;
         }
@@ -880,6 +950,9 @@ bool AgentSyncProtocol::runSession(const SessionContent& content)
         m_syncState.responseReceived = false;
         m_syncState.syncFailed = false;
         m_syncState.expectingChecksumResult = !content.checksums.empty();
+        // Record the session ID so applyHttpResultCode() can reject stale HCRESULT
+        // callbacks that arrive after a timeout and a subsequent session start.
+        m_syncState.currentSession = session;
     }
 
     const auto message = buildFullSessionMessage(content);
@@ -893,15 +966,13 @@ bool AgentSyncProtocol::runSession(const SessionContent& content)
              "Sending session " + std::to_string(session) + " as one message (" +
              std::to_string(message.size()) + " bytes).");
 
-    // A refused hand-off usually means the intake is briefly down (an agentd
-    // restart); pausing before the resend keeps the retry budget from being
-    // burnt in one connect-refusal burst. The wait sits on the state cv so a
-    // stop cuts it short.
+    // A refused hand-off usually means the intake socket is briefly down (agentd
+    // restart); a short backoff and a small number of retries avoid burning the
+    // budget in a tight connect-refusal burst. The wait uses the state cv so a
+    // stop() call cuts it short.
     constexpr auto RESEND_BACKOFF = std::chrono::seconds(1);
 
-    // The whole session is retried under the same id; the manager dedups on it,
-    // so a resend after a lost answer cannot double-apply anything.
-    for (unsigned int attempt = 0; attempt <= m_retries; ++attempt)
+    for (unsigned int attempt = 0; attempt <= SYNC_HANDOFF_RETRIES; ++attempt)
     {
         if (shouldStop())
         {
@@ -920,40 +991,47 @@ bool AgentSyncProtocol::runSession(const SessionContent& content)
             continue;
         }
 
+        // Session successfully handed off to the transport. The HTTPS client now
+        // owns the send and will fire on_sync_response for EVERY outcome (200,
+        // error, timeout, abort). The module therefore waits indefinitely here —
+        // no module-level response timeout exists. Only shouldStop() (agent
+        // shutdown) interrupts the wait early; items are reset to PENDING and
+        // the next periodic cycle retries them.
         std::unique_lock<std::mutex> lock(m_syncState.mtx);
-
-        if (m_syncState.cv.wait_for(lock, m_timeout, [&]
-    {
-        return m_syncState.responseReceived || m_syncState.syncFailed || shouldStop();
-        }))
+#ifdef WAZUH_UNIT_TESTING
+        const bool conditionMet = m_syncState.cv.wait_for(lock, std::chrono::seconds(2), [&]
         {
-            if (m_syncState.syncFailed)
-            {
-                m_logger(LOG_DEBUG, "Synchronization failed: Manager reported an error status.");
-                return false;
-            }
+            return m_syncState.responseReceived || m_syncState.syncFailed || shouldStop();
+        });
 
-            if (m_syncState.responseReceived)
-            {
-                return true;
-            }
-
-            return false; // Woken by the stop.
+        if (!conditionMet)
+        {
+            m_syncState.lastSyncResult = SyncResult::END_TIMEOUT_ERROR;
+            m_syncState.lastSyncManagerNotReady = true;
         }
 
-        m_logger(LOG_DEBUG, "Timed out waiting for the answer to session " +
-                 std::to_string(session) + ". Retrying the whole session.");
+#else
+        m_syncState.cv.wait(lock, [&]
+        {
+            return m_syncState.responseReceived || m_syncState.syncFailed || shouldStop();
+        });
+#endif
+
+        if (m_syncState.syncFailed)
+        {
+            m_logger(LOG_DEBUG, "Synchronization failed: Manager reported an error status.");
+            return false;
+        }
+
+        if (m_syncState.responseReceived)
+        {
+            return true;
+        }
+
+        return false; // Woken by stop().
     }
 
-    if (!shouldStop())
-    {
-        std::lock_guard<std::mutex> lock(m_syncState.mtx);
-        m_syncState.lastSyncResult = SyncResult::END_TIMEOUT_ERROR;
-        // Nothing came back for the session: the manager is most likely not ready
-        // for this agent yet. The module retries on its next cycle.
-        m_syncState.lastSyncManagerNotReady = true;
-    }
-
+    // All hand-off attempts failed: the local sync intake is unavailable.
     return false;
 }
 
@@ -970,10 +1048,22 @@ bool AgentSyncProtocol::parseResponseBuffer(const uint8_t* data, size_t length)
         if (length >= HTTP_RESULT_PREFIX.size() &&
                 std::memcmp(data, HTTP_RESULT_PREFIX.data(), HTTP_RESULT_PREFIX.size()) == 0)
         {
-            const std::string resultCodeStr(reinterpret_cast<const char*>(data) + HTTP_RESULT_PREFIX.size(),
-                                            length - HTTP_RESULT_PREFIX.size());
-            const int resultCode = std::stoi(resultCodeStr);
-            return applyHttpResultCode(resultCode);
+            // HCRESULT format: "HCRESULT:<session>:<code>" (new, session-correlated)
+            //               or "HCRESULT:<code>"           (legacy, no session check)
+            const std::string remainder(reinterpret_cast<const char*>(data) + HTTP_RESULT_PREFIX.size(),
+                                        length - HTTP_RESULT_PREFIX.size());
+            const auto colon = remainder.find(':');
+
+            if (colon != std::string::npos)
+            {
+                const uint64_t receivedSession = std::stoull(remainder.substr(0, colon));
+                const int resultCode = std::stoi(remainder.substr(colon + 1));
+                return applyHttpResultCode(resultCode, receivedSession);
+            }
+
+            // Legacy format (no session number) — skip correlation check.
+            const int resultCode = std::stoi(remainder);
+            return applyHttpResultCode(resultCode, 0);
         }
 
         flatbuffers::Verifier verifier(data, length);
@@ -1054,13 +1144,27 @@ bool AgentSyncProtocol::parseResponseBuffer(const uint8_t* data, size_t length)
     }
 }
 
-bool AgentSyncProtocol::applyHttpResultCode(int resultCode)
+bool AgentSyncProtocol::applyHttpResultCode(int resultCode, uint64_t expectedSession)
 {
     std::lock_guard<std::mutex> lock(m_syncState.mtx);
 
     if (m_syncState.phase != SyncPhase::WaitingResponse)
     {
         m_logger(LOG_DEBUG, "Discarded response code: protocol is not waiting for a sync answer.");
+        return false;
+    }
+
+    // Transport-level session correlation: reject responses that belong to a
+    // previous (timed-out) session.  A zero expectedSession means the caller
+    // comes from the legacy HCRESULT path (no session number) and skips this check.
+    if (expectedSession != 0 && m_syncState.currentSession != 0 &&
+            expectedSession != m_syncState.currentSession)
+    {
+        m_logger(LOG_DEBUG,
+                 "Discarded stale HCRESULT: received session " +
+                 std::to_string(expectedSession) +
+                 " does not match current session " +
+                 std::to_string(m_syncState.currentSession) + ".");
         return false;
     }
 

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -15,6 +15,7 @@
 #include "metadata_provider.h"
 
 #include <flatbuffers/flatbuffers.h>
+#include <cstring>
 #include <memory>
 #include <set>
 
@@ -36,11 +37,11 @@ static std::string determineSyncFailureReasonBasedOnSyncResult(SyncResult result
             break;
 
         case SyncResult::END_TIMEOUT_ERROR:
-            failureReason = "Timed out waiting for manager response to End message.";
+            failureReason = "Timed out waiting for manager response.";
             break;
 
         case SyncResult::PROTOCOL_ERROR:
-            failureReason = "Manager sent an unexpected or invalid response.";
+            failureReason = "Manager reported synchronization failure.";
             break;
 
         case SyncResult::NO_GROUPS_ERROR:
@@ -190,37 +191,17 @@ SyncModuleResult AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
 
     clearSyncState();
 
-    std::vector<PersistedData> dataToSync;
-
-    if (mode == Mode::FULL)
+    if (mode == Mode::DELTA)
     {
-        // For FULL mode, use in-memory data for recovery scenarios
-        dataToSync = m_inMemoryData;
+        return synchronizeDeltaByBlocks(option);
     }
-    else
-    {
-        // For DELTA mode, use traditional database persistence
-        try
-        {
-            if (!m_persistentQueue)
-            {
-                throw std::runtime_error("DELTA mode requires a persistent queue. Initialize AgentSyncProtocol with a valid dbPath.");
-            }
 
-            dataToSync = m_persistentQueue->fetchAndMarkForSync();
-        }
-        catch (const std::exception& e)
-        {
-            const std::string reason = std::string("Failed to fetch items for sync: ") + e.what();
-            m_logger(LOG_ERROR, reason);
-            return {false, {}};
-        }
-    }
+    // For FULL mode, use in-memory data for recovery scenarios
+    std::vector<PersistedData> dataToSync = m_inMemoryData;
 
     if (dataToSync.empty())
     {
-        const std::string modeStr = (mode == Mode::FULL) ? "FULL" : "DELTA";
-        m_logger(LOG_DEBUG, "No items to synchronize in " + modeStr + " mode");
+        m_logger(LOG_DEBUG, "No items to synchronize in FULL mode");
         return {true, {}};
     }
 
@@ -229,7 +210,6 @@ SyncModuleResult AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
         dataToSync[i].seq = i;
     }
 
-    // Separate DataValue and DataContext items
     std::vector<PersistedData> dataValueItems;
     std::vector<PersistedData> dataContextItems;
 
@@ -245,7 +225,6 @@ SyncModuleResult AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
         }
     }
 
-    // Extract unique indices from the DataValue items
     std::set<std::string> uniqueIndicesSet;
 
     for (const auto& item : dataValueItems)
@@ -261,46 +240,144 @@ SyncModuleResult AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
     content.dataContexts = std::move(dataContextItems);
     const bool success = runSession(content);
 
+    if (success)
+    {
+        m_logger(LOG_DEBUG_VERBOSE, "Synchronization completed successfully.");
+        m_inMemoryData.clear();
+    }
+
+    std::string failureReason = determineSyncFailureReasonBasedOnSyncResult(m_syncState.lastSyncResult);
+    const bool stopped = shouldStop();
+    const bool managerNotReady = m_syncState.lastSyncManagerNotReady;
+    const unsigned int consecutiveFailures = trackSyncOutcome(success, stopped);
+    clearSyncState();
+    return {success, failureReason, stopped, managerNotReady, consecutiveFailures};
+}
+
+bool AgentSyncProtocol::isUncappedSyncOption(Option option) const
+{
+    return option == Option::VDFIRST || option == Option::VDSYNC;
+}
+
+SyncModuleResult AgentSyncProtocol::synchronizeDeltaByBlocks(Option option)
+{
     try
     {
-        if (success)
+        if (!m_persistentQueue)
         {
-            m_logger(LOG_DEBUG_VERBOSE, "Synchronization completed successfully.");
-
-            if (mode == Mode::FULL)
-            {
-                // For FULL mode, clear the in-memory data after successful sync
-                m_inMemoryData.clear();
-            }
-            else
-            {
-                // No need to check m_persistentQueue for nullptr here as it was validated earlier
-                // For DELTA mode, clear database synced items
-                m_persistentQueue->clearSyncedItems();
-            }
-        }
-        else
-        {
-            if (mode == Mode::FULL)
-            {
-                m_inMemoryData.clear();
-            }
-            else
-            {
-                // No need to check m_persistentQueue for nullptr here as it was validated earlier
-                m_persistentQueue->resetSyncingItems();
-            }
+            throw std::runtime_error("DELTA mode requires a persistent queue. Initialize AgentSyncProtocol with a valid dbPath.");
         }
     }
     catch (const std::exception& e)
     {
-        m_logger(LOG_ERROR, std::string("Failed to finalize sync state: ") + e.what());
+        const std::string reason = std::string("Failed to initialize DELTA sync: ") + e.what();
+        m_logger(LOG_ERROR, reason);
+        return {false, {}};
     }
 
-    std::string failureReason = determineSyncFailureReasonBasedOnSyncResult(m_syncState.lastSyncResult);
-    // Report whether a stop was requested so the caller can demote an expected
-    // shutdown-time failure from WARNING to INFO/DEBUG.
-    // (shouldStop() reads m_stopRequested, which clearSyncState() does not touch.)
+    const bool uncapped = isUncappedSyncOption(option);
+    const size_t fetchMaxBytes =
+        uncapped
+        ? 0
+        : (FULLSESSION_MAX_BYTES > FULLSESSION_PREFILTER_GRACE_BYTES
+           ? FULLSESSION_MAX_BYTES - FULLSESSION_PREFILTER_GRACE_BYTES
+           : FULLSESSION_MAX_BYTES);
+    bool success = true;
+    bool sentAny = false;
+    size_t blocksSent = 0;
+
+    while (!shouldStop() && blocksSent < FULLSESSION_MAX_BLOCKS_PER_SYNC)
+    {
+        std::vector<PersistedData> dataToSync;
+
+        try
+        {
+            dataToSync = m_persistentQueue->fetchAndMarkForSync(fetchMaxBytes);
+        }
+        catch (const std::exception& e)
+        {
+            const std::string reason = std::string("Failed to fetch items for sync: ") + e.what();
+            m_logger(LOG_ERROR, reason);
+            success = false;
+            break;
+        }
+
+        if (dataToSync.empty())
+        {
+            if (!sentAny)
+            {
+                m_logger(LOG_DEBUG, "No items to synchronize in DELTA mode");
+            }
+
+            break;
+        }
+
+        for (size_t i = 0; i < dataToSync.size(); ++i)
+        {
+            dataToSync[i].seq = i;
+        }
+
+        std::vector<PersistedData> dataValueItems;
+        std::vector<PersistedData> dataContextItems;
+        dataValueItems.reserve(dataToSync.size());
+        dataContextItems.reserve(dataToSync.size());
+
+        for (auto& item : dataToSync)
+        {
+            if (item.is_data_context)
+            {
+                dataContextItems.push_back(std::move(item));
+            }
+            else
+            {
+                dataValueItems.push_back(std::move(item));
+            }
+        }
+
+        std::set<std::string> uniqueIndicesSet;
+
+        for (const auto& item : dataValueItems)
+        {
+            uniqueIndicesSet.insert(item.index);
+        }
+
+        SessionContent content;
+        content.mode = Mode::DELTA;
+        content.indices.assign(uniqueIndicesSet.begin(), uniqueIndicesSet.end());
+        content.option = option;
+        content.dataValues = std::move(dataValueItems);
+        content.dataContexts = std::move(dataContextItems);
+
+        success = runSession(content);
+
+        try
+        {
+            if (success)
+            {
+                sentAny = true;
+                ++blocksSent;
+                m_persistentQueue->clearSyncedItems();
+            }
+            else
+            {
+                m_persistentQueue->resetSyncingItems();
+                break;
+            }
+        }
+        catch (const std::exception& e)
+        {
+            m_logger(LOG_ERROR, std::string("Failed to finalize DELTA sync block: ") + e.what());
+            success = false;
+            break;
+        }
+    }
+
+    if (shouldStop() && !sentAny)
+    {
+        success = false;
+    }
+
+    const std::string failureReason = determineSyncFailureReasonBasedOnSyncResult(m_syncState.lastSyncResult);
     const bool stopped = shouldStop();
     const bool managerNotReady = m_syncState.lastSyncManagerNotReady;
     const unsigned int consecutiveFailures = trackSyncOutcome(success, stopped);
@@ -656,8 +733,7 @@ uint64_t AgentSyncProtocol::nextSessionId()
     return (static_cast<uint64_t>(now) << 12) | (counter.fetch_add(1) & 0xFFF);
 }
 
-std::vector<uint8_t> AgentSyncProtocol::buildFullSessionMessage(uint64_t session,
-                                                                const SessionContent& content)
+std::vector<uint8_t> AgentSyncProtocol::buildFullSessionMessage(const SessionContent& content)
 {
     try
     {
@@ -697,7 +773,6 @@ std::vector<uint8_t> AgentSyncProtocol::buildFullSessionMessage(uint64_t session
 
             Wazuh::SyncSchema::DataValueBuilder dataValueBuilder(builder);
             dataValueBuilder.add_seq(item.seq);
-            dataValueBuilder.add_session(session);
             dataValueBuilder.add_id(idStr);
             dataValueBuilder.add_index(idxStr);
             dataValueBuilder.add_version(item.version);
@@ -730,7 +805,6 @@ std::vector<uint8_t> AgentSyncProtocol::buildFullSessionMessage(uint64_t session
 
             Wazuh::SyncSchema::DataContextBuilder dataContextBuilder(builder);
             dataContextBuilder.add_seq(item.seq);
-            dataContextBuilder.add_session(session);
             dataContextBuilder.add_id(idStr);
             dataContextBuilder.add_index(idxStr);
             dataContextBuilder.add_data(dataVec);
@@ -746,7 +820,6 @@ std::vector<uint8_t> AgentSyncProtocol::buildFullSessionMessage(uint64_t session
 
             Wazuh::SyncSchema::DataCleanBuilder dataCleanBuilder(builder);
             dataCleanBuilder.add_seq(item.seq);
-            dataCleanBuilder.add_session(session);
             dataCleanBuilder.add_index(idxStr);
             cleanOffsets.push_back(dataCleanBuilder.Finish());
         }
@@ -760,14 +833,12 @@ std::vector<uint8_t> AgentSyncProtocol::buildFullSessionMessage(uint64_t session
             auto checksumStr = builder.CreateString(entry.checksum);
 
             Wazuh::SyncSchema::ChecksumModuleBuilder checksumBuilder(builder);
-            checksumBuilder.add_session(session);
             checksumBuilder.add_index(idxStr);
             checksumBuilder.add_checksum(checksumStr);
             checksumOffsets.push_back(checksumBuilder.Finish());
         }
 
         Wazuh::SyncSchema::EndBuilder endBuilder(builder);
-        endBuilder.add_session(session);
         const auto endOffset = endBuilder.Finish();
 
         auto batchesVec = builder.CreateVector(batchOffsets);
@@ -776,7 +847,6 @@ std::vector<uint8_t> AgentSyncProtocol::buildFullSessionMessage(uint64_t session
         auto checksumsVec = builder.CreateVector(checksumOffsets);
 
         Wazuh::SyncSchema::FullSessionBuilder fullSessionBuilder(builder);
-        fullSessionBuilder.add_session(session);
         fullSessionBuilder.add_start(startOffset);
         fullSessionBuilder.add_batches(batchesVec);
         fullSessionBuilder.add_contexts(contextsVec);
@@ -806,13 +876,13 @@ bool AgentSyncProtocol::runSession(const SessionContent& content)
 
     {
         std::lock_guard<std::mutex> lock(m_syncState.mtx);
-        m_syncState.session = session;
-        // The whole session is in flight from the moment it is sent, so the only
-        // thing left to wait for is the manager's verdict.
-        m_syncState.phase = SyncPhase::WaitingEndAck;
+        m_syncState.phase = SyncPhase::WaitingResponse;
+        m_syncState.responseReceived = false;
+        m_syncState.syncFailed = false;
+        m_syncState.expectingChecksumResult = !content.checksums.empty();
     }
 
-    const auto message = buildFullSessionMessage(session, content);
+    const auto message = buildFullSessionMessage(content);
 
     if (message.empty())
     {
@@ -854,7 +924,7 @@ bool AgentSyncProtocol::runSession(const SessionContent& content)
 
         if (m_syncState.cv.wait_for(lock, m_timeout, [&]
     {
-        return m_syncState.endAckReceived || m_syncState.syncFailed || shouldStop();
+        return m_syncState.responseReceived || m_syncState.syncFailed || shouldStop();
         }))
         {
             if (m_syncState.syncFailed)
@@ -863,7 +933,7 @@ bool AgentSyncProtocol::runSession(const SessionContent& content)
                 return false;
             }
 
-            if (m_syncState.endAckReceived)
+            if (m_syncState.responseReceived)
             {
                 return true;
             }
@@ -897,6 +967,15 @@ bool AgentSyncProtocol::parseResponseBuffer(const uint8_t* data, size_t length)
 
     try
     {
+        if (length >= HTTP_RESULT_PREFIX.size() &&
+                std::memcmp(data, HTTP_RESULT_PREFIX.data(), HTTP_RESULT_PREFIX.size()) == 0)
+        {
+            const std::string resultCodeStr(reinterpret_cast<const char*>(data) + HTTP_RESULT_PREFIX.size(),
+                                            length - HTTP_RESULT_PREFIX.size());
+            const int resultCode = std::stoi(resultCodeStr);
+            return applyHttpResultCode(resultCode);
+        }
+
         flatbuffers::Verifier verifier(data, length);
 
         if (!Wazuh::SyncSchema::VerifyMessageBuffer(verifier))
@@ -915,12 +994,11 @@ bool AgentSyncProtocol::parseResponseBuffer(const uint8_t* data, size_t length)
             case Wazuh::SyncSchema::MessageType::EndAck:
                 {
                     const auto* endAck = message->content_as_EndAck();
-                    const uint64_t incomingSession = endAck->session();
 
-                    if (!validatePhaseAndSession(SyncPhase::WaitingEndAck, incomingSession))
+                    if (m_syncState.phase != SyncPhase::WaitingResponse)
                     {
-                        m_logger(LOG_DEBUG, "Parsing EndAck, invalid phase or session.");
-                        break;
+                        m_logger(LOG_DEBUG, "Discarded response: protocol is not waiting for a sync answer.");
+                        return true;
                     }
 
                     if (endAck->status() == Wazuh::SyncSchema::Status::Error ||
@@ -953,10 +1031,10 @@ bool AgentSyncProtocol::parseResponseBuffer(const uint8_t* data, size_t length)
                     }
 
                     m_syncState.lastSyncResult = SyncResult::SUCCESS;
-                    m_syncState.endAckReceived = true;
+                    m_syncState.responseReceived = true;
                     m_syncState.cv.notify_all();
 
-                    m_logger(LOG_DEBUG, "EndAck session '" + std::to_string(incomingSession) + "' ended" );
+                    m_logger(LOG_DEBUG, "Sync response received with success status.");
                     break;
                 }
 
@@ -976,22 +1054,36 @@ bool AgentSyncProtocol::parseResponseBuffer(const uint8_t* data, size_t length)
     }
 }
 
-bool AgentSyncProtocol::validatePhaseAndSession(const SyncPhase receivedPhase, const uint64_t incomingSession)
+bool AgentSyncProtocol::applyHttpResultCode(int resultCode)
 {
-    if (m_syncState.phase != receivedPhase)
+    std::lock_guard<std::mutex> lock(m_syncState.mtx);
+
+    if (m_syncState.phase != SyncPhase::WaitingResponse)
     {
-        m_logger(LOG_DEBUG, "Discarded. Received phase '" + std::to_string(static_cast<int>(receivedPhase)) + "' but current phase is '" + std::to_string(static_cast<int>
-                 (m_syncState.phase)) + "'.");
+        m_logger(LOG_DEBUG, "Discarded response code: protocol is not waiting for a sync answer.");
         return false;
     }
 
-    if (m_syncState.session != incomingSession)
+    if (resultCode == 0)
     {
-        m_logger(LOG_DEBUG, "Discarded. Session mismatch. Expected session '" + std::to_string(m_syncState.session) + "' but session received is '" + std::to_string(
-                     incomingSession) + "'.");
-        return false;
+        m_syncState.lastSyncResult = SyncResult::SUCCESS;
+        m_syncState.responseReceived = true;
+        m_syncState.cv.notify_all();
+        return true;
     }
 
+    m_syncState.syncFailed = true;
+
+    if (m_syncState.expectingChecksumResult)
+    {
+        m_syncState.lastSyncResult = SyncResult::CHECKSUM_ERROR;
+    }
+    else
+    {
+        m_syncState.lastSyncResult = SyncResult::PROTOCOL_ERROR;
+    }
+
+    m_syncState.cv.notify_all();
     return true;
 }
 

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -121,37 +121,10 @@ void AgentSyncProtocol::persistDifference(const std::string& id,
     }
 }
 
-void AgentSyncProtocol::persistDifferenceInMemory(const std::string& id,
-                                                  Operation operation,
-                                                  const std::string& index,
-                                                  const std::string& data,
-                                                  uint64_t version)
-{
-    try
-    {
-        PersistedData persistedData;
-        persistedData.seq = 0;  // Will be assigned during synchronization
-        persistedData.id = id;
-        persistedData.index = index;
-        persistedData.data = data;
-        persistedData.operation = operation;
-        persistedData.version = version;
-
-        m_inMemoryData.push_back(std::move(persistedData));
-    }
-    // LCOV_EXCL_START
-    catch (const std::exception& e)
-    {
-        m_logger(LOG_ERROR, std::string("Failed to persist item in memory: ") + e.what());
-    }
-
-    // LCOV_EXCL_STOP
-}
-
 SyncModuleResult AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
 {
     // Validate synchronization mode
-    if (mode != Mode::FULL && mode != Mode::DELTA)
+    if (mode != Mode::DELTA)
     {
         m_logger(LOG_ERROR, "Invalid synchronization mode: " + std::to_string(static_cast<int>(mode)));
         return {false, {}};
@@ -188,131 +161,7 @@ SyncModuleResult AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
 
     clearSyncState();
 
-    if (mode == Mode::DELTA)
-    {
-        return synchronizeDeltaByBlocks(option);
-    }
-
-    // For FULL mode, use in-memory data for recovery scenarios.
-    // Non-VD flows are byte-capped so the HTTP transport receives a bounded payload.
-    // VD flows (VDFIRST / VDSYNC) are deliberately uncapped.
-    std::vector<PersistedData> dataToSync;
-    {
-        const bool uncapped = isUncappedSyncOption(option);
-        const size_t fetchMaxBytes =
-            uncapped
-            ? 0
-            : (FULLSESSION_MAX_BYTES > FULLSESSION_PREFILTER_GRACE_BYTES
-               ? FULLSESSION_MAX_BYTES - FULLSESSION_PREFILTER_GRACE_BYTES
-               : FULLSESSION_MAX_BYTES);
-
-        if (uncapped || fetchMaxBytes == 0)
-        {
-            dataToSync = m_inMemoryData;
-        }
-        else
-        {
-            size_t estimatedBytes = 0;
-
-            for (const auto& item : m_inMemoryData)
-            {
-                const size_t est = item.id.size() + item.index.size() + item.data.size() + 512U;
-
-                if (!dataToSync.empty() && estimatedBytes + est > fetchMaxBytes)
-                {
-                    break;
-                }
-
-                if (dataToSync.empty() && estimatedBytes + est > fetchMaxBytes)
-                {
-                    m_logger(LOG_WARNING,
-                             "FULL mode: single item (~" + std::to_string(est) +
-                             " B) exceeds byte cap (" + std::to_string(fetchMaxBytes) +
-                             " B); sending it alone.");
-                }
-
-                estimatedBytes += est;
-                dataToSync.push_back(item);
-            }
-
-            if (dataToSync.size() < m_inMemoryData.size())
-            {
-                m_logger(LOG_WARNING,
-                         "FULL mode: payload truncated from " +
-                         std::to_string(m_inMemoryData.size()) + " to " +
-                         std::to_string(dataToSync.size()) +
-                         " items to stay within byte cap.");
-            }
-        }
-    }
-
-    if (dataToSync.empty())
-    {
-        m_logger(LOG_DEBUG, "No items to synchronize in FULL mode");
-        return {true, {}};
-    }
-
-    // Remember how many items are included so we can trim m_inMemoryData on success.
-    const size_t sentCount = dataToSync.size();
-
-    for (size_t i = 0; i < dataToSync.size(); ++i)
-    {
-        dataToSync[i].seq = i;
-    }
-
-    std::vector<PersistedData> dataValueItems;
-    std::vector<PersistedData> dataContextItems;
-
-    for (auto& item : dataToSync)
-    {
-        if (item.is_data_context)
-        {
-            dataContextItems.push_back(std::move(item));
-        }
-        else
-        {
-            dataValueItems.push_back(std::move(item));
-        }
-    }
-
-    std::set<std::string> uniqueIndicesSet;
-
-    for (const auto& item : dataValueItems)
-    {
-        uniqueIndicesSet.insert(item.index);
-    }
-
-    SessionContent content;
-    content.mode = mode;
-    content.indices.assign(uniqueIndicesSet.begin(), uniqueIndicesSet.end());
-    content.option = option;
-    content.dataValues = std::move(dataValueItems);
-    content.dataContexts = std::move(dataContextItems);
-    const bool success = runSession(content);
-
-    if (success)
-    {
-        m_logger(LOG_DEBUG_VERBOSE, "Synchronization completed successfully.");
-
-        // Erase only the items that were part of this session; any unsent tail
-        // (due to byte-cap truncation) stays in m_inMemoryData for the next cycle.
-        if (sentCount >= m_inMemoryData.size())
-        {
-            m_inMemoryData.clear();
-        }
-        else
-        {
-            m_inMemoryData.erase(m_inMemoryData.begin(),
-                                 m_inMemoryData.begin() + static_cast<ptrdiff_t>(sentCount));
-        }
-    }
-
-    std::string failureReason = determineSyncFailureReasonBasedOnSyncResult(m_syncState.lastSyncResult);
-    const bool stopped = shouldStop();
-    const bool managerNotReady = m_syncState.lastSyncManagerNotReady;
-    const unsigned int consecutiveFailures = trackSyncOutcome(success, stopped);
-    clearSyncState();
-    return {success, failureReason, stopped, managerNotReady, consecutiveFailures};
+    return synchronizeDeltaByBlocks(option);
 }
 
 bool AgentSyncProtocol::isUncappedSyncOption(Option option) const
@@ -511,11 +360,6 @@ bool AgentSyncProtocol::requiresFullSync(const std::string& index,
         clearSyncState();
         return result;
     }
-}
-
-void AgentSyncProtocol::clearInMemoryData()
-{
-    m_inMemoryData.clear();
 }
 
 SyncModuleResult AgentSyncProtocol::synchronizeMetadataOrGroups(Mode mode,
@@ -842,7 +686,6 @@ std::vector<uint8_t> AgentSyncProtocol::buildFullSessionMessage(const SessionCon
                                reinterpret_cast<const int8_t*>(item.data.data()), item.data.size());
 
             Wazuh::SyncSchema::DataValueBuilder dataValueBuilder(builder);
-            dataValueBuilder.add_seq(item.seq);
             dataValueBuilder.add_id(idStr);
             dataValueBuilder.add_index(idxStr);
             dataValueBuilder.add_version(item.version);
@@ -864,7 +707,6 @@ std::vector<uint8_t> AgentSyncProtocol::buildFullSessionMessage(const SessionCon
                                reinterpret_cast<const int8_t*>(item.data.data()), item.data.size());
 
             Wazuh::SyncSchema::DataContextBuilder dataContextBuilder(builder);
-            dataContextBuilder.add_seq(item.seq);
             dataContextBuilder.add_id(idStr);
             dataContextBuilder.add_index(idxStr);
             dataContextBuilder.add_data(dataVec);
@@ -879,23 +721,26 @@ std::vector<uint8_t> AgentSyncProtocol::buildFullSessionMessage(const SessionCon
             auto idxStr = builder.CreateString(item.index);
 
             Wazuh::SyncSchema::DataCleanBuilder dataCleanBuilder(builder);
-            dataCleanBuilder.add_seq(item.seq);
             dataCleanBuilder.add_index(idxStr);
             cleanOffsets.push_back(dataCleanBuilder.Finish());
         }
 
-        std::vector<flatbuffers::Offset<Wazuh::SyncSchema::ChecksumModule>> checksumOffsets;
-        checksumOffsets.reserve(content.checksums.size());
+        // An integrity check always covers a single index/module (see requiresFullSync()),
+        // so content.checksums never holds more than one entry.
+        flatbuffers::Offset<Wazuh::SyncSchema::ChecksumModule> checksumOffset;
+        bool hasChecksum = false;
 
-        for (const auto& entry : content.checksums)
+        if (!content.checksums.empty())
         {
+            const auto& entry = content.checksums.front();
             auto idxStr = builder.CreateString(entry.index);
             auto checksumStr = builder.CreateString(entry.checksum);
 
             Wazuh::SyncSchema::ChecksumModuleBuilder checksumBuilder(builder);
             checksumBuilder.add_index(idxStr);
             checksumBuilder.add_checksum(checksumStr);
-            checksumOffsets.push_back(checksumBuilder.Finish());
+            checksumOffset = checksumBuilder.Finish();
+            hasChecksum = true;
         }
 
         Wazuh::SyncSchema::EndBuilder endBuilder(builder);
@@ -915,13 +760,10 @@ std::vector<uint8_t> AgentSyncProtocol::buildFullSessionMessage(const SessionCon
             payloadOffset = cleansBuilder.Finish().Union();
             payloadType = Wazuh::SyncSchema::SessionPayload::Cleans;
         }
-        else if (!checksumOffsets.empty())
+        else if (hasChecksum)
         {
-            auto itemsVec = builder.CreateVector(checksumOffsets);
-            Wazuh::SyncSchema::ChecksumsBuilder checksumsBuilder(builder);
-            checksumsBuilder.add_items(itemsVec);
-            payloadOffset = checksumsBuilder.Finish().Union();
-            payloadType = Wazuh::SyncSchema::SessionPayload::Checksums;
+            payloadOffset = checksumOffset.Union();
+            payloadType = Wazuh::SyncSchema::SessionPayload::ChecksumModule;
         }
         else if (!valueOffsets.empty() || !contextOffsets.empty())
         {
@@ -1222,7 +1064,6 @@ Wazuh::SyncSchema::Mode AgentSyncProtocol::toProtocolMode(Mode mode) const
 {
     static const std::unordered_map<Mode, Wazuh::SyncSchema::Mode> modeMap =
     {
-        {Mode::FULL, Wazuh::SyncSchema::Mode::ModuleFull},
         {Mode::DELTA, Wazuh::SyncSchema::Mode::ModuleDelta},
         {Mode::CHECK, Wazuh::SyncSchema::Mode::ModuleCheck},
         {Mode::METADATA_DELTA, Wazuh::SyncSchema::Mode::MetadataDelta},

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -334,36 +334,70 @@ bool AgentSyncProtocol::requiresFullSync(const std::string& index,
         return false; // Return false as this is not a checksum error from manager
     }
 
-    clearSyncState();
+#ifdef WAZUH_UNIT_TESTING
+    constexpr auto CHECKSUM_RETRY_DELAY = std::chrono::milliseconds(50);
+#else
+    // The indexer may not have caught up with a recent bulk write yet, so a single
+    // 409 isn't trusted as a genuine mismatch on its own -- see
+    // CHECKSUM_MISMATCH_MAX_ATTEMPTS's doc comment for why this budget exists.
+    constexpr auto CHECKSUM_RETRY_DELAY = std::chrono::seconds(10);
+#endif
 
-    // The integrity check is Start + ChecksumModule + End, now one message.
-    SessionContent content;
-    content.mode = Mode::CHECK;
-    content.indices = {index};
-    content.checksums = {{index, checksum}};
-
-    if (runSession(content))
+    for (unsigned int attempt = 1; attempt <= CHECKSUM_MISMATCH_MAX_ATTEMPTS; ++attempt)
     {
-        m_logger(LOG_DEBUG, "Module integrity check completed successfully for index: " + index);
-        clearSyncState();
-        return false; // Integrity is valid, no sync required
-    }
-    else
-    {
-        // Only return true if manager explicitly reported Status=Error (CHECKSUM_ERROR)
-        // All other errors (communication, timeout, etc.) should return false
-        bool result = (m_syncState.lastSyncResult == SyncResult::CHECKSUM_ERROR);
-
-        std::string message =
-            (m_syncState.lastSyncResult == SyncResult::CHECKSUM_ERROR)
-            ? "Checksum validation failed, full sync required"
-            : "Manager is offline";
-
-        m_logger(LOG_DEBUG, "Module integrity check failed for index: " + index + " - " + message);
+        if (shouldStop())
+        {
+            return false;
+        }
 
         clearSyncState();
-        return result;
+
+        // The integrity check is Start + ChecksumModule, now one message.
+        SessionContent content;
+        content.mode = Mode::CHECK;
+        content.indices = {index};
+        content.checksums = {{index, checksum}};
+
+        if (runSession(content))
+        {
+            m_logger(LOG_DEBUG, "Module integrity check completed successfully for index: " + index +
+                     " (attempt " + std::to_string(attempt) + "/" +
+                     std::to_string(CHECKSUM_MISMATCH_MAX_ATTEMPTS) + ")");
+            clearSyncState();
+            return false; // Integrity is valid, no sync required
+        }
+
+        // Only spend the retry budget on an explicit checksum mismatch (409). Any other
+        // failure (communication error, manager offline, timeout) returns false right
+        // away -- it says nothing about whether the checksum actually matches.
+        const bool isChecksumMismatch = (m_syncState.lastSyncResult == SyncResult::CHECKSUM_ERROR);
+        clearSyncState();
+
+        if (!isChecksumMismatch)
+        {
+            m_logger(LOG_DEBUG, "Module integrity check failed for index: " + index + " - Manager is offline");
+            return false;
+        }
+
+        if (attempt < CHECKSUM_MISMATCH_MAX_ATTEMPTS)
+        {
+            m_logger(LOG_DEBUG, "Checksum mismatch reported by manager for index: " + index +
+                     " (attempt " + std::to_string(attempt) + "/" +
+                     std::to_string(CHECKSUM_MISMATCH_MAX_ATTEMPTS) +
+                     "); the indexer may not have caught up with a recent write yet, retrying.");
+
+            std::unique_lock<std::mutex> lock(m_syncState.mtx);
+            m_syncState.cv.wait_for(lock, CHECKSUM_RETRY_DELAY, [this] { return shouldStop(); });
+        }
+        else
+        {
+            m_logger(LOG_DEBUG, "Checksum validation failed for index: " + index + " after " +
+                     std::to_string(CHECKSUM_MISMATCH_MAX_ATTEMPTS) +
+                     " attempts - full sync required");
+        }
     }
+
+    return true;
 }
 
 SyncModuleResult AgentSyncProtocol::synchronizeMetadataOrGroups(Mode mode,
@@ -496,7 +530,6 @@ bool AgentSyncProtocol::notifyDataClean(const std::vector<std::string>& indices,
 flatbuffers::Offset<Wazuh::SyncSchema::Start> AgentSyncProtocol::waitMetadataAndBuildStart(
     flatbuffers::FlatBufferBuilder& builder,
     Mode mode,
-    size_t dataSize,
     const std::vector<std::string>& uniqueIndices,
     Option option,
     std::optional<uint64_t> globalVersion)
@@ -589,7 +622,6 @@ flatbuffers::Offset<Wazuh::SyncSchema::Start> AgentSyncProtocol::waitMetadataAnd
         Wazuh::SyncSchema::StartBuilder startBuilder(builder);
         startBuilder.add_module_(module);
         startBuilder.add_mode(protocolMode);
-        startBuilder.add_size(static_cast<uint64_t>(dataSize));
         startBuilder.add_index(indices);
 
         // Translate Option enum to Schema Option
@@ -657,16 +689,10 @@ std::vector<uint8_t> AgentSyncProtocol::buildFullSessionMessage(const SessionCon
     {
         flatbuffers::FlatBufferBuilder builder;
 
-        // The size announced in Start counts every item the session carries.
-        const size_t itemCount = content.dataValues.size() +
-                                 content.dataContexts.size() +
-                                 content.dataCleans.size();
-
         // Every nested table has to be finished before the parent builder opens,
         // so Start and all the item vectors are built up front.
         const auto startOffset = waitMetadataAndBuildStart(builder,
                                                            content.mode,
-                                                           itemCount,
                                                            content.indices,
                                                            content.option,
                                                            content.globalVersion);

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -853,16 +853,6 @@ std::vector<uint8_t> AgentSyncProtocol::buildFullSessionMessage(const SessionCon
             valueOffsets.push_back(dataValueBuilder.Finish());
         }
 
-        std::vector<flatbuffers::Offset<Wazuh::SyncSchema::DataBatch>> batchOffsets;
-
-        if (!valueOffsets.empty())
-        {
-            auto valuesVec = builder.CreateVector(valueOffsets);
-            Wazuh::SyncSchema::DataBatchBuilder dataBatchBuilder(builder);
-            dataBatchBuilder.add_values(valuesVec);
-            batchOffsets.push_back(dataBatchBuilder.Finish());
-        }
-
         std::vector<flatbuffers::Offset<Wazuh::SyncSchema::DataContext>> contextOffsets;
         contextOffsets.reserve(content.dataContexts.size());
 
@@ -911,17 +901,48 @@ std::vector<uint8_t> AgentSyncProtocol::buildFullSessionMessage(const SessionCon
         Wazuh::SyncSchema::EndBuilder endBuilder(builder);
         const auto endOffset = endBuilder.Finish();
 
-        auto batchesVec = builder.CreateVector(batchOffsets);
-        auto contextsVec = builder.CreateVector(contextOffsets);
-        auto cleansVec = builder.CreateVector(cleanOffsets);
-        auto checksumsVec = builder.CreateVector(checksumOffsets);
+        // A session carries exactly one of these: a data sync (values and/or
+        // contexts), a clean notification, or a checksum check - never a mix,
+        // so the three go through one union instead of three optional fields.
+        Wazuh::SyncSchema::SessionPayload payloadType = Wazuh::SyncSchema::SessionPayload::NONE;
+        flatbuffers::Offset<void> payloadOffset;
+
+        if (!cleanOffsets.empty())
+        {
+            auto itemsVec = builder.CreateVector(cleanOffsets);
+            Wazuh::SyncSchema::CleansBuilder cleansBuilder(builder);
+            cleansBuilder.add_items(itemsVec);
+            payloadOffset = cleansBuilder.Finish().Union();
+            payloadType = Wazuh::SyncSchema::SessionPayload::Cleans;
+        }
+        else if (!checksumOffsets.empty())
+        {
+            auto itemsVec = builder.CreateVector(checksumOffsets);
+            Wazuh::SyncSchema::ChecksumsBuilder checksumsBuilder(builder);
+            checksumsBuilder.add_items(itemsVec);
+            payloadOffset = checksumsBuilder.Finish().Union();
+            payloadType = Wazuh::SyncSchema::SessionPayload::Checksums;
+        }
+        else if (!valueOffsets.empty() || !contextOffsets.empty())
+        {
+            auto valuesVec = builder.CreateVector(valueOffsets);
+            auto contextsVec = builder.CreateVector(contextOffsets);
+            Wazuh::SyncSchema::SyncDataBuilder syncDataBuilder(builder);
+            syncDataBuilder.add_values(valuesVec);
+            syncDataBuilder.add_contexts(contextsVec);
+            payloadOffset = syncDataBuilder.Finish().Union();
+            payloadType = Wazuh::SyncSchema::SessionPayload::SyncData;
+        }
 
         Wazuh::SyncSchema::FullSessionBuilder fullSessionBuilder(builder);
         fullSessionBuilder.add_start(startOffset);
-        fullSessionBuilder.add_batches(batchesVec);
-        fullSessionBuilder.add_contexts(contextsVec);
-        fullSessionBuilder.add_cleans(cleansVec);
-        fullSessionBuilder.add_checksums(checksumsVec);
+
+        if (payloadType != Wazuh::SyncSchema::SessionPayload::NONE)
+        {
+            fullSessionBuilder.add_payload_type(payloadType);
+            fullSessionBuilder.add_payload(payloadOffset);
+        }
+
         fullSessionBuilder.add_end(endOffset);
         const auto fullSessionOffset = fullSessionBuilder.Finish();
 

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol_c_interface.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol_c_interface.cpp
@@ -11,7 +11,7 @@
 // LCOV_EXCL_START
 extern "C" {
 
-    AgentSyncProtocolHandle* asp_create(const char* module, const char* db_path, asp_logger_t logger, unsigned int timeout, unsigned int retries)
+    AgentSyncProtocolHandle* asp_create(const char* module, const char* db_path, asp_logger_t logger)
     {
         try
         {
@@ -25,8 +25,7 @@ extern "C" {
 
             std::optional<std::string> dbPathOpt = db_path ? std::make_optional(std::string(db_path)) : std::nullopt;
 
-            return reinterpret_cast<AgentSyncProtocolHandle*>(new AgentSyncProtocolWrapper(module, std::move(dbPathOpt), std::move(logger_wrapper),
-                                                                                           std::chrono::seconds(timeout), retries));
+            return reinterpret_cast<AgentSyncProtocolHandle*>(new AgentSyncProtocolWrapper(module, std::move(dbPathOpt), std::move(logger_wrapper)));
         }
         catch (const std::exception& ex)
         {

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol_c_interface.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol_c_interface.cpp
@@ -79,32 +79,6 @@ extern "C" {
         }
     }
 
-    void asp_persist_diff_in_memory(AgentSyncProtocolHandle* handle,
-                                    const char* id,
-                                    Operation_t operation,
-                                    const char* index,
-                                    const char* data,
-                                    uint64_t version)
-    {
-        try
-        {
-            if (!handle || !id || !index || !data) return;
-
-            auto* wrapper = reinterpret_cast<AgentSyncProtocolWrapper*>(handle);
-            wrapper->impl->persistDifferenceInMemory(id,
-                                                     static_cast<Operation>(operation),
-                                                     index, data, version);
-        }
-        catch (const std::exception& ex)
-        {
-            return;
-        }
-        catch (...)
-        {
-            return;
-        }
-    }
-
     SyncModuleResult_t asp_sync_module(AgentSyncProtocolHandle* handle,
                                        Mode_t mode)
     {
@@ -179,25 +153,6 @@ extern "C" {
         catch (...)
         {
             return false;
-        }
-    }
-
-    void asp_clear_in_memory_data(AgentSyncProtocolHandle* handle)
-    {
-        try
-        {
-            if (!handle) return;
-
-            auto* wrapper = reinterpret_cast<AgentSyncProtocolWrapper*>(handle);
-            wrapper->impl->clearInMemoryData();
-        }
-        catch (const std::exception& ex)
-        {
-            return;
-        }
-        catch (...)
-        {
-            return;
         }
     }
 

--- a/src/shared_modules/sync_protocol/src/ipersistent_queue_storage.hpp
+++ b/src/shared_modules/sync_protocol/src/ipersistent_queue_storage.hpp
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <vector>
 #include "ipersistent_queue.hpp"
 
@@ -35,9 +36,10 @@ class IPersistentQueueStorage
         /// @param batch Vector of messages to persist atomically.
         virtual void submitBatch(const std::vector<PersistedData>& batch) = 0;
 
-        /// @brief Fetches a batch of pending messages and marks them as SYNCING.
+        /// @brief Fetches a batch of pending messages up to a byte budget and marks them as SYNCING.
+        /// @param maxBytes Maximum estimated payload size to collect. 0 means no byte cap.
         /// @return A vector of messages now marked as SYNCING.
-        virtual std::vector<PersistedData> fetchAndMarkForSync() = 0;
+        virtual std::vector<PersistedData> fetchAndMarkForSync(size_t maxBytes = 0) = 0;
 
         /// @brief Fetches pending items without marking them for sync.
         /// @param onlyDataValues If true, only returns items with is_data_context=false

--- a/src/shared_modules/sync_protocol/src/persistent_queue.cpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue.cpp
@@ -143,14 +143,14 @@ void PersistentQueue::flushPendingBuffer()
     }
 }
 
-std::vector<PersistedData> PersistentQueue::fetchAndMarkForSync()
+std::vector<PersistedData> PersistentQueue::fetchAndMarkForSync(size_t maxBytes)
 {
     flushPendingBuffer();
 
     try
     {
         std::lock_guard<std::mutex> storageLock(m_storageMutex);
-        return m_storage->fetchAndMarkForSync();
+        return m_storage->fetchAndMarkForSync(maxBytes);
     }
     catch (const std::exception& ex)
     {

--- a/src/shared_modules/sync_protocol/src/persistent_queue.hpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue.hpp
@@ -59,9 +59,10 @@ class PersistentQueue : public IPersistentQueue
                     uint64_t version,
                     bool isDataContext = false) override;
 
-        /// @brief Fetches a batch of pending messages and marks them for synchronization.
+        /// @brief Fetches a batch of pending messages up to a byte budget and marks them for synchronization.
+        /// @param maxBytes Maximum estimated payload size to collect. 0 means no byte cap.
         /// @return A vector of messages now marked as SYNCING.
-        std::vector<PersistedData> fetchAndMarkForSync() override;
+        std::vector<PersistedData> fetchAndMarkForSync(size_t maxBytes = 0) override;
 
         /// @brief Fetches pending items without marking them for sync.
         /// @param onlyDataValues If true, only returns items with is_data_context=false

--- a/src/shared_modules/sync_protocol/src/persistent_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue_storage.cpp
@@ -12,6 +12,20 @@
 #include "logging_helper.hpp"
 #include <filesystem>
 
+namespace
+{
+    constexpr size_t SYNC_BLOCK_ESTIMATED_OVERHEAD_BYTES = 8U * 1024U;
+    constexpr size_t SYNC_ITEM_ESTIMATED_OVERHEAD_BYTES = 512U;
+
+    size_t estimateSerializedItemBytes(const PersistedData& data)
+    {
+        return data.id.size()
+               + data.index.size()
+               + data.data.size()
+               + SYNC_ITEM_ESTIMATED_OVERHEAD_BYTES;
+    }
+} // namespace
+
 PersistentQueueStorage::PersistentQueueStorage(const std::string& dbPath, LoggerFunc logger, std::shared_ptr<IFileSystemWrapper> fileSystemWrapper)
     : m_connection(createOrOpenDatabase(dbPath)),
       m_dbPath(dbPath),
@@ -226,16 +240,17 @@ void PersistentQueueStorage::submitBatch(const std::vector<PersistedData>& batch
     // LCOV_EXCL_STOP
 }
 
-std::vector<PersistedData> PersistentQueueStorage::fetchAndMarkForSync()
+std::vector<PersistedData> PersistentQueueStorage::fetchAndMarkForSync(size_t maxBytes)
 {
     std::vector<PersistedData> result;
     std::vector<int64_t> idsToUpdate;
+    size_t estimatedBytes = SYNC_BLOCK_ESTIMATED_OVERHEAD_BYTES;
 
     m_connection.execute("BEGIN IMMEDIATE TRANSACTION;");
 
     try
     {
-        std::string selectQuery =
+        const std::string selectQuery =
             "SELECT rowid, id, idx, data, operation, version, is_data_context "
             "FROM persistent_queue "
             "WHERE sync_status = ? "
@@ -254,7 +269,19 @@ std::vector<PersistedData> PersistentQueueStorage::fetchAndMarkForSync()
             data.operation = static_cast<Operation>(selectStmt.value<int>(4));
             data.version = static_cast<uint64_t>(selectStmt.value<int64_t>(5));
             data.is_data_context = selectStmt.value<int>(6) != 0;
+            const size_t estimatedItemBytes = estimateSerializedItemBytes(data);
 
+            if (maxBytes > 0 && !result.empty() && estimatedBytes + estimatedItemBytes > maxBytes)
+            {
+                break;
+            }
+
+            if (maxBytes > 0 && result.empty() && estimatedBytes + estimatedItemBytes > maxBytes)
+            {
+                m_logger(LOG_DEBUG, "PersistentQueueStorage: A single pending item exceeds the fetch byte budget; selecting it alone.");
+            }
+
+            estimatedBytes += estimatedItemBytes;
             idsToUpdate.push_back(rowid);
             result.emplace_back(std::move(data));
         }

--- a/src/shared_modules/sync_protocol/src/persistent_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue_storage.cpp
@@ -17,6 +17,9 @@ namespace
     constexpr size_t SYNC_BLOCK_ESTIMATED_OVERHEAD_BYTES = 8U * 1024U;
     constexpr size_t SYNC_ITEM_ESTIMATED_OVERHEAD_BYTES = 512U;
 
+    /// @brief Consecutive cycles a lone oversized item is resent before it is dropped.
+    constexpr unsigned int MAX_OVERSIZED_ATTEMPTS = 5U;
+
     size_t estimateSerializedItemBytes(const PersistedData& data)
     {
         return data.id.size()
@@ -244,6 +247,7 @@ std::vector<PersistedData> PersistentQueueStorage::fetchAndMarkForSync(size_t ma
 {
     std::vector<PersistedData> result;
     std::vector<int64_t> idsToUpdate;
+    std::vector<int64_t> idsToDrop;
     size_t estimatedBytes = SYNC_BLOCK_ESTIMATED_OVERHEAD_BYTES;
 
     m_connection.execute("BEGIN IMMEDIATE TRANSACTION;");
@@ -279,6 +283,34 @@ std::vector<PersistedData> PersistentQueueStorage::fetchAndMarkForSync(size_t ma
                     break;
                 }
 
+                if (data.id == m_oversizedItemId)
+                {
+                    ++m_oversizedItemAttempts;
+                }
+                else
+                {
+                    m_oversizedItemId = data.id;
+                    m_oversizedItemAttempts = 1;
+                }
+
+                if (m_oversizedItemAttempts > MAX_OVERSIZED_ATTEMPTS)
+                {
+                    // This item alone has exceeded the cap for MAX_OVERSIZED_ATTEMPTS
+                    // consecutive cycles: whatever rejected it before will reject it
+                    // again, and every item behind it (rowid ASC) is starved as long as
+                    // it stays PENDING. Drop it instead of resending it forever.
+                    m_logger(LOG_ERROR,
+                             "PersistentQueueStorage: Dropping pending item (~" +
+                             std::to_string(estimatedItemBytes) +
+                             " B) after " + std::to_string(m_oversizedItemAttempts) +
+                             " consecutive cycles alone over the byte cap (" +
+                             std::to_string(maxBytes) + " B); it was blocking every item behind it.");
+                    idsToDrop.push_back(rowid);
+                    m_oversizedItemId.clear();
+                    m_oversizedItemAttempts = 0;
+                    continue;
+                }
+
                 // First item already exceeds the cap. Enforcing the limit here
                 // would leave the item stuck in PENDING forever, so we accept it
                 // once but emit a WARNING so operators can investigate oversized records.
@@ -287,7 +319,16 @@ std::vector<PersistedData> PersistentQueueStorage::fetchAndMarkForSync(size_t ma
                          std::to_string(estimatedItemBytes) +
                          " B) exceeds the byte cap (" +
                          std::to_string(maxBytes) +
-                         " B); sending it alone. Consider reducing individual item size.");
+                         " B); sending it alone (attempt " +
+                         std::to_string(m_oversizedItemAttempts) + "/" +
+                         std::to_string(MAX_OVERSIZED_ATTEMPTS) +
+                         "). Consider reducing individual item size.");
+            }
+            else if (data.id == m_oversizedItemId)
+            {
+                // No longer alone over the cap (e.g. coalesced smaller): clear its streak.
+                m_oversizedItemId.clear();
+                m_oversizedItemAttempts = 0;
             }
 
             estimatedBytes += estimatedItemBytes;
@@ -295,16 +336,39 @@ std::vector<PersistedData> PersistentQueueStorage::fetchAndMarkForSync(size_t ma
             result.emplace_back(std::move(data));
         }
 
+        // SQLite has a limit on the number of parameters in a single query
+        // (typically 999). To handle an unlimited number of ids, both batched
+        // statements below process them in chunks.
+        constexpr size_t BATCH_SIZE = 500;
+
+        for (size_t i = 0; i < idsToDrop.size(); i += BATCH_SIZE)
+        {
+            std::string deleteQuery = "DELETE FROM persistent_queue WHERE rowid IN (";
+
+            size_t batch_end = std::min(i + BATCH_SIZE, idsToDrop.size());
+
+            for (size_t j = i; j < batch_end; ++j)
+            {
+                deleteQuery += (j == i ? "?" : ",?");
+            }
+
+            deleteQuery += ");";
+
+            SQLite3Wrapper::Statement deleteStmt(m_connection, deleteQuery);
+
+            for (size_t j = i; j < batch_end; ++j)
+            {
+                deleteStmt.bind(static_cast<int32_t>((j - i) + 1), idsToDrop[j]);
+            }
+
+            deleteStmt.step();
+        }
+
         if (idsToUpdate.empty())
         {
             m_connection.execute("COMMIT;");
             return result;
         }
-
-        // SQLite has a limit on the number of parameters in a single query
-        // (typically 999). To handle an unlimited number of pending items,
-        // we process the UPDATE statement in batches.
-        constexpr size_t BATCH_SIZE = 500;
 
         for (size_t i = 0; i < idsToUpdate.size(); i += BATCH_SIZE)
         {

--- a/src/shared_modules/sync_protocol/src/persistent_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue_storage.cpp
@@ -271,14 +271,23 @@ std::vector<PersistedData> PersistentQueueStorage::fetchAndMarkForSync(size_t ma
             data.is_data_context = selectStmt.value<int>(6) != 0;
             const size_t estimatedItemBytes = estimateSerializedItemBytes(data);
 
-            if (maxBytes > 0 && !result.empty() && estimatedBytes + estimatedItemBytes > maxBytes)
+            if (maxBytes > 0 && estimatedBytes + estimatedItemBytes > maxBytes)
             {
-                break;
-            }
+                if (!result.empty())
+                {
+                    // Normal budget exhaustion: stop before adding this item.
+                    break;
+                }
 
-            if (maxBytes > 0 && result.empty() && estimatedBytes + estimatedItemBytes > maxBytes)
-            {
-                m_logger(LOG_DEBUG, "PersistentQueueStorage: A single pending item exceeds the fetch byte budget; selecting it alone.");
+                // First item already exceeds the cap. Enforcing the limit here
+                // would leave the item stuck in PENDING forever, so we accept it
+                // once but emit a WARNING so operators can investigate oversized records.
+                m_logger(LOG_WARNING,
+                         "PersistentQueueStorage: A single pending item (~" +
+                         std::to_string(estimatedItemBytes) +
+                         " B) exceeds the byte cap (" +
+                         std::to_string(maxBytes) +
+                         " B); sending it alone. Consider reducing individual item size.");
             }
 
             estimatedBytes += estimatedItemBytes;

--- a/src/shared_modules/sync_protocol/src/persistent_queue_storage.hpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue_storage.hpp
@@ -58,9 +58,10 @@ class PersistentQueueStorage : public IPersistentQueueStorage
         /// @param batch Vector of messages to persist atomically.
         void submitBatch(const std::vector<PersistedData>& batch) override;
 
-        /// @brief Fetches a batch of pending messages and marks them as SYNCING.
+        /// @brief Fetches a batch of pending messages up to a byte budget and marks them as SYNCING.
+        /// @param maxBytes Maximum estimated payload size to collect. 0 means no byte cap.
         /// @return A vector of messages now marked as SYNCING.
-        std::vector<PersistedData> fetchAndMarkForSync() override;
+        std::vector<PersistedData> fetchAndMarkForSync(size_t maxBytes = 0) override;
 
         /// @brief Fetches pending items without marking them for sync.
         /// @param onlyDataValues If true, only returns items with is_data_context=false

--- a/src/shared_modules/sync_protocol/src/persistent_queue_storage.hpp
+++ b/src/shared_modules/sync_protocol/src/persistent_queue_storage.hpp
@@ -98,6 +98,16 @@ class PersistentQueueStorage : public IPersistentQueueStorage
         /// @brief Filesystem wrapper for operations
         std::shared_ptr<IFileSystemWrapper> m_fileSystemWrapper;
 
+        /// @brief Id of the pending item currently stuck as a lone oversized block, if any.
+        std::string m_oversizedItemId;
+
+        /// @brief Consecutive fetchAndMarkForSync() calls in which m_oversizedItemId was
+        ///        resent alone because it exceeds the byte cap on its own. Reset once a
+        ///        different item takes its place. Past MAX_OVERSIZED_ATTEMPTS the item is
+        ///        dropped instead of resent, so a size it can never fit into cannot block
+        ///        every item behind it forever.
+        unsigned int m_oversizedItemAttempts = 0;
+
         /// @brief Creates the persistent_queue table if it doesn't already exist.
         void createTableIfNotExists();
 

--- a/src/shared_modules/sync_protocol/tests/mocks/mock_agent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/tests/mocks/mock_agent_sync_protocol.hpp
@@ -15,16 +15,9 @@ class MockAgentSyncProtocol : public IAgentSyncProtocol
                     (const std::string& id, Operation operation, const std::string& index, const std::string& data, uint64_t version, bool isDataContext),
                     (override));
 
-        MOCK_METHOD(void,
-                    persistDifferenceInMemory,
-                    (const std::string& id, Operation operation, const std::string& index, const std::string& data, uint64_t version),
-                    (override));
-
         MOCK_METHOD(SyncModuleResult, synchronizeModule, (Mode mode, Option option), (override));
 
         MOCK_METHOD(bool, requiresFullSync, (const std::string& index, const std::string& checksum), (override));
-
-        MOCK_METHOD(void, clearInMemoryData, (), (override));
 
         MOCK_METHOD(SyncModuleResult, synchronizeMetadataOrGroups, (Mode mode, const std::vector<std::string>& indices, uint64_t globalVersion), (override));
 

--- a/src/shared_modules/sync_protocol/tests/mocks/mock_sync_transport.hpp
+++ b/src/shared_modules/sync_protocol/tests/mocks/mock_sync_transport.hpp
@@ -126,21 +126,20 @@ inline const Wazuh::SyncSchema::FullSession* capturedSession(
     return message ? message->content_as<Wazuh::SyncSchema::FullSession>() : nullptr;
 }
 
-/// @brief How many DataValue entries the session carried, across every batch.
-inline int countedDataValues(const Wazuh::SyncSchema::FullSession* session)
+/// @brief The session's SyncData payload, or nullptr if it carries something else.
+inline const Wazuh::SyncSchema::SyncData* syncData(const Wazuh::SyncSchema::FullSession* session)
 {
-    int total = 0;
-
-    if (session && session->batches())
+    if (session && session->payload_type() == Wazuh::SyncSchema::SessionPayload::SyncData)
     {
-        for (const auto* batch : *session->batches())
-        {
-            if (batch && batch->values())
-            {
-                total += static_cast<int>(batch->values()->size());
-            }
-        }
+        return session->payload_as_SyncData();
     }
 
-    return total;
+    return nullptr;
+}
+
+/// @brief How many DataValue entries the session carried.
+inline int countedDataValues(const Wazuh::SyncSchema::FullSession* session)
+{
+    const auto* data = syncData(session);
+    return (data && data->values()) ? static_cast<int>(data->values()->size()) : 0;
 }

--- a/src/shared_modules/sync_protocol/tests/mocks/mock_sync_transport.hpp
+++ b/src/shared_modules/sync_protocol/tests/mocks/mock_sync_transport.hpp
@@ -103,7 +103,6 @@ inline void answerSession(const std::shared_ptr<MockSyncTransport>& transport,
     flatbuffers::FlatBufferBuilder builder;
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(builder);
     endAckBuilder.add_status(status);
-    endAckBuilder.add_session(transport->session());
     auto endAckOffset = endAckBuilder.Finish();
     auto message = Wazuh::SyncSchema::CreateMessage(
                        builder, Wazuh::SyncSchema::MessageType::EndAck, endAckOffset.Union());

--- a/src/shared_modules/sync_protocol/tests/mocks/mock_sync_transport.hpp
+++ b/src/shared_modules/sync_protocol/tests/mocks/mock_sync_transport.hpp
@@ -89,25 +89,22 @@ class MockSyncTransport : public ISyncSessionTransport
         std::atomic<bool> m_available {true};
 };
 
-/// @brief Answers the session the protocol is waiting on, the way the manager
-///        does: one EndAck carrying the session's own id.
+/// @brief Answers the session the protocol is waiting on, the way the manager does:
+///        one HCRESULT carrying the raw HTTP status code (see
+///        AgentSyncProtocol::applyHttpResult - there is no EndAck FlatBuffer message
+///        anymore). forSession=0 skips the protocol's session-correlation check.
 inline void answerSession(const std::shared_ptr<MockSyncTransport>& transport,
                           const std::function<void(const uint8_t*, size_t)>& feed,
-                          Wazuh::SyncSchema::Status status = Wazuh::SyncSchema::Status::Ok)
+                          int httpCode = 200, uint64_t forSession = 0)
 {
     if (!transport->waitForSession())
     {
         return; // The caller's assertions report the timeout.
     }
 
-    flatbuffers::FlatBufferBuilder builder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(builder);
-    endAckBuilder.add_status(status);
-    auto endAckOffset = endAckBuilder.Finish();
-    auto message = Wazuh::SyncSchema::CreateMessage(
-                       builder, Wazuh::SyncSchema::MessageType::EndAck, endAckOffset.Union());
-    builder.Finish(message);
-    feed(builder.GetBufferPointer(), builder.GetSize());
+    const std::string text = "HCRESULT:" + std::to_string(forSession) + ":" +
+                             std::to_string(httpCode) + ":{}";
+    feed(reinterpret_cast<const uint8_t*>(text.data()), text.size());
 }
 
 /// @brief The FullSession the protocol handed over, for tests that assert on

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -85,6 +85,25 @@ class AgentSyncProtocolTest : public ::testing::Test
             metadata_provider_reset();
         }
 
+        /// Builds the wire format https_client_bridge.c sends for a /stateful outcome:
+        /// "HCRESULT:<session>:<http_code>:<body>". forSession=0 skips the protocol's
+        /// session-correlation check (matching how these tests never cared about it
+        /// before the HTTP-result contract existed).
+        static std::vector<uint8_t> buildHcResult(int httpCode, const std::string& body = "{}",
+                                                  uint64_t forSession = 0)
+        {
+            const std::string text = "HCRESULT:" + std::to_string(forSession) + ":" +
+                                     std::to_string(httpCode) + ":" + body;
+            return std::vector<uint8_t>(text.begin(), text.end());
+        }
+
+        /// Feeds a /stateful HTTP result to the protocol, as https_client_bridge.c would.
+        bool feedHttpResult(int httpCode, const std::string& body = "{}", uint64_t forSession = 0)
+        {
+            const auto buf = buildHcResult(httpCode, body, forSession);
+            return protocol->parseResponseBuffer(buf.data(), buf.size());
+        }
+
         std::shared_ptr<MockPersistentQueue> mockQueue;
         std::shared_ptr<MockSyncTransport> mockSyncTransport =
             std::make_shared<MockSyncTransport>();
@@ -344,16 +363,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleOfflineEndAckReportsManagerNotRea
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
 
     // EndAck with Offline status
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Offline);
-    auto endAckOffset = endAckBuilder.Finish();
-    auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                          endBuilder,
-                          Wazuh::SyncSchema::MessageType::EndAck,
-                          endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-    protocol->parseResponseBuffer(endBuilder.GetBufferPointer(), endBuilder.GetSize());
+    feedHttpResult(503);  // was Status::Offline
 
     syncThread.join();
 
@@ -465,16 +475,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSuccessResetsConsecutiveFailures)
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
 
     // EndAck Ok
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    auto endAckOffset = endAckBuilder.Finish();
-    auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                          endBuilder,
-                          Wazuh::SyncSchema::MessageType::EndAck,
-                          endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-    protocol->parseResponseBuffer(endBuilder.GetBufferPointer(), endBuilder.GetSize());
+    feedHttpResult(200);  // was Status::Ok
 
     syncThread.join();
 
@@ -730,16 +731,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleDeltaStopsAfterTenBlocks)
             {
                 lastSendCount = currentSendCount;
 
-                flatbuffers::FlatBufferBuilder endBuilder;
-                Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-                endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-                auto endAckOffset = endAckBuilder.Finish();
-                auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                                      endBuilder,
-                                      Wazuh::SyncSchema::MessageType::EndAck,
-                                      endAckOffset.Union());
-                endBuilder.Finish(endMessage);
-                protocol->parseResponseBuffer(endBuilder.GetBufferPointer(), endBuilder.GetSize());
+                feedHttpResult(200);  // was Status::Ok
                 ++handled;
                 continue;
             }
@@ -799,16 +791,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleDeltaUsesBytePrefilterBudgetForSy
 
     EXPECT_TRUE(mockSyncTransport->waitForSession());
 
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    auto endAckOffset = endAckBuilder.Finish();
-    auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                          endBuilder,
-                          Wazuh::SyncSchema::MessageType::EndAck,
-                          endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-    protocol->parseResponseBuffer(endBuilder.GetBufferPointer(), endBuilder.GetSize());
+    feedHttpResult(200);  // was Status::Ok
 
     syncThread.join();
     EXPECT_TRUE(result.success);
@@ -854,16 +837,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleDeltaBypassesBytePrefilterBudgetF
 
         EXPECT_GT(mockSyncTransport->sendCount(), sendCountBefore);
 
-        flatbuffers::FlatBufferBuilder endBuilder;
-        Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-        endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-        auto endAckOffset = endAckBuilder.Finish();
-        auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                              endBuilder,
-                              Wazuh::SyncSchema::MessageType::EndAck,
-                              endAckOffset.Union());
-        endBuilder.Finish(endMessage);
-        protocol->parseResponseBuffer(endBuilder.GetBufferPointer(), endBuilder.GetSize());
+        feedHttpResult(200);  // was Status::Ok
 
         syncThread.join();
         EXPECT_TRUE(result.success);
@@ -899,16 +873,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleDeltaAllowsOversizedRealPayloadWh
     });
 
     EXPECT_TRUE(mockSyncTransport->waitForSession());
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    auto endAckOffset = endAckBuilder.Finish();
-    auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                          endBuilder,
-                          Wazuh::SyncSchema::MessageType::EndAck,
-                          endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-    protocol->parseResponseBuffer(endBuilder.GetBufferPointer(), endBuilder.GetSize());
+    feedHttpResult(200);  // was Status::Ok
 
     syncThread.join();
 
@@ -958,16 +923,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleDeltaAbortsRemainingBlocksAfterSe
                 lastSendCount = currentSendCount;
                 ++handled;
 
-                flatbuffers::FlatBufferBuilder endBuilder;
-                Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-                endAckBuilder.add_status(handled == 1 ? Wazuh::SyncSchema::Status::Ok : Wazuh::SyncSchema::Status::Error);
-                auto endAckOffset = endAckBuilder.Finish();
-                auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                                      endBuilder,
-                                      Wazuh::SyncSchema::MessageType::EndAck,
-                                      endAckOffset.Union());
-                endBuilder.Finish(endMessage);
-                protocol->parseResponseBuffer(endBuilder.GetBufferPointer(), endBuilder.GetSize());
+                feedHttpResult(handled == 1 ? 200 : 500);  // was Status::Ok : Status::Error
                 continue;
             }
 
@@ -1078,20 +1034,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleEndFailDueToManager)
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
 
     // EndAck with ERROR status
-    flatbuffers::FlatBufferBuilder endBuilder;
-
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Error); // syncFailed = true
-    auto endAckOffset = endAckBuilder.Finish();
-
-    auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                          endBuilder,
-                          Wazuh::SyncSchema::MessageType::EndAck,
-                          endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-
-    const uint8_t* endBuffer = endBuilder.GetBufferPointer();
-    protocol->parseResponseBuffer(endBuffer, endBuilder.GetSize());
+    feedHttpResult(500);  // was Status::Error
 
     syncThread.join();
 }
@@ -1169,20 +1112,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSuccessWithNoReqRet)
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
 
     // EndAck
-    flatbuffers::FlatBufferBuilder endBuilder;
-
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    auto endAckOffset = endAckBuilder.Finish();
-
-    auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                          endBuilder,
-                          Wazuh::SyncSchema::MessageType::EndAck,
-                          endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-
-    const uint8_t* endBuffer = endBuilder.GetBufferPointer();
-    protocol->parseResponseBuffer(endBuffer, endBuilder.GetSize());
+    feedHttpResult(200);  // was Status::Ok
 
     syncThread.join();
 }
@@ -1232,19 +1162,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleFinalizeSyncStateException)
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
 
     // EndAck
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    auto endAckOffset = endAckBuilder.Finish();
-
-    auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                          endBuilder,
-                          Wazuh::SyncSchema::MessageType::EndAck,
-                          endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-
-    const uint8_t* endBuffer = endBuilder.GetBufferPointer();
-    protocol->parseResponseBuffer(endBuffer, endBuilder.GetSize());
+    feedHttpResult(200);  // was Status::Ok
 
     syncThread.join();
 
@@ -1307,20 +1225,7 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWhenNotWaitingForEndAck)
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
     protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
-    flatbuffers::FlatBufferBuilder builder;
-
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(builder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    auto endAckOffset = endAckBuilder.Finish();
-
-    auto message = Wazuh::SyncSchema::CreateMessage(
-                       builder,
-                       Wazuh::SyncSchema::MessageType::EndAck,
-                       endAckOffset.Union());
-    builder.Finish(message);
-
-    const uint8_t* buffer = builder.GetBufferPointer();
-    bool response = protocol->parseResponseBuffer(buffer, builder.GetSize());
+    bool response = feedHttpResult(200);  // was Status::Ok
 
     EXPECT_TRUE(response);
 }
@@ -1357,27 +1262,14 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckError)
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
 
     // EndAck with ERROR status
-    flatbuffers::FlatBufferBuilder endBuilder;
-
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Error); // Status Error
-    auto endAckOffset = endAckBuilder.Finish();
-
-    auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                          endBuilder,
-                          Wazuh::SyncSchema::MessageType::EndAck,
-                          endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-
-    const uint8_t* endBuffer = endBuilder.GetBufferPointer();
-    bool response = protocol->parseResponseBuffer(endBuffer, endBuilder.GetSize());
+    bool response = feedHttpResult(500);  // was Status::Error
 
     EXPECT_TRUE(response);
 
     syncThread.join();
 
     // Transient manager-reported failures must be debug, not error (issue #36724).
-    logCapture.expectDebugNotError("Received EndAck with Error status");
+    logCapture.expectDebugNotError("Manager reported a protocol error (500)");
     logCapture.expectDebugNotError("Synchronization failed: Manager reported an error status.");
 }
 
@@ -1413,27 +1305,14 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckOffline)
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
 
     // EndAck with OFFLINE status
-    flatbuffers::FlatBufferBuilder endBuilder;
-
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Offline); // Status Offline
-    auto endAckOffset = endAckBuilder.Finish();
-
-    auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                          endBuilder,
-                          Wazuh::SyncSchema::MessageType::EndAck,
-                          endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-
-    const uint8_t* endBuffer = endBuilder.GetBufferPointer();
-    bool response = protocol->parseResponseBuffer(endBuffer, endBuilder.GetSize());
+    bool response = feedHttpResult(503);  // was Status::Offline
 
     EXPECT_TRUE(response);
 
     syncThread.join();
 
     // Offline EndAck is the same transient class: debug, not error (issue #36724).
-    logCapture.expectDebugNotError("Received EndAck with Offline status");
+    logCapture.expectDebugNotError("Manager reported not ready (503)");
 }
 
 TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckSuccess)
@@ -1468,20 +1347,7 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckSuccess)
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
 
     // EndAck with OK status
-    flatbuffers::FlatBufferBuilder endBuilder;
-
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok); // Status Ok
-    auto endAckOffset = endAckBuilder.Finish();
-
-    auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                          endBuilder,
-                          Wazuh::SyncSchema::MessageType::EndAck,
-                          endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-
-    const uint8_t* endBuffer = endBuilder.GetBufferPointer();
-    bool response = protocol->parseResponseBuffer(endBuffer, endBuilder.GetSize());
+    bool response = feedHttpResult(200);  // was Status::Ok
 
     EXPECT_TRUE(response);
 
@@ -1539,19 +1405,7 @@ TEST_F(AgentSyncProtocolTest, RequiresFullSyncWithMatchingChecksum)
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
 
     // EndAck with matching checksum (Status::Ok)
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    auto endAckOffset = endAckBuilder.Finish();
-
-    auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                          endBuilder,
-                          Wazuh::SyncSchema::MessageType::EndAck,
-                          endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-
-    const uint8_t* endBuffer = endBuilder.GetBufferPointer();
-    protocol->parseResponseBuffer(endBuffer, endBuilder.GetSize());
+    feedHttpResult(200);  // was Status::Ok
 
     syncThread.join();
 }
@@ -1588,19 +1442,7 @@ TEST_F(AgentSyncProtocolTest, RequiresFullSyncWithNonMatchingChecksum)
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
 
     // EndAck with non-matching checksum (Status::ChecksumMismatch indicates mismatch)
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::ChecksumMismatch);
-    auto endAckOffset = endAckBuilder.Finish();
-
-    auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                          endBuilder,
-                          Wazuh::SyncSchema::MessageType::EndAck,
-                          endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-
-    const uint8_t* endBuffer = endBuilder.GetBufferPointer();
-    protocol->parseResponseBuffer(endBuffer, endBuilder.GetSize());
+    feedHttpResult(409);  // was Status::ChecksumMismatch
 
     syncThread.join();
 }
@@ -1689,19 +1531,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithMetadataDeltaMode)
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
 
     // EndAck
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    auto endAckOffset = endAckBuilder.Finish();
-
-    auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                          endBuilder,
-                          Wazuh::SyncSchema::MessageType::EndAck,
-                          endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-
-    const uint8_t* endBuffer = endBuilder.GetBufferPointer();
-    protocol->parseResponseBuffer(endBuffer, endBuilder.GetSize());
+    feedHttpResult(200);  // was Status::Ok
 
     syncThread.join();
 }
@@ -1737,19 +1567,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithMetadataCheckMode)
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
 
     // EndAck
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    auto endAckOffset = endAckBuilder.Finish();
-
-    auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                          endBuilder,
-                          Wazuh::SyncSchema::MessageType::EndAck,
-                          endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-
-    const uint8_t* endBuffer = endBuilder.GetBufferPointer();
-    protocol->parseResponseBuffer(endBuffer, endBuilder.GetSize());
+    feedHttpResult(200);  // was Status::Ok
 
     syncThread.join();
 }
@@ -1785,19 +1603,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithGroupDeltaMode)
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
 
     // EndAck
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    auto endAckOffset = endAckBuilder.Finish();
-
-    auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                          endBuilder,
-                          Wazuh::SyncSchema::MessageType::EndAck,
-                          endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-
-    const uint8_t* endBuffer = endBuilder.GetBufferPointer();
-    protocol->parseResponseBuffer(endBuffer, endBuilder.GetSize());
+    feedHttpResult(200);  // was Status::Ok
 
     syncThread.join();
 }
@@ -1833,19 +1639,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithGroupCheckMode)
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
 
     // EndAck
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    auto endAckOffset = endAckBuilder.Finish();
-
-    auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                          endBuilder,
-                          Wazuh::SyncSchema::MessageType::EndAck,
-                          endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-
-    const uint8_t* endBuffer = endBuilder.GetBufferPointer();
-    protocol->parseResponseBuffer(endBuffer, endBuilder.GetSize());
+    feedHttpResult(200);  // was Status::Ok
 
     syncThread.join();
 }
@@ -1962,19 +1756,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithEndAckError)
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
 
     // EndAck with Error status
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Error);
-    auto endAckOffset = endAckBuilder.Finish();
-
-    auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                          endBuilder,
-                          Wazuh::SyncSchema::MessageType::EndAck,
-                          endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-
-    const uint8_t* endBuffer = endBuilder.GetBufferPointer();
-    protocol->parseResponseBuffer(endBuffer, endBuilder.GetSize());
+    feedHttpResult(500);  // was Status::Error
 
     syncThread.join();
 }
@@ -2169,19 +1951,7 @@ TEST_F(AgentSyncProtocolTest, NotifyDataCleanEndAckError)
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
 
     // Send EndAck with ERROR status
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Error);
-    auto endAckOffset = endAckBuilder.Finish();
-
-    auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                          endBuilder,
-                          Wazuh::SyncSchema::MessageType::EndAck,
-                          endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-
-    const uint8_t* endBuffer = endBuilder.GetBufferPointer();
-    protocol->parseResponseBuffer(endBuffer, endBuilder.GetSize());
+    feedHttpResult(500);  // was Status::Error
 
     syncThread.join();
 }
@@ -2213,19 +1983,7 @@ TEST_F(AgentSyncProtocolTest, NotifyDataCleanClearItemsByIndexThrows)
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
 
     // Send EndAck with OK status
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    auto endAckOffset = endAckBuilder.Finish();
-
-    auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                          endBuilder,
-                          Wazuh::SyncSchema::MessageType::EndAck,
-                          endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-
-    const uint8_t* endBuffer = endBuilder.GetBufferPointer();
-    protocol->parseResponseBuffer(endBuffer, endBuilder.GetSize());
+    feedHttpResult(200);  // was Status::Ok
 
     syncThread.join();
 }
@@ -2257,19 +2015,7 @@ TEST_F(AgentSyncProtocolTest, NotifyDataCleanSuccessWithSingleIndex)
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
 
     // Send EndAck with OK status
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    auto endAckOffset = endAckBuilder.Finish();
-
-    auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                          endBuilder,
-                          Wazuh::SyncSchema::MessageType::EndAck,
-                          endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-
-    const uint8_t* endBuffer = endBuilder.GetBufferPointer();
-    protocol->parseResponseBuffer(endBuffer, endBuilder.GetSize());
+    feedHttpResult(200);  // was Status::Ok
 
     syncThread.join();
 }
@@ -2305,19 +2051,7 @@ TEST_F(AgentSyncProtocolTest, NotifyDataCleanSuccessWithMultipleIndices)
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
 
     // Send EndAck with OK status
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    auto endAckOffset = endAckBuilder.Finish();
-
-    auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                          endBuilder,
-                          Wazuh::SyncSchema::MessageType::EndAck,
-                          endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-
-    const uint8_t* endBuffer = endBuilder.GetBufferPointer();
-    protocol->parseResponseBuffer(endBuffer, endBuilder.GetSize());
+    feedHttpResult(200);  // was Status::Ok
 
     syncThread.join();
 }
@@ -2441,17 +2175,7 @@ TEST_F(AgentSyncProtocolTest, NotifyDataCleanLogsErrorWithoutQueue)
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
 
     // Send EndAck with OK status
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    auto endAckOffset = endAckBuilder.Finish();
-
-    auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                          endBuilder, Wazuh::SyncSchema::MessageType::EndAck, endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-
-    const uint8_t* endBuffer = endBuilder.GetBufferPointer();
-    protocol->parseResponseBuffer(endBuffer, endBuilder.GetSize());
+    feedHttpResult(200);  // was Status::Ok
 
     syncThread.join();
 
@@ -2527,18 +2251,76 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckChecksumMismatch)
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
 
     // EndAck with ChecksumMismatch status
-    flatbuffers::FlatBufferBuilder endBuilder2;
+    bool response = feedHttpResult(409);  // was Status::ChecksumMismatch
 
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder2(endBuilder2);
-    endAckBuilder2.add_status(Wazuh::SyncSchema::Status::ChecksumMismatch); // Status ChecksumMismatch
-    auto endAckOffset2 = endAckBuilder2.Finish();
+    EXPECT_TRUE(response);
 
-    auto endMessage2 =
-        Wazuh::SyncSchema::CreateMessage(endBuilder2, Wazuh::SyncSchema::MessageType::EndAck, endAckOffset2.Union());
-    endBuilder2.Finish(endMessage2);
+    syncThread.join();
+}
 
-    const uint8_t* endBuffer2 = endBuilder2.GetBufferPointer();
-    bool response = protocol->parseResponseBuffer(endBuffer2, endBuilder2.GetSize());
+// 413: the manager rejected the session as larger than its total in-flight budget
+// (see the D2 HTTP contract). New behavior - never existed as an EndAck status.
+TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithPayloadTooLarge)
+{
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&)
+    {
+    };
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
+
+    std::thread syncThread(
+        [this]()
+    {
+        std::vector<PersistedData> testData =
+        {
+            {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
+        };
+
+        EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) ).WillOnce(Return(testData));
+
+        SyncModuleResult syncResult = protocol->synchronizeModule(Mode::DELTA);
+        EXPECT_FALSE(syncResult.success);
+        EXPECT_FALSE(syncResult.managerNotReady) << "413 is not a manager-not-ready condition";
+        EXPECT_NE(syncResult.failureReason.find("too large"), std::string::npos);
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+
+    bool response = feedHttpResult(413, R"({"error":"session exceeds max_inflight_bytes","code":413})");
+
+    EXPECT_TRUE(response);
+
+    syncThread.join();
+}
+
+// httpCode 0: no HTTP response at all (timeout/connect/TLS failure/abort) - treated
+// like a 503, since the transport layer already exhausted its own retries.
+TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithNoHttpResponse)
+{
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&)
+    {
+    };
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
+
+    std::thread syncThread(
+        [this]()
+    {
+        std::vector<PersistedData> testData =
+        {
+            {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
+        };
+
+        EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) ).WillOnce(Return(testData));
+
+        SyncModuleResult syncResult = protocol->synchronizeModule(Mode::DELTA);
+        EXPECT_FALSE(syncResult.success);
+        EXPECT_TRUE(syncResult.managerNotReady);
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+
+    bool response = feedHttpResult(0, "");
 
     EXPECT_TRUE(response);
 
@@ -2577,18 +2359,7 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckGenericError)
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
 
     // EndAck with Error status (which should map to GENERIC_ERROR)
-    flatbuffers::FlatBufferBuilder endBuilder;
-
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Error); // Status Error
-    auto endAckOffset = endAckBuilder.Finish();
-
-    auto endMessage =
-        Wazuh::SyncSchema::CreateMessage(endBuilder, Wazuh::SyncSchema::MessageType::EndAck, endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-
-    const uint8_t* endBuffer = endBuilder.GetBufferPointer();
-    bool response = protocol->parseResponseBuffer(endBuffer, endBuilder.GetSize());
+    bool response = feedHttpResult(500);  // was Status::Error
 
     EXPECT_TRUE(response);
 
@@ -3278,173 +3049,6 @@ TEST_F(AgentSyncProtocolTest, VDWorkflow_FetchOnlyDataValues)
 
 // Verifies that EndAck{Processing} is correctly parsed and the sync continues waiting.
 // After Processing, the protocol must accept a subsequent EndAck{Ok} and complete.
-TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckProcessing)
-{
-    mockQueue = std::make_shared<MockPersistentQueue>();
-    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
-
-    std::vector<PersistedData> testData =
-    {
-        {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1},
-    };
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) ).WillOnce(Return(testData))
-    .WillRepeatedly(Return(std::vector<PersistedData> {}));
-    EXPECT_CALL(*mockQueue, clearSyncedItems()).Times(1);
-
-    std::thread syncThread([this]()
-    {
-        SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
-        EXPECT_TRUE(result.success);
-    });
-
-    // StartAck
-    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
-    {
-    }
-
-    // EndAck{Processing}: parseResponseBuffer must return true and sync must not terminate
-    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
-    {
-        flatbuffers::FlatBufferBuilder builder;
-        Wazuh::SyncSchema::EndAckBuilder endAckBuilder(builder);
-        endAckBuilder.add_status(Wazuh::SyncSchema::Status::Processing);
-        auto offset = endAckBuilder.Finish();
-        builder.Finish(Wazuh::SyncSchema::CreateMessage(builder, Wazuh::SyncSchema::MessageType::EndAck, offset.Union()));
-        bool response = protocol->parseResponseBuffer(builder.GetBufferPointer(), builder.GetSize());
-        EXPECT_TRUE(response);
-    }
-
-    // EndAck{Ok}: sync must complete successfully
-    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
-    {
-        flatbuffers::FlatBufferBuilder builder;
-        Wazuh::SyncSchema::EndAckBuilder endAckBuilder(builder);
-        endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-        auto offset = endAckBuilder.Finish();
-        builder.Finish(Wazuh::SyncSchema::CreateMessage(builder, Wazuh::SyncSchema::MessageType::EndAck, offset.Union()));
-        protocol->parseResponseBuffer(builder.GetBufferPointer(), builder.GetSize());
-    }
-
-    syncThread.join();
-}
-
-// Verifies the main VD-scanner-slow scenario:
-// manager responds Processing to End (session enqueued, scanner running),
-// then sends EndAck{Ok} when processing completes. Sync must succeed.
-TEST_F(AgentSyncProtocolTest, SynchronizeModuleProcessingAckThenEndAckSuccess)
-{
-    mockQueue = std::make_shared<MockPersistentQueue>();
-    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
-
-    std::vector<PersistedData> testData =
-    {
-        {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1},
-        {0, "test_id_2", "test_index_2", "test_data_2", Operation::MODIFY, 2},
-    };
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) ).WillOnce(Return(testData))
-    .WillRepeatedly(Return(std::vector<PersistedData> {}));
-    EXPECT_CALL(*mockQueue, clearSyncedItems()).Times(1);
-
-    std::thread syncThread([this]()
-    {
-        SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
-        EXPECT_TRUE(result.success);
-    });
-
-    // StartAck
-    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
-    {
-    }
-
-    // EndAck{Processing}: manager received End and started processing
-    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
-    {
-        flatbuffers::FlatBufferBuilder builder;
-        Wazuh::SyncSchema::EndAckBuilder endAckBuilder(builder);
-        endAckBuilder.add_status(Wazuh::SyncSchema::Status::Processing);
-        auto offset = endAckBuilder.Finish();
-        builder.Finish(Wazuh::SyncSchema::CreateMessage(builder, Wazuh::SyncSchema::MessageType::EndAck, offset.Union()));
-        protocol->parseResponseBuffer(builder.GetBufferPointer(), builder.GetSize());
-    }
-
-    // EndAck{Ok}: manager finished processing
-    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
-    {
-        flatbuffers::FlatBufferBuilder builder;
-        Wazuh::SyncSchema::EndAckBuilder endAckBuilder(builder);
-        endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-        auto offset = endAckBuilder.Finish();
-        builder.Finish(Wazuh::SyncSchema::CreateMessage(builder, Wazuh::SyncSchema::MessageType::EndAck, offset.Union()));
-        protocol->parseResponseBuffer(builder.GetBufferPointer(), builder.GetSize());
-    }
-
-    syncThread.join();
-}
-
-// Verifies that EndAck{Processing} does not consume a retry slot.
-//
-// With retries=0 (single End attempt allowed), the only way to succeed is if
-// the post-Processing timeout does NOT increment the attempt counter (sentEnd=false).
-// Without the sentEnd guard, attempt would reach 1 > 0 and the sync would fail
-// before EndAck{Ok} arrives.
-//
-// Flow: End → Processing → timeout (sentEnd=false → no attempt++) → End → EndAck{Ok} → success
-TEST_F(AgentSyncProtocolTest, SynchronizeModuleProcessingAckDoesNotConsumeRetry)
-{
-    mockQueue = std::make_shared<MockPersistentQueue>();
-    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    // retries=0: only one End attempt. A timeout after Processing must not consume it.
-    const unsigned int retries_zero = 0;
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
-
-    std::vector<PersistedData> testData =
-    {
-        {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1},
-    };
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) ).WillOnce(Return(testData))
-    .WillRepeatedly(Return(std::vector<PersistedData> {}));
-    EXPECT_CALL(*mockQueue, clearSyncedItems()).Times(1);
-
-    std::thread syncThread([this]()
-    {
-        SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
-        EXPECT_TRUE(result.success);
-    });
-
-    // StartAck
-    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
-    {
-    }
-
-    // EndAck{Processing}: manager received End (session enqueued, scanner running)
-    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
-    {
-        flatbuffers::FlatBufferBuilder builder;
-        Wazuh::SyncSchema::EndAckBuilder endAckBuilder(builder);
-        endAckBuilder.add_status(Wazuh::SyncSchema::Status::Processing);
-        auto offset = endAckBuilder.Finish();
-        builder.Finish(Wazuh::SyncSchema::CreateMessage(builder, Wazuh::SyncSchema::MessageType::EndAck, offset.Union()));
-        protocol->parseResponseBuffer(builder.GetBufferPointer(), builder.GetSize());
-    }
-
-    // Wait for the post-Processing timeout (min_timeout=1s) to expire plus a buffer,
-    // then inject EndAck{Ok} while the agent is waiting on the re-sent End.
-    // If the fix is absent, the loop would have exited (attempt > 0) before this point.
-    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
-    {
-        flatbuffers::FlatBufferBuilder builder;
-        Wazuh::SyncSchema::EndAckBuilder endAckBuilder(builder);
-        endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-        auto offset = endAckBuilder.Finish();
-        builder.Finish(Wazuh::SyncSchema::CreateMessage(builder, Wazuh::SyncSchema::MessageType::EndAck, offset.Union()));
-        protocol->parseResponseBuffer(builder.GetBufferPointer(), builder.GetSize());
-    }
-
-    syncThread.join();
-}
-
 namespace
 {
     std::mutex END_RETRY_TEST_MTX;
@@ -3545,12 +3149,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleConcurrentCallIsSkippedAndDoesNot
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
     {
-        flatbuffers::FlatBufferBuilder builder;
-        Wazuh::SyncSchema::EndAckBuilder endAckBuilder(builder);
-        endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-        auto offset = endAckBuilder.Finish();
-        builder.Finish(Wazuh::SyncSchema::CreateMessage(builder, Wazuh::SyncSchema::MessageType::EndAck, offset.Union()));
-        protocol->parseResponseBuffer(builder.GetBufferPointer(), builder.GetSize());
+        feedHttpResult(200);  // was Status::Ok
     }
 
     syncThread.join();

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -18,6 +18,7 @@
 #include "metadata_provider.h"
 
 #include <future>
+#include <atomic>
 #include <mutex>
 #include <optional>
 #include <thread>
@@ -38,7 +39,7 @@ class MockPersistentQueue : public IPersistentQueue
                                    Operation operation,
                                    uint64_t version,
                                    bool isDataContext), (override));
-        MOCK_METHOD(std::vector<PersistedData>, fetchAndMarkForSync, (), (override));
+        MOCK_METHOD(std::vector<PersistedData>, fetchAndMarkForSync, (size_t maxItems), (override));
         MOCK_METHOD(std::vector<PersistedData>, fetchPendingItems, (bool onlyDataValues), (override));
         MOCK_METHOD(void, clearSyncedItems, (), (override));
         MOCK_METHOD(void, resetSyncingItems, (), (override));
@@ -247,7 +248,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleFetchAndMarkForSyncThrowsExceptio
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
     protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
 
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .WillOnce(::testing::Throw(std::runtime_error("Test exception")));
 
     SyncModuleResult result = protocol->synchronizeModule(
@@ -263,7 +264,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleDataToSyncEmpty)
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
     protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
 
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .WillOnce(Return(std::vector<PersistedData> {}));
 
     SyncModuleResult result = protocol->synchronizeModule(
@@ -281,7 +282,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleFullModeWithEmptyInMemoryData)
     protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
 
     // Expect NO calls to fetchAndMarkForSync since FULL mode uses in-memory data
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .Times(0);
 
     SyncModuleResult result = protocol->synchronizeModule(
@@ -302,7 +303,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleFullModeWithInMemoryData)
     protocol->persistDifferenceInMemory("memory_id_2", Operation::MODIFY, "memory_index_2", "memory_data_2", 2);
 
     // Expect NO calls to fetchAndMarkForSync since FULL mode uses in-memory data
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .Times(0);
 
     // Expect NO calls to clearSyncedItems or resetSyncingItems since FULL mode clears in-memory data
@@ -331,7 +332,6 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleFullModeWithInMemoryData)
     flatbuffers::FlatBufferBuilder endBuilder;
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
 
     auto endMessage = Wazuh::SyncSchema::CreateMessage(
@@ -356,7 +356,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleFullModeFailureKeepsInMemoryData)
     protocol->persistDifferenceInMemory("memory_id_1", Operation::CREATE, "memory_index_1", "memory_data_1", 1);
 
     // Expect NO calls to database methods since FULL mode uses in-memory data
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .Times(0);
     EXPECT_CALL(*mockQueue, resetSyncingItems())
     .Times(0);
@@ -367,7 +367,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleFullModeFailureKeepsInMemoryData)
                               );
 
     EXPECT_FALSE(result.success);  // Should fail due to timeout
-    EXPECT_EQ(result.failureReason, "Timed out waiting for manager response to End message.");
+    EXPECT_EQ(result.failureReason, "Timed out waiting for manager response.");
     // The manager did not answer the handshake.
     EXPECT_TRUE(result.managerNotReady);
     // First failure of the streak: the module reports it at INFO and retries.
@@ -392,7 +392,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleCountsConsecutiveFailures)
                                                    mockQueue,
                                                    mockSyncTransport);
 
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .Times(0);
     EXPECT_CALL(*mockQueue, resetSyncingItems())
     .Times(0);
@@ -434,7 +434,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleOfflineStartAckReportsManagerNotR
         {
             {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
         };
-        EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+        EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
         .WillOnce(Return(testData));
 
         result = protocol->synchronizeModule(Mode::DELTA);
@@ -465,7 +465,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleOfflineEndAckReportsManagerNotRea
         {
             {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
         };
-        EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+        EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
         .WillOnce(Return(testData));
 
         result = protocol->synchronizeModule(Mode::DELTA);
@@ -481,7 +481,6 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleOfflineEndAckReportsManagerNotRea
     flatbuffers::FlatBufferBuilder endBuilder;
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Offline);
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
     auto endMessage = Wazuh::SyncSchema::CreateMessage(
                           endBuilder,
@@ -512,7 +511,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleEndTimeoutReportsManagerNotReady)
         {
             {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
         };
-        EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+        EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
         .WillOnce(Return(testData));
 
         result = protocol->synchronizeModule(Mode::DELTA);
@@ -585,7 +584,6 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSuccessResetsConsecutiveFailures)
     flatbuffers::FlatBufferBuilder endBuilder;
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
     auto endMessage = Wazuh::SyncSchema::CreateMessage(
                           endBuilder,
@@ -607,7 +605,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleInvalidModeValidation)
     protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
 
     // Expect NO calls to any queue methods since validation should fail early
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .Times(0);
     EXPECT_CALL(*mockQueue, clearSyncedItems())
     .Times(0);
@@ -638,7 +636,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSendSessionFails)
         {0, "test_id_2", "test_index_2", "test_data_2", Operation::MODIFY, 2}
     };
 
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .WillOnce(Return(testData));
 
     EXPECT_CALL(*mockQueue, resetSyncingItems())
@@ -649,7 +647,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSendSessionFails)
                               );
 
     EXPECT_FALSE(result.success);
-    EXPECT_EQ(result.failureReason, "Timed out waiting for manager response to End message.");
+    EXPECT_EQ(result.failureReason, "Timed out waiting for manager response.");
 }
 
 TEST_F(AgentSyncProtocolTest, SendStartWaitsUntilMetadataAvailable)
@@ -754,7 +752,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSessionTimeout)
         {0, "test_id_2", "test_index_2", "test_data_2", Operation::MODIFY, 2}
     };
 
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .WillOnce(Return(testData));
 
     EXPECT_CALL(*mockQueue, resetSyncingItems())
@@ -765,7 +763,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSessionTimeout)
                               );
 
     EXPECT_FALSE(result.success);
-    EXPECT_EQ(result.failureReason, "Timed out waiting for manager response to End message.");
+    EXPECT_EQ(result.failureReason, "Timed out waiting for manager response.");
 }
 
 TEST_F(AgentSyncProtocolTest, SynchronizeModuleSendDataMessagesFails)
@@ -784,7 +782,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSendDataMessagesFails)
         {0, "test_id_2", "test_index_2", "test_data_2", Operation::MODIFY, 2}
     };
 
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .WillOnce(Return(testData));
 
     EXPECT_CALL(*mockQueue, resetSyncingItems())
@@ -806,6 +804,322 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSendDataMessagesFails)
     syncThread.join();
 }
 
+TEST_F(AgentSyncProtocolTest, SynchronizeModuleDeltaStopsAfterTenBlocks)
+{
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger,
+                                                   std::chrono::seconds(max_timeout),
+                                                   retries, mockQueue, mockSyncTransport);
+
+    std::vector<PersistedData> testData =
+    {
+        {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
+    };
+
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
+    .Times(10)
+    .WillRepeatedly(Return(testData));
+    EXPECT_CALL(*mockQueue, clearSyncedItems())
+    .Times(10);
+    EXPECT_CALL(*mockQueue, resetSyncingItems())
+    .Times(0);
+
+    std::atomic<bool> syncDone{false};
+    auto syncFuture = std::async(std::launch::async, [this, &syncDone]()
+    {
+        auto result = protocol->synchronizeModule(Mode::DELTA);
+        syncDone.store(true, std::memory_order_release);
+        return result;
+    });
+
+    std::thread ackThread([this, &syncDone]()
+    {
+        int handled = 0;
+        int lastSendCount = 0;
+
+        while (handled < 10)
+        {
+            const int currentSendCount = mockSyncTransport->sendCount();
+
+            if (currentSendCount > lastSendCount)
+            {
+                lastSendCount = currentSendCount;
+
+                flatbuffers::FlatBufferBuilder endBuilder;
+                Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
+                endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
+                auto endAckOffset = endAckBuilder.Finish();
+                auto endMessage = Wazuh::SyncSchema::CreateMessage(
+                                      endBuilder,
+                                      Wazuh::SyncSchema::MessageType::EndAck,
+                                      endAckOffset.Union());
+                endBuilder.Finish(endMessage);
+                protocol->parseResponseBuffer(endBuilder.GetBufferPointer(), endBuilder.GetSize());
+                ++handled;
+                continue;
+            }
+
+            if (syncDone.load(std::memory_order_acquire) && currentSendCount == lastSendCount)
+            {
+                break;
+            }
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    });
+
+    if (syncFuture.wait_for(std::chrono::seconds(10)) == std::future_status::timeout)
+    {
+        syncDone.store(true, std::memory_order_release);
+        ackThread.join();
+        FAIL() << "Sync thread did not finish in time; block limit may be broken";
+    }
+
+    const SyncModuleResult result = syncFuture.get();
+    syncDone.store(true, std::memory_order_release);
+    ackThread.join();
+
+    EXPECT_TRUE(result.success);
+    EXPECT_EQ(mockSyncTransport->sendCount(), 10);
+}
+
+TEST_F(AgentSyncProtocolTest, SynchronizeModuleDeltaUsesBytePrefilterBudgetForSyncOption)
+{
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger,
+                                                   std::chrono::seconds(max_timeout),
+                                                   retries, mockQueue, mockSyncTransport);
+
+    constexpr size_t FULLSESSION_MAX_BYTES = 5U * 1024U * 1024U;
+    constexpr size_t FULLSESSION_PREFILTER_GRACE_BYTES = 64U * 1024U;
+    constexpr size_t EXPECTED_BUDGET = FULLSESSION_MAX_BYTES - FULLSESSION_PREFILTER_GRACE_BYTES;
+
+    std::vector<PersistedData> testData =
+    {
+        {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
+    };
+
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(EXPECTED_BUDGET))
+    .WillOnce(Return(testData))
+    .WillOnce(Return(std::vector<PersistedData> {}));
+    EXPECT_CALL(*mockQueue, clearSyncedItems())
+    .Times(1);
+    EXPECT_CALL(*mockQueue, resetSyncingItems())
+    .Times(0);
+
+    SyncModuleResult result;
+    std::thread syncThread([this, &result]()
+    {
+        result = protocol->synchronizeModule(Mode::DELTA, Option::SYNC);
+    });
+
+    EXPECT_TRUE(mockSyncTransport->waitForSession());
+
+    flatbuffers::FlatBufferBuilder endBuilder;
+    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
+    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
+    auto endAckOffset = endAckBuilder.Finish();
+    auto endMessage = Wazuh::SyncSchema::CreateMessage(
+                          endBuilder,
+                          Wazuh::SyncSchema::MessageType::EndAck,
+                          endAckOffset.Union());
+    endBuilder.Finish(endMessage);
+    protocol->parseResponseBuffer(endBuilder.GetBufferPointer(), endBuilder.GetSize());
+
+    syncThread.join();
+    EXPECT_TRUE(result.success);
+}
+
+TEST_F(AgentSyncProtocolTest, SynchronizeModuleDeltaBypassesBytePrefilterBudgetForVDOptions)
+{
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger,
+                                                   std::chrono::seconds(max_timeout),
+                                                   retries, mockQueue, mockSyncTransport);
+
+    std::vector<PersistedData> testData =
+    {
+        {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
+    };
+
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(0))
+    .WillOnce(Return(testData))
+    .WillOnce(Return(std::vector<PersistedData> {}))
+    .WillOnce(Return(testData))
+    .WillOnce(Return(std::vector<PersistedData> {}));
+    EXPECT_CALL(*mockQueue, clearSyncedItems())
+    .Times(2);
+    EXPECT_CALL(*mockQueue, resetSyncingItems())
+    .Times(0);
+
+    auto runAndAck = [this](Option option)
+    {
+        SyncModuleResult result;
+        const int sendCountBefore = mockSyncTransport->sendCount();
+        std::thread syncThread([this, option, &result]()
+        {
+            result = protocol->synchronizeModule(Mode::DELTA, option);
+        });
+
+        auto waitDeadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+
+        while (mockSyncTransport->sendCount() <= sendCountBefore &&
+                std::chrono::steady_clock::now() < waitDeadline)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+
+        EXPECT_GT(mockSyncTransport->sendCount(), sendCountBefore);
+
+        flatbuffers::FlatBufferBuilder endBuilder;
+        Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
+        endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
+        auto endAckOffset = endAckBuilder.Finish();
+        auto endMessage = Wazuh::SyncSchema::CreateMessage(
+                              endBuilder,
+                              Wazuh::SyncSchema::MessageType::EndAck,
+                              endAckOffset.Union());
+        endBuilder.Finish(endMessage);
+        protocol->parseResponseBuffer(endBuilder.GetBufferPointer(), endBuilder.GetSize());
+
+        syncThread.join();
+        EXPECT_TRUE(result.success);
+    };
+
+    runAndAck(Option::VDFIRST);
+    runAndAck(Option::VDSYNC);
+}
+
+TEST_F(AgentSyncProtocolTest, SynchronizeModuleDeltaAllowsOversizedRealPayloadWhenPrefilterSelectedIt)
+{
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger,
+                                                   std::chrono::seconds(max_timeout),
+                                                   retries, mockQueue, mockSyncTransport);
+
+    std::vector<PersistedData> oversizedBlock =
+    {
+        {0, "test_id_1", "test_index_1", std::string(6U * 1024U * 1024U, 'x'), Operation::CREATE, 1}
+    };
+
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_))
+    .WillOnce(Return(oversizedBlock))
+    .WillOnce(Return(std::vector<PersistedData> {}));
+    EXPECT_CALL(*mockQueue, resetSyncingItems())
+    .Times(0);
+    EXPECT_CALL(*mockQueue, clearSyncedItems())
+    .Times(1);
+
+    SyncModuleResult result;
+    std::thread syncThread([this, &result]()
+    {
+        result = protocol->synchronizeModule(Mode::DELTA, Option::SYNC);
+    });
+
+    EXPECT_TRUE(mockSyncTransport->waitForSession());
+    flatbuffers::FlatBufferBuilder endBuilder;
+    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
+    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
+    auto endAckOffset = endAckBuilder.Finish();
+    auto endMessage = Wazuh::SyncSchema::CreateMessage(
+                          endBuilder,
+                          Wazuh::SyncSchema::MessageType::EndAck,
+                          endAckOffset.Union());
+    endBuilder.Finish(endMessage);
+    protocol->parseResponseBuffer(endBuilder.GetBufferPointer(), endBuilder.GetSize());
+
+    syncThread.join();
+
+    EXPECT_TRUE(result.success);
+    EXPECT_EQ(mockSyncTransport->sendCount(), 1);
+}
+
+TEST_F(AgentSyncProtocolTest, SynchronizeModuleDeltaAbortsRemainingBlocksAfterSecondBlockFailure)
+{
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger,
+                                                   std::chrono::seconds(max_timeout),
+                                                   retries, mockQueue, mockSyncTransport);
+
+    std::vector<PersistedData> testData =
+    {
+        {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
+    };
+
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_))
+    .Times(2)
+    .WillOnce(Return(testData))
+    .WillOnce(Return(testData));
+    EXPECT_CALL(*mockQueue, clearSyncedItems())
+    .Times(1);
+    EXPECT_CALL(*mockQueue, resetSyncingItems())
+    .Times(1);
+
+    std::atomic<bool> syncDone{false};
+    auto syncFuture = std::async(std::launch::async, [this, &syncDone]()
+    {
+        auto result = protocol->synchronizeModule(Mode::DELTA, Option::SYNC);
+        syncDone.store(true, std::memory_order_release);
+        return result;
+    });
+
+    std::thread ackThread([this, &syncDone]()
+    {
+        int handled = 0;
+        int lastSendCount = 0;
+
+        while (handled < 2)
+        {
+            const int currentSendCount = mockSyncTransport->sendCount();
+
+            if (currentSendCount > lastSendCount)
+            {
+                lastSendCount = currentSendCount;
+                ++handled;
+
+                flatbuffers::FlatBufferBuilder endBuilder;
+                Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
+                endAckBuilder.add_status(handled == 1 ? Wazuh::SyncSchema::Status::Ok : Wazuh::SyncSchema::Status::Error);
+                auto endAckOffset = endAckBuilder.Finish();
+                auto endMessage = Wazuh::SyncSchema::CreateMessage(
+                                      endBuilder,
+                                      Wazuh::SyncSchema::MessageType::EndAck,
+                                      endAckOffset.Union());
+                endBuilder.Finish(endMessage);
+                protocol->parseResponseBuffer(endBuilder.GetBufferPointer(), endBuilder.GetSize());
+                continue;
+            }
+
+            if (syncDone.load(std::memory_order_acquire) && currentSendCount == lastSendCount)
+            {
+                break;
+            }
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    });
+
+    if (syncFuture.wait_for(std::chrono::seconds(10)) == std::future_status::timeout)
+    {
+        syncDone.store(true, std::memory_order_release);
+        ackThread.join();
+        FAIL() << "Sync thread did not finish in time while validating block-failure abort behavior";
+    }
+
+    const SyncModuleResult result = syncFuture.get();
+    syncDone.store(true, std::memory_order_release);
+    ackThread.join();
+
+    EXPECT_FALSE(result.success);
+    EXPECT_EQ(result.failureReason, "Manager reported synchronization failure.");
+    EXPECT_EQ(mockSyncTransport->sendCount(), 2);
+}
+
 TEST_F(AgentSyncProtocolTest, SynchronizeModuleStopWakesEndAckWait)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
@@ -819,7 +1133,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleStopWakesEndAckWait)
         {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
     };
 
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .WillOnce(Return(testData));
 
     EXPECT_CALL(*mockQueue, resetSyncingItems())
@@ -866,7 +1180,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleEndFailDueToManager)
         {0, "test_id_2", "test_index_2", "test_data_2", Operation::MODIFY, 2}
     };
 
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .WillOnce(Return(testData));
 
     EXPECT_CALL(*mockQueue, resetSyncingItems())
@@ -879,7 +1193,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleEndFailDueToManager)
                                       Mode::DELTA
                                   );
         EXPECT_FALSE(result.success);
-        EXPECT_EQ(result.failureReason, "Manager sent an unexpected or invalid response.");
+        EXPECT_EQ(result.failureReason, "Manager reported synchronization failure.");
     });
 
     EXPECT_TRUE(mockSyncTransport->waitForSession());
@@ -894,7 +1208,6 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleEndFailDueToManager)
 
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Error); // syncFailed = true
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
 
     auto endMessage = Wazuh::SyncSchema::CreateMessage(
@@ -922,7 +1235,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleEndAckTimeout)
         {0, "test_id_2", "test_index_2", "test_data_2", Operation::MODIFY, 2}
     };
 
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .WillOnce(Return(testData));
 
     EXPECT_CALL(*mockQueue, resetSyncingItems())
@@ -935,7 +1248,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleEndAckTimeout)
                                       Mode::DELTA
                                   );
         EXPECT_FALSE(result.success);
-        EXPECT_EQ(result.failureReason, "Timed out waiting for manager response to End message.");
+        EXPECT_EQ(result.failureReason, "Timed out waiting for manager response.");
     });
 
     EXPECT_TRUE(mockSyncTransport->waitForSession());
@@ -958,8 +1271,9 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSuccessWithNoReqRet)
         {0, "test_id_2", "test_index_2", "test_data_2", Operation::MODIFY, 2}
     };
 
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
-    .WillOnce(Return(testData));
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
+    .WillOnce(Return(testData))
+    .WillRepeatedly(Return(std::vector<PersistedData>{}));
 
     EXPECT_CALL(*mockQueue, clearSyncedItems())
     .Times(1);
@@ -985,7 +1299,6 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSuccessWithNoReqRet)
 
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
 
     auto endMessage = Wazuh::SyncSchema::CreateMessage(
@@ -1013,8 +1326,9 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSuccessWithReqRet)
         {0, "test_id_2", "test_index_2", "test_data_2", Operation::MODIFY, 2}
     };
 
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
-    .WillOnce(Return(testData));
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
+    .WillOnce(Return(testData))
+    .WillRepeatedly(Return(std::vector<PersistedData>{}));
 
     EXPECT_CALL(*mockQueue, clearSyncedItems())
     .Times(1);
@@ -1047,7 +1361,6 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSuccessWithReqRet)
     auto seqRangesVector = reqRetBuilder.CreateVector(seqRanges);
 
     Wazuh::SyncSchema::ReqRetBuilder reqRetBuilderObj(reqRetBuilder);
-    reqRetBuilderObj.add_session(session);
     reqRetBuilderObj.add_seq(seqRangesVector);
     auto reqRetOffset = reqRetBuilderObj.Finish();
 
@@ -1068,7 +1381,6 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSuccessWithReqRet)
 
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
 
     auto endMessage = Wazuh::SyncSchema::CreateMessage(
@@ -1091,7 +1403,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleFinalizeSyncStateException)
     std::string loggedMessage;
     LoggerFunc testLogger = [&loggedMessage](modules_log_level_t level, const std::string & message)
     {
-        if (level == LOG_ERROR && message.find("Failed to finalize sync state") != std::string::npos)
+        if (level == LOG_ERROR && message.find("Failed to finalize DELTA sync block") != std::string::npos)
         {
             loggedMessage = message;
         }
@@ -1106,7 +1418,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleFinalizeSyncStateException)
     };
 
     // Set up mock expectations for successful sync until the finalization phase
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .WillOnce(testing::Return(testData));
 
     // The clearSyncedItems call will throw an exception
@@ -1117,7 +1429,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleFinalizeSyncStateException)
     std::thread syncThread([this]()
     {
         SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
-        EXPECT_TRUE(result.success); // Should still return true despite the exception in finalization
+        EXPECT_FALSE(result.success); // Finalization failed and must abort the DELTA cycle
     });
 
     EXPECT_TRUE(mockSyncTransport->waitForSession());
@@ -1131,7 +1443,6 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleFinalizeSyncStateException)
     flatbuffers::FlatBufferBuilder endBuilder;
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
 
     auto endMessage = Wazuh::SyncSchema::CreateMessage(
@@ -1146,7 +1457,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleFinalizeSyncStateException)
     syncThread.join();
 
     // Verify that the error was logged
-    EXPECT_TRUE(loggedMessage.find("Failed to finalize sync state") != std::string::npos);
+    EXPECT_TRUE(loggedMessage.find("Failed to finalize DELTA sync block") != std::string::npos);
     EXPECT_TRUE(loggedMessage.find("Simulated clearSyncedItems exception") != std::string::npos);
 }
 
@@ -1208,7 +1519,6 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWhenNotWaitingForEndAck)
 
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(builder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
 
     auto message = Wazuh::SyncSchema::CreateMessage(
@@ -1238,7 +1548,7 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckError)
             {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
         };
 
-        EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+        EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
         .WillOnce(Return(testData));
 
         protocol->synchronizeModule(
@@ -1259,7 +1569,6 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckError)
 
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Error); // Status Error
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
 
     auto endMessage = Wazuh::SyncSchema::CreateMessage(
@@ -1295,7 +1604,7 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckOffline)
             {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
         };
 
-        EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+        EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
         .WillOnce(Return(testData));
 
         protocol->synchronizeModule(
@@ -1316,7 +1625,6 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckOffline)
 
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Offline); // Status Offline
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
 
     auto endMessage = Wazuh::SyncSchema::CreateMessage(
@@ -1350,8 +1658,9 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckSuccess)
             {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
         };
 
-        EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
-        .WillOnce(Return(testData));
+        EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
+        .WillOnce(Return(testData))
+        .WillRepeatedly(Return(std::vector<PersistedData>{}));
 
         protocol->synchronizeModule(
             Mode::DELTA
@@ -1371,7 +1680,6 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckSuccess)
 
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok); // Status Ok
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
 
     auto endMessage = Wazuh::SyncSchema::CreateMessage(
@@ -1417,7 +1725,7 @@ TEST_F(AgentSyncProtocolTest, RequiresFullSyncWithMatchingChecksum)
     const std::string testChecksum = "matching_checksum";
 
     // Expect NO calls to database methods since no data needs to be sent
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .Times(0);
 
     // Start requiresFullSync in a separate thread
@@ -1442,7 +1750,6 @@ TEST_F(AgentSyncProtocolTest, RequiresFullSyncWithMatchingChecksum)
     flatbuffers::FlatBufferBuilder endBuilder;
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
 
     auto endMessage = Wazuh::SyncSchema::CreateMessage(
@@ -1467,7 +1774,7 @@ TEST_F(AgentSyncProtocolTest, RequiresFullSyncWithNonMatchingChecksum)
     const std::string testChecksum = "non_matching_checksum";
 
     // Expect NO calls to database methods since no data needs to be sent
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .Times(0);
 
     // Start requiresFullSync in a separate thread
@@ -1492,7 +1799,6 @@ TEST_F(AgentSyncProtocolTest, RequiresFullSyncWithNonMatchingChecksum)
     flatbuffers::FlatBufferBuilder endBuilder;
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::ChecksumMismatch);
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
 
     auto endMessage = Wazuh::SyncSchema::CreateMessage(
@@ -1600,7 +1906,7 @@ TEST_F(AgentSyncProtocolTest, ClearInMemoryDataAfterFailedFullSync)
     protocol->persistDifferenceInMemory("memory_id_2", Operation::MODIFY, "memory_index_2", "memory_data_2", 2);
 
     // Expect NO calls to database methods since FULL mode uses in-memory data
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .Times(0);
     EXPECT_CALL(*mockQueue, resetSyncingItems())
     .Times(0);
@@ -1611,7 +1917,7 @@ TEST_F(AgentSyncProtocolTest, ClearInMemoryDataAfterFailedFullSync)
                               );
 
     EXPECT_FALSE(result.success);  // Should fail due to timeout
-    EXPECT_EQ(result.failureReason, "Timed out waiting for manager response to End message.");
+    EXPECT_EQ(result.failureReason, "Timed out waiting for manager response.");
 
     // Clear in-memory data after failed sync
     EXPECT_NO_THROW(protocol->clearInMemoryData());
@@ -1651,7 +1957,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithMetadataDeltaMode)
     protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
 
     // Expect NO calls to fetchAndMarkForSync since metadata/groups mode doesn't send data items
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .Times(0);
 
     // Start synchronizeMetadataOrGroups in a separate thread
@@ -1678,7 +1984,6 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithMetadataDeltaMode)
     flatbuffers::FlatBufferBuilder endBuilder;
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
 
     auto endMessage = Wazuh::SyncSchema::CreateMessage(
@@ -1700,7 +2005,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithMetadataCheckMode)
     protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
 
     // Expect NO calls to fetchAndMarkForSync since metadata/groups mode doesn't send data items
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .Times(0);
 
     // Start synchronizeMetadataOrGroups in a separate thread
@@ -1727,7 +2032,6 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithMetadataCheckMode)
     flatbuffers::FlatBufferBuilder endBuilder;
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
 
     auto endMessage = Wazuh::SyncSchema::CreateMessage(
@@ -1749,7 +2053,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithGroupDeltaMode)
     protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
 
     // Expect NO calls to fetchAndMarkForSync since metadata/groups mode doesn't send data items
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .Times(0);
 
     // Start synchronizeMetadataOrGroups in a separate thread
@@ -1776,7 +2080,6 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithGroupDeltaMode)
     flatbuffers::FlatBufferBuilder endBuilder;
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
 
     auto endMessage = Wazuh::SyncSchema::CreateMessage(
@@ -1798,7 +2101,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithGroupCheckMode)
     protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
 
     // Expect NO calls to fetchAndMarkForSync since metadata/groups mode doesn't send data items
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .Times(0);
 
     // Start synchronizeMetadataOrGroups in a separate thread
@@ -1825,7 +2128,6 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithGroupCheckMode)
     flatbuffers::FlatBufferBuilder endBuilder;
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
 
     auto endMessage = Wazuh::SyncSchema::CreateMessage(
@@ -1895,7 +2197,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsSessionTimeout)
                               );
 
     EXPECT_FALSE(result.success);
-    EXPECT_EQ(result.failureReason, "Timed out waiting for manager response to End message.");
+    EXPECT_EQ(result.failureReason, "Timed out waiting for manager response.");
 }
 
 TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsEndAckTimeout)
@@ -1914,7 +2216,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsEndAckTimeout)
                                       12345 // globalVersion
                                   );
         EXPECT_FALSE(result.success);
-        EXPECT_EQ(result.failureReason, "Timed out waiting for manager response to End message.");
+        EXPECT_EQ(result.failureReason, "Timed out waiting for manager response.");
     });
 
     // Wait for start message
@@ -1957,7 +2259,6 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithEndAckError)
     flatbuffers::FlatBufferBuilder endBuilder;
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Error);
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
 
     auto endMessage = Wazuh::SyncSchema::CreateMessage(
@@ -2169,7 +2470,6 @@ TEST_F(AgentSyncProtocolTest, NotifyDataCleanEndAckError)
     flatbuffers::FlatBufferBuilder endBuilder;
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Error);
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
 
     auto endMessage = Wazuh::SyncSchema::CreateMessage(
@@ -2214,7 +2514,6 @@ TEST_F(AgentSyncProtocolTest, NotifyDataCleanClearItemsByIndexThrows)
     flatbuffers::FlatBufferBuilder endBuilder;
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
 
     auto endMessage = Wazuh::SyncSchema::CreateMessage(
@@ -2259,7 +2558,6 @@ TEST_F(AgentSyncProtocolTest, NotifyDataCleanSuccessWithSingleIndex)
     flatbuffers::FlatBufferBuilder endBuilder;
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
 
     auto endMessage = Wazuh::SyncSchema::CreateMessage(
@@ -2308,7 +2606,6 @@ TEST_F(AgentSyncProtocolTest, NotifyDataCleanSuccessWithMultipleIndices)
     flatbuffers::FlatBufferBuilder endBuilder;
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
 
     auto endMessage = Wazuh::SyncSchema::CreateMessage(
@@ -2413,7 +2710,7 @@ TEST_F(AgentSyncProtocolTest, DeltaModeSyncLogsErrorWithoutQueue)
 
     EXPECT_FALSE(result.success);
     EXPECT_EQ(loggedLevel, LOG_ERROR);
-    EXPECT_TRUE(loggedMessage.find("Failed to fetch items for sync") != std::string::npos);
+    EXPECT_TRUE(loggedMessage.find("Failed to initialize DELTA sync") != std::string::npos);
     EXPECT_TRUE(loggedMessage.find("requires a persistent queue") != std::string::npos);
 }
 
@@ -2451,7 +2748,6 @@ TEST_F(AgentSyncProtocolTest, NotifyDataCleanLogsErrorWithoutQueue)
     flatbuffers::FlatBufferBuilder endBuilder;
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
 
     auto endMessage = Wazuh::SyncSchema::CreateMessage(
@@ -2528,7 +2824,7 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckChecksumMismatch)
             {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
         };
 
-        EXPECT_CALL(*mockQueue, fetchAndMarkForSync()).WillOnce(Return(testData));
+        EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) ).WillOnce(Return(testData));
 
         SyncModuleResult syncResult = protocol->synchronizeModule(Mode::DELTA);
         EXPECT_FALSE(syncResult.success);
@@ -2547,7 +2843,6 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckChecksumMismatch)
 
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder2(endBuilder2);
     endAckBuilder2.add_status(Wazuh::SyncSchema::Status::ChecksumMismatch); // Status ChecksumMismatch
-    endAckBuilder2.add_session(session);
     auto endAckOffset2 = endAckBuilder2.Finish();
 
     auto endMessage2 =
@@ -2585,7 +2880,7 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckGenericError)
             {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
         };
 
-        EXPECT_CALL(*mockQueue, fetchAndMarkForSync()).WillOnce(Return(testData));
+        EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) ).WillOnce(Return(testData));
 
         SyncModuleResult syncResult = protocol->synchronizeModule(Mode::DELTA);
         EXPECT_FALSE(syncResult.success);
@@ -2604,7 +2899,6 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckGenericError)
 
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Error); // Status Error
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
 
     auto endMessage =
@@ -3440,7 +3734,8 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckProcessing)
     {
         {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1},
     };
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync()).WillOnce(Return(testData));
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) ).WillOnce(Return(testData))
+    .WillRepeatedly(Return(std::vector<PersistedData>{}));
     EXPECT_CALL(*mockQueue, clearSyncedItems()).Times(1);
 
     std::thread syncThread([this]()
@@ -3460,7 +3755,6 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckProcessing)
         flatbuffers::FlatBufferBuilder builder;
         Wazuh::SyncSchema::EndAckBuilder endAckBuilder(builder);
         endAckBuilder.add_status(Wazuh::SyncSchema::Status::Processing);
-        endAckBuilder.add_session(mockSyncTransport->session());
         auto offset = endAckBuilder.Finish();
         builder.Finish(Wazuh::SyncSchema::CreateMessage(builder, Wazuh::SyncSchema::MessageType::EndAck, offset.Union()));
         bool response = protocol->parseResponseBuffer(builder.GetBufferPointer(), builder.GetSize());
@@ -3473,7 +3767,6 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckProcessing)
         flatbuffers::FlatBufferBuilder builder;
         Wazuh::SyncSchema::EndAckBuilder endAckBuilder(builder);
         endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-        endAckBuilder.add_session(mockSyncTransport->session());
         auto offset = endAckBuilder.Finish();
         builder.Finish(Wazuh::SyncSchema::CreateMessage(builder, Wazuh::SyncSchema::MessageType::EndAck, offset.Union()));
         protocol->parseResponseBuffer(builder.GetBufferPointer(), builder.GetSize());
@@ -3497,7 +3790,8 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleProcessingAckThenEndAckSuccess)
         {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1},
         {0, "test_id_2", "test_index_2", "test_data_2", Operation::MODIFY, 2},
     };
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync()).WillOnce(Return(testData));
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) ).WillOnce(Return(testData))
+    .WillRepeatedly(Return(std::vector<PersistedData>{}));
     EXPECT_CALL(*mockQueue, clearSyncedItems()).Times(1);
 
     std::thread syncThread([this]()
@@ -3517,7 +3811,6 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleProcessingAckThenEndAckSuccess)
         flatbuffers::FlatBufferBuilder builder;
         Wazuh::SyncSchema::EndAckBuilder endAckBuilder(builder);
         endAckBuilder.add_status(Wazuh::SyncSchema::Status::Processing);
-        endAckBuilder.add_session(mockSyncTransport->session());
         auto offset = endAckBuilder.Finish();
         builder.Finish(Wazuh::SyncSchema::CreateMessage(builder, Wazuh::SyncSchema::MessageType::EndAck, offset.Union()));
         protocol->parseResponseBuffer(builder.GetBufferPointer(), builder.GetSize());
@@ -3529,7 +3822,6 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleProcessingAckThenEndAckSuccess)
         flatbuffers::FlatBufferBuilder builder;
         Wazuh::SyncSchema::EndAckBuilder endAckBuilder(builder);
         endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-        endAckBuilder.add_session(mockSyncTransport->session());
         auto offset = endAckBuilder.Finish();
         builder.Finish(Wazuh::SyncSchema::CreateMessage(builder, Wazuh::SyncSchema::MessageType::EndAck, offset.Union()));
         protocol->parseResponseBuffer(builder.GetBufferPointer(), builder.GetSize());
@@ -3559,7 +3851,8 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleProcessingAckDoesNotConsumeRetry)
     {
         {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1},
     };
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync()).WillOnce(Return(testData));
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) ).WillOnce(Return(testData))
+    .WillRepeatedly(Return(std::vector<PersistedData>{}));
     EXPECT_CALL(*mockQueue, clearSyncedItems()).Times(1);
 
     std::thread syncThread([this]()
@@ -3579,7 +3872,6 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleProcessingAckDoesNotConsumeRetry)
         flatbuffers::FlatBufferBuilder builder;
         Wazuh::SyncSchema::EndAckBuilder endAckBuilder(builder);
         endAckBuilder.add_status(Wazuh::SyncSchema::Status::Processing);
-        endAckBuilder.add_session(mockSyncTransport->session());
         auto offset = endAckBuilder.Finish();
         builder.Finish(Wazuh::SyncSchema::CreateMessage(builder, Wazuh::SyncSchema::MessageType::EndAck, offset.Union()));
         protocol->parseResponseBuffer(builder.GetBufferPointer(), builder.GetSize());
@@ -3593,7 +3885,6 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleProcessingAckDoesNotConsumeRetry)
         flatbuffers::FlatBufferBuilder builder;
         Wazuh::SyncSchema::EndAckBuilder endAckBuilder(builder);
         endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-        endAckBuilder.add_session(mockSyncTransport->session());
         auto offset = endAckBuilder.Finish();
         builder.Finish(Wazuh::SyncSchema::CreateMessage(builder, Wazuh::SyncSchema::MessageType::EndAck, offset.Union()));
         protocol->parseResponseBuffer(builder.GetBufferPointer(), builder.GetSize());
@@ -3670,7 +3961,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleConcurrentCallIsSkippedAndDoesNot
 
     // First call fetches data and runs a full sync; second concurrent call finds an
     // empty queue (or is blocked by the guard before reaching the queue).
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync())
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .WillOnce(Return(testData))     // first (in-flight) call
     .WillRepeatedly(Return(std::vector<PersistedData> {})); // any subsequent call
     EXPECT_CALL(*mockQueue, clearSyncedItems()).Times(1);
@@ -3706,7 +3997,6 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleConcurrentCallIsSkippedAndDoesNot
         flatbuffers::FlatBufferBuilder builder;
         Wazuh::SyncSchema::EndAckBuilder endAckBuilder(builder);
         endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-        endAckBuilder.add_session(mockSyncTransport->session());
         auto offset = endAckBuilder.Finish();
         builder.Finish(Wazuh::SyncSchema::CreateMessage(builder, Wazuh::SyncSchema::MessageType::EndAck, offset.Union()));
         protocol->parseResponseBuffer(builder.GetBufferPointer(), builder.GetSize());

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -1410,6 +1410,10 @@ TEST_F(AgentSyncProtocolTest, RequiresFullSyncWithMatchingChecksum)
     syncThread.join();
 }
 
+// A single 409 no longer means "full sync required" -- the manager's old internal
+// retry-against-indexer loop moved to the agent (2026-08-04, #38117/#38128), so this
+// now takes CHECKSUM_MISMATCH_MAX_ATTEMPTS (5) consecutive 409s before the agent
+// trusts the mismatch as genuine.
 TEST_F(AgentSyncProtocolTest, RequiresFullSyncWithNonMatchingChecksum)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
@@ -1423,28 +1427,70 @@ TEST_F(AgentSyncProtocolTest, RequiresFullSyncWithNonMatchingChecksum)
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .Times(0);
 
-    // Start requiresFullSync in a separate thread
-    std::thread syncThread([this, &testIndex, &testChecksum]()
+    bool result = false;
+    std::thread syncThread([this, &testIndex, &testChecksum, &result]()
     {
-        bool result = protocol->requiresFullSync(
-                          testIndex,
-                          testChecksum
-                      );
-        EXPECT_TRUE(result);
+        result = protocol->requiresFullSync(testIndex, testChecksum);
     });
 
-    // Wait for start message
-    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+    int handled = 0;
+    int lastSendCount = 0;
 
-    // StartAck
+    while (handled < 5)
+    {
+        const int currentSendCount = mockSyncTransport->sendCount();
 
-    // Wait for checksum message
-    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+        if (currentSendCount > lastSendCount)
+        {
+            lastSendCount = currentSendCount;
+            feedHttpResult(409);  // was Status::ChecksumMismatch
+            ++handled;
+            continue;
+        }
 
-    // EndAck with non-matching checksum (Status::ChecksumMismatch indicates mismatch)
-    feedHttpResult(409);  // was Status::ChecksumMismatch
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
 
     syncThread.join();
+    EXPECT_TRUE(result);
+    EXPECT_EQ(mockSyncTransport->sendCount(), 5);
+}
+
+// The whole point of moving the retry budget to the agent: a checksum mismatch caused
+// by the indexer not having caught up with a recent bulk write yet must resolve on
+// retry, not force a full sync.
+TEST_F(AgentSyncProtocolTest, RequiresFullSyncRecoversAfterTransientMismatch)
+{
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
+
+    const std::string testIndex = "test_index";
+    const std::string testChecksum = "test_checksum";
+
+    bool result = true;
+    std::thread syncThread([this, &testIndex, &testChecksum, &result]()
+    {
+        result = protocol->requiresFullSync(testIndex, testChecksum);
+    });
+
+    // First attempt: 409 (indexer hasn't caught up yet).
+    EXPECT_TRUE(mockSyncTransport->waitForSession());
+    feedHttpResult(409);
+
+    // Second attempt: 200 (indexer caught up) -- must NOT need all 5 attempts.
+    const int sendCountBefore = mockSyncTransport->sendCount();
+
+    while (mockSyncTransport->sendCount() <= sendCountBefore)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    feedHttpResult(200);
+
+    syncThread.join();
+    EXPECT_FALSE(result);
+    EXPECT_EQ(mockSyncTransport->sendCount(), 2);
 }
 
 TEST_F(AgentSyncProtocolTest, RequiresFullSyncNoQueueAvailable)

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -133,21 +133,6 @@ TEST_F(AgentSyncProtocolTest, PersistDifferenceCatchesException)
     EXPECT_NO_THROW(protocol->persistDifference(testId, testOperation, testIndex, testData, testVersion));
 }
 
-TEST_F(AgentSyncProtocolTest, PersistDifferenceInMemorySuccess)
-{
-    mockQueue = std::make_shared<MockPersistentQueue>();
-    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
-
-    const std::string testId = "memory_test_id";
-    const std::string testIndex = "memory_test_index";
-    const std::string testData = "memory_test_data";
-    const Operation testOperation = Operation::CREATE;
-    const uint64_t testVersion = 456;
-
-    EXPECT_NO_THROW(protocol->persistDifferenceInMemory(testId, testOperation, testIndex, testData, testVersion));
-}
-
 TEST_F(AgentSyncProtocolTest, SynchronizeModuleTransportUnavailable)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
@@ -261,109 +246,6 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleDataToSyncEmpty)
     EXPECT_TRUE(result.success);
 }
 
-// Tests for synchronizeModule with Mode::FULL (using in-memory data)
-TEST_F(AgentSyncProtocolTest, SynchronizeModuleFullModeWithEmptyInMemoryData)
-{
-    mockQueue = std::make_shared<MockPersistentQueue>();
-    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
-
-    // Expect NO calls to fetchAndMarkForSync since FULL mode uses in-memory data
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
-    .Times(0);
-
-    SyncModuleResult result = protocol->synchronizeModule(
-                                  Mode::FULL
-                              );
-
-    EXPECT_TRUE(result.success);  // Should return true for empty in-memory data
-}
-
-TEST_F(AgentSyncProtocolTest, SynchronizeModuleFullModeWithInMemoryData)
-{
-    mockQueue = std::make_shared<MockPersistentQueue>();
-    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
-
-    // Add some in-memory data
-    protocol->persistDifferenceInMemory("memory_id_1", Operation::CREATE, "memory_index_1", "memory_data_1", 1);
-    protocol->persistDifferenceInMemory("memory_id_2", Operation::MODIFY, "memory_index_2", "memory_data_2", 2);
-
-    // Expect NO calls to fetchAndMarkForSync since FULL mode uses in-memory data
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
-    .Times(0);
-
-    // Expect NO calls to clearSyncedItems or resetSyncingItems since FULL mode clears in-memory data
-    EXPECT_CALL(*mockQueue, clearSyncedItems())
-    .Times(0);
-    EXPECT_CALL(*mockQueue, resetSyncingItems())
-    .Times(0);
-
-    // Start synchronization in FULL mode
-    std::thread syncThread([this]()
-    {
-        SyncModuleResult result = protocol->synchronizeModule(
-                                      Mode::FULL
-                                  );
-        EXPECT_TRUE(result.success);
-    });
-
-    EXPECT_TRUE(mockSyncTransport->waitForSession());
-
-    // StartAck
-
-    // Wait for data messages
-    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
-
-    // EndAck
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    auto endAckOffset = endAckBuilder.Finish();
-
-    auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                          endBuilder,
-                          Wazuh::SyncSchema::MessageType::EndAck,
-                          endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-
-    const uint8_t* endBuffer = endBuilder.GetBufferPointer();
-    protocol->parseResponseBuffer(endBuffer, endBuilder.GetSize());
-
-    syncThread.join();
-}
-
-TEST_F(AgentSyncProtocolTest, SynchronizeModuleFullModeFailureKeepsInMemoryData)
-{
-    mockQueue = std::make_shared<MockPersistentQueue>();
-    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
-
-    // Add some in-memory data
-    protocol->persistDifferenceInMemory("memory_id_1", Operation::CREATE, "memory_index_1", "memory_data_1", 1);
-
-    // Expect NO calls to database methods since FULL mode uses in-memory data
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
-    .Times(0);
-    EXPECT_CALL(*mockQueue, resetSyncingItems())
-    .Times(0);
-
-    // Simulate synchronization failure (timeout)
-    SyncModuleResult result = protocol->synchronizeModule(
-                                  Mode::FULL
-                              );
-
-    EXPECT_FALSE(result.success);  // Should fail due to timeout
-    EXPECT_EQ(result.failureReason, "Timed out waiting for manager response.");
-    // The manager did not answer the handshake.
-    EXPECT_TRUE(result.managerNotReady);
-    // First failure of the streak: the module reports it at INFO and retries.
-    EXPECT_EQ(result.consecutiveFailures, 1u);
-
-    // In-memory data should be kept for potential retry, so we can add more data
-    EXPECT_NO_THROW(protocol->persistDifferenceInMemory("memory_id_2", Operation::MODIFY, "memory_index_2", "memory_data_2", 2));
-}
-
 // The consecutive-failure streak is what tells a brief post-restart hiccup apart from a lasting
 // condition (for example the manager having no indexer available, which also answers "not ready").
 // Without it the modules would demote a permanent sync outage to INFO forever.
@@ -377,21 +259,20 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleCountsConsecutiveFailures)
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
     protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
+    // There must be something to synchronize on every attempt, otherwise the sync short-circuits
+    // as a success and never reaches the handshake.
+    std::vector<PersistedData> testData =
+    {
+        {0, "memory_id_1", "memory_index_1", "memory_data_1", Operation::CREATE, 1}
+    };
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
-    .Times(0);
-    EXPECT_CALL(*mockQueue, resetSyncingItems())
-    .Times(0);
+    .WillRepeatedly(Return(testData));
 
     unsigned int previous = 0;
 
     for (unsigned int attempt = 1; attempt <= SYNC_MANAGER_NOT_READY_TOLERANCE + 1; ++attempt)
     {
-        // There must be something to synchronize on every attempt, otherwise the sync short-circuits
-        // as a success and never reaches the handshake.
-        protocol->clearInMemoryData();
-        protocol->persistDifferenceInMemory("memory_id_1", Operation::CREATE, "memory_index_1", "memory_data_1", 1);
-
-        SyncModuleResult result = protocol->synchronizeModule(Mode::FULL);
+        SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
         EXPECT_FALSE(result.success);
         EXPECT_TRUE(result.managerNotReady);
         // The count grows while the condition does not clear, so the module escalates to WARNING once
@@ -521,16 +402,23 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleStoppedDoesNotCountTowardsStreak)
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
     protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
+    // There must be something to synchronize on every attempt, otherwise the sync short-circuits
+    // as a success and never reaches the handshake.
+    std::vector<PersistedData> testData =
+    {
+        {0, "memory_id_1", "memory_index_1", "memory_data_1", Operation::CREATE, 1}
+    };
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
+    .WillRepeatedly(Return(testData));
+
     // First failure (Start timeout) puts the streak at 1.
-    protocol->persistDifferenceInMemory("memory_id_1", Operation::CREATE, "memory_index_1", "memory_data_1", 1);
-    SyncModuleResult firstFailure = protocol->synchronizeModule(Mode::FULL);
+    SyncModuleResult firstFailure = protocol->synchronizeModule(Mode::DELTA);
     EXPECT_FALSE(firstFailure.success);
     EXPECT_EQ(firstFailure.consecutiveFailures, 1u);
 
     // A stop-aborted sync must leave the streak where it was.
     protocol->stop();
-    protocol->persistDifferenceInMemory("memory_id_2", Operation::MODIFY, "memory_index_2", "memory_data_2", 2);
-    SyncModuleResult stoppedResult = protocol->synchronizeModule(Mode::FULL);
+    SyncModuleResult stoppedResult = protocol->synchronizeModule(Mode::DELTA);
     EXPECT_FALSE(stoppedResult.success);
     EXPECT_TRUE(stoppedResult.stopped);
     EXPECT_EQ(stoppedResult.consecutiveFailures, 1u);
@@ -544,19 +432,30 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSuccessResetsConsecutiveFailures)
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
     protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
+    // There must be something to synchronize on every attempt, otherwise the sync short-circuits
+    // as a success and never reaches the handshake. The first (failing) attempt aborts after its
+    // one block, so it only ever fetches once; the second (successful) attempt's block loop keeps
+    // going after that block succeeds, so it needs an empty fetch afterwards to stop cleanly
+    // instead of trying (and hanging on) a second block.
+    std::vector<PersistedData> testData =
+    {
+        {0, "memory_id_1", "memory_index_1", "memory_data_1", Operation::CREATE, 1}
+    };
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
+    .WillOnce(Return(testData))
+    .WillOnce(Return(testData))
+    .WillRepeatedly(Return(std::vector<PersistedData> {}));
+
     // First failure (Start timeout) puts the streak at 1.
-    protocol->persistDifferenceInMemory("memory_id_1", Operation::CREATE, "memory_index_1", "memory_data_1", 1);
-    SyncModuleResult firstFailure = protocol->synchronizeModule(Mode::FULL);
+    SyncModuleResult firstFailure = protocol->synchronizeModule(Mode::DELTA);
     EXPECT_FALSE(firstFailure.success);
     EXPECT_EQ(firstFailure.consecutiveFailures, 1u);
 
     // Second sync: drive a full successful handshake, which must reset the streak to 0.
-    protocol->persistDifferenceInMemory("memory_id_2", Operation::MODIFY, "memory_index_2", "memory_data_2", 2);
-
     SyncModuleResult successResult;
     std::thread syncThread([this, &successResult]()
     {
-        successResult = protocol->synchronizeModule(Mode::FULL);
+        successResult = protocol->synchronizeModule(Mode::DELTA);
     });
 
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
@@ -639,7 +538,12 @@ TEST_F(AgentSyncProtocolTest, SendStartWaitsUntilMetadataAvailable)
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
     protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
-    protocol->persistDifferenceInMemory("id1", Operation::CREATE, "index1", "data1", 1);
+    std::vector<PersistedData> testData =
+    {
+        {0, "id1", "index1", "data1", Operation::CREATE, 1}
+    };
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
+    .WillRepeatedly(Return(testData));
 
     // Remove metadata so provider returns -1 on the first polls
     metadata_provider_reset();
@@ -647,7 +551,7 @@ TEST_F(AgentSyncProtocolTest, SendStartWaitsUntilMetadataAvailable)
     std::atomic<bool> syncDone{false};
     auto syncFuture = std::async(std::launch::async, [&]()
     {
-        SyncModuleResult result = protocol->synchronizeModule(Mode::FULL);
+        SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
         syncDone = true;
         return result;
     });
@@ -692,14 +596,19 @@ TEST_F(AgentSyncProtocolTest, SendStartAbortedOnStopWhileWaitingForMetadata)
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
     protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
-    protocol->persistDifferenceInMemory("id1", Operation::CREATE, "index1", "data1", 1);
+    std::vector<PersistedData> testData =
+    {
+        {0, "id1", "index1", "data1", Operation::CREATE, 1}
+    };
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
+    .WillRepeatedly(Return(testData));
 
     // Remove metadata so provider returns -1 indefinitely
     metadata_provider_reset();
 
     auto syncFuture = std::async(std::launch::async, [&]()
     {
-        return protocol->synchronizeModule(Mode::FULL);
+        return protocol->synchronizeModule(Mode::DELTA);
     });
 
     // Let the thread enter the metadata polling loop
@@ -1278,88 +1187,6 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSuccessWithNoReqRet)
     syncThread.join();
 }
 
-TEST_F(AgentSyncProtocolTest, SynchronizeModuleSuccessWithReqRet)
-{
-    mockQueue = std::make_shared<MockPersistentQueue>();
-
-    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
-
-    std::vector<PersistedData> testData =
-    {
-        {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1},
-        {0, "test_id_2", "test_index_2", "test_data_2", Operation::MODIFY, 2}
-    };
-
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
-    .WillOnce(Return(testData))
-    .WillRepeatedly(Return(std::vector<PersistedData> {}));
-
-    EXPECT_CALL(*mockQueue, clearSyncedItems())
-    .Times(1);
-
-    // Start synchronization
-    std::thread syncThread([this]()
-    {
-        SyncModuleResult result = protocol->synchronizeModule(
-                                      Mode::DELTA
-                                  );
-        EXPECT_TRUE(result.success);
-    });
-
-    EXPECT_TRUE(mockSyncTransport->waitForSession());
-
-    // StartAck
-
-    // Wait for initial data messages to be sent
-    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
-
-    // ReqRet with valid ranges 1-2
-    flatbuffers::FlatBufferBuilder reqRetBuilder;
-
-    std::vector<flatbuffers::Offset<Wazuh::SyncSchema::Pair>> seqRanges;
-
-    // Range 1-2
-    auto range1 = Wazuh::SyncSchema::CreatePair(reqRetBuilder, 1, 2);
-    seqRanges.push_back(range1);
-
-    auto seqRangesVector = reqRetBuilder.CreateVector(seqRanges);
-
-    Wazuh::SyncSchema::ReqRetBuilder reqRetBuilderObj(reqRetBuilder);
-    reqRetBuilderObj.add_seq(seqRangesVector);
-    auto reqRetOffset = reqRetBuilderObj.Finish();
-
-    auto reqRetMessage = Wazuh::SyncSchema::CreateMessage(
-                             reqRetBuilder,
-                             Wazuh::SyncSchema::MessageType::ReqRet,
-                             reqRetOffset.Union());
-    reqRetBuilder.Finish(reqRetMessage);
-
-    const uint8_t* reqRetBuffer = reqRetBuilder.GetBufferPointer();
-    protocol->parseResponseBuffer(reqRetBuffer, reqRetBuilder.GetSize());
-
-    // Wait for data resend
-    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
-
-    // EndAck
-    flatbuffers::FlatBufferBuilder endBuilder;
-
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    auto endAckOffset = endAckBuilder.Finish();
-
-    auto endMessage = Wazuh::SyncSchema::CreateMessage(
-                          endBuilder,
-                          Wazuh::SyncSchema::MessageType::EndAck,
-                          endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-
-    const uint8_t* endBuffer = endBuilder.GetBufferPointer();
-    protocol->parseResponseBuffer(endBuffer, endBuilder.GetSize());
-
-    syncThread.join();
-}
-
 TEST_F(AgentSyncProtocolTest, SynchronizeModuleFinalizeSyncStateException)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
@@ -1828,86 +1655,6 @@ TEST_F(AgentSyncProtocolTest, RequiresFullSyncStartAckTimeout)
                   );
 
     EXPECT_FALSE(result);
-}
-
-// Tests for clearInMemoryData
-TEST_F(AgentSyncProtocolTest, ClearInMemoryDataWithEmptyData)
-{
-    mockQueue = std::make_shared<MockPersistentQueue>();
-    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
-
-    // Clear empty in-memory data should not throw
-    EXPECT_NO_THROW(protocol->clearInMemoryData());
-}
-
-TEST_F(AgentSyncProtocolTest, ClearInMemoryDataWithData)
-{
-    mockQueue = std::make_shared<MockPersistentQueue>();
-    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
-
-    // Add some in-memory data
-    protocol->persistDifferenceInMemory("memory_id_1", Operation::CREATE, "memory_index_1", "memory_data_1", 1);
-    protocol->persistDifferenceInMemory("memory_id_2", Operation::MODIFY, "memory_index_2", "memory_data_2", 2);
-    protocol->persistDifferenceInMemory("memory_id_3", Operation::DELETE_, "memory_index_3", "memory_data_3", 3);
-
-    // Clear in-memory data should not throw
-    EXPECT_NO_THROW(protocol->clearInMemoryData());
-}
-
-TEST_F(AgentSyncProtocolTest, ClearInMemoryDataAfterFailedFullSync)
-{
-    mockQueue = std::make_shared<MockPersistentQueue>();
-    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
-
-    // Add some in-memory data
-    protocol->persistDifferenceInMemory("memory_id_1", Operation::CREATE, "memory_index_1", "memory_data_1", 1);
-    protocol->persistDifferenceInMemory("memory_id_2", Operation::MODIFY, "memory_index_2", "memory_data_2", 2);
-
-    // Expect NO calls to database methods since FULL mode uses in-memory data
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
-    .Times(0);
-    EXPECT_CALL(*mockQueue, resetSyncingItems())
-    .Times(0);
-
-    // Simulate synchronization failure (timeout)
-    SyncModuleResult result = protocol->synchronizeModule(
-                                  Mode::FULL
-                              );
-
-    EXPECT_FALSE(result.success);  // Should fail due to timeout
-    EXPECT_EQ(result.failureReason, "Timed out waiting for manager response.");
-
-    // Clear in-memory data after failed sync
-    EXPECT_NO_THROW(protocol->clearInMemoryData());
-
-    // Verify data is cleared by attempting to add new data and sync with empty state
-    protocol->persistDifferenceInMemory("memory_id_3", Operation::CREATE, "memory_index_3", "memory_data_3", 3);
-
-    // This should work without issues
-    EXPECT_NO_THROW(protocol->clearInMemoryData());
-}
-
-TEST_F(AgentSyncProtocolTest, ClearInMemoryDataMultipleTimes)
-{
-    mockQueue = std::make_shared<MockPersistentQueue>();
-    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
-
-    // Add data and clear multiple times
-    protocol->persistDifferenceInMemory("memory_id_1", Operation::CREATE, "memory_index_1", "memory_data_1", 1);
-    EXPECT_NO_THROW(protocol->clearInMemoryData());
-
-    protocol->persistDifferenceInMemory("memory_id_2", Operation::MODIFY, "memory_index_2", "memory_data_2", 2);
-    EXPECT_NO_THROW(protocol->clearInMemoryData());
-
-    protocol->persistDifferenceInMemory("memory_id_3", Operation::DELETE_, "memory_index_3", "memory_data_3", 3);
-    EXPECT_NO_THROW(protocol->clearInMemoryData());
-
-    // Clear on already empty data
-    EXPECT_NO_THROW(protocol->clearInMemoryData());
 }
 
 // Tests for synchronizeMetadataOrGroups

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -72,14 +72,10 @@ class AgentSyncProtocolTest : public ::testing::Test
 
             // Set logger via asp_create
 
-            auto handle = asp_create(
-                              "test_module",
-                              ":memory:",
-                              +[](modules_log_level_t, const char* s)
+            auto handle = asp_create("test_module", ":memory:", +[](modules_log_level_t, const char* s)
             {
                 std::cout << s << std::endl;
-            }
-            , max_timeout, retries);
+            });
             asp_destroy(handle);
         }
 
@@ -105,7 +101,7 @@ TEST_F(AgentSyncProtocolTest, PersistDifferenceSuccess)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     const std::string testId = "test_id";
     const std::string testIndex = "test_index";
@@ -123,7 +119,7 @@ TEST_F(AgentSyncProtocolTest, PersistDifferenceCatchesException)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     const std::string testId = "test_id";
     const std::string testIndex = "test_index";
@@ -141,7 +137,7 @@ TEST_F(AgentSyncProtocolTest, PersistDifferenceInMemorySuccess)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     const std::string testId = "memory_test_id";
     const std::string testIndex = "memory_test_index";
@@ -157,9 +153,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleTransportUnavailable)
     mockQueue = std::make_shared<MockPersistentQueue>();
 
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries,
-                                                   mockQueue,
-                                                   mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
     mockSyncTransport->setAvailable(false);
 
     SyncModuleResult result = protocol->synchronizeModule(
@@ -177,9 +171,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleReportsStoppedWhenStopRequested)
     mockQueue = std::make_shared<MockPersistentQueue>();
 
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries,
-                                                   mockQueue,
-                                                   mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
     mockSyncTransport->setAvailable(false);
 
     // Simulate a shutdown/stop being requested before the sync runs.
@@ -201,9 +193,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleDoesNotReportTransientOnTransport
     mockQueue = std::make_shared<MockPersistentQueue>();
 
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries,
-                                                   mockQueue,
-                                                   mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
     mockSyncTransport->setAvailable(false);
 
     SyncModuleResult result = protocol->synchronizeModule(
@@ -222,10 +212,7 @@ TEST_F(AgentSyncProtocolTest, CInterfacePropagatesStoppedFlag)
     // exist here, so synchronizeModule() returns at the checkStatus early out
     // (no persistent-queue data needed).
 
-    auto* handle = asp_create("test_module",
-                              ":memory:",
-    +[](modules_log_level_t, const char*) {},
-    max_timeout, retries);
+    auto* handle = asp_create("test_module", ":memory:", +[](modules_log_level_t, const char*) {});
     ASSERT_NE(handle, nullptr);
 
     // No stop requested: a real failure must not be flagged as shutdown-induced.
@@ -246,7 +233,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleFetchAndMarkForSyncThrowsExceptio
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .WillOnce(::testing::Throw(std::runtime_error("Test exception")));
@@ -262,7 +249,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleDataToSyncEmpty)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .WillOnce(Return(std::vector<PersistedData> {}));
@@ -279,7 +266,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleFullModeWithEmptyInMemoryData)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Expect NO calls to fetchAndMarkForSync since FULL mode uses in-memory data
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
@@ -296,7 +283,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleFullModeWithInMemoryData)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Add some in-memory data
     protocol->persistDifferenceInMemory("memory_id_1", Operation::CREATE, "memory_index_1", "memory_data_1", 1);
@@ -350,7 +337,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleFullModeFailureKeepsInMemoryData)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Add some in-memory data
     protocol->persistDifferenceInMemory("memory_id_1", Operation::CREATE, "memory_index_1", "memory_data_1", 1);
@@ -388,9 +375,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleCountsConsecutiveFailures)
     // it returns before the streak is tracked.
 
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries,
-                                                   mockQueue,
-                                                   mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .Times(0);
@@ -425,7 +410,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleOfflineStartAckReportsManagerNotR
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     SyncModuleResult result;
     std::thread syncThread([this, &result]()
@@ -456,7 +441,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleOfflineEndAckReportsManagerNotRea
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     SyncModuleResult result;
     std::thread syncThread([this, &result]()
@@ -502,7 +487,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleEndTimeoutReportsManagerNotReady)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     SyncModuleResult result;
     std::thread syncThread([this, &result]()
@@ -534,7 +519,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleStoppedDoesNotCountTowardsStreak)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // First failure (Start timeout) puts the streak at 1.
     protocol->persistDifferenceInMemory("memory_id_1", Operation::CREATE, "memory_index_1", "memory_data_1", 1);
@@ -557,7 +542,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSuccessResetsConsecutiveFailures)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // First failure (Start timeout) puts the streak at 1.
     protocol->persistDifferenceInMemory("memory_id_1", Operation::CREATE, "memory_index_1", "memory_data_1", 1);
@@ -602,7 +587,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleInvalidModeValidation)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Expect NO calls to any queue methods since validation should fail early
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
@@ -626,9 +611,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSendSessionFails)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries,
-                                                   mockQueue,
-                                                   mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<PersistedData> testData =
     {
@@ -654,9 +637,7 @@ TEST_F(AgentSyncProtocolTest, SendStartWaitsUntilMetadataAvailable)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger,
-                                                   std::chrono::seconds(min_timeout),
-                                                   retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     protocol->persistDifferenceInMemory("id1", Operation::CREATE, "index1", "data1", 1);
 
@@ -709,9 +690,7 @@ TEST_F(AgentSyncProtocolTest, SendStartAbortedOnStopWhileWaitingForMetadata)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger,
-                                                   std::chrono::seconds(min_timeout),
-                                                   retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     protocol->persistDifferenceInMemory("id1", Operation::CREATE, "index1", "data1", 1);
 
@@ -744,7 +723,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSessionTimeout)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<PersistedData> testData =
     {
@@ -772,9 +751,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSendDataMessagesFails)
 
     static int callCount = 0;
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries,
-                                                   mockQueue,
-                                                   mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<PersistedData> testData =
     {
@@ -808,9 +785,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleDeltaStopsAfterTenBlocks)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger,
-                                                   std::chrono::seconds(max_timeout),
-                                                   retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<PersistedData> testData =
     {
@@ -888,9 +863,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleDeltaUsesBytePrefilterBudgetForSy
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger,
-                                                   std::chrono::seconds(max_timeout),
-                                                   retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     constexpr size_t FULLSESSION_MAX_BYTES = 5U * 1024U * 1024U;
     constexpr size_t FULLSESSION_PREFILTER_GRACE_BYTES = 64U * 1024U;
@@ -936,9 +909,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleDeltaBypassesBytePrefilterBudgetF
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger,
-                                                   std::chrono::seconds(max_timeout),
-                                                   retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<PersistedData> testData =
     {
@@ -997,9 +968,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleDeltaAllowsOversizedRealPayloadWh
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger,
-                                                   std::chrono::seconds(max_timeout),
-                                                   retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<PersistedData> oversizedBlock =
     {
@@ -1042,9 +1011,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleDeltaAbortsRemainingBlocksAfterSe
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger,
-                                                   std::chrono::seconds(max_timeout),
-                                                   retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<PersistedData> testData =
     {
@@ -1124,9 +1091,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleStopWakesEndAckWait)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger,
-                                                   std::chrono::seconds(max_timeout),
-                                                   retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<PersistedData> testData =
     {
@@ -1172,7 +1137,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleEndFailDueToManager)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<PersistedData> testData =
     {
@@ -1227,7 +1192,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleEndAckTimeout)
     mockQueue = std::make_shared<MockPersistentQueue>();
 
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<PersistedData> testData =
     {
@@ -1263,7 +1228,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSuccessWithNoReqRet)
     mockQueue = std::make_shared<MockPersistentQueue>();
 
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<PersistedData> testData =
     {
@@ -1273,7 +1238,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSuccessWithNoReqRet)
 
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .WillOnce(Return(testData))
-    .WillRepeatedly(Return(std::vector<PersistedData>{}));
+    .WillRepeatedly(Return(std::vector<PersistedData> {}));
 
     EXPECT_CALL(*mockQueue, clearSyncedItems())
     .Times(1);
@@ -1318,7 +1283,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSuccessWithReqRet)
     mockQueue = std::make_shared<MockPersistentQueue>();
 
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<PersistedData> testData =
     {
@@ -1328,7 +1293,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleSuccessWithReqRet)
 
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
     .WillOnce(Return(testData))
-    .WillRepeatedly(Return(std::vector<PersistedData>{}));
+    .WillRepeatedly(Return(std::vector<PersistedData> {}));
 
     EXPECT_CALL(*mockQueue, clearSyncedItems())
     .Times(1);
@@ -1409,7 +1374,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleFinalizeSyncStateException)
         }
     };
 
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Create some sample data for synchronization to make it successful
     std::vector<PersistedData> testData =
@@ -1465,7 +1430,7 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithNullBuffer)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     bool response = protocol->parseResponseBuffer(nullptr, 0);
 
@@ -1513,7 +1478,7 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWhenNotWaitingForEndAck)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     flatbuffers::FlatBufferBuilder builder;
 
@@ -1538,7 +1503,7 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckError)
     mockQueue = std::make_shared<MockPersistentQueue>();
     LogCapture logCapture;
     LoggerFunc testLogger = logCapture.logger();
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Enter in WaitingEndAck phase
     std::thread syncThread([this]()
@@ -1594,7 +1559,7 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckOffline)
     mockQueue = std::make_shared<MockPersistentQueue>();
     LogCapture logCapture;
     LoggerFunc testLogger = logCapture.logger();
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Enter in WaitingEndAck phase
     std::thread syncThread([this]()
@@ -1648,7 +1613,7 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckSuccess)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Enter in WaitingEndAck phase
     std::thread syncThread([this]()
@@ -1660,7 +1625,7 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckSuccess)
 
         EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
         .WillOnce(Return(testData))
-        .WillRepeatedly(Return(std::vector<PersistedData>{}));
+        .WillRepeatedly(Return(std::vector<PersistedData> {}));
 
         protocol->synchronizeModule(
             Mode::DELTA
@@ -1701,7 +1666,7 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithUnknownMessageType)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     flatbuffers::FlatBufferBuilder builder;
 
@@ -1719,7 +1684,7 @@ TEST_F(AgentSyncProtocolTest, RequiresFullSyncWithMatchingChecksum)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     const std::string testIndex = "test_index";
     const std::string testChecksum = "matching_checksum";
@@ -1768,7 +1733,7 @@ TEST_F(AgentSyncProtocolTest, RequiresFullSyncWithNonMatchingChecksum)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     const std::string testIndex = "test_index";
     const std::string testChecksum = "non_matching_checksum";
@@ -1818,9 +1783,7 @@ TEST_F(AgentSyncProtocolTest, RequiresFullSyncNoQueueAvailable)
     mockQueue = std::make_shared<MockPersistentQueue>();
 
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries,
-                                                   mockQueue,
-                                                   mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     const std::string testIndex = "test_index";
     const std::string testChecksum = "test_checksum";
@@ -1837,9 +1800,7 @@ TEST_F(AgentSyncProtocolTest, RequiresFullSyncSendStartFails)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries,
-                                                   mockQueue,
-                                                   mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     const std::string testIndex = "test_index";
     const std::string testChecksum = "test_checksum";
@@ -1856,7 +1817,7 @@ TEST_F(AgentSyncProtocolTest, RequiresFullSyncStartAckTimeout)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     const std::string testIndex = "test_index";
     const std::string testChecksum = "test_checksum";
@@ -1874,7 +1835,7 @@ TEST_F(AgentSyncProtocolTest, ClearInMemoryDataWithEmptyData)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Clear empty in-memory data should not throw
     EXPECT_NO_THROW(protocol->clearInMemoryData());
@@ -1884,7 +1845,7 @@ TEST_F(AgentSyncProtocolTest, ClearInMemoryDataWithData)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Add some in-memory data
     protocol->persistDifferenceInMemory("memory_id_1", Operation::CREATE, "memory_index_1", "memory_data_1", 1);
@@ -1899,7 +1860,7 @@ TEST_F(AgentSyncProtocolTest, ClearInMemoryDataAfterFailedFullSync)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Add some in-memory data
     protocol->persistDifferenceInMemory("memory_id_1", Operation::CREATE, "memory_index_1", "memory_data_1", 1);
@@ -1933,7 +1894,7 @@ TEST_F(AgentSyncProtocolTest, ClearInMemoryDataMultipleTimes)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Add data and clear multiple times
     protocol->persistDifferenceInMemory("memory_id_1", Operation::CREATE, "memory_index_1", "memory_data_1", 1);
@@ -1954,7 +1915,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithMetadataDeltaMode)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Expect NO calls to fetchAndMarkForSync since metadata/groups mode doesn't send data items
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
@@ -2002,7 +1963,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithMetadataCheckMode)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Expect NO calls to fetchAndMarkForSync since metadata/groups mode doesn't send data items
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
@@ -2050,7 +2011,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithGroupDeltaMode)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Expect NO calls to fetchAndMarkForSync since metadata/groups mode doesn't send data items
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
@@ -2098,7 +2059,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithGroupCheckMode)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Expect NO calls to fetchAndMarkForSync since metadata/groups mode doesn't send data items
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
@@ -2146,7 +2107,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithInvalidMode)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Try with Mode::DELTA (not allowed for synchronizeMetadataOrGroups)
     std::vector<std::string> testIndices = {"test-index-1", "test-index-2"};
@@ -2164,9 +2125,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsTransportUnavailable)
     mockQueue = std::make_shared<MockPersistentQueue>();
 
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries,
-                                                   mockQueue,
-                                                   mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
     mockSyncTransport->setAvailable(false);
 
     std::vector<std::string> testIndices = {"test-index-1", "test-index-2"};
@@ -2186,7 +2145,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsSessionTimeout)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Don't send any response, causing timeout
     std::vector<std::string> testIndices = {"test-index-1", "test-index-2"};
@@ -2204,7 +2163,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsEndAckTimeout)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Start synchronizeMetadataOrGroups in a separate thread
     std::thread syncThread([this]()
@@ -2233,7 +2192,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeMetadataOrGroupsWithEndAckError)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Start synchronizeMetadataOrGroups in a separate thread
     std::thread syncThread([this]()
@@ -2278,7 +2237,7 @@ TEST_F(AgentSyncProtocolTest, DeleteDatabaseCallsQueueDeleteDatabase)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     EXPECT_CALL(*mockQueue, deleteDatabase())
     .Times(1);
@@ -2301,7 +2260,7 @@ TEST_F(AgentSyncProtocolTest, DeleteDatabaseThrowsOnQueueError)
         }
     };
 
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     EXPECT_CALL(*mockQueue, deleteDatabase())
     .WillOnce(::testing::Throw(std::runtime_error("Database deletion failed")));
@@ -2316,7 +2275,7 @@ TEST_F(AgentSyncProtocolTest, NotifyDataCleanWithEmptyIndices)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<std::string> emptyIndices;
 
@@ -2333,9 +2292,7 @@ TEST_F(AgentSyncProtocolTest, NotifyDataCleanNoQueueAvailable)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries,
-                                                   mockQueue,
-                                                   mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<std::string> indices = {"test_index_1", "test_index_2"};
 
@@ -2352,9 +2309,7 @@ TEST_F(AgentSyncProtocolTest, NotifyDataCleanSendStartFails)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries,
-                                                   mockQueue,
-                                                   mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<std::string> indices = {"test_index_1", "test_index_2"};
 
@@ -2371,7 +2326,7 @@ TEST_F(AgentSyncProtocolTest, NotifyDataCleanStartAckTimeout)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<std::string> indices = {"test_index_1"};
 
@@ -2388,7 +2343,7 @@ TEST_F(AgentSyncProtocolTest, NotifyDataCleanStartAckError)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<std::string> indices = {"test_index_1"};
 
@@ -2414,7 +2369,7 @@ TEST_F(AgentSyncProtocolTest, NotifyDataCleanEndAckTimeout)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<std::string> indices = {"test_index_1"};
 
@@ -2444,7 +2399,7 @@ TEST_F(AgentSyncProtocolTest, NotifyDataCleanEndAckError)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<std::string> indices = {"test_index_1"};
 
@@ -2488,7 +2443,7 @@ TEST_F(AgentSyncProtocolTest, NotifyDataCleanClearItemsByIndexThrows)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<std::string> indices = {"test_index_1"};
 
@@ -2532,7 +2487,7 @@ TEST_F(AgentSyncProtocolTest, NotifyDataCleanSuccessWithSingleIndex)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<std::string> indices = {"test_index_1"};
 
@@ -2576,7 +2531,7 @@ TEST_F(AgentSyncProtocolTest, NotifyDataCleanSuccessWithMultipleIndices)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(min_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<std::string> indices = {"test_index_1", "test_index_2", "test_index_3"};
 
@@ -2625,7 +2580,7 @@ TEST_F(AgentSyncProtocolTest, NotifyDataCleanNoAnswerLeavesDatabaseUntouched)
     mockQueue = std::make_shared<MockPersistentQueue>();
 
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<std::string> indices = {"test_index_1"};
 
@@ -2656,9 +2611,7 @@ TEST_F(AgentSyncProtocolTest, ConstructionWithoutDbPathSuccess)
     // Construct without dbPath
     EXPECT_NO_THROW(
     {
-        protocol = std::make_unique<AgentSyncProtocol>("test_module", std::nullopt, testLogger,
-                                                       std::chrono::seconds(max_timeout),
-                                                       retries, nullptr, mockSyncTransport);
+        protocol = std::make_unique<AgentSyncProtocol>("test_module", std::nullopt, testLogger, nullptr, mockSyncTransport);
     });
 }
 
@@ -2675,9 +2628,7 @@ TEST_F(AgentSyncProtocolTest, PersistDifferenceLogsErrorWithoutQueue)
     };
 
     // Construct without dbPath and without queue
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", std::nullopt, testLogger,
-                                                   std::chrono::seconds(max_timeout),
-                                                   retries, nullptr, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", std::nullopt, testLogger, nullptr, mockSyncTransport);
 
     // persistDifference should log error when no queue is available
     protocol->persistDifference("id1", Operation::CREATE, "index1", "data1", 1);
@@ -2701,9 +2652,7 @@ TEST_F(AgentSyncProtocolTest, DeltaModeSyncLogsErrorWithoutQueue)
     };
 
     // Construct without dbPath
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", std::nullopt, testLogger,
-                                                   std::chrono::seconds(max_timeout),
-                                                   retries, nullptr, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", std::nullopt, testLogger, nullptr, mockSyncTransport);
 
     // DELTA mode should return false and log error when no queue is available
     SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
@@ -2727,7 +2676,7 @@ TEST_F(AgentSyncProtocolTest, NotifyDataCleanLogsErrorWithoutQueue)
     };
 
     // Construct without dbPath
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", std::nullopt, testLogger, std::chrono::seconds(max_timeout), retries, nullptr, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", std::nullopt, testLogger, nullptr, mockSyncTransport);
 
     std::vector<std::string> indices = {"test_index_1"};
 
@@ -2788,9 +2737,7 @@ TEST_F(AgentSyncProtocolTest, DeleteDatabaseLogsErrorWithoutQueue)
     };
 
     // Construct without dbPath
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", std::nullopt, testLogger,
-                                                   std::chrono::seconds(max_timeout),
-                                                   retries, nullptr, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", std::nullopt, testLogger, nullptr, mockSyncTransport);
 
     // deleteDatabase should log error when no queue is available
     protocol->deleteDatabase();
@@ -2807,13 +2754,7 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckChecksumMismatch)
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&)
     {
     };
-    protocol = std::make_unique<AgentSyncProtocol>("test_module",
-                                                   ":memory:",
-                                                   testLogger,
-                                                   std::chrono::seconds(max_timeout),
-                                                   retries,
-                                                   mockQueue,
-                                                   mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Enter in WaitingEndAck phase
     std::thread syncThread(
@@ -2863,13 +2804,7 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckGenericError)
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&)
     {
     };
-    protocol = std::make_unique<AgentSyncProtocol>("test_module",
-                                                   ":memory:",
-                                                   testLogger,
-                                                   std::chrono::seconds(max_timeout),
-                                                   retries,
-                                                   mockQueue,
-                                                   mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Enter in WaitingEndAck phase
     std::thread syncThread(
@@ -2927,8 +2862,7 @@ TEST(InterfaceDestructorTest, IAgentSyncProtocolDeletingDestructor)
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
 
     // Create AgentSyncProtocol through base interface pointer
-    protocol = new AgentSyncProtocol("test_module", std::nullopt, testLogger, std::chrono::seconds(1000), 1, mockQueue,
-                                     std::make_shared<MockSyncTransport>());
+    protocol = new AgentSyncProtocol("test_module", std::nullopt, testLogger, mockQueue, std::make_shared<MockSyncTransport>());
 
     // Delete through base pointer - this calls D0 destructor
     delete protocol;
@@ -2949,14 +2883,7 @@ TEST_F(AgentSyncProtocolTest, fetchPendingItems_WithNullPersistentQueue)
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
 
     // Create AgentSyncProtocol WITHOUT persistent queue (dbPath = std::nullopt)
-    protocol = std::make_unique<AgentSyncProtocol>(
-                   "test_module",
-                   std::nullopt,  // No dbPath - persistent queue will be null
-                   testLogger,
-                   std::chrono::seconds(1),
-                   retries,
-                   nullptr  // No persistent queue
-                   , mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", std::nullopt, testLogger, nullptr, mockSyncTransport);
 
     // fetchPendingItems should catch exception and return empty vector
     auto result = protocol->fetchPendingItems(true);
@@ -2976,14 +2903,7 @@ TEST_F(AgentSyncProtocolTest, fetchPendingItems_OnlyDataValues_True)
 
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
 
-    protocol = std::make_unique<AgentSyncProtocol>(
-                   "test_module",
-                   ":memory:",
-                   testLogger,
-                   std::chrono::seconds(1),
-                   retries,
-                   mockQueue
-                   , mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Prepare test data - DataValue items only
     std::vector<PersistedData> expectedData;
@@ -3035,14 +2955,7 @@ TEST_F(AgentSyncProtocolTest, fetchPendingItems_OnlyDataValues_False)
 
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
 
-    protocol = std::make_unique<AgentSyncProtocol>(
-                   "test_module",
-                   ":memory:",
-                   testLogger,
-                   std::chrono::seconds(1),
-                   retries,
-                   mockQueue
-                   , mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Prepare test data - Mix of DataValue and DataContext
     std::vector<PersistedData> expectedData;
@@ -3090,14 +3003,7 @@ TEST_F(AgentSyncProtocolTest, fetchPendingItems_EmptyQueue)
 
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
 
-    protocol = std::make_unique<AgentSyncProtocol>(
-                   "test_module",
-                   ":memory:",
-                   testLogger,
-                   std::chrono::seconds(1),
-                   retries,
-                   mockQueue
-                   , mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Mock fetchPendingItems to return empty vector
     EXPECT_CALL(*mockQueue, fetchPendingItems(true))
@@ -3123,14 +3029,7 @@ TEST_F(AgentSyncProtocolTest, fetchPendingItems_MultipleIndices)
 
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
 
-    protocol = std::make_unique<AgentSyncProtocol>(
-                   "test_module",
-                   ":memory:",
-                   testLogger,
-                   std::chrono::seconds(1),
-                   retries,
-                   mockQueue
-                   , mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Prepare test data from multiple indices
     std::vector<PersistedData> expectedData;
@@ -3186,14 +3085,7 @@ TEST_F(AgentSyncProtocolTest, fetchPendingItems_DifferentOperations)
 
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
 
-    protocol = std::make_unique<AgentSyncProtocol>(
-                   "test_module",
-                   ":memory:",
-                   testLogger,
-                   std::chrono::seconds(1),
-                   retries,
-                   mockQueue
-                   , mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Prepare test data with different operations
     std::vector<PersistedData> expectedData;
@@ -3256,14 +3148,7 @@ TEST_F(AgentSyncProtocolTest, fetchPendingItems_ExceptionHandling)
         }
     };
 
-    protocol = std::make_unique<AgentSyncProtocol>(
-                   "test_module",
-                   ":memory:",
-                   testLogger,
-                   std::chrono::seconds(1),
-                   retries,
-                   mockQueue
-                   , mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Mock fetchPendingItems to throw exception
     EXPECT_CALL(*mockQueue, fetchPendingItems(true))
@@ -3290,14 +3175,7 @@ TEST_F(AgentSyncProtocolTest, fetchPendingItems_LargeDataSet)
 
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
 
-    protocol = std::make_unique<AgentSyncProtocol>(
-                   "test_module",
-                   ":memory:",
-                   testLogger,
-                   std::chrono::seconds(1),
-                   retries,
-                   mockQueue
-                   , mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Prepare large dataset (1000 items)
     std::vector<PersistedData> expectedData;
@@ -3341,14 +3219,7 @@ TEST_F(AgentSyncProtocolTest, fetchPendingItems_SequenceNumberOrdering)
 
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
 
-    protocol = std::make_unique<AgentSyncProtocol>(
-                   "test_module",
-                   ":memory:",
-                   testLogger,
-                   std::chrono::seconds(1),
-                   retries,
-                   mockQueue
-                   , mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Prepare test data with specific sequence numbers
     std::vector<PersistedData> expectedData;
@@ -3406,14 +3277,7 @@ TEST_F(AgentSyncProtocolTest, clearAllDataContext_WithValidQueue)
 
     auto logger = [](modules_log_level_t, const std::string&) {};
 
-    protocol = std::make_unique<AgentSyncProtocol>(
-                   "test_module",
-                   std::nullopt,
-                   logger,
-                   std::chrono::seconds(max_timeout),
-                   retries,
-                   mockQueue
-                   , mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", std::nullopt, logger, mockQueue, mockSyncTransport);
 
     // Expect clearAllDataContext to be called once
     EXPECT_CALL(*mockQueue, clearAllDataContext())
@@ -3432,14 +3296,7 @@ TEST_F(AgentSyncProtocolTest, clearAllDataContext_WithNullQueue)
 
     auto logger = [](modules_log_level_t, const std::string&) {};
 
-    protocol = std::make_unique<AgentSyncProtocol>(
-                   "test_module",
-                   std::nullopt,
-                   logger,
-                   std::chrono::seconds(max_timeout),
-                   retries,
-                   nullptr
-                   , mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", std::nullopt, logger, nullptr, mockSyncTransport);
 
     // Should not throw when queue is null
     EXPECT_NO_THROW(protocol->clearAllDataContext());
@@ -3455,14 +3312,7 @@ TEST_F(AgentSyncProtocolTest, clearAllDataContext_ExceptionHandling)
 
     auto logger = [](modules_log_level_t, const std::string&) {};
 
-    protocol = std::make_unique<AgentSyncProtocol>(
-                   "test_module",
-                   std::nullopt,
-                   logger,
-                   std::chrono::seconds(max_timeout),
-                   retries,
-                   mockQueue
-                   , mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", std::nullopt, logger, mockQueue, mockSyncTransport);
 
     // Make clearAllDataContext throw an exception
     EXPECT_CALL(*mockQueue, clearAllDataContext())
@@ -3487,14 +3337,7 @@ TEST_F(AgentSyncProtocolTest, notifyDataClean_WithSyncOption_EmptyIndices)
 
     auto logger = [](modules_log_level_t, const std::string&) {};
 
-    protocol = std::make_unique<AgentSyncProtocol>(
-                   "test_module",
-                   ":memory:",
-                   logger,
-                   std::chrono::seconds(max_timeout),
-                   retries,
-                   mockQueue
-                   , mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", logger, mockQueue, mockSyncTransport);
 
     std::vector<std::string> emptyIndices;
 
@@ -3513,14 +3356,7 @@ TEST_F(AgentSyncProtocolTest, notifyDataClean_WithSyncOption_MultipleIndices)
 
     auto logger = [](modules_log_level_t, const std::string&) {};
 
-    protocol = std::make_unique<AgentSyncProtocol>(
-                   "test_module",
-                   ":memory:",
-                   logger,
-                   std::chrono::seconds(max_timeout),
-                   retries,
-                   mockQueue
-                   , mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", logger, mockQueue, mockSyncTransport);
 
     std::vector<std::string> indices =
     {
@@ -3543,14 +3379,7 @@ TEST_F(AgentSyncProtocolTest, notifyDataClean_DefaultOption)
 
     auto logger = [](modules_log_level_t, const std::string&) {};
 
-    protocol = std::make_unique<AgentSyncProtocol>(
-                   "test_module",
-                   ":memory:",
-                   logger,
-                   std::chrono::seconds(max_timeout),
-                   retries,
-                   mockQueue
-                   , mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", logger, mockQueue, mockSyncTransport);
 
     std::vector<std::string> indices = {"wazuh-states-inventory-hardware"};
 
@@ -3567,14 +3396,7 @@ TEST_F(AgentSyncProtocolTest, notifyDataClean_WithNullQueue)
 
     auto logger = [](modules_log_level_t, const std::string&) {};
 
-    protocol = std::make_unique<AgentSyncProtocol>(
-                   "test_module",
-                   std::nullopt,
-                   logger,
-                   std::chrono::seconds(max_timeout),
-                   retries,
-                   nullptr
-                   , mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", std::nullopt, logger, nullptr, mockSyncTransport);
 
     std::vector<std::string> indices = {"wazuh-states-inventory-hardware"};
 
@@ -3628,14 +3450,7 @@ TEST_F(AgentSyncProtocolTest, VDWorkflow_ClearDataContextBeforeSync)
 
     auto logger = [](modules_log_level_t, const std::string&) {};
 
-    protocol = std::make_unique<AgentSyncProtocol>(
-                   "syscollector_vd",
-                   ":memory:",
-                   logger,
-                   std::chrono::seconds(max_timeout),
-                   retries,
-                   mockQueue
-                   , mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("syscollector_vd", ":memory:", logger, mockQueue, mockSyncTransport);
 
     // Step 1: Clear all DataContext
     EXPECT_CALL(*mockQueue, clearAllDataContext())
@@ -3674,14 +3489,7 @@ TEST_F(AgentSyncProtocolTest, VDWorkflow_FetchOnlyDataValues)
 
     auto logger = [](modules_log_level_t, const std::string&) {};
 
-    protocol = std::make_unique<AgentSyncProtocol>(
-                   "syscollector_vd",
-                   ":memory:",
-                   logger,
-                   std::chrono::seconds(max_timeout),
-                   retries,
-                   mockQueue
-                   , mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("syscollector_vd", ":memory:", logger, mockQueue, mockSyncTransport);
 
     // Create mixed data (DataValue and DataContext)
     std::vector<PersistedData> allData;
@@ -3727,15 +3535,14 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckProcessing)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger,
-                                                   std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<PersistedData> testData =
     {
         {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1},
     };
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) ).WillOnce(Return(testData))
-    .WillRepeatedly(Return(std::vector<PersistedData>{}));
+    .WillRepeatedly(Return(std::vector<PersistedData> {}));
     EXPECT_CALL(*mockQueue, clearSyncedItems()).Times(1);
 
     std::thread syncThread([this]()
@@ -3782,8 +3589,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleProcessingAckThenEndAckSuccess)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger,
-                                                   std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<PersistedData> testData =
     {
@@ -3791,7 +3597,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleProcessingAckThenEndAckSuccess)
         {0, "test_id_2", "test_index_2", "test_data_2", Operation::MODIFY, 2},
     };
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) ).WillOnce(Return(testData))
-    .WillRepeatedly(Return(std::vector<PersistedData>{}));
+    .WillRepeatedly(Return(std::vector<PersistedData> {}));
     EXPECT_CALL(*mockQueue, clearSyncedItems()).Times(1);
 
     std::thread syncThread([this]()
@@ -3844,15 +3650,14 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleProcessingAckDoesNotConsumeRetry)
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
     // retries=0: only one End attempt. A timeout after Processing must not consume it.
     const unsigned int retries_zero = 0;
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger,
-                                                   std::chrono::seconds(min_timeout), retries_zero, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<PersistedData> testData =
     {
         {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1},
     };
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) ).WillOnce(Return(testData))
-    .WillRepeatedly(Return(std::vector<PersistedData>{}));
+    .WillRepeatedly(Return(std::vector<PersistedData> {}));
     EXPECT_CALL(*mockQueue, clearSyncedItems()).Times(1);
 
     std::thread syncThread([this]()
@@ -3951,8 +3756,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleConcurrentCallIsSkippedAndDoesNot
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
-    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger,
-                                                   std::chrono::seconds(max_timeout), retries, mockQueue, mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<PersistedData> testData =
     {

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol_datacontext.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol_datacontext.cpp
@@ -112,13 +112,7 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleWithOnlyDataValueItems
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&)
     {
     };
-    protocol = std::make_unique<AgentSyncProtocol>("test_module",
-                                                   ":memory:",
-                                                   testLogger,
-                                                   std::chrono::seconds(max_timeout),
-                                                   retries,
-                                                   mockQueue,
-                                                   mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Only DataValue items (is_data_context = false)
     std::vector<PersistedData> testData = {{0, "id_1", "network", "net_data_1", Operation::CREATE, 1, false},
@@ -126,7 +120,7 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleWithOnlyDataValueItems
     };
 
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) ).WillOnce(Return(testData))
-    .WillRepeatedly(Return(std::vector<PersistedData>{}));
+    .WillRepeatedly(Return(std::vector<PersistedData> {}));
     EXPECT_CALL(*mockQueue, clearSyncedItems()).Times(1);
 
     std::thread syncThread(
@@ -165,13 +159,7 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleWithOnlyDataContextIte
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&)
     {
     };
-    protocol = std::make_unique<AgentSyncProtocol>("test_module",
-                                                   ":memory:",
-                                                   testLogger,
-                                                   std::chrono::seconds(max_timeout),
-                                                   retries,
-                                                   mockQueue,
-                                                   mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Only DataContext items (is_data_context = true)
     std::vector<PersistedData> testData = {{0, "ctx_id_1", "vd_packages", "package_data_1", Operation::CREATE, 1, true},
@@ -179,7 +167,7 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleWithOnlyDataContextIte
     };
 
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) ).WillOnce(Return(testData))
-    .WillRepeatedly(Return(std::vector<PersistedData>{}));
+    .WillRepeatedly(Return(std::vector<PersistedData> {}));
     EXPECT_CALL(*mockQueue, clearSyncedItems()).Times(1);
 
     std::thread syncThread(
@@ -223,13 +211,7 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleWithMixedDataValueAndD
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&)
     {
     };
-    protocol = std::make_unique<AgentSyncProtocol>("test_module",
-                                                   ":memory:",
-                                                   testLogger,
-                                                   std::chrono::seconds(max_timeout),
-                                                   retries,
-                                                   mockQueue,
-                                                   mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     // Mixed DataValue and DataContext items
     std::vector<PersistedData> testData =
@@ -241,7 +223,7 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleWithMixedDataValueAndD
     };
 
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) ).WillOnce(Return(testData))
-    .WillRepeatedly(Return(std::vector<PersistedData>{}));
+    .WillRepeatedly(Return(std::vector<PersistedData> {}));
     EXPECT_CALL(*mockQueue, clearSyncedItems()).Times(1);
 
     std::thread syncThread(
@@ -290,13 +272,7 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleDataContextFailureDoes
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&)
     {
     };
-    protocol = std::make_unique<AgentSyncProtocol>("test_module",
-                                                   ":memory:",
-                                                   testLogger,
-                                                   std::chrono::seconds(max_timeout),
-                                                   retries,
-                                                   mockQueue,
-                                                   mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<PersistedData> testData =
     {
@@ -318,8 +294,15 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleDataContextFailureDoes
 
     // Send StartAck
 
-    // Wait for failure
-    std::this_thread::sleep_for(std::chrono::milliseconds(delay * 2));
+    // Send EndAck with Error status to fail the session
+    flatbuffers::FlatBufferBuilder endBuilder;
+    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
+    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Error);
+    auto endAckOffset = endAckBuilder.Finish();
+    auto endMessage =
+        Wazuh::SyncSchema::CreateMessage(endBuilder, Wazuh::SyncSchema::MessageType::EndAck, endAckOffset.Union());
+    endBuilder.Finish(endMessage);
+    protocol->parseResponseBuffer(endBuilder.GetBufferPointer(), endBuilder.GetSize());
 
     syncThread.join();
 }
@@ -344,13 +327,7 @@ TEST_F(AgentSyncProtocolDataContextTest, DataBatch_DataValuesAreBatchedTogether)
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&)
     {
     };
-    protocol = std::make_unique<AgentSyncProtocol>("test_module",
-                                                   ":memory:",
-                                                   testLogger,
-                                                   std::chrono::seconds(max_timeout),
-                                                   retries,
-                                                   mockQueue,
-                                                   mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<PersistedData> testData = {{0, "id_1", "network", "net_data_1", Operation::CREATE, 1, false},
         {1, "id_2", "processes", "proc_data_1", Operation::CREATE, 1, false},
@@ -358,7 +335,7 @@ TEST_F(AgentSyncProtocolDataContextTest, DataBatch_DataValuesAreBatchedTogether)
     };
 
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) ).WillOnce(Return(testData))
-    .WillRepeatedly(Return(std::vector<PersistedData>{}));
+    .WillRepeatedly(Return(std::vector<PersistedData> {}));
     EXPECT_CALL(*mockQueue, clearSyncedItems()).Times(1);
 
     std::thread syncThread(
@@ -406,20 +383,14 @@ TEST_F(AgentSyncProtocolDataContextTest, DataBatch_BatchContainsExpectedDataValu
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&)
     {
     };
-    protocol = std::make_unique<AgentSyncProtocol>("test_module",
-                                                   ":memory:",
-                                                   testLogger,
-                                                   std::chrono::seconds(max_timeout),
-                                                   retries,
-                                                   mockQueue,
-                                                   mockSyncTransport);
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
     std::vector<PersistedData> testData = {{0, "host_id_1", "network", "net_data", Operation::CREATE, 1, false},
         {1, "host_id_2", "packages", "pkg_data", Operation::CREATE, 1, false}
     };
 
     EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) ).WillOnce(Return(testData))
-    .WillRepeatedly(Return(std::vector<PersistedData>{}));
+    .WillRepeatedly(Return(std::vector<PersistedData> {}));
     EXPECT_CALL(*mockQueue, clearSyncedItems()).Times(1);
 
     std::thread syncThread(

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol_datacontext.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol_datacontext.cpp
@@ -45,7 +45,7 @@ class MockPersistentQueue : public IPersistentQueue
                      uint64_t version,
                      bool isDataContext),
                     (override));
-        MOCK_METHOD(std::vector<PersistedData>, fetchAndMarkForSync, (), (override));
+        MOCK_METHOD(std::vector<PersistedData>, fetchAndMarkForSync, (size_t maxItems), (override));
         MOCK_METHOD(std::vector<PersistedData>, fetchPendingItems, (bool onlyDataValues), (override));
         MOCK_METHOD(void, clearSyncedItems, (), (override));
         MOCK_METHOD(void, resetSyncingItems, (), (override));
@@ -125,7 +125,8 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleWithOnlyDataValueItems
         {1, "id_2", "processes", "proc_data_1", Operation::CREATE, 1, false}
     };
 
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync()).WillOnce(Return(testData));
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) ).WillOnce(Return(testData))
+    .WillRepeatedly(Return(std::vector<PersistedData>{}));
     EXPECT_CALL(*mockQueue, clearSyncedItems()).Times(1);
 
     std::thread syncThread(
@@ -146,7 +147,6 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleWithOnlyDataValueItems
     flatbuffers::FlatBufferBuilder endBuilder;
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
     auto endMessage =
         Wazuh::SyncSchema::CreateMessage(endBuilder, Wazuh::SyncSchema::MessageType::EndAck, endAckOffset.Union());
@@ -178,7 +178,8 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleWithOnlyDataContextIte
         {1, "ctx_id_2", "vd_system", "os_data", Operation::CREATE, 1, true}
     };
 
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync()).WillOnce(Return(testData));
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) ).WillOnce(Return(testData))
+    .WillRepeatedly(Return(std::vector<PersistedData>{}));
     EXPECT_CALL(*mockQueue, clearSyncedItems()).Times(1);
 
     std::thread syncThread(
@@ -199,7 +200,6 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleWithOnlyDataContextIte
     flatbuffers::FlatBufferBuilder endBuilder;
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
     auto endMessage =
         Wazuh::SyncSchema::CreateMessage(endBuilder, Wazuh::SyncSchema::MessageType::EndAck, endAckOffset.Union());
@@ -240,7 +240,8 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleWithMixedDataValueAndD
         {3, "ctx_id_2", "vd_system", "os_data", Operation::CREATE, 1, true}           // DataContext
     };
 
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync()).WillOnce(Return(testData));
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) ).WillOnce(Return(testData))
+    .WillRepeatedly(Return(std::vector<PersistedData>{}));
     EXPECT_CALL(*mockQueue, clearSyncedItems()).Times(1);
 
     std::thread syncThread(
@@ -261,7 +262,6 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleWithMixedDataValueAndD
     flatbuffers::FlatBufferBuilder endBuilder;
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
     auto endMessage =
         Wazuh::SyncSchema::CreateMessage(endBuilder, Wazuh::SyncSchema::MessageType::EndAck, endAckOffset.Union());
@@ -304,7 +304,7 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleDataContextFailureDoes
         {1, "ctx_id_1", "vd_packages", "package_data_1", Operation::CREATE, 1, true}
     };
 
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync()).WillOnce(Return(testData));
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) ).WillOnce(Return(testData));
     EXPECT_CALL(*mockQueue, resetSyncingItems()).Times(1); // Should reset due to DataContext failure
 
     std::thread syncThread(
@@ -357,7 +357,8 @@ TEST_F(AgentSyncProtocolDataContextTest, DataBatch_DataValuesAreBatchedTogether)
         {2, "id_3", "packages", "pkg_data_1", Operation::CREATE, 1, false}
     };
 
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync()).WillOnce(Return(testData));
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) ).WillOnce(Return(testData))
+    .WillRepeatedly(Return(std::vector<PersistedData>{}));
     EXPECT_CALL(*mockQueue, clearSyncedItems()).Times(1);
 
     std::thread syncThread(
@@ -375,7 +376,6 @@ TEST_F(AgentSyncProtocolDataContextTest, DataBatch_DataValuesAreBatchedTogether)
     flatbuffers::FlatBufferBuilder endBuilder;
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
     auto endMessage =
         Wazuh::SyncSchema::CreateMessage(endBuilder, Wazuh::SyncSchema::MessageType::EndAck, endAckOffset.Union());
@@ -418,7 +418,8 @@ TEST_F(AgentSyncProtocolDataContextTest, DataBatch_BatchContainsExpectedDataValu
         {1, "host_id_2", "packages", "pkg_data", Operation::CREATE, 1, false}
     };
 
-    EXPECT_CALL(*mockQueue, fetchAndMarkForSync()).WillOnce(Return(testData));
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) ).WillOnce(Return(testData))
+    .WillRepeatedly(Return(std::vector<PersistedData>{}));
     EXPECT_CALL(*mockQueue, clearSyncedItems()).Times(1);
 
     std::thread syncThread(
@@ -436,7 +437,6 @@ TEST_F(AgentSyncProtocolDataContextTest, DataBatch_BatchContainsExpectedDataValu
     flatbuffers::FlatBufferBuilder endBuilder;
     Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
     endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    endAckBuilder.add_session(mockSyncTransport->session());
     auto endAckOffset = endAckBuilder.Finish();
     auto endMessage =
         Wazuh::SyncSchema::CreateMessage(endBuilder, Wazuh::SyncSchema::MessageType::EndAck, endAckOffset.Union());

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol_datacontext.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol_datacontext.cpp
@@ -257,8 +257,10 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleWithMixedDataValueAndD
     const auto* session = capturedSession(mockSyncTransport, keepAlive);
     ASSERT_NE(nullptr, session);
     EXPECT_EQ(2, countedDataValues(session));
-    ASSERT_NE(nullptr, session->contexts());
-    EXPECT_EQ(2u, session->contexts()->size());
+    const auto* data = syncData(session);
+    ASSERT_NE(nullptr, data);
+    ASSERT_NE(nullptr, data->contexts());
+    EXPECT_EQ(2u, data->contexts()->size());
 }
 
 TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleDataContextFailureDoesNotAffectDataValue)
@@ -308,12 +310,13 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleDataContextFailureDoes
 }
 
 // ========================================
-// Tests for DataBatch protocol behavior
+// Tests for SyncData payload behavior
 // ========================================
 
-TEST_F(AgentSyncProtocolDataContextTest, DataBatch_DataValuesAreBatchedTogether)
+TEST_F(AgentSyncProtocolDataContextTest, SyncData_DataValuesArriveTogether)
 {
-    // DataValues in DELTA mode must be sent inside a DataBatch, not as individual DataValue messages.
+    // DataValues in DELTA mode must be sent inside the session's SyncData payload,
+    // not as individual DataValue messages.
     mockQueue = std::make_shared<MockPersistentQueue>();
 
     static int dataBatchMessagesSent = 0;
@@ -361,19 +364,19 @@ TEST_F(AgentSyncProtocolDataContextTest, DataBatch_DataValuesAreBatchedTogether)
 
     syncThread.join();
 
-    // All DataValues must arrive inside DataBatch messages, never as individual DataValue messages
+    // All DataValues must arrive inside the session's SyncData payload, never as
+    // individual DataValue messages.
     std::vector<uint8_t> keepAlive;
     const auto* session = capturedSession(mockSyncTransport, keepAlive);
     ASSERT_NE(nullptr, session);
     EXPECT_EQ(1, mockSyncTransport->sendCount());          // One message for the whole session.
-    ASSERT_NE(nullptr, session->batches());
-    EXPECT_EQ(1u, session->batches()->size());             // No ~60 KB split any more.
+    ASSERT_NE(nullptr, syncData(session));                 // No ~60 KB split any more.
     EXPECT_EQ(3, countedDataValues(session));
 }
 
-TEST_F(AgentSyncProtocolDataContextTest, DataBatch_BatchContainsExpectedDataValues)
+TEST_F(AgentSyncProtocolDataContextTest, SyncData_PayloadContainsExpectedDataValues)
 {
-    // Verify that the DataBatch payload carries the correct seq and id for each DataValue.
+    // Verify that the SyncData payload carries the correct seq and id for each DataValue.
     mockQueue = std::make_shared<MockPersistentQueue>();
 
     static std::vector<std::pair<uint64_t, std::string>> received; // {seq, id}
@@ -419,9 +422,9 @@ TEST_F(AgentSyncProtocolDataContextTest, DataBatch_BatchContainsExpectedDataValu
     std::vector<uint8_t> keepAlive;
     const auto* session = capturedSession(mockSyncTransport, keepAlive);
     ASSERT_NE(nullptr, session);
-    ASSERT_NE(nullptr, session->batches());
-    ASSERT_EQ(1u, session->batches()->size());
-    const auto* values = session->batches()->Get(0)->values();
+    const auto* data = syncData(session);
+    ASSERT_NE(nullptr, data);
+    const auto* values = data->values();
     ASSERT_NE(nullptr, values);
     ASSERT_EQ(2u, values->size());
     EXPECT_EQ(0u, values->Get(0)->seq());

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol_datacontext.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol_datacontext.cpp
@@ -427,8 +427,6 @@ TEST_F(AgentSyncProtocolDataContextTest, SyncData_PayloadContainsExpectedDataVal
     const auto* values = data->values();
     ASSERT_NE(nullptr, values);
     ASSERT_EQ(2u, values->size());
-    EXPECT_EQ(0u, values->Get(0)->seq());
     EXPECT_EQ("host_id_1", values->Get(0)->id()->str());
-    EXPECT_EQ(1u, values->Get(1)->seq());
     EXPECT_EQ("host_id_2", values->Get(1)->id()->str());
 }

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol_datacontext.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol_datacontext.cpp
@@ -81,6 +81,16 @@ class AgentSyncProtocolDataContextTest : public ::testing::Test
             metadata_provider_reset();
         }
 
+        /// Feeds a /stateful HTTP result to the protocol, as https_client_bridge.c
+        /// would: "HCRESULT:<session>:<http_code>:<body>". forSession=0 skips the
+        /// protocol's session-correlation check.
+        bool feedHttpResult(int httpCode, const std::string& body = "{}", uint64_t forSession = 0)
+        {
+            const std::string text = "HCRESULT:" + std::to_string(forSession) + ":" +
+                                     std::to_string(httpCode) + ":" + body;
+            return protocol->parseResponseBuffer(reinterpret_cast<const uint8_t*>(text.data()), text.size());
+        }
+
         std::shared_ptr<MockPersistentQueue> mockQueue;
         std::shared_ptr<MockSyncTransport> mockSyncTransport =
             std::make_shared<MockSyncTransport>();
@@ -138,14 +148,7 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleWithOnlyDataValueItems
     std::this_thread::sleep_for(std::chrono::milliseconds(delay * 2));
 
     // Send EndAck
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    auto endAckOffset = endAckBuilder.Finish();
-    auto endMessage =
-        Wazuh::SyncSchema::CreateMessage(endBuilder, Wazuh::SyncSchema::MessageType::EndAck, endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-    protocol->parseResponseBuffer(endBuilder.GetBufferPointer(), endBuilder.GetSize());
+    feedHttpResult(200);  // was Status::Ok
 
     syncThread.join();
 }
@@ -185,14 +188,7 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleWithOnlyDataContextIte
     std::this_thread::sleep_for(std::chrono::milliseconds(delay * 2));
 
     // Send EndAck
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    auto endAckOffset = endAckBuilder.Finish();
-    auto endMessage =
-        Wazuh::SyncSchema::CreateMessage(endBuilder, Wazuh::SyncSchema::MessageType::EndAck, endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-    protocol->parseResponseBuffer(endBuilder.GetBufferPointer(), endBuilder.GetSize());
+    feedHttpResult(200);  // was Status::Ok
 
     syncThread.join();
 }
@@ -241,14 +237,7 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleWithMixedDataValueAndD
     std::this_thread::sleep_for(std::chrono::milliseconds(delay * 3));
 
     // Send EndAck
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    auto endAckOffset = endAckBuilder.Finish();
-    auto endMessage =
-        Wazuh::SyncSchema::CreateMessage(endBuilder, Wazuh::SyncSchema::MessageType::EndAck, endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-    protocol->parseResponseBuffer(endBuilder.GetBufferPointer(), endBuilder.GetSize());
+    feedHttpResult(200);  // was Status::Ok
 
     syncThread.join();
 
@@ -297,14 +286,7 @@ TEST_F(AgentSyncProtocolDataContextTest, SynchronizeModuleDataContextFailureDoes
     // Send StartAck
 
     // Send EndAck with Error status to fail the session
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Error);
-    auto endAckOffset = endAckBuilder.Finish();
-    auto endMessage =
-        Wazuh::SyncSchema::CreateMessage(endBuilder, Wazuh::SyncSchema::MessageType::EndAck, endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-    protocol->parseResponseBuffer(endBuilder.GetBufferPointer(), endBuilder.GetSize());
+    feedHttpResult(500);  // was Status::Error
 
     syncThread.join();
 }
@@ -353,14 +335,7 @@ TEST_F(AgentSyncProtocolDataContextTest, SyncData_DataValuesArriveTogether)
 
     std::this_thread::sleep_for(std::chrono::milliseconds(delay * 2));
 
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    auto endAckOffset = endAckBuilder.Finish();
-    auto endMessage =
-        Wazuh::SyncSchema::CreateMessage(endBuilder, Wazuh::SyncSchema::MessageType::EndAck, endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-    protocol->parseResponseBuffer(endBuilder.GetBufferPointer(), endBuilder.GetSize());
+    feedHttpResult(200);  // was Status::Ok
 
     syncThread.join();
 
@@ -408,14 +383,7 @@ TEST_F(AgentSyncProtocolDataContextTest, SyncData_PayloadContainsExpectedDataVal
 
     std::this_thread::sleep_for(std::chrono::milliseconds(delay * 2));
 
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndAckBuilder endAckBuilder(endBuilder);
-    endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-    auto endAckOffset = endAckBuilder.Finish();
-    auto endMessage =
-        Wazuh::SyncSchema::CreateMessage(endBuilder, Wazuh::SyncSchema::MessageType::EndAck, endAckOffset.Union());
-    endBuilder.Finish(endMessage);
-    protocol->parseResponseBuffer(endBuilder.GetBufferPointer(), endBuilder.GetSize());
+    feedHttpResult(200);  // was Status::Ok
 
     syncThread.join();
 

--- a/src/shared_modules/sync_protocol/tests/test_persistent_queue.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_persistent_queue.cpp
@@ -22,7 +22,7 @@ class MockPersistentQueueStorage : public IPersistentQueueStorage
     public:
         MOCK_METHOD(void, submitOrCoalesce, (const PersistedData& data), (override));
         MOCK_METHOD(void, submitBatch, (const std::vector<PersistedData>& batch), (override));
-        MOCK_METHOD(std::vector<PersistedData>, fetchAndMarkForSync, (), (override));
+        MOCK_METHOD(std::vector<PersistedData>, fetchAndMarkForSync, (size_t maxItems), (override));
         MOCK_METHOD(std::vector<PersistedData>, fetchPending, (bool onlyDataValues), (override));
         MOCK_METHOD(void, removeAllSynced, (), (override));
         MOCK_METHOD(void, resetAllSyncing, (), (override));
@@ -150,7 +150,7 @@ TEST(PersistentQueueTest, FailedBatchIsRetainedAndRetriedOnNextFlushCycle)
     .WillOnce(Return())
     .WillOnce(SaveArg<0>(&retryBatch));
 
-    EXPECT_CALL(*mockStorage, fetchAndMarkForSync())
+    EXPECT_CALL(*mockStorage, fetchAndMarkForSync(_) )
     .WillRepeatedly(Return(std::vector<PersistedData> {}));
 
     {
@@ -184,7 +184,7 @@ TEST(PersistentQueueTest, FetchAllReturnsAllMessages)
         {0, "id2", "idx", "{}", Operation::MODIFY, 0}
     };
 
-    EXPECT_CALL(*mockStorage, fetchAndMarkForSync())
+    EXPECT_CALL(*mockStorage, fetchAndMarkForSync(_) )
     .WillOnce(testing::Return(fakeData));
 
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
@@ -198,7 +198,7 @@ TEST(PersistentQueueTest, FetchAndMarkForSyncThrowsOnStorageError)
 {
     auto mockStorage = std::make_shared<MockPersistentQueueStorage>();
 
-    EXPECT_CALL(*mockStorage, fetchAndMarkForSync())
+    EXPECT_CALL(*mockStorage, fetchAndMarkForSync(_) )
     .WillOnce(testing::Throw(std::runtime_error("Simulated error obtaining items for sync")));
 
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};

--- a/src/shared_modules/sync_protocol/tests/test_persistent_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_persistent_queue_storage.cpp
@@ -403,13 +403,29 @@ TEST_F(PersistentQueueStorageTest, FetchAndMarkForSyncByteBudgetSelectsPrefixOnl
     EXPECT_EQ(secondBlock[0].id, "id2");
 }
 
+// An oversized single item (bigger than the byte cap) must still be returned so
+// the queue does not get stuck, BUT the implementation must emit a LOG_WARNING
+// rather than silently swallowing the violation.
 TEST_F(PersistentQueueStorageTest, FetchAndMarkForSyncByteBudgetAlwaysReturnsAtLeastOneItem)
 {
-    storage->submitOrCoalesce(PersistedData{0, "id1", "index1", "payload1", Operation::CREATE, 1});
+    // Use a fresh storage instance with a capturing logger.
+    bool warnEmitted = false;
+    LoggerFunc capturingLogger = [&warnEmitted](modules_log_level_t level, const std::string & msg)
+    {
+        if (level == LOG_WARNING && msg.find("exceeds") != std::string::npos)
+        {
+            warnEmitted = true;
+        }
+    };
+    auto capStorage = std::make_unique<PersistentQueueStorage>(":memory:", capturingLogger);
 
-    const auto block = storage->fetchAndMarkForSync(1);
+    capStorage->submitOrCoalesce(PersistedData{0, "id1", "index1", "payload1", Operation::CREATE, 1});
+
+    // Budget of 1 byte — the item is far larger than that.
+    const auto block = capStorage->fetchAndMarkForSync(1);
     ASSERT_EQ(block.size(), static_cast<size_t>(1));
     EXPECT_EQ(block[0].id, "id1");
+    EXPECT_TRUE(warnEmitted) << "Expected LOG_WARNING when a single item exceeds the byte cap";
 }
 
 TEST_F(PersistentQueueStorageTest, FetchAndMarkForSyncWithoutByteBudgetReturnsAllPendingRows)

--- a/src/shared_modules/sync_protocol/tests/test_persistent_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_persistent_queue_storage.cpp
@@ -421,11 +421,58 @@ TEST_F(PersistentQueueStorageTest, FetchAndMarkForSyncByteBudgetAlwaysReturnsAtL
 
     capStorage->submitOrCoalesce(PersistedData{0, "id1", "index1", "payload1", Operation::CREATE, 1});
 
-    // Budget of 1 byte — the item is far larger than that.
+    // Budget of 1 byte ï¿½ the item is far larger than that.
     const auto block = capStorage->fetchAndMarkForSync(1);
     ASSERT_EQ(block.size(), static_cast<size_t>(1));
     EXPECT_EQ(block[0].id, "id1");
     EXPECT_TRUE(warnEmitted) << "Expected LOG_WARNING when a single item exceeds the byte cap";
+}
+
+// A single item that keeps exceeding the byte cap across consecutive cycles (e.g.
+// the manager keeps rejecting it with a real 413) must not block the queue behind
+// it forever: past MAX_OVERSIZED_ATTEMPTS (5) cycles it is dropped instead of
+// resent, freeing up whatever was stuck behind it.
+TEST_F(PersistentQueueStorageTest, FetchAndMarkForSyncDropsPersistentlyOversizedItemAfterMaxAttempts)
+{
+    int errorCount = 0;
+    LoggerFunc capturingLogger = [&errorCount](modules_log_level_t level, const std::string & msg)
+    {
+        if (level == LOG_ERROR && msg.find("Dropping") != std::string::npos)
+        {
+            ++errorCount;
+        }
+    };
+    auto capStorage = std::make_unique<PersistentQueueStorage>(":memory:", capturingLogger);
+
+    capStorage->submitOrCoalesce(PersistedData{0, "stuck_id", "index1", "payload1", Operation::CREATE, 1});
+    capStorage->submitOrCoalesce(PersistedData{0, "id2", "index1", "payload2", Operation::CREATE, 1});
+
+    // Simulate consecutive failed sync cycles: each one selects the oversized item
+    // alone, then the caller resets it back to PENDING (as agent_sync_protocol does
+    // on a rejected/failed session) so it is reselected next cycle.
+    for (int cycle = 0; cycle < 5; ++cycle)
+    {
+        const auto block = capStorage->fetchAndMarkForSync(1);
+        ASSERT_EQ(block.size(), static_cast<size_t>(1));
+        EXPECT_EQ(block[0].id, "stuck_id");
+        capStorage->resetAllSyncing();
+    }
+
+    EXPECT_EQ(errorCount, 0) << "Should not drop before exceeding MAX_OVERSIZED_ATTEMPTS";
+
+    // One more cycle crosses the threshold: the item is dropped, and the second
+    // item (previously starved behind it) is now free to be selected.
+    const auto finalBlock = capStorage->fetchAndMarkForSync(1);
+    EXPECT_GE(errorCount, 1) << "Expected LOG_ERROR when the item is finally dropped";
+    ASSERT_EQ(finalBlock.size(), static_cast<size_t>(1));
+    EXPECT_EQ(finalBlock[0].id, "id2");
+
+    capStorage->resetAllSyncing();
+
+    // stuck_id must be gone for good; only id2 remains pending.
+    const auto afterDrop = capStorage->fetchAndMarkForSync(1000);
+    ASSERT_EQ(afterDrop.size(), static_cast<size_t>(1));
+    EXPECT_EQ(afterDrop[0].id, "id2");
 }
 
 TEST_F(PersistentQueueStorageTest, FetchAndMarkForSyncWithoutByteBudgetReturnsAllPendingRows)

--- a/src/shared_modules/sync_protocol/tests/test_persistent_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_persistent_queue_storage.cpp
@@ -386,6 +386,45 @@ TEST_F(PersistentQueueStorageTest, RemoveByIndexDeletesItemsInAnyStatus)
     EXPECT_EQ(remainingItems[0].index, "index2");
 }
 
+TEST_F(PersistentQueueStorageTest, FetchAndMarkForSyncByteBudgetSelectsPrefixOnly)
+{
+    storage->submitOrCoalesce(PersistedData{0, "id1", "index1", "payload1", Operation::CREATE, 1});
+    storage->submitOrCoalesce(PersistedData{0, "id2", "index1", "payload2", Operation::CREATE, 1});
+    storage->submitOrCoalesce(PersistedData{0, "id3", "index1", "payload3", Operation::CREATE, 1});
+
+    const auto firstBlock = storage->fetchAndMarkForSync(1);
+    ASSERT_EQ(firstBlock.size(), static_cast<size_t>(1));
+    EXPECT_EQ(firstBlock[0].id, "id1");
+
+    storage->removeAllSynced();
+
+    const auto secondBlock = storage->fetchAndMarkForSync(1);
+    ASSERT_EQ(secondBlock.size(), static_cast<size_t>(1));
+    EXPECT_EQ(secondBlock[0].id, "id2");
+}
+
+TEST_F(PersistentQueueStorageTest, FetchAndMarkForSyncByteBudgetAlwaysReturnsAtLeastOneItem)
+{
+    storage->submitOrCoalesce(PersistedData{0, "id1", "index1", "payload1", Operation::CREATE, 1});
+
+    const auto block = storage->fetchAndMarkForSync(1);
+    ASSERT_EQ(block.size(), static_cast<size_t>(1));
+    EXPECT_EQ(block[0].id, "id1");
+}
+
+TEST_F(PersistentQueueStorageTest, FetchAndMarkForSyncWithoutByteBudgetReturnsAllPendingRows)
+{
+    storage->submitOrCoalesce(PersistedData{0, "id1", "index1", "payload1", Operation::CREATE, 1});
+    storage->submitOrCoalesce(PersistedData{0, "id2", "index1", "payload2", Operation::MODIFY, 1});
+    storage->submitOrCoalesce(PersistedData{0, "id3", "index1", "payload3", Operation::DELETE_, 1});
+
+    const auto rows = storage->fetchAndMarkForSync(0);
+    ASSERT_EQ(rows.size(), static_cast<size_t>(3));
+    EXPECT_EQ(rows[0].id, "id1");
+    EXPECT_EQ(rows[1].id, "id2");
+    EXPECT_EQ(rows[2].id, "id3");
+}
+
 // Test class for testing deleteDatabase method with mock filesystem wrapper
 class PersistentQueueStorageDeleteDatabaseTest : public ::testing::Test
 {

--- a/src/shared_modules/sync_protocol/tests/test_sync_protocol_integration.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_sync_protocol_integration.cpp
@@ -211,14 +211,7 @@ TEST_F(SyncProtocolIntegrationTest, AgentSyncProtocol_PersistAndFetch)
      */
 
     // Create real AgentSyncProtocol with real database
-    AgentSyncProtocol protocol(
-        "syscollector_vd",
-        testDbPath,
-        logger,
-        std::chrono::seconds(3),
-        1,
-        nullptr  // Let protocol create its own PersistentQueue
-    );
+    AgentSyncProtocol protocol("syscollector_vd", testDbPath, logger, nullptr);
 
     // Persist some data
     std::string packageId = "pkg_001";
@@ -257,14 +250,7 @@ TEST_F(SyncProtocolIntegrationTest, AgentSyncProtocol_VDWorkflow_ClearAndFetch)
      * 5. Verify correct behavior
      */
 
-    AgentSyncProtocol protocol(
-        "syscollector_vd",
-        testDbPath,
-        logger,
-        std::chrono::seconds(3),
-        1,
-        nullptr
-    );
+    AgentSyncProtocol protocol("syscollector_vd", testDbPath, logger, nullptr);
 
     // Step 1: Persist DataValue items
     protocol.persistDifference("pkg1", Operation::CREATE,
@@ -311,14 +297,7 @@ TEST_F(SyncProtocolIntegrationTest, AgentSyncProtocol_MultipleIndices)
      * 3. Verifies correct index assignment
      */
 
-    AgentSyncProtocol protocol(
-        "syscollector_vd",
-        testDbPath,
-        logger,
-        std::chrono::seconds(3),
-        1,
-        nullptr
-    );
+    AgentSyncProtocol protocol("syscollector_vd", testDbPath, logger, nullptr);
 
     // Persist to packages index
     protocol.persistDifference("item1", Operation::CREATE,
@@ -367,14 +346,7 @@ TEST_F(SyncProtocolIntegrationTest, AgentSyncProtocol_DataPersistenceAcrossInsta
 
     // Create first instance and persist data
     {
-        AgentSyncProtocol protocol1(
-            "syscollector_vd",
-            testDbPath,
-            logger,
-            std::chrono::seconds(3),
-            1,
-            nullptr
-        );
+        AgentSyncProtocol protocol1("syscollector_vd", testDbPath, logger, nullptr);
 
         protocol1.persistDifference("persistent_item", Operation::CREATE,
                                     "wazuh-states-vulnerabilities-packages",
@@ -384,14 +356,7 @@ TEST_F(SyncProtocolIntegrationTest, AgentSyncProtocol_DataPersistenceAcrossInsta
 
     // Create second instance with same database
     {
-        AgentSyncProtocol protocol2(
-            "syscollector_vd",
-            testDbPath,
-            logger,
-            std::chrono::seconds(3),
-            1,
-            nullptr
-        );
+        AgentSyncProtocol protocol2("syscollector_vd", testDbPath, logger, nullptr);
 
         // Fetch items - should still have the item from protocol1
         auto items = protocol2.fetchPendingItems(true);

--- a/src/shared_modules/sync_protocol/testtool/main.cpp
+++ b/src/shared_modules/sync_protocol/testtool/main.cpp
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <iostream>
 #include <memory>
+#include <string>
 
 #include "agent_sync_protocol.hpp"
 #include "agent_sync_protocol_types.hpp"
@@ -14,7 +15,8 @@ const unsigned int retries = 1;
 const uint8_t timeout = 2;
 
 /// Stands in for the queue-sync socket: takes the one FullSession message and
-/// answers it the way the manager would, with an Ok EndAck for its session.
+/// answers it the way the manager would, with a 200 OK /stateful HTTP result
+/// for its session.
 class LoopbackTransport final : public ISyncSessionTransport
 {
     public:
@@ -25,14 +27,8 @@ class LoopbackTransport final : public ISyncSessionTransport
 
         bool sendSession(uint64_t session, const std::vector<uint8_t>&) override
         {
-            flatbuffers::FlatBufferBuilder builder;
-            Wazuh::SyncSchema::EndAckBuilder endAckBuilder(builder);
-            endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-            auto endAckOffset = endAckBuilder.Finish();
-            auto message = Wazuh::SyncSchema::CreateMessage(
-                               builder, Wazuh::SyncSchema::MessageType::EndAck, endAckOffset.Union());
-            builder.Finish(message);
-            g_proto->parseResponseBuffer(builder.GetBufferPointer(), builder.GetSize());
+            const std::string response = "HCRESULT:" + std::to_string(session) + ":200:";
+            g_proto->parseResponseBuffer(reinterpret_cast<const uint8_t*>(response.data()), response.size());
             return true;
         }
 };

--- a/src/shared_modules/sync_protocol/testtool/main.cpp
+++ b/src/shared_modules/sync_protocol/testtool/main.cpp
@@ -54,7 +54,7 @@ int main()
         proto.persistDifference("id1", Operation::CREATE, "idx1", "{\"k\":\"v1\"}", 1);
         proto.persistDifference("id2", Operation::MODIFY, "idx2", "{\"k\":\"v2\"}", 2);
 
-        bool ok = proto.synchronizeModule(Mode::FULL).success;
+        bool ok = proto.synchronizeModule(Mode::DELTA).success;
         std::cout << (ok ? "OK" : "FAIL") << std::endl;
         return ok ? 0 : 1;
     }

--- a/src/shared_modules/sync_protocol/testtool/main.cpp
+++ b/src/shared_modules/sync_protocol/testtool/main.cpp
@@ -47,7 +47,7 @@ int main()
             std::cout << "[Test sync_protocol]: " << msg << std::endl;
         };
 
-        AgentSyncProtocol proto{"sync_protocol", ":memory:", std::move(testLogger), std::chrono::seconds(timeout), retries,
+        AgentSyncProtocol proto{"sync_protocol", ":memory:", std::move(testLogger),
                                 nullptr, std::make_shared<LoopbackTransport>()};
         g_proto = &proto;
 

--- a/src/shared_modules/sync_protocol/testtool/main.cpp
+++ b/src/shared_modules/sync_protocol/testtool/main.cpp
@@ -28,7 +28,6 @@ class LoopbackTransport final : public ISyncSessionTransport
             flatbuffers::FlatBufferBuilder builder;
             Wazuh::SyncSchema::EndAckBuilder endAckBuilder(builder);
             endAckBuilder.add_status(Wazuh::SyncSchema::Status::Ok);
-            endAckBuilder.add_session(session);
             auto endAckOffset = endAckBuilder.Finish();
             auto message = Wazuh::SyncSchema::CreateMessage(
                                builder, Wazuh::SyncSchema::MessageType::EndAck, endAckOffset.Union());

--- a/src/shared_modules/utils/flatbuffers/schemas/inventorySync.fbs
+++ b/src/shared_modules/utils/flatbuffers/schemas/inventorySync.fbs
@@ -37,7 +37,6 @@ table DataContext {
 table Start {
     module: string;
     mode: Mode;
-    size: ulong;
     index: [string];
     option: Option;
     architecture: string;

--- a/src/shared_modules/utils/flatbuffers/schemas/inventorySync.fbs
+++ b/src/shared_modules/utils/flatbuffers/schemas/inventorySync.fbs
@@ -14,14 +14,6 @@ enum Operation: byte {
     Delete
 }
 
-enum Status: byte {
-    Ok,
-    Error,
-    Offline,
-    ChecksumMismatch,
-    Processing
-}
-
 enum Option: byte {
     Sync,
     VDFirst,
@@ -63,13 +55,6 @@ table Start {
     cluster_node: string;
 }
 
-table End {
-}
-
-table EndAck {
-    status: Status;
-}
-
 table DataClean {
     index: string;
 }
@@ -105,19 +90,11 @@ union SessionPayload {
 
 /// A whole synchronization session as ONE message.
 ///
-/// The chunked Start -> StartAck -> DataBatch[] -> End -> EndAck exchange used to
-/// exist because the module->agentd transport was a DGRAM socket bounded by
-/// OS_MAXSTR (65536), which forced sessions to be split into ~60 KB batches. Over
-/// the STREAM sync socket that bound is gone, so the whole session crosses at once
-/// and the manager answers it with a single result. StartAck and DataBatch (along
-/// with the per-chunk exchange they supported) no longer exist as message types.
-///
 /// The session id is chosen by the AGENT here, not handed back by an ack,
 /// so a retried session keeps the same id and the manager can dedup it.
 table FullSession {
     start: Start;
     payload: SessionPayload;
-    end: End;
 }
 
 union MessageType {
@@ -125,8 +102,6 @@ union MessageType {
     DataClean,
     ChecksumModule,
     Start,
-    End,
-    EndAck,
     DataContext,
     FullSession
 }

--- a/src/shared_modules/utils/flatbuffers/schemas/inventorySync.fbs
+++ b/src/shared_modules/utils/flatbuffers/schemas/inventorySync.fbs
@@ -52,6 +52,7 @@ table Start {
     global_version: ulong;
     cluster_name: string;
     cluster_node: string;
+    feed_offset: ulong;
 }
 
 table DataClean {

--- a/src/shared_modules/utils/flatbuffers/schemas/inventorySync.fbs
+++ b/src/shared_modules/utils/flatbuffers/schemas/inventorySync.fbs
@@ -1,7 +1,6 @@
 namespace Wazuh.SyncSchema;
 
 enum Mode: byte {
-    ModuleFull,
     ModuleDelta,
     ModuleCheck,
     MetadataDelta,
@@ -30,7 +29,6 @@ enum Option: byte {
 }
 
 table DataValue {
-    seq: ulong;
     operation: Operation;
     id: string;
     index: string;
@@ -39,7 +37,6 @@ table DataValue {
 }
 
 table DataContext {
-    seq: ulong;
     id: string;
     index: string;
     data: [byte];
@@ -66,10 +63,6 @@ table Start {
     cluster_node: string;
 }
 
-table StartAck {
-    status: Status;
-}
-
 table End {
 }
 
@@ -77,27 +70,13 @@ table EndAck {
     status: Status;
 }
 
-table Pair {
-    begin: ulong;
-    end: ulong;
-}
-
-table ReqRet {
-    seq: [Pair];
-}
-
 table DataClean {
-    seq: ulong;
     index: string;
 }
 
 table ChecksumModule {
     index: string;
     checksum: string;
-}
-
-table DataBatch {
-    values: [DataValue];
 }
 
 /// The data-sync payload of a FullSession: DataValue items (module/metadata
@@ -108,31 +87,32 @@ table SyncData {
     contexts: [DataContext];
 }
 
+/// A session may clean several indices at once (e.g. FIM clearing files,
+/// registry keys, and registry values together), so this is a real array.
 table Cleans {
     items: [DataClean];
 }
 
-table Checksums {
-    items: [ChecksumModule];
-}
-
 /// A session carries exactly one of these: a data sync, a clean notification,
-/// or an integrity checksum - never a combination.
+/// or an integrity checksum - never a combination. An integrity check always
+/// covers a single index/module, so it references ChecksumModule directly
+/// instead of wrapping it in an array table.
 union SessionPayload {
     SyncData,
     Cleans,
-    Checksums
+    ChecksumModule
 }
 
 /// A whole synchronization session as ONE message.
 ///
-/// The chunked Start -> StartAck -> DataBatch[] -> End -> EndAck exchange exists
-/// because the module->agentd transport was a DGRAM socket bounded by OS_MAXSTR
-/// (65536), which forced sessions to be split into ~60 KB batches. Over the
-/// STREAM sync socket that bound is gone, so the whole session crosses at once
-/// and the manager answers it with a single result.
+/// The chunked Start -> StartAck -> DataBatch[] -> End -> EndAck exchange used to
+/// exist because the module->agentd transport was a DGRAM socket bounded by
+/// OS_MAXSTR (65536), which forced sessions to be split into ~60 KB batches. Over
+/// the STREAM sync socket that bound is gone, so the whole session crosses at once
+/// and the manager answers it with a single result. StartAck and DataBatch (along
+/// with the per-chunk exchange they supported) no longer exist as message types.
 ///
-/// The session id is chosen by the AGENT here, not handed back by a StartAck,
+/// The session id is chosen by the AGENT here, not handed back by an ack,
 /// so a retried session keeps the same id and the manager can dedup it.
 table FullSession {
     start: Start;
@@ -145,12 +125,9 @@ union MessageType {
     DataClean,
     ChecksumModule,
     Start,
-    StartAck,
     End,
     EndAck,
-    ReqRet,
     DataContext,
-    DataBatch,
     FullSession
 }
 

--- a/src/shared_modules/utils/flatbuffers/schemas/inventorySync.fbs
+++ b/src/shared_modules/utils/flatbuffers/schemas/inventorySync.fbs
@@ -100,6 +100,30 @@ table DataBatch {
     values: [DataValue];
 }
 
+/// The data-sync payload of a FullSession: DataValue items (module/metadata
+/// upserts and deletes) and DataContext items (vulnerability-detection data)
+/// travel together in the same session, so both live here side by side.
+table SyncData {
+    values: [DataValue];
+    contexts: [DataContext];
+}
+
+table Cleans {
+    items: [DataClean];
+}
+
+table Checksums {
+    items: [ChecksumModule];
+}
+
+/// A session carries exactly one of these: a data sync, a clean notification,
+/// or an integrity checksum - never a combination.
+union SessionPayload {
+    SyncData,
+    Cleans,
+    Checksums
+}
+
 /// A whole synchronization session as ONE message.
 ///
 /// The chunked Start -> StartAck -> DataBatch[] -> End -> EndAck exchange exists
@@ -112,10 +136,7 @@ table DataBatch {
 /// so a retried session keeps the same id and the manager can dedup it.
 table FullSession {
     start: Start;
-    batches: [DataBatch];
-    contexts: [DataContext];
-    cleans: [DataClean];
-    checksums: [ChecksumModule];
+    payload: SessionPayload;
     end: End;
 }
 

--- a/src/shared_modules/utils/flatbuffers/schemas/inventorySync.fbs
+++ b/src/shared_modules/utils/flatbuffers/schemas/inventorySync.fbs
@@ -31,7 +31,6 @@ enum Option: byte {
 
 table DataValue {
     seq: ulong;
-    session: ulong;
     operation: Operation;
     id: string;
     index: string;
@@ -41,7 +40,6 @@ table DataValue {
 
 table DataContext {
     seq: ulong;
-    session: ulong;
     id: string;
     index: string;
     data: [byte];
@@ -70,16 +68,13 @@ table Start {
 
 table StartAck {
     status: Status;
-    session: ulong;
 }
 
 table End {
-    session: ulong;
 }
 
 table EndAck {
     status: Status;
-    session: ulong;
 }
 
 table Pair {
@@ -89,17 +84,14 @@ table Pair {
 
 table ReqRet {
     seq: [Pair];
-    session: ulong;
 }
 
 table DataClean {
     seq: ulong;
-    session: ulong;
     index: string;
 }
 
 table ChecksumModule {
-    session: ulong;
     index: string;
     checksum: string;
 }
@@ -119,7 +111,6 @@ table DataBatch {
 /// The session id is chosen by the AGENT here, not handed back by a StartAck,
 /// so a retried session keeps the same id and the manager can dedup it.
 table FullSession {
-    session: ulong;
     start: Start;
     batches: [DataBatch];
     contexts: [DataContext];

--- a/src/syscheckd/src/config.c
+++ b/src/syscheckd/src/config.c
@@ -486,7 +486,6 @@ cJSON *getSyscheckConfig(void) {
     cJSON_AddStringToObject(synchronization, "enabled", syscheck.enable_synchronization ? "yes" : "no");
     cJSON_AddNumberToObject(synchronization, "interval", syscheck.sync_interval);
     cJSON_AddNumberToObject(synchronization, "max_eps", syscheck.sync_max_eps);
-    cJSON_AddNumberToObject(synchronization, "response_timeout", syscheck.sync_response_timeout);
     cJSON_AddNumberToObject(synchronization, "integrity_interval", syscheck.integrity_interval);
     cJSON_AddNumberToObject(synchronization, "sync_end_delay", syscheck.sync_end_delay);
 

--- a/src/syscheckd/src/recovery/recovery.c
+++ b/src/syscheckd/src/recovery/recovery.c
@@ -95,8 +95,36 @@ void fim_recovery_persist_table_and_resync(char* table_name, AgentSyncProtocolHa
 
     int item_count = cJSON_GetArraySize(items);
 
-    // Make sure memory is clean before we start to persist
-    asp_clear_in_memory_data(handle);
+    // The sync index only depends on the table, not on any individual item.
+    const char* recovery_index = NULL;
+    if (strcmp(table_name, FIMDB_FILE_TABLE_NAME) == 0) {
+        recovery_index = FIM_FILES_SYNC_INDEX;
+    }
+#ifdef WIN32
+    else if (strcmp(table_name, FIMDB_REGISTRY_KEY_TABLENAME) == 0) {
+        recovery_index = FIM_REGISTRY_KEYS_SYNC_INDEX;
+    }
+    else if (strcmp(table_name, FIMDB_REGISTRY_VALUE_TABLENAME) == 0) {
+        recovery_index = FIM_REGISTRY_VALUES_SYNC_INDEX;
+    }
+#endif
+    else {
+        merror("Invalid table name: %s", table_name);
+        cJSON_Delete(items);
+        return;
+    }
+
+    // Clear the manager's index for this table before resending: recovery is now a
+    // DataClean followed by a DELTA sync of the fresh snapshot, never Mode::FULL (which
+    // used to make the manager unconditionally deleteByQuery over a byte-capped/truncated
+    // payload and could permanently drop whatever didn't fit in that one session).
+    const char* clean_indices[] = { recovery_index };
+    if (!asp_notify_data_clean(handle, clean_indices, 1)) {
+        merror("Failed to clear index '%s' before recovery resync for table %s; will retry later",
+               recovery_index, table_name);
+        cJSON_Delete(items);
+        return;
+    }
 
     // Process each item
     for (int i = 0; i < item_count; i++) {
@@ -221,7 +249,7 @@ void fim_recovery_persist_table_and_resync(char* table_name, AgentSyncProtocolHa
 
                 // Persist only if validation passed
                 if (validation_passed) {
-                    asp_persist_diff_in_memory(handle, hashed_id, OPERATION_CREATE, index, stateful_event_str, document_version);
+                    asp_persist_diff(handle, hashed_id, OPERATION_CREATE, index, stateful_event_str, document_version);
                 }
 
                 os_free(stateful_event_str);
@@ -234,14 +262,14 @@ void fim_recovery_persist_table_and_resync(char* table_name, AgentSyncProtocolHa
         os_free(id_str);
     }
 
-    mdebug1("Persisted %d recovery items in memory", item_count);
+    mdebug1("Persisted %d recovery items", item_count);
     mdebug1("Starting recovery synchronization...");
 
     // Clean up items array
     cJSON_Delete(items);
 
     // Synchronize
-    SyncModuleResult_t result = asp_sync_module(handle, MODE_FULL);
+    SyncModuleResult_t result = asp_sync_module(handle, MODE_DELTA);
 
     if (result.success) {
         mdebug1("Recovery completed successfully");

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -488,7 +488,7 @@ void fim_initialize() {
     notify_scan = syscheck.notify_first_scan;
 
     // Initialize sync handle early so it's available for document promotion
-    syscheck.sync_handle = asp_create("fim", FIM_SYNC_PROTOCOL_DB_PATH, loggingFunction, syscheck.sync_response_timeout, FIM_SYNC_RETRIES);
+    syscheck.sync_handle = asp_create("fim", FIM_SYNC_PROTOCOL_DB_PATH, loggingFunction);
     if (!syscheck.sync_handle) {
         merror_exit("Failed to initialize AgentSyncProtocol");
     }

--- a/src/unit_tests/client-agent/https_client_stubs.c
+++ b/src/unit_tests/client-agent/https_client_stubs.c
@@ -52,11 +52,7 @@ bool hc_submit_event(void *handle, const uint8_t *frame, size_t length)
     return false;
 }
 
-/* Windows delivers /stateful sessions in-process, so the bridge calls this
- * one only there -- which is why its absence broke the winagent test link
- * while the POSIX build, whose sessions arrive over the sync socket, was fine. */
-bool hc_submit_sync_session(void *handle, const char *session_id, const uint8_t *buffer,
-                            size_t length)
+bool hc_submit_sync_session(void *handle, const char *session_id, const uint8_t *buffer, size_t length)
 {
     (void)handle;
     (void)session_id;

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -516,7 +516,7 @@ target_compile_options(test_recovery PRIVATE "-Wall")
 set(RECOVERY_BASE_FLAGS "-Wl,--wrap,fim_db_get_last_sync_time -Wl,--wrap,fim_db_update_last_sync_time_value \
                          -Wl,--wrap,fim_db_get_every_element -Wl,--wrap,fim_db_calculate_table_checksum \
                          -Wl,--wrap,fim_db_increase_each_entry_version \
-                         -Wl,--wrap,asp_clear_in_memory_data -Wl,--wrap,asp_persist_diff_in_memory \
+                         -Wl,--wrap,asp_notify_data_clean -Wl,--wrap,asp_persist_diff \
                          -Wl,--wrap,asp_sync_module -Wl,--wrap,asp_requires_full_sync \
                          -Wl,--wrap,merror -Wl,--wrap,minfo -Wl,--wrap,mdebug1 \
                          -Wl,--wrap,build_stateful_event_file -Wl,--wrap,build_stateful_event_registry_key \

--- a/src/unit_tests/syscheckd/test_recovery.c
+++ b/src/unit_tests/syscheckd/test_recovery.c
@@ -167,8 +167,11 @@ static void test_fim_recovery_persist_table_and_resync_success(void **state) {
     expect_string(__wrap_fim_db_get_every_element, row_filter, "WHERE sync=1");
     will_return(__wrap_fim_db_get_every_element, test_items);
 
-    // Expect asp_clear_in_memory_data call
-    expect_value(__wrap_asp_clear_in_memory_data, handle, handle);
+    // Expect asp_notify_data_clean call (clears the manager's index before resending)
+    expect_value(__wrap_asp_notify_data_clean, handle, handle);
+    expect_any(__wrap_asp_notify_data_clean, indices);
+    expect_value(__wrap_asp_notify_data_clean, indices_count, 1);
+    will_return(__wrap_asp_notify_data_clean, true);
 
     // Orphan guard: path must still resolve to a config
     expect_string(__wrap_fim_configuration_directory, path, "/tmp/test.txt");
@@ -184,16 +187,17 @@ static void test_fim_recovery_persist_table_and_resync_success(void **state) {
     // Schema validator is not initialized (no validation)
     will_return(__wrap_schema_validator_is_initialized, false);
 
-    // Expect asp_persist_diff_in_memory call - validate all parameters
-    expect_value(__wrap_asp_persist_diff_in_memory, handle, handle);
-    expect_any(__wrap_asp_persist_diff_in_memory, id);
-    expect_value(__wrap_asp_persist_diff_in_memory, operation, OPERATION_CREATE);
-    expect_string(__wrap_asp_persist_diff_in_memory, index, FIM_FILES_SYNC_INDEX);
-    expect_any(__wrap_asp_persist_diff_in_memory, data);
+    // Expect asp_persist_diff call - validate all parameters
+    expect_value(__wrap_asp_persist_diff, handle, handle);
+    expect_any(__wrap_asp_persist_diff, id);
+    expect_value(__wrap_asp_persist_diff, operation, OPERATION_CREATE);
+    expect_string(__wrap_asp_persist_diff, index, FIM_FILES_SYNC_INDEX);
+    expect_any(__wrap_asp_persist_diff, data);
+    expect_value(__wrap_asp_persist_diff, version, 1);
 
     // Expect asp_sync_module call - return success
     expect_value(__wrap_asp_sync_module, handle, handle);
-    expect_value(__wrap_asp_sync_module, mode, MODE_FULL);
+    expect_value(__wrap_asp_sync_module, mode, MODE_DELTA);
     will_return(__wrap_asp_sync_module, true);
 
     // Call the function
@@ -228,8 +232,11 @@ static void test_fim_recovery_persist_table_and_resync_failure(void **state) {
     expect_string(__wrap_fim_db_get_every_element, row_filter, "WHERE sync=1");
     will_return(__wrap_fim_db_get_every_element, test_items);
 
-    // Expect asp_clear_in_memory_data call
-    expect_value(__wrap_asp_clear_in_memory_data, handle, handle);
+    // Expect asp_notify_data_clean call (clears the manager's index before resending)
+    expect_value(__wrap_asp_notify_data_clean, handle, handle);
+    expect_any(__wrap_asp_notify_data_clean, indices);
+    expect_value(__wrap_asp_notify_data_clean, indices_count, 1);
+    will_return(__wrap_asp_notify_data_clean, true);
 
     // Orphan guard: path must still resolve to a config
     expect_string(__wrap_fim_configuration_directory, path, "/tmp/test2.txt");
@@ -245,16 +252,17 @@ static void test_fim_recovery_persist_table_and_resync_failure(void **state) {
     // Schema validator is not initialized (no validation)
     will_return(__wrap_schema_validator_is_initialized, false);
 
-    // Expect asp_persist_diff_in_memory call - validate all parameters
-    expect_value(__wrap_asp_persist_diff_in_memory, handle, handle);
-    expect_any(__wrap_asp_persist_diff_in_memory, id);
-    expect_value(__wrap_asp_persist_diff_in_memory, operation, OPERATION_CREATE);
-    expect_string(__wrap_asp_persist_diff_in_memory, index, FIM_FILES_SYNC_INDEX);
-    expect_any(__wrap_asp_persist_diff_in_memory, data);
+    // Expect asp_persist_diff call - validate all parameters
+    expect_value(__wrap_asp_persist_diff, handle, handle);
+    expect_any(__wrap_asp_persist_diff, id);
+    expect_value(__wrap_asp_persist_diff, operation, OPERATION_CREATE);
+    expect_string(__wrap_asp_persist_diff, index, FIM_FILES_SYNC_INDEX);
+    expect_any(__wrap_asp_persist_diff, data);
+    expect_value(__wrap_asp_persist_diff, version, 1);
 
     // Expect asp_sync_module call - return failure
     expect_value(__wrap_asp_sync_module, handle, handle);
-    expect_value(__wrap_asp_sync_module, mode, MODE_FULL);
+    expect_value(__wrap_asp_sync_module, mode, MODE_DELTA);
     will_return(__wrap_asp_sync_module, false);
 
     // Call the function
@@ -404,12 +412,15 @@ static void test_fim_recovery_persist_table_and_resync_skips_orphan_paths(void *
     expect_string(__wrap_fim_db_get_every_element, row_filter, "WHERE sync=1");
     will_return(__wrap_fim_db_get_every_element, test_items);
 
-    expect_value(__wrap_asp_clear_in_memory_data, handle, handle);
+    expect_value(__wrap_asp_notify_data_clean, handle, handle);
+    expect_any(__wrap_asp_notify_data_clean, indices);
+    expect_value(__wrap_asp_notify_data_clean, indices_count, 1);
+    will_return(__wrap_asp_notify_data_clean, true);
 
     // Orphaned path: config lookup returns NULL -> row is skipped entirely.
     expect_string(__wrap_fim_configuration_directory, path, "/home/vagrant/orphan.txt");
     will_return(__wrap_fim_configuration_directory, NULL);
-    // No build_stateful_event_file / asp_persist_diff_in_memory expectations for the orphan row.
+    // No build_stateful_event_file / asp_persist_diff expectations for the orphan row.
 
     // Live path: config lookup returns non-NULL -> normal pipeline.
     expect_string(__wrap_fim_configuration_directory, path, "/etc/passwd");
@@ -422,14 +433,15 @@ static void test_fim_recovery_persist_table_and_resync_skips_orphan_paths(void *
 
     will_return(__wrap_schema_validator_is_initialized, false);
 
-    expect_value(__wrap_asp_persist_diff_in_memory, handle, handle);
-    expect_any(__wrap_asp_persist_diff_in_memory, id);
-    expect_value(__wrap_asp_persist_diff_in_memory, operation, OPERATION_CREATE);
-    expect_string(__wrap_asp_persist_diff_in_memory, index, FIM_FILES_SYNC_INDEX);
-    expect_any(__wrap_asp_persist_diff_in_memory, data);
+    expect_value(__wrap_asp_persist_diff, handle, handle);
+    expect_any(__wrap_asp_persist_diff, id);
+    expect_value(__wrap_asp_persist_diff, operation, OPERATION_CREATE);
+    expect_string(__wrap_asp_persist_diff, index, FIM_FILES_SYNC_INDEX);
+    expect_any(__wrap_asp_persist_diff, data);
+    expect_value(__wrap_asp_persist_diff, version, 1);
 
     expect_value(__wrap_asp_sync_module, handle, handle);
-    expect_value(__wrap_asp_sync_module, mode, MODE_FULL);
+    expect_value(__wrap_asp_sync_module, mode, MODE_DELTA);
     will_return(__wrap_asp_sync_module, true);
 
     fim_recovery_persist_table_and_resync(FIMDB_FILE_TABLE_NAME, handle, &mock_directories);

--- a/src/unit_tests/syscheckd/test_syscheck.c
+++ b/src/unit_tests/syscheckd/test_syscheck.c
@@ -102,7 +102,6 @@ void test_fim_initialize(void **state)
 {
     syscheck_config *syscheck_conf = *state;
     syscheck.sync_end_delay = 1;
-    syscheck.sync_response_timeout = 30;
     syscheck.sync_max_eps = 3;
 
 #ifdef TEST_WINAGENT
@@ -122,8 +121,6 @@ void test_fim_initialize(void **state)
     will_return(__wrap_w_query_agentd, true);
 
     expect_string(__wrap_asp_create, module, "fim");
-    expect_value(__wrap_asp_create, timeout, syscheck.sync_response_timeout);
-    expect_value(__wrap_asp_create, retries, FIM_SYNC_RETRIES);
 
     will_return(__wrap_asp_create, (AgentSyncProtocolHandle*)0xABCD1234);
 
@@ -214,11 +211,8 @@ void test_Start_win32_Syscheck_corrupted_config_file(void **state) {
     expect_wrapper_fim_db_init(0, 100000, 100000);
 
     syscheck.sync_end_delay = 1;
-    syscheck.sync_response_timeout = 30;
     syscheck.sync_max_eps = 3;
     expect_string(__wrap_asp_create, module, "fim");
-    expect_value(__wrap_asp_create, timeout, syscheck.sync_response_timeout);
-    expect_value(__wrap_asp_create, retries, FIM_SYNC_RETRIES);
     will_return(__wrap_asp_create, (AgentSyncProtocolHandle*)0xABCD1234);
 
     // Schema validator initialization
@@ -261,11 +255,8 @@ void test_Start_win32_Syscheck_syscheck_disabled_1(void **state) {
     expect_string(__wrap__minfo, formatted_msg, FIM_DISK_QUOTA_LIMIT_DISABLED);
 
     syscheck.sync_end_delay = 1;
-    syscheck.sync_response_timeout = 30;
     syscheck.sync_max_eps = 3;
     expect_string(__wrap_asp_create, module, "fim");
-    expect_value(__wrap_asp_create, timeout, syscheck.sync_response_timeout);
-    expect_value(__wrap_asp_create, retries, FIM_SYNC_RETRIES);
     will_return(__wrap_asp_create, (AgentSyncProtocolHandle*)0xABCD1234);
 
     snprintf(info_msg, OS_MAXSTR, "Started (pid: %d).", getpid());
@@ -309,11 +300,8 @@ void test_Start_win32_Syscheck_syscheck_disabled_2(void **state) {
     expect_string(__wrap__minfo, formatted_msg, FIM_DISK_QUOTA_LIMIT_DISABLED);
 
     syscheck.sync_end_delay = 1;
-    syscheck.sync_response_timeout = 30;
     syscheck.sync_max_eps = 3;
     expect_string(__wrap_asp_create, module, "fim");
-    expect_value(__wrap_asp_create, timeout, syscheck.sync_response_timeout);
-    expect_value(__wrap_asp_create, retries, FIM_SYNC_RETRIES);
     will_return(__wrap_asp_create, (AgentSyncProtocolHandle*)0xABCD1234);
 
     snprintf(info_msg, OS_MAXSTR, "Started (pid: %d).", getpid());
@@ -394,11 +382,8 @@ void test_Start_win32_Syscheck_dirs_and_registry(void **state) {
     expect_wrapper_fim_db_init(0, 100000, 100000);
 
     syscheck.sync_end_delay = 1;
-    syscheck.sync_response_timeout = 30;
     syscheck.sync_max_eps = 3;
     expect_string(__wrap_asp_create, module, "fim");
-    expect_value(__wrap_asp_create, timeout, syscheck.sync_response_timeout);
-    expect_value(__wrap_asp_create, retries, FIM_SYNC_RETRIES);
     will_return(__wrap_asp_create, (AgentSyncProtocolHandle*)0xABCD1234);
 
     snprintf(info_msg, OS_MAXSTR, "Started (pid: %d).", getpid());
@@ -460,11 +445,8 @@ void test_Start_win32_Syscheck_whodata_active(void **state) {
     expect_wrapper_fim_db_init(0, 100000, 100000);
 
     syscheck.sync_end_delay = 1;
-    syscheck.sync_response_timeout = 30;
     syscheck.sync_max_eps = 3;
     expect_string(__wrap_asp_create, module, "fim");
-    expect_value(__wrap_asp_create, timeout, syscheck.sync_response_timeout);
-    expect_value(__wrap_asp_create, retries, FIM_SYNC_RETRIES);
     will_return(__wrap_asp_create, (AgentSyncProtocolHandle*)0xABCD1234);
 
     expect_string(__wrap__minfo, formatted_msg, FIM_FILE_SIZE_LIMIT_DISABLED);

--- a/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.c
@@ -47,18 +47,6 @@ SyncModuleResult_t __wrap_asp_sync_module(AgentSyncProtocolHandle* handle,
     return result;
 }
 
-void __wrap_asp_persist_diff_in_memory(AgentSyncProtocolHandle* handle,
-                                       const char* id,
-                                       int operation,
-                                       const char* index,
-                                       const char* data) {
-    check_expected_ptr(handle);
-    check_expected_ptr(id);
-    check_expected(operation);
-    check_expected_ptr(index);
-    check_expected_ptr(data);
-}
-
 bool __wrap_asp_requires_full_sync(AgentSyncProtocolHandle* handle,
                                    const char* index,
                                    const char* checksum) {
@@ -73,10 +61,6 @@ bool __wrap_asp_parse_response_buffer(AgentSyncProtocolHandle* handle, const uin
     check_expected_ptr(data);
     check_expected(length);
     return mock_type(bool);
-}
-
-void __wrap_asp_clear_in_memory_data(AgentSyncProtocolHandle* handle) {
-    check_expected_ptr(handle);
 }
 
 SyncModuleResult_t __wrap_asp_sync_metadata_or_groups(AgentSyncProtocolHandle* handle,

--- a/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.c
@@ -12,12 +12,10 @@
 __attribute__((weak)) void __wrap_asp_sync_module_hook(void) {
 }
 
-AgentSyncProtocolHandle* __wrap_asp_create(const char* module, const char* db_path, asp_logger_t logger, unsigned int timeout, unsigned int retries) {
+AgentSyncProtocolHandle* __wrap_asp_create(const char* module, const char* db_path, asp_logger_t logger) {
     check_expected_ptr(module);
     (void)db_path;
     (void)logger;
-    check_expected(timeout);
-    check_expected(retries);
     return mock_ptr_type(AgentSyncProtocolHandle*);
 }
 

--- a/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.h
@@ -28,12 +28,6 @@ void __wrap_asp_persist_diff(AgentSyncProtocolHandle* handle,
                              const char* data,
                              uint64_t version);
 
-void __wrap_asp_persist_diff_in_memory(AgentSyncProtocolHandle* handle,
-                                       const char* id,
-                                       int operation,
-                                       const char* index,
-                                       const char* data);
-
 SyncModuleResult_t __wrap_asp_sync_module(AgentSyncProtocolHandle* handle,
                                           int mode);
 
@@ -42,8 +36,6 @@ bool __wrap_asp_requires_full_sync(AgentSyncProtocolHandle* handle,
                                    const char* checksum);
 
 bool __wrap_asp_parse_response_buffer(AgentSyncProtocolHandle* handle, const uint8_t* data, size_t length);
-
-void __wrap_asp_clear_in_memory_data(AgentSyncProtocolHandle* handle);
 
 SyncModuleResult_t __wrap_asp_sync_metadata_or_groups(AgentSyncProtocolHandle* handle,
                                                       int mode);

--- a/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared_modules/agent_sync_protocol_wrappers.h
@@ -17,7 +17,7 @@
 #include <stdbool.h>
 #include "agent_sync_protocol_c_interface.h"
 
-AgentSyncProtocolHandle* __wrap_asp_create(const char* module, const char* db_path, asp_logger_t logger, unsigned int timeout, unsigned int retries);
+AgentSyncProtocolHandle* __wrap_asp_create(const char* module, const char* db_path, asp_logger_t logger);
 
 void __wrap_asp_destroy(AgentSyncProtocolHandle* handle);
 

--- a/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
@@ -87,11 +87,6 @@ class AgentInfoImpl
         /// @param moduleName Name of the module
         void initSyncProtocol(const std::string& moduleName);
 
-        /// @brief Set synchronization parameters
-        /// @param timeout Response timeout in seconds
-        /// @param retries Number of retries
-        void setSyncParameters(uint32_t timeout, uint32_t retries);
-
         /// @brief Set the predicate used to detect that a shutdown is in progress.
         /// It complements the module's own stop flag so that failures caused by the global agent
         /// shutdown (which happens before this module receives its own stop) are logged at a lower
@@ -343,12 +338,6 @@ class AgentInfoImpl
 
         /// @brief Sync protocol for agent synchronization
         std::unique_ptr<IAgentSyncProtocol> m_spSyncProtocol;
-
-        /// @brief Sync configuration: response timeout in seconds
-        uint32_t m_syncResponseTimeout = 30;
-
-        /// @brief Sync configuration: number of retries
-        uint32_t m_syncRetries = 5;
 
         /// @brief Flag to track if module has been stopped.
         /// Atomic so the poll loops can read it without holding m_mutex while

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -364,9 +364,7 @@ void AgentInfoImpl::initSyncProtocol(const std::string& moduleName)
     {
         m_spSyncProtocol = std::make_unique<AgentSyncProtocol>(moduleName,
                                                                std::nullopt,
-                                                               logger_func,
-                                                               std::chrono::seconds(m_syncResponseTimeout),
-                                                               m_syncRetries);
+                                                               logger_func);
         m_logFunction(LOG_DEBUG, "Agent-info sync protocol initialized with only in-memory synchronization");
     }
     catch (const std::exception& ex)
@@ -375,15 +373,6 @@ void AgentInfoImpl::initSyncProtocol(const std::string& moduleName)
         // Re-throw to allow caller to handle
         throw;
     }
-}
-
-void AgentInfoImpl::setSyncParameters(uint32_t timeout, uint32_t retries)
-{
-    m_syncResponseTimeout = timeout;
-    m_syncRetries = retries;
-
-    m_logFunction(LOG_DEBUG,
-                  "Sync parameters set: timeout=" + std::to_string(timeout) + "s, retries=" + std::to_string(retries));
 }
 
 void AgentInfoImpl::setIsShuttingDownFunction(std::function<bool()> isShuttingDown)

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_dbsync_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_dbsync_test.cpp
@@ -138,18 +138,7 @@ TEST_F(AgentInfoDBSyncIntegrationTest, GetCreateStatementReturnsValidSQL)
     EXPECT_THAT(m_logOutput, ::testing::HasSubstr("AgentInfo initialized"));
 }
 
-TEST_F(AgentInfoDBSyncIntegrationTest, SetSyncParametersConfiguresValues)
-{
-    m_agentInfo = std::make_shared<AgentInfoImpl>(":memory:", nullptr, m_logFunc, m_queryModuleFunc, m_mockDBSync);
 
-    // Set sync parameters
-    EXPECT_NO_THROW(m_agentInfo->setSyncParameters(60, 5));
-
-    // Verify the log message contains the parameters
-    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("Sync parameters set"));
-    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("timeout=60"));
-    EXPECT_THAT(m_logOutput, ::testing::HasSubstr("retries=5"));
-}
 
 TEST_F(AgentInfoDBSyncIntegrationTest, InitSyncProtocolLogsMessages)
 {

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_integrity_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_integrity_test.cpp
@@ -233,7 +233,7 @@ TEST_F(AgentInfoIntegrityTest, IntegrityCheckTriggeredWhenIntervalElapsed)
                       m_mockFileSystem
                   );
 
-    m_agentInfo->setSyncParameters(1, 1);
+
 
     m_agentInfo->initSyncProtocol("test_module");
 
@@ -334,7 +334,7 @@ TEST_F(AgentInfoIntegrityTest, IntegrityCheckRunsAfterDeltaSyncCompletes)
                       m_mockFileSystem
                   );
 
-    m_agentInfo->setSyncParameters(1, 0);
+
 
     m_agentInfo->initSyncProtocol("test_module");
 
@@ -438,7 +438,7 @@ TEST_F(AgentInfoIntegrityTest, IntegrityCheckForBothMetadataAndGroups)
                       m_mockFileSystem
                   );
 
-    m_agentInfo->setSyncParameters(1, 1);
+
 
     m_agentInfo->initSyncProtocol("test_module");
 

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_successful_coordination_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_successful_coordination_test.cpp
@@ -104,7 +104,7 @@ TEST_F(AgentInfoSuccessfulCoordinationTest, CoordinationWithNoModulesAvailable)
                   );
 
     // Set very short timeouts to make tests finish quickly
-    m_agentInfo->setSyncParameters(1, 1); // 1 second timeout, 1 retry
+    // 1 second timeout, 1 retry
 
     // Initialize sync protocol
     m_agentInfo->initSyncProtocol("test_module");
@@ -206,7 +206,7 @@ TEST_F(AgentInfoSuccessfulCoordinationTest, CompleteSuccessfulCoordinationFlow)
                   );
 
     // Set very short timeouts to make tests finish quickly
-    m_agentInfo->setSyncParameters(1, 1); // 1 second timeout, 1 retry
+    // 1 second timeout, 1 retry
 
     // Initialize sync protocol
     m_agentInfo->initSyncProtocol("test_module");
@@ -309,7 +309,7 @@ TEST_F(AgentInfoSuccessfulCoordinationTest, SuccessfulFlushOperation)
                   );
 
     // Set very short timeouts to make tests finish quickly
-    m_agentInfo->setSyncParameters(1, 1); // 1 second timeout, 1 retry
+    // 1 second timeout, 1 retry
 
     m_agentInfo->initSyncProtocol("test_module");
 
@@ -397,7 +397,7 @@ TEST_F(AgentInfoSuccessfulCoordinationTest, SuccessfulResumeOperation)
                   );
 
     // Set very short timeouts to make tests finish quickly
-    m_agentInfo->setSyncParameters(1, 1); // 1 second timeout, 1 retry
+    // 1 second timeout, 1 retry
 
     m_agentInfo->initSyncProtocol("test_module");
 
@@ -476,7 +476,7 @@ TEST_F(AgentInfoSuccessfulCoordinationTest, CoordinationCompletionMessage)
                   );
 
     // Set very short timeouts to make tests finish quickly
-    m_agentInfo->setSyncParameters(1, 1); // 1 second timeout, 1 retry
+    // 1 second timeout, 1 retry
 
     m_agentInfo->initSyncProtocol("test_module");
 

--- a/src/wazuh_modules/agent_info/src/agent_info.cpp
+++ b/src/wazuh_modules/agent_info/src/agent_info.cpp
@@ -341,9 +341,6 @@ void agent_info_start(const struct wm_agent_info_t* agent_info_config)
     // metadata/groups synchronization was disabled without any error.
     try
     {
-        g_agent_info_impl->setSyncParameters(agent_info_config->sync.sync_response_timeout,
-                                             agent_info_config->sync.sync_retries);
-
         if (g_module_name)
         {
             if (g_log_callback)

--- a/src/wazuh_modules/inventory_sync/src/agentSession.hpp
+++ b/src/wazuh_modules/inventory_sync/src/agentSession.hpp
@@ -88,6 +88,11 @@ class AgentSessionImpl final
     bool m_endEnqueued = false;         ///< Whether the END message has been enqueued
     uint64_t m_declaredSize {0};        ///< DataValue count declared in the Start message (for quota accounting)
     const LogFn& m_logFn;               ///< Log function for this session
+    // TODO(#38117): seq field removed from FlatBuffer schema on the agent side (agreed with server team);
+    // this manager-generated arrival-order counter is a temporary placeholder for GapSet completeness
+    // tracking. It does not detect out-of-order delivery or true retransmission the way the agent-supplied
+    // seq did - real support requires the FullSession-based redesign owned by the server team.
+    uint64_t m_seqCounter {0};
 
 public:
     explicit AgentSessionImpl(const uint64_t sessionId,
@@ -101,6 +106,11 @@ public:
         , m_logFn(logFn)
 
     {
+        // TODO(#38117): StartAck removed from FlatBuffer schema/agent side - the manager no longer
+        // acknowledges session establishment. responseDispatcher is kept as a constructor parameter
+        // for call-site compatibility (it's still used by handleEnd()) but unused here.
+        (void)responseDispatcher;
+
         if (data == nullptr)
         {
             throw AgentSessionException("Invalid data");
@@ -178,7 +188,14 @@ public:
             data->mode() != Wazuh::SyncSchema::Mode_GroupDelta && data->mode() != Wazuh::SyncSchema::Mode_GroupCheck &&
             data->mode() != Wazuh::SyncSchema::Mode_ModuleCheck)
         {
-            responseDispatcher.sendStartAck(Wazuh::SyncSchema::Status_Error, agentId, sessionId, moduleName);
+            // TODO(#38117): StartAck removed from FlatBuffer schema/agent side - the manager no
+            // longer acknowledges session establishment at all.
+            LOGFN_WARN(m_logFn,
+                       "Start: invalid size 0 for mode %d (agent '%.*s', module '%s'); rejecting session.",
+                       static_cast<int>(data->mode()),
+                       static_cast<int>(agentId.size()),
+                       agentId.data(),
+                       std::string(moduleName.data(), moduleName.size()).c_str());
             throw AgentSessionException("Invalid size");
         }
 
@@ -216,9 +233,6 @@ public:
                      m_context->sessionId,
                      m_context->clusterName.c_str(),
                      m_context->clusterNode.c_str());
-
-        responseDispatcher.sendStartAck(
-            Wazuh::SyncSchema::Status_Ok, m_context->agentId, m_context->sessionId, m_context->moduleName);
     }
 
     /// Deleted copy constructor and assignment operator (C.12 compliant).
@@ -250,7 +264,8 @@ public:
 
         std::lock_guard lock(m_mutex);
 
-        const auto seq = data->seq();
+        // TODO(#38117): seq field removed from FlatBuffer schema on the agent side; see m_seqCounter.
+        const auto seq = m_seqCounter++;
         // TODO(#38117): session field removed from FlatBuffer schema on the agent side;
         // use the manager-side sessionId as the storage key component instead.
         const auto session = m_context->sessionId;
@@ -278,7 +293,7 @@ public:
 
         // The validation of the sequence number against declared size is performed above, so if we reach this line
         // the observation should not throw, though if it does the data chunk is already stored.
-        m_gapSet->observe(data->seq());
+        m_gapSet->observe(seq);
 
         LOGFN_DEBUG2(m_logFn,
                      "Data received: %s %llu %llu %s",
@@ -373,7 +388,8 @@ public:
 
         std::lock_guard lock(m_mutex);
 
-        const auto seq = data->seq();
+        // TODO(#38117): seq field removed from FlatBuffer schema on the agent side; see m_seqCounter.
+        const auto seq = m_seqCounter++;
         // TODO(#38117): session field removed from FlatBuffer schema on the agent side;
         // use the manager-side sessionId as the storage key component instead.
         const auto session = m_context->sessionId;
@@ -439,7 +455,8 @@ public:
 
         std::lock_guard lock(m_mutex);
 
-        const auto seq = data->seq();
+        // TODO(#38117): seq field removed from FlatBuffer schema on the agent side; see m_seqCounter.
+        const auto seq = m_seqCounter++;
         // TODO(#38117): session field removed from FlatBuffer schema on the agent side;
         // use the manager-side sessionId as the storage key component instead.
         const auto session = m_context->sessionId;
@@ -503,9 +520,10 @@ public:
     /**
      * @brief Handles the end-of-transmission signal from the agent.
      *
-     * If all chunks were received, pushes the final acknowledgment. Otherwise, triggers missing range dispatch.
+     * If all chunks were received, pushes the final acknowledgment. Otherwise, the session
+     * is left incomplete and pending (see TODO below).
      *
-     * @param responseDispatcher Dispatcher used to report missing sequences (if any).
+     * @param responseDispatcher Dispatcher used to send the final acknowledgment.
      */
     void handleEnd(const TResponseDispatcher& responseDispatcher)
     {
@@ -530,8 +548,18 @@ public:
         }
         else
         {
-            responseDispatcher.sendEndMissingSeq(
-                m_context->agentId, m_context->sessionId, m_context->moduleName, m_gapSet->ranges());
+            // TODO(#38117): ReqRet (request-retransmission-of-missing-ranges) removed from the
+            // FlatBuffer schema/agent side - the agent no longer sends chunked DataBatch messages
+            // or handles a ReqRet reply at all, so this "missing sequences" case can no longer be
+            // resolved by asking the agent to resend. This whole chunked/GapSet completeness path
+            // is unreachable under the current one-shot FullSession model; the session is simply
+            // left incomplete/pending here until the server team's FullSession-based rewrite.
+            LOGFN_WARN(m_logFn,
+                       "End received with missing sequences for session %llu (agent '%s', module '%s'); "
+                       "session left incomplete.",
+                       m_context->sessionId,
+                       m_context->agentId.c_str(),
+                       m_context->moduleName.c_str());
         }
     }
 

--- a/src/wazuh_modules/inventory_sync/src/agentSession.hpp
+++ b/src/wazuh_modules/inventory_sync/src/agentSession.hpp
@@ -527,14 +527,18 @@ public:
      */
     void handleEnd(const TResponseDispatcher& responseDispatcher)
     {
+        // TODO(#38117): EndAck removed from FlatBuffer schema/agent side - the manager no
+        // longer acknowledges End at all. responseDispatcher is kept as a parameter for
+        // call-site compatibility but unused here; the real /stateful HTTP response is the
+        // server team's own follow-up (see the FullSession-handling gap noted throughout).
+        (void)responseDispatcher;
+
         std::lock_guard lock(m_mutex);
         m_endReceived = true;
 
         if (m_endEnqueued)
         {
             LOGFN_DEBUG2(m_logFn, "End already enqueued for session %llu", m_context->sessionId);
-            responseDispatcher.sendEndAck(
-                Wazuh::SyncSchema::Status_Processing, m_context->agentId, m_context->sessionId, m_context->moduleName);
             return;
         }
 
@@ -543,8 +547,6 @@ public:
             LOGFN_DEBUG2(m_logFn, "All sequences received for session %llu", m_context->sessionId);
             m_indexerQueue.push(Response({.status = ResponseStatus::Ok, .context = m_context}));
             m_endEnqueued = true;
-            responseDispatcher.sendEndAck(
-                Wazuh::SyncSchema::Status_Processing, m_context->agentId, m_context->sessionId, m_context->moduleName);
         }
         else
         {

--- a/src/wazuh_modules/inventory_sync/src/agentSession.hpp
+++ b/src/wazuh_modules/inventory_sync/src/agentSession.hpp
@@ -251,7 +251,9 @@ public:
         std::lock_guard lock(m_mutex);
 
         const auto seq = data->seq();
-        const auto session = data->session();
+        // TODO(#38117): session field removed from FlatBuffer schema on the agent side;
+        // use the manager-side sessionId as the storage key component instead.
+        const auto session = m_context->sessionId;
 
         LOGFN_DEBUG2(m_logFn, "Handling sequence number '%llu' for session '%llu'", seq, session);
 
@@ -372,7 +374,9 @@ public:
         std::lock_guard lock(m_mutex);
 
         const auto seq = data->seq();
-        const auto session = data->session();
+        // TODO(#38117): session field removed from FlatBuffer schema on the agent side;
+        // use the manager-side sessionId as the storage key component instead.
+        const auto session = m_context->sessionId;
 
         LOGFN_DEBUG2(m_logFn, "Handling DataContext sequence number '%llu' for session '%llu'", seq, session);
 
@@ -436,7 +440,9 @@ public:
         std::lock_guard lock(m_mutex);
 
         const auto seq = data->seq();
-        const auto session = data->session();
+        // TODO(#38117): session field removed from FlatBuffer schema on the agent side;
+        // use the manager-side sessionId as the storage key component instead.
+        const auto session = m_context->sessionId;
 
         LOGFN_DEBUG2(m_logFn, "Handling DataClean sequence number '%llu' for session '%llu'", seq, session);
 

--- a/src/wazuh_modules/inventory_sync/src/agentSession.hpp
+++ b/src/wazuh_modules/inventory_sync/src/agentSession.hpp
@@ -95,8 +95,17 @@ class AgentSessionImpl final
     uint64_t m_seqCounter {0};
 
 public:
+    // TODO(#38117): size removed from FlatBuffer schema on the agent side (agreed with server
+    // team) - the manager can no longer read a declared DataValue count off the wire at all.
+    // declaredSize is now a caller-supplied parameter instead of data->size(): the real fix
+    // (deriving it from the actual FullSession payload post-parse, once the FullSession-based
+    // dispatch rewrite lands) is the server team's own follow-up. Until then, production
+    // call sites pass 0 - see the TODO at the InventorySyncFacade construction site for what
+    // that disables (the DataValue quota reservation; GapSet(0) also means the completeness
+    // gate below is trivially satisfied immediately instead of after real items arrive).
     explicit AgentSessionImpl(const uint64_t sessionId,
                               Wazuh::SyncSchema::Start const* data,
+                              const uint64_t declaredSize,
                               TStore& store,
                               TIndexerQueue& indexerQueue,
                               const TResponseDispatcher& responseDispatcher,
@@ -181,26 +190,14 @@ public:
         }
 
         // Create new session.
-        // Size validation: MetadataDelta, MetadataCheck, GroupDelta, GroupCheck, ModuleCheck don't send data messages,
-        // so size can be 0
-        if (data->size() == 0 && data->mode() != Wazuh::SyncSchema::Mode_MetadataDelta &&
-            data->mode() != Wazuh::SyncSchema::Mode_MetadataCheck &&
-            data->mode() != Wazuh::SyncSchema::Mode_GroupDelta && data->mode() != Wazuh::SyncSchema::Mode_GroupCheck &&
-            data->mode() != Wazuh::SyncSchema::Mode_ModuleCheck)
-        {
-            // TODO(#38117): StartAck removed from FlatBuffer schema/agent side - the manager no
-            // longer acknowledges session establishment at all.
-            LOGFN_WARN(m_logFn,
-                       "Start: invalid size 0 for mode %d (agent '%.*s', module '%s'); rejecting session.",
-                       static_cast<int>(data->mode()),
-                       static_cast<int>(agentId.size()),
-                       agentId.data(),
-                       std::string(moduleName.data(), moduleName.size()).c_str());
-            throw AgentSessionException("Invalid size");
-        }
+        // TODO(#38117): size removed from FlatBuffer schema on the agent side (agreed with
+        // server team) - the manager can no longer validate "size 0 only for modes that don't
+        // send data messages" against a declared wire value. That check belongs in the
+        // FullSession-based rewrite (server team's own follow-up), where a mismatch between
+        // the actual payload item count and the mode can be caught after parsing instead.
 
-        m_declaredSize = data->size();
-        m_gapSet = std::make_unique<GapSet>(data->size());
+        m_declaredSize = declaredSize;
+        m_gapSet = std::make_unique<GapSet>(declaredSize);
 
         m_context =
             std::make_shared<Context>(Context {.mode = data->mode(),

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -321,27 +321,6 @@ class InventorySyncFacadeImpl final
                 LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: ChecksumModule handled for session %llu", 0ULL);
             }
         }
-        else if (syncMessage->content_type() == Wazuh::SyncSchema::MessageType_End)
-        {
-            const auto end = syncMessage->content_as<Wazuh::SyncSchema::End>();
-            if (!end)
-            {
-                throw InventorySyncException("Invalid end message");
-            }
-
-            // Check if session exists.
-            std::shared_lock lock(m_agentSessionsMutex);
-            if (auto it = m_agentSessions.find(0ULL); it == m_agentSessions.end())
-            {
-                LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: Session not found, sessionId: %llu", 0ULL);
-            }
-            else
-            {
-                // Handle end.
-                it->second.handleEnd(*m_responseDispatcher);
-                LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: End handled for session %llu", 0ULL);
-            }
-        }
         else
         {
             throw InventorySyncException("Invalid message type");
@@ -708,9 +687,8 @@ public:
                                 ctx->ownsAgentLock = false;
                                 unlockAgent(ctx->agentId);
 
-                                // Send ACK to agent.
-                                m_responseDispatcher->sendEndAck(
-                                    Wazuh::SyncSchema::Status_Ok, ctx->agentId, ctx->sessionId, ctx->moduleName);
+                                // TODO(#38117): EndAck removed from FlatBuffer schema/agent side - the
+                                // real /stateful HTTP response is the server team's own follow-up.
                                 // Delete Session.
                                 if (eraseSession(ctx->sessionId) == 0)
                                 {
@@ -751,9 +729,8 @@ public:
                                 ctx->ownsAgentLock = false;
                                 unlockAgent(ctx->agentId);
 
-                                // Send ACK to agent.
-                                m_responseDispatcher->sendEndAck(
-                                    Wazuh::SyncSchema::Status_Ok, ctx->agentId, ctx->sessionId, ctx->moduleName);
+                                // TODO(#38117): EndAck removed from FlatBuffer schema/agent side - the
+                                // real /stateful HTTP response is the server team's own follow-up.
                                 // Delete Session.
                                 if (eraseSession(ctx->sessionId) == 0)
                                 {
@@ -786,9 +763,8 @@ public:
                                 ctx->ownsAgentLock = false;
                                 unlockAgent(ctx->agentId);
 
-                                // Send ACK to agent.
-                                m_responseDispatcher->sendEndAck(
-                                    Wazuh::SyncSchema::Status_Ok, ctx->agentId, ctx->sessionId, ctx->moduleName);
+                                // TODO(#38117): EndAck removed from FlatBuffer schema/agent side - the
+                                // real /stateful HTTP response is the server team's own follow-up.
                                 // Delete Session.
                                 if (eraseSession(ctx->sessionId) == 0)
                                 {
@@ -834,9 +810,8 @@ public:
                                 ctx->ownsAgentLock = false;
                                 unlockAgent(ctx->agentId);
 
-                                // Send ACK to agent.
-                                m_responseDispatcher->sendEndAck(
-                                    Wazuh::SyncSchema::Status_Ok, ctx->agentId, ctx->sessionId, ctx->moduleName);
+                                // TODO(#38117): EndAck removed from FlatBuffer schema/agent side - the
+                                // real /stateful HTTP response is the server team's own follow-up.
                                 // Delete Session.
                                 if (eraseSession(ctx->sessionId) == 0)
                                 {
@@ -875,10 +850,7 @@ public:
                                 LOGFN_ERROR(m_logFn,
                                             "ModuleCheck: No index specified for agent %s",
                                             res.context->agentId.c_str());
-                                m_responseDispatcher->sendEndAck(Wazuh::SyncSchema::Status_Error,
-                                                                 res.context->agentId,
-                                                                 res.context->sessionId,
-                                                                 res.context->moduleName);
+                                // TODO(#38117): EndAck removed from FlatBuffer schema/agent side.
                             }
                             else
                             {
@@ -927,10 +899,7 @@ public:
                                     LOGFN_INFO(m_logFn,
                                                "ModuleCheck: Checksums match for agent %s - no full resync needed",
                                                res.context->agentId.c_str());
-                                    m_responseDispatcher->sendEndAck(Wazuh::SyncSchema::Status_Ok,
-                                                                     res.context->agentId,
-                                                                     res.context->sessionId,
-                                                                     res.context->moduleName);
+                                    // TODO(#38117): EndAck removed from FlatBuffer schema/agent side.
                                 }
                                 else
                                 {
@@ -939,10 +908,7 @@ public:
                                                "full resync required",
                                                res.context->agentId.c_str(),
                                                MAX_RETRIES);
-                                    m_responseDispatcher->sendEndAck(Wazuh::SyncSchema::Status_ChecksumMismatch,
-                                                                     res.context->agentId,
-                                                                     res.context->sessionId,
-                                                                     res.context->moduleName);
+                                    // TODO(#38117): EndAck removed from FlatBuffer schema/agent side.
                                 }
                             }
                         }
@@ -950,10 +916,7 @@ public:
                         {
                             LOGFN_ERROR(
                                 m_logFn, "ModuleCheck failed for agent %s: %s", res.context->agentId.c_str(), e.what());
-                            m_responseDispatcher->sendEndAck(Wazuh::SyncSchema::Status_Error,
-                                                             res.context->agentId,
-                                                             res.context->sessionId,
-                                                             res.context->moduleName);
+                            // TODO(#38117): EndAck removed from FlatBuffer schema/agent side.
                         }
 
                         if (eraseSession(res.context->sessionId) == 0)
@@ -1179,8 +1142,6 @@ public:
                             {
                                 // On the first manager startup the CVE feed may still be downloading.
                                 // Block here until it's ready so the scan doesn't run against empty data.
-                                // The agent stays in Status_Processing (sent at End-message time) and
-                                // gets Status_Ok once the scan finishes.
                                 if (!VulnerabilityScannerFacade::instance().isFeedReady())
                                 {
                                     VulnerabilityScannerFacade::instance().waitForFeedReady();
@@ -1258,10 +1219,7 @@ public:
                                                             "agent %s: %s",
                                                             res.context->agentId.c_str(),
                                                             e.what());
-                                                m_responseDispatcher->sendEndAck(Wazuh::SyncSchema::Status_Error,
-                                                                                 res.context->agentId,
-                                                                                 res.context->sessionId,
-                                                                                 res.context->moduleName);
+                                                // TODO(#38117): EndAck removed from FlatBuffer schema/agent side.
                                                 m_dataStore->deleteByPrefix(std::to_string(res.context->sessionId));
                                                 eraseSession(res.context->sessionId);
                                                 m_sessionCompletedCV.notify_all();
@@ -1299,9 +1257,8 @@ public:
                             m_indexerConnector->registerNotify(
                                 [this, ctx = res.context]()
                                 {
-                                    // Send ACK to agent.
-                                    m_responseDispatcher->sendEndAck(
-                                        Wazuh::SyncSchema::Status_Ok, ctx->agentId, ctx->sessionId, ctx->moduleName);
+                                    // TODO(#38117): EndAck removed from FlatBuffer schema/agent side - the
+                                    // real /stateful HTTP response is the server team's own follow-up.
                                     // Delete data from database.
                                     m_dataStore->deleteByPrefix(std::to_string(ctx->sessionId));
                                     // Delete Session.
@@ -1322,10 +1279,7 @@ public:
                                          "InventorySyncFacade::start: No bulk data or deleteByQuery, sending immediate "
                                          "response for session %llu",
                                          res.context->sessionId);
-                            m_responseDispatcher->sendEndAck(Wazuh::SyncSchema::Status_Ok,
-                                                             res.context->agentId,
-                                                             res.context->sessionId,
-                                                             res.context->moduleName);
+                            // TODO(#38117): EndAck removed from FlatBuffer schema/agent side.
                             m_dataStore->deleteByPrefix(std::to_string(res.context->sessionId));
                             if (eraseSession(res.context->sessionId) == 0)
                             {
@@ -1353,11 +1307,7 @@ public:
                         unlockAgent(res.context->agentId);
                     }
 
-                    // Send ACK to agent.
-                    m_responseDispatcher->sendEndAck(Wazuh::SyncSchema::Status_Error,
-                                                     res.context->agentId,
-                                                     res.context->sessionId,
-                                                     res.context->moduleName);
+                    // TODO(#38117): EndAck removed from FlatBuffer schema/agent side.
                     // Delete data from database.
                     m_dataStore->deleteByPrefix(std::to_string(res.context->sessionId));
                     // Delete Session.
@@ -1382,11 +1332,7 @@ public:
                         unlockAgent(res.context->agentId);
                     }
 
-                    // Send ACK to agent.
-                    m_responseDispatcher->sendEndAck(Wazuh::SyncSchema::Status_Error,
-                                                     res.context->agentId,
-                                                     res.context->sessionId,
-                                                     res.context->moduleName);
+                    // TODO(#38117): EndAck removed from FlatBuffer schema/agent side.
                     // Delete data from database.
                     m_dataStore->deleteByPrefix(std::to_string(res.context->sessionId));
                     // Delete Session.

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -134,16 +134,15 @@ class InventorySyncFacadeImpl final
 
             // Check if session exists.
             std::shared_lock lock(m_agentSessionsMutex);
-            if (auto it = m_agentSessions.find(data->session()); it == m_agentSessions.end())
+            if (auto it = m_agentSessions.find(0ULL); it == m_agentSessions.end())
             {
-                LOGFN_DEBUG2(
-                    m_logFn, "InventorySyncFacade::start: Session not found, sessionId: %llu", data->session());
+                LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: Session not found, sessionId: %llu", 0ULL);
             }
             else
             {
                 // Handle data - pass the raw flatbuffer bytes directly
                 it->second.handleData(data, reinterpret_cast<const uint8_t*>(dataRaw.data()), dataRaw.size());
-                LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: Data handled for session %llu", data->session());
+                LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: Data handled for session %llu", 0ULL);
             }
         }
         else if (syncMessage->content_type() == Wazuh::SyncSchema::MessageType_DataClean)
@@ -156,18 +155,16 @@ class InventorySyncFacadeImpl final
 
             // Check if session exists.
             std::shared_lock lock(m_agentSessionsMutex);
-            if (auto it = m_agentSessions.find(dataClean->session()); it == m_agentSessions.end())
+            if (auto it = m_agentSessions.find(0ULL); it == m_agentSessions.end())
             {
-                LOGFN_DEBUG2(m_logFn,
-                             "InventorySyncFacade::start: Session not found for DataClean, sessionId: %llu",
-                             dataClean->session());
+                LOGFN_DEBUG2(
+                    m_logFn, "InventorySyncFacade::start: Session not found for DataClean, sessionId: %llu", 0ULL);
             }
             else
             {
                 // Handle DataClean - stores index and tracks seq number
                 it->second.handleDataClean(dataClean);
-                LOGFN_DEBUG2(
-                    m_logFn, "InventorySyncFacade::start: DataClean handled for session %llu", dataClean->session());
+                LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: DataClean handled for session %llu", 0ULL);
             }
         }
         else if (syncMessage->content_type() == Wazuh::SyncSchema::MessageType_DataContext)
@@ -180,20 +177,17 @@ class InventorySyncFacadeImpl final
 
             // Check if session exists.
             std::shared_lock lock(m_agentSessionsMutex);
-            if (auto it = m_agentSessions.find(dataContext->session()); it == m_agentSessions.end())
+            if (auto it = m_agentSessions.find(0ULL); it == m_agentSessions.end())
             {
-                LOGFN_DEBUG2(m_logFn,
-                             "InventorySyncFacade::start: Session not found for DataContext, sessionId: %llu",
-                             dataContext->session());
+                LOGFN_DEBUG2(
+                    m_logFn, "InventorySyncFacade::start: Session not found for DataContext, sessionId: %llu", 0ULL);
             }
             else
             {
                 // Handle DataContext - stores context in RocksDB and tracks seq number
                 it->second.handleDataContext(
                     dataContext, reinterpret_cast<const uint8_t*>(dataRaw.data()), dataRaw.size());
-                LOGFN_DEBUG2(m_logFn,
-                             "InventorySyncFacade::start: DataContext handled for session %llu",
-                             dataContext->session());
+                LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: DataContext handled for session %llu", 0ULL);
             }
         }
         else if (syncMessage->content_type() == Wazuh::SyncSchema::MessageType_DataBatch)
@@ -216,11 +210,9 @@ class InventorySyncFacadeImpl final
                     continue;
                 }
 
-                if (auto it = m_agentSessions.find(dataValue->session()); it == m_agentSessions.end())
+                if (auto it = m_agentSessions.find(0ULL); it == m_agentSessions.end())
                 {
-                    LOGFN_DEBUG2(m_logFn,
-                                 "InventorySyncFacade::start: Session not found, sessionId: %llu",
-                                 dataValue->session());
+                    LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: Session not found, sessionId: %llu", 0ULL);
                 }
                 else
                 {
@@ -239,7 +231,7 @@ class InventorySyncFacadeImpl final
 
                         Wazuh::SyncSchema::DataValueBuilder dataValueBuilder(dvBuilder);
                         dataValueBuilder.add_seq(dataValue->seq());
-                        dataValueBuilder.add_session(dataValue->session());
+                        // TODO(#38117): session field removed from agent FlatBuffer schema
                         dataValueBuilder.add_id(idStr);
                         dataValueBuilder.add_index(idxStr);
                         dataValueBuilder.add_version(dataValue->version());
@@ -252,15 +244,14 @@ class InventorySyncFacadeImpl final
                         dvBuilder.Finish(msgOffset);
 
                         it->second.handleData(dataValue, dvBuilder.GetBufferPointer(), dvBuilder.GetSize());
-                        LOGFN_DEBUG2(m_logFn,
-                                     "InventorySyncFacade::start: DataBatch item handled for session %llu",
-                                     dataValue->session());
+                        LOGFN_DEBUG2(
+                            m_logFn, "InventorySyncFacade::start: DataBatch item handled for session %llu", 0ULL);
                     }
                     catch (const std::exception& e)
                     {
                         LOGFN_ERROR(m_logFn,
                                     "InventorySyncFacade::start: DataBatch item failed for session %llu, seq %llu: %s",
-                                    dataValue->session(),
+                                    0ULL,
                                     dataValue->seq(),
                                     e.what());
                     }
@@ -389,19 +380,15 @@ class InventorySyncFacadeImpl final
 
             // Check if session exists.
             std::shared_lock lock(m_agentSessionsMutex);
-            if (auto it = m_agentSessions.find(checksumModule->session()); it == m_agentSessions.end())
+            if (auto it = m_agentSessions.find(0ULL); it == m_agentSessions.end())
             {
-                LOGFN_DEBUG2(m_logFn,
-                             "InventorySyncFacade::start: Session not found, sessionId: %llu",
-                             checksumModule->session());
+                LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: Session not found, sessionId: %llu", 0ULL);
             }
             else
             {
                 // Handle checksum module.
                 it->second.handleChecksumModule(checksumModule);
-                LOGFN_DEBUG2(m_logFn,
-                             "InventorySyncFacade::start: ChecksumModule handled for session %llu",
-                             checksumModule->session());
+                LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: ChecksumModule handled for session %llu", 0ULL);
             }
         }
         else if (syncMessage->content_type() == Wazuh::SyncSchema::MessageType_End)
@@ -414,15 +401,15 @@ class InventorySyncFacadeImpl final
 
             // Check if session exists.
             std::shared_lock lock(m_agentSessionsMutex);
-            if (auto it = m_agentSessions.find(end->session()); it == m_agentSessions.end())
+            if (auto it = m_agentSessions.find(0ULL); it == m_agentSessions.end())
             {
-                LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: Session not found, sessionId: %llu", end->session());
+                LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: Session not found, sessionId: %llu", 0ULL);
             }
             else
             {
                 // Handle end.
                 it->second.handleEnd(*m_responseDispatcher);
-                LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: End handled for session %llu", end->session());
+                LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: End handled for session %llu", 0ULL);
             }
         }
         else

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -241,8 +241,14 @@ class InventorySyncFacadeImpl final
                 }
                 else
                 {
-                    // Reserve DataValue quota for this session. Reject if reservation would underflow.
-                    const uint64_t requestedSize = startMsg->size();
+                    // TODO(#38117): size removed from FlatBuffer schema on the agent side (agreed
+                    // with server team) - the manager can no longer read a declared DataValue
+                    // count off the wire before a session is admitted. This reservation is a
+                    // no-op (0) until the FullSession-based rewrite (server team's own follow-up)
+                    // derives it from the actual payload item count after parsing instead of a
+                    // pre-declared Start field. The DataValue quota cap is effectively disabled
+                    // until then.
+                    const uint64_t requestedSize = 0;
                     uint64_t remaining = m_dataValueQuotaRemaining.load(std::memory_order_relaxed);
                     bool admitted = false;
                     while (remaining >= requestedSize)
@@ -284,6 +290,7 @@ class InventorySyncFacadeImpl final
                             m_agentSessions.try_emplace(sessionId,
                                                         sessionId,
                                                         startMsg,
+                                                        requestedSize,
                                                         *m_dataStore,
                                                         *m_indexerQueue,
                                                         *m_responseDispatcher,

--- a/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
+++ b/src/wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp
@@ -190,74 +190,6 @@ class InventorySyncFacadeImpl final
                 LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: DataContext handled for session %llu", 0ULL);
             }
         }
-        else if (syncMessage->content_type() == Wazuh::SyncSchema::MessageType_DataBatch)
-        {
-            const auto dataBatch = syncMessage->content_as<Wazuh::SyncSchema::DataBatch>();
-            if (!dataBatch || !dataBatch->values())
-            {
-                throw InventorySyncException("Invalid data batch message");
-            }
-
-            LOGFN_DEBUG2(m_logFn,
-                         "InventorySyncFacade::start: Received DataBatch with %zu DataValues.",
-                         dataBatch->values()->size());
-
-            std::shared_lock lock(m_agentSessionsMutex);
-            for (const auto* dataValue : *dataBatch->values())
-            {
-                if (!dataValue)
-                {
-                    continue;
-                }
-
-                if (auto it = m_agentSessions.find(0ULL); it == m_agentSessions.end())
-                {
-                    LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: Session not found, sessionId: %llu", 0ULL);
-                }
-                else
-                {
-                    try
-                    {
-                        // Re-serialize each DataValue as a standalone Message{DataValue} FlatBuffer.
-                        // RocksDB consumers (indexer) expect individual DataValue messages per key.
-                        flatbuffers::FlatBufferBuilder dvBuilder;
-                        const auto* idRaw = dataValue->id();
-                        const auto* idxRaw = dataValue->index();
-                        const auto* dataRaw = dataValue->data();
-                        auto idStr = dvBuilder.CreateString(idRaw ? idRaw->string_view() : std::string_view {});
-                        auto idxStr = dvBuilder.CreateString(idxRaw ? idxRaw->string_view() : std::string_view {});
-                        auto dataVec = dataRaw ? dvBuilder.CreateVector(dataRaw->data(), dataRaw->size())
-                                               : dvBuilder.CreateVector<int8_t>({});
-
-                        Wazuh::SyncSchema::DataValueBuilder dataValueBuilder(dvBuilder);
-                        dataValueBuilder.add_seq(dataValue->seq());
-                        // TODO(#38117): session field removed from agent FlatBuffer schema
-                        dataValueBuilder.add_id(idStr);
-                        dataValueBuilder.add_index(idxStr);
-                        dataValueBuilder.add_version(dataValue->version());
-                        dataValueBuilder.add_operation(dataValue->operation());
-                        dataValueBuilder.add_data(dataVec);
-                        auto dvOffset = dataValueBuilder.Finish();
-
-                        auto msgOffset = Wazuh::SyncSchema::CreateMessage(
-                            dvBuilder, Wazuh::SyncSchema::MessageType_DataValue, dvOffset.Union());
-                        dvBuilder.Finish(msgOffset);
-
-                        it->second.handleData(dataValue, dvBuilder.GetBufferPointer(), dvBuilder.GetSize());
-                        LOGFN_DEBUG2(
-                            m_logFn, "InventorySyncFacade::start: DataBatch item handled for session %llu", 0ULL);
-                    }
-                    catch (const std::exception& e)
-                    {
-                        LOGFN_ERROR(m_logFn,
-                                    "InventorySyncFacade::start: DataBatch item failed for session %llu, seq %llu: %s",
-                                    0ULL,
-                                    dataValue->seq(),
-                                    e.what());
-                    }
-                }
-            }
-        }
         else if (syncMessage->content_type() == Wazuh::SyncSchema::MessageType_Start)
         {
             const auto startMsg = syncMessage->content_as<Wazuh::SyncSchema::Start>();
@@ -279,15 +211,15 @@ class InventorySyncFacadeImpl final
             const bool isVDModule = (moduleNameStr == "syscollector_vd");
             if (isAgentLocked(agentIdStr, isVDModule))
             {
+                // TODO(#38117): StartAck removed from FlatBuffer schema/agent side - the manager no
+                // longer acknowledges this rejection.
                 LOGFN_DEBUG2(m_logFn,
                              "InventorySyncFacade::start: Agent %s is locked, rejecting new session",
                              agentIdStr.c_str());
-                m_responseDispatcher->sendStartAck(Wazuh::SyncSchema::Status_Error, agentId, -1, moduleName);
             }
             else if (!m_indexerConnector->isAvailable())
             {
                 LOGFN_DEBUG2(m_logFn, "InventorySyncFacade::start: No available server");
-                m_responseDispatcher->sendStartAck(Wazuh::SyncSchema::Status_Offline, agentId, -1, moduleName);
             }
             else
             {
@@ -306,7 +238,6 @@ class InventorySyncFacadeImpl final
                                m_agentSessions.size(),
                                m_maxSessions,
                                std::string(agentId).c_str());
-                    m_responseDispatcher->sendStartAck(Wazuh::SyncSchema::Status_Offline, agentId, -1, moduleName);
                 }
                 else
                 {
@@ -331,7 +262,6 @@ class InventorySyncFacadeImpl final
                                    static_cast<unsigned long long>(requestedSize),
                                    static_cast<unsigned long long>(remaining),
                                    std::string(agentId).c_str());
-                        m_responseDispatcher->sendStartAck(Wazuh::SyncSchema::Status_Offline, agentId, -1, moduleName);
                     }
                     else
                     {
@@ -1036,12 +966,11 @@ public:
                     else
                     {
                         // Track whether anything was actually enqueued to the indexer connector.
-                        // The Mode_ModuleFull branch and the dataCleanIndices loop both rely on
-                        // res.context->indices / dataCleanIndices being non-empty AFTER the layer-2
-                        // filter; if every entry got dropped (e.g. an agent sent only non-states
-                        // indices) we must NOT register a notify callback that would never fire —
-                        // it would strand the session's final end_ack and leak through to a future
-                        // session's response stream.
+                        // The dataCleanIndices loop relies on dataCleanIndices being non-empty AFTER
+                        // the layer-2 filter; if every entry got dropped (e.g. an agent sent only
+                        // non-states indices) we must NOT register a notify callback that would
+                        // never fire — it would strand the session's final end_ack and leak through
+                        // to a future session's response stream.
                         bool hasDeleteByQueryEnqueued = false;
 
                         // Execute DataClean deletions if any were received during the session
@@ -1057,32 +986,6 @@ public:
                                              "InventorySyncFacade::start: Deleting data from index '%s' for agent %s",
                                              index.c_str(),
                                              res.context->agentId.c_str());
-                                try
-                                {
-                                    m_indexerConnector->deleteByQuery(index, res.context->agentId, m_clusterName);
-                                    hasDeleteByQueryEnqueued = true;
-                                }
-                                catch (const std::exception& e)
-                                {
-                                    LOGFN_WARN(m_logFn,
-                                               "InventorySyncFacade::start: deleteByQuery rejected for index '%s' "
-                                               "(session %llu): %s",
-                                               index.c_str(),
-                                               res.context->sessionId,
-                                               e.what());
-                                }
-                            }
-                        }
-
-                        // Send delete by query to indexer if mode is full.
-                        if (res.context->mode == Wazuh::SyncSchema::Mode_ModuleFull)
-                        {
-                            LOGFN_DEBUG2(m_logFn,
-                                         "InventorySyncFacade::start: Deleting by query for %zu indices...",
-                                         res.context->indices.size());
-                            // Delete from all indices specified in the Start message
-                            for (const auto& index : res.context->indices)
-                            {
                                 try
                                 {
                                     m_indexerConnector->deleteByQuery(index, res.context->agentId, m_clusterName);
@@ -1173,12 +1076,11 @@ public:
                                     // Validate that the data field is present for Upsert operations
                                     if (!data->data())
                                     {
-                                        LOGFN_WARN(
-                                            m_logFn,
-                                            "InventorySyncFacade::start: skipping bulk entry for session "
-                                            "%llu (seq %llu) - DataValue missing required 'data' field for Upsert",
-                                            res.context->sessionId,
-                                            data->seq());
+                                        // TODO(#38117): seq field removed from agent FlatBuffer schema
+                                        LOGFN_WARN(m_logFn,
+                                                   "InventorySyncFacade::start: skipping bulk entry for session "
+                                                   "%llu - DataValue missing required 'data' field for Upsert",
+                                                   res.context->sessionId);
                                         continue;
                                     }
 
@@ -1189,21 +1091,21 @@ public:
                                     }
                                     catch (const nlohmann::json::parse_error& e)
                                     {
+                                        // TODO(#38117): seq field removed from agent FlatBuffer schema
                                         LOGFN_WARN(m_logFn,
                                                    "InventorySyncFacade::start: skipping bulk entry for session "
-                                                   "%llu (seq %llu) - DataValue body is not valid JSON: %s",
+                                                   "%llu - DataValue body is not valid JSON: %s",
                                                    res.context->sessionId,
-                                                   data->seq(),
                                                    e.what());
                                         continue;
                                     }
                                     if (!document.is_object())
                                     {
+                                        // TODO(#38117): seq field removed from agent FlatBuffer schema
                                         LOGFN_WARN(m_logFn,
                                                    "InventorySyncFacade::start: skipping bulk entry for session "
-                                                   "%llu (seq %llu) - DataValue body is not a JSON object",
-                                                   res.context->sessionId,
-                                                   data->seq());
+                                                   "%llu - DataValue body is not a JSON object",
+                                                   res.context->sessionId);
                                         continue;
                                     }
                                 }
@@ -1386,11 +1288,11 @@ public:
 
                         // Only register notify callback if there's bulk data or deleteByQuery
                         // operations actually enqueued. Checking hasDeleteByQueryEnqueued (instead
-                        // of mode == Mode_ModuleFull or dataCleanIndices.empty()) is critical: if
-                        // every potential delete target was filtered out by the inventory_sync
-                        // index allowlist, no HTTP request will be made and no future flush will
-                        // fire the notify — the callback would be stranded and leak its end_ack
-                        // into the next session's response stream.
+                        // of dataCleanIndices.empty()) is critical: if every potential delete target
+                        // was filtered out by the inventory_sync index allowlist, no HTTP request
+                        // will be made and no future flush will fire the notify — the callback
+                        // would be stranded and leak its end_ack into the next session's response
+                        // stream.
                         if (hasBulkData || hasDeleteByQueryEnqueued)
                         {
                             // Register notify callback for bulk operations (after accumulating all data)

--- a/src/wazuh_modules/inventory_sync/src/responseDispatcher.hpp
+++ b/src/wazuh_modules/inventory_sync/src/responseDispatcher.hpp
@@ -122,7 +122,8 @@ public:
         responseMessage.builder.Clear();
         responseMessage.agentId = agentId;
         responseMessage.moduleName = moduleName;
-        auto startAckOffset = Wazuh::SyncSchema::CreateStartAck(responseMessage.builder, status, sessionId);
+        // TODO(#38117): session field removed from agent FlatBuffer schema (sessionId arg)
+        auto startAckOffset = Wazuh::SyncSchema::CreateStartAck(responseMessage.builder, status);
 
         auto messageOffset = Wazuh::SyncSchema::CreateMessage(
             responseMessage.builder, Wazuh::SyncSchema::MessageType_StartAck, startAckOffset.Union());
@@ -140,7 +141,8 @@ public:
         responseMessage.builder.Clear();
         responseMessage.agentId = agentId;
         responseMessage.moduleName = moduleName;
-        auto startAckOffset = Wazuh::SyncSchema::CreateEndAck(responseMessage.builder, status, sessionId);
+        // TODO(#38117): session field removed from agent FlatBuffer schema (sessionId arg)
+        auto startAckOffset = Wazuh::SyncSchema::CreateEndAck(responseMessage.builder, status);
 
         auto messageOffset = Wazuh::SyncSchema::CreateMessage(
             responseMessage.builder, Wazuh::SyncSchema::MessageType_EndAck, startAckOffset.Union());
@@ -166,7 +168,8 @@ public:
             convertedRanges.push_back(offset);
         }
 
-        auto endOffset = Wazuh::SyncSchema::CreateReqRetDirect(responseMessage.builder, &convertedRanges, sessionId);
+        // TODO(#38117): session field removed from agent FlatBuffer schema (sessionId arg)
+        auto endOffset = Wazuh::SyncSchema::CreateReqRetDirect(responseMessage.builder, &convertedRanges);
         auto messageOffset = Wazuh::SyncSchema::CreateMessage(
             responseMessage.builder, Wazuh::SyncSchema::MessageType_ReqRet, endOffset.Union());
         responseMessage.builder.Finish(messageOffset);

--- a/src/wazuh_modules/inventory_sync/src/responseDispatcher.hpp
+++ b/src/wazuh_modules/inventory_sync/src/responseDispatcher.hpp
@@ -112,25 +112,6 @@ public:
         , m_logFn(Log::currentModuleLogFn())
     {
     }
-
-    void sendEndAck(const Wazuh::SyncSchema::Status status,
-                    std::string_view agentId,
-                    const uint64_t sessionId,
-                    std::string_view moduleName) const
-    {
-        ResponseMessage responseMessage;
-        responseMessage.builder.Clear();
-        responseMessage.agentId = agentId;
-        responseMessage.moduleName = moduleName;
-        // TODO(#38117): session field removed from agent FlatBuffer schema (sessionId arg)
-        auto startAckOffset = Wazuh::SyncSchema::CreateEndAck(responseMessage.builder, status);
-
-        auto messageOffset = Wazuh::SyncSchema::CreateMessage(
-            responseMessage.builder, Wazuh::SyncSchema::MessageType_EndAck, startAckOffset.Union());
-        responseMessage.builder.Finish(messageOffset);
-
-        m_responseDispatcher->push(std::move(responseMessage));
-    }
 };
 
 using ResponseDispatcher = ResponseDispatcherImpl<ResponseQueue>;

--- a/src/wazuh_modules/inventory_sync/src/responseDispatcher.hpp
+++ b/src/wazuh_modules/inventory_sync/src/responseDispatcher.hpp
@@ -113,25 +113,6 @@ public:
     {
     }
 
-    void sendStartAck(const Wazuh::SyncSchema::Status status,
-                      std::string_view agentId,
-                      const uint64_t sessionId,
-                      std::string_view moduleName) const
-    {
-        ResponseMessage responseMessage;
-        responseMessage.builder.Clear();
-        responseMessage.agentId = agentId;
-        responseMessage.moduleName = moduleName;
-        // TODO(#38117): session field removed from agent FlatBuffer schema (sessionId arg)
-        auto startAckOffset = Wazuh::SyncSchema::CreateStartAck(responseMessage.builder, status);
-
-        auto messageOffset = Wazuh::SyncSchema::CreateMessage(
-            responseMessage.builder, Wazuh::SyncSchema::MessageType_StartAck, startAckOffset.Union());
-        responseMessage.builder.Finish(messageOffset); // Print complete message buffer in hex with spaces
-
-        m_responseDispatcher->push(std::move(responseMessage));
-    }
-
     void sendEndAck(const Wazuh::SyncSchema::Status status,
                     std::string_view agentId,
                     const uint64_t sessionId,
@@ -146,32 +127,6 @@ public:
 
         auto messageOffset = Wazuh::SyncSchema::CreateMessage(
             responseMessage.builder, Wazuh::SyncSchema::MessageType_EndAck, startAckOffset.Union());
-        responseMessage.builder.Finish(messageOffset);
-
-        m_responseDispatcher->push(std::move(responseMessage));
-    }
-
-    void sendEndMissingSeq(const std::string_view agentId,
-                           const uint64_t sessionId,
-                           std::string_view moduleName,
-                           const std::vector<std::pair<uint64_t, uint64_t>>& ranges) const
-    {
-        ResponseMessage responseMessage;
-        responseMessage.builder.Clear();
-        responseMessage.agentId = agentId;
-        responseMessage.moduleName = moduleName;
-        std::vector<flatbuffers::Offset<Wazuh::SyncSchema::Pair>> convertedRanges;
-
-        for (const auto& [first, second] : ranges)
-        {
-            auto offset = Wazuh::SyncSchema::CreatePair(responseMessage.builder, first, second);
-            convertedRanges.push_back(offset);
-        }
-
-        // TODO(#38117): session field removed from agent FlatBuffer schema (sessionId arg)
-        auto endOffset = Wazuh::SyncSchema::CreateReqRetDirect(responseMessage.builder, &convertedRanges);
-        auto messageOffset = Wazuh::SyncSchema::CreateMessage(
-            responseMessage.builder, Wazuh::SyncSchema::MessageType_ReqRet, endOffset.Union());
         responseMessage.builder.Finish(messageOffset);
 
         m_responseDispatcher->push(std::move(responseMessage));

--- a/src/wazuh_modules/inventory_sync/tests/unit/agentSession_test.cpp
+++ b/src/wazuh_modules/inventory_sync/tests/unit/agentSession_test.cpp
@@ -38,6 +38,10 @@ protected:
     uint64_t sessionId = 12345;
     std::string agentId = "001";
 
+    // TODO(#38117): size removed from FlatBuffer schema on the agent side (agreed with server
+    // team). `size` stays a parameter here (rather than touching every call site) - it is now
+    // threaded directly into AgentSessionForTest's declaredSize constructor argument at each
+    // call site instead of being encoded into the FlatBuffer.
     flatbuffers::Offset<Wazuh::SyncSchema::Start>
     createStartMessage(uint64_t size,
                        const std::string& agentIdStr = "001",
@@ -46,6 +50,7 @@ protected:
                        const std::string& moduleName = "syscollector",
                        Wazuh::SyncSchema::Mode mode = Wazuh::SyncSchema::Mode_ModuleDelta)
     {
+        (void)size;
         auto agentIdOffset = builder.CreateString(agentIdStr);
         auto agentNameOffset = builder.CreateString(agentName);
         auto agentVersionOffset = builder.CreateString(agentVersion);
@@ -53,7 +58,6 @@ protected:
 
         Wazuh::SyncSchema::StartBuilder startBuilder(builder);
         startBuilder.add_module_(moduleOffset);
-        startBuilder.add_size(size);
         startBuilder.add_mode(mode);
         startBuilder.add_option(Wazuh::SyncSchema::Option_Sync);
         startBuilder.add_agentid(agentIdOffset);
@@ -76,7 +80,7 @@ TEST_F(AgentSessionTest, Constructor_Success)
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
     ASSERT_NO_THROW({
-        AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+        AgentSessionForTest session(sessionId, start, 10, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
     });
 }
 
@@ -85,28 +89,20 @@ TEST_F(AgentSessionTest, Constructor_NullData)
     EXPECT_THROW(
         {
             AgentSessionForTest session(
-                sessionId, nullptr, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+                sessionId, nullptr, 0, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
         },
         AgentSessionException);
 }
 
-TEST_F(AgentSessionTest, Constructor_InvalidSize)
-{
-    auto startMsg = createStartMessage(0);
-    builder.Finish(startMsg);
-    auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
-
-    EXPECT_THROW(
-        {
-            AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
-        },
-        AgentSessionException);
-}
+// TODO(#38117): size removed from FlatBuffer schema on the agent side (agreed with server
+// team) - the manager can no longer validate "size 0 invalid for modes that send data
+// messages" against a declared wire value, so this test's premise (constructing with a
+// Delta-mode Start and declaredSize=0 must throw) no longer holds; that check belongs in
+// the FullSession-based rewrite (server team's own follow-up).
 
 TEST_F(AgentSessionTest, Constructor_NullModule)
 {
     Wazuh::SyncSchema::StartBuilder startBuilder(builder);
-    startBuilder.add_size(10);
     startBuilder.add_mode(Wazuh::SyncSchema::Mode_ModuleDelta);
     startBuilder.add_option(Wazuh::SyncSchema::Option_Sync);
     auto startMsg = startBuilder.Finish();
@@ -116,7 +112,7 @@ TEST_F(AgentSessionTest, Constructor_NullModule)
 
     // Now this should succeed since we use the constructor parameter for moduleName
     EXPECT_NO_THROW({
-        AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+        AgentSessionForTest session(sessionId, start, 10, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
     });
 }
 
@@ -126,7 +122,7 @@ TEST_F(AgentSessionTest, Constructor_ValidAgentIdZero)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 10, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 }
 
 TEST_F(AgentSessionTest, HandleData_Success)
@@ -135,7 +131,7 @@ TEST_F(AgentSessionTest, HandleData_Success)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 1, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     flatbuffers::FlatBufferBuilder dataBuilder;
 
@@ -162,7 +158,7 @@ TEST_F(AgentSessionTest, HandleData_CompletesGapSet_EndNotReceived)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 1, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     flatbuffers::FlatBufferBuilder dataBuilder;
 
@@ -189,7 +185,7 @@ TEST_F(AgentSessionTest, HandleData_CompletesGapSet_EndReceived)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 1, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     session.handleEnd(mockResponseDispatcher); // Simulate end received first
 
@@ -218,7 +214,7 @@ TEST_F(AgentSessionTest, HandleEnd_GapSetNotEmpty)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 2, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     EXPECT_CALL(mockIndexerQueue, push(_)).Times(0);
 
@@ -231,7 +227,7 @@ TEST_F(AgentSessionTest, HandleEnd_GapSetEmpty)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 1, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     flatbuffers::FlatBufferBuilder dataBuilder;
 
@@ -262,7 +258,7 @@ TEST_F(AgentSessionTest, HandleChecksumModule_Success)
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
     // Create session with ModuleCheck mode (size can be 0 for ModuleCheck)
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 0, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     // Create ChecksumModule message
     flatbuffers::FlatBufferBuilder checksumBuilder;
@@ -287,7 +283,7 @@ TEST_F(AgentSessionTest, HandleChecksumModule_NullData)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 0, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     EXPECT_THROW({ session.handleChecksumModule(nullptr); }, AgentSessionException);
 }
@@ -299,7 +295,7 @@ TEST_F(AgentSessionTest, HandleChecksumModule_EmptyChecksum)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 0, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     // Create ChecksumModule message with no checksum
     flatbuffers::FlatBufferBuilder checksumBuilder;
@@ -322,7 +318,7 @@ TEST_F(AgentSessionTest, HandleDataClean_Success)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 1, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     // Create DataClean message
     flatbuffers::FlatBufferBuilder dataCleanBuilder;
@@ -345,7 +341,7 @@ TEST_F(AgentSessionTest, HandleDataClean_MultipleIndices)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 3, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     // Create DataClean messages for multiple indices
     std::vector<std::string> indices = {
@@ -372,7 +368,7 @@ TEST_F(AgentSessionTest, HandleDataClean_NullData)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 1, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     // Passing null should throw
     ASSERT_THROW({ session.handleDataClean(nullptr); }, AgentSessionException);
@@ -384,7 +380,7 @@ TEST_F(AgentSessionTest, HandleDataClean_WithEnd)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 1, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     // Create DataClean message
     flatbuffers::FlatBufferBuilder dataCleanBuilder;
@@ -413,7 +409,7 @@ TEST_F(AgentSessionTest, HandleDataContext_Success)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 1, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     // Create DataContext message
     flatbuffers::FlatBufferBuilder dataContextBuilder;
@@ -448,7 +444,7 @@ TEST_F(AgentSessionTest, HandleDataContext_MultipleMessages)
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
     EXPECT_CALL(mockStore, put(_, _)).Times(3); // Expect 3 put calls for 3 DataContext messages
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 3, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     // Create multiple DataContext messages
     for (size_t i = 0; i < 3; ++i)
@@ -480,7 +476,7 @@ TEST_F(AgentSessionTest, HandleDataContext_NullData)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 1, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     // Passing null should throw
     ASSERT_THROW({ session.handleDataContext(nullptr, nullptr, 0); }, AgentSessionException);
@@ -493,7 +489,7 @@ TEST_F(AgentSessionTest, HandleDataContext_WithEnd)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 1, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     // Create DataContext message
     flatbuffers::FlatBufferBuilder dataContextBuilder;
@@ -523,9 +519,12 @@ TEST_F(AgentSessionTest, HandleDataContext_WithEnd)
     ASSERT_NO_THROW({ session.handleEnd(mockResponseDispatcher); });
 }
 
+// TODO(#38117): size removed from FlatBuffer schema on the agent side - this test's original
+// premise ("size 0 is valid for ModuleCheck") no longer applies since the manager can't
+// validate a declared size against the mode at all anymore; kept as a smoke test that
+// declaredSize=0 (the caller-supplied constructor argument) still constructs successfully.
 TEST_F(AgentSessionTest, Constructor_ValidSize_ModuleCheck)
 {
-    // Create a StartMessage with ModuleCheck mode and size 0 (which is valid for ModuleCheck)
     auto agentIdOffset = builder.CreateString("001");
     auto agentNameOffset = builder.CreateString("test-agent");
     auto agentVersionOffset = builder.CreateString("4.0.0");
@@ -533,7 +532,6 @@ TEST_F(AgentSessionTest, Constructor_ValidSize_ModuleCheck)
 
     Wazuh::SyncSchema::StartBuilder startBuilder(builder);
     startBuilder.add_module_(moduleOffset);
-    startBuilder.add_size(0);
     startBuilder.add_mode(Wazuh::SyncSchema::Mode_ModuleCheck);
     startBuilder.add_option(Wazuh::SyncSchema::Option_Sync);
     startBuilder.add_agentid(agentIdOffset);
@@ -545,7 +543,7 @@ TEST_F(AgentSessionTest, Constructor_ValidSize_ModuleCheck)
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
     ASSERT_NO_THROW({
-        AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+        AgentSessionForTest session(sessionId, start, 0, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
     });
 }
 
@@ -556,6 +554,10 @@ TEST_F(AgentSessionTest, Constructor_ValidSize_ModuleCheck)
 
 namespace
 {
+    // TODO(#38117): size removed from FlatBuffer schema on the agent side (agreed with server
+    // team). `size` stays a parameter here (rather than touching every call site) - it is now
+    // threaded directly into AgentSessionForTest's declaredSize constructor argument at each
+    // call site instead of being encoded into the FlatBuffer.
     flatbuffers::Offset<Wazuh::SyncSchema::Start>
     createStartWithIndices(flatbuffers::FlatBufferBuilder& builder,
                            uint64_t size,
@@ -563,6 +565,7 @@ namespace
                            Wazuh::SyncSchema::Mode mode = Wazuh::SyncSchema::Mode_ModuleDelta,
                            const std::string& moduleName = "syscollector")
     {
+        (void)size;
         auto agentIdOffset = builder.CreateString("001");
         auto agentNameOffset = builder.CreateString("test-agent");
         auto agentVersionOffset = builder.CreateString("4.0.0");
@@ -578,7 +581,6 @@ namespace
 
         Wazuh::SyncSchema::StartBuilder startBuilder(builder);
         startBuilder.add_module_(moduleOffset);
-        startBuilder.add_size(size);
         startBuilder.add_mode(mode);
         startBuilder.add_option(Wazuh::SyncSchema::Option_Sync);
         startBuilder.add_agentid(agentIdOffset);
@@ -595,7 +597,7 @@ TEST_F(AgentSessionTest, Constructor_StartIndices_FiltersOutNonStatePrefix)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 1, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     const auto& storedIndices = session.getContext()->indices;
     ASSERT_EQ(storedIndices.size(), 1u);
@@ -609,7 +611,7 @@ TEST_F(AgentSessionTest, Constructor_StartIndices_EmptyPrefixOnlyRejected)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 1, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     EXPECT_TRUE(session.getContext()->indices.empty());
 }
@@ -621,7 +623,7 @@ TEST_F(AgentSessionTest, Constructor_StartIndices_AllValidPassedThrough)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 1, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     EXPECT_EQ(session.getContext()->indices.size(), 3u);
 }
@@ -634,7 +636,7 @@ TEST_F(AgentSessionTest, Constructor_StartIndices_RejectsOutOfScopeStateIndex)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 1, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     const auto& storedIndices = session.getContext()->indices;
     ASSERT_EQ(storedIndices.size(), 1u);
@@ -655,7 +657,7 @@ TEST_F(AgentSessionTest, Constructor_StartIndices_RejectsManagerGovernanceIndice
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 1, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     // Only the in-scope vulnerabilities index survives.
     const auto& storedIndices = session.getContext()->indices;
@@ -694,7 +696,7 @@ TEST_F(AgentSessionTest, HandleChecksumModule_NonStateIndex_Ignored)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 0, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     flatbuffers::FlatBufferBuilder checksumBuilder;
     auto checksumStr = checksumBuilder.CreateString("abc123");
@@ -722,7 +724,7 @@ TEST_F(AgentSessionTest, HandleChecksumModule_StateIndex_Stored)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 0, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     flatbuffers::FlatBufferBuilder checksumBuilder;
     auto checksumStr = checksumBuilder.CreateString("abc123");
@@ -746,7 +748,7 @@ TEST_F(AgentSessionTest, HandleDataClean_NonStateIndex_Ignored)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 1, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     flatbuffers::FlatBufferBuilder dcBuilder;
     auto indexStr = dcBuilder.CreateString("wazuh-not-states");
@@ -773,7 +775,7 @@ TEST_F(AgentSessionTest, HandleData_SeqOutOfRange_DoesNotStore)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 1, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     flatbuffers::FlatBufferBuilder dataBuilder;
     std::vector<int8_t> testData = {0x01};
@@ -807,7 +809,7 @@ TEST_F(AgentSessionTest, HandleDataContext_SeqOutOfRange_DoesNotStore)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 1, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     flatbuffers::FlatBufferBuilder dcBuilder;
     std::vector<int8_t> raw = {0x01};
@@ -841,7 +843,7 @@ TEST_F(AgentSessionTest, HandleDataClean_SeqOutOfRange_DoesNotInsertIndex)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 1, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     flatbuffers::FlatBufferBuilder dcBuilder1;
     auto indexStr1 = dcBuilder1.CreateString("wazuh-states-fim-files");
@@ -881,7 +883,7 @@ TEST_F(AgentSessionTest, HandleData_DuplicateAfterEnd_DoesNotRePush)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 1, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     flatbuffers::FlatBufferBuilder dataBuilder;
     std::vector<int8_t> testData = {0x01};
@@ -912,7 +914,7 @@ TEST_F(AgentSessionTest, HandleDataContext_DuplicateAfterEnd_DoesNotRePush)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 1, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     flatbuffers::FlatBufferBuilder dcBuilder;
     std::vector<int8_t> raw = {0x01};
@@ -942,7 +944,7 @@ TEST_F(AgentSessionTest, HandleDataClean_DuplicateAfterEnd_DoesNotRePush)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 1, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     flatbuffers::FlatBufferBuilder dcBuilder;
     auto indexStr = dcBuilder.CreateString("wazuh-states-fim-files");
@@ -972,7 +974,7 @@ TEST_F(AgentSessionTest, HandleChecksumModule_AfterEnd_IsIgnored)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, 0, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     EXPECT_CALL(mockIndexerQueue, push(_)).Times(1);
 
@@ -996,14 +998,17 @@ TEST_F(AgentSessionTest, HandleChecksumModule_AfterEnd_IsIgnored)
     EXPECT_TRUE(session.getContext()->checksumIndex.empty());
 }
 
-TEST_F(AgentSessionTest, DeclaredSize_ReturnsValueFromStart)
+// TODO(#38117): size removed from FlatBuffer schema on the agent side - declaredSize() now
+// returns whatever the caller passed as the constructor's declaredSize argument, not a value
+// read from Start (see the class-level TODO on AgentSessionImpl's constructor).
+TEST_F(AgentSessionTest, DeclaredSize_ReturnsConstructorArgument)
 {
     constexpr uint64_t kSize = 5;
     auto startMsg = createStartMessage(kSize, "001");
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
+    AgentSessionForTest session(sessionId, start, kSize, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     EXPECT_EQ(session.declaredSize(), kSize);
 }

--- a/src/wazuh_modules/inventory_sync/tests/unit/agentSession_test.cpp
+++ b/src/wazuh_modules/inventory_sync/tests/unit/agentSession_test.cpp
@@ -250,7 +250,6 @@ TEST_F(AgentSessionTest, HandleEnd_GapSetEmpty)
     session.handleData(data, reinterpret_cast<const uint8_t*>(data->data()->data()), data->data()->size());
 
     EXPECT_CALL(mockIndexerQueue, push(_)).Times(1);
-    EXPECT_CALL(mockResponseDispatcher, sendEndAck(Wazuh::SyncSchema::Status_Processing, _, _, _)).Times(1);
 
     session.handleEnd(mockResponseDispatcher);
 }
@@ -401,17 +400,9 @@ TEST_F(AgentSessionTest, HandleDataClean_WithEnd)
     // Handle DataClean message
     session.handleDataClean(dataClean);
 
-    // Create and handle End message
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndBuilder endMsgBuilder(endBuilder);
-    auto endMsg = endMsgBuilder.Finish();
-    endBuilder.Finish(endMsg);
-
-    auto end = flatbuffers::GetRoot<Wazuh::SyncSchema::End>(endBuilder.GetBufferPointer());
-
+    // Handle End
     // Expect the indexer queue to be pushed when all sequences received
     EXPECT_CALL(mockIndexerQueue, push(_)).Times(1);
-    EXPECT_CALL(mockResponseDispatcher, sendEndAck(Wazuh::SyncSchema::Status_Processing, _, _, _)).Times(1);
     ASSERT_NO_THROW({ session.handleEnd(mockResponseDispatcher); });
 }
 
@@ -526,17 +517,9 @@ TEST_F(AgentSessionTest, HandleDataContext_WithEnd)
     // Handle DataContext message
     session.handleDataContext(dataContext, dataContextBuilder.GetBufferPointer(), dataContextBuilder.GetSize());
 
-    // Create and handle End message
-    flatbuffers::FlatBufferBuilder endBuilder;
-    Wazuh::SyncSchema::EndBuilder endMsgBuilder(endBuilder);
-    auto endMsg = endMsgBuilder.Finish();
-    endBuilder.Finish(endMsg);
-
-    auto end = flatbuffers::GetRoot<Wazuh::SyncSchema::End>(endBuilder.GetBufferPointer());
-
+    // Handle End
     // Expect the indexer queue to be pushed when all sequences received
     EXPECT_CALL(mockIndexerQueue, push(_)).Times(1);
-    EXPECT_CALL(mockResponseDispatcher, sendEndAck(Wazuh::SyncSchema::Status_Processing, _, _, _)).Times(1);
     ASSERT_NO_THROW({ session.handleEnd(mockResponseDispatcher); });
 }
 
@@ -912,7 +895,6 @@ TEST_F(AgentSessionTest, HandleData_DuplicateAfterEnd_DoesNotRePush)
 
     EXPECT_CALL(mockStore, put(_, _)).Times(1);
     EXPECT_CALL(mockIndexerQueue, push(_)).Times(1);
-    EXPECT_CALL(mockResponseDispatcher, sendEndAck(Wazuh::SyncSchema::Status_Processing, _, _, _)).Times(1);
 
     session.handleData(data, reinterpret_cast<const uint8_t*>(data->data()->data()), data->data()->size());
     session.handleEnd(mockResponseDispatcher);
@@ -944,7 +926,6 @@ TEST_F(AgentSessionTest, HandleDataContext_DuplicateAfterEnd_DoesNotRePush)
 
     EXPECT_CALL(mockStore, put(_, _)).Times(1);
     EXPECT_CALL(mockIndexerQueue, push(_)).Times(1);
-    EXPECT_CALL(mockResponseDispatcher, sendEndAck(Wazuh::SyncSchema::Status_Processing, _, _, _)).Times(1);
 
     session.handleDataContext(ctx, reinterpret_cast<const uint8_t*>(ctx->data()->data()), ctx->data()->size());
     session.handleEnd(mockResponseDispatcher);
@@ -973,7 +954,6 @@ TEST_F(AgentSessionTest, HandleDataClean_DuplicateAfterEnd_DoesNotRePush)
     auto dc = flatbuffers::GetRoot<Wazuh::SyncSchema::DataClean>(dcBuilder.GetBufferPointer());
 
     EXPECT_CALL(mockIndexerQueue, push(_)).Times(1);
-    EXPECT_CALL(mockResponseDispatcher, sendEndAck(Wazuh::SyncSchema::Status_Processing, _, _, _)).Times(1);
 
     session.handleDataClean(dc);
     session.handleEnd(mockResponseDispatcher);
@@ -995,7 +975,6 @@ TEST_F(AgentSessionTest, HandleChecksumModule_AfterEnd_IsIgnored)
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     EXPECT_CALL(mockIndexerQueue, push(_)).Times(1);
-    EXPECT_CALL(mockResponseDispatcher, sendEndAck(Wazuh::SyncSchema::Status_Processing, _, _, _)).Times(1);
 
     // End first.
     session.handleEnd(mockResponseDispatcher);

--- a/src/wazuh_modules/inventory_sync/tests/unit/agentSession_test.cpp
+++ b/src/wazuh_modules/inventory_sync/tests/unit/agentSession_test.cpp
@@ -44,7 +44,7 @@ protected:
                        const std::string& agentName = "test-agent",
                        const std::string& agentVersion = "4.0.0",
                        const std::string& moduleName = "syscollector",
-                       Wazuh::SyncSchema::Mode mode = Wazuh::SyncSchema::Mode_ModuleFull)
+                       Wazuh::SyncSchema::Mode mode = Wazuh::SyncSchema::Mode_ModuleDelta)
     {
         auto agentIdOffset = builder.CreateString(agentIdStr);
         auto agentNameOffset = builder.CreateString(agentName);
@@ -75,8 +75,6 @@ TEST_F(AgentSessionTest, Constructor_Success)
 
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
-
     ASSERT_NO_THROW({
         AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
     });
@@ -98,7 +96,6 @@ TEST_F(AgentSessionTest, Constructor_InvalidSize)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(Wazuh::SyncSchema::Status_Error, _, _, _)).Times(1);
     EXPECT_THROW(
         {
             AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
@@ -110,7 +107,7 @@ TEST_F(AgentSessionTest, Constructor_NullModule)
 {
     Wazuh::SyncSchema::StartBuilder startBuilder(builder);
     startBuilder.add_size(10);
-    startBuilder.add_mode(Wazuh::SyncSchema::Mode_ModuleFull);
+    startBuilder.add_mode(Wazuh::SyncSchema::Mode_ModuleDelta);
     startBuilder.add_option(Wazuh::SyncSchema::Option_Sync);
     auto startMsg = startBuilder.Finish();
 
@@ -118,7 +115,6 @@ TEST_F(AgentSessionTest, Constructor_NullModule)
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
     // Now this should succeed since we use the constructor parameter for moduleName
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(Wazuh::SyncSchema::Status_Ok, _, _, _)).Times(1);
     EXPECT_NO_THROW({
         AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
     });
@@ -130,8 +126,6 @@ TEST_F(AgentSessionTest, Constructor_ValidAgentIdZero)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(Wazuh::SyncSchema::Status_Ok, _, _, _)).Times(1);
-
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 }
 
@@ -141,7 +135,6 @@ TEST_F(AgentSessionTest, HandleData_Success)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     flatbuffers::FlatBufferBuilder dataBuilder;
@@ -151,7 +144,6 @@ TEST_F(AgentSessionTest, HandleData_Success)
     auto dataVector = dataBuilder.CreateVector(testData);
 
     Wazuh::SyncSchema::DataValueBuilder dataMsgBuilder(dataBuilder);
-    dataMsgBuilder.add_seq(0);
     dataMsgBuilder.add_data(dataVector);
     auto dataMsg = dataMsgBuilder.Finish();
     dataBuilder.Finish(dataMsg);
@@ -170,7 +162,6 @@ TEST_F(AgentSessionTest, HandleData_CompletesGapSet_EndNotReceived)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     flatbuffers::FlatBufferBuilder dataBuilder;
@@ -180,7 +171,6 @@ TEST_F(AgentSessionTest, HandleData_CompletesGapSet_EndNotReceived)
     auto dataVector = dataBuilder.CreateVector(testData);
 
     Wazuh::SyncSchema::DataValueBuilder dataMsgBuilder(dataBuilder);
-    dataMsgBuilder.add_seq(0);
     dataMsgBuilder.add_data(dataVector);
     auto dataMsg = dataMsgBuilder.Finish();
     dataBuilder.Finish(dataMsg);
@@ -199,10 +189,8 @@ TEST_F(AgentSessionTest, HandleData_CompletesGapSet_EndReceived)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
-    EXPECT_CALL(mockResponseDispatcher, sendEndMissingSeq(_, _, _, _)).Times(1);
     session.handleEnd(mockResponseDispatcher); // Simulate end received first
 
     flatbuffers::FlatBufferBuilder dataBuilder;
@@ -212,7 +200,6 @@ TEST_F(AgentSessionTest, HandleData_CompletesGapSet_EndReceived)
     auto dataVector = dataBuilder.CreateVector(testData);
 
     Wazuh::SyncSchema::DataValueBuilder dataMsgBuilder(dataBuilder);
-    dataMsgBuilder.add_seq(0);
     dataMsgBuilder.add_data(dataVector);
     auto dataMsg = dataMsgBuilder.Finish();
     dataBuilder.Finish(dataMsg);
@@ -231,10 +218,8 @@ TEST_F(AgentSessionTest, HandleEnd_GapSetNotEmpty)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
-    EXPECT_CALL(mockResponseDispatcher, sendEndMissingSeq(_, _, _, _)).Times(1);
     EXPECT_CALL(mockIndexerQueue, push(_)).Times(0);
 
     session.handleEnd(mockResponseDispatcher);
@@ -246,7 +231,6 @@ TEST_F(AgentSessionTest, HandleEnd_GapSetEmpty)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     flatbuffers::FlatBufferBuilder dataBuilder;
@@ -256,7 +240,6 @@ TEST_F(AgentSessionTest, HandleEnd_GapSetEmpty)
     auto dataVector = dataBuilder.CreateVector(testData);
 
     Wazuh::SyncSchema::DataValueBuilder dataMsgBuilder(dataBuilder);
-    dataMsgBuilder.add_seq(0);
     dataMsgBuilder.add_data(dataVector);
     auto dataMsg = dataMsgBuilder.Finish();
     dataBuilder.Finish(dataMsg);
@@ -267,7 +250,6 @@ TEST_F(AgentSessionTest, HandleEnd_GapSetEmpty)
     session.handleData(data, reinterpret_cast<const uint8_t*>(data->data()->data()), data->data()->size());
 
     EXPECT_CALL(mockIndexerQueue, push(_)).Times(1);
-    EXPECT_CALL(mockResponseDispatcher, sendEndMissingSeq(_, _, _, _)).Times(0);
     EXPECT_CALL(mockResponseDispatcher, sendEndAck(Wazuh::SyncSchema::Status_Processing, _, _, _)).Times(1);
 
     session.handleEnd(mockResponseDispatcher);
@@ -281,7 +263,6 @@ TEST_F(AgentSessionTest, HandleChecksumModule_Success)
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
     // Create session with ModuleCheck mode (size can be 0 for ModuleCheck)
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     // Create ChecksumModule message
@@ -307,7 +288,6 @@ TEST_F(AgentSessionTest, HandleChecksumModule_NullData)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     EXPECT_THROW({ session.handleChecksumModule(nullptr); }, AgentSessionException);
@@ -320,7 +300,6 @@ TEST_F(AgentSessionTest, HandleChecksumModule_EmptyChecksum)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     // Create ChecksumModule message with no checksum
@@ -344,7 +323,6 @@ TEST_F(AgentSessionTest, HandleDataClean_Success)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     // Create DataClean message
@@ -352,7 +330,6 @@ TEST_F(AgentSessionTest, HandleDataClean_Success)
     auto indexStr = dataCleanBuilder.CreateString("wazuh-states-fim-files");
 
     Wazuh::SyncSchema::DataCleanBuilder dataCleanMsgBuilder(dataCleanBuilder);
-    dataCleanMsgBuilder.add_seq(0);
     dataCleanMsgBuilder.add_index(indexStr);
     auto dataCleanMsg = dataCleanMsgBuilder.Finish();
     dataCleanBuilder.Finish(dataCleanMsg);
@@ -369,7 +346,6 @@ TEST_F(AgentSessionTest, HandleDataClean_MultipleIndices)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     // Create DataClean messages for multiple indices
@@ -382,7 +358,6 @@ TEST_F(AgentSessionTest, HandleDataClean_MultipleIndices)
         auto indexStr = dataCleanBuilder.CreateString(indices[i]);
 
         Wazuh::SyncSchema::DataCleanBuilder dataCleanMsgBuilder(dataCleanBuilder);
-        dataCleanMsgBuilder.add_seq(i);
         dataCleanMsgBuilder.add_index(indexStr);
         auto dataCleanMsg = dataCleanMsgBuilder.Finish();
         dataCleanBuilder.Finish(dataCleanMsg);
@@ -398,7 +373,6 @@ TEST_F(AgentSessionTest, HandleDataClean_NullData)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     // Passing null should throw
@@ -411,7 +385,6 @@ TEST_F(AgentSessionTest, HandleDataClean_WithEnd)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     // Create DataClean message
@@ -419,7 +392,6 @@ TEST_F(AgentSessionTest, HandleDataClean_WithEnd)
     auto indexStr = dataCleanBuilder.CreateString("wazuh-states-fim-files");
 
     Wazuh::SyncSchema::DataCleanBuilder dataCleanMsgBuilder(dataCleanBuilder);
-    dataCleanMsgBuilder.add_seq(0);
     dataCleanMsgBuilder.add_index(indexStr);
     auto dataCleanMsg = dataCleanMsgBuilder.Finish();
     dataCleanBuilder.Finish(dataCleanMsg);
@@ -450,7 +422,6 @@ TEST_F(AgentSessionTest, HandleDataContext_Success)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     // Create DataContext message
@@ -461,7 +432,6 @@ TEST_F(AgentSessionTest, HandleDataContext_Success)
     auto dataVec = dataContextBuilder.CreateVector(contextData);
 
     Wazuh::SyncSchema::DataContextBuilder dataContextMsgBuilder(dataContextBuilder);
-    dataContextMsgBuilder.add_seq(0);
     dataContextMsgBuilder.add_id(idStr);
     dataContextMsgBuilder.add_index(indexStr);
     dataContextMsgBuilder.add_data(dataVec);
@@ -486,7 +456,6 @@ TEST_F(AgentSessionTest, HandleDataContext_MultipleMessages)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     EXPECT_CALL(mockStore, put(_, _)).Times(3); // Expect 3 put calls for 3 DataContext messages
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
@@ -500,7 +469,6 @@ TEST_F(AgentSessionTest, HandleDataContext_MultipleMessages)
         auto dataVec = dataContextBuilder.CreateVector(contextData);
 
         Wazuh::SyncSchema::DataContextBuilder dataContextMsgBuilder(dataContextBuilder);
-        dataContextMsgBuilder.add_seq(i);
         dataContextMsgBuilder.add_id(idStr);
         dataContextMsgBuilder.add_index(indexStr);
         dataContextMsgBuilder.add_data(dataVec);
@@ -521,7 +489,6 @@ TEST_F(AgentSessionTest, HandleDataContext_NullData)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     // Passing null should throw
@@ -535,7 +502,6 @@ TEST_F(AgentSessionTest, HandleDataContext_WithEnd)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     // Create DataContext message
@@ -546,7 +512,6 @@ TEST_F(AgentSessionTest, HandleDataContext_WithEnd)
     auto dataVec = dataContextBuilder.CreateVector(contextData);
 
     Wazuh::SyncSchema::DataContextBuilder dataContextMsgBuilder(dataContextBuilder);
-    dataContextMsgBuilder.add_seq(0);
     dataContextMsgBuilder.add_id(idStr);
     dataContextMsgBuilder.add_index(indexStr);
     dataContextMsgBuilder.add_data(dataVec);
@@ -596,91 +561,9 @@ TEST_F(AgentSessionTest, Constructor_ValidSize_ModuleCheck)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(Wazuh::SyncSchema::Status_Ok, _, _, _)).Times(1);
     ASSERT_NO_THROW({
         AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
     });
-}
-
-TEST_F(AgentSessionTest, HandleData_ReserializedFromDataBatch)
-{
-    // Simulates what inventorySyncFacade does when handling a DataBatch:
-    // each DataValue is re-serialized as a standalone Message{DataValue} FlatBuffer
-    // and stored via handleData. Verifies the roundtrip preserves seq/session/id.
-    constexpr size_t ITEM_COUNT = 3;
-
-    auto startMsg = createStartMessage(ITEM_COUNT, "001");
-    builder.Finish(startMsg);
-    auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
-
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
-    EXPECT_CALL(mockStore, put(_, _)).Times(static_cast<int>(ITEM_COUNT));
-    AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
-
-    // Build a DataBatch containing ITEM_COUNT DataValues
-    flatbuffers::FlatBufferBuilder batchBuilder;
-    std::vector<flatbuffers::Offset<Wazuh::SyncSchema::DataValue>> dvOffsets;
-    for (uint64_t i = 0; i < ITEM_COUNT; ++i)
-    {
-        auto idStr = batchBuilder.CreateString(std::string("id-") + std::to_string(i));
-        auto idxStr = batchBuilder.CreateString("network");
-        std::vector<int8_t> rawData = {static_cast<int8_t>(i), 0x02, 0x03};
-        auto dataVec = batchBuilder.CreateVector(rawData);
-
-        Wazuh::SyncSchema::DataValueBuilder dvBuilder(batchBuilder);
-        dvBuilder.add_seq(i);
-        dvBuilder.add_id(idStr);
-        dvBuilder.add_index(idxStr);
-        dvBuilder.add_data(dataVec);
-        dvOffsets.push_back(dvBuilder.Finish());
-    }
-    auto valuesVec = batchBuilder.CreateVector(dvOffsets);
-    Wazuh::SyncSchema::DataBatchBuilder dataBatchBuilder(batchBuilder);
-    dataBatchBuilder.add_values(valuesVec);
-    auto batchOffset = dataBatchBuilder.Finish();
-    auto batchMsgOffset =
-        Wazuh::SyncSchema::CreateMessage(batchBuilder, Wazuh::SyncSchema::MessageType_DataBatch, batchOffset.Union());
-    batchBuilder.Finish(batchMsgOffset);
-
-    // Unpack DataBatch and re-serialize each DataValue as a standalone Message{DataValue}
-    auto batchMsg = Wazuh::SyncSchema::GetMessage(batchBuilder.GetBufferPointer());
-    const auto* dataBatch = batchMsg->content_as<Wazuh::SyncSchema::DataBatch>();
-    ASSERT_NE(dataBatch, nullptr);
-    ASSERT_NE(dataBatch->values(), nullptr);
-    ASSERT_EQ(dataBatch->values()->size(), ITEM_COUNT);
-
-    for (const auto* dv : *dataBatch->values())
-    {
-        ASSERT_NE(dv, nullptr);
-        flatbuffers::FlatBufferBuilder dvBuilder;
-        const auto* idRaw = dv->id();
-        const auto* idxRaw = dv->index();
-        const auto* dataRaw = dv->data();
-        auto idStr = dvBuilder.CreateString(idRaw ? idRaw->string_view() : std::string_view {});
-        auto idxStr = dvBuilder.CreateString(idxRaw ? idxRaw->string_view() : std::string_view {});
-        auto dataVec =
-            dataRaw ? dvBuilder.CreateVector(dataRaw->data(), dataRaw->size()) : dvBuilder.CreateVector<int8_t>({});
-
-        Wazuh::SyncSchema::DataValueBuilder dataValueBuilder(dvBuilder);
-        dataValueBuilder.add_seq(dv->seq());
-        dataValueBuilder.add_id(idStr);
-        dataValueBuilder.add_index(idxStr);
-        dataValueBuilder.add_version(dv->version());
-        dataValueBuilder.add_operation(dv->operation());
-        dataValueBuilder.add_data(dataVec);
-        auto dvOffset = dataValueBuilder.Finish();
-
-        auto msgOffset =
-            Wazuh::SyncSchema::CreateMessage(dvBuilder, Wazuh::SyncSchema::MessageType_DataValue, dvOffset.Union());
-        dvBuilder.Finish(msgOffset);
-
-        auto reserializedMsg = Wazuh::SyncSchema::GetMessage(dvBuilder.GetBufferPointer());
-        auto reserialized = reserializedMsg->content_as<Wazuh::SyncSchema::DataValue>();
-        ASSERT_NE(reserialized, nullptr);
-        EXPECT_EQ(reserialized->seq(), dv->seq());
-
-        ASSERT_NO_THROW({ session.handleData(reserialized, dvBuilder.GetBufferPointer(), dvBuilder.GetSize()); });
-    }
 }
 
 // =============================================================================
@@ -694,7 +577,7 @@ namespace
     createStartWithIndices(flatbuffers::FlatBufferBuilder& builder,
                            uint64_t size,
                            const std::vector<std::string>& indices,
-                           Wazuh::SyncSchema::Mode mode = Wazuh::SyncSchema::Mode_ModuleFull,
+                           Wazuh::SyncSchema::Mode mode = Wazuh::SyncSchema::Mode_ModuleDelta,
                            const std::string& moduleName = "syscollector")
     {
         auto agentIdOffset = builder.CreateString("001");
@@ -729,7 +612,6 @@ TEST_F(AgentSessionTest, Constructor_StartIndices_FiltersOutNonStatePrefix)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(Wazuh::SyncSchema::Status_Ok, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     const auto& storedIndices = session.getContext()->indices;
@@ -744,7 +626,6 @@ TEST_F(AgentSessionTest, Constructor_StartIndices_EmptyPrefixOnlyRejected)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(Wazuh::SyncSchema::Status_Ok, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     EXPECT_TRUE(session.getContext()->indices.empty());
@@ -757,7 +638,6 @@ TEST_F(AgentSessionTest, Constructor_StartIndices_AllValidPassedThrough)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(Wazuh::SyncSchema::Status_Ok, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     EXPECT_EQ(session.getContext()->indices.size(), 3u);
@@ -771,7 +651,6 @@ TEST_F(AgentSessionTest, Constructor_StartIndices_RejectsOutOfScopeStateIndex)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(Wazuh::SyncSchema::Status_Ok, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     const auto& storedIndices = session.getContext()->indices;
@@ -788,12 +667,11 @@ TEST_F(AgentSessionTest, Constructor_StartIndices_RejectsManagerGovernanceIndice
                                             "wazuh-states-cluster-nodes",
                                             "wazuh-states-manager-status",
                                             "wazuh-states-vulnerabilities"},
-                                           Wazuh::SyncSchema::Mode_ModuleFull,
+                                           Wazuh::SyncSchema::Mode_ModuleDelta,
                                            "syscollector_vd");
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(Wazuh::SyncSchema::Status_Ok, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     // Only the in-scope vulnerabilities index survives.
@@ -833,7 +711,6 @@ TEST_F(AgentSessionTest, HandleChecksumModule_NonStateIndex_Ignored)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     flatbuffers::FlatBufferBuilder checksumBuilder;
@@ -862,7 +739,6 @@ TEST_F(AgentSessionTest, HandleChecksumModule_StateIndex_Stored)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     flatbuffers::FlatBufferBuilder checksumBuilder;
@@ -887,14 +763,12 @@ TEST_F(AgentSessionTest, HandleDataClean_NonStateIndex_Ignored)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     flatbuffers::FlatBufferBuilder dcBuilder;
     auto indexStr = dcBuilder.CreateString("wazuh-not-states");
 
     Wazuh::SyncSchema::DataCleanBuilder b(dcBuilder);
-    b.add_seq(0);
     b.add_index(indexStr);
     auto msg = b.Finish();
     dcBuilder.Finish(msg);
@@ -907,31 +781,35 @@ TEST_F(AgentSessionTest, HandleDataClean_NonStateIndex_Ignored)
 
 TEST_F(AgentSessionTest, HandleData_SeqOutOfRange_DoesNotStore)
 {
-    // declaredSize=1 means only seq=0 is valid. seq=1 is out of range and must
-    // be rejected. m_gapSet->observe throws std::out_of_range and the handler
-    // surfaces it; m_store.put is NEVER reached, so the bulk path stays clean
-    // of orphan keys.
+    // TODO(#38117): seq field removed from FlatBuffer schema on the agent side; the manager now
+    // assigns it internally via a per-session arrival-order counter (AgentSessionImpl::m_seqCounter).
+    // declaredSize=1 means only the first call gets an in-range seq (0); a second call gets seq=1,
+    // which is out of range and must be rejected. m_gapSet->observe throws std::out_of_range and the
+    // handler surfaces it; m_store.put is NEVER reached for the rejected call.
     auto startMsg = createStartMessage(1, "001");
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     flatbuffers::FlatBufferBuilder dataBuilder;
     std::vector<int8_t> testData = {0x01};
     auto dataVector = dataBuilder.CreateVector(testData);
     Wazuh::SyncSchema::DataValueBuilder dvb(dataBuilder);
-    dvb.add_seq(1); // OUT OF RANGE
     dvb.add_data(dataVector);
     auto dvOff = dvb.Finish();
     dataBuilder.Finish(dvOff);
 
     auto data = flatbuffers::GetRoot<Wazuh::SyncSchema::DataValue>(dataBuilder.GetBufferPointer());
 
-    EXPECT_CALL(mockStore, put(_, _)).Times(0);
+    EXPECT_CALL(mockStore, put(_, _)).Times(1);
     EXPECT_CALL(mockIndexerQueue, push(_)).Times(0);
 
+    // First call consumes the only declared slot (seq=0).
+    ASSERT_NO_THROW(
+        { session.handleData(data, reinterpret_cast<const uint8_t*>(data->data()->data()), data->data()->size()); });
+
+    // Second call is assigned seq=1, which is out of declared size bounds (declaredSize=1).
     EXPECT_THROW(
         { session.handleData(data, reinterpret_cast<const uint8_t*>(data->data()->data()), data->data()->size()); },
         std::out_of_range);
@@ -939,26 +817,31 @@ TEST_F(AgentSessionTest, HandleData_SeqOutOfRange_DoesNotStore)
 
 TEST_F(AgentSessionTest, HandleDataContext_SeqOutOfRange_DoesNotStore)
 {
+    // TODO(#38117): seq field removed from FlatBuffer schema on the agent side; see the m_seqCounter
+    // note in HandleData_SeqOutOfRange_DoesNotStore. First call consumes the only declared slot
+    // (seq=0); the second call is assigned seq=1, out of range for declaredSize=1.
     auto startMsg = createStartMessage(1, "001");
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     flatbuffers::FlatBufferBuilder dcBuilder;
     std::vector<int8_t> raw = {0x01};
     auto dataVec = dcBuilder.CreateVector(raw);
     Wazuh::SyncSchema::DataContextBuilder b(dcBuilder);
-    b.add_seq(1); // OUT OF RANGE
     b.add_data(dataVec);
     auto off = b.Finish();
     dcBuilder.Finish(off);
 
     auto ctx = flatbuffers::GetRoot<Wazuh::SyncSchema::DataContext>(dcBuilder.GetBufferPointer());
 
-    EXPECT_CALL(mockStore, put(_, _)).Times(0);
+    EXPECT_CALL(mockStore, put(_, _)).Times(1);
     EXPECT_CALL(mockIndexerQueue, push(_)).Times(0);
+
+    ASSERT_NO_THROW({
+        session.handleDataContext(ctx, reinterpret_cast<const uint8_t*>(ctx->data()->data()), ctx->data()->size());
+    });
 
     EXPECT_THROW(
         { session.handleDataContext(ctx, reinterpret_cast<const uint8_t*>(ctx->data()->data()), ctx->data()->size()); },
@@ -967,104 +850,122 @@ TEST_F(AgentSessionTest, HandleDataContext_SeqOutOfRange_DoesNotStore)
 
 TEST_F(AgentSessionTest, HandleDataClean_SeqOutOfRange_DoesNotInsertIndex)
 {
+    // TODO(#38117): seq field removed from FlatBuffer schema on the agent side; see the m_seqCounter
+    // note in HandleData_SeqOutOfRange_DoesNotStore. A first DataClean consumes the only declared
+    // slot (seq=0) and is accepted; a second DataClean (distinct index, to tell them apart) is
+    // assigned seq=1, out of range for declaredSize=1, and must not insert its own index.
     auto startMsg = createStartMessage(1, "001", "test-agent", "4.0.0", "fim", Wazuh::SyncSchema::Mode_ModuleDelta);
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
-    flatbuffers::FlatBufferBuilder dcBuilder;
-    auto indexStr = dcBuilder.CreateString("wazuh-states-fim-files");
-    Wazuh::SyncSchema::DataCleanBuilder b(dcBuilder);
-    b.add_seq(1); // OUT OF RANGE (declared size is 1)
-    b.add_index(indexStr);
-    auto msg = b.Finish();
-    dcBuilder.Finish(msg);
+    flatbuffers::FlatBufferBuilder dcBuilder1;
+    auto indexStr1 = dcBuilder1.CreateString("wazuh-states-fim-files");
+    Wazuh::SyncSchema::DataCleanBuilder b1(dcBuilder1);
+    b1.add_index(indexStr1);
+    auto msg1 = b1.Finish();
+    dcBuilder1.Finish(msg1);
+    auto dc1 = flatbuffers::GetRoot<Wazuh::SyncSchema::DataClean>(dcBuilder1.GetBufferPointer());
+    ASSERT_NO_THROW({ session.handleDataClean(dc1); });
 
-    auto dc = flatbuffers::GetRoot<Wazuh::SyncSchema::DataClean>(dcBuilder.GetBufferPointer());
+    flatbuffers::FlatBufferBuilder dcBuilder2;
+    auto indexStr2 = dcBuilder2.CreateString("wazuh-states-fim-registry-keys");
+    Wazuh::SyncSchema::DataCleanBuilder b2(dcBuilder2);
+    b2.add_index(indexStr2);
+    auto msg2 = b2.Finish();
+    dcBuilder2.Finish(msg2);
+    auto dc2 = flatbuffers::GetRoot<Wazuh::SyncSchema::DataClean>(dcBuilder2.GetBufferPointer());
 
     EXPECT_CALL(mockIndexerQueue, push(_)).Times(0);
+    EXPECT_THROW({ session.handleDataClean(dc2); }, std::out_of_range);
 
-    EXPECT_THROW({ session.handleDataClean(dc); }, std::out_of_range);
-    EXPECT_TRUE(session.getContext()->dataCleanIndices.empty());
+    ASSERT_EQ(session.getContext()->dataCleanIndices.size(), 1u);
+    EXPECT_TRUE(session.getContext()->dataCleanIndices.count("wazuh-states-fim-files") == 1);
+    EXPECT_TRUE(session.getContext()->dataCleanIndices.count("wazuh-states-fim-registry-keys") == 0);
 }
 
 TEST_F(AgentSessionTest, HandleData_DuplicateAfterEnd_DoesNotRePush)
 {
+    // TODO(#38117): seq field removed from FlatBuffer schema on the agent side; the manager now
+    // assigns it internally via a per-session arrival-order counter (AgentSessionImpl::m_seqCounter),
+    // which cannot recognize a retransmission of the same logical item the way the agent-supplied
+    // seq did. A "retransmission" now consumes a NEW counter value, which - for a session with
+    // declaredSize=1 - is out of range and rejected with std::out_of_range instead of being silently
+    // absorbed. This is a known, accepted regression of this temporary shim (see class-level TODO);
+    // real retry/dedup semantics require the FullSession-based manager rewrite owned by the server team.
     auto startMsg = createStartMessage(1, "001");
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     flatbuffers::FlatBufferBuilder dataBuilder;
     std::vector<int8_t> testData = {0x01};
     auto dataVector = dataBuilder.CreateVector(testData);
     Wazuh::SyncSchema::DataValueBuilder dvb(dataBuilder);
-    dvb.add_seq(0);
     dvb.add_data(dataVector);
     auto dvOff = dvb.Finish();
     dataBuilder.Finish(dvOff);
 
     auto data = flatbuffers::GetRoot<Wazuh::SyncSchema::DataValue>(dataBuilder.GetBufferPointer());
 
-    // Two store puts (one per delivery — idempotent overwrite), one indexer
-    // push only — the duplicate must NOT re-enqueue after the End has been
-    // forwarded to the indexer.
-    EXPECT_CALL(mockStore, put(_, _)).Times(2);
+    EXPECT_CALL(mockStore, put(_, _)).Times(1);
     EXPECT_CALL(mockIndexerQueue, push(_)).Times(1);
     EXPECT_CALL(mockResponseDispatcher, sendEndAck(Wazuh::SyncSchema::Status_Processing, _, _, _)).Times(1);
 
     session.handleData(data, reinterpret_cast<const uint8_t*>(data->data()->data()), data->data()->size());
     session.handleEnd(mockResponseDispatcher);
-    // Retransmission arrives AFTER the End has been pushed.
-    session.handleData(data, reinterpret_cast<const uint8_t*>(data->data()->data()), data->data()->size());
+    // Retransmission arrives AFTER the End has been pushed; it gets a new (out-of-range) seq.
+    EXPECT_THROW(
+        { session.handleData(data, reinterpret_cast<const uint8_t*>(data->data()->data()), data->data()->size()); },
+        std::out_of_range);
 }
 
 TEST_F(AgentSessionTest, HandleDataContext_DuplicateAfterEnd_DoesNotRePush)
 {
+    // TODO(#38117): see the m_seqCounter note in HandleData_DuplicateAfterEnd_DoesNotRePush - a
+    // retransmission now consumes a new (out-of-range) seq under declaredSize=1 and is rejected.
     auto startMsg = createStartMessage(1, "001");
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     flatbuffers::FlatBufferBuilder dcBuilder;
     std::vector<int8_t> raw = {0x01};
     auto dataVec = dcBuilder.CreateVector(raw);
     Wazuh::SyncSchema::DataContextBuilder b(dcBuilder);
-    b.add_seq(0);
     b.add_data(dataVec);
     auto off = b.Finish();
     dcBuilder.Finish(off);
 
     auto ctx = flatbuffers::GetRoot<Wazuh::SyncSchema::DataContext>(dcBuilder.GetBufferPointer());
 
-    EXPECT_CALL(mockStore, put(_, _)).Times(2);
+    EXPECT_CALL(mockStore, put(_, _)).Times(1);
     EXPECT_CALL(mockIndexerQueue, push(_)).Times(1);
     EXPECT_CALL(mockResponseDispatcher, sendEndAck(Wazuh::SyncSchema::Status_Processing, _, _, _)).Times(1);
 
     session.handleDataContext(ctx, reinterpret_cast<const uint8_t*>(ctx->data()->data()), ctx->data()->size());
     session.handleEnd(mockResponseDispatcher);
-    session.handleDataContext(ctx, reinterpret_cast<const uint8_t*>(ctx->data()->data()), ctx->data()->size());
+    EXPECT_THROW(
+        { session.handleDataContext(ctx, reinterpret_cast<const uint8_t*>(ctx->data()->data()), ctx->data()->size()); },
+        std::out_of_range);
 }
 
 TEST_F(AgentSessionTest, HandleDataClean_DuplicateAfterEnd_DoesNotRePush)
 {
+    // TODO(#38117): see the m_seqCounter note in HandleData_DuplicateAfterEnd_DoesNotRePush - a
+    // retransmission now consumes a new (out-of-range) seq under declaredSize=1 and is rejected.
     auto startMsg = createStartMessage(1, "001", "test-agent", "4.0.0", "fim", Wazuh::SyncSchema::Mode_ModuleDelta);
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     flatbuffers::FlatBufferBuilder dcBuilder;
     auto indexStr = dcBuilder.CreateString("wazuh-states-fim-files");
     Wazuh::SyncSchema::DataCleanBuilder b(dcBuilder);
-    b.add_seq(0);
     b.add_index(indexStr);
     auto msg = b.Finish();
     dcBuilder.Finish(msg);
@@ -1076,7 +977,8 @@ TEST_F(AgentSessionTest, HandleDataClean_DuplicateAfterEnd_DoesNotRePush)
 
     session.handleDataClean(dc);
     session.handleEnd(mockResponseDispatcher);
-    session.handleDataClean(dc); // duplicate after the End was pushed
+    // Retransmission after the End was pushed; it gets a new (out-of-range) seq.
+    EXPECT_THROW({ session.handleDataClean(dc); }, std::out_of_range);
 }
 
 TEST_F(AgentSessionTest, HandleChecksumModule_AfterEnd_IsIgnored)
@@ -1090,7 +992,6 @@ TEST_F(AgentSessionTest, HandleChecksumModule_AfterEnd_IsIgnored)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     EXPECT_CALL(mockIndexerQueue, push(_)).Times(1);
@@ -1123,7 +1024,6 @@ TEST_F(AgentSessionTest, DeclaredSize_ReturnsValueFromStart)
     builder.Finish(startMsg);
     auto start = flatbuffers::GetRoot<Wazuh::SyncSchema::Start>(builder.GetBufferPointer());
 
-    EXPECT_CALL(mockResponseDispatcher, sendStartAck(_, _, _, _)).Times(1);
     AgentSessionForTest session(sessionId, start, mockStore, mockIndexerQueue, mockResponseDispatcher, s_logFn);
 
     EXPECT_EQ(session.declaredSize(), kSize);

--- a/src/wazuh_modules/inventory_sync/tests/unit/agentSession_test.cpp
+++ b/src/wazuh_modules/inventory_sync/tests/unit/agentSession_test.cpp
@@ -152,7 +152,6 @@ TEST_F(AgentSessionTest, HandleData_Success)
 
     Wazuh::SyncSchema::DataValueBuilder dataMsgBuilder(dataBuilder);
     dataMsgBuilder.add_seq(0);
-    dataMsgBuilder.add_session(sessionId);
     dataMsgBuilder.add_data(dataVector);
     auto dataMsg = dataMsgBuilder.Finish();
     dataBuilder.Finish(dataMsg);
@@ -182,7 +181,6 @@ TEST_F(AgentSessionTest, HandleData_CompletesGapSet_EndNotReceived)
 
     Wazuh::SyncSchema::DataValueBuilder dataMsgBuilder(dataBuilder);
     dataMsgBuilder.add_seq(0);
-    dataMsgBuilder.add_session(sessionId);
     dataMsgBuilder.add_data(dataVector);
     auto dataMsg = dataMsgBuilder.Finish();
     dataBuilder.Finish(dataMsg);
@@ -215,7 +213,6 @@ TEST_F(AgentSessionTest, HandleData_CompletesGapSet_EndReceived)
 
     Wazuh::SyncSchema::DataValueBuilder dataMsgBuilder(dataBuilder);
     dataMsgBuilder.add_seq(0);
-    dataMsgBuilder.add_session(sessionId);
     dataMsgBuilder.add_data(dataVector);
     auto dataMsg = dataMsgBuilder.Finish();
     dataBuilder.Finish(dataMsg);
@@ -260,7 +257,6 @@ TEST_F(AgentSessionTest, HandleEnd_GapSetEmpty)
 
     Wazuh::SyncSchema::DataValueBuilder dataMsgBuilder(dataBuilder);
     dataMsgBuilder.add_seq(0);
-    dataMsgBuilder.add_session(sessionId);
     dataMsgBuilder.add_data(dataVector);
     auto dataMsg = dataMsgBuilder.Finish();
     dataBuilder.Finish(dataMsg);
@@ -294,7 +290,6 @@ TEST_F(AgentSessionTest, HandleChecksumModule_Success)
     auto indexStr = checksumBuilder.CreateString("wazuh-states-vulnerabilities");
 
     Wazuh::SyncSchema::ChecksumModuleBuilder checksumModuleBuilder(checksumBuilder);
-    checksumModuleBuilder.add_session(sessionId);
     checksumModuleBuilder.add_checksum(checksumStr);
     checksumModuleBuilder.add_index(indexStr);
     auto checksumMsg = checksumModuleBuilder.Finish();
@@ -333,7 +328,6 @@ TEST_F(AgentSessionTest, HandleChecksumModule_EmptyChecksum)
     auto indexStr = checksumBuilder.CreateString("wazuh-states-vulnerabilities");
 
     Wazuh::SyncSchema::ChecksumModuleBuilder checksumModuleBuilder(checksumBuilder);
-    checksumModuleBuilder.add_session(sessionId);
     checksumModuleBuilder.add_index(indexStr);
     auto checksumMsg = checksumModuleBuilder.Finish();
     checksumBuilder.Finish(checksumMsg);
@@ -358,7 +352,6 @@ TEST_F(AgentSessionTest, HandleDataClean_Success)
     auto indexStr = dataCleanBuilder.CreateString("wazuh-states-fim-files");
 
     Wazuh::SyncSchema::DataCleanBuilder dataCleanMsgBuilder(dataCleanBuilder);
-    dataCleanMsgBuilder.add_session(sessionId);
     dataCleanMsgBuilder.add_seq(0);
     dataCleanMsgBuilder.add_index(indexStr);
     auto dataCleanMsg = dataCleanMsgBuilder.Finish();
@@ -389,7 +382,6 @@ TEST_F(AgentSessionTest, HandleDataClean_MultipleIndices)
         auto indexStr = dataCleanBuilder.CreateString(indices[i]);
 
         Wazuh::SyncSchema::DataCleanBuilder dataCleanMsgBuilder(dataCleanBuilder);
-        dataCleanMsgBuilder.add_session(sessionId);
         dataCleanMsgBuilder.add_seq(i);
         dataCleanMsgBuilder.add_index(indexStr);
         auto dataCleanMsg = dataCleanMsgBuilder.Finish();
@@ -427,7 +419,6 @@ TEST_F(AgentSessionTest, HandleDataClean_WithEnd)
     auto indexStr = dataCleanBuilder.CreateString("wazuh-states-fim-files");
 
     Wazuh::SyncSchema::DataCleanBuilder dataCleanMsgBuilder(dataCleanBuilder);
-    dataCleanMsgBuilder.add_session(sessionId);
     dataCleanMsgBuilder.add_seq(0);
     dataCleanMsgBuilder.add_index(indexStr);
     auto dataCleanMsg = dataCleanMsgBuilder.Finish();
@@ -441,7 +432,6 @@ TEST_F(AgentSessionTest, HandleDataClean_WithEnd)
     // Create and handle End message
     flatbuffers::FlatBufferBuilder endBuilder;
     Wazuh::SyncSchema::EndBuilder endMsgBuilder(endBuilder);
-    endMsgBuilder.add_session(sessionId);
     auto endMsg = endMsgBuilder.Finish();
     endBuilder.Finish(endMsg);
 
@@ -471,7 +461,6 @@ TEST_F(AgentSessionTest, HandleDataContext_Success)
     auto dataVec = dataContextBuilder.CreateVector(contextData);
 
     Wazuh::SyncSchema::DataContextBuilder dataContextMsgBuilder(dataContextBuilder);
-    dataContextMsgBuilder.add_session(sessionId);
     dataContextMsgBuilder.add_seq(0);
     dataContextMsgBuilder.add_id(idStr);
     dataContextMsgBuilder.add_index(indexStr);
@@ -511,7 +500,6 @@ TEST_F(AgentSessionTest, HandleDataContext_MultipleMessages)
         auto dataVec = dataContextBuilder.CreateVector(contextData);
 
         Wazuh::SyncSchema::DataContextBuilder dataContextMsgBuilder(dataContextBuilder);
-        dataContextMsgBuilder.add_session(sessionId);
         dataContextMsgBuilder.add_seq(i);
         dataContextMsgBuilder.add_id(idStr);
         dataContextMsgBuilder.add_index(indexStr);
@@ -558,7 +546,6 @@ TEST_F(AgentSessionTest, HandleDataContext_WithEnd)
     auto dataVec = dataContextBuilder.CreateVector(contextData);
 
     Wazuh::SyncSchema::DataContextBuilder dataContextMsgBuilder(dataContextBuilder);
-    dataContextMsgBuilder.add_session(sessionId);
     dataContextMsgBuilder.add_seq(0);
     dataContextMsgBuilder.add_id(idStr);
     dataContextMsgBuilder.add_index(indexStr);
@@ -577,7 +564,6 @@ TEST_F(AgentSessionTest, HandleDataContext_WithEnd)
     // Create and handle End message
     flatbuffers::FlatBufferBuilder endBuilder;
     Wazuh::SyncSchema::EndBuilder endMsgBuilder(endBuilder);
-    endMsgBuilder.add_session(sessionId);
     auto endMsg = endMsgBuilder.Finish();
     endBuilder.Finish(endMsg);
 
@@ -643,7 +629,6 @@ TEST_F(AgentSessionTest, HandleData_ReserializedFromDataBatch)
 
         Wazuh::SyncSchema::DataValueBuilder dvBuilder(batchBuilder);
         dvBuilder.add_seq(i);
-        dvBuilder.add_session(sessionId);
         dvBuilder.add_id(idStr);
         dvBuilder.add_index(idxStr);
         dvBuilder.add_data(dataVec);
@@ -678,7 +663,6 @@ TEST_F(AgentSessionTest, HandleData_ReserializedFromDataBatch)
 
         Wazuh::SyncSchema::DataValueBuilder dataValueBuilder(dvBuilder);
         dataValueBuilder.add_seq(dv->seq());
-        dataValueBuilder.add_session(dv->session());
         dataValueBuilder.add_id(idStr);
         dataValueBuilder.add_index(idxStr);
         dataValueBuilder.add_version(dv->version());
@@ -694,7 +678,6 @@ TEST_F(AgentSessionTest, HandleData_ReserializedFromDataBatch)
         auto reserialized = reserializedMsg->content_as<Wazuh::SyncSchema::DataValue>();
         ASSERT_NE(reserialized, nullptr);
         EXPECT_EQ(reserialized->seq(), dv->seq());
-        EXPECT_EQ(reserialized->session(), sessionId);
 
         ASSERT_NO_THROW({ session.handleData(reserialized, dvBuilder.GetBufferPointer(), dvBuilder.GetSize()); });
     }
@@ -858,7 +841,6 @@ TEST_F(AgentSessionTest, HandleChecksumModule_NonStateIndex_Ignored)
     auto indexStr = checksumBuilder.CreateString("wazuh-other-foo");
 
     Wazuh::SyncSchema::ChecksumModuleBuilder cmBuilder(checksumBuilder);
-    cmBuilder.add_session(sessionId);
     cmBuilder.add_checksum(checksumStr);
     cmBuilder.add_index(indexStr);
     auto cmMsg = cmBuilder.Finish();
@@ -888,7 +870,6 @@ TEST_F(AgentSessionTest, HandleChecksumModule_StateIndex_Stored)
     auto indexStr = checksumBuilder.CreateString("wazuh-states-vulnerabilities");
 
     Wazuh::SyncSchema::ChecksumModuleBuilder cmBuilder(checksumBuilder);
-    cmBuilder.add_session(sessionId);
     cmBuilder.add_checksum(checksumStr);
     cmBuilder.add_index(indexStr);
     auto cmMsg = cmBuilder.Finish();
@@ -913,7 +894,6 @@ TEST_F(AgentSessionTest, HandleDataClean_NonStateIndex_Ignored)
     auto indexStr = dcBuilder.CreateString("wazuh-not-states");
 
     Wazuh::SyncSchema::DataCleanBuilder b(dcBuilder);
-    b.add_session(sessionId);
     b.add_seq(0);
     b.add_index(indexStr);
     auto msg = b.Finish();
@@ -943,7 +923,6 @@ TEST_F(AgentSessionTest, HandleData_SeqOutOfRange_DoesNotStore)
     auto dataVector = dataBuilder.CreateVector(testData);
     Wazuh::SyncSchema::DataValueBuilder dvb(dataBuilder);
     dvb.add_seq(1); // OUT OF RANGE
-    dvb.add_session(sessionId);
     dvb.add_data(dataVector);
     auto dvOff = dvb.Finish();
     dataBuilder.Finish(dvOff);
@@ -972,7 +951,6 @@ TEST_F(AgentSessionTest, HandleDataContext_SeqOutOfRange_DoesNotStore)
     auto dataVec = dcBuilder.CreateVector(raw);
     Wazuh::SyncSchema::DataContextBuilder b(dcBuilder);
     b.add_seq(1); // OUT OF RANGE
-    b.add_session(sessionId);
     b.add_data(dataVec);
     auto off = b.Finish();
     dcBuilder.Finish(off);
@@ -999,7 +977,6 @@ TEST_F(AgentSessionTest, HandleDataClean_SeqOutOfRange_DoesNotInsertIndex)
     flatbuffers::FlatBufferBuilder dcBuilder;
     auto indexStr = dcBuilder.CreateString("wazuh-states-fim-files");
     Wazuh::SyncSchema::DataCleanBuilder b(dcBuilder);
-    b.add_session(sessionId);
     b.add_seq(1); // OUT OF RANGE (declared size is 1)
     b.add_index(indexStr);
     auto msg = b.Finish();
@@ -1027,7 +1004,6 @@ TEST_F(AgentSessionTest, HandleData_DuplicateAfterEnd_DoesNotRePush)
     auto dataVector = dataBuilder.CreateVector(testData);
     Wazuh::SyncSchema::DataValueBuilder dvb(dataBuilder);
     dvb.add_seq(0);
-    dvb.add_session(sessionId);
     dvb.add_data(dataVector);
     auto dvOff = dvb.Finish();
     dataBuilder.Finish(dvOff);
@@ -1061,7 +1037,6 @@ TEST_F(AgentSessionTest, HandleDataContext_DuplicateAfterEnd_DoesNotRePush)
     auto dataVec = dcBuilder.CreateVector(raw);
     Wazuh::SyncSchema::DataContextBuilder b(dcBuilder);
     b.add_seq(0);
-    b.add_session(sessionId);
     b.add_data(dataVec);
     auto off = b.Finish();
     dcBuilder.Finish(off);
@@ -1089,7 +1064,6 @@ TEST_F(AgentSessionTest, HandleDataClean_DuplicateAfterEnd_DoesNotRePush)
     flatbuffers::FlatBufferBuilder dcBuilder;
     auto indexStr = dcBuilder.CreateString("wazuh-states-fim-files");
     Wazuh::SyncSchema::DataCleanBuilder b(dcBuilder);
-    b.add_session(sessionId);
     b.add_seq(0);
     b.add_index(indexStr);
     auto msg = b.Finish();
@@ -1130,7 +1104,6 @@ TEST_F(AgentSessionTest, HandleChecksumModule_AfterEnd_IsIgnored)
     auto checksumStr = checksumBuilder.CreateString("late-checksum");
     auto indexStr = checksumBuilder.CreateString("wazuh-states-vulnerabilities");
     Wazuh::SyncSchema::ChecksumModuleBuilder cmBuilder(checksumBuilder);
-    cmBuilder.add_session(sessionId);
     cmBuilder.add_checksum(checksumStr);
     cmBuilder.add_index(indexStr);
     auto cmMsg = cmBuilder.Finish();

--- a/src/wazuh_modules/inventory_sync/tests/unit/datavalue_null_validation_test.cpp
+++ b/src/wazuh_modules/inventory_sync/tests/unit/datavalue_null_validation_test.cpp
@@ -63,7 +63,6 @@ protected:
 
         Wazuh::SyncSchema::DataValueBuilder dvBuilder(builder);
         dvBuilder.add_seq(1);
-        dvBuilder.add_session(1);
         dvBuilder.add_operation(operation);
 
         if (includeId)
@@ -216,7 +215,6 @@ TEST_F(DataValueNullValidationTest, EmptyStringId_DifferentFromNullId)
 
     Wazuh::SyncSchema::DataValueBuilder dvBuilder(builder);
     dvBuilder.add_seq(1);
-    dvBuilder.add_session(1);
     dvBuilder.add_operation(Wazuh::SyncSchema::Operation_Upsert);
     dvBuilder.add_id(idOff);
     dvBuilder.add_index(indexOff);

--- a/src/wazuh_modules/inventory_sync/tests/unit/datavalue_null_validation_test.cpp
+++ b/src/wazuh_modules/inventory_sync/tests/unit/datavalue_null_validation_test.cpp
@@ -62,7 +62,6 @@ protected:
         }
 
         Wazuh::SyncSchema::DataValueBuilder dvBuilder(builder);
-        dvBuilder.add_seq(1);
         dvBuilder.add_operation(operation);
 
         if (includeId)
@@ -214,7 +213,6 @@ TEST_F(DataValueNullValidationTest, EmptyStringId_DifferentFromNullId)
     auto dataOff = builder.CreateVector(reinterpret_cast<const int8_t*>(json), 2);
 
     Wazuh::SyncSchema::DataValueBuilder dvBuilder(builder);
-    dvBuilder.add_seq(1);
     dvBuilder.add_operation(Wazuh::SyncSchema::Operation_Upsert);
     dvBuilder.add_id(idOff);
     dvBuilder.add_index(indexOff);

--- a/src/wazuh_modules/inventory_sync/tests/unit/mock_agentSession.hpp
+++ b/src/wazuh_modules/inventory_sync/tests/unit/mock_agentSession.hpp
@@ -33,16 +33,6 @@ public:
     virtual ~MockResponseDispatcher() = default;
     MOCK_METHOD(
         void,
-        sendStartAck,
-        (Wazuh::SyncSchema::Status status, std::string_view agentId, uint64_t sessionId, std::string_view moduleName),
-        (const));
-    MOCK_CONST_METHOD4(sendEndMissingSeq,
-                       void(std::string_view agentId,
-                            uint64_t sessionId,
-                            std::string_view moduleName,
-                            const std::vector<std::pair<uint64_t, uint64_t>>& ranges));
-    MOCK_METHOD(
-        void,
         sendEndAck,
         (Wazuh::SyncSchema::Status status, std::string_view agentId, uint64_t sessionId, std::string_view moduleName),
         (const));

--- a/src/wazuh_modules/inventory_sync/tests/unit/mock_agentSession.hpp
+++ b/src/wazuh_modules/inventory_sync/tests/unit/mock_agentSession.hpp
@@ -26,16 +26,13 @@ public:
     MOCK_METHOD(void, push, (const Response& response));
 };
 
-// Mock for TResponseDispatcher
+// Mock for TResponseDispatcher. TODO(#38117): StartAck/EndAck removed from FlatBuffer
+// schema/agent side - the manager no longer acknowledges sessions via either, so this
+// mock has no methods left. Kept as a type for AgentSessionImpl's template parameter.
 class MockResponseDispatcher
 {
 public:
     virtual ~MockResponseDispatcher() = default;
-    MOCK_METHOD(
-        void,
-        sendEndAck,
-        (Wazuh::SyncSchema::Status status, std::string_view agentId, uint64_t sessionId, std::string_view moduleName),
-        (const));
 };
 
 #endif // _MOCK_AGENT_SESSION_HPP

--- a/src/wazuh_modules/inventory_sync/tests/unit/responseDispatcher_test.cpp
+++ b/src/wazuh_modules/inventory_sync/tests/unit/responseDispatcher_test.cpp
@@ -29,33 +29,6 @@ protected:
     using ResponseDispatcherForTest = ResponseDispatcherImpl<MockResponseQueue>;
 };
 
-TEST_F(ResponseDispatcherTest, SendStartAck)
-{
-    auto* mockQueue = new StrictMock<MockResponseQueue>();
-    ResponseDispatcherForTest dispatcher(mockQueue);
-
-    std::string agentId = "001";
-    uint64_t sessionId = 12345;
-    std::string moduleName = "syscollector";
-
-    EXPECT_CALL(*mockQueue, push(_))
-        .WillOnce(Invoke(
-            [&](ResponseMessage&& responseMsg)
-            {
-                auto msg = flatbuffers::GetRoot<Wazuh::SyncSchema::Message>(responseMsg.builder.GetBufferPointer());
-                ASSERT_EQ(msg->content_type(), Wazuh::SyncSchema::MessageType_StartAck);
-
-                auto startAck = msg->content_as_StartAck();
-                ASSERT_NE(startAck, nullptr);
-                EXPECT_EQ(startAck->status(), Wazuh::SyncSchema::Status_Ok);
-                // TODO(#38117): session field removed from agent FlatBuffer schema
-                // EXPECT_EQ(startAck->session(), 12345);
-                // Note: StartAck schema doesn't include module field
-            }));
-
-    dispatcher.sendStartAck(Wazuh::SyncSchema::Status_Ok, agentId, sessionId, moduleName);
-}
-
 TEST_F(ResponseDispatcherTest, SendEndAck)
 {
     auto* mockQueue = new StrictMock<MockResponseQueue>();
@@ -81,35 +54,4 @@ TEST_F(ResponseDispatcherTest, SendEndAck)
             }));
 
     dispatcher.sendEndAck(Wazuh::SyncSchema::Status_Error, agentId, sessionId, moduleName);
-}
-
-TEST_F(ResponseDispatcherTest, SendEndMissingSeq)
-{
-    auto* mockQueue = new StrictMock<MockResponseQueue>();
-    ResponseDispatcherForTest dispatcher(mockQueue);
-
-    uint64_t sessionId = 98765;
-    std::vector<std::pair<uint64_t, uint64_t>> ranges = {{1, 5}, {8, 10}};
-
-    EXPECT_CALL(*mockQueue, push(_))
-        .WillOnce(Invoke(
-            [&](ResponseMessage&& responseMsg)
-            {
-                auto msg = flatbuffers::GetRoot<Wazuh::SyncSchema::Message>(responseMsg.builder.GetBufferPointer());
-                ASSERT_EQ(msg->content_type(), Wazuh::SyncSchema::MessageType_ReqRet);
-
-                auto reqRet = msg->content_as_ReqRet();
-                ASSERT_NE(reqRet, nullptr);
-                // TODO(#38117): session field removed from agent FlatBuffer schema
-                // EXPECT_EQ(reqRet->session(), 98765);
-
-                auto receivedRanges = reqRet->seq();
-                ASSERT_EQ(receivedRanges->size(), 2);
-                EXPECT_EQ(receivedRanges->Get(0)->begin(), 1);
-                EXPECT_EQ(receivedRanges->Get(0)->end(), 5);
-                EXPECT_EQ(receivedRanges->Get(1)->begin(), 8);
-                EXPECT_EQ(receivedRanges->Get(1)->end(), 10);
-            }));
-
-    dispatcher.sendEndMissingSeq("001", sessionId, "test_module", ranges);
 }

--- a/src/wazuh_modules/inventory_sync/tests/unit/responseDispatcher_test.cpp
+++ b/src/wazuh_modules/inventory_sync/tests/unit/responseDispatcher_test.cpp
@@ -29,29 +29,6 @@ protected:
     using ResponseDispatcherForTest = ResponseDispatcherImpl<MockResponseQueue>;
 };
 
-TEST_F(ResponseDispatcherTest, SendEndAck)
-{
-    auto* mockQueue = new StrictMock<MockResponseQueue>();
-    ResponseDispatcherForTest dispatcher(mockQueue);
-
-    std::string agentId = "002";
-    uint64_t sessionId = 54321;
-    std::string moduleName = "another_module";
-
-    EXPECT_CALL(*mockQueue, push(_))
-        .WillOnce(Invoke(
-            [&](ResponseMessage&& responseMsg)
-            {
-                auto msg = flatbuffers::GetRoot<Wazuh::SyncSchema::Message>(responseMsg.builder.GetBufferPointer());
-                ASSERT_EQ(msg->content_type(), Wazuh::SyncSchema::MessageType_EndAck);
-
-                auto endAck = msg->content_as_EndAck();
-                ASSERT_NE(endAck, nullptr);
-                EXPECT_EQ(endAck->status(), Wazuh::SyncSchema::Status_Error);
-                // TODO(#38117): session field removed from agent FlatBuffer schema
-                // EXPECT_EQ(endAck->session(), 54321);
-                // Note: EndAck schema doesn't include module field
-            }));
-
-    dispatcher.sendEndAck(Wazuh::SyncSchema::Status_Error, agentId, sessionId, moduleName);
-}
+// TODO(#38117): StartAck/EndAck removed from FlatBuffer schema/agent side - the manager
+// no longer acknowledges sessions via either, so ResponseDispatcherImpl has no methods
+// left to test here. The real /stateful HTTP response is the server team's own follow-up.

--- a/src/wazuh_modules/inventory_sync/tests/unit/responseDispatcher_test.cpp
+++ b/src/wazuh_modules/inventory_sync/tests/unit/responseDispatcher_test.cpp
@@ -48,7 +48,8 @@ TEST_F(ResponseDispatcherTest, SendStartAck)
                 auto startAck = msg->content_as_StartAck();
                 ASSERT_NE(startAck, nullptr);
                 EXPECT_EQ(startAck->status(), Wazuh::SyncSchema::Status_Ok);
-                EXPECT_EQ(startAck->session(), 12345);
+                // TODO(#38117): session field removed from agent FlatBuffer schema
+                // EXPECT_EQ(startAck->session(), 12345);
                 // Note: StartAck schema doesn't include module field
             }));
 
@@ -74,7 +75,8 @@ TEST_F(ResponseDispatcherTest, SendEndAck)
                 auto endAck = msg->content_as_EndAck();
                 ASSERT_NE(endAck, nullptr);
                 EXPECT_EQ(endAck->status(), Wazuh::SyncSchema::Status_Error);
-                EXPECT_EQ(endAck->session(), 54321);
+                // TODO(#38117): session field removed from agent FlatBuffer schema
+                // EXPECT_EQ(endAck->session(), 54321);
                 // Note: EndAck schema doesn't include module field
             }));
 
@@ -98,7 +100,8 @@ TEST_F(ResponseDispatcherTest, SendEndMissingSeq)
 
                 auto reqRet = msg->content_as_ReqRet();
                 ASSERT_NE(reqRet, nullptr);
-                EXPECT_EQ(reqRet->session(), 98765);
+                // TODO(#38117): session field removed from agent FlatBuffer schema
+                // EXPECT_EQ(reqRet->session(), 98765);
 
                 auto receivedRanges = reqRet->seq();
                 ASSERT_EQ(receivedRanges->size(), 2);

--- a/src/wazuh_modules/inventory_sync/testtool/main.cpp
+++ b/src/wazuh_modules/inventory_sync/testtool/main.cpp
@@ -258,7 +258,13 @@ public:
 };
 
 /**
- * @brief Response server for receiving EndAck messages.
+ * @brief Response server listening on the legacy ARQUEUE socket.
+ *
+ * TODO(#38117): StartAck/EndAck removed from FlatBuffer schema/agent side - the manager
+ * no longer acknowledges sessions via either, so nothing this server could receive here
+ * is a valid response anymore (see handleFlatBufferMessage). Kept listening (rather than
+ * removed outright) in case future testtool work needs a socket to receive on; the real
+ * /stateful HTTP response is the server team's own follow-up.
  */
 class ResponseServer
 {
@@ -267,21 +273,11 @@ private:
     std::thread m_serverThread;
     std::atomic<bool> m_shouldStop {false};
     std::string m_path;
-
-    // TODO(#38117): StartAck removed from FlatBuffer schema/agent side - the manager no longer
-    // acknowledges session establishment at all, so there is nothing to wait for here anymore.
-    std::promise<void>& m_endAckPromise;
-    std::atomic<bool>& m_receivedEndAck;
     bool m_verbose;
 
 public:
-    ResponseServer(std::string path,
-                   std::promise<void>& endAckPromise,
-                   std::atomic<bool>& receivedEndAck,
-                   bool verbose = false)
+    ResponseServer(std::string path, bool verbose = false)
         : m_path(std::move(path))
-        , m_endAckPromise(endAckPromise)
-        , m_receivedEndAck(receivedEndAck)
         , m_verbose(verbose)
     {
         m_socketFd = socket(AF_UNIX, SOCK_DGRAM, 0);
@@ -441,30 +437,10 @@ private:
 
         auto message = Wazuh::SyncSchema::GetMessage(data);
 
-        switch (message->content_type())
-        {
-            case Wazuh::SyncSchema::MessageType_EndAck: handleEndAck(message->content_as_EndAck()); break;
-            default:
-                std::cout << "[WARN] Unknown message type: " << static_cast<int>(message->content_type()) << std::endl;
-        }
-    }
-
-    void handleEndAck(const Wazuh::SyncSchema::EndAck* endAck)
-    {
-        std::cout << "[INFO] ✓ EndAck received" << std::endl;
-        // TODO(#38117): session field removed from agent FlatBuffer schema
-        std::cout << "       Status: " << static_cast<int>(endAck->status()) << std::endl;
-
-        if (!m_receivedEndAck.exchange(true))
-        {
-            try
-            {
-                m_endAckPromise.set_value();
-            }
-            catch (const std::future_error&)
-            {
-            }
-        }
+        // TODO(#38117): StartAck/EndAck removed from FlatBuffer schema/agent side - the
+        // manager no longer acknowledges sessions via either, so no message type this
+        // testtool could receive here is a valid response anymore.
+        std::cout << "[WARN] Unknown message type: " << static_cast<int>(message->content_type()) << std::endl;
     }
 };
 
@@ -735,23 +711,6 @@ public:
 
         return {builder.GetBufferPointer(), builder.GetBufferPointer() + builder.GetSize()};
     }
-
-    /**
-     * @brief Build End message.
-     */
-    static std::vector<uint8_t> buildEnd(uint64_t session)
-    {
-        flatbuffers::FlatBufferBuilder builder;
-
-        Wazuh::SyncSchema::EndBuilder endBuilder(builder);
-        // TODO(#38117): session field removed from agent FlatBuffer schema
-        auto endOffset = endBuilder.Finish();
-
-        auto message = Wazuh::SyncSchema::CreateMessage(builder, Wazuh::SyncSchema::MessageType_End, endOffset.Union());
-        builder.Finish(message);
-
-        return {builder.GetBufferPointer(), builder.GetBufferPointer() + builder.GetSize()};
-    }
 };
 
 // Command line parser
@@ -797,16 +756,9 @@ void sendEvent(bool verbose,
                uint32_t waitTime,
                RouterProvider& routerProvider,
                FakeReportServer& fakeReportServer,
-               uint64_t& sessionId,
-               std::promise<void>& endAckPromise,
-               std::atomic<bool>& receivedEndAck)
+               uint64_t& sessionId)
 {
-    // Reset promise for new iteration
-    endAckPromise = std::promise<void>();
-    receivedEndAck = false;
     sessionId = 0;
-
-    auto endAckFuture = endAckPromise.get_future();
 
     // Load test data
     AgentTestData testData;
@@ -908,10 +860,9 @@ void sendEvent(bool verbose,
         routerProvider.send(std::vector<char>(msg.begin(), msg.end()));
     }
 
-    // Send END
-    std::cout << "[SEND] End message" << std::endl;
-    auto endMsg = MessageBuilder::buildEnd(sessionId);
-    routerProvider.send(std::vector<char>(endMsg.begin(), endMsg.end()));
+    // TODO(#38117): End removed from FlatBuffer schema/agent side - the real agent no
+    // longer sends a standalone End message (or any of the chunked messages this testtool
+    // simulates above); it sends one FullSession. Nothing to send here anymore.
 
     std::cout << "\n[INFO] Waiting " << waitTime << " seconds for VD processing..." << std::endl;
     std::this_thread::sleep_for(std::chrono::seconds(waitTime));
@@ -1021,10 +972,8 @@ int main(int argc, char* argv[])
         fakeReportServer.start();
 
         uint64_t sessionId = 0;
-        std::promise<void> endAckPromise;
-        std::atomic<bool> receivedEndAck {false};
 
-        ResponseServer responseServer(DEFAULT_ARQUEUE, endAckPromise, receivedEndAck, config.verbose);
+        ResponseServer responseServer(DEFAULT_ARQUEUE, config.verbose);
         responseServer.start();
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
@@ -1041,23 +990,14 @@ int main(int argc, char* argv[])
                               config.waitTime,
                               routerProvider,
                               fakeReportServer,
-                              sessionId,
-                              endAckPromise,
-                              receivedEndAck);
+                              sessionId);
                 }
             }
         }
         else
         {
             // Single file
-            sendEvent(config.verbose,
-                      config.input,
-                      config.waitTime,
-                      routerProvider,
-                      fakeReportServer,
-                      sessionId,
-                      endAckPromise,
-                      receivedEndAck);
+            sendEvent(config.verbose, config.input, config.waitTime, routerProvider, fakeReportServer, sessionId);
         }
 
         // Cleanup

--- a/src/wazuh_modules/inventory_sync/testtool/main.cpp
+++ b/src/wazuh_modules/inventory_sync/testtool/main.cpp
@@ -460,10 +460,11 @@ private:
 
     void handleStartAck(const Wazuh::SyncSchema::StartAck* startAck)
     {
-        m_sessionId = startAck->session();
+        // TODO(#38117): session field removed from agent FlatBuffer schema; m_sessionId always 0 now
+        m_sessionId = 0; // was: startAck->session()
 
         std::cout << "[INFO] ✓ StartAck received" << std::endl;
-        std::cout << "       Session: " << m_sessionId << std::endl;
+        std::cout << "       Session: " << m_sessionId << " (deprecated field)" << std::endl;
         std::cout << "       Status: " << static_cast<int>(startAck->status()) << std::endl;
 
         if (!m_receivedStartAck.exchange(true))
@@ -481,7 +482,7 @@ private:
     void handleEndAck(const Wazuh::SyncSchema::EndAck* endAck)
     {
         std::cout << "[INFO] ✓ EndAck received" << std::endl;
-        std::cout << "       Session: " << endAck->session() << std::endl;
+        // TODO(#38117): session field removed from agent FlatBuffer schema
         std::cout << "       Status: " << static_cast<int>(endAck->status()) << std::endl;
 
         if (!m_receivedEndAck.exchange(true))
@@ -498,7 +499,8 @@ private:
 
     void handleReqRet(const Wazuh::SyncSchema::ReqRet* reqRet)
     {
-        std::cout << "[INFO] ✓ ReqRet received - Session: " << reqRet->session();
+        // TODO(#38117): session field removed from agent FlatBuffer schema
+        std::cout << "[INFO] ✓ ReqRet received";
         if (reqRet->seq())
         {
             std::cout << ", Missing ranges: " << reqRet->seq()->size();
@@ -727,7 +729,7 @@ public:
         auto dataVec = builder.CreateVector(reinterpret_cast<const int8_t*>(sourceJson.data()), sourceJson.size());
 
         Wazuh::SyncSchema::DataValueBuilder dataBuilder(builder);
-        dataBuilder.add_session(session);
+        // TODO(#38117): session field removed from agent FlatBuffer schema
         dataBuilder.add_seq(seq);
         dataBuilder.add_operation(operation);
         dataBuilder.add_index(indexStr);
@@ -763,7 +765,7 @@ public:
         auto dataVec = builder.CreateVector(reinterpret_cast<const int8_t*>(sourceJson.data()), sourceJson.size());
 
         Wazuh::SyncSchema::DataContextBuilder dataBuilder(builder);
-        dataBuilder.add_session(session);
+        // TODO(#38117): session field removed from agent FlatBuffer schema
         dataBuilder.add_seq(seq);
         dataBuilder.add_index(indexStr);
         dataBuilder.add_id(idStr);
@@ -785,7 +787,7 @@ public:
         flatbuffers::FlatBufferBuilder builder;
 
         Wazuh::SyncSchema::EndBuilder endBuilder(builder);
-        endBuilder.add_session(session);
+        // TODO(#38117): session field removed from agent FlatBuffer schema
         auto endOffset = endBuilder.Finish();
 
         auto message = Wazuh::SyncSchema::CreateMessage(builder, Wazuh::SyncSchema::MessageType_End, endOffset.Union());

--- a/src/wazuh_modules/inventory_sync/testtool/main.cpp
+++ b/src/wazuh_modules/inventory_sync/testtool/main.cpp
@@ -258,7 +258,7 @@ public:
 };
 
 /**
- * @brief Response server for receiving StartAck/EndAck/ReqRet messages.
+ * @brief Response server for receiving EndAck messages.
  */
 class ResponseServer
 {
@@ -268,26 +268,19 @@ private:
     std::atomic<bool> m_shouldStop {false};
     std::string m_path;
 
-    uint64_t& m_sessionId;
-    std::promise<void>& m_startAckPromise;
+    // TODO(#38117): StartAck removed from FlatBuffer schema/agent side - the manager no longer
+    // acknowledges session establishment at all, so there is nothing to wait for here anymore.
     std::promise<void>& m_endAckPromise;
-    std::atomic<bool>& m_receivedStartAck;
     std::atomic<bool>& m_receivedEndAck;
     bool m_verbose;
 
 public:
     ResponseServer(std::string path,
-                   uint64_t& sessionId,
-                   std::promise<void>& startAckPromise,
                    std::promise<void>& endAckPromise,
-                   std::atomic<bool>& receivedStartAck,
                    std::atomic<bool>& receivedEndAck,
                    bool verbose = false)
         : m_path(std::move(path))
-        , m_sessionId(sessionId)
-        , m_startAckPromise(startAckPromise)
         , m_endAckPromise(endAckPromise)
-        , m_receivedStartAck(receivedStartAck)
         , m_receivedEndAck(receivedEndAck)
         , m_verbose(verbose)
     {
@@ -450,32 +443,9 @@ private:
 
         switch (message->content_type())
         {
-            case Wazuh::SyncSchema::MessageType_StartAck: handleStartAck(message->content_as_StartAck()); break;
             case Wazuh::SyncSchema::MessageType_EndAck: handleEndAck(message->content_as_EndAck()); break;
-            case Wazuh::SyncSchema::MessageType_ReqRet: handleReqRet(message->content_as_ReqRet()); break;
             default:
                 std::cout << "[WARN] Unknown message type: " << static_cast<int>(message->content_type()) << std::endl;
-        }
-    }
-
-    void handleStartAck(const Wazuh::SyncSchema::StartAck* startAck)
-    {
-        // TODO(#38117): session field removed from agent FlatBuffer schema; m_sessionId always 0 now
-        m_sessionId = 0; // was: startAck->session()
-
-        std::cout << "[INFO] ✓ StartAck received" << std::endl;
-        std::cout << "       Session: " << m_sessionId << " (deprecated field)" << std::endl;
-        std::cout << "       Status: " << static_cast<int>(startAck->status()) << std::endl;
-
-        if (!m_receivedStartAck.exchange(true))
-        {
-            try
-            {
-                m_startAckPromise.set_value();
-            }
-            catch (const std::future_error&)
-            {
-            }
         }
     }
 
@@ -496,17 +466,6 @@ private:
             }
         }
     }
-
-    void handleReqRet(const Wazuh::SyncSchema::ReqRet* reqRet)
-    {
-        // TODO(#38117): session field removed from agent FlatBuffer schema
-        std::cout << "[INFO] ✓ ReqRet received";
-        if (reqRet->seq())
-        {
-            std::cout << ", Missing ranges: " << reqRet->seq()->size();
-        }
-        std::cout << std::endl;
-    }
 };
 
 /**
@@ -514,10 +473,6 @@ private:
  */
 inline Wazuh::SyncSchema::Mode parseMode(const std::string& modeStr)
 {
-    if (modeStr == "full" || modeStr == "ModuleFull")
-    {
-        return Wazuh::SyncSchema::Mode_ModuleFull;
-    }
     if (modeStr == "delta" || modeStr == "ModuleDelta")
     {
         return Wazuh::SyncSchema::Mode_ModuleDelta;
@@ -706,7 +661,7 @@ public:
     /**
      * @brief Build DataValue message from payload JSON.
      *
-     * @param session   Session ID from StartAck
+     * @param session   Unused (session field removed from FlatBuffer schema)
      * @param seq       Sequence number
      * @param payload   Complete JSON payload (checksum/package/host/state...)
      * @param index     Index name (wazuh-states-inventory-packages/system/hotfixes)
@@ -730,7 +685,8 @@ public:
 
         Wazuh::SyncSchema::DataValueBuilder dataBuilder(builder);
         // TODO(#38117): session field removed from agent FlatBuffer schema
-        dataBuilder.add_seq(seq);
+        // TODO(#38117): seq field removed from agent FlatBuffer schema
+        (void)seq;
         dataBuilder.add_operation(operation);
         dataBuilder.add_index(indexStr);
         dataBuilder.add_id(idStr);
@@ -747,7 +703,7 @@ public:
     /**
      * @brief Build DataContext message from payload JSON.
      *
-     * @param session   Session ID from StartAck
+     * @param session   Unused (session field removed from FlatBuffer schema)
      * @param seq       Sequence number
      * @param payload   Complete JSON payload
      * @param index     Index name
@@ -766,7 +722,8 @@ public:
 
         Wazuh::SyncSchema::DataContextBuilder dataBuilder(builder);
         // TODO(#38117): session field removed from agent FlatBuffer schema
-        dataBuilder.add_seq(seq);
+        // TODO(#38117): seq field removed from agent FlatBuffer schema
+        (void)seq;
         dataBuilder.add_index(indexStr);
         dataBuilder.add_id(idStr);
         dataBuilder.add_data(dataVec);
@@ -841,19 +798,14 @@ void sendEvent(bool verbose,
                RouterProvider& routerProvider,
                FakeReportServer& fakeReportServer,
                uint64_t& sessionId,
-               std::promise<void>& startAckPromise,
                std::promise<void>& endAckPromise,
-               std::atomic<bool>& receivedStartAck,
                std::atomic<bool>& receivedEndAck)
 {
-    // Reset promises for new iteration
-    startAckPromise = std::promise<void>();
+    // Reset promise for new iteration
     endAckPromise = std::promise<void>();
-    receivedStartAck = false;
     receivedEndAck = false;
     sessionId = 0;
 
-    auto startAckFuture = startAckPromise.get_future();
     auto endAckFuture = endAckPromise.get_future();
 
     // Load test data
@@ -898,10 +850,8 @@ void sendEvent(bool verbose,
     auto startMsg = MessageBuilder::buildStart(testData.start, totalMessages, indices);
     routerProvider.send(std::vector<char>(startMsg.begin(), startMsg.end()));
 
-    if (startAckFuture.wait_for(std::chrono::seconds(10)) == std::future_status::timeout)
-    {
-        throw std::runtime_error("Timeout waiting for StartAck");
-    }
+    // TODO(#38117): StartAck removed from FlatBuffer schema/agent side - the manager no longer
+    // acknowledges Start at all, so proceed directly to sending data messages.
 
     // Send DataValue messages
     uint64_t seq = 0;
@@ -1071,18 +1021,10 @@ int main(int argc, char* argv[])
         fakeReportServer.start();
 
         uint64_t sessionId = 0;
-        std::promise<void> startAckPromise;
         std::promise<void> endAckPromise;
-        std::atomic<bool> receivedStartAck {false};
         std::atomic<bool> receivedEndAck {false};
 
-        ResponseServer responseServer(DEFAULT_ARQUEUE,
-                                      sessionId,
-                                      startAckPromise,
-                                      endAckPromise,
-                                      receivedStartAck,
-                                      receivedEndAck,
-                                      config.verbose);
+        ResponseServer responseServer(DEFAULT_ARQUEUE, endAckPromise, receivedEndAck, config.verbose);
         responseServer.start();
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
@@ -1100,9 +1042,7 @@ int main(int argc, char* argv[])
                               routerProvider,
                               fakeReportServer,
                               sessionId,
-                              startAckPromise,
                               endAckPromise,
-                              receivedStartAck,
                               receivedEndAck);
                 }
             }
@@ -1116,9 +1056,7 @@ int main(int argc, char* argv[])
                       routerProvider,
                       fakeReportServer,
                       sessionId,
-                      startAckPromise,
                       endAckPromise,
-                      receivedStartAck,
                       receivedEndAck);
         }
 

--- a/src/wazuh_modules/inventory_sync/testtool/main.cpp
+++ b/src/wazuh_modules/inventory_sync/testtool/main.cpp
@@ -86,13 +86,12 @@ struct AgentTestData
      *     "osversion": "22.04",
      *     "groups": ["default", "extra-group"],
      *
-     *     // Optional; if omitted, indices and size are computed automatically
+     *     // Optional; if omitted, indices are computed automatically
      *     "indices": [
      *       "wazuh-states-inventory-packages",
      *       "wazuh-states-inventory-system",
      *       "wazuh-states-inventory-hotfixes"
-     *     ],
-     *     "size": 5
+     *     ]
      *   },
      *   "data_values": [
      *     {
@@ -527,11 +526,10 @@ public:
      * @brief Build Start message from JSON description.
      *
      * @param startJson   "Start" object from the input file.
-     * @param defaultSize Number of messages (data_values + data_context) if size is not set in JSON.
      * @param defaultIndices Indices inferred from data_values/data_context if not set in JSON.
      */
-    static std::vector<uint8_t>
-    buildStart(const nlohmann::json& startJson, uint64_t defaultSize, const std::vector<std::string>& defaultIndices)
+    static std::vector<uint8_t> buildStart(const nlohmann::json& startJson,
+                                           const std::vector<std::string>& defaultIndices)
     {
         flatbuffers::FlatBufferBuilder builder;
 
@@ -553,8 +551,6 @@ public:
 
         std::string optionStr = startJson.value("option", std::string("VDSync"));
         auto option = parseOption(optionStr);
-
-        uint64_t size = startJson.value("size", defaultSize);
 
         // Indices: either provided in Start or inferred from messages
         std::vector<std::string> indices;
@@ -611,7 +607,6 @@ public:
         Wazuh::SyncSchema::StartBuilder startBuilder(builder);
         startBuilder.add_module_(module);
         startBuilder.add_mode(mode);
-        startBuilder.add_size(size);
         startBuilder.add_index(indicesOffset);
         startBuilder.add_option(option);
         startBuilder.add_agentid(agentIdStr);
@@ -799,7 +794,7 @@ void sendEvent(bool verbose,
 
     // Send START
     std::cout << "[SEND] Start message" << std::endl;
-    auto startMsg = MessageBuilder::buildStart(testData.start, totalMessages, indices);
+    auto startMsg = MessageBuilder::buildStart(testData.start, indices);
     routerProvider.send(std::vector<char>(startMsg.begin(), startMsg.end()));
 
     // TODO(#38117): StartAck removed from FlatBuffer schema/agent side - the manager no longer

--- a/src/wazuh_modules/sca/include/sca.h
+++ b/src/wazuh_modules/sca/include/sca.h
@@ -61,7 +61,7 @@ EXPORTED void sca_set_log_function(log_callback_t log_callback);
 
 EXPORTED void sca_set_push_functions(push_stateless_func stateless_func, push_stateful_func stateful_func);
 
-EXPORTED void sca_set_sync_parameters(const char* module_name, const char* sync_db_path, unsigned int timeout, unsigned int retries, unsigned int integrity_interval);
+EXPORTED void sca_set_sync_parameters(const char* module_name, const char* sync_db_path, unsigned int integrity_interval);
 
 // Sync protocol C wrapper functions
 EXPORTED bool sca_sync_module(Mode_t mode);
@@ -95,7 +95,7 @@ typedef void (*sca_set_log_function_func)(log_callback_t log_callback);
 
 typedef void (*sca_set_push_functions_func)(push_stateless_func stateless_func, push_stateful_func stateful_func);
 
-typedef void (*sca_set_sync_parameters_func)(const char* module_name, const char* sync_db_path, unsigned int timeout, unsigned int retries, unsigned int integrity_interval);
+typedef void (*sca_set_sync_parameters_func)(const char* module_name, const char* sync_db_path, unsigned int integrity_interval);
 
 // Sync protocol C wrapper functions
 typedef bool(*sca_sync_module_func)(Mode_t mode);

--- a/src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp
+++ b/src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp
@@ -100,7 +100,7 @@ class SecurityConfigurationAssessment
         /// @param timeout Timeout for synchronization responses
         /// @param retries Number of retries for synchronization
         /// @param integrityInterval Interval in seconds between integrity checks (0 = disabled)
-        void initSyncProtocol(const std::string& moduleName, const std::string& syncDbPath, std::chrono::seconds timeout, unsigned int retries,
+        void initSyncProtocol(const std::string& moduleName, const std::string& syncDbPath,
                               std::chrono::seconds integrityInterval);
 
         /// @brief Synchronize the module

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -475,7 +475,7 @@ std::string SecurityConfigurationAssessment::calculateSyncedChecksChecksum()
 
 // Sync protocol methods implementation
 void SecurityConfigurationAssessment::initSyncProtocol(const std::string& moduleName, const std::string& syncDbPath,
-                                                       std::chrono::seconds timeout, unsigned int retries, std::chrono::seconds integrityInterval)
+                                                       std::chrono::seconds integrityInterval)
 {
     auto logger_func = [](modules_log_level_t level, const std::string & msg)
     {
@@ -488,7 +488,7 @@ void SecurityConfigurationAssessment::initSyncProtocol(const std::string& module
             // Publish under the exclusive lock: wcom queries can arrive while the module
             // is still starting up, and they read the pointer under the shared lock.
             std::unique_lock<std::shared_mutex> lock(m_resourcesMutex);
-            m_spSyncProtocol = std::make_shared<AgentSyncProtocol>(moduleName, syncDbPath, logger_func, timeout, retries);
+            m_spSyncProtocol = std::make_shared<AgentSyncProtocol>(moduleName, syncDbPath, logger_func);
         }
         LoggingHelper::getInstance().log(LOG_DEBUG, "SCA sync protocol initialized successfully with database: " + syncDbPath);
 

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -1244,7 +1244,16 @@ SyncModuleResult SecurityConfigurationAssessment::synchronizeDatabaseSnapshot(bo
             LOG_DEBUG,
             "Retrieved " + std::to_string(checks.size()) + " synced checks from database for SCA " + syncReason);
 
-        m_spSyncProtocol->clearInMemoryData();
+        // Clear the manager's index before resending: a full-replace sync is now a
+        // DataClean followed by a DELTA sync of the fresh snapshot, never Mode::FULL (which
+        // used to make the manager unconditionally deleteByQuery over a byte-capped/truncated
+        // payload and could permanently drop whatever didn't fit in that one session).
+        if (!m_spSyncProtocol->notifyDataClean({SCA_SYNC_INDEX}))
+        {
+            LoggingHelper::getInstance().log(
+                LOG_WARNING, "Failed to clear SCA index before " + syncReason + "; will retry later");
+            return {false, {}};
+        }
 
         for (const auto& check : checks)
         {
@@ -1312,7 +1321,7 @@ SyncModuleResult SecurityConfigurationAssessment::synchronizeDatabaseSnapshot(bo
                 const std::vector<unsigned char> hashResult = hash.hash();
                 std::string hashedId = Utils::asciiToHex(hashResult);
 
-                m_spSyncProtocol->persistDifferenceInMemory(
+                m_spSyncProtocol->persistDifference(
                     hashedId,
                     Operation::CREATE,
                     SCA_SYNC_INDEX,
@@ -1325,7 +1334,7 @@ SyncModuleResult SecurityConfigurationAssessment::synchronizeDatabaseSnapshot(bo
         }
 
         LoggingHelper::getInstance().log(LOG_DEBUG, "Triggering full synchronization for SCA " + syncReason);
-        SyncModuleResult result = m_spSyncProtocol->synchronizeModule(Mode::FULL);
+        SyncModuleResult result = m_spSyncProtocol->synchronizeModule(Mode::DELTA);
 
         if (result.success)
         {

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_recovery_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_recovery_test.cpp
@@ -93,7 +93,7 @@ class SCARecoveryTest : public ::testing::Test
             try
             {
                 m_sca->initSyncProtocol("test_module", "test_sync.db",
-                                        std::chrono::seconds(30), 3, integrityInterval);
+                                        integrityInterval);
             }
             catch (const std::exception&)
             {

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp
@@ -598,26 +598,23 @@ TEST_F(ScaTest, SyncModule_PerformsInitialFullSnapshotBeforeFirstSync)
         {"sync", 1}
     });
 
-    EXPECT_CALL(*mockSyncProtocol, clearInMemoryData())
-    .Times(1);
-    EXPECT_CALL(*mockSyncProtocol, persistDifferenceInMemory(testing::_, Operation::CREATE, SCA_SYNC_INDEX, testing::_, 7))
+    EXPECT_CALL(*mockSyncProtocol, notifyDataClean(testing::_, Option::SYNC))
+    .WillOnce(testing::Return(true));
+    EXPECT_CALL(*mockSyncProtocol, persistDifference(testing::_, Operation::CREATE, SCA_SYNC_INDEX, testing::_, 7, false))
     .WillOnce(testing::Invoke([](const std::string&,
                                  Operation,
                                  const std::string&,
                                  const std::string & data,
-                                 uint64_t)
+                                 uint64_t,
+                                 bool)
     {
         const auto payload = nlohmann::json::parse(data);
         EXPECT_EQ(payload["check"]["id"], "check-1");
         EXPECT_EQ(payload["check"]["result"], "Not applicable");
         EXPECT_EQ(payload["policy"]["id"], "policy-1");
     }));
-    EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::FULL, Option::SYNC))
-    .WillOnce(testing::Return(SyncModuleResult{true}));
     EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
-    .Times(0);
-    EXPECT_CALL(*mockSyncProtocol, persistDifference(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
-    .Times(0);
+    .WillOnce(testing::Return(SyncModuleResult{true}));
 
     EXPECT_TRUE(scaMock.syncModule(Mode::DELTA));
 
@@ -646,11 +643,11 @@ TEST_F(ScaTest, SyncModule_UsesDeltaAfterFirstSyncCompleted)
 
     EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::DELTA, Option::SYNC))
     .WillOnce(testing::Return(SyncModuleResult{true}));
-    EXPECT_CALL(*mockSyncProtocol, synchronizeModule(Mode::FULL, Option::SYNC))
+    // After the first sync, periodic syncs call synchronizeModule() directly and never go
+    // through the snapshot-rebuild path (notifyDataClean + persistDifference per item).
+    EXPECT_CALL(*mockSyncProtocol, notifyDataClean(testing::_, testing::_))
     .Times(0);
-    EXPECT_CALL(*mockSyncProtocol, clearInMemoryData())
-    .Times(0);
-    EXPECT_CALL(*mockSyncProtocol, persistDifferenceInMemory(testing::_, testing::_, testing::_, testing::_, testing::_))
+    EXPECT_CALL(*mockSyncProtocol, persistDifference(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
     .Times(0);
 
     EXPECT_TRUE(scaMock.syncModule(Mode::DELTA));

--- a/src/wazuh_modules/sca/src/sca.cpp
+++ b/src/wazuh_modules/sca/src/sca.cpp
@@ -425,16 +425,18 @@ std::string SCA::query(const std::string& jsonQuery)
 /// @brief C-style wrapper for SCA module synchronization.
 ///
 /// Provides a C-compatible interface for triggering database synchronization
-/// of the SCA module with configurable parameters.
+/// of the SCA module.
 ///
-/// @param mode Synchronization mode (MODE_FULL or MODE_DELTA)
+/// @param mode Synchronization mode (only MODE_DELTA is meaningful here; a full
+///        replace is now a DataClean + DELTA sequence handled internally by
+///        performRecovery(), not by this entry point).
 /// @return true if synchronization succeeds, false otherwise
 bool sca_sync_module(Mode_t mode)
 {
-    Mode syncMode = (mode == MODE_FULL) ? Mode::FULL : Mode::DELTA;
+    (void)mode;
     // The C++ syncModule() already logs a WARNING with the failure reason before returning.
     // The C caller only needs the bool to track sync state (e.g. first_sync_completed).
-    return SCA::instance().syncModule(syncMode);
+    return SCA::instance().syncModule(Mode::DELTA);
 }
 
 /// @brief C-style wrapper for persisting SCA differences.

--- a/src/wazuh_modules/sca/src/sca.cpp
+++ b/src/wazuh_modules/sca/src/sca.cpp
@@ -25,8 +25,6 @@ static yaml_to_cjson_func g_yaml_to_cjson_func = NULL;
 
 static const char* g_module_name = NULL;
 static const char* g_sync_db_path = NULL;
-static unsigned int g_sync_timeout = 30;
-static unsigned int g_sync_retries = 3;
 static unsigned int g_integrity_interval = 86400;
 
 /// @brief Sets the message pushing functions for SCA module.
@@ -52,13 +50,10 @@ void sca_set_push_functions(push_stateless_func stateless_func, push_stateful_fu
 /// @param timeout Default timeout for synchronization operations in seconds
 /// @param retries Default number of retries for synchronization operations
 /// @param integrity_interval Interval in seconds between integrity checks (0 = disabled)
-void sca_set_sync_parameters(const char* module_name, const char* sync_db_path, unsigned int timeout, unsigned int retries, unsigned int integrity_interval)
+void sca_set_sync_parameters(const char* module_name, const char* sync_db_path, unsigned int integrity_interval)
 {
     g_module_name = module_name;
     g_sync_db_path = sync_db_path;
-
-    g_sync_timeout = timeout;
-    g_sync_retries = retries;
     g_integrity_interval = integrity_interval;
 }
 
@@ -237,7 +232,7 @@ void SCA::init()
         {
             m_sca = std::make_unique<SecurityConfigurationAssessment>(SCA_DB_DISK_PATH);
 
-            m_sca->initSyncProtocol(g_module_name, g_sync_db_path, std::chrono::seconds(g_sync_timeout), g_sync_retries,
+            m_sca->initSyncProtocol(g_module_name, g_sync_db_path,
                                     std::chrono::seconds(g_integrity_interval));
 
             auto persistStatefulMessage = [](const std::string & id, Operation_t operation, const std::string & index, const std::string & message, uint64_t version) -> int

--- a/src/wazuh_modules/src/wm_sca.c
+++ b/src/wazuh_modules/src/wm_sca.c
@@ -60,7 +60,6 @@ static atomic_int_t g_n_msg_sent = ATOMIC_INT_INITIALIZER(0);
 // SCA sync protocol variables
 unsigned int sca_enable_synchronization = 1;     // Database synchronization enabled (default value)
 uint32_t sca_sync_interval = 300;                // Database synchronization interval (default value)
-uint32_t sca_sync_response_timeout = 60;         // Database synchronization response timeout (default value)
 uint32_t sca_integrity_interval = 86400;         // Integrity check interval in seconds (default value, 0 = disabled)
 
 // Forward declarations
@@ -455,7 +454,7 @@ static void wm_handle_sca_disable_and_notify_data_clean()
         // Set the sync protocol parameters
         if (sca_set_sync_parameters_ptr)
         {
-            sca_set_sync_parameters_ptr(SCA_WM_NAME, SCA_SYNC_PROTOCOL_DB_PATH, sca_sync_response_timeout, SCA_SYNC_RETRIES, sca_integrity_interval);
+            sca_set_sync_parameters_ptr(SCA_WM_NAME, SCA_SYNC_PROTOCOL_DB_PATH, sca_integrity_interval);
         }
 
         sca_init_ptr = so_get_function_sym(sca_module, "sca_init");
@@ -565,13 +564,12 @@ void * wm_sca_main(wm_sca_t * data) {
         sca_enable_synchronization = data->sync.enable_synchronization;
         if (sca_enable_synchronization) {
             sca_sync_interval = data->sync.sync_interval;
-            sca_sync_response_timeout = data->sync.sync_response_timeout;
             sca_integrity_interval = data->sync.integrity_interval;
         }
 
         // Set the sync protocol parameters
         if (sca_set_sync_parameters_ptr) {
-            sca_set_sync_parameters_ptr(SCA_WM_NAME, SCA_SYNC_PROTOCOL_DB_PATH, sca_sync_response_timeout, SCA_SYNC_RETRIES, sca_integrity_interval);
+            sca_set_sync_parameters_ptr(SCA_WM_NAME, SCA_SYNC_PROTOCOL_DB_PATH, sca_integrity_interval);
         }
 
         // Set the yaml to cjson function
@@ -813,8 +811,6 @@ cJSON *wm_sca_dump(const wm_sca_t * data) {
     cJSON_AddNumberToObject(synchronization, "sync_end_delay", data->sync.sync_end_delay);
     cJSON_AddNumberToObject(synchronization, "interval", data->sync.sync_interval);
     cJSON_AddNumberToObject(synchronization, "max_eps", data->sync.sync_max_eps);
-    cJSON_AddNumberToObject(synchronization, "response_timeout", data->sync.sync_response_timeout);
-
     cJSON_AddItemToObject(wm_wd, "synchronization", synchronization);
 
     cJSON_AddItemToObject(root,"sca",wm_wd);

--- a/src/wazuh_modules/src/wm_sca.h
+++ b/src/wazuh_modules/src/wm_sca.h
@@ -30,7 +30,6 @@ typedef struct wm_sca_db_sync_flags_t {
     unsigned int enable_synchronization:1;  // Enable database synchronization
     uint32_t sync_interval;                 // Synchronization interval
     uint32_t sync_end_delay;                // Delay for synchronization end message
-    uint32_t sync_response_timeout;         // Minimum interval for the synchronization process
     long sync_max_eps;                      // Maximum events per second for synchronization messages.
     uint32_t integrity_interval;            // Integrity check interval (0 = disabled)
 } wm_sca_db_sync_flags_t;

--- a/src/wazuh_modules/src/wm_syscollector.c
+++ b/src/wazuh_modules/src/wm_syscollector.c
@@ -120,7 +120,6 @@ syscollector_set_agentd_query_func_ptr syscollector_set_agentd_query_func_setter
 
 unsigned int enable_synchronization = 1;     // Database synchronization enabled (default value)
 uint32_t sync_interval = 300;                // Database synchronization interval (default value)
-uint32_t sync_response_timeout = 30;         // Database synchronization response timeout (default value)
 uint32_t integrity_interval = 86400;         // Integrity check interval in seconds (default value)
 
 long syscollector_max_eps = 50;          // Number of events per second (default value)
@@ -493,7 +492,7 @@ static void wm_handle_sys_disabled_and_notify_data_clean(wm_sys_t* sys)
                               sys->flags.browser_extensions,
                               sys->flags.notify_first_scan);
 
-        syscollector_init_sync_ptr(WM_SYS_LOCATION, SYS_SYNC_PROTOCOL_DB_PATH, SYS_SYNC_PROTOCOL_VD_DB_PATH, sync_response_timeout, SYS_SYNC_RETRIES,
+        syscollector_init_sync_ptr(WM_SYS_LOCATION, SYS_SYNC_PROTOCOL_DB_PATH, SYS_SYNC_PROTOCOL_VD_DB_PATH,
                                    integrity_interval);
 
         if (syscollector_notify_data_clean_ptr && syscollector_delete_database_ptr)
@@ -637,7 +636,6 @@ void* wm_sys_main(wm_sys_t* sys)
         if (enable_synchronization)
         {
             sync_interval = sys->sync.sync_interval;
-            sync_response_timeout = sys->sync.sync_response_timeout;
             integrity_interval = sys->sync.integrity_interval;
         }
 
@@ -686,7 +684,7 @@ void* wm_sys_main(wm_sys_t* sys)
         // Initialize sync protocol AFTER init (so logger is available)
         if (enable_synchronization && syscollector_init_sync_ptr && syscollector_sync_module_ptr)
         {
-            syscollector_init_sync_ptr(WM_SYS_LOCATION, SYS_SYNC_PROTOCOL_DB_PATH, SYS_SYNC_PROTOCOL_VD_DB_PATH, sync_response_timeout, SYS_SYNC_RETRIES,
+            syscollector_init_sync_ptr(WM_SYS_LOCATION, SYS_SYNC_PROTOCOL_DB_PATH, SYS_SYNC_PROTOCOL_VD_DB_PATH,
                                        integrity_interval);
 #ifndef WIN32
             // Launch inventory synchronization thread as joinable so we can wait for it
@@ -894,7 +892,6 @@ cJSON* wm_sys_dump(const wm_sys_t* sys)
     cJSON_AddStringToObject(synchronization, "enabled", sys->sync.enable_synchronization ? "yes" : "no");
     cJSON_AddNumberToObject(synchronization, "interval", sys->sync.sync_interval);
     cJSON_AddNumberToObject(synchronization, "max_eps", sys->sync.sync_max_eps);
-    cJSON_AddNumberToObject(synchronization, "response_timeout", sys->sync.sync_response_timeout);
     cJSON_AddNumberToObject(synchronization, "sync_end_delay", sys->sync.sync_end_delay);
     cJSON_AddNumberToObject(synchronization, "integrity_interval", sys->sync.integrity_interval);
 

--- a/src/wazuh_modules/src/wm_syscollector.h
+++ b/src/wazuh_modules/src/wm_syscollector.h
@@ -47,7 +47,6 @@ typedef struct wm_sys_db_sync_flags_t {
     unsigned int enable_synchronization:1;  // Enable database synchronization
     uint32_t sync_interval;                 // Synchronization interval
     uint32_t sync_end_delay;                // Delay for synchronization end message
-    uint32_t sync_response_timeout;         // Minimum interval for the synchronization process
     long sync_max_eps;                      // Maximum events per second for synchronization messages.
     uint32_t integrity_interval;            // Integrity check interval (0 = disabled)
 } wm_sys_db_sync_flags_t;

--- a/src/wazuh_modules/syscollector/include/syscollector.h
+++ b/src/wazuh_modules/syscollector/include/syscollector.h
@@ -83,8 +83,8 @@ EXPORTED void syscollector_release_resources();
 EXPORTED void syscollector_start();
 
 // Sync protocol C wrapper functions
-EXPORTED void syscollector_init_sync(const char* moduleName, const char* syncDbPath, const char* syncDbPathVD, unsigned int timeout,
-                                     unsigned int retries, uint32_t integrityInterval);
+EXPORTED void syscollector_init_sync(const char* moduleName, const char* syncDbPath, const char* syncDbPathVD,
+                                     uint32_t integrityInterval);
 EXPORTED bool syscollector_sync_module(Mode_t mode);
 EXPORTED void syscollector_persist_diff(const char* id, Operation_t operation, const char* index, const char* data, uint64_t version);
 EXPORTED bool syscollector_parse_response(const unsigned char* data, size_t length);
@@ -142,8 +142,8 @@ typedef void(*syscollector_stop_func)();
 typedef void(*syscollector_release_resources_func)();
 
 // Sync protocol C wrapper functions
-typedef void(*syscollector_init_sync_func)(const char* moduleName, const char* syncDbPath, const char* syncDbPathVD, unsigned int timeout,
-                                           unsigned int retries, uint32_t integrityInterval);
+typedef void(*syscollector_init_sync_func)(const char* moduleName, const char* syncDbPath, const char* syncDbPathVD,
+                                           uint32_t integrityInterval);
 typedef bool(*syscollector_sync_module_func)(Mode_t mode);
 typedef void(*syscollector_persist_diff_func)(const char* id, Operation_t operation, const char* index, const char* data, uint64_t version);
 typedef bool(*syscollector_parse_response_func)(const unsigned char* data, size_t length);

--- a/src/wazuh_modules/syscollector/include/syscollector.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector.hpp
@@ -92,7 +92,7 @@ class EXPORTED Syscollector final
 
         // Sync protocol methods
         void initSyncProtocol(const std::string& moduleName, const std::string& syncDbPath, const std::string& syncDbPathVD,
-                              std::chrono::seconds timeout, unsigned int retries, uint32_t integrityInterval);
+                              uint32_t integrityInterval);
         SyncModuleResult syncModule(Mode mode);
         void persistDifference(const std::string& id, Operation operation, const std::string& index, const std::string& data, uint64_t version, bool isDataContext = false);
         bool parseResponseBuffer(const uint8_t* data, size_t length);

--- a/src/wazuh_modules/syscollector/src/syscollector.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollector.cpp
@@ -144,15 +144,15 @@ void syscollector_release_resources()
     Syscollector::instance().releaseResources();
 }
 
-void syscollector_init_sync(const char* moduleName, const char* syncDbPath, const char* syncDbPathVD, unsigned int timeout,
-                            unsigned int retries, uint32_t integrityInterval)
+void syscollector_init_sync(const char* moduleName, const char* syncDbPath, const char* syncDbPathVD,
+                            uint32_t integrityInterval)
 {
     if (moduleName && syncDbPath && syncDbPathVD)
     {
         try
         {
-            Syscollector::instance().initSyncProtocol(std::string(moduleName), std::string(syncDbPath), std::string(syncDbPathVD), std::chrono::seconds(timeout),
-                                                      retries, integrityInterval);
+            Syscollector::instance().initSyncProtocol(std::string(moduleName), std::string(syncDbPath), std::string(syncDbPathVD),
+                                                      integrityInterval);
         }
         catch (const std::exception& ex)
         {

--- a/src/wazuh_modules/syscollector/src/syscollector.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollector.cpp
@@ -169,10 +169,12 @@ void syscollector_init_sync(const char* moduleName, const char* syncDbPath, cons
 
 bool syscollector_sync_module(Mode_t mode)
 {
-    Mode syncMode = (mode == MODE_FULL) ? Mode::FULL : Mode::DELTA;
+    (void)mode;
     // Syscollector::syncModule() already logs a WARNING with the failure reason before returning.
     // The C caller only needs the bool to track sync state (e.g. first_sync_completed).
-    return Syscollector::instance().syncModule(syncMode).success;
+    // Only MODE_DELTA is meaningful here: a full replace is now a DataClean + DELTA
+    // sequence handled internally by the recovery path, not by this entry point.
+    return Syscollector::instance().syncModule(Mode::DELTA).success;
 }
 
 void syscollector_persist_diff(const char* id, Operation_t operation, const char* index, const char* data, uint64_t version)

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -4699,7 +4699,16 @@ void Syscollector::runRecoveryProcess()
                     return;
                 }
 
-                m_spSyncProtocol->clearInMemoryData();
+                // Clear the manager's index before resending: a full-replace sync is now a
+                // DataClean followed by a DELTA sync of the fresh snapshot, never Mode::FULL
+                // (which used to make the manager unconditionally deleteByQuery over a
+                // byte-capped/truncated payload and could permanently drop whatever didn't
+                // fit in that one session).
+                if (!m_spSyncProtocol->notifyDataClean({index}))
+                {
+                    m_logFunction(LOG_WARNING, "Failed to clear index " + index + " before recovery resync for table " + tableName + "; will retry later");
+                    return;
+                }
 
                 for (const auto& item : items)
                 {
@@ -4722,7 +4731,7 @@ void Syscollector::runRecoveryProcess()
 
                     if (shouldPersist)
                     {
-                        m_spSyncProtocol->persistDifferenceInMemory(
+                        m_spSyncProtocol->persistDifference(
                             calculateHashId(item, tableName),
                             Operation::CREATE,
                             index,
@@ -4732,9 +4741,9 @@ void Syscollector::runRecoveryProcess()
                     }
                 }
 
-                m_logFunction(LOG_DEBUG, "Persisted " + std::to_string(items.size()) + " recovery items in memory");
+                m_logFunction(LOG_DEBUG, "Persisted " + std::to_string(items.size()) + " recovery items");
                 m_logFunction(LOG_DEBUG, "Starting recovery synchronization...");
-                bool recoverySucceeded = syncModule(Mode::FULL).success;
+                bool recoverySucceeded = syncModule(Mode::DELTA).success;
 
                 if (recoverySucceeded)
                 {

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -2247,9 +2247,9 @@ void Syscollector::setJsonFieldArray(nlohmann::json& target,
 
 // Sync protocol methods implementation
 void Syscollector::initSyncProtocol(const std::string& moduleName, const std::string& syncDbPath, const std::string& syncDbPathVD,
-                                    std::chrono::seconds timeout, unsigned int retries, uint32_t integrityInterval)
+                                    uint32_t integrityInterval)
 {
-    m_dataCleanRetries = retries;  // Same as sync retries for data clean notifications
+    m_dataCleanRetries = 3;  // Fixed default; the transport handles HTTP-level retries.
     m_integrityIntervalValue = integrityInterval;
 
     auto logger_func = [this](modules_log_level_t level, const std::string & msg)
@@ -2265,12 +2265,12 @@ void Syscollector::initSyncProtocol(const std::string& moduleName, const std::st
     try
     {
         // Initialize regular sync protocol
-        m_spSyncProtocol = std::make_unique<AgentSyncProtocol>(moduleName, syncDbPath, logger_func, timeout, retries);
+        m_spSyncProtocol = std::make_unique<AgentSyncProtocol>(moduleName, syncDbPath, logger_func);
         m_logFunction(LOG_DEBUG, "Syscollector sync protocol initialized successfully with database: " + syncDbPath);
 
         // Initialize VD sync protocol with different module name to avoid routing conflicts
         std::string vdModuleName = moduleName + "_vd";
-        m_spSyncProtocolVD = std::make_unique<AgentSyncProtocol>(vdModuleName, syncDbPathVD, logger_func_vd, timeout, retries);
+        m_spSyncProtocolVD = std::make_unique<AgentSyncProtocol>(vdModuleName, syncDbPathVD, logger_func_vd);
         m_logFunction(LOG_DEBUG, "Syscollector VD sync protocol initialized successfully with database: " + syncDbPathVD + " and module name: " + vdModuleName);
 
         // Initialize schema validator factory from embedded resources

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -2805,12 +2805,7 @@ TEST_F(SyscollectorImpTest, queryCommandFlushReportsCompletedError)
                                   3600, false, false, false, false, false, false,
                                   false, false, false, false, false, false, false, false);
 
-    Syscollector::instance().initSyncProtocol("syscollector",
-                                              ":memory:",
-                                              ":memory:",
-                                              std::chrono::seconds(1),
-                                              1,
-                                              0);
+    Syscollector::instance().initSyncProtocol("syscollector", ":memory:", ":memory:", 0);
 
     // No sync intake socket is available in the test environment, so the flush
     // synchronization fails and the query must report completed with error.
@@ -3510,14 +3505,8 @@ TEST_F(SyscollectorImpTest, initSyncProtocol_AllModulesEnabled)
     // Test initSyncProtocol - should not throw
     EXPECT_NO_THROW(
     {
-        Syscollector::instance().initSyncProtocol(
-            "syscollector",
-            ":memory:",
-            ":memory:",
-            std::chrono::seconds(5),
-            3,
-            86400
-        );
+        Syscollector::instance().initSyncProtocol("syscollector", ":memory:", ":memory:", 86400
+                                                 );
     });
 
     Syscollector::instance().destroy();
@@ -3561,14 +3550,8 @@ TEST_F(SyscollectorImpTest, initSyncProtocol_PackagesDisabled)
     // Test initSyncProtocol - should not throw
     EXPECT_NO_THROW(
     {
-        Syscollector::instance().initSyncProtocol(
-            "syscollector",
-            ":memory:",
-            ":memory:",
-            std::chrono::seconds(5),
-            3,
-            86400
-        );
+        Syscollector::instance().initSyncProtocol("syscollector", ":memory:", ":memory:", 86400
+                                                 );
     });
 
     Syscollector::instance().destroy();
@@ -3612,14 +3595,8 @@ TEST_F(SyscollectorImpTest, initSyncProtocol_OsDisabled)
     // Test initSyncProtocol - should not throw
     EXPECT_NO_THROW(
     {
-        Syscollector::instance().initSyncProtocol(
-            "syscollector",
-            ":memory:",
-            ":memory:",
-            std::chrono::seconds(5),
-            3,
-            86400
-        );
+        Syscollector::instance().initSyncProtocol("syscollector", ":memory:", ":memory:", 86400
+                                                 );
     });
 
     Syscollector::instance().destroy();
@@ -3663,14 +3640,9 @@ TEST_F(SyscollectorImpTest, initSyncProtocol_DifferentParameters)
     // Test with different parameter values
     EXPECT_NO_THROW(
     {
-        Syscollector::instance().initSyncProtocol(
-            "syscollector",
-            ":memory:",
-            ":memory:",
-            std::chrono::seconds(15),  // Different timeout
-            5,                          // Different retries
-            86400
-        );
+        Syscollector::instance().initSyncProtocol("syscollector", ":memory:", ":memory:", // Different retries
+                                                  86400
+                                                 );
     });
 
     Syscollector::instance().destroy();
@@ -4145,14 +4117,8 @@ TEST_F(SyscollectorImpTest, initSyncProtocolWithIntegrityInterval)
 
     // Initialize sync protocol with integrity interval
     EXPECT_NO_THROW(
-        Syscollector::instance().initSyncProtocol(
-            "syscollector",
-            ":memory:",
-            ":memory:",
-            std::chrono::seconds(30),
-            3,
-            86400  // 24 hours integrity interval
-        )
+        Syscollector::instance().initSyncProtocol("syscollector", ":memory:", ":memory:", 86400  // 24 hours integrity interval
+                                                 )
     );
 
     Syscollector::instance().destroy();
@@ -4191,14 +4157,8 @@ TEST_F(SyscollectorImpTest, runRecoveryProcessWithSyncProtocol)
                                   3600, false, true, false, false, false, false, false, false, false, false, false, false, false, false);
 
     // Initialize sync protocol
-    Syscollector::instance().initSyncProtocol(
-        "syscollector",
-        ":memory:",
-        ":memory:",
-        std::chrono::seconds(30),
-        3,
-        86400
-    );
+    Syscollector::instance().initSyncProtocol("syscollector", ":memory:", ":memory:", 86400
+                                             );
 
     // Run recovery process - should execute without throwing
     EXPECT_NO_THROW(Syscollector::instance().runRecoveryProcess());
@@ -4262,14 +4222,8 @@ TEST_F(SyscollectorImpTest, schemaValidationAcceptsValidDataAfterCorrections)
                                           5, true, true, false, false, false, false, false, false, false, false, false, false, false, false);
 
             // Initialize sync protocol to enable schema validation
-            Syscollector::instance().initSyncProtocol(
-                "syscollector",
-                ":memory:",
-                ":memory:",
-                std::chrono::seconds(5),
-                3,
-                86400
-            );
+            Syscollector::instance().initSyncProtocol("syscollector", ":memory:", ":memory:", 86400
+                                                     );
 
             Syscollector::instance().start();
         }
@@ -4362,14 +4316,8 @@ TEST_F(SyscollectorImpTest, schemaValidationWithCorrectedDataTypes)
                                           5, true, true, false, false, false, true, false, false, false, false, false, false, false, false);
 
             // Initialize sync protocol to enable schema validation
-            Syscollector::instance().initSyncProtocol(
-                "syscollector",
-                ":memory:",
-                ":memory:",
-                std::chrono::seconds(5),
-                3,
-                86400
-            );
+            Syscollector::instance().initSyncProtocol("syscollector", ":memory:", ":memory:", 86400
+                                                     );
 
             Syscollector::instance().start();
         }
@@ -4449,14 +4397,8 @@ TEST_F(SyscollectorImpTest, hardwareCpuSpeedZeroIsReportedAsNull)
                                           5, true, true, false, false, false, false, false, false, false, false, false, false, false, false);
 
             // Initialize sync protocol to enable schema validation
-            Syscollector::instance().initSyncProtocol(
-                "syscollector",
-                ":memory:",
-                ":memory:",
-                std::chrono::seconds(5),
-                3,
-                86400
-            );
+            Syscollector::instance().initSyncProtocol("syscollector", ":memory:", ":memory:", 86400
+                                                     );
 
             Syscollector::instance().start();
         }
@@ -4651,14 +4593,8 @@ TEST_F(SyscollectorImpTest, schemaValidationDiscardsInvalidMtuValueOnWindows)
                                           5, true, false, false, true, false, false, false, false, false, false, false, false, false, false);
 
             // Initialize sync protocol to enable schema validation
-            Syscollector::instance().initSyncProtocol(
-                "syscollector",
-                ":memory:",
-                ":memory:",
-                std::chrono::seconds(5),
-                3,
-                86400
-            );
+            Syscollector::instance().initSyncProtocol("syscollector", ":memory:", ":memory:", 86400
+                                                     );
 
             Syscollector::instance().start();
         }
@@ -4742,14 +4678,8 @@ TEST_F(SyscollectorImpTest, schemaValidationDiscardsInvalidMtuValueOnUnix)
                                           5, true, false, false, true, false, false, false, false, false, false, false, false, false, false);
 
             // Initialize sync protocol to enable schema validation
-            Syscollector::instance().initSyncProtocol(
-                "syscollector",
-                ":memory:",
-                ":memory:",
-                std::chrono::seconds(5),
-                3,
-                86400
-            );
+            Syscollector::instance().initSyncProtocol("syscollector", ":memory:", ":memory:", 86400
+                                                     );
 
             Syscollector::instance().start();
         }
@@ -4852,14 +4782,8 @@ TEST_F(SyscollectorImpTest, schemaValidationRejectsInvalidDataWithMock)
             SchemaValidator::SchemaValidatorFactory::getInstance().initialize(mockValidators);
 
             // Initialize sync protocol
-            Syscollector::instance().initSyncProtocol(
-                "syscollector",
-                ":memory:",
-                ":memory:",
-                std::chrono::seconds(5),
-                3,
-                86400
-            );
+            Syscollector::instance().initSyncProtocol("syscollector", ":memory:", ":memory:", 86400
+                                                     );
 
             Syscollector::instance().start();
         }
@@ -4985,14 +4909,8 @@ TEST_F(SyscollectorImpTest, schemaValidationDiscardsWhenValidatorNotFound)
             SchemaValidator::SchemaValidatorFactory::getInstance().initialize(mockValidators);
 
             // Initialize sync protocol
-            Syscollector::instance().initSyncProtocol(
-                "syscollector",
-                ":memory:",
-                ":memory:",
-                std::chrono::seconds(5),
-                3,
-                86400
-            );
+            Syscollector::instance().initSyncProtocol("syscollector", ":memory:", ":memory:", 86400
+                                                     );
 
             Syscollector::instance().start();
         }

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollector_vd_tests.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollector_vd_tests.cpp
@@ -170,14 +170,8 @@ TEST_F(SyscollectorVDTest, PersistDifference_VDTableRoutesToVDProtocol)
     // Initialize sync protocols
     EXPECT_NO_THROW(
     {
-        Syscollector::instance().initSyncProtocol(
-            "syscollector",
-            ":memory:",
-            ":memory:",
-            std::chrono::seconds(5),
-            3,
-            86400
-        );
+        Syscollector::instance().initSyncProtocol("syscollector", ":memory:", ":memory:", 86400
+                                                 );
     });
 
     // Test routing for VD tables (system, packages, hotfixes)
@@ -253,14 +247,8 @@ TEST_F(SyscollectorVDTest, PersistDifference_NonVDTableRoutesToRegularProtocol)
     // Initialize sync protocols
     EXPECT_NO_THROW(
     {
-        Syscollector::instance().initSyncProtocol(
-            "syscollector",
-            ":memory:",
-            ":memory:",
-            std::chrono::seconds(5),
-            3,
-            86400
-        );
+        Syscollector::instance().initSyncProtocol("syscollector", ":memory:", ":memory:", 86400
+                                                 );
     });
 
     // Test routing for non-VD tables
@@ -393,14 +381,8 @@ TEST_F(SyscollectorVDTest, ParseResponseBuffer_RoutesToRegularProtocol)
     // Initialize sync protocols
     EXPECT_NO_THROW(
     {
-        Syscollector::instance().initSyncProtocol(
-            "syscollector",
-            ":memory:",
-            ":memory:",
-            std::chrono::seconds(5),
-            3,
-            86400
-        );
+        Syscollector::instance().initSyncProtocol("syscollector", ":memory:", ":memory:", 86400
+                                                 );
     });
 
     // Test parseResponseBuffer with sample data
@@ -508,14 +490,8 @@ TEST_F(SyscollectorVDTest, ParseResponseBufferVD_RoutesToVDProtocol)
     // Initialize sync protocols
     EXPECT_NO_THROW(
     {
-        Syscollector::instance().initSyncProtocol(
-            "syscollector",
-            ":memory:",
-            ":memory:",
-            std::chrono::seconds(5),
-            3,
-            86400
-        );
+        Syscollector::instance().initSyncProtocol("syscollector", ":memory:", ":memory:", 86400
+                                                 );
     });
 
     // Test parseResponseBufferVD with sample data

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
@@ -268,7 +268,9 @@ private:
     static Context buildContextFromAgent(const AgentContextData& agent, const OsContextData& osData)
     {
         Context context {};
-        context.mode = Wazuh::SyncSchema::Mode_ModuleFull;
+        // mode is not consumed on this path: this Context is built standalone to reuse its
+        // fields for indexing, not fed through InventorySyncFacade's session queue.
+        context.mode = Wazuh::SyncSchema::Mode_ModuleDelta;
         context.option = Wazuh::SyncSchema::Option_VDSync;
         context.sessionId = 0;
         context.moduleName = "vulnerability-scanner";

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
@@ -180,8 +180,8 @@ public:
      * @brief Blocks until the CVE feed is fully loaded or the scanner is stopped.
      *
      * VDFirst/VDSync session threads call this when the feed is not yet available.
-     * The agent stays in Status_Processing (sent at End-message time) while waiting;
-     * once this returns the caller checks isFeedReady() again before scanning.
+     * The agent simply blocks while waiting; once this returns the caller checks
+     * isFeedReady() again before scanning.
      *
      * Returns immediately if the feed is already ready or if stop() was called.
      * After a 30-minute timeout it logs a warning and returns so the session

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_test.cpp
@@ -145,14 +145,15 @@ std::vector<uint8_t> createDataValueMessage(uint64_t sessionId,
                                             const std::string& jsonData,
                                             Wazuh::SyncSchema::Operation operation)
 {
+    // TODO(#38117): seq/session fields removed from FlatBuffer schema on the agent side.
+    (void)sessionId;
     flatbuffers::FlatBufferBuilder builder;
 
     auto indexOffset = builder.CreateString(index);
     auto idOffset = builder.CreateString(documentId);
     auto dataVector = builder.CreateVector(reinterpret_cast<const int8_t*>(jsonData.data()), jsonData.size());
 
-    auto dataValue =
-        Wazuh::SyncSchema::CreateDataValue(builder, sessionId, operation, indexOffset, idOffset, 0, dataVector);
+    auto dataValue = Wazuh::SyncSchema::CreateDataValue(builder, operation, indexOffset, idOffset, 0, dataVector);
     auto message =
         Wazuh::SyncSchema::CreateMessage(builder, Wazuh::SyncSchema::MessageType_DataValue, dataValue.Union());
 
@@ -169,13 +170,15 @@ std::vector<uint8_t> createDataContextMessage(uint64_t sessionId,
                                               const std::string& documentId,
                                               const std::string& jsonData)
 {
+    // TODO(#38117): seq/session fields removed from FlatBuffer schema on the agent side.
+    (void)sessionId;
     flatbuffers::FlatBufferBuilder builder;
 
     auto indexOffset = builder.CreateString(index);
     auto idOffset = builder.CreateString(documentId);
     auto dataVector = builder.CreateVector(reinterpret_cast<const int8_t*>(jsonData.data()), jsonData.size());
 
-    auto dataContext = Wazuh::SyncSchema::CreateDataContext(builder, sessionId, indexOffset, idOffset, dataVector);
+    auto dataContext = Wazuh::SyncSchema::CreateDataContext(builder, indexOffset, idOffset, dataVector);
     auto message =
         Wazuh::SyncSchema::CreateMessage(builder, Wazuh::SyncSchema::MessageType_DataContext, dataContext.Union());
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_test.cpp
@@ -152,7 +152,7 @@ std::vector<uint8_t> createDataValueMessage(uint64_t sessionId,
     auto dataVector = builder.CreateVector(reinterpret_cast<const int8_t*>(jsonData.data()), jsonData.size());
 
     auto dataValue =
-        Wazuh::SyncSchema::CreateDataValue(builder, sessionId, 0, operation, indexOffset, idOffset, 0, dataVector);
+        Wazuh::SyncSchema::CreateDataValue(builder, sessionId, operation, indexOffset, idOffset, 0, dataVector);
     auto message =
         Wazuh::SyncSchema::CreateMessage(builder, Wazuh::SyncSchema::MessageType_DataValue, dataValue.Union());
 
@@ -175,7 +175,7 @@ std::vector<uint8_t> createDataContextMessage(uint64_t sessionId,
     auto idOffset = builder.CreateString(documentId);
     auto dataVector = builder.CreateVector(reinterpret_cast<const int8_t*>(jsonData.data()), jsonData.size());
 
-    auto dataContext = Wazuh::SyncSchema::CreateDataContext(builder, sessionId, 0, indexOffset, idOffset, dataVector);
+    auto dataContext = Wazuh::SyncSchema::CreateDataContext(builder, sessionId, indexOffset, idOffset, dataVector);
     auto message =
         Wazuh::SyncSchema::CreateMessage(builder, Wazuh::SyncSchema::MessageType_DataContext, dataContext.Union());
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/vulnerabilityScannerFacade_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/vulnerabilityScannerFacade_test.cpp
@@ -42,13 +42,15 @@ void VulnerabilityScannerFacadeTest::TearDown()
 // Helper to create FlatBuffer DataContext message
 std::vector<uint8_t> createTestDataContext(uint64_t sessionId, const std::string& jsonData)
 {
+    // TODO(#38117): seq/session fields removed from FlatBuffer schema on the agent side.
+    (void)sessionId;
     flatbuffers::FlatBufferBuilder builder;
 
     auto indexOffset = builder.CreateString("wazuh-states-inventory-system");
     auto idOffset = builder.CreateString("test001");
     auto dataVector = builder.CreateVector(reinterpret_cast<const int8_t*>(jsonData.data()), jsonData.size());
 
-    auto dataContext = Wazuh::SyncSchema::CreateDataContext(builder, sessionId, indexOffset, idOffset, dataVector);
+    auto dataContext = Wazuh::SyncSchema::CreateDataContext(builder, indexOffset, idOffset, dataVector);
     auto message =
         Wazuh::SyncSchema::CreateMessage(builder, Wazuh::SyncSchema::MessageType_DataContext, dataContext.Union());
 

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/vulnerabilityScannerFacade_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/vulnerabilityScannerFacade_test.cpp
@@ -48,7 +48,7 @@ std::vector<uint8_t> createTestDataContext(uint64_t sessionId, const std::string
     auto idOffset = builder.CreateString("test001");
     auto dataVector = builder.CreateVector(reinterpret_cast<const int8_t*>(jsonData.data()), jsonData.size());
 
-    auto dataContext = Wazuh::SyncSchema::CreateDataContext(builder, sessionId, 0, indexOffset, idOffset, dataVector);
+    auto dataContext = Wazuh::SyncSchema::CreateDataContext(builder, sessionId, indexOffset, idOffset, dataVector);
     auto message =
         Wazuh::SyncSchema::CreateMessage(builder, Wazuh::SyncSchema::MessageType_DataContext, dataContext.Union());
 


### PR DESCRIPTION
## Description

This pull request updates the agent-side stateful synchronization flow to prevent oversized
FullSession payloads, avoid unbounded DELTA cycles, and â€” following agreements reached with the
server team during this PR's development â€” replace the old `End`/`EndAck` FlatBuffer
acknowledgement with a plain HTTP-status-code result contract, add an agent-side
checksum-mismatch retry loop, and drop the now-unused `Start.size` field.

Closes #38117

## Proposed Changes

### Original scope: size-capped DELTA sync

- Refactored DELTA synchronization to run in capped block cycles (`max 10 blocks` per
  `synchronizeModule()` invocation).
- Added queue prefiltering by estimated payload size in `fetchAndMarkForSync(size_t maxBytes)`
  instead of row count limiting.
- Added a grace margin (`5 MiB - 64 KiB`) for non-VD prefilter fetches to reduce repeated
  retries due to estimation mismatch.
- Kept VD flows (`Option::VDFIRST`, `Option::VDSYNC`) uncapped.
- Removed redundant protocol-layer oversize blocking, keeping the root control at queue
  fetch/prefilter level.

### D2 HTTP-result contract (agreed with the server team during development)

The manager no longer answers a `/stateful` session with a FlatBuffer `EndAck` message. It
answers with a single HTTP response, and the agent interprets the raw status code directly in
`AgentSyncProtocol::applyHttpResult()` (bypassing the shared `/stateless`+`/stateful` D9
classifier, since its 409/413/503 meanings are `/stateless`-specific and collide with the new
`/stateful` semantics):

| HTTP code | Meaning | Agent behavior |
|---|---|---|
| 200 | Success | Session complete |
| 409 | Checksum mismatch | See retry logic below |
| 413 | Payload too large | `PAYLOAD_TOO_LARGE`; module retries next cycle (splitting **not yet implemented** â€” known gap, see below) |
| 503 (+ `Retry-After`) | Manager not ready | Handled transparently by `https_client`'s own retry/backoff (`OutcomeClass::BackPressure`), below `agent_sync_protocol` |
| 400/403/500 | Protocol error | Logged, not blindly retried with identical bytes |

`End`/`EndAck`/`Status`/`StartAck`/`DataBatch`/`ReqRet`/`Mode::FULL` were removed from the
FlatBuffer schema (`inventorySync.fbs`) and all dependent agent-side and manager-side code, since
the whole session now crosses in one `FullSession` message instead of a chunked
Startâ†’DataBatch[]â†’End exchange.

### Agent-side checksum-mismatch retry added

The manager retries an integrity check against its indexer up to 5 times internally before
answering 409 (to absorb indexing lag after a bulk write); that manager-side loop is untouched by
this PR. This PR adds the same tolerance on the agent side, so a transient 409 doesn't need a
manager-side retry to avoid a needless full resync:
`AgentSyncProtocol::requiresFullSync()` now retries a 409 up to `CHECKSUM_MISMATCH_MAX_ATTEMPTS`
(5) times, 10 seconds apart, before trusting the mismatch as genuine and requesting a full sync.
Any other failure (communication error, manager offline) still returns immediately without
spending this retry budget.

The two loops are temporarily redundant: the manager's own retry loop
(`wazuh_modules/inventory_sync/src/inventorySyncFacade.hpp`) is scheduled for removal in the
separate manager-side `inventory_sync` refactor PR, once the agent-side retry above is confirmed
sufficient on its own. Removing it here would be out of scope â€” this PR does not touch
manager-side `inventory_sync` behavior.

### `Start.size` removed

Agreed with the server team: `Start.size` was a leftover of the old chunked-`DataBatch` protocol
â€” the agent never read it back, and with the whole session now crossing in one `FullSession`
message, the field is redundant with the payload's own item counts. On the manager side
(`wazuh_modules/inventory_sync/`), the field also fed a `GapSet`-based completeness gate and a
DataValue quota cap â€” but that code path is currently unreachable from live traffic (the real
agent's `FullSession` message isn't dispatched there yet; that rewrite is the server team's own
pending follow-up), so it's shimmed with a caller-supplied `declaredSize` parameter instead of
reading `Start.size` off the wire (`TODO(#38117)`, same pattern as the other schema removals
above).

### Reliability hardening (from a subsequent detailed code review of this PR)

- **Bounded module-side wait for the manager's answer** (`AgentSyncProtocol::runSession()`):
  the HTTPS client fires `on_sync_response` for every outcome within `wazuh-agentd`, but that
  result still crosses the local bridge (`https_client_bridge.c`) and a module-local socket to
  reach the waiting module, and that hop can silently drop it (no route for the session id, a
  full module socket, an ignored `wmcom_send`/`ag_send_syscheck` failure). Without a ceiling, a
  dropped delivery wedged the module's sync state forever â€” `m_syncInProgress` never releases,
  so every subsequent `synchronizeModule()` call short-circuits and logs success while nothing
  actually syncs. Added `SESSION_RESPONSE_TIMEOUT` (15 minutes â€” well above `https_client`'s own
  worst case for one `/stateful` session: 5 attempts Ã— 120s timeout + 4 backoff gaps capped at
  60s, â‰ˆ14 minutes), so a dropped delivery now surfaces as a logged failure and retries next
  cycle instead of hanging indefinitely.
- **Persistently oversized queue item no longer blocks the queue forever**
  (`PersistentQueueStorage::fetchAndMarkForSync()`): a pending item that alone exceeds the byte
  cap is still sent alone (existing behavior, needed so it isn't starved by the cap), but if the
  manager keeps rejecting it (real `413`) it was resent every cycle, blocking every other item
  behind it (`ORDER BY rowid ASC`) with no way out. After `MAX_OVERSIZED_ATTEMPTS` (5)
  consecutive cycles as the lone oversized item, it is now dropped (`LOG_ERROR`) instead of
  resent, freeing the queue.
- **`applyHttpResult()` now accepts the full 2xx range, not just literal `200`**: the
  `/stateful` contract already documents a future `202` (queued-processing endpoint,
  `syncEndpoint.cpp`) as a deliberate accepted-but-not-`200` answer; before this fix that would
  have fallen into the default protocol-error branch.

## Results and Evidence

### Test environment

Real, packaged `wazuh-agent_5.0.0-0_amd64_1f1bb62.deb` â€” built from this PR's own current tip
(commit `ca377231235ff15d234565c7f14bfefd31b35f2d`, verified via
`gh api repos/wazuh/wazuh/commits/1f1bb62` resolving to a merge of that exact commit) via
[wazuh-agent-packages run 30956609638](https://github.com/wazuh/wazuh-agent-packages/actions/runs/30956609638) â€”
installed via `dpkg -i` in a disposable Ubuntu 22.04 container, talking over real TLS +
AES-CMAC to the branch's own manager simulator (`mock_manager.py`, updated for the new
HTTP-result contract, with `--force-409-stateful`, `--force-409-checksum-index`,
`--force-413-stateful`, `--force-503-stateful` hooks added to drive each scenario below on
demand). Agent config: `<synchronization><interval>` shortened to 10s and
`<integrity_interval>` to 15s so both DELTA and checksum cycles fire quickly during a short test
run; otherwise stock `ossec-agent.conf` defaults.

### Golden path â€” FIM, syscollector, syscollector_vd, SCA all sync successfully

```
/stateful -> 200  module=fim           mode=ModuleDelta  values=847  (534432 B)
/stateful -> 200  module=syscollector  mode=ModuleDelta  values=82   (44280 B)
/stateful -> 200  module=syscollector_vd mode=ModuleDelta values=134 (82168 B)
/stateful -> 200  module=sca           mode=ModuleDelta  values=0 cleans=1 (436 B)
/stateful -> 200  module=sca           mode=ModuleDelta  values=207  (610712 B)
/stateful -> 200  module=syscollector  mode=ModuleDelta  values=7    (4216 B)
```

Full decoded `FullSession` dumps (Start metadata, every `DataValue`/`DataContext` item) were
captured for each of these â€” confirms the wire format is correct end to end with `Start.size`
gone.

### 409 checksum mismatch â€” recovers within the retry budget (transient mismatch)

FIM and SCA's integrity checks each hit one forced 409, then succeeded on the very next attempt â€”
**10 seconds later**, matching `CHECKSUM_RETRY_DELAY` exactly â€” with **no full resync triggered**:

```
19:46:30 -> 409  module=fim  mode=ModuleCheck  checksum=index=wazuh-states-fim-files  (forced, attempt #1)
19:46:31 -> 409  module=sca  mode=ModuleCheck  checksum=index=wazuh-states-sca        (forced, attempt #2)
19:46:40 -> 200  module=fim  mode=ModuleCheck  checksum=index=wazuh-states-fim-files  <- exactly 10s later, recovered
19:46:41 -> 200  module=sca  mode=ModuleCheck  checksum=index=wazuh-states-sca        <- exactly 10s later, recovered
```

### 409 checksum mismatch â€” exhausts all 5 attempts, triggers a full resync (persistent mismatch)

A single index (`wazuh-states-fim-files`) was forced to 409 on every attempt. The agent retried
exactly `CHECKSUM_MISMATCH_MAX_ATTEMPTS` (5) times, 10 seconds apart each:

```
19:56:49 -> 409  (attempt 1/5)
19:56:59 -> 409  (attempt 2/5, +10s)
19:57:09 -> 409  (attempt 3/5, +10s)
19:57:20 -> 409  (attempt 4/5, +11s)
19:57:30 -> 409  (attempt 5/5, +10s)
```

Immediately after the 5th exhausted attempt, FIM triggered a full resync â€” the *same* 847-value
session as the golden path above, proving `requiresFullSync()` correctly returned `true` only
after the full retry budget was spent:

```
19:57:31 -> 200  module=fim  mode=ModuleDelta  values=0 contexts=0 cleans=1  (448 B)   <- resync prep
19:57:31 -> 200  module=fim  mode=ModuleDelta  values=847 contexts=0 cleans=0 (534432 B) <- full resync, same size as golden path
```

### 413 payload too large

```
wazuh-syscheckd: WARNING: Session rejected as too large by the manager (413): {"error": "payload_too_large", "code": 413}
wazuh-syscheckd: WARNING: FIM synchronization failed: Manager rejected the session as too large (413); it must be split and resent.
wazuh-modulesd:syscollector: WARNING: Session rejected as too large by the manager (413): {"error": "payload_too_large", "code": 413}
wazuh-modulesd:syscollector: WARNING: Syscollector synchronization failed: Manager rejected the session as too large (413); it must be split and resent.
```

No crash, no infinite retry loop â€” the module logs a WARNING and retries on its next scheduled
cycle. **Known gap**: agent-side session splitting on 413 is not implemented yet (the log
message says "must be split and resent," but nothing actually splits it today) â€” this needs
further design input before implementation; tracked as a deferred follow-up.

### 503 manager not ready

```
20:02:13 -> 503  module=fim  mode=ModuleDelta  values=847  (Retry-After: 5s, forced #1)
20:02:13 -> 503  module=fim  mode=ModuleDelta  values=847  (Retry-After: 5s, forced #2)
20:02:15 -> 200  module=fim  mode=ModuleDelta  values=847  <- same session, no data loss/duplication
```

Handled transparently by `https_client`'s own retry/backoff layer (`OutcomeClass::BackPressure`),
below `agent_sync_protocol` â€” the exact same session bytes get resent, no special handling
needed at the sync-protocol layer for this code.

### Build validation

- `agent_sync_protocol_tests`: **175/175 pass** (agent-side; includes the new
  `RequiresFullSyncRecoversAfterTransientMismatch` test, the updated
  `RequiresFullSyncWithNonMatchingChecksum` â€” now asserting exactly 5 attempts â€” and the new
  `FetchAndMarkForSyncDropsPersistentlyOversizedItemAfterMaxAttempts` covering the oversized-item
  drop above).
- `https_client_unit_test`: **278/278 pass**.
- `agentd_lib`, `wazuh-agentd`/`wazuh-modulesd`/`wazuh-syscheckd` (full non-unit-test build):
  compile and link clean.
- Manager-side `wazuh_modules/inventory_sync/` changes are **statically verified only** â€” this
  worktree's `TARGET=agent` build excludes that module entirely
  (`wazuh_modules/CMakeLists.txt:72`), consistent with it being unreachable from live traffic
  today (see `Start.size` section above).

## Artifacts Affected

- `libagent_sync_protocol.so`, `libhttps_client.so` â€” agent-side sync protocol + HTTPS transport.
- `client-agent/src/https_client_bridge.c` â€” wire format between `https_client` and
  `agent_sync_protocol` (`HCRESULT:<session>:<code>:<body>` over the sync socket).
- `wazuh_modules/inventory_sync/` (manager side) â€” schema-removal shims only, not functionally
  exercised by live traffic yet.
- `shared_modules/utils/flatbuffers/schemas/inventorySync.fbs` â€” schema changes.

## Configuration Changes

- No user-facing configuration was added.
- No `internal_options` entry was introduced.
- Fixed protocol constants:
  - FullSession byte cap reference: `5 MiB`
  - Prefilter grace: `64 KiB`
  - DELTA block cap per cycle: `10`
  - Checksum-mismatch retry budget: `5` attempts, `10s` apart
    (`CHECKSUM_MISMATCH_MAX_ATTEMPTS`/`CHECKSUM_RETRY_DELAY`)

## Documentation Updates

- No product/user documentation changes were required for this internal protocol iteration.

## Tests Introduced

- `src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp`,
  `test_agent_sync_protocol_datacontext.cpp`, `test_persistent_queue_storage.cpp`.
- Coverage includes: byte-budget fetch prefilter, VD uncapped fetch, DELTA block cap and
  block-failure abort, the new HTTP-result contract (200/409/413/503/400/500), the
  checksum-mismatch retry-and-recover and retry-and-exhaust paths, updated
  `End`/`EndAck`/`Status`-era expectations, and the persistently-oversized-item drop after
  `MAX_OVERSIZED_ATTEMPTS` cycles.

## Known Gaps / Deferred Follow-ups

- **413 session splitting**: the agent logs and retries next cycle but does not yet split an
  oversized session â€” needs further design input. Mitigated in the meantime: an item that stays
  oversized for `MAX_OVERSIZED_ATTEMPTS` consecutive cycles is dropped instead of resent
  forever (see "Reliability hardening" above), so this gap no longer blocks the whole queue.
- **Manager-side `inventory_sync` `FullSession` dispatch**: the manager doesn't dispatch on
  `MessageType_FullSession` yet (still per-message `Start`/`DataValue`/`DataContext`/`DataClean`
  dispatch), so a real `/stateful` request would currently hit "Invalid message type" â€” this is
  the server team's own pending rewrite, referenced throughout the `TODO(#38117)` comments in
  `wazuh_modules/inventory_sync/`.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided (real packaged agent + manager simulator, all HTTP-result codes exercised)
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] No mixed-version compatibility handling required for this protocol iteration (as agreed for 5.0 development scope)
