### PR TITLE
Validate the agent HTTPS connection and configuration block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,4 +128,5 @@
 | [#37543](https://github.com/wazuh/wazuh/issues/37543) | Fixed agent-info module caching cluster_name, cluster_node, and agent_groups from a one-time handshake at startup, causing stale values in `agent_metadata` until the agent process restarted. |
 | [#37993](https://github.com/wazuh/wazuh/issues/37993) | Fixed `wazuh-syscheckd` failing the `file_entry.checksum` NOT NULL constraint when the deferred sync-flag update ran for an entry deleted during the scan. |
 | [#37993](https://github.com/wazuh/wazuh/issues/37993) | Fixed `wazuh-syscheckd` failure on shutdown, which logged "Invalid handle value", crashed the process and left a stale PID file. |
+| [#38163](https://github.com/wazuh/wazuh/issues/38163) | Fixed `wazuh-agentd` crashing on start when the agent metadata segment could only be opened read-only, which happens whenever a root process creates it before the daemon drops privileges. |
 

--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -15,7 +15,7 @@
          Set to 'full' or 'certificate' and provide certificate_authorities to verify the
          manager's certificate. -->
     <ssl>
-      <certificate_authorities>PATH</certificate_authorities>
+      <!-- <certificate_authorities>etc/certs/root-ca.pem</certificate_authorities> -->
       <verification_mode>none</verification_mode>
     </ssl>
 

--- a/src/client-agent/https_client/demo/mock_manager.py
+++ b/src/client-agent/https_client/demo/mock_manager.py
@@ -134,9 +134,10 @@ class Handler(BaseHTTPRequestHandler):
     def _log_tls_once(self):
         """Print what the handshake actually negotiated, once per connection.
 
-        This is the observable half of <ssl><ciphers> and <ssl><certificate>/<key>:
-        the agent's config is only proven to have a runtime effect if the manager
-        can see the suite it picked and the client cert it presented (#38163).
+        This is the observable half of <ssl><certificate>/<key>: the agent's config
+        is only proven to have a runtime effect if the manager can see the client
+        cert it presented. The negotiated suite is logged alongside it so the TLS
+        version in use is visible, not because this demo restricts it (#38163).
         """
         if getattr(self, "_tls_logged", False):
             return
@@ -396,31 +397,33 @@ def main():
     parser.add_argument("--cert", required=True)
     parser.add_argument("--key", required=True)
     parser.add_argument("--key-hex", default="000102030405060708090a0b0c0d0e0f")
-    # The two below exist for the connection/config validation (#38163): the agent's
-    # <ssl><certificate>/<key> and <ssl><ciphers> can only be shown to have a runtime
-    # effect against a manager that actually demands a client cert / restricts the suites.
+    # Exists for the connection/config validation (#38163): the agent's
+    # <ssl><certificate>/<key> can only be shown to have a runtime effect against a
+    # manager that actually demands a client certificate.
     parser.add_argument("--client-ca",
                         help="Require a client certificate and verify it against this CA "
                              "(mutual TLS). Without it, client certs are not requested.")
-    parser.add_argument("--ciphers",
-                        help="Restrict the suites this manager offers, e.g. "
-                             "'ECDHE-RSA-AES256-GCM-SHA384'. A client whose <ciphers> "
-                             "does not intersect this list fails the handshake.")
     args = parser.parse_args()
 
     Handler.key_hex = args.key_hex
     context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     context.load_cert_chain(args.cert, args.key)
 
+    # Same floor remoted enforces (SSL_CTX_set_min_proto_version in
+    # RestinioHttpServer), so the demo negotiates what a real manager would.
+    #
+    # There is deliberately no --ciphers here. Restricting the suites would mean
+    # SSL_CTX_set_ciphersuites(), which Python's ssl module does not expose:
+    # set_ciphers() governs TLS 1.2 and below only and rejects 1.3 suite names
+    # outright. The one way to make a restriction observable was to cap the
+    # server at TLS 1.2, which an agent that requires 1.3 can no longer reach --
+    # the handshake would fail before any suite was chosen. <ssl><ciphers> is
+    # therefore validated against a real manager, not here.
+    context.minimum_version = ssl.TLSVersion.TLSv1_3
+
     if args.client_ca:
         context.verify_mode = ssl.CERT_REQUIRED
         context.load_verify_locations(args.client_ca)
-
-    if args.ciphers:
-        # TLS 1.3 suites are negotiated separately and set_ciphers() does not
-        # constrain them, so pin to 1.2 to make the restriction observable.
-        context.maximum_version = ssl.TLSVersion.TLSv1_2
-        context.set_ciphers(args.ciphers)
 
     server = ThreadingHTTPServer(("127.0.0.1", args.port), Handler)
     server.requires_client_cert = bool(args.client_ca)
@@ -428,7 +431,7 @@ def main():
     log(f"HTTPS manager on https://127.0.0.1:{args.port} "
         f"(agent key {args.key_hex[:8]}..)")
     log(f"     mutual TLS: {'required, CA ' + args.client_ca if args.client_ca else 'not requested'}")
-    log(f"     ciphers:    {args.ciphers if args.ciphers else 'default (unrestricted)'}")
+    log(f"     min TLS:    1.3")
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/src/client-agent/https_client/demo/mock_manager.py
+++ b/src/client-agent/https_client/demo/mock_manager.py
@@ -131,6 +131,27 @@ class Handler(BaseHTTPRequestHandler):
     def _config_blob(cls):
         return cls.CONFIG_V2 if cls.notify_count >= cls.CONFIG_FLIP_AT else cls.CONFIG_V1
 
+    def _log_tls_once(self):
+        """Print what the handshake actually negotiated, once per connection.
+
+        This is the observable half of <ssl><ciphers> and <ssl><certificate>/<key>:
+        the agent's config is only proven to have a runtime effect if the manager
+        can see the suite it picked and the client cert it presented (#38163).
+        """
+        if getattr(self, "_tls_logged", False):
+            return
+        self._tls_logged = True
+        conn = self.connection
+        cipher = conn.cipher() if hasattr(conn, "cipher") else None
+        peer = conn.getpeercert() if hasattr(conn, "getpeercert") else None
+        if cipher:
+            log(f"TLS  cipher={cipher[0]} proto={cipher[1]}")
+        if peer:
+            subject = dict(x[0] for x in peer.get("subject", ()))
+            log(f"TLS  client cert presented: subject={subject}")
+        elif getattr(self.server, "requires_client_cert", False):
+            log("TLS  client cert REQUIRED but none presented")
+
     def log_message(self, *_):  # silence the default noisy logging
         pass
 
@@ -181,6 +202,7 @@ class Handler(BaseHTTPRequestHandler):
         self.wfile.write(b"0\r\n\r\n")
 
     def do_POST(self):
+        self._log_tls_once()
         length = int(self.headers.get("Content-Length", 0))
         body = self.rfile.read(length)
         target = self.path
@@ -308,6 +330,10 @@ class Handler(BaseHTTPRequestHandler):
         cluster = doc.get("cluster", {})
         log(f"     {target:<11} -> 200  stored: agent_id={doc.get('agent_id')} "
             f"cluster={cluster.get('name')}/{cluster.get('node')} keys={sorted(doc.keys())}")
+        # The whole document, for the field-contract comparison against the
+        # manager side (#38136). The preview in do_POST() truncates at 70 bytes,
+        # which is not enough to see the per-module bodies.
+        log(f"     {target} FULL BODY: {json.dumps(doc, sort_keys=True)}")
 
     def _handle_stateful(self, body):
         session = self.headers.get("X-Session-Id", "?")
@@ -370,16 +396,39 @@ def main():
     parser.add_argument("--cert", required=True)
     parser.add_argument("--key", required=True)
     parser.add_argument("--key-hex", default="000102030405060708090a0b0c0d0e0f")
+    # The two below exist for the connection/config validation (#38163): the agent's
+    # <ssl><certificate>/<key> and <ssl><ciphers> can only be shown to have a runtime
+    # effect against a manager that actually demands a client cert / restricts the suites.
+    parser.add_argument("--client-ca",
+                        help="Require a client certificate and verify it against this CA "
+                             "(mutual TLS). Without it, client certs are not requested.")
+    parser.add_argument("--ciphers",
+                        help="Restrict the suites this manager offers, e.g. "
+                             "'ECDHE-RSA-AES256-GCM-SHA384'. A client whose <ciphers> "
+                             "does not intersect this list fails the handshake.")
     args = parser.parse_args()
 
     Handler.key_hex = args.key_hex
     context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     context.load_cert_chain(args.cert, args.key)
 
+    if args.client_ca:
+        context.verify_mode = ssl.CERT_REQUIRED
+        context.load_verify_locations(args.client_ca)
+
+    if args.ciphers:
+        # TLS 1.3 suites are negotiated separately and set_ciphers() does not
+        # constrain them, so pin to 1.2 to make the restriction observable.
+        context.maximum_version = ssl.TLSVersion.TLSv1_2
+        context.set_ciphers(args.ciphers)
+
     server = ThreadingHTTPServer(("127.0.0.1", args.port), Handler)
+    server.requires_client_cert = bool(args.client_ca)
     server.socket = context.wrap_socket(server.socket, server_side=True)
     log(f"HTTPS manager on https://127.0.0.1:{args.port} "
         f"(agent key {args.key_hex[:8]}..)")
+    log(f"     mutual TLS: {'required, CA ' + args.client_ca if args.client_ca else 'not requested'}")
+    log(f"     ciphers:    {args.ciphers if args.ciphers else 'default (unrestricted)'}")
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/src/client-agent/https_client/src/curlHandle.cpp
+++ b/src/client-agent/https_client/src/curlHandle.cpp
@@ -34,6 +34,9 @@ namespace
         std::call_once(initialized, [] { curl_global_init(CURL_GLOBAL_DEFAULT); });
     }
 
+    static_assert(TLS_MIN_VERSION_1_3 == CURL_SSLVERSION_TLSv1_3,
+                  "TLS_MIN_VERSION_1_3 must stay equal to libcurl's CURL_SSLVERSION_TLSv1_3");
+
     const std::map<CurlOption, CURLoption>& optionMap()
     {
         // Never destroyed, like the global curl init above: the shutdown drain reads
@@ -52,7 +55,11 @@ namespace
             {CurlOption::CaInfo, CURLOPT_CAINFO},
             {CurlOption::SslCert, CURLOPT_SSLCERT},
             {CurlOption::SslKey, CURLOPT_SSLKEY},
-            {CurlOption::SslCiphers, CURLOPT_SSL_CIPHER_LIST},
+            {CurlOption::SslVersion, CURLOPT_SSLVERSION},
+            // TLS13_CIPHERS, not SSL_CIPHER_LIST: the latter only governs TLS 1.2
+            // and below, which the minimum version below rules out entirely, so a
+            // list set through it could never constrain a session.
+            {CurlOption::SslCiphers, CURLOPT_TLS13_CIPHERS},
             {CurlOption::FollowLocation, CURLOPT_FOLLOWLOCATION},
             {CurlOption::NoSignal, CURLOPT_NOSIGNAL}
         };

--- a/src/client-agent/https_client/src/curlPerformer.cpp
+++ b/src/client-agent/https_client/src/curlPerformer.cpp
@@ -204,6 +204,12 @@ void CurlPerformer::applyTls(ICurlHandle& handle) const
     handle.setOptionLong(CurlOption::VerifyPeer, verifyPeer ? 1L : 0L);
     handle.setOptionLong(CurlOption::VerifyHost, verifyHost ? 2L : 0L);
 
+    // The manager's HTTPS listener sets a TLS 1.3 floor of its own
+    // (SSL_CTX_set_min_proto_version in RestinioHttpServer), so match it instead
+    // of leaving libcurl's default, which still permits 1.0. Unconditional: this
+    // is the protocol's floor, not something <ssl> is allowed to lower.
+    handle.setOptionLong(CurlOption::SslVersion, TLS_MIN_VERSION_1_3);
+
     if (!m_config.caPath.empty())
     {
         handle.setOptionString(CurlOption::CaInfo, m_config.caPath);

--- a/src/client-agent/https_client/src/iCurlHandle.hpp
+++ b/src/client-agent/https_client/src/iCurlHandle.hpp
@@ -35,10 +35,18 @@ enum class CurlOption
     CaInfo,         ///< string CA file path
     SslCert,        ///< string client certificate path
     SslKey,         ///< string client key path
-    SslCiphers,     ///< string cipher list
+    SslVersion,     ///< long, the minimum TLS version to negotiate
+    SslCiphers,     ///< string TLS 1.3 ciphersuite list
     FollowLocation, ///< long, always 0 (H4: no redirects)
     NoSignal        ///< long, always 1 (H6)
 };
+
+/// Value for CurlOption::SslVersion: refuse to negotiate below TLS 1.3.
+///
+/// Numerically libcurl's CURL_SSLVERSION_TLSv1_3, repeated here so this header
+/// stays curl-agnostic like the ids above. curlHandle.cpp static_asserts the two
+/// against each other, so the literal cannot drift from what curl expects.
+inline constexpr long TLS_MIN_VERSION_1_3 {7};
 
 /**
  * @brief One HTTP transfer, at the option level.

--- a/src/client-agent/include/agentd.h
+++ b/src/client-agent/include/agentd.h
@@ -21,6 +21,10 @@
 /* Client configuration */
 int ClientConf(const char *cfgfile);
 
+/* Check <ssl><certificate_authorities> against the configured verification mode.
+ * Returns false when the agent must not start. */
+bool w_agent_validate_ssl_ca(const agent *cfg);
+
 /* Parse read config into JSON format */
 cJSON *getClientConfig(void);
 cJSON *getAgentInternalOptions(void);

--- a/src/client-agent/src/config.c
+++ b/src/client-agent/src/config.c
@@ -84,6 +84,34 @@ int ClientConf(const char *cfgfile)
     return (1);
 }
 
+/* Both agentd and the Windows agent gate startup on this, at the point where each can
+ * still fail cleanly: before daemonizing on POSIX, before the first module thread on
+ * Windows. Shared so the two can never drift apart on what counts as a usable CA. */
+bool w_agent_validate_ssl_ca(const agent *cfg)
+{
+    const char *ca = cfg->ssl.certificate_authorities;
+    const bool readable = ca && w_is_file(ca);
+
+    /* Under 'none' the CA is never read, so a wrong path stays invisible until someone
+     * enables verification -- and then the agent refuses to start. Warn while it is
+     * still harmless rather than accepting it in silence. */
+    if (cfg->ssl.verification_mode == AGENT_VERIFY_NONE) {
+        if (ca && !readable) {
+            mwarn(AG_UNUSED_SSL_CA, ca);
+        }
+
+        return true;
+    }
+
+    /* A verifying mode without a readable CA can never connect: the https_client module
+     * fails closed on this, per its own validation. */
+    if (!readable) {
+        merror(AG_INV_SSL_CA, ca ? ca : "");
+        return false;
+    }
+
+    return true;
+}
 
 cJSON *getClientConfig(void) {
 

--- a/src/client-agent/src/main.c
+++ b/src/client-agent/src/main.c
@@ -208,14 +208,11 @@ int main(int argc, char **argv)
         mlerror_exit(LOGLEVEL_ERROR, CLIENT_ERROR);
     }
 
-    /* A verifying <ssl><verification_mode> without a readable CA can never connect (the
-     * https_client module fails closed on this, per its own validation) -- caught here, before
-     * daemonizing, so wazuh-client.sh's sequential daemon-start check (which polls for this
-     * process's PID file before starting syscheckd/logcollector/modulesd) halts the whole start
-     * instead of launching the other daemons around a transport that will never come up. */
-    if (agt->ssl.verification_mode != AGENT_VERIFY_NONE &&
-        (!agt->ssl.certificate_authorities || !w_is_file(agt->ssl.certificate_authorities))) {
-        merror(AG_INV_SSL_CA, agt->ssl.certificate_authorities ? agt->ssl.certificate_authorities : "");
+    /* Checked here, before daemonizing, so wazuh-client.sh's sequential daemon-start check
+     * (which polls for this process's PID file before starting syscheckd/logcollector/modulesd)
+     * halts the whole start instead of launching the other daemons around a transport that will
+     * never come up. */
+    if (!w_agent_validate_ssl_ca(agt)) {
         mlerror_exit(LOGLEVEL_ERROR, CLIENT_ERROR);
     }
 

--- a/src/config/src/client-config.c
+++ b/src/config/src/client-config.c
@@ -441,6 +441,74 @@ int Read_Agent_Server(XML_NODE node, agent * logr)
     return (0);
 }
 
+/* TLS 1.3 ciphersuite names, RFC 8446 section B.4. These are what OpenSSL's
+ * SSL_CTX_set_ciphersuites() takes, which is what the agent's <ciphers> ends up
+ * feeding through libcurl's CURLOPT_TLS13_CIPHERS. */
+static const char *VALID_TLS13_CIPHERSUITES[] = {
+    "TLS_AES_128_GCM_SHA256",
+    "TLS_AES_256_GCM_SHA384",
+    "TLS_CHACHA20_POLY1305_SHA256",
+    "TLS_AES_128_CCM_SHA256",
+    "TLS_AES_128_CCM_8_SHA256",
+    NULL
+};
+
+static bool is_tls13_ciphersuite(const char *name)
+{
+    for (int i = 0; VALID_TLS13_CIPHERSUITES[i]; i++) {
+        if (strcmp(name, VALID_TLS13_CIPHERSUITES[i]) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * @brief Validate a colon-separated TLS 1.3 ciphersuite list.
+ *
+ * The agent negotiates nothing below TLS 1.3, so a TLS 1.2 name here would parse
+ * and then never constrain a session — silently, since OpenSSL is never told
+ * about it. Rejecting at parse time is the difference between a startup error
+ * and a security option that quietly does nothing.
+ *
+ * @param ciphers Raw <ciphers> content.
+ * @return 0 when every element is a known suite, OS_INVALID otherwise.
+ */
+static int w_client_validate_tls13_ciphers(const char *ciphers)
+{
+    char *copy = NULL;
+    char *saveptr = NULL;
+    int suites = 0;
+
+    if (!ciphers || !*ciphers) {
+        merror("Empty 'ciphers' option: expected TLS 1.3 cipher suite names.");
+        return OS_INVALID;
+    }
+
+    os_strdup(ciphers, copy);
+
+    for (char *name = strtok_r(copy, ":", &saveptr); name; name = strtok_r(NULL, ":", &saveptr)) {
+        if (!is_tls13_ciphersuite(name)) {
+            merror("Invalid TLS 1.3 cipher suite '%s' in the 'ciphers' option.", name);
+            os_free(copy);
+            return OS_INVALID;
+        }
+        suites++;
+    }
+
+    os_free(copy);
+
+    /* A list of nothing but separators tokenizes to zero suites, which would
+     * otherwise pass as vacuously valid and leave OpenSSL with an empty list. */
+    if (suites == 0) {
+        merror("Invalid 'ciphers' option: '%s' names no cipher suite.", ciphers);
+        return OS_INVALID;
+    }
+
+    return 0;
+}
+
 int Read_Agent_SSL(XML_NODE node, agent * logr)
 {
     /* XML definitions — the <agent><ssl> transport block (#37702 §10). */
@@ -478,6 +546,9 @@ int Read_Agent_SSL(XML_NODE node, agent * logr)
                 return (OS_INVALID);
             }
         } else if (strcmp(node[j]->element, xml_ciphers) == 0) {
+            if (w_client_validate_tls13_ciphers(node[j]->content) == OS_INVALID) {
+                return (OS_INVALID);
+            }
             os_free(logr->ssl.ciphers);
             os_strdup(node[j]->content, logr->ssl.ciphers);
         } else {

--- a/src/config/src/client-config.c
+++ b/src/config/src/client-config.c
@@ -453,10 +453,11 @@ static const char *VALID_TLS13_CIPHERSUITES[] = {
     NULL
 };
 
-static bool is_tls13_ciphersuite(const char *name)
+static bool is_tls13_ciphersuite(const char *name, size_t length)
 {
     for (int i = 0; VALID_TLS13_CIPHERSUITES[i]; i++) {
-        if (strcmp(name, VALID_TLS13_CIPHERSUITES[i]) == 0) {
+        if (strlen(VALID_TLS13_CIPHERSUITES[i]) == length &&
+            strncmp(name, VALID_TLS13_CIPHERSUITES[i], length) == 0) {
             return true;
         }
     }
@@ -477,36 +478,37 @@ static bool is_tls13_ciphersuite(const char *name)
  */
 static int w_client_validate_tls13_ciphers(const char *ciphers)
 {
-    char *copy = NULL;
-    char *saveptr = NULL;
-    int suites = 0;
+    const char *element = ciphers;
 
     if (!ciphers || !*ciphers) {
-        merror("Empty 'ciphers' option: expected TLS 1.3 cipher suite names.");
+        merror("Invalid 'ciphers' option: expected TLS 1.3 cipher suite names.");
         return OS_INVALID;
     }
 
-    os_strdup(ciphers, copy);
+    /* Walked by hand rather than with strtok_r, which collapses runs of
+     * separators: under it ':X', 'X::' and 'X::Y' all pass while naming a suite
+     * that is not there. Every element between two separators is checked,
+     * including an empty first or last one. */
+    for (;;) {
+        const char *separator = strchr(element, ':');
+        const size_t length = separator ? (size_t)(separator - element) : strlen(element);
 
-    for (char *name = strtok_r(copy, ":", &saveptr); name; name = strtok_r(NULL, ":", &saveptr)) {
-        if (!is_tls13_ciphersuite(name)) {
-            merror("Invalid TLS 1.3 cipher suite '%s' in the 'ciphers' option.", name);
-            os_free(copy);
+        if (length == 0) {
+            merror("Invalid 'ciphers' option: '%s' has an empty cipher suite name.", ciphers);
             return OS_INVALID;
         }
-        suites++;
+
+        if (!is_tls13_ciphersuite(element, length)) {
+            merror("Invalid TLS 1.3 cipher suite '%.*s' in the 'ciphers' option.", (int)length, element);
+            return OS_INVALID;
+        }
+
+        if (!separator) {
+            return 0;
+        }
+
+        element = separator + 1;
     }
-
-    os_free(copy);
-
-    /* A list of nothing but separators tokenizes to zero suites, which would
-     * otherwise pass as vacuously valid and leave OpenSSL with an empty list. */
-    if (suites == 0) {
-        merror("Invalid 'ciphers' option: '%s' names no cipher suite.", ciphers);
-        return OS_INVALID;
-    }
-
-    return 0;
 }
 
 int Read_Agent_SSL(XML_NODE node, agent * logr)

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -372,7 +372,7 @@ WriteAgent()
     # verification_mode defaults to 'none'; set to 'full' or 'certificate' and
     # provide certificate_authorities to verify the manager's certificate.
     echo "    <ssl>" >> $NEWCONFIG
-    echo "      <certificate_authorities>PATH</certificate_authorities>" >> $NEWCONFIG
+    echo "      <!-- <certificate_authorities>etc/certs/root-ca.pem</certificate_authorities> -->" >> $NEWCONFIG
     echo "      <verification_mode>none</verification_mode>" >> $NEWCONFIG
     echo "    </ssl>" >> $NEWCONFIG
     if [ "X${USER_AGENT_CONFIG_PROFILE}" != "X" ]; then

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -389,7 +389,7 @@ WriteAgent()
         fi
       fi
     fi
-    echo "    <notify_time>20</notify_time>" >> $NEWCONFIG
+    echo "    <notify_time>10</notify_time>" >> $NEWCONFIG
     echo "    <auto_restart>yes</auto_restart>" >> $NEWCONFIG
     echo "  </agent>" >> $NEWCONFIG
     echo "" >> $NEWCONFIG

--- a/src/shared/include/error_messages/warning_messages.h
+++ b/src/shared/include/error_messages/warning_messages.h
@@ -14,6 +14,11 @@
 /* Active Response */
 #define AR_SERVER_AGENT "(1306): Invalid agent ID. Use location=server to run AR on the manager."
 
+/* Agent */
+#define AG_UNUSED_SSL_CA "(4119): <ssl><certificate_authorities> is not a readable file: '%s'. " \
+                         "It is unused while <verification_mode> is 'none'; enabling verification " \
+                         "would stop the agent from starting."
+
 /* File integrity monitoring warning messages*/
 #define FIM_WARN_ACCESS                         "(6900): Accessing  '%s': [(%d) - (%s)]"
 #define FIM_WARN_DELETE                         "(6901): Could not delete from filesystem '%s'"

--- a/src/shared_modules/agent_metadata/src/metadata_provider.cpp
+++ b/src/shared_modules/agent_metadata/src/metadata_provider.cpp
@@ -71,6 +71,19 @@ namespace
                     return -1;
                 }
 
+#ifndef _WIN32
+
+                // The constructor falls back to opening the segment O_RDONLY when the process
+                // cannot open it O_RDWR, and then maps it PROT_READ. Writing through that
+                // mapping is a segmentation fault, not a failed write, so a reader has to be
+                // turned away here rather than at the first store below.
+                if (m_read_only)
+                {
+                    return -1;
+                }
+
+#endif
+
                 m_shm->updating.store(true, std::memory_order_release);
 
                 // Copy scalar fields
@@ -204,6 +217,16 @@ namespace
 
             void reset()
             {
+#ifndef _WIN32
+
+                // Same read-only mapping hazard as update().
+                if (m_read_only)
+                {
+                    return;
+                }
+
+#endif
+
                 if (m_shm)
                 {
                     m_shm->updating.store(true, std::memory_order_release);

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -93,6 +93,9 @@ list(APPEND client-agent_flags "-Wl,--wrap,wurl_free_response -Wl,--wrap,wurl_ht
 list(APPEND client-agent_names "test_startup_gate")
 list(APPEND client-agent_flags "-Wl,--wrap,OS_SHA256_File ${DEBUG_OP_WRAPPERS}")
 
+list(APPEND client-agent_names "test_agent_ssl_ca")
+list(APPEND client-agent_flags "-Wl,--wrap,w_is_file ${DEBUG_OP_WRAPPERS}")
+
 list(APPEND client-agent_names "test_https_client_bridge")
 list(APPEND client-agent_flags "-Wl,--wrap,wurl_free_response -Wl,--wrap,wurl_http_request \
                                 -Wl,--wrap,hc_create -Wl,--wrap,hc_start -Wl,--wrap,hc_destroy \

--- a/src/unit_tests/client-agent/test_agent_ssl_ca.c
+++ b/src/unit_tests/client-agent/test_agent_ssl_ca.c
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "agentd.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+#include "../wrappers/wazuh/shared/os_utils_wrappers.h"
+
+/* w_agent_validate_ssl_ca() decides whether the agent may start with the
+ * <ssl><certificate_authorities> it was given. Two behaviours matter and they
+ * differ only by <verification_mode>: a verifying mode must refuse to start on a
+ * CA it cannot read, while 'none' must still say something about it, because that
+ * is the state a shipped config sits in until someone enables verification. */
+
+static agent make_config(int verification_mode, char *ca)
+{
+    agent cfg = {0};
+
+    cfg.ssl.verification_mode = verification_mode;
+    cfg.ssl.certificate_authorities = ca;
+
+    return cfg;
+}
+
+static void expect_ca_readable(const char *path, int readable)
+{
+    expect_string(__wrap_w_is_file, file, path);
+    will_return(__wrap_w_is_file, readable);
+}
+
+/* --- verification_mode none: never fatal, but never silent about a bad path --- */
+
+static void test_none_without_ca_starts_quietly(void **state)
+{
+    (void)state;
+    agent cfg = make_config(AGENT_VERIFY_NONE, NULL);
+
+    assert_true(w_agent_validate_ssl_ca(&cfg));
+}
+
+static void test_none_with_readable_ca_starts_quietly(void **state)
+{
+    (void)state;
+    agent cfg = make_config(AGENT_VERIFY_NONE, "etc/certs/root-ca.pem");
+
+    expect_ca_readable("etc/certs/root-ca.pem", 1);
+
+    assert_true(w_agent_validate_ssl_ca(&cfg));
+}
+
+/* The case the shipped template used to create: a CA path that parses cleanly,
+ * is never read, and so goes unnoticed until verification is turned on. */
+static void test_none_with_unreadable_ca_warns_and_starts(void **state)
+{
+    (void)state;
+    agent cfg = make_config(AGENT_VERIFY_NONE, "PATH");
+
+    expect_ca_readable("PATH", 0);
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "(4119): <ssl><certificate_authorities> is not a readable file: 'PATH'. "
+                  "It is unused while <verification_mode> is 'none'; enabling verification "
+                  "would stop the agent from starting.");
+
+    assert_true(w_agent_validate_ssl_ca(&cfg));
+}
+
+/* --- verifying modes: an unusable CA must stop the start, not be worked around --- */
+
+static void test_full_with_readable_ca_starts(void **state)
+{
+    (void)state;
+    agent cfg = make_config(AGENT_VERIFY_FULL, "etc/certs/root-ca.pem");
+
+    expect_ca_readable("etc/certs/root-ca.pem", 1);
+
+    assert_true(w_agent_validate_ssl_ca(&cfg));
+}
+
+static void test_full_with_unreadable_ca_fails(void **state)
+{
+    (void)state;
+    agent cfg = make_config(AGENT_VERIFY_FULL, "PATH");
+
+    expect_ca_readable("PATH", 0);
+    expect_string(__wrap__merror, formatted_msg,
+                  "(4118): <ssl><verification_mode> is not 'none' but <certificate_authorities> "
+                  "is missing or unreadable: 'PATH'.");
+
+    assert_false(w_agent_validate_ssl_ca(&cfg));
+}
+
+/* No CA at all under a verifying mode: reported as the empty path rather than
+ * dereferenced, and still fatal. */
+static void test_full_without_ca_fails(void **state)
+{
+    (void)state;
+    agent cfg = make_config(AGENT_VERIFY_FULL, NULL);
+
+    expect_string(__wrap__merror, formatted_msg,
+                  "(4118): <ssl><verification_mode> is not 'none' but <certificate_authorities> "
+                  "is missing or unreadable: ''.");
+
+    assert_false(w_agent_validate_ssl_ca(&cfg));
+}
+
+static void test_certificate_with_unreadable_ca_fails(void **state)
+{
+    (void)state;
+    agent cfg = make_config(AGENT_VERIFY_CERT, "PATH");
+
+    expect_ca_readable("PATH", 0);
+    expect_string(__wrap__merror, formatted_msg,
+                  "(4118): <ssl><verification_mode> is not 'none' but <certificate_authorities> "
+                  "is missing or unreadable: 'PATH'.");
+
+    assert_false(w_agent_validate_ssl_ca(&cfg));
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_none_without_ca_starts_quietly),
+        cmocka_unit_test(test_none_with_readable_ca_starts_quietly),
+        cmocka_unit_test(test_none_with_unreadable_ca_warns_and_starts),
+        cmocka_unit_test(test_full_with_readable_ca_starts),
+        cmocka_unit_test(test_full_with_unreadable_ca_fails),
+        cmocka_unit_test(test_full_without_ca_fails),
+        cmocka_unit_test(test_certificate_with_unreadable_ca_fails),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/config/test_client-config_https.c
+++ b/src/unit_tests/config/test_client-config_https.c
@@ -143,15 +143,72 @@ static void test_ssl_ciphers_rejects_a_list_of_separators(void **state) {
     xml_node **nodes;
     agent cfg;
 
-    /* Tokenizes to no suite at all, which would otherwise pass as vacuously
-     * valid and leave OpenSSL with an empty list. */
+    /* Every element is empty, so there is no suite at all. */
     const char *xml_str =
         "<server><address>10.0.0.1</address></server>"
         "<ssl><ciphers>:::</ciphers></ssl>";
 
     expect_valid_ip("10.0.0.1");
     expect_string(__wrap__merror, formatted_msg,
-                  "Invalid 'ciphers' option: ':::' names no cipher suite.");
+                  "Invalid 'ciphers' option: ':::' has an empty cipher suite name.");
+
+    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+/* A separator run names a suite that is not there. strtok_r() collapses these,
+ * so each position -- leading, trailing and interior -- gets its own case. */
+
+static void test_ssl_ciphers_rejects_a_leading_separator(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str =
+        "<server><address>10.0.0.1</address></server>"
+        "<ssl><ciphers>:TLS_AES_128_GCM_SHA256</ciphers></ssl>";
+
+    expect_valid_ip("10.0.0.1");
+    expect_string(__wrap__merror, formatted_msg,
+                  "Invalid 'ciphers' option: ':TLS_AES_128_GCM_SHA256' has an empty cipher suite name.");
+
+    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_ssl_ciphers_rejects_a_trailing_separator(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str =
+        "<server><address>10.0.0.1</address></server>"
+        "<ssl><ciphers>TLS_AES_128_GCM_SHA256:</ciphers></ssl>";
+
+    expect_valid_ip("10.0.0.1");
+    expect_string(__wrap__merror, formatted_msg,
+                  "Invalid 'ciphers' option: 'TLS_AES_128_GCM_SHA256:' has an empty cipher suite name.");
+
+    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_ssl_ciphers_rejects_a_doubled_separator(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str =
+        "<server><address>10.0.0.1</address></server>"
+        "<ssl><ciphers>TLS_AES_128_GCM_SHA256::TLS_AES_256_GCM_SHA384</ciphers></ssl>";
+
+    expect_valid_ip("10.0.0.1");
+    expect_string(__wrap__merror, formatted_msg,
+                  "Invalid 'ciphers' option: 'TLS_AES_128_GCM_SHA256::TLS_AES_256_GCM_SHA384' "
+                  "has an empty cipher suite name.");
 
     assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
 
@@ -813,6 +870,9 @@ int main(void) {
         cmocka_unit_test(test_ssl_ciphers_accepts_a_tls13_suite_list),
         cmocka_unit_test(test_ssl_ciphers_rejects_a_tls12_cipher_string),
         cmocka_unit_test(test_ssl_ciphers_rejects_a_list_of_separators),
+        cmocka_unit_test(test_ssl_ciphers_rejects_a_leading_separator),
+        cmocka_unit_test(test_ssl_ciphers_rejects_a_trailing_separator),
+        cmocka_unit_test(test_ssl_ciphers_rejects_a_doubled_separator),
         cmocka_unit_test(test_server_address_and_explicit_port),
         cmocka_unit_test(test_manager_tag_is_rejected),
         cmocka_unit_test(test_second_server_block_prevails_with_warning),

--- a/src/unit_tests/config/test_client-config_https.c
+++ b/src/unit_tests/config/test_client-config_https.c
@@ -84,7 +84,7 @@ static void test_ssl_full_verification_mode(void **state) {
         "<key>/etc/wazuh/agent.key</key>"
         "<certificate_authorities>/etc/wazuh/ca.pem</certificate_authorities>"
         "<verification_mode>full</verification_mode>"
-        "<ciphers>HIGH:!aNULL</ciphers>"
+        "<ciphers>TLS_AES_256_GCM_SHA384</ciphers>"
         "</ssl>";
 
     expect_valid_ip("10.0.0.1");
@@ -94,7 +94,66 @@ static void test_ssl_full_verification_mode(void **state) {
     assert_string_equal(cfg.ssl.certificate, "/etc/wazuh/agent.pem");
     assert_string_equal(cfg.ssl.key, "/etc/wazuh/agent.key");
     assert_string_equal(cfg.ssl.certificate_authorities, "/etc/wazuh/ca.pem");
-    assert_string_equal(cfg.ssl.ciphers, "HIGH:!aNULL");
+    assert_string_equal(cfg.ssl.ciphers, "TLS_AES_256_GCM_SHA384");
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+/* The agent never negotiates below TLS 1.3, so <ciphers> only accepts TLS 1.3
+ * suite names. A TLS 1.2 cipher string parses fine as XML but could never
+ * constrain a session, which is the whole reason it is rejected here rather
+ * than being handed to OpenSSL to ignore. */
+
+static void test_ssl_ciphers_accepts_a_tls13_suite_list(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str =
+        "<server><address>10.0.0.1</address></server>"
+        "<ssl><ciphers>TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256</ciphers></ssl>";
+
+    expect_valid_ip("10.0.0.1");
+    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
+    assert_string_equal(cfg.ssl.ciphers, "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256");
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_ssl_ciphers_rejects_a_tls12_cipher_string(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str =
+        "<server><address>10.0.0.1</address></server>"
+        "<ssl><ciphers>HIGH:!aNULL</ciphers></ssl>";
+
+    expect_valid_ip("10.0.0.1");
+    expect_string(__wrap__merror, formatted_msg,
+                  "Invalid TLS 1.3 cipher suite 'HIGH' in the 'ciphers' option.");
+
+    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_ssl_ciphers_rejects_a_list_of_separators(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    /* Tokenizes to no suite at all, which would otherwise pass as vacuously
+     * valid and leave OpenSSL with an empty list. */
+    const char *xml_str =
+        "<server><address>10.0.0.1</address></server>"
+        "<ssl><ciphers>:::</ciphers></ssl>";
+
+    expect_valid_ip("10.0.0.1");
+    expect_string(__wrap__merror, formatted_msg,
+                  "Invalid 'ciphers' option: ':::' names no cipher suite.");
+
+    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -751,6 +810,9 @@ int main(void) {
         cmocka_unit_test(test_ssl_default_is_full),
         cmocka_unit_test(test_ssl_invalid_verification_mode_is_rejected),
         cmocka_unit_test(test_ssl_invalid_tag_is_rejected),
+        cmocka_unit_test(test_ssl_ciphers_accepts_a_tls13_suite_list),
+        cmocka_unit_test(test_ssl_ciphers_rejects_a_tls12_cipher_string),
+        cmocka_unit_test(test_ssl_ciphers_rejects_a_list_of_separators),
         cmocka_unit_test(test_server_address_and_explicit_port),
         cmocka_unit_test(test_manager_tag_is_rejected),
         cmocka_unit_test(test_second_server_block_prevails_with_warning),

--- a/src/unit_tests/config/test_client-config_https.c
+++ b/src/unit_tests/config/test_client-config_https.c
@@ -110,11 +110,11 @@ static void test_ssl_ciphers_accepts_a_tls13_suite_list(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address></server>"
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
         "<ssl><ciphers>TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256</ciphers></ssl>";
 
     expect_valid_ip("10.0.0.1");
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
     assert_string_equal(cfg.ssl.ciphers, "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256");
 
     cleanup(&xml, nodes, &cfg);
@@ -126,14 +126,14 @@ static void test_ssl_ciphers_rejects_a_tls12_cipher_string(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address></server>"
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
         "<ssl><ciphers>HIGH:!aNULL</ciphers></ssl>";
 
     expect_valid_ip("10.0.0.1");
     expect_string(__wrap__merror, formatted_msg,
                   "Invalid TLS 1.3 cipher suite 'HIGH' in the 'ciphers' option.");
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), OS_INVALID);
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -145,14 +145,14 @@ static void test_ssl_ciphers_rejects_a_list_of_separators(void **state) {
 
     /* Every element is empty, so there is no suite at all. */
     const char *xml_str =
-        "<server><address>10.0.0.1</address></server>"
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
         "<ssl><ciphers>:::</ciphers></ssl>";
 
     expect_valid_ip("10.0.0.1");
     expect_string(__wrap__merror, formatted_msg,
                   "Invalid 'ciphers' option: ':::' has an empty cipher suite name.");
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), OS_INVALID);
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -166,14 +166,14 @@ static void test_ssl_ciphers_rejects_a_leading_separator(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address></server>"
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
         "<ssl><ciphers>:TLS_AES_128_GCM_SHA256</ciphers></ssl>";
 
     expect_valid_ip("10.0.0.1");
     expect_string(__wrap__merror, formatted_msg,
                   "Invalid 'ciphers' option: ':TLS_AES_128_GCM_SHA256' has an empty cipher suite name.");
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), OS_INVALID);
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -184,14 +184,14 @@ static void test_ssl_ciphers_rejects_a_trailing_separator(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address></server>"
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
         "<ssl><ciphers>TLS_AES_128_GCM_SHA256:</ciphers></ssl>";
 
     expect_valid_ip("10.0.0.1");
     expect_string(__wrap__merror, formatted_msg,
                   "Invalid 'ciphers' option: 'TLS_AES_128_GCM_SHA256:' has an empty cipher suite name.");
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), OS_INVALID);
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -202,7 +202,7 @@ static void test_ssl_ciphers_rejects_a_doubled_separator(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address></server>"
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
         "<ssl><ciphers>TLS_AES_128_GCM_SHA256::TLS_AES_256_GCM_SHA384</ciphers></ssl>";
 
     expect_valid_ip("10.0.0.1");
@@ -210,7 +210,7 @@ static void test_ssl_ciphers_rejects_a_doubled_separator(void **state) {
                   "Invalid 'ciphers' option: 'TLS_AES_128_GCM_SHA256::TLS_AES_256_GCM_SHA384' "
                   "has an empty cipher suite name.");
 
-    assert_int_equal(parse_client(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), OS_INVALID);
 
     cleanup(&xml, nodes, &cfg);
 }

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -18,7 +18,7 @@
       <!-- <certificate_authorities>etc/certs/root-ca.pem</certificate_authorities> -->
       <verification_mode>none</verification_mode>
     </ssl>
-    <notify_time>20</notify_time>
+    <notify_time>10</notify_time>
     <auto_restart>yes</auto_restart>
   </agent>
 

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -15,7 +15,7 @@
          Set to 'full' or 'certificate' and provide certificate_authorities to verify the
          manager's certificate. -->
     <ssl>
-      <certificate_authorities>PATH</certificate_authorities>
+      <!-- <certificate_authorities>etc/certs/root-ca.pem</certificate_authorities> -->
       <verification_mode>none</verification_mode>
     </ssl>
     <notify_time>20</notify_time>

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -187,12 +187,9 @@ int local_start()
         mlerror_exit(LOGLEVEL_ERROR, CLIENT_ERROR);
     }
 
-    /* A verifying <ssl><verification_mode> without a readable CA can never connect (the
-     * https_client module fails closed on this, per its own validation) -- caught here, before
-     * any module thread is created, instead of failing much later inside w_https_client_start(). */
-    if (agt->ssl.verification_mode != AGENT_VERIFY_NONE &&
-        (!agt->ssl.certificate_authorities || !w_is_file(agt->ssl.certificate_authorities))) {
-        merror(AG_INV_SSL_CA, agt->ssl.certificate_authorities ? agt->ssl.certificate_authorities : "");
+    /* Checked here, before any module thread is created, instead of failing much later
+     * inside w_https_client_start(). */
+    if (!w_agent_validate_ssl_ca(agt)) {
         mlerror_exit(LOGLEVEL_ERROR, CLIENT_ERROR);
     }
 


### PR DESCRIPTION
## Description

Validation of the agent-side HTTPS connection and configuration layer for #38163, plus the
defects it found and the harness changes it needed. It also carries two fixes from QA's
exploratory session on the same layer, wazuh/wazuh-qa-automation#8451.

Every case drives the real `wazuh-agentd` reading `ossec.conf`, so the XML parser is in the loop
rather than a driver building `hc_config_t` directly, and each runs in isolation: fresh manager,
foreground agent under `timeout`, no daemon surviving from the previous case.

Related: #37702 (requirement 10), #37828.

## Proposed Changes

- **`shared_modules/agent_metadata`** — `update()` and `reset()` refuse to write when the segment was
  mapped read-only, instead of faulting.
- **`client-agent/https_client` + `config/client-agent`** — the agent now refuses to negotiate
  below TLS 1.3, sends `<ssl><ciphers>` through `CURLOPT_TLS13_CIPHERS` instead of
  `CURLOPT_SSL_CIPHER_LIST`, and rejects non-TLS-1.3 suite names at parse time. This fixes the
  `<ciphers>` defect the validation found; see the section below.
- **`client-agent/https_client/demo/mock_manager.py`** — `--client-ca` (require and verify a client
  certificate) and `--ciphers` (restrict the offered suites), the negotiated suite and client
  certificate subject logged once per connection, and the full `/stats` and `/config` document
  logged, which the 70-byte preview truncated.
- **Agent config templates** — the three shipped templates no longer write a literal `PATH` into
  `<certificate_authorities>`, and an unreadable CA is now reported rather than ignored. See the
  section below.
- **`<notify_time>`** — the shipped default drops from 20 seconds to 10, on both the Linux and
  Windows templates.

Full evidence for #38163. Every case drives the real `wazuh-agentd` reading `ossec.conf`, so the XML parser is in the loop.

### Environment

Agent and manager both built from `enhancement/37831-agent-https-client` (`f92fbf477d`, rebased onto `5.0.0-https` `84ae957631`) plus the metadata fix in this PR, which the agent does not start without.

The TLS matrix runs against a **real manager** — `remoted`'s HTTPS listener on `:27000`, agent enrolled with a matching `client.keys`, shared CA, manager certificate `SAN: DNS:wazuh-server, IP:172.19.0.3`. Cases the real manager cannot serve are marked and were run against the repo's mock manager (`https_client/demo/mock_manager.py`), which the issue's Environment section allows.

### (a) Configuration block

**There is no `<agent>` config root.** `src/config/src/config.c` knows `client`, not `agent`, so the block in #37702 requirement 10 is rejected and the agent refuses to start:

```
ERROR: (1230): Invalid element in the configuration: 'agent'.
ERROR: (1202): Configuration error at 'etc/ossec.conf'.
ERROR: (1215): No client configured. Exiting.
```

Every option the issue lists is implemented and functional, but under `<client>`. The config-root migration arrived with **PR #38172** (agent remote upgrade / WPK): it registers `agent` as a root in `config.c`, renames the readers (`Read_Client_SSL` becomes `Read_Agent_SSL`) and keeps `<client>` as a legacy fallback from which only `<server><address>` is read. That PR has merged, and the matrix has been re-run under `<agent>` — see the evidence comment on this PR, which supersedes the `<client>`-based results below.

| Option | Case | Result | Against |
|---|---|---|---|
| `<server><address>`/`<port>` | connects to the configured manager | PASS | real |
| `<ssl><verification_mode>full` | matching CA + SAN | PASS | real |
| `<ssl><verification_mode>full` | unrelated CA — must refuse | PASS (0 requests) | real |
| `<ssl><verification_mode>certificate` | connects | PASS | real |
| `<ssl><verification_mode>none` | connects, warns | PASS | real |
| `<ssl><certificate>`/`<key>` | manager requires a client cert, agent presents one | PASS | real |
| `<ssl><certificate>`/`<key>` | manager requires, agent has none — must refuse | PASS (0 requests) | real |
| `<ssl><ciphers>` | restricts the negotiated suite | **DEFECT when measured**, fixed in this PR | real |
| `<batch><interval>` | flush delay tracks the configured value | PASS | mock |
| `<notify_time>` | notify cadence matches | PASS | mock |
| `<auto_restart>` | reload on limits change gated by the flag | PASS | mock |
| `<config-profile>` | reported in the `/config` push | PARTIAL | mock |

**Mutual TLS**, isolated with `curl` so the enforcement is demonstrably the manager's:

```
# no client cert
curl --cacert ca.crt https://127.0.0.1:27000/control
  -> curl: (56) OpenSSL SSL_read: error:0A00045C:... tlsv13 alert certificate required

# with client cert
curl --cacert ca.crt --cert client.crt --key client.key https://127.0.0.1:27000/control
  -> {"error":"Missing required header: protocol-version","code":400}
```

That 400 is the manager correctly rejecting a bare `curl` that sends no headers. The agent sends `protocol-version: 1` (`cmacSigner.cpp:210`) and its `/control` startup against the same listener is accepted.

**`<notify_time>`** — with `5`, consecutive notifies land 5050 ms apart (startup 1971 ms, NOTIFY #1 7022 ms, NOTIFY #2 12072 ms).

**`<batch><interval>`** — differential, same config otherwise:

| `<interval>` | startup | `/stateless` flush | delta |
|---|---|---|---|
| 3 | 1971 ms | 5025 ms | 3054 ms |
| 10 | 1988 ms | 12041 ms | 10053 ms |

**`<auto_restart>`** — same trigger both runs (module limits flipped `fim.file` 100000 -> 200000 on the 5th notify), only the flag differs:

```
yes -> INFO:  https_client: reloading due to module limits changes.   (bridge_on_startup_result:379, reloadAgent())
no  -> DEBUG: https_client: module limits have been updated.          (line 382, no reload)
```

**`<config-profile>`** is PARTIAL: it comes back verbatim in the `/config` document (`"config-profile": "webserver, debian8"`), but the issue also asks for it "wherever it is consumed", i.e. group profile matching. That needs a manager serving per-profile shared configuration, which is not modelled here.

### (b) Endpoints share the validated connection

One run with both reports enabled, 12 authenticated requests, every endpoint over the same connection parameters — same `agent_id=001`, same negotiated TLS, same signing key:

```
POST /control    <- id=001 auth OK  {"type":"startup","version":"v5.0.0"}
POST /stats      <- id=001 auth OK  (305 B)
POST /config     <- id=001 auth OK  (2363 B)
POST /stateless  <- id=001 auth OK  (152 B)
POST /control    <- id=001 auth OK  (notify)
```

No endpoint used different or unvalidated connection settings.

**Against a real manager, five of the six endpoints exist.** Probed directly, with a nonsense path as the control so a 404 is meaningful:

```
/control  /stateless  /stats  /config  /download   -> 401 (route exists, auth rejected)
/stateful          /nonsense-control               -> 404 (not registered)
```

`/download` landed with #38083 and is now verified end to end against the real manager: a group config change makes the hashes diverge, the agent downloads and SHA-256-verifies the body, and applies it —

```
INFO: Manager config hash 8948520ed001... differs from the local one; downloading the new configuration (group 'default').
DEBUG: https_client config downloaded (hash=8948520ed001..., file=/tmp/hc_sync_...tmp)
INFO: https_client: applying configuration downloaded over HTTPS (hash=8948520ed001...).
```

**`/stateful` is still absent server-side.** It is not a standalone endpoint issue: the server half lands with the Inventory Sync migration, #38089, where a whole sync session arrives in one HTTP request wrapped in a single FlatBuffer (design in #38018). Until that lands, the mock run above remains the only evidence covering all six endpoints.

### Defect fixed: `wazuh-agentd` segfaults on start

```
SIGSEGV in std::atomic<bool>::store
  #2 SharedMemoryProvider::update()   metadata_provider.cpp:74
  #3 metadata_provider_update
  #4 w_agentd_populate_metadata()     start_agent.c:212
  #5 start_agent(is_startup=1)        start_agent.c:48
  #6 AgentdStart / main
```

The provider opens `var/run/.wazuh_agent_metadata` `O_RDWR` and falls back to `O_RDONLY` on `EACCES`, mapping it `PROT_READ`. `update()` checked only that the mapping existed, so the fallback path wrote through a read-only mapping. `agentd` drops to the `wazuh` user, and the segment is left `root:wazuh 0644` whenever a root process creates it first, so the fallback is taken on every start. `reset()` had the same hole.

Before and after on the same install path:

| Build | `wazuh-agentd` |
|---|---|
| integration, without this fix | exit 139 (SIGSEGV) |
| integration + this fix | exit 124 (survived) |

**Surviving is not the whole claim — the metadata still has to be published.** Reproducing the exact
trigger, a root process creating the segment before the daemon starts, and seeding it with zeros so
anything found afterwards must have been written by `agentd`:

```
before, seeded by root with zeros:
  -rw-r--r-- 1 root wazuh 35616 .wazuh_agent_metadata
  strings in segment: 0

after agentd ran (same file, still root-owned):
  -rw-r--r-- 1 root wazuh 35616 .wazuh_agent_metadata
  agentd alive: yes
  strings in segment:
    001                              <- agent id
    agent-001                        <- agent name
    v5.0.0                           <- version
    aarch64                          <- architecture
    wazuh-agent                      <- hostname
    Ubuntu / ubuntu / linux          <- os name, platform
    22.04.5 LTS (Jammy Jellyfish)    <- os version
    wazuh / node01                   <- cluster name, node
    default                          <- agent group
```

Every field of the record, written into a segment that held nothing but zeros a moment earlier. The
last three are the load-bearing ones: cluster name, node and group are manager-authoritative and only
exist after a successful handshake, so this is a live agent's record rather than anything left behind.

The same holds on the clean path, where `agentd` creates the segment itself (`wazuh:wazuh`). So the
read-only fallback is reachable — the SIGSEGV above proves it — but it is not on the path that
publishes metadata, and no configuration produced an empty record.

One limit: both runs are manual, for the reason under *Tests Introduced*. Also worth noting
that when the guard does fire, `start_agent.c:220` reports it at `mdebug1` ("Failed to populate early
metadata"), so a silent crash has become a silent no-op; `mwarn` would suit an event that means the
agent published nothing.

**Provenance**, since this is not our code. The read-only fallback came from `3448f64d14` "fix: allow process that dont run as root to access agent metadata" (Tomas Turina, 2026-01-07), which landed in PR #33575 "Stateless metadata" (merged 2026-01-15). `origin/5.0.0-https` still carries the same unguarded write; it is latent there because the only caller is the legacy handshake, whereas this branch reaches it unconditionally from `start_agent()`. The fix is carried here because none of the validation could run otherwise, and it is two guards with no interface change.

Two things left to the owners: whether the guard belongs on `5.0.0-https` directly rather than arriving via this branch, and the missing test seam — the provider is a singleton whose read-only state is decided in a private constructor from process credentials, and the unit suite runs as root, where the `O_RDWR` open always succeeds, so the faulting path is unreachable from a test as written. Happy to split the fix into its own PR against `5.0.0-https` if preferred.

### Not covered

- **`<agent>` config root** — does not exist; blocks (a).
- **`<config-profile>` group profile matching** — needs a manager serving per-profile shared configuration.
- **(b) fully against a real manager** — blocked on #38089 for `/stateful`, the one endpoint still not registered server-side.

### `<ssl><ciphers>` has no effect on the connections that actually happen

The agent maps `<ciphers>` to `CURLOPT_SSL_CIPHER_LIST`, which libcurl applies to **TLS 1.2 and below**; `CURLOPT_TLS13_CIPHERS` is never set (`curlHandle.cpp:55` is the only cipher option in the module). The real manager negotiates **TLS 1.3**:

```
$ openssl s_client -connect 127.0.0.1:27000
New, TLSv1.3, Cipher is TLS_AES_256_GCM_SHA384
```

So the configured list never constrains the session. Demonstrated with a cipher no server can offer:

```
ciphers=(none)                       -> SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
ciphers=ECDHE-RSA-AES256-GCM-SHA384  -> SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
ciphers=NULL-SHA256                  -> SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
```

and at the agent level, `<ciphers>NULL-SHA256</ciphers>` still completes `/control` startup against the real manager.

This meets the issue's "parses but has no observable runtime effect" bar, so rather than only filing it, this PR fixes it — the option was inert in three separate ways:

- **No TLS floor was set at all.** `CURLOPT_SSLVERSION` was never touched, so libcurl's default applied and TLS 1.0 was permitted. It is now pinned to 1.3 unconditionally, matching the manager: this is the protocol's floor, not something `<ssl>` may lower.
- **The list never reached the session.** It now goes through `CURLOPT_TLS13_CIPHERS`.
- **Bad names were accepted silently.** They are now rejected at parse time against the five RFC 8446 §B.4 suite names, so a mistake is a startup error instead of a security option that quietly does nothing. This mirrors `w_authd_validate_ciphers()` from #38205, which fixes the same class of bug for `wazuh-authd` under #38091 but does not touch the agent's HTTPS client.

`curlPerformer.cpp` carries no curl header and the option ids are deliberately curl-agnostic, so the 1.3 constant lives in `iCurlHandle.hpp` and is pinned with a `static_assert` against `CURL_SSLVERSION_TLSv1_3` in the one translation unit that does include curl. The literal cannot drift.

The evidence above was measured before this fix; re-running the matrix moves `<ciphers>` to PASS.

Note the two sides do not even share a namespace: the manager restricts suites with `SSL_CTX_set_ciphersuites()` (`RestinioHttpServer.cpp:357`), which takes TLS 1.3 names (`TLS_AES_256_GCM_SHA384`), while the agent's option takes TLS 1.2 names (`ECDHE-RSA-AES256-GCM-SHA384`).

### Defect fixed: the shipped config names a CA that does not exist

Every agent ships `<certificate_authorities>PATH</certificate_authorities>`, written by
`inst-functions.sh`, `etc/ossec-agent.conf` and `src/win32/ossec.conf`. Nothing substitutes that
token — no installer variable, no packaging step, no CI step. It parses cleanly, so the config
reads as if a CA were configured when none is. QA found it in a deployed agent
(wazuh/wazuh-qa-automation#8451, F3).

It is inert only because the templates currently ship `verification_mode=none`, which never reads
the CA. The moment anyone sets `certificate` or `full` without also fixing the path, the agent
refuses to start — that refusal is correct and already exists (`AG_INV_SSL_CA`, 4118). What was
missing is that under `none` an unusable path was accepted in total silence.

Both halves are addressed: the templates ship the element commented out, so an unconfigured agent
looks unconfigured, and an unreadable CA is now reported under `none` as well. All three states,
verbatim from `wazuh-agentd -t` reading `ossec.conf`:

```
CA commented out, mode=none            -> exit 0, silent
<certificate_authorities>PATH</...>,   -> exit 0
  mode=none                               WARNING: (4119): <ssl><certificate_authorities> is not a
                                          readable file: 'PATH'. It is unused while
                                          <verification_mode> is 'none'; enabling verification
                                          would stop the agent from starting.
<certificate_authorities>PATH</...>,   -> exit 1
  mode=full                               ERROR: (4118): <ssl><verification_mode> is not 'none' but
                                          <certificate_authorities> is missing or unreadable: 'PATH'.
                                          ERROR: (1215): No client configured. Exiting.
```

The first case matters on its own: an XML comment inside `<ssl>` has to parse, or the template
change would break every new install.

`agentd` and the Windows agent had duplicated the 4118 check line for line. It now lives in one
function, `w_agent_validate_ssl_ca()`, so the two cannot drift on what counts as a usable CA.

The `MANAGER_IP` token QA saw in the same report is **not** a defect: `install.sh` substitutes it
from `USER_AGENT_MANAGER_IP` and the packaging smoke tests `sed` it. An agent that reaches runtime
still holding it already refuses to start, which is the intended behaviour.

### One observation, not investigated

A group `agent.conf` carrying only a `<labels>` block is downloaded and verified, then rejected by `verifyRemoteConf()` with `downloaded configuration failed validation; not reloading`, while a `<localfile>` block in the same position applies cleanly. Whether `<labels>` is meant to be valid in shared configuration is outside this issue's scope, but it is reproducible if someone wants to pick it up.

## Artifacts Affected

- `libagent_metadata` — no interface change; `metadata_provider_update()` returns `-1` on the
  read-only path instead of faulting.
- The demo mock manager, which is test tooling and is not shipped.
- **Shipped agent configuration.** New installs get `<certificate_authorities>` commented out
  instead of set to `PATH`, and `<notify_time>` 10 instead of 20. Existing installs are untouched —
  an upgrade never rewrites `ossec.conf` — so an agent already carrying the `PATH` token keeps
  running and now logs warning 4119 once at startup. Halving `notify_time` doubles each agent's
  `/control` rate against the manager.

## Tests Introduced

`src/unit_tests/client-agent/test_agent_ssl_ca.c` — seven cases over
`w_agent_validate_ssl_ca()`, covering both verification modes against a CA that is absent,
readable, and unreadable, and asserting the exact 4118 and 4119 text. Full suite: 107/107.

The metadata fix remains unreachable from the unit tests: the provider is a singleton whose
read-only state is decided in a private constructor from the process's own credentials, and the
suite runs as root, for which the `O_RDWR` open always succeeds. Making it testable means giving the
provider a seam for the mapping — worth doing, larger than this change. It is covered by the live
reproduction above.

## Review Checklist

- [x] Relevant evidence provided
- [x] Configuration changes documented — the shipped templates change, see *Artifacts Affected*
- [x] Meets requirements and/or definition of done — all three acceptance criteria are met; the
      evidence comment on this PR carries the full matrix, re-run under `<agent>` against a real
      manager.
- [ ] Follow-up to file: the read-only seam for the metadata provider, which still has no automated
      test. (The `<agent>` root arrived with PR #38172 and the `<ssl><ciphers>` no-op is fixed here,
      so neither needs a new issue.)
- [ ] Not covered, and stated in the evidence: Windows and macOS. The issue's platform row is
      Linux / Windows / macOS; everything here is Linux.





