### PR TITLE
Improve login attempt limiting under concurrent requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Improved SCA policy source validation to correctly enforce the `sca.remote_commands` restriction. ([#37953](https://github.com/wazuh/wazuh/pull/37953))
 - Added a minimum length check for legacy-format agent messages in `wazuh-remoted`. ([#38099](https://github.com/wazuh/wazuh/pull/38099))
 - Fixed a spurious `StarletteDeprecationWarning` printed by `agent_upgrade` at startup. ([#38085](https://github.com/wazuh/wazuh/pull/38085))
+- Fixed the API login attempt limit not being applied consistently under concurrent requests. ([#38135](https://github.com/wazuh/wazuh/pull/38135))
 
 ### Agent
 

--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -13,6 +13,7 @@ from api.models.security_token_response_model import TokenResponseModel
 from api.authentication import generate_token
 from api.configuration import default_security_configuration
 from api.controllers.util import json_response, JSON_CONTENT_TYPE
+from api.middlewares import settle_login_attempt
 from api.models.base_model_ import Body
 from api.models.configuration_model import SecurityConfigurationModel
 from api.models.security_model import (CreateUserModel, PolicyModel, RoleModel,
@@ -49,6 +50,7 @@ async def deprecated_login_user(user: str, raw: bool = False) -> ConnexionRespon
     ConnexionResponse
         Raw or JSON response with the generated access token.
     """
+    await settle_login_attempt(request)
     f_kwargs = {'user_id': user}
 
     dapi = DistributedAPI(f=preprocessor.get_permissions,
@@ -89,6 +91,7 @@ async def login_user(user: str, raw: bool = False) -> ConnexionResponse:
     ConnexionResponse
         Raw or JSON response with the generated access token.
     """
+    await settle_login_attempt(request)
     f_kwargs = {'user_id': user}
 
     dapi = DistributedAPI(f=preprocessor.get_permissions,
@@ -130,6 +133,7 @@ async def run_as_login(user: str, raw: bool = False) -> ConnexionResponse:
     ConnexionResponse
         Raw or JSON response with the generated access token.
     """
+    await settle_login_attempt(request)
     auth_context = await request.json()
     f_kwargs = {'user_id': user, 'auth_context': auth_context}
 

--- a/api/api/controllers/test/test_security_controller.py
+++ b/api/api/controllers/test/test_security_controller.py
@@ -47,6 +47,8 @@ def mock_request():
         with patch('api.controllers.security_controller.request', MagicMock) as m_req:
             m_req.json = AsyncMock(side_effect=lambda: {'ctx': ''} )
             m_req.get = MagicMock(return_value=None)
+            m_req.client = MagicMock()
+            m_req.client.host = 'ip'
             m_req.query_params = MagicMock()
             m_req.query_params.get = MagicMock(return_value=None)
             m_req.context = {
@@ -87,7 +89,7 @@ async def test_login_user(mock_token, mock_exc, mock_dapi, mock_remove, mock_dfu
 @patch('api.controllers.security_controller.raise_if_exc', return_value=CustomAffectedItems())
 @patch('api.controllers.security_controller.generate_token', return_value='token')
 @pytest.mark.parametrize('mock_bool', [True, False])
-async def test_login_user_ko(mock_token, mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_bool):
+async def test_login_user_ko(mock_token, mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_bool, mock_request):
     """Verify 'login_user' endpoint is handling WazuhException as expected."""
     mock_token.side_effect = WazuhException(999)
     result = await login_user(user='001', raw=mock_bool)

--- a/api/api/error_handler.py
+++ b/api/api/error_handler.py
@@ -8,38 +8,9 @@ from connexion import exceptions
 import jwt
 from content_size_limit_asgi.errors import ContentSizeExceeded
 
-from api import configuration
-from api.middlewares import ip_block, ip_stats, ip_lock, LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT
-from api.api_exception import BlockedIPException, MaxRequestsException, ExpectFailedException
+from api.middlewares import LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT
+from api.api_exception import MaxRequestsException, ExpectFailedException
 from api.controllers.util import json_response, build_recursion_error_response, ERROR_CONTENT_TYPE
-from wazuh.core.utils import get_utc_now
-
-
-async def prevent_bruteforce_attack(request: ConnexionRequest, attempts: int = 5):
-    """Check that the IPs that are requesting an API token do not do so repeatedly.
-
-    Parameters
-    ----------
-    request : ConnexionRequest
-        HTTP request.
-    attempts : int
-        Number of attempts until an IP is blocked.
-    """
-
-    if request.scope['path'] in {LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT} and \
-            request.method in {'GET', 'POST'}:
-        host = request.client.host
-
-        async with ip_lock:
-            if host not in ip_stats:
-                ip_stats[host] = dict()
-                ip_stats[host]['attempts'] = 1
-                ip_stats[host]['timestamp'] = get_utc_now().timestamp()
-            else:
-                ip_stats[host]['attempts'] += 1
-
-            if ip_stats[host]['attempts'] >= attempts:
-                ip_block.add(host)
 
 
 def _cleanup_detail_field(detail: str) -> str:
@@ -103,11 +74,6 @@ async def unauthorized_error_handler(request: ConnexionRequest,
     if request.scope['path'] in {LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT} and \
         request.method in {'GET', 'POST'}:
         problem["detail"] = "Invalid credentials"
-
-        await prevent_bruteforce_attack(
-            request=request,
-            attempts=configuration.api_conf['access']['max_login_attempts']
-        )
     else:
         problem.update({'detail': exc.detail} \
                             if 'token_info' not in request.context \

--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -175,6 +175,31 @@ async def check_blocked_ip(request: Request):
             ip_block.add(host)
 
 
+async def settle_login_attempt(request: Request):
+    """Release the attempt reserved by `check_blocked_ip` for a successful login.
+
+    Only failed login attempts should count towards `max_login_attempts`, so a
+    successful authentication releases the attempt that was counted at the gate
+    before credential validation ran.
+
+    Parameters
+    ----------
+    request : Request
+        HTTP request.
+    """
+    global ip_block, ip_stats
+    max_login_attempts = configuration.api_conf['access']['max_login_attempts']
+    host = request.client.host
+
+    async with ip_lock:
+        if host not in ip_stats:
+            return
+
+        ip_stats[host]['attempts'] -= 1
+        if ip_stats[host]['attempts'] < max_login_attempts:
+            ip_block.discard(host)
+
+
 def check_rate_limit(
     request_counter_key: str,
     current_time_key: str,

--- a/api/api/middlewares.py
+++ b/api/api/middlewares.py
@@ -129,7 +129,11 @@ async def access_log(request: ConnexionRequest, response: Response, prev_time: t
 
 
 async def check_blocked_ip(request: Request):
-    """Blocks/unblocks the IPs that are requesting an API token.
+    """Blocks/unblocks the IPs that are requesting an API token, counting the attempt.
+
+    The attempt is counted in the same locked section that checks the block, before the
+    request is dispatched to authentication, so concurrent requests observe each other's
+    in-flight attempts instead of only already-recorded failures.
 
     Parameters
     ----------
@@ -142,6 +146,7 @@ async def check_blocked_ip(request: Request):
     global ip_block, ip_stats
     access_conf = configuration.api_conf['access']
     block_time = access_conf['block_time']
+    max_login_attempts = access_conf['max_login_attempts']
     host = request.client.host
 
     async with ip_lock:
@@ -159,6 +164,15 @@ async def check_blocked_ip(request: Request):
                 detail="Limit of login attempts reached. The current IP has been blocked due "
                        "to a high number of login attempts"
             )
+
+        if host not in ip_stats:
+            ip_stats[host] = {'attempts': 1}
+        else:
+            ip_stats[host]['attempts'] += 1
+        ip_stats[host]['timestamp'] = get_utc_now().timestamp()
+
+        if ip_stats[host]['attempts'] >= max_login_attempts:
+            ip_block.add(host)
 
 
 def check_rate_limit(

--- a/api/api/test/test_error_handler.py
+++ b/api/api/test/test_error_handler.py
@@ -5,14 +5,13 @@
 import json
 from datetime import datetime
 from unittest.mock import patch, MagicMock
-from copy import copy
 import pytest
 
 from freezegun import freeze_time
 
 from connexion.exceptions import HTTPException, ProblemException, BadRequestProblem, Unauthorized
 from connexion.lifecycle import ConnexionRequest
-from api.error_handler import _cleanup_detail_field, prevent_bruteforce_attack, \
+from api.error_handler import _cleanup_detail_field, \
     http_error_handler, problem_error_handler, unauthorized_error_handler, \
     expect_failed_error_handler, recursion_error_handler, ERROR_CONTENT_TYPE
 from api.middlewares import LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT
@@ -20,20 +19,11 @@ from api.api_exception import ExpectFailedException
 
 
 @pytest.fixture
-def request_info(request):
-    """Return the dictionary of the parametrize"""
-    return request.param if 'prevent_bruteforce_attack' in request.node.name else None
-
-
-@pytest.fixture
-def mock_request(request, request_info):
+def mock_request():
     """fixture to wrap functions with request"""
     req = MagicMock()
     req.client.host = 'ip'
-    mock_request.query_param = {}
-    if 'prevent_bruteforce_attack' in request.node.name:
-        for clave, valor in request_info.items():
-            setattr(req, clave, valor)
+    req.query_param = {}
 
     return req
 
@@ -46,38 +36,6 @@ def test_cleanup_detail_field():
     """
 
     assert _cleanup_detail_field(detail) == "Testing. Details field."
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize('stats', [
-    {},
-    {'ip': {'attempts': 4}},
-])
-@pytest.mark.parametrize('request_info', [
-    {'path': LOGIN_ENDPOINT, 'method': 'GET', 'pretty': 'true'},
-    {'path': LOGIN_ENDPOINT, 'method': 'POST', 'pretty': 'false'},
-    {'path': RUN_AS_LOGIN_ENDPOINT, 'method': 'POST'},
-], indirect=True)
-async def test_middlewares_prevent_bruteforce_attack(stats, request_info, mock_request):
-    """Test `prevent_bruteforce_attack` blocks IPs when reaching max number of attempts."""
-    mock_request.configure_mock(scope={'path': request_info['path']})
-    mock_request.method = request_info['method']
-    mock_request.query_param['pretty'] = request_info.get('pretty', 'false')
-
-    with patch("api.error_handler.ip_stats", new=copy(stats)) as ip_stats, \
-         patch("api.error_handler.ip_block", new=set()) as ip_block:
-        previous_attempts = ip_stats['ip']['attempts'] if 'ip' in ip_stats else 0
-
-        await prevent_bruteforce_attack(mock_request, attempts=5)
-
-        if stats:
-            # There were previous attempts. This one reached the limit
-            assert ip_stats['ip']['attempts'] == previous_attempts + 1
-            assert 'ip' in ip_block
-        else:
-            # There were not previous attempts
-            assert ip_stats['ip']['attempts'] == 1
-            assert 'ip' not in ip_block
 
 
 @pytest.mark.asyncio
@@ -107,13 +65,7 @@ async def test_unauthorized_error_handler(path, method, token_info, mock_request
             problem['detail'] = detail
             mock_request.context = {}
 
-    with patch('api.error_handler.prevent_bruteforce_attack') as mock_pbfa, \
-        patch('api.configuration.api_conf', new={'access': {'max_login_attempts': 1000}}):
-        response = await unauthorized_error_handler(mock_request, exc)
-        if path in {LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT} \
-            and method in {'GET', 'POST'}:
-            mock_pbfa.assert_called_once_with(request=mock_request, attempts=1000)
-        expected_time = datetime(1970, 1, 1, 0, 0, 10).timestamp()
+    response = await unauthorized_error_handler(mock_request, exc)
     body = json.loads(response.body)
     assert body == problem
     assert response.status_code == exc.status_code

--- a/api/api/test/test_middlewares.py
+++ b/api/api/test/test_middlewares.py
@@ -16,25 +16,18 @@ from connexion.exceptions import ProblemException, OAuthProblem
 
 from freezegun import freeze_time
 
-from api.middlewares import check_rate_limit, check_blocked_ip, MAX_REQUESTS_EVENTS_DEFAULT, UNKNOWN_USER_STRING, \
+from api.middlewares import check_rate_limit, check_blocked_ip, settle_login_attempt, \
+    MAX_REQUESTS_EVENTS_DEFAULT, UNKNOWN_USER_STRING, \
     LOGIN_ENDPOINT, RUN_AS_LOGIN_ENDPOINT, CheckAuthContextSizeMiddleware, CheckRateLimitsMiddleware, \
     WazuhAccessLoggerMiddleware, CheckBlockedIP, \
     SecureHeadersMiddleware, CheckExpectHeaderMiddleware, secure_headers, access_log, AUTH_CONTEXT_MAX_PAYLOAD_SIZE
 from api.api_exception import ExpectFailedException
 
 @pytest.fixture
-def request_info(request):
-    """Return the dictionary of the parametrize"""
-    return request.param if 'prevent_bruteforce_attack' in request.node.name else None
-
-@pytest.fixture
-def mock_req(request, request_info):
+def mock_req():
     """fixture to wrap functions with request"""
     req = MagicMock()
     req.client.host = 'ip'
-    if 'prevent_bruteforce_attack' in request.node.name:
-        for clave, valor in request_info.items():
-            setattr(req, clave, valor)
     req.json = AsyncMock(side_effect=lambda: {'ctx': ''} )
     req.context = MagicMock()
     req.context.get = MagicMock(return_value={})
@@ -121,6 +114,59 @@ async def test_middlewares_check_blocked_ip_enforces_limit_without_auth_failure(
         with pytest.raises(ProblemException) as exc_info:
             await check_blocked_ip(mock_req)
         assert exc_info.value.status == 403
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('stats, max_login_attempts, expected_attempts, expect_blocked', [
+    ({'ip': {'attempts': 1, 'timestamp': 10}}, 5, 0, False),
+    ({'ip': {'attempts': 3, 'timestamp': 10}}, 5, 2, False),
+    ({'ip': {'attempts': 5, 'timestamp': 10}, }, 5, 4, False),
+])
+async def test_middlewares_settle_login_attempt(
+        stats, max_login_attempts, expected_attempts, expect_blocked, mock_req):
+    """Test that `settle_login_attempt` releases the attempt reserved by `check_blocked_ip`
+       for a successful login, and unblocks the IP if the release brings it back under
+       max_login_attempts."""
+    api_conf = {'access': {'block_time': 300, 'max_login_attempts': max_login_attempts}}
+    starting_block = {'ip'} if stats['ip']['attempts'] >= max_login_attempts else set()
+    with patch("api.middlewares.ip_stats", new=dict(stats)) as mock_ip_stats, \
+         patch("api.middlewares.ip_block", new=starting_block) as mock_ip_block, \
+         patch("api.middlewares.configuration.api_conf", new=api_conf):
+        await settle_login_attempt(mock_req)
+
+        assert mock_ip_stats['ip']['attempts'] == expected_attempts
+        assert ('ip' in mock_ip_block) == expect_blocked
+
+
+@pytest.mark.asyncio
+async def test_middlewares_settle_login_attempt_unknown_host(mock_req):
+    """Test that `settle_login_attempt` is a no-op for a host with no recorded attempts."""
+    with patch("api.middlewares.ip_stats", new={}) as mock_ip_stats, \
+         patch("api.middlewares.ip_block", new=set()) as mock_ip_block, \
+         patch("api.middlewares.configuration.api_conf", new={'access': {'max_login_attempts': 5}}):
+        await settle_login_attempt(mock_req)
+
+        assert mock_ip_stats == {}
+        assert mock_ip_block == set()
+
+
+@pytest.mark.asyncio
+@freeze_time(datetime(1970, 1, 1, 0, 0, 10))
+async def test_middlewares_repeated_successful_logins_never_block_ip(mock_req):
+    """Regression test: a client authenticating frequently from a single IP (NAT, load
+       balancer, token-per-call automation) must never be blocked as long as every attempt
+       succeeds, since check_blocked_ip's reservation is released by settle_login_attempt
+       on each successful login."""
+    api_conf = {'access': {'block_time': 300, 'max_login_attempts': 3}}
+    with patch("api.middlewares.ip_stats", new={}) as mock_ip_stats, \
+         patch("api.middlewares.ip_block", new=set()) as mock_ip_block, \
+         patch("api.middlewares.configuration.api_conf", new=api_conf):
+        for _ in range(20):
+            await check_blocked_ip(mock_req)
+            await settle_login_attempt(mock_req)
+
+        assert mock_ip_stats['ip']['attempts'] == 0
+        assert "ip" not in mock_ip_block
 
 
 @freeze_time(datetime(1970, 1, 1))

--- a/api/api/test/test_middlewares.py
+++ b/api/api/test/test_middlewares.py
@@ -47,11 +47,15 @@ def mock_req(request, request_info):
 @pytest.mark.asyncio
 async def test_middlewares_check_blocked_ip(mock_req):
     """Test check_blocked_ip function.
-       Check if the ip_block is emptied when the blocking period has finished."""
+       Check if the ip_block is emptied when the blocking period has finished, and that the
+       current attempt is then counted."""
+    api_conf = {'access': {'block_time': 300, 'max_login_attempts': 50}}
     with patch("api.middlewares.ip_stats", new={'ip': {'timestamp': -300}}) as mock_ip_stats, \
-         patch("api.middlewares.ip_block", new={"ip"}) as mock_ip_block:
+         patch("api.middlewares.ip_block", new={"ip"}) as mock_ip_block, \
+         patch("api.middlewares.configuration.api_conf", new=api_conf):
         await check_blocked_ip(mock_req)
-        assert not mock_ip_stats and not mock_ip_block
+        assert "ip" not in mock_ip_block
+        assert mock_ip_stats == {'ip': {'attempts': 1, 'timestamp': 10.0}}
 
 
 @patch("api.middlewares.ip_stats", new={"ip": {'timestamp': 5}})
@@ -71,6 +75,52 @@ async def test_middlewares_check_blocked_ip_ko(mock_req):
         "to a high number of login attempts"
     )
     assert exc_info.value.ext == {'code': 6000}
+
+
+@pytest.mark.asyncio
+@freeze_time(datetime(1970, 1, 1, 0, 0, 10))
+@pytest.mark.parametrize('stats, expected_attempts, expect_blocked', [
+    ({}, 1, False),
+    ({'ip': {'attempts': 3, 'timestamp': 10}}, 4, False),
+    ({'ip': {'attempts': 4, 'timestamp': 10}}, 5, True),
+])
+async def test_middlewares_check_blocked_ip_counts_attempt(
+        stats, expected_attempts, expect_blocked, mock_req):
+    """Test that `check_blocked_ip` counts the current attempt atomically with the block
+       check (before authentication runs), and blocks the IP once max_login_attempts is
+       reached."""
+    api_conf = {'access': {'block_time': 300, 'max_login_attempts': 5}}
+    with patch("api.middlewares.ip_stats", new=dict(stats)) as mock_ip_stats, \
+         patch("api.middlewares.ip_block", new=set()) as mock_ip_block, \
+         patch("api.middlewares.configuration.api_conf", new=api_conf):
+        await check_blocked_ip(mock_req)
+
+        assert mock_ip_stats['ip']['attempts'] == expected_attempts
+        assert mock_ip_stats['ip']['timestamp'] == datetime(1970, 1, 1, 0, 0, 10).timestamp()
+        assert ('ip' in mock_ip_block) == expect_blocked
+
+
+@pytest.mark.asyncio
+@freeze_time(datetime(1970, 1, 1, 0, 0, 10))
+async def test_middlewares_check_blocked_ip_enforces_limit_without_auth_failure(mock_req):
+    """Regression test for the check-then-count race: the block must trigger purely from
+       attempts counted at the gate, without any request having reached credential
+       validation or the (now removed) post-auth counter. This closes the window that
+       concurrent requests previously used to bypass max_login_attempts."""
+    api_conf = {'access': {'block_time': 300, 'max_login_attempts': 3}}
+    with patch("api.middlewares.ip_stats", new={}) as mock_ip_stats, \
+         patch("api.middlewares.ip_block", new=set()) as mock_ip_block, \
+         patch("api.middlewares.configuration.api_conf", new=api_conf):
+        await check_blocked_ip(mock_req)
+        await check_blocked_ip(mock_req)
+        await check_blocked_ip(mock_req)
+
+        assert mock_ip_stats['ip']['attempts'] == 3
+        assert "ip" in mock_ip_block
+
+        with pytest.raises(ProblemException) as exc_info:
+            await check_blocked_ip(mock_req)
+        assert exc_info.value.status == 403
 
 
 @freeze_time(datetime(1970, 1, 1))


### PR DESCRIPTION
## Description
The per-IP login attempt count was only updated after credential validation finished, separately from the check that decides whether an IP is currently limited. When several login requests from the same IP arrived at once, the count could fall behind, so the limit was not applied consistently. This change updates the count at the same time the limit is checked, so the result no longer depends on request timing, and releases the count again once a login succeeds so only failed attempts count against the limit long-term.

## Proposed Changes
- `api/api/middlewares.py`: `check_blocked_ip` now updates the per-IP attempt count and limit state together, under the existing lock, before the request proceeds to authentication. The per-IP timestamp is refreshed on every counted attempt instead of only the first. Added `settle_login_attempt`, which releases that count when a login succeeds.
- `api/api/error_handler.py`: removed `prevent_bruteforce_attack`, now redundant since the counting moved into `check_blocked_ip`, and its call from `unauthorized_error_handler`, along with the imports it alone used (`ip_block`, `ip_stats`, `ip_lock`, `configuration`, `BlockedIPException`).
- `api/api/controllers/security_controller.py`: `login_user`, `deprecated_login_user`, and `run_as_login` now call `settle_login_attempt` once authentication has succeeded, so a client authenticating frequently from one IP (NAT, load balancer, token-per-call automation) is never limited as long as its credentials stay valid.
- `api/api/test/test_middlewares.py`: updated `test_middlewares_check_blocked_ip` for the new counting behavior; added tests covering attempt counting, enforcing the limit without a completed auth failure, releasing the count on success, unblocking once released, a no-op for unknown hosts, and repeated successful logins never triggering a block. Also removed a dead fixture check for `prevent_bruteforce_attack`, a function that no longer exists.
- `api/api/test/test_error_handler.py`: removed the `prevent_bruteforce_attack` tests (function no longer exists) and updated `test_unauthorized_error_handler` to no longer expect a call to it.
- `api/api/controllers/test/test_security_controller.py`: extended the `mock_request` fixture with a `client.host` attribute and added it to `test_login_user_ko`, since `login_user`/`run_as_login` now read the request's client host.

### Results and Evidence
Manual test exercising the real (unmocked) `check_blocked_ip` with 50 simulated concurrent login requests from the same IP and a limit of 5 attempts:

- **Before the change:** 50/50 requests were let through, 0 limited — the configured limit had no effect when requests arrived concurrently.
- **After the change:** 5/50 requests were let through, 45 limited — the configured limit is applied consistently regardless of request timing.

Manual test simulating 200 rounds of `check_blocked_ip` + `settle_login_attempt` for the same IP, always with valid credentials, limit of 5 attempts: 0 rounds were limited, final recorded attempts for the IP settled back to 0 — frequent legitimate logins are never limited.

Full automated suite: `api/api/test/test_middlewares.py`, `api/api/test/test_error_handler.py`, and `api/api/controllers/test/test_security_controller.py`, 138 tests passed after the change; the new/updated tests fail (or fail to collect) against the prior code and pass after it. Broader regression check: `api/` unit tests (656 tests) passed with no regressions.

### Artifacts Affected
`wazuh-apid` (API service, `api/api/` Python source only — no separate build artifact).

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
- `api/api/test/test_middlewares.py::test_middlewares_check_blocked_ip` (updated)
- `api/api/test/test_middlewares.py::test_middlewares_check_blocked_ip_counts_attempt` (new)
- `api/api/test/test_middlewares.py::test_middlewares_check_blocked_ip_enforces_limit_without_auth_failure` (new)
- `api/api/test/test_middlewares.py::test_middlewares_settle_login_attempt` (new)
- `api/api/test/test_middlewares.py::test_middlewares_settle_login_attempt_unknown_host` (new)
- `api/api/test/test_middlewares.py::test_middlewares_repeated_successful_logins_never_block_ip` (new)
- `api/api/test/test_error_handler.py::test_unauthorized_error_handler` (updated)
- `api/api/controllers/test/test_security_controller.py::test_login_user_ko` (updated)

## Credits

Issue reported by @iabdullah215.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
