### PR TITLE
Pause module production while manager is unreachable

### DIFF
--- a/src/client-agent/https_client/include/https_client.h
+++ b/src/client-agent/https_client/include/https_client.h
@@ -270,6 +270,12 @@ typedef struct hc_callbacks_t
     /// Called on the control thread before each Notify (not the dispatcher), so
     /// it must be a fast, non-blocking read. Null means no host block is sent.
     void (*on_collect_host)(char* json_out, size_t cap, void* user_data);
+
+    /// /control has been unreachable at the TRANSPORT level for a threshold
+    /// number of consecutive attempts (paused=true), or has succeeded again
+    /// (paused=false). The consumer arms/disarms its producer lock so modules
+    /// stop generating events they cannot deliver.
+    void (*on_producer_pause)(bool paused, void* user_data);
     void* user_data;
 } hc_callbacks_t;
 

--- a/src/client-agent/https_client/src/callbackDispatcher.cpp
+++ b/src/client-agent/https_client/src/callbackDispatcher.cpp
@@ -229,3 +229,13 @@ void CallbackDispatcher::onBufferLevel(hc_buffer_level_t level)
 
     enqueue([this, level] { m_callbacks.on_buffer_level(level, m_callbacks.user_data); });
 }
+
+void CallbackDispatcher::onProducerPause(bool paused)
+{
+    if (m_callbacks.on_producer_pause == nullptr)
+    {
+        return;
+    }
+
+    enqueue([this, paused] { m_callbacks.on_producer_pause(paused, m_callbacks.user_data); });
+}

--- a/src/client-agent/https_client/src/callbackDispatcher.hpp
+++ b/src/client-agent/https_client/src/callbackDispatcher.hpp
@@ -57,6 +57,7 @@ class CallbackDispatcher final : public ICallbackSink
         void onSyncResponse(const std::string& sessionId, int result, const std::string& body) override;
         void onStateChange(hc_conn_state_t state) override;
         void onBufferLevel(hc_buffer_level_t level) override;
+        void onProducerPause(bool paused) override;
 
     private:
         void run();

--- a/src/client-agent/https_client/src/callbackSink.hpp
+++ b/src/client-agent/https_client/src/callbackSink.hpp
@@ -53,6 +53,9 @@ class ICallbackSink
         virtual void onSyncResponse(const std::string& sessionId, int result, const std::string& body) = 0;
         virtual void onStateChange(hc_conn_state_t state) = 0;
         virtual void onBufferLevel(hc_buffer_level_t level) = 0;
+        /// /control is confirmed unreachable (true) or reachable again (false);
+        /// the core arms/disarms its producer lock. Emitted on transitions only.
+        virtual void onProducerPause(bool paused) = 0;
 };
 
 #endif // _HC_CALLBACK_SINK_HPP

