### PR TITLE
Downsize non-compile agent package-build jobs to the CodeBuild `small` tier

### DIFF
--- a/.github/workflows/5_builderpackage_agent-linux-arm64.yml
+++ b/.github/workflows/5_builderpackage_agent-linux-arm64.yml
@@ -191,7 +191,9 @@ jobs:
       id-token: write
       contents: read
     needs: build-deb-arm64
-    runs-on: codebuild-github-actions-codebuild-runner-agent-arm-${{ github.run_id }}-${{ github.run_attempt }}
+    # `-small` overrides the instance size for this job only: no compilation
+    # happens here, so the 2 vCPU tier is sufficient. See #38174.
+    runs-on: codebuild-github-actions-codebuild-runner-agent-arm-${{ github.run_id }}-${{ github.run_attempt }}-small
     timeout-minutes: 30
     name: Test DEB package
 
@@ -312,7 +314,9 @@ jobs:
       contents: read
     needs: [build-deb-arm64, test-deb-arm64]
     if: success()
-    runs-on: codebuild-github-actions-codebuild-runner-agent-arm-${{ github.run_id }}-${{ github.run_attempt }}
+    # `-small` overrides the instance size for this job only: no compilation
+    # happens here, so the 2 vCPU tier is sufficient. See #38174.
+    runs-on: codebuild-github-actions-codebuild-runner-agent-arm-${{ github.run_id }}-${{ github.run_attempt }}-small
     timeout-minutes: 15
     name: Upload DEB to S3
 
@@ -535,7 +539,9 @@ jobs:
       id-token: write
       contents: read
     needs: build-rpm-arm64
-    runs-on: codebuild-github-actions-codebuild-runner-agent-arm-${{ github.run_id }}-${{ github.run_attempt }}
+    # `-small` overrides the instance size for this job only: no compilation
+    # happens here, so the 2 vCPU tier is sufficient. See #38174.
+    runs-on: codebuild-github-actions-codebuild-runner-agent-arm-${{ github.run_id }}-${{ github.run_attempt }}-small
     timeout-minutes: 30
     name: Test RPM package
 
@@ -656,7 +662,9 @@ jobs:
       contents: read
     needs: [build-rpm-arm64, test-rpm-arm64]
     if: success()
-    runs-on: codebuild-github-actions-codebuild-runner-agent-arm-${{ github.run_id }}-${{ github.run_attempt }}
+    # `-small` overrides the instance size for this job only: no compilation
+    # happens here, so the 2 vCPU tier is sufficient. See #38174.
+    runs-on: codebuild-github-actions-codebuild-runner-agent-arm-${{ github.run_id }}-${{ github.run_attempt }}-small
     timeout-minutes: 15
     name: Upload RPM to S3
 

--- a/.github/workflows/5_builderpackage_agent-linux-arm64.yml
+++ b/.github/workflows/5_builderpackage_agent-linux-arm64.yml
@@ -191,9 +191,7 @@ jobs:
       id-token: write
       contents: read
     needs: build-deb-arm64
-    # `-small` overrides the instance size for this job only: no compilation
-    # happens here, so the 2 vCPU tier is sufficient. See #38174.
-    runs-on: codebuild-github-actions-codebuild-runner-agent-arm-${{ github.run_id }}-${{ github.run_attempt }}-small
+    runs-on: codebuild-github-actions-codebuild-runner-agent-arm-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
     name: Test DEB package
 
@@ -539,9 +537,7 @@ jobs:
       id-token: write
       contents: read
     needs: build-rpm-arm64
-    # `-small` overrides the instance size for this job only: no compilation
-    # happens here, so the 2 vCPU tier is sufficient. See #38174.
-    runs-on: codebuild-github-actions-codebuild-runner-agent-arm-${{ github.run_id }}-${{ github.run_attempt }}-small
+    runs-on: codebuild-github-actions-codebuild-runner-agent-arm-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
     name: Test RPM package
 

