### PR TITLE
Adjust the agent's shipped configuration and batching limits

### DIFF
--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -11,14 +11,6 @@
       <port>1517</port>
     </server>
 
-    <!-- HTTPS transport TLS settings; verification_mode: full|certificate|none (default: none).
-         Set to 'full' or 'certificate' and provide certificate_authorities to verify the
-         manager's certificate. -->
-    <ssl>
-      <!-- <certificate_authorities>etc/certs/root-ca.pem</certificate_authorities> -->
-      <verification_mode>none</verification_mode>
-    </ssl>
-
     <config-profile>debian, debian8</config-profile>
   </agent>
 

--- a/src/client-agent/https_client/include/https_client.h
+++ b/src/client-agent/https_client/include/https_client.h
@@ -138,7 +138,7 @@ typedef struct hc_config_t
     uint32_t buffer_flood_tolerance_s; ///< agent.tolerance: seconds FULL must
     ///< hold before FLOOD; 0 -> 15.
 
-    uint32_t notify_interval_s;         ///< notify_time; 0 -> 20.
+    uint32_t notify_interval_s;         ///< notify_time; 0 -> 10.
     uint32_t rejected_retry_interval_s; ///< Slow re-Startup cadence; 0 -> 60.
 
     /// Safety bound for a remote_upgrade WPK download; 0 -> 200 MiB.

--- a/src/client-agent/https_client/src/httpsClientFacade.cpp
+++ b/src/client-agent/https_client/src/httpsClientFacade.cpp
@@ -24,7 +24,7 @@ namespace
     /// "" when fn is null, so an unset callback degrades to "no extra metadata"
     /// rather than a crash.
     std::function<std::string()> makeMetadataCollector(void (*fn)(char*, size_t, void*),
-                                                        void* userData)
+                                                       void* userData)
     {
         return [fn, userData]() -> std::string
         {

--- a/src/client-agent/https_client/src/moduleConfig.cpp
+++ b/src/client-agent/https_client/src/moduleConfig.cpp
@@ -47,7 +47,7 @@ ModuleConfig ModuleConfig::fromC(const hc_config_t& config)
     typed.bufferWarnLevel = orDefault<uint32_t>(config.buffer_warn_level, 90);
     typed.bufferNormalLevel = orDefault<uint32_t>(config.buffer_normal_level, 70);
     typed.bufferFloodToleranceS = orDefault<uint32_t>(config.buffer_flood_tolerance_s, 15);
-    typed.notifyIntervalS = orDefault<uint32_t>(config.notify_interval_s, 20);
+    typed.notifyIntervalS = orDefault<uint32_t>(config.notify_interval_s, 10);
     typed.rejectedRetryIntervalS = orDefault<uint32_t>(config.rejected_retry_interval_s, 60);
     typed.wpkMaxDownloadBytes = orDefault<uint64_t>(config.wpk_max_download_bytes, 200ULL * 1024 * 1024);
     typed.statsEnabled = config.stats_enabled;

--- a/src/client-agent/https_client/src/moduleConfig.hpp
+++ b/src/client-agent/https_client/src/moduleConfig.hpp
@@ -48,7 +48,7 @@ struct ModuleConfig
         uint32_t bufferNormalLevel {70};
         uint32_t bufferFloodToleranceS {15};
 
-        uint32_t notifyIntervalS {20};
+        uint32_t notifyIntervalS {10};
         uint32_t rejectedRetryIntervalS {60};
 
         /// Safety bound for a remote_upgrade WPK download: stops a

--- a/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
+++ b/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
@@ -427,6 +427,48 @@ TEST_F(FacadeE2eTest, IntervalFlushesABatchThatNeverReachesTheSize)
     EXPECT_TRUE(waitForBody(peek, "/peek/stateless", "interval-only-flush", 4000));
 }
 
+TEST_F(FacadeE2eTest, ControlKeepsItsNotifyCadenceWhileEventsAreStillBatching)
+{
+    // /control is not part of the batch. The batch window here outlasts the test,
+    // so the submitted event has to still be sitting in the accumulator when the
+    // notifies land -- which is what makes this an observation and not a guess: if
+    // the two planes shared a timer, either the notifies would stall behind the
+    // batch or the event would ride out with one of them.
+    const uint16_t port = TLS_PORT + 11;
+    FakeManager manager {port, KEY_HEX, /*tls=*/true};
+
+    Recorder recorder;
+    hc_config_t config = tlsConfig();
+    config.server_port = port;
+    config.notify_interval_s = 1;
+    config.batch_size_bytes = 1024 * 1024; // No size flush.
+    config.batch_interval_ms = 60000;      // No interval flush while this test runs.
+    hc_callbacks_t callbacks {};
+    callbacks.on_startup_result = onStartup;
+    callbacks.user_data = &recorder;
+
+    hc_handle* handle = hc_create(&config, &callbacks);
+    ASSERT_NE(nullptr, handle);
+    const HandleGuard guard {handle};
+    ASSERT_TRUE(hc_start(handle));
+    ASSERT_TRUE(waitFor(recorder.startupCount, 1, 3000));
+
+    const std::string event = "1:/loc:held-in-the-batch";
+    ASSERT_TRUE(hc_submit_event(handle, reinterpret_cast<const uint8_t*>(event.data()),
+                                event.size()));
+
+    httplib::Client peek {std::string {"https://127.0.0.1:"} + std::to_string(port)};
+    peek.enable_server_certificate_verification(false);
+    const int notifiesBefore = peekCount(peek, "/peek/notifies");
+
+    // Three notify_time periods' worth of notifies, none of them waiting on the batch.
+    EXPECT_TRUE(waitForCount(peek, "/peek/notifies", notifiesBefore + 3, 8000));
+
+    const auto stateless = peek.Get("/peek/stateless");
+    ASSERT_TRUE(static_cast<bool>(stateless));
+    EXPECT_EQ(std::string::npos, stateless->body.find("held-in-the-batch"));
+}
+
 TEST_F(FacadeE2eTest, LargeSyncSessionFromTheIntakeSocketReachesTheManager)
 {
     // The full chain: a producer streams a multi-MB session over the local

--- a/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
+++ b/src/client-agent/https_client/tests/component/facadeE2e_component_test.cpp
@@ -395,6 +395,38 @@ TEST_F(FacadeE2eTest, SizeThresholdFlushesBeforeTheBatchInterval)
     EXPECT_NE(std::string::npos, received.find("size-wakeup-first"));
 }
 
+TEST_F(FacadeE2eTest, IntervalFlushesABatchThatNeverReachesTheSize)
+{
+    // The companion to SizeThresholdFlushesBeforeTheBatchInterval: the same OR,
+    // seen from the other side. One short event against a 1 MiB limit can only
+    // leave when the interval closes the window.
+    const uint16_t port = TLS_PORT + 10;
+    FakeManager manager {port, KEY_HEX, /*tls=*/true};
+
+    Recorder recorder;
+    hc_config_t config = tlsConfig();
+    config.server_port = port;
+    config.batch_size_bytes = 1024 * 1024; // Far above anything this test sends.
+    config.batch_interval_ms = 300;
+    hc_callbacks_t callbacks {};
+    callbacks.on_startup_result = onStartup;
+    callbacks.user_data = &recorder;
+
+    hc_handle* handle = hc_create(&config, &callbacks);
+    ASSERT_NE(nullptr, handle);
+    const HandleGuard guard {handle};
+    ASSERT_TRUE(hc_start(handle));
+    ASSERT_TRUE(waitFor(recorder.startupCount, 1, 3000));
+
+    const std::string event = "1:/loc:interval-only-flush";
+    ASSERT_TRUE(hc_submit_event(handle, reinterpret_cast<const uint8_t*>(event.data()),
+                                event.size()));
+
+    httplib::Client peek {std::string {"https://127.0.0.1:"} + std::to_string(port)};
+    peek.enable_server_certificate_verification(false);
+    EXPECT_TRUE(waitForBody(peek, "/peek/stateless", "interval-only-flush", 4000));
+}
+
 TEST_F(FacadeE2eTest, LargeSyncSessionFromTheIntakeSocketReachesTheManager)
 {
     // The full chain: a producer streams a multi-MB session over the local

--- a/src/client-agent/https_client/tests/unit/moduleConfig_test.cpp
+++ b/src/client-agent/https_client/tests/unit/moduleConfig_test.cpp
@@ -41,7 +41,7 @@ TEST(ModuleConfigTest, DefaultsAppliedOnZeroFields)
     EXPECT_EQ(1024u * 1024u, typed.batchSizeBytes);
     EXPECT_EQ(10000u, typed.batchIntervalMs);
     EXPECT_EQ(4u, typed.bufferCapMultiplier);
-    EXPECT_EQ(20u, typed.notifyIntervalS);
+    EXPECT_EQ(10u, typed.notifyIntervalS);
     EXPECT_EQ(60u, typed.rejectedRetryIntervalS);
     EXPECT_EQ(10000u, typed.requestTimeoutMs);
     EXPECT_EQ(120000u, typed.statefulTimeoutMs);

--- a/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
@@ -52,7 +52,7 @@ namespace
         const auto jsonStart = start + prefix.size();
         const auto newline = sentBody.find('\n', jsonStart);
         const auto jsonText = sentBody.substr(
-            jsonStart, newline == std::string::npos ? std::string::npos : newline - jsonStart);
+                                  jsonStart, newline == std::string::npos ? std::string::npos : newline - jsonStart);
         return nlohmann::json::parse(jsonText)["wazuh"];
     }
 
