### PR TITLE
Agent alignment to the final manager HTTPS contract

### DIFF
--- a/src/client-agent/https_client/include/https_client.h
+++ b/src/client-agent/https_client/include/https_client.h
@@ -262,6 +262,14 @@ typedef struct hc_callbacks_t
     /// logged and the cycle skipped.
     char* (*collect_stats)(void* user_data);
     char* (*collect_config)(void* user_data);
+
+    /// Fills json_out (capacity cap, NUL-terminated) with the host metadata JSON
+    /// object for the /control Notify: {"hostname":..,"architecture":..,"ip":..,
+    /// "os":{"name":..,"version":..,"platform":..,"type":..}}. Write an empty
+    /// string when metadata is not yet available; the Notify then omits host.
+    /// Called on the control thread before each Notify (not the dispatcher), so
+    /// it must be a fast, non-blocking read. Null means no host block is sent.
+    void (*on_collect_host)(char* json_out, size_t cap, void* user_data);
     void* user_data;
 } hc_callbacks_t;
 

--- a/src/client-agent/https_client/src/controlStateMachine.hpp
+++ b/src/client-agent/https_client/src/controlStateMachine.hpp
@@ -40,7 +40,7 @@ class ControlStateMachine final
         enum class Event
         {
             StartupAccepted,
-            StartupRejected, ///< 426 / 400 at Startup or Notify.
+            StartupRejected, ///< 409 / 400 at Startup or Notify.
             AuthFailed,      ///< 401.
             TransientFailure,
             NotifyOk,

--- a/src/client-agent/https_client/src/controlStream.cpp
+++ b/src/client-agent/https_client/src/controlStream.cpp
@@ -24,6 +24,7 @@ namespace
     {
         HttpRequestSpec spec;
         spec.target = "/control";
+        spec.contentType = "application/json";
         spec.body = reinterpret_cast<const uint8_t*>(body.data());
         spec.bodyLength = body.size();
         spec.timeoutMs = timeoutMs;
@@ -115,7 +116,8 @@ ControlStream::ControlStream(const ModuleConfig& config, IHttpPerformer& perform
                              const ISigner& signer, IClock& clock, IRandom& random,
                              ICallbackSink& sink, ISpoolFileFactory& spoolFactory,
                              ConfigHashState& configHash, ClusterIdentity& cluster,
-                             AuthGate& authGate, ITaskIdStore& taskStore)
+                             AuthGate& authGate, ITaskIdStore& taskStore,
+                             std::function<std::string()> collectHost)
     : m_config(config)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
     , m_sender(performer, signer, clock, m_backoff, &authGate)
@@ -127,6 +129,7 @@ ControlStream::ControlStream(const ModuleConfig& config, IHttpPerformer& perform
     , m_cluster(cluster)
     , m_authGate(authGate)
     , m_taskStore(taskStore)
+    , m_collectHost(std::move(collectHost))
 {
 }
 
@@ -226,6 +229,7 @@ OutcomeClass ControlStream::sendStartup(Waiter& waiter)
 
     const auto result = m_sender.send(controlSpec(body, m_config.requestTimeoutMs), waiter,
                                       CONTROL_MAX_ATTEMPTS);
+    updateLocalIp(result.response);
 
     if (result.outcome == OutcomeClass::Ok)
     {
@@ -256,14 +260,40 @@ OutcomeClass ControlStream::sendStartup(Waiter& waiter)
 
 OutcomeClass ControlStream::sendNotify(Waiter& waiter)
 {
-    // The keepalive request is bare; the manager reports the
+    // Keepalive: type + agent version + host metadata. The manager reports the
     // hashes and tasks in the response.
-    const std::string body = R"({"type":"notify"})";
+    nlohmann::json request;
+    request["type"] = "notify";
+    request["agent"]["version"] = m_config.version;
+
+    // Host block, pulled fresh from the agent metadata each Notify. Omitted when
+    // the source is unavailable (empty/malformed), never fatal.
+    if (m_collectHost)
+    {
+        auto host = nlohmann::json::parse(m_collectHost(), nullptr, false);
+
+        if (!host.is_discarded() && host.is_object())
+        {
+            // The agent's own IP toward the manager is a transport-layer fact the
+            // module owns (CURLINFO_LOCAL_IP from the last /control connection),
+            // not agent metadata; inject it here. Absent until the first
+            // connection succeeds, then carried on every Notify.
+            if (!m_localIp.empty())
+            {
+                host["ip"] = m_localIp;
+            }
+
+            request["host"] = std::move(host);
+        }
+    }
+
+    const std::string body = request.dump();
 
     LOGFN_DEBUG2(m_logFn, "Sending /control notify.");
 
     const auto result = m_sender.send(controlSpec(body, m_config.requestTimeoutMs), waiter,
                                       CONTROL_MAX_ATTEMPTS);
+    updateLocalIp(result.response);
     const auto effects = m_machine.onEvent(eventFor(result.outcome));
     applyEffects(effects, {});
 
@@ -487,6 +517,16 @@ void ControlStream::joinUpgradeWork()
     if (m_upgradeThread.joinable())
     {
         m_upgradeThread.join();
+    }
+}
+
+void ControlStream::updateLocalIp(const HttpResponse& response)
+{
+    // curl reports the local address only after a connection was established;
+    // keep the last known value so a transient failure does not blank host.ip.
+    if (!response.localIp.empty())
+    {
+        m_localIp = response.localIp;
     }
 }
 

--- a/src/client-agent/https_client/src/controlStream.hpp
+++ b/src/client-agent/https_client/src/controlStream.hpp
@@ -27,6 +27,7 @@
 #include "taskIdStore.hpp"
 #include "wpkFetcher.hpp"
 
+#include <functional>
 #include <string>
 #include <thread>
 #include <vector>
@@ -46,7 +47,8 @@ class ControlStream final
         ControlStream(const ModuleConfig& config, IHttpPerformer& performer, const ISigner& signer,
                       IClock& clock, IRandom& random, ICallbackSink& sink,
                       ISpoolFileFactory& spoolFactory, ConfigHashState& configHash,
-                      ClusterIdentity& cluster, AuthGate& authGate, ITaskIdStore& taskStore);
+                      ClusterIdentity& cluster, AuthGate& authGate, ITaskIdStore& taskStore,
+                      std::function<std::string()> collectHost = {});
 
         /// Safety net for any destruction path that doesn't go through HttpsClientFacade::
         /// stop() first (e.g. a test constructing a bare ControlStream): joins m_upgradeThread
@@ -91,6 +93,7 @@ class ControlStream final
         void maybeArmSettingsRefresh(const std::string& incoming);
         void maybeDownloadConfig(const std::string& managerHash, const std::string& group,
                                  Waiter& waiter);
+        void updateLocalIp(const HttpResponse& response);
         ControlStateMachine::Event eventFor(OutcomeClass outcome) const;
 
         const ModuleConfig& m_config;
@@ -105,6 +108,12 @@ class ControlStream final
         AuthGate& m_authGate;
         ControlStateMachine m_machine;
         ITaskIdStore& m_taskStore;
+        /// Pull-source for the Notify host block, fed from the agent's
+        /// metadata_provider. Empty/unset -> no host block (metadata not ready).
+        std::function<std::string()> m_collectHost;
+        /// The agent's own IP (CURLINFO_LOCAL_IP), captured from the last
+        /// /control connection and reported as host.ip on the next Notify.
+        std::string m_localIp;
         const LogFn m_logFn {HTTPS_CLIENT_LOGTAG};
 
         /// SHA-256 of the exact startup-response bytes (the local settings

--- a/src/client-agent/https_client/src/curlHandle.cpp
+++ b/src/client-agent/https_client/src/curlHandle.cpp
@@ -268,6 +268,13 @@ namespace
                 return code;
             }
 
+            std::string localIp() override
+            {
+                char* ip = nullptr;
+                curl_easy_getinfo(m_handle, CURLINFO_LOCAL_IP, &ip);
+                return ip != nullptr ? std::string(ip) : std::string();
+            }
+
         private:
             CURL* m_handle {nullptr};
             curl_slist* m_headers {nullptr};

--- a/src/client-agent/https_client/src/curlPerformer.cpp
+++ b/src/client-agent/https_client/src/curlPerformer.cpp
@@ -70,6 +70,7 @@ HttpResponse CurlPerformer::perform(const HttpRequestSpec& spec)
 
     response.status = handle->perform();
     response.httpCode = handle->responseCode();
+    response.localIp = handle->localIp();
     return response;
 }
 
