### PR TITLE
Register the manager's HTTPS dependency stack in the externals manifest

### DIFF
--- a/packages/externals/build_external.sh
+++ b/packages/externals/build_external.sh
@@ -137,20 +137,26 @@ fi
 # shellcheck disable=SC1091
 source "${WAZUH_SRC}/packages/externals/external_sources.sh"
 
-# Substitute {version}, {version_us}, and {version_concat} in a URL template.
+# Substitute {version}, {version_us}, {version_dash} and {version_concat} in a
+# URL template.
 # {version_concat} maps a dotted version like "3.51.1" to sqlite's
 # concatenated form "3510100" — major (raw) + minor (2 digits) + patch (2
 # digits) + a "00" trailing release counter. sqlite is the only consumer
 # today; the format is documented at https://www.sqlite.org/download.html.
+# {version_dash} maps "1.38.2" to "1-38-2", which is how asio tags its
+# releases (asio-1-38-2). Keeping the substitution here means every dep is
+# still named with a plain dotted version in the workflow input.
 expand_url() {
     local template="$1" version="$2"
     local version_us="${version//./_}"
+    local version_dash="${version//./-}"
     local maj min pat
     IFS='.' read -r maj min pat _ <<< "${version}"
     local version_concat
     version_concat="$(printf '%d%02d%02d00' "${maj:-0}" "${min:-0}" "${pat:-0}")"
     template="${template//\{version\}/${version}}"
     template="${template//\{version_us\}/${version_us}}"
+    template="${template//\{version_dash\}/${version_dash}}"
     template="${template//\{version_concat\}/${version_concat}}"
     echo "$template"
 }

--- a/packages/externals/external_sources.sh
+++ b/packages/externals/external_sources.sh
@@ -132,6 +132,17 @@ _reg fast_float         "https://github.com/fastfloat/fast_float/archive/refs/ta
 _reg tzdata             "https://data.iana.org/time-zones/releases/tzdata{version}.tar.gz"                                        tar.gz  0  tzdata             false  "https://data.iana.org/time-zones/"
 _reg geo_db             "TBD"                                                                                                     tar.gz  0  geo_db             false  "https://www.maxmind.com/"
 
+# The manager's HTTPS listener stack: restinio plus the asio, llhttp and
+# expected-lite it is built against, and zstd. asio tags releases with dashes
+# (asio-1-38-2), hence {version_dash}; llhttp puts its tags under a release/
+# prefix; restinio and zstd publish source tarballs as release assets, which is
+# what src/external/ currently vendors.
+_reg asio               "https://github.com/chriskohlhoff/asio/archive/refs/tags/asio-{version_dash}.tar.gz"                       tar.gz  1  asio               false  "https://github.com/chriskohlhoff/asio"
+_reg expected-lite      "https://github.com/martinmoene/expected-lite/archive/refs/tags/v{version}.tar.gz"                        tar.gz  1  expected-lite      false  "https://github.com/martinmoene/expected-lite"
+_reg llhttp             "https://github.com/nodejs/llhttp/archive/refs/tags/release/v{version}.tar.gz"                            tar.gz  1  llhttp             false  "https://github.com/nodejs/llhttp"
+_reg restinio           "https://github.com/Stiffstream/restinio/releases/download/v{version}/restinio-{version}.tar.bz2"          tar.bz2 1  restinio           false  "https://github.com/Stiffstream/restinio"
+_reg zstd               "https://github.com/facebook/zstd/releases/download/v{version}/zstd-{version}.tar.gz"                      tar.gz  1  zstd               false  "https://github.com/facebook/zstd"
+
 # Sanity check: warn if any registered name has no corresponding directory in
 # src/external/. The script can decide whether to error or just log; this is
 # informational. Skipped at source-time (no side effects beyond array writes).


### PR DESCRIPTION
## Description

The `5.X - Package - Build external dependencies` workflow cannot produce a dependency tree a manager can build against. Its two manager smoke builds fail while every build leg reports success, so the gap only surfaces at the very last step.

Five deps belong to the manager's dep set in `src/Makefile` but were never registered in `packages/externals/external_sources.sh`: `asio`, `expected-lite`, `llhttp`, `restinio` and `zstd` — restinio and the libraries it is built against, plus zstd. `build_external.sh` skips anything with no manifest entry, so nothing is snapshotted and nothing reaches `libraries/sources/`.

