### PR TITLE
Agent remote upgrade (WPK) compatibility with the 5.x HTTPS control path

### DIFF
--- a/docs/guide/migration/upgrade-4x-to-5x.md
+++ b/docs/guide/migration/upgrade-4x-to-5x.md
@@ -60,7 +60,9 @@ The following changes were identified during agent startup validation after upgr
 
 | 4.X configuration element | 5.0 status | Agent log message (observed) | Required action |
 |---|---|---|---|
-| `<client><server>...</server></client>` | Deprecated | `INFO: The <server> tag is deprecated, please use <manager> instead.` | Replace `<server>` with `<manager>`. |
+| `<client>...</client>` | Renamed | `INFO: <agent><server><address> is not configured. Using <client><server><address> 'MANAGER_IP' with the default port 1517.` | Rename the block to `<agent>`. A 5.0 agent still starts without the rename: it reads `<server><address>` from the old block and defaults the port to `1517`. Nothing else inside `<client>` is read. |
+| `<client><manager>...</manager></client>` | Invalid | `INFO: (1230): Invalid element in the configuration: 'manager'.` | Rename `<manager>` to `<server>` inside `<agent>`. The 4.14 templates already ship `<server>`. |
+| `<client><server><port>1514</port></server></client>` | Changed default | — | The agent talks HTTPS to the manager on `1517`. Inside `<agent>`, remove the port to take the new default or set `1517` explicitly; inside a legacy `<client>` block the port is not read at all. |
 | `<client><server><protocol>...</protocol></server></client>` | Ignored | `INFO: Ignoring the 'protocol' option. Switching to TCP.` | Remove `<protocol>`. TCP is used. |
 | `<client><crypto_method>...</crypto_method></client>` | Ignored | `INFO: Ignoring the 'crypto_method' option. Switching to AES.` | Remove `<crypto_method>`. |
 | `<syscheck><scan_on_start>...</scan_on_start></syscheck>` | Invalid | `INFO: (1230): Invalid element in the configuration: 'scan_on_start'.` | Remove this element from `syscheck` (Always executed on start). |
@@ -84,7 +86,7 @@ These messages are resolved by removing the invalid elements listed above.
 
 ## `ossec.conf` quick before/after examples
 
-### Client connection block
+### Agent connection block
 
 Before (4.X style):
 
@@ -102,13 +104,20 @@ Before (4.X style):
 After (5.0 compatible):
 
 ```xml
-<client>
-	<manager>
+<agent>
+	<server>
 		<address>MANAGER_IP</address>
-		<port>1514</port>
-	</manager>
-</client>
+		<port>1517</port>
+	</server>
+</agent>
 ```
+
+`<client>` is renamed to `<agent>` in 5.0: one block under two names, never both. Options for an agent that is already on 5.0 with the old block:
+
+- **Leave it.** The agent reads `<server><address>` from `<client>` and uses port `1517`. It connects, and logs which value it inherited. Nothing else in the block is read, so options such as `<enrollment>` or `<config-profile>` stop having an effect.
+- **Rename it** to `<agent>`, which is what a fresh 5.0 install ships. Every option in the block is read again.
+
+Recommended: rename it. The fallback exists so a remote upgrade cannot strand an agent, not as a configuration to keep.
 
 ### Removed modules
 
@@ -163,7 +172,7 @@ Recommended handling:
 
 After upgrading and cleaning configuration, verify:
 
-1. Agent successfully connects over TCP to manager on port `1514`.
+1. Agent successfully connects to the manager over HTTPS on port `1517`.
 2. Enrollment/service endpoint is reachable on port `1515` (if enrollment is being used).
 3. Agent and manager versions are both compatible with 5.0 communication protocol.
 
@@ -179,9 +188,24 @@ Workaround checklist:
 
 - Confirm manager is up and reachable from the agent host.
 - Confirm manager has been migrated to a compatible 5.0 deployment.
-- Confirm firewall/network rules allow `1514/tcp` and `1515/tcp`.
-- Confirm the agent points to the correct manager address in `<client><manager>`.
+- Confirm firewall/network rules allow `1517/tcp` (agent to manager) and `1515/tcp` (enrollment).
+- Confirm the agent points to the correct manager address in `<agent><server><address>`.
 - Confirm enrollment credentials: if enrollment fails with `Invalid password (from manager)`, verify that the password in `/var/ossec/etc/authd.pass` on the agent matches `/var/wazuh-manager/etc/authd.pass` on the manager.
+
+## Remote upgrade (WPK)
+
+A remote upgrade from 4.14.X to 5.0.0 never rewrites `ossec.conf`: the file the 4.X agent had is the file the 5.0 agent reads, which is why the `<client>` fallback above exists.
+
+Before installing anything, the WPK installer checks that the manager accepts connections on the HTTPS port the upgraded agent will use, and aborts if it does not:
+
+```console
+2026/07/31 00:26:57 - Checking connectivity to MANAGER_IP:1517.
+2026/07/31 00:26:58 - Upgrade failed. The manager is not reachable at MANAGER_IP:1517, interrupting upgrade.
+```
+
+The abort happens before the package manager runs, so the agent stays on 4.14.X, keeps running, and the upgrade can be retried once `1517` is reachable. `upgrade_result` is `2`.
+
+The target address and port come from the same place the agent reads them: `<agent><server>` first, then `<client><server><address>`, with `1517` as the port default.
 
 ## Validation checklist
 
@@ -189,5 +213,6 @@ Migration is complete when all conditions below are met:
 
 - Agent was upgraded using the required version path.
 - No invalid `syscheck`/`rootcheck` element warnings remain.
-- No deprecated `<server>`, `protocol`, or `crypto_method` warnings remain.
+- The connection block is `<agent>`, and no `<client>` fallback message remains in `ossec.log`.
+- No deprecated `protocol` or `crypto_method` messages remain.
 - Agent stays connected to the manager and sends events normally.

--- a/docs/ref/configuration/agent/README.md
+++ b/docs/ref/configuration/agent/README.md
@@ -17,7 +17,7 @@ Configuration reference for Wazuh agent components.
 | [Active Response](../../modules/active-response/configuration.md) | `<active-response>` | `execd.*` |
 | [Agent Info](../../modules/agent_info/configuration.md) | `<agent-info>` | - |
 | [Agent Upgrade](../../modules/agent_upgrade/configuration.md) | `<agent-upgrade>` | - |
-| [Client](../../modules/client/configuration.md) | `<client>`, `<anti_tampering>` | `agent.*`, `windows.*` (Windows only) |
+| [Client](../../modules/client/configuration.md) | `<agent>`, `<anti_tampering>` | `agent.*`, `windows.*` (Windows only) |
 | [Command](../../modules/command/configuration.md) | `<wodle name="command">` | `wazuh_command.*` |
 | [Logcollector](../../modules/logcollector/configuration.md) | `<localfile>`, `<socket>` | `logcollector.*` |
 | [Logging](../../modules/logging/configuration.md) | `<logging>` | - |

--- a/docs/ref/modules/agent_upgrade/README.md
+++ b/docs/ref/modules/agent_upgrade/README.md
@@ -3,7 +3,7 @@
 The agent upgrade module handles remote agent upgrades using WPK (Wazuh Package Kit) files. It has two roles depending on where it runs:
 
 - **Manager side** — validates upgrade requests coming from the Server API, resolves the target WPK for each agent, and creates a `remote_upgrade` task in the [Task Manager](../task_manager/README.md) with the metadata the agent will need to fetch and install the package.
-- **Agent side** — listens on the agent's local `queue/sockets/upgrade` socket and executes the file-transfer / install commands (`open`, `write`, `close`, `sha1`, `upgrade`) issued by the agent daemon after the WPK has been received.
+- **Agent side** — listens on the agent's local `queue/sockets/upgrade` socket and executes the `upgrade` command issued by the agent daemon once the WPK has been downloaded. After the agent restarts, it reports the outcome as a stateless event and erases its local `upgrade_result` file.
 
 Source: [src/wazuh_modules/src/agent_upgrade/](../../../../src/wazuh_modules/src/agent_upgrade/)
 
@@ -46,8 +46,9 @@ API / agent_upgrade CLI  ──►  queue/tasks/upgrade  (agent_upgrade manager)
 
 The manager-side module does **not** send WPK data to the agent directly. Once the task has been stored in the Task Manager, the module is done with that request. Task delivery depends on the target agent's version:
 
-- **5.x agents** pull the task from the manager's HTTPS control endpoint on their next poll, download the WPK through the same HTTPS interface, and hand the file off to their local upgrade module for installation.
-- **4.x agents** are served by the manager's compatibility push path, which reads pending tasks from the Task Manager and forwards the WPK to the agent through the existing agent-manager channel using the same `open` / `write` / `close` / `sha1` / `upgrade` commands understood by the agent-side listener.
+**5.x agents** pull the task from the manager's HTTPS control endpoint on their next poll, download the WPK through the same HTTPS interface, and hand the file off to their local upgrade module for installation.
+
+A **4.x agent** installs the WPK with its own 4.x upgrade module, which is why a 5.0.0 WPK still has to be consumable by 4.x code: the WPK's `upgrade.sh` / `upgrade.bat` and `pkg_installer.sh` run under the agent being replaced, not under 5.x. Getting a task's WPK to a 4.x agent is not handled by this module.
 
 Because task IDs are derived deterministically from `agent_id`, `task_type`, `create_time`, and the request timestamp forwarded from the API, the same upgrade request routed to different manager nodes produces the same `task_id` and does not double-schedule the upgrade.
 
@@ -74,23 +75,19 @@ download the WPK. If the file is missing on that node, the upgrade will fail.
 | `queue/tasks/upgrade` | Inbound   | Receives `upgrade` / `upgrade_custom` commands from the Server API |
 | `queue/tasks/task`    | Outbound  | Sends `create_task` requests to the Task Manager                   |
 
-The manager-side module no longer connects directly to Remoted or drives a WPK transfer thread pool from the API request path. For 5.x agents, WPK bytes flow from the manager to the agent through the HTTPS server on the manager, driven by the agent's poll. For 4.x agents, the manager's compatibility push path reads the pending task from the Task Manager and delivers the WPK over the existing agent-manager channel.
+The manager-side module no longer connects directly to Remoted or drives a WPK transfer thread pool from the API request path. For 5.x agents, WPK bytes are meant to flow from the manager to the agent through the HTTPS server on the manager, driven by the agent's poll: the agent fetches the file with `POST /download` once `/control` hands it a `remote_upgrade` task.
 
 ---
 
 ## Agent-side flow
 
-On the agent, the upgrade module runs a listener on the local Unix domain socket `queue/sockets/upgrade` (`AGENT_UPGRADE_SOCK`). It accepts JSON commands issued by the agent daemon after a `remote_upgrade` task has been delivered and the WPK has been retrieved:
+On the agent, the upgrade module runs a listener on the local Unix domain socket `queue/sockets/upgrade` (`AGENT_UPGRADE_SOCK`). A 5.x agent downloads the WPK itself over HTTPS, so the listener accepts one JSON command, issued by the agent daemon once the file is on disk:
 
-| Command   | Parameters                          | Purpose                                                                                            |
-| --------- | ----------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `open`    | `file`, `mode` (`w` / `wb`)         | Create the WPK file inside the agent's incoming directory                                          |
-| `write`   | `file`, `buffer` (base64), `length` | Append a chunk of WPK data to the opened file                                                      |
-| `close`   | `file`                              | Close and flush the WPK file                                                                       |
-| `sha1`    | `file`                              | Compute and return the SHA-1 of the received file for validation                                   |
-| `upgrade` | `file`, `installer`                 | Verify the WPK signature, uncompress, unmerge into the upgrade directory and execute the installer |
+| Command   | Parameters          | Purpose                                                                                            |
+| --------- | ------------------- | -------------------------------------------------------------------------------------------------- |
+| `upgrade` | `file`, `installer` | Verify the WPK signature, uncompress, unmerge into the upgrade directory and execute the installer |
 
-All five commands are gated by the `allow_upgrades` flag, which reflects the agent's `<agent-upgrade><enabled>` setting. When disabled, every command is answered with `Upgrade module is disabled or not ready yet` (error code `ERROR_UPGRADES_NOT_ALLOWED`).
+The command is gated by the `allow_upgrades` flag, which reflects the agent's `<agent-upgrade><enabled>` setting. When disabled, it is answered with `Upgrade module is disabled or not ready yet` (error code `ERROR_UPGRADES_NOT_ALLOWED`).
 
 The `upgrade` command:
 1. Verifies the WPK signature against the CA store (see `ca_verification` / `ca_store`).
@@ -118,4 +115,4 @@ Windows agents accept the same JSON commands but through the agentd IPC layer in
 | `manager/wm_agent_upgrade_parsing.c`  | Parses API messages and formats responses                                 |
 | `manager/wm_agent_upgrade_validate.c` | Version / platform / WPK integrity checks                                 |
 | `agent/wm_agent_upgrade_agent.c`      | Agent-side listener on `queue/sockets/upgrade` (POSIX)                    |
-| `agent/wm_agent_upgrade_com.c`        | Implementation of `open`, `write`, `close`, `sha1`, `upgrade`             |
+| `agent/wm_agent_upgrade_com.c`        | Implementation of the `upgrade` command                                   |

--- a/docs/ref/modules/client/README.md
+++ b/docs/ref/modules/client/README.md
@@ -10,7 +10,7 @@ The client module (`agentd`) manages the communication between Wazuh agents and 
 
 **Configuration file:** `/var/ossec/etc/ossec.conf`
 
-**XML Section:** `<client>`, `<anti_tampering>`
+**XML Section:** `<agent>`, `<anti_tampering>`
 
 ---
 
@@ -59,15 +59,15 @@ For complete configuration options, see:
 Quick configuration example:
 
 ```xml
-<client>
+<agent>
   <server>
     <address>manager.example.com</address>
-    <port>1514</port>
+    <port>1517</port>
     <protocol>tcp</protocol>
   </server>
   <config-profile>web-servers</config-profile>
   <auto_restart>yes</auto_restart>
-</client>
+</agent>
 
 <anti_tampering>
   <disabled>no</disabled>
@@ -168,7 +168,7 @@ tail -f /var/ossec/logs/ossec.log
 
 Common issues:
 - Incorrect manager address or port
-- Firewall blocking port 1514
+- Firewall blocking port 1517
 - Agent key not registered on manager
 - Manager not accepting connections (`remoted` not running)
 

--- a/docs/ref/modules/client/configuration.md
+++ b/docs/ref/modules/client/configuration.md
@@ -438,14 +438,6 @@ Full example with all sections:
       <address>manager1.example.com</address>
       <port>1517</port>
     </server>
-    <ssl>
-      <certificate_authorities>/var/ossec/etc/manager-ca.pem</certificate_authorities>
-      <verification_mode>full</verification_mode>
-    </ssl>
-    <batch>
-      <size>1MB</size>
-      <interval>10s</interval>
-    </batch>
     <config-profile>webserver,production,linux</config-profile>
     <notify_time>60</notify_time>
     <time-reconnect>60</time-reconnect>

--- a/docs/ref/modules/client/configuration.md
+++ b/docs/ref/modules/client/configuration.md
@@ -4,7 +4,7 @@ Complete configuration reference for the Wazuh agent daemon (agentd).
 
 **Configuration file:** `/var/ossec/etc/ossec.conf` (Linux/Unix) or `C:\Program Files (x86)\ossec-agent\ossec.conf` (Windows)
 
-**XML Sections:** `<client>`, `<anti_tampering>`
+**XML Sections:** `<agent>`, `<anti_tampering>`
 
 **Module:** Agent-only
 
@@ -14,13 +14,15 @@ For module overview and architecture, see [Client Module](index.html).
 
 ---
 
-## Client Configuration (`<client>`)
+## Agent Configuration (`<agent>`)
 
 Configures the agent's connection to the Wazuh manager.
 
+`<client>` is the 4.X name of this block and is renamed to `<agent>` in 5.0. A configuration left by a 4.X agent still starts: `<server><address>` is read from `<client>` and the port defaults to `1517`. No other option inside `<client>` is read, so rename the block to `<agent>` to keep them all.
+
 ### server
 
-Manager server configuration block. Multiple `<server>` blocks can be defined for failover.
+Manager server configuration block.
 
 **Sub-options:**
 
@@ -34,11 +36,12 @@ Manager IP address or hostname.
 
 #### port
 
-Manager port number.
+Manager port number for the agent's HTTPS connection.
 
-- **Default value:** `1514`
+- **Default value:** `1517`
 - **Allowed values:** Valid port number (1-65535)
-- **Example:** `1514`
+- **Example:** `1517`
+- **Note:** A `<port>` inside a legacy `<client><server>` block is not read.
 
 #### protocol
 
@@ -247,7 +250,7 @@ Network interface index to bind for enrollment connection.
 ## Client Buffer Configuration (`<client_buffer>`)
 
 Removed in 5.0.0: buffering and pacing belong to the HTTPS transport's
-accumulator, configured under `<client><batch>`. The section is still accepted
+accumulator, configured under `<agent><batch>`. The section is still accepted
 and ignored, with a warning.
 
 ---
@@ -365,10 +368,10 @@ monitord.rotate_log=1
 Single manager, standard settings:
 
 ```xml
-<client>
+<agent>
   <server>
     <address>10.0.0.10</address>
-    <port>1514</port>
+    <port>1517</port>
     <protocol>tcp</protocol>
   </server>
   <config-profile>webserver,production</config-profile>
@@ -376,36 +379,7 @@ Single manager, standard settings:
   <time-reconnect>60</time-reconnect>
   <auto_restart>yes</auto_restart>
   <crypto_method>aes</crypto_method>
-</client>
-```
-
-### Failover Configuration
-
-Multiple managers for high availability:
-
-```xml
-<client>
-  <server>
-    <address>manager1.example.com</address>
-    <port>1514</port>
-    <protocol>tcp</protocol>
-    <max_retries>3</max_retries>
-  </server>
-  <server>
-    <address>manager2.example.com</address>
-    <port>1514</port>
-    <protocol>tcp</protocol>
-    <max_retries>3</max_retries>
-  </server>
-  <server>
-    <address>manager3.example.com</address>
-    <port>1514</port>
-    <protocol>tcp</protocol>
-    <max_retries>3</max_retries>
-  </server>
-  <notify_time>30</notify_time>
-  <time-reconnect>30</time-reconnect>
-</client>
+</agent>
 ```
 
 ### Auto-Enrollment Configuration
@@ -413,7 +387,7 @@ Multiple managers for high availability:
 Automatic agent registration:
 
 ```xml
-<client>
+<agent>
   <enrollment>
     <enabled>yes</enabled>
     <manager_address>manager.example.com</manager_address>
@@ -424,10 +398,10 @@ Automatic agent registration:
   </enrollment>
   <server>
     <address>manager.example.com</address>
-    <port>1514</port>
+    <port>1517</port>
     <protocol>tcp</protocol>
   </server>
-</client>
+</agent>
 ```
 
 ### Client Buffer Configuration
@@ -435,12 +409,12 @@ Automatic agent registration:
 High-volume environment:
 
 ```xml
-<client>
+<agent>
   <batch>
     <size>10MB</size>
     <interval>5s</interval>
   </batch>
-</client>
+</agent>
 ```
 
 ### Anti-Tampering Configuration
@@ -459,19 +433,19 @@ Full example with all sections:
 
 ```xml
 <ossec_config>
-  <client>
+  <agent>
     <server>
       <address>manager1.example.com</address>
-      <port>1514</port>
-      <protocol>tcp</protocol>
-      <max_retries>5</max_retries>
+      <port>1517</port>
     </server>
-    <server>
-      <address>manager2.example.com</address>
-      <port>1514</port>
-      <protocol>tcp</protocol>
-      <max_retries>5</max_retries>
-    </server>
+    <ssl>
+      <certificate_authorities>/var/ossec/etc/manager-ca.pem</certificate_authorities>
+      <verification_mode>full</verification_mode>
+    </ssl>
+    <batch>
+      <size>1MB</size>
+      <interval>10s</interval>
+    </batch>
     <config-profile>webserver,production,linux</config-profile>
     <notify_time>60</notify_time>
     <time-reconnect>60</time-reconnect>
@@ -483,7 +457,7 @@ Full example with all sections:
       <port>1515</port>
       <groups>webservers,production</groups>
     </enrollment>
-  </client>
+  </agent>
 
   <anti_tampering>
     <package_uninstallation>yes</package_uninstallation>
@@ -501,7 +475,7 @@ Full example with all sections:
 
 ### disable-active-response
 
-**DEPRECATED:** The `<disable-active-response>` tag within `<client>` is parsed but has no effect.
+**DEPRECATED:** The `<disable-active-response>` tag within `<agent>` is parsed but has no effect.
 
 - **Status:** Deprecated silent no-op
 - **Behavior:** Parser accepts the tag but does not use the value

--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -5,7 +5,7 @@
 -->
 
 <ossec_config>
-  <client>
+  <agent>
     <server>
       <address>IP</address>
       <port>1517</port>
@@ -20,7 +20,7 @@
     </ssl>
 
     <config-profile>debian, debian8</config-profile>
-  </client>
+  </agent>
 
   <!-- Policy monitoring -->
   <rootcheck>

--- a/etc/templates/config/README.md
+++ b/etc/templates/config/README.md
@@ -42,12 +42,13 @@
     header-comments.template
 
     <ossec_config>
-        <client>
+        <agent>
           <server>
             <address>192.168.10.100</address>
+            <port>1517</port>
           </server>
           <config-profile>distribution, distributionVersion</config-profile>
-        </client>
+        </agent>
 
         logging.template
 

--- a/src/client-agent/src/config.c
+++ b/src/client-agent/src/config.c
@@ -47,6 +47,8 @@ int ClientConf(const char *cfgfile)
     agt->execdq = 0;
     agt->profile = NULL;
     agt->flags.auto_restart = 1;
+    agt->flags.agent_address = 0;
+    agt->flags.agent_port = 0;
     agt->notify_time = 0;
     agt->max_time_reconnect_try = 0;
     agt->main_ip_update_interval = 0;

--- a/src/client-agent/src/config.c
+++ b/src/client-agent/src/config.c
@@ -47,8 +47,6 @@ int ClientConf(const char *cfgfile)
     agt->execdq = 0;
     agt->profile = NULL;
     agt->flags.auto_restart = 1;
