### PR TITLE
Regenerate the 5.0.1 changelog in the table format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,49 @@
-# [v5.0.1]
+## [v5.0.1]
 
-## Added
+### Manager
 
-## Changed
+#### Added
 
-## Removed
+| Issue | Comment |
+|-------|---------|
 
-## Fixed
+#### Changed
+
+| Issue | Comment |
+|-------|---------|
+
+#### Removed
+
+| Issue | Comment |
+|-------|---------|
+
+#### Fixed
+
+| Issue | Comment |
+|-------|---------|
+
+### Agent
+
+#### Added
+
+| Issue | Comment |
+|-------|---------|
+
+#### Changed
+
+| Issue | Comment |
+|-------|---------|
+
+#### Removed
+
+| Issue | Comment |
+|-------|---------|
+
+#### Fixed
+
+| Issue | Comment |
+|-------|---------|
 
 ## Prior versions
 
-- [v5.0.0](https://github.com/wazuh/wazuh/blob/5.0.0/CHANGELOG.md)
+- [v5.0.0](https://github.com/wazuh/wazuh/blob/v5.0.0/CHANGELOG.md)


### PR DESCRIPTION
## Description

Part of #38255.

The `5.0.1` root `CHANGELOG.md` was still in the pre-table format (`# [v5.0.1]` with flat `## Added/Changed/...` sections and a `blob/5.0.0` prior-versions link), so the table format established in `5.0.0` by #38076 never reached it: the `5.0.0 -> 5.0.1` upward merge could not carry it because `5.0.1` used a link-based skeleton with no inline block.

## Proposed Changes

- Regenerate `CHANGELOG.md` as the exact skeleton produced by `tools/repository_bumper.sh` (`update_root_changelog`) for `v5.0.1`: `## [v5.0.1]` with `### Manager`/`### Agent` groups, each with `#### Added/Changed/Removed/Fixed` blocks holding an empty `| Issue | Comment |` table, plus `## Prior versions` linking to `v5.0.0`.
- Tables are empty on purpose: there are no `5.0.1`-specific entries yet. Only the format is fixed so future entries and the bumper stay consistent.

### Results and Evidence

Generated with the bumper's own skeleton logic, so it matches byte-for-byte what a bump to `5.0.1` would produce.

```
$ head -1 CHANGELOG.md          -> ## [v5.0.1]
$ grep -c '| Issue | Comment |' CHANGELOG.md   -> 8   (Manager+Agent x4 blocks)
$ grep 'Prior versions' -A2 CHANGELOG.md        -> - [v5.0.0](.../blob/v5.0.0/CHANGELOG.md)
```

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
