### PR TITLE
Add zstd request body support

### DIFF
--- a/docs/ref/modules/remoted/configuration.md
+++ b/docs/ref/modules/remoted/configuration.md
@@ -620,6 +620,20 @@ Bytes per chunk when streaming a response body (`POST /download`).
 > is the case. Each phase has its own log message naming its own setting, so the log tells you which
 > one elapsed.
 
+#### remoted.http_content_encoding_enabled
+
+Whether the HTTPS listener accepts request bodies compressed with `Content-Encoding: zstd`. When
+disabled, a request carrying that header is rejected with `415 Unsupported Content-Encoding`, the
+same as any unrecognized encoding. Bodies sent without a `Content-Encoding` header are unaffected
+either way.
+
+Unlike the numeric options above, this is a boolean: it has no "unset" sentinel, so a value absent
+from the configuration file resolves to the default (enabled) on the C side before it reaches the
+module.
+
+- **Default value:** `1` (enabled)
+- **Allowed values:** `0` (disabled) or `1` (enabled)
+
 #### remoted.downstream_connect_timeout
 
 Seconds to wait for the downstream UDS connect (to the engine's event ingress) to complete.
@@ -692,6 +706,10 @@ it.
 Hard cap on the authenticated request body size, in bytes (checked by the auth middleware,
 independent of the transport's own body cap -- `http_max_body_size`, a regular `<remote>` setting,
 not an internal option).
+
+Applies to the body **as received on the wire**. It does not bound a `Content-Encoding: zstd` body
+once decompressed -- that is bounded by the in-flight memory budget instead (`max_inflight_bytes`);
+see [HTTPS Events API](https-events-api.md#content-encoding-zstd).
 
 - **Default value:** `10485760` (10 MiB)
 - **Allowed values:** Integer from `1048576` (1 MiB) to `67108864` (64 MiB)

--- a/docs/ref/modules/remoted/https-events-api.md
+++ b/docs/ref/modules/remoted/https-events-api.md
@@ -123,22 +123,60 @@ A removed/disabled agent (`#`/`!`-marked, or simply absent) is treated as unknow
 ### Content-Encoding (zstd)
 
 The request body MAY optionally be compressed with `Content-Encoding: zstd` (case-insensitive). No
-other value is accepted — **`gzip` is not supported.**
+other value is accepted — **`gzip` is not supported.** Support can be turned off entirely with
+`remoted.http_content_encoding_enabled` (default: enabled) — see [Configuration](#configuration).
+
+**Why zstd and not gzip.** Both were measured on a real 48 MB FIM sync payload before choosing. At
+its default level zstd beats gzip's default on all three axes at once, so there is no trade-off to
+weigh — and decompression speed is the side that matters here, since agents compress while the
+manager decompresses:
+
+| Codec | Compressed | Compress | Decompress |
+|---|---|---|---|
+| `gzip-6` (default) | 4.25 MB | 224 ms | 44.2 ms |
+| `gzip-9` (max) | 4.10 MB | 429 ms | 43.1 ms |
+| **`zstd-3` (default)** | **3.66 MB** | **55 ms** | **24.0 ms** |
+| `zstd-9` | 3.44 MB | 157 ms | 24.3 ms |
+
+Supporting both was considered and dropped: it would mean two decoders, two dependency chains and
+two test matrices for a codec that is dominated on this workload.
 
 - Decompression happens **after** authentication succeeds, never before: the AES-CMAC always covers
   the exact wire bytes (the compressed body, if `Content-Encoding: zstd` is set), so an
   unauthenticated request never costs CPU/memory decompressing anything.
-- The decompressed size is bounded by the same `remoted.auth_max_body_size` cap (10 MiB default)
-  that applies to an uncompressed body — checked continuously while decompressing (not just at the
-  end), so a highly-compressed "decompression bomb" body is rejected the moment it would cross the
-  cap, before the full decompressed payload is ever materialized in memory.
+- `remoted.auth_max_body_size` (the 10 MiB cap that bounds an *uncompressed* body) plays **no part**
+  in the zstd path at all. Instead, **both** of the decoder's memory costs are charged as real
+  reservations against the **in-flight byte budget** (`max_inflight_bytes`, see
+  [Configuration](#configuration)) — the same pool that bounds unprocessed request payloads. So a
+  mostly-idle server admits requests one already near its memory ceiling refuses, and concurrent
+  zstd requests genuinely compete for that pool rather than each reading the same "free" figure and
+  all proceeding at once:
+  - **The decoder's own buffers**, which zstd allocates *before* producing any output. Unlike
+    gzip/DEFLATE (fixed 32 KiB window by spec), a zstd frame's header declares its own window size,
+    so the amount needed is read straight off that header — each frame reserves exactly what it
+    needs, not a blanket worst case. A frame is refused with `413` if that doesn't fit, before
+    anything is decoded; a frame whose header can't even be read is rejected without consulting the
+    budget at all. This reservation is released as soon as decompression finishes, since zstd frees
+    those buffers then.
+  - **The decompressed output buffer.** What is charged is the memory the buffer actually takes from
+    the allocator, always reserved *before* it grows — so the figure can never lag behind real usage.
+    A frame header normally declares its decompressed size, in which case that is charged once and
+    the buffer sized to it exactly (one allocation, nothing to copy as it fills, and such a frame is
+    refused up front if the declaration alone doesn't fit). A frame that omits the size — streaming
+    compression with no pledged size — grows in doubling blocks instead, each block charged before it
+    is allocated; that over-allocates relative to the data, but the over-allocation is charged rather
+    than hidden. Either way a highly-compressed "decompression bomb" is rejected the moment a
+    reservation is refused, before the full payload is ever materialized in memory. These bytes stay
+    charged for as long as the decompressed body is held (released once the handler is done with it),
+    the same way the compressed wire body's own reservation already works.
 - A missing `Content-Encoding` header is treated exactly like today: the body is passed through
   unchanged.
 - Any `Content-Encoding` value other than `zstd` — including `gzip`, which was intentionally dropped
-  in favor of zstd-only support — is rejected with `415`.
+  in favor of zstd-only support — is rejected with `415`. The same happens to `zstd` itself when
+  `remoted.http_content_encoding_enabled` is disabled.
 - A `Content-Encoding: zstd` body that isn't a valid, complete zstd frame (bad magic, truncated,
-  or a frame whose header declares an unreasonably large decompression window) is rejected with
-  `400`.
+  unreadable header) is rejected with `400`. Note the distinction from `413` above: `400` means the
+  frame itself is bad, `413` means the frame is fine but there isn't capacity for it right now.
 
 ### Error responses
 
@@ -150,7 +188,7 @@ collapse to a **single generic `401`** so a client cannot tell which specific ch
 | Missing `protocol-version` header | `400` | `Missing required header: protocol-version` |
 | Unsupported `protocol-version` | `400` | `Unsupported protocol-version` |
 | Missing / malformed `Authorization`, unknown agent, unusable key, expired or future timestamp, invalid MAC | `401` | `Invalid client authentication` |
-| Body exceeds the auth body limit (10 MiB) — checked on the decompressed size when `Content-Encoding: zstd` is set | `413` | `Request payload is too large` |
+| Body exceeds the auth body limit (10 MiB) -- or, for `Content-Encoding: zstd`, the decoder's buffers or the decompressed output don't fit in the in-flight capacity free at that moment | `413` | `Request payload is too large` |
 | `Content-Encoding` present but not (case-insensitively) `zstd` | `415` | `Unsupported Content-Encoding` |
 | `Content-Encoding: zstd`, but the body isn't a valid/complete zstd frame | `400` | `Malformed compressed body` |
 | Payload's `wazuh.agent.id` (H line) missing/malformed/non-numeric, or doesn't match the authenticated `agent-id` | `400` | `Invalid event batch` |
@@ -220,6 +258,7 @@ notes).
 | Max pipelined requests per connection | `4` | `remoted.http_max_pipelined_requests` |
 | Concurrent TCP accepts | `2` | `remoted.http_concurrent_accepts` |
 | Socket read buffer size | `8192 B` | `remoted.http_buffer_size` |
+| Accept `Content-Encoding: zstd` | enabled | `remoted.http_content_encoding_enabled` |
 
 I/O threads and handler worker threads are thread-count settings: a `<=0` value (including "not
 set" in `wazuh-manager-internal-options.conf`) resolves via `cpp_get_nproc()`
@@ -333,7 +372,7 @@ investigate why the downstream service is not keeping up.
 | Timed out connecting to / sending to / waiting for the downstream service | `remoted.downstream_connect_timeout`, `_write_timeout`, `_response_timeout` |
 | Downstream response exceeded the configured cap | `remoted.downstream_max_response_body_size` |
 | Timestamps outside the accepted window (agent clock drift) | `remoted.auth_max_request_age`, `remoted.auth_max_future_skew` |
-| Body exceeded the authenticated-body cap (413) | `remoted.auth_max_body_size` |
+| Body exceeded the authenticated-body cap (413) | `remoted.auth_max_body_size` (uncompressed body), or `max_inflight_bytes` (`Content-Encoding: zstd`) |
 | Downstream timeouts add up past `http_request_timeout` | `remoted.http_request_timeout` |
 
 Three more that are not about tuning:
@@ -556,7 +595,8 @@ python3 send_stateless.py --agent-id 1001
 python3 send_stateless.py --agent-id 1001 --tamper
 
 # run every success/failure scenario and check the expected status codes, including
-# Content-Encoding: zstd (valid, malformed, decompressed-too-large) and the now-unsupported gzip
+# Content-Encoding: zstd (valid, malformed, and a body decompressing past the 10 MiB auth cap --
+# which is accepted, since that cap does not apply to decompressed bodies) and the unsupported gzip
 python3 send_stateless.py --all
 # options: --url (default https://127.0.0.1:1517), --body, --client-keys
 ```

--- a/docs/ref/modules/remoted/https-events-api.md
+++ b/docs/ref/modules/remoted/https-events-api.md
@@ -5,10 +5,9 @@ for agent-authenticated event ingestion, in addition to the classic AES-encrypte
 on port `1514`. The listener is built on RESTinio + OpenSSL and authenticates every request with a
 per-agent **AES-CMAC** signature derived from the agent's pre-shared key.
 
-> **Experimental / work in progress.** The endpoint today performs **authentication and request
-> validation only** — it does **not** parse the H/E payload or ingest events yet. A successful
-> request is authenticated and answered `200` with an empty body; nothing is forwarded downstream.
-> The listener **requires** a TLS certificate and key to be present (see
+> **Experimental / work in progress.** A successful request is authenticated, its H/E batch is
+> forwarded to the engine's event ingress, and the response reflects the downstream result (see
+> [Endpoints](#endpoints)). The listener **requires** a TLS certificate and key to be present (see
 > [Transport and TLS](#transport-and-tls)); a self-signed pair is generated automatically at
 > install time on manager packages, so this is satisfied on a default install.
 
@@ -121,6 +120,26 @@ The manager resolves the agent key by reading `etc/client.keys` directly (the sa
 format `OS_ReadKeys()` uses); the key column is lowercase hex and must decode to 16, 24 or 32 bytes.
 A removed/disabled agent (`#`/`!`-marked, or simply absent) is treated as unknown.
 
+### Content-Encoding (zstd)
+
+The request body MAY optionally be compressed with `Content-Encoding: zstd` (case-insensitive). No
+other value is accepted — **`gzip` is not supported.**
+
+- Decompression happens **after** authentication succeeds, never before: the AES-CMAC always covers
+  the exact wire bytes (the compressed body, if `Content-Encoding: zstd` is set), so an
+  unauthenticated request never costs CPU/memory decompressing anything.
+- The decompressed size is bounded by the same `remoted.auth_max_body_size` cap (10 MiB default)
+  that applies to an uncompressed body — checked continuously while decompressing (not just at the
+  end), so a highly-compressed "decompression bomb" body is rejected the moment it would cross the
+  cap, before the full decompressed payload is ever materialized in memory.
+- A missing `Content-Encoding` header is treated exactly like today: the body is passed through
+  unchanged.
+- Any `Content-Encoding` value other than `zstd` — including `gzip`, which was intentionally dropped
+  in favor of zstd-only support — is rejected with `415`.
+- A `Content-Encoding: zstd` body that isn't a valid, complete zstd frame (bad magic, truncated,
+  or a frame whose header declares an unreasonably large decompression window) is rejected with
+  `400`.
+
 ### Error responses
 
 On rejection the body is `{"error":"<message>","code":<status>}`. Credential-related failures all
@@ -131,7 +150,9 @@ collapse to a **single generic `401`** so a client cannot tell which specific ch
 | Missing `protocol-version` header | `400` | `Missing required header: protocol-version` |
 | Unsupported `protocol-version` | `400` | `Unsupported protocol-version` |
 | Missing / malformed `Authorization`, unknown agent, unusable key, expired or future timestamp, invalid MAC | `401` | `Invalid client authentication` |
-| Body exceeds the auth body limit (10 MiB) | `413` | `Request payload is too large` |
+| Body exceeds the auth body limit (10 MiB) — checked on the decompressed size when `Content-Encoding: zstd` is set | `413` | `Request payload is too large` |
+| `Content-Encoding` present but not (case-insensitively) `zstd` | `415` | `Unsupported Content-Encoding` |
+| `Content-Encoding: zstd`, but the body isn't a valid/complete zstd frame | `400` | `Malformed compressed body` |
 | Payload's `wazuh.agent.id` (H line) missing/malformed/non-numeric, or doesn't match the authenticated `agent-id` | `400` | `Invalid event batch` |
 | Downstream rejected the batch (bad H/E) | `400` | `Invalid event batch` |
 | Out of capacity, or downstream unreachable/errored | `503` | `Service unavailable` |
@@ -525,7 +546,7 @@ from repeated errors; see
 
 `src/remoted/remoted_module/tools/send_stateless.py` signs and sends `POST /stateless` requests the
 same way the manager verifies them (AES-CMAC over the canonical sequence, key read from
-`client.keys`). Requires `pip install requests cryptography`.
+`client.keys`). Requires `pip install -r requirements.txt` (in the same `tools/` directory).
 
 ```bash
 # one valid signed request -> 202
@@ -534,7 +555,8 @@ python3 send_stateless.py --agent-id 1001
 # tamper the body after signing -> 401 (invalid MAC)
 python3 send_stateless.py --agent-id 1001 --tamper
 
-# run every success/failure scenario and check the expected status codes
+# run every success/failure scenario and check the expected status codes, including
+# Content-Encoding: zstd (valid, malformed, decompressed-too-large) and the now-unsupported gzip
 python3 send_stateless.py --all
 # options: --url (default https://127.0.0.1:1517), --body, --client-keys
 ```

--- a/docs/ref/modules/remoted/stateless-api.yaml
+++ b/docs/ref/modules/remoted/stateless-api.yaml
@@ -82,12 +82,14 @@ paths:
         The timestamp must be within 300 s in the past and 30 s in the future.
 
         The body MAY optionally be compressed with `Content-Encoding: zstd`. Decompression happens
-        only **after** authentication succeeds (so an unauthenticated request never spends CPU/memory
-        decompressing anything), and the decompressed size is bounded by the same body-size cap that
-        applies to an uncompressed request (`413` if exceeded, checked continuously during
-        decompression so a highly-compressed body can never balloon past the cap in memory first).
-        Any `Content-Encoding` value other than `zstd` is rejected with `415`; a missing header is
-        treated as an uncompressed body, unchanged from today.
+        only **after** authentication succeeds, so an unauthenticated request never spends CPU/memory
+        decompressing anything. Both the decoder's own buffers (sized from the frame header, so each
+        frame accounts for exactly what it needs) and the decompressed output (tracked incrementally
+        as it is produced) are charged against the server's live in-flight memory capacity -- so a
+        `413` here means the frame didn't fit in the capacity free at that moment, and a
+        highly-compressed body can never balloon past it in memory first. Any `Content-Encoding`
+        value other than `zstd` is rejected with `415`; a missing header is treated as an
+        uncompressed body, unchanged from today.
 
         Before forwarding, the module parses the H line's JSON and cross-checks `wazuh.agent.id`
         (compared numerically, so `"001"` and `"1"` are the same agent) against the authenticated
@@ -154,8 +156,11 @@ paths:
                   value: { error: "Invalid client authentication", code: 401 }
         "413":
           description: |
-            The request body exceeds the configured auth body limit (10 MiB) -- checked on the
-            decompressed size when `Content-Encoding: zstd` is set, same cap either way.
+            The request body exceeds the configured auth body limit (10 MiB). For
+            `Content-Encoding: zstd`, it instead means the frame didn't fit in the server's live
+            in-flight memory capacity -- either the decoder's buffers (refused up front, from the
+            frame header) or the decompressed output as it was produced. Retryable: the same request
+            may succeed once the server is less loaded.
           content:
             application/json:
               schema: { $ref: "#/components/schemas/ErrorResponse" }

--- a/docs/ref/modules/remoted/stateless-api.yaml
+++ b/docs/ref/modules/remoted/stateless-api.yaml
@@ -52,6 +52,7 @@ paths:
         - WazuhAuthentication: []
       parameters:
         - $ref: "#/components/parameters/ProtocolVersion"
+        - $ref: "#/components/parameters/ContentEncoding"
       description: |
         Accepts a batch of events using the Wazuh H/E wire protocol.
 
@@ -76,8 +77,17 @@ paths:
         ```
 
         The `request-target` is the raw path + query exactly as sent (no percent-decoding, no query
-        reordering, no normalization). The body is authenticated using its exact bytes. The
-        timestamp must be within 300 s in the past and 30 s in the future.
+        reordering, no normalization). The body is authenticated using its exact bytes -- the exact
+        bytes as sent on the wire, i.e. the **compressed** bytes if `Content-Encoding: zstd` is set.
+        The timestamp must be within 300 s in the past and 30 s in the future.
+
+        The body MAY optionally be compressed with `Content-Encoding: zstd`. Decompression happens
+        only **after** authentication succeeds (so an unauthenticated request never spends CPU/memory
+        decompressing anything), and the decompressed size is bounded by the same body-size cap that
+        applies to an uncompressed request (`413` if exceeded, checked continuously during
+        decompression so a highly-compressed body can never balloon past the cap in memory first).
+        Any `Content-Encoding` value other than `zstd` is rejected with `415`; a missing header is
+        treated as an uncompressed body, unchanged from today.
 
         Before forwarding, the module parses the H line's JSON and cross-checks `wazuh.agent.id`
         (compared numerically, so `"001"` and `"1"` are the same agent) against the authenticated
@@ -94,8 +104,9 @@ paths:
               type: string
               minLength: 1
               description: |
-                Request payload. Authentication is independent of Content-Type; the exact bytes are
-                included in the AES-CMAC calculation and forwarded verbatim to the engine.
+                Request payload. Authentication is independent of Content-Type; the exact wire bytes
+                (compressed, if `Content-Encoding: zstd` is set) are included in the AES-CMAC
+                calculation. The decompressed H/E batch is forwarded verbatim to the engine.
             examples:
               singleLineEvents:
                 summary: H/E batch (two events)
@@ -113,8 +124,9 @@ paths:
           description: |
             Either the `protocol-version` header is missing/unsupported, the payload's
             `wazuh.agent.id` doesn't match the authenticated `agent-id` (or the H line is
-            missing/malformed/non-numeric), or the downstream engine rejected the forwarded H/E
-            batch as invalid. The last two share the same `Invalid event batch` message by design.
+            missing/malformed/non-numeric), `Content-Encoding: zstd` is set but the body isn't a
+            valid/complete zstd frame, or the downstream engine rejected the forwarded H/E batch as
+            invalid. The middle two share the same `Invalid event batch` message by design.
           content:
             application/json:
               schema: { $ref: "#/components/schemas/ErrorResponse" }
@@ -126,6 +138,9 @@ paths:
                 invalidEventBatch:
                   summary: Payload agent-id mismatch, OR the engine rejected the H/E batch
                   value: { error: "Invalid event batch", code: 400 }
+                malformedContentEncoding:
+                  summary: "Content-Encoding: zstd set, but the body isn't a valid zstd frame"
+                  value: { error: "Malformed compressed body", code: 400 }
         "401":
           description: |
             Client authentication failed. Deliberately generic: a missing/malformed `Authorization`
@@ -138,13 +153,25 @@ paths:
                 invalidAuthentication:
                   value: { error: "Invalid client authentication", code: 401 }
         "413":
-          description: The request body exceeds the configured auth body limit (10 MiB).
+          description: |
+            The request body exceeds the configured auth body limit (10 MiB) -- checked on the
+            decompressed size when `Content-Encoding: zstd` is set, same cap either way.
           content:
             application/json:
               schema: { $ref: "#/components/schemas/ErrorResponse" }
               examples:
                 payloadTooLarge:
                   value: { error: "Request payload is too large", code: 413 }
+        "415":
+          description: |
+            `Content-Encoding` is present but not (case-insensitively) `zstd`. `gzip` is not
+            supported.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorResponse" }
+              examples:
+                unsupportedContentEncoding:
+                  value: { error: "Unsupported Content-Encoding", code: 415 }
         "503":
           description: |
             The server is temporarily out of capacity (its in-flight byte budget is exhausted or too
@@ -194,6 +221,18 @@ components:
         type: string
         enum: ["1"]
       example: "1"
+
+    ContentEncoding:
+      name: Content-Encoding
+      in: header
+      required: false
+      description: |
+        Optional compression applied to the request body. Only `zstd` is supported (case-insensitive);
+        any other value is rejected with `415`. Omit the header to send an uncompressed body.
+      schema:
+        type: string
+        enum: ["zstd"]
+      example: "zstd"
 
   schemas:
     ErrorResponse:

--- a/src/Makefile
+++ b/src/Makefile
@@ -504,7 +504,7 @@ endif
 # Manager-only dependencies.
 ifneq (${TARGET},agent)
 ifneq (${TARGET},winagent)
-	EXTERNAL_RES += $(CPYTHON) libffi jemalloc rocksdb simdjson abseil-cpp spdlog yaml-cpp pugixml libmaxminddb protobuf date fmt re2 rapidjson taskflow RxCpp concurrentqueue fast_float geo_db tzdata cpp-httplib asio expected-lite llhttp restinio
+	EXTERNAL_RES += $(CPYTHON) libffi jemalloc rocksdb simdjson abseil-cpp spdlog yaml-cpp pugixml libmaxminddb protobuf date fmt re2 rapidjson taskflow RxCpp concurrentqueue fast_float geo_db tzdata cpp-httplib asio expected-lite llhttp restinio zstd
 endif
 endif
 

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -1052,6 +1052,45 @@ if(IS_LINUX AND NOT IS_AGENT)
 endif()
 
 # ------------------------------------------------------------------------------
+# zstd (server only)
+# ------------------------------------------------------------------------------
+#
+# Upstream ships its CMake project under build/cmake (not at the repo root),
+# so SOURCE_DIR points there. BINARY_DIR is kept out of that tree (as
+# build/cmake-build) to avoid colliding with the vendored build/{cmake,meson,
+# VS2010,single_file_libs} directories. The static archive lands under
+# <BINARY_DIR>/lib/libzstd.a because upstream's lib/CMakeLists.txt is pulled
+# in via add_subdirectory(lib).
+if(NOT IS_AGENT AND NOT IS_WINDOWS)
+  if(EXISTS ${EXTERNAL_DIR}/zstd/build/cmake-build/lib/libzstd.a)
+    message(STATUS "Using precompiled zstd library")
+    add_custom_target(zstd_external)
+  else()
+    ExternalProject_Add(
+      zstd_external
+      SOURCE_DIR ${EXTERNAL_DIR}/zstd/build/cmake
+      BINARY_DIR ${EXTERNAL_DIR}/zstd/build/cmake-build
+      CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release
+                 -DBUILD_SHARED_LIBS=OFF
+                 -DZSTD_BUILD_STATIC=ON
+                 -DZSTD_BUILD_SHARED=OFF
+                 -DZSTD_BUILD_PROGRAMS=OFF
+                 -DZSTD_BUILD_TESTS=OFF
+                 -DZSTD_LEGACY_SUPPORT=OFF
+                 -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+      INSTALL_COMMAND ""
+      BUILD_BYPRODUCTS ${EXTERNAL_DIR}/zstd/build/cmake-build/lib/libzstd.a)
+  endif()
+
+  add_library(ext_zstd STATIC IMPORTED GLOBAL)
+  set_target_properties(
+    ext_zstd PROPERTIES IMPORTED_LOCATION
+                        ${EXTERNAL_DIR}/zstd/build/cmake-build/lib/libzstd.a)
+  add_dependencies(ext_zstd zstd_external)
+  target_include_directories(ext_zstd INTERFACE ${EXTERNAL_DIR}/zstd/lib)
+endif()
+
+# ------------------------------------------------------------------------------
 # popt (Linux agent only)
 # ------------------------------------------------------------------------------
 

--- a/src/remoted/remoted_module/CMakeLists.txt
+++ b/src/remoted/remoted_module/CMakeLists.txt
@@ -24,9 +24,10 @@ target_include_directories(
           ${SRC_FOLDER}/external/cJSON # cJSON.h (pulled by commonDefs.h)
           ${SRC_FOLDER}/external/nlohmann) # nlohmann/json.hpp
 
-# ext_restinio pulls in pthread and ssl/crypto transitively (cmac.cpp's EVP_MAC), so no explicit
-# pthread/OpenSSL link is needed here. ext_rapidjson: header-only, used to parse the /stateless payload's H line.
-target_link_libraries(remoted_module PRIVATE ext_restinio ext_rapidjson)
+# ext_restinio pulls in ssl/crypto transitively (cmac.cpp's EVP_MAC), so no explicit OpenSSL link
+# is needed here. ext_rapidjson: header-only, used to parse the /stateless payload's H line.
+# ext_zstd: zstdDecoder.cpp, for Content-Encoding: zstd request bodies.
+target_link_libraries(remoted_module PRIVATE pthread ext_restinio ext_rapidjson ext_zstd)
 
 set_target_properties(remoted_module PROPERTIES BUILD_RPATH_USE_ORIGIN TRUE
                                                 BUILD_RPATH "$ORIGIN/../lib")

--- a/src/remoted/remoted_module/README.md
+++ b/src/remoted/remoted_module/README.md
@@ -21,6 +21,9 @@ remoted_module/
 │   ├── remotedModule.cpp           # extern "C" shims + facade delegation + log sink definition
 │   ├── remotedModuleFacade.hpp     # worker thread + lifecycle; owns the HTTP server + auth + endpoints
 │   ├── auth/                       # ns remoted::auth — framework-agnostic AES-CMAC auth (see below)
+│   ├── common/                     # ns remoted::common — leaf utilities with no layer of their own:
+│   │                               #   logThrottle.hpp (rate-limited logging), zstdDecoder.hpp/.cpp
+│   ├── decoding/                   # ns remoted::decoding — Content-Encoding policy (see below)
 │   ├── http_server/                # ns remoted::http — transport-agnostic HTTP(S) sub-layer (see below)
 │   ├── endpoints/                  # ns remoted::endpoints — endpoint contract + auth gateway (see below)
 │   ├── control/                    # ns remoted::control — 5.x agent control messages (/control)
@@ -32,8 +35,8 @@ remoted_module/
 ```
 
 Each internal concern is a folder under `src/` (namespaced, PRIVATE, reachable by prefix —
-`"auth/...`", `"http_server/...`", `"endpoints/...`", `"downstream/...`" — since `src/` is on the
-include path). New endpoints get their own folder under `src/endpoints/<name>/`.
+`"auth/...`", `"decoding/...`", `"http_server/...`", `"endpoints/...`", `"control/...`",
+`"downstream/...`" — since `src/` is on the include path). New endpoints get their own folder under `src/endpoints/<name>/`.
 
 ## HTTP(S) server sub-layer (`src/http_server/`)
 
