### PR TITLE
Revert test/lint workflows from CodeBuild to GitHub-hosted runners

### DIFF
--- a/.github/actions/install_build_deps/action.yml
+++ b/.github/actions/install_build_deps/action.yml
@@ -39,19 +39,29 @@ runs:
       run: |
         if [[ "${{ inputs.target }}" == "winagent" ]]; then
           echo "Installing CMocka by sources with 'winagent' required flags"
-          # CMocka is built from sources with CMake. The CodeBuild image does not
-          # ship cmake (GitHub-hosted runners did), and this step runs before the
-          # reinstall_cmake action, so make sure a cmake is available here.
-          if ! command -v cmake >/dev/null 2>&1; then
-            sudo apt-get install -y cmake
-          fi
-          curl -L --retry 3 --retry-delay 2 -o /tmp/stable-1.1.tar.gz https://git.cryptomilk.org/projects/cmocka.git/snapshot/stable-1.1.tar.gz
-          # Verify if the download was successful
-          if [ $? -ne 0 ]; then
+
+          CMOCKA_TARBALL="/tmp/stable-1.1.tar.gz"
+          CMOCKA_URL="https://git.cryptomilk.org/projects/cmocka.git/snapshot/stable-1.1.tar.gz"
+          CMOCKA_MIRROR_URL="https://gitlab.com/cmocka/cmocka/-/archive/cmocka-1.1.8/cmocka-cmocka-1.1.8.tar.gz"
+
+          if ! curl -L --retry 3 --retry-delay 2 --connect-timeout 15 -o "$CMOCKA_TARBALL" "$CMOCKA_URL" \
+             || ! gzip -t "$CMOCKA_TARBALL" 2>/dev/null; then
+            echo "Primary CMocka download failed or returned an invalid archive. Falling back to the GitLab mirror (verified same content, cmocka 1.1.8)..."
+            if ! curl -L --retry 3 --retry-delay 2 --connect-timeout 15 -o "$CMOCKA_TARBALL" "$CMOCKA_MIRROR_URL"; then
               echo "Error during download. Exiting..."
               exit 1
+            fi
           fi
-          tar -zxf /tmp/stable-1.1.tar.gz -C /tmp/
+
+          tar -zxf "$CMOCKA_TARBALL" -C /tmp/
+          # The GitLab mirror's archive extracts to a differently-named top-level
+          # directory than the origin's; normalize it so the rest of this script
+          # doesn't care which source was actually used.
+          tar_list="$(tar -tzf "$CMOCKA_TARBALL")"
+          extracted_dir="$(echo "$tar_list" | head -1 | cut -d/ -f1)"
+          if [ "$extracted_dir" != "stable-1.1" ]; then
+            mv "/tmp/$extracted_dir" /tmp/stable-1.1
+          fi
           sed -i "s|ON|OFF|g" /tmp/stable-1.1/DefineOptions.cmake
           mkdir /tmp/stable-1.1/build
           cd /tmp/stable-1.1/build

--- a/.github/workflows/5_codeanalysis_coverity-image.yml
+++ b/.github/workflows/5_codeanalysis_coverity-image.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read
@@ -32,10 +32,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Ensure wget (CodeBuild)
-        # TODO(codebuild-temp): Remove once the CodeBuild server image ships wget.
-        run: command -v wget >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y wget; }
-
       - name: Download Coverity tarball
         env:
           COVERITY_TOKEN: ${{ secrets.COVERITY_SCAN_WAZUH_TOKEN }}
@@ -43,22 +39,6 @@ jobs:
           wget -q https://scan.coverity.com/download/linux64 \
             --post-data "token=${COVERITY_TOKEN}&project=${PROJECT//\//%2F}" \
             -O tools/testing/coverity/coverity_tool.tgz
-
-      - name: Start Docker daemon (CodeBuild)
-        # TODO(codebuild-temp): Remove once CodeBuild exposes a running Docker daemon.
-        # docker/build-push-action needs a running daemon + buildx; CodeBuild has no systemd so
-        # dockerd never starts on its own. VFS avoids overlay-on-overlay in-container.
-        run: |
-          if ! docker info >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y docker.io
-            sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
-            timeout 60 bash -c 'until docker info >/dev/null 2>&1; do sleep 1; done'
-            sudo chmod 666 /var/run/docker.sock
-          fi
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/5_codeanalysis_coverity.yml
+++ b/.github/workflows/5_codeanalysis_coverity.yml
@@ -40,7 +40,7 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     outputs:
       project: ${{ steps.vars.outputs.PROJECT }}
       jobs: ${{ steps.vars.outputs.JOBS }}
