### PR TITLE
Agent and manager default connection timing parameters

### DIFF
--- a/.github/actions/check_files/deb_linux_agent_amd64.csv
+++ b/.github/actions/check_files/deb_linux_agent_amd64.csv
@@ -23,7 +23,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libagent_info.so,root,wazuh,750,file,-rwxr-x---,389488,0.1
 /var/ossec/lib/libagent_metadata.so,root,wazuh,750,file,-rwxr-x---,14448,0.1
 /var/ossec/lib/libgcc_s.so.1,root,wazuh,750,file,-rwxr-x---,183248,0.1
-/var/ossec/etc/internal_options.conf,root,wazuh,640,file,-rw-r-----,6576,0.1
+/var/ossec/etc/internal_options.conf,root,wazuh,640,file,-rw-r-----,9604,0.1
 /var/ossec/etc/wpk_root.pem,root,wazuh,640,file,-rw-r-----,1367,0.1
 /var/ossec/etc/localtime,root,wazuh,640,file,-rw-r-----,118,0.1
 /var/ossec/etc/client.keys,root,wazuh,640,file,-rw-r-----,0,0.1

--- a/.github/actions/check_files/deb_linux_agent_i386.csv
+++ b/.github/actions/check_files/deb_linux_agent_i386.csv
@@ -23,7 +23,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libagent_info.so,root,wazuh,750,file,-rwxr-x---,402688,0.1
 /var/ossec/lib/libagent_metadata.so,root,wazuh,750,file,-rwxr-x---,8816,0.1
 /var/ossec/lib/libgcc_s.so.1,root,wazuh,750,file,-rwxr-x---,118632,0.1
-/var/ossec/etc/internal_options.conf,root,wazuh,640,file,-rw-r-----,6576,0.1
+/var/ossec/etc/internal_options.conf,root,wazuh,640,file,-rw-r-----,9604,0.1
 /var/ossec/etc/wpk_root.pem,root,wazuh,640,file,-rw-r-----,1367,0.1
 /var/ossec/etc/localtime,root,wazuh,640,file,-rw-r-----,118,0.1
 /var/ossec/etc/client.keys,root,wazuh,640,file,-rw-r-----,0,0.1

--- a/.github/actions/check_files/rpm_linux_agent_amd64.csv
+++ b/.github/actions/check_files/rpm_linux_agent_amd64.csv
@@ -87,7 +87,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libagent_info.so,root,wazuh,750,file,-rwxr-x---,418344,0.1
 /var/ossec/lib/libagent_metadata.so,root,wazuh,750,file,-rwxr-x---,14472,0.1
 /var/ossec/lib/libgcc_s.so.1,root,wazuh,750,file,-rwxr-x---,187064,0.1
-/var/ossec/etc/internal_options.conf,root,wazuh,640,file,-rw-r-----,6576,0.1
+/var/ossec/etc/internal_options.conf,root,wazuh,640,file,-rw-r-----,9604,0.1
 /var/ossec/etc/wpk_root.pem,root,wazuh,640,file,-rw-r-----,1367,0.1
 /var/ossec/etc/localtime,root,wazuh,640,file,-rw-r-----,118,0.1
 /var/ossec/etc/client.keys,root,wazuh,640,file,-rw-r-----,0,0.1

--- a/.github/actions/check_files/rpm_linux_agent_i386.csv
+++ b/.github/actions/check_files/rpm_linux_agent_i386.csv
@@ -87,7 +87,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libagent_info.so,root,wazuh,750,file,-rwxr-x---,416056,0.1
 /var/ossec/lib/libagent_metadata.so,root,wazuh,750,file,-rwxr-x---,8768,0.1
 /var/ossec/lib/libgcc_s.so.1,root,wazuh,750,file,-rwxr-x---,111408,0.1
-/var/ossec/etc/internal_options.conf,root,wazuh,640,file,-rw-r-----,6576,0.1
+/var/ossec/etc/internal_options.conf,root,wazuh,640,file,-rw-r-----,9604,0.1
 /var/ossec/etc/wpk_root.pem,root,wazuh,640,file,-rw-r-----,1367,0.1
 /var/ossec/etc/localtime,root,wazuh,640,file,-rw-r-----,118,0.1
 /var/ossec/etc/client.keys,root,wazuh,640,file,-rw-r-----,0,0.1

--- a/docs/ref/modules/client/configuration.md
+++ b/docs/ref/modules/client/configuration.md
@@ -316,6 +316,67 @@ agent.min_eps=50
 agent.state_interval=5
 ```
 
+### HTTPS Connection Timing
+
+These control the agent's half of the HTTPS timing contract with the manager. Each one pairs with
+a manager-side deadline, so they should be changed together with the corresponding
+`remoted.*` option rather than on their own — see
+[remoted configuration](../remoted/configuration.md#https-agent-server-remoted_module).
+
+An attempt count is the **total** number of tries, not retries after the first: `1` means "send
+once, never retry". Only retryable failures and back-pressure (`503`) consume an attempt;
+authentication failures, permanent errors and version rejections stop immediately. A step's worst
+case is therefore about `attempts × timeout` plus the jittered backoff between tries — check that
+figure against `<global><agents_disconnection_time>` before raising either.
+
+```ini
+# Per-request budget for /control, /stateless, /stats and /config, in
+# milliseconds (default: 10000, range 1000-600000). Covers DNS, TCP, TLS and
+# transfer -- there is no separate connect or handshake timeout.
+agent.https_request_timeout=10000
+
+# Per-request budget for large transfers: /stateful and both POST /download
+# kinds, config and WPK (default: 90000, range 1000-3600000)
+agent.https_stateful_timeout=90000
+
+# Retry backoff, full jitter: the delay before attempt n is uniform in
+# [0, min(cap, base * 2^n)], reset on success, tracked per stream.
+agent.https_backoff_base=1000
+agent.https_backoff_cap=60000
+
+# Retry cadence for Startup after the manager rejects the agent's version,
+# in seconds (default: 60, range 1-86400)
+agent.https_rejected_retry_interval=60
+
+# Largest WPK accepted by a remote_upgrade download, in bytes
+# (default: 209715200 = 200 MiB)
+agent.https_wpk_max_download_bytes=209715200
+
+# Per-stream retry budgets, total tries (range 1-64)
+agent.https_control_attempts=4
+agent.https_stateless_attempts=5
+agent.https_stateful_attempts=5
+agent.https_download_attempts=2
+
+# Consecutive undeliverable /control steps before event producers pause;
+# one deliverable step releases the pause (default: 2, range 1-1000)
+agent.https_producer_pause_threshold=2
+```
+
+### Enrollment Retry
+
+Not part of the HTTPS request path, but it bounds how long the agent can be held up before it
+next talks to the manager.
+
+```ini
+# Enrollment retry ramp, shared by the initial-enrollment loop and the
+# https_client re-enrollment loop: the delay grows by <delta> seconds after
+# each failed attempt, up to <max>. Both loops read these same two options,
+# so they cannot drift apart.
+agent.enrollment_retry_delta=5
+agent.enrollment_retry_max=60
+```
+
 ### Buffer Settings
 
 ```ini

--- a/docs/ref/modules/inventory-sync-server/configuration.md
+++ b/docs/ref/modules/inventory-sync-server/configuration.md
@@ -331,6 +331,21 @@ wazuh_modules.inventory_sync_server_vd_scan_queue_slots=0
 
 ---
 