@@ -179,6 +180,11 @@ void CurlPerformer::configureRequest(ICurlHandle& handle, const HttpRequestSpec&
     for (const auto& header : spec.headers)
     {
         handle.appendHeader(header);
+    }
+
+    if (!spec.contentType.empty())
+    {
+        handle.appendHeader("Content-Type: " + spec.contentType);
     }
 
     handle.appendHeader("Expect:"); // Disable 100-continue; keep a fixed Content-Length.

--- a/src/client-agent/https_client/src/httpTypes.hpp
+++ b/src/client-agent/https_client/src/httpTypes.hpp
@@ -37,10 +37,10 @@ enum class OutcomeClass
     Ok,
     Retryable,
     BackPressure,    ///< 503 + Retry-After / 429: server delay wins when longer.
-    AuthFail,        ///< 401 (or 403): re-sign and retry on a slow cadence.
+    AuthFail,        ///< 401: one fresh-timestamp retry, then re-enrollment.
     Permanent,       ///< 400/...: retrying identical bytes cannot succeed.
     PayloadTooLarge, ///< 413: /stateless splits + resends smaller (#37835).
-    VersionRejected, ///< 426 at Startup: REJECTED state, slow re-Startup.
+    VersionRejected, ///< 409 at Startup: REJECTED state, slow re-Startup.
     Interrupted      ///< Aborted by shutdown: never a silent success.
 };
 
@@ -81,6 +81,8 @@ inline int toHcResult(OutcomeClass outcome)
 struct HttpRequestSpec
 {
     std::string target;                ///< e.g. "/stateless" (also the MAC'd target).
+    std::string contentType;           ///< Emitted as Content-Type when non-empty; empty
+    ///< leaves libcurl's default (non-JSON endpoints).
     std::vector<std::string> headers;  ///< Extra headers (auth headers included).
     const uint8_t* body {nullptr};     ///< In-memory body (nullptr when file-backed).
     size_t bodyLength {0};
@@ -101,6 +103,8 @@ struct HttpResponse
     TransportStatus status {TransportStatus::OtherError};
     long httpCode {0};
     long retryAfterSeconds {0}; ///< Parsed Retry-After header (0 = absent).
+    std::string localIp;        ///< Local IP of the connection (CURLINFO_LOCAL_IP);
+    ///< the agent's own address toward the manager.
     std::string body;
 };
 

--- a/src/client-agent/https_client/src/httpsClientFacade.cpp
+++ b/src/client-agent/https_client/src/httpsClientFacade.cpp
@@ -13,6 +13,30 @@
 
 #include "curlHandle.hpp"
 
+#include <functional>
+#include <string>
+
+namespace
+{
+    /// Wraps the C on_collect_host callback as the pull-source ControlStream
+    /// uses for the Notify host block. Returns "" when the callback is unset.
+    std::function<std::string()> makeHostCollector(const hc_callbacks_t& callbacks)
+    {
+        return [fn = callbacks.on_collect_host, userData = callbacks.user_data]() -> std::string
+        {
+            if (fn == nullptr)
+            {
+                return {};
+            }
+
+            char buffer[4096] = {};
+            fn(buffer, sizeof(buffer), userData);
+            buffer[sizeof(buffer) - 1] = '\0';
+            return std::string(buffer);
+        };
+    }
+} // namespace
+
 HttpsClientFacade::HttpsClientFacade(const hc_config_t& config, const hc_callbacks_t& callbacks)
     : m_config(ModuleConfig::fromC(config))
     , m_keyProvider(m_config.agentKeyHex)
@@ -27,7 +51,7 @@ HttpsClientFacade::HttpsClientFacade(const hc_config_t& config, const hc_callbac
     , m_stateful(m_config, m_performer, m_signer, m_clock, m_random, m_spoolFactory, m_dispatcher,
                  m_authGate)
     , m_control(m_config, m_performer, m_signer, m_clock, m_random, m_dispatcher, m_spoolFactory,
-                m_configHash, m_cluster, m_authGate, m_taskStore)
+                m_configHash, m_cluster, m_authGate, m_taskStore, makeHostCollector(callbacks))
     , m_reporter(m_config, m_performer, m_signer, m_clock, m_random, m_authGate, m_cluster,
                  m_collectors)
 {

--- a/src/client-agent/https_client/src/iCurlHandle.hpp
+++ b/src/client-agent/https_client/src/iCurlHandle.hpp
@@ -68,6 +68,7 @@ class ICurlHandle
 
         virtual TransportStatus perform() = 0;
         virtual long responseCode() = 0;
+        virtual std::string localIp() = 0; ///< CURLINFO_LOCAL_IP after perform().
 };
 
 using CurlHandleFactory = std::function<std::unique_ptr<ICurlHandle>()>;

--- a/src/client-agent/https_client/src/outcomeClassifier.cpp
+++ b/src/client-agent/https_client/src/outcomeClassifier.cpp
@@ -30,7 +30,7 @@ OutcomeClass classifyOutcome(const HttpResponse& response)
         return OutcomeClass::Ok;
     }
 
-    if (code == 401 || code == 403) // 401 per #37732; 403 kept until FR7.4 is reconciled (T2)
+    if (code == 401) // Generic auth failure, the only auth code in the contract.
     {
         return OutcomeClass::AuthFail;
     }
@@ -42,11 +42,10 @@ OutcomeClass classifyOutcome(const HttpResponse& response)
         return OutcomeClass::PayloadTooLarge;
     }
 
-    // Version/protocol rejection: 426 per the #37732 proposal, 409 per the
-    // #37733 Task Manager OpenAPI ("Protocol version not supported"). Both
-    // accepted until the two specs reconcile; either way the client goes
-    // REJECTED and re-tries Startup on the slow cadence.
-    if (code == 426 || code == 409)
+    // 409 Conflict: protocol/agent version not supported (the #37733 /control
+    // contract). The client goes REJECTED and re-tries Startup on the slow
+    // cadence.
+    if (code == 409)
     {
         return OutcomeClass::VersionRejected;
     }