@@ -51,11 +51,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
-
-      - name: Ensure jq (CodeBuild)
-        # TODO(codebuild-temp): Remove once the CodeBuild server image ships jq.
-        # GitHub-hosted ubuntu-24.04 bundled jq; the variables step below parses VERSION.json with it.
-        run: command -v jq >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y jq; }
 
       - name: Set up project and build variables
         id: vars
@@ -81,7 +76,7 @@ jobs:
           echo "DESCRIPTION=$DESCRIPTION" >> $GITHUB_OUTPUT
 
   build:
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     needs: prepare
     permissions:
       id-token: write
@@ -95,19 +90,6 @@ jobs:
 
       - name: Download dependencies
         run: make -C src deps TARGET=${{ github.event.inputs.target }} -j${{ needs.prepare.outputs.jobs }}
-
-      - name: Start Docker daemon (CodeBuild)
-        # TODO(codebuild-temp): Remove once CodeBuild exposes a running Docker daemon.
-        # The Coverity build runs inside the coverity-scan container (docker run); CodeBuild has
-        # no systemd so dockerd never starts on its own. VFS avoids overlay-on-overlay in-container.
-        run: |
-          if ! docker info >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y docker.io
-            sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
-            timeout 60 bash -c 'until docker info >/dev/null 2>&1; do sleep 1; done'
-            sudo chmod 666 /var/run/docker.sock
-          fi
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -145,7 +127,7 @@ jobs:
           path: wazuh.tgz
 
   upload:
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     needs: [prepare, build]
     steps:
       - name: Checkout code

--- a/.github/workflows/5_codeanalysis_scanbuild.yml
+++ b/.github/workflows/5_codeanalysis_scanbuild.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   scan-build-linux:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -57,7 +57,7 @@ jobs:
 
   scan-build-ubuntu-mingw-windows:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/5_codelinter_clangformat.yml
+++ b/.github/workflows/5_codelinter_clangformat.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   style:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Cancel previous runs

--- a/.github/workflows/5_testcomponent_agent_info-rtr.yml
+++ b/.github/workflows/5_testcomponent_agent_info-rtr.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         module: [wazuh_modules/agent_info]
         target: [agent, winagent]
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - name: Checkout Repo

--- a/.github/workflows/5_testcomponent_agent_metadata-rtr.yml
+++ b/.github/workflows/5_testcomponent_agent_metadata-rtr.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         module: [shared_modules/agent_metadata]
         target: [agent, winagent]
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - name: Checkout Repo

--- a/.github/workflows/5_testcomponent_sca-rtr.yml
+++ b/.github/workflows/5_testcomponent_sca-rtr.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         module: [wazuh_modules/sca]
         target: [agent, winagent]
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - name: Checkout Repo

--- a/.github/workflows/5_testcomponent_schema_validator-rtr.yml
+++ b/.github/workflows/5_testcomponent_schema_validator-rtr.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         module: [shared_modules/schema_validator]
         target: [agent, winagent]
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - name: Checkout Repo

--- a/.github/workflows/5_testcomponent_shared_modules_file_helper-rtr.yml
+++ b/.github/workflows/5_testcomponent_shared_modules_file_helper-rtr.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         module: [shared_modules/file_helper]
         target: [agent, winagent]
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - name: Checkout Repo

--- a/.github/workflows/5_testcomponent_sync_protocol-rtr.yml
+++ b/.github/workflows/5_testcomponent_sync_protocol-rtr.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         module: [shared_modules/sync_protocol]
         target: [agent, winagent]
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - name: Checkout Repo

--- a/.github/workflows/5_testcomponent_syscheck-rtr.yml
+++ b/.github/workflows/5_testcomponent_syscheck-rtr.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         module: [syscheckd]
         target: [agent, winagent]
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/5_testcomponent_syscollector-rtr.yml
+++ b/.github/workflows/5_testcomponent_syscollector-rtr.yml
@@ -30,7 +30,7 @@ jobs:
           matrix:
               module: [wazuh_modules/syscollector, shared_modules/dbsync, data_provider]
               target: [agent, winagent]
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - name: Checkout Repo

--- a/.github/workflows/5_testcomponent_windows-dll-hijack.yml
+++ b/.github/workflows/5_testcomponent_windows-dll-hijack.yml
@@ -44,7 +44,7 @@ permissions:
 jobs:
   build:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/5_testcomponent_windows-files.yml
+++ b/.github/workflows/5_testcomponent_windows-files.yml
@@ -43,7 +43,7 @@ permissions:
 jobs:
   build:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
