### PR TITLE
Build the Windows agent's curl against OpenSSL so it can reach a TLS 1.3 manager

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -411,7 +411,7 @@ ifneq (,$(shell curl --help all 2>/dev/null | grep -F -- '--retry-all-errors'))
 	INDEXER_CURL_FLAGS += --retry-all-errors
 endif
 INDEXER_CURL := curl $(INDEXER_CURL_FLAGS) -o
-DEPS_VERSION = 99-38163
+DEPS_VERSION = 99-37702
 RESOURCES_URL_BASE := https://packages.wazuh.com/deps/
 RESOURCES_URL := $(RESOURCES_URL_BASE)$(DEPS_VERSION)
 CPYTHON := cpython

--- a/src/Makefile
+++ b/src/Makefile
@@ -411,7 +411,7 @@ ifneq (,$(shell curl --help all 2>/dev/null | grep -F -- '--retry-all-errors'))
 	INDEXER_CURL_FLAGS += --retry-all-errors
 endif
 INDEXER_CURL := curl $(INDEXER_CURL_FLAGS) -o
-DEPS_VERSION = 99-37702
+DEPS_VERSION = 99-38163
 RESOURCES_URL_BASE := https://packages.wazuh.com/deps/
 RESOURCES_URL := $(RESOURCES_URL_BASE)$(DEPS_VERSION)
 CPYTHON := cpython

--- a/src/client-agent/https_client/src/curlHandle.cpp
+++ b/src/client-agent/https_client/src/curlHandle.cpp
@@ -37,6 +37,9 @@ namespace
     static_assert(TLS_MIN_VERSION_1_3 == CURL_SSLVERSION_TLSv1_3,
                   "TLS_MIN_VERSION_1_3 must stay equal to libcurl's CURL_SSLVERSION_TLSv1_3");
 
+    static_assert(TLS_NATIVE_CA_STORE == CURLSSLOPT_NATIVE_CA,
+                  "TLS_NATIVE_CA_STORE must stay equal to libcurl's CURLSSLOPT_NATIVE_CA");
+
     const std::map<CurlOption, CURLoption>& optionMap()
     {
         // Never destroyed, like the global curl init above: the shutdown drain reads
@@ -60,6 +63,7 @@ namespace
             // and below, which the minimum version below rules out entirely, so a
             // list set through it could never constrain a session.
             {CurlOption::SslCiphers, CURLOPT_TLS13_CIPHERS},
+            {CurlOption::SslOptions, CURLOPT_SSL_OPTIONS},
             {CurlOption::FollowLocation, CURLOPT_FOLLOWLOCATION},
             {CurlOption::NoSignal, CURLOPT_NOSIGNAL}
         };

--- a/src/client-agent/https_client/src/curlPerformer.cpp
+++ b/src/client-agent/https_client/src/curlPerformer.cpp
@@ -27,6 +27,44 @@
 namespace
 {
     using FilePtr = std::unique_ptr<std::FILE, decltype(&std::fclose)>;
+
+    /// Names the options applyTls() sets, so a rejected one is nameable in the
+    /// log instead of surfacing as a bare handshake failure.
+    const char* optionName(CurlOption option)
+    {
+        switch (option)
+        {
+            case CurlOption::VerifyPeer:
+                return "SSL_VERIFYPEER";
+
+            case CurlOption::VerifyHost:
+                return "SSL_VERIFYHOST";
+
+            case CurlOption::CaInfo:
+                return "CAINFO";
+
+            case CurlOption::SslCert:
+                return "SSLCERT";
+
+            case CurlOption::SslKey:
+                return "SSLKEY";
+
+            case CurlOption::SslVersion:
+                return "SSLVERSION";
+
+            case CurlOption::SslCiphers:
+                return "TLS13_CIPHERS";
+
+            case CurlOption::FollowLocation:
+                return "FOLLOWLOCATION";
+
+            case CurlOption::NoSignal:
+                return "NOSIGNAL";
+
+            default:
+                return "unknown"; // LCOV_EXCL_LINE: applyTls sets none of the rest.
+        }
+    }
 }
 
 CurlPerformer::CurlPerformer(const ModuleConfig& config, CurlHandleFactory factory)
@@ -66,7 +104,12 @@ HttpResponse CurlPerformer::perform(const HttpRequestSpec& spec)
     const FilePtr responseGuard {responseFile, std::fclose};
 
     configureRequest(*handle, spec, response);
-    applyTls(*handle);
+
+    if (!applyTls(*handle))
+    {
+        response.status = TransportStatus::TlsFail;
+        return response;
+    }
 
     response.status = handle->perform();
     response.httpCode = handle->responseCode();
@@ -197,35 +240,67 @@ void CurlPerformer::configureRequest(ICurlHandle& handle, const HttpRequestSpec&
     }
 }
 