--- a/src/client-agent/https_client/src/controlStream.cpp
+++ b/src/client-agent/https_client/src/controlStream.cpp
@@ -20,6 +20,9 @@ namespace
 {
     constexpr uint32_t CONTROL_MAX_ATTEMPTS = 4;
 
+    // Consecutive undeliverable `/control` outcomes before producers are paused.
+    constexpr uint32_t CONTROL_UNDELIVERABLE_THRESHOLD = 2;
+
     HttpRequestSpec controlSpec(const std::string& body, uint32_t timeoutMs)
     {
         HttpRequestSpec spec;
@@ -140,13 +143,22 @@ ControlStream::~ControlStream()
 
 bool ControlStream::step(Waiter& waiter)
 {
+    const OutcomeClass outcome = runStep(waiter);
+    updateProducerPause(outcome);
+    return isRegistered();
+}
+
+OutcomeClass ControlStream::runStep(Waiter& waiter)
+{
     // The 401 pause converges the machine to AUTH_ERROR from the control
     // thread only (whichever stream saw the first 401 woke this loop); once a
     // new key clears the pause, recover and re-register.
     if (m_authGate.paused())
     {
         applyEffects(m_machine.onEvent(ControlStateMachine::Event::AuthFailed), {});
-        return isRegistered();
+        // Nothing is sent while the gate is latched, so the cycle itself is what
+        // gets observed: the credential is still rejected.
+        return OutcomeClass::AuthFail;
     }
 
     if (m_machine.state() == ControlStateMachine::State::AuthError)
@@ -157,18 +169,16 @@ bool ControlStream::step(Waiter& waiter)
     switch (m_machine.nextAction())
     {
         case ControlStateMachine::ActionKind::Startup:
-            sendStartup(waiter);
-            break;
+            return sendStartup(waiter);
 
         case ControlStateMachine::ActionKind::Notify:
-            sendNotify(waiter);
-            break;
+            return sendNotify(waiter);
 
         default:
-            break; // LCOV_EXCL_LINE: Idle only when Stopping, never driven here.
+            // LCOV_EXCL_START: Idle only when Stopping, never driven here.
+            return OutcomeClass::Interrupted;
+            // LCOV_EXCL_STOP
     }
-
-    return isRegistered();
 }
 
 void ControlStream::drainStep(Waiter& waiter)
@@ -426,6 +436,74 @@ void ControlStream::maybeArmSettingsRefresh(const std::string& incoming)
     m_refreshedForSettingsHash = incoming;
     m_settingsLoopWarned = false;
     m_machine.onEvent(ControlStateMachine::Event::SettingsChanged);
+}
+
+/* Turns one iteration's outcome into the producer-pause decision. Fed only from
+ * step(): drainStep() is one best-effort attempt during drain, and arming there
+ * would leave WAIT_FILE behind after a clean stop. */
+void ControlStream::updateProducerPause(OutcomeClass outcome)
+{
+    if (outcome == OutcomeClass::Interrupted)
+    {
+        // Shutdown cut the attempt short, or there was nothing to send: no
+        // evidence either way, so the streak is left alone rather than reset.
+        return;
+    }
+
+    if (outcome == OutcomeClass::Ok)
+    {
+        m_undeliverableStreak = 0;
+
+        if (m_producersPaused)
+        {
+            m_producersPaused = false;
+            // Debug: the consumer emits the operator-facing line, so logging
+            // louder here would double every transition.
+            LOGFN_DEBUG1(m_logFn, "/control deliverable again; releasing the producer pause.");
+            m_sink.onProducerPause(false);
+        }
+
+        return;
+    }
+
+    // Undeliverable with nothing already in motion to change it. AuthFail only
+    // surfaces once the timestamp-corrected retry has also failed, so the key is
+    // genuinely bad and only re-enrollment can recover it; VersionRejected needs
+    // one side upgraded. Excluded: answers that clear on their own (5xx,
+    // 429/503, 413) and a plain 400.
+    const bool blocksDelivery = outcome == OutcomeClass::Unreachable ||
+                                outcome == OutcomeClass::AuthFail ||
+                                outcome == OutcomeClass::VersionRejected;
+
+    if (!blocksDelivery)
+    {
+        // Clears on its own, so it breaks the run. It does not lift an existing
+        // pause: only a success does.
+        m_undeliverableStreak = 0;
+        return;
+    }
+
+    if (m_producersPaused)
+    {
+        // Already paused: nothing to report, and the streak has served its
+        // purpose until a success resets it.
+        LOGFN_DEBUG1(m_logFn, "/control still undeliverable; event production stays paused.");
+        return;
+    }
+
+    if (++m_undeliverableStreak < CONTROL_UNDELIVERABLE_THRESHOLD)
+    {
+        LOGFN_DEBUG1(m_logFn, "/control undeliverable, outcome %d (%u/%u).",
+                     static_cast<int>(outcome), m_undeliverableStreak,
+                     CONTROL_UNDELIVERABLE_THRESHOLD);
+        return;
+    }
+
+    m_producersPaused = true;
+    LOGFN_DEBUG1(m_logFn, "/control undeliverable, outcome %d (%u/%u); pausing event production.",
+                 static_cast<int>(outcome), m_undeliverableStreak,
+                 CONTROL_UNDELIVERABLE_THRESHOLD);
+    m_sink.onProducerPause(true);
 }
 
 void ControlStream::dispatchPlannedTasks(std::vector<NotifyTask> batch, Waiter& waiter)

--- a/src/client-agent/https_client/src/controlStream.hpp
+++ b/src/client-agent/https_client/src/controlStream.hpp
@@ -82,6 +82,9 @@ class ControlStream final
         void joinUpgradeWork();
 
     private:
+        /// One iteration's worth of work, returning what it observed so step()
+        /// has a single place to feed the producer-pause decision.
+        OutcomeClass runStep(Waiter& waiter);
         OutcomeClass sendStartup(Waiter& waiter);
         OutcomeClass sendNotify(Waiter& waiter);
         void sendShutdown(Waiter& waiter);
@@ -91,6 +94,7 @@ class ControlStream final
         void dispatchPlannedTasks(std::vector<NotifyTask> batch, Waiter& waiter);
         void dispatchUpgradeTask(const NotifyTask& task, Waiter& waiter);
         void maybeArmSettingsRefresh(const std::string& incoming);
+        void updateProducerPause(OutcomeClass outcome);
         void maybeDownloadConfig(const std::string& managerHash, const std::string& group,
                                  Waiter& waiter);
         void updateLocalIp(const HttpResponse& response);
@@ -134,6 +138,13 @@ class ControlStream final
         /// instance. See joinUpgradeWork() for shutdown ordering.
         std::thread m_upgradeThread;
 
+        /// Consecutive undeliverable /control outcomes (see blocksDelivery).
+        uint32_t m_undeliverableStreak {0};
+
+        /// Whether we have told the core to pause its producers. Tracks only our
+        /// own transitions, so it starts false even though agentd arms the lock
+        /// at boot for its own reasons.
+        bool m_producersPaused {false};
 };
 
 #endif // _HC_CONTROL_STREAM_HPP

--- a/src/client-agent/https_client/src/httpTypes.hpp
+++ b/src/client-agent/https_client/src/httpTypes.hpp
@@ -32,10 +32,16 @@ enum class TransportStatus
 };
 
 /// D9 outcome classes for a completed attempt.
+///
+/// Each value names what was OBSERVED, not what policy applies to it: three of
+/// them are retried (Unreachable, ServerError, BackPressure).
+
 enum class OutcomeClass
 {
     Ok,
-    Retryable,
+    Unreachable,     ///< Transport failed; no HTTP status ever arrived.
+    ServerError,     ///< Answered, unhappily, and worth retrying: 5xx other than
+    ///< 503, plus the 403/426 an intermediary can inject.
     BackPressure,    ///< 503 + Retry-After / 429: server delay wins when longer.
     AuthFail,        ///< 401: one fresh-timestamp retry, then re-enrollment.
     Permanent,       ///< 400/...: retrying identical bytes cannot succeed.
@@ -52,7 +58,11 @@ inline int toHcResult(OutcomeClass outcome)
         case OutcomeClass::Ok:
             return HC_RESULT_OK;
 
-        case OutcomeClass::Retryable:
+        // Both cross the ABI as RETRYABLE: the C core only needs the policy,
+        // and the arm/disarm decision that needs the finer fact never leaves
+        // the module (ControlStream owns it), so hc_result_t is unchanged.
+        case OutcomeClass::Unreachable:
+        case OutcomeClass::ServerError:
             return HC_RESULT_RETRYABLE;
 
         case OutcomeClass::BackPressure:

--- a/src/client-agent/https_client/src/outcomeClassifier.cpp
+++ b/src/client-agent/https_client/src/outcomeClassifier.cpp
@@ -20,7 +20,10 @@ OutcomeClass classifyOutcome(const HttpResponse& response)
 
     if (response.status != TransportStatus::Ok)
     {
-        return OutcomeClass::Retryable; // timeout / connect / TLS / other transport error
+        // timeout / connect / DNS / TLS / other transport error: no HTTP status
+        // ever arrived, so the manager is not answering at all. This is the one
+        // class that arms the producer pause.
+        return OutcomeClass::Unreachable;
     }
 
     const long code = response.httpCode;
@@ -56,13 +59,15 @@ OutcomeClass classifyOutcome(const HttpResponse& response)
     }
 
     // 403/426 are not part of the manager contract: they reach the agent only