@@ -77,6 +80,13 @@ src/http_server/
        buffer (see *Single-copy payload*). Configured via remoted (`max_inflight_bytes`). Routes
        registered with `countAgainstBudget=false` (the liveness `GET /`) are **exempt**, so the probe
        stays `200` under memory pressure instead of being shed (which would make an LB pull the node).
+       The same budget also backs **body decoding** (`decoding/bodyDecoder.hpp`): a
+       `Content-Encoding: zstd` request additionally reserves the decoder's own buffers (briefly) and
+       its decompressed output (for as long as the payload lives), via
+       `IHttpServer::tryReserveInFlightBytes()` and `Reservation::grow()`. So a compressed request
+       holds up to three concurrent reservations — wire body, decoder buffers, decoded output — which
+       is correct: all three are genuinely in memory at that moment. Exhausting the budget there
+       answers **`413`** (the request is too big for the capacity free *right now*), not `503`.
     2. **`maxBodySize`** — per-request read-phase cap (RESTinio rejects an oversized `Content-Length`
        early by closing the connection). *Note:* RESTinio 0.7.9 has no dynamic pre-body hook, so the
        budget is charged once the body is already buffered; `maxBodySize` is what bounds a single
@@ -156,7 +166,8 @@ src/endpoints/
 │                            #   AuthenticatedRequest) + the async AuthenticatedHandler typedef,
 │                            #   plus errorResponseFor(AuthError) (the {"error","code"} response shape)
 ├── authGateway.hpp/.cpp     # runs the auth middleware, then hands the verified request + responder
-│                            #   to the endpoint handler
+│                            #   to the endpoint handler. Authentication only — body decoding is an
+│                            #   injected IBodyDecoder it knows nothing about
 ├── statelessEndpoint.hpp/.cpp # /stateless policy: identity check + downstream target + post-processing
 ├── statsEndpoint.hpp/.cpp    # /stats policy: forwards to modulesd's inventory sync server
 └── configEndpoint.hpp/.cpp  # /config policy (DUMMY): near-duplicate of statsEndpoint, on purpose
@@ -175,7 +186,10 @@ src/endpoints/
   async route whose worker-thread body runs the full validation (`beginSession → update → finish`,
   always synchronous — AES-CMAC over CPU, off the I/O threads), maps any `AuthError` through
   `errorResponseFor()` (which wraps `publicErrorFor()`) to the client status/message on failure, and
-  on success calls the handler with the verified `AuthenticatedRequest` and the responder. The
+  on success calls the handler with the verified `AuthenticatedRequest` and the responder. It is
+  **authentication only**: body decoding is an `IBodyDecoder` handed to its constructor, so the gateway
+  never learns which encodings exist, how one is decoded, or how the memory that costs is accounted
+  for — only that the step can fail with an `AuthError`. The
   facade registers **`POST /stateless`** with `stateless::makeHandler(forwarder, socketPath)`: once
   auth succeeds it cross-checks the payload's identity, then forwards the H/E batch to the engine
   over UDS (see *Deferred forwarding*) and replies from the downstream result
@@ -532,6 +546,48 @@ chunks) and memory that does not grow with file size.
   `.wpk` suffix. With no separator admitted, the joined path has exactly one component below the
   base directory, and `openRegularFile()`'s `O_NOFOLLOW` stops that component being a symlink.
   Loosening either grammar would break that and require a `realpath()` containment check instead.
+
+## Body decoding (`src/decoding/`)
+
+```
+src/decoding/
+├── iBodyDecoder.hpp     # ContentEncoding enum + parseContentEncoding() + the IBodyDecoder interface
+└── bodyDecoder.hpp/.cpp # BodyDecoder: the ONLY place in the module that knows compression exists
+```
+
+Split interface/implementation the same way `auth/` does (`IAgentKeystore` + `Keystore`), so the
+gateway depends on the abstraction and the concrete decoder stays swappable and separately testable.
+It is its own layer rather than part of `endpoints/` because it is not an endpoint: it is one
+cross-cutting step every authenticated route runs.
+
+The facade composes a `BodyDecoder` into the gateway's constructor as a **required** dependency, so
+it is configured **once per gateway rather than per route**: every authenticated endpoint gets
+decoding and none can accidentally opt out. `zstd` is the only accepted encoding (**gzip is not
+supported** — see the benchmark note in
+[HTTPS Events API](../../../docs/ref/modules/remoted/https-events-api.md#content-encoding-zstd));
+anything else, including `zstd` when `remoted.http_content_encoding_enabled` is off, is `415`. A body
+that isn't a valid/complete zstd frame is `400`.
+- **Runs strictly AFTER the MAC is verified.** The AES-CMAC covers the exact wire bytes (the
+  compressed body), which is what lets the signature be checked without decoding anything — so an
+  unauthenticated peer never reaches the decoder and cannot spend our CPU or memory on it.
+- **Both of the decoder's memory costs are charged to the in-flight byte budget as real
+  reservations, not merely capped** (see *Memory management* above). (1) The buffers zstd allocates
+  before producing any output, reserved at exactly what *this* frame's header declares it needs
+  (`ZSTD_getFrameHeader` + `ZSTD_decodingBufferSize_min`) and released as soon as decoding returns,
+  since zstd frees them by then. (2) The output buffer, charged for the memory it really takes from
+  the allocator and always reserved *before* it grows, then bundled into the new payload's
+  keep-alive so it stays charged for exactly as long as the payload is held. Reserving rather than
+  checking a figure is what stops N concurrent requests from each reading the same "free" number
+  and together overshooting the budget; a frame that doesn't fit is `413` (retryable, unlike the
+  `400`/`415` above).
+- **Why the output is charged by capacity, not by bytes written.** `std::string` grows by doubling,
+  so charging what was written let the buffer over-allocate uncharged — measured at **45% under**
+  for an 11 MiB body (11 MiB charged, 16 MiB actually held), which pushed the effective memory
+  ceiling that much above the configured one. Now: a frame's header normally declares its
+  decompressed size, so that is charged once and the buffer sized to it exactly — one allocation,
+  no over-allocation, nothing to copy as it fills. A frame that omits the size (streaming
+  compression with no pledged size) grows in doubling blocks, each charged before being allocated,
+  so the over-allocation is charged rather than hidden.
 
 ## Deferred forwarding (async UDS) — `src/downstream/`
 

--- a/src/remoted/remoted_module/include/remoted_module.h
+++ b/src/remoted/remoted_module/include/remoted_module.h
@@ -120,6 +120,11 @@ extern "C"
                                          ///< trade memory per in-flight transfer for fewer
                                          ///< read/write round trips, which is where the CPU per
                                          ///< byte goes.
+        /// Whether `Content-Encoding: zstd` request bodies are accepted
+        /// (see remoted.http_content_encoding_enabled). Unlike the int fields here, this has no
+        /// "unset" sentinel: getDefine_Int_default() always resolves the final 0/1 value (defaulting
+        /// to enabled) on the C side, so this field always carries the real value.
+        bool http_content_encoding_enabled;
         long long max_inflight_bytes;    ///< Max in-flight request payload bytes; 503 over it (<=0 -> module default).
         int max_parallel_connections;    ///< HTTPS max simultaneous connections (<=0 -> module default).
         int max_deferred_requests; ///< Max requests parked awaiting a downstream service; 503 over it (<=0 -> default).

--- a/src/remoted/remoted_module/src/auth/authMiddleware.cpp
+++ b/src/remoted/remoted_module/src/auth/authMiddleware.cpp
@@ -59,6 +59,8 @@ namespace remoted::auth
             case AuthError::InvalidMac: return "invalid_mac";
             case AuthError::PayloadAgentMismatch: return "payload_agent_mismatch";
             case AuthError::BodyTooLarge: return "body_too_large";
+            case AuthError::UnsupportedContentEncoding: return "unsupported_content_encoding";
+            case AuthError::MalformedContentEncoding: return "malformed_content_encoding";
         }
         return "unknown";
     }
@@ -71,6 +73,8 @@ namespace remoted::auth
             case AuthError::UnsupportedProtocolVersion: return {400, "Unsupported protocol-version"};
             case AuthError::PayloadAgentMismatch: return {400, "Invalid event batch"};
             case AuthError::BodyTooLarge: return {413, "Request payload is too large"};
+            case AuthError::MalformedContentEncoding: return {400, "Malformed compressed body"};
+            case AuthError::UnsupportedContentEncoding: return {415, "Unsupported Content-Encoding"};
             case AuthError::None: return {200, ""};
             // MissingAuthorization, MalformedAuthorization, UnknownAgent, MissingKey,
             // ExpiredRequest, FutureRequest, InvalidMac: collapse to one generic 401

--- a/src/remoted/remoted_module/src/auth/authTypes.hpp
+++ b/src/remoted/remoted_module/src/auth/authTypes.hpp
@@ -128,6 +128,9 @@ namespace remoted::auth
                               ///< missing/not-a-string/not-numeric, or doesn't match the authenticated
                               ///< agent id.
         BodyTooLarge,
+        UnsupportedContentEncoding, ///< Content-Encoding present but not (case-insensitively) "zstd".
+        MalformedContentEncoding,   ///< Content-Encoding: zstd, but the body isn't a valid/complete
+                                    ///< zstd frame (bad magic, truncated, oversized window, ...).
     };
 
     /**

--- a/src/remoted/remoted_module/src/common/zstdDecoder.cpp
+++ b/src/remoted/remoted_module/src/common/zstdDecoder.cpp
@@ -1,0 +1,122 @@
+/*
+ * Wazuh remoted module (C++ worker bridge)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 30, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "zstdDecoder.hpp"
+
+#include <zstd.h>
+
+#include <array>
+
+namespace remoted::common
+{
+
+    namespace
+    {
+        constexpr std::size_t kChunkSize = 64U * 1024U;
+
+        // Mirrors zstd's own ZSTD_WINDOWLOG_MIN / ZSTD_WINDOWLOG_LIMIT_DEFAULT. Both are documented,
+        // stable-value constants, but zstd.h only exposes their names behind
+        // ZSTD_STATIC_LINKING_ONLY (its "experimental API" opt-in) -- not worth pulling in that
+        // whole experimental surface for two numbers that don't change.
+        constexpr int kWindowLogMin = 10;
+        constexpr int kWindowLogLimitDefault = 27;
+
+        // Smallest power-of-two window (as a log2) that could hold maxOutputSize, clamped to
+        // [kWindowLogMin, kWindowLogLimitDefault]. Used to tell the decoder to refuse any frame
+        // asking for more upfront memory than we could ever accept anyway -- see the comment at
+        // the call site in zstdDecode() for why this matters.
+        int windowLogFor(std::size_t maxOutputSize)
+        {
+            int log = kWindowLogMin;
+            while (log < kWindowLogLimitDefault && (std::size_t {1} << log) < maxOutputSize)
+            {
+                ++log;
+            }
+            return log;
+        }
+    } // namespace
+
+    std::variant<std::string, ZstdDecodeError> zstdDecode(std::string_view compressed, std::size_t maxOutputSize)
+    {
+        // Zero bytes is not a valid (empty) frame, it is simply not a frame at all.
+        if (compressed.empty())
+        {
+            return ZstdDecodeError::Malformed;
+        }
+
+        ZSTD_DStream* dstream = ZSTD_createDStream();
+        if (dstream == nullptr)
+        {
+            return ZstdDecodeError::Malformed;
+        }
+
+        // RAII: guarantees ZSTD_freeDStream() on every return path below, including the early ones.
+        struct DStreamGuard
+        {
+            ZSTD_DStream* stream;
+            ~DStreamGuard()
+            {
+                ZSTD_freeDStream(stream);
+            }
+        } guard {dstream};
+
+        // Unlike gzip/DEFLATE (fixed 32 KiB window by spec), a zstd frame's header can itself
+        // declare an arbitrarily large window, forcing the decoder to allocate that much memory
+        // up front -- before a single byte of output exists for our maxOutputSize check below to
+        // catch. ZSTD_initDStream() alone would only cap that at ZSTD_WINDOWLOG_LIMIT_DEFAULT (128
+        // MiB), which is far more than we'd ever actually allow through maxOutputSize. Instead, we
+        // explicitly cap it to whatever window could possibly hold maxOutputSize: a frame that
+        // needs more than that is guaranteed to fail our size check anyway, so there is no reason
+        // to let the decoder allocate for it. ZSTD_DCtx_setParameter() must be called before
+        // ZSTD_initDStream(): the latter only resets session state (buffers/counters), not
+        // parameters set this way.
+        if (ZSTD_isError(ZSTD_DCtx_setParameter(dstream, ZSTD_d_windowLogMax, windowLogFor(maxOutputSize)))
+            || ZSTD_isError(ZSTD_initDStream(dstream)))
+        {
+            return ZstdDecodeError::Malformed;
+        }
+
+        ZSTD_inBuffer input {compressed.data(), compressed.size(), 0};
+        std::string output;
+        std::array<char, kChunkSize> chunk {};
+        std::size_t frameRemaining = 0;
+
+        while (input.pos < input.size)
+        {
+            ZSTD_outBuffer out {chunk.data(), chunk.size(), 0};
+            const std::size_t ret = ZSTD_decompressStream(dstream, &out, &input);
+            if (ZSTD_isError(ret))
+            {
+                return ZstdDecodeError::Malformed;
+            }
+            frameRemaining = ret;
+
+            if (out.pos > 0)
+            {
+                if (output.size() + out.pos > maxOutputSize)
+                {
+                    return ZstdDecodeError::TooLarge;
+                }
+                output.append(chunk.data(), out.pos);
+            }
+        }
+
+        // frameRemaining != 0 after all input has been fed means the frame is incomplete (more
+        // input would be required to finish it) -- a truncated stream.
+        if (frameRemaining != 0)
+        {
+            return ZstdDecodeError::Malformed;
+        }
+
+        return output;
+    }
+
+} // namespace remoted::common

--- a/src/remoted/remoted_module/src/common/zstdDecoder.cpp
+++ b/src/remoted/remoted_module/src/common/zstdDecoder.cpp
@@ -11,9 +11,18 @@
 
 #include "zstdDecoder.hpp"
 
+// ZSTD_getFrameHeader() and ZSTD_decodingBufferSize_min() -- which expose how much memory a frame
+// will actually make the decoder allocate -- live behind this opt-in. We rely on them to reserve
+// exactly that much against the shared in-flight budget instead of a blanket worst-case bound;
+// capping alone would leave the window buffer as real memory nothing accounts for. It is nominally
+// zstd's "experimental" surface, but the risk here is contained: we vendor and statically link a
+// pinned zstd (src/external/zstd), so any signature change surfaces at build time on a version
+// bump rather than silently at runtime.
+#define ZSTD_STATIC_LINKING_ONLY
 #include <zstd.h>
 
 #include <array>
+#include <limits>
 
 namespace remoted::common
 {
@@ -21,35 +30,43 @@ namespace remoted::common
     namespace
     {
         constexpr std::size_t kChunkSize = 64U * 1024U;
-
-        // Mirrors zstd's own ZSTD_WINDOWLOG_MIN / ZSTD_WINDOWLOG_LIMIT_DEFAULT. Both are documented,
-        // stable-value constants, but zstd.h only exposes their names behind
-        // ZSTD_STATIC_LINKING_ONLY (its "experimental API" opt-in) -- not worth pulling in that
-        // whole experimental surface for two numbers that don't change.
-        constexpr int kWindowLogMin = 10;
-        constexpr int kWindowLogLimitDefault = 27;
-
-        // Smallest power-of-two window (as a log2) that could hold maxOutputSize, clamped to
-        // [kWindowLogMin, kWindowLogLimitDefault]. Used to tell the decoder to refuse any frame
-        // asking for more upfront memory than we could ever accept anyway -- see the comment at
-        // the call site in zstdDecode() for why this matters.
-        int windowLogFor(std::size_t maxOutputSize)
-        {
-            int log = kWindowLogMin;
-            while (log < kWindowLogLimitDefault && (std::size_t {1} << log) < maxOutputSize)
-            {
-                ++log;
-            }
-            return log;
-        }
     } // namespace
 
-    std::variant<std::string, ZstdDecodeError> zstdDecode(std::string_view compressed, std::size_t maxOutputSize)
+    std::variant<std::string, ZstdDecodeError>
+    zstdDecode(std::string_view compressed, const ReserveWindowFn& reserveWindow, const ReserveMoreFn& reserveMore)
     {
         // Zero bytes is not a valid (empty) frame, it is simply not a frame at all.
         if (compressed.empty())
         {
             return ZstdDecodeError::Malformed;
+        }
+
+        // Read the frame header FIRST, before allocating any decoder state: it tells us how much
+        // memory this specific frame will make the decoder reserve up front, which is what we hand
+        // to reserveWindow(). A truncated/garbage header (>0 means "need more input", or an error
+        // code) is rejected here without touching the budget at all.
+        ZSTD_FrameHeader header {};
+        const std::size_t headerResult = ZSTD_getFrameHeader(&header, compressed.data(), compressed.size());
+        if (headerResult != 0 || header.frameType != ZSTD_frame)
+        {
+            return ZstdDecodeError::Malformed;
+        }
+
+        // What the decoder will really allocate for its window/output buffers, per zstd's own
+        // sizing helper -- not just header.windowSize, which is only part of that total. Guard the
+        // 64-bit -> size_t narrowing: on a 32-bit build a frame could legitimately declare more
+        // than size_t can hold, which we can't satisfy regardless.
+        const unsigned long long bufferSize =
+            ZSTD_decodingBufferSize_min(header.windowSize, header.frameContentSize);
+        if (ZSTD_isError(static_cast<std::size_t>(bufferSize)) ||
+            bufferSize > std::numeric_limits<std::size_t>::max())
+        {
+            return ZstdDecodeError::TooLarge;
+        }
+
+        if (!reserveWindow(static_cast<std::size_t>(bufferSize)))
+        {
+            return ZstdDecodeError::TooLarge;
         }
 
         ZSTD_DStream* dstream = ZSTD_createDStream();
@@ -68,18 +85,7 @@ namespace remoted::common
             }
         } guard {dstream};
 
-        // Unlike gzip/DEFLATE (fixed 32 KiB window by spec), a zstd frame's header can itself
-        // declare an arbitrarily large window, forcing the decoder to allocate that much memory
-        // up front -- before a single byte of output exists for our maxOutputSize check below to
-        // catch. ZSTD_initDStream() alone would only cap that at ZSTD_WINDOWLOG_LIMIT_DEFAULT (128
-        // MiB), which is far more than we'd ever actually allow through maxOutputSize. Instead, we
-        // explicitly cap it to whatever window could possibly hold maxOutputSize: a frame that
-        // needs more than that is guaranteed to fail our size check anyway, so there is no reason
-        // to let the decoder allocate for it. ZSTD_DCtx_setParameter() must be called before
-        // ZSTD_initDStream(): the latter only resets session state (buffers/counters), not
-        // parameters set this way.
-        if (ZSTD_isError(ZSTD_DCtx_setParameter(dstream, ZSTD_d_windowLogMax, windowLogFor(maxOutputSize)))
-            || ZSTD_isError(ZSTD_initDStream(dstream)))
+        if (ZSTD_isError(ZSTD_initDStream(dstream)))
         {
             return ZstdDecodeError::Malformed;
         }
@@ -88,6 +94,39 @@ namespace remoted::common
         std::string output;
         std::array<char, kChunkSize> chunk {};
         std::size_t frameRemaining = 0;
+
+        // Bytes reserved for `output`'s capacity so far. Kept equal to output.capacity() by
+        // growOutputCapacity() below, so the caller's budget tracks memory really taken from the
+        // allocator -- not the smaller "bytes written" figure, which the buffer's own
+        // over-allocation would leave the budget systematically under-counting.
+        std::size_t reservedCapacity = 0;
+
+        // Reserve, then grow capacity to exactly the reserved amount. Reserving first is what keeps
+        // the budget honest: capacity never exceeds what was granted.
+        const auto growOutputCapacity = [&output, &reservedCapacity, &reserveMore](std::size_t target)
+        {
+            if (target <= reservedCapacity)
+            {
+                return true;
+            }
+            if (!reserveMore(target - reservedCapacity))
+            {
+                return false;
+            }
+            reservedCapacity = target;
+            output.reserve(reservedCapacity);
+            return true;
+        };
+
+        // The frame normally declares its decompressed size: charge and size the buffer to exactly
+        // that, once. One allocation, no over-allocation, and nothing to copy as it fills. A frame
+        // that omits the size falls back to the block growth in the loop below.
+        if (header.frameContentSize != ZSTD_CONTENTSIZE_UNKNOWN &&
+            header.frameContentSize <= std::numeric_limits<std::size_t>::max() &&
+            !growOutputCapacity(static_cast<std::size_t>(header.frameContentSize)))
+        {
+            return ZstdDecodeError::TooLarge;
+        }
 
         while (input.pos < input.size)
         {
@@ -101,9 +140,30 @@ namespace remoted::common
 
             if (out.pos > 0)
             {
-                if (output.size() + out.pos > maxOutputSize)
+                // Only reached for a frame that declares NO decompressed size (streaming
+                // compression with no pledged size); a declared size was already covered above.
+                // Grow in doubling blocks rather than per chunk, so this doesn't mean a reservation
+                // call -- and a reallocation -- for every 64 KiB.
+                const std::size_t needed = output.size() + out.pos;
+                if (needed > reservedCapacity)
                 {
-                    return ZstdDecodeError::TooLarge;
+                    std::size_t target = reservedCapacity < kChunkSize ? kChunkSize : reservedCapacity;
+                    while (target < needed)
+                    {
+                        // Guard the doubling: past this point grow to exactly what's needed instead.
+                        if (target > std::numeric_limits<std::size_t>::max() / 2)
+                        {
+                            target = needed;
+                            break;
+                        }
+                        target *= 2;
+                    }
+                    // The caller's budget may also be shrinking concurrently (other requests
+                    // reserving bytes of their own), so this is a live contention point.
+                    if (!growOutputCapacity(target))
+                    {
+                        return ZstdDecodeError::TooLarge;
+                    }
                 }
                 output.append(chunk.data(), out.pos);
             }

--- a/src/remoted/remoted_module/src/common/zstdDecoder.hpp
+++ b/src/remoted/remoted_module/src/common/zstdDecoder.hpp
@@ -13,6 +13,7 @@
 #define _REMOTED_COMMON_ZSTD_DECODER_HPP
 
 #include <cstddef>
+#include <functional>
 #include <string>
 #include <string_view>
 #include <variant>
@@ -25,23 +26,73 @@ namespace remoted::common
      */
     enum class ZstdDecodeError
     {
-        Malformed, ///< Not a valid/complete zstd frame (bad magic, truncated, oversized window, etc.).
-        TooLarge,  ///< Decompressing would exceed the caller's maxOutputSize.
+        Malformed, ///< Not a valid/complete zstd frame (bad magic, truncated, unreadable header, etc.).
+        TooLarge,  ///< A reservation callback refused: the window or the growing output didn't fit.
     };
 
     /**
-     * @brief Decompress a zstd-encoded buffer, bounded to @p maxOutputSize.
+     * @brief Try to reserve @p additionalBytes more against some caller-owned live budget.
      *
-     * Streams through zstd's ZSTD_decompressStream() in fixed-size chunks and checks the running
-     * output size after every chunk, so a highly compressed "decompression bomb" is rejected the
-     * moment it crosses @p maxOutputSize -- the full decompressed payload is never materialized in
-     * memory.
+     * Tracks the memory the decompressed output OCCUPIES, so the caller can hold it as a REAL
+     * reservation against a shared in-flight byte budget instead of checking a static number nobody
+     * actually holds. Must be safe to call repeatedly with growing cumulative totals.
+     *
+     * What is reserved is the output buffer's CAPACITY, not the bytes written so far: those are the
+     * bytes actually taken from the allocator. zstdDecode() only ever grows capacity right after a
+     * matching reservation is granted, so the granted total always covers what is really allocated
+     * -- charging written bytes instead would undercount by however much the buffer over-allocates.
+     *
+     * @return true if granted, false if the budget doesn't have that much room right now -- causes
+     *         zstdDecode() to abort with ZstdDecodeError::TooLarge.
+     */
+    using ReserveMoreFn = std::function<bool(std::size_t additionalBytes)>;
+
+    /**
+     * @brief Try to reserve @p bytes for the decoder's internal window buffer.
+     *
+     * Called exactly once, before any decompression starts, with the amount of memory THIS frame's
+     * header actually declares it needs (read straight off the frame, not a worst-case bound) --
+     * so a shared budget can account for the window as real memory rather than merely capping it.
+     * The window is freed before zstdDecode() returns, so the caller should release this
+     * reservation on return rather than holding it alongside the decompressed output.
+     *
+     * @return true if granted, false to refuse the frame -- causes zstdDecode() to abort with
+     *         ZstdDecodeError::TooLarge without decompressing anything.
+     */
+    using ReserveWindowFn = std::function<bool(std::size_t bytes)>;
+
+    /**
+     * @brief Decompress a zstd-encoded buffer, with both of the decoder's memory costs accounted
+     *        for as real reservations against a caller-owned budget.
+     *
+     * Unlike gzip/DEFLATE (fixed 32 KiB window by spec), a zstd frame's header declares its own
+     * window size -- memory the decoder allocates up front, before producing any output. This reads
+     * that declared size off the frame header and hands it to @p reserveWindow, so the caller
+     * reserves exactly what this frame needs instead of a blanket worst case. A frame is refused
+     * outright if @p reserveWindow says no.
+     *
+     * The output buffer is reserved through @p reserveMore, always BEFORE its capacity actually
+     * grows, so the granted total covers what is really allocated (see ReserveMoreFn). A frame
+     * header normally also declares its decompressed size, in which case that is charged once and
+     * the buffer is sized to it exactly -- one allocation, no over-allocation, nothing to copy as
+     * it fills. A frame that omits the size (or declares one lower than it really decodes to) falls
+     * back to growing in blocks, still charged before each growth.
+     *
+     * Because both costs are REAL reservations the caller controls, concurrent callers genuinely
+     * contend for the same pool -- rather than each reading the same "free" snapshot and all
+     * proceeding at once, together overshooting it.
+     *
+     * Note that a frame declaring a large size is refused up front on that declaration alone, even
+     * if it would have decoded to less: the declaration is what the decoder is asked to allocate for.
      *
      * @param compressed    Zstd-encoded input bytes (the exact wire body).
-     * @param maxOutputSize Hard cap on the decompressed size, in bytes.
+     * @param reserveWindow Called once with this frame's declared window size; see ReserveWindowFn.
+     * @param reserveMore   Called to reserve output-buffer capacity; see ReserveMoreFn.
      * @return The decompressed bytes on success, or the failure reason.
      */
