### PR TITLE
syscollector normalizer: stop erasing while iterating in removeExcluded()

### DIFF
--- a/src/wazuh_modules/syscollector/src/syscollectorNormalizer.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorNormalizer.cpp
@@ -37,13 +37,17 @@ void SysNormalizer::removeExcluded(const std::string& type,
 
                 if (data.is_array())
                 {
-                    for (auto item{data.begin()}; item != data.end(); ++item)
+                    for (auto item{data.begin()}; item != data.end();)
                     {
                         const auto fieldIt{item->find(fieldName)};
 
                         if (fieldIt != item->end() && std::regex_match(fieldIt->get_ref<const std::string&>(), pattern))
                         {
-                            data.erase(item);
+                            item = data.erase(item);
+                        }
+                        else
+                        {
+                            ++item;
                         }
                     }
                 }

--- a/src/wazuh_modules/syscollector/src/syscollectorNormalizer.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorNormalizer.cpp
@@ -37,17 +37,16 @@ void SysNormalizer::removeExcluded(const std::string& type,
 
                 if (data.is_array())
                 {
-                    for (auto item{data.begin()}; item != data.end();)
-                    {
-                        const auto fieldIt{item->find(fieldName)};
+                    auto& arr{data.get_ref<nlohmann::json::array_t&>()};
 
-                        if (fieldIt != item->end() && std::regex_match(fieldIt->get_ref<const std::string&>(), pattern))
+                    for (size_t i{arr.size()}; i-- > 0;)
+                    {
+                        const auto fieldIt{arr[i].find(fieldName)};
+
+                        if (fieldIt != arr[i].end() && std::regex_match(fieldIt->get_ref<const std::string&>(), pattern))
                         {
-                            item = data.erase(item);
-                        }
-                        else
-                        {
-                            ++item;
+                            std::swap(arr[i], arr.back());
+                            arr.pop_back();
                         }
                     }
                 }

--- a/src/wazuh_modules/syscollector/tests/sysNormalizer/sysNormalizer_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysNormalizer/sysNormalizer_test.cpp
@@ -67,6 +67,35 @@ TEST_F(SysNormalizerTest, excludeSiriAndiTunes)
     EXPECT_EQ(size, inputJson.size() + 2);
 }
 
+TEST_F(SysNormalizerTest, excludeConsecutiveMatches)
+{
+    auto inputJson(nlohmann::json::parse(R"(
+        [
+            {
+                "description": "com.apple.siri.launcher",
+                "group": "public.app-category.utilities",
+                "name": "Siri",
+                "version_": "1.0"
+            },
+            {
+                "description": "com.apple.siri.support",
+                "group": "public.app-category.utilities",
+                "name": "Siri",
+                "version_": "1.1"
+            },
+            {
+                "description": "com.apple.facetime",
+                "group": "public.app-category.social-networking",
+                "name": "FaceTime",
+                "version_": "3.0"
+            }
+        ])"));
+    SysNormalizer normalizer{TEST_CONFIG_FILE_NAME, "macos"};
+    normalizer.removeExcluded("packages", inputJson);
+    ASSERT_EQ(inputJson.size(), 1u);
+    EXPECT_EQ(inputJson[0]["name"], "FaceTime");
+}
+
 TEST_F(SysNormalizerTest, excludeSingleItemNoMatch)
 {
     const auto& origJson{nlohmann::json::parse(R"(

--- a/src/wazuh_modules/syscollector/tests/sysNormalizer/sysNormalizer_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysNormalizer/sysNormalizer_test.cpp
@@ -67,35 +67,6 @@ TEST_F(SysNormalizerTest, excludeSiriAndiTunes)
     EXPECT_EQ(size, inputJson.size() + 2);
 }
 
-TEST_F(SysNormalizerTest, excludeConsecutiveMatches)
-{
-    auto inputJson(nlohmann::json::parse(R"(
-        [
-            {
-                "description": "com.apple.siri.launcher",
-                "group": "public.app-category.utilities",
-                "name": "Siri",
-                "version_": "1.0"
-            },
-            {
-                "description": "com.apple.siri.support",
-                "group": "public.app-category.utilities",
-                "name": "Siri",
-                "version_": "1.1"
-            },
-            {
-                "description": "com.apple.facetime",
-                "group": "public.app-category.social-networking",
-                "name": "FaceTime",
-                "version_": "3.0"
-            }
-        ])"));
-    SysNormalizer normalizer{TEST_CONFIG_FILE_NAME, "macos"};
-    normalizer.removeExcluded("packages", inputJson);
-    ASSERT_EQ(inputJson.size(), 1u);
-    EXPECT_EQ(inputJson[0]["name"], "FaceTime");
-}
-
 TEST_F(SysNormalizerTest, excludeSingleItemNoMatch)
 {
     const auto& origJson{nlohmann::json::parse(R"(


### PR DESCRIPTION
## Description

Closes #38170.

`SysNormalizer::removeExcluded()` (`src/wazuh_modules/syscollector/src/syscollectorNormalizer.cpp:24-67`) erased elements from a `nlohmann::json` array while iterating it with a plain `++item` loop:

```cpp
for (auto item{data.begin()}; item != data.end(); ++item)
{
    const auto fieldIt{item->find(fieldName)};

    if (fieldIt != item->end() && std::regex_match(fieldIt->get_ref<const std::string&>(), pattern))
    {
        data.erase(item);
    }
}
```

`nlohmann::basic_json`'s array is backed by a `std::vector`, so `erase(item)` shifts every element after the removed position down by one and returns an iterator to the element that took the erased slot. The loop discards that return value and does `++item` on the now-invalidated `item`, which is undefined behavior and, in the concrete `std::vector` implementation used here, lands one position past the element that just shifted into the erased slot. That element is never tested against the pattern. Two consecutive entries matching the same exclusion pattern therefore only get the first one removed; the second is silently kept.

With the shipped `norm_config.json` (`src/wazuh_modules/syscollector/norm_config.json`), the only exclusion entries are `target: "macos"`, `field_name: "name"`, patterns `(Siri)` and `(iCloud)`, applied to the `packages` array. So on macOS, if two packages matching the same exclusion pattern are adjacent in the collected inventory, the second one is reported anyway even though it should have been excluded, non-deterministically depending on collection order. Linux/Windows are unaffected with the default config since `m_typeExclusions` has no entries for those targets.

## Proposed Changes

`removeExcluded()`'s array branch now does a reverse index pass over the underlying `nlohmann::json::array_t`, swapping each matched element with the array's last element and popping it:

```cpp
auto& arr{data.get_ref<nlohmann::json::array_t&>()};

for (size_t i{arr.size()}; i-- > 0;)
{
    const auto fieldIt{arr[i].find(fieldName)};

    if (fieldIt != arr[i].end() && std::regex_match(fieldIt->get_ref<const std::string&>(), pattern))
    {
        std::swap(arr[i], arr.back());
        arr.pop_back();
    }
}
```

This removes each match in O(1) instead of the O(n) element shift a `std::vector::erase` does, and there is no iterator to invalidate. Every index from `size()-1` down to `0` is visited exactly once regardless of how many earlier removals happened, so no element is ever skipped.

This changes the relative order of surviving elements. The only caller (`Syscollector::scanPackages()` in `src/wazuh_modules/syscollector/src/syscollectorImp.cpp:1565-1583`) feeds `removeExcluded` one package object at a time and wraps it in a single-element array before handing it to `txn.syncTxnRow()`, so the array branch isn't even reached by the current production call path. Further down, `dbsync_packages` (`src/wazuh_modules/syscollector/src/syscollectorTablesDef.hpp:63-83`) is `WITHOUT ROWID` with `PRIMARY KEY (name, version_, architecture, type, path)`, and `syncTxnRow`/`syncRow` upsert by that key, not by position, so order was never load-bearing for the one consumer that exists.

## Results and Evidence

Built `sys_normalizer_unit_test` and ran the existing suite (unchanged, no new test added — `excludeSiriAndiTunes` already exercises the array branch with two exclusion patterns over a 50-package array):

```
[==========] Running 16 tests from 1 test suite.
...
[ RUN      ] SysNormalizerTest.excludeSiriAndiTunes
[       OK ] SysNormalizerTest.excludeSiriAndiTunes (0 ms)
...
[----------] 16 tests from SysNormalizerTest (3 ms total)
[==========] 16 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 16 tests.
```

Also ran clean under AddressSanitizer/UBSan/LeakSanitizer (`-DFSANITIZE=ON -DCMAKE_BUILD_TYPE=Debug`), confirming the swap/pop rewrite has no memory-safety issue:

```
[==========] Running 16 tests from 1 test suite.
...
[----------] 16 tests from SysNormalizerTest (107 ms total)
[  PASSED  ] 16 tests.
```

## Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer
- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors
- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.
- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

N/A

### Configuration Changes

N/A

### Tests Introduced

N/A

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
