### PR TITLE
Release Windows hotfixes' per-thread COM context on the calling thread instead of at thread exit

### DIFF
--- a/src/data_provider/include/sysInfo.hpp
+++ b/src/data_provider/include/sysInfo.hpp
@@ -51,6 +51,7 @@ class EXPORTED SysInfo: public ISysInfo
         nlohmann::json users();
         nlohmann::json services();
         nlohmann::json browserExtensions();
+        void releaseThreadResources();
     private:
         virtual nlohmann::json getHardware() const;
         virtual nlohmann::json getPackages() const;

--- a/src/data_provider/include/sysInfoInterface.h
+++ b/src/data_provider/include/sysInfoInterface.h
@@ -35,6 +35,12 @@ class ISysInfo
         virtual void packages(std::function<void(nlohmann::json&)>) = 0;
         virtual void processes(std::function<void(nlohmann::json&)>) = 0;
 
+        // Releases any per-thread resources allocated on the calling thread, on the
+        // calling thread, before that thread exits. Must be called explicitly instead of
+        // relying on automatic (e.g. thread_local) teardown, which is not guaranteed to
+        // run correctly for a module loaded dynamically at runtime. Windows-only in
+        // practice (releases hotfixes()' per-thread COM context); a no-op elsewhere.
+        virtual void releaseThreadResources() = 0;
 };
 
 #endif //_SYS_INFO_INTERFACE

--- a/src/data_provider/src/sysInfo.cpp
+++ b/src/data_provider/src/sysInfo.cpp
@@ -77,6 +77,14 @@ nlohmann::json SysInfo::browserExtensions()
     return getBrowserExtensions();
 }
 
+#ifndef _WIN32
+void SysInfo::releaseThreadResources()
+{
+    // No per-thread resources to release outside Windows -- sysInfoWin.cpp provides
+    // the real implementation for _WIN32 builds.
+}
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -1000,14 +1000,24 @@ void SysInfo::getPackages(std::function<void(nlohmann::json&)> callback) const
 
 namespace
 {
-    /// @brief RAII per-thread COM initializer for the syscollector hotfixes collector.
+    /// @brief Per-thread COM initializer for the syscollector hotfixes collector.
     ///
     /// getHotfixes() runs on syscollector's single long-lived scan thread, so COM is
     /// initialized once per thread (issue #37655) instead of on every scan cycle: a
     /// per-cycle CoInitializeEx/CoUninitialize churns the COM/RPC infrastructure (notably
-    /// the Windows Update Agent) and leaks ~1 anonymous Event handle per cycle. The
-    /// destructor runs when the thread exits (thread_local storage), balancing the
-    /// CoInitializeEx we own.
+    /// the Windows Update Agent) and leaks ~1 anonymous Event handle per cycle.
+    ///
+    /// This is deliberately *not* an RAII guard: release() must be called explicitly, on
+    /// this thread, before the thread exits -- see SysInfo::releaseThreadResources().
+    /// sysinfo.dll is loaded via LoadLibrary rather than linked statically
+    /// (src/shared/src/sym_load.c), and thread_local destructors are not reliably
+    /// invoked with a valid `this` by the OS/MinGW-emutls at thread exit for a
+    /// dynamically-loaded module. Calling CoUninitialize() from ~ThreadComContext() used
+    /// to fault with a null `this` inside ntdll's own thread-exit teardown, taking the
+    /// whole process down on shutdown once nothing raced past that fault anymore. There
+    /// is deliberately no user-declared destructor here, so this type stays trivially
+    /// destructible: if release() is ever skipped on some exit path, the worst case is a
+    /// leaked COM reference for that thread's remaining lifetime, not a crash.
     class ThreadComContext final
     {
         public:
@@ -1025,7 +1035,7 @@ namespace
 
                     if (SUCCEEDED(hres))
                     {
-                        // We added the reference, so we must balance it on thread exit.
+                        // We added the reference, so we must balance it in release().
                         m_usable = true;
                         m_ownsInit = true;
                     }
@@ -1043,19 +1053,38 @@ namespace
                 return m_usable;
             }
 
-            ~ThreadComContext()
+            /// @brief Balances the CoInitializeEx we own, if any. Must be called
+            /// explicitly on this same thread before the thread exits. Safe to call
+            /// more than once, and safe to skip.
+            void release()
             {
                 if (m_ownsInit)
                 {
                     CoUninitialize();
+                    m_ownsInit = false;
                 }
+
+                m_usable = false;
             }
 
         private:
             bool m_usable {false};
             bool m_ownsInit {false};
     };