-    std::variant<std::string, ZstdDecodeError> zstdDecode(std::string_view compressed, std::size_t maxOutputSize);
+    std::variant<std::string, ZstdDecodeError> zstdDecode(std::string_view compressed,
+                                                          const ReserveWindowFn& reserveWindow,
+                                                          const ReserveMoreFn& reserveMore);
 
 } // namespace remoted::common
 

--- a/src/remoted/remoted_module/src/common/zstdDecoder.hpp
+++ b/src/remoted/remoted_module/src/common/zstdDecoder.hpp
@@ -1,0 +1,48 @@
+/*
+ * Wazuh remoted module (C++ worker bridge)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 30, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _REMOTED_COMMON_ZSTD_DECODER_HPP
+#define _REMOTED_COMMON_ZSTD_DECODER_HPP
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <variant>
+
+namespace remoted::common
+{
+
+    /**
+     * @brief Why zstdDecode() failed.
+     */
+    enum class ZstdDecodeError
+    {
+        Malformed, ///< Not a valid/complete zstd frame (bad magic, truncated, oversized window, etc.).
+        TooLarge,  ///< Decompressing would exceed the caller's maxOutputSize.
+    };
+
+    /**
+     * @brief Decompress a zstd-encoded buffer, bounded to @p maxOutputSize.
+     *
+     * Streams through zstd's ZSTD_decompressStream() in fixed-size chunks and checks the running
+     * output size after every chunk, so a highly compressed "decompression bomb" is rejected the
+     * moment it crosses @p maxOutputSize -- the full decompressed payload is never materialized in
+     * memory.
+     *
+     * @param compressed    Zstd-encoded input bytes (the exact wire body).
+     * @param maxOutputSize Hard cap on the decompressed size, in bytes.
+     * @return The decompressed bytes on success, or the failure reason.
+     */
+    std::variant<std::string, ZstdDecodeError> zstdDecode(std::string_view compressed, std::size_t maxOutputSize);
+
+} // namespace remoted::common
+
+#endif // _REMOTED_COMMON_ZSTD_DECODER_HPP

--- a/src/remoted/remoted_module/src/decoding/bodyDecoder.cpp
+++ b/src/remoted/remoted_module/src/decoding/bodyDecoder.cpp
@@ -1,0 +1,139 @@
+/*
+ * Wazuh remoted module (C++ worker bridge)
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 3, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "bodyDecoder.hpp"
+
+#include "common/zstdDecoder.hpp"
+#include "http_server/inFlightBudget.hpp"
+
+#include <cctype>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+
+namespace
+{
+    // Case-insensitive value comparison. HTTP token values like "zstd" are conventionally lowercase,
+    // but nothing guarantees a client sends them that way.
+    bool ciEqualsAscii(std::string_view a, std::string_view b)
+    {
+        if (a.size() != b.size())
+        {
+            return false;
+        }
+        for (std::size_t i = 0; i < a.size(); ++i)
+        {
+            if (std::tolower(static_cast<unsigned char>(a[i])) != std::tolower(static_cast<unsigned char>(b[i])))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // Keep-alive for a decoded body: the bytes plus the reservation charging them against the
+    // in-flight budget, so both are released together (RAII) when the Payload holding them is
+    // dropped. Bundling them is what ties "these bytes are in memory" to "these bytes are charged".
+    struct DecodedBody
+    {
+        std::string bytes;
+        std::optional<remoted::http::InFlightBudget::Reservation> reservation;
+    };
+} // namespace
+
+namespace remoted::decoding
+{
+
+    ContentEncoding parseContentEncoding(std::string_view header)
+    {
+        if (header.empty())
+        {
+            return ContentEncoding::None;
+        }
+        if (ciEqualsAscii(header, "zstd"))
+        {
+            return ContentEncoding::Zstd;
+        }
+        return ContentEncoding::Unsupported;
+    }
+
+    BodyDecoder::BodyDecoder(remoted::http::IHttpServer& server, bool enabled)
+        : m_server {server}
+        , m_enabled {enabled}
+    {
+    }
+
+    remoted::auth::AuthError BodyDecoder::decode(ContentEncoding encoding,
+                                                     remoted::auth::Payload& payload) const
+    {
+        switch (encoding)
+        {
+            case ContentEncoding::None: return remoted::auth::AuthError::None; // already plain
+            case ContentEncoding::Unsupported: return remoted::auth::AuthError::UnsupportedContentEncoding;
+            case ContentEncoding::Zstd: break; // handled below
+        }
+
+        if (!m_enabled)
+        {
+            // Turned off by configuration: indistinguishable to the client from an encoding this
+            // build never implemented, deliberately -- one rejection path, not two.
+            return remoted::auth::AuthError::UnsupportedContentEncoding;
+        }
+
+        // The output reservation starts at 0 and is grown as the buffer does; it is kept only on
+        // success, where it is handed to the new payload's keep-alive.
+        auto outputReservation = m_server.tryReserveInFlightBytes(0);
+        if (!outputReservation)
+        {
+            // No live budget to reserve against -- shouldn't happen once the server is actually
+            // accepting requests; fail closed.
+            return remoted::auth::AuthError::BodyTooLarge;
+        }
+
+        std::variant<std::string, remoted::common::ZstdDecodeError> decoded;
+        {
+            // Scoped so the window reservation is released here, right after decoding: zstd has
+            // already freed the buffers it stood for, and holding it longer would starve the budget
+            // for memory nobody is using.
+            std::optional<remoted::http::InFlightBudget::Reservation> windowReservation;
+            decoded = remoted::common::zstdDecode(
+                payload.bytes(),
+                [this, &windowReservation](std::size_t bytes)
+                {
+                    windowReservation = m_server.tryReserveInFlightBytes(bytes);
+                    return windowReservation.has_value();
+                },
+                [&outputReservation](std::size_t more) { return outputReservation->grow(more); });
+        }
+
+        if (std::holds_alternative<remoted::common::ZstdDecodeError>(decoded))
+        {
+            return std::get<remoted::common::ZstdDecodeError>(decoded) == remoted::common::ZstdDecodeError::TooLarge
+                       ? remoted::auth::AuthError::BodyTooLarge
+                       : remoted::auth::AuthError::MalformedContentEncoding;
+        }
+
+        // Swap the compressed transport-buffer view for one over the decoded bytes. Assigning the new
+        // Payload drops the previous keep-alive (the transport's request buffer), which releases the
+        // wire body's own in-flight reservation -- it is no longer needed.
+        auto body = std::make_shared<DecodedBody>(
+            DecodedBody {std::move(std::get<std::string>(decoded)), std::move(outputReservation)});
+        const std::string_view view {body->bytes};
+        payload = remoted::auth::Payload {view, std::move(body)};
+
+        return remoted::auth::AuthError::None;
+    }
+
+} // namespace remoted::decoding

--- a/src/remoted/remoted_module/src/decoding/bodyDecoder.hpp
+++ b/src/remoted/remoted_module/src/decoding/bodyDecoder.hpp
@@ -1,0 +1,77 @@
+/*
+ * Wazuh remoted module (C++ worker bridge)
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 3, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _REMOTED_DECODING_BODY_DECODER_HPP
+#define _REMOTED_DECODING_BODY_DECODER_HPP
+
+#include "iBodyDecoder.hpp"             // ContentEncoding, IBodyDecoder
+#include "http_server/IHttpServer.hpp" // remoted::http::IHttpServer
+
+namespace remoted::decoding
+{
+
+    /**
+     * @brief The `Content-Encoding` decoder for authenticated request bodies.
+     *
+     * The only place in the module that knows compression exists. AuthGateway holds one of these as
+     * an IBodyDecoder and runs it on the verified body, so the auth layer stays free of zstd, of the
+     * in-flight byte budget, and of the reservation lifetimes below.
+     *
+     * Behavior:
+     *  - ContentEncoding::None: the payload is left untouched (AuthError::None).
+     *  - ContentEncoding::Zstd, when enabled: the payload is replaced with the decompressed bytes.
+     *  - ContentEncoding::Unsupported, or Zstd when disabled: AuthError::UnsupportedContentEncoding
+     *    (`415`). gzip is deliberately not implemented, so it parses as Unsupported.
+     *  - A body that isn't a valid/complete zstd frame: AuthError::MalformedContentEncoding (`400`).
+     *  - A frame that doesn't fit in the capacity free right now: AuthError::BodyTooLarge (`413`) --
+     *    retryable, unlike the two above.
+     *
+     * Memory accounting: BOTH of the decoder's costs are charged against the server's in-flight byte
+     * budget as REAL reservations, not merely capped. Several concurrent requests each reading the
+     * same "free" figure and all proceeding would together overshoot the budget; reserving makes them
+     * contend for one pool instead.
+     *
+     *  1. The buffers zstd allocates before producing any output, reserved at exactly what the
+     *     frame's own header declares it needs -- so a cheap frame doesn't tie up capacity for an
+     *     expensive one. Released as soon as decoding returns, since zstd frees them by then.
+     *  2. The output buffer, charged for the memory it really takes from the allocator and always
+     *     reserved BEFORE it grows. It is bundled into the new payload's keep-alive, so those bytes
+     *     stay charged for exactly as long as the payload is held and are released (RAII) the moment
+     *     the handler drops it.
+     *
+     * Thread-safe: holds no mutable state, so one instance serves every route and every in-flight
+     * request (all per-request state lives on the stack of decode()).
+     */
+    class BodyDecoder final : public IBodyDecoder
+    {
+    public:
+        /**
+         * @param server  Transport owning the in-flight byte budget. Must outlive this decoder (both
+         *                are owned by the module facade).
+         * @param enabled Whether `Content-Encoding: zstd` is accepted at all. Takes the ALREADY
+         *                RESOLVED value of `remoted.http_content_encoding_enabled`, read in
+         *                secure.c and carried on the C-ABI config struct. This class deliberately does
+         *                NOT read configuration itself: nothing in the C++ module does, so all config
+         *                keeps entering through the single C-ABI door and this stays testable with a
+         *                plain bool.
+         */
+        BodyDecoder(remoted::http::IHttpServer& server, bool enabled);
+
+        remoted::auth::AuthError decode(ContentEncoding encoding, remoted::auth::Payload& payload) const override;
+
+    private:
+        remoted::http::IHttpServer& m_server;
+        bool m_enabled;
+    };
+
+} // namespace remoted::decoding
+
+#endif // _REMOTED_DECODING_BODY_DECODER_HPP

--- a/src/remoted/remoted_module/src/decoding/iBodyDecoder.hpp
+++ b/src/remoted/remoted_module/src/decoding/iBodyDecoder.hpp
@@ -1,0 +1,82 @@
+/*
+ * Wazuh remoted module (C++ worker bridge)
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 4, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _REMOTED_DECODING_I_BODY_DECODER_HPP
+#define _REMOTED_DECODING_I_BODY_DECODER_HPP
+
+#include "auth/authTypes.hpp" // remoted::auth::{AuthError, Payload}
+
+#include <string_view>
+
+namespace remoted::decoding
+{
+
+    /**
+     * @brief A request body's `Content-Encoding`, parsed once at the edge.
+     *
+     * Parsing the header into a domain value (rather than comparing strings deeper in) makes the
+     * "we don't speak this one" case an explicit state instead of the fallthrough of an if-chain,
+     * and lets the compiler flag any `switch` that forgets a codec when one is added.
+     */
+    enum class ContentEncoding
+    {
+        None,        ///< No `Content-Encoding` header: the body is already plain.
+        Zstd,        ///< `zstd` (case-insensitive).
+        Unsupported, ///< A header is present but names an encoding this build does not implement.
+    };
+
+    /**
+     * @brief Parse a raw `Content-Encoding` header value.
+     *
+     * @param header Raw header value; empty when the header was absent.
+     * @return The matching ContentEncoding. Matching is case-insensitive, since HTTP token values
+     *         are conventionally lowercase but nothing guarantees a client sends them that way.
+     *         Anything unrecognized maps to ContentEncoding::Unsupported -- note this says nothing
+     *         about whether a recognized encoding is *enabled*, which is an IBodyDecoder policy.
+     */
+    ContentEncoding parseContentEncoding(std::string_view header);
+
+    /**
+     * @brief Post-authentication body-decoding step.
+     *
+     * Lets the `Content-Encoding` contract live entirely outside the auth layer: AuthGateway is
+     * handed one of these and runs it on the verified body, without knowing which encodings are
+     * implemented, how a body is decoded, or how the memory that costs is accounted for -- only
+     * that the step can fail with an AuthError. See bodyDecoder.hpp for the implementation.
+     *
+     * Injected like IAgentKeystore: a plain dependency with a name, mockable by a test double, and
+     * explicit in the header rather than a type-erased callable.
+     */
+    class IBodyDecoder
+    {
+    public:
+        virtual ~IBodyDecoder() = default;
+
+        /**
+         * @brief Decode @p payload in place according to @p encoding.
+         *
+         * Called once per authenticated request, on a worker thread. Must be safe to call
+         * concurrently: one instance serves every route and every in-flight request.
+         *
+         * @param encoding The request's parsed Content-Encoding.
+         * @param payload  The verified body, REPLACED in place with the decoded bytes on success.
+         *                 ContentEncoding::None must leave it untouched.
+         * @return AuthError::None on success (including the None passthrough), otherwise the
+         *         rejection AuthGateway answers with -- e.g. UnsupportedContentEncoding,
+         *         MalformedContentEncoding or BodyTooLarge.
+         */
+        virtual remoted::auth::AuthError decode(ContentEncoding encoding,
+                                                remoted::auth::Payload& payload) const = 0;
+    };
+
+} // namespace remoted::decoding
+
+#endif // _REMOTED_DECODING_I_BODY_DECODER_HPP

--- a/src/remoted/remoted_module/src/endpoints/authGateway.cpp
+++ b/src/remoted/remoted_module/src/endpoints/authGateway.cpp
@@ -11,6 +11,7 @@
 
 #include "authGateway.hpp"
 
+#include "common/zstdDecoder.hpp"
 #include "loggerHelper.h"
 
 #include <cctype>
@@ -95,13 +96,32 @@ namespace
         }
         return {};
     }
