### PR TITLE
Align the agent's /stats and /config field names with the manager contract

### DIFF
--- a/src/client-agent/include/agentd.h
+++ b/src/client-agent/include/agentd.h
@@ -26,7 +26,7 @@ int ClientConf(const char *cfgfile);
 bool w_agent_validate_ssl_ca(const agent *cfg);
 
 /* Parse read config into JSON format */
-cJSON *getClientConfig(void);
+cJSON *getAgentConfig(void);
 cJSON *getAgentInternalOptions(void);
 #ifndef WIN32
 cJSON *getAntiTamperingConfig(void);

--- a/src/client-agent/include/agentd.h
+++ b/src/client-agent/include/agentd.h
@@ -136,6 +136,13 @@ size_t agcom_getallconfig(char ** output);
 size_t agcom_getallstats(char ** output);
 
 /**
+ * @brief Answer "getstate" with the agent state wrapped in the socket envelope.
+ * @param output Pointer to store the allocated response string.
+ * @return Length of the response string.
+ */
+size_t agcom_getstate(char ** output);
+
+/**
  * @brief Collect every module's configuration into one /config document.
  *
  * Queries each agent daemon once and concatenates what they report.

--- a/src/client-agent/include/state.h
+++ b/src/client-agent/include/state.h
@@ -14,6 +14,14 @@
 #define W_AGENTD_STATE_TIME_FORMAT "%Y-%m-%d %H:%M:%S" ///< Time format for the JSON and the file output
 #define W_AGENTD_STATE_TIME_LENGHT (19 + 1)            ///< Maximum time size
 
+/* The JSON surfaces (getstate and the /stats push) report UTC in ISO 8601. Only
+ * the agent knows its own offset, so a naive local time cannot be recovered
+ * downstream; emitting the instant unambiguously makes the manager's
+ * normalize_agent_timestamps() a no-op. The .state text file above keeps the
+ * local-time format, which is operator-facing. */
+#define W_AGENTD_STATE_TIME_FORMAT_ISO8601 "%Y-%m-%dT%H:%M:%SZ"
+#define W_AGENTD_STATE_TIME_ISO8601_LENGHT (20 + 1)
+
 /* State file and JSON responses field's names */
 #define W_AGENTD_JSON_ERROR       "error"          ///< An error code
 #define W_AGENTD_JSON_DATA        "data"           ///< The information of the response
@@ -25,10 +33,19 @@
 #define W_AGENTD_FIELD_MSG_BUFF   "msg_buffer"     ///< Number of current buffered events
 #define W_AGENTD_FIELD_EN_BUFF    "buffer_enabled" ///< Anti-flooding mechanism (buffer) is enable
 
-/* /control task dispatch metrics */
-#define W_AGENTD_FIELD_TASK_DISPATCHED  "task_dispatched"          ///< Tasks routed to a handler
-#define W_AGENTD_FIELD_TASK_DUPLICATE   "task_discarded_duplicate" ///< Tasks discarded as duplicates
-#define W_AGENTD_FIELD_TASK_FAILED      "task_failed"              ///< Tasks that failed to dispatch/execute
+/* Field names for the JSON report. The manager indexes what the agent sends with
+ * no compensation of its own, so these are the contract with wazuh-agent-stats
+ * (wazuh.agent.statistics.agent.*) rather than a local choice. Nesting follows
+ * the schema's dotted convention (wazuh.agent.id, host.os.name); ".total" is the
+ * wcs marker for a counter monotonic over the process's uptime. */
+#define W_AGENTD_FIELD_MESSAGES       "messages" ///< Message counters, grouped
+#define W_AGENTD_FIELD_MESSAGES_COUNT "count"    ///< Number of generated events
+
+#define W_AGENTD_FIELD_TASKS            "tasks"               ///< /control task counters, grouped
+#define W_AGENTD_FIELD_TASK_DISPATCHED  "dispatched"          ///< Tasks routed to a handler
+#define W_AGENTD_FIELD_TASK_DUPLICATE   "discarded_duplicate" ///< Tasks discarded as duplicates
+#define W_AGENTD_FIELD_TASK_FAILED      "failed"              ///< Tasks that failed to dispatch/execute
+#define W_AGENTD_FIELD_TOTAL            "total"               ///< Monotonic counter under each
 
 #include "shared.h"
 #include "read-agents.h"
@@ -88,6 +105,17 @@ void w_agentd_state_update(w_agentd_state_update_t type, void * data);
  * @brief Returns statistics in real time
  * @return Statistics in raw json format
  */
-char * w_agentd_state_get();
+/**
+ * @brief Build the agent's statistics body.
+ *
+ * The bare body, with no {"error","data"} envelope: that is socket framing for
+ * "getstate", which its own call site adds, while over HTTPS the error is the
+ * response status. Fields with no producer left on this branch are omitted
+ * rather than sent empty -- an empty string does not parse as a `date` and the
+ * indexer rejects the whole document for it.
+ *
+ * @return Allocated object the caller owns, or NULL on allocation failure.
+ */
+cJSON * w_agentd_state_get(void);
 
 #endif /* AGENTD_STATE_H */

