### PR TITLE
Migrate candidate workers from AWS to Github-hosted runners

### DIFF
--- a/.github/actions/upload_s3_artifact/action.yml
+++ b/.github/actions/upload_s3_artifact/action.yml
@@ -8,8 +8,8 @@ description: >
   AWS credentials are configured by the action itself via OIDC, so the calling
   job only needs `permissions: id-token: write`. Pass the region via the
   `aws_region` input (set it to the CI_AWS_REGION secret at the call site).
-  Requires `7z` and the AWS CLI on the runner (present on the CodeBuild and
-  GitHub-hosted windows-2025 images used by these workflows).
+  Requires an archiver (`7z`, `zip`, or python3 as a fallback) and the AWS CLI
+  on the runner; all runner images used by these workflows provide them.
 
 inputs:
   name:

--- a/.github/workflows/5_builderpackage_engine-standalone.yml
+++ b/.github/workflows/5_builderpackage_engine-standalone.yml
@@ -47,7 +47,7 @@ env:
 jobs:
   build:
     name: Build Manager (${{ matrix.arch }})
-    runs-on: ${{ matrix.arch == 'arm64' && format('codebuild-github-actions-codebuild-runner-server-arm-{0}-{1}', github.run_id, github.run_attempt) || format('codebuild-github-actions-codebuild-runner-server-amd-{0}-{1}', github.run_id, github.run_attempt) }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     permissions:
       id-token: write
       contents: read
@@ -88,20 +88,10 @@ jobs:
               ;;
           esac
 
-      - name: CodeBuild workarounds
-        # TODO: Remove once DevOps exposes host Docker socket or configures DinD in CodeBuild
+      - name: Prepare build environment
         run: |
-          # 1. Docker daemon: CodeBuild has no systemd so dockerd never starts.
-          #    VFS storage driver avoids overlay-on-overlay which is not supported inside containers.
-          if ! docker info &>/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y docker.io
-            sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
-            timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
-            sudo chmod 666 /var/run/docker.sock
-          fi
-          # 2. Git repo format: actions/checkout on newer git writes repositoryformatversion=1
-          #    which the older git inside builder Docker images cannot read.
+          # Git repo format: actions/checkout on newer git writes repositoryformatversion=1
+          # which the older git inside builder Docker images cannot read.
           git config core.repositoryformatversion 0
           # Install pip3
           if ! command -v pip3 >/dev/null 2>&1; then
@@ -132,7 +122,7 @@ jobs:
   check_standalone_engine:
     name: Test standalone engine (${{ matrix.arch }})
 
-    runs-on: ${{ matrix.arch == 'arm64' && format('codebuild-github-actions-codebuild-runner-server-arm-{0}-{1}', github.run_id, github.run_attempt) || format('codebuild-github-actions-codebuild-runner-server-amd-{0}-{1}', github.run_id, github.run_attempt) }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/5_builderpackage_manager.yml
+++ b/.github/workflows/5_builderpackage_manager.yml
@@ -109,7 +109,7 @@ jobs:
       AWS_MAX_ATTEMPTS: "10"
       AWS_RETRY_MODE: adaptive
 
-    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && format('codebuild-github-actions-codebuild-runner-server-arm-{0}-{1}', github.run_id, github.run_attempt) || format('codebuild-github-actions-codebuild-runner-server-amd-{0}-{1}', github.run_id, github.run_attempt) }}
+    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     timeout-minutes: 90
     name: Build ${{ inputs.system }} wazuh-manager on ${{ inputs.architecture }}
 
@@ -163,20 +163,10 @@ jobs:
           else echo "TAG=${{ inputs.docker_image_tag }}" >> $GITHUB_ENV; fi
           echo "CONTAINER_NAME=pkg_${{ inputs.system }}_manager_builder_${{ env.PACKAGE_ARCH }}" >> $GITHUB_ENV
 
