### PR TITLE
Report disabled root decoder during policy promotion

### DIFF
--- a/docs/ref/modules/engine/README.md
+++ b/docs/ref/modules/engine/README.md
@@ -1098,6 +1098,9 @@ Attributes are configuration details and metadata about the asset. Every asset s
 - **`name`**: Uniquely identifies the asset using the pattern `<asset_type>/<name>/<version>` (e.g. `decoder/aws-cloudtrail/0`).
 - **`id`**: A UUIDv4 string that uniquely identifies the asset across the system.
 - **`enabled`**: Boolean flag. Disabled assets are ignored when building the policy operational graph.
+  The policy's root decoder is the one exception: because it anchors the whole decoder tree, the build
+  fails with an explicit error if it is disabled, belongs only to disabled integrations, or is not
+  referenced by any integration of the policy.
 - **`metadata`**: Descriptive information about the asset. Common sub-fields include `module`, `title`, `description`,
   `compatibility`, `versions`, `author`, and `references`.
 - **`parents`**: Lists the parent asset names that define the asset's position in the asset graph.

--- a/src/engine/source/builder/src/policy/factory.cpp
+++ b/src/engine/source/builder/src/policy/factory.cpp
@@ -230,6 +230,36 @@ BuiltAssets buildAssets(const cm::store::dataType::Policy& policy,
         }
     }
 
+    // Decoders that declare no parent of their own were attached above to the integration default
+    // parent or, failing that, to the policy root decoder. If any decoder ended up depending on the
+    // root but the root itself never made it into the tree, the graph is unbuildable.
+    // Reachable when the root decoder is disabled, belongs only to disabled
+    // integrations, or is not referenced by any integration of the policy.
+    // Policies whose decoders all declare explicit parents never depend on the root, so they are left
+    // alone: the root decoder is legitimately absent from the tree there.
+    const auto decodersIt = builtAssets.find(AssetPipelineStage::DECODERS_TREE);
+    if (decodersIt != builtAssets.end() && !isAlreadyBuilt(rootDecoderName.toStr(), AssetPipelineStage::DECODERS_TREE))
+    {
+        const auto& decoders = decodersIt->second.assets;
+        const bool rootIsRequired =
+            std::any_of(decoders.cbegin(),
+                        decoders.cend(),
+                        [&rootDecoderName](const auto& entry)
+                        {
+                            const auto& parents = entry.second.parents();
+                            return std::find(parents.cbegin(), parents.cend(), rootDecoderName) != parents.cend();
+                        });
+
+        if (rootIsRequired)
+        {
+            throw std::runtime_error(fmt::format(
+                "The root decoder '{}' [id: '{}'] is required by the policy decoders but is not part of its enabled "
+                "content; it must be enabled and belong to an enabled integration of the policy",
+                rootDecoderName.toStr(),
+                policy.getRootDecoderUUID()));
+        }
+    }
+
     assetBuilder->clearIntegrationData();
 
     // Filters

--- a/src/engine/source/builder/src/policy/factory.cpp
+++ b/src/engine/source/builder/src/policy/factory.cpp
@@ -164,6 +164,13 @@ BuiltAssets buildAssets(const cm::store::dataType::Policy& policy,
 
             if (!syntax::asset::isEnabledResource(decoder))
             {
+                if (decUUID == policy.getRootDecoderUUID())
+                {
+                    throw std::runtime_error(
+                        fmt::format("The root decoder '{}' [id: '{}'] is disabled; enable it before using this policy",
+                                    rootDecoderName.toStr(),
+                                    decUUID));
+                }
                 continue;
             }
 

--- a/src/engine/source/builder/test/src/unit/policy/factory_test.cpp
+++ b/src/engine/source/builder/test/src/unit/policy/factory_test.cpp
@@ -1920,4 +1920,94 @@ INSTANTIATE_TEST_SUITE_P(
                              return OrderCheck {RT::DECODER, "decoder/root/0", {"decoder/X/0", "decoder/Z/0"}};
                          }}))));
 
+TEST(BuildAssetsRootDecoder, DisabledRootDecoderIsReportedExplicitly)
+{
+    const std::string integUUID = "550e8400-e29b-41d4-a716-446655440501";
+    const std::string rootUUID = "550e8400-e29b-41d4-a716-446655440599";
+
+    auto policy = dataType::Policy(
+        "test_policy", true, rootUUID, {integUUID}, {}, {}, {}, "UNDEFINED", "", false, false, true);
+
+    auto reader = std::make_shared<MockICMStoreNSReader>();
+    auto buildCtx = std::make_shared<builder::builders::BuildCtx>();
+    auto registry = builder::mocks::MockMetaRegistry<builder::builders::OpBuilderEntry,
+                                                     builder::builders::StageBuilder,
+                                                     builder::builders::EnrichmentBuilder>::createMock();
+    buildCtx->setRegistry(registry);
+    auto assetBuilder = std::make_shared<PassthroughAssetBuilder>();
+
+    dataType::Integration integration(
+        integUUID, "test_integration", true, "system-activity", std::nullopt, {}, {rootUUID}, false);
+
+    EXPECT_CALL(*reader, resolveNameFromUUID(rootUUID))
+        .WillRepeatedly(testing::Return(std::make_tuple("decoder/live-proof-1394/0", RT::DECODER)));
+    EXPECT_CALL(*reader, getIntegrationByUUID(integUUID)).WillOnce(testing::Return(integration));
+    EXPECT_CALL(*reader, getAssetByUUID(rootUUID))
+        .WillOnce(testing::Return(mkAssetJson("decoder/live-proof-1394/0", /*enabled=*/false)));
+
+    EXPECT_THROW(
+        {
+            try
+            {
+                (void)factory::buildAssets(policy, reader, assetBuilder, /*isTestMode=*/true);
+            }
+            catch (const std::runtime_error& e)
+            {
+                EXPECT_THAT(e.what(), testing::HasSubstr("root decoder"));
+                EXPECT_THAT(e.what(), testing::HasSubstr("decoder/live-proof-1394/0"));
+                EXPECT_THAT(e.what(), testing::HasSubstr(rootUUID));
+                EXPECT_THAT(e.what(), testing::HasSubstr("disabled"));
+                EXPECT_THAT(e.what(), testing::Not(testing::HasSubstr("Policy must have at least")));
+                throw;
+            }
+        },
+        std::runtime_error);
+}
+
+TEST(BuildAssetsRootDecoder, EnabledRootDecoderAlsoReferencedByDisabledIntegrationStillBuilds)
+{
+    const std::string disabledIntegUUID = "550e8400-e29b-41d4-a716-446655440601";
+    const std::string enabledIntegUUID = "550e8400-e29b-41d4-a716-446655440602";
+    const std::string rootUUID = "550e8400-e29b-41d4-a716-446655440699";
+
+    auto policy = dataType::Policy("test_policy",
+                                   true,
+                                   rootUUID,
+                                   {disabledIntegUUID, enabledIntegUUID},
+                                   {},
+                                   {},
+                                   {},
+                                   "UNDEFINED",
+                                   "",
+                                   false,
+                                   false,
+                                   true);
+
+    auto reader = std::make_shared<MockICMStoreNSReader>();
+    auto buildCtx = std::make_shared<builder::builders::BuildCtx>();
+    auto registry = builder::mocks::MockMetaRegistry<builder::builders::OpBuilderEntry,
+                                                     builder::builders::StageBuilder,
+                                                     builder::builders::EnrichmentBuilder>::createMock();
+    buildCtx->setRegistry(registry);
+    auto assetBuilder = std::make_shared<PassthroughAssetBuilder>();
+
+    dataType::Integration disabledInteg(
+        disabledIntegUUID, "disabled_integration", false, "system-activity", std::nullopt, {}, {rootUUID}, false);
+    dataType::Integration enabledInteg(
+        enabledIntegUUID, "enabled_integration", true, "system-activity", std::nullopt, {}, {rootUUID}, false);
+
+    EXPECT_CALL(*reader, resolveNameFromUUID(rootUUID))
+        .WillRepeatedly(testing::Return(std::make_tuple("decoder/live-proof-1394/0", RT::DECODER)));
+    EXPECT_CALL(*reader, getIntegrationByUUID(disabledIntegUUID)).WillOnce(testing::Return(disabledInteg));
+    EXPECT_CALL(*reader, getIntegrationByUUID(enabledIntegUUID)).WillOnce(testing::Return(enabledInteg));
+    EXPECT_CALL(*reader, getAssetByUUID(rootUUID))
+        .WillOnce(testing::Return(mkAssetJson("decoder/live-proof-1394/0", /*enabled=*/true)));
+
+    factory::BuiltAssets built;
+    ASSERT_NO_THROW(built = factory::buildAssets(policy, reader, assetBuilder, /*isTestMode=*/true));
+
+    const auto& decoders = built.at(factory::AssetPipelineStage::DECODERS_TREE);
+    EXPECT_EQ(decoders.assets.count(base::Name("decoder/live-proof-1394/0")), 1u);
+}
+
 } // namespace buildassetsordertest