-    // from an intermediary (reverse proxy, WAF, mTLS gateway). Treat them as
-    // transient so a /stateless batch is preserved and retried, never dropped
-    // (Permanent would consume the batch and count it as lost).
+    // from an intermediary (reverse proxy, WAF, mTLS gateway). Transient so a
+    // /stateless batch is retried rather than consumed as Permanent, and not
+    // Unreachable because something did answer.
     if (code == 403 || code == 426)
     {
-        return OutcomeClass::Retryable;
+        return OutcomeClass::ServerError;
     }
 
-    return (code >= 500) ? OutcomeClass::Retryable : OutcomeClass::Permanent;
+    // 5xx other than the 503 handled above (500, and 502/504 only when an
+    // intermediary is in the path).
+    return (code >= 500) ? OutcomeClass::ServerError : OutcomeClass::Permanent;
 }

--- a/src/client-agent/https_client/src/retrySender.cpp
+++ b/src/client-agent/https_client/src/retrySender.cpp
@@ -111,5 +111,6 @@ std::chrono::milliseconds RetrySender::delayFor(const Result& result)
 
 bool RetrySender::isRetryable(OutcomeClass outcome)
 {
-    return outcome == OutcomeClass::Retryable || outcome == OutcomeClass::BackPressure;
+    return outcome == OutcomeClass::Unreachable || outcome == OutcomeClass::ServerError ||
+           outcome == OutcomeClass::BackPressure;
 }

--- a/src/client-agent/https_client/tests/unit/controlStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/controlStream_test.cpp
@@ -841,3 +841,227 @@ TEST_F(ControlStreamTest, MalformedNotifyBodyIsIgnored)
     m_stream.step(m_waiter); // No crash, no dispatch.
 }
 
