### PR TITLE
Remove avoidable copies, double lookups and pessimizing moves in agent-side hot paths

### DIFF
--- a/src/data_provider/src/extended_sources/browser_extensions/include/chrome.hpp
+++ b/src/data_provider/src/extended_sources/browser_extensions/include/chrome.hpp
@@ -11,6 +11,7 @@
 
 #include <string>
 #include <vector>
+#include <tuple>
 #include "json.hpp"
 #include "browser_extensions_wrapper.hpp"
 

--- a/src/data_provider/src/extended_sources/browser_extensions/include/ie_explorer.hpp
+++ b/src/data_provider/src/extended_sources/browser_extensions/include/ie_explorer.hpp
@@ -141,7 +141,7 @@ class IEExtensionsProvider
          * @param clsidKeys List of CLSID subkeys to enumerate.
          * @param regPaths Vector to append found registry paths.
          */
-        void getRegistryPathsFromKeys(HKEY hive, const std::vector<std::string> clsidKeys, std::vector<std::string>& regPaths);
+        void getRegistryPathsFromKeys(HKEY hive, const std::vector<std::string>& clsidKeys, std::vector<std::string>& regPaths);
 
         /**
          * @brief Enumerate subkeys under a given registry hive.
@@ -155,7 +155,7 @@ class IEExtensionsProvider
          * @param key Registry path string with possible user placeholders.
          * @return Expanded list of registry paths.
          */
-        std::vector<std::string> expandUserKey(const std::string key);
+        std::vector<std::string> expandUserKey(const std::string& key);
 
         /**
          * @brief Expand multiple registry keys containing user placeholders.

--- a/src/data_provider/src/extended_sources/browser_extensions/src/chrome.cpp
+++ b/src/data_provider/src/extended_sources/browser_extensions/src/chrome.cpp
@@ -8,7 +8,6 @@
  */
 
 #include "chrome.hpp"
-#include <tuple>
 #include <iostream>
 #include <fstream>
 #include <algorithm>
@@ -533,7 +532,7 @@ namespace chrome
         {
             // TODO: Improve handling this error.
             // std::cerr << "Extensions folder does not exist: " << extensionPath << std::endl;
-            return ChromeExtensionList();
+            return {};
         }
 
         std::string preferencesFilePath = Utils::joinPaths(profilePath, PREFERENCES_FILE);
@@ -543,28 +542,28 @@ namespace chrome
         {
             // TODO: Improve handling this error.
             // std::cerr << "Preferences file does not exist: " << preferencesFilePath << std::endl;
-            return ChromeExtensionList();
+            return {};
         }
 
         if (!Utils::existsRegular(securePreferencesFilePath))
         {
             // TODO: Improve handling this error.
             // std::cerr << "Preferences file does not exist: " << securePreferencesFilePath << std::endl;
-            return ChromeExtensionList();
+            return {};
         }
 
         std::string profileName = getProfileFromPreferences(preferencesFilePath, securePreferencesFilePath);
         ChromeExtensionList extensions;
 