@@ -54,6 +53,15 @@ OutcomeClass classifyOutcome(const HttpResponse& response)
     if (code == 429 || code == 503)
     {
         return OutcomeClass::BackPressure;
+    }
+
+    // 403/426 are not part of the manager contract: they reach the agent only
+    // from an intermediary (reverse proxy, WAF, mTLS gateway). Treat them as
+    // transient so a /stateless batch is preserved and retried, never dropped
+    // (Permanent would consume the batch and count it as lost).
+    if (code == 403 || code == 426)
+    {
+        return OutcomeClass::Retryable;
     }
 
     return (code >= 500) ? OutcomeClass::Retryable : OutcomeClass::Permanent;

--- a/src/client-agent/https_client/src/retrySender.cpp
+++ b/src/client-agent/https_client/src/retrySender.cpp
@@ -30,10 +30,20 @@ RetrySender::Result RetrySender::send(const HttpRequestSpec& spec, Waiter& waite
     base.abortFlag = waiter.stopFlag();
 
     Result result;
+    bool authRetried = false;
 
     for (uint32_t attempt = 1; attempt <= maxAttempts; attempt++)
     {
         result = attemptOnce(base);
+
+        // One-shot 401 retry: a 401 can be a just-expired/edge timestamp as
+        // easily as a dead key. Resign with a fresh timestamp (attemptOnce
+        // re-signs) and try once more; only a second 401 escalates below.
+        if (result.outcome == OutcomeClass::AuthFail && !authRetried)
+        {
+            authRetried = true;
+            result = attemptOnce(base);
+        }
 
         if (!isRetryable(result.outcome) || attempt == maxAttempts)
         {
@@ -53,8 +63,9 @@ RetrySender::Result RetrySender::send(const HttpRequestSpec& spec, Waiter& waite
     }
     else if (result.outcome == OutcomeClass::AuthFail && m_authGate != nullptr)
     {
-        // 401 on any endpoint: the credential is dead. Pause everything and
-        // ask for re-enrollment (once per incident). #37828.
+        // A 401 that survived the one-shot fresh-timestamp retry above: treat it
+        // as a dead credential. Pause everything and ask for re-enrollment (once
+        // per incident). #37828.
         m_authGate->reportAuthFailure();
     }
 

--- a/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
+++ b/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
@@ -57,6 +57,15 @@ namespace
         }
     }
 
+    /// Stands in for the agent's metadata_provider collector: supplies the host
+    /// fields the module cannot know (hostname/architecture/os). host.ip is NOT
+    /// provided here; the module injects it from the live connection.
+    void collectHostStub(char* json_out, size_t cap, void*)
+    {
+        std::snprintf(json_out, cap,
+                      R"({"hostname":"h","architecture":"x86_64","os":{"type":"linux"}})");
+    }
+
     void onSync(const char*, int, const char*, size_t, void* userData)
     {
         static_cast<Recorder*>(userData)->syncCount++;
@@ -279,6 +288,60 @@ TEST_F(FacadeE2eTest, RegistersOverTlsAndStopsCleanly)
     EXPECT_NE(recorder.states.end(),
               std::find(recorder.states.begin(), recorder.states.end(), HC_STATE_REGISTERED));
     EXPECT_EQ(HC_STATE_STOPPED, recorder.states.back());
+}
+
+TEST_F(FacadeE2eTest, ControlRequestsAdvertiseJsonContentType)
+{
+    // End-to-end proof that /control carries Content-Type: application/json over
+    // the real curl path (the unit test only proves CurlPerformer emits it).
+    const uint16_t port = TLS_PORT + 7;
+    FakeManager manager {port, KEY_HEX, /*tls=*/true};
+
+    Recorder recorder;
+    hc_config_t config = tlsConfig();
+    config.server_port = port;
+    hc_callbacks_t callbacks {};
+    callbacks.on_startup_result = onStartup;
+    callbacks.user_data = &recorder;
+
+    hc_handle* handle = hc_create(&config, &callbacks);
+    ASSERT_NE(nullptr, handle);
+    ASSERT_TRUE(hc_start(handle));
+    ASSERT_TRUE(waitFor(recorder.startupCount, 1, 3000)); // Registered (startup on /control).
+
+    httplib::Client peek {std::string {"https://127.0.0.1:"} + std::to_string(port)};
+    peek.enable_server_certificate_verification(false);
+    EXPECT_TRUE(waitForBody(peek, "/peek/control-content-type", "application/json", 3000));
+
+    hc_destroy(handle);
+}
+
+TEST_F(FacadeE2eTest, NotifyHostCarriesTheLiveLocalIp)
+{
+    // End-to-end proof that host.ip is populated from the real connection
+    // (CURLINFO_LOCAL_IP), not from the retired getsockname(agt->sock) path.
+    // The loopback fake manager yields a local IP of 127.0.0.1.
+    const uint16_t port = TLS_PORT + 8;
+    FakeManager manager {port, KEY_HEX, /*tls=*/true};
+
+    Recorder recorder;
+    hc_config_t config = tlsConfig();
+    config.server_port = port;
+    hc_callbacks_t callbacks {};
+    callbacks.on_startup_result = onStartup;
+    callbacks.on_collect_host = collectHostStub;
+    callbacks.user_data = &recorder;
+
+    hc_handle* handle = hc_create(&config, &callbacks);
+    ASSERT_NE(nullptr, handle);
+    const HandleGuard guard {handle};
+    ASSERT_TRUE(hc_start(handle));
+    ASSERT_TRUE(waitFor(recorder.startupCount, 1, 3000)); // Registered.
+
+    httplib::Client peek {std::string {"https://127.0.0.1:"} + std::to_string(port)};
+    peek.enable_server_certificate_verification(false);
+    // The first Notify carries the host block with the injected local IP.
+    EXPECT_TRUE(waitForBody(peek, "/peek/last-notify", R"("ip":"127.0.0.1")", 5000));
 }
 
 TEST_F(FacadeE2eTest, SizeThresholdFlushesBeforeTheBatchInterval)

--- a/src/client-agent/https_client/tests/component/fakeManager.hpp
+++ b/src/client-agent/https_client/tests/component/fakeManager.hpp
@@ -35,7 +35,7 @@
  *        idiom). It validates the AES-CMAC of every request server-side with
  *        the shared key, so a 200 proves real cross-implementation auth
  *        interop; a mismatch yields 401. It supports a one-shot 503 (back-
- *        pressure), a session LRU-of-one (dedup), and a 426 mode.
+ *        pressure), a session LRU-of-one (dedup), and a 409 version-reject mode.
  *
  * The child process runs the server; the parent asserts on the responses it
  * receives (the two sides do not share memory).
@@ -340,9 +340,17 @@ class FakeManager final
             // whether a graceful stop actually sends {"type":"shutdown"}.
             auto controlTypes = std::make_shared<std::string>();
             auto controlMutex = std::make_shared<std::mutex>();
