### PR TITLE
Fix wildcard matching in the installed-files check

### DIFF
--- a/.github/actions/check_files/check_files.py
+++ b/.github/actions/check_files/check_files.py
@@ -258,6 +258,31 @@ def get_current_items(scan_path='/var/ossec', size_check=False, ignore_names=[])
 """
 
 
+def path_match(filename, pattern):
+    """Match a filename against a glob pattern segment by segment.
+
+    A wildcard is not allowed to span path separators: both the filename
+    and the pattern are split into their components and each pair is
+    matched independently. This keeps a '*' from crossing a directory
+    boundary regardless of how many characters it expands to. Both '/'
+    (Unix) and '\\' (Windows) separators are supported.
+
+    Args:
+        filename (str): The current file path being checked.
+        pattern (str): The expected path, possibly containing glob wildcards.
+
+    Returns:
+        bool: True if the filename matches the pattern.
+    """
+    file_parts = filename.replace('\\', '/').split('/')
+    pattern_parts = pattern.replace('\\', '/').split('/')
+
+    if len(file_parts) != len(pattern_parts):
+        return False
+
+    return all(fnmatch.fnmatch(f, p) for f, p in zip(file_parts, pattern_parts))
+
+
 def csv_to_dict(file_path, key_column):
     data_dict = {}
 
@@ -466,9 +491,10 @@ if __name__ == "__main__":
             # 2. Check for matches with glob patterns if no exact match found
             if not matched:
                 for pattern, expected_item_fields in glob_patterns.items():
-                    # Check if the pattern matches the current file name
-                    # Note: Only the current directory is considered (no subdirectories)
-                    if fnmatch.fnmatch(current_file_name, pattern) and '/' not in current_file_name[len(pattern)-1:]:
+                    # Check if the pattern matches the current file name.
+                    # Matching is done per path segment so a wildcard never
+                    # spans a directory separator.
+                    if path_match(current_file_name, pattern):
                         matched = True
                         matches[pattern] = True
 

--- a/.github/actions/check_files/test_check_files.py
+++ b/.github/actions/check_files/test_check_files.py
@@ -1,0 +1,60 @@
+import sys
+import types
+
+import pytest
+
+# check_files.py imports pandas at module load time, but path_match does not
+# need it. Provide a lightweight stub so the module can be imported in a plain
+# test environment (the real pandas is used if it happens to be installed).
+sys.modules.setdefault('pandas', types.ModuleType('pandas'))
+
+from check_files import path_match  # noqa: E402
+
+
+class TestPathMatch:
+    """Tests for the glob matching used against the expected-files CSV."""
+
+    @pytest.mark.parametrize("filename", [
+        # The temp directory name expands to different lengths; every one of
+        # these must match the same pattern. Long expansions used to break the
+        # previous length-based check and were wrongly reported as unexpected.
+        "/var/ossec/tmp/sca-4.9-x-tmp/rhel/8/sca.files",
+        "/var/ossec/tmp/sca-4.14.8-a1b2c3-tmp/rhel/8/sca.files",
+        "/var/ossec/tmp/sca-4.14.8-12345678901234-tmp/rhel/8/sca.files",
+        "/var/ossec/tmp/sca-4.14.8-0000000000000000000000-tmp/rhel/8/sca.files",
+    ])
+    def test_wildcard_in_middle_segment_any_length(self, filename):
+        pattern = "/var/ossec/tmp/sca-4.*-*-tmp/rhel/8/sca.files"
+        assert path_match(filename, pattern)
+
+    def test_wildcard_does_not_cross_directory_separator(self):
+        # A '*' inside a segment must not swallow additional directories.
+        pattern = "/var/ossec/tmp/sca-4.*-*-tmp/rhel/8/sca.files"
+        filename = "/var/ossec/tmp/sca-4.14.8-x/extra/y-tmp/rhel/8/sca.files"
+        assert not path_match(filename, pattern)
+
+    def test_trailing_wildcard_matches_exact_and_suffix(self):
+        pattern = "/var/ossec/ruleset/sca/cis_alma_linux_8.yml*"
+        assert path_match("/var/ossec/ruleset/sca/cis_alma_linux_8.yml", pattern)
+        assert path_match("/var/ossec/ruleset/sca/cis_alma_linux_8.yml.gz", pattern)
+
+    def test_trailing_wildcard_does_not_match_deeper_path(self):
+        pattern = "/var/ossec/ruleset/sca/cis_alma_linux_8.yml*"
+        filename = "/var/ossec/ruleset/sca/cis_alma_linux_8.yml/child"
+        assert not path_match(filename, pattern)
+
+    def test_different_segment_count_is_not_a_match(self):
+        pattern = "/var/ossec/tmp/sca-4.*-*-tmp/rhel/8/sca.files"
+        assert not path_match("/var/ossec/tmp/sca-4.14.8-x-tmp/rhel/8", pattern)
+
+    def test_literal_path_without_wildcards(self):
+        pattern = "/var/ossec/etc/ossec.conf"
+        assert path_match("/var/ossec/etc/ossec.conf", pattern)
+        assert not path_match("/var/ossec/etc/ossec.conf.bak", pattern)
+
+    def test_windows_backslash_paths(self):
+        pattern = r"C:\Program Files (x86)\ossec-agent\*.dll"
+        assert path_match(r"C:\Program Files (x86)\ossec-agent\dbsync.dll", pattern)
+        # The wildcard must stay within its segment on Windows too.
+        assert not path_match(
+            r"C:\Program Files (x86)\ossec-agent\sub\dbsync.dll", pattern)


### PR DESCRIPTION
## Description

The `check_files` GitHub Action validates that the files installed under `/var/ossec` match an expected CSV manifest per package. Manifest entries may contain glob wildcards, most notably the SCA temporary directory whose name expands at runtime (e.g. `sca-4.*-*-tmp`).

The previous matching combined `fnmatch` with a length-based guard (`'/' not in current_file_name[len(pattern)-1:]`) intended to stop a wildcard from spanning directory separators. Because that guard sliced the current path at an offset derived from the *pattern* length, its result depended on how many characters the wildcard expanded to. When the temporary directory name was long enough, valid files were reported as unexpected and the check failed, even though the file was correct.

This change replaces the length-based heuristic with per-segment matching, so a wildcard is confined to a single path component regardless of its expanded length. Both `/` (Unix) and `\` (Windows) separators are handled.

Closes: https://github.com/wazuh/wazuh/issues/38211

## Proposed Changes

- Added a `path_match(filename, pattern)` helper that splits both the path and the pattern into components and matches them component by component with `fnmatch`, requiring an equal number of segments.
- Replaced the fragile `fnmatch(...) and '/' not in current_file_name[len(pattern)-1:]` condition in the comparison loop with a call to `path_match`.

### Results and Evidence

🟢 https://github.com/wazuh/wazuh-agent-packages/actions/runs/31086473840

### Artifacts Affected

None. The change is limited to the CI validation tooling and does not modify any packaged or installed file.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

Added `.github/actions/check_files/test_check_files.py` with cases covering:

- Mid-segment wildcards matching the SCA temporary directory across a range of expanded lengths (the regression that previously failed).
- Wildcards not crossing a directory separator (Unix and Windows).
- Trailing wildcards matching an exact name and a suffix, but not a deeper path.
- Mismatching segment counts, and literal paths without wildcards.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
