### PR TITLE
AWS integration tests: isolate concurrent runs on the shared bucket with a per-run S3 namespace (GITHUB_RUN_ID) [5.0.0]

### DIFF
--- a/.github/workflows/5_testintegration_linux-integration-tests.yml
+++ b/.github/workflows/5_testintegration_linux-integration-tests.yml
@@ -226,6 +226,7 @@ jobs:
           cd tests/integration
           set +e
           sudo GITHUB_SHA="${{ github.sha }}" GITHUB_REF_NAME="${BRANCH_NAME}" \
+            GITHUB_RUN_ID="${GITHUB_RUN_ID}" \
             AWS_VPC_ID="${AWS_VPC_ID}" \
             AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" \
             AWS_IT_CLEANUP_MANIFEST="${AWS_IT_CLEANUP_MANIFEST}" \

--- a/tests/integration/test_aws/conftest.py
+++ b/tests/integration/test_aws/conftest.py
@@ -38,11 +38,12 @@ from wazuh_testing.utils.services import control_service
 from wazuh_testing.constants.aws import US_EAST_1_REGION
 
 # Keys permanently seeded by DevOps in the shared bucket that tests must never delete.
+# Only the CloudTrail seed is mirrored: it already gives find_account_ids the AWSLogs/<acct>/
+# CommonPrefix. An ELB seed would land in elasticloadbalancing/.../2022/11/20/, the same prefix the
+# alb/clb/nlb tests read, inflating their event count (found 2, expected 1).
 _PERMANENT_SEED_KEYS = frozenset({
     'AWSLogs/819751203818/CloudTrail/us-east-1/2022/11/20/'
     '819751203818_CloudTrail_us-east-1_20221120T0000Z_372406355707169122.json',
-    'AWSLogs/819751203818/elasticloadbalancing/us-east-1/2022/11/20/'
-    '819751203818_elasticloadbalancing_us-east-1_net.qatests_20221120T0000Z_1412953514070675864_29.145.39.119.log',
 })
 # VPC permanent seed is identified by this flow-log-ID substring in its S3 key.
 _PERMANENT_SEED_FLOW_LOG_IDS = frozenset({'fl-0754d951c16f517fa'})
@@ -98,8 +99,7 @@ def _copy_seeds_into_namespace(s3_client, bucket_name):
                 CopySource={'Bucket': bucket_name, 'Key': key})
             copied += 1
         except Exception as exc:
-            # A single missing seed is tolerated (e.g. the ELB seed is not always present): any one seed
-            # under AWSLogs/ gives the module's check_bucket the CommonPrefix it needs.
+            # Tolerate a per-seed copy failure; the fail-fast below only triggers if nothing seeded.
             logger.warning("Could not copy seed '%s' into run namespace '%s/': %s", key, _RUN_ID, exc)
     if not copied:
         # Nothing seeded: the module's check_bucket/find_account_ids would find no AWSLogs/ structure and

--- a/tests/integration/test_aws/conftest.py
+++ b/tests/integration/test_aws/conftest.py
@@ -38,13 +38,19 @@ from wazuh_testing.utils.services import control_service
 from wazuh_testing.constants.aws import US_EAST_1_REGION
 
 # Keys permanently seeded by DevOps in the shared bucket that tests must never delete.
-# Only the CloudTrail seed is mirrored: it already gives find_account_ids the AWSLogs/<acct>/
-# CommonPrefix. An ELB seed would land in elasticloadbalancing/.../2022/11/20/, the same prefix the
-# alb/clb/nlb tests read, inflating their event count (found 2, expected 1).
-_PERMANENT_SEED_KEYS = frozenset({
-    'AWSLogs/819751203818/CloudTrail/us-east-1/2022/11/20/'
-    '819751203818_CloudTrail_us-east-1_20221120T0000Z_372406355707169122.json',
-})
+_SEED_CLOUDTRAIL = ('AWSLogs/819751203818/CloudTrail/us-east-1/2022/11/20/'
+                    '819751203818_CloudTrail_us-east-1_20221120T0000Z_372406355707169122.json')
+_SEED_ELB = ('AWSLogs/819751203818/elasticloadbalancing/us-east-1/2022/11/20/'
+             '819751203818_elasticloadbalancing_us-east-1_net.qatests_'
+             '20221120T0000Z_1412953514070675864_29.145.39.119.log')
+
+# Seeds DevOps keeps in the bucket: no test may ever delete them (guards _safe_delete_key and the
+# stale-orphan auto-heal in _assert_prefix_clean against wiping them in a local, non-namespaced run).
+_PERMANENT_SEED_KEYS = frozenset({_SEED_CLOUDTRAIL, _SEED_ELB})
+
+# Subset mirrored into the run namespace. The ELB seed is left out on purpose: it would land in the
+# elasticloadbalancing/.../2022/11/20/ prefix the alb/clb/nlb tests read and inflate their count.
+_MIRRORED_SEED_KEYS = frozenset({_SEED_CLOUDTRAIL})
 # VPC permanent seed is identified by this flow-log-ID substring in its S3 key.
 _PERMANENT_SEED_FLOW_LOG_IDS = frozenset({'fl-0754d951c16f517fa'})
 
@@ -93,7 +99,7 @@ def _copy_seeds_into_namespace(s3_client, bucket_name):
     if not _RUN_ID:
         return
     copied = 0
-    for key in _PERMANENT_SEED_KEYS:
+    for key in _MIRRORED_SEED_KEYS:
         try:
             s3_client.Object(bucket_name, f"{_RUN_ID}/{key}").copy_from(
                 CopySource={'Bucket': bucket_name, 'Key': key})
@@ -106,7 +112,7 @@ def _copy_seeds_into_namespace(s3_client, bucket_name):
         # the suite would fail with unrelated messages. Fail fast, here, instead of masking it downstream.
         raise RuntimeError(
             f"No permanent seed could be copied into run namespace '{_RUN_ID}/' "
-            f"(all {len(_PERMANENT_SEED_KEYS)} failed); the namespace has no AWSLogs/ structure to read."
+            f"(all {len(_MIRRORED_SEED_KEYS)} failed); the namespace has no AWSLogs/ structure to read."
         )
 
 
@@ -580,7 +586,7 @@ def test_configuration() -> dict:
 
 
 @pytest.fixture(scope='session', autouse=True)
-def aws_run_namespace():
+def aws_run_namespace(request):
     """Isolate this run under '<GITHUB_RUN_ID>/' on the shared bucket (issue #38194).
 
     Mirrors the permanent seeds into the namespace at session start so the module's check_bucket /
@@ -588,7 +594,11 @@ def aws_run_namespace():
     end. No-op locally (no GITHUB_RUN_ID). Uses its own S3 resource because it is session-scoped.
     """
     bucket = os.environ.get('AWS_BUCKET_NAME')
-    if not _RUN_ID or not bucket:
+    # Matrix jobs share GITHUB_RUN_ID and the 'test_aws/' target (aws vs aws_inspector, split by -k), so a
+    # session may run no bucket test at all (e.g. inspector). Skipping those keeps that session from
+    # deleting the namespace out from under a sibling job still using it.
+    needs_bucket = any('create_test_bucket' in i.fixturenames for i in request.session.items)
+    if not _RUN_ID or not bucket or not needs_bucket:
         yield
         return
     profile = os.environ.get('AWS_PROFILE', 'default')

--- a/tests/integration/test_aws/conftest.py
+++ b/tests/integration/test_aws/conftest.py
@@ -687,17 +687,19 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client, create_test_bucke
                         "AWS_VPC_ID is not set. A pre-existing VPC ID is required "
                         "for VPC flow log tests. Set the IT_AWS_VPC_ID GitHub secret."
                     )