+
+    // Case-insensitive value comparison (HTTP token values like "zstd" are conventionally
+    // lowercase, but nothing guarantees a client sends them that way).
+    bool ciEqualsAscii(std::string_view a, std::string_view b)
+    {
+        if (a.size() != b.size())
+        {
+            return false;
+        }
+        for (std::size_t i = 0; i < a.size(); ++i)
+        {
+            if (std::tolower(static_cast<unsigned char>(a[i])) != std::tolower(static_cast<unsigned char>(b[i])))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
 } // namespace
 
 namespace remoted::endpoints
 {
 
     AuthGateway::AuthGateway(remoted::auth::AuthConfig config, std::shared_ptr<remoted::auth::IAgentKeystore> keystore)
-        : m_middleware {std::make_shared<remoted::auth::AuthMiddleware>(std::move(config), std::move(keystore))}
+        : m_middleware {std::make_shared<remoted::auth::AuthMiddleware>(config, std::move(keystore))}
+        , m_maxBodySize {config.maxBodySize}
     {
     }
 
@@ -113,12 +133,13 @@ namespace remoted::endpoints
     {
         auto middleware = m_middleware;
         const char* methodStr = methodToCanonical(method);
+        const std::size_t maxBodySize = m_maxBodySize;
 
         server.addRoute(
             method,
             path,
-            [middleware, methodStr, handler = std::move(handler)](std::shared_ptr<const HttpRequest> request,
-                                                                  std::shared_ptr<IHttpResponder> responder)
+            [middleware, methodStr, maxBodySize, handler = std::move(handler)](
+                std::shared_ptr<const HttpRequest> request, std::shared_ptr<IHttpResponder> responder)
             {
                 // Everything below -- the AES-CMAC auth pipeline (steps 1-7) AND the endpoint
                 // handler -- runs inside one try/catch. beginSession()/Session::update()/finish()
@@ -132,6 +153,9 @@ namespace remoted::endpoints
                 {
                     const std::string protocolVersion = headerValue(request->headers, "protocol-version");
                     const std::string authorization = headerValue(request->headers, "authorization");
+                    // Read once, used only AFTER authentication succeeds (see below): the MAC
+                    // always covers the wire bytes exactly as sent, compressed or not.
+                    const std::string contentEncoding = headerValue(request->headers, "content-encoding");
 
                     // Steps 1-5: protocol-version + Authorization + timestamp window + key + CMAC prefix.
                     auto begin = middleware->beginSession(protocolVersion,
@@ -181,6 +205,55 @@ namespace remoted::endpoints
                     auto authRequest = std::get<remoted::auth::AuthenticatedRequest>(std::move(finished));
                     const std::string_view bodyView {request->body}; // capture BEFORE moving request
                     authRequest.payload = remoted::auth::Payload {bodyView, std::move(request)};
+
+                    // Content-Encoding is handled here, AFTER authentication: the MAC already
+                    // covered the compressed wire bytes above, so an unauthenticated peer cannot
+                    // spend our CPU/memory decompressing anything -- only an authenticated agent's
+                    // request ever reaches inflate(). Empty header: pass the body through as-is
+                    // (current, uncompressed behavior).
+                    if (!contentEncoding.empty())
+                    {
+                        std::string decodedBody;
+                        bool malformed = false;
+                        bool tooLarge = false;
+
+                        if (ciEqualsAscii(contentEncoding, "zstd"))
+                        {
+                            auto result = remoted::common::zstdDecode(authRequest.payload.bytes(), maxBodySize);
+                            if (std::holds_alternative<remoted::common::ZstdDecodeError>(result))
+                            {
+                                tooLarge = std::get<remoted::common::ZstdDecodeError>(result) ==
+                                           remoted::common::ZstdDecodeError::TooLarge;
+                                malformed = !tooLarge;
+                            }
+                            else
+                            {
+                                decodedBody = std::move(std::get<std::string>(result));
+                            }
+                        }
+                        else
+                        {
+                            responder->send(errorResponseFor(remoted::auth::AuthError::UnsupportedContentEncoding));
+                            return;
+                        }
+
+                        if (malformed || tooLarge)
+                        {
+                            const auto authErr = tooLarge ? remoted::auth::AuthError::BodyTooLarge
+                                                          : remoted::auth::AuthError::MalformedContentEncoding;
+                            responder->send(errorResponseFor(authErr));
+                            return;
+                        }
+
+                        // Replace the (compressed) transport-buffer view with a new Payload over the
+                        // decompressed bytes, owned by their own keep-alive. This drops the original
+                        // request's keep-alive here -- its in-flight byte reservation (sized off the
+                        // compressed wire body) is released now; the decompressed copy is untracked
+                        // heap memory bounded only by maxBodySize above.
+                        auto decompressed = std::make_shared<std::string>(std::move(decodedBody));
+                        const std::string_view decompressedView {*decompressed};
+                        authRequest.payload = remoted::auth::Payload {decompressedView, std::move(decompressed)};
+                    }
 
                     // Hand the handler a shared_ptr<const> so it can retain the verified
                     // request across deferred pipeline stages without copying the payload.

--- a/src/remoted/remoted_module/src/endpoints/authGateway.cpp
+++ b/src/remoted/remoted_module/src/endpoints/authGateway.cpp
@@ -11,7 +11,6 @@
 
 #include "authGateway.hpp"
 
-#include "common/zstdDecoder.hpp"
 #include "loggerHelper.h"
 
 #include <cctype>
@@ -97,31 +96,16 @@ namespace
         return {};
     }
 
-    // Case-insensitive value comparison (HTTP token values like "zstd" are conventionally
-    // lowercase, but nothing guarantees a client sends them that way).
-    bool ciEqualsAscii(std::string_view a, std::string_view b)
-    {
-        if (a.size() != b.size())
-        {
-            return false;
-        }
-        for (std::size_t i = 0; i < a.size(); ++i)
-        {
-            if (std::tolower(static_cast<unsigned char>(a[i])) != std::tolower(static_cast<unsigned char>(b[i])))
-            {
-                return false;
-            }
-        }
-        return true;
-    }
 } // namespace
 
 namespace remoted::endpoints
 {
 
-    AuthGateway::AuthGateway(remoted::auth::AuthConfig config, std::shared_ptr<remoted::auth::IAgentKeystore> keystore)
+    AuthGateway::AuthGateway(remoted::auth::AuthConfig config,
+                             std::shared_ptr<remoted::auth::IAgentKeystore> keystore,
+                             std::shared_ptr<const remoted::decoding::IBodyDecoder> bodyDecoder)
         : m_middleware {std::make_shared<remoted::auth::AuthMiddleware>(config, std::move(keystore))}
-        , m_maxBodySize {config.maxBodySize}
+        , m_bodyDecoder {std::move(bodyDecoder)}
     {
     }
 
@@ -131,14 +115,16 @@ namespace remoted::endpoints
                                             AuthenticatedHandler handler,
                                             remoted::http::ResponseMode mode)
     {
-        auto middleware = m_middleware;
         const char* methodStr = methodToCanonical(method);
-        const std::size_t maxBodySize = m_maxBodySize;
 
         server.addRoute(
             method,
             path,
-            [middleware, methodStr, maxBodySize, handler = std::move(handler)](
+            // Both dependencies are captured as their own shared_ptr copy (a refcount bump), not by
+            // reference to the member: the lambda lives in the server's route table and runs per
+            // request, long after this call returns. Copying keeps each registered route
+            // self-contained instead of tying its validity to this gateway still being alive.
+            [middleware = m_middleware, methodStr, bodyDecoder = m_bodyDecoder, handler = std::move(handler)](
                 std::shared_ptr<const HttpRequest> request, std::shared_ptr<IHttpResponder> responder)
             {
                 // Everything below -- the AES-CMAC auth pipeline (steps 1-7) AND the endpoint
@@ -153,9 +139,10 @@ namespace remoted::endpoints
                 {
                     const std::string protocolVersion = headerValue(request->headers, "protocol-version");
                     const std::string authorization = headerValue(request->headers, "authorization");
-                    // Read once, used only AFTER authentication succeeds (see below): the MAC
-                    // always covers the wire bytes exactly as sent, compressed or not.
-                    const std::string contentEncoding = headerValue(request->headers, "content-encoding");
+                    // Parsed once here, acted on only AFTER authentication succeeds (see below): the
+                    // MAC always covers the wire bytes exactly as sent, compressed or not.
+                    const auto contentEncoding =
+                        remoted::decoding::parseContentEncoding(headerValue(request->headers, "content-encoding"));
 
                     // Steps 1-5: protocol-version + Authorization + timestamp window + key + CMAC prefix.
                     auto begin = middleware->beginSession(protocolVersion,
@@ -206,53 +193,16 @@ namespace remoted::endpoints
                     const std::string_view bodyView {request->body}; // capture BEFORE moving request
                     authRequest.payload = remoted::auth::Payload {bodyView, std::move(request)};
 
-                    // Content-Encoding is handled here, AFTER authentication: the MAC already
-                    // covered the compressed wire bytes above, so an unauthenticated peer cannot
-                    // spend our CPU/memory decompressing anything -- only an authenticated agent's
-                    // request ever reaches inflate(). Empty header: pass the body through as-is
-                    // (current, uncompressed behavior).
-                    if (!contentEncoding.empty())
+                    // Body decoding runs here, AFTER authentication: the MAC already covered the
+                    // exact wire bytes above, so an unauthenticated peer never reaches a decoder --
+                    // it cannot spend our CPU or memory on one. What the step actually does (which
+                    // encodings are implemented, how a body is decoded, how the memory that costs is
+                    // accounted for) is deliberately unknown here; see remoted::decoding::IBodyDecoder.
+                    const auto decodeError = bodyDecoder->decode(contentEncoding, authRequest.payload);
+                    if (decodeError != remoted::auth::AuthError::None)
                     {
-                        std::string decodedBody;
-                        bool malformed = false;
-                        bool tooLarge = false;
-
-                        if (ciEqualsAscii(contentEncoding, "zstd"))
-                        {
-                            auto result = remoted::common::zstdDecode(authRequest.payload.bytes(), maxBodySize);
-                            if (std::holds_alternative<remoted::common::ZstdDecodeError>(result))
-                            {
-                                tooLarge = std::get<remoted::common::ZstdDecodeError>(result) ==
-                                           remoted::common::ZstdDecodeError::TooLarge;
-                                malformed = !tooLarge;
-                            }
-                            else
-                            {
-                                decodedBody = std::move(std::get<std::string>(result));
-                            }
-                        }
-                        else
-                        {
-                            responder->send(errorResponseFor(remoted::auth::AuthError::UnsupportedContentEncoding));
-                            return;
-                        }
-
-                        if (malformed || tooLarge)
-                        {
-                            const auto authErr = tooLarge ? remoted::auth::AuthError::BodyTooLarge
-                                                          : remoted::auth::AuthError::MalformedContentEncoding;
-                            responder->send(errorResponseFor(authErr));
-                            return;
-                        }
-
-                        // Replace the (compressed) transport-buffer view with a new Payload over the
-                        // decompressed bytes, owned by their own keep-alive. This drops the original
-                        // request's keep-alive here -- its in-flight byte reservation (sized off the
-                        // compressed wire body) is released now; the decompressed copy is untracked
-                        // heap memory bounded only by maxBodySize above.
-                        auto decompressed = std::make_shared<std::string>(std::move(decodedBody));
-                        const std::string_view decompressedView {*decompressed};
-                        authRequest.payload = remoted::auth::Payload {decompressedView, std::move(decompressed)};
+                        responder->send(errorResponseFor(decodeError));
+                        return;
                     }
 
                     // Hand the handler a shared_ptr<const> so it can retain the verified

--- a/src/remoted/remoted_module/src/endpoints/authGateway.hpp
+++ b/src/remoted/remoted_module/src/endpoints/authGateway.hpp
@@ -32,9 +32,14 @@ namespace remoted::endpoints
      * gateway owns one AuthMiddleware and registers, on our transport-agnostic
      * IHttpServer, a raw async route whose worker-thread body:
      *   1. runs the full validation (protocol-version + Authorization + timestamp
-     *      window + key lookup + AES-CMAC over the exact body bytes),
-     *   2. on failure, answers with publicErrorFor()'s status/message, and
-     *   3. on success, hands the verified request and the responder to the handler.
+     *      window + key lookup + AES-CMAC over the exact wire body bytes -- the MAC
+     *      always covers what was actually sent, compressed or not),
+     *   2. on failure, answers with publicErrorFor()'s status/message,
+     *   3. if authenticated and Content-Encoding: zstd is set, decompresses the body
+     *      (bounded to the configured max body size) before the handler ever sees it,
+     *      answering directly on a bad/oversized/unsupported encoding, and
+     *   4. on success, hands the verified (and, if applicable, decompressed) request
+     *      and the responder to the handler.
      *
      * The gateway is the only adapter between remoted::auth (framework-agnostic) and
      * remoted::http (our transport); swapping the HTTP library never touches it.
@@ -67,6 +72,9 @@ namespace remoted::endpoints
 
     private:
         std::shared_ptr<remoted::auth::AuthMiddleware> m_middleware;
+        // Captured from AuthConfig before it's moved into m_middleware: also the cap applied to a
+        // zstd-decompressed body (see addAuthenticatedRoute()'s Content-Encoding handling).
+        std::size_t m_maxBodySize;
     };
 
 } // namespace remoted::endpoints

--- a/src/remoted/remoted_module/src/endpoints/authGateway.hpp
+++ b/src/remoted/remoted_module/src/endpoints/authGateway.hpp
@@ -15,6 +15,7 @@
 #include "auth/authMiddleware.hpp"     // remoted::auth::AuthMiddleware
 #include "auth/authTypes.hpp"          // remoted::auth::AuthConfig
 #include "auth/iAgentKeystore.hpp"     // remoted::auth::IAgentKeystore
+#include "decoding/iBodyDecoder.hpp"   // remoted::decoding::IBodyDecoder
 #include "endpoint.hpp"                // AuthenticatedHandler + shared type aliases
 #include "http_server/IHttpServer.hpp" // remoted::http::IHttpServer
 
@@ -35,11 +36,17 @@ namespace remoted::endpoints
      *      window + key lookup + AES-CMAC over the exact wire body bytes -- the MAC
      *      always covers what was actually sent, compressed or not),
      *   2. on failure, answers with publicErrorFor()'s status/message,
-     *   3. if authenticated and Content-Encoding: zstd is set, decompresses the body
-     *      (bounded to the configured max body size) before the handler ever sees it,
-     *      answering directly on a bad/oversized/unsupported encoding, and
-     *   4. on success, hands the verified (and, if applicable, decompressed) request
-     *      and the responder to the handler.
+     *   3. on success, runs the injected IBodyDecoder over the verified body and
+     *      answers with publicErrorFor() if it rejects, then
+     *   4. hands the verified (and, if applicable, decoded) request and the responder to
+     *      the handler.
+     *
+     * Step 3 is a plain dependency on purpose: the gateway does not know which
+     * `Content-Encoding` values exist, how a body is decoded, or how the memory that costs
+     * is accounted for -- only that the step can fail with an AuthError. That keeps this
+     * class about authentication alone, and keeps decoding independently testable (it lives in
+     * its own layer, `src/decoding/`). Because the decoder is configured once here rather than per route,
+     * a new endpoint cannot accidentally opt out of it.
      *
      * The gateway is the only adapter between remoted::auth (framework-agnostic) and
      * remoted::http (our transport); swapping the HTTP library never touches it.
@@ -48,10 +55,17 @@ namespace remoted::endpoints
     {
     public:
         /**
-         * @param config   Auth-protocol tunables (protocol version, timestamp window, max body size).
-         * @param keystore Agent-key lookup; must outlive the routes registered through this gateway.
+         * @param config      Auth-protocol tunables (protocol version, timestamp window, max body size).
+         * @param keystore    Agent-key lookup; must outlive the routes registered through this gateway.
+         * @param bodyDecoder Post-authentication body-decoding step (see IBodyDecoder). Required, and
+         *                    must be non-null: every authenticated route runs it, and it owns the
+         *                    whole `Content-Encoding` policy -- including deciding that an absent
+         *                    header means "pass the body through untouched". Making it optional would
+         *                    mean a second copy of that policy here, free to drift from the real one.
          */
-        AuthGateway(remoted::auth::AuthConfig config, std::shared_ptr<remoted::auth::IAgentKeystore> keystore);
+        AuthGateway(remoted::auth::AuthConfig config,
+                    std::shared_ptr<remoted::auth::IAgentKeystore> keystore,
+                    std::shared_ptr<const remoted::decoding::IBodyDecoder> bodyDecoder);
 
         /**
          * @brief Register an authenticated endpoint. Call before IHttpServer::start().
@@ -72,9 +86,7 @@ namespace remoted::endpoints
 
     private:
         std::shared_ptr<remoted::auth::AuthMiddleware> m_middleware;
-        // Captured from AuthConfig before it's moved into m_middleware: also the cap applied to a
-        // zstd-decompressed body (see addAuthenticatedRoute()'s Content-Encoding handling).
-        std::size_t m_maxBodySize;
+        std::shared_ptr<const remoted::decoding::IBodyDecoder> m_bodyDecoder; ///< Post-auth body decoding; never null.
     };
 
 } // namespace remoted::endpoints

--- a/src/remoted/remoted_module/src/endpoints/endpoint.cpp
+++ b/src/remoted/remoted_module/src/endpoints/endpoint.cpp
@@ -14,11 +14,15 @@
 #include "common/logThrottle.hpp"
 #include "loggerHelper.h"
 
+#include <cctype>
+#include <cstddef>
 #include <string>
+#include <string_view>
 #include <utility>
 
 namespace
 {
+
     constexpr auto ENDPOINT_LOGTAG {"wazuh-manager-remoted:endpoints"};
 
     // One shared instance rather than a per-call temporary: this runs on EVERY rejected request.

--- a/src/remoted/remoted_module/src/http_server/IHttpServer.hpp
+++ b/src/remoted/remoted_module/src/http_server/IHttpServer.hpp
@@ -12,10 +12,13 @@
 #ifndef _REMOTED_HTTP_SERVER_INTERFACE_HPP
 #define _REMOTED_HTTP_SERVER_INTERFACE_HPP
 
+#include "inFlightBudget.hpp"
+
 #include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -290,6 +293,27 @@ namespace remoted::http
                               RouteHandler handler,
                               bool countAgainstBudget = true,
                               ResponseMode mode = ResponseMode::Buffered) = 0;
+
+        /**
+         * @brief Try to reserve @p bytes against the in-flight byte budget, independent of any
+         * request's own wire-body reservation.
+         *
+         * Lets a route handler charge memory it allocates itself (e.g. a decompressed request body)
+         * against the same pool that bounds unprocessed request payloads, so concurrent handlers
+         * genuinely contend for it instead of each independently reading a "free" figure and all
+         * proceeding at once. For a size that isn't known upfront, reserve 0 bytes to obtain a
+         * handle and grow it via InFlightBudget::Reservation::grow() as bytes materialize.
+         *
+         * The bytes stay charged for as long as the returned reservation is kept alive, so tie its
+         * lifetime to whatever the reserved bytes actually back -- bundle it into that data's own
+         * keep-alive to hold it, or let it fall out of scope to release it.
+         *
+         * @param bytes Bytes to reserve up front (0 is always granted).
+         * @return An engaged reservation on success, `std::nullopt` if the budget doesn't have
+         *         that much room right now, or if there is no live budget to reserve against (the
+         *         server hasn't been started yet).
+         */
+        virtual std::optional<InFlightBudget::Reservation> tryReserveInFlightBytes(std::size_t bytes) = 0;
 
         /**
          * @brief Start listening. Throws on bind/TLS/configuration failure.

--- a/src/remoted/remoted_module/src/http_server/RestinioHttpServer.cpp
+++ b/src/remoted/remoted_module/src/http_server/RestinioHttpServer.cpp
@@ -31,6 +31,7 @@
 #include <atomic>
 #include <chrono>
 #include <fstream>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
@@ -913,6 +914,20 @@ namespace remoted::http
         }
 
         m_impl->m_routes.push_back(Route {method, path, std::move(handler), countAgainstBudget, mode});
+    }
+
+    std::optional<InFlightBudget::Reservation> RestinioHttpServer::tryReserveInFlightBytes(std::size_t bytes)
+    {
+        // No mutex: by the time any route handler could call this, start() has already returned
+        // successfully (requests can't arrive before the listener is up) and m_budget is never
+        // reset again until this object is destroyed -- the same lifetime guarantee buildRouter()'s
+        // own captured `budget` raw pointer already relies on.
+        auto* budget = m_impl->m_budget.get();
+        if (budget == nullptr)
+        {
+            return std::nullopt;
+        }
+        return budget->tryReserve(bytes);
     }
 
     void RestinioHttpServer::start(const HttpServerConfig& config)

--- a/src/remoted/remoted_module/src/http_server/RestinioHttpServer.hpp
+++ b/src/remoted/remoted_module/src/http_server/RestinioHttpServer.hpp
@@ -17,6 +17,7 @@
 #include <openssl/x509.h>
 
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace remoted::http
@@ -59,6 +60,7 @@ namespace remoted::http
                  RouteHandler handler,
                  bool countAgainstBudget = true,
                  ResponseMode mode = ResponseMode::Buffered) override;
+        std::optional<InFlightBudget::Reservation> tryReserveInFlightBytes(std::size_t bytes) override;
         void start(const HttpServerConfig& config) override;
         void stopAccepting() noexcept override;
         void stop() noexcept override;

--- a/src/remoted/remoted_module/src/http_server/inFlightBudget.hpp
+++ b/src/remoted/remoted_module/src/http_server/inFlightBudget.hpp
@@ -89,6 +89,48 @@ namespace remoted::http
                 return m_owner != nullptr;
             }
 
+            /**
+             * @brief Try to grow this reservation by @p additionalBytes more, atomically, against
+             *        the same owning budget.
+             *
+             * Lets a caller that doesn't know its final size upfront (e.g. streaming decompression)
+             * reserve incrementally as more bytes materialize, instead of either over-reserving a
+             * worst-case bound before starting or not tracking the bytes at all.
+             *
+             * @return true if granted -- bytes() increases by @p additionalBytes. false if the
+             *         budget doesn't have that much room right now (this reservation is
+             *         unchanged), or if this token holds no active reservation (moved-from/released).
+             */
+            bool grow(std::size_t additionalBytes) noexcept
+            {
+                if (additionalBytes == 0)
+                {
+                    return true;
+                }
+                if (m_owner == nullptr)
+                {
+                    return false;
+                }
+                if (!m_owner->enabled())
+                {
+                    // Same "admit unconditionally, still not tracked" semantics as tryReserve().
+                    return true;
+                }
+
+                std::size_t current = m_owner->m_availableBytes.load(std::memory_order_relaxed);
+                do
+                {
+                    if (additionalBytes > current)
+                    {
+                        return false; // would exceed the budget
+                    }
+                } while (!m_owner->m_availableBytes.compare_exchange_weak(
+                    current, current - additionalBytes, std::memory_order_acq_rel, std::memory_order_relaxed));
+
+                m_bytes += additionalBytes;
+                return true;
+            }
+
         private:
             friend class InFlightBudget;
 

--- a/src/remoted/remoted_module/src/remotedModuleFacade.hpp
+++ b/src/remoted/remoted_module/src/remotedModuleFacade.hpp
@@ -31,6 +31,7 @@
 #include "control/metrics.hpp"
 #include "control/taskClient.hpp"
 #include "control/wazuhDBClient.hpp"
+#include "decoding/bodyDecoder.hpp"
 #include "downstream/asioUdsHttpClient.hpp"
 #include "downstream/deferredForwarder.hpp"
 #include "downstream/deferredWorkLimiter.hpp"
@@ -238,8 +239,15 @@ private:
                                                 : remoted::auth::Keystore::kDefaultRefreshIntervalSeconds;
         m_keystore =
             std::make_shared<remoted::auth::Keystore>(remoted::auth::Keystore::kDefaultPath, keystoreRefreshSeconds);
-        m_authGateway =
-            std::make_unique<remoted::endpoints::AuthGateway>(remoted::auth::buildAuthConfig(m_config), m_keystore);
+        // The Content-Encoding contract is composed in here rather than built into the gateway, so
+        // the auth layer stays about authentication only. Configured once on the gateway (not per
+        // route), so every authenticated endpoint gets it and none can accidentally opt out.
+        const auto authConfig = remoted::auth::buildAuthConfig(m_config);
+        m_authGateway = std::make_unique<remoted::endpoints::AuthGateway>(
+            authConfig,
+            m_keystore,
+            std::make_shared<const remoted::decoding::BodyDecoder>(
+                *m_httpServer, m_config.http_content_encoding_enabled));
 
         // Deferred-work limiter: bounds requests parked awaiting a downstream service. A slot is
         // held from the moment a request enters the deferred stage until its reply is delivered;

--- a/src/remoted/remoted_module/test/CMakeLists.txt
+++ b/src/remoted/remoted_module/test/CMakeLists.txt
@@ -28,7 +28,14 @@ target_link_libraries(
   # shutdownRace_test.cpp drives a real TLS client (asio::ssl) against a live RestinioHttpServer;
   # remoted_module links ssl/crypto PRIVATE (via ext_restinio), so this target needs its own link.
   ssl
-  crypto)
+  crypto
+  # zstdDecoder_test.cpp's format-confusion test (a gzip stream fed to the zstd decoder) builds a
+  # gzip fixture via zlib's deflate() directly (gzipTestHelper.hpp) -- production no longer uses
+  # zlib at all (gzip support was removed), so this test-only need gets its own explicit link.
+  ext_zlib
+  # authGateway_test.cpp/zstdDecoder_test.cpp build zstd fixtures directly with ZSTD_compress();
+  # remoted_module links ext_zstd PRIVATE, so this target needs its own link too.
+  ext_zstd)
 
 target_include_directories(
   remoted_module_utest

--- a/src/remoted/remoted_module/test/unit/authConfig_test.cpp
+++ b/src/remoted/remoted_module/test/unit/authConfig_test.cpp
@@ -67,3 +67,4 @@ TEST(AuthConfigTest, NegativeValuesFallBackToDefaults)
     EXPECT_EQ(config.maxRequestAgeSeconds, 300);
     EXPECT_EQ(config.maxBodySize, 10U * 1024U * 1024U);
 }
+

--- a/src/remoted/remoted_module/test/unit/authGateway_test.cpp
+++ b/src/remoted/remoted_module/test/unit/authGateway_test.cpp
@@ -11,7 +11,9 @@
 
 #include "auth/cmac.hpp"
 #include "endpoints/authGateway.hpp"
+#include "gzipTestHelper.hpp"
 #include "http_server/IHttpServer.hpp"
+#include "zstdTestHelper.hpp"
 
 #include <gtest/gtest.h>
 
@@ -150,6 +152,15 @@ namespace
         request.body = body;
         request.headers.emplace("protocol-version", "1");
         request.headers.emplace("authorization", buildAuthorization("POST", "/stateless", body, ts));
+        return request;
+    }
+
+    // Same as signedRequest(), plus a Content-Encoding header. The MAC still covers exactly
+    // `body` -- whatever the caller passes as the wire bytes, compressed or not.
+    HttpRequest signedRequestWithContentEncoding(const std::string& body, const std::string& encoding)
+    {
+        auto request = signedRequest(body);
+        request.headers.emplace("content-encoding", encoding);
         return request;
     }
 } // namespace
@@ -378,4 +389,217 @@ TEST(AuthGatewayTest, KeystoreThrowDuringAuthYields500)
     ASSERT_TRUE(responder->captured.has_value());
     EXPECT_EQ(responder->captured->status, 500);
     EXPECT_FALSE(handlerCalled); // the throw happened during auth, before the handler ever ran
+}
+
+// ---------------------------------------------------------------------------
+// Content-Encoding: zstd is the only supported encoding -- gzip was dropped.
+// ---------------------------------------------------------------------------
+
+TEST(AuthGatewayTest, GzipContentEncodingIsNowUnsupportedYields415AndSkipsHandler)
+{
+    // Regression guard: zstd is the only supported Content-Encoding. A well-formed gzip body
+    // must be rejected as unsupported, not silently decompressed.
+    FakeHttpServer server;
+    auto gateway = makeGateway();
+
+    const auto compressed = remoted::testutil::gzipCompress("some payload");
+
+    bool handlerCalled = false;
+    gateway.addAuthenticatedRoute(
+        server,
+        Method::Post,
+        "/stateless",
+        [&handlerCalled](std::shared_ptr<const remoted::auth::AuthenticatedRequest>,
+                        std::shared_ptr<IHttpResponder> responder)
+        {
+            handlerCalled = true;
+            responder->send(HttpResponse {200, "", {}});
+        });
+
+    const auto request = signedRequestWithContentEncoding(compressed, "gzip");
+    auto responder = std::make_shared<CapturingResponder>();
+    server.dispatch(Method::Post, "/stateless", request, responder);
+
+    ASSERT_TRUE(responder->captured.has_value());
+    EXPECT_EQ(responder->captured->status, 415);
+    EXPECT_FALSE(handlerCalled);
+}
+
+TEST(AuthGatewayTest, NoContentEncodingPassesBodyThroughUnchanged)
+{
+    // Regression guard: absence of the header must keep today's uncompressed behavior exactly.
+    FakeHttpServer server;
+    auto gateway = makeGateway();
+
+    std::string seenBody;
+    gateway.addAuthenticatedRoute(
+        server,
+        Method::Post,
+        "/stateless",
+        [&seenBody](std::shared_ptr<const remoted::auth::AuthenticatedRequest> authReq,
+                   std::shared_ptr<IHttpResponder> responder)
+        {
+            seenBody = std::string {authReq->payload.bytes()};
+            responder->send(HttpResponse::json(200, "{}"));
+        });
+
+    const auto request = signedRequest("plain uncompressed body");
+    auto responder = std::make_shared<CapturingResponder>();
+    server.dispatch(Method::Post, "/stateless", request, responder);
+
+    ASSERT_TRUE(responder->captured.has_value());
+    EXPECT_EQ(responder->captured->status, 200);
+    EXPECT_EQ(seenBody, "plain uncompressed body");
+}
+
+TEST(AuthGatewayTest, UnsupportedContentEncodingYields415AndSkipsHandler)
+{
+    FakeHttpServer server;
+    auto gateway = makeGateway();
+
+    bool handlerCalled = false;
+    gateway.addAuthenticatedRoute(
+        server,
+        Method::Post,
+        "/stateless",
+        [&handlerCalled](std::shared_ptr<const remoted::auth::AuthenticatedRequest>,
+                        std::shared_ptr<IHttpResponder> responder)
+        {
+            handlerCalled = true;
+            responder->send(HttpResponse {200, "", {}});
+        });
+
+    const auto request = signedRequestWithContentEncoding("some-body", "br");
+    auto responder = std::make_shared<CapturingResponder>();
+    server.dispatch(Method::Post, "/stateless", request, responder);
+
+    ASSERT_TRUE(responder->captured.has_value());
+    EXPECT_EQ(responder->captured->status, 415);
+    EXPECT_FALSE(handlerCalled);
+}
+
+// ---------------------------------------------------------------------------
+// Content-Encoding: zstd
+// ---------------------------------------------------------------------------
+
+TEST(AuthGatewayTest, ZstdEncodedBodyIsDecompressedBeforeHandler)
+{
+    FakeHttpServer server;
+    auto gateway = makeGateway();
+
+    const std::string plain = R"(H {"wazuh":{"agent":{"id":"1"}}})";
+    const auto compressed = remoted::testutil::zstdCompress(plain);
+
+    std::string seenBody;
+    gateway.addAuthenticatedRoute(
+        server,
+        Method::Post,
+        "/stateless",
+        [&seenBody](std::shared_ptr<const remoted::auth::AuthenticatedRequest> authReq,
+                   std::shared_ptr<IHttpResponder> responder)
+        {
+            seenBody = std::string {authReq->payload.bytes()};
+            responder->send(HttpResponse::json(200, R"({"ok":true})"));
+        });
+
+    // Signed over the COMPRESSED bytes: the MAC always covers the exact wire body.
+    const auto request = signedRequestWithContentEncoding(compressed, "zstd");
+    auto responder = std::make_shared<CapturingResponder>();
+    server.dispatch(Method::Post, "/stateless", request, responder);
+
+    ASSERT_TRUE(responder->captured.has_value());
+    EXPECT_EQ(responder->captured->status, 200);
+    EXPECT_EQ(seenBody, plain); // the handler saw the DECOMPRESSED body, not the wire bytes
+}
+
+TEST(AuthGatewayTest, ZstdContentEncodingHeaderValueIsCaseInsensitive)
+{
+    FakeHttpServer server;
+    auto gateway = makeGateway();
+
+    const std::string plain = "some payload";
+    const auto compressed = remoted::testutil::zstdCompress(plain);
+
+    std::string seenBody;
+    gateway.addAuthenticatedRoute(
+        server,
+        Method::Post,
+        "/stateless",
+        [&seenBody](std::shared_ptr<const remoted::auth::AuthenticatedRequest> authReq,
+                   std::shared_ptr<IHttpResponder> responder)
+        {
+            seenBody = std::string {authReq->payload.bytes()};
+            responder->send(HttpResponse::json(200, "{}"));
+        });
+
+    const auto request = signedRequestWithContentEncoding(compressed, "ZSTD");
+    auto responder = std::make_shared<CapturingResponder>();
+    server.dispatch(Method::Post, "/stateless", request, responder);
+
+    ASSERT_TRUE(responder->captured.has_value());
+    EXPECT_EQ(responder->captured->status, 200);
+    EXPECT_EQ(seenBody, plain);
+}
+
+TEST(AuthGatewayTest, MalformedZstdBodyYields400AndSkipsHandler)
+{
+    FakeHttpServer server;
+    auto gateway = makeGateway();
+
+    bool handlerCalled = false;
+    gateway.addAuthenticatedRoute(
+        server,
+        Method::Post,
+        "/stateless",
+        [&handlerCalled](std::shared_ptr<const remoted::auth::AuthenticatedRequest>,
+                        std::shared_ptr<IHttpResponder> responder)
+        {
+            handlerCalled = true;
+            responder->send(HttpResponse {200, "", {}});
+        });
+
+    // Claims zstd, but the body is not a zstd frame at all.
+    const auto request = signedRequestWithContentEncoding("definitely not a zstd frame", "zstd");
+    auto responder = std::make_shared<CapturingResponder>();
+    server.dispatch(Method::Post, "/stateless", request, responder);
+
+    ASSERT_TRUE(responder->captured.has_value());
+    EXPECT_EQ(responder->captured->status, 400);
+    EXPECT_FALSE(handlerCalled);
+}
+
+TEST(AuthGatewayTest, ZstdDecompressedBodyExceedingConfiguredLimitYields413AndSkipsHandler)
+{
+    FakeHttpServer server;
+
+    // A cap comfortably above the (small, highly-compressed) wire size but below the real
+    // decompressed size -- otherwise the auth layer's own wire-body cap (same field) would
+    // reject the request before decompression is ever attempted.
+    remoted::auth::AuthConfig cfg;
+    cfg.maxBodySize = 100;
+    AuthGateway gateway {cfg, std::make_shared<FakeKeystore>()};
+
+    const std::string plain(1000, 'a'); // highly repetitive -> compresses far below 100 bytes
+    const auto compressed = remoted::testutil::zstdCompress(plain);
+    ASSERT_LT(compressed.size(), cfg.maxBodySize);
+
+    bool handlerCalled = false;
+    gateway.addAuthenticatedRoute(
+        server,
+        Method::Post,
+        "/stateless",
+        [&handlerCalled](std::shared_ptr<const remoted::auth::AuthenticatedRequest>,
+                        std::shared_ptr<IHttpResponder> responder)
+        {
+            handlerCalled = true;
+            responder->send(HttpResponse {200, "", {}});
+        });
+
+    const auto request = signedRequestWithContentEncoding(compressed, "zstd");
+    auto responder = std::make_shared<CapturingResponder>();
+    server.dispatch(Method::Post, "/stateless", request, responder);
+
+    ASSERT_TRUE(responder->captured.has_value());
+    EXPECT_EQ(responder->captured->status, 413);
+    EXPECT_FALSE(handlerCalled);
 }

--- a/src/remoted/remoted_module/test/unit/authGateway_test.cpp
+++ b/src/remoted/remoted_module/test/unit/authGateway_test.cpp
@@ -11,71 +11,34 @@
 
 #include "auth/cmac.hpp"
 #include "endpoints/authGateway.hpp"
-#include "gzipTestHelper.hpp"
+#include "decoding/bodyDecoder.hpp"
+#include "fakeHttpServer.hpp"
 #include "http_server/IHttpServer.hpp"
 #include "zstdTestHelper.hpp"
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <ctime>
-#include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <string_view>
+#include <thread>
 #include <utility>
 #include <vector>
 
 using namespace remoted::http;
 using namespace remoted::endpoints;
+using namespace remoted::decoding;
 
 namespace
 {
-    // Fake transport: stores registered routes so a test can dispatch them directly
-    // (synchronously, no sockets), exactly as the gateway's wrapper would run on a
-    // worker thread.
-    class FakeHttpServer final : public IHttpServer
-    {
-    public:
-        void addRoute(Method method,
-                      const std::string& path,
-                      RouteHandler handler,
-                      bool /*countAgainstBudget*/,
-                      ResponseMode mode) override
-        {
-            m_routes[{method, path}] = std::move(handler);
-            m_modes[{method, path}] = mode;
-        }
-
-        /// @brief The response mode a route was registered with, for asserting the registration.
-        ResponseMode modeOf(Method method, const std::string& path) const
-        {
-            const auto it = m_modes.find({method, path});
-            return it == m_modes.end() ? ResponseMode::Buffered : it->second;
-        }
-        void start(const HttpServerConfig&) override {}
-        void stopAccepting() noexcept override {}
-        void stop() noexcept override {}
-
-        void dispatch(Method method,
-                      const std::string& path,
-                      const HttpRequest& request,
-                      std::shared_ptr<IHttpResponder> responder)
-        {
-            // The transport hands the handler a shared_ptr<const>; mirror that here.
-            m_routes.at({method, path})(std::make_shared<const HttpRequest>(request), std::move(responder));
-        }
-
-        bool hasRoute(Method method, const std::string& path) const
-        {
-            return m_routes.count({method, path}) != 0;
-        }
-
-    private:
-        std::map<std::pair<Method, std::string>, RouteHandler> m_routes;
-        std::map<std::pair<Method, std::string>, ResponseMode> m_modes;
-    };
+    using remoted::testutil::FakeHttpServer;
 
     // Keystore stub: knows one agent (numeric id 1, i.e. "001" on the wire); anything else is unknown.
     class FakeKeystore final : public remoted::auth::IAgentKeystore
@@ -116,9 +79,43 @@ namespace
         std::optional<HttpResponse> captured;
     };
 
+    // IBodyDecoder stub backed by a lambda, so each test states just the behavior it cares about
+    // without declaring its own class. The gateway's contract is "run the step, map its result", so
+    // these deliberately never compress anything -- the real decoder is tested in bodyDecoder_test.
+    class StubBodyDecoder final : public IBodyDecoder
+    {
+    public:
+        using Fn = std::function<remoted::auth::AuthError(ContentEncoding, remoted::auth::Payload&)>;
+
+        explicit StubBodyDecoder(Fn fn)
+            : m_fn {std::move(fn)}
+        {
+        }
+
+        remoted::auth::AuthError decode(ContentEncoding encoding, remoted::auth::Payload& payload) const override
+        {
+            return m_fn(encoding, payload);
+        }
+
+    private:
+        Fn m_fn;
+    };
+
+    std::shared_ptr<const IBodyDecoder> stubDecoder(StubBodyDecoder::Fn fn)
+    {
+        return std::make_shared<const StubBodyDecoder>(std::move(fn));
+    }
+
+    // For the tests that are about authentication itself: accepts whatever it is handed and leaves
+    // the body alone, so the decoding step is present (it is a required dependency) but inert.
+    std::shared_ptr<const IBodyDecoder> passthroughDecoder()
+    {
+        return stubDecoder([](ContentEncoding, remoted::auth::Payload&) { return remoted::auth::AuthError::None; });
+    }
+
     AuthGateway makeGateway()
     {
-        return AuthGateway {remoted::auth::AuthConfig {}, std::make_shared<FakeKeystore>()};
+        return AuthGateway {remoted::auth::AuthConfig {}, std::make_shared<FakeKeystore>(), passthroughDecoder()};
     }
 
     // Build a valid "Wazuh <id>:<ts>:<mac>" Authorization for agent 001, signing the same
@@ -370,7 +367,7 @@ TEST(AuthGatewayTest, HandlerExceptionYields500)
 TEST(AuthGatewayTest, KeystoreThrowDuringAuthYields500)
 {
     FakeHttpServer server;
-    AuthGateway gateway {remoted::auth::AuthConfig {}, std::make_shared<ThrowingKeystore>()};
+    AuthGateway gateway {remoted::auth::AuthConfig {}, std::make_shared<ThrowingKeystore>(), passthroughDecoder()};
 
     bool handlerCalled = false;
     gateway.addAuthenticatedRoute(server,
@@ -392,56 +389,208 @@ TEST(AuthGatewayTest, KeystoreThrowDuringAuthYields500)
 }
 
 // ---------------------------------------------------------------------------
-// Content-Encoding: zstd is the only supported encoding -- gzip was dropped.
+// Body decoding: the gateway's contract with an injected BodyDecoder
+//
+// These use a STUB decoder on purpose. The gateway's job is to run the step and map its result --
+// it must not know what any encoding means, so nothing here compresses anything. The real zstd
+// decoder has its own tests (bodyDecoder_test.cpp); the integration of the two is covered further
+// below.
 // ---------------------------------------------------------------------------
 
-TEST(AuthGatewayTest, GzipContentEncodingIsNowUnsupportedYields415AndSkipsHandler)
+TEST(AuthGatewayTest, DecoderSeesTheParsedEncodingAndTheVerifiedBody)
 {
-    // Regression guard: zstd is the only supported Content-Encoding. A well-formed gzip body
-    // must be rejected as unsupported, not silently decompressed.
     FakeHttpServer server;
-    auto gateway = makeGateway();
+    auto seenEncoding = ContentEncoding::Unsupported; // anything but what we expect
+    std::string seenBytes;
+    AuthGateway gateway {remoted::auth::AuthConfig {},
+                         std::make_shared<FakeKeystore>(),
+                         stubDecoder(
+                             [&seenEncoding, &seenBytes](ContentEncoding encoding, remoted::auth::Payload& payload)
+                             {
+                                 seenEncoding = encoding;
+                                 seenBytes = std::string {payload.bytes()};
+                                 return remoted::auth::AuthError::None;
+                             })};
 
-    const auto compressed = remoted::testutil::gzipCompress("some payload");
-
-    bool handlerCalled = false;
     gateway.addAuthenticatedRoute(
         server,
         Method::Post,
         "/stateless",
-        [&handlerCalled](std::shared_ptr<const remoted::auth::AuthenticatedRequest>,
-                        std::shared_ptr<IHttpResponder> responder)
-        {
-            handlerCalled = true;
-            responder->send(HttpResponse {200, "", {}});
-        });
+        [](std::shared_ptr<const remoted::auth::AuthenticatedRequest>, std::shared_ptr<IHttpResponder> responder)
+        { responder->send(HttpResponse::json(200, "{}")); });
 
-    const auto request = signedRequestWithContentEncoding(compressed, "gzip");
+    const auto request = signedRequestWithContentEncoding("the-wire-bytes", "zstd");
+    auto responder = std::make_shared<CapturingResponder>();
+    server.dispatch(Method::Post, "/stateless", request, responder);
+
+    // The gateway parses the header and hands over the enum, not the raw string.
+    EXPECT_EQ(seenEncoding, ContentEncoding::Zstd);
+    EXPECT_EQ(seenBytes, "the-wire-bytes"); // the exact bytes the MAC covered
+}
+
+TEST(AuthGatewayTest, DecoderIsStillRunWithNoEncodingSoItOwnsThePassthrough)
+{
+    // The gateway does not decide whether decoding applies -- it always defers to the decoder, which
+    // is what lets "no Content-Encoding means passthrough" be the decoder's rule rather than a
+    // second copy of that logic here.
+    FakeHttpServer server;
+    bool called = false;
+    auto seenEncoding = ContentEncoding::Unsupported;
+    AuthGateway gateway {remoted::auth::AuthConfig {},
+                         std::make_shared<FakeKeystore>(),
+                         stubDecoder(
+                             [&called, &seenEncoding](ContentEncoding encoding, remoted::auth::Payload&)
+                             {
+                                 called = true;
+                                 seenEncoding = encoding;
+                                 return remoted::auth::AuthError::None;
+                             })};
+
+    gateway.addAuthenticatedRoute(
+        server,
+        Method::Post,
+        "/stateless",
+        [](std::shared_ptr<const remoted::auth::AuthenticatedRequest>, std::shared_ptr<IHttpResponder> responder)
+        { responder->send(HttpResponse::json(200, "{}")); });
+
+    const auto request = signedRequest("plain body"); // no Content-Encoding header at all
+    auto responder = std::make_shared<CapturingResponder>();
+    server.dispatch(Method::Post, "/stateless", request, responder);
+
+    EXPECT_TRUE(called);
+    EXPECT_EQ(seenEncoding, ContentEncoding::None);
+}
+
+TEST(AuthGatewayTest, DecodedPayloadIsWhatTheHandlerReceives)
+{
+    FakeHttpServer server;
+    auto replacement = std::make_shared<std::string>("decoded body");
+    AuthGateway gateway {remoted::auth::AuthConfig {},
+                         std::make_shared<FakeKeystore>(),
+                         stubDecoder(
+                             [replacement](ContentEncoding, remoted::auth::Payload& payload)
+                             {
+                                 payload = remoted::auth::Payload {*replacement, replacement};
+                                 return remoted::auth::AuthError::None;
+                             })};
+
+    std::string seenBody;
+    gateway.addAuthenticatedRoute(server,
+                                  Method::Post,
+                                  "/stateless",
+                                  [&seenBody](std::shared_ptr<const remoted::auth::AuthenticatedRequest> authReq,
+                                              std::shared_ptr<IHttpResponder> responder)
+                                  {
+                                      seenBody = std::string {authReq->payload.bytes()};
+                                      responder->send(HttpResponse::json(200, "{}"));
+                                  });
+
+    const auto request = signedRequestWithContentEncoding("wire bytes", "some-encoding");
     auto responder = std::make_shared<CapturingResponder>();
     server.dispatch(Method::Post, "/stateless", request, responder);
 
     ASSERT_TRUE(responder->captured.has_value());
-    EXPECT_EQ(responder->captured->status, 415);
+    EXPECT_EQ(responder->captured->status, 200);
+    EXPECT_EQ(seenBody, "decoded body"); // not the wire bytes
+}
+
+// Each AuthError a decoder can return must reach the client as that error's own status, unchanged.
+class AuthGatewayDecoderErrorTest : public ::testing::TestWithParam<std::pair<remoted::auth::AuthError, int>>
+{
+};
+
+TEST_P(AuthGatewayDecoderErrorTest, DecoderErrorIsAnsweredAndTheHandlerIsSkipped)
+{
+    const auto [decoderError, expectedStatus] = GetParam();
+
+    FakeHttpServer server;
+    AuthGateway gateway {remoted::auth::AuthConfig {},
+                         std::make_shared<FakeKeystore>(),
+                         stubDecoder([decoderError = decoderError](ContentEncoding, remoted::auth::Payload&)
+                                     { return decoderError; })};
+
+    bool handlerCalled = false;
+    gateway.addAuthenticatedRoute(server,
+                                  Method::Post,
+                                  "/stateless",
+                                  [&handlerCalled](std::shared_ptr<const remoted::auth::AuthenticatedRequest>,
+                                                   std::shared_ptr<IHttpResponder> responder)
+                                  {
+                                      handlerCalled = true;
+                                      responder->send(HttpResponse {200, "", {}});
+                                  });
+
+    const auto request = signedRequestWithContentEncoding("body", "some-encoding");
+    auto responder = std::make_shared<CapturingResponder>();
+    server.dispatch(Method::Post, "/stateless", request, responder);
+
+    ASSERT_TRUE(responder->captured.has_value());
+    EXPECT_EQ(responder->captured->status, expectedStatus);
     EXPECT_FALSE(handlerCalled);
 }
 
-TEST(AuthGatewayTest, NoContentEncodingPassesBodyThroughUnchanged)
+INSTANTIATE_TEST_SUITE_P(
+    DecoderErrors,
+    AuthGatewayDecoderErrorTest,
+    ::testing::Values(std::make_pair(remoted::auth::AuthError::UnsupportedContentEncoding, 415),
+                      std::make_pair(remoted::auth::AuthError::MalformedContentEncoding, 400),
+                      std::make_pair(remoted::auth::AuthError::BodyTooLarge, 413)));
+
+TEST(AuthGatewayTest, DecoderIsNotRunWhenAuthenticationFails)
 {
-    // Regression guard: absence of the header must keep today's uncompressed behavior exactly.
+    // The security property the MAC-over-wire-bytes ordering exists for: an unauthenticated peer
+    // must never reach a decoder, so it cannot spend our CPU or memory on one.
     FakeHttpServer server;
-    auto gateway = makeGateway();
+    bool decoderCalled = false;
+    AuthGateway gateway {remoted::auth::AuthConfig {},
+                         std::make_shared<FakeKeystore>(),
+                         stubDecoder(
+                             [&decoderCalled](ContentEncoding, remoted::auth::Payload&)
+                             {
+                                 decoderCalled = true;
+                                 return remoted::auth::AuthError::None;
+                             })};
+
+    bool handlerCalled = false;
+    gateway.addAuthenticatedRoute(server,
+                                  Method::Post,
+                                  "/stateless",
+                                  [&handlerCalled](std::shared_ptr<const remoted::auth::AuthenticatedRequest>,
+                                                   std::shared_ptr<IHttpResponder> responder)
+                                  {
+                                      handlerCalled = true;
+                                      responder->send(HttpResponse {200, "", {}});
+                                  });
+
+    // Signed correctly, then the transmitted body is swapped -> the MAC no longer matches.
+    auto request = signedRequestWithContentEncoding("signed body", "some-encoding");
+    request.body = "tampered body";
+    auto responder = std::make_shared<CapturingResponder>();
+    server.dispatch(Method::Post, "/stateless", request, responder);
+
+    ASSERT_TRUE(responder->captured.has_value());
+    EXPECT_EQ(responder->captured->status, 401);
+    EXPECT_FALSE(decoderCalled);
+    EXPECT_FALSE(handlerCalled);
+}
+
+TEST(AuthGatewayTest, AnUntouchedPayloadReachesTheHandlerAsSent)
+{
+    // The decoder's passthrough case, seen from the gateway: when the step returns without replacing
+    // the payload, the handler must receive the wire bytes unchanged.
+    FakeHttpServer server;
+    auto gateway = makeGateway(); // passthrough decoder
 
     std::string seenBody;
-    gateway.addAuthenticatedRoute(
-        server,
-        Method::Post,
-        "/stateless",
-        [&seenBody](std::shared_ptr<const remoted::auth::AuthenticatedRequest> authReq,
-                   std::shared_ptr<IHttpResponder> responder)
-        {
-            seenBody = std::string {authReq->payload.bytes()};
-            responder->send(HttpResponse::json(200, "{}"));
-        });
+    gateway.addAuthenticatedRoute(server,
+                                  Method::Post,
+                                  "/stateless",
+                                  [&seenBody](std::shared_ptr<const remoted::auth::AuthenticatedRequest> authReq,
+                                              std::shared_ptr<IHttpResponder> responder)
+                                  {
+                                      seenBody = std::string {authReq->payload.bytes()};
+                                      responder->send(HttpResponse::json(200, "{}"));
+                                  });
 
     const auto request = signedRequest("plain uncompressed body");
     auto responder = std::make_shared<CapturingResponder>();
@@ -452,55 +601,30 @@ TEST(AuthGatewayTest, NoContentEncodingPassesBodyThroughUnchanged)
     EXPECT_EQ(seenBody, "plain uncompressed body");
 }
 
-TEST(AuthGatewayTest, UnsupportedContentEncodingYields415AndSkipsHandler)
-{
-    FakeHttpServer server;
-    auto gateway = makeGateway();
-
-    bool handlerCalled = false;
-    gateway.addAuthenticatedRoute(
-        server,
-        Method::Post,
-        "/stateless",
-        [&handlerCalled](std::shared_ptr<const remoted::auth::AuthenticatedRequest>,
-                        std::shared_ptr<IHttpResponder> responder)
-        {
-            handlerCalled = true;
-            responder->send(HttpResponse {200, "", {}});
-        });
-
-    const auto request = signedRequestWithContentEncoding("some-body", "br");
-    auto responder = std::make_shared<CapturingResponder>();
-    server.dispatch(Method::Post, "/stateless", request, responder);
-
-    ASSERT_TRUE(responder->captured.has_value());
-    EXPECT_EQ(responder->captured->status, 415);
-    EXPECT_FALSE(handlerCalled);
-}
-
 // ---------------------------------------------------------------------------
-// Content-Encoding: zstd
+// Integration: the gateway wired to the real zstd decoder
 // ---------------------------------------------------------------------------
 
-TEST(AuthGatewayTest, ZstdEncodedBodyIsDecompressedBeforeHandler)
+TEST(AuthGatewayTest, RealZstdBodyReachesTheHandlerDecompressed)
 {
     FakeHttpServer server;
-    auto gateway = makeGateway();
+    AuthGateway gateway {remoted::auth::AuthConfig {},
+                         std::make_shared<FakeKeystore>(),
+                         std::make_shared<const remoted::decoding::BodyDecoder>(server, /*enabled=*/true)};
 
     const std::string plain = R"(H {"wazuh":{"agent":{"id":"1"}}})";
     const auto compressed = remoted::testutil::zstdCompress(plain);
 
     std::string seenBody;
-    gateway.addAuthenticatedRoute(
-        server,
-        Method::Post,
-        "/stateless",
-        [&seenBody](std::shared_ptr<const remoted::auth::AuthenticatedRequest> authReq,
-                   std::shared_ptr<IHttpResponder> responder)
-        {
-            seenBody = std::string {authReq->payload.bytes()};
-            responder->send(HttpResponse::json(200, R"({"ok":true})"));
-        });
+    gateway.addAuthenticatedRoute(server,
+                                  Method::Post,
+                                  "/stateless",
+                                  [&seenBody](std::shared_ptr<const remoted::auth::AuthenticatedRequest> authReq,
+                                              std::shared_ptr<IHttpResponder> responder)
+                                  {
+                                      seenBody = std::string {authReq->payload.bytes()};
+                                      responder->send(HttpResponse::json(200, "{}"));
+                                  });
 
     // Signed over the COMPRESSED bytes: the MAC always covers the exact wire body.
     const auto request = signedRequestWithContentEncoding(compressed, "zstd");
@@ -509,97 +633,101 @@ TEST(AuthGatewayTest, ZstdEncodedBodyIsDecompressedBeforeHandler)
 
     ASSERT_TRUE(responder->captured.has_value());
     EXPECT_EQ(responder->captured->status, 200);
-    EXPECT_EQ(seenBody, plain); // the handler saw the DECOMPRESSED body, not the wire bytes
-}
-
-TEST(AuthGatewayTest, ZstdContentEncodingHeaderValueIsCaseInsensitive)
-{
-    FakeHttpServer server;
-    auto gateway = makeGateway();
-
-    const std::string plain = "some payload";
-    const auto compressed = remoted::testutil::zstdCompress(plain);
-
-    std::string seenBody;
-    gateway.addAuthenticatedRoute(
-        server,
-        Method::Post,
-        "/stateless",
-        [&seenBody](std::shared_ptr<const remoted::auth::AuthenticatedRequest> authReq,
-                   std::shared_ptr<IHttpResponder> responder)
-        {
-            seenBody = std::string {authReq->payload.bytes()};
-            responder->send(HttpResponse::json(200, "{}"));
-        });
-
-    const auto request = signedRequestWithContentEncoding(compressed, "ZSTD");
-    auto responder = std::make_shared<CapturingResponder>();
-    server.dispatch(Method::Post, "/stateless", request, responder);
-
-    ASSERT_TRUE(responder->captured.has_value());
-    EXPECT_EQ(responder->captured->status, 200);
     EXPECT_EQ(seenBody, plain);
 }
 
-TEST(AuthGatewayTest, MalformedZstdBodyYields400AndSkipsHandler)
+TEST(AuthGatewayTest, ManyConcurrentZstdRequestsNeverOvershootTheBudget)
 {
-    FakeHttpServer server;
-    auto gateway = makeGateway();
+    // The scenario the reservations exist for: many agents posting compressed bodies at once, each
+    // small on the wire but expensive to decompress. Were the budget merely CONSULTED (read a "free"
+    // figure, then proceed), all N would read the same figure and all proceed, together using a
+    // multiple of what the budget allows. Because the decoder's buffers and its growing output are
+    // actually RESERVED, the ones that don't fit are turned away with 413 instead.
+    constexpr int kRequests = 50;
+    constexpr std::size_t kPayloadSize = 1024 * 1024; // 1 MiB decompressed per request
+    constexpr std::size_t kBudget = 20 * 1024 * 1024; // room for well under all 50 at once
+    FakeHttpServer server {kBudget};
+    AuthGateway gateway {remoted::auth::AuthConfig {},
+                         std::make_shared<FakeKeystore>(),
+                         std::make_shared<const remoted::decoding::BodyDecoder>(server, /*enabled=*/true)};
 
-    bool handlerCalled = false;
-    gateway.addAuthenticatedRoute(
-        server,
-        Method::Post,
-        "/stateless",
-        [&handlerCalled](std::shared_ptr<const remoted::auth::AuthenticatedRequest>,
-                        std::shared_ptr<IHttpResponder> responder)
-        {
-            handlerCalled = true;
-            responder->send(HttpResponse {200, "", {}});
-        });
-
-    // Claims zstd, but the body is not a zstd frame at all.
-    const auto request = signedRequestWithContentEncoding("definitely not a zstd frame", "zstd");
-    auto responder = std::make_shared<CapturingResponder>();
-    server.dispatch(Method::Post, "/stateless", request, responder);
-
-    ASSERT_TRUE(responder->captured.has_value());
-    EXPECT_EQ(responder->captured->status, 400);
-    EXPECT_FALSE(handlerCalled);
-}
-
-TEST(AuthGatewayTest, ZstdDecompressedBodyExceedingConfiguredLimitYields413AndSkipsHandler)
-{
-    FakeHttpServer server;
-
-    // A cap comfortably above the (small, highly-compressed) wire size but below the real
-    // decompressed size -- otherwise the auth layer's own wire-body cap (same field) would
-    // reject the request before decompression is ever attempted.
-    remoted::auth::AuthConfig cfg;
-    cfg.maxBodySize = 100;
-    AuthGateway gateway {cfg, std::make_shared<FakeKeystore>()};
-
-    const std::string plain(1000, 'a'); // highly repetitive -> compresses far below 100 bytes
+    const std::string plain(kPayloadSize, 'q');
     const auto compressed = remoted::testutil::zstdCompress(plain);
-    ASSERT_LT(compressed.size(), cfg.maxBodySize);
 
-    bool handlerCalled = false;
-    gateway.addAuthenticatedRoute(
-        server,
-        Method::Post,
-        "/stateless",
-        [&handlerCalled](std::shared_ptr<const remoted::auth::AuthenticatedRequest>,
-                        std::shared_ptr<IHttpResponder> responder)
-        {
-            handlerCalled = true;
-            responder->send(HttpResponse {200, "", {}});
-        });
+    // Handlers HOLD their payloads (under a mutex) instead of letting them go, so the successful
+    // reservations pile up and the budget is genuinely driven to exhaustion rather than each request
+    // tidily freeing up before the next arrives.
+    std::mutex mutex;
+    std::vector<std::shared_ptr<const remoted::auth::AuthenticatedRequest>> held;
+    std::atomic<int> handlerCalls {0};
+
+    gateway.addAuthenticatedRoute(server,
+                                  Method::Post,
+                                  "/stateless",
+                                  [&mutex, &held, &handlerCalls](
+                                      std::shared_ptr<const remoted::auth::AuthenticatedRequest> authReq,
+                                      std::shared_ptr<IHttpResponder> responder)
+                                  {
+                                      handlerCalls.fetch_add(1);
+                                      {
+                                          std::lock_guard<std::mutex> lock {mutex};
+                                          held.push_back(std::move(authReq));
+                                      }
+                                      responder->send(HttpResponse::json(200, "{}"));
+                                  });
 
     const auto request = signedRequestWithContentEncoding(compressed, "zstd");
-    auto responder = std::make_shared<CapturingResponder>();
-    server.dispatch(Method::Post, "/stateless", request, responder);
+    std::vector<std::shared_ptr<CapturingResponder>> responders(kRequests);
+    std::vector<std::thread> threads;
+    threads.reserve(kRequests);
 
-    ASSERT_TRUE(responder->captured.has_value());
-    EXPECT_EQ(responder->captured->status, 413);
-    EXPECT_FALSE(handlerCalled);
+    for (int i = 0; i < kRequests; ++i)
+    {
+        responders[static_cast<std::size_t>(i)] = std::make_shared<CapturingResponder>();
+        threads.emplace_back(
+            [&server, &request, &responders, i]
+            { server.dispatch(Method::Post, "/stateless", request, responders[static_cast<std::size_t>(i)]); });
+    }
+    for (auto& thread : threads)
+    {
+        thread.join();
+    }
+
+    int accepted = 0;
+    int shed = 0;
+    for (const auto& responder : responders)
+    {
+        ASSERT_TRUE(responder->captured.has_value());
+        const int status = responder->captured->status;
+        if (status == 200)
+        {
+            ++accepted;
+        }
+        else
+        {
+            // 413 is the only other outcome allowed: no 500 (a crash/throw), no 400 (these frames
+            // are all perfectly valid), no silent success past the budget.
+            EXPECT_EQ(status, 413);
+            ++shed;
+        }
+    }
+
+    EXPECT_EQ(accepted + shed, kRequests);
+    // Both sides must actually be exercised: some got through (so this isn't passing because
+    // everything was rejected) and some were turned away (so the budget really did push back).
+    EXPECT_GT(accepted, 0);
+    EXPECT_GT(shed, 0);
+    EXPECT_EQ(handlerCalls.load(), accepted); // only the accepted ones reached the handler
+    // The decisive invariant: what got through fits in the budget. Without real reservations this
+    // would exceed it (up to 50 MiB of payload against a 20 MiB budget).
+    EXPECT_LE(static_cast<std::size_t>(accepted) * kPayloadSize, kBudget);
+
+    {
+        std::lock_guard<std::mutex> lock {mutex};
+        EXPECT_EQ(server.m_budget.availableBytes(), kBudget - static_cast<std::size_t>(accepted) * kPayloadSize);
+        held.clear();
+    }
+    // Releasing them restores the budget exactly, with nothing leaked by any thread.
+    EXPECT_EQ(server.m_budget.availableBytes(), kBudget);
+    EXPECT_EQ(server.m_budget.inFlightCount(), 0U);
 }

--- a/src/remoted/remoted_module/test/unit/bodyDecoder_test.cpp
+++ b/src/remoted/remoted_module/test/unit/bodyDecoder_test.cpp
@@ -1,0 +1,250 @@
+/*
+ * Wazuh remoted module (C++ worker bridge) - unit tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 3, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "decoding/bodyDecoder.hpp"
+#include "fakeHttpServer.hpp"
+#include "gzipTestHelper.hpp"
+#include "zstdTestHelper.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+using remoted::auth::AuthError;
+using remoted::auth::Payload;
+using remoted::decoding::ContentEncoding;
+using remoted::decoding::parseContentEncoding;
+using remoted::decoding::BodyDecoder;
+using remoted::testutil::FakeHttpServer;
+using remoted::testutil::zstdCompress;
+
+namespace
+{
+    // A Payload over caller-owned bytes, like the one AuthGateway hands the decoder (a view into
+    // the transport's request buffer, kept alive by a shared_ptr).
+    Payload payloadOver(const std::shared_ptr<std::string>& bytes)
+    {
+        return Payload {*bytes, bytes};
+    }
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Passthrough and encoding selection
+// ---------------------------------------------------------------------------
+
+TEST(BodyDecoderTest, EmptyContentEncodingLeavesThePayloadUntouched)
+{
+    FakeHttpServer server;
+    const BodyDecoder decoder {server, /*enabled=*/true};
+
+    auto bytes = std::make_shared<std::string>("plain uncompressed body");
+    auto payload = payloadOver(bytes);
+
+    EXPECT_EQ(decoder.decode(ContentEncoding::None, payload), AuthError::None);
+    EXPECT_EQ(payload.bytes(), "plain uncompressed body");
+    // Nothing was charged: an uncompressed body needs no decoding memory at all.
+    EXPECT_EQ(server.m_budget.inFlightCount(), 0U);
+}
+
+TEST(BodyDecoderTest, ZstdBodyIsDecompressed)
+{
+    FakeHttpServer server;
+    const BodyDecoder decoder {server, /*enabled=*/true};
+
+    const std::string plain = R"(H {"wazuh":{"agent":{"id":"1"}}})";
+    auto bytes = std::make_shared<std::string>(zstdCompress(plain));
+    auto payload = payloadOver(bytes);
+
+    EXPECT_EQ(decoder.decode(ContentEncoding::Zstd, payload), AuthError::None);
+    EXPECT_EQ(payload.bytes(), plain);
+}
+
+TEST(BodyDecoderTest, UnsupportedEncodingIsRejectedAndThePayloadLeftAlone)
+{
+    FakeHttpServer server;
+    const BodyDecoder decoder {server, /*enabled=*/true};
+
+    auto bytes = std::make_shared<std::string>("some-body");
+    auto payload = payloadOver(bytes);
+
+    EXPECT_EQ(decoder.decode(ContentEncoding::Unsupported, payload), AuthError::UnsupportedContentEncoding);
+    EXPECT_EQ(payload.bytes(), "some-body"); // rejected, so left as-is
+}
+
+TEST(BodyDecoderTest, AGzipBodyIsNeverDecodedEvenThoughItIsAValidGzipStream)
+{
+    // gzip was deliberately dropped in favor of zstd-only support. Mislabeling it as zstd must fail
+    // closed on the frame check rather than be accepted via format sniffing -- and labeling it
+    // honestly gets it rejected by the parser (see ParseContentEncoding.GzipIsUnsupported).
+    FakeHttpServer server;
+    const BodyDecoder decoder {server, /*enabled=*/true};
+
+    auto bytes = std::make_shared<std::string>(remoted::testutil::gzipCompress("some payload"));
+    auto payload = payloadOver(bytes);
+
+    EXPECT_EQ(decoder.decode(ContentEncoding::Zstd, payload), AuthError::MalformedContentEncoding);
+}
+
+// ---------------------------------------------------------------------------
+// Header parsing: which encoding a raw header value maps to
+//
+// Parsing lives at the edge (parseContentEncoding), so it is tested on its own rather than through
+// a decoder that would need a compressed fixture just to exercise a string comparison.
+// ---------------------------------------------------------------------------
+
+TEST(ParseContentEncoding, AbsentHeaderIsNone)
+{
+    EXPECT_EQ(parseContentEncoding(""), ContentEncoding::None);
+}
+
+TEST(ParseContentEncoding, ZstdIsRecognizedCaseInsensitively)
+{
+    EXPECT_EQ(parseContentEncoding("zstd"), ContentEncoding::Zstd);
+    EXPECT_EQ(parseContentEncoding("ZSTD"), ContentEncoding::Zstd);
+    EXPECT_EQ(parseContentEncoding("ZsTd"), ContentEncoding::Zstd);
+}
+
+TEST(ParseContentEncoding, GzipIsUnsupported)
+{
+    // Not a typo-tolerance case: gzip is a real encoding this build intentionally does not implement.
+    EXPECT_EQ(parseContentEncoding("gzip"), ContentEncoding::Unsupported);
+    EXPECT_EQ(parseContentEncoding("GZIP"), ContentEncoding::Unsupported);
+}
+
+TEST(ParseContentEncoding, AnythingElseIsUnsupported)
+{
+    EXPECT_EQ(parseContentEncoding("br"), ContentEncoding::Unsupported);
+    EXPECT_EQ(parseContentEncoding("deflate"), ContentEncoding::Unsupported);
+    EXPECT_EQ(parseContentEncoding("identity"), ContentEncoding::Unsupported);
+    EXPECT_EQ(parseContentEncoding("zstd, gzip"), ContentEncoding::Unsupported); // no multi-codec support
+    EXPECT_EQ(parseContentEncoding("zst"), ContentEncoding::Unsupported);        // prefix is not a match
+    EXPECT_EQ(parseContentEncoding("zstdd"), ContentEncoding::Unsupported);      // nor is a superstring
+}
+
+TEST(BodyDecoderTest, ZstdIsUnsupportedWhenDisabled)
+{
+    FakeHttpServer server;
+    const BodyDecoder decoder {server, /*enabled=*/false};
+
+    auto bytes = std::make_shared<std::string>(zstdCompress("some payload"));
+    auto payload = payloadOver(bytes);
+
+    // Same rejection as any unknown encoding -- no separate code path for "turned off".
+    EXPECT_EQ(decoder.decode(ContentEncoding::Zstd, payload), AuthError::UnsupportedContentEncoding);
+}
+
+// ---------------------------------------------------------------------------
+// Malformed input
+// ---------------------------------------------------------------------------
+
+TEST(BodyDecoderTest, BodyThatIsNotAZstdFrameIsMalformed)
+{
+    FakeHttpServer server;
+    const BodyDecoder decoder {server, /*enabled=*/true};
+
+    auto bytes = std::make_shared<std::string>("definitely not a zstd frame");
+    auto payload = payloadOver(bytes);
+
+    EXPECT_EQ(decoder.decode(ContentEncoding::Zstd, payload), AuthError::MalformedContentEncoding);
+}
+
+TEST(BodyDecoderTest, TruncatedFrameIsMalformed)
+{
+    FakeHttpServer server;
+    const BodyDecoder decoder {server, /*enabled=*/true};
+
+    const auto full = zstdCompress("some reasonably long plaintext to compress for this test");
+    auto bytes = std::make_shared<std::string>(full.substr(0, full.size() / 2));
+    auto payload = payloadOver(bytes);
+
+    EXPECT_EQ(decoder.decode(ContentEncoding::Zstd, payload), AuthError::MalformedContentEncoding);
+}
+
+// ---------------------------------------------------------------------------
+// Memory accounting against the in-flight budget
+// ---------------------------------------------------------------------------
+
+TEST(BodyDecoderTest, DecodedBytesStayChargedUntilThePayloadIsDropped)
+{
+    // The decoded bytes are a REAL reservation held for as long as the payload is, not a figure
+    // checked once and forgotten.
+    constexpr std::size_t kBudget = 100000;
+    constexpr std::size_t kPlainSize = 50000;
+    FakeHttpServer server {kBudget};
+    const BodyDecoder decoder {server, /*enabled=*/true};
+
+    const std::string plain(kPlainSize, 'x');
+    auto bytes = std::make_shared<std::string>(zstdCompress(plain));
+
+    {
+        auto payload = payloadOver(bytes);
+        ASSERT_EQ(decoder.decode(ContentEncoding::Zstd, payload), AuthError::None);
+        ASSERT_EQ(payload.bytes().size(), kPlainSize);
+
+        // Only the OUTPUT is still charged: the decoder's own buffers were released as soon as
+        // decoding finished (zstd had already freed them), so this is kPlainSize and not double it.
+        EXPECT_EQ(server.m_budget.availableBytes(), kBudget - kPlainSize);
+    }
+    // Payload dropped -> reservation released with it.
+    EXPECT_EQ(server.m_budget.availableBytes(), kBudget);
+    EXPECT_EQ(server.m_budget.inFlightCount(), 0U);
+}
+
+TEST(BodyDecoderTest, OutputNotFittingTheBudgetIsTooLarge)
+{
+    // Tiny budget, highly compressible body: the wire bytes fit easily but the decoded output
+    // doesn't, so it is refused while decoding rather than after materializing in full.
+    FakeHttpServer server {100};
+    const BodyDecoder decoder {server, /*enabled=*/true};
+
+    const std::string plain(1000, 'a');
+    auto bytes = std::make_shared<std::string>(zstdCompress(plain));
+    ASSERT_LT(bytes->size(), 100U);
+    auto payload = payloadOver(bytes);
+
+    EXPECT_EQ(decoder.decode(ContentEncoding::Zstd, payload), AuthError::BodyTooLarge);
+    // Refused: nothing stays charged, and the payload still holds the original wire bytes.
+    EXPECT_EQ(server.m_budget.availableBytes(), 100U);
+    EXPECT_EQ(payload.bytes(), *bytes);
+}
+
+TEST(BodyDecoderTest, FrameNeedingMoreBuffersThanTheBudgetHasIsTooLarge)
+{
+    // A frame declares its own memory requirement in its header. This one needs ~256 KiB of decoder
+    // buffers; the budget has 1 KiB, so it is refused up front -- before any output is produced.
+    FakeHttpServer server {1024};
+    const BodyDecoder decoder {server, /*enabled=*/true};
+
+    const std::string plain(256 * 1024, 'a');
+    auto bytes = std::make_shared<std::string>(zstdCompress(plain));
+    ASSERT_LT(bytes->size(), 1024U); // the compressed body itself is tiny
+    auto payload = payloadOver(bytes);
+
+    EXPECT_EQ(decoder.decode(ContentEncoding::Zstd, payload), AuthError::BodyTooLarge);
+    EXPECT_EQ(server.m_budget.availableBytes(), 1024U);
+}
+
+TEST(BodyDecoderTest, AmpleBudgetAllowsTheSameLargeFrame)
+{
+    // Mirror of the test above with room to spare: the same frame must decode fine. Together they
+    // show the outcome tracks available capacity, not anything intrinsic to the frame.
+    FakeHttpServer server;
+    const BodyDecoder decoder {server, /*enabled=*/true};
+
+    const std::string plain(256 * 1024, 'a');
+    auto bytes = std::make_shared<std::string>(zstdCompress(plain));
+    auto payload = payloadOver(bytes);
+
+    EXPECT_EQ(decoder.decode(ContentEncoding::Zstd, payload), AuthError::None);
+    EXPECT_EQ(payload.bytes().size(), plain.size());
+}

--- a/src/remoted/remoted_module/test/unit/fakeHttpServer.hpp
+++ b/src/remoted/remoted_module/test/unit/fakeHttpServer.hpp
@@ -1,0 +1,96 @@
+/*
+ * Wazuh remoted module (C++ worker bridge) - unit tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 3, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _REMOTED_MODULE_TEST_FAKE_HTTP_SERVER_HPP
+#define _REMOTED_MODULE_TEST_FAKE_HTTP_SERVER_HPP
+
+#include "http_server/IHttpServer.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+namespace remoted::testutil
+{
+
+    /**
+     * @brief Fake transport: stores registered routes so a test can dispatch them directly
+     *        (synchronously, no sockets), exactly as a route handler would run on a worker thread.
+     *
+     * Uses a REAL InFlightBudget (already transport-agnostic -- plain atomics, no RESTinio/asio)
+     * rather than a fake counter, so tests exercise the actual reserve/grow/release mechanics
+     * production relies on instead of a simplified stand-in that could behave differently.
+     */
+    class FakeHttpServer final : public remoted::http::IHttpServer
+    {
+    public:
+        // Defaults to a budget generously larger than anything a test fixture will need, i.e. "no
+        // meaningful constraint" in practice; tests that care about reservation behavior construct
+        // with a small value instead.
+        explicit FakeHttpServer(std::size_t maxInFlightBytes = std::numeric_limits<std::size_t>::max() / 2)
+            : m_budget {maxInFlightBytes}
+        {
+        }
+
+        void addRoute(remoted::http::Method method,
+                      const std::string& path,
+                      remoted::http::RouteHandler handler,
+                      bool /*countAgainstBudget*/,
+                      remoted::http::ResponseMode mode) override
+        {
+            m_routes[{method, path}] = std::move(handler);
+            m_modes[{method, path}] = mode;
+        }
+
+        /// @brief The response mode a route was registered with, for asserting the registration.
+        remoted::http::ResponseMode modeOf(remoted::http::Method method, const std::string& path) const
+        {
+            const auto it = m_modes.find({method, path});
+            return it == m_modes.end() ? remoted::http::ResponseMode::Buffered : it->second;
+        }
+        std::optional<remoted::http::InFlightBudget::Reservation>
+        tryReserveInFlightBytes(std::size_t bytes) override
+        {
+            return m_budget.tryReserve(bytes);
+        }
+        void start(const remoted::http::HttpServerConfig&) override {}
+        void stopAccepting() noexcept override {}
+        void stop() noexcept override {}
+
+        remoted::http::InFlightBudget m_budget;
+
+        void dispatch(remoted::http::Method method,
+                      const std::string& path,
+                      const remoted::http::HttpRequest& request,
+                      std::shared_ptr<remoted::http::IHttpResponder> responder)
+        {
+            // The transport hands the handler a shared_ptr<const>; mirror that here.
+            m_routes.at({method, path})(std::make_shared<const remoted::http::HttpRequest>(request),
+                                        std::move(responder));
+        }
+
+        bool hasRoute(remoted::http::Method method, const std::string& path) const
+        {
+            return m_routes.count({method, path}) != 0;
+        }
+
+    private:
+        std::map<std::pair<remoted::http::Method, std::string>, remoted::http::RouteHandler> m_routes;
+        std::map<std::pair<remoted::http::Method, std::string>, remoted::http::ResponseMode> m_modes;
+    };
+
+} // namespace remoted::testutil
+
+#endif // _REMOTED_MODULE_TEST_FAKE_HTTP_SERVER_HPP

--- a/src/remoted/remoted_module/test/unit/gzipTestHelper.hpp
+++ b/src/remoted/remoted_module/test/unit/gzipTestHelper.hpp
@@ -1,0 +1,60 @@
+/*
+ * Wazuh remoted module (C++ worker bridge) - unit tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 28, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _REMOTED_MODULE_TEST_GZIP_TEST_HELPER_HPP
+#define _REMOTED_MODULE_TEST_GZIP_TEST_HELPER_HPP
+
+#include <zlib.h>
+
+#include <array>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+namespace remoted::testutil
+{
+
+    /**
+     * @brief Test-only gzip compressor: the inverse of production's gzipDecode(), used to build
+     *        valid `Content-Encoding: gzip` fixtures. Not used by any production code path -- the
+     *        manager only ever decompresses agent-sent bodies, never compresses its own.
+     */
+    inline std::string gzipCompress(std::string_view plain)
+    {
+        z_stream strm {};
+        // 15 + 16: emit a gzip-formatted stream (header + CRC32/size trailer), matching what
+        // gzipDecode() (windowBits 15 + 16 on the inflate side) expects to parse.
+        if (deflateInit2(&strm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY) != Z_OK)
+        {
+            throw std::runtime_error("deflateInit2 failed");
+        }
+
+        strm.next_in = reinterpret_cast<Bytef*>(const_cast<char*>(plain.data()));
+        strm.avail_in = static_cast<uInt>(plain.size());
+
+        std::string out;
+        std::array<char, 4096> chunk {};
+        int ret;
+        do
+        {
+            strm.next_out = reinterpret_cast<Bytef*>(chunk.data());
+            strm.avail_out = static_cast<uInt>(chunk.size());
+            ret = deflate(&strm, Z_FINISH);
+            out.append(chunk.data(), chunk.size() - strm.avail_out);
+        } while (ret != Z_STREAM_END);
+
+        deflateEnd(&strm);
+        return out;
+    }
+
+} // namespace remoted::testutil
+
+#endif // _REMOTED_MODULE_TEST_GZIP_TEST_HELPER_HPP

