### PR TITLE
Remove stale EC2-timing exclusion in syscollector-rtr

### DIFF
--- a/.github/workflows/4_testcomponent_syscollector-rtr.yml
+++ b/.github/workflows/4_testcomponent_syscollector-rtr.yml
@@ -44,14 +44,6 @@ jobs:
         with:
           python-version-file: ".github/workflows/.python-version"
           architecture: x64
-      - name: Exclude timing-sensitive test on CodeBuild runners
-        if: matrix.module == 'wazuh_modules/syscollector'
-        # TODO(codebuild-temp): Remove when destroyWaitsForSyncLoopCompletion is fixed for EC2.
-        # The test sleeps 1 s assuming the first syscollector scan completes in that time, but EC2
-        # instances are slower than self-hosted runners. destroy() returns before syncLoopExited
-        # is set to true, causing the assertion at syscollectorImp_test.cpp:2523 to fail.
-        run: |
-          echo "GTEST_FILTER=-SyscollectorImpTest.destroyWaitsForSyncLoopCompletion" >> $GITHUB_ENV
       - name: Run RTR for module ${{ matrix.module }} and target ${{ matrix.target }}
         run: |
           cd src/


### PR DESCRIPTION
|Related issue|
|---|
|#38265|

## Description

`4_testcomponent_syscollector-rtr.yml` still excluded `SyscollectorImpTest.destroyWaitsForSyncLoopCompletion` via a `GTEST_FILTER` override, under a step named "Exclude timing-sensitive test on CodeBuild runners". That exclusion existed only because this workflow used to run on AWS CodeBuild/EC2 runners, which were slower than the test's 1-second timing assumption. #38223 already moved this workflow's `runs-on:` back to `ubuntu-24.04` (GitHub-hosted), but left this now-inapplicable exclusion step in place under a comment that no longer matches reality. #38188 did the identical runner reversion on `5.0.0`'s equivalent file and dropped this same exclusion there — `origin/5.0.0`'s current copy of that file has no such step at all.

This PR removes the stale exclusion step (and its `GTEST_FILTER` override) from `4_testcomponent_syscollector-rtr.yml`, so `SyscollectorImpTest.destroyWaitsForSyncLoopCompletion` runs like every other test in the suite again.

Closes #38265.

## Configuration options

N/A — this PR only changes a CI workflow file (`.github/workflows/4_testcomponent_syscollector-rtr.yml`). No configuration parameters are affected.

## Logs/Alerts example

N/A for application logs/alerts — this is a CI-workflow-only change with no product-log output. Evidence instead comes from two workflow runs of the RTR job with the exclusion step removed:

**Real GitHub Actions run (authoritative):** [run 31234482085](https://github.com/wazuh/wazuh/actions/runs/31234482085), dispatched via `workflow_dispatch` on this PR's branch, head SHA `b621177d165b3302ea9b4feeacc52016ee0a91f4` — **conclusion: success**. All 12 matrix jobs (4 modules × 3 targets) passed, including all three `wazuh_modules/syscollector` targets (`agent`, `winagent`, `server`).

Relevant excerpt from the `wazuh_modules/syscollector`, `agent` job log ([job 93044404017](https://github.com/wazuh/wazuh/actions/runs/31234482085/job/93044404017)) — no exclusion step runs, and the full test suite (which now includes the previously-filtered test) passes:

```
[95m <wazuh_modules/syscollector>=============== Running Tests       ===============<wazuh_modules/syscollector>
[92m [sys_normalizer_unit_test: PASSED]
[92m [syscollectorimp_unit_test: PASSED]
[92m <wazuh_modules/syscollector>[All tests: PASSED]<wazuh_modules/syscollector>
[95m <wazuh_modules/syscollector>=============== Running Coverage    ===============<wazuh_modules/syscollector>
[92m [Lines Coverage 96.5%: PASSED]
[92m [Functions Coverage 100.0%: PASSED]
[95m <wazuh_modules/syscollector>=============== Running Valgrind    ===============<wazuh_modules/syscollector>
[92m [sys_normalizer_unit_test : PASSED]
[92m [syscollectorimp_unit_test : PASSED]
[92m <wazuh_modules/syscollector>[Memory leak check: PASSED]<wazuh_modules/syscollector>
[92m [ASAN: PASSED]
[92m <wazuh_modules/syscollector>[RTR: PASSED]<wazuh_modules/syscollector>
```

**Local corroboration before pushing:** the same workflow (scoped to `wazuh_modules/syscollector`/`agent`) was also run locally through a container-based GitHub Actions runner emulator to validate the change before consuming CI minutes. It reached the same result — `[All tests: PASSED]`, `[RTR: PASSED]` — confirming the fix ahead of the real dispatch above.

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [x] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components

<!-- Ruleset required checks, rules/decoder -->
- Decoder/Rule tests
  - [ ] Added unit testing files ".ini"
  - [ ] runtests.py executed without errors