+TEST_F(ControlStreamTest, ASingleUnreachableStepDoesNotPauseProducers)
+{
+    // One transport failure is a blip. The threshold is deliberately above 1.
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
+    .WillRepeatedly(Return(response(TransportStatus::Timeout, 0)));
+    EXPECT_CALL(m_sink, onProducerPause(_)).Times(0);
+    m_waiter.script({true, true, true});
+
+    m_stream.step(m_waiter); // Startup.
+    m_stream.step(m_waiter); // 1/2: counted, no pause.
+}
+
+TEST_F(ControlStreamTest, ThresholdPausesOnceAndRecoveryReleasesWithoutAStateChange)
+{
+    // The whole lifecycle, and the reason this callback has to exist: losing the
+    // manager while Registered changes no state, so both the arm and the release
+    // are invisible to onStateChange -- only the initial registration emits one.
+    int attempt = 0;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillRepeatedly(Invoke(
+                        [&](const HttpRequestSpec&)
+    {
+        attempt++;
+
+        if (attempt == 1)
+        {
+            return response(TransportStatus::Ok, 200, "{}"); // Startup.
+        }
+
+        // Attempts 2-13: three failing steps of four attempts each.
+        return attempt <= 13 ? response(TransportStatus::Timeout, 0)
+               : response(TransportStatus::Ok, 200, "{}");
+    }));
+
+    // Counted through the expectations as well as by gmock, so the assertions
+    // between steps can pin WHICH step causes each transition. Totals and order
+    // alone would not: a threshold that regressed to 1 would arm on the step
+    // before and still satisfy them.
+    int pauses = 0;
+    int resumes = 0;
+
+    ::testing::InSequence sequence;
+    EXPECT_CALL(m_sink, onStateChange(HC_STATE_REGISTERED)).Times(1);
+    EXPECT_CALL(m_sink, onProducerPause(true)).Times(1)
+    .WillOnce(Invoke([&](bool)
+    {
+        pauses++;
+    }));
+    EXPECT_CALL(m_sink, onProducerPause(false)).Times(1)
+    .WillOnce(Invoke([&](bool)
+    {
+        resumes++;
+    }));
+    m_waiter.script({true, true, true, true, true, true, true, true, true});
+
+    m_stream.step(m_waiter); // Startup -> REGISTERED: the only state change.
+
+    m_stream.step(m_waiter);
+    EXPECT_EQ(0, pauses); // 1/2: counted, not armed yet.
+
+    m_stream.step(m_waiter);
+    EXPECT_EQ(1, pauses); // 2/2: armed here, and not before.
+
+    m_stream.step(m_waiter);
+    EXPECT_EQ(1, pauses);  // Still unreachable: no second announcement.
+    EXPECT_EQ(0, resumes);
+
+    m_stream.step(m_waiter);
+    EXPECT_EQ(1, resumes); // The successful notify releases it.
+}
+
+TEST_F(ControlStreamTest, SelfClearingFailuresNeverPauseProducers)
+{
+    // A 500 is answered and clears on its own, so it breaks the run rather than
+    // counting toward it. ServerError IS retryable, so each step spends four
+    // attempts and three waiter answers; unscripted they would come back
+    // Interrupted and the test would pass having proved nothing.
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
+    .WillRepeatedly(Return(response(TransportStatus::Ok, 500)));
+    EXPECT_CALL(m_sink, onProducerPause(_)).Times(0);
+    m_waiter.script({true, true, true, true, true, true, true, true, true});
+
+    m_stream.step(m_waiter); // Startup.
+    m_stream.step(m_waiter);
+    m_stream.step(m_waiter);
+    m_stream.step(m_waiter); // Three answered failures, still no pause.
+}
+
+TEST_F(ControlStreamTest, VersionRejectionPausesProducers)
+{
+    // Beyond what the issue asks for: 409 cannot succeed until one side is
+    // upgraded, so events would drop for the whole duration. Not retryable, so a
+    // step is one attempt and no script is needed.
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
+    .WillRepeatedly(Return(response(TransportStatus::Ok, 409)));
+    EXPECT_CALL(m_sink, onProducerPause(true)).Times(1);
+    EXPECT_CALL(m_sink, onProducerPause(false)).Times(0);
+
+    m_stream.step(m_waiter); // Startup accepted.
+    m_stream.step(m_waiter); // 409: 1/2.
+    m_stream.step(m_waiter); // 409: 2/2 -> pause.
+    m_stream.step(m_waiter); // Still rejected: announced once only.
+}
+
+TEST_F(ControlStreamTest, LatchedAuthFailurePausesProducersAcrossGatedCycles)
+{
+    // WillRepeatedly, so the one-shot fresh-timestamp retry gets a 401 too and
+    // escalates. That is the only AuthFail ever observed through a send: from the
+    // next cycle on nothing is sent at all, and runStep() reports the gated cycle
+    // as AuthFail so the condition keeps being counted while it lasts.
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
+    .WillRepeatedly(Return(response(TransportStatus::Ok, 401)));
+    // Counted so the assertions below can pin the pause to the GATED cycle. That
+    // is the whole claim: without counting gated cycles the streak would freeze
+    // at 1 and never arm, and a total of one would not distinguish the two.
+    int pauses = 0;
+    EXPECT_CALL(m_sink, onProducerPause(true)).Times(1)
+    .WillOnce(Invoke([&](bool)
+    {
+        pauses++;
+    }));
+    EXPECT_CALL(m_sink, onProducerPause(false)).Times(0);
+
+    m_stream.step(m_waiter); // Startup accepted.
+
+    m_stream.step(m_waiter); // 401 twice -> gate latches, 1/2.
+    EXPECT_TRUE(m_authGate.paused());
+    EXPECT_EQ(0, pauses); // The 401 itself does not arm.
+
+    m_stream.step(m_waiter);
+    EXPECT_EQ(1, pauses); // The gated cycle, sending nothing, is what arms it.
+
+    m_stream.step(m_waiter);
+    EXPECT_EQ(1, pauses); // Still gated: announced once only.
+}
+
+TEST_F(ControlStreamTest, ANewKeyClearsTheAuthPauseAndResumesProducers)
+{
+    // The grace period matters because of this path: re-enrollment supplies a new
+    // key, the gate clears and producers resume.
+    //
+    // TWO 401s, not one: a 401 gets a one-shot retry with a fresh timestamp, so a
+    // single one is absorbed by the sender and never surfaces as AuthFail. Only
+    // the second escalates, which is what latches the gate.
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
+    .WillOnce(Return(response(TransportStatus::Ok, 401)))
+    .WillOnce(Return(response(TransportStatus::Ok, 401)))
+    .WillRepeatedly(Return(response(TransportStatus::Ok, 200, "{}")));
+
+    int resumes = 0;
+
+    ::testing::InSequence sequence;
+    EXPECT_CALL(m_sink, onProducerPause(true)).Times(1);
+    EXPECT_CALL(m_sink, onProducerPause(false)).Times(1)
+    .WillOnce(Invoke([&](bool)
+    {
+        resumes++;
+    }));
+
+    m_stream.step(m_waiter); // Startup accepted.
+    m_stream.step(m_waiter); // 401, retried, 401 again -> gate latches, 1/2.
+    m_stream.step(m_waiter); // Gated cycle -> 2/2 -> pause.
+
+    m_authGate.release();  // What hc_set_agent_key() does after re-enrolling.
+    EXPECT_EQ(0, resumes); // Clearing the gate alone does not resume.
+
+    m_stream.step(m_waiter);
+    EXPECT_EQ(1, resumes); // The successful startup that follows does.
+}
+
+TEST_F(ControlStreamTest, AnInterruptedAttemptIsNotAConfirmedDisconnect)
+{
+    // Shutdown cut the attempt short, so it proves nothing -- and the response
+    // still carries the PREVIOUS attempt's transport status, which is why the
+    // Interrupted check has to come before anything reads that field. No script:
+    // the waiter answers false, which is what makes the outcome Interrupted.
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
+    .WillRepeatedly(Return(response(TransportStatus::Timeout, 0)));
+    EXPECT_CALL(m_sink, onProducerPause(_)).Times(0);
+
+    m_stream.step(m_waiter); // Startup.
+    m_stream.step(m_waiter); // Interrupted.
+    m_stream.step(m_waiter); // Interrupted again: two would have been enough.
+}
+
+TEST_F(ControlStreamTest, AFailingShutdownDoesNotCountTowardTheThreshold)
+{
+    // drainStep is excluded on purpose: one best-effort attempt at a possibly
+    // dead manager, and arming there would leave WAIT_FILE on disk after a clean
+    // stop, blocking the next boot's producers. Only a successful registration
+    // clears it, so an agent whose manager is still down when it restarts would
+    // come up with its modules parked.
+    //
+    // One shutdown, which is all a real drain does, then two real failing steps.
+    // Had the shutdown been counted the arm would land on the first of them
+    // instead of the second, which is what the assertions below pin down.
+    int pauses = 0;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
+    .WillRepeatedly(Return(response(TransportStatus::Timeout, 0)));
+    EXPECT_CALL(m_sink, onProducerPause(true)).Times(1)
+    .WillOnce(Invoke([&](bool)
+    {
+        pauses++;
+    }));
+    EXPECT_CALL(m_sink, onProducerPause(false)).Times(0);
+    m_waiter.script({true, true, true, true, true, true});
+
+    m_stream.step(m_waiter);      // Startup accepted.
+    m_stream.drainStep(m_waiter); // Fails, and must contribute nothing.
+
+    m_stream.step(m_waiter);
+    EXPECT_EQ(0, pauses); // 1/2, not 2/2: the shutdown was not counted.
+
+    m_stream.step(m_waiter);
+    EXPECT_EQ(1, pauses); // Two real steps are still what arms it.
+}
+

