### PR TITLE
ruleset: rewrite Palo Alto decoders/rules for PAN-OS v11.x LEEF format

### DIFF
--- a/ruleset/decoders/0505-paloalto_decoders.xml
+++ b/ruleset/decoders/0505-paloalto_decoders.xml
@@ -1,191 +1,319 @@
 <!--
-  Copyright (C) 2015, Wazuh Inc.
+  Palo Alto v11.1 decoders.
 -->
 
+
+<!--******************Palo Alto User-ID decoders******************* -->
 <!--
-  Palo Alto v8.X - v10.X decoders.
+Feb 11 17:46:22 PANFW01 LEEF:2.0|
+Palo Alto Networks|PAN-OS Syslog Integration|11.1.6-h3|login
+|x7C|ProfileToken=0x0|TimeReceived=2026/02/11 17:46:21|
+DeviceSN=016201046640|cat=USERID|ConfigVersion=11.1.6-h3|
+devTime=Feb 11 2026 13:46:21 GMT|VirtualLocation=vsys1|src=192.9.200.90|
+usrName=eagle\UCSDEVSPSRV01$|MappingDataSourceName=ucprdc02.eagle.com|
+EventIdName=0|CountofRepeats=1|MappingTimeout=0|srcPort=0|dstPort=0|
+MappingDataSource=active-directory|MappingDataSourceType=|
+SequenceNo=7484098497199366899|DGHierarchyLevel1=0|DGHierarchyLevel2=0|
+DGHierarchyLevel3=0|DGHierarchyLevel4=0|VirtualSystemName=|DeviceName=PANFW01|
+VirtualSystemID=1|MFAFactorType=|AuthCompletionTime=2026/02/11 17:37:19|
+AuthFactorNo=1|UGFlags=0x0|UserIdentifiedBySource=eagle\UCSDEVSPSRV01$|
+Tag=|TimeGeneratedHighResolution=2026-02-11T17:46:22.429+04:00|
+devTimeFormat=Feb 11 2026 13:46:21 GMT
+-->
+<!--
+  Fields : devTime, VirtualLocation, src, usrName, MappingDataSourceName, EventIdName, CountofRepeats,MappingTimeout,srcPort, dstPort,
+  MappingDataSource, MappingDataSourceType, SequenceNo, DGHierarchyLevel1,DGHierarchyLevel2,DGHierarchyLevel3, DGHierarchyLevel4,
+  VirtualSystemName, DeviceName, VirtualSystemID,MFAFactorType,AuthCompletionTime, AuthFactorNo, UGFlags, UserIdentifiedBySource, Tag,
 -->
 
+<decoder name="paloalto-userid">
+    <type>syslog</type>
+    <program_name>LEEF</program_name>
+    <prematch type="pcre2">cat=USERID</prematch>
+</decoder>
+
+<decoder name="paloalto-userid-fields">
+    <parent>paloalto-userid</parent>
+    <regex>\.*\|(\.*)\|\.*\|\.*\|\.*\|devTime=(\.*)\|VirtualLocation=(\.*)\|src=(\.*)\|usrName=(\.*)\|MappingDataSourceName=(\.*)\|EventIdName=(\.*)\|CountofRepeats=(\.*)\|MappingTimeout=(\.*)\|srcPort=(\.*)\|dstPort=(\.*)\|\.*</regex>
+    <order>subType,devTime,virtualLocation,srcip,username,mappingDataSourceName,eventIdName,countofRepeats,mappingTimeout,srcport,dstport</order>
+</decoder>
+
+<decoder name="paloalto-userid-fields">
+    <parent>paloalto-userid</parent>
+    <regex>\.*\|MappingDataSource=(\.*)\|MappingDataSourceType=(\.*)\|SequenceNo=(\.*)\|DGHierarchyLevel1=(\.*)\|DGHierarchyLevel2=(\.*)\|DGHierarchyLevel3=(\.*)\|DGHierarchyLevel4=(\.*)\|\.*</regex>
+    <order>mappingDataSource,mappingDataSourceType,sequenceNo,DGHierarchyLevel1,DGHierarchyLevel2,DGHierarchyLevel3,DGHierarchyLevel4</order>
+</decoder>
+
+<decoder name="paloalto-userid-fields">
+    <parent>paloalto-userid</parent>
+    <regex>\.*\|VirtualSystemName=(\.*)\|DeviceName=(\.*)\|VirtualSystemID=(\.*)\|MFAFactorType=(\.*)\|AuthCompletionTime=(\.*)\|AuthFactorNo=(\.*)\|UGFlags=(\.*)\|UserIdentifiedBySource=(\.*)\|Tag=(\.*)\|\.*</regex>
+    <order>virtualSystemName,deviceName,virtualSystemID,mfaFactorType,authCompletionTime,authFactorNo,ugFlags,userIdentifiedBySource,tag</order>
+</decoder>
+
+<!--******************Palo Alto IPTAG decoders******************* -->
+<!--
+Feb 12 13:30:17 PANFW01 LEEF:2.0|Palo Alto Networks|PAN-OS Syslog Integration|
+11.1.6-h3|register|x7C|ProfileToken=0x0|TimeReceived=2026/02/12 13:30:16|DeviceSN=016201046640|
+cat=IPTAG|SubType=0|ConfigVersion=11.1.6-h3|devTime=Feb 12 2026 09:30:16 GMT|VirtualLocation=vsys1|
+src=172.16.26.54|TagName=[Machine Authenticated]|CountOfRepeats=1|MappingTimeout=0|
+MappingDataSource=XMLAPI|MappingDataSourceType=xml-api|MappingDataSourceSubType=unknown|SequenceNo=7484098496031649376|
+DGHierarchyLevel1=0|DGHierarchyLevel2=0|DGHierarchyLevel3=0|DGHierarchyLevel4=0|VirtualSystemName=|DeviceName=PANFW01|
+VirtualSystemID=1|IPSubnetRange=|TimeGeneratedHighResolution=2026-02-12T13:30:17.139+04:00|devTimeFormat=Feb 12 2026 09:30:16 GMT
+-->
+<!--
+  Fields : devTime, VirtualLocation, src, TagName,CountOfRepeats,MappingTimeout,
+  MappingDataSource,MappingDataSourceType,MappingDataSourceSubType,SequenceNo,DGHierarchyLevel1,DGHierarchyLevel2,DGHierarchyLevel3,DGHierarchyLevel4,
+  VirtualSystemName,DeviceName,VirtualSystemID,IPSubnetRange,
+-->
+
+<decoder name="paloalto-iptag">
+    <type>syslog</type>
+    <program_name>LEEF</program_name>
+    <prematch type="pcre2">cat=IPTAG</prematch>
+</decoder>
+
+<decoder name="paloalto-iptag-fields">
+    <parent>paloalto-iptag</parent>
+    <regex>\.*\|SubType=(\.*)\|ConfigVersion=\.*\|devTime=(\.*)\|VirtualLocation=(\.*)\|src=(\.*)\|TagName=(\.*)\|CountOfRepeats=(\.*)\|MappingTimeout=(\.*)\|\.*</regex>
+    <order>subType,devTime,virtualLocation,srcip,tagName,countofRepeats,mappingTimeout</order>
+</decoder>
+
+<decoder name="paloalto-iptag-fields">
+    <parent>paloalto-iptag</parent>
+    <regex>\.*\|MappingDataSource=(\.*)\|MappingDataSourceType=(\.*)\|MappingDataSourceSubType=(\.*)\|SequenceNo=(\.*)\|DGHierarchyLevel1=(\.*)\|DGHierarchyLevel2=(\.*)\|DGHierarchyLevel3=(\.*)\|DGHierarchyLevel4=(\.*)\|\.*</regex>
+    <order>mappingDataSource,mappingDataSourceType,mappingDataSourceSubType,sequenceNo,DGHierarchyLevel1,DGHierarchyLevel2,DGHierarchyLevel3,DGHierarchyLevel4</order>
+</decoder>
+
+<decoder name="paloalto-iptag-fields">
+    <parent>paloalto-iptag</parent>
+    <regex>\.*\|VirtualSystemName=(\.*)\|DeviceName=(\.*)\|VirtualSystemID=(\.*)\|IPSubnetRange=(\.*)\|\.*</regex>
+    <order>virtualSystemName,deviceName,virtualSystemID,ipSubnetRange</order>
+</decoder>
+
+<!--******************Palo Alto SYSTEM decoders******************* -->
+<!--
+Feb 12 13:34:18 PANFW01 LEEF:2.0|Palo Alto Networks|PAN-OS Syslog Integration|11.1.6-h3|
+auth-success|x7C|TimeReceived=2026/02/12 13:34:17|DeviceSN=016201046640|cat=SYSTEM|Subtype=auth|
+devTime=Feb 12 2026 09:34:17 GMT|VirtualSystem=|Filename=|Module=general|sev=1|Severity=informational|
+msg="authenticated for user 'seyam_backup'.   From: 172.16.3.99."|sequence=7484098496036218022|ActionFlags=0x0|
+DeviceGroupHierarchyL1=0|DeviceGroupHierarchyL2=0|DeviceGroupHierarchyL3=0|DeviceGroupHierarchyL4=0|vSrcName=|DeviceName=PANFW01
+-->
+<!--
+  Fields: Subtype,devTime,VirtualSystem,Filename,Module,sev,Severity,msg,sequence,ActionFlags,
+  DeviceGroupHierarchyL1,DeviceGroupHierarchyL2,DeviceGroupHierarchyL3,DeviceGroupHierarchyL4,vSrcName,DeviceName
+-->
+
+<decoder name="paloalto-system">
+    <type>syslog</type>
+    <program_name>LEEF</program_name>
+    <prematch type="pcre2">cat=SYSTEM</prematch>
+</decoder>
+
+<decoder name="paloalto-system-fields">
+    <parent>paloalto-system</parent>
+    <regex>\.*\|Subtype=(\.*)\|devTime=(\.*)\|VirtualSystem=(\.*)\|Filename=(\.*)\|Module=(\.*)\|sev=(\.*)\|Severity=(\S*)\|msg="(\.*)"\|\.*</regex>
+    <order>subtype,devTime,virtualSystem,filename,module,sev,severity,message</order>
+</decoder>
+
+<decoder name="paloalto-system-fields">
+    <parent>paloalto-system</parent>
+    <regex>\.*\|sequence=(\.*)\|ActionFlags=(\.*)\|DeviceGroupHierarchyL1=\.*\|DeviceGroupHierarchyL2=\.*\|DeviceGroupHierarchyL3=\.*\|DeviceGroupHierarchyL4=\.*\|\.*</regex>
+    <order>sequenceNo,actionFlags</order>
+</decoder>
+
+<decoder name="paloalto-system-fields">
+    <parent>paloalto-system</parent>
+    <regex>\.*\|vSrcName=(\.*)\|DeviceName=(\.*)\|\.*</regex>
+    <order>vSrcName,deviceName</order>
+</decoder>
+
+<!--******************Palo Alto HIPMATCH decoders******************* -->
+<!--
+Feb 12 14:14:23 PANFW01 LEEF:2.0|Palo Alto Networks|PAN-OS Syslog Integration|11.1.6-h3|HIP-Profile|
+x7C|ProfileToken=0x0|TimeReceived=2026/02/12 14:14:22|DeviceSN=016201046640|cat=HIPMATCH|SubType=0|
+ConfigVersion=11.1.6-h3|devTime=Feb 12 2026 10:14:22 GMT|usrName=eagle\mabbas|VirtualLocation=vsys1
+|identHostName=HO473686L.UCSNET.com|EndpointOSType=Windows|iOSsrc=172.16.125.135|CountOfRepeats=1|
+SequenceNo=7484098496031627145|DGHierarchyLevel1=0|DGHierarchyLevel2=0|DGHierarchyLevel3=0|
+DGHierarchyLevel4=0|VirtualSystemName=|DeviceName=PANFW01|VirtualSystemID=1|SourceIPv6=0.0.0.0|
+HostID=|EndpointSerialNumber=|SourceDeviceCategory=0|SourceDeviceModel=profile|SourceDeviceMac=|
+TimestampDeviceIdentification=2026/02/12 14:14:22|TimeGeneratedHighResolution=2026-02-12T14:14:23.277+04:00|
+devTimeFormat=Feb 12 2026 10:14:22 GMT
+
+-->
+<!--
+  Fields: Subtype,devTime,usrName,VirtualLocation,identHostName,EndpointOSType,iOSsrc,CountOfRepeats,
+  SequenceNo,DGHierarchyLevel1,DGHierarchyLevel2,DGHierarchyLevel3,DGHierarchyLevel4,VirtualSystemName,DeviceName
+  VirtualSystemID,SourceIPv6,HostID,EndpointSerialNumber,SourceDeviceCategory,SourceDeviceModel,SourceDeviceMac
+-->
+
+<decoder name="paloalto-hipmatch">
+    <type>syslog</type>
+    <program_name>LEEF</program_name>
+    <prematch type="pcre2">cat=HIPMATCH</prematch>
+</decoder>
+
+<decoder name="paloalto-hipmatch-fields">
+    <parent>paloalto-hipmatch</parent>
+    <regex>\.*\|SubType=(\.*)\|ConfigVersion=\.*\|devTime=(\.*)\|usrName=(\.*)\|VirtualLocation=(\.*)\|identHostName=(\.*)\|EndpointOSType=(\.*)\|iOSsrc=(\.*)\|CountOfRepeats=(\.*)\|\.*</regex>
+    <order>subtype,devTime,username,virtualLocation,hostname,ostype,srcip,countOfRepeats</order>
+</decoder>
+
+<decoder name="paloalto-hipmatch-fields">
+    <parent>paloalto-hipmatch</parent>
+    <regex>\.*\|SequenceNo=(\.*)\|DGHierarchyLevel1=(\.*)\|DGHierarchyLevel2=(\.*)\|DGHierarchyLevel3=(\.*)\|DGHierarchyLevel4=(\.*)\|VirtualSystemName=(\.*)\|DeviceName=(\.*)\|VirtualSystemID=(\.*)\|\.*</regex>
+    <order>sequenceNo,DGHierarchyLevel1,DGHierarchyLevel2,DGHierarchyLevel3,DGHierarchyLevel4,virtualSystemName,deviceName,virtualSystemID</order>
+</decoder>
+
+<!--******************Palo Alto THREAT decoders******************* -->
 <!-- 