--- a/.github/workflows/5_builderpackage_agent-linux.yml
+++ b/.github/workflows/5_builderpackage_agent-linux.yml
@@ -205,7 +205,9 @@ jobs:
       id-token: write
       contents: read
     needs: build-deb
-    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    # `-small` overrides the instance size for this job only: no compilation
+    # happens here, so the 2 vCPU tier is sufficient. See #38174.
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}-small
     timeout-minutes: 30
     name: Test DEB ${{ matrix.arch }} package
     strategy:
@@ -366,7 +368,9 @@ jobs:
       contents: read
     needs: [build-deb, test-deb]
     if: success()
-    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    # `-small` overrides the instance size for this job only: no compilation
+    # happens here, so the 2 vCPU tier is sufficient. See #38174.
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}-small
     timeout-minutes: 15
     name: Upload DEB ${{ matrix.arch }} to S3
     strategy:
@@ -574,7 +578,9 @@ jobs:
       id-token: write
       contents: read
     needs: build-rpm
-    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    # `-small` overrides the instance size for this job only: no compilation
+    # happens here, so the 2 vCPU tier is sufficient. See #38174.
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}-small
     timeout-minutes: 30
     name: Test RPM ${{ matrix.arch }} package
     strategy:
@@ -743,7 +749,9 @@ jobs:
       contents: read
     needs: [build-rpm, test-rpm]
     if: success()
-    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    # `-small` overrides the instance size for this job only: no compilation
+    # happens here, so the 2 vCPU tier is sufficient. See #38174.
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}-small
     timeout-minutes: 15
     name: Upload RPM ${{ matrix.arch }} to S3
     strategy:
@@ -825,7 +833,9 @@ jobs:
 
   detect-changes:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    # `-small` overrides the instance size for this job only: no compilation
+    # happens here, so the 2 vCPU tier is sufficient. See #38174.
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}-small
     timeout-minutes: 10
     name: Detect changed Linux test modules
     permissions:

--- a/.github/workflows/5_builderpackage_agent-macos.yml
+++ b/.github/workflows/5_builderpackage_agent-macos.yml
@@ -232,7 +232,9 @@ jobs:
       contents: read
     needs: [build-macos-intel64, test-macos-intel64]
     if: success()
-    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    # `-small` overrides the instance size for this job only: no compilation
+    # happens here, so the 2 vCPU tier is sufficient. See #38174.
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}-small
     timeout-minutes: 15
     name: Upload PKG to S3 (intel64)
 
@@ -493,7 +495,9 @@ jobs:
       contents: read
     needs: [build-macos-arm64, test-macos-arm64]
     if: success()
-    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    # `-small` overrides the instance size for this job only: no compilation
+    # happens here, so the 2 vCPU tier is sufficient. See #38174.
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}-small
     timeout-minutes: 15
     name: Upload PKG to S3 (arm64)
 
@@ -593,7 +597,9 @@ jobs:
 
   detect-changes:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    # `-small` overrides the instance size for this job only: no compilation
+    # happens here, so the 2 vCPU tier is sufficient. See #38174.
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}-small
     timeout-minutes: 10
     name: Detect changed macOS test modules
     permissions:

--- a/.github/workflows/5_builderpackage_agent-windows.yml
+++ b/.github/workflows/5_builderpackage_agent-windows.yml
@@ -56,7 +56,9 @@ permissions:
 jobs:
   detect-changes:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    # `-small` overrides the instance size for this job only: no compilation
+    # happens here, so the 2 vCPU tier is sufficient. See #38174.
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}-small
     name: Detect changed Windows test modules
     outputs:
       matrix: ${{ steps.detect.outputs.matrix }}
@@ -444,7 +446,9 @@ jobs:
       contents: read
     needs: [package-windows-i686, test-windows-i686]
     if: success()