--- a/src/client-agent/https_client/tests/unit/mocks/mockCallbackSink.hpp
+++ b/src/client-agent/https_client/tests/unit/mocks/mockCallbackSink.hpp
@@ -39,6 +39,7 @@ class MockCallbackSink : public ICallbackSink
                     (const std::string& sessionId, int result, const std::string& body), (override));
         MOCK_METHOD(void, onStateChange, (hc_conn_state_t state), (override));
         MOCK_METHOD(void, onBufferLevel, (hc_buffer_level_t level), (override));
+        MOCK_METHOD(void, onProducerPause, (bool paused), (override));
 };
 
 #endif // _HC_MOCK_CALLBACK_SINK_HPP

--- a/src/client-agent/https_client/tests/unit/outcomeClassifier_test.cpp
+++ b/src/client-agent/https_client/tests/unit/outcomeClassifier_test.cpp
@@ -62,27 +62,30 @@ INSTANTIATE_TEST_SUITE_P(
         ClassifierCase {TransportStatus::Ok, 200, OutcomeClass::Ok},
         ClassifierCase {TransportStatus::Ok, 201, OutcomeClass::Ok},
         ClassifierCase {TransportStatus::Ok, 299, OutcomeClass::Ok},
-        // Transport errors are retryable.
-        ClassifierCase {TransportStatus::Timeout, 0, OutcomeClass::Retryable},
-        ClassifierCase {TransportStatus::ConnectFail, 0, OutcomeClass::Retryable},
-        ClassifierCase {TransportStatus::TlsFail, 0, OutcomeClass::Retryable},
-        ClassifierCase {TransportStatus::OtherError, 0, OutcomeClass::Retryable},
+        // Transport errors: retryable AND the confirmed-disconnect class that
+        // arms the producer pause. TlsFail is deliberately in here too: no HTTP
+        // status arrived, so the manager did not answer.
+        ClassifierCase {TransportStatus::Timeout, 0, OutcomeClass::Unreachable},
+        ClassifierCase {TransportStatus::ConnectFail, 0, OutcomeClass::Unreachable},
+        ClassifierCase {TransportStatus::TlsFail, 0, OutcomeClass::Unreachable},
+        ClassifierCase {TransportStatus::OtherError, 0, OutcomeClass::Unreachable},
         // Auth: 401 only. 403 is not an auth code in the final contract; as a
         // non-contract intermediary code it is transient, so events are kept.
         ClassifierCase {TransportStatus::Ok, 401, OutcomeClass::AuthFail},
-        ClassifierCase {TransportStatus::Ok, 403, OutcomeClass::Retryable},
+        ClassifierCase {TransportStatus::Ok, 403, OutcomeClass::ServerError},
         // Version rejection: 409 Conflict per the #37733 /control contract.
         // 426 was the superseded #37732 proposal; now a transient intermediary
-        // code (Retryable) rather than a batch-dropping Permanent.
+        // code rather than a batch-dropping Permanent.
         ClassifierCase {TransportStatus::Ok, 409, OutcomeClass::VersionRejected},
-        ClassifierCase {TransportStatus::Ok, 426, OutcomeClass::Retryable},
+        ClassifierCase {TransportStatus::Ok, 426, OutcomeClass::ServerError},
         // Back-pressure signals.
         ClassifierCase {TransportStatus::Ok, 429, OutcomeClass::BackPressure},
         ClassifierCase {TransportStatus::Ok, 503, OutcomeClass::BackPressure},
-        // Server errors are retryable.
-        ClassifierCase {TransportStatus::Ok, 500, OutcomeClass::Retryable},
-        ClassifierCase {TransportStatus::Ok, 502, OutcomeClass::Retryable},
-        ClassifierCase {TransportStatus::Ok, 504, OutcomeClass::Retryable},
+        // Retryable but NOT a disconnect: an HTTP status came back, so something
+        // answered. 503 is BackPressure above; 403/426 share this class.
+        ClassifierCase {TransportStatus::Ok, 500, OutcomeClass::ServerError},
+        ClassifierCase {TransportStatus::Ok, 502, OutcomeClass::ServerError},
+        ClassifierCase {TransportStatus::Ok, 504, OutcomeClass::ServerError},
         // 413: the /stateless split-and-resend class (#37835), distinct from
         // the generic permanent drop.
         ClassifierCase {TransportStatus::Ok, 413, OutcomeClass::PayloadTooLarge},
@@ -101,7 +104,10 @@ TEST(OutcomeClassifierTest, AbortedIsInterruptedNeverOk)
 TEST(OutcomeClassifierTest, HcResultMapping)
 {
     EXPECT_EQ(HC_RESULT_OK, toHcResult(OutcomeClass::Ok));
-    EXPECT_EQ(HC_RESULT_RETRYABLE, toHcResult(OutcomeClass::Retryable));
+    // Both halves of the former Retryable class still cross the ABI as
+    // RETRYABLE: the split is internal to the module (#38010).
+    EXPECT_EQ(HC_RESULT_RETRYABLE, toHcResult(OutcomeClass::Unreachable));
+    EXPECT_EQ(HC_RESULT_RETRYABLE, toHcResult(OutcomeClass::ServerError));
     EXPECT_EQ(HC_RESULT_BACKPRESSURE, toHcResult(OutcomeClass::BackPressure));
     EXPECT_EQ(HC_RESULT_AUTH_FAIL, toHcResult(OutcomeClass::AuthFail));
     EXPECT_EQ(HC_RESULT_PERMANENT, toHcResult(OutcomeClass::Permanent));

--- a/src/client-agent/https_client/tests/unit/retrySender_test.cpp
+++ b/src/client-agent/https_client/tests/unit/retrySender_test.cpp
@@ -106,7 +106,7 @@ TEST_F(RetrySenderTest, EveryRetryIsFreshlySigned)
 
     const auto result = m_sender.send(makeSpec(), m_waiter, 2);
 
-    EXPECT_EQ(OutcomeClass::Retryable, result.outcome);
+    EXPECT_EQ(OutcomeClass::ServerError, result.outcome); // 500: the manager answered.
     ASSERT_EQ(2u, authorizations.size());
     // Different timestamp -> different ts field AND different MAC.
     EXPECT_NE(authorizations[0], authorizations[1]);
@@ -248,7 +248,7 @@ TEST_F(RetrySenderTest, MaxAttemptsBoundsTheLoop)
 
     const auto result = m_sender.send(makeSpec(), m_waiter, 3);
 
-    EXPECT_EQ(OutcomeClass::Retryable, result.outcome);
+    EXPECT_EQ(OutcomeClass::Unreachable, result.outcome); // Timeout: no answer at all.
     EXPECT_EQ(2u, m_waiter.requestedDelays().size()); // No delay after the last attempt.
 }
 

--- a/src/client-agent/src/agentd.c
+++ b/src/client-agent/src/agentd.c
@@ -121,8 +121,6 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
 
     start_agent(1);
 
-    os_delwait();
-
     // Ignore SIGPIPE signal to prevent the process from crashing
     struct sigaction act;
     memset(&act, 0, sizeof(act));

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -24,8 +24,10 @@
  * on_reenroll_required is wired to the existing authd flow (try_enroll_to_server,
  * start_agent.c) and hc_set_agent_key(); on_state_change feeds the .state file
  * (client-agent/include/state.h) and, since WAIT_FILE/os_setwait() had no HTTPS
- * release path either, also clears that producer lock on REGISTERED.
- * on_startup_result applies module limits and cluster-name authority, and
+ * release path either, also clears a stale producer lock on REGISTERED.
+ * on_producer_pause arms and releases that same lock while running, so a
+ * sustained manager outage stops modules generating events the agent could only
+ * drop. on_startup_result applies module limits and cluster-name authority, and
  * on_config_downloaded writes/applies merged.mg and releases the startup_gate.
  *
  * Since #38030 this is the agent's only transport, so every manager-visible
@@ -1132,17 +1134,12 @@ static void bridge_on_state_change(int state, void *user_data)
     mdebug1("https_client connection state -> %s (%d)", bridge_str_conn_state(state), state);
     w_agentd_state_update(UPDATE_STATUS, (void *)bridge_map_agent_status(state));
 
-    /* Interim fix for the WAIT_FILE/os_setwait() producer lock (armed
-     * unconditionally at agent startup, see agentd.c's AgentdStart()): it is
-     * otherwise only ever cleared by a successful LEGACY plaintext handshake,
-     * which permanently blocks every module's SendMSG/SendBinaryMSG against a
-     * pure-HTTPS manager even though /control is fully connected and healthy.
-     * A successful HTTPS registration is the equivalent "the manager
-     * acknowledged us" signal, so clear the lock here too. os_delwait() is
-     * idempotent (unlink() on an already-absent WAIT_FILE is a harmless
-     * no-op, and __wait_lock is just reset to 0), so it is safe to call
-     * unconditionally on every REGISTERED transition, including a later one
-     * after a reconnect. */
+    /* Clears a producer lock that outlived whatever armed it: a successful
+     * registration means the manager just acknowledged us, so anything still on
+     * disk is stale. That covers the boot-time arm in AgentdStart() and a lock
+     * left behind by an unclean exit -- on_producer_pause below cannot clear
+     * the latter, since it only fires on a paused->running transition and each
+     * run starts believing it has paused nothing. os_delwait() is idempotent. */
     if (state == HC_STATE_REGISTERED) {
         os_delwait();
     }
@@ -1163,6 +1160,21 @@ static char *bridge_collect_stats(void *user_data)
 {
     (void)user_data;
     return w_agent_collect_stats();
+}
+
+static void bridge_on_producer_pause(bool paused, void *user_data)
+{
+    (void)user_data;
+
+    if (paused) {
+        mwarn(SERVER_UNAV);
+        os_setwait();
+        w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_NACTIVE);
+    } else {
+        minfo(SERVER_UP);
+        os_delwait();
+        w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_ACTIVE);
+    }
 }
 
 /* Occupancy thresholds the module reports against, so the log lines can quote
@@ -1517,6 +1529,7 @@ void w_https_client_start(void)
     callbacks.collect_stats = bridge_collect_stats;
     callbacks.collect_config = bridge_collect_config;
     callbacks.on_collect_host = bridge_on_collect_host;
+    callbacks.on_producer_pause = bridge_on_producer_pause;
 
     g_https_client = hc_create(&config, &callbacks);
     if (!g_https_client) {

--- a/src/shared/include/error_messages/error_messages.h
+++ b/src/shared/include/error_messages/error_messages.h
@@ -541,8 +541,8 @@
 /* Wait operations */
 #define WAITING_MSG     "Process locked due to agent is offline. Waiting for connection..."
 #define WAITING_FREE    "Agent is now online. Process unlocked, continuing..."