--- a/src/client-agent/src/agcom.c
+++ b/src/client-agent/src/agcom.c
@@ -44,8 +44,7 @@ size_t agcom_dispatch(char * command, char ** output){
         return agcom_getallstats(output);
 
     } else if (strcmp(rcv_comm, "getstate") == 0) {
-        *output = w_agentd_state_get();
-        return strlen(*output);
+        return agcom_getstate(output);
     } else if (strcmp(rcv_comm, "gethandshake") == 0) {
         return agcom_gethandshake(output);
     } else if (strcmp(rcv_comm, "getstartupgate") == 0) {
@@ -128,7 +127,7 @@ error:
 
 size_t agcom_getallconfig(char ** output) {
 
-    cJSON *report = cJSON_CreateArray();
+    cJSON *report = cJSON_CreateObject();
     cJSON *body = cJSON_CreateObject();
 
     module_report_merge(body, getClientConfig());
@@ -137,19 +136,47 @@ size_t agcom_getallconfig(char ** output) {
     module_report_merge(body, getAntiTamperingConfig());
 #endif
 
-    module_report_add_config(report, AGCOM_MODULE_NAME, body);
+    module_report_add(report, AGCOM_MODULE_NAME, body);
     return module_report_reply(report, output);
+}
+
+/* "getstate" is a socket call, and the {"error","data"} envelope is its framing:
+ * the body itself carries no error channel. Added here rather than inside
+ * w_agentd_state_get() so the /stats push, where the response status is the
+ * error channel, can send the body bare. */
+size_t agcom_getstate(char ** output) {
+
+    cJSON *envelope = cJSON_CreateObject();
+    cJSON *body = w_agentd_state_get();
+    char *json_str = NULL;
+
+    if (!envelope || !body) {
+        cJSON_Delete(envelope);
+        cJSON_Delete(body);
+        os_strdup("err Could not build the agent state", *output);
+        return strlen(*output);
+    }
+
+    cJSON_AddNumberToObject(envelope, W_AGENTD_JSON_ERROR, 0);
+    cJSON_AddItemToObject(envelope, W_AGENTD_JSON_DATA, body);
+
+    json_str = cJSON_PrintUnformatted(envelope);
+    cJSON_Delete(envelope);
+
+    if (!json_str) {
+        os_strdup("err Could not serialize the agent state", *output);
+        return strlen(*output);
+    }
+
+    *output = json_str;
+    return strlen(*output);
 }
 
 size_t agcom_getallstats(char ** output) {
 
-    cJSON *report = cJSON_CreateArray();
-    char *state = w_agentd_state_get();
+    cJSON *report = cJSON_CreateObject();
 
-    /* w_agentd_state_get() hands back a serialized document; parse it so the
-     * report carries the object rather than a string holding JSON. */
-    module_report_add_stats(report, AGCOM_MODULE_NAME, state ? cJSON_Parse(state) : NULL);
-    os_free(state);
+    module_report_add(report, AGCOM_MODULE_NAME, w_agentd_state_get());
     return module_report_reply(report, output);
 }
 

--- a/src/client-agent/src/agcom.c
+++ b/src/client-agent/src/agcom.c
@@ -81,8 +81,11 @@ size_t agcom_getconfig(const char * section, char ** output) {
     cJSON *cfg;
     char *json_str;
 
-    if (strcmp(section, "client") == 0){
-        if (cfg = getClientConfig(), cfg) {
+    /* "client" is the 4.x name of this section and stays accepted so the Server
+     * API's existing /config/agent/client path keeps working; the document it
+     * returns is keyed "agent" either way. */
+    if (strcmp(section, "agent") == 0 || strcmp(section, "client") == 0){
+        if (cfg = getAgentConfig(), cfg) {
             *output = strdup("ok");
             json_str = cJSON_PrintUnformatted(cfg);
             wm_strcat(output, json_str, ' ');
@@ -130,7 +133,7 @@ size_t agcom_getallconfig(char ** output) {
     cJSON *report = cJSON_CreateObject();
     cJSON *body = cJSON_CreateObject();
 
-    module_report_merge(body, getClientConfig());
+    module_report_merge(body, getAgentConfig());
     module_report_merge(body, getAgentInternalOptions());
 #ifndef WIN32
     module_report_merge(body, getAntiTamperingConfig());

--- a/src/client-agent/src/agent_report.c
+++ b/src/client-agent/src/agent_report.c
@@ -183,7 +183,7 @@ static cJSON *report_entries(const char *target, char *reply) {
         return NULL;
     }
 
-    if (entries = cJSON_Parse(reply + 3), !entries || !cJSON_IsArray(entries)) {
+    if (entries = cJSON_Parse(reply + 3), !entries || !cJSON_IsObject(entries)) {
         mdebug1("Component '%s' answered with something other than a report.", target);
         cJSON_Delete(entries);
         entries = NULL;
@@ -194,16 +194,18 @@ static cJSON *report_entries(const char *target, char *reply) {
 }
 
 /**
- * @brief Move every entry of a component's array into the combined report.
- * @param report Destination array.
- * @param entries Source array. Consumed by this call.
+ * @brief Move every module of a component's report into the combined one.
+ * @param report Destination object, keyed by module name.
+ * @param entries Source object. Consumed by this call.
  */
 static void report_absorb(cJSON *report, cJSON *entries) {
     cJSON *entry = NULL;
 
     while (entries && (entry = entries->child)) {
         cJSON_DetachItemViaPointer(entries, entry);
-        cJSON_AddItemToArray(report, entry);
+        /* Same key-lifetime rule as module_report_merge(): cJSON copies the key
+         * before releasing the item's own, so passing entry->string is safe. */
+        cJSON_AddItemToObject(report, entry->string, entry);
     }
 
     cJSON_Delete(entries);
@@ -217,7 +219,7 @@ static void report_absorb(cJSON *report, cJSON *entries) {
  */
 static char *report_collect(const report_source_t *sources, size_t count) {
     cJSON *root = cJSON_CreateObject();
-    cJSON *report = cJSON_CreateArray();
+    cJSON *report = cJSON_CreateObject();
     char *document = NULL;
     size_t i;
 

--- a/src/client-agent/src/config.c
+++ b/src/client-agent/src/config.c
@@ -113,7 +113,7 @@ bool w_agent_validate_ssl_ca(const agent *cfg)
     return true;
 }
 
-cJSON *getClientConfig(void) {
+cJSON *getAgentConfig(void) {
 
     if (!agt) {
         return NULL;
@@ -121,14 +121,14 @@ cJSON *getClientConfig(void) {
 
     unsigned int i;
     cJSON *root = cJSON_CreateObject();
-    cJSON *client = cJSON_CreateObject();
+    cJSON *agent_config = cJSON_CreateObject();
 
-    if (agt->profile) cJSON_AddStringToObject(client,"config-profile",agt->profile);
-    cJSON_AddNumberToObject(client,"notify_time",agt->notify_time);
-    cJSON_AddNumberToObject(client,"time-reconnect",agt->max_time_reconnect_try);
-    cJSON_AddNumberToObject(client,"ip_update_interval",agt->main_ip_update_interval);
-    if (agt->flags.auto_restart) cJSON_AddStringToObject(client,"auto_restart","yes"); else cJSON_AddStringToObject(client,"auto_restart","no");
-    if (agt->flags.remote_conf) cJSON_AddStringToObject(client,"remote_conf","yes"); else cJSON_AddStringToObject(client,"remote_conf","no");
+    if (agt->profile) cJSON_AddStringToObject(agent_config,"config-profile",agt->profile);
+    cJSON_AddNumberToObject(agent_config,"notify_time",agt->notify_time);
+    cJSON_AddNumberToObject(agent_config,"time-reconnect",agt->max_time_reconnect_try);
+    cJSON_AddNumberToObject(agent_config,"ip_update_interval",agt->main_ip_update_interval);
+    if (agt->flags.auto_restart) cJSON_AddStringToObject(agent_config,"auto_restart","yes"); else cJSON_AddStringToObject(agent_config,"auto_restart","no");
+    if (agt->flags.remote_conf) cJSON_AddStringToObject(agent_config,"remote_conf","yes"); else cJSON_AddStringToObject(agent_config,"remote_conf","no");
     if (agt->server) {
         cJSON *servers = cJSON_CreateArray();
         for (i=0;agt->server[i].rip;i++) {
@@ -144,7 +144,7 @@ cJSON *getClientConfig(void) {
 
             cJSON_AddItemToArray(servers,server);
         }
-        cJSON_AddItemToObject(client,"manager",servers);
+        cJSON_AddItemToObject(agent_config,"manager",servers);
     }
 
     if (agt->enrollment_cfg) {
@@ -176,21 +176,21 @@ cJSON *getClientConfig(void) {
         if(agt->enrollment_cfg->cert_cfg->authpass)
             cJSON_AddStringToObject(enrollment_cfg, "authorization_pass_path", agt->enrollment_cfg->cert_cfg->authpass_file);
 
-        cJSON_AddItemToObject(client,"enrollment",enrollment_cfg);
+        cJSON_AddItemToObject(agent_config,"enrollment",enrollment_cfg);
     }
     /* The two periodic report pushes (#37843). Reported so the /config document
      * says whether the agent is reporting, and on what cadence. */
     cJSON *stats_report = cJSON_CreateObject();
     cJSON_AddStringToObject(stats_report, "enabled", agt->stats_report.enabled ? "yes" : "no");
     cJSON_AddNumberToObject(stats_report, "interval", agt->stats_report.interval);
-    cJSON_AddItemToObject(client, "stats_report", stats_report);
+    cJSON_AddItemToObject(agent_config, "stats_report", stats_report);
 
     cJSON *config_report = cJSON_CreateObject();
     cJSON_AddStringToObject(config_report, "enabled", agt->config_report.enabled ? "yes" : "no");
     cJSON_AddNumberToObject(config_report, "interval", agt->config_report.interval);
-    cJSON_AddItemToObject(client, "config_report", config_report);
+    cJSON_AddItemToObject(agent_config, "config_report", config_report);
 
-    cJSON_AddItemToObject(root,"client",client);
+    cJSON_AddItemToObject(root, "agent", agent_config);
 
     return root;
 }

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -875,6 +875,14 @@ static void bridge_on_remote_upgrade_ready(const char *task_id, const char *wpk_
 static void bridge_on_manager_config_hash(const char *config_hash, void *user_data)
 {
     (void)user_data;
+
+    /* An accepted Notify is the agent's keepalive: it is the same event the
+     * manager records as one. Taken here rather than at send time (where the
+     * legacy notify.c put it, right after send_msg(), so it advanced even with
+     * the network down) so the value proves a completed round trip. */
+    time_t now = time(NULL);
+    w_agentd_state_update(UPDATE_KEEPALIVE, &now);
+
     startup_gate_check_manager_config_hash(config_hash);
 }
 

--- a/src/client-agent/src/state.c
+++ b/src/client-agent/src/state.c
@@ -22,6 +22,9 @@
 
 #ifdef WIN32
 #define localtime_r(x, y) localtime_s(y, x)
+/* No portable gmtime_r on the mingw C runtime; same shim the other C callers
+ * use (see syscheckd/src/file/events.c). */
+#define gmtime_r(x, y) (gmtime_s(y, x) == 0 ? (y) : NULL)
 #endif
 
 agent_state_t agent_state = { .status = GA_STATUS_PENDING };
@@ -243,61 +246,67 @@ void w_agentd_state_update(w_agentd_state_update_t type, void * data) {
     return;
 }
 
-char * w_agentd_state_get() {
+/* Each task counter is reported as {"total": n}: ".total" is the wcs marker for
+ * a counter that is monotonic over the process's uptime. */
+static void w_agentd_state_add_counter(cJSON * parent, const char * name, unsigned int value) {
+    cJSON * counter = cJSON_CreateObject();
 
-    const char * status = NULL;
-    char last_keepalive[W_AGENTD_STATE_TIME_LENGHT] = {0};
-    char last_ack[W_AGENTD_STATE_TIME_LENGHT] = {0};
-    unsigned int count;
-    unsigned int sent;
-    unsigned int dispatched;
-    unsigned int duplicate;
-    unsigned int failed;
+    if (!counter) {
+        return;
+    }
 
+    cJSON_AddNumberToObject(counter, W_AGENTD_FIELD_TOTAL, value);
+    cJSON_AddItemToObject(parent, name, counter);
+}
+
+cJSON * w_agentd_state_get(void) {
+
+    char last_keepalive[W_AGENTD_STATE_TIME_ISO8601_LENGHT] = {0};
     struct tm tm = {.tm_sec = 0};
-    char * retval = NULL;
-    cJSON * json_retval = cJSON_CreateObject();
-    cJSON * data = cJSON_CreateObject();
 
-    /* Get status info */
+    cJSON * body = cJSON_CreateObject();
+    cJSON * messages = cJSON_CreateObject();
+    cJSON * tasks = cJSON_CreateObject();
+
+    if (!body || !messages || !tasks) {
+        cJSON_Delete(body);
+        cJSON_Delete(messages);
+        cJSON_Delete(tasks);
+        return NULL;
+    }
+
     w_mutex_lock(&state_mutex);
-    status = get_str_status(agent_state.status);
+    const char * status = get_str_status(agent_state.status);
 
+    /* gmtime_r, not localtime_r: only the agent knows its own offset, so a naive
+     * local time cannot be resolved to an instant downstream. */
     if (agent_state.last_keepalive) {
-        localtime_r(&agent_state.last_keepalive, &tm);
-        strftime(last_keepalive, sizeof(last_keepalive), W_AGENTD_STATE_TIME_FORMAT, &tm);
+        gmtime_r(&agent_state.last_keepalive, &tm);
+        strftime(last_keepalive, sizeof(last_keepalive), W_AGENTD_STATE_TIME_FORMAT_ISO8601, &tm);
     }
 
-    if (agent_state.last_ack) {
-        localtime_r(&agent_state.last_ack, &tm);
-        strftime(last_ack, sizeof(last_ack), W_AGENTD_STATE_TIME_FORMAT, &tm);
-    }
-
-    count = agent_state.msg_count;
-    sent = agent_state.msg_sent;
-    dispatched = agent_state.task_dispatched;
-    duplicate = agent_state.task_discarded_duplicate;
-    failed = agent_state.task_failed;
+    const unsigned int count = agent_state.msg_count;
+    const unsigned int dispatched = agent_state.task_dispatched;
+    const unsigned int duplicate = agent_state.task_discarded_duplicate;
+    const unsigned int failed = agent_state.task_failed;
     w_mutex_unlock(&state_mutex);
 
-    /* json response */
-    cJSON_AddNumberToObject(json_retval, W_AGENTD_JSON_ERROR, 0);
-    cJSON_AddItemToObject(json_retval, W_AGENTD_JSON_DATA, data);
+    cJSON_AddStringToObject(body, W_AGENTD_FIELD_STATUS, status);
 
-    cJSON_AddStringToObject(data, W_AGENTD_FIELD_STATUS, status);
-    cJSON_AddStringToObject(data, W_AGENTD_FIELD_KEEP_ALIVE, last_keepalive);
-    cJSON_AddStringToObject(data, W_AGENTD_FIELD_LAST_ACK, last_ack);
-    cJSON_AddNumberToObject(data, W_AGENTD_FIELD_MSG_COUNT, count);
-    cJSON_AddNumberToObject(data, W_AGENTD_FIELD_MSG_SENT, sent);
-    /* No agentd-side buffer: the accumulator exposes a ladder, not a count. */
-    cJSON_AddNumberToObject(data, W_AGENTD_FIELD_MSG_BUFF, 0);
-    cJSON_AddBoolToObject(data, W_AGENTD_FIELD_EN_BUFF, false);
-    cJSON_AddNumberToObject(data, W_AGENTD_FIELD_TASK_DISPATCHED, dispatched);
-    cJSON_AddNumberToObject(data, W_AGENTD_FIELD_TASK_DUPLICATE, duplicate);
-    cJSON_AddNumberToObject(data, W_AGENTD_FIELD_TASK_FAILED, failed);
+    /* Omitted rather than sent empty: the field is mapped `date`, and an empty
+     * string is not a parsable one, so the indexer would reject the whole
+     * document -- silently, since the push is fire-and-forget. */
+    if (last_keepalive[0] != '\0') {
+        cJSON_AddStringToObject(body, W_AGENTD_FIELD_KEEP_ALIVE, last_keepalive);
+    }
 
-    retval = cJSON_PrintUnformatted(json_retval);
-    cJSON_Delete(json_retval);
+    cJSON_AddNumberToObject(messages, W_AGENTD_FIELD_MESSAGES_COUNT, count);
+    cJSON_AddItemToObject(body, W_AGENTD_FIELD_MESSAGES, messages);
 
-    return retval;
+    w_agentd_state_add_counter(tasks, W_AGENTD_FIELD_TASK_DISPATCHED, dispatched);
+    w_agentd_state_add_counter(tasks, W_AGENTD_FIELD_TASK_DUPLICATE, duplicate);
+    w_agentd_state_add_counter(tasks, W_AGENTD_FIELD_TASK_FAILED, failed);
+    cJSON_AddItemToObject(body, W_AGENTD_FIELD_TASKS, tasks);
+
+    return body;
 }

--- a/src/logcollector/src/lccom.c
+++ b/src/logcollector/src/lccom.c
@@ -463,25 +463,25 @@ size_t lccom_getstate(char ** output, bool getNextPage) {
 
 size_t lccom_getallconfig(char ** output) {
 
-    cJSON *report = cJSON_CreateArray();
+    cJSON *report = cJSON_CreateObject();
     cJSON *body = cJSON_CreateObject();
 
     module_report_merge(body, getLocalfileConfig());
     module_report_merge(body, getSocketConfig());
     module_report_merge(body, getLogcollectorInternalOptions());
 
-    module_report_add_config(report, LCCOM_MODULE_NAME, body);
+    module_report_add(report, LCCOM_MODULE_NAME, body);
     return module_report_reply(report, output);
 }
 
 size_t lccom_getallstats(char ** output) {
 
-    cJSON *report = cJSON_CreateArray();
+    cJSON *report = cJSON_CreateObject();
 
     /* Straight from the state rather than through lccom_getstate(): the report
      * wants the statistics themselves, without that path's error envelope or
      * its 64k paging, which a single reply cannot carry anyway. */
-    module_report_add_stats(report, LCCOM_MODULE_NAME, w_logcollector_state_get());
+    module_report_add(report, LCCOM_MODULE_NAME, w_logcollector_state_get());
     return module_report_reply(report, output);
 }
 

--- a/src/logcollector/src/state.c
+++ b/src/logcollector/src/state.c
@@ -18,10 +18,13 @@
 
 #ifdef WIN32
 #define localtime_r(x, y) localtime_s(y, x)
+/* No portable gmtime_r on the mingw C runtime; same shim the other C callers
+ * use (see syscheckd/src/file/events.c). */
+#define gmtime_r(x, y) (gmtime_s(y, x) == 0 ? (y) : NULL)
 #endif
 
-#define W_LC_STATE_TIME_FORMAT "%Y-%m-%d %H:%M:%S" ///< Time format for the JSON and the file output
-#define W_LC_STATE_TIME_LENGHT (19 + 1)            ///< Maximum time size
+#define W_LC_STATE_TIME_FORMAT "%Y-%m-%dT%H:%M:%SZ" ///< ISO 8601 UTC, for the JSON and the file output
+#define W_LC_STATE_TIME_LENGHT (20 + 1)              ///< Maximum time size
 
 /* Global variables */
 
@@ -411,12 +414,12 @@ cJSON * _w_logcollector_generate_state(w_lc_state_storage_t * state, bool restar
     }
 
     // Convert timestamp to string
-    localtime_r(&state->start, &tm);
+    gmtime_r(&state->start, &tm);
     strftime(timestamp_tmp, sizeof(timestamp_tmp), W_LC_STATE_TIME_FORMAT, &tm);
     cJSON_AddStringToObject(lc_stats_json, "start", timestamp_tmp);
 
     time_t now = time(NULL);
-    localtime_r(&now, &tm);
+    gmtime_r(&now, &tm);
     strftime(timestamp_tmp, sizeof(timestamp_tmp), W_LC_STATE_TIME_FORMAT, &tm);
     cJSON_AddStringToObject(lc_stats_json, "end", timestamp_tmp);
 

--- a/src/os_execd/src/wcom.c
+++ b/src/os_execd/src/wcom.c
@@ -193,7 +193,7 @@ size_t wcom_uncompress(const char * source, const char * target, char ** output)
 
 size_t wcom_getallconfig(char ** output) {
 
-    cJSON *report = cJSON_CreateArray();
+    cJSON *report = cJSON_CreateObject();
     cJSON *body = cJSON_CreateObject();
 
     /* No "cluster" section here: it is manager-only and reaching it depends on
@@ -202,7 +202,7 @@ size_t wcom_getallconfig(char ** output) {
     module_report_merge(body, getLoggingConfig());
     module_report_merge(body, getExecdInternalOptions());
 
-    module_report_add_config(report, WCOM_MODULE_NAME, body);
+    module_report_add(report, WCOM_MODULE_NAME, body);
     return module_report_reply(report, output);
 }
 

--- a/src/shared/include/module_report.h
+++ b/src/shared/include/module_report.h
@@ -14,15 +14,19 @@
 #include <stddef.h>
 #include "cJSON.h"
 
-/* A report is a JSON array where each entry names one module and carries its
- * body:
+/* A report is a JSON object keyed by module name:
  *
- *   [{"module": "fim", "config": {...}}, {"module": "logcollector", ...}]
+ *   {"fim": {...}, "logcollector": {...}}
  *
  * Every agent daemon answers "getallconfig" / "getallstats" with the report for
  * the modules it hosts, so the HTTPS client needs one query per daemon instead
- * of one per configuration section. The client concatenates the arrays into the
- * document it pushes to /config and /stats. */
+ * of one per configuration section. The client merges the objects into the
+ * document it pushes to /config and /stats.
+ *
+ * Keyed rather than an array of {"module": name, ...} entries so the manager
+ * only has to validate the object and move it under wazuh.agent.statistics:
+ * one entry per module is already the invariant, and a stored array cannot be
+ * read back by key without a `nested` mapping. */
 
 /**
  * @brief Move every member of a section into a module body.
@@ -37,25 +41,16 @@
 void module_report_merge(cJSON *body, cJSON *section);
 
 /**
- * @brief Append a {"module": name, "config": body} entry to a report.
+ * @brief Store a module's body in a report under its own name.
  *
  * A module that produced nothing is left out rather than reported empty, so the
  * manager can tell "not configured" from "configured with no options".
  *
- * @param report Destination array.
+ * @param report Destination object.
  * @param module Module name as the manager knows it, e.g. "fim".
  * @param body Module body. Consumed by this call.
  */
-void module_report_add_config(cJSON *report, const char *module, cJSON *body);
-
-/**
- * @brief Append a {"module": name, "stats": body} entry to a report.
- *
- * @param report Destination array.
- * @param module Module name as the manager knows it, e.g. "logcollector".
- * @param body Module body. Consumed by this call.
- */
-void module_report_add_stats(cJSON *report, const char *module, cJSON *body);
+void module_report_add(cJSON *report, const char *module, cJSON *body);
 
 /**
  * @brief Serialize a report into the "ok <json>" reply a dispatcher returns.

--- a/src/shared/src/module_report.c
+++ b/src/shared/src/module_report.c
@@ -33,16 +33,7 @@ void module_report_merge(cJSON *body, cJSON *section) {
     cJSON_Delete(section);
 }
 
-/**
- * @brief Append a {"module": name, <key>: body} entry, dropping empty bodies.
- * @param report Destination array.
- * @param module Module name.
- * @param key Name under which the body is stored.
- * @param body Module body. Consumed by this call.
- */
-static void module_report_add(cJSON *report, const char *module, const char *key, cJSON *body) {
-    cJSON *entry = NULL;
-
+void module_report_add(cJSON *report, const char *module, cJSON *body) {
     if (!report || !module || !body) {
         cJSON_Delete(body);
         return;
@@ -53,22 +44,7 @@ static void module_report_add(cJSON *report, const char *module, const char *key
         return;
     }
 
-    if (entry = cJSON_CreateObject(), !entry) {
-        cJSON_Delete(body);
-        return;
-    }
-
-    cJSON_AddStringToObject(entry, "module", module);
-    cJSON_AddItemToObject(entry, key, body);
-    cJSON_AddItemToArray(report, entry);
-}
-
-void module_report_add_config(cJSON *report, const char *module, cJSON *body) {
-    module_report_add(report, module, "config", body);
-}
-
-void module_report_add_stats(cJSON *report, const char *module, cJSON *body) {
-    module_report_add(report, module, "stats", body);
+    cJSON_AddItemToObject(report, module, body);
 }
 
 size_t module_report_reply(cJSON *report, char **output) {

--- a/src/syscheckd/src/syscom.c
+++ b/src/syscheckd/src/syscom.c
@@ -272,7 +272,7 @@ error:
 size_t syscom_getallconfig(char ** output) {
     assert(output != NULL);
 
-    cJSON *report = cJSON_CreateArray();
+    cJSON *report = cJSON_CreateObject();
     cJSON *body = cJSON_CreateObject();
 
     /* rootcheck ships inside this daemon, so it rides along in fim's body
@@ -281,7 +281,7 @@ size_t syscom_getallconfig(char ** output) {
     module_report_merge(body, getRootcheckConfig());
     module_report_merge(body, getSyscheckInternalOptions());
 
-    module_report_add_config(report, SYSCOM_MODULE_NAME, body);
+    module_report_add(report, SYSCOM_MODULE_NAME, body);
     return module_report_reply(report, output);
 }
 

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -73,14 +73,14 @@ endif()
 
 list(APPEND client-agent_names "test_agcom")
 if(${TARGET} STREQUAL "winagent")
-list(APPEND client-agent_flags "-Wl,--wrap,getClientConfig \
+list(APPEND client-agent_flags "-Wl,--wrap,getAgentConfig \
                                 -Wl,--wrap,getLabelsConfig -Wl,--wrap,getAgentInternalOptions \
                                 -Wl,--wrap,getAntiTamperingConfig -Wl,--wrap,w_agentd_state_get \
                                 -Wl,--wrap=syscom_dispatch -Wl,--wrap=Start_win32_Syscheck \
                                 -Wl,--wrap=is_fim_shutdown -Wl,--wrap=fim_db_teardown \
                                 -Wl,--wrap=_imp__dbsync_initialize -Wl,--wrap=_imp__rsync_initialize")
 else()
-list(APPEND client-agent_flags "-Wl,--wrap,getClientConfig \
+list(APPEND client-agent_flags "-Wl,--wrap,getAgentConfig \
                                 -Wl,--wrap,getLabelsConfig -Wl,--wrap,getAgentInternalOptions \
                                 -Wl,--wrap,getAntiTamperingConfig -Wl,--wrap,w_agentd_state_get")
 endif()

--- a/src/unit_tests/client-agent/test_agcom.c
+++ b/src/unit_tests/client-agent/test_agcom.c
@@ -27,7 +27,7 @@ static cJSON *g_anti_tampering_cfg = NULL;
 static cJSON *g_state_body = NULL;
 
 /* --- Stub implementations --- */
-cJSON* __wrap_getClientConfig(void)
+cJSON* __wrap_getAgentConfig(void)
 {
     cJSON* ret = g_client_cfg;
     g_client_cfg = NULL;
@@ -138,7 +138,7 @@ static void test_agcom_getconfig_client_ok(void** state)
     char command[] = "getconfig client";
     char* output = NULL;
 
-    g_client_cfg = make_simple_json("client", "ok");
+    g_client_cfg = make_simple_json("agent", "ok");
 
     size_t len = agcom_dispatch(command, &output);
 
@@ -226,7 +226,7 @@ static void test_agcom_getallconfig_reports_every_section_as_one_module(void** s
     char command[] = "getallconfig";
     char* output = NULL;
 
-    g_client_cfg = make_simple_json("client", "ok");
+    g_client_cfg = make_simple_json("agent", "ok");
     g_internal_cfg = make_simple_json("internal", "ok");
 #ifndef WIN32
     g_anti_tampering_cfg = make_simple_json("anti_tampering", "ok");
@@ -245,7 +245,7 @@ static void test_agcom_getallconfig_reports_every_section_as_one_module(void** s
     /* Keyed by module name, body directly under it. */
     cJSON* config = cJSON_GetObjectItem(report, "agent");
     assert_non_null(config);
-    assert_non_null(cJSON_GetObjectItem(config, "client"));
+    assert_non_null(cJSON_GetObjectItem(config, "agent"));
     assert_non_null(cJSON_GetObjectItem(config, "internal"));
 #ifndef WIN32
     assert_non_null(cJSON_GetObjectItem(config, "anti_tampering"));
@@ -262,7 +262,7 @@ static void test_agcom_getallconfig_omits_sections_that_are_unset(void** state)
     char* output = NULL;
 
     /* Only the client section is configured; the rest return NULL. */
-    g_client_cfg = make_simple_json("client", "ok");
+    g_client_cfg = make_simple_json("agent", "ok");
 
     size_t len = agcom_dispatch(command, &output);
 
@@ -270,7 +270,7 @@ static void test_agcom_getallconfig_omits_sections_that_are_unset(void** state)
 
     cJSON* report = cJSON_Parse(output + 3);
     cJSON* config = cJSON_GetObjectItem(report, "agent");
-    assert_non_null(cJSON_GetObjectItem(config, "client"));
+    assert_non_null(cJSON_GetObjectItem(config, "agent"));
     assert_null(cJSON_GetObjectItem(config, "internal"));
 
     cJSON_Delete(report);

--- a/src/unit_tests/client-agent/test_agcom.c
+++ b/src/unit_tests/client-agent/test_agcom.c
@@ -24,7 +24,7 @@ static cJSON *g_internal_cfg = NULL;
 #ifndef WIN32
 static cJSON *g_anti_tampering_cfg = NULL;
 #endif
-static const char *g_state_output = "ok state";
+static cJSON *g_state_body = NULL;
 
 /* --- Stub implementations --- */
 cJSON* __wrap_getClientConfig(void)
@@ -53,9 +53,12 @@ cJSON* __wrap_getAntiTamperingConfig(void)
 }
 #endif
 
-char* __wrap_w_agentd_state_get(void)
+cJSON* __wrap_w_agentd_state_get(void)
 {
-    return strdup(g_state_output);
+    cJSON* ret = g_state_body;
+    g_state_body = NULL;
+
+    return ret;
 }
 
 /* --- Helpers --- */
@@ -102,18 +105,30 @@ static void test_agcom_dispatch_unknown_command(void** state)
     free(output);
 }
 
-static void test_agcom_dispatch_getstate(void** state)
+static void test_agcom_dispatch_getstate_wraps_the_body_in_the_envelope(void** state)
 {
     (void)state;
     char command[] = "getstate";
     char* output = NULL;
 
+    g_state_body = make_simple_json("status", "connected");
+
     size_t len = agcom_dispatch(command, &output);
 
     assert_non_null(output);
-    assert_string_equal(output, "ok state");
     assert_int_equal((int)len, (int)strlen(output));
 
+    /* "getstate" is a socket call: the envelope is its framing, added at this
+     * call site rather than by w_agentd_state_get(), which the /stats push
+     * sends bare. */
+    cJSON* parsed = cJSON_Parse(output);
+    assert_non_null(parsed);
+    assert_int_equal(cJSON_GetObjectItem(parsed, "error")->valueint, 0);
+    assert_string_equal(
+        cJSON_GetObjectItem(cJSON_GetObjectItem(parsed, "data"), "status")->valuestring,
+        "connected");
+
+    cJSON_Delete(parsed);
     free(output);
 }
 
@@ -227,12 +242,9 @@ static void test_agcom_getallconfig_reports_every_section_as_one_module(void** s
     assert_non_null(report);
     /* One entry for the whole daemon, with every section inside it: this is
      * what saves the caller a query per section. */
-    assert_int_equal(cJSON_GetArraySize(report), 1);
-
-    cJSON* entry = cJSON_GetArrayItem(report, 0);
-    assert_string_equal(cJSON_GetObjectItem(entry, "module")->valuestring, "agent");
-
-    cJSON* config = cJSON_GetObjectItem(entry, "config");
+    /* Keyed by module name, body directly under it. */
+    cJSON* config = cJSON_GetObjectItem(report, "agent");
+    assert_non_null(config);
     assert_non_null(cJSON_GetObjectItem(config, "client"));
     assert_non_null(cJSON_GetObjectItem(config, "internal"));
 #ifndef WIN32
@@ -257,7 +269,7 @@ static void test_agcom_getallconfig_omits_sections_that_are_unset(void** state)
     assert_int_equal((int)len, (int)strlen(output));
 
     cJSON* report = cJSON_Parse(output + 3);
-    cJSON* config = cJSON_GetObjectItem(cJSON_GetArrayItem(report, 0), "config");
+    cJSON* config = cJSON_GetObjectItem(report, "agent");
     assert_non_null(cJSON_GetObjectItem(config, "client"));
     assert_null(cJSON_GetObjectItem(config, "internal"));
 
@@ -265,44 +277,57 @@ static void test_agcom_getallconfig_omits_sections_that_are_unset(void** state)
     free(output);
 }
 
-static void test_agcom_getallstats_carries_the_state_as_an_object(void** state)
+static void test_agcom_getallstats_reports_the_grouped_message_counters(void** state)
 {
     (void)state;
     char command[] = "getallstats";
     char* output = NULL;
-    const char* previous = g_state_output;
 
-    g_state_output = "{\"status\":\"connected\"}";
+    /* The shape the manager indexes: no {"error","data"} envelope, and the
+     * message counters grouped under "messages". */
+    cJSON* report = cJSON_CreateObject();
+    cJSON* messages = cJSON_CreateObject();
+    cJSON* sent = cJSON_CreateObject();
+    cJSON_AddStringToObject(report, "status", "connected");
+    cJSON_AddNumberToObject(messages, "count", 602);
+    cJSON_AddNumberToObject(messages, "buffered", 0);
+    cJSON_AddNumberToObject(sent, "total", 689);
+    cJSON_AddItemToObject(messages, "sent", sent);
+    cJSON_AddItemToObject(report, "messages", messages);
+    g_state_body = report;
 
     size_t len = agcom_dispatch(command, &output);
 
     assert_int_equal((int)len, (int)strlen(output));
 
-    cJSON* report = cJSON_Parse(output + 3);
-    cJSON* entry = cJSON_GetArrayItem(report, 0);
-    assert_string_equal(cJSON_GetObjectItem(entry, "module")->valuestring, "agent");
-    /* Parsed, not embedded as a string holding JSON. */
-    assert_string_equal(
-        cJSON_GetObjectItem(cJSON_GetObjectItem(entry, "stats"), "status")->valuestring,
-        "connected");
+    cJSON* parsed = cJSON_Parse(output + 3);
+    cJSON* stats = cJSON_GetObjectItem(parsed, "agent");
+    assert_non_null(stats);
+    assert_null(cJSON_GetObjectItem(stats, "data"));
+    assert_null(cJSON_GetObjectItem(stats, "msg_count"));
 
-    cJSON_Delete(report);
+    cJSON* out_messages = cJSON_GetObjectItem(stats, "messages");
+    assert_non_null(out_messages);
+    assert_int_equal(cJSON_GetObjectItem(out_messages, "count")->valueint, 602);
+    assert_int_equal(cJSON_GetObjectItem(out_messages, "buffered")->valueint, 0);
+    assert_int_equal(
+        cJSON_GetObjectItem(cJSON_GetObjectItem(out_messages, "sent"), "total")->valueint, 689);
+
+    cJSON_Delete(parsed);
     free(output);
-    g_state_output = previous;
 }
 
-static void test_agcom_getallstats_drops_state_that_is_not_json(void** state)
+static void test_agcom_getallstats_drops_an_unavailable_report(void** state)
 {
     (void)state;
     char command[] = "getallstats";
     char* output = NULL;
 
-    /* g_state_output is the default "ok state", which is not a document. The
-     * entry must be left out rather than reported as a broken one. */
+    /* g_stats_report is NULL: the entry is left out rather than reported empty. */
     size_t len = agcom_dispatch(command, &output);
 
     assert_int_equal((int)len, (int)strlen(output));
-    assert_string_equal(output, "ok []");
+    assert_string_equal(output, "ok {}");
 
     free(output);
 }
@@ -312,7 +337,7 @@ int main(void)
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_agcom_dispatch_getconfig_missing_args),
         cmocka_unit_test(test_agcom_dispatch_unknown_command),
-        cmocka_unit_test(test_agcom_dispatch_getstate),
+        cmocka_unit_test(test_agcom_dispatch_getstate_wraps_the_body_in_the_envelope),
         cmocka_unit_test(test_agcom_getconfig_client_ok),
         cmocka_unit_test(test_agcom_getconfig_internal_ok),
 #ifndef WIN32
@@ -322,8 +347,8 @@ int main(void)
         cmocka_unit_test(test_agcom_getconfig_unknown_section),
         cmocka_unit_test(test_agcom_getallconfig_reports_every_section_as_one_module),
         cmocka_unit_test(test_agcom_getallconfig_omits_sections_that_are_unset),
-        cmocka_unit_test(test_agcom_getallstats_carries_the_state_as_an_object),
-        cmocka_unit_test(test_agcom_getallstats_drops_state_that_is_not_json),
+        cmocka_unit_test(test_agcom_getallstats_reports_the_grouped_message_counters),
+        cmocka_unit_test(test_agcom_getallstats_drops_an_unavailable_report),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/client-agent/test_agent_report.c
+++ b/src/unit_tests/client-agent/test_agent_report.c
@@ -166,18 +166,8 @@ static void expecting_debug_logs(void)
 
 static cJSON* module_named(cJSON* document, const char* name)
 {
-    cJSON* modules = cJSON_GetObjectItem(document, "modules");
-    cJSON* entry = NULL;
-
-    cJSON_ArrayForEach(entry, modules) {
-        cJSON* module = cJSON_GetObjectItem(entry, "module");
-
-        if (module && strcmp(module->valuestring, name) == 0) {
-            return entry;
-        }
-    }
-
-    return NULL;
+    /* "modules" is keyed by module name, so this is a direct lookup. */
+    return cJSON_GetObjectItem(cJSON_GetObjectItem(document, "modules"), name);
 }
 
 /* --- Tests --- */
@@ -185,13 +175,12 @@ static void test_collect_config_merges_every_daemon_into_one_document(void** sta
 {
     (void)state;
     const answer_t answers[] = {
-        {"agent", "ok [{\"module\":\"agent\",\"config\":{\"client\":{}}}]"},
-        {"syscheck", "ok [{\"module\":\"fim\",\"config\":{\"syscheck\":{}}}]"},
-        {"logcollector", "ok [{\"module\":\"logcollector\",\"config\":{\"localfile\":[]}}]"},
+        {"agent", "ok {\"agent\":{\"client\":{}}}"},
+        {"syscheck", "ok {\"fim\":{\"syscheck\":{}}}"},
+        {"logcollector", "ok {\"logcollector\":{\"localfile\":[]}}"},
         /* One daemon, two modules: modulesd reports each wodle separately. */
-        {"wmodules", "ok [{\"module\":\"syscollector\",\"config\":{}},"
-                     "{\"module\":\"sca\",\"config\":{}}]"},
-        {"com", "ok [{\"module\":\"execd\",\"config\":{\"active-response\":[]}}]"},
+        {"wmodules", "ok {\"syscollector\":{},\"sca\":{}}"},
+        {"com", "ok {\"execd\":{\"active-response\":[]}}"},
     };
 
     given(answers, 5);
@@ -205,7 +194,7 @@ static void test_collect_config_merges_every_daemon_into_one_document(void** sta
 
     /* One query per daemon, and every module they named is present. */
     assert_int_equal(g_connect_calls, 5);
-    assert_int_equal(cJSON_GetArraySize(cJSON_GetObjectItem(parsed, "modules")), 6);
+    assert_int_equal(cJSON_GetArraySize(cJSON_GetObjectItem(parsed, "modules")), 6); /* object members */
     assert_non_null(module_named(parsed, "agent"));
     assert_non_null(module_named(parsed, "fim"));
     assert_non_null(module_named(parsed, "logcollector"));
@@ -221,10 +210,10 @@ static void test_collect_config_reports_the_daemons_that_are_up(void** state)
 {
     (void)state;
     const answer_t answers[] = {
-        {"agent", "ok [{\"module\":\"agent\",\"config\":{\"client\":{}}}]"},
+        {"agent", "ok {\"agent\":{\"client\":{}}}"},
         {"syscheck", NULL},         /* not running */
         {"logcollector", "err Could not get requested section"},
-        {"wmodules", "ok [{\"module\":\"sca\",\"config\":{}}]"},
+        {"wmodules", "ok {\"sca\":{}}"},
         {"com", NULL},
     };
 
@@ -270,9 +259,9 @@ static void test_collect_config_ignores_a_reply_that_is_not_a_report(void** stat
 {
     (void)state;
     const answer_t answers[] = {
-        {"agent", "ok {\"module\":\"agent\"}"},   /* an object, not an array */
+        {"agent", "ok [{\"module\":\"agent\"}]"},  /* the old array shape */
         {"syscheck", "ok not json at all"},
-        {"logcollector", "ok [{\"module\":\"logcollector\",\"config\":{}}]"},
+        {"logcollector", "ok {\"logcollector\":{}}"},
         {"wmodules", NULL},
         {"com", NULL},
     };
@@ -294,8 +283,8 @@ static void test_collect_stats_only_asks_the_daemons_that_produce_them(void** st
 {
     (void)state;
     const answer_t answers[] = {
-        {"agent", "ok [{\"module\":\"agent\",\"stats\":{\"status\":\"connected\"}}]"},
-        {"logcollector", "ok [{\"module\":\"logcollector\",\"stats\":{}}]"},
+        {"agent", "ok {\"agent\":{\"status\":\"connected\"}}"},
+        {"logcollector", "ok {\"logcollector\":{}}"},
     };
 
     given(answers, 2);

--- a/src/unit_tests/client-agent/test_agentd_state.c
+++ b/src/unit_tests/client-agent/test_agentd_state.c
@@ -22,7 +22,7 @@
 
 const char * get_str_status(agent_status_t status);
 void w_agentd_state_update(w_agentd_state_update_t type, void * data);
-char * w_agentd_state_get();
+cJSON * w_agentd_state_get(void);
 
 extern agent_state_t agent_state;
 
@@ -202,583 +202,134 @@ void test_w_agentd_state_update_task_failed(void ** state)
 
 /* w_agentd_state_get */
 
-void test_w_agentd_state_get_last_keepalive(void ** state)
+/* The getter now builds the body the manager indexes: no {"error","data"}
+ * envelope (agcom_getstate adds that), counters grouped, and only fields with a
+ * real producer behind them. The mocked cJSON_CreateObject hands back the same
+ * pointer for the body and every nested object, which is all these need. */
+static void expect_counter(const char * name)
+{
+    will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
+    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TOTAL);
+    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
+    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, true);
+    (void)name;
+}
+
+void test_w_agentd_state_get_groups_the_counters(void ** state)
 {
     agent_state.status = GA_STATUS_ACTIVE;
     agent_state.last_keepalive = 10;
 
+    /* body, messages, tasks */
+    will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
     will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
     will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
 
     expect_function_call(__wrap_pthread_mutex_lock);
-
-    will_return(__wrap_strftime,"2021-01-25 12:18:37");
-    will_return(__wrap_strftime, 20);
-
-    will_return(__wrap_strftime,"2021-01-25 13:00:00");
-    will_return(__wrap_strftime, 20);
-
+    will_return(__wrap_strftime, "2021-01-25T12:18:37Z");
+    will_return(__wrap_strftime, 21);
     expect_function_call(__wrap_pthread_mutex_unlock);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_JSON_ERROR);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_function_call(__wrap_cJSON_AddItemToObject);
-    will_return(__wrap_cJSON_AddItemToObject, true);
 
     expect_string(__wrap_cJSON_AddStringToObject, name, W_AGENTD_FIELD_STATUS);
     expect_string(__wrap_cJSON_AddStringToObject, string, "connected");
     will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
 
     expect_string(__wrap_cJSON_AddStringToObject, name, W_AGENTD_FIELD_KEEP_ALIVE);
-    expect_string(__wrap_cJSON_AddStringToObject, string, "2021-01-25 12:18:37");
+    expect_string(__wrap_cJSON_AddStringToObject, string, "2021-01-25T12:18:37Z");
     will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
 
-    expect_string(__wrap_cJSON_AddStringToObject, name, W_AGENTD_FIELD_LAST_ACK);
-    expect_string(__wrap_cJSON_AddStringToObject, string, "2021-01-25 13:00:00");
-    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MSG_COUNT);
+    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MESSAGES_COUNT);
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
     will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, true);
 
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MSG_SENT);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
+    expect_counter(W_AGENTD_FIELD_TASK_DISPATCHED);
+    expect_counter(W_AGENTD_FIELD_TASK_DUPLICATE);
+    expect_counter(W_AGENTD_FIELD_TASK_FAILED);
 
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MSG_BUFF);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, true);
 
-    will_return(__wrap_cJSON_AddBoolToObject, (cJSON *)1);
+    cJSON * retval = w_agentd_state_get();
 
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TASK_DISPATCHED);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TASK_DUPLICATE);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TASK_FAILED);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    will_return(__wrap_cJSON_PrintUnformatted, "unknown");
-
-    expect_function_call(__wrap_cJSON_Delete);
-
-    const char * retval = w_agentd_state_get();
-
-    assert_string_equal(retval,"unknown");
-
+    assert_ptr_equal(retval, (cJSON *)1);
 }
 
-void test_w_agentd_state_get_last_ack(void ** state)
+void test_w_agentd_state_get_omits_an_unset_keepalive(void ** state)
 {
     agent_state.status = GA_STATUS_ACTIVE;
-    agent_state.last_keepalive = 10;
-    agent_state.last_ack = 10;
+    /* No UPDATE_KEEPALIVE has landed yet. The field is mapped `date` in the
+     * index and an empty string does not parse as one, which rejects the whole
+     * document -- so it must be left out entirely, not sent as "". */
+    agent_state.last_keepalive = 0;
 
+    will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
     will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
     will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
 
     expect_function_call(__wrap_pthread_mutex_lock);
-    will_return(__wrap_strftime,"2021-01-25 12:18:37");
-    will_return(__wrap_strftime, 20);
-
-    will_return(__wrap_strftime,"2021-01-25 13:00:00");
-    will_return(__wrap_strftime, 20);
     expect_function_call(__wrap_pthread_mutex_unlock);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_JSON_ERROR);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_function_call(__wrap_cJSON_AddItemToObject);
-    will_return(__wrap_cJSON_AddItemToObject, true);
 
     expect_string(__wrap_cJSON_AddStringToObject, name, W_AGENTD_FIELD_STATUS);
     expect_string(__wrap_cJSON_AddStringToObject, string, "connected");
     will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
 
-    expect_string(__wrap_cJSON_AddStringToObject, name, W_AGENTD_FIELD_KEEP_ALIVE);
-    expect_string(__wrap_cJSON_AddStringToObject, string, "2021-01-25 12:18:37");
-    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
+    /* No second AddStringToObject: that is the assertion. */
 
-    expect_string(__wrap_cJSON_AddStringToObject, name, W_AGENTD_FIELD_LAST_ACK);
-    expect_string(__wrap_cJSON_AddStringToObject, string, "2021-01-25 13:00:00");
-    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MSG_COUNT);
+    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MESSAGES_COUNT);
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
     will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, true);
 
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MSG_SENT);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MSG_BUFF);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    will_return(__wrap_cJSON_AddBoolToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TASK_DISPATCHED);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TASK_DUPLICATE);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TASK_FAILED);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    will_return(__wrap_cJSON_PrintUnformatted, "unknown");
-
-    expect_function_call(__wrap_cJSON_Delete);
-
-    const char * retval = w_agentd_state_get();
-
-    assert_string_equal(retval,"unknown");
-
-}
-
-void test_w_agentd_state_get_buffer_disabled(void ** state)
-{
-    agent_state.status = GA_STATUS_ACTIVE;
-    agent_state.last_keepalive = 10;
-    agent_state.last_ack = 10;
-
-    will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
-    will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
-
-    expect_function_call(__wrap_pthread_mutex_lock);
-    will_return(__wrap_strftime,"2021-01-25 12:18:37");
-    will_return(__wrap_strftime, 20);
-
-    will_return(__wrap_strftime,"2021-01-25 13:00:00");
-    will_return(__wrap_strftime, 20);
-    expect_function_call(__wrap_pthread_mutex_unlock);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_JSON_ERROR);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
+    expect_counter(W_AGENTD_FIELD_TASK_DISPATCHED);
+    expect_counter(W_AGENTD_FIELD_TASK_DUPLICATE);
+    expect_counter(W_AGENTD_FIELD_TASK_FAILED);
 
     expect_function_call(__wrap_cJSON_AddItemToObject);
     will_return(__wrap_cJSON_AddItemToObject, true);
 
-    expect_string(__wrap_cJSON_AddStringToObject, name, W_AGENTD_FIELD_STATUS);
-    expect_string(__wrap_cJSON_AddStringToObject, string, "connected");
-    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
+    cJSON * retval = w_agentd_state_get();
 
-    expect_string(__wrap_cJSON_AddStringToObject, name, W_AGENTD_FIELD_KEEP_ALIVE);
-    expect_string(__wrap_cJSON_AddStringToObject, string, "2021-01-25 12:18:37");
-    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddStringToObject, name, W_AGENTD_FIELD_LAST_ACK);
-    expect_string(__wrap_cJSON_AddStringToObject, string, "2021-01-25 13:00:00");
-    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MSG_COUNT);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MSG_SENT);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MSG_BUFF);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    will_return(__wrap_cJSON_AddBoolToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TASK_DISPATCHED);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TASK_DUPLICATE);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TASK_FAILED);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    will_return(__wrap_cJSON_PrintUnformatted, "unknown");
-
-    expect_function_call(__wrap_cJSON_Delete);
-
-    const char * retval = w_agentd_state_get();
-
-    assert_string_equal(retval,"unknown");
-
+    assert_ptr_equal(retval, (cJSON *)1);
 }
 
-void test_w_agentd_state_get_buffer_empty(void ** state)
-{
-    agent_state.status = GA_STATUS_ACTIVE;
-    agent_state.last_keepalive = 10;
-    agent_state.last_ack = 10;
-
-    will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
-    will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
-
-    expect_function_call(__wrap_pthread_mutex_lock);
-    will_return(__wrap_strftime, "2021-01-25 12:18:37");
-    will_return(__wrap_strftime, 20);
-
-    will_return(__wrap_strftime, "2021-01-25 13:00:00");
-    will_return(__wrap_strftime, 20);
-    expect_function_call(__wrap_pthread_mutex_unlock);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_JSON_ERROR);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_function_call(__wrap_cJSON_AddItemToObject);
-    will_return(__wrap_cJSON_AddItemToObject, true);
-
-    expect_string(__wrap_cJSON_AddStringToObject, name, W_AGENTD_FIELD_STATUS);
-    expect_string(__wrap_cJSON_AddStringToObject, string, "connected");
-    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddStringToObject, name, W_AGENTD_FIELD_KEEP_ALIVE);
-    expect_string(__wrap_cJSON_AddStringToObject, string, "2021-01-25 12:18:37");
-    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddStringToObject, name, W_AGENTD_FIELD_LAST_ACK);
-    expect_string(__wrap_cJSON_AddStringToObject, string, "2021-01-25 13:00:00");
-    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MSG_COUNT);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MSG_SENT);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MSG_BUFF);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    will_return(__wrap_cJSON_AddBoolToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TASK_DISPATCHED);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TASK_DUPLICATE);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TASK_FAILED);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    will_return(__wrap_cJSON_PrintUnformatted, "unknown");
-
-    expect_function_call(__wrap_cJSON_Delete);
-
-    const char * retval = w_agentd_state_get();
-
-    assert_string_equal(retval,"unknown");
-
-}
-
-void test_w_agentd_state_get_pending(void ** state)
-{
-    agent_state.status = GA_STATUS_PENDING;
-    agent_state.last_keepalive = 10;
-    agent_state.last_ack = 10;
-
-    will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
-    will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
-
-    expect_function_call(__wrap_pthread_mutex_lock);
-    will_return(__wrap_strftime, "2021-01-25 12:18:37");
-    will_return(__wrap_strftime, 20);
-
-    will_return(__wrap_strftime, "2021-01-25 13:00:00");
-    will_return(__wrap_strftime, 20);
-    expect_function_call(__wrap_pthread_mutex_unlock);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_JSON_ERROR);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_function_call(__wrap_cJSON_AddItemToObject);
-    will_return(__wrap_cJSON_AddItemToObject, true);
-
-    expect_string(__wrap_cJSON_AddStringToObject, name, W_AGENTD_FIELD_STATUS);
-    expect_string(__wrap_cJSON_AddStringToObject, string, "pending");
-    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddStringToObject, name, W_AGENTD_FIELD_KEEP_ALIVE);
-    expect_string(__wrap_cJSON_AddStringToObject, string, "2021-01-25 12:18:37");
-    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddStringToObject, name, W_AGENTD_FIELD_LAST_ACK);
-    expect_string(__wrap_cJSON_AddStringToObject, string, "2021-01-25 13:00:00");
-    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MSG_COUNT);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MSG_SENT);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MSG_BUFF);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    will_return(__wrap_cJSON_AddBoolToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TASK_DISPATCHED);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TASK_DUPLICATE);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TASK_FAILED);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    will_return(__wrap_cJSON_PrintUnformatted, "unknown");
-
-    expect_function_call(__wrap_cJSON_Delete);
-
-    const char * retval = w_agentd_state_get();
-
-    assert_string_equal(retval,"unknown");
-
-}
-
-void test_w_agentd_state_get_conected(void ** state)
-{
-    agent_state.status = GA_STATUS_ACTIVE;
-    agent_state.last_keepalive = 10;
-    agent_state.last_ack = 10;
-
-    will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
-    will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
-
-    expect_function_call(__wrap_pthread_mutex_lock);
-    will_return(__wrap_strftime, "2021-01-25 12:18:37");
-    will_return(__wrap_strftime, 20);
-
-    will_return(__wrap_strftime, "2021-01-25 13:00:00");
-    will_return(__wrap_strftime, 20);
-    expect_function_call(__wrap_pthread_mutex_unlock);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_JSON_ERROR);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_function_call(__wrap_cJSON_AddItemToObject);
-    will_return(__wrap_cJSON_AddItemToObject, true);
-
-    expect_string(__wrap_cJSON_AddStringToObject, name, W_AGENTD_FIELD_STATUS);
-    expect_string(__wrap_cJSON_AddStringToObject, string, "connected");
-    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddStringToObject, name, W_AGENTD_FIELD_KEEP_ALIVE);
-    expect_string(__wrap_cJSON_AddStringToObject, string, "2021-01-25 12:18:37");
-    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddStringToObject, name, W_AGENTD_FIELD_LAST_ACK);
-    expect_string(__wrap_cJSON_AddStringToObject, string, "2021-01-25 13:00:00");
-    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MSG_COUNT);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MSG_SENT);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MSG_BUFF);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    will_return(__wrap_cJSON_AddBoolToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TASK_DISPATCHED);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TASK_DUPLICATE);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TASK_FAILED);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    will_return(__wrap_cJSON_PrintUnformatted, "unknown");
-
-    expect_function_call(__wrap_cJSON_Delete);
-
-    const char * retval = w_agentd_state_get();
-
-    assert_string_equal(retval,"unknown");
-
-}
-
-void test_w_agentd_state_get_disconected(void ** state)
-{
-    agent_state.status = GA_STATUS_NACTIVE;
-    agent_state.last_keepalive = 10;
-    agent_state.last_ack = 10;
-
-    will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
-    will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
-
-    expect_function_call(__wrap_pthread_mutex_lock);
-    will_return(__wrap_strftime, "2021-01-25 12:18:37");
-    will_return(__wrap_strftime, 20);
-
-    will_return(__wrap_strftime, "2021-01-25 13:00:00");
-    will_return(__wrap_strftime, 20);
-    expect_function_call(__wrap_pthread_mutex_unlock);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_JSON_ERROR);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_function_call(__wrap_cJSON_AddItemToObject);
-    will_return(__wrap_cJSON_AddItemToObject, true);
-
-    expect_string(__wrap_cJSON_AddStringToObject, name, W_AGENTD_FIELD_STATUS);
-    expect_string(__wrap_cJSON_AddStringToObject, string, "disconnected");
-    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddStringToObject, name, W_AGENTD_FIELD_KEEP_ALIVE);
-    expect_string(__wrap_cJSON_AddStringToObject, string, "2021-01-25 12:18:37");
-    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddStringToObject, name, W_AGENTD_FIELD_LAST_ACK);
-    expect_string(__wrap_cJSON_AddStringToObject, string, "2021-01-25 13:00:00");
-    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MSG_COUNT);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MSG_SENT);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MSG_BUFF);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    will_return(__wrap_cJSON_AddBoolToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TASK_DISPATCHED);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TASK_DUPLICATE);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TASK_FAILED);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    will_return(__wrap_cJSON_PrintUnformatted, "unknown");
-
-    expect_function_call(__wrap_cJSON_Delete);
-
-    const char * retval = w_agentd_state_get();
-
-    assert_string_equal(retval,"unknown");
-
-}
-
-void test_w_agentd_state_get_unknown(void ** state)
+void test_w_agentd_state_get_unknown_status(void ** state)
 {
     agent_state.status = 5;
-    agent_state.last_keepalive = 10;
-    agent_state.last_ack = 10;
+    agent_state.last_keepalive = 0;
 
     will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
     will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
-
-    expect_string(__wrap__merror, formatted_msg, "At get_str_status(): Unknown status (5)");
+    will_return(__wrap_cJSON_CreateObject, (cJSON *)1);
 
     expect_function_call(__wrap_pthread_mutex_lock);
-    will_return(__wrap_strftime, "2021-01-25 12:18:37");
-    will_return(__wrap_strftime, 20);
-
-    will_return(__wrap_strftime, "2021-01-25 13:00:00");
-    will_return(__wrap_strftime, 20);
+    expect_string(__wrap__merror, formatted_msg, "At get_str_status(): Unknown status (5)");
     expect_function_call(__wrap_pthread_mutex_unlock);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_JSON_ERROR);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_function_call(__wrap_cJSON_AddItemToObject);
