### PR TITLE
HTTPS:  Bug fixes found while manually QA-ing

### DIFF
--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -11,9 +11,9 @@
       <port>1517</port>
     </server>
 
-    <!-- HTTPS transport TLS settings; verification_mode: full|certificate|none (default: full) -->
-    <!-- TEMPORARY: shipped as 'none' to unblock the test suite (no CA available there);
-         revert to 'full' + a real <certificate_authorities> path before release. -->
+    <!-- HTTPS transport TLS settings; verification_mode: full|certificate|none (default: none).
+         Set to 'full' or 'certificate' and provide certificate_authorities to verify the
+         manager's certificate. -->
     <ssl>
       <certificate_authorities>PATH</certificate_authorities>
       <verification_mode>none</verification_mode>

--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -12,9 +12,11 @@
     </server>
 
     <!-- HTTPS transport TLS settings; verification_mode: full|certificate|none (default: full) -->
+    <!-- TEMPORARY: shipped as 'none' to unblock the test suite (no CA available there);
+         revert to 'full' + a real <certificate_authorities> path before release. -->
     <ssl>
       <certificate_authorities>PATH</certificate_authorities>
-      <verification_mode>full</verification_mode>
+      <verification_mode>none</verification_mode>
     </ssl>
 
     <config-profile>debian, debian8</config-profile>

--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -8,14 +8,14 @@
   <client>
     <server>
       <address>IP</address>
+      <port>1517</port>
     </server>
 
-    <!-- HTTPS transport TLS settings; verification_mode: full|certificate|none (default: full)
+    <!-- HTTPS transport TLS settings; verification_mode: full|certificate|none (default: full) -->
     <ssl>
-      <certificate_authorities>path</certificate_authorities>
+      <certificate_authorities>PATH</certificate_authorities>
       <verification_mode>full</verification_mode>
     </ssl>
-    -->
 
     <config-profile>debian, debian8</config-profile>
   </client>

--- a/src/client-agent/https_client/include/https_client.h
+++ b/src/client-agent/https_client/include/https_client.h
@@ -246,6 +246,13 @@ typedef struct hc_callbacks_t
     /// agent's startup hash gate) can reconcile it even when nothing needs
     /// downloading. Empty when the manager reported none.
     void (*on_manager_config_hash)(const char* config_hash, void* user_data);
+    /// The agent's current group set as the manager reported it on the last
+    /// accepted Notify (comma-joined, manager's own order) -- fired only when it
+    /// differs from what was last reported (Startup included), so a consumer
+    /// doesn't republish identity data on every Notify for nothing. Empty is a
+    /// valid, meaningful value (no groups), not a placeholder for "default": do
+    /// not substitute a fallback here the way /download's group selector does.
+    void (*on_agent_groups)(const char* groups_csv, void* user_data);
     /// The HTTP outcome for a /stateful session. Unlike every other outcome in this
     /// header, `result` here is the RAW HTTP status code the manager answered with
     /// (200, 400, 403, 409, 413, 500, 503...), not an hc_result_t - the /stateful

--- a/src/client-agent/https_client/src/callbackDispatcher.cpp
+++ b/src/client-agent/https_client/src/callbackDispatcher.cpp
@@ -193,6 +193,19 @@ void CallbackDispatcher::onManagerConfigHash(const std::string& configHash)
     });
 }
 
+void CallbackDispatcher::onAgentGroups(const std::string& groupsCsv)
+{
+    if (m_callbacks.on_agent_groups == nullptr)
+    {
+        return;
+    }
+
+    enqueue([this, groupsCsv]
+    {
+        m_callbacks.on_agent_groups(groupsCsv.c_str(), m_callbacks.user_data);
+    });
+}
+
 void CallbackDispatcher::onSyncResponse(const std::string& sessionId, int result,
                                         const std::string& body)
 {

--- a/src/client-agent/https_client/src/callbackDispatcher.hpp
+++ b/src/client-agent/https_client/src/callbackDispatcher.hpp
@@ -54,6 +54,7 @@ class CallbackDispatcher final : public ICallbackSink
         void onTaskFailed(const std::string& taskId, const std::string& taskType,
                           const std::string& reason) override;
         void onManagerConfigHash(const std::string& configHash) override;
+        void onAgentGroups(const std::string& groupsCsv) override;
         void onSyncResponse(const std::string& sessionId, int result, const std::string& body) override;
         void onStateChange(hc_conn_state_t state) override;
         void onBufferLevel(hc_buffer_level_t level) override;

--- a/src/client-agent/https_client/src/callbackSink.hpp
+++ b/src/client-agent/https_client/src/callbackSink.hpp
@@ -50,6 +50,9 @@ class ICallbackSink
         virtual void onTaskFailed(const std::string& taskId, const std::string& taskType,
                                   const std::string& reason) = 0;
         virtual void onManagerConfigHash(const std::string& configHash) = 0;
+        /// The agent's current group set (comma-joined, manager's own order, empty
+        /// meaning none), fired only when it changed since the last report.
+        virtual void onAgentGroups(const std::string& groupsCsv) = 0;
         virtual void onSyncResponse(const std::string& sessionId, int result, const std::string& body) = 0;
         virtual void onStateChange(hc_conn_state_t state) = 0;
         virtual void onBufferLevel(hc_buffer_level_t level) = 0;

--- a/src/client-agent/https_client/src/configFetcher.cpp
+++ b/src/client-agent/https_client/src/configFetcher.cpp
@@ -79,9 +79,14 @@ std::shared_ptr<SpoolFile> ConfigFetcher::fetch(const std::string& expectedHash,
 
     if (result.outcome != OutcomeClass::Ok)
     {
-        LOGFN_WARN(m_logFn, "Config download for group '%s' failed (outcome %d); "
-                   "the next notify re-triggers it.", group.c_str(),
-                   static_cast<int>(result.outcome));
+        // A failed download is expected, self-correcting noise, not an operator-actionable
+        // event: it can legitimately happen whenever the manager's config_hash doesn't (yet)
+        // resolve to real content -- e.g. its "0" sentinel for "nothing resolved yet for this
+        // group set" right after a group membership change (confirmed with the manager team)
+        // -- and the next notify simply re-triggers it either way.
+        LOGFN_DEBUG1(m_logFn, "Config download for group '%s' failed (outcome %d); "
+                     "the next notify re-triggers it.", group.c_str(),
+                     static_cast<int>(result.outcome));
         return nullptr;
     }
 

--- a/src/client-agent/https_client/src/controlStateMachine.hpp
+++ b/src/client-agent/https_client/src/controlStateMachine.hpp
@@ -62,7 +62,11 @@ class ControlStateMachine final
             bool applyHandshake {false}; ///< Apply the returned handshake JSON.
             bool stateChanged {false};   ///< The published hc_conn_state_t changed.
             bool slowCadence {false};    ///< Use the rejected-retry interval, not notify.
-            bool resetCadence {false};   ///< Return to the normal Notify cadence.
+            /// Startup was just accepted (first connect, reconnect, or a settings-refresh
+            /// in place): the hashes and any pending tasks only ever arrive on Notify, so
+            /// the caller should send one immediately instead of waiting a full notify
+            /// cycle for it.
+            bool resetCadence {false};
         };
 
         ControlStateMachine() = default;

--- a/src/client-agent/https_client/src/controlStream.cpp
+++ b/src/client-agent/https_client/src/controlStream.cpp
@@ -46,19 +46,40 @@ namespace
         return it->is_string() ? it->get<std::string>() : it->dump();
     }
 
-    /// The group whose merged config /download serves. Agents can belong to several groups;
-    /// until multi-group reporting settles, the first reported group is used.
-    std::string firstGroup(const nlohmann::json& agent)
+    /// The group selector /download's config resource_id expects. The manager's own
+    /// config_hash (controlHandler.cpp's toGroupsCsv) and merged.mg resolution
+    /// (hashCache.cpp's getMergedMgPath) both key a multi-group agent by ALL its
+    /// groups, comma-joined, in the exact order it reports them -- never just the
+    /// first. Preserving that same order (as reported here, not re-sorted) is what
+    /// reproduces the manager's own CSV byte-for-byte; the download endpoint natively
+    /// accepts this selector (downloadEndpoint.cpp's isValidGroupSelector).
+    std::string groupsCsv(const nlohmann::json& agent)
     {
         const auto groups = agent.find("groups");
 
-        if (groups != agent.end() && groups->is_array() && !groups->empty() &&
-                groups->front().is_string())
+        if (groups == agent.end() || !groups->is_array() || groups->empty())
         {
-            return groups->front().get<std::string>();
+            return "default";
         }
 
-        return "default";
+        std::string csv;
+
+        for (const auto& value : *groups)
+        {
+            if (!value.is_string())
+            {
+                continue;
+            }
+
+            if (!csv.empty())
+            {
+                csv.push_back(',');
+            }
+
+            csv += value.get<std::string>();
+        }
+
+        return csv.empty() ? "default" : csv;
     }
 
     /// The Notify batch after dedup: fresh, identifiable tasks only.
@@ -243,11 +264,9 @@ OutcomeClass ControlStream::sendStartup(Waiter& waiter)
 
     if (result.outcome == OutcomeClass::Ok)
     {
-        // settings_hash baseline: SHA-256 over the exact response bytes. The
-        // manager must hash the serialization it sends; the refresh latch
-        // below degrades a mismatch to a one-time warning instead of a
-        // startup storm.
-        m_settingsHash = sha256Hex(result.response.body.data(), result.response.body.size());
+        m_settingsHash = computeSettingsHash(result.response.body);
+        LOGFN_DEBUG2(m_logFn, "settings_hash baseline computed from the startup response: %s",
+                     m_settingsHash.c_str());
         applyClusterIdentity(result.response.body);
     }
 
@@ -327,6 +346,41 @@ void ControlStream::applyEffects(const ControlStateMachine::Effects& effects,
     {
         m_sink.onStartupResult(true, handshake);
     }
+
+    if (effects.resetCadence)
+    {
+        m_fastFollowup = true;
+    }
+}
+
+std::string ControlStream::computeSettingsHash(const std::string& startupBody) const
+{
+    // Deliberately narrower than the full Startup response: matches the manager's
+    // HashCache::getSettingsHash() (remoted_module/src/control/hashCache.cpp), which
+    // hashes only limits + cluster. agent.groups is excluded on both sides -- a
+    // group's config content is already covered by config_hash/merged.mg, so
+    // settings_hash only needs to track the two fields the agent has no other way
+    // to detect a change in.
+    const auto parsed = nlohmann::json::parse(startupBody, nullptr, false);
+    nlohmann::json envelope;
+
+    if (!parsed.is_discarded() && parsed.is_object())
+    {
+        const auto limits = parsed.find("limits");
+        if (limits != parsed.end())
+        {
+            envelope["limits"] = *limits;
+        }
+
+        const auto cluster = parsed.find("cluster");
+        if (cluster != parsed.end())
+        {
+            envelope["cluster"] = *cluster;
+        }
+    }
+
+    const std::string body = envelope.dump();
+    return sha256Hex(body.data(), body.size());
 }
 
 void ControlStream::applyClusterIdentity(const std::string& startupBody)
@@ -376,14 +430,18 @@ void ControlStream::handleNotifyBody(const std::string& body, Waiter& waiter)
         // gate waits on the manager-validated configuration and, when the
         // hashes already agree, no download fires to tell it so.
         m_sink.onManagerConfigHash(managerHash);
