### PR TITLE
Fix Windows agent crash on reconnection when the manager rejects its key

### DIFF
--- a/src/wazuh_modules/syscollector/include/syscollector.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector.hpp
@@ -14,6 +14,7 @@
 #include <thread>
 #include <condition_variable>
 #include <mutex>
+#include <shared_mutex>
 #include <memory>
 #include <optional>
 #include <atomic>
@@ -470,6 +471,17 @@ class EXPORTED Syscollector final
 
         // Mutex for thread-safe access to limits and counts
         std::mutex                                                               m_limitsMutex;
+
+        /// @brief Serializes releaseResources() against the entry points that other threads
+        /// keep driving while the module tears down: wcom's dispatcher is detached and never
+        /// joined, and agent-info's coordination polls call query() in-process from its own
+        /// module thread (e.g. the get_first_sync_completed guard, which reaches
+        /// getMetadataValue() and dereferences m_spDBSync). Those entry points take it shared
+        /// around each access; initSyncProtocol() publishes the protocols under the exclusive
+        /// lock and releaseResources() resets the members under it. The scan and sync workers
+        /// do not take it: they are joined before releaseResources() runs. Mirrors
+        /// SecurityConfigurationAssessment::m_resourcesMutex, added for the same defect.
+        mutable std::shared_mutex                                                m_resourcesMutex;
 };
 
 

--- a/src/wazuh_modules/syscollector/include/syscollector.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector.hpp
@@ -169,6 +169,11 @@ class EXPORTED Syscollector final
          * @return true if first VD sync is done, false if this is the first scan (VDFIRST)
          */
         bool isVDFirstSyncDone();