+            // The Content-Type each /control request advertised, so a test can
+            // confirm the per-endpoint header survives the real curl path (the
+            // unit test only proves CurlPerformer emits it). Same peek idiom.
+            auto controlContentTypes = std::make_shared<std::string>();
+            // The last Notify body, so a test can confirm the real host block
+            // (including host.ip from the live connection) over the curl path.
+            auto lastNotifyBody = std::make_shared<std::string>();
 
             server.Post("/control",
-                        [verify, settingsFlipAfter, notifyCount, configHash, controlTypes, controlMutex](
+                        [verify, settingsFlipAfter, notifyCount, configHash, controlTypes,
+                                 controlContentTypes, lastNotifyBody, controlMutex](
                             const httplib::Request & request, httplib::Response & response)
             {
                 if (!verify("/control", request))
@@ -351,9 +359,15 @@ class FakeManager final
                     return;
                 }
 
+                {
+                    std::lock_guard<std::mutex> lock(*controlMutex);
+                    *controlContentTypes += request.get_header_value("Content-Type");
+                    *controlContentTypes += ";";
+                }
+
                 if (request.has_header("X-Reject-Version"))
                 {
-                    response.status = 426;
+                    response.status = 409;
                     return;
                 }
 
@@ -402,6 +416,10 @@ class FakeManager final
                 if (request.body.find("\"type\":\"notify\"") != std::string::npos)
                 {
                     notifyCount->fetch_add(1);
+                    {
+                        std::lock_guard<std::mutex> lock(*controlMutex);
+                        *lastNotifyBody = request.body;
+                    }
                     const std::string agent =
                         configHash.empty()
                         ? std::string {R"({"groups":["default"]})"}
@@ -432,6 +450,24 @@ class FakeManager final
                 std::lock_guard<std::mutex> lock(*controlMutex);
                 response.status = 200;
                 response.set_content(*controlTypes, "text/plain");
+            });
+
+            server.Get("/peek/control-content-type",
+                       [controlContentTypes, controlMutex](const httplib::Request&,
+                                                           httplib::Response & response)
+            {
+                std::lock_guard<std::mutex> lock(*controlMutex);
+                response.status = 200;
+                response.set_content(*controlContentTypes, "text/plain");
+            });
+
+            server.Get("/peek/last-notify",
+                       [lastNotifyBody, controlMutex](const httplib::Request&,
+                                                      httplib::Response & response)
+            {
+                std::lock_guard<std::mutex> lock(*controlMutex);
+                response.status = 200;
+                response.set_content(*lastNotifyBody, "text/plain");
             });
         }
 

--- a/src/client-agent/https_client/tests/component/httpsClient_component_test.cpp
+++ b/src/client-agent/https_client/tests/component/httpsClient_component_test.cpp
@@ -293,10 +293,10 @@ TEST_F(ComponentTest, ControlStartupReturnsHandshakeJson)
     EXPECT_NE(std::string::npos, response.body.find("\"limits\""));
 }
 
-TEST_F(ComponentTest, VersionRejectionSurfacesAs426)
+TEST_F(ComponentTest, VersionRejectionSurfacesAs409)
 {
     const auto response = sendSigned(m_performer, m_signer, "/control",
                                      R"({"type":"startup"})", {"X-Reject-Version: 1"});
-    EXPECT_EQ(426, response.httpCode);
+    EXPECT_EQ(409, response.httpCode);
     EXPECT_EQ(OutcomeClass::VersionRejected, classifyOutcome(response));
 }