-        maybeDownloadConfig(managerHash, firstGroup(*agent), waiter);
+        maybeDownloadConfig(managerHash, groupsCsv(*agent), waiter);
     }
 }
 
 void ControlStream::maybeDownloadConfig(const std::string& managerHash, const std::string& group,
                                         Waiter& waiter)
 {
-    if (managerHash.empty() || managerHash == m_configHash.get())
+    const std::string localHash = m_configHash.get();
+    LOGFN_DEBUG2(m_logFn, "config_hash check: manager=%s local=%s",
+                 managerHash.c_str(), localHash.c_str());
+
+    if (managerHash.empty() || managerHash == localHash)
     {
         return; // Nothing reported, or already in sync.
     }
@@ -406,6 +464,9 @@ void ControlStream::maybeDownloadConfig(const std::string& managerHash, const st
 
 void ControlStream::maybeArmSettingsRefresh(const std::string& incoming)
 {
+    LOGFN_DEBUG2(m_logFn, "settings_hash check: manager=%s local=%s",
+                 incoming.c_str(), m_settingsHash.c_str());
+
     if (incoming.empty())
     {
         return; // The manager did not report a settings hash.
@@ -436,6 +497,11 @@ void ControlStream::maybeArmSettingsRefresh(const std::string& incoming)
     m_refreshedForSettingsHash = incoming;
     m_settingsLoopWarned = false;
     m_machine.onEvent(ControlStateMachine::Event::SettingsChanged);
+
+    // Unlike config_hash (maybeDownloadConfig fetches inline, same cycle), the
+    // refresh Startup this arms is only actually sent on the NEXT step() --
+    // don't make that wait a full notify_interval_s too.
+    m_fastFollowup = true;
 }
 
 /* Turns one iteration's outcome into the producer-pause decision. Fed only from

--- a/src/client-agent/https_client/src/controlStream.cpp
+++ b/src/client-agent/https_client/src/controlStream.cpp
@@ -381,12 +381,14 @@ std::string ControlStream::computeSettingsHash(const std::string& startupBody) c
     if (!parsed.is_discarded() && parsed.is_object())
     {
         const auto limits = parsed.find("limits");
+
         if (limits != parsed.end())
         {
             envelope["limits"] = *limits;
         }
 
         const auto cluster = parsed.find("cluster");
+
         if (cluster != parsed.end())
         {
             envelope["cluster"] = *cluster;

--- a/src/client-agent/https_client/src/controlStream.cpp
+++ b/src/client-agent/https_client/src/controlStream.cpp
@@ -46,20 +46,19 @@ namespace
         return it->is_string() ? it->get<std::string>() : it->dump();
     }
 
-    /// The group selector /download's config resource_id expects. The manager's own
-    /// config_hash (controlHandler.cpp's toGroupsCsv) and merged.mg resolution
-    /// (hashCache.cpp's getMergedMgPath) both key a multi-group agent by ALL its
-    /// groups, comma-joined, in the exact order it reports them -- never just the
-    /// first. Preserving that same order (as reported here, not re-sorted) is what
-    /// reproduces the manager's own CSV byte-for-byte; the download endpoint natively
-    /// accepts this selector (downloadEndpoint.cpp's isValidGroupSelector).
-    std::string groupsCsv(const nlohmann::json& agent)
+    /// The agent's groups, comma-joined in the exact order the manager reports them
+    /// (never re-sorted -- see groupsCsv() below for why order matters) and, unlike
+    /// groupsCsv(), left EMPTY when the agent has none. Empty is meaningful to
+    /// downstream consumers (agcom.c: "Empty agent_groups is allowed - fallback to
+    /// merge.mg will be used"), so this must not carry /download's own "default"
+    /// substitution.
+    std::string rawGroupsCsv(const nlohmann::json& agent)
     {
         const auto groups = agent.find("groups");
 
-        if (groups == agent.end() || !groups->is_array() || groups->empty())
+        if (groups == agent.end() || !groups->is_array())
         {
-            return "default";
+            return {};
         }
 
         std::string csv;
@@ -79,6 +78,21 @@ namespace
             csv += value.get<std::string>();
         }
 
+        return csv;
+    }
+
+    /// The group selector /download's config resource_id expects. The manager's own
+    /// config_hash (controlHandler.cpp's toGroupsCsv) and merged.mg resolution
+    /// (hashCache.cpp's getMergedMgPath) both key a multi-group agent by ALL its
+    /// groups, comma-joined, in the exact order it reports them -- never just the
+    /// first. Preserving that same order (as reported here, not re-sorted) is what
+    /// reproduces the manager's own CSV byte-for-byte; the download endpoint natively
+    /// accepts this selector (downloadEndpoint.cpp's isValidGroupSelector). Unlike
+    /// rawGroupsCsv(), "no groups reported" falls back to "default" here: /download
+    /// needs some group to ask for, and every agent is implicitly in it.
+    std::string groupsCsv(const nlohmann::json& agent)
+    {
+        const std::string csv = rawGroupsCsv(agent);
         return csv.empty() ? "default" : csv;
     }
 
@@ -431,6 +445,7 @@ void ControlStream::handleNotifyBody(const std::string& body, Waiter& waiter)
         // hashes already agree, no download fires to tell it so.
         m_sink.onManagerConfigHash(managerHash);
         maybeDownloadConfig(managerHash, groupsCsv(*agent), waiter);
+        maybeReportAgentGroups(rawGroupsCsv(*agent));
     }
 }
 
@@ -460,6 +475,26 @@ void ControlStream::maybeDownloadConfig(const std::string& managerHash, const st
     // hc_set_config_hash and the next mismatch re-downloads.
     m_configHash.set(managerHash);
     m_sink.onConfigDownloaded(managerHash, std::move(file));
+}
+
+/* agent.groups is otherwise a Startup-only fact on the C side (see
+ * https_client_bridge.c's bridge_apply_agent_groups(), called only from
+ * on_startup_result). A group-only change never re-triggers a Startup (settings_hash
+ * deliberately excludes groups; config_hash covers the group's actual config content,
+ * not the manager-side membership list itself), so without this the group set the
+ * agent reports downstream (agcom's gethandshake, /stats and /config tagging) would
+ * go stale forever after the first Startup. Fires only on an actual change so a
+ * consumer isn't asked to republish identity data on every Notify for nothing. */
+void ControlStream::maybeReportAgentGroups(const std::string& csv)
+{
+    if (m_groupsReported && csv == m_lastReportedGroupsCsv)
+    {
+        return;
+    }
+
+    m_lastReportedGroupsCsv = csv;
+    m_groupsReported = true;
+    m_sink.onAgentGroups(csv);
 }
 
 void ControlStream::maybeArmSettingsRefresh(const std::string& incoming)

--- a/src/client-agent/https_client/src/controlStream.cpp
+++ b/src/client-agent/https_client/src/controlStream.cpp
@@ -359,6 +359,14 @@ void ControlStream::applyEffects(const ControlStateMachine::Effects& effects,
     if (effects.applyHandshake)
     {
         m_sink.onStartupResult(true, handshake);
+
+        // onStartupResult(true, ...) is what drives bridge_apply_agent_groups() on the C
+        // side (Startup-only, unconditional overwrite) -- so the baseline maybeReportAgentGroups()
+        // dedupes against is now stale by construction if this Startup's groups differ from
+        // whatever the last Notify reported. Clear the latch so the very next Notify
+        // unconditionally re-syncs, instead of silently matching a group set the bridge no
+        // longer holds.
+        m_groupsReported = false;
     }
 
     if (effects.resetCadence)

--- a/src/client-agent/https_client/src/controlStream.hpp
+++ b/src/client-agent/https_client/src/controlStream.hpp
@@ -113,6 +113,7 @@ class ControlStream final
         void updateProducerPause(OutcomeClass outcome);
         void maybeDownloadConfig(const std::string& managerHash, const std::string& group,
                                  Waiter& waiter);
+        void maybeReportAgentGroups(const std::string& csv);
         void updateLocalIp(const HttpResponse& response);
         ControlStateMachine::Event eventFor(OutcomeClass outcome) const;
 
@@ -145,6 +146,13 @@ class ControlStream final
         /// refreshing forever (guards a non-deterministic manager hash).
         std::string m_refreshedForSettingsHash;
         bool m_settingsLoopWarned {false};
+
+        /// The agent.groups CSV last reported to the sink (Startup or Notify), raw
+        /// (no "default" fallback -- that substitution is /download's alone). Unset
+        /// until the first Startup/Notify with a groups field; compared against on
+        /// every Notify so onAgentGroups() only fires on an actual change.
+        bool m_groupsReported {false};
+        std::string m_lastReportedGroupsCsv;
 
         /// Background thread for the current/last remote_upgrade's download+dispatch: must not
         /// run inline on the control thread, since that would stall the next Notify for the

--- a/src/client-agent/https_client/src/controlStream.hpp
+++ b/src/client-agent/https_client/src/controlStream.hpp
@@ -67,6 +67,19 @@ class ControlStream final
         hc_conn_state_t connState() const;
         bool isRegistered() const;
 
+        /// True exactly once after either: (a) the step() whose Startup was just
+        /// accepted (first connect, reconnect, or a settings-refresh in place), so the
+        /// Notify that reveals the hashes/tasks isn't delayed a full cycle, or (b) a
+        /// Notify that just armed a settings-refresh Startup, so that refresh itself
+        /// isn't delayed a full cycle either. Consumed on read: the caller acts on it
+        /// for one interval only.
+        bool consumeFastFollowup()
+        {
+            const bool value = m_fastFollowup;
+            m_fastFollowup = false;
+            return value;
+        }
+
         /// True while retrying Startup (Rejected/AuthError): use the slow cadence.
         bool useSlowCadence() const
         {
@@ -89,6 +102,9 @@ class ControlStream final
         OutcomeClass sendNotify(Waiter& waiter);
         void sendShutdown(Waiter& waiter);
         void applyEffects(const ControlStateMachine::Effects& effects, const std::string& handshake);
+        /// SHA-256 of limits + cluster only, extracted from the startup response --
+        /// see the .cpp for why agent.groups is deliberately excluded.
+        std::string computeSettingsHash(const std::string& startupBody) const;
         void applyClusterIdentity(const std::string& startupBody);
         void handleNotifyBody(const std::string& body, Waiter& waiter);
         void dispatchPlannedTasks(std::vector<NotifyTask> batch, Waiter& waiter);
@@ -145,6 +161,9 @@ class ControlStream final
         /// own transitions, so it starts false even though agentd arms the lock
         /// at boot for its own reasons.
         bool m_producersPaused {false};
+
+        /// Set from Effects::resetCadence; see consumeFastFollowup().
+        bool m_fastFollowup {false};
 };
 
 #endif // _HC_CONTROL_STREAM_HPP

--- a/src/client-agent/https_client/src/httpsClientFacade.cpp
+++ b/src/client-agent/https_client/src/httpsClientFacade.cpp
@@ -217,6 +217,11 @@ void HttpsClientFacade::stop()
 
 void HttpsClientFacade::controlLoop()
 {
+    // The hashes and any pending tasks only ever arrive on Notify, so a Startup that
+    // just got accepted (first connect, reconnect, or a settings-refresh in place)
+    // shouldn't sit idle for a full notify cycle before the first one is sent.
+    constexpr std::chrono::seconds FAST_FOLLOWUP_INTERVAL {1};
+
     while (true)
     {
         const bool registered = m_control.step(m_controlWaiter);
@@ -226,7 +231,9 @@ void HttpsClientFacade::controlLoop()
             m_gate.open();
         }
 
-        if (!m_controlWaiter.waitFor(controlInterval()))
+        const auto interval = m_control.consumeFastFollowup() ? FAST_FOLLOWUP_INTERVAL : controlInterval();
+
+        if (!m_controlWaiter.waitFor(interval))
         {
             break;
         }

--- a/src/client-agent/https_client/src/moduleConfig.cpp
+++ b/src/client-agent/https_client/src/moduleConfig.cpp
@@ -87,7 +87,9 @@ bool ModuleConfig::validateTls(const IFsProbe& fsProbe, const LogFn& logFn) cons
 
     if (verifyMode == HC_VERIFY_NONE)
     {
-        LOGFN_WARN(logFn, "https_client TLS verification is DISABLED (verify_mode=none).");
+        // The agent's own configured default (client-config.h's agent_verify_mode_t),
+        // not an operator opt-out to flag -- informational, not a WARNING.
+        LOGFN_INFO(logFn, "https_client TLS verification is DISABLED (verify_mode=none).");
         return true;
     }
 

--- a/src/client-agent/https_client/src/moduleConfig.cpp
+++ b/src/client-agent/https_client/src/moduleConfig.cpp
@@ -91,13 +91,16 @@ bool ModuleConfig::validateTls(const IFsProbe& fsProbe, const LogFn& logFn) cons
         return true;
     }
 
-    // Fail closed (H1): a verifying mode without a readable CA never sends.
+    // Fail closed (H1): a verifying mode without a readable CA never sends. This can never
+    // self-resolve without an operator fixing the config (mirrors main.c's hard exit on a
+    // missing/invalid <server><address>) -- CRITICAL terminates the daemon via the bridge's log
+    // callback instead of leaving it running with a permanently dead transport.
     if (caPath.empty() || !fsProbe.isReadableFile(caPath))
     {
-        LOGFN_ERROR(logFn,
-                    "https_client config rejected: verify_mode requires a readable CA file "
-                    "(certificate_authorities='%s').",
-                    caPath.c_str());
+        LOGFN_CRITICAL(logFn,
+                       "https_client config rejected: verify_mode requires a readable CA file "
+                       "(certificate_authorities='%s').",
+                       caPath.c_str());
         return false;
     }
 

--- a/src/client-agent/https_client/tests/component/fakeManager.hpp
+++ b/src/client-agent/https_client/tests/component/fakeManager.hpp
@@ -17,6 +17,7 @@
 #include "keyProvider.hpp"
 
 #include "external/cpp-httplib/httplib.h"
+#include "external/nlohmann/json.hpp"
 
 #include <openssl/evp.h>
 #include <openssl/x509.h>
@@ -29,6 +30,30 @@
 #include <string>
 #include <sys/wait.h>
 #include <unistd.h>
+
+// Mirrors the real manager's HashCache::getSettingsHash() (remoted_module/src/
+// control/hashCache.cpp) and the agent's ControlStream::computeSettingsHash():
+// limits + cluster only, agent.groups excluded -- NOT a raw hash of the startup
+// body's bytes, since nlohmann::json always dumps object keys alphabetically
+// regardless of the literal source order.
+inline std::string fakeManagerSettingsHash(const std::string& startupBody)
+{
+    const auto parsed = nlohmann::json::parse(startupBody);
+    nlohmann::json envelope;
+
+    if (parsed.contains("limits"))
+    {
+        envelope["limits"] = parsed.at("limits");
+    }
+
+    if (parsed.contains("cluster"))
+    {
+        envelope["cluster"] = parsed.at("cluster");
+    }
+
+    const std::string body = envelope.dump();
+    return sha256Hex(body.data(), body.size());
+}
 
 /**
  * @brief Fork-based plaintext fake manager (the http-request component-test
@@ -427,7 +452,7 @@ class FakeManager final
                         R"({"groups":["default"],"config_hash":")" + configHash + R"("})";
                     response.set_content(
                         R"({"agent":)" + agent + R"(,"settings_hash":")" +
-                        sha256Hex(startupBody.data(), startupBody.size()) + R"("})",
+                        fakeManagerSettingsHash(startupBody) + R"("})",
                         "application/json");
                     return;
                 }

--- a/src/client-agent/https_client/tests/unit/controlStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/controlStream_test.cpp
@@ -535,6 +535,52 @@ TEST_F(ControlStreamTest, AgentGroupsReportedOnFirstNotifyThenOnlyOnChange)
     m_stream.step(m_waiter); // Notify: groups changed, re-fires.
 }
 
+TEST_F(ControlStreamTest, AgentGroupsReReportedAfterARefreshStartupEvenWhenUnchanged)
+{
+    // bridge_apply_agent_groups() (https_client_bridge.c) overwrites the C-side agent_agent_groups
+    // unconditionally on every accepted Startup -- including a settings-refresh one, whose own
+    // body may carry a different group snapshot than the last Notify reported. If the dedupe
+    // latch survives that Startup, a Notify reporting the SAME groups as before the refresh would
+    // be wrongly deduped, leaving the C side pointed at whatever the refresh Startup wrote. The
+    // latch must therefore be cleared on every accepted Startup, not just group changes.
+    const std::string startupV1 = R"({"limits":{"eps":0}})";
+    const std::string startupV2 = R"({"limits":{"eps":100}})";
+    const std::string hashV2 = managerSettingsHash(startupV2);
+    const std::string notifyArmsRefresh =
+        R"({"status":"ok","agent":{"groups":["default"]},"settings_hash":")" + hashV2 + R"("})";
+    const std::string notifyAfterRefresh = R"({"status":"ok","agent":{"groups":["default"]}})";
+
+    std::vector<std::string> requestTypes;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillRepeatedly(Invoke(
+                        [&](const HttpRequestSpec & spec)
+    {
+        const std::string body = bodyOf(spec);
+        requestTypes.push_back(body.find("startup") != std::string::npos ? "startup"
+                               : "notify");
+
+        if (requestTypes.size() == 1)
+        {
+            return response(TransportStatus::Ok, 200, startupV1);
+        }
+
+        if (requestTypes.back() == "startup")
+        {
+            return response(TransportStatus::Ok, 200, startupV2);
+        }
+
+        return response(TransportStatus::Ok, 200,
+                        requestTypes.size() == 2 ? notifyArmsRefresh : notifyAfterRefresh);
+    }));
+
+    EXPECT_CALL(m_sink, onAgentGroups("default")).Times(2);
+
+    m_stream.step(m_waiter); // Startup (v1 baseline).
+    m_stream.step(m_waiter); // Notify: reports "default" (1st fire), arms a settings refresh.
+    m_stream.step(m_waiter); // Refresh Startup (v2) -- must clear the groups-reported latch.
+    m_stream.step(m_waiter); // Notify: "default" again -- re-fires despite being unchanged.
+}
+
 TEST_F(ControlStreamTest, AgentGroupsReportsEmptyRatherThanDefaultFallback)
 {
     // Unlike /download's resource_id (which substitutes "default" when the agent

--- a/src/client-agent/https_client/tests/unit/controlStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/controlStream_test.cpp
@@ -505,6 +505,51 @@ TEST_F(ControlStreamTest, MultiGroupAgentRequestsAllGroupsCommaJoined)
     EXPECT_EQ(R"({"resource_type":"config","resource_id":"default,test"})", downloadBody);
 }
 
+TEST_F(ControlStreamTest, AgentGroupsReportedOnFirstNotifyThenOnlyOnChange)
+{
+    // A group-only change never re-triggers a Startup (settings_hash excludes
+    // groups by design), so onAgentGroups is the only thing that keeps a
+    // consumer's group set from going stale -- it must fire once for the first
+    // report and again only when the manager-reported set actually changes.
+    const std::string notifyDefault = R"({"agent":{"groups":["default"]}})";
+    const std::string notifySame = R"({"agent":{"groups":["default"]}})";
+    const std::string notifyChanged = R"({"agent":{"groups":["default","test"]}})";
+
+    testing::InSequence seq;
+    EXPECT_CALL(m_sink, onAgentGroups("default"));
+    EXPECT_CALL(m_sink, onAgentGroups("default,test"));
+
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))             // Startup.
+    .WillOnce(Return(response(TransportStatus::Ok, 200, notifyDefault)))    // First report.
+    .WillOnce(Return(response(TransportStatus::Ok, 200, notifySame)))       // Unchanged: no re-fire.
+    .WillOnce(Return(response(TransportStatus::Ok, 200, notifyChanged)));   // Changed: re-fires.
+
+    m_stream.step(m_waiter); // Startup.
+    m_stream.step(m_waiter); // Notify: first report.
+    m_stream.step(m_waiter); // Notify: same groups, no call.
+    m_stream.step(m_waiter); // Notify: groups changed, re-fires.
+}
+
+TEST_F(ControlStreamTest, AgentGroupsReportsEmptyRatherThanDefaultFallback)
+{
+    // Unlike /download's resource_id (which substitutes "default" when the agent
+    // has no groups, since /download always needs some group to ask for), an
+    // empty group set here must stay empty: agcom.c treats it as a distinct,
+    // meaningful value ("Empty agent_groups is allowed - fallback to merge.mg
+    // will be used"), not a synonym for being in "default".
+    const std::string notifyNoGroups = R"({"agent":{"groups":[]}})";
+
+    EXPECT_CALL(m_sink, onAgentGroups(std::string {}));
+
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, notifyNoGroups)));
+
+    m_stream.step(m_waiter); // Startup.
+    m_stream.step(m_waiter); // Notify: no groups -> reports empty, not "default".
+}
+
 TEST_F(ControlStreamTest, MatchingConfigHashDoesNotDownload)
 {
     // Local hash is "abc": a notify reporting "abc" triggers nothing, and

--- a/src/client-agent/https_client/tests/unit/controlStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/controlStream_test.cpp
@@ -142,8 +142,8 @@ TEST_F(ControlStreamTest, FastFollowupArmedOnceAfterStartupAccepted)
     .WillOnce(Return(response(TransportStatus::Ok, 200, R"({})")));
 
     m_stream.step(m_waiter); // Startup accepted: hashes/tasks only arrive on the
-                             // Notify that follows, so the caller shouldn't idle a
-                             // full notify cycle before sending one.
+    // Notify that follows, so the caller shouldn't idle a
+    // full notify cycle before sending one.
     EXPECT_TRUE(m_stream.consumeFastFollowup());
     EXPECT_FALSE(m_stream.consumeFastFollowup()); // Consume-once: not re-armed on read.
 
@@ -515,15 +515,19 @@ TEST_F(ControlStreamTest, AgentGroupsReportedOnFirstNotifyThenOnlyOnChange)
     const std::string notifySame = R"({"agent":{"groups":["default"]}})";
     const std::string notifyChanged = R"({"agent":{"groups":["default","test"]}})";
 
-    testing::InSequence seq;
-    EXPECT_CALL(m_sink, onAgentGroups("default"));
-    EXPECT_CALL(m_sink, onAgentGroups("default,test"));
-
     EXPECT_CALL(m_performer, perform(_))
     .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))             // Startup.
     .WillOnce(Return(response(TransportStatus::Ok, 200, notifyDefault)))    // First report.
     .WillOnce(Return(response(TransportStatus::Ok, 200, notifySame)))       // Unchanged: no re-fire.
     .WillOnce(Return(response(TransportStatus::Ok, 200, notifyChanged)));   // Changed: re-fires.
+
+    {
+        // Scoped so only the two reports are ordered: an InSequence covering the
+        // transport too would demand every perform() happen after them.
+        testing::InSequence seq;
+        EXPECT_CALL(m_sink, onAgentGroups("default"));
+        EXPECT_CALL(m_sink, onAgentGroups("default,test"));
+    }
 
     m_stream.step(m_waiter); // Startup.
     m_stream.step(m_waiter); // Notify: first report.

--- a/src/client-agent/https_client/tests/unit/controlStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/controlStream_test.cpp
@@ -48,6 +48,29 @@ namespace
         return std::string {reinterpret_cast<const char*>(spec.body), spec.bodyLength};
     }
 
+    // Mirrors the manager's HashCache::getSettingsHash() (limits + cluster only,
+    // agent.groups excluded) and ControlStream::computeSettingsHash() -- NOT a raw
+    // hash of startupBody's bytes, since nlohmann::json always dumps object keys
+    // alphabetically regardless of the literal source order.
+    std::string managerSettingsHash(const std::string& startupBody)
+    {
+        const auto parsed = nlohmann::json::parse(startupBody);
+        nlohmann::json envelope;
+
+        if (parsed.contains("limits"))
+        {
+            envelope["limits"] = parsed.at("limits");
+        }
+
+        if (parsed.contains("cluster"))
+        {
+            envelope["cluster"] = parsed.at("cluster");
+        }
+
+        const std::string body = envelope.dump();
+        return sha256Hex(body.data(), body.size());
+    }
+
     class ControlStreamTest : public ::testing::Test
     {
         protected:
@@ -112,6 +135,42 @@ TEST_F(ControlStreamTest, StartupBodyCarriesTypeAndVersionOnly)
     EXPECT_EQ(std::string::npos, sent.find("config_checksum"));
 }
 
+TEST_F(ControlStreamTest, FastFollowupArmedOnceAfterStartupAccepted)
+{
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, R"({"limits":{}})")))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, R"({})")));
+
+    m_stream.step(m_waiter); // Startup accepted: hashes/tasks only arrive on the
+                             // Notify that follows, so the caller shouldn't idle a
+                             // full notify cycle before sending one.
+    EXPECT_TRUE(m_stream.consumeFastFollowup());
+    EXPECT_FALSE(m_stream.consumeFastFollowup()); // Consume-once: not re-armed on read.
+
+    m_stream.step(m_waiter); // Notify: no Startup accepted this cycle.
+    EXPECT_FALSE(m_stream.consumeFastFollowup());
+}
+
+TEST_F(ControlStreamTest, FastFollowupAlsoArmedWhenASettingsRefreshIsQueued)
+{
+    // Arming the refresh (SettingsChanged) is a separate event from StartupAccepted:
+    // without its own fast-followup, the refresh Startup itself would sit queued for
+    // a full notify_interval_s before ever being sent.
+    const std::string startupV1 = R"({"limits":{"eps":0}})";
+    const std::string notifyMismatch =
+        R"({"settings_hash":")" + managerSettingsHash(R"({"limits":{"eps":9}})") + R"("})";
+
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, startupV1))) // Startup.
+    .WillOnce(Return(response(TransportStatus::Ok, 200, notifyMismatch))); // Notify: arms refresh.
+
+    m_stream.step(m_waiter); // Startup accepted.
+    EXPECT_TRUE(m_stream.consumeFastFollowup()); // Consumed here, not left for the assertion below.
+
+    m_stream.step(m_waiter); // Notify: settings_hash mismatch -> arms a refresh Startup.
+    EXPECT_TRUE(m_stream.consumeFastFollowup());
+}
+
 TEST_F(ControlStreamTest, StartupStoresManagerAuthoritativeClusterIdentity)
 {
     EXPECT_CALL(m_performer, perform(_))
@@ -138,7 +197,7 @@ TEST_F(ControlStreamTest, SettingsRefreshStartupAlsoOverwritesCluster)
     const std::string startupV1 = R"({"limits":{"eps":0},"cluster":{"name":"c1","node":"n1"}})";
     const std::string startupV2 = R"({"limits":{"eps":9},"cluster":{"name":"c2","node":"n2"}})";
     const std::string notifyV2 =
-        R"({"settings_hash":")" + sha256Hex(startupV2.data(), startupV2.size()) + R"("})";
+        R"({"settings_hash":")" + managerSettingsHash(startupV2) + R"("})";
 
     int calls = 0;
     EXPECT_CALL(m_performer, perform(_))
@@ -306,7 +365,7 @@ TEST_F(ControlStreamTest, SettingsMismatchTriggersOneStartupRefresh)
 {
     const std::string startupV1 = R"({"limits":{"eps":0}})";
     const std::string startupV2 = R"({"limits":{"eps":100}})";
-    const std::string hashV2 = sha256Hex(startupV2.data(), startupV2.size());
+    const std::string hashV2 = managerSettingsHash(startupV2);
     const std::string notifyWithV2 =
         R"({"status":"ok","settings_hash":")" + hashV2 + R"("})";
 
@@ -416,6 +475,34 @@ TEST_F(ControlStreamTest, ConfigMismatchDownloadsVerifiesAndDelivers)
     const std::string content {std::istreambuf_iterator<char>(file),
                                std::istreambuf_iterator<char>()};
     EXPECT_EQ(blob, content);
+}
+
+TEST_F(ControlStreamTest, MultiGroupAgentRequestsAllGroupsCommaJoined)
+{
+    // A multi-group agent must send every reported group, comma-joined and in the
+    // manager's own order, as resource_id -- the manager's config_hash/merged.mg for
+    // a multi-group agent is keyed by that same CSV (controlHandler.cpp's
+    // toGroupsCsv, hashCache.cpp's getMergedMgPath); requesting only the first group
+    // would fetch a different (single-group) merged.mg that can never match the
+    // hash the manager actually reported, looping forever.
+    const std::string notify =
+        R"({"status":"ok","agent":{"groups":["default","test"],"config_hash":"multi-hash"}})";
+
+    std::string downloadBody;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))    // Startup.
+    .WillOnce(Return(response(TransportStatus::Ok, 200, notify))) // Notify.
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & spec)
+    {
+        downloadBody = bodyOf(spec);
+        return response(TransportStatus::Ok, 404); // Content irrelevant to this test.
+    }));
+
+    m_stream.step(m_waiter); // Startup.
+    m_stream.step(m_waiter); // Notify -> download attempt.
+
+    EXPECT_EQ(R"({"resource_type":"config","resource_id":"default,test"})", downloadBody);
 }
 
 TEST_F(ControlStreamTest, MatchingConfigHashDoesNotDownload)

--- a/src/client-agent/https_client/tests/unit/mocks/mockCallbackSink.hpp
+++ b/src/client-agent/https_client/tests/unit/mocks/mockCallbackSink.hpp
@@ -35,6 +35,7 @@ class MockCallbackSink : public ICallbackSink
                     (const std::string& taskId, const std::string& taskType, const std::string& reason),
                     (override));
         MOCK_METHOD(void, onManagerConfigHash, (const std::string& configHash), (override));
+        MOCK_METHOD(void, onAgentGroups, (const std::string& groupsCsv), (override));
         MOCK_METHOD(void, onSyncResponse,
                     (const std::string& sessionId, int result, const std::string& body), (override));
         MOCK_METHOD(void, onStateChange, (hc_conn_state_t state), (override));

--- a/src/client-agent/include/agentd.h
+++ b/src/client-agent/include/agentd.h
@@ -34,7 +34,13 @@ void AgentdStart(int uid, int gid, const char *user, const char *group) __attrib
 /* Event Forwarder */
 void *EventForward(void);
 
-/* Read the keys, arm the startup gate and report the agent start */
+/* Arm the startup gate and block until the agent has a valid key (enrolling
+ * if needed). Must run before the HTTPS client is ever started: it validates
+ * the key once, with no retry, so it must never see an empty keystore. */
+void start_agent_prepare(void);
+
+/* Publish the agent metadata and report the agent start. Must run after the
+ * HTTPS client has started: it submits the start event through it. */
 void start_agent(int is_startup);
 
 /* Publish the agent metadata into shared memory */

--- a/src/client-agent/src/agentd.c
+++ b/src/client-agent/src/agentd.c
@@ -110,6 +110,11 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
     w_agentd_state_init();
     w_create_thread(state_main, NULL);
 
+    /* Enrollment (blocking until a valid key exists) and the startup gate
+     * must both be ready before the HTTPS client is ever started: it reads
+     * client.keys exactly once, at creation, with no retry on failure. */
+    start_agent_prepare();
+
     /* HTTPS client: the agent's only transport. It owns the connection
      * lifecycle, the keepalives, the buffering and the shutdown notification. */
     w_https_client_start();

--- a/src/client-agent/src/event-forward.c
+++ b/src/client-agent/src/event-forward.c
@@ -33,7 +33,22 @@ void *EventForward()
          * frame class left to route. The accumulator owns the back-pressure
          * (drop-newest), so a full one drops this frame and the loop goes on. */
         w_agentd_state_update(INCREMENT_MSG_COUNT, NULL);
-        w_https_client_submit_event(msg, recv_b);
+
+        /* SendMSGAction() (mq_op.c) writes these frames via OS_SendUnix(..., 0),
+         * whose "size == 0 means C string" convention sends strlen(msg) + 1
+         * bytes -- the NUL terminator rides along as part of the datagram.
+         * w_https_client_submit_event() is strictly length-delimited, not
+         * NUL-terminated, so left uncorrected that trailing NUL becomes a real
+         * extra byte of event content on the wire. Trim exactly one, mirroring
+         * what the legacy handshake path used to do (send_msg(msg, -1) ->
+         * strlen()) before 6867e35baa ("route the agent's events to /stateless
+         * only") collapsed both frame classes into this raw datagram length. */
+        ssize_t content_len = recv_b;
+        if (content_len > 0 && msg[content_len - 1] == '\0') {
+            content_len--;
+        }
+
+        w_https_client_submit_event(msg, content_len);
     }
 
     return (NULL);

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -1378,8 +1378,17 @@ static bool bridge_build_config(hc_config_t *config)
      * local test it explores a path where the key is NULL and reports the
      * strncpy() below, plus the keys.keyentries[0]->id read above it. */
     if (raw_key == NULL || !bridge_key_is_valid(raw_key)) {
-        merror("https_client: agent key is missing or has an invalid length for AES-CMAC "
-               "(expected 32, 48 or 64 hex characters); refusing to start.");
+        /* keys.keysize == 0 means "never enrolled" (start_agent_prepare()
+         * blocks on enrollment before this ever runs, so this should not be
+         * reachable in practice -- kept as defense-in-depth against a future
+         * ordering regression). A non-zero keysize with an invalid raw_key is
+         * a genuinely corrupt client.keys, worth an ERROR. */
+        if (keys.keysize == 0) {
+            mdebug1("https_client: not enrolled yet (no client.keys); deferring start.");
+        } else {
+            merror("https_client: agent key is missing or has an invalid length for AES-CMAC "
+                   "(expected 32, 48 or 64 hex characters); refusing to start.");
+        }
         return false;
     }
     if (keys.keyentries[0]->id) {

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -879,6 +879,41 @@ static void bridge_on_manager_config_hash(const char *config_hash, void *user_da
     startup_gate_check_manager_config_hash(config_hash);
 }
 
+/* Notify-driven groups refresh: a group-only change never re-triggers a Startup
+ * (settings_hash deliberately excludes groups; config_hash covers the group's own
+ * config content, not the manager-side membership list), so without this
+ * agent_agent_groups -- and everything that reads it: agcom_gethandshake(), the
+ * metadata this republishes -- would go stale forever after the first Startup.
+ * Unlike bridge_apply_agent_groups() (Startup-only, walks a cJSON array), this
+ * takes the plain CSV the module already built (ControlStream's rawGroupsCsv())
+ * -- the RAW value, not /download's "default"-substituted one: empty is
+ * meaningful here (see agcom.c's own comment on an empty agent_groups falling
+ * back to merged.mg) and must be preserved as empty, not turned into "default".
+ * Compares before writing so an unchanged report (the module already dedupes,
+ * this is defense in depth) doesn't pay for a metadata republish. */
+static void bridge_on_agent_groups(const char *groups_csv, void *user_data)
+{
+    (void)user_data;
+
+    if (!groups_csv) {
+        return;
+    }
+
+    bool changed = false;
+
+    w_mutex_lock(&agent_handshake_mutex);
+    if (strcmp(agent_agent_groups, groups_csv) != 0) {
+        snprintf(agent_agent_groups, sizeof(agent_agent_groups), "%s", groups_csv);
+        changed = true;
+    }
+    w_mutex_unlock(&agent_handshake_mutex);
+
+    if (changed) {
+        mdebug1("https_client: agent groups -> %s.", agent_agent_groups[0] ? agent_agent_groups : "(none)");
+        w_agentd_populate_metadata();
+    }
+}
+
 /* Applies a downloaded merged configuration and releases the startup gate.
  *
  * file_path is a module-owned temp file valid ONLY until the callback that
@@ -1544,6 +1579,7 @@ void w_https_client_start(void)
     callbacks.on_remote_upgrade_ready = bridge_on_remote_upgrade_ready;
     callbacks.on_task_failed = bridge_on_task_failed;
     callbacks.on_manager_config_hash = bridge_on_manager_config_hash;
+    callbacks.on_agent_groups = bridge_on_agent_groups;
     callbacks.on_config_downloaded = bridge_on_config_downloaded;
     callbacks.on_sync_response = bridge_on_sync_response;
     callbacks.on_state_change = bridge_on_state_change;

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -308,8 +308,8 @@ static void bridge_apply_cluster_identity(const cJSON *root)
 }
 
 /* agent_groups: HTTPS nests the array under "agent":{"groups":[...]} (see
- * ControlStream's firstGroup(), which reads the same object for /download's
- * group parameter) rather than start_agent.c's flat "agent_groups" array.
+ * ControlStream's groupsCsv(), which reads the same object for /download's
+ * resource_id) rather than start_agent.c's flat "agent_groups" array.
  * Builds the same CSV shape agent_agent_groups already holds for legacy. */
 static void bridge_apply_agent_groups(const cJSON *root)
 {

--- a/src/client-agent/src/main.c
+++ b/src/client-agent/src/main.c
@@ -161,11 +161,10 @@ int main(int argc, char **argv)
         merror_exit(MEM_ERROR, errno, strerror(errno));
     }
 
-    /* TEMPORARY: default to no TLS verification when <ssl> is absent from the config,
-     * so an unmodified pre-HTTPS config (upgrade case: no <ssl> block at all) doesn't
-     * hard-exit on AG_INV_SSL_CA. ClientConf()/Read_Client_SSL() below still overrides
-     * this to whatever <ssl><verification_mode> the config actually sets. Revert
-     * before release -- the correct default is AGENT_VERIFY_FULL (fail-closed). */
+    /* Default to no TLS verification when <ssl> is absent from the config -- e.g. an
+     * unmodified pre-HTTPS config (upgrade case: no <ssl> block at all), which would
+     * otherwise hard-exit on AG_INV_SSL_CA. ClientConf()/Read_Client_SSL() below still
+     * overrides this to whatever <ssl><verification_mode> the config actually sets. */
     agt->ssl.verification_mode = AGENT_VERIFY_NONE;
 
     atc = (anti_tampering *)calloc(1, sizeof(anti_tampering));

--- a/src/client-agent/src/main.c
+++ b/src/client-agent/src/main.c
@@ -161,6 +161,13 @@ int main(int argc, char **argv)
         merror_exit(MEM_ERROR, errno, strerror(errno));
     }
 
+    /* TEMPORARY: default to no TLS verification when <ssl> is absent from the config,
+     * so an unmodified pre-HTTPS config (upgrade case: no <ssl> block at all) doesn't
+     * hard-exit on AG_INV_SSL_CA. ClientConf()/Read_Client_SSL() below still overrides
+     * this to whatever <ssl><verification_mode> the config actually sets. Revert
+     * before release -- the correct default is AGENT_VERIFY_FULL (fail-closed). */
+    agt->ssl.verification_mode = AGENT_VERIFY_NONE;
+
     atc = (anti_tampering *)calloc(1, sizeof(anti_tampering));
     if (!atc) {
         merror_exit(MEM_ERROR, errno, strerror(errno));

--- a/src/client-agent/src/main.c
+++ b/src/client-agent/src/main.c
@@ -202,6 +202,17 @@ int main(int argc, char **argv)
         mlerror_exit(LOGLEVEL_ERROR, CLIENT_ERROR);
     }
 
+    /* A verifying <ssl><verification_mode> without a readable CA can never connect (the
+     * https_client module fails closed on this, per its own validation) -- caught here, before
+     * daemonizing, so wazuh-client.sh's sequential daemon-start check (which polls for this
+     * process's PID file before starting syscheckd/logcollector/modulesd) halts the whole start
+     * instead of launching the other daemons around a transport that will never come up. */
+    if (agt->ssl.verification_mode != AGENT_VERIFY_NONE &&
+        (!agt->ssl.certificate_authorities || !w_is_file(agt->ssl.certificate_authorities))) {
+        merror(AG_INV_SSL_CA, agt->ssl.certificate_authorities ? agt->ssl.certificate_authorities : "");
+        mlerror_exit(LOGLEVEL_ERROR, CLIENT_ERROR);
+    }
+
     if (agt->notify_time == 0) {
         agt->notify_time = NOTIFY_TIME;
     }

--- a/src/client-agent/src/start_agent.c
+++ b/src/client-agent/src/start_agent.c
@@ -30,6 +30,17 @@
 static void w_agentd_keys_init (void);
 STATIC void send_msg_on_startup(void);
 
+/* Arm the startup gate and block until the agent has a usable key, enrolling
+ * if needed (see w_agentd_keys_init()). Must complete before the HTTPS client
+ * is ever started: bridge_build_config() reads client.keys exactly once, at
+ * hc_create() time, with no retry -- if it sees an empty keystore there the
+ * client never runs, silently, for the rest of the process's life. */
+void start_agent_prepare(void)
+{
+    startup_gate_initialize();
+    w_agentd_keys_init();
+}
+
 /* Bring the agent up. There is no connection to establish here any more: the
  * HTTPS module owns registration and its retries. What is left is what the
  * legacy handshake did around it. */
@@ -38,9 +49,6 @@ void start_agent(int is_startup)
     if (!is_startup) {
         return;
     }
-
-    startup_gate_initialize();
-    w_agentd_keys_init();
 
     /* Published from the legacy handshake ACK before; everything but the
      * cluster/groups fields is local, and the bridge republishes those from

--- a/src/config/include/client-config.h
+++ b/src/config/include/client-config.h
@@ -29,11 +29,14 @@ typedef struct agent_server {
 
 /* TLS verification posture for the HTTPS transport.
  * Values mirror the module ABI's hc_verify_mode_t so the bridge can copy them
- * verbatim into hc_config_t. FULL is 0 so a zero-initialized config fails closed. */
+ * verbatim into hc_config_t. FULL is 0, so a zero-initialized struct that never
+ * goes through the agent's own default-setting path (main.c/win_utils.c, right
+ * after allocating agt) still fails closed. The agent's own configured default
+ * (when <ssl> is absent) is NONE, set explicitly there -- see AGENT_VERIFY_NONE. */
 typedef enum agent_verify_mode_t {
-    AGENT_VERIFY_FULL = 0, ///< Verify peer against the CA and check the hostname (default).
+    AGENT_VERIFY_FULL = 0, ///< Verify peer against the CA and check the hostname.
     AGENT_VERIFY_CERT = 1, ///< Verify peer against the CA only.
-    AGENT_VERIFY_NONE = 2  ///< No TLS verification (explicit opt-out).
+    AGENT_VERIFY_NONE = 2  ///< No TLS verification (the agent's own configured default).
 } agent_verify_mode_t;
 
 /* Agent-side HTTPS transport TLS settings: the <client><ssl> block (FR10 / #37702 §10). */

--- a/src/config/include/client-config.h
+++ b/src/config/include/client-config.h
@@ -116,4 +116,9 @@ bool Validate_IPv6_Link_Local_Interface(agent_server *servers);
 #define DEFAULT_MAX_RETRIES 5
 #define DEFAULT_RETRY_INTERVAL 10
 
+/* Port used when <server><port> is unspecified. Must mirror the manager's
+ * DEFAULT_HTTPS_PORT (src/remoted/remoted_module/src/http_server/httpServerConfig.cpp)
+ * since the agent has no legacy-transport fallback to default to instead. */
+#define DEFAULT_HTTPS_CLIENT_PORT 1517
+
 #endif /* CAGENTD_H */

--- a/src/config/src/client-config.c
+++ b/src/config/src/client-config.c
@@ -25,7 +25,7 @@ int Read_Client(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unuse
     int i = 0;
     char f_ip[128] = {'\0'};
     char * rip = NULL;
-    int port = DEFAULT_REMOTE_PORT;
+    int port = DEFAULT_HTTPS_CLIENT_PORT;
 
     /* XML definitions */
     const char *xml_client_manager = "manager";
@@ -278,7 +278,7 @@ int Read_Client_Server(XML_NODE node, agent * logr)
     char * rip = NULL;
     /* Default values */
     uint32_t network_interface = 0;
-    int port = DEFAULT_REMOTE_PORT;
+    int port = DEFAULT_HTTPS_CLIENT_PORT;
     int max_retries = DEFAULT_MAX_RETRIES;
     int retry_interval = DEFAULT_RETRY_INTERVAL;
 

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -360,9 +360,8 @@ WriteAgent()
     fi
     echo "      <port>1517</port>" >> $NEWCONFIG
     echo "    </server>" >> $NEWCONFIG
-    # TEMPORARY: shipped as 'none' to unblock the test suite (no CA available
-    # there); revert to 'full' + a real certificate_authorities path before
-    # release.
+    # verification_mode defaults to 'none'; set to 'full' or 'certificate' and
+    # provide certificate_authorities to verify the manager's certificate.
     echo "    <ssl>" >> $NEWCONFIG
     echo "      <certificate_authorities>PATH</certificate_authorities>" >> $NEWCONFIG
     echo "      <verification_mode>none</verification_mode>" >> $NEWCONFIG

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -358,8 +358,12 @@ WriteAgent()
     else
       echo "      <address>$HNAME</address>" >> $NEWCONFIG
     fi
-    echo "      <port>1514</port>" >> $NEWCONFIG
+    echo "      <port>1517</port>" >> $NEWCONFIG
     echo "    </server>" >> $NEWCONFIG
+    echo "    <ssl>" >> $NEWCONFIG
+    echo "      <certificate_authorities>PATH</certificate_authorities>" >> $NEWCONFIG
+    echo "      <verification_mode>full</verification_mode>" >> $NEWCONFIG
+    echo "    </ssl>" >> $NEWCONFIG
     if [ "X${USER_AGENT_CONFIG_PROFILE}" != "X" ]; then
          PROFILE=${USER_AGENT_CONFIG_PROFILE}
          echo "    <config-profile>$PROFILE</config-profile>" >> $NEWCONFIG

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -360,9 +360,12 @@ WriteAgent()
     fi
     echo "      <port>1517</port>" >> $NEWCONFIG
     echo "    </server>" >> $NEWCONFIG
+    # TEMPORARY: shipped as 'none' to unblock the test suite (no CA available
+    # there); revert to 'full' + a real certificate_authorities path before
+    # release.
     echo "    <ssl>" >> $NEWCONFIG
     echo "      <certificate_authorities>PATH</certificate_authorities>" >> $NEWCONFIG
-    echo "      <verification_mode>full</verification_mode>" >> $NEWCONFIG
+    echo "      <verification_mode>none</verification_mode>" >> $NEWCONFIG
     echo "    </ssl>" >> $NEWCONFIG
     if [ "X${USER_AGENT_CONFIG_PROFILE}" != "X" ]; then
          PROFILE=${USER_AGENT_CONFIG_PROFILE}

--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -77,7 +77,7 @@ add_adress_block() {
     {
         echo "    <server>"
         echo "      <address>${ADDRESSES[last_index]}</address>"
-        echo "      <port>1514</port>"
+        echo "      <port>1517</port>"
         echo "    </server>"
     } >> "${TMP_SERVER}"
 

--- a/src/shared/include/error_messages/error_messages.h
+++ b/src/shared/include/error_messages/error_messages.h
@@ -295,6 +295,7 @@
 #define AG_TOKEN_FAIL   "(4115): Error trying to get API token with login: %s"
 #define AG_API_ERROR_CODE  "(4116): Unexpected status code in Wazuh agent package uninstallation request: %ld\n"
 #define AG_REQUEST_FAIL    "(4117): Failed validation request to uninstall Wazuh agent package."
+#define AG_INV_SSL_CA      "(4118): <ssl><verification_mode> is not 'none' but <certificate_authorities> is missing or unreadable: '%s'."
 
 /* Rules reading errors */
 #define RL_INV_ROOT     "(5101): Invalid root element: '%s'."

--- a/src/shared_modules/utils/loggerHelper.h
+++ b/src/shared_modules/utils/loggerHelper.h
@@ -52,7 +52,7 @@ constexpr auto MAXLEN {65536};
 // same log-then-exit(1) sequence as _merror_exit()/_mlerror_exit() (shared/src/debug_op.c), for
 // a config that can never work as given (mirrors client-agent/src/main.c's own hard exit on a
 // missing/invalid <server><address>). It must never be silently dropped.
-#define LOGFN_CRITICAL(fn, fmt, ...) (fn).critical({__FILE__, __LINE__, __func__}, fmt, ##__VA_ARGS__)
+#define LOGFN_CRITICAL(fn, fmt, ...) do { (fn).critical({__FILE__, __LINE__, __func__}, fmt, ##__VA_ARGS__); } while (0)
 // clang-format on
 
 namespace Log

--- a/src/shared_modules/utils/loggerHelper.h
+++ b/src/shared_modules/utils/loggerHelper.h
@@ -45,6 +45,14 @@ constexpr auto MAXLEN {65536};
 #define LOGFN_DEBUG1(fn, fmt, ...) do { if (Log::isDebugEnabled())  { (fn).debug1({__FILE__, __LINE__, __func__}, fmt, ##__VA_ARGS__); } } while (0)
 #define LOGFN_DEBUG2(fn, fmt, ...) do { if (Log::isDebug2Enabled()) { (fn).debug2({__FILE__, __LINE__, __func__}, fmt, ##__VA_ARGS__); } } while (0)
 #define LOGFN_ERROR(fn, fmt, ...)  do { if (Log::isErrorEnabled())  { (fn).error( {__FILE__, __LINE__, __func__}, fmt, ##__VA_ARGS__); } } while (0)
+// CRITICAL is unfiltered by design (no isCriticalEnabled() gate): the shared C/C++ logging
+// bridge every module wires in as its log callback (mtLoggingFunctionsWrapper,
+// shared/src/debug_op.c -- used by https_client, remoted_module, inventory_sync,
+// vulnerability_scanner and content_manager alike) logs then exit(1)s on this level, the exact
+// same log-then-exit(1) sequence as _merror_exit()/_mlerror_exit() (shared/src/debug_op.c), for
+// a config that can never work as given (mirrors client-agent/src/main.c's own hard exit on a
+// missing/invalid <server><address>). It must never be silently dropped.
+#define LOGFN_CRITICAL(fn, fmt, ...) (fn).critical({__FILE__, __LINE__, __func__}, fmt, ##__VA_ARGS__)
 // clang-format on
 
 namespace Log
@@ -372,6 +380,19 @@ namespace Log
                 std::va_list args;
                 va_start(args, fmt);
                 GLOBAL_LOG_FUNCTION(LOGLEVEL_ERROR, m_tag.c_str(), src.file, src.line, src.func, fmt, args);
+                va_end(args);
+            }
+        }
+
+        // Unrecoverable misconfiguration: the caller's log callback is expected to terminate
+        // the process on this level (see mtLoggingFunctionsWrapper). Not level-filtered.
+        __attribute__((visibility("hidden"))) void critical(SourceFile src, const char* fmt, ...) const
+        {
+            if (GLOBAL_LOG_FUNCTION)
+            {
+                std::va_list args;
+                va_start(args, fmt);
+                GLOBAL_LOG_FUNCTION(LOGLEVEL_CRITICAL, m_tag.c_str(), src.file, src.line, src.func, fmt, args);
                 va_end(args);
             }
         }

--- a/src/unit_tests/client-agent/test_https_client_bridge.c
+++ b/src/unit_tests/client-agent/test_https_client_bridge.c
@@ -237,6 +237,10 @@ static void set_agent_key(const char *id, const char *raw_key)
     if (raw_key) {
         os_strdup(raw_key, keys.keyentries[0]->raw_key);
     }
+    /* Mirrors OS_AddKey()/OS_ReadKeys(): a real (even if since-corrupted)
+     * entry means keysize is at least 1. keysize == 0 is reserved for "never
+     * enrolled" (see bridge_build_config()'s DEBUG-vs-ERROR split). */
+    keys.keysize = 1;
 }
 
 /* Allocates agt->enrollment_cfg with enabled=true; when manager_name is
@@ -469,6 +473,25 @@ static void test_missing_key_refuses_to_start(void **state)
     expect_string(__wrap__merror, formatted_msg,
                   "https_client: agent key is missing or has an invalid length for AES-CMAC "
                   "(expected 32, 48 or 64 hex characters); refusing to start.");
+
+    w_https_client_start();
+    /* No hc_create expectation: must not be reached. */
+}
+
+/* keysize == 0 is "never enrolled yet" -- an expected transient on a fresh
+ * agent, not an error. start_agent_prepare() blocks on enrollment before
+ * w_https_client_start() ever runs, so this should not be reachable in
+ * practice; kept as defense-in-depth against a future ordering regression. */
+static void test_no_keystore_defers_at_debug(void **state)
+{
+    (void)state;
+    os_free(keys.keyentries[0]->raw_key);
+    keys.keyentries[0]->raw_key = NULL;
+    keys.keysize = 0;
+
+    expect_string(__wrap__minfo, formatted_msg, "https_client: starting.");
+    expect_string(__wrap__mdebug1, formatted_msg,
+                  "https_client: not enrolled yet (no client.keys); deferring start.");
 
     w_https_client_start();
     /* No hc_create expectation: must not be reached. */
@@ -1913,6 +1936,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_config_checksum_is_sha256_of_local_merged_file, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_config_checksum_is_empty_when_local_file_unreadable, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_missing_key_refuses_to_start, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_no_keystore_defers_at_debug, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_wrong_length_key_refuses_to_start, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_non_hex_key_refuses_to_start, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_valid_48_char_key_is_accepted, setup_test, teardown_test),

--- a/src/unit_tests/client-agent/test_https_client_bridge.c
+++ b/src/unit_tests/client-agent/test_https_client_bridge.c
@@ -1332,6 +1332,61 @@ static void test_startup_result_limits_unchanged_no_reload(void **state)
     w_https_client_stop();
 }
 
+/* on_agent_groups: the Notify-driven groups refresh (bug #11). Unlike
+ * bridge_apply_agent_groups() (Startup-only), this is the only thing that keeps
+ * agent_agent_groups from going stale after a group-only change, since settings_hash
+ * deliberately excludes groups and never re-triggers a Startup for one. */
+
+static void test_agent_groups_notify_updates_on_change(void **state)
+{
+    (void)state;
+    start_client_successfully();
+    strcpy(agent_agent_groups, "default");
+
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: agent groups -> default,test.");
+
+    g_captured_callbacks.on_agent_groups("default,test", g_captured_callbacks.user_data);
+
+    assert_string_equal(agent_agent_groups, "default,test");
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+static void test_agent_groups_notify_no_op_when_unchanged(void **state)
+{
+    (void)state;
+    start_client_successfully();
+    strcpy(agent_agent_groups, "default,test");
+
+    /* No "agent groups ->" log expected: unchanged, so the compare-before-write
+     * short-circuits before the log/republish. */
+    g_captured_callbacks.on_agent_groups("default,test", g_captured_callbacks.user_data);
+
+    assert_string_equal(agent_agent_groups, "default,test");
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+static void test_agent_groups_notify_preserves_empty(void **state)
+{
+    (void)state;
+    start_client_successfully();
+    strcpy(agent_agent_groups, "default");
+
+    /* Empty is a real, meaningful value here (agcom.c: fallback to merged.mg),
+     * never turned into "default" the way /download's own selector would. */
+    expect_string(__wrap__mdebug1, formatted_msg, "https_client: agent groups -> (none).");
+
+    g_captured_callbacks.on_agent_groups("", g_captured_callbacks.user_data);
+
+    assert_string_equal(agent_agent_groups, "");
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
 static void test_startup_result_missing_limits_object_leaves_limits_unchanged(void **state)
 {
     (void)state;
@@ -1979,6 +2034,9 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_startup_result_limits_unchanged_no_reload, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_startup_result_missing_limits_object_leaves_limits_unchanged, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_startup_result_cluster_and_groups_cleared_when_absent, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_agent_groups_notify_updates_on_change, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_agent_groups_notify_no_op_when_unchanged, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_agent_groups_notify_preserves_empty, setup_test, teardown_test),
         // Durable check-and-record callback
         cmocka_unit_test_setup_teardown(test_check_and_record_task_new_returns_one, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_check_and_record_task_duplicate_returns_zero_and_counts_it, setup_test, teardown_test),

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -93,6 +93,18 @@ static const std::map<std::string, std::vector<std::string>> MODULE_INDICES_MAP
         }
     }};
 
+// Indices tagged with agent metadata (cluster_name, cluster_node, groups) that are not owned by
+// any single coordinatable module -- wazuh-agent-config/wazuh-agent-stats are written by the
+// manager's /config and /stats endpoints (inventory_sync_server's configEndpoint/statsEndpoint)
+// from the periodic push in https_client's reporterStream, not by a wodle this module ever pauses.
+// A metadata/groups change must still re-tag them, so they are added unconditionally alongside
+// whatever COORDINATION_MODULES were actually paused this cycle.
+static const std::vector<std::string> AGENT_LEVEL_INDICES
+{
+    "wazuh-agent-config",
+    "wazuh-agent-stats"
+};
+
 const char* AGENT_METADATA_SQL_STATEMENT = "CREATE TABLE IF NOT EXISTS agent_metadata ("
                                            "agent_id          TEXT NOT NULL PRIMARY KEY,"
                                            "agent_name        TEXT,"
@@ -1941,6 +1953,11 @@ AgentInfoImpl::CoordinationResult AgentInfoImpl::coordinateModules(const std::st
             }
         }
 
+        // Not owned by any single coordinatable module, so never reached via the loop above --
+        // a metadata/groups change still needs to re-tag them regardless of which modules were
+        // actually paused this cycle.
+        indicesToSync.insert(indicesToSync.end(), AGENT_LEVEL_INDICES.begin(), AGENT_LEVEL_INDICES.end());
+
         if (m_spSyncProtocol)
         {
             SyncModuleResult syncResult = m_spSyncProtocol->synchronizeMetadataOrGroups(
@@ -2526,6 +2543,8 @@ bool AgentInfoImpl::performIntegritySync(const std::string& table)
         {
             indicesToCheck.insert(indicesToCheck.end(), indices.begin(), indices.end());
         }
+
+        indicesToCheck.insert(indicesToCheck.end(), AGENT_LEVEL_INDICES.begin(), AGENT_LEVEL_INDICES.end());
 
         // Perform integrity check - no globalVersion needed for CHECK modes
         SyncModuleResult syncResult = m_spSyncProtocol->synchronizeMetadataOrGroups(TABLE_CHECK_MODE_MAP.at(table), indicesToCheck);

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -86,13 +86,13 @@ public function config()
                 formatted_list = vbCrLf
                 for i=0 to UBound(ip_list)
                     If ip_list(i) <> "" Then
-                        formatted_list = formatted_list & "    <manager>" & vbCrLf
+                        formatted_list = formatted_list & "    <server>" & vbCrLf
                         formatted_list = formatted_list & "      <address>" & ip_list(i) & "</address>" & vbCrLf
-                        formatted_list = formatted_list & "      <port>1514</port>" & vbCrLf
+                        formatted_list = formatted_list & "      <port>1517</port>" & vbCrLf
                         if i = UBound(ip_list) then
-                            formatted_list = formatted_list & "    </manager>"
+                            formatted_list = formatted_list & "    </server>"
                         Else
-                            formatted_list = formatted_list & "    </manager>" & vbCrLf
+                            formatted_list = formatted_list & "    </server>" & vbCrLf
                         End If
                     End If
                 next
@@ -101,7 +101,10 @@ public function config()
 
             If WAZUH_MANAGER_PORT <> "" Then ' manager server_port
                 If InStr(strText, "<port>") > 0 Then
-                    strText = Replace(strText, "<port>1514</port>", "<port>" & WAZUH_MANAGER_PORT & "</port>")
+                    Set re = new regexp
+                    re.Pattern = "<port>.*</port>"
+                    re.Global = True
+                    strText = re.Replace(strText, "<port>" & WAZUH_MANAGER_PORT & "</port>")
                 End If
 
             End If
@@ -221,7 +224,12 @@ public function config()
         Set file = objFSO.OpenTextFile(home_dir & "profile-" & OS_VERSION & ".template", ForReading)
         newline = file.ReadAll
         file.Close
-        re.Pattern = "(</manager>)"
+        ' The shipped template uses <server> (the deprecated <manager> tag only
+        ' survives on an upgraded ossec.conf that predates that migration), so
+        ' this must anchor on either closing tag to keep inserting the profile
+        ' block right after the server/manager block on both fresh installs
+        ' and upgrades.
+        re.Pattern = "(</server>|</manager>)"
         re.Global = False
         strNewText = re.Replace(strNewText, "$1" & vbCrLf & "    " & newline)
     End If

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -11,9 +11,9 @@
       <address>0.0.0.0</address>
       <port>1517</port>
     </server>
-    <!-- HTTPS transport TLS settings; verification_mode: full|certificate|none (default: full) -->
-    <!-- TEMPORARY: shipped as 'none' to unblock the test suite (no CA available there);
-         revert to 'full' + a real <certificate_authorities> path before release. -->
+    <!-- HTTPS transport TLS settings; verification_mode: full|certificate|none (default: none).
+         Set to 'full' or 'certificate' and provide certificate_authorities to verify the
+         manager's certificate. -->
     <ssl>
       <certificate_authorities>PATH</certificate_authorities>
       <verification_mode>none</verification_mode>

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -7,12 +7,16 @@
 <ossec_config>
 
   <client>
-    <manager>
+    <server>
       <address>0.0.0.0</address>
-      <port>1514</port>
-    </manager>
+      <port>1517</port>
+    </server>
+    <!-- HTTPS transport TLS settings; verification_mode: full|certificate|none (default: full) -->
+    <ssl>
+      <certificate_authorities>PATH</certificate_authorities>
+      <verification_mode>full</verification_mode>
+    </ssl>
     <notify_time>20</notify_time>
-    <time-reconnect>60</time-reconnect>
     <auto_restart>yes</auto_restart>
   </client>
 

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -12,9 +12,11 @@
       <port>1517</port>
     </server>
     <!-- HTTPS transport TLS settings; verification_mode: full|certificate|none (default: full) -->
+    <!-- TEMPORARY: shipped as 'none' to unblock the test suite (no CA available there);
+         revert to 'full' + a real <certificate_authorities> path before release. -->
     <ssl>
       <certificate_authorities>PATH</certificate_authorities>
-      <verification_mode>full</verification_mode>
+      <verification_mode>none</verification_mode>
     </ssl>
     <notify_time>20</notify_time>
     <auto_restart>yes</auto_restart>

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -181,6 +181,15 @@ int local_start()
         mlerror_exit(LOGLEVEL_ERROR, CLIENT_ERROR);
     }
 
+    /* A verifying <ssl><verification_mode> without a readable CA can never connect (the
+     * https_client module fails closed on this, per its own validation) -- caught here, before
+     * any module thread is created, instead of failing much later inside w_https_client_start(). */
+    if (agt->ssl.verification_mode != AGENT_VERIFY_NONE &&
+        (!agt->ssl.certificate_authorities || !w_is_file(agt->ssl.certificate_authorities))) {
+        merror(AG_INV_SSL_CA, agt->ssl.certificate_authorities ? agt->ssl.certificate_authorities : "");
+        mlerror_exit(LOGLEVEL_ERROR, CLIENT_ERROR);
+    }
+
     if (agt->notify_time == 0) {
         agt->notify_time = NOTIFY_TIME;
     }
@@ -191,8 +200,6 @@ int local_start()
         agt->max_time_reconnect_try = (agt->notify_time * 3);
         minfo("Max time to reconnect can't be less than notify_time(%d), using notify_time*3 (%d)", agt->notify_time, agt->max_time_reconnect_try);
     }