-  Apr 30 06:00:00 xx-xx-xx.xx 1,2020/02/09 00:00:00,00000000,SYSTEM,
-  Apr 30 06:00:00 xx-xx-xx.xx 1,2020/02/09 00:00:00,00000000,TRAFFIC,
-  Apr 30 06:00:00 xx-xx-xx.xx 1,2020/02/09 00:00:00,00000000,CONFIG,
-  Apr 30 06:00:00 xx-xx-xx.xx 1,2020/02/09 00:00:00,00000000,THREAT,
-  Apr 30 06:00:00 xx-xx-xx.xx 1,2020/02/09 00:00:00,00000000,OTHERS,
-  Apr 30 06:00:00 xx-xx-xx.xx 1,2020/02/09 00:00:00,00000000,SYSTEM,general,0,2020/00/00 00:00:00,,general,,0,0,general,informational,"xxxxxxxxxxxxxxx",0000000,0x0,0,0,0,0,,XXX-XX-XX
-  Apr 30 06:00:00 xx-xx-xx.xx 1,2020/02/09 00:00:00,00000000,SYSTEM,general,0,2020/00/00 00:00:00,,general,,0,0,general,low,"xxxxxxxxxxxxxxx",0000000,0x0,0,0,0,0,,XXX-XX-XX
-  Apr 30 06:00:00 xx-xx-xx.xx 1,2020/02/09 00:00:00,00000000,SYSTEM,general,0,2020/00/00 00:00:00,,general,,0,0,general,medium,"xxxxxxxxxxxxxxx",0000000,0x0,0,0,0,0,,XXX-XX-XX
-  0,2021/07/12 09:46:23,321321321,THREAT,vulnerability,0,2021/07/12 09:46:00,199.195.252.165,172.30.250.61,199.195.252.165,10.20.0.19,GPS-UAT-MODULR-Web-443-OUT,,,web-browsing,vsys1,YYYYYYYYYYY,ZZZZZZZZZZZ,ethernet1/1,tunnel.2,UATH-LogForwarding,2021/07/12 09:46:00,51557,1,55094,443,55094,443,0x502000,tcp,reset-both,"getuser",DCS-2530L Unauthenticated Information Disclosure Vulnerability(90255),any,high,client-to-server,561,0xa000000000000000,United States,172.16.0.0-172.31.255.255,0,,0,,,1,,,,,,,,0,41,225,0,0,,UAT-INTERNET-FW-01,,,,,0,,0,,N/A,info-leak,AppThreat-8428-6809,0x2,0,4294967295,,"  ",dd3035a9-452f-4073-a1bc-169f4b453e6a,0,,0.0.0.0,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-07-12T09:46:01.359+01:00,,  ,
-  Apr 30 06:00:00 xx-xx-xx.xx 1,2020/02/09 00:00:00,00000000,SYSTEM,general,0,2020/00/00 00:00:00,,general,,0,0,general,high,"xxxxxxxxxxxxxxx",0000000,0x0,0,0,0,0,,XXX-XX-XX
-  Apr 30 06:00:00 xx-xx-xx.xx 1,2020/02/09 00:00:00,00000000,SYSTEM,general,0,2020/00/00 00:00:00,,general,,0,0,general,critical,"xxxxxxxxxxxxxxx",0000000,0x0,0,0,0,0,,XXX-XX-XX
-  0,2021/07/15 11:58:58,1321564321,TRAFFIC,N/A,0,2021/07/15 11:59:02,10.210.0.84,51.11.168.232,,,DENY-ALL,,,not-applicable,vsys1,INSPECTION,INSPECTION,ethernet1/1,,AWS-PANORAMA,2021/07/15 11:59:02,0,1,500,500,0,0,0x0,udp,deny,0,0,0,1,2021/07/15 11:59:02,0,any,0,91501273,0x8000000000000000,10.0.0.0-10.255.255.255,YYYYYYYYYYYY,0,1,0,policy-deny,150,42,25,260,,P1A-GWLB-CORE-FW01,from-policy,,,0,,0,,N/A,0,0,0,0,49543e97-7c8c-44a3-bbd9-031caeb1a65e,0,0,,,,,,,,0.0.0.0,,,,,,,,,,,,,,,,,,,,,,,,,,,2021-07-15T11:59:03.547+01:00,,
-  May 00 00:00:00 XXX-XX-00 1,2020/00/00 00:00:00,00000000,TRAFFIC,start,0000,2020/06/00 00:00:00,00.00.000.00,00.00.00.0,0.0.0.0,0.0.0.0,xxx-xxx_xxxx,,,xxx,xxxxx,xxxx,xxxx,xxxx.0,xxx.000,xxxxxxxx,2020/00/00 00:00:00,0000,1,0000,000,0,0,0x0,xxx,xxxx,000,000,00,0,2020/00/00 00:00:00,1,any,0,0000000,0x0,00.0.0.0-00.000.000.000,00.0.0.0-00.000.000.000,0,0,0,n/a,0,0,0,0,,xxx-xx-01,from-policy,,,0,,0,,N/A,0,0,0,0,00000-0000-00xx00-00xx-0x0x0x000xx,0
-  May 00 00:00:00 XXX-XX-00 1,2020/00/00 00:00:00,00000000,TRAFFIC,end,0000,2020/06/00 00:00:00,00.00.000.00,00.00.00.0,0.0.0.0,0.0.0.0,xxx-xxx_xxxx,,,xxx,xxxxx,xxxx,xxxx,xxxx.0,xxx.000,xxxxxxxx,2020/00/00 00:00:00,0000,1,0000,000,0,0,0x0,xxx,xxxx,000,000,00,0,2020/00/00 00:00:00,1,any,0,0000000,0x0,00.0.0.0-00.000.000.000,00.0.0.0-00.000.000.000,0,0,0,n/a,0,0,0,0,,xxx-xx-01,from-policy,,,0,,0,,N/A,0,0,0,0,00000-0000-00xx00-00xx-0x0x0x000xx,0
-  May 00 00:00:00 XXX-XX-00 1,2020/00/00 00:00:00,00000000,TRAFFIC,drop,0000,2020/06/00 00:00:00,00.00.000.00,00.00.00.0,0.0.0.0,0.0.0.0,xxx-xxx_xxxx,,,xxx,xxxxx,xxxx,xxxx,xxxx.0,xxx.000,xxxxxxxx,2020/00/00 00:00:00,0000,1,0000,000,0,0,0x0,xxx,xxxx,000,000,00,0,2020/00/00 00:00:00,1,any,0,0000000,0x0,00.0.0.0-00.000.000.000,00.0.0.0-00.000.000.000,0,0,0,n/a,0,0,0,0,,xxx-xx-01,from-policy,,,0,,0,,N/A,0,0,0,0,00000-0000-00xx00-00xx-0x0x0x000xx,0
-  May 00 00:00:00 XXX-XX-00 1,2020/00/00 00:00:00,00000000,TRAFFIC,deny,0000,2020/06/00 00:00:00,00.00.000.00,00.00.00.0,0.0.0.0,0.0.0.0,xxx-xxx_xxxx,,,xxx,xxxxx,xxxx,xxxx,xxxx.0,xxx.000,xxxxxxxx,2020/00/00 00:00:00,0000,1,0000,000,0,0,0x0,xxx,xxxx,000,000,00,0,2020/00/00 00:00:00,1,any,0,0000000,0x0,00.0.0.0-00.000.000.000,00.0.0.0-00.000.000.000,0,0,0,n/a,0,0,0,0,,xxx-xx-01,from-policy,,,0,,0,,N/A,0,0,0,0,00000-0000-00xx00-00xx-0x0x0x000xx,0 
+Feb 24 22:20:59 PANFW01 LEEF:2.0|Palo Alto Networks|PAN-OS Syslog Integration|11.1.6-h3|SCAN: Host Sweep(8002)|x7C|
+ReceiveTime=2026/02/24 22:20:58|SerialNumber=016201046640|cat=THREAT|Subtype=scan|devTime=Feb 24 2026 18:20:58 GMT|
+src=137.184.174.149|dst=172.16.50.36|srcPostNAT=0.0.0.0|dstPostNAT=0.0.0.0|RuleName=|usrName=|SourceUser=|
+DestinationUser=|Application=not-applicable|VirtualSystem=vsys1|SourceZone=Untrust-DMZ|DestinationZone=Trust-DMZ|
+IngressInterface=ethernet1/3|EgressInterface=|LogForwardingProfile=DMZ Threats|SessionID=0|RepeatCount=1|srcPort=36774|
+dstPort=443|srcPostNATPort=0|dstPostNATPort=0|Flags=0x2000|proto=tcp|action=alert|Miscellaneous=|ThreatID=SCAN: Host Sweep(8002)|
+URLCategory=any|sev=3|Severity=medium|Direction=client-to-server|sequence=7484098493538761469|ActionFlags=0x0|
+SourceLocation=Canada|DestinationLocation=172.16.0.0-172.31.255.255|ContentType=|PCAP_ID=0|FileDigest=|Cloud=|URLIndex=0|
+RequestMethod=|Subject=|DeviceGroupHierarchyL1=0|DeviceGroupHierarchyL2=0|DeviceGroupHierarchyL3=0|DeviceGroupHierarchyL4=0|
+vSrcName=|DeviceName=PANFW01|SrcUUID=|DstUUID=|TunnelID=0|MonitorTag=|ParentSessionID=0|ParentStartTime=|TunnelType=N/A|
+ThreatCategory=scan|ContentVer=AppThreat-0-0
+
+Jun 14 06:07:45 PANFW01 LEEF:2.0|Palo Alto Networks|PAN-OS Syslog Integration|11.1.6-h3|
+XMRig Miner Command and Control Traffic Detection(85886)|x7C|ReceiveTime=2026/06/14 06:07:44|
+SerialNumber=016201046640|cat=THREAT|Subtype=spyware|devTime=Jun 14 2026 02:07:44 GMT|src=185.213.175.176|
+dst=172.17.50.49|srcPostNAT=0.0.0.0|dstPostNAT=0.0.0.0|RuleName=DMZ  Incoming|usrName=|SourceUser=|DestinationUser=|
+Application=json-rpc|VirtualSystem=vsys1|SourceZone=Untrust-DMZ|DestinationZone=Trust-DMZ|
+IngressInterface=ethernet1/3|EgressInterface=ethernet1/4|LogForwardingProfile=Medium Threats|SessionID=348216|
+RepeatCount=1|srcPort=33562|dstPort=443|srcPostNATPort=0|dstPostNATPort=0|Flags=0x6000|proto=tcp|action=reset-both|
+Miscellaneous=|ThreatID=XMRig Miner Command and Control Traffic Detection(85886)|URLCategory=any|sev=5|
+Severity=critical|Direction=client-to-server|sequence=7484098493910195286|ActionFlags=0x0|SourceLocation=Spain|
+DestinationLocation=172.16.0.0-172.31.255.255|ContentType=|PCAP_ID=0|FileDigest=|Cloud=|URLIndex=0|RequestMethod=|
+Subject=|DeviceGroupHierarchyL1=0|DeviceGroupHierarchyL2=0|DeviceGroupHierarchyL3=0|DeviceGroupHierarchyL4=0|
+vSrcName=|DeviceName=PANFW01|SrcUUID=|DstUUID=|TunnelID=0|MonitorTag=|ParentSessionID=0|ParentStartTime=|
+TunnelType=N/A|ThreatCategory=cryptominer|ContentVer=AppThreat-9113-10104
 -->
-
-<!-- Generic Palo Alto decoder -->
-<decoder name="paloalto">
-  <prematch type="pcre2">^[^,]*,\d+\/\d+\/\d+\s\d+:\d+:\d+,\d+,\w+,</prematch>
+<!--
+  Fields: Subtype,devTime,src,dst,srcPostNAT,dstPostNAT,RuleName,usrName,SourceUser,DestinationUser,
+  Application,VirtualSystem,SourceZone,DestinationZone,IngressInterface,EgressInterface,LogForwardingProfile,
+  SessionID,RepeatCount,srcPort,dstPort,srcPostNATPort,dstPostNATPort,Flags,proto,action,Miscellaneous,ThreatID,
+  URLCategory,sev,Severity,Direction,sequence,ActionFlags,SourceLocation,DestinationLocation,ContentType,PCAP_ID,
+  FileDigest,Cloud,URLIndex,RequestMethod,Subject,DeviceGroupHierarchyL1,DeviceGroupHierarchyL2,DeviceGroupHierarchyL3,
+  DeviceGroupHierarchyL4,vSrcName,DeviceName,SrcUUID,DstUUID,TunnelID,MonitorTag,ParentSessionID,ParentStartTime,
+  TunnelType,ThreatCategory
+--> 
+<decoder name="paloalto-threat">
+    <type>syslog</type>
+    <program_name>LEEF</program_name>
+    <prematch type="pcre2">cat=THREAT</prematch>
 </decoder>
 
