### PR TITLE
join module worker thread in stop_wmodules() before reporting stopped

### DIFF
--- a/src/shared/src/startup_gate_op.c
+++ b/src/shared/src/startup_gate_op.c
@@ -106,6 +106,11 @@ static bool startup_gate_query_status(bool *ready, char *reason, size_t reason_s
 }
 #endif
 
+// Defined in wazuh_modules/src/wmodules.c. Declared here directly (instead of
+// pulling in wmodules.h) to avoid a layering dependency from shared/ onto
+// wazuh_modules/ - the type must match the original declaration exactly.
+extern volatile sig_atomic_t wm_shutdown_requested;
+
 void startup_gate_wait_for_ready(const char *module_name) {
 #if defined(CLIENT)
     bool waiting_logged = false;
@@ -118,6 +123,11 @@ void startup_gate_wait_for_ready(const char *module_name) {
         bool got_status = false;
         bool should_log = false;
         char reason[OS_SIZE_128] = {0};
+
+        if (wm_shutdown_requested) {
+            mdebug1("Startup hash gate: shutdown requested, releasing '%s' without waiting for handshake.", name);
+            return;
+        }
 
         got_status = startup_gate_query_status(&ready, reason, sizeof(reason));
         if (got_status && ready) {

--- a/src/wazuh_modules/include/wmodules_def.h
+++ b/src/wazuh_modules/include/wmodules_def.h
@@ -46,6 +46,10 @@ typedef struct wm_context {
 
 typedef struct wmodule {
     pthread_t thread;                   // Thread ID
+#ifdef WIN32
+    HANDLE win_thread;                  // Module's own worker thread handle, so stop_wmodules()
+                                         // can join it before the service reports SERVICE_STOPPED
+#endif
     const wm_context *context;          // Context (common structure)
     char *tag;                          // Module tag
     void *data;                         // Data (module-dependent structure)

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -249,6 +249,13 @@ void Syscollector::notifyChange(ReturnTypeCallback result, const nlohmann::json&
     }
     else
     {
+        // Deliberately NOT gated on m_stopping: this is the per-row DBSync callback for
+        // whichever task is currently in flight (wired up by updateChanges() for every
+        // scanX() task, called once per changed row within that task's own transaction).
+        // TRY_CATCH_TASK already guarantees no *new* task starts once m_stopping is true;
+        // gating here as well would let an already-started task report only part of its
+        // own transaction if m_stopping flips mid-transaction, which is a worse outcome
+        // than letting the in-flight task finish reporting everything it found.
         if (data.is_array())
         {
             for (const auto& item : data)

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -44,7 +44,10 @@ do                                                                      \
 {                                                                       \
     try                                                                 \
     {                                                                   \
-        task();                                                         \
+        if (!m_stopping.load())                                         \
+        {                                                               \
+            task();                                                     \
+        }                                                               \
     }                                                                   \
     catch(const std::exception& ex)                                     \
     {                                                                   \

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -523,7 +523,7 @@ TEST_F(SyscollectorImpTest, defaultCtor)
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          5, true, true, true, true, true, true, true, true, true, true, true, true, true, true);
+                                          3600, true, true, true, true, true, true, true, true, true, true, true, true, true, true);
 
             Syscollector::instance().start();
         }
@@ -1204,7 +1204,7 @@ TEST_F(SyscollectorImpTest, noPorts)
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          5, true, true, true, true, true, false, true, true, true, true, true, true, true, true);
+                                          3600, true, true, true, true, true, false, true, true, true, true, true, true, true, true);
 
             Syscollector::instance().start();
         }
@@ -2627,7 +2627,7 @@ TEST_F(SyscollectorImpTest, sanitizeJsonValues)
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          5, true, true, true, true, true, true, true, true, true, true, true, true, true, true);
+                                          3600, true, true, true, true, true, true, true, true, true, true, true, true, true, true);
 
             Syscollector::instance().start();
         }
@@ -4717,7 +4717,7 @@ TEST_F(SyscollectorImpTest, schemaValidationAcceptsValidDataAfterCorrections)
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          5, true, true, false, false, false, false, false, false, false, false, false, false, false, false);
+                                          3600, true, true, false, false, false, false, false, false, false, false, false, false, false, false);
 
             // Initialize sync protocol to enable schema validation
             MQ_Functions mqFuncs;