--- a/src/client-agent/https_client/tests/unit/controlStateMachine_test.cpp
+++ b/src/client-agent/https_client/tests/unit/controlStateMachine_test.cpp
@@ -122,7 +122,7 @@ TEST(ControlStateMachineTest, RegisteredAuthFailedDemotesToAuthError)
 TEST(ControlStateMachineTest, RegisteredVersionRejectionDemotesToRejected)
 {
     auto machine = inState(State::Registered);
-    // A 426 arriving during Notify (StartupRejected event) demotes.
+    // A 409 arriving during Notify (StartupRejected event) demotes.
     const auto effects = machine.onEvent(Event::StartupRejected);
     EXPECT_EQ(State::Rejected, machine.state());
     EXPECT_TRUE(effects.slowCadence);
@@ -228,7 +228,7 @@ TEST(ControlStateMachineTest, TransientFailureKeepsAnArmedRefresh)
 
 TEST(ControlStateMachineTest, DemotionClearsAnArmedRefresh)
 {
-    // A refresh Startup answered 426/401 demotes; the slow re-Startup cadence
+    // A refresh Startup answered 409/401 demotes; the slow re-Startup cadence
     // owns recovery and the one-shot refresh request must not linger.
     for (const auto event :
             {

--- a/src/client-agent/https_client/tests/unit/controlStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/controlStream_test.cpp
@@ -16,6 +16,8 @@
 #include "mockCallbackSink.hpp"
 #include "mockHttpPerformer.hpp"
 
+#include "external/nlohmann/json.hpp"
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -30,12 +32,14 @@ using ::testing::Return;
 
 namespace
 {
-    HttpResponse response(TransportStatus status, long code, const std::string& body = {})
+    HttpResponse response(TransportStatus status, long code, const std::string& body = {},
+                          const std::string& localIp = {})
     {
         HttpResponse value;
         value.status = status;
         value.httpCode = code;
         value.body = body;
+        value.localIp = localIp;
         return value;
     }
 
@@ -54,7 +58,8 @@ namespace
                 , m_configHash("abc")
                 , m_authGate(m_sink, [] {})
             , m_stream(m_config, m_performer, m_signer, m_clock, m_random, m_sink,
-                       m_spoolFactory, m_configHash, m_cluster, m_authGate, m_taskStore)
+                       m_spoolFactory, m_configHash, m_cluster, m_authGate, m_taskStore,
+                       [this] { return m_hostJson; })
             {
             }
 
@@ -82,6 +87,7 @@ namespace
             AuthGate m_authGate;
             FakeWaiter m_waiter;
             FakeTaskIdStore m_taskStore;
+            std::string m_hostJson; ///< Injected Notify host block ("" -> omitted).
             ControlStream m_stream;
     };
 } // namespace
@@ -174,7 +180,7 @@ TEST_F(ControlStreamTest, VersionRejectionGoesRejected)
 {
     EXPECT_CALL(m_sink, onStateChange(HC_STATE_REJECTED));
     EXPECT_CALL(m_sink, onStartupResult(false, _)); // A rejected startup is reported to the consumer.
-    EXPECT_CALL(m_performer, perform(_)).WillOnce(Return(response(TransportStatus::Ok, 426)));
+    EXPECT_CALL(m_performer, perform(_)).WillOnce(Return(response(TransportStatus::Ok, 409)));
 
     EXPECT_FALSE(m_stream.step(m_waiter));
     EXPECT_EQ(HC_STATE_REJECTED, m_stream.connState());
@@ -183,7 +189,10 @@ TEST_F(ControlStreamTest, VersionRejectionGoesRejected)
 TEST_F(ControlStreamTest, PersistentAuthFailureGoesAuthError)
 {
     EXPECT_CALL(m_sink, onStateChange(HC_STATE_AUTH_ERROR));
-    EXPECT_CALL(m_performer, perform(_)).WillOnce(Return(response(TransportStatus::Ok, 401)));
+    // A 401 gets one fresh-timestamp retry; a second 401 escalates to AUTH_ERROR.
+    EXPECT_CALL(m_performer, perform(_))
+    .Times(2)
+    .WillRepeatedly(Return(response(TransportStatus::Ok, 401)));
 
     EXPECT_FALSE(m_stream.step(m_waiter));
     EXPECT_EQ(HC_STATE_AUTH_ERROR, m_stream.connState());
@@ -194,6 +203,7 @@ TEST_F(ControlStreamTest, PausedGateSkipsHttpAndReleaseResumesWithAFreshStartup)
     // First step: 401 startup engages the gate (via RetrySender) -> AUTH_ERROR.
     EXPECT_CALL(m_performer, perform(_))
     .WillOnce(Return(response(TransportStatus::Ok, 401)))   // Startup -> 401.
+    .WillOnce(Return(response(TransportStatus::Ok, 401)))   // One-shot auth retry -> 401 -> pause.
     .WillOnce(Invoke(                                       // Post-release startup.
                   [&](const HttpRequestSpec & spec)
     {
@@ -215,21 +225,81 @@ TEST_F(ControlStreamTest, PausedGateSkipsHttpAndReleaseResumesWithAFreshStartup)
     EXPECT_EQ(HC_STATE_REGISTERED, m_stream.connState());
 }
 
-TEST_F(ControlStreamTest, NotifyRequestIsBare)
+TEST_F(ControlStreamTest, NotifyCarriesTypeVersionAndHost)
 {
-    // 5.1.2: the agent sends nothing but the discriminator; the manager
-    // reports groups/config_hash/settings_hash in the response.
+    // The collector supplies hostname/architecture/os; host.ip is injected by
+    // the module from the connection's local IP (CURLINFO_LOCAL_IP), captured
+    // on the preceding Startup response.
+    m_hostJson = R"({"hostname":"ubuntu-test","architecture":"x86_64",)"
+                 R"("os":{"name":"Ubuntu","version":"20.04","platform":"ubuntu","type":"linux"}})";
+
+    std::string sent;
     EXPECT_CALL(m_performer, perform(_))
-    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}", "192.168.1.100"))) // Startup: local IP.
     .WillOnce(Invoke(
                   [&](const HttpRequestSpec & spec)
     {
-        EXPECT_EQ(R"({"type":"notify"})", bodyOf(spec));
+        sent = bodyOf(spec);
         return response(TransportStatus::Ok, 200, "{}");
     }));
 
     m_stream.step(m_waiter); // Startup.
     m_stream.step(m_waiter); // Notify.
+
+    const auto body = nlohmann::json::parse(sent);
+    EXPECT_EQ("notify", body.at("type"));
+    EXPECT_EQ("5.1.0", body.at("agent").at("version"));
+    EXPECT_EQ("ubuntu-test", body.at("host").at("hostname"));
+    EXPECT_EQ("x86_64", body.at("host").at("architecture"));
+    EXPECT_EQ("192.168.1.100", body.at("host").at("ip")); // From CURLINFO_LOCAL_IP.
+    EXPECT_EQ("linux", body.at("host").at("os").at("type"));
+}
+
+TEST_F(ControlStreamTest, NotifyHostOmitsIpWhenLocalIpUnknown)
+{
+    // Host metadata is available but no connection has reported a local IP yet:
+    // the host block is sent without the ip key rather than an empty one.
+    m_hostJson = R"({"hostname":"h","os":{"type":"linux"}})";
+
+    std::string sent;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}"))) // Startup: no local IP.
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & spec)
+    {
+        sent = bodyOf(spec);
+        return response(TransportStatus::Ok, 200, "{}");
+    }));
+
+    m_stream.step(m_waiter); // Startup.
+    m_stream.step(m_waiter); // Notify.
+
+    const auto body = nlohmann::json::parse(sent);
+    EXPECT_TRUE(body.at("host").is_object());
+    EXPECT_FALSE(body.at("host").contains("ip"));
+}
+
+TEST_F(ControlStreamTest, NotifyOmitsHostWhenMetadataUnavailable)
+{
+    m_hostJson.clear(); // metadata_provider not ready yet.
+
+    std::string sent;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & spec)
+    {
+        sent = bodyOf(spec);
+        return response(TransportStatus::Ok, 200, "{}");
+    }));
+
+    m_stream.step(m_waiter); // Startup.
+    m_stream.step(m_waiter); // Notify.
+
+    const auto body = nlohmann::json::parse(sent);
+    EXPECT_EQ("notify", body.at("type"));
+    EXPECT_EQ("5.1.0", body.at("agent").at("version"));
+    EXPECT_FALSE(body.contains("host"));
 }
 
 TEST_F(ControlStreamTest, SettingsMismatchTriggersOneStartupRefresh)

--- a/src/client-agent/https_client/tests/unit/curlPerformer_test.cpp
+++ b/src/client-agent/https_client/tests/unit/curlPerformer_test.cpp
@@ -97,6 +97,47 @@ TEST(CurlPerformerTest, MemoryBodyMapsToExactOptions)
     EXPECT_EQ(200, response.httpCode);
 }
 
+TEST(CurlPerformerTest, ContentTypeEmittedWhenSet)
+{
+    auto mock = std::make_unique<NiceMock<MockCurlHandle>>();
+    auto* handle = mock.get();
+    allowOtherOptions(*handle);
+    const auto config = makeConfig(HC_VERIFY_NONE);
+
+    const uint8_t body[] = R"({"type":"notify"})";
+    HttpRequestSpec spec;
+    spec.target = "/control";
+    spec.contentType = "application/json";
+    spec.body = body;
+    spec.bodyLength = sizeof(body) - 1;
+
+    EXPECT_CALL(*handle, appendHeader("Content-Type: application/json"));
+    EXPECT_CALL(*handle, perform()).WillOnce(Return(TransportStatus::Ok));
+
+    auto performer = makePerformer(config, std::move(mock));
+    performer.perform(spec);
+}
+
+TEST(CurlPerformerTest, NoContentTypeWhenUnset)
+{
+    auto mock = std::make_unique<NiceMock<MockCurlHandle>>();
+    auto* handle = mock.get();
+    allowOtherOptions(*handle);
+    const auto config = makeConfig(HC_VERIFY_NONE);
+
+    const uint8_t body[] = "H {}\n";
+    HttpRequestSpec spec;
+    spec.target = "/stateless"; // */* endpoint: keep libcurl's default.
+    spec.body = body;
+    spec.bodyLength = sizeof(body) - 1;
+
+    EXPECT_CALL(*handle, appendHeader(::testing::StartsWith("Content-Type:"))).Times(0);
+    EXPECT_CALL(*handle, perform()).WillOnce(Return(TransportStatus::Ok));
+
+    auto performer = makePerformer(config, std::move(mock));
+    performer.perform(spec);
+}
+
 TEST(CurlPerformerTest, ResponseBodyAndRetryAfterFlowBack)
 {
     auto mock = std::make_unique<NiceMock<MockCurlHandle>>();

--- a/src/client-agent/https_client/tests/unit/mocks/mockCurlHandle.hpp
+++ b/src/client-agent/https_client/tests/unit/mocks/mockCurlHandle.hpp
@@ -30,6 +30,7 @@ class MockCurlHandle : public ICurlHandle
         MOCK_METHOD(void, wireAbort, (const std::atomic<bool>* abortFlag), (override));
         MOCK_METHOD(TransportStatus, perform, (), (override));
         MOCK_METHOD(long, responseCode, (), (override));
+        MOCK_METHOD(std::string, localIp, (), (override));
 };
 
 #endif // _HC_MOCK_CURL_HANDLE_HPP

