### PR TITLE
Reject symlinks when writing files staged under the incoming directory

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -568,6 +568,7 @@
 #define WM_UPGRADE_UNSIGN_FILE_ERROR                "(8139): At %s: Could not unsign package file '%s'"
 #define WM_UPGRADE_FILE_OPEN_ERROR                  "(8140): At %s: Unable to open '%s'"
 #define WM_UPGRADE_CANNOT_READ                      "(8141): At %s: Unable to read '%s'"
+#define WM_UPGRADE_SYMLINK_REJECTED                 "(8142): At %s: Refused to open '%s': the path is a symbolic link."
 
 #define MOD_TASK_CHECK_DB_ERROR                     "(8250): DB integrity is invalid. Exiting..."
 #define MOD_TASK_CREATE_SOCK_ERROR                  "(8251): Queue '%s' not accessible: '%s'. Exiting..."

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -368,6 +368,15 @@ https://www.gnu.org/licenses/gpl.html\n"
 #define O_CLOEXEC 0
 #endif
 
+/* Not every agent platform this tree still builds for (AIX, Solaris 10, HP-UX) is guaranteed to define
+ * O_DIRECTORY. Falling back to 0 only loses an early "this must be a directory" check: openat() on a
+ * descriptor that is not a directory fails with ENOTDIR anyway. Note that O_NOFOLLOW deliberately gets
+ * no such fallback -- defining it to 0 would silently disable a security check instead of failing the
+ * build, which is the outcome we want to hear about. */
+#ifndef O_DIRECTORY
+#define O_DIRECTORY 0
+#endif
+
 /* XML global elements */
 #ifndef xml_global
 #define xml_global "global"

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -507,15 +507,16 @@ FILE * wfopen(const char * pathname, const char * mode);
  * @brief Create or truncate a file inside a base directory for writing, without following symlinks.
  *
  * Intended for directories that only ever hold files written by Wazuh itself (var/incoming and
- * friends): a symlink, FIFO, device or directory found at the target path is rejected instead of
- * being opened through. @p filename must be a bare file name; it is rejected if it is empty, "."
- * or "..", if it refers to a parent folder, or if it contains a path separator, so the resulting
- * open cannot escape @p basedir.
+ * friends): a symlink, hard link, FIFO, device or directory found at the target path is rejected
+ * instead of being written through. @p filename must be a bare file name; it is rejected if it is
+ * empty, "." or "..", if it refers to a parent folder, or if it contains a path separator, so the
+ * resulting open cannot escape @p basedir.
  *
- * On Linux/macOS the file is opened relative to a descriptor of @p basedir with O_NOFOLLOW, and the
- * descriptor is confirmed to be a regular file before being wrapped in a stream. On Windows the
- * file is opened without reparse-point processing and truncated only after the handle has been
- * confirmed to be a regular file, so the target of a symlink or junction is never modified.
+ * On both platforms the file is opened without truncating, the descriptor is vetted, and only then is
+ * the file truncated: truncating at open time would destroy the target of a hard link before anything
+ * about it could be checked. On Linux/macOS the open is relative to a descriptor of @p basedir and
+ * uses O_NOFOLLOW; on Windows it skips reparse-point processing. In both cases the descriptor must
+ * turn out to be a regular file with a link count of exactly 1.
  *
  * @param basedir Base directory holding the file. Not created by this function.
  * @param filename Bare file name inside @p basedir.

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -408,6 +408,19 @@ int w_ref_parent_folder(const char * path);
 
 
 /**
+ * @brief Check that a name is a bare file name, safe to join to a base directory.
+ *
+ * Rejects the empty string, "." and "..", any name referring to a parent folder, and any name
+ * containing a path separator, so that joining it to a base directory cannot escape that directory
+ * and so that it can be used as-is in a directory-relative open.
+ *
+ * @param filename Name to be checked.
+ * @return 1 if the name is a bare file name, 0 otherwise.
+ */
+int w_is_bare_filename(const char * filename);
+
+
+/**
  * @brief Read directory and return an array of contained files and folders, sorted alphabetically.
  *
  * @param name Path of the directory.
@@ -488,6 +501,28 @@ int w_stat(const char * pathname,
  * @return File pointer.
  */
 FILE * wfopen(const char * pathname, const char * mode);