-#define SERVER_UNAV     "Server unavailable. Setting lock."
-#define SERVER_UP       "Server responded. Releasing lock."
+#define SERVER_UNAV     "Manager unreachable. Pausing module event production."
+#define SERVER_UP       "Manager reachable again. Resuming module event production."
 #define LOCK_RES        "Agent auto-restart locked for %ld seconds."
 
 /* Buffer alerts */

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -105,7 +105,8 @@ list(APPEND client-agent_flags "-Wl,--wrap,wurl_free_response -Wl,--wrap,wurl_ht
                                 -Wl,--wrap,wfopen \
                                 -Wl,--wrap,verifyRemoteConf -Wl,--wrap,reloadAgent \
                                 -Wl,--wrap,w_agentd_populate_metadata \
-                                -Wl,--wrap,startup_gate_release_from_https_apply -Wl,--wrap,os_delwait \
+                                -Wl,--wrap,startup_gate_release_from_https_apply \
+                                -Wl,--wrap,os_delwait -Wl,--wrap,os_setwait \
                                 -Wl,--wrap,OS_SHA256_File \
                                 -Wl,--wrap,task_registry_check_and_record \
                                 -Wl,--wrap,restartAgent \

--- a/src/unit_tests/client-agent/test_https_client_bridge.c
+++ b/src/unit_tests/client-agent/test_https_client_bridge.c
@@ -108,8 +108,13 @@ void __wrap_startup_gate_release_from_https_apply(void)
     function_called();
 }
 