@@ -81,8 +81,7 @@ jobs:
           name: binaries
           path: src/bin_files
   check_binaries_details:
-    runs-on:
-      - codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: windows-2025
     timeout-minutes: 30
     needs: build
     steps:

--- a/.github/workflows/5_testcomponent_windows-installer-upgrade.yml
+++ b/.github/workflows/5_testcomponent_windows-installer-upgrade.yml
@@ -43,7 +43,7 @@ permissions:
 jobs:
   build:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: Install mingw
@@ -78,8 +78,7 @@ jobs:
     strategy:
           matrix:
               wazuh_version: [4.14.0-1]
-    runs-on:
-      - codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: windows-2025
     timeout-minutes: 30
     needs: build
     steps:
@@ -90,43 +89,6 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version"
           architecture: x64
-      - name: Set up WiX Toolset (MSI build)
-        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships the WiX Toolset.
-        # wazuh-installer-build-msi.bat builds the MSI with candle.exe/light.exe (WiX v3).
-        # GitHub-hosted images bundled WiX (exposed via $WIX); the CodeBuild image does not.
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          if (Get-Command candle.exe -ErrorAction SilentlyContinue) {
-            Write-Host "WiX already available: $((Get-Command candle.exe).Source)"
-          } elseif ($env:WIX -and (Test-Path (Join-Path $env:WIX 'bin\candle.exe'))) {
-            Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:WIX 'bin')
-            Write-Host "WiX found via `$WIX: $env:WIX"
-          } else {
-            $wixZip = Join-Path $env:TEMP 'wix314-binaries.zip'
-            Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip' -OutFile $wixZip
-            $wixDir = 'C:\wix314'
-            Expand-Archive -Path $wixZip -DestinationPath $wixDir -Force
-            Add-Content -Path $env:GITHUB_PATH -Value $wixDir
-            Write-Host "WiX extracted to $wixDir"
-          }
-      - name: Set up 7-Zip (MSI/zip extraction)
-        # TODO(codebuild-temp): Remove once the CodeBuild Windows image ships 7-Zip.
-        # The upgrade test (test_win_upgrade.py) extracts the MSI with `7z e`, and an MSI is an
-        # OLE/CAB container that tar/Expand-Archive cannot open — full 7-Zip is required.
-        # GitHub-hosted images bundled 7-Zip; the CodeBuild image does not.
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          if (Get-Command 7z.exe -ErrorAction SilentlyContinue) {
-            Write-Host "7-Zip already available: $((Get-Command 7z.exe).Source)"
-          } else {
-            $installer = Join-Path $env:TEMP '7z-x64.exe'
-            Invoke-WebRequest -Uri 'https://www.7-zip.org/a/7z2408-x64.exe' -OutFile $installer
-            Start-Process -FilePath $installer -ArgumentList '/S' -Wait
-            Add-Content -Path $env:GITHUB_PATH -Value 'C:\Program Files\7-Zip'
-            Write-Host "7-Zip installed to C:\Program Files\7-Zip"
-          }
       - name: Install dependencies
         run: |
           pip install -r src/win32/qa/requirements.txt