-void CurlPerformer::applyTls(ICurlHandle& handle) const
+bool CurlPerformer::applyTls(ICurlHandle& handle) const
 {
     const bool verifyPeer = m_config.verifyMode != HC_VERIFY_NONE;
     const bool verifyHost = m_config.verifyMode == HC_VERIFY_FULL;
-    handle.setOptionLong(CurlOption::VerifyPeer, verifyPeer ? 1L : 0L);
-    handle.setOptionLong(CurlOption::VerifyHost, verifyHost ? 2L : 0L);
 
     // The manager's HTTPS listener sets a TLS 1.3 floor of its own
     // (SSL_CTX_set_min_proto_version in RestinioHttpServer), so match it instead
     // of leaving libcurl's default, which still permits 1.0. Unconditional: this
     // is the protocol's floor, not something <ssl> is allowed to lower.
-    handle.setOptionLong(CurlOption::SslVersion, TLS_MIN_VERSION_1_3);
+    return setMandatoryOption(handle, CurlOption::VerifyPeer, verifyPeer ? 1L : 0L)
+           && setMandatoryOption(handle, CurlOption::VerifyHost, verifyHost ? 2L : 0L)
+           && setMandatoryOption(handle, CurlOption::SslVersion, TLS_MIN_VERSION_1_3)
+           && applyTrustAnchors(handle)
+           && applyClientCertificate(handle)
+           && applyCiphers(handle)
+           && setMandatoryOption(handle, CurlOption::FollowLocation, 0L) // H4: no redirects.
+           && setMandatoryOption(handle, CurlOption::NoSignal, 1L);      // H6.
+}
 
-    if (!m_config.caPath.empty())
+bool CurlPerformer::applyTrustAnchors(ICurlHandle& handle) const
+{
+    return m_config.caPath.empty()
+           || setMandatoryOption(handle, CurlOption::CaInfo, m_config.caPath);
+}
+
+bool CurlPerformer::applyClientCertificate(ICurlHandle& handle) const
+{
+    if (m_config.clientCert.empty())
     {
-        handle.setOptionString(CurlOption::CaInfo, m_config.caPath);
+        return true;
     }
 
-    if (!m_config.clientCert.empty())
+    return setMandatoryOption(handle, CurlOption::SslCert, m_config.clientCert)
+           && setMandatoryOption(handle, CurlOption::SslKey, m_config.clientKey);
+}
+
+bool CurlPerformer::applyCiphers(ICurlHandle& handle) const
+{
+    return m_config.ciphers.empty()
+           || setMandatoryOption(handle, CurlOption::SslCiphers, m_config.ciphers);
+}
+
+bool CurlPerformer::setMandatoryOption(ICurlHandle& handle, CurlOption option, long value) const
+{
+    if (handle.setOptionLong(option, value))
     {
-        handle.setOptionString(CurlOption::SslCert, m_config.clientCert);
-        handle.setOptionString(CurlOption::SslKey, m_config.clientKey);
+        return true;
     }
 
-    if (!m_config.ciphers.empty())
+    LOGFN_ERROR(m_logFn, "libcurl rejected %s; refusing to connect without it.", optionName(option));
+    return false;
+}
+
+bool CurlPerformer::setMandatoryOption(ICurlHandle& handle, CurlOption option,
+                                       const std::string& value) const
+{
+    if (handle.setOptionString(option, value))
     {
-        handle.setOptionString(CurlOption::SslCiphers, m_config.ciphers);
+        return true;
     }
 
-    handle.setOptionLong(CurlOption::FollowLocation, 0L); // H4: no redirects.
-    handle.setOptionLong(CurlOption::NoSignal, 1L);       // H6.
+    LOGFN_ERROR(m_logFn, "libcurl rejected %s; refusing to connect without it.", optionName(option));
+    return false;
 }

--- a/src/client-agent/https_client/src/curlPerformer.cpp
+++ b/src/client-agent/https_client/src/curlPerformer.cpp
@@ -55,6 +55,9 @@ namespace
             case CurlOption::SslCiphers:
                 return "TLS13_CIPHERS";
 
+            case CurlOption::SslOptions:
+                return "SSL_OPTIONS";
+
             case CurlOption::FollowLocation:
                 return "FOLLOWLOCATION";
 
