### PR TITLE
Upgrade result silent on aborted upgrade

### DIFF
--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -23,28 +23,35 @@ if [ -z "${INSTALLDIR}" ]; then
     INSTALLDIR="${WAZUH_HOME}"
 fi
 
+# Write the upgrade result and 'reload' modulesd
+abort_upgrade() {
+    echo -ne "$1" > ./var/upgrade/upgrade_result
+    rm -f $LOCK
+    if [ -x ./bin/wazuh-control ]; then
+        echo "$(date +"%Y/%m/%d %H:%M:%S") - Reloading the Wazuh agent to report the upgrade result." >> ./logs/upgrade.log
+        ./bin/wazuh-control reload >> ./logs/upgrade.log 2>&1
+    else
+        echo "$(date +"%Y/%m/%d %H:%M:%S") - Cannot reload the Wazuh agent, ./bin/wazuh-control not found. The result will be reported on the next agent restart." >> ./logs/upgrade.log
+    fi
+    exit 1
+}
+
 echo "$(date +"%Y/%m/%d %H:%M:%S") - Checking execution path." >> ./logs/upgrade.log
 
 
 if [[ "$OS" == "Darwin" ]]; then
     if [ "${WAZUH_HOME}" != "/Library/Ossec" ]; then
         echo "$(date +"%Y/%m/%d %H:%M:%S") - Execution path is wrong (it should be /Library/Ossec), interrupting upgrade." >> ./logs/upgrade.log
-        echo -ne "2" > ./var/upgrade/upgrade_result
-        rm -f $LOCK
-        exit 1
+        abort_upgrade "2"
     fi
 elif [[ "$OS" == "Linux" ]]; then
     if [ "${WAZUH_HOME}" != "${INSTALLDIR}" ]; then
         echo "$(date +"%Y/%m/%d %H:%M:%S") - Execution path is wrong (it should be ${INSTALLDIR}), interrupting upgrade." >> ./logs/upgrade.log
-        echo -ne "2" > ./var/upgrade/upgrade_result
-        rm -f $LOCK
-        exit 1
+        abort_upgrade "2"
     fi
 else
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. Unsupported OS." >> ./logs/upgrade.log
-    echo -ne "2" > ./var/upgrade/upgrade_result
-    rm -f $LOCK
-    exit 1
+    abort_upgrade "2"
 fi
 
 # Read <block><sub><tag> from the agent configuration, taking the last match.
@@ -100,18 +107,14 @@ fi
 
 if [ -z "${SERVER_ADDRESS}" ]; then
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. No manager address found in the configuration." >> ./logs/upgrade.log
-    echo -ne "2" > ./var/upgrade/upgrade_result
-    rm -f $LOCK
-    exit 1
+    abort_upgrade "2"
 fi
 
 echo "$(date +"%Y/%m/%d %H:%M:%S") - Checking connectivity to ${SERVER_ADDRESS}:${SERVER_PORT}." >> ./logs/upgrade.log
 
 if ! probe_server "${SERVER_ADDRESS}" "${SERVER_PORT}"; then
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. The manager is not reachable at ${SERVER_ADDRESS}:${SERVER_PORT}, interrupting upgrade." >> ./logs/upgrade.log
-    echo -ne "2" > ./var/upgrade/upgrade_result
-    rm -f $LOCK
-    exit 1
+    abort_upgrade "2"
 fi
 
 echo "$(date +"%Y/%m/%d %H:%M:%S") - Manager reachable at ${SERVER_ADDRESS}:${SERVER_PORT}." >> ./logs/upgrade.log
@@ -124,27 +127,21 @@ elif [[ "$OS" == "Linux" ]]; then
             rpm -UFvh ./var/upgrade/wazuh-agent* >> ./logs/upgrade.log 2>&1
         else
             echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. RPM package found but rpm command not found." >> ./logs/upgrade.log
-            echo -ne "2" > ./var/upgrade/upgrade_result
-            rm -f $LOCK
-            exit 1
+            abort_upgrade "2"
         fi
     elif find ./var/upgrade/ -mindepth 1 -maxdepth 1 -type f -name "*.deb" | read; then
         if command -v dpkg >/dev/null 2>&1; then
             dpkg -i --force-confdef ./var/upgrade/wazuh-agent* >> ./logs/upgrade.log 2>&1
         else
             echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. DEB package found but dpkg command not found." >> ./logs/upgrade.log
-            echo -ne "2" > ./var/upgrade/upgrade_result
-            rm -f $LOCK
-            exit 1
+            abort_upgrade "2"
         fi
     elif find ./var/upgrade/ -mindepth 1 -maxdepth 1 -type f -name "*.apk" | read; then
         if command -v apk >/dev/null 2>&1; then
             apk add --allow-untrusted --force ./var/upgrade/wazuh-agent* >> ./logs/upgrade.log 2>&1
         else
             echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. APK package found but apk command not found." >> ./logs/upgrade.log
