### PR TITLE
Add sccache compilation caching to the legacy unit tests and syscollector RTR workflows

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -1,0 +1,142 @@
+name: "Setup sccache"
+description: >
+  Installs sccache with the Amazon S3 backend and transparently wraps every
+  compiler present on the runner (gcc/g++, clang, the mingw crosses) through
+  PATH masquerade, so make- and cmake-based builds get compilation caching
+  with no build-system changes. Requires AWS credentials already present in
+  the environment (aws-actions/configure-aws-credentials) with read/write
+  access to the cache prefix. If a probe write to the prefix fails, the
+  action disables itself with a warning and the build runs uncached.
+
+inputs:
+  bucket:
+    description: S3 bucket that stores the compilation cache
+    required: true
+  region:
+    description: AWS region of the bucket
+    required: true
+  key-prefix:
+    description: Key prefix for cache objects inside the bucket
+    required: false
+    default: "sccache"
+  version:
+    description: sccache release to install
+    required: false
+    default: "0.8.1"
+
+runs:
+  using: composite
+  steps:
+    - name: Install sccache
+      shell: bash
+      run: |
+        case "$(uname -m)" in
+          aarch64|arm64) arch="aarch64" ;;
+          *) arch="x86_64" ;;
+        esac
+        v="v${{ inputs.version }}"
+        curl -sSL --retry 3 \
+          "https://github.com/mozilla/sccache/releases/download/${v}/sccache-${v}-${arch}-unknown-linux-musl.tar.gz" \
+          | tar xz -C /tmp
+        sudo install -m 0755 "/tmp/sccache-${v}-${arch}-unknown-linux-musl/sccache" /usr/local/bin/sccache
+        sccache --version
+
+    - name: Probe cache prefix access
+      shell: bash
+      run: |
+        # The bucket input may arrive as "s3://name[/base/path]" (that is how
+        # the CI secret is stored and how upload_s3_artifact consumes it) or
+        # as a bare bucket name. Normalize to name + effective key prefix.
+        # The derived bare name is not covered by secret masking, so no S3
+        # output may reach the log: verdicts only.
+        raw="${{ inputs.bucket }}"
+        raw="${raw#s3://}"
+        bucket_name="${raw%%/*}"
+        base=""
+        case "$raw" in */*) base="${raw#*/}" ;; esac
+        prefix="${base:+${base%/}/}${{ inputs.key-prefix }}"
+        {
+          echo "SCCACHE_BUCKET_NAME=$bucket_name"
+          echo "SCCACHE_EFFECTIVE_PREFIX=$prefix"
+        } >> "$GITHUB_ENV"
+        # The bucket may live in a different region than the CI default; the
+        # AWS CLI follows the S3 301 redirect transparently but sccache's S3
+        # client does not, so resolve the real region from the unauthenticated
+        # x-amz-bucket-region header and fall back to the input.
+        detected=$(curl -sI --max-time 10 "https://${bucket_name}.s3.amazonaws.com/" \
+          | tr -d '\r' | awk -F': ' 'tolower($1)=="x-amz-bucket-region"{print $2}')
+        region="${detected:-${{ inputs.region }}}"
+        echo "SCCACHE_RESOLVED_REGION=$region" >> "$GITHUB_ENV"
+        echo "bucket region resolved: $region"
+        probe="s3://${bucket_name}/${prefix}/.probe-${GITHUB_RUN_ID}"
+        if echo ok | aws s3 cp - "$probe" --region "$region" >/dev/null 2>&1; then
+          aws s3 rm "$probe" --region "$region" >/dev/null 2>&1 || true
+          echo "SCCACHE_PROBE_OK=1" >> "$GITHUB_ENV"
+          echo "probe OK: read/write available on the cache prefix"
+        else
+          echo "SCCACHE_PROBE_OK=0" >> "$GITHUB_ENV"
+          echo "::warning title=sccache disabled::the CI role cannot write to the cache prefix; building uncached"
+        fi
+
+    - name: Configure environment and wrap compilers
+      shell: bash
+      run: |
+        [ "$SCCACHE_PROBE_OK" = "1" ] || exit 0
+        {
+          echo "SCCACHE_BUCKET=$SCCACHE_BUCKET_NAME"
+          echo "SCCACHE_REGION=$SCCACHE_RESOLVED_REGION"
+          echo "SCCACHE_S3_KEY_PREFIX=$SCCACHE_EFFECTIVE_PREFIX"
+          echo "SCCACHE_IDLE_TIMEOUT=0"
+        } >> "$GITHUB_ENV"
+
+        # PATH masquerade instead of CC/CXX overrides: src/Makefile hardcodes
+        # CC=gcc, cmake discovers compilers from PATH, and the winagent target
+        # uses the mingw crosses — one wrapper directory ahead of PATH covers
+        # all of them. Real paths are resolved here, before the wrapper dir
+        # enters PATH, so a wrapper can never recurse into itself.
+        wrapdir="${RUNNER_TEMP}/sccache-wrappers"
+        mkdir -p "$wrapdir"
+        candidates="cc c++ gcc g++ gcc-14 g++-14 clang clang++ \
+          x86_64-w64-mingw32-gcc x86_64-w64-mingw32-g++ \
+          x86_64-w64-mingw32-gcc-posix x86_64-w64-mingw32-g++-posix \
+          i686-w64-mingw32-gcc i686-w64-mingw32-g++ \
+          i686-w64-mingw32-gcc-posix i686-w64-mingw32-g++-posix"
+        for name in $candidates; do
+          real="$(command -v "$name" 2>/dev/null)" || continue
+          [ -n "$real" ] || continue
+          printf '#!/bin/sh\nexec /usr/local/bin/sccache %s "$@"\n' "$real" > "$wrapdir/$name"
+          chmod +x "$wrapdir/$name"
+          echo "wrapped $name -> $real"
+        done
+        echo "$wrapdir" >> "$GITHUB_PATH"
+
+    - name: Start sccache server
+      shell: bash
+      run: |
+        [ "$SCCACHE_PROBE_OK" = "1" ] || exit 0
+        # A cache problem must never fail the job: on any startup error,
+        # sanitize the output (it can carry the unmasked bucket name),
+        # remove the compiler wrappers and continue uncached.
+        set +e
+        out=$(SCCACHE_BUCKET="$SCCACHE_BUCKET_NAME" \
+              SCCACHE_REGION="$SCCACHE_RESOLVED_REGION" \
+              SCCACHE_S3_KEY_PREFIX="$SCCACHE_EFFECTIVE_PREFIX" \
+              SCCACHE_IDLE_TIMEOUT=0 \
+              SCCACHE_LOG=debug \
+              SCCACHE_ERROR_LOG=/tmp/sccache_server.log \
+              sccache --start-server 2>&1)
+        rc=$?
+        set -e
+        if [ "$rc" -ne 0 ]; then
+          echo "$out" | sed "s/${SCCACHE_BUCKET_NAME}/<bucket>/g" | head -20
+          if [ -f /tmp/sccache_server.log ]; then
+            echo "── server debug log (sanitized):"
+            sed "s/${SCCACHE_BUCKET_NAME}/<bucket>/g" /tmp/sccache_server.log | grep -iE "error|stat|check|403|404|denied|response" | head -30
+          fi
+          echo "::warning title=sccache disabled::server failed to start (rc=$rc); building uncached"
+          rm -rf "${RUNNER_TEMP}/sccache-wrappers"
+          echo "SCCACHE_PROBE_OK=0" >> "$GITHUB_ENV"
+          exit 0
+        fi
+        sccache --zero-stats >/dev/null 2>&1 || true
+        echo "sccache server started"

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -55,10 +55,14 @@ runs:
         base=""
         case "$raw" in */*) base="${raw#*/}" ;; esac
         prefix="${base:+${base%/}/}${{ inputs.key-prefix }}"