-
-    startup_gate_initialize();
 
     if(agt->enrollment_cfg && agt->enrollment_cfg->enabled) {
         // If autoenrollment is enabled, we will avoid exit if there is no valid key
@@ -224,6 +231,11 @@ int local_start()
 
     /* Set wait lock before starting threads */
     os_setwait();
+
+    /* Enrollment (blocking until a valid key exists) and the startup gate
+     * must both be ready before the HTTPS client is ever started: it reads
+     * client.keys exactly once, at creation, with no retry on failure. */
+    start_agent_prepare();
 
     /* HTTPS client: the agent's only transport (mirrors AgentdStart on POSIX;
      * the Windows startup path is separate). Started before any producer

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -155,11 +155,10 @@ int local_start()
     /* Start agent */
     os_calloc(1, sizeof(agent), agt);
 
-    /* TEMPORARY: default to no TLS verification when <ssl> is absent from the config,
-     * so an unmodified pre-HTTPS config (upgrade case: no <ssl> block at all) doesn't
-     * hard-exit on AG_INV_SSL_CA. ClientConf()/Read_Client_SSL() below still overrides
-     * this to whatever <ssl><verification_mode> the config actually sets. Revert
-     * before release -- the correct default is AGENT_VERIFY_FULL (fail-closed). */
+    /* Default to no TLS verification when <ssl> is absent from the config -- e.g. an
+     * unmodified pre-HTTPS config (upgrade case: no <ssl> block at all), which would
+     * otherwise hard-exit on AG_INV_SSL_CA. ClientConf()/Read_Client_SSL() below still
+     * overrides this to whatever <ssl><verification_mode> the config actually sets. */
     agt->ssl.verification_mode = AGENT_VERIFY_NONE;
 
     /* Configuration file not present */

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -155,6 +155,13 @@ int local_start()
     /* Start agent */
     os_calloc(1, sizeof(agent), agt);
 
+    /* TEMPORARY: default to no TLS verification when <ssl> is absent from the config,
+     * so an unmodified pre-HTTPS config (upgrade case: no <ssl> block at all) doesn't
+     * hard-exit on AG_INV_SSL_CA. ClientConf()/Read_Client_SSL() below still overrides
+     * this to whatever <ssl><verification_mode> the config actually sets. Revert
+     * before release -- the correct default is AGENT_VERIFY_FULL (fail-closed). */
+    agt->ssl.verification_mode = AGENT_VERIFY_NONE;
+
     /* Configuration file not present */
     if (File_DateofChange(cfg) < 0) {
         merror_exit("Configuration file '%s' not found", cfg);


### PR DESCRIPTION
## Description

Bug fixes found while manually QA-ing a clean install of the agent-side HTTPS migration
(epic #37831, integration branch `enhancement/37831-agent-https-client`, tracked in PR #38012).
This branch (`fix/37831-https-agent-bugfixes`) collects fixes as they come up during that QA
pass, rather than filing one issue per bug.

<!-- Closes # (fill in per-bug issue numbers here as they get filed, if any) -->

**Resolved by aligning the agent, not the manager** (see bug #9 below): the manager's
`settings_hash` (`remoted_module/src/control/hashCache.cpp`) only ever hashes `limits` + `cluster`
— never `agent.groups` — and its own doc comment says this is deliberate. The agent's own
`config_hash`/`merged.mg` path already covers group-derived config changes, so `settings_hash`
narrowing to match the manager (rather than the other way around) loses nothing and needs no
manager-side change at all. A manager-side fix branch was drafted, then discarded in favor of
this.

## Proposed Changes

### Fixed

| # | What | Where |
|---|---|---|
| 1 | Agent's default port when `<server><port>` is unspecified silently fell back to the legacy `DEFAULT_REMOTE_PORT` (1514) instead of the manager's actual HTTPS listener default (1517, `DEFAULT_HTTPS_PORT` in `remoted_module/http_server/httpServerConfig.cpp`). On a clean install pointed at a real HTTPS manager with no explicit `<port>`, the agent tried the wrong port and never connected. | `src/config/include/client-config.h` (new `DEFAULT_HTTPS_CLIENT_PORT` macro), `src/config/src/client-config.c` (`Read_Client`, `Read_Client_Server`) |
| 2 | Every shipped/generated agent config template either omitted the `<ssl>` block entirely or hid it inside an XML comment, with no `<certificate_authorities>` placeholder — silently refusing to start the HTTPS transport with no visible template guidance pointing at the fix. `<ssl>` is now visible by default everywhere, with a `PATH` placeholder for `certificate_authorities` for whoever turns on `full`/`certificate` verification. **Product decision, 2026-08-06 (supersedes the 2026-08-05 "temporary" framing of this and bug #6): `verification_mode` defaults to `none`, permanently** — not a stopgap for the test suite. All three templates ship `none` as the stable default; `main.c`/`win_utils.c` set `agt->ssl.verification_mode = AGENT_VERIFY_NONE` right after allocating `agt` (before `ClientConf()` parses the real config, so an explicit `<ssl>` block still overrides it) as the agent's actual configured default for the "no `<ssl>` block at all" case (e.g. an upgraded pre-HTTPS config), covering what a template change alone can't reach. `client-config.h`'s `agent_verify_mode_t` doc comment updated to stop calling `AGENT_VERIFY_FULL` "the default" — it's the zero-initialized-struct fail-closed value (an invariant for callers that skip the agent's own default-setting path), not the agent's own configured one anymore. The resulting "TLS verification is DISABLED" log (`moduleConfig.cpp`) is downgraded from WARNING to INFO to match — it now reports the intended default, not an operator opt-out worth flagging. | `etc/ossec-agent.conf`, `src/win32/ossec.conf`, `src/init/inst-functions.sh` (`WriteAgent()` — the actual generator the interactive Linux tar/rpm/deb installer uses), `src/client-agent/src/main.c`, `src/win32/win_utils.c`, `src/config/include/client-config.h`, `src/client-agent/https_client/src/moduleConfig.cpp` |
| 3 | Same `WriteAgent()` generator also hardcoded the stale `<port>1514</port>` (same root cause as #1) for every interactive Linux install. | `src/init/inst-functions.sh` |
| 4 | `src/win32/ossec.conf` used the deprecated `<manager>` tag instead of `<server>` (emits a one-time deprecation warning on every fresh Windows install for no reason) and a dead `<time-reconnect>` option (no-op under the HTTPS transport, per `client-config.c`'s own deprecation warning). Cleaned up while touching this block. | `src/win32/ossec.conf` |
| 5 | On a fresh agent with no/empty `client.keys`, `AgentdStart()`/`local_start()` started the HTTPS client **before** enrollment ran. `bridge_build_config()` validates the signing key exactly once, at creation, with no retry — it saw the empty keystore, logged an ERROR ("agent key is missing or has an invalid length…"), and gave up permanently (single call site, no restart). Enrollment then ran and wrote a valid key moments later, but nothing ever restarted the client: the agent stayed enrolled yet unable to send events over HTTPS (silently dropped) until a manual restart. (Whether `modulesd`/`logcollector`/`execd` also hang forever on the HTTPS-only startup gate in this state depends on `<remote_conf>` being enabled — not confirmed for the reproducing config; the transport half of the bug holds either way.) Root-caused against the pre-HTTPS `5.0.0` behavior (`start_agent.c`'s `w_agentd_keys_init()`, which always blocked on enrollment *before* any transport was touched) — this was a regression introduced when the epic wired in the HTTPS client without re-checking that invariant. Fix: split key-init/enrollment (now `start_agent_prepare()`) out from the "report" phase and call it *before* `w_https_client_start()` on both POSIX and Windows; the ERROR log is now DEBUG for the genuinely-expected "never enrolled yet" case (`keys.keysize == 0`), reserving ERROR for an actually corrupt `client.keys`. | `src/client-agent/include/agentd.h`, `src/client-agent/src/start_agent.c`, `src/client-agent/src/agentd.c`, `src/win32/win_utils.c`, `src/client-agent/src/https_client_bridge.c` |
| 6 | Once bug #5 was fixed, a still-unreadable `<ssl><certificate_authorities>` (e.g. the shipped `PATH` placeholder never replaced with a real CA) surfaced a sibling issue: `https_client` fails its internal config validation and refuses to start, but `w_https_client_start()` just logs an ERROR and returns — the daemon (and every sibling process) keeps running, `systemctl status` reports `active (running)`, while the transport is permanently dead for the rest of the process's life (no retry, same "single call site" structure as #5, just a different unrecoverable precondition). Worse: on Linux, `wazuh-client.sh`'s `start_service()` launches `execd → agentd → syscheckd → logcollector → modulesd` *sequentially*, polling each daemon's PID file before starting the next — the exact guard rail that should stop a broken agent from launching the rest. But `agentd.c`'s `CreatePID()` runs immediately after forking, long before this (async, enrollment-gated) check ever runs, so the script sees "agentd is up" and starts every other daemon before the CA problem even surfaces. Real fix (two layers): (a) **the actual fix** — this is pure static config (`agt->ssl.*`, parsed before `AgentdStart()`/`local_start()` is even called), so it's now validated in `client-agent/src/main.c` and `win32/win_utils.c`, right next to the existing `Validate_Address()`/`Validate_IPv6_Link_Local_Interface()` checks, *before daemonizing* — mirrors that exact precedent (`merror` + `mlerror_exit`). This makes `wazuh-client.sh`'s existing sequential-start guard work correctly for free: agentd now fails before ever writing its PID file, so the script halts before starting syscheckd/logcollector/modulesd at all. (b) **defense-in-depth** — added `LOGFN_CRITICAL` (`shared_modules/utils/loggerHelper.h` had the level constant and the C-side exit-on-critical handling in `mtLoggingFunctionsWrapper`, `shared/src/debug_op.c`, already — the exact same log-then-`exit(1)` sequence as `_merror_exit`, just previously unreachable since no C++ call site could emit at that level) and switched the CA-missing check in `moduleConfig.cpp`'s `validateTls()` to it, in case this is ever reached anyway (e.g. a CA file that existed at main.c's check but was deleted before `w_https_client_start()` ran). Scoped narrowly: other `validate()` failures (missing `server_host`/`agent_id`, unknown `verify_mode`, mismatched client cert/key) are left at ERROR. | `src/client-agent/src/main.c`, `src/win32/win_utils.c`, `src/shared/include/error_messages/error_messages.h` (new `AG_INV_SSL_CA`), `src/shared_modules/utils/loggerHelper.h`, `src/client-agent/https_client/src/moduleConfig.cpp` |
| 7 | `HttpsClientFacade::controlLoop()` always slept the full `notify_interval_s` after *every* `/control` step, including right after a Startup was just accepted (first connect, reconnect, or a settings-refresh in place) — but hashes and any pending tasks only ever arrive on Notify, so this added a full, avoidable ~20s (default) dead gap before the agent could even learn about a settings/config mismatch or a pending task. The state machine already computed an `Effects::resetCadence` flag exactly on Startup-accepted (`controlStateMachine.cpp`), but it was dead code — never consumed anywhere. Wired it through: new `ControlStream::consumeFastFollowup()` (consume-once) surfaces it, and `controlLoop()` now waits only 1s (not the full interval) for the one step immediately following any Startup acceptance. New unit test `FastFollowupArmedOnceAfterStartupAccepted`; checked the e2e/component tests aren't affected (already configured with `notify_interval_s=1`, so no timing-math change there). **Extended further**: a second, separate gap existed between a settings_hash mismatch being *detected* on Notify (`maybeArmSettingsRefresh()`'s `SettingsChanged` event, which doesn't go through `StartupAccepted`) and the refresh Startup it queues actually being *sent* — that transition wasn't covered by the above, so it still waited a full cycle. `config_hash` never had this problem (`maybeDownloadConfig()` fetches inline, same cycle, no queuing). `maybeArmSettingsRefresh()` now also sets the fast-followup flag directly when arming a refresh. New unit test `FastFollowupAlsoArmedWhenASettingsRefreshIsQueued`. | `src/client-agent/https_client/src/controlStateMachine.hpp`, `src/client-agent/https_client/src/controlStream.hpp`, `src/client-agent/https_client/src/controlStream.cpp`, `src/client-agent/https_client/src/httpsClientFacade.cpp`, `src/client-agent/https_client/tests/unit/controlStream_test.cpp` |
| 8 | Added DEBUG2-level tracing for the `settings_hash`/`config_hash` comparisons in `controlStream.cpp`, logging both the manager-reported and locally-computed values at the exact point of comparison (`sendStartup()`'s baseline computation, `maybeArmSettingsRefresh()`, `maybeDownloadConfig()`) — previously only the *mismatch* case was logged (and only the manager's value, never the agent's own baseline side by side), making it hard to see exactly where/why two hashes diverge without reproducing the hash by hand. No functional change; pure observability, gated behind DEBUG2 so it's silent by default. | `src/client-agent/https_client/src/controlStream.cpp` |
| 9 | The `settings_hash` mismatch (bug behind the warning above) was root-caused to the agent and manager hashing different documents: the agent hashed the *entire* `/control` startup response (`limits`+`cluster`+`agent.groups`), the manager's `HashCache::getSettingsHash()` hashes only `limits`+`cluster` — and, verified directly, that method takes **zero parameters** at every layer (`hashCache.hpp:40`, `.cpp:163`, call site `controlHandler.cpp:469`), so it structurally cannot vary per-agent/per-group; its own doc comment says this is deliberate. A manager-side fix (parameterize `getSettingsHash` by `groupsCsv`, mirroring the adjacent `getConfigHash`/`mergedMgPath` pattern) was drafted and then discarded: `config_hash`/`merged.mg` already covers group-derived config changes, so narrowing the *agent's* hash to match the manager (rather than making the manager match a spec that contradicts its own code) is the smaller, lower-risk change, and needs no manager-side edit at all. New `ControlStream::computeSettingsHash()` extracts and re-hashes only `limits`+`cluster` from the startup response, matching the manager exactly. Updated two unit tests that were hashing raw literal bytes (now nlohmann::json-inconsistent with the new field-extraction approach — object keys always dump alphabetically, so a literal source string doesn't reproduce it) via a new `managerSettingsHash()` test helper, and updated the component test double `fakeManager.hpp` (`fakeManagerSettingsHash()`) the same way, so it keeps accurately simulating the real manager. | `src/client-agent/https_client/src/controlStream.hpp`, `src/client-agent/https_client/src/controlStream.cpp`, `src/client-agent/https_client/tests/unit/controlStream_test.cpp`, `src/client-agent/https_client/tests/component/fakeManager.hpp` |
| 10 | An agent in 2+ groups (e.g. `default,test`) looped forever failing to apply its config: `handleNotifyBody()` requested `/download` with only `firstGroup(*agent)` — literally the first element of the reported `groups` array — while the manager's advertised `config_hash` is for the agent's *full* group set (`controlHandler.cpp`'s `toGroupsCsv(refreshedEntry->groups)`, `hashCache.cpp`'s `getMergedMgPath(groupsCsv)`). The agent downloaded the single-group `merged.mg`, its hash never matched the multi-group hash the manager advertised (`configFetcher.cpp`: "Downloaded config hash ... does not match the advertised ...; discarding it."), and it retried every notify, forever. Verified against the manager too: `src/remoted/remoted_module/src/endpoints/downloadEndpoint.cpp`'s `/download` endpoint already natively accepts a comma-separated multi-group selector as `resource_id` (`isValidGroupSelector()`, `GROUP_SEPARATOR = ','`) — the manager side was already built for this, the agent just wasn't using it. Fix: renamed `firstGroup()` to `groupsCsv()`, now joining every reported group with commas, in the exact order the manager itself reported them (order matters — it's what makes the CSV byte-identical to what the manager hashed). New unit test `MultiGroupAgentRequestsAllGroupsCommaJoined`; existing single-group tests are unaffected (a one-element CSV has no comma, same string as before). | `src/client-agent/https_client/src/controlStream.cpp`, `src/client-agent/https_client/tests/unit/controlStream_test.cpp`, `src/client-agent/src/https_client_bridge.c` (stale comment reference only) |
| 11 | `agent_agent_groups` (the C global feeding `agcom_gethandshake()`'s local IPC response, and seeded into agent metadata) went stale forever after a group-only change: its only writer, `bridge_apply_agent_groups()`, runs only from `bridge_on_startup_result()` — and, after bug #9, a group-only change no longer re-triggers a Startup (`settings_hash` deliberately excludes groups; `config_hash` covers the group's own config content, not the manager-side membership list). Not a regression from bug #9 — a pre-existing gap since the bridge was introduced (a group-only change never re-armed the old, groups-inclusive `settings_hash` twice either, since the loop-breaker latches on the first mismatch). Impact was contained (agent-info re-derives groups from `merged.mg` every cycle and self-corrects), but the `agcom` field itself never recovers without an agentd restart. Fix: new `on_agent_groups(groups_csv, user_data)` ABI callback (`ICallbackSink::onAgentGroups`) that `handleNotifyBody()` fires whenever the Notify-reported group set changes since the last report (Startup or Notify) — separate from `onStartupResult`, since reusing that would also overwrite cluster identity, which a Notify body doesn't carry. New `rawGroupsCsv()` split out from the existing `groupsCsv()` (which still substitutes `"default"` for `/download`'s benefit): the new callback must report a genuinely empty group set as empty, since `agcom.c` treats that as meaningful ("fallback to merge.mg"), not as a synonym for `"default"`. Bridge side: `bridge_on_agent_groups()` compares before writing (defense in depth) and republishes metadata only on an actual change. New unit tests `AgentGroupsReportedOnFirstNotifyThenOnlyOnChange`, `AgentGroupsReportsEmptyRatherThanDefaultFallback`. | `src/client-agent/https_client/include/https_client.h`, `src/client-agent/https_client/src/callbackSink.hpp`, `src/client-agent/https_client/src/callbackDispatcher.hpp`, `src/client-agent/https_client/src/callbackDispatcher.cpp`, `src/client-agent/https_client/src/controlStream.hpp`, `src/client-agent/https_client/src/controlStream.cpp`, `src/client-agent/https_client/tests/unit/mocks/mockCallbackSink.hpp`, `src/client-agent/https_client/tests/unit/controlStream_test.cpp`, `src/client-agent/src/https_client_bridge.c` |
| 12 | Every stateless event sent by a Linux/macOS agent arrived at the manager with a trailing `0x00` byte appended to its JSON content (seen in `event.original`). Root cause: `EventForward()` (`event-forward.c`) passes the raw `recv()`-returned datagram length straight to `w_https_client_submit_event()`, but `SendMSGAction()` (`shared/src/mq_op.c`) writes these frames via `OS_SendUnix(..., 0)`, whose `size == 0` ("it's a C string") convention sends `strlen(msg) + 1` bytes — the NUL terminator rides along as part of the datagram. The pre-HTTPS legacy code compensated for this explicitly (`send_msg(msg, -1)` resolved to `strlen()` for text frames); commit `6867e35baa` ("route the agent's events to /stateless only") collapsed both frame classes into the raw datagram length and lost that compensation. Since `hc_submit_event`/the whole `/stateless` pipeline is strictly length-delimited (never NUL-terminated), the extra byte rode all the way to the wire uncaught — the AES-CMAC signs the corrupted body consistently, so the manager accepts it without any error, it just stores the extra byte. Windows was never affected (`win_utils.c` already calls `w_https_client_submit_event(tmpstr, strlen(tmpstr))` directly, no queue involved). Fix: trim exactly one trailing NUL from the datagram length before handing it to the transport, mirroring the legacy compensation. **Known gap**: no unit test added — `EventForward()` has no existing CMocka coverage in this tree, and the shared `__wrap_recv` test wrapper is a fixed, magic-fd-keyed stub built for other tests' scenarios, not a controllable mock; standing up a clean one needs new CMakeLists wiring (`--wrap` flags) I didn't want to get wrong unbuilt. Worth adding before merge. | `src/client-agent/src/event-forward.c` |
| 13 | `ConfigFetcher::fetch()` logged a WARNING on every `/download` failure, including the transient window right after a group membership change where the manager reports `config_hash: "0"` — its own sentinel for "no resolved config for this group set yet" (see bug #10/#11's investigation). Confirmed with the manager team: `"0"` is an expected, legitimate value, not an anomaly, so a download attempt failing because of it (or any other transient reason — the next notify re-triggers it regardless of cause) isn't operator-actionable. Fix: downgraded unconditionally to DEBUG1, simpler than conditioning on `expectedHash == "0"` specifically. **Known gap**: no test added — this gtest suite (`controlStream_test.cpp`) has no log-level assertion mechanism at all (no test here ever wires up `Log::assignLogFunction`); standing one up for a one-line severity change is out of scope. | `src/client-agent/https_client/src/configFetcher.cpp` |


### Results and Evidence

All excerpts below are from real `ossec.log` runs (`agent.debug=2`) against a real manager
(vagrant AIO box, 192.168.1.233) during this QA pass, on the built agent binary. No `ctest`/CMocka
run has been done this session — only live agent behavior is evidenced here.

**Bug #5 (enroll before HTTPS client starts).** Enrollment completes and `w_agentd_keys_init()`
returns *before* `w_https_client_start()` is ever called:
```
2026/08/05 19:27:23 wazuh-agentd[884391] enrollment_op.c:468 at w_enrollment_process_agent_key(): INFO: Valid key received
...
2026/08/05 19:27:43 wazuh-agentd[884391] start_agent.c:112 at w_agentd_keys_init(): DEBUG: Using AES as encryption method.
2026/08/05 19:27:43 wazuh-agentd[884391] https_client_bridge.c:1513 at w_https_client_start(): INFO: https_client: starting.
```

**Bug #6 (fail fast before daemonizing on an invalid SSL config).** The new `main.c` check firing
exactly as designed against a genuine pre-HTTPS upgrade config with no `<ssl>` block at all (this
is also what prompted the temporary `verification_mode=none` override — see bug #2):
```
2026/08/05 23:44:27 wazuh-agentd: ERROR: (4118): <ssl><verification_mode> is not 'none' but <certificate_authorities> is missing or unreadable: ''.
2026/08/05 23:44:27 wazuh-agentd: ERROR: (1215): No client configured. Exiting.
wazuh-agentd: Configuration error. Exiting
```

**Bug #7 (fast-followup notify).** Startup accepted and the following Notify sent ~1s later
(previously would have waited the full `notify_interval_s`, 20s by default):
```
2026/08/05 20:14:59 wazuh-agentd:https-client[911837] httpsClientFacade.cpp:89 at start(): INFO: Starting https_client (server=192.168.1.233:1517, agent=007).
2026/08/05 20:14:59 wazuh-agentd[911837] https_client_bridge.c:1134 at bridge_on_state_change(): DEBUG: https_client connection state -> registered (2)
2026/08/05 20:15:00 wazuh-agentd:https-client[911837] controlStream.cpp:300 at sendNotify(): DEBUG: Sending /control notify.
```

**Bug #8 (hash comparison debug logs).** Both sides visible at the exact point of comparison,
where previously only a mismatch (and only the manager's value) was ever logged:
```
2026/08/05 19:57:45 wazuh-agentd:https-client[911837] controlStream.cpp:446 at maybeArmSettingsRefresh(): DEBUG: settings_hash check: manager=504421067d411b3efa6165073eda60fabd0cded3ad28c0691af4ab00d78d78f6 local=504421067d411b3efa6165073eda60fabd0cded3ad28c0691af4ab00d78d78f6
```

**Bug #9 (settings_hash converges).** `manager=` and `local=` identical on every single Notify for
the full agent lifetime, in a run that previously logged `WARNING: settings_hash ... still
mismatches after a refresh` on every cycle:
```
2026/08/05 19:57:45 ... settings_hash check: manager=504421067d411b3efa6165073eda60fabd0cded3ad28c0691af4ab00d78d78f6 local=504421067d411b3efa6165073eda60fabd0cded3ad28c0691af4ab00d78d78f6
2026/08/05 20:00:06 ... settings_hash check: manager=504421067d411b3efa6165073eda60fabd0cded3ad28c0691af4ab00d78d78f6 local=504421067d411b3efa6165073eda60fabd0cded3ad28c0691af4ab00d78d78f6
```
(No `WARNING: ... still mismatches` line appears anywhere in this run, from Startup through
shutdown.)

**Bug #10 (multi-group `/download`).** Agent added to a second group mid-run; the download
correctly requests both groups joined, and converges on the very next Notify (no repeat loop):
```
2026/08/05 20:16:01 ... INFO: Manager config hash 16843afaa8342b5b72c5f1c72b912c3e79c36d6ce61ce932279964587f63d93a differs from the local one; downloading the new configuration (group 'default,test').
2026/08/05 20:16:01 ... DEBUG: Sending /download (resource_type=config, resource_id='default,test').
2026/08/05 20:16:01 ... DEBUG: Config download (resource_id='default,test') delivered by the manager.
2026/08/05 20:16:21 ... config_hash check: manager=16843afaa8342b5b72c5f1c72b912c3e79c36d6ce61ce932279964587f63d93a local=16843afaa8342b5b72c5f1c72b912c3e79c36d6ce61ce932279964587f63d93a
```

**Bug #11 (agent_groups propagated from Notify).** `bridge_on_agent_groups()` firing on a
Notify-only group change (no agentd restart, no Startup):
```
2026/08/05 21:41:09 wazuh-agentd[967465] https_client_bridge.c:912 at bridge_on_agent_groups(): DEBUG: https_client: agent groups -> default,test,test2.
```

**Bug #12 (trailing NUL on `/stateless`).** <!-- User to add a capture of the affected events
(before/after) here. -->

### Artifacts Affected

- `wazuh-agentd` (Linux): default `<server><port>` behavior when unspecified, the config
  generated by the interactive installer (`install.sh` → `WriteAgent()`), the pre-daemonize SSL
  validation in `main.c`, the startup ordering in `AgentdStart()`, and the `/stateless` event
  forwarding path (`event-forward.c`).
- `wazuh-agentd` (Windows): shipped default `ossec.conf` template (`src/win32/ossec.conf`), the
  pre-daemonize SSL validation and startup ordering in `win_utils.c`'s `local_start()`.
- `libhttps_client` (the C++ transport module, both platforms): `/control` Startup/Notify timing
  (bugs #7), `settings_hash`/`config_hash` computation and logging (bugs #8, #9, #10), and
  agent-group propagation to the C bridge (bug #11).
- `etc/ossec-agent.conf`: static reference/default template.

### Configuration Changes

- Default `<server><port>` (when the tag is omitted) changes from `1514` to `1517`, matching the
  manager's HTTPS listener default. No effect on configs that already set `<port>` explicitly.
- The `<ssl>` block is now emitted/shown by default (with a `PATH` placeholder for
  `certificate_authorities`) everywhere it was previously absent or commented out.
  `verification_mode` defaults to `none` (see bug #2) — a permanent product decision
  (2026-08-06), not a stopgap. Templates ship it explicitly; `main.c`/`win_utils.c` also set it as
  the agent's actual configured default for the "no `<ssl>` block at all" case (e.g. an upgraded
  pre-HTTPS config).

### Documentation Updates

<!-- TODO -->

### Tests Introduced

- `src/unit_tests/client-agent/test_https_client_bridge.c`: new `test_no_keystore_defers_at_debug`
  (bug #5's DEBUG-vs-ERROR split, `keys.keysize == 0`). Updated `set_agent_key()` to set
  `keys.keysize = 1`, matching production's `OS_AddKey()`/`OS_ReadKeys()` semantics, so the three
  existing invalid-key tests keep exercising the (still correct) ERROR branch for a genuinely
  corrupt `client.keys`.
- No new tests yet for the reordering itself (`start_agent_prepare()` / `AgentdStart()` /
  `local_start()`): neither `test_agentd.c` nor `test_win_utils.c` exercises those functions'
  control flow today (verified — grep for `AgentdStart`/`local_start` in both finds no callers);
  this PR doesn't change that. `test_start_agent.c`'s existing `start_agent(0)` no-op test still
  holds unchanged.
- Bug #6 (`LOGFN_CRITICAL`): no new gtest added yet. Existing `moduleConfig_test.cpp` cases for
  the CA-missing branch (`FullModeFailsClosedWithoutCa`, `FullModeFailsClosedWhenCaUnreadable`,
  `CertModeAlsoRequiresCa`) keep passing unchanged — `TEST_LOG`'s sink is intentionally left
  unassigned in that file ("LOGFN_* are no-ops"), so switching ERROR→CRITICAL doesn't change what
  they assert (`EXPECT_FALSE(...validate(...))`), and none of them risk an actual `exit(1)`.
  Checked every component test that exercises `HC_VERIFY_FULL`/`HC_VERIFY_CERT`
  (`tlsVerification_component_test.cpp` only) — all supply a real, readable CA path, so none hit
  this branch either. A dedicated test asserting the CRITICAL level itself (e.g. a mock log sink
  capturing the level argument) is still worth adding.
- Bug #11 (`on_agent_groups`): new gtest cases `AgentGroupsReportedOnFirstNotifyThenOnlyOnChange`
  and `AgentGroupsReportsEmptyRatherThanDefaultFallback` (`controlStream_test.cpp`), plus new
  cmocka cases `test_agent_groups_notify_updates_on_change`,
  `test_agent_groups_notify_no_op_when_unchanged` and `test_agent_groups_notify_preserves_empty`
  (`test_https_client_bridge.c`) covering the C-side dedup/write/republish. `MockCallbackSink`
  updated with the new `onAgentGroups` method (pure virtual on `ICallbackSink`, would otherwise
  fail to instantiate).
- Bug #12 (trailing NUL on `/stateless`): **no test added.** `EventForward()` has no existing
  CMocka coverage in this tree; the shared `__wrap_recv` wrapper (`wrappers/linux/socket_wrappers.c`)
  is a fixed, magic-fd-keyed stub built for other tests' scenarios, not a controllable mock for
  this one. Standing up a clean test needs new CMakeLists `--wrap` wiring I didn't want to get
  wrong unbuilt (`recv`, `w_https_client_submit_event`, `w_agentd_state_update`). Worth adding
  before merge.
- <!-- TODO: build + run the full cmocka suite AND the https_client gtest suite in Docker to
  confirm all of the above, and the client-config parsing tests for bugs #1-4, actually pass --
  not yet done this session -->

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