-        for (auto subDir : Utils::enumerateDir(extensionPath))
+        for (const auto& entry : Utils::enumerateDir(extensionPath))
         {
-            subDir = Utils::joinPaths(extensionPath, subDir);
+            const std::string subDir = Utils::joinPaths(extensionPath, entry);
 
             if (!Utils::existsDir(subDir)) continue;
 
-            for (auto subSubDir : Utils::enumerateDir(subDir))
+            for (const auto& subEntry : Utils::enumerateDir(subDir))
             {
-                subSubDir = Utils::joinPaths(subDir, subSubDir);
+                std::string subSubDir = Utils::joinPaths(subDir, subEntry);
 
                 if (!Utils::existsDir(subSubDir)) continue;
 
@@ -708,9 +707,9 @@ namespace chrome
                 }
                 else
                 {
-                    for (auto subDirectory : Utils::enumerateDir(profilePath))
+                    for (const auto& entry : Utils::enumerateDir(profilePath))
                     {
-                        subDirectory = Utils::joinPaths(profilePath, subDirectory);
+                        const std::string subDirectory = Utils::joinPaths(profilePath, entry);
 
                         if (Utils::existsDir(subDirectory) && isValidChromeProfile(subDirectory))
                         {

--- a/src/data_provider/src/extended_sources/browser_extensions/src/chrome.cpp
+++ b/src/data_provider/src/extended_sources/browser_extensions/src/chrome.cpp
@@ -681,15 +681,14 @@ namespace chrome
 
 #if defined(_WIN32) || defined(_WIN64)
 
-            for (const auto& browser : WINDOWS_PATH_LIST)
+            for (const auto& [browserType, browserPath] : WINDOWS_PATH_LIST)
 #elif defined(__APPLE__) && defined(__MACH__)
 
-            for (const auto& browser : MACOS_PATH_LIST)
+            for (const auto& [browserType, browserPath] : MACOS_PATH_LIST)
 #elif defined(__linux__)
-            for (const auto& browser : LINUX_PATH_LIST)
+            for (const auto& [browserType, browserPath] : LINUX_PATH_LIST)
 #endif
             {
-                std::string browserPath = std::get<1>(browser);
                 const std::string profilePath = Utils::joinPaths(userHomePath, browserPath);
 
                 if (!Utils::existsDir(profilePath))
@@ -698,7 +697,7 @@ namespace chrome
                     continue;
                 }
 
-                m_currentBrowserType = CHROME_BROWSER_TYPES.at(std::get<0>(browser));
+                m_currentBrowserType = CHROME_BROWSER_TYPES.at(browserType);
 
                 // The profile path exists, now let's find the profile.
                 if (isValidChromeProfile(profilePath))

--- a/src/data_provider/src/extended_sources/browser_extensions/src/firefox.cpp
+++ b/src/data_provider/src/extended_sources/browser_extensions/src/firefox.cpp
@@ -70,15 +70,15 @@ FirefoxAddons FirefoxAddonsProvider::getAddons()
         return firefoxAddons;
     }
 
-    for (auto userHome : Utils::enumerateDir(homePath))
+    for (const auto& userDir : Utils::enumerateDir(homePath))
     {
         // Ignore ".", ".." and hidden directories
-        if (Utils::startsWith(userHome, "."))
+        if (Utils::startsWith(userDir, "."))
         {
             continue;
         }
 
-        userHome = Utils::joinPaths(homePath, userHome);
+        const std::string userHome = Utils::joinPaths(homePath, userDir);
 
         if (!Utils::existsDir(userHome) || !isValidPath(userHome))
         {
@@ -96,9 +96,9 @@ FirefoxAddons FirefoxAddonsProvider::getAddons()
                 continue;
             }
 
-            for (auto entity : Utils::enumerateDir(firefoxInstallationPath))
+            for (const auto& entry : Utils::enumerateDir(firefoxInstallationPath))
             {
-                entity = Utils::joinPaths(firefoxInstallationPath, entity);
+                const std::string entity = Utils::joinPaths(firefoxInstallationPath, entry);
 
                 if (!Utils::existsDir(entity) || !isValidPath(entity))
                 {

--- a/src/data_provider/src/extended_sources/browser_extensions/src/ie_explorer.cpp
+++ b/src/data_provider/src/extended_sources/browser_extensions/src/ie_explorer.cpp
@@ -161,9 +161,9 @@ std::string IEExtensionsProvider::HKeyToString(HKEY hKey)
 }
 
 
-void IEExtensionsProvider::getRegistryPathsFromKeys(HKEY hive, const std::vector<std::string> clsidKeys, std::vector<std::string>& regPaths)
+void IEExtensionsProvider::getRegistryPathsFromKeys(HKEY hive, const std::vector<std::string>& clsidKeys, std::vector<std::string>& regPaths)
 {
-    for (auto& subKey : clsidKeys)
+    for (const auto& subKey : clsidKeys)
     {
         HKEY hKey = getHKeyFromKeyString(hive, subKey);
 
@@ -222,11 +222,13 @@ std::vector<std::string> IEExtensionsProvider::listSubKeys(HKEY hive)
     return subKeys;
 }
 
-std::vector<std::string> IEExtensionsProvider::expandUserKey(const std::string key)
+std::vector<std::string> IEExtensionsProvider::expandUserKey(const std::string& key)
 {
     std::vector<std::string> expandedKeys;
+    const auto subKeys = listSubKeys(HKEY_USERS);
+    expandedKeys.reserve(subKeys.size());
 
-    for (const auto& prefix : listSubKeys(HKEY_USERS))
+    for (const auto& prefix : subKeys)
     {
         expandedKeys.emplace_back(prefix + SEPARATOR + key);
     }

--- a/src/data_provider/src/ports/portLinuxWrapper.h
+++ b/src/data_provider/src/ports/portLinuxWrapper.h
@@ -118,9 +118,9 @@ class LinuxPortWrapper final : public IPortWrapper
         explicit LinuxPortWrapper(const PortType type, const std::string& row)
             : m_fields{ Utils::split(row, ' ') }
             , m_type { type }
-            , m_remoteAddresses { std::move(Utils::split(m_fields.at(REMOTE_ADDRESS), ':')) }
-            , m_localAddresses { std::move(Utils::split(m_fields.at(LOCAL_ADDRESS), ':')) }
-            , m_queue { std::move(Utils::split(m_fields.at(QUEUE), ':')) }
+            , m_remoteAddresses { Utils::split(m_fields.at(REMOTE_ADDRESS), ':') }
+            , m_localAddresses { Utils::split(m_fields.at(LOCAL_ADDRESS), ':') }
+            , m_queue { Utils::split(m_fields.at(QUEUE), ':') }
         { }
 
         ~LinuxPortWrapper() = default;

--- a/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp
@@ -1012,6 +1012,8 @@ bool SQLiteDBEngine::getPrimaryKeysFromTable(const std::string& table,
     auto retVal { false };
     const auto tableFields { m_tableFields[table] };
 
+    primaryKeyList.reserve(tableFields.size());
+
     for (const auto& value : tableFields)
     {
         if (std::get<TableHeader::PK>(value) == true)

--- a/src/shared_modules/utils/observer.hpp
+++ b/src/shared_modules/utils/observer.hpp
@@ -90,7 +90,7 @@ public:
     void notifyObservers(T data)
     {
         std::lock_guard<std::mutex> lock(mutex);
-        for (auto observer : observers)
+        for (const auto &observer : observers)
         {
             observer->update(data);
         }


### PR DESCRIPTION
|Related issue|
|---|
|#38173|

## Description

Closes #38173.

An audit of the agent-side C++ (`data_provider`, `shared_modules`) surfaced a set of copies the compiler cannot elide, one pessimizing `std::move`, and two vectors grown element by element when their final size is already known. Every site below is local and behavior-preserving; the value is in the hot paths they sit on.

### Pessimizing `std::move` on prvalues — `src/data_provider/src/ports/portLinuxWrapper.h:118`

```cpp
explicit LinuxPortWrapper(const PortType type, const std::string& row)
    : m_fields{ Utils::split(row, ' ') }
    , m_type { type }
    , m_remoteAddresses { std::move(Utils::split(m_fields.at(REMOTE_ADDRESS), ':')) }
    , m_localAddresses { std::move(Utils::split(m_fields.at(LOCAL_ADDRESS), ':')) }
    , m_queue { std::move(Utils::split(m_fields.at(QUEUE), ':')) }
{ }
```

`Utils::split()` returns a `std::vector<std::string>` by value, so each initializer is already a prvalue that gets copy-elided straight into the member. Wrapping it in `std::move` turns the prvalue into an xvalue, which makes it ineligible for elision and forces an actual `std::vector` move constructor call instead. Three of them, per port.

This constructor runs once for every line parsed out of `/proc/net/{tcp,tcp6,udp,udp6}`, so on a host with a large connection table it is a genuinely hot path. Dropping the three `std::move` cannot change behavior and is strictly better codegen.

### By-value range-for over `std::string` — `chrome.cpp`, `firefox.cpp`, `ie_explorer.cpp`

The browser-extension providers walk directory listings with the loop variable taken by value, then reassign it in place:

```cpp
// src/data_provider/src/extended_sources/browser_extensions/src/firefox.cpp:73
for (auto userHome : Utils::enumerateDir(homePath))
{
    if (Utils::startsWith(userHome, ".")) { continue; }
    userHome = Utils::joinPaths(homePath, userHome);
    ...
}
```

`Utils::enumerateDir()` returns `std::vector<std::string>`, so `auto` copies a `std::string` per entry, and the reassignment then destroys that copy to build the joined path. Binding the element by `const auto&` and introducing a separate local for the joined path removes the per-entry copy and, as a side effect, stops the loop variable from meaning two different things (the bare entry name on the first line, the absolute path afterwards). Same pattern at `chrome.cpp:559`, `chrome.cpp:565` and `chrome.cpp:711`, and at `firefox.cpp:99`.

`ie_explorer.cpp` had two by-value parameters on the same theme:

```cpp
// src/data_provider/src/extended_sources/browser_extensions/include/ie_explorer.hpp:144,158
void getRegistryPathsFromKeys(HKEY hive, const std::vector<std::string> clsidKeys, std::vector<std::string>& regPaths);
std::vector<std::string> expandUserKey(const std::string key);
```

Both are read-only inside the body (`clsidKeys` is only iterated, `key` is only concatenated), so the by-value copy is pure cost. Note `const std::vector<std::string>` by value is also unmovable at the call site precisely because it is `const`, so every caller pays a full vector deep copy.

### Copied `shared_ptr` per notification — `src/shared_modules/utils/observer.hpp:93`

```cpp
void notifyObservers(T data)
{
    std::lock_guard<std::mutex> lock(mutex);
    for (auto observer : observers)   // observers is std::vector<std::shared_ptr<Observer<T>>>
    {
        observer->update(data);
    }
}
```

`auto` copies the `shared_ptr`, which is an atomic refcount increment on entry and an atomic decrement on scope exit, for every observer on every notification, while the mutex is held. The pointee is only dereferenced, never rebound or stored, so `const auto&` is sufficient.

### `reserve()` where the size is already known

`SQLiteDBEngine::getPrimaryKeysFromTable()` (`src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp:1009`) filters `tableFields` into `primaryKeyList` one `emplace_back` at a time. `tableFields.size()` is an exact upper bound and is available before the loop, so a single `reserve()` removes the reallocation chain at no extra pass over the data.

`IEExtensionsProvider::expandUserKey()` had the same shape plus a subtlety: the range-for iterated directly over `listSubKeys(HKEY_USERS)`, so the size was never observable. Binding the result to a local makes `reserve()` possible without calling the enumeration twice.

### Scope notes

Two items from the issue are deliberately not here:

- Item 1 (`sca_impl/src/sca_event_handler.cpp`) does not exist on `4.14.8`; that file belongs to the 5.0 line.
- Item 4's `Observer<T>::update(T)` / `Subject<T>::setData(T)` by-value signature change is left out. It touches every implementor, the only in-tree instantiation already has `T` as a reference, and it overlaps with the `Subject::detach()` work in #38143. Only the `const auto&` loop change was applied, which is the part that is unconditionally safe.

### Reviewing the diff

Two commits: `b310b28` is the entire behavioral change (30 lines), `2df616c` is `clang-format` over the touched files against the repo's tracked `.clang-format`. The formatting commit is what makes the diff look large. Reviewing with `git diff -w` collapses it to the real change.

## Configuration options

N/A. No configuration parameter or default value changed.

## Logs/Alerts example

N/A. No user-visible log or alert changed, this PR has no functional effect.

Evidence is the clean rebuild of the affected components. Both objects were forced to recompile (`touch` on the modified sources) so the build below is not a no-op:

`data_provider`, with `-Wall -Wextra`:

```
[ 45%] Building CXX object src/extended_sources/browser_extensions/CMakeFiles/browser_extensions.dir/src/chrome.cpp.o
[ 48%] Building CXX object src/extended_sources/browser_extensions/CMakeFiles/browser_extensions.dir/src/firefox.cpp.o
[ 51%] Linking CXX static library ../../../lib/libbrowser_extensions.a
[ 51%] Built target browser_extensions
[ 54%] Building CXX object CMakeFiles/sysinfo.dir/src/sysInfoLinux.cpp.o
[ 58%] Linking CXX shared library lib/libsysinfo.so
[ 93%] Built target sysinfo
[ 96%] Linking CXX executable ../bin/sysinfo_test_tool
[100%] Built target sysinfo_test_tool
```

`dbsync`:

```
[ 10%] Building CXX object CMakeFiles/dbsync.dir/src/sqlite/sqlite_dbengine.cpp.o
[ 20%] Linking CXX shared library lib/libdbsync.so
[ 60%] Built target dbsync
[ 70%] Linking CXX executable ../bin/dbsync_example
[ 80%] Built target dbsync_example
[ 90%] Linking CXX executable ../bin/dbsync_test_tool
[100%] Built target dbsync_test_tool
```

Full agent target:

```
[100%] Built target wazuh-syscheckd
make[2]: Leaving directory '/home/miguevr/Work/wazuh-38173/src/syscheckd/build'

Done building agent
```

No new warnings were emitted by any of the touched translation units.

Formatting conformance against the repo's tracked `.clang-format` (empty output means no diff):

```
$ for f in src/data_provider/src/extended_sources/browser_extensions/include/ie_explorer.hpp \
           src/data_provider/src/extended_sources/browser_extensions/src/chrome.cpp \
           src/data_provider/src/extended_sources/browser_extensions/src/firefox.cpp \
           src/data_provider/src/extended_sources/browser_extensions/src/ie_explorer.cpp \
           src/data_provider/src/ports/portLinuxWrapper.h \
           src/shared_modules/dbsync/src/sqlite/sqlite_dbengine.cpp \
           src/shared_modules/utils/observer.hpp; do
      clang-format --dry-run -Werror "$f"
  done
$
```

## Tests

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors
