### PR TITLE
Merge 4.14.8 into 4.14.9

### DIFF
--- a/.github/actions/check_files/check_files.py
+++ b/.github/actions/check_files/check_files.py
@@ -258,6 +258,31 @@ def get_current_items(scan_path='/var/ossec', size_check=False, ignore_names=[])
 """
 
 
+def path_match(filename, pattern):
+    """Match a filename against a glob pattern segment by segment.
+
+    A wildcard is not allowed to span path separators: both the filename
+    and the pattern are split into their components and each pair is
+    matched independently. This keeps a '*' from crossing a directory
+    boundary regardless of how many characters it expands to. Both '/'
+    (Unix) and '\\' (Windows) separators are supported.
+
+    Args:
+        filename (str): The current file path being checked.
+        pattern (str): The expected path, possibly containing glob wildcards.
+
+    Returns:
+        bool: True if the filename matches the pattern.
+    """
+    file_parts = filename.replace('\\', '/').split('/')
+    pattern_parts = pattern.replace('\\', '/').split('/')
+
+    if len(file_parts) != len(pattern_parts):
+        return False
+
+    return all(fnmatch.fnmatch(f, p) for f, p in zip(file_parts, pattern_parts))
+
+
 def csv_to_dict(file_path, key_column):
     data_dict = {}
 
@@ -466,9 +491,10 @@ if __name__ == "__main__":
             # 2. Check for matches with glob patterns if no exact match found
             if not matched:
                 for pattern, expected_item_fields in glob_patterns.items():
-                    # Check if the pattern matches the current file name
-                    # Note: Only the current directory is considered (no subdirectories)
-                    if fnmatch.fnmatch(current_file_name, pattern) and '/' not in current_file_name[len(pattern)-1:]:
+                    # Check if the pattern matches the current file name.
+                    # Matching is done per path segment so a wildcard never
+                    # spans a directory separator.
+                    if path_match(current_file_name, pattern):
                         matched = True
                         matches[pattern] = True
 

--- a/.github/actions/check_files/test_check_files.py
+++ b/.github/actions/check_files/test_check_files.py
@@ -1,0 +1,60 @@
+import sys
+import types
+
+import pytest
+
+# check_files.py imports pandas at module load time, but path_match does not
+# need it. Provide a lightweight stub so the module can be imported in a plain
+# test environment (the real pandas is used if it happens to be installed).
+sys.modules.setdefault('pandas', types.ModuleType('pandas'))
+
+from check_files import path_match  # noqa: E402
+
+
+class TestPathMatch:
+    """Tests for the glob matching used against the expected-files CSV."""
+
+    @pytest.mark.parametrize("filename", [
+        # The temp directory name expands to different lengths; every one of
+        # these must match the same pattern. Long expansions used to break the
+        # previous length-based check and were wrongly reported as unexpected.
+        "/var/ossec/tmp/sca-4.9-x-tmp/rhel/8/sca.files",
+        "/var/ossec/tmp/sca-4.14.8-a1b2c3-tmp/rhel/8/sca.files",
+        "/var/ossec/tmp/sca-4.14.8-12345678901234-tmp/rhel/8/sca.files",
+        "/var/ossec/tmp/sca-4.14.8-0000000000000000000000-tmp/rhel/8/sca.files",
+    ])
+    def test_wildcard_in_middle_segment_any_length(self, filename):
+        pattern = "/var/ossec/tmp/sca-4.*-*-tmp/rhel/8/sca.files"
+        assert path_match(filename, pattern)
+
+    def test_wildcard_does_not_cross_directory_separator(self):
+        # A '*' inside a segment must not swallow additional directories.
+        pattern = "/var/ossec/tmp/sca-4.*-*-tmp/rhel/8/sca.files"
+        filename = "/var/ossec/tmp/sca-4.14.8-x/extra/y-tmp/rhel/8/sca.files"
+        assert not path_match(filename, pattern)
+
+    def test_trailing_wildcard_matches_exact_and_suffix(self):
+        pattern = "/var/ossec/ruleset/sca/cis_alma_linux_8.yml*"
+        assert path_match("/var/ossec/ruleset/sca/cis_alma_linux_8.yml", pattern)
+        assert path_match("/var/ossec/ruleset/sca/cis_alma_linux_8.yml.gz", pattern)
+
+    def test_trailing_wildcard_does_not_match_deeper_path(self):
+        pattern = "/var/ossec/ruleset/sca/cis_alma_linux_8.yml*"
+        filename = "/var/ossec/ruleset/sca/cis_alma_linux_8.yml/child"
+        assert not path_match(filename, pattern)
+
+    def test_different_segment_count_is_not_a_match(self):
+        pattern = "/var/ossec/tmp/sca-4.*-*-tmp/rhel/8/sca.files"
+        assert not path_match("/var/ossec/tmp/sca-4.14.8-x-tmp/rhel/8", pattern)
+
+    def test_literal_path_without_wildcards(self):
+        pattern = "/var/ossec/etc/ossec.conf"
+        assert path_match("/var/ossec/etc/ossec.conf", pattern)
+        assert not path_match("/var/ossec/etc/ossec.conf.bak", pattern)
+
+    def test_windows_backslash_paths(self):
+        pattern = r"C:\Program Files (x86)\ossec-agent\*.dll"
+        assert path_match(r"C:\Program Files (x86)\ossec-agent\dbsync.dll", pattern)
+        # The wildcard must stay within its segment on Windows too.
+        assert not path_match(
+            r"C:\Program Files (x86)\ossec-agent\sub\dbsync.dll", pattern)

--- a/.github/actions/install_build_deps/action.yml
+++ b/.github/actions/install_build_deps/action.yml
@@ -39,13 +39,29 @@ runs:
       run: |
         if [[ "${{ inputs.target }}" == "winagent" ]]; then
           echo "Installing CMocka by sources with 'winagent' required flags"
-          curl -L --retry 3 --retry-delay 2 -o /tmp/stable-1.1.tar.gz https://git.cryptomilk.org/projects/cmocka.git/snapshot/stable-1.1.tar.gz
-          # Verify if the download was successful
-          if [ $? -ne 0 ]; then
+
+          CMOCKA_TARBALL="/tmp/stable-1.1.tar.gz"
+          CMOCKA_URL="https://git.cryptomilk.org/projects/cmocka.git/snapshot/stable-1.1.tar.gz"
+          CMOCKA_MIRROR_URL="https://gitlab.com/cmocka/cmocka/-/archive/cmocka-1.1.8/cmocka-cmocka-1.1.8.tar.gz"
+
+          if ! curl -L --retry 3 --retry-delay 2 --connect-timeout 15 -o "$CMOCKA_TARBALL" "$CMOCKA_URL" \
+             || ! gzip -t "$CMOCKA_TARBALL" 2>/dev/null; then
+            echo "Primary CMocka download failed or returned an invalid archive. Falling back to the GitLab mirror (verified same content, cmocka 1.1.8)..."
+            if ! curl -L --retry 3 --retry-delay 2 --connect-timeout 15 -o "$CMOCKA_TARBALL" "$CMOCKA_MIRROR_URL"; then
               echo "Error during download. Exiting..."
               exit 1
+            fi
           fi
-          tar -zxf /tmp/stable-1.1.tar.gz -C /tmp/
+
+          tar -zxf "$CMOCKA_TARBALL" -C /tmp/
+          # The GitLab mirror's archive extracts to a differently-named top-level
+          # directory than the origin's; normalize it so the rest of this script
+          # doesn't care which source was actually used.
+          tar_list="$(tar -tzf "$CMOCKA_TARBALL")"
+          extracted_dir="$(echo "$tar_list" | head -1 | cut -d/ -f1)"
+          if [ "$extracted_dir" != "stable-1.1" ]; then
+            mv "/tmp/$extracted_dir" /tmp/stable-1.1
+          fi
           sed -i "s|ON|OFF|g" /tmp/stable-1.1/DefineOptions.cmake
           mkdir /tmp/stable-1.1/build
           cd /tmp/stable-1.1/build

--- a/.github/workflows/4_builderpackage_manager-multiples.yml
+++ b/.github/workflows/4_builderpackage_manager-multiples.yml
@@ -37,6 +37,7 @@ permissions:
 
 jobs:
   select-targets:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     name: Select build targets (Wazuh Managers)
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     outputs:
@@ -58,6 +59,7 @@ jobs:
             return { include: matrix };
           result-encoding: json
   build-wazuh-manager:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     name: Build Wazuh Manager
     needs: select-targets
     strategy:

--- a/.github/workflows/4_builderprecompiled_vdscanner-testtools.yml
+++ b/.github/workflows/4_builderprecompiled_vdscanner-testtools.yml
@@ -44,7 +44,7 @@ jobs:
     name: VD Scanner Tools Delivery
 
     # Runs only if the PR status is different to Draft
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 60
 

--- a/.github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml
+++ b/.github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml
@@ -5,6 +5,7 @@ on:
     - cron: "20 0 * * *"
 
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - ".github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml"
       - ".github/actions/compile_and_test/action.yml"
@@ -87,7 +88,7 @@ jobs:
         shell: bash
 
   vulnerability_scanner_database_workflow_changes:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && !github.event.pull_request.draft
 
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
 

--- a/.github/workflows/4_codeanalysis_python.yml
+++ b/.github/workflows/4_codeanalysis_python.yml
@@ -3,6 +3,7 @@ name: 4.X - Python static code analysis on PR
 
 on:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - ".github/workflows/4_codeanalysis_python.yml"
       - "framework/**/*.py"
@@ -13,6 +14,7 @@ env:
 
 jobs:
   bandit-scan:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout repo

--- a/.github/workflows/4_codeanalysis_scanbuild.yml
+++ b/.github/workflows/4_codeanalysis_scanbuild.yml
@@ -2,6 +2,7 @@ name: 4.X - Scan Build
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/**"
       - ".github/workflows/4_codeanalysis_scanbuild.yml"
@@ -12,6 +13,7 @@ permissions:
 
 jobs:
   scan-build-linux:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     strategy:
       fail-fast: false
@@ -51,6 +53,7 @@ jobs:
         run: exit 1
 
   scan-build-ubuntu-mingw-windows:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -88,6 +91,7 @@ jobs:
         run: exit 1
 
   scan-build-macos-agent:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/4_codelinter_clangformat.yml
+++ b/.github/workflows/4_codelinter_clangformat.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   style:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:

--- a/.github/workflows/4_testcomponent_build-macos.yml
+++ b/.github/workflows/4_testcomponent_build-macos.yml
@@ -2,12 +2,14 @@ name: 4.X - macOS compilation test
 
 on:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/**"
       - ".github/workflows/4_testcomponent_build-macos.yml"
 
 jobs:
   build-sonoma:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: macos-14
     steps:
       - name: Checkout Repo

--- a/.github/workflows/4_testcomponent_indexer-connector.yml
+++ b/.github/workflows/4_testcomponent_indexer-connector.yml
@@ -20,6 +20,7 @@ permissions:
 
 jobs:
   indexer_connector-qa:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/4_testcomponent_inventory-harvester.yml
+++ b/.github/workflows/4_testcomponent_inventory-harvester.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   inventory-harvester-modules:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Cancel previous runs
@@ -47,6 +48,7 @@ jobs:
           valgrind: "true"
 
   inventory-harvester-asan:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     strategy:
       matrix:
         os: [ubuntu-24.04, ubuntu-22.04]

--- a/.github/workflows/4_testcomponent_keystore.yml
+++ b/.github/workflows/4_testcomponent_keystore.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   wazuh-keystore-qa:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/4_testcomponent_syscheck-rtr.yml
+++ b/.github/workflows/4_testcomponent_syscheck-rtr.yml
@@ -3,6 +3,7 @@ name: 4.X - Running RTR. Module syscheck for agent/winagent targets
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/ci/**"
       - "src/build.py"
@@ -18,6 +19,7 @@ permissions:
 
 jobs:
   rtr:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/4_testcomponent_syscollector-rtr.yml
+++ b/.github/workflows/4_testcomponent_syscollector-rtr.yml
@@ -3,6 +3,7 @@ name: 4.X - Running RTR. Module syscollector and its dependencies for agent/wina
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/ci/**"
       - "src/build.py"
@@ -19,6 +20,7 @@ permissions:
 
 jobs:
   rtr:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     strategy:
           fail-fast: false
           matrix:

--- a/.github/workflows/4_testcomponent_sysinfo-linux.yml
+++ b/.github/workflows/4_testcomponent_sysinfo-linux.yml
@@ -3,6 +3,7 @@ name: 4.X - Syscollector test on Ubuntu
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - ".github/workflows/4_testcomponent_sysinfo-linux.yml"
       - "src/data_provider/**"
@@ -12,6 +13,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo

--- a/.github/workflows/4_testcomponent_sysinfo-macos.yml
+++ b/.github/workflows/4_testcomponent_sysinfo-macos.yml
@@ -3,6 +3,7 @@ name: 4.X - Syscollector test on macOS
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - ".github/workflows/4_testcomponent_sysinfo-macos.yml"
       - "src/data_provider/**"
@@ -12,6 +13,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: macos-14
     steps:
       - name: Checkout Repo

--- a/.github/workflows/4_testcomponent_sysinfo-windows.yml
+++ b/.github/workflows/4_testcomponent_sysinfo-windows.yml
@@ -3,6 +3,7 @@ name: 4.X - Syscollector test on Windows
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - ".github/workflows/4_testcomponent_sysinfo-windows.yml"
       - "src/data_provider/**"
@@ -16,6 +17,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -84,6 +86,7 @@ jobs:
           name: syscollector
           path: src/wazuh_modules/syscollector/build/bin
   run-on-windows:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build
     runs-on: codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:

--- a/.github/workflows/4_testcomponent_vulnerability-scanner.yml
+++ b/.github/workflows/4_testcomponent_vulnerability-scanner.yml
@@ -23,6 +23,7 @@ permissions:
 
 jobs:
   style-and-documentation:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
@@ -154,6 +155,7 @@ jobs:
           id: vulnerability_scanner
 
   vulnerability-scanner-modules:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: style-and-documentation
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
 
@@ -245,6 +247,7 @@ jobs:
           id: vulnerability_scanner
 
   vulnerability-scanner-modules-asan:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: style-and-documentation
 
     strategy:
@@ -304,6 +307,7 @@ jobs:
           asan: "true"
 
   vulnerability-scanner-modules-qa:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     env:
       OFFLINE_CONFIG_FILE: config.content_generation.json

--- a/.github/workflows/4_testcomponent_windows-dll-hijack.yml
+++ b/.github/workflows/4_testcomponent_windows-dll-hijack.yml
@@ -3,6 +3,7 @@ name: 4.X - Testing DLL search order to prevent hijack
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/**"
       - ".github/workflows/4_testcomponent_windows-dll-hijack.yml"
@@ -13,6 +14,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -59,6 +61,7 @@ jobs:
           name: configuration
           path: src/configuration_files
   check_dll_on_windows:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     # NOTE: stays on the GitHub-hosted Windows runners. This test drives Process Monitor, which
     # captures via a kernel minifilter driver. CodeBuild's Windows fleet runs process-isolated
     # containers (no FltMgr / kernel-driver loading), so Procmon captures zero events there.

--- a/.github/workflows/4_testcomponent_windows-files.yml
+++ b/.github/workflows/4_testcomponent_windows-files.yml
@@ -2,6 +2,7 @@ name: 4.X - Windows binaries' details
 
 on:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/**"
       - ".github/workflows/4_testcomponent_windows-files.yml"
@@ -12,6 +13,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -45,6 +47,7 @@ jobs:
           name: binaries
           path: src/bin_files
   check_binaries_details:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-agent-windows-amd-${{ github.run_id }}-${{ github.run_attempt }}
     needs: build
     steps:

--- a/.github/workflows/4_testcomponent_windows-installer-upgrade.yml
+++ b/.github/workflows/4_testcomponent_windows-installer-upgrade.yml
@@ -2,6 +2,7 @@ name: 4.X - Windows upgrade test
 
 on:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/**"
       - ".github/actions/upload_s3_artifact/**"
@@ -14,6 +15,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Install mingw
@@ -43,6 +45,7 @@ jobs:
           path: win-agent-base.zip
 
   check_upgrade_result:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     strategy:
           matrix:
               wazuh_version: [4.5.2-1]

--- a/.github/workflows/4_testintegration_agentd-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_agentd-tier-0-1-lin.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_agentd-tier-0-1-lin.yml"
         - "src/client-agent/**"
@@ -20,6 +21,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_agentd-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_agentd-tier-0-1-win.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_agentd-tier-0-1-win.yml"
         - "src/client-agent/**"
@@ -26,6 +27,7 @@ permissions:
 jobs:
   # Build the winagent on linux.
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -58,6 +60,7 @@ jobs:
           path: src/winagent
   # Execute the tests on windows.
   run-test:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/4_testintegration_analysisd-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_analysisd-tier-0-1.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_analysisd-tier-0-1.yml"
         - "src/analysisd/**"
@@ -21,6 +22,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_api-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_api-tier-0-1.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_api-tier-0-1.yml"
         - "api/**"
@@ -22,6 +23,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_authd-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_authd-tier-0-1.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_authd-tier-0-1.yml"
         - "src/config/authd-config.c"
@@ -20,6 +21,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_aws-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_aws-tier-0-1.yml
@@ -27,6 +27,9 @@ jobs:
       QA_IT_FW_BRANCH: ${{ github.base_ref || inputs.base_qa_it_fw_branch }}
       AWS_VPC_ID: ${{ secrets.IT_AWS_VPC_ID }}
       AWS_BUCKET_NAME: ${{ secrets.IT_AWS_BUCKET_NAME }}
+      # Manifest of every S3 key the tests upload, so the always() cleanup step can delete them
+      # even if the job is cancelled before pytest teardown runs.
+      AWS_IT_CLEANUP_MANIFEST: ${{ github.workspace }}/aws_it_uploaded_keys.txt
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo
@@ -164,7 +167,7 @@ jobs:
         if: steps.filter.outputs.parser == 'true'
         run: |
           cd tests/integration
-          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 test_aws/test_parser.py
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" AWS_IT_CLEANUP_MANIFEST="${AWS_IT_CLEANUP_MANIFEST}" python3 -m pytest -vvv --tier 0 --tier 1 test_aws/test_parser.py
 
       - name: Run every test due to base WazuhIntegration class change or manual dispatch
         if: steps.filter.outputs.integration == 'true' || github.event_name == 'workflow_dispatch'
@@ -172,71 +175,71 @@ jobs:
           cd tests/integration
           # Inspector is excluded here and run in its own step ('Run Inspector tests') that
           # re-assumes the chained role right before, so its 1h-capped session stays fresh.
-          sudo AWS_VPC_ID="${AWS_VPC_ID}" AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k "not inspector" test_aws/
+          sudo AWS_VPC_ID="${AWS_VPC_ID}" AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" AWS_IT_CLEANUP_MANIFEST="${AWS_IT_CLEANUP_MANIFEST}" python3 -m pytest -vvv --tier 0 --tier 1 -k "not inspector" test_aws/
 
       - name: Run Custom Buckets tests
         if: steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k kms test_aws/
-          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k macie test_aws/
-          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k trusted_advisor test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" AWS_IT_CLEANUP_MANIFEST="${AWS_IT_CLEANUP_MANIFEST}" python3 -m pytest -vvv --tier 0 --tier 1 -k kms test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" AWS_IT_CLEANUP_MANIFEST="${AWS_IT_CLEANUP_MANIFEST}" python3 -m pytest -vvv --tier 0 --tier 1 -k macie test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" AWS_IT_CLEANUP_MANIFEST="${AWS_IT_CLEANUP_MANIFEST}" python3 -m pytest -vvv --tier 0 --tier 1 -k trusted_advisor test_aws/
 
       - name: Run Config tests
         if: steps.filter.outputs.config == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k config test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" AWS_IT_CLEANUP_MANIFEST="${AWS_IT_CLEANUP_MANIFEST}" python3 -m pytest -vvv --tier 0 --tier 1 -k config test_aws/
 
       - name: Run GuardDuty tests
         if: steps.filter.outputs.guardduty == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k guardduty test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" AWS_IT_CLEANUP_MANIFEST="${AWS_IT_CLEANUP_MANIFEST}" python3 -m pytest -vvv --tier 0 --tier 1 -k guardduty test_aws/
 
       - name: Run CloudTrail tests
         if: steps.filter.outputs.cloudtrail == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k cloudtrail test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" AWS_IT_CLEANUP_MANIFEST="${AWS_IT_CLEANUP_MANIFEST}" python3 -m pytest -vvv --tier 0 --tier 1 -k cloudtrail test_aws/
 
       - name: Run Load Balancers tests
         if: steps.filter.outputs.loadbalancers == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k alb test_aws/
-          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k clb test_aws/
-          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k nlb test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" AWS_IT_CLEANUP_MANIFEST="${AWS_IT_CLEANUP_MANIFEST}" python3 -m pytest -vvv --tier 0 --tier 1 -k alb test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" AWS_IT_CLEANUP_MANIFEST="${AWS_IT_CLEANUP_MANIFEST}" python3 -m pytest -vvv --tier 0 --tier 1 -k clb test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" AWS_IT_CLEANUP_MANIFEST="${AWS_IT_CLEANUP_MANIFEST}" python3 -m pytest -vvv --tier 0 --tier 1 -k nlb test_aws/
 
       - name: Run Server Access tests
         if: steps.filter.outputs.serveraccess == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k server_access test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" AWS_IT_CLEANUP_MANIFEST="${AWS_IT_CLEANUP_MANIFEST}" python3 -m pytest -vvv --tier 0 --tier 1 -k server_access test_aws/
 
       - name: Run Umbrella tests
         if: steps.filter.outputs.umbrella == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k cisco test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" AWS_IT_CLEANUP_MANIFEST="${AWS_IT_CLEANUP_MANIFEST}" python3 -m pytest -vvv --tier 0 --tier 1 -k cisco test_aws/
 
       - name: Run VPC Flow tests
         if: steps.filter.outputs.vpcflow == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo AWS_VPC_ID="${AWS_VPC_ID}" AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k vpc test_aws/
+          sudo AWS_VPC_ID="${AWS_VPC_ID}" AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" AWS_IT_CLEANUP_MANIFEST="${AWS_IT_CLEANUP_MANIFEST}" python3 -m pytest -vvv --tier 0 --tier 1 -k vpc test_aws/
 
       - name: Run WAF tests
         if: steps.filter.outputs.waf == 'true' || steps.filter.outputs.bucket == 'true'
         run: |
           cd tests/integration
-          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k waf test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" AWS_IT_CLEANUP_MANIFEST="${AWS_IT_CLEANUP_MANIFEST}" python3 -m pytest -vvv --tier 0 --tier 1 -k waf test_aws/
 
       - name: Run CloudWatch tests
         if: steps.filter.outputs.cloudwatch == 'true'
         run: |
           cd tests/integration
-          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k cloudwatch test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" AWS_IT_CLEANUP_MANIFEST="${AWS_IT_CLEANUP_MANIFEST}" python3 -m pytest -vvv --tier 0 --tier 1 -k cloudwatch test_aws/
 
       - name: Run Inspector tests
         # !cancelled() overrides the implicit success() so this step still runs when an
@@ -275,10 +278,36 @@ jobs:
           sudo aws configure set region us-east-2 --profile inspector_tests
 
           cd tests/integration
-          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 -k inspector test_aws/
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" AWS_IT_CLEANUP_MANIFEST="${AWS_IT_CLEANUP_MANIFEST}" python3 -m pytest -vvv --tier 0 --tier 1 -k inspector test_aws/
 
       - name: Run Custom Bucket tests
         if: steps.filter.outputs.custom_bucket == 'true'
         run: |
           cd tests/integration
-          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" python3 -m pytest -vvv --tier 0 --tier 1 test_aws/test_custom_bucket.py
+          sudo AWS_BUCKET_NAME="${AWS_BUCKET_NAME}" AWS_IT_CLEANUP_MANIFEST="${AWS_IT_CLEANUP_MANIFEST}" python3 -m pytest -vvv --tier 0 --tier 1 test_aws/test_custom_bucket.py
+
+      - name: Clean up uploaded S3 test artifacts
+        # always() so this runs even when the job is CANCELLED - the dominant source of orphan
+        # objects, since pytest teardown does not run on a hard cancel. The manifest lists every key
+        # the tests uploaded (recorded at upload time); we delete each one, skipping permanent seeds.
+        if: always()
+        run: |
+          MANIFEST="${AWS_IT_CLEANUP_MANIFEST}"
+          if [ ! -f "$MANIFEST" ]; then
+            echo "No cleanup manifest found; nothing to delete."
+            exit 0
+          fi
+          # Permanent DevOps seeds that must never be deleted (belt-and-suspenders; the manifest never
+          # records them, but guard here in case a future test key ever matches one).
+          SEED_CLOUDTRAIL="AWSLogs/819751203818/CloudTrail/us-east-1/2022/11/20/819751203818_CloudTrail_us-east-1_20221120T0000Z_372406355707169122.json"
+          SEED_ELB="AWSLogs/819751203818/elasticloadbalancing/us-east-1/2022/11/20/819751203818_elasticloadbalancing_us-east-1_net.qatests_20221120T0000Z_1412953514070675864_29.145.39.119.log"
+          sudo sort -u "$MANIFEST" | while IFS= read -r key; do
+            [ -z "$key" ] && continue
+            if [ "$key" = "$SEED_CLOUDTRAIL" ] || [ "$key" = "$SEED_ELB" ]; then
+              echo "Skipping permanent seed: $key"
+              continue
+            fi
+            echo "Deleting s3://${AWS_BUCKET_NAME}/${key}"
+            sudo aws s3 rm "s3://${AWS_BUCKET_NAME}/${key}" --profile default || true
+          done
+          sudo rm -f "$MANIFEST" || true

--- a/.github/workflows/4_testintegration_aws-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_aws-tier-0-1.yml
@@ -12,12 +12,14 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - ".github/workflows/4_testintegration_aws-tier-0-1.yml"
       - "wodles/aws/**"
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     permissions:
       id-token: write  # Required for OIDC token generation (aws-actions/configure-aws-credentials)
       contents: read

--- a/.github/workflows/4_testintegration_enrollment-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_enrollment-tier-0-1-lin.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_enrollment-tier-0-1-lin.yml"
         - "src/client-agent/**"
@@ -21,6 +22,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_enrollment-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_enrollment-tier-0-1-win.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_enrollment-tier-0-1-win.yml"
         - "src/client-agent/**"
@@ -27,6 +28,7 @@ permissions:
 jobs:
   # Build the winagent on linux.
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -59,6 +61,7 @@ jobs:
           path: src/winagent
   # Execute the tests on windows.
   run-test:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/4_testintegration_execd-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_execd-tier-0-1-lin.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_execd-tier-0-1-lin.yml"
         - "src/config/active-response.c"
@@ -19,6 +20,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_execd-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_execd-tier-0-1-win.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_execd-tier-0-1-win.yml"
         - "src/config/active-response.c"
@@ -25,6 +26,7 @@ permissions:
 jobs:
   # Build the winagent on linux.
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -57,6 +59,7 @@ jobs:
           path: src/winagent
   # Execute the tests on windows.
   run-test:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/4_testintegration_fim-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_fim-tier-0-1-lin.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_fim-tier-0-1-lin.yml"
         - "src/config/syscheck-config.c"
@@ -19,6 +20,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_fim-tier-0-1-macos.yml
+++ b/.github/workflows/4_testintegration_fim-tier-0-1-macos.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_fim-tier-0-1-macos.yml"
         - "src/config/syscheck-config.c"
@@ -19,6 +20,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_fim-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_fim-tier-0-1-win.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_fim-tier-0-1-win.yml"
         - "src/config/syscheck-config.c"
@@ -24,6 +25,7 @@ permissions:
 jobs:
   # Build the winagent on linux.
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -56,6 +58,7 @@ jobs:
           path: src/winagent
   # Execute the tests on windows.
   run-test:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/4_testintegration_github-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_github-tier-0-1-lin.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_github-tier-0-1-lin.yml"
         - "src/config/wmodules-github.c"
@@ -19,6 +20,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_github-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_github-tier-0-1-win.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_github-tier-0-1-win.yml"
         - "src/config/wmodules-github.c"
@@ -25,6 +26,7 @@ permissions:
 jobs:
   # Build the winagent on linux.
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -57,6 +59,7 @@ jobs:
           path: src/winagent
   # Execute the tests on windows.
   run-test:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/4_testintegration_integratord-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_integratord-tier-0-1.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_integratord-tier-0-1.yml"
         - "src/config/integrator-config.c"
@@ -19,6 +20,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_inventory-harvester.yml
+++ b/.github/workflows/4_testintegration_inventory-harvester.yml
@@ -3,6 +3,7 @@ name: 4.X - Inventory Harvester - Integration tests
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
   # Pull request events
     types: [synchronize, opened, reopened, ready_for_review]
   # Path filtering
@@ -17,6 +18,7 @@ on:
 
 jobs:
   inventory-harvester-qa:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:

--- a/.github/workflows/4_testintegration_logcollector-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_logcollector-tier-0-1-lin.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_logcollector-tier-0-1-lin.yml"
         - "src/config/localfile-config.c"
@@ -19,6 +20,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_logcollector-tier-0-1-macos.yml
+++ b/.github/workflows/4_testintegration_logcollector-tier-0-1-macos.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_logcollector-tier-0-1-macos.yml"
         - "src/config/localfile-config.c"
@@ -19,6 +20,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_logcollector-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_logcollector-tier-0-1-win.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_logcollector-tier-0-1-win.yml"
         - "src/config/localfile-config.c"
@@ -24,6 +25,7 @@ permissions:
 jobs:
   # Build the winagent on linux.
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -56,6 +58,7 @@ jobs:
           path: src/winagent
   # Execute the tests on windows.
   run-test:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/4_testintegration_logtest-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_logtest-tier-0-1.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_logtest-tier-0-1.yml"
         - "src/analysisd/logtest.c"
@@ -20,6 +21,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_msgraph-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_msgraph-tier-0-1-lin.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_msgraph-tier-0-1-lin.yml"
         - "src/config/wmodules-ms-graph.c"
@@ -19,6 +20,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_office365-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_office365-tier-0-1-lin.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_office365-tier-0-1-lin.yml"
         - "src/config/wmodules-office365.c"
@@ -19,6 +20,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_office365-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_office365-tier-0-1-win.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_office365-tier-0-1-win.yml"
         - "src/config/wmodules-office365.c"
@@ -25,6 +26,7 @@ permissions:
 jobs:
   # Build the winagent on linux.
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -57,6 +59,7 @@ jobs:
           path: src/winagent
   # Execute the tests on windows.
   run-test:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/4_testintegration_rbac-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_rbac-tier-0-1.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_rbac-tier-0-1.yml"
         - "framework/wazuh/rbac/"
@@ -21,6 +22,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_remoted-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_remoted-tier-0-1.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_remoted-tier-0-1.yml"
         - "src/config/remote-config.c"
@@ -20,6 +21,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_ruleset.yml
+++ b/.github/workflows/4_testintegration_ruleset.yml
@@ -3,6 +3,7 @@ name: 4.X - Ruleset - Integration tests
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_ruleset.yml"
         - "ruleset/**"
@@ -13,6 +14,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout Repo

--- a/.github/workflows/4_testintegration_sca-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_sca-tier-0-1-lin.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_sca-tier-0-1-lin.yml"
         - "src/config/wmodules-sca.c"
@@ -19,6 +20,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_sca-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_sca-tier-0-1-win.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_sca-tier-0-1-win.yml"
         - "src/config/wmodules-sca.c"
@@ -26,6 +27,7 @@ permissions:
 jobs:
   # Build the winagent on linux.
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -58,6 +60,7 @@ jobs:
           path: src/winagent
   # Execute the tests on windows.
   run-test:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/4_testintegration_syscollector-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_syscollector-tier-0-1-lin.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_syscollector-tier-0-1-lin.yml"
         - "src/config/wmodules-syscollector.c"
@@ -18,6 +19,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testintegration_syscollector-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_syscollector-tier-0-1-win.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_syscollector-tier-0-1-win.yml"
         - "src/config/wmodules-syscollector.c"
@@ -24,6 +25,7 @@ permissions:
 jobs:
   # Build the winagent on linux.
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v3
@@ -56,6 +58,7 @@ jobs:
           path: src/winagent
   # Execute the tests on windows.
   run-test:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/4_testintegration_wazuh_db-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_wazuh_db-tier-0-1.yml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - ".github/workflows/4_testintegration_wazuh_db-tier-0-1.yml"
         - "src/config/wazuh_db-config.c"
@@ -19,6 +20,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testunit_api.yml
+++ b/.github/workflows/4_testunit_api.yml
@@ -13,6 +13,7 @@ on:
         required: false
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - '.github/workflows/4_testunit_api.yml'
       - 'api/**'
@@ -22,6 +23,7 @@ on:
 
 jobs:
   build: 
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     strategy:
       fail-fast: false

--- a/.github/workflows/4_testunit_external-integrations.yml
+++ b/.github/workflows/4_testunit_external-integrations.yml
@@ -13,6 +13,7 @@ on:
         required: false
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - '.github/workflows/4_testunit_external-integrations.yml'
       - 'integrations/**'
@@ -21,6 +22,7 @@ on:
 
 jobs:
   build: 
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     strategy:
       fail-fast: false

--- a/.github/workflows/4_testunit_framework.yml
+++ b/.github/workflows/4_testunit_framework.yml
@@ -13,6 +13,7 @@ on:
         required: false
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - '.github/workflows/4_testunit_framework.yml'
       - 'framework/**'
@@ -20,6 +21,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     strategy:
       fail-fast: false

--- a/.github/workflows/4_testunit_inventory-harvester.yml
+++ b/.github/workflows/4_testunit_inventory-harvester.yml
@@ -3,6 +3,7 @@ name: 4.X - Inventory Harvester - Unit tests
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
   # Pull request events
     types: [synchronize, opened, reopened, ready_for_review]
   # Path filtering
@@ -17,6 +18,7 @@ permissions:
 
 jobs:
   inventory-harvester-modules:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Cancel previous runs
@@ -59,6 +61,7 @@ jobs:
           id: inventory_harvester
 
   inventory-harvester-asan:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     strategy:
       matrix:
         os: [ ubuntu-24.04, ubuntu-22.04 ]

--- a/.github/workflows/4_testunit_linux-win.yml
+++ b/.github/workflows/4_testunit_linux-win.yml
@@ -8,12 +8,14 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
         - "src/**"
         - ".github/workflows/4_testunit_linux-win.yml"
 
 jobs:
   Unit-Tests:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     strategy:
           fail-fast: false
           matrix:

--- a/.github/workflows/4_testunit_macos.yml
+++ b/.github/workflows/4_testunit_macos.yml
@@ -3,12 +3,14 @@ name: 4.X - macOS - Unit tests
 on:
   workflow_dispatch:
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "src/**"
       - ".github/workflows/4_testunit_macos.yml"
 
 jobs:
   build-sonoma:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: macos-14
     steps:
       - name: Checkout Repo

--- a/.github/workflows/4_testunit_python-coverage.yml
+++ b/.github/workflows/4_testunit_python-coverage.yml
@@ -7,10 +7,12 @@ on:
         required: true
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - '.github/workflows/4_testunit_python-coverage.yml'
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}

--- a/.github/workflows/4_testunit_wodles.yml
+++ b/.github/workflows/4_testunit_wodles.yml
@@ -13,6 +13,7 @@ on:
         required: false
         default: 'main'
   pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - '.github/workflows/4_testunit_wodles.yml'
       - 'wodles/**'
@@ -21,6 +22,7 @@ on:
 
 jobs:
   build: 
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Fixed the API login attempt limit not being applied consistently under concurrent requests. ([#38135](https://github.com/wazuh/wazuh/pull/38135))
 - Fixed a heap buffer write in `wazuh-analysisd` when generating FIM alerts by resizing `full_log` before writing. ([#38145](https://github.com/wazuh/wazuh/pull/38145))
 - Fixed password validation not being enforced for empty passwords in the `update_user` API endpoint. ([#38180](https://github.com/wazuh/wazuh/pull/38180))
+- Fixed API tokens for `run_as` users not being invalidated on logout or role revocation. ([#38193](https://github.com/wazuh/wazuh/pull/38193))
 
 ### Agent
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Fixed a heap buffer write in `wazuh-analysisd` when generating FIM alerts by resizing `full_log` before writing. ([#38145](https://github.com/wazuh/wazuh/pull/38145))
 - Fixed password validation not being enforced for empty passwords in the `update_user` API endpoint. ([#38180](https://github.com/wazuh/wazuh/pull/38180))
 - Fixed API tokens for `run_as` users not being invalidated on logout or role revocation. ([#38193](https://github.com/wazuh/wazuh/pull/38193))
+- Fixed a remote-command configuration validation bypass where upper- or mixed-case XML element names let command `localfile` and `wodle` blocks pass the `remote_commands` restriction. ([#38239](https://github.com/wazuh/wazuh/pull/38239))
 
 ### Agent
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Restricted the upgrade commands accepted from the agent message channel in Analysisd. ([#37745](https://github.com/wazuh/wazuh/pull/37745))
 - Added destination path validation when deleting rule and decoder files. ([#37838](https://github.com/wazuh/wazuh/pull/37838))
 - Added source path validation when retrieving CDB list files. ([#37901](https://github.com/wazuh/wazuh/pull/37901))
+- Added path validation when listing and deleting CDB list files. ([#38214](https://github.com/wazuh/wazuh/pull/38214))
 - Fixed the `aws-s3` wodle failing to parse configuration values that contain spaces, such as `discard_regex`, `discard_field`, `aws_profile`, `aws_account_alias`, `path` and `path_suffix`. ([#37929](https://github.com/wazuh/wazuh/pull/37929))
 - Fixed wazuh-db exiting the worker thread instead of closing the peer socket when an oversized message is received. ([#37850](https://github.com/wazuh/wazuh/pull/37850))
 - Improved SCA policy source validation to correctly enforce the `sca.remote_commands` restriction. ([#37953](https://github.com/wazuh/wazuh/pull/37953))

--- a/api/api/authentication.py
+++ b/api/api/authentication.py
@@ -258,7 +258,13 @@ def check_token(username: str, roles: tuple, token_nbf_time: int, run_as: bool) 
             if not am.user_allow_run_as(user['username']) and set(user_roles) != set(roles):
                 return {'valid': False}
             with TokenManager() as tm:
-                for role in user_roles:
+                # Always validate the user and run_as blacklists, even when the token carries no roles.
+                if not tm.is_token_valid(user_id=user_id, token_nbf_time=int(token_nbf_time), run_as=run_as):
+                    return {'valid': False}
+                # Validate every role carried by the token, not only the statically-linked ones.
+                # run_as users have their roles assigned dynamically, so those roles travel in the
+                # token (roles) instead of being returned by get_all_roles_from_user (user_roles).
+                for role in set(user_roles) | set(roles):
                     if not tm.is_token_valid(role_id=role, user_id=user_id, token_nbf_time=int(token_nbf_time),
                                              run_as=run_as):
                         return {'valid': False}

--- a/api/api/test/test_authentication.py
+++ b/api/api/test/test_authentication.py
@@ -204,6 +204,83 @@ def test_check_token(mock_tokenmanager):
     assert result == {'valid': ANY, 'policies': ANY}
 
 
+def _orm_manager_mock(instance):
+    """Return a MagicMock whose context-manager protocol yields `instance`."""
+    manager = MagicMock()
+    manager.return_value.__enter__.return_value = instance
+    return manager
+
+
+@patch('api.authentication.optimize_resources', return_value={})
+def test_check_token_runas_revoked_at_user_level(mock_optimize):
+    """A run_as user with no statically-linked roles must be validated against the token blacklist.
+
+    This covers logout and user-level revocation, whose blacklist entry is keyed on the user and
+    was never consulted when the per-role loop iterated over an empty user_roles list.
+    """
+    am = MagicMock()
+    am.get_user.return_value = {'id': 101, 'username': 'rauser'}
+    am.user_allow_run_as.return_value = True
+    urm = MagicMock()
+    urm.get_all_roles_from_user.return_value = []
+    tm = MagicMock()
+    tm.is_token_valid.return_value = False
+
+    with patch('api.authentication.AuthenticationManager', _orm_manager_mock(am)), \
+            patch('api.authentication.UserRolesManager', _orm_manager_mock(urm)), \
+            patch('api.authentication.TokenManager', _orm_manager_mock(tm)):
+        result = authentication.check_token(username='rauser', roles=tuple([1]), token_nbf_time=100,
+                                            run_as=True, origin_node_type='master')
+
+    assert result == {'valid': False}
+    tm.is_token_valid.assert_any_call(user_id=101, token_nbf_time=100, run_as=True)
+
+
+@patch('api.authentication.optimize_resources', return_value={})
+def test_check_token_runas_revoked_dynamic_role(mock_optimize):
+    """Revoking a dynamically-granted role must invalidate a run_as token carrying it.
+
+    The role travels in the token (roles) and is absent from user_roles, so the validity check
+    must be driven by the token's roles, not only the statically-linked ones.
+    """
+    am = MagicMock()
+    am.get_user.return_value = {'id': 101, 'username': 'rauser'}
+    am.user_allow_run_as.return_value = True
+    urm = MagicMock()
+    urm.get_all_roles_from_user.return_value = []
+    tm = MagicMock()
+    tm.is_token_valid.side_effect = lambda **kwargs: kwargs.get('role_id') != 1
+
+    with patch('api.authentication.AuthenticationManager', _orm_manager_mock(am)), \
+            patch('api.authentication.UserRolesManager', _orm_manager_mock(urm)), \
+            patch('api.authentication.TokenManager', _orm_manager_mock(tm)):
+        result = authentication.check_token(username='rauser', roles=tuple([1]), token_nbf_time=200,
+                                            run_as=True, origin_node_type='master')
+
+    assert result == {'valid': False}
+    tm.is_token_valid.assert_any_call(role_id=1, user_id=101, token_nbf_time=200, run_as=True)
+
+
+@patch('api.authentication.optimize_resources', return_value={'policy': 'test'})
+def test_check_token_runas_valid(mock_optimize):
+    """A run_as user with a non-revoked token remains valid."""
+    am = MagicMock()
+    am.get_user.return_value = {'id': 101, 'username': 'rauser'}
+    am.user_allow_run_as.return_value = True
+    urm = MagicMock()
+    urm.get_all_roles_from_user.return_value = []
+    tm = MagicMock()
+    tm.is_token_valid.return_value = True
+
+    with patch('api.authentication.AuthenticationManager', _orm_manager_mock(am)), \
+            patch('api.authentication.UserRolesManager', _orm_manager_mock(urm)), \
+            patch('api.authentication.TokenManager', _orm_manager_mock(tm)):
+        result = authentication.check_token(username='rauser', roles=tuple([1]), token_nbf_time=300,
+                                            run_as=True, origin_node_type='master')
+
+    assert result == {'valid': True, 'policies': {'policy': 'test'}}
+
+
 @pytest.mark.asyncio
 @patch('api.authentication.jwt.decode')
 @patch('api.authentication.generate_keypair', return_value=('-----BEGIN PRIVATE KEY-----',

--- a/framework/wazuh/cdb_list.py
+++ b/framework/wazuh/cdb_list.py
@@ -61,8 +61,10 @@ def get_lists(filename: list = None, offset: int = 0, limit: int = common.DATABA
 
     lists = list()
     for path in get_filenames_paths(filename):
-        # Only files which exist and whose dirname is the one specified by the user (if any), will be added to response.
-        if not any([dirname is not None and path_dirname(path) != dirname, not isfile(path)]):
+        # Only files which exist, stay inside the lists directory and whose dirname is the one specified by the
+        # user (if any), will be added to response.
+        if not any([dirname is not None and path_dirname(path) != dirname, not isfile(path),
+                    commonpath([realpath(path), realpath(common.USER_LISTS_PATH)]) != realpath(common.USER_LISTS_PATH)]):
             lists.append({'items': [{'key': key, 'value': value} for key, value in get_list_from_file(path).items()],
                           'relative_dirname': path_dirname(to_relative_path(path)),
                           'filename': split(to_relative_path(path))[1]})
@@ -189,6 +191,9 @@ def delete_list_file(filename: list) -> AffectedItemsWazuhResult:
     full_path = join(common.USER_LISTS_PATH, filename[0])
 
     try:
+        # Ensure the resolved path stays inside the lists directory.
+        if commonpath([realpath(full_path), realpath(common.USER_LISTS_PATH)]) != realpath(common.USER_LISTS_PATH):
+            raise WazuhError(1804, extra_message=f"{filename[0]} is outside the lists directory")
         delete_list(to_relative_path(full_path))
 
         result.affected_items.append(to_relative_path(full_path))

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -712,6 +712,29 @@ def test_plain_dict_to_nested_dict():
      {'localfile': {'allow': False, 'exceptions': []},
       'wodle_command': {'allow': False, 'exceptions': []}},
      False),
+
+    # Test case where the command log_format tag name is uppercased with a lowercase decoy (should raise when not allowed)
+    ("<ossec_config><localfile><log_format>syslog</log_format><LOG_FORMAT>full_command</LOG_FORMAT>"
+     "<command>id</command></localfile></ossec_config>",
+     "<ossec_config><localfile><log_format>syslog</log_format><location>/var/log/test.log</location></localfile></ossec_config>",
+     {'localfile': {'allow': False, 'exceptions': []},
+      'wodle_command': {'allow': True, 'exceptions': []}},
+     True),
+
+    # Test case where the command log_format tag name uses mixed case (should raise when not allowed)
+    ("<ossec_config><localfile><log_format>syslog</log_format><Log_Format>command</Log_Format>"
+     "<command>echo test</command></localfile></ossec_config>",
+     "<ossec_config><localfile><log_format>syslog</log_format><location>/var/log/test.log</location></localfile></ossec_config>",
+     {'localfile': {'allow': False, 'exceptions': []},
+      'wodle_command': {'allow': True, 'exceptions': []}},
+     True),
+
+    # Test case where the wodle command tag name is uppercased (should raise when not allowed)
+    ('<ossec_config><wodle name="command"><COMMAND>ls -la</COMMAND></wodle></ossec_config>',
+     '<ossec_config><wodle name="command"><tag>value</tag></wodle></ossec_config>',
+     {'localfile': {'allow': True, 'exceptions': []},
+      'wodle_command': {'allow': False, 'exceptions': []}},
+     True),
 ])
 def test_check_remote_commands(new_conf, original_conf, allow_config, should_raise):
     """Tests check_remote_commands with different remote command inputs."""

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -970,7 +970,7 @@ def xml_to_dict(root, section_path: list):
 
         if len(element):
             for child in element:
-                result[child.tag] = element_to_dict(child)
+                result[child.tag.lower()] = element_to_dict(child)
         else:
             result = {
                 'attrib': element.attrib,

--- a/framework/wazuh/tests/test_cdb_list.py
+++ b/framework/wazuh/tests/test_cdb_list.py
@@ -422,3 +422,38 @@ def test_delete_list_file_ko():
     with patch('wazuh.cdb_list.common.USER_LISTS_PATH', new=DATA_PATH):
         result = delete_list_file(['test_file'])
         assert result.render()['data']['failed_items'][0]['error']['code'] == 1906
+
+
+@patch('wazuh.cdb_list.common.USER_LISTS_PATH', new=DATA_PATH)
+def test_get_lists_outside_lists_path():
+    """Check that a file resolving outside the lists directory is not read nor returned."""
+    outside_file = os.path.join(DATA_PATH, os.pardir, 'outside_list')
+    try:
+        with open(outside_file, 'w') as f:
+            f.write('key:value\n')
+        with patch('wazuh.cdb_list.get_filenames_paths', return_value=[outside_file]):
+            with patch('wazuh.cdb_list.get_list_from_file') as mock_get_list_from_file:
+                result = get_lists(filename=['outside_list'])
+                assert isinstance(result, AffectedItemsWazuhResult)
+                assert result.total_affected_items == 0
+                assert result.affected_items == []
+                mock_get_list_from_file.assert_not_called()
+    finally:
+        try:
+            os.remove(outside_file)
+        except Exception:
+            pass
+
+
+@pytest.mark.parametrize("filename", [
+    '../../../../../../etc/passwd',
+    os.path.join(DATA_PATH, os.pardir, 'rbac.db'),
+])
+@patch('wazuh.cdb_list.common.USER_LISTS_PATH', new=DATA_PATH)
+@patch('wazuh.cdb_list.delete_list')
+def test_delete_list_file_path_traversal(mock_delete_list, filename):
+    """Check that a filename resolving outside the lists directory is rejected and not deleted."""
+    result = delete_list_file([filename])
+    assert isinstance(result, AffectedItemsWazuhResult)
+    assert result.render()['data']['failed_items'][0]['error']['code'] == 1804
+    mock_delete_list.assert_not_called()

--- a/src/data_provider/src/osinfo/sysOsParsers.cpp
+++ b/src/data_provider/src/osinfo/sysOsParsers.cpp
@@ -457,6 +457,8 @@ bool MacOsParser::parseUname(const std::string& in, nlohmann::json& output)
         {"22", "Ventura"},
         {"23", "Sonoma"},
         {"24", "Sequoia"},
+        {"25", "Tahoe"},
+        {"26", "Golden Gate"},
     };
     constexpr auto PATTERN_MATCH{"[0-9]+"};
     std::string match;

--- a/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
+++ b/src/data_provider/tests/sysInfo/sysInfoParsers_test.cpp
@@ -614,6 +614,72 @@ TEST_F(SysInfoParsersTest, MacOS)
     EXPECT_EQ("6", output["os_patch"]);
 }
 
+TEST_F(SysInfoParsersTest, MacOSTahoeCodename)
+{
+    constexpr auto MACOS_SW_VERSION
+    {
+        R"(
+        ProductName:	macOS
+        ProductVersion:	26.5.1
+        BuildVersion:	25F74
+        )"
+    };
+    constexpr auto MACOS_UNAME
+    {
+        "25.5.0"
+    };
+    nlohmann::json output;
+    MacOsParser parser;
+    EXPECT_TRUE(parser.parseSwVersion(MACOS_SW_VERSION, output));
+    EXPECT_TRUE(parser.parseUname(MACOS_UNAME, output));
+    EXPECT_EQ("26.5.1", output["os_version"]);
+    EXPECT_EQ("Tahoe", output["os_codename"]);
+}
+
+TEST_F(SysInfoParsersTest, MacOSGoldenGateCodename)
+{
+    constexpr auto MACOS_SW_VERSION
+    {
+        R"(
+        ProductName:	macOS
+        ProductVersion:	27.0
+        BuildVersion:	26A5000a
+        )"
+    };
+    constexpr auto MACOS_UNAME
+    {
+        "26.0.0"
+    };
+    nlohmann::json output;
+    MacOsParser parser;
+    EXPECT_TRUE(parser.parseSwVersion(MACOS_SW_VERSION, output));
+    EXPECT_TRUE(parser.parseUname(MACOS_UNAME, output));
+    EXPECT_EQ("27.0", output["os_version"]);
+    EXPECT_EQ("Golden Gate", output["os_codename"]);
+}
+
+TEST_F(SysInfoParsersTest, MacOSUnmappedCodenameIsEmpty)
+{
+    constexpr auto MACOS_SW_VERSION
+    {
+        R"(
+        ProductName:	macOS
+        ProductVersion:	28.0
+        BuildVersion:	27A100
+        )"
+    };
+    constexpr auto MACOS_UNAME
+    {
+        "27.0.0"
+    };
+    nlohmann::json output;
+    MacOsParser parser;
+    EXPECT_TRUE(parser.parseSwVersion(MACOS_SW_VERSION, output));
+    EXPECT_TRUE(parser.parseUname(MACOS_UNAME, output));
+    EXPECT_EQ("28.0", output["os_version"]);
+    EXPECT_EQ("", output["os_codename"]);
+}
+
 TEST_F(SysInfoParsersTest, MacOSOsDefaultName)
 {
     constexpr auto MACOS_SW_VERSION

--- a/src/headers/version_op.h
+++ b/src/headers/version_op.h
@@ -37,6 +37,9 @@ typedef struct os_info {
 } os_info;
 
 
+/// Value returned by OSX_ReleaseName() when the Darwin version is not mapped to a release name.
+#define OSX_UNKNOWN_RELEASE_NAME "Unknown"
+
 /**
  * @brief Get the macOS release name corresponding to a version number.
  *

--- a/src/shared/version_op.c
+++ b/src/shared/version_op.c
@@ -393,6 +393,8 @@ const char *OSX_ReleaseName(int version) {
     /* 22 */ "Ventura",
     /* 23 */ "Sonoma",
     /* 24 */ "Sequoia",
+    /* 25 */ "Tahoe",
+    /* 26 */ "Golden Gate",
     };
 
     version -= 10;
@@ -400,7 +402,7 @@ const char *OSX_ReleaseName(int version) {
     if (version >= 0 && (unsigned)version < sizeof(R_NAMES) / sizeof(char *)) {
         return R_NAMES[version];
     } else {
-        return "Unknown";
+        return OSX_UNKNOWN_RELEASE_NAME;
     }
 }
 
@@ -788,7 +790,13 @@ os_info *get_unix_version()
                             char *kern = NULL;
                             os_malloc(match_size + 1, kern);
                             snprintf(kern, match_size +1, "%.*s", match_size, buff + match[1].rm_so);
-                            w_strdup(OSX_ReleaseName(atoi(kern)), info->os_codename);
+                            const char *release_name = OSX_ReleaseName(atoi(kern));
+                            /* Leave the codename unset for Darwin versions that are not in the release
+                             * name table yet, so the reported version stays clean instead of showing
+                             * "<version> (Unknown)" on every macOS release newer than the table. */
+                            if (strcmp(release_name, OSX_UNKNOWN_RELEASE_NAME) != 0) {
+                                w_strdup(release_name, info->os_codename);
+                            }
                             free(kern);
                         }
                         pclose(cmd_output_ver);

--- a/src/unit_tests/shared/test_version_op.c
+++ b/src/unit_tests/shared/test_version_op.c
@@ -1263,6 +1263,133 @@ void test_get_unix_version_fail_os_release_uname_darwin(void **state)
     assert_string_equal(ret->sysname, "Linux");
 }
 
+/* Feed the mocks needed to reach the macOS branch of get_unix_version(), so the caller only has to
+ * provide the sw_vers product version and the uname -r output under test. */
+static void expect_darwin_version_calls(const char *product_version, const char *kernel_release)
+{
+    static const char *RELEASE_FILES[] = {
+        "/etc/os-release", "/usr/lib/os-release", "/etc/centos-release", "/etc/fedora-release",
+        "/etc/redhat-release", "/etc/arch-release", "/etc/gentoo-release", "/etc/SuSE-release",
+        "/etc/lsb-release", "/etc/debian_version", "/etc/slackware-version", "/etc/alpine-release",
+    };
+
+    for (unsigned i = 0; i < sizeof(RELEASE_FILES) / sizeof(char *); i++) {
+        expect_string(__wrap_wfopen, path, RELEASE_FILES[i]);
+        expect_string(__wrap_wfopen, mode, "r");
+        will_return(__wrap_wfopen, 0);
+    }
+
+    // uname
+    char *uname_path = NULL;
+    os_strdup("/path/to/uname", uname_path);
+    expect_string(__wrap_get_binary_path, command, "uname");
+    will_return(__wrap_get_binary_path, uname_path);
+    will_return(__wrap_get_binary_path, 0);
+
+    expect_string(__wrap_popen, command, "/path/to/uname");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "Darwin\n");
+
+    // system_profiler SPSoftwareDataType
+    char *system_profiler_path = NULL;
+    os_strdup("/path/to/system_profiler", system_profiler_path);
+    expect_string(__wrap_get_binary_path, command, "system_profiler");
+    will_return(__wrap_get_binary_path, system_profiler_path);
+    will_return(__wrap_get_binary_path, 0);
+
+    expect_string(__wrap_popen, command, "/path/to/system_profiler SPSoftwareDataType");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "Software:\n");
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "    System Version: macOS 26.5.1 (25F74)\n");
+
+    expect_value(__wrap_pclose, __stream, 1);
+    will_return(__wrap_pclose, 1);
+
+    // sw_vers -productVersion
+    char *sw_vers_path = NULL;
+    os_strdup("/path/to/sw_vers", sw_vers_path);
+    expect_string(__wrap_get_binary_path, command, "sw_vers");
+    will_return(__wrap_get_binary_path, sw_vers_path);
+    will_return(__wrap_get_binary_path, 0);
+
+    expect_string(__wrap_popen, command, "/path/to/sw_vers -productVersion");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, product_version);
+
+    expect_value(__wrap_pclose, __stream, 1);
+    will_return(__wrap_pclose, 1);
+
+    // sw_vers -buildVersion
+    expect_string(__wrap_popen, command, "/path/to/sw_vers -buildVersion");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, "25F74\n");
+
+    expect_value(__wrap_pclose, __stream, 1);
+    will_return(__wrap_pclose, 1);
+
+    // uname -r
+    expect_string(__wrap_popen, command, "/path/to/uname -r");
+    expect_string(__wrap_popen, type, "r");
+    will_return(__wrap_popen, 1);
+
+    expect_value(__wrap_fgets, __stream, 1);
+    will_return(__wrap_fgets, kernel_release);
+
+    expect_value(__wrap_pclose, __stream, 1);
+    will_return(__wrap_pclose, 1);
+
+    expect_value(__wrap_pclose, __stream, 1);
+    will_return(__wrap_pclose, 1);
+}
+
+void test_get_unix_version_darwin_mapped_codename(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // macOS 26 Tahoe runs Darwin 25
+    expect_darwin_version_calls("26.5.1\n", "25.5.0\n");
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_platform, "darwin");
+    assert_string_equal(ret->os_codename, "Tahoe");
+    assert_string_equal(ret->os_version, "26.5.1 (Tahoe)");
+}
+
+void test_get_unix_version_darwin_unmapped_codename(void **state)
+{
+    (void) state;
+    os_info *ret;
+
+    // Darwin version newer than the release name table: no codename, and no "(Unknown)" suffix
+    expect_darwin_version_calls("28.0\n", "27.0.0\n");
+
+    ret = get_unix_version();
+    *state = ret;
+
+    assert_non_null(ret);
+    assert_string_equal(ret->os_platform, "darwin");
+    assert_null(ret->os_codename);
+    assert_string_equal(ret->os_version, "28.0");
+}
+
 void test_get_unix_version_fail_os_release_uname_darwin_no_key(void **state)
 {
     (void) state;
@@ -2185,7 +2312,9 @@ void test_OSX_ReleaseName(void **state) {
     assert_string_equal(OSX_ReleaseName(22), "Ventura");
     assert_string_equal(OSX_ReleaseName(23), "Sonoma");
     assert_string_equal(OSX_ReleaseName(24), "Sequoia");
-    assert_string_equal(OSX_ReleaseName(25), "Unknown");
+    assert_string_equal(OSX_ReleaseName(25), "Tahoe");
+    assert_string_equal(OSX_ReleaseName(26), "Golden Gate");
+    assert_string_equal(OSX_ReleaseName(27), "Unknown");
 }
 
 #endif
@@ -2381,6 +2510,8 @@ int main(void) {
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_alpine, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_darwin, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_darwin_no_key, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_darwin_mapped_codename, delete_os_info),
+            cmocka_unit_test_teardown(test_get_unix_version_darwin_unmapped_codename, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_sunos, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_sunos_10_scenario_one, delete_os_info),
             cmocka_unit_test_teardown(test_get_unix_version_fail_os_release_uname_sunos_10_scenario_two, delete_os_info),

--- a/tests/integration/test_aws/conftest.py
+++ b/tests/integration/test_aws/conftest.py
@@ -46,6 +46,26 @@ _PERMANENT_SEED_KEYS = frozenset({
 _PERMANENT_SEED_FLOW_LOG_IDS = frozenset({'fl-0754d951c16f517fa'})
 
 
+def _record_uploaded_key(key):
+    """Append an uploaded key to the cleanup manifest, if one is configured.
+
+    pytest teardown only deletes the keys of its own run and only runs after 'yield', so a hard-cancelled
+    CI job (e.g. a new push cancelling the in-flight run) leaves the already-uploaded files as orphans.
+    Recording every key here, at upload time, lets a CI step with 'if: always()' delete them even when the
+    job is cancelled before teardown. The manifest path comes from AWS_IT_CLEANUP_MANIFEST; when it is not
+    set (e.g. local runs) this is a no-op and normal teardown still applies.
+    """
+    manifest = os.environ.get('AWS_IT_CLEANUP_MANIFEST')
+    if not manifest:
+        return
+    try:
+        with open(manifest, 'a') as handle:
+            handle.write(f"{key}\n")
+            handle.flush()
+    except OSError as exc:
+        logger.warning("Could not record uploaded key '%s' to manifest '%s': %s", key, manifest, exc)
+
+
 def _safe_delete_key(key, bucket_name, s3_client):
     """Delete one key from the shared bucket; log failures; refuse to touch permanent seeds."""
     if key in _PERMANENT_SEED_KEYS or any(fid in key for fid in _PERMANENT_SEED_FLOW_LOG_IDS):
@@ -61,14 +81,22 @@ def _safe_delete_key(key, bucket_name, s3_client):
 
 
 def _assert_prefix_clean(bucket_name, key, s3_client):
-    """Raise RuntimeError at setup time if any unexpected object already occupies the date-level prefix of key.
+    """Raise RuntimeError at setup time if any unexpected object already occupies the exact prefix level of key.
 
     A single list_objects_v2 scoped to the exact prefix catches future seed collisions immediately,
     rather than letting them produce a confusing count mismatch downstream.
+
+    The listing uses Delimiter='/' so it only inspects objects that live DIRECTLY under the prefix,
+    not nested sub-"folders". This matters for flat-layout bucket types (e.g. server_access, whose key
+    is 'test_prefix/<file>'), where key.rsplit('/', 1)[0] collapses to the shared 'test_prefix/' root:
+    without the delimiter the guard would also scan unrelated objects nested deeper under that root
+    (e.g. the load balancers' 'test_prefix/AWSLogs/.../elasticloadbalancing/...') and raise a false
+    positive. Date-partitioned types (cloudtrail, ELB, umbrella, ...) keep their files directly at the
+    date-level prefix, so they are still checked exactly as before.
     """
     prefix = key.rsplit('/', 1)[0] + '/'
     unexpected = [
-        obj.key for obj in s3_client.Bucket(bucket_name).objects.filter(Prefix=prefix)
+        obj.key for obj in s3_client.Bucket(bucket_name).objects.filter(Prefix=prefix, Delimiter='/')
         if obj.key not in _PERMANENT_SEED_KEYS
         and not any(fid in obj.key for fid in _PERMANENT_SEED_FLOW_LOG_IDS)
         and not obj.key.endswith('/')  # skip S3 folder-marker objects (empty keys ending with /)
@@ -426,6 +454,9 @@ def manage_bucket_files(metadata: dict, s3_client, ec2_client):
                 _assert_prefix_clean(bucket_name, key, s3_client)
 
             for data, key in files_to_upload:
+                # Record the key BEFORE uploading so a cancelled job can still clean it up.
+                _record_uploaded_key(key)
+
                 # Upload file to bucket
                 upload_bucket_file(bucket_name=bucket_name,
                                    data=data,

--- a/tests/integration/test_aws/conftest.py
+++ b/tests/integration/test_aws/conftest.py
@@ -66,6 +66,17 @@ def _record_uploaded_key(key):
         logger.warning("Could not record uploaded key '%s' to manifest '%s': %s", key, manifest, exc)
 
 
+@pytest.fixture
+def record_uploaded_key():
+    """Expose _record_uploaded_key to test bodies that upload objects themselves.
+
+    manage_bucket_files records the keys it uploads, but a few tests upload directly in their body
+    (e.g. test_bucket_multiple_calls). Those must register their key too, otherwise a hard cancel
+    during the test would orphan the object - the exact case this cleanup targets.
+    """
+    return _record_uploaded_key
+
+
 def _safe_delete_key(key, bucket_name, s3_client):
     """Delete one key from the shared bucket; log failures; refuse to touch permanent seeds."""
     if key in _PERMANENT_SEED_KEYS or any(fid in key for fid in _PERMANENT_SEED_FLOW_LOG_IDS):
@@ -87,14 +98,20 @@ def _assert_prefix_clean(bucket_name, key, s3_client):
     rather than letting them produce a confusing count mismatch downstream.
 
     The listing uses Delimiter='/' so it only inspects objects that live DIRECTLY under the prefix,
-    not nested sub-"folders". This matters for flat-layout bucket types (e.g. server_access, whose key
-    is 'test_prefix/<file>'), where key.rsplit('/', 1)[0] collapses to the shared 'test_prefix/' root:
+    not nested sub-"folders". This matters for bucket types whose key is '<path>/<file>' (e.g.
+    server_access configured with a path, giving 'test_prefix/<file>'), where key.rsplit('/', 1)[0]
+    collapses to the shared '<path>/' root:
     without the delimiter the guard would also scan unrelated objects nested deeper under that root
     (e.g. the load balancers' 'test_prefix/AWSLogs/.../elasticloadbalancing/...') and raise a false
     positive. Date-partitioned types (cloudtrail, ELB, umbrella, ...) keep their files directly at the
     date-level prefix, so they are still checked exactly as before.
+
+    For flat, root-level keys (a pathless bucket type, e.g. server_access with no path, whose key has
+    no '/') the prefix is '' so the listing scopes to root-level objects only (Prefix='' + Delimiter='/'
+    returns just the bucket root, and the nested permanent seeds are excluded). Without this, the prefix
+    would be '<filename>/' - a prefix nothing matches - and a root-level orphan would go undetected.
     """
-    prefix = key.rsplit('/', 1)[0] + '/'
+    prefix = key.rsplit('/', 1)[0] + '/' if '/' in key else ''
     unexpected = [
         obj.key for obj in s3_client.Bucket(bucket_name).objects.filter(Prefix=prefix, Delimiter='/')
         if obj.key not in _PERMANENT_SEED_KEYS

--- a/tests/integration/test_aws/event_monitor.py
+++ b/tests/integration/test_aws/event_monitor.py
@@ -36,6 +36,12 @@ def make_aws_callback(pattern, prefix=''):
     return lambda line: regex.match(line)
 
 
+# CLI arguments whose value the module wraps in double quotes via wm_aws_add_quoted_arg()
+# (src/wazuh_modules/src/wm_aws.c) so the value survives the word-splitting wm_exec() performs.
+_QUOTED_ARGS = frozenset({'--aws_profile', '--aws_account_alias', '--trail_prefix',
+                          '--trail_suffix', '--discard-field', '--discard-regex'})
+
+
 def callback_detect_aws_module_called(parameters):
     """Detect if aws module was called with correct parameters.
 
@@ -45,13 +51,24 @@ def callback_detect_aws_module_called(parameters):
     Returns:
         Callable: Callback to match the line.
     """
-    pattern = fr'{AWS_MODULE_STARTED_PARAMETRIZED}{" ".join(parameters)}\n*'
+    # Normalise the EXPECTED side so the value of every _QUOTED_ARGS argument carries exactly one pair
+    # of double quotes (test cases are inconsistent: some already include the quotes, others don't).
+    # The logged line is NOT altered, so the assertion still requires the module to actually quote
+    # those values - a quoting regression (dropping wm_aws_add_quoted_arg) makes this fail instead of
+    # silently passing. re.escape keeps the match literal, since some values (e.g. discard_regex) are
+    # themselves regexes and must not be interpreted as such.
+    expected = []
+    quote_next = False
+    for token in parameters:
+        if quote_next:
+            token = '"{}"'.format(token.strip('"'))
+            quote_next = False
+        else:
+            quote_next = token in _QUOTED_ARGS
+        expected.append(token)
+    pattern = fr'{AWS_MODULE_STARTED_PARAMETRIZED}{re.escape(" ".join(expected))}\n*'
     regex = re.compile(pattern)
-    # The module wraps some CLI arguments in double quotes (e.g. --trail_prefix "value") so their
-    # values survive the word-splitting wm_exec() performs; the expected parameters are unquoted,
-    # so strip the quotes from the logged command before matching. Backward compatible: lines
-    # without quotes are unchanged.
-    return lambda line: regex.match(line.replace('"', ''))
+    return lambda line: regex.match(line)
 
 
 def callback_detect_aws_error_for_missing_type(line):

--- a/tests/integration/test_aws/event_monitor.py
+++ b/tests/integration/test_aws/event_monitor.py
@@ -47,7 +47,11 @@ def callback_detect_aws_module_called(parameters):
     """
     pattern = fr'{AWS_MODULE_STARTED_PARAMETRIZED}{" ".join(parameters)}\n*'
     regex = re.compile(pattern)
-    return lambda line: regex.match(line)
+    # The module wraps some CLI arguments in double quotes (e.g. --trail_prefix "value") so their
+    # values survive the word-splitting wm_exec() performs; the expected parameters are unquoted,
+    # so strip the quotes from the logged command before matching. Backward compatible: lines
+    # without quotes are unchanged.
+    return lambda line: regex.match(line.replace('"', ''))
 
 
 def callback_detect_aws_error_for_missing_type(line):

--- a/tests/integration/test_aws/test_only_logs_after.py
+++ b/tests/integration/test_aws/test_only_logs_after.py
@@ -710,7 +710,7 @@ configurator.configure_test(cases_file='cases_bucket_multiple_calls.yaml')
                          ids=configurator.cases_ids)
 def test_bucket_multiple_calls(
         metadata, mark_cases_as_skipped, clean_s3_cloudtrail_db, s3_client, create_test_bucket, manage_bucket_files,
-        load_wazuh_basic_configuration, restart_wazuh_function
+        load_wazuh_basic_configuration, restart_wazuh_function, record_uploaded_key
 ):
     """
     description: Call the AWS module multiple times with different only_logs_after values.
@@ -882,6 +882,9 @@ def test_bucket_multiple_calls(
                                   suffix='',
                                   date='')
     metadata['filename'] = key
+
+    # Record the key before uploading so a hard cancel during this test still cleans it up.
+    record_uploaded_key(key)
 
     upload_bucket_file(bucket_name=bucket_name,
                        data=data,


### PR DESCRIPTION
## Description

Scheduled weekly upward merge. Part of #38255 (Week #32).

Merges branch `4.14.8` into `4.14.9`.

## Proposed Changes

- Merge `origin/4.14.8` into `4.14.9`.

### Results and Evidence

Merged with no conflicts. Incoming changes (25 commits): macOS 26/27 codename reporting fix, check_files glob matching fix, run_as token blacklist validation, cluster-callable CDB list path validation, case-insensitive remote command validation, AWS IT artifact cleanup and quoted-args fixes, CI draft-PR skip for 4.x workflows, and cmocka mirror fallback. Version metadata unchanged (4.14.9).

```
$ git merge origin/4.14.8        # Automatic merge went well
$ git rev-list --count HEAD..origin/4.14.8   -> 0
$ git rev-list --count HEAD..origin/4.14.9   -> 0
$ grep version VERSION.json      -> 4.14.9
```

### Artifacts Affected

- Agent/manager binaries (version_op, sysinfo os parsers) and API framework.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