@@ -281,7 +281,8 @@ TEST_F(StatelessStreamTest, HeaderLineIsRefreshedOnEveryFlushNotCachedAtConstruc
     // line must reflect collectHost's CURRENT return value at each flush, not
     // whatever was available when the stream was built.
     std::string clusterName = "";
-    StatelessStream stream {
+    StatelessStream stream
+    {
         m_config,   m_performer, m_signer, m_clock, m_random, m_sink, m_authGate,
         [&clusterName]
         {

--- a/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
@@ -133,6 +133,22 @@ TEST_F(StatelessStreamTest, FlushOnSizeThresholdSendsHeaderAndEvents)
     EXPECT_LE(sentBody.size(), m_config.batchSizeBytes);
 }
 
+TEST_F(StatelessStreamTest, FlushesOnTheIntervalWithoutEverReachingTheSize)
+{
+    // The other arm of <batch>: a batch leaves on size OR on interval. One short
+    // event never crosses the size threshold, so the interval is the only thing
+    // that can get it out -- without it a quiet agent would sit on its events.
+    // WillOnce also pins the first half of the rule: the tick before the interval
+    // elapses must not send, or this expectation sees two calls.
+    EXPECT_CALL(m_performer, perform(_)).WillOnce(Return(response(TransportStatus::Ok, 200)));
+
+    EXPECT_FALSE(submitResult("a").shouldWakeSender); // Below the size threshold.
+    EXPECT_EQ(std::chrono::milliseconds {m_config.batchIntervalMs}, m_stream.tick(m_waiter, false));
+
+    m_clock.advance(std::chrono::milliseconds {m_config.batchIntervalMs});
+    m_stream.tick(m_waiter, false);
+}
+
 TEST_F(StatelessStreamTest, TheHeaderLineEscapesTheAgentId)
 {
     // The H line is JSON: an id carrying a quote must not be able to close the

--- a/src/client-agent/src/config.c
+++ b/src/client-agent/src/config.c
@@ -52,6 +52,12 @@ int ClientConf(const char *cfgfile)
     agt->main_ip_update_interval = 0;
     agt->server_count = 0;
 
+    /* The shipped configuration carries no <ssl> block, so this is the posture most
+     * agents actually run with -- as is any config written before the HTTPS transport
+     * existed. It is not the enum's zero value (FULL), which would make every one of
+     * those agents refuse to start on a missing CA, so it has to be set by hand. */
+    agt->ssl.verification_mode = AGENT_VERIFY_NONE;
+
 #ifndef WIN32
     atc->package_uninstallation = false;
 #endif

--- a/src/client-agent/src/main.c
+++ b/src/client-agent/src/main.c
@@ -161,12 +161,6 @@ int main(int argc, char **argv)
         merror_exit(MEM_ERROR, errno, strerror(errno));
     }
 
-    /* Default to no TLS verification when <ssl> is absent from the config -- e.g. an
-     * unmodified pre-HTTPS config (upgrade case: no <ssl> block at all), which would
-     * otherwise hard-exit on AG_INV_SSL_CA. ClientConf()/Read_Client_SSL() below still
-     * overrides this to whatever <ssl><verification_mode> the config actually sets. */
-    agt->ssl.verification_mode = AGENT_VERIFY_NONE;
-
     atc = (anti_tampering *)calloc(1, sizeof(anti_tampering));
     if (!atc) {
         merror_exit(MEM_ERROR, errno, strerror(errno));

--- a/src/config/include/client-config.h
+++ b/src/config/include/client-config.h
@@ -115,6 +115,20 @@ bool Validate_Address(agent_server *servers);
  */
 bool Validate_IPv6_Link_Local_Interface(agent_server *servers);
 
+/**
+ * @brief Read the <agent><batch> limits, for daemons that do not own the block.
+ *
+ * agentd reads the whole <agent> block; the daemons hosting the sync protocol need
+ * the same limits without it, since Read_Agent fills structures agentd allocates
+ * beforehand. The local file is read first and the centralized one second, so the
+ * manager's value wins - the order ClientConf applies them in.
+ *
+ * @param cfgfile Local configuration file, or NULL to skip it.
+ * @param sharedcfg Centralized configuration file, or NULL to skip it.
+ * @param batch Limits to fill; each value is left alone when unconfigured.
+ */
+void w_read_agent_batch(const char *cfgfile, const char *sharedcfg, agent_batch *batch);
+
 #define DEFAULT_MAX_RETRIES 5
 #define DEFAULT_RETRY_INTERVAL 10
 

--- a/src/config/include/client-config.h
+++ b/src/config/include/client-config.h
@@ -30,9 +30,8 @@ typedef struct agent_server {
 /* TLS verification posture for the HTTPS transport.
  * Values mirror the module ABI's hc_verify_mode_t so the bridge can copy them
  * verbatim into hc_config_t. FULL is 0, so a zero-initialized struct that never
- * goes through the agent's own default-setting path (main.c/win_utils.c, right
- * after allocating agt) still fails closed. The agent's own configured default
- * (when <ssl> is absent) is NONE, set explicitly there -- see AGENT_VERIFY_NONE. */
+ * goes through the agent's own default-setting path (ClientConf) still fails
+ * closed. The agent's own default, applied when <ssl> is absent, is NONE. */
 typedef enum agent_verify_mode_t {
     AGENT_VERIFY_FULL = 0, ///< Verify peer against the CA and check the hostname.
     AGENT_VERIFY_CERT = 1, ///< Verify peer against the CA only.

--- a/src/config/include/config.h
+++ b/src/config/include/config.h
@@ -56,11 +56,12 @@ int Read_SCA(const OS_XML *xml, xml_node *node, void *d1, void *d2);
 int Read_AGENT_INFO(const OS_XML* xml, xml_node* node, void* d1);
 
 /**
- * @brief Read the configuration for client section with centralized configuration
+ * @brief Read the <agent> block as it arrives through the centralized configuration
+ * @param xml XML object
  * @param node XML node to analyze
- * @param d1 Pub/Sub configuration structure
+ * @param d1 Agent configuration structure
  */
-int Read_Agent_Shared(XML_NODE node, void *d1);
+int Read_Agent_Shared(const OS_XML *xml, XML_NODE node, void *d1);
 
 /**
  * @brief Read the configuration for Google Cloud Pub/Sub

--- a/src/config/src/client-config.c
+++ b/src/config/src/client-config.c
@@ -760,21 +760,41 @@ static int read_local_agent_batch(const char *cfgfile, agent *out)
     return result;
 }
 
+/**
+ * @brief Copy the limits one source set over what the caller already had.
+ *
+ * Each limit stands on its own, so a source naming only one leaves the other alone --
+ * which is how the centralized block overrides just the parts it mentions.
+ */
+static void apply_agent_batch(const agent_batch *from, agent_batch *to)
+{
+    if (from->size > 0) {
+        to->size = from->size;
+    }
+
+    if (from->interval > 0) {
+        to->interval = from->interval;
+    }
+}
+
 void w_read_agent_batch(const char *cfgfile, const char *sharedcfg, agent_batch *batch)
 {
-    agent parsed = { .server = NULL };
+    agent local = { .server = NULL };
+    agent shared = { .server = NULL };
 
     if (!batch) {
         return;
     }
 
     /* Read_Agent_Batch fills each limit as it walks it, so a block whose second
-     * element is invalid has already assigned the first. Nothing is applied unless
-     * both reads come back clean: a rejected configuration must leave the caller on
-     * its defaults, not on the half of it that happened to parse. */
-    if (cfgfile && read_local_agent_batch(cfgfile, &parsed) < 0) {
+     * element is invalid has already assigned the first. Nothing is applied unless the
+     * read comes back clean: a rejected configuration must leave the caller on its
+     * defaults, not on the half of it that happened to parse. */
+    if (cfgfile && read_local_agent_batch(cfgfile, &local) < 0) {
         return;
     }
+
+    apply_agent_batch(&local.batch, batch);
 
     /* The centralized file goes through ReadConfig so it gets the same
      * agent_config name/os/profile filtering every other module gets; the local
@@ -782,19 +802,26 @@ void w_read_agent_batch(const char *cfgfile, const char *sharedcfg, agent_batch 
      *
      * Checked for existence first because ReadConfig answers OS_INVALID for a file
      * that is merely absent, and most agents have never been pushed one -- without
-     * this, "no shared configuration" would throw away the local <batch> too. */
+     * this, "no shared configuration" would throw away the local <batch> too.
+     *
+     * Read into a struct of its own so a rejected centralized block cannot be
+     * half-applied on top of a local one that did parse, and so that local one still
+     * stands when the centralized file is unusable. That last part is what agentd
+     * already does with the same two files -- ClientConf does not check this call at
+     * all -- and without it one agent runs two different session limits, agentd on
+     * the local value and syscheckd and the modules on the built-in default.
+     *
+     * Warned about here because ReadConfig stays quiet on the agent: its XML_ERROR is
+     * compiled out under CLIENT for centralized reads, so nothing else says why the
+     * pushed limits were ignored. */
     if (sharedcfg && w_is_file(sharedcfg) &&
-            ReadConfig(CCLIENT | CAGENT_CONFIG, sharedcfg, &parsed, NULL) < 0) {
+            ReadConfig(CCLIENT | CAGENT_CONFIG, sharedcfg, &shared, NULL) < 0) {
+        mwarn("Could not read the centralized configuration '%s'. Keeping the local <agent><batch> limits.",
+              sharedcfg);
         return;
     }
 
-    if (parsed.batch.size > 0) {
-        batch->size = parsed.batch.size;
-    }
-
-    if (parsed.batch.interval > 0) {
-        batch->interval = parsed.batch.interval;
-    }
+    apply_agent_batch(&shared.batch, batch);
 }
 
 int Read_Agent_Enrollment(XML_NODE node, agent * logr){

--- a/src/config/src/client-config.c
+++ b/src/config/src/client-config.c
@@ -671,6 +671,95 @@ int Read_Agent_Batch(XML_NODE node, agent * logr)
     return (0);
 }
 
+/**
+ * @brief Read <batch> out of one <agent> block, ignoring every other option.
+ */
+static void read_batch_of_agent_block(const OS_XML *xml, xml_node *agent_node, agent *out)
+{
+    XML_NODE options = OS_GetElementsbyNode(xml, agent_node);
+
+    for (int i = 0; options && options[i]; i++) {
+        XML_NODE limits = NULL;
+
+        if (!options[i]->element || strcmp(options[i]->element, "batch") != 0) {
+            continue;
+        }
+
+        if ((limits = OS_GetElementsbyNode(xml, options[i]))) {
+            Read_Agent_Batch(limits, out);
+            OS_ClearNode(limits);
+        }
+    }
+
+    OS_ClearNode(options);
+}
+
+/**
+ * @brief Walk one configuration root looking for <agent> blocks.
+ */
+static void read_batch_of_root(const OS_XML *xml, xml_node *root_node, agent *out)
+{
+    XML_NODE blocks = OS_GetElementsbyNode(xml, root_node);
+
+    for (int i = 0; blocks && blocks[i]; i++) {
+        if (blocks[i]->element && strcmp(blocks[i]->element, "agent") == 0) {
+            read_batch_of_agent_block(xml, blocks[i], out);
+        }
+    }
+
+    OS_ClearNode(blocks);
+}
+
+/**
+ * @brief Read <agent><batch> straight out of a local configuration file.
+ */
+static void read_local_agent_batch(const char *cfgfile, agent *out)
+{
+    OS_XML xml;
+    XML_NODE root = NULL;
+
+    if (OS_ReadXML(cfgfile, &xml) < 0) {
+        return; /* Unreadable or absent: the caller's values stand. */
+    }
+
+    root = OS_GetElementsbyNode(&xml, NULL);
+
+    for (int i = 0; root && root[i]; i++) {
+        read_batch_of_root(&xml, root[i], out);
+    }
+
+    OS_ClearNode(root);
+    OS_ClearXML(&xml);
+}
+
+void w_read_agent_batch(const char *cfgfile, const char *sharedcfg, agent_batch *batch)
+{
+    agent parsed = { .server = NULL };
+
+    if (!batch) {
+        return;
+    }
+
+    if (cfgfile) {
+        read_local_agent_batch(cfgfile, &parsed);
+    }
+
+    /* The centralized file goes through ReadConfig so it gets the same
+     * agent_config name/os/profile filtering every other module gets; the local
+     * one cannot, because Read_Agent expects structures agentd sets up first. */
+    if (sharedcfg) {
+        ReadConfig(CCLIENT | CAGENT_CONFIG, sharedcfg, &parsed, NULL);
+    }
+
+    if (parsed.batch.size > 0) {
+        batch->size = parsed.batch.size;
+    }
+
+    if (parsed.batch.interval > 0) {
+        batch->interval = parsed.batch.interval;
+    }
+}
+
 int Read_Agent_Enrollment(XML_NODE node, agent * logr){
     /* XML definitions */
     const char *xml_enabled = "enabled";

--- a/src/config/src/client-config.c
+++ b/src/config/src/client-config.c
@@ -637,6 +637,12 @@ int Read_Agent_Batch(XML_NODE node, agent * logr)
      * keeps the milliseconds the module wants inside 32 bits. */
     const long max_interval = 86400;
 
+    /* Upper bound so the value survives the trip into a 32-bit agent's size_t, where
+     * anything past 4 GiB wraps -- and exactly 4 GiB wraps to zero, which every reader
+     * takes as "unset". A gigabyte is already far past useful: the stateless
+     * accumulator reserves a multiple of this, and one sync session is held to it. */
+    const long long max_size = 1024LL * 1024 * 1024;
+
     for (int j = 0; node[j]; j++) {
         if (!node[j]->element) {
             merror(XML_ELEMNULL);
@@ -647,7 +653,7 @@ int Read_Agent_Batch(XML_NODE node, agent * logr)
         } else if (strcmp(node[j]->element, xml_size) == 0) {
             const long long size = w_validate_bytes(node[j]->content);
 
-            if (size <= 0) {
+            if (size <= 0 || size > max_size) {
                 merror(XML_VALUEERR, node[j]->element, node[j]->content);
                 return (OS_INVALID);
             }
@@ -673,10 +679,12 @@ int Read_Agent_Batch(XML_NODE node, agent * logr)
 
 /**
  * @brief Read <batch> out of one <agent> block, ignoring every other option.
+ * @return 0 on success, OS_INVALID when the block does not parse.
  */
-static void read_batch_of_agent_block(const OS_XML *xml, xml_node *agent_node, agent *out)
+static int read_batch_of_agent_block(const OS_XML *xml, xml_node *agent_node, agent *out)
 {
     XML_NODE options = OS_GetElementsbyNode(xml, agent_node);
+    int result = 0;
 
     for (int i = 0; options && options[i]; i++) {
         XML_NODE limits = NULL;
@@ -686,50 +694,70 @@ static void read_batch_of_agent_block(const OS_XML *xml, xml_node *agent_node, a
         }
 
         if ((limits = OS_GetElementsbyNode(xml, options[i]))) {
-            Read_Agent_Batch(limits, out);
+            if (Read_Agent_Batch(limits, out) < 0) {
+                result = OS_INVALID;
+            }
+
             OS_ClearNode(limits);
         }
     }
 
     OS_ClearNode(options);
+    return result;
 }
 
 /**
  * @brief Walk one configuration root looking for <agent> blocks.
+ * @return 0 on success, OS_INVALID when any of them does not parse.
  */
-static void read_batch_of_root(const OS_XML *xml, xml_node *root_node, agent *out)
+static int read_batch_of_root(const OS_XML *xml, xml_node *root_node, agent *out)
 {
     XML_NODE blocks = OS_GetElementsbyNode(xml, root_node);
+    int result = 0;
 
     for (int i = 0; blocks && blocks[i]; i++) {
         if (blocks[i]->element && strcmp(blocks[i]->element, "agent") == 0) {
-            read_batch_of_agent_block(xml, blocks[i], out);
+            if (read_batch_of_agent_block(xml, blocks[i], out) < 0) {
+                result = OS_INVALID;
+            }
         }
     }
 
     OS_ClearNode(blocks);
+    return result;
 }
 
 /**
  * @brief Read <agent><batch> straight out of a local configuration file.
+ * @return 0 when the file had nothing to object to (including having nothing to say,
+ *         or not being there at all), OS_INVALID when a block was rejected.
  */
-static void read_local_agent_batch(const char *cfgfile, agent *out)
+static int read_local_agent_batch(const char *cfgfile, agent *out)
 {
     OS_XML xml;
     XML_NODE root = NULL;
+    int result = 0;
 
     if (OS_ReadXML(cfgfile, &xml) < 0) {
-        return; /* Unreadable or absent: the caller's values stand. */
+        /* Absent or unreadable: nothing to contribute, and not this function's to
+         * report -- the daemon reads the same file for its own configuration and
+         * fails loudly there. A failed read still leaves the object holding
+         * whatever it allocated before giving up, so it is cleared either way. */
+        OS_ClearXML(&xml);
+        return 0;
     }
 
     root = OS_GetElementsbyNode(&xml, NULL);
 
     for (int i = 0; root && root[i]; i++) {
-        read_batch_of_root(&xml, root[i], out);
+        if (read_batch_of_root(&xml, root[i], out) < 0) {
+            result = OS_INVALID;
+        }
     }
 
     OS_ClearNode(root);
     OS_ClearXML(&xml);
+    return result;
 }
 
 void w_read_agent_batch(const char *cfgfile, const char *sharedcfg, agent_batch *batch)
@@ -740,15 +768,24 @@ void w_read_agent_batch(const char *cfgfile, const char *sharedcfg, agent_batch 
         return;
     }
 
-    if (cfgfile) {
-        read_local_agent_batch(cfgfile, &parsed);
+    /* Read_Agent_Batch fills each limit as it walks it, so a block whose second
+     * element is invalid has already assigned the first. Nothing is applied unless
+     * both reads come back clean: a rejected configuration must leave the caller on
+     * its defaults, not on the half of it that happened to parse. */
+    if (cfgfile && read_local_agent_batch(cfgfile, &parsed) < 0) {
+        return;
     }
 
     /* The centralized file goes through ReadConfig so it gets the same
      * agent_config name/os/profile filtering every other module gets; the local
-     * one cannot, because Read_Agent expects structures agentd sets up first. */
-    if (sharedcfg) {
-        ReadConfig(CCLIENT | CAGENT_CONFIG, sharedcfg, &parsed, NULL);
+     * one cannot, because Read_Agent expects structures agentd sets up first.
+     *
+     * Checked for existence first because ReadConfig answers OS_INVALID for a file
+     * that is merely absent, and most agents have never been pushed one -- without
+     * this, "no shared configuration" would throw away the local <batch> too. */
+    if (sharedcfg && w_is_file(sharedcfg) &&
+            ReadConfig(CCLIENT | CAGENT_CONFIG, sharedcfg, &parsed, NULL) < 0) {
+        return;
     }
 
     if (parsed.batch.size > 0) {

--- a/src/config/src/client-config.c
+++ b/src/config/src/client-config.c
@@ -294,17 +294,36 @@ int Read_Legacy_Client_Address(const OS_XML *xml, XML_NODE node, void *d1, __att
     return (0);
 }
 
-int Read_Agent_Shared(XML_NODE node, void *d1)
+int Read_Agent_Shared(const OS_XML *xml, XML_NODE node, void *d1)
 {
+    /* XML definitions - what a manager may set through the centralized
+     * configuration. Everything else in <agent> stays local to the endpoint. */
+    const char *xml_agent_batch = "batch";
+
+    agent * logr = (agent *)d1;
     int i = 0;
 
     for (i = 0; node[i]; i++) {
+        XML_NODE chld_node = NULL;
+
         if (!node[i]->element) {
             merror(XML_ELEMNULL);
             return (OS_INVALID);
         } else if (!node[i]->content) {
             merror(XML_VALUENULL, node[i]->element);
             return (OS_INVALID);
+        } else if (strcmp(node[i]->element, xml_agent_batch) == 0) {
+            /* How much traffic an agent is allowed to push at the manager is a
+             * fleet-wide call, not a per-endpoint one, so <batch> is pushed the
+             * same way the module configurations already are (#38163). */
+            if ((chld_node = OS_GetElementsbyNode(xml, node[i]))) {
+                if (Read_Agent_Batch(chld_node, logr) < 0) {
+                    OS_ClearNode(chld_node);
+                    return (OS_INVALID);
+                }
+
+                OS_ClearNode(chld_node);
+            }
         } else if (strcmp(node[i]->element, "force_reconnect_interval") == 0) {
             mwarn("Deprecated option 'force_reconnect_interval' is not longer available.");
         } else {

--- a/src/config/src/config.c
+++ b/src/config/src/config.c
@@ -88,7 +88,7 @@ static int read_main_elements(const OS_XML *xml, int modules,
         } else if (chld_node && (strcmp(node[i]->element, osagent) == 0)) {
             if (modules & CCLIENT) {
                 if (modules & CAGENT_CONFIG) {
-                    if (Read_Agent_Shared(chld_node, d1) < 0) {
+                    if (Read_Agent_Shared(xml, chld_node, d1) < 0) {
                         goto fail;
                     }
                 }
@@ -104,7 +104,7 @@ static int read_main_elements(const OS_XML *xml, int modules,
              * is read from it - as the fallback for <agent><server><address>. */
             if (modules & CCLIENT) {
                 if (modules & CAGENT_CONFIG) {
-                    if (Read_Agent_Shared(chld_node, d1) < 0){
+                    if (Read_Agent_Shared(xml, chld_node, d1) < 0){
                         goto fail;
                     }
                 }

--- a/src/config/src/config.c
+++ b/src/config/src/config.c
@@ -287,11 +287,17 @@ int ReadConfig(int modules, const char *cfgfile, void *d1, void *d2)
         } else {
             merror(XML_ERROR, cfgfile, xml.err, xml.err_line);
         }
+
+        /* A failed read still leaves the object holding whatever it allocated before
+         * giving up, exactly like the successful path -- every other exit below
+         * clears it, these two early ones were simply missed. */
+        OS_ClearXML(&xml);
         return (OS_INVALID);
     }
 
     node = OS_GetElementsbyNode(&xml, NULL);
     if (!node) {
+        OS_ClearXML(&xml);
         return (0);
     }
 

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -383,7 +383,6 @@ WriteAgent()
         fi
       fi
     fi
-    echo "    <notify_time>10</notify_time>" >> $NEWCONFIG
     echo "    <auto_restart>yes</auto_restart>" >> $NEWCONFIG
     echo "  </agent>" >> $NEWCONFIG
     echo "" >> $NEWCONFIG

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -369,12 +369,6 @@ WriteAgent()
     fi
     echo "      <port>1517</port>" >> $NEWCONFIG
     echo "    </server>" >> $NEWCONFIG
-    # verification_mode defaults to 'none'; set to 'full' or 'certificate' and
-    # provide certificate_authorities to verify the manager's certificate.
-    echo "    <ssl>" >> $NEWCONFIG
-    echo "      <!-- <certificate_authorities>etc/certs/root-ca.pem</certificate_authorities> -->" >> $NEWCONFIG
-    echo "      <verification_mode>none</verification_mode>" >> $NEWCONFIG
-    echo "    </ssl>" >> $NEWCONFIG
     if [ "X${USER_AGENT_CONFIG_PROFILE}" != "X" ]; then
          PROFILE=${USER_AGENT_CONFIG_PROFILE}
          echo "    <config-profile>$PROFILE</config-profile>" >> $NEWCONFIG

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -383,7 +383,6 @@ WriteAgent()
         fi
       fi
     fi
-    echo "    <auto_restart>yes</auto_restart>" >> $NEWCONFIG
     echo "  </agent>" >> $NEWCONFIG
     echo "" >> $NEWCONFIG
 

--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -250,7 +250,14 @@ add_auto_enrollment () {
 # Add the auto_enrollment block to the configuration file
 concat_conf() {
 
-    ${sed} "/<\/auto_restart>/r ${TMP_ENROLLMENT}" "${CONF_FILE}"
+    # Anchored on the block that opens the agent configuration rather than on any
+    # option inside it: the shipped file only carries what an install has to fill
+    # in, so no individual option is guaranteed to be there to anchor on.
+    if grep -q "<agent>" "${CONF_FILE}"; then
+        ${sed} "/<agent>/r ${TMP_ENROLLMENT}" "${CONF_FILE}"
+    else
+        ${sed} "/<client>/r ${TMP_ENROLLMENT}" "${CONF_FILE}"
+    fi
 
     rm -f "${TMP_ENROLLMENT}"
 

--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -53,6 +53,33 @@ delete_blank_lines() {
 
 }
 
+# Set an option of the agent block, adding it when the shipped configuration does
+# not carry it. Options left at their default are no longer written to ossec.conf,
+# so edit_value_tag alone would find nothing to substitute and quietly do nothing.
+set_agent_option() {
+
+    if [ -z "$2" ]; then
+        return
+    fi
+
+    if grep -q "<$1>" "${CONF_FILE}"; then
+        edit_value_tag "$1" "$2"
+        return
+    fi
+
+    echo "    <$1>$2</$1>" > "${TMP_SERVER}"
+
+    # A package upgrade keeps the 4.x file, where the block is still <client>.
+    if grep -q "<agent>" "${CONF_FILE}"; then
+        ${sed} "/<agent>/r ${TMP_SERVER}" "${CONF_FILE}"
+    else
+        ${sed} "/<client>/r ${TMP_SERVER}" "${CONF_FILE}"
+    fi
+
+    rm -f "${TMP_SERVER}"
+
+}
+
 delete_auto_enrollment_tag() {
 
     # Delete the configuration tag if its value is empty
@@ -294,7 +321,7 @@ main () {
     fi
 
     # Options to be modified in wazuh configuration file
-    edit_value_tag "notify_time" "${WAZUH_KEEP_ALIVE_INTERVAL}"
+    set_agent_option "notify_time" "${WAZUH_KEEP_ALIVE_INTERVAL}"
     edit_value_tag "time-reconnect" "${WAZUH_TIME_RECONNECT}"
 
     unset_vars

--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -12,6 +12,7 @@ INSTALLDIR=${1}
 CONF_FILE="${INSTALLDIR}/etc/ossec.conf"
 TMP_ENROLLMENT="${INSTALLDIR}/tmp/enrollment-configuration"
 TMP_SERVER="${INSTALLDIR}/tmp/server-configuration"
+TMP_INSERT="${INSTALLDIR}/tmp/insert-output"
 WAZUH_REGISTRATION_PASSWORD_PATH="etc/authd.pass"
 WAZUH_MACOS_AGENT_DEPLOYMENT_VARS="/tmp/wazuh_envs"
 
@@ -53,6 +54,63 @@ delete_blank_lines() {
 
 }
 
+# Insert a file's contents inside the agent configuration block, once.
+#
+# The opening tag has to be alone on its own line AND outside any comment to be
+# matched, so a block someone commented out cannot take the insertion -- which is not
+# hypothetical: commenting out the whole <agent> block is how you disable it, and the
+# commented copy comes first in the file. A package upgrade keeps the 4.x file, where
+# the block is still spelled <client>, hence both names.
+#
+# Written back through the existing file rather than moved over it, so the
+# permissions and ownership ossec.conf was installed with survive.
+insert_into_agent_block() {
+
+    awk -v payload_file="$1" '
+        BEGIN {
+            while ((getline line < payload_file) > 0) {
+                payload = payload line "\n"
+            }
+            close(payload_file)
+        }
+        in_comment {
+            if ($0 ~ /-->/) { in_comment = 0 }
+            print
+            next
+        }
+        !inserted && /^[[:space:]]*<(agent|client)>[[:space:]]*$/ {
+            print
+            printf "%s", payload
+            inserted = 1
+            next
+        }
+        {
+            if ($0 ~ /<!--/ && $0 !~ /-->/) { in_comment = 1 }
+            print
+        }
+    ' "${CONF_FILE}" > "${TMP_INSERT}" && cat "${TMP_INSERT}" > "${CONF_FILE}"
+
+    rm -f "${TMP_INSERT}"
+
+}
+
+# True when the option is really set, as opposed to appearing inside a comment.
+# Commented-out options are exactly how the shipped files used to show an example,
+# and editing one leaves the setting the caller asked for unwritten.
+agent_option_is_set() {
+
+    awk -v tag="$1" '
+        in_comment {
+            if ($0 ~ /-->/) { in_comment = 0 }
+            next
+        }
+        $0 ~ "^[[:space:]]*<" tag ">" { found = 1; exit }
+        { if ($0 ~ /<!--/ && $0 !~ /-->/) { in_comment = 1 } }
+        END { exit found ? 0 : 1 }
+    ' "${CONF_FILE}"
+
+}
+
 # Set an option of the agent block, adding it when the shipped configuration does
 # not carry it. Options left at their default are no longer written to ossec.conf,
 # so edit_value_tag alone would find nothing to substitute and quietly do nothing.
@@ -62,20 +120,13 @@ set_agent_option() {
         return
     fi
 
-    if grep -q "<$1>" "${CONF_FILE}"; then
+    if agent_option_is_set "$1"; then
         edit_value_tag "$1" "$2"
         return
     fi
 
     echo "    <$1>$2</$1>" > "${TMP_SERVER}"
-
-    # A package upgrade keeps the 4.x file, where the block is still <client>.
-    if grep -q "<agent>" "${CONF_FILE}"; then
-        ${sed} "/<agent>/r ${TMP_SERVER}" "${CONF_FILE}"
-    else
-        ${sed} "/<client>/r ${TMP_SERVER}" "${CONF_FILE}"
-    fi
-
+    insert_into_agent_block "${TMP_SERVER}"
     rm -f "${TMP_SERVER}"
 
 }
@@ -108,13 +159,7 @@ add_adress_block() {
         echo "    </server>"
     } >> "${TMP_SERVER}"
 
-    # A 5.x package ships <agent>, but a package upgrade preserves the 4.x file, so
-    # WAZUH_MANAGER can land on a configuration that still spells the block <client>.
-    if grep -q "<agent>" "${CONF_FILE}"; then
-        ${sed} "/<agent>/r ${TMP_SERVER}" "${CONF_FILE}"
-    else
-        ${sed} "/<client>/r ${TMP_SERVER}" "${CONF_FILE}"
-    fi
+    insert_into_agent_block "${TMP_SERVER}"
 
     rm -f "${TMP_SERVER}"
 
@@ -221,16 +266,21 @@ tolower () {
 # Add auto-enrollment configuration block
 add_auto_enrollment () {
 
+    # Only the children are collected here; concat_conf writes the block around them.
     start_config="$(grep -n "<enrollment>" "${CONF_FILE}" | cut -d':' -f 1)"
     end_config="$(grep -n "</enrollment>" "${CONF_FILE}" | cut -d':' -f 1)"
     if [ -n "${start_config}" ] && [ -n "${end_config}" ]; then
         start_config=$(( start_config + 1 ))
         end_config=$(( end_config - 1 ))
-        sed -n "${start_config},${end_config}p" "${INSTALLDIR}/etc/ossec.conf" >> "${TMP_ENROLLMENT}"
+        sed -n "${start_config},${end_config}p" "${CONF_FILE}" >> "${TMP_ENROLLMENT}"
+
+        # Take the block out while it is being rewritten. Without this the original
+        # stays put and concat_conf adds a second one, so running the configuration
+        # twice leaves two enrollment blocks in the file.
+        ${sed} "/<enrollment>/,/<\/enrollment>/d" "${CONF_FILE}"
     else
         # Write the client configuration block
         {
-            echo "    <enrollment>"
             echo "      <enabled>yes</enabled>"
             echo "      <manager_address>MANAGER_IP</manager_address>"
             echo "      <port>1515</port>"
@@ -241,7 +291,6 @@ add_auto_enrollment () {
             echo "      <agent_key_path>/path/to/agent.key</agent_key_path>"
             echo "      <authorization_pass_path>/path/to/authd.pass</authorization_pass_path>"
             echo "      <delay_after_enrollment>20</delay_after_enrollment>"
-            echo "    </enrollment>"
         } >> "${TMP_ENROLLMENT}"
     fi
 
@@ -253,11 +302,17 @@ concat_conf() {
     # Anchored on the block that opens the agent configuration rather than on any
     # option inside it: the shipped file only carries what an install has to fill
     # in, so no individual option is guaranteed to be there to anchor on.
-    if grep -q "<agent>" "${CONF_FILE}"; then
-        ${sed} "/<agent>/r ${TMP_ENROLLMENT}" "${CONF_FILE}"
-    else
-        ${sed} "/<client>/r ${TMP_ENROLLMENT}" "${CONF_FILE}"
-    fi
+    #
+    # The wrapper goes on here, not when the children are collected, so an option
+    # edit_value_tag had to append lands inside the block rather than after it.
+    {
+        echo "    <enrollment>"
+        cat "${TMP_ENROLLMENT}"
+        echo "    </enrollment>"
+    } > "${TMP_ENROLLMENT}.block"
+    mv "${TMP_ENROLLMENT}.block" "${TMP_ENROLLMENT}"
+
+    insert_into_agent_block "${TMP_ENROLLMENT}"
 
     rm -f "${TMP_ENROLLMENT}"
 

--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -267,19 +267,68 @@ tolower () {
 add_auto_enrollment () {
 
     # Only the children are collected here; concat_conf writes the block around them.
-    start_config="$(grep -n "<enrollment>" "${CONF_FILE}" | cut -d':' -f 1)"
-    end_config="$(grep -n "</enrollment>" "${CONF_FILE}" | cut -d':' -f 1)"
-    if [ -n "${start_config}" ] && [ -n "${end_config}" ]; then
-        start_config=$(( start_config + 1 ))
-        end_config=$(( end_config - 1 ))
-        sed -n "${start_config},${end_config}p" "${CONF_FILE}" >> "${TMP_ENROLLMENT}"
+    # The block is taken out as it is read, because concat_conf puts it back: leaving
+    # the original in place is what used to give two enrollment blocks on a re-run.
+    #
+    # One awk pass rather than grep plus a sed range, because both mishandle a block
+    # written on a single line. `sed "/<enrollment>/,/<\/enrollment>/d"` only starts
+    # looking for the closing pattern on the line AFTER the opening match, so with
+    # both tags on one line the range never closes and the delete runs to the end of
+    # the file -- </agent>, every block below it and </ossec_config> along with it.
+    # The grep line numbers have the mirror problem: start equals end, so the
+    # "children" range is inverted and copies out the wrong line.
+    #
+    # Comments are skipped for the same reason insert_into_agent_block skips them: a
+    # block someone commented out is not the one being configured. A second block is
+    # dropped rather than left behind, so a re-run cannot accumulate them.
+    #
+    # Truncated up front: awk only opens the file when the block has children, so a
+    # leftover from an interrupted run would otherwise be picked up as this one's.
+    : > "${TMP_ENROLLMENT}"
 
-        # Take the block out while it is being rewritten. Without this the original
-        # stays put and concat_conf adds a second one, so running the configuration
-        # twice leaves two enrollment blocks in the file.
-        ${sed} "/<enrollment>/,/<\/enrollment>/d" "${CONF_FILE}"
+    if awk -v children="${TMP_ENROLLMENT}" '
+        in_comment {
+            if ($0 ~ /-->/) { in_comment = 0 }
+            print
+            next
+        }
+        /<!--/ {
+            if ($0 !~ /-->/) { in_comment = 1 }
+            print
+            next
+        }
+        in_block {
+            if ($0 ~ /<\/enrollment>/) { in_block = 0; next }
+            if (capture) { print > children }
+            next
+        }
+        /<enrollment>/ {
+            capture = !found
+            found = 1
+            if ($0 ~ /<\/enrollment>/) {
+                # Whole block on one line: keep what sits between the tags.
+                inner = $0
+                sub(/^.*<enrollment>/, "", inner)
+                sub(/<\/enrollment>.*$/, "", inner)
+                if (capture && inner ~ /[^[:space:]]/) { print inner > children }
+            } else {
+                in_block = 1
+            }
+            next
+        }
+        { print }
+        # An unterminated block means the file is not what we think it is; report it
+        # as unusable so the copy is discarded and the original is left untouched.
+        # Spelled out rather than with a ternary, which not every awk parses after
+        # exit -- the macOS agent runs this through BSD awk.
+        END {
+            if (found && !in_block) { exit 0 }
+            exit 1
+        }
+    ' "${CONF_FILE}" > "${TMP_INSERT}"; then
+        cat "${TMP_INSERT}" > "${CONF_FILE}"
     else
-        # Write the client configuration block
+        # No block to reuse. Truncating also drops whatever a half-read one left.
         {
             echo "      <enabled>yes</enabled>"
             echo "      <manager_address>MANAGER_IP</manager_address>"
@@ -291,8 +340,10 @@ add_auto_enrollment () {
             echo "      <agent_key_path>/path/to/agent.key</agent_key_path>"
             echo "      <authorization_pass_path>/path/to/authd.pass</authorization_pass_path>"
             echo "      <delay_after_enrollment>20</delay_after_enrollment>"
-        } >> "${TMP_ENROLLMENT}"
+        } > "${TMP_ENROLLMENT}"
     fi
+
+    rm -f "${TMP_INSERT}"
 
 }
 

--- a/src/init/tests/test_register_configure_agent.sh
+++ b/src/init/tests/test_register_configure_agent.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+
+# Copyright (C) 2015, Wazuh Inc.
+#
+# This program is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
+
+# Drives register_configure_agent.sh against a throwaway INSTALLDIR and checks what
+# it leaves in ossec.conf. The script rewrites the file the packages ship, so the
+# cases that matter are the destructive ones: nothing it does may drop a block it was
+# not asked to touch.
+#
+#   ./test_register_configure_agent.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="${SCRIPT_DIR}/../register_configure_agent.sh"
+
+failures=0
+checks=0
+
+# Run the target against ${1} as the starting ossec.conf, with the caller's
+# WAZUH_* variables already exported. Echoes the resulting file.
+run_target() {
+
+    local conf_body="$1"
+    local installdir
+
+    installdir="$(mktemp -d)"
+    mkdir -p "${installdir}/etc" "${installdir}/tmp" "${installdir}/logs"
+    printf '%s' "${conf_body}" > "${installdir}/etc/ossec.conf"
+
+    # The script chowns ossec.log to root:wazuh when WAZUH_MANAGER is set; pre-create
+    # it so an unprivileged run does not stop there.
+    touch "${installdir}/logs/ossec.log"
+
+    bash "${TARGET}" "${installdir}" >/dev/null 2>&1
+
+    cat "${installdir}/etc/ossec.conf"
+    rm -rf "${installdir}"
+
+}
+
+check() {
+
+    local name="$1" expected="$2" actual="$3"
+
+    checks=$(( checks + 1 ))
+    if [ "${expected}" = "${actual}" ]; then
+        echo "ok   - ${name}"
+    else
+        failures=$(( failures + 1 ))
+        echo "FAIL - ${name}"
+        echo "--- expected ---"
+        echo "${expected}"
+        echo "--- actual ---"
+        echo "${actual}"
+        echo "---"
+    fi
+
+}
+
+# Everything except the enrollment block, which the script owns and rewrites. What is
+# left is the part no run is allowed to touch.
+outside_enrollment() {
+
+    awk '
+        in_block { if ($0 ~ /<\/enrollment>/) { in_block = 0 } ; next }
+        /<enrollment>/ { if ($0 !~ /<\/enrollment>/) { in_block = 1 } ; next }
+        /^[[:space:]]*$/ { next }
+        { print }
+    '
+
+}
+
+# Reports every surrounding line the run dropped, so a truncation shows up as the
+# tags it ate rather than as a diff of the whole file.
+missing_lines() {
+
+    local before after line
+
+    before="$(printf '%s\n' "$1" | outside_enrollment)"
+    after="$(printf '%s\n' "$2" | outside_enrollment)"
+
+    while IFS= read -r line; do
+        if ! printf '%s\n' "${after}" | grep -qF -- "${line}"; then
+            printf '%s\n' "${line}"
+        fi
+    done <<< "${before}"
+
+}
+
+MULTILINE_CONF='<ossec_config>
+  <agent>
+    <server>
+      <address>MANAGER_IP</address>
+    </server>
+    <enrollment>
+      <enabled>yes</enabled>
+      <port>1515</port>
+    </enrollment>
+    <config-profile>CONFIG_PROFILE</config-profile>
+  </agent>
+  <rootcheck>
+    <disabled>no</disabled>
+  </rootcheck>
+</ossec_config>
+'
+
+SINGLE_LINE_CONF='<ossec_config>
+  <agent>
+    <server><address>MANAGER_IP</address></server>
+    <enrollment><enabled>yes</enabled><port>1515</port></enrollment>
+    <config-profile>CONFIG_PROFILE</config-profile>
+  </agent>
+  <rootcheck>
+    <disabled>no</disabled>
+  </rootcheck>
+</ossec_config>
+'
+
+NO_ENROLLMENT_CONF='<ossec_config>
+  <agent>
+    <server>
+      <address>MANAGER_IP</address>
+    </server>
+  </agent>
+  <rootcheck>
+    <disabled>no</disabled>
+  </rootcheck>
+</ossec_config>
+'
+
+COMMENTED_CONF='<ossec_config>
+  <!--
+  <agent>
+    <enrollment>
+      <enabled>no</enabled>
+    </enrollment>
+  </agent>
+  -->
+  <agent>
+    <server>
+      <address>MANAGER_IP</address>
+    </server>
+  </agent>
+</ossec_config>
+'
+
+export WAZUH_REGISTRATION_SERVER="10.0.0.2"
+
+# The regression the review caught: with the block on one line, the sed range never
+# closed and the delete ran to EOF.
+actual="$(run_target "${SINGLE_LINE_CONF}")"
+check "a single-line enrollment block keeps the rest of the file" \
+      "" "$(missing_lines "${SINGLE_LINE_CONF}" "${actual}")"
+
+actual="$(run_target "${MULTILINE_CONF}")"
+check "a multi-line enrollment block keeps the rest of the file" \
+      "" "$(missing_lines "${MULTILINE_CONF}" "${actual}")"
+
+# Whatever the layout was, exactly one block comes back, inside <agent>.
+for name in SINGLE_LINE_CONF MULTILINE_CONF NO_ENROLLMENT_CONF; do
+    actual="$(run_target "${!name}")"
+    check "${name}: exactly one <enrollment> opening tag" \
+          "1" "$(printf '%s\n' "${actual}" | grep -c "<enrollment>")"
+    check "${name}: the configured registration server is written" \
+          "1" "$(printf '%s\n' "${actual}" | grep -c "<manager_address>10.0.0.2</manager_address>")"
+done
+
+# Running twice must converge: the second pass rewrites the block the first wrote
+# instead of adding another one.
+first="$(run_target "${SINGLE_LINE_CONF}")"
+second="$(run_target "${first}")"
+check "a second run does not add a second block" \
+      "1" "$(printf '%s\n' "${second}" | grep -c "<enrollment>")"
+check "a second run keeps the rest of the file" \
+      "" "$(missing_lines "${first}" "${second}")"
+
+# A commented-out block is not the one being configured, and must survive untouched.
+actual="$(run_target "${COMMENTED_CONF}")"
+check "the commented-out block is left alone" \
+      "1" "$(printf '%s\n' "${actual}" | grep -c "<enabled>no</enabled>")"
+check "the commented-out block does not absorb the insertion" \
+      "" "$(missing_lines "${COMMENTED_CONF}" "${actual}")"
+
+echo
+echo "${checks} checks, ${failures} failed"
+[ "${failures}" -eq 0 ]

--- a/src/remoted/src/legacy_task_delivery.c
+++ b/src/remoted/src/legacy_task_delivery.c
@@ -655,7 +655,15 @@ bool legacy_task_process_upgrade_ack(const char *agent_id, const char *ack_json)
     }
 
     cJSON *parameters_obj = cJSON_GetObjectItem(ack, "parameters");
-    cJSON *error_obj = parameters_obj ? cJSON_GetObjectItem(parameters_obj, "error") : NULL;
+
+    if (!cJSON_IsObject(parameters_obj)) {
+        mdebug1("legacy_task_delivery: agent '%s' sent an upgrade acknowledgment with a missing or "
+                "invalid 'parameters', ignoring", agent_id);
+        cJSON_Delete(ack);
+        return false;
+    }
+
+    cJSON *error_obj = cJSON_GetObjectItem(parameters_obj, "error");
 
     if (!cJSON_IsNumber(error_obj)) {
         mdebug1("legacy_task_delivery: agent '%s' sent an upgrade acknowledgment with a missing or "

--- a/src/shared/include/defs.h
+++ b/src/shared/include/defs.h
@@ -88,7 +88,7 @@ https://www.gnu.org/licenses/gpl.html\n"
 #endif
 
 /* Notify the manager */
-#define NOTIFY_TIME    20 // ... every 20 seconds
+#define NOTIFY_TIME    10 // ... every 10 seconds
 #define RECONNECT_TIME 60 // Time to reconnect
 
 /* User Configuration */

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
@@ -69,6 +69,18 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         /// @copydoc IAgentSyncProtocol::deleteDatabase
         void deleteDatabase() override;
 
+        /// @brief Set the ceiling on how many bytes one sync session may carry.
+        ///
+        /// The value belongs to <agent><batch><size>, the same limit that bounds a
+        /// /stateless request, but this library cannot read it: it links neither the
+        /// configuration layer nor an XML parser. The daemon hosting the modules reads
+        /// it and hands it down before any module builds its protocol instance;
+        /// instances take a copy at construction, so a late call never changes a
+        /// session already being planned. Zero leaves the built-in default in place.
+        ///
+        /// @param maxBytes Maximum bytes per session, or 0 to keep the default.
+        static void setSessionMaxBytes(size_t maxBytes);
+
         /// @copydoc IAgentSyncProtocol::stop
         void stop() override;
 
@@ -336,7 +348,17 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         /// resetting the streak on it is correct regardless of which flow observed it.
         std::atomic<unsigned int> m_consecutiveSyncFailures{0};
 
+        /// Built-in ceiling on one session, used until a daemon calls
+        /// setSessionMaxBytes() with what <agent><batch><size> says.
         static constexpr size_t FULLSESSION_MAX_BYTES = 5U * 1024U * 1024U;
+
+        /// Process-wide, because the limit is one agent-wide decision and the modules
+        /// that build these instances have no configuration of their own to carry it.
+        static std::atomic<size_t> s_sessionMaxBytes;
+
+        /// This instance's copy, taken at construction.
+        size_t m_sessionMaxBytes {FULLSESSION_MAX_BYTES};
+
         static constexpr size_t FULLSESSION_PREFILTER_GRACE_BYTES = 64U * 1024U;
         static constexpr size_t FULLSESSION_MAX_BLOCKS_PER_SYNC = 10U;
         static constexpr std::string_view HTTP_RESULT_PREFIX = "HCRESULT:";

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface.h
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface.h
@@ -19,6 +19,16 @@
 extern "C" {
 #endif
 
+/// @brief Sets the ceiling on how many bytes one sync session may carry.
+///
+/// The value belongs to <agent><batch><size>, which this library cannot read: it links
+/// neither the configuration layer nor an XML parser. The daemon hosting the modules
+/// reads it and calls this before any module builds its protocol instance. Zero leaves
+/// the built-in default in place.
+///
+/// @param max_session_bytes Maximum bytes per session, or 0 to keep the default.
+void asp_set_session_max_bytes(uint64_t max_session_bytes);
+
 /// @brief Creates an instance of AgentSyncProtocol.
 ///
 /// @param module Name of the module associated with this instance.

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -61,12 +61,23 @@ static std::string determineSyncFailureReasonBasedOnSyncResult(SyncResult result
     return failureReason;
 }
 
+std::atomic<size_t> AgentSyncProtocol::s_sessionMaxBytes {AgentSyncProtocol::FULLSESSION_MAX_BYTES};
+
+void AgentSyncProtocol::setSessionMaxBytes(size_t maxBytes)
+{
+    if (maxBytes > 0)
+    {
+        s_sessionMaxBytes.store(maxBytes);
+    }
+}
+
 AgentSyncProtocol::AgentSyncProtocol(const std::string& moduleName, std::optional<std::string> dbPath, LoggerFunc logger,
                                      std::shared_ptr<IPersistentQueue> queue,
                                      std::shared_ptr<ISyncSessionTransport> syncTransport)
     : m_moduleName(moduleName),
       m_persistentQueue(nullptr), // Ensure initialized to nullptr
-      m_logger(std::move(logger))
+      m_logger(std::move(logger)),
+      m_sessionMaxBytes(s_sessionMaxBytes.load())
 {
     if (!m_logger)
     {
@@ -193,9 +204,9 @@ SyncModuleResult AgentSyncProtocol::synchronizeDeltaByBlocks(Option option)
     const size_t fetchMaxBytes =
         uncapped
         ? 0
-        : (FULLSESSION_MAX_BYTES > FULLSESSION_PREFILTER_GRACE_BYTES
-           ? FULLSESSION_MAX_BYTES - FULLSESSION_PREFILTER_GRACE_BYTES
-           : FULLSESSION_MAX_BYTES);
+        : (m_sessionMaxBytes > FULLSESSION_PREFILTER_GRACE_BYTES
+           ? m_sessionMaxBytes - FULLSESSION_PREFILTER_GRACE_BYTES
+           : m_sessionMaxBytes);
     bool success = true;
     bool sentAny = false;
     size_t blocksSent = 0;

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol_c_interface.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol_c_interface.cpp
@@ -11,6 +11,11 @@
 // LCOV_EXCL_START
 extern "C" {
 
+    void asp_set_session_max_bytes(uint64_t max_session_bytes)
+    {
+        AgentSyncProtocol::setSessionMaxBytes(static_cast<size_t>(max_session_bytes));
+    }
+
     AgentSyncProtocolHandle* asp_create(const char* module, const char* db_path, asp_logger_t logger)
     {
         try

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -797,6 +797,104 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleDeltaUsesBytePrefilterBudgetForSy
     EXPECT_TRUE(result.success);
 }
 
+/// Puts the built-in default back when it goes out of scope. The limit is
+/// process-wide, so a test that changes it would otherwise leak into the next one.
+class SessionMaxBytesGuard final
+{
+    public:
+        explicit SessionMaxBytesGuard(size_t bytes)
+        {
+            AgentSyncProtocol::setSessionMaxBytes(bytes);
+        }
+
+        ~SessionMaxBytesGuard()
+        {
+            AgentSyncProtocol::setSessionMaxBytes(5U * 1024U * 1024U);
+        }
+
+        SessionMaxBytesGuard(const SessionMaxBytesGuard&) = delete;
+        SessionMaxBytesGuard& operator=(const SessionMaxBytesGuard&) = delete;
+};
+
+TEST_F(AgentSyncProtocolTest, SessionByteBudgetFollowsTheConfiguredSessionMax)
+{
+    // <agent><batch><size> bounds a sync session the same way it bounds a
+    // /stateless request; before it was configurable this budget was fixed at
+    // 5 MiB whatever the agent had been told.
+    constexpr size_t CONFIGURED_MAX_BYTES = 512U * 1024U;
+    constexpr size_t FULLSESSION_PREFILTER_GRACE_BYTES = 64U * 1024U;
+    constexpr size_t EXPECTED_BUDGET = CONFIGURED_MAX_BYTES - FULLSESSION_PREFILTER_GRACE_BYTES;
+
+    const SessionMaxBytesGuard guard {CONFIGURED_MAX_BYTES};
+
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
+
+    std::vector<PersistedData> testData =
+    {
+        {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
+    };
+
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(EXPECTED_BUDGET))
+    .WillOnce(Return(testData))
+    .WillOnce(Return(std::vector<PersistedData> {}));
+    EXPECT_CALL(*mockQueue, clearSyncedItems())
+    .Times(1);
+
+    SyncModuleResult result;
+    std::thread syncThread([this, &result]()
+    {
+        result = protocol->synchronizeModule(Mode::DELTA, Option::SYNC);
+    });
+
+    EXPECT_TRUE(mockSyncTransport->waitForSession());
+
+    feedHttpResult(200);
+
+    syncThread.join();
+    EXPECT_TRUE(result.success);
+}
+
+TEST_F(AgentSyncProtocolTest, AnUnsetSessionMaxKeepsTheBuiltInDefault)
+{
+    // Zero is what an absent <batch><size> reaches the module as, so it has to
+    // read as "leave the default alone" rather than as a zero-byte session.
+    constexpr size_t FULLSESSION_MAX_BYTES = 5U * 1024U * 1024U;
+    constexpr size_t FULLSESSION_PREFILTER_GRACE_BYTES = 64U * 1024U;
+    constexpr size_t EXPECTED_BUDGET = FULLSESSION_MAX_BYTES - FULLSESSION_PREFILTER_GRACE_BYTES;
+
+    AgentSyncProtocol::setSessionMaxBytes(0);
+
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
+
+    std::vector<PersistedData> testData =
+    {
+        {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
+    };
+
+    EXPECT_CALL(*mockQueue, fetchAndMarkForSync(EXPECTED_BUDGET))
+    .WillOnce(Return(testData))
+    .WillOnce(Return(std::vector<PersistedData> {}));
+    EXPECT_CALL(*mockQueue, clearSyncedItems())
+    .Times(1);
+
+    SyncModuleResult result;
+    std::thread syncThread([this, &result]()
+    {
+        result = protocol->synchronizeModule(Mode::DELTA, Option::SYNC);
+    });
+
+    EXPECT_TRUE(mockSyncTransport->waitForSession());
+
+    feedHttpResult(200);
+
+    syncThread.join();
+    EXPECT_TRUE(result.success);
+}
+
 TEST_F(AgentSyncProtocolTest, SynchronizeModuleDeltaBypassesBytePrefilterBudgetForVDOptions)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();

--- a/src/syscheckd/src/main.c
+++ b/src/syscheckd/src/main.c
@@ -13,6 +13,9 @@
  */
 #include "rootcheck.h"
 #include "agent_sync_protocol_c_interface.h"
+#ifdef CLIENT
+#include "client-config.h"
+#endif
 #include "db.h"
 #include "shared.h"
 #include "syscheck.h"
@@ -281,6 +284,20 @@ int main(int argc, char **argv)
     if (File_DateofChange(cfg) < 0) {
         merror_exit(NO_CONFIG, cfg);
     }
+
+#ifdef CLIENT
+    /* The sync protocol bounds one session by <agent><batch><size>, the same limit
+     * that bounds a /stateless request. The block belongs to the agent rather than
+     * to this daemon, and the protocol reads no configuration of its own, so it is
+     * read here and handed down before fim_initialize() builds the instance. */
+    agent_batch batch = { .size = 0, .interval = 0 };
+    w_read_agent_batch(WAZUHCONF, AGENTCONFIG, &batch);
+    asp_set_session_max_bytes((uint64_t)batch.size);
+
+    if (batch.size > 0) {
+        mdebug1("Sync sessions bounded to %lld bytes by <agent><batch><size>.", batch.size);
+    }
+#endif
 
     /* Read syscheck config */
     if ((r = Read_Syscheck_Config(cfg)) < 0) {

--- a/src/unit_tests/config/test_client-config_https.c
+++ b/src/unit_tests/config/test_client-config_https.c
@@ -678,6 +678,27 @@ static void test_batch_zero_size_is_rejected(void **state) {
     cleanup(&xml, nodes, &cfg);
 }
 
+static void test_batch_size_beyond_the_cap_is_rejected(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    /* Above a gigabyte the value stops being useful and starts being dangerous:
+     * a 32-bit agent's size_t wraps past 4 GiB, and 4 GiB exactly wraps to zero,
+     * which every reader downstream takes as "unset". */
+    const char *xml_str =
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<batch><size>2GB</size></batch>";
+
+    expect_valid_ip("10.0.0.1");
+    expect_string(__wrap__merror, formatted_msg,
+                  "(1235): Invalid value for element 'size': 2GB.");
+
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
 static void test_batch_interval_beyond_a_day_is_rejected(void **state) {
     OS_XML xml = {0};
     xml_node **nodes;
@@ -815,6 +836,45 @@ static void test_read_agent_batch_leaves_the_caller_defaults_when_absent(void **
     write_conf("<ossec_config><agent>"
                "<server><address>10.0.0.1</address></server>"
                "</agent></ossec_config>");
+
+    w_read_agent_batch(BATCH_TEST_CONF, NULL, &batch);
+
+    assert_int_equal(batch.size, 777);
+    assert_int_equal(batch.interval, 42);
+
+    remove(BATCH_TEST_CONF);
+}
+
+static void test_read_agent_batch_applies_the_local_file_with_no_shared_one(void **state) {
+    agent_batch batch = {0};
+
+    /* Most agents have never been pushed an agent.conf. The reader must treat that
+     * as "nothing centralized to add", not as a failed read that discards the local
+     * block along with it. */
+    write_conf("<ossec_config><agent>"
+               "<batch><size>3MB</size></batch>"
+               "</agent></ossec_config>");
+
+    w_read_agent_batch(BATCH_TEST_CONF, "/tmp/test_client-config_https_no_shared.conf", &batch);
+
+    assert_int_equal(batch.size, 3 * 1024 * 1024);
+
+    remove(BATCH_TEST_CONF);
+}
+
+static void test_read_agent_batch_applies_nothing_when_the_block_is_rejected(void **state) {
+    agent_batch batch = { .size = 777, .interval = 42 };
+
+    /* Read_Agent_Batch assigns each limit as it walks it, so by the time the bad
+     * element is reached the size is already in the struct. Nothing may reach the
+     * caller: a configuration the agent refuses must not be half-applied in the
+     * daemons that only borrow it. */
+    write_conf("<ossec_config><agent>"
+               "<batch><size>3MB</size><nonsense>1</nonsense></batch>"
+               "</agent></ossec_config>");
+
+    expect_string(__wrap__merror, formatted_msg,
+                  "(1230): Invalid element in the configuration: 'nonsense'.");
 
     w_read_agent_batch(BATCH_TEST_CONF, NULL, &batch);
 
@@ -1029,6 +1089,8 @@ int main(void) {
         cmocka_unit_test(test_agent_invalid_tag_is_rejected),
         cmocka_unit_test(test_read_agent_batch_takes_the_limits_from_the_file),
         cmocka_unit_test(test_read_agent_batch_leaves_the_caller_defaults_when_absent),
+        cmocka_unit_test(test_read_agent_batch_applies_the_local_file_with_no_shared_one),
+        cmocka_unit_test(test_read_agent_batch_applies_nothing_when_the_block_is_rejected),
         cmocka_unit_test(test_read_agent_batch_survives_a_missing_file),
         cmocka_unit_test(test_shared_batch_is_parsed),
         cmocka_unit_test(test_shared_batch_is_validated_like_a_local_one),
@@ -1037,6 +1099,7 @@ int main(void) {
         cmocka_unit_test(test_batch_is_unset_when_absent),
         cmocka_unit_test(test_batch_size_without_a_suffix_is_bytes),
         cmocka_unit_test(test_batch_zero_size_is_rejected),
+        cmocka_unit_test(test_batch_size_beyond_the_cap_is_rejected),
         cmocka_unit_test(test_batch_interval_beyond_a_day_is_rejected),
         cmocka_unit_test(test_batch_invalid_tag_is_rejected),
         cmocka_unit_test(test_reports_are_off_when_absent),

--- a/src/unit_tests/config/test_client-config_https.c
+++ b/src/unit_tests/config/test_client-config_https.c
@@ -779,6 +779,60 @@ static void test_shared_config_still_refuses_local_only_options(void **state) {
     cleanup(&xml, nodes, &cfg);
 }
 
+/* w_read_agent_batch: the limits as the sync-protocol daemons read them */
+
+#define BATCH_TEST_CONF "/tmp/test_client-config_https_batch.conf"
+
+static void write_conf(const char *body) {
+    FILE *fp = fopen(BATCH_TEST_CONF, "w");
+
+    assert_non_null(fp);
+    fputs(body, fp);
+    fclose(fp);
+}
+
+static void test_read_agent_batch_takes_the_limits_from_the_file(void **state) {
+    agent_batch batch = {0};
+
+    write_conf("<ossec_config><agent>"
+               "<server><address>10.0.0.1</address></server>"
+               "<batch><size>3MB</size><interval>45s</interval></batch>"
+               "</agent></ossec_config>");
+
+    /* No <server> parsing, so no OS_IsValidIP expectation: the walk only opens
+     * <batch>, which is what keeps this off Read_Agent and its allocations. */
+    w_read_agent_batch(BATCH_TEST_CONF, NULL, &batch);
+
+    assert_int_equal(batch.size, 3 * 1024 * 1024);
+    assert_int_equal(batch.interval, 45);
+
+    remove(BATCH_TEST_CONF);
+}
+
+static void test_read_agent_batch_leaves_the_caller_defaults_when_absent(void **state) {
+    agent_batch batch = { .size = 777, .interval = 42 };
+
+    write_conf("<ossec_config><agent>"
+               "<server><address>10.0.0.1</address></server>"
+               "</agent></ossec_config>");
+
+    w_read_agent_batch(BATCH_TEST_CONF, NULL, &batch);
+
+    assert_int_equal(batch.size, 777);
+    assert_int_equal(batch.interval, 42);
+
+    remove(BATCH_TEST_CONF);
+}
+
+static void test_read_agent_batch_survives_a_missing_file(void **state) {
+    agent_batch batch = { .size = 777, .interval = 42 };
+
+    w_read_agent_batch("/tmp/test_client-config_https_no_such.conf", NULL, &batch);
+
+    assert_int_equal(batch.size, 777);
+    assert_int_equal(batch.interval, 42);
+}
+
 /* Deprecated legacy-TCP options: accepted, ignored, warned (#37702 restriction 4) */
 
 static void test_time_reconnect_is_deprecated(void **state) {
@@ -973,6 +1027,9 @@ int main(void) {
         cmocka_unit_test(test_legacy_client_is_ignored_once_agent_set_the_address),
         cmocka_unit_test(test_fresh_install_template_shape),
         cmocka_unit_test(test_agent_invalid_tag_is_rejected),
+        cmocka_unit_test(test_read_agent_batch_takes_the_limits_from_the_file),
+        cmocka_unit_test(test_read_agent_batch_leaves_the_caller_defaults_when_absent),
+        cmocka_unit_test(test_read_agent_batch_survives_a_missing_file),
         cmocka_unit_test(test_shared_batch_is_parsed),
         cmocka_unit_test(test_shared_batch_is_validated_like_a_local_one),
         cmocka_unit_test(test_shared_config_still_refuses_local_only_options),

--- a/src/unit_tests/config/test_client-config_https.c
+++ b/src/unit_tests/config/test_client-config_https.c
@@ -561,9 +561,9 @@ static void test_legacy_client_is_ignored_once_agent_set_the_address(void **stat
     cleanup(&agent_xml, agent_nodes, &cfg);
 }
 
-/* What the 5.x templates ship (etc/ossec-agent.conf, src/win32/ossec.conf): the whole
- * block renamed, so every 4.x <client> option is now read under <agent>. */
-static void test_fresh_install_template_shape(void **state) {
+/* The 4.x <client> options are still read, just no longer written: the block was
+ * renamed to <agent>, and an upgraded file carries whatever it was left with. */
+static void test_agent_block_reads_the_legacy_client_options(void **state) {
     OS_XML xml = {0};
     xml_node **nodes;
     agent cfg;
@@ -586,6 +586,34 @@ static void test_fresh_install_template_shape(void **state) {
     assert_string_equal(cfg.profile, "debian, debian8");
     assert_int_equal(cfg.notify_time, 20);
     assert_int_equal(cfg.flags.auto_restart, 1);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+/* What the templates actually ship now (etc/ossec-agent.conf, src/win32/ossec.conf,
+ * and inst-functions.sh's WriteAgent): an address, a port, and nothing that only
+ * restates a default. Everything left out has to come back as "unset" here, because
+ * that is what makes ClientConf's defaults the ones an agent ends up running on. */
+static void test_fresh_install_template_shape(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str =
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<config-profile>debian, debian8</config-profile>";
+
+    expect_valid_ip("10.0.0.1");
+
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
+
+    assert_int_equal(cfg.server_count, 1);
+    assert_string_equal(cfg.server[0].rip, "10.0.0.1");
+    assert_int_equal(cfg.server[0].port, DEFAULT_HTTPS_REMOTE_PORT);
+    assert_string_equal(cfg.profile, "debian, debian8");
+    assert_int_equal(cfg.notify_time, 0);        /* ClientConf turns 0 into NOTIFY_TIME. */
+    assert_int_equal(cfg.batch.size, 0);         /* Module default (1 MiB / 5 MiB). */
+    assert_int_equal(cfg.batch.interval, 0);
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -1085,6 +1113,7 @@ int main(void) {
         cmocka_unit_test(test_legacy_client_without_an_address_sets_no_server),
         cmocka_unit_test(test_agent_block_replaces_a_legacy_address),
         cmocka_unit_test(test_legacy_client_is_ignored_once_agent_set_the_address),
+        cmocka_unit_test(test_agent_block_reads_the_legacy_client_options),
         cmocka_unit_test(test_fresh_install_template_shape),
         cmocka_unit_test(test_agent_invalid_tag_is_rejected),
         cmocka_unit_test(test_read_agent_batch_takes_the_limits_from_the_file),

--- a/src/unit_tests/config/test_client-config_https.c
+++ b/src/unit_tests/config/test_client-config_https.c
@@ -912,6 +912,52 @@ static void test_read_agent_batch_applies_nothing_when_the_block_is_rejected(voi
     remove(BATCH_TEST_CONF);
 }
 
+#define BATCH_SHARED_CONF "/tmp/test_client-config_https_batch_shared.conf"
+
+static void write_shared_conf(const char *body) {
+    FILE *fp = fopen(BATCH_SHARED_CONF, "w");
+
+    assert_non_null(fp);
+    fputs(body, fp);
+    fclose(fp);
+}
+
+static void test_read_agent_batch_keeps_the_local_block_when_the_shared_one_is_rejected(void **state) {
+    agent_batch batch = {0};
+
+    /* The local block parsed cleanly and stands on its own; a centralized file the
+     * agent cannot read is no reason to throw it away. Discarding it left the caller
+     * on zero, which the sync protocol reads as "unset" and answers with its built-in
+     * default -- while agentd, which never checks this same read, kept running on the
+     * local value, so one agent ran two different session limits.
+     *
+     * Broken at the XML level rather than with an invalid element: a rejected element
+     * sits behind ReadConfig's agent_config profile gate, which wants a real
+     * queue/sockets/.agent_info to get past. Both routes end in ReadConfig answering
+     * OS_INVALID, which is all this function reacts to.
+     *
+     * The warning is the only message the run produces. config.c is linked from the
+     * agent build, so its XML_ERROR for a centralized read is compiled out under
+     * CLIENT -- that silence is the reason the warning exists. */
+    write_conf("<ossec_config><agent>"
+               "<batch><size>3MB</size><interval>45s</interval></batch>"
+               "</agent></ossec_config>");
+    write_shared_conf("<agent_config><agent><batch><size>9MB</size>");
+
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "Could not read the centralized configuration '" BATCH_SHARED_CONF
+                  "'. Keeping the local <agent><batch> limits.");
+
+    w_read_agent_batch(BATCH_TEST_CONF, BATCH_SHARED_CONF, &batch);
+
+    /* The local values, and nothing from the file that failed. */
+    assert_int_equal(batch.size, 3 * 1024 * 1024);
+    assert_int_equal(batch.interval, 45);
+
+    remove(BATCH_TEST_CONF);
+    remove(BATCH_SHARED_CONF);
+}
+
 static void test_read_agent_batch_survives_a_missing_file(void **state) {
     agent_batch batch = { .size = 777, .interval = 42 };
 
@@ -1120,6 +1166,7 @@ int main(void) {
         cmocka_unit_test(test_read_agent_batch_leaves_the_caller_defaults_when_absent),
         cmocka_unit_test(test_read_agent_batch_applies_the_local_file_with_no_shared_one),
         cmocka_unit_test(test_read_agent_batch_applies_nothing_when_the_block_is_rejected),
+        cmocka_unit_test(test_read_agent_batch_keeps_the_local_block_when_the_shared_one_is_rejected),
         cmocka_unit_test(test_read_agent_batch_survives_a_missing_file),
         cmocka_unit_test(test_shared_batch_is_parsed),
         cmocka_unit_test(test_shared_batch_is_validated_like_a_local_one),

--- a/src/unit_tests/config/test_client-config_https.c
+++ b/src/unit_tests/config/test_client-config_https.c
@@ -247,19 +247,39 @@ static void test_ssl_none_verification_mode(void **state) {
     cleanup(&xml, nodes, &cfg);
 }
 
-static void test_ssl_default_is_full(void **state) {
+static void test_ssl_zero_initialized_reads_as_full(void **state) {
     OS_XML xml = {0};
     xml_node **nodes;
     agent cfg;
 
-    /* No <ssl> block at all: zero-initialized struct must read as FULL
-     * (AGENT_VERIFY_FULL == 0), so an agent that forgets TLS config still
+    /* No <ssl> block at all: a zero-initialized struct reads as FULL
+     * (AGENT_VERIFY_FULL == 0), so a caller that never sets a default still
      * fails closed rather than silently disabling verification. */
     const char *xml_str = "<server><address>10.0.0.1</address><port>1517</port></server>";
 
     expect_valid_ip("10.0.0.1");
     assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
     assert_int_equal(cfg.ssl.verification_mode, AGENT_VERIFY_FULL);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_ssl_absent_keeps_the_default_the_caller_set(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    /* The parser never invents a verification mode, which is what lets ClientConf
+     * own the agent's own default of NONE: with no <ssl> block the value the
+     * caller came in with is still there afterwards. */
+    const char *xml_str = "<server><address>10.0.0.1</address><port>1517</port></server>";
+
+    memset(&cfg, 0, sizeof(cfg));
+    cfg.ssl.verification_mode = AGENT_VERIFY_NONE;
+
+    expect_valid_ip("10.0.0.1");
+    assert_int_equal(parse_agent_into(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(cfg.ssl.verification_mode, AGENT_VERIFY_NONE);
 
     cleanup(&xml, nodes, &cfg);
 }
@@ -864,7 +884,8 @@ int main(void) {
         cmocka_unit_test(test_ssl_full_verification_mode),
         cmocka_unit_test(test_ssl_certificate_verification_mode),
         cmocka_unit_test(test_ssl_none_verification_mode),
-        cmocka_unit_test(test_ssl_default_is_full),
+        cmocka_unit_test(test_ssl_zero_initialized_reads_as_full),
+        cmocka_unit_test(test_ssl_absent_keeps_the_default_the_caller_set),
         cmocka_unit_test(test_ssl_invalid_verification_mode_is_rejected),
         cmocka_unit_test(test_ssl_invalid_tag_is_rejected),
         cmocka_unit_test(test_ssl_ciphers_accepts_a_tls13_suite_list),

--- a/src/unit_tests/config/test_client-config_https.c
+++ b/src/unit_tests/config/test_client-config_https.c
@@ -713,6 +713,72 @@ static void test_batch_invalid_tag_is_rejected(void **state) {
     cleanup(&xml, nodes, &cfg);
 }
 
+/* <batch> through the centralized configuration (etc/shared/agent.conf) */
+
+/* Parses `xml_str` as the body of an <agent> block pushed by the manager, via the
+ * real Read_Agent_Shared. Same cleanup as parse_agent(). */
+static int parse_agent_shared(const char *xml_str, OS_XML *xml, xml_node ***nodes, agent *cfg) {
+    memset(cfg, 0, sizeof(*cfg));
+
+    if (OS_ReadXMLString(xml_str, xml) != 0) {
+        return OS_INVALID;
+    }
+
+    if (*nodes = OS_GetElementsbyNode(xml, NULL), *nodes == NULL) {
+        return OS_INVALID;
+    }
+
+    return Read_Agent_Shared(xml, *nodes, cfg);
+}
+
+static void test_shared_batch_is_parsed(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str = "<batch><size>2MB</size><interval>30s</interval></batch>";
+
+    assert_int_equal(parse_agent_shared(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(cfg.batch.size, 2 * 1024 * 1024);
+    assert_int_equal(cfg.batch.interval, 30);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_shared_batch_is_validated_like_a_local_one(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    /* Pushed centrally or written locally, the same value is the same mistake:
+     * the manager does not get a laxer parser. */
+    const char *xml_str = "<batch><size>0</size></batch>";
+
+    expect_string(__wrap__merror, formatted_msg,
+                  "(1235): Invalid value for element 'size': 0.");
+
+    assert_int_equal(parse_agent_shared(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_shared_config_still_refuses_local_only_options(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    /* <batch> is opened up, not the whole block: the manager has no business
+     * setting how often this endpoint checks in. */
+    const char *xml_str = "<notify_time>5</notify_time>";
+
+    expect_string(__wrap__merror, formatted_msg,
+                  "(1230): Invalid element in the configuration: 'notify_time'.");
+
+    assert_int_equal(parse_agent_shared(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
 /* Deprecated legacy-TCP options: accepted, ignored, warned (#37702 restriction 4) */
 
 static void test_time_reconnect_is_deprecated(void **state) {
@@ -907,6 +973,9 @@ int main(void) {
         cmocka_unit_test(test_legacy_client_is_ignored_once_agent_set_the_address),
         cmocka_unit_test(test_fresh_install_template_shape),
         cmocka_unit_test(test_agent_invalid_tag_is_rejected),
+        cmocka_unit_test(test_shared_batch_is_parsed),
+        cmocka_unit_test(test_shared_batch_is_validated_like_a_local_one),
+        cmocka_unit_test(test_shared_config_still_refuses_local_only_options),
         cmocka_unit_test(test_batch_size_and_interval_are_parsed),
         cmocka_unit_test(test_batch_is_unset_when_absent),
         cmocka_unit_test(test_batch_size_without_a_suffix_is_bytes),

--- a/src/unit_tests/remoted/test_legacy_task_delivery.c
+++ b/src/unit_tests/remoted/test_legacy_task_delivery.c
@@ -999,6 +999,35 @@ void test_process_upgrade_ack_unexpected_command_ignored(void **state) {
     legacy_task_drain_clear_upgrade_replies();
 }
 
+void test_process_upgrade_ack_missing_parameters_ignored(void **state) {
+    (void) state;
+
+    expect_string(__wrap__mdebug1, formatted_msg,
+        "legacy_task_delivery: agent '005' sent an upgrade acknowledgment with a missing or "
+        "invalid 'parameters', ignoring");
+
+    bool result = legacy_task_process_upgrade_ack("005", "{\"command\":\"upgrade_update_status\"}");
+
+    assert_false(result);
+
+    legacy_task_drain_clear_upgrade_replies();
+}
+
+void test_process_upgrade_ack_non_object_parameters_ignored(void **state) {
+    (void) state;
+
+    expect_string(__wrap__mdebug1, formatted_msg,
+        "legacy_task_delivery: agent '005' sent an upgrade acknowledgment with a missing or "
+        "invalid 'parameters', ignoring");
+
+    bool result = legacy_task_process_upgrade_ack("005",
+        "{\"command\":\"upgrade_update_status\",\"parameters\":\"not an object\"}");
+
+    assert_false(result);
+
+    legacy_task_drain_clear_upgrade_replies();
+}
+
 void test_process_upgrade_ack_missing_error_field_ignored(void **state) {
     (void) state;
 
@@ -1133,6 +1162,8 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_process_upgrade_ack_failure_still_replies_clear_upgrade_result, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_process_upgrade_ack_malformed_json_ignored, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_process_upgrade_ack_unexpected_command_ignored, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_process_upgrade_ack_missing_parameters_ignored, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_process_upgrade_ack_non_object_parameters_ignored, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_process_upgrade_ack_missing_error_field_ignored, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_process_upgrade_ack_reply_failure_still_returns_true, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_process_upgrade_ack_burst_of_agents_does_not_block, test_setup, test_teardown),

--- a/src/wazuh_modules/inventory_sync/benchmark/tool_simulator/cmd/benchmark_sender/main.go
+++ b/src/wazuh_modules/inventory_sync/benchmark/tool_simulator/cmd/benchmark_sender/main.go
@@ -33,7 +33,7 @@ func main() {
 		// Session-level timing knobs (start_ack_timeout, end_ack_timeout,
 		// end_ack_processing_timeout, post_data_delay) are scenario-only.
 		// Set them per-step or via `defaults:` in the scenario JSON.
-		keepaliveInterval = flag.Duration("keepalive-interval", 20*time.Second, "How often each agent emits a control-message keepalive (`#!-<JSON>`). Matches the real agent's NOTIFY_TIME default. Pass 0s to disable keepalives entirely (the initial startup + final shutdown frames are still sent).")
+		keepaliveInterval = flag.Duration("keepalive-interval", 10*time.Second, "How often each agent emits a control-message keepalive (`#!-<JSON>`). Matches the real agent's NOTIFY_TIME default. Pass 0s to disable keepalives entirely (the initial startup + final shutdown frames are still sent).")
 		debug             = flag.Bool("debug", false, "Debug logging")
 		reportEngine      = flag.Bool("report-engine", true, "Emit engine_* columns in bench.csv")
 	)

--- a/src/wazuh_modules/src/main.c
+++ b/src/wazuh_modules/src/main.c
@@ -17,6 +17,10 @@
 #include "wmodules.h"
 #include <sys/types.h>
 #include "startup_gate_op.h"
+#ifdef CLIENT
+#include "agent_sync_protocol_c_interface.h"
+#include "client-config.h"
+#endif
 
 static void wm_help();                  // Print help.
 static void wm_setup();                 // Setup function. Exits on error.
@@ -181,6 +185,21 @@ void wm_setup()
     if (wm_config() < 0) {
         exit(EXIT_FAILURE);
     }
+
+#ifdef CLIENT
+    // The sync protocol bounds one session by <agent><batch><size>, the same limit
+    // that bounds a /stateless request. The block belongs to the agent rather than
+    // to any module here, and the modules that build the protocol instances can
+    // read no configuration at all, so it is read once and handed down before
+    // wm_check() starts any of them.
+    agent_batch batch = { .size = 0, .interval = 0 };
+    w_read_agent_batch(WAZUHCONF, AGENTCONFIG, &batch);
+    asp_set_session_max_bytes((uint64_t)batch.size);
+
+    if (batch.size > 0) {
+        mdebug1("Sync sessions bounded to %lld bytes by <agent><batch><size>.", batch.size);
+    }
+#endif
 
     // Go daemon
 

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -118,6 +118,11 @@ public function config()
                     re.Pattern = "<notify_time>.*</notify_time>"
                     re.Global = True
                     strText = re.Replace(strText, "<notify_time>" & WAZUH_KEEP_ALIVE_INTERVAL & "</notify_time>")
+                Else
+                    ' The shipped configuration no longer carries the options it left at
+                    ' their default, so there is nothing to replace on a fresh install.
+                    ' Add the tag instead of dropping the property the user asked for.
+                    strText = Replace(strText, "  </agent>", "    <notify_time>" & WAZUH_KEEP_ALIVE_INTERVAL & "</notify_time>" & vbCrLf & "  </agent>")
                 End If
             End If
 

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -11,7 +11,6 @@
       <address>0.0.0.0</address>
       <port>1517</port>
     </server>
-    <auto_restart>yes</auto_restart>
   </agent>
 
   <!-- Log analysis -->

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -11,13 +11,6 @@
       <address>0.0.0.0</address>
       <port>1517</port>
     </server>
-    <!-- HTTPS transport TLS settings; verification_mode: full|certificate|none (default: none).
-         Set to 'full' or 'certificate' and provide certificate_authorities to verify the
-         manager's certificate. -->
-    <ssl>
-      <!-- <certificate_authorities>etc/certs/root-ca.pem</certificate_authorities> -->
-      <verification_mode>none</verification_mode>
-    </ssl>
     <notify_time>10</notify_time>
     <auto_restart>yes</auto_restart>
   </agent>

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -11,7 +11,6 @@
       <address>0.0.0.0</address>
       <port>1517</port>
     </server>
-    <notify_time>10</notify_time>
     <auto_restart>yes</auto_restart>
   </agent>
 

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -20,6 +20,7 @@
 #include "os_net.h"
 #include "dll_load_notify.h"
 #include "startup_gate_op.h"
+#include "agent_sync_protocol_c_interface.h"
 
 #ifdef WAZUH_UNIT_TESTING
 #include "unit_tests/wrappers/windows/libc/kernel32_wrappers.h"
@@ -328,6 +329,16 @@ int local_start()
     /* Read wodle configuration */
     if (wm_config() < 0) {
         mlerror_exit(LOGLEVEL_ERROR, CONFIG_ERROR, cfg);
+    }
+
+    /* Same session ceiling modulesd applies on the other platforms. Taken straight
+     * from the agent configuration this process already read, local and centralized
+     * merged, rather than re-reading the files. Must precede the module threads:
+     * each protocol instance copies the limit when it is built. */
+    asp_set_session_max_bytes((uint64_t)agt->batch.size);
+
+    if (agt->batch.size > 0) {
+        mdebug1("Sync sessions bounded to %lld bytes by <agent><batch><size>.", agt->batch.size);
     }
 
     /* Start modules */

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -226,6 +226,18 @@ int local_start()
         minfo("Max time to reconnect can't be less than notify_time(%d), using notify_time*3 (%d)", agt->notify_time, agt->max_time_reconnect_try);
     }
 
+    /* Same session ceiling modulesd applies on the other platforms, taken straight from
+     * the configuration this process already read (local and centralized merged) rather
+     * than re-reading the files. It has to be set here, while the configuration is being
+     * finalized and before any thread exists: syscheck is started below and builds its
+     * protocol instance on that thread, and an instance copies the limit once, when it
+     * is constructed. Setting it any later is a race the module usually wins. */
+    asp_set_session_max_bytes((uint64_t)agt->batch.size);
+
+    if (agt->batch.size > 0) {
+        mdebug1("Sync sessions bounded to %lld bytes by <agent><batch><size>.", agt->batch.size);
+    }
+
     if(agt->enrollment_cfg && agt->enrollment_cfg->enabled) {
         // If autoenrollment is enabled, we will avoid exit if there is no valid key
         OS_PassEmptyKeyfile();
@@ -329,16 +341,6 @@ int local_start()
     /* Read wodle configuration */
     if (wm_config() < 0) {
         mlerror_exit(LOGLEVEL_ERROR, CONFIG_ERROR, cfg);
-    }
-
-    /* Same session ceiling modulesd applies on the other platforms. Taken straight
-     * from the agent configuration this process already read, local and centralized
-     * merged, rather than re-reading the files. Must precede the module threads:
-     * each protocol instance copies the limit when it is built. */
-    asp_set_session_max_bytes((uint64_t)agt->batch.size);
-
-    if (agt->batch.size > 0) {
-        mdebug1("Sync sessions bounded to %lld bytes by <agent><batch><size>.", agt->batch.size);
     }
 
     /* Start modules */

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -182,12 +182,6 @@ int local_start()
     /* Start agent */
     os_calloc(1, sizeof(agent), agt);
 
-    /* Default to no TLS verification when <ssl> is absent from the config -- e.g. an
-     * unmodified pre-HTTPS config (upgrade case: no <ssl> block at all), which would
-     * otherwise hard-exit on AG_INV_SSL_CA. ClientConf()/Read_Client_SSL() below still
-     * overrides this to whatever <ssl><verification_mode> the config actually sets. */
-    agt->ssl.verification_mode = AGENT_VERIFY_NONE;
-
     /* Configuration file not present */
     if (File_DateofChange(cfg) < 0) {
         merror_exit("Configuration file '%s' not found", cfg);

--- a/tools/manager_benchmark/tool_simulator/docu/03-control-protocol.md
+++ b/tools/manager_benchmark/tool_simulator/docu/03-control-protocol.md
@@ -120,8 +120,8 @@ above). All four are sender bugs and **MUST** fail the run.
 
 | Knob | Value | Where |
 |---|---|---|
-| Real agent keepalive interval | **20 s** by default | `NOTIFY_TIME` in `src/shared/include/defs.h`, overridable with `<client><notify_time>` |
-| Sender default | **20 s**, `--keepalive-interval` | Matches the agent so a fleet of N produces the real N/20 requests per second |
+| Real agent keepalive interval | **10 s** by default | `NOTIFY_TIME` in `src/shared/include/defs.h`, overridable with `<agent><notify_time>` |
+| Sender default | **10 s**, `--keepalive-interval` | Matches the agent so a fleet of N produces the real N/10 requests per second |
 | Manager write throttle | **60 s** | `kKeepaliveThrottleSec`: how often a `notify` actually writes to wazuh-db |
 | Manager groups refresh | **60 s** | `kGroupsRefreshIntervalSec` |
 


### PR DESCRIPTION
## Description

Follow-up adjustments on issue #38163, from the configuration review of the agent's
HTTPS transport. Two groups of changes:

**What the shipped configuration says.** Every option the templates wrote was set to
the value the agent already applies on its own, so the file restated defaults while
reading like a deliberate choice. `<ssl>`, `<notify_time>` and `<auto_restart>` are
gone from the templates and the defaults are now stated once, in code. A fresh install
gets this:

```xml
  <agent>
    <server>
      <address>MANAGER_IP</address>
      <port>1517</port>
    </server>
    <config-profile>ubuntu, ubuntu22</config-profile>
  </agent>
```

**What `<batch>` reaches.** It can now be pushed from the centralized configuration,
and it bounds a stateful sync session as well as a `/stateless` request — that ceiling
was a 5 MiB constant. Where each limit comes from after this PR:

| | size | interval |
|---|---|---|
| `/stateless` | `<agent><batch><size>` — unset: 1 MiB | `<agent><batch><interval>` — unset: 10 s |
| `/stateful` | `<agent><batch><size>` — unset: 5 MiB | the module's own `<synchronization><interval>` — unset: 300 s |

The flush rule (size OR interval) and the `/control` cadence were already what they
should be; they had no test holding them there, and now they do.

## Acceptance criteria

| # | Criterion | Commit |
|---|---|---|
| 1 | `<ssl>` not present by default in the templates or `ossec.conf` | `a37f3e81be` |
| 2 | `verification_mode` defaults to `none` | `bc77ac4bdf` |
| 3 | `auto_restart` not present by default | `2bd4ff57ad` |
| 4 | `notify_time` not present by default | `09f9cb1599` |
| 5 | Batch sent on max size **or** interval | `a52931b446` |
| 6 | Stateful messages: configurable max size (was hardcoded 5 MiB) and interval | `aa46f1a7a5` |
| 7 | `<batch>` configurable through the centralized configuration | `8102fecbb8` |
| 8 | `/control` outside the batch, on its own `notify_time` | `ca16c22a23` |

Evidence for each is in the comment below.

## Notes for review

**The removals had callers.** `register_configure_agent.sh` inserted the enrollment
block after `</auto_restart>` and set `notify_time` by substituting a tag it assumed
was there. Dropping either option silently breaks a deployment variable, so both are
re-anchored on the agent block itself rather than on an option inside it.

**`<batch><size>` has two "off" positions.** Set it and both planes use that number.
Leave it out and each keeps the limit it had before this PR — 1 MiB for a `/stateless`
request, 5 MiB for a sync session — rather than one silently shrinking or growing.
It is capped at 1 GiB, far above any useful batch and inside every `size_t` it has to
survive: past 4 GiB a 32-bit agent wraps, and exactly 4 GiB wraps to zero, which every
reader downstream takes as "unset".

**It also bounds slightly different things on each side.** For `/stateless` it is the
maximum body of one request, and it is adaptive: a 413 halves it and success ramps it
back. For `/stateful` it is the maximum pulled from the persistent queue per block,
less a 64 KiB prefilter grace, and one sync cycle can still send up to
`FULLSESSION_MAX_BLOCKS_PER_SYNC` (10) of those blocks — that multiplier is unchanged
and still a constant.
