### PR TITLE
Validate read paths in group configuration and daemon stats retrieval

### DIFF
--- a/framework/wazuh/core/configuration.py
+++ b/framework/wazuh/core/configuration.py
@@ -752,6 +752,11 @@ def get_agent_conf(group_id: str = None, offset: int = 0, limit: int = common.DA
         raise WazuhResourceNotFound(1710, group_id)
     agent_conf = os_path.join(common.SHARED_PATH, group_id if group_id is not None else '', filename)
 
+    # Ensure the resolved path stays inside the group directory.
+    base_path = os_path.join(common.SHARED_PATH, group_id if group_id is not None else '')
+    if os_path.commonpath([os_path.realpath(agent_conf), os_path.realpath(base_path)]) != os_path.realpath(base_path):
+        raise WazuhError(1006, agent_conf)
+
     if not os_path.exists(agent_conf):
         raise WazuhError(1006, agent_conf)
 
@@ -856,6 +861,11 @@ def get_file_conf(filename: str, group_id: str = None, type_conf: str = None, ra
         raise WazuhResourceNotFound(1710, group_id)
 
     file_path = os_path.join(common.SHARED_PATH, group_id if not filename == 'ar.conf' else '', filename)
+
+    # Ensure the resolved path stays inside the group directory.
+    base_path = os_path.join(common.SHARED_PATH, group_id if not filename == 'ar.conf' else '')
+    if os_path.commonpath([os_path.realpath(file_path), os_path.realpath(base_path)]) != os_path.realpath(base_path):
+        raise WazuhError(1006, file_path)
 
     if not os_path.exists(file_path):
         raise WazuhError(1006, file_path)

--- a/framework/wazuh/core/tests/test_configuration.py
+++ b/framework/wazuh/core/tests/test_configuration.py
@@ -331,6 +331,24 @@ def test_get_file_conf():
             configuration.get_file_conf(filename='agent.conf', group_id='default', type_conf='noconf')
 
 
+def test_get_agent_conf_path_traversal():
+    """Check that a filename resolving outside the group directory is rejected and not read."""
+    with patch('wazuh.core.common.SHARED_PATH', new=os.path.join(parent_directory, tmp_path, 'configuration')):
+        with patch('wazuh.core.configuration.load_wazuh_xml') as mock_load:
+            with pytest.raises(WazuhError, match=".* 1006 .*"):
+                configuration.get_agent_conf(group_id='default', filename='../ossec.conf')
+            mock_load.assert_not_called()
+
+
+def test_get_file_conf_path_traversal():
+    """Check that a filename resolving outside the group directory is rejected and not read."""
+    with patch('wazuh.core.common.SHARED_PATH', new=os.path.join(parent_directory, tmp_path, 'configuration')):
+        with patch('builtins.open') as mock_open_fn:
+            with pytest.raises(WazuhError, match=".* 1006 .*"):
+                configuration.get_file_conf(filename='../ossec.conf', group_id='default', raw=True)
+            mock_open_fn.assert_not_called()
+
+
 def test_parse_internal_options():
     with patch('wazuh.core.common.INTERNAL_OPTIONS_CONF',
                new=os.path.join(parent_directory, tmp_path, 'configuration/noexists.conf')):

--- a/framework/wazuh/stats.py
+++ b/framework/wazuh/stats.py
@@ -247,6 +247,9 @@ def deprecated_get_daemons_stats(filename):
         some_msg='Could not read statistical information for some nodes',
         none_msg='Could not read statistical information for any node'
     )
+    # Only the known daemon stats files may be read through this callable.
+    if filename not in (common.ANALYSISD_STATS, common.REMOTED_STATS):
+        raise exception.WazuhError(1308, extra_message=filename)
     result.affected_items = get_daemons_stats_(filename)
     result.total_affected_items = len(result.affected_items)
 

--- a/framework/wazuh/tests/test_stats.py
+++ b/framework/wazuh/tests/test_stats.py
@@ -167,9 +167,17 @@ def test_get_daemons_stats_all_agents(mock_get_daemons_stats_socket, daemons_lis
 @patch('wazuh.stats.get_daemons_stats_', return_value=[{"events_decoded": 1.0}])
 def test_deprecated_get_daemons_stats(mock_daemons_stats_):
     """Makes sure deprecated_get_daemons_stats() fit with the expected."""
-    response = stats.deprecated_get_daemons_stats('filename')
+    response = stats.deprecated_get_daemons_stats(stats.common.ANALYSISD_STATS)
     assert isinstance(response, AffectedItemsWazuhResult), 'The result is not WazuhResult type'
     assert response.total_affected_items == len(response.affected_items)
+
+
+@patch('wazuh.stats.get_daemons_stats_')
+def test_deprecated_get_daemons_stats_path_traversal(mock_daemons_stats_):
+    """Check that a filename outside the known daemon stats files is rejected and not read."""
+    with pytest.raises(stats.exception.WazuhError, match=".* 1308 .*"):
+        stats.deprecated_get_daemons_stats('/etc/passwd')
+    mock_daemons_stats_.assert_not_called()
 
 
 @pytest.mark.parametrize('component', [


### PR DESCRIPTION
## Description
This PR is a continuation of #37901. That fix closed the CDB list readers (`get_list_file`, and later `get_lists`, `delete_list_file`, `upload_list_file`); this one extends the same containment check to the remaining cluster-callable readers of the same class surfaced by the reporter.

`get_file_conf` and `get_agent_conf` built their source path by joining a caller-supplied `filename` under `SHARED_PATH/<group_id>` with no containment check, and `deprecated_get_daemons_stats` opened a caller-supplied `filename` directly. Reachable through the cluster callable path (`as_wazuh_object` → `DistributedAPI.run_local`), which bypasses the REST controller's filename validators, these readers allowed a cluster peer to read files outside the group directory and outside the known daemon stats files. The fix resolves each path and rejects it before the file is opened when it falls outside the expected directory (group readers) or is not one of the known daemon stats files (stats reader).

## Proposed Changes
- `framework/wazuh/core/configuration.py`: in `get_file_conf` and `get_agent_conf`, resolve the candidate path with `realpath` and raise `WazuhError(1006)` if it is not contained within the group directory, before the file is read.
- `framework/wazuh/stats.py`: in `deprecated_get_daemons_stats`, raise `WazuhError(1308)` if `filename` is not one of `common.ANALYSISD_STATS` / `common.REMOTED_STATS`, before calling `get_daemons_stats_`.

### Results and Evidence
- `pytest framework/wazuh/core/tests/test_configuration.py framework/wazuh/tests/test_stats.py framework/wazuh/core/tests/test_stats.py` — 149 passed, 0 failed.
- The three new tests fail against the pre-fix code and pass after the fix (verified by stashing the source changes and re-running only the new tests: 3 failed → 3 passed).
- The new tests assert that a traversal filename is rejected with the expected error code and that the underlying reader (`load_wazuh_xml` / `open` / `get_daemons_stats_`) is never invoked.

### Artifacts Affected
- wazuh-clusterd

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
- `test_get_agent_conf_path_traversal` and `test_get_file_conf_path_traversal` in `framework/wazuh/core/tests/test_configuration.py`: assert a filename resolving outside the group directory is rejected with error code 1006 and the file is never read.
- `test_deprecated_get_daemons_stats_path_traversal` in `framework/wazuh/tests/test_stats.py`: asserts a filename outside the known daemon stats files is rejected with error code 1308 and `get_daemons_stats_` is never invoked.
- Updated `test_deprecated_get_daemons_stats` in the same file to pass a known stats path so it remains valid under the new check.

## Credits
Thanks to @namd0ng for reporting this issue.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
