### PR TITLE
Do not unwind wazuh-syscheckd while the FIM threads are still running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,5 +119,5 @@
 | [#37656](https://github.com/wazuh/wazuh/issues/37656) | Fixed an unbounded memory leak in `wazuh-modulesd` caused by a missing RPM macro context cleanup on every package scan cycle. |
 | [#37543](https://github.com/wazuh/wazuh/issues/37543) | Fixed agent-info module caching cluster_name, cluster_node, and agent_groups from a one-time handshake at startup, causing stale values in `agent_metadata` until the agent process restarted. |
 | [#37993](https://github.com/wazuh/wazuh/issues/37993) | Fixed `wazuh-syscheckd` failing the `file_entry.checksum` NOT NULL constraint when the deferred sync-flag update ran for an entry deleted during the scan. |
-| [#37993](https://github.com/wazuh/wazuh/issues/37993) | Fixed `wazuh-syscheckd` unwinding its static destructors on shutdown while the FIM scan thread was still using them, which logged "Invalid handle value." bursts and non-printable messages, crashed the process and left a stale PID file. |
+| [#37993](https://github.com/wazuh/wazuh/issues/37993) | Fixed `wazuh-syscheckd` failure on shutdown, which logged "Invalid handle value", crashed the process and left a stale PID file. |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,4 +119,5 @@
 | [#37656](https://github.com/wazuh/wazuh/issues/37656) | Fixed an unbounded memory leak in `wazuh-modulesd` caused by a missing RPM macro context cleanup on every package scan cycle. |
 | [#37543](https://github.com/wazuh/wazuh/issues/37543) | Fixed agent-info module caching cluster_name, cluster_node, and agent_groups from a one-time handshake at startup, causing stale values in `agent_metadata` until the agent process restarted. |
 | [#37993](https://github.com/wazuh/wazuh/issues/37993) | Fixed `wazuh-syscheckd` failing the `file_entry.checksum` NOT NULL constraint when the deferred sync-flag update ran for an entry deleted during the scan. |
+| [#37993](https://github.com/wazuh/wazuh/issues/37993) | Fixed `wazuh-syscheckd` unwinding its static destructors on shutdown while the FIM scan thread was still using them, which logged "Invalid handle value." bursts and non-printable messages, crashed the process and left a stale PID file. |
 

--- a/src/syscheckd/src/main.c
+++ b/src/syscheckd/src/main.c
@@ -122,7 +122,7 @@ static void *fim_shutdown_waiter(__attribute__((unused)) void *arg)
          * (stop-aware waits, predicated sends, 1-second sleeps), so it reports its exit
          * through fim_sync_exit_pipe well within this timeout. If it does not, skip the
          * join and the teardown below — destroying the handle under a live thread is the
-         * use-after-free this waiter exists to prevent — and let HandleSIG() exit. */
+         * use-after-free this waiter exists to prevent — and proceed to _exit(). */
         struct pollfd sync_exit_poll = { .fd = fim_sync_exit_pipe[0], .events = POLLIN, .revents = 0 };
         int poll_ret;
 

--- a/src/syscheckd/src/main.c
+++ b/src/syscheckd/src/main.c
@@ -174,7 +174,14 @@ static void *fim_shutdown_waiter(__attribute__((unused)) void *arg)
         }
     }
 
-    HandleSIG((int)fim_shutdown_sig);
+    /* Not HandleSIG(): its exit() would run the static destructors and the atexit handlers
+     * while the threads this waiter could not join are still using them (issue #37993). */
+    minfo(SIGNAL_RECV, (int)fim_shutdown_sig, strsignal((int)fim_shutdown_sig));
+#ifdef ENABLE_AUDIT
+    clean_rules();
+#endif
+    DeletePID(ARGV0);
+    _exit(1);
 
     return NULL;
 }

--- a/src/syscheckd/src/whodata/audit_rule_handling.c
+++ b/src/syscheckd/src/whodata/audit_rule_handling.c
@@ -251,6 +251,11 @@ int fim_manipulated_audit_rules() {
 void clean_rules(void) {
     OSListNode *node;
 
+    /* Also reached before audit_init() built the list, e.g. when Auditd is not running. */
+    if (whodata_directories == NULL) {
+        return;
+    }
+
     w_mutex_lock(&rules_mutex);
 
     atomic_int_set(&audit_thread_active, 0);


### PR DESCRIPTION
## Description

Second of the two error patterns reported for `wazuh-syscheckd` during the 5.x vs 4.x performance test: `ERROR: Invalid handle value.` bursts right after SIGTERM on 7 of 100 agents, followed on 5 of those 7 by log lines carrying raw non-printable bytes. The first pattern (`file_entry.checksum` NOT NULL) was fixed in #38045.

Reproducing it showed the reported log lines are the mild face of the fault. When the SIGTERM lands while a scheduled scan is running, the daemon **crashes** and leaves a stale PID file behind, with no memory-debugging tooling involved.

Closes #37993

## Proposed Changes

`fim_shutdown_waiter()` leaves through `HandleSIG()`, whose `exit()` runs the C++ static destructors and the `atexit` handlers:

```c
// src/shared/src/sig_op.c:37
void HandleSIG(int sig)
{
    minfo(SIGNAL_RECV, sig, strsignal(sig));

    exit(1);
}
```

The threads that use those objects are never joined. The waiter guards only `fim_db_teardown()` against a live scan, with a trylock, and unwinds anyway:

```c
// src/syscheckd/src/main.c:167
if (pthread_mutex_trylock(&syscheck.fim_scan_mutex) == 0)
{
    fim_db_teardown();
}
else
{
    mdebug1("Skipping the FIM database teardown: a scan is in progress.");
}

HandleSIG((int)fim_shutdown_sig);
```

So a SIGTERM during a scheduled scan skips the teardown and then frees, underneath the still-running scan thread, everything it is holding:

- `PipelineFactory`'s map frees the pipeline, so `fim_db_transaction_sync_row()` (`db.cpp:430`) reads a freed map node in `PipelineFactory::pipeline()` and throws `INVALID_HANDLE`, logged as the bare `err.what()` — the reported message, one line per file.
- `DBSyncImplementation` frees the database context, corrupting the buffers the scan is building.
- `isValidISO8601Date()`'s function-local `static std::regex` is freed while `regex_match()` reads it, so valid timestamps start failing schema validation.

That matches the reported timing: first occurrence clusters at 41-47 min after agent start on all 7 nodes, a scheduled-scan boundary, and it only hit the agents whose SIGTERM landed mid-scan.

### The change

Leave without unwinding, so nothing is freed while those threads run, and call directly the two `atexit` handlers that did matter:

```c
    /* Not HandleSIG(): its exit() would run the static destructors and the atexit handlers
     * while the threads this waiter could not join are still using them (issue #37993). */
    minfo(SIGNAL_RECV, (int)fim_shutdown_sig, strsignal((int)fim_shutdown_sig));
#ifdef ENABLE_AUDIT
    clean_rules();
#endif
    DeletePID(ARGV0);
    _exit(1);
```

`clean_rules()` is now reachable on paths where `audit_init()` returned before it built the rule list — most commonly when Auditd is not running — so it returns early when there is nothing to walk:

```c
 void clean_rules(void) {
     OSListNode *node;

+    /* Also reached before audit_init() built the list, e.g. when Auditd is not running. */
+    if (whodata_directories == NULL) {
+        return;
+    }
+
     w_mutex_lock(&rules_mutex);
```

Three files, `+14 −1`. No shared library is touched. `fim.db` needs no unwinding of its own: it runs `journal_mode = truncate` (`sqlite_dbengine.cpp:620`), and the ordered `fim_db_teardown()` above still closes it when no scan is in flight.

An earlier revision instead made the individual objects immortal. Rejected on measurement: it only moves the fault to the next static (fixing the pipeline left the daemon still aborting on the freed database context), and making `DBSyncImplementation` immortal stops dbsync closing its SQLite connections at exit, which the dbsync RTR leak gate correctly caught as 4 `possibly lost` page-cache blocks.

### Results and Evidence

Isolated Ubuntu 24.04 VM (kernel 6.8.0-136, `auditd` 3.1.2), agent built from this branch. `/var/fimvg` holds 140 000 files so a scheduled scan is still walking when the signal arrives; `/var/fimwd` is the whodata directory. Every round of scenario 1 reached the reported precondition (`teardown-skipped=1`).

One baseline shutdown, in order:

```
fim_scan.c:61   fim_scan(): INFO: (6008): File integrity monitoring scan started.
main.c:173      fim_shutdown_waiter(): DEBUG: Skipping the FIM database teardown: a scan is in progress.
sig_op.c:39     HandleSIG(): INFO: (1225): SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
file.c:316      transaction_callback(): DEBUG: INSERTED: file_limit=0 (unlimited), sync_flag=1, path=/var/fimvg/v_9321
run_check.c:434 validate_and_persist_fim_event(): DEBUG: Ignoring schema validation failure for file
                /var/fimvg/v_9321 during shutdown: file.mtime: Invalid date format.
                Expected ISO8601, got: 2026-08-04T06:28:19.000Z
Segmentation fault (core dumped)
```

The scan is still inserting after `HandleSIG()`, and `2026-08-04T06:28:19.000Z` is valid ISO8601 being rejected by the freed regex.

**Scenario 1 — the reported fault. SIGTERM 3 s into the scan, 6 rounds:**

| build | shutdown result | stale PID files |
|---|---|---|
| base `93e4ed7ec1` | **2/6 SIGSEGV** | 2 |
| this change | **6/6 clean exit(1)** | 0 |

On a busier 4-core container the same base build aborted 6/6 (`pure virtual method called`) and 6/6 SIGSEGV under `MALLOC_PERTURB_=170`; this change was 6/6 clean in both.

**Scenario 2 — whodata with the audit provider, `auditd` running. Are the Audit rules removed on stop?**

| build | rule while running | rules after SIGTERM |
|---|---|---|
| base | `-w /var/fimwd -p wa -k wazuh_fim` | 0 |
| this change | `-w /var/fimwd -p wa -k wazuh_fim` | **0** |

Without the explicit `clean_rules()` call this left the rule loaded (1 instead of 0), which is the regression `_exit()` introduces and why that call is in the diff.

**Scenario 3 — whodata configured but `auditd` stopped**, so `audit_init()` returns before building the rule list:

| build | result |
|---|---|
| base | clean exit(1) |
| `clean_rules()` without the NULL guard | **SIGSEGV** |
| this change | clean exit(1) |

**Scenario 4 — whodata off, plain realtime:** base clean exit(1), this change clean exit(1).

Under `valgrind --tool=memcheck` the base reports the use-after-free and names the owner. Trimmed of template noise:

```
==10902== Invalid read of size 8
==10902==    at 0x4CA5A33: _M_lower_bound(...) (stl_tree.h:1952)
==10902==    by 0x4CA4E6D: find(void* const&) (stl_tree.h:2532)
==10902==    by 0x4CA139B: DbSync::PipelineFactory::pipeline(void*) (dbsyncPipelineFactory.cpp:170)
==10902==    by 0x4C57D8A: DBSyncTxn::syncTxnRow(...) (dbsync.cpp:996)
==10902==    by 0x496FC67: fim_db_transaction_sync_row (db.cpp:430)
==10902==    by 0x12AACF: fim_file (file.c:1092)
==10902==    by 0x12A8F9: fim_directory (file.c:1058)
==10902==    by 0x12B680: fim_file_scan (file.c:1324)
==10902==    by 0x12DC81: fim_scan (fim_scan.c:71)
==10902==  Address 0x83002d0 is 32 bytes inside a block of size 56 free'd
==10902==    at 0x484A61D: operator delete(void*, unsigned long)
==10902==    by 0x4CA4B24: _M_erase(...) (stl_tree.h:1938)
==10902==    by 0x4CA4207: ~_Rb_tree() (stl_tree.h:986)
==10902==    by 0x4CA3A0B: ~map() (stl_map.h:314)
==10902==    by 0x4CA3A5B: DbSync::PipelineFactory::~PipelineFactory() (dbsyncPipelineFactory.h:49)
```

With this change, memcheck reports `0 errors from 0 contexts` and no invalid accesses over the same rounds.

The abort that survived the intermediate revision was caught under gdb on the scan thread, inside `nlohmann::json::parse` on a buffer holding JSON spliced with an SQL column list, which is what freeing the database context does to the event being built:

```
#2  nlohmann::...::lexer::reset () at json.hpp:8624
#9  SchemaValidator::SchemaValidatorEngine::validate (...) at schemaValidator.cpp:390
#11 validate_and_persist_fim_event (...) at run_check.c:425
#12 transaction_callback (resultType=INSERTED, ...) at file.c:494
#18 DbSync::Pipeline::dispatchResult (...) at dbsyncPipelineFactory.cpp:135
buffer: "state":{"a01f0d1113683264c07ce7603b85967"}},"f3d6455cc7d75cf0472"},"ttributes,uid,gid,owner,group_,hash_md5,hash_sha1,
```

Minimality was established by removing each line and re-measuring, not by inspection:

| variant | diff | result |
|---|---|---|
| `_exit` plus `DeleteState()`, longer comments | +8 −1 | fixes scenario 1 |
| `DeleteState()` dropped | +5 −1 | fixes scenario 1 (syscheckd writes no state file) |
| `DeletePID()` also dropped | +4 −1 | fixes scenario 1 but leaves **3 stale PID files in 3 rounds** — rejected |
| `clean_rules()` added, no NULL guard | +8 −1 | scenario 2 fixed, **scenario 3 SIGSEGV** — rejected |
| NULL guard added (this PR) | **+14 −1** | all four scenarios pass |

The `#ifdef ENABLE_AUDIT` around the call cannot be dropped: `clean_rules()` is defined inside `#ifdef ENABLE_AUDIT` in `audit_rule_handling.c:15`. Gating the call on `syscheck.enable_whodata` instead of guarding the function does not work either, because `audit_init()` has `return -1` paths before `fim_audit_rules_init()` — scenario 3 is exactly that case.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

Built for `TARGET=agent DEBUG=yes` with `-DINOTIFY_ENABLED=ON -DENABLE_AUDIT=ON`. The `main.c` change is inside `#ifndef WIN32` and the `audit_rule_handling.c` change inside `#ifdef __linux__`, so Windows is unaffected; macOS was not built locally.

One residual note for the reviewer: `clean_rules()` takes `rules_mutex`, so it can block if the rule-reload thread holds it at that moment. The `atexit(clean_rules)` registration it replaces had exactly the same exposure, so this is not new, but it now happens on a path bounded by `wazuh-control`'s SIGKILL escalation.

### Artifacts Affected

- `wazuh-syscheckd` (Linux, macOS)

No shared library is touched, so no other module changes behaviour.

### Configuration Changes

N/A

### Tests Introduced

None. The fault is a race between process unwinding and threads that are never joined, which needs a real process exit under live worker threads to express; the scenarios above cover it, including the whodata/Audit paths on a real `auditd`.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