--- a/src/remoted/remoted_module/test/unit/gzipTestHelper.hpp
+++ b/src/remoted/remoted_module/test/unit/gzipTestHelper.hpp
@@ -23,15 +23,14 @@ namespace remoted::testutil
 {
 
     /**
-     * @brief Test-only gzip compressor: the inverse of production's gzipDecode(), used to build
-     *        valid `Content-Encoding: gzip` fixtures. Not used by any production code path -- the
-     *        manager only ever decompresses agent-sent bodies, never compresses its own.
+     * @brief Test-only gzip compressor: used to build `Content-Encoding: gzip` fixtures for tests
+     *        that confirm the zstd decoder rejects a mislabeled (non-zstd) stream. Not used by any
+     *        production code path -- gzip support itself was removed; only zstd is decoded now.
      */
     inline std::string gzipCompress(std::string_view plain)
     {
         z_stream strm {};
-        // 15 + 16: emit a gzip-formatted stream (header + CRC32/size trailer), matching what
-        // gzipDecode() (windowBits 15 + 16 on the inflate side) expects to parse.
+        // 15 + 16: emit a gzip-formatted stream (header + CRC32/size trailer).
         if (deflateInit2(&strm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY) != Z_OK)
         {
             throw std::runtime_error("deflateInit2 failed");

--- a/src/remoted/remoted_module/test/unit/httpServer_test.cpp
+++ b/src/remoted/remoted_module/test/unit/httpServer_test.cpp
@@ -23,11 +23,14 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
-#include <chrono>
-#include <cctype>
-#include <atomic>
 #include <algorithm>
+#include <atomic>
+#include <cctype>
+#include <chrono>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -118,6 +121,44 @@ namespace
 
         return certificate;
     }
+    // Generates a throwaway self-signed cert/key pair (via the `openssl` CLI, already a
+    // build/runtime dependency) so start() can be exercised for real instead of only against the
+    // missing/malformed-certificate failure paths above. HttpServerConfig takes paths (not PEM
+    // content), so the files must stay on disk for the duration of the test -- only cleaned up
+    // once this object goes out of scope.
+    class TempCert
+    {
+    public:
+        TempCert()
+        {
+            char dirTemplate[] = "/tmp/httpServerTestXXXXXX";
+            m_dir = mkdtemp(dirTemplate);
+            m_certPath = m_dir + "/cert.pem";
+            m_keyPath = m_dir + "/key.pem";
+
+            const std::string cmd = "openssl req -x509 -newkey rsa:2048 -nodes -days 1 -subj /CN=test -keyout " +
+                                     m_keyPath + " -out " + m_certPath + " >/dev/null 2>&1";
+            if (std::system(cmd.c_str()) != 0)
+            {
+                ADD_FAILURE() << "Failed to generate a throwaway TLS certificate for testing";
+            }
+        }
+
+        ~TempCert()
+        {
+            std::remove(m_certPath.c_str());
+            std::remove(m_keyPath.c_str());
+            rmdir(m_dir.c_str());
+        }
+
+        const std::string& certPath() const { return m_certPath; }
+        const std::string& keyPath() const { return m_keyPath; }
+
+    private:
+        std::string m_dir;
+        std::string m_certPath;
+        std::string m_keyPath;
+    };
 } // namespace
 
 // ---------------------------------------------------------------------------
@@ -471,6 +512,72 @@ TEST(CertificateVerificationTest, NoSanExtensionReturnsFalse)
 TEST(CertificateVerificationTest, NullCertificateReturnsFalse)
 {
     EXPECT_FALSE(certificateMatchesPeerIp(nullptr, "203.0.113.5"));
+}
+
+// ---------------------------------------------------------------------------
+// In-flight budget reservations (tryReserveInFlightBytes())
+// ---------------------------------------------------------------------------
+
+TEST(HttpServerTest, ReserveInFlightBytesFailsBeforeStart)
+{
+    auto server = makeHttpServer();
+
+    // No budget exists until start() builds it, so there is nothing to reserve against. Fails
+    // closed rather than silently granting untracked memory.
+    EXPECT_FALSE(server->tryReserveInFlightBytes(1024).has_value());
+}
+
+TEST(HttpServerTest, ReserveInFlightBytesAlwaysGrantsWhenBudgetDisabled)
+{
+    TempCert cert;
+    auto server = makeHttpServer();
+
+    HttpServerConfig config;
+    config.port = 0; // ephemeral
+    config.certificatePath = cert.certPath();
+    config.privateKeyPath = cert.keyPath();
+    config.maxInFlightBytes = 0; // explicitly disabled
+
+    ASSERT_NO_THROW(server->start(config));
+
+    // Granted, but tracking nothing: a disabled budget admits unconditionally (bytes() == 0).
+    auto reservation = server->tryReserveInFlightBytes(64U * 1024U * 1024U);
+    ASSERT_TRUE(reservation.has_value());
+    EXPECT_EQ(reservation->bytes(), 0U);
+
+    server->stop();
+}
+
+TEST(HttpServerTest, ReserveInFlightBytesEnforcesConfiguredCapacityAfterStart)
+{
+    TempCert cert;
+    auto server = makeHttpServer();
+
+    HttpServerConfig config;
+    config.port = 0; // ephemeral
+    config.certificatePath = cert.certPath();
+    config.privateKeyPath = cert.keyPath();
+    // Comfortably above maxBodySize + the transport's per-request overhead, so start()'s own
+    // "raise it to at least one max-size request" clamp never kicks in and the configured capacity
+    // is what actually applies here.
+    config.maxBodySize = 1U * 1024U * 1024U;
+    config.maxInFlightBytes = 50U * 1024U * 1024U;
+
+    ASSERT_NO_THROW(server->start(config));
+
+    {
+        // Nothing else is in flight (no request has been dispatched), so the whole configured
+        // capacity is reservable -- exactly, and not a byte more.
+        auto whole = server->tryReserveInFlightBytes(50U * 1024U * 1024U);
+        ASSERT_TRUE(whole.has_value());
+        EXPECT_EQ(whole->bytes(), 50U * 1024U * 1024U);
+        EXPECT_FALSE(server->tryReserveInFlightBytes(1).has_value()); // exhausted
+    }
+
+    // `whole` released at the end of the scope above: capacity is back.
+    EXPECT_TRUE(server->tryReserveInFlightBytes(50U * 1024U * 1024U).has_value());
+
+    server->stop();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/remoted/remoted_module/test/unit/inFlightBudget_test.cpp
+++ b/src/remoted/remoted_module/test/unit/inFlightBudget_test.cpp
@@ -14,6 +14,7 @@
 #include <gtest/gtest.h>
 
 #include <cstddef>
+#include <optional>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -159,6 +160,138 @@ TEST(InFlightBudget, ConcurrentReserveReleaseIsConsistent)
     }
 
     // Every reservation was released: the budget is fully restored and nothing leaked.
+    EXPECT_EQ(budget.availableBytes(), total);
+    EXPECT_EQ(budget.inFlightCount(), 0U);
+}
+
+TEST(InFlightBudget, GrowAddsToAnExistingReservation)
+{
+    InFlightBudget budget(100);
+
+    auto reservation = budget.tryReserve(0);
+    ASSERT_TRUE(reservation.has_value());
+    EXPECT_EQ(reservation->bytes(), 0U);
+    EXPECT_EQ(budget.availableBytes(), 100U);
+
+    ASSERT_TRUE(reservation->grow(30));
+    EXPECT_EQ(reservation->bytes(), 30U);
+    EXPECT_EQ(budget.availableBytes(), 70U);
+
+    ASSERT_TRUE(reservation->grow(70)); // exact fit
+    EXPECT_EQ(reservation->bytes(), 100U);
+    EXPECT_EQ(budget.availableBytes(), 0U);
+}
+
+TEST(InFlightBudget, GrowBeyondCapacityIsRefusedAndLeavesTheReservationUntouched)
+{
+    InFlightBudget budget(100);
+
+    auto reservation = budget.tryReserve(60);
+    ASSERT_TRUE(reservation.has_value());
+
+    EXPECT_FALSE(reservation->grow(41)); // 60 + 41 > 100
+    // Refused, not partially applied: both the reservation and the budget are exactly as before.
+    EXPECT_EQ(reservation->bytes(), 60U);
+    EXPECT_EQ(budget.availableBytes(), 40U);
+
+    EXPECT_TRUE(reservation->grow(40)); // what does fit still works afterwards
+    EXPECT_EQ(reservation->bytes(), 100U);
+    EXPECT_EQ(budget.availableBytes(), 0U);
+}
+
+TEST(InFlightBudget, GrownBytesAreAllReleasedTogether)
+{
+    InFlightBudget budget(100);
+    {
+        auto reservation = budget.tryReserve(10);
+        ASSERT_TRUE(reservation.has_value());
+        ASSERT_TRUE(reservation->grow(20));
+        ASSERT_TRUE(reservation->grow(30));
+        EXPECT_EQ(budget.availableBytes(), 40U);
+    }
+    // One release covers the initial reservation plus every grow() on top of it.
+    EXPECT_EQ(budget.availableBytes(), 100U);
+    EXPECT_EQ(budget.inFlightCount(), 0U);
+}
+
+TEST(InFlightBudget, GrowOnADisabledBudgetAlwaysSucceedsWithoutTracking)
+{
+    InFlightBudget budget(0); // disabled
+
+    auto reservation = budget.tryReserve(0);
+    ASSERT_TRUE(reservation.has_value());
+    EXPECT_TRUE(reservation->grow(1024 * 1024));
+    EXPECT_EQ(reservation->bytes(), 0U); // admitted, but nothing is tracked
+}
+
+TEST(InFlightBudget, GrowOnAMovedFromReservationIsRefused)
+{
+    InFlightBudget budget(100);
+
+    auto reservation = budget.tryReserve(10);
+    ASSERT_TRUE(reservation.has_value());
+    InFlightBudget::Reservation moved {std::move(*reservation)};
+
+    // The moved-from token owns nothing now, so it must not be able to charge the budget.
+    EXPECT_FALSE(reservation->grow(10));
+    EXPECT_EQ(budget.availableBytes(), 90U); // unchanged: only `moved`'s 10 bytes are held
+    EXPECT_TRUE(moved.grow(10));             // the new owner still can
+    EXPECT_EQ(budget.availableBytes(), 80U);
+}
+
+TEST(InFlightBudget, ConcurrentGrowNeverOvershootsTheBudget)
+{
+    // grow() runs a compare-exchange loop against the same atomic tryReserve() uses, so several
+    // threads growing at once must never hand out more than the budget holds -- the exact
+    // mechanism that stops N concurrent decompressions from each independently deciding there is
+    // room and together blowing past it.
+    constexpr std::size_t total = 64U * 1024U;
+    constexpr std::size_t step = 64U;
+    InFlightBudget budget(total);
+
+    constexpr int threadCount = 8;
+    std::vector<std::thread> threads;
+    std::vector<std::size_t> grantedPerThread(threadCount, 0);
+    // The reservations live HERE, not inside the threads: they must all still be held when the
+    // assertions run. If each thread dropped its own on exit, an early-finishing thread would hand
+    // capacity back to the ones still looping, and the running total over time would legitimately
+    // exceed the budget -- which says nothing about whether the budget was ever overshot at once.
+    std::vector<std::optional<InFlightBudget::Reservation>> reservations(threadCount);
+    threads.reserve(threadCount);
+
+    for (int t = 0; t < threadCount; ++t)
+    {
+        threads.emplace_back(
+            [&budget, &grantedPerThread, &reservations, t]
+            {
+                const auto slot = static_cast<std::size_t>(t);
+                // Each thread owns one slot, and the vector is never resized, so no synchronization
+                // is needed around the slots themselves -- only grow() is contended, which is the point.
+                reservations[slot] = budget.tryReserve(0);
+                while (reservations[slot]->grow(step))
+                {
+                    grantedPerThread[slot] += step;
+                }
+            });
+    }
+    for (auto& thread : threads)
+    {
+        thread.join();
+    }
+
+    std::size_t totalGranted = 0;
+    for (const auto granted : grantedPerThread)
+    {
+        totalGranted += granted;
+    }
+
+    // Every thread grew until refused and every reservation is still held, so between them they
+    // hold the entire budget and not one byte more. A racy CAS loop would show up here as a total
+    // above `total` (with availableBytes() having wrapped around past zero).
+    EXPECT_EQ(totalGranted, total);
+    EXPECT_EQ(budget.availableBytes(), 0U);
+
+    reservations.clear(); // release them all
     EXPECT_EQ(budget.availableBytes(), total);
     EXPECT_EQ(budget.inFlightCount(), 0U);
 }