+        # State travels between steps in a file, never through GITHUB_ENV:
+        # job-level env is echoed into the env block of any later step that
+        # declares env:, which would print the bucket name in a public log.
+        envfile="${RUNNER_TEMP}/sccache.env"
         {
-          echo "SCCACHE_BUCKET_NAME=$bucket_name"
-          echo "SCCACHE_EFFECTIVE_PREFIX=$prefix"
-        } >> "$GITHUB_ENV"
+          echo "SCCACHE_BUCKET_NAME='$bucket_name'"
+          echo "SCCACHE_EFFECTIVE_PREFIX='$prefix'"
+        } > "$envfile"
         # The bucket may live in a different region than the CI default; the
         # AWS CLI follows the S3 301 redirect transparently but sccache's S3
         # client does not, so resolve the real region from the unauthenticated
@@ -66,28 +70,23 @@ runs:
         detected=$(curl -sI --max-time 10 "https://${bucket_name}.s3.amazonaws.com/" \
           | tr -d '\r' | awk -F': ' 'tolower($1)=="x-amz-bucket-region"{print $2}')
         region="${detected:-${{ inputs.region }}}"
-        echo "SCCACHE_RESOLVED_REGION=$region" >> "$GITHUB_ENV"
+        echo "SCCACHE_RESOLVED_REGION='$region'" >> "$envfile"
         echo "bucket region resolved: $region"
         probe="s3://${bucket_name}/${prefix}/.probe-${GITHUB_RUN_ID}"
         if echo ok | aws s3 cp - "$probe" --region "$region" >/dev/null 2>&1; then
           aws s3 rm "$probe" --region "$region" >/dev/null 2>&1 || true
-          echo "SCCACHE_PROBE_OK=1" >> "$GITHUB_ENV"
+          echo "SCCACHE_PROBE_OK=1" >> "$envfile"
           echo "probe OK: read/write available on the cache prefix"
         else
-          echo "SCCACHE_PROBE_OK=0" >> "$GITHUB_ENV"
+          echo "SCCACHE_PROBE_OK=0" >> "$envfile"
           echo "::warning title=sccache disabled::the CI role cannot write to the cache prefix; building uncached"
         fi
 
     - name: Configure environment and wrap compilers
       shell: bash
       run: |
+        . "${RUNNER_TEMP}/sccache.env"
         [ "$SCCACHE_PROBE_OK" = "1" ] || exit 0
-        {
-          echo "SCCACHE_BUCKET=$SCCACHE_BUCKET_NAME"
-          echo "SCCACHE_REGION=$SCCACHE_RESOLVED_REGION"
-          echo "SCCACHE_S3_KEY_PREFIX=$SCCACHE_EFFECTIVE_PREFIX"
-          echo "SCCACHE_IDLE_TIMEOUT=0"
-        } >> "$GITHUB_ENV"
 
         # PATH masquerade instead of CC/CXX overrides: src/Makefile hardcodes
         # CC=gcc, cmake discovers compilers from PATH, and the winagent target
@@ -113,6 +112,7 @@ runs:
     - name: Start sccache server
       shell: bash
       run: |