-    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    # `-small` overrides the instance size for this job only: no compilation
+    # happens here, so the 2 vCPU tier is sufficient. See #38174.
+    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}-small
     timeout-minutes: 15
     name: Upload MSI to S3
 


### PR DESCRIPTION
# Downsize non-compile agent package-build jobs to the CodeBuild `small` tier

## Description

Related issue: #38174

The agent package-build workflows run every job on the project default of 4 vCPU / 8 GB, regardless of what the job actually does. A job that only downloads a package from S3 and verifies it gets the same hardware as a job that compiles the agent. CodeBuild bills per compute-minute at a per-tier rate, so the light jobs have been paying the compile-tier rate for work that peaks at a few hundred megabytes of RAM.

This PR appends the `-small` instance-size override to the 12 jobs across the four agent package-build workflows that do not compile anything and were measured to run no slower on the smaller tier. No CodeBuild project is modified: the override is per job, expressed in the runner label, and the `small` tier is already enabled on both the `agent-amd` and `agent-arm` projects.

Scope note: this is the `wazuh/wazuh` half of the work. The `wazuh-agent-packages` half is five further jobs and will come as a separate PR in that repo. This PR is intentionally not marked as closing #38174, since the issue also carries a savings-quantification acceptance criterion that needs per-job minute totals from AWS, which cannot be produced from inside the repo.

## Proposed Changes

The `-small` suffix is added to these 12 jobs:

| Workflow | Jobs resized |
|---|---|
| `5_builderpackage_agent-linux.yml` | `test-deb`, `test-rpm`, `upload-deb-to-s3`, `upload-rpm-to-s3`, `detect-changes` |
| `5_builderpackage_agent-linux-arm64.yml` | `upload-deb-arm64-to-s3`, `upload-rpm-arm64-to-s3` |
| `5_builderpackage_agent-windows.yml` | `detect-changes`, `upload-windows-i686-to-s3` |
| `5_builderpackage_agent-macos.yml` | `upload-macos-intel64-to-s3`, `upload-macos-arm64-to-s3`, `detect-changes` |

Each site looks like this, with the rationale inline so the suffix does not read as a typo:

```yaml
    # `-small` overrides the instance size for this job only: no compilation
    # happens here, so the 2 vCPU tier is sufficient. See #38174.
    runs-on: codebuild-github-actions-codebuild-runner-agent-amd-${{ github.run_id }}-${{ github.run_attempt }}-small
```

**What is deliberately left alone, and why.** The five compile jobs — `build-deb`, `build-rpm`, `build-deb-arm64`, `build-rpm-arm64`, `build-windows-i686` — keep the project default. CloudWatch shows them saturating 93–99 % of 4 vCPU while using only 29–36 % of RAM, and CodeBuild pairs vCPU and memory at a fixed ratio, so there is no tier that trims the unused memory while keeping 4 vCPU. Downsizing them would roughly double a ~6 minute compile at roughly half the rate: cost-neutral at best, and twice the PR feedback latency on workflows that run 700–800 times a month.

`package-windows-i686` and `test-windows-i686` are also unchanged, for a different reason: CodeBuild's Windows environments offer only `medium` and `large`, and the `agent-windows-amd` fleet already sits on `medium`. There is no smaller Windows tier to move to.

`test-deb-arm64` and `test-rpm-arm64` were resized in the first iteration of this PR and then reverted, because CI measured a 2.7× slowdown on both. The evidence is in the section below. Their amd64 counterparts are unaffected and stay resized, so the exclusion is specific to ARM rather than to package testing in general.

**Why the single-label form** (`…-${{ github.run_attempt }}-small`) rather than a `runs-on` list with `- instance-size:small`. With the list form, each override is a separate label, so jobs in the same workflow run end up carrying different numbers of labels — and AWS documents that a job with fewer labels can then be claimed by the runner created for a job with more, leaving the other job without a runner. Since this change resizes the light jobs but not the compile jobs in the same workflow, the list form would have required adding a unique custom label to every job in each file, including the ones not being resized. The single-label form registers exactly one label per runner, so the hazard cannot occur, and it keeps `runs-on:` scalar.

### Results and Evidence

**Override behaviour verified on a throwaway branch** before any of these edits were written. Four jobs, a baseline and a `-small` leg on each fleet, reporting `nproc`, `MemTotal`, architecture and `CODEBUILD_BUILD_IMAGE`. Run: https://github.com/wazuh/wazuh/actions/runs/30944545442 (the probe branch has since been deleted; the run is retained).

| Leg | vCPU | MemTotal | Arch | `CODEBUILD_BUILD_IMAGE` |
|---|---|---|---|---|
| `agent-amd` — baseline | 4 | 7.5 GiB | x86_64 | `aws/codebuild/standard:7.0` |
| `agent-amd` — `-small` | **2** | **3.6 GiB** | x86_64 | `aws/codebuild/standard:7.0` |
| `agent-arm` — baseline | 4 | 7.7 GiB | aarch64 | custom ECR `ubuntu-arm64-runner:latest` |
| `agent-arm` — `-small` | **2** | **3.8 GiB** | aarch64 | custom ECR `ubuntu-arm64-runner:latest` |

Three things this establishes. The bare suffix is parsed with the environment type and image identifier both omitted — vCPU actually dropped, so it was applied rather than silently ignored. The `agent-arm` project keeps its custom ECR image and stays on `aarch64` under the override, which was the material risk: a fallback to a curated default image would have broken the ARM builds outright. And `small` is already permitted on both projects, so no DevOps-side change is a prerequisite for merging this. Both `-small` legs finished in 2–4 seconds, the same as the baselines, so there is no cold-start penalty on the smaller tier.

The baseline legs are load-bearing evidence, not redundancy: an override that is silently ignored also produces a green job, and only the comparison against the baseline distinguishes "applied" from "ignored".

**Headroom for the resized jobs.** The `small` tier provides 2 vCPU and 3.6–3.8 GiB of usable `MemTotal`. Per the CloudWatch data gathered in wazuh-automation#3637, the package-verification jobs peak at roughly 300 MB on amd64 and 600 MB on ARM, and the upload and change-detection jobs are S3 transfers and `git diff`/`jq` invocations lasting well under a minute. Every resized job sits far below the new ceiling.

**Utilization of the jobs left at the default**, from the same source, showing why they were excluded:

| Job | CPU peak | Memory peak |
|---|---|---|
| Build DEB amd64 | 98.8 % of 4 vCPU | 2 740 MB (35.7 %) |
| Build RPM amd64 | 98.9 % | 2 734 MB (35.6 %) |
| Build DEB arm64 | 92.9 % | 2 408 MB (30.5 %) |
| Build RPM arm64 | 98.7 % | 2 306 MB (29.2 %) |

CPU percentages are CloudWatch's own; memory percentages are computed against the `MemTotal` measured above rather than the nominal 8 GB.

**Functional verification of the resized jobs themselves** comes from this PR's own CI. All four workflows are `pull_request`-triggered, so every resized job executes on the `small` tier as part of review. Two full CI runs were taken. Every resized job ran — none was skipped — and all passed, which matters because a green workflow could also mean the jobs never executed.

Durations were compared against four recent runs of the same workflows on other branches at the default tier, rather than against the per-workflow averages in #38149. Those averages have a minimum of 0 minutes because many runs skip everything matrix-driven, so they are not comparable to a full run.

| Job | `small`, run 1 | `small`, run 2 | Default tier baseline |
|---|---|---|---|
| `test-deb` (amd64) | 2.7 min | 3.0 min | 2.7 / 3.0 |
| `test-rpm` (amd64) | 3.9 min | 2.8 min | 2.4 / 3.0 |
| `upload-deb-to-s3` | 0.6 min | 0.6 min | 0.7 / 0.7 |
| `upload-rpm-to-s3` | 0.9 min | 0.6 min | 0.4 / 0.8 |
| `detect-changes` (Linux) | 0.9 min | 0.9 min | 0.7 / 0.7 |
| `upload-deb-arm64-to-s3` | 0.3 min | 0.3 min | 0.2–0.3 |
| `upload-rpm-arm64-to-s3` | 0.3 min | 0.3 min | 0.2–0.3 |