+
+    // One instance per thread; in practice there is exactly one (syscollector's own
+    // long-lived Windows scan thread). Deliberately not `static` inside getHotfixes()
+    // any more so releaseThreadResources() can reach the same instance explicitly.
+    thread_local ThreadComContext g_hotfixComContext; // NOLINT(cert-err58-cpp)
 } // namespace
+
+void SysInfo::releaseThreadResources()
+{
+    // Explicit, same-thread replacement for ~ThreadComContext() -- call this from the
+    // syscollector worker thread before it exits, never rely on automatic thread_local
+    // teardown for this object. See the ThreadComContext comment above.
+    g_hotfixComContext.release();
+}
 
 nlohmann::json SysInfo::getHotfixes() const
 {
@@ -1063,13 +1092,8 @@ nlohmann::json SysInfo::getHotfixes() const
     std::ostringstream oss;
     ComHelper comHelper;
 
-    // Initialize COM once per thread instead of per scan cycle (issue #37655). The RAII
-    // guard initializes COM once, retries on transient failure, tolerates COM already
-    // being initialized in another apartment, and balances CoUninitialize when the
-    // collection thread exits.
-    static thread_local ThreadComContext comContext;
-
-    if (comContext.ensureInitialized())
+    // Initialize COM once per thread instead of per scan cycle (issue #37655).
+    if (g_hotfixComContext.ensureInitialized())
     {
         try
         {

--- a/src/data_provider/tests/mocks/mock_sysinfo.hpp
+++ b/src/data_provider/tests/mocks/mock_sysinfo.hpp
@@ -22,4 +22,5 @@ class MockSysInfo : public ISysInfo
         MOCK_METHOD(nlohmann::json, browserExtensions, (), (override));
         MOCK_METHOD(void, packages, (std::function<void(nlohmann::json&)>), (override));
         MOCK_METHOD(void, processes, (std::function<void(nlohmann::json&)>), (override));
+        MOCK_METHOD(void, releaseThreadResources, (), (override));
 };

--- a/src/data_provider/tests/sysInfo/sysInfoWin_stub.cpp
+++ b/src/data_provider/tests/sysInfo/sysInfoWin_stub.cpp
@@ -1,0 +1,22 @@
+/*
+ * Wazuh SYSINFO
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "sysInfo.hpp"
+
+// sysinfo_unit_test only compiles sysInfo.cpp (see CMakeLists.txt), not sysInfoWin.cpp,
+// so on Windows it never gets the real implementation of releaseThreadResources() --
+// and sysInfo.cpp's own fallback is guarded out under _WIN32 to avoid colliding with
+// that real one in a full agent build. This stub plugs that gap for this test binary
+// only. Guarded so it stays an empty translation unit on non-Windows platforms, where
+// this directory's *.cpp glob (see CMakeLists.txt) would otherwise pick it up too and
+// collide with sysInfo.cpp's own fallback definition.
+#ifdef _WIN32
+void SysInfo::releaseThreadResources() {}
+#endif

--- a/src/wazuh_modules/syscollector/include/syscollector.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector.hpp
@@ -88,6 +88,15 @@ class EXPORTED Syscollector final
         void start();
         void quiesce();
         void releaseResources();
+
+        /**
+         * @brief Signal stop, then release resources synchronously if the scan isn't busy.
+         *
+         * Must be called from the same thread that called start(), since releaseResources()
+         * releases per-thread resources (e.g. the Windows hotfixes() COM context) on the
+         * calling thread. Calling this from a different thread releases the wrong thread's
+         * resources and leaves start()'s thread never explicitly released.
+         */
         void destroy();
 
         // Sync protocol methods

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -763,6 +763,16 @@ void Syscollector::releaseResources()
     m_spNormalizer.reset();
     m_spSyncProtocol.reset();
     m_spSyncProtocolVD.reset();
+
+    if (m_spInfo)
+    {
+        // Release this thread's per-thread resources (Windows: the hotfixes() COM
+        // context) explicitly, on this thread, before m_spInfo is destroyed and before
+        // this thread exits -- see releaseThreadResources()'s implementation for why
+        // this can no longer be left to automatic thread_local teardown at thread exit.
+        m_spInfo->releaseThreadResources();
+    }
+
     m_spInfo.reset();
 }
 

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -630,9 +630,11 @@ TEST_F(SyscollectorImpTest, noScanOnStart)
 // resources (on Windows: the hotfixes() COM context) on this thread, before m_spInfo is
 // destroyed -- instead of relying on automatic thread_local teardown at thread exit,
 // which used to fault with a null `this` inside sysinfo.dll every time the syscollector
-// worker thread exited. destroy() calls releaseResources() internally, so this exercises
-// the exact call path wm_sys_main() takes on Windows.
-TEST_F(SyscollectorImpTest, destroyReleasesSysInfoThreadResources)
+// worker thread exited. This mirrors the exact call path wm_sys_main() takes: start() and
+// releaseResources() run sequentially on the same worker thread, while quiesce() (the
+// stop signal) is issued from a different, control thread -- so releaseThreadResources()
+// must land on the thread that actually owns the per-thread resources, not the caller's.
+TEST_F(SyscollectorImpTest, releaseResourcesReleasesSysInfoThreadResourcesOnStartThread)
 {
     const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
     EXPECT_CALL(*spInfoWrapper, hardware()).Times(0);
@@ -660,11 +662,17 @@ TEST_F(SyscollectorImpTest, destroyReleasesSysInfoThreadResources)
                                           3600, false);
 
             Syscollector::instance().start();
+
+            // Same-thread sequencing as wm_sys_main(): releaseResources() runs on the
+            // worker thread right after start() returns, before the thread exits.
+            Syscollector::instance().releaseResources();
         }
     };
 
     std::this_thread::sleep_for(std::chrono::seconds{2});