-    will_return(__wrap_cJSON_AddItemToObject, true);
 
     expect_string(__wrap_cJSON_AddStringToObject, name, W_AGENTD_FIELD_STATUS);
     expect_string(__wrap_cJSON_AddStringToObject, string, "unknown");
     will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
 
-    expect_string(__wrap_cJSON_AddStringToObject, name, W_AGENTD_FIELD_KEEP_ALIVE);
-    expect_string(__wrap_cJSON_AddStringToObject, string, "2021-01-25 12:18:37");
-    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddStringToObject, name, W_AGENTD_FIELD_LAST_ACK);
-    expect_string(__wrap_cJSON_AddStringToObject, string, "2021-01-25 13:00:00");
-    will_return(__wrap_cJSON_AddStringToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MSG_COUNT);
+    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MESSAGES_COUNT);
     expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
     will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, true);
 
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MSG_SENT);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 1);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
+    expect_counter(W_AGENTD_FIELD_TASK_DISPATCHED);
+    expect_counter(W_AGENTD_FIELD_TASK_DUPLICATE);
+    expect_counter(W_AGENTD_FIELD_TASK_FAILED);
 
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_MSG_BUFF);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
+    expect_function_call(__wrap_cJSON_AddItemToObject);
+    will_return(__wrap_cJSON_AddItemToObject, true);
 
