### PR TITLE
Report macOS 26 and 27 release codenames

### DIFF
--- a/.github/actions/install_build_deps/action.yml
+++ b/.github/actions/install_build_deps/action.yml
@@ -39,13 +39,29 @@ runs:
       run: |
         if [[ "${{ inputs.target }}" == "winagent" ]]; then
           echo "Installing CMocka by sources with 'winagent' required flags"
-          curl -L --retry 3 --retry-delay 2 -o /tmp/stable-1.1.tar.gz https://git.cryptomilk.org/projects/cmocka.git/snapshot/stable-1.1.tar.gz
-          # Verify if the download was successful
-          if [ $? -ne 0 ]; then
+
+          CMOCKA_TARBALL="/tmp/stable-1.1.tar.gz"
+          CMOCKA_URL="https://git.cryptomilk.org/projects/cmocka.git/snapshot/stable-1.1.tar.gz"
+          CMOCKA_MIRROR_URL="https://gitlab.com/cmocka/cmocka/-/archive/cmocka-1.1.8/cmocka-cmocka-1.1.8.tar.gz"
+
+          if ! curl -L --retry 3 --retry-delay 2 --connect-timeout 15 -o "$CMOCKA_TARBALL" "$CMOCKA_URL" \
+             || ! gzip -t "$CMOCKA_TARBALL" 2>/dev/null; then
+            echo "Primary CMocka download failed or returned an invalid archive. Falling back to the GitLab mirror (verified same content, cmocka 1.1.8)..."
+            if ! curl -L --retry 3 --retry-delay 2 --connect-timeout 15 -o "$CMOCKA_TARBALL" "$CMOCKA_MIRROR_URL"; then
               echo "Error during download. Exiting..."
               exit 1
+            fi
           fi
-          tar -zxf /tmp/stable-1.1.tar.gz -C /tmp/
+
+          tar -zxf "$CMOCKA_TARBALL" -C /tmp/
+          # The GitLab mirror's archive extracts to a differently-named top-level
+          # directory than the origin's; normalize it so the rest of this script
+          # doesn't care which source was actually used.
+          tar_list="$(tar -tzf "$CMOCKA_TARBALL")"
+          extracted_dir="$(echo "$tar_list" | head -1 | cut -d/ -f1)"
+          if [ "$extracted_dir" != "stable-1.1" ]; then
+            mv "/tmp/$extracted_dir" /tmp/stable-1.1
+          fi
           sed -i "s|ON|OFF|g" /tmp/stable-1.1/DefineOptions.cmake
           mkdir /tmp/stable-1.1/build
           cd /tmp/stable-1.1/build

--- a/src/data_provider/src/osinfo/sysOsParsers.cpp
+++ b/src/data_provider/src/osinfo/sysOsParsers.cpp
@@ -457,6 +457,8 @@ bool MacOsParser::parseUname(const std::string& in, nlohmann::json& output)
         {"22", "Ventura"},
         {"23", "Sonoma"},
         {"24", "Sequoia"},
+        {"25", "Tahoe"},
+        {"26", "Golden Gate"},
     };
     constexpr auto PATTERN_MATCH{"[0-9]+"};
     std::string match;

--- a/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
+++ b/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
@@ -614,6 +614,72 @@ TEST_F(SysInfoParsersTest, MacOS)
     EXPECT_EQ("6", output["os_patch"]);
 }
 