-    agt->flags.agent_address = 0;
-    agt->flags.agent_port = 0;
     agt->notify_time = 0;
     agt->max_time_reconnect_try = 0;
     agt->main_ip_update_interval = 0;

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -792,8 +792,7 @@ void *bridge_upgrade_thread(void *arg)
 
     if (error_code == 0) {
         minfo("https_client: remote_upgrade task %s dispatched to the upgrade module (installer "
-              "running; the agent may restart shortly). No /control response is sent "
-              "(fire-and-forget, #37834).", ctx->task_id);
+              "running; the agent may restart shortly). No /control response is sent.", ctx->task_id);
         ok = true;
     } else {
         merror("https_client: remote_upgrade task %s: upgrade module rejected the command: %s",

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -1659,7 +1659,7 @@ static bool bridge_submit_sync_session(const char *session_id, const uint8_t *bu
 /* No internal-option gate: by the time AgentdStart() (and so this) runs,
  * client-agent/src/main.c has already refused to start the daemon at all
  * (merror + mlerror_exit, a hard exit) unless agt->server[0] carries a
- * validated address; the port always has a default (DEFAULT_REMOTE_PORT)
+ * validated address; the port always has a default (DEFAULT_HTTPS_REMOTE_PORT)
  * when unspecified. HTTPS is the only transport on offer, so there is
  * nothing left to gate. */
 void w_https_client_start(void)

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -17,7 +17,7 @@
  * see w_https_client_start()'s comment) and no alternative transport is
  * offered.
  *
- * The config surface (<server>/<ssl>, parsed by Read_Client/Read_Client_SSL
+ * The config surface (<server>/<ssl>, parsed by Read_Agent/Read_Agent_SSL
  * in src/config/src/client-config.c) and the real TLS wiring are done: the
  * module's own fail-closed validation (ModuleConfig::validateTls) now gets a
  * real verify_mode/CA/cert/key/ciphers instead of a forced HC_VERIFY_NONE.

--- a/src/client-agent/src/reload_agent.c
+++ b/src/client-agent/src/reload_agent.c
@@ -119,7 +119,7 @@ int verifyRemoteConf(){
     } else if (Test_Localfile(configPath) < 0) {
 		snprintf(msg_output, OS_MAXSTR, "%c:%s:%s: '%s'. ",  LOCALFILE_MQ, "wazuh-agent", AG_IN_RCON, "localfile");
 		goto fail;
-    } else if (Test_Client(configPath) < 0) {
+    } else if (Test_Agent(configPath) < 0) {
 		snprintf(msg_output, OS_MAXSTR, "%c:%s:%s: '%s'. ",  LOCALFILE_MQ, "wazuh-agent", AG_IN_RCON, "client");
 		goto fail;
 	} else if (Test_WModule(configPath) < 0) {

--- a/src/config/include/client-config.h
+++ b/src/config/include/client-config.h
@@ -17,6 +17,8 @@
 typedef struct agent_flags_t {
     unsigned int auto_restart:1;
     unsigned int remote_conf:1;
+    unsigned int agent_address:1; ///< <agent><server><address> was present in the configuration.
+    unsigned int agent_port:1;    ///< <agent><server><port> was present in the configuration.
 } agent_flags_t;
 
 typedef struct agent_server {
@@ -101,6 +103,18 @@ typedef struct _anti_tampering {
 
 /* Frees the Client struct  */
 void Free_Client(agent * config);
+
+/**
+ * @brief Apply the <agent><server> fallbacks once the whole configuration is read.
+ *
+ * A 4.x agent upgraded over WPK keeps its old <client> block untouched, so the
+ * HTTPS endpoint has to be reconciled at read time: the address falls
+ * back to <client><server><address> and the port to DEFAULT_HTTPS_REMOTE_PORT.
+ * Logs what was inherited and what was defaulted.
+ *
+ * @param config Agent configuration already filled by ReadConfig().
+ */
+void Reconcile_Agent_Server(agent * config);
 
 /**
  * @brief Check if address has default values

--- a/src/config/include/client-config.h
+++ b/src/config/include/client-config.h
@@ -17,8 +17,6 @@
 typedef struct agent_flags_t {
     unsigned int auto_restart:1;
     unsigned int remote_conf:1;
-    unsigned int agent_address:1; ///< <agent><server><address> was present in the configuration.
-    unsigned int agent_port:1;    ///< <agent><server><port> was present in the configuration.
 } agent_flags_t;
 
 typedef struct agent_server {
@@ -41,7 +39,7 @@ typedef enum agent_verify_mode_t {
     AGENT_VERIFY_NONE = 2  ///< No TLS verification (the agent's own configured default).
 } agent_verify_mode_t;
 
-/* Agent-side HTTPS transport TLS settings: the <client><ssl> block (FR10 / #37702 §10). */
+/* Agent-side HTTPS transport TLS settings: the <agent><ssl> block (FR10 / #37702 §10). */
 typedef struct agent_ssl {
     char * certificate;             ///< <certificate>: optional client (mTLS) certificate.
     char * key;                     ///< <key>: optional client (mTLS) private key.
@@ -51,7 +49,7 @@ typedef struct agent_ssl {
 } agent_ssl;
 
 /**
- * @brief <client><batch>: the /stateless send-rate model (#37835).
+ * @brief <agent><batch>: the /stateless send-rate model (#37835).
  *
  * Replaces the leaky bucket's <client_buffer><events_per_second> pacing for
  * stateless traffic. Zero means "unset": the transport module applies its own
@@ -63,7 +61,7 @@ typedef struct agent_batch {
 } agent_batch;
 
 /**
- * @brief <client><stats_report> / <client><config_report>: the periodic push of
+ * @brief <agent><stats_report> / <agent><config_report>: the periodic push of
  *        a whole-agent snapshot to /stats and /config (#37843).
  *
  * The two are independent and both stay off until <enabled> says otherwise.
@@ -89,10 +87,10 @@ typedef struct _agent {
     char *profile;
     int package_uninstallation;
     agent_flags_t flags;
-    agent_ssl ssl;     ///< HTTPS transport TLS settings (<client><ssl>).
-    agent_batch batch; ///< /stateless batching limits (<client><batch>).
-    agent_report stats_report;  ///< Periodic /stats push (<client><stats_report>).
-    agent_report config_report; ///< Periodic /config push (<client><config_report>).
+    agent_ssl ssl;     ///< HTTPS transport TLS settings (<agent><ssl>).
+    agent_batch batch; ///< /stateless batching limits (<agent><batch>).
+    agent_report stats_report;  ///< Periodic /stats push (<agent><stats_report>).
+    agent_report config_report; ///< Periodic /config push (<agent><config_report>).
     w_enrollment_ctx *enrollment_cfg;
 } agent;
 
@@ -101,20 +99,8 @@ typedef struct _anti_tampering {
     bool package_uninstallation;
 } anti_tampering;
 
-/* Frees the Client struct  */
-void Free_Client(agent * config);
-
-/**
- * @brief Apply the <agent><server> fallbacks once the whole configuration is read.
- *
- * A 4.x agent upgraded over WPK keeps its old <client> block untouched, so the
- * HTTPS endpoint has to be reconciled at read time: the address falls
- * back to <client><server><address> and the port to DEFAULT_HTTPS_REMOTE_PORT.
- * Logs what was inherited and what was defaulted.
- *
- * @param config Agent configuration already filled by ReadConfig().
- */
-void Reconcile_Agent_Server(agent * config);
+/* Frees the agent struct  */
+void Free_Agent(agent * config);
 
 /**
  * @brief Check if address has default values
@@ -124,7 +110,7 @@ void Reconcile_Agent_Server(agent * config);
 bool Validate_Address(agent_server *servers);
 
 /**
- * @brief Checks if at least one <manager> block is not a link-local ipv6 address or it has a network interface configured.
+ * @brief Checks if at least one <server> block is not a link-local ipv6 address or it has a network interface configured.
  * @param servers Server(s) configuration block in agent ossec.conf
  * @return Returns true if successful and false if not success.
  */

--- a/src/config/include/config.h
+++ b/src/config/include/config.h
@@ -49,9 +49,8 @@ int Read_Syscheck(const OS_XML *xml, XML_NODE node, void *d1, void *d2);
 int Read_Rootcheck(XML_NODE node, void *d1, void *d2);
 int Read_Localfile(XML_NODE node, void *d1, void *d2);
 int Read_Remote(const OS_XML *xml,XML_NODE node, void *d1, void *d2);
-int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, void *d2);
 int Read_Agent(const OS_XML *xml, XML_NODE node, void *d1, void *d2);
-int Read_ClientBuffer(XML_NODE node, void *d1, void *d2);
+int Read_Legacy_Client_Address(const OS_XML *xml, XML_NODE node, void *d1, void *d2);
 int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2);
 int Read_SCA(const OS_XML *xml, xml_node *node, void *d1, void *d2);
 int Read_AGENT_INFO(const OS_XML* xml, xml_node* node, void* d1);
@@ -61,7 +60,7 @@ int Read_AGENT_INFO(const OS_XML* xml, xml_node* node, void* d1);
  * @param node XML node to analyze
  * @param d1 Pub/Sub configuration structure
  */
-int Read_Client_Shared(XML_NODE node, void *d1);
+int Read_Agent_Shared(XML_NODE node, void *d1);
 
 /**
  * @brief Read the configuration for Google Cloud Pub/Sub
@@ -129,7 +128,7 @@ int Test_Rootcheck(const char * path);
 int Test_Localfile(const char * path);
 
 /* Verifies that the configuration for Client is correct. Return 0 on success or -1 on error.  */
-int Test_Client(const char * path);
+int Test_Agent(const char * path);
 
 /* Verifies that the configuration for ClientBuffer is correct. Return 0 on success or -1 on error.  */
 

--- a/src/config/include/config.h
+++ b/src/config/include/config.h
@@ -50,6 +50,8 @@ int Read_Rootcheck(XML_NODE node, void *d1, void *d2);
 int Read_Localfile(XML_NODE node, void *d1, void *d2);
 int Read_Remote(const OS_XML *xml,XML_NODE node, void *d1, void *d2);
 int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, void *d2);
+int Read_Agent(const OS_XML *xml, XML_NODE node, void *d1, void *d2);
+int Read_ClientBuffer(XML_NODE node, void *d1, void *d2);
 int Read_WModule(const OS_XML *xml, xml_node *node, void *d1, void *d2);
 int Read_SCA(const OS_XML *xml, xml_node *node, void *d1, void *d2);
 int Read_AGENT_INFO(const OS_XML* xml, xml_node* node, void* d1);

--- a/src/config/src/client-config.c
+++ b/src/config/src/client-config.c
@@ -236,11 +236,14 @@ int Read_Agent(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
  * only has <client> (#38103). The address is taken when <agent> did not already provide
  * one - so <agent> wins whichever block comes first - and everything else under <client>
  * is ignored rather than rejected, since the block is 4.x's and its options are not.
+ *
+ * Repeated addresses resolve the same way as under <agent>: the last one prevails
  */
 int Read_Legacy_Client_Address(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused)) void *d2)
 {
     const char *xml_agent_server = "server";
     const char *xml_agent_addr = "address";
+    char * address = NULL;
 
     agent * logr = (agent *)d1;
 
@@ -265,24 +268,28 @@ int Read_Legacy_Client_Address(const OS_XML *xml, XML_NODE node, void *d1, __att
                 continue;
             }
 
-            os_calloc(2, sizeof(agent_server), logr->server);
-            os_strdup(chld_node[j]->content, logr->server[0].rip);
-            if (strchr(logr->server[0].rip, ':') != NULL) {
-                os_realloc(logr->server[0].rip, IPSIZE + 1, logr->server[0].rip);
-                OS_ExpandIPv6(logr->server[0].rip, IPSIZE);
-            }
-            logr->server[0].port = DEFAULT_HTTPS_REMOTE_PORT;
-            logr->server_count = 1;
-
-            minfo("<agent><server><address> is not configured. Using <client><server><address> '%s' "
-                  "with the default port %d.", logr->server[0].rip, DEFAULT_HTTPS_REMOTE_PORT);
-
-            OS_ClearNode(chld_node);
-            return (0);
+            os_free(address);
+            os_strdup(chld_node[j]->content, address);
         }
 
         OS_ClearNode(chld_node);
     }
+
+    if (!address) {
+        return (0);
+    }
+
+    os_calloc(2, sizeof(agent_server), logr->server);
+    logr->server[0].rip = address;
+    if (strchr(logr->server[0].rip, ':') != NULL) {
+        os_realloc(logr->server[0].rip, IPSIZE + 1, logr->server[0].rip);
+        OS_ExpandIPv6(logr->server[0].rip, IPSIZE);
+    }
+    logr->server[0].port = DEFAULT_HTTPS_REMOTE_PORT;
+    logr->server_count = 1;
+
+    minfo("<agent><server><address> is not configured. Using <client><server><address> '%s' "
+          "with the default port %d.", logr->server[0].rip, DEFAULT_HTTPS_REMOTE_PORT);
 
     return (0);
 }

--- a/src/config/src/client-config.c
+++ b/src/config/src/client-config.c
@@ -14,18 +14,34 @@
 #include "config.h"
 #include "sec.h"
 
-int Read_Client_Server(XML_NODE node, agent *logr);
+int Read_Client_Server(XML_NODE node, agent *logr, bool from_agent_block);
 int Read_Client_SSL(XML_NODE node, agent *logr);
 int Read_Client_Batch(XML_NODE node, agent *logr);
 int Read_Client_Report(XML_NODE node, agent_report *report);
 int Read_Client_Enrollment(XML_NODE node, agent *logr);
+static int read_client_block(const OS_XML *xml, XML_NODE node, void *d1, bool from_agent_block);
 
+/**
+ * @brief Read the agent block, whether it is spelled <agent> or the legacy <client>.
+ *
+ * <client> is renamed to <agent> in 5.x: <agent> is always preferred, but <client> is still
+ * accepted for backwards compatibility only during an upgrade from 4.x.
+ */
 int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused)) void *d2)
+{
+    return read_client_block(xml, node, d1, false);
+}
+
+int Read_Agent(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused)) void *d2)
+{
+    return read_client_block(xml, node, d1, true);
+}
+
+static int read_client_block(const OS_XML *xml, XML_NODE node, void *d1, bool from_agent_block)
 {
     int i = 0;
     char f_ip[128] = {'\0'};
     char * rip = NULL;
-    int port = DEFAULT_HTTPS_CLIENT_PORT;
 
     /* XML definitions */
     const char *xml_client_manager = "manager";
@@ -87,17 +103,9 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
             }
 
         } else if (strcmp(node[i]->element, xml_client_port) == 0) {
-            mwarn("The <%s> tag is deprecated, please use <manager><port> instead.", xml_client_port);
-
-            if (!OS_StrIsNum(node[i]->content)) {
-                merror(XML_VALUEERR, node[i]->element, node[i]->content);
-                return (OS_INVALID);
-            }
-
-            if (port = atoi(node[i]->content), port <= 0 || port > 65535) {
-                merror(PORT_ERROR, port);
-                return (OS_INVALID);
-            }
+            /* A legacy port only ever names the removed 1514 channel (#38103). */
+            minfo("Ignoring the <client><%s> option. The HTTPS port is taken from <agent><server><port>.",
+                  xml_client_port);
         }
         /* Get parameters for each configured manager/server block */
         else if (strcmp(node[i]->element, xml_client_server) == 0 ||
@@ -109,7 +117,7 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
                 merror(XML_INVELEM, node[i]->element);
                 return (OS_INVALID);
             }
-            if (Read_Client_Server(chld_node, logr) < 0) {
+            if (Read_Client_Server(chld_node, logr, from_agent_block) < 0) {
                 OS_ClearNode(chld_node);
                 return (OS_INVALID);
             }
@@ -231,11 +239,11 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
         }
     }
 
-    // Assign global port to legacy configurations
+    // Assign the default port to legacy configurations
 
     for (i = 0; i < logr->server_count; ++i) {
         if (!logr->server[i].port) {
-            logr->server[i].port = port;
+            logr->server[i].port = DEFAULT_HTTPS_REMOTE_PORT;
         }
     }
     return (0);
@@ -263,7 +271,19 @@ int Read_Client_Shared(XML_NODE node, void *d1)
     return (0);
 }
 
-int Read_Client_Server(XML_NODE node, agent * logr)
+/**
+ * @brief Read a <server> block, either the new <agent><server> or the legacy <client><server>.
+ *
+ * Both names describe the same single manager endpoint (#38103): <agent> is the
+ * 5.x name and wins when both are present, and <client><server><port> is
+ * ignored because it can only carry the removed 1514 port.
+ *
+ * @param node Children of the <server> element.
+ * @param logr Agent configuration to fill.
+ * @param from_agent_block true when the block came from <agent>, false for <client>.
+ * @return 0 on success, OS_INVALID on error.
+ */
+int Read_Client_Server(XML_NODE node, agent * logr, bool from_agent_block)
 {
     /* XML definitions */
     const char *xml_client_addr = "address";
@@ -278,7 +298,8 @@ int Read_Client_Server(XML_NODE node, agent * logr)
     char * rip = NULL;
     /* Default values */
     uint32_t network_interface = 0;
-    int port = DEFAULT_HTTPS_CLIENT_PORT;
+    int port = DEFAULT_HTTPS_REMOTE_PORT;
+    bool port_set = false;
     int max_retries = DEFAULT_MAX_RETRIES;
     int retry_interval = DEFAULT_RETRY_INTERVAL;
 
@@ -304,6 +325,13 @@ int Read_Client_Server(XML_NODE node, agent * logr)
                 return (OS_INVALID);
             }
         } else if (strcmp(node[j]->element, xml_client_port) == 0) {
+            if (!from_agent_block) {
+                /* A legacy port only ever names the removed 1514 channel (#38103). */
+                minfo("Ignoring the <client><server><%s> option. The HTTPS port is taken from "
+                      "<agent><server><%s>.", xml_client_port, xml_client_port);
+                continue;
+            }
+
             if (!OS_StrIsNum(node[j]->content)) {
                 merror(XML_VALUEERR, node[j]->element, node[j]->content);
                 return (OS_INVALID);
@@ -313,6 +341,8 @@ int Read_Client_Server(XML_NODE node, agent * logr)
                 merror(PORT_ERROR, port);
                 return (OS_INVALID);
             }
+
+            port_set = true;
         } else if (strcmp(node[j]->element, xml_interface) == 0) {
             if (!OS_StrIsNum(node[j]->content)) {
                 merror(XML_VALUEERR, node[j]->element, node[j]->content);
@@ -343,12 +373,24 @@ int Read_Client_Server(XML_NODE node, agent * logr)
         return (OS_INVALID);
     }
 
+    /* <agent><server> is the 5.x name for the same endpoint, so it wins over the
+     * legacy <client><server> whichever order they appear in (#38103). */
+    if (!from_agent_block && logr->flags.agent_address) {
+        minfo("Ignoring <client><server><%s>: <agent><server><%s> is already set.",
+              xml_client_addr, xml_client_addr);
+        return (0);
+    }
+
     /* Single <server> block: the last one prevails (#37702 restriction 2) and
      * server rotation is removed (restriction 3), so replace any previous entry
      * instead of appending. The array keeps a NULL-rip sentinel at index 1. */
     if (logr->server) {
         if (logr->server_count > 0) {
-            mwarn("Only one <server> block is supported; the last one prevails.");
+            if (from_agent_block && !logr->flags.agent_address) {
+                minfo("Both <agent><server> and <client><server> are configured; <agent> prevails.");
+            } else {
+                mwarn("Only one <server> block is supported; the last one prevails.");
+            }
         }
         for (int k = 0; logr->server[k].rip; k++) {
             os_free(logr->server[k].rip);
@@ -370,7 +412,37 @@ int Read_Client_Server(XML_NODE node, agent * logr)
     logr->server[0].retry_interval = retry_interval;
     logr->server_count = 1;
 
+    if (from_agent_block) {
+        logr->flags.agent_address = 1;
+        logr->flags.agent_port = port_set ? 1 : 0;
+    }
+
     return (0);
+}
+
+void Reconcile_Agent_Server(agent * config)
+{
+    if (!config) {
+        return;
+    }
+
+    /* A WPK upgrade never rewrites ossec.conf, so a 4.x agent reaches 5.x with
+     * only the legacy <client><server> block (#38103). */
+    if (!config->flags.agent_address) {
+        if (config->server && config->server[0].rip) {
+            minfo("<agent><server><address> is not configured. Using <client><server><address> '%s'.",
+                  config->server[0].rip);
+        } else {
+            merror("No manager address configured: set <agent><server><address>.");
+            return;
+        }
+    }
+
+    if (!config->flags.agent_port) {
+        config->server[0].port = DEFAULT_HTTPS_REMOTE_PORT;
+        minfo("<agent><server><port> is not configured. Using the default port %d.",
+              DEFAULT_HTTPS_REMOTE_PORT);
+    }
 }
 
 int Read_Client_SSL(XML_NODE node, agent * logr)

--- a/src/config/src/client-config.c
+++ b/src/config/src/client-config.c
@@ -14,42 +14,31 @@
 #include "config.h"
 #include "sec.h"
 
-int Read_Client_Server(XML_NODE node, agent *logr, bool from_agent_block);
-int Read_Client_SSL(XML_NODE node, agent *logr);
-int Read_Client_Batch(XML_NODE node, agent *logr);
-int Read_Client_Report(XML_NODE node, agent_report *report);
-int Read_Client_Enrollment(XML_NODE node, agent *logr);
-static int read_client_block(const OS_XML *xml, XML_NODE node, void *d1, bool from_agent_block);
+int Read_Agent_Server(XML_NODE node, agent *logr);
+int Read_Agent_SSL(XML_NODE node, agent *logr);
+int Read_Agent_Batch(XML_NODE node, agent *logr);
+int Read_Agent_Report(XML_NODE node, agent_report *report);
+int Read_Agent_Enrollment(XML_NODE node, agent *logr);
 
 /**
- * @brief Read the agent block, whether it is spelled <agent> or the legacy <client>.
+ * @brief Read the <agent> block, the 5.x name of what 4.x spelled <client> (#38103).
  *
- * <client> is renamed to <agent> in 5.x: <agent> is always preferred, but <client> is still
- * accepted for backwards compatibility only during an upgrade from 4.x.
+ * The legacy name is not a second spelling of this block: an upgrade never rewrites
+ * ossec.conf, so a file left by 4.x is read for one value only, by
+ * Read_Legacy_Client_Address().
  */
-int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused)) void *d2)
-{
-    return read_client_block(xml, node, d1, false);
-}
-
 int Read_Agent(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused)) void *d2)
-{
-    return read_client_block(xml, node, d1, true);
-}
-
-static int read_client_block(const OS_XML *xml, XML_NODE node, void *d1, bool from_agent_block)
 {
     int i = 0;
     char f_ip[128] = {'\0'};
     char * rip = NULL;
 
     /* XML definitions */
-    const char *xml_client_manager = "manager";
-    const char *xml_client_server = "server";
-    const char *xml_client_ssl = "ssl";
-    const char *xml_client_batch = "batch";
-    const char *xml_client_stats_report = "stats_report";
-    const char *xml_client_config_report = "config_report";
+    const char *xml_agent_server = "server";
+    const char *xml_agent_ssl = "ssl";
+    const char *xml_agent_batch = "batch";
+    const char *xml_agent_stats_report = "stats_report";
+    const char *xml_agent_config_report = "config_report";
     const char *xml_local_ip = "local_ip";
     const char *xml_ar_disabled = "disable-active-response";
     const char *xml_notify_time = "notify_time";
@@ -58,12 +47,11 @@ static int read_client_block(const OS_XML *xml, XML_NODE node, void *d1, bool fr
     const char *xml_profile_name = "config-profile";
     const char *xml_auto_restart = "auto_restart";
     const char *xml_crypto_method = "crypto_method";
-    const char *xml_client_enrollment = "enrollment";
+    const char *xml_agent_enrollment = "enrollment";
 
     /* Old XML definitions */
-    const char *xml_client_ip = "server-ip";
-    const char *xml_client_hostname = "server-hostname";
-    const char *xml_client_port = "port";
+    const char *xml_agent_ip = "server-ip";
+    const char *xml_agent_hostname = "server-hostname";
     const char *xml_protocol = "protocol";
 
     agent * logr = (agent *)d1;
@@ -83,8 +71,8 @@ static int read_client_block(const OS_XML *xml, XML_NODE node, void *d1, bool fr
             mwarn("The <%s> tag has no functionality, so it will have no effect.", xml_local_ip);
         }
         /* Get manager IP */
-        else if (strcmp(node[i]->element, xml_client_ip) == 0) {
-            mwarn("The <%s> tag is deprecated, please use <manager><address> instead.", xml_client_ip);
+        else if (strcmp(node[i]->element, xml_agent_ip) == 0) {
+            mwarn("The <%s> tag is deprecated, please use <server><address> instead.", xml_agent_ip);
 
             if (OS_IsValidIP(node[i]->content, NULL) != 1) {
                 merror(INVALID_IP, node[i]->content);
@@ -92,8 +80,8 @@ static int read_client_block(const OS_XML *xml, XML_NODE node, void *d1, bool fr
             }
 
             rip = node[i]->content;
-        } else if (strcmp(node[i]->element, xml_client_hostname) == 0) {
-            mwarn("The <%s> tag is deprecated, please use <manager><address> instead.", xml_client_hostname);
+        } else if (strcmp(node[i]->element, xml_agent_hostname) == 0) {
+            mwarn("The <%s> tag is deprecated, please use <server><address> instead.", xml_agent_hostname);
             if (strchr(node[i]->content, '/') ==  NULL) {
                 snprintf(f_ip, 127, "%s/", node[i]->content);
                 rip = f_ip;
@@ -102,66 +90,58 @@ static int read_client_block(const OS_XML *xml, XML_NODE node, void *d1, bool fr
                 return (OS_INVALID);
             }
 
-        } else if (strcmp(node[i]->element, xml_client_port) == 0) {
-            /* A legacy port only ever names the removed 1514 channel (#38103). */
-            minfo("Ignoring the <client><%s> option. The HTTPS port is taken from <agent><server><port>.",
-                  xml_client_port);
         }
-        /* Get parameters for each configured manager/server block */
-        else if (strcmp(node[i]->element, xml_client_server) == 0 ||
-                 strcmp(node[i]->element, xml_client_manager) == 0) {
-            if (strcmp(node[i]->element, xml_client_manager) == 0) {
-                minfo("The <%s> tag is deprecated, please use <server> instead.", xml_client_manager);
-            }
+        /* Get parameters for the configured server block */
+        else if (strcmp(node[i]->element, xml_agent_server) == 0) {
             if (!(chld_node = OS_GetElementsbyNode(xml, node[i]))) {
                 merror(XML_INVELEM, node[i]->element);
                 return (OS_INVALID);
             }
-            if (Read_Client_Server(chld_node, logr, from_agent_block) < 0) {
+            if (Read_Agent_Server(chld_node, logr) < 0) {
                 OS_ClearNode(chld_node);
                 return (OS_INVALID);
             }
             OS_ClearNode(chld_node);
-        } else if (strcmp(node[i]->element, xml_client_ssl) == 0) {
+        } else if (strcmp(node[i]->element, xml_agent_ssl) == 0) {
             /* HTTPS transport TLS settings (sibling of <server>, #37702 §10). */
             if ((chld_node = OS_GetElementsbyNode(xml, node[i]))) {
-                if (Read_Client_SSL(chld_node, logr) < 0) {
+                if (Read_Agent_SSL(chld_node, logr) < 0) {
                     OS_ClearNode(chld_node);
                     return (OS_INVALID);
                 }
                 OS_ClearNode(chld_node);
             }
-        } else if (strcmp(node[i]->element, xml_client_batch) == 0) {
+        } else if (strcmp(node[i]->element, xml_agent_batch) == 0) {
             /* <batch><size>/<interval>: the /stateless send-rate model that
              * replaces the leaky bucket's pacing (#37835). */
             if ((chld_node = OS_GetElementsbyNode(xml, node[i]))) {
-                if (Read_Client_Batch(chld_node, logr) < 0) {
+                if (Read_Agent_Batch(chld_node, logr) < 0) {
                     OS_ClearNode(chld_node);
                     return (OS_INVALID);
                 }
                 OS_ClearNode(chld_node);
             }
-        } else if (strcmp(node[i]->element, xml_client_stats_report) == 0) {
+        } else if (strcmp(node[i]->element, xml_agent_stats_report) == 0) {
             /* <stats_report>/<config_report>: the two independent periodic
              * pushes to /stats and /config (#37843). Both off by default. */
             if ((chld_node = OS_GetElementsbyNode(xml, node[i]))) {
-                if (Read_Client_Report(chld_node, &logr->stats_report) < 0) {
+                if (Read_Agent_Report(chld_node, &logr->stats_report) < 0) {
                     OS_ClearNode(chld_node);
                     return (OS_INVALID);
                 }
                 OS_ClearNode(chld_node);
             }
-        } else if (strcmp(node[i]->element, xml_client_config_report) == 0) {
+        } else if (strcmp(node[i]->element, xml_agent_config_report) == 0) {
             if ((chld_node = OS_GetElementsbyNode(xml, node[i]))) {
-                if (Read_Client_Report(chld_node, &logr->config_report) < 0) {
+                if (Read_Agent_Report(chld_node, &logr->config_report) < 0) {
                     OS_ClearNode(chld_node);
                     return (OS_INVALID);
                 }
                 OS_ClearNode(chld_node);
             }
-        } else if (strcmp(node[i]->element, xml_client_enrollment) == 0) {
+        } else if (strcmp(node[i]->element, xml_agent_enrollment) == 0) {
             if ((chld_node = OS_GetElementsbyNode(xml, node[i]))) {
-                if (Read_Client_Enrollment(chld_node, logr) < 0) {
+                if (Read_Agent_Enrollment(chld_node, logr) < 0) {
                     OS_ClearNode(chld_node);
                     return (OS_INVALID);
                 }
@@ -249,7 +229,65 @@ static int read_client_block(const OS_XML *xml, XML_NODE node, void *d1, bool fr
     return (0);
 }
 
-int Read_Client_Shared(XML_NODE node, void *d1)
+/**
+ * @brief Read the one value still wanted from a 4.x <client> block: <server><address>.
+ *
+ * A WPK upgrade never rewrites ossec.conf, so a 5.x agent can start against a file that
+ * only has <client> (#38103). The address is taken when <agent> did not already provide
+ * one - so <agent> wins whichever block comes first - and everything else under <client>
+ * is ignored rather than rejected, since the block is 4.x's and its options are not.
+ */
+int Read_Legacy_Client_Address(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused)) void *d2)
+{
+    const char *xml_agent_server = "server";
+    const char *xml_agent_addr = "address";
+
+    agent * logr = (agent *)d1;
+
+    if (logr->server) {
+        return (0);
+    }
+
+    for (int i = 0; node[i]; i++) {
+        XML_NODE chld_node = NULL;
+
+        if (!node[i]->element || strcmp(node[i]->element, xml_agent_server) != 0) {
+            continue;
+        }
+
+        if (!(chld_node = OS_GetElementsbyNode(xml, node[i]))) {
+            continue;
+        }
+
+        for (int j = 0; chld_node[j]; j++) {
+            if (!chld_node[j]->element || !chld_node[j]->content ||
+                strcmp(chld_node[j]->element, xml_agent_addr) != 0) {
+                continue;
+            }
+
+            os_calloc(2, sizeof(agent_server), logr->server);
+            os_strdup(chld_node[j]->content, logr->server[0].rip);
+            if (strchr(logr->server[0].rip, ':') != NULL) {
+                os_realloc(logr->server[0].rip, IPSIZE + 1, logr->server[0].rip);
+                OS_ExpandIPv6(logr->server[0].rip, IPSIZE);
+            }
+            logr->server[0].port = DEFAULT_HTTPS_REMOTE_PORT;
+            logr->server_count = 1;
+
+            minfo("<agent><server><address> is not configured. Using <client><server><address> '%s' "
+                  "with the default port %d.", logr->server[0].rip, DEFAULT_HTTPS_REMOTE_PORT);
+
+            OS_ClearNode(chld_node);
+            return (0);
+        }
+
+        OS_ClearNode(chld_node);
+    }
+
+    return (0);
+}
+
+int Read_Agent_Shared(XML_NODE node, void *d1)
 {
     int i = 0;
 
@@ -272,22 +310,17 @@ int Read_Client_Shared(XML_NODE node, void *d1)
 }
 
 /**
- * @brief Read a <server> block, either the new <agent><server> or the legacy <client><server>.
- *
- * Both names describe the same single manager endpoint (#38103): <agent> is the
- * 5.x name and wins when both are present, and <client><server><port> is
- * ignored because it can only carry the removed 1514 port.
+ * @brief Read the <agent><server> block: the single manager endpoint.
  *
  * @param node Children of the <server> element.
  * @param logr Agent configuration to fill.
- * @param from_agent_block true when the block came from <agent>, false for <client>.
  * @return 0 on success, OS_INVALID on error.
  */
-int Read_Client_Server(XML_NODE node, agent * logr, bool from_agent_block)
+int Read_Agent_Server(XML_NODE node, agent * logr)
 {
     /* XML definitions */
-    const char *xml_client_addr = "address";
-    const char *xml_client_port = "port";
+    const char *xml_agent_addr = "address";
+    const char *xml_agent_port = "port";
     const char *xml_interface = "interface_index";
     const char *xml_protocol = "protocol";
     const char *xml_max_retries = "max_retries";
@@ -314,7 +347,7 @@ int Read_Client_Server(XML_NODE node, agent * logr, bool from_agent_block)
             return (OS_INVALID);
         }
         /* Get server address (IP or hostname) */
-        else if (strcmp(node[j]->element, xml_client_addr) == 0) {
+        else if (strcmp(node[j]->element, xml_agent_addr) == 0) {
             if (OS_IsValidIP(node[j]->content, NULL) == 1) {
                 rip = node[j]->content;
             } else if (strchr(node[j]->content, '/') ==  NULL) {
@@ -324,14 +357,7 @@ int Read_Client_Server(XML_NODE node, agent * logr, bool from_agent_block)
                 merror(AG_INV_HOST, node[j]->content);
                 return (OS_INVALID);
             }
-        } else if (strcmp(node[j]->element, xml_client_port) == 0) {
-            if (!from_agent_block) {
-                /* A legacy port only ever names the removed 1514 channel (#38103). */
-                minfo("Ignoring the <client><server><%s> option. The HTTPS port is taken from "
-                      "<agent><server><%s>.", xml_client_port, xml_client_port);
-                continue;
-            }
-
+        } else if (strcmp(node[j]->element, xml_agent_port) == 0) {
             if (!OS_StrIsNum(node[j]->content)) {
                 merror(XML_VALUEERR, node[j]->element, node[j]->content);
                 return (OS_INVALID);
@@ -373,24 +399,12 @@ int Read_Client_Server(XML_NODE node, agent * logr, bool from_agent_block)
         return (OS_INVALID);
     }
 
-    /* <agent><server> is the 5.x name for the same endpoint, so it wins over the
-     * legacy <client><server> whichever order they appear in (#38103). */
-    if (!from_agent_block && logr->flags.agent_address) {
-        minfo("Ignoring <client><server><%s>: <agent><server><%s> is already set.",
-              xml_client_addr, xml_client_addr);
-        return (0);
-    }
-
     /* Single <server> block: the last one prevails (#37702 restriction 2) and
      * server rotation is removed (restriction 3), so replace any previous entry
      * instead of appending. The array keeps a NULL-rip sentinel at index 1. */
     if (logr->server) {
         if (logr->server_count > 0) {
-            if (from_agent_block && !logr->flags.agent_address) {
-                minfo("Both <agent><server> and <client><server> are configured; <agent> prevails.");
-            } else {
-                mwarn("Only one <server> block is supported; the last one prevails.");
-            }
+            mwarn("Only one <server> block is supported; the last one prevails.");
         }
         for (int k = 0; logr->server[k].rip; k++) {
             os_free(logr->server[k].rip);
@@ -412,42 +426,17 @@ int Read_Client_Server(XML_NODE node, agent * logr, bool from_agent_block)
     logr->server[0].retry_interval = retry_interval;
     logr->server_count = 1;
 
-    if (from_agent_block) {
-        logr->flags.agent_address = 1;
-        logr->flags.agent_port = port_set ? 1 : 0;
+    if (!port_set) {
+        minfo("<agent><server><port> is not configured. Using the default port %d.",
+              DEFAULT_HTTPS_REMOTE_PORT);
     }
 
     return (0);
 }
 
-void Reconcile_Agent_Server(agent * config)
+int Read_Agent_SSL(XML_NODE node, agent * logr)
 {
-    if (!config) {
-        return;
-    }
-
-    /* A WPK upgrade never rewrites ossec.conf, so a 4.x agent reaches 5.x with
-     * only the legacy <client><server> block (#38103). */
-    if (!config->flags.agent_address) {
-        if (config->server && config->server[0].rip) {
-            minfo("<agent><server><address> is not configured. Using <client><server><address> '%s'.",
-                  config->server[0].rip);
-        } else {
-            merror("No manager address configured: set <agent><server><address>.");
-            return;
-        }
-    }
-
-    if (!config->flags.agent_port) {
-        config->server[0].port = DEFAULT_HTTPS_REMOTE_PORT;
-        minfo("<agent><server><port> is not configured. Using the default port %d.",
-              DEFAULT_HTTPS_REMOTE_PORT);
-    }
-}
-
-int Read_Client_SSL(XML_NODE node, agent * logr)
-{
-    /* XML definitions — the <client><ssl> transport block (#37702 §10). */
+    /* XML definitions — the <agent><ssl> transport block (#37702 §10). */
     const char *xml_certificate = "certificate";
     const char *xml_key = "key";
     const char *xml_certificate_authorities = "certificate_authorities";
@@ -493,7 +482,7 @@ int Read_Client_SSL(XML_NODE node, agent * logr)
     return (0);
 }
 
-int Read_Client_Report(XML_NODE node, agent_report * report)
+int Read_Agent_Report(XML_NODE node, agent_report * report)
 {
     /* XML definitions - shared by <stats_report> and <config_report> (#37843);
      * <interval> takes the usual suffixes: <interval>1h</interval>. */
@@ -538,9 +527,9 @@ int Read_Client_Report(XML_NODE node, agent_report * report)
     return (0);
 }
 
-int Read_Client_Batch(XML_NODE node, agent * logr)
+int Read_Agent_Batch(XML_NODE node, agent * logr)
 {
-    /* XML definitions - the <client><batch> block (#37835). Both accept the
+    /* XML definitions - the <agent><batch> block (#37835). Both accept the
      * usual suffixes: <size>1MB</size>, <interval>10s</interval>. */
     const char *xml_size = "size";
     const char *xml_interval = "interval";
@@ -583,7 +572,7 @@ int Read_Client_Batch(XML_NODE node, agent * logr)
     return (0);
 }
 
-int Read_Client_Enrollment(XML_NODE node, agent * logr){
+int Read_Agent_Enrollment(XML_NODE node, agent * logr){
     /* XML definitions */
     const char *xml_enabled = "enabled";
     const char *xml_manager_addr = "manager_address";
@@ -790,16 +779,16 @@ int Read_AntiTampering(XML_NODE node, void *d1) {
     return 0;
 }
 
-int Test_Client(const char * path){
+int Test_Agent(const char * path){
     int fail = 0;
-    agent test_client = { .server = NULL };
+    agent test_agent = { .server = NULL };
 
-    if (ReadConfig(CAGENT_CONFIG | CCLIENT, path, &test_client, NULL) < 0) {
+    if (ReadConfig(CAGENT_CONFIG | CCLIENT, path, &test_agent, NULL) < 0) {
 		merror(RCONFIG_ERROR,"Client", path);
 		fail = 1;
 	}
 
-    Free_Client(&test_client);
+    Free_Agent(&test_agent);
 
     if (fail) {
         return -1;
@@ -808,7 +797,7 @@ int Test_Client(const char * path){
     }
 }
 
-void Free_Client(agent * config){
+void Free_Agent(agent * config){
     if (config) {
         int i;
 

--- a/src/config/src/config.c
+++ b/src/config/src/config.c
@@ -86,11 +86,9 @@ static int read_main_elements(const OS_XML *xml, int modules,
                 goto fail;
             }
         } else if (chld_node && (strcmp(node[i]->element, osagent) == 0)) {
-            /* <agent> is <client> renamed (#38103): same reader, same remote
-             * agent.conf restrictions. */
             if (modules & CCLIENT) {
                 if (modules & CAGENT_CONFIG) {
-                    if (Read_Client_Shared(chld_node, d1) < 0) {
+                    if (Read_Agent_Shared(chld_node, d1) < 0) {
                         goto fail;
                     }
                 }
@@ -101,14 +99,17 @@ static int read_main_elements(const OS_XML *xml, int modules,
                 }
             }
         } else if (chld_node && (strcmp(node[i]->element, osclient) == 0)) {
+            /* 4.x spelled this block <client> (#38103). An upgrade never rewrites
+             * ossec.conf, so the block is still accepted, but only <server><address>
+             * is read from it - as the fallback for <agent><server><address>. */
             if (modules & CCLIENT) {
                 if (modules & CAGENT_CONFIG) {
-                    if (Read_Client_Shared(chld_node, d1) < 0){
+                    if (Read_Agent_Shared(chld_node, d1) < 0){
                         goto fail;
                     }
                 }
                 else {
-                    if (Read_Client(xml, chld_node, d1, d2) < 0){
+                    if (Read_Legacy_Client_Address(xml, chld_node, d1, d2) < 0){
                         goto fail;
                     }
                 }

--- a/src/config/src/config.c
+++ b/src/config/src/config.c
@@ -29,6 +29,7 @@ static int read_main_elements(const OS_XML *xml, int modules,
     const char *osremote = "remote";                            /* Agent Config  */
     const char *osclient = "client";                            /* Agent Config  */
     const char *osbuffer = "client_buffer";                     /* Removed in 5.0.0 (#38030) */
+    const char *osagent = "agent";                              /* Agent Config (HTTPS endpoint) */
     const char *osactiveresponse = "active-response";           /* Agent Active Response Config  */
     const char *oswmodule = "wodle";                            /* Wodle - Wazuh Module  */
     const char *oslogging = "logging";                          /* Logging Config */
@@ -83,6 +84,21 @@ static int read_main_elements(const OS_XML *xml, int modules,
         } else if (chld_node && (strcmp(node[i]->element, osremote) == 0)) {
             if ((modules & CREMOTE) && (Read_Remote(xml, chld_node, d1, d2) < 0)) {
                 goto fail;
+            }
+        } else if (chld_node && (strcmp(node[i]->element, osagent) == 0)) {
+            /* <agent> is <client> renamed (#38103): same reader, same remote
+             * agent.conf restrictions. */
+            if (modules & CCLIENT) {
+                if (modules & CAGENT_CONFIG) {
+                    if (Read_Client_Shared(chld_node, d1) < 0) {
+                        goto fail;
+                    }
+                }
+                else {
+                    if (Read_Agent(xml, chld_node, d1, d2) < 0) {
+                        goto fail;
+                    }
+                }
             }
         } else if (chld_node && (strcmp(node[i]->element, osclient) == 0)) {
             if (modules & CCLIENT) {

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -351,7 +351,8 @@ WriteAgent()
     echo "" >> $NEWCONFIG
 
     echo "<ossec_config>" >> $NEWCONFIG
-    echo "  <client>" >> $NEWCONFIG
+    # <client> is renamed to <agent> in 5.x: same options, new block name.
+    echo "  <agent>" >> $NEWCONFIG
     echo "    <server>" >> $NEWCONFIG
     if [ "X${HNAME}" = "X" ]; then
       echo "      <address>$SERVER_IP</address>" >> $NEWCONFIG
@@ -382,7 +383,7 @@ WriteAgent()
     fi
     echo "    <notify_time>20</notify_time>" >> $NEWCONFIG
     echo "    <auto_restart>yes</auto_restart>" >> $NEWCONFIG
-    echo "  </client>" >> $NEWCONFIG
+    echo "  </agent>" >> $NEWCONFIG
     echo "" >> $NEWCONFIG
 
     # Rootcheck

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -47,6 +47,63 @@ else
     exit 1
 fi
 
+# Read the first <tag> nested in <block> from the agent configuration
+xml_value() {
+    tr -d '\n\r' < ./etc/ossec.conf 2>/dev/null | grep -o "<$1>.*</$1>" | \
+        grep -o "<$2>[^<]*</$2>" | head -1 | sed -e "s|<$2>||" -e "s|</$2>||" -e 's|^ *||' -e 's| *$||'
+}
+
+# Check that the manager accepts connections on the HTTPS control port. There is
+# no `timeout` on macOS, so the connection attempt runs in the background and is
+# killed after PROBE_TIMEOUT seconds.
+probe_manager() {
+    PROBE_TIMEOUT=5
+    ( exec 3<>"/dev/tcp/${1}/${2}" ) > /dev/null 2>&1 &
+    PROBE_PID=$!
+    WAITED=0
+    while kill -0 ${PROBE_PID} 2>/dev/null && [ ${WAITED} -lt ${PROBE_TIMEOUT} ]; do
+        sleep 1
+        WAITED=$((WAITED + 1))
+    done
+    if kill -0 ${PROBE_PID} 2>/dev/null; then
+        kill -9 ${PROBE_PID} 2>/dev/null
+        wait ${PROBE_PID} 2>/dev/null
+        return 1
+    fi
+    wait ${PROBE_PID}
+    return $?
+}
+
+# The 5x agent requires the manager address inside the <agent> block, falling back to the <client> block when upgrading from 4x versions.
+MANAGER_ADDRESS=$(xml_value agent address)
+if [ -z "${MANAGER_ADDRESS}" ]; then
+    MANAGER_ADDRESS=$(xml_value client address)
+fi
+
+# The 5x agent requires the manager port inside the <agent> block, falling back to 1517 when upgrading from 4x versions.
+MANAGER_PORT=$(xml_value agent port)
+if [ -z "${MANAGER_PORT}" ]; then
+    MANAGER_PORT=1517
+fi
+
+if [ -z "${MANAGER_ADDRESS}" ]; then
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. No manager address found in the configuration." >> ./logs/upgrade.log
+    echo -ne "2" > ./var/upgrade/upgrade_result
+    rm -f $LOCK
+    exit 1
+fi
+
+echo "$(date +"%Y/%m/%d %H:%M:%S") - Checking connectivity to ${MANAGER_ADDRESS}:${MANAGER_PORT}." >> ./logs/upgrade.log
+
+if ! probe_manager "${MANAGER_ADDRESS}" "${MANAGER_PORT}"; then
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. The manager is not reachable at ${MANAGER_ADDRESS}:${MANAGER_PORT}, interrupting upgrade." >> ./logs/upgrade.log
+    echo -ne "2" > ./var/upgrade/upgrade_result
+    rm -f $LOCK
+    exit 1
+fi
+
+echo "$(date +"%Y/%m/%d %H:%M:%S") - Manager reachable at ${MANAGER_ADDRESS}:${MANAGER_PORT}." >> ./logs/upgrade.log
+
 if [[ "$OS" == "Darwin" ]]; then
     installer -pkg ./var/upgrade/wazuh-agent* -target / >> ./logs/upgrade.log 2>&1
 elif [[ "$OS" == "Linux" ]]; then

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -53,10 +53,10 @@ xml_value() {
         grep -o "<$2>[^<]*</$2>" | head -1 | sed -e "s|<$2>||" -e "s|</$2>||" -e 's|^ *||' -e 's| *$||'
 }
 
-# Check that the manager accepts connections on the HTTPS control port. There is
+# Check that the server accepts connections on the HTTPS control port. There is
 # no `timeout` on macOS, so the connection attempt runs in the background and is
 # killed after PROBE_TIMEOUT seconds.
-probe_manager() {
+probe_server() {
     PROBE_TIMEOUT=5
     ( exec 3<>"/dev/tcp/${1}/${2}" ) > /dev/null 2>&1 &
     PROBE_PID=$!
@@ -74,35 +74,35 @@ probe_manager() {
     return $?
 }
 
-# The 5x agent requires the manager address inside the <agent> block, falling back to the <client> block when upgrading from 4x versions.
-MANAGER_ADDRESS=$(xml_value agent address)
-if [ -z "${MANAGER_ADDRESS}" ]; then
-    MANAGER_ADDRESS=$(xml_value client address)
+# The 5x agent reads the server address from the <agent> block, falling back to the <client> block when upgrading from 4x versions.
+SERVER_ADDRESS=$(xml_value agent address)
+if [ -z "${SERVER_ADDRESS}" ]; then
+    SERVER_ADDRESS=$(xml_value client address)
 fi
 
-# The 5x agent requires the manager port inside the <agent> block, falling back to 1517 when upgrading from 4x versions.
-MANAGER_PORT=$(xml_value agent port)
-if [ -z "${MANAGER_PORT}" ]; then
-    MANAGER_PORT=1517
+# The 5x agent reads the server port from the <agent> block, falling back to 1517 when upgrading from 4x versions.
+SERVER_PORT=$(xml_value agent port)
+if [ -z "${SERVER_PORT}" ]; then
+    SERVER_PORT=1517
 fi
 
-if [ -z "${MANAGER_ADDRESS}" ]; then
+if [ -z "${SERVER_ADDRESS}" ]; then
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. No manager address found in the configuration." >> ./logs/upgrade.log
     echo -ne "2" > ./var/upgrade/upgrade_result
     rm -f $LOCK
     exit 1
 fi
 
-echo "$(date +"%Y/%m/%d %H:%M:%S") - Checking connectivity to ${MANAGER_ADDRESS}:${MANAGER_PORT}." >> ./logs/upgrade.log
+echo "$(date +"%Y/%m/%d %H:%M:%S") - Checking connectivity to ${SERVER_ADDRESS}:${SERVER_PORT}." >> ./logs/upgrade.log
 
-if ! probe_manager "${MANAGER_ADDRESS}" "${MANAGER_PORT}"; then
-    echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. The manager is not reachable at ${MANAGER_ADDRESS}:${MANAGER_PORT}, interrupting upgrade." >> ./logs/upgrade.log
+if ! probe_server "${SERVER_ADDRESS}" "${SERVER_PORT}"; then
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. The manager is not reachable at ${SERVER_ADDRESS}:${SERVER_PORT}, interrupting upgrade." >> ./logs/upgrade.log
     echo -ne "2" > ./var/upgrade/upgrade_result
     rm -f $LOCK
     exit 1
 fi
 
-echo "$(date +"%Y/%m/%d %H:%M:%S") - Manager reachable at ${MANAGER_ADDRESS}:${MANAGER_PORT}." >> ./logs/upgrade.log
+echo "$(date +"%Y/%m/%d %H:%M:%S") - Manager reachable at ${SERVER_ADDRESS}:${SERVER_PORT}." >> ./logs/upgrade.log
 
 if [[ "$OS" == "Darwin" ]]; then
     installer -pkg ./var/upgrade/wazuh-agent* -target / >> ./logs/upgrade.log 2>&1

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -47,17 +47,29 @@ else
     exit 1
 fi
 
-# Read the first <tag> nested in <block> from the agent configuration
+# Read <block><sub><tag> from the agent configuration, taking the last match.
 xml_value() {
     tr -d '\n\r' < ./etc/ossec.conf 2>/dev/null | grep -o "<$1>.*</$1>" | \
-        grep -o "<$2>[^<]*</$2>" | head -1 | sed -e "s|<$2>||" -e "s|</$2>||" -e 's|^ *||' -e 's| *$||'
+        grep -o "<$2>.*</$2>" | grep -o "<$3>[^<]*</$3>" | tail -1 | \
+        sed -e "s|<$3>||" -e "s|</$3>||" -e 's|^ *||' -e 's| *$||'
 }
 
-# Check that the server accepts connections on the HTTPS control port. There is
-# no `timeout` on macOS, so the connection attempt runs in the background and is
-# killed after PROBE_TIMEOUT seconds.
+# Check that the manager answers on the HTTPS control port. GET / is remoted's
+# unauthenticated health probe and returns 200 {"status":"ok","module":"remoted"}
 probe_server() {
     PROBE_TIMEOUT=5
+
+    if command -v curl > /dev/null 2>&1; then
+        curl -k -s -f -m ${PROBE_TIMEOUT} -o /dev/null "https://${1}:${2}/"
+        return $?
+    fi
+
+    if command -v wget > /dev/null 2>&1; then
+        wget -q --no-check-certificate --timeout=${PROBE_TIMEOUT} --tries=1 -O /dev/null "https://${1}:${2}/"
+        return $?
+    fi
+
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Neither curl nor wget found, falling back to a TCP connectivity check." >> ./logs/upgrade.log
     ( exec 3<>"/dev/tcp/${1}/${2}" ) > /dev/null 2>&1 &
     PROBE_PID=$!
     WAITED=0
@@ -75,13 +87,13 @@ probe_server() {
 }
 
 # The 5x agent reads the server address from the <agent> block, falling back to the <client> block when upgrading from 4x versions.
-SERVER_ADDRESS=$(xml_value agent address)
+SERVER_ADDRESS=$(xml_value agent server address)
 if [ -z "${SERVER_ADDRESS}" ]; then
-    SERVER_ADDRESS=$(xml_value client address)
+    SERVER_ADDRESS=$(xml_value client server address)
 fi
 
 # The 5x agent reads the server port from the <agent> block, falling back to 1517 when upgrading from 4x versions.
-SERVER_PORT=$(xml_value agent port)
+SERVER_PORT=$(xml_value agent server port)
 if [ -z "${SERVER_PORT}" ]; then
     SERVER_PORT=1517
 fi

--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -81,7 +81,13 @@ add_adress_block() {
         echo "    </server>"
     } >> "${TMP_SERVER}"
 
-    ${sed} "/<client>/r ${TMP_SERVER}" "${CONF_FILE}"
+    # A 5.x package ships <agent>, but a package upgrade preserves the 4.x file, so
+    # WAZUH_MANAGER can land on a configuration that still spells the block <client>.
+    if grep -q "<agent>" "${CONF_FILE}"; then
+        ${sed} "/<agent>/r ${TMP_SERVER}" "${CONF_FILE}"
+    else
+        ${sed} "/<client>/r ${TMP_SERVER}" "${CONF_FILE}"
+    fi
 
     rm -f "${TMP_SERVER}"
 

--- a/src/shared/include/defs.h
+++ b/src/shared/include/defs.h
@@ -343,6 +343,10 @@ https://www.gnu.org/licenses/gpl.html\n"
 #define DEFAULT_REMOTE_PORT 1514 /* Default encrypted */
 #endif
 
+#ifndef DEFAULT_HTTPS_REMOTE_PORT
+#define DEFAULT_HTTPS_REMOTE_PORT 1517 /* Default agent HTTPS control port */
+#endif
+
 #ifndef O_CLOEXEC
 #define O_CLOEXEC 0
 #endif

--- a/src/unit_tests/client-agent/test_https_client_bridge.c
+++ b/src/unit_tests/client-agent/test_https_client_bridge.c
@@ -1844,7 +1844,7 @@ static void test_upgrade_thread_module_accepts_counts_dispatched(void **state)
     expect_string(__wrap__minfo, formatted_msg,
                   "https_client: remote_upgrade task t-up dispatched to the upgrade module "
                   "(installer running; the agent may restart shortly). No /control response is "
-                  "sent (fire-and-forget, #37834).");
+                  "sent.");
     expect_value(__wrap_w_agentd_state_update, type, INCREMENT_TASK_DISPATCHED);
     expect_value(__wrap_w_agentd_state_update, data, NULL);
 
@@ -1887,7 +1887,7 @@ static void test_upgrade_thread_lock_restart_connect_failure_still_dispatches(vo
     expect_string(__wrap__minfo, formatted_msg,
                   "https_client: remote_upgrade task t-up dispatched to the upgrade module "
                   "(installer running; the agent may restart shortly). No /control response is "
-                  "sent (fire-and-forget, #37834).");
+                  "sent.");
     expect_value(__wrap_w_agentd_state_update, type, INCREMENT_TASK_DISPATCHED);
     expect_value(__wrap_w_agentd_state_update, data, NULL);
 
@@ -1931,7 +1931,7 @@ static void test_upgrade_thread_lock_restart_send_failure_still_dispatches(void 
     expect_string(__wrap__minfo, formatted_msg,
                   "https_client: remote_upgrade task t-up dispatched to the upgrade module "
                   "(installer running; the agent may restart shortly). No /control response is "
-                  "sent (fire-and-forget, #37834).");
+                  "sent.");
     expect_value(__wrap_w_agentd_state_update, type, INCREMENT_TASK_DISPATCHED);
     expect_value(__wrap_w_agentd_state_update, data, NULL);
 

--- a/src/unit_tests/config/test_client-config_https.c
+++ b/src/unit_tests/config/test_client-config_https.c
@@ -20,38 +20,18 @@
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../wrappers/wazuh/shared/validate_op_wrappers.h"
 
-/* Read_Client_Server validates every <address> through OS_IsValidIP; queue one
+/* Read_Agent_Server validates every <address> through OS_IsValidIP; queue one
  * "valid IPv4, no expansion needed" expectation per <address> in the fragment
- * before calling parse_client(). */
+ * before calling parse_agent(). */
 static void expect_valid_ip(const char *ip) {
     expect_string(__wrap_OS_IsValidIP, ip_address, ip);
     expect_value(__wrap_OS_IsValidIP, final_ip, NULL);
     will_return(__wrap_OS_IsValidIP, 1);
 }
 
-/* Parses `xml_str` as the body of <client>...</client> into a fresh agent
- * struct via the real Read_Client. Caller must Free_Client + OS_ClearNode +
+/* Parses `xml_str` as the body of <agent>...</agent> into a fresh agent
+ * struct via the real Read_Agent. Caller must Free_Agent + OS_ClearNode +
  * OS_ClearXML the outputs. */
-static int parse_client_into(const char *xml_str, OS_XML *xml, xml_node ***nodes, agent *cfg) {
-    if (OS_ReadXMLString(xml_str, xml) != 0) {
-        return OS_INVALID;
-    }
-
-    if (*nodes = OS_GetElementsbyNode(xml, NULL), *nodes == NULL) {
-        return OS_INVALID;
-    }
-
-    return Read_Client(xml, *nodes, cfg, NULL);
-}
-
-static int parse_client(const char *xml_str, OS_XML *xml, xml_node ***nodes, agent *cfg) {
-    memset(cfg, 0, sizeof(*cfg));
-
-    return parse_client_into(xml_str, xml, nodes, cfg);
-}
-
-/* Parses `xml_str` as the body of <agent>...</agent>. Does not reset cfg, so it
- * can run before or after parse_client() on the same struct. */
 static int parse_agent_into(const char *xml_str, OS_XML *xml, xml_node ***nodes, agent *cfg) {
     if (OS_ReadXMLString(xml_str, xml) != 0) {
         return OS_INVALID;
@@ -70,8 +50,22 @@ static int parse_agent(const char *xml_str, OS_XML *xml, xml_node ***nodes, agen
     return parse_agent_into(xml_str, xml, nodes, cfg);
 }
 
+/* Parses `xml_str` as the body of a legacy 4.x <client>...</client>. Does not reset
+ * cfg, so it can run after parse_agent() on the same struct. */
+static int parse_legacy_client(const char *xml_str, OS_XML *xml, xml_node ***nodes, agent *cfg) {
+    if (OS_ReadXMLString(xml_str, xml) != 0) {
+        return OS_INVALID;
+    }
+
+    if (*nodes = OS_GetElementsbyNode(xml, NULL), *nodes == NULL) {
+        return OS_INVALID;
+    }
+
+    return Read_Legacy_Client_Address(xml, *nodes, cfg, NULL);
+}
+
 static void cleanup(OS_XML *xml, xml_node **nodes, agent *cfg) {
-    Free_Client(cfg);
+    Free_Agent(cfg);
     OS_ClearNode(nodes);
     OS_ClearXML(xml);
 }
@@ -84,7 +78,7 @@ static void test_ssl_full_verification_mode(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address></server>"
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
         "<ssl>"
         "<certificate>/etc/wazuh/agent.pem</certificate>"
         "<key>/etc/wazuh/agent.key</key>"
@@ -94,7 +88,7 @@ static void test_ssl_full_verification_mode(void **state) {
         "</ssl>";
 
     expect_valid_ip("10.0.0.1");
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
 
     assert_int_equal(cfg.ssl.verification_mode, AGENT_VERIFY_FULL);
     assert_string_equal(cfg.ssl.certificate, "/etc/wazuh/agent.pem");
@@ -111,11 +105,11 @@ static void test_ssl_certificate_verification_mode(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address></server>"
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
         "<ssl><verification_mode>certificate</verification_mode></ssl>";
 
     expect_valid_ip("10.0.0.1");
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
     assert_int_equal(cfg.ssl.verification_mode, AGENT_VERIFY_CERT);
 
     cleanup(&xml, nodes, &cfg);
@@ -127,11 +121,11 @@ static void test_ssl_none_verification_mode(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address></server>"
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
         "<ssl><verification_mode>none</verification_mode></ssl>";
 
     expect_valid_ip("10.0.0.1");
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
     assert_int_equal(cfg.ssl.verification_mode, AGENT_VERIFY_NONE);
 
     cleanup(&xml, nodes, &cfg);
@@ -145,10 +139,10 @@ static void test_ssl_default_is_full(void **state) {
     /* No <ssl> block at all: zero-initialized struct must read as FULL
      * (AGENT_VERIFY_FULL == 0), so an agent that forgets TLS config still
      * fails closed rather than silently disabling verification. */
-    const char *xml_str = "<server><address>10.0.0.1</address></server>";
+    const char *xml_str = "<server><address>10.0.0.1</address><port>1517</port></server>";
 
     expect_valid_ip("10.0.0.1");
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
     assert_int_equal(cfg.ssl.verification_mode, AGENT_VERIFY_FULL);
 
     cleanup(&xml, nodes, &cfg);
@@ -160,14 +154,14 @@ static void test_ssl_invalid_verification_mode_is_rejected(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address></server>"
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
         "<ssl><verification_mode>bogus</verification_mode></ssl>";
 
     expect_valid_ip("10.0.0.1");
     expect_string(__wrap__merror, formatted_msg,
                   "(1235): Invalid value for element 'verification_mode': bogus.");
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), OS_INVALID);
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -178,21 +172,21 @@ static void test_ssl_invalid_tag_is_rejected(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address></server>"
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
         "<ssl><bogus_tag>x</bogus_tag></ssl>";
 
     expect_valid_ip("10.0.0.1");
     expect_string(__wrap__merror, formatted_msg,
                   "(1230): Invalid element in the configuration: 'bogus_tag'.");
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), OS_INVALID);
 
     cleanup(&xml, nodes, &cfg);
 }
 
-/* <server> / <manager> naming (issue #37828, epic #37702 §10 decision: <server> canonical) */
+/* <server> naming and the endpoint it carries */
 
-static void test_server_tag_is_canonical_no_warning(void **state) {
+static void test_server_address_and_explicit_port(void **state) {
     OS_XML xml = {0};
     xml_node **nodes;
     agent cfg;
@@ -200,38 +194,27 @@ static void test_server_tag_is_canonical_no_warning(void **state) {
     const char *xml_str = "<server><address>10.0.0.1</address><port>8443</port></server>";
 
     expect_valid_ip("10.0.0.1");
-    expect_string(__wrap__minfo, formatted_msg,
-                  "Ignoring the <client><server><port> option. The HTTPS port is taken from "
-                  "<agent><server><port>.");
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
 
     assert_int_equal(cfg.server_count, 1);
     assert_string_equal(cfg.server[0].rip, "10.0.0.1");
-    assert_int_equal(cfg.server[0].port, DEFAULT_HTTPS_REMOTE_PORT);
+    assert_int_equal(cfg.server[0].port, 8443);
 
     cleanup(&xml, nodes, &cfg);
 }
 
-static void test_manager_tag_is_deprecated_but_works(void **state) {
+static void test_manager_tag_is_rejected(void **state) {
     OS_XML xml = {0};
     xml_node **nodes;
     agent cfg;
 
-    const char *xml_str = "<manager><address>10.0.0.1</address><port>8443</port></manager>";
+    const char *xml_str = "<manager><address>10.0.0.1</address></manager>";
 
-    expect_valid_ip("10.0.0.1");
-    expect_string(__wrap__minfo, formatted_msg,
-                  "The <manager> tag is deprecated, please use <server> instead.");
-    expect_string(__wrap__minfo, formatted_msg,
-                  "Ignoring the <client><server><port> option. The HTTPS port is taken from "
-                  "<agent><server><port>.");
+    expect_string(__wrap__merror, formatted_msg,
+                  "(1230): Invalid element in the configuration: 'manager'.");
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
-
-    assert_int_equal(cfg.server_count, 1);
-    assert_string_equal(cfg.server[0].rip, "10.0.0.1");
-    assert_int_equal(cfg.server[0].port, DEFAULT_HTTPS_REMOTE_PORT);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), OS_INVALID);
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -249,25 +232,19 @@ static void test_second_server_block_prevails_with_warning(void **state) {
 
     expect_valid_ip("10.0.0.1");
     expect_valid_ip("10.0.0.2");
-    expect_string(__wrap__minfo, formatted_msg,
-                  "Ignoring the <client><server><port> option. The HTTPS port is taken from "
-                  "<agent><server><port>.");
-    expect_string(__wrap__minfo, formatted_msg,
-                  "Ignoring the <client><server><port> option. The HTTPS port is taken from "
-                  "<agent><server><port>.");
     expect_string(__wrap__mwarn, formatted_msg,
                   "Only one <server> block is supported; the last one prevails.");
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
 
     assert_int_equal(cfg.server_count, 1);
     assert_string_equal(cfg.server[0].rip, "10.0.0.2");
-    assert_int_equal(cfg.server[0].port, DEFAULT_HTTPS_REMOTE_PORT);
+    assert_int_equal(cfg.server[0].port, 8443);
 
     cleanup(&xml, nodes, &cfg);
 }
 
-/* <agent><server>: the 5.x endpoint and its fallbacks (#38103) */
+/* <agent><server> and the one value still read from a legacy <client> (#38103) */
 
 static void test_agent_server_address_and_port_are_parsed(void **state) {
     OS_XML xml = {0};
@@ -283,11 +260,6 @@ static void test_agent_server_address_and_port_are_parsed(void **state) {
     assert_int_equal(cfg.server_count, 1);
     assert_string_equal(cfg.server[0].rip, "10.0.0.5");
     assert_int_equal(cfg.server[0].port, 1600);
-    assert_int_equal(cfg.flags.agent_address, 1);
-    assert_int_equal(cfg.flags.agent_port, 1);
-
-    Reconcile_Agent_Server(&cfg);
-    assert_int_equal(cfg.server[0].port, 1600);
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -300,63 +272,99 @@ static void test_agent_server_port_defaults_to_1517(void **state) {
     const char *xml_str = "<server><address>10.0.0.5</address></server>";
 
     expect_valid_ip("10.0.0.5");
-
-    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
-    assert_int_equal(cfg.flags.agent_port, 0);
-
     expect_string(__wrap__minfo, formatted_msg,
                   "<agent><server><port> is not configured. Using the default port 1517.");
 
-    Reconcile_Agent_Server(&cfg);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
     assert_int_equal(cfg.server[0].port, DEFAULT_HTTPS_REMOTE_PORT);
 
     cleanup(&xml, nodes, &cfg);
 }
 
-static void test_agent_server_address_falls_back_to_client(void **state) {
+static void test_legacy_client_address_is_the_fallback(void **state) {
     OS_XML xml = {0};
     xml_node **nodes;
     agent cfg;
 
-    /* What a 4.x agent upgraded over WPK looks like: only the legacy block. */
-    const char *xml_str = "<server><address>10.0.0.1</address></server>";
-
-    expect_valid_ip("10.0.0.1");
-
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
-    assert_int_equal(cfg.flags.agent_address, 0);
+    memset(&cfg, 0, sizeof(cfg));
 
     expect_string(__wrap__minfo, formatted_msg,
-                  "<agent><server><address> is not configured. Using <client><server><address> '10.0.0.1'.");
-    expect_string(__wrap__minfo, formatted_msg,
-                  "<agent><server><port> is not configured. Using the default port 1517.");
+                  "<agent><server><address> is not configured. Using <client><server><address> "
+                  "'10.0.0.1' with the default port 1517.");
 
-    Reconcile_Agent_Server(&cfg);
+    assert_int_equal(parse_legacy_client("<server><address>10.0.0.1</address><port>1517</port></server>",
+                                         &xml, &nodes, &cfg), 0);
 
+    assert_int_equal(cfg.server_count, 1);
     assert_string_equal(cfg.server[0].rip, "10.0.0.1");
     assert_int_equal(cfg.server[0].port, DEFAULT_HTTPS_REMOTE_PORT);
 
     cleanup(&xml, nodes, &cfg);
 }
 
-static void test_agent_block_prevails_when_read_after_client(void **state) {
-    OS_XML client_xml = {0};
+static void test_legacy_client_reads_nothing_but_the_address(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str =
+        "<server><address>10.0.0.1</address><port>1514</port><protocol>tcp</protocol></server>"
+        "<crypto_method>aes</crypto_method>"
+        "<config-profile>ubuntu, ubuntu22</config-profile>"
+        "<notify_time>77</notify_time>"
+        "<enrollment><enabled>yes</enabled></enrollment>";
+
+    memset(&cfg, 0, sizeof(cfg));
+
+    expect_string(__wrap__minfo, formatted_msg,
+                  "<agent><server><address> is not configured. Using <client><server><address> "
+                  "'10.0.0.1' with the default port 1517.");
+
+    assert_int_equal(parse_legacy_client(xml_str, &xml, &nodes, &cfg), 0);
+
+    assert_int_equal(cfg.server[0].port, DEFAULT_HTTPS_REMOTE_PORT);
+    assert_int_equal(cfg.notify_time, 0);
+    assert_null(cfg.profile);
+    assert_null(cfg.enrollment_cfg);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_legacy_client_without_an_address_sets_no_server(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    memset(&cfg, 0, sizeof(cfg));
+
+    assert_int_equal(parse_legacy_client("<config-profile>ubuntu</config-profile>",
+                                         &xml, &nodes, &cfg), 0);
+
+    assert_null(cfg.server);
+    assert_int_equal(cfg.server_count, 0);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_agent_block_replaces_a_legacy_address(void **state) {
+    OS_XML legacy_xml = {0};
     OS_XML agent_xml = {0};
-    xml_node **client_nodes;
+    xml_node **legacy_nodes;
     xml_node **agent_nodes;
     agent cfg;
 
-    expect_valid_ip("10.0.0.1");
-    expect_string(__wrap__minfo, formatted_msg,
-                  "Ignoring the <client><server><port> option. The HTTPS port is taken from "
-                  "<agent><server><port>.");
+    memset(&cfg, 0, sizeof(cfg));
 
-    assert_int_equal(parse_client("<server><address>10.0.0.1</address><port>1514</port></server>",
-                                  &client_xml, &client_nodes, &cfg), 0);
+    expect_string(__wrap__minfo, formatted_msg,
+                  "<agent><server><address> is not configured. Using <client><server><address> "
+                  "'10.0.0.1' with the default port 1517.");
+
+    assert_int_equal(parse_legacy_client("<server><address>10.0.0.1</address><port>1517</port></server>",
+                                         &legacy_xml, &legacy_nodes, &cfg), 0);
 
     expect_valid_ip("10.0.0.5");
-    expect_string(__wrap__minfo, formatted_msg,
-                  "Both <agent><server> and <client><server> are configured; <agent> prevails.");
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "Only one <server> block is supported; the last one prevails.");
 
     assert_int_equal(parse_agent_into("<server><address>10.0.0.5</address><port>1600</port></server>",
                                       &agent_xml, &agent_nodes, &cfg), 0);
@@ -365,16 +373,16 @@ static void test_agent_block_prevails_when_read_after_client(void **state) {
     assert_string_equal(cfg.server[0].rip, "10.0.0.5");
     assert_int_equal(cfg.server[0].port, 1600);
 
-    OS_ClearNode(client_nodes);
-    OS_ClearXML(&client_xml);
+    OS_ClearNode(legacy_nodes);
+    OS_ClearXML(&legacy_xml);
     cleanup(&agent_xml, agent_nodes, &cfg);
 }
 
-static void test_agent_block_prevails_when_read_before_client(void **state) {
-    OS_XML client_xml = {0};
+static void test_legacy_client_is_ignored_once_agent_set_the_address(void **state) {
     OS_XML agent_xml = {0};
-    xml_node **client_nodes;
+    OS_XML legacy_xml = {0};
     xml_node **agent_nodes;
+    xml_node **legacy_nodes;
     agent cfg;
 
     expect_valid_ip("10.0.0.5");
@@ -382,27 +390,20 @@ static void test_agent_block_prevails_when_read_before_client(void **state) {
     assert_int_equal(parse_agent("<server><address>10.0.0.5</address><port>1600</port></server>",
                                  &agent_xml, &agent_nodes, &cfg), 0);
 
-    expect_valid_ip("10.0.0.1");
-    expect_string(__wrap__minfo, formatted_msg,
-                  "Ignoring the <client><server><port> option. The HTTPS port is taken from "
-                  "<agent><server><port>.");
-    expect_string(__wrap__minfo, formatted_msg,
-                  "Ignoring <client><server><address>: <agent><server><address> is already set.");
-
-    assert_int_equal(parse_client_into("<server><address>10.0.0.1</address><port>1514</port></server>",
-                                       &client_xml, &client_nodes, &cfg), 0);
+    assert_int_equal(parse_legacy_client("<server><address>10.0.0.1</address><port>1517</port></server>",
+                                         &legacy_xml, &legacy_nodes, &cfg), 0);
 
     assert_int_equal(cfg.server_count, 1);
     assert_string_equal(cfg.server[0].rip, "10.0.0.5");
     assert_int_equal(cfg.server[0].port, 1600);
 
-    OS_ClearNode(client_nodes);
-    OS_ClearXML(&client_xml);
+    OS_ClearNode(legacy_nodes);
+    OS_ClearXML(&legacy_xml);
     cleanup(&agent_xml, agent_nodes, &cfg);
 }
 
 /* What the 5.x templates ship (etc/ossec-agent.conf, src/win32/ossec.conf): the whole
- * block renamed, so every <client> option is now read under <agent>. */
+ * block renamed, so every 4.x <client> option is now read under <agent>. */
 static void test_fresh_install_template_shape(void **state) {
     OS_XML xml = {0};
     xml_node **nodes;
@@ -422,15 +423,10 @@ static void test_fresh_install_template_shape(void **state) {
     assert_int_equal(cfg.server_count, 1);
     assert_string_equal(cfg.server[0].rip, "10.0.0.1");
     assert_int_equal(cfg.server[0].port, DEFAULT_HTTPS_REMOTE_PORT);
-    assert_int_equal(cfg.flags.agent_address, 1);
-    assert_int_equal(cfg.flags.agent_port, 1);
     assert_int_equal(cfg.ssl.verification_mode, AGENT_VERIFY_FULL);
     assert_string_equal(cfg.profile, "debian, debian8");
     assert_int_equal(cfg.notify_time, 20);
     assert_int_equal(cfg.flags.auto_restart, 1);
-
-    /* Nothing to reconcile: both options came from <agent>, so no log is emitted. */
-    Reconcile_Agent_Server(&cfg);
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -449,17 +445,6 @@ static void test_agent_invalid_tag_is_rejected(void **state) {
     cleanup(&xml, nodes, &cfg);
 }
 
-static void test_reconcile_without_any_address_fails(void **state) {
-    agent cfg;
-
-    memset(&cfg, 0, sizeof(cfg));
-
-    expect_string(__wrap__merror, formatted_msg,
-                  "No manager address configured: set <agent><server><address>.");
-
-    Reconcile_Agent_Server(&cfg);
-}
-
 /* <batch>: accepted, ignored here (owned by the events module, issue 06) */
 
 static void test_batch_size_and_interval_are_parsed(void **state) {
@@ -468,12 +453,12 @@ static void test_batch_size_and_interval_are_parsed(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address></server>"
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
         "<batch><size>1MB</size><interval>10s</interval></batch>";
 
     expect_valid_ip("10.0.0.1");
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
     assert_int_equal(cfg.batch.size, 1024 * 1024);
     assert_int_equal(cfg.batch.interval, 10);
 
@@ -486,11 +471,11 @@ static void test_batch_is_unset_when_absent(void **state) {
     agent cfg;
 
     /* Zero is what the transport module reads as "apply your own default". */
-    const char *xml_str = "<server><address>10.0.0.1</address></server>";
+    const char *xml_str = "<server><address>10.0.0.1</address><port>1517</port></server>";
 
     expect_valid_ip("10.0.0.1");
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
     assert_int_equal(cfg.batch.size, 0);
     assert_int_equal(cfg.batch.interval, 0);
 
@@ -503,12 +488,12 @@ static void test_batch_size_without_a_suffix_is_bytes(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address></server>"
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
         "<batch><size>2048</size></batch>";
 
     expect_valid_ip("10.0.0.1");
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
     assert_int_equal(cfg.batch.size, 2048);
 
     cleanup(&xml, nodes, &cfg);
@@ -522,14 +507,14 @@ static void test_batch_zero_size_is_rejected(void **state) {
     /* A zero payload can never carry an event; refuse it rather than let it
      * read as "unset" and silently fall back to the default. */
     const char *xml_str =
-        "<server><address>10.0.0.1</address></server>"
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
         "<batch><size>0</size></batch>";
 
     expect_valid_ip("10.0.0.1");
     expect_string(__wrap__merror, formatted_msg,
                   "(1235): Invalid value for element 'size': 0.");
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), OS_INVALID);
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -540,14 +525,14 @@ static void test_batch_interval_beyond_a_day_is_rejected(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address></server>"
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
         "<batch><interval>2d</interval></batch>";
 
     expect_valid_ip("10.0.0.1");
     expect_string(__wrap__merror, formatted_msg,
                   "(1235): Invalid value for element 'interval': 2d.");
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), OS_INVALID);
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -558,13 +543,13 @@ static void test_batch_invalid_tag_is_rejected(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address></server>"
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
         "<batch><nonsense>1</nonsense></batch>";
 
     expect_valid_ip("10.0.0.1");
     expect_string(__wrap__merror, formatted_msg, "(1230): Invalid element in the configuration: 'nonsense'.");
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), OS_INVALID);
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -577,14 +562,14 @@ static void test_time_reconnect_is_deprecated(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address></server>"
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
         "<time-reconnect>60</time-reconnect>";
 
     expect_valid_ip("10.0.0.1");
     expect_string(__wrap__mwarn, formatted_msg,
                   "The <time-reconnect> option is deprecated and no longer has any effect.");
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -594,13 +579,13 @@ static void test_max_retries_is_deprecated(void **state) {
     xml_node **nodes;
     agent cfg;
 
-    const char *xml_str = "<server><address>10.0.0.1</address><max_retries>3</max_retries></server>";
+    const char *xml_str = "<server><address>10.0.0.1</address><port>1517</port><max_retries>3</max_retries></server>";
 
     expect_valid_ip("10.0.0.1");
     expect_string(__wrap__mwarn, formatted_msg,
                   "The <max_retries> option is deprecated and no longer has any effect.");
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -610,13 +595,13 @@ static void test_retry_interval_is_deprecated(void **state) {
     xml_node **nodes;
     agent cfg;
 
-    const char *xml_str = "<server><address>10.0.0.1</address><retry_interval>5</retry_interval></server>";
+    const char *xml_str = "<server><address>10.0.0.1</address><port>1517</port><retry_interval>5</retry_interval></server>";
 
     expect_valid_ip("10.0.0.1");
     expect_string(__wrap__mwarn, formatted_msg,
                   "The <retry_interval> option is deprecated and no longer has any effect.");
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -631,11 +616,11 @@ static void test_reports_are_off_when_absent(void **state) {
 
     /* Both pushes must default to off: the manager's config/stats indices have
      * a single writer, and nobody asked for it yet. */
-    const char *xml_str = "<server><address>10.0.0.1</address></server>";
+    const char *xml_str = "<server><address>10.0.0.1</address><port>1517</port></server>";
 
     expect_valid_ip("10.0.0.1");
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
     assert_int_equal(cfg.stats_report.enabled, 0);
     assert_int_equal(cfg.config_report.enabled, 0);
     assert_int_equal(cfg.stats_report.interval, 0);
@@ -652,12 +637,12 @@ static void test_reports_are_independent_of_each_other(void **state) {
     /* The issue requires two separate toggles: enabling stats must leave the
      * config push alone. */
     const char *xml_str =
-        "<server><address>10.0.0.1</address></server>"
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
         "<stats_report><enabled>yes</enabled><interval>30s</interval></stats_report>";
 
     expect_valid_ip("10.0.0.1");
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
     assert_int_equal(cfg.stats_report.enabled, 1);
     assert_int_equal(cfg.stats_report.interval, 30);
     assert_int_equal(cfg.config_report.enabled, 0);
@@ -671,13 +656,13 @@ static void test_reports_accept_time_suffixes(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address></server>"
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
         "<stats_report><enabled>yes</enabled><interval>2m</interval></stats_report>"
         "<config_report><enabled>yes</enabled><interval>1h</interval></config_report>";
 
     expect_valid_ip("10.0.0.1");
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
     assert_int_equal(cfg.stats_report.interval, 120);
     assert_int_equal(cfg.config_report.interval, 3600);
 
@@ -690,13 +675,13 @@ static void test_report_enabled_rejects_a_non_boolean(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address></server>"
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
         "<config_report><enabled>maybe</enabled></config_report>";
 
     expect_valid_ip("10.0.0.1");
     expect_any(__wrap__merror, formatted_msg);
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), OS_INVALID);
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -707,13 +692,13 @@ static void test_report_interval_beyond_a_day_is_rejected(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address></server>"
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
         "<stats_report><interval>2d</interval></stats_report>";
 
     expect_valid_ip("10.0.0.1");
     expect_any(__wrap__merror, formatted_msg);
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), OS_INVALID);
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -724,13 +709,13 @@ static void test_report_invalid_tag_is_rejected(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address></server>"
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
         "<stats_report><cadence>30s</cadence></stats_report>";
 
     expect_valid_ip("10.0.0.1");
     expect_any(__wrap__merror, formatted_msg);
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), OS_INVALID);
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -743,17 +728,18 @@ int main(void) {
         cmocka_unit_test(test_ssl_default_is_full),
         cmocka_unit_test(test_ssl_invalid_verification_mode_is_rejected),
         cmocka_unit_test(test_ssl_invalid_tag_is_rejected),
-        cmocka_unit_test(test_server_tag_is_canonical_no_warning),
-        cmocka_unit_test(test_manager_tag_is_deprecated_but_works),
+        cmocka_unit_test(test_server_address_and_explicit_port),
+        cmocka_unit_test(test_manager_tag_is_rejected),
         cmocka_unit_test(test_second_server_block_prevails_with_warning),
         cmocka_unit_test(test_agent_server_address_and_port_are_parsed),
         cmocka_unit_test(test_agent_server_port_defaults_to_1517),
-        cmocka_unit_test(test_agent_server_address_falls_back_to_client),
-        cmocka_unit_test(test_agent_block_prevails_when_read_after_client),
-        cmocka_unit_test(test_agent_block_prevails_when_read_before_client),
+        cmocka_unit_test(test_legacy_client_address_is_the_fallback),
+        cmocka_unit_test(test_legacy_client_reads_nothing_but_the_address),
+        cmocka_unit_test(test_legacy_client_without_an_address_sets_no_server),
+        cmocka_unit_test(test_agent_block_replaces_a_legacy_address),
+        cmocka_unit_test(test_legacy_client_is_ignored_once_agent_set_the_address),
         cmocka_unit_test(test_fresh_install_template_shape),
         cmocka_unit_test(test_agent_invalid_tag_is_rejected),
-        cmocka_unit_test(test_reconcile_without_any_address_fails),
         cmocka_unit_test(test_batch_size_and_interval_are_parsed),
         cmocka_unit_test(test_batch_is_unset_when_absent),
         cmocka_unit_test(test_batch_size_without_a_suffix_is_bytes),

--- a/src/unit_tests/config/test_client-config_https.c
+++ b/src/unit_tests/config/test_client-config_https.c
@@ -330,6 +330,29 @@ static void test_legacy_client_reads_nothing_but_the_address(void **state) {
     cleanup(&xml, nodes, &cfg);
 }
 
+static void test_legacy_client_takes_the_last_address(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str =
+        "<server><address>10.0.0.1</address></server>"
+        "<server><address>10.0.0.2</address></server>";
+
+    memset(&cfg, 0, sizeof(cfg));
+
+    expect_string(__wrap__minfo, formatted_msg,
+                  "<agent><server><address> is not configured. Using <client><server><address> "
+                  "'10.0.0.2' with the default port 1517.");
+
+    assert_int_equal(parse_legacy_client(xml_str, &xml, &nodes, &cfg), 0);
+
+    assert_int_equal(cfg.server_count, 1);
+    assert_string_equal(cfg.server[0].rip, "10.0.0.2");
+
+    cleanup(&xml, nodes, &cfg);
+}
+
 static void test_legacy_client_without_an_address_sets_no_server(void **state) {
     OS_XML xml = {0};
     xml_node **nodes;
@@ -735,6 +758,7 @@ int main(void) {
         cmocka_unit_test(test_agent_server_port_defaults_to_1517),
         cmocka_unit_test(test_legacy_client_address_is_the_fallback),
         cmocka_unit_test(test_legacy_client_reads_nothing_but_the_address),
+        cmocka_unit_test(test_legacy_client_takes_the_last_address),
         cmocka_unit_test(test_legacy_client_without_an_address_sets_no_server),
         cmocka_unit_test(test_agent_block_replaces_a_legacy_address),
         cmocka_unit_test(test_legacy_client_is_ignored_once_agent_set_the_address),

--- a/src/unit_tests/config/test_client-config_https.c
+++ b/src/unit_tests/config/test_client-config_https.c
@@ -32,9 +32,7 @@ static void expect_valid_ip(const char *ip) {
 /* Parses `xml_str` as the body of <client>...</client> into a fresh agent
  * struct via the real Read_Client. Caller must Free_Client + OS_ClearNode +
  * OS_ClearXML the outputs. */
-static int parse_client(const char *xml_str, OS_XML *xml, xml_node ***nodes, agent *cfg) {
-    memset(cfg, 0, sizeof(*cfg));
-
+static int parse_client_into(const char *xml_str, OS_XML *xml, xml_node ***nodes, agent *cfg) {
     if (OS_ReadXMLString(xml_str, xml) != 0) {
         return OS_INVALID;
     }
@@ -44,6 +42,32 @@ static int parse_client(const char *xml_str, OS_XML *xml, xml_node ***nodes, age
     }
 
     return Read_Client(xml, *nodes, cfg, NULL);
+}
+
+static int parse_client(const char *xml_str, OS_XML *xml, xml_node ***nodes, agent *cfg) {
+    memset(cfg, 0, sizeof(*cfg));
+
+    return parse_client_into(xml_str, xml, nodes, cfg);
+}
+
+/* Parses `xml_str` as the body of <agent>...</agent>. Does not reset cfg, so it
+ * can run before or after parse_client() on the same struct. */
+static int parse_agent_into(const char *xml_str, OS_XML *xml, xml_node ***nodes, agent *cfg) {
+    if (OS_ReadXMLString(xml_str, xml) != 0) {
+        return OS_INVALID;
+    }
+
+    if (*nodes = OS_GetElementsbyNode(xml, NULL), *nodes == NULL) {
+        return OS_INVALID;
+    }
+
+    return Read_Agent(xml, *nodes, cfg, NULL);
+}
+
+static int parse_agent(const char *xml_str, OS_XML *xml, xml_node ***nodes, agent *cfg) {
+    memset(cfg, 0, sizeof(*cfg));
+
+    return parse_agent_into(xml_str, xml, nodes, cfg);
 }
 
 static void cleanup(OS_XML *xml, xml_node **nodes, agent *cfg) {
@@ -176,11 +200,15 @@ static void test_server_tag_is_canonical_no_warning(void **state) {
     const char *xml_str = "<server><address>10.0.0.1</address><port>8443</port></server>";
 
     expect_valid_ip("10.0.0.1");
+    expect_string(__wrap__minfo, formatted_msg,
+                  "Ignoring the <client><server><port> option. The HTTPS port is taken from "
+                  "<agent><server><port>.");
+
     assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
 
     assert_int_equal(cfg.server_count, 1);
     assert_string_equal(cfg.server[0].rip, "10.0.0.1");
-    assert_int_equal(cfg.server[0].port, 8443);
+    assert_int_equal(cfg.server[0].port, DEFAULT_HTTPS_REMOTE_PORT);
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -195,12 +223,15 @@ static void test_manager_tag_is_deprecated_but_works(void **state) {
     expect_valid_ip("10.0.0.1");
     expect_string(__wrap__minfo, formatted_msg,
                   "The <manager> tag is deprecated, please use <server> instead.");
+    expect_string(__wrap__minfo, formatted_msg,
+                  "Ignoring the <client><server><port> option. The HTTPS port is taken from "
+                  "<agent><server><port>.");
 
     assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
 
     assert_int_equal(cfg.server_count, 1);
     assert_string_equal(cfg.server[0].rip, "10.0.0.1");
-    assert_int_equal(cfg.server[0].port, 8443);
+    assert_int_equal(cfg.server[0].port, DEFAULT_HTTPS_REMOTE_PORT);
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -218,6 +249,12 @@ static void test_second_server_block_prevails_with_warning(void **state) {
 
     expect_valid_ip("10.0.0.1");
     expect_valid_ip("10.0.0.2");
+    expect_string(__wrap__minfo, formatted_msg,
+                  "Ignoring the <client><server><port> option. The HTTPS port is taken from "
+                  "<agent><server><port>.");
+    expect_string(__wrap__minfo, formatted_msg,
+                  "Ignoring the <client><server><port> option. The HTTPS port is taken from "
+                  "<agent><server><port>.");
     expect_string(__wrap__mwarn, formatted_msg,
                   "Only one <server> block is supported; the last one prevails.");
 
@@ -225,9 +262,202 @@ static void test_second_server_block_prevails_with_warning(void **state) {
 
     assert_int_equal(cfg.server_count, 1);
     assert_string_equal(cfg.server[0].rip, "10.0.0.2");
-    assert_int_equal(cfg.server[0].port, 8443);
+    assert_int_equal(cfg.server[0].port, DEFAULT_HTTPS_REMOTE_PORT);
 
     cleanup(&xml, nodes, &cfg);
+}
+
+/* <agent><server>: the 5.x endpoint and its fallbacks (#38103) */
+
+static void test_agent_server_address_and_port_are_parsed(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str = "<server><address>10.0.0.5</address><port>1600</port></server>";
+
+    expect_valid_ip("10.0.0.5");
+
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
+
+    assert_int_equal(cfg.server_count, 1);
+    assert_string_equal(cfg.server[0].rip, "10.0.0.5");
+    assert_int_equal(cfg.server[0].port, 1600);
+    assert_int_equal(cfg.flags.agent_address, 1);
+    assert_int_equal(cfg.flags.agent_port, 1);
+
+    Reconcile_Agent_Server(&cfg);
+    assert_int_equal(cfg.server[0].port, 1600);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_agent_server_port_defaults_to_1517(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str = "<server><address>10.0.0.5</address></server>";
+
+    expect_valid_ip("10.0.0.5");
+
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(cfg.flags.agent_port, 0);
+
+    expect_string(__wrap__minfo, formatted_msg,
+                  "<agent><server><port> is not configured. Using the default port 1517.");
+
+    Reconcile_Agent_Server(&cfg);
+    assert_int_equal(cfg.server[0].port, DEFAULT_HTTPS_REMOTE_PORT);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_agent_server_address_falls_back_to_client(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    /* What a 4.x agent upgraded over WPK looks like: only the legacy block. */
+    const char *xml_str = "<server><address>10.0.0.1</address></server>";
+
+    expect_valid_ip("10.0.0.1");
+
+    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(cfg.flags.agent_address, 0);
+
+    expect_string(__wrap__minfo, formatted_msg,
+                  "<agent><server><address> is not configured. Using <client><server><address> '10.0.0.1'.");
+    expect_string(__wrap__minfo, formatted_msg,
+                  "<agent><server><port> is not configured. Using the default port 1517.");
+
+    Reconcile_Agent_Server(&cfg);
+
+    assert_string_equal(cfg.server[0].rip, "10.0.0.1");
+    assert_int_equal(cfg.server[0].port, DEFAULT_HTTPS_REMOTE_PORT);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_agent_block_prevails_when_read_after_client(void **state) {
+    OS_XML client_xml = {0};
+    OS_XML agent_xml = {0};
+    xml_node **client_nodes;
+    xml_node **agent_nodes;
+    agent cfg;
+
+    expect_valid_ip("10.0.0.1");
+    expect_string(__wrap__minfo, formatted_msg,
+                  "Ignoring the <client><server><port> option. The HTTPS port is taken from "
+                  "<agent><server><port>.");
+
+    assert_int_equal(parse_client("<server><address>10.0.0.1</address><port>1514</port></server>",
+                                  &client_xml, &client_nodes, &cfg), 0);
+
+    expect_valid_ip("10.0.0.5");
+    expect_string(__wrap__minfo, formatted_msg,
+                  "Both <agent><server> and <client><server> are configured; <agent> prevails.");
+
+    assert_int_equal(parse_agent_into("<server><address>10.0.0.5</address><port>1600</port></server>",
+                                      &agent_xml, &agent_nodes, &cfg), 0);
+
+    assert_int_equal(cfg.server_count, 1);
+    assert_string_equal(cfg.server[0].rip, "10.0.0.5");
+    assert_int_equal(cfg.server[0].port, 1600);
+
+    OS_ClearNode(client_nodes);
+    OS_ClearXML(&client_xml);
+    cleanup(&agent_xml, agent_nodes, &cfg);
+}
+
+static void test_agent_block_prevails_when_read_before_client(void **state) {
+    OS_XML client_xml = {0};
+    OS_XML agent_xml = {0};
+    xml_node **client_nodes;
+    xml_node **agent_nodes;
+    agent cfg;
+
+    expect_valid_ip("10.0.0.5");
+
+    assert_int_equal(parse_agent("<server><address>10.0.0.5</address><port>1600</port></server>",
+                                 &agent_xml, &agent_nodes, &cfg), 0);
+
+    expect_valid_ip("10.0.0.1");
+    expect_string(__wrap__minfo, formatted_msg,
+                  "Ignoring the <client><server><port> option. The HTTPS port is taken from "
+                  "<agent><server><port>.");
+    expect_string(__wrap__minfo, formatted_msg,
+                  "Ignoring <client><server><address>: <agent><server><address> is already set.");
+
+    assert_int_equal(parse_client_into("<server><address>10.0.0.1</address><port>1514</port></server>",
+                                       &client_xml, &client_nodes, &cfg), 0);
+
+    assert_int_equal(cfg.server_count, 1);
+    assert_string_equal(cfg.server[0].rip, "10.0.0.5");
+    assert_int_equal(cfg.server[0].port, 1600);
+
+    OS_ClearNode(client_nodes);
+    OS_ClearXML(&client_xml);
+    cleanup(&agent_xml, agent_nodes, &cfg);
+}
+
+/* What the 5.x templates ship (etc/ossec-agent.conf, src/win32/ossec.conf): the whole
+ * block renamed, so every <client> option is now read under <agent>. */
+static void test_fresh_install_template_shape(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str =
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<ssl><verification_mode>full</verification_mode></ssl>"
+        "<config-profile>debian, debian8</config-profile>"
+        "<notify_time>20</notify_time>"
+        "<auto_restart>yes</auto_restart>";
+
+    expect_valid_ip("10.0.0.1");
+
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
+
+    assert_int_equal(cfg.server_count, 1);
+    assert_string_equal(cfg.server[0].rip, "10.0.0.1");
+    assert_int_equal(cfg.server[0].port, DEFAULT_HTTPS_REMOTE_PORT);
+    assert_int_equal(cfg.flags.agent_address, 1);
+    assert_int_equal(cfg.flags.agent_port, 1);
+    assert_int_equal(cfg.ssl.verification_mode, AGENT_VERIFY_FULL);
+    assert_string_equal(cfg.profile, "debian, debian8");
+    assert_int_equal(cfg.notify_time, 20);
+    assert_int_equal(cfg.flags.auto_restart, 1);
+
+    /* Nothing to reconcile: both options came from <agent>, so no log is emitted. */
+    Reconcile_Agent_Server(&cfg);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_agent_invalid_tag_is_rejected(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str = "<nonsense>1</nonsense>";
+
+    expect_string(__wrap__merror, formatted_msg, "(1230): Invalid element in the configuration: 'nonsense'.");
+
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_reconcile_without_any_address_fails(void **state) {
+    agent cfg;
+
+    memset(&cfg, 0, sizeof(cfg));
+
+    expect_string(__wrap__merror, formatted_msg,
+                  "No manager address configured: set <agent><server><address>.");
+
+    Reconcile_Agent_Server(&cfg);
 }
 
 /* <batch>: accepted, ignored here (owned by the events module, issue 06) */
@@ -516,6 +746,14 @@ int main(void) {
         cmocka_unit_test(test_server_tag_is_canonical_no_warning),
         cmocka_unit_test(test_manager_tag_is_deprecated_but_works),
         cmocka_unit_test(test_second_server_block_prevails_with_warning),
+        cmocka_unit_test(test_agent_server_address_and_port_are_parsed),
+        cmocka_unit_test(test_agent_server_port_defaults_to_1517),
+        cmocka_unit_test(test_agent_server_address_falls_back_to_client),
+        cmocka_unit_test(test_agent_block_prevails_when_read_after_client),
+        cmocka_unit_test(test_agent_block_prevails_when_read_before_client),
+        cmocka_unit_test(test_fresh_install_template_shape),
+        cmocka_unit_test(test_agent_invalid_tag_is_rejected),
+        cmocka_unit_test(test_reconcile_without_any_address_fails),
         cmocka_unit_test(test_batch_size_and_interval_are_parsed),
         cmocka_unit_test(test_batch_is_unset_when_absent),
         cmocka_unit_test(test_batch_size_without_a_suffix_is_bytes),

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_agent.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_agent.c
@@ -31,6 +31,9 @@
 #ifndef TEST_WINAGENT
 void* wm_agent_upgrade_listen_messages(void *arg);
 #endif
+void wm_agent_upgrade_check_status(void);
+bool wm_upgrade_agent_search_upgrade_result(int *queue_fd);
+void wm_upgrade_agent_send_result_event(int *queue_fd, wm_upgrade_agent_state state, unsigned int raw_code);
 bool wm_agent_upgrade_is_shutting_down(void);
 
 // Setup / teardown
@@ -67,6 +70,554 @@ int __wrap_CreateThread(void * (*function_pointer)(void *), void *data) {
 }
 
 // Tests
+
+void test_wm_upgrade_agent_send_result_event_successful(void **state)
+{
+    (void) state;
+    int queue = 0;
+    int result = 0;
+    wm_upgrade_agent_state upgrade_state = WM_UPGRADE_SUCCESSFUL;
+
+    expect_value(__wrap_wm_sendmsg, usec, 1000000);
+    expect_value(__wrap_wm_sendmsg, queue, queue);
+    expect_string(__wrap_wm_sendmsg, message, "{\"collector\":\"upgrade_result\","
+                                               "\"module\":\"agent-upgrade\","
+                                               "\"data\":{\"error\":0,"
+                                                       "\"message\":\"Upgrade was successful\","
+                                                       "\"status\":\"Done\"}}");
+    expect_string(__wrap_wm_sendmsg, locmsg, AGENT_UPGRADE_WM_NAME);
+    expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
+
+    will_return(__wrap_wm_sendmsg, result);
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:agent-upgrade");
+    expect_string(__wrap__mtdebug1, formatted_msg, "(8163): Sending upgrade ACK event: "
+                                                   "'{\"collector\":\"upgrade_result\","
+                                                     "\"module\":\"agent-upgrade\","
+                                                     "\"data\":{\"error\":0,"
+                                                             "\"message\":\"Upgrade was successful\","
+                                                             "\"status\":\"Done\"}}'");
+
+    wm_upgrade_agent_send_result_event(&queue, upgrade_state, (unsigned int)upgrade_state);
+
+    assert_int_equal(queue, 0);
+}
+
+void test_wm_upgrade_agent_send_result_event_failed(void **state)
+{
+    (void) state;
+    int queue = 0;
+    int result = 0;
+    wm_upgrade_agent_state upgrade_state = WM_UPGRADE_FAILED;
+
+    expect_value(__wrap_wm_sendmsg, usec, 1000000);
+    expect_value(__wrap_wm_sendmsg, queue, queue);
+    expect_string(__wrap_wm_sendmsg, message, "{\"collector\":\"upgrade_result\","
+                                               "\"module\":\"agent-upgrade\","
+                                               "\"data\":{\"error\":2,"
+                                                       "\"message\":\"Upgrade failed\","
+                                                       "\"status\":\"Failed\"}}");
+    expect_string(__wrap_wm_sendmsg, locmsg, AGENT_UPGRADE_WM_NAME);
+    expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
+
+    will_return(__wrap_wm_sendmsg, result);
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:agent-upgrade");
+    expect_string(__wrap__mtdebug1, formatted_msg, "(8163): Sending upgrade ACK event: "
+                                                   "'{\"collector\":\"upgrade_result\","
+                                                     "\"module\":\"agent-upgrade\","
+                                                     "\"data\":{\"error\":2,"
+                                                             "\"message\":\"Upgrade failed\","
+                                                             "\"status\":\"Failed\"}}'");
+
+    wm_upgrade_agent_send_result_event(&queue, upgrade_state, (unsigned int)upgrade_state);
+
+    assert_int_equal(queue, 0);
+}
+
+void test_wm_upgrade_agent_send_result_event_error(void **state)
+{
+    (void) state;
+    int queue = 0;
+    int result = -1;
+    wm_upgrade_agent_state upgrade_state = WM_UPGRADE_FAILED;
+
+    expect_value(__wrap_wm_sendmsg, usec, 1000000);
+    expect_value(__wrap_wm_sendmsg, queue, queue);
+    expect_string(__wrap_wm_sendmsg, message, "{\"collector\":\"upgrade_result\","
+                                               "\"module\":\"agent-upgrade\","
+                                               "\"data\":{\"error\":2,"
+                                                       "\"message\":\"Upgrade failed\","
+                                                       "\"status\":\"Failed\"}}");
+    expect_string(__wrap_wm_sendmsg, locmsg, AGENT_UPGRADE_WM_NAME);
+    expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
+
+    will_return(__wrap_wm_sendmsg, result);
+
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:agent-upgrade");
+    expect_string(__wrap__mterror, formatted_msg, "(1210): Queue 'queue/sockets/queue' not accessible: 'Success'");
+
+    expect_string(__wrap_StartMQPredicated, path, DEFAULTQUEUE);
+    expect_value(__wrap_StartMQPredicated, type, WRITE);
+    expect_value(__wrap_StartMQPredicated, fn_ptr, wm_agent_upgrade_is_shutting_down);
+    will_return(__wrap_StartMQPredicated, 1);
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:agent-upgrade");
+    expect_string(__wrap__mtdebug1, formatted_msg, "(8163): Sending upgrade ACK event: "
+                                                   "'{\"collector\":\"upgrade_result\","
+                                                     "\"module\":\"agent-upgrade\","
+                                                     "\"data\":{\"error\":2,"
+                                                             "\"message\":\"Upgrade failed\","
+                                                             "\"status\":\"Failed\"}}'");
+
+    wm_upgrade_agent_send_result_event(&queue, upgrade_state, (unsigned int)upgrade_state);
+
+    assert_int_equal(queue, 1);
+}
+
+void test_wm_upgrade_agent_send_result_event_error_exit(void **state)
+{
+    (void) state;
+    int queue = 0;
+    int result = -1;
+    wm_upgrade_agent_state upgrade_state = WM_UPGRADE_FAILED;
+
+    expect_value(__wrap_wm_sendmsg, usec, 1000000);
+    expect_value(__wrap_wm_sendmsg, queue, queue);
+    expect_string(__wrap_wm_sendmsg, message, "{\"collector\":\"upgrade_result\","
+                                               "\"module\":\"agent-upgrade\","
+                                               "\"data\":{\"error\":2,"
+                                                       "\"message\":\"Upgrade failed\","
+                                                       "\"status\":\"Failed\"}}");
+    expect_string(__wrap_wm_sendmsg, locmsg, AGENT_UPGRADE_WM_NAME);
+    expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
+
+    will_return(__wrap_wm_sendmsg, result);
+
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:agent-upgrade");
+    expect_string(__wrap__mterror, formatted_msg, "(1210): Queue 'queue/sockets/queue' not accessible: 'Success'");
+
+    expect_string(__wrap_StartMQPredicated, path, DEFAULTQUEUE);
+    expect_value(__wrap_StartMQPredicated, type, WRITE);
+    expect_value(__wrap_StartMQPredicated, fn_ptr, wm_agent_upgrade_is_shutting_down);
+    will_return(__wrap_StartMQPredicated, -1);
+
+    expect_string(__wrap__mterror_exit, tag, "wazuh-modulesd:agent-upgrade");
+    expect_string(__wrap__mterror_exit, formatted_msg, "(1211): Unable to access queue: 'queue/sockets/queue'. Giving up.");
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:agent-upgrade");
+    expect_string(__wrap__mtdebug1, formatted_msg, "(8163): Sending upgrade ACK event: "
+                                                   "'{\"collector\":\"upgrade_result\","
+                                                     "\"module\":\"agent-upgrade\","
+                                                     "\"data\":{\"error\":2,"
+                                                             "\"message\":\"Upgrade failed\","
+                                                             "\"status\":\"Failed\"}}'");
+
+    wm_upgrade_agent_send_result_event(&queue, upgrade_state, (unsigned int)upgrade_state);
+
+    assert_int_equal(queue, -1);
+}
+
+void test_wm_upgrade_agent_send_result_event_shutdown(void **state)
+{
+    (void) state;
+    int queue = 0;
+    int result = -1;
+    wm_upgrade_agent_state upgrade_state = WM_UPGRADE_FAILED;
+
+    expect_value(__wrap_wm_sendmsg, usec, 1000000);
+    expect_value(__wrap_wm_sendmsg, queue, queue);
+    expect_string(__wrap_wm_sendmsg, message, "{\"collector\":\"upgrade_result\","
+                                               "\"module\":\"agent-upgrade\","
+                                               "\"data\":{\"error\":2,"
+                                                       "\"message\":\"Upgrade failed\","
+                                                       "\"status\":\"Failed\"}}");
+    expect_string(__wrap_wm_sendmsg, locmsg, AGENT_UPGRADE_WM_NAME);
+    expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
+
+    will_return(__wrap_wm_sendmsg, result);
+
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:agent-upgrade");
+    expect_string(__wrap__mterror, formatted_msg, "(1210): Queue 'queue/sockets/queue' not accessible: 'Success'");
+
+    expect_string(__wrap_StartMQPredicated, path, DEFAULTQUEUE);
+    expect_value(__wrap_StartMQPredicated, type, WRITE);
+    expect_value(__wrap_StartMQPredicated, fn_ptr, wm_agent_upgrade_is_shutting_down);
+    will_return(__wrap_StartMQPredicated, OS_INVALID);
+
+    // Simulates SIGTERM arriving during the StartMQPredicated retry loop: the
+    // predicate fires, the wrapper returns OS_INVALID, and the function must
+    // return without escalating to mterror_exit.
+    wm_shutdown_requested = 1;
+
+    wm_upgrade_agent_send_result_event(&queue, upgrade_state, (unsigned int)upgrade_state);
+
+    assert_int_equal(queue, OS_INVALID);
+
+    wm_shutdown_requested = 0;
+}
+
+void test_wm_upgrade_agent_search_upgrade_result_successful(void **state)
+{
+    (void) state;
+    int queue = 0;
+    int result = 0;
+    wm_upgrade_agent_state upgrade_state = WM_UPGRADE_SUCCESSFUL;
+
+    expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, (FILE*)1);
+
+#ifdef TEST_WINAGENT
+    expect_value(wrap_fgets, __stream, (FILE*)1);
+    will_return(wrap_fgets, "0\n");
+#else
+    expect_value(__wrap_fgets, __stream, (FILE*)1);
+    will_return(__wrap_fgets, "0\n");
+#endif
+
+    expect_value(__wrap_fclose, _File, (FILE*)1);
+    will_return(__wrap_fclose, 1);
+
+    expect_value(__wrap_wm_sendmsg, usec, 1000000);
+    expect_value(__wrap_wm_sendmsg, queue, queue);
+    expect_string(__wrap_wm_sendmsg, message, "{\"collector\":\"upgrade_result\","
+                                               "\"module\":\"agent-upgrade\","
+                                               "\"data\":{\"error\":0,"
+                                                       "\"message\":\"Upgrade was successful\","
+                                                       "\"status\":\"Done\"}}");
+    expect_string(__wrap_wm_sendmsg, locmsg, AGENT_UPGRADE_WM_NAME);
+    expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
+
+    will_return(__wrap_wm_sendmsg, result);
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:agent-upgrade");
+    expect_string(__wrap__mtdebug1, formatted_msg, "(8163): Sending upgrade ACK event: "
+                                                   "'{\"collector\":\"upgrade_result\","
+                                                     "\"module\":\"agent-upgrade\","
+                                                     "\"data\":{\"error\":0,"
+                                                             "\"message\":\"Upgrade was successful\","
+                                                             "\"status\":\"Done\"}}'");
+
+    expect_string(__wrap_remove, filename, WM_AGENT_UPGRADE_RESULT_FILE);
+    will_return(__wrap_remove, 0);
+
+    int ret = wm_upgrade_agent_search_upgrade_result(&queue);
+
+    assert_int_equal(ret, 0);
+    assert_int_equal(queue, 0);
+}
+
+void test_wm_upgrade_agent_search_upgrade_result_failed_missing_dependency(void **state)
+{
+    (void) state;
+    int queue = 0;
+    int result = 0;
+
+    expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, (FILE*)1);
+
+#ifdef TEST_WINAGENT
+    expect_value(wrap_fgets, __stream, (FILE*)1);
+    will_return(wrap_fgets, "1\n");
+#else
+    expect_value(__wrap_fgets, __stream, (FILE*)1);
+    will_return(__wrap_fgets, "1\n");
+#endif
+
+    expect_value(__wrap_fclose, _File, (FILE*)1);
+    will_return(__wrap_fclose, 1);
+
+    expect_value(__wrap_wm_sendmsg, usec, 1000000);
+    expect_value(__wrap_wm_sendmsg, queue, queue);
+    expect_string(__wrap_wm_sendmsg, message, "{\"collector\":\"upgrade_result\","
+                                               "\"module\":\"agent-upgrade\","
+                                               "\"data\":{\"error\":1,"
+                                                       "\"message\":\"Upgrade failed: intermediate version required\","
+                                                       "\"status\":\"Failed\"}}");
+    expect_string(__wrap_wm_sendmsg, locmsg, AGENT_UPGRADE_WM_NAME);
+    expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
+
+    will_return(__wrap_wm_sendmsg, result);
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:agent-upgrade");
+    expect_string(__wrap__mtdebug1, formatted_msg, "(8163): Sending upgrade ACK event: "
+                                                   "'{\"collector\":\"upgrade_result\","
+                                                     "\"module\":\"agent-upgrade\","
+                                                     "\"data\":{\"error\":1,"
+                                                             "\"message\":\"Upgrade failed: intermediate version required\","
+                                                             "\"status\":\"Failed\"}}'");
+
+    expect_string(__wrap_remove, filename, WM_AGENT_UPGRADE_RESULT_FILE);
+    will_return(__wrap_remove, 0);
+
+    int ret = wm_upgrade_agent_search_upgrade_result(&queue);
+
+    assert_int_equal(ret, 0);
+    assert_int_equal(queue, 0);
+}
+
+void test_wm_upgrade_agent_search_upgrade_result_failed(void **state)
+{
+    (void) state;
+    int queue = 0;
+    int result = 0;
+    wm_upgrade_agent_state upgrade_state = WM_UPGRADE_FAILED;
+
+    expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, (FILE*)1);
+
+#ifdef TEST_WINAGENT
+    expect_value(wrap_fgets, __stream, (FILE*)1);
+    will_return(wrap_fgets, "2\n");
+#else
+    expect_value(__wrap_fgets, __stream, (FILE*)1);
+    will_return(__wrap_fgets, "2\n");
+#endif
+
+    expect_value(__wrap_fclose, _File, (FILE*)1);
+    will_return(__wrap_fclose, 1);
+
+    expect_value(__wrap_wm_sendmsg, usec, 1000000);
+    expect_value(__wrap_wm_sendmsg, queue, queue);
+    expect_string(__wrap_wm_sendmsg, message, "{\"collector\":\"upgrade_result\","
+                                               "\"module\":\"agent-upgrade\","
+                                               "\"data\":{\"error\":2,"
+                                                       "\"message\":\"Upgrade failed\","
+                                                       "\"status\":\"Failed\"}}");
+    expect_string(__wrap_wm_sendmsg, locmsg, AGENT_UPGRADE_WM_NAME);
+    expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
+
+    will_return(__wrap_wm_sendmsg, result);
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:agent-upgrade");
+    expect_string(__wrap__mtdebug1, formatted_msg, "(8163): Sending upgrade ACK event: "
+                                                   "'{\"collector\":\"upgrade_result\","
+                                                     "\"module\":\"agent-upgrade\","
+                                                     "\"data\":{\"error\":2,"
+                                                             "\"message\":\"Upgrade failed\","
+                                                             "\"status\":\"Failed\"}}'");
+
+    expect_string(__wrap_remove, filename, WM_AGENT_UPGRADE_RESULT_FILE);
+    will_return(__wrap_remove, 0);
+
+    int ret = wm_upgrade_agent_search_upgrade_result(&queue);
+
+    assert_int_equal(ret, 0);
+    assert_int_equal(queue, 0);
+}
+
+void test_wm_upgrade_agent_search_upgrade_result_error_open(void **state)
+{
+    (void) state;
+    int queue = 0;
+    int result = 0;
+    wm_upgrade_agent_state upgrade_state = WM_UPGRADE_FAILED;
+
+    expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, NULL);
+
+    int ret = wm_upgrade_agent_search_upgrade_result(&queue);
+
+    assert_int_equal(ret, 0);
+    assert_int_equal(queue, 0);
+}
+
+void test_wm_upgrade_agent_search_upgrade_result_error_code(void **state)
+{
+    (void) state;
+    int queue = 0;
+    int result = 0;
+
+    expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, (FILE*)1);
+
+#ifdef TEST_WINAGENT
+    expect_value(wrap_fgets, __stream, (FILE*)1);
+    will_return(wrap_fgets, "5\n");
+#else
+    expect_value(__wrap_fgets, __stream, (FILE*)1);
+    will_return(__wrap_fgets, "5\n");
+#endif
+
+    expect_value(__wrap_fclose, _File, (FILE*)1);
+    will_return(__wrap_fclose, 1);
+
+    expect_value(__wrap_wm_sendmsg, usec, 1000000);
+    expect_value(__wrap_wm_sendmsg, queue, queue);
+    expect_string(__wrap_wm_sendmsg, message, "{\"collector\":\"upgrade_result\","
+                                               "\"module\":\"agent-upgrade\","
+                                               "\"data\":{\"error\":5,"
+                                                       "\"message\":\"Upgrade failed\","
+                                                       "\"status\":\"Failed\"}}");
+    expect_string(__wrap_wm_sendmsg, locmsg, AGENT_UPGRADE_WM_NAME);
+    expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
+
+    will_return(__wrap_wm_sendmsg, result);
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:agent-upgrade");
+    expect_string(__wrap__mtdebug1, formatted_msg, "(8163): Sending upgrade ACK event: "
+                                                   "'{\"collector\":\"upgrade_result\","
+                                                     "\"module\":\"agent-upgrade\","
+                                                     "\"data\":{\"error\":5,"
+                                                             "\"message\":\"Upgrade failed\","
+                                                             "\"status\":\"Failed\"}}'");
+
+    expect_string(__wrap_remove, filename, WM_AGENT_UPGRADE_RESULT_FILE);
+    will_return(__wrap_remove, 0);
+
+    int ret = wm_upgrade_agent_search_upgrade_result(&queue);
+
+    assert_int_equal(ret, 0);
+    assert_int_equal(queue, 0);
+}
+void test_wm_agent_upgrade_check_status_successful(void **state)
+{
+    int queue = 0;
+    int result = 0;
+
+    expect_string(__wrap_StartMQPredicated, path, DEFAULTQUEUE);
+    expect_value(__wrap_StartMQPredicated, type, WRITE);
+    expect_value(__wrap_StartMQPredicated, fn_ptr, wm_agent_upgrade_is_shutting_down);
+    will_return(__wrap_StartMQPredicated, queue);
+
+#ifndef TEST_WINAGENT
+    expect_any_always(__wrap_sleep, seconds);
+#endif
+
+    expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, (FILE*)1);
+
+#ifdef TEST_WINAGENT
+    expect_value(wrap_fgets, __stream, (FILE*)1);
+    will_return(wrap_fgets, "0\n");
+#else
+    expect_value(__wrap_fgets, __stream, (FILE*)1);
+    will_return(__wrap_fgets, "0\n");
+#endif
+
+    expect_value(__wrap_fclose, _File, (FILE*)1);
+    will_return(__wrap_fclose, 1);
+
+    expect_value(__wrap_wm_sendmsg, usec, 1000000);
+    expect_value(__wrap_wm_sendmsg, queue, queue);
+    expect_string(__wrap_wm_sendmsg, message, "{\"collector\":\"upgrade_result\","
+                                               "\"module\":\"agent-upgrade\","
+                                               "\"data\":{\"error\":0,"
+                                                       "\"message\":\"Upgrade was successful\","
+                                                       "\"status\":\"Done\"}}");
+    expect_string(__wrap_wm_sendmsg, locmsg, AGENT_UPGRADE_WM_NAME);
+    expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
+
+    will_return(__wrap_wm_sendmsg, result);
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:agent-upgrade");
+    expect_string(__wrap__mtdebug1, formatted_msg, "(8163): Sending upgrade ACK event: "
+                                                   "'{\"collector\":\"upgrade_result\","
+                                                     "\"module\":\"agent-upgrade\","
+                                                     "\"data\":{\"error\":0,"
+                                                             "\"message\":\"Upgrade was successful\","
+                                                             "\"status\":\"Done\"}}'");
+
+    expect_string(__wrap_remove, filename, WM_AGENT_UPGRADE_RESULT_FILE);
+    will_return(__wrap_remove, 0);
+
+    wm_agent_upgrade_check_status();
+}
+
+void test_wm_agent_upgrade_check_status_retries_an_empty_result_file(void **state)
+{
+    int queue = 0;
+    int result = 0;
+
+    expect_string(__wrap_StartMQPredicated, path, DEFAULTQUEUE);
+    expect_value(__wrap_StartMQPredicated, type, WRITE);
+    expect_value(__wrap_StartMQPredicated, fn_ptr, wm_agent_upgrade_is_shutting_down);
+    will_return(__wrap_StartMQPredicated, queue);
+
+#ifndef TEST_WINAGENT
+    expect_any_always(__wrap_sleep, seconds);
+#endif
+
+    expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, (FILE*)1);
+
+#ifdef TEST_WINAGENT
+    expect_value(wrap_fgets, __stream, (FILE*)1);
+    will_return(wrap_fgets, NULL);
+#else
+    expect_value(__wrap_fgets, __stream, (FILE*)1);
+    will_return(__wrap_fgets, NULL);
+#endif
+
+    expect_value(__wrap_fclose, _File, (FILE*)1);
+    will_return(__wrap_fclose, 1);
+
+    expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, (FILE*)1);
+
+#ifdef TEST_WINAGENT
+    expect_value(wrap_fgets, __stream, (FILE*)1);
+    will_return(wrap_fgets, "2\n");
+#else
+    expect_value(__wrap_fgets, __stream, (FILE*)1);
+    will_return(__wrap_fgets, "2\n");
+#endif
+
+    expect_value(__wrap_fclose, _File, (FILE*)1);
+    will_return(__wrap_fclose, 1);
+
+    expect_value(__wrap_wm_sendmsg, usec, 1000000);
+    expect_value(__wrap_wm_sendmsg, queue, queue);
+    expect_string(__wrap_wm_sendmsg, message, "{\"collector\":\"upgrade_result\","
+                                               "\"module\":\"agent-upgrade\","
+                                               "\"data\":{\"error\":2,"
+                                                       "\"message\":\"Upgrade failed\","
+                                                       "\"status\":\"Failed\"}}");
+    expect_string(__wrap_wm_sendmsg, locmsg, AGENT_UPGRADE_WM_NAME);
+    expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
+
+    will_return(__wrap_wm_sendmsg, result);
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:agent-upgrade");
+    expect_string(__wrap__mtdebug1, formatted_msg, "(8163): Sending upgrade ACK event: "
+                                                   "'{\"collector\":\"upgrade_result\","
+                                                     "\"module\":\"agent-upgrade\","
+                                                     "\"data\":{\"error\":2,"
+                                                             "\"message\":\"Upgrade failed\","
+                                                             "\"status\":\"Failed\"}}'");
+
+    expect_string(__wrap_remove, filename, WM_AGENT_UPGRADE_RESULT_FILE);
+    will_return(__wrap_remove, 0);
+
+    wm_agent_upgrade_check_status();
+}
+
+void test_wm_agent_upgrade_check_status_queue_error(void **state)
+{
+    int queue = -1;
+
+    expect_string(__wrap_StartMQPredicated, path, DEFAULTQUEUE);
+    expect_value(__wrap_StartMQPredicated, type, WRITE);
+    expect_value(__wrap_StartMQPredicated, fn_ptr, wm_agent_upgrade_is_shutting_down);
+    will_return(__wrap_StartMQPredicated, queue);
+
+#ifndef TEST_WINAGENT
+    expect_any_always(__wrap_sleep, seconds);
+#endif
+
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:agent-upgrade");
+    expect_string(__wrap__mterror, formatted_msg, "(8113): Could not open default queue to send upgrade notification.");
+
+    wm_agent_upgrade_check_status();
+}
 
 #ifndef TEST_WINAGENT
 
@@ -411,6 +962,19 @@ void test_wm_agent_upgrade_start_agent_module_enabled(void **state)
     expect_memory(__wrap_CreateThread, function_pointer, wm_agent_upgrade_listen_messages, sizeof(wm_agent_upgrade_listen_messages));
 #endif
 
+    expect_string(__wrap_StartMQPredicated, path, DEFAULTQUEUE);
+    expect_value(__wrap_StartMQPredicated, type, WRITE);
+    expect_value(__wrap_StartMQPredicated, fn_ptr, wm_agent_upgrade_is_shutting_down);
+    will_return(__wrap_StartMQPredicated, 0);
+
+#ifndef TEST_WINAGENT
+    expect_any_always(__wrap_sleep, seconds);
+#endif
+
+    expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, NULL);
+
     wm_agent_upgrade_start_agent_module(config, 1);
 
     assert_int_equal(allow_upgrades, true);
@@ -433,6 +997,24 @@ void test_wm_agent_upgrade_start_agent_module_disabled(void **state)
 
 int main(void) {
     const struct CMUnitTest tests[] = {
+        // wm_upgrade_agent_send_result_event
+        cmocka_unit_test_setup(test_wm_upgrade_agent_send_result_event_successful, setup_test_executions),
+        cmocka_unit_test_setup(test_wm_upgrade_agent_send_result_event_failed, setup_test_executions),
+        cmocka_unit_test_setup(test_wm_upgrade_agent_send_result_event_error, setup_test_executions),
+        cmocka_unit_test_setup(test_wm_upgrade_agent_send_result_event_shutdown, setup_test_executions),
+        // test_wm_upgrade_agent_send_result_event_error_exit disabled: _mterror_exit is declared
+        // __attribute__((noreturn)), so any code after the wrapped call is undefined behavior
+        // and segfaults under ASAN. This path is not testable via cmocka without setjmp/longjmp.
+        // wm_upgrade_agent_search_upgrade_result
+        cmocka_unit_test_setup(test_wm_upgrade_agent_search_upgrade_result_successful, setup_test_executions),
+        cmocka_unit_test_setup(test_wm_upgrade_agent_search_upgrade_result_failed, setup_test_executions),
+        cmocka_unit_test_setup(test_wm_upgrade_agent_search_upgrade_result_failed_missing_dependency, setup_test_executions),
+        cmocka_unit_test_setup(test_wm_upgrade_agent_search_upgrade_result_error_open, setup_test_executions),
+        cmocka_unit_test_setup(test_wm_upgrade_agent_search_upgrade_result_error_code, setup_test_executions),
+        // wm_agent_upgrade_check_status
+        cmocka_unit_test_setup(test_wm_agent_upgrade_check_status_successful, setup_test_executions),
+        cmocka_unit_test_setup(test_wm_agent_upgrade_check_status_retries_an_empty_result_file, setup_test_executions),
+        cmocka_unit_test_setup(test_wm_agent_upgrade_check_status_queue_error, setup_test_executions),
 #ifndef TEST_WINAGENT
         // wm_agent_upgrade_listen_messages
         cmocka_unit_test(test_wm_agent_upgrade_listen_messages_ok),

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_agent.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_agent.c
@@ -69,6 +69,19 @@ int __wrap_CreateThread(void * (*function_pointer)(void *), void *data) {
     return 1;
 }
 
+/* w_is_file() is wfopen() plus fclose(), and both are wrapped here, so an upgrade
+ * marker is made to look present or absent through those. */
+static void expect_marker_probe(const char *path, int exists) {
+    expect_string(__wrap_wfopen, path, path);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, exists ? (FILE*)1 : NULL);
+
+    if (exists) {
+        expect_value(__wrap_fclose, _File, (FILE*)1);
+        will_return(__wrap_fclose, 1);
+    }
+}
+
 // Tests
 
 void test_wm_upgrade_agent_send_result_event_successful(void **state)
@@ -409,16 +422,40 @@ void test_wm_upgrade_agent_search_upgrade_result_failed(void **state)
     assert_int_equal(queue, 0);
 }
 
-void test_wm_upgrade_agent_search_upgrade_result_error_open(void **state)
+void test_wm_upgrade_agent_search_upgrade_result_not_written_yet(void **state)
 {
     (void) state;
     int queue = 0;
-    int result = 0;
-    wm_upgrade_agent_state upgrade_state = WM_UPGRADE_FAILED;
 
     expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
     expect_string(__wrap_wfopen, mode, "r");
     will_return(__wrap_wfopen, NULL);
+
+    int ret = wm_upgrade_agent_search_upgrade_result(&queue);
+
+    assert_int_equal(ret, 1);
+    assert_int_equal(queue, 0);
+}
+
+void test_wm_upgrade_agent_search_upgrade_result_unusable_content(void **state)
+{
+    (void) state;
+    int queue = 0;
+
+    expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, (FILE*)1);
+
+#ifdef TEST_WINAGENT
+    expect_value(wrap_fgets, __stream, (FILE*)1);
+    will_return(wrap_fgets, "not-a-code\n");
+#else
+    expect_value(__wrap_fgets, __stream, (FILE*)1);
+    will_return(__wrap_fgets, "not-a-code\n");
+#endif
+
+    expect_value(__wrap_fclose, _File, (FILE*)1);
+    will_return(__wrap_fclose, 1);
 
     int ret = wm_upgrade_agent_search_upgrade_result(&queue);
 
@@ -480,6 +517,8 @@ void test_wm_agent_upgrade_check_status_successful(void **state)
     int queue = 0;
     int result = 0;
 
+    expect_marker_probe(WM_AGENT_UPGRADE_RESULT_FILE, 1);
+
     expect_string(__wrap_StartMQPredicated, path, DEFAULTQUEUE);
     expect_value(__wrap_StartMQPredicated, type, WRITE);
     expect_value(__wrap_StartMQPredicated, fn_ptr, wm_agent_upgrade_is_shutting_down);
@@ -534,6 +573,8 @@ void test_wm_agent_upgrade_check_status_retries_an_empty_result_file(void **stat
 {
     int queue = 0;
     int result = 0;
+
+    expect_marker_probe(WM_AGENT_UPGRADE_RESULT_FILE, 1);
 
     expect_string(__wrap_StartMQPredicated, path, DEFAULTQUEUE);
     expect_value(__wrap_StartMQPredicated, type, WRITE);
@@ -604,6 +645,35 @@ void test_wm_agent_upgrade_check_status_queue_error(void **state)
 {
     int queue = -1;
 
+    expect_marker_probe(WM_AGENT_UPGRADE_RESULT_FILE, 1);
+
+    expect_string(__wrap_StartMQPredicated, path, DEFAULTQUEUE);
+    expect_value(__wrap_StartMQPredicated, type, WRITE);
+    expect_value(__wrap_StartMQPredicated, fn_ptr, wm_agent_upgrade_is_shutting_down);
+    will_return(__wrap_StartMQPredicated, queue);
+
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:agent-upgrade");
+    expect_string(__wrap__mterror, formatted_msg, "(8113): Could not open default queue to send upgrade notification.");
+
+    wm_agent_upgrade_check_status();
+}
+
+void test_wm_agent_upgrade_check_status_returns_when_no_upgrade_ran(void **state)
+{
+    expect_marker_probe(WM_AGENT_UPGRADE_RESULT_FILE, 0);
+    expect_marker_probe(WM_AGENT_UPGRADE_LOCK_FILE, 0);
+
+    wm_agent_upgrade_check_status();
+}
+
+void test_wm_agent_upgrade_check_status_waits_for_a_result_file_that_does_not_exist_yet(void **state)
+{
+    int queue = 0;
+    int result = 0;
+
+    expect_marker_probe(WM_AGENT_UPGRADE_RESULT_FILE, 0);
+    expect_marker_probe(WM_AGENT_UPGRADE_LOCK_FILE, 1);
+
     expect_string(__wrap_StartMQPredicated, path, DEFAULTQUEUE);
     expect_value(__wrap_StartMQPredicated, type, WRITE);
     expect_value(__wrap_StartMQPredicated, fn_ptr, wm_agent_upgrade_is_shutting_down);
@@ -613,8 +683,72 @@ void test_wm_agent_upgrade_check_status_queue_error(void **state)
     expect_any_always(__wrap_sleep, seconds);
 #endif
 
-    expect_string(__wrap__mterror, tag, "wazuh-modulesd:agent-upgrade");
-    expect_string(__wrap__mterror, formatted_msg, "(8113): Could not open default queue to send upgrade notification.");
+    expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, NULL);
+
+    expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
+    expect_string(__wrap_wfopen, mode, "r");
+    will_return(__wrap_wfopen, (FILE*)1);
+
+#ifdef TEST_WINAGENT
+    expect_value(wrap_fgets, __stream, (FILE*)1);
+    will_return(wrap_fgets, "0\n");
+#else
+    expect_value(__wrap_fgets, __stream, (FILE*)1);
+    will_return(__wrap_fgets, "0\n");
+#endif
+
+    expect_value(__wrap_fclose, _File, (FILE*)1);
+    will_return(__wrap_fclose, 1);
+
+    expect_value(__wrap_wm_sendmsg, usec, 1000000);
+    expect_value(__wrap_wm_sendmsg, queue, queue);
+    expect_string(__wrap_wm_sendmsg, message, "{\"collector\":\"upgrade_result\","
+                                               "\"module\":\"agent-upgrade\","
+                                               "\"data\":{\"error\":0,"
+                                                       "\"message\":\"Upgrade was successful\","
+                                                       "\"status\":\"Done\"}}");
+    expect_string(__wrap_wm_sendmsg, locmsg, AGENT_UPGRADE_WM_NAME);
+    expect_value(__wrap_wm_sendmsg, loc, LOCALFILE_MQ);
+
+    will_return(__wrap_wm_sendmsg, result);
+
+    expect_string(__wrap__mtdebug1, tag, "wazuh-modulesd:agent-upgrade");
+    expect_string(__wrap__mtdebug1, formatted_msg, "(8163): Sending upgrade ACK event: "
+                                                   "'{\"collector\":\"upgrade_result\","
+                                                     "\"module\":\"agent-upgrade\","
+                                                     "\"data\":{\"error\":0,"
+                                                             "\"message\":\"Upgrade was successful\","
+                                                             "\"status\":\"Done\"}}'");
+
+    expect_string(__wrap_remove, filename, WM_AGENT_UPGRADE_RESULT_FILE);
+    will_return(__wrap_remove, 0);
+
+    wm_agent_upgrade_check_status();
+}
+
+void test_wm_agent_upgrade_check_status_gives_up_after_the_read_budget(void **state)
+{
+    int queue = 0;
+
+    expect_marker_probe(WM_AGENT_UPGRADE_RESULT_FILE, 0);
+    expect_marker_probe(WM_AGENT_UPGRADE_LOCK_FILE, 1);
+
+    expect_string(__wrap_StartMQPredicated, path, DEFAULTQUEUE);
+    expect_value(__wrap_StartMQPredicated, type, WRITE);
+    expect_value(__wrap_StartMQPredicated, fn_ptr, wm_agent_upgrade_is_shutting_down);
+    will_return(__wrap_StartMQPredicated, queue);
+
+#ifndef TEST_WINAGENT
+    expect_any_always(__wrap_sleep, seconds);
+#endif
+
+    for (int i = 0; i < WM_AGENT_UPGRADE_RESULT_MAX_READS; i++) {
+        expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
+        expect_string(__wrap_wfopen, mode, "r");
+        will_return(__wrap_wfopen, NULL);
+    }
 
     wm_agent_upgrade_check_status();
 }
@@ -962,18 +1096,8 @@ void test_wm_agent_upgrade_start_agent_module_enabled(void **state)
     expect_memory(__wrap_CreateThread, function_pointer, wm_agent_upgrade_listen_messages, sizeof(wm_agent_upgrade_listen_messages));
 #endif
 
-    expect_string(__wrap_StartMQPredicated, path, DEFAULTQUEUE);
-    expect_value(__wrap_StartMQPredicated, type, WRITE);
-    expect_value(__wrap_StartMQPredicated, fn_ptr, wm_agent_upgrade_is_shutting_down);
-    will_return(__wrap_StartMQPredicated, 0);
-
-#ifndef TEST_WINAGENT
-    expect_any_always(__wrap_sleep, seconds);
-#endif
-
-    expect_string(__wrap_wfopen, path, WM_AGENT_UPGRADE_RESULT_FILE);
-    expect_string(__wrap_wfopen, mode, "r");
-    will_return(__wrap_wfopen, NULL);
+    expect_marker_probe(WM_AGENT_UPGRADE_RESULT_FILE, 0);
+    expect_marker_probe(WM_AGENT_UPGRADE_LOCK_FILE, 0);
 
     wm_agent_upgrade_start_agent_module(config, 1);
 
@@ -1009,12 +1133,16 @@ int main(void) {
         cmocka_unit_test_setup(test_wm_upgrade_agent_search_upgrade_result_successful, setup_test_executions),
         cmocka_unit_test_setup(test_wm_upgrade_agent_search_upgrade_result_failed, setup_test_executions),
         cmocka_unit_test_setup(test_wm_upgrade_agent_search_upgrade_result_failed_missing_dependency, setup_test_executions),
-        cmocka_unit_test_setup(test_wm_upgrade_agent_search_upgrade_result_error_open, setup_test_executions),
+        cmocka_unit_test_setup(test_wm_upgrade_agent_search_upgrade_result_not_written_yet, setup_test_executions),
+        cmocka_unit_test_setup(test_wm_upgrade_agent_search_upgrade_result_unusable_content, setup_test_executions),
         cmocka_unit_test_setup(test_wm_upgrade_agent_search_upgrade_result_error_code, setup_test_executions),
         // wm_agent_upgrade_check_status
         cmocka_unit_test_setup(test_wm_agent_upgrade_check_status_successful, setup_test_executions),
         cmocka_unit_test_setup(test_wm_agent_upgrade_check_status_retries_an_empty_result_file, setup_test_executions),
         cmocka_unit_test_setup(test_wm_agent_upgrade_check_status_queue_error, setup_test_executions),
+        cmocka_unit_test_setup(test_wm_agent_upgrade_check_status_returns_when_no_upgrade_ran, setup_test_executions),
+        cmocka_unit_test_setup(test_wm_agent_upgrade_check_status_waits_for_a_result_file_that_does_not_exist_yet, setup_test_executions),
+        cmocka_unit_test_setup(test_wm_agent_upgrade_check_status_gives_up_after_the_read_budget, setup_test_executions),
 #ifndef TEST_WINAGENT
         // wm_agent_upgrade_listen_messages
         cmocka_unit_test(test_wm_agent_upgrade_listen_messages_ok),

--- a/src/util/src/verify-agent-conf.c
+++ b/src/util/src/verify-agent-conf.c
@@ -159,7 +159,7 @@ int verify_agent_conf(const char * path) {
         return -1;
     } else if (Test_Localfile(path) < 0) {
         return -1;
-    } else if (Test_Client(path) < 0) {
+    } else if (Test_Agent(path) < 0) {
         return -1;
     } else if (Test_WModule(path) < 0) {
         return -1;

--- a/src/wazuh_modules/src/agent_upgrade/agent/wm_agent_upgrade_agent.c
+++ b/src/wazuh_modules/src/agent_upgrade/agent/wm_agent_upgrade_agent.c
@@ -65,8 +65,8 @@ STATIC void wm_agent_upgrade_check_status(void);
  * operation and reports it as a stateless event, erasing the file afterwards (#38103).
  * @param queue_fd file descriptor of the queue where the event will be sent
  * @return a flag indicating whether the file should be read again
- * @retval true the file exists but carried no complete code yet, so retry
- * @retval false the result was reported and erased, or there is no result file
+ * @retval true the installer has not written a complete code yet, so retry
+ * @retval false the result was reported and erased, or the file holds no usable code
  * */
 STATIC bool wm_upgrade_agent_search_upgrade_result(int* queue_fd);
 
@@ -198,6 +198,17 @@ STATIC void* wm_agent_upgrade_listen_messages(__attribute__((unused)) void* arg)
 STATIC void wm_agent_upgrade_check_status(void)
 {
     /**
+     * Nothing to report unless an upgrade just ran. The installer creates its in-progress
+     * lock before it restarts this agent and removes it only after writing
+     * upgrade_result, so anywhere between those two points at least one of the two files
+     * is on disk. Neither present is an ordinary restart
+     */
+    if (!w_is_file(WM_AGENT_UPGRADE_RESULT_FILE) && !w_is_file(WM_AGENT_UPGRADE_LOCK_FILE))
+    {
+        return;
+    }
+
+    /**
      *  StartMQ will wait until agent connection which is when the pkg_install.sh will write
      *  the upgrade result. The predicate aborts the retry loop on shutdown so the module
      *  does not block past the cooperative cancellation deadline.
@@ -209,43 +220,32 @@ STATIC void wm_agent_upgrade_check_status(void)
         return;
     }
 
-    // Wait until pkg_installer script verifies the agent was connected and writes the upgrade_result file
-    wm_sleep_interruptible(WM_AGENT_UPGRADE_RESULT_WAIT_TIME);
-    if (wm_shutdown_requested)
-    {
-        return;
-    }
-
     if (queue_fd < 0)
     {
         mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_QUEUE_FD);
+        return;
     }
-    else
-    {
-        bool result_available = true;
-        /**
-         * The result is reported as a stateless event and the file is erased in the same
-         * pass (#38103), so this runs at most once per upgrade. The loop is kept for the
-         * case where the file exists but is still empty: pkg_installer.sh writes it after
-         * the agent reconnects, so a partial read is retried on a fixed interval.
-         * */
-        while (result_available)
-        {
-            result_available = wm_upgrade_agent_search_upgrade_result(&queue_fd);
 
-            if (result_available)
-            {
-                wm_sleep_interruptible(WM_AGENT_UPGRADE_RESULT_RETRY_TIME);
-                if (wm_shutdown_requested)
-                {
-                    break;
-                }
-            }
+    /**
+     * The result is reported as a stateless event and the file is erased in the same pass
+     */
+    for (int reads = 0; reads < WM_AGENT_UPGRADE_RESULT_MAX_READS; reads++)
+    {
+        wm_sleep_interruptible(reads == 0 ? WM_AGENT_UPGRADE_RESULT_WAIT_TIME : WM_AGENT_UPGRADE_RESULT_RETRY_TIME);
+        if (wm_shutdown_requested)
+        {
+            break;
         }
-#ifndef WIN32
-        close(queue_fd);
-#endif
+
+        if (!wm_upgrade_agent_search_upgrade_result(&queue_fd))
+        {
+            break;
+        }
     }
+
+#ifndef WIN32
+    close(queue_fd);
+#endif
 }
 
 STATIC bool wm_upgrade_agent_search_upgrade_result(int* queue_fd)
@@ -254,35 +254,40 @@ STATIC bool wm_upgrade_agent_search_upgrade_result(int* queue_fd)
     const char* PATH = WM_AGENT_UPGRADE_RESULT_FILE;
 
     FILE* result_file = wfopen(PATH, "r");
-    if (result_file)
+    if (!result_file)
     {
-        if (fgets(buffer, 20, result_file) == NULL)
-        {
-            fclose(result_file);
-            return true;
-        }
-        fclose(result_file);
-
-        char* endptr;
-        unsigned long raw_code = strtoul(buffer, &endptr, 10);
-        if (endptr != buffer && (*endptr == '\0' || *endptr == '\n' || *endptr == '\r'))
-        {
-            wm_upgrade_agent_state state =
-                (raw_code < WM_UPGRADE_MAX_STATE) ? (wm_upgrade_agent_state)raw_code : WM_UPGRADE_FAILED;
-            wm_upgrade_agent_send_result_event(queue_fd, state, (unsigned int)raw_code);
-
-            /* The manager used to clear this file by answering the ack with
-             * clear_upgrade_result (#38103). A stateless event is not answered, so the
-             * result is reported once and dropped here instead of retried forever. */
-            if (remove(WM_AGENT_UPGRADE_RESULT_FILE) != 0)
-            {
-                mtdebug1(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_ERASE_FILE_ERROR, "check_status",
-                         WM_AGENT_UPGRADE_RESULT_FILE);
-            }
-
-            return false;
-        }
+        /* The installer writes this only after the upgraded agent reconnects, so an
+         * absent file means "not written yet", not "no upgrade to report". */
+        return true;
     }
+
+    if (fgets(buffer, 20, result_file) == NULL)
+    {
+        fclose(result_file);
+        return true;
+    }
+    fclose(result_file);
+
+    char* endptr;
+    unsigned long raw_code = strtoul(buffer, &endptr, 10);
+    if (endptr == buffer || (*endptr != '\0' && *endptr != '\n' && *endptr != '\r'))
+    {
+        // Not a partial write but content no code can be made of: nothing to wait for
+        return false;
+    }
+
+    wm_upgrade_agent_state state =
+        (raw_code < WM_UPGRADE_MAX_STATE) ? (wm_upgrade_agent_state)raw_code : WM_UPGRADE_FAILED;
+    wm_upgrade_agent_send_result_event(queue_fd, state, (unsigned int)raw_code);
+
+    /* The manager used to clear this file by answering the ack with
+     * clear_upgrade_result (#38103). A stateless event is not answered, so the
+     * result is reported once and dropped here instead of retried forever. */
+    if (remove(WM_AGENT_UPGRADE_RESULT_FILE) != 0)
+    {
+        mtdebug1(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_ERASE_FILE_ERROR, "check_status", WM_AGENT_UPGRADE_RESULT_FILE);
+    }
+
     return false;
 }
 

--- a/src/wazuh_modules/src/agent_upgrade/agent/wm_agent_upgrade_agent.c
+++ b/src/wazuh_modules/src/agent_upgrade/agent/wm_agent_upgrade_agent.c
@@ -26,8 +26,23 @@
 #define STATIC static
 #endif
 
+static const char* upgrade_messages[] = {[WM_UPGRADE_SUCCESSFUL] = "Upgrade was successful",
+                                         [WM_UPGRADE_FAILED_INTERMEDIATE] = "Upgrade failed: intermediate version required",
+                                         [WM_UPGRADE_FAILED] = "Upgrade failed"};
+
+static const char* upgrade_statuses[] = {[WM_UPGRADE_SUCCESSFUL] = "Done",
+                                         [WM_UPGRADE_FAILED_INTERMEDIATE] = "Failed",
+                                         [WM_UPGRADE_FAILED] = "Failed"};
+
 // CA certificates
 char** wcom_ca_store = NULL;
+
+/* Predicate for StartMQPredicated: aborts the open-queue retry loop on shutdown so the
+ * result reporter cannot block past the cooperative cancellation deadline. */
+STATIC bool wm_agent_upgrade_is_shutting_down(void)
+{
+    return wm_shutdown_requested != 0;
+}
 
 #ifndef WIN32
 
@@ -38,6 +53,43 @@ char** wcom_ca_store = NULL;
 STATIC void* wm_agent_upgrade_listen_messages(__attribute__((unused)) void* arg);
 
 #endif
+
+/**
+ * Checks if an agent has been recently upgraded, by reading the upgrade_result file, and
+ * reports the outcome as a stateless event. Blocks until the agent's event queue is up.
+ * */
+STATIC void wm_agent_upgrade_check_status(void);
+
+/**
+ * Checks in the upgrade_results file for a code that determines the result of the upgrade
+ * operation and reports it as a stateless event, erasing the file afterwards (#38103).
+ * @param queue_fd file descriptor of the queue where the event will be sent
+ * @return a flag indicating whether the file should be read again
+ * @retval true the file exists but carried no complete code yet, so retry
+ * @retval false the result was reported and erased, or there is no result file
+ * */
+STATIC bool wm_upgrade_agent_search_upgrade_result(int* queue_fd);
+
+/**
+ * Reads the upgrade_result file if it is present and reports the result as a stateless
+ * event (#38103), the same egress every other module event takes: the frame goes to
+ * DEFAULTQUEUE, EventForward() hands it to the HTTPS /stateless accumulator.
+ *
+ * Example event:
+ * {
+ *	  "collector": "upgrade_result",
+ *	  "module": "agent-upgrade",
+ *	  "data": {
+ *        "status": "Failed",
+ *        "error": 2,
+ *        "message": "Upgrade failed"
+ *	  }
+ * }
+ * @param queue_fd File descriptor of the event queue
+ * @param state upgrade result state
+ * @param raw_code raw numeric code read from upgrade_result file
+ * */
+STATIC void wm_upgrade_agent_send_result_event(int* queue_fd, wm_upgrade_agent_state state, unsigned int raw_code);
 
 void wm_agent_upgrade_start_agent_module(__attribute__((unused)) const wm_agent_configs* agent_config, const int enabled)
 {
@@ -56,6 +108,12 @@ void wm_agent_upgrade_start_agent_module(__attribute__((unused)) const wm_agent_
 #ifndef WIN32
     w_create_thread(wm_agent_upgrade_listen_messages, NULL);
 #endif
+
+    if (enabled)
+    {
+        // Runs on the module's own thread, so blocking here waits out the upgrade only
+        wm_agent_upgrade_check_status();
+    }
 }
 
 #ifndef WIN32
@@ -136,3 +194,136 @@ STATIC void* wm_agent_upgrade_listen_messages(__attribute__((unused)) void* arg)
 }
 
 #endif
+
+STATIC void wm_agent_upgrade_check_status(void)
+{
+    /**
+     *  StartMQ will wait until agent connection which is when the pkg_install.sh will write
+     *  the upgrade result. The predicate aborts the retry loop on shutdown so the module
+     *  does not block past the cooperative cancellation deadline.
+     */
+    int queue_fd = StartMQPredicated(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS, wm_agent_upgrade_is_shutting_down);
+
+    if (wm_shutdown_requested)
+    {
+        return;
+    }
+
+    // Wait until pkg_installer script verifies the agent was connected and writes the upgrade_result file
+    wm_sleep_interruptible(WM_AGENT_UPGRADE_RESULT_WAIT_TIME);
+    if (wm_shutdown_requested)
+    {
+        return;
+    }
+
+    if (queue_fd < 0)
+    {
+        mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_QUEUE_FD);
+    }
+    else
+    {
+        bool result_available = true;
+        /**
+         * The result is reported as a stateless event and the file is erased in the same
+         * pass (#38103), so this runs at most once per upgrade. The loop is kept for the
+         * case where the file exists but is still empty: pkg_installer.sh writes it after
+         * the agent reconnects, so a partial read is retried on a fixed interval.
+         * */
+        while (result_available)
+        {
+            result_available = wm_upgrade_agent_search_upgrade_result(&queue_fd);
+
+            if (result_available)
+            {
+                wm_sleep_interruptible(WM_AGENT_UPGRADE_RESULT_RETRY_TIME);
+                if (wm_shutdown_requested)
+                {
+                    break;
+                }
+            }
+        }
+#ifndef WIN32
+        close(queue_fd);
+#endif
+    }
+}
+
+STATIC bool wm_upgrade_agent_search_upgrade_result(int* queue_fd)
+{
+    char buffer[20];
+    const char* PATH = WM_AGENT_UPGRADE_RESULT_FILE;
+
+    FILE* result_file = wfopen(PATH, "r");
+    if (result_file)
+    {
+        if (fgets(buffer, 20, result_file) == NULL)
+        {
+            fclose(result_file);
+            return true;
+        }
+        fclose(result_file);
+
+        char* endptr;
+        unsigned long raw_code = strtoul(buffer, &endptr, 10);
+        if (endptr != buffer && (*endptr == '\0' || *endptr == '\n' || *endptr == '\r'))
+        {
+            wm_upgrade_agent_state state =
+                (raw_code < WM_UPGRADE_MAX_STATE) ? (wm_upgrade_agent_state)raw_code : WM_UPGRADE_FAILED;
+            wm_upgrade_agent_send_result_event(queue_fd, state, (unsigned int)raw_code);
+
+            /* The manager used to clear this file by answering the ack with
+             * clear_upgrade_result (#38103). A stateless event is not answered, so the
+             * result is reported once and dropped here instead of retried forever. */
+            if (remove(WM_AGENT_UPGRADE_RESULT_FILE) != 0)
+            {
+                mtdebug1(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_ERASE_FILE_ERROR, "check_status",
+                         WM_AGENT_UPGRADE_RESULT_FILE);
+            }
+
+            return false;
+        }
+    }
+    return false;
+}
+
+STATIC void wm_upgrade_agent_send_result_event(int* queue_fd, wm_upgrade_agent_state state, unsigned int raw_code)
+{
+    int msg_delay = 1000000 / wm_max_eps;
+    cJSON* root = cJSON_CreateObject();
+    cJSON* data = cJSON_CreateObject();
+
+    cJSON_AddStringToObject(root, "collector", "upgrade_result");
+    cJSON_AddStringToObject(root, "module", AGENT_UPGRADE_WM_NAME);
+    cJSON_AddNumberToObject(data, "error", raw_code);
+    cJSON_AddStringToObject(data, "message", upgrade_messages[state]);
+    cJSON_AddStringToObject(data, "status", upgrade_statuses[state]);
+    cJSON_AddItemToObject(root, "data", data);
+
+    char* msg_string = cJSON_PrintUnformatted(root);
+    /* LOCALFILE_MQ with the module name as location: the frame every other module
+     * event uses, so EventForward() routes it to /stateless instead of the legacy
+     * "u:upgrade_module:" header remoted special-cases (secure.c:1141). */
+    if (wm_sendmsg(msg_delay, *queue_fd, msg_string, AGENT_UPGRADE_WM_NAME, LOCALFILE_MQ) < 0)
+    {
+        mterror(WM_AGENT_UPGRADE_LOGTAG, QUEUE_ERROR, DEFAULTQUEUE, strerror(errno));
+        if (*queue_fd >= 0)
+        {
+            close(*queue_fd);
+        }
+        *queue_fd = StartMQPredicated(DEFAULTQUEUE, WRITE, INFINITE_OPENQ_ATTEMPTS, wm_agent_upgrade_is_shutting_down);
+        if (wm_shutdown_requested)
+        {
+            os_free(msg_string);
+            cJSON_Delete(root);
+            return;
+        }
+        if (*queue_fd < 0)
+        {
+            mterror_exit(WM_AGENT_UPGRADE_LOGTAG, QUEUE_FATAL, DEFAULTQUEUE);
+        }
+    }
+
+    mtdebug1(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_ACK_MESSAGE, msg_string);
+    os_free(msg_string);
+    cJSON_Delete(root);
+}

--- a/src/wazuh_modules/src/agent_upgrade/agent/wm_agent_upgrade_agent.h
+++ b/src/wazuh_modules/src/agent_upgrade/agent/wm_agent_upgrade_agent.h
@@ -14,6 +14,24 @@
 
 #include "wm_agent_upgrade.h"
 
+#ifdef WIN32
+#define WM_AGENT_UPGRADE_RESULT_FILE UPGRADE_DIR "\\upgrade_result"
+#else
+#define WM_AGENT_UPGRADE_RESULT_FILE UPGRADE_DIR "/upgrade_result"
+#endif
+
+/* Seconds before the first upgrade_result read, and between re-reads of an incomplete one. */
+#define WM_AGENT_UPGRADE_RESULT_WAIT_TIME 30
+#define WM_AGENT_UPGRADE_RESULT_RETRY_TIME 30
+
+/* The codes pkg_installer.sh / do_upgrade.ps1 write into upgrade_result. */
+typedef enum _wm_upgrade_agent_state {
+    WM_UPGRADE_SUCCESSFUL = 0,
+    WM_UPGRADE_FAILED_INTERMEDIATE,
+    WM_UPGRADE_FAILED,
+    WM_UPGRADE_MAX_STATE
+} wm_upgrade_agent_state;
+
 extern char **wcom_ca_store;
 
 extern bool allow_upgrades;

--- a/src/wazuh_modules/src/agent_upgrade/agent/wm_agent_upgrade_agent.h
+++ b/src/wazuh_modules/src/agent_upgrade/agent/wm_agent_upgrade_agent.h
@@ -16,13 +16,16 @@
 
 #ifdef WIN32
 #define WM_AGENT_UPGRADE_RESULT_FILE UPGRADE_DIR "\\upgrade_result"
+#define WM_AGENT_UPGRADE_LOCK_FILE UPGRADE_DIR "\\upgrade_in_progress"
 #else
 #define WM_AGENT_UPGRADE_RESULT_FILE UPGRADE_DIR "/upgrade_result"
+#define WM_AGENT_UPGRADE_LOCK_FILE UPGRADE_DIR "/upgrade_in_progress_pid"
 #endif
 
-/* Seconds before the first upgrade_result read, and between re-reads of an incomplete one. */
+/* Seconds before the first upgrade_result read, between re-reads, and how many reads. */
 #define WM_AGENT_UPGRADE_RESULT_WAIT_TIME 30
 #define WM_AGENT_UPGRADE_RESULT_RETRY_TIME 30
+#define WM_AGENT_UPGRADE_RESULT_MAX_READS 4
 
 /* The codes pkg_installer.sh / do_upgrade.ps1 write into upgrade_result. */
 typedef enum _wm_upgrade_agent_state {

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -84,6 +84,9 @@ public function config()
 
                 not_replaced = True
                 formatted_list = vbCrLf
+                ' <server> inside <agent> since 5.x: <agent> takes no other
+                ' element name, so writing back the legacy <manager> would make the
+                ' agent reject its own configuration.
                 for i=0 to UBound(ip_list)
                     If ip_list(i) <> "" Then
                         formatted_list = formatted_list & "    <server>" & vbCrLf
@@ -132,9 +135,9 @@ public function config()
             enrollment_list = "    <enrollment>" & vbCrLf
             enrollment_list = enrollment_list & "      <enabled>yes</enabled>" & vbCrLf
             enrollment_list = enrollment_list & "    </enrollment>" & vbCrLf
-            enrollment_list = enrollment_list & "  </client>" & vbCrLf
+            enrollment_list = enrollment_list & "  </agent>" & vbCrLf
 
-            strText = Replace(strText, "  </client>", enrollment_list)
+            strText = Replace(strText, "  </agent>", enrollment_list)
 
             If WAZUH_REGISTRATION_SERVER <> "" Then
                 strText = Replace(strText, "    </enrollment>", "      <manager_address>" & WAZUH_REGISTRATION_SERVER & "</manager_address>"& vbCrLf &"    </enrollment>")

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -275,6 +275,75 @@ if ($msi_new_version -ne $null) {
     }
 }
 
+# Read the first <tag> nested in <block> from the agent configuration
+function get_conf_value($block, $tag) {
+    $conf_path = Join-Path $wazuhDir "ossec.conf"
+    if (-Not (Test-Path $conf_path)) {
+        return $null
+    }
+    # Strip CR and LF independently: the shipped template is LF-only, and .NET's `.`
+    # does not cross a newline, so a CRLF-only strip leaves the block unmatchable.
+    $conf = (Get-Content $conf_path -Raw) -replace "`r", "" -replace "`n", ""
+    $block_match = [regex]::Match($conf, "<$block>(.*)</$block>")
+    if (-Not $block_match.Success) {
+        return $null
+    }
+    $tag_match = [regex]::Match($block_match.Groups[1].Value, "<$tag>([^<]*)</$tag>")
+    if (-Not $tag_match.Success) {
+        return $null
+    }
+    return $tag_match.Groups[1].Value.Trim()
+}
+
+# Check that the manager accepts connections on the HTTPS control port
+function probe_manager($server, $port) {
+    $client = New-Object System.Net.Sockets.TcpClient
+    try {
+        $async = $client.BeginConnect($server, [int]$port, $null, $null)
+        if (-Not $async.AsyncWaitHandle.WaitOne(5000, $false)) {
+            return $false
+        }
+        $client.EndConnect($async)
+        return $true
+    } catch {
+        return $false
+    } finally {
+        $client.Close()
+    }
+}
+
+# The 5x agent requires the manager address inside the <agent> block, falling back to the <client> block when upgrading from 4x versions.
+$manager_address = get_conf_value "agent" "address"
+if ([string]::IsNullOrEmpty($manager_address)) {
+    $manager_address = get_conf_value "client" "address"
+}
+
+# The 5x agent requires the manager port inside the <agent> block, falling back to 1517 when upgrading from 4x versions.
+$manager_port = get_conf_value "agent" "port"
+if ([string]::IsNullOrEmpty($manager_port)) {
+    $manager_port = "1517"
+}
+
+if ([string]::IsNullOrEmpty($manager_address)) {
+    write-output "$(Get-Date -format u) - Upgrade failed: no manager address found in the configuration." >> .\upgrade\upgrade.log
+    write-output "2" | out-file ".\upgrade\upgrade_result" -encoding ascii
+    remove_upgrade_files
+    Restart-Service -Name "Wazuh" -Force -ErrorAction SilentlyContinue
+    exit 1
+}
+
+write-output "$(Get-Date -format u) - Checking connectivity to $($manager_address):$($manager_port)." >> .\upgrade\upgrade.log
+
+if (-Not (probe_manager $manager_address $manager_port)) {
+    write-output "$(Get-Date -format u) - Upgrade failed: the manager is not reachable at $($manager_address):$($manager_port), interrupting upgrade." >> .\upgrade\upgrade.log
+    write-output "2" | out-file ".\upgrade\upgrade_result" -encoding ascii
+    remove_upgrade_files
+    Restart-Service -Name "Wazuh" -Force -ErrorAction SilentlyContinue
+    exit 1
+}
+
+write-output "$(Get-Date -format u) - Manager reachable at $($manager_address):$($manager_port)." >> .\upgrade\upgrade.log
+
 # Ensure no other instance of msiexec is running by stopping them
 try {
     $proc = Get-Process -Name "msiexec" -ErrorAction Stop

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -275,8 +275,8 @@ if ($msi_new_version -ne $null) {
     }
 }
 
-# Read the first <tag> nested in <block> from the agent configuration
-function get_conf_value($block, $tag) {
+# Read <block><sub><tag> from the agent configuration, taking the last match.
+function get_conf_value($block, $sub, $tag) {
     $conf_path = Join-Path $wazuhDir "ossec.conf"
     if (-Not (Test-Path $conf_path)) {
         return $null
@@ -288,38 +288,43 @@ function get_conf_value($block, $tag) {
     if (-Not $block_match.Success) {
         return $null
     }
-    $tag_match = [regex]::Match($block_match.Groups[1].Value, "<$tag>([^<]*)</$tag>")
-    if (-Not $tag_match.Success) {
+    $sub_match = [regex]::Match($block_match.Groups[1].Value, "<$sub>(.*)</$sub>")
+    if (-Not $sub_match.Success) {
         return $null
     }
-    return $tag_match.Groups[1].Value.Trim()
+    $tag_matches = [regex]::Matches($sub_match.Groups[1].Value, "<$tag>([^<]*)</$tag>")
+    if ($tag_matches.Count -eq 0) {
+        return $null
+    }
+    return $tag_matches[$tag_matches.Count - 1].Groups[1].Value.Trim()
 }
 
-# Check that the server accepts connections on the HTTPS control port
+# Check that the manager answers on the HTTPS control port. GET / is remoted's
+# unauthenticated health probe and returns 200 {"status":"ok","module":"remoted"}
 function probe_server($server, $port) {
-    $client = New-Object System.Net.Sockets.TcpClient
+    $saved_callback = [System.Net.ServicePointManager]::ServerCertificateValidationCallback
+    $saved_protocol = [System.Net.ServicePointManager]::SecurityProtocol
     try {
-        $async = $client.BeginConnect($server, [int]$port, $null, $null)
-        if (-Not $async.AsyncWaitHandle.WaitOne(5000, $false)) {
-            return $false
-        }
-        $client.EndConnect($async)
-        return $true
+        [System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
+        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
+        $response = Invoke-WebRequest -Uri "https://$($server):$($port)/" -UseBasicParsing -TimeoutSec 5
+        return ($response.StatusCode -eq 200)
     } catch {
         return $false
     } finally {
-        $client.Close()
+        [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $saved_callback
+        [System.Net.ServicePointManager]::SecurityProtocol = $saved_protocol
     }
 }
 
 # The 5x agent reads the server address from the <agent> block, falling back to the <client> block when upgrading from 4x versions.
-$server_address = get_conf_value "agent" "address"
+$server_address = get_conf_value "agent" "server" "address"
 if ([string]::IsNullOrEmpty($server_address)) {
-    $server_address = get_conf_value "client" "address"
+    $server_address = get_conf_value "client" "server" "address"
 }
 
 # The 5x agent reads the server port from the <agent> block, falling back to 1517 when upgrading from 4x versions.
-$server_port = get_conf_value "agent" "port"
+$server_port = get_conf_value "agent" "server" "port"
 if ([string]::IsNullOrEmpty($server_port)) {
     $server_port = "1517"
 }

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -281,8 +281,7 @@ function get_conf_value($block, $sub, $tag) {
     if (-Not (Test-Path $conf_path)) {
         return $null
     }
-    # Strip CR and LF independently: the shipped template is LF-only, and .NET's `.`
-    # does not cross a newline, so a CRLF-only strip leaves the block unmatchable.
+    # Strip CR and LF separately: the shipped template is LF-only, and `.` never matches a newline.
     $conf = (Get-Content $conf_path -Raw) -replace "`r", "" -replace "`n", ""
     $block_match = [regex]::Match($conf, "<$block>(.*)</$block>")
     if (-Not $block_match.Success) {
@@ -299,21 +298,32 @@ function get_conf_value($block, $sub, $tag) {
     return $tag_matches[$tag_matches.Count - 1].Groups[1].Value.Trim()
 }
 
-# Check that the manager answers on the HTTPS control port. GET / is remoted's
-# unauthenticated health probe and returns 200 {"status":"ok","module":"remoted"}
+# Accept any certificate: the manager's is self-signed. Compiled, because .NET calls this
+# on a worker thread where a PowerShell scriptblock cannot run.
+if (-not ("WazuhProbeTrust" -as [type])) {
+    Add-Type @"
+using System.Net;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+public static class WazuhProbeTrust {
+    public static RemoteCertificateValidationCallback Always =
+        delegate (object s, X509Certificate c, X509Chain ch, SslPolicyErrors e) { return true; };
+}
+"@
+}
+
+# Check the manager is up: GET / is remoted's health endpoint and answers 200.
+# Never pin the TLS version here: the listener is TLS 1.3-only, so Tls12 fails the handshake.
 function probe_server($server, $port) {
     $saved_callback = [System.Net.ServicePointManager]::ServerCertificateValidationCallback
-    $saved_protocol = [System.Net.ServicePointManager]::SecurityProtocol
     try {
-        [System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
-        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
+        [System.Net.ServicePointManager]::ServerCertificateValidationCallback = [WazuhProbeTrust]::Always
         $response = Invoke-WebRequest -Uri "https://$($server):$($port)/" -UseBasicParsing -TimeoutSec 5
         return ($response.StatusCode -eq 200)
     } catch {
         return $false
     } finally {
         [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $saved_callback
-        [System.Net.ServicePointManager]::SecurityProtocol = $saved_protocol
     }
 }
 

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -295,8 +295,8 @@ function get_conf_value($block, $tag) {
     return $tag_match.Groups[1].Value.Trim()
 }
 
-# Check that the manager accepts connections on the HTTPS control port
-function probe_manager($server, $port) {
+# Check that the server accepts connections on the HTTPS control port
+function probe_server($server, $port) {
     $client = New-Object System.Net.Sockets.TcpClient
     try {
         $async = $client.BeginConnect($server, [int]$port, $null, $null)
@@ -312,19 +312,19 @@ function probe_manager($server, $port) {
     }
 }
 
-# The 5x agent requires the manager address inside the <agent> block, falling back to the <client> block when upgrading from 4x versions.
-$manager_address = get_conf_value "agent" "address"
-if ([string]::IsNullOrEmpty($manager_address)) {
-    $manager_address = get_conf_value "client" "address"
+# The 5x agent reads the server address from the <agent> block, falling back to the <client> block when upgrading from 4x versions.
+$server_address = get_conf_value "agent" "address"
+if ([string]::IsNullOrEmpty($server_address)) {
+    $server_address = get_conf_value "client" "address"
 }
 
-# The 5x agent requires the manager port inside the <agent> block, falling back to 1517 when upgrading from 4x versions.
-$manager_port = get_conf_value "agent" "port"
-if ([string]::IsNullOrEmpty($manager_port)) {
-    $manager_port = "1517"
+# The 5x agent reads the server port from the <agent> block, falling back to 1517 when upgrading from 4x versions.
+$server_port = get_conf_value "agent" "port"
+if ([string]::IsNullOrEmpty($server_port)) {
+    $server_port = "1517"
 }
 
-if ([string]::IsNullOrEmpty($manager_address)) {
+if ([string]::IsNullOrEmpty($server_address)) {
     write-output "$(Get-Date -format u) - Upgrade failed: no manager address found in the configuration." >> .\upgrade\upgrade.log
     write-output "2" | out-file ".\upgrade\upgrade_result" -encoding ascii
     remove_upgrade_files
@@ -332,17 +332,17 @@ if ([string]::IsNullOrEmpty($manager_address)) {
     exit 1
 }
 
-write-output "$(Get-Date -format u) - Checking connectivity to $($manager_address):$($manager_port)." >> .\upgrade\upgrade.log
+write-output "$(Get-Date -format u) - Checking connectivity to $($server_address):$($server_port)." >> .\upgrade\upgrade.log
 
-if (-Not (probe_manager $manager_address $manager_port)) {
-    write-output "$(Get-Date -format u) - Upgrade failed: the manager is not reachable at $($manager_address):$($manager_port), interrupting upgrade." >> .\upgrade\upgrade.log
+if (-Not (probe_server $server_address $server_port)) {
+    write-output "$(Get-Date -format u) - Upgrade failed: the manager is not reachable at $($server_address):$($server_port), interrupting upgrade." >> .\upgrade\upgrade.log
     write-output "2" | out-file ".\upgrade\upgrade_result" -encoding ascii
     remove_upgrade_files
     Restart-Service -Name "Wazuh" -Force -ErrorAction SilentlyContinue
     exit 1
 }
 
-write-output "$(Get-Date -format u) - Manager reachable at $($manager_address):$($manager_port)." >> .\upgrade\upgrade.log
+write-output "$(Get-Date -format u) - Manager reachable at $($server_address):$($server_port)." >> .\upgrade\upgrade.log
 
 # Ensure no other instance of msiexec is running by stopping them
 try {

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -6,7 +6,7 @@
 
 <ossec_config>
 
-  <client>
+  <agent>
     <server>
       <address>0.0.0.0</address>
       <port>1517</port>
@@ -20,7 +20,7 @@
     </ssl>
     <notify_time>20</notify_time>
     <auto_restart>yes</auto_restart>
-  </client>
+  </agent>
 
   <!-- Log analysis -->
   <localfile>

--- a/src/win32/ui/common.c
+++ b/src/win32/ui/common.c
@@ -331,7 +331,10 @@ int get_ossec_server()
     char *str = NULL;
     int success = 0;
 
-    /* Definitions */
+    /* Definitions. <agent> is the 5.x name of the block; the <client> paths are kept
+     * because a WPK upgrade never rewrites ossec.conf
+     */
+    const char *(xml_agentaddr[]) = {"ossec_config", "agent", "server", "address", NULL};
     const char *(xml_manageraddr[]) = {"ossec_config", "client", "manager", "address", NULL};
     const char *(xml_serverip[]) = {"ossec_config", "client", "server-ip", NULL};
     const char *(xml_serverhost[]) = {"ossec_config", "client", "server-hostname", NULL};
@@ -349,7 +352,13 @@ int get_ossec_server()
     }
     config_inst.server_type = 0;
 
-    /* Get IP address of manager */
+    /* Get IP address of the server */
+    if (str = OS_GetOneContentforElement(&xml, xml_agentaddr), str) {
+        config_inst.server_type = OS_IsValidIP(str, NULL) == 1 ? SERVER_IP_USED : SERVER_HOST_USED;
+        config_inst.server = str;
+        success = 1;
+        goto ret;
+    }
     if (str = OS_GetOneContentforElement(&xml, xml_manageraddr), str) {
         if (OS_IsValidIP(str, NULL) == 1) {
             config_inst.server_type = SERVER_IP_USED;
@@ -451,12 +460,17 @@ int run_cmd(char *cmd, HWND hwnd)
 /* Set OSSEC Server IP */
 int set_ossec_server(char *ip, HWND hwnd)
 {
-    const char **xml_pt = NULL;
-    const char **xml_alt_pt = NULL;
     OS_XML xml;
     char *str = NULL;
+    const char *(xml_agentaddr[]) = {"ossec_config", "agent", "server", "address", NULL};
     const char *(xml_manageraddr[]) = {"ossec_config", "client", "manager", "address", NULL};
     const char *(xml_serveraddr[]) = {"ossec_config", "client", "server", "address", NULL};
+    /* Write order. The block that already holds an address is tried first so an
+     * upgraded 4.x file keeps its <client> shape and a 5.x file gets <agent>.
+     * The remaining paths are the fallback for a config that has neither. */
+    const char **xml_paths[] = {xml_agentaddr, xml_manageraddr, xml_serveraddr};
+    const size_t xml_paths_len = sizeof(xml_paths) / sizeof(xml_paths[0]);
+    size_t i;
     char config_tmp[] = CONFIG;
     char *conf_file = basename_ex(config_tmp);
 
@@ -478,23 +492,20 @@ int set_ossec_server(char *ip, HWND hwnd)
         config_inst.server_type = SERVER_IP_USED;
     }
 
-    /* Keep manager/server tag compatibility depending on current config. */
+    /* Keep agent/manager/server tag compatibility depending on current config: move the
+     * block that already carries an address to the front of the write order. */
     if (OS_ReadXML(CONFIG, &xml) == 0) {
-        if (str = OS_GetOneContentforElement(&xml, xml_manageraddr), str) {
-            xml_pt = xml_manageraddr;
-            free(str);
-        } else if (str = OS_GetOneContentforElement(&xml, xml_serveraddr), str) {
-            xml_pt = xml_serveraddr;
-            free(str);
-        } else {
-            xml_pt = xml_manageraddr;
+        for (i = 0; i < xml_paths_len; i++) {
+            if (str = OS_GetOneContentforElement(&xml, xml_paths[i]), str) {
+                free(str);
+                const char **found = xml_paths[i];
+                xml_paths[i] = xml_paths[0];
+                xml_paths[0] = found;
+                break;
+            }
         }
         OS_ClearXML(&xml);
-    } else {
-        xml_pt = xml_manageraddr;
     }
-
-    xml_alt_pt = (xml_pt == xml_manageraddr) ? xml_serveraddr : xml_manageraddr;
 
     /* Create temporary file */
     if (mkstemp_ex(tmp_path) == -1) {
@@ -504,8 +515,12 @@ int set_ossec_server(char *ip, HWND hwnd)
     }
 
     /* Read the XML. Print error and line number. */
-    if (OS_WriteXML(CONFIG, tmp_path, xml_pt, NULL, ip) != 0 &&
-        OS_WriteXML(CONFIG, tmp_path, xml_alt_pt, NULL, ip) != 0) {
+    int written = 0;
+    for (i = 0; i < xml_paths_len && !written; i++) {
+        written = OS_WriteXML(CONFIG, tmp_path, xml_paths[i], NULL, ip) == 0;
+    }
+
+    if (!written) {
         MessageBox(hwnd, "Unable to set OSSEC Server IP Address.\r\n"
                    "(Internal error on the XML Write).",
                    "Error -- Failure Setting IP", MB_OK);


### PR DESCRIPTION
## Description

A 4.x agent upgraded over WPK keeps its own `ossec.conf`, so a 5.x agent has to start against a file written for the legacy 1514 channel. Without this, the upgraded agent either points at a port the manager no longer serves or refuses its own configuration, and the upgrade strands the agent.

This pull request makes that transition land on a working HTTPS control path without ever rewriting the agent's configuration, renames the connection block for fresh installs, aborts an upgrade that would strand the agent, and reports the upgrade outcome as a stateless event.

Closes #38103

## Proposed Changes

**Configuration: `<client>` renamed to `<agent>`**

- `<agent>` is the 5.x name of the block. One reader serves it (`Read_Agent`), and the legacy `<client>` is read for a single value, `<server><address>`, as the fallback for an upgraded agent. `<agent>` prevails whichever block appears first.
- `<manager>` is no longer accepted as an alias for `<server>`: it is an invalid element. `v4.14.7` ships `<server>` on every platform, and the manager already refuses upgrades to 5.x from agents older than `4.14.0` (`wm_agent_upgrade_validate.c:207-211`), so no reachable upgrade path carries it.
- `<client><server><port>` is ignored and the port defaults to `1517` through the new `DEFAULT_HTTPS_REMOTE_PORT`. `DEFAULT_REMOTE_PORT` stays at 1514 for the manager's own block.
- Symbols follow the block: `Read_Agent_Server/SSL/Batch/Enrollment/Report/Shared`, `Free_Agent`, `Test_Agent`.

**Fresh installs ship `<agent>`**

Both templates, plus the three writers that would otherwise put the endpoint back under the old name: the source installer (`inst-functions.sh`), the `WAZUH_MANAGER` rewrite used by the deb/rpm/macOS packages (`register_configure_agent.sh`), and the MSI custom action (`InstallerScripts.vbs`, which also wrote `<manager>` and port 1514, and whose enrollment and profile-template anchors moved with the rename).

Manage-Agent (`win32ui`) follows too. It read and wrote `ossec_config/client/…` only, so after the rename it showed no server and wrote the endpoint into a `<client>` block the agent ignores. It now tries `<agent><server><address>` first and keeps the `<client>` paths for a preserved 4.x file; on write, whichever block already carries an address goes first, so an upgraded config keeps its shape.

**WPK installer aborts when the manager's HTTPS port is unreachable**

`pkg_installer.sh` (Linux/macOS) and `do_upgrade.ps1` (Windows) resolve the endpoint the way the agent does, under the block's own name (`probe_server`, `SERVER_ADDRESS`/`SERVER_PORT`, `$server_address`/`$server_port`). `<agent><server>` first, then `<client><server><address>`, last value prevailing, port defaulting to `1517`, and probe it before any package install. On failure the upgrade aborts with `upgrade_result` = `2`, leaving the working 4.x agent in place so the upgrade can be retried.

The probe is an HTTPS request: `GET /` is remoted's unauthenticated health endpoint (`remotedModuleFacade.hpp`, 200 `{"status":"ok","module":"remoted"}`).

`pkg_installer.sh` tries `curl -k -f` first, then `wget --no-check-certificate`: between them they cover what the documented install paths already put on the host, though neither is a package dependency. With neither present it falls back to the previous `/dev/tcp` probe and its own 5 s watchdog, since macOS ships no `timeout`. That last path is the only one that cannot tell remoted from any other listener, and it fails closed. `do_upgrade.ps1` uses `Invoke-WebRequest` with a 5 s timeout and a scoped certificate-validation override, matching the documented Windows install step.

**Upgrade result reported as a stateless event**

The agent no longer emits the `u:upgrade_module:` control ack that only legacy remoted understood. It reports the outcome as a module event on the HTTPS `/stateless` egress, using the frame every other module event uses (`LOCALFILE_MQ`, module name as location):

```json
{"collector":"upgrade_result","module":"agent-upgrade","data":{"error":0,"message":"Upgrade was successful","status":"Done"}}
```

Reported once, after which the agent erases its own `upgrade_result` file. Nothing acks a stateless event, so delivery is at-most-once by design: the event is emitted, queued, and the module moves on.

The reporter runs from `wm_agent_upgrade_start_agent_module`, on the upgrade module's own thread, so waiting for the installer to write the file blocks nothing else. Two things bound that wait:

- **It only starts when an upgrade actually ran.** The installer creates its in-progress lock (`var/upgrade/upgrade_in_progress_pid`, `upgrade\upgrade_in_progress` on Windows) before restarting the agent and removes it only after writing the result, so between those points at least one of the two files exists. Neither present is an ordinary restart, and the reporter returns before opening a queue or waiting on anything, which is every restart that is not post-upgrade.
- **A missing result file means "not yet", not "nothing to report".** The installer writes it only once the upgraded agent reconnects, up to ~70 s after the restart on Windows (`do_upgrade.ps1` settles 10 s then waits 30 × 2 s for `connected`). A single read at a fixed offset drops the event whenever the reconnect outruns it, so the read is retried on a bounded budget (`WM_AGENT_UPGRADE_RESULT_MAX_READS`, 4 × 30 s) instead of giving up. Content that is neither absent nor partial but simply unusable still stops immediately.

### Results and Evidence

Manager: Built from this branch and installed on an AIO.
Agent Ubuntu 24.04.4 arm64: package built from this branch, upgraded over a WPK built from this branch.
Agent macOS 15.7.7 arm64: package built from this branch, upgraded over a WPK built from this branch.
Agent Win11 arm64: package built from this branch, upgraded over a WPK built from this branch.

Fresh installation agent config:

```xml
<ossec_config>
  <agent>
    <server>
      <address>192.168.18.238</address>
      <port>1517</port>
    </server>
    <ssl>
      <verification_mode>none</verification_mode>
    </ssl>
    <config-profile>ubuntu, ubuntu24, ubuntu24.04</config-profile>
<!--
macos:
    <config-profile>darwin, darwin24, darwin24.6</config-profile>
windows:
    <config-profile>windows, windows10</config-profile>
    <time-reconnect>60</time-reconnect>
-->
    <notify_time>20</notify_time>
    <auto_restart>yes</auto_restart>
    <enrollment>
      <enabled>yes</enabled>
      <authorization_pass_path>etc/authd.pass</authorization_pass_path>
    </enrollment>
  </agent>
...
</ossec_config>
```

> Block `<ssl><verification_mode>none</verification_mode></ssl>` added to allow agent reconnection after upgrade.

The upgrade was driven through the API, via the following command:

Linux:

```bash
root@aio-ubuntu-arm:~# TOKEN=$(curl -sk -X POST "https://192.168.18.238:55000/security/user/authenticate?raw=true" -u wazuh:wazuh)
root@aio-ubuntu-arm:~# curl -sk -X PUT "https://192.168.18.238:55000/agents/upgrade_custom?agents_list=001&file_path=/var/wazuh-manager/var/upgrade/wazuh-agent_5.0.0-0_arm64_8b81704.deb.wpk&installer=upgrade.sh&pretty=true"   -H "Authorization: Bearer $TOKEN"
{
   "data": {
      "affected_items": [
         "001"
      ],
      "total_affected_items": 1,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "All upgrade tasks were created",
   "error": 0
}
```

Macos:

```bash
root@aio-ubuntu-arm:~# TOKEN=$(curl -sk -X POST "https://192.168.18.238:55000/security/user/authenticate?raw=true" -u wazuh:wazuh)
root@aio-ubuntu-arm:~# curl -sk -X PUT "https://192.168.18.238:55000/agents/upgrade_custom?agents_list=002&file_path=/var/wazuh-manager/var/upgrade/wazuh-agent_5.0.0-1_arm64_8b81704.pkg.wpk&installer=upgrade.sh&pretty=true"   -H "Authorization: Bearer $TOKEN"
{
   "data": {
      "affected_items": [
         "002"
      ],
      "total_affected_items": 1,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "All upgrade tasks were created",
   "error": 0
}
```

Windows:

```bash
root@aio-ubuntu-arm:~# TOKEN=$(curl -sk -X POST "https://192.168.18.238:55000/security/user/authenticate?raw=true" -u wazuh:wazuh)
root@aio-ubuntu-arm:~# curl -sk -X PUT "https://192.168.18.238:55000/agents/upgrade_custom?agents_list=003&file_path=/var/wazuh-manager/var/upgrade/wazuh-agent_5.0.0-0_windows_bb14dea.msi.wpk&pretty=true" -H "Authorization: Bearer $TOKEN"
{
   "data": {
      "affected_items": [
         "003"
      ],
      "total_affected_items": 1,
      "total_failed_items": 0,
      "failed_items": []
   },
   "message": "All upgrade tasks were created",
   "error": 0
}
```

The agent receives the task and start the update:

Linux:

```text
...
2026/08/06 16:07:24 wazuh-agentd: INFO: https_client: remote_upgrade task ca07196e-fc80-312e-33d7-48d72638952a dispatched to the upgrade module (installer running; the agent may restart shortly). No /control response is sent.
...
```

From `upgrade.log`:

```text
2026/08/06 16:07:29 - Upgrade started.
2026/08/06 16:07:29 - Checking execution path.
2026/08/06 16:07:29 - Checking connectivity to 192.168.18.238:1517.
2026/08/06 16:07:29 - Manager reachable at 192.168.18.238:1517.
(Reading database ... 78140 files and directories currently installed.)
Preparing to unpack .../wazuh-agent_5.0.0-0_arm64_8b81704.deb ...
Unpacking wazuh-agent (5.0.0-0) over (5.0.0-0) ...
Setting up wazuh-agent (5.0.0-0) ...
Processing triggers for libc-bin (2.39-0ubuntu8.7) ...
2026/08/06 16:07:39 - Installation result = 0
2026/08/06 16:07:39 - Checking for Wazuh Agent control script.
2026/08/06 16:07:39 - Restarting Wazuh Agent.
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v5.0.0 Stopped
Starting Wazuh v5.0.0...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
2026/08/06 16:07:47 - Waiting connection... Remaining attempts: 30.
2026/08/06 16:07:48 - Status = connected.
2026/08/06 16:07:48 - Connected to manager.
2026/08/06 16:07:48 - Upgrade finished successfully.
```

Macos:

```text
...
2026/08/06 23:35:54 wazuh-agentd: INFO: https_client: remote_upgrade task 6ef92310-6615-1aba-d623-680038c968b0 dispatched to the upgrade module (installer running; the agent may restart shortly). No /control response is sent.
...
```

From `upgrade.log`:

```text
2026/08/06 23:35:59 - Upgrade started.
2026/08/06 23:35:59 - Checking execution path.
2026/08/06 23:35:59 - Checking connectivity to 192.168.18.238:1517.
2026/08/06 23:35:59 - Manager reachable at 192.168.18.238:1517.
installer: Package name is wazuh-agent_5.0.0-1_arm64_8b81704
installer: Upgrading at base path /
installer: The upgrade was successful.
2026/08/06 23:36:08 - Installation result = 0
2026/08/06 23:36:08 - Checking for Wazuh Agent control script.
2026/08/06 23:36:08 - Restarting Wazuh Agent.
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-agentd...
Killing wazuh-execd...
Wazuh v5.0.0 Stopped
Starting Wazuh v5.0.0...
Started wazuh-execd...
Started wazuh-agentd...
Started wazuh-syscheckd...
Started wazuh-logcollector...
Started wazuh-modulesd...
Completed.
2026/08/06 23:36:26 - Waiting connection... Remaining attempts: 30.
2026/08/06 23:36:27 - Status = connected.
2026/08/06 23:36:28 - Connected to manager.
2026/08/06 23:36:28 - Upgrade finished successfully.
```

Windows:

```text
...
2026/08/06 21:02:55 wazuh-agent: INFO: https_client: remote_upgrade task bcd6b3cb-91af-ea0c-0715-827314a8dae1 dispatched to the upgrade module (installer running; the agent may restart shortly). No /control response is sent.
...
```

From `upgrade.log`:

```text
2026-08-06 21:03:07Z - Sysnative Powershell will be used to access the registry.
2026-08-06 21:03:08Z - Found Wazuh installation at: HKLM:\SOFTWARE\WOW6432Node\Wazuh, Inc.\Wazuh Agent\WazuhInstallDir = C:\Program Files (x86)\ossec-agent\
2026-08-06 21:03:08Z - Extracted version from VERSION.json : 5.0.0.
2026-08-06 21:03:08Z - Current version: 5.0.0.
2026-08-06 21:03:08Z - Extracting the version from MSI file.
2026-08-06 21:03:13Z - MSI new version: v5.0.0.
2026-08-06 21:03:14Z - Checking connectivity to 192.168.18.238:1517.
2026-08-06 21:03:14Z - Manager reachable at 192.168.18.238:1517.
2026-08-06 21:03:14Z - Killed msiexec process(es).
2026-08-06 21:03:14Z - Stopping win32ui process.
2026-08-06 21:03:14Z - Tried to stop process win32ui: Cannot find a process with the name "win32ui". Verify the process name and call the cmdlet again.
2026-08-06 21:03:14Z - Stopping Wazuh service.
2026-08-06 21:03:20Z - Starting upgrade process.
2026-08-06 21:03:20Z - Installing MSI to: C:\Program Files (x86)\ossec-agent\ (msiexec.exe /i wazuh-agent_5.0.0-0_windows_bb14dea.msi APPLICATIONFOLDER="C:\Program Files (x86)\ossec-agent\" WIXUI_INSTALLDIR=APPLICATIONFOLDER REBOOT=ReallySuppress /qn /l*v installer.log)
2026-08-06 21:03:26Z - Extracted version from VERSION.json : 5.0.0.
2026-08-06 21:03:26Z - Waiting for the Wazuh-Agent installation to end.
2026-08-06 21:03:28Z - Extracted version from VERSION.json : 5.0.0.
2026-08-06 21:03:28Z - Waiting for the Wazuh-Agent installation to end.
2026-08-06 21:03:30Z - Extracted version from VERSION.json : 5.0.0.
2026-08-06 21:03:30Z - Waiting for the Wazuh-Agent installation to end.
2026-08-06 21:03:32Z - Extracted version from VERSION.json : 5.0.0.
2026-08-06 21:03:32Z - Waiting for the Wazuh-Agent installation to end.
2026-08-06 21:03:34Z - Extracted version from VERSION.json : 5.0.0.
2026-08-06 21:03:34Z - Waiting for the Wazuh-Agent installation to end.
2026-08-06 21:03:36Z - Extracted version from VERSION.json : 5.0.0.
2026-08-06 21:03:36Z - Starting Wazuh-Agent service.
2026-08-06 21:03:37Z - Installation finished.
2026-08-06 21:03:37Z - Process ID: 1668.
2026-08-06 21:03:47Z - Reading status file: status='connected'.
2026-08-06 21:03:48Z - Upgrade finished successfully.
2026-08-06 21:03:48Z - Extracted version from VERSION.json : 5.0.0.
2026-08-06 21:03:48Z - New version: 5.0.0.
```

After upgrade the agent reconnects and sends the stateless event (currently lands as unclassified):

<img width="2504" height="644" alt="Screenshot 2026-08-06 at 7 09 24 PM" src="https://github.com/user-attachments/assets/95fee4c4-87a1-44c1-90c8-3dd47eabae66" />

<img width="1977" height="622" alt="image" src="https://github.com/user-attachments/assets/aaece7fa-f221-4eef-bcb0-26dbc178e892" />

<img width="1986" height="623" alt="image" src="https://github.com/user-attachments/assets/31a6dced-ce16-45eb-9c0c-7d5d4311f8a3" />

<img width="1981" height="1024" alt="image" src="https://github.com/user-attachments/assets/fb18ef94-f078-48bd-b3c2-5272a44e2586" />

### Artifacts Affected

- Agent executables: `wazuh-agentd` (configuration reader), `wazuh-modulesd` (upgrade module) and `win32ui.exe` (Manage-Agent).
- Default configuration files: `etc/ossec-agent.conf` and `src/win32/ossec.conf` now ship `<agent>` with port `1517`.
- Packages: every agent package, through the installer scripts that write the connection block (`inst-functions.sh`, `register_configure_agent.sh`, `InstallerScripts.vbs`).
- WPK contents: `pkg_installer.sh` and `do_upgrade.ps1` ship inside the WPK.

### Configuration Changes

- `<client>` is renamed to `<agent>`. A configuration carrying only `<client>` still starts, with `<server><address>` read from it and the port defaulted, and the agent logs what it inherited. Every other option in a legacy `<client>` block stops taking effect, so the rename is the supported end state.
- The two names can appear together, and usefully so: because the legacy reader only fires while no server is set, an `<agent>` block holding just `<ssl>` supplies TLS while a legacy `<client><server>` still supplies the address. That is the minimal edit that makes an upgraded 4.x configuration able to transmit, and it is verified end to end.
- `<manager>` is no longer accepted; use `<server>`.
- `<agent><server><port>` defaults to `1517`. A `<port>` inside a legacy `<client><server>` block is ignored.

### Documentation Updates

- `docs/guide/migration/upgrade-4x-to-5x.md`: the `<client>` → `<agent>` rename and its fallback, `<manager>` now invalid, the `1517` default, the before/after example, connectivity checks and troubleshooting on the new port, and a new "Remote upgrade (WPK)" section covering the probe and its abort semantics.
- `docs/ref/modules/agent_upgrade/README.md`: the agent reports the outcome as a stateless event and erases its local `upgrade_result`.
- `docs/ref/modules/client/configuration.md` and `README.md`: block renamed, port default `1517`, a legacy `<client><server><port>` documented as ignored.
- `docs/ref/configuration/agent/README.md` and `etc/templates/config/README.md`: index row and template example.

### Tests Introduced

- `src/unit_tests/config/test_client-config_https.c`.
- `src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_agent.c`.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...