### PR TITLE
Fix remote-command configuration validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Fixed a heap buffer write in `wazuh-analysisd` when generating FIM alerts by resizing `full_log` before writing. ([#38145](https://github.com/wazuh/wazuh/pull/38145))
 - Fixed password validation not being enforced for empty passwords in the `update_user` API endpoint. ([#38180](https://github.com/wazuh/wazuh/pull/38180))
 - Fixed API tokens for `run_as` users not being invalidated on logout or role revocation. ([#38193](https://github.com/wazuh/wazuh/pull/38193))
+- Fixed a remote-command configuration validation bypass where upper- or mixed-case XML element names let command `localfile` and `wodle` blocks pass the `remote_commands` restriction. ([#38239](https://github.com/wazuh/wazuh/pull/38239))
 
 ### Agent
 

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -712,6 +712,29 @@ def test_plain_dict_to_nested_dict():
      {'localfile': {'allow': False, 'exceptions': []},
       'wodle_command': {'allow': False, 'exceptions': []}},
      False),
+
+    # Test case where the command log_format tag name is uppercased with a lowercase decoy (should raise when not allowed)
+    ("<ossec_config><localfile><log_format>syslog</log_format><LOG_FORMAT>full_command</LOG_FORMAT>"
+     "<command>id</command></localfile></ossec_config>",
+     "<ossec_config><localfile><log_format>syslog</log_format><location>/var/log/test.log</location></localfile></ossec_config>",
+     {'localfile': {'allow': False, 'exceptions': []},
+      'wodle_command': {'allow': True, 'exceptions': []}},
+     True),
+
+    # Test case where the command log_format tag name uses mixed case (should raise when not allowed)
+    ("<ossec_config><localfile><log_format>syslog</log_format><Log_Format>command</Log_Format>"
+     "<command>echo test</command></localfile></ossec_config>",
+     "<ossec_config><localfile><log_format>syslog</log_format><location>/var/log/test.log</location></localfile></ossec_config>",
+     {'localfile': {'allow': False, 'exceptions': []},
+      'wodle_command': {'allow': True, 'exceptions': []}},
+     True),
+
+    # Test case where the wodle command tag name is uppercased (should raise when not allowed)
+    ('<ossec_config><wodle name="command"><COMMAND>ls -la</COMMAND></wodle></ossec_config>',
+     '<ossec_config><wodle name="command"><tag>value</tag></wodle></ossec_config>',
+     {'localfile': {'allow': True, 'exceptions': []},
+      'wodle_command': {'allow': False, 'exceptions': []}},
+     True),
 ])
 def test_check_remote_commands(new_conf, original_conf, allow_config, should_raise):
     """Tests check_remote_commands with different remote command inputs."""

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -970,7 +970,7 @@ def xml_to_dict(root, section_path: list):
 
         if len(element):
             for child in element:
-                result[child.tag] = element_to_dict(child)
+                result[child.tag.lower()] = element_to_dict(child)
         else:
             result = {
                 'attrib': element.attrib,


### PR DESCRIPTION
## Description
When uploading a manager configuration, `check_remote_commands` classifies `<localfile>`/`<wodle>` command blocks by reading XML element names case-sensitively, while `wazuh-logcollector` matches those element names case-insensitively. An element written in a different case (for example `<LOG_FORMAT>full_command</LOG_FORMAT>`) was therefore invisible to the validator but honored by the collector, letting a command block pass validation even with `remote_commands.localfile.allow: no`. The fix normalizes the element tag case when building the configuration dictionary so the validator classifies elements the same way the parser does.

## Proposed Changes
- `framework/wazuh/core/utils.py`: in `element_to_dict` (used by `xml_to_dict`), build the dictionary key from the lower-cased element tag instead of the verbatim tag, so upper/mixed-case element names collapse onto their canonical key. This makes `check_remote_commands` (and the sibling upload-configuration validators that share `element_to_dict`) recognize command blocks regardless of tag case.
- `framework/wazuh/core/tests/test_utils.py`: add parametrized cases to `test_check_remote_commands` covering upper/mixed-case tag names.

### Results and Evidence
`test_check_remote_commands` — before the fix the three new cases fail (the bypass is reproduced), after the fix all pass:

```
# before the fix
3 failed, 7 passed, 314 deselected

# after the fix
10 passed, 314 deselected
```

Full module suite after the fix (no regressions in the other validators that share `element_to_dict`):

```
framework/wazuh/core/tests/test_utils.py .... 324 passed
```

Server build (`make TARGET=server`) completed successfully with the change in place.

### Artifacts Affected
Wazuh manager framework / API (`wazuh-apid`), bundled in the `wazuh-manager` package. No agent-side or C binaries are affected.

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
Three cases added to `test_check_remote_commands` in `framework/wazuh/core/tests/test_utils.py`:
- localfile with a lowercase `<log_format>` decoy plus an uppercase `<LOG_FORMAT>full_command</LOG_FORMAT>`.
- localfile with a mixed-case `<Log_Format>command</Log_Format>`.
- wodle command block with an uppercase `<COMMAND>` element.

## Credits
Reported by @namd0ng.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
