### PR TITLE
Rightsize codebuild runners

### DIFF
--- a/.github/workflows/5_builderpackage_engine-standalone.yml
+++ b/.github/workflows/5_builderpackage_engine-standalone.yml
@@ -132,7 +132,11 @@ jobs:
   check_standalone_engine:
     name: Test standalone engine (${{ matrix.arch }})
 
-    runs-on: ${{ matrix.arch == 'arm64' && format('codebuild-github-actions-codebuild-runner-server-arm-{0}-{1}', github.run_id, github.run_attempt) || format('codebuild-github-actions-codebuild-runner-server-amd-{0}-{1}', github.run_id, github.run_attempt) }}
+    # `small` instance (2 vCPU, 3.0 GiB usable): downloads and starts the prebuilt engine,
+    # no compilation. Measured 5/5 passes per architecture, peak 0.9 GiB, duration unchanged
+    # at 0.8 min (x64) / 0.3 min (arm64). The `-small` suffix keeps this job at one label —
+    # read the note in 5_testcomponent_keystore.yml before switching to separate labels.
+    runs-on: ${{ matrix.arch == 'arm64' && format('codebuild-github-actions-codebuild-runner-server-arm-{0}-{1}-small', github.run_id, github.run_attempt) || format('codebuild-github-actions-codebuild-runner-server-amd-{0}-{1}-small', github.run_id, github.run_attempt) }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/5_codeanalysis_python_bandit_pr.yml
+++ b/.github/workflows/5_codeanalysis_python_bandit_pr.yml
@@ -20,7 +20,10 @@ env:
 jobs:
   bandit-scan:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    # `small` instance (2 vCPU, 3.0 GiB usable): single-process Python static analysis.
+    # The `-small` suffix keeps this job at one label — read the note in
+    # 5_testcomponent_keystore.yml before switching to a separate `instance-size:` label.
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}-small
     timeout-minutes: 20
     steps:
       - name: Checkout repo

--- a/.github/workflows/5_codequality_changelog.yml
+++ b/.github/workflows/5_codequality_changelog.yml
@@ -12,7 +12,10 @@ jobs:
   # Enforces the update of a changelog file on every pull request
   verify-changelog:
     if: ${{ !github.event.pull_request.draft && github.repository == 'wazuh/wazuh' }}
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    # `small` instance (2 vCPU, 3.0 GiB usable): this job only diffs the changelog file.
+    # The `-small` suffix keeps this job at one label — read the note in
+    # 5_testcomponent_keystore.yml before switching to a separate `instance-size:` label.
+    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}-small
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/5_testcomponent_keystore.yml
+++ b/.github/workflows/5_testcomponent_keystore.yml
@@ -20,7 +20,16 @@ concurrency:
 jobs:
   keystore-tests:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: ${{ format('codebuild-github-actions-codebuild-runner-server-amd-{0}-{1}', github.run_id, github.run_attempt) }}
+    # `small` instance (2 vCPU, 3.0 GiB usable): build_target_cpp runs `cmake --build`
+    # without --parallel and build_external_deps caps its make at -j2, so this job never
+    # uses more than two cores. Measured 10/10 passes per matrix leg, peak 1.4 GiB.
+    #
+    # The `-small` suffix form is deliberate: a separate `instance-size:small` label would
+    # give this job a different label count than its siblings, and per the AWS docs a job
+    # with fewer labels can be picked up by a runner created for a job with more, leaving
+    # that job without a runner. Keep the size inside the single label.
+    # https://docs.aws.amazon.com/codebuild/latest/userguide/sample-github-action-runners-update-labels.html
+    runs-on: ${{ format('codebuild-github-actions-codebuild-runner-server-amd-{0}-{1}-small', github.run_id, github.run_attempt) }}
     timeout-minutes: 60
     strategy:
       fail-fast: true

--- a/.github/workflows/5_testintegration_linux-integration-tests.yml
+++ b/.github/workflows/5_testintegration_linux-integration-tests.yml
@@ -97,6 +97,11 @@ jobs:
       BUILD_WORKFLOW: 5_builderpackage_agent-linux.yml
       PACKAGES_PATH: /tmp/packages
       AGENT_PACKAGE_REGEXP: wazuh-agent.*amd64.*\.deb
+    # NOTE: deliberately NOT downsized to a `small` instance. These suites are pytest with no
+    # compilation, so they look like obvious candidates, but a measured A/B found that fim
+    # tier-0 fails test_fill_capacity's real-time event-count assertion on 2 vCPU while
+    # passing at this size on the identical package (agentd tier-0-1 passed on both).
+    # Data: https://github.com/wazuh/wazuh/pull/38215#issuecomment-5204406595
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo

--- a/.github/workflows/5_testunit_shared_modules_utils.yml
+++ b/.github/workflows/5_testunit_shared_modules_utils.yml
@@ -23,6 +23,14 @@ permissions:
 jobs:
   shared_modules_utils-modules:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    # NOTE: deliberately NOT downsized to a `small` instance, and neither is -asan below.
+    # utils_utest contains AsyncValueDispatcherTest.CancelFunctionality, which waits for its
+    # counter to reach 5, cancels, then asserts 10 — items 6..10 are unsynchronised, so the
+    # outcome depends on when the worker thread is scheduled. Measured on 2 vCPU: this job
+    # failed 10/10 and -asan failed 1/23, against zero failures on that test at this size.
+    # The race is in the test, not in valgrind; running under valgrind only makes it
+    # near-deterministic. Revisit once the test synchronises on all 10 items.
+    # Data: https://github.com/wazuh/wazuh/pull/38215#issuecomment-5205906176
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 60
     steps:
@@ -68,6 +76,7 @@ jobs:
 
   shared_modules_utils-asan:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    # NOTE: not downsized — see the AsyncValueDispatcherTest note on the job above.
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
## Description

Related to #38150.

`github-actions-codebuild-runner-server-amd` and `-server-arm` are configured as `BUILD_GENERAL1_MEDIUM` (4 vCPU / 8 GB) and every job targeting them gets that instance, whether it can use it or not. A per-job audit of where that project's spend actually goes (posted as a comment below) shows most of it is `-j$(nproc)` C/C++ compilation that genuinely needs the cores — but a handful of jobs cannot use more than 2 vCPU by construction and were paying the medium rate ($0.0100/min) anyway.

This PR overrides the instance size to `small` (2 vCPU / 3 GB usable, $0.0050/min) for those jobs only. Two further jobs were downsized and then reverted after repeated runs showed a latent test race failing on 2 vCPU — the saving is correspondingly modest, and the results comment below documents exactly what was measured and rejected. Compile jobs that scale with `$(nproc)` are deliberately left on medium: halving their rate roughly doubles their duration, which trades PR feedback latency for money rather than saving it, and would breach several existing `timeout-minutes` values.

## Proposed Changes

Appended an `instance-size` override to the CodeBuild runner label of the four Server-project jobs that cannot use four cores. Each was validated by repeated execution, not a single run (counts in the results comment below):

| Workflow / job | Why `small` is safe | Mean duration |
|---|---|---|
| `5_testcomponent_keystore.yml` `keystore-tests` | `build_target_cpp` runs `cmake --build` with no `--parallel`; dependency build pinned to `-j2` in `build_external_deps` — **10/10 per matrix leg on small** | 4.6 / 4.8 min |
| `5_codequality_changelog.yml` `verify-changelog` | changelog diff only, no compilation | <1 min |
| `5_codeanalysis_python_bandit_pr.yml` `bandit-scan` | single-process bandit | <1 min |
| `5_builderpackage_engine-standalone.yml` `check_standalone_engine` | downloads and starts a prebuilt engine, no compilation — **5/5 per architecture on small** | 0.8 / 0.3 min |

The override uses the single-label form documented by AWS:

```yaml
runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}-small
```