@@ -261,8 +264,23 @@ bool CurlPerformer::applyTls(ICurlHandle& handle) const
 
 bool CurlPerformer::applyTrustAnchors(ICurlHandle& handle) const
 {
-    return m_config.caPath.empty()
-           || setMandatoryOption(handle, CurlOption::CaInfo, m_config.caPath);
+    if (!m_config.caPath.empty())
+    {
+        // An explicit <ca> is the whole trust set; adding the machine's stores
+        // on top of it would widen what the agent accepts.
+        return setMandatoryOption(handle, CurlOption::CaInfo, m_config.caPath);
+    }
+
+#ifdef WIN32
+    // Windows curl is built against our OpenSSL (src/external/CMakeLists.txt),
+    // which carries no CA bundle there, so without this nothing is trusted at
+    // all. Schannel used to consult the Windows stores implicitly; this asks
+    // OpenSSL for the same ROOT+CA stores through the Win32 crypto API.
+    return setMandatoryOption(handle, CurlOption::SslOptions, TLS_NATIVE_CA_STORE);
+#else
+    // Elsewhere libcurl already defaults to the system bundle it was built with.
+    return true;
+#endif
 }
 
 bool CurlPerformer::applyClientCertificate(ICurlHandle& handle) const

--- a/src/client-agent/https_client/src/curlPerformer.hpp
+++ b/src/client-agent/https_client/src/curlPerformer.hpp
@@ -15,6 +15,7 @@
 #include "iCurlHandle.hpp"
 #include "iHttpPerformer.hpp"
 #include "moduleConfig.hpp"