-      - name: CodeBuild workarounds
-        # TODO: Remove once DevOps exposes host Docker socket or configures DinD in CodeBuild
+      - name: Prepare build environment
         run: |
-          # 1. Docker daemon: CodeBuild has no systemd so dockerd never starts.
-          #    VFS storage driver avoids overlay-on-overlay which is not supported inside containers.
-          if ! docker info &>/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y docker.io
-            sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
-            timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
-            sudo chmod 666 /var/run/docker.sock
-          fi
-          # 2. Git repo format: actions/checkout on newer git writes repositoryformatversion=1
-          #    which the older git inside builder Docker images cannot read.
+          # Git repo format: actions/checkout on newer git writes repositoryformatversion=1
+          # which the older git inside builder Docker images cannot read.
           git config core.repositoryformatversion 0
           # Install uuidgen
           if ! command -v uuidgen >/dev/null 2>&1; then
@@ -186,7 +176,7 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.CI_WAZUHCI_DOCKERHUB_USER }} 
+          username: ${{ secrets.CI_WAZUHCI_DOCKERHUB_USER }}
           password: ${{ secrets.CI_WAZUHCI_DOCKERHUB_TOKEN }}
 
       - name: Download docker image for package building
@@ -203,7 +193,7 @@ jobs:
           cat VERSION.json
 
       - name: Build ${{ inputs.system }} wazuh-manager on ${{ inputs.architecture }}
-        timeout-minutes: 45
+        timeout-minutes: 60
         working-directory: packages
         run: |
           SHORT_COMMIT=$(git rev-parse --short HEAD)

--- a/.github/workflows/5_builderprecompiled_docker-images-upload-manager.yml
+++ b/.github/workflows/5_builderprecompiled_docker-images-upload-manager.yml
@@ -48,7 +48,7 @@ jobs:
       packages: write
       actions: write
 
-    runs-on: ${{ inputs.architecture == 'arm64' && format('codebuild-github-actions-codebuild-runner-server-arm-{0}-{1}', github.run_id, github.run_attempt) || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.architecture == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     timeout-minutes: 180
     name: Package - Upload pkg_${{ inputs.system }}_manager_builder_${{ inputs.architecture }} with tag ${{ inputs.docker_image_tag }}
 

--- a/.github/workflows/5_buildpackage_internal_tools.yml
+++ b/.github/workflows/5_buildpackage_internal_tools.yml
@@ -36,11 +36,11 @@ jobs:
   build:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     name: Build ${{ matrix.system }} / ${{ matrix.arch }}
-    runs-on: ${{ (matrix.arch == 'arm64' || matrix.arch == 'aarch64') && format('codebuild-github-actions-codebuild-runner-server-arm-{0}-{1}', github.run_id, github.run_attempt) || format('codebuild-github-actions-codebuild-runner-server-amd-{0}-{1}', github.run_id, github.run_attempt) }}
+    runs-on: ${{ (matrix.arch == 'arm64' || matrix.arch == 'aarch64') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     permissions:
       id-token: write
       contents: read
-    timeout-minutes: 20
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:
@@ -53,26 +53,15 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || '' }}
 
-      - name: CodeBuild workarounds
-        # TODO: Remove once DevOps exposes host Docker socket or configures DinD in CodeBuild
-        run: |
-          # 1. Docker daemon: CodeBuild has no systemd so dockerd never starts.
-          #    VFS storage driver avoids overlay-on-overlay which is not supported inside containers.
-          if ! docker info &>/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y docker.io
-            sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
-            timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
-            sudo chmod 666 /var/run/docker.sock
-          fi
-          # 2. Git repo format: actions/checkout on newer git writes repositoryformatversion=1
-          #    which the older git inside builder Docker images cannot read.
-          git config core.repositoryformatversion 0
+      - name: Fix git repository format for builder images
+        # actions/checkout on newer git writes repositoryformatversion=1, which the
+        # older git inside the builder Docker images cannot read.
+        run: git config core.repositoryformatversion 0
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.CI_WAZUHCI_DOCKERHUB_USER }} 
+          username: ${{ secrets.CI_WAZUHCI_DOCKERHUB_USER }}
           password: ${{ secrets.CI_WAZUHCI_DOCKERHUB_TOKEN }}
 
       - name: Resolve extension

--- a/.github/workflows/5_codeanalysis_python_bandit_pr.yml
+++ b/.github/workflows/5_codeanalysis_python_bandit_pr.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   bandit-scan:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - name: Checkout repo

--- a/.github/workflows/5_codequality_changelog.yml
+++ b/.github/workflows/5_codequality_changelog.yml
@@ -12,7 +12,7 @@ jobs:
   # Enforces the update of a changelog file on every pull request
   verify-changelog:
     if: ${{ !github.event.pull_request.draft && github.repository == 'wazuh/wazuh' }}
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/5_testcomponent_keystore.yml
+++ b/.github/workflows/5_testcomponent_keystore.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   keystore-tests:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: ${{ format('codebuild-github-actions-codebuild-runner-server-amd-{0}-{1}', github.run_id, github.run_attempt) }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
       fail-fast: true

--- a/.github/workflows/5_testintegration_linux-integration-tests.yml
+++ b/.github/workflows/5_testintegration_linux-integration-tests.yml
@@ -97,7 +97,7 @@ jobs:
       BUILD_WORKFLOW: 5_builderpackage_agent-linux.yml
       PACKAGES_PATH: /tmp/packages
       AGENT_PACKAGE_REGEXP: wazuh-agent.*amd64.*\.deb
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -164,11 +164,7 @@ jobs:
           fi
           git clone -b ${QA_BRANCH} --single-branch https://github.com/wazuh/qa-integration-framework.git
           # The framework is installed for the system python3 that `sudo python`
-          # uses to run the tests. CodeBuild images ship no pip for it (the
-          # GitHub-hosted runner did), so install it and target it explicitly.
-          if ! sudo python3 -m pip --version >/dev/null 2>&1; then
-            sudo apt-get update && sudo apt-get install -y python3-pip
-          fi
+          # uses to run the tests, so target that interpreter explicitly.
           sudo python3 -m pip install --break-system-packages qa-integration-framework/
           sudo rm -rf qa-integration-framework/
 

--- a/.github/workflows/5_testunit_shared_modules_utils.yml
+++ b/.github/workflows/5_testunit_shared_modules_utils.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   shared_modules_utils-modules:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - name: Cancel previous runs
@@ -68,7 +68,7 @@ jobs:
 
   shared_modules_utils-asan:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - name: Checkout repository

--- a/.github/workflows/6_builderpackage_server.yml
+++ b/.github/workflows/6_builderpackage_server.yml
@@ -101,7 +101,7 @@ permissions:
 
 jobs:
   Build-server-packages:
-    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && format('codebuild-github-actions-codebuild-runner-server-arm-{0}-{1}', github.run_id, github.run_attempt) || 'ubuntu-24.04' }}
+    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     timeout-minutes: 35
     name: Build ${{ inputs.system }} wazuh-server on ${{ inputs.architecture }}
 
@@ -137,21 +137,10 @@ jobs:
           else echo "TAG=${{ inputs.docker_image_tag }}" >> $GITHUB_ENV; fi
           echo "CONTAINER_NAME=pkg_${{ inputs.system }}_server_builder_${{ env.ARCH }}" >> $GITHUB_ENV
 
-      - name: CodeBuild workarounds
-        # TODO: Remove once DevOps exposes host Docker socket or configures DinD in CodeBuild
-        run: |
-          # 1. Docker daemon: CodeBuild has no systemd so dockerd never starts.
-          #    VFS storage driver avoids overlay-on-overlay which is not supported inside containers.
-          if ! docker info &>/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y docker.io
-            sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
-            timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
-            sudo chmod 666 /var/run/docker.sock
-          fi
-          # 2. Git repo format: actions/checkout on newer git writes repositoryformatversion=1
-          #    which the older git inside builder Docker images cannot read.
-          git config core.repositoryformatversion 0
+      - name: Fix git repository format for builder images
+        # actions/checkout on newer git writes repositoryformatversion=1, which the
+        # older git inside the builder Docker images cannot read.
+        run: git config core.repositoryformatversion 0
 
       - name: Download docker image for package building
         run: |

--- a/.github/workflows/6_builderprecompiled_server-images.yml
+++ b/.github/workflows/6_builderprecompiled_server-images.yml
@@ -37,7 +37,7 @@ on:
 
 jobs:
   Upload-package-building-images:
-    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && format('codebuild-github-actions-codebuild-runner-server-arm-{0}-{1}', github.run_id, github.run_attempt) || 'ubuntu-24.04' }}
+    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     timeout-minutes: 140
     name: Package - Upload pkg_${{ inputs.system }}_server_builder_${{ inputs.architecture }} with tag ${{ inputs.docker_image_tag }}
 
@@ -79,21 +79,10 @@ jobs:
           cp src/engine/vcpkg-configuration.json $dockerfile_path
           cp src/engine/vcpkg.json $dockerfile_path
 
-      - name: CodeBuild workarounds
-        # TODO: Remove once DevOps exposes host Docker socket or configures DinD in CodeBuild
-        run: |
-          # 1. Docker daemon: CodeBuild has no systemd so dockerd never starts.
-          #    VFS storage driver avoids overlay-on-overlay which is not supported inside containers.
-          if ! docker info &>/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y docker.io
-            sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
-            timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
-            sudo chmod 666 /var/run/docker.sock
-          fi
-          # 2. Git repo format: actions/checkout on newer git writes repositoryformatversion=1
-          #    which the older git inside builder Docker images cannot read.
-          git config core.repositoryformatversion 0
+      - name: Fix git repository format for builder images
+        # actions/checkout on newer git writes repositoryformatversion=1, which the
+        # older git inside the builder Docker images cannot read.
+        run: git config core.repositoryformatversion 0
 
       - name: Build and push image pkg_${{ inputs.system }}_server_builder_${{ env.ARCH }} with tag ${{ env.TAG }} to Github Container Registry
         run:


### PR DESCRIPTION
## Description

As part of the CI/CD cost audit tracked in #38148, this PR is the **server-side counterpart to #38188** (which did the same for the agent-side workflows). It audits every `wazuh/wazuh` CI job running on the AWS CodeBuild `server-amd`/`server-arm` fleets and migrates them to GitHub-hosted runners.

**After this PR, no workflow on the `5.0.0` line references the CodeBuild server fleet at all** — `grep -r "codebuild-github-actions-codebuild-runner-server" .github/` returns nothing.

Closes #38148

## Proposed Changes

**Test / lint / analysis workflows** (5 files, 6 job definitions) → `ubuntu-24.04`:
`5_testintegration_linux-integration-tests.yml`, `5_testunit_shared_modules_utils.yml`, `5_testcomponent_keystore.yml`, `5_codequality_changelog.yml`, `5_codeanalysis_python_bandit_pr.yml`.

**Package-build workflows** → `ubuntu-24.04` / `ubuntu-24.04-arm`:
`5_builderpackage_manager.yml`, `5_builderpackage_engine-standalone.yml`, `5_buildpackage_internal_tools.yml`, plus the arm64 legs of `6_builderpackage_server.yml`, `6_builderprecompiled_server-images.yml` and `5_builderprecompiled_docker-images-upload-manager.yml` (their amd64 legs were already GitHub-hosted).

**Supporting fixes:**
- `5_testintegration_linux-integration-tests.yml` — removed a dead `python3-pip` shim that existed only because CodeBuild images ship no `pip` for the system `python3`.
- `.github/actions/upload_s3_artifact/action.yml` — corrected a stale doc comment about which runner images provide `7z`/AWS CLI.

No application/product source code is changed — this is CI configuration only.

> [!IMPORTANT]
> **This migration exposed a `check_files` privilege bug; the fix is already on `5.0.0` via #38225 and is not part of this diff.**
> The manager package build installs into `/var/wazuh-manager`, which is `drwxr-x--- root`. `check_files.py` ran unprivileged. A CodeBuild runner executes **as root** so it could read the tree; a GitHub-hosted runner executes as **`uid=1001(runner)`** and could not — measured on a live runner: **0 files visible as `runner`, 8,444 as root**, which surfaced as `152 expected files were not found`.
> The guard elevates only when needed, so CodeBuild (already root) is unaffected:
> ```bash
> SUDO=""; if [ "$(id -u)" -ne 0 ]; then SUDO="sudo"; fi
> ${SUDO} venv/bin/python3 check_files.py ...
> ```
> Ownership assertions still hold: `translate_uid`/`translate_gid` match **numerically** (uid 105 → `wazuh-manager`) regardless of the host's `/etc/passwd`, so differing account names on the runner image are not an issue.
> The action is shared with the agent package workflows, so the fix was routed through the agent migration PR (#38225, merged 2026-08-07); this PR's checks run against a base that already contains it.

> [!NOTE]
> **Disk was the one unverified risk for the package builds, and it is not a constraint.** GitHub-hosted runners provide **145 GB** disks, not the 14 GB often quoted. Measured with an in-job sampler during a full manager build:
>
> | Arch | Peak used on `/` | Min available |
> |---|---:|---:|
> | arm64 | 42 GiB | **101 GiB** |
> | amd64 | 63 GiB | **80 GiB** |
>
> RAM and CPU were never in question either — peak 4.5 GB against 16 GB, and identical 4 vCPU on both backends.

### Audit — decision matrix (5.0.0 line)

Metrics from the GitHub Actions API, window **2026-07-09 → 2026-08-06**. Run counts exact; job composition sampled 15–25 runs per workflow.

| Workflow | Runs/28d | CodeBuild min/28d | ~$/28d | Verdict |
|---|---:|---:|---:|---|
| `5_builderpackage_manager.yml` (via `-multiples`) | ~523 eff. | ~28,100 | ~$275 | **Migrate** |
| `5_testintegration_linux-integration-tests.yml` | 761 | ~10,800 | ~$106 | **Migrate** |
| `5_testunit_shared_modules_utils.yml` | 138 | ~3,970 | ~$39 | **Migrate** |
| `5_builderpackage_engine-standalone.yml` | 130 | ~3,900 | ~$38 | **Migrate** |
| `5_testcomponent_keystore.yml` | 127 | ~850 | ~$8 | **Migrate** |
| `5_buildpackage_internal_tools.yml` | 49 | ~660 | ~$6.5 | **Migrate** |
| `5_codequality_changelog.yml` | 963 | ~145 | ~$1.4 | **Migrate** |
| `5_codeanalysis_python_bandit_pr.yml` | 124 | ~75 | ~$0.7 | **Migrate** |
| arm64 legs of the 3 semi-migrated workflows | rare | ~0 | ~$0 | **Migrate** |

**Total: ~15,850 + ~32,660 ≈ 48,500 CodeBuild min/28d removed ≈ $475/28d (~$508/month)**, at the $0.0098/min rate implied by the [DevOps cost report](https://github.com/wazuh/wazuh-automation/issues/3637#issuecomment-5134583245).

There is no offsetting cost: `wazuh/wazuh` is a **public** repository, so standard GitHub-hosted runners — including `ubuntu-24.04-arm` — bill nothing and have no minute cap.

All AWS access in the migrated workflows is OIDC role-assumption (or static bucket keys in one case) with **no VPC dependency anywhere**, so it works unchanged from GitHub-hosted runners.

## Results and Evidence

**Methodology.** Evidence comes from this PR's own `pull_request` checks plus dedicated `workflow_dispatch` validations on a throwaway branch for the package builds (which are not `pull_request`-triggered). Baselines are the mean of **successful** CodeBuild jobs of the same name over the same 28-day window (`n` per row).

### Test / lint workflows — 6/6 pass, all at or faster than baseline

| Workflow | Job | CodeBuild baseline | GitHub-hosted | Δ | Evidence |
|---|---|---:|---:|---|---|
| `5_codequality_changelog.yml` | `verify-changelog` | 6s (n=9) | 8s | noise | [pass](https://github.com/wazuh/wazuh/actions/runs/31165212409/job/92824307531) |
| `5_codeanalysis_python_bandit_pr.yml` | `bandit-scan` | 72s (n=11) | **47s** | **−35%** | [pass](https://github.com/wazuh/wazuh/actions/runs/31165213304/job/92824310097) |
| `5_testcomponent_keystore.yml` | `Run tests (valgrind)` | 234s (n=17) | **117s** | **−50%** | [pass](https://github.com/wazuh/wazuh/actions/runs/31165212198/job/92824306880) |
| `5_testcomponent_keystore.yml` | `Run tests (asan)` | 228s (n=17) | **97s** | **−57%** | [pass](https://github.com/wazuh/wazuh/actions/runs/31165212198/job/92824306749) |
| `5_testunit_shared_modules_utils.yml` | `-modules` | 504s (n=8) | **376s** | **−25%** | [pass](https://github.com/wazuh/wazuh/actions/runs/31165212797/job/92824370831) |
| `5_testunit_shared_modules_utils.yml` | `-asan` | 1176s (n=18) | **870s** | **−26%** | [pass](https://github.com/wazuh/wazuh/actions/runs/31165212797/job/92824370817) |

### Package builds — validated on this PR's own checks, and faster

| Build | CodeBuild baseline | GitHub-hosted (this PR) | Evidence |
|---|---:|---:|---|
| manager deb/amd64 | 19.2m (n=40) | **18m59s** | [pass](https://github.com/wazuh/wazuh/actions/runs/31187377166/job/92895702265) |
| manager deb/arm64 | 19.2m (n=40) | **11m4s** | [pass](https://github.com/wazuh/wazuh/actions/runs/31187377166/job/92895701947) |
| manager rpm/x86_64 | 19.2m (n=40) | **17m15s** | [pass](https://github.com/wazuh/wazuh/actions/runs/31187377166/job/92895701957) |
| manager rpm/aarch64 | 19.2m (n=40) | **13m50s** | [pass](https://github.com/wazuh/wazuh/actions/runs/31187377166/job/92895701969) |
| engine-standalone x64 | 18.4m (n=24) | **14m0s** | [pass](https://github.com/wazuh/wazuh/actions/runs/31187377237/job/92895238718) |
| engine-standalone arm64 | 18.4m (n=24) | **13m32s** | [pass](https://github.com/wazuh/wazuh/actions/runs/31187377237/job/92895238710) |
| engine standalone smoke test (x64 / arm64) | — | 23s / 22s | [pass](https://github.com/wazuh/wazuh/actions/runs/31187377237/job/92899415344) |
| internal-tools deb amd64 / arm64 | 3.9m | 1m28s / 1m24s | [pass](https://github.com/wazuh/wazuh/actions/runs/31187376833/job/92895237367) |
| internal-tools rpm amd64 / arm64 | 3.9m | 9m52s / 3m3s | [pass](https://github.com/wazuh/wazuh/actions/runs/31187376833/job/92895237436) |

**All 12 package-build jobs pass on the PR's own checks**, every one of them on GitHub-hosted runners, and every manager/engine build at or faster than its CodeBuild baseline.

Same 4 vCPU with 16 GB instead of 8 GB, so every build is at least as fast — arm64 markedly so.

### Integration tests — 11 of 12 modules pass

Exercised across every changed Linux module by this PR's matrix ([run 31165212190](https://github.com/wazuh/wazuh/actions/runs/31165212190)): `agentd` 30m26s, `aws_inspector` 1m32s, `enrollment` 3m10s, `execd` 1m45s, `fim (tier-0)` 57m32s, `fim (tier-1)` 32m45s, `github` 5m4s, `logcollector` 8m13s, `office365` 5m0s, `sca` 3m4s, `syscollector` 14m36s — all ✅. `aws` is covered below.

Stability was additionally checked by repeat dispatches: keystore 8/8 jobs over 4 runs, `shared_modules_utils` 4/4 over 2 runs.

### `IT Linux - aws` — pre-existing, deterministic, not this PR

Fails in **setup** with **116 passed, 3 skipped, 1 error**:

```
SETUP COLLISION: unexpected object(s) already exist at prefix
'AWSLogs/819751203818/CloudTrail/<region>/2022/11/20/' in bucket '***'
```

The colliding object is **byte-identical across three unrelated branches and both runner backends** (`…_20221120T0000Z_5789919203502280457.json`) — a single orphan in the shared CI bucket, not a race. Re-running reproduces it exactly. It is not one of the two permanent seeds the workflow protects. Full cross-run evidence, including its likely origin in three cancelled `aws` jobs on 08-04/08-05, is in [this comment](https://github.com/wazuh/wazuh/pull/38233#issuecomment-5216477051).

Owned by #38101 / the CI bucket: delete that key, or add it to `_PERMANENT_SEED_KEYS` in the framework's `conftest.py`. Every AWS-sensitive step in the migrated job passes, and `aws_inspector` — same credential path, same migrated workflow — passes in 1m32s.

### Note on `execd`

Repeat runs established that `IT Linux - execd` failures track **which agent package is installed**, not the runner: one branch's package passed 2/2 (74s), two others failed 4/4 (~11m, identical assertion). On this PR's own check it passes in 1m45s.

## Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux — manager deb built successfully on both `ubuntu-24.04` and `ubuntu-24.04-arm`; engine-standalone and internal-tools likewise.
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check) — keystore `Run tests (valgrind)` (117s) and `shared_modules_utils` pass on `ubuntu-24.04`.
  - [x] AddressSanitizer — keystore `Run tests (asan)` (97s) and `shared_modules_utils-asan` (870s) pass on `ubuntu-24.04`.
- Memory tests for Windows — N/A, no Windows workflow is touched.
- Memory tests for macOS — N/A, no macOS workflow is touched.

- Decoder/Rule tests _(Wazuh v4.x)_ — N/A, targets the 5.0.0 branch only.

- Engine _(Wazuh v5.x and above)_
  - [x] `5_builderpackage_engine-standalone.yml` builds and its standalone smoke test passes on both arches on GitHub-hosted runners.

- Wazuh server API/Framework — N/A, CI runner configuration only.

### Artifacts Affected

None. Package contents are unchanged — the same builder Docker images produce the same packages; only the machine executing them changes. The manager build's `Check installed files` validation passes on the new runners, confirming byte-level package layout is intact.

### Configuration Changes

- `runs-on:` changed in 11 workflow files: CodeBuild server labels → `ubuntu-24.04` / `ubuntu-24.04-arm`.
- One dead CodeBuild `python3-pip` shim removed; one stale doc comment corrected.
- Depends on the `check_files` privilege fix already on `5.0.0` (#38225); no action code changes here.
- No user-facing defaults, parameters or backward-compatibility concerns.

### Tests Introduced

None. Existing suites are re-run under a different CI runner backend to validate the migration; see Results and Evidence.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality — N/A for new tests; the existing suites were re-run on the new backend, 6/6 test-lint job definitions, 12/12 package-build jobs and 11/12 IT modules green
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues — the two non-passing checks are tracked elsewhere (#38101 for the `aws` orphan; the `winagent` RTR hang is a pre-existing intermittent unrelated to this diff) and #38274 tracks the `execd` finding



