### PR TITLE
Enforce token revocation for run_as (authorization-context) API sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Fixed the API login attempt limit not being applied consistently under concurrent requests. ([#38135](https://github.com/wazuh/wazuh/pull/38135))
 - Fixed a heap buffer write in `wazuh-analysisd` when generating FIM alerts by resizing `full_log` before writing. ([#38145](https://github.com/wazuh/wazuh/pull/38145))
 - Fixed password validation not being enforced for empty passwords in the `update_user` API endpoint. ([#38180](https://github.com/wazuh/wazuh/pull/38180))
+- Fixed API tokens for `run_as` users not being invalidated on logout or role revocation. ([#38193](https://github.com/wazuh/wazuh/pull/38193))
 
 ### Agent
 

--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -258,7 +258,13 @@ def check_token(username: str, roles: tuple, token_nbf_time: int, run_as: bool) 
             if not am.user_allow_run_as(user['username']) and set(user_roles) != set(roles):
                 return {'valid': False}
             with TokenManager() as tm:
-                for role in user_roles:
+                # Always validate the user and run_as blacklists, even when the token carries no roles.
+                if not tm.is_token_valid(user_id=user_id, token_nbf_time=int(token_nbf_time), run_as=run_as):
+                    return {'valid': False}
+                # Validate every role carried by the token, not only the statically-linked ones.
+                # run_as users have their roles assigned dynamically, so those roles travel in the
+                # token (roles) instead of being returned by get_all_roles_from_user (user_roles).
+                for role in set(user_roles) | set(roles):
                     if not tm.is_token_valid(role_id=role, user_id=user_id, token_nbf_time=int(token_nbf_time),
                                              run_as=run_as):
                         return {'valid': False}

--- a/api/api/test/test_authentication.py
+++ b/api/api/test/test_authentication.py
@@ -204,6 +204,83 @@ def test_check_token(mock_tokenmanager):
     assert result == {'valid': ANY, 'policies': ANY}
 
 
+def _orm_manager_mock(instance):
+    """Return a MagicMock whose context-manager protocol yields `instance`."""
+    manager = MagicMock()
+    manager.return_value.__enter__.return_value = instance
+    return manager
+
+
+@patch('api.authentication.optimize_resources', return_value={})
+def test_check_token_runas_revoked_at_user_level(mock_optimize):
+    """A run_as user with no statically-linked roles must be validated against the token blacklist.
+
+    This covers logout and user-level revocation, whose blacklist entry is keyed on the user and
+    was never consulted when the per-role loop iterated over an empty user_roles list.
+    """
+    am = MagicMock()
+    am.get_user.return_value = {'id': 101, 'username': 'rauser'}
+    am.user_allow_run_as.return_value = True
+    urm = MagicMock()
+    urm.get_all_roles_from_user.return_value = []
+    tm = MagicMock()
+    tm.is_token_valid.return_value = False
+
+    with patch('api.authentication.AuthenticationManager', _orm_manager_mock(am)), \
+            patch('api.authentication.UserRolesManager', _orm_manager_mock(urm)), \
+            patch('api.authentication.TokenManager', _orm_manager_mock(tm)):
+        result = authentication.check_token(username='rauser', roles=tuple([1]), token_nbf_time=100,
+                                            run_as=True, origin_node_type='master')
+
+    assert result == {'valid': False}
+    tm.is_token_valid.assert_any_call(user_id=101, token_nbf_time=100, run_as=True)
+
+
+@patch('api.authentication.optimize_resources', return_value={})
+def test_check_token_runas_revoked_dynamic_role(mock_optimize):
+    """Revoking a dynamically-granted role must invalidate a run_as token carrying it.
+
+    The role travels in the token (roles) and is absent from user_roles, so the validity check
+    must be driven by the token's roles, not only the statically-linked ones.
+    """
+    am = MagicMock()
+    am.get_user.return_value = {'id': 101, 'username': 'rauser'}
+    am.user_allow_run_as.return_value = True
+    urm = MagicMock()
+    urm.get_all_roles_from_user.return_value = []
+    tm = MagicMock()
+    tm.is_token_valid.side_effect = lambda **kwargs: kwargs.get('role_id') != 1
+
+    with patch('api.authentication.AuthenticationManager', _orm_manager_mock(am)), \
+            patch('api.authentication.UserRolesManager', _orm_manager_mock(urm)), \
+            patch('api.authentication.TokenManager', _orm_manager_mock(tm)):
+        result = authentication.check_token(username='rauser', roles=tuple([1]), token_nbf_time=200,
+                                            run_as=True, origin_node_type='master')
+
+    assert result == {'valid': False}
+    tm.is_token_valid.assert_any_call(role_id=1, user_id=101, token_nbf_time=200, run_as=True)
+
+
+@patch('api.authentication.optimize_resources', return_value={'policy': 'test'})
+def test_check_token_runas_valid(mock_optimize):
+    """A run_as user with a non-revoked token remains valid."""
+    am = MagicMock()
+    am.get_user.return_value = {'id': 101, 'username': 'rauser'}
+    am.user_allow_run_as.return_value = True
+    urm = MagicMock()
+    urm.get_all_roles_from_user.return_value = []
+    tm = MagicMock()
+    tm.is_token_valid.return_value = True
+
+    with patch('api.authentication.AuthenticationManager', _orm_manager_mock(am)), \
+            patch('api.authentication.UserRolesManager', _orm_manager_mock(urm)), \
+            patch('api.authentication.TokenManager', _orm_manager_mock(tm)):
+        result = authentication.check_token(username='rauser', roles=tuple([1]), token_nbf_time=300,
+                                            run_as=True, origin_node_type='master')
+
+    assert result == {'valid': True, 'policies': {'policy': 'test'}}
+
+
 @pytest.mark.asyncio
 @patch('api.authentication.jwt.decode')
 @patch('api.authentication.generate_keypair', return_value=('-----BEGIN PRIVATE KEY-----',


### PR DESCRIPTION
## Description
For an authorization-context / `run_as` API user with no statically-linked roles (the standard SSO shape), `check_token` never consulted the token blacklist, so revoking the user's dynamically-granted role or logging them out left their already-issued token fully valid. The fix validates the user and `run_as` blacklists unconditionally and checks every role carried by the token, so revocation and logout now take effect immediately for these sessions.

## Proposed Changes
- `api/api/authentication.py`: in `check_token`, consult the token blacklist for the user and `run_as` unconditionally (independently of the per-role loop), and drive the per-role validity check from the roles carried by the token (`roles`) unioned with the statically-linked roles (`user_roles`), instead of iterating only over `user_roles`.
- `api/api/test/test_authentication.py`: add regression tests covering user-level revocation/logout and dynamic-role revocation for `run_as` users, plus the valid-token path.

### Results and Evidence
Manual test against a running single-node manager (Wazuh 4.14.8, API on port 55000), reproducing the reported scenario with a built-in control. Two users are compared:

- `rauser` — `run_as` user, `allow_run_as: true`, `roles: []` (no static roles), matched by an auth-context rule (`MATCH department=SecOpsAdmins`) linked to role `1` (administrator).
- `ctluser` — ordinary control user, statically linked to role `1`.

Each user logs in (both tokens carry `rbac_roles: [1]`), logs itself out with `DELETE /security/user/authenticate`, and then retries its own token against `GET /security/users`. Both logout calls return `{"message": "User <name> was successfully logged out", "error": 0}`. Only the `check_token` body changes between the two runs; the API is restarted in between.

Before the change:

```
token valid before logout   rauser -> HTTP 200    ctluser -> HTTP 200
same token after logout      rauser -> HTTP 200    ctluser -> HTTP 401
                                    ^ still valid          ^ invalidated
```

After the change (same manager, same scenario):

```
token valid before logout   rauser -> HTTP 200    ctluser -> HTTP 200
same token after logout      rauser -> HTTP 401    ctluser -> HTTP 401
                                    ^ invalidated          ^ unchanged
```

The control user (`ctluser`) is invalidated by the same logout call in both runs, which narrows the behavior to the zero-static-role `run_as` path; the change aligns it with ordinary users without altering their behavior.

### Artifacts Affected
Wazuh manager API (bundled `framework`/`api` Python code). No C/C++ binary or package rebuild is required by this change.

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
- `test_check_token_runas_revoked_at_user_level` — `api/api/test/test_authentication.py`
- `test_check_token_runas_revoked_dynamic_role` — `api/api/test/test_authentication.py`
- `test_check_token_runas_valid` — `api/api/test/test_authentication.py`

## Credits
Reported by @TarPeg007.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