-    Syscollector::instance().destroy();
+
+    // Issued from the test/control thread, like wm_sys_stop() does in production.
+    Syscollector::instance().quiesce();
 
     if (t.joinable())
     {

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -626,6 +626,52 @@ TEST_F(SyscollectorImpTest, noScanOnStart)
     }
 }
 
+// releaseResources() must explicitly release the ISysInfo implementation's per-thread
+// resources (on Windows: the hotfixes() COM context) on this thread, before m_spInfo is
+// destroyed -- instead of relying on automatic thread_local teardown at thread exit,
+// which used to fault with a null `this` inside sysinfo.dll every time the syscollector
+// worker thread exited. destroy() calls releaseResources() internally, so this exercises
+// the exact call path wm_sys_main() takes on Windows.
+TEST_F(SyscollectorImpTest, destroyReleasesSysInfoThreadResources)
+{
+    const auto spInfoWrapper{std::make_shared<MockSysInfo>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, os()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, packages(_)).Times(0);
+    EXPECT_CALL(*spInfoWrapper, networks()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, processes(_)).Times(0);
+    EXPECT_CALL(*spInfoWrapper, ports()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, hotfixes()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, groups()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, users()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, releaseThreadResources()).Times(1);
+
+    std::thread t
+    {
+        [&spInfoWrapper]()
+        {
+            Syscollector::instance().init(spInfoWrapper,
+                                          reportFunction,
+                                          persistFunction,
+                                          logFunction,
+                                          SYSCOLLECTOR_DB_PATH,
+                                          "",
+                                          "",
+                                          3600, false);
+
+            Syscollector::instance().start();
+        }
+    };
+
+    std::this_thread::sleep_for(std::chrono::seconds{2});
+    Syscollector::instance().destroy();
+
+    if (t.joinable())
+    {
+        t.join();
+    }
+}
+
 TEST_F(SyscollectorImpTest, noHardware)
 {
     const auto spInfoWrapper{std::make_shared<MockSysInfo>()};

--- a/src/wazuh_modules/syscollector/testtool/main.cpp
+++ b/src/wazuh_modules/syscollector/testtool/main.cpp
@@ -100,7 +100,12 @@ int main(int argc, const char* argv[])
                     std::this_thread::sleep_for(std::chrono::seconds(sleepTime));
                 }
 