+        . "${RUNNER_TEMP}/sccache.env"
         [ "$SCCACHE_PROBE_OK" = "1" ] || exit 0
         # A cache problem must never fail the job: on any startup error,
         # sanitize the output (it can carry the unmasked bucket name),
@@ -135,7 +135,6 @@ runs:
           fi
           echo "::warning title=sccache disabled::server failed to start (rc=$rc); building uncached"
           rm -rf "${RUNNER_TEMP}/sccache-wrappers"
-          echo "SCCACHE_PROBE_OK=0" >> "$GITHUB_ENV"
           exit 0
         fi
         sccache --zero-stats >/dev/null 2>&1 || true

--- a/.github/workflows/5_testcomponent_agent_info-rtr.yml
+++ b/.github/workflows/5_testcomponent_agent_info-rtr.yml
@@ -45,6 +45,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Run Unit tests for module ${{ matrix.module }} and target ${{ matrix.target }}
         run: |
           cd src/
@@ -58,3 +73,6 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: coverage_report ${{ matrix.target }}
           path: ./**/coverage_report/**
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/5_testcomponent_agent_metadata-rtr.yml
+++ b/.github/workflows/5_testcomponent_agent_metadata-rtr.yml
@@ -43,6 +43,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Run RTR for module ${{ matrix.module }} and target ${{ matrix.target }}
         run: |
           cd src/
@@ -56,3 +71,6 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: coverage_report ${{ matrix.target }}
           path: ./**/coverage_report/**
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/5_testcomponent_contentmanager.yml
+++ b/.github/workflows/5_testcomponent_contentmanager.yml
@@ -41,7 +41,6 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: ./.github/actions/build_external_deps
       # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
       - name: "Configure AWS credentials for the compilation cache"
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
@@ -57,6 +56,7 @@ jobs:
           bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
           region: ${{ secrets.CI_AWS_REGION }}
           key-prefix: sccache/5.0.0
+      - uses: ./.github/actions/build_external_deps
       - uses: ./.github/actions/build_target_cpp
         with:
           target: "content_manager_ctest"

--- a/.github/workflows/5_testcomponent_contentmanager.yml
+++ b/.github/workflows/5_testcomponent_contentmanager.yml
@@ -20,6 +20,9 @@ jobs:
   contentmanager-tests:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     timeout-minutes: 60
     strategy:
       fail-fast: true
@@ -39,7 +42,21 @@ jobs:
           submodules: recursive
 
       - uses: ./.github/actions/build_external_deps
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - uses: ./.github/actions/build_target_cpp
         with:
           target: "content_manager_ctest"
@@ -50,3 +67,6 @@ jobs:
         with:
           target: "content_manager_ctest"
           valgrind: ${{ matrix.valgrind_enabled }}
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/5_testcomponent_indexer-connector.yml
+++ b/.github/workflows/5_testcomponent_indexer-connector.yml
@@ -21,6 +21,9 @@ jobs:
   indexer-connector-tests:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     timeout-minutes: 60
     strategy:
       fail-fast: true
@@ -41,7 +44,21 @@ jobs:
 
       - name: Install compatible CMake
         uses: ./.github/actions/reinstall_cmake
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Build external dependencies
         uses: ./.github/actions/build_external_deps
 
@@ -57,3 +74,6 @@ jobs:
         with:
           valgrind: "${{ matrix.valgrind_enabled }}"
           target: "indexer_connector_ctests"
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/5_testcomponent_keystore.yml
+++ b/.github/workflows/5_testcomponent_keystore.yml
@@ -21,6 +21,9 @@ jobs:
   keystore-tests:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     timeout-minutes: 60
     strategy:
       fail-fast: true
@@ -41,7 +44,21 @@ jobs:
 
       - name: Install compatible CMake
         uses: ./.github/actions/reinstall_cmake
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Build external dependencies
         uses: ./.github/actions/build_external_deps
 
@@ -58,3 +75,6 @@ jobs:
           valgrind: "${{ matrix.valgrind_enabled }}"
           target: "keystore_ctests"
           preload: "true"
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/5_testcomponent_router.yml
+++ b/.github/workflows/5_testcomponent_router.yml
@@ -41,7 +41,6 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: ./.github/actions/build_external_deps
       # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
       - name: "Configure AWS credentials for the compilation cache"
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
@@ -57,6 +56,7 @@ jobs:
           bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
           region: ${{ secrets.CI_AWS_REGION }}
           key-prefix: sccache/5.0.0
+      - uses: ./.github/actions/build_external_deps
       - uses: ./.github/actions/build_target_cpp
         with:
           target: "librouter_ctest"

--- a/.github/workflows/5_testcomponent_router.yml
+++ b/.github/workflows/5_testcomponent_router.yml
@@ -20,6 +20,9 @@ jobs:
   router-tests:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     timeout-minutes: 60
     strategy:
       fail-fast: true
@@ -39,7 +42,21 @@ jobs:
           submodules: recursive
 
       - uses: ./.github/actions/build_external_deps
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - uses: ./.github/actions/build_target_cpp
         with:
           target: "librouter_ctest"
@@ -50,3 +67,6 @@ jobs:
         with:
           target: "librouter_ctest"
           valgrind: ${{ matrix.valgrind_enabled }}
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/5_testcomponent_sca-rtr.yml
+++ b/.github/workflows/5_testcomponent_sca-rtr.yml
@@ -45,6 +45,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Run Unit tests for module ${{ matrix.module }} and target ${{ matrix.target }}
         run: |
           cd src/
@@ -58,3 +73,6 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: coverage_report ${{ matrix.target }}
           path: ./**/coverage_report/**
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/5_testcomponent_schema_validator-rtr.yml
+++ b/.github/workflows/5_testcomponent_schema_validator-rtr.yml
@@ -43,6 +43,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Run RTR for module ${{ matrix.module }} and target ${{ matrix.target }}
         run: |
           cd src/
@@ -56,3 +71,6 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: coverage_report ${{ matrix.target }}
           path: ./**/coverage_report/**
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/5_testcomponent_shared_modules_file_helper-rtr.yml
+++ b/.github/workflows/5_testcomponent_shared_modules_file_helper-rtr.yml
@@ -43,6 +43,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Run RTR for module ${{ matrix.module }} and target ${{ matrix.target }}
         run: |
           cd src/
@@ -56,3 +71,6 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: coverage_report ${{ matrix.target }}
           path: ./**/coverage_report/**
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/5_testcomponent_sync_protocol-rtr.yml
+++ b/.github/workflows/5_testcomponent_sync_protocol-rtr.yml
@@ -43,6 +43,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Run RTR for module ${{ matrix.module }} and target ${{ matrix.target }}
         run: |
           cd src/
@@ -56,3 +71,6 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: coverage_report ${{ matrix.target }}
           path: ./**/coverage_report/**
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/5_testcomponent_syscheck-rtr.yml
+++ b/.github/workflows/5_testcomponent_syscheck-rtr.yml
@@ -45,7 +45,21 @@ jobs:
           architecture: x64
 
       - uses: ./.github/actions/reinstall_cmake
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Run RTR
         run: |
           cd src/ || exit 1
@@ -60,3 +74,6 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: coverage_report_${{ matrix.target }}
           path: ./**/coverage_report/**
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/5_testcomponent_syscollector-rtr.yml
+++ b/.github/workflows/5_testcomponent_syscollector-rtr.yml
@@ -48,10 +48,30 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache. Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Run RTR for module ${{ matrix.module }} and target ${{ matrix.target }}
         run: |
           cd src/
           python build.py --target ${{ matrix.target }} --readytoreview ${{ matrix.module }}
+      - name: "Compilation cache statistics"
+        if: always()
+        # grep filters the "Cache location" line: it carries the bucket name,
+        # which secret masking does not cover once the s3:// scheme is stripped.
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
       - name: Creating a valid artifact name
         if: always()
         run: |

--- a/.github/workflows/5_testcomponent_vulnerability-scanner.yml
+++ b/.github/workflows/5_testcomponent_vulnerability-scanner.yml
@@ -21,6 +21,9 @@ jobs:
   vulnerability-scanner-modules:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     timeout-minutes: 60
     steps:
       - name: Cancel previous runs
@@ -37,7 +40,21 @@ jobs:
 
       - name: Install compatible CMake
         uses: ./.github/actions/reinstall_cmake
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Build external dependencies
         uses: ./.github/actions/build_external_deps
 
@@ -53,10 +70,16 @@ jobs:
         with:
           valgrind: "true"
           target: "vulnerability_scanner_component_tests"
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
 
   vulnerability-scanner-modules-asan:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     timeout-minutes: 60
     steps:
       - name: Checkout repository
@@ -66,7 +89,21 @@ jobs:
 
       - name: Install compatible CMake
         uses: ./.github/actions/reinstall_cmake
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Build external dependencies
         uses: ./.github/actions/build_external_deps
 
@@ -82,3 +119,6 @@ jobs:
         with:
           valgrind: "false"
           target: "vulnerability_scanner_component_tests"
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/5_testcomponent_windows-dll-hijack.yml
+++ b/.github/workflows/5_testcomponent_windows-dll-hijack.yml
@@ -55,7 +55,21 @@ jobs:
           sudo apt-get install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 make -y || exit 1
 
       - uses: ./.github/actions/reinstall_cmake
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: make deps
         run: make -C src deps TARGET=winagent -j2 || exit 1
 
@@ -94,6 +108,9 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: configuration
           path: src/configuration_files
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
 
   check_dll_on_windows:
     # NOTE: stays on the GitHub-hosted Windows runner. This test drives Process Monitor, which

--- a/.github/workflows/5_testcomponent_windows-files.yml
+++ b/.github/workflows/5_testcomponent_windows-files.yml
@@ -53,6 +53,21 @@ jobs:
           sudo apt install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 make -y
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: make deps
         run: make -C src deps TARGET=winagent -j2
       - name: make
@@ -80,6 +95,9 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: binaries
           path: src/bin_files
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
   check_binaries_details:
     runs-on: windows-2025
     timeout-minutes: 30

--- a/.github/workflows/5_testcomponent_windows-installer-upgrade.yml
+++ b/.github/workflows/5_testcomponent_windows-installer-upgrade.yml
@@ -53,6 +53,21 @@ jobs:
       - uses: actions/checkout@v3
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: make deps
         run: make -C src deps TARGET=winagent -j2
       - name: make
@@ -73,6 +88,9 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: win-agent-base.zip
           path: win-agent-base.zip
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
 
   check_upgrade_result:
     strategy:

--- a/.github/workflows/5_testintegration_engine.yml
+++ b/.github/workflows/5_testintegration_engine.yml
@@ -30,7 +30,21 @@ jobs:
 
       - name: Install CMake
         uses: ./.github/actions/reinstall_cmake
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Build Wazuh manager
         run: |
           make deps -C src TARGET=manager -j$(nproc)
@@ -86,6 +100,9 @@ jobs:
           bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           aws_region: ${{ secrets.CI_AWS_REGION }}
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
 
   helper_tests:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}

--- a/.github/workflows/5_testintegration_inventory-sync.yml
+++ b/.github/workflows/5_testintegration_inventory-sync.yml
@@ -106,7 +106,21 @@ jobs:
       - name: Install compatible CMake
         if: inputs.build_run_id == ''
         uses: ./.github/actions/reinstall_cmake
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Build wazuh-manager
         if: inputs.build_run_id == ''
         run: |
@@ -210,3 +224,6 @@ jobs:
           bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           aws_region: ${{ secrets.CI_AWS_REGION }}
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/5_testintegration_manager.yml
+++ b/.github/workflows/5_testintegration_manager.yml
@@ -177,7 +177,21 @@ jobs:
       - name: Install compatible CMake
         if: inputs.build_run_id == ''
         uses: ./.github/actions/reinstall_cmake
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Build wazuh-manager
         if: inputs.build_run_id == ''
         run: |
@@ -292,3 +306,6 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: wazuh-logs-${{ matrix.name }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/wazuh-logs
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/5_testintegration_vulnerability-scanner.yml
+++ b/.github/workflows/5_testintegration_vulnerability-scanner.yml
@@ -42,7 +42,21 @@ jobs:
 
       - name: Install compatible CMake
         uses: ./.github/actions/reinstall_cmake
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Build external dependencies
         uses: ./.github/actions/build_external_deps
 
@@ -76,3 +90,6 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: QA log files
           path: ${{ github.workspace }}/qa_logs
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/5_testunit_contentmanager.yml
+++ b/.github/workflows/5_testunit_contentmanager.yml
@@ -41,7 +41,21 @@ jobs:
 
       - name: Project dependencies
         uses: ./.github/actions/build_external_deps
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Content manager - Build tests
         uses: ./.github/actions/build_target_cpp
         with:
@@ -63,6 +77,9 @@ jobs:
           path: src/shared_modules/content_manager
           id: content_manager
           threshold: "65"
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
 
   contentmanager-asan:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -76,7 +93,21 @@ jobs:
 
       - name: Project dependencies
         uses: ./.github/actions/build_external_deps
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Content manager - Build tests
         uses: ./.github/actions/build_target_cpp
         with:
@@ -89,3 +120,6 @@ jobs:
         with:
           target: "content_manager_utest"
           valgrind: "false"
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/5_testunit_contentmanager.yml
+++ b/.github/workflows/5_testunit_contentmanager.yml
@@ -39,8 +39,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Project dependencies
-        uses: ./.github/actions/build_external_deps
       # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
       - name: "Configure AWS credentials for the compilation cache"
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
@@ -56,6 +54,8 @@ jobs:
           bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
           region: ${{ secrets.CI_AWS_REGION }}
           key-prefix: sccache/5.0.0
+      - name: Project dependencies
+        uses: ./.github/actions/build_external_deps
       - name: Content manager - Build tests
         uses: ./.github/actions/build_target_cpp
         with:
@@ -91,8 +91,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Project dependencies
-        uses: ./.github/actions/build_external_deps
       # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
       - name: "Configure AWS credentials for the compilation cache"
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
@@ -108,6 +106,8 @@ jobs:
           bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
           region: ${{ secrets.CI_AWS_REGION }}
           key-prefix: sccache/5.0.0
+      - name: Project dependencies
+        uses: ./.github/actions/build_external_deps
       - name: Content manager - Build tests
         uses: ./.github/actions/build_target_cpp
         with:

--- a/.github/workflows/5_testunit_engine.yml
+++ b/.github/workflows/5_testunit_engine.yml
@@ -31,7 +31,21 @@ jobs:
 
       - name: Install CMake
         uses: ./.github/actions/reinstall_cmake
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Force ENGINE_ENABLE_ASAN=ON in CMakeLists
 
         run: |
@@ -68,3 +82,6 @@ jobs:
           bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           aws_region: ${{ secrets.CI_AWS_REGION }}
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/5_testunit_indexerconnector.yml
+++ b/.github/workflows/5_testunit_indexerconnector.yml
@@ -39,8 +39,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Project dependencies
-        uses: ./.github/actions/build_external_deps
       # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
       - name: "Configure AWS credentials for the compilation cache"
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
@@ -56,6 +54,8 @@ jobs:
           bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
           region: ${{ secrets.CI_AWS_REGION }}
           key-prefix: sccache/5.0.0
+      - name: Project dependencies
+        uses: ./.github/actions/build_external_deps
       - name: Indexer connector - Build tests
         uses: ./.github/actions/build_target_cpp
         with:
@@ -91,8 +91,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Project dependencies
-        uses: ./.github/actions/build_external_deps
       # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
       - name: "Configure AWS credentials for the compilation cache"
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
@@ -108,6 +106,8 @@ jobs:
           bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
           region: ${{ secrets.CI_AWS_REGION }}
           key-prefix: sccache/5.0.0
+      - name: Project dependencies
+        uses: ./.github/actions/build_external_deps
       - name: Indexer connector - Build tests
         uses: ./.github/actions/build_target_cpp
         with:

--- a/.github/workflows/5_testunit_indexerconnector.yml
+++ b/.github/workflows/5_testunit_indexerconnector.yml
@@ -41,7 +41,21 @@ jobs:
 
       - name: Project dependencies
         uses: ./.github/actions/build_external_deps
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Indexer connector - Build tests
         uses: ./.github/actions/build_target_cpp
         with:
@@ -63,6 +77,9 @@ jobs:
           path: src/shared_modules/indexer_connector
           id: indexer_connector
           validate_function_coverage: "false"
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
 
   indexerconnector-asan:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -76,7 +93,21 @@ jobs:
 
       - name: Project dependencies
         uses: ./.github/actions/build_external_deps
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Indexer connector - Build tests
         uses: ./.github/actions/build_target_cpp
         with:
@@ -89,3 +120,6 @@ jobs:
         with:
           target: "indexer_connector_utest"
           valgrind: "false"
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/5_testunit_inventorysync.yml
+++ b/.github/workflows/5_testunit_inventorysync.yml
@@ -39,8 +39,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Project dependencies
-        uses: ./.github/actions/build_external_deps
       # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
       - name: "Configure AWS credentials for the compilation cache"
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
@@ -56,6 +54,8 @@ jobs:
           bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
           region: ${{ secrets.CI_AWS_REGION }}
           key-prefix: sccache/5.0.0
+      - name: Project dependencies
+        uses: ./.github/actions/build_external_deps
       - name: Inventory sync - Build tests
         uses: ./.github/actions/build_target_cpp
         with:
@@ -92,8 +92,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Project dependencies
-        uses: ./.github/actions/build_external_deps
       # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
       - name: "Configure AWS credentials for the compilation cache"
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
@@ -109,6 +107,8 @@ jobs:
           bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
           region: ${{ secrets.CI_AWS_REGION }}
           key-prefix: sccache/5.0.0
+      - name: Project dependencies
+        uses: ./.github/actions/build_external_deps
       - name: Inventory sync - Build tests
         uses: ./.github/actions/build_target_cpp
         with:

--- a/.github/workflows/5_testunit_inventorysync.yml
+++ b/.github/workflows/5_testunit_inventorysync.yml
@@ -41,7 +41,21 @@ jobs:
 
       - name: Project dependencies
         uses: ./.github/actions/build_external_deps
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Inventory sync - Build tests
         uses: ./.github/actions/build_target_cpp
         with:
@@ -64,6 +78,9 @@ jobs:
           test_directory: src/wazuh_modules/inventory_sync
           id: inventory_sync
           validate_function_coverage: "false"
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
 
   inventorysync-asan:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -77,7 +94,21 @@ jobs:
 
       - name: Project dependencies
         uses: ./.github/actions/build_external_deps
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Inventory sync - Build tests
         uses: ./.github/actions/build_target_cpp
         with:
@@ -90,3 +121,6 @@ jobs:
         with:
           target: "inventory_sync_utest"
           valgrind: "false"
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/5_testunit_linux-win.yml
+++ b/.github/workflows/5_testunit_linux-win.yml
@@ -84,6 +84,22 @@ jobs:
           gcc --version
           g++ --version
           gcov --version
+      # Compilation cache. Placed after the gcc 14.3 install so the wrappers
+      # resolve the final compilers. Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: "Build wazuh"
         uses: ./.github/actions/build_test_flags
         with:
@@ -99,3 +115,8 @@ jobs:
           bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           aws_region: ${{ secrets.CI_AWS_REGION }}
+      - name: "Compilation cache statistics"
+        if: always()
+        # grep filters the "Cache location" line: it carries the bucket name,
+        # which secret masking does not cover once the s3:// scheme is stripped.
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/5_testunit_router.yml
+++ b/.github/workflows/5_testunit_router.yml
@@ -41,7 +41,21 @@ jobs:
 
       - name: Project dependencies
         uses: ./.github/actions/build_external_deps
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Router - Build tests
         uses: ./.github/actions/build_target_cpp
         with:
@@ -63,6 +77,9 @@ jobs:
           path: src/shared_modules/router
           id: router
           validate_function_coverage: "false"
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
 
   router-asan:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -76,7 +93,21 @@ jobs:
 
       - name: Project dependencies
         uses: ./.github/actions/build_external_deps
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Router - Build tests
         uses: ./.github/actions/build_target_cpp
         with:
@@ -89,3 +120,6 @@ jobs:
         with:
           target: "librouter_utest"
           valgrind: "false"
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/5_testunit_router.yml
+++ b/.github/workflows/5_testunit_router.yml
@@ -39,8 +39,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Project dependencies
-        uses: ./.github/actions/build_external_deps
       # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
       - name: "Configure AWS credentials for the compilation cache"
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
@@ -56,6 +54,8 @@ jobs:
           bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
           region: ${{ secrets.CI_AWS_REGION }}
           key-prefix: sccache/5.0.0
+      - name: Project dependencies
+        uses: ./.github/actions/build_external_deps
       - name: Router - Build tests
         uses: ./.github/actions/build_target_cpp
         with:
@@ -91,8 +91,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Project dependencies
-        uses: ./.github/actions/build_external_deps
       # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
       - name: "Configure AWS credentials for the compilation cache"
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
@@ -108,6 +106,8 @@ jobs:
           bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
           region: ${{ secrets.CI_AWS_REGION }}
           key-prefix: sccache/5.0.0
+      - name: Project dependencies
+        uses: ./.github/actions/build_external_deps
       - name: Router - Build tests
         uses: ./.github/actions/build_target_cpp
         with:

--- a/.github/workflows/5_testunit_shared_modules_utils.yml
+++ b/.github/workflows/5_testunit_shared_modules_utils.yml
@@ -40,7 +40,21 @@ jobs:
 
       - name: Install a compatible CMake
         uses: ./.github/actions/reinstall_cmake
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Project dependencies
         uses: ./.github/actions/build_external_deps
 
@@ -65,6 +79,9 @@ jobs:
           path: src/shared_modules/utils
           id: utils_utest
           validate_function_coverage: "false"
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
 
   shared_modules_utils-asan:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -78,7 +95,21 @@ jobs:
 
       - name: Install a compatible CMake
         uses: ./.github/actions/reinstall_cmake
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Project dependencies
         uses: ./.github/actions/build_external_deps
 
@@ -94,3 +125,6 @@ jobs:
         with:
           target: "utils_utest"
           valgrind: "false"
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/5_testunit_vulnerability-scanner.yml
+++ b/.github/workflows/5_testunit_vulnerability-scanner.yml
@@ -42,7 +42,21 @@ jobs:
 
       - name: Install compatible CMake
         uses: ./.github/actions/reinstall_cmake
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Build external dependencies
         uses: ./.github/actions/build_external_deps
 
@@ -67,6 +81,9 @@ jobs:
           path: src/wazuh_modules/vulnerability_scanner
           id: vulnerability_scanner
           validate_function_coverage: "false"
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
 
   vulnerability-scanner-modules-asan:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -80,7 +97,21 @@ jobs:
 
       - name: Install compatible CMake
         uses: ./.github/actions/reinstall_cmake
-
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/5.0.0
       - name: Build external dependencies
         uses: ./.github/actions/build_external_deps
 
@@ -96,3 +127,6 @@ jobs:
         with:
           valgrind: "false"
           target: "vulnerability_scanner_unit_tests"
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true


### PR DESCRIPTION
## Description

Related to #38139.

CI recompiles an almost identical source tree from scratch on every run: the legacy unit tests rebuild every external dependency (`make clean-deps && make deps`) plus the full tree per target on each PR push, and every RTR job configures and compiles the shared modules again. sccache memoizes each individual compiler invocation in S3 — keyed by compiler binary, full command line and preprocessed source — so translation units that did not change between runs are served from cache. A cache hit is byte-equivalent to compiling: any difference in flags, headers or source produces a different key and a normal compile.

This PR ran as a two-stage effort. First a **pilot** on the two most informative workflows — `5_testunit_linux-win.yml` (the most expensive PR-blocking job, 76 min baseline, carrying the open question of coverage instrumentation) and `5_testcomponent_syscollector-rtr.yml` (the cmake/`build.py` path plus the mingw crosses) — so the rollout decision rested on measured hit rates. With the pilot measured (tables below), the same setup was **extended to every 5.0.0 workflow that compiles on the runner: 26 workflows**, all sharing the `sccache/5.0.0` prefix so common code compiled by different workflows hits the same cache.

## Proposed Changes

- New composite action **`.github/actions/setup-sccache`**:
  - Installs sccache with the S3 backend, reusing the existing CI infrastructure: `CI_INTERNAL_S3_BUCKET` + `CI_OIDC_ROLE_ARN` via OIDC, key prefix `sccache/5.0.0`. Same-repo PR runs already hold write access to this bucket for artifact uploads, so the cache adds no new attack surface; fork PRs get no credentials and build uncached, as today.
  - **Probes the cache prefix before enabling anything**: if the role cannot write, the action emits a warning and the build proceeds uncached. A cache problem can never break CI.
  - Wraps every compiler present on the runner through **PATH masquerade** (wrapper scripts resolved to absolute real paths ahead of `PATH`): covers the hardcoded `CC=gcc` in `src/Makefile`, cmake discovery, the custom gcc 14.3 install, and the mingw crosses — with zero build-system changes.
  - Normalizes the bucket secret, which embeds the `s3://` scheme (see Results). Since the derived bare bucket name is not covered by GitHub secret masking on a public repository, every S3 command in the action is kept silent, the stats step filters the cache-location line, and the action passes state between its steps through a file in `RUNNER_TEMP` — job-level env set through `GITHUB_ENV` is echoed into the `env:` block of later steps, which would print the bucket name.
- **26 workflows instrumented** with the same three-step pattern (AWS credentials with a 2 h session, `setup-sccache`, and a final `sccache --show-stats` step under `if: always()`):
  - RTR family (8): syscollector, syscheck, sca, agent_info, agent_metadata, schema_validator, shared_modules_file_helper, sync_protocol.
  - C/C++ unit tests: linux-win (legacy), engine, contentmanager, indexerconnector, inventorysync, router, shared_modules_utils, vulnerability-scanner.
  - Component tests: keystore, contentmanager, indexer-connector, router, vulnerability-scanner, and the winagent mingw `build` jobs of windows-{dll-hijack,files,installer-upgrade}.
  - Integration-test builds: engine, manager, inventory-sync, vulnerability-scanner.
  - The setup is always placed **before the first cmake configure** of the job: cmake bakes the compiler's absolute path into `CMakeCache.txt`, so wrappers created afterwards are silently bypassed (measured: zero compile requests) — this ordering is the one non-obvious rule for anyone adding the action to another workflow.
- **Deliberately excluded**: coverity and scan-build (caching would bypass the analysis), the package builds (they compile inside builder containers), the macOS suites (darwin binary not wired yet), and everything that does not compile on the runner.

### Results and Evidence

**The integration is fail-safe, demonstrated in production.** The first pilot dispatches ran with the cache silently disabled (the bucket-secret scheme issue below): all 9 jobs passed, identical to an uncached run — [UT run](https://github.com/wazuh/wazuh/actions/runs/31586587377), [RTR run](https://github.com/wazuh/wazuh/actions/runs/31586589629). Those runs double as clean baselines on the same runner class:

| Job | Baseline (uncached, ubuntu-24.04) |
|---|---:|
| Unit-Tests (manager) | 76 min |
| Unit-Tests (winagent) | 46 min |
| Unit-Tests (agent) | 19 min |
| RTR syscollector (agent / winagent) | 27 / 18 min |
| RTR data_provider (agent / winagent) | 25 / 17 min |
| RTR dbsync (agent / winagent) | 24 / 17 min |

**The existing CI role can read and write the cache prefix** — verified with a dispatch probe after normalizing the bucket: [probe run](https://github.com/wazuh/wazuh/actions/runs/31592153922) (`VERDICT: READ+WRITE OK on the sccache prefix`). No IAM or bucket change is needed.

**Two environment quirks worth recording, both handled inside the action:**
1. `CI_INTERNAL_S3_BUCKET` stores the value *with* the `s3://` scheme embedded (that is how `upload_s3_artifact` consumes it). Any consumer that prepends the scheme builds `s3://s3://…` and fails parameter validation before reaching IAM. The action strips the scheme and folds any base path into the effective key prefix.
2. The bucket lives in a different region than the CI default. The AWS CLI follows the S3 301 redirect transparently — which is why artifact uploads always worked — but sccache's S3 client does not, and its startup storage check dies on the redirect (`Unexpected (permanent) at stat`, [smoke evidence](https://github.com/wazuh/wazuh/actions/runs/31593743688)). The action resolves the real region from the unauthenticated `x-amz-bucket-region` header. End-to-end validation after the fix: a hello.c compiled twice through the wrappers gives 1 miss + 1 hit ([smoke run](https://github.com/wazuh/wazuh/actions/runs/31593898174)).

#### Cold/warm measurement — the pilot result

Same commit, same runner class, dispatched sequentially. **Cold** ([RTR](https://github.com/wazuh/wazuh/actions/runs/31593978062), [UT](https://github.com/wazuh/wazuh/actions/runs/31593980476)) populates the cache; **warm** ([RTR](https://github.com/wazuh/wazuh/actions/runs/31600546513), [UT](https://github.com/wazuh/wazuh/actions/runs/31600549423)) consumes it. All 18 jobs green in both.

| Job | Baseline (uncached) | Cold (populating) | Warm | Warm vs baseline | Warm hits/misses |
|---|---:|---:|---:|---:|---|
| Unit-Tests (manager) | 76 min | 78.1 min | **7.6 min** | **−90%** | 1171/4 |
| Unit-Tests (winagent) | 46 min | 44.1 min | **24.1 min** | −48% | 910/1 |
| Unit-Tests (agent) | 19 min | 20.8 min | **4.9 min** | −74% | 876/1 |
| RTR syscollector (agent / winagent) | 27 / 18 min | 21.9 / 17.5 min | **11 / 10.3 min** | −59% / −43% | 2161/0 · 1363/1 |
| RTR data_provider (agent / winagent) | 25 / 17 min | 21.3 / 15.6 min | **5.7 / 8.1 min** | −77% / −52% | 2161/0 · 1364/0 |
| RTR dbsync (agent / winagent) | 24 / 17 min | 21.1 / 15.7 min | **4.9 / 7.3 min** | −80% / −57% | 2161/0 · 1364/0 |

Readings that matter for the rollout decision:

- **Non-cacheable compilations: 0 across all 18 jobs.** The open question about coverage instrumentation making part of the build uncacheable is answered: nothing in these workflows is rejected by sccache.
- **Cold costs nothing**: populating the cache runs at baseline speed (manager 78.1 vs 76 min, and the RTR cold was actually *faster* than baseline because its six jobs share compilations within the same run — dbsync/data_provider/syscollector all rebuild the shared modules and hit each other's fresh entries).
- **Warm hit rates are 96–99%** of compile requests, on both native gcc and the mingw crosses.
- Per PR touching `src/`, the three Unit-Test jobs drop from 141 to ~37 job-minutes, and the PR-blocking wall-clock for the slowest check (manager) from 76 to under 8 minutes.

#### Rollout validation — cross-workflow sharing confirmed

`5_testcomponent_syscheck-rtr.yml`, instrumented in the rollout and never run before, was **born warm** from the cache populated by other workflows: 2161 hits / 0 misses (agent leg, [run](https://github.com/wazuh/wazuh/actions/runs/31687987327)), 5 min against the ~24 min of comparable RTR baselines. The shared prefix turns every workflow's compilation into every other workflow's cache.

### Artifacts Affected

None. CI configuration only: no product source, packaging or configuration is touched. Test binaries are compiled through sccache, whose hits are byte-equivalent recompilations.

### Configuration Changes

None user-facing. CI-internal: cache objects live under `sccache/5.0.0` in the internal CI bucket; an S3 lifecycle rule for the `sccache/` prefix should be requested before rollout to bound storage growth (not blocking the pilot).

### Documentation Updates

None.

### Tests Introduced

None. The existing suites run unchanged; the pilot's purpose is to measure their build phase under the cache.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided — baselines, probe, and the cold/warm comparison with per-job hit rates
- [ ] Tests cover the new functionality — N/A, CI configuration; validated by the pilot runs themselves
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes — N/A
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (`no-changelog`)
