### PR TITLE
Windows agent: safer MSI upgrade under a pending system restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## [v4.14.9]
 
+### Agent
+
+#### Fixed
+
+- Fixed the Windows agent MSI upgrade leaving the agent broken after the next reboot, and the silent `/q` upgrade hanging, when a system restart was pending. ([#38277](https://github.com/wazuh/wazuh/pull/38277))
+
 ## [v4.14.8]
 
 ### Manager

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -203,14 +203,15 @@ function install {
 
         write-output "$(Get-Date -format u) - Installing MSI to: $installDir (msiexec.exe $($msiArgs -join ' '))" >> .\upgrade\upgrade.log
 
-        Start-Process -FilePath "msiexec.exe" -ArgumentList $msiArgs -Wait -NoNewWindow
+        $process = Start-Process -FilePath "msiexec.exe" -ArgumentList $msiArgs -Wait -NoNewWindow -PassThru
+        write-output "$(Get-Date -format u) - msiexec finished with exit code: $($process.ExitCode)." >> .\upgrade\upgrade.log
+
+        return $process.ExitCode
 
     } catch {
         write-output "$(Get-Date -format u) - Installation failed: $($_.Exception.Message)" >> .\upgrade\upgrade.log
-        return $false
+        return -1
     }
-
-    return $true
 }
 
 # Check that the Wazuh installation runs on the expected path
@@ -242,7 +243,7 @@ if ($msi_new_version -ne $null) {
 Get-Process msiexec | Stop-Process -ErrorAction SilentlyContinue -Force
 
 # Install with explicit INSTALLDIR
-install -installDir $wazuhDir
+$msi_exit_code = install -installDir $wazuhDir
 check-installation
 
 write-output "$(Get-Date -format u) - Installation finished." >> .\upgrade\upgrade.log
@@ -266,15 +267,20 @@ while($status -ne "connected"  -And $counter -gt 0) {
 }
 Write-Output "$(Get-Date -Format u) - Reading status file: status='$status'." >> .\upgrade\upgrade.log
 
-if ($status -ne "connected") {
-    write-output "$(Get-Date -format u) - Upgrade failed." >> .\upgrade\upgrade.log
+# Verify the committed on-disk state before reporting success, instead of trusting
+# the staged files alone. The upgrade is successful only if msiexec committed cleanly
+# (exit code 0; a reboot-required result is a failure because a restart is never
+# allowed), the version written to disk matches the MSI, and the agent reconnects.
+$new_version = get-version
+$version_ok = ($msi_new_version -eq $null) -or ("v$new_version" -eq $msi_new_version)
+
+if ($msi_exit_code -ne 0 -Or (-Not $version_ok) -Or ($status -ne "connected")) {
+    write-output "$(Get-Date -format u) - Upgrade failed (msiexec exit code: $($msi_exit_code), on-disk version: $($new_version), status: $($status))." >> .\upgrade\upgrade.log
     write-output "2" | out-file ".\upgrade\upgrade_result" -encoding ascii
 }
 else {
     write-output "0" | out-file ".\upgrade\upgrade_result" -encoding ascii
-    write-output "$(Get-Date -format u) - Upgrade finished successfully." >> .\upgrade\upgrade.log
-    $new_version = get-version
-    write-output "$(Get-Date -format u) - New version: $($new_version)." >> .\upgrade\upgrade.log
+    write-output "$(Get-Date -format u) - Upgrade finished successfully. New version: $($new_version)." >> .\upgrade\upgrade.log
 }
 
 remove_upgrade_files

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -149,17 +149,19 @@ function Get-MSIProductVersion {
     }
 
     try {
-        # Get the line that contains "ProductVersion"
-        $msi_version_info = Get-Content $logFilePath | Select-String "ProductVersion" | ForEach-Object { $_.Line }
+        # Match "ProductVersion = x.y.z" and take the first hit. Matching directly with
+        # Select-String avoids running -match against a collection of lines, which does not
+        # populate $Matches and would leave a stale or empty version.
+        $match = Get-Content $logFilePath | Select-String -Pattern "ProductVersion\s*=\s*([0-9\.]+)" | Select-Object -First 1
 
         # Check if the version format is valid
-        if (-not ($msi_version_info -match "ProductVersion\s*=\s*([0-9\.]+)")) {
+        if (-not $match) {
             write-output "$(Get-Date -format u) - Invalid ProductVersion format in the MSI log: $logFilePath" >> .\upgrade\upgrade.log
             return $null
         }
 
         # Return the version with the 'v' prefix
-        $product_version = "v$($matches[1])"
+        $product_version = "v$($match.Matches[0].Groups[1].Value)"
         return $product_version
 
     } catch {
@@ -272,7 +274,12 @@ Write-Output "$(Get-Date -Format u) - Reading status file: status='$status'." >>
 # (exit code 0; a reboot-required result is a failure because a restart is never
 # allowed), the version written to disk matches the MSI, and the agent reconnects.
 $new_version = get-version
-$version_ok = ($msi_new_version -eq $null) -or ("v$new_version" -eq $msi_new_version)
+if ($msi_new_version -eq $null) {
+    write-output "$(Get-Date -format u) - Skipping on-disk version check: the MSI version could not be determined." >> .\upgrade\upgrade.log
+    $version_ok = $true
+} else {
+    $version_ok = ("v$new_version" -eq $msi_new_version)
+}
 
 if ($msi_exit_code -ne 0 -Or (-Not $version_ok) -Or ($status -ne "connected")) {
     write-output "$(Get-Date -format u) - Upgrade failed (msiexec exit code: $($msi_exit_code), on-disk version: $($new_version), status: $($status))." >> .\upgrade\upgrade.log

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -6,6 +6,12 @@
 
         <!-- Never restart the machine nor prompt for a restart during install, upgrade or uninstall. -->
         <Property Id="REBOOT" Value="ReallySuppress" />
+
+        <!-- Do not run while a system restart is pending: abort before making any change so the
+             install is never left half-committed and later broken by the pending restart. Uninstall
+             and repair of an already-installed product are still allowed. -->
+        <Condition Message="A system restart is pending on this computer. Please reboot and run the Wazuh agent installer again."><![CDATA[Installed OR NOT MsiSystemRebootPending]]></Condition>
+
         <!-- Default configuration values -->
         <Property Id="WAZUH_MANAGER" Secure="yes"/>
         <Property Id="WAZUH_MANAGER_PORT" Secure="yes"/>

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -4,6 +4,8 @@
         <Package Description="Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring" Comments="wazuh-agent" InstallerVersion="200" Compressed="yes" />
         <Media Id="1" Cabinet="simple.cab" EmbedCab="yes" CompressionLevel="high" />
 
+        <!-- Never restart the machine nor prompt for a restart during install, upgrade or uninstall. -->
+        <Property Id="REBOOT" Value="ReallySuppress" />
         <!-- Default configuration values -->
         <Property Id="WAZUH_MANAGER" Secure="yes"/>
         <Property Id="WAZUH_MANAGER_PORT" Secure="yes"/>

--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -4,8 +4,6 @@
         <Package Description="Wazuh helps you to gain security visibility into your infrastructure by monitoring hosts at an operating system and application level. It provides the following capabilities: log analysis, file integrity monitoring, intrusions detection and policy and compliance monitoring" Comments="wazuh-agent" InstallerVersion="200" Compressed="yes" />
         <Media Id="1" Cabinet="simple.cab" EmbedCab="yes" CompressionLevel="high" />
 
-        <!-- Disable Restart Manager -->
-        <Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable"/>
         <!-- Default configuration values -->
         <Property Id="WAZUH_MANAGER" Secure="yes"/>
         <Property Id="WAZUH_MANAGER_PORT" Secure="yes"/>


### PR DESCRIPTION
## Description

The Windows agent MSI could behave incorrectly when the host had a **pending system restart** (`MsiSystemRebootPending=1`), for example during an OS cumulative-update transition:

- A silent (`/q`) upgrade of a **running** agent could stall on the built-in *FilesInUse* handling until an internal timeout, because the Restart Manager was disabled.
- An upgrade could report success while file operations were deferred to the next restart; on that restart the install was reverted, leaving the agent incomplete and `WazuhSvc` unregistered.

This PR makes the installer honor two invariants: **it never restarts the system**, and **it never leaves the package in a half-committed state**. It does so by returning to the Restart Manager for in-place file replacement, suppressing any installer-initiated restart, aborting cleanly when a restart is already pending, and making the WPK upgrade script validate the committed result before reporting success.

## Proposed Changes

- **Re-enable the Restart Manager** in the MSI (remove `MSIRESTARTMANAGERCONTROL=Disable`). The running agent's binary is released and replaced in place, which removes the silent-upgrade stall and avoids scheduling file operations for the next restart. The GUI is still force-closed by the existing `CloseGUI` action, so the reason it was originally disabled no longer applies.
- **Suppress all installer-initiated restarts** by authoring `REBOOT=ReallySuppress` into the package, so no invocation path (interactive, silent `/q`, or WPK) can restart the machine or prompt for a restart.
- **Abort cleanly when a restart is pending** via a launch condition on `MsiSystemRebootPending`. Fresh installs and upgrades stop before making any change; uninstall and repair of an already-installed product are still allowed, so the user is never trapped and any existing agent stays intact.
- **Stop the WPK upgrade from reporting a false success** in `do_upgrade.ps1`: capture the `msiexec` exit code (a reboot-required result is treated as a failure), verify that the version committed on disk matches the MSI, and only then report success; otherwise report failure and leave the previous agent running.

### Results and Evidence

Verified on Windows (build 26200) with the agent already installed and **running**, and a
**pending system restart** in place, using the documented silent upgrade
(`msiexec /i wazuh-agent-4.14.9-1.msi /qn /l*v install.log`). The installer aborts cleanly at
`LaunchConditions` **before any file or registry change**: `msiexec` returns `1603` (fail-fast,
not a false success), no restart is triggered, and the existing running agent is left untouched.

Key lines from the verbose log (full `install.log` attached):

```
Adding MsiSystemRebootPending property. Its value is '1'.                 <- pending restart detected
Adding WIX_UPGRADE_DETECTED property. Its value is '{4C64...}'            <- upgrade over the running agent
Property(S): REBOOT = ReallySuppress                                      <- restart suppression active
Property(S): WAZUHRUNNING = Running
Action start ...: LaunchConditions.
Product: Wazuh Agent -- A system restart is pending on this computer. Please reboot and run the Wazuh agent installer again.
Action ended ...: LaunchConditions. Return value 3.
Action ended ...: INSTALL. Return value 3.
Product: Wazuh Agent -- Installation failed.
... Installation success or error status: 1603.
MainEngineThread is returning 1603
```

Crucially, no `InstallValidate`, `RemoveExistingProducts`, `InstallFiles` or any deferred/commit
action runs after `LaunchConditions`, so nothing is staged or queued for the next restart:
`wazuh-agent.exe`, `WazuhSvc` and `VERSION.json` remain as they were and the agent keeps running.
The `1603` here is the intended fail-fast ("aborted before making changes"), not a broken install.
When invoked from WPK, `do_upgrade.ps1` now treats this non-zero exit as a failure and leaves the
previous agent in place instead of reporting success.

**Baseline (no pending restart) — running agent upgrades cleanly:** with the pending-restart state
removed, the same silent command upgrades a **running** agent to 4.14.9 and returns exit code `0`,
with no restart. `VERSION.json` after the upgrade:

```json
{
    "version": "4.14.9",
    "stage": "alpha0"
}
```

The 4.14.9 package uses the Restart Manager and carries `REBOOT=ReallySuppress` with no
`MSIRESTARTMANAGERCONTROL` property (full `install2.log` attached):

```
RESTART MANAGER: Will attempt to shut down and restart applications in no UI modes.
RESTART MANAGER: Detected that the service WazuhSvc will be stopped ... we will not attempt to stop this service using Restart Manager
Property(S): ProductVersion = 4.14.9
Property(S): REBOOT = ReallySuppress
... Installation success or error status: 0.
MainEngineThread is returning 0
```

Any `RESTART MANAGER: Disabled by MSIRESTARTMANAGERCONTROL` / FilesInUse lines in this log come
from removing the previously installed 4.14.6 (`Property(N): ProductVersion = 4.14.6`, built before
this change), not from the 4.14.9 package. Upgrades starting from a build that already includes this
change no longer take that path.

**Post-reboot health check:** after the baseline upgrade to 4.14.9, the host was restarted. The
agent starts, enrolls, connects and comes online normally — the install survives the restart intact,
with no reverted files or missing service (`ossec.log` attached):

```
wazuh-agent: INFO: Valid key received
wazuh-agent: INFO: Trying to connect to server ([127.0.0.1]:1514/tcp).
wazuh-agent: INFO: (4102): Connected to the server ([127.0.0.1]:1514/tcp).
wazuh-agent: INFO: Agent is now online. Process unlocked, continuing...
sca: INFO: Security Configuration Assessment scan finished. Duration: 127 seconds.
```

The SCA scan runs from the installed ruleset under `C:\Program Files (x86)\ossec-agent\`, confirming
the upgraded files are present and functional after the restart.

**How to reproduce / verify (pending-restart scenario):**

Preconditions: a Windows host with the agent installed and running (e.g. 4.14.5).

1. Put the system into a pending-restart state by adding a benign pending file rename
   (single line; works in both Command Prompt and PowerShell):
   ```
   reg add "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager" /v PendingFileRenameOperations /t REG_MULTI_SZ /d "\??\C:\pending-test.tmp\0" /f
   ```
2. Attempt the upgrade:
   ```
   msiexec /i wazuh-agent-4.14.9-1.msi /qn /l*v install.log
   ```
3. Expected result (fixed): `msiexec` fails fast with exit code `1603` and `install.log`
   contains the message *"A system restart is pending on this computer..."*. No files are
   modified: `wazuh-agent.exe`, `WazuhSvc` and `VERSION.json` remain as before, and the
   original agent keeps running. After restarting the host, the agent is still the original
   version and fully functional (no leftover `*.save`-only / incomplete install).
4. Remove the test state and confirm a normal upgrade still works:
   ```
   reg delete "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager" /v PendingFileRenameOperations /f
   msiexec /i wazuh-agent-4.14.9-1.msi /qn /l*v install2.log
   ```
   Expected: the upgrade completes, `VERSION.json` reflects the new version, `WazuhSvc` is
   running, and the machine is not restarted.

Complementary check (running-agent silent upgrade): with the agent running and **no** pending
restart, `msiexec /i wazuh-agent-<ver>.msi /qn` completes without stalling on FilesInUse.

### Artifacts Affected

- Windows agent MSI package (`wazuh-agent-*.msi`, built from `wazuh-installer.wxs`).
- WPK remote-upgrade bundle (includes `do_upgrade.ps1`).

### Configuration Changes

None. The changes are internal to the MSI packaging; no user-facing configuration is added or modified.

### Documentation Updates

None required.

### Tests Introduced

N/A — there are no automated tests for the MSI installer. Manual verification steps are provided under *Results and Evidence*.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