-                Syscollector::instance().destroy();
+                // Only signal stop from this thread. releaseResources() must run on the
+                // same thread that called start() (below), since it releases per-thread
+                // resources -- e.g. Windows' hotfixes() COM context -- on the calling
+                // thread. Calling destroy() here would release the wrong thread's
+                // resources; see Syscollector::destroy()'s documented contract.
+                Syscollector::instance().quiesce();
             }
         };
 


### PR DESCRIPTION
## Description

On Windows, every agent service stop crashed with an access violation in `sysinfo.dll` (`0xc0000005` at a constant `+0xca90` offset) and failed with `ERROR_BROKEN_PIPE (109)` — the SCM losing the process before it could report `SERVICE_STOPPED`. Live reproduction plus a debugger session against the crash dump traced this to `ThreadComContext` (`src/data_provider/src/sysInfoWin.cpp`), a `thread_local` object with a non-trivial destructor that calls `CoUninitialize()`, declared inside `sysinfo.dll` — a module loaded dynamically at runtime rather than linked statically. Windows/MinGW's thread-local-storage teardown does not reliably invoke that destructor with a valid `this` when the owning thread exits, so the destructor faulted on a null pointer every time syscollector's worker thread terminated.

Closes #38241

## Proposed Changes

- Added `ISysInfo::releaseThreadResources()` / `SysInfo::releaseThreadResources()`, an explicit, same-thread replacement for the COM-context teardown that used to run in `ThreadComContext`'s destructor. The Windows implementation calls the existing `release()` logic directly; every other platform gets a single no-op definition guarded by `#ifndef _WIN32`.
- `ThreadComContext` no longer declares a destructor at all (kept trivially destructible on purpose): its `CoUninitialize()` balancing call moved into an explicit `release()` method that must be invoked by the caller before the owning thread exits.
- `Syscollector::releaseResources()` now calls `m_spInfo->releaseThreadResources()` on its own worker thread, immediately before releasing `m_spInfo` — i.e. before that thread's function returns, instead of leaving the cleanup to run automatically during thread-exit teardown.
- Added a mock method and a unit test asserting `releaseResources()` calls `releaseThreadResources()` exactly once on the `ISysInfo` implementation.

### Results and Evidence

**Reproduced before the fix**, on a real Windows Server 2025 host running a 5.0.0 nightly agent build with `syscollector` enabled (`scan_on_start: yes`): the very first `Restart-Service -Name wazuh` crashed and failed.

```
[Microsoft.PowerShell.Commands.ServiceCommandException] Service 'wazuh (WazuhSvc)' cannot be stopped due to the following error: Cannot stop WazuhSvc service on computer '.'.
[System.InvalidOperationException] Cannot stop WazuhSvc service on computer '.'.
[System.ComponentModel.Win32Exception] The pipe has been ended
NativeErrorCode=109
```