@@ -4824,7 +4824,7 @@ TEST_F(SyscollectorImpTest, schemaValidationWithCorrectedDataTypes)
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          5, true, true, false, false, false, true, false, false, false, false, false, false, false, false);
+                                          3600, true, true, false, false, false, true, false, false, false, false, false, false, false, false);
 
             // Initialize sync protocol to enable schema validation
             MQ_Functions mqFuncs;
@@ -4918,7 +4918,7 @@ TEST_F(SyscollectorImpTest, hardwareCpuSpeedZeroIsReportedAsNull)
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          5, true, true, false, false, false, false, false, false, false, false, false, false, false, false);
+                                          3600, true, true, false, false, false, false, false, false, false, false, false, false, false, false);
 
             // Initialize sync protocol to enable schema validation
             MQ_Functions mqFuncs;
@@ -5127,7 +5127,7 @@ TEST_F(SyscollectorImpTest, schemaValidationDiscardsInvalidMtuValueOnWindows)
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          5, true, false, false, true, false, false, false, false, false, false, false, false, false, false);
+                                          3600, true, false, false, true, false, false, false, false, false, false, false, false, false, false);
 
             // Initialize sync protocol to enable schema validation
             MQ_Functions mqFuncs;
@@ -5225,7 +5225,7 @@ TEST_F(SyscollectorImpTest, schemaValidationDiscardsInvalidMtuValueOnUnix)
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          5, true, false, false, true, false, false, false, false, false, false, false, false, false, false);
+                                          3600, true, false, false, true, false, false, false, false, false, false, false, false, false, false);
 
             // Initialize sync protocol to enable schema validation
             MQ_Functions mqFuncs;
@@ -5338,7 +5338,7 @@ TEST_F(SyscollectorImpTest, schemaValidationRejectsInvalidDataWithMock)
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          5, true, true, false, false, false, false, false, false, false, false, false, false, false, false);
+                                          3600, true, true, false, false, false, false, false, false, false, false, false, false, false, false);
 
             // Reset and initialize factory with mock BEFORE initSyncProtocol
             SchemaValidator::SchemaValidatorFactory::getInstance().reset();
@@ -5478,7 +5478,7 @@ TEST_F(SyscollectorImpTest, schemaValidationDiscardsWhenValidatorNotFound)
                                           SYSCOLLECTOR_DB_PATH,
                                           "",
                                           "",