+
+        /// @brief Body of deleteDatabase() without taking m_resourcesMutex.
+        /// @note The caller must already hold m_resourcesMutex. Exists so callers that
+        /// already hold it shared do not acquire it a second time on the same thread.
+        void deleteDatabaseUnlocked();
         void persistVDFirstSyncIfNeeded(const bool vdResult, const bool firstSyncDone);
         /**
          * @brief Processes VD DataContext after scan completes

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -756,6 +756,21 @@ void Syscollector::quiesce()
 
 void Syscollector::releaseResources()
 {
+    // Take the flush controller out under the exclusive lock (so a concurrent "flush" query
+    // sees either the live controller or none) but destroy it outside of it: its destructor
+    // joins the flush worker, which runs executeFlushSync() -> synchronizeModule() without
+    // taking m_resourcesMutex, so joining it while holding the lock would be pointless and
+    // resetting the protocols before the join would be a use-after-free. quiesce()'s
+    // waitForFlushToFinish() is not enough on its own: it only joins the worker that exists
+    // at that instant, and flush() has no m_stopping check, so a "flush" query accepted
+    // right afterwards spawns a worker that outlives it.
+    std::unique_ptr<Utils::AsyncFlushController> flushController;
+    {
+        std::unique_lock<std::shared_mutex> resourcesLock(m_resourcesMutex);
+        flushController = std::move(m_asyncFlushController);
+    }
+    flushController.reset();
+
     // Exclude the entry points that other threads keep driving while the module tears down.
     // The scan and sync workers are joined before this runs (see wm_syscollector.c), but
     // query() is not: wcom's dispatcher is detached and agent-info polls it in-process, so
@@ -2902,7 +2917,17 @@ void Syscollector::deleteDatabase()
     // outlive the module teardown (wcom's detached dispatcher and agent-info's in-process
     // coordination polls), so the members it reaches must not be reset underneath it.
     std::shared_lock<std::shared_mutex> resourcesLock(m_resourcesMutex);
+    deleteDatabaseUnlocked();
+}
 
+void Syscollector::deleteDatabaseUnlocked()
+{
+    // The caller must already hold m_resourcesMutex. This body is split out of
+    // deleteDatabase() so deleteDisableCollectorsData(), which holds the mutex shared for
+    // its whole body, does not acquire a second shared lock on the same thread: most
+    // std::shared_mutex implementations block new readers once a writer is queued, so the
+    // nested acquisition would wait behind a pending releaseResources() or
+    // initSyncProtocol() while still holding the outer lock those writers are waiting for.
     if (m_spSyncProtocol)
     {
         m_spSyncProtocol->deleteDatabase();
@@ -4392,7 +4417,9 @@ void Syscollector::deleteDisableCollectorsData()
             m_logFunction(LOG_INFO, "All collectors are disabled. Deleting entire database.");
         }
 
-        deleteDatabase();
+        // Already holding m_resourcesMutex shared; call the non-locking body so we do not
+        // take a second shared lock on this thread (see deleteDatabaseUnlocked()).
+        deleteDatabaseUnlocked();
         m_disabledCollectorsIndicesWithData.clear();
         return;
         // LCOV_EXCL_STOP

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -756,6 +756,15 @@ void Syscollector::quiesce()
 
 void Syscollector::releaseResources()
 {
+    // Exclude the entry points that other threads keep driving while the module tears down.
+    // The scan and sync workers are joined before this runs (see wm_syscollector.c), but
+    // query() is not: wcom's dispatcher is detached and agent-info polls it in-process, so
+    // without this lock a get_first_sync_completed query could be inside getMetadataValue()
+    // dereferencing m_spDBSync while it is reset here, crashing the agent (issue #38203).
+    // quiesce() always runs first and stops the sync protocols, so anything holding the
+    // shared lock is already unwinding before this exclusive lock is requested.
+    std::unique_lock<std::shared_mutex> resourcesLock(m_resourcesMutex);
+
     // Explicitly release all resources to ensure clean state between tests
     // and prevent use-after-free when Syscollector singleton destructs
     // after static dependencies have already been destroyed
@@ -2271,6 +2280,10 @@ void Syscollector::initSyncProtocol(const std::string& moduleName, const std::st
                                     unsigned int retries,
                                     size_t maxEps, uint32_t integrityInterval)
 {
+    // Publish the protocols under the exclusive lock so a concurrent reader taking the
+    // shared lock sees either a fully constructed protocol or none, never a half-assigned one.
+    std::unique_lock<std::shared_mutex> resourcesLock(m_resourcesMutex);
+
     m_dataCleanRetries = retries;  // Same as sync retries for data clean notifications
     m_integrityIntervalValue = integrityInterval;
 
@@ -2462,6 +2475,11 @@ SyncModuleResult Syscollector::syncModule(Mode mode)
 
 void Syscollector::persistDifference(const std::string& id, Operation operation, const std::string& index, const std::string& data, uint64_t version, bool isDataContext)
 {
+    // Serialize against releaseResources(): this entry point is driven by threads that
+    // outlive the module teardown (wcom's detached dispatcher and agent-info's in-process
+    // coordination polls), so the members it reaches must not be reset underneath it.
+    std::shared_lock<std::shared_mutex> resourcesLock(m_resourcesMutex);
+
     // VD tables: system (os), packages, hotfixes
     bool isVDTable = (index == SYSCOLLECTOR_SYNC_INDEX_SYSTEM ||
                       index == SYSCOLLECTOR_SYNC_INDEX_PACKAGES ||
@@ -2479,6 +2497,11 @@ void Syscollector::persistDifference(const std::string& id, Operation operation,
 
 bool Syscollector::parseResponseBuffer(const uint8_t* data, size_t length)
 {
+    // Serialize against releaseResources(): this entry point is driven by threads that
+    // outlive the module teardown (wcom's detached dispatcher and agent-info's in-process
+    // coordination polls), so the members it reaches must not be reset underneath it.
+    std::shared_lock<std::shared_mutex> resourcesLock(m_resourcesMutex);
+
     // Route to regular (non-VD) sync protocol only
     if (m_spSyncProtocol)
     {
@@ -2490,6 +2513,11 @@ bool Syscollector::parseResponseBuffer(const uint8_t* data, size_t length)
 
 bool Syscollector::parseResponseBufferVD(const uint8_t* data, size_t length)
 {
+    // Serialize against releaseResources(): this entry point is driven by threads that
+    // outlive the module teardown (wcom's detached dispatcher and agent-info's in-process
+    // coordination polls), so the members it reaches must not be reset underneath it.
+    std::shared_lock<std::shared_mutex> resourcesLock(m_resourcesMutex);
+
     // Route to VD sync protocol only
     if (m_spSyncProtocolVD)
     {
@@ -2855,6 +2883,11 @@ void Syscollector::processVDDataContext()
 
 bool Syscollector::notifyDataClean(const std::vector<std::string>& indices)
 {
+    // Serialize against releaseResources(): this entry point is driven by threads that
+    // outlive the module teardown (wcom's detached dispatcher and agent-info's in-process
+    // coordination polls), so the members it reaches must not be reset underneath it.
+    std::shared_lock<std::shared_mutex> resourcesLock(m_resourcesMutex);
+
     if (m_spSyncProtocol)
     {
         return m_spSyncProtocol->notifyDataClean(indices);
@@ -2865,6 +2898,11 @@ bool Syscollector::notifyDataClean(const std::vector<std::string>& indices)
 
 void Syscollector::deleteDatabase()
 {
+    // Serialize against releaseResources(): this entry point is driven by threads that
+    // outlive the module teardown (wcom's detached dispatcher and agent-info's in-process
+    // coordination polls), so the members it reaches must not be reset underneath it.
+    std::shared_lock<std::shared_mutex> resourcesLock(m_resourcesMutex);
+
     if (m_spSyncProtocol)
     {
         m_spSyncProtocol->deleteDatabase();
@@ -3234,6 +3272,11 @@ void Syscollector::unlockScanMutex()
 
 std::string Syscollector::query(const std::string& jsonQuery)
 {
+    // Serialize against releaseResources(): this entry point is driven by threads that
+    // outlive the module teardown (wcom's detached dispatcher and agent-info's in-process
+    // coordination polls), so the members it reaches must not be reset underneath it.
+    std::shared_lock<std::shared_mutex> resourcesLock(m_resourcesMutex);
+
     // Log the received query
     if (m_logFunction)
     {
@@ -4276,6 +4319,11 @@ void Syscollector::checkDisabledCollectorsIndicesWithData()
 
 bool Syscollector::notifyDisableCollectorsDataClean()
 {
+    // Serialize against releaseResources(): this entry point is driven by threads that
+    // outlive the module teardown (wcom's detached dispatcher and agent-info's in-process
+    // coordination polls), so the members it reaches must not be reset underneath it.
+    std::shared_lock<std::shared_mutex> resourcesLock(m_resourcesMutex);
+
     if (m_disabledCollectorsIndicesWithData.empty())
     {
         if (m_logFunction)
@@ -4320,6 +4368,11 @@ bool Syscollector::notifyDisableCollectorsDataClean()
 
 void Syscollector::deleteDisableCollectorsData()
 {
+    // Serialize against releaseResources(): this entry point is driven by threads that
+    // outlive the module teardown (wcom's detached dispatcher and agent-info's in-process
+    // coordination polls), so the members it reaches must not be reset underneath it.
+    std::shared_lock<std::shared_mutex> resourcesLock(m_resourcesMutex);
+
     if (m_disabledCollectorsIndicesWithData.empty())
     {
         if (m_logFunction)
@@ -4496,6 +4549,15 @@ bool Syscollector::checkIfFullSyncRequired(const std::string& tableName)
 bool Syscollector::getMetadataValue(const std::string& key, int64_t& value)
 {
     value = 0;
+
+    // Callers reach this from query(), which holds m_resourcesMutex shared, so the pointer
+    // cannot be reset underneath us. Checked anyway, as every other DBSync user in this file
+    // does: a null dereference here raises an SEH access violation on Windows, which the
+    // catch below cannot handle, and it takes the whole agent process down.
+    if (!m_spDBSync)
+    {
+        return false;
+    }
 
     auto callback = [&value](ReturnTypeCallback result, const nlohmann::json & data)
     {

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -756,29 +756,27 @@ void Syscollector::quiesce()
 
 void Syscollector::releaseResources()
 {
-    // Take the flush controller out under the exclusive lock (so a concurrent "flush" query
-    // sees either the live controller or none) but destroy it outside of it: its destructor
-    // joins the flush worker, which runs executeFlushSync() -> synchronizeModule() without
-    // taking m_resourcesMutex, so joining it while holding the lock would be pointless and
-    // resetting the protocols before the join would be a use-after-free. quiesce()'s
-    // waitForFlushToFinish() is not enough on its own: it only joins the worker that exists
-    // at that instant, and flush() has no m_stopping check, so a "flush" query accepted
-    // right afterwards spawns a worker that outlives it.
-    std::unique_ptr<Utils::AsyncFlushController> flushController;
-    {
-        std::unique_lock<std::shared_mutex> resourcesLock(m_resourcesMutex);
-        flushController = std::move(m_asyncFlushController);
-    }
-    flushController.reset();
-
-    // Exclude the entry points that other threads keep driving while the module tears down.
-    // The scan and sync workers are joined before this runs (see wm_syscollector.c), but
-    // query() is not: wcom's dispatcher is detached and agent-info polls it in-process, so
-    // without this lock a get_first_sync_completed query could be inside getMetadataValue()
-    // dereferencing m_spDBSync while it is reset here, crashing the agent (issue #38203).
-    // quiesce() always runs first and stops the sync protocols, so anything holding the
-    // shared lock is already unwinding before this exclusive lock is requested.
+    // Exclude the entry points that other threads keep driving while the module tears
+    // down. The scan and sync workers are joined before this runs (see wm_syscollector.c),
+    // but query() is not: wcom's dispatcher is detached and agent-info polls it in-process,
+    // so without this lock a get_first_sync_completed query could be inside
+    // getMetadataValue() dereferencing m_spDBSync while it is reset here (issue #38203).
     std::unique_lock<std::shared_mutex> resourcesLock(m_resourcesMutex);
+
+    // Join any in-flight asynchronous flush before the members it uses are reset.
+    // The worker runs executeFlushSync() -> synchronizeModule() on its own thread and
+    // takes no lock, so quiesce()'s waitForFlushToFinish() misses a flush accepted
+    // afterwards (flush() has no m_stopping check). Holding the exclusive lock here also
+    // stops a new flush being accepted, because flush() is only reachable through
+    // query(), which takes the lock shared.
+    //
+    // The controller is joined, not destroyed: it is created once in the constructor of
+    // this singleton, so destroying it would leave the module permanently unable to flush
+    // for the rest of the process lifetime.
+    if (m_asyncFlushController)
+    {
+        m_asyncFlushController->waitForFlushToFinish();
+    }
 
     // Explicitly release all resources to ensure clean state between tests
     // and prevent use-after-free when Syscollector singleton destructs

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -3020,6 +3020,7 @@ TEST_F(SyscollectorImpTest, releaseResourcesJoinsInFlightFlushBeforeResettingSyn
     s_workerLeftProtocol = false;
 
     const auto spInfoWrapper {std::make_shared<MockSysInfo>()};
+    EXPECT_CALL(*spInfoWrapper, releaseThreadResources()).Times(testing::AnyNumber());
     EXPECT_CALL(*spInfoWrapper, hardware()).Times(0);
     EXPECT_CALL(*spInfoWrapper, os()).Times(0);
 

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -2998,6 +2998,104 @@ TEST_F(SyscollectorImpTest, queryCommandFlushReportsCompletedError)
     Syscollector::instance().destroy();
 }
 
+// Regression test for the flush path of issue #38203.
+//
+// releaseResources() must join the asynchronous flush worker before resetting the sync
+// protocols. That worker runs executeFlushSync() -> synchronizeModule() on
+// AsyncFlushController's own thread, which takes no lock and is not covered by the module
+// teardown: quiesce()'s waitForFlushToFinish() only joins a worker that already exists when
+// it runs, and flush() has no m_stopping check, so a "flush" query accepted right afterwards
+// spawns one that outlives it. Resetting m_spSyncProtocol while that worker is inside it is
+// a use-after-free.
+//
+// The MQ start callback parks the worker inside the sync protocol, so the race is
+// deterministic rather than timing dependent.
+TEST_F(SyscollectorImpTest, releaseResourcesJoinsInFlightFlushBeforeResettingSyncProtocol)
+{
+    static std::atomic<bool> s_blockStart {false};
+    static std::atomic<bool> s_startEntered {false};
+    static std::atomic<bool> s_workerLeftProtocol {false};
+    s_blockStart = true;
+    s_startEntered = false;
+    s_workerLeftProtocol = false;
+
+    const auto spInfoWrapper {std::make_shared<MockSysInfo>()};
+    EXPECT_CALL(*spInfoWrapper, hardware()).Times(0);
+    EXPECT_CALL(*spInfoWrapper, os()).Times(0);
+
+    Syscollector::instance().init(spInfoWrapper,
+                                  reportFunction,
+                                  persistFunction,
+                                  logFunction,
+                                  SYSCOLLECTOR_DB_PATH,
+                                  "",
+                                  "",
+                                  3600, false, false, false, false, false, false,
+                                  false, false, false, false, false, false, false, false);
+
+    MQ_Functions blockingMq {};
+    blockingMq.start = [](const char*, short, short) -> int
+    {
+        s_startEntered = true;
+
+        while (s_blockStart)
+        {
+            std::this_thread::yield();
+        }
+
+        // Set on the flush worker thread, while it is still inside the sync protocol.
+        s_workerLeftProtocol = true;
+        return 1;
+    };
+    blockingMq.send_binary = [](int, const void*, size_t, const char*, char) -> int
+    {
+        return 0;
+    };
+
+    Syscollector::instance().initSyncProtocol("syscollector",
+                                              ":memory:",
+                                              ":memory:",
+                                              blockingMq,
+                                              std::chrono::seconds(0),
+                                              std::chrono::seconds(1),
+                                              1,
+                                              100,
+                                              0);
+
+    // Start a flush and wait until its worker is parked inside the sync protocol.
+    auto flushResponse = nlohmann::json::parse(Syscollector::instance().query(R"({"command":"flush"})"));
+    EXPECT_EQ(flushResponse["error"], MQ_SUCCESS);
+    EXPECT_TRUE(waitUntil([]()
+    {
+        return s_startEntered.load();
+    }));
+
+    std::atomic<bool> releaseReturned {false};
+    std::atomic<bool> workerHadFinished {false};
+
+    std::thread releaser([&releaseReturned, &workerHadFinished]()
+    {
+        Syscollector::instance().releaseResources();
+        // The invariant under test: by the time releaseResources() returns, the flush
+        // worker must already have left the sync protocol.
+        workerHadFinished = s_workerLeftProtocol.load();
+        releaseReturned = true;
+    });
+
+    // While the worker is parked, releaseResources() must not complete.
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    EXPECT_FALSE(releaseReturned.load())
+            << "releaseResources() returned while a flush worker was still inside the sync protocol";
+
+    s_blockStart = false;
+    releaser.join();
+
+    EXPECT_TRUE(workerHadFinished.load())
+            << "releaseResources() reset the sync protocols before joining the flush worker";
+
+    Syscollector::instance().destroy();
+}
+
 TEST_F(SyscollectorImpTest, executeFlushSync_VDEnabled_FirstSyncNotDone_FlushSucceeds)
 {
     const auto spInfoWrapper {std::make_shared<MockSysInfo>()};


### PR DESCRIPTION
## Description

Closes #38203

The Windows agent crashes with an access violation inside `syscollector.dll`, taking the whole process down. When it happens during reconnection the agent stops retrying, never re-enrolls, and the reported integration test times out.

```sql
Faulting application name: wazuh-agent.exe, version: 5.0.0.0
Faulting module name: syscollector.dll, version: 5.0.0.0
Exception code: 0xc0000005
Fault offset: 0x00012313
```

The fault resolves to `Syscollector::getMetadataValue()`, at the point where it dereferences `m_spDBSync`:

```asm
12310:  8b 48 6c    mov 0x6c(%eax),%ecx    ; ecx = this->m_spDBSync
12313:  8b 01       mov (%ecx),%eax        ; faults here, reading the vptr through a null pointer
12330:  ff d0       call *%eax             ; virtual call, selectRows()
```

`Syscollector::query()` is reachable from threads the module never owns: wcom's dispatcher is detached and never joined, and agent-info's coordination polls call it in-process from their own module thread. The `get_first_sync_completed` query reaches `getMetadataValue()`, which used `m_spDBSync` with no null check and no synchronization. `m_spDBSync` can be null in two distinct situations, and both were reachable:

- **Initialization failed.** `init()` throws while constructing DBSync (for example `sqlite: database is locked` when a previous agent process still holds `local.db`). `m_spDBSync` stays null and `start()` bails out with "Cannot start Syscollector - module initialization failed", but nothing gates `query()` on `m_initialized`, so the next coordination poll dereferences null. This is the path behind the crashes actually captured: all five had `module initialization failed` in the log.
- **Teardown.** `releaseResources()` resets `m_spDBSync` and the sync protocols with no lock, relying on the scan and sync workers having been joined. That covers the module's own threads, not the query entry point, so an in-flight query can be inside a check-then-use while the members are reset.

This is the same defect class that df06f36bec fixed in SCA ("fix(sca): exclude live query paths from the module teardown"), whose description names `get_first_sync_completed` explicitly. That fix was never mirrored into Syscollector, although both modules share the same structure, the same teardown ordering and the same entry points. `git log -S m_resourcesMutex` returns that single SCA commit and nothing under `src/wazuh_modules/syscollector`.

The query path became reachable in 5323683e80 ("feat(syscollector): persist first sync completion"), which added `getMetadataValue()` together with the `get_first_sync_completed` command.

Reported as a flaky Windows integration test, because the visible symptom is `test_agentd_reconection_enrollment_with_keys` timing out: the agent logs one failed handshake attempt and then dies, so the remaining retries and the re-enrollment never happen.

```sql
09:06:43 wazuh-agent: INFO: (4102): Connected to the server ([127.0.0.1]:1514/tcp).
09:06:44 wazuh-agent: ERROR: (1137): Lost connection with manager. Setting lock.
09:06:44 wazuh-agent: INFO: Trying to connect to server ([127.0.0.1]:1514/tcp).
09:06:44 wazuh-agent: WARNING: (1214): Problem receiving message from '127.0.0.1'.
```

Nothing follows for the remaining 150 seconds, because there is no process left to write it.

## Proposed Changes

**Guard the pointer.**

- Check `m_spDBSync` in `getMetadataValue()` before use, as the other twelve DBSync users in the file already do. This is what stops the crash actually observed: a null dereference raises an SEH access violation on Windows, which the surrounding `catch (const std::exception&)` cannot handle, so the process dies rather than the error being swallowed.

**Serialize the live entry points against teardown.**

- Add `m_resourcesMutex` (`std::shared_mutex`), mirroring `SecurityConfigurationAssessment::m_resourcesMutex`.
- Take it **shared** in the entry points driven by threads that outlive the teardown: `query`, `persistDifference`, `parseResponseBuffer`, `parseResponseBufferVD`, `notifyDataClean`, `deleteDatabase`, `notifyDisableCollectorsDataClean`, `deleteDisableCollectorsData`.
- Take it **exclusive** in `releaseResources()`, so members are reset only when no entry point is inside them, and in `initSyncProtocol()`, so a concurrent reader sees a fully constructed protocol or none.

**Wait for any in-flight flush before resetting what it uses.**

- `releaseResources()` now joins the asynchronous flush worker, under the exclusive lock, before the sync protocols and DBSync are reset.
- Without this the flush path stayed open: a wcom `flush` query calls `startFlush()`, which spawns its own thread and returns immediately, so `query()` releases the shared lock while `executeFlushSync()` keeps dereferencing `m_spSyncProtocol` and `m_spSyncProtocolVD` under no lock. `quiesce()`'s `waitForFlushToFinish()` only joins a worker that already exists when it runs, and `flush()` has no `m_stopping` check, so a flush accepted just afterwards outlives it.
- Holding the exclusive lock across the join also prevents a **new** flush being accepted, because `flush()` is only reachable through `query()`, which takes the lock shared. Joining while holding it is safe: the worker takes no lock and never re-enters a Syscollector entry point.
- The controller is joined rather than destroyed. It is created once in the constructor of this singleton, so destroying it would leave the module unable to flush for the rest of the process lifetime. An earlier revision of this PR did destroy it, which broke every subsequent flush in the unit-test binary and hung `destroyWaitsForOngoingFlush`; that is fixed here.

**Avoid a nested shared lock.**

- `deleteDisableCollectorsData()` holds `m_resourcesMutex` shared for its whole body and called `deleteDatabase()`, which acquired a second shared lock on the same thread. `std::shared_mutex` blocks new readers once a writer is queued, so with `releaseResources()` or `initSyncProtocol()` waiting, the nested acquisition would deadlock against the outer lock this thread still holds. The body is split into `deleteDatabaseUnlocked()`, called from the path that already holds the mutex.

Ordering is unchanged and safe: `quiesce()` still runs before `releaseResources()` in both callers (`destroy()`, and `syscollector_stop()` followed by `syscollector_release_resources()` in `wm_syscollector.c`). It sets `m_stopping`, notifies the condition variables and stops both sync protocols, so anything holding the shared lock is already unwinding before the exclusive lock is requested.

No lock-order inversion is introduced. `query()` acquires no other mutex, `initSyncProtocol()` is never called internally, and `destroy()` releases `m_scan_mutex` before calling `releaseResources()`. Every entry point was traced for nested acquisition; the only real case was the one fixed above.

### Results and Evidence

Reproduced and validated on Windows 11 with the 5.0.0 agent, running `test_agentd_reconection_enrollment_with_keys` in a loop against the test simulators.

| | Before the fix | After the fix |
|---|---|---|
| Runs | 30 | 100 |
| Test failures caused by the crash | 5 | 0 |
| `syscollector.dll` access violations in the Windows event log | 5 | 0 |
| Failure rate | ~17 % | 0 % |

Before the fix, every failing run left one Event ID 1000 in the Windows Application log, always the same module, exception code and fault offset, with timestamps matching the test failures to the second. It reproduced at `windows.debug` 0 and 2 alike, so it was not an artefact of diagnostic logging.

| Crash time | `windows.debug` | Test |
|------------|-----------------|------|
| 2026-08-06 16:25:36 | 2 | fail |
| 2026-08-10 08:46:27 | 2 | fail |
| 2026-08-10 08:57:03 | 0 | fail |
| 2026-08-10 09:06:44 | 0 | fail |
| 2026-08-10 09:11:51 | 0 | fail |

After installing an agent built from this branch, 100 consecutive runs produced no `syscollector.dll` crash. If the crash rate were unchanged, observing zero in 100 runs would have a probability of roughly 1 in 100 million.

The single test failure in those 100 runs was unrelated to this change: the first iteration after a fresh install failed on `Connected to the server message not found`, and the agent's own log shows it connecting normally after two `(1216)` retries while the simulator was not yet listening. `wait_connect()` uses `only_new_events=True`, so the connect line fell outside its monitoring window. That is a race in the test harness, not in the agent.

A separate crash signature, `libstdc++-6.dll` with exception `0x40000015`, also appears in the same window. It is a different defect, is not touched by this change, and failed no test.

An agent package built from the final commit on this branch was additionally installed on Windows 11 against a real manager and exercised end to end: inventory (packages, processes, hotfixes and the OS record, with the host name and counts cross-checked against the machine itself), policy assessment (482 checks evaluated) and file integrity monitoring (a monitored file created and modified, and the change detected). No regression in any of them.

The full syscollector unit-test binary passes locally, 88 tests, including the pre-existing flush and teardown tests. All CI checks on the branch pass, among them `rtr (wazuh_modules/syscollector)` for both `agent` and `winagent`, which an earlier revision of this PR had been stalling to their one-hour limit.

### Artifacts Affected

- `syscollector.dll` on all platforms. The crash was only observed on Windows, but the defect is not platform specific: on Linux and macOS syscollector runs inside `wazuh-modulesd` as a separate process, so the same fault kills that process while `wazuh-agentd` keeps running. The agent then looks healthy while inventory, policy assessment and the other wodles stop silently, which is why the Windows-only integration test was the one that caught it.
- No changes to configuration, on-disk databases, message formats or public interfaces.

### Configuration Changes

None. No new options, no changed defaults, no compatibility considerations.

### Documentation Updates

None required.

### Tests Introduced

- `releaseResourcesJoinsInFlightFlushBeforeResettingSyncProtocol` in `syscollectorImp_test.cpp`. It parks a flush worker inside the sync protocol using a blocking MQ callback, calls `releaseResources()` on another thread, and asserts both that it does not return while the worker is parked and that the worker had left the protocol before it returned. Without the fix `releaseResources()` returns immediately and the test fails.

The existing integration test `test_agentd/test_reconnection/test_agentd_reconection_enrollment_with_keys.py` already covers the reported path and is what surfaced the crash.

A unit test for the null-pointer path would need to drive `query()` against a module whose `init()` failed, which the current fixtures do not model; it is covered by the guard matching the file's existing idiom and by the 100-run validation above.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