Seen on run [31604805833](https://github.com/wazuh/wazuh/actions/runs/31604805833) (dispatched from #38320): 6/6 build legs green, `consolidate` green, agent and winagent smoke builds green, both manager smoke builds red.

## Proposed Changes

- Register the five deps in `packages/externals/external_sources.sh`.
- Add `{version_dash}` to `expand_url()` in `packages/externals/build_external.sh`, because asio tags releases as `asio-1-38-2`. Doing the mapping in the substitution keeps asio's workflow input a plain dotted version like every other dep.

`cpython` is also reported as "not in manifest" and is intentionally left that way: its build is special-cased, and it already reaches the tree through the passthrough path — the smoke build downloads it successfully.

### Results and Evidence

**The mechanism, from the failing run's own logs.** Each build leg (`rpm-amd64-manager` shown):

```
skipping asio (not in manifest)
skipping cpython (not in manifest)
skipping expected-lite (not in manifest)
skipping llhttp (not in manifest)
skipping restinio (not in manifest)
skipping zstd (not in manifest)
```

`build_external.sh` snapshots sources with:

```bash
for name in ${DEPS_FOR_LEG}; do
    if [ -z "${EXT_URL[$name]:-}" ]; then
        log "skipping ${name} (not in manifest)"; continue
    fi
    snapshot_source "${name}"
done
```

No entry → no `<dep>_src.zip`. `generate_external.sh` packs `libraries/sources/` from those zips, so the five are absent from the consolidated tree, and the manager smoke build stops at the first one it needs:

```
[-] Downloading dependency cpp-httplib ...
[+] Dependency cpp-httplib installed successfully
[-] Downloading dependency asio ...
make: *** [external/asio.tar.gz] Error 37
```

Error 37 is curl's `CURLE_FILE_COULDNT_READ_FILE`: the smoke build points `make deps` at the consolidated tree over `file://`, so a missing tarball surfaces as a read error rather than a 404. Fixing only `asio` would then have failed on `expected-lite`, and so on.

**Every new entry was resolved through the shipped `expand_url()`** at the versions `src/external/` vendors today (1.38.2, 0.10.0, 9.4.2, 0.7.9, 1.5.7 — read from the vendored headers: `ASIO_VERSION 103802`, `RESTINIO_VERSION_*`, `LLHTTP_VERSION_*`, `ZSTD_VERSION_*`, `expected_lite_*`):

```
  asio           200 fmt=tar.gz  strip=1  .../asio/archive/refs/tags/asio-1-38-2.tar.gz
  expected-lite  200 fmt=tar.gz  strip=1  .../expected-lite/archive/refs/tags/v0.10.0.tar.gz
  llhttp         200 fmt=tar.gz  strip=1  .../llhttp/archive/refs/tags/release/v9.4.2.tar.gz
  restinio       200 fmt=tar.bz2 strip=1  .../restinio/releases/download/v0.7.9/restinio-0.7.9.tar.bz2
  zstd           200 fmt=tar.gz  strip=1  .../zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz
```

**Strip levels and source choice were verified against the vendored trees**, not assumed. Each tarball was downloaded and its marker file located:

| dep | marker as vendored | position in tarball | strip |
|---|---|---|---|
| asio | `include/asio/version.hpp` | `asio-asio-1-38-2/include/asio/version.hpp` | 1 |
| restinio | `dev/restinio/version.hpp` | `restinio-0.7.9/dev/restinio/version.hpp` | 1 |
| llhttp | `include/llhttp.h` | `llhttp-release-v9.4.2/include/llhttp.h` | 1 |
| zstd | `lib/zstd.h` | `zstd-1.5.7/lib/zstd.h` | 1 |
| expected-lite | `include/nonstd/expected.hpp` | `expected-lite-0.10.0/include/nonstd/expected.hpp` | 1 |

restinio is taken from the **release asset** rather than the tag archive because that is what is vendored: at strip 1 the asset yields `dev externals.rb LICENSE LICENSE.catch2 LICENSE.expected-lite LICENSE.fmtlib LICENSE.llhttp LICENSE.zlib README.md`, matching `src/external/restinio/` exactly, whereas the archive lacks those `LICENSE.*` files. The non-`-full` asset is the right one — the vendored `dev/` bundles no third-party deps, since we vendor asio, llhttp and expected-lite ourselves.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux <!-- no source compiled by this change; it is packaging metadata -->
  - [ ] Windows
  - [ ] MAC OS X
- [x] Log syntax and correct language review — only the new `skipping ...` cases disappear; no new messages

- Memory tests for Linux — N/A (shell manifest, no compiled code)
- Memory tests for Windows — N/A
- Memory tests for macOS — N/A
- Decoder/Rule tests _(Wazuh v4.x)_ — N/A
- Engine _(Wazuh v5.x and above)_ — N/A
- Wazuh server API/Framework — N/A

**Not yet verified, and it needs a maintainer with dispatch rights:** a full `5.X - Package - Build external dependencies` run. What is proven here is that the five URLs resolve through the shipped substitution code and extract to the layout `src/external/` expects; what a real run adds is that each leg snapshots them and both manager smoke builds go green. That run is the acceptance test for this PR.

### Artifacts Affected

- The published externals tree: `libraries/sources/` gains `asio`, `expected-lite`, `llhttp`, `restinio` and `zstd`.
- No Wazuh binary changes.

### Configuration Changes

None. `{version_dash}` is a new URL-template placeholder, additive and used only by the asio entry.

### Tests Introduced

None — this repository has no test harness for the packaging manifests. The workflow's manager smoke build is the existing check that catches exactly this class of gap, and it is the one that caught it.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality — no harness exists for these manifests; the workflow's smoke build is the check
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

### Note for the reviewer

Worth deciding separately: the manifest can drift from `src/Makefile` silently, and the cost is a red workflow that looks like a build failure. `build_external.sh` already computes `DEPS_FOR_LEG` from the Makefile, so it could fail loudly — or the workflow could assert the manifest covers every dep in the target's set — instead of logging `skipping ... (not in manifest)` and carrying on to produce an incomplete tree. Out of scope here, but it is the reason this reached a dispatched run.