-            echo -ne "2" > ./var/upgrade/upgrade_result
-            rm -f $LOCK
-            exit 1
+            abort_upgrade "2"
         fi
     else
         if [ -e ./var/upgrade/install.sh ]; then
@@ -152,16 +149,12 @@ elif [[ "$OS" == "Linux" ]]; then
             ./var/upgrade/install.sh >> ./logs/upgrade.log 2>&1
         else
             echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. No package or sources found." >> ./logs/upgrade.log
-            echo -ne "2" > ./var/upgrade/upgrade_result
-            rm -f $LOCK
-            exit 1
+            abort_upgrade "2"
         fi
     fi
 else
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. Unsupported OS." >> ./logs/upgrade.log
-    echo -ne "2" > ./var/upgrade/upgrade_result
-    rm -f $LOCK
-    exit 1
+    abort_upgrade "2"
 fi
 
 
@@ -177,9 +170,7 @@ if [ -f "./bin/wazuh-control" ]; then
     ./bin/wazuh-control restart >> ./logs/upgrade.log 2>&1
 else
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed: wazuh-control not found." >> ./logs/upgrade.log
-    echo -ne "2" > ./var/upgrade/upgrade_result
-    rm -f $LOCK
-    exit 1
+    abort_upgrade "2"
 fi
 
 sleep 1

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -26,13 +26,13 @@ fi
 # Write the upgrade result and 'reload' modulesd
 abort_upgrade() {
     echo -ne "$1" > ./var/upgrade/upgrade_result
-    rm -f $LOCK
     if [ -x ./bin/wazuh-control ]; then
         echo "$(date +"%Y/%m/%d %H:%M:%S") - Reloading the Wazuh agent to report the upgrade result." >> ./logs/upgrade.log
         ./bin/wazuh-control reload >> ./logs/upgrade.log 2>&1
     else
         echo "$(date +"%Y/%m/%d %H:%M:%S") - Cannot reload the Wazuh agent, ./bin/wazuh-control not found. The result will be reported on the next agent restart." >> ./logs/upgrade.log
     fi
+    rm -f $LOCK
     exit 1
 }
 

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -238,6 +238,7 @@ if ($normalizedWazuhDir -ne $currentDir) {
     Write-Output "$(Get-Date -format u) - Current working directory is not the Wazuh installation directory. Aborting." >> .\upgrade\upgrade.log
     Write-output "2" | out-file ".\upgrade\upgrade_result" -encoding ascii
     remove_upgrade_files
+    Restart-Service -Name "Wazuh" -Force -ErrorAction SilentlyContinue
     exit 1
 }
 

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -33,7 +33,7 @@ function get-version {
             Write-Output "$(Get-Date -format u) - Extracted version from $JsonFile : $version." >> .\upgrade\upgrade.log
         } else {
             Write-Output "$(Get-Date -format u) - Failed to extract version from JSON file $JsonFile." >> .\upgrade\upgrade.log
-            exit 1
+            return $null
         }
     }
     # fallback to the plain text VERSION file
@@ -43,7 +43,7 @@ function get-version {
         Write-Output "$(Get-Date -format u) - Extracted version from $TextFile : $version." >> .\upgrade\upgrade.log
     } else {
         Write-Output "$(Get-Date -format u) - Error: No version file found (expected $JsonFile or $TextFile)." >> .\upgrade\upgrade.log
-        exit 1
+        return $null
     }
 
     return $version
@@ -54,6 +54,15 @@ function remove_upgrade_files {
     Remove-Item -Path ".\upgrade\*"  -Exclude "*.log", "upgrade_result" -ErrorAction SilentlyContinue
     Remove-Item -Path ".\wazuh-agent*.msi" -ErrorAction SilentlyContinue
     Remove-Item -Path ".\do_upgrade.ps1" -ErrorAction SilentlyContinue
+}
+
+
+# Write the upgrade result, remove upgrade files and restart the service
+function abort_upgrade($code) {
+    write-output "$code" | out-file ".\upgrade\upgrade_result" -encoding ascii
+    remove_upgrade_files
+    Restart-Service -Name "Wazuh" -Force -ErrorAction SilentlyContinue
+    exit 1
 }
 
 