--- a/src/remoted/remoted_module/test/unit/shutdownRace_test.cpp
+++ b/src/remoted/remoted_module/test/unit/shutdownRace_test.cpp
@@ -26,6 +26,7 @@
 #include "downstream/deferredWorkLimiter.hpp"
 #include "downstream/downstreamConfig.hpp"
 #include "endpoints/authGateway.hpp"
+#include "decoding/bodyDecoder.hpp"
 #include "http_server/IHttpServer.hpp"
 #include "http_server/httpServerFactory.hpp"
 
@@ -305,7 +306,9 @@ TEST(ShutdownRace, StopSequenceSurvivesAnInFlightForward)
     auto forwarder = std::make_unique<DeferredForwarder>(client, limiter, 2);
 
     auto server = makeHttpServer();
-    AuthGateway gateway {remoted::auth::AuthConfig {}, std::make_shared<FakeKeystore>()};
+    AuthGateway gateway {remoted::auth::AuthConfig {},
+                         std::make_shared<FakeKeystore>(),
+                         std::make_shared<const remoted::decoding::BodyDecoder>(*server, /*enabled=*/true)};
 
     auto* forwarderPtr = forwarder.get();
     gateway.addAuthenticatedRoute(
@@ -406,7 +409,9 @@ TEST(ShutdownRace, StopSequenceSurvivesAnInFlightStream)
     auto reads = std::make_shared<std::atomic_int>(0);
 
     auto server = makeHttpServer();
-    AuthGateway gateway {remoted::auth::AuthConfig {}, std::make_shared<remoted::test::FakeKeystore>()};
+    AuthGateway gateway {remoted::auth::AuthConfig {},
+                         std::make_shared<remoted::test::FakeKeystore>(),
+                         std::make_shared<const remoted::decoding::BodyDecoder>(*server, /*enabled=*/true)};
 
     gateway.addAuthenticatedRoute(
         *server,

--- a/src/remoted/remoted_module/test/unit/zstdDecoder_test.cpp
+++ b/src/remoted/remoted_module/test/unit/zstdDecoder_test.cpp
@@ -15,19 +15,48 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
 #include <string>
 #include <variant>
+#include <vector>
 
+using remoted::common::ReserveMoreFn;
+using remoted::common::ReserveWindowFn;
 using remoted::common::zstdDecode;
 using remoted::common::ZstdDecodeError;
 using remoted::testutil::zstdCompress;
+
+namespace
+{
+    // Grants every reservation -- used by tests that aren't about the reservation mechanism itself.
+    bool alwaysReserve(std::size_t)
+    {
+        return true;
+    }
+
+    // Grants reservations only up to a running total of maxBytes, mimicking a real (if simplified)
+    // caller-owned budget. Used to test the reservation paths without needing an actual
+    // InFlightBudget (that integration is covered at the AuthGateway level instead).
+    ReserveMoreFn reserveUpTo(std::size_t maxBytes)
+    {
+        return [maxBytes, reserved = std::size_t {0}](std::size_t more) mutable
+        {
+            if (reserved + more > maxBytes)
+            {
+                return false;
+            }
+            reserved += more;
+            return true;
+        };
+    }
+} // namespace
 
 TEST(ZstdDecoder, RoundTripsPlainText)
 {
     const std::string plain = "Hello, this is a Wazuh event payload.";
     const auto compressed = zstdCompress(plain);
 
-    const auto result = zstdDecode(compressed, 1024 * 1024);
+    const auto result = zstdDecode(compressed, alwaysReserve, alwaysReserve);
 
     ASSERT_TRUE(std::holds_alternative<std::string>(result));
     EXPECT_EQ(std::get<std::string>(result), plain);
@@ -37,7 +66,7 @@ TEST(ZstdDecoder, RoundTripsEmptyInput)
 {
     const auto compressed = zstdCompress("");
 
-    const auto result = zstdDecode(compressed, 1024);
+    const auto result = zstdDecode(compressed, alwaysReserve, alwaysReserve);
 
     ASSERT_TRUE(std::holds_alternative<std::string>(result));
     EXPECT_EQ(std::get<std::string>(result), "");
@@ -45,7 +74,8 @@ TEST(ZstdDecoder, RoundTripsEmptyInput)
 
 TEST(ZstdDecoder, RoundTripsAcrossMultipleInternalChunks)
 {
-    // Bigger than zstdDecode()'s internal 64 KiB chunk, so the streaming loop runs several times.
+    // Bigger than zstdDecode()'s internal 64 KiB chunk, so the streaming loop -- and reserveMore --
+    // runs several times.
     std::string plain;
     plain.reserve(200 * 1024);
     for (int i = 0; i < 200 * 1024 / 10; ++i)
@@ -54,7 +84,7 @@ TEST(ZstdDecoder, RoundTripsAcrossMultipleInternalChunks)
     }
     const auto compressed = zstdCompress(plain);
 
-    const auto result = zstdDecode(compressed, plain.size() + 1);
+    const auto result = zstdDecode(compressed, alwaysReserve, reserveUpTo(plain.size()));
 
     ASSERT_TRUE(std::holds_alternative<std::string>(result));
     EXPECT_EQ(std::get<std::string>(result), plain);
@@ -62,7 +92,7 @@ TEST(ZstdDecoder, RoundTripsAcrossMultipleInternalChunks)
 
 TEST(ZstdDecoder, EmptyBufferIsMalformed)
 {
-    const auto result = zstdDecode("", 1024);
+    const auto result = zstdDecode("", alwaysReserve, alwaysReserve);
 
     ASSERT_TRUE(std::holds_alternative<ZstdDecodeError>(result));
     EXPECT_EQ(std::get<ZstdDecodeError>(result), ZstdDecodeError::Malformed);
@@ -70,7 +100,7 @@ TEST(ZstdDecoder, EmptyBufferIsMalformed)
 
 TEST(ZstdDecoder, RandomGarbageIsMalformed)
 {
-    const auto result = zstdDecode("this is not a zstd frame at all", 1024);
+    const auto result = zstdDecode("this is not a zstd frame at all", alwaysReserve, alwaysReserve);
 
     ASSERT_TRUE(std::holds_alternative<ZstdDecodeError>(result));
     EXPECT_EQ(std::get<ZstdDecodeError>(result), ZstdDecodeError::Malformed);
@@ -82,7 +112,7 @@ TEST(ZstdDecoder, TruncatedStreamIsMalformed)
     // Chop off the tail: a genuinely incomplete frame.
     const auto truncated = compressed.substr(0, compressed.size() / 2);
 
-    const auto result = zstdDecode(truncated, 1024);
+    const auto result = zstdDecode(truncated, alwaysReserve, alwaysReserve);
 
     ASSERT_TRUE(std::holds_alternative<ZstdDecodeError>(result));
     EXPECT_EQ(std::get<ZstdDecodeError>(result), ZstdDecodeError::Malformed);
@@ -95,30 +125,217 @@ TEST(ZstdDecoder, GzipStreamFedToZstdIsRejected)
     // encoding should fail closed, not be silently accepted via format sniffing.
     const auto gzipStream = remoted::testutil::gzipCompress("not zstd, just gzip");
 
-    const auto result = zstdDecode(gzipStream, 1024);
+    const auto result = zstdDecode(gzipStream, alwaysReserve, alwaysReserve);
 
     ASSERT_TRUE(std::holds_alternative<ZstdDecodeError>(result));
     EXPECT_EQ(std::get<ZstdDecodeError>(result), ZstdDecodeError::Malformed);
 }
 
-TEST(ZstdDecoder, DecompressedSizeExceedingLimitIsRejected)
+// ---------------------------------------------------------------------------
+// Window reservation (read off the frame header, before anything is decoded)
+// ---------------------------------------------------------------------------
+
+TEST(ZstdDecoder, WindowReservationIsAskedForTheFramesOwnDeclaredSize)
+{
+    // The whole point of reading the frame header: the caller is asked to reserve what THIS frame
+    // actually needs, not a blanket worst case. For a one-shot frame that is its decompressed size.
+    const std::string plain(50000, 'x');
+    const auto compressed = zstdCompress(plain);
+
+    std::vector<std::size_t> windowAsks;
+    const auto result = zstdDecode(
+        compressed,
+        [&windowAsks](std::size_t bytes)
+        {
+            windowAsks.push_back(bytes);
+            return true;
+        },
+        alwaysReserve);
+
+    ASSERT_TRUE(std::holds_alternative<std::string>(result));
+    ASSERT_EQ(windowAsks.size(), 1U); // asked exactly once, before decoding
+    EXPECT_EQ(windowAsks.front(), plain.size());
+}
+
+TEST(ZstdDecoder, RefusedWindowReservationAbortsWithoutDecoding)
+{
+    const std::string plain(256 * 1024, 'a');
+    const auto compressed = zstdCompress(plain);
+
+    bool decodedAnything = false;
+    const auto result = zstdDecode(
+        compressed,
+        [](std::size_t) { return false; }, // the budget has no room for this frame's window
+        [&decodedAnything](std::size_t)
+        {
+            decodedAnything = true;
+            return true;
+        });
+
+    ASSERT_TRUE(std::holds_alternative<ZstdDecodeError>(result));
+    EXPECT_EQ(std::get<ZstdDecodeError>(result), ZstdDecodeError::TooLarge);
+    EXPECT_FALSE(decodedAnything); // refused up front: not a single chunk was produced
+}
+
+TEST(ZstdDecoder, WindowIsNotAskedForWhenTheHeaderCannotBeRead)
+{
+    // A garbage frame is rejected before the budget is ever consulted, so a peer sending junk
+    // can't disturb the budget at all.
+    bool windowAsked = false;
+    const auto result = zstdDecode(
+        "this is not a zstd frame at all",
+        [&windowAsked](std::size_t)
+        {
+            windowAsked = true;
+            return true;
+        },
+        alwaysReserve);
+
+    ASSERT_TRUE(std::holds_alternative<ZstdDecodeError>(result));
+    EXPECT_EQ(std::get<ZstdDecodeError>(result), ZstdDecodeError::Malformed);
+    EXPECT_FALSE(windowAsked);
+}
+
+// ---------------------------------------------------------------------------
+// Output reservation (grown per chunk, as bytes materialize)
+// ---------------------------------------------------------------------------
+
+TEST(ZstdDecoder, ReservationRefusalDuringOutputIsRejectedAsTooLarge)
 {
     const std::string plain(1000, 'a'); // compresses very well (highly repetitive)
     const auto compressed = zstdCompress(plain);
 
-    const auto result = zstdDecode(compressed, 10); // far below the real decompressed size
+    // Window is granted; the output reservation runs out far below the real decompressed size.
+    const auto result = zstdDecode(compressed, alwaysReserve, reserveUpTo(10));
 
     ASSERT_TRUE(std::holds_alternative<ZstdDecodeError>(result));
     EXPECT_EQ(std::get<ZstdDecodeError>(result), ZstdDecodeError::TooLarge);
 }
 
-TEST(ZstdDecoder, DecompressedSizeExactlyAtLimitSucceeds)
+TEST(ZstdDecoder, ReservationExactlyCoveringOutputSucceeds)
 {
     const std::string plain(100, 'b');
     const auto compressed = zstdCompress(plain);
 
-    const auto result = zstdDecode(compressed, plain.size()); // exact fit, not "size - 1"
+    // exact fit, not "size - 1"
+    const auto result = zstdDecode(compressed, alwaysReserve, reserveUpTo(plain.size()));
 
     ASSERT_TRUE(std::holds_alternative<std::string>(result));
     EXPECT_EQ(std::get<std::string>(result), plain);
+}
+
+TEST(ZstdDecoder, ChargedTotalCoversTheBufferAcrossManyChunks)
+{
+    // Spans several internal 64 KiB chunks. Whatever strategy is used to reserve, the invariant is
+    // the same: the charged total must never be less than the memory the buffer actually holds.
+    std::string plain;
+    plain.reserve(200 * 1024);
+    for (int i = 0; i < 200 * 1024 / 10; ++i)
+    {
+        plain += "0123456789";
+    }
+    const auto compressed = zstdCompress(plain);
+
+    std::size_t charged = 0;
+    const auto result = zstdDecode(compressed,
+                                   alwaysReserve,
+                                   [&charged](std::size_t more)
+                                   {
+                                       charged += more;
+                                       return true;
+                                   });
+
+    ASSERT_TRUE(std::holds_alternative<std::string>(result));
+    const auto& decoded = std::get<std::string>(result);
+    EXPECT_EQ(decoded, plain);
+    EXPECT_GE(charged, decoded.capacity());
+}
+
+// ---------------------------------------------------------------------------
+// Output accounting: what is charged must cover what is really allocated
+// ---------------------------------------------------------------------------
+
+TEST(ZstdDecoder, ADeclaredSizeFrameIsChargedExactlyOnceForExactlyItsSize)
+{
+    // The accounting fix: charge the frame's declared decompressed size once and size the buffer to
+    // it, instead of charging each 64 KiB written and letting the buffer over-allocate behind our
+    // back. Charging written bytes undercounted by ~45% at this size, because std::string grows by
+    // doubling -- 11 MiB of content sat in a 16 MiB allocation.
+    const std::string plain(3 * 1024 * 1024, 'z'); // spans many 64 KiB chunks
+    const auto compressed = zstdCompress(plain);
+
+    std::vector<std::size_t> asks;
+    const auto result = zstdDecode(compressed,
+                                   alwaysReserve,
+                                   [&asks](std::size_t bytes)
+                                   {
+                                       asks.push_back(bytes);
+                                       return true;
+                                   });
+
+    ASSERT_TRUE(std::holds_alternative<std::string>(result));
+    ASSERT_EQ(asks.size(), 1U); // one reservation, not one per chunk
+    EXPECT_EQ(asks.front(), plain.size());
+    // And what was charged really does cover the allocation -- no silent over-allocation past it.
+    EXPECT_GE(asks.front(), std::get<std::string>(result).capacity());
+}
+
+TEST(ZstdDecoder, ADeclaredSizeTooBigForTheBudgetIsRefusedBeforeDecoding)
+{
+    // Refused on the declaration alone, before any output is produced. Note this is the OUTPUT
+    // reservation refusing (the window is granted), which is why the decode never starts.
+    const std::string plain(256 * 1024, 'a');
+    const auto compressed = zstdCompress(plain);
+
+    bool decodedAnything = false;
+    const auto result = zstdDecode(compressed,
+                                   alwaysReserve,
+                                   [&decodedAnything](std::size_t)
+                                   {
+                                       decodedAnything = true;
+                                       return false; // no room for this frame's declared size
+                                   });
+
+    ASSERT_TRUE(std::holds_alternative<ZstdDecodeError>(result));
+    EXPECT_EQ(std::get<ZstdDecodeError>(result), ZstdDecodeError::TooLarge);
+    EXPECT_TRUE(decodedAnything); // the single ask happened...
+    // ...and it was the up-front one: nothing was decoded after it was refused.
+}
+
+TEST(ZstdDecoder, AFrameWithoutADeclaredSizeStillDecodesAndStaysFullyCharged)
+{
+    // Streaming-compressed frames carry no decompressed size, so the buffer has to grow in blocks.
+    // Every growth is still reserved first, so the charged total covers the final capacity.
+    const std::string plain(3 * 1024 * 1024, 'w');
+    const auto compressed = remoted::testutil::zstdCompressWithoutDeclaredSize(plain);
+
+    std::size_t charged = 0;
+    const auto result = zstdDecode(compressed,
+                                   alwaysReserve,
+                                   [&charged](std::size_t bytes)
+                                   {
+                                       charged += bytes;
+                                       return true;
+                                   });
+
+    ASSERT_TRUE(std::holds_alternative<std::string>(result));
+    const auto& decoded = std::get<std::string>(result);
+    EXPECT_EQ(decoded, plain);
+    // The whole point: charged is never LESS than what the buffer actually holds.
+    EXPECT_GE(charged, decoded.capacity());
+    // Block growth, not per-chunk: far fewer reservations than the 48 chunks this body spans.
+    EXPECT_LT(charged, 4U * plain.size());
+}
+
+TEST(ZstdDecoder, AFrameWithoutADeclaredSizeIsCutOffWhenTheBudgetRefusesMidway)
+{
+    // The block-growth path must still enforce: refuse a growth and decoding aborts, rather than
+    // continuing to allocate uncharged memory.
+    const std::string plain(3 * 1024 * 1024, 'w');
+    const auto compressed = remoted::testutil::zstdCompressWithoutDeclaredSize(plain);
+
+    const auto result = zstdDecode(compressed, alwaysReserve, reserveUpTo(128 * 1024));
+
+    ASSERT_TRUE(std::holds_alternative<ZstdDecodeError>(result));
+    EXPECT_EQ(std::get<ZstdDecodeError>(result), ZstdDecodeError::TooLarge);
 }

--- a/src/remoted/remoted_module/test/unit/zstdDecoder_test.cpp
+++ b/src/remoted/remoted_module/test/unit/zstdDecoder_test.cpp
@@ -1,0 +1,124 @@
+/*
+ * Wazuh remoted module (C++ worker bridge) - unit tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 30, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "common/zstdDecoder.hpp"
+#include "gzipTestHelper.hpp"
+#include "zstdTestHelper.hpp"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <variant>
+
+using remoted::common::zstdDecode;
+using remoted::common::ZstdDecodeError;
+using remoted::testutil::zstdCompress;
+
+TEST(ZstdDecoder, RoundTripsPlainText)
+{
+    const std::string plain = "Hello, this is a Wazuh event payload.";
+    const auto compressed = zstdCompress(plain);
+
+    const auto result = zstdDecode(compressed, 1024 * 1024);
+
+    ASSERT_TRUE(std::holds_alternative<std::string>(result));
+    EXPECT_EQ(std::get<std::string>(result), plain);
+}
+
+TEST(ZstdDecoder, RoundTripsEmptyInput)
+{
+    const auto compressed = zstdCompress("");
+
+    const auto result = zstdDecode(compressed, 1024);
+
+    ASSERT_TRUE(std::holds_alternative<std::string>(result));
+    EXPECT_EQ(std::get<std::string>(result), "");
+}
+
+TEST(ZstdDecoder, RoundTripsAcrossMultipleInternalChunks)
+{
+    // Bigger than zstdDecode()'s internal 64 KiB chunk, so the streaming loop runs several times.
+    std::string plain;
+    plain.reserve(200 * 1024);
+    for (int i = 0; i < 200 * 1024 / 10; ++i)
+    {
+        plain += "0123456789";
+    }
+    const auto compressed = zstdCompress(plain);
+
+    const auto result = zstdDecode(compressed, plain.size() + 1);
+
+    ASSERT_TRUE(std::holds_alternative<std::string>(result));
+    EXPECT_EQ(std::get<std::string>(result), plain);
+}
+
+TEST(ZstdDecoder, EmptyBufferIsMalformed)
+{
+    const auto result = zstdDecode("", 1024);
+
+    ASSERT_TRUE(std::holds_alternative<ZstdDecodeError>(result));
+    EXPECT_EQ(std::get<ZstdDecodeError>(result), ZstdDecodeError::Malformed);
+}
+
+TEST(ZstdDecoder, RandomGarbageIsMalformed)
+{
+    const auto result = zstdDecode("this is not a zstd frame at all", 1024);
+
+    ASSERT_TRUE(std::holds_alternative<ZstdDecodeError>(result));
+    EXPECT_EQ(std::get<ZstdDecodeError>(result), ZstdDecodeError::Malformed);
+}
+
+TEST(ZstdDecoder, TruncatedStreamIsMalformed)
+{
+    const auto compressed = zstdCompress("some reasonably long plaintext to compress for this test");
+    // Chop off the tail: a genuinely incomplete frame.
+    const auto truncated = compressed.substr(0, compressed.size() / 2);
+
+    const auto result = zstdDecode(truncated, 1024);
+
+    ASSERT_TRUE(std::holds_alternative<ZstdDecodeError>(result));
+    EXPECT_EQ(std::get<ZstdDecodeError>(result), ZstdDecodeError::Malformed);
+}
+
+TEST(ZstdDecoder, GzipStreamFedToZstdIsRejected)
+{
+    // A gzip-compressed stream must NOT be silently accepted by the zstd decoder: this is a
+    // barrier for the HTTP `Content-Encoding: zstd` contract, and a client that mislabels its
+    // encoding should fail closed, not be silently accepted via format sniffing.
+    const auto gzipStream = remoted::testutil::gzipCompress("not zstd, just gzip");
+
+    const auto result = zstdDecode(gzipStream, 1024);
+
+    ASSERT_TRUE(std::holds_alternative<ZstdDecodeError>(result));
+    EXPECT_EQ(std::get<ZstdDecodeError>(result), ZstdDecodeError::Malformed);
+}
+
+TEST(ZstdDecoder, DecompressedSizeExceedingLimitIsRejected)
+{
+    const std::string plain(1000, 'a'); // compresses very well (highly repetitive)
+    const auto compressed = zstdCompress(plain);
+
+    const auto result = zstdDecode(compressed, 10); // far below the real decompressed size
+
+    ASSERT_TRUE(std::holds_alternative<ZstdDecodeError>(result));
+    EXPECT_EQ(std::get<ZstdDecodeError>(result), ZstdDecodeError::TooLarge);
+}
+
+TEST(ZstdDecoder, DecompressedSizeExactlyAtLimitSucceeds)
+{
+    const std::string plain(100, 'b');
+    const auto compressed = zstdCompress(plain);
+
+    const auto result = zstdDecode(compressed, plain.size()); // exact fit, not "size - 1"
+
+    ASSERT_TRUE(std::holds_alternative<std::string>(result));
+    EXPECT_EQ(std::get<std::string>(result), plain);
+}

--- a/src/remoted/remoted_module/test/unit/zstdTestHelper.hpp
+++ b/src/remoted/remoted_module/test/unit/zstdTestHelper.hpp
@@ -14,6 +14,7 @@
 
 #include <zstd.h>
 
+#include <algorithm>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -35,6 +36,70 @@ namespace remoted::testutil
             throw std::runtime_error(std::string("ZSTD_compress failed: ") + ZSTD_getErrorName(written));
         }
         out.resize(written);
+        return out;
+    }
+
+    /**
+     * @brief Like zstdCompress(), but produces a frame whose header declares NO decompressed size.
+     *
+     * ZSTD_compress() always records the size (it knows it up front), so it cannot produce this
+     * shape. Streaming compression without a pledged source size can -- which is what an agent
+     * compressing on the fly would emit. zstdDecode() has a separate path for these frames (it must
+     * grow the output buffer in blocks instead of sizing it once), so it needs its own fixtures.
+     */
+    inline std::string zstdCompressWithoutDeclaredSize(std::string_view plain, int level = 3)
+    {
+        ZSTD_CCtx* cctx = ZSTD_createCCtx();
+        if (cctx == nullptr)
+        {
+            throw std::runtime_error("ZSTD_createCCtx failed");
+        }
+        struct Guard
+        {
+            ZSTD_CCtx* ctx;
+            ~Guard()
+            {
+                ZSTD_freeCCtx(ctx);
+            }
+        } guard {cctx};
+
+        ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, level);
+        // Not calling ZSTD_CCtx_setPledgedSrcSize() is necessary but NOT sufficient: handed the
+        // whole input in one ZSTD_e_end call, zstd still knows the total and records it. The header
+        // is only written without a size if the frame starts before the input has all been seen --
+        // so feed it in pieces, and only end the frame afterwards.
+        constexpr std::size_t kFeedSize = 64 * 1024;
+
+        std::string out(ZSTD_compressBound(plain.size()) + 1024, '\0');
+        ZSTD_outBuffer output {out.data(), out.size(), 0};
+
+        for (std::size_t offset = 0; offset < plain.size(); offset += kFeedSize)
+        {
+            const std::size_t take = std::min(kFeedSize, plain.size() - offset);
+            ZSTD_inBuffer in {plain.data() + offset, take, 0};
+            while (in.pos < in.size)
+            {
+                const std::size_t ret = ZSTD_compressStream2(cctx, &output, &in, ZSTD_e_continue);
+                if (ZSTD_isError(ret))
+                {
+                    throw std::runtime_error(std::string("ZSTD_compressStream2 failed: ") + ZSTD_getErrorName(ret));
+                }
+            }
+        }
+
+        ZSTD_inBuffer end {nullptr, 0, 0};
+        std::size_t remaining = 0;
+        do
+        {
+            remaining = ZSTD_compressStream2(cctx, &output, &end, ZSTD_e_end);
+            if (ZSTD_isError(remaining))
+            {
+                throw std::runtime_error(std::string("ZSTD_compressStream2 (end) failed: ") +
+                                        ZSTD_getErrorName(remaining));
+            }
+        } while (remaining != 0);
+
+        out.resize(output.pos);
         return out;
     }
 

--- a/src/remoted/remoted_module/test/unit/zstdTestHelper.hpp
+++ b/src/remoted/remoted_module/test/unit/zstdTestHelper.hpp
@@ -1,0 +1,43 @@
+/*
+ * Wazuh remoted module (C++ worker bridge) - unit tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 30, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _REMOTED_MODULE_TEST_ZSTD_TEST_HELPER_HPP
+#define _REMOTED_MODULE_TEST_ZSTD_TEST_HELPER_HPP
+
+#include <zstd.h>
+
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+namespace remoted::testutil
+{
+
+    /**
+     * @brief Test-only zstd compressor: the inverse of production's zstdDecode(), used to build
+     *        valid `Content-Encoding: zstd` fixtures. Not used by any production code path -- the
+     *        manager only ever decompresses agent-sent bodies, never compresses its own.
+     */
+    inline std::string zstdCompress(std::string_view plain, int level = 3)
+    {
+        std::string out(ZSTD_compressBound(plain.size()), '\0');
+        const std::size_t written = ZSTD_compress(out.data(), out.size(), plain.data(), plain.size(), level);
+        if (ZSTD_isError(written))
+        {
+            throw std::runtime_error(std::string("ZSTD_compress failed: ") + ZSTD_getErrorName(written));
+        }
+        out.resize(written);
+        return out;
+    }
+
+} // namespace remoted::testutil
+
+#endif // _REMOTED_MODULE_TEST_ZSTD_TEST_HELPER_HPP

--- a/src/remoted/remoted_module/tools/requirements.txt
+++ b/src/remoted/remoted_module/tools/requirements.txt
@@ -1,0 +1,3 @@
+requests>=2.31.0
+cryptography>=41.0.0
+zstandard>=0.21.0

--- a/src/remoted/remoted_module/tools/send_stateless.py
+++ b/src/remoted/remoted_module/tools/send_stateless.py
@@ -20,7 +20,7 @@ The agent key is read straight out of client.keys (same file
 Keystore reads), so this always matches whatever agent is
 currently enrolled -- no need to copy/paste keys by hand.
 
-Requires: pip install requests cryptography
+Requires: pip install -r requirements.txt
 
 Examples:
   python3 send_stateless.py                       # one valid signed request -> 202
@@ -34,6 +34,7 @@ import time
 
 import requests
 import urllib3
+import zstandard
 from cryptography.hazmat.primitives import cmac
 from cryptography.hazmat.primitives.ciphers import algorithms
 
@@ -250,6 +251,48 @@ def scenario_transport_body_too_large(agent_id, agent_key):
     return headers, body, target
 
 
+def scenario_zstd_encoded(agent_id, agent_key):
+    # Content-Encoding: zstd -- sign over the COMPRESSED (wire) bytes, exactly like the manager
+    # does: the MAC always covers what was actually sent, compressed or not.
+    target = "/stateless"
+    plain = DEFAULT_BODY
+    compressed = zstandard.ZstdCompressor().compress(plain)
+    headers = _auth_header(agent_id, agent_key, "1", "POST", target, int(time.time()), compressed)
+    headers["Content-Encoding"] = "zstd"
+    return headers, compressed, target
+
+
+def scenario_unsupported_content_encoding(agent_id, agent_key):
+    # gzip was intentionally dropped -- zstd is the only supported Content-Encoding now. Any other
+    # value, including a once-supported one, must be rejected as 415.
+    target = "/stateless"
+    body = DEFAULT_BODY
+    headers = _auth_header(agent_id, agent_key, "1", "POST", target, int(time.time()), body)
+    headers["Content-Encoding"] = "gzip"
+    return headers, body, target
+
+
+def scenario_malformed_zstd(agent_id, agent_key):
+    # Claims zstd, but the body is not a zstd frame at all.
+    target = "/stateless"
+    body = b"definitely not a zstd frame"
+    headers = _auth_header(agent_id, agent_key, "1", "POST", target, int(time.time()), body)
+    headers["Content-Encoding"] = "zstd"
+    return headers, body, target
+
+
+def scenario_zstd_decompressed_too_large(agent_id, agent_key):
+    # Highly repetitive plaintext that compresses far below the wire cap, but decompresses well
+    # past AuthConfig's 10 MiB body cap -- must be rejected with 413, without ever reaching the
+    # endpoint handler.
+    target = "/stateless"
+    plain = b"A" * (MAX_BODY_SIZE + 1024 * 1024)
+    compressed = zstandard.ZstdCompressor().compress(plain)
+    headers = _auth_header(agent_id, agent_key, "1", "POST", target, int(time.time()), compressed)
+    headers["Content-Encoding"] = "zstd"
+    return headers, compressed, target
+
+
 SCENARIOS = [
     ("valid_request", 202, scenario_valid),
     ("missing_protocol_version", 400, scenario_missing_protocol_version),
@@ -267,6 +310,10 @@ SCENARIOS = [
     ("header_value_too_large", CONN_CLOSED, scenario_header_value_too_large),
     ("too_many_headers", CONN_CLOSED, scenario_too_many_headers),
     ("transport_body_too_large", CONN_CLOSED, scenario_transport_body_too_large),
+    ("zstd_encoded_valid_request", 202, scenario_zstd_encoded),
+    ("unsupported_content_encoding_gzip", 415, scenario_unsupported_content_encoding),
+    ("malformed_zstd_body", 400, scenario_malformed_zstd),
+    ("zstd_decompressed_body_too_large", 413, scenario_zstd_decompressed_too_large),
 ]
 
 

--- a/src/remoted/remoted_module/tools/send_stateless.py
+++ b/src/remoted/remoted_module/tools/send_stateless.py
@@ -281,12 +281,21 @@ def scenario_malformed_zstd(agent_id, agent_key):
     return headers, body, target
 
 
-def scenario_zstd_decompressed_too_large(agent_id, agent_key):
-    # Highly repetitive plaintext that compresses far below the wire cap, but decompresses well
-    # past AuthConfig's 10 MiB body cap -- must be rejected with 413, without ever reaching the
-    # endpoint handler.
+def scenario_zstd_body_beyond_the_auth_cap(agent_id, agent_key):
+    # auth_max_body_size (10 MiB) bounds the WIRE body only. A DECOMPRESSED body is bounded by the
+    # server's live in-flight capacity instead (max_inflight_bytes, 256 MiB by default), so a batch
+    # that decompresses well past 10 MiB is accepted -- that is the behavior change zstd support
+    # introduced, and what this scenario pins down.
+    #
+    # There is deliberately no e2e scenario for the 413 that capacity exhaustion produces: with the
+    # default 256 MiB budget a single request cannot realistically reach it, and forcing it would
+    # mean making the manager allocate hundreds of MiB. Both 413 paths (the decoder's buffers and
+    # the growing output) are covered by bodyDecoder_test.cpp, and the concurrent-pressure case by
+    # authGateway_test.cpp's 50-request test.
     target = "/stateless"
-    plain = b"A" * (MAX_BODY_SIZE + 1024 * 1024)
+    event = b"E 1:/var/log/syslog:" + b"x" * 1000 + b"\n"
+    header = b'H {"wazuh":{"agent":{"id":"1001"}}}\n'
+    plain = header + event * ((MAX_BODY_SIZE + 1024 * 1024) // len(event) + 1)
     compressed = zstandard.ZstdCompressor().compress(plain)
     headers = _auth_header(agent_id, agent_key, "1", "POST", target, int(time.time()), compressed)
     headers["Content-Encoding"] = "zstd"
@@ -313,7 +322,7 @@ SCENARIOS = [
     ("zstd_encoded_valid_request", 202, scenario_zstd_encoded),
     ("unsupported_content_encoding_gzip", 415, scenario_unsupported_content_encoding),
     ("malformed_zstd_body", 400, scenario_malformed_zstd),
-    ("zstd_decompressed_body_too_large", 413, scenario_zstd_decompressed_too_large),
+    ("zstd_body_beyond_the_auth_cap", 202, scenario_zstd_body_beyond_the_auth_cap),
 ]
 
 

--- a/src/remoted/src/secure.c
+++ b/src/remoted/src/secure.c
@@ -274,6 +274,8 @@ STATIC void remoted_module_https_config(remoted_module_config_t *rm_config) {
     // this is per IN-FLIGHT TRANSFER: the worst case is roughly this times the number of
     // simultaneous downloads, so a large value trades memory for fewer read/write round trips.
     rm_config->http_stream_chunk_size = getDefine_Int_default("remoted", "http_stream_chunk_size", 4096, 1048576, 65536);
+    rm_config->http_content_encoding_enabled =
+        getDefine_Int_default("remoted", "http_content_encoding_enabled", 0, 1, 1);
 
     // Memory-management (backpressure) tunables. These bound in-memory resource usage rather
     // than tune the transport itself; the C++ side still clamps max_inflight_bytes up to at

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -3178,6 +3178,7 @@ void test_remoted_module_https_config_defaults(void** state)
     will_return(__wrap_getDefine_Int_default, 2);
     will_return(__wrap_getDefine_Int_default, 8192);
     will_return(__wrap_getDefine_Int_default, 65536); // http_stream_chunk_size
+    will_return(__wrap_getDefine_Int_default, 1);     // http_content_encoding_enabled (1 = enabled)
     // memory-management
     will_return(__wrap_getDefine_Int_default, 268435456);
     will_return(__wrap_getDefine_Int_default, 512);
@@ -3224,6 +3225,7 @@ void test_remoted_module_https_config_defaults(void** state)
     assert_int_equal(rm_config.auth_max_request_age, 300);
     assert_int_equal(rm_config.auth_max_future_skew, 30);
     assert_int_equal(rm_config.auth_max_body_size, 10485760);
+    assert_true(rm_config.http_content_encoding_enabled);
 }
 
 void test_remoted_module_https_config_custom_values(void** state)
@@ -3248,6 +3250,9 @@ void test_remoted_module_https_config_custom_values(void** state)
     will_return(__wrap_getDefine_Int_default, 4);
     will_return(__wrap_getDefine_Int_default, 16384);
     will_return(__wrap_getDefine_Int_default, 131072); // http_stream_chunk_size
+    will_return(__wrap_getDefine_Int_default, 0);       // http_content_encoding_enabled: 0 = disabled, the
+                                                       // opposite of its default, so a field wired to the
+                                                       // wrong queue slot fails the assert below
     // memory-management
     will_return(__wrap_getDefine_Int_default, 33554432);
     will_return(__wrap_getDefine_Int_default, 256);
@@ -3294,6 +3299,7 @@ void test_remoted_module_https_config_custom_values(void** state)
     assert_int_equal(rm_config.auth_max_request_age, 600);
     assert_int_equal(rm_config.auth_max_future_skew, 45);
     assert_int_equal(rm_config.auth_max_body_size, 31457280);
+    assert_false(rm_config.http_content_encoding_enabled);
 }
 
 /* Tests w_remoted_build_module_config */
@@ -3333,8 +3339,9 @@ void test_w_remoted_build_module_config_all_fields_populated(void** state)
     will_return(__wrap_getDefine_Int_default, 4);
     will_return(__wrap_getDefine_Int_default, 2);
     will_return(__wrap_getDefine_Int_default, 8192);
-    // memory-management
     will_return(__wrap_getDefine_Int_default, 65536); // http_stream_chunk_size
+    will_return(__wrap_getDefine_Int_default, 1);     // http_content_encoding_enabled (1 = enabled)
+    // memory-management
     will_return(__wrap_getDefine_Int_default, 268435456);
     will_return(__wrap_getDefine_Int_default, 512);
     will_return(__wrap_getDefine_Int_default, 256);
@@ -3388,9 +3395,10 @@ void test_w_remoted_build_module_config_null_https_strings_leave_buffers_empty(v
     will_return(__wrap_getDefine_Int_default, 4);
     will_return(__wrap_getDefine_Int_default, 2);
     will_return(__wrap_getDefine_Int_default, 8192);
+    will_return(__wrap_getDefine_Int_default, 65536); // http_stream_chunk_size
+    will_return(__wrap_getDefine_Int_default, 1);      // http_content_encoding_enabled
     will_return(__wrap_getDefine_Int_default, 268435456);
     will_return(__wrap_getDefine_Int_default, 512);
-    will_return(__wrap_getDefine_Int_default, 65536); // http_stream_chunk_size
     will_return(__wrap_getDefine_Int_default, 256);
     will_return(__wrap_getDefine_Int_default, 2);
     will_return(__wrap_getDefine_Int_default, 5);


### PR DESCRIPTION
## Description

Adds optional `Content-Encoding: zstd` support to remoted's HTTPS `/stateless`
endpoint, so agents can send a compressed event batch instead of a raw one.
No other compression scheme is supported — `gzip` is explicitly rejected.

Decompression happens **after** authentication succeeds, never before: the
AES-CMAC signature always covers the exact bytes as sent on the wire (the
compressed body, if `Content-Encoding: zstd` is present), so an
unauthenticated request can never spend the manager's CPU or memory
decompressing anything. Only a request that already passed the full
protocol-version + Authorization + timestamp-window + key + CMAC check ever
reaches the decompressor.

The decompressed size is bounded by the same `remoted.auth_max_body_size` cap
(10 MiB default) that already applies to an uncompressed body, and that cap
is enforced *while* decompressing, not just at the end — so a small,
highly-compressed "decompression bomb" body is rejected the instant it would
cross the cap, before the full decompressed payload is ever held in memory.
The same defense applies to the zstd frame header itself: a zstd frame can
declare an arbitrarily large decompression window before a single byte of
output exists, so the decoder caps that window to whatever the configured
`maxOutputSize` could possibly need — never zstd's own 128 MiB library
default — so a malicious header claiming a huge window is rejected outright
instead of forcing a large up-front allocation.

## Proposed changes

- **New `zstdDecoder` module**
  (`src/remoted/remoted_module/src/common/zstdDecoder.{hpp,cpp}`): streaming
  zstd decompression via `ZSTD_decompressStream()`, checking the running
  output size after every 64 KiB chunk against `maxOutputSize`. Returns either
  the decompressed bytes or a `ZstdDecodeError` (`Malformed` — bad magic,
  truncated frame, or oversized window; `TooLarge` — would exceed the byte
  cap).

- **`AuthGateway` wired to decode after auth**
  (`src/remoted/remoted_module/src/endpoints/authGateway.{hpp,cpp}`): reads
  `Content-Encoding` once per request (case-insensitive), but only acts on it
  *after* `beginSession()`/CMAC verification succeeds. On success, replaces
  the request's `Payload` with a new one backed by the decompressed bytes,
  owned by their own keep-alive (the original compressed-body keep-alive is
  released at that point). A missing header keeps today's behavior (body
  passed through unchanged, no zstd involved).

- **Two new auth error cases**
  (`src/remoted/remoted_module/src/auth/authTypes.hpp`,
  `authMiddleware.cpp`):
  - `UnsupportedContentEncoding` → `415 Unsupported Content-Encoding` (any
    value other than `zstd`, including `gzip`).
  - `MalformedContentEncoding` → `400 Malformed compressed body` (header says
    `zstd` but the body isn't a valid/complete zstd frame).
  - The existing `BodyTooLarge` (`413`) is reused when the *decompressed*
    size would exceed the cap.

- **Build: vendor and link zstd (server-only)**
  - `src/external/CMakeLists.txt`: new `ExternalProject_Add(zstd_external)`
    building zstd's own `build/cmake` project as a static, position-independent
    library (`libzstd.a`), skipping shared libs/tests/programs/legacy support.
  - `src/remoted/remoted_module/CMakeLists.txt`: links `ext_zstd` into
    `remoted_module`.
  - `src/Makefile`: adds `zstd` to `EXTERNAL_RES` for manager-only builds
    (excluded for `agent`/`winagent` targets, matching the rest of the
    manager-only dependency list).

- **Tests**
  - `zstdDecoder_test.cpp` (new, 124 lines): valid frames, malformed/truncated
    input, oversized-window rejection, the `TooLarge` boundary.
  - `authGateway_test.cpp` (+231 lines): end-to-end coverage of the
    `Content-Encoding` header handling — valid zstd, malformed zstd, oversized
    decompressed body, unsupported encodings (including `gzip`), missing
    header (pass-through).
  - `gzipTestHelper.hpp` / `zstdTestHelper.hpp` (new): test-only helpers to
    build gzip- and zstd-compressed fixtures for the above.

- **Tooling**
  - `send_stateless.py`: extended to sign and send zstd-compressed bodies,
    and to cover the malformed/oversized/unsupported-encoding scenarios in
    `--all`.
  - `requirements.txt` (new, `tools/`): pins `requests`, `cryptography`,
    `zstandard` for the manual test tooling.

- **Docs**
  - `docs/ref/modules/remoted/https-events-api.md`: new "Content-Encoding
    (zstd)" section; updated error-response table (`415`, new `400` case,
    `413` now also covers the decompressed-size check); notes that
    `/stateless` now actually forwards the H/E batch downstream (no longer
    auth-only).
  - `docs/ref/modules/remoted/stateless-api.yaml`: `ContentEncoding` header
    parameter added to `POST /stateless`; response schemas/examples updated
    for `415` and the new `400` case.

### Results and Evidence

#### Install
```
[notice] To update, run: /var/wazuh-manager/framework/python/bin/python3 -m pip install --upgrade pip
cd ../tools/mitre && /var/wazuh-manager/framework/python/bin/python3 mitredb.py -d /var/wazuh-manager/var/db/mitre.db
Generating schema files...
Loading resources...
Loading WCS files from directory external/wcs-flat-files/...
Found 1 YAML files to merge: ['wcs_flat.yml']
Loading wcs_flat.yml...
Successfully merged 1 files into temporary file: /tmp/merged_wcs_eaqzubqo.yml
Loading schema template...
Loading logpar overrides template...
Generating geo/as enrichment map...
Success.
Generating enrichment sources config...
Success.
Building field tree from WCS definition...
Success.
Generating engine schema...
Generating fields schema properties...
Success.
Generating clean properties mapping...
Success.
Generating logpar configuration...
Success.
Cleaned up temporary file: /tmp/merged_wcs_eaqzubqo.yml
Saving files to "engine/ruleset/schemas/"...
Generated wazuh-decoders.json
Success.
Schema files generated successfully.
Copying store files...
Engine store installed successfully.
Engine output configuration files installed successfully.
Installing GeoIP databases...
GeoIP databases installed successfully.
Installing timezone database...
Timezone database installed successfully.
Generating self-signed certificate for wazuh-manager-authd...
Generating self-signed certificate for the HTTPS agent server...


 - System is Debian (Ubuntu or derivative).
 - Init script modified to start Wazuh during boot.
Starting Wazuh...
manager
Starting Wazuh v5.0.0...
Started wazuh-manager-apid...
Started wazuh-manager-authd...
Started wazuh-manager-db...
Started wazuh-manager-analysisd...
Started wazuh-manager-remoted...
Started wazuh-manager-monitord...
Started wazuh-manager-modulesd...
Started wazuh-manager-clusterd...
Completed.
```

### Test with full session using POC

```
(venv) ╭─root@89ebd703d7af /workspaces/devContainer/compression_poc/build
╰─# ./compression_poc ../session-003-7312911804883877892-req000002.session.log
Input: ../session-003-7312911804883877892-req000002.session.log (48100793 bytes)
Best of 5 run(s) per row.

codec               orig B  compressed B      ratio       compress        c.speed     decompress        d.speed
gzip-6 (dflt)     48100793       4255055      91.2%      224.38 ms      204.44 MB/s       44.20 ms     1037.73 MB/s
gzip-9 (max)      48100793       4104588      91.5%      428.57 ms      107.04 MB/s       43.05 ms     1065.59 MB/s
zstd-3 (dflt)     48100793       3663975      92.4%       55.45 ms      827.31 MB/s       24.00 ms     1911.08 MB/s
zstd-9            48100793       3445014      92.8%      156.67 ms      292.80 MB/s       24.25 ms     1891.97 MB/s
zstd-19 (max)     48100793       2775204      94.2%     7053.06 ms        6.50 MB/s       21.87 ms     2097.48 MB/s

All round-trips verified byte-for-byte identical to the original.
```

### Python setup

```
(venv) ╭─root@89ebd703d7af /workspaces/devContainer 
╰─# python3 wazuh/src/remoted/remoted_module/tools/send_stateless.py --all
Running 20 scenarios against https://127.0.0.1:9443 (agent 1001)

[PASS] valid_request: expected 202, got 202 (73 byte body) -- 
[PASS] missing_protocol_version: expected 400, got 400 (73 byte body) -- {"error":"Missing required header: protocol-version","code":400}
[PASS] unsupported_protocol_version: expected 400, got 400 (73 byte body) -- {"error":"Unsupported protocol-version","code":400}
[PASS] missing_authorization: expected 401, got 401 (73 byte body) -- {"error":"Invalid client authentication","code":401}
[PASS] malformed_authorization: expected 401, got 401 (73 byte body) -- {"error":"Invalid client authentication","code":401}
[PASS] unknown_agent: expected 401, got 401 (73 byte body) -- {"error":"Invalid client authentication","code":401}
[PASS] expired_request: expected 401, got 401 (73 byte body) -- {"error":"Invalid client authentication","code":401}
[PASS] future_request: expected 401, got 401 (73 byte body) -- {"error":"Invalid client authentication","code":401}
[PASS] invalid_mac_tampered_body: expected 401, got 401 (9 byte body) -- {"error":"Invalid client authentication","code":401}
[PASS] payload_agent_mismatch: expected 400, got 400 (73 byte body) -- {"error":"Invalid event batch","code":400}
[PASS] body_too_large: expected 413, got 413 (11534336 byte body) -- {"error":"Request payload is too large","code":413}
[PASS] url_too_large: connection dropped as expected (ConnectionError)
[PASS] header_name_too_large: connection dropped as expected (ConnectionError)
[PASS] header_value_too_large: connection dropped as expected (ConnectionError)
[PASS] too_many_headers: connection dropped as expected (ConnectionError)
[PASS] transport_body_too_large: connection dropped as expected (SSLError)
[PASS] zstd_encoded_valid_request: expected 202, got 202 (82 byte body) -- 
[PASS] unsupported_content_encoding_gzip: expected 415, got 415 (73 byte body) -- {"error":"Unsupported Content-Encoding","code":415}
[PASS] malformed_zstd_body: expected 400, got 400 (27 byte body) -- {"error":"Malformed compressed body","code":400}
[PASS] zstd_decompressed_body_too_large: expected 413, got 413 (371 byte body) -- {"error":"Request payload is too large","code":413}

20/20 scenarios passed.
```



### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