+#include "moduleLog.hpp"
 
 /**
  * @brief Maps an HttpRequestSpec onto option calls of an injected
@@ -36,13 +37,25 @@ class CurlPerformer final : public IHttpPerformer
                                    HttpResponse& response, std::FILE** fileOut) const;
         void configureRequest(ICurlHandle& handle, const HttpRequestSpec& spec,
                               HttpResponse& response) const;
-        void applyTls(ICurlHandle& handle) const;
+
+        /// @return false as soon as one option is rejected; the caller must not
+        ///         perform the request, because a TLS option that did not apply
+        ///         silently weakens the connection.
+        bool applyTls(ICurlHandle& handle) const;
+        bool applyTrustAnchors(ICurlHandle& handle) const;
+        bool applyClientCertificate(ICurlHandle& handle) const;
+        bool applyCiphers(ICurlHandle& handle) const;
+
+        /// Sets an option whose failure aborts the request, and says which one.
+        bool setMandatoryOption(ICurlHandle& handle, CurlOption option, long value) const;
+        bool setMandatoryOption(ICurlHandle& handle, CurlOption option, const std::string& value) const;
 
         // By value: callers routinely build a ModuleConfig as a temporary
         // (e.g. makeConfig()-style test helpers); a reference member would
         // dangle the moment that temporary's full expression ends.
         ModuleConfig m_config;
         CurlHandleFactory m_factory;
+        const LogFn m_logFn {HTTPS_CLIENT_LOGTAG};
 };
 
 #endif // _HC_CURL_PERFORMER_HPP

--- a/src/client-agent/https_client/src/iCurlHandle.hpp
+++ b/src/client-agent/https_client/src/iCurlHandle.hpp
@@ -37,6 +37,7 @@ enum class CurlOption
     SslKey,         ///< string client key path
     SslVersion,     ///< long, the minimum TLS version to negotiate
     SslCiphers,     ///< string TLS 1.3 ciphersuite list
+    SslOptions,     ///< long, the TLS behaviour bitmask
     FollowLocation, ///< long, always 0 (H4: no redirects)
     NoSignal        ///< long, always 1 (H6)
 };
@@ -47,6 +48,12 @@ enum class CurlOption
 /// stays curl-agnostic like the ids above. curlHandle.cpp static_asserts the two
 /// against each other, so the literal cannot drift from what curl expects.
 inline constexpr long TLS_MIN_VERSION_1_3 {7};
+
+/// Value for CurlOption::SslOptions: trust the platform's own certificate store.
+///
+/// Numerically libcurl's CURLSSLOPT_NATIVE_CA, static_asserted in curlHandle.cpp
+/// like the version above.
+inline constexpr long TLS_NATIVE_CA_STORE {1L << 4};
 
 /**
  * @brief One HTTP transfer, at the option level.

--- a/src/client-agent/https_client/tests/unit/curlPerformer_test.cpp
+++ b/src/client-agent/https_client/tests/unit/curlPerformer_test.cpp
@@ -233,6 +233,37 @@ TEST(CurlPerformerTest, ClientCertAndCiphersApplied)
     performer.perform(HttpRequestSpec {});
 }
 
+TEST(CurlPerformerTest, RejectedTlsOptionAbortsBeforePerforming)
+{
+    auto mock = std::make_unique<NiceMock<MockCurlHandle>>();
+    auto* handle = mock.get();
+    allowOtherOptions(*handle);
+
+    // What a backend that does not implement the option answers.
+    EXPECT_CALL(*handle, setOptionLong(CurlOption::SslVersion, _)).WillOnce(Return(false));
+    EXPECT_CALL(*handle, perform()).Times(0);
+
+    auto performer = makePerformer(makeConfig(HC_VERIFY_FULL), std::move(mock));
+    const auto response = performer.perform(HttpRequestSpec {});
+    EXPECT_EQ(TransportStatus::TlsFail, response.status);
+}
+
+TEST(CurlPerformerTest, RejectedCipherListAbortsBeforePerforming)
+{
+    auto mock = std::make_unique<NiceMock<MockCurlHandle>>();
+    auto* handle = mock.get();
+    allowOtherOptions(*handle);
+    auto config = makeConfig(HC_VERIFY_FULL);
+    config.ciphers = "TLS_AES_128_GCM_SHA256";
+
+    EXPECT_CALL(*handle, setOptionString(CurlOption::SslCiphers, _)).WillOnce(Return(false));
+    EXPECT_CALL(*handle, perform()).Times(0);
+
+    auto performer = makePerformer(config, std::move(mock));
+    const auto response = performer.perform(HttpRequestSpec {});
+    EXPECT_EQ(TransportStatus::TlsFail, response.status);
+}
+
 TEST(CurlPerformerTest, FileBodyStreamsInsteadOfPostFields)
 {
     const std::string path = ::testing::TempDir() + "hc_curl_performer_body.tmp";

--- a/src/client-agent/https_client/tests/unit/curlPerformer_test.cpp
+++ b/src/client-agent/https_client/tests/unit/curlPerformer_test.cpp
@@ -264,6 +264,40 @@ TEST(CurlPerformerTest, RejectedCipherListAbortsBeforePerforming)
     EXPECT_EQ(TransportStatus::TlsFail, response.status);
 }
 
+TEST(CurlPerformerTest, ConfiguredCaIsTheWholeTrustSet)
+{
+    auto mock = std::make_unique<NiceMock<MockCurlHandle>>();
+    auto* handle = mock.get();
+    allowOtherOptions(*handle);
+    auto config = makeConfig(HC_VERIFY_FULL);
+    config.caPath = "/etc/ca.pem";
+
+    EXPECT_CALL(*handle, setOptionString(CurlOption::CaInfo, "/etc/ca.pem"));
+    // The machine's own stores are never added on top of it.
+    EXPECT_CALL(*handle, setOptionLong(CurlOption::SslOptions, _)).Times(0);
+
+    auto performer = makePerformer(config, std::move(mock));
+    performer.perform(HttpRequestSpec {});
+}
+
+TEST(CurlPerformerTest, TrustAnchorsWithoutConfiguredCa)
+{
+    auto mock = std::make_unique<NiceMock<MockCurlHandle>>();
+    auto* handle = mock.get();
+    allowOtherOptions(*handle);
+
+    EXPECT_CALL(*handle, setOptionString(CurlOption::CaInfo, _)).Times(0);
+#ifdef WIN32
+    // Our OpenSSL-backed Windows curl has no bundle of its own to fall back on.
+    EXPECT_CALL(*handle, setOptionLong(CurlOption::SslOptions, TLS_NATIVE_CA_STORE));
+#else
+    EXPECT_CALL(*handle, setOptionLong(CurlOption::SslOptions, _)).Times(0);
+#endif
+
+    auto performer = makePerformer(makeConfig(HC_VERIFY_FULL), std::move(mock));
+    performer.perform(HttpRequestSpec {});
+}
+
 TEST(CurlPerformerTest, FileBodyStreamsInsteadOfPostFields)
 {
     const std::string path = ::testing::TempDir() + "hc_curl_performer_body.tmp";

--- a/src/client-agent/https_client/tests/unit/mocks/mockCurlHandle.hpp
+++ b/src/client-agent/https_client/tests/unit/mocks/mockCurlHandle.hpp
@@ -19,6 +19,19 @@
 class MockCurlHandle : public ICurlHandle
 {
     public:
+        MockCurlHandle()
+        {
+            // A real handle accepts these; without a default the mock answers
+            // false and CurlPerformer would abort every request as a rejected
+            // TLS option. Tests that want a rejection say so explicitly.
+            ON_CALL(*this, setOptionLong(::testing::_, ::testing::_))
+            .WillByDefault(::testing::Return(true));
+            ON_CALL(*this, setOptionString(::testing::_, ::testing::_))
+            .WillByDefault(::testing::Return(true));
+            ON_CALL(*this, setOptionPtr(::testing::_, ::testing::_))
+            .WillByDefault(::testing::Return(true));
+        }
+
         MOCK_METHOD(bool, setOptionLong, (CurlOption option, long value), (override));
         MOCK_METHOD(bool, setOptionString, (CurlOption option, const std::string& value), (override));
         MOCK_METHOD(bool, setOptionPtr, (CurlOption option, const void* value), (override));

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -251,6 +251,16 @@ add_dependencies(ext_libyaml libyaml_external)
 # ------------------------------------------------------------------------------
 
 if(IS_WINDOWS)
+  # OpenSSL, not Schannel. Schannel cannot negotiate TLS 1.3 before Windows 11
+  # / Server 2022, and it does not advertise SSLSUPP_TLS13_CIPHERSUITES, so
+  # CURLOPT_TLS13_CIPHERS comes back CURLE_NOT_BUILT_IN. The manager's HTTPS
+  # listener pins a hardcoded TLS 1.3 floor, so a Schannel agent cannot reach
+  # it at all on those Windows versions. The rest of the agent (ssl_op.c,
+  # enrollment, authd) already links the mingw OpenSSL built above, so pointing
+  # curl at the same tree costs no extra dependency. Callers must set
+  # CURLSSLOPT_NATIVE_CA to keep validating against the Windows certificate
+  # store, which Schannel used to give us for free.
+  #
   # _WIN32_WINNT=0x0600 (Vista) is the rest of the project's target — see
   # src/syscheckd/CMakeLists.txt, src/wazuh_modules/CMakeLists.txt, etc.
   # Curl ≥ 8.x's configure refuses to build for anything older. MinGW 12+
@@ -258,18 +268,27 @@ if(IS_WINDOWS)
   # implicitly, but the compile_windows_agent image (ubuntu:22.04) ships
   # MinGW 10, which still defaults to 0x0501 (XP). Set it explicitly so the
   # build is portable across MinGW versions.
+  #
+  # --with-openssl=DIR searches DIR/lib, but our OpenSSL builds in-source, so
+  # the archives sit at DIR/ — hence the explicit -L, same as the Linux and
+  # Darwin arms. LIBS is what configure's own OpenSSL probe needs to link:
+  # libcrypto's Windows engine calls into the certificate store (crypt32) and
+  # its socket BIO into winsock (ws2_32), and without both, `HMAC_Update in
+  # -lcrypto` fails and configure aborts with "OpenSSL could not be detected".
   set(CURL_CONFIGURE_CMD
       ${CMAKE_COMMAND}
       -E
       env
       "CFLAGS=-fPIC -D_WIN32_WINNT=0x0600"
+      "LDFLAGS=-L${EXTERNAL_DIR}/openssl"
+      "LIBS=-lcrypt32 -lws2_32"
       CC=${MINGW_CC}
       ${EXTERNAL_DIR}/curl/configure
       --host=${MINGW_HOST}
       PREFIX=${MINGW_PREFIX}
       --enable-static=yes
       --disable-shared
-      --with-schannel
+      --with-openssl=${EXTERNAL_DIR}/openssl
       --disable-ldap
       --without-libidn2
       --without-libpsl

--- a/src/shared/src/url.c
+++ b/src/shared/src/url.c
@@ -336,6 +336,31 @@ int wurl_request_uncompress_bz2_gz(const char * url, const char * dest, const ch
 }
 #endif
 
+/*
+ * Point libcurl at the CA certificates this host trusts. HTTPS URLs only; a
+ * plain HTTP request needs no trust anchors.
+ *
+ * On Windows the agent's libcurl is built against our own OpenSSL rather than
+ * Schannel (src/external/CMakeLists.txt), and that build carries no CA bundle,
+ * so the Windows certificate stores have to be asked for explicitly — Schannel
+ * used to consult them on its own. Elsewhere the bundle path libcurl was
+ * compiled with may not exist on this host (the dependency is precompiled), so
+ * the file is looked up at run time instead.
+ */
+static CURLcode wurl_set_trust_anchors(CURL *curl, const char *url) {
+    if (strncmp(url, "https", 5) != 0) {
+        return CURLE_OK;
+    }
+
+#ifdef WIN32
+    return curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, (long)CURLSSLOPT_NATIVE_CA);
+#else
+    char const *cert = find_cert_list();
+
+    return cert ? curl_easy_setopt(curl, CURLOPT_CAINFO, cert) : CURLE_OK;
+#endif
+}
+
 curl_response* wurl_http_request(char *method, char **headers, const char* url, const char *payload, size_t max_size, const long timeout, const char *userpass, bool ssl_verify) {
     curl_response *response;
     struct curl_slist* headers_list = NULL;
@@ -358,17 +383,7 @@ curl_response* wurl_http_request(char *method, char **headers, const char* url, 
     }
 
     res = curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, method);
-
-#ifndef WIN32
-    char const *cert = find_cert_list();
-
-    // Enable SSL check if url is HTTPS
-    if (!strncmp(url, "https", 5)) {
-        if (NULL != cert) {
-            res += curl_easy_setopt(curl, CURLOPT_CAINFO, cert);
-        }
-    }
-#endif
+    res += wurl_set_trust_anchors(curl, url);
 
     // Ignore SSL verification
     if (!ssl_verify) {

--- a/src/unit_tests/shared/test_url.c
+++ b/src/unit_tests/shared/test_url.c
@@ -78,6 +78,11 @@ void test_wurl_http_request_headers_list_null(void **state)
         expect_value(wrap_curl_easy_setopt, curl, curl);
         will_return(wrap_curl_easy_setopt, CURLE_OK);
 
+        // Windows has no CA file to point at: curl is asked for the system stores.
+        expect_value(wrap_curl_easy_setopt, option, CURLOPT_SSL_OPTIONS);
+        expect_value(wrap_curl_easy_setopt, curl, curl);
+        will_return(wrap_curl_easy_setopt, CURLE_OK);
+
         expect_string(wrap_curl_slist_append, data, "User-Agent: curl/7.58.0");
         expect_value(wrap_curl_slist_append, list, NULL);
         will_return(wrap_curl_slist_append, headers);
@@ -137,8 +142,6 @@ void test_wurl_http_request_headers_tmp_null(void **state)
         expect_value(wrap_curl_easy_cleanup, curl, curl);
     #else
         will_return(__wrap_curl_easy_init, curl);
-
-        expect_FileSize("/etc/ssl/certs/ca-certificates.crt", 1);
 
         expect_value(__wrap_curl_easy_setopt, option, CURLOPT_CUSTOMREQUEST);
         expect_value(__wrap_curl_easy_setopt, curl, curl);
@@ -224,8 +227,6 @@ void test_wurl_http_request_curl_easy_perform_fail_with_headers(void **state)
         expect_value(wrap_curl_easy_cleanup, curl, curl);
     #else
         will_return(__wrap_curl_easy_init, curl);
-
-        expect_FileSize("/etc/ssl/certs/ca-certificates.crt", 1);
 
         expect_value(__wrap_curl_easy_setopt, option, CURLOPT_CUSTOMREQUEST);
         expect_value(__wrap_curl_easy_setopt, curl, curl);
@@ -333,8 +334,6 @@ void test_wurl_http_request_curl_easy_perform_fail_with_payload(void **state)
         expect_value(wrap_curl_easy_cleanup, curl, curl);
     #else
         will_return(__wrap_curl_easy_init, curl);
-
-        expect_FileSize("/etc/ssl/certs/ca-certificates.crt", 1);
 
         expect_value(__wrap_curl_easy_setopt, option, CURLOPT_CUSTOMREQUEST);
         expect_value(__wrap_curl_easy_setopt, curl, curl);
@@ -447,8 +446,6 @@ void test_wurl_http_request_curl_easy_perform_fail_timeout(void **state)
     #else
         will_return(__wrap_curl_easy_init, curl);
 
-        expect_FileSize("/etc/ssl/certs/ca-certificates.crt", 1);
-
         expect_value(__wrap_curl_easy_setopt, option, CURLOPT_CUSTOMREQUEST);
         expect_value(__wrap_curl_easy_setopt, curl, curl);
         will_return(__wrap_curl_easy_setopt, CURLE_OK);
@@ -560,8 +557,6 @@ void test_wurl_http_request_curl_easy_setopt_fail(void **state)
         expect_value(__wrap_curl_easy_setopt, curl, curl);
         will_return(__wrap_curl_easy_setopt, CURLE_OK);
 
-        expect_FileSize("/etc/ssl/certs/ca-certificates.crt", 1);
-
         expect_string(__wrap_curl_slist_append, data, "User-Agent: curl/7.58.0");
         expect_value(__wrap_curl_slist_append, list, NULL);
         will_return(__wrap_curl_slist_append, headers);
@@ -670,8 +665,6 @@ void test_wurl_http_request_success(void **state)
 
     #else
         will_return(__wrap_curl_easy_init, curl);
-
-        expect_FileSize("/etc/ssl/certs/ca-certificates.crt", 1);
 
         expect_value(__wrap_curl_easy_setopt, option, CURLOPT_CUSTOMREQUEST);
         expect_value(__wrap_curl_easy_setopt, curl, curl);


### PR DESCRIPTION
## Description

The manager's HTTPS listener pins a TLS 1.3 floor in code (`SSL_CTX_set_min_proto_version(..., TLS1_3_VERSION)`, `RestinioHttpServer.cpp`) and exposes no option to lower it. The Windows agent's libcurl was built `--with-schannel`, and Schannel cannot negotiate TLS 1.3 before Windows 11 / Server 2022, nor does it advertise `SSLSUPP_TLS13_CIPHERSUITES`, so `CURLOPT_TLS13_CIPHERS` returns `CURLE_NOT_BUILT_IN` and `<ssl><ciphers>` is inert there.

Net effect: a Windows 10 / Server 2019 agent cannot reach a 5.0 manager at all.

Related issue: #38163
Follow-up to the TLS review on #38190 (https://github.com/wazuh/wazuh/pull/38190#issuecomment-5211701233).

## Proposed Changes

**1. winagent curl is now built against our OpenSSL** (`src/external/CMakeLists.txt`). The rest of the agent — `ssl_op.c`, enrollment, authd — already links the mingw OpenSSL built in the same file, so this adds no dependency. `LIBS=-lcrypt32 -lws2_32` is what configure's own OpenSSL probe needs to link a static mingw OpenSSL; without it the probe fails and configure aborts with "OpenSSL could not be detected".

**2. `CURLSSLOPT_NATIVE_CA` so the Windows certificate store keeps being trusted.** The OpenSSL build ships no CA bundle on Windows (`configure` reports `ca cert bundle: no`), so without this nothing would verify. Applied in the `https_client` transport and in `wurl_http_request` — the path agentd's uninstall check and the github / office365 / ms-graph modules go through. An explicitly configured `<ca>` still stands alone: the machine's stores are not added on top of it.

**3. `DEPS_VERSION` now points at `99-38163`** (`src/Makefile`), the first externals bundle built from this branch. Without this the change is inert in the product: `make deps` pulls a precompiled curl and the CMake short-circuits on it, so the winagent kept linking the Schannel curl built on 2026-05-19 and the new configure flag only took effect in a local `EXTERNAL_SRC_ONLY=yes` build.

**4. `curlPerformer::applyTls()` no longer discards `setOption` results.** A TLS option the backend rejects was silently skipped and the request went out weaker than configured. Now the first rejection names the option in the log and fails the request as `TlsFail`, before `perform()` runs.

### Results and Evidence

Verified on a live setup: manager built from this branch running in a container, and a **Windows 10 Enterprise 10.0.19045** guest (VirtualBox/Vagrant) running agents built from this branch and from `5.0.0-https` unmodified. Full transcripts — every command with host, user, cwd, timestamp and exit code — are in the evidence comment below.

**1. The change reaches curl only when curl is compiled.** Same recipe on both branches, differing only by these commits:

| build | `USE_OPENSSL` | `USE_SCHANNEL` |
|---|---|---|
| this branch | `1` | undef |
| `5.0.0-https` | undef | `1` |

```
SSL:              enabled (OpenSSL)
ca cert bundle:   no
libwazuhext.dll -> CertOpenSystemStoreA/W, CertEnumCertificatesInStore
```

**2. The manager really does refuse anything below TLS 1.3** (from the host, against the running manager):

```
TLS 1.3 -> New, TLSv1.3, Cipher is TLS_AES_256_GCM_SHA384
TLS 1.2 -> tlsv1 alert protocol version (SSL alert number 70), Cipher is (NONE)
```

**3. Windows 10's Schannel cannot reach that listener**, shown with the OS's own Schannel-backed curl, after confirming TCP reachability (`Test-NetConnection 10.0.2.2:1517` -> `True`):

```
curl 8.4.0 (Windows) libcurl/8.4.0 Schannel WinIDN

manager :1517, default    -> curl: (35) schannel: next InitializeSecurityContext failed:
                              SEC_E_ILLEGAL_MESSAGE (0x80090326)
manager :1517, --tlsv1.3  -> curl: (35) schannel: AcquireCredentialsHandle failed:
                              SEC_E_ALGORITHM_MISMATCH (0x80090331)
api.github.com            -> http 200
login.microsoftonline.com -> http 302
```

Schannel cannot even acquire credentials for TLS 1.3, while the same curl reaches GitHub and Microsoft normally.

**4. Agent A/B on that guest** — same machine, same agent key, same `ossec.conf`, only the binaries differ:

| | this branch (curl+OpenSSL) | `5.0.0-https` (curl+Schannel) |
|---|---|---|
| manager `:1517` | `Starting https_client (server=10.0.2.2:1517, agent=001)`, held for the whole run, no transport error | `WARNING: Manager unreachable. Pausing module event production.` |
| github module | `Module GitHub started` -> `{"message":"Bad credentials", "status":"401"}` from api.github.com | never ran (events paused) |
| office365 module | `Module Office365 started` -> `AADSTS700038 ... Trace ID: 285bc340-...` from login.microsoftonline.com | never ran (events paused) |

The module credentials are deliberately invalid, so `401` and `AADSTS700038` are the expected answers: receiving an authenticated-layer response proves the TLS handshake **and** the Windows certificate-store validation both succeeded, which is what change 2 preserves now that the OpenSSL build carries no CA bundle.

Note the blast radius on the unpatched build: because the agent pauses module event production while the manager is unreachable, a Windows 10 agent without this change produces nothing at all, not just no control channel.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux <!-- not exercised by this PR's verification; CI covers it -->
  - [x] Windows — `make TARGET=winagent DEBUG=1` cross-built with `i686-w64-mingw32-gcc 13-win32`, both with the default precompiled deps and with `EXTERNAL_SRC_ONLY=yes`
  - [ ] MAC OS X <!-- N/A: the change is winagent-only -->
- [x] Log syntax and correct language review — new failure path logs the rejected TLS option by name

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check) — see the open point below
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_ — N/A
- Engine _(Wazuh v5.x and above)_ — N/A
- Wazuh server API/Framework — N/A

### Artifacts Affected

- Windows agent binaries: `libwazuhext.dll` (now links OpenSSL-backed libcurl and the Windows certificate-store entry points), `libhttps_client.dll`, `wazuh-agent.exe`.
- The winagent build of `external/curl` — its TLS backend changes from Schannel to OpenSSL.
- No Linux/macOS artifact changes: the modified CMake arm is inside `if(IS_WINDOWS)`.

### Configuration Changes

No new parameters and no default value changes. Behaviour notes:

- `<ssl><ciphers>` / `CURLOPT_TLS13_CIPHERS` becomes effective on Windows; under Schannel it was silently inert.
- An explicitly configured `<ca>` keeps standing alone — the machine's certificate stores are not added on top of it. Only the unset case now falls back to the Windows stores via `CURLSSLOPT_NATIVE_CA`.
- A TLS option the backend rejects now fails the request instead of being skipped, so a configuration that silently degraded before will now surface as an error.

### Tests Introduced

- `curlPerformer_test.cpp`: cases covering the new `applyTls()` behaviour — a rejected `setOption` fails the request as `TlsFail` before `perform()` runs, and names the offending option.
- `mockCurlHandle.hpp`: `setOption` returns a code so rejection can be simulated.
- `test_url.c`: updated for `wurl_http_request` setting `CURLSSLOPT_NATIVE_CA`.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues — see the open points below

### Open points for the reviewer

**1. ~~The shipped MSI does not get this change~~ — resolved by the `DEPS_VERSION` bump.** Recorded here because it is the crux of this PR and was true until the bundle existed.

`make deps` fetches precompiled libraries by default and the build skips curl entirely (`[2%] Built target curl_external`), which is the path `5_builderpackage_agent-windows.yml:121` uses. Against `99-37702` that meant the Schannel curl regardless of the configure flag. Comparing the two bundles' `windows/curl.tar.gz` directly:

| bundle | `USE_OPENSSL` | `USE_SCHANNEL` | `curl_config.h` |
|---|---|---|---|
| `99-37702` (previous) | undef | `1` | 2026-05-19 |
| `99-38163` (this branch) | `1` | undef | 2026-08-12 |

With `DEPS_VERSION = 99-38163`, the **default** build path — no `EXTERNAL_SRC_ONLY`, curl not recompiled — now produces `USE_OPENSSL 1`, and the agent built that way was re-tested on the Windows 10 guest end to end. Evidence in the comment below.

**2. The RTR valgrind failure is a flaky test, not a memory problem** (investigated locally, reproducing the RTR command exactly: `valgrind --leak-check=full --show-leak-kinds=all -q --error-exitcode=1 <test>` on a `TARGET=agent DEBUG=1 TEST=1 VALGRIND=1` build).

What valgrind actually reports on the failing run: `0` definitely lost, `0` indirectly lost, `0` memcheck errors. The non-zero exit comes from a gtest failure inside the run — `FacadeE2eTest.AHeldStatefulRequestDoesNotStallStatelessOrControl`, taking 34.5 s under valgrind against 1.2 s without it. For reference the branch has *fewer* possibly-lost records than the base (70 vs 76), and the base exits 0 with 76, so leaks are not what fails the stage.

| run | result |
|---|---|
| this branch, full suite, run 1 | exit 1 — that test failed (34.5 s) |
| this branch, full suite, runs 2 and 3 | exit 0 — 38/38 passed |
| `5.0.0-https`, full suite | exit 0 — 38/38 passed |
| that test alone under valgrind, this branch | passes: 8.5 s, 10.7 s |
| that test alone under valgrind, `5.0.0-https` | passes: 12.9 s, 10.9 s |
| that test without valgrind, this branch | passes: 1.2 s |

One failure in three identical runs, passing in isolation on both branches, and faster in isolation here than on the base. It is a timing-sensitive test that only trips inside the full 38-test suite under valgrind's slowdown, not something these commits introduce. Worth a separate issue to make that test robust under valgrind.

**3. Unrelated red checks on this PR** (verified as pre-existing on the base, not caused by these commits):
- `Unit-Tests (manager)` — fails in `test_client-config_https` / `test_read_agent_batch_keeps_the_local_block_when_the_shared_one_is_rejected`. That file is not touched here, the test exists on `5.0.0-https`, and the same job fails on #38304, a different branch on the same base.
- `IT Linux/Windows - agentd` and `- enrollment` — the same four suites fail on #38304 against the same base.