+TEST_F(SysInfoParsersTest, MacOSTahoeCodename)
+{
+    constexpr auto MACOS_SW_VERSION
+    {
+        R"(
+        ProductName:	macOS
+        ProductVersion:	26.5.1
+        BuildVersion:	25F74
+        )"
+    };
+    constexpr auto MACOS_UNAME
+    {
+        "25.5.0"
+    };
+    nlohmann::json output;
+    MacOsParser parser;
+    EXPECT_TRUE(parser.parseSwVersion(MACOS_SW_VERSION, output));
+    EXPECT_TRUE(parser.parseUname(MACOS_UNAME, output));
+    EXPECT_EQ("26.5.1", output["os_version"]);
+    EXPECT_EQ("Tahoe", output["os_codename"]);
+}
+
+TEST_F(SysInfoParsersTest, MacOSGoldenGateCodename)
+{
+    constexpr auto MACOS_SW_VERSION
+    {
+        R"(
+        ProductName:	macOS
+        ProductVersion:	27.0
+        BuildVersion:	26A5000a
+        )"
+    };
+    constexpr auto MACOS_UNAME
+    {
+        "26.0.0"
+    };
+    nlohmann::json output;
+    MacOsParser parser;
+    EXPECT_TRUE(parser.parseSwVersion(MACOS_SW_VERSION, output));
+    EXPECT_TRUE(parser.parseUname(MACOS_UNAME, output));
+    EXPECT_EQ("27.0", output["os_version"]);
+    EXPECT_EQ("Golden Gate", output["os_codename"]);
+}
+
+TEST_F(SysInfoParsersTest, MacOSUnmappedCodenameIsEmpty)
+{
+    constexpr auto MACOS_SW_VERSION
+    {
+        R"(
+        ProductName:	macOS
+        ProductVersion:	28.0
+        BuildVersion:	27A100
+        )"
+    };
+    constexpr auto MACOS_UNAME
+    {
+        "27.0.0"
+    };
+    nlohmann::json output;
+    MacOsParser parser;
+    EXPECT_TRUE(parser.parseSwVersion(MACOS_SW_VERSION, output));
+    EXPECT_TRUE(parser.parseUname(MACOS_UNAME, output));
+    EXPECT_EQ("28.0", output["os_version"]);
+    EXPECT_EQ("", output["os_codename"]);
+}
+
 TEST_F(SysInfoParsersTest, MacOSOsDefaultName)
 {
     constexpr auto MACOS_SW_VERSION

--- a/src/headers/version_op.h
+++ b/src/headers/version_op.h
@@ -37,6 +37,9 @@ typedef struct os_info {
 } os_info;
 
 
+/// Value returned by OSX_ReleaseName() when the Darwin version is not mapped to a release name.
+#define OSX_UNKNOWN_RELEASE_NAME "Unknown"
+
 /**
  * @brief Get the macOS release name corresponding to a version number.
  *

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -393,6 +393,8 @@ const char *OSX_ReleaseName(int version) {
     /* 22 */ "Ventura",
     /* 23 */ "Sonoma",
     /* 24 */ "Sequoia",
+    /* 25 */ "Tahoe",
+    /* 26 */ "Golden Gate",
     };
 
     version -= 10;
@@ -400,7 +402,7 @@ const char *OSX_ReleaseName(int version) {
     if (version >= 0 && (unsigned)version < sizeof(R_NAMES) / sizeof(char *)) {
         return R_NAMES[version];
     } else {
-        return "Unknown";
+        return OSX_UNKNOWN_RELEASE_NAME;
     }
 }
 
@@ -788,7 +790,13 @@ os_info *get_unix_version()
                             char *kern = NULL;
                             os_malloc(match_size + 1, kern);
                             snprintf(kern, match_size +1, "%.*s", match_size, buff + match[1].rm_so);
-                            w_strdup(OSX_ReleaseName(atoi(kern)), info->os_codename);
+                            const char *release_name = OSX_ReleaseName(atoi(kern));
+                            /* Leave the codename unset for Darwin versions that are not in the release
+                             * name table yet, so the reported version stays clean instead of showing
+                             * "<version> (Unknown)" on every macOS release newer than the table. */
+                            if (strcmp(release_name, OSX_UNKNOWN_RELEASE_NAME) != 0) {
+                                w_strdup(release_name, info->os_codename);
+                            }
                             free(kern);
                         }
                         pclose(cmd_output_ver);

--- a/src/unit_tests/shared/test_version_op.c
+++ b/src/unit_tests/shared/test_version_op.c
@@ -1263,6 +1263,133 @@ void test_get_unix_version_fail_os_release_uname_darwin(void **state)
     assert_string_equal(ret->sysname, "Linux");
 }
 