--- a/src/client-agent/https_client/tests/unit/outcomeClassifier_test.cpp
+++ b/src/client-agent/https_client/tests/unit/outcomeClassifier_test.cpp
@@ -67,13 +67,15 @@ INSTANTIATE_TEST_SUITE_P(
         ClassifierCase {TransportStatus::ConnectFail, 0, OutcomeClass::Retryable},
         ClassifierCase {TransportStatus::TlsFail, 0, OutcomeClass::Retryable},
         ClassifierCase {TransportStatus::OtherError, 0, OutcomeClass::Retryable},
-        // Auth: 401 per #37732; 403 kept until FR7.4 is reconciled (T2).
+        // Auth: 401 only. 403 is not an auth code in the final contract; as a
+        // non-contract intermediary code it is transient, so events are kept.
         ClassifierCase {TransportStatus::Ok, 401, OutcomeClass::AuthFail},
-        ClassifierCase {TransportStatus::Ok, 403, OutcomeClass::AuthFail},
-        // Version rejection: 426 per #37732, 409 per the #37733 OpenAPI
-        // ("Protocol version not supported"); both accepted until reconciled.
-        ClassifierCase {TransportStatus::Ok, 426, OutcomeClass::VersionRejected},
+        ClassifierCase {TransportStatus::Ok, 403, OutcomeClass::Retryable},
+        // Version rejection: 409 Conflict per the #37733 /control contract.
+        // 426 was the superseded #37732 proposal; now a transient intermediary
+        // code (Retryable) rather than a batch-dropping Permanent.
         ClassifierCase {TransportStatus::Ok, 409, OutcomeClass::VersionRejected},
+        ClassifierCase {TransportStatus::Ok, 426, OutcomeClass::Retryable},
         // Back-pressure signals.
         ClassifierCase {TransportStatus::Ok, 429, OutcomeClass::BackPressure},
         ClassifierCase {TransportStatus::Ok, 503, OutcomeClass::BackPressure},

--- a/src/client-agent/https_client/tests/unit/retrySender_test.cpp
+++ b/src/client-agent/https_client/tests/unit/retrySender_test.cpp
@@ -156,32 +156,68 @@ TEST_F(RetrySenderTest, PayloadTooLargeReturnsImmediately)
     EXPECT_TRUE(m_waiter.requestedDelays().empty());
 }
 
-TEST_F(RetrySenderTest, AuthFailureReturnsImmediately)
+TEST_F(RetrySenderTest, RepeatedAuthFailureReturnsAuthFail)
 {
-    EXPECT_CALL(m_performer, perform(_)).WillOnce(Return(response(TransportStatus::Ok, 401)));
+    // A 401 triggers one fresh-timestamp retry; a second 401 is the verdict.
+    EXPECT_CALL(m_performer, perform(_))
+    .Times(2)
+    .WillRepeatedly(Return(response(TransportStatus::Ok, 401)));
     const auto result = m_sender.send(makeSpec(), m_waiter, 4);
     EXPECT_EQ(OutcomeClass::AuthFail, result.outcome); // Re-enroll policy is the caller's.
+    EXPECT_TRUE(m_waiter.requestedDelays().empty());   // The auth retry is immediate.
 }
 
-TEST_F(RetrySenderTest, AuthFailureEngagesTheAuthGateButSuccessDoesNot)
+TEST_F(RetrySenderTest, AuthFailureRecoversWithAFreshTimestamp)
+{
+    // The first 401 is an edge/expired timestamp; the immediate resign succeeds.
+    std::vector<std::string> authorizations;
+    EXPECT_CALL(m_performer, perform(_))
+    .Times(2)
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & spec)
+    {
+        authorizations.push_back(spec.headers.back());
+        m_clock.advance(std::chrono::seconds {5}); // Clock moves before the retry.
+        return response(TransportStatus::Ok, 401);
+    }))
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & spec)
+    {
+        authorizations.push_back(spec.headers.back());
+        return response(TransportStatus::Ok, 200);
+    }));
+
+    const auto result = m_sender.send(makeSpec(), m_waiter, 4);
+
+    EXPECT_EQ(OutcomeClass::Ok, result.outcome);
+    ASSERT_EQ(2u, authorizations.size());
+    EXPECT_NE(authorizations[0], authorizations[1]); // Retry was freshly signed.
+    EXPECT_TRUE(m_waiter.requestedDelays().empty());  // No backoff between the two.
+}
+
+TEST_F(RetrySenderTest, AuthGateEscalatesOnlyAfterTheRetryAlsoFails)
 {
     ::testing::NiceMock<MockCallbackSink> sink;
     AuthGate gate {sink, [] {}};
     RetrySender guarded {m_performer, m_signer, m_clock, m_backoff, &gate};
 
+    // First send: a 401 then a 200 on the retry -> recovered, no pause.
     EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 401)))
     .WillOnce(Return(response(TransportStatus::Ok, 200)))
+    // Second send: two 401s -> escalate.
+    .WillOnce(Return(response(TransportStatus::Ok, 401)))
     .WillOnce(Return(response(TransportStatus::Ok, 401)));
 
     guarded.send(makeSpec(), m_waiter, 1);
-    EXPECT_FALSE(gate.paused()); // 200: no pause.
+    EXPECT_FALSE(gate.paused()); // Retry recovered: no pause.
     guarded.send(makeSpec(), m_waiter, 1);
-    EXPECT_TRUE(gate.paused());  // 401: paused.
+    EXPECT_TRUE(gate.paused());  // Retry also 401: paused.
 }
 
 TEST_F(RetrySenderTest, VersionRejectionReturnsImmediately)
 {
-    EXPECT_CALL(m_performer, perform(_)).WillOnce(Return(response(TransportStatus::Ok, 426)));
+    EXPECT_CALL(m_performer, perform(_)).WillOnce(Return(response(TransportStatus::Ok, 409)));
     const auto result = m_sender.send(makeSpec(), m_waiter, 4);
     EXPECT_EQ(OutcomeClass::VersionRejected, result.outcome);
 }

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -47,6 +47,7 @@
 #include "task_registry_client.h" /* durable task_id registry client */
 #include "wm_agent_upgrade_agent.h" /* wm_agent_upgrade_process_command */
 #include "cJSON.h"
+#include "metadata_provider.h" /* metadata_provider_get(): host metadata for the Notify */
 #include "os_net.h"
 #include "state.h" /* w_agentd_state_update, INCREMENT_TASK_* */
 
@@ -1217,6 +1218,69 @@ static void bridge_on_buffer_level(int level, void *user_data)
     }
 }
 
