### PR TITLE
Skip 4.x CI checks on draft pull requests

### DIFF
--- a/.github/workflows/4_builderpackage_manager-multiples.yml
+++ b/.github/workflows/4_builderpackage_manager-multiples.yml
@@ -37,6 +37,7 @@ permissions:
 
 jobs:
   select-targets:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     name: Select build targets (Wazuh Managers)
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     outputs:
@@ -58,6 +59,7 @@ jobs:
             return { include: matrix };
           result-encoding: json
   build-wazuh-manager:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     name: Build Wazuh Manager
     needs: select-targets
     strategy:

--- a/.github/workflows/4_builderprecompiled_vdscanner-testtools.yml
+++ b/.github/workflows/4_builderprecompiled_vdscanner-testtools.yml
@@ -44,7 +44,7 @@ jobs:
     name: VD Scanner Tools Delivery
 
     # Runs only if the PR status is different to Draft
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 60
 

--- a/.github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml
+++ b/.github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml
@@ -5,6 +5,7 @@ on:
     - cron: "20 0 * * *"
 
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - ".github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml"
       - ".github/actions/compile_and_test/action.yml"
@@ -87,7 +88,7 @@ jobs:
         shell: bash
 
   vulnerability_scanner_database_workflow_changes:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && !github.event.pull_request.draft
 
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
 

--- a/.github/workflows/4_codeanalysis_python.yml
+++ b/.github/workflows/4_codeanalysis_python.yml
@@ -3,6 +3,7 @@ name: 4.X - Python static code analysis on PR
 
 on:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - ".github/workflows/4_codeanalysis_python.yml"
       - "framework/**/*.py"
@@ -13,6 +14,7 @@ env:
 
 jobs:
   bandit-scan:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout repo