+/* Feed the mocks needed to reach the macOS branch of get_unix_version(), so the caller only has to
+ * provide the sw_vers product version and the uname -r output under test. */
+static void expect_darwin_version_calls(const char *product_version, const char *kernel_release)
+{
+    static const char *RELEASE_FILES[] = {
+        "/etc/os-release", "/usr/lib/os-release", "/etc/centos-release", "/etc/fedora-release",
+        "/etc/redhat-release", "/etc/arch-release", "/etc/gentoo-release", "/etc/SuSE-release",
+        "/etc/lsb-release", "/etc/debian_version", "/etc/slackware-version", "/etc/alpine-release",
+    };
+
+    for (unsigned i = 0; i < sizeof(RELEASE_FILES) / sizeof(char *); i++) {
+        expect_string(__wrap_wfopen, path, RELEASE_FILES[i]);
+        expect_string(__wrap_wfopen, mode, "r");
+        will_return(__wrap_wfopen, 0);
+    }
+
+    // uname
+    char *uname_path = NULL;
+    os_strdup("/path/to/uname", uname_path);
+    expect_string(__wrap_get_binary_path, command, "uname");
+    will_return(__wrap_get_binary_path, uname_path);
+    will_return(__wrap_get_binary_path, 0);
+
+    expect_string(__wrap_popen, command, "/path/to/uname");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "Darwin\n");
+
+    // system_profiler SPSoftwareDataType
+    char *system_profiler_path = NULL;
+    os_strdup("/path/to/system_profiler", system_profiler_path);
+    expect_string(__wrap_get_binary_path, command, "system_profiler");
+    will_return(__wrap_get_binary_path, system_profiler_path);
+    will_return(__wrap_get_binary_path, 0);
+
+    expect_string(__wrap_popen, command, "/path/to/system_profiler SPSoftwareDataType");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "Software:\n");
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "    System Version: macOS 26.5.1 (25F74)\n");
+
+    expect_value(__wrap_pclose, __stream, 1);
+    will_return(__wrap_pclose, 1);
+
+    // sw_vers -productVersion
+    char *sw_vers_path = NULL;
+    os_strdup("/path/to/sw_vers", sw_vers_path);
+    expect_string(__wrap_get_binary_path, command, "sw_vers");
+    will_return(__wrap_get_binary_path, sw_vers_path);
+    will_return(__wrap_get_binary_path, 0);
+
+    expect_string(__wrap_popen, command, "/path/to/sw_vers -productVersion");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, product_version);
+
+    expect_value(__wrap_pclose, __stream, 1);
+    will_return(__wrap_pclose, 1);
+
+    // sw_vers -buildVersion
+    expect_string(__wrap_popen, command, "/path/to/sw_vers -buildVersion");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "25F74\n");
+
+    expect_value(__wrap_pclose, __stream, 1);
+    will_return(__wrap_pclose, 1);
+
+    // uname -r
+    expect_string(__wrap_popen, command, "/path/to/uname -r");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, kernel_release);
+
+    expect_value(__wrap_pclose, __stream, 1);
+    will_return(__wrap_pclose, 1);
+
+    expect_value(__wrap_pclose, __stream, 1);
+    will_return(__wrap_pclose, 1);
+}
+
+void test_get_unix_version_darwin_mapped_codename(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // macOS 26 Tahoe runs Darwin 25
+    expect_darwin_version_calls("26.5.1\n", "25.5.0\n");
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_platform, "darwin");
+    assert_string_equal(ret->os_codename, "Tahoe");
+    assert_string_equal(ret->os_version, "26.5.1 (Tahoe)");
+}
+
+void test_get_unix_version_darwin_unmapped_codename(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Darwin version newer than the release name table: no codename, and no "(Unknown)" suffix
+    expect_darwin_version_calls("28.0\n", "27.0.0\n");
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_platform, "darwin");
+    assert_null(ret->os_codename);
+    assert_string_equal(ret->os_version, "28.0");
+}
+
 void test_get_unix_version_fail_os_release_uname_darwin_no_key(void **state)
 {
     (void) state;
@@ -2185,7 +2312,9 @@ void test_OSX_ReleaseName(void **state) {
     assert_string_equal(OSX_ReleaseName(22), "Ventura");
     assert_string_equal(OSX_ReleaseName(23), "Sonoma");
     assert_string_equal(OSX_ReleaseName(24), "Sequoia");
-    assert_string_equal(OSX_ReleaseName(25), "Unknown");
+    assert_string_equal(OSX_ReleaseName(25), "Tahoe");
+    assert_string_equal(OSX_ReleaseName(26), "Golden Gate");
+    assert_string_equal(OSX_ReleaseName(27), "Unknown");
 }
 
 #endif
@@ -2381,6 +2510,8 @@ int main(void) {
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_alpine, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_darwin, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_darwin_no_key, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_darwin_mapped_codename, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_darwin_unmapped_codename, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_sunos, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_sunos_10_scenario_one, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_sunos_10_scenario_two, delete_os_info),


### PR DESCRIPTION
## Description

Closes #38185

macOS agents on macOS 26 (Tahoe) report their operating system as `macOS 26.5.1 (Unknown)`. The codename is not read from the system, since macOS does not expose it: the agent derives it from the Darwin kernel major version through a hardcoded table that was last updated for macOS 15 Sequoia (Darwin 24). macOS 26 runs Darwin 25, which falls outside the table, so the lookup returns the literal string `Unknown` and that value is appended to the reported version.

This PR adds the missing releases to the table and stops appending the codename when it cannot be resolved, so a macOS release newer than the table reports a plain version instead of a visible defect.

## Proposed Changes

- Added the missing Darwin to release name mappings in `src/shared/version_op.c` (`OSX_ReleaseName`): `25` to `Tahoe` (macOS 26) and `26` to `Golden Gate` (macOS 27, currently in beta).
- Added the same two entries to `MAC_CODENAME_MAP` in `src/data_provider/src/osinfo/sysOsParsers.cpp`, which feeds the `agent_info` module and the system inventory `os_codename` field. This table is a second, independent copy of the same mapping.
- Added the `OSX_UNKNOWN_RELEASE_NAME` definition in `src/headers/version_op.h`, so callers can detect the fallback value instead of comparing against a duplicated literal.
- `get_unix_version()` no longer stores the codename when it resolves to the fallback. As a result the reported version stays clean (`26.5.1`) instead of `26.5.1 (Unknown)` for any macOS release newer than the table. This matches the existing behaviour of Linux distributions that do not publish a codename, such as Amazon Linux 2023.

Note on compatibility: the manager already tolerates a macOS version string without the parenthesized codename. `remoted_op.c` strips the ` (...)` suffix when parsing the agent uname string, and the existing unit tests already cover the empty codename case.

<details>
<summary>Unrelated CI fix included: cmocka download for <code>winagent</code> jobs</summary>

This branch also carries one change outside the scope of the issue, in `.github/actions/install_build_deps/action.yml`. It is needed because the `winagent` jobs of this PR cannot run without it.

`git.cryptomilk.org` now serves its cgit snapshot endpoint behind anti-bot protection and answers `HTTP 500` with an HTML page. The step downloaded that page, and since `curl` exits 0 on an HTTP error, the existing `if [ $? -ne 0 ]` guard never triggered, so the job failed later at `tar`:

```sql
100  3261    0  3261    0     0   8500      0
gzip: stdin: not in gzip format
tar: Child returned status 1
##[error]Process completed with exit code 2.
```

Only `winagent` legs are affected, because they build cmocka from source with mingw cross-compile flags. Every other target installs `libcmocka-dev` from apt, which is why the other checks passed.

The change validates the downloaded archive and falls back to the GitLab mirror, normalizing the extracted directory name. It is taken verbatim from wazuh/wazuh#38188, which applied the same fix to `5.0.0`, so the `Install CMocka` step is byte-identical between this branch and `origin/5.0.0` and future merges of this segment stay clean.

Applied here on the suggestion of the author of #38188, to unblock this PR. If reviewers prefer it as a standalone CI pull request against `4.14.8`, so that it can merge independently and unblock other 4.x branches, this commit can be moved out on request.

</details>

### Results and Evidence

#### Summary

| What | Result |
|---|---|
| Agent build (`make TARGET=agent TEST=yes DEBUG=1`) | Passed, no errors |
| `test_version_op` unit tests | 48/48 passed |
| `sysinfo_unit_test`, macOS cases | 5/5 passed |
| Real macOS 26.5.2 Tahoe agent, codename reported | `Unknown` before, `Tahoe` after |
| Syscollector OS inventory, codename stored | empty before, `Tahoe` after |
| Ubuntu control agent | Unaffected, still `Noble Numbat` |

#### Verified on a real macOS 26 Tahoe host

One host, `macOS 26.5.2` on `Darwin 25.5.0`, arm64 (Apple M2), enrolled twice against the same 4.14.7 manager: agent 001 with the unmodified `v4.14.7` package and agent 002 with a `v4.14.8` package built from this branch. The manager itself is agent 000 on Ubuntu 24.04 and acts as the control case. The agent build is the only variable between 001 and 002.

| Agent | Agent version | OS | Darwin | OS code name | OS version reported |
|---|---|---|---|---|---|
| 001 `macos-tahoe-baseline` | v4.14.7 | macOS 26.5.2 | 25.5.0 | `Unknown` | `26.5.2` |
| 002 `macos-tahoe-fix` | v4.14.8, this branch | macOS 26.5.2 | 25.5.0 | **`Tahoe`** | `26.5.2` |

Both affected code paths were checked, since the codename is resolved twice by two independent tables:

> Note on the 4.x agent list: the Endpoints "Operating system" column keeps showing `macOS 26.5.2` for both agents, and that is correct. The 4.x manager splits the parenthesized codename out of the version string into its own column (`remoted_op.c`), so on this branch the fix is observable in the `os_codename` field rather than in the displayed string. On 5.x the fix was also validated on a real Tahoe host: the system inventory field `host.os.codename` goes from `null` to `Tahoe`. There, the agent list shows `macOS 26.5.2 (Tahoe)` only for roughly the first minute after the agent starts, because the `agent_info` module then overwrites `host.os.version` with the sysinfo value, whose codename lives in a separate field that the 5.x agent record does not carry.

<details>
<summary>Endpoints, Export formatted (CSV), before and after side by side</summary>

```sql
ID,Status,Name,IP address,Group,Manager,Node,Registration date,Version,Last keep alive,OS version architecture,OS version build,OS code name,OS version major,OS version minor,OS name,OS platform,OS uname,OS version
000,active,ip-XXX-XXX-XXX-XXX,XXX,,ip-XXX-XXX-XXX-XXX,node01,2026-08-04T19:45:55+00:00,Wazuh v4.14.7,9999-12-31T23:59:59+00:00,x86_64,,Noble Numbat,24,04,Ubuntu,ubuntu,Linux |ip-XXX-XXX-XXX-XXX |6.17.0-1015-aws |#15~24.04.1-Ubuntu SMP Thu May  7 17:00:14 UTC 2026 |x86_64,24.04.4 LTS
001,disconnected,macos-tahoe-baseline,XXX,"[""default""]",ip-XXX-XXX-XXX-XXX,node01,2026-08-04T19:52:50+00:00,Wazuh v4.14.7,2026-08-04T20:25:41+00:00,arm64,,Unknown,26,5,macOS,darwin,Darwin |ip-XXX-XXX-XXX-XXX.ec2.internal |25.5.0 |Darwin Kernel Version 25.5.0: Tue Jun  9 22:27:52 PDT 2026; root:xnu-12377.121.10~1/RELEASE_ARM64_T8112 |arm64,26.5.2
002,active,macos-tahoe-fix,XXX,"[""default""]",ip-XXX-XXX-XXX-XXX,node01,2026-08-04T20:32:10+00:00,Wazuh v4.14.8,2026-08-04T20:32:50+00:00,arm64,,Tahoe,26,5,macOS,darwin,Darwin |ip-XXX-XXX-XXX-XXX.ec2.internal |25.5.0 |Darwin Kernel Version 25.5.0: Tue Jun  9 22:27:52 PDT 2026; root:xnu-12377.121.10~1/RELEASE_ARM64_T8112 |arm64,26.5.2
```

`uname -r` reports `25.5.0` for macOS `26.5.2`, which is the Darwin 25 to macOS 26 Tahoe mapping added by this PR.

</details>

<details>
<summary>Manager databases, baseline agent (001, v4.14.7)</summary>

```sql
sqlite3 /var/ossec/queue/db/global.db "SELECT id, os_name, os_version, os_codename, os_major, os_minor FROM agent WHERE id=1;"
1|macOS|26.5.2|Unknown|26|5

sqlite3 /var/ossec/queue/db/001.db "SELECT os_name, os_version, os_codename, os_major, os_minor, os_build FROM sys_osinfo;"
macOS|26.5.2||26|5|25F84
```

Both fallbacks appear at once: `Unknown` from `version_op.c` and an empty string from `sysOsParsers.cpp`.

</details>

<details>
<summary>Manager database, fixed agent (002, v4.14.8 from this branch)</summary>

```sql
sqlite3 /var/ossec/queue/db/002.db "SELECT os_name, os_version, os_codename, os_build FROM sys_osinfo;"
macOS|26.5.2|Tahoe|25F84
```

The system inventory scan now stores the codename, where the baseline stored an empty string.

</details>

<details>
<summary>API responses, baseline agent (001, v4.14.7)</summary>

```sql
GET /agents?agents_list=001&select=os.name,os.version,os.codename,os.major,os.minor,os.build
        "os": {
          "codename": "Unknown",
          "major": "26",
          "minor": "5",
          "name": "macOS",
          "version": "26.5.2"
        },

GET /syscollector/001/os
        "os": {
          "build": "25F84",
          "major": "26",
          "minor": "5",
          "name": "macOS",
          "platform": "darwin",
          "version": "26.5.2"
        },
        "release": "25.5.0",
        "sysname": "Darwin",
        "architecture": "arm64",
```

`os.codename` is absent from the syscollector response rather than reported as `Unknown`, because the API omits the empty stored value.

</details>

<details>
<summary>Unit tests, <code>test_version_op</code> (48 tests, macOS cases shown)</summary>

```sql
[ RUN      ] test_get_unix_version_fail_os_release_uname_darwin
[       OK ] test_get_unix_version_fail_os_release_uname_darwin
[ RUN      ] test_get_unix_version_fail_os_release_uname_darwin_no_key
[       OK ] test_get_unix_version_fail_os_release_uname_darwin_no_key
[ RUN      ] test_get_unix_version_darwin_mapped_codename
[       OK ] test_get_unix_version_darwin_mapped_codename
[ RUN      ] test_get_unix_version_darwin_unmapped_codename
[       OK ] test_get_unix_version_darwin_unmapped_codename
[ RUN      ] test_OSX_ReleaseName
[       OK ] test_OSX_ReleaseName
[==========] tests: 48 test(s) run.
[  PASSED  ] 48 test(s).
```

</details>

<details>
<summary>Unit tests, <code>sysinfo_unit_test</code> (macOS parser cases)</summary>

```sql
[==========] Running 5 tests from 1 test suite.
[ RUN      ] SysInfoParsersTest.MacOS
[       OK ] SysInfoParsersTest.MacOS (2 ms)
[ RUN      ] SysInfoParsersTest.MacOSTahoeCodename
[       OK ] SysInfoParsersTest.MacOSTahoeCodename (0 ms)
[ RUN      ] SysInfoParsersTest.MacOSGoldenGateCodename
[       OK ] SysInfoParsersTest.MacOSGoldenGateCodename (0 ms)
[ RUN      ] SysInfoParsersTest.MacOSUnmappedCodenameIsEmpty
[       OK ] SysInfoParsersTest.MacOSUnmappedCodenameIsEmpty (0 ms)
[ RUN      ] SysInfoParsersTest.MacOSOsDefaultName
[       OK ] SysInfoParsersTest.MacOSOsDefaultName (0 ms)
[  PASSED  ] 5 tests.
```

</details>

#### Behaviour of the changed lookup, per Darwin version

| Darwin | macOS | Reported codename | Reported version on the agent |
|---|---|---|---|
| 24 | 15 Sequoia | `Sequoia` | `15.6 (Sequoia)` |
| 25 | 26 Tahoe | `Tahoe` | `26.5.2 (Tahoe)` |
| 26 | 27 Golden Gate | `Golden Gate` | `27.0 (Golden Gate)` |
| 27 | not released | none | `28.0`, with no `(Unknown)` suffix |

Rows for Darwin 24 and 25 are confirmed on real hosts. Darwin 26 and 27 are covered by unit tests only, since no macOS 27 host was available.

### Artifacts Affected

- `wazuh-agentd` (agent metadata sent in the keepalive, and the legacy uname string).
- `libsysinfo` / `libsyscollector` (system inventory `os_codename`).
- All macOS agent packages. Linux and Windows agents are unaffected in behaviour, but the shared library is rebuilt.

### Configuration Changes

N/A. 

### Documentation Updates

N/A.

### Tests Introduced

- `src/unit_tests/shared/test_version_op.c`:
  - Extended `test_OSX_ReleaseName` with Darwin `25` (`Tahoe`), `26` (`Golden Gate`) and `27` (still `Unknown`).
  - `test_get_unix_version_darwin_mapped_codename`: a macOS host on Darwin 25 reports `os_codename` `Tahoe` and `os_version` `26.5.1 (Tahoe)`.
  - `test_get_unix_version_darwin_unmapped_codename`: a macOS host on a Darwin version outside the table reports no codename and a bare `28.0`, with no `(Unknown)` suffix.
- `src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp`:
  - `MacOSTahoeCodename` and `MacOSGoldenGateCodename`: `sw_vers` plus `uname -r` output resolve to the new codenames.
  - `MacOSUnmappedCodenameIsEmpty`: an unmapped Darwin version yields an empty codename.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)