### PR TITLE
Remove always-zero millisecond computation from timeHelper

### DIFF
--- a/src/shared_modules/utils/timeHelper.h
+++ b/src/shared_modules/utils/timeHelper.h
@@ -17,16 +17,16 @@
 #include <cmath>
 #include <ctime>
 #include <iomanip>
+#include <regex>
 #include <sstream>
 #include <string>
-#include <regex>
 #if __cplusplus >= 201703L
 #include <charconv>
 #include <string_view>
 #endif
 
 #define ISO8601_LENGTH_WITH_MS 24
-#define ISO8601_LENGTH_NO_MS 20
+#define ISO8601_LENGTH_NO_MS   20
 
 #ifdef WIN32
 
@@ -59,9 +59,7 @@ namespace Utils
     static std::string getTimestamp(const std::time_t& time, const bool utc = true)
     {
         std::stringstream ss;
-        struct tm buf
-        {
-        };
+        struct tm buf {};
 
         // gmtime: result expressed as a UTC time
         tm const* localTime {utc ? gmtime_r(&time, &buf) : localtime_r(&time, &buf)};
@@ -106,9 +104,7 @@ namespace Utils
     static std::string getCompactTimestamp(const std::time_t& time, const bool utc = true)
     {
         std::stringstream ss;
-        struct tm buf
-        {
-        };
+        struct tm buf {};
 
         // gmtime: result expressed as a UTC time
         tm const* localTime {utc ? gmtime_r(&time, &buf) : localtime_r(&time, &buf)};
@@ -139,9 +135,7 @@ namespace Utils
         auto itt = std::chrono::system_clock::to_time_t(now);
 
         std::ostringstream ss;
-        struct tm buf
-        {
-        };
+        struct tm buf {};
         tm const* localTime = gmtime_r(&itt, &buf);
 
         if (localTime == nullptr)
@@ -293,9 +287,7 @@ namespace Utils
         {
             std::time_t time = timestamp;
             std::ostringstream output;
-            struct tm buf
-            {
-            };
+            struct tm buf {};
             tm const* localTime = gmtime_r(&time, &buf);
             if (localTime == nullptr)
             {
@@ -309,9 +301,7 @@ namespace Utils
         {
             std::time_t time = timestamp;
             std::ostringstream output;
-            struct tm buf
-            {
-            };
+            struct tm buf {};
             tm const* localTime = gmtime_r(&time, &buf);
             if (localTime == nullptr)
             {
@@ -341,9 +331,7 @@ namespace Utils
             }
             std::time_t time = std::stoi(timestamp);
             std::ostringstream output;
-            struct tm buf
-            {
-            };
+            struct tm buf {};
             tm const* localTime = gmtime_r(&time, &buf);
             if (localTime == nullptr)
             {
@@ -360,7 +348,8 @@ namespace Utils
                 // Check if timestamp has the format "YYYY/MM/DD hh:mm:ss"
                 // if not, check if it is already ISO8601.
                 auto ISO8601Timestamp = timestampToISO8601(std::string(timestamp));
-                return ISO8601Timestamp.empty() ? normalizeTimestampISO8601(std::string(timestamp)) : std::move(ISO8601Timestamp);
+                return ISO8601Timestamp.empty() ? normalizeTimestampISO8601(std::string(timestamp))
+                                                : std::move(ISO8601Timestamp);
             }
             std::time_t time;
             auto [ptr, ec] = std::from_chars(timestamp.data(), timestamp.data() + timestamp.size(), time);
@@ -369,9 +358,7 @@ namespace Utils
                 return "";
             }
             std::ostringstream output;
-            struct tm buf
-            {
-            };
+            struct tm buf {};
             tm const* localTime = gmtime_r(&time, &buf);
             if (localTime == nullptr)
             {

--- a/src/shared_modules/utils/timeHelper.h
+++ b/src/shared_modules/utils/timeHelper.h
@@ -185,8 +185,6 @@ namespace Utils
         }
         std::time_t time = std::mktime(&tm);
 
-        auto itt = std::chrono::system_clock::from_time_t(time);
-
         std::ostringstream output;
         struct tm const* localTime = gmtime_r(&time, &tm);
 
@@ -195,14 +193,8 @@ namespace Utils
             return "";
         }
 
-        output << std::put_time(localTime, "%Y-%m-%dT%H:%M:%S");
-
-        // Get milliseconds from the current time
-        auto milliseconds =
-            std::chrono::duration_cast<std::chrono::milliseconds>(itt.time_since_epoch()).count() % 1000;
-
-        // ISO 8601
-        output << '.' << std::setfill('0') << std::setw(3) << milliseconds << 'Z';
+        // ISO 8601. "YYYY/MM/DD hh:mm:ss" carries no sub-second part.
+        output << std::put_time(localTime, "%Y-%m-%dT%H:%M:%S") << ".000Z";
 
         return output.str();
     }
@@ -300,7 +292,6 @@ namespace Utils
         if constexpr (std::is_same_v<std::decay_t<T>, uint32_t>)
         {
             std::time_t time = timestamp;
-            auto itt = std::chrono::system_clock::from_time_t(time);
             std::ostringstream output;
             struct tm buf
             {
@@ -310,18 +301,13 @@ namespace Utils
             {
                 return "";
             }
-            output << std::put_time(localTime, "%Y-%m-%dT%H:%M:%S");
-            // Get milliseconds from the current time
-            auto milliseconds =
-                std::chrono::duration_cast<std::chrono::milliseconds>(itt.time_since_epoch()).count() % 1000;
-            // ISO 8601
-            output << '.' << std::setfill('0') << std::setw(3) << milliseconds << 'Z';
+            // ISO 8601. A whole-second timestamp carries no sub-second part.
+            output << std::put_time(localTime, "%Y-%m-%dT%H:%M:%S") << ".000Z";
             return output.str();
         }
         else if constexpr (std::is_same_v<std::decay_t<T>, double>)
         {
             std::time_t time = timestamp;
-            auto itt = std::chrono::system_clock::from_time_t(time);
             std::ostringstream output;
             struct tm buf
             {
@@ -334,11 +320,8 @@ namespace Utils
             output << std::put_time(localTime, "%Y-%m-%dT%H:%M:%S");
             if (std::abs(timestamp - static_cast<int>(timestamp)) < 1e-9)
             {
-                // Get milliseconds from the current time
-                auto milliseconds =
-                    std::chrono::duration_cast<std::chrono::milliseconds>(itt.time_since_epoch()).count() % 1000;
-                // ISO 8601
-                output << '.' << std::setfill('0') << std::setw(3) << milliseconds << 'Z';
+                // ISO 8601. No fractional part to render.
+                output << ".000Z";
             }
             else
             {
@@ -357,7 +340,6 @@ namespace Utils
                 return ISO8601Timestamp.empty() ? normalizeTimestampISO8601(timestamp) : std::move(ISO8601Timestamp);
             }
             std::time_t time = std::stoi(timestamp);
-            auto itt = std::chrono::system_clock::from_time_t(time);
             std::ostringstream output;
             struct tm buf
             {
@@ -367,12 +349,8 @@ namespace Utils
             {
                 return "";
             }
-            output << std::put_time(localTime, "%Y-%m-%dT%H:%M:%S");
-            // Get milliseconds from the current time
-            auto milliseconds =
-                std::chrono::duration_cast<std::chrono::milliseconds>(itt.time_since_epoch()).count() % 1000;
-            // ISO 8601
-            output << '.' << std::setfill('0') << std::setw(3) << milliseconds << 'Z';
+            // ISO 8601. A whole-second timestamp carries no sub-second part.
+            output << std::put_time(localTime, "%Y-%m-%dT%H:%M:%S") << ".000Z";
             return output.str();
         }
         else if constexpr (std::is_same_v<std::decay_t<T>, std::string_view>)
@@ -390,7 +368,6 @@ namespace Utils
             {
                 return "";
             }
-            auto itt = std::chrono::system_clock::from_time_t(time);
             std::ostringstream output;
             struct tm buf
             {
@@ -400,12 +377,8 @@ namespace Utils
             {
                 return "";
             }
-            output << std::put_time(localTime, "%Y-%m-%dT%H:%M:%S");
-            // Get milliseconds from the current time
-            auto milliseconds =
-                std::chrono::duration_cast<std::chrono::milliseconds>(itt.time_since_epoch()).count() % 1000;
-            // ISO 8601
-            output << '.' << std::setfill('0') << std::setw(3) << milliseconds << 'Z';
+            // ISO 8601. A whole-second timestamp carries no sub-second part.
+            output << std::put_time(localTime, "%Y-%m-%dT%H:%M:%S") << ".000Z";
             return output.str();
         }
         else


### PR DESCRIPTION
## Description

`Utils::rawTimestampToISO8601()` and `Utils::timestampToISO8601()` in `src/shared_modules/utils/timeHelper.h` advertise millisecond precision they cannot produce. Both compute the millisecond field out of a `std::chrono::time_point` obtained from `std::chrono::system_clock::from_time_t()`, whose granularity is a whole second, so the `% 1000` that extracts the sub-second part is a compile-time-constant zero.

The emitted values are correct (the seconds are right, and `.000` is the right rendering for a whole-second input), but the code reads as if it recovers a sub-second component from the input. It does not, and cannot: a `uint32_t` or a `"YYYY/MM/DD hh:mm:ss"` string has no sub-second component to recover. The comment above the computation, *"Get milliseconds from the current time"*, is doubly misleading, since the value it operates on is not the current time either.

Closes #38047

## Proposed Changes

Five call sites in `src/shared_modules/utils/timeHelper.h`, all the same defect.

**Mechanism.** In the `uint32_t` branch of the template, `timeHelper.h:300-320` before the change:

```cpp
std::time_t time = timestamp;
auto itt = std::chrono::system_clock::from_time_t(time);   // whole-second granularity
...
output << std::put_time(localTime, "%Y-%m-%dT%H:%M:%S");
// Get milliseconds from the current time
auto milliseconds =
    std::chrono::duration_cast<std::chrono::milliseconds>(itt.time_since_epoch()).count() % 1000;
// ISO 8601
output << '.' << std::setfill('0') << std::setw(3) << milliseconds << 'Z';
```

`from_time_t(t)` returns a `time_point` at exactly `t` seconds since epoch. Casting its `time_since_epoch()` to milliseconds therefore always yields `t * 1000`, an exact multiple of 1000, and `% 1000` is always `0`. There is no input, including the current time, for which this expression returns anything else.

**Change.** Append the `.000Z` literal and drop the `itt` local, the `duration_cast`, and the misleading comment:

```cpp
std::time_t time = timestamp;
std::ostringstream output;
...
// ISO 8601. A whole-second timestamp carries no sub-second part.
output << std::put_time(localTime, "%Y-%m-%dT%H:%M:%S") << ".000Z";
```

Applied to:

| Location | Input type |
|---|---|
| `timeHelper.h:170` `timestampToISO8601()` | `"YYYY/MM/DD hh:mm:ss"` string, parsed via `std::get_time` + `std::mktime` |
| `timeHelper.h:292` `rawTimestampToISO8601()` | `uint32_t` |
| `timeHelper.h:308` `rawTimestampToISO8601()` | `double`, integral path (`std::abs(timestamp - static_cast<int>(timestamp)) < 1e-9`) |
| `timeHelper.h:333` `rawTimestampToISO8601()` | `std::string` of digits |
| `timeHelper.h:356` `rawTimestampToISO8601()` | `std::string_view` of digits |

The fractional path of the `double` branch is untouched. It is the one place in the function that already handled the sub-second part correctly, by rounding `(timestamp - static_cast<int>(timestamp)) * 1000`, and it remains the only branch whose input actually carries sub-second information.

`timestampToISO8601()` is not listed in the issue but carries the identical dead computation in the same header, and is reachable from the `std::string` / `std::string_view` branches of `rawTimestampToISO8601()` when the input is not numeric, so it is fixed in the same pass.

Net effect: `-37 / +10` lines, no behavioral change.

### Results and Evidence

All runs below are on this branch's working tree, `g++ (GCC) 16.1.1`, `-std=c++17`.

**1. The removed expression is a constant zero.** Standalone program applying the deleted computation to a range of `uint32_t` inputs:

```
from_time_t(1) = 1000 ms ; % 1000 = 0
from_time_t(999999999) = 999999999000 ms ; % 1000 = 0
from_time_t(1605232465) = 1605232465000 ms ; % 1000 = 0
from_time_t(1700000000) = 1700000000000 ms ; % 1000 = 0
from_time_t(2147483647) = 2147483647000 ms ; % 1000 = 0
```

**2. Output is byte-identical before and after.** The same dump program was compiled twice, once against `timeHelper.h` at `93e4ed7ec1` (branch point) and once against the patched header, then run under `TZ=UTC` and diffed:

```
$ g++ -std=c++17 -Wall -Wextra -I old dump.cpp -o dump_before
$ g++ -std=c++17 -Wall -Wextra -I new dump.cpp -o dump_after
$ TZ=UTC ./dump_before > before.txt ; TZ=UTC ./dump_after > after.txt
$ diff -u before.txt after.txt
$ echo $?
0
```

Covered inputs and their (identical) output:

```
u32  0 -> 1970-01-01T00:00:00.000Z
str  0 -> 1970-01-01T00:00:00.000Z
sv   0 -> 1970-01-01T00:00:00.000Z
u32  1 -> 1970-01-01T00:00:01.000Z
str  1 -> 1970-01-01T00:00:01.000Z
sv   1 -> 1970-01-01T00:00:01.000Z
u32  999999999 -> 2001-09-09T01:46:39.000Z
str  999999999 -> 2001-09-09T01:46:39.000Z
sv   999999999 -> 2001-09-09T01:46:39.000Z
u32  1605232465 -> 2020-11-13T01:54:25.000Z
str  1605232465 -> 2020-11-13T01:54:25.000Z
sv   1605232465 -> 2020-11-13T01:54:25.000Z
u32  1700000000 -> 2023-11-14T22:13:20.000Z
str  1700000000 -> 2023-11-14T22:13:20.000Z
sv   1700000000 -> 2023-11-14T22:13:20.000Z
u32  2147483647 -> 2038-01-19T03:14:07.000Z
str  2147483647 -> 2038-01-19T03:14:07.000Z
sv   2147483647 -> 2038-01-19T03:14:07.000Z
dbl  0 -> 1970-01-01T00:00:00.000Z
dbl  1.5 -> 1970-01-01T00:00:01.500Z
dbl  1.60523e+09 -> 2020-11-13T01:54:25.000Z
dbl  1.60523e+09 -> 2020-11-13T01:54:25.665Z
dbl  1.60523e+09 -> 2020-11-13T01:54:25.040Z
dbl  1.60523e+09 -> 2020-11-13T01:54:25.999Z
ts   2025/12/01 18:25:40 -> '2025-12-01T18:25:40.000Z'
ts   2025/06/30 18:29:50 -> '2025-06-30T18:29:50.000Z'
ts   21:00:00 -> ''
```

The `dbl 1.5 -> ...01.500Z` and `...25.665Z` / `...25.040Z` / `...25.999Z` lines confirm the fractional `double` path is unaffected; the `ts 21:00:00 -> ''` line confirms the parse-failure early return in `timestampToISO8601()` is unaffected.

**3. Existing unit tests pass, before and after.** `src/shared_modules/utils/tests/timeHelper_test.cpp` already asserts `.000Z` on every affected input (`timeHelper_test.cpp:92-93, 98, 102, 106, 128-131`), so it is a direct regression guard for this change. Built with `-Wall -Wextra -Werror` against both headers:

```
=== BEFORE (93e4ed7ec1) ===
[       OK ] TimeUtilsTest.RawTimestampToISO8601 (0 ms)
[----------] 8 tests from TimeUtilsTest (1 ms total)
[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 8 tests.

=== AFTER (this branch) ===
[       OK ] TimeUtilsTest.RawTimestampToISO8601 (0 ms)
[----------] 8 tests from TimeUtilsTest (1 ms total)
[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 8 tests.
```

Full suite, after:

```
[==========] Running 8 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 8 tests from TimeUtilsTest
[ RUN      ] TimeUtilsTest.CheckTimestamp
[       OK ] TimeUtilsTest.CheckTimestamp (0 ms)
[ RUN      ] TimeUtilsTest.CheckTimestampValidFormat
[       OK ] TimeUtilsTest.CheckTimestampValidFormat (0 ms)
[ RUN      ] TimeUtilsTest.CheckTimestampInvalidFormat
[       OK ] TimeUtilsTest.CheckTimestampInvalidFormat (0 ms)
[ RUN      ] TimeUtilsTest.CheckTimestampError
[       OK ] TimeUtilsTest.CheckTimestampError (0 ms)
[ RUN      ] TimeUtilsTest.CheckCompactTimestampValidFormat
[       OK ] TimeUtilsTest.CheckCompactTimestampValidFormat (0 ms)
[ RUN      ] TimeUtilsTest.CheckCompactTimestampInvalidFormat
[       OK ] TimeUtilsTest.CheckCompactTimestampInvalidFormat (0 ms)
[ RUN      ] TimeUtilsTest.TimestampToISO8601
[       OK ] TimeUtilsTest.TimestampToISO8601 (0 ms)
[ RUN      ] TimeUtilsTest.RawTimestampToISO8601
[       OK ] TimeUtilsTest.RawTimestampToISO8601 (0 ms)
[----------] 8 tests from TimeUtilsTest (1 ms total)
[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 8 tests.
```

No new warnings on either build.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

Only the Linux column applies: the change is in a header-only utility, the removed code has no platform-conditional behavior, and the Windows path differs only by the `gmtime_r` shim at `timeHelper.h:33`, which is untouched. Memory tooling is not applicable, the change removes two stack locals and adds no allocation.

### Artifacts Affected

None in terms of behavior. `src/shared_modules/utils/timeHelper.h` is a header-only utility, so every consumer recompiles but emits the same values:

- `wazuh-agent` / `wazuh-modulesd` inventory (`process.start` on Linux `src/data_provider/src/sysInfoLinux.cpp:117`, Windows `src/data_provider/src/sysInfoWin.cpp:390`, macOS `src/data_provider/src/sysInfoMac.cpp:80`)
- `package.installed` for snap packages, `PackageLinuxHelper::parseSnap` in `src/data_provider/src/packages/packageLinuxParserHelper.h`

### Configuration Changes

N/A

### Tests Introduced

None. The existing `TimeUtilsTest.RawTimestampToISO8601` and `TimeUtilsTest.TimestampToISO8601` cases in `src/shared_modules/utils/tests/timeHelper_test.cpp` already pin `.000Z` for every affected input type and serve as the regression guard, as shown in the evidence above. Adding cases would duplicate them.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
