### PR TITLE
Prevent Windows agent crash when promoting FIM registry rows whose configuration was removed

### DIFF
--- a/.github/workflows/5_testunit_macos.yml
+++ b/.github/workflows/5_testunit_macos.yml
@@ -39,8 +39,29 @@ jobs:
       - name: Install cmocka 1.1.7 and lcov
         run: |
           brew install lcov
-          curl -LO https://cmocka.org/files/1.1/cmocka-1.1.7.tar.xz
-          tar -xf cmocka-1.1.7.tar.xz
+
+          CMOCKA_TARBALL="cmocka-1.1.7.tar.xz"
+          CMOCKA_URL="https://cmocka.org/files/1.1/cmocka-1.1.7.tar.xz"
+          CMOCKA_MIRROR_URL="https://gitlab.com/cmocka/cmocka/-/archive/cmocka-1.1.7/cmocka-cmocka-1.1.7.tar.gz"
+
+          if ! curl -fL --retry 3 --retry-delay 2 --connect-timeout 15 --max-time 300 -o "$CMOCKA_TARBALL" "$CMOCKA_URL" \
+             || ! tar -tf "$CMOCKA_TARBALL" >/dev/null 2>&1; then
+            echo "Primary CMocka download failed or returned an invalid archive. Falling back to the GitLab mirror (same upstream tag, cmocka 1.1.7)..."
+            CMOCKA_TARBALL="cmocka-1.1.7.tar.gz"
+            if ! curl -fL --retry 3 --retry-delay 2 --connect-timeout 15 --max-time 300 -o "$CMOCKA_TARBALL" "$CMOCKA_MIRROR_URL"; then
+              echo "Error during download. Exiting..."
+              exit 1
+            fi
+          fi
+
+          tar -xf "$CMOCKA_TARBALL"
+          # The GitLab mirror's archive extracts to cmocka-cmocka-1.1.7/ rather than cmocka-1.1.7/;
+          # normalize it so the rest of this step doesn't care which source was actually used.
+          extracted_dir="$(tar -tf "$CMOCKA_TARBALL" | head -1 | cut -d/ -f1)"
+          if [ "$extracted_dir" != "cmocka-1.1.7" ]; then
+            mv "$extracted_dir" cmocka-1.1.7
+          fi
+
           cd cmocka-1.1.7
           mkdir build && cd build
           cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local

--- a/src/syscheckd/src/recovery/recovery.c
+++ b/src/syscheckd/src/recovery/recovery.c
@@ -190,11 +190,23 @@ void fim_recovery_persist_table_and_resync(char* table_name, AgentSyncProtocolHa
             stateful_event = buildFileStatefulEvent(path, item_copy, checksum, document_version, directories_list);
         }
 #ifdef WIN32