@@ -109,11 +118,14 @@ function check-process {
 function check-installation {
     $actual_version = get-version
     $counter = 5
-    while($actual_version -eq $current_version -And $counter -gt 0) {
+    while(($null -eq $actual_version -Or $actual_version -eq $current_version) -And $counter -gt 0) {
         write-output "$(Get-Date -format u) - Waiting for the Wazuh-Agent installation to end." >> .\upgrade\upgrade.log
         $counter--
         Start-Sleep 2
         $actual_version = get-version
+    }
+    if ($null -eq $actual_version) {
+        write-output "$(Get-Date -format u) - Could not read the installed version after the installation." >> .\upgrade\upgrade.log
     }
     write-output "$(Get-Date -format u) - Starting Wazuh-Agent service." >> .\upgrade\upgrade.log
     Start-Service -Name "Wazuh"
@@ -236,14 +248,15 @@ $currentDir = (Get-Location).Path.TrimEnd('\')
 
 if ($normalizedWazuhDir -ne $currentDir) {
     Write-Output "$(Get-Date -format u) - Current working directory is not the Wazuh installation directory. Aborting." >> .\upgrade\upgrade.log
-    Write-output "2" | out-file ".\upgrade\upgrade_result" -encoding ascii
-    remove_upgrade_files
-    Restart-Service -Name "Wazuh" -Force -ErrorAction SilentlyContinue
-    exit 1
+    abort_upgrade "2"
 }
 
 # Get current version
 $current_version = get-version
+if ($null -eq $current_version) {
+    write-output "$(Get-Date -format u) - Upgrade failed: could not read the current agent version." >> .\upgrade\upgrade.log
+    abort_upgrade "2"
+}
 write-output "$(Get-Date -format u) - Current version: $($current_version)." >> .\upgrade\upgrade.log
 
 # Get new msi version
@@ -262,17 +275,11 @@ if ($msi_new_version -ne $null) {
         $current_ver = [Version]($current_version -replace '^v', '')
         if ($target_ver -ge [Version]"5.0.0" -and $current_ver -lt [Version]"4.14.0") {
             write-output "$(Get-Date -format u) - Upgrade failed: direct upgrade to v5.0.0 is not supported from version $($current_version). Please upgrade to v4.14.x first." >> .\upgrade\upgrade.log
-            write-output "1" | out-file ".\upgrade\upgrade_result" -encoding ascii
-            remove_upgrade_files
-            Restart-Service -Name "Wazuh" -Force -ErrorAction SilentlyContinue
-            exit 1
+            abort_upgrade "1"
         }
     } catch {
         write-output "$(Get-Date -format u) - Could not compare versions for compatibility check: $($_.Exception.Message)" >> .\upgrade\upgrade.log
-        write-output "2" | out-file ".\upgrade\upgrade_result" -encoding ascii
-        remove_upgrade_files
-        Restart-Service -Name "Wazuh" -Force -ErrorAction SilentlyContinue
-        exit 1
+        abort_upgrade "2"
     }
 }
 
@@ -342,20 +349,14 @@ if ([string]::IsNullOrEmpty($server_port)) {
 
 if ([string]::IsNullOrEmpty($server_address)) {
     write-output "$(Get-Date -format u) - Upgrade failed: no manager address found in the configuration." >> .\upgrade\upgrade.log
-    write-output "2" | out-file ".\upgrade\upgrade_result" -encoding ascii
-    remove_upgrade_files
-    Restart-Service -Name "Wazuh" -Force -ErrorAction SilentlyContinue
-    exit 1
+    abort_upgrade "2"
 }
 
 write-output "$(Get-Date -format u) - Checking connectivity to $($server_address):$($server_port)." >> .\upgrade\upgrade.log
 
 if (-Not (probe_server $server_address $server_port)) {
     write-output "$(Get-Date -format u) - Upgrade failed: the manager is not reachable at $($server_address):$($server_port), interrupting upgrade." >> .\upgrade\upgrade.log
-    write-output "2" | out-file ".\upgrade\upgrade_result" -encoding ascii
-    remove_upgrade_files
-    Restart-Service -Name "Wazuh" -Force -ErrorAction SilentlyContinue
-    exit 1
+    abort_upgrade "2"
 }
 
 write-output "$(Get-Date -format u) - Manager reachable at $($server_address):$($server_port)." >> .\upgrade\upgrade.log


### PR DESCRIPTION
## Description

When testing item (d) of #38160 via the upgrade fail path: the port-1517 pre-check finding the manager unreachable, the agent does not send the ACK with the upgrade result to the manager once the upgrade is aborted due to a missing restart of modulesd.

The `agent-upgrade` module reads `var/upgrade/upgrade_result` once, when modulesd starts (`wm_agent_upgrade_check_status`, `src/wazuh_modules/src/agent_upgrade/agent/wm_agent_upgrade_agent.c:198`). On Linux and macOS the only restart in `pkg_installer.sh` sits inside the install branch (`:170`), reached only after `dpkg`/`rpm`/`apk`/`installer` has run. Every earlier `exit 1` wrote the result code and returned without touching the daemons: nothing stopped, nothing restarted, so the file was never sampled and the manager never learned the upgrade had failed. On Windows the same class of abort already restarted the service, except for the wrong-directory check.

Closes #38160

## Proposed Changes

- `src/init/pkg_installer.sh`: new `abort_upgrade()` helper that writes the `upgrade_result`, runs `./bin/wazuh-control reload`, and releases the lock; this replaces the eleven `echo -ne "2" / rm -f $LOCK / exit 1` blocks. `reload` restarts every agent daemon except `wazuh-agentd` (`src/init/wazuh-client.sh:371-383`), so modulesd re-reads the result file while the manager session and the event queue stay up. When `./bin/wazuh-control` is missing the helper logs that the result will be reported on the next agent restart.
- `src/win32/do_upgrade.ps1`: new `abort_upgrade($code)` helper that writes `upgrade_result`, runs `remove_upgrade_files`, and `Restart-Service`. All six abort paths route through it, including the wrong-directory check that previously exited without restarting the service.
- `src/win32/do_upgrade.ps1`: `get-version` returns `$null` instead of calling `exit`, matching `get_msi_version`. `exit` inside a PowerShell function terminates the whole script, so an unreadable version file during `check-installation` used to abort after `install` had already stopped the service and deleted `upgrade_result`, leaving the agent down with nothing to report. The result is still the connection check's to decide, because an agent that comes back connected is working whether or not its version file is.
- `src/win32/do_upgrade.ps1`: `check-installation` (`:118-132`) treats an unreadable version like an unchanged one instead of reading it as "the install finished", so the retry loop keeps waiting through the moment the MSI has not written `VERSION.json` yet, which is what that loop exists for. If the version is still unreadable when the budget runs out it is logged, and the run continues to `Start-Service` either way. Nothing is written to `upgrade_result` there: the connection check further down owns the verdict, because an agent that comes back connected is working whether or not its version file is.


### Coverage

Every path that writes `upgrade_result`, and how the result now reaches the manager.

| Platform | Failure | Location | Code | Before | Now |
|---|---|---|---|---|---|
| Linux/macOS | Wrong execution path (macOS) | `pkg_installer.sh:45` | 2 | not reported | result written; the cwd is not the install directory, so `./bin/wazuh-control` is not there and it is reported on the next agent restart |
| Linux/macOS | Wrong execution path (Linux) | `pkg_installer.sh:50` | 2 | not reported | result written; the cwd is not the install directory, so `./bin/wazuh-control` is not there and it is reported on the next agent restart |
| Linux/macOS | Unsupported OS, pre-check | `pkg_installer.sh:54` | 2 | not reported | `reload` |
| Linux/macOS | No manager address in the configuration | `pkg_installer.sh:110` | 2 | not reported | `reload` |
| Linux/macOS | Manager unreachable on the HTTPS control port | `pkg_installer.sh:117` | 2 | not reported | `reload` |
| Linux/macOS | RPM package found, `rpm` missing | `pkg_installer.sh:130` | 2 | not reported | `reload` |
| Linux/macOS | DEB package found, `dpkg` missing | `pkg_installer.sh:137` | 2 | not reported | `reload` |
| Linux/macOS | APK package found, `apk` missing | `pkg_installer.sh:144` | 2 | not reported | `reload` |
| Linux/macOS | No package or sources in the WPK | `pkg_installer.sh:152` | 2 | not reported | `reload` |
| Linux/macOS | Unsupported OS, install branch | `pkg_installer.sh:157` | 2 | not reported | `reload` |
| Linux/macOS | `wazuh-control` not found | `pkg_installer.sh:173` | 2 | not reported | logged, reported on next restart |
| Linux/macOS | Install ran, agent connected | `pkg_installer.sh:193` | 0 | reported | unchanged, `restart` at `:170` |
| Linux/macOS | Install ran, agent not connected | `pkg_installer.sh:199` | 2 | reported | unchanged, `restart` at `:170` |
| Windows | Version file unreadable or missing, before the install | `do_upgrade.ps1:36`, `:46`, caller `:258` | 2 | script exited, nothing written, agent left as it was | `$null` returned to the caller, which writes the result and restarts the service |
| Windows | Version file unreadable or missing, after the install | `do_upgrade.ps1:128` | — | script exited with the service already stopped by `install` and no result written | waited out, then logged; the run continues to `Start-Service` and the connection check decides the result at `:400`/`:403` |
| Windows | Working directory is not the install directory | `do_upgrade.ps1:251` | 2 | not reported | `Restart-Service` |
| Windows | Direct upgrade to 5.x from below 4.14 | `do_upgrade.ps1:278` | 1 | reported | unchanged, `Restart-Service` |
| Windows | Version comparison failed | `do_upgrade.ps1:282` | 2 | reported | unchanged, `Restart-Service` |
| Windows | No manager address in the configuration | `do_upgrade.ps1:352` | 2 | reported | unchanged, `Restart-Service` |
| Windows | Manager unreachable on the HTTPS control port | `do_upgrade.ps1:359` | 2 | reported | unchanged, `Restart-Service` |
| Windows | Install ran, agent not connected | `do_upgrade.ps1:400` | 2 | reported | unchanged, service started at `:131` |
| Windows | Install ran, agent connected | `do_upgrade.ps1:403` | 0 | reported | unchanged, service started at `:131` |

### Results and Evidence

Tested with `pkg_installer.sh` from this branch. The manager is unreachable on 1517, so the run takes the probe abort of item (d) from issue #38160 .

#### macOS agent v4.14.7

**Baseline**

```console
agent-macos-arm:~ root# cat /Library/Ossec/VERSION.json
{
    "version": "4.14.7",
    "stage": "rc1",
    "commit": "8c41e20"
}
agent-macos-arm:~ root# ls /Library/Ossec/var/run/*.pid
/Library/Ossec/var/run/wazuh-agentd-622.pid
/Library/Ossec/var/run/wazuh-execd-4146.pid
/Library/Ossec/var/run/wazuh-logcollector-4185.pid
/Library/Ossec/var/run/wazuh-modulesd-4234.pid
/Library/Ossec/var/run/wazuh-syscheckd-4162.pid
agent-macos-arm:~ root# /Library/Ossec/bin/wazuh-control status
wazuh-modulesd is running...
wazuh-logcollector is running...
wazuh-syscheckd is running...
wazuh-agentd is running...
wazuh-execd is running...
```

**Run `pkg_installer.sh`**

```console
agent-macos-arm:~ root# cd /Library/Ossec && ./var/upgrade/pkg_installer.sh
```

**Upgrade result in `upgrade.log`**

```text
agent-macos-arm:~ root# cat /Library/Ossec/logs/upgrade.log
2026/08/13 00:14:00 - Upgrade started.
2026/08/13 00:14:00 - Checking execution path.
2026/08/13 00:14:00 - Checking connectivity to 192.168.18.238:1517.
2026/08/13 00:14:05 - Upgrade failed. The manager is not reachable at 192.168.18.238:1517, interrupting upgrade.
2026/08/13 00:14:05 - Reloading the Wazuh agent to report the upgrade result.
2026/08/13 00:14:05 wazuh-agentd[12764] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2026/08/13 00:14:05 wazuh-agentd[12764] main.c:198 at main(): DEBUG: Wazuh home directory: /Library/Ossec
2026/08/13 00:14:05 wazuh-agentd[12764] main.c:200 at main(): DEBUG: Started (pid: 12764).
2026/08/13 00:14:05 wazuh-agentd[12764] agent_op.c:221 at os_read_agent_profile(): DEBUG: Calling os_read_agent_profile().
2026/08/13 00:14:05 wazuh-agentd[12764] agent_op.c:240 at os_read_agent_profile(): DEBUG: os_read_agent_profile() = [darwin, darwin24, darwin24.6]
2026/08/13 00:14:05 wazuh-agentd[12764] config.c:463 at ReadConfig(): DEBUG: agent_config element does not have any attributes.
2026/08/13 00:14:05 wazuh-agentd[12764] agent_op.c:221 at os_read_agent_profile(): DEBUG: Calling os_read_agent_profile().
2026/08/13 00:14:05 wazuh-agentd[12764] agent_op.c:240 at os_read_agent_profile(): DEBUG: os_read_agent_profile() = [darwin, darwin24, darwin24.6]
2026/08/13 00:14:05 wazuh-agentd[12764] config.c:463 at ReadConfig(): DEBUG: agent_config element does not have any attributes.
2026/08/13 00:14:05 wazuh-modulesd[12767] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2026/08/13 00:14:05 wazuh-modulesd[12767] main.c:80 at main(): DEBUG: Wazuh home directory: /Library/Ossec
2026/08/13 00:14:05 wazuh-modulesd[12767] wmodules-osquery-monitor.c:90 at wm_osquery_monitor_read(): DEBUG: Logpath read: /var/log/osquery/osqueryd.results.log
2026/08/13 00:14:05 wazuh-modulesd[12767] wmodules-osquery-monitor.c:102 at wm_osquery_monitor_read(): DEBUG: configPath read: /etc/osquery/osquery.conf
2026/08/13 00:14:05 wazuh-modulesd[12767] agent_op.c:221 at os_read_agent_profile(): DEBUG: Calling os_read_agent_profile().
2026/08/13 00:14:05 wazuh-modulesd[12767] agent_op.c:240 at os_read_agent_profile(): DEBUG: os_read_agent_profile() = [darwin, darwin24, darwin24.6]
2026/08/13 00:14:05 wazuh-modulesd[12767] config.c:463 at ReadConfig(): DEBUG: agent_config element does not have any attributes.
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-execd...
Wazuh v4.14.7 Stopped
Starting Wazuh v4.14.7...
Started wazuh-execd...
wazuh-agentd already running...
Started wazuh-syscheckd...
Started wazuh-logcollector...
2026/08/13 00:14:10 wazuh-modulesd[12919] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2026/08/13 00:14:10 wazuh-modulesd[12919] main.c:80 at main(): DEBUG: Wazuh home directory: /Library/Ossec
2026/08/13 00:14:10 wazuh-modulesd[12919] wmodules-osquery-monitor.c:90 at wm_osquery_monitor_read(): DEBUG: Logpath read: /var/log/osquery/osqueryd.results.log
2026/08/13 00:14:10 wazuh-modulesd[12919] wmodules-osquery-monitor.c:102 at wm_osquery_monitor_read(): DEBUG: configPath read: /etc/osquery/osquery.conf
2026/08/13 00:14:10 wazuh-modulesd[12919] agent_op.c:221 at os_read_agent_profile(): DEBUG: Calling os_read_agent_profile().
2026/08/13 00:14:10 wazuh-modulesd[12919] agent_op.c:240 at os_read_agent_profile(): DEBUG: os_read_agent_profile() = [darwin, darwin24, darwin24.6]
2026/08/13 00:14:10 wazuh-modulesd[12919] config.c:463 at ReadConfig(): DEBUG: agent_config element does not have any attributes.
Started wazuh-modulesd...
Completed.
```

**After reload**

```console
agent-macos-arm:~ root# ls /Library/Ossec/var/run/*.pid
/Library/Ossec/var/run/wazuh-agentd-622.pid
/Library/Ossec/var/run/wazuh-execd-12829.pid
/Library/Ossec/var/run/wazuh-logcollector-12872.pid
/Library/Ossec/var/run/wazuh-modulesd-12921.pid
/Library/Ossec/var/run/wazuh-syscheckd-12844.pid
agent-macos-arm:~ root# /Library/Ossec/bin/wazuh-control status
wazuh-modulesd is running...
wazuh-logcollector is running...
wazuh-syscheckd is running...
wazuh-agentd is running...
wazuh-execd is running...
```

**ACK report**

```text
2026/08/13 00:14:40 wazuh-modulesd:agent-upgrade[12919] wm_agent_upgrade_agent.c:283 at wm_upgrade_agent_send_ack_message(): DEBUG: (8163): Sending upgrade ACK event: '{"command":"upgrade_update_status","parameters":{"error":2,"message":"Upgrade failed","status":"Failed"}}'
```

**Event in dashboard**

<img width="1974" height="946" alt="Screenshot 2026-08-12 at 7 21 24 PM" src="https://github.com/user-attachments/assets/863d3fed-527e-452f-96d5-1f94b3b98a31" />

Before the change the same forced failure produced no event, the evidence of previous runs are located in #38160 

#### Linux agent v4.14.7

**Baseline**

```console
root@agent-ubuntu24-arm:~# cat /var/ossec/VERSION.json
{
    "version": "4.14.7",
    "stage": "rc1",
    "commit": "8c41e20"
}
root@agent-ubuntu24-arm:~# ls /var/ossec/var/run/*.pid
/var/ossec/var/run/wazuh-agentd-4660.pid
/var/ossec/var/run/wazuh-execd-8263.pid
/var/ossec/var/run/wazuh-logcollector-8319.pid
/var/ossec/var/run/wazuh-modulesd-8368.pid
/var/ossec/var/run/wazuh-syscheckd-8277.pid
root@agent-ubuntu24-arm:~# /var/ossec/bin/wazuh-control status
wazuh-modulesd is running...
wazuh-logcollector is running...
wazuh-syscheckd is running...
wazuh-agentd is running...
wazuh-execd is running...
```

**Run `pkg_installer.sh`**

```console
root@agent-ubuntu24-arm:~# cd /var/ossec && ./var/upgrade/pkg_installer.sh
```

**Upgrade result in `upgrade.log`**

```text
root@agent-ubuntu24-arm:~# cat /var/ossec/logs/upgrade.log
2026/08/12 19:29:10 - Upgrade started.
2026/08/12 19:29:10 - Checking execution path.
2026/08/12 19:29:10 - Checking connectivity to 192.168.18.238:1517.
2026/08/12 19:29:16 - Upgrade failed. The manager is not reachable at 192.168.18.238:1517, interrupting upgrade.
2026/08/12 19:29:16 - Reloading the Wazuh agent to report the upgrade result.
2026/08/12 19:29:16 wazuh-agentd[10739] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2026/08/12 19:29:16 wazuh-agentd[10739] main.c:198 at main(): DEBUG: Wazuh home directory: /var/ossec
2026/08/12 19:29:16 wazuh-agentd[10739] main.c:200 at main(): DEBUG: Started (pid: 10739).
2026/08/12 19:29:16 wazuh-agentd[10739] agent_op.c:221 at os_read_agent_profile(): DEBUG: Calling os_read_agent_profile().
2026/08/12 19:29:16 wazuh-agentd[10739] agent_op.c:240 at os_read_agent_profile(): DEBUG: os_read_agent_profile() = [ubuntu, ubuntu24, ubuntu24.04]
2026/08/12 19:29:16 wazuh-agentd[10739] config.c:463 at ReadConfig(): DEBUG: agent_config element does not have any attributes.
2026/08/12 19:29:16 wazuh-agentd[10739] agent_op.c:221 at os_read_agent_profile(): DEBUG: Calling os_read_agent_profile().
2026/08/12 19:29:16 wazuh-agentd[10739] agent_op.c:240 at os_read_agent_profile(): DEBUG: os_read_agent_profile() = [ubuntu, ubuntu24, ubuntu24.04]
2026/08/12 19:29:16 wazuh-agentd[10739] config.c:463 at ReadConfig(): DEBUG: agent_config element does not have any attributes.
2026/08/12 19:29:16 wazuh-modulesd[10742] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2026/08/12 19:29:16 wazuh-modulesd[10742] main.c:80 at main(): DEBUG: Wazuh home directory: /var/ossec
2026/08/12 19:29:16 wazuh-modulesd[10742] wmodules-osquery-monitor.c:90 at wm_osquery_monitor_read(): DEBUG: Logpath read: /var/log/osquery/osqueryd.results.log
2026/08/12 19:29:16 wazuh-modulesd[10742] wmodules-osquery-monitor.c:102 at wm_osquery_monitor_read(): DEBUG: configPath read: /etc/osquery/osquery.conf
2026/08/12 19:29:16 wazuh-modulesd[10742] agent_op.c:221 at os_read_agent_profile(): DEBUG: Calling os_read_agent_profile().
2026/08/12 19:29:16 wazuh-modulesd[10742] agent_op.c:240 at os_read_agent_profile(): DEBUG: os_read_agent_profile() = [ubuntu, ubuntu24, ubuntu24.04]
2026/08/12 19:29:16 wazuh-modulesd[10742] config.c:463 at ReadConfig(): DEBUG: agent_config element does not have any attributes.
Killing wazuh-modulesd...
Killing wazuh-logcollector...
Killing wazuh-syscheckd...
Killing wazuh-execd...
Wazuh v4.14.7 Stopped
Starting Wazuh v4.14.7...
Started wazuh-execd...
wazuh-agentd already running...
Started wazuh-syscheckd...
Started wazuh-logcollector...
2026/08/12 19:29:21 wazuh-modulesd[10893] debug_op.c:116 at _log_function(): DEBUG: Logging module auto-initialized
2026/08/12 19:29:21 wazuh-modulesd[10893] main.c:80 at main(): DEBUG: Wazuh home directory: /var/ossec
2026/08/12 19:29:21 wazuh-modulesd[10893] wmodules-osquery-monitor.c:90 at wm_osquery_monitor_read(): DEBUG: Logpath read: /var/log/osquery/osqueryd.results.log
2026/08/12 19:29:21 wazuh-modulesd[10893] wmodules-osquery-monitor.c:102 at wm_osquery_monitor_read(): DEBUG: configPath read: /etc/osquery/osquery.conf
2026/08/12 19:29:21 wazuh-modulesd[10893] agent_op.c:221 at os_read_agent_profile(): DEBUG: Calling os_read_agent_profile().
2026/08/12 19:29:21 wazuh-modulesd[10893] agent_op.c:240 at os_read_agent_profile(): DEBUG: os_read_agent_profile() = [ubuntu, ubuntu24, ubuntu24.04]
2026/08/12 19:29:21 wazuh-modulesd[10893] config.c:463 at ReadConfig(): DEBUG: agent_config element does not have any attributes.
Started wazuh-modulesd...
Completed.
```

**After reload**

```console
root@agent-ubuntu24-arm:~# ls /var/ossec/var/run/*.pid
/var/ossec/var/run/wazuh-agentd-4660.pid
/var/ossec/var/run/wazuh-execd-10790.pid
/var/ossec/var/run/wazuh-logcollector-10846.pid
/var/ossec/var/run/wazuh-modulesd-10895.pid
/var/ossec/var/run/wazuh-syscheckd-10804.pid
root@agent-ubuntu24-arm:~# /var/ossec/bin/wazuh-control status
wazuh-modulesd is running...
wazuh-logcollector is running...
wazuh-syscheckd is running...
wazuh-agentd is running...
wazuh-execd is running...
```

**ACK report**

```text
2026/08/12 19:29:51 wazuh-modulesd:agent-upgrade[10893] wm_agent_upgrade_agent.c:283 at wm_upgrade_agent_send_ack_message(): DEBUG: (8163): Sending upgrade ACK event: '{"command":"upgrade_update_status","parameters":{"error":2,"message":"Upgrade failed","status":"Failed"}}'
```

**Event in dashboard**

<img width="1973" height="947" alt="Screenshot 2026-08-12 at 7 33 02 PM" src="https://github.com/user-attachments/assets/ba16bd50-0420-4b81-a70d-88baebdd57d2" />

Before the change the same forced failure produced no event, the evidence of previous runs are located in #38160 

-------------

Tested with `do_upgrade.ps1` from this branch. The manager is reachable on 1517, so the run do a full 4x to 5x-https upgrade.

#### Windows agent v4.14.7

**Baseline**

```console
PS C:\Users\wazuh> Get-Content 'C:\Program Files (x86)\ossec-agent\VERSION.json'
{
    "version": "4.14.7",
    "stage": "rc1",
    "commit": "8c41e20"
}
PS C:\Users\wazuh> Get-Service WazuhSvc

Status   Name               DisplayName
------   ----               -----------
Running  WazuhSvc           Wazuh


```

**Test-only edit in `do_upgrade.ps1` script**

> This forces the "corrupt" `VERSION.json` file after upgrade.

```diff
install -installDir $wazuhDir
+ Remove-Item ".\VERSION.json" -Force -ErrorAction SilentlyContinue 
check-installation
```

**Run `do_upgrade.ps1`**

```console
PS C:\Users\wazuh> Set-Location 'C:\Program Files (x86)\ossec-agent\'
PS C:\Program Files (x86)\ossec-agent> .\upgrade\do_upgrade.ps1
```

**Upgrade result in `upgrade.log`**

```text
PS C:\Users\wazuh> Get-Content 'C:\Program Files (x86)\ossec-agent\upgrade\upgrade.log'

2026-08-13 18:32:15Z - Found Wazuh installation at: HKLM:\SOFTWARE\WOW6432Node\Wazuh, Inc.\Wazuh Agent\WazuhInstallDir = C:\Program Files (x86)\ossec-agent\
2026-08-13 18:32:15Z - Extracted version from VERSION.json : 4.14.7.
2026-08-13 18:32:15Z - Current version: 4.14.7.
2026-08-13 18:32:15Z - Extracting the version from MSI file.
2026-08-13 18:32:16Z - MSI new version: v5.0.0.
2026-08-13 18:32:17Z - Checking connectivity to 192.168.18.238:1517.
2026-08-13 18:32:17Z - Manager reachable at 192.168.18.238:1517.
2026-08-13 18:32:17Z - Killed msiexec process(es).
2026-08-13 18:32:17Z - Stopping win32ui process.
2026-08-13 18:32:17Z - Tried to stop process win32ui: Cannot find a process with the name "win32ui". Verify the process name and call the cmdlet again.
2026-08-13 18:32:17Z - Stopping Wazuh service.
2026-08-13 18:32:22Z - Starting upgrade process.
2026-08-13 18:32:22Z - Installing MSI to: C:\Program Files (x86)\ossec-agent\ (msiexec.exe /i wazuh-agent_5.0.0-0_windows_c21ecaa.msi APPLICATIONFOLDER="C:\Program Files (x86)\ossec-agent\" WIXUI_INSTALLDIR=APPLICATIONFOLDER REBOOT=ReallySuppress /qn /l*v installer.log)
2026-08-13 18:32:27Z - Error: No version file found (expected VERSION.json or VERSION).
2026-08-13 18:32:27Z - Waiting for the Wazuh-Agent installation to end.
2026-08-13 18:32:29Z - Error: No version file found (expected VERSION.json or VERSION).
2026-08-13 18:32:29Z - Waiting for the Wazuh-Agent installation to end.
2026-08-13 18:32:31Z - Error: No version file found (expected VERSION.json or VERSION).
2026-08-13 18:32:31Z - Waiting for the Wazuh-Agent installation to end.
2026-08-13 18:32:33Z - Error: No version file found (expected VERSION.json or VERSION).
2026-08-13 18:32:33Z - Waiting for the Wazuh-Agent installation to end.
2026-08-13 18:32:35Z - Error: No version file found (expected VERSION.json or VERSION).
2026-08-13 18:32:35Z - Waiting for the Wazuh-Agent installation to end.
2026-08-13 18:32:37Z - Error: No version file found (expected VERSION.json or VERSION).
2026-08-13 18:32:37Z - Could not read the installed version after the installation.
2026-08-13 18:32:37Z - Starting Wazuh-Agent service.
2026-08-13 18:32:37Z - Installation finished.
2026-08-13 18:32:37Z - Process ID: 8920.
2026-08-13 18:32:38Z - Reading status file: status='connected'.
2026-08-13 18:32:38Z - Upgrade finished successfully.
2026-08-13 18:32:38Z - Error: No version file found (expected VERSION.json or VERSION).
2026-08-13 18:32:38Z - New version: .
```

**After upgrade**

```console
PS C:\Users\wazuh> Get-Service WazuhSvc

Status   Name               DisplayName
------   ----               -----------
Running  WazuhSvc           Wazuh


```

> Before this fix, this scenario leaves the agent stopped.

**ACK report**

No ACK since this path happens after the upgrade, agent is now 5.0.0-https (only stateless event).

**Event in dashboard**

<img width="1975" height="979" alt="Screenshot 2026-08-13 at 6 39 57 PM" src="https://github.com/user-attachments/assets/747d5cf3-1399-4103-b5fa-4f716a6b98e1" />

### Artifacts Affected

- WPK packages for Linux and macOS agents, which carry `pkg_installer.sh`.
- WPK packages for Windows agents, which carry `do_upgrade.ps1`.

No binaries, and no packages of the agent itself.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...