--- a/src/engine/source/builder/test/src/unit/policy/factory_test.cpp
+++ b/src/engine/source/builder/test/src/unit/policy/factory_test.cpp
@@ -2010,4 +2010,66 @@ TEST(BuildAssetsRootDecoder, EnabledRootDecoderAlsoReferencedByDisabledIntegrati
     EXPECT_EQ(decoders.assets.count(base::Name("decoder/live-proof-1394/0")), 1u);
 }
 
+TEST(BuildAssetsRootDecoder, RootDecoderReachableOnlyThroughDisabledIntegrationIsReportedExplicitly)
+{
+    const std::string disabledIntegUUID = "550e8400-e29b-41d4-a716-446655440701";
+    const std::string enabledIntegUUID = "550e8400-e29b-41d4-a716-446655440702";
+    const std::string childUUID = "550e8400-e29b-41d4-a716-446655440703";
+    const std::string rootUUID = "550e8400-e29b-41d4-a716-446655440799";
+
+    auto policy = dataType::Policy("test_policy",
+                                   true,
+                                   rootUUID,
+                                   {disabledIntegUUID, enabledIntegUUID},
+                                   {},
+                                   {},
+                                   {},
+                                   "UNDEFINED",
+                                   "",
+                                   false,
+                                   false,
+                                   true);
+
+    auto reader = std::make_shared<MockICMStoreNSReader>();
+    auto buildCtx = std::make_shared<builder::builders::BuildCtx>();
+    auto registry = builder::mocks::MockMetaRegistry<builder::builders::OpBuilderEntry,
+                                                     builder::builders::StageBuilder,
+                                                     builder::builders::EnrichmentBuilder>::createMock();
+    buildCtx->setRegistry(registry);
+    auto assetBuilder = std::make_shared<PassthroughAssetBuilder>();
+
+    // The root decoder is listed only by a disabled integration, so the per-decoder guard never sees it.
+    dataType::Integration disabledInteg(
+        disabledIntegUUID, "disabled_integration", false, "system-activity", std::nullopt, {}, {rootUUID}, false);
+    dataType::Integration enabledInteg(
+        enabledIntegUUID, "enabled_integration", true, "system-activity", std::nullopt, {}, {childUUID}, false);
+
+    EXPECT_CALL(*reader, resolveNameFromUUID(rootUUID))
+        .WillRepeatedly(testing::Return(std::make_tuple("decoder/live-proof-1394/0", RT::DECODER)));
+    EXPECT_CALL(*reader, getIntegrationByUUID(disabledIntegUUID)).WillOnce(testing::Return(disabledInteg));
+    EXPECT_CALL(*reader, getIntegrationByUUID(enabledIntegUUID)).WillOnce(testing::Return(enabledInteg));
+    // The disabled integration is skipped wholesale, so the root decoder asset is never fetched.
+    EXPECT_CALL(*reader, getAssetByUUID(rootUUID)).Times(0);
+    EXPECT_CALL(*reader, getAssetByUUID(childUUID))
+        .WillOnce(testing::Return(mkAssetJson("decoder/child/0", /*enabled=*/true)));
+
+    EXPECT_THROW(
+        {
+            try
+            {
+                (void)factory::buildAssets(policy, reader, assetBuilder, /*isTestMode=*/true);
+            }
+            catch (const std::runtime_error& e)
+            {
+                EXPECT_THAT(e.what(), testing::HasSubstr("root decoder"));
+                EXPECT_THAT(e.what(), testing::HasSubstr("decoder/live-proof-1394/0"));
+                EXPECT_THAT(e.what(), testing::HasSubstr(rootUUID));
+                EXPECT_THAT(e.what(), testing::Not(testing::HasSubstr("Policy must have at least")));
+                EXPECT_THAT(e.what(), testing::Not(testing::HasSubstr("does not exist, required by")));
+                throw;
+            }
+        },
+        std::runtime_error);
+}
+
 } // namespace buildassetsordertest


### PR DESCRIPTION
## Description

When a space's `root_decoder` is disabled, promoting that space (`draft → test`) correctly fails, but the error message gives no indication of the real cause. It does not name the decoder, never mentions "root decoder" or "disabled", and read literally it suggests the policy has no decoders configured at all — which is false.