+
+
+/**
+ * @brief Create or truncate a file inside a base directory for writing, without following symlinks.
+ *
+ * Intended for directories that only ever hold files written by Wazuh itself (var/incoming and
+ * friends): a symlink, FIFO, device or directory found at the target path is rejected instead of
+ * being opened through. @p filename must be a bare file name; it is rejected if it is empty, "."
+ * or "..", if it refers to a parent folder, or if it contains a path separator, so the resulting
+ * open cannot escape @p basedir.
+ *
+ * On Linux/macOS the file is opened relative to a descriptor of @p basedir with O_NOFOLLOW, and the
+ * descriptor is confirmed to be a regular file before being wrapped in a stream. On Windows the
+ * file is opened without reparse-point processing and truncated only after the handle has been
+ * confirmed to be a regular file, so the target of a symlink or junction is never modified.
+ *
+ * @param basedir Base directory holding the file. Not created by this function.
+ * @param filename Bare file name inside @p basedir.
+ * @param mode Open mode, either "w" or "wb".
+ * @return File pointer on success, NULL on error (sets errno).
+ */
+FILE * w_fopen_nofollow(const char * basedir, const char * filename, const char * mode);
 
 
 /**

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -159,7 +159,8 @@ size_t wcom_uncompress(const char * source, const char * target, char ** output)
         return strlen(*output);
     }
 
-    if (ftarget = wfopen(final_target, "wb"), !ftarget) {
+    // Not wfopen(): a symlink left at final_target would be followed, truncating its target.
+    if (ftarget = w_fopen_nofollow(INCOMING_DIR, target, "wb"), !ftarget) {
         gzclose(fsource);
         merror("At WCOM uncompress: Unable to open '%s'", final_target);
         os_strdup("err Unable to open target", *output);
@@ -536,7 +537,10 @@ void * wcom_main(__attribute__((unused)) void * arg) {
 
 int _jailfile(char finalpath[PATH_MAX + 1], const char * basedir, const char * filename) {
 
-    if (w_ref_parent_folder(filename)) {
+    // A bare file name is all that is ever legitimate here. Rejecting separators also keeps the
+    // directory-relative open in w_fopen_nofollow() confined to basedir, since a separator-containing
+    // or absolute name would otherwise be resolved ignoring the directory descriptor.
+    if (!w_is_bare_filename(filename)) {
         return -1;
     }
 

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -162,7 +162,13 @@ size_t wcom_uncompress(const char * source, const char * target, char ** output)
     // Not wfopen(): a symlink left at final_target would be followed, truncating its target.
     if (ftarget = w_fopen_nofollow(INCOMING_DIR, target, "wb"), !ftarget) {
         gzclose(fsource);
-        merror("At WCOM uncompress: Unable to open '%s'", final_target);
+        // Same reasoning as in the upgrade module: strerror() has no useful text for ELOOP on Windows,
+        // so the one failure worth alerting on gets its own message.
+        if (errno == ELOOP) {
+            merror("At WCOM uncompress: Refused to open '%s': the path is a symbolic link", final_target);
+        } else {
+            merror("At WCOM uncompress: Unable to open '%s'", final_target);
+        }
         os_strdup("err Unable to open target", *output);
         return strlen(*output);
     }

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -161,10 +161,13 @@ size_t wcom_uncompress(const char * source, const char * target, char ** output)
 
     // Not wfopen(): a symlink left at final_target would be followed, truncating its target.
     if (ftarget = w_fopen_nofollow(INCOMING_DIR, target, "wb"), !ftarget) {
+        // Saved before gzclose(): the close() and free() it performs internally are free to clobber
+        // errno, which would silently downgrade the message below to the generic one.
+        const int open_errno = errno;
         gzclose(fsource);
         // Same reasoning as in the upgrade module: strerror() has no useful text for ELOOP on Windows,
         // so the one failure worth alerting on gets its own message.
-        if (errno == ELOOP) {
+        if (open_errno == ELOOP) {
             merror("At WCOM uncompress: Refused to open '%s': the path is a symbolic link", final_target);
         } else {
             merror("At WCOM uncompress: Unable to open '%s'", final_target);

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2565,6 +2565,43 @@ FILE * wfopen(const char * pathname, const char * mode) {
 }
 
 
+#ifdef WIN32
+/**
+ * Translate a Win32 error into an errno value. Assigning GetLastError() straight into errno, as the
+ * older helpers in this file do, is wrong twice over: the numbering spaces are unrelated, so strerror()
+ * prints something misleading, and a raw Win32 code can collide with an errno that callers test for --
+ * ERROR_INVALID_TARGET_HANDLE is 114, which is mingw's ELOOP, the very value w_fopen_nofollow() uses to
+ * report a rejected symlink.
+ */
+static int w_win32_to_errno(DWORD error) {
+    switch (error) {
+    case ERROR_FILE_NOT_FOUND:
+    case ERROR_PATH_NOT_FOUND:
+    case ERROR_INVALID_DRIVE:
+        return ENOENT;
+    case ERROR_ACCESS_DENIED:
+    case ERROR_NETWORK_ACCESS_DENIED:
+        return EACCES;
+    case ERROR_SHARING_VIOLATION:
+    case ERROR_LOCK_VIOLATION:
+        return EBUSY;
+    case ERROR_FILE_EXISTS:
+    case ERROR_ALREADY_EXISTS:
+        return EEXIST;
+    case ERROR_DISK_FULL:
+        return ENOSPC;
+    case ERROR_INVALID_NAME:
+    case ERROR_BAD_PATHNAME:
+        return EINVAL;
+    case ERROR_TOO_MANY_OPEN_FILES:
+        return EMFILE;
+    default:
+        return EIO;
+    }
+}
+#endif
+
+
 FILE * w_fopen_nofollow(const char * basedir, const char * filename, const char * mode) {
     if (!basedir || !mode || (strcmp(mode, "w") && strcmp(mode, "wb")) || !w_is_bare_filename(filename)) {
         errno = EINVAL;
@@ -2591,12 +2628,12 @@ FILE * w_fopen_nofollow(const char * basedir, const char * filename, const char 
                         NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
 
     if (hFile == INVALID_HANDLE_VALUE) {
-        errno = GetLastError();
+        errno = w_win32_to_errno(GetLastError());
         return NULL;
     }
 
     if (!GetFileInformationByHandle(hFile, &file_info)) {
-        errno = GetLastError();
+        errno = w_win32_to_errno(GetLastError());
         CloseHandle(hFile);
         return NULL;
     }
@@ -2624,20 +2661,24 @@ FILE * w_fopen_nofollow(const char * basedir, const char * filename, const char 
 
     // The file pointer sits at the beginning of the file, so this truncates it.
     if (!SetEndOfFile(hFile)) {
-        errno = GetLastError();
+        errno = w_win32_to_errno(GetLastError());
         CloseHandle(hFile);
         return NULL;
     }
 
+    // _open_osfhandle() and _fdopen() are CRT calls: they set errno and leave the Win32 last error
+    // alone, so errno is left exactly as they reported it.
     if (fd = _open_osfhandle((intptr_t)hFile, flags), fd < 0) {
-        errno = GetLastError();
         CloseHandle(hFile);
         return NULL;
     }
 
+    // From here on the descriptor owns the handle, so it has to be closed through the CRT: calling
+    // CloseHandle() would release the handle while leaving the descriptor allocated forever.
     if (fp = _fdopen(fd, mode), fp == NULL) {
-        errno = GetLastError();
-        CloseHandle(hFile);
+        const int fdopen_errno = errno;
+        _close(fd);
+        errno = fdopen_errno;
         return NULL;
     }
 

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2290,6 +2290,28 @@ int w_ref_parent_folder(const char * path) {
 }
 
 
+int w_is_bare_filename(const char * filename) {
+
+    // "." is not caught by w_ref_parent_folder(), which only rejects references to a parent folder.
+    if (!filename || !*filename || strcmp(filename, ".") == 0) {
+        return 0;
+    }
+
+    if (strchr(filename, '/')) {
+        return 0;
+    }
+
+#ifdef WIN32
+    // Windows accepts both separators, so a name holding either one is not a bare file name.
+    if (strchr(filename, '\\')) {
+        return 0;
+    }
+#endif
+
+    return w_ref_parent_folder(filename) ? 0 : 1;
+}
+
+
 cJSON* getunameJSON()
 {
     os_info *read_info;
@@ -2539,6 +2561,127 @@ FILE * wfopen(const char * pathname, const char * mode) {
 
 #else
     return fopen(pathname, mode);
+#endif
+}
+
+
+FILE * w_fopen_nofollow(const char * basedir, const char * filename, const char * mode) {
+    if (!basedir || !mode || (strcmp(mode, "w") && strcmp(mode, "wb")) || !w_is_bare_filename(filename)) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+#ifdef WIN32
+    char final_path[PATH_MAX + 1];
+    BY_HANDLE_FILE_INFORMATION file_info;
+    HANDLE hFile;
+    int flags = strchr(mode, 'b') ? 0 : _O_TEXT;
+    int fd;
+    FILE * fp;
+
+    if (snprintf(final_path, sizeof(final_path), "%s\\%s", basedir, filename) > PATH_MAX) {
+        errno = ENAMETOOLONG;
+        return NULL;
+    }
+
+    // OPEN_ALWAYS rather than CREATE_ALWAYS: the file must not be truncated before the handle has been
+    // confirmed to be a regular file. FILE_FLAG_OPEN_REPARSE_POINT makes the handle refer to a symlink
+    // or junction itself instead of to its target, so the target is never opened nor modified.
+    hFile = wCreateFile(final_path, GENERIC_WRITE, FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
+                        NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
+
+    if (hFile == INVALID_HANDLE_VALUE) {
+        errno = GetLastError();
+        return NULL;
+    }
+
+    if (!GetFileInformationByHandle(hFile, &file_info)) {
+        errno = GetLastError();
+        CloseHandle(hFile);
+        return NULL;
+    }
+
+    if (file_info.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
+        CloseHandle(hFile);
+        errno = ELOOP;
+        return NULL;
+    }
+
+    if (file_info.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+        CloseHandle(hFile);
+        errno = EISDIR;
+        return NULL;
+    }
+
+    // The file pointer sits at the beginning of the file, so this truncates it.
+    if (!SetEndOfFile(hFile)) {
+        errno = GetLastError();
+        CloseHandle(hFile);
+        return NULL;
+    }
+
+    if (fd = _open_osfhandle((intptr_t)hFile, flags), fd < 0) {
+        errno = GetLastError();
+        CloseHandle(hFile);
+        return NULL;
+    }
+
+    if (fp = _fdopen(fd, mode), fp == NULL) {
+        errno = GetLastError();
+        CloseHandle(hFile);
+        return NULL;
+    }
+
+    return fp;
+#else
+    struct stat statbuf;
+    FILE * fp;
+    int dirfd;
+    int fd;
+    int saved_errno;
+    int flags;
+
+    if (dirfd = open(basedir, O_RDONLY | O_DIRECTORY | O_CLOEXEC), dirfd < 0) {
+        return NULL;
+    }
+
+    // O_NOFOLLOW makes the open fail with ELOOP if the target is a symlink, and O_NONBLOCK keeps it
+    // from blocking on a FIFO waiting for a reader. Both are needed before O_TRUNC takes effect.
+    fd = openat(dirfd, filename, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW | O_CLOEXEC | O_NONBLOCK, 0640);
+    saved_errno = errno;
+    close(dirfd);
+
+    if (fd < 0) {
+        errno = saved_errno;
+        return NULL;
+    }
+
+    // Rules out anything O_NOFOLLOW does not, such as a block or character device.
+    if (fstat(fd, &statbuf) < 0) {
+        saved_errno = errno;
+        close(fd);
+        errno = saved_errno;
+        return NULL;
+    }
+
+    if (!S_ISREG(statbuf.st_mode)) {
+        close(fd);
+        errno = EINVAL;
+        return NULL;
+    }
+
+    // O_NONBLOCK has no effect on a regular file, but the stream is expected to behave like fopen's.
+    if (flags = fcntl(fd, F_GETFL), flags != -1) {
+        fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
+    }
+
+    if (fp = fdopen(fd, mode), fp == NULL) {
+        saved_errno = errno;
+        close(fd);
+        errno = saved_errno;
+    }
+
+    return fp;
 #endif
 }
 

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2613,6 +2613,15 @@ FILE * w_fopen_nofollow(const char * basedir, const char * filename, const char 
         return NULL;
     }
 
+    // An NTFS hard link carries neither of the attributes above, and unlike a symlink it needs no
+    // privilege to create (mklink /H), so it is the easier of the two to plant. The link count is the
+    // only thing that distinguishes it.
+    if (file_info.nNumberOfLinks != 1) {
+        CloseHandle(hFile);
+        errno = EMLINK;
+        return NULL;
+    }
+
     // The file pointer sits at the beginning of the file, so this truncates it.
     if (!SetEndOfFile(hFile)) {
         errno = GetLastError();
@@ -2645,9 +2654,13 @@ FILE * w_fopen_nofollow(const char * basedir, const char * filename, const char 
         return NULL;
     }
 
-    // O_NOFOLLOW makes the open fail with ELOOP if the target is a symlink, and O_NONBLOCK keeps it
-    // from blocking on a FIFO waiting for a reader. Both are needed before O_TRUNC takes effect.
-    fd = openat(dirfd, filename, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW | O_CLOEXEC | O_NONBLOCK, 0640);
+    // O_NOFOLLOW makes the open fail with ELOOP if the target is a symlink, and O_NONBLOCK keeps it from
+    // blocking on a FIFO waiting for a reader. Deliberately NOT O_TRUNC: truncating at open time would
+    // destroy the target before anything about it can be checked, which is precisely how a hard link
+    // slips through — it is a regular file, so no file type test can tell it apart. The file is
+    // truncated below instead, once the descriptor has been vetted, mirroring what the Windows branch
+    // does with OPEN_ALWAYS plus SetEndOfFile().
+    fd = openat(dirfd, filename, O_WRONLY | O_CREAT | O_NOFOLLOW | O_CLOEXEC | O_NONBLOCK, 0640);
     saved_errno = errno;
     close(dirfd);
 
@@ -2667,6 +2680,21 @@ FILE * w_fopen_nofollow(const char * basedir, const char * filename, const char 
     if (!S_ISREG(statbuf.st_mode)) {
         close(fd);
         errno = EINVAL;
+        return NULL;
+    }
+
+    // A hard link is a regular file by every other measure; the link count is what gives it away.
+    if (statbuf.st_nlink != 1) {
+        close(fd);
+        errno = EMLINK;
+        return NULL;
+    }
+
+    // Safe now: the descriptor is known to point at a lone regular file.
+    if (ftruncate(fd, 0) < 0) {
+        saved_errno = errno;
+        close(fd);
+        errno = saved_errno;
         return NULL;
     }
 

--- a/src/unit_tests/shared/test_file_op.c
+++ b/src/unit_tests/shared/test_file_op.c
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <dirent.h>
 #include <errno.h>
+#include <fcntl.h>
 #include "../headers/defs.h"
 #include "../headers/file_op.h"
 #include "../error_messages/error_messages.h"
@@ -1778,6 +1779,175 @@ void test_cldir_ex_ignore_partial_path_match(void **state) {
     assert_int_equal(ret, 0);
 }
 
+/* Tests w_fopen_nofollow */
+
+// These tests run against the real file system: a symlink cannot be mocked into existence, and the
+// property under test is precisely what the operating system does with one.
+
+static char nofollow_dir[PATH_MAX + 1];
+
+static void nofollow_path(char path[PATH_MAX + 1], const char * name) {
+    snprintf(path, PATH_MAX + 1, "%s/%s", nofollow_dir, name);
+}
+
+static void nofollow_create_file(const char * name, const char * content) {
+    char path[PATH_MAX + 1];
+    int fd;
+
+    nofollow_path(path, name);
+    fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0640);
+    assert_int_not_equal(fd, -1);
+    assert_int_equal(write(fd, content, strlen(content)), (ssize_t)strlen(content));
+    close(fd);
+}
+
+static off_t nofollow_size(const char * name) {
+    char path[PATH_MAX + 1];
+    struct stat statbuf;
+
+    nofollow_path(path, name);
+    assert_int_equal(stat(path, &statbuf), 0);
+    return statbuf.st_size;
+}
+
+static int setup_nofollow(void **state) {
+    // The file operations below must reach the file system, not the wrappers.
+    test_mode = 0;
+    snprintf(nofollow_dir, sizeof(nofollow_dir), "/tmp/wazuh_nofollow_XXXXXX");
+    assert_non_null(mkdtemp(nofollow_dir));
+    return 0;
+}
+
+static int teardown_nofollow(void **state) {
+    const char * entries[] = { "regular", "link", "dangling", "fifo", "subdir", "target", "victim", NULL };
+    char path[PATH_MAX + 1];
+    int i;
+
+    for (i = 0; entries[i]; i++) {
+        nofollow_path(path, entries[i]);
+        remove(path);
+    }
+
+    remove(nofollow_dir);
+    test_mode = 1;
+    return 0;
+}
+
+void test_w_fopen_nofollow_regular_file(void **state) {
+    FILE * fp = w_fopen_nofollow(nofollow_dir, "regular", "wb");
+
+    assert_non_null(fp);
+    assert_int_equal(fwrite("content", 1, 7, fp), 7);
+    assert_int_equal(fclose(fp), 0);
+    assert_int_equal(nofollow_size("regular"), 7);
+}
+
+void test_w_fopen_nofollow_truncates_existing_file(void **state) {
+    FILE * fp;
+
+    nofollow_create_file("regular", "previous content");
+
+    fp = w_fopen_nofollow(nofollow_dir, "regular", "wb");
+    assert_non_null(fp);
+    assert_int_equal(fclose(fp), 0);
+    assert_int_equal(nofollow_size("regular"), 0);
+}
+
+void test_w_fopen_nofollow_symlink_rejected(void **state) {
+    char target[PATH_MAX + 1];
+    char link[PATH_MAX + 1];
+
+    nofollow_create_file("victim", "sensitive data");
+    nofollow_path(target, "victim");
+    nofollow_path(link, "link");
+    assert_int_equal(symlink(target, link), 0);
+
+    errno = 0;
+    assert_null(w_fopen_nofollow(nofollow_dir, "link", "wb"));
+    // Linux and macOS report ELOOP for O_NOFOLLOW, other systems are allowed to report EMLINK.
+    assert_true(errno == ELOOP || errno == EMLINK);
+    // The whole point: the symlink target was neither opened nor truncated.
+    assert_int_equal(nofollow_size("victim"), 14);
+}
+
+void test_w_fopen_nofollow_dangling_symlink_rejected(void **state) {
+    char link[PATH_MAX + 1];
+    char created[PATH_MAX + 1];
+    struct stat statbuf;
+
+    nofollow_path(link, "dangling");
+    nofollow_path(created, "target");
+    assert_int_equal(symlink(created, link), 0);
+
+    errno = 0;
+    assert_null(w_fopen_nofollow(nofollow_dir, "dangling", "wb"));
+    assert_true(errno == ELOOP || errno == EMLINK);
+    // O_CREAT must not have created the file the dangling symlink points at.
+    assert_int_equal(stat(created, &statbuf), -1);
+}
+
+void test_w_fopen_nofollow_fifo_rejected(void **state) {
+    char path[PATH_MAX + 1];
+    struct stat statbuf;
+
+    nofollow_path(path, "fifo");
+    assert_int_equal(mkfifo(path, 0640), 0);
+
+    // Must return instead of blocking on the FIFO waiting for a reader.
+    assert_null(w_fopen_nofollow(nofollow_dir, "fifo", "wb"));
+    assert_int_equal(stat(path, &statbuf), 0);
+    assert_true(S_ISFIFO(statbuf.st_mode));
+}
+
+void test_w_fopen_nofollow_directory_rejected(void **state) {
+    char path[PATH_MAX + 1];
+
+    nofollow_path(path, "subdir");
+    assert_int_equal(mkdir(path, 0750), 0);
+
+    errno = 0;
+    assert_null(w_fopen_nofollow(nofollow_dir, "subdir", "wb"));
+    assert_int_equal(errno, EISDIR);
+}
+
+void test_w_fopen_nofollow_invalid_name(void **state) {
+    const char * names[] = { "", ".", "..", "../victim", "subdir/victim", "/etc/passwd", NULL };
+    int i;
+
+    for (i = 0; names[i]; i++) {
+        errno = 0;
+        assert_null(w_fopen_nofollow(nofollow_dir, names[i], "wb"));
+        assert_int_equal(errno, EINVAL);
+    }
+
+    errno = 0;
+    assert_null(w_fopen_nofollow(nofollow_dir, NULL, "wb"));
+    assert_int_equal(errno, EINVAL);
+}
+
+void test_w_fopen_nofollow_invalid_mode(void **state) {
+    const char * modes[] = { "r", "rb", "a", "w+", "", NULL };
+    int i;
+
+    for (i = 0; modes[i]; i++) {
+        errno = 0;
+        assert_null(w_fopen_nofollow(nofollow_dir, "regular", modes[i]));
+        assert_int_equal(errno, EINVAL);
+    }
+
+    errno = 0;
+    assert_null(w_fopen_nofollow(nofollow_dir, "regular", NULL));
+    assert_int_equal(errno, EINVAL);
+}
+
+void test_w_fopen_nofollow_missing_basedir(void **state) {
+    char basedir[PATH_MAX + 1];
+
+    snprintf(basedir, sizeof(basedir), "%s/subdir", nofollow_dir);
+
+    assert_null(w_fopen_nofollow(basedir, "regular", "wb"));
+}
+
 #endif /* TEST_WINAGENT */
 
 int main(void) {
@@ -1840,6 +2010,16 @@ int main(void) {
         cmocka_unit_test(test_cldir_ex_ignore_rmdir_ex_failure),
         cmocka_unit_test(test_cldir_ex_ignore_multiple_files_in_ignore),
         cmocka_unit_test(test_cldir_ex_ignore_partial_path_match),
+        // w_fopen_nofollow
+        cmocka_unit_test_setup_teardown(test_w_fopen_nofollow_regular_file, setup_nofollow, teardown_nofollow),
+        cmocka_unit_test_setup_teardown(test_w_fopen_nofollow_truncates_existing_file, setup_nofollow, teardown_nofollow),
+        cmocka_unit_test_setup_teardown(test_w_fopen_nofollow_symlink_rejected, setup_nofollow, teardown_nofollow),
+        cmocka_unit_test_setup_teardown(test_w_fopen_nofollow_dangling_symlink_rejected, setup_nofollow, teardown_nofollow),
+        cmocka_unit_test_setup_teardown(test_w_fopen_nofollow_fifo_rejected, setup_nofollow, teardown_nofollow),
+        cmocka_unit_test_setup_teardown(test_w_fopen_nofollow_directory_rejected, setup_nofollow, teardown_nofollow),
+        cmocka_unit_test_setup_teardown(test_w_fopen_nofollow_invalid_name, setup_nofollow, teardown_nofollow),
+        cmocka_unit_test_setup_teardown(test_w_fopen_nofollow_invalid_mode, setup_nofollow, teardown_nofollow),
+        cmocka_unit_test_setup_teardown(test_w_fopen_nofollow_missing_basedir, setup_nofollow, teardown_nofollow),
 #else
         cmocka_unit_test(test_get_UTC_modification_time_success),
         cmocka_unit_test(test_get_UTC_modification_time_fail_get_handle),

--- a/src/unit_tests/shared/test_file_op.c
+++ b/src/unit_tests/shared/test_file_op.c
@@ -1870,6 +1870,23 @@ void test_w_fopen_nofollow_symlink_rejected(void **state) {
     assert_int_equal(nofollow_size("victim"), 14);
 }
 
+void test_w_fopen_nofollow_hard_link_rejected(void **state) {
+    char target[PATH_MAX + 1];
+    char hardlink[PATH_MAX + 1];
+
+    nofollow_create_file("victim", "sensitive data");
+    nofollow_path(target, "victim");
+    nofollow_path(hardlink, "link");
+    assert_int_equal(link(target, hardlink), 0);
+
+    errno = 0;
+    assert_null(w_fopen_nofollow(nofollow_dir, "link", "wb"));
+    assert_int_equal(errno, EMLINK);
+    // A hard link is a regular file, so nothing but the link count rules it out — and the open must not
+    // have truncated it on the way to finding that out.
+    assert_int_equal(nofollow_size("victim"), 14);
+}
+
 void test_w_fopen_nofollow_dangling_symlink_rejected(void **state) {
     char link[PATH_MAX + 1];
     char created[PATH_MAX + 1];
@@ -2014,6 +2031,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_w_fopen_nofollow_regular_file, setup_nofollow, teardown_nofollow),
         cmocka_unit_test_setup_teardown(test_w_fopen_nofollow_truncates_existing_file, setup_nofollow, teardown_nofollow),
         cmocka_unit_test_setup_teardown(test_w_fopen_nofollow_symlink_rejected, setup_nofollow, teardown_nofollow),
+        cmocka_unit_test_setup_teardown(test_w_fopen_nofollow_hard_link_rejected, setup_nofollow, teardown_nofollow),
         cmocka_unit_test_setup_teardown(test_w_fopen_nofollow_dangling_symlink_rejected, setup_nofollow, teardown_nofollow),
         cmocka_unit_test_setup_teardown(test_w_fopen_nofollow_fifo_rejected, setup_nofollow, teardown_nofollow),
         cmocka_unit_test_setup_teardown(test_w_fopen_nofollow_directory_rejected, setup_nofollow, teardown_nofollow),

--- a/src/unit_tests/wazuh_modules/agent_upgrade/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/CMakeLists.txt
@@ -81,6 +81,7 @@ else()
     list(APPEND upgrade_flags "-Wl,--wrap,w_ref_parent_folder -Wl,--wrap,w_wpk_unsign -Wl,--wrap,unlink -Wl,--wrap,getpid -Wl,--wrap,gzopen \
                                -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove \
                                -Wl,--wrap,gzclose -Wl,--wrap,gzread -Wl,--wrap,mkstemp -Wl,--wrap,atexit -Wl,--wrap,chmod -Wl,--wrap,stat -Wl,--wrap,wfopen \
+                               -Wl,--wrap,w_fopen_nofollow \
                                -Wl,--wrap,OS_SHA1_File -Wl,--wrap,getDefine_Int -Wl,--wrap,cldir_ex -Wl,--wrap,UnmergeFiles -Wl,--wrap,wm_exec -Wl,--wrap,remove \
                                -Wl,--wrap,fgetpos -Wl,--wrap=fgetc  -Wl,--wrap,popen ${DEBUG_OP_WRAPPERS}")
 

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_com.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_com.c
@@ -589,6 +589,31 @@ void test_wm_agent_upgrade_com_open_invalid_open(void **state) {
     os_free(response);
 }
 
+void test_wm_agent_upgrade_com_open_symlink_rejected(void **state) {
+    cJSON * command = *state;
+
+    expect_string(__wrap_w_ref_parent_folder, path, "test_file");
+    will_return(__wrap_w_ref_parent_folder, 0);
+
+    expect_w_fopen_nofollow(INCOMING_DIR, "test_file", "w", NULL);
+
+    // The dedicated message, not the strerror-based one: on Windows strerror(ELOOP) has no text.
+    expect_string(__wrap__mterror, tag, "wazuh-modulesd:agent-upgrade");
+    expect_string(__wrap__mterror, formatted_msg,
+                  "(8142): At open: Refused to open 'test_file': the path is a symbolic link.");
+
+    errno = ELOOP;
+
+    char *response = wm_agent_upgrade_com_open(command);
+    cJSON *response_object = cJSON_Parse(response);
+    assert_int_equal(cJSON_GetObjectItem(response_object, task_manager_json_keys[WM_TASK_ERROR])->valueint, 6);
+    // The ack carries the fixed reason too, not strerror(ELOOP).
+    assert_string_equal(cJSON_GetObjectItem(response_object, task_manager_json_keys[WM_TASK_ERROR_MESSAGE])->valuestring,
+                        "File Open Error: the path is a symbolic link");
+    cJSON_Delete(response_object);
+    os_free(response);
+}
+
 void test_wm_agent_upgrade_com_open_success(void **state) {
     cJSON * command = *state;
 
@@ -1904,6 +1929,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_com_open_unsopported_mode, setup_open1, teardown_commands),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_com_open_invalid_file_name, setup_open2, teardown_commands),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_com_open_invalid_open, setup_open2, teardown_commands),
+        cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_com_open_symlink_rejected, setup_open2, teardown_commands),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_com_open_success, setup_open2, teardown_commands),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_com_write_file_closed, setup_write, teardown_commands),
         cmocka_unit_test_setup_teardown(test_wm_agent_upgrade_com_write_invalid_file_name, setup_write, teardown_commands),

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_com.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_com.c
@@ -122,6 +122,32 @@ void test_jailfile_valid_path(void **state) {
 #endif
 }
 
+void test_jailfile_empty_name(void **state) {
+    char finalpath[PATH_MAX + 1];
+
+    int ret = _jailfile(finalpath, TMP_DIR, "");
+    assert_int_equal(ret, -1);
+}
+
+void test_jailfile_current_folder(void **state) {
+    char finalpath[PATH_MAX + 1];
+
+    int ret = _jailfile(finalpath, TMP_DIR, ".");
+    assert_int_equal(ret, -1);
+}
+
+void test_jailfile_path_separator(void **state) {
+    char finalpath[PATH_MAX + 1];
+
+    int ret = _jailfile(finalpath, TMP_DIR, "subfolder/test_filename");
+    assert_int_equal(ret, -1);
+
+#ifdef TEST_WINAGENT
+    ret = _jailfile(finalpath, TMP_DIR, "subfolder\\test_filename");
+    assert_int_equal(ret, -1);
+#endif
+}
+
 void test_unsign_invalid_source_incomming(void **state) {
     char finalpath[PATH_MAX + 1];
     char *source =  *state;
@@ -549,9 +575,7 @@ void test_wm_agent_upgrade_com_open_invalid_open(void **state) {
     expect_string(__wrap_w_ref_parent_folder, path, "test_file");
     will_return(__wrap_w_ref_parent_folder, 0);
 
-    expect_any(__wrap_wfopen, path);
-    expect_string(__wrap_wfopen, mode, "w");
-    will_return(__wrap_wfopen, 0);
+    expect_w_fopen_nofollow(INCOMING_DIR, "test_file", "w", NULL);
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:agent-upgrade");
     expect_string(__wrap__mterror, formatted_msg,   "(1103): Could not open file 'test_file' due to [(2)-(No such file or directory)].");
@@ -571,9 +595,7 @@ void test_wm_agent_upgrade_com_open_success(void **state) {
     expect_string(__wrap_w_ref_parent_folder, path, "test_file");
     will_return(__wrap_w_ref_parent_folder, 0);
 
-    expect_any(__wrap_wfopen, path);
-    expect_string(__wrap_wfopen, mode, "w");
-    will_return(__wrap_wfopen, 4);
+    expect_w_fopen_nofollow(INCOMING_DIR, "test_file", "w", (FILE *)4);
 
     char *response = wm_agent_upgrade_com_open(command);
     cJSON *response_object = cJSON_Parse(response);
@@ -1857,6 +1879,9 @@ int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown(test_jailfile_invalid_path, setup_jailfile, teardown_jailfile),
         cmocka_unit_test_setup_teardown(test_jailfile_valid_path, setup_jailfile, teardown_jailfile),
+        cmocka_unit_test(test_jailfile_empty_name),
+        cmocka_unit_test(test_jailfile_current_folder),
+        cmocka_unit_test(test_jailfile_path_separator),
         cmocka_unit_test_setup_teardown(test_unsign_invalid_source_incomming, setup_jailfile, teardown_jailfile),
         cmocka_unit_test_setup_teardown(test_unsign_invalid_source_temp, setup_jailfile, teardown_jailfile),
         #ifdef TEST_WINAGENT

--- a/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.c
@@ -116,6 +116,22 @@ void expect_wfopen(const char * path, const char * mode, FILE *ret) {
     will_return(__wrap_wfopen, ret);
 }
 
+// No __real_ fallback on purpose: referencing it would force every test binary that links these
+// wrappers to pass -Wl,--wrap,w_fopen_nofollow, as happens with wfopen above.
+FILE *__wrap_w_fopen_nofollow(const char * basedir, const char * filename, const char * mode) {
+    check_expected(basedir);
+    check_expected(filename);
+    check_expected(mode);
+    return mock_type(FILE *);
+}
+
+void expect_w_fopen_nofollow(const char * basedir, const char * filename, const char * mode, FILE *ret) {
+    expect_string(__wrap_w_fopen_nofollow, basedir, basedir);
+    expect_string(__wrap_w_fopen_nofollow, filename, filename);
+    expect_string(__wrap_w_fopen_nofollow, mode, mode);
+    will_return(__wrap_w_fopen_nofollow, ret);
+}
+
 char ** __wrap_wreaddir(const char * name) {
     check_expected(name);
     return mock_type(char**);

--- a/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.h
@@ -49,6 +49,9 @@ void expect_w_uncompress_gzfile(const char * gzfilesrc, const char * gzfiledst, 
 FILE *__wrap_wfopen(const char * __filename, const char * __modes);
 void expect_wfopen(const char * __filename, const char * __modes, FILE *ret);
 
+FILE *__wrap_w_fopen_nofollow(const char * basedir, const char * filename, const char * mode);
+void expect_w_fopen_nofollow(const char * basedir, const char * filename, const char * mode, FILE *ret);
+
 char ** __wrap_wreaddir(const char * name);
 
 void expect_wreaddir_call(const char *dir, char **files);

--- a/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
+++ b/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
@@ -157,17 +157,6 @@ STATIC int _jailfile(char finalpath[PATH_MAX + 1], const char * basedir, const c
 STATIC int _unsign(const char * source, char dest[PATH_MAX + 1]);
 STATIC int _uncompress(const char * source, const char *package, char dest[PATH_MAX + 1]);
 
-#ifndef WIN32
-/**
- * Create/truncate `filename` under `basedir` for writing without following a symlink
- * placed at that path, using descriptor-relative operations (openat + O_NOFOLLOW).
- * @param basedir jailed base directory (must already have passed _jailfile validation)
- * @param filename bare file name, validated by _jailfile (no separators, no "..")
- * @return an open FILE* in "wb" mode, or NULL (errno set) on failure
- * */
-STATIC FILE * _jailfopen(const char * basedir, const char * filename);
-#endif
-
 size_t wm_agent_upgrade_process_command(const char *buffer, char **output) {
     cJSON *buffer_obj = cJSON_Parse(buffer);
 
@@ -240,11 +229,8 @@ STATIC char * wm_agent_upgrade_com_open(const cJSON* json_object) {
         return wm_agent_upgrade_command_ack(ERROR_INVALID_FILE_NAME, error_messages[ERROR_INVALID_FILE_NAME]);
     }
 
-#ifndef WIN32
-    file.fp = _jailfopen(INCOMING_DIR, file_path_obj->valuestring);
-#else
-    file.fp = wfopen(final_path, mode_obj->valuestring);
-#endif
+    // Not wfopen(): a symlink left at final_path would be followed, truncating its target.
+    file.fp = w_fopen_nofollow(INCOMING_DIR, file_path_obj->valuestring, mode_obj->valuestring);
 
     if (file.fp) {
         snprintf(file.path, sizeof(file.path), "%s", final_path);
@@ -417,16 +403,10 @@ STATIC char * wm_agent_upgrade_com_clear_result() {
 
 STATIC int _jailfile(char finalpath[PATH_MAX + 1], const char * basedir, const char * filename) {
 
-    // Reject empty names, "." and any path separator: a bare file name is all that's
-    // ever legitimate here, and rejecting separators also keeps _jailfopen()'s openat()
-    // calls confined to basedir (an absolute or separator-containing name passed to
-    // openat() would otherwise be resolved ignoring the directory descriptor).
-    if (!filename || !*filename || strcmp(filename, ".") == 0 || w_ref_parent_folder(filename)
-        || strchr(filename, '/')
-#ifdef WIN32
-        || strchr(filename, '\\')
-#endif
-    ) {
+    // A bare file name is all that is ever legitimate here. Rejecting separators also keeps the
+    // directory-relative open in w_fopen_nofollow() confined to basedir, since a separator-containing
+    // or absolute name would otherwise be resolved ignoring the directory descriptor.
+    if (!w_is_bare_filename(filename)) {
         return -1;
     }
 
@@ -436,47 +416,6 @@ STATIC int _jailfile(char finalpath[PATH_MAX + 1], const char * basedir, const c
     return snprintf(finalpath, PATH_MAX + 1, "%s\\%s", basedir, filename) > PATH_MAX ? -1 : 0;
 #endif
 }
-
-#ifndef WIN32
-STATIC FILE * _jailfopen(const char * basedir, const char * filename) {
-    int dirfd = open(basedir, O_DIRECTORY | O_CLOEXEC);
-    if (dirfd < 0) {
-        return NULL;
-    }
-
-    int fd = openat(dirfd, filename, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW | O_CLOEXEC, 0640);
-    int openat_errno = errno;
-    close(dirfd);
-
-    if (fd < 0) {
-        errno = openat_errno;
-        return NULL;
-    }
-
-    struct stat statbuf;
-    if (fstat(fd, &statbuf) < 0) {
-        int fstat_errno = errno;
-        close(fd);
-        errno = fstat_errno;
-        return NULL;
-    }
-
-    if (!S_ISREG(statbuf.st_mode)) {
-        close(fd);
-        errno = ELOOP;
-        return NULL;
-    }
-
-    FILE * fp = fdopen(fd, "wb");
-    if (!fp) {
-        int fdopen_errno = errno;
-        close(fd);
-        errno = fdopen_errno;
-    }
-
-    return fp;
-}
-#endif
 
 STATIC int _unsign(const char * source, char dest[PATH_MAX + 1]) {
     const char TEMPLATE[] = ".gz.XXXXXX";

--- a/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
+++ b/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
@@ -157,6 +157,17 @@ STATIC int _jailfile(char finalpath[PATH_MAX + 1], const char * basedir, const c
 STATIC int _unsign(const char * source, char dest[PATH_MAX + 1]);
 STATIC int _uncompress(const char * source, const char *package, char dest[PATH_MAX + 1]);
 
+#ifndef WIN32
+/**
+ * Create/truncate `filename` under `basedir` for writing without following a symlink
+ * placed at that path, using descriptor-relative operations (openat + O_NOFOLLOW).
+ * @param basedir jailed base directory (must already have passed _jailfile validation)
+ * @param filename bare file name, validated by _jailfile (no separators, no "..")
+ * @return an open FILE* in "wb" mode, or NULL (errno set) on failure
+ * */
+STATIC FILE * _jailfopen(const char * basedir, const char * filename);
+#endif
+
 size_t wm_agent_upgrade_process_command(const char *buffer, char **output) {
     cJSON *buffer_obj = cJSON_Parse(buffer);
 
@@ -229,7 +240,13 @@ STATIC char * wm_agent_upgrade_com_open(const cJSON* json_object) {
         return wm_agent_upgrade_command_ack(ERROR_INVALID_FILE_NAME, error_messages[ERROR_INVALID_FILE_NAME]);
     }
 
-    if (file.fp = wfopen(final_path, mode_obj->valuestring), file.fp) {
+#ifndef WIN32
+    file.fp = _jailfopen(INCOMING_DIR, file_path_obj->valuestring);
+#else
+    file.fp = wfopen(final_path, mode_obj->valuestring);
+#endif
+
+    if (file.fp) {
         snprintf(file.path, sizeof(file.path), "%s", final_path);
         return wm_agent_upgrade_command_ack(ERROR_OK, error_messages[ERROR_OK]);
     } else {
@@ -400,7 +417,16 @@ STATIC char * wm_agent_upgrade_com_clear_result() {
 
 STATIC int _jailfile(char finalpath[PATH_MAX + 1], const char * basedir, const char * filename) {
 
-    if (w_ref_parent_folder(filename)) {
+    // Reject empty names, "." and any path separator: a bare file name is all that's
+    // ever legitimate here, and rejecting separators also keeps _jailfopen()'s openat()
+    // calls confined to basedir (an absolute or separator-containing name passed to
+    // openat() would otherwise be resolved ignoring the directory descriptor).
+    if (!filename || !*filename || strcmp(filename, ".") == 0 || w_ref_parent_folder(filename)
+        || strchr(filename, '/')
+#ifdef WIN32
+        || strchr(filename, '\\')
+#endif
+    ) {
         return -1;
     }
 
@@ -410,6 +436,47 @@ STATIC int _jailfile(char finalpath[PATH_MAX + 1], const char * basedir, const c
     return snprintf(finalpath, PATH_MAX + 1, "%s\\%s", basedir, filename) > PATH_MAX ? -1 : 0;
 #endif
 }
+
+#ifndef WIN32
+STATIC FILE * _jailfopen(const char * basedir, const char * filename) {
+    int dirfd = open(basedir, O_DIRECTORY | O_CLOEXEC);
+    if (dirfd < 0) {
+        return NULL;
+    }
+
+    int fd = openat(dirfd, filename, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW | O_CLOEXEC, 0640);
+    int openat_errno = errno;
+    close(dirfd);
+
+    if (fd < 0) {
+        errno = openat_errno;
+        return NULL;
+    }
+
+    struct stat statbuf;
+    if (fstat(fd, &statbuf) < 0) {
+        int fstat_errno = errno;
+        close(fd);
+        errno = fstat_errno;
+        return NULL;
+    }
+
+    if (!S_ISREG(statbuf.st_mode)) {
+        close(fd);
+        errno = ELOOP;
+        return NULL;
+    }
+
+    FILE * fp = fdopen(fd, "wb");
+    if (!fp) {
+        int fdopen_errno = errno;
+        close(fd);
+        errno = fdopen_errno;
+    }
+
+    return fp;
+}
+#endif
 
 STATIC int _unsign(const char * source, char dest[PATH_MAX + 1]) {
     const char TEMPLATE[] = ".gz.XXXXXX";

--- a/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
+++ b/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
@@ -236,10 +236,24 @@ STATIC char * wm_agent_upgrade_com_open(const cJSON* json_object) {
         snprintf(file.path, sizeof(file.path), "%s", final_path);
         return wm_agent_upgrade_command_ack(ERROR_OK, error_messages[ERROR_OK]);
     } else {
-        mterror(WM_AGENT_UPGRADE_LOGTAG, FOPEN_ERROR, file_path_obj->valuestring, errno, strerror(errno));
+        // Saved before logging: mterror() writes to the log file, which is free to clobber errno.
+        const int open_errno = errno;
+        // ELOOP is what w_fopen_nofollow() reports for a symlink: from O_NOFOLLOW on POSIX, and set
+        // explicitly on Windows when the handle turns out to be a reparse point. It gets its own message
+        // and its own reason text because both otherwise lean on strerror(), which says nothing useful
+        // here — mingw has no text for ELOOP and prints "Unknown error", hiding the one case worth
+        // alerting on. The error code stays ERROR_FILE_OPEN, so the response protocol is unchanged.
+        const char *reason = (open_errno == ELOOP) ? "the path is a symbolic link" : strerror(open_errno);
+
+        if (open_errno == ELOOP) {
+            mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_SYMLINK_REJECTED, "open", file_path_obj->valuestring);
+        } else {
+            mterror(WM_AGENT_UPGRADE_LOGTAG, FOPEN_ERROR, file_path_obj->valuestring, open_errno, strerror(open_errno));
+        }
+
         char *output;
         os_malloc(OS_MAXSTR + 1, output);
-        snprintf(output, OS_MAXSTR + 1, error_messages[ERROR_FILE_OPEN], strerror(errno));
+        snprintf(output, OS_MAXSTR + 1, error_messages[ERROR_FILE_OPEN], reason);
         char *response = wm_agent_upgrade_command_ack(ERROR_FILE_OPEN, output);
         os_free(output);
         return response;


### PR DESCRIPTION
## Description

`_jailfile()` only rejected `..` in a caller-supplied file name before joining it under `INCOMING_DIR`, and never checked what the resulting path actually was. `wm_agent_upgrade_com_open()` then called `wfopen(final_path, "wb")`, which on POSIX is a plain `fopen()` and on Windows reaches `CreateFile` without `FILE_FLAG_OPEN_REPARSE_POINT`. On both platforms a symlink sitting at that path is followed and its target truncated on open, and a hard link — which no file-type test can distinguish from an ordinary file — is written straight through. No `O_NOFOLLOW`, `openat()` or `fstat()` check existed anywhere in this path.

The same `_jailfile()` exists byte-for-byte in `src/os_execd/wcom.c`, whose `wcom_uncompress()` performs the same unprotected `wfopen(final_target, "wb")` under `INCOMING_DIR`. Both dispatchers are reachable from the same remote request path (`src/client-agent/request.c`), so hardening only the upgrade module would have left the identical primitive exposed — and that second one is the worse of the two: `wcom_uncompress()` does not merely truncate the target, it writes the decompressed contents of the source archive into it, so the write is fully attacker-controlled rather than just destructive. That was measured on a live agent, not inferred; see the evidence below.

Not a vulnerability in itself — no attacker-reachable path is known today, and nothing legitimate ever places a link of either kind under `var/incoming`. Filed and fixed as hardening.

Closes #38200

Found and reported by @halas98.

## Proposed Changes

- **New `w_fopen_nofollow()`** (`src/shared/file_op.c`): creates or truncates a file inside a base directory without following links, so both call sites share one implementation instead of duplicating platform-specific logic. The order of operations is the substance of the fix: the file is opened **without** truncating, the descriptor is vetted, and only then is the file truncated. Truncating at open time would destroy the target before anything about it could be checked, which is exactly how a hard link gets through.
- **POSIX path**: opens the base directory with `O_RDONLY|O_DIRECTORY|O_CLOEXEC`, then `openat()`s the target with `O_WRONLY|O_CREAT|O_NOFOLLOW|O_CLOEXEC|O_NONBLOCK`, `fstat()`s the descriptor to confirm a regular file with a link count of exactly 1, and truncates with `ftruncate()` before `fdopen()`. `O_NONBLOCK` matters on its own: without it an existing FIFO at that path makes `openat()` block waiting for a reader, and no later check is ever reached — the thread serving the upgrade socket simply hangs.
- **Windows is covered too**, rather than left unchanged. `wfopen()` cannot be used because `CREATE_ALWAYS` truncates at open time. `w_fopen_nofollow()` opens with `OPEN_ALWAYS | FILE_FLAG_OPEN_REPARSE_POINT`, which yields a handle to a reparse point itself rather than to its target, rejects the handle if `GetFileInformationByHandle()` reports `FILE_ATTRIBUTE_REPARSE_POINT`, `FILE_ATTRIBUTE_DIRECTORY` or `nNumberOfLinks != 1`, and only then truncates with `SetEndOfFile()`. The hard-link check matters more here than on POSIX: an NTFS hard link needs no privilege to create (`mklink /H`), unlike a symlink.
- **Windows error reporting**: Win32 errors are no longer assigned straight into `errno`. The numbering spaces are unrelated, so `strerror()` printed something misleading, and a raw Win32 code could collide with an errno the callers test for — `ERROR_INVALID_TARGET_HANDLE` is 114, which is mingw's `ELOOP`, the value used to report a refused symlink. Win32 failures now go through a small mapping that cannot return `ELOOP`; CRT failures (`_open_osfhandle()`, `_fdopen()`) leave `errno` as the CRT set it. The `_fdopen()` failure path also called `CloseHandle()` after `_open_osfhandle()` had transferred ownership to the descriptor, leaking one CRT descriptor per failure; it now calls `_close()`.
- **New `w_is_bare_filename()`** (`src/shared/file_op.c`): single source of truth for the name validation, rejecting the empty string, `.`, `..`, any name referring to a parent folder, and any name containing a path separator. Rejecting separators is what keeps the directory-relative `openat()` confined to the base directory, since an absolute or separator-containing name would otherwise be resolved ignoring the directory descriptor.
- **`wm_agent_upgrade_com.c`**: `_jailfile()` now delegates to `w_is_bare_filename()`, and `wm_agent_upgrade_com_open()` calls `w_fopen_nofollow()` on every platform instead of `wfopen()`. The caller-supplied mode is still honoured and still restricted to `w`/`wb`.
- **`os_execd/wcom.c`**: the same hardening applied to its duplicated `_jailfile()` and to the `wfopen()` in `wcom_uncompress()`.
- **A message of its own for the rejection.** A refused symlink is reported as `ELOOP`, and both the log line and the command response derived their text from `strerror()`, which has nothing useful to say about it on Windows: mingw carries no message for `ELOOP` and prints `"Unknown error"`, so the one failure worth alerting on was indistinguishable from noise. This adds `WM_UPGRADE_SYMLINK_REJECTED` (8142) and a fixed reason in the ack; the error code stays `ERROR_FILE_OPEN`, so the response protocol is unchanged. `errno` is captured before logging in both call sites, since `mterror()` and `gzclose()` are both free to clobber it before the reason text is read.
- **`O_DIRECTORY` fallback** (`src/headers/defs.h`): `openat()` and `O_DIRECTORY` are the first uses of either in this tree, and the Makefile still carries AIX, Solaris and HP-UX agent branches. This is a build concern rather than a behavioural one — WPK remote upgrade is not offered for those platforms, so neither call site is ever exercised there — and falling back to 0 costs only an early check, since `openat()` on a non-directory descriptor fails with `ENOTDIR` anyway. `O_NOFOLLOW` deliberately gets no fallback: defining it to 0 would quietly disable a security check instead of failing the build.

Scope deliberately left out of this PR, worth a follow-up issue: `_uncompress()` writes into `TMP_DIR` through `wfopen()` at a predictable name, `wm_agent_upgrade_com_sha1()` reopens by path rather than by descriptor, `write`/`close` identify the open file by `strcmp()` on its path instead of by inode, and `UnmergeFiles()` repeats the same weak defense. Separately, `wfopen()` itself carries the same two Windows defects fixed here in the new helper; correcting it there would change `errno` for every consumer in the tree, which is more than this PR should take on.

### Results and Evidence

#### Unit tests

`TARGET=agent`, exercising the real file system rather than mocks — a link cannot be mocked into existence, and the property under test is precisely what the operating system does with one:

```
$ ./shared/test_file_op
[ RUN      ] test_w_fopen_nofollow_regular_file              [       OK ]
[ RUN      ] test_w_fopen_nofollow_truncates_existing_file   [       OK ]
[ RUN      ] test_w_fopen_nofollow_symlink_rejected          [       OK ]
[ RUN      ] test_w_fopen_nofollow_hard_link_rejected        [       OK ]
[ RUN      ] test_w_fopen_nofollow_dangling_symlink_rejected [       OK ]
[ RUN      ] test_w_fopen_nofollow_fifo_rejected             [       OK ]
[ RUN      ] test_w_fopen_nofollow_directory_rejected        [       OK ]
[ RUN      ] test_w_fopen_nofollow_invalid_name              [       OK ]
[ RUN      ] test_w_fopen_nofollow_invalid_mode              [       OK ]
[ RUN      ] test_w_fopen_nofollow_missing_basedir           [       OK ]
[==========] tests: 53 test(s) run.
[  PASSED  ] 53 test(s).
```

`test_w_fopen_nofollow_symlink_rejected` and `test_w_fopen_nofollow_hard_link_rejected` are the regression tests for this issue: each writes a known payload into a `victim` file, points a link at it, asserts the open fails, and asserts that `victim` still holds its bytes afterwards.

#### End-to-end A/B on a real Windows agent

Wazuh manager 4.14.9 driving a Windows Server 2022 agent, exercising the actual upgrade socket rather than a standalone program. Commands are injected on the manager through `queue/sockets/remote` using the same `"%.3d upgrade <json>"` format that `wm_agent_upgrade_send_open()` uses, which reaches `wm_agent_upgrade_process_command()` on the agent by way of `client-agent/request.c`; `wcom` is reached the same way with a `com` target. Stock 4.14.7 from the official MSI, then the same agent upgraded by a WPK built from this branch.

| Test | stock 4.14.7 | this PR |
|---|---|---|
| symlink to a file | `ok` — target **36 → 0 bytes** | `error 6 the path is a symbolic link` — 36 bytes, content intact |
| **hard link** (`mklink /H`, no privilege needed) | `ok` — target **30 → 0 bytes** | `error 6 Too many links` — 30 bytes, content intact |
| **symlink, `com uncompress`** | `ok` — target **overwritten with the archive payload** | `err Unable to open target` — content intact |
| junction (`mklink /J`) | `error 6 Input/output error` | `error 6 Permission denied` |
| directory | `error 6 Input/output error` | `error 6 Permission denied` |
| `subdir/x.wpk` | `error 6 No such process` | `error 5 Invalid file name` |
| truncation of an existing file | 36 → 0 bytes | 36 → 0 bytes |
| plain valid name | `error 0` | `error 0` |

The junction and directory rows show the Windows error-reporting fix rather than a change in outcome: both were already refused, but by `CreateFile` failing with `ERROR_ACCESS_DENIED` for `GENERIC_WRITE` on a directory. That code is 5, and the old `errno = GetLastError()` made `strerror()` print `EIO`'s text, `"Input/output error"`. It now maps to `EACCES` and reads `"Permission denied"`, which is what actually happened.

The rejection as it appears on the agent:

```
ack:       {"error":6,"message":"File Open Error: the path is a symbolic link","data":[]}
ossec.log: wazuh-modulesd:agent-upgrade: ERROR: (8142): At open: Refused to open 'malicious.wpk': the path is a symbolic link.
           wazuh-agent: ERROR: At WCOM uncompress: Refused to open 'incoming\target.wpk': the path is a symbolic link
```

The two lines carry different tags because the two call sites live in different daemons.

No regression in the upgrade flow. A real WPK upgrade was run twice: once from the stock agent, which delivered the patched build, and once again from the **patched** agent — the run that matters, because that is this code executing `open → write → close → sha1 → upgrade`:

```
Agent 004 upgraded: Wazuh v4.14.7 -> Wazuh v4.14.9      # transfer executed by stock code
Agent 004 upgraded: Wazuh v4.14.9 -> Wazuh v4.14.9      # transfer executed by this code
```

Repeating the symlink and hard-link tests after that upgrade still refuses both with the targets intact.

#### End-to-end A/B on a real Linux agent

Ubuntu 22.04 agent against the same manager. On POSIX both call sites listen on local sockets — the upgrade module on `queue/sockets/upgrade` and `wcom` on `queue/sockets/com` — so these were driven directly on the agent.

| Test | stock 4.14.7 | this PR |
|---|---|---|
| symlink, `upgrade` socket | `ok` — target **36 → 0 bytes** | `error 6 the path is a symbolic link` — 36 bytes, content intact |
| **hard link** | `ok` — target **30 → 0 bytes** | `error 6 Too many links` — 30 bytes, content intact |
| **symlink, `com uncompress`** | `ok` — target **overwritten with the archive payload** | `err Unable to open target` — content intact |
| **FIFO** | **blocks** — the socket thread is left stuck in `openat()` | `error 6 No such device or address` (`ENXIO`), returns immediately |
| directory | `error 6 Is a directory` | `error 6 Is a directory` — unchanged |
| `subdir/x.wpk` | `error 6 No such file or directory` | `error 5 Invalid file name` |
| `../x.wpk` | `error 5 Invalid file name` | `error 5 Invalid file name` — unchanged |
| `.` | `error 6 Is a directory` | `error 5 Invalid file name` |
| truncation of an existing file | 36 → 0 bytes | 36 → 0 bytes |
| mode of a newly created file | `644 root:root` | `640 root:root` |

The FIFO row is why `O_NONBLOCK` is part of this change: on the stock agent that request never returns and the thread serving the upgrade socket stays stuck, so the agent had to be restarted before the run could continue. The `com uncompress` row is the arbitrary-write case — on the stock agent the target did not end up empty, it ended up containing the payload from the source archive. The truncation row is the regression check for moving truncation out of the open: with `O_TRUNC` gone, a mistake there would leave stale bytes in legitimately written WPKs. A real WPK upgrade executed by the patched agent (`v4.14.9 -> v4.14.9`) confirms the whole path end to end.

Two rows deliberately reported as unchanged rather than as wins: a plain directory was already refused by `fopen()` with `EISDIR`, and `../x.wpk` was already caught by `w_ref_parent_folder()`. What the name validation actually adds is rejecting `.` and rejecting embedded separators, both of which the old `_jailfile()` accepted.

For transparency on how these were gathered: the Linux stock comparison and the hard-link comparison were run against successive builds of this branch rather than in a single pass — the hard link was found by review after the first round — while the Windows table above is a single A/B against the final state of the branch. Every row was observed, none inferred.

#### Not verified

- The `_fdopen()` descriptor leak is verified by inspection and compilation only. Forcing that path means exhausting the CRT descriptor table, which was not attempted.
- The `O_DIRECTORY` fallback cannot be exercised here: on Linux and mingw the macro is defined, so the fallback is inert. It would take an AIX, Solaris or HP-UX build to reach it.
- macOS was not exercised on an agent. The POSIX path is shared with Linux, and `O_NOFOLLOW`, `O_NONBLOCK`, `st_nlink` and `ftruncate()` behave the same there.

### Artifacts Affected

- `wazuh-modulesd` — agent upgrade module, both POSIX and Windows agent builds.
- `wazuh-execd` — `wcom` request dispatcher, agent-side only. Reachable remotely from the manager on every platform, and additionally on a local socket (`queue/sockets/com`) on POSIX.
- `libwazuh` — two new public functions in `src/shared/file_op.c` plus one file-static Win32 error mapper; no existing function changes behavior, so no other consumer is affected.

Behavioral change only, no new files or binaries. One deliberate difference: files created under `var/incoming` are now created with mode `0640` instead of `fopen()`'s `0666 & ~umask`, matching the permissions `_unsign()` already applies to its temporary files. Files that already exist keep their mode, since the creation mode only applies on creation.

### Configuration Changes

N/A — no configuration option is added, removed or reinterpreted.

### Documentation Updates

N/A — no user-facing behavior changes; the new shared functions are documented with Doxygen comments in `src/headers/file_op.h`.

### Tests Introduced

- `src/unit_tests/shared/test_file_op.c` — ten new tests covering `w_fopen_nofollow()` against the real file system: regular file creation, truncation of an existing file, symlink rejection with the target left intact, hard link rejection with the target left intact, dangling symlink rejection with no file created at the link target, FIFO rejection without blocking, directory rejection, invalid names (empty, `.`, `..`, `../victim`, `subdir/victim`, absolute, `NULL`), invalid modes, and a missing base directory.
- `src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_com.c` — three new `_jailfile()` rejection cases (empty name, `.`, path separator including the Windows separator under `TEST_WINAGENT`), a new case asserting that an `ELOOP` failure produces message 8142 and the fixed reason in the ack rather than `strerror()` text, and the two `wm_agent_upgrade_com_open()` tests migrated from `__wrap_wfopen` to the new `__wrap_w_fopen_nofollow`.
- `src/unit_tests/wrappers/wazuh/shared/file_op_wrappers.{c,h}` — wrapper and `expect_` helper for `w_fopen_nofollow`. It intentionally has no `__real_` fallback: referencing one would force every test binary that links these wrappers to add `-Wl,--wrap,w_fopen_nofollow`, which is exactly why `--wrap,wfopen` appears in so many flag lists today.

Note for reviewers on where the evidence comes from: on `4.14.x`, `src/unit_tests/wazuh_modules/CMakeLists.txt` only adds `add_subdirectory(agent_upgrade)` under `TARGET=server`, while `test_wm_agent_upgrade_com` and `test_wm_agent_upgrade_agent` are declared in the `else()` branch of that subdirectory's own `CMakeLists.txt`. Those two binaries are therefore never compiled on this branch — the changes to that file are verified by compilation only, and will run on the upward merge to `5.0.0`, where both are wired for `agent` and `winagent`. That is why the executable unit-test evidence above comes from `test_file_op`, where the security property now lives, and why the module-level behavior is evidenced by the end-to-end A/B on real agents instead.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented — N/A, no configuration changes
- [x] Developer documentation reflects the changes — Doxygen comments on both new shared functions
- [ ] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
