### PR TITLE
Fix bad formatted vulnerability scanner database workflow

### DIFF
--- a/.github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml
+++ b/.github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml
@@ -114,17 +114,17 @@ jobs:
 
     runs-on: ubuntu-24.04
 
-      steps:
-        - name: Checkout repository
-          uses: actions/checkout@v3
-          with:
-            fetch-depth: 0
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-        ########################
-        # Compilation          #
-        ########################
-        - name: Compile
-          uses: ./.github/actions/vulnerability_scanner/compile
+      ########################
+      # Compilation          #
+      ########################
+      - name: Compile
+        uses: ./.github/actions/vulnerability_scanner/compile
 
       ########################
       # Content generation   #
@@ -134,19 +134,19 @@ jobs:
         with:
           content_version: ${{ inputs.content_version }}
 
-        ########################
-        # Content upload       #
-        ########################
-        - name: Upload database to S3
-          if: ${{ inputs.upload_to_s3 }}
-          run: |
-            root_folder=$(pwd)
-            bucket="${{ secrets.FEED_AWS_BUCKET }}"
-            file="vd_1.0.0_vd_${{ inputs.content_version }}.tar.xz"
-            dest_dir="deps/vulnerability_model_database"
-            aws s3 cp ${file} s3://${bucket}/${dest_dir}/${file}
-          env:
-            AWS_ACCESS_KEY_ID: ${{ secrets.FEED_AWS_KEY_ID }}
-            AWS_SECRET_ACCESS_KEY: ${{ secrets.FEED_AWS_SECRET_ACCESS_KEY}}
-            AWS_DEFAULT_REGION: 'us-west-1'
-          shell: bash
+      ########################
+      # Content upload       #
+      ########################
+      - name: Upload database to S3
+        if: ${{ inputs.upload_to_s3 }}
+        run: |
+          root_folder=$(pwd)
+          bucket="${{ secrets.FEED_AWS_BUCKET }}"
+          file="vd_1.0.0_vd_${{ inputs.content_version }}.tar.xz"
+          dest_dir="deps/vulnerability_model_database"
+          aws s3 cp ${file} s3://${bucket}/${dest_dir}/${file}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.FEED_AWS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.FEED_AWS_SECRET_ACCESS_KEY}}
+          AWS_DEFAULT_REGION: 'us-west-1'
+        shell: bash

--- a/.github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml
+++ b/.github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml
@@ -62,6 +62,8 @@ jobs:
 
           # Replace all occurrences of 'wazuh_version' with 'content_version' in all .yml files
           find .github/actions .github/workflows -type f -name "*.yml" -exec sed -i 's/wazuh_version/content_version/g' {} +
+        env:
+          CONTENT_VERSION: ${{ matrix.content_version }}
 
       # Restore missing template file.
       - name: Restore missing template file


### PR DESCRIPTION
## Description

The workflow file `.github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml` is invalid YAML on `5.0.0` since the merge of 4.14.8 (#37973): the conflict resolution mixed 4-space and 6-space indentation inside the `vulnerability_scanner_database_manual_update` job. As a consequence, every push on branches based on `5.0.0` produces a failed run with no jobs ("workflow file issue").

This is a port of #38220, already merged into `main`, keeping the file byte-identical across branches so the next upward merges resolve cleanly.

Related issue: https://github.com/wazuh/internal-devel-requests/issues/5791

## Proposed Changes

- Cherry-pick of the two commits from #38220: re-indent the `manual_update` job steps and restore the missing `env` block.

### Results and Evidence

YAML validation before and after the fix:

```
$ git show origin/5.0.0:.github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml | ruby -ryaml -e 'YAML.load(STDIN.read)'
mapping values are not allowed in this context at line 117 column 12

$ git show fix/vd-db-workflow-invalid-format-5.0.0:.github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml | ruby -ryaml -e 'YAML.load(STDIN.read); puts "YAML OK"'
YAML OK
```

The resulting file is byte-identical to `main` after #38220, verified by hash, and a simulated merge (`git merge-tree`) of this branch into `5.0.1` and `main` reports no conflict on this file:

```
fix/vd-db-workflow-invalid-format-5.0.0    06e364b7bbe8170a46cfcf11261ef1227bab0509
fix/vd-db-workflow-invalid-format-5.0.1    06e364b7bbe8170a46cfcf11261ef1227bab0509
origin/main                                06e364b7bbe8170a46cfcf11261ef1227bab0509
```

### Artifacts Affected

None, CI workflow file only.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None.

## Review Checklist
- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