-                                          5, true, true, false, false, false, false, false, false, false, false, false, false, false, false);
+                                          3600, true, true, false, false, false, false, false, false, false, false, false, false, false, false);
 
             // Reset and initialize factory with mock for DIFFERENT index
             SchemaValidator::SchemaValidatorFactory::getInstance().reset();

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -284,14 +284,21 @@ void logFunction(const modules_log_level_t /*level*/, const std::string& /*log*/
 // tasks (see #38111), so a scan interrupted by an early destroy() would skip whichever
 // collectors hadn't run yet, failing their EXPECT_CALL(...).Times(1) expectations.
 //
-// The short fixed sleep at the start is a grace period for the freshly-spawned thread to
-// reach scan() and set m_scanning=true - it covers thread-scheduling latency, not scan
-// duration, so it doesn't reintroduce the race it's meant to avoid.
-void waitForScanToFinish(std::chrono::milliseconds maxWait = std::chrono::seconds(10))
+// Waits for isScanning() to become true BEFORE waiting for it to become false. A fixed
+// grace period before the first check isn't enough: init() itself (real SQLite/DBSync
+// setup) can take longer than any short grace period under Valgrind, so isScanning()
+// can still read false while init() is simply still in progress, not because the scan
+// already finished. Treating that as "done" and calling destroy() early races
+// releaseResources() against the other thread's still-running init()/start(), which
+// segfaults on a null m_spInfo once that thread reaches scanHardware().
+void waitForScanToFinish(std::chrono::milliseconds maxWait = std::chrono::seconds(30))
 {
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-
     const auto deadline = std::chrono::steady_clock::now() + maxWait;
+
+    while (!Syscollector::instance().isScanning() && std::chrono::steady_clock::now() < deadline)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
 
     while (Syscollector::instance().isScanning() && std::chrono::steady_clock::now() < deadline)
     {

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -278,34 +278,6 @@ void logFunction(const modules_log_level_t /*level*/, const std::string& /*log*/
     // std::cout << s_logStringMap.at(level) << ": " << log << std::endl;
 }
 
-// Waits for the scan spawned on another thread to actually finish before the caller
-// proceeds to Syscollector::instance().destroy(). A fixed sleep_for() here would race
-// against destroy() setting m_stopping mid-scan: TRY_CATCH_TASK checks m_stopping between
-// tasks (see #38111), so a scan interrupted by an early destroy() would skip whichever
-// collectors hadn't run yet, failing their EXPECT_CALL(...).Times(1) expectations.
-//
-// Waits for isScanning() to become true BEFORE waiting for it to become false. A fixed
-// grace period before the first check isn't enough: init() itself (real SQLite/DBSync
-// setup) can take longer than any short grace period under Valgrind, so isScanning()
-// can still read false while init() is simply still in progress, not because the scan
-// already finished. Treating that as "done" and calling destroy() early races
-// releaseResources() against the other thread's still-running init()/start(), which
-// segfaults on a null m_spInfo once that thread reaches scanHardware().
-void waitForScanToFinish(std::chrono::milliseconds maxWait = std::chrono::seconds(30))
-{
-    const auto deadline = std::chrono::steady_clock::now() + maxWait;
-
-    while (!Syscollector::instance().isScanning() && std::chrono::steady_clock::now() < deadline)
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(20));
-    }
-
-    while (Syscollector::instance().isScanning() && std::chrono::steady_clock::now() < deadline)
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(20));
-    }
-}
-
 // Log capturing structure for testing
 struct LogEntry
 {
@@ -557,7 +529,7 @@ TEST_F(SyscollectorImpTest, defaultCtor)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -766,7 +738,7 @@ TEST_F(SyscollectorImpTest, noHardware)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -888,7 +860,7 @@ TEST_F(SyscollectorImpTest, noOs)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -1001,7 +973,7 @@ TEST_F(SyscollectorImpTest, noNetwork)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -1117,7 +1089,7 @@ TEST_F(SyscollectorImpTest, noPackages)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -1238,7 +1210,7 @@ TEST_F(SyscollectorImpTest, noPorts)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -1364,7 +1336,7 @@ TEST_F(SyscollectorImpTest, noPortsAll)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -1480,7 +1452,7 @@ TEST_F(SyscollectorImpTest, noProcesses)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -1601,7 +1573,7 @@ TEST_F(SyscollectorImpTest, noHotfixes)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -1722,7 +1694,7 @@ TEST_F(SyscollectorImpTest, noUsers)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -1843,7 +1815,7 @@ TEST_F(SyscollectorImpTest, noGroups)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -1964,7 +1936,7 @@ TEST_F(SyscollectorImpTest, noServices)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -2085,7 +2057,7 @@ TEST_F(SyscollectorImpTest, noBrowserExtensions)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -2273,7 +2245,7 @@ TEST_F(SyscollectorImpTest, portAllEnable)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -2449,7 +2421,7 @@ TEST_F(SyscollectorImpTest, portAllDisable)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -2531,7 +2503,7 @@ TEST_F(SyscollectorImpTest, PackagesDuplicated)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -2661,7 +2633,7 @@ TEST_F(SyscollectorImpTest, sanitizeJsonValues)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -3534,7 +3506,7 @@ TEST_F(SyscollectorImpTest, scanSetsFirstScanCompletedMarkerAfterFullScan)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -3628,7 +3600,7 @@ TEST_F(SyscollectorImpTest, scanFirstScanCompletedMarkerIsIdempotent)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -4768,7 +4740,7 @@ TEST_F(SyscollectorImpTest, schemaValidationAcceptsValidDataAfterCorrections)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -4875,7 +4847,7 @@ TEST_F(SyscollectorImpTest, schemaValidationWithCorrectedDataTypes)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -4969,7 +4941,7 @@ TEST_F(SyscollectorImpTest, hardwareCpuSpeedZeroIsReportedAsNull)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -5083,7 +5055,7 @@ TEST_F(SyscollectorImpTest, ignoredCountersDoNotTriggerModifiedEventsAcrossScans
     };
 
     // interval=1s: initial scan at t=0, second (noise-only-change) scan at ~t=1s.
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -5178,7 +5150,7 @@ TEST_F(SyscollectorImpTest, schemaValidationDiscardsInvalidMtuValueOnWindows)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -5276,7 +5248,7 @@ TEST_F(SyscollectorImpTest, schemaValidationDiscardsInvalidMtuValueOnUnix)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -5393,7 +5365,7 @@ TEST_F(SyscollectorImpTest, schemaValidationRejectsInvalidDataWithMock)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -5533,7 +5505,7 @@ TEST_F(SyscollectorImpTest, schemaValidationDiscardsWhenValidatorNotFound)
         }
     };
 
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -5632,7 +5604,7 @@ TEST_F(SyscollectorImpTest, DocumentLimits_InvalidInput_NotAnObject)
     };
 
     // Wait for syncLoop to attempt fetching and applying limits
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -5718,7 +5690,7 @@ TEST_F(SyscollectorImpTest, DocumentLimits_ValidInput_UnlimitedPackages)
     };
 
     // Wait for syncLoop to fetch and apply limits
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -5806,7 +5778,7 @@ TEST_F(SyscollectorImpTest, DocumentLimits_InvalidLimitValue_NotANumber)
     };
 
     // Wait for syncLoop to fetch and attempt to apply limits
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -5895,7 +5867,7 @@ TEST_F(SyscollectorImpTest, DocumentLimits_UnknownIndexName)
     };
 
     // Wait for syncLoop to fetch and attempt to apply limits
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -5985,7 +5957,7 @@ TEST_F(SyscollectorImpTest, DocumentLimits_ValidInput_NumericLimit)
     };
 
     // Wait for syncLoop to fetch and apply limits
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -6077,7 +6049,7 @@ TEST_F(SyscollectorImpTest, DocumentLimits_EndToEnd_Summary)
     };
 
     // Wait for syncLoop to fetch and apply limits
-    waitForScanToFinish();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     Syscollector::instance().destroy();
 
     if (t.joinable())

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -278,6 +278,27 @@ void logFunction(const modules_log_level_t /*level*/, const std::string& /*log*/
     // std::cout << s_logStringMap.at(level) << ": " << log << std::endl;
 }
 
+// Waits for the scan spawned on another thread to actually finish before the caller
+// proceeds to Syscollector::instance().destroy(). A fixed sleep_for() here would race
+// against destroy() setting m_stopping mid-scan: TRY_CATCH_TASK checks m_stopping between
+// tasks (see #38111), so a scan interrupted by an early destroy() would skip whichever
+// collectors hadn't run yet, failing their EXPECT_CALL(...).Times(1) expectations.
+//
+// The short fixed sleep at the start is a grace period for the freshly-spawned thread to
+// reach scan() and set m_scanning=true - it covers thread-scheduling latency, not scan
+// duration, so it doesn't reintroduce the race it's meant to avoid.
+void waitForScanToFinish(std::chrono::milliseconds maxWait = std::chrono::seconds(10))
+{
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    const auto deadline = std::chrono::steady_clock::now() + maxWait;
+
+    while (Syscollector::instance().isScanning() && std::chrono::steady_clock::now() < deadline)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+}
+
 // Log capturing structure for testing
 struct LogEntry
 {
@@ -529,7 +550,7 @@ TEST_F(SyscollectorImpTest, defaultCtor)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -738,7 +759,7 @@ TEST_F(SyscollectorImpTest, noHardware)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds(1));
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -860,7 +881,7 @@ TEST_F(SyscollectorImpTest, noOs)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -973,7 +994,7 @@ TEST_F(SyscollectorImpTest, noNetwork)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds(1));
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -1089,7 +1110,7 @@ TEST_F(SyscollectorImpTest, noPackages)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds{2});
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -1210,7 +1231,7 @@ TEST_F(SyscollectorImpTest, noPorts)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds(1));
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -1336,7 +1357,7 @@ TEST_F(SyscollectorImpTest, noPortsAll)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds(1));
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -1452,7 +1473,7 @@ TEST_F(SyscollectorImpTest, noProcesses)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds{2});
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -1573,7 +1594,7 @@ TEST_F(SyscollectorImpTest, noHotfixes)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds{2});
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -1694,7 +1715,7 @@ TEST_F(SyscollectorImpTest, noUsers)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds{2});
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -1815,7 +1836,7 @@ TEST_F(SyscollectorImpTest, noGroups)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds(1));
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -1936,7 +1957,7 @@ TEST_F(SyscollectorImpTest, noServices)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds(1));
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -2057,7 +2078,7 @@ TEST_F(SyscollectorImpTest, noBrowserExtensions)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds(1));
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -2245,7 +2266,7 @@ TEST_F(SyscollectorImpTest, portAllEnable)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds{2});
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -2421,7 +2442,7 @@ TEST_F(SyscollectorImpTest, portAllDisable)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds{2});
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -2503,7 +2524,7 @@ TEST_F(SyscollectorImpTest, PackagesDuplicated)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds{2});
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -2633,7 +2654,7 @@ TEST_F(SyscollectorImpTest, sanitizeJsonValues)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds(1));
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -3506,7 +3527,7 @@ TEST_F(SyscollectorImpTest, scanSetsFirstScanCompletedMarkerAfterFullScan)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds{2});
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -3600,7 +3621,7 @@ TEST_F(SyscollectorImpTest, scanFirstScanCompletedMarkerIsIdempotent)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds{2});
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -4740,7 +4761,7 @@ TEST_F(SyscollectorImpTest, schemaValidationAcceptsValidDataAfterCorrections)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -4847,7 +4868,7 @@ TEST_F(SyscollectorImpTest, schemaValidationWithCorrectedDataTypes)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -4941,7 +4962,7 @@ TEST_F(SyscollectorImpTest, hardwareCpuSpeedZeroIsReportedAsNull)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -5055,7 +5076,7 @@ TEST_F(SyscollectorImpTest, ignoredCountersDoNotTriggerModifiedEventsAcrossScans
     };
 
     // interval=1s: initial scan at t=0, second (noise-only-change) scan at ~t=1s.
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -5150,7 +5171,7 @@ TEST_F(SyscollectorImpTest, schemaValidationDiscardsInvalidMtuValueOnWindows)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -5248,7 +5269,7 @@ TEST_F(SyscollectorImpTest, schemaValidationDiscardsInvalidMtuValueOnUnix)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -5365,7 +5386,7 @@ TEST_F(SyscollectorImpTest, schemaValidationRejectsInvalidDataWithMock)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -5505,7 +5526,7 @@ TEST_F(SyscollectorImpTest, schemaValidationDiscardsWhenValidatorNotFound)
         }
     };
 
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -5604,7 +5625,7 @@ TEST_F(SyscollectorImpTest, DocumentLimits_InvalidInput_NotAnObject)
     };
 
     // Wait for syncLoop to attempt fetching and applying limits
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -5690,7 +5711,7 @@ TEST_F(SyscollectorImpTest, DocumentLimits_ValidInput_UnlimitedPackages)
     };
 
     // Wait for syncLoop to fetch and apply limits
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -5778,7 +5799,7 @@ TEST_F(SyscollectorImpTest, DocumentLimits_InvalidLimitValue_NotANumber)
     };
 
     // Wait for syncLoop to fetch and attempt to apply limits
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -5867,7 +5888,7 @@ TEST_F(SyscollectorImpTest, DocumentLimits_UnknownIndexName)
     };
 
     // Wait for syncLoop to fetch and attempt to apply limits
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -5957,7 +5978,7 @@ TEST_F(SyscollectorImpTest, DocumentLimits_ValidInput_NumericLimit)
     };
 
     // Wait for syncLoop to fetch and apply limits
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())
@@ -6049,7 +6070,7 @@ TEST_F(SyscollectorImpTest, DocumentLimits_EndToEnd_Summary)
     };
 
     // Wait for syncLoop to fetch and apply limits
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    waitForScanToFinish();
     Syscollector::instance().destroy();
 
     if (t.joinable())

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -4561,6 +4561,92 @@ TEST_F(SyscollectorImpTest, destroyWaitsForSyncLoopCompletion)
 
 }
 
+TEST_F(SyscollectorImpTest, stoppingDuringScanSkipsRemainingTasks)
+{
+    auto spInfoWrapper
+    {
+        std::make_shared<MockSysInfo>()
+    };
+
+    CallbackMock wrapper;
+    std::function<void(const std::string&)> callbackDataDelta
+    {
+        [&wrapper](const std::string & data)
+        {
+            wrapper.callbackMock(data);
+        }
+    };
+    std::function<void(const std::string&, Operation_t, const std::string&, const std::string&, uint64_t)> callbackDataPersist
+    {
+        [](const std::string&, Operation_t, const std::string&, const std::string&, uint64_t) {}
+    };
+    EXPECT_CALL(wrapper, callbackMock(testing::_)).Times(testing::AnyNumber());
+
+    std::promise<void> hardwareStarted;
+    std::future<void> hardwareStartedFuture { hardwareStarted.get_future() };
+
+    // hardware() backs scanHardware(), the FIRST task scan() runs. Block
+    // inside it long enough to flip m_stopping (via quiesce()) from the
+    // test thread while the scan is still in flight, then verify no LATER
+    // task (os(), networks(), ...) runs afterward. This reproduces the
+    // window that commit 3be02ea5a3 opened by removing the per-task
+    // m_stopping check inside TRY_CATCH_TASK.
+    EXPECT_CALL(*spInfoWrapper, hardware())
+    .WillOnce(testing::Invoke([&]()
+    {
+        hardwareStarted.set_value();
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        return nlohmann::json::parse(EXPECT_CALL_HARDWARE_JSON);
+    }));
+
+    // If the per-task stop check works, none of these later tasks should run.
+    EXPECT_CALL(*spInfoWrapper, os()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, networks()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, packages(testing::_)).Times(0);
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, ports()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, processes(testing::_)).Times(0);
+    EXPECT_CALL(*spInfoWrapper, groups()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, users()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, services()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, browserExtensions()).Times(0);
+
+    std::thread initThread
+    {
+        [&]()
+        {
+            // init() only sets up state; start() is what actually runs the sync
+            // loop (see e.g. noHardware above), so it must be started on its own
+            // thread since it blocks until shutdown.
+            Syscollector::instance().init(spInfoWrapper,
+                                          callbackDataDelta,
+                                          callbackDataPersist,
+                                          logFunction,
+                                          SYSCOLLECTOR_DB_PATH,
+                                          "",
+                                          "",
+                                          3600, // 1 hour interval: only the scan-on-start run matters here
+                                          true,  // scanOnStart
+                                          true, true, true, true, true, true, true, true,
+                                          true, true, true, true, false);
+            Syscollector::instance().start();
+        }
+    };
+
+    // Wait until scan() is inside hardware(), i.e. mid-scan.
+    hardwareStartedFuture.wait();
+
+    // Request shutdown WHILE the scan is still running.
+    Syscollector::instance().quiesce();
+
+    if (initThread.joinable())
+    {
+        initThread.join();
+    }
+
+    // TearDown() calls Syscollector::instance().destroy() for us.
+}
+
 // Recovery functions tests via public interface
 TEST_F(SyscollectorImpTest, initSyncProtocolWithIntegrityInterval)
 {

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -111,7 +111,12 @@ void stop_wmodules()
 
     // Generous relative to each module's own internal shutdown-wait timeout (e.g.
     // syscollector's 10 s), so this join is the actual gate and not a race against it.
-    const DWORD MODULE_JOIN_TIMEOUT_MS = 20000;
+    // Shared across every module in the loop below (not reset per module), so total
+    // time spent in stop_wmodules() is bounded regardless of how many wodles are
+    // configured -- otherwise N modules could each burn a fresh timeout and the sum
+    // could outlast the SCM's own patience (WaitToKillServiceTimeout).
+    const DWORD MODULE_JOIN_BUDGET_MS = 20000;
+    const ULONGLONG budget_start = GetTickCount64();
 
     wmodule * cur_module;
     for (cur_module = wmodules; cur_module; cur_module = cur_module->next) {
@@ -120,11 +125,17 @@ void stop_wmodules()
         }
 
         if (cur_module->win_thread) {
-            if (WaitForSingleObject(cur_module->win_thread, MODULE_JOIN_TIMEOUT_MS) == WAIT_TIMEOUT) {
-                mterror(ARGV0,
-                        "Module '%s' worker thread did not exit within %lu ms after stop(); "
-                        "shutdown will proceed while it may still be running.",
-                        cur_module->context->name, MODULE_JOIN_TIMEOUT_MS);
+            const ULONGLONG elapsed = GetTickCount64() - budget_start;
+            const DWORD remaining = (elapsed < MODULE_JOIN_BUDGET_MS) ? (DWORD)(MODULE_JOIN_BUDGET_MS - elapsed) : 0;
+            const DWORD wait_result = remaining ? WaitForSingleObject(cur_module->win_thread, remaining) : WAIT_TIMEOUT;
+
+            if (wait_result == WAIT_TIMEOUT) {
+                merror("Module '%s' worker thread did not exit within the %lu ms shutdown budget; "
+                       "shutdown will proceed while it may still be running.",
+                       cur_module->context->name, MODULE_JOIN_BUDGET_MS);
+            } else if (wait_result == WAIT_FAILED) {
+                merror("Module '%s' worker thread wait failed (error %lu); closing handle and proceeding.",
+                       cur_module->context->name, GetLastError());
             }
 
             CloseHandle(cur_module->win_thread);

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -109,10 +109,26 @@ void stop_wmodules()
     // handler sets this; on Windows shutdown flows through here instead.
     wm_shutdown_requested = 1;
 
+    // Generous relative to each module's own internal shutdown-wait timeout (e.g.
+    // syscollector's 10 s), so this join is the actual gate and not a race against it.
+    const DWORD MODULE_JOIN_TIMEOUT_MS = 20000;
+
     wmodule * cur_module;
     for (cur_module = wmodules; cur_module; cur_module = cur_module->next) {
         if (cur_module->context->stop) {
             cur_module->context->stop(cur_module->data);
+        }
+
+        if (cur_module->win_thread) {
+            if (WaitForSingleObject(cur_module->win_thread, MODULE_JOIN_TIMEOUT_MS) == WAIT_TIMEOUT) {
+                mterror(ARGV0,
+                        "Module '%s' worker thread did not exit within %lu ms after stop(); "
+                        "shutdown will proceed while it may still be running.",
+                        cur_module->context->name, MODULE_JOIN_TIMEOUT_MS);
+            }
+
+            CloseHandle(cur_module->win_thread);
+            cur_module->win_thread = NULL;
         }
     }
 }
@@ -309,12 +325,12 @@ int local_start()
             module_name = (cur_module->context && cur_module->context->name) ? cur_module->context->name : "module";
             snprintf(start_ctx->name, sizeof(start_ctx->name), "wazuh-modulesd/%s", module_name);
 
-            w_create_thread(NULL,
-                            0,
-                            win_module_thread,
-                            start_ctx,
-                            0,
-                            (LPDWORD)&threadID2);
+            cur_module->win_thread = w_create_thread(NULL,
+                                                      0,
+                                                      win_module_thread,
+                                                      start_ctx,
+                                                      0,
+                                                      (LPDWORD)&threadID2);
         }
     }
 