-                # The flow log's dedup key is (VPC, traffic type, destination), all shared across runs, so
-                # two concurrent runs (issue #38194) collide with FlowLogAlreadyExists. Reuse the existing
-                # one when that happens; only the run that actually created it deletes it in teardown. The
-                # flow_log_id is just used to name the synthetic S3 object, so a shared id is harmless.
+                # Per-run destination (issue #38194): garbage falls under '<run>/' so _delete_run_namespace
+                # removes it, and the dedup key (VPC, traffic type, destination) becomes unique per run so
+                # concurrent runs no longer collide with FlowLogAlreadyExists. '_flowlogs/' keeps it out of
+                # '<run>/AWSLogs/...' where the module reads. Root destination locally (no run id).
+                log_destination = (f'arn:aws:s3:::{bucket_name}/{_RUN_ID}/_flowlogs/'
+                                   if _RUN_ID else f'arn:aws:s3:::{bucket_name}')
                 try:
                     response = ec2_client.create_flow_logs(
                         ResourceIds=[vpc_id],
                         ResourceType='VPC',
                         TrafficType='REJECT',
                         LogDestinationType='s3',
-                        LogDestination=f'arn:aws:s3:::{bucket_name}'
+                        LogDestination=log_destination
                     )
                     unsuccessful = response.get('Unsuccessful', [])
                     if unsuccessful:

--- a/tests/integration/test_aws/conftest.py
+++ b/tests/integration/test_aws/conftest.py
@@ -8,6 +8,7 @@ This module contains all necessary components (fixtures, classes, methods) to co
 
 import os
 import time
+import random
 import pytest
 import boto3
 from datetime import datetime, timedelta, timezone
