### PR TITLE
Enforce password validation for empty passwords in `update_user`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Fixed a spurious `StarletteDeprecationWarning` printed by `agent_upgrade` at startup. ([#38085](https://github.com/wazuh/wazuh/pull/38085))
 - Fixed the API login attempt limit not being applied consistently under concurrent requests. ([#38135](https://github.com/wazuh/wazuh/pull/38135))
 - Fixed a heap buffer write in `wazuh-analysisd` when generating FIM alerts by resizing `full_log` before writing. ([#38145](https://github.com/wazuh/wazuh/pull/38145))
+- Fixed password validation not being enforced for empty passwords in the `update_user` API endpoint. ([#38180](https://github.com/wazuh/wazuh/pull/38180))
 
 ### Agent
 

--- a/framework/wazuh/security.py
+++ b/framework/wazuh/security.py
@@ -223,7 +223,7 @@ def update_user(user_id: str = None, password: str = None, current_user: str = N
     """
     if password is None:
         raise WazuhError(4001)
-    if password:
+    if password is not None:
         if len(password) > 64 or len(password) < 8:
             raise WazuhError(5009)
         elif not _user_password.match(password):

--- a/framework/wazuh/tests/data/security/users_roles_test_cases.yml
+++ b/framework/wazuh/tests/data/security/users_roles_test_cases.yml
@@ -164,6 +164,25 @@ update_user:
       failed_items:
         "5011":
           - 1
+  - params:
+      user_id:
+        - 1
+      password: ""
+      current_user: normal
+    result:
+      affected_items: []
+      failed_items:
+        "5009":
+          - 1
+  - params:
+      user_id:
+        - 102
+      password: ""
+    result:
+      affected_items: []
+      failed_items:
+        "5009":
+          - 102
 remove_users:
   - params:
       user_ids:


### PR DESCRIPTION
## Description
`update_user` in the security framework only ran its password validation when the password was truthy, so an empty string skipped the length, complexity, and reserved-user checks and was accepted. The fix compares the password against `None` instead, so every provided password is validated and an empty one is rejected with error 5009.

## Proposed Changes
- `framework/wazuh/security.py`: in `update_user`, replace `if password:` with `if password is not None:` so the validation runs for every non-`None` password.
- `framework/wazuh/tests/data/security/users_roles_test_cases.yml`: add two `update_user` cases asserting that an empty password is rejected with `WazuhError(5009)`.

### Results and Evidence
Tests run with the bundled interpreter (`/var/ossec/framework/python/bin/python3`, Python 3.10) in a virtualenv with `framework/requirements-dev.txt`.

- Full `test_security.py` with the fix: **74 passed**.
- The two new cases fail without the fix and pass with it.
- Live check against the running patched manager: updating a user with an empty password is rejected with `HTTP 400` / `error 5009`; existing valid credentials continue to authenticate normally.

### Artifacts Affected
`wazuh-manager` — API/framework Python code (`framework/wazuh/security.py`). No binaries or packaging changes.

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
Two data-driven `update_user` cases in `framework/wazuh/tests/data/security/users_roles_test_cases.yml`, exercised by `test_security` in `framework/wazuh/tests/test_security.py`.

## Credits
Reported by @iabdullah215.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