-    will_return(__wrap_cJSON_AddBoolToObject, (cJSON *)1);
+    cJSON * retval = w_agentd_state_get();
 
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TASK_DISPATCHED);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TASK_DUPLICATE);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    expect_string(__wrap_cJSON_AddNumberToObject, name, W_AGENTD_FIELD_TASK_FAILED);
-    expect_value(__wrap_cJSON_AddNumberToObject, number, 0);
-    will_return(__wrap_cJSON_AddNumberToObject, (cJSON *)1);
-
-    will_return(__wrap_cJSON_PrintUnformatted, "unknown");
-
-    expect_function_call(__wrap_cJSON_Delete);
-
-    const char * retval = w_agentd_state_get();
-
-    assert_string_equal(retval,"unknown");
-
+    assert_ptr_equal(retval, (cJSON *)1);
 }
 
 int main(void) {
@@ -799,14 +350,14 @@ int main(void) {
         cmocka_unit_test(test_w_agentd_state_update_msg_send),
 
         // Tests w_agentd_state_get
-        cmocka_unit_test(test_w_agentd_state_get_last_keepalive),
-        cmocka_unit_test(test_w_agentd_state_get_last_ack),
-        cmocka_unit_test(test_w_agentd_state_get_buffer_disabled),
-        cmocka_unit_test(test_w_agentd_state_get_buffer_empty),
-        cmocka_unit_test(test_w_agentd_state_get_pending),
-        cmocka_unit_test(test_w_agentd_state_get_conected),
-        cmocka_unit_test(test_w_agentd_state_get_disconected),
-        cmocka_unit_test(test_w_agentd_state_get_unknown),
+        cmocka_unit_test(test_w_agentd_state_get_groups_the_counters),
+        cmocka_unit_test(test_w_agentd_state_get_omits_an_unset_keepalive),
+        cmocka_unit_test(test_w_agentd_state_get_unknown_status),
+        
+        
+        
+        
+        
 
         // Tests w_agentd_state_update (task dispatch metrics) -- run
         // after the get_* tests above, which assert the fields start at 0.

--- a/src/unit_tests/shared/test_module_report.c
+++ b/src/unit_tests/shared/test_module_report.c
@@ -72,37 +72,41 @@ static void test_merge_consumes_the_section_even_without_a_body(void** state)
     module_report_merge(NULL, wrapped_section("syscheck", "frequency", "43200"));
 }
 
-/* --- module_report_add_config / _add_stats --- */
-static void test_add_config_names_the_module_and_nests_its_body(void** state)
+/* --- module_report_add --- */
+static void test_add_keys_the_body_by_module_name(void** state)
 {
     (void)state;
-    cJSON* report = cJSON_CreateArray();
+    cJSON* report = cJSON_CreateObject();
     cJSON* body = cJSON_CreateObject();
 
     cJSON_AddStringToObject(body, "disabled", "no");
-    module_report_add_config(report, "fim", body);
+    module_report_add(report, "fim", body);
 
-    assert_int_equal(cJSON_GetArraySize(report), 1);
-    cJSON* entry = cJSON_GetArrayItem(report, 0);
-    assert_string_equal(cJSON_GetObjectItem(entry, "module")->valuestring, "fim");
-    assert_string_equal(
-        cJSON_GetObjectItem(cJSON_GetObjectItem(entry, "config"), "disabled")->valuestring, "no");
+    /* Keyed by name, with the body directly under it: no {"module": ...}
+     * wrapper for the manager to walk. */
+    cJSON* stored = cJSON_GetObjectItem(report, "fim");
+    assert_non_null(stored);
+    assert_string_equal(cJSON_GetObjectItem(stored, "disabled")->valuestring, "no");
 
     cJSON_Delete(report);
 }
 
-static void test_add_stats_files_the_body_under_stats(void** state)
+static void test_add_keeps_each_module_separate(void** state)
 {
     (void)state;
-    cJSON* report = cJSON_CreateArray();
-    cJSON* body = cJSON_CreateObject();
+    cJSON* report = cJSON_CreateObject();
+    cJSON* fim = cJSON_CreateObject();
+    cJSON* lc = cJSON_CreateObject();
 
-    cJSON_AddNumberToObject(body, "events", 12);
-    module_report_add_stats(report, "logcollector", body);
+    cJSON_AddStringToObject(fim, "disabled", "no");
+    cJSON_AddNumberToObject(lc, "events", 12);
+    module_report_add(report, "fim", fim);
+    module_report_add(report, "logcollector", lc);
 
-    cJSON* entry = cJSON_GetArrayItem(report, 0);
-    assert_null(cJSON_GetObjectItem(entry, "config"));
-    assert_non_null(cJSON_GetObjectItem(entry, "stats"));
+    assert_non_null(cJSON_GetObjectItem(report, "fim"));
+    assert_non_null(cJSON_GetObjectItem(report, "logcollector"));
+    assert_int_equal(
+        cJSON_GetObjectItem(cJSON_GetObjectItem(report, "logcollector"), "events")->valueint, 12);
 
     cJSON_Delete(report);
 }
@@ -110,14 +114,15 @@ static void test_add_stats_files_the_body_under_stats(void** state)
 static void test_add_leaves_out_a_module_that_reported_nothing(void** state)
 {
     (void)state;
-    cJSON* report = cJSON_CreateArray();
+    cJSON* report = cJSON_CreateObject();
 
     /* An empty body and a missing one both mean "this module said nothing", so
      * neither may appear: absent and empty must stay distinguishable. */
-    module_report_add_config(report, "fim", cJSON_CreateObject());
-    module_report_add_config(report, "logcollector", NULL);
+    module_report_add(report, "fim", cJSON_CreateObject());
+    module_report_add(report, "logcollector", NULL);
 
-    assert_int_equal(cJSON_GetArraySize(report), 0);
+    assert_null(cJSON_GetObjectItem(report, "fim"));
+    assert_null(cJSON_GetObjectItem(report, "logcollector"));
 
     cJSON_Delete(report);
 }
@@ -126,17 +131,17 @@ static void test_add_leaves_out_a_module_that_reported_nothing(void** state)
 static void test_reply_prefixes_the_serialized_report_with_ok(void** state)
 {
     (void)state;
-    cJSON* report = cJSON_CreateArray();
+    cJSON* report = cJSON_CreateObject();
     cJSON* body = cJSON_CreateObject();
     char* output = NULL;
 
     cJSON_AddStringToObject(body, "disabled", "no");
-    module_report_add_config(report, "fim", body);
+    module_report_add(report, "fim", body);
 
     size_t length = module_report_reply(report, &output);
 
     assert_non_null(output);
-    assert_string_equal(output, "ok [{\"module\":\"fim\",\"config\":{\"disabled\":\"no\"}}]");
+    assert_string_equal(output, "ok {\"fim\":{\"disabled\":\"no\"}}");
     assert_int_equal((int)length, (int)strlen(output));
 
     free(output);
@@ -147,11 +152,11 @@ static void test_reply_still_answers_when_no_module_reported(void** state)
     (void)state;
     char* output = NULL;
 
-    /* An empty array is a valid answer: the daemon is up and hosts nothing
+    /* An empty object is a valid answer: the daemon is up and hosts nothing
      * worth reporting. The caller must not read that as a failure. */
-    size_t length = module_report_reply(cJSON_CreateArray(), &output);
+    size_t length = module_report_reply(cJSON_CreateObject(), &output);
 
-    assert_string_equal(output, "ok []");
+    assert_string_equal(output, "ok {}");
     assert_int_equal((int)length, (int)strlen(output));
 
     free(output);
@@ -163,8 +168,8 @@ int main(void)
         cmocka_unit_test(test_merge_moves_every_section_under_one_body),
         cmocka_unit_test(test_merge_ignores_a_getter_that_returned_nothing),
         cmocka_unit_test(test_merge_consumes_the_section_even_without_a_body),
-        cmocka_unit_test(test_add_config_names_the_module_and_nests_its_body),
-        cmocka_unit_test(test_add_stats_files_the_body_under_stats),
+        cmocka_unit_test(test_add_keys_the_body_by_module_name),
+        cmocka_unit_test(test_add_keeps_each_module_separate),
         cmocka_unit_test(test_add_leaves_out_a_module_that_reported_nothing),
         cmocka_unit_test(test_reply_prefixes_the_serialized_report_with_ok),
         cmocka_unit_test(test_reply_still_answers_when_no_module_reported),

--- a/src/unit_tests/syscheckd/test_syscom.c
+++ b/src/unit_tests/syscheckd/test_syscom.c
@@ -355,7 +355,7 @@ void test_syscom_dispatch_getallconfig(void **state)
 
     /* Every getter empty still has to be a report, not a rejection: the caller
      * tells "this daemon reported nothing" from "this daemon is unreachable". */
-    assert_string_equal(output, "ok []");
+    assert_string_equal(output, "ok {}");
     assert_int_equal(ret, strlen(output));
 }
 

--- a/src/unit_tests/wazuh_modules/wmodules/test_wmcom.c
+++ b/src/unit_tests/wazuh_modules/wmodules/test_wmcom.c
@@ -66,7 +66,7 @@ static cJSON* entry_named(cJSON* report, const char* name)
     cJSON* entry = NULL;
 
     cJSON_ArrayForEach(entry, report) {
-        if (strcmp(cJSON_GetObjectItem(entry, "module")->valuestring, name) == 0) {
+        if (entry->string && strcmp(entry->string, name) == 0) {
             return entry;
         }
     }
@@ -95,11 +95,11 @@ static void test_getallconfig_gives_each_wodle_its_own_entry(void** state)
 
     /* One daemon, but the modules it hosts stay individually addressable
      * instead of being buried in a single "wmodules" blob. */
-    assert_int_equal(cJSON_GetArraySize(report), 2);
+    assert_int_equal(cJSON_GetArraySize(report), 2); /* object members */
     assert_non_null(entry_named(report, "syscollector"));
     assert_non_null(entry_named(report, "sca"));
     assert_string_equal(
-        cJSON_GetObjectItem(cJSON_GetObjectItem(entry_named(report, "sca"), "config"),
+        cJSON_GetObjectItem(entry_named(report, "sca"),
                             "disabled")->valuestring,
         "no");
 
@@ -123,7 +123,7 @@ static void test_getallconfig_reports_internal_options_separately(void** state)
     cJSON* report = cJSON_Parse(output + 3);
 
     /* Internal options belong to modulesd itself, not to any one wodle. */
-    assert_int_equal(cJSON_GetArraySize(report), 2);
+    assert_int_equal(cJSON_GetArraySize(report), 2); /* object members */
     assert_non_null(entry_named(report, "wmodules"));
 
     cJSON_Delete(report);
@@ -140,7 +140,7 @@ static void test_getallconfig_answers_even_with_no_wodles_loaded(void** state)
      * answer, so the caller can tell it apart from an unreachable socket. */
     size_t len = wmcom_dispatch(command, strlen(command), &output);
 
-    assert_string_equal(output, "ok []");
+    assert_string_equal(output, "ok {}");
     assert_int_equal((int)len, (int)strlen(output));
 
     free(output);

--- a/src/wazuh_modules/src/wmcom.c
+++ b/src/wazuh_modules/src/wmcom.c
@@ -72,7 +72,7 @@ static void wmcom_report_wodles(cJSON * report, const cJSON * modules) {
 
     cJSON_ArrayForEach(wodle, wodles) {
         if (wodle->child) {
-            module_report_add_config(report, wodle->child->string,
+            module_report_add(report, wodle->child->string,
                                      cJSON_Duplicate(wodle->child, true));
         }
     }
@@ -80,7 +80,7 @@ static void wmcom_report_wodles(cJSON * report, const cJSON * modules) {
 
 size_t wmcom_getallconfig(char ** output) {
 
-    cJSON *report = cJSON_CreateArray();
+    cJSON *report = cJSON_CreateObject();
     cJSON *modules = getModulesConfig();
     cJSON *internal = cJSON_CreateObject();
 
@@ -88,7 +88,7 @@ size_t wmcom_getallconfig(char ** output) {
     cJSON_Delete(modules);
 
     module_report_merge(internal, getModulesInternalOptions());
-    module_report_add_config(report, WMCOM_MODULE_NAME, internal);
+    module_report_add(report, WMCOM_MODULE_NAME, internal);
     return module_report_reply(report, output);
 }
 


### PR DESCRIPTION
## Description

Aligns the field names the agent reports with the ones the manager indexes, on both periodic pushes.
The manager stores each document as it arrives and transforms nothing, so these names are a contract
rather than a local choice.

- **`/stats`** — the document shape, the field names and the timestamp format, per #38136.
- **`/config`** — the agentd section is reported as `agent`, the block's 5.0 name.

Stacked on #38190. Review that one first; the diff here is the last two commits.

Related: #38023, #38024, #38136, #37843, #38172.

The index templates these names have to match are tracked on the indexer side and are **both still
open**, so they need checking before this is relied on:

- [wazuh-indexer-plugins#1419](https://github.com/wazuh/wazuh-indexer-plugins/issues/1419) — agent's
  config index. Already maps `wazuh.agent.configuration.content.agent.agent`, which is what this PR
  emits.
- [wazuh-indexer-plugins#1425](https://github.com/wazuh/wazuh-indexer-plugins/issues/1425) — agent's
  stats index.

## Proposed Changes

### `/stats`

What the agent puts on the wire, captured from a live agent against the demo mock:

```json
{
  "agent_id": "001",
  "cluster": { "name": "demo", "node": "node01" },
  "modules": {
    "agent": {
      "status": "connected",
      "last_keepalive": "2026-08-05T12:50:34Z",
      "messages": { "count": 1 },
      "tasks": {
        "dispatched":          { "total": 0 },
        "discarded_duplicate": { "total": 0 },
        "failed":              { "total": 4 }
      }
    }
  }
}
```

`logcollector` is absent from that capture only because its `state_interval` (60 s) had not elapsed
in a 25 s run; its body is unchanged apart from the timestamp format.

| Change | How |
|---|---|
| `modules` is an object keyed by module name | `module_report_add()` stores the body under the module name. The `_add_config`/`_add_stats` variants collapse into one, since without the envelope they do the same thing. All five dispatchers and the agentd aggregator merge objects. |
| No `error`/`data` envelope | `w_agentd_state_get()` returns `cJSON *`; the new `agcom_getstate()` adds the envelope at the socket call site, where `getstate`'s own protocol needs it. |
| ISO 8601 UTC timestamps | `state.h` and `logcollector/src/state.c`, both moved from `localtime_r` to `gmtime_r`. This makes the manager's `normalize_agent_timestamps()` the no-op it expects for a 5.x agent. |
| Counters expanded and nested | `messages.count`; `tasks.{dispatched,discarded_duplicate,failed}.total`. |
| `last_keepalive` carries a value | `UPDATE_KEEPALIVE` is taken in `bridge_on_manager_config_hash()`, i.e. on an accepted Notify rather than at send time, so the value proves a completed round trip instead of advancing with the network down. |
| `last_ack`, `msg_sent`, `msg_buffer`, `buffer_enabled` dropped | Omitted from the report. The flat names stay on the `.state` text file, which still has producers for them. |

Three design calls worth naming:

- **`last_keepalive` is omitted, not emptied.** An empty string would reject the document, and the
  first push happens before any Notify has landed. Same reasoning applies to any future field with no
  value yet.
- **The format change is global for the JSON**, not report-path only: `getstate` and `/stats` return
  the same body and differ only by the envelope. The `.state` text file keeps local time, being
  operator-facing. Keeping the envelope at the `getstate` call site is load-bearing rather than
  cosmetic: `framework/wazuh/core/stats.py:176,180` reads `socket_response['error']` and
  `['data']`, so dropping it globally would have broken the Server API outright.
- **`gmtime_r` does not exist on the mingw C runtime** and there is no global shim — callers define
  their own (`syscheckd/src/file/events.c:13`). Both files here carry it, otherwise the winagent
  build breaks. Logcollector was also formatting with `localtime_r` while emitting a `Z` suffix,
  asserting UTC over a local-time value.

### `/config`

`<client>` is renamed to `<agent>` in 5.0 (#38172), and the `wazuh-agent-config` template maps the
agentd section under `content.agent.agent` — module name, then section name, the same nesting as
`content.fim.syscheck`. A document still keyed `client` lands outside that mapping.

#38172 renames the XML side (the parser, and `Read_Client_SSL` to `Read_Agent_SSL`) but not
`client-agent/src/config.c`, which is what emits the JSON key. Without this the agent would parse
`<agent>` and still report `client`.

So `getClientConfig()` becomes `getAgentConfig()` and emits `"agent"` — the function is renamed with
the key rather than left describing something it no longer produces. `getconfig` still answers to
`client` as well as `agent`, because the Server API validates that path parameter against an enum in
`api/api/spec/spec.yaml` that only lists `client`; dropping it would break
`GET /agents/{id}/config/agent/client`, which is the only spelling the API can send.

## Artifacts Affected

`libwazuhshared` (`module_report`), `wazuh-agentd`, `wazuh-logcollector`, `wazuh-syscheckd`,
`wazuh-modulesd`, `wazuh-execd` — the five dispatchers that build a report. No interface change
outside `module_report.h` and `state.h`.

Downstream: `/stats` documents land in `wazuh-agent-stats` and `/config` documents in
`wazuh-agent-config`, both keyed by the names above.

## Tests Introduced

Legacy suite **106/106**. `test_module_report`, `test_agcom`, `test_agent_report`, `test_wmcom`,
`test_syscom` and `test_agentd_state` reworked for the object shape. The eight `w_agentd_state_get`
cases collapse to three — most exercised fields that no longer exist; the survivors cover the grouped
counters, the omitted-keepalive path and an unknown status. `test_agent_report`'s "not a report"
negative case feeds an array, which is what is invalid under the new contract.

No Server API coordination is needed any more. `GET /agents/{agent_id}/stats/{component}` read the
live agent over a socket rather than the index, so this rename used to surface on that endpoint
directly — but #38024 removed the endpoint, and with it the tavern case that asserted the old flat
names. Statistics are read from the `wazuh-agent-stats` index now.

## Review Checklist

- [x] Relevant evidence provided
- [x] Configuration changes documented (none)
- [x] Meets requirements and/or definition of done
- [ ] Confirm the templates in wazuh-indexer-plugins#1419. The
      config mapping is `dynamic: false`, so a document keyed the old way is stored but never
      indexed — it fails quietly rather than loudly.