-        else if (strcmp(table_name, FIMDB_REGISTRY_KEY_TABLENAME) == 0) {
-            stateful_event = buildRegistryKeyStatefulEvent(path, item_copy, checksum, document_version, arch);
-        }
-        else if (strcmp(table_name, FIMDB_REGISTRY_VALUE_TABLENAME) == 0) {
-            stateful_event = buildRegistryValueStatefulEvent(path, value, item_copy, checksum, document_version, arch);
+        else if (strcmp(table_name, FIMDB_REGISTRY_KEY_TABLENAME) == 0 ||
+                 strcmp(table_name, FIMDB_REGISTRY_VALUE_TABLENAME) == 0) {
+            // Same reasoning as the file_entry branch above, resolved against syscheck.registry:
+            // a shared-config push can replace the <syscheck> registry entries, leaving rows whose
+            // path no longer matches any configured entry for this architecture.
+            if (fim_registry_configuration(path, arch) == NULL) {
+                mdebug2("Skipping recovery of orphaned path (no active configuration): %s", path);
+                cJSON_Delete(item_copy);
+                os_free(id_str);
+                continue;
+            }
+
+            if (strcmp(table_name, FIMDB_REGISTRY_KEY_TABLENAME) == 0) {
+                stateful_event = buildRegistryKeyStatefulEvent(path, item_copy, checksum, document_version, arch);
+            } else {
+                stateful_event = buildRegistryValueStatefulEvent(path, value, item_copy, checksum, document_version, arch);
+            }
         }
 #endif // WIN32
         if (stateful_event) {

--- a/src/syscheckd/src/registry/events.c
+++ b/src/syscheckd/src/registry/events.c
@@ -192,6 +192,13 @@ cJSON *fim_registry_value_attributes_json(const cJSON* dbsync_event, const fim_r
 
     cJSON *attributes = cJSON_CreateObject();
 
+    // Every branch below reads configuration->opts to know which checks are enabled, so a NULL
+    // configuration leaves nothing to translate. Callers are expected to reject it beforehand
+    // (see build_stateful_event_registry_value); this keeps the public helper from faulting.
+    if (configuration == NULL) {
+        return attributes;
+    }
+
     if (data) {
         if (configuration->opts & CHECK_SIZE) {
             cJSON_AddNumberToObject(attributes, "size", data->size);
@@ -311,6 +318,12 @@ cJSON *fim_registry_value_attributes_json(const cJSON* dbsync_event, const fim_r
  */
 cJSON *fim_registry_key_attributes_json(const cJSON* dbsync_event, const fim_registry_key *data, const registry_t *configuration) {
     cJSON *attributes = cJSON_CreateObject();
+
+    // See fim_registry_value_attributes_json: configuration->opts drives every branch below, and the
+    // optimizer hoists that read above the `if (data)` test, so a NULL configuration faults either way.
+    if (configuration == NULL) {
+        return attributes;
+    }
 
     if (data) {
         if (configuration->opts & CHECK_PERM) {

--- a/src/syscheckd/src/registry/registry.c
+++ b/src/syscheckd/src/registry/registry.c
@@ -153,6 +153,15 @@ cJSON* build_stateful_event_registry(const char* path, const char* sha1_hash, co
 
 cJSON* build_stateful_event_registry_key(const char* path, const char* sha1_hash, const uint64_t document_version, int arch, const cJSON *dbsync_event, fim_registry_key *registry_data){
     const registry_t* config = fim_registry_configuration(path, arch);
+
+    // If config is NULL the attributes cannot be translated: fim_registry_key_attributes_json needs it
+    // to know which checks are enabled. Callers replaying rows from the local DB (startup promotion,
+    // recovery resync) may hand us a path that is no longer covered by the current configuration.
+    if (config == NULL) {
+        merror("Failed to get configuration for registry path: %s", path);
+        return NULL;
+    }
+
     cJSON* registry_stateful = fim_registry_key_attributes_json(dbsync_event, registry_data, config);
 
     cJSON* stateful_event = build_stateful_event_registry(path, sha1_hash, document_version, arch, dbsync_event, registry_stateful);
@@ -168,6 +177,13 @@ cJSON* build_stateful_event_registry_key(const char* path, const char* sha1_hash
 
 cJSON* build_stateful_event_registry_value(const char* path, const char* value, const char* sha1_hash, const uint64_t document_version, int arch, const cJSON *dbsync_event, fim_registry_value_data *registry_data){
     const registry_t* config = fim_registry_configuration(path, arch);
+
+    // Same as build_stateful_event_registry_key: without configuration there is nothing to translate.
+    if (config == NULL) {
+        merror("Failed to get configuration for registry path: %s", path);
+        return NULL;
+    }
+
     cJSON* registry_stateful = fim_registry_value_attributes_json(dbsync_event, registry_data, config);
 
     char *utf8_value = auto_to_utf8(value);
@@ -1172,6 +1188,15 @@ registry_t *fim_registry_configuration(const char *key, int arch) {
     int top = 0;
     int match;
     registry_t *ret = NULL;
+
+    // syscheck.registry is normally left as REGISTRY_EMPTY by Read_Syscheck_Config, but that fallback
+    // sits after its OS_INVALID returns: an unparseable ossec.conf leaves it NULL, and
+    // Start_win32_Syscheck's dump_syscheck_registry() recovery only runs on the "disabled" branch,
+    // while fim_initialize() runs unconditionally. Guard here so every caller is safe.
+    if (syscheck.registry == NULL) {
+        mdebug2(FIM_CONFIGURATION_NOTFOUND, "registry", key);
+        return NULL;
+    }
 
     for (it = 0; syscheck.registry[it].entry; it++) {
         if (arch != syscheck.registry[it].arch) {

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -25,6 +25,9 @@
 #include "schemaValidator_c.h"
 #include "agentd_query.h"
 #include <limits.h>
+#ifdef WIN32
+#include "registry.h"
+#endif
 
 // Global variables
 syscheck_config syscheck;
@@ -150,37 +153,87 @@ void process_pending_sync_updates(char* table_name, OSList *pending_items) {
 /**
  * @brief Drop documents whose path is no longer covered by the current FIM configuration.
  *
- * Run before promoting file_entry rows at startup: if a directory was removed from the
+ * Run before promoting rows at startup: if a monitored path was removed from the
  * configuration since the last run (e.g. an agent group with a realtime FIM rule was
- * unassigned), the persisted rows for files under that path can no longer build a
- * stateful event — build_stateful_event_file would fail and log a spurious ERROR.
+ * unassigned, or the <syscheck> registry entries were replaced by a shared-config push),
+ * the persisted rows under that path can no longer build a stateful event — the
+ * build_stateful_event_* helpers would fail and log a spurious ERROR.
  * The scheduled scan that follows fim_initialize emits the real DELETE for these
  * rows via handle_orphaned_delete, so dropping them here is safe.
  *
- * Only applies to file_entry; registry tables use a different config model.
+ * file_entry rows are resolved against syscheck.directories; on Windows the registry
+ * tables are resolved against syscheck.registry, which is keyed by path *and* architecture.
  *
  * @param table_name Name of the table the documents belong to.
  * @param docs cJSON array of documents about to be promoted. Modified in place.
  * @return Number of documents dropped.
  */
 int drop_orphaned_promoted_documents(const char* table_name, cJSON* docs) {
-    if (!docs || !cJSON_IsArray(docs) || strcmp(table_name, FIMDB_FILE_TABLE_NAME) != 0) {
+    if (!docs || !cJSON_IsArray(docs) || table_name == NULL) {
+        return 0;
+    }
+
+    const bool is_file = strcmp(table_name, FIMDB_FILE_TABLE_NAME) == 0;
+#ifdef WIN32
+    const bool is_registry = strcmp(table_name, FIMDB_REGISTRY_KEY_TABLENAME) == 0 ||
+                             strcmp(table_name, FIMDB_REGISTRY_VALUE_TABLENAME) == 0;
+#else
+    const bool is_registry = false;
+#endif
+
+    if (!is_file && !is_registry) {
         return 0;
     }
 
     int dropped = 0;
-    for (int i = cJSON_GetArraySize(docs) - 1; i >= 0; i--) {
-        const cJSON* item = cJSON_GetArrayItem(docs, i);
+
+    // Walk the child list directly instead of indexing: cJSON_GetArrayItem and
+    // cJSON_DeleteItemFromArray both traverse from the head, so an index-based loop is O(n^2).
+    // The registry tables reach tens of thousands of rows and this runs on the startup path.
+    cJSON* item = docs->child;
+
+    while (item != NULL) {
+        // Saved before any detach, which unlinks item from the list.
+        cJSON* next = item->next;
+
         const cJSON* path_json = cJSON_GetObjectItem(item, "path");
         const char* path = cJSON_GetStringValue(path_json);
         if (path == NULL) {
+            item = next;
             continue;
         }
-        if (fim_configuration_directory(path, false, syscheck.directories) == NULL) {
+
+        bool orphaned = false;
+
+        if (is_file) {
+            orphaned = fim_configuration_directory(path, false, syscheck.directories) == NULL;
+        }
+#ifdef WIN32
+        else {
+            // Registry rows are only meaningful together with their architecture: the same path can
+            // be monitored for [x32], [x64] or both. A row without it cannot be resolved at all.
+            const char* arch_str = cJSON_GetStringValue(cJSON_GetObjectItem(item, "architecture"));
+
+            if (arch_str == NULL) {
+                mdebug2("Skipping promotion of registry document without architecture: %s", path);
+                cJSON_Delete(cJSON_DetachItemViaPointer(docs, item));
+                dropped++;
+                item = next;
+                continue;
+            }
+
+            const int arch = (strcmp(arch_str, "[x32]") == 0) ? ARCH_32BIT : ARCH_64BIT;
+            orphaned = fim_registry_configuration(path, arch) == NULL;
+        }
+#endif
+
+        if (orphaned) {
             mdebug2("Skipping promotion of orphaned path (no active configuration): %s", path);
-            cJSON_DeleteItemFromArray(docs, i);
+            cJSON_Delete(cJSON_DetachItemViaPointer(docs, item));
             dropped++;
         }
+
+        item = next;
     }
     return dropped;
 }

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -501,6 +501,7 @@ target_link_libraries(test_fim_sync_limits SYSCHECK_O ${TEST_DEPS})
 if(${TARGET} STREQUAL "winagent")
   target_link_libraries(test_fim_sync_limits "${FIM_SYNC_LIMITS_BASE_FLAGS} -Wl,--wrap,syscom_dispatch -Wl,--wrap,Start_win32_Syscheck \
                                 -Wl,--wrap=is_fim_shutdown -Wl,--wrap=_imp__dbsync_initialize \
+                                -Wl,--wrap,fim_registry_configuration \
                                 -Wl,--wrap=fim_db_teardown" fimdb)
 else()
   target_link_libraries(test_fim_sync_limits "${FIM_SYNC_LIMITS_BASE_FLAGS}")
@@ -529,6 +530,7 @@ target_link_libraries(test_recovery SYSCHECK_O ${TEST_DEPS})
 if(${TARGET} STREQUAL "winagent")
   target_link_libraries(test_recovery "${RECOVERY_BASE_FLAGS} -Wl,--wrap=is_fim_shutdown \
                                        -Wl,--wrap=fim_db_teardown -Wl,--wrap=Start_win32_Syscheck \
+                                       -Wl,--wrap,fim_registry_configuration \
                                        -Wl,--wrap=syscom_dispatch" fimdb)
 else()
   target_link_libraries(test_recovery "${RECOVERY_BASE_FLAGS} -Wl,--wrap,time")

--- a/src/unit_tests/syscheckd/registry/test_events.c
+++ b/src/unit_tests/syscheckd/registry/test_events.c
@@ -387,6 +387,64 @@ void test_registry_value_attributes_json_dbsync(void **state) {
 }
 
 
+/* A NULL configuration must yield an empty attributes object instead of faulting.
+ * Every branch of these helpers reads configuration->opts, and at -O2 that load is hoisted above the
+ * `if (data)` test, so both the entry and the dbsync flavour crash without the guard. */
+
+void test_registry_key_attributes_json_null_configuration_with_data(void **state) {
+    json_data_t *data = calloc(1, sizeof(json_data_t));
+    fim_registry_key registry_data = DEFAULT_REGISTRY_KEY;
+
+    cJSON *event = fim_registry_key_attributes_json(NULL, &registry_data, NULL);
+
+    data->data2 = event;
+    *state = data;
+
+    assert_non_null(event);
+    assert_string_equal("{}", cJSON_PrintUnformatted(event));
+}
+
+void test_registry_key_attributes_json_null_configuration_dbsync(void **state) {
+    json_data_t *data = calloc(1, sizeof(json_data_t));
+    cJSON *dbsync_event = cJSON_Parse("{\"path\":\"HKEY_LOCAL_MACHINE\\\\Security\",\"uid\":\"110\",\"mtime\":1100}");
+
+    cJSON *event = fim_registry_key_attributes_json(dbsync_event, NULL, NULL);
+
+    data->data1 = dbsync_event;
+    data->data2 = event;
+    *state = data;
+
+    assert_non_null(event);
+    assert_string_equal("{}", cJSON_PrintUnformatted(event));
+}
+
+void test_registry_value_attributes_json_null_configuration_with_data(void **state) {
+    json_data_t *data = calloc(1, sizeof(json_data_t));
+    fim_registry_value_data registry_data = DEFAULT_REGISTRY_VALUE;
+
+    cJSON *event = fim_registry_value_attributes_json(NULL, &registry_data, NULL);
+
+    data->data2 = event;
+    *state = data;
+
+    assert_non_null(event);
+    assert_string_equal("{}", cJSON_PrintUnformatted(event));
+}
+
+void test_registry_value_attributes_json_null_configuration_dbsync(void **state) {
+    json_data_t *data = calloc(1, sizeof(json_data_t));
+    cJSON *dbsync_event = cJSON_Parse("{\"path\":\"HKEY_LOCAL_MACHINE\\\\Security\",\"size\":50,\"type\":1}");
+
+    cJSON *event = fim_registry_value_attributes_json(dbsync_event, NULL, NULL);
+
+    data->data1 = dbsync_event;
+    data->data2 = event;
+    *state = data;
+
+    assert_non_null(event);
+    assert_string_equal("{}", cJSON_PrintUnformatted(event));
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         // tests registry key transaction callback
@@ -408,6 +466,10 @@ int main(void) {
         cmocka_unit_test_teardown(test_registry_key_attributes_json_dbsync, teardown_cjson_data),
         cmocka_unit_test_teardown(test_registry_value_attributes_json_entry, teardown_cjson_data),
         cmocka_unit_test_teardown(test_registry_value_attributes_json_dbsync, teardown_cjson_data),
+        cmocka_unit_test_teardown(test_registry_key_attributes_json_null_configuration_with_data, teardown_cjson_data),
+        cmocka_unit_test_teardown(test_registry_key_attributes_json_null_configuration_dbsync, teardown_cjson_data),
+        cmocka_unit_test_teardown(test_registry_value_attributes_json_null_configuration_with_data, teardown_cjson_data),
+        cmocka_unit_test_teardown(test_registry_value_attributes_json_null_configuration_dbsync, teardown_cjson_data),
 
     };
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/syscheckd/registry/test_registry.c
+++ b/src/unit_tests/syscheckd/registry/test_registry.c
@@ -386,6 +386,55 @@ static void test_fim_registry_configuration_null_key(void **state) {
     assert_null(configuration);
 }
 
+// An unparseable ossec.conf leaves syscheck.registry NULL: the REGISTRY_EMPTY fallback in
+// Read_Syscheck_Config sits after its OS_INVALID returns, Start_win32_Syscheck's
+// dump_syscheck_registry() recovery only runs on the "disabled" branch, and fim_initialize()
+// runs unconditionally. The lookup must tolerate it instead of dereferencing a NULL array.
+static void test_fim_registry_configuration_null_registry_array(void **state) {
+    registry_t *saved = syscheck.registry;
+    registry_t *configuration;
+
+    expect_any_always(__wrap__mdebug2, formatted_msg);
+
+    syscheck.registry = NULL;
+    configuration = fim_registry_configuration("HKEY_LOCAL_MACHINE\\Security", ARCH_64BIT);
+    syscheck.registry = saved;
+
+    assert_null(configuration);
+}
+
+/* The stateful-event builders must refuse a path that no longer resolves to a
+ * configured registry entry instead of handing a NULL configuration to the attribute helpers.
+ * This is the path taken when rows persisted under an older <syscheck> config are replayed from
+ * the local DB (startup promotion in fim_initialize, recovery resync). */
+
+static void test_build_stateful_event_registry_key_no_configuration(void **state) {
+    (void) state;
+
+    expect_any_always(__wrap__mdebug2, formatted_msg);
+    expect_string(__wrap__merror, formatted_msg,
+                  "Failed to get configuration for registry path: HKEY_LOCAL_MACHINE\\Security");
+
+    cJSON *event = build_stateful_event_registry_key("HKEY_LOCAL_MACHINE\\Security", "1234567890ABCDEF1234567890ABCDEF12345678",
+                                                     1, ARCH_64BIT, NULL, NULL);
+
+    assert_null(event);
+}
+
+static void test_build_stateful_event_registry_value_no_configuration(void **state) {
+    (void) state;
+
+    expect_any_always(__wrap__mdebug2, formatted_msg);
+    expect_string(__wrap__merror, formatted_msg,
+                  "Failed to get configuration for registry path: HKEY_LOCAL_MACHINE\\Security");
+
+    cJSON *event = build_stateful_event_registry_value("HKEY_LOCAL_MACHINE\\Security", "TestValue",
+                                                       "1234567890ABCDEF1234567890ABCDEF12345678",
+                                                       1, ARCH_64BIT, NULL, NULL);
+
+    assert_null(event);
+}
+
 static void test_fim_registry_validate_recursion_level_null_configuration(void **state) {
     char *path = "HKEY_LOCAL_MACHINE\\Software\\Classes\\something";
     int ret;
@@ -1983,6 +2032,11 @@ int main(void) {
         cmocka_unit_test(test_fim_registry_configuration_registry_not_found_arch_does_not_match),
         cmocka_unit_test(test_fim_registry_configuration_registry_not_found_path_does_not_match),
         cmocka_unit_test(test_fim_registry_configuration_null_key),
+        cmocka_unit_test(test_fim_registry_configuration_null_registry_array),
+
+        /* build_stateful_event_registry_* tests */
+        cmocka_unit_test(test_build_stateful_event_registry_key_no_configuration),
+        cmocka_unit_test(test_build_stateful_event_registry_value_no_configuration),
 
         /* fim_registry_validate_recursion_level tests */
         cmocka_unit_test(test_fim_registry_validate_recursion_level_null_configuration),

--- a/src/unit_tests/syscheckd/test_fim_sync_limits.c
+++ b/src/unit_tests/syscheckd/test_fim_sync_limits.c
@@ -31,6 +31,13 @@ extern int drop_orphaned_promoted_documents(const char* table_name, cJSON* docs)
 // (real __wrap_fim_configuration_directory lives in create_db_wrappers.c)
 static directory_t mock_drop_directory_config = {0};
 
+#ifdef WIN32
+// Stand-in registry_t pointer for "config exists" signal in the registry drop tests
+static registry_t mock_drop_registry_config = {0};
+
+registry_t* __wrap_fim_registry_configuration(const char* key, int arch);
+#endif
+
 // Local wrapper declarations (defined per-test-file like test_recovery.c)
 cJSON* __wrap_build_stateful_event_file(const char* path, const char* sha1_hash,
                                         const uint64_t document_version, const cJSON *dbsync_event,
@@ -107,6 +114,12 @@ cJSON* __wrap_build_stateful_event_registry_value(const char* path, const char* 
     check_expected(document_version);
     check_expected(arch);
     return mock_ptr_type(cJSON*);
+}
+
+registry_t* __wrap_fim_registry_configuration(const char* key, int arch) {
+    check_expected(key);
+    check_expected(arch);
+    return mock_ptr_type(registry_t*);
 }
 #endif
 
@@ -549,9 +562,9 @@ static void test_drop_orphaned_promoted_documents_no_orphans(void **state) {
     cJSON_AddItemToArray(docs, create_file_doc("/etc/passwd", "abc123", 1));
     cJSON_AddItemToArray(docs, create_file_doc("/etc/hosts", "def456", 1));
 
-    expect_string(__wrap_fim_configuration_directory, path, "/etc/hosts");
-    will_return(__wrap_fim_configuration_directory, &mock_drop_directory_config);
     expect_string(__wrap_fim_configuration_directory, path, "/etc/passwd");
+    will_return(__wrap_fim_configuration_directory, &mock_drop_directory_config);
+    expect_string(__wrap_fim_configuration_directory, path, "/etc/hosts");
     will_return(__wrap_fim_configuration_directory, &mock_drop_directory_config);
 
     int dropped = drop_orphaned_promoted_documents(FIMDB_FILE_TABLE_NAME, docs);
@@ -570,12 +583,12 @@ static void test_drop_orphaned_promoted_documents_some_orphans(void **state) {
     cJSON_AddItemToArray(docs, create_file_doc("/etc/passwd", "abc123", 1));
     cJSON_AddItemToArray(docs, create_file_doc("/home/vagrant/orphan.txt", "ghi789", 2));
 
-    // Helper walks the array from the tail down; tail item is "/home/vagrant/orphan.txt".
-    expect_string(__wrap_fim_configuration_directory, path, "/home/vagrant/orphan.txt");
-    will_return(__wrap_fim_configuration_directory, NULL);
-
+    // Helper walks the array from the head; head item is "/etc/passwd".
     expect_string(__wrap_fim_configuration_directory, path, "/etc/passwd");
     will_return(__wrap_fim_configuration_directory, &mock_drop_directory_config);
+
+    expect_string(__wrap_fim_configuration_directory, path, "/home/vagrant/orphan.txt");
+    will_return(__wrap_fim_configuration_directory, NULL);
 
     expect_string(__wrap__mdebug2, formatted_msg,
                   "Skipping promotion of orphaned path (no active configuration): /home/vagrant/orphan.txt");
@@ -598,15 +611,15 @@ static void test_drop_orphaned_promoted_documents_all_orphans(void **state) {
     cJSON_AddItemToArray(docs, create_file_doc("/home/vagrant/a.txt", "a", 1));
     cJSON_AddItemToArray(docs, create_file_doc("/home/vagrant/b.txt", "b", 1));
 
-    expect_string(__wrap_fim_configuration_directory, path, "/home/vagrant/b.txt");
-    will_return(__wrap_fim_configuration_directory, NULL);
     expect_string(__wrap_fim_configuration_directory, path, "/home/vagrant/a.txt");
+    will_return(__wrap_fim_configuration_directory, NULL);
+    expect_string(__wrap_fim_configuration_directory, path, "/home/vagrant/b.txt");
     will_return(__wrap_fim_configuration_directory, NULL);
 
     expect_string(__wrap__mdebug2, formatted_msg,
-                  "Skipping promotion of orphaned path (no active configuration): /home/vagrant/b.txt");
-    expect_string(__wrap__mdebug2, formatted_msg,
                   "Skipping promotion of orphaned path (no active configuration): /home/vagrant/a.txt");
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "Skipping promotion of orphaned path (no active configuration): /home/vagrant/b.txt");
 
     int dropped = drop_orphaned_promoted_documents(FIMDB_FILE_TABLE_NAME, docs);
 
@@ -616,16 +629,115 @@ static void test_drop_orphaned_promoted_documents_all_orphans(void **state) {
     cJSON_Delete(docs);
 }
 
-// Registry tables go through a different config model and must be left untouched.
-static void test_drop_orphaned_promoted_documents_registry_noop(void **state) {
+// Tables the helper does not know about must be left untouched.
+static void test_drop_orphaned_promoted_documents_unknown_table_noop(void **state) {
+    (void) state;
+
+    cJSON* docs = cJSON_CreateArray();
+    cJSON_AddItemToArray(docs, create_file_doc("/etc/passwd", "abc123", 1));
+
+    // No lookup expectation: the helper must short-circuit before calling any config resolver.
+    int dropped = drop_orphaned_promoted_documents("unknown_table", docs);
+
+    assert_int_equal(dropped, 0);
+    assert_int_equal(cJSON_GetArraySize(docs), 1);
+
+    cJSON_Delete(docs);
+}
+
+#ifdef WIN32
+/* Tests for the registry side of drop_orphaned_promoted_documents() */
+
+// A registry key whose path is no longer under any configured entry is dropped; the one still
+// covered survives, and each row is resolved with its own architecture.
+static void test_drop_orphaned_promoted_documents_registry_key_orphan(void **state) {
+    (void) state;
+
+    cJSON* docs = cJSON_CreateArray();
+    cJSON_AddItemToArray(docs, create_registry_key_doc("HKEY_LOCAL_MACHINE\\Software\\WazuhLoadTest",
+                                                       "abc123", 1, "[x64]"));
+    cJSON_AddItemToArray(docs, create_registry_key_doc("HKEY_LOCAL_MACHINE\\Security", "def456", 1, "[x32]"));
+
+    // Helper walks the array from the head; head item is the still-covered [x64] one.
+    expect_string(__wrap_fim_registry_configuration, key, "HKEY_LOCAL_MACHINE\\Software\\WazuhLoadTest");
+    expect_value(__wrap_fim_registry_configuration, arch, ARCH_64BIT);
+    will_return(__wrap_fim_registry_configuration, &mock_drop_registry_config);
+
+    expect_string(__wrap_fim_registry_configuration, key, "HKEY_LOCAL_MACHINE\\Security");
+    expect_value(__wrap_fim_registry_configuration, arch, ARCH_32BIT);
+    will_return(__wrap_fim_registry_configuration, NULL);
+
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "Skipping promotion of orphaned path (no active configuration): HKEY_LOCAL_MACHINE\\Security");
+
+    int dropped = drop_orphaned_promoted_documents(FIMDB_REGISTRY_KEY_TABLENAME, docs);
+
+    assert_int_equal(dropped, 1);
+    assert_int_equal(cJSON_GetArraySize(docs), 1);
+    assert_string_equal(cJSON_GetStringValue(cJSON_GetObjectItem(cJSON_GetArrayItem(docs, 0), "path")),
+                        "HKEY_LOCAL_MACHINE\\Software\\WazuhLoadTest");
+
+    cJSON_Delete(docs);
+}
+
+// The registry value table is filtered the same way as the key table.
+static void test_drop_orphaned_promoted_documents_registry_value_orphan(void **state) {
+    (void) state;
+
+    cJSON* docs = cJSON_CreateArray();
+    cJSON_AddItemToArray(docs, create_registry_value_doc("HKEY_LOCAL_MACHINE\\Security", "TestValue",
+                                                         "abc123", 1, "[x64]"));
+
+    expect_string(__wrap_fim_registry_configuration, key, "HKEY_LOCAL_MACHINE\\Security");
+    expect_value(__wrap_fim_registry_configuration, arch, ARCH_64BIT);
+    will_return(__wrap_fim_registry_configuration, NULL);
+
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "Skipping promotion of orphaned path (no active configuration): HKEY_LOCAL_MACHINE\\Security");
+
+    int dropped = drop_orphaned_promoted_documents(FIMDB_REGISTRY_VALUE_TABLENAME, docs);
+
+    assert_int_equal(dropped, 1);
+    assert_int_equal(cJSON_GetArraySize(docs), 0);
+
+    cJSON_Delete(docs);
+}
+
+// A registry row without "architecture" cannot be resolved, so it is dropped without a lookup.
+static void test_drop_orphaned_promoted_documents_registry_missing_architecture(void **state) {
     (void) state;
 
     cJSON* docs = cJSON_CreateArray();
     cJSON* doc = cJSON_CreateObject();
-    cJSON_AddStringToObject(doc, "path", "HKEY_LOCAL_MACHINE\\Software\\Test");
+    cJSON_AddStringToObject(doc, "path", "HKEY_LOCAL_MACHINE\\Security");
+    cJSON_AddStringToObject(doc, "checksum", "abc123");
+    cJSON_AddNumberToObject(doc, "version", 1);
     cJSON_AddItemToArray(docs, doc);
 
-    // No fim_configuration_directory expectation: the helper must short-circuit before calling it.
+    // No fim_registry_configuration expectation: the row is dropped before the lookup.
+    expect_string(__wrap__mdebug2, formatted_msg,
+                  "Skipping promotion of registry document without architecture: HKEY_LOCAL_MACHINE\\Security");
+
+    int dropped = drop_orphaned_promoted_documents(FIMDB_REGISTRY_KEY_TABLENAME, docs);
+
+    assert_int_equal(dropped, 1);
+    assert_int_equal(cJSON_GetArraySize(docs), 0);
+
+    cJSON_Delete(docs);
+}
+
+// Registry rows still covered by the configuration are promoted untouched.
+static void test_drop_orphaned_promoted_documents_registry_no_orphans(void **state) {
+    (void) state;
+
+    cJSON* docs = cJSON_CreateArray();
+    cJSON_AddItemToArray(docs, create_registry_key_doc("HKEY_LOCAL_MACHINE\\Software\\WazuhLoadTest",
+                                                       "abc123", 1, "[x32]"));
+
+    expect_string(__wrap_fim_registry_configuration, key, "HKEY_LOCAL_MACHINE\\Software\\WazuhLoadTest");
+    expect_value(__wrap_fim_registry_configuration, arch, ARCH_32BIT);
+    will_return(__wrap_fim_registry_configuration, &mock_drop_registry_config);
+
     int dropped = drop_orphaned_promoted_documents(FIMDB_REGISTRY_KEY_TABLENAME, docs);
 
     assert_int_equal(dropped, 0);
@@ -633,6 +745,7 @@ static void test_drop_orphaned_promoted_documents_registry_noop(void **state) {
 
     cJSON_Delete(docs);
 }
+#endif
 
 // NULL/empty/non-array inputs must be tolerated without crashing.
 static void test_drop_orphaned_promoted_documents_null_and_invalid_inputs(void **state) {
@@ -677,8 +790,15 @@ int main(void) {
         cmocka_unit_test(test_drop_orphaned_promoted_documents_no_orphans),
         cmocka_unit_test(test_drop_orphaned_promoted_documents_some_orphans),
         cmocka_unit_test(test_drop_orphaned_promoted_documents_all_orphans),
-        cmocka_unit_test(test_drop_orphaned_promoted_documents_registry_noop),
+        cmocka_unit_test(test_drop_orphaned_promoted_documents_unknown_table_noop),
         cmocka_unit_test(test_drop_orphaned_promoted_documents_null_and_invalid_inputs),
+#ifdef WIN32
+        // registry side of drop_orphaned_promoted_documents
+        cmocka_unit_test(test_drop_orphaned_promoted_documents_registry_key_orphan),
+        cmocka_unit_test(test_drop_orphaned_promoted_documents_registry_value_orphan),
+        cmocka_unit_test(test_drop_orphaned_promoted_documents_registry_missing_architecture),
+        cmocka_unit_test(test_drop_orphaned_promoted_documents_registry_no_orphans),
+#endif
     };
 
     return cmocka_run_group_tests(tests, setup_group, teardown_group);

--- a/src/unit_tests/syscheckd/test_recovery.c
+++ b/src/unit_tests/syscheckd/test_recovery.c
@@ -37,6 +37,7 @@ cJSON* __wrap_build_stateful_event_file(const char* path, const char* sha1_hash,
 #ifdef WIN32
 cJSON* __wrap_build_stateful_event_registry_key(const char* path, const char* sha1_hash, const uint64_t document_version, int arch, const cJSON *dbsync_event, fim_registry_key *data);
 cJSON* __wrap_build_stateful_event_registry_value(const char* path, const char* value, const char* sha1_hash, const uint64_t document_version, int arch, const cJSON *dbsync_event, fim_registry_value_data *registry_data);
+registry_t* __wrap_fim_registry_configuration(const char* key, int arch);
 #endif
 
 // Mock directories list for tests
@@ -44,6 +45,11 @@ static OSList mock_directories = {0};
 
 // Stand-in directory_t pointer for tests that only need a non-NULL "config exists" signal
 static directory_t mock_directory_config = {0};
+
+#ifdef WIN32
+// Same idea for the registry config model
+static registry_t mock_registry_config = {0};
+#endif
 
 // Mock implementations
 int64_t __wrap_fim_db_get_last_sync_time(const char* table_name) {
@@ -75,6 +81,12 @@ cJSON* __wrap_build_stateful_event_registry_key(const char* path, const char* sh
 cJSON* __wrap_build_stateful_event_registry_value(const char* path, const char* value, const char* sha1_hash, const uint64_t document_version, int arch, const cJSON *dbsync_event, fim_registry_value_data *registry_data) {
     check_expected_ptr(path);
     return mock_ptr_type(cJSON*);
+}
+
+registry_t* __wrap_fim_registry_configuration(const char* key, int arch) {
+    check_expected(key);
+    check_expected(arch);
+    return mock_ptr_type(registry_t*);
 }
 #endif
 
@@ -509,6 +521,74 @@ static void test_buildRegistryValueStatefulEvent_success(void **state) {
     cJSON_Delete(value_data);
     cJSON_Delete(result);
 }
+
+// Registry rows are filtered the same way as file rows. The orphaned key (its path
+// is no longer under any configured <windows_registry> entry) must be skipped before reaching
+// buildRegistryKeyStatefulEvent, which would otherwise build an event with a NULL configuration.
+static void test_fim_recovery_persist_table_and_resync_skips_orphan_registry_keys(void **state) {
+    (void) state;
+    AgentSyncProtocolHandle* handle = (AgentSyncProtocolHandle*)0x1234;
+
+    expect_any_always(__wrap__mdebug1, formatted_msg);
+    expect_any_always(__wrap__mdebug2, formatted_msg);
+
+    cJSON* test_items = cJSON_CreateArray();
+
+    cJSON* orphan_item = cJSON_CreateObject();
+    cJSON_AddStringToObject(orphan_item, "path", "HKEY_LOCAL_MACHINE\\Security");
+    cJSON_AddStringToObject(orphan_item, "checksum", "orphan-sha");
+    cJSON_AddNumberToObject(orphan_item, "version", 1);
+    cJSON_AddStringToObject(orphan_item, "architecture", "[x32]");
+    cJSON_AddItemToArray(test_items, orphan_item);
+
+    cJSON* live_item = cJSON_CreateObject();
+    cJSON_AddStringToObject(live_item, "path", "HKEY_LOCAL_MACHINE\\Software\\WazuhLoadTest");
+    cJSON_AddStringToObject(live_item, "checksum", "live-sha");
+    cJSON_AddNumberToObject(live_item, "version", 1);
+    cJSON_AddStringToObject(live_item, "architecture", "[x64]");
+    cJSON_AddItemToArray(test_items, live_item);
+
+    expect_string(__wrap_fim_db_increase_each_entry_version, table_name, FIMDB_REGISTRY_KEY_TABLENAME);
+    will_return(__wrap_fim_db_increase_each_entry_version, 0);
+
+    expect_string(__wrap_fim_db_get_every_element, table_name, FIMDB_REGISTRY_KEY_TABLENAME);
+    expect_string(__wrap_fim_db_get_every_element, row_filter, "WHERE sync=1");
+    will_return(__wrap_fim_db_get_every_element, test_items);
+
+    expect_value(__wrap_asp_clear_in_memory_data, handle, handle);
+
+    // Orphaned key: config lookup returns NULL -> row is skipped entirely.
+    expect_string(__wrap_fim_registry_configuration, key, "HKEY_LOCAL_MACHINE\\Security");
+    expect_value(__wrap_fim_registry_configuration, arch, ARCH_32BIT);
+    will_return(__wrap_fim_registry_configuration, NULL);
+    // No build_stateful_event_registry_key / asp_persist_diff_in_memory expectations for it.
+
+    // Live key: config lookup returns non-NULL -> normal pipeline.
+    expect_string(__wrap_fim_registry_configuration, key, "HKEY_LOCAL_MACHINE\\Software\\WazuhLoadTest");
+    expect_value(__wrap_fim_registry_configuration, arch, ARCH_64BIT);
+    will_return(__wrap_fim_registry_configuration, &mock_registry_config);
+
+    expect_string(__wrap_build_stateful_event_registry_key, path, "HKEY_LOCAL_MACHINE\\Software\\WazuhLoadTest");
+    cJSON* mock_event = cJSON_CreateObject();
+    cJSON_AddStringToObject(mock_event, "type", "registry_key");
+    will_return(__wrap_build_stateful_event_registry_key, mock_event);
+
+    will_return(__wrap_schema_validator_is_initialized, false);
+
+    expect_value(__wrap_asp_persist_diff_in_memory, handle, handle);
+    expect_any(__wrap_asp_persist_diff_in_memory, id);
+    expect_value(__wrap_asp_persist_diff_in_memory, operation, OPERATION_CREATE);
+    expect_string(__wrap_asp_persist_diff_in_memory, index, FIM_REGISTRY_KEYS_SYNC_INDEX);
+    expect_any(__wrap_asp_persist_diff_in_memory, data);
+
+    expect_value(__wrap_asp_sync_module, handle, handle);
+    expect_value(__wrap_asp_sync_module, mode, MODE_FULL);
+    will_return(__wrap_asp_sync_module, true);
+
+    fim_recovery_persist_table_and_resync(FIMDB_REGISTRY_KEY_TABLENAME, handle, &mock_directories);
+
+    // test_items is freed by the function.
+}
 #endif // WIN32
 
 int main(void) {
@@ -528,6 +608,7 @@ int main(void) {
 #ifdef WIN32
         cmocka_unit_test(test_buildRegistryKeyStatefulEvent_success),
         cmocka_unit_test(test_buildRegistryValueStatefulEvent_success),
+        cmocka_unit_test(test_fim_recovery_persist_table_and_resync_skips_orphan_registry_keys),
 #endif
     };
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
## Description

Closes #38345

In the Nightly of 12/08/2026 the Windows 11 agent (`5.0.0-rc1`, commit `51bbe72`) terminated with an unhandled `EXCEPTION_ACCESS_VIOLATION` (`0xc0000005`) roughly two seconds after a shared-configuration restart. The Service Control Manager logged event 7034, the service stayed `Stopped` with no recovery action configured, and the agent therefore appeared permanently disconnected from the manager.

The provided core dump is a full-memory minidump, so the crash could be located exactly rather than inferred. The faulting address `wazuh-agent.exe+0x40eb6` matches the `Exception Offset` reported by WER, and the instruction there is `mov eax,[eax+8]` executed with `EAX = 0`, which matches the exception information `[0, 8]` (read at address `0x8`). On 32-bit, `registry_t` is `{ char *entry; int arch; int opts; ... }`, so offset `+8` is `opts`: the crash is a `configuration->opts` read with `configuration == NULL`, inside `fim_registry_key_attributes_json()` (`src/syscheckd/src/registry/events.c`). The arguments recovered from the stack are `data = NULL` and `configuration = NULL`, and the return chain resolves to `persist_sync_documents()` → `build_stateful_event_registry_key(path, ..., NULL)` → `fim_registry_key_attributes_json()`. The document being promoted at that moment, read out of the dump heap, was:

```json
{ "path": "HKEY_LOCAL_MACHINE\\Security", "architecture": "[x32]", "sync": 0, "version": 1, "checksum": "8df4a7115fb0cadb1e8823ad18ea73e49689974c" }
```

The `ossec.log` confirms the sequence. The previous process (pid 1924, 04:08:20) monitored the **default** `<windows_registry>` entries — `HKEY_LOCAL_MACHINE\Security` among them — scanned them into `fim.db` and completed a FIM synchronization at 04:08:51, leaving registry rows persisted locally. The configuration push at 04:15:59 replaced the `<syscheck>` block so that the new process (pid 3488, 04:16:06) monitors only `HKLM\SOFTWARE\WazuhLoadTest` for `[x64]` and `[x32]`. Because `registry_key_limit` defaults to `0` (unlimited), `fim_initialize()` raises the limit to `INT_MAX` and promotes every `sync=0` registry row before any scan runs. For every persisted path no longer covered by the new configuration, `fim_registry_configuration()` returns `NULL` — a documented and entirely expected outcome — and the attribute helpers dereferenced it without checking. GCC `-O2` hoists the `configuration->opts` load above the `if (data)` branch, so the fault happens on both branches regardless of `data`.

The `command` wodle mentioned in the issue title is **coincidental**: both wodles start in the same second as `fim_initialize()`, but nothing in the crashing call chain touches the modules framework.

This is the registry half of a defect already fixed for files. Commit `2665ace78c` (*"fix: drop orphan paths before promoting FIM rows on agent startup"*, #36134) addressed the identical scenario for `file_entry` and explicitly scoped the registry tables out (*"Only applies to file_entry; registry tables use a different config model"*). On Linux the file path merely logs an ERROR because `build_stateful_event_file()` null-checks the configuration; the registry equivalents did not, so on Windows the same situation kills the agent process. The same exposure exists in the recovery/integrity path, which replays rows with `WHERE sync=1` through the very same builders.

## Proposed Changes

- **`src/syscheckd/src/registry/registry.c`** — `build_stateful_event_registry_key()` and `build_stateful_event_registry_value()` now log `Failed to get configuration for registry path: <path>` and return `NULL` when `fim_registry_configuration()` finds no matching entry, mirroring the existing guard in `build_stateful_event_file()`. Both call sites already tolerate a `NULL` event, so nothing downstream changes.
- **`src/syscheckd/src/registry/events.c`** — `fim_registry_key_attributes_json()` and `fim_registry_value_attributes_json()` return the empty attributes object when `configuration == NULL`. This is defence in depth: both are public through `registry.h`, and this is the exact instruction that faulted.
- **`src/syscheckd/src/syscheck.c`** — `drop_orphaned_promoted_documents()` now covers `registry_key` and `registry_data` in addition to `file_entry`, resolving each row against `syscheck.registry` by path **and** architecture (`[x32]` → `ARCH_32BIT`, otherwise `ARCH_64BIT`). Rows whose path no longer matches any configured entry, and rows carrying no `architecture` field, are dropped before `persist_sync_documents()`, so orphans are never marked `sync=1` without an event having been queued. The scheduled scan that follows `fim_initialize()` emits the real DELETE for them through the existing `handle_orphaned_delete_registry_key()` path. The stale *"Only applies to file_entry"* documentation comment was updated accordingly.
- **`src/syscheckd/src/syscheck.c`** — added the `registry.h` include under `#ifdef WIN32`. The WIN32 block was calling `build_stateful_event_registry_key()` through an implicit declaration; `fim_registry_configuration()` returns a pointer, so a correct prototype is required.
- **`src/syscheckd/src/recovery/recovery.c`** — the two registry branches of `fim_recovery_persist_table_and_resync()` were merged and now perform the same orphan skip as the `file_entry` branch introduced by #36134, logging `Skipping recovery of orphaned path (no active configuration): <path>`. The integrity sweep reads `WHERE sync=1` and would otherwise feed the same orphan rows straight back into the builders.
- **`src/syscheckd/src/registry/registry.c`** — `fim_registry_configuration()` now returns NULL when `syscheck.registry` itself is NULL, matching the guards already present in `fim_registry_scan()` (`registry.c:2022`) and `run_check.c:155`. This closes a second route to the same access violation: an unparseable `ossec.conf` makes `Read_Syscheck_Config()` return `OS_INVALID` *before* the `REGISTRY_EMPTY` fallback (`syscheckd/src/config.c:78`), `Start_win32_Syscheck()` only applies its `dump_syscheck_registry()` recovery on the "disabled" branch, and `fim_initialize()` runs unconditionally — so the lookup could be reached with a NULL array. Pre-existing (the old code reached the same function through the builder), fixed here because it is the same crash class.
- **`src/syscheckd/src/syscheck.c`** — `drop_orphaned_promoted_documents()` now walks the document list by pointer (`cJSON_DetachItemViaPointer`) instead of by index. `cJSON_GetArrayItem()` and `cJSON_DeleteItemFromArray()` both traverse from the head, so the original index-based loop was O(n²) with two traversals per iteration. That was harmless for `file_entry` but this PR feeds it the registry tables, which reach tens of thousands of rows on the startup path.

### Unrelated CI fix carried in this PR

Committed separately (`ci(macos): fall back to a GitLab mirror when cmocka.org is unreachable`) so it can be reviewed — or dropped — independently of the FIM fix.

- **`.github/workflows/5_testunit_macos.yml`** — the macOS unit-test job installed CMocka with a bare `curl -LO` against `cmocka.org`, with no retry, no timeout and no fallback, so the job failed with `curl: (28) Failed to connect to cmocka.org port 443 after 75015 ms`. It also ran without curl's `-f`, so an HTTP error page would have been saved as if it were the archive and surfaced later as a confusing `tar` error. This applies the same fallback already used for the winagent path in `.github/actions/install_build_deps/action.yml` (#38188): try the origin, and on failure — or if the downloaded file is not a valid archive — retry against the GitLab mirror. Pinned to the same upstream 1.1.7 tag, so the installed version is unchanged; the mirror's archive extracts to `cmocka-cmocka-1.1.7/` so the directory name is normalized.

The fallback was exercised for real on this PR: `cmocka.org` failed all four attempts with `curl: (28) SSL connection timeout`, the mirror took over, and the job finished green with `100% tests passed out of 57`.

### Results and Evidence

The change was cross-compiled for `TARGET=winagent` with `TEST=1` and the unit tests were executed under wine on the build host. All 14 `syscheckd` suites pass (`100% tests passed, 0 tests failed out of 14`), including the four touched by this PR: `test_fim_sync_limits` (22), `test_recovery` (15), `test_registry` (75) and `test_events` (22).

A negative control was run to confirm the new tests actually cover the crash rather than merely passing alongside it: reverting only the two guards in `registry.c` and `events.c` and rebuilding makes the four new `test_events` cases abort with `EXCEPTION_ACCESS_VIOLATION` — the same exception observed on the agent — and the two new `test_registry` cases fail.

```
[ RUN      ] test_registry_value_attributes_json_null_configuration_dbsync
Could not run test: EXCEPTION_ACCESS_VIOLATION occurred at 004058ee.
EXCEPTION_ACCESS_VIOLATION occurred at 004023ae.
[  ERROR   ] test_registry_value_attributes_json_null_configuration_dbsync
[==========] tests: 22 test(s) run.
[  PASSED  ] 18 test(s).
```

With the fix in place:

```
    Start 10: test_fim_sync_limits
10/14 Test #10: test_fim_sync_limits .............   Passed    4.96 sec
    Start 11: test_recovery
11/14 Test #11: test_recovery ....................   Passed    4.99 sec
    Start 12: test_registry
12/14 Test #12: test_registry ....................   Passed    4.99 sec
    Start 13: test_events
13/14 Test #13: test_events ......................   Passed    4.86 sec

100% tests passed, 0 tests failed out of 14
```

#### End-to-end reproduction (Windows 11, agent `5.0.0-rc1` commit `51bbe72`, manager 5.0.0)

The crash was reproduced deterministically on a Windows 11 VM running the **same CI build as the Nightly** (build timestamp `0x6a7bc91e` in both). The precondition requires the `registry_key` table to hold **both** `sync=1` and `sync=0` rows: `fim_db_count_synced_docs()` filters `WHERE sync = 1` to decide whether promotion runs at all, and `fim_db_get_documents_to_promote()` filters `WHERE sync = 0` to pick what to promote. The supported way to produce that mix is the manager-pushed document limit (`fim.registry_key_limit`, `src/remoted/src/config.c`), which is exactly what a load-test environment like the Nightly exercises.

1. Agent enrolled with the **default** `<syscheck>` (default `<windows_registry>` entries, `HKEY_LOCAL_MACHINE\Security` among them). Full scan + FIM synchronization completed → 6477 `registry_key` rows, all `sync=1`.
2. `fim.registry_key_limit=100` set on the manager and the agent restarted → the documented demotion path ran (`Sent 6377 demoted documents to persistent queue for table registry_key`), leaving **6377 rows at `sync=0` and 100 at `sync=1`**.
3. Limit raised back to `0` (unlimited) on the manager, agent stopped, and the `<syscheck>` block replaced with only `<windows_registry check_all="yes" arch="both">HKLM\SOFTWARE\WazuhLoadTest</windows_registry>`, keeping `fim.db`.
4. Agent started.

`fim.db` state at the end of step 2, confirming the precondition:

```
registry_key : sync=0 -> 6377,  sync=1 -> 100
registry_data: sync=0 -> 21138, sync=1 -> 100
HKEY_LOCAL_MACHINE\Security  [x32]  sync=0
```

**Before the fix** — the agent died 1 second after startup and the service stayed `Stopped`:

```
2026/08/12 12:04:50 wazuh-agent[9232] registry.c:1190 at fim_registry_configuration(): DEBUG: (6319): No configuration found for (registry):'HKEY_LOCAL_MACHINE\Security'
```

```
Faulting application name: wazuh-agent.exe, version: 5.0.0.0, time stamp: 0x6a7bc91e
Faulting module name: wazuh-agent.exe, version: 5.0.0.0, time stamp: 0x6a7bc91e
Exception code: 0xc0000005
Fault offset: 0x00040eb6
Faulting process id: 0x2410
Faulting application path: C:\Program Files (x86)\ossec-agent\wazuh-agent.exe
```

```
The Wazuh service terminated unexpectedly.  It has done this 1 time(s).      (System, event 7034)
Get-Service WazuhSvc -> Stopped
```

The `Fault offset: 0x00040eb6` is **byte-identical to the one reported in the issue**. A full minidump captured from this run resolves to the same crash site and the same arguments as the dump attached to the issue:

| | Issue dump | Reproduced dump |
|---|---|---|
| Exception | `0xc0000005`, info `[0, 8]` | `0xc0000005`, info `[0, 8]` |
| EIP | `wazuh-agent.exe+0x40eb6` | `wazuh-agent.exe+0x40eb6` |
| Faulting instruction | `8b 40 08` (`mov eax,[eax+8]`) | `8b 40 08` |
| `EAX` / `ESI` | `0` / `0` | `0` / `0` |
| `data` argument | `NULL` | `NULL` |
| `configuration` argument | `NULL` | `NULL` |
| Return chain | `+0x394bb` ← `+0x40ea0`, `+0x2734e` ← `+0x39480` | identical |
| Document being promoted | `HKEY_LOCAL_MACHINE\Security` `[x32]` `sync=0` | `HKEY_LOCAL_MACHINE\Security` `[x32]` `sync=0` |

**After the fix** — the CI package built from this branch (commit `15e9f2c`) was installed on the same VM. The installer performs a clean install, so `ossec.conf`, `local_internal_options.conf`, `client.keys` and the whole `queue\` directory were restored from a backup taken before the crash, leaving **the binary as the only difference** between the two runs. The precondition was re-verified in `fim.db` immediately before starting:

```
registry_key : sync=0 -> 6377,  sync=1 -> 100
registry_data: sync=0 -> 21138, sync=1 -> 100
HKEY_LOCAL_MACHINE\Security  [x32]  sync=0
```

The agent started and stayed up:

```
Get-Service WazuhSvc -> Running
Application event 1000 since start -> NONE
System event 7034 since start      -> NONE
WER local dumps since start        -> NONE
2026/08/12 12:25:54 run_check.c:1096 at fim_run_integrity(): INFO: FIM synchronization finished successfully.
```

The new filter ran and dropped the orphans instead of promoting them — 29307 rows across both registry tables, including the exact path that crashed the unpatched build:

```
2026/08/12 12:20:02 wazuh-agent[5524] syscheck.c:221 at drop_orphaned_promoted_documents(): DEBUG: Skipping promotion of orphaned path (no active configuration): HKEY_LOCAL_MACHINE\Security
```

```
2026/08/12 12:20:02 wazuh-agent[5524] syscheck.c:600 at fim_initialize(): DEBUG: Document limit increased from  100 to 2147483647 for index registry_key. Currently synced documents: 100
2026/08/12 12:20:02 wazuh-agent[5524] syscheck.c:413 at persist_sync_documents(): DEBUG: Sent 0 promoted documents to persistent queue for table registry_key
2026/08/12 12:20:15 wazuh-agent[5524] syscheck.c:600 at fim_initialize(): DEBUG: Document limit increased from  100 to 2147483647 for index registry_data. Currently synced documents: 100
2026/08/12 12:20:15 wazuh-agent[5524] syscheck.c:413 at persist_sync_documents(): DEBUG: Sent 0 promoted documents to persistent queue for table registry_data
```

The `2147483647` confirms the exact code path from the analysis: `registry_key_limit == 0` is raised to `INT_MAX`, so `*synced_docs_ptr < limit` holds and promotion runs — it just no longer feeds orphaned rows to the builders. Note that **no** `Failed to get configuration for registry path` error was logged: the pre-filter (change 2) caught every orphan before the builder guard (change 1) was needed, which is the intended layering — the guard is the safety net that keeps the process alive, the filter is the root-cause fix that keeps the log clean.

#### Re-validation after review feedback

The whole scenario was re-run on the same VM with the CI package built from the updated branch (merge commit `2c78ae2`), restoring the same backup so the `fim.db` precondition was byte-identical (`registry_key` 6377/100, `registry_data` 21138/100). Result unchanged: service `Running`, no event 1000, no event 7034, no crash dump, `FIM synchronization finished successfully`, and the orphan pre-filter still dropped every row including `HKEY_LOCAL_MACHINE\Security`, with `Sent 0 promoted documents` for both registry tables and zero builder errors.

The pointer-based walk also shortened the measured window. Between the `registry_key` and `registry_data` promotion messages — which covers `fim_db_get_documents_to_promote()` building 21,138 JSON documents from SQLite, the filter itself, and 21k `debug=2` log lines — the index-based version took 13 s (12:20:02 → 12:20:15) and the pointer-based version took 6 s (14:01:39 → 14:01:45) on the same data and the same VM. That window is not exclusively the loop, and this is a single sample, so treat it as directional rather than as a benchmark; the complexity argument stands on its own from the code.

### Artifacts Affected

`wazuh-agent.exe` (Windows agent) — the affected code lives in the FIM subsystem (`wazuh-syscheckd`), which on Windows is linked into the single `wazuh-agent.exe` binary. The registry code paths are `WIN32`-only, so the Linux/macOS agent and the manager binaries are unaffected at runtime; the only change outside a `#ifdef WIN32` block is the restructuring of `drop_orphaned_promoted_documents()`, whose `file_entry` behaviour is unchanged.

### Configuration Changes

None. No new or modified settings; the fix only changes how already-persisted rows are handled when the existing `<syscheck>` registry configuration no longer covers them.

### Documentation Updates

None required. No user-facing behaviour or option changes. In-code documentation was updated where it had become incorrect: the `drop_orphaned_promoted_documents()` doc comment no longer claims the helper only applies to `file_entry`.

### Tests Introduced

- `src/unit_tests/syscheckd/registry/test_events.c` — 4 cases covering a `NULL` configuration in `fim_registry_key_attributes_json()` and `fim_registry_value_attributes_json()`, for both the entry (`data != NULL`) and dbsync (`data == NULL`) flavours. These are the cases that crash without the fix.
- `src/unit_tests/syscheckd/registry/test_registry.c` — 2 cases asserting `build_stateful_event_registry_key()` and `build_stateful_event_registry_value()` return `NULL` and log the error when the path resolves to no configuration, plus `test_fim_registry_configuration_null_registry_array` covering the `syscheck.registry == NULL` guard.
- `src/unit_tests/syscheckd/test_fim_sync_limits.c` — 4 new cases for the registry side of `drop_orphaned_promoted_documents()`: orphaned registry key dropped while a still-covered one survives, orphaned registry value dropped, `[x32]` vs `[x64]` resolution, and a row with no `architecture`. The pre-existing `test_drop_orphaned_promoted_documents_registry_noop` asserted the opposite behaviour and was replaced with an unknown-table no-op case that keeps the short-circuit coverage.
- `src/unit_tests/syscheckd/test_recovery.c` — `test_fim_recovery_persist_table_and_resync_skips_orphan_registry_keys`, the registry counterpart of the existing `..._skips_orphan_paths`.
- `src/unit_tests/syscheckd/CMakeLists.txt` — wraps `fim_registry_configuration` in the `winagent` link flags of `test_fim_sync_limits` and `test_recovery`.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