-/* WAIT_FILE/os_setwait release path: no pre-existing wrapper for this ABI. */
+/* WAIT_FILE producer lock: no pre-existing wrapper for either ABI. */
 void __wrap_os_delwait(void)
+{
+    function_called();
+}
+
+void __wrap_os_setwait(void)
 {
     function_called();
 }
@@ -751,6 +756,42 @@ static void test_registered_state_twice_clears_wait_file_each_time(void **state)
     expect_value(__wrap_w_agentd_state_update, data, GA_STATUS_ACTIVE);
     expect_function_call(__wrap_os_delwait);
     g_captured_callbacks.on_state_change(HC_STATE_REGISTERED, g_captured_callbacks.user_data);
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+/* on_producer_pause: the confirmed-disconnect pause. Both directions move the
+ * lock and the .state status together. */
+static void test_producer_pause_arms_the_lock_and_reports_disconnected(void **state)
+{
+    (void)state;
+    start_client_successfully();
+
+    expect_string(__wrap__mwarn, formatted_msg, "Manager unreachable. Pausing module event production.");
+    expect_function_call(__wrap_os_setwait);
+    expect_value(__wrap_w_agentd_state_update, type, UPDATE_STATUS);
+    expect_value(__wrap_w_agentd_state_update, data, GA_STATUS_NACTIVE);
+
+    g_captured_callbacks.on_producer_pause(true, g_captured_callbacks.user_data);
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+/* The release cannot ride on on_state_change: an agent that loses the manager
+ * while REGISTERED never leaves that state, so there is no transition to hook. */
+static void test_producer_pause_release_clears_the_lock_and_reports_connected(void **state)
+{
+    (void)state;
+    start_client_successfully();
+
+    expect_string(__wrap__minfo, formatted_msg, "Manager reachable again. Resuming module event production.");
+    expect_function_call(__wrap_os_delwait);
+    expect_value(__wrap_w_agentd_state_update, type, UPDATE_STATUS);
+    expect_value(__wrap_w_agentd_state_update, data, GA_STATUS_ACTIVE);
+
+    g_captured_callbacks.on_producer_pause(false, g_captured_callbacks.user_data);
 
     expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
     w_https_client_stop();
@@ -1886,6 +1927,8 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_reenroll_thread_logs_error_when_new_key_fails_validation, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_registered_state_maps_to_active, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_registered_state_twice_clears_wait_file_each_time, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_producer_pause_arms_the_lock_and_reports_disconnected, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_producer_pause_release_clears_the_lock_and_reports_connected, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_starting_state_maps_to_pending, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_stopped_state_maps_to_nactive, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_rejected_state_maps_to_nactive, setup_test, teardown_test),

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -343,8 +343,6 @@ int local_start()
 
     start_agent(1);
 
-    os_delwait();
-
     /* Delete agent state file at exit */
     atexit(DeleteState);
 


### PR DESCRIPTION
## Description

Under the legacy TCP transport the agent held a global producer lock: while the manager was confirmed unreachable, every module stopped generating events instead of piling up ones the agent could not deliver. Every place that armed that lock was TCP-specific and went away with the legacy path, and the HTTPS migration deliberately did not replace them — relying instead on per-request retry plus a bounded accumulator that drops the newest event when full.

That turns a prolonged outage into silent data loss, which is exactly what the legacy lock existed to prevent. This pull request restores the guarantee, scoped to the case where the manager is provably absent rather than merely slow or unhappy.

The distinction matters more than "some events are lost": a paused producer *preserves* data that a dropping one destroys. A log collector blocked before enqueuing has not advanced past those lines, so the file on disk remains the buffer and everything ships once the manager returns. A producer that keeps running into a full accumulator loses those events permanently.

Closes #38010

## Proposed Changes

- After two consecutive transport-level failures on the control endpoint — timeout, connection refused, DNS failure, TLS failure — the agent pauses event production. Every module blocks before enqueuing a new event, mirroring the legacy TCP behaviour.
- Production resumes on the very next successful control exchange. No threshold is needed for recovery.
- Only transport-level failures count toward the threshold. Anything the manager actually answers — authentication rejection, version rejection, any other 4xx or 5xx — proves it is reachable, so it never arms the pause and it cancels an in-progress count instead.
- The shutdown notification is deliberately excluded from the count. It is a single best-effort attempt at a possibly dead manager, and letting it arm the lock would leave the lock behind after a clean stop and block the next start-up.
- **The transport now owns the lock outright.** The agent still arms it at start-up, but the unconditional release that used to follow the start-up handshake is gone: reaching that point no longer implies the manager was ever reached, so releasing there left a window on every boot against a down manager where modules produced events the agent could only drop. The release now comes from a successful registration, and nothing else.
- Consequently, if the transport cannot start at all (an unusable signing key, TLS settings that fail closed) modules stay paused until the configuration is fixed and the agent restarted. With no client, the bridge discards every submission without even a trace, so letting producers run in that state would be precisely the silent loss this lock exists to prevent.
- The two operator-facing messages now name the effect rather than the mechanism: "Manager unreachable. Pausing module event production." instead of "Server unavailable. Setting lock."

### Results and Evidence

Full cycle against the HTTPS manager simulator, with a real agent and its modules. The simulator was stopped to make the manager unreachable, then restarted.

```sql
2026/07/31 15:39:53 wazuh-agentd:https-client[138749] controlStream.cpp at updateProducerPause(): DEBUG: /control unreachable (1/2).
2026/07/31 15:41:02 wazuh-agentd:https-client[138749] controlStream.cpp at updateProducerPause(): DEBUG: /control unreachable (2/2); pausing event production.
2026/07/31 15:41:02 wazuh-agentd[138749] https_client_bridge.c at bridge_on_producer_pause(): WARNING: Manager unreachable. Pausing module event production.
2026/07/31 15:41:07 wazuh-logcollector: WARNING: Process locked due to agent is offline. Waiting for connection...
2026/07/31 15:42:11 wazuh-agentd:https-client[138749] controlStream.cpp at updateProducerPause(): DEBUG: /control still unreachable; event production stays paused.
2026/07/31 15:44:16 wazuh-agentd:https-client[138749] controlStream.cpp at updateProducerPause(): DEBUG: /control still unreachable; event production stays paused.
2026/07/31 15:45:22 wazuh-agentd:https-client[138749] controlStream.cpp at updateProducerPause(): DEBUG: /control reachable again; releasing the producer pause.
2026/07/31 15:45:22 wazuh-agentd[138749] https_client_bridge.c at bridge_on_producer_pause(): INFO: Manager reachable again. Resuming module event production.
2026/07/31 15:45:27 wazuh-logcollector: INFO: Agent is now online. Process unlocked, continuing...
```

The two `wazuh-logcollector` lines are the guarantee itself: a real module blocking before it enqueues, and resuming afterwards. They are emitted by the module, not the agent daemon.

Agent state file, before and during the outage:

```sql
# Agent status:
status='connected'

# Agent status:
status='disconnected'
```

Both scenarios tested on ubuntu and windows.

Timing observed: the lock armed 69 seconds after the first failed attempt in one run and 21 seconds in another. Both are in range. A refused connection fails in essentially no time, so the floor is the notify cadence plus two full-jitter back-off draws that can each come out near zero (~20 s), and the ceiling is those draws at their maxima (~80 s). Recovery was noticed 66 seconds after the previous probe, consistent with the back-off having grown to its ceiling during the outage — worth knowing, because after a long outage a recovery can legitimately take about a minute to be detected.

A start-up against an unreachable manager also shows the pause and the start-up hash gate together: modules do not appear at all until the gate releases, which needs a Notify carrying the manager's config hash. That gate is independent of this lock — it is a condition variable with no queue involvement — so an agent started before its manager stays quiet until the manager answers, then everything comes up one notify cycle later. Pre-existing behaviour, not introduced here, but easy to mistake for this change.

Also verified manually:

- Shutting the agent down while paused stops it promptly rather than hanging, because the file integrity module can break out of the wait to exit.
- A stale lock left on disk by an unclean exit is cleared on the next successful registration.

### Artifacts Affected

- `wazuh-agentd` (Linux, Windows, macOS)
- The agent HTTPS client shared library

### Configuration Changes

None.

### Documentation Updates

None required.

### Tests Introduced

**Unit — HTTPS client:** one test per branch of the pause decision: a single failure not reaching the threshold; the threshold arming exactly once, staying quiet for the rest of the outage, then releasing on recovery; self-clearing answers (5xx) never pausing; version rejection pausing; a latched authentication failure pausing across the cycles where the gate short-circuits and nothing is sent; a new key clearing that pause and resuming; an attempt interrupted by shutdown not counting; and a failing shutdown notification never pausing.

**Unit — agent bridge:** both directions of the new callback, asserting the log line, the lock operation and the reported status together, since those three are the whole observable behaviour.

So the coverage split is: the unit tests own the decision logic and the callback contract on both sides of the ABI, and the manual runs own the end-to-end guarantee. What remains untested by automation is the transport error mapping itself, which every other failure path in the client already depends on.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] Manual cycle re-run on the current base, without the local patches the first capture needed

