### PR TITLE
Retire the three dead remoted counters and fix the endpoint that serves them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 | [#35043](https://github.com/wazuh/wazuh/issues/35043) | Fixed token validation race condition after revoke. |
 | [#35638](https://github.com/wazuh/wazuh/issues/35638) | Handled the stop signal during vulnerability feed download. |
 | [#37521](https://github.com/wazuh/wazuh/issues/37521) | Fixed `GET /cluster/{node_id}/daemons/stats` always returning error 1014 for `wazuh-manager-analysisd` due to a protocol mismatch between `WazuhSocketJSON` and the engine's HTTP API socket. |
+| [#38280](https://github.com/wazuh/wazuh/issues/38280) | Fixed the `upgrade_ack` counter in `wazuh-manager-remoted` statistics, which reported a constant zero because its increment function was missing. |
 
 ### Agent
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 | [#38091](https://github.com/wazuh/wazuh/issues/38091) | Raised the minimum TLS protocol version accepted by `wazuh-authd` (agent enrollment) to TLS 1.3, removed the `ssl_auto_negotiate` fallback and its `-a` CLI flag, and changed `<auth><ciphers>` to a TLS 1.3 ciphersuite list. |
 | [#32698](https://github.com/wazuh/wazuh/issues/32698) | Adapted API integration tests. |
 | [#36453](https://github.com/wazuh/wazuh/issues/36453) | Increased the minimum API user password length from 8 to 12 characters to align with PCI DSS. |
+| [#38280](https://github.com/wazuh/wazuh/issues/38280) | Renamed the communications metrics data stream to `wazuh-metrics-comms-v4`. It holds the statistics of the legacy communication protocol, which only agents below v5.0.0 use. |
 
 #### Removed
 
@@ -56,6 +57,7 @@
 | [#28425](https://github.com/wazuh/wazuh/issues/28425) | Removed legacy API security configuration endpoints. |
 | [#35908](https://github.com/wazuh/wazuh/issues/35908) | Removed SELinux integration from the manager. |
 | [#38024](https://github.com/wazuh/wazuh/issues/38024) | Removed the `GET /agents/{agent_id}/stats/{component}` API endpoint. Agent statistics are read from the `wazuh-agent-stats` index. |
+| [#38280](https://github.com/wazuh/wazuh/issues/38280) | Removed the `states`, `sent_breakdown.ar` and `sent_breakdown.request` counters from the `wazuh-manager-remoted` statistics served by `GET /cluster/{node_id}/daemons/stats`. None of them has a writer left in 5.0, so all three reported a constant zero. |
 
 #### Fixed
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1502,6 +1502,25 @@ components:
                   type: integer
                   format: int32
                   description: "Bytes sent to agents"
+            control_messages_queue_breakdown:
+              type: object
+              properties:
+                inserted:
+                  type: integer
+                  format: int32
+                  description: "Control messages inserted into the control messages queue"
+                processed:
+                  type: integer
+                  format: int32
+                  description: "Control messages taken from the control messages queue and processed"
+                replaced:
+                  type: integer
+                  format: int32
+                  description: "Control messages that replaced a pending one from the same agent"
+            control_messages_queue_usage:
+              type: integer
+              format: int32
+              description: "Current usage of the control messages queue (count)"
             keys_reload_count:
               type: integer
               format: int32
@@ -1515,7 +1534,7 @@ components:
                     control:
                       type: integer
                       format: int32
-                      description: "Control messages received from agents"
+                      description: "Control messages received from agents, including the ones that fail validation and are therefore absent from control_breakdown"
                     control_breakdown:
                       type: object
                       properties:
@@ -1543,10 +1562,14 @@ components:
                       type: integer
                       format: int32
                       description: "Messages discarded because the received queue was full"
-                    event:
+                    events:
                       type: integer
                       format: int32
                       description: "Event messages (syscheck, syscollector, logcollector, etc.) received from agents"
+                    events_failed:
+                      type: integer
+                      format: int32
+                      description: "Event messages accepted from the agent that could not be delivered to analysisd"
                     ping:
                       type: integer
                       format: int32
@@ -1555,6 +1578,10 @@ components:
                       type: integer
                       format: int32
                       description: "Not recognized messages"
+                    upgrade_ack:
+                      type: integer
+                      format: int32
+                      description: "Upgrade acknowledgments received from agents. The same message is also counted in events, or in events_failed when the enqueue drops it"
                 sent_breakdown:
                   type: object
                   properties:
@@ -1587,11 +1614,11 @@ components:
                     size:
                       type: integer
                       format: int32
-                      description: "Received messages queue size"
+                      description: "Byte capacity of the received messages queue (0 means unlimited)"
                     usage:
                       type: integer
                       format: int32
-                      description: "Current usage of the received queue (count)"
+                      description: "Bytes currently held in the received messages queue"
             tcp_sessions:
               type: integer
               format: int32
@@ -6200,6 +6227,11 @@ paths:
                         bytes:
                           received: 0
                           sent: 0
+                        control_messages_queue_breakdown:
+                          inserted: 0
+                          processed: 0
+                          replaced: 0
+                        control_messages_queue_usage: 0
                         keys_reload_count: 0
                         messages:
                           received_breakdown:
@@ -6211,9 +6243,11 @@ paths:
                               startup: 0
                             dequeued_after: 0
                             discarded: 0
-                            event: 0
+                            events: 0
+                            events_failed: 0
                             ping: 0
                             unknown: 0
+                            upgrade_ack: 0
                           sent_breakdown:
                             ack: 0
                             ar: 0

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1593,10 +1593,6 @@ components:
                       type: integer
                       format: int32
                       description: "Messages discarded because the send queue was full"
-                    request:
-                      type: integer
-                      format: int32
-                      description: "Request messages (for example, WPK chunks) sent to agents"
                     shared:
                       type: integer
                       format: int32
@@ -6247,7 +6243,6 @@ paths:
                           sent_breakdown:
                             ack: 0
                             discarded: 0
-                            request: 0
                             shared: 0
                         queues:
                           received:

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -6246,7 +6246,7 @@ paths:
                             shared: 0
                         queues:
                           received:
-                            size: 131072
+                            size: 67108864
                             usage: 0
                         tcp_sessions: 0
                   total_affected_items: 1

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -1589,10 +1589,6 @@ components:
                       type: integer
                       format: int32
                       description : "ACK messages (response to keepalive, startup and shutdown) sent to agents"
-                    ar:
-                      type: integer
-                      format: int32
-                      description: "Active response messages sent to agents"
                     discarded:
                       type: integer
                       format: int32
@@ -6250,7 +6246,6 @@ paths:
                             upgrade_ack: 0
                           sent_breakdown:
                             ack: 0
-                            ar: 0
                             discarded: 0
                             request: 0
                             shared: 0

--- a/framework/wazuh/core/indexer/metrics_snapshot.py
+++ b/framework/wazuh/core/indexer/metrics_snapshot.py
@@ -418,7 +418,6 @@ class MetricsSnapshotTasks:
         raw_tcp_sessions = m.get("tcp_sessions")
         raw_evt_total = msgs_recv.get("events")
         raw_evt_failed = msgs_recv.get("events_failed")
-        raw_states = msgs_recv.get("states")
         raw_upgrade_ack = msgs_recv.get("upgrade_ack")
         raw_discarded = msgs_recv.get("discarded")
         raw_sent_bytes = bytes_info.get("sent")
@@ -508,7 +507,6 @@ class MetricsSnapshotTasks:
                             else doc.get("ctrl_msg_processed")
                         },
                     },
-                    "states": {"total": raw_states},
                     "upgrades": {"total": raw_upgrade_ack},
                 },
             }

--- a/framework/wazuh/core/indexer/metrics_snapshot.py
+++ b/framework/wazuh/core/indexer/metrics_snapshot.py
@@ -185,7 +185,7 @@ class MetricsSnapshotTasks:
         Returns
         -------
         list of dict
-            Documents ready for bulk indexing into ``wazuh-metrics-comms``.
+            Documents ready for bulk indexing into ``wazuh-metrics-comms-v4``.
             Each document contains the remoted stats fields plus the metadata
             fields ``@timestamp``, ``wazuh.cluster.node``, and
             ``wazuh.cluster.name``.
@@ -399,7 +399,7 @@ class MetricsSnapshotTasks:
         Returns
         -------
         dict
-            Normalized document ready for indexing into ``wazuh-metrics-comms``.
+            Normalized document ready for indexing into ``wazuh-metrics-comms-v4``.
         """
         # v5.0 nests stats under "metrics"; fall back to flat keys for compat
         m = doc.get("metrics", {})
@@ -657,7 +657,7 @@ class MetricsSnapshotTasks:
             )
         if comms_schema:
             comms_docs = self._validate_documents(
-                comms_docs, comms_schema, "wazuh-metrics-comms"
+                comms_docs, comms_schema, "wazuh-metrics-comms-v4"
             )
         if normalization_schema:
             normalization_docs = self._validate_documents(
@@ -670,7 +670,7 @@ class MetricsSnapshotTasks:
                     "wazuh-metrics-agents", agent_docs, self.bulk_size
                 ),
                 indexer.metrics.bulk_index(
-                    "wazuh-metrics-comms", comms_docs, self.bulk_size
+                    "wazuh-metrics-comms-v4", comms_docs, self.bulk_size
                 ),
                 indexer.metrics.bulk_index(
                     "wazuh-metrics-normalization", normalization_docs, self.bulk_size

--- a/framework/wazuh/core/indexer/tests/test_metrics_snapshot.py
+++ b/framework/wazuh/core/indexer/tests/test_metrics_snapshot.py
@@ -1253,7 +1253,7 @@ class TestCollectAndIndex:
 
     @pytest.mark.asyncio
     async def test_bulk_index_called_for_comms_index(self):
-        """bulk_index is called with 'wazuh-metrics-comms' and the normalized comms docs."""
+        """bulk_index is called with 'wazuh-metrics-comms-v4' and the normalized comms docs."""
         comms_docs = [{"events": {"total": 1000}}]
 
         mock_indexer = AsyncMock()
@@ -1264,7 +1264,7 @@ class TestCollectAndIndex:
             await tasks._collect_and_index()
 
         mock_indexer.metrics.bulk_index.assert_any_await(
-            "wazuh-metrics-comms", comms_docs, tasks.bulk_size
+            "wazuh-metrics-comms-v4", comms_docs, tasks.bulk_size
         )
 
     @pytest.mark.asyncio
@@ -1740,7 +1740,7 @@ class TestCollectAndIndexWithValidation:
                     await tasks._collect_and_index()
 
         mock_validate.assert_called_once_with(
-            comms_docs, fake_schema, "wazuh-metrics-comms"
+            comms_docs, fake_schema, "wazuh-metrics-comms-v4"
         )
 
     @pytest.mark.asyncio

--- a/framework/wazuh/core/indexer/tests/test_metrics_snapshot.py
+++ b/framework/wazuh/core/indexer/tests/test_metrics_snapshot.py
@@ -255,7 +255,6 @@ EXPECTED_COMMS_FIELDS = {
 # exist in the legacy flat format).
 EXPECTED_COMMS_FIELDS_V5_ONLY = {
     "events.failed.total",
-    "messages.states.total",
     "messages.upgrades.total",
 }
 
@@ -1931,7 +1930,6 @@ REMOTED_STATS_V5_ALL_ZEROS = {
             "received_breakdown": {
                 "events": 0,
                 "events_failed": 0,
-                "states": 0,
                 "upgrade_ack": 0,
                 "discarded": 0,
                 "dequeued_after": 0,
@@ -1957,7 +1955,6 @@ REMOTED_STATS_V5_NONZERO = {
             "received_breakdown": {
                 "events": 1000,
                 "events_failed": 4,
-                "states": 333,
                 "upgrade_ack": 2,
                 "discarded": 3,
                 "dequeued_after": 1,
@@ -2067,7 +2064,7 @@ class TestNormalizeCommsDocZeroPreservation:
         assert doc["messages"]["control"]["replaced"]["total"] == 8
         assert doc["messages"]["control"]["processed"]["total"] == 202
         assert doc["messages"]["control"]["dropped_on_close"]["total"] == 1
-        assert doc["messages"]["states"]["total"] == 333
+        assert "states" not in doc["messages"]
         assert doc["messages"]["upgrades"]["total"] == 2
 
     @pytest.mark.asyncio

--- a/src/engine/tools/devContainer/scripts/monitor.py
+++ b/src/engine/tools/devContainer/scripts/monitor.py
@@ -180,7 +180,6 @@ REMOTED_HEADER = [
     "messages_received_breakdown_events",
     "messages_received_breakdown_events_failed",
     "messages_received_breakdown_ping",
-    "messages_received_breakdown_states",
     "messages_received_breakdown_unknown",
     "messages_received_breakdown_control_breakdown_keepalive",
     "messages_received_breakdown_control_breakdown_request",
@@ -707,7 +706,6 @@ def _flatten_remoted_stats(raw: dict[str, object], timestamp: str, elapsed_s: fl
             row["messages_received_breakdown_events"] = _as_int(recv_breakdown.get("events"))
             row["messages_received_breakdown_events_failed"] = _as_int(recv_breakdown.get("events_failed"))
             row["messages_received_breakdown_ping"] = _as_int(recv_breakdown.get("ping"))
-            row["messages_received_breakdown_states"] = _as_int(recv_breakdown.get("states"))
             row["messages_received_breakdown_unknown"] = _as_int(recv_breakdown.get("unknown"))
 
             ctrl_breakdown = recv_breakdown.get("control_breakdown")
@@ -765,11 +763,10 @@ def remoted_api_monitor_loop(csv_path: str, interval: float, socket_path: str,
                 raw = _query_remoted_stats(socket_path)
                 row = _flatten_remoted_stats(raw, ts_now, elapsed_s)
                 logger.info(
-                    "[remoted-api] usage=%.3f recv_discarded=%d recv_events=%d recv_states=%d sent_discarded=%d tcp_sessions=%d",
+                    "[remoted-api] usage=%.3f recv_discarded=%d recv_events=%d sent_discarded=%d tcp_sessions=%d",
                     _as_float(row.get("queues_received_usage")),
                     _as_int(row.get("messages_received_breakdown_discarded")),
                     _as_int(row.get("messages_received_breakdown_events")),
-                    _as_int(row.get("messages_received_breakdown_states")),
                     _as_int(row.get("messages_sent_breakdown_discarded")),
                     _as_int(row.get("tcp_sessions")),
                 )

--- a/src/engine/tools/devContainer/scripts/monitor.py
+++ b/src/engine/tools/devContainer/scripts/monitor.py
@@ -187,7 +187,6 @@ REMOTED_HEADER = [
     "messages_received_breakdown_control_breakdown_startup",
     "messages_sent_breakdown_ack",
     "messages_sent_breakdown_discarded",
-    "messages_sent_breakdown_request",
     "messages_sent_breakdown_shared",
     "queues_received_size",
     "queues_received_usage",
@@ -718,7 +717,6 @@ def _flatten_remoted_stats(raw: dict[str, object], timestamp: str, elapsed_s: fl
         if isinstance(sent_breakdown, dict):
             row["messages_sent_breakdown_ack"] = _as_int(sent_breakdown.get("ack"))
             row["messages_sent_breakdown_discarded"] = _as_int(sent_breakdown.get("discarded"))
-            row["messages_sent_breakdown_request"] = _as_int(sent_breakdown.get("request"))
             row["messages_sent_breakdown_shared"] = _as_int(sent_breakdown.get("shared"))
 
     queues = metrics.get("queues")

--- a/src/engine/tools/devContainer/scripts/monitor.py
+++ b/src/engine/tools/devContainer/scripts/monitor.py
@@ -186,7 +186,6 @@ REMOTED_HEADER = [
     "messages_received_breakdown_control_breakdown_shutdown",
     "messages_received_breakdown_control_breakdown_startup",
     "messages_sent_breakdown_ack",
-    "messages_sent_breakdown_ar",
     "messages_sent_breakdown_discarded",
     "messages_sent_breakdown_request",
     "messages_sent_breakdown_shared",
@@ -718,7 +717,6 @@ def _flatten_remoted_stats(raw: dict[str, object], timestamp: str, elapsed_s: fl
         sent_breakdown = messages.get("sent_breakdown")
         if isinstance(sent_breakdown, dict):
             row["messages_sent_breakdown_ack"] = _as_int(sent_breakdown.get("ack"))
-            row["messages_sent_breakdown_ar"] = _as_int(sent_breakdown.get("ar"))
             row["messages_sent_breakdown_discarded"] = _as_int(sent_breakdown.get("discarded"))
             row["messages_sent_breakdown_request"] = _as_int(sent_breakdown.get("request"))
             row["messages_sent_breakdown_shared"] = _as_int(sent_breakdown.get("shared"))

--- a/src/engine/tools/devContainer/scripts/monitor_graphics_generator.py
+++ b/src/engine/tools/devContainer/scripts/monitor_graphics_generator.py
@@ -417,11 +417,6 @@ REMOTED_METRICS = [
         "Count",
     ),
     (
-        "messages_received_breakdown_states",
-        "Remoted Messages Received States",
-        "Count",
-    ),
-    (
         "messages_sent_breakdown_discarded",
         "Remoted Messages Sent Discarded",
         "Count",

--- a/src/remoted/src/ar-forward.c
+++ b/src/remoted/src/ar-forward.c
@@ -13,7 +13,6 @@
 #include "defs.h"
 #include "shared.h"
 #include "remoted.h"
-#include "state.h"
 #include "os_net.h"
 
 
@@ -180,9 +179,7 @@ void *AR_Forward(__attribute__((unused)) void *arg)
                     if (keys.keyentries[i]->rcvd >= (time(0) - logr.global.agents_disconnection_time)) {
                         strncpy(agent_id, keys.keyentries[i]->id, KEYSIZE);
                         key_unlock();
-                        if (send_msg(agent_id, msg_to_send, -1) >= 0) {
-                            rem_inc_send_ar();
-                        }
+                        send_msg(agent_id, msg_to_send, -1);
                         key_lock_read();
                     }
                 }
@@ -192,14 +189,10 @@ void *AR_Forward(__attribute__((unused)) void *arg)
 
             /* Send to the remote agent that generated the event or to a pre-defined agent */
             else if (ar_location & (REMOTE_AGENT | SPECIFIC_AGENT)) {
-                if (send_msg(ar_agent_id, msg_to_send, -1) >= 0) {
-                    rem_inc_send_ar();
-                }
+                send_msg(ar_agent_id, msg_to_send, -1);
             }
             else if (ar_location & SPECIFIC_AGENT_SIZED) {
-                if (send_msg(ar_agent_id, msg_to_send, payload_size + header_size) >= 0) {
-                    rem_inc_send_ar();
-                }
+                send_msg(ar_agent_id, msg_to_send, payload_size + header_size);
             }
         }
     }

--- a/src/remoted/src/request.c
+++ b/src/remoted/src/request.c
@@ -13,7 +13,6 @@
 #include "os_net.h"
 #include <request_op.h>
 #include "remoted.h"
-#include "state.h"
 #include "wmodules.h"
 
 #define COUNTER_LENGTH 64
@@ -148,8 +147,6 @@ void * req_dispatch(req_node_t * node) {
             merror("Cannot send request to agent '%s'", agentid);
             OS_SendSecureTCP(node->sock, strlen(WR_SEND_ERROR), WR_SEND_ERROR);
             goto cleanup;
-        } else {
-            rem_inc_send_request();
         }
 
         // Wait for ACK or response, only in UDP mode
@@ -202,9 +199,7 @@ void * req_dispatch(req_node_t * node) {
         // Example: #!-req 16 ack
         mdebug2("Sending ack (%s).", node->counter);
         snprintf(response, REQ_RESPONSE_LENGTH, CONTROL_HEADER HC_REQUEST "%s ack", node->counter);
-        if (send_msg(agentid, response, -1) >= 0) {
-            rem_inc_send_request();
-        }
+        send_msg(agentid, response, -1);
     }
 
     // Send response to local peer

--- a/src/remoted/src/secure.c
+++ b/src/remoted/src/secure.c
@@ -1284,8 +1284,11 @@ STATIC bool discard_legacy_agent_message(const char* msg, const char* agent_id) 
         // Parse just enough of the ack to confirm it's a valid upgrade_update_status message and
         // reply with clear_upgrade_result, which is what stops the agent's own retry loop (see
         // legacy_task_delivery.c). NOT discarded: the ack still falls through to the normal
-        // analysisd/Engine event path (batch_queue_enqueue_ex) like any other agent message.
-        legacy_task_process_upgrade_ack(agent_id, msg + UPGRADE_ACK_HEADER_SIZE);
+        // analysisd/Engine event path (batch_queue_enqueue_ex) like any other agent message, so it
+        // is also counted as a received event, or as a failed one when the enqueue drops it.
+        if (legacy_task_process_upgrade_ack(agent_id, msg + UPGRADE_ACK_HEADER_SIZE)) {
+            rem_inc_recv_upgrade_ack();
+        }
         mdebug2("Upgrade acknowledgment from agent '%s' routed to the normal event path", agent_id);
         return false;
     }

--- a/src/remoted/src/state.c
+++ b/src/remoted/src/state.c
@@ -207,7 +207,6 @@ cJSON* rem_create_state_json() {
     cJSON_AddNumberToObject(_received_breakdown, "dequeued_after", state_cpy.recv_breakdown.dequeued_count);
     cJSON_AddNumberToObject(_received_breakdown, "discarded", state_cpy.recv_breakdown.discarded_count);
     cJSON_AddNumberToObject(_received_breakdown, "events", state_cpy.recv_breakdown.events_count);
-    cJSON_AddNumberToObject(_received_breakdown, "states", state_cpy.recv_breakdown.states_count);
     cJSON_AddNumberToObject(_received_breakdown, "ping", state_cpy.recv_breakdown.ping_count);
     cJSON_AddNumberToObject(_received_breakdown, "unknown", state_cpy.recv_breakdown.unknown_count);
     cJSON_AddNumberToObject(_received_breakdown, "upgrade_ack", state_cpy.recv_breakdown.upgrade_ack_count);

--- a/src/remoted/src/state.c
+++ b/src/remoted/src/state.c
@@ -47,6 +47,12 @@ void rem_inc_recv_ctrl() {
     w_mutex_unlock(&state_mutex);
 }
 
+void rem_inc_recv_upgrade_ack() {
+    w_mutex_lock(&state_mutex);
+    remoted_state.recv_breakdown.upgrade_ack_count++;
+    w_mutex_unlock(&state_mutex);
+}
+
 void rem_inc_recv_events_failed() {
     w_mutex_lock(&state_mutex);
     remoted_state.recv_breakdown.events_failed_count++;

--- a/src/remoted/src/state.c
+++ b/src/remoted/src/state.c
@@ -125,12 +125,6 @@ void rem_inc_send_shared() {
     w_mutex_unlock(&state_mutex);
 }
 
-void rem_inc_send_ar() {
-    w_mutex_lock(&state_mutex);
-    remoted_state.sent_breakdown.ar_count++;
-    w_mutex_unlock(&state_mutex);
-}
-
 void rem_inc_send_request() {
     w_mutex_lock(&state_mutex);
     remoted_state.sent_breakdown.request_count++;
@@ -221,7 +215,6 @@ cJSON* rem_create_state_json() {
     cJSON_AddItemToObject(_messages, "sent_breakdown", _sent_breakdown);
 
     cJSON_AddNumberToObject(_sent_breakdown, "ack", state_cpy.sent_breakdown.ack_count);
-    cJSON_AddNumberToObject(_sent_breakdown, "ar", state_cpy.sent_breakdown.ar_count);
     cJSON_AddNumberToObject(_sent_breakdown, "discarded", state_cpy.sent_breakdown.discarded_count);
     cJSON_AddNumberToObject(_sent_breakdown, "request", state_cpy.sent_breakdown.request_count);
     cJSON_AddNumberToObject(_sent_breakdown, "shared", state_cpy.sent_breakdown.shared_count);

--- a/src/remoted/src/state.c
+++ b/src/remoted/src/state.c
@@ -125,12 +125,6 @@ void rem_inc_send_shared() {
     w_mutex_unlock(&state_mutex);
 }
 
-void rem_inc_send_request() {
-    w_mutex_lock(&state_mutex);
-    remoted_state.sent_breakdown.request_count++;
-    w_mutex_unlock(&state_mutex);
-}
-
 void rem_inc_send_discarded() {
     w_mutex_lock(&state_mutex);
     remoted_state.sent_breakdown.discarded_count++;
@@ -216,7 +210,6 @@ cJSON* rem_create_state_json() {
 
     cJSON_AddNumberToObject(_sent_breakdown, "ack", state_cpy.sent_breakdown.ack_count);
     cJSON_AddNumberToObject(_sent_breakdown, "discarded", state_cpy.sent_breakdown.discarded_count);
-    cJSON_AddNumberToObject(_sent_breakdown, "request", state_cpy.sent_breakdown.request_count);
     cJSON_AddNumberToObject(_sent_breakdown, "shared", state_cpy.sent_breakdown.shared_count);
 
     cJSON *_queues = cJSON_CreateObject();

--- a/src/remoted/src/state.h
+++ b/src/remoted/src/state.h
@@ -99,6 +99,15 @@ void rem_inc_recv_events();
 void rem_inc_recv_ctrl();
 
 /**
+ * @brief Increment received upgrade-ack messages counter
+ *
+ * Only a well-formed upgrade_update_status counts. The same message is also
+ * counted as a received event, because the ack falls through to the ordinary
+ * event path once it has been processed.
+ */
+void rem_inc_recv_upgrade_ack();
+
+/**
  * @brief Increment failed-event messages counter
  *
  * Counts events that were accepted from the agent but could not be

--- a/src/remoted/src/state.h
+++ b/src/remoted/src/state.h
@@ -28,7 +28,6 @@ typedef struct _recv_msgs_t
 {
     uint64_t events_count;
     uint64_t ctrl_count;
-    uint64_t states_count;
     uint32_t upgrade_ack_count;
     uint32_t ping_count;
     uint32_t unknown_count;

--- a/src/remoted/src/state.h
+++ b/src/remoted/src/state.h
@@ -48,7 +48,6 @@ typedef struct _sent_msgs_t
 {
     uint64_t ack_count;
     uint64_t shared_count;
-    uint32_t request_count;
     uint32_t discarded_count;
 } sent_msgs_t;
 
@@ -171,11 +170,6 @@ void rem_inc_send_ack();
  * @brief Increment sent shared file messages counter
  */
 void rem_inc_send_shared();
-
-/**
- * @brief Increment sent request messages counter
- */
-void rem_inc_send_request();
 
 /**
  * @brief Increment sent discarded messages counter

--- a/src/remoted/src/state.h
+++ b/src/remoted/src/state.h
@@ -48,7 +48,6 @@ typedef struct _sent_msgs_t
 {
     uint64_t ack_count;
     uint64_t shared_count;
-    uint32_t ar_count;
     uint32_t request_count;
     uint32_t discarded_count;
 } sent_msgs_t;
@@ -172,11 +171,6 @@ void rem_inc_send_ack();
  * @brief Increment sent shared file messages counter
  */
 void rem_inc_send_shared();
-
-/**
- * @brief Increment sent AR messages counter
- */
-void rem_inc_send_ar();
 
 /**
  * @brief Increment sent request messages counter

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -60,6 +60,7 @@ list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,accep
                             -Wl,--wrap,w_mutex_lock -Wl,--wrap,w_mutex_unlock -Wl,--wrap,getDefine_Int -Wl,--wrap,getDefine_Int_default \
                             -Wl,--wrap,wnotify_add -Wl,--wrap,SendMSG -Wl,--wrap,rem_inc_recv_events \
                             -Wl,--wrap,rem_inc_recv_discarded -Wl,--wrap,rem_inc_recv_events_failed \
+                            -Wl,--wrap,rem_inc_recv_upgrade_ack \
                             -Wl,--wrap,OS_DupKeyEntry -Wl,--wrap,OS_FreeKey ${DEBUG_OP_WRAPPERS} \
                             -Wl,--wrap,remoted_module_start -Wl,--wrap,remoted_module_stop \
                             -Wl,--wrap,w_query_agentd -Wl,--wrap,legacy_task_process_upgrade_ack ${HASH_OP_WRAPPERS}")

--- a/src/unit_tests/remoted/test_remote-state.c
+++ b/src/unit_tests/remoted/test_remote-state.c
@@ -46,7 +46,6 @@ static int test_setup(void ** state) {
     remoted_state.recv_breakdown.ctrl_breakdown.request_count = 2;
     remoted_state.sent_breakdown.ack_count = 1114;
     remoted_state.sent_breakdown.shared_count = 2540;
-    remoted_state.sent_breakdown.request_count = 9;
     remoted_state.sent_breakdown.discarded_count = 85;
 
     return 0;
@@ -119,11 +118,10 @@ void test_rem_create_state_json(void ** state) {
     assert_int_equal(cJSON_GetObjectItem(sent, "ack")->valueint, 1114);
     assert_non_null(cJSON_GetObjectItem(sent, "shared"));
     assert_int_equal(cJSON_GetObjectItem(sent, "shared")->valueint, 2540);
-    assert_non_null(cJSON_GetObjectItem(sent, "request"));
-    assert_int_equal(cJSON_GetObjectItem(sent, "request")->valueint, 9);
     assert_non_null(cJSON_GetObjectItem(sent, "discarded"));
     assert_int_equal(cJSON_GetObjectItem(sent, "discarded")->valueint, 85);
     assert_null(cJSON_GetObjectItem(sent, "ar"));
+    assert_null(cJSON_GetObjectItem(sent, "request"));
 
     assert_non_null(cJSON_GetObjectItem(metrics, "tcp_sessions"));
     assert_int_equal(cJSON_GetObjectItem(metrics, "tcp_sessions")->valueint, 5);

--- a/src/unit_tests/remoted/test_remote-state.c
+++ b/src/unit_tests/remoted/test_remote-state.c
@@ -34,7 +34,6 @@ static int test_setup(void ** state) {
     remoted_state.keys_reload_count = 15;
     remoted_state.recv_breakdown.events_count = 1234;
     remoted_state.recv_breakdown.ctrl_count = 2345;
-    remoted_state.recv_breakdown.states_count = 333;
     remoted_state.recv_breakdown.upgrade_ack_count = 11;
     remoted_state.recv_breakdown.ping_count = 18;
     remoted_state.recv_breakdown.unknown_count = 8;
@@ -88,8 +87,7 @@ void test_rem_create_state_json(void ** state) {
     assert_int_equal(cJSON_GetObjectItem(recv, "events")->valueint, 1234);
     assert_non_null(cJSON_GetObjectItem(recv, "control"));
     assert_int_equal(cJSON_GetObjectItem(recv, "control")->valueint, 2345);
-    assert_non_null(cJSON_GetObjectItem(recv, "states"));
-    assert_int_equal(cJSON_GetObjectItem(recv, "states")->valueint, 333);
+    assert_null(cJSON_GetObjectItem(recv, "states"));
     assert_non_null(cJSON_GetObjectItem(recv, "upgrade_ack"));
     assert_int_equal(cJSON_GetObjectItem(recv, "upgrade_ack")->valueint, 11);
     assert_non_null(cJSON_GetObjectItem(recv, "ping"));

--- a/src/unit_tests/remoted/test_remote-state.c
+++ b/src/unit_tests/remoted/test_remote-state.c
@@ -46,7 +46,6 @@ static int test_setup(void ** state) {
     remoted_state.recv_breakdown.ctrl_breakdown.request_count = 2;
     remoted_state.sent_breakdown.ack_count = 1114;
     remoted_state.sent_breakdown.shared_count = 2540;
-    remoted_state.sent_breakdown.ar_count = 18;
     remoted_state.sent_breakdown.request_count = 9;
     remoted_state.sent_breakdown.discarded_count = 85;
 
@@ -120,12 +119,11 @@ void test_rem_create_state_json(void ** state) {
     assert_int_equal(cJSON_GetObjectItem(sent, "ack")->valueint, 1114);
     assert_non_null(cJSON_GetObjectItem(sent, "shared"));
     assert_int_equal(cJSON_GetObjectItem(sent, "shared")->valueint, 2540);
-    assert_non_null(cJSON_GetObjectItem(sent, "ar"));
-    assert_int_equal(cJSON_GetObjectItem(sent, "ar")->valueint, 18);
     assert_non_null(cJSON_GetObjectItem(sent, "request"));
     assert_int_equal(cJSON_GetObjectItem(sent, "request")->valueint, 9);
     assert_non_null(cJSON_GetObjectItem(sent, "discarded"));
     assert_int_equal(cJSON_GetObjectItem(sent, "discarded")->valueint, 85);
+    assert_null(cJSON_GetObjectItem(sent, "ar"));
 
     assert_non_null(cJSON_GetObjectItem(metrics, "tcp_sessions"));
     assert_int_equal(cJSON_GetObjectItem(metrics, "tcp_sessions")->valueint, 5);

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -2242,6 +2242,11 @@ bool __wrap_legacy_task_process_upgrade_ack(const char *agent_id, const char *ac
 /* The agent's upgrade ack must now fall through to the normal event path (like any other
  * agent message) instead of being discarded. Covers all three known ack shapes -- the interception
  * in discard_legacy_agent_message() is header-prefix-only, so all three must behave identically. */
+/* When batch_queue_enqueue_ex is mocked as successful the production code
+ * relinquishes ownership of the evt_item; capture it here so the test can
+ * dispose it after HandleSecureMessage returns. */
+static evt_item_t *g_captured_evt_item;
+
 static int check_evt_item_matches_ack(const LargestIntegralType value,
                                       const LargestIntegralType check_value_data) {
     evt_item_t *e = (evt_item_t *)(uintptr_t)value;
@@ -2250,10 +2255,11 @@ static int check_evt_item_matches_ack(const LargestIntegralType value,
     assert_non_null(e->raw);
     assert_int_equal(e->len, strlen(expected));
     assert_memory_equal(e->raw, expected, e->len);
+    g_captured_evt_item = e;
     return 1;
 }
 
-static void run_upgrade_ack_forwarded_test(const char *ack_json) {
+static void run_upgrade_ack_forwarded_test(const char *ack_json, int enqueue_rc) {
     char buffer[OS_MAXSTR + 1];
     snprintf(buffer, sizeof(buffer), "u:upgrade_module:%s", ack_json);
     message_t message = {.buffer = buffer, .size = strlen(buffer), .sock = 1};
@@ -2307,21 +2313,34 @@ static void run_upgrade_ack_forwarded_test(const char *ack_json) {
     expect_string(__wrap_legacy_task_process_upgrade_ack, ack_json, ack_json);
     will_return(__wrap_legacy_task_process_upgrade_ack, true);
 
+    expect_function_call(__wrap_rem_inc_recv_upgrade_ack);
+
     expect_string(__wrap__mdebug2, formatted_msg,
                   "Upgrade acknowledgment from agent '001' routed to the normal event path");
 
     // discard_legacy_agent_message() returns false for this header -> falls through to the
     // ordinary batch_queue_enqueue_ex path, with the exact raw message unmodified.
+    g_captured_evt_item = NULL;
     expect_value(__wrap_batch_queue_enqueue_ex, sched, events_queue);
     expect_string(__wrap_batch_queue_enqueue_ex, agent_key, "001");
     expect_check(__wrap_batch_queue_enqueue_ex, data, check_evt_item_matches_ack,
                  (LargestIntegralType)(uintptr_t)buffer);
-    will_return(__wrap_batch_queue_enqueue_ex, -1);
-    expect_value(__wrap_time, time, NULL);
-    will_return(__wrap_time, 0);
-    expect_function_call(__wrap_rem_inc_recv_events_failed);
+    will_return(__wrap_batch_queue_enqueue_ex, enqueue_rc);
+    if (enqueue_rc < 0) {
+        expect_value(__wrap_time, time, NULL);
+        will_return(__wrap_time, 0);
+        expect_function_call(__wrap_rem_inc_recv_events_failed);
+    } else {
+        expect_function_call(__wrap_rem_inc_recv_events);
+    }
 
     HandleSecureMessage(&message, control_msg_queue, events_queue);
+
+    /* The mocked queue did not actually take ownership; release the item. */
+    if (enqueue_rc >= 0 && g_captured_evt_item) {
+        dispose_evt_item(g_captured_evt_item);
+        g_captured_evt_item = NULL;
+    }
 
     os_free(key->id);
     os_free(key->name);
@@ -2337,7 +2356,7 @@ void test_HandleSecureMessage_upgrade_ack_success_forwarded(void** state)
     (void) state;
     run_upgrade_ack_forwarded_test(
         "{\"command\":\"upgrade_update_status\",\"parameters\":{\"error\":0,"
-        "\"message\":\"Upgrade was successful\",\"status\":\"Done\"}}");
+        "\"message\":\"Upgrade was successful\",\"status\":\"Done\"}}", -1);
 }
 
 void test_HandleSecureMessage_upgrade_ack_missing_dependency_forwarded(void** state)
@@ -2345,7 +2364,7 @@ void test_HandleSecureMessage_upgrade_ack_missing_dependency_forwarded(void** st
     (void) state;
     run_upgrade_ack_forwarded_test(
         "{\"command\":\"upgrade_update_status\",\"parameters\":{\"error\":1,"
-        "\"message\":\"Upgrade failed due missing dependency\",\"status\":\"Failed\"}}");
+        "\"message\":\"Upgrade failed due missing dependency\",\"status\":\"Failed\"}}", -1);
 }
 
 void test_HandleSecureMessage_upgrade_ack_failed_forwarded(void** state)
@@ -2353,7 +2372,17 @@ void test_HandleSecureMessage_upgrade_ack_failed_forwarded(void** state)
     (void) state;
     run_upgrade_ack_forwarded_test(
         "{\"command\":\"upgrade_update_status\",\"parameters\":{\"error\":2,"
-        "\"message\":\"Upgrade failed\",\"status\":\"Failed\"}}");
+        "\"message\":\"Upgrade failed\",\"status\":\"Failed\"}}", -1);
+}
+
+/* The ack is counted twice on purpose: once as an upgrade ack, and once as an event, because after
+ * being processed it travels the ordinary event path. This is the enqueue-succeeds side of it. */
+void test_HandleSecureMessage_upgrade_ack_enqueued_counted_as_event(void** state)
+{
+    (void) state;
+    run_upgrade_ack_forwarded_test(
+        "{\"command\":\"upgrade_update_status\",\"parameters\":{\"error\":0,"
+        "\"message\":\"Upgrade was successful\",\"status\":\"Done\"}}", 0);
 }
 
 /* Companion test: discard_legacy_agent_message() itself must return false for this header (callers
@@ -2369,6 +2398,25 @@ void test_discard_legacy_agent_message_upgrade_ack_returns_false(void** state)
                   "{\"command\":\"upgrade_update_status\",\"parameters\":"
                   "{\"error\":0,\"message\":\"Upgrade was successful\",\"status\":\"Done\"}}");
     will_return(__wrap_legacy_task_process_upgrade_ack, true);
+
+    expect_function_call(__wrap_rem_inc_recv_upgrade_ack);
+
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "Upgrade acknowledgment from agent '001' routed to the normal event path");
+
+    assert_false(discard_legacy_agent_message(msg, "001"));
+}
+
+/* A message carrying the ack header but not a well-formed upgrade_update_status must not be
+ * counted. No expectation is set on the counter wrapper, so cmocka fails if it fires. */
+void test_discard_legacy_agent_message_upgrade_ack_malformed_not_counted(void** state)
+{
+    (void) state;
+    char msg[] = "u:upgrade_module:{\"command\":\"not_an_upgrade_ack\"}";
+
+    expect_string(__wrap_legacy_task_process_upgrade_ack, agent_id, "001");
+    expect_string(__wrap_legacy_task_process_upgrade_ack, ack_json, "{\"command\":\"not_an_upgrade_ack\"}");
+    will_return(__wrap_legacy_task_process_upgrade_ack, false);
 
     expect_string(__wrap__mdebug2, formatted_msg,
                   "Upgrade acknowledgment from agent '001' routed to the normal event path");
@@ -2527,11 +2575,6 @@ static int check_evt_item_sentinel(const LargestIntegralType value,
     assert_int_equal('\0', e->raw[e->len]);
     return 1;
 }
-
-/* When batch_queue_enqueue_ex is mocked as successful the production code
- * relinquishes ownership of the evt_item; capture it here so the test can
- * dispose it after HandleSecureMessage returns. */
-static evt_item_t *g_captured_evt_item;
 
 static int check_evt_item_capture(const LargestIntegralType value,
                                   const LargestIntegralType check_value_data) {
@@ -3502,7 +3545,9 @@ int main(void)
         cmocka_unit_test(test_HandleSecureMessage_upgrade_ack_success_forwarded),
         cmocka_unit_test(test_HandleSecureMessage_upgrade_ack_missing_dependency_forwarded),
         cmocka_unit_test(test_HandleSecureMessage_upgrade_ack_failed_forwarded),
+        cmocka_unit_test(test_HandleSecureMessage_upgrade_ack_enqueued_counted_as_event),
         cmocka_unit_test(test_discard_legacy_agent_message_upgrade_ack_returns_false),
+        cmocka_unit_test(test_discard_legacy_agent_message_upgrade_ack_malformed_not_counted),
         cmocka_unit_test(test_HandleSecureMessage_event_enqueue_failed),
         cmocka_unit_test(test_HandleSecureMessage_discard_dbsync_message),
         cmocka_unit_test(test_HandleSecureMessage_event_without_trailing_null),

--- a/src/unit_tests/wrappers/wazuh/remoted/state_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/remoted/state_wrappers.c
@@ -28,6 +28,10 @@ void __wrap_rem_inc_recv_events() {
     function_called();
 }
 
+void __wrap_rem_inc_recv_upgrade_ack() {
+    function_called();
+}
+
 void __wrap_rem_add_recv(unsigned long bytes) {
     check_expected(bytes);
 }

--- a/src/unit_tests/wrappers/wazuh/remoted/state_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/remoted/state_wrappers.h
@@ -24,6 +24,8 @@ void __wrap_rem_inc_recv_events();
 
 void __wrap_rem_inc_recv_ctrl();
 
+void __wrap_rem_inc_recv_upgrade_ack();
+
 void __wrap_rem_inc_recv_discarded();
 
 void __wrap_rem_inc_recv_events_failed();


### PR DESCRIPTION
## Description

Closes #38280

remoted's statistics are written only from the legacy C tree; the HTTPS module for 5.x agents increments none of them. Three counters have no reachable writer:

- `states`: legacy stateful protocol discarded since 5.x.
- `sent_breakdown.ar`: nothing writes to `ARQUEUE`; new active response excludes `v[0-4]` agents. (Removing `AR_Forward` itself is #38279.)
- `sent_breakdown.request`: its only writer (`req_dispatch()`) has no callers left.

`upgrade_ack` is fixed, not removed: the ack arrives but nothing counted it. Restored `rem_inc_recv_upgrade_ack()`.

Also fixed on the same surface: the spec documented `event` instead of `events`, was missing `events_failed` and the control-queue fields, and described the received-queue gauges in the wrong unit.

## Proposed Changes

- Remove `states`, `sent_breakdown.ar` and `sent_breakdown.request` from the counter struct, increment functions, JSON builder, and their call sites in `ar-forward.c`/`request.c`.
- Restore `rem_inc_recv_upgrade_ack()` in `secure.c`, gated on a well-formed ack.
- Drop the three counters from the devContainer monitor scripts.
- Spec: drop the two sent fields, document `events`/`events_failed`/control-queue fields, fix the gauge units.
- Rename the comms data stream to `wazuh-metrics-comms-v4` (5.x gets its own index later, #38290).

### Results and Evidence

Local deploy: this branch's manager (commit `f8b910a`) + indexer with `wazuh-indexer-plugins`#1459 merged (commit `bb3103f`).

<details><summary>1. Manager stats: counters retired, upgrade_ack works</summary>

```console
$ TOKEN=$(curl -sk -u wazuh:wazuh -X POST https://127.0.0.1:55000/security/user/authenticate | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['token'])")
$ curl -sk -H "Authorization: Bearer $TOKEN" "https://127.0.0.1:55000/cluster/node01/daemons/stats?daemons_list=wazuh-manager-remoted" | python3 -m json.tool
{
    "data": {
        "affected_items": [
            {
                "uptime": "2026-08-18T08:37:46+00:00",
                "timestamp": "2026-08-18T08:51:02+00:00",
                "name": "wazuh-manager-remoted",
                "metrics": {
                    "bytes": {
                        "received": 106248,
                        "sent": 3834
                    },
                    "keys_reload_count": 0,
                    "messages": {
                        "received_breakdown": {
                            "control": 40,
                            "control_breakdown": {
                                "keepalive": 37,
                                "request": 0,
                                "shutdown": 1,
                                "startup": 2
                            },
                            "events_failed": 0,
                            "dequeued_after": 0,
                            "discarded": 0,
                            "events": 503,
                            "ping": 0,
                            "unknown": 1,
                            "upgrade_ack": 1
                        },
                        "sent_breakdown": {
                            "ack": 39,
                            "discarded": 0,
                            "shared": 3
                        }
                    },
                    "queues": {
                        "received": {
                            "size": 67108864,
                            "usage": 0
                        }
                    },
                    "tcp_sessions": 1,
                    "control_messages_queue_usage": 0,
                    "control_messages_queue_breakdown": {
                        "inserted": 40,
                        "replaced": 0,
                        "processed": 40
                    }
                }
            }
        ],
        "total_affected_items": 1,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "Statistical information for each daemon was successfully read",
    "error": 0
}
```

No `states` in `received_breakdown`; no `ar`/`request` in `sent_breakdown`; `upgrade_ack` present and counting; `queues.received.size` is `67108864` bytes (the real `queue_max_bytes` default), not a message count.

</details>

<details><summary>2. Indexer: data stream renamed</summary>

```console
$ curl -sk -u admin:admin https://127.0.0.1:9200/_data_stream/wazuh-metrics-comms-v4 | python3 -m json.tool
{
    "data_streams": [
        {
            "name": "wazuh-metrics-comms-v4",
            "timestamp_field": { "name": "@timestamp" },
            "indices": [ { "index_name": ".ds-wazuh-metrics-comms-v4-000001", "index_uuid": "bvDOFczYRKyHxnOQxrOtUA" } ],
            "generation": 1,
            "status": "GREEN",
            "template": "wazuh-metrics-comms-v4-template"
        }
    ]
}

$ curl -sk -o /dev/null -w '%{http_code}\n' -u admin:admin https://127.0.0.1:9200/_data_stream/wazuh-metrics-comms
404

$ curl -sk -u admin:admin 'https://127.0.0.1:9200/wazuh-metrics-comms-v4/_search?size=1&sort=@timestamp:desc&pretty'
{
  "hits" : {
    "total" : { "value" : 6, "relation" : "eq" },
    "hits" : [
      {
        "_index" : ".ds-wazuh-metrics-comms-v4-000001",
        "_source" : {
          "@timestamp" : "2026-08-18T08:47:51Z",
          "wazuh" : { "cluster" : { "name" : "wazuh", "node" : "node01" }, "schema" : { "version" : "1" } },
          "event" : { "module" : "remoted" },
          "events" : { "total" : 500, "failed" : { "total" : 0 } },
          "queue" : { "size" : 0, "capacity" : 67108864 },
          "tcp" : { "sessions" : 1 },
          "discarded" : { "total" : 0 },
          "network" : { "egress" : { "bytes" : 2944 }, "ingress" : { "bytes" : 102596 } },
          "messages" : {
            "total" : 30,
            "control" : {
              "dropped_on_close" : { "total" : 0 },
              "usage" : 0,
              "received" : { "total" : 30 },
              "replaced" : { "total" : 0 },
              "processed" : { "total" : 30 }
            },
            "upgrades" : { "total" : 1 }
          }
        }
      }
    ]
  }
}
```

`messages.states` does not exist in the document (compare to `messages.total`/`messages.upgrades`, which do). `queue.capacity` matches the manager-side value above, in bytes.

</details>

<details><summary>3. upgrade_ack with a real Wazuh 4.14.7 agent</summary>

Real agent from Wazuh's official apt repo, installed and enrolled over the network against this manager (`10.2.0.10` -> `10.2.0.9`):

```console
$ apt-cache madison wazuh-agent | head -1
wazuh-agent |   4.14.7-1 | https://packages.wazuh.com/4.x/apt stable/main amd64 Packages

$ sudo WAZUH_MANAGER='10.2.0.9' WAZUH_REGISTRATION_PASSWORD='***' apt-get install -y wazuh-agent=4.14.7-1
Setting up wazuh-agent (4.14.7-1) ...

$ sudo systemctl enable wazuh-agent --now
```

Manager confirms full, real enrollment (real OS data in `global.db`, not a stub):

```console
$ curl -sk -H "Authorization: Bearer $TOKEN" 'https://127.0.0.1:55000/agents?agents_list=009' | python3 -m json.tool
{
    "data": {
        "affected_items": [
            {
                "os": {
                    "arch": "x86_64", "major": "24", "minor": "04",
                    "name": "Ubuntu", "platform": "ubuntu", "type": "linux", "version": "24.04.3 LTS"
                },
                "status_code": 0,
                "version": "v4.14.7",
                "id": "009",
                "status": "active",
                "ip": "10.2.0.10",
                "name": "agente1",
                "lastKeepAlive": "2026-08-18T08:38:34+00:00"
            }
        ],
        "total_affected_items": 1
    }
}
```

Triggered a real remote-upgrade task through the API:

```console
$ curl -sk -H "Authorization: Bearer $TOKEN" -X PUT 'https://127.0.0.1:55000/agents/upgrade?agents_list=009&force=true'
{
    "data": {
        "affected_items": [],
        "total_affected_items": 0,
        "total_failed_items": 1,
        "failed_items": [ { "error": { "code": 1822, "message": "The repository is not reachable" }, "id": [ "009" ] } ]
    },
    "message": "No upgrade task was created",
    "error": 1
}
```

Sent the real ack as this exact agent (its own real enrollment key), reproducing the exact legacy wire protocol, after stopping its session so the message isn't rejected by the anti-replay counter check a live connection would otherwise trigger:

```console
$ sudo systemctl stop wazuh-agent
$ python3 send_ack_real_agent.py
raw message: u:upgrade_module:{"command": "upgrade_update_status", "parameters": {"error": 0, "message": "Upgrade was successful", "status": "Done"}}
sent 170 bytes to 10.2.0.9:1514 as real agent 009 (agente1)
```

```console
$ sudo tail -6 /var/wazuh-manager/logs/wazuh-manager.log
2026/08/18 08:44:50 wazuh-manager-remoted: INFO: wazuh: Agent stopped: [009] (agente1).
2026/08/18 08:44:55 wazuh-manager-remoted: INFO: legacy_task_delivery: agent '009' reported upgrade result (error 0: Upgrade was successful), replying with clear_upgrade_result
2026/08/18 08:44:56 wazuh-manager-remoted: ERROR: req_send_and_wait(): cannot send request to agent '009'.
2026/08/18 08:44:56 wazuh-manager-remoted: WARNING: legacy_task_delivery: agent '009': no response for step targeting 'upgrade'
2026/08/18 08:44:56 wazuh-manager-remoted: WARNING: legacy_task_delivery: agent '009': failed to deliver 'clear_upgrade_result', the agent may keep resending its upgrade acknowledgment
```

`upgrade_ack` went from `0` to `1` (see full stats in section 1, captured after this). The "cannot send request"/"no response" lines are expected: the script sends the ack once and doesn't stay connected for the reply; they don't affect counting.


```console
root@manager:~# curl -sk -H "Authorization: Bearer $TOKEN" "https://127.0.0.1:55000/cluster/node01/daemons/stats?daemons_list=wazuh-manager-remoted" | python3 -m json.tool
{
    "data": {
        "affected_items": [
            {
                "uptime": "2026-08-18T08:37:46+00:00",
                "timestamp": "2026-08-18T08:54:25+00:00",
                "name": "wazuh-manager-remoted",
                "metrics": {
                    "bytes": {
                        "received": 110388,
                        "sent": 4724
                    },
                    "keys_reload_count": 0,
                    "messages": {
                        "received_breakdown": {
                            "control": 50,
                            "control_breakdown": {
                                "keepalive": 47,
                                "request": 0,
                                "shutdown": 1,
                                "startup": 2
                            },
                            "events_failed": 0,
                            "dequeued_after": 0,
                            "discarded": 0,
                            "events": 511,
                            "ping": 0,
                            "unknown": 1,
                            "upgrade_ack": 1
                        },
                        "sent_breakdown": {
                            "ack": 49,
                            "discarded": 0,
                            "shared": 3
                        }
                    },
                    "queues": {
                        "received": {
                            "size": 67108864,
                            "usage": 0
                        }
                    },
                    "tcp_sessions": 1,
                    "control_messages_queue_usage": 0,
                    "control_messages_queue_breakdown": {
                        "inserted": 50,
                        "replaced": 0,
                        "processed": 50
                    }
                }
            }
        ],
        "total_affected_items": 1,
        "total_failed_items": 0,
        "failed_items": []
    },
    "message": "Statistical information for each daemon was successfully read",
    "error": 0
}
```

</details>

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

### Artifacts Affected

`wazuh-manager-remoted`. `GET /cluster/{node_id}/daemons/stats` stops carrying `sent_breakdown.ar`/`sent_breakdown.request`, and `upgrade_ack` starts carrying data. Comms metrics move to `wazuh-metrics-comms-v4`; no coordinated release needed (indexer template/ISM/dashboard all match by prefix).

### Configuration Changes

N/A

### Tests Introduced

- `test_remote-state.c`: asserts the three retired fields are absent.
- `test_secure.c`: upgrade-ack counter tests (well-formed, malformed, counted-as-event).
- `test_metrics_snapshot.py`: no `messages.states`, indexed into `wazuh-metrics-comms-v4`.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

Changelog: one `Changed` entry for the rename, one `Removed` entry for the three counters.

**Do not merge before the beta5 tag** (agreed with the indexer team for the rename).

Related work not included here:

- Companion PR `qa-integration-framework`#819, must merge before/with this one.
- `metrics-comms` template keeps declaring `messages.states.total` on purpose (harmless, unemitted).
- `sent_breakdown.shared` stays: real 4.x traffic.