The compile jobs left at the default tier were checked too, to confirm the override did not leak: `build-deb-arm64` 5.7 / 5.5 min against a 5.6–5.9 baseline, `build-rpm-arm64` 6.8 / 7.2 against 7.0–7.6, `build-deb` 5.8 / 6.1 against 5.6–6.1, `build-windows-i686` 6.5 min against 6.5. All within normal variance.

**Why `test-deb-arm64` and `test-rpm-arm64` were reverted.** These two regressed sharply and reproducibly:

| Job | `small`, run 1 | `small`, run 2 | Default tier baseline | Factor |
|---|---|---|---|---|
| `test-deb-arm64` | 12.4 min | 11.8 min | 4.5 / 4.5 / 4.6 / 4.7 | ~2.6× |
| `test-rpm-arm64` | 16.9 min | 16.6 min | 5.7 / 6.4 / 6.4 / 6.6 | ~2.7× |

The baseline varies by ±0.5 min across four runs on four different branches, so a consistent 2.6–2.7× across two independent runs is not infrastructure noise. It is also a net loss in cost, not just in latency: the `small` tier bills at roughly half the per-minute rate, so 2.7× the duration is about 1.35× the spend. Both jobs are strictly worse on both axes, which is the regression the issue's own scope of work warns against.

The step-level breakdown of `test-rpm-arm64` locates most of it in one step:

| Step | `small` | Default tier |
|---|---|---|
| Download docker image for testing | 9.7 min | 2.9 min |
| Test install package | 2.0 min | 0.6 min |
| Test uninstall package | 2.2 min | 1.1 min |
| Test upgrade from 4.14.7 to 5.0.0 | 2.1 min | 1.2 min |
| CodeBuild workarounds | 0.4 min | 0.4 min |

The image pull accounts for about 65 % of the added time, but not all of it — the three test steps also ran 1.8–3.3× slower. So caching the test image would reduce the regression without removing it: with a free pull, the remaining steps still total ~6.7 min on `small` against ~3.3 min at the default tier. Reverting these two jobs is the right call independently of any future caching work.

**A side finding worth acting on separately.** On amd64 the same "Download docker image for testing" step takes 0.8 min *on the `small` tier*, against 2.9 min for ARM *at the default tier* — the ARM pull is roughly 3.6× slower before instance size is considered at all. That cost is being paid today, on every ARM package test job, and it dwarfs anything this PR saves. Worth investigating whether the ARM test image comes from a different registry, is substantially larger, or simply misses the Docker layer cache that the curated `aws/codebuild/standard:7.0` image provides and the custom `ubuntu-arm64-runner` image does not. This is out of scope here and is recorded on #38174 as a follow-up.

### Artifacts Affected

None. No package, binary, installer or artifact content changes; the produced DEB, RPM and MSI packages are byte-for-byte unaffected. The change is confined to which CodeBuild instance size executes 12 of these four workflows' non-compile jobs.

### Configuration Changes

No product or agent configuration changes. CI-only: four workflow files under `.github/workflows/`, 12 `runs-on:` lines plus their explanatory comments. No CodeBuild project, fleet or IAM change is required, and none was made.

### Documentation Updates

None required. The rationale is captured inline at each changed site and in the audit comment on #38174.

### Tests Introduced

None. This is a CI configuration change with no product code, so there is no unit or integration test to add. The evidence in place of tests is twofold: the pre-flight probe run linked above, which validated the override mechanism in isolation, and this PR's own CI runs, which exercise all 12 resized jobs end to end and are what caught the ARM regression.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