+### wazuh_modules.inventory_sync_server_session_query_batch_size
+
+Indexer search page size used while draining a session.
+
+```ini
+wazuh_modules.inventory_sync_server_session_query_batch_size=0
+```
+
+- **Default value:** `0` (1000 documents)
+- **Allowed values:** 0 to 100000
+- **Note:** Larger pages mean fewer round-trips to the indexer but a bigger response held in memory
+  per query.
+
+---
+
 ### Indexer connectors (`indexer_sync_*` and `indexer_async_*`)
 
 The module builds BOTH a synchronous and an asynchronous connector over one shared indexer session, and

--- a/docs/ref/modules/remoted/configuration.md
+++ b/docs/ref/modules/remoted/configuration.md
@@ -743,6 +743,70 @@ see [HTTPS Events API](https-events-api.md#content-encoding-zstd).
 - **Default value:** `10485760` (10 MiB)
 - **Allowed values:** Integer from `1048576` (1 MiB) to `67108864` (64 MiB)
 
+#### remoted.control_keepalive_throttle
+
+Minimum seconds between two wazuh-db keepalive writes for the same agent. `notify` requests
+arriving faster than this are answered normally but absorbed in memory without touching the
+database.
+
+- **Default value:** `60`
+- **Allowed values:** Integer from `1` to `3600`
+- **Note:** This must stay at or above the agent's notify cadence, or every notify becomes a
+  database write. It must also stay well below `<global><agents_disconnection_time>` (default
+  `15m`), since a throttled notify is what refreshes `last_keepalive` -- set the throttle above
+  the disconnection time and active agents are reported as disconnected.
+
+#### remoted.control_groups_refresh_interval
+
+Seconds between refreshes of the cached shared-group listing used to answer `/control`.
+
+- **Default value:** `60`
+- **Allowed values:** Integer from `1` to `3600`
+- **Note:** This is the propagation latency an agent sees for a centralised-configuration change.
+
+#### remoted.control_wdb_request_connections
+
+Size of the wazuh-db connection pool the control plane uses.
+
+- **Default value:** `4`
+- **Allowed values:** Integer from `1` to `64`
+
+#### remoted.control_wdb_roundtrip_deadline
+
+Milliseconds a single wazuh-db round-trip may take before the control handler gives up.
+
+- **Default value:** `2000`
+- **Allowed values:** Integer from `100` to `30000`
+- **Note:** Exceeding it surfaces to the agent as a `503` on `/control`.
+
+#### remoted.control_wdb_max_queue_size
+
+High-water mark for queued wazuh-db requests; over it the handler reports QueueFull.
+
+- **Default value:** `10000`
+- **Allowed values:** Integer from `100` to `1000000`
+
+#### remoted.control_tm_concurrency
+
+Concurrent task-manager requests the control plane may have in flight.
+
+- **Default value:** `4`
+- **Allowed values:** Integer from `1` to `64`
+
+#### remoted.control_tm_deadline
+
+Milliseconds a single task-manager round-trip may take.
+
+- **Default value:** `2000`
+- **Allowed values:** Integer from `100` to `30000`
+
+#### remoted.control_tm_max_queue_size
+
+High-water mark for queued task-manager requests.
+
+- **Default value:** `10000`
+- **Allowed values:** Integer from `100` to `1000000`
+
 ---
 
 ## Configuration Examples

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -140,6 +140,58 @@ agent.state_interval=5
 # Maximum time waiting for a server response in TCP (seconds) [1..600]
 agent.recv_timeout=60
 
+# HTTPS agent<->manager connection timing. These are one half of a contract with
+# the manager: raising a timeout or an attempt count here without checking the
+# manager's own deadlines (remoted.http_request_timeout and the downstream chain
+# behind it) is what produces retries against requests the manager still goes on
+# to complete. Change them in pairs, on both sides.
+
+# Per-request budget for /control, /stateless, /stats and /config, in
+# milliseconds [1000..600000]. Covers DNS, TCP, TLS and transfer -- curl is
+# given no separate connect or handshake timeout.
+agent.https_request_timeout=10000
+# Per-request budget for the large transfers -- /stateful and both POST
+# /download kinds (shared configuration and WPK) -- in milliseconds
+# [1000..3600000]
+agent.https_stateful_timeout=90000
+# Retry backoff, full jitter: the delay before attempt n is uniform in
+# [0, min(cap, base * 2^n)], reset on success, tracked per stream.
+# Base, in milliseconds [100..60000]
+agent.https_backoff_base=1000
+# Cap, in milliseconds [1000..3600000]
+agent.https_backoff_cap=60000
+# How often to retry Startup after the manager rejects the agent's version,
+# in seconds [1..86400]
+agent.https_rejected_retry_interval=60
+# Largest WPK accepted by a remote_upgrade download, in bytes
+# [1048576..2147483647]
+agent.https_wpk_max_download_bytes=209715200
+
+# Per-stream retry budgets, counted as TOTAL tries: 1 means "send once, never
+# retry". Only retryable failures and back-pressure (503) consume an attempt;
+# authentication failures, permanent errors and version rejections stop
+# immediately. A step's worst case is about attempts x the matching timeout
+# above, plus the backoff between tries.
+# /control [1..64]
+agent.https_control_attempts=4
+# /stateless [1..64]
+agent.https_stateless_attempts=5
+# /stateful [1..64]
+agent.https_stateful_attempts=5
+# POST /download, configuration and WPK alike [1..64]
+agent.https_download_attempts=2
+# Consecutive undeliverable /control steps before event producers are paused;
+# one deliverable step releases the pause [1..1000]
+agent.https_producer_pause_threshold=2
+
+# Enrollment retry ramp, shared by the initial-enrollment loop and the
+# https_client re-enrollment loop: the delay grows by <delta> after each failed
+# attempt, up to <max>.
+# Increment in seconds [1..3600]
+agent.enrollment_retry_delta=5
+# Cap in seconds [1..86400]
+agent.enrollment_retry_max=60
+
 # TCP keepalive options for agent->manager connections
 # Time (in seconds) the connection needs to remain idle before TCP starts sending keepalive probes [1..7200]
 agent.tcp_keepidle=60

--- a/src/client-agent/https_client/include/https_client.h
+++ b/src/client-agent/https_client/include/https_client.h
@@ -152,10 +152,25 @@ typedef struct hc_config_t
 
     uint32_t request_timeout_ms;  ///< Per request; 0 -> 10000.
     uint32_t stateful_timeout_ms; ///< Large transfers (/stateful, /download);
-    ///< 0 -> 120000.
+    ///< 0 -> 90000.
     uint32_t backoff_base_ms;     ///< Full-jitter base; 0 -> 1000.
     uint32_t backoff_cap_ms;      ///< Full-jitter cap; 0 -> 60000.
     uint32_t drain_timeout_ms;    ///< Shutdown drain window; 0 -> 5000.
+
+    /* Per-stream retry budgets. An attempt count is the TOTAL number of tries,
+     * not the number of retries after the first: 1 means "send once, never
+     * retry". Only Retryable and BackPressure outcomes consume an attempt.
+     * These bound how long one step can take against the manager's own
+     * deadlines, so they are part of the agent/manager timing contract rather
+     * than free-form tuning. */
+    uint32_t control_max_attempts;    ///< /control; 0 -> 4.
+    uint32_t stateless_max_attempts;  ///< /stateless; 0 -> 5.
+    uint32_t stateful_max_attempts;   ///< /stateful; 0 -> 5.
+    uint32_t download_max_attempts;   ///< POST /download, config and WPK alike; 0 -> 2.
+
+    /// Consecutive undeliverable /control steps before event producers are
+    /// paused; a single deliverable step resets the streak. 0 -> 2.
+    uint32_t producer_pause_threshold;
 
     char spool_dir[HC_MAX_PATH];  ///< Spool dir for temp files; empty -> system tmp.
 

--- a/src/client-agent/https_client/src/configFetcher.cpp
+++ b/src/client-agent/https_client/src/configFetcher.cpp
@@ -18,9 +18,6 @@
 
 namespace
 {
-    /// Few attempts on purpose: the next Notify re-arms a failed fetch.
-    constexpr uint32_t DOWNLOAD_MAX_ATTEMPTS = 2;
-
     /// Safety bound for a config download: merged.mg is normally KB-scale, so
     /// this only exists to stop a hostile or faulty manager exhausting the disk.
     constexpr uint64_t CONFIG_MAX_DOWNLOAD_BYTES = 64ULL * 1024 * 1024;
@@ -76,7 +73,7 @@ std::shared_ptr<SpoolFile> ConfigFetcher::fetch(const std::string& expectedHash,
     LOGFN_DEBUG2(m_logFn, "Sending /download (resource_type=config, resource_id='%s').",
                  group.c_str());
 
-    const auto result = m_sender.send(spec, waiter, DOWNLOAD_MAX_ATTEMPTS);
+    const auto result = m_sender.send(spec, waiter, m_config.downloadMaxAttempts);
 
     if (result.outcome != OutcomeClass::Ok)
     {

--- a/src/client-agent/https_client/src/controlStream.cpp
+++ b/src/client-agent/https_client/src/controlStream.cpp
@@ -19,11 +19,6 @@
 
 namespace
 {
-    constexpr uint32_t CONTROL_MAX_ATTEMPTS = 4;
-
-    // Consecutive undeliverable `/control` outcomes before producers are paused.
-    constexpr uint32_t CONTROL_UNDELIVERABLE_THRESHOLD = 2;
-
     HttpRequestSpec controlSpec(const std::string& body, uint32_t timeoutMs)
     {
         HttpRequestSpec spec;
@@ -277,7 +272,7 @@ OutcomeClass ControlStream::sendStartup(Waiter& waiter)
     LOGFN_DEBUG2(m_logFn, "Sending /control startup.");
 
     const auto result = m_sender.send(controlSpec(body, m_config.requestTimeoutMs), waiter,
-                                      CONTROL_MAX_ATTEMPTS);
+                                      m_config.controlMaxAttempts);
     updateLocalIp(result.response);
 
     if (result.outcome == OutcomeClass::Ok)
@@ -339,7 +334,7 @@ OutcomeClass ControlStream::sendNotify(Waiter& waiter)
     LOGFN_DEBUG2(m_logFn, "Sending /control notify.");
 
     const auto result = m_sender.send(controlSpec(body, m_config.requestTimeoutMs), waiter,
-                                      CONTROL_MAX_ATTEMPTS);
+                                      m_config.controlMaxAttempts);
     updateLocalIp(result.response);
     const auto effects = m_machine.onEvent(eventFor(result.outcome));
     applyEffects(effects, {});
@@ -633,18 +628,18 @@ void ControlStream::updateProducerPause(OutcomeClass outcome)
         return;
     }
 
-    if (++m_undeliverableStreak < CONTROL_UNDELIVERABLE_THRESHOLD)
+    if (++m_undeliverableStreak < m_config.producerPauseThreshold)
     {
         LOGFN_DEBUG1(m_logFn, "/control undeliverable (%s) (%u/%u).",
                      outcomeName(outcome), m_undeliverableStreak,
-                     CONTROL_UNDELIVERABLE_THRESHOLD);
+                     m_config.producerPauseThreshold);
         return;
     }
 
     m_producersPaused = true;
     LOGFN_DEBUG1(m_logFn, "/control undeliverable (%s) (%u/%u); pausing event production.",
                  outcomeName(outcome), m_undeliverableStreak,
-                 CONTROL_UNDELIVERABLE_THRESHOLD);
+                 m_config.producerPauseThreshold);
     m_sink.onProducerPause(true);
 }
 