Matching Windows Application-log entry:

```
Faulting application name: wazuh-agent.exe, version: 5.0.0.0, time stamp: 0x6a7531a7
Faulting module name: sysinfo.dll, version: 5.0.0.0, time stamp: 0x6a753117
Exception code: 0xc0000005
Fault offset: 0x0000ca90
```

`ossec.log` for that cycle — the process died with no further output after the syscollector module finished, before either of the module's own shutdown timeouts could fire:

```
2026/08/07 12:39:45 wazuh-agent[4360] win_service.c:282 at OssecServiceCtrlHandler(): INFO: Received exit signal. Starting exit process.
2026/08/07 12:39:45 wazuh-agent[4360] win_service.c:288 at OssecServiceCtrlHandler(): INFO: Set pending exit signal.
2026/08/07 12:39:51 wazuh-modulesd:syscollector[4360] wm_syscollector.c:786 at wm_sys_main(): INFO: Module finished.
```
_(no `Exit completed successfully.` line — the process was already gone)_

A debugger session against a captured crash dump decoded the exact faulting instruction as a null-pointer member read inside a two-boolean-member object whose second member gates a call to an imported function — a byte-for-byte match for `ThreadComContext`'s `m_ownsInit` flag and its `CoUninitialize()` call, confirming the root cause described above.

**Verified after the fix**, on the same host, same configuration, after installing a package built from this branch: four consecutive `Restart-Service -Name wazuh` cycles, all clean.

```
cycle 1: OK
cycle 2: OK
cycle 3: OK
```
_(plus the initial restart immediately after install, also successful)_

`ossec.log` for every one of those cycles now shows the line that was missing before:

```
2026/08/07 14:49:26 wazuh-agent: INFO: Received exit signal. Starting exit process.
2026/08/07 14:49:26 wazuh-agent: INFO: Set pending exit signal.
2026/08/07 14:49:28 wazuh-modulesd:syscollector: INFO: Module finished.
2026/08/07 14:49:28 wazuh-agent: INFO: Exit completed successfully.
```

No new crash was recorded in the Windows Application log for any of the four post-fix restarts; the most recent crash on record predates the fix install (the old binary crashing during the stop issued just before it was uninstalled).

### Manual tests with their corresponding evidence

The verification performed for this PR was a live functional reproduction on a real Windows host (service restarted repeatedly before and after the fix, comparing crash-log and Application-Error-log output) rather than the specific tooling listed below, so none of these are checked from this session's evidence alone — please run/confirm the applicable ones before merge.

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

Note: a Windows agent package was built from this branch through the project's standard package-build pipeline and completed successfully, producing an installable `.msi` — this confirms the branch compiles and links for Windows, but build-warning output was not specifically audited, so "Compilation without warnings" is left unchecked pending that review.

### Artifacts Affected

- `sysinfo.dll` (Windows `data_provider` library) — houses the changed `ThreadComContext`/`releaseThreadResources()` logic.
- `wazuh-agent.exe` / the syscollector module inside the Windows agent package — calls the new cleanup hook during shutdown.
- Windows agent installer package (`.msi`) — rebuilt and manually verified for this fix; no other platform's package output changes behaviorally (all non-Windows platforms get a no-op).

### Configuration Changes

N/A — no configuration parameters were added, removed, or changed.

### Tests Introduced

Added `SyscollectorImpTest.destroyReleasesSysInfoThreadResources` (`src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp`), which exercises the same call path `wm_sys_main()` takes on Windows: it initializes `Syscollector` with a mocked `ISysInfo`, calls `destroy()` (which internally calls `releaseResources()`), and asserts `releaseThreadResources()` is invoked on the mock exactly once. This is a cross-platform unit test (runs on every CI platform, not just Windows) that pins the call-site wiring; it does not and cannot exercise the underlying OS-level thread-exit behavior itself, which is why the live reproduction above was necessary to confirm the actual fix.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