@@ -90,12 +91,23 @@ def _copy_seeds_into_namespace(s3_client, bucket_name):
     """
     if not _RUN_ID:
         return
+    copied = 0
     for key in _PERMANENT_SEED_KEYS:
         try:
             s3_client.Object(bucket_name, f"{_RUN_ID}/{key}").copy_from(
                 CopySource={'Bucket': bucket_name, 'Key': key})
+            copied += 1
         except Exception as exc:
-            logger.warning("Could not copy seed '%s' into run namespace: %s", key, exc)
+            # A single missing seed is tolerated (e.g. the ELB seed is not always present): any one seed
+            # under AWSLogs/ gives the module's check_bucket the CommonPrefix it needs.
+            logger.warning("Could not copy seed '%s' into run namespace '%s/': %s", key, _RUN_ID, exc)
+    if not copied:
+        # Nothing seeded: the module's check_bucket/find_account_ids would find no AWSLogs/ structure and
+        # the suite would fail with unrelated messages. Fail fast, here, instead of masking it downstream.
+        raise RuntimeError(
+            f"No permanent seed could be copied into run namespace '{_RUN_ID}/' "
+            f"(all {len(_PERMANENT_SEED_KEYS)} failed); the namespace has no AWSLogs/ structure to read."
+        )
 
 
 def _delete_run_namespace(s3_client, bucket_name):
@@ -127,15 +139,41 @@ def _prefixes_overlap(a, b):
     return a.startswith(b) or b.startswith(a)
 
 
-def _merge_queue_configs(cfg, keep_rule=None, add_rule=None):
-    """Rebuild a bucket notification config from an existing one: drop our own rule and any rule whose
-    prefix filter OVERLAPS ours (a legacy no-filter rule or a stale one - S3 forbids overlapping prefixes
-    for the same event), optionally add ours, and preserve Topic/Lambda/EventBridge configs so we never
-    clobber unrelated notifications. Distinct '<run>/' prefixes never overlap, so concurrent runs survive."""
+def _queue_exists(sqs_client, queue_arn):
+    """True if the SQS queue behind an ARN still exists. S3 validates EVERY destination on a notification
+    PUT, so a single dangling destination (a queue swept after its run was hard-cancelled) rejects the
+    whole config with InvalidArgument, bricking the shared bucket until someone edits it by hand."""
+    if not queue_arn:
+        return False
+    try:
+        sqs_client.get_queue_url(QueueName=queue_arn.rsplit(':', 1)[-1])
+        return True
+    except ClientError as exc:
+        # Only a confirmed 'gone' drops a foreign rule; any other error keeps it.
+        return not exc.response['Error']['Code'].endswith('NonExistentQueue')
+
+
+def _merge_queue_configs(cfg, add_rule=None, sqs_client=None):
+    """Rebuild a bucket notification config from an existing one: drop our own rule, any rule whose prefix
+    OVERLAPS ours (a legacy no-filter rule; S3 forbids overlapping prefixes for the same event), and any
+    stale per-run rule whose SQS queue no longer exists (left by a hard-cancelled run; keeping it makes
+    every later PUT fail). Optionally add ours; preserve Topic/Lambda/EventBridge configs. Distinct
+    '<run>/' prefixes never overlap, so concurrent runs survive."""
     rule_id = _notif_rule_id()
     own_prefix = f"{_RUN_ID}/"
-    queues = [q for q in cfg.get('QueueConfigurations', [])
-              if q.get('Id') != rule_id and not _prefixes_overlap(_rule_prefix(q), own_prefix)]
+    queues = []
+    for q in cfg.get('QueueConfigurations', []):
+        if q.get('Id') == rule_id:
+            continue
+        if _prefixes_overlap(_rule_prefix(q), own_prefix):
+            logger.warning("Dropping notification rule %s: its prefix overlaps ours (S3 forbids "
+                           "overlapping prefixes for the same event)", q.get('Id'))
+            continue
+        if (sqs_client is not None and str(q.get('Id', '')).startswith('wazuh-it-')
+                and not _queue_exists(sqs_client, q.get('QueueArn', ''))):
+            logger.warning("Dropping stale notification rule %s (its SQS queue no longer exists)", q.get('Id'))
+            continue
+        queues.append(q)
     if add_rule:
         queues.append(add_rule)
     out = {'QueueConfigurations': queues}
@@ -145,14 +183,46 @@ def _merge_queue_configs(cfg, keep_rule=None, add_rule=None):
     return out
 
 
-def _set_run_bucket_notification(s3_resource, bucket_name, sqs_queue_arn):
+def _rule_ids(cfg):
+    return {q.get('Id') for q in cfg.get('QueueConfigurations', [])}
+
+
+def _put_notification(client, bucket_name, sqs_client, want_rule=None):
+    """Read-modify-write the shared bucket->SQS notification config, converging on a concurrent run's
+    racing put. S3 has no conditional/ETag put here, so verify BOTH directions: our own rule landed (or
+    was removed) AND every foreign rule we snapshotted is still present; if a racing put clobbered one,
+    retry and the merge restores it from a fresh snapshot. This narrows but does NOT fully close the
+    window - a per-run bucket or an external lock would; good enough for the handful of concurrent AWS IT
+    runs. Returns True on success."""
+    rule_id = _notif_rule_id()
+    for attempt in range(5):
+        try:
+            cfg = client.get_bucket_notification_configuration(Bucket=bucket_name)
+            keep = _rule_ids(_merge_queue_configs(cfg, sqs_client=sqs_client))
+            client.put_bucket_notification_configuration(
+                Bucket=bucket_name,
+                NotificationConfiguration=_merge_queue_configs(cfg, add_rule=want_rule, sqs_client=sqs_client))
+            seen = _rule_ids(client.get_bucket_notification_configuration(Bucket=bucket_name))
+        except ClientError as exc:
+            # A racing run can delete its queue between our GET and PUT, leaving a dangling destination
+            # S3 rejects; retrying re-reads and drops it. Never fail setup/teardown on a transient error.
+            logger.warning("Notification put attempt %s failed for run %s: %s", attempt, _RUN_ID, exc)
+            time.sleep(1 + attempt + random.random())
+            continue
+        own_ok = (rule_id in seen) if want_rule else (rule_id not in seen)
+        if own_ok and keep <= seen:
+            return True
+        time.sleep(1 + attempt + random.random())  # jitter so two runs don't lock-step
+    return False
+
+
+def _set_run_bucket_notification(s3_resource, bucket_name, sqs_queue_arn, sqs_client):
     """Concurrency-safe bucket->SQS notification for the custom-bucket tests (issue #38194).
 
     The bucket notification config is a single shared resource and the framework helper REPLACES it, so
     two concurrent runs clobber each other. Instead register THIS run's queue with a '<run>/' prefix
-    filter, merged into the existing config, so each run is only notified of its own uploads. Read-modify-
-    write with a verify+retry loop to converge if a concurrent run's put races ours. Locally (no run id)
-    fall back to a plain single-queue put (original behaviour).
+    filter, merged into the existing config (dropping stale rules), so each run is only notified of its
+    own uploads. Locally (no run id) fall back to a plain single-queue put (original behaviour).
     """
     client = s3_resource.meta.client
     if not _RUN_ID:
@@ -163,35 +233,17 @@ def _set_run_bucket_notification(s3_resource, bucket_name, sqs_queue_arn):
         return
     rule = {'Id': _notif_rule_id(), 'QueueArn': sqs_queue_arn, 'Events': ['s3:ObjectCreated:*'],
             'Filter': {'Key': {'FilterRules': [{'Name': 'prefix', 'Value': f'{_RUN_ID}/'}]}}}
-    for _ in range(5):
-        cfg = client.get_bucket_notification_configuration(Bucket=bucket_name)
-        client.put_bucket_notification_configuration(
-            Bucket=bucket_name, NotificationConfiguration=_merge_queue_configs(cfg, add_rule=rule))
-        check = client.get_bucket_notification_configuration(Bucket=bucket_name)
-        if any(q.get('Id') == rule['Id'] for q in check.get('QueueConfigurations', [])):
-            return
-    logger.warning("Could not persist bucket notification rule for run %s", _RUN_ID)
+    if not _put_notification(client, bucket_name, sqs_client, want_rule=rule):
+        logger.warning("Could not persist bucket notification rule for run %s", _RUN_ID)
 
 
-def _remove_run_bucket_notification(s3_resource, bucket_name):
-    """Remove THIS run's notification rule at teardown, preserving other runs' rules. Read-modify-write
-    with a verify+retry loop so a concurrent run's racing put does not resurrect our rule or drop theirs."""
+def _remove_run_bucket_notification(s3_resource, bucket_name, sqs_client):
+    """Remove THIS run's notification rule at teardown, preserving other runs' rules (verify+retry via
+    _put_notification, which also drops stale rules whose queue is gone)."""
     if not _RUN_ID:
         return
-    client = s3_resource.meta.client
-    rule_id = _notif_rule_id()
-    for _ in range(5):
-        try:
-            cfg = client.get_bucket_notification_configuration(Bucket=bucket_name)
-            client.put_bucket_notification_configuration(
-                Bucket=bucket_name, NotificationConfiguration=_merge_queue_configs(cfg))
-            check = client.get_bucket_notification_configuration(Bucket=bucket_name)
-            if not any(q.get('Id') == rule_id for q in check.get('QueueConfigurations', [])):
-                return
-        except Exception as exc:
-            logger.warning("Could not remove bucket notification rule for run %s: %s", _RUN_ID, exc)
-            return
-    logger.warning("Bucket notification rule for run %s may persist after teardown", _RUN_ID)
+    if not _put_notification(s3_resource.meta.client, bucket_name, sqs_client, want_rule=None):
+        logger.warning("Bucket notification rule for run %s may persist after teardown", _RUN_ID)
 
 
 _GUARDDUTY_SHARED_BUCKET_INCOMPATIBLE = {
@@ -593,7 +645,7 @@ def create_test_bucket(metadata: dict, test_configuration: dict, aws_run_namespa
 
 
 @pytest.fixture
-def manage_bucket_files(metadata: dict, s3_client, ec2_client):
+def manage_bucket_files(metadata: dict, s3_client, ec2_client, create_test_bucket):
     """Upload a file to S3 bucket and delete after the test ends.
 
     Args:
@@ -942,7 +994,7 @@ def manage_log_group_events(metadata: dict, logs_clients):
 
 
 @pytest.fixture
-def set_test_sqs_queue(metadata: dict, sqs_manager, s3_client) -> None:
+def set_test_sqs_queue(metadata: dict, sqs_manager, s3_client, create_test_bucket) -> None:
     """Create a test SQS queue.
 
     Args:
@@ -976,7 +1028,7 @@ def set_test_sqs_queue(metadata: dict, sqs_manager, s3_client) -> None:
                        client=sqs_client)
 
         # Set bucket notification configuration (per-run, prefix-filtered, merged - see helper).
-        _set_run_bucket_notification(s3_client, bucket_name, sqs_queue_arn)
+        _set_run_bucket_notification(s3_client, bucket_name, sqs_queue_arn, sqs_client)
 
     except ClientError as error:
         # Check if the sqs exist
@@ -992,7 +1044,7 @@ def set_test_sqs_queue(metadata: dict, sqs_manager, s3_client) -> None:
     yield
 
     # Remove only this run's notification rule so a concurrent run's rule survives.
-    _remove_run_bucket_notification(s3_client, bucket_name)
+    _remove_run_bucket_notification(s3_client, bucket_name, sqs_client)
 
 
 """DB fixtures"""

--- a/tests/integration/test_aws/conftest.py
+++ b/tests/integration/test_aws/conftest.py
@@ -165,9 +165,12 @@ def _merge_queue_configs(cfg, add_rule=None, sqs_client=None):
     for q in cfg.get('QueueConfigurations', []):
         if q.get('Id') == rule_id:
             continue
-        if _prefixes_overlap(_rule_prefix(q), own_prefix):
-            logger.warning("Dropping notification rule %s: its prefix overlaps ours (S3 forbids "
-                           "overlapping prefixes for the same event)", q.get('Id'))
+        if (_prefixes_overlap(_rule_prefix(q), own_prefix)
+                and any(e.startswith('s3:ObjectCreated') for e in q.get('Events', []))):
+            # Only overlaps that share our event type (ObjectCreated) are what S3 rejects; a rule on a
+            # different event (e.g. ObjectRemoved) is left alone.
+            logger.warning("Dropping notification rule %s: prefix overlaps ours for ObjectCreated "
+                           "(S3 forbids overlapping prefixes per event type)", q.get('Id'))
             continue
         if (sqs_client is not None and str(q.get('Id', '')).startswith('wazuh-it-')
                 and not _queue_exists(sqs_client, q.get('QueueArn', ''))):
@@ -178,7 +181,7 @@ def _merge_queue_configs(cfg, add_rule=None, sqs_client=None):
         queues.append(add_rule)
     out = {'QueueConfigurations': queues}
     for k in ('TopicConfigurations', 'LambdaFunctionConfigurations', 'EventBridgeConfiguration'):
-        if cfg.get(k):
+        if k in cfg:  # keep by presence, not truthiness: EventBridge is '{}' (falsy) when enabled
             out[k] = cfg[k]
     return out
 
@@ -234,7 +237,11 @@ def _set_run_bucket_notification(s3_resource, bucket_name, sqs_queue_arn, sqs_cl
     rule = {'Id': _notif_rule_id(), 'QueueArn': sqs_queue_arn, 'Events': ['s3:ObjectCreated:*'],
             'Filter': {'Key': {'FilterRules': [{'Name': 'prefix', 'Value': f'{_RUN_ID}/'}]}}}
     if not _put_notification(client, bucket_name, sqs_client, want_rule=rule):
-        logger.warning("Could not persist bucket notification rule for run %s", _RUN_ID)
+        # Fail setup loudly: a missing s3:GetBucketNotification permission looks exactly like this, and
+        # without the rule the test would upload, wait 30s and die on failed_sqs_message_retrieval.
+        raise RuntimeError(
+            f"Could not persist the bucket notification rule for run {_RUN_ID} after retries; "
+            "see the preceding warnings for the AWS error.")
 
 
 def _remove_run_bucket_notification(s3_resource, bucket_name, sqs_client):
@@ -653,25 +660,15 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client, create_test_bucke
         s3_client (boto3.resources.base.ServiceResource): S3 client used to manage the bucket resources.
         ec2_client (Service client instance): EC2 client to manage VPC resources.
     """
-    # Get bucket name
     bucket_name = metadata['bucket_name']
-
-    # Get bucket type
     bucket_type = metadata['bucket_type']
-
-    # Get only_logs_after, regions, prefix and suffix if set to generate file accordingly
     file_creation_date = metadata.get('only_logs_after')
     regions = metadata.get('regions', US_EAST_1_REGION).split(',')
     prefix = metadata.get('path', '')
     suffix = metadata.get('path_suffix', '')
-
-    # Check if the VPC type is the one to be tested
     vpc_bucket = bucket_type == 'vpcflow'
-
-    # Check if logs need to be created
     log_number = metadata.get("expected_results", 1) > 0
 
-    # Generate files
     # Use the original YAML bucket name for generate_file — the framework derives the
     # custom type (kms/macie/trusted) from bucket_name.split('-')[1], which breaks with
     # the shared bucket name. All actual S3 operations still use the shared bucket_name.
@@ -748,16 +745,11 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client, create_test_bucke
             for data, key in files_to_upload:
                 # Record the key BEFORE uploading so a cancelled job can still clean it up.
                 _record_uploaded_key(key)
-
-                # Upload file to bucket
                 upload_bucket_file(bucket_name=bucket_name,
                                    data=data,
                                    key=key,
                                    client=s3_client)
-
                 logger.debug('Uploaded file: %s to bucket "%s"', key, bucket_name)
-
-                # Set filename for test execution
                 metadata['uploaded_file'] += key
                 uploaded_keys.append(key)
 
@@ -1002,7 +994,6 @@ def set_test_sqs_queue(metadata: dict, sqs_manager, s3_client, create_test_bucke
         sqs_manager (fixture): The SQS set for the test.
         s3_client (boto3.resources.base.ServiceResource): S3 client used to manage bucket resources.
     """
-    # Get bucket name
     bucket_name = metadata["bucket_name"]
     # The queue name is already unique per run: configurator._modify_metadata appends a random per-session
     # '-<uuid>-todelete' suffix, so concurrent runs never share a queue. (Do NOT append GITHUB_RUN_ID here:
@@ -1013,25 +1004,16 @@ def set_test_sqs_queue(metadata: dict, sqs_manager, s3_client, create_test_bucke
     sqs_queues, sqs_client = sqs_manager
 
     try:
-        # Create SQS and get URL
         sqs_queue_url = create_sqs_queue(sqs_name=sqs_name, client=sqs_client)
-        # Add it to sqs set
         sqs_queues.add(sqs_queue_url)
-
-        # Get SQS Queue ARN
         sqs_queue_arn = get_sqs_queue_arn(sqs_url=sqs_queue_url, client=sqs_client)
-
-        # Set policy
         set_sqs_policy(bucket_name=bucket_name,
                        sqs_queue_url=sqs_queue_url,
                        sqs_queue_arn=sqs_queue_arn,
                        client=sqs_client)
-
-        # Set bucket notification configuration (per-run, prefix-filtered, merged - see helper).
         _set_run_bucket_notification(s3_client, bucket_name, sqs_queue_arn, sqs_client)
 
     except ClientError as error:
-        # Check if the sqs exist
         if error.response['Error']['Code'] == 'ResourceNotFound':
             logger.error(f"SQS Queue {sqs_name} already exists")
             raise error

--- a/tests/integration/test_aws/conftest.py
+++ b/tests/integration/test_aws/conftest.py
@@ -54,6 +54,146 @@ _PERMANENT_SEED_FLOW_LOG_IDS = frozenset({'fl-0754d951c16f517fa'})
 # under it; comfortably shorter than "the mess just sits there until someone notices manually".
 _ORPHAN_STALENESS_THRESHOLD = timedelta(hours=3)
 
+# Per-run S3 namespace to isolate concurrent AWS IT runs on the shared bucket (issue #38194).
+# Every key a run uploads - and the module's configured path - is placed under "<GITHUB_RUN_ID>/",
+# so two runs executing at the same time never share keys/prefixes. Empty locally (no GITHUB_RUN_ID),
+# which keeps the current bucket layout for local runs.
+_RUN_ID = os.environ.get('GITHUB_RUN_ID', '')
+
+_GUARDDUTY_SHARED_BUCKET_INCOMPATIBLE = {
+    'guardduty_discard_regex',
+    'guardduty_without_only_logs_after',
+    'guardduty_with_only_logs_after',
+    'guardduty_only_logs_after_multiple_calls',
+    'guardduty_remove_from_bucket',
+}
+
+
+def _namespaced(path):
+    """Prefix a bucket path with the per-run namespace: '<run>/<path>' in CI, '<path>' locally.
+
+    The original path's trailing-slash semantics are preserved (only the run id is prepended): the module
+    builds its base prefix as '{path}AWSLogs/' (string concat, not a path join), so an empty path must map
+    to '<run>/' - WITH the trailing slash - to read '<run>/AWSLogs/...'. Stripping it would yield
+    '<run>AWSLogs/' and the module would find nothing. os.path.join in generate_file tolerates either form.
+    """
+    path = path or ''
+    if not _RUN_ID:
+        return path
+    return f"{_RUN_ID}/{path}"
+
+
+def _copy_seeds_into_namespace(s3_client, bucket_name):
+    """Mirror the permanent seeds under the per-run namespace so the module's check_bucket /
+    find_account_ids see the expected AWSLogs/ structure at '<run>/AWSLogs/...'. The originals at the
+    bucket root are never modified; the copies live under '<run>/' and are removed with the namespace.
+    """
+    if not _RUN_ID:
+        return
+    for key in _PERMANENT_SEED_KEYS:
+        try:
+            s3_client.Object(bucket_name, f"{_RUN_ID}/{key}").copy_from(
+                CopySource={'Bucket': bucket_name, 'Key': key})
+        except Exception as exc:
+            logger.warning("Could not copy seed '%s' into run namespace: %s", key, exc)
+
+
+def _delete_run_namespace(s3_client, bucket_name):
+    """Delete the whole per-run namespace '<run>/' (test data + seed copies). Never touches the root."""
+    if not _RUN_ID:
+        return
+    try:
+        s3_client.Bucket(bucket_name).objects.filter(Prefix=f"{_RUN_ID}/").delete()
+    except Exception as exc:
+        logger.warning("Could not delete run namespace '%s/': %s", _RUN_ID, exc)
+
+
+def _notif_rule_id():
+    return f"wazuh-it-{_RUN_ID}"
+
+
+def _rule_prefix(queue_config):
+    """Return the S3 key prefix filter of a QueueConfiguration rule, or '' if it has no prefix filter."""
+    for fr in queue_config.get('Filter', {}).get('Key', {}).get('FilterRules', []):
+        if fr.get('Name', '').lower() == 'prefix':
+            return fr.get('Value', '')
+    return ''
+
+
+def _prefixes_overlap(a, b):
+    """S3 rejects two notification rules for the same event whose prefixes overlap (one is a prefix of the
+    other). Distinct per-run '<run>/' namespaces never overlap; an empty prefix (a legacy no-filter rule)
+    overlaps everything."""
+    return a.startswith(b) or b.startswith(a)
+
+
+def _merge_queue_configs(cfg, keep_rule=None, add_rule=None):
+    """Rebuild a bucket notification config from an existing one: drop our own rule and any rule whose
+    prefix filter OVERLAPS ours (a legacy no-filter rule or a stale one - S3 forbids overlapping prefixes
+    for the same event), optionally add ours, and preserve Topic/Lambda/EventBridge configs so we never
+    clobber unrelated notifications. Distinct '<run>/' prefixes never overlap, so concurrent runs survive."""
+    rule_id = _notif_rule_id()
+    own_prefix = f"{_RUN_ID}/"
+    queues = [q for q in cfg.get('QueueConfigurations', [])
+              if q.get('Id') != rule_id and not _prefixes_overlap(_rule_prefix(q), own_prefix)]
+    if add_rule:
+        queues.append(add_rule)
+    out = {'QueueConfigurations': queues}
+    for k in ('TopicConfigurations', 'LambdaFunctionConfigurations', 'EventBridgeConfiguration'):
+        if cfg.get(k):
+            out[k] = cfg[k]
+    return out
+
+
+def _set_run_bucket_notification(s3_resource, bucket_name, sqs_queue_arn):
+    """Concurrency-safe bucket->SQS notification for the custom-bucket tests (issue #38194).
+
+    The bucket notification config is a single shared resource and the framework helper REPLACES it, so
+    two concurrent runs clobber each other. Instead register THIS run's queue with a '<run>/' prefix
+    filter, merged into the existing config, so each run is only notified of its own uploads. Read-modify-
+    write with a verify+retry loop to converge if a concurrent run's put races ours. Locally (no run id)
+    fall back to a plain single-queue put (original behaviour).
+    """
+    client = s3_resource.meta.client
+    if not _RUN_ID:
+        client.put_bucket_notification_configuration(
+            Bucket=bucket_name,
+            NotificationConfiguration={'QueueConfigurations': [
+                {'QueueArn': sqs_queue_arn, 'Events': ['s3:ObjectCreated:*']}]})
+        return
+    rule = {'Id': _notif_rule_id(), 'QueueArn': sqs_queue_arn, 'Events': ['s3:ObjectCreated:*'],
+            'Filter': {'Key': {'FilterRules': [{'Name': 'prefix', 'Value': f'{_RUN_ID}/'}]}}}
+    for _ in range(5):
+        cfg = client.get_bucket_notification_configuration(Bucket=bucket_name)
+        client.put_bucket_notification_configuration(
+            Bucket=bucket_name, NotificationConfiguration=_merge_queue_configs(cfg, add_rule=rule))
+        check = client.get_bucket_notification_configuration(Bucket=bucket_name)
+        if any(q.get('Id') == rule['Id'] for q in check.get('QueueConfigurations', [])):
+            return
+    logger.warning("Could not persist bucket notification rule for run %s", _RUN_ID)
+
+
+def _remove_run_bucket_notification(s3_resource, bucket_name):
+    """Remove THIS run's notification rule at teardown, preserving other runs' rules. Read-modify-write
+    with a verify+retry loop so a concurrent run's racing put does not resurrect our rule or drop theirs."""
+    if not _RUN_ID:
+        return
+    client = s3_resource.meta.client
+    rule_id = _notif_rule_id()
+    for _ in range(5):
+        try:
+            cfg = client.get_bucket_notification_configuration(Bucket=bucket_name)
+            client.put_bucket_notification_configuration(
+                Bucket=bucket_name, NotificationConfiguration=_merge_queue_configs(cfg))
+            check = client.get_bucket_notification_configuration(Bucket=bucket_name)
+            if not any(q.get('Id') == rule_id for q in check.get('QueueConfigurations', [])):
+                return
+        except Exception as exc:
+            logger.warning("Could not remove bucket notification rule for run %s: %s", _RUN_ID, exc)
+            return
+    logger.warning("Bucket notification rule for run %s may persist after teardown", _RUN_ID)
+
+
 _GUARDDUTY_SHARED_BUCKET_INCOMPATIBLE = {
     'guardduty_discard_regex',
     'guardduty_without_only_logs_after',
@@ -94,40 +234,16 @@ def record_uploaded_key():
     return _record_uploaded_key
 
 
-def _record_uploaded_key(key):
-    """Append an uploaded key to the cleanup manifest, if one is configured.
-
-    pytest teardown only deletes the keys of its own run and only runs after 'yield', so a hard-cancelled
-    CI job (e.g. a new push cancelling the in-flight run) leaves the already-uploaded files as orphans.
-    Recording every key here, at upload time, lets a CI step with 'if: always()' delete them even when the
-    job is cancelled before teardown. The manifest path comes from AWS_IT_CLEANUP_MANIFEST; when it is not
-    set (e.g. local runs) this is a no-op and normal teardown still applies.
-    """
-    manifest = os.environ.get('AWS_IT_CLEANUP_MANIFEST')
-    if not manifest:
-        return
-    try:
-        with open(manifest, 'a') as handle:
-            handle.write(f"{key}\n")
-            handle.flush()
-    except OSError as exc:
-        logger.warning("Could not record uploaded key '%s' to manifest '%s': %s", key, manifest, exc)
-
-
-@pytest.fixture
-def record_uploaded_key():
-    """Expose _record_uploaded_key to test bodies that upload objects themselves.
-
-    manage_bucket_files records the keys it uploads, but a few tests upload directly in their body
-    (e.g. test_bucket_multiple_calls). Those must register their key too, otherwise a hard cancel
-    during the test would orphan the object - the exact case this cleanup targets.
-    """
-    return _record_uploaded_key
+def _is_permanent_seed(key):
+    """True if key is a permanent seed - the root seed OR its per-run namespaced copy ('<run>/<seed>')."""
+    candidate = key[len(_RUN_ID) + 1:] if _RUN_ID and key.startswith(f"{_RUN_ID}/") else key
+    return (candidate in _PERMANENT_SEED_KEYS
+            or any(fid in key for fid in _PERMANENT_SEED_FLOW_LOG_IDS))
 
 
 def _safe_delete_key(key, bucket_name, s3_client):
     """Delete one key from the shared bucket; log failures; refuse to touch permanent seeds."""
-    if key in _PERMANENT_SEED_KEYS or any(fid in key for fid in _PERMANENT_SEED_FLOW_LOG_IDS):
+    if _is_permanent_seed(key):
         logger.warning("TEARDOWN: skipping permanent seed key: %s", key)
         return
     try:
@@ -162,8 +278,7 @@ def _assert_prefix_clean(bucket_name, key, s3_client):
     prefix = key.rsplit('/', 1)[0] + '/' if '/' in key else ''
     unexpected = [
         obj for obj in s3_client.Bucket(bucket_name).objects.filter(Prefix=prefix, Delimiter='/')
-        if obj.key not in _PERMANENT_SEED_KEYS
-        and not any(fid in obj.key for fid in _PERMANENT_SEED_FLOW_LOG_IDS)
+        if not _is_permanent_seed(obj.key)  # root seeds and their per-run namespaced copies
         and not obj.key.endswith('/')  # skip S3 folder-marker objects (empty keys ending with /)
     ]
     if not unexpected:
@@ -405,14 +520,34 @@ def test_configuration() -> dict:
     return {}
 
 
+@pytest.fixture(scope='session', autouse=True)
+def aws_run_namespace():
+    """Isolate this run under '<GITHUB_RUN_ID>/' on the shared bucket (issue #38194).
+
+    Mirrors the permanent seeds into the namespace at session start so the module's check_bucket /
+    find_account_ids find the AWSLogs/ structure under '<run>/', and deletes the whole namespace at the
+    end. No-op locally (no GITHUB_RUN_ID). Uses its own S3 resource because it is session-scoped.
+    """
+    bucket = os.environ.get('AWS_BUCKET_NAME')
+    if not _RUN_ID or not bucket:
+        yield
+        return
+    profile = os.environ.get('AWS_PROFILE', 'default')
+    s3 = boto3.Session(profile_name=profile).resource(service_name='s3', region_name=US_EAST_1_REGION)
+    _copy_seeds_into_namespace(s3, bucket)
+    yield
+    _delete_run_namespace(s3, bucket)
+
+
 @pytest.fixture()
-def create_test_bucket(metadata: dict, test_configuration: dict):
+def create_test_bucket(metadata: dict, test_configuration: dict, aws_run_namespace):
     """Use a pre-existing S3 bucket for tests.
 
     Args:
         metadata (dict): Bucket information.
         test_configuration (dict): Wazuh configuration template built at import time.
             Patched in-place so set_wazuh_configuration writes the shared bucket into ossec.conf.
+        aws_run_namespace: ensures the per-run namespace (seeds) is set up before the test.
     """
     shared_bucket = os.environ.get('AWS_BUCKET_NAME')
     if not shared_bucket:
@@ -426,6 +561,16 @@ def create_test_bucket(metadata: dict, test_configuration: dict):
     # Override so all S3 operations and the Wazuh module CLI use the shared bucket.
     metadata['bucket_name'] = shared_bucket
 
+    # Namespace the bucket path under the per-run prefix so concurrent runs never share keys. The
+    # uploaded keys (via manage_bucket_files -> generate_file) and the module's configured <path> both
+    # use this value, so they stay aligned. No-op locally.
+    namespaced_path = _namespaced(metadata.get('path', ''))
+    # Only mutate metadata['path'] when a run namespace is active; otherwise (local, no GITHUB_RUN_ID)
+    # leave it untouched so path-less cases keep no 'path' key and the tests don't emit a spurious
+    # --trail_prefix "" that the module (empty path) never logs.
+    if _RUN_ID:
+        metadata['path'] = namespaced_path
+
     # Patch test_configuration so set_wazuh_configuration writes the shared bucket into ossec.conf.
     # Without this, ossec.conf keeps the YAML name (plus the session suffix added by _modify_metadata),
     # causing a mismatch with metadata['bucket_name'] and triggering incorrect_parameters failures.
@@ -433,9 +578,18 @@ def create_test_bucket(metadata: dict, test_configuration: dict):
         for element in section.get('elements', []):
             bucket_cfg = element.get('bucket')
             if isinstance(bucket_cfg, dict):
-                for bucket_elem in bucket_cfg.get('elements', []):
+                bucket_elements = bucket_cfg.setdefault('elements', [])
+                path_found = False
+                for bucket_elem in bucket_elements:
                     if 'name' in bucket_elem:
                         bucket_elem['name']['value'] = shared_bucket
+                    if 'path' in bucket_elem:
+                        bucket_elem['path']['value'] = namespaced_path
+                        path_found = True
+                # A path-less bucket type (reads the bucket root) needs an explicit <path> so the
+                # module reads under the run namespace instead of the shared root.
+                if _RUN_ID and not path_found:
+                    bucket_elements.append({'path': {'value': namespaced_path}})
 
 
 @pytest.fixture
@@ -475,6 +629,7 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
         files_to_upload = []
         metadata['uploaded_file'] = ''
         flow_log_id = None
+        flow_log_owned = False
         try:
             if vpc_bucket:
                 vpc_id = os.environ.get('AWS_VPC_ID')
@@ -483,21 +638,38 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
                         "AWS_VPC_ID is not set. A pre-existing VPC ID is required "
                         "for VPC flow log tests. Set the IT_AWS_VPC_ID GitHub secret."
                     )
-                response = ec2_client.create_flow_logs(
-                    ResourceIds=[vpc_id],
-                    ResourceType='VPC',
-                    TrafficType='REJECT',
-                    LogDestinationType='s3',
-                    LogDestination=f'arn:aws:s3:::{bucket_name}'
-                )
-                unsuccessful = response.get('Unsuccessful', [])
-                if unsuccessful:
-                    err = unsuccessful[0]['Error']
-                    raise RuntimeError(
-                        f"Failed to create VPC flow log on {vpc_id}: "
-                        f"[{err['Code']}] {err['Message']}"
+                # The flow log's dedup key is (VPC, traffic type, destination), all shared across runs, so
+                # two concurrent runs (issue #38194) collide with FlowLogAlreadyExists. Reuse the existing
+                # one when that happens; only the run that actually created it deletes it in teardown. The
+                # flow_log_id is just used to name the synthetic S3 object, so a shared id is harmless.
+                try:
+                    response = ec2_client.create_flow_logs(
+                        ResourceIds=[vpc_id],
+                        ResourceType='VPC',
+                        TrafficType='REJECT',
+                        LogDestinationType='s3',
+                        LogDestination=f'arn:aws:s3:::{bucket_name}'
                     )
-                flow_log_id = response['FlowLogIds'][0]
+                    unsuccessful = response.get('Unsuccessful', [])
+                    if unsuccessful:
+                        err = unsuccessful[0]['Error']
+                        if err['Code'] == 'FlowLogAlreadyExists':
+                            raise ClientError({'Error': err}, 'CreateFlowLogs')
+                        raise RuntimeError(
+                            f"Failed to create VPC flow log on {vpc_id}: "
+                            f"[{err['Code']}] {err['Message']}"
+                        )
+                    flow_log_id = response['FlowLogIds'][0]
+                    flow_log_owned = True
+                except ClientError as fl_error:
+                    if fl_error.response['Error']['Code'] != 'FlowLogAlreadyExists':
+                        raise
+                    existing = ec2_client.describe_flow_logs(
+                        Filters=[{'Name': 'resource-id', 'Values': [vpc_id]}])
+                    flow_logs = existing.get('FlowLogs', [])
+                    if not flow_logs:
+                        raise
+                    flow_log_id = flow_logs[0]['FlowLogId']
                 metadata['flow_log_id'] = flow_log_id
                 for region in regions:
                     data, key = generate_file(bucket_type=bucket_type,
@@ -543,7 +715,7 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
                 "bucket_name": bucket_name,
                 "error": str(error)
             })
-            if flow_log_id is not None:
+            if flow_log_owned and flow_log_id is not None:
                 try:
                     ec2_client.delete_flow_logs(FlowLogIds=[flow_log_id])
                 except Exception:
@@ -556,7 +728,7 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
                 "bucket_name": bucket_name,
                 "error": str(error)
             })
-            if flow_log_id is not None:
+            if flow_log_owned and flow_log_id is not None:
                 try:
                     ec2_client.delete_flow_logs(FlowLogIds=[flow_log_id])
                 except Exception:
@@ -575,7 +747,7 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
         for key in all_keys:
             _safe_delete_key(key, bucket_name, s3_client)
 
-        if vpc_bucket and flow_log_id is not None:
+        if vpc_bucket and flow_log_owned and flow_log_id is not None:
             try:
                 ec2_client.delete_flow_logs(FlowLogIds=[flow_log_id])
             except Exception as exc:
@@ -780,7 +952,10 @@ def set_test_sqs_queue(metadata: dict, sqs_manager, s3_client) -> None:
     """
     # Get bucket name
     bucket_name = metadata["bucket_name"]
-    # Get SQS name
+    # The queue name is already unique per run: configurator._modify_metadata appends a random per-session
+    # '-<uuid>-todelete' suffix, so concurrent runs never share a queue. (Do NOT append GITHUB_RUN_ID here:
+    # it would land after '-todelete' and fall outside the IAM policy's allowed queue-name pattern.) The
+    # cross-run collision that issue #38194 fixes is the bucket notification, handled below.
     sqs_name = metadata["sqs_name"]
 
     sqs_queues, sqs_client = sqs_manager
@@ -800,10 +975,8 @@ def set_test_sqs_queue(metadata: dict, sqs_manager, s3_client) -> None:
                        sqs_queue_arn=sqs_queue_arn,
                        client=sqs_client)
 
-        # Set bucket notification configuration
-        set_bucket_event_notification_configuration(bucket_name=bucket_name,
-                                                    sqs_queue_arn=sqs_queue_arn,
-                                                    client=s3_client)
+        # Set bucket notification configuration (per-run, prefix-filtered, merged - see helper).
+        _set_run_bucket_notification(s3_client, bucket_name, sqs_queue_arn)
 
     except ClientError as error:
         # Check if the sqs exist
@@ -815,6 +988,11 @@ def set_test_sqs_queue(metadata: dict, sqs_manager, s3_client) -> None:
 
     except Exception as error:
         raise error
+
+    yield
+
+    # Remove only this run's notification rule so a concurrent run's rule survives.
+    _remove_run_bucket_notification(s3_client, bucket_name)
 
 
 """DB fixtures"""

--- a/tests/integration/test_aws/test_basic.py
+++ b/tests/integration/test_aws/test_basic.py
@@ -94,6 +94,12 @@ def test_bucket_defaults(
         '--debug', '2'
     ]
 
+    # Under the per-run namespace (issue #38194) create_test_bucket injects a <path> into the config, so
+    # the module is invoked with --trail_prefix. No-op locally (no namespace -> no 'path' in metadata).
+    if metadata.get('path'):
+        parameters.insert(3, metadata['path'])
+        parameters.insert(3, '--trail_prefix')
+
     # Check AWS module started
     log_monitor.start(
         timeout=TIMEOUT[20],

--- a/tests/integration/test_aws/test_only_logs_after.py
+++ b/tests/integration/test_aws/test_only_logs_after.py
@@ -869,12 +869,26 @@ def test_bucket_multiple_calls(
         effective_bucket_type = data_bucket_name.split('-')[1]
     elif bucket_type == 'guardduty' and 'native' in data_bucket_name:
         effective_bucket_type = 'native-guardduty'
-    last_marker_key = get_last_file_key(effective_bucket_type, bucket_name, datetime.utcnow(), region, s3_client)
+    # Upload under the run namespace (metadata['path']) so the module - configured with the same
+    # namespaced <path> - actually finds the file, and it lands inside the prefix this run cleans up.
+    ns_prefix = metadata.get('path') or ''
+    last_marker_key = get_last_file_key(effective_bucket_type, bucket_name, datetime.utcnow(), region,
+                                        s3_client, prefix=ns_prefix)
+    # The run namespace (issue #38194) also holds the copied CloudTrail/ELB seeds under '<run>/AWSLogs/'.
+    # Custom bucket types (kms, macie, waf, ...) keep their data directly under '<run>/<date>/', so
+    # get_last_file_key - which lists the whole namespace - would pick the seed ('AWSLogs/' sorts after
+    # digits) instead of the type's own last file. When the type has data outside AWSLogs/, take that as
+    # the marker so it matches what the module actually processes. No-op locally (no namespace).
+    if ns_prefix:
+        own_keys = [obj.key for obj in s3_client.Bucket(bucket_name).objects.filter(Prefix=ns_prefix)
+                    if 'AWSLogs/' not in obj.key]
+        if own_keys:
+            last_marker_key = max(own_keys)
     if bucket_type == VPC_FLOW_TYPE:
         data, key = generate_file(bucket_type=bucket_type,
                                   bucket_name=data_bucket_name,
                                   region=region,
-                                  prefix='',
+                                  prefix=ns_prefix,
                                   suffix='',
                                   date='',
                                   flow_log_id=metadata['flow_log_id'])
@@ -882,7 +896,7 @@ def test_bucket_multiple_calls(
         data, key = generate_file(bucket_type=bucket_type,
                                   bucket_name=data_bucket_name,
                                   region=region,
-                                  prefix='',
+                                  prefix=ns_prefix,
                                   suffix='',
                                   date='')
     metadata['filename'] = key

--- a/tests/integration/test_aws/test_path_suffix.py
+++ b/tests/integration/test_aws/test_path_suffix.py
@@ -104,7 +104,19 @@ def test_path_suffix(
     only_logs_after = metadata['only_logs_after']
     path_suffix = metadata['path_suffix']
     expected_results = metadata['expected_results']
-    pattern = fr".*WARNING: Bucket:  -  No logs found in 'AWSLogs/{path_suffix}/'. Check the provided prefix.*\n*"
+    # The module reports "no data" for an empty path_suffix in one of two valid ways, depending on whether
+    # the per-run namespace prefix ('<run>/', issue #38194) has any sibling content when check_bucket runs:
+    #   - find_account_ids: "No logs found in '<run>/AWSLogs/<suffix>/'. Check the provided prefix" (the
+    #     base prefix lists no account), or
+    #   - check_bucket: "No files were found in '<bucket>/<run>/<suffix>/'. No logs will be processed" (the
+    #     run prefix itself lists empty, e.g. the empty cases upload nothing).
+    # Accept either. '.*' before the suffix tolerates the '<run>/' prefix; both match locally (no namespace).
+    pattern = (
+        fr".*WARNING: Bucket:  -  (?:"
+        fr"No logs found in '.*AWSLogs/{path_suffix}/'. Check the provided prefix"
+        fr"|No files were found in '.*{path_suffix}/'. No logs will be processed"
+        fr").*\n*"
+    )
 
     parameters = [
         'wodles/aws/aws-s3',
@@ -114,6 +126,12 @@ def test_path_suffix(
         '--type', bucket_type,
         '--debug', '2'
     ]
+
+    # Under the per-run namespace (issue #38194) create_test_bucket injects a <path> into the config, so
+    # the module is invoked with --trail_prefix. No-op locally (no namespace -> no 'path' in metadata).
+    if metadata.get('path'):
+        parameters.insert(3, metadata['path'])
+        parameters.insert(3, '--trail_prefix')
 
     # Check AWS module started
     log_monitor.start(
@@ -149,9 +167,11 @@ def test_path_suffix(
     assert path_exist(path=S3_CLOUDTRAIL_DB_PATH)
 
     if expected_results:
+        # 'ns' is the per-run namespace prefix ('<run>/') injected under issue #38194, or '' locally.
+        ns = metadata.get('path', '')
         data = get_s3_db_row(table_name=bucket_type)
-        assert f"{bucket_name}/{path_suffix}/" == data.bucket_path
-        assert data.log_key.startswith(f"AWSLogs/{path_suffix}/")
+        assert f"{bucket_name}/{ns}{path_suffix}/" == data.bucket_path
+        assert data.log_key.startswith(f"{ns}AWSLogs/{path_suffix}/")
     else:
         assert not table_exists_or_has_values(table_name=bucket_type)
 

--- a/tests/integration/test_aws/test_path_suffix.py
+++ b/tests/integration/test_aws/test_path_suffix.py
@@ -104,13 +104,12 @@ def test_path_suffix(
     only_logs_after = metadata['only_logs_after']
     path_suffix = metadata['path_suffix']
     expected_results = metadata['expected_results']
-    # The module reports "no data" for an empty path_suffix in one of two valid ways, depending on whether
-    # the per-run namespace prefix ('<run>/', issue #38194) has any sibling content when check_bucket runs:
-    #   - find_account_ids: "No logs found in '<run>/AWSLogs/<suffix>/'. Check the provided prefix" (the
-    #     base prefix lists no account), or
-    #   - check_bucket: "No files were found in '<bucket>/<run>/<suffix>/'. No logs will be processed" (the
-    #     run prefix itself lists empty, e.g. the empty cases upload nothing).
-    # Accept either. '.*' before the suffix tolerates the '<run>/' prefix; both match locally (no namespace).
+    # The module signals an empty path_suffix with one of two messages depending on the runtime: the
+    # manager path emits find_account_ids' "No logs found ... Check the provided prefix"; the agent path
+    # emits check_bucket's "No files were found ... No logs will be processed" even in a healthy run.
+    # Accept either. This is safe against a broken/unseeded namespace: _copy_seeds_into_namespace fails the
+    # session fast if nothing seeds, so a run that reaches here always has the AWSLogs/ structure. '.*'
+    # before the suffix tolerates the '<run>/' prefix (issue #38194); both match locally (no namespace).
     pattern = (
         fr".*WARNING: Bucket:  -  (?:"
         fr"No logs found in '.*AWSLogs/{path_suffix}/'. Check the provided prefix"

--- a/tests/integration/test_aws/test_regions.py
+++ b/tests/integration/test_aws/test_regions.py
@@ -119,6 +119,12 @@ def test_regions(
         '--debug', '2'
     ]
 
+    # Under the per-run namespace (issue #38194) create_test_bucket injects a <path> into the config, so
+    # the module is invoked with --trail_prefix. No-op locally (no namespace -> no 'path' in metadata).
+    if metadata.get('path'):
+        parameters.insert(3, metadata['path'])
+        parameters.insert(3, '--trail_prefix')
+
     # Check AWS module started
     log_monitor.start(
         timeout=session_parameters.default_timeout,
@@ -150,7 +156,12 @@ def test_regions(
             if hasattr(row, "aws_region"):
                 assert row.aws_region in regions_list
             else:
-                assert row.log_key.split("/")[3] in regions_list
+                # Strip the per-run namespace prefix (issue #38194) so the region stays at the same
+                # positional index as without a namespace. No-op locally (no 'path' in metadata).
+                log_key = row.log_key
+                if metadata.get('path'):
+                    log_key = log_key[len(metadata['path']):]
+                assert log_key.split("/")[3] in regions_list
 
     else:
         invalid_region = None


### PR DESCRIPTION
## Description

The AWS integration tests run against a single shared S3 bucket (plus a shared VPC and a shared SQS queue), so two runs executing at the same time interfere. This makes the AWS integration tests safe to run in parallel by isolating each run across the three resources that concurrent runs otherwise collide on:

- **S3 keys**: every key and the module's configured path go under a per-run namespace `s3://<bucket>/<GITHUB_RUN_ID>/...`, so runs never share keys (`SETUP COLLISION`, cross counts, one run's teardown deleting another's objects).
- **VPC Flow Log**: its dedup key `(VPC, TrafficType, destination)` is shared, so a second concurrent run hits `FlowLogAlreadyExists`. The run now reuses the existing flow log and only its creator deletes it.
- **SQS notification**: the bucket event notification is a single shared object. Each run registers its own prefix-filtered rule (`<run>/`) merged with the others (read-modify-write) instead of replacing the whole config, so concurrent runs are never notified of each other's uploads.

Runs keep executing in **parallel** (no serialization).

**Proposed Release:** v5.0.0
**Issue:** wazuh/wazuh#38194
**Internal Reference:** N/A

## Proposed Changes

- `tests/integration/test_aws/conftest.py`:
  - **S3 namespace**: `_namespaced()` prefixes the bucket path with `<GITHUB_RUN_ID>/` (no-op locally). Uploaded keys and the module's `<path>` stay aligned; a path-less bucket type gets an explicit `<path>` so it reads under the namespace. Session fixture `aws_run_namespace` mirrors the permanent seeds into `<run>/AWSLogs/...` at start and deletes the whole `<run>/` namespace at the end; the root seeds are never modified. `_is_permanent_seed()` recognizes both the root seeds and their per-run copies.
  - **VPC Flow Log**: on `FlowLogAlreadyExists`, reuse the existing flow log (`describe_flow_logs`); only the run that created it deletes it in teardown (`flow_log_owned`). The flow-log id is only used to name the synthetic object, so sharing it is harmless.
  - **SQS**: `_set_run_bucket_notification` registers a per-run prefix-filtered rule and `_merge_queue_configs` rebuilds the config preserving other runs' rules, dropping our own and any rule whose prefix overlaps ours (a legacy no-filter rule; S3 rejects overlapping prefixes for the same event). Read-modify-write with a verify+retry loop. Teardown removes only this run's rule. The queue name is already unique per run (framework session suffix).
  - Coexists with the base's orphan self-heal / collision guard (`_assert_prefix_clean`, staleness threshold), reusing the namespace-aware seed check.
  - Test adjustments for the namespaced `<path>` in `test_basic.py`, `test_regions.py`, `test_only_logs_after.py`, and the empty-suffix warning in `test_path_suffix.py`.
- `.github/workflows/5_testintegration_linux-integration-tests.yml`: pass `GITHUB_RUN_ID` through the `sudo` pytest invocation so the namespace activates in CI (sudo resets the environment). The existing manifest-based `if: always()` cleanup is unchanged.

## Dependencies

The OIDC role used by the AWS integration tests needs `s3:GetBucketNotification` on the shared bucket (it already had `PutBucketNotification`) for the SQS notification merge to read the current config. Granted by the DevOps team.

### Results and Evidence

**Validated under real concurrency**: this run and the 4.14.8 run (#38254) overlapped in time and both passed, so the S3 namespace, the VPC Flow Log reuse and the per-run SQS notification merge all hold with two runs live at once.

- 5.0.0 run: https://github.com/wazuh/wazuh/actions/runs/32106801242 (`IT Linux - aws`: 117 passed, 0 failed, including both `custom_bucket` SQS cases and the `vpc_*` cases).

Also validated locally with `moto` (mocked S3/EC2/SQS) against the real module code and the harness: per-run namespace + cross-run isolation, VPC create-or-reuse (owner-only delete, no orphan), and the SQS notification merge (two runs' prefix-filtered rules coexist, teardown of one preserves the other, worst-case interleave converges, legacy overlapping rule dropped).

### Artifacts Affected

- `tests/integration/test_aws/conftest.py`
- `tests/integration/test_aws/test_basic.py`, `test_regions.py`, `test_only_logs_after.py`, `test_path_suffix.py`
- `.github/workflows/5_testintegration_linux-integration-tests.yml`

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Integration Tests (infrastructure).
- **Details:** No new test cases. Per-run isolation (S3 namespace + VPC flow log reuse + SQS notification merge) so concurrent AWS IT runs no longer collide; validated locally with `moto` and in CI under real concurrency.

## Review Checklist

> No compiled code changes (Python + workflow only) - compilation and memory checks are N/A.

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