--- a/.github/workflows/4_codeanalysis_scanbuild.yml
+++ b/.github/workflows/4_codeanalysis_scanbuild.yml
@@ -2,6 +2,7 @@ name: 4.X - Scan Build
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/**"
       - ".github/workflows/4_codeanalysis_scanbuild.yml"
@@ -12,6 +13,7 @@ permissions:
 
 jobs:
   scan-build-linux:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     strategy:
       fail-fast: false
@@ -51,6 +53,7 @@ jobs:
         run: exit 1
 
   scan-build-ubuntu-mingw-windows:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -88,6 +91,7 @@ jobs:
         run: exit 1
 
   scan-build-macos-agent:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/4_codelinter_clangformat.yml
+++ b/.github/workflows/4_codelinter_clangformat.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   style:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:

--- a/.github/workflows/4_testcomponent_build-macos.yml
+++ b/.github/workflows/4_testcomponent_build-macos.yml
@@ -2,12 +2,14 @@ name: 4.X - macOS compilation test
 
 on:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/**"
       - ".github/workflows/4_testcomponent_build-macos.yml"
 
 jobs:
   build-sonoma:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: macos-14
     steps:
       - name: Checkout Repo

--- a/.github/workflows/4_testcomponent_indexer-connector.yml
+++ b/.github/workflows/4_testcomponent_indexer-connector.yml
@@ -20,6 +20,7 @@ permissions:
 
 jobs:
   indexer_connector-qa:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/4_testcomponent_inventory-harvester.yml
+++ b/.github/workflows/4_testcomponent_inventory-harvester.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   inventory-harvester-modules:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Cancel previous runs
@@ -47,6 +48,7 @@ jobs:
           valgrind: "true"
 
   inventory-harvester-asan:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     strategy:
       matrix:
         os: [ubuntu-24.04, ubuntu-22.04]

--- a/.github/workflows/4_testcomponent_keystore.yml
+++ b/.github/workflows/4_testcomponent_keystore.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   wazuh-keystore-qa:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/4_testcomponent_syscheck-rtr.yml
+++ b/.github/workflows/4_testcomponent_syscheck-rtr.yml
@@ -3,6 +3,7 @@ name: 4.X - Running RTR. Module syscheck for agent/winagent targets
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/ci/**"
       - "src/build.py"
@@ -18,6 +19,7 @@ permissions:
 
 jobs:
   rtr:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/4_testcomponent_syscollector-rtr.yml
+++ b/.github/workflows/4_testcomponent_syscollector-rtr.yml
@@ -3,6 +3,7 @@ name: 4.X - Running RTR. Module syscollector and its dependencies for agent/wina
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/ci/**"
       - "src/build.py"
@@ -19,6 +20,7 @@ permissions:
 
 jobs:
   rtr:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     strategy:
           fail-fast: false
           matrix:

--- a/.github/workflows/4_testcomponent_sysinfo-linux.yml
+++ b/.github/workflows/4_testcomponent_sysinfo-linux.yml
@@ -3,6 +3,7 @@ name: 4.X - Syscollector test on Ubuntu
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - ".github/workflows/4_testcomponent_sysinfo-linux.yml"
       - "src/data_provider/**"
@@ -12,6 +13,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo

--- a/.github/workflows/4_testcomponent_sysinfo-macos.yml
+++ b/.github/workflows/4_testcomponent_sysinfo-macos.yml
@@ -3,6 +3,7 @@ name: 4.X - Syscollector test on macOS
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - ".github/workflows/4_testcomponent_sysinfo-macos.yml"
       - "src/data_provider/**"
@@ -12,6 +13,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: macos-14
     steps:
       - name: Checkout Repo

--- a/.github/workflows/4_testcomponent_sysinfo-windows.yml
+++ b/.github/workflows/4_testcomponent_sysinfo-windows.yml
@@ -3,6 +3,7 @@ name: 4.X - Syscollector test on Windows
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - ".github/workflows/4_testcomponent_sysinfo-windows.yml"
       - "src/data_provider/**"
@@ -16,6 +17,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -84,6 +86,7 @@ jobs:
           name: syscollector
           path: src/wazuh_modules/syscollector/build/bin
   run-on-windows:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build
     runs-on: codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:

--- a/.github/workflows/4_testcomponent_vulnerability-scanner.yml
+++ b/.github/workflows/4_testcomponent_vulnerability-scanner.yml
@@ -23,6 +23,7 @@ permissions:
 
 jobs:
   style-and-documentation:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
@@ -154,6 +155,7 @@ jobs:
           id: vulnerability_scanner
 
   vulnerability-scanner-modules:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: style-and-documentation
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
 
@@ -245,6 +247,7 @@ jobs:
           id: vulnerability_scanner
 
   vulnerability-scanner-modules-asan:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: style-and-documentation
 
     strategy:
@@ -304,6 +307,7 @@ jobs:
           asan: "true"
 
   vulnerability-scanner-modules-qa:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     env:
       OFFLINE_CONFIG_FILE: config.content_generation.json

--- a/.github/workflows/4_testcomponent_windows-dll-hijack.yml
+++ b/.github/workflows/4_testcomponent_windows-dll-hijack.yml
@@ -3,6 +3,7 @@ name: 4.X - Testing DLL search order to prevent hijack
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/**"
       - ".github/workflows/4_testcomponent_windows-dll-hijack.yml"
@@ -13,6 +14,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -59,6 +61,7 @@ jobs:
           name: configuration
           path: src/configuration_files
   check_dll_on_windows:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     # NOTE: stays on the GitHub-hosted Windows runners. This test drives Process Monitor, which
     # captures via a kernel minifilter driver. CodeBuild's Windows fleet runs process-isolated
     # containers (no FltMgr / kernel-driver loading), so Procmon captures zero events there.

--- a/.github/workflows/4_testcomponent_windows-files.yml
+++ b/.github/workflows/4_testcomponent_windows-files.yml
@@ -2,6 +2,7 @@ name: 4.X - Windows binaries' details
 
 on:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/**"
       - ".github/workflows/4_testcomponent_windows-files.yml"
@@ -12,6 +13,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -45,6 +47,7 @@ jobs:
           name: binaries
           path: src/bin_files
   check_binaries_details:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
     needs: build
     steps:

--- a/.github/workflows/4_testcomponent_windows-installer-upgrade.yml
+++ b/.github/workflows/4_testcomponent_windows-installer-upgrade.yml
@@ -2,6 +2,7 @@ name: 4.X - Windows upgrade test
 
 on:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/**"
       - ".github/actions/upload_s3_artifact/**"
@@ -14,6 +15,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Install mingw
@@ -43,6 +45,7 @@ jobs:
           path: win-agent-base.zip
 
   check_upgrade_result:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     strategy:
           matrix:
               wazuh_version: [4.5.2-1]

--- a/.github/workflows/4_testintegration_agentd-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_agentd-tier-0-1-lin.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_agentd-tier-0-1-lin.yml"
         - "src/client-agent/**"
@@ -20,6 +21,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_agentd-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_agentd-tier-0-1-win.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_agentd-tier-0-1-win.yml"
         - "src/client-agent/**"
@@ -26,6 +27,7 @@ permissions:
 jobs:
   # Build the winagent on linux.
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -58,6 +60,7 @@ jobs:
           path: src/winagent
   # Execute the tests on windows.
   run-test:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/4_testintegration_analysisd-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_analysisd-tier-0-1.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_analysisd-tier-0-1.yml"
         - "src/analysisd/**"
@@ -21,6 +22,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_api-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_api-tier-0-1.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_api-tier-0-1.yml"
         - "api/**"
@@ -22,6 +23,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_authd-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_authd-tier-0-1.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_authd-tier-0-1.yml"
         - "src/config/authd-config.c"
@@ -20,6 +21,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_aws-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_aws-tier-0-1.yml
@@ -12,12 +12,14 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - ".github/workflows/4_testintegration_aws-tier-0-1.yml"
       - "wodles/aws/**"
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     permissions:
       id-token: write  # Required for OIDC token generation (aws-actions/configure-aws-credentials)
       contents: read

--- a/.github/workflows/4_testintegration_enrollment-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_enrollment-tier-0-1-lin.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_enrollment-tier-0-1-lin.yml"
         - "src/client-agent/**"
@@ -21,6 +22,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_enrollment-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_enrollment-tier-0-1-win.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_enrollment-tier-0-1-win.yml"
         - "src/client-agent/**"
@@ -27,6 +28,7 @@ permissions:
 jobs:
   # Build the winagent on linux.
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -59,6 +61,7 @@ jobs:
           path: src/winagent
   # Execute the tests on windows.
   run-test:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/4_testintegration_execd-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_execd-tier-0-1-lin.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_execd-tier-0-1-lin.yml"
         - "src/config/active-response.c"
@@ -19,6 +20,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_execd-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_execd-tier-0-1-win.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_execd-tier-0-1-win.yml"
         - "src/config/active-response.c"
@@ -25,6 +26,7 @@ permissions:
 jobs:
   # Build the winagent on linux.
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -57,6 +59,7 @@ jobs:
           path: src/winagent
   # Execute the tests on windows.
   run-test:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/4_testintegration_fim-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_fim-tier-0-1-lin.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_fim-tier-0-1-lin.yml"
         - "src/config/syscheck-config.c"
@@ -19,6 +20,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_fim-tier-0-1-macos.yml
+++ b/.github/workflows/4_testintegration_fim-tier-0-1-macos.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_fim-tier-0-1-macos.yml"
         - "src/config/syscheck-config.c"
@@ -19,6 +20,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_fim-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_fim-tier-0-1-win.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_fim-tier-0-1-win.yml"
         - "src/config/syscheck-config.c"
@@ -24,6 +25,7 @@ permissions:
 jobs:
   # Build the winagent on linux.
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -56,6 +58,7 @@ jobs:
           path: src/winagent
   # Execute the tests on windows.
   run-test:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/4_testintegration_github-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_github-tier-0-1-lin.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_github-tier-0-1-lin.yml"
         - "src/config/wmodules-github.c"
@@ -19,6 +20,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_github-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_github-tier-0-1-win.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_github-tier-0-1-win.yml"
         - "src/config/wmodules-github.c"
@@ -25,6 +26,7 @@ permissions:
 jobs:
   # Build the winagent on linux.
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -57,6 +59,7 @@ jobs:
           path: src/winagent
   # Execute the tests on windows.
   run-test:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/4_testintegration_integratord-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_integratord-tier-0-1.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_integratord-tier-0-1.yml"
         - "src/config/integrator-config.c"
@@ -19,6 +20,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_inventory-harvester.yml
+++ b/.github/workflows/4_testintegration_inventory-harvester.yml
@@ -3,6 +3,7 @@ name: 4.X - Inventory Harvester - Integration tests
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
   # Pull request events
     types: [synchronize, opened, reopened, ready_for_review]
   # Path filtering
@@ -17,6 +18,7 @@ on:
 
 jobs:
   inventory-harvester-qa:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:

--- a/.github/workflows/4_testintegration_logcollector-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_logcollector-tier-0-1-lin.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_logcollector-tier-0-1-lin.yml"
         - "src/config/localfile-config.c"
@@ -19,6 +20,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_logcollector-tier-0-1-macos.yml
+++ b/.github/workflows/4_testintegration_logcollector-tier-0-1-macos.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_logcollector-tier-0-1-macos.yml"
         - "src/config/localfile-config.c"
@@ -19,6 +20,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_logcollector-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_logcollector-tier-0-1-win.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_logcollector-tier-0-1-win.yml"
         - "src/config/localfile-config.c"
@@ -24,6 +25,7 @@ permissions:
 jobs:
   # Build the winagent on linux.
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -56,6 +58,7 @@ jobs:
           path: src/winagent
   # Execute the tests on windows.
   run-test:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/4_testintegration_logtest-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_logtest-tier-0-1.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_logtest-tier-0-1.yml"
         - "src/analysisd/logtest.c"
@@ -20,6 +21,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_msgraph-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_msgraph-tier-0-1-lin.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_msgraph-tier-0-1-lin.yml"
         - "src/config/wmodules-ms-graph.c"
@@ -19,6 +20,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_office365-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_office365-tier-0-1-lin.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_office365-tier-0-1-lin.yml"
         - "src/config/wmodules-office365.c"
@@ -19,6 +20,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_office365-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_office365-tier-0-1-win.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_office365-tier-0-1-win.yml"
         - "src/config/wmodules-office365.c"
@@ -25,6 +26,7 @@ permissions:
 jobs:
   # Build the winagent on linux.
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -57,6 +59,7 @@ jobs:
           path: src/winagent
   # Execute the tests on windows.
   run-test:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/4_testintegration_rbac-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_rbac-tier-0-1.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_rbac-tier-0-1.yml"
         - "framework/wazuh/rbac/"
@@ -21,6 +22,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_remoted-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_remoted-tier-0-1.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_remoted-tier-0-1.yml"
         - "src/config/remote-config.c"
@@ -20,6 +21,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_ruleset.yml
+++ b/.github/workflows/4_testintegration_ruleset.yml
@@ -3,6 +3,7 @@ name: 4.X - Ruleset - Integration tests
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_ruleset.yml"
         - "ruleset/**"
@@ -13,6 +14,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo

--- a/.github/workflows/4_testintegration_sca-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_sca-tier-0-1-lin.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_sca-tier-0-1-lin.yml"
         - "src/config/wmodules-sca.c"
@@ -19,6 +20,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_sca-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_sca-tier-0-1-win.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_sca-tier-0-1-win.yml"
         - "src/config/wmodules-sca.c"
@@ -26,6 +27,7 @@ permissions:
 jobs:
   # Build the winagent on linux.
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -58,6 +60,7 @@ jobs:
           path: src/winagent
   # Execute the tests on windows.
   run-test:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/4_testintegration_syscollector-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_syscollector-tier-0-1-lin.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_syscollector-tier-0-1-lin.yml"
         - "src/config/wmodules-syscollector.c"
@@ -18,6 +19,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_syscollector-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_syscollector-tier-0-1-win.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_syscollector-tier-0-1-win.yml"
         - "src/config/wmodules-syscollector.c"
@@ -24,6 +25,7 @@ permissions:
 jobs:
   # Build the winagent on linux.
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -56,6 +58,7 @@ jobs:
           path: src/winagent
   # Execute the tests on windows.
   run-test:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/4_testintegration_wazuh_db-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_wazuh_db-tier-0-1.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_wazuh_db-tier-0-1.yml"
         - "src/config/wazuh_db-config.c"
@@ -19,6 +20,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testunit_api.yml
+++ b/.github/workflows/4_testunit_api.yml
@@ -13,6 +13,7 @@ on:
         required: false
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - '.github/workflows/4_testunit_api.yml'
       - 'api/**'
@@ -22,6 +23,7 @@ on:
 
 jobs:
   build: 
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     strategy:
       fail-fast: false

--- a/.github/workflows/4_testunit_external-integrations.yml
+++ b/.github/workflows/4_testunit_external-integrations.yml
@@ -13,6 +13,7 @@ on:
         required: false
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - '.github/workflows/4_testunit_external-integrations.yml'
       - 'integrations/**'
@@ -21,6 +22,7 @@ on:
 
 jobs:
   build: 
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     strategy:
       fail-fast: false

--- a/.github/workflows/4_testunit_framework.yml
+++ b/.github/workflows/4_testunit_framework.yml
@@ -13,6 +13,7 @@ on:
         required: false
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - '.github/workflows/4_testunit_framework.yml'
       - 'framework/**'
@@ -20,6 +21,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     strategy:
       fail-fast: false

--- a/.github/workflows/4_testunit_inventory-harvester.yml
+++ b/.github/workflows/4_testunit_inventory-harvester.yml
@@ -3,6 +3,7 @@ name: 4.X - Inventory Harvester - Unit tests
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
   # Pull request events
     types: [synchronize, opened, reopened, ready_for_review]
   # Path filtering
@@ -17,6 +18,7 @@ permissions:
 
 jobs:
   inventory-harvester-modules:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Cancel previous runs
@@ -59,6 +61,7 @@ jobs:
           id: inventory_harvester
 
   inventory-harvester-asan:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     strategy:
       matrix:
         os: [ ubuntu-24.04, ubuntu-22.04 ]

--- a/.github/workflows/4_testunit_linux-win.yml
+++ b/.github/workflows/4_testunit_linux-win.yml
@@ -8,12 +8,14 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - "src/**"
         - ".github/workflows/4_testunit_linux-win.yml"
 
 jobs:
   Unit-Tests:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     strategy:
           fail-fast: false
           matrix:

--- a/.github/workflows/4_testunit_macos.yml
+++ b/.github/workflows/4_testunit_macos.yml
@@ -3,12 +3,14 @@ name: 4.X - macOS - Unit tests
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/**"
       - ".github/workflows/4_testunit_macos.yml"
 
 jobs:
   build-sonoma:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: macos-14
     steps:
       - name: Checkout Repo

--- a/.github/workflows/4_testunit_python-coverage.yml
+++ b/.github/workflows/4_testunit_python-coverage.yml
@@ -7,10 +7,12 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - '.github/workflows/4_testunit_python-coverage.yml'
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testunit_wodles.yml
+++ b/.github/workflows/4_testunit_wodles.yml
@@ -13,6 +13,7 @@ on:
         required: false
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - '.github/workflows/4_testunit_wodles.yml'
       - 'wodles/**'
@@ -21,6 +22,7 @@ on:
 
 jobs:
   build: 
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description

Pull-request-triggered `4.x` workflows currently run on every push to a pull request, including while the PR is still a draft. This wastes CI capacity on changes that are not yet ready for review.

This PR makes those workflows skip execution while a pull request is in draft state, and start automatically once the PR is marked *ready for review*. The same criterion is already applied to the `5.x` workflows; this change brings the `4.x` workflows in line.

Relates to #38238.

## Proposed Changes

Applied to every `4.x` workflow triggered by `pull_request` (60 workflows in total; 59 files modified, one already matched the target state):

1. **Add `ready_for_review` to the `pull_request` trigger types** (`[synchronize, opened, reopened, ready_for_review]`) so the checks are (re)triggered the moment a draft is marked ready for review.
2. **Guard every top-level job** with:
   ```yaml
   if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
   ```
   Jobs still run for non-PR events (`push`, `schedule`, `workflow_dispatch`, `workflow_call`) and, on pull requests, only when the PR is not a draft.

Workflows **not** triggered by `pull_request` are intentionally left unchanged.

### Results and Evidence

The evidence is this pull request's own checks list: while the PR is kept in draft, the affected `4.x` checks do not run; once it is marked ready for review, they trigger as expected.

### Artifacts Affected

N/A

### Configuration Changes

The change is limited to GitHub Actions workflow definitions: the `pull_request` trigger now lists `ready_for_review` among its activity types, and each job carries the draft guard described above. No product configuration is affected.

### Documentation Updates

N/A

### Tests Introduced

N/A

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