-<!-- Palo Alto system decoders -->
-<!-- Supported versions
-  8.X-9.X: FUTURE_USE, Receive Time, Serial Number, Type, Content/Threat Type, FUTURE_USE, Generated Time, Virtual System, Event ID, Object, FUTURE_USE, FUTURE_USE, Module, Severity, Description, Sequence Number, Action Flags, Device Group Hierarchy Level 1, Device Group Hierarchy Level 2, Device Group Hierarchy Level 3, Device Group Hierarchy Level 4, Virtual System Name, Device Name
-  10.X: FUTURE_USE, Receive Time, Serial Number, Type, Content/Threat Type, FUTURE_USE, Generated Time, Virtual System, Event ID, Object, FUTURE_USE, FUTURE_USE, Module, Severity, Description, Sequence Number, Action Flags, Device Group Hierarchy Level 1, Device Group Hierarchy Level 2, Device Group Hierarchy Level 3, Device Group Hierarchy Level 4, Virtual System Name, Device Name, FUTURE_USE, FUTURE_USE, High Resolution Timestamp
+<decoder name="paloalto-threat-fields">
+    <parent>paloalto-threat</parent>
+    <regex>\.*\|Subtype=(\.*)\|devTime=(\.*)\|src=(\.*)\|dst=(\.*)\|srcPostNAT=(\.*)\|dstPostNAT=(\.*)\|RuleName=\.*\|usrName=(\.*)\|\.*</regex>
+    <order>subtype,devTime,srcip,dstip,srcipPostNAT,dstipPostNAT,username</order>
+</decoder>
+
+<decoder name="paloalto-threat-fields">
+    <parent>paloalto-threat</parent>
+    <regex>\.*\|SourceUser=(\.*)\|DestinationUser=(\.*)\|Application=(\.*)\|VirtualSystem=\.*\|SourceZone=(\.*)\|DestinationZone=(\.*)\|\.*</regex>
+    <order>srcuser,dstuser,application,srczone,dstzone</order>
+</decoder>
+
+<decoder name="paloalto-threat-fields">
+    <parent>paloalto-threat</parent>
+    <regex>\.*\|IngressInterface=\.*\|EgressInterface=\.*\|LogForwardingProfile=(\.*)\|SessionID=(\.*)\|RepeatCount=(\.*)\|srcPort=(\.*)\|dstPort=(\.*)\|\.*</regex>
+    <order>logForwardingProfile,sessionID,repeatCount,srcport,dstport</order>
+</decoder>
+<decoder name="paloalto-threat-fields">
+    <parent>paloalto-threat</parent>
+    <regex>\.*\|srcPostNATPort=(\.*)\|dstPostNATPort=(\.*)\|Flags=(\.*)\|proto=(\.*)\|action=(\.*)\|Miscellaneous=(\.*)\|ThreatID=(\.*)\|\.*</regex>
+    <order>srcPostNATPort,dstPostNATPort,flags,protocol,action,miscellaneous,threatID</order>
+</decoder>
+
+<decoder name="paloalto-threat-fields">
+    <parent>paloalto-threat</parent>
+    <regex>\.*\|URLCategory=(\.*)\|sev=(\.*)\|Severity=(\.*)\|Direction=(\.*)\|sequence=(\.*)\|ActionFlags=(\.*)\|SourceLocation=(\.*)\|DestinationLocation=(\.*)\|\.*</regex>
+    <order>urlCategory,sev,severity,direction,sequence,actionFlags,srclocation,dstlocation</order>
+</decoder>
+
+<decoder name="paloalto-threat-fields">
+    <parent>paloalto-threat</parent>
+    <regex>\.*\|ContentType=(\.*)\|PCAP_ID=\.*\|FileDigest=(\.*)\|Cloud=(\.*)\|URLIndex=(\.*)\|RequestMethod=(\.*)\|Subject=(\.*)\|\.*</regex>
+    <order>contentType,fileDigest,cloud,urlIndex,requestMethod,subject</order>
+</decoder>
+
+<decoder name="paloalto-threat-fields">
+    <parent>paloalto-threat</parent>
+    <regex>\.*\|DeviceName=(\.*)\|SrcUUID=\.*\|DstUUID=\.*\|TunnelID=\.*\|MonitorTag=\.*\|ParentSessionID=\.*\|ParentStartTime=\.*\|TunnelType=(\.*)\|\.*</regex>
+    <order>deviceName,tunnelType</order>
+</decoder>
+
+<decoder name="paloalto-threat-fields">
+    <parent>paloalto-threat</parent>
+    <regex>\.*\|ThreatCategory=(\.*)\|\.*</regex>
+    <order>threatCategory</order>
+</decoder>
+<!--******************Palo Alto TRAFFIC decoders******************* -->
+<!-- 
+Mar  9 12:50:56 PANFW01 LEEF:2.0|Palo Alto Networks|PAN-OS Syslog Integration|11.1.6-h3|allow|x7C|cat=TRAFFIC|
+devTime=Mar 09 2026 08:50:55 GMT|SerialNumber=016201046640|Subtype=end|src=172.16.176.65|dst=192.9.200.227|
+srcPostNAT=0.0.0.0|dstPostNAT=0.0.0.0|RuleName=Branches-to-HO-False positive|usrName=|DestinationUser=eagle\admgr|
+Application=dns-base|VirtualSystem=vsys1|SourceZone=Untrust-Int-GW|DestinationZone=Trust-Int-GW|
+IngressInterface=ethernet1/19|EgressInterface=ethernet1/20|LogForwardingProfile=Medium Threats|SessionID=827653|
+RepeatCount=1|srcPort=54448|dstPort=53|srcPostNATPort=0|dstPostNATPort=0|Flags=0x4019|proto=udp|totalBytes=231|
+srcBytes=81|dstBytes=150|totalPackets=2|dstPackets=1|srcPackets=1|start=Mar 09 2026 08:50:55 GMT|ElapsedTime=0|
+URLCategory=any|sequence=7484098568435057916|SessionEndReason=aged-out|DeviceGroupHierarchyL1=0|DeviceGroupHierarchyL2=0|
+DeviceGroupHierarchyL3=0|vSrcName=|DeviceName=PANFW01|ActionSource=from-policy|ActionFlags=0x0|SrcUUID=|DstUUID=|TunnelID=0|
+MonitorTag=|ParentSessionID=0|ParentStartTime=|TunnelType=N/ARuleUUID=0054993b-8d33-4fb4-88c6-bcf6b79458a1|PolicyID=|
+LinkDetail=|SDWANCluster=|SDWANDevice=|SDWANClustype=|SDWANSite=|DynamicUsrgrp=|XFFIP=|SrcDeviceCat=|SrcDeviceProf=|
+SrcDeviceModel=|SrcDeviceVendor=|SrcDeviceOS=|SrcDeviceOSv=|SrcHostname=|SrcMac=|DstDeviceCat=|DstDeviceProf=|DstDeviceModel=|
+DstDeviceVendor=|DstDeviceOS=|DstDeviceOSv=|DstHostname=|DstMac=|ContainerName=|PODNamespace=|PODName
 -->