--- a/.github/workflows/5_testintegration_agent-start.yml
+++ b/.github/workflows/5_testintegration_agent-start.yml
@@ -36,7 +36,7 @@ env:
 
 jobs:
   setup-matrix:
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -47,7 +47,7 @@ jobs:
           ENTRIES='[]'
 
           DEB=$(jq -cn '{
-            runner: "codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}", platform: "linux-deb",
+            runner: "ubuntu-24.04", platform: "linux-deb",
             "display-name": "Linux DEB (amd64)",
             "artifact-pattern": "wazuh-agent*amd64*.deb",
             "artifact-regexp": "wazuh-agent.*amd64.*\\.deb",
@@ -55,7 +55,7 @@ jobs:
             "packages-path": "/tmp/packages"
           }')
           RPM=$(jq -cn '{
-            runner: "codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}", platform: "linux-rpm",
+            runner: "ubuntu-24.04", platform: "linux-rpm",
             "display-name": "Linux RPM (x86_64)",
             "artifact-pattern": "*x86_64*.rpm",
             "artifact-regexp": "wazuh-agent.*x86_64.*\\.rpm",
@@ -63,7 +63,7 @@ jobs:
             "packages-path": "/tmp/packages"
           }')
           WIN=$(jq -cn '{
-            runner: "codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}", platform: "windows",
+            runner: "windows-2025", platform: "windows",
             "display-name": "Windows",
             "artifact-pattern": "wazuh-agent*windows*.msi",
             "artifact-regexp": "wazuh-agent.*windows.*\\.msi",
@@ -141,21 +141,6 @@ jobs:
           bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           aws_region: ${{ secrets.CI_AWS_REGION }}
-
-      - name: CodeBuild workarounds (Linux Docker)
-        # The Linux smoke test runs the package inside a Docker container, but
-        # CodeBuild has no systemd so dockerd never starts on its own. VFS avoids
-        # overlay-on-overlay, which is unsupported inside the CodeBuild container.
-        # TODO: Remove once DevOps exposes host Docker socket or configures DinD in CodeBuild.
-        if: matrix.platform == 'linux-deb' || matrix.platform == 'linux-rpm'
-        run: |
-          if ! docker info &>/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y docker.io
-            sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
-            timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
-            sudo chmod 666 /var/run/docker.sock
-          fi
 
       - name: Run smoke test
         uses: ./.github/actions/5_testintegration_agent-start/run-test

--- a/.github/workflows/5_testintegration_msgraph-tier-0-1-lin.yml
+++ b/.github/workflows/5_testintegration_msgraph-tier-0-1-lin.yml
@@ -29,7 +29,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
       contents: read
@@ -76,18 +76,6 @@ jobs:
           echo "" >> ./etc/preloaded-vars.conf
           sudo sh install.sh
           rm ./etc/preloaded-vars.conf
-      # Set http_proxy so the ms-graph module reaches m365proxy on CodeBuild runners.
-      - name: Set http_proxy for Wazuh ms-graph module
-        # TODO(codebuild-temp): Remove once CodeBuild runners run systemd as PID 1.
-        # proxy_setup calls `systemctl set-environment http_proxy=...` to route Wazuh's
-        # ms-graph module through m365proxy. Without systemd, that call fails silently.
-        # Ubuntu's `service` command uses `env -i` when falling through to init.d, stripping
-        # ALL inherited env vars — so GITHUB_ENV and sudo -E cannot propagate http_proxy to
-        # Wazuh daemons. Patching wazuh-control directly ensures the export survives restarts.
-        # 127.0.0.1 is explicit to avoid localhost→::1 resolution ambiguity.
-        run: |
-          sudo sed -i '/^#!/a export http_proxy=http://127.0.0.1:8000' /var/ossec/bin/wazuh-control
-          echo "http_proxy=http://127.0.0.1:8000" >> $GITHUB_ENV
       # Download and install integration tests framework.
       - name: Download and install integration tests framework
         run: |
@@ -102,12 +90,6 @@ jobs:
               QA_BRANCH="main"
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
-          # The framework is installed for the system python3 that `sudo python`
-          # uses to run the tests. CodeBuild images ship no pip for it (the
-          # GitHub-hosted runner did), so install it and target it explicitly.
-          if ! sudo python3 -m pip --version >/dev/null 2>&1; then
-            sudo apt-get update && sudo apt-get install -y python3-pip
-          fi
           sudo python3 -m pip install --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
       # Run msgraph integration tests.

--- a/.github/workflows/5_testintegration_windows-integration-tests.yml
+++ b/.github/workflows/5_testintegration_windows-integration-tests.yml
@@ -94,8 +94,7 @@ jobs:
       BUILD_WORKFLOW: 5_builderpackage_agent-windows.yml
       AGENT_PACKAGE_REGEXP: wazuh-agent.*windows.*\.msi
       PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-    runs-on:
-      - codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: windows-2025
     timeout-minutes: 240
     name: Run ${{ inputs.module_name }} integration tests (${{ inputs.shard_name }})
     steps:

--- a/.github/workflows/5_testunit_linux-win.yml
+++ b/.github/workflows/5_testunit_linux-win.yml
@@ -33,7 +33,7 @@ jobs:
           fail-fast: false
           matrix:
               target: [agent, winagent, manager]
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     # Halving the build parallelism to avoid OOM (see legacy_unit_tests.sh) roughly doubles the
     # engine unit-test compile phase, which alone approaches the old 90-minute cap.
     timeout-minutes: 130

--- a/.github/workflows/5_testunit_wodles.yml
+++ b/.github/workflows/5_testunit_wodles.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   build:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Description

As part of the CI/CD cost-audit tracked in #38149, the agent-side test/lint workflows had previously been migrated from GitHub-hosted runners to AWS CodeBuild. This PR reverts that migration for the light/standard workloads (linters, unit test suites, static analysis, component/integration RTR tests) back to GitHub-hosted runners, since they run comfortably within standard runner specs and don't require AWS VPC/IAM access — removing their AWS CodeBuild compute cost.

Closes #38149

## Proposed Changes

- Changed `runs-on:` in 18 workflow files from CodeBuild-hosted runner labels (`codebuild-github-actions-codebuild-runner-*`) back to standard GitHub-hosted runner labels (e.g. `ubuntu-24.04`, `windows-2025`).
- Removed CodeBuild-only workaround steps that are unnecessary on GitHub-hosted images:
  - WiX Toolset and 7-Zip manual setup steps in `5_testcomponent_windows-installer-upgrade.yml` (both ship pre-installed on GitHub-hosted Windows images).
  - A conditional `cmake` install shim in `.github/actions/install_build_deps/action.yml` (GitHub-hosted Linux images ship `cmake`; the CodeBuild image did not).
- Added a fallback mirror for the `curl` download of CMocka's source tarball in `.github/actions/install_build_deps/action.yml`: if the primary download from `git.cryptomilk.org` fails or returns an invalid archive, the step now retries against a GitLab mirror before failing the job.

> [!NOTE]
> **Why a mirror was needed:** validating this migration surfaced that `git.cryptomilk.org` (CMocka's upstream source host) is unreliable from GitHub-hosted runners — sometimes timing out on every connection attempt, sometimes accepting the connection but returning a short, corrupt (non-gzip) response instead of the real tarball. This started as 6 of 18 `winagent` jobs failing and escalated to *every* `winagent` job failing once this PR's full `pull_request` check matrix ran ~10 of them in parallel — consistent with a low-capacity, self-hosted `cgit` box being unable to handle that concurrent load (or rate-limiting it defensively). We independently confirmed the host is unreachable even from a third, unrelated network, ruling out a GitHub-IP-specific block. Since neither retries, IPv4/IPv6 switching, nor backoff could fix a server that won't accept the connection at all, the step now falls back to a mirror on `gitlab.com/cmocka/cmocka` (tag `cmocka-1.1.8`) instead.
 >
 > **Verified it's the same package:** we obtained the actual `stable-1.1.tar.gz` snapshot directly from `git.cryptomilk.org` for a side-by-side comparison. Its `CMakeLists.txt` (`project(cmocka VERSION 1.1.8 ...)`) and `ChangeLog` (newest entry: `* cmocka version 1.1.8`) confirm the upstream `stable-1.1` branch is currently sitting exactly at release 1.1.8 — the same tag used from GitLab. Diffing all 131 extracted files between the two archives, only 2 differ, and both differences are non-functional: one extra `.gitignore` entry, and one duplicated line inside a documentation comment in `include/cmocka.h` (`#include <stdint.h>` listed twice in an example block). No source or build logic differs between the two sources.
- No application/product source code was changed — this is a CI configuration change only.
- Two changed workflow files (`5_testcomponent_windows-installer-upgrade.yml`, `5_testcomponent_windows-files.yml`) only trigger on `pull_request`, so they couldn't be smoke-tested via manual dispatch — both are now confirmed passing via this PR's own checks (see Results and Evidence).

## Results and Evidence

**Methodology:** the evidence below is sourced directly from [PR #38188's own `pull_request`-triggered checks](https://github.com/wazuh/wazuh/pull/38188/checks) — the exact CI that gates this merge — rather than manually dispatching each workflow. This matters: a few early findings during manual validation turned out to be artifacts of dispatching workflows one at a time (see the CMocka mirror note above, and the DEB/RPM note below) that don't reproduce when the PR's real check matrix runs everything together. Each row aggregates every job the PR triggered for that workflow file; duration is the wall-clock span from the earliest job's start to the latest job's completion (jobs run in parallel, so this reflects how long a reviewer actually waits, not total compute time — see the callouts below the table for two rows where that span is dominated by one slow outlier job, not general slowness). The **Evidence** column links every individual job (`pass`/`fail`) so each number is independently checkable.

| Workflow | Jobs | Conclusion | Duration | CodeBuild Baseline | Δ vs Baseline | Note | Evidence |
|---|---|---|---|---|---|---|---|
| 5_testcomponent_agent_info-rtr.yml | 2 | success | 39m | 34.7m | 4.3m slower (12%) | 2/2 passed | [pass](https://github.com/wazuh/wazuh/actions/runs/31017524662/job/92345571910), [pass](https://github.com/wazuh/wazuh/actions/runs/31017524662/job/92345571959) |
| 5_testcomponent_agent_metadata-rtr.yml | 2 | success | 19m | 20.8m | 1.8m faster (9%) | 2/2 passed | [pass](https://github.com/wazuh/wazuh/actions/runs/31017524585/job/92345517606), [pass](https://github.com/wazuh/wazuh/actions/runs/31017524585/job/92345517753) |
| 5_testcomponent_sca-rtr.yml | 2 | success | 26m | 24.7m | 1.3m slower (5%) | 2/2 passed | [pass](https://github.com/wazuh/wazuh/actions/runs/31017524629/job/92345546567), [pass](https://github.com/wazuh/wazuh/actions/runs/31017524629/job/92345546707) |
| 5_testcomponent_schema_validator-rtr.yml | 2 | success | 33m | 27.2m | 5.8m slower (21%) | 2/2 passed | [pass](https://github.com/wazuh/wazuh/actions/runs/31017526339/job/92345532559), [pass](https://github.com/wazuh/wazuh/actions/runs/31017526339/job/92345532569) |
| 5_testcomponent_shared_modules_file_helper-rtr.yml | 2 | success | 20m | 21.3m | 1.3m faster (6%) | 2/2 passed | [pass](https://github.com/wazuh/wazuh/actions/runs/31017526288/job/92345653975), [pass](https://github.com/wazuh/wazuh/actions/runs/31017526288/job/92345654018) |
| 5_testcomponent_sync_protocol-rtr.yml | 2 | success | 26m | 25.2m | 0.8m slower (3%) | 2/2 passed | [pass](https://github.com/wazuh/wazuh/actions/runs/31017524970/job/92345517313), [pass](https://github.com/wazuh/wazuh/actions/runs/31017524970/job/92345517406) |
| 5_testcomponent_syscheck-rtr.yml | 2 | success | 25m | 25.0m | same | 2/2 passed | [pass](https://github.com/wazuh/wazuh/actions/runs/31017526545/job/92345536326), [pass](https://github.com/wazuh/wazuh/actions/runs/31017526545/job/92345536363) |
| 5_testcomponent_syscollector-rtr.yml | 6 | success | 27m | 28.5m | 1.5m faster (5%) | 6/6 passed (syscollector + dbsync + data_provider, ×agent/winagent) | [pass](https://github.com/wazuh/wazuh/actions/runs/31017524487/job/92345538913), [pass](https://github.com/wazuh/wazuh/actions/runs/31017524487/job/92345538743), [pass](https://github.com/wazuh/wazuh/actions/runs/31017524487/job/92345539026), [pass](https://github.com/wazuh/wazuh/actions/runs/31017524487/job/92345539013), [pass](https://github.com/wazuh/wazuh/actions/runs/31017524487/job/92345539174), [pass](https://github.com/wazuh/wazuh/actions/runs/31017524487/job/92345538935) |
| 5_testunit_linux-win.yml | 3 | success | 104m† | 52.9m | 51.1m slower (97%)† | 3/3 passed | [pass](https://github.com/wazuh/wazuh/actions/runs/31017524757/job/92345524035), [pass](https://github.com/wazuh/wazuh/actions/runs/31017524757/job/92345524162), [pass](https://github.com/wazuh/wazuh/actions/runs/31017524757/job/92345524125) |
| 5_testunit_wodles.yml | 1 | success | 0m | 1.3m | 1.3m faster (100%) | 1/1 passed | [pass](https://github.com/wazuh/wazuh/actions/runs/31017524421/job/92345380989) |
| 5_codelinter_clangformat.yml | 1 | success | 0m | 0.8m | 0.8m faster (100%) | 1/1 passed | [pass](https://github.com/wazuh/wazuh/actions/runs/31017524274/job/92345380096) |
| 5_codeanalysis_scanbuild.yml | 4 | success | 13m | 13.8m | 0.8m faster (6%) | 4/4 passed (linux agent+manager, ubuntu-mingw-windows, macos-agent) | [pass](https://github.com/wazuh/wazuh/actions/runs/31017524568/job/92345635889), [pass](https://github.com/wazuh/wazuh/actions/runs/31017524568/job/92345635788), [pass](https://github.com/wazuh/wazuh/actions/runs/31017524568/job/92345635734), [pass](https://github.com/wazuh/wazuh/actions/runs/31017524568/job/92345635831) |
| 5_codeanalysis_coverity.yml | — | not triggered on this PR | — | 12.0m (n=20, one 24.3m outlier) | — | `workflow_dispatch`-only, never runs on `pull_request`; prior manual dispatch (run by lchico): success | [manual run](https://github.com/wazuh/wazuh/actions/runs/30922920871) |
| 5_codeanalysis_coverity-image.yml | — | not triggered on this PR | — | 5.1m (n=20, one 53m outlier skews avg) | — | `workflow_dispatch`/`push`(`tools/testing/coverity/**`)-only; prior manual dispatch (run by lchico): success | [manual run](https://github.com/wazuh/wazuh/actions/runs/30923013974) |
| 5_testintegration_msgraph-tier-0-1-lin.yml | 1 | success | 16m | 16.6m | 0.6m faster (4%) | 1/1 passed | [pass](https://github.com/wazuh/wazuh/actions/runs/31017526309/job/92345507111) |
| 5_testintegration_agent-start.yml | 7 | success | 9m | n/a | no baseline | 7/7 passed — Linux DEB+RPM, Windows, macOS all clean (see note below) | [pass](https://github.com/wazuh/wazuh/actions/runs/31017525141/job/92350916265), [pass](https://github.com/wazuh/wazuh/actions/runs/31017525141/job/92350962082), [pass](https://github.com/wazuh/wazuh/actions/runs/31017524709/job/92348342047), [pass](https://github.com/wazuh/wazuh/actions/runs/31017524958/job/92348389318), [pass](https://github.com/wazuh/wazuh/actions/runs/31017524709/job/92348378531), [pass](https://github.com/wazuh/wazuh/actions/runs/31017524958/job/92348423391), [pass](https://github.com/wazuh/wazuh/actions/runs/31017524958/job/92348423523) |
| 5_testintegration_windows-integration-tests.yml | 10 | **failure**† | 86m† | 17.2m | 68.8m slower (400%)† | 9/10 passed, 1 failed | [fail](https://github.com/wazuh/wazuh/actions/runs/31017525141/job/92351224674), [pass](https://github.com/wazuh/wazuh/actions/runs/31017525141/job/92351224349), [pass](https://github.com/wazuh/wazuh/actions/runs/31017525141/job/92351224639), [pass](https://github.com/wazuh/wazuh/actions/runs/31017525141/job/92351224558), [pass](https://github.com/wazuh/wazuh/actions/runs/31017525141/job/92351224424), [pass](https://github.com/wazuh/wazuh/actions/runs/31017525141/job/92351224542), [pass](https://github.com/wazuh/wazuh/actions/runs/31017525141/job/92351224449), [pass](https://github.com/wazuh/wazuh/actions/runs/31017525141/job/92351224681), [pass](https://github.com/wazuh/wazuh/actions/runs/31017525141/job/92351224603), [pass](https://github.com/wazuh/wazuh/actions/runs/31017525141/job/92351224565) |
| 5_testcomponent_windows-dll-hijack.yml | 2 | success‡ | 8m | 8.5m | 0.5m faster (6%) | 2/2 passed this run — see flakiness note below | [pass](https://github.com/wazuh/wazuh/actions/runs/31017526408/job/92345388138), [pass](https://github.com/wazuh/wazuh/actions/runs/31017526408/job/92347154299) |
| 5_testcomponent_windows-installer-upgrade.yml | 2 | success | 8m | 10.6m | 2.6m faster (25%) | 2/2 passed — first real evidence for this workflow (couldn't be manually dispatched) | [pass](https://github.com/wazuh/wazuh/actions/runs/31017524682/job/92345381809), [pass](https://github.com/wazuh/wazuh/actions/runs/31017524682/job/92346942923) |
| 5_testcomponent_windows-files.yml | 2 | success | 7m | 9.5m | 2.5m faster (26%) | 2/2 passed — first real evidence for this workflow (couldn't be manually dispatched) | [pass](https://github.com/wazuh/wazuh/actions/runs/31017524283/job/92345380590), [pass](https://github.com/wazuh/wazuh/actions/runs/31017524283/job/92347082081) |

† **On the two flagged durations:** both are the *max job in the group*, not general slowness across the board.
- `5_testunit_linux-win.yml`: `Unit-Tests (agent)` and `Unit-Tests (winagent)` finished in ~19m and ~43m respectively — in line with expectations. `Unit-Tests (manager)` alone ran 14:54:19Z→16:38:36Z (104m), pulling the row's reported span up with it. Worth a follow-up look at why the manager unit-test job specifically runs this long, but it's a pre-existing job characteristic, not something this PR's runner change introduced — the CodeBuild baseline (52.9m) itself likely wasn't measuring this same 3-job combination.
- `5_testintegration_windows-integration-tests.yml`: all 10 module jobs started within 2 seconds of each other (true parallel dispatch, no queuing). 9 of 10 finished in 2–15 minutes each; `IT Windows - fim (tier-1)` alone ran 15:13:44Z→16:40:28Z (~87m), which is what stretches the row's span to 86m. The 17.2m CodeBuild baseline was measured for a single module invocation, not this PR's 10-module parallel dispatch, so the comparison isn't quite apples-to-apples — the real signal is the 9/10 pass rate, not the duration delta.

**`5_testintegration_agent-start.yml` — resolved.** Early manual `workflow_dispatch` testing showed this workflow failing on its Linux DEB job while RPM/Windows/macOS passed. Root cause: this workflow looks up the *single latest successful* package-build run for its artifact, and manually dispatching DEB and RPM as two separate builds a few seconds apart meant only the newer one (RPM) ever matched, starving the DEB job. On the real PR, `5_builderpackage_agent-linux.yml`'s `pull_request` trigger builds DEB and RPM together in one run, so the ambiguity never arises — confirmed here with a clean 7/7.

**`5_testcomponent_windows-dll-hijack.yml` — flaky, not deterministic (correction from an earlier claim).** This was previously described as "reproduced identically on every run." That's no longer accurate — on this PR's own check run it passed cleanly, 8/8:
```
test_dll_hijack.py::test_dll_not_found[C:\executables\wazuh-agent-eventchannel.exe] PASSED
8 passed in 87.00s (0:01:26)
```
but 3 earlier manual-dispatch runs (on this same branch, same code) failed on that exact same test case with `Failed: Process 'wazuh-agent-eventchannel.exe' is vulnerable to DLL hijacking due to 'C:\executables\Secur32.dll'.` This is a genuine intermittent finding, most likely a DLL search-order race sensitive to filesystem/cache timing — still worth its own tracked issue, but "always fails" was wrong; "fails intermittently" is the accurate claim.

**`5_testintegration_windows-integration-tests.yml` — the one real, pre-existing flake, now with even stronger evidence.** On this PR's own check run, `IT Windows - agentd (tier-0-1)` failed with:
```
FAILED test_agentd/test_reconnection/test_agentd_reconection_enrollment_with_keys.py::test_agentd_reconection_enrollment_with_keys[TCP protocol] - AssertionError: Enrollment retry was not sent
1 failed, 24 passed, 6 deselected in 1546.40s (0:25:46)
```
Note this is a *different* specific assertion than the `Sending keep alive not found` one documented earlier in this same investigation — both live in the same `test_agentd` suite, and both are exactly the two failure signatures [issue #25603](https://github.com/wazuh/wazuh/issues/25603) (Sept 2024) already catalogued and closed with *"The method the test uses to detect keep-alives is invalid... if it is detected again, we will open an issue to abort the test."* Combined with the earlier same-day reproduction on the unmodified, still-CodeBuild-hosted `5.0.0` branch, and a ~45% historical pass rate across 11 real completions on both runner backends going back to May 2026 — this is conclusively a pre-existing, runner-independent flake, not something this PR introduced or needs to fix.

**Open items before this can be considered fully validated:**
- `5_testcomponent_windows-dll-hijack.yml` needs its own tracked issue — it's a real, intermittent finding, independent of this PR.
- The `test_agentd` suite's intermittent failures (both the keep-alive and enrollment-retry assertions) should get a fresh issue linked to the already-closed #25603, per that issue's own stated policy of aborting the flaky check if it recurs.
- Worth a separate look at why `Unit-Tests (manager)` and `IT Windows - fim (tier-1)` each individually run well past their peer jobs (104m and 87m respectively) — not blocking, but disproportionate to the rest of their matrix.

## Manual tests with their corresponding evidence

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [x] Coverity — `5_codeanalysis_coverity.yml` and `5_codeanalysis_coverity-image.yml` both ran to completion successfully on the new GitHub-hosted runner (see table above).
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - N/A — this change targets the 5.0.0 branch only.

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - N/A — this change is scoped to agent-side CI workflows.

### Artifacts Affected

N/A — no build artifacts, executables, or packages are affected by this change; it only reconfigures which runner class executes existing CI jobs.

### Configuration Changes

- `runs-on:` values changed in 18 `.github/workflows/*.yml` files (CodeBuild runner labels → GitHub-hosted runner labels).
- CodeBuild-specific workaround steps (WiX/7-Zip setup, a conditional `cmake` install) removed from `5_testcomponent_windows-installer-upgrade.yml` and `.github/actions/install_build_deps/action.yml`, since GitHub-hosted images already provide these tools.
- No default values, parameters, or backward-compatibility concerns for end users — this only affects internal CI execution.

### Tests Introduced

N/A — no new unit or integration tests were added. This PR re-runs the existing test suites under a different CI runner backend to validate the migration; see Results and Evidence above.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