This is deliberate rather than a separate `- instance-size:small` label: a differing label count between jobs of the same workflow run lets one job get picked up by the runner created for another, [per the AWS docs](https://docs.aws.amazon.com/codebuild/latest/userguide/sample-github-action-runners-update-labels.html). That rationale is written into `5_testcomponent_keystore.yml` next to the label rather than living only here — the failure mode is hanging jobs, and it is invisible to anyone tidying the label toward the more prominently documented multi-label form. No CodeBuild project, fleet or IAM change is needed for this to take effect, and any branch without this patch keeps using the project default.

Two further files change comments only, no behaviour: `5_testunit_shared_modules_utils.yml` and `5_testintegration_linux-integration-tests.yml` each gain a `NOTE` recording that downsizing was measured and rejected, with the data linked. Both rejections cost real CI time to establish — the integration-test one took a 57-minute run — so the next person to look at these jobs should not have to rediscover them.

> [!NOTE]
> **Scope on this branch.** #38188 already moved the agent-side light workloads on `5.0.0` off CodeBuild to GitHub-hosted runners, so the jobs listed above are what remains downsizable here. `main` still runs five more jobs in the same category (`5_testcomponent_windows-{dll-hijack,files,installer-upgrade}` `build`, which pin `make` to `-j2`, plus `5_codelinter_clangformat.yml` and `5_testunit_wodles.yml`) — worth the same patch as a follow-up if `main` keeps them on CodeBuild.
>
> **Sizing vs. migrating.** For these five jobs specifically, following #38188 and moving them to `ubuntu-24.04` would save 100% of their minutes instead of 50%, since `wazuh/wazuh` is public and standard runners bill nothing. That is a concurrency trade-off rather than a sizing one, so it is left out of this PR and raised in the audit comment instead.

### The other eight server-runner jobs, and why they stay put

For completeness — there are 13 jobs on the two Server projects. Four are downsized above; here is every one that is not, so the sweep is auditable rather than implied:

| Job | Why it keeps the project default |
|---|---|
| `5_builderpackage_manager.yml::Build-manager-packages` | `-j$(nproc)` package build — needs the cores |
| `5_builderpackage_engine-standalone.yml::build` | `-j$(nproc)` engine build |
| `5_buildpackage_internal_tools.yml::build` | `-j$(nproc)` build |
| `6_builderpackage_server.yml::Build-server-packages` | `-j$(nproc)` build (ARM) |
| `5_testintegration_linux-integration-tests.yml::run-test` | **measured and rejected** — `fim` tier-0 fails a real-time capacity assertion on `small`; see the A/B comment below |
| `5_testunit_shared_modules_utils.yml::shared_modules_utils-modules` | **downsized, then reverted** — `AsyncValueDispatcherTest.CancelFunctionality` failed **10/10** on `small` against 10/10 passing at the default size |
| `5_testunit_shared_modules_utils.yml::shared_modules_utils-asan` | **downsized, then reverted** — same test, 1 failure in 23 runs on `small`, 0 in 26 at the default size |
| `5_builderprecompiled_docker-images-upload-manager.yml::Upload-package-building-images` | `docker build`/push of a builder image; did not register in the 28-day cost sample (~$0/month) |
| `6_builderprecompiled_server-images.yml::Upload-package-building-images` | `workflow_dispatch`-only; ~$0/month |

The last two are the only ones excluded on value rather than on evidence. Both are legitimate `small` candidates worth ~$0/month, and verifying them means actually publishing a builder image to GHCR — not a side effect worth triggering for no saving.

### Results and Evidence

**Measured, not assumed.** The two heaviest jobs in the set were dispatched on two throwaway branches carrying identical temporary probes — one with the `-small` label, one on the project default — so this is a same-day A/B on the same workload rather than a comparison against a historical mean. All jobs passed on both sizes.

The override provably takes effect:

| Probe | `-small` label | project default |
|---|---|---|
| `nproc` | **2** | 4 |
| `MemTotal` | **3.60 GiB** | 7.43 GiB |
| container limit (cgroup) | **3.00 GiB** | 6.75 GiB |

Duration and cost per run:

| Job | default (4 vCPU) | `small` (2 vCPU) | Δ duration | Cost/run before → after |
|---|---|---|---|---|
| `shared_modules_utils-modules` | 10.4 min | 10.4 min | **none** | $0.104 → $0.052 (−50%) |
| `shared_modules_utils-asan` | 19.0 min | 22.5 min | **+18%** | $0.190 → $0.113 (−41%) |
| `keystore-tests (asan)` | 4.8 min | 5.6 min | +17% | $0.048 → $0.028 (−42%) |
| `keystore-tests (valgrind)` | 4.8 min* | 5.0 min | +4% | $0.048 → $0.025 (−48%) |
| `check_standalone_engine (x64)` | 0.5 min | 0.6 min | none meaningful | $0.005 → $0.003 (−40%) |
| `check_standalone_engine (arm64)` | 0.3 min | 0.3 min | **none** | $0.002 → $0.001 (−50%) |

\* the valgrind control job actually recorded 14.8 min, but 10.7 of those were a flaky `Keystore - Run tests` step; its sibling asan job on the same instance took 4.8 min, so 4.8 is the fair baseline.

Both probe branches were new, so neither could read the Actions dependency cache (caches are branch-scoped and fall back only to the base branch). That inflates the absolute durations of the `Build external dependencies` / `Project dependencies` steps equally on both sides — it does not affect the comparison, but it is why `keystore-tests` shows 4.8 min here against a 2.5 min steady-state mean.

Peak memory sampled during each run: keystore 1.25–1.36 GiB, `check_standalone_engine` 0.79 GiB (x86) and 0.90 GiB (ARM), and `shared_modules_utils-asan` **1.99 GiB on small against the 3.00 GiB container limit** (66%), 2.17 GiB when the same job ran on the default size. No OOM on any job. The engine test was the one whose footprint was genuinely unknown before this — it uses about a quarter of what `small` provides.

So the `-j2`/single-threaded reasoning holds for `shared_modules_utils-modules` (identical duration, half price) but only partly for the ASAN job: its `cmake --build` step still slowed 13.3 → 15.5 min on half the cores. The trade there is 3.5 min of extra wall-clock for 41% less cost — worth taking in my view, since these jobs are not the critical path on a PR, but a reviewer who weighs feedback latency higher should say so and I will drop that one job back to the default.

#### Run evidence

Every measurement above, linked to the job it came from. `small` and reference were dispatched minutes apart on the same commit and, for the IT rows, against the identical prebuilt package — so the instance size is the only variable.

| Job | `small` run | duration | reference run | duration | Δ |
|---|---|---|---|---|---|
| `keystore-tests (asan)` | [pass](https://github.com/wazuh/wazuh/actions/runs/31090415449/job/92579812498) | 5.6 min | [pass](https://github.com/wazuh/wazuh/actions/runs/31090417721/job/92579814083) | 4.8 min | +17% |
| `keystore-tests (valgrind)` | [pass](https://github.com/wazuh/wazuh/actions/runs/31090415449/job/92579812441) | 5.0 min | [pass](https://github.com/wazuh/wazuh/actions/runs/31090417721/job/92579814020) | 14.8 min † | — |
| `check_standalone_engine (x64)` | [pass](https://github.com/wazuh/wazuh/actions/runs/31101892725/job/92621735859) | 0.6 min | [pass](https://github.com/wazuh/wazuh/actions/runs/31044531438/job/92441882171) ‡ | 0.5 min | none meaningful |
| `check_standalone_engine (arm64)` | [pass](https://github.com/wazuh/wazuh/actions/runs/31101892725/job/92621735935) | 0.3 min | [pass](https://github.com/wazuh/wazuh/actions/runs/31044531438/job/92441882160) ‡ | 0.3 min | none |

† This reference job spent 10.7 of its 14.8 min in a flaky `Keystore - Run tests` step; its sibling asan job on the same instance took 4.8 min, which is the fair baseline. Not an instance-size effect in either direction.

‡ No same-day control was dispatched for the engine test — its reference is the most recent successful run at the default size on another branch. Its `build` dependency did run at the default size in the `small` dispatch, so only the test job differed.

Rejected candidate, for the record — the integration tests (full reasoning in the comment below):

| Job | `small` run | duration | reference run | duration |
|---|---|---|---|---|
| `IT Linux - fim (tier-0)` | [**fail**](https://github.com/wazuh/wazuh/actions/runs/31095575470/job/92596668901) | 57.7 min | [pass](https://github.com/wazuh/wazuh/actions/runs/31095588383/job/92596716565) | 52.7 min |
| `IT Linux - agentd (tier-0-1)` | [pass](https://github.com/wazuh/wazuh/actions/runs/31095582167/job/92596691154) | 32.2 min | [pass](https://github.com/wazuh/wazuh/actions/runs/31095594737/job/92596734990) | 30.6 min |

Estimated saving for the jobs in this PR, over the same window as the [cost report](https://github.com/wazuh/wazuh-automation/issues/3637#issuecomment-5133556830) (2026-07-01 → 2026-07-28) and priced at the same rates:

| | Minutes / month | Rate | Cost / month |
|---|---|---|---|
| Before | ~660 | $0.0100 / $0.0070 (ARM) | ~$6.6 |
| After | ~660 | $0.0050 / $0.0035 (ARM) | ~$3.3 |

Those minutes are the total across every branch that runs these workflow files; this PR captures the share that runs on `5.0.0`-based branches.

This PR's own CI re-confirms it end to end: `verify-changelog`, `bandit-scan`, `keystore-tests` and both `shared_modules_utils-*` jobs all run on the overridden labels, so a mis-formed label would show up here as a job that never gets a runner. (They currently report `skipping` because the PR is a draft.)

The full per-job attribution of `server-amd` / `server-arm`, the reasoning for leaving the compile jobs on medium, and the higher-value levers found along the way (compiler caching, ARM price/performance, free public-repo runners) are in the audit comment below.

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

None. CI configuration only: six GitHub Actions workflow definitions under `.github/workflows/` — four with `runs-on` label changes, two with explanatory comments alone. No product source, packaging or default configuration is touched.

### Configuration Changes

CI infrastructure only: the `runs-on` label of the four jobs above now carries a `-small` instance-size suffix. `check_standalone_engine` is the one that touches `server-arm` as well as `server-amd`, since its label is an arch ternary. Nothing changes in the CodeBuild project configuration itself.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

One thing for the reviewer to weigh: the usable memory on `small` is 3.0 GiB, not the nominal 4 GB, and the ASAN build of `shared_modules_utils` peaks at 1.99 GiB of it. That is the thinnest margin in the set — if it ever OOMs, the fix is to drop that single job back to the default rather than revert the set.
