### PR TITLE
fix(analysisd): make CDB list lookups atomic to prevent spurious "not found"

### DIFF
--- a/src/analysisd/cdb/cdb.c
+++ b/src/analysisd/cdb/cdb.c
@@ -108,22 +108,19 @@ static int match(struct cdb *c, char *key, unsigned int len, uint32 pos)
     return 1;
 }
 
-int cdb_findnext(struct cdb *c, char *key, unsigned int len)
+static int cdb_findnext_unlocked(struct cdb *c, char *key, unsigned int len)
 {
     char buf[8];
     uint32 pos;
     uint32 u;
 
-    w_mutex_lock(&c->mutex);
     if (!c->loop) {
         u = cdb_hash(key, len);
         if (cdb_read(c, buf, 8, (u << 3) & 2047) == -1) {
-            w_mutex_unlock(&c->mutex);
             return -1;
         }
         uint32_unpack(buf + 4, &c->hslots);
         if (!c->hslots) {
-            w_mutex_unlock(&c->mutex);
             return 0;
         }
         uint32_unpack(buf, &c->hpos);
@@ -136,12 +133,10 @@ int cdb_findnext(struct cdb *c, char *key, unsigned int len)
 
     while (c->loop < c->hslots) {
         if (cdb_read(c, buf, 8, c->kpos) == -1) {
-            w_mutex_unlock(&c->mutex);
             return -1;
         }
         uint32_unpack(buf + 4, &pos);
         if (!pos) {
-            w_mutex_unlock(&c->mutex);
             return 0;
         }
         c->loop += 1;
@@ -152,29 +147,38 @@ int cdb_findnext(struct cdb *c, char *key, unsigned int len)
         uint32_unpack(buf, &u);
         if (u == c->khash) {
             if (cdb_read(c, buf, 8, pos) == -1) {
-                w_mutex_unlock(&c->mutex);
                 return -1;
             }
             uint32_unpack(buf, &u);
             if (u == len)
                 switch (match(c, key, len, pos + 8)) {
                     case -1:
-                        w_mutex_unlock(&c->mutex);
                         return -1;
                     case 1:
                         uint32_unpack(buf + 4, &c->dlen);
                         c->dpos = pos + 8 + len;
-                        w_mutex_unlock(&c->mutex);
                         return 1;
                 }
         }
     }
-    w_mutex_unlock(&c->mutex);
     return 0;
+}
+
+int cdb_findnext(struct cdb *c, char *key, unsigned int len)
+{
+    int ret;
+    w_mutex_lock(&c->mutex);
+    ret = cdb_findnext_unlocked(c, key, len);
+    w_mutex_unlock(&c->mutex);
+    return ret;
 }
 
 int cdb_find(struct cdb *c, char *key, unsigned int len)
 {
-    cdb_findstart(c);
-    return cdb_findnext(c, key, len);
+    int ret;
+    w_mutex_lock(&c->mutex);
+    c->loop = 0;
+    ret = cdb_findnext_unlocked(c, key, len);
+    w_mutex_unlock(&c->mutex);
+    return ret;
 }


### PR DESCRIPTION
## Description

`cdb_find()` in `src/analysisd/cdb/cdb.c` performed a lookup as two independently locked
operations. `cdb_findstart()` locked, reset `c->loop` and unlocked, after which `cdb_findnext()`
re-acquired the lock and skipped initialisation whenever `c->loop` was non-zero. Since `struct cdb`
is shared per CDB list (`ListNode` embeds it) and rule evaluation is multi-threaded
(`num_rule_matching_threads`, defaulting to the CPU core count), two concurrent lookups on the same
list could interleave in that gap so one search continued from the other's cursor and reported
"not found" for a key that is present.

All six CDB lookup types reach `cdb_find()`, so all are affected. `match_key`, `match_key_value`,
`address_match_key` and `address_match_key_value` fail silently (a real match is missed with no
indication). `not_match_key` and `not_address_match_key` fail loudly (the rule fires when it should
not). This reaches the default ruleset, since the shipped `etc/lists/malicious-ioc/*` lists are
queried by shipped rules.

Closes #38324

## Proposed Changes

- Split the search body of `cdb_findnext()` into a `static int cdb_findnext_unlocked()` helper that
  assumes the caller already holds `c->mutex`, removing the nine lock and unlock calls that were
  scattered through its return paths.
- `cdb_findnext()` becomes a thin wrapper that takes `c->mutex` around the helper, preserving its
  exported signature and behaviour.
- `cdb_find()` now takes `c->mutex` once, resets `c->loop`, runs the search and unlocks, so a single
  lookup is atomic with respect to the shared cursor state.
- `cdb_findstart()` is left unchanged for API compatibility. It is no longer on the `cdb_find()`
  path.

One file changed, `src/analysisd/cdb/cdb.c`, 16 insertions and 12 deletions. No public API or ABI
change, and no change needed in `cdb.h`, `lists_list.c` or any caller. Safe with the existing
non-recursive mutex because neither `cdb_read()` nor `match()` takes it.

Not addressed here, and noted in the issue as worth separate treatment:

1. Callers that iterate duplicate keys with `cdb_findstart()` followed by repeated `cdb_findnext()`
   calls still need the lock held across the whole iteration, since the cursor is only protected per
   call.
2. The `*_key_value` paths read `cdb_datapos()`/`cdb_datalen()`, that is `c->dpos`/`c->dlen`, from
   the shared handle after `cdb_find()` returns. `lrule->mutex` is per rule while `struct cdb` is
   per list, so another rule's search on the same list can overwrite them in between. Closing that
   window requires returning position and length via out-parameters, which would be an API change.

### Results and Evidence

Reproducer built against the unmodified CDB sources from this branch, full source in #38324. It
creates a `.cdb` with Wazuh's own `cdb_make`, shares one `struct cdb` across N threads exactly as
analysisd does per list, and looks up only keys that are present. Any miss is a defect.

Before, on unmodified `4.14.9` (13-key list, 20,000 lookups per thread), Linux x86_64, gcc -O2:

```
threads=1    lookups=20000      spurious_misses=0        rate=0.0000%
threads=2    lookups=40000      spurious_misses=54       rate=0.1350%
threads=4    lookups=80000      spurious_misses=67       rate=0.0838%
threads=8    lookups=160000     spurious_misses=32010    rate=20.0063%
threads=16   lookups=320000     spurious_misses=64541    rate=20.1691%
```

Same harness on macOS, clang -O2, 8 physical cores:

```
threads=1    lookups=20000      spurious_misses=0        rate=0.0000%
threads=2    lookups=40000      spurious_misses=101      rate=0.2525%
threads=4    lookups=80000      spurious_misses=3700     rate=4.6250%
threads=8    lookups=160000     spurious_misses=6198     rate=3.8737%
threads=16   lookups=320000     spurious_misses=6817     rate=2.1303%
threads=32   lookups=3200000    spurious_misses=70178    rate=2.1931%
```

With a 1000-key list, 8 threads at 50,000 lookups each:

```
threads=8    lookups=400000     spurious_misses=14775    rate=3.6938%
```

After this change, same harness and same inputs, Linux x86_64:

```
threads=1    lookups=20000      spurious_misses=0        rate=0.0000%
threads=2    lookups=40000      spurious_misses=0        rate=0.0000%
threads=4    lookups=80000      spurious_misses=0        rate=0.0000%
threads=8    lookups=160000     spurious_misses=0        rate=0.0000%
threads=16   lookups=320000     spurious_misses=0        rate=0.0000%
```

macOS, extended to 32 threads at 100,000 lookups each:

```
threads=1    lookups=20000      spurious_misses=0        rate=0.0000%
threads=2    lookups=40000      spurious_misses=0        rate=0.0000%
threads=4    lookups=80000      spurious_misses=0        rate=0.0000%
threads=8    lookups=160000     spurious_misses=0        rate=0.0000%
threads=16   lookups=320000     spurious_misses=0        rate=0.0000%
threads=32   lookups=3200000    spurious_misses=0        rate=0.0000%
```

And the 1000-key list at 8 threads:

```
threads=8    lookups=400000     spurious_misses=0        rate=0.0000%
```

The absolute rate before the fix is timing-dependent and varies by platform and list size. What is
stable is that single-threaded is 0 before and after, and 2 or more threads is never 0 before the
fix and always 0 after it.

Single-threaded being 0 is also why `wazuh-logtest` cannot surface this: the `<rule_test>` path is
effectively serialised. Helgrind, DRD and TSan do not flag it either, because every access to the
shared cursor fields is already mutex-protected. The defect is the placement of the critical
section, not a missing lock, so there is no data race for them to detect.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux (`gcc -O2 -pthread`, `cdb.c` plus its CDB dependencies, no warnings)
  - [ ] Windows (not run; `analysisd` is manager-only, and I do not have the full build environment)
  - [x] MAC OS X (`clang -O2 -pthread`, same set, no warnings)
- [x] Log syntax and correct language review (no log strings added or changed)

- Memory tests for Linux
  - [ ] Coverity (not run)
  - [ ] Valgrind (memcheck and descriptor leaks check) (not run on the full binary; the change adds
        no allocation, no descriptor handling and no new control flow, only lock placement)
  - [ ] AddressSanitizer (not run)
- Memory tests for Windows
  - [ ] Coverity (N/A, manager-only code path)
  - [ ] UMDH (N/A, manager-only code path)
- Memory tests for macOS
  - [ ] Leaks (not run)
  - [ ] AddressSanitizer (not run)

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini" (N/A, no decoder or rule content changed)
  - [ ] `runtests.py` executed without errors (not run)

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel (N/A, `src/analysisd/cdb/` does not exist on the 5.x branches)
  - [ ] ASAN for test (utest/ctest) (N/A)
  - [ ] TSAN for test and wazuh-engine (N/A)

- Wazuh server API/Framework
  - [ ] Run API Integration Tests (N/A, no API surface touched)

I have deliberately not ticked boxes for suites I did not run. The evidence I do have is the
before/after reproducer output above, on two platforms and two compilers, plus a behaviour check
that a rule using `lookup="not_match_key"` against a list containing the looked-up key no longer
fires spuriously under load, and that the equivalent `match_key` rule no longer misses.

### Artifacts Affected

- `wazuh-analysisd` (manager only). No other executable, package or default configuration file is
  affected.

### Configuration Changes

N/A. No new configuration parameters, no changed defaults, no backward compatibility concerns.

### Tests Introduced

None in this PR, and I would like guidance on whether you want one.

I could not construct a deterministic single-threaded test that fails before the fix, because
`cdb_find()` resets `c->loop` itself, so the defect only appears under interleaving. A regression
test therefore has to be threaded. As a regression test that is still safe in CI: after the fix it
is deterministic and cannot fail, so the only possible failure mode is a false negative, never a
flaky red. Happy to add it under `src/unit_tests/analysisd/` with a tunable iteration count if you
want it in this PR.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality (see "Tests Introduced" above)
- [x] Configuration changes documented (N/A, none)
- [x] Developer documentation reflects the changes (N/A, no documented behaviour changes)
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

Targeting `4.14.9` because `src/analysisd/cdb/cdb.c` is byte-identical on `master`, `4.14.8` and
`4.14.9`, and does not exist on `5.0.0`, `5.0.1` or `main`. Happy to retarget or backport if you
prefer a different branch.
