### PR TITLE
Various https log imoprovements + fix `auto_restart`

### DIFF
--- a/src/client-agent/https_client/src/configFetcher.cpp
+++ b/src/client-agent/https_client/src/configFetcher.cpp
@@ -84,9 +84,9 @@ std::shared_ptr<SpoolFile> ConfigFetcher::fetch(const std::string& expectedHash,
         // resolve to real content -- e.g. its "0" sentinel for "nothing resolved yet for this
         // group set" right after a group membership change (confirmed with the manager team)
         // -- and the next notify simply re-triggers it either way.
-        LOGFN_DEBUG1(m_logFn, "Config download for group '%s' failed (outcome %d); "
+        LOGFN_DEBUG1(m_logFn, "Config download for group '%s' failed (%s); "
                      "the next notify re-triggers it.", group.c_str(),
-                     static_cast<int>(result.outcome));
+                     outcomeName(result.outcome));
         return nullptr;
     }
 

--- a/src/client-agent/https_client/src/controlStream.cpp
+++ b/src/client-agent/https_client/src/controlStream.cpp
@@ -242,8 +242,8 @@ void ControlStream::sendShutdown(Waiter& waiter)
 
     if (result.outcome != OutcomeClass::Ok)
     {
-        LOGFN_WARN(m_logFn, "Shutdown notification to the manager failed (outcome %d).",
-                   static_cast<int>(result.outcome));
+        LOGFN_WARN(m_logFn, "Shutdown notification to the manager failed (%s).",
+                   outcomeName(result.outcome));
     }
     else
     {
@@ -604,15 +604,15 @@ void ControlStream::updateProducerPause(OutcomeClass outcome)
 
     if (++m_undeliverableStreak < CONTROL_UNDELIVERABLE_THRESHOLD)
     {
-        LOGFN_DEBUG1(m_logFn, "/control undeliverable, outcome %d (%u/%u).",
-                     static_cast<int>(outcome), m_undeliverableStreak,
+        LOGFN_DEBUG1(m_logFn, "/control undeliverable (%s) (%u/%u).",
+                     outcomeName(outcome), m_undeliverableStreak,
                      CONTROL_UNDELIVERABLE_THRESHOLD);
         return;
     }
 
     m_producersPaused = true;
-    LOGFN_DEBUG1(m_logFn, "/control undeliverable, outcome %d (%u/%u); pausing event production.",
-                 static_cast<int>(outcome), m_undeliverableStreak,
+    LOGFN_DEBUG1(m_logFn, "/control undeliverable (%s) (%u/%u); pausing event production.",
+                 outcomeName(outcome), m_undeliverableStreak,
                  CONTROL_UNDELIVERABLE_THRESHOLD);
     m_sink.onProducerPause(true);
 }

--- a/src/client-agent/https_client/src/controlStream.cpp
+++ b/src/client-agent/https_client/src/controlStream.cpp
@@ -12,6 +12,7 @@
 #include "controlStream.hpp"
 
 #include "digest.hpp"
+#include "loggerHelper.h"
 #include "taskBatch.hpp"
 
 #include "external/nlohmann/json.hpp"
@@ -471,8 +472,8 @@ void ControlStream::maybeDownloadConfig(const std::string& managerHash, const st
         return; // Nothing reported, or already in sync.
     }
 
-    LOGFN_INFO(m_logFn, "Manager config hash %s differs from the local one; downloading "
-               "the new configuration (group '%s').", managerHash.c_str(), group.c_str());
+    LOGFN_DEBUG1(m_logFn, "Manager config hash %s differs from the local one; downloading "
+                 "the new configuration (group '%s').", managerHash.c_str(), group.c_str());
     auto file = m_fetcher.fetch(managerHash, group, waiter);
 
     if (!file)

--- a/src/client-agent/https_client/src/controlStream.cpp
+++ b/src/client-agent/https_client/src/controlStream.cpp
@@ -464,16 +464,19 @@ void ControlStream::maybeDownloadConfig(const std::string& managerHash, const st
                                         Waiter& waiter)
 {
     const std::string localHash = m_configHash.get();
-    LOGFN_DEBUG2(m_logFn, "config_hash check: manager=%s local=%s",
-                 managerHash.c_str(), localHash.c_str());
 
     if (managerHash.empty() || managerHash == localHash)
     {
+        // Every notify reports a hash, so this is the steady state: DEBUG2 to
+        // keep DEBUG1 for the notifies that actually make something happen.
+        LOGFN_DEBUG2(m_logFn, "Shared agent configuration unchanged (manager=%s local=%s); "
+                     "nothing to download.", managerHash.c_str(), localHash.c_str());
         return; // Nothing reported, or already in sync.
     }
 
-    LOGFN_DEBUG1(m_logFn, "Manager config hash %s differs from the local one; downloading "
-                 "the new configuration (group '%s').", managerHash.c_str(), group.c_str());
+    LOGFN_DEBUG1(m_logFn, "Manager config hash %s differs from the local one (%s); downloading "
+                 "the new configuration (group '%s').", managerHash.c_str(), localHash.c_str(),
+                 group.c_str());
     auto file = m_fetcher.fetch(managerHash, group, waiter);
 
     if (!file)

--- a/src/client-agent/https_client/src/httpTypes.hpp
+++ b/src/client-agent/https_client/src/httpTypes.hpp
@@ -50,6 +50,44 @@ enum class OutcomeClass
     Interrupted      ///< Aborted by shutdown: never a silent success.
 };
 
+/// Name of an OutcomeClass, for logs: the class is the reason a request
+/// failed, and an ordinal does not carry it to the reader.
+inline const char* outcomeName(OutcomeClass outcome)
+{
+    switch (outcome)
+    {
+        case OutcomeClass::Ok:
+            return "Ok";
+
+        case OutcomeClass::Unreachable:
+            return "Unreachable";
+
+        case OutcomeClass::ServerError:
+            return "ServerError";
+
+        case OutcomeClass::BackPressure:
+            return "BackPressure";
+
+        case OutcomeClass::AuthFail:
+            return "AuthFail";
+
+        case OutcomeClass::Permanent:
+            return "Permanent";
+
+        case OutcomeClass::PayloadTooLarge:
+            return "PayloadTooLarge";
+
+        case OutcomeClass::VersionRejected:
+            return "VersionRejected";
+
+        case OutcomeClass::Interrupted:
+            return "Interrupted";
+
+        default:
+            return "Unknown";
+    }
+}
+
 /// Maps an OutcomeClass onto the hc_result_t that crosses the C ABI.
 inline int toHcResult(OutcomeClass outcome)
 {

--- a/src/client-agent/https_client/src/httpsClientFacade.cpp
+++ b/src/client-agent/https_client/src/httpsClientFacade.cpp
@@ -87,7 +87,7 @@ bool HttpsClientFacade::start()
 
     if (m_started)
     {
-        LOGFN_WARN(m_logFn, "https_client already started, ignoring start request.");
+        LOGFN_WARN(m_logFn, "Already started, ignoring start request.");
         return true;
     }
 
@@ -96,7 +96,7 @@ bool HttpsClientFacade::start()
         // Single-shot: per-run state (waiter, gate, state machine) is not reset,
         // so a restart would launch a control thread that exits immediately.
         // Fail closed instead of returning a misleading success.
-        LOGFN_WARN(m_logFn, "https_client was stopped; create a new instance to start again.");
+        LOGFN_WARN(m_logFn, "Stopped; create a new instance to start again.");
         return false;
     }
 
@@ -162,12 +162,12 @@ void HttpsClientFacade::startSyncIntake()
 
     if (m_syncIntake->start())
     {
-        LOGFN_INFO(m_logFn, "https_client sync intake listening on %s.",
+        LOGFN_INFO(m_logFn, "Sync intake listening on %s.",
                    m_config.syncSocketPath.c_str());
     }
     else
     {
-        LOGFN_ERROR(m_logFn, "https_client sync intake failed to bind %s.",
+        LOGFN_ERROR(m_logFn, "Sync intake failed to bind %s.",
                     m_config.syncSocketPath.c_str());
         m_syncIntake.reset();
     }

--- a/src/client-agent/https_client/src/httpsClientFacade.cpp
+++ b/src/client-agent/https_client/src/httpsClientFacade.cpp
@@ -24,7 +24,7 @@ namespace
     /// "" when fn is null, so an unset callback degrades to "no extra metadata"
     /// rather than a crash.
     std::function<std::string()> makeMetadataCollector(void (*fn)(char*, size_t, void*),
-                                                        void* userData)
+                                                       void* userData)
     {
         return [fn, userData]() -> std::string
         {

--- a/src/client-agent/https_client/src/moduleConfig.cpp
+++ b/src/client-agent/https_client/src/moduleConfig.cpp
@@ -70,7 +70,7 @@ bool ModuleConfig::validate(const IFsProbe& fsProbe, const LogFn& logFn) const
 {
     if (serverHost.empty() || agentId.empty())
     {
-        LOGFN_ERROR(logFn, "https_client config rejected: server_host and agent_id are mandatory.");
+        LOGFN_ERROR(logFn, "Config rejected: server_host and agent_id are mandatory.");
         return false;
     }
 
@@ -81,7 +81,7 @@ bool ModuleConfig::validateTls(const IFsProbe& fsProbe, const LogFn& logFn) cons
 {
     if (verifyMode != HC_VERIFY_FULL && verifyMode != HC_VERIFY_CERT && verifyMode != HC_VERIFY_NONE)
     {
-        LOGFN_ERROR(logFn, "https_client config rejected: unknown verify_mode %d.", verifyMode);
+        LOGFN_ERROR(logFn, "Config rejected: unknown verify_mode %d.", verifyMode);
         return false;
     }
 
@@ -89,7 +89,7 @@ bool ModuleConfig::validateTls(const IFsProbe& fsProbe, const LogFn& logFn) cons
     {
         // The agent's own configured default (client-config.h's agent_verify_mode_t),
         // not an operator opt-out to flag -- informational, not a WARNING.
-        LOGFN_INFO(logFn, "https_client TLS verification is DISABLED (verify_mode=none).");
+        LOGFN_INFO(logFn, "TLS verification is DISABLED (verify_mode=none).");
         return true;
     }
 
@@ -118,13 +118,13 @@ bool ModuleConfig::validateClientCert(const IFsProbe& fsProbe, const LogFn& logF
 
     if (clientCert.empty() || clientKey.empty())
     {
-        LOGFN_ERROR(logFn, "https_client config rejected: client certificate and key must be set together.");
+        LOGFN_ERROR(logFn, "Config rejected: client certificate and key must be set together.");
         return false;
     }
 
     if (!fsProbe.isReadableFile(clientCert) || !fsProbe.isReadableFile(clientKey))
     {
-        LOGFN_ERROR(logFn, "https_client config rejected: client certificate or key is not readable.");
+        LOGFN_ERROR(logFn, "Config rejected: client certificate or key is not readable.");
         return false;
     }
 

--- a/src/client-agent/https_client/src/wpkFetcher.cpp
+++ b/src/client-agent/https_client/src/wpkFetcher.cpp
@@ -71,7 +71,7 @@ std::shared_ptr<SpoolFile> WpkFetcher::fetch(const std::string& wpkFile,
     if (result.outcome != OutcomeClass::Ok)
     {
         LOGFN_WARN(m_logFn, "WPK download for '%s' failed (%s); aborting the upgrade "
-                   "(no /control response is sent; fire-and-forget, #37834).",
+                   "(no /control response is sent; fire-and-forget).",
                    wpkFile.c_str(), outcomeName(result.outcome));
         return nullptr;
     }

--- a/src/client-agent/https_client/src/wpkFetcher.cpp
+++ b/src/client-agent/https_client/src/wpkFetcher.cpp
@@ -70,9 +70,9 @@ std::shared_ptr<SpoolFile> WpkFetcher::fetch(const std::string& wpkFile,
 
     if (result.outcome != OutcomeClass::Ok)
     {
-        LOGFN_WARN(m_logFn, "WPK download for '%s' failed (outcome %d); aborting the upgrade "
+        LOGFN_WARN(m_logFn, "WPK download for '%s' failed (%s); aborting the upgrade "
                    "(no /control response is sent; fire-and-forget, #37834).",
-                   wpkFile.c_str(), static_cast<int>(result.outcome));
+                   wpkFile.c_str(), outcomeName(result.outcome));
         return nullptr;
     }
 

--- a/src/client-agent/https_client/tests/unit/hcInterface_test.cpp
+++ b/src/client-agent/https_client/tests/unit/hcInterface_test.cpp
@@ -261,23 +261,37 @@ TEST_F(HcInterfaceTest, LifecycleChurn)
     // The designated ThreadSanitizer workload: a fresh handle each cycle (the
     // client is single-shot) with concurrent submits from another thread,
     // exercising the full create/start/stop/destroy race surface.
-    for (int cycle = 0; cycle < 20; cycle++)
+    //
+    constexpr int CYCLES = 20;
+    constexpr int MAX_SUBMITS = 500;
+    constexpr int SUBMITS_BEFORE_STOP = 50;
+
+    for (int cycle = 0; cycle < CYCLES; cycle++)
     {
         hc_handle* handle = hc_create(&m_config, &m_callbacks);
         ASSERT_NE(nullptr, handle);
         ASSERT_TRUE(hc_start(handle));
         std::atomic<bool> submitting {true};
+        std::atomic<int> submitted {0};
         std::thread producer(
             [&]
         {
             const uint8_t frame[] = "1:/var/log/syslog:churn";
 
-            while (submitting.load())
+            for (int n = 0; n < MAX_SUBMITS && submitting.load(); n++)
             {
                 hc_submit_event(handle, frame, sizeof(frame) - 1);
+                submitted.fetch_add(1, std::memory_order_relaxed);
             }
         });
-        std::this_thread::sleep_for(std::chrono::milliseconds {2});
+
+        // Stop only once submits are demonstrably in flight, so the race the
+        // test exists for still happens without depending on the wall clock.
+        while (submitted.load(std::memory_order_relaxed) < SUBMITS_BEFORE_STOP)
+        {
+            std::this_thread::yield();
+        }
+
         hc_stop(handle);
         submitting = false;
         producer.join();

--- a/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
@@ -52,7 +52,7 @@ namespace
         const auto jsonStart = start + prefix.size();
         const auto newline = sentBody.find('\n', jsonStart);
         const auto jsonText = sentBody.substr(
-            jsonStart, newline == std::string::npos ? std::string::npos : newline - jsonStart);
+                                  jsonStart, newline == std::string::npos ? std::string::npos : newline - jsonStart);
         return nlohmann::json::parse(jsonText)["wazuh"];
     }
 
@@ -265,7 +265,8 @@ TEST_F(StatelessStreamTest, HeaderLineIsRefreshedOnEveryFlushNotCachedAtConstruc
     // line must reflect collectHost's CURRENT return value at each flush, not
     // whatever was available when the stream was built.
     std::string clusterName = "";
-    StatelessStream stream {
+    StatelessStream stream
+    {
         m_config,   m_performer, m_signer, m_clock, m_random, m_sink, m_authGate,
         [&clusterName]
         {

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -927,28 +927,25 @@ static void bridge_on_agent_groups(const char *groups_csv, void *user_data)
  * received it returns (the module deletes it right after) -- so the very
  * first thing this does is copy it into SHAREDCFG_FILE.
  *
- * Mirrors the legacy apply chain (client-agent/src/receiver.c's FILE_CLOSE_HEADER
- * handling: UnmergeFiles -> cldir_ex_ignore -> verifyRemoteConf -> reloadAgent),
- * reusing the exact same shared-code calls, including receiver.c's own
- * anti-race sequencing between reloadAgent() and the gate release (see its
- * "the reload chain ... is the normal release path" comment): if
- * reloadAgent() actually dispatches, the gate is deliberately NOT released
- * here -- releasing it unconditionally could let a module still blocked in
+ * The apply chain is UnmergeFiles -> cldir_ex_ignore -> verifyRemoteConf ->
+ * reloadAgent, and whether that last step runs depends on two things: a
+ * blocked startup gate (modules are waiting for this very configuration to
+ * start, so they must be started with it) and <auto_restart> (which governs
+ * picking up a configuration change on an agent already running).
+ *
+ * Anti-race sequencing between reloadAgent() and the gate release: when
+ * reloadAgent() dispatches, the gate is deliberately NOT released here --
+ * releasing it unconditionally could let a module still blocked in
  * startup_gate_wait_for_ready() unblock and start a moment before the reload
  * chain (modulesd CONTROL_SOCK -> wazuh-control reload -> SIGUSR1) restarts
  * it anyway. client-agent/src/agentd.c's own SIGUSR1 handling
  * (needs_config_reload) calls startup_gate_release_from_https_apply()
- * once that restart has actually happened -- this is the transport-agnostic
- * release path for the common case.
+ * once that restart has actually happened.
  *
- * The one deliberate difference from receiver.c: the HTTPS /control contract
- * has no merged_sum handshake field, so there is no later handshake
- * retry to lean on if reloadAgent() cannot even dispatch (control socket
- * unreachable). receiver.c's own fallback ("release inline only if
- * reloadAgent() fails") is mirrored exactly below for that case -- see the
- * reload/gate block near the end of this function, and
- * startup_gate_release_from_https_apply()'s own comment for why that inline
- * release is safe even without the legacy MD5 comparison.
+ * When reloadAgent() cannot even dispatch (control socket unreachable) no
+ * SIGUSR1 will ever arrive, and the /control contract has no handshake retry
+ * to lean on, so the gate is released inline instead -- see
+ * startup_gate_release_from_https_apply()'s own comment for why that is safe.
  */
 static void bridge_on_config_downloaded(const char *config_hash, const char *file_path,
                                         void *user_data)
@@ -1013,43 +1010,47 @@ static void bridge_on_config_downloaded(const char *config_hash, const char *fil
     free_strarray(ignore_list);
 
     if (!agt->flags.remote_conf) {
-        /* Mirrors receiver.c: the files are staged either way, but nothing
-         * reloads or gates on remote configuration when the agent has opted
-         * out of it. */
+        /* The files are staged either way, but nothing reloads or gates on
+         * remote configuration when the agent has opted out of it. */
         return;
     }
 
     if (verifyRemoteConf()) {
         /* Invalid remote configuration: verifyRemoteConf() already reported it
          * to the manager (AG_IN_RCON). Do not reload or release the gate with
-         * a configuration known to be broken -- mirrors receiver.c, which
-         * skips its own reload/gate block on the same check. */
+         * a configuration known to be broken. */
         merror("https_client: downloaded configuration failed validation; not reloading.");
         return;
     }
 
-    minfo("https_client: applying configuration downloaded over HTTPS (hash=%s).",
-          config_hash ? config_hash : "?");
+    mdebug1("https_client: applying configuration downloaded over HTTPS (hash=%s).",
+            config_hash ? config_hash : "?");
 
-    /* Anti-race sequencing, mirroring receiver.c's own FILE_CLOSE_HEADER
-     * handling (see its "the reload chain ... is the normal release path"
-     * comment): if reloadAgent() actually dispatches, do NOT release the gate
-     * here. Doing so unconditionally could let a module still blocked in
-     * startup_gate_wait_for_ready() unblock and start a moment before the
-     * reload chain (modulesd CONTROL_SOCK -> wazuh-control reload -> SIGUSR1)
-     * restarts it anyway -- the exact "briefly start with the new config and
-     * then get killed" race receiver.c was written to avoid. agentd.c's own
-     * SIGUSR1 handling (needs_config_reload) already calls
-     * startup_gate_release_from_https_apply() once that restart has actually
-     * happened.
+    /* A blocked gate means modules are still waiting in
+     * startup_gate_wait_for_ready() for the configuration that just arrived:
+     * they have to be started with it, so that reload runs whatever
+     * <auto_restart> says (and stays quiet -- it is the initial apply, not a
+     * change to what the agent was already running). The gate's precondition
+     * holds by construction here: the module SHA-256-verified these bytes
+     * against the manager's config_hash before the callback fired, and they
+     * are now what SHAREDCFG_FILE holds.
      *
-     * Only release inline here as a fallback when reloadAgent() itself could
-     * not even dispatch (control socket unreachable) -- no SIGUSR1 will ever
-     * arrive to do it later in that case, so the gate would otherwise stay
-     * stuck. This is also, concretely, the fresh-install/first-boot case:
-     * modulesd/monitoring processes are still blocked in their very first
-     * startup_gate_wait_for_ready() call and have no prior instance to
-     * restart, so there is nothing to race against. */
+     * With the gate already open the reload only serves to pick up a changed
+     * configuration, which is exactly what <auto_restart> governs: when it is
+     * off the files stay staged for whenever the agent restarts next. */
+    const bool gate_was_blocked = !startup_gate_is_ready();
+
+    if (!agt->flags.auto_restart && !gate_was_blocked) {
+        mdebug1("https_client: shared agent configuration has been updated.");
+        return;
+    }
+
+    if (!agt->flags.auto_restart) {
+        mdebug1("https_client: reloading to apply startup hash validated configuration.");
+    } else {
+        minfo("https_client: reloading due to shared configuration changes.");
+    }
+
     if (!reloadAgent()) {
         mdebug1("https_client: could not dispatch the reload chain; releasing "
                 "the startup gate directly instead (no restart will arrive to do it).");

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -378,10 +378,10 @@ static void bridge_on_startup_result(bool accepted, const char *metadata_json, v
 
         if (previous_limits.limits_received && module_limits_changed(&previous_limits, &agent_module_limits)) {
             if (agt->flags.auto_restart) {
-                minfo("https_client: reloading due to module limits changes.");
+                minfo("Agent is reloading due to module limits changes.");
                 reloadAgent();
             } else {
-                mdebug1("https_client: module limits have been updated.");
+                mdebug1("Module limits have been updated.");
             }
         }
     } else {
@@ -975,7 +975,7 @@ static void bridge_on_config_downloaded(const char *config_hash, const char *fil
      * manager's hash, forcing an endless re-download/reload loop (observed
      * as a real, Windows-only regression during real-package validation). */
     if (w_copy_file(file_path, SHAREDCFG_FILE, 'b', NULL, 0) != 0) {
-        merror("https_client: could not copy the downloaded configuration into '%s'; "
+        merror("Could not copy the downloaded configuration into '%s'; "
                "keeping the previously applied one.", SHAREDCFG_FILE);
         if (handle) {
             /* What's actually on disk is still the old config, not config_hash:
@@ -991,7 +991,7 @@ static void bridge_on_config_downloaded(const char *config_hash, const char *fil
     os_strdup(SHAREDCFG_FILENAME, *ignore_list);
 
     if (!UnmergeFiles(SHAREDCFG_FILE, SHAREDCFG_DIR, OS_TEXT, &ignore_list)) {
-        merror("https_client: failed to unmerge the downloaded configuration "
+        merror("Failed to unmerge the downloaded configuration "
                "('%s'); keeping the previously applied files.", SHAREDCFG_FILE);
         /* Manager-visible report, now over /stateless. */
         char unmerge_fail_msg[OS_MAXSTR];
@@ -1005,7 +1005,7 @@ static void bridge_on_config_downloaded(const char *config_hash, const char *fil
     }
 
     if (cldir_ex_ignore(SHAREDCFG_DIR, (const char **)ignore_list)) {
-        mwarn("https_client: could not clean up the shared configuration directory.");
+        mwarn("Could not clean up the shared configuration directory.");
     }
     free_strarray(ignore_list);
 
@@ -1019,11 +1019,11 @@ static void bridge_on_config_downloaded(const char *config_hash, const char *fil
         /* Invalid remote configuration: verifyRemoteConf() already reported it
          * to the manager (AG_IN_RCON). Do not reload or release the gate with
          * a configuration known to be broken. */
-        merror("https_client: downloaded configuration failed validation; not reloading.");
+        merror("Downloaded configuration failed validation; not reloading.");
         return;
     }
 
-    mdebug1("https_client: applying configuration downloaded over HTTPS (hash=%s).",
+    mdebug1("Applying configuration downloaded over HTTPS (hash=%s).",
             config_hash ? config_hash : "?");
 
     /* A blocked gate means modules are still waiting in
@@ -1041,18 +1041,18 @@ static void bridge_on_config_downloaded(const char *config_hash, const char *fil
     const bool gate_was_blocked = !startup_gate_is_ready();
 
     if (!agt->flags.auto_restart && !gate_was_blocked) {
-        mdebug1("https_client: shared agent configuration has been updated.");
+        mdebug1("Shared agent configuration has been updated.");
         return;
     }
 
     if (!agt->flags.auto_restart) {
-        mdebug1("https_client: reloading to apply startup hash validated configuration.");
+        mdebug1("Agent is reloading to apply startup hash validated configuration.");
     } else {
-        minfo("https_client: reloading due to shared configuration changes.");
+        minfo("Agent is reloading due to shared configuration changes.");
     }
 
     if (!reloadAgent()) {
-        mdebug1("https_client: could not dispatch the reload chain; releasing "
+        mdebug1("Could not dispatch the reload chain; releasing "
                 "the startup gate directly instead (no restart will arrive to do it).");
         startup_gate_release_from_https_apply();
     }

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -1029,24 +1029,25 @@ static void bridge_on_config_downloaded(const char *config_hash, const char *fil
     /* A blocked gate means modules are still waiting in
      * startup_gate_wait_for_ready() for the configuration that just arrived:
      * they have to be started with it, so that reload runs whatever
-     * <auto_restart> says (and stays quiet -- it is the initial apply, not a
-     * change to what the agent was already running). The gate's precondition
-     * holds by construction here: the module SHA-256-verified these bytes
-     * against the manager's config_hash before the callback fired, and they
-     * are now what SHAREDCFG_FILE holds.
+     * <auto_restart> says. The gate's precondition holds by construction here:
+     * the module SHA-256-verified these bytes against the manager's
+     * config_hash before the callback fired, and they are now what
+     * SHAREDCFG_FILE holds.
      *
      * With the gate already open the reload only serves to pick up a changed
      * configuration, which is exactly what <auto_restart> governs: when it is
-     * off the files stay staged for whenever the agent restarts next. */
+     * off the files stay staged for whenever the agent restarts next. Say so at
+     * INFO -- what is on disk is no longer what the running agent applies, and
+     * only an operator can close that gap. */
     const bool gate_was_blocked = !startup_gate_is_ready();
 
     if (!agt->flags.auto_restart && !gate_was_blocked) {
-        mdebug1("Shared agent configuration has been updated.");
+        minfo("Agent must restart to apply the new shared configuration; auto_restart is disabled.");
         return;
     }
 
     if (!agt->flags.auto_restart) {
-        mdebug1("Agent is reloading to apply startup hash validated configuration.");
+        minfo("Agent is reloading to apply startup hash validated configuration.");
     } else {
         minfo("Agent is reloading due to shared configuration changes.");
     }

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -109,6 +109,7 @@ list(APPEND client-agent_flags "-Wl,--wrap,wurl_free_response -Wl,--wrap,wurl_ht
                                 -Wl,--wrap,verifyRemoteConf -Wl,--wrap,reloadAgent \
                                 -Wl,--wrap,w_agentd_populate_metadata \
                                 -Wl,--wrap,startup_gate_release_from_https_apply \
+                                -Wl,--wrap,startup_gate_is_ready \
                                 -Wl,--wrap,os_delwait -Wl,--wrap,os_setwait \
                                 -Wl,--wrap,OS_SHA256_File \
                                 -Wl,--wrap,task_registry_check_and_record \

--- a/src/unit_tests/client-agent/test_https_client_bridge.c
+++ b/src/unit_tests/client-agent/test_https_client_bridge.c
@@ -108,6 +108,14 @@ void __wrap_startup_gate_release_from_https_apply(void)
     function_called();
 }
 
+/* bridge_on_config_downloaded() reads the gate to tell an initial apply
+ * (modules still blocked, reload regardless of <auto_restart>) from a
+ * configuration change on a running agent (<auto_restart> decides). */
+bool __wrap_startup_gate_is_ready(void)
+{
+    return mock();
+}
+
 /* WAIT_FILE producer lock: no pre-existing wrapper for either ABI. */
 void __wrap_os_delwait(void)
 {
@@ -988,27 +996,35 @@ static void expect_copy_unmerge_cleanup_ok(void)
     will_return(__wrap_cldir_ex_ignore, 0);
 }
 
-/* Anti-race sequencing (per receiver.c's own "the reload chain ... is the
- * normal release path" comment): when reloadAgent() actually dispatches, the
- * gate must NOT be released here -- agentd.c's own SIGUSR1 handling
- * (needs_config_reload) releases it once the restart that reload triggers
- * has actually happened, exactly mirroring how it already does this for the
- * legacy path via startup_gate_refresh_from_local_hash(). Releasing inline
- * regardless of reloadAgent()'s outcome would let a module still blocked in
- * startup_gate_wait_for_ready() unblock and start a moment before the reload
- * chain restarts it anyway. */
+/* The hash of the bytes just applied: a debug detail, unlike the reload the
+ * user does see reported at INFO. */
+static void expect_applying_config_log(void)
+{
+    expect_string(__wrap__mdebug1, formatted_msg,
+                  "https_client: applying configuration downloaded over HTTPS (hash="
+                  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b85).");
+}
+
+/* Anti-race sequencing: when reloadAgent() actually dispatches, the gate must
+ * NOT be released here -- agentd.c's own SIGUSR1 handling
+ * (needs_config_reload) releases it once the restart that reload triggers has
+ * actually happened. Releasing inline regardless of reloadAgent()'s outcome
+ * would let a module still blocked in startup_gate_wait_for_ready() unblock
+ * and start a moment before the reload chain restarts it anyway. */
 static void test_config_downloaded_happy_path_reload_dispatched_defers_gate_to_sigusr1(void **state)
 {
     (void)state;
     agt->flags.remote_conf = 1;
+    agt->flags.auto_restart = 1;
     start_client_successfully();
 
     expect_config_downloaded_log(DOWNLOAD_HASH, DOWNLOAD_FILE);
     expect_copy_unmerge_cleanup_ok();
     will_return(__wrap_verifyRemoteConf, 0); /* valid */
+    expect_applying_config_log();
+    will_return(__wrap_startup_gate_is_ready, false); /* Still blocked: initial apply. */
     expect_string(__wrap__minfo, formatted_msg,
-                  "https_client: applying configuration downloaded over HTTPS (hash="
-                  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b85).");
+                  "https_client: reloading due to shared configuration changes.");
     will_return(__wrap_reloadAgent, true);
     /* No expect_function_call(__wrap_startup_gate_release_from_https_apply):
      * must NOT be reached when the reload chain actually dispatched. */
@@ -1029,19 +1045,72 @@ static void test_config_downloaded_releases_gate_when_reload_chain_unreachable(v
 {
     (void)state;
     agt->flags.remote_conf = 1;
+    agt->flags.auto_restart = 1;
     start_client_successfully();
 
     expect_config_downloaded_log(DOWNLOAD_HASH, DOWNLOAD_FILE);
     expect_copy_unmerge_cleanup_ok();
     will_return(__wrap_verifyRemoteConf, 0);
+    expect_applying_config_log();
+    will_return(__wrap_startup_gate_is_ready, false);
     expect_string(__wrap__minfo, formatted_msg,
-                  "https_client: applying configuration downloaded over HTTPS (hash="
-                  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b85).");
+                  "https_client: reloading due to shared configuration changes.");
     will_return(__wrap_reloadAgent, false); /* Control socket unreachable (e.g. first boot). */
     expect_string(__wrap__mdebug1, formatted_msg,
                   "https_client: could not dispatch the reload chain; releasing "
                   "the startup gate directly instead (no restart will arrive to do it).");
     expect_function_call(__wrap_startup_gate_release_from_https_apply);
+
+    g_captured_callbacks.on_config_downloaded(DOWNLOAD_HASH, DOWNLOAD_FILE, g_captured_callbacks.user_data);
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+/* <auto_restart>no</auto_restart> on an agent whose modules are already
+ * running: the configuration is staged for the next restart, and nothing is
+ * reloaded behind the user's back. */
+static void test_config_downloaded_auto_restart_disabled_stages_without_reloading(void **state)
+{
+    (void)state;
+    agt->flags.remote_conf = 1;
+    agt->flags.auto_restart = 0;
+    start_client_successfully();
+
+    expect_config_downloaded_log(DOWNLOAD_HASH, DOWNLOAD_FILE);
+    expect_copy_unmerge_cleanup_ok();
+    will_return(__wrap_verifyRemoteConf, 0);
+    expect_applying_config_log();
+    will_return(__wrap_startup_gate_is_ready, true); /* Modules already started. */
+    expect_string(__wrap__mdebug1, formatted_msg,
+                  "https_client: shared agent configuration has been updated.");
+    /* No reloadAgent/gate-release expectation: must not be reached. */
+
+    g_captured_callbacks.on_config_downloaded(DOWNLOAD_HASH, DOWNLOAD_FILE, g_captured_callbacks.user_data);
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+/* <auto_restart>no</auto_restart> cannot leave modules blocked forever: with
+ * the gate still closed they are waiting for this very configuration to
+ * start, so the reload runs anyway -- quietly, since it applies the initial
+ * configuration rather than a change to a running one. */
+static void test_config_downloaded_blocked_gate_reloads_despite_auto_restart_disabled(void **state)
+{
+    (void)state;
+    agt->flags.remote_conf = 1;
+    agt->flags.auto_restart = 0;
+    start_client_successfully();
+
+    expect_config_downloaded_log(DOWNLOAD_HASH, DOWNLOAD_FILE);
+    expect_copy_unmerge_cleanup_ok();
+    will_return(__wrap_verifyRemoteConf, 0);
+    expect_applying_config_log();
+    will_return(__wrap_startup_gate_is_ready, false);
+    expect_string(__wrap__mdebug1, formatted_msg,
+                  "https_client: reloading to apply startup hash validated configuration.");
+    will_return(__wrap_reloadAgent, true);
 
     g_captured_callbacks.on_config_downloaded(DOWNLOAD_HASH, DOWNLOAD_FILE, g_captured_callbacks.user_data);
 
@@ -2021,6 +2090,8 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_submit_event_is_a_noop_once_stopping, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_config_downloaded_happy_path_reload_dispatched_defers_gate_to_sigusr1, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_config_downloaded_releases_gate_when_reload_chain_unreachable, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_config_downloaded_auto_restart_disabled_stages_without_reloading, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_config_downloaded_blocked_gate_reloads_despite_auto_restart_disabled, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_config_downloaded_invalid_config_skips_reload_and_gate, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_config_downloaded_remote_conf_disabled_stages_files_only, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_config_downloaded_copy_failure_corrects_module_hash, setup_test, teardown_test),

--- a/src/unit_tests/client-agent/test_https_client_bridge.c
+++ b/src/unit_tests/client-agent/test_https_client_bridge.c
@@ -1068,8 +1068,9 @@ static void test_config_downloaded_releases_gate_when_reload_chain_unreachable(v
 }
 
 /* <auto_restart>no</auto_restart> on an agent whose modules are already
- * running: the configuration is staged for the next restart, and nothing is
- * reloaded behind the user's back. */
+ * running: the configuration is staged for the next restart, nothing is
+ * reloaded behind the user's back, and the operator is told at INFO that the
+ * agent is now running configuration older than what is on disk. */
 static void test_config_downloaded_auto_restart_disabled_stages_without_reloading(void **state)
 {
     (void)state;
@@ -1082,8 +1083,8 @@ static void test_config_downloaded_auto_restart_disabled_stages_without_reloadin
     will_return(__wrap_verifyRemoteConf, 0);
     expect_applying_config_log();
     will_return(__wrap_startup_gate_is_ready, true); /* Modules already started. */
-    expect_string(__wrap__mdebug1, formatted_msg,
-                  "Shared agent configuration has been updated.");
+    expect_string(__wrap__minfo, formatted_msg,
+                  "Agent must restart to apply the new shared configuration; auto_restart is disabled.");
     /* No reloadAgent/gate-release expectation: must not be reached. */
 
     g_captured_callbacks.on_config_downloaded(DOWNLOAD_HASH, DOWNLOAD_FILE, g_captured_callbacks.user_data);
@@ -1094,8 +1095,8 @@ static void test_config_downloaded_auto_restart_disabled_stages_without_reloadin
 
 /* <auto_restart>no</auto_restart> cannot leave modules blocked forever: with
  * the gate still closed they are waiting for this very configuration to
- * start, so the reload runs anyway -- quietly, since it applies the initial
- * configuration rather than a change to a running one. */
+ * start, so the reload runs anyway, and is reported like any other restart the
+ * agent decides on its own. */
 static void test_config_downloaded_blocked_gate_reloads_despite_auto_restart_disabled(void **state)
 {
     (void)state;
@@ -1108,7 +1109,7 @@ static void test_config_downloaded_blocked_gate_reloads_despite_auto_restart_dis
     will_return(__wrap_verifyRemoteConf, 0);
     expect_applying_config_log();
     will_return(__wrap_startup_gate_is_ready, false);
-    expect_string(__wrap__mdebug1, formatted_msg,
+    expect_string(__wrap__minfo, formatted_msg,
                   "Agent is reloading to apply startup hash validated configuration.");
     will_return(__wrap_reloadAgent, true);
 

--- a/src/unit_tests/client-agent/test_https_client_bridge.c
+++ b/src/unit_tests/client-agent/test_https_client_bridge.c
@@ -1001,7 +1001,7 @@ static void expect_copy_unmerge_cleanup_ok(void)
 static void expect_applying_config_log(void)
 {
     expect_string(__wrap__mdebug1, formatted_msg,
-                  "https_client: applying configuration downloaded over HTTPS (hash="
+                  "Applying configuration downloaded over HTTPS (hash="
                   "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b85).");
 }
 
@@ -1024,7 +1024,7 @@ static void test_config_downloaded_happy_path_reload_dispatched_defers_gate_to_s
     expect_applying_config_log();
     will_return(__wrap_startup_gate_is_ready, false); /* Still blocked: initial apply. */
     expect_string(__wrap__minfo, formatted_msg,
-                  "https_client: reloading due to shared configuration changes.");
+                  "Agent is reloading due to shared configuration changes.");
     will_return(__wrap_reloadAgent, true);
     /* No expect_function_call(__wrap_startup_gate_release_from_https_apply):
      * must NOT be reached when the reload chain actually dispatched. */
@@ -1054,10 +1054,10 @@ static void test_config_downloaded_releases_gate_when_reload_chain_unreachable(v
     expect_applying_config_log();
     will_return(__wrap_startup_gate_is_ready, false);
     expect_string(__wrap__minfo, formatted_msg,
-                  "https_client: reloading due to shared configuration changes.");
+                  "Agent is reloading due to shared configuration changes.");
     will_return(__wrap_reloadAgent, false); /* Control socket unreachable (e.g. first boot). */
     expect_string(__wrap__mdebug1, formatted_msg,
-                  "https_client: could not dispatch the reload chain; releasing "
+                  "Could not dispatch the reload chain; releasing "
                   "the startup gate directly instead (no restart will arrive to do it).");
     expect_function_call(__wrap_startup_gate_release_from_https_apply);
 
@@ -1083,7 +1083,7 @@ static void test_config_downloaded_auto_restart_disabled_stages_without_reloadin
     expect_applying_config_log();
     will_return(__wrap_startup_gate_is_ready, true); /* Modules already started. */
     expect_string(__wrap__mdebug1, formatted_msg,
-                  "https_client: shared agent configuration has been updated.");
+                  "Shared agent configuration has been updated.");
     /* No reloadAgent/gate-release expectation: must not be reached. */
 
     g_captured_callbacks.on_config_downloaded(DOWNLOAD_HASH, DOWNLOAD_FILE, g_captured_callbacks.user_data);
@@ -1109,7 +1109,7 @@ static void test_config_downloaded_blocked_gate_reloads_despite_auto_restart_dis
     expect_applying_config_log();
     will_return(__wrap_startup_gate_is_ready, false);
     expect_string(__wrap__mdebug1, formatted_msg,
-                  "https_client: reloading to apply startup hash validated configuration.");
+                  "Agent is reloading to apply startup hash validated configuration.");
     will_return(__wrap_reloadAgent, true);
 
     g_captured_callbacks.on_config_downloaded(DOWNLOAD_HASH, DOWNLOAD_FILE, g_captured_callbacks.user_data);
@@ -1128,7 +1128,7 @@ static void test_config_downloaded_invalid_config_skips_reload_and_gate(void **s
     expect_copy_unmerge_cleanup_ok();
     will_return(__wrap_verifyRemoteConf, -1); /* invalid */
     expect_string(__wrap__merror, formatted_msg,
-                  "https_client: downloaded configuration failed validation; not reloading.");
+                  "Downloaded configuration failed validation; not reloading.");
     /* No reloadAgent/gate-release expectation: must not be reached. */
 
     g_captured_callbacks.on_config_downloaded(DOWNLOAD_HASH, DOWNLOAD_FILE, g_captured_callbacks.user_data);
@@ -1169,7 +1169,7 @@ static void test_config_downloaded_copy_failure_corrects_module_hash(void **stat
     will_return(__wrap_w_copy_file, -1); /* I/O error */
 
     expect_string(__wrap__merror, formatted_msg,
-                  "https_client: could not copy the downloaded configuration into "
+                  "Could not copy the downloaded configuration into "
                   "'" SHAREDCFG_FILE "'; keeping the previously applied one.");
     expect_value(__wrap_hc_set_config_hash, handle, FAKE_HANDLE);
     expect_string(__wrap_hc_set_config_hash, config_hash, "");
@@ -1203,7 +1203,7 @@ static void test_config_downloaded_unmerge_failure_corrects_module_hash(void **s
     will_return(__wrap_UnmergeFiles, 0); /* failure */
 
     expect_string(__wrap__merror, formatted_msg,
-                  "https_client: failed to unmerge the downloaded configuration "
+                  "Failed to unmerge the downloaded configuration "
                   "('" SHAREDCFG_FILE "'); keeping the previously applied files.");
     /* AG_IN_UNMERGE manager-visible report, now submitted to the /stateless
      * accumulator like any other event. */
@@ -1332,7 +1332,7 @@ static void test_startup_result_limits_changed_reloads_under_auto_restart(void *
 
     expect_any(__wrap__mdebug1, formatted_msg);
     expect_string(__wrap__mdebug1, formatted_msg, "https_client: module limits received from manager.");
-    expect_string(__wrap__minfo, formatted_msg, "https_client: reloading due to module limits changes.");
+    expect_string(__wrap__minfo, formatted_msg, "Agent is reloading due to module limits changes.");
     will_return(__wrap_reloadAgent, true);
     expect_string(__wrap__mdebug1, formatted_msg, "https_client: cluster identity -> name='demo-cluster', node='node01'.");
     expect_string(__wrap__mdebug1, formatted_msg, "https_client: agent groups -> default,linux.");
@@ -1363,7 +1363,7 @@ static void test_startup_result_limits_changed_no_reload_without_auto_restart(vo
 
     expect_any(__wrap__mdebug1, formatted_msg);
     expect_string(__wrap__mdebug1, formatted_msg, "https_client: module limits received from manager.");
-    expect_string(__wrap__mdebug1, formatted_msg, "https_client: module limits have been updated.");
+    expect_string(__wrap__mdebug1, formatted_msg, "Module limits have been updated.");
     /* No reloadAgent expectation: must not be reached. */
     expect_string(__wrap__mdebug1, formatted_msg, "https_client: cluster identity -> name='demo-cluster', node='node01'.");
     expect_string(__wrap__mdebug1, formatted_msg, "https_client: agent groups -> default,linux.");


### PR DESCRIPTION
## Description

The agent's HTTPS transport printed its outcome class as a raw enum integer, which means nothing to anyone reading `ossec.log`, and some of those lines carried internal issue references too. Reviewing them surfaced further problems in the same area — the transport announced its own name three different ways in a single startup sequence, routine configuration bookkeeping was logged at INFO while the one message a reader actually wants (that the agent is restarting itself) was missing entirely — so this PR covers the whole log surface of the HTTPS transport, plus one behavior bug that porting the missing message uncovered and one test that was timing out the module's RTR job.

## Proposed Changes

One note per commit:

**`feat: dont reload when auto_restart is 'no'`** — Behavior fix. On the HTTPS path a downloaded shared configuration always triggered a reload, ignoring `<auto_restart>no</auto_restart>`. The configuration is now staged for the next restart instead. 

**`feat: improve https retry logs`** — Failed HTTPS requests now name their failure class instead of printing the enum's integer value.

``` sql
- /control undeliverable, outcome 2 (2/3).
+ /control undeliverable (ServerError) (2/3).
```

**`feat: remove task numbers from https logs`** — Dropped the internal issue reference that had leaked into the WPK download failure line.

``` sql
- WPK download for 'wazuh_agent.wpk' failed (Unreachable); aborting the upgrade (no /control response is sent; fire-and-forget, #37834).
+ WPK download for 'wazuh_agent.wpk' failed (Unreachable); aborting the upgrade (no /control response is sent; fire-and-forget).
```


**`fix: remove https_client suffix from client logs`** — Agent-side messages describing the agent's own behavior no longer carry a subsystem prefix, so they read under the plain `wazuh-agentd` tag and in the same words the legacy transport used.

``` sql
- 2026/08/10 16:38:03 wazuh-agentd: INFO: https_client: applying configuration downloaded over HTTPS (hash=cbbce061...).
+ 2026/08/10 16:38:03 wazuh-agentd: INFO: Agent is reloading due to shared configuration changes.
```

**`fix: remove extra https_client tag from logs`** — Messages from the C++ module already log under a `wazuh-agentd:https-client` tag, so they no longer repeat `https_client` in the message text as well.

``` sql
- 2026/08/10 16:38:01 wazuh-agentd:https-client: INFO: https_client TLS verification is DISABLED (verify_mode=none).
+ 2026/08/10 16:38:01 wazuh-agentd:https-client: INFO: TLS verification is DISABLED (verify_mode=none).
```

**`fix: demote unchanged config message to debug1`** — Every notify reports a config hash, so the steady-state check sits at debug level 2 and states its conclusion in words rather than leaving the reader to compare two hashes. Debug level 1 is now reserved for the notifies that actually start a download.

``` sql
- config_hash check: manager=cbbce061... local=cbbce061...
+ Shared agent configuration unchanged (manager=cbbce061... local=cbbce061...); nothing to download.
```

**`test: stop LifecycleChurn hanging the valgrind job`** — CI fix, no product code touched. The module's RTR job was being cancelled at the 60-minute limit on Linux, because one unit test let a producer thread submit events in an unbounded loop that only ended once teardown returned. The volume of work therefore scaled with how slow the run was, so under valgrind the test fed itself: 21m17s of a 22m29s suite. Capping the producer and handing off to teardown on a counter instead of a sleep brings that test to 563 ms and the whole suite to 11s, with the race it was written to catch still happening.

## Results and Evidence

Failure outcomes, all five lines, before:

``` sql
Shutdown notification to the manager failed (outcome 1).
/control undeliverable, outcome 2 (2/3).
/control undeliverable, outcome 2 (3/3); pausing event production.
Config download for group 'default' failed (outcome 5); the next notify re-triggers it.
WPK download for 'wazuh_agent.wpk' failed (outcome 1); aborting the upgrade (no /control response is sent; fire-and-forget, #37834).
```

And after:

``` sql
Shutdown notification to the manager failed (Unreachable).
/control undeliverable (ServerError) (2/3).
/control undeliverable (ServerError) (3/3); pausing event production.
Config download for group 'default' failed (Permanent); the next notify re-triggers it.
WPK download for 'wazuh_agent.wpk' failed (Unreachable); aborting the upgrade (no /control response is sent; fire-and-forget).
```

Startup, as observed before, with the subsystem named three different ways:

``` sql
2026/08/10 16:38:01 wazuh-agentd: INFO: (1410): Reading authentication keys file.
2026/08/10 16:38:01 wazuh-agentd: INFO: https_client: starting.
2026/08/10 16:38:01 wazuh-agentd:https-client: INFO: https_client TLS verification is DISABLED (verify_mode=none).
2026/08/10 16:38:01 wazuh-agentd:https-client: INFO: Starting https_client (server=192.168.56.1:1517, agent=002).
2026/08/10 16:38:01 wazuh-agentd:https-client: INFO: https_client sync intake listening on queue/sockets/queue-sync.
```

And after:

``` sql
2026/08/10 16:38:01 wazuh-agentd: INFO: (1410): Reading authentication keys file.
2026/08/10 16:38:01 wazuh-agentd: INFO: https_client: starting.
2026/08/10 16:38:01 wazuh-agentd:https-client: INFO: TLS verification is DISABLED (verify_mode=none).
2026/08/10 16:38:01 wazuh-agentd:https-client: INFO: Starting https_client (server=192.168.56.1:1517, agent=002).
2026/08/10 16:38:01 wazuh-agentd:https-client: INFO: Sync intake listening on queue/sockets/queue-sync.
```

Shared configuration arriving with `<auto_restart>yes</auto_restart>`, before, where the applied hash was reported at INFO and the restart itself was never mentioned:

``` sql
2026/08/10 16:38:03 wazuh-agentd: INFO: https_client: applying configuration downloaded over HTTPS (hash=cbbce061b393204ecc28d65b800445cd624cc3538d38c0f019ae808d1597eca1).
```

And after, with the hash moved to debug and the restart reported:

``` sql
2026/08/10 16:38:03 wazuh-agentd: INFO: Agent is reloading due to shared configuration changes.
```

The same arrival with `<auto_restart>no</auto_restart>`, which previously produced that identical reload and now stages the files silently, reporting only at debug:

``` sql
2026/08/10 16:38:03 wazuh-agentd: DEBUG: Shared agent configuration has been updated.
```

RTR timing for the `client-agent/https_client` module, measured with the same valgrind flags CI uses:

| | Before | After |
|---|---|---|
| `HcInterfaceTest.LifecycleChurn` | 21m 17s | 563 ms |
| Full unit suite under valgrind | 22m 29s | 11 s |
| Full unit suite, native | 0.25 s | 0.25 s |
| Tests passing | 302/302 | 302/302 |
| Valgrind exit code | 0 | 0 |

### Artifacts Affected

- `wazuh-agentd` (all platforms), through the bundled HTTPS client transport module.

No change to default configuration files or packaging.

### Configuration Changes

None. 

### Documentation Updates

None.

### Tests Introduced

Two unit tests in the agent's HTTPS bridge suite cover the shared-configuration reload decision that previously had none: one asserts that an agent with automatic restarts disabled stages the new configuration and does not reload, and the other asserts that the first-boot case still reloads, because leaving it out would let the modules start on stale configuration. Both assert the log line each path produces. The existing tests around the same path were updated for the new levels and wording.

`HcInterfaceTest.LifecycleChurn` was reshaped rather than added to: its producer thread is now capped and hands off to teardown on a counter instead of a sleep, so the concurrency it exercises no longer depends on how fast the machine is. All 20 churn cycles are kept and submits still race teardown.

Full agent unit test suite and the HTTPS module's own 302 unit tests pass, natively and under valgrind.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