+/* Host metadata source for the /control Notify. Pulled fresh each Notify from
+ * the shared metadata_provider (hostname/architecture/os.*). Writes an empty
+ * string when metadata is not yet available, so the module omits the host
+ * block. The agent IP is NOT sourced here: on the HTTPS agent there is no live
+ * manager socket (agt->sock is permanently -1), so the module adds host.ip from
+ * the actual connection (CURLINFO_LOCAL_IP) instead. Runs on the module's
+ * control thread; a shared-memory read, fast and non-blocking. */
+static void bridge_on_collect_host(char *json_out, size_t cap, void *user_data)
+{
+    (void)user_data;
+
+    if (json_out == NULL || cap == 0) {
+        return;
+    }
+
+    json_out[0] = '\0';
+
+    agent_metadata_t metadata = {0};
+
+    if (metadata_provider_get(&metadata) != 0) {
+        mdebug2("https_client: host metadata not available yet; sending Notify without host.");
+        return;
+    }
+
+    cJSON *host = cJSON_CreateObject();
+
+    if (host == NULL) {
+        metadata_provider_free_metadata(&metadata);
+        return;
+    }
+
+    if (metadata.hostname[0]) {
+        cJSON_AddStringToObject(host, "hostname", metadata.hostname);
+    }
+    if (metadata.architecture[0]) {
+        cJSON_AddStringToObject(host, "architecture", metadata.architecture);
+    }
+
+    cJSON *os = cJSON_CreateObject();
+    if (metadata.os_name[0]) {
+        cJSON_AddStringToObject(os, "name", metadata.os_name);
+    }
+    if (metadata.os_version[0]) {
+        cJSON_AddStringToObject(os, "version", metadata.os_version);
+    }
+    if (metadata.os_platform[0]) {
+        cJSON_AddStringToObject(os, "platform", metadata.os_platform);
+    }
+    if (metadata.os_type[0]) {
+        cJSON_AddStringToObject(os, "type", metadata.os_type);
+    }
+    cJSON_AddItemToObject(host, "os", os);
+
+    char *printed = cJSON_PrintUnformatted(host);
+    if (printed) {
+        snprintf(json_out, cap, "%s", printed);
+        os_free(printed);
+    }
+
+    cJSON_Delete(host);
+    metadata_provider_free_metadata(&metadata);
+}
+
 /* Maps the agent config parser's verification_mode enum onto the module
  * ABI's hc_verify_mode_t. The two are defined in independent headers with
  * matching values by convention (both documented "FULL is 0, fails closed");
@@ -1445,6 +1509,7 @@ void w_https_client_start(void)
     callbacks.on_buffer_level = bridge_on_buffer_level;
     callbacks.collect_stats = bridge_collect_stats;
     callbacks.collect_config = bridge_collect_config;
+    callbacks.on_collect_host = bridge_on_collect_host;
 
     g_https_client = hc_create(&config, &callbacks);
     if (!g_https_client) {


### PR DESCRIPTION
## Description

This PR aligns the agent-side HTTPS client (`src/client-agent/https_client/`) with the final manager transport/`/control` contract, removing obsolete compatibility assumptions. It audits AES-CMAC signing (already matches, no change), sends the required `host` metadata in `/control` notify, sets the per-endpoint `Content-Type`, recovers from a single `401` with a fresh timestamp before escalating to re-enrollment, and drops the legacy status-code branches (`403`, `426`).

Review fixes: `host.ip` is now sourced from the live connection (`CURLINFO_LOCAL_IP`) instead of the retired `get_agent_ip()`/`getsockname(agt->sock)` path, which is dead on the HTTPS agent (`agt->sock` is permanently `-1`). And `403`/`426` now map to `Retryable` rather than `Permanent`, so an intermediary (reverse proxy, WAF, mTLS gateway) answering those codes no longer causes `/stateless` events to be dropped.

**Proposed Release:** v5.0.0
**Issue:** wazuh/wazuh#38119
**Internal Reference:** agent HTTPS epic wazuh/wazuh#37831 (integrates into `5.0.0-https` via wazuh/wazuh#38012)

## Proposed Changes

- **`/control` notify `host`** - notify now sends `type` + `agent.version` + a `host` block (`hostname`, `architecture`, `ip`, `os.{name,version,platform,type}}`). Added a new `on_collect_host` ABI callback (`include/https_client.h`), threaded a `std::function` into `ControlStream` (`src/controlStream.{hpp,cpp}`, `src/httpsClientFacade.cpp`), and implemented the C collector in `src/client-agent/src/https_client_bridge.c` (fed from `metadata_provider_get()`). Host block is omitted when metadata isn't ready yet.
- **`host.ip` from the live connection** - `hostname`/`architecture`/`os` come from the collector; `host.ip` is a transport fact the module owns, so it is captured via `CURLINFO_LOCAL_IP` (new `ICurlHandle::localIp()` in `curlHandle.cpp`, mirroring `responseCode()`), carried up in `HttpResponse.localIp`, and injected by `ControlStream` on the next notify. The bridge no longer uses the retired `get_agent_ip()`.
- **`403`/`426` are transient, not fatal** - they map to `Retryable` (not `Permanent`), so `/stateless` preserves and retries the batch instead of dropping it when an intermediary returns those codes.
- **Per-endpoint `Content-Type`** - added `HttpRequestSpec.contentType` (`src/httpTypes.hpp`); `CurlPerformer` emits `Content-Type` only when set (`src/curlPerformer.cpp`); `/control` -> `application/json` (`src/controlStream.cpp`). `/stateless` (`*/*`), `/stateful` and `/download` left unset.
- **`401` recovery** - `RetrySender` now retries once immediately with a fresh timestamp on a `401`, and escalates to re-enrollment only if the retry also returns `401` (`src/retrySender.cpp`). This is the contract's retry behavior verbatim (keep body, new timestamp, resign, resend).
- **Strict status codes** - `outcomeClassifier.cpp`: auth is `401` only (`403` is no longer auth); version rejection is `409` only (`426` is the superseded proposal). Both `403` and `426`, being outside the contract, are treated as transient (`Retryable`) so events are not lost. Stale comments updated in `httpTypes.hpp` and `controlStateMachine.hpp`.
- **AES-CMAC audit** - verified the canonical request and headers already match the contract field-by-field; no code change required.
- Tests, mocks (`fakeManager`) and the component suite updated to the new contract, including a new end-to-end `Content-Type` assertion.

### Results and Evidence

Built and validated locally on Linux against the branch's vendored dependencies (`DEPS_VERSION = 99-37361`).

**AES-CMAC canonical matches the contract (wazuh/wazuh#37732) exactly** - `WAZUH-REQUEST\n1\n<UPPER-METHOD>\n<target>\n<agent-id>\n<timestamp>\n<body>`, no trailing LF; `Authorization: Wazuh <id>:<ts>:<mac>`, 32 lowercase hex.

Unit test suite (`https_client_unit_test`):

```bash
$ ./hc_unit
[----------] Global test environment tear-down
[==========] 258 tests from 28 test suites ran.
[  PASSED  ] 258 tests.

# Tests covering this PR's changes:
[ OK ] ControlStreamTest.NotifyCarriesTypeVersionAndHost          # host.ip injected from CURLINFO_LOCAL_IP
[ OK ] ControlStreamTest.NotifyHostOmitsIpWhenLocalIpUnknown
[ OK ] ControlStreamTest.NotifyOmitsHostWhenMetadataUnavailable
[ OK ] CurlPerformerTest.ContentTypeEmittedWhenSet
[ OK ] CurlPerformerTest.NoContentTypeWhenUnset
[ OK ] RetrySenderTest.RepeatedAuthFailureReturnsAuthFail
[ OK ] RetrySenderTest.AuthFailureRecoversWithAFreshTimestamp
[ OK ] RetrySenderTest.AuthGateEscalatesOnlyAfterTheRetryAlsoFails
# OutcomeClassifierTable (parametrized): 403 -> Retryable, 426 -> Retryable, 409 -> VersionRejected
```

Component test suite (`https_client_component_test`, real TLS + libcurl against the fake manager):

```bash
$ ./hc_comp
[==========] 34 tests from 6 test suites ran.
[  PASSED  ] 34 tests.