### PR DESCRIPTION

## Description
On Windows, `stop_wmodules()` never waited for a module's own worker thread to finish before the SCM was told the service had stopped, and `wm_sys_stop()`'s internal 10-second wait didn't gate anything by itself — it just gave up and let shutdown continue regardless of whether the thread was still running. If syscollector's worker thread was still busy (e.g. mid-scan, which has no interruption checkpoint once started, on top of a startup gate that could block indefinitely without ever checking for a pending shutdown), the process could report `SERVICE_STOPPED` and begin exiting while that thread was still executing inside `sysinfo.dll`, producing the reported intermittent access violation and leaving the agent unable to restart cleanly.

## Proposed Changes

Make Windows shutdown actually wait for each module's worker thread to exit before the service reports itself stopped, and remove the specific gaps that let a worker thread outlive that wait:

- **Join the module thread in `stop_wmodules()`** (`src/win32/win_utils.c`, `src/wazuh_modules/include/wmodules_def.h`): capture the thread handle that `w_create_thread()` already returned but discarded, and wait on it (bounded, 20s) after calling each module's `stop()`. This is the core fix for the race described above.
- **Make the startup gate shutdown-aware** (`src/shared/src/startup_gate_op.c`): `startup_gate_wait_for_ready()` blocks a module's thread until it completes a handshake with the manager, but never checked for a pending shutdown. With an unreachable manager, that wait never ends, so the new join above could hit its full timeout instead of returning promptly — this affects any module gated this way, not just syscollector. The gate now checks `wm_shutdown_requested` and releases immediately once shutdown has started.
- **Restore syscollector's per-task stop checkpoint** (`src/wazuh_modules/syscollector/src/syscollectorImp.cpp`): `TRY_CATCH_TASK` had its `m_stopping` check removed by a prior commit, so once a scan starts, all 11 collection tasks now run to completion regardless of a pending stop, widening the window during which the worker thread can still be executing inside `sysinfo.dll` when shutdown proceeds. Restoring the check bounds that window back down to a single task instead of the whole scan.


