### PR TITLE
Validate CDB list paths in list-retrieval and delete cluster callables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Restricted the upgrade commands accepted from the agent message channel in Analysisd. ([#37745](https://github.com/wazuh/wazuh/pull/37745))
 - Added destination path validation when deleting rule and decoder files. ([#37838](https://github.com/wazuh/wazuh/pull/37838))
 - Added source path validation when retrieving CDB list files. ([#37901](https://github.com/wazuh/wazuh/pull/37901))
+- Added path validation when listing and deleting CDB list files. ([#38214](https://github.com/wazuh/wazuh/pull/38214))
 - Fixed the `aws-s3` wodle failing to parse configuration values that contain spaces, such as `discard_regex`, `discard_field`, `aws_profile`, `aws_account_alias`, `path` and `path_suffix`. ([#37929](https://github.com/wazuh/wazuh/pull/37929))
 - Fixed wazuh-db exiting the worker thread instead of closing the peer socket when an oversized message is received. ([#37850](https://github.com/wazuh/wazuh/pull/37850))
 - Improved SCA policy source validation to correctly enforce the `sca.remote_commands` restriction. ([#37953](https://github.com/wazuh/wazuh/pull/37953))

--- a/framework/wazuh/cdb_list.py
+++ b/framework/wazuh/cdb_list.py
@@ -61,8 +61,10 @@ def get_lists(filename: list = None, offset: int = 0, limit: int = common.DATABA
 
     lists = list()
     for path in get_filenames_paths(filename):
-        # Only files which exist and whose dirname is the one specified by the user (if any), will be added to response.
-        if not any([dirname is not None and path_dirname(path) != dirname, not isfile(path)]):
+        # Only files which exist, stay inside the lists directory and whose dirname is the one specified by the
+        # user (if any), will be added to response.
+        if not any([dirname is not None and path_dirname(path) != dirname, not isfile(path),
+                    commonpath([realpath(path), realpath(common.USER_LISTS_PATH)]) != realpath(common.USER_LISTS_PATH)]):
             lists.append({'items': [{'key': key, 'value': value} for key, value in get_list_from_file(path).items()],
                           'relative_dirname': path_dirname(to_relative_path(path)),
                           'filename': split(to_relative_path(path))[1]})
@@ -189,6 +191,9 @@ def delete_list_file(filename: list) -> AffectedItemsWazuhResult:
     full_path = join(common.USER_LISTS_PATH, filename[0])
 
     try:
+        # Ensure the resolved path stays inside the lists directory.
+        if commonpath([realpath(full_path), realpath(common.USER_LISTS_PATH)]) != realpath(common.USER_LISTS_PATH):
+            raise WazuhError(1804, extra_message=f"{filename[0]} is outside the lists directory")
         delete_list(to_relative_path(full_path))
 
         result.affected_items.append(to_relative_path(full_path))

--- a/framework/wazuh/tests/test_cdb_list.py
+++ b/framework/wazuh/tests/test_cdb_list.py
@@ -422,3 +422,38 @@ def test_delete_list_file_ko():
     with patch('wazuh.cdb_list.common.USER_LISTS_PATH', new=DATA_PATH):
         result = delete_list_file(['test_file'])
         assert result.render()['data']['failed_items'][0]['error']['code'] == 1906
+
+
+@patch('wazuh.cdb_list.common.USER_LISTS_PATH', new=DATA_PATH)
+def test_get_lists_outside_lists_path():
+    """Check that a file resolving outside the lists directory is not read nor returned."""
+    outside_file = os.path.join(DATA_PATH, os.pardir, 'outside_list')
+    try:
+        with open(outside_file, 'w') as f:
+            f.write('key:value\n')
+        with patch('wazuh.cdb_list.get_filenames_paths', return_value=[outside_file]):
+            with patch('wazuh.cdb_list.get_list_from_file') as mock_get_list_from_file:
+                result = get_lists(filename=['outside_list'])
+                assert isinstance(result, AffectedItemsWazuhResult)
+                assert result.total_affected_items == 0
+                assert result.affected_items == []
+                mock_get_list_from_file.assert_not_called()
+    finally:
+        try:
+            os.remove(outside_file)
+        except Exception:
+            pass
+
+
+@pytest.mark.parametrize("filename", [
+    '../../../../../../etc/passwd',
+    os.path.join(DATA_PATH, os.pardir, 'rbac.db'),
+])
+@patch('wazuh.cdb_list.common.USER_LISTS_PATH', new=DATA_PATH)
+@patch('wazuh.cdb_list.delete_list')
+def test_delete_list_file_path_traversal(mock_delete_list, filename):
+    """Check that a filename resolving outside the lists directory is rejected and not deleted."""
+    result = delete_list_file([filename])
+    assert isinstance(result, AffectedItemsWazuhResult)
+    assert result.render()['data']['failed_items'][0]['error']['code'] == 1804
+    mock_delete_list.assert_not_called()


### PR DESCRIPTION
## Description
`get_lists()` and `delete_list_file()` built filesystem paths from a caller-supplied filename without verifying that the resolved path stayed inside the CDB lists directory (`etc/lists`). Reached through the internal cluster RPC path — which bypasses the REST/OpenAPI parameter validators — this let a cluster peer read a class of files and delete files outside the lists directory on the master. The fix adds a `realpath`/`commonpath` containment check to both functions, matching the pattern already applied to `get_list_file` and the rule/decoder delete helpers.

## Proposed Changes
- `framework/wazuh/cdb_list.py`: `get_lists()` now skips any resolved path that falls outside `USER_LISTS_PATH`; `delete_list_file()` now raises `WazuhError(1804)` when the resolved path escapes `USER_LISTS_PATH`, before any deletion is attempted.
- `framework/wazuh/tests/test_cdb_list.py`: added tests covering both functions with traversal and absolute-path inputs.
- `CHANGELOG.md`: added an entry under `v4.14.8` → Manager → Fixed.

### Results and Evidence
New tests fail before the fix and pass after it. Full `test_cdb_list.py` suites pass with no regressions.

```
# Without the fix (source reverted):
FAILED test_cdb_list.py::test_get_lists_outside_lists_path
FAILED test_cdb_list.py::test_delete_list_file_path_traversal[../../../../../../etc/passwd]
FAILED test_cdb_list.py::test_delete_list_file_path_traversal[.../test_cdb_list/../rbac.db]
3 failed

# With the fix:
framework/wazuh/tests/test_cdb_list.py .................... (and core suite)
96 passed
```

### Artifacts Affected
Wazuh manager — bundled framework (`framework/wazuh/cdb_list.py`). No C/C++ components affected.

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
- `framework/wazuh/tests/test_cdb_list.py::test_get_lists_outside_lists_path`
- `framework/wazuh/tests/test_cdb_list.py::test_delete_list_file_path_traversal` (parametrized: traversal and absolute-path inputs)

## Credits
Reported by @yoojoon2.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