# End-to-end tests covering this PR's changes:
[ OK ] FacadeE2eTest.ControlRequestsAdvertiseJsonContentType         # /control sends application/json over real curl
[ OK ] FacadeE2eTest.NotifyHostCarriesTheLiveLocalIp (1204 ms)       # notify body received by the manager carries "ip":"127.0.0.1"
[ OK ] FacadeE2eTest.KeyRotationFiresReenrollAndHcSetAgentKeyRecovers   # 401 -> retry -> re-enroll path intact
[ OK ] ComponentTest.VersionRejectionSurfacesAs409
```

Memory safety - unit suite rebuilt with **AddressSanitizer + UndefinedBehaviorSanitizer + LeakSanitizer** and re-run (clean):

```bash
$ ASAN_OPTIONS=detect_leaks=1 ./hc_unit_asan
[==========] 258 tests from 28 test suites ran.
[  PASSED  ] 258 tests.
# exit=0 - no AddressSanitizer/LeakSanitizer errors, no leaks
# (one pre-existing UBSan note in moduleConfig.cpp:78 for an out-of-range verify_mode
#  fed by a validation test - not touched by this PR)
```

The C bridge collector (`bridge_on_collect_host`, not covered by the C++ suites) was exercised against the real `cJSON` + `metadata_provider` under ASan/UBSan/LeakSanitizer, 1000 iterations plus the metadata-unavailable branch:

```bash
$ ASAN_OPTIONS=detect_leaks=1 ./bridge_asan
get rc=0 host=ubuntu-test
last host json: {"hostname":"ubuntu-test","architecture":"x86_64","ip":"192.168.1.100","os":{"name":"Ubuntu","version":"20.04","platform":"ubuntu","type":"linux"}}
no-metadata json: ''        # metadata-not-ready branch: host omitted
# exit=0 - no leaks, no UB, no descriptor issues; output matches the contract shape
```

Diff summary (18 files, +347/-41):

```bash
$ git diff --stat origin/enhancement/37831-agent-https-client...HEAD
 src/client-agent/https_client/include/https_client.h                         |  7 ++
 src/client-agent/https_client/src/controlStateMachine.hpp                    |  2 +-
 src/client-agent/https_client/src/controlStream.cpp                          | 46 +++++++++-
 src/client-agent/https_client/src/controlStream.hpp                          | 11 ++-
 src/client-agent/https_client/src/curlHandle.cpp                             |  7 ++
 src/client-agent/https_client/src/curlPerformer.cpp                          |  6 ++
 src/client-agent/https_client/src/httpTypes.hpp                              |  8 +-
 src/client-agent/https_client/src/httpsClientFacade.cpp                      | 26 ++++++-
 src/client-agent/https_client/src/iCurlHandle.hpp                            |  1 +
 src/client-agent/https_client/src/outcomeClassifier.cpp                      | 20 +++--
 src/client-agent/https_client/src/retrySender.cpp                            | 15 +++-
 src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp   | 63 ++++++++++++++
 src/client-agent/https_client/tests/component/fakeManager.hpp                | 42 +++++++++-
 src/client-agent/https_client/tests/component/httpsClient_component_test.cpp |  4 +-
 src/client-agent/https_client/tests/unit/controlStateMachine_test.cpp        |  4 +-
 src/client-agent/https_client/tests/unit/controlStream_test.cpp              | 86 +++++++++++++++++--
 src/client-agent/https_client/tests/unit/curlPerformer_test.cpp              | 41 +++++++++
 src/client-agent/https_client/tests/unit/mocks/mockCurlHandle.hpp            |  1 +
 src/client-agent/https_client/tests/unit/outcomeClassifier_test.cpp          | 12 +--
 src/client-agent/https_client/tests/unit/retrySender_test.cpp                | 48 ++++++++++--
 src/client-agent/src/https_client_bridge.c                                   | 65 +++++++++++++++
 21 files changed, 473 insertions(+), 42 deletions(-)
```

**Open points (out of this PR's control):**
- The `401` clock-skew *delta* (manager-time response header) described in the issue is **not** present in the accessible contract (the `401` is a bare JSON body, no headers). This PR ships the contract-defined retry (fresh timestamp); the delta/persistence is deferred pending the header name/format from the manager-side `https-events-api.md`.
- The issue says `/download` is "not JSON", but the authoritative `/download` contract (wazuh/wazuh#37733) declares its request body as `application/json`. Left unset per the issue text; needs a manager-side confirmation on which is authoritative.

### Artifacts Affected

- `src/client-agent/https_client/include/https_client.h`
- `src/client-agent/https_client/src/controlStream.cpp` / `controlStream.hpp`
- `src/client-agent/https_client/src/httpsClientFacade.cpp`
- `src/client-agent/https_client/src/curlPerformer.cpp` / `curlHandle.cpp` / `iCurlHandle.hpp`
- `src/client-agent/https_client/src/httpTypes.hpp`
- `src/client-agent/https_client/src/outcomeClassifier.cpp`
- `src/client-agent/https_client/src/retrySender.cpp`
- `src/client-agent/https_client/src/controlStateMachine.hpp`
- `src/client-agent/src/https_client_bridge.c`
- Tests/mocks: `tests/unit/{controlStream,curlPerformer,retrySender,outcomeClassifier,controlStateMachine}_test.cpp`, `tests/unit/mocks/mockCurlHandle.hpp`, `tests/component/{facadeE2e,httpsClient}_component_test.cpp`, `tests/component/fakeManager.hpp`

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Unit Tests + Component Tests.
- **Details:** New unit tests for the notify `host` payload (present / omitted / ip-omitted-until-known), the per-endpoint `Content-Type` (emitted/not), the `401` one-shot retry (recovers on fresh timestamp / escalates on repeated `401`), and the status codes (`403`/`426` -> `Retryable`, `409` -> `VersionRejected`). New end-to-end component tests over real TLS + libcurl: `/control` advertises `application/json`, and the notify body received by the manager carries `host.ip` from the live connection. Full suites pass: 258/258 unit, 34/34 component; AddressSanitizer/LeakSanitizer clean.

## Review Checklist

**Manual tests with their corresponding evidence:**

- Compilation without warnings on every supported platform

    - [ ] Linux
    - [ ] Windows
    - [ ] MAC OS X

- [ ] Log syntax and correct language review

- Memory tests for Linux

    - [ ] Coverity
    - [ ] Valgrind (memcheck and descriptor leaks check)
    - [x] AddressSanitizer (unit suite + bridge collector; ASan/UBSan/LeakSanitizer clean)

**General Checklist:**

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented (N/A)
- [ ] Developer documentation reflects the changes (code comments updated)
- [ ] Meets requirements and/or definition of done (401 clock-skew delta deferred - see Open points)
- [ ] No unresolved dependencies with other issues (manager-side header + `/download` type to confirm)