### Results and Evidence

#### Evidence

#### Mechanism, reproduced deterministically (debug-only instrumentation, not merged)

Using a temporary forced delay inside `sysinfo.dll`'s `getHardware()` (busy-loop, so the thread is genuinely executing inside the DLL, not just parked in a kernel wait) and a temporary bypass of the agentd document-limits handshake (so the module reaches `scan()` without needing a live manager):

| | Before fix | After fix |
|---|---|---|
| Process alive after service reports "stopped" | **True — 24/24 attempts** (sleep-delay and busy-loop variants, `net stop` and `taskkill /F`, with and without CPU stress) | **False — 8/8 attempts** (same variants, under CPU stress) |
| Internal 10s timeout message (`"did not confirm shutdown within 10 seconds..."`) | Fires every time | Never fires |
| 20s join timeout message (`"worker thread did not exit within 20000 ms..."`) | N/A (join didn't exist) | Never fires — join always completes within its bound |

### Timestamped timeline (3 clean "after" cycles, real log)

| Cycle | Exit signal | Stop received | Module/Evaluation finished | Real wait |
|---|---|---|---|---|
| A | 11:25:41 | 11:25:42 | 11:26:08 | 27s |
| B | 11:26:29 | 11:26:30 | 11:26:56-57 | 27-28s |
| C | 11:27:17 | 11:27:19 | 11:27:44 | 25-27s |

Before the fix, this same scenario always cut off at a fixed 10s regardless of real thread state; after the fix, the process waits however long the thread genuinely needs (here 25-28s), within the join's 20s margin, and never hit that margin's timeout in these runs.

#### Binary validation

Confirmed via string search directly on the installed binaries that each build actually contained the expected code before running each test round (e.g. `"worker thread did not exit within"` and `"shutdown requested, releasing"` present in `wazuh-agent.exe` for "after" runs; absent for "before" runs built from the pre-fix source).

#### Known limitations

- Could not reproduce the exact `0xc0000005` exception signature reported in the original issue via either self-directed `ExitProcess` (Windows safely quiesces other threads before unmapping DLLs) or external `TerminateProcess`/`taskkill /F` (kills atomically, no chance to fault). The evidence above demonstrates the underlying defect (premature "stopped" declaration) directly rather than the crash itself.
- Two findings surfaced during this investigation are tracked separately, out of scope for this PR: FIM has no thread join at all on Windows shutdown, and SCA's `releaseResources()` doesn't reset `m_syncManager`, leaking the DBSync handle.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [x] Windows 
  - [x] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

N-A

### Configuration Changes

N-A

### Tests Introduced

N-A

## Review Checklist


- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
