### PR TITLE
Add same_user PAM frequency rule

### DIFF
--- a/ruleset/rules/0085-pam_rules.xml
+++ b/ruleset/rules/0085-pam_rules.xml
@@ -78,6 +78,17 @@
     <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>
 
+  <rule id="5558" level="10" frequency="8" timeframe="180">
+    <if_matched_sid>5503</if_matched_sid>
+    <same_user />
+    <description>PAM: Multiple failed logins for the same user in a small period of time.</description>
+    <mitre>
+      <id>T1110</id>
+    </mitre>
+    <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+  </rule>
+
+
   <rule id="5552" level="0">
     <if_sid>5500</if_sid>
     <match>gdm:auth): conversation failed</match>


### PR DESCRIPTION
## Description

Adds a PAM frequency rule to detect repeated authentication failures for the same user when a source IP is unavailable.

This addresses the detection gap where rule `5551` uses `<same_source_ip />` and therefore cannot detect repeated failures for local authentication events without a source IP.

Closes #16252

## Proposed Changes

* Added PAM rule `5558`.
* The rule monitors events matched by rule `5503`.
* Uses `<same_user />` to correlate repeated authentication failures for the same user.
* Triggers after 8 matching failures within 180 seconds.
* Uses level 10 and MITRE ATT&CK technique `T1110`.
* Preserves the existing compliance groups used by the related PAM brute force detection rule.

### Results and Evidence

The new rule was added to:

`ruleset/rules/0085-pam_rules.xml`

The resulting rule is:

```xml
<rule id="5558" level="10" frequency="8" timeframe="180">
  <if_matched_sid>5503</if_matched_sid>
  <same_user />
  <description>PAM: Multiple failed logins for the same user in a small period of time.</description>
  <mitre>
    <id>T1110</id>
  </mitre>
  <group>authentication_failures,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_11.4,gpg13_7.8,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
</rule>
```

Manual validation performed:

* XML parsing completed successfully.
* Verified rule `5558` exists exactly once.
* Verified the final branch contains only the intended rule change.
* `git diff --check` completed without errors.

### Manual tests with their corresponding evidence

* Compilation without warnings on every supported platform

  * [ ] Linux
  * [ ] Windows
  * [ ] MAC OS X

* [x] Log syntax and correct language review

* Memory tests for Linux

  * [ ] Coverity
  * [ ] Valgrind (memcheck and descriptor leaks check)
  * [ ] AddressSanitizer

* Memory tests for Windows

  * [ ] Coverity
  * [ ] UMDH

* Memory tests for macOS

  * [ ] Leaks
  * [ ] AddressSanitizer

* Decoder/Rule tests *(Wazuh v4.x)*

  * [ ] Added unit testing files ".ini"
  * [ ] `runtests.py` executed without errors

* Engine *(Wazuh v5.x and above)*

  * [ ] Test run in parallel
  * [ ] ASAN for test (utest/ctest)
  * [ ] TSAN for test and wazuh-engine.

* Wazuh server API/Framework

  * [ ] Run API Integration Tests

### Artifacts Affected

* `ruleset/rules/0085-pam_rules.xml`

### Configuration Changes

N/A

### Tests Introduced

Manual validation was performed using wazuh-logtest with repeated local PAM authentication failures where rhost was unavailable. After 8 matching failures for the same user within the configured 180 second timeframe, rule 5558 triggered successfully at level 10.

The final ruleset was also checked to confirm that rule 5558 exists exactly once, and git diff --check completed without errors.

## Review Checklist

* [x] Code changes reviewed
* [x] Relevant evidence provided
* [ ] Tests cover the new functionality
* [x] Configuration changes documented
* [ ] Developer documentation reflects the changes
* [ ] Meets requirements and/or definition of done
* [ ] No unresolved dependencies with other issues