--- a/src/client-agent/https_client/src/moduleConfig.cpp
+++ b/src/client-agent/https_client/src/moduleConfig.cpp
@@ -57,10 +57,15 @@ ModuleConfig ModuleConfig::fromC(const hc_config_t& config)
     typed.version = boundedString(config.version, sizeof(config.version));
     typed.configChecksum = boundedString(config.config_checksum, sizeof(config.config_checksum));
     typed.requestTimeoutMs = orDefault<uint32_t>(config.request_timeout_ms, 10000);
-    typed.statefulTimeoutMs = orDefault<uint32_t>(config.stateful_timeout_ms, 120000);
+    typed.statefulTimeoutMs = orDefault<uint32_t>(config.stateful_timeout_ms, 90000);
     typed.backoffBaseMs = orDefault<uint32_t>(config.backoff_base_ms, 1000);
     typed.backoffCapMs = orDefault<uint32_t>(config.backoff_cap_ms, 60000);
     typed.drainTimeoutMs = orDefault<uint32_t>(config.drain_timeout_ms, 5000);
+    typed.controlMaxAttempts = orDefault<uint32_t>(config.control_max_attempts, 4);
+    typed.statelessMaxAttempts = orDefault<uint32_t>(config.stateless_max_attempts, 5);
+    typed.statefulMaxAttempts = orDefault<uint32_t>(config.stateful_max_attempts, 5);
+    typed.downloadMaxAttempts = orDefault<uint32_t>(config.download_max_attempts, 2);
+    typed.producerPauseThreshold = orDefault<uint32_t>(config.producer_pause_threshold, 2);
     typed.spoolDir = boundedString(config.spool_dir, sizeof(config.spool_dir));
     typed.syncSocketPath = boundedString(config.sync_socket_path, sizeof(config.sync_socket_path));
     typed.httpsCompressionEnabled = config.https_compression_enabled;
@@ -75,7 +80,26 @@ bool ModuleConfig::validate(const IFsProbe& fsProbe, const LogFn& logFn) const
         return false;
     }
 
-    return validateTls(fsProbe, logFn) && validateClientCert(fsProbe, logFn);
+    return validateTiming(logFn) && validateTls(fsProbe, logFn) && validateClientCert(fsProbe, logFn);
+}
+
+bool ModuleConfig::validateTiming(const LogFn& logFn) const
+{
+    // Paired internal options: getDefine_Int_default() range-checks each one on its own, but
+    // nothing relates the two, so an inverted pair is reachable from two individually valid
+    // values. Rejected rather than silently reordered -- an inverted min/max is always an
+    // operator error, and starting with a quietly corrected value hides it.
+    if (backoffBaseMs > backoffCapMs)
+    {
+        LOGFN_ERROR(logFn,
+                    "Config rejected: agent.https_backoff_base (%u) is above "
+                    "agent.https_backoff_cap (%u).",
+                    backoffBaseMs,
+                    backoffCapMs);
+        return false;
+    }
+
+    return true;
 }
 
 bool ModuleConfig::validateTls(const IFsProbe& fsProbe, const LogFn& logFn) const

--- a/src/client-agent/https_client/src/moduleConfig.hpp
+++ b/src/client-agent/https_client/src/moduleConfig.hpp
@@ -60,10 +60,20 @@ struct ModuleConfig
         std::string configChecksum;
 
         uint32_t requestTimeoutMs {10000};
-        uint32_t statefulTimeoutMs {120000};
+        uint32_t statefulTimeoutMs {90000};
         uint32_t backoffBaseMs {1000};
         uint32_t backoffCapMs {60000};
         uint32_t drainTimeoutMs {5000};
+
+        // Per-stream retry budgets (total tries, not retries-after-the-first).
+        // Consumed only by Retryable/BackPressure outcomes.
+        uint32_t controlMaxAttempts {4};
+        uint32_t statelessMaxAttempts {5};
+        uint32_t statefulMaxAttempts {5};
+        uint32_t downloadMaxAttempts {2};
+
+        /// Consecutive undeliverable /control steps before producers pause.
+        uint32_t producerPauseThreshold {2};
 
         std::string spoolDir;
 
@@ -92,6 +102,7 @@ struct ModuleConfig
         std::string baseUrl() const;
 
     private:
+        bool validateTiming(const LogFn& logFn) const;
         bool validateTls(const IFsProbe& fsProbe, const LogFn& logFn) const;
         bool validateClientCert(const IFsProbe& fsProbe, const LogFn& logFn) const;
 };

--- a/src/client-agent/https_client/src/statefulStream.cpp
+++ b/src/client-agent/https_client/src/statefulStream.cpp
@@ -15,7 +15,6 @@
 
 namespace
 {
-    constexpr uint32_t STATEFUL_MAX_ATTEMPTS = 5;
     constexpr size_t STATEFUL_MAX_QUEUE = 64;
 } // namespace
 
@@ -194,7 +193,7 @@ StatefulStream::SendResult StatefulStream::sendSession(const Session& session, W
                      static_cast<unsigned long long>(session.size));
     }
 
-    const auto result = m_sender.send(spec, waiter, STATEFUL_MAX_ATTEMPTS);
+    const auto result = m_sender.send(spec, waiter, m_config.statefulMaxAttempts);
     // The /stateful contract is interpreted from the raw HTTP status code and body by
     // agent_sync_protocol, not from the shared D9 OutcomeClass (see SendResult::httpCode).
     // result.response.httpCode is 0 when no HTTP response was received (m_sender's retry

--- a/src/client-agent/https_client/src/statelessStream.cpp
+++ b/src/client-agent/https_client/src/statelessStream.cpp
@@ -15,8 +15,6 @@
 
 namespace
 {
-    constexpr uint32_t STATELESS_MAX_ATTEMPTS = 5;
-
     /// Builds the H metadata line that opens every /stateless body (#37732).
     ///
     /// Always carries wazuh.agent.id -- statelessEndpoint.cpp's
@@ -132,7 +130,7 @@ std::chrono::milliseconds StatelessStream::tick(Waiter& waiter, bool force)
     // waits and retries on this stream's own thread; the next flush is thus
     // naturally deferred while the accumulator (fed by the intake thread) keeps
     // absorbing (D5/D6).
-    if (flushDue(force) && flushOnce(waiter, m_config.requestTimeoutMs, STATELESS_MAX_ATTEMPTS)
+    if (flushDue(force) && flushOnce(waiter, m_config.requestTimeoutMs, m_config.statelessMaxAttempts)
             && flushDue(false))
     {
         // Keep draining back-to-back while a backlog stays above the threshold.

--- a/src/client-agent/https_client/src/wpkFetcher.cpp
+++ b/src/client-agent/https_client/src/wpkFetcher.cpp
@@ -18,12 +18,6 @@
 
 namespace
 {
-    /// Few attempts on purpose, matching ConfigFetcher: a WPK is fetched once
-    /// per task_id (the durable registry already guarantees that), so there
-    /// is no "next notify re-arms it" safety net here -- a failed download
-    /// simply aborts the upgrade (fire-and-forget).
-    constexpr uint32_t WPK_DOWNLOAD_MAX_ATTEMPTS = 2;
-
     std::string lowered(std::string value)
     {
         std::transform(value.begin(), value.end(), value.begin(),
@@ -67,7 +61,7 @@ std::shared_ptr<SpoolFile> WpkFetcher::fetch(const std::string& wpkFile,
     spec.maxResponseBytes = m_config.wpkMaxDownloadBytes;
     spec.timeoutMs = m_config.statefulTimeoutMs; // The large-transfer class.
 
-    const auto result = m_sender.send(spec, waiter, WPK_DOWNLOAD_MAX_ATTEMPTS);
+    const auto result = m_sender.send(spec, waiter, m_config.downloadMaxAttempts);
 
     if (result.outcome != OutcomeClass::Ok)
     {

--- a/src/client-agent/https_client/tests/unit/moduleConfig_test.cpp
+++ b/src/client-agent/https_client/tests/unit/moduleConfig_test.cpp
@@ -44,11 +44,16 @@ TEST(ModuleConfigTest, DefaultsAppliedOnZeroFields)
     EXPECT_EQ(10u, typed.notifyIntervalS);
     EXPECT_EQ(60u, typed.rejectedRetryIntervalS);
     EXPECT_EQ(10000u, typed.requestTimeoutMs);
-    EXPECT_EQ(120000u, typed.statefulTimeoutMs);
+    EXPECT_EQ(90000u, typed.statefulTimeoutMs);
     EXPECT_EQ(1000u, typed.backoffBaseMs);
     EXPECT_EQ(60000u, typed.backoffCapMs);
     EXPECT_EQ(5000u, typed.drainTimeoutMs);
     EXPECT_EQ(200ULL * 1024 * 1024, typed.wpkMaxDownloadBytes);
+    EXPECT_EQ(4u, typed.controlMaxAttempts);
+    EXPECT_EQ(5u, typed.statelessMaxAttempts);
+    EXPECT_EQ(5u, typed.statefulMaxAttempts);
+    EXPECT_EQ(2u, typed.downloadMaxAttempts);
+    EXPECT_EQ(2u, typed.producerPauseThreshold);
     EXPECT_FALSE(typed.statsEnabled);
     EXPECT_EQ(60u, typed.statsIntervalS);
     EXPECT_FALSE(typed.configReportEnabled);
@@ -68,10 +73,28 @@ TEST(ModuleConfigTest, ExplicitValuesAreKept)
     config.server_port = 27840;
     config.batch_size_bytes = 2048;
     config.notify_interval_s = 5;
+    config.request_timeout_ms = 25000;
+    config.stateful_timeout_ms = 300000;
+    config.backoff_base_ms = 500;
+    config.backoff_cap_ms = 30000;
+    config.control_max_attempts = 2;
+    config.stateless_max_attempts = 3;
+    config.stateful_max_attempts = 3;
+    config.download_max_attempts = 1;
+    config.producer_pause_threshold = 5;
     const auto typed = ModuleConfig::fromC(config);
     EXPECT_EQ(27840, typed.serverPort);
     EXPECT_EQ(2048u, typed.batchSizeBytes);
     EXPECT_EQ(5u, typed.notifyIntervalS);
+    EXPECT_EQ(25000u, typed.requestTimeoutMs);
+    EXPECT_EQ(300000u, typed.statefulTimeoutMs);
+    EXPECT_EQ(500u, typed.backoffBaseMs);
+    EXPECT_EQ(30000u, typed.backoffCapMs);
+    EXPECT_EQ(2u, typed.controlMaxAttempts);
+    EXPECT_EQ(3u, typed.statelessMaxAttempts);
+    EXPECT_EQ(3u, typed.statefulMaxAttempts);
+    EXPECT_EQ(1u, typed.downloadMaxAttempts);
+    EXPECT_EQ(5u, typed.producerPauseThreshold);
 }
 
 TEST(ModuleConfigTest, UnterminatedFixedFieldIsBounded)
@@ -167,6 +190,30 @@ TEST(ModuleConfigTest, NoneModeIsValidWithoutCa)
 {
     NiceMock<MockFsProbe> fsProbe;
     EXPECT_TRUE(ModuleConfig::fromC(minimalConfig()).validate(fsProbe, TEST_LOG));
+}
+
+// -----------------------------------------------------------------------------
+// Paired timing options. getDefine_Int_default() range-checks each option on its
+// own, so an inverted pair is reachable from two individually valid values --
+// nothing else relates them.
+// -----------------------------------------------------------------------------
+
+TEST(ModuleConfigTest, ValidateRejectsInvertedBackoffBounds)
+{
+    NiceMock<MockFsProbe> fsProbe;
+    auto config = minimalConfig();
+    config.backoff_base_ms = 60000;
+    config.backoff_cap_ms = 1000;
+    EXPECT_FALSE(ModuleConfig::fromC(config).validate(fsProbe, TEST_LOG));
+}
+
+TEST(ModuleConfigTest, ValidateAcceptsEqualPairedBounds)
+{
+    NiceMock<MockFsProbe> fsProbe;
+    auto config = minimalConfig();
+    config.backoff_base_ms = 2000;
+    config.backoff_cap_ms = 2000;
+    EXPECT_TRUE(ModuleConfig::fromC(config).validate(fsProbe, TEST_LOG));
 }
 
 TEST(ModuleConfigTest, ClientCertRequiresBothHalves)

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -109,11 +109,12 @@ static bool bridge_stopping(void)
     return stopping;
 }
 
-/* Mirrors the incremental back-off already used for the initial-enrollment
- * loop (start_agent.c's w_agentd_keys_init: 5s steps up to a 60s cap). Not
- * reused directly because those constants are file-local to start_agent.c. */
-#define BRIDGE_REENROLL_RETRY_DELTA_S 5
-#define BRIDGE_REENROLL_RETRY_MAX_S 60
+/* Same incremental back-off as the initial-enrollment loop (start_agent.c's
+ * w_agentd_keys_init). Both read the same two internal options, so the two
+ * loops can no longer drift apart -- which is what the duplicated file-local
+ * constants used to risk. */
+#define BRIDGE_REENROLL_RETRY_DELTA_S_DEFAULT 5
+#define BRIDGE_REENROLL_RETRY_MAX_S_DEFAULT 60
 
 /* Runs off the dispatcher thread (spawned by bridge_on_reenroll_required):
  * the module's callback contract forbids blocking it, and enrollment can
@@ -151,8 +152,12 @@ void *bridge_reenroll_thread(void *arg)
         }
 
         if (enroll_result != 0) {
-            if (delay_sleep < BRIDGE_REENROLL_RETRY_MAX_S) {
-                delay_sleep += BRIDGE_REENROLL_RETRY_DELTA_S;
+            const int retry_max = getDefine_Int_default("agent", "enrollment_retry_max", 1, 86400,
+                                                       BRIDGE_REENROLL_RETRY_MAX_S_DEFAULT);
+            const int retry_delta = getDefine_Int_default("agent", "enrollment_retry_delta", 1, 3600,
+                                                         BRIDGE_REENROLL_RETRY_DELTA_S_DEFAULT);
+            if (delay_sleep < retry_max) {
+                delay_sleep += retry_delta;
             }
             mdebug1("https_client: re-enrollment attempt failed; retrying in %d seconds.", delay_sleep);
             sleep((unsigned int)delay_sleep);
@@ -1618,6 +1623,37 @@ static bool bridge_build_config(hc_config_t *config)
     config->stats_interval_s = (uint32_t)agt->stats_report.interval;
     config->config_report_enabled = agt->config_report.enabled;
     config->config_report_interval_s = (uint32_t)agt->config_report.interval;
+
+    /* Connection timing contract (#38284). Every value below used to be a
+     * compile-time constant the bridge never populated, so the agreed
+     * agent<->manager defaults could only be changed by rebuilding. They are
+     * internal options now; getDefine_Int_default() keeps the module's own
+     * fallback reachable, so a stripped internal_options.conf cannot stop the
+     * agent from starting (getDefine_Int would merror_exit instead).
+     *
+     * The module reads 0 as "use my default", and the defaults below are the
+     * same numbers, so an unset option and an explicit default agree. */
+    config->request_timeout_ms =
+        (uint32_t)getDefine_Int_default("agent", "https_request_timeout", 1000, 600000, 10000);
+    config->stateful_timeout_ms =
+        (uint32_t)getDefine_Int_default("agent", "https_stateful_timeout", 1000, 3600000, 90000);
+    config->backoff_base_ms = (uint32_t)getDefine_Int_default("agent", "https_backoff_base", 100, 60000, 1000);
+    config->backoff_cap_ms = (uint32_t)getDefine_Int_default("agent", "https_backoff_cap", 1000, 3600000, 60000);
+    config->rejected_retry_interval_s =
+        (uint32_t)getDefine_Int_default("agent", "https_rejected_retry_interval", 1, 86400, 60);
+    config->wpk_max_download_bytes =
+        (uint64_t)getDefine_Int_default("agent", "https_wpk_max_download_bytes", 1048576, 2147483647, 209715200);
+
+    /* Per-stream retry budgets: TOTAL tries, so 1 means "never retry". A step's
+     * worst case is roughly attempts x its timeout plus the jittered backoff
+     * between them, which is what has to stay inside the manager's own
+     * deadlines -- raise these together with the timeouts above, not alone. */
+    config->control_max_attempts = (uint32_t)getDefine_Int_default("agent", "https_control_attempts", 1, 64, 4);
+    config->stateless_max_attempts = (uint32_t)getDefine_Int_default("agent", "https_stateless_attempts", 1, 64, 5);
+    config->stateful_max_attempts = (uint32_t)getDefine_Int_default("agent", "https_stateful_attempts", 1, 64, 5);
+    config->download_max_attempts = (uint32_t)getDefine_Int_default("agent", "https_download_attempts", 1, 64, 2);
+    config->producer_pause_threshold =
+        (uint32_t)getDefine_Int_default("agent", "https_producer_pause_threshold", 1, 1000, 2);
 
     /* Occupancy ladder: the same internal options the legacy client buffer
      * read, so tuned thresholds keep working. */

--- a/src/client-agent/src/start_agent.c
+++ b/src/client-agent/src/start_agent.c
@@ -24,8 +24,8 @@
     #define STATIC static
 #endif
 
-#define ENROLLMENT_RETRY_TIME_MAX   60
-#define ENROLLMENT_RETRY_TIME_DELTA 5
+#define ENROLLMENT_RETRY_TIME_MAX_DEFAULT   60
+#define ENROLLMENT_RETRY_TIME_DELTA_DEFAULT 5
 
 static void w_agentd_keys_init (void);
 STATIC void send_msg_on_startup(void);
@@ -86,8 +86,12 @@ static void w_agentd_keys_init (void) {
 
                 /* Sleep between retries */
                 if (registration_status != 0) {
-                    if (delay_sleep < ENROLLMENT_RETRY_TIME_MAX) {
-                        delay_sleep += ENROLLMENT_RETRY_TIME_DELTA;
+                    const int retry_max = getDefine_Int_default("agent", "enrollment_retry_max", 1, 86400,
+                                                               ENROLLMENT_RETRY_TIME_MAX_DEFAULT);
+                    const int retry_delta = getDefine_Int_default("agent", "enrollment_retry_delta", 1, 3600,
+                                                                 ENROLLMENT_RETRY_TIME_DELTA_DEFAULT);
+                    if (delay_sleep < retry_max) {
+                        delay_sleep += retry_delta;
                     }
                     mdebug1("Sleeping %d seconds before trying to enroll again", delay_sleep);
                     sleep(delay_sleep);

--- a/src/remoted/remoted_module/include/remoted_module.h
+++ b/src/remoted/remoted_module/include/remoted_module.h
@@ -167,6 +167,8 @@ extern "C"
         int tm_concurrency;              ///< Task Manager concurrency limit (<=0 -> 10).
         int tm_deadline_ms;              ///< Task Manager per-request deadline in milliseconds (<=0 -> 200).
         int tm_max_queue_size; ///< Task Manager request queue high-water mark; QueueFull over it (<=0 -> 10000).
+        int keepalive_throttle_sec; ///< Minimum seconds between two wazuh-db keepalive writes for the same agent;
+                                    ///< notifies arriving faster are absorbed in memory (<=0 -> 60).
     } remoted_module_config_t;
 
     /**

--- a/src/remoted/remoted_module/src/control/controlConfig.cpp
+++ b/src/remoted/remoted_module/src/control/controlConfig.cpp
@@ -58,6 +58,11 @@ namespace remoted::control
             cfg.tmMaxQueueSize = static_cast<uint32_t>(c.tm_max_queue_size);
         }
 
+        if (c.keepalive_throttle_sec > 0)
+        {
+            cfg.keepaliveThrottleSec = static_cast<uint32_t>(c.keepalive_throttle_sec);
+        }
+
         if (std::strlen(c.limits_json) > 0)
         {
             try

--- a/src/remoted/remoted_module/test/unit/controlConfig_test.cpp
+++ b/src/remoted/remoted_module/test/unit/controlConfig_test.cpp
@@ -97,6 +97,7 @@ TEST(ControlConfigTest, PositiveOverridesReplaceDefaults)
     raw.tm_concurrency = 20;
     raw.tm_deadline_ms = 500;
     raw.tm_max_queue_size = 20000;
+    raw.keepalive_throttle_sec = 15;
 
     const auto cfg = buildControlConfig(raw);
 
@@ -107,6 +108,7 @@ TEST(ControlConfigTest, PositiveOverridesReplaceDefaults)
     EXPECT_EQ(cfg.tmConcurrency, 20U);
     EXPECT_EQ(cfg.tmDeadlineMs, 500U);
     EXPECT_EQ(cfg.tmMaxQueueSize, 20000U);
+    EXPECT_EQ(cfg.keepaliveThrottleSec, 15U);
 }
 
 // -----------------------------------------------------------------------------
@@ -125,6 +127,7 @@ TEST(ControlConfigTest, NonPositiveValuesFallBackToDefaults)
     raw.tm_concurrency = -1;
     raw.tm_deadline_ms = -1;
     raw.tm_max_queue_size = -1;
+    raw.keepalive_throttle_sec = -1;
 
     const auto cfg = buildControlConfig(raw);
 
@@ -135,6 +138,7 @@ TEST(ControlConfigTest, NonPositiveValuesFallBackToDefaults)
     EXPECT_EQ(cfg.tmConcurrency, kTmConcurrency);
     EXPECT_EQ(cfg.tmDeadlineMs, kTmDeadlineMs);
     EXPECT_EQ(cfg.tmMaxQueueSize, kTaskMaxQueueSize);
+    EXPECT_EQ(cfg.keepaliveThrottleSec, kKeepaliveThrottleSec);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/remoted/src/secure.c
+++ b/src/remoted/src/secure.c
@@ -419,6 +419,12 @@ STATIC void remoted_module_control_config(remoted_module_config_t *rm_config) {
     rm_config->tm_deadline_ms = getDefine_Int_default("remoted", "control_tm_deadline", 100, 30000, 2000);
     rm_config->tm_max_queue_size = getDefine_Int_default("remoted", "control_tm_max_queue_size", 100, 1000000, 10000);
 
+    // Keepalive write throttle: the manager half of the agent/manager timing contract. It bounds
+    // how often a notify reaches wazuh-db, so the wazuh-db write load it produces scales with the
+    // fleet -- it has to be settable before any notify cadence is agreed with the agent, and it
+    // must stay above whatever cadence the agent ships.
+    rm_config->keepalive_throttle_sec = getDefine_Int_default("remoted", "control_keepalive_throttle", 1, 3600, 60);
+
     extern module_limits_t manager_module_limits;
     extern bool manager_module_limits_enabled;
 

--- a/src/wazuh_modules/inventory_sync_server/include/inventory_sync_server.h
+++ b/src/wazuh_modules/inventory_sync_server/include/inventory_sync_server.h
@@ -248,6 +248,11 @@ extern "C"
          */
         long long indexer_async_max_queue_bytes;
 
+        /// Indexer search page size while draining a session. Larger pages mean fewer round trips
+        /// per session at a proportionally larger response to hold in memory, so the right value
+        /// follows the indexer's sizing rather than this module's. <=0 -> 1000.
+        int session_query_batch_size;
+
         /* ---- Nested, opaque ---- */
         /**
          * @brief The <indexer> configuration block, verbatim, as nested cJSON.

--- a/src/wazuh_modules/inventory_sync_server/src/inventorySyncServerFacade.hpp
+++ b/src/wazuh_modules/inventory_sync_server/src/inventorySyncServerFacade.hpp
@@ -855,6 +855,7 @@ namespace invsync
                 pipelineConfig.bulkFlushBytes = m_config.indexer_sync_max_bulk_size > 0
                                                     ? static_cast<std::size_t>(m_config.indexer_sync_max_bulk_size)
                                                     : DEFAULT_BULK_FLUSH_BYTES;
+                pipelineConfig.sessionQueryBatchSize = m_config.session_query_batch_size;
                 pipelineClusterName = invsync::common::buildClusterIdentity(m_config).clusterName;
 
                 if (needSession || needSync || needAsync || needPipeline)

--- a/src/wazuh_modules/inventory_sync_server/src/sync/sessionProcessor.cpp
+++ b/src/wazuh_modules/inventory_sync_server/src/sync/sessionProcessor.cpp
@@ -57,19 +57,19 @@ namespace
     /**
      * @brief Checksum-of-checksums, ported from the legacy facade (inventorySyncFacade.hpp:434-503).
      *
-     * Pages the agent's documents by `checksum.hash.sha1 asc` (search_after, batches of 1000),
-     * concatenates the checksums in that order and hashes the concatenation. The query shape and
-     * the ordering are the CONTRACT with what the agent computes locally, so they are kept
-     * byte-identical.
+     * Pages the agent's documents by `checksum.hash.sha1 asc` (search_after, batches of
+     * @p batchSize), concatenates the checksums in that order and hashes the concatenation. The
+     * query shape and the ordering are the CONTRACT with what the agent computes locally, so they
+     * are kept byte-identical.
      */
     std::string calculateChecksumOfChecksums(invsync::indexer::IIndexerConnectorSync& connector,
                                              const std::string& index,
                                              const std::string& agentId,
-                                             const std::string& clusterName)
+                                             const std::string& clusterName,
+                                             std::size_t batchSize)
     {
         std::string concatenatedChecksums;
         std::string searchAfter;
-        constexpr std::size_t BATCH_SIZE = 1000;
 
         while (true)
         {
@@ -78,7 +78,7 @@ namespace
             invsync::sync::querybuilder::addClusterScope(searchQuery, clusterName);
             searchQuery["_source"] = nlohmann::json::array({"checksum.hash.sha1"});
             searchQuery["sort"] = nlohmann::json::array({nlohmann::json::object({{"checksum.hash.sha1", "asc"}})});
-            searchQuery["size"] = BATCH_SIZE;
+            searchQuery["size"] = batchSize;
 
             if (!searchAfter.empty())
             {
@@ -108,7 +108,7 @@ namespace
                 }
             }
 
-            if (hits.size() < BATCH_SIZE)
+            if (hits.size() < batchSize)
             {
                 break;
             }
@@ -384,7 +384,8 @@ namespace invsync::sync
         // ONE attempt, no retries (D16): the worker already flushed this agent's earlier deltas
         // (same shard, batch cut), so the only staleness left is the indexer's refresh interval --
         // and a false mismatch there costs one full resync, which is correct, just expensive.
-        const auto calculated = calculateChecksumOfChecksums(connector, index, session.agentId, m_managerClusterName);
+        const auto calculated =
+            calculateChecksumOfChecksums(connector, index, session.agentId, m_managerClusterName, m_queryBatchSize);
 
         if (calculated != claimed)
         {

--- a/src/wazuh_modules/inventory_sync_server/src/sync/sessionProcessor.hpp
+++ b/src/wazuh_modules/inventory_sync_server/src/sync/sessionProcessor.hpp
@@ -61,11 +61,19 @@ namespace invsync::sync
      */
     class SessionProcessor final
     {
+        /// Indexer search page size while draining a session.
+        static constexpr std::size_t DEFAULT_QUERY_BATCH_SIZE {1000};
+
     public:
         /// @param metrics OPTIONAL registry for the document counters (D18); null counts nothing.
+        /// queryBatchSize follows the module's <=0 -> default convention, so modulesd can pass the
+        /// internal option through unconditionally.
         explicit SessionProcessor(std::string managerClusterName,
-                                  const std::shared_ptr<wazuh::metrics::IManager>& metrics = nullptr)
+                                  const std::shared_ptr<wazuh::metrics::IManager>& metrics = nullptr,
+                                  int queryBatchSize = 0)
             : m_managerClusterName {std::move(managerClusterName)}
+            , m_queryBatchSize {queryBatchSize > 0 ? static_cast<std::size_t>(queryBatchSize)
+                                                   : DEFAULT_QUERY_BATCH_SIZE}
         {
             if (metrics)
             {
@@ -102,6 +110,8 @@ namespace invsync::sync
                                                indexer::IIndexerConnectorSync& connector) const;
 
         std::string m_managerClusterName;
+
+        std::size_t m_queryBatchSize {DEFAULT_QUERY_BATCH_SIZE};
         // D18 counters, resolved once at construction (null when metrics are off, e.g. most tests).
         std::shared_ptr<wazuh::metrics::ICounter> m_docsIndexed;
         std::shared_ptr<wazuh::metrics::ICounter> m_docsSkipped;

--- a/src/wazuh_modules/inventory_sync_server/src/sync/syncPipeline.cpp
+++ b/src/wazuh_modules/inventory_sync_server/src/sync/syncPipeline.cpp
@@ -47,7 +47,7 @@ namespace invsync::sync
                                std::shared_ptr<wazuh::metrics::IManager> metrics)
         : m_config {config}
         , m_metrics {metrics ? std::move(metrics) : std::make_shared<wazuh::metrics::Manager>()}
-        , m_processor {std::move(managerClusterName), m_metrics}
+        , m_processor {std::move(managerClusterName), m_metrics, config.sessionQueryBatchSize}
         , m_registry {std::move(registry)}
         , m_connectors {std::move(connectors)}
     {

--- a/src/wazuh_modules/inventory_sync_server/src/sync/syncPipeline.hpp
+++ b/src/wazuh_modules/inventory_sync_server/src/sync/syncPipeline.hpp
@@ -42,6 +42,8 @@ namespace invsync::sync
         /// Group-commit threshold: a worker flushes its open batch when the staged payload bytes
         /// reach this (mirrors the connector's own max_bulk_size) or when its queue drains.
         std::size_t bulkFlushBytes {10U * 1024U * 1024U};
+        /// Indexer search page size the session processor uses while draining a session.
+        int sessionQueryBatchSize {0}; ///< <=0 -> SessionProcessor's own default.
     };
 
     /**

--- a/src/wazuh_modules/src/wm_inventory_sync_server.c
+++ b/src/wazuh_modules/src/wm_inventory_sync_server.c
@@ -139,6 +139,10 @@ static void wm_inventory_sync_server_read_tunables(inventory_sync_server_config_
     /* Max 10, not 30: modulesd gives the WHOLE daemon 30 s to shut down, so letting one module's drain
      * window alone consume all of it defeats the budget this value exists to respect. */
     config->drain_timeout = getDefine_Int_default("wazuh_modules", "inventory_sync_server_drain_timeout", 0, 10, 0);
+    /* Indexer search page size while draining a session. Sized against the indexer's own limits
+     * (page size vs. response memory), which this module cannot know at build time. */
+    config->session_query_batch_size =
+        getDefine_Int_default("wazuh_modules", "inventory_sync_server_session_query_batch_size", 0, 100000, 0);
     config->max_parallel_connections =
         getDefine_Int_default("wazuh_modules", "inventory_sync_server_max_parallel_connections", 0, 65536, 0);
     /* Route-class admission (QoS). The liveness class stays fixed inside the module -- it is a term


### PR DESCRIPTION
## Description

The agent and the manager each defined their own connection timing values, and a large part of them
were compile-time constants with no configuration surface at all. On the agent side the per-request
timeouts, the retry budgets, the backoff parameters and the producer-pause threshold were `constexpr`
values the C bridge never populated, so the agreed defaults could only be changed by rebuilding — and
that blocked the agreement itself: the two teams cannot converge on a value that only exists as a
constant in a header.

This pull request turns the values that genuinely belong to the agent/manager timing contract into
internal options: **18 new options**, 15 on the agent (`agent.*`, read from `internal_options.conf` /
`local_internal_options.conf`) and 3 on the manager (`remoted.*` and
`wazuh_modules.inventory_sync_server_*`, overridable from `wazuh-manager-internal-options.conf`).

Related to #38284.

### Scope: what is deliberately NOT configurable

An earlier revision of this PR exposed 50 options. That was too many. The bar applied since:

> An option earns its existence only if the correct value depends on the **deployment** — fleet size,
> endpoint network, hardware, indexer sizing — and support would plausibly tell an administrator to
> change it during a real incident.

Internal mechanics fail that bar and stay compiled in, because exposing them turns implementation
details into a compatibility surface without giving anyone a decision they can actually make:
control-plane cadences, module heartbeats, the inventory-sync shutdown ladder, internal retry counts,
worker wake periods, the log-throttle window, accounting constants, in-memory queue depths and the
per-endpoint body caps.

Concretely, this removed 26 manager options and 6 agent options versus the earlier revision, along
with the two mechanisms that existed only to serve them (see below). Everything removed reverted to
the compile-time constant it had before, so no default moved as a result.

## Proposed Changes

Two mechanisms, chosen by what each value could actually reach:

1. **Config read** where a configuration object was already in scope — the agent's `hc_config_t` →
   `ModuleConfig` chain, and the session query batch size through `SyncPipelineConfig` →
   `SessionProcessor`.
2. **Constructor argument** where the class already carried configuration — the VD scan read timeout
   through `ScanVdHandlerImpl` → `Impl`.

Every option follows the existing `<=0 -> built-in default` convention, so agentd, remoted and
modulesd pass their values through unconditionally.

A third mechanism present in the earlier revision — a settable process-wide default, used for
`LogThrottle`'s window and the six per-endpoint body caps — is **gone**, together with the options it
served. `LogThrottle` is back to a `constexpr` window and the new `protocolLimits.hpp` header no
longer exists.

### One default did change

`agent.https_stateful_timeout` ships as **90000 ms**, while the constant it replaced was
**120000 ms**. This covers `/stateful` and both `POST /download` kinds (shared configuration and
WPK). Every other value in this PR resolves to exactly what it resolved to before.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

### Artifacts Affected

- `wazuh-agentd` and the `https_client` module (Linux, Windows, macOS).
- `wazuh-remoted` and the `remoted_module` library.
- `wazuh-modulesd` and the `inventory_sync_server` module.
- Default configuration file `etc/internal_options.conf`: 15 new `agent.*` entries, growing it from
  6919 to 9744 bytes. The file is read by the agent only — the manager leaves `WAZUH_DEFINES`
  undefined and takes overrides from `etc/wazuh-manager-internal-options.conf`, shipped empty and
  unchanged here.
- Public C ABI: new fields on `hc_config_t`, `remoted_module_config_t` and
  `inventory_sync_server_config_t`. All three are zero-initialised by every caller and have no
  positional aggregate-initialisation sites, so the additions are source-compatible.
- Agent check files: the four Linux agent manifests that pin `internal_options.conf`'s size.

### Configuration Changes

Every value below was a compile-time constant before this PR. Ranges are enforced by
`getDefine_Int_default()`, which rejects an out-of-range or non-numeric value by refusing to start
the daemon rather than clamping.

#### Agent — `agent.*` (`etc/internal_options.conf`)

An attempt count is the **total** number of tries, not retries after the first: `1` means "send once,
never retry". Only retryable failures and back-pressure (`503`) consume an attempt; authentication
failures, permanent errors and version rejections stop immediately. A step's worst case is therefore
about `attempts × timeout` plus the jittered backoff between tries — check that figure against
`<global><agents_disconnection_time>` before raising either.

| Was (constant) | Now (option) | Default | Range |
|---|---|---|---|
| `request_timeout_ms` (never populated) | `agent.https_request_timeout` | `10000` ms | 1000–600000 |
| `stateful_timeout_ms` (never populated) | `agent.https_stateful_timeout` | **`90000` ms** (was 120000) | 1000–3600000 |
| `backoff_base_ms` (never populated) | `agent.https_backoff_base` | `1000` ms | 100–60000 |
| `backoff_cap_ms` (never populated) | `agent.https_backoff_cap` | `60000` ms | 1000–3600000 |
| `rejected_retry_interval_s` (never populated) | `agent.https_rejected_retry_interval` | `60` s | 1–86400 |
| `wpk_max_download_bytes` (never populated) | `agent.https_wpk_max_download_bytes` | `209715200` (200 MiB) | 1048576–2147483647 |
| `CONTROL_MAX_ATTEMPTS` | `agent.https_control_attempts` | `4` | 1–64 |
| `STATELESS_MAX_ATTEMPTS` | `agent.https_stateless_attempts` | `5` | 1–64 |
| `STATEFUL_MAX_ATTEMPTS` | `agent.https_stateful_attempts` | `5` | 1–64 |
| `DOWNLOAD_MAX_ATTEMPTS` + `WPK_DOWNLOAD_MAX_ATTEMPTS` | `agent.https_download_attempts` | `2` | 1–64 |
| `CONTROL_UNDELIVERABLE_THRESHOLD` | `agent.https_producer_pause_threshold` | `2` | 1–1000 |
| `REPORTER_MAX_ATTEMPTS` | `agent.https_reporter_attempts` | `1` | 1–64 |
| `FAST_FOLLOWUP_INTERVAL` | `agent.https_fast_followup_interval` | `1` s | 1–3600 |
| `ENROLLMENT_RETRY_TIME_DELTA` + `BRIDGE_REENROLL_RETRY_DELTA_S` | `agent.enrollment_retry_delta` | `5` s | 1–3600 |
| `ENROLLMENT_RETRY_TIME_MAX` + `BRIDGE_REENROLL_RETRY_MAX_S` | `agent.enrollment_retry_max` | `60` s | 1–86400 |

The two enrollment values were duplicated file-local constants in `start_agent.c` and
`https_client_bridge.c`; both loops now read one shared pair and can no longer drift apart. The two
download-attempt constants were likewise duplicated across the config and WPK fetchers.

`ModuleConfig::validateTiming()` rejects an inverted `backoff_base` / `backoff_cap` pair at startup.
`getDefine_Int_default()` range-checks each option on its own but cannot relate two of them, so an
inverted pair is reachable from two individually valid values.

#### Manager — `remoted.*` and `wazuh_modules.*` (`etc/wazuh-manager-internal-options.conf`)

| Was (constant) | Now (option) | Default | Range |
|---|---|---|---|
| `kKeepaliveThrottleSec` | `remoted.control_keepalive_throttle` | `60` s | 1–3600 |
| `VD_SCAN_READ_TIMEOUT_SECONDS` | `remoted.scanvd_read_timeout` | `60` s | **31**–3600 |
| `BATCH_SIZE` | `wazuh_modules.inventory_sync_server_session_query_batch_size` | `1000` | 0–100000 |

Why each of these three survived the bar above:

- **`control_keepalive_throttle`** bounds how often a `notify` reaches wazuh-db, so the write load it
  produces scales with the fleet. It is the manager half of the timing contract and has to be
  settable before any notify cadence is agreed with the agent. It must stay at or above the agent's
  notify cadence, and well below `<global><agents_disconnection_time>`.
- **`scanvd_read_timeout`** is a deadline against another daemon whose scan duration grows with the
  agent's inventory. Its floor of **31** is the only range here derived from a real constraint rather
  than convention: modulesd's scan handler can legitimately block ~30 s in its pause/quiesce drain
  before scanning starts, so a lower timeout misreads an in-progress scan as a network failure and
  retries it while the first attempt is still running.
- **`session_query_batch_size`** is the indexer search page size while draining a session. Larger
  pages mean fewer round trips at a proportionally larger response held in memory, so the right value
  follows the indexer's sizing rather than this module's. It keeps the module's `0 -> built-in
  default` convention, so the shipped `0` means `1000`.

### Tests Introduced

No new test files; the two existing configuration-resolution suites were extended.

- `src/client-agent/https_client/tests/unit/moduleConfig_test.cpp`: the new fields added to the
  zeroed-config defaults case and to an explicit-override case, plus two cases for
  `validateTiming()` — inverted backoff bounds rejected, and equal bounds accepted (the boundary,
  since the check is `>` and not `>=`).
- `src/remoted/remoted_module/test/unit/controlConfig_test.cpp`: `keepaliveThrottleSec` added to the
  defaults, positive-override and negative-guard cases. The negative case matters because
  `buildControlConfig()` casts to `uint32_t`, so a negative must fall back rather than wrap.

**Coverage gap worth stating plainly:** `remoted.scanvd_read_timeout` and
`inventory_sync_server_session_query_batch_size` have no test asserting the value reaches its
consumer. That is the failure mode to watch for here — during development one option was read,
range-checked, stored in the struct and then silently ignored because the middle of the chain was
missing, and no existing test would have caught it.

### Validation performed

Run against a clean Ubuntu 24.04 VM using the same tools CI uses:

- **astyle 3.1** (the exact version CI installs) over `client-agent/https_client`: **PASS**.
- **clang-format 22.1.1** (the Wazuh binary from `packages.wazuh.com`) over all 83
  `inventory_sync_server` files: **PASS**, 0 warnings.
- **cppcheck** via `build.py --readytoreview`: **PASS**.
- Unit test suites: **not yet run** — `cmocka` was missing in the validation environment, which
  blocked the `https_client` build behind it. `remoted_module_utest` and the InventorySyncServer
  suites have not been run either.

> These runs were performed on the earlier, larger revision of this branch and have **not** been
> re-run since the option set was reduced. Most of the reduction is a revert to previously-compiling
> code, but the formatting and static-analysis passes should be repeated before merge.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