The root cause is that the policy factory filters out every disabled resource while assembling the decoder tree, and only afterwards checks "does the tree contain at least one decoder". The root decoder is therefore dropped silently, and the failure surfaces later as a generic, count-based message that points the user in the wrong direction.

Promotion is the only path where this can happen unnoticed: the engine's `POST /content/validate/policy` handler imports the candidate content with `force=true`, which skips every soft validation (`CrudService::importNamespace`). Validation on that path is effectively "build the policy for real and see if it throws", so the diagnosis has to come from the builder itself.

Closes #37928

## Proposed Changes

- **`src/engine/source/builder/src/policy/factory.cpp`**
  - Report a disabled root decoder explicitly while walking the decoders of an enabled integration, instead of silently skipping it like any other disabled asset.
  - Add a post-loop guard for the cases the per-decoder check cannot reach. `policy.root_decoder` is a standalone UUID with no structural link to the integrations list, so the root decoder can be absent from the built tree while still being required by it — for example when it belongs only to a **disabled** integration, or to no integration of the policy at all. The guard fires only when some built decoder actually depends on the root decoder as a parent, so policies whose decoders all declare explicit parents (and therefore never reference the root) are left untouched.
  - Include `<algorithm>` for `std::any_of` / `std::find`.

- **`src/engine/source/builder/test/src/unit/policy/factory_test.cpp`** — three unit tests covering the disabled root decoder, the disabled-integration path, and the enabled control case.

- **`docs/ref/modules/engine/README.md`** — the asset `enabled` flag was documented as "Disabled assets are ignored when building the policy operational graph". That is no longer true for the root decoder; the exception is now documented.

- **`CHANGELOG.md`** — added the `#37928` entry under `v5.0.0 → Manager → Fixed`.

### Results and Evidence

<details><summary>Before the fix — both failure modes are opaque</summary>
<p>

```text
# engine-public cm policy-validate -n test --load-in-tester -c "$(cat full-policy-enabled.json)"
# (succeeds, no output)

# engine-public cm policy-validate -n test --load-in-tester -c "$(cat full-policy-disabled-root.json)"
Error validating policy: Failed to create the testing environment: Policy must have at least a decoders

# engine-public cm policy-validate -n test --load-in-tester -c "$(cat full-policy-gap-disabled-integration.json)"
Error validating policy: Failed to create the testing environment: Parent 'decoder/dev-root/0' does not exist, required by [decoder/dev-child/0]
```

</p>
</details>

<details><summary>After the fix — both name the root decoder and state the cause</summary>
<p>

```text
# engine-public cm policy-validate -n test --load-in-tester -c "$(cat full-policy-enabled.json)"
# (succeeds, no output)

# engine-public cm policy-validate -n test --load-in-tester -c "$(cat full-policy-disabled-root.json)"
Error validating policy: Failed to create the testing environment: The root decoder 'decoder/dev-root/0' [id: '550e8400-e29b-41d4-a716-446655440000'] is disabled; enable it before using this policy

# engine-public cm policy-validate -n test --load-in-tester -c "$(cat full-policy-gap-disabled-integration.json)"
Error validating policy: Failed to create the testing environment: The root decoder 'decoder/dev-root/0' [id: '550e8400-e29b-41d4-a716-446655440000'] is not part of the policy's enabled content; it must be enabled and belong to an enabled integration of the policy
```

<!-- TODO: re-capture the third command. The output above was recorded before the post-loop guard was
     narrowed to fire only when a decoder actually depends on the root; the message now reads
     "... is required by the policy decoders but is not part of its enabled content; ...". -->


Temporary namespaces are still cleaned up on failure, and the existing `test` session is left untouched:

```text
# engine-private ns list
- logtest_d8bb02
- cmsync_standard_37f2
```

</p>
</details>

<details><summary>Unit and component test suites — 3,885 tests, 0 failures</summary>
<p>

```text
cmstore_utest     :: [  PASSED  ] 222 tests.
cmstore_ctest     :: [  PASSED  ] 24 tests.
cmcrud_utest      :: [  PASSED  ] 98 tests.
cmcrud_ctest      :: [  PASSED  ] 13 tests.
builder_utest     :: [  PASSED  ] 3120 tests.
builder_ctest     :: [  PASSED  ] 28 tests.
router_utest      :: [  PASSED  ] 272 tests.
router_ctest      :: [  PASSED  ] 25 tests.
api_cmcrud_utest  :: [  PASSED  ] 30 tests.
api_tester_utest  :: [  PASSED  ] 53 tests.
```

</p>
</details>

<details><summary>New unit tests</summary>
<p>

```text
[ RUN      ] BuildAssetsRootDecoder.DisabledRootDecoderIsReportedExplicitly
[       OK ] BuildAssetsRootDecoder.DisabledRootDecoderIsReportedExplicitly (0 ms)
[ RUN      ] BuildAssetsRootDecoder.EnabledRootDecoderAlsoReferencedByDisabledIntegrationStillBuilds
[       OK ] BuildAssetsRootDecoder.EnabledRootDecoderAlsoReferencedByDisabledIntegrationStillBuilds (0 ms)
[ RUN      ] BuildAssetsRootDecoder.RootDecoderReachableOnlyThroughDisabledIntegrationIsReportedExplicitly
[       OK ] BuildAssetsRootDecoder.RootDecoderReachableOnlyThroughDisabledIntegrationIsReportedExplicitly (0 ms)
[----------] 3 tests from BuildAssetsRootDecoder (0 ms total)
[  PASSED  ] 3 tests.
```

</p>
</details>

<details><summary>Compilation — Linux, no warnings</summary>
<p>

```text
$ make builder_ctest builder_utest router_ctest router_utest api_tester_utest \
       api_cmcrud_utest cmcrud_ctest cmcrud_utest cmstore_ctest cmstore_utest -j16
make=0
$ grep -ciE "warning:" build.log
0
```

</p>
</details>

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

Linux compilation evidence is in the collapsible block above. Windows and macOS are not applicable: the change is in `wazuh-engine`, a manager-only artifact.

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

N/A — this is a v5.x engine change; the v4.x decoder/rule test harness does not apply.

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

<!-- TODO: run the utest/ctest suites under ASAN and TSAN and attach the output before merge. The suites above were run in a plain Debug build. -->

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

<!-- TODO: the engine integration suite (test/integration_tests) was not executed; the manual promotion evidence above was produced against a running manager instead. -->

### Artifacts Affected

- `wazuh-engine` (manager only) — the policy builder now raises two additional, more specific errors during policy build. Surfaced to API clients through `POST /content/validate/policy` as HTTP 400, prefixed by `Failed to create the testing environment:`.
- No packaging, default configuration file, or agent-side artifact is affected.

### Configuration Changes

N/A — no new or modified configuration parameters, defaults, or compatibility constraints. Only the text of two runtime error messages changes; no error code or response shape is altered.

### Tests Introduced

Three unit tests in `src/engine/source/builder/test/src/unit/policy/factory_test.cpp`, suite `BuildAssetsRootDecoder`:

| Test | Scope |
|---|---|
| `DisabledRootDecoderIsReportedExplicitly` | Root decoder disabled inside an enabled integration. Asserts the error names the decoder, its UUID and the word "disabled", and no longer contains `Policy must have at least`. |
| `RootDecoderReachableOnlyThroughDisabledIntegrationIsReportedExplicitly` | Root decoder reachable only through a disabled integration, with a second enabled integration contributing a child decoder that inherits it as parent. Asserts the explicit error replaces the opaque `Parent '...' does not exist, required by [...]`. |
| `EnabledRootDecoderAlsoReferencedByDisabledIntegrationStillBuilds` | Control case: an enabled root decoder also listed by a disabled integration still builds, and the disabled integration is skipped exactly once. |

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented — N/A, no configuration changes
- [x] Developer documentation reflects the changes — `docs/ref/modules/engine/README.md`
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ASAN/TSAN runs and the engine integration suite still pending (see TODO markers above)

Additional notes for reviewers:

- The degenerate case where the root decoder is disabled **and** the policy builds no other decoder at all still yields `Policy must have at least a decoders`. That message is accurate there (the policy genuinely has no decoders), so it was left as is.
- Consider a follow-up Behave scenario next to `test/integration_tests/crud_cm/features/crud_cm.feature:142` ("Fail to upsert a policy with an invalid root decoder id") to cover this at the API layer.
- Unrelated pre-existing inaccuracy spotted while tracing the error path: `docs/ref/modules/engine/public-api.yaml` documents the `tester_post_failed` 400 example as `Failed to create tester entry: <details>`, but the handler returns the error verbatim with no such prefix.