-<decoder name="paloalto-system-fields">
-  <parent>paloalto</parent>
-  <prematch type="pcre2">^[^,]*,\d+\/\d+\/\d+\s\d+:\d+:\d+,\d+,SYSTEM,</prematch>
-  <regex type="pcre2">^[^,]*,(\d+\/\d+\/\d+\s\d+:\d+:\d+),(\d+),(SYSTEM)</regex>
-  <order>receive_time, serial_number, type</order>
-</decoder>
-
-<decoder name="paloalto-system-fields">
-  <parent>paloalto</parent>
-  <regex type="pcre2" offset="after_regex">^,([^,]*),[^,]*,([^,]*),([^,]*),([^,]*),([^,]*),[^,]*,[^,]*,([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*)</regex>
-  <order>content_threat_type, generated_time, virtual_system, event_id, object, module, severity, description, sequence_number, action_flags, device_group_hierarchy_level_1, device_group_hierarchy_level_2, device_group_hierarchy_level_3, device_group_hierarchy_level_4, virtual_system_name, device_name</order>
-</decoder>
-
-<decoder name="paloalto-system-fields">
-  <parent>paloalto</parent>
-  <regex type="pcre2" offset="after_regex">^,[^,]*,[^,]*,([^,]*)</regex>
-  <order>high_resolution_timestamp</order>
-</decoder>
-
-<!-- Palo Alto traffic decoders -->
-<!-- Supported versions
-  8.0: FUTURE_USE, Receive Time, Serial Number, Type, Threat/Content Type, FUTURE_USE, Generated Time, Source Address, Destination Address, NAT Source IP, NAT Destination IP, Rule Name, Source User, Destination User, Application, Virtual System, Source Zone, Destination Zone, Inbound Interface, Outbound Interface, Log Action, FUTURE_USE, Session ID, Repeat Count, Source Port, Destination Port, NAT Source Port, NAT Destination Port, Flags, Protocol, Action, Bytes, Bytes Sent, Bytes Received, Packets, Start Time, Elapsed Time, Category, FUTURE_USE, Sequence Number, Action Flags, Source Country, Destination Country, FUTURE_USE, Packets Sent, Packets Received, Session End Reason, Device Group Hierarchy Level 1, Device Group Hierarchy Level 2, Device Group Hierarchy Level 3, Device Group Hierarchy Level 4, Virtual System Name, Device Name, Action Source, Source VM UUID, Destination VM UUID, Tunnel ID/IMSI, Monitor Tag/IMEI, Parent Session ID, Parent Start Time, Tunnel Type
-  8.1: FUTURE_USE, Receive Time, Serial Number, Type, Threat/Content Type, FUTURE_USE, Generated Time, Source Address, Destination Address, NAT Source IP, NAT Destination IP, Rule Name, Source User, Destination User, Application, Virtual System, Source Zone, Destination Zone, Inbound Interface, Outbound Interface, Log Action, FUTURE_USE, Session ID, Repeat Count, Source Port, Destination Port, NAT Source Port, NAT Destination Port, Flags, Protocol, Action, Bytes, Bytes Sent, Bytes Received, Packets, Start Time, Elapsed Time, Category, FUTURE_USE, Sequence Number, Action Flags, Source Country, Destination Country, FUTURE_USE, Packets Sent, Packets Received, Session End Reason, Device Group Hierarchy Level 1, Device Group Hierarchy Level 2, Device Group Hierarchy Level 3, Device Group Hierarchy Level 4, Virtual System Name, Device Name, Action Source, Source VM UUID, Destination VM UUID, Tunnel ID/IMSI, Monitor Tag/IMEI, Parent Session ID, Parent Start Time, Tunnel Type, SCTP Association ID, SCTP Chunks, SCTP Chunks Sent, SCTP Chunks Received
-  9.0: FUTURE_USE, Receive Time, Serial Number, Type, Threat/Content Type, FUTURE_USE, Generated Time, Source Address, Destination Address, NAT Source IP, NAT Destination IP, Rule Name, Source User, Destination User, Application, Virtual System, Source Zone, Destination Zone, Inbound Interface, Outbound Interface, Log Action, FUTURE_USE, Session ID, Repeat Count, Source Port, Destination Port, NAT Source Port, NAT Destination Port, Flags, Protocol, Action, Bytes, Bytes Sent, Bytes Received, Packets, Start Time, Elapsed Time, Category, FUTURE_USE, Sequence Number, Action Flags, Source Country, Destination Country, FUTURE_USE, Packets Sent, Packets Received, Session End Reason, Device Group Hierarchy Level 1, Device Group Hierarchy Level 2, Device Group Hierarchy Level 3, Device Group Hierarchy Level 4, Virtual System Name, Device Name, Action Source, Source VM UUID, Destination VM UUID, Tunnel ID/IMSI, Monitor Tag/IMEI, Parent Session ID, Parent Start Time, Tunnel Type, SCTP Association ID, SCTP Chunks, SCTP Chunks Sent, SCTP Chunks Received, Rule UUID, HTTP/2 Connection
-  9.1: FUTURE_USE, Receive Time, Serial Number, Type, Threat/Content Type, FUTURE_USE, Generated Time, Source Address, Destination Address, NAT Source IP, NAT Destination IP, Rule Name, Source User, Destination User, Application, Virtual System, Source Zone, Destination Zone, Inbound Interface, Outbound Interface, Log Action, FUTURE_USE, Session ID, Repeat Count, Source Port, Destination Port, NAT Source Port, NAT Destination Port, Flags, Protocol, Action, Bytes, Bytes Sent, Bytes Received, Packets, Start Time, Elapsed Time, Category, FUTURE_USE, Sequence Number, Action Flags, Source Country, Destination Country, FUTURE_USE, Packets Sent, Packets Received, Session End Reason, Device Group Hierarchy Level 1, Device Group Hierarchy Level 2, Device Group Hierarchy Level 3, Device Group Hierarchy Level 4, Virtual System Name, Device Name, Action Source, Source VM UUID, Destination VM UUID, Tunnel ID/IMSI, Monitor Tag/IMEI, Parent Session ID, Parent Start Time, Tunnel Type, SCTP Association ID, SCTP Chunks, SCTP Chunks Sent, SCTP Chunks Received, Rule UUID, HTTP/2 Connection, App Flap Count, Policy ID, Link Switches, SD-WAN Cluster, SD-WAN Device Type, SD-WAN Cluster Type, SD-WAN Site, Dynamic User Group Name
-  10.0: FUTURE_USE, Receive Time, Serial Number, Type, Threat/Content Type, FUTURE_USE, Generated Time, Source Address, Destination Address, NAT Source IP, NAT Destination IP, Rule Name, Source User, Destination User, Application, Virtual System, Source Zone, Destination Zone, Inbound Interface, Outbound Interface, Log Action, FUTURE_USE, Session ID, Repeat Count, Source Port, Destination Port, NAT Source Port, NAT Destination Port, Flags, Protocol, Action, Bytes, Bytes Sent, Bytes Received, Packets, Start Time, Elapsed Time, Category, FUTURE_USE, Sequence Number, Action Flags, Source Country, Destination Country, FUTURE_USE, Packets Sent, Packets Received, Session End Reason, Device Group Hierarchy Level 1, Device Group Hierarchy Level 2, Device Group Hierarchy Level 3, Device Group Hierarchy Level 4, Virtual System Name, Device Name, Action Source, Source VM UUID, Destination VM UUID, Tunnel ID/IMSI, Monitor Tag/IMEI, Parent Session ID, Parent Start Time, Tunnel Type, SCTP Association ID, SCTP Chunks, SCTP Chunks Sent, SCTP Chunks Received, Rule UUID, HTTP/2 Connection, App Flap Count, Policy ID, Link Switches, SD-WAN Cluster, SD-WAN Device Type, SD-WAN Cluster Type, SD-WAN Site, Dynamic User Group Name, XFF Address, Source Device Category, Source Device Profile, Source Device Model, Source Device Vendor, Source Device OS Family, Source Device OS Version, Source Hostname, Source Mac Address, Destination Device Category, Destination Device Profile, Destination Device Model, Destination Device Vendor, Destination Device OS Family, Destination Device OS Version, Destination Hostname, Destination Mac Address, Container ID, POD Namespace, POD Name, Source External Dynamic List, Destination External Dynamic List, Host ID, Serial Number, Source Dynamic Address Group, Destination Dynamic Address Group, Session Owner, High Resolution Timestamp, A Slice Service Type, A Slice Differentiator
-  10.1: FUTURE_USE, Receive Time, Serial Number, Type, Threat/Content Type, FUTURE_USE, Generated Time, Source Address, Destination Address, NAT Source IP, NAT Destination IP, Rule Name, Source User, Destination User, Application, Virtual System, Source Zone, Destination Zone, Inbound Interface, Outbound Interface, Log Action, FUTURE_USE, Session ID, Repeat Count, Source Port, Destination Port, NAT Source Port, NAT Destination Port, Flags, Protocol, Action, Bytes, Bytes Sent, Bytes Received, Packets, Start Time, Elapsed Time, Category, FUTURE_USE, Sequence Number, Action Flags, Source Country, Destination Country, FUTURE_USE, Packets Sent, Packets Received, Session End Reason, Device Group Hierarchy Level 1, Device Group Hierarchy Level 2, Device Group Hierarchy Level 3, Device Group Hierarchy Level 4, Virtual System Name, Device Name, Action Source, Source VM UUID, Destination VM UUID, Tunnel ID/IMSI, Monitor Tag/IMEI, Parent Session ID, Parent Start Time, Tunnel Type, SCTP Association ID, SCTP Chunks, SCTP Chunks Sent, SCTP Chunks Received, Rule UUID, HTTP/2 Connection, App Flap Count, Policy ID, Link Switches, SD-WAN Cluster, SD-WAN Device Type, SD-WAN Cluster Type, SD-WAN Site, Dynamic User Group Name, XFF Address, Source Device Category, Source Device Profile, Source Device Model, Source Device Vendor, Source Device OS Family, Source Device OS Version, Source Hostname, Source Mac Address, Destination Device Category, Destination Device Profile, Destination Device Model, Destination Device Vendor, Destination Device OS Family, Destination Device OS Version, Destination Hostname, Destination Mac Address, Container ID, POD Namespace, POD Name, Source External Dynamic List, Destination External Dynamic List, Host ID, Serial Number, Source Dynamic Address Group, Destination Dynamic Address Group, Session Owner, High Resolution Timestamp, A Slice Service Type, A Slice Differentiator, Application Subcategory, Application Category, Application Technology, Application Risk, Application Characteristic, Application Container, Application SaaS, Application Sanctioned State
--->
-<decoder name="paloalto-traffic-fields">
-  <parent>paloalto</parent>
-  <prematch type="pcre2">^[^,]*,\d+\/\d+\/\d+\s\d+:\d+:\d+,\d+,TRAFFIC,</prematch>
-  <regex type="pcre2">^[^,]*,(\d+\/\d+\/\d+\s\d+:\d+:\d+),(\d+),(TRAFFIC)</regex>
-  <order>receive_time, serial_number, type</order>
+<!--
+  Fields: devTime,SerialNumber,Subtype,src,dst,srcPostNAT,dstPostNAT,RuleName,usrName,DestinationUser,
+  Application,VirtualSystem,SourceZone,DestinationZone,IngressInterface,EgressInterface,LogForwardingProfile,
+  SessionID,srcBytes,dstBytes,totalPackets,dstPackets,srcPackets,start,ElapsedTime,URLCategory,sequence,
+  SessionEndReason,DeviceGroupHierarchyL1,DeviceGroupHierarchyL2,DeviceGroupHierarchyL3,vSrcName,DeviceName,
+  ActionSource,ActionFlags,SrcUUID,DstUUID,TunnelID,MonitorTag,ParentSessionID,ParentStartTime,
+--> 
+<decoder name="paloalto-traffic">
+    <type>syslog</type>
+    <program_name>LEEF</program_name>
+    <prematch type="pcre2">cat=TRAFFIC</prematch>
 </decoder>
 
 <decoder name="paloalto-traffic-fields">
-  <parent>paloalto</parent>
-  <regex type="pcre2" offset="after_regex">^,([^,]*),[^,]*,([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),[^,]*,([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),[^,]*,([^,]*),([^,]*),([^,]*),([^,]*),[^,]*,([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*)</regex>
-  <order>content_type, generated_time, source_address, destination_address, nat_source_ip, nat_destination_ip, rule_name, source_user, destination_user, application, virtual_system, source_zone, destination_zone, inbound_interface, outbound_interface, log_action, session_id, repeat_count, source_port, destination_port, nat_source_port, nat_destination_port, flags, protocol, action, bytes, bytes_sent, bytes_received, packets, start_time, elapsed_time, category, sequence_number, action_flags, source_country, destination_country, packets_sent, packets_received, session_end_reason, device_group_hierarchy_level_1, device_group_hierarchy_level_2, device_group_hierarchy_level_3, device_group_hierarchy_level_4, virtual_system_name, device_name, action_source, source_vm_uuid, destination_vm_uuid, tunnel_id_imsi, monitor_tag_imei, parent_session_id, parent_start_time, tunnel_type</order>
+    <parent>paloalto-traffic</parent>
+    <regex>\.*\|devTime=(\.*)\|SerialNumber=\.*\|Subtype=(\.*)\|src=(\.*)\|dst=(\.*)\|srcPostNAT=(\.*)\|dstPostNAT=(\.*)\|RuleName=(\.*)\|\.*</regex>
+    <order>devTime,subtype,srcip,dstip,srcipPostNAT,dstipPostNAT,rulename</order>
 </decoder>
 
 <decoder name="paloalto-traffic-fields">
-  <parent>paloalto</parent>
-  <regex type="pcre2" offset="after_regex">^,([^,]*),([^,]*),([^,]*),([^,]*)</regex>
-  <order>sctp_association_id, sctp_chunks, sctp_chunks_sent, sctp_chunks_received</order>
+    <parent>paloalto-traffic</parent>
+    <regex>\.*\|usrName=(\.*)\|DestinationUser=(\.*)\|Application=(\.*)\|VirtualSystem=\.*\|SourceZone=(\.*)\|DestinationZone=(\.*)\|\.*</regex>
+    <order>srcuser,dstuser,application,srczone,dstzone</order>
 </decoder>
 
 <decoder name="paloalto-traffic-fields">
-  <parent>paloalto</parent>
-  <regex type="pcre2" offset="after_regex">^,([^,]*),([^,]*)</regex>
-  <order>rule_uuid, http_2_connection</order>
+    <parent>paloalto-traffic</parent>
+    <regex>\.*\|IngressInterface=\.*\|EgressInterface=\.*\|LogForwardingProfile=\.*\|SessionID=(\.*)\|srcBytes=\.*\|dstBytes=\.*\|totalPackets=(\.*)\|\.*</regex>
+    <order>sessionID,totalPackets</order>
 </decoder>
 
 <decoder name="paloalto-traffic-fields">
-  <parent>paloalto</parent>
-  <regex type="pcre2" offset="after_regex">^,([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*)</regex>
-  <order>app_flap_count, policy_id, link_switches, sd_wan_cluster, sd_wan_device_type, sd_wan_cluster_type, sd_wan_site, dynamic_user_group_name</order>
+    <parent>paloalto-traffic</parent>
+    <regex>\.*\|dstPackets=(\.*)\|srcPackets=(\.*)\|start=(\.*)\|ElapsedTime=(\.*)\|URLCategory=(\.*)\|sequence=\.*\|SessionEndReason=(\.*)\|\.*</regex>
+    <order>dstPackets,srcPackets,start,elapsedTime,urlCategory,sessionEndReason</order>
 </decoder>
 
 <decoder name="paloalto-traffic-fields">
-  <parent>paloalto</parent>
-  <regex type="pcre2" offset="after_regex">^,([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*)</regex>
-  <order>xff_address, source_device_category, source_device_profile, source_device_model, source_device_vendor, source_device_os_family, source_device_os_version, source_hostname, source_mac_address, destination_device_category, destination_device_profile, destination_device_model, destination_device_vendor, destination_device_os_family, destination_device_os_version, destination_hostname, destination_mac_address, container_id, pod_namespace, pod_name, source_external_dynamic_list, destination_external_dynamic_list, host_id, serial_number, source_dynamic_address_group, destination_dynamic_address_group, session_owner, high_resolution_timestamp, a_slice_service_type, a_slice_differentiator</order>
+    <parent>paloalto-traffic</parent>
+    <regex>\.*\|DeviceGroupHierarchyL1=\.*\|DeviceGroupHierarchyL2=\.*\|DeviceGroupHierarchyL3=\.*\|vSrcName=\.*\|DeviceName=(\.*)\|ActionFlags=(\.*)\|\.*</regex>
+    <order>deviceName,actionFlags</order>
 </decoder>
 
 <decoder name="paloalto-traffic-fields">
-  <parent>paloalto</parent>
-  <regex type="pcre2" offset="after_regex">^,([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*)</regex>
-  <order>application_subcategory, application_category, application_technology, application_risk, application_characteristic, application_container, application_saas, application_sanctioned_state</order>
-</decoder>
-
-<!-- Palo Alto config decoders -->
-<!-- Supported versions
-  8.X: FUTURE_USE, Receive Time, Serial Number, Type, Subtype, FUTURE_USE, Generated Time, Host, Virtual System, Command, Admin, Client, Result, Configuration Path, Before Change Detail, After Change Detail, Sequence Number, Action Flags, Device Group Hierarchy Level 1, Device Group Hierarchy Level 2, Device Group Hierarchy Level 3, Device Group Hierarchy Level 4, Virtual System Name, Device Name
-  9->10.X: FUTURE_USE, Receive Time, Serial Number, Type, Subtype, FUTURE_USE, Generated Time, Host, Virtual System, Command, Admin, Client, Result, Configuration Path, Before Change Detail, After Change Detail, Sequence Number, Action Flags, Device Group Hierarchy Level 1, Device Group Hierarchy Level 2, Device Group Hierarchy Level 3, Device Group Hierarchy Level 4, Virtual System Name, Device Name, Device Group, Audit Comment
--->
-<decoder name="paloalto-config-fields">
-  <parent>paloalto</parent>
-  <prematch type="pcre2">^[^,]*,\d+\/\d+\/\d+\s\d+:\d+:\d+,\d+,CONFIG,</prematch>
-  <regex type="pcre2">^[^,]*,(\d+\/\d+\/\d+\s\d+:\d+:\d+),(\d+),(CONFIG)</regex>
-  <order>receive_time, serial_number, type</order>
-</decoder>
-
-<decoder name="paloalto-config-fields">
-  <parent>paloalto</parent>
-  <regex type="pcre2" offset="after_regex">^,([^,]*),[^,]*,([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*)</regex>
-  <order>subtype, generated_time, host, virtual_system, command, admin, client, result, configuration_path, before_change_detail, after_change_detail, sequence_number, action_flags, device_group_hierarchy_level_1, device_group_hierarchy_level_2, device_group_hierarchy_level_3, device_group_hierarchy_level_4, virtual_system_name, device_name</order>
-</decoder>
-
-<decoder name="paloalto-config-fields">
-  <parent>paloalto</parent>
-  <regex type="pcre2" offset="after_regex">^,([^,]*),([^,]*)</regex>
-  <order>device_group, audit_comment</order>
-</decoder>
-
-<!-- Palo Alto threat decoders -->
-<!-- Supported versions
-  8.0: FUTURE_USE, Receive Time, Serial Number, Type, Threat/Content Type, FUTURE_USE, Generated Time, Source Address, Destination Address, NAT Source IP, NAT Destination IP, Rule Name, Source User, Destination User, Application, Virtual System, Source Zone, Destination Zone, Inbound Interface, Outbound Interface, Log Action, FUTURE_USE, Session ID, Repeat Count, Source Port, Destination Port, NAT Source Port, NAT Destination Port, Flags, IP Protocol, Action, URL/Filename, Threat ID, Category, Severity, Direction, Sequence Number, Action Flags, Source Location, Destination Location, FUTURE_USE, Content Type, PCAP_ID, File Digest, Cloud, URL Index, User Agent, File Type, X-Forwarded-For, Referer, Sender, Subject, Recipient, Report ID, Device Group Hierarchy Level 1, Device Group Hierarchy Level 2, Device Group Hierarchy Level 3, Device Group Hierarchy Level 4, Virtual System Name, Device Name, FUTURE_USE, Source VM UUID, Destination VM UUID, HTTP Method, Tunnel ID/IMSI, Monitor Tag/IMEI, Parent Session ID, Parent Start Time, Tunnel Type, Threat Category, Content Version, FUTURE_USE
-  8.1: FUTURE_USE, Receive Time, Serial Number, Type, Threat/Content Type, FUTURE_USE, Generated Time, Source Address, Destination Address, NAT Source IP, NAT Destination IP, Rule Name, Source User, Destination User, Application, Virtual System, Source Zone, Destination Zone, Inbound Interface, Outbound Interface, Log Action, FUTURE_USE, Session ID, Repeat Count, Source Port, Destination Port, NAT Source Port, NAT Destination Port, Flags, IP Protocol, Action, URL/Filename, Threat ID, Category, Severity, Direction, Sequence Number, Action Flags, Source Location, Destination Location, FUTURE_USE, Content Type, PCAP_ID, File Digest, Cloud, URL Index, User Agent, File Type, X-Forwarded-For, Referer, Sender, Subject, Recipient, Report ID, Device Group Hierarchy Level 1, Device Group Hierarchy Level 2, Device Group Hierarchy Level 3, Device Group Hierarchy Level 4, Virtual System Name, Device Name, FUTURE_USE, Source VM UUID, Destination VM UUID, HTTP Method, Tunnel ID/IMSI, Monitor Tag/IMEI, Parent Session ID, Parent Start Time, Tunnel Type, Threat Category, Content Version, FUTURE_USE, SCTP Association ID, Payload Protocol ID, HTTP Headers
-  9.0: FUTURE_USE, Receive Time, Serial Number, Type, Threat/Content Type, FUTURE_USE, Generated Time, Source Address, Destination Address, NAT Source IP, NAT Destination IP, Rule Name, Source User, Destination User, Application, Virtual System, Source Zone, Destination Zone, Inbound Interface, Outbound Interface, Log Action, FUTURE_USE, Session ID, Repeat Count, Source Port, Destination Port, NAT Source Port, NAT Destination Port, Flags, IP Protocol, Action, URL/Filename, Threat ID, Category, Severity, Direction, Sequence Number, Action Flags, Source Location, Destination Location, FUTURE_USE, Content Type, PCAP_ID, File Digest, Cloud, URL Index, User Agent, File Type, X-Forwarded-For, Referer, Sender, Subject, Recipient, Report ID, Device Group Hierarchy Level 1, Device Group Hierarchy Level 2, Device Group Hierarchy Level 3, Device Group Hierarchy Level 4, Virtual System Name, Device Name, FUTURE_USE, Source VM UUID, Destination VM UUID, HTTP Method, Tunnel ID/IMSI, Monitor Tag/IMEI, Parent Session ID, Parent Start Time, Tunnel Type, Threat Category, Content Version, FUTURE_USE, SCTP Association ID, Payload Protocol ID, HTTP Headers, URL Category List, Rule UUID, HTTP/2 Connection
-  9.1: FUTURE_USE, Receive Time, Serial Number, Type, Threat/Content Type, FUTURE_USE, Generated Time, Source Address, Destination Address, NAT Source IP, NAT Destination IP, Rule Name, Source User, Destination User, Application, Virtual System, Source Zone, Destination Zone, Inbound Interface, Outbound Interface, Log Action, FUTURE_USE, Session ID, Repeat Count, Source Port, Destination Port, NAT Source Port, NAT Destination Port, Flags, IP Protocol, Action, URL/Filename, Threat ID, Category, Severity, Direction, Sequence Number, Action Flags, Source Location, Destination Location, FUTURE_USE, Content Type, PCAP_ID, File Digest, Cloud, URL Index, User Agent, File Type, X-Forwarded-For, Referer, Sender, Subject, Recipient, Report ID, Device Group Hierarchy Level 1, Device Group Hierarchy Level 2, Device Group Hierarchy Level 3, Device Group Hierarchy Level 4, Virtual System Name, Device Name, FUTURE_USE, Source VM UUID, Destination VM UUID, HTTP Method, Tunnel ID/IMSI, Monitor Tag/IMEI, Parent Session ID, Parent Start Time, Tunnel Type, Threat Category, Content Version, FUTURE_USE, SCTP Association ID, Payload Protocol ID, HTTP Headers, URL Category List, Rule UUID, HTTP/2 Connection, Dynamic User Group Name
-  10.0: FUTURE_USE, Receive Time, Serial Number, Type, Threat/Content Type, FUTURE_USE, Generated Time, Source Address, Destination Address, NAT Source IP, NAT Destination IP, Rule Name, Source User, Destination User, Application, Virtual System, Source Zone, Destination Zone, Inbound Interface, Outbound Interface, Log Action, FUTURE_USE, Session ID, Repeat Count, Source Port, Destination Port, NAT Source Port, NAT Destination Port, Flags, IP Protocol, Action, URL/Filename, Threat ID, Category, Severity, Direction, Sequence Number, Action Flags, Source Location, Destination Location, FUTURE_USE, Content Type, PCAP_ID, File Digest, Cloud, URL Index, User Agent, File Type, X-Forwarded-For, Referer, Sender, Subject, Recipient, Report ID, Device Group Hierarchy Level 1, Device Group Hierarchy Level 2, Device Group Hierarchy Level 3, Device Group Hierarchy Level 4, Virtual System Name, Device Name, FUTURE_USE, Source VM UUID, Destination VM UUID, HTTP Method, Tunnel ID/IMSI, Monitor Tag/IMEI, Parent Session ID, Parent Start Time, Tunnel Type, Threat Category, Content Version, FUTURE_USE, SCTP Association ID, Payload Protocol ID, HTTP Headers, URL Category List, Rule UUID, HTTP/2 Connection, Dynamic User Group Name, XFF Address, Source Device Category, Source Device Profile, Source Device Model, Source Device Vendor, Source Device OS Family, Source Device OS Version, Source Hostname, Source MAC Address, Destination Device Category, Destination Device Profile, Destination Device Model, Destination Device Vendor, Destination Device OS Family, Destination Device OS Version, Destination Hostname, Destination MAC Address, Container ID, POD Namespace, POD Name, Source External Dynamic List, Destination External Dynamic List, Host ID, Serial Number, Domain EDL, Source Dynamic Address Group, Destination Dynamic Address Group, Session Owner, Partial Hash, High Resolution Timestamp, Reason, Justification, A Slice Service Type
-  10.1: FUTURE_USE, Receive Time, Serial Number, Type, Threat/Content Type, FUTURE_USE, Generated Time, Source Address, Destination Address, NAT Source IP, NAT Destination IP, Rule Name, Source User, Destination User, Application, Virtual System, Source Zone, Destination Zone, Inbound Interface, Outbound Interface, Log Action, FUTURE_USE, Session ID, Repeat Count, Source Port, Destination Port, NAT Source Port, NAT Destination Port, Flags, IP Protocol, Action, URL/Filename, Threat ID, Category, Severity, Direction, Sequence Number, Action Flags, Source Location, Destination Location, FUTURE_USE, Content Type, PCAP_ID, File Digest, Cloud, URL Index, User Agent, File Type, X-Forwarded-For, Referer, Sender, Subject, Recipient, Report ID, Device Group Hierarchy Level 1, Device Group Hierarchy Level 2, Device Group Hierarchy Level 3, Device Group Hierarchy Level 4, Virtual System Name, Device Name, FUTURE_USE, Source VM UUID, Destination VM UUID, HTTP Method, Tunnel ID/IMSI, Monitor Tag/IMEI, Parent Session ID, Parent Start Time, Tunnel Type, Threat Category, Content Version, FUTURE_USE, SCTP Association ID, Payload Protocol ID, HTTP Headers, URL Category List, Rule UUID, HTTP/2 Connection, Dynamic User Group Name, XFF Address, Source Device Category, Source Device Profile, Source Device Model, Source Device Vendor, Source Device OS Family, Source Device OS Version, Source Hostname, Source MAC Address, Destination Device Category, Destination Device Profile, Destination Device Model, Destination Device Vendor, Destination Device OS Family, Destination Device OS Version, Destination Hostname, Destination MAC Address, Container ID, POD Namespace, POD Name, Source External Dynamic List, Destination External Dynamic List, Host ID, Serial Number, Domain EDL, Source Dynamic Address Group, Destination Dynamic Address Group, Session Owner, Partial Hash, High Resolution Timestamp, Reason, Justification, A Slice Service Type, Application Subcategory, Application Category, Application Technology, Application Risk, Application Characteristic, Application Container, Application SaaS, Application Sanctioned State
--->
-<decoder name="paloalto-threat-fields">
-  <parent>paloalto</parent>
-  <prematch type="pcre2">^[^,]*,\d+\/\d+\/\d+\s\d+:\d+:\d+,\d+,THREAT,</prematch>
-  <regex type="pcre2">^[^,]*,(\d+\/\d+\/\d+\s\d+:\d+:\d+),(\d+),(THREAT)</regex>
-  <order>receive_time, serial_number, type</order>
-</decoder>
-
-<decoder name="paloalto-threat-fields">
-  <parent>paloalto</parent>
-  <regex type="pcre2" offset="after_regex">^,([^,]*),[^,]*,([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),[^,]*,([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),[^,]*,([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),[^,]*,([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),[^,]*</regex>
-  <order>threat_content_type, generated_time, source_address, destination_address, nat_source_ip, nat_destination_ip, rule_name, source_user, destination_user, application, virtual_system, source_zone, destination_zone, inbound_interface, outbound_interface, log_action, session_id, repeat_count, source_port, destination_port, nat_source_port, nat_destination_port, flags, ip_protocol, action, url_filename, threat_id, category, severity, direction, sequence_number, action_flags, source_location, destination_location, content_type, pcap_id, file_digest, cloud, url_index, user_agent, file_type, x_forwarded_for, referer, sender, subject, recipient, report_id, device_group_hierarchy_level_1, device_group_hierarchy_level_2, device_group_hierarchy_level_3, device_group_hierarchy_level_4, virtual_system_name, device_name, source_vm_uuid, destination_vm_uuid, http_method, tunnel_id_imsi, monitor_tag_imei, parent_session_id, parent_start_time, tunnel_type, threat_category, content_version</order>
-</decoder>
-
-<decoder name="paloalto-threat-fields">
-  <parent>paloalto</parent>
-  <regex type="pcre2" offset="after_regex">^,([^,]*),([^,]*),([^,]*)</regex>
-  <order>sctp_association_id, payload_protocol_id, http_headers</order>
-</decoder>
-
-<decoder name="paloalto-threat-fields">
-  <parent>paloalto</parent>
-  <regex type="pcre2" offset="after_regex">^,([^,]*),([^,]*),([^,]*)</regex>
-  <order>url_category_list, rule_uuid, http_2_connection</order>
-</decoder>
-
-<decoder name="paloalto-threat-fields">
-  <parent>paloalto</parent>
-  <regex type="pcre2" offset="after_regex">^,([^,]*)</regex>
-  <order>dynamic_user_group_name</order>
-</decoder>
-
-<decoder name="paloalto-threat-fields">
-  <parent>paloalto</parent>
-  <regex type="pcre2" offset="after_regex">^,([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*)</regex>
-  <order>xff_address, source_device_category, source_device_profile, source_device_model, source_device_vendor, source_device_os_family, source_device_os_version, source_hostname, source_mac_address, destination_device_category, destination_device_profile, destination_device_model, destination_device_vendor, destination_device_os_family, destination_device_os_version, destination_hostname, destination_mac_address, container_id, pod_namespace, pod_name, source_external_dynamic_list, destination_external_dynamic_list, host_id, serial_number, domain_edl, source_dynamic_address_group, destination_dynamic_address_group, session_owner, partial_hash, high_resolution_timestamp, reason, justification, a_slice_service_type</order>
-</decoder>
-
-<decoder name="paloalto-threat-fields">
-  <parent>paloalto</parent>
-  <regex type="pcre2" offset="after_regex">^,([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*),([^,]*)</regex>
-  <order>application_subcategory, application_category, application_technology, application_risk, application_characteristic, application_container, application_saas, application_sanctioned_state</order>
-</decoder>
-
-<!-- Generic decoder for others modules not decoded further-->
-<decoder name="paloalto-others">
-  <parent>paloalto</parent>
-  <prematch type="pcre2">^[^,]*,\d+\/\d+\/\d+\s\d+:\d+:\d+,\d+,\w+,</prematch>
-  <regex type="pcre2">^[^,]*,(\d+\/\d+\/\d+\s\d+:\d+:\d+),(\d+),(\w+)</regex>
-  <order>receive_time, serial_number, type</order>
+    <parent>paloalto-traffic</parent>
+    <regex>\.*\|SrcUUID=\.*\|DstUUID=\.*\|TunnelID=\.*\|MonitorTag=\.*\|ParentSessionID=(\.*)\|ParentStartTime=(\.*)\|\.*</regex>
+    <order>parentSessionID,parentStartTime</order>
 </decoder>

--- a/ruleset/rules/0700-paloalto_rules.xml
+++ b/ruleset/rules/0700-paloalto_rules.xml
@@ -1,77 +1,64 @@
 <!--
-  Copyright (C) 2015, Wazuh Inc.
--->
-
-<!-- 
-  Palo Alto v8.X - v10.X rules
-    Palo Alto rules ID:           64500 - 64508
+  Palo Alto v11.1 rules.
 -->
 
 <group name="paloalto,">
+    <!-- paltoalto system -->
+    <rule id="64500" level="0">
+        <decoded_as>paloalto-system</decoded_as>
+        <description>paloalto System decoded grouped alerts</description>
+    </rule>
+    <rule id="64501" level="5">
+        <if_sid>64500</if_sid>
 
-  <!-- Generic rule -->
-  <rule id="64500" level="0">
-    <decoded_as>paloalto</decoded_as>
-    <description>Palo Alto $(type) event.</description>
-  </rule>
+        <field name="severity" type="pcre2">^(?!\s*(?i)(informational|low)?\s*$).+</field>
+        <description>System alert has been triggered</description>
+    </rule>
+    
+    <!-- paltoalto iptag -->
+    <rule id="64510" level="0">
+        <decoded_as>paloalto-iptag</decoded_as>
+        <description>paloalto IPtag decoded grouped alerts</description>
+    </rule>
 
-  <!-- Generic by severity(informational, low, medium, high, critical) rules, THREAT and SYSTEM only so far -->
-  <rule id="64501" level="2">
-    <if_sid>64500</if_sid>
-    <field name="severity" type="pcre2">(?i)^(?:informational|low)$</field>
-    <description>Palo Alto $(type): $(severity) event.</description>
-  </rule>
+    <!-- paltoalto userid -->
+    <rule id="64520" level="0">
+        <decoded_as>paloalto-userid</decoded_as>
+        <description>paloalto UserId decoded grouped alerts</description>
+    </rule>
 
-  <rule id="64502" level="3">
-    <if_sid>64500</if_sid>
-    <field name="severity" type="pcre2">(?i)^medium$</field>
-    <description>Palo Alto $(type): $(severity) event.</description>
-  </rule>
+    <!-- paltoalto hipmatch -->
+    <rule id="64530" level="0">
+        <decoded_as>paloalto-hipmatch</decoded_as>
+        <description>paloalto Hipmatch decoded grouped alerts</description>
+    </rule>
 
-  <rule id="64503" level="5">
-    <if_sid>64500</if_sid>
-    <field name="severity" type="pcre2">(?i)^high$</field>
-    <description>Palo Alto $(type): $(severity) event.</description>
-  </rule>
+    <!-- paltoalto threat -->
+    <rule id="64540" level="0">
+        <decoded_as>paloalto-threat</decoded_as>
+        <description>paloalto Threat decoded grouped alerts</description>
+    </rule>
+    <rule id="64541" level="5">
+        <if_sid>64540</if_sid>
+        <field name="severity" type="pcre2">^(?!\s*(?i)(informational|low)?\s*$).+</field>
+        <description>$(threatCategory) threat alert has been triggered</description>
+    </rule>
 
-  <rule id="64504" level="11">
-    <if_sid>64500</if_sid>
-    <field name="severity" type="pcre2">(?i)^critical$</field>
-    <description>Palo Alto $(type): $(severity) event.</description>
-  </rule>
+    <!-- paltoalto traffic -->
+    <rule id="64550" level="0">
+        <decoded_as>paloalto-traffic</decoded_as>
+        <description>paloalto Traffic decoded grouped alerts</description>
+    </rule>
 
-  <!-- Specific rules -->
-  <!-- Traffic -->
-  <rule id="64505" level="0">
-    <if_sid>64500</if_sid>
-    <field name="type">^Traffic$</field>
-    <field name="content_type" type="pcre2">(?i)^.+$</field>
-    <description>Palo Alto Traffic: $(content_type) event.</description>
-  </rule>
-
-  <rule id="64506" level="2">
-    <if_sid>64505</if_sid>
-    <field name="content_type">start</field>
-    <description>Palo Alto Traffic: Session started log on $(device_name).</description>
-    <group>gdpr_IV_35.7.d,gpg13_4.12,hipaa_164.312.b,pci_dss_1.4,pci_dss_10.6.1,pci_dss_11.4,tsc_CC6.1,tsc_CC6.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,tsc_CC7.4,</group>
-  </rule>
-
-  <rule id="64507" level="2">
-    <if_sid>64505</if_sid>
-    <field name="content_type">end</field>
-    <description>Palo Alto Traffic: Session ended on $(device_name) from $(source_address) to $(destination_address). Reason: $(session_end_reason).</description>
-    <group>gdpr_IV_35.7.d,gpg13_4.12,hipaa_164.312.b,pci_dss_1.4,pci_dss_10.6.1,pci_dss_11.4,tsc_CC6.1,tsc_CC6.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,tsc_CC7.4,</group>
-  </rule>
-
-  <rule id="64508" level="6">
-    <if_sid>64505</if_sid>
-    <field name="content_type" type="pcre2">^(?:drop|deny)$</field>
-    <description>Palo Alto Traffic: Session dropped  on $(device_name) from $(source_address) to $(destination_address). Reason: $(session_end_reason). Action: $(action).</description>
-    <mitre>
-      <id>T1072</id>
-      <id>T1190</id>
-    </mitre>
-    <group>gdpr_IV_35.7.d,gpg13_4.12,hipaa_164.312.b,pci_dss_1.4,pci_dss_10.6.1,pci_dss_11.4,tsc_CC6.1,tsc_CC6.7,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,tsc_CC7.4,</group>
-  </rule>
-
+    <rule id="64551" level="2">
+        <if_sid>64550</if_sid>
+        <field name="subtype" type="pcre2">^(?!\s*(?i)(start|end)?\s*$).+</field>
+        <description>traffic from $(srcip) has been seen dropped or denied</description>
+    </rule>
+    <rule id="64552" level="5" frequency="5" timeframe="180">
+        <if_matched_sid>64551</if_matched_sid>
+        <same_srcip/>
+        <same_dstip/>
+        <description>traffic from $(srcip) to $(dstip) has been denied or dropped for multiple times</description>
+    </rule>
 </group>

--- a/ruleset/testing/tests/paloalto.ini
+++ b/ruleset/testing/tests/paloalto.ini
@@ -1,74 +1,70 @@
 ;  Copyright (C) 2015, Wazuh Inc.
 ;
-;  Tests for products: 
-;    Palo Alto v8.X - v10.X rules
+;  Tests for products:
+;    Palo Alto v11.x rules
 ;
-;  Sample logs source: 
+;  Sample logs source:
 ;    Vendor: Palo Alto Networks
-;    Model: Panorama
+;    Model: PAN-OS Syslog Integration (LEEF format)
 ;      SYSTEM Logs
-;      CONFIG Logs
-;      TRAFFIC Logs
+;      IPTAG Logs
+;      USERID Logs
+;      HIPMATCH Logs
 ;      THREAT Logs
+;      TRAFFIC Logs
 
+;# Can't yet test frequency  <rule id="64552" level="5" frequency="5" timeframe="180">
 
-[Palo Alto generic]
-log 1 pass = Apr 30 06:00:00 xx-xx-xx.xx 1,2020/02/09 00:00:00,00000000,SYSTEM,
-log 2 pass = Apr 30 06:00:00 xx-xx-xx.xx 1,2020/02/09 00:00:00,00000000,TRAFFIC,
-log 3 pass = Apr 30 06:00:00 xx-xx-xx.xx 1,2020/02/09 00:00:00,00000000,CONFIG,
-log 4 pass = Apr 30 06:00:00 xx-xx-xx.xx 1,2020/02/09 00:00:00,00000000,THREAT,
-log 5 pass = Apr 30 06:00:00 xx-xx-xx.xx 1,2020/02/09 00:00:00,00000000,OTHERS,
+[Palo Alto system grouped]
+log 1 pass = Feb 12 13:34:18 PANFW01 LEEF:2.0|Palo Alto Networks|PAN-OS Syslog Integration|11.1.6-h3|auth-success|x7C|TimeReceived=2026/02/12 13:34:17|DeviceSN=016201046640|cat=SYSTEM|Subtype=auth|devTime=Feb 12 2026 09:34:17 GMT|VirtualSystem=|Filename=|Module=general|sev=1|Severity=informational|msg="authenticated for user 'seyam_backup'.   From: 172.16.3.99."|sequence=7484098496036218022|ActionFlags=0x0|DeviceGroupHierarchyL1=0|DeviceGroupHierarchyL2=0|DeviceGroupHierarchyL3=0|DeviceGroupHierarchyL4=0|vSrcName=|DeviceName=PANFW01|
 rule = 64500
 alert = 0
-decoder = paloalto
+decoder = paloalto-system
 
-[Palo Alto severity informational/low]
-log 1 pass = Apr 30 06:00:00 xx-xx-xx.xx 1,2020/02/09 00:00:00,00000000,SYSTEM,general,0,2020/00/00 00:00:00,,general,,0,0,general,informational,"xxxxxxxxxxxxxxx",0000000,0x0,0,0,0,0,,XXX-XX-XX
-log 2 pass = Apr 30 06:00:00 xx-xx-xx.xx 1,2020/02/09 00:00:00,00000000,SYSTEM,general,0,2020/00/00 00:00:00,,general,,0,0,general,low,"xxxxxxxxxxxxxxx",0000000,0x0,0,0,0,0,,XXX-XX-XX
+[Palo Alto system severity alert]
+log 1 pass = Feb 12 13:34:18 PANFW01 LEEF:2.0|Palo Alto Networks|PAN-OS Syslog Integration|11.1.6-h3|auth-fail|x7C|TimeReceived=2026/02/12 13:34:17|DeviceSN=016201046640|cat=SYSTEM|Subtype=auth|devTime=Feb 12 2026 09:34:17 GMT|VirtualSystem=|Filename=|Module=general|sev=5|Severity=critical|msg="authentication failed for user 'admin'.   From: 172.16.3.99."|sequence=7484098496036218023|ActionFlags=0x0|DeviceGroupHierarchyL1=0|DeviceGroupHierarchyL2=0|DeviceGroupHierarchyL3=0|DeviceGroupHierarchyL4=0|vSrcName=|DeviceName=PANFW01|
 rule = 64501
-alert = 2
-decoder = paloalto
-
-[Palo Alto severity medium]
-log 1 pass = Apr 30 06:00:00 xx-xx-xx.xx 1,2020/02/09 00:00:00,00000000,SYSTEM,general,0,2020/00/00 00:00:00,,general,,0,0,general,medium,"xxxxxxxxxxxxxxx",0000000,0x0,0,0,0,0,,XXX-XX-XX
-rule = 64502
-alert = 3
-decoder = paloalto
-
-[Palo Alto severity high]
-log 1 pass = 0,2021/07/12 09:46:23,321321321,THREAT,vulnerability,0,2021/07/12 09:46:00,199.195.252.165,172.30.250.61,199.195.252.165,10.20.0.19,GPS-UAT-MODULR-Web-443-OUT,,,web-browsing,vsys1,YYYYYYYYYYY,ZZZZZZZZZZZ,ethernet1/1,tunnel.2,UATH-LogForwarding,2021/07/12 09:46:00,51557,1,55094,443,55094,443,0x502000,tcp,reset-both,"getuser",DCS-2530L Unauthenticated Information Disclosure Vulnerability(90255),any,high,client-to-server,561,0xa000000000000000,United States,172.16.0.0-172.31.255.255,0,,0,,,1,,,,,,,,0,41,225,0,0,,UAT-INTERNET-FW-01,,,,,0,,0,,N/A,info-leak,AppThreat-8428-6809,0x2,0,4294967295,,"  ",dd3035a9-452f-4073-a1bc-169f4b453e6a,0,,0.0.0.0,,,,,,,,,,,,,,,,,,,,,,,,,,,0,2021-07-12T09:46:01.359+01:00,,  ,
-log 2 pass = Apr 30 06:00:00 xx-xx-xx.xx 1,2020/02/09 00:00:00,00000000,SYSTEM,general,0,2020/00/00 00:00:00,,general,,0,0,general,high,"xxxxxxxxxxxxxxx",0000000,0x0,0,0,0,0,,XXX-XX-XX
-rule = 64503
 alert = 5
-decoder = paloalto
+decoder = paloalto-system
 
-[Palo Alto severity critical]
-log 1 pass = Apr 30 06:00:00 xx-xx-xx.xx 1,2020/02/09 00:00:00,00000000,SYSTEM,general,0,2020/00/00 00:00:00,,general,,0,0,general,critical,"xxxxxxxxxxxxxxx",0000000,0x0,0,0,0,0,,XXX-XX-XX
-rule = 64504
-alert = 11
-decoder = paloalto
-
-[Palo Alto traffic]
-log 1 pass = 0,2021/07/15 11:58:58,1321564321,TRAFFIC,N/A,0,2021/07/15 11:59:02,10.210.0.84,51.11.168.232,,,DENY-ALL,,,not-applicable,vsys1,INSPECTION,INSPECTION,ethernet1/1,,AWS-PANORAMA,2021/07/15 11:59:02,0,1,500,500,0,0,0x0,udp,deny,0,0,0,1,2021/07/15 11:59:02,0,any,0,91501273,0x8000000000000000,10.0.0.0-10.255.255.255,YYYYYYYYYYYY,0,1,0,policy-deny,150,42,25,260,,P1A-GWLB-CORE-FW01,from-policy,,,0,,0,,N/A,0,0,0,0,49543e97-7c8c-44a3-bbd9-031caeb1a65e,0,0,,,,,,,,0.0.0.0,,,,,,,,,,,,,,,,,,,,,,,,,,,2021-07-15T11:59:03.547+01:00,,
-rule = 64505
+[Palo Alto iptag grouped]
+log 1 pass = Feb 12 13:30:17 PANFW01 LEEF:2.0|Palo Alto Networks|PAN-OS Syslog Integration|11.1.6-h3|register|x7C|ProfileToken=0x0|TimeReceived=2026/02/12 13:30:16|DeviceSN=016201046640|cat=IPTAG|SubType=0|ConfigVersion=11.1.6-h3|devTime=Feb 12 2026 09:30:16 GMT|VirtualLocation=vsys1|src=172.16.26.54|TagName=[Machine Authenticated]|CountOfRepeats=1|MappingTimeout=0|MappingDataSource=XMLAPI|MappingDataSourceType=xml-api|MappingDataSourceSubType=unknown|SequenceNo=7484098496031649376|DGHierarchyLevel1=0|DGHierarchyLevel2=0|DGHierarchyLevel3=0|DGHierarchyLevel4=0|VirtualSystemName=|DeviceName=PANFW01|VirtualSystemID=1|IPSubnetRange=|TimeGeneratedHighResolution=2026-02-12T13:30:17.139+04:00|devTimeFormat=Feb 12 2026 09:30:16 GMT
+rule = 64510
 alert = 0
-decoder = paloalto
+decoder = paloalto-iptag
 
-[Palo Alto traffic start]
-log 1 pass = May 00 00:00:00 XXX-XX-00 1,2020/00/00 00:00:00,00000000,TRAFFIC,start,0000,2020/06/00 00:00:00,00.00.000.00,00.00.00.0,0.0.0.0,0.0.0.0,xxx-xxx_xxxx,,,xxx,xxxxx,xxxx,xxxx,xxxx.0,xxx.000,xxxxxxxx,2020/00/00 00:00:00,0000,1,0000,000,0,0,0x0,xxx,xxxx,000,000,00,0,2020/00/00 00:00:00,1,any,0,0000000,0x0,00.0.0.0-00.000.000.000,00.0.0.0-00.000.000.000,0,0,0,n/a,0,0,0,0,,xxx-xx-01,from-policy,,,0,,0,,N/A,0,0,0,0,00000-0000-00xx00-00xx-0x0x0x000xx,0
-rule = 64506
+[Palo Alto userid grouped]
+log 1 pass = Feb 11 17:46:22 PANFW01 LEEF:2.0|Palo Alto Networks|PAN-OS Syslog Integration|11.1.6-h3|login|x7C|ProfileToken=0x0|TimeReceived=2026/02/11 17:46:21|DeviceSN=016201046640|cat=USERID|ConfigVersion=11.1.6-h3|devTime=Feb 11 2026 13:46:21 GMT|VirtualLocation=vsys1|src=192.9.200.90|usrName=eagle\UCSDEVSPSRV01$|MappingDataSourceName=ucprdc02.eagle.com|EventIdName=0|CountofRepeats=1|MappingTimeout=0|srcPort=0|dstPort=0|MappingDataSource=active-directory|MappingDataSourceType=|SequenceNo=7484098497199366899|DGHierarchyLevel1=0|DGHierarchyLevel2=0|DGHierarchyLevel3=0|DGHierarchyLevel4=0|VirtualSystemName=|DeviceName=PANFW01|VirtualSystemID=1|MFAFactorType=|AuthCompletionTime=2026/02/11 17:37:19|AuthFactorNo=1|UGFlags=0x0|UserIdentifiedBySource=eagle\UCSDEVSPSRV01$|Tag=|TimeGeneratedHighResolution=2026-02-11T17:46:22.429+04:00|devTimeFormat=Feb 11 2026 13:46:21 GMT
+rule = 64520
+alert = 0
+decoder = paloalto-userid
+
+[Palo Alto hipmatch grouped]
+log 1 pass = Feb 12 14:14:23 PANFW01 LEEF:2.0|Palo Alto Networks|PAN-OS Syslog Integration|11.1.6-h3|HIP-Profile|x7C|ProfileToken=0x0|TimeReceived=2026/02/12 14:14:22|DeviceSN=016201046640|cat=HIPMATCH|SubType=0|ConfigVersion=11.1.6-h3|devTime=Feb 12 2026 10:14:22 GMT|usrName=eagle\mabbas|VirtualLocation=vsys1|identHostName=HO473686L.UCSNET.com|EndpointOSType=Windows|iOSsrc=172.16.125.135|CountOfRepeats=1|SequenceNo=7484098496031627145|DGHierarchyLevel1=0|DGHierarchyLevel2=0|DGHierarchyLevel3=0|DGHierarchyLevel4=0|VirtualSystemName=|DeviceName=PANFW01|VirtualSystemID=1|SourceIPv6=0.0.0.0|HostID=|EndpointSerialNumber=|SourceDeviceCategory=0|SourceDeviceModel=profile|SourceDeviceMac=|TimestampDeviceIdentification=2026/02/12 14:14:22|TimeGeneratedHighResolution=2026-02-12T14:14:23.277+04:00|devTimeFormat=Feb 12 2026 10:14:22 GMT
+rule = 64530
+alert = 0
+decoder = paloalto-hipmatch
+
+[Palo Alto threat grouped]
+log 1 pass = Feb 24 22:20:59 PANFW01 LEEF:2.0|Palo Alto Networks|PAN-OS Syslog Integration|11.1.6-h3|SCAN: Host Sweep(8002)|x7C|ReceiveTime=2026/02/24 22:20:58|SerialNumber=016201046640|cat=THREAT|Subtype=scan|devTime=Feb 24 2026 18:20:58 GMT|src=137.184.174.149|dst=172.16.50.36|srcPostNAT=0.0.0.0|dstPostNAT=0.0.0.0|RuleName=|usrName=|SourceUser=|DestinationUser=|Application=not-applicable|VirtualSystem=vsys1|SourceZone=Untrust-DMZ|DestinationZone=Trust-DMZ|IngressInterface=ethernet1/3|EgressInterface=|LogForwardingProfile=DMZ Threats|SessionID=0|RepeatCount=1|srcPort=36774|dstPort=443|srcPostNATPort=0|dstPostNATPort=0|Flags=0x2000|proto=tcp|action=alert|Miscellaneous=|ThreatID=SCAN: Host Sweep(8002)|URLCategory=any|sev=1|Severity=informational|Direction=client-to-server|sequence=7484098493538761469|ActionFlags=0x0|SourceLocation=Canada|DestinationLocation=172.16.0.0-172.31.255.255|ContentType=|PCAP_ID=0|FileDigest=|Cloud=|URLIndex=0|RequestMethod=|Subject=|DeviceGroupHierarchyL1=0|DeviceGroupHierarchyL2=0|DeviceGroupHierarchyL3=0|DeviceGroupHierarchyL4=0|vSrcName=|DeviceName=PANFW01|SrcUUID=|DstUUID=|TunnelID=0|MonitorTag=|ParentSessionID=0|ParentStartTime=|TunnelType=N/A|ThreatCategory=scan|ContentVer=AppThreat-0-0
+rule = 64540
+alert = 0
+decoder = paloalto-threat
+
+[Palo Alto threat severity alert]
+log 1 pass = Jun 14 06:07:45 PANFW01 LEEF:2.0|Palo Alto Networks|PAN-OS Syslog Integration|11.1.6-h3|XMRig Miner Command and Control Traffic Detection(85886)|x7C|ReceiveTime=2026/06/14 06:07:44|SerialNumber=016201046640|cat=THREAT|Subtype=spyware|devTime=Jun 14 2026 02:07:44 GMT|src=185.213.175.176|dst=172.17.50.49|srcPostNAT=0.0.0.0|dstPostNAT=0.0.0.0|RuleName=DMZ  Incoming|usrName=|SourceUser=|DestinationUser=|Application=json-rpc|VirtualSystem=vsys1|SourceZone=Untrust-DMZ|DestinationZone=Trust-DMZ|IngressInterface=ethernet1/3|EgressInterface=ethernet1/4|LogForwardingProfile=Medium Threats|SessionID=348216|RepeatCount=1|srcPort=33562|dstPort=443|srcPostNATPort=0|dstPostNATPort=0|Flags=0x6000|proto=tcp|action=reset-both|Miscellaneous=|ThreatID=XMRig Miner Command and Control Traffic Detection(85886)|URLCategory=any|sev=5|Severity=critical|Direction=client-to-server|sequence=7484098493910195286|ActionFlags=0x0|SourceLocation=Spain|DestinationLocation=172.16.0.0-172.31.255.255|ContentType=|PCAP_ID=0|FileDigest=|Cloud=|URLIndex=0|RequestMethod=|Subject=|DeviceGroupHierarchyL1=0|DeviceGroupHierarchyL2=0|DeviceGroupHierarchyL3=0|DeviceGroupHierarchyL4=0|vSrcName=|DeviceName=PANFW01|SrcUUID=|DstUUID=|TunnelID=0|MonitorTag=|ParentSessionID=0|ParentStartTime=|TunnelType=N/A|ThreatCategory=cryptominer|ContentVer=AppThreat-9113-10104
+rule = 64541
+alert = 5
+decoder = paloalto-threat
+
+[Palo Alto traffic grouped]
+log 1 pass = Mar  9 12:50:56 PANFW01 LEEF:2.0|Palo Alto Networks|PAN-OS Syslog Integration|11.1.6-h3|allow|x7C|cat=TRAFFIC|devTime=Mar 09 2026 08:50:55 GMT|SerialNumber=016201046640|Subtype=end|src=172.16.176.65|dst=192.9.200.227|srcPostNAT=0.0.0.0|dstPostNAT=0.0.0.0|RuleName=Branches-to-HO-False positive|usrName=|DestinationUser=eagle\admgr|Application=dns-base|VirtualSystem=vsys1|SourceZone=Untrust-Int-GW|DestinationZone=Trust-Int-GW|IngressInterface=ethernet1/19|EgressInterface=ethernet1/20|LogForwardingProfile=Medium Threats|SessionID=827653|RepeatCount=1|srcPort=54448|dstPort=53|srcPostNATPort=0|dstPostNATPort=0|Flags=0x4019|proto=udp|totalBytes=231|srcBytes=81|dstBytes=150|totalPackets=2|dstPackets=1|srcPackets=1|start=Mar 09 2026 08:50:55 GMT|ElapsedTime=0|URLCategory=any|sequence=7484098568435057916|SessionEndReason=aged-out|DeviceGroupHierarchyL1=0|DeviceGroupHierarchyL2=0|DeviceGroupHierarchyL3=0|vSrcName=|DeviceName=PANFW01|ActionSource=from-policy|ActionFlags=0x0|SrcUUID=|DstUUID=|TunnelID=0|MonitorTag=|ParentSessionID=0|ParentStartTime=|
+rule = 64550
+alert = 0
+decoder = paloalto-traffic
+
+[Palo Alto traffic dropped or denied]
+log 1 pass = Mar  9 12:50:56 PANFW01 LEEF:2.0|Palo Alto Networks|PAN-OS Syslog Integration|11.1.6-h3|deny|x7C|cat=TRAFFIC|devTime=Mar 09 2026 08:50:55 GMT|SerialNumber=016201046640|Subtype=deny|src=172.16.176.65|dst=192.9.200.227|srcPostNAT=0.0.0.0|dstPostNAT=0.0.0.0|RuleName=Branches-to-HO-Deny-All|usrName=|DestinationUser=eagle\admgr|Application=dns-base|VirtualSystem=vsys1|SourceZone=Untrust-Int-GW|DestinationZone=Trust-Int-GW|IngressInterface=ethernet1/19|EgressInterface=ethernet1/20|LogForwardingProfile=Medium Threats|SessionID=827654|RepeatCount=1|srcPort=54449|dstPort=53|srcPostNATPort=0|dstPostNATPort=0|Flags=0x4019|proto=udp|totalBytes=0|srcBytes=0|dstBytes=0|totalPackets=0|dstPackets=0|srcPackets=0|start=Mar 09 2026 08:50:55 GMT|ElapsedTime=0|URLCategory=any|sequence=7484098568435057917|SessionEndReason=policy-deny|DeviceGroupHierarchyL1=0|DeviceGroupHierarchyL2=0|DeviceGroupHierarchyL3=0|vSrcName=|DeviceName=PANFW01|ActionSource=from-policy|ActionFlags=0x0|SrcUUID=|DstUUID=|TunnelID=0|MonitorTag=|ParentSessionID=0|ParentStartTime=|
+rule = 64551
 alert = 2
-decoder = paloalto
-
-[Palo Alto traffic end]
-log 1 pass = May 00 00:00:00 XXX-XX-00 1,2020/00/00 00:00:00,00000000,TRAFFIC,end,0000,2020/06/00 00:00:00,00.00.000.00,00.00.00.0,0.0.0.0,0.0.0.0,xxx-xxx_xxxx,,,xxx,xxxxx,xxxx,xxxx,xxxx.0,xxx.000,xxxxxxxx,2020/00/00 00:00:00,0000,1,0000,000,0,0,0x0,xxx,xxxx,000,000,00,0,2020/00/00 00:00:00,1,any,0,0000000,0x0,00.0.0.0-00.000.000.000,00.0.0.0-00.000.000.000,0,0,0,n/a,0,0,0,0,,xxx-xx-01,from-policy,,,0,,0,,N/A,0,0,0,0,00000-0000-00xx00-00xx-0x0x0x000xx,0
-rule = 64507
-alert = 2
-decoder = paloalto
-
-[Palo Alto traffic dropped]
-log 1 pass = May 00 00:00:00 XXX-XX-00 1,2020/00/00 00:00:00,00000000,TRAFFIC,drop,0000,2020/06/00 00:00:00,00.00.000.00,00.00.00.0,0.0.0.0,0.0.0.0,xxx-xxx_xxxx,,,xxx,xxxxx,xxxx,xxxx,xxxx.0,xxx.000,xxxxxxxx,2020/00/00 00:00:00,0000,1,0000,000,0,0,0x0,xxx,xxxx,000,000,00,0,2020/00/00 00:00:00,1,any,0,0000000,0x0,00.0.0.0-00.000.000.000,00.0.0.0-00.000.000.000,0,0,0,n/a,0,0,0,0,,xxx-xx-01,from-policy,,,0,,0,,N/A,0,0,0,0,00000-0000-00xx00-00xx-0x0x0x000xx,0
-log 2 pass = May 00 00:00:00 XXX-XX-00 1,2020/00/00 00:00:00,00000000,TRAFFIC,deny,0000,2020/06/00 00:00:00,00.00.000.00,00.00.00.0,0.0.0.0,0.0.0.0,xxx-xxx_xxxx,,,xxx,xxxxx,xxxx,xxxx,xxxx.0,xxx.000,xxxxxxxx,2020/00/00 00:00:00,0000,1,0000,000,0,0,0x0,xxx,xxxx,000,000,00,0,2020/00/00 00:00:00,1,any,0,0000000,0x0,00.0.0.0-00.000.000.000,00.0.0.0-00.000.000.000,0,0,0,n/a,0,0,0,0,,xxx-xx-01,from-policy,,,0,,0,,N/A,0,0,0,0,00000-0000-00xx00-00xx-0x0x0x000xx,0
-rule = 64508
-alert = 6
-decoder = paloalto
+decoder = paloalto-traffic


### PR DESCRIPTION
## Description
Replaces the legacy v8-v10 CSV-format Palo Alto decoders and rules with support for the PAN-OS v11.x LEEF syslog format (USERID, IPTAG, SYSTEM, HIPMATCH, THREAT, and TRAFFIC event categories).

Manually verified against a live wazuh-manager with wazuh-logtest.

## Proposed Changes
- `ruleset/decoders/0505-paloalto_decoders.xml`: rewritten to parse the PAN-OS v11.x LEEF format, adding dedicated decoders for `paloalto-userid`, `paloalto-iptag`, `paloalto-system`, `paloalto-hipmatch`, `paloalto-threat`, and `paloalto-traffic`. 
- `ruleset/rules/0700-paloalto_rules.xml`: rewritten to key off the new decoders (rule IDs 64500-64552), including severity-based alerting for SYSTEM/THREAT and dropped/denied-traffic detection for TRAFFIC, with a frequency-correlation rule (64552) for repeated drops/denials from the same source/destination.
- `ruleset/testing/tests/paloalto.ini`: rewritten to cover the new decoders/rules with real PAN-OS v11.x sample logs. 

## Results and Evidence
### Paloalto-Iptag
**Phase 1: Completed pre-decoding.
        full event: 'Feb 12 13:30:17 PANFW01 LEEF:2.0|Palo Alto Networks|PAN-OS Syslog Integration|11.1.6-h3|register|x7C|ProfileToken=0x0|TimeReceived=2026/02/12 13:30:16|DeviceSN=016201046640|cat=IPTAG|SubType=0|ConfigVersion=11.1.6-h3|devTime=Feb 12 2026 09:30:16 GMT|VirtualLocation=vsys1|src=172.16.26.54|TagName=[Machine Authenticated]|CountOfRepeats=1|MappingTimeout=0|MappingDataSource=XMLAPI|MappingDataSourceType=xml-api|MappingDataSourceSubType=unknown|SequenceNo=7484098496031649376|DGHierarchyLevel1=0|DGHierarchyLevel2=0|DGHierarchyLevel3=0|DGHierarchyLevel4=0|VirtualSystemName=|DeviceName=PANFW01|VirtualSystemID=1|IPSubnetRange=|TimeGeneratedHighResolution=2026-02-12T13:30:17.139+04:00|devTimeFormat=Feb 12 2026 09:30:16 GMT'
        timestamp: 'Feb 12 13:30:17'
        hostname: 'PANFW01'
        program_name: 'LEEF'

**Phase 2: Completed decoding.
        name: 'paloalto-iptag'
        DGHierarchyLevel1: '0'
        DGHierarchyLevel2: '0'
        DGHierarchyLevel3: '0'
        DGHierarchyLevel4: '0'
        countofRepeats: '1'
        devTime: 'Feb 12 2026 09:30:16 GMT'
        deviceName: 'PANFW01'
        mappingDataSource: 'XMLAPI'
        mappingDataSourceSubType: 'unknown'
        mappingDataSourceType: 'xml-api'
        mappingTimeout: '0'
        sequenceNo: '7484098496031649376'
        srcip: '172.16.26.54'
        subType: '0'
        tagName: '[Machine Authenticated]'
        virtualLocation: 'vsys1'
        virtualSystemID: '1'

**Phase 3: Completed filtering (rules).
        id: '64510'
        level: '3'
        description: 'paloalto IPtag decoded grouped alerts'
        groups: '['paloalto']'
        firedtimes: '1'
        mail: 'False'
**Alert to be generated.

### Paloalto-hipmatch 
**Phase 1: Completed pre-decoding.
        full event: 'Feb 12 14:14:23 PANFW01 LEEF:2.0|Palo Alto Networks|PAN-OS Syslog Integration|11.1.6-h3|HIP-Profile|x7C|ProfileToken=0x0|TimeReceived=2026/02/12 14:14:22|DeviceSN=016201046640|cat=HIPMATCH|SubType=0|ConfigVersion=11.1.6-h3|devTime=Feb 12 2026 10:14:22 GMT|usrName=eagle\mabbas|VirtualLocation=vsys1|identHostName=HO473686L.EAGLE.com|EndpointOSType=Windows|iOSsrc=172.16.125.135|CountOfRepeats=1|SequenceNo=7484098496031627145|DGHierarchyLevel1=0|DGHierarchyLevel2=0|DGHierarchyLevel3=0|DGHierarchyLevel4=0|VirtualSystemName=|DeviceName=PANFW01|VirtualSystemID=1|SourceIPv6=0.0.0.0|HostID=|EndpointSerialNumber=|SourceDeviceCategory=0|SourceDeviceModel=profile|SourceDeviceMac=|TimestampDeviceIdentification=2026/02/12 14:14:22|TimeGeneratedHighResolution=2026-02-12T14:14:23.277+04:00|devTimeFormat=Feb 12 2026 10:14:22 GMT'
        timestamp: 'Feb 12 14:14:23'
        hostname: 'PANFW01'
        program_name: 'LEEF'

**Phase 2: Completed decoding.
        name: 'paloalto-hipmatch'
        DGHierarchyLevel1: '0'
        DGHierarchyLevel2: '0'
        DGHierarchyLevel3: '0'
        DGHierarchyLevel4: '0'
        countOfRepeats: '1'
        devTime: 'Feb 12 2026 10:14:22 GMT'
        deviceName: 'PANFW01'
        hostname: 'HO473686L.EAGLE.com'
        ostype: 'Windows'
        sequenceNo: '7484098496031627145'
        srcip: '172.16.125.135'
        subtype: '0'
        username: 'eagle\mabbas'
        virtualLocation: 'vsys1'
        virtualSystemID: '1'

**Phase 3: Completed filtering (rules).
        id: '64530'
        level: '3'
        description: 'paloalto Hipmatch decoded grouped alerts'
        groups: '['paloalto']'
        firedtimes: '1'
        mail: 'False'
**Alert to be generated.

### paloalto-system
**Phase 1: Completed pre-decoding.
        full event: 'Feb 12 13:34:18 PANFW01 LEEF:2.0|Palo Alto Networks|PAN-OS Syslog Integration|11.1.6-h3|auth-success|x7C|TimeReceived=2026/02/12 13:34:17|DeviceSN=016201046640|cat=SYSTEM|Subtype=auth|devTime=Feb 12 2026 09:34:17 GMT|VirtualSystem=|Filename=|Module=general|sev=1|Severity=formational|msg="authenticated for user 'seyam_backup'.   From: 172.16.3.99."|sequence=7484098496036218022|ActionFlags=0x0|DeviceGroupHierarchyL1=0|DeviceGroupHierarchyL2=0|DeviceGroupHierarchyL3=0|DeviceGroupHierarchyL4=0|vSrcName=|DeviceName=PANFW01'
        timestamp: 'Feb 12 13:34:18'
        hostname: 'PANFW01'
        program_name: 'LEEF'

**Phase 2: Completed decoding.
        name: 'paloalto-system'
        actionFlags: '0x0'
        devTime: 'Feb 12 2026 09:34:17 GMT'
        deviceName: 'PANFW01'
        message: 'authenticated for user 'seyam_backup'.   From: 172.16.3.99.'
        module: 'general'
        sequenceNo: '7484098496036218022'
        sev: '1'
        severity: 'formational'
        subtype: 'auth'

**Phase 3: Completed filtering (rules).
        id: '64501'
        level: '5'
        description: 'System alert has been triggered'
        groups: '['paloalto']'
        firedtimes: '1'
        mail: 'False'
**Alert to be generated.

### paloalto-threat 

**Phase 1: Completed pre-decoding.
        full event: 'Apr 23 01:36:26 PANFW01 LEEF:2.0|Palo Alto Networks|PAN-OS Syslog Integration|11.1.6-h3|HTTP SQL Injection Attempt(30514)|x7C|ReceiveTime=2026/04/23 01:36:25|SerialNumber=016201046640|cat=THREAT|Subtype=vulnerability|devTime=Apr 22 2026 21:36:25 GMT|src=172.239.105.112|dst=172.16.50.42|srcPostNAT=0.0.0.0|dstPostNAT=0.0.0.0|RuleName=DMZ  Incoming|usrName=|SourceUser=|DestinationUser=|Application=web-browsing|VirtualSystem=vsys1|SourceZone=Untrust-DMZ|DestinationZone=Trust-DMZ|IngressInterface=ethernet1/3|EgressInterface=ethernet1/4|LogForwardingProfile=Medium Threats|SessionID=95655|RepeatCount=1|srcPort=31015|dstPort=80|srcPostNATPort=0|dstPostNATPort=0|Flags=0x6000|proto=tcp|action=drop|Miscellaneous="5.195.37.165/index.php?controller=pjAdminOrders&action=pjActionGetNewOrder&column=(SELECT+(CASE+WHEN+(4213=4213)+THEN+0x63726561746564+ELSE+(SELECT+7877+UNION+SELECT+7153)+END))&direction=ASC&page=1&rowCount=50&q=%e2%80%99%e2%80%99&type="|ThreatID=HTTP SQL Injection Attempt(30514)|URLCategory=unknown|sev=3|Severity=medium|Direction=client-to-server|sequence=7484098493804856527|ActionFlags=0x0|SourceLocation=United Kingdom|DestinationLocation=172.16.0.0-172.31.255.255|ContentType=|PCAP_ID=0|FileDigest=|Cloud=|URLIndex=1|RequestMethod=|Subject=|DeviceGroupHierarchyL1=0|DeviceGroupHierarchyL2=0|DeviceGroupHierarchyL3=0|DeviceGroupHierarchyL4=0|vSrcName=|DeviceName=PANFW01|SrcUUID=|DstUUID=|TunnelID=0|MonitorTag=|ParentSessionID=0|ParentStartTime=|TunnelType=N/A|ThreatCategory=sql-injection|ContentVer=AppThreat-9091-9995'
        timestamp: 'Apr 23 01:36:26'
        hostname: 'PANFW01'
        program_name: 'LEEF'

**Phase 2: Completed decoding.
        name: 'paloalto-threat'
        action: 'drop'
        actionFlags: '0x0'
        application: 'web-browsing'
        devTime: 'Apr 22 2026 21:36:25 GMT'
        deviceName: 'PANFW01'
        direction: 'client-to-server'
        dstPostNATPort: '0'
        dstip: '172.16.50.42'
        dstipPostNAT: '0.0.0.0'
        dstlocation: '172.16.0.0-172.31.255.255'
        dstport: '80'
        dstuser: ''
        dstzone: 'Trust-DMZ'
        flags: '0x6000'
        logForwardingProfile: 'Medium Threats'
        miscellaneous: '"5.195.37.165/index.php?controller=pjAdminOrders&action=pjActionGetNewOrder&column=(SELECT+(CASE+WHEN+(4213=4213)+THEN+0x63726561746564+ELSE+(SELECT+7877+UNION+SELECT+7153)+END))&direction=ASC&page=1&rowCount=50&q=%e2%80%99%e2%80%99&type="'
        protocol: 'tcp'
        repeatCount: '1'
        sequence: '7484098493804856527'
        sessionID: '95655'
        sev: '3'
        severity: 'medium'
        srcPostNATPort: '0'
        srcip: '172.239.105.112'
        srcipPostNAT: '0.0.0.0'
        srclocation: 'United Kingdom'
        srcport: '31015'
        srcuser: ''
        srczone: 'Untrust-DMZ'
        subtype: 'vulnerability'
        threatCategory: 'sql-injection'
        threatID: 'HTTP SQL Injection Attempt(30514)'
        tunnelType: 'N/A'
        urlCategory: 'unknown'
        urlIndex: '1'

**Phase 3: Completed filtering (rules).
        id: '64541'
        level: '5'
        description: 'vulnerability threat alert has been triggered'
        groups: '['paloalto']'
        firedtimes: '1'
        mail: 'False'
**Alert to be generated.

### paloalto-traffic
**Phase 1: Completed pre-decoding.
        full event: 'Mar 13 13:25:53 PANFW01 LEEF:2.0|Palo Alto Networks|PAN-OS Syslog Integration|11.1.6-h3|reset-both|x7C|cat=TRAFFIC|devTime=Mar 13 2026 09:25:53 GMT|SerialNumber=016201046640|Subtype=deny|src=10.10.10.151|dst=63.140.62.120|srcPostNAT=0.0.0.0|dstPostNAT=0.0.0.0|RuleName=interzone-default|usrName=eagle\talmazrouei|DestinationUser=|Application=ssl|VirtualSystem=vsys1|SourceZone=Trust-Int-GW|DestinationZone=Untrust-Int-GW|IngressInterface=ethernet1/20|EgressInterface=ethernet1/19|LogForwardingProfile=Medium Threats|SessionID=1006206|RepeatCount=1|srcPort=65434|dstPort=443|srcPostNATPort=0|dstPostNATPort=0|Flags=0x4400|proto=tcp|totalBytes=3938|srcBytes=609|dstBytes=3329|totalPackets=10|dstPackets=5|srcPackets=5|start=Mar 13 2026 09:25:53 GMT|ElapsedTime=0|URLCategory=computer-and-internet-info|sequence=7484098569904686710|SessionEndReason=policy-deny|DeviceGroupHierarchyL1=0|DeviceGroupHierarchyL2=0|DeviceGroupHierarchyL3=0|vSrcName=|DeviceName=PANFW01|ActionSource=from-application|ActionFlags=0x0|SrcUUID=|DstUUID=|TunnelID=0|MonitorTag=|ParentSessionID=0|ParentStartTime=|TunnelType=N/ARuleUUID=b40f8c3c-3c96-4c8d-b120-9f29d345cfa7|PolicyID=|LinkDetail=|SDWANCluster=|SDWANDevice=|SDWANClustype=|SDWANSite=|DynamicUsrgrp=|XFFIP=|SrcDeviceCat=|SrcDeviceProf=|SrcDeviceModel=|SrcDeviceVendor=|SrcDeviceOS=|SrcDeviceOSv=|SrcHostname=|SrcMac=|DstDeviceCat=|DstDeviceProf=|DstDeviceModel=|DstDeviceVendor=|DstDeviceOS=|DstDeviceOSv=|DstHostname=|DstMac=|'
        timestamp: 'Mar 13 13:25:53'
        hostname: 'PANFW01'
        program_name: 'LEEF'

**Phase 2: Completed decoding.
        name: 'paloalto-traffic'
        application: 'ssl'
        devTime: 'Mar 13 2026 09:25:53 GMT'
        dstPackets: '5'
        dstip: '63.140.62.120'
        dstipPostNAT: '0.0.0.0'
        dstuser: ''
        dstzone: 'Untrust-Int-GW'
        elapsedTime: '0'
        parentSessionID: '0'
        rulename: 'interzone-default'
        sessionEndReason: 'policy-deny'
        srcPackets: '5'
        srcip: '10.10.10.151'
        srcipPostNAT: '0.0.0.0'
        srcuser: 'eagle\talmazrouei'
        srczone: 'Trust-Int-GW'
        start: 'Mar 13 2026 09:25:53 GMT'
        subtype: 'deny'
        urlCategory: 'computer-and-internet-info'

**Phase 3: Completed filtering (rules).
        id: '64551'
        level: '2'
        description: 'traffic from 10.10.10.151 has been seen dropped or denied'
        groups: '['paloalto']'
        firedtimes: '1'
        mail: 'False'

### paloalto-userid

**Phase 1: Completed pre-decoding.
        full event: 'Feb 11 17:46:22 PANFW01 LEEF:2.0|Palo Alto Networks|PAN-OS Syslog Integration|11.1.6-h3|login|x7C|ProfileToken=0x0|TimeReceived=2026/02/11 17:46:21|DeviceSN=016201046640|cat=USERID|ConfigVersion=11.1.6-h3|devTime=Feb 11 2026 13:46:21 GMT|VirtualLocation=vsys1|src=192.9.200.90|usrName=eagle\UCSDEVSPSRV01$|MappingDataSourceName=ucprdc02.eagle.com|EventIdName=0|CountofRepeats=1|MappingTimeout=0|srcPort=0|dstPort=0|MappingDataSource=active-directory|MappingDataSourceType=|SequenceNo=7484098497199366899|DGHierarchyLevel1=0|DGHierarchyLevel2=0|DGHierarchyLevel3=0|DGHierarchyLevel4=0|VirtualSystemName=|DeviceName=PANFW01|VirtualSystemID=1|MFAFactorType=|AuthCompletionTime=2026/02/11 17:37:19|AuthFactorNo=1|UGFlags=0x0|UserIdentifiedBySource=eagle\UCSDEVSPSRV01$|Tag=|TimeGeneratedHighResolution=2026-02-11T17:46:22.429+04:00|devTimeFormat=Feb 11 2026 13:46:21 GMT'
        timestamp: 'Feb 11 17:46:22'
        hostname: 'PANFW01'
        program_name: 'LEEF'

**Phase 2: Completed decoding.
        name: 'paloalto-userid'
        DGHierarchyLevel1: '0'
        DGHierarchyLevel2: '0'
        DGHierarchyLevel3: '0'
        DGHierarchyLevel4: '0'
        authCompletionTime: '2026/02/11 17:37:19'
        authFactorNo: '1'
        countofRepeats: '1'
        devTime: 'Feb 11 2026 13:46:21 GMT'
        deviceName: 'PANFW01'
        dstport: '0'
        eventIdName: '0'
        mappingDataSource: 'active-directory'
        mappingDataSourceName: 'ucprdc02.eagle.com'
        mappingTimeout: '0'
        sequenceNo: '7484098497199366899'
        srcip: '192.9.200.90'
        srcport: '0'
        subType: 'Palo Alto Networks'
        ugFlags: '0x0'
        userIdentifiedBySource: 'eagle\UCSDEVSPSRV01$'
        username: 'eagle\UCSDEVSPSRV01$'
        virtualLocation: 'vsys1'
        virtualSystemID: '1'

**Phase 3: Completed filtering (rules).
        id: '64520'
        level: '3'
        description: 'paloalto UserId decoded grouped alerts'
        groups: '['paloalto']'
        firedtimes: '1'
        mail: 'False'
**Alert to be generated.


### Manual tests with their corresponding evidence

- Decoder/Rule tests _(Wazuh v4.x)_
  - [X] Added unit testing files ".ini"
  - [X] `runtests.py` executed without errors

### Artifacts Affected
- `ruleset/decoders/0505-paloalto_decoders.xml`
- `ruleset/rules/0700-paloalto_rules.xml`
- `ruleset/testing/tests/paloalto.ini`


### Configuration Changes
N/A

## Review Checklist

- [X] Code changes reviewed
- [X] Relevant evidence provided
- [X] Tests cover the new functionality
- [X] Configuration changes documented
- [ ] Developer documentation reflects the changes 
- [X] Meets requirements and/or definition of done
- [X] No unresolved dependencies with other issues
