### PR TITLE
Enhancement/38308 agent https zstd compression

### DIFF
--- a/.github/actions/check_files/deb_linux_agent_amd64.csv
+++ b/.github/actions/check_files/deb_linux_agent_amd64.csv
@@ -10,7 +10,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12374168,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,505104,0.1
 /var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,241184,0.1
-/var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,476176,0.1
+/var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,1153344,0.1
 /var/ossec/lib/libschema_validator.so,root,wazuh,750,file,-rwxr-x---,390232,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2603392,0.1
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,253344,0.1

--- a/.github/actions/check_files/deb_linux_agent_i386.csv
+++ b/.github/actions/check_files/deb_linux_agent_i386.csv
@@ -10,7 +10,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12358288,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,525380,0.1
 /var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,216020,0.1
-/var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,381752,0.1
+/var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,1058920,0.1
 /var/ossec/lib/libschema_validator.so,root,wazuh,750,file,-rwxr-x---,426324,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2792476,0.1
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,273712,0.1

--- a/.github/actions/check_files/rpm_linux_agent_amd64.csv
+++ b/.github/actions/check_files/rpm_linux_agent_amd64.csv
@@ -74,7 +74,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12417720,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,484376,0.1
 /var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,249336,0.1
-/var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,455704,0.1
+/var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,1132872,0.1
 /var/ossec/lib/libschema_validator.so,root,wazuh,750,file,-rwxr-x---,386024,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2555328,0.1
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,224672,0.1

--- a/.github/actions/check_files/rpm_linux_agent_i386.csv
+++ b/.github/actions/check_files/rpm_linux_agent_i386.csv
@@ -74,7 +74,7 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/ossec/lib/libwazuhext.so,root,wazuh,750,file,-rwxr-x---,12362096,0.1
 /var/ossec/lib/libdbsync.so,root,wazuh,750,file,-rwxr-x---,541828,0.1
 /var/ossec/lib/libagent_sync_protocol.so,root,wazuh,750,file,-rwxr-x---,216520,0.1
-/var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,365376,0.1
+/var/ossec/lib/libhttps_client.so,root,wazuh,750,file,-rwxr-x---,1042544,0.1
 /var/ossec/lib/libschema_validator.so,root,wazuh,750,file,-rwxr-x---,398136,0.1
 /var/ossec/lib/libsysinfo.so,root,wazuh,750,file,-rwxr-x---,2717844,0.1
 /var/ossec/lib/libfimdb.so,root,wazuh,750,file,-rwxr-x---,259032,0.1

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -122,7 +122,7 @@ agent.tolerance=15
 agent.warn_level=90
 # Level of occupied capacity in Agent buffer to come back to normal state
 agent.normal_level=70
-# Compress HTTPS request bodies with zstd (#38308)
+# Compress HTTPS request bodies with zstd
 # 0. Disabled
 # 1. Enabled
 agent.https_compression_enabled=0

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -122,6 +122,10 @@ agent.tolerance=15
 agent.warn_level=90
 # Level of occupied capacity in Agent buffer to come back to normal state
 agent.normal_level=70
+# Compress HTTPS request bodies with zstd (#38308)
+# 0. Disabled
+# 1. Enabled
+agent.https_compression_enabled=0
 # Minimum events per second, configurable at XML settings [1..1000]
 agent.min_eps=50
 # Interval for agent status file updating (seconds) [0..86400]

--- a/src/Makefile
+++ b/src/Makefile
@@ -509,11 +509,10 @@ endif
 endif
 
 # zstd: request/response body compression. Manager-side decode is already
-# merged (#38129); agent-side compression (#38308) needs it too, so it moves
-# out of the manager-only set above. Built on every non-winagent target for
-# now -- winagent's MinGW cross-compile toolchain args are a dedicated
-# follow-up (verified against packages/windows/Dockerfile), not part of this
-# pass.
+# merged (#38129); agent-side compression needs it too, so it moves out of
+# the manager-only set above. Built on every non-winagent target for now --
+# winagent's MinGW cross-compile toolchain args are a dedicated follow-up
+# (verified against packages/windows/Dockerfile), not part of this pass.
 ifneq (${TARGET},winagent)
 	EXTERNAL_RES += zstd
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -476,7 +476,7 @@ endif
 #     shared by the unit-test CI, whose deps step runs `make deps TARGET=...`
 #     WITHOUT TEST=1 and only enables tests at build time. Gating these behind a
 #     TEST flag drops them from that bundle and breaks every test build (#36247).
-EXTERNAL_RES := cJSON openssl zlib sqlite libyaml curl libpcre2 nlohmann flatbuffers bzip2 googletest benchmark
+EXTERNAL_RES := cJSON openssl zlib sqlite libyaml curl libpcre2 nlohmann flatbuffers bzip2 zstd googletest benchmark
 
 # Linux unit-test wrapper dependencies (every Linux leg except the winagent
 # cross-compile). unit_tests/wrappers/externals/{audit,procpc} include
@@ -506,15 +506,6 @@ ifneq (${TARGET},agent)
 ifneq (${TARGET},winagent)
 	EXTERNAL_RES += $(CPYTHON) libffi jemalloc rocksdb simdjson abseil-cpp spdlog yaml-cpp pugixml libmaxminddb protobuf date fmt re2 rapidjson taskflow RxCpp concurrentqueue fast_float geo_db tzdata cpp-httplib asio expected-lite llhttp restinio
 endif
-endif
-
-# zstd: request/response body compression. Manager-side decode is already
-# merged (#38129); agent-side compression needs it too, so it moves out of
-# the manager-only set above. Built on every non-winagent target for now --
-# winagent's MinGW cross-compile toolchain args are a dedicated follow-up
-# (verified against packages/windows/Dockerfile), not part of this pass.
-ifneq (${TARGET},winagent)
-	EXTERNAL_RES += zstd
 endif
 
 EXTERNAL_DIR := $(EXTERNAL_RES:%=external/%)

--- a/src/Makefile
+++ b/src/Makefile
@@ -504,8 +504,18 @@ endif
 # Manager-only dependencies.
 ifneq (${TARGET},agent)
 ifneq (${TARGET},winagent)
-	EXTERNAL_RES += $(CPYTHON) libffi jemalloc rocksdb simdjson abseil-cpp spdlog yaml-cpp pugixml libmaxminddb protobuf date fmt re2 rapidjson taskflow RxCpp concurrentqueue fast_float geo_db tzdata cpp-httplib asio expected-lite llhttp restinio zstd
+	EXTERNAL_RES += $(CPYTHON) libffi jemalloc rocksdb simdjson abseil-cpp spdlog yaml-cpp pugixml libmaxminddb protobuf date fmt re2 rapidjson taskflow RxCpp concurrentqueue fast_float geo_db tzdata cpp-httplib asio expected-lite llhttp restinio
 endif
+endif
+
+# zstd: request/response body compression. Manager-side decode is already
+# merged (#38129); agent-side compression (#38308) needs it too, so it moves
+# out of the manager-only set above. Built on every non-winagent target for
+# now -- winagent's MinGW cross-compile toolchain args are a dedicated
+# follow-up (verified against packages/windows/Dockerfile), not part of this
+# pass.
+ifneq (${TARGET},winagent)
+	EXTERNAL_RES += zstd
 endif
 
 EXTERNAL_DIR := $(EXTERNAL_RES:%=external/%)

--- a/src/client-agent/https_client/CMakeLists.txt
+++ b/src/client-agent/https_client/CMakeLists.txt
@@ -32,15 +32,9 @@ target_include_directories(
           ${SRC_FOLDER}/external/openssl/include)
 
 # wazuhext carries the vendored libcurl + OpenSSL symbols for agent targets.
-target_link_libraries(https_client PRIVATE wazuhext pthread)
-
-# ext_zstd: request-body compression, same target remoted_module already
-# links for the manager-side decode (#38129). Not built for winagent (see
-# src/Makefile / src/external/CMakeLists.txt) -- compression is compiled out
-# there (retrySender.cpp's #ifndef WIN32), so don't link it either.
-if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
-  target_link_libraries(https_client PRIVATE ext_zstd)
-endif()
+# ext_zstd: request-body compression, same target remoted_module
+# already links for the manager-side decode (#38129).
+target_link_libraries(https_client PRIVATE wazuhext pthread ext_zstd)
 
 set_target_properties(https_client PROPERTIES BUILD_RPATH_USE_ORIGIN TRUE
                                               BUILD_RPATH "$ORIGIN/../lib")
@@ -52,10 +46,20 @@ endif()
 # winagent: emit the .def at link time and generate the MinGW delay-load
 # import library the final win32 executables link against (the
 # agent_sync_protocol recipe).
+#
+# --exclude-libs=libzstd.a: MinGW auto-exports every global symbol from a
+# shared library by default (unlike ELF's convention), so without this,
+# zstd's own public C API (ZSTD_isError, etc.) leaks into this DLL's export
+# table/.def and gets its own delay-load thunk -- colliding with the real
+# ZSTD_isError the test binary also links directly via ext_zstd (needed
+# there to independently decompress and verify what this library produced).
+# Confirmed empirically: omitting this flag produces a real
+# "multiple definition of `ZSTD_isError'" link error building
+# https_client_unit_test.exe.
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   set_target_properties(
     https_client PROPERTIES LINK_FLAGS
-                            "-Wl,--add-stdcall-alias -Wl,--output-def,libhttps_client.def")
+                            "-Wl,--add-stdcall-alias -Wl,--exclude-libs,libzstd.a -Wl,--output-def,libhttps_client.def")
 
   find_program(DLLTOOL i686-w64-mingw32-dlltool)
   if(NOT DLLTOOL)

--- a/src/client-agent/https_client/CMakeLists.txt
+++ b/src/client-agent/https_client/CMakeLists.txt
@@ -32,7 +32,7 @@ target_include_directories(
           ${SRC_FOLDER}/external/openssl/include)
 
 # wazuhext carries the vendored libcurl + OpenSSL symbols for agent targets.
-# ext_zstd: request-body compression (#38308), same target remoted_module
+# ext_zstd: request-body compression, same target remoted_module
 # already links for the manager-side decode (#38129).
 target_link_libraries(https_client PRIVATE wazuhext pthread ext_zstd)
 

--- a/src/client-agent/https_client/CMakeLists.txt
+++ b/src/client-agent/https_client/CMakeLists.txt
@@ -32,9 +32,15 @@ target_include_directories(
           ${SRC_FOLDER}/external/openssl/include)
 
 # wazuhext carries the vendored libcurl + OpenSSL symbols for agent targets.
-# ext_zstd: request-body compression, same target remoted_module
-# already links for the manager-side decode (#38129).
-target_link_libraries(https_client PRIVATE wazuhext pthread ext_zstd)
+target_link_libraries(https_client PRIVATE wazuhext pthread)
+
+# ext_zstd: request-body compression, same target remoted_module already
+# links for the manager-side decode (#38129). Not built for winagent (see
+# src/Makefile / src/external/CMakeLists.txt) -- compression is compiled out
+# there (retrySender.cpp's #ifndef WIN32), so don't link it either.
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  target_link_libraries(https_client PRIVATE ext_zstd)
+endif()
 
 set_target_properties(https_client PROPERTIES BUILD_RPATH_USE_ORIGIN TRUE
                                               BUILD_RPATH "$ORIGIN/../lib")

--- a/src/client-agent/https_client/CMakeLists.txt
+++ b/src/client-agent/https_client/CMakeLists.txt
@@ -32,7 +32,9 @@ target_include_directories(
           ${SRC_FOLDER}/external/openssl/include)
 
 # wazuhext carries the vendored libcurl + OpenSSL symbols for agent targets.
-target_link_libraries(https_client PRIVATE wazuhext pthread)
+# ext_zstd: request-body compression (#38308), same target remoted_module
+# already links for the manager-side decode (#38129).
+target_link_libraries(https_client PRIVATE wazuhext pthread ext_zstd)
 
 set_target_properties(https_client PROPERTIES BUILD_RPATH_USE_ORIGIN TRUE
                                               BUILD_RPATH "$ORIGIN/../lib")

--- a/src/client-agent/https_client/include/https_client.h
+++ b/src/client-agent/https_client/include/https_client.h
@@ -172,7 +172,7 @@ typedef struct hc_config_t
     bool config_report_enabled;
     uint32_t config_report_interval_s; ///< 0 -> 3600.
 
-    /// zstd-compress in-memory request bodies before signing/sending (#38308).
+    /// zstd-compress in-memory request bodies before signing/sending.
     /// internal_options.conf (agent.https_compression_enabled), not a <client>
     /// XML setting -- OFF by default.
     bool https_compression_enabled;

--- a/src/client-agent/https_client/include/https_client.h
+++ b/src/client-agent/https_client/include/https_client.h
@@ -171,6 +171,11 @@ typedef struct hc_config_t
     uint32_t stats_interval_s;         ///< 0 -> 60.
     bool config_report_enabled;
     uint32_t config_report_interval_s; ///< 0 -> 3600.
+
+    /// zstd-compress in-memory request bodies before signing/sending (#38308).
+    /// internal_options.conf (agent.https_compression_enabled), not a <client>
+    /// XML setting -- OFF by default.
+    bool https_compression_enabled;
 } hc_config_t;
 
 /**

--- a/src/client-agent/https_client/src/compressionGate.hpp
+++ b/src/client-agent/https_client/src/compressionGate.hpp
@@ -15,7 +15,7 @@
 #include <atomic>
 
 /**
- * @brief The zstd-rejected latch (#38308). Whether the manager accepts
+ * @brief The zstd-rejected latch. Whether the manager accepts
  *        Content-Encoding: zstd is a property of the manager/connection, not
  *        of which endpoint asked -- so every RetrySender on this agent shares
  *        one gate: the first 415 disables compression for all six send

--- a/src/client-agent/https_client/src/compressionGate.hpp
+++ b/src/client-agent/https_client/src/compressionGate.hpp
@@ -1,0 +1,45 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 12, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _HC_COMPRESSION_GATE_HPP
+#define _HC_COMPRESSION_GATE_HPP
+
+#include <atomic>
+
+/**
+ * @brief The zstd-rejected latch (#38308). Whether the manager accepts
+ *        Content-Encoding: zstd is a property of the manager/connection, not
+ *        of which endpoint asked -- so every RetrySender on this agent shares
+ *        one gate: the first 415 disables compression for all six send
+ *        paths, for the rest of this agent's run.
+ *
+ * One-way (unlike AuthGate): the manager's lack of zstd support does not
+ * change without a restart, so there is no release()/re-arm.
+ */
+class CompressionGate final
+{
+    public:
+        /// A compressed attempt got a 415. Idempotent; safe from any thread.
+        void reportRejected()
+        {
+            m_disabled.store(true, std::memory_order_relaxed);
+        }
+
+        bool disabled() const
+        {
+            return m_disabled.load(std::memory_order_relaxed);
+        }
+
+    private:
+        std::atomic<bool> m_disabled {false};
+};
+
+#endif // _HC_COMPRESSION_GATE_HPP

--- a/src/client-agent/https_client/src/configFetcher.cpp
+++ b/src/client-agent/https_client/src/configFetcher.cpp
@@ -38,10 +38,11 @@ namespace
 
 ConfigFetcher::ConfigFetcher(const ModuleConfig& config, IHttpPerformer& performer,
                              const ISigner& signer, IClock& clock, IRandom& random,
-                             ISpoolFileFactory& spoolFactory, AuthGate& authGate)
+                             ISpoolFileFactory& spoolFactory, AuthGate& authGate,
+                             CompressionGate& compressionGate)
     : m_config(config)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
-    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &authGate)
+    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate)
     , m_spoolFactory(spoolFactory)
 {
 }

--- a/src/client-agent/https_client/src/configFetcher.cpp
+++ b/src/client-agent/https_client/src/configFetcher.cpp
@@ -41,7 +41,7 @@ ConfigFetcher::ConfigFetcher(const ModuleConfig& config, IHttpPerformer& perform
                              ISpoolFileFactory& spoolFactory, AuthGate& authGate)
     : m_config(config)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
-    , m_sender(performer, signer, clock, m_backoff, &authGate)
+    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &authGate)
     , m_spoolFactory(spoolFactory)
 {
 }

--- a/src/client-agent/https_client/src/configFetcher.hpp
+++ b/src/client-agent/https_client/src/configFetcher.hpp
@@ -40,7 +40,8 @@ class ConfigFetcher final
     public:
         ConfigFetcher(const ModuleConfig& config, IHttpPerformer& performer,
                       const ISigner& signer, IClock& clock, IRandom& random,
-                      ISpoolFileFactory& spoolFactory, AuthGate& authGate);
+                      ISpoolFileFactory& spoolFactory, AuthGate& authGate,
+                      CompressionGate& compressionGate);
 
         /// Downloads the config for `group`, expecting the given SHA-256.
         /// Returns the verified spool file (deleted on drop) or nullptr on

--- a/src/client-agent/https_client/src/controlStream.cpp
+++ b/src/client-agent/https_client/src/controlStream.cpp
@@ -155,16 +155,16 @@ ControlStream::ControlStream(const ModuleConfig& config, IHttpPerformer& perform
                              const ISigner& signer, IClock& clock, IRandom& random,
                              ICallbackSink& sink, ISpoolFileFactory& spoolFactory,
                              ConfigHashState& configHash, ClusterIdentity& cluster,
-                             AuthGate& authGate, ITaskIdStore& taskStore,
-                             IVdOffsetStore& vdOffsetStore,
+                             AuthGate& authGate, CompressionGate& compressionGate,
+                             ITaskIdStore& taskStore, IVdOffsetStore& vdOffsetStore,
                              std::function<std::string()> collectHost)
     : m_config(config)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
-    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &authGate)
+    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate)
     , m_clock(clock)
     , m_sink(sink)
-    , m_fetcher(config, performer, signer, clock, random, spoolFactory, authGate)
-    , m_wpkFetcher(config, performer, signer, clock, random, spoolFactory, authGate)
+    , m_fetcher(config, performer, signer, clock, random, spoolFactory, authGate, compressionGate)
+    , m_wpkFetcher(config, performer, signer, clock, random, spoolFactory, authGate, compressionGate)
     , m_configHash(configHash)
     , m_cluster(cluster)
     , m_authGate(authGate)

--- a/src/client-agent/https_client/src/controlStream.cpp
+++ b/src/client-agent/https_client/src/controlStream.cpp
@@ -160,7 +160,7 @@ ControlStream::ControlStream(const ModuleConfig& config, IHttpPerformer& perform
                              std::function<std::string()> collectHost)
     : m_config(config)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
-    , m_sender(performer, signer, clock, m_backoff, &authGate)
+    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &authGate)
     , m_clock(clock)
     , m_sink(sink)
     , m_fetcher(config, performer, signer, clock, random, spoolFactory, authGate)

--- a/src/client-agent/https_client/src/controlStream.hpp
+++ b/src/client-agent/https_client/src/controlStream.hpp
@@ -49,8 +49,9 @@ class ControlStream final
         ControlStream(const ModuleConfig& config, IHttpPerformer& performer, const ISigner& signer,
                       IClock& clock, IRandom& random, ICallbackSink& sink,
                       ISpoolFileFactory& spoolFactory, ConfigHashState& configHash,
-                      ClusterIdentity& cluster, AuthGate& authGate, ITaskIdStore& taskStore,
-                      IVdOffsetStore& vdOffsetStore, std::function<std::string()> collectHost = {});
+                      ClusterIdentity& cluster, AuthGate& authGate, CompressionGate& compressionGate,
+                      ITaskIdStore& taskStore, IVdOffsetStore& vdOffsetStore,
+                      std::function<std::string()> collectHost = {});
 
         /// Safety net for any destruction path that doesn't go through HttpsClientFacade::
         /// stop() first (e.g. a test constructing a bare ControlStream): joins m_upgradeThread

--- a/src/client-agent/https_client/src/exclusiveTempFile.cpp
+++ b/src/client-agent/https_client/src/exclusiveTempFile.cpp
@@ -1,0 +1,143 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 17, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "exclusiveTempFile.hpp"
+
+#include <atomic>
+#include <cerrno>
+#include <cstdio>
+#include <random>
+#include <thread>
+
+#ifdef WIN32
+#include <fcntl.h>
+#include <io.h>
+#include <process.h>
+#include <share.h>
+#include <sys/stat.h>
+#else
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+namespace
+{
+    std::string defaultTempDir()
+    {
+#ifdef WIN32
+        const char* candidates[] = {std::getenv("TEMP"), std::getenv("TMP")};
+#else
+        const char* candidates[] = {std::getenv("TMPDIR"), "/tmp"};
+#endif
+
+        for (const char* candidate : candidates)
+        {
+            if (candidate != nullptr && candidate[0] != '\0')
+            {
+                return candidate;
+            }
+        }
+
+        return "."; // LCOV_EXCL_LINE: at least one candidate is always set in practice.
+    }
+
+    std::string threadIdHex()
+    {
+        const auto id = std::hash<std::thread::id> {}(std::this_thread::get_id());
+        char buffer[32];
+        std::snprintf(buffer, sizeof(buffer), "%zx", id);
+        return buffer;
+    }
+
+    std::string pidHex()
+    {
+#ifdef WIN32
+        const auto pid = static_cast<unsigned long>(_getpid());
+#else
+        const auto pid = static_cast<unsigned long>(::getpid());
+#endif
+        char buffer[24];
+        std::snprintf(buffer, sizeof(buffer), "%lx", pid);
+        return buffer;
+    }
+
+    std::string randomTokenHex()
+    {
+        // Thread-local RNG: callers spool/compress from several module threads
+        // at once; a shared generator would need locking. Seeded once per
+        // thread from the OS entropy source, so the next path is unpredictable.
+        static thread_local std::mt19937_64 engine {std::random_device {}()};
+        char buffer[24];
+        std::snprintf(buffer, sizeof(buffer), "%016llx",
+                      static_cast<unsigned long long>(engine()));
+        return buffer;
+    }
+
+    std::string uniquePath(const std::string& dir, const std::string& prefix)
+    {
+        // pid + thread id + a monotonic counter (shared across every caller of
+        // this function, spool or compress alike) + a random token order the
+        // name and make it unpredictable, so it cannot be pre-planted to force
+        // the exclusive create below to collide.
+        static std::atomic<uint64_t> counter {0};
+        return dir + "/" + prefix + pidHex() + "_" + threadIdHex() + "_"
+               + std::to_string(counter++) + "_" + randomTokenHex() + ".tmp";
+    }
+
+    // Atomic, exclusive create (O_EXCL) with owner-only permissions. Returns a
+    // file descriptor, or -1 with errno set (EEXIST when the path already
+    // exists). Never follows an existing symlink -- the create simply fails.
+    int openExclusive(const std::string& path)
+    {
+#ifdef WIN32
+        int fd = -1;
+        _sopen_s(&fd, path.c_str(), _O_CREAT | _O_EXCL | _O_WRONLY | _O_BINARY, _SH_DENYRW,
+                 _S_IREAD | _S_IWRITE);
+        return fd;
+#else
+        return ::open(path.c_str(), O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC, S_IRUSR | S_IWUSR);
+#endif
+    }
+} // namespace
+
+int createExclusiveTempFile(const std::string& dir, const std::string& prefix, std::string& outPath)
+{
+    constexpr int maxAttempts = 100;
+    const std::string effectiveDir = dir.empty() ? defaultTempDir() : dir;
+
+    for (int attempt = 0; attempt < maxAttempts; attempt++)
+    {
+        outPath = uniquePath(effectiveDir, prefix);
+        const int fd = openExclusive(outPath);
+
+        if (fd >= 0)
+        {
+            return fd;
+        }
+
+        if (errno != EEXIST)
+        {
+            return -1; // Unwritable/missing dir, etc.: not a collision.
+        }
+    }
+
+    return -1; // LCOV_EXCL_LINE: exhausting 100 random names is not reproducible.
+}
+
+void closeExclusiveTempFile(int fd)
+{
+#ifdef WIN32
+    _close(fd);
+#else
+    ::close(fd);
+#endif
+}

--- a/src/client-agent/https_client/src/exclusiveTempFile.hpp
+++ b/src/client-agent/https_client/src/exclusiveTempFile.hpp
@@ -1,0 +1,37 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 17, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _HC_EXCLUSIVE_TEMP_FILE_HPP
+#define _HC_EXCLUSIVE_TEMP_FILE_HPP
+
+#include <string>
+
+/// Creates a new, uniquely-named file under `dir` atomically and exclusively
+/// (O_EXCL) with owner-only permissions, so a shared dir (e.g. /tmp) cannot be
+/// used to hijack or read back the file's contents via a pre-planted symlink
+/// -- the create simply fails on an existing path rather than following it.
+/// An empty `dir` falls back to TMPDIR/TEMP/TMP or "/tmp" (never silently
+/// resolves to the process's cwd via a bare relative path) -- callers whose
+/// own configured spool directory can be unset (e.g. ModuleConfig::spoolDir,
+/// which nothing populates today) don't each need their own fallback.
+/// `prefix` names the caller (e.g. "hc_sync_", "hc_zstd_") for easier
+/// spool-dir triage; the rest of the name is unpredictable (pid + thread id +
+/// a monotonic counter + a random token), so it cannot be pre-planted to force
+/// a collision. Retries on the (essentially impossible) random-name collision;
+/// any other error means the directory is unusable. On success, returns an
+/// open, writable fd and sets `outPath` to the created path. On failure,
+/// returns -1 (errno set, except after exhausting collision retries).
+int createExclusiveTempFile(const std::string& dir, const std::string& prefix, std::string& outPath);
+
+/// Portable close() wrapper, paired with the fd createExclusiveTempFile() returns.
+void closeExclusiveTempFile(int fd);
+
+#endif // _HC_EXCLUSIVE_TEMP_FILE_HPP

--- a/src/client-agent/https_client/src/fileCompressor.cpp
+++ b/src/client-agent/https_client/src/fileCompressor.cpp
@@ -1,0 +1,162 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 17, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "fileCompressor.hpp"
+
+#include "exclusiveTempFile.hpp"
+
+#include <zstd.h>
+
+#include <array>
+#include <cstdio>
+
+namespace
+{
+    constexpr size_t FILE_CHUNK = 64 * 1024; // Matches cmacSigner.cpp/zstdDecoder.cpp.
+    // Matches the level RetrySender uses for in-memory bodies (retrySender.cpp).
+    constexpr int kCompressionLevel = 3;
+
+    using FilePtr = std::unique_ptr<std::FILE, decltype(&std::fclose)>;
+
+    struct CCtxGuard
+    {
+        ZSTD_CCtx* ctx;
+        ~CCtxGuard()
+        {
+            ZSTD_freeCCtx(ctx);
+        }
+    };
+} // namespace
+
+std::optional<std::pair<std::unique_ptr<SpoolFile>, uint64_t>>
+ZstdFileCompressor::compress(const std::string& sourcePath, uint64_t sourceSize,
+                             const std::string& spoolDir, const std::atomic<bool>* abortFlag)
+{
+    const FilePtr source {std::fopen(sourcePath.c_str(), "rb"), std::fclose};
+
+    if (!source)
+    {
+        return std::nullopt;
+    }
+
+    std::string destPath;
+    const int destFd = createExclusiveTempFile(spoolDir, "hc_zstd_", destPath);
+
+    if (destFd < 0)
+    {
+        return std::nullopt;
+    }
+
+#ifdef WIN32
+    FilePtr dest {_fdopen(destFd, "wb"), std::fclose};
+#else
+    FilePtr dest {fdopen(destFd, "wb"), std::fclose};
+#endif
+
+    if (!dest)
+    {
+        closeExclusiveTempFile(destFd); // fdopen() failed: the fd is still ours to close.
+        std::remove(destPath.c_str());
+        return std::nullopt; // LCOV_EXCL_LINE: fdopen() on a just-opened fd doesn't fail in practice.
+    }
+
+    ZSTD_CCtx* cctx = ZSTD_createCCtx();
+
+    if (cctx == nullptr)
+    {
+        std::remove(destPath.c_str());
+        return std::nullopt; // LCOV_EXCL_LINE: allocation failure only.
+    }
+
+    const CCtxGuard guard {cctx};
+
+    if (ZSTD_isError(ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, kCompressionLevel)) ||
+            ZSTD_isError(ZSTD_CCtx_setPledgedSrcSize(cctx, sourceSize)))
+    {
+        std::remove(destPath.c_str());
+        return std::nullopt; // LCOV_EXCL_LINE: cannot fail on a freshly created CCtx.
+    }
+
+    std::array<uint8_t, FILE_CHUNK> inChunk {};
+    std::array<uint8_t, FILE_CHUNK> outChunk {};
+    uint64_t compressedSize = 0;
+
+    auto flushOutput = [&](const ZSTD_outBuffer& output)
+    {
+        if (output.pos == 0)
+        {
+            return true;
+        }
+
+        if (std::fwrite(outChunk.data(), 1, output.pos, dest.get()) != output.pos)
+        {
+            return false; // LCOV_EXCL_LINE: write failure is not reproducible in tests.
+        }
+
+        compressedSize += output.pos;
+        return true;
+    };
+
+    size_t bytesRead = 0;
+
+    while ((bytesRead = std::fread(inChunk.data(), 1, inChunk.size(), source.get())) > 0)
+    {
+        if (abortFlag != nullptr && abortFlag->load())
+        {
+            std::remove(destPath.c_str());
+            return std::nullopt;
+        }
+
+        ZSTD_inBuffer input {inChunk.data(), bytesRead, 0};
+
+        while (input.pos < input.size)
+        {
+            ZSTD_outBuffer output {outChunk.data(), outChunk.size(), 0};
+            const size_t ret = ZSTD_compressStream2(cctx, &output, &input, ZSTD_e_continue);
+
+            if (ZSTD_isError(ret) || !flushOutput(output))
+            {
+                std::remove(destPath.c_str());
+                return std::nullopt;
+            }
+        }
+    }
+
+    if (std::ferror(source.get()))
+    {
+        std::remove(destPath.c_str());
+        return std::nullopt;
+    }
+
+    // Flush the frame epilogue: feed no more input, ZSTD_e_end, until zstd
+    // reports nothing left buffered (return value 0). Handles the empty-file
+    // case correctly too (produces a minimal valid zstd frame).
+    const ZSTD_inBuffer noMoreInput {nullptr, 0, 0};
+    size_t remaining = 0;
+
+    do
+    {
+        ZSTD_outBuffer output {outChunk.data(), outChunk.size(), 0};
+        ZSTD_inBuffer endInput = noMoreInput;
+        remaining = ZSTD_compressStream2(cctx, &output, &endInput, ZSTD_e_end);
+
+        if (ZSTD_isError(remaining) || !flushOutput(output))
+        {
+            std::remove(destPath.c_str());
+            return std::nullopt;
+        }
+    }
+    while (remaining != 0);
+
+    dest.reset(); // Close (flush to disk) before handing the path off.
+
+    return std::make_pair(std::make_unique<SpoolFile>(destPath), compressedSize);
+}

--- a/src/client-agent/https_client/src/fileCompressor.cpp
+++ b/src/client-agent/https_client/src/fileCompressor.cpp
@@ -37,8 +37,8 @@ namespace
 } // namespace
 
 std::optional<std::pair<std::unique_ptr<SpoolFile>, uint64_t>>
-ZstdFileCompressor::compress(const std::string& sourcePath, uint64_t sourceSize,
-                             const std::string& spoolDir, const std::atomic<bool>* abortFlag)
+                                                            ZstdFileCompressor::compress(const std::string& sourcePath, uint64_t sourceSize,
+                                                                                         const std::string& spoolDir, const std::atomic<bool>* abortFlag)
 {
     const FilePtr source {std::fopen(sourcePath.c_str(), "rb"), std::fclose};
 
@@ -89,7 +89,7 @@ ZstdFileCompressor::compress(const std::string& sourcePath, uint64_t sourceSize,
     std::array<uint8_t, FILE_CHUNK> outChunk {};
     uint64_t compressedSize = 0;
 
-    auto flushOutput = [&](const ZSTD_outBuffer& output)
+    auto flushOutput = [&](const ZSTD_outBuffer & output)
     {
         if (output.pos == 0)
         {

--- a/src/client-agent/https_client/src/fileCompressor.hpp
+++ b/src/client-agent/https_client/src/fileCompressor.hpp
@@ -1,0 +1,59 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 17, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _HC_FILE_COMPRESSOR_HPP
+#define _HC_FILE_COMPRESSOR_HPP
+
+#include "spoolFile.hpp"
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+/// Streams a file through zstd into a new spool file, one chunk at a time --
+/// never loading more than one chunk of either the source or the compressed
+/// output into memory, so a multi-MB /stateful session never sits fully in
+/// RAM (matching the existing spool/sign design's own "flat memory"
+/// property). Injected so tests can force compression failures without
+/// touching zstd or the filesystem.
+class IFileCompressor
+{
+    public:
+        virtual ~IFileCompressor() = default;
+
+        /// Compresses sourcePath (exactly sourceSize bytes) into a new,
+        /// exclusively-created temp file under spoolDir. abortFlag, when
+        /// non-null, is checked between chunks; a set flag aborts the
+        /// compression (deleting the partial output) rather than running it
+        /// to completion -- so a large session's compression can't stall
+        /// agent shutdown. Returns the compressed SpoolFile and its size, or
+        /// nullopt on any failure (unreadable source, disk full, zstd error,
+        /// abort) -- callers fall back to sending the uncompressed original.
+        virtual std::optional<std::pair<std::unique_ptr<SpoolFile>, uint64_t>>
+        compress(const std::string& sourcePath, uint64_t sourceSize, const std::string& spoolDir,
+                 const std::atomic<bool>* abortFlag) = 0;
+};
+
+/// Real implementation: ZSTD_compressStream2 at the same level RetrySender
+/// uses for in-memory bodies, streamed in 64 KiB chunks (matching
+/// cmacSigner.cpp::signFile() and the manager's zstdDecoder.cpp).
+class ZstdFileCompressor final : public IFileCompressor
+{
+    public:
+        std::optional<std::pair<std::unique_ptr<SpoolFile>, uint64_t>>
+        compress(const std::string& sourcePath, uint64_t sourceSize, const std::string& spoolDir,
+                 const std::atomic<bool>* abortFlag) override;
+};
+
+#endif // _HC_FILE_COMPRESSOR_HPP

--- a/src/client-agent/https_client/src/fileCompressor.hpp
+++ b/src/client-agent/https_client/src/fileCompressor.hpp
@@ -41,8 +41,8 @@ class IFileCompressor
         /// nullopt on any failure (unreadable source, disk full, zstd error,
         /// abort) -- callers fall back to sending the uncompressed original.
         virtual std::optional<std::pair<std::unique_ptr<SpoolFile>, uint64_t>>
-        compress(const std::string& sourcePath, uint64_t sourceSize, const std::string& spoolDir,
-                 const std::atomic<bool>* abortFlag) = 0;
+                                                                            compress(const std::string& sourcePath, uint64_t sourceSize, const std::string& spoolDir,
+                                                                                     const std::atomic<bool>* abortFlag) = 0;
 };
 
 /// Real implementation: ZSTD_compressStream2 at the same level RetrySender
@@ -52,8 +52,8 @@ class ZstdFileCompressor final : public IFileCompressor
 {
     public:
         std::optional<std::pair<std::unique_ptr<SpoolFile>, uint64_t>>
-        compress(const std::string& sourcePath, uint64_t sourceSize, const std::string& spoolDir,
-                 const std::atomic<bool>* abortFlag) override;
+                                                                    compress(const std::string& sourcePath, uint64_t sourceSize, const std::string& spoolDir,
+                                                                             const std::atomic<bool>* abortFlag) override;
 };
 
 #endif // _HC_FILE_COMPRESSOR_HPP

--- a/src/client-agent/https_client/src/httpTypes.hpp
+++ b/src/client-agent/https_client/src/httpTypes.hpp
@@ -147,6 +147,11 @@ struct HttpRequestSpec
     size_t bodyLength {0};
     std::string bodyFilePath;          ///< When non-empty: stream the body from this file.
     uint64_t bodyFileSize {0};
+    std::string precompressedBodyFilePath; ///< Optional zstd-compressed sibling of
+    ///< bodyFilePath, precomputed once by the caller (only /stateful today).
+    ///< attemptOnce() swaps it in when compression is enabled/allowed; empty
+    ///< means no such sibling exists, so bodyFilePath is sent as-is.
+    uint64_t precompressedBodyFileSize {0};
     std::string responseFilePath;      ///< When non-empty: stream the response body to this
     ///< file (truncated per attempt) instead of
     ///< HttpResponse::body.

--- a/src/client-agent/https_client/src/httpTypes.hpp
+++ b/src/client-agent/https_client/src/httpTypes.hpp
@@ -47,6 +47,8 @@ enum class OutcomeClass
     Permanent,       ///< 400/...: retrying identical bytes cannot succeed.
     PayloadTooLarge, ///< 413: /stateless splits + resends smaller (#37835).
     VersionRejected, ///< 409 at Startup: REJECTED state, slow re-Startup.
+    CompressionRejected, ///< 415: manager doesn't accept Content-Encoding: zstd;
+    ///< RetrySender retries once, uncompressed (#38308).
     Interrupted      ///< Aborted by shutdown: never a silent success.
 };
 
@@ -79,6 +81,9 @@ inline const char* outcomeName(OutcomeClass outcome)
 
         case OutcomeClass::VersionRejected:
             return "VersionRejected";
+
+        case OutcomeClass::CompressionRejected:
+            return "CompressionRejected";
 
         case OutcomeClass::Interrupted:
             return "Interrupted";
@@ -116,6 +121,12 @@ inline int toHcResult(OutcomeClass outcome)
             return HC_RESULT_PERMANENT;
 
         case OutcomeClass::VersionRejected:
+            return HC_RESULT_PERMANENT;
+
+        // Reached here only if RetrySender's one-shot uncompressed retry was
+        // itself rejected too (unexpected -- the manager should never 415 an
+        // uncompressed body) -- same terminal treatment as Permanent.
+        case OutcomeClass::CompressionRejected:
             return HC_RESULT_PERMANENT;
 
         default:

--- a/src/client-agent/https_client/src/httpTypes.hpp
+++ b/src/client-agent/https_client/src/httpTypes.hpp
@@ -48,7 +48,7 @@ enum class OutcomeClass
     PayloadTooLarge, ///< 413: /stateless splits + resends smaller (#37835).
     VersionRejected, ///< 409 at Startup: REJECTED state, slow re-Startup.
     CompressionRejected, ///< 415: manager doesn't accept Content-Encoding: zstd;
-    ///< RetrySender retries once, uncompressed (#38308).
+    ///< RetrySender retries once, uncompressed.
     Interrupted      ///< Aborted by shutdown: never a silent success.
 };
 

--- a/src/client-agent/https_client/src/httpsClientFacade.cpp
+++ b/src/client-agent/https_client/src/httpsClientFacade.cpp
@@ -67,14 +67,14 @@ HttpsClientFacade::HttpsClientFacade(const hc_config_t& config, const hc_callbac
     , m_vdOffsetStore(callbacks.vd_offset_observe, callbacks.vd_offset_clear_pending, callbacks.user_data)
     , m_collectors(callbacks)
     , m_stateless(m_config, m_performer, m_signer, m_clock, m_random, m_dispatcher, m_authGate,
-                  makeStatelessHostCollector(callbacks))
+                  m_compressionGate, makeStatelessHostCollector(callbacks))
     , m_stateful(m_config, m_performer, m_signer, m_clock, m_random, m_spoolFactory, m_dispatcher,
-                 m_authGate)
+                 m_authGate, m_compressionGate)
     , m_control(m_config, m_performer, m_signer, m_clock, m_random, m_dispatcher, m_spoolFactory,
-                m_configHash, m_cluster, m_authGate, m_taskStore, m_vdOffsetStore,
+                m_configHash, m_cluster, m_authGate, m_compressionGate, m_taskStore, m_vdOffsetStore,
                 makeHostCollector(callbacks))
-    , m_reporter(m_config, m_performer, m_signer, m_clock, m_random, m_authGate, m_cluster,
-                 m_collectors)
+    , m_reporter(m_config, m_performer, m_signer, m_clock, m_random, m_authGate, m_compressionGate,
+                 m_cluster, m_collectors)
 {
 }
 

--- a/src/client-agent/https_client/src/httpsClientFacade.cpp
+++ b/src/client-agent/https_client/src/httpsClientFacade.cpp
@@ -69,7 +69,7 @@ HttpsClientFacade::HttpsClientFacade(const hc_config_t& config, const hc_callbac
     , m_stateless(m_config, m_performer, m_signer, m_clock, m_random, m_dispatcher, m_authGate,
                   m_compressionGate, makeStatelessHostCollector(callbacks))
     , m_stateful(m_config, m_performer, m_signer, m_clock, m_random, m_spoolFactory, m_dispatcher,
-                 m_authGate, m_compressionGate)
+                 m_authGate, m_compressionGate, m_fileCompressor)
     , m_control(m_config, m_performer, m_signer, m_clock, m_random, m_dispatcher, m_spoolFactory,
                 m_configHash, m_cluster, m_authGate, m_compressionGate, m_taskStore, m_vdOffsetStore,
                 makeHostCollector(callbacks))

--- a/src/client-agent/https_client/src/httpsClientFacade.hpp
+++ b/src/client-agent/https_client/src/httpsClientFacade.hpp
@@ -17,6 +17,7 @@
 #include "clusterIdentity.hpp"
 #include "cmacSigner.hpp"
 #include "collectorSource.hpp"
+#include "compressionGate.hpp"
 #include "configHashState.hpp"
 #include "controlStream.hpp"
 #include "reporterStream.hpp"
@@ -102,6 +103,9 @@ class HttpsClientFacade final
         // The wake lambda runs later, so referencing m_controlWaiter (declared
         // below) is safe.
         AuthGate m_authGate {m_dispatcher, [this] { m_controlWaiter.notify(); }};
+        // Shared across every stream's RetrySender (#38308): one 415 disables
+        // compression agent-wide for the rest of this run.
+        CompressionGate m_compressionGate;
 
         CallbackCollectorSource m_collectors;
         StatelessStream m_stateless;

--- a/src/client-agent/https_client/src/httpsClientFacade.hpp
+++ b/src/client-agent/https_client/src/httpsClientFacade.hpp
@@ -103,7 +103,7 @@ class HttpsClientFacade final
         // The wake lambda runs later, so referencing m_controlWaiter (declared
         // below) is safe.
         AuthGate m_authGate {m_dispatcher, [this] { m_controlWaiter.notify(); }};
-        // Shared across every stream's RetrySender (#38308): one 415 disables
+        // Shared across every stream's RetrySender: one 415 disables
         // compression agent-wide for the rest of this run.
         CompressionGate m_compressionGate;
 

--- a/src/client-agent/https_client/src/httpsClientFacade.hpp
+++ b/src/client-agent/https_client/src/httpsClientFacade.hpp
@@ -22,6 +22,7 @@
 #include "controlStream.hpp"
 #include "reporterStream.hpp"
 #include "curlPerformer.hpp"
+#include "fileCompressor.hpp"
 #include "https_client.h"
 #include "keyProvider.hpp"
 #include "moduleConfig.hpp"
@@ -93,6 +94,7 @@ class HttpsClientFacade final
         ConfigKeyProvider m_keyProvider;
         CmacSigner m_signer;
         TempSpoolFactory m_spoolFactory;
+        ZstdFileCompressor m_fileCompressor; // /stateful only; compresses spooled sessions once, up front.
         CurlPerformer m_performer;
         CallbackDispatcher m_dispatcher;
         ConfigHashState m_configHash;

--- a/src/client-agent/https_client/src/moduleConfig.cpp
+++ b/src/client-agent/https_client/src/moduleConfig.cpp
@@ -63,6 +63,7 @@ ModuleConfig ModuleConfig::fromC(const hc_config_t& config)
     typed.drainTimeoutMs = orDefault<uint32_t>(config.drain_timeout_ms, 5000);
     typed.spoolDir = boundedString(config.spool_dir, sizeof(config.spool_dir));
     typed.syncSocketPath = boundedString(config.sync_socket_path, sizeof(config.sync_socket_path));
+    typed.httpsCompressionEnabled = config.https_compression_enabled;
     return typed;
 }
 

--- a/src/client-agent/https_client/src/moduleConfig.hpp
+++ b/src/client-agent/https_client/src/moduleConfig.hpp
@@ -74,6 +74,10 @@ struct ModuleConfig
         uint32_t configReportIntervalS {3600};
         std::string syncSocketPath; ///< Stateful sync-intake STREAM socket; empty = disabled.
 
+        // #38308: zstd-compress in-memory request bodies before signing/sending.
+        // internal_options.conf (agent.https_compression_enabled), off by default.
+        bool httpsCompressionEnabled {false};
+
         // Always "https" in production (fromC never changes it); the component
         // test overrides it to "http" to drive the real curl path against a
         // plaintext fake manager.

--- a/src/client-agent/https_client/src/moduleConfig.hpp
+++ b/src/client-agent/https_client/src/moduleConfig.hpp
@@ -74,7 +74,7 @@ struct ModuleConfig
         uint32_t configReportIntervalS {3600};
         std::string syncSocketPath; ///< Stateful sync-intake STREAM socket; empty = disabled.
 
-        // #38308: zstd-compress in-memory request bodies before signing/sending.
+        // zstd-compress in-memory request bodies before signing/sending.
         // internal_options.conf (agent.https_compression_enabled), off by default.
         bool httpsCompressionEnabled {false};
 

--- a/src/client-agent/https_client/src/outcomeClassifier.cpp
+++ b/src/client-agent/https_client/src/outcomeClassifier.cpp
@@ -53,6 +53,14 @@ OutcomeClass classifyOutcome(const HttpResponse& response)
         return OutcomeClass::VersionRejected;
     }
 
+    // 415: the manager's BodyDecoder doesn't accept Content-Encoding: zstd
+    // (disabled server-side, or an intermediary stripped/rejected it) --
+    // RetrySender retries once, uncompressed (#38308).
+    if (code == 415)
+    {
+        return OutcomeClass::CompressionRejected;
+    }
+
     if (code == 429 || code == 503)
     {
         return OutcomeClass::BackPressure;

--- a/src/client-agent/https_client/src/outcomeClassifier.cpp
+++ b/src/client-agent/https_client/src/outcomeClassifier.cpp
@@ -55,7 +55,7 @@ OutcomeClass classifyOutcome(const HttpResponse& response)
 
     // 415: the manager's BodyDecoder doesn't accept Content-Encoding: zstd
     // (disabled server-side, or an intermediary stripped/rejected it) --
-    // RetrySender retries once, uncompressed (#38308).
+    // RetrySender retries once, uncompressed.
     if (code == 415)
     {
         return OutcomeClass::CompressionRejected;

--- a/src/client-agent/https_client/src/reporterStream.cpp
+++ b/src/client-agent/https_client/src/reporterStream.cpp
@@ -32,11 +32,11 @@ namespace
 
 ReporterStream::ReporterStream(const ModuleConfig& config, IHttpPerformer& performer,
                                const ISigner& signer, IClock& clock, IRandom& random,
-                               AuthGate& authGate, ClusterIdentity& cluster,
-                               ICollectorSource& collectors)
+                               AuthGate& authGate, CompressionGate& compressionGate,
+                               ClusterIdentity& cluster, ICollectorSource& collectors)
     : m_config(config)
     , m_sendBackoff(config.backoffBaseMs, config.backoffCapMs, random)
-    , m_sender(performer, signer, clock, m_sendBackoff, config.httpsCompressionEnabled, &authGate)
+    , m_sender(performer, signer, clock, m_sendBackoff, config.httpsCompressionEnabled, &compressionGate, &authGate)
     , m_clock(clock)
     , m_authGate(authGate)
     , m_cluster(cluster)

--- a/src/client-agent/https_client/src/reporterStream.cpp
+++ b/src/client-agent/https_client/src/reporterStream.cpp
@@ -36,7 +36,7 @@ ReporterStream::ReporterStream(const ModuleConfig& config, IHttpPerformer& perfo
                                ICollectorSource& collectors)
     : m_config(config)
     , m_sendBackoff(config.backoffBaseMs, config.backoffCapMs, random)
-    , m_sender(performer, signer, clock, m_sendBackoff, &authGate)
+    , m_sender(performer, signer, clock, m_sendBackoff, config.httpsCompressionEnabled, &authGate)
     , m_clock(clock)
     , m_authGate(authGate)
     , m_cluster(cluster)

--- a/src/client-agent/https_client/src/reporterStream.hpp
+++ b/src/client-agent/https_client/src/reporterStream.hpp
@@ -37,8 +37,8 @@ class ReporterStream final
 {
     public:
         ReporterStream(const ModuleConfig& config, IHttpPerformer& performer, const ISigner& signer,
-                       IClock& clock, IRandom& random, AuthGate& authGate, ClusterIdentity& cluster,
-                       ICollectorSource& collectors);
+                       IClock& clock, IRandom& random, AuthGate& authGate, CompressionGate& compressionGate,
+                       ClusterIdentity& cluster, ICollectorSource& collectors);
 
         /// True when at least one reporter is enabled (the facade only starts
         /// the worker then).

--- a/src/client-agent/https_client/src/retrySender.cpp
+++ b/src/client-agent/https_client/src/retrySender.cpp
@@ -50,31 +50,43 @@ RetrySender::Result RetrySender::send(const HttpRequestSpec& spec, Waiter& waite
     {
         result = attemptOnce(base);
 
-        // One-shot 401 retry: a 401 can be a just-expired/edge timestamp as
-        // easily as a dead key. Resign with a fresh timestamp (attemptOnce
-        // re-signs) and try once more; only a second 401 escalates below.
-        if (result.outcome == OutcomeClass::AuthFail && !authRetried)
+        // Both one-shot retries below can fire in either order within the same
+        // outer attempt (a 415's uncompressed retry can itself land a 401, and
+        // vice versa), so loop until neither applies rather than checking each
+        // only once -- otherwise a 401 produced by the compression retry would
+        // skip its own auth grace-retry and escalate straight to reportAuthFailure().
+        for (;;)
         {
-            authRetried = true;
-            result = attemptOnce(base);
-        }
-
-        // One-shot compression retry: a 415 means the manager doesn't accept
-        // Content-Encoding: zstd. Report it to the shared gate first -- every
-        // RetrySender on this agent stops compressing from here on, for the
-        // rest of this run -- then retry; attemptOnce() re-checks the
-        // now-disabled gate itself, so this retry is naturally uncompressed
-        // with no separate "forced uncompressed" parameter needed.
-        if (result.outcome == OutcomeClass::CompressionRejected && !compressionRetried)
-        {
-            compressionRetried = true;
-
-            if (m_compressionGate != nullptr)
+            // One-shot 401 retry: a 401 can be a just-expired/edge timestamp as
+            // easily as a dead key. Resign with a fresh timestamp (attemptOnce
+            // re-signs) and try once more; only a second 401 escalates below.
+            if (result.outcome == OutcomeClass::AuthFail && !authRetried)
             {
-                m_compressionGate->reportRejected();
+                authRetried = true;
+                result = attemptOnce(base);
+                continue;
             }
 
-            result = attemptOnce(base);
+            // One-shot compression retry: a 415 means the manager doesn't accept
+            // Content-Encoding: zstd. Report it to the shared gate first -- every
+            // RetrySender on this agent stops compressing from here on, for the
+            // rest of this run -- then retry; attemptOnce() re-checks the
+            // now-disabled gate itself, so this retry is naturally uncompressed
+            // with no separate "forced uncompressed" parameter needed.
+            if (result.outcome == OutcomeClass::CompressionRejected && !compressionRetried)
+            {
+                compressionRetried = true;
+
+                if (m_compressionGate != nullptr)
+                {
+                    m_compressionGate->reportRejected();
+                }
+
+                result = attemptOnce(base);
+                continue;
+            }
+
+            break;
         }
 
         if (!isRetryable(result.outcome) || attempt == maxAttempts)

--- a/src/client-agent/https_client/src/retrySender.cpp
+++ b/src/client-agent/https_client/src/retrySender.cpp
@@ -18,9 +18,9 @@
 
 namespace
 {
-// Matches the level the manager's own test-only compressor
-// (zstdTestHelper.hpp's zstdCompress()) uses to build its zstd fixtures.
-constexpr int kCompressionLevel = 3;
+    // Matches the level the manager's own test-only compressor
+    // (zstdTestHelper.hpp's zstdCompress()) uses to build its zstd fixtures.
+    constexpr int kCompressionLevel = 3;
 } // namespace
 
 RetrySender::RetrySender(IHttpPerformer& performer, const ISigner& signer, IClock& clock,
@@ -125,6 +125,7 @@ RetrySender::Result RetrySender::attemptOnce(const HttpRequestSpec& base)
     // CMAC covers the wire bytes.
     std::vector<uint8_t> compressedBody;
     const bool gateAllowsCompression = m_compressionGate == nullptr || !m_compressionGate->disabled();
+
     if (m_compressionEnabled && gateAllowsCompression && attempt.bodyFilePath.empty() && attempt.bodyLength > 0)
     {
         compressedBody.resize(ZSTD_compressBound(attempt.bodyLength));
@@ -138,6 +139,7 @@ RetrySender::Result RetrySender::attemptOnce(const HttpRequestSpec& base)
             attempt.bodyLength = compressedBody.size();
             attempt.headers.push_back("Content-Encoding: zstd");
         }
+
         // else: fall through and send the original, uncompressed body -- a
         // one-shot ZSTD_compress() into a ZSTD_compressBound()-sized buffer
         // should never actually fail, but never lose the request over it.

--- a/src/client-agent/https_client/src/retrySender.cpp
+++ b/src/client-agent/https_client/src/retrySender.cpp
@@ -14,13 +14,17 @@
 #include <algorithm>
 #include <vector>
 
+#ifndef WIN32
 #include <zstd.h>
+#endif
 
 namespace
 {
+#ifndef WIN32
 // Matches the level the manager's own test-only compressor
 // (zstdTestHelper.hpp's zstdCompress()) uses to build its zstd fixtures.
 constexpr int kCompressionLevel = 3;
+#endif
 } // namespace
 
 RetrySender::RetrySender(IHttpPerformer& performer, const ISigner& signer, IClock& clock,
@@ -108,10 +112,16 @@ RetrySender::Result RetrySender::attemptOnce(const HttpRequestSpec& base)
 {
     HttpRequestSpec attempt = base; // Fresh copy: the auth pair differs per attempt.
 
+#ifndef WIN32
     // In-memory bodies only -- /stateful's file-backed path is untouched (its
     // spool file is read twice, independently, by signFile() and the
     // performer; compressing it needs a different design, out of scope here).
     // Compressed before signing so the CMAC covers the wire bytes.
+    // zstd isn't vendored for winagent yet (deliberately out of scope --
+    // see src/Makefile/src/external/CMakeLists.txt), so this whole block is
+    // compiled out there; m_compressionEnabled/m_compressionGate stay real
+    // members either way so the constructor and call sites don't need their
+    // own #ifdef.
     std::vector<uint8_t> compressedBody;
     const bool gateAllowsCompression = m_compressionGate == nullptr || !m_compressionGate->disabled();
     if (m_compressionEnabled && gateAllowsCompression && attempt.bodyFilePath.empty() && attempt.bodyLength > 0)
@@ -131,6 +141,7 @@ RetrySender::Result RetrySender::attemptOnce(const HttpRequestSpec& base)
         // one-shot ZSTD_compress() into a ZSTD_compressBound()-sized buffer
         // should never actually fail, but never lose the request over it.
     }
+#endif
 
     const auto timestamp = m_clock.wallSeconds();
     const auto headers =

--- a/src/client-agent/https_client/src/retrySender.cpp
+++ b/src/client-agent/https_client/src/retrySender.cpp
@@ -120,10 +120,9 @@ RetrySender::Result RetrySender::attemptOnce(const HttpRequestSpec& base)
 {
     HttpRequestSpec attempt = base; // Fresh copy: the auth pair differs per attempt.
 
-    // In-memory bodies only -- /stateful's file-backed path is untouched (its
-    // spool file is read twice, independently, by signFile() and the
-    // performer; compressing it needs a different design, out of scope here).
-    // Compressed before signing so the CMAC covers the wire bytes.
+    // In-memory bodies: compressed here, per attempt (cheap for the small
+    // buffers every other send path uses). Compressed before signing so the
+    // CMAC covers the wire bytes.
     std::vector<uint8_t> compressedBody;
     const bool gateAllowsCompression = m_compressionGate == nullptr || !m_compressionGate->disabled();
     if (m_compressionEnabled && gateAllowsCompression && attempt.bodyFilePath.empty() && attempt.bodyLength > 0)
@@ -142,6 +141,20 @@ RetrySender::Result RetrySender::attemptOnce(const HttpRequestSpec& base)
         // else: fall through and send the original, uncompressed body -- a
         // one-shot ZSTD_compress() into a ZSTD_compressBound()-sized buffer
         // should never actually fail, but never lose the request over it.
+    }
+    else if (m_compressionEnabled && gateAllowsCompression && !attempt.bodyFilePath.empty()
+             && !attempt.precompressedBodyFilePath.empty())
+    {
+        // File-backed bodies (/stateful): compressing a potentially multi-MB
+        // spool file per attempt would be wasteful under retries, so the
+        // caller (StatefulStream) compresses once, up front, and hands us the
+        // compressed sibling's path/size here. Swapped in fresh on every call,
+        // exactly like the in-memory branch above -- a 415 disables the gate,
+        // and the next attemptOnce() naturally falls through to this `else`
+        // and sends the original, uncompressed file with no header.
+        attempt.bodyFilePath = attempt.precompressedBodyFilePath;
+        attempt.bodyFileSize = attempt.precompressedBodyFileSize;
+        attempt.headers.push_back("Content-Encoding: zstd");
     }
 
     const auto timestamp = m_clock.wallSeconds();

--- a/src/client-agent/https_client/src/retrySender.cpp
+++ b/src/client-agent/https_client/src/retrySender.cpp
@@ -12,13 +12,24 @@
 #include "retrySender.hpp"
 
 #include <algorithm>
+#include <vector>
+
+#include <zstd.h>
+
+namespace
+{
+// Matches the level the manager's own test-only compressor
+// (zstdTestHelper.hpp's zstdCompress()) uses to build its zstd fixtures.
+constexpr int kCompressionLevel = 3;
+} // namespace
 
 RetrySender::RetrySender(IHttpPerformer& performer, const ISigner& signer, IClock& clock,
-                         Backoff& backoff, AuthGate* authGate)
+                         Backoff& backoff, bool compressionEnabled, AuthGate* authGate)
     : m_performer(performer)
     , m_signer(signer)
     , m_clock(clock)
     , m_backoff(backoff)
+    , m_compressionEnabled(compressionEnabled)
     , m_authGate(authGate)
 {
 }
@@ -75,6 +86,30 @@ RetrySender::Result RetrySender::send(const HttpRequestSpec& spec, Waiter& waite
 RetrySender::Result RetrySender::attemptOnce(const HttpRequestSpec& base)
 {
     HttpRequestSpec attempt = base; // Fresh copy: the auth pair differs per attempt.
+
+    // In-memory bodies only -- /stateful's file-backed path is untouched (its
+    // spool file is read twice, independently, by signFile() and the
+    // performer; compressing it needs a different design, out of scope here).
+    // Compressed before signing so the CMAC covers the wire bytes.
+    std::vector<uint8_t> compressedBody;
+    if (m_compressionEnabled && attempt.bodyFilePath.empty() && attempt.bodyLength > 0)
+    {
+        compressedBody.resize(ZSTD_compressBound(attempt.bodyLength));
+        const size_t written = ZSTD_compress(compressedBody.data(), compressedBody.size(), attempt.body,
+                                             attempt.bodyLength, kCompressionLevel);
+
+        if (!ZSTD_isError(written))
+        {
+            compressedBody.resize(written);
+            attempt.body = compressedBody.data();
+            attempt.bodyLength = compressedBody.size();
+            attempt.headers.push_back("Content-Encoding: zstd");
+        }
+        // else: fall through and send the original, uncompressed body -- a
+        // one-shot ZSTD_compress() into a ZSTD_compressBound()-sized buffer
+        // should never actually fail, but never lose the request over it.
+    }
+
     const auto timestamp = m_clock.wallSeconds();
     const auto headers =
         attempt.bodyFilePath.empty()

--- a/src/client-agent/https_client/src/retrySender.cpp
+++ b/src/client-agent/https_client/src/retrySender.cpp
@@ -24,12 +24,14 @@ constexpr int kCompressionLevel = 3;
 } // namespace
 
 RetrySender::RetrySender(IHttpPerformer& performer, const ISigner& signer, IClock& clock,
-                         Backoff& backoff, bool compressionEnabled, AuthGate* authGate)
+                         Backoff& backoff, bool compressionEnabled, CompressionGate* compressionGate,
+                         AuthGate* authGate)
     : m_performer(performer)
     , m_signer(signer)
     , m_clock(clock)
     , m_backoff(backoff)
     , m_compressionEnabled(compressionEnabled)
+    , m_compressionGate(compressionGate)
     , m_authGate(authGate)
 {
 }
@@ -42,6 +44,7 @@ RetrySender::Result RetrySender::send(const HttpRequestSpec& spec, Waiter& waite
 
     Result result;
     bool authRetried = false;
+    bool compressionRetried = false;
 
     for (uint32_t attempt = 1; attempt <= maxAttempts; attempt++)
     {
@@ -53,6 +56,24 @@ RetrySender::Result RetrySender::send(const HttpRequestSpec& spec, Waiter& waite
         if (result.outcome == OutcomeClass::AuthFail && !authRetried)
         {
             authRetried = true;
+            result = attemptOnce(base);
+        }
+
+        // One-shot compression retry: a 415 means the manager doesn't accept
+        // Content-Encoding: zstd. Report it to the shared gate first -- every
+        // RetrySender on this agent stops compressing from here on, for the
+        // rest of this run (#38308) -- then retry; attemptOnce() re-checks the
+        // now-disabled gate itself, so this retry is naturally uncompressed
+        // with no separate "forced uncompressed" parameter needed.
+        if (result.outcome == OutcomeClass::CompressionRejected && !compressionRetried)
+        {
+            compressionRetried = true;
+
+            if (m_compressionGate != nullptr)
+            {
+                m_compressionGate->reportRejected();
+            }
+
             result = attemptOnce(base);
         }
 
@@ -92,7 +113,8 @@ RetrySender::Result RetrySender::attemptOnce(const HttpRequestSpec& base)
     // performer; compressing it needs a different design, out of scope here).
     // Compressed before signing so the CMAC covers the wire bytes.
     std::vector<uint8_t> compressedBody;
-    if (m_compressionEnabled && attempt.bodyFilePath.empty() && attempt.bodyLength > 0)
+    const bool gateAllowsCompression = m_compressionGate == nullptr || !m_compressionGate->disabled();
+    if (m_compressionEnabled && gateAllowsCompression && attempt.bodyFilePath.empty() && attempt.bodyLength > 0)
     {
         compressedBody.resize(ZSTD_compressBound(attempt.bodyLength));
         const size_t written = ZSTD_compress(compressedBody.data(), compressedBody.size(), attempt.body,

--- a/src/client-agent/https_client/src/retrySender.cpp
+++ b/src/client-agent/https_client/src/retrySender.cpp
@@ -14,17 +14,13 @@
 #include <algorithm>
 #include <vector>
 
-#ifndef WIN32
 #include <zstd.h>
-#endif
 
 namespace
 {
-#ifndef WIN32
 // Matches the level the manager's own test-only compressor
 // (zstdTestHelper.hpp's zstdCompress()) uses to build its zstd fixtures.
 constexpr int kCompressionLevel = 3;
-#endif
 } // namespace
 
 RetrySender::RetrySender(IHttpPerformer& performer, const ISigner& signer, IClock& clock,
@@ -112,16 +108,10 @@ RetrySender::Result RetrySender::attemptOnce(const HttpRequestSpec& base)
 {
     HttpRequestSpec attempt = base; // Fresh copy: the auth pair differs per attempt.
 
-#ifndef WIN32
     // In-memory bodies only -- /stateful's file-backed path is untouched (its
     // spool file is read twice, independently, by signFile() and the
     // performer; compressing it needs a different design, out of scope here).
     // Compressed before signing so the CMAC covers the wire bytes.
-    // zstd isn't vendored for winagent yet (deliberately out of scope --
-    // see src/Makefile/src/external/CMakeLists.txt), so this whole block is
-    // compiled out there; m_compressionEnabled/m_compressionGate stay real
-    // members either way so the constructor and call sites don't need their
-    // own #ifdef.
     std::vector<uint8_t> compressedBody;
     const bool gateAllowsCompression = m_compressionGate == nullptr || !m_compressionGate->disabled();
     if (m_compressionEnabled && gateAllowsCompression && attempt.bodyFilePath.empty() && attempt.bodyLength > 0)
@@ -141,7 +131,6 @@ RetrySender::Result RetrySender::attemptOnce(const HttpRequestSpec& base)
         // one-shot ZSTD_compress() into a ZSTD_compressBound()-sized buffer
         // should never actually fail, but never lose the request over it.
     }
-#endif
 
     const auto timestamp = m_clock.wallSeconds();
     const auto headers =

--- a/src/client-agent/https_client/src/retrySender.cpp
+++ b/src/client-agent/https_client/src/retrySender.cpp
@@ -62,7 +62,7 @@ RetrySender::Result RetrySender::send(const HttpRequestSpec& spec, Waiter& waite
         // One-shot compression retry: a 415 means the manager doesn't accept
         // Content-Encoding: zstd. Report it to the shared gate first -- every
         // RetrySender on this agent stops compressing from here on, for the
-        // rest of this run (#38308) -- then retry; attemptOnce() re-checks the
+        // rest of this run -- then retry; attemptOnce() re-checks the
         // now-disabled gate itself, so this retry is naturally uncompressed
         // with no separate "forced uncompressed" parameter needed.
         if (result.outcome == OutcomeClass::CompressionRejected && !compressionRetried)

--- a/src/client-agent/https_client/src/retrySender.hpp
+++ b/src/client-agent/https_client/src/retrySender.hpp
@@ -40,10 +40,13 @@ class RetrySender final
             HttpResponse response;
         };
 
+        /// compressionEnabled: zstd-compress in-memory bodies (Content-Encoding:
+        /// zstd) before signing, so the CMAC covers the wire bytes (#38308).
+        /// File-backed bodies (/stateful) are untouched -- out of scope here.
         /// authGate (optional): a 401 from any send reports here, pausing all
         /// traffic and surfacing re-enrollment once (#37828).
         RetrySender(IHttpPerformer& performer, const ISigner& signer, IClock& clock, Backoff& backoff,
-                    AuthGate* authGate = nullptr);
+                    bool compressionEnabled, AuthGate* authGate = nullptr);
 
         /// spec.headers carry the non-auth headers; the auth pair is appended per
         /// attempt. AuthFail/Permanent/VersionRejected/Interrupted return
@@ -59,6 +62,7 @@ class RetrySender final
         const ISigner& m_signer;
         IClock& m_clock;
         Backoff& m_backoff;
+        bool m_compressionEnabled;
         AuthGate* m_authGate;
 };
 

--- a/src/client-agent/https_client/src/retrySender.hpp
+++ b/src/client-agent/https_client/src/retrySender.hpp
@@ -42,8 +42,10 @@ class RetrySender final
         };
 
         /// compressionEnabled: zstd-compress in-memory bodies (Content-Encoding:
-        /// zstd) before signing, so the CMAC covers the wire bytes.
-        /// File-backed bodies (/stateful) are untouched -- out of scope here.
+        /// zstd) before signing, so the CMAC covers the wire bytes. File-backed
+        /// bodies (/stateful) are compressed once by the caller, not here --
+        /// attemptOnce() swaps in HttpRequestSpec::precompressedBodyFilePath
+        /// when the caller set one and the gate currently allows compression.
         /// compressionGate (optional, shared across every RetrySender on this
         /// agent): a 415 reports here and disables compression for all six
         /// send paths for the rest of this run; send() retries once,

--- a/src/client-agent/https_client/src/retrySender.hpp
+++ b/src/client-agent/https_client/src/retrySender.hpp
@@ -42,7 +42,7 @@ class RetrySender final
         };
 
         /// compressionEnabled: zstd-compress in-memory bodies (Content-Encoding:
-        /// zstd) before signing, so the CMAC covers the wire bytes (#38308).
+        /// zstd) before signing, so the CMAC covers the wire bytes.
         /// File-backed bodies (/stateful) are untouched -- out of scope here.
         /// compressionGate (optional, shared across every RetrySender on this
         /// agent): a 415 reports here and disables compression for all six

--- a/src/client-agent/https_client/src/retrySender.hpp
+++ b/src/client-agent/https_client/src/retrySender.hpp
@@ -15,6 +15,7 @@
 #include "authGate.hpp"
 #include "backoff.hpp"
 #include "cmacSigner.hpp"
+#include "compressionGate.hpp"
 #include "iHttpPerformer.hpp"
 #include "outcomeClassifier.hpp"
 #include "stopToken.hpp"
@@ -43,10 +44,15 @@ class RetrySender final
         /// compressionEnabled: zstd-compress in-memory bodies (Content-Encoding:
         /// zstd) before signing, so the CMAC covers the wire bytes (#38308).
         /// File-backed bodies (/stateful) are untouched -- out of scope here.
+        /// compressionGate (optional, shared across every RetrySender on this
+        /// agent): a 415 reports here and disables compression for all six
+        /// send paths for the rest of this run; send() retries once,
+        /// uncompressed, on the same 415.
         /// authGate (optional): a 401 from any send reports here, pausing all
         /// traffic and surfacing re-enrollment once (#37828).
         RetrySender(IHttpPerformer& performer, const ISigner& signer, IClock& clock, Backoff& backoff,
-                    bool compressionEnabled, AuthGate* authGate = nullptr);
+                    bool compressionEnabled, CompressionGate* compressionGate = nullptr,
+                    AuthGate* authGate = nullptr);
 
         /// spec.headers carry the non-auth headers; the auth pair is appended per
         /// attempt. AuthFail/Permanent/VersionRejected/Interrupted return
@@ -63,6 +69,7 @@ class RetrySender final
         IClock& m_clock;
         Backoff& m_backoff;
         bool m_compressionEnabled;
+        CompressionGate* m_compressionGate;
         AuthGate* m_authGate;
 };
 

--- a/src/client-agent/https_client/src/spoolFile.cpp
+++ b/src/client-agent/https_client/src/spoolFile.cpp
@@ -11,21 +11,13 @@
 
 #include "spoolFile.hpp"
 
-#include <cerrno>
+#include "exclusiveTempFile.hpp"
+
 #include <cstdio>
-#include <random>
-#include <string>
-#include <thread>
 
 #ifdef WIN32
-#include <fcntl.h>
 #include <io.h>
-#include <process.h>
-#include <share.h>
-#include <sys/stat.h>
 #else
-#include <fcntl.h>
-#include <sys/stat.h>
 #include <unistd.h>
 #endif
 
@@ -50,53 +42,6 @@ namespace
         return "."; // LCOV_EXCL_LINE: at least one candidate is always set in practice.
     }
 
-    std::string threadIdHex()
-    {
-        const auto id = std::hash<std::thread::id> {}(std::this_thread::get_id());
-        char buffer[32];
-        std::snprintf(buffer, sizeof(buffer), "%zx", id);
-        return buffer;
-    }
-
-    std::string pidHex()
-    {
-#ifdef WIN32
-        const auto pid = static_cast<unsigned long>(_getpid());
-#else
-        const auto pid = static_cast<unsigned long>(::getpid());
-#endif
-        char buffer[24];
-        std::snprintf(buffer, sizeof(buffer), "%lx", pid);
-        return buffer;
-    }
-
-    std::string randomTokenHex()
-    {
-        // Thread-local RNG: spool() runs from several module threads at once; a
-        // shared generator would need locking. Seeded once per thread from the
-        // OS entropy source, so the next spool path is unpredictable.
-        static thread_local std::mt19937_64 engine {std::random_device {}()};
-        char buffer[24];
-        std::snprintf(buffer, sizeof(buffer), "%016llx",
-                      static_cast<unsigned long long>(engine()));
-        return buffer;
-    }
-
-    // Atomic, exclusive create (O_EXCL) with owner-only permissions. Returns a
-    // file descriptor, or -1 with errno set (EEXIST when the path already
-    // exists). Never follows an existing symlink -- the create simply fails.
-    int openExclusive(const std::string& path)
-    {
-#ifdef WIN32
-        int fd = -1;
-        _sopen_s(&fd, path.c_str(), _O_CREAT | _O_EXCL | _O_WRONLY | _O_BINARY, _SH_DENYRW,
-                 _S_IREAD | _S_IWRITE);
-        return fd;
-#else
-        return ::open(path.c_str(), O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC, S_IRUSR | S_IWUSR);
-#endif
-    }
-
     bool writeAll(int fd, const uint8_t* buffer, size_t length)
     {
         size_t written = 0;
@@ -118,15 +63,6 @@ namespace
         }
 
         return true;
-    }
-
-    void closeFd(int fd)
-    {
-#ifdef WIN32
-        _close(fd);
-#else
-        ::close(fd);
-#endif
     }
 } // namespace
 
@@ -173,39 +109,16 @@ TempSpoolFactory::TempSpoolFactory(std::string spoolDir)
 
 std::unique_ptr<SpoolFile> TempSpoolFactory::spool(const uint8_t* buffer, size_t length)
 {
-    // Create the file atomically and exclusively with owner-only permissions.
-    // A pre-existing path -- e.g. a symlink an attacker planted in a shared
-    // spool dir (/tmp) -- fails the create (EEXIST) instead of being followed
-    // and truncated, so it can neither hijack a victim file nor read back the
-    // session bytes. The retry loop handles the (essentially impossible)
-    // random-name collision; any other error means the dir is unusable.
-    constexpr int maxAttempts = 100;
     std::string path;
-    int fd = -1;
-
-    for (int attempt = 0; attempt < maxAttempts; attempt++)
-    {
-        path = uniquePath();
-        fd = openExclusive(path);
-
-        if (fd >= 0)
-        {
-            break;
-        }
-
-        if (errno != EEXIST)
-        {
-            return nullptr; // Unwritable/missing dir, etc.: not a collision.
-        }
-    }
+    const int fd = createExclusiveTempFile(m_spoolDir, "hc_sync_", path);
 
     if (fd < 0)
     {
-        return nullptr; // LCOV_EXCL_LINE: exhausting 100 random names is not reproducible.
+        return nullptr;
     }
 
     const bool ok = length == 0 || writeAll(fd, buffer, length);
-    closeFd(fd);
+    closeExclusiveTempFile(fd);
 
     if (!ok)
     {
@@ -214,14 +127,4 @@ std::unique_ptr<SpoolFile> TempSpoolFactory::spool(const uint8_t* buffer, size_t
     }
 
     return std::make_unique<SpoolFile>(path);
-}
-
-std::string TempSpoolFactory::uniquePath()
-{
-    // pid + thread id + per-factory counter order the name; a random token
-    // makes the next path unpredictable (so it cannot be pre-planted to force
-    // the exclusive create to fail). Including the pid keeps the name honestly
-    // unique across agent restarts, not merely within one process.
-    return m_spoolDir + "/hc_sync_" + pidHex() + "_" + threadIdHex() + "_"
-           + std::to_string(m_counter++) + "_" + randomTokenHex() + ".tmp";
 }

--- a/src/client-agent/https_client/src/spoolFile.hpp
+++ b/src/client-agent/https_client/src/spoolFile.hpp
@@ -12,7 +12,6 @@
 #ifndef _HC_SPOOL_FILE_HPP
 #define _HC_SPOOL_FILE_HPP
 
-#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -53,7 +52,9 @@ class ISpoolFileFactory
 /// Writes the buffer to a temp file under the configured spool directory,
 /// created atomically and exclusively (O_EXCL) with owner-only permissions so
 /// a shared dir (/tmp) cannot be used to hijack or read the spooled bytes.
-/// Portable across POSIX and Windows.
+/// Portable across POSIX and Windows. The exclusive-create itself lives in
+/// exclusiveTempFile.hpp, shared with ZstdFileCompressor's own temp output
+/// file so that security-relevant logic exists in exactly one place.
 class TempSpoolFactory final : public ISpoolFileFactory
 {
     public:
@@ -61,13 +62,7 @@ class TempSpoolFactory final : public ISpoolFileFactory
         std::unique_ptr<SpoolFile> spool(const uint8_t* buffer, size_t length) override;
 
     private:
-        std::string uniquePath();
-
         std::string m_spoolDir;
-
-        /// Atomic: spools happen from the stateful thread AND the control
-        /// thread (config downloads), concurrently.
-        std::atomic<uint64_t> m_counter {0};
 };
 
 #endif // _HC_SPOOL_FILE_HPP

--- a/src/client-agent/https_client/src/statefulStream.cpp
+++ b/src/client-agent/https_client/src/statefulStream.cpp
@@ -22,12 +22,15 @@ namespace
 StatefulStream::StatefulStream(const ModuleConfig& config, IHttpPerformer& performer,
                                const ISigner& signer, IClock& clock, IRandom& random,
                                ISpoolFileFactory& spoolFactory, ICallbackSink& sink,
-                               AuthGate& authGate, CompressionGate& compressionGate)
+                               AuthGate& authGate, CompressionGate& compressionGate,
+                               IFileCompressor& fileCompressor)
     : m_config(config)
     , m_authGate(authGate)
+    , m_compressionGate(compressionGate)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
     , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate)
     , m_spoolFactory(spoolFactory)
+    , m_fileCompressor(fileCompressor)
     , m_sink(sink)
     , m_maxQueue(STATEFUL_MAX_QUEUE)
 {
@@ -144,6 +147,31 @@ StatefulStream::SendResult StatefulStream::sendSession(const Session& session, W
     spec.bodyFileSize = session.size;
     spec.timeoutMs = m_config.statefulTimeoutMs;
     spec.headers.push_back("X-Session-Id: " + session.id); // Stable across retries (LRU dedup).
+
+    // Compress once, up front -- not per retry attempt like the in-memory send
+    // paths, since this body can be multi-MB and STATEFUL_MAX_ATTEMPTS allows
+    // up to 5 attempts per session. RetrySender::attemptOnce() swaps the
+    // precompressed sibling in per attempt (HttpRequestSpec::
+    // precompressedBodyFilePath) whenever the shared gate still allows it,
+    // falling back to spec.bodyFilePath (untouched here) on its own if a 415
+    // disables the gate mid-session. Kept alive until send() returns, below.
+    std::unique_ptr<SpoolFile> compressedSpool;
+
+    if (m_config.httpsCompressionEnabled && !m_compressionGate.disabled() && session.size > 0)
+    {
+        auto compressed = m_fileCompressor.compress(spec.bodyFilePath, spec.bodyFileSize,
+                                                     m_config.spoolDir, waiter.stopFlag());
+
+        if (compressed)
+        {
+            compressedSpool = std::move(compressed->first);
+            spec.precompressedBodyFilePath = compressedSpool->path();
+            spec.precompressedBodyFileSize = compressed->second;
+        }
+        // else: compression failed (disk full, aborted, etc.) -- fall through
+        // and send the original file uncompressed; never lose the session
+        // over a compression failure.
+    }
 
     // Operational visibility (send-time debug log, mirroring statelessStream.cpp's own
     // "Sending /stateless batch" one): logged before the request so the size is on record

--- a/src/client-agent/https_client/src/statefulStream.cpp
+++ b/src/client-agent/https_client/src/statefulStream.cpp
@@ -26,7 +26,7 @@ StatefulStream::StatefulStream(const ModuleConfig& config, IHttpPerformer& perfo
     : m_config(config)
     , m_authGate(authGate)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
-    , m_sender(performer, signer, clock, m_backoff, &authGate)
+    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &authGate)
     , m_spoolFactory(spoolFactory)
     , m_sink(sink)
     , m_maxQueue(STATEFUL_MAX_QUEUE)

--- a/src/client-agent/https_client/src/statefulStream.cpp
+++ b/src/client-agent/https_client/src/statefulStream.cpp
@@ -160,7 +160,7 @@ StatefulStream::SendResult StatefulStream::sendSession(const Session& session, W
     if (m_config.httpsCompressionEnabled && !m_compressionGate.disabled() && session.size > 0)
     {
         auto compressed = m_fileCompressor.compress(spec.bodyFilePath, spec.bodyFileSize,
-                                                     m_config.spoolDir, waiter.stopFlag());
+                                                    m_config.spoolDir, waiter.stopFlag());
 
         if (compressed)
         {
@@ -168,6 +168,7 @@ StatefulStream::SendResult StatefulStream::sendSession(const Session& session, W
             spec.precompressedBodyFilePath = compressedSpool->path();
             spec.precompressedBodyFileSize = compressed->second;
         }
+
         // else: compression failed (disk full, aborted, etc.) -- fall through
         // and send the original file uncompressed; never lose the session
         // over a compression failure.

--- a/src/client-agent/https_client/src/statefulStream.cpp
+++ b/src/client-agent/https_client/src/statefulStream.cpp
@@ -22,11 +22,11 @@ namespace
 StatefulStream::StatefulStream(const ModuleConfig& config, IHttpPerformer& performer,
                                const ISigner& signer, IClock& clock, IRandom& random,
                                ISpoolFileFactory& spoolFactory, ICallbackSink& sink,
-                               AuthGate& authGate)
+                               AuthGate& authGate, CompressionGate& compressionGate)
     : m_config(config)
     , m_authGate(authGate)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
-    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &authGate)
+    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate)
     , m_spoolFactory(spoolFactory)
     , m_sink(sink)
     , m_maxQueue(STATEFUL_MAX_QUEUE)

--- a/src/client-agent/https_client/src/statefulStream.hpp
+++ b/src/client-agent/https_client/src/statefulStream.hpp
@@ -13,6 +13,7 @@
 #define _HC_STATEFUL_STREAM_HPP
 
 #include "callbackSink.hpp"
+#include "fileCompressor.hpp"
 #include "moduleConfig.hpp"
 #include "moduleLog.hpp"
 #include "retrySender.hpp"
@@ -34,14 +35,19 @@
  *        file (adopted from the intake, which streamed it off the local
  *        socket) — the latter keeps the whole path off-heap. Retries reuse the
  *        same X-Session-Id so the manager LRU dedups; the outcome is delivered
- *        through the sink.
+ *        through the sink. When compression is enabled and not yet rejected,
+ *        sendSession() compresses the spooled file once, up front (not per
+ *        retry attempt -- unlike the in-memory send paths, this body can be
+ *        multi-MB), handing RetrySender a precompressed sibling file it swaps
+ *        in per attempt; a 415 falls back to the original file automatically.
  */
 class StatefulStream final
 {
     public:
         StatefulStream(const ModuleConfig& config, IHttpPerformer& performer, const ISigner& signer,
                        IClock& clock, IRandom& random, ISpoolFileFactory& spoolFactory,
-                       ICallbackSink& sink, AuthGate& authGate, CompressionGate& compressionGate);
+                       ICallbackSink& sink, AuthGate& authGate, CompressionGate& compressionGate,
+                       IFileCompressor& fileCompressor);
 
         /// Intake: spool the buffer to a temp file and enqueue it. Returns false
         /// when the queue is full or the spool fails.
@@ -84,9 +90,11 @@ class StatefulStream final
 
         const ModuleConfig& m_config;
         AuthGate& m_authGate;
+        CompressionGate& m_compressionGate;
         Backoff m_backoff;
         RetrySender m_sender;
         ISpoolFileFactory& m_spoolFactory;
+        IFileCompressor& m_fileCompressor;
         ICallbackSink& m_sink;
 
         mutable std::mutex m_mutex;

--- a/src/client-agent/https_client/src/statefulStream.hpp
+++ b/src/client-agent/https_client/src/statefulStream.hpp
@@ -41,7 +41,7 @@ class StatefulStream final
     public:
         StatefulStream(const ModuleConfig& config, IHttpPerformer& performer, const ISigner& signer,
                        IClock& clock, IRandom& random, ISpoolFileFactory& spoolFactory,
-                       ICallbackSink& sink, AuthGate& authGate);
+                       ICallbackSink& sink, AuthGate& authGate, CompressionGate& compressionGate);
 
         /// Intake: spool the buffer to a temp file and enqueue it. Returns false
         /// when the queue is full or the spool fails.

--- a/src/client-agent/https_client/src/statelessStream.cpp
+++ b/src/client-agent/https_client/src/statelessStream.cpp
@@ -84,6 +84,7 @@ namespace
 StatelessStream::StatelessStream(const ModuleConfig& config, IHttpPerformer& performer,
                                  const ISigner& signer, IClock& clock, IRandom& random,
                                  ICallbackSink& sink, AuthGate& authGate,
+                                 CompressionGate& compressionGate,
                                  std::function<std::string()> collectHost)
     : m_config(config)
     , m_clock(clock)
@@ -91,7 +92,7 @@ StatelessStream::StatelessStream(const ModuleConfig& config, IHttpPerformer& per
     , m_accumulator(config.batchSizeBytes, config.bufferCapMultiplier, config.batchIntervalMs)
     , m_payload(config.batchSizeBytes)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
-    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &authGate)
+    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate)
     , m_sink(sink)
     , m_collectHost(std::move(collectHost))
     , m_headerLine(buildHeaderLine(config.agentId, m_collectHost))

--- a/src/client-agent/https_client/src/statelessStream.cpp
+++ b/src/client-agent/https_client/src/statelessStream.cpp
@@ -91,7 +91,7 @@ StatelessStream::StatelessStream(const ModuleConfig& config, IHttpPerformer& per
     , m_accumulator(config.batchSizeBytes, config.bufferCapMultiplier, config.batchIntervalMs)
     , m_payload(config.batchSizeBytes)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
-    , m_sender(performer, signer, clock, m_backoff, &authGate)
+    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &authGate)
     , m_sink(sink)
     , m_collectHost(std::move(collectHost))
     , m_headerLine(buildHeaderLine(config.agentId, m_collectHost))

--- a/src/client-agent/https_client/src/statelessStream.hpp
+++ b/src/client-agent/https_client/src/statelessStream.hpp
@@ -51,7 +51,7 @@ class StatelessStream final
         ///        line carries only wazuh.agent.id, as before this field existed.
         StatelessStream(const ModuleConfig& config, IHttpPerformer& performer, const ISigner& signer,
                         IClock& clock, IRandom& random, ICallbackSink& sink, AuthGate& authGate,
-                        std::function<std::string()> collectHost = {});
+                        CompressionGate& compressionGate, std::function<std::string()> collectHost = {});
 
         /// Intake entry point (from agentd's EventForward seam). Emits a buffer
         /// level change if the append crosses a ladder threshold and tells the

--- a/src/client-agent/https_client/src/wpkFetcher.cpp
+++ b/src/client-agent/https_client/src/wpkFetcher.cpp
@@ -37,10 +37,11 @@ namespace
 
 WpkFetcher::WpkFetcher(const ModuleConfig& config, IHttpPerformer& performer,
                        const ISigner& signer, IClock& clock, IRandom& random,
-                       ISpoolFileFactory& spoolFactory, AuthGate& authGate)
+                       ISpoolFileFactory& spoolFactory, AuthGate& authGate,
+                       CompressionGate& compressionGate)
     : m_config(config)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
-    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &authGate)
+    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate)
     , m_spoolFactory(spoolFactory)
 {
 }

--- a/src/client-agent/https_client/src/wpkFetcher.cpp
+++ b/src/client-agent/https_client/src/wpkFetcher.cpp
@@ -40,7 +40,7 @@ WpkFetcher::WpkFetcher(const ModuleConfig& config, IHttpPerformer& performer,
                        ISpoolFileFactory& spoolFactory, AuthGate& authGate)
     : m_config(config)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
-    , m_sender(performer, signer, clock, m_backoff, &authGate)
+    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &authGate)
     , m_spoolFactory(spoolFactory)
 {
 }

--- a/src/client-agent/https_client/src/wpkFetcher.hpp
+++ b/src/client-agent/https_client/src/wpkFetcher.hpp
@@ -45,7 +45,8 @@ class WpkFetcher final
     public:
         WpkFetcher(const ModuleConfig& config, IHttpPerformer& performer,
                    const ISigner& signer, IClock& clock, IRandom& random,
-                   ISpoolFileFactory& spoolFactory, AuthGate& authGate);
+                   ISpoolFileFactory& spoolFactory, AuthGate& authGate,
+                   CompressionGate& compressionGate);
 
         /// Downloads the WPK named `wpkFile`, expecting the given SHA-1.
         /// Returns the verified spool file (deleted on drop) or nullptr on

--- a/src/client-agent/https_client/tests/CMakeLists.txt
+++ b/src/client-agent/https_client/tests/CMakeLists.txt
@@ -70,6 +70,7 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
     optimized gtest
     optimized gmock
     https_client
+    ext_zstd
     ${SRC_FOLDER}/external/openssl/libssl.a
     ${SRC_FOLDER}/external/openssl/libcrypto.a
     pthread)

--- a/src/client-agent/https_client/tests/CMakeLists.txt
+++ b/src/client-agent/https_client/tests/CMakeLists.txt
@@ -24,14 +24,8 @@ target_link_libraries(
   optimized gtest
   optimized gmock
   https_client
+  ext_zstd
   pthread)
-
-# Not built for winagent -- see https_client/CMakeLists.txt's matching guard.
-# Plain (non-keyword) signature, matching the target_link_libraries() call
-# above -- CMake forbids mixing plain and keyword signatures on one target.
-if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
-  target_link_libraries(https_client_unit_test ext_zstd)
-endif()
 
 target_include_directories(
   https_client_unit_test

--- a/src/client-agent/https_client/tests/CMakeLists.txt
+++ b/src/client-agent/https_client/tests/CMakeLists.txt
@@ -24,8 +24,14 @@ target_link_libraries(
   optimized gtest
   optimized gmock
   https_client
-  ext_zstd
   pthread)
+
+# Not built for winagent -- see https_client/CMakeLists.txt's matching guard.
+# Plain (non-keyword) signature, matching the target_link_libraries() call
+# above -- CMake forbids mixing plain and keyword signatures on one target.
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  target_link_libraries(https_client_unit_test ext_zstd)
+endif()
 
 target_include_directories(
   https_client_unit_test

--- a/src/client-agent/https_client/tests/CMakeLists.txt
+++ b/src/client-agent/https_client/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(
   optimized gtest
   optimized gmock
   https_client
+  ext_zstd
   pthread)
 
 target_include_directories(

--- a/src/client-agent/https_client/tests/component/httpsClient_component_test.cpp
+++ b/src/client-agent/https_client/tests/component/httpsClient_component_test.cpp
@@ -313,7 +313,8 @@ TEST_F(ComponentTest, StatefulSessionCompressesToASmallerWireSizeAndDecompresses
     spec.bodyFilePath = compressedSpool->path();
     spec.bodyFileSize = compressedSize;
     spec.timeoutMs = 3000;
-    spec.headers = {
+    spec.headers =
+    {
         "X-Session-Id: sess-cmp-zstd", "Content-Encoding: zstd", headers->protocolVersion,
         headers->authorization
     };
@@ -333,7 +334,7 @@ TEST_F(ComponentTest, StatefulSessionCompressesToASmallerWireSizeAndDecompresses
                                        std::istreambuf_iterator<char> {}};
     std::vector<char> decompressed(payload.size());
     const size_t decompressedSize = ZSTD_decompress(decompressed.data(), decompressed.size(),
-                                                     compressedBytes.data(), compressedBytes.size());
+                                                    compressedBytes.data(), compressedBytes.size());
     ASSERT_FALSE(ZSTD_isError(decompressedSize));
     ASSERT_EQ(payload.size(), decompressedSize);
     EXPECT_EQ(payload, std::string(decompressed.begin(), decompressed.end()));

--- a/src/client-agent/https_client/tests/component/httpsClient_component_test.cpp
+++ b/src/client-agent/https_client/tests/component/httpsClient_component_test.cpp
@@ -234,7 +234,7 @@ TEST_F(ComponentTest, BackPressureIsHonoredAndEachRetryReSigns)
     SystemClock clock;
     Mt19937Random random;
     Backoff backoff {10, 50, random};
-    RetrySender sender {m_performer, m_signer, clock, backoff};
+    RetrySender sender {m_performer, m_signer, clock, backoff, false};
     Waiter waiter;
 
     const std::string body = "H {}\nE 1:l:bp\n";

--- a/src/client-agent/https_client/tests/component/httpsClient_component_test.cpp
+++ b/src/client-agent/https_client/tests/component/httpsClient_component_test.cpp
@@ -21,6 +21,7 @@
 #include "curlHandle.hpp"
 #include "curlPerformer.hpp"
 #include "fakeManager.hpp"
+#include "fileCompressor.hpp"
 #include "keyProvider.hpp"
 #include "moduleConfig.hpp"
 #include "retrySender.hpp"
@@ -29,10 +30,13 @@
 
 #include <gtest/gtest.h>
 
+#include <zstd.h>
+
 #include <cstring>
 #include <fstream>
 #include <regex>
 #include <string>
+#include <vector>
 
 #include <unistd.h>
 
@@ -283,6 +287,56 @@ TEST_F(ComponentTest, StatefulSessionStreamsFromSpoolAndDedupsOnReplay)
     const auto replay = sendSession("sess-cmp-1");
     EXPECT_EQ(200, replay.httpCode);
     EXPECT_NE(std::string::npos, replay.body.find("\"cached\":true"));
+}
+
+TEST_F(ComponentTest, StatefulSessionCompressesToASmallerWireSizeAndDecompressesToTheOriginal)
+{
+    // Same shape as the uncompressed test above, but the session is
+    // compressed first (as StatefulStream::sendSession() now does) and the
+    // compressed sibling is what actually crosses the real curl path.
+    TempSpoolFactory factory {::testing::TempDir()};
+    std::string payload(64 * 1024, 'D'); // Larger than one read chunk.
+    std::memcpy(&payload[0], "FULLSESSION:syscollector:", 25);
+    const auto spool = factory.spool(reinterpret_cast<const uint8_t*>(payload.data()), payload.size());
+    ASSERT_NE(nullptr, spool);
+
+    ZstdFileCompressor compressor;
+    const auto compressed = compressor.compress(spool->path(), payload.size(), ::testing::TempDir(), nullptr);
+    ASSERT_TRUE(compressed.has_value());
+    const auto& [compressedSpool, compressedSize] = *compressed;
+    ASSERT_LT(compressedSize, payload.size()); // Actually shrank.
+
+    const auto headers = m_signer.signFile("POST", "/stateful", compressedSpool->path(),
+                                           SystemClock {}.wallSeconds());
+    HttpRequestSpec spec;
+    spec.target = "/stateful";
+    spec.bodyFilePath = compressedSpool->path();
+    spec.bodyFileSize = compressedSize;
+    spec.timeoutMs = 3000;
+    spec.headers = {
+        "X-Session-Id: sess-cmp-zstd", "Content-Encoding: zstd", headers->protocolVersion,
+        headers->authorization
+    };
+
+    const auto response = m_performer.perform(spec);
+
+    EXPECT_EQ(200, response.httpCode);
+    // This fake manager doesn't decode the body (see fakeManager.hpp) -- it
+    // just reports how many bytes it received, so this proves the *wire*
+    // request really did carry the smaller, compressed byte count.
+    EXPECT_NE(std::string::npos, response.body.find("\"bytes\":" + std::to_string(compressedSize)));
+
+    // Prove those wire bytes are what a real IBodyDecoder would accept: read
+    // them back independently and decompress with zstd.
+    std::ifstream compressedFile {compressedSpool->path(), std::ios::binary};
+    const std::string compressedBytes {std::istreambuf_iterator<char> {compressedFile},
+                                       std::istreambuf_iterator<char> {}};
+    std::vector<char> decompressed(payload.size());
+    const size_t decompressedSize = ZSTD_decompress(decompressed.data(), decompressed.size(),
+                                                     compressedBytes.data(), compressedBytes.size());
+    ASSERT_FALSE(ZSTD_isError(decompressedSize));
+    ASSERT_EQ(payload.size(), decompressedSize);
+    EXPECT_EQ(payload, std::string(decompressed.begin(), decompressed.end()));
 }
 
 TEST_F(ComponentTest, ControlStartupReturnsHandshakeJson)

--- a/src/client-agent/https_client/tests/unit/controlStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/controlStream_test.cpp
@@ -82,8 +82,8 @@ namespace
                 , m_configHash("abc")
                 , m_authGate(m_sink, [] {})
             , m_stream(m_config, m_performer, m_signer, m_clock, m_random, m_sink,
-                       m_spoolFactory, m_configHash, m_cluster, m_authGate, m_taskStore,
-                       m_vdOffsetStore, [this] { return m_hostJson; })
+                       m_spoolFactory, m_configHash, m_cluster, m_authGate, m_compressionGate,
+                       m_taskStore, m_vdOffsetStore, [this] { return m_hostJson; })
             {
             }
 
@@ -109,6 +109,7 @@ namespace
             ConfigHashState m_configHash;
             ClusterIdentity m_cluster;
             AuthGate m_authGate;
+            CompressionGate m_compressionGate;
             FakeWaiter m_waiter;
             FakeTaskIdStore m_taskStore;
             FakeVdOffsetStore m_vdOffsetStore;

--- a/src/client-agent/https_client/tests/unit/fileCompressor_test.cpp
+++ b/src/client-agent/https_client/tests/unit/fileCompressor_test.cpp
@@ -71,7 +71,7 @@ TEST_F(FileCompressorTest, RoundTripCompressesAndDecompressesBackToTheSource)
 
     std::vector<char> decompressed(plain.size());
     const size_t decompressedSize = ZSTD_decompress(decompressed.data(), decompressed.size(),
-                                                     compressedBytes.data(), compressedBytes.size());
+                                                    compressedBytes.data(), compressedBytes.size());
     ASSERT_FALSE(ZSTD_isError(decompressedSize));
     ASSERT_EQ(plain.size(), decompressedSize);
     EXPECT_EQ(plain, std::string(decompressed.begin(), decompressed.end()));
@@ -139,7 +139,7 @@ TEST_F(FileCompressorTest, EmptySourceProducesAValidMinimalFrame)
     const std::string compressedBytes = readWholeFile(result->first->path());
     std::vector<char> decompressed(1);
     const size_t decompressedSize = ZSTD_decompress(decompressed.data(), decompressed.size(),
-                                                     compressedBytes.data(), compressedBytes.size());
+                                                    compressedBytes.data(), compressedBytes.size());
     ASSERT_FALSE(ZSTD_isError(decompressedSize));
     EXPECT_EQ(0u, decompressedSize);
 }

--- a/src/client-agent/https_client/tests/unit/fileCompressor_test.cpp
+++ b/src/client-agent/https_client/tests/unit/fileCompressor_test.cpp
@@ -1,0 +1,145 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 17, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "fileCompressor.hpp"
+
+#include <gtest/gtest.h>
+
+// ZSTD_getFrameHeader()/ZSTD_FrameHeader live behind this opt-in (same as the
+// manager's zstdDecoder.cpp) -- used here only to assert the pledged content
+// size made it into the frame, not in the production code under test.
+#define ZSTD_STATIC_LINKING_ONLY
+#include <zstd.h>
+
+#include <fstream>
+#include <vector>
+
+namespace
+{
+    std::string writeTempFile(const std::string& name, const std::string& contents)
+    {
+        const std::string path = ::testing::TempDir() + name;
+        std::ofstream file {path, std::ios::binary};
+        file << contents;
+        file.close();
+        return path;
+    }
+
+    std::string readWholeFile(const std::string& path)
+    {
+        std::ifstream file {path, std::ios::binary};
+        return std::string {std::istreambuf_iterator<char> {file}, std::istreambuf_iterator<char> {}};
+    }
+
+    bool fileExists(const std::string& path)
+    {
+        return std::ifstream {path}.good();
+    }
+
+    class FileCompressorTest : public ::testing::Test
+    {
+        protected:
+            ZstdFileCompressor m_compressor;
+            std::string m_spoolDir = ::testing::TempDir();
+    };
+} // namespace
+
+TEST_F(FileCompressorTest, RoundTripCompressesAndDecompressesBackToTheSource)
+{
+    // Long and repetitive so it actually shrinks under zstd's frame overhead.
+    const std::string plain(2000, 'a');
+    const std::string sourcePath = writeTempFile("hc_fc_roundtrip_src.bin", plain);
+
+    const auto result = m_compressor.compress(sourcePath, plain.size(), m_spoolDir, nullptr);
+
+    ASSERT_TRUE(result.has_value());
+    const auto& [spoolFile, compressedSize] = *result;
+    ASSERT_NE(nullptr, spoolFile);
+    EXPECT_TRUE(fileExists(spoolFile->path()));
+    EXPECT_LT(compressedSize, plain.size());
+
+    const std::string compressedBytes = readWholeFile(spoolFile->path());
+    ASSERT_EQ(compressedSize, compressedBytes.size());
+
+    std::vector<char> decompressed(plain.size());
+    const size_t decompressedSize = ZSTD_decompress(decompressed.data(), decompressed.size(),
+                                                     compressedBytes.data(), compressedBytes.size());
+    ASSERT_FALSE(ZSTD_isError(decompressedSize));
+    ASSERT_EQ(plain.size(), decompressedSize);
+    EXPECT_EQ(plain, std::string(decompressed.begin(), decompressed.end()));
+}
+
+TEST_F(FileCompressorTest, CompressedFrameDeclaresThePledgedContentSize)
+{
+    const std::string plain(500, 'b');
+    const std::string sourcePath = writeTempFile("hc_fc_pledged_src.bin", plain);
+
+    const auto result = m_compressor.compress(sourcePath, plain.size(), m_spoolDir, nullptr);
+
+    ASSERT_TRUE(result.has_value());
+    const std::string compressedBytes = readWholeFile(result->first->path());
+
+    ZSTD_FrameHeader header {};
+    const size_t headerResult = ZSTD_getFrameHeader(&header, compressedBytes.data(), compressedBytes.size());
+    ASSERT_EQ(0u, headerResult); // 0 == header fully parsed.
+    EXPECT_EQ(plain.size(), header.frameContentSize);
+}
+
+TEST_F(FileCompressorTest, UnreadableSourceReturnsNullopt)
+{
+    const auto result =
+        m_compressor.compress("/nonexistent/hc-spool/session.bin", 4, m_spoolDir, nullptr);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(FileCompressorTest, UnwritableSpoolDirReturnsNullopt)
+{
+    const std::string sourcePath = writeTempFile("hc_fc_unwritable_src.bin", "body");
+    const auto result = m_compressor.compress(sourcePath, 4, "/nonexistent/hc-spool-dir", nullptr);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(FileCompressorTest, EmptySpoolDirFallsBackToADefaultTempDirectory)
+{
+    // ModuleConfig::spoolDir is never actually populated by the C bridge
+    // today -- callers (StatefulStream) pass it straight through, so an empty
+    // string here must still succeed rather than trying to write to "/".
+    const std::string sourcePath = writeTempFile("hc_fc_empty_dir_src.bin", "body");
+    const auto result = m_compressor.compress(sourcePath, 4, "", nullptr);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(fileExists(result->first->path()));
+}
+
+TEST_F(FileCompressorTest, AbortFlagStopsCompressionAndReturnsNullopt)
+{
+    const std::string plain(2000, 'c');
+    const std::string sourcePath = writeTempFile("hc_fc_abort_src.bin", plain);
+
+    const std::atomic<bool> abortFlag {true}; // Already set before the first chunk is read.
+    const auto result = m_compressor.compress(sourcePath, plain.size(), m_spoolDir, &abortFlag);
+
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(FileCompressorTest, EmptySourceProducesAValidMinimalFrame)
+{
+    const std::string sourcePath = writeTempFile("hc_fc_empty_src.bin", "");
+
+    const auto result = m_compressor.compress(sourcePath, 0, m_spoolDir, nullptr);
+
+    ASSERT_TRUE(result.has_value());
+    const std::string compressedBytes = readWholeFile(result->first->path());
+    std::vector<char> decompressed(1);
+    const size_t decompressedSize = ZSTD_decompress(decompressed.data(), decompressed.size(),
+                                                     compressedBytes.data(), compressedBytes.size());
+    ASSERT_FALSE(ZSTD_isError(decompressedSize));
+    EXPECT_EQ(0u, decompressedSize);
+}

--- a/src/client-agent/https_client/tests/unit/mocks/mockFileCompressor.hpp
+++ b/src/client-agent/https_client/tests/unit/mocks/mockFileCompressor.hpp
@@ -1,0 +1,28 @@
+/*
+ * Wazuh agent HTTPS client (C++ transport module)
+ * Copyright (C) 2015, Wazuh Inc.
+ * July 17, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _HC_MOCK_FILE_COMPRESSOR_HPP
+#define _HC_MOCK_FILE_COMPRESSOR_HPP
+
+#include "fileCompressor.hpp"
+
+#include <gmock/gmock.h>
+
+class MockFileCompressor : public IFileCompressor
+{
+    public:
+        MOCK_METHOD((std::optional<std::pair<std::unique_ptr<SpoolFile>, uint64_t>>), compress,
+                    (const std::string& sourcePath, uint64_t sourceSize, const std::string& spoolDir,
+                     const std::atomic<bool>* abortFlag),
+                    (override));
+};
+
+#endif // _HC_MOCK_FILE_COMPRESSOR_HPP

--- a/src/client-agent/https_client/tests/unit/moduleConfig_test.cpp
+++ b/src/client-agent/https_client/tests/unit/moduleConfig_test.cpp
@@ -53,6 +53,7 @@ TEST(ModuleConfigTest, DefaultsAppliedOnZeroFields)
     EXPECT_EQ(60u, typed.statsIntervalS);
     EXPECT_FALSE(typed.configReportEnabled);
     EXPECT_EQ(3600u, typed.configReportIntervalS);
+    EXPECT_FALSE(typed.httpsCompressionEnabled);
 }
 
 TEST(ModuleConfigTest, ZeroedVerifyModeIsFullFailClosed)

--- a/src/client-agent/https_client/tests/unit/outcomeClassifier_test.cpp
+++ b/src/client-agent/https_client/tests/unit/outcomeClassifier_test.cpp
@@ -89,6 +89,9 @@ INSTANTIATE_TEST_SUITE_P(
         // 413: the /stateless split-and-resend class (#37835), distinct from
         // the generic permanent drop.
         ClassifierCase {TransportStatus::Ok, 413, OutcomeClass::PayloadTooLarge},
+        // 415: the manager rejects Content-Encoding: zstd (#38308) --
+        // RetrySender retries once, uncompressed.
+        ClassifierCase {TransportStatus::Ok, 415, OutcomeClass::CompressionRejected},
         // Permanent for this payload.
         ClassifierCase {TransportStatus::Ok, 400, OutcomeClass::Permanent},
         ClassifierCase {TransportStatus::Ok, 404, OutcomeClass::Permanent}));
@@ -112,5 +115,6 @@ TEST(OutcomeClassifierTest, HcResultMapping)
     EXPECT_EQ(HC_RESULT_AUTH_FAIL, toHcResult(OutcomeClass::AuthFail));
     EXPECT_EQ(HC_RESULT_PERMANENT, toHcResult(OutcomeClass::Permanent));
     EXPECT_EQ(HC_RESULT_PERMANENT, toHcResult(OutcomeClass::VersionRejected));
+    EXPECT_EQ(HC_RESULT_PERMANENT, toHcResult(OutcomeClass::CompressionRejected));
     EXPECT_EQ(HC_RESULT_ERROR, toHcResult(OutcomeClass::Interrupted));
 }

--- a/src/client-agent/https_client/tests/unit/outcomeClassifier_test.cpp
+++ b/src/client-agent/https_client/tests/unit/outcomeClassifier_test.cpp
@@ -89,7 +89,7 @@ INSTANTIATE_TEST_SUITE_P(
         // 413: the /stateless split-and-resend class (#37835), distinct from
         // the generic permanent drop.
         ClassifierCase {TransportStatus::Ok, 413, OutcomeClass::PayloadTooLarge},
-        // 415: the manager rejects Content-Encoding: zstd (#38308) --
+        // 415: the manager rejects Content-Encoding: zstd --
         // RetrySender retries once, uncompressed.
         ClassifierCase {TransportStatus::Ok, 415, OutcomeClass::CompressionRejected},
         // Permanent for this payload.

--- a/src/client-agent/https_client/tests/unit/reporterStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/reporterStream_test.cpp
@@ -87,6 +87,7 @@ namespace
             ScriptedRandom m_random {{0.0}};
             NiceMock<MockCallbackSink> m_sink;
             AuthGate m_authGate;
+            CompressionGate m_compressionGate;
             ClusterIdentity m_cluster;
             FakeCollectorSource m_collectors;
             MockHttpPerformer m_performer;
@@ -97,7 +98,7 @@ namespace
 TEST_F(ReporterStreamTest, DisabledReportersNeverCollectOrSend)
 {
     const auto config = makeConfig(false, false);
-    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate,
+    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate, m_compressionGate,
                              m_cluster, m_collectors};
     EXPECT_FALSE(reporter.anyEnabled());
     EXPECT_CALL(m_performer, perform(_)).Times(0);
@@ -110,7 +111,7 @@ TEST_F(ReporterStreamTest, StampsAgentIdAndClusterAndPostsToStats)
 {
     m_cluster.set("prod", "node01");
     const auto config = makeConfig(true, false);
-    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate,
+    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate, m_compressionGate,
                              m_cluster, m_collectors};
 
     std::string body;
@@ -134,7 +135,7 @@ TEST_F(ReporterStreamTest, StampOverwritesCollectorSuppliedIdentityFields)
     m_cluster.set("authoritative", "n1");
     m_collectors.m_stats = R"({"agent_id":"WRONG","cluster":"WRONG","x":1})";
     const auto config = makeConfig(true, false);
-    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate,
+    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate, m_compressionGate,
                              m_cluster, m_collectors};
 
     std::string body;
@@ -155,7 +156,7 @@ TEST_F(ReporterStreamTest, NullCollectorReturnSkipsWithoutSending)
 {
     m_collectors.m_stats = std::nullopt;
     const auto config = makeConfig(true, false);
-    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate,
+    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate, m_compressionGate,
                              m_cluster, m_collectors};
     EXPECT_CALL(m_performer, perform(_)).Times(0);
     reporter.tick(m_waiter, true);
@@ -166,7 +167,7 @@ TEST_F(ReporterStreamTest, NonObjectCollectorReturnIsSkipped)
 {
     m_collectors.m_stats = R"(["not","an","object"])";
     const auto config = makeConfig(true, false);
-    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate,
+    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate, m_compressionGate,
                              m_cluster, m_collectors};
     EXPECT_CALL(m_performer, perform(_)).Times(0);
     reporter.tick(m_waiter, true);
@@ -175,7 +176,7 @@ TEST_F(ReporterStreamTest, NonObjectCollectorReturnIsSkipped)
 TEST_F(ReporterStreamTest, UnregisteredOrPausedSkipsAndKeepsDueness)
 {
     const auto config = makeConfig(true, false);
-    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate,
+    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate, m_compressionGate,
                              m_cluster, m_collectors};
     EXPECT_CALL(m_performer, perform(_)).Times(0);
     reporter.tick(m_waiter, false); // Not registered.
@@ -187,7 +188,7 @@ TEST_F(ReporterStreamTest, UnregisteredOrPausedSkipsAndKeepsDueness)
 TEST_F(ReporterStreamTest, IntervalGovernsTheNextSend)
 {
     const auto config = makeConfig(true, false);
-    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate,
+    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate, m_compressionGate,
                              m_cluster, m_collectors};
     EXPECT_CALL(m_performer, perform(_)).WillRepeatedly(Return(response(TransportStatus::Ok, 200)));
 
@@ -203,7 +204,7 @@ TEST_F(ReporterStreamTest, IntervalGovernsTheNextSend)
 TEST_F(ReporterStreamTest, BackPressureDefersOnlyThatPath)
 {
     const auto config = makeConfig(true, true);
-    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate,
+    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate, m_compressionGate,
                              m_cluster, m_collectors};
     // Both due at epoch: stats 503 (Retry-After 5), config 200.
     EXPECT_CALL(m_performer, perform(_))

--- a/src/client-agent/https_client/tests/unit/retrySender_test.cpp
+++ b/src/client-agent/https_client/tests/unit/retrySender_test.cpp
@@ -25,6 +25,8 @@
 
 #include <zstd.h>
 
+#include <fstream>
+
 using ::testing::_;
 using ::testing::Contains;
 using ::testing::Invoke;
@@ -40,6 +42,15 @@ namespace
         value.httpCode = code;
         value.retryAfterSeconds = retryAfter;
         return value;
+    }
+
+    std::string writeTempFile(const std::string& name, const std::string& contents)
+    {
+        const std::string path = ::testing::TempDir() + name;
+        std::ofstream file {path, std::ios::binary};
+        file << contents;
+        file.close();
+        return path;
     }
 
     class RetrySenderTest : public ::testing::Test
@@ -365,7 +376,9 @@ TEST_F(RetrySenderTest, CompressedBodyIsSignedOverTheCompressedBytes)
 TEST_F(RetrySenderTest, CompressionEnabledSkipsFileBackedBodies)
 {
     // Same fixture as FileBackedSpecsAreSignedThroughSignFile above, but with
-    // compression on: /stateful's file-backed path must stay untouched.
+    // compression on: without a precompressedBodyFilePath set (the caller's
+    // job -- see CompressedFileBackedAttemptRejectedWith415RetriesOnceUncompressedAndSucceeds
+    // below), a file-backed body is still sent exactly as-is.
     RetrySender compressing {m_performer, m_signer, m_clock, m_backoff, true};
     HttpRequestSpec spec;
     spec.target = "/stateful";
@@ -479,4 +492,146 @@ TEST_F(RetrySenderTest, AuthFailureFromTheCompressionRetryStillGetsItsOwnGraceRe
 
     EXPECT_EQ(OutcomeClass::Ok, result.outcome);
     EXPECT_FALSE(authGate.paused()); // Recovered by its own grace retry: never escalated.
+}
+
+TEST_F(RetrySenderTest, PrecompressedFileBodyIsUsedAndSignedOverItsBytes)
+{
+    // /stateful's own caller (StatefulStream) compresses once, up front, and
+    // hands the sibling's path/size here -- attemptOnce() must swap it in and
+    // sign over ITS bytes, not the original file's.
+    RetrySender compressing {m_performer, m_signer, m_clock, m_backoff, true};
+
+    const std::string originalPath = writeTempFile("hc_rs_original.bin", "the original body");
+    const std::string compressedPath = writeTempFile("hc_rs_precompressed.bin", "zstd-ish bytes");
+
+    HttpRequestSpec spec;
+    spec.target = "/stateful";
+    spec.bodyFilePath = originalPath;
+    spec.bodyFileSize = 17;
+    spec.precompressedBodyFilePath = compressedPath;
+    spec.precompressedBodyFileSize = 14;
+
+    std::string seenBodyFilePath;
+    uint64_t seenBodyFileSize = 0;
+    std::vector<std::string> seenHeaders;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & attempt)
+    {
+        seenBodyFilePath = attempt.bodyFilePath;
+        seenBodyFileSize = attempt.bodyFileSize;
+        seenHeaders = attempt.headers;
+        return response(TransportStatus::Ok, 200);
+    }));
+
+    const auto result = compressing.send(spec, m_waiter, 1);
+
+    EXPECT_EQ(OutcomeClass::Ok, result.outcome);
+    EXPECT_EQ(compressedPath, seenBodyFilePath);
+    EXPECT_EQ(14u, seenBodyFileSize);
+    EXPECT_THAT(seenHeaders, Contains("Content-Encoding: zstd"));
+
+    // The CMAC must cover the compressed file's bytes, not the original's.
+    const auto expected = m_signer.signFile("POST", spec.target, compressedPath, m_clock.wallSeconds());
+    ASSERT_TRUE(expected.has_value());
+    EXPECT_THAT(seenHeaders, Contains(expected->authorization));
+}
+
+TEST_F(RetrySenderTest, CompressedFileBackedAttemptRejectedWith415RetriesOnceUncompressedAndSucceeds)
+{
+    CompressionGate gate;
+    RetrySender compressing {m_performer, m_signer, m_clock, m_backoff, true, &gate};
+
+    const std::string originalPath = writeTempFile("hc_rs_415_original.bin", "the original body");
+    const std::string compressedPath = writeTempFile("hc_rs_415_precompressed.bin", "zstd-ish bytes");
+
+    HttpRequestSpec spec;
+    spec.target = "/stateful";
+    spec.bodyFilePath = originalPath;
+    spec.bodyFileSize = 17;
+    spec.precompressedBodyFilePath = compressedPath;
+    spec.precompressedBodyFileSize = 14;
+
+    std::vector<std::string> firstBodyFilePathAndHeaders;
+    std::vector<std::string> secondBodyFilePathAndHeaders;
+    EXPECT_CALL(m_performer, perform(_))
+    .Times(2)
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & attempt)
+    {
+        firstBodyFilePathAndHeaders = attempt.headers;
+        firstBodyFilePathAndHeaders.push_back(attempt.bodyFilePath);
+        return response(TransportStatus::Ok, 415);
+    }))
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & attempt)
+    {
+        secondBodyFilePathAndHeaders = attempt.headers;
+        secondBodyFilePathAndHeaders.push_back(attempt.bodyFilePath);
+        return response(TransportStatus::Ok, 200);
+    }));
+
+    const auto result = compressing.send(spec, m_waiter, 1);
+
+    EXPECT_EQ(OutcomeClass::Ok, result.outcome);
+    EXPECT_THAT(firstBodyFilePathAndHeaders, Contains("Content-Encoding: zstd"));
+    EXPECT_THAT(firstBodyFilePathAndHeaders, Contains(compressedPath));
+    EXPECT_THAT(secondBodyFilePathAndHeaders, Not(Contains("Content-Encoding: zstd")));
+    EXPECT_THAT(secondBodyFilePathAndHeaders, Contains(originalPath));
+    EXPECT_TRUE(gate.disabled());
+}
+
+TEST_F(RetrySenderTest, SecondFileBackedCompressionRejectionTerminatesWithoutLooping)
+{
+    // No gate here: nothing disables compression between attempts, so both
+    // calls keep trying the precompressed sibling -- proving the one-shot
+    // retry is bounded per send() call for file bodies too, not just because
+    // the gate happened to help.
+    RetrySender compressing {m_performer, m_signer, m_clock, m_backoff, true};
+
+    const std::string originalPath = writeTempFile("hc_rs_loop_original.bin", "the original body");
+    const std::string compressedPath = writeTempFile("hc_rs_loop_precompressed.bin", "zstd-ish bytes");
+
+    HttpRequestSpec spec;
+    spec.target = "/stateful";
+    spec.bodyFilePath = originalPath;
+    spec.bodyFileSize = 17;
+    spec.precompressedBodyFilePath = compressedPath;
+    spec.precompressedBodyFileSize = 14;
+
+    EXPECT_CALL(m_performer, perform(_)).Times(2).WillRepeatedly(Return(response(TransportStatus::Ok, 415)));
+
+    const auto result = compressing.send(spec, m_waiter, 4); // maxAttempts=4, but never a 3rd call.
+    EXPECT_EQ(OutcomeClass::CompressionRejected, result.outcome);
+}
+
+TEST_F(RetrySenderTest, FileBackedSenderSkipsCompressionOnceTheSharedGateIsAlreadyDisabled)
+{
+    // The gate is shared across every stream regardless of body shape: an
+    // in-memory sender's earlier 415 must stop a file-backed sender from ever
+    // trying to compress, without it seeing a 415 itself.
+    CompressionGate gate;
+    gate.reportRejected();
+    RetrySender compressing {m_performer, m_signer, m_clock, m_backoff, true, &gate};
+
+    const std::string originalPath = writeTempFile("hc_rs_gate_original.bin", "the original body");
+
+    HttpRequestSpec spec;
+    spec.target = "/stateful";
+    spec.bodyFilePath = originalPath;
+    spec.bodyFileSize = 17;
+    spec.precompressedBodyFilePath = writeTempFile("hc_rs_gate_precompressed.bin", "zstd-ish bytes");
+    spec.precompressedBodyFileSize = 14;
+
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & attempt)
+    {
+        EXPECT_THAT(attempt.headers, Not(Contains("Content-Encoding: zstd")));
+        EXPECT_EQ(originalPath, attempt.bodyFilePath);
+        return response(TransportStatus::Ok, 200);
+    }));
+
+    const auto result = compressing.send(spec, m_waiter, 1);
+    EXPECT_EQ(OutcomeClass::Ok, result.outcome);
 }

--- a/src/client-agent/https_client/tests/unit/retrySender_test.cpp
+++ b/src/client-agent/https_client/tests/unit/retrySender_test.cpp
@@ -203,7 +203,7 @@ TEST_F(RetrySenderTest, AuthGateEscalatesOnlyAfterTheRetryAlsoFails)
 {
     ::testing::NiceMock<MockCallbackSink> sink;
     AuthGate gate {sink, [] {}};
-    RetrySender guarded {m_performer, m_signer, m_clock, m_backoff, false, &gate};
+    RetrySender guarded {m_performer, m_signer, m_clock, m_backoff, false, nullptr, &gate};
 
     // First send: a 401 then a 200 on the retry -> recovered, no pause.
     EXPECT_CALL(m_performer, perform(_))
@@ -374,4 +374,83 @@ TEST_F(RetrySenderTest, CompressionEnabledSkipsFileBackedBodies)
 
     const auto result = compressing.send(spec, m_waiter, 4);
     EXPECT_EQ(OutcomeClass::Permanent, result.outcome);
+}
+
+TEST_F(RetrySenderTest, CompressedAttemptRejectedWith415RetriesOnceUncompressedAndSucceeds)
+{
+    CompressionGate gate;
+    RetrySender compressing {m_performer, m_signer, m_clock, m_backoff, true, &gate};
+
+    const std::string plain(200, 'a'); // Long enough to actually compress.
+    HttpRequestSpec spec = makeSpec();
+    spec.body = reinterpret_cast<const uint8_t*>(plain.data());
+    spec.bodyLength = plain.size();
+
+    std::vector<std::vector<std::string>> seenHeadersPerAttempt;
+    EXPECT_CALL(m_performer, perform(_))
+    .Times(2)
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & attempt)
+    {
+        seenHeadersPerAttempt.push_back(attempt.headers);
+        return response(TransportStatus::Ok, 415);
+    }))
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & attempt)
+    {
+        seenHeadersPerAttempt.push_back(attempt.headers);
+        return response(TransportStatus::Ok, 200);
+    }));
+
+    const auto result = compressing.send(spec, m_waiter, 1);
+
+    EXPECT_EQ(OutcomeClass::Ok, result.outcome); // The request itself still succeeded.
+    ASSERT_EQ(2u, seenHeadersPerAttempt.size());
+    EXPECT_THAT(seenHeadersPerAttempt[0], Contains("Content-Encoding: zstd"));
+    EXPECT_THAT(seenHeadersPerAttempt[1], Not(Contains("Content-Encoding: zstd")));
+    EXPECT_TRUE(gate.disabled()); // Latched for the rest of this agent's run.
+}
+
+TEST_F(RetrySenderTest, CompressionRejectionDisablesTheSharedGateForOtherSenders)
+{
+    // Two independent RetrySender instances (as two different streams would
+    // each own) sharing ONE gate: the first's 415 must stop the second from
+    // ever trying to compress, without the second seeing a 415 itself.
+    CompressionGate gate;
+    RetrySender first {m_performer, m_signer, m_clock, m_backoff, true, &gate};
+    RetrySender second {m_performer, m_signer, m_clock, m_backoff, true, &gate};
+
+    const std::string plain(200, 'a');
+    HttpRequestSpec spec = makeSpec();
+    spec.body = reinterpret_cast<const uint8_t*>(plain.data());
+    spec.bodyLength = plain.size();
+
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 415))) // first: rejected.
+    .WillOnce(Return(response(TransportStatus::Ok, 200))) // first's retry: uncompressed, succeeds.
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & attempt)
+    {
+        // second's only attempt: the gate is already disabled, so it never
+        // even tries to compress -- no header, no wasted round trip.
+        EXPECT_THAT(attempt.headers, Not(Contains("Content-Encoding: zstd")));
+        return response(TransportStatus::Ok, 200);
+    }));
+
+    first.send(spec, m_waiter, 1);
+    ASSERT_TRUE(gate.disabled());
+    const auto result = second.send(spec, m_waiter, 1);
+    EXPECT_EQ(OutcomeClass::Ok, result.outcome);
+}
+
+TEST_F(RetrySenderTest, SecondCompressionRejectionTerminatesWithoutLooping)
+{
+    // No gate here: nothing disables compression between attempts, so both
+    // calls try to compress -- proving the one-shot retry is bounded per
+    // send() call regardless, not just because the gate happened to help.
+    RetrySender compressing {m_performer, m_signer, m_clock, m_backoff, true};
+    EXPECT_CALL(m_performer, perform(_)).Times(2).WillRepeatedly(Return(response(TransportStatus::Ok, 415)));
+
+    const auto result = compressing.send(makeSpec(), m_waiter, 4); // maxAttempts=4, but never a 3rd call.
+    EXPECT_EQ(OutcomeClass::CompressionRejected, result.outcome);
 }

--- a/src/client-agent/https_client/tests/unit/retrySender_test.cpp
+++ b/src/client-agent/https_client/tests/unit/retrySender_test.cpp
@@ -23,8 +23,12 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <zstd.h>
+
 using ::testing::_;
+using ::testing::Contains;
 using ::testing::Invoke;
+using ::testing::Not;
 using ::testing::Return;
 
 namespace
@@ -44,7 +48,7 @@ namespace
             RetrySenderTest()
                 : m_signer("001", m_keyProvider)
                 , m_backoff(1000, 60000, m_random)
-                , m_sender(m_performer, m_signer, m_clock, m_backoff)
+                , m_sender(m_performer, m_signer, m_clock, m_backoff, false)
             {
             }
 
@@ -199,7 +203,7 @@ TEST_F(RetrySenderTest, AuthGateEscalatesOnlyAfterTheRetryAlsoFails)
 {
     ::testing::NiceMock<MockCallbackSink> sink;
     AuthGate gate {sink, [] {}};
-    RetrySender guarded {m_performer, m_signer, m_clock, m_backoff, &gate};
+    RetrySender guarded {m_performer, m_signer, m_clock, m_backoff, false, &gate};
 
     // First send: a 401 then a 200 on the retry -> recovered, no pause.
     EXPECT_CALL(m_performer, perform(_))
@@ -270,7 +274,7 @@ TEST_F(RetrySenderTest, UnusableCredentialsArePermanentWithoutSending)
 {
     const ConfigKeyProvider badProvider {"zz"};
     const CmacSigner badSigner {"001", badProvider};
-    RetrySender sender {m_performer, badSigner, m_clock, m_backoff};
+    RetrySender sender {m_performer, badSigner, m_clock, m_backoff, false};
     EXPECT_CALL(m_performer, perform(_)).Times(0);
 
     const auto result = sender.send(makeSpec(), m_waiter, 4);
@@ -287,5 +291,87 @@ TEST_F(RetrySenderTest, FileBackedSpecsAreSignedThroughSignFile)
     EXPECT_CALL(m_performer, perform(_)).Times(0);
 
     const auto result = m_sender.send(spec, m_waiter, 4);
+    EXPECT_EQ(OutcomeClass::Permanent, result.outcome);
+}
+
+TEST_F(RetrySenderTest, CompressionDisabledLeavesBodyAndHeadersUnchanged)
+{
+    // m_sender is built with compressionEnabled=false: the default, and what
+    // every test above this one already exercises implicitly.
+    std::vector<uint8_t> receivedBody;
+    std::vector<std::string> receivedHeaders;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & spec)
+    {
+        receivedBody.assign(spec.body, spec.body + spec.bodyLength);
+        receivedHeaders = spec.headers;
+        return response(TransportStatus::Ok, 200);
+    }));
+
+    const auto spec = makeSpec();
+    const auto result = m_sender.send(spec, m_waiter, 1);
+
+    EXPECT_EQ(OutcomeClass::Ok, result.outcome);
+    EXPECT_THAT(receivedHeaders, Not(Contains("Content-Encoding: zstd")));
+    ASSERT_EQ(spec.bodyLength, receivedBody.size());
+    EXPECT_TRUE(std::equal(receivedBody.begin(), receivedBody.end(), spec.body));
+}
+
+TEST_F(RetrySenderTest, CompressedBodyIsSignedOverTheCompressedBytes)
+{
+    RetrySender compressing {m_performer, m_signer, m_clock, m_backoff, true};
+
+    // A longer, repetitive body: makeSpec()'s 4-byte "body" wouldn't actually
+    // shrink under zstd's frame overhead.
+    const std::string plain(200, 'a');
+    HttpRequestSpec spec = makeSpec();
+    spec.body = reinterpret_cast<const uint8_t*>(plain.data());
+    spec.bodyLength = plain.size();
+
+    std::vector<uint8_t> receivedBody;
+    std::vector<std::string> receivedHeaders;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & attempt)
+    {
+        receivedBody.assign(attempt.body, attempt.body + attempt.bodyLength);
+        receivedHeaders = attempt.headers;
+        return response(TransportStatus::Ok, 200);
+    }));
+
+    const auto result = compressing.send(spec, m_waiter, 1);
+
+    EXPECT_EQ(OutcomeClass::Ok, result.outcome);
+    EXPECT_THAT(receivedHeaders, Contains("Content-Encoding: zstd"));
+    EXPECT_LT(receivedBody.size(), plain.size()); // Actually shrank.
+
+    std::vector<uint8_t> decompressed(plain.size());
+    const size_t decompressedSize =
+        ZSTD_decompress(decompressed.data(), decompressed.size(), receivedBody.data(), receivedBody.size());
+    ASSERT_FALSE(ZSTD_isError(decompressedSize));
+    ASSERT_EQ(plain.size(), decompressedSize);
+    EXPECT_EQ(plain, std::string(decompressed.begin(), decompressed.end()));
+
+    // The CMAC must cover the wire (compressed) bytes, not the original --
+    // re-signing the exact received bytes at the same timestamp (the clock
+    // never advanced) must reproduce the exact Authorization header sent.
+    const auto expected =
+        m_signer.sign("POST", spec.target, receivedBody.data(), receivedBody.size(), m_clock.wallSeconds());
+    ASSERT_TRUE(expected.has_value());
+    EXPECT_THAT(receivedHeaders, Contains(expected->authorization));
+}
+
+TEST_F(RetrySenderTest, CompressionEnabledSkipsFileBackedBodies)
+{
+    // Same fixture as FileBackedSpecsAreSignedThroughSignFile above, but with
+    // compression on: /stateful's file-backed path must stay untouched.
+    RetrySender compressing {m_performer, m_signer, m_clock, m_backoff, true};
+    HttpRequestSpec spec;
+    spec.target = "/stateful";
+    spec.bodyFilePath = "/nonexistent/hc-spool/session.bin";
+    EXPECT_CALL(m_performer, perform(_)).Times(0);
+
+    const auto result = compressing.send(spec, m_waiter, 4);
     EXPECT_EQ(OutcomeClass::Permanent, result.outcome);
 }

--- a/src/client-agent/https_client/tests/unit/retrySender_test.cpp
+++ b/src/client-agent/https_client/tests/unit/retrySender_test.cpp
@@ -23,11 +23,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-// zstd isn't vendored for winagent (see src/Makefile / src/external/CMakeLists.txt);
-// only the two tests below that actually round-trip real compressed bytes need it.
-#ifndef WIN32
 #include <zstd.h>
-#endif
 
 using ::testing::_;
 using ::testing::Contains;
@@ -322,10 +318,6 @@ TEST_F(RetrySenderTest, CompressionDisabledLeavesBodyAndHeadersUnchanged)
     EXPECT_TRUE(std::equal(receivedBody.begin(), receivedBody.end(), spec.body));
 }
 
-// Compression is compiled out of retrySender.cpp on winagent (#ifndef WIN32
-// there); this test asserts real compression happened, so it's excluded here
-// too rather than failing on a platform that never compresses.
-#ifndef WIN32
 TEST_F(RetrySenderTest, CompressedBodyIsSignedOverTheCompressedBytes)
 {
     RetrySender compressing {m_performer, m_signer, m_clock, m_backoff, true};
@@ -369,7 +361,6 @@ TEST_F(RetrySenderTest, CompressedBodyIsSignedOverTheCompressedBytes)
     ASSERT_TRUE(expected.has_value());
     EXPECT_THAT(receivedHeaders, Contains(expected->authorization));
 }
-#endif // WIN32
 
 TEST_F(RetrySenderTest, CompressionEnabledSkipsFileBackedBodies)
 {
@@ -385,9 +376,6 @@ TEST_F(RetrySenderTest, CompressionEnabledSkipsFileBackedBodies)
     EXPECT_EQ(OutcomeClass::Permanent, result.outcome);
 }
 
-// Same exclusion reason as above: asserts the first attempt was actually
-// compressed, which never happens on winagent.
-#ifndef WIN32
 TEST_F(RetrySenderTest, CompressedAttemptRejectedWith415RetriesOnceUncompressedAndSucceeds)
 {
     CompressionGate gate;
@@ -422,7 +410,6 @@ TEST_F(RetrySenderTest, CompressedAttemptRejectedWith415RetriesOnceUncompressedA
     EXPECT_THAT(seenHeadersPerAttempt[1], Not(Contains("Content-Encoding: zstd")));
     EXPECT_TRUE(gate.disabled()); // Latched for the rest of this agent's run.
 }
-#endif // WIN32
 
 TEST_F(RetrySenderTest, CompressionRejectionDisablesTheSharedGateForOtherSenders)
 {

--- a/src/client-agent/https_client/tests/unit/retrySender_test.cpp
+++ b/src/client-agent/https_client/tests/unit/retrySender_test.cpp
@@ -454,3 +454,29 @@ TEST_F(RetrySenderTest, SecondCompressionRejectionTerminatesWithoutLooping)
     const auto result = compressing.send(makeSpec(), m_waiter, 4); // maxAttempts=4, but never a 3rd call.
     EXPECT_EQ(OutcomeClass::CompressionRejected, result.outcome);
 }
+
+TEST_F(RetrySenderTest, AuthFailureFromTheCompressionRetryStillGetsItsOwnGraceRetry)
+{
+    // The 415's one-shot uncompressed retry can itself land a transient 401.
+    // That 401 must get its own fresh-timestamp grace retry -- not skip
+    // straight past it just because the compression retry already ran.
+    ::testing::NiceMock<MockCallbackSink> sink;
+    AuthGate authGate {sink, [] {}};
+    CompressionGate compressionGate;
+    RetrySender compressing {m_performer, m_signer, m_clock, m_backoff, true, &compressionGate, &authGate};
+
+    const std::string plain(200, 'a'); // Long enough to actually compress.
+    HttpRequestSpec spec = makeSpec();
+    spec.body = reinterpret_cast<const uint8_t*>(plain.data());
+    spec.bodyLength = plain.size();
+
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 415))) // Rejected: retry uncompressed.
+    .WillOnce(Return(response(TransportStatus::Ok, 401))) // Uncompressed retry: transient 401.
+    .WillOnce(Return(response(TransportStatus::Ok, 200))); // Auth grace retry: recovers.
+
+    const auto result = compressing.send(spec, m_waiter, 1);
+
+    EXPECT_EQ(OutcomeClass::Ok, result.outcome);
+    EXPECT_FALSE(authGate.paused()); // Recovered by its own grace retry: never escalated.
+}

--- a/src/client-agent/https_client/tests/unit/retrySender_test.cpp
+++ b/src/client-agent/https_client/tests/unit/retrySender_test.cpp
@@ -23,7 +23,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+// zstd isn't vendored for winagent (see src/Makefile / src/external/CMakeLists.txt);
+// only the two tests below that actually round-trip real compressed bytes need it.
+#ifndef WIN32
 #include <zstd.h>
+#endif
 
 using ::testing::_;
 using ::testing::Contains;
@@ -318,6 +322,10 @@ TEST_F(RetrySenderTest, CompressionDisabledLeavesBodyAndHeadersUnchanged)
     EXPECT_TRUE(std::equal(receivedBody.begin(), receivedBody.end(), spec.body));
 }
 
+// Compression is compiled out of retrySender.cpp on winagent (#ifndef WIN32
+// there); this test asserts real compression happened, so it's excluded here
+// too rather than failing on a platform that never compresses.
+#ifndef WIN32
 TEST_F(RetrySenderTest, CompressedBodyIsSignedOverTheCompressedBytes)
 {
     RetrySender compressing {m_performer, m_signer, m_clock, m_backoff, true};
@@ -361,6 +369,7 @@ TEST_F(RetrySenderTest, CompressedBodyIsSignedOverTheCompressedBytes)
     ASSERT_TRUE(expected.has_value());
     EXPECT_THAT(receivedHeaders, Contains(expected->authorization));
 }
+#endif // WIN32
 
 TEST_F(RetrySenderTest, CompressionEnabledSkipsFileBackedBodies)
 {
@@ -376,6 +385,9 @@ TEST_F(RetrySenderTest, CompressionEnabledSkipsFileBackedBodies)
     EXPECT_EQ(OutcomeClass::Permanent, result.outcome);
 }
 
+// Same exclusion reason as above: asserts the first attempt was actually
+// compressed, which never happens on winagent.
+#ifndef WIN32
 TEST_F(RetrySenderTest, CompressedAttemptRejectedWith415RetriesOnceUncompressedAndSucceeds)
 {
     CompressionGate gate;
@@ -410,6 +422,7 @@ TEST_F(RetrySenderTest, CompressedAttemptRejectedWith415RetriesOnceUncompressedA
     EXPECT_THAT(seenHeadersPerAttempt[1], Not(Contains("Content-Encoding: zstd")));
     EXPECT_TRUE(gate.disabled()); // Latched for the rest of this agent's run.
 }
+#endif // WIN32
 
 TEST_F(RetrySenderTest, CompressionRejectionDisablesTheSharedGateForOtherSenders)
 {

--- a/src/client-agent/https_client/tests/unit/statefulStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/statefulStream_test.cpp
@@ -11,6 +11,7 @@
 
 #include "fakeSysSeams.hpp"
 #include "mockCallbackSink.hpp"
+#include "mockFileCompressor.hpp"
 #include "mockHttpPerformer.hpp"
 #include "mockSpoolFactory.hpp"
 #include "shared_modules/sync_protocol/include/sync_session_wire.hpp"
@@ -24,8 +25,10 @@
 
 using ::testing::_;
 using ::testing::ByMove;
+using ::testing::Contains;
 using ::testing::Invoke;
 using ::testing::NiceMock;
+using ::testing::Not;
 using ::testing::Return;
 
 namespace
@@ -60,7 +63,7 @@ namespace
                 , m_config(makeConfig())
                 , m_authGate(m_sink, [] {})
             , m_stream(m_config, m_performer, m_signer, m_clock, m_random, m_spoolFactory, m_sink,
-                       m_authGate, m_compressionGate)
+                       m_authGate, m_compressionGate, m_fileCompressor)
             {
                 // By default the spool factory writes the bytes to a unique temp
                 // file (submit spools now, so every submit needs a real file).
@@ -97,6 +100,7 @@ namespace
             MockHttpPerformer m_performer;
             AuthGate m_authGate;
             CompressionGate m_compressionGate;
+            NiceMock<MockFileCompressor> m_fileCompressor;
             FakeWaiter m_waiter;
             StatefulStream m_stream;
             int m_spoolCounter {0};
@@ -313,4 +317,111 @@ TEST_F(StatefulStreamTest, AdoptedSessionFilesAreIdCheckedToo)
     EXPECT_FALSE(m_stream.submitFile("sess\r\nX-Injected: 1", "/tmp/hc_never_read", 4));
     EXPECT_FALSE(m_stream.hasPending());
     EXPECT_TRUE(m_stream.submitFile("adopted-1", "/tmp/hc_never_read", 4));
+}
+
+namespace
+{
+    ModuleConfig makeCompressingConfig()
+    {
+        hc_config_t config {};
+        std::strncpy(config.server_host, "127.0.0.1", sizeof(config.server_host) - 1);
+        std::strncpy(config.agent_id, "001", sizeof(config.agent_id) - 1);
+        config.verify_mode = HC_VERIFY_NONE;
+        config.https_compression_enabled = 1;
+        return ModuleConfig::fromC(config);
+    }
+} // namespace
+
+TEST_F(StatefulStreamTest, CompressionEnabledCompressesOnceAndCleansUpTheTempFile)
+{
+    // compressionEnabled is captured by RetrySender at construction time, so
+    // this needs its own StatefulStream (the fixture's m_stream was built from
+    // makeConfig()'s default-off config) -- same reason retrySender_test.cpp
+    // constructs a separate RetrySender per compression test rather than
+    // mutating the fixture's config after the fact.
+    ModuleConfig compressingConfig = makeCompressingConfig();
+    StatefulStream compressing {compressingConfig,  m_performer,        m_signer,
+                                m_clock,            m_random,           m_spoolFactory,
+                                m_sink,             m_authGate,         m_compressionGate,
+                                m_fileCompressor};
+
+    const std::string originalPath = ::testing::TempDir() + "hc_stateful_compress_src.tmp";
+    EXPECT_CALL(m_spoolFactory, spool(_, 4u))
+    .WillOnce(Return(ByMove(makeSpoolAt(originalPath, "body"))));
+
+    const std::string compressedPath = ::testing::TempDir() + "hc_stateful_compress_out.tmp";
+    {
+        std::ofstream out {compressedPath, std::ios::binary};
+        out << "Z"; // Placeholder compressed bytes; only the path/size matter to this test.
+    }
+    EXPECT_CALL(m_fileCompressor, compress(originalPath, 4u, _, _))
+    .WillOnce(Return(ByMove(std::make_optional(
+                                std::make_pair(std::make_unique<SpoolFile>(compressedPath), uint64_t {1})))));
+
+    std::string seenBodyFilePath;
+    std::vector<std::string> seenHeaders;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & spec)
+    {
+        seenBodyFilePath = spec.bodyFilePath;
+        seenHeaders = spec.headers;
+        return response(TransportStatus::Ok, 200, "{}");
+    }));
+
+    ASSERT_TRUE(compressing.submit("sess-1", reinterpret_cast<const uint8_t*>("body"), 4));
+    EXPECT_TRUE(compressing.step(m_waiter));
+
+    EXPECT_EQ(compressedPath, seenBodyFilePath); // Sent the compressed sibling, not the original.
+    EXPECT_THAT(seenHeaders, Contains("Content-Encoding: zstd"));
+    EXPECT_FALSE(fileExists(compressedPath)); // Cleaned up once sendSession() returned.
+    EXPECT_FALSE(fileExists(originalPath));   // The session's own spool file too (normal cleanup).
+}
+
+TEST_F(StatefulStreamTest, CompressionFailureFallsBackToTheOriginalFileUncompressed)
+{
+    ModuleConfig compressingConfig = makeCompressingConfig();
+    StatefulStream compressing {compressingConfig,  m_performer,        m_signer,
+                                m_clock,            m_random,           m_spoolFactory,
+                                m_sink,             m_authGate,         m_compressionGate,
+                                m_fileCompressor};
+
+    const std::string originalPath = ::testing::TempDir() + "hc_stateful_compress_fail.tmp";
+    EXPECT_CALL(m_spoolFactory, spool(_, 4u))
+    .WillOnce(Return(ByMove(makeSpoolAt(originalPath, "body"))));
+    EXPECT_CALL(m_fileCompressor, compress(_, _, _, _)).WillOnce(Return(ByMove(std::nullopt)));
+
+    std::string seenBodyFilePath;
+    std::vector<std::string> seenHeaders;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & spec)
+    {
+        seenBodyFilePath = spec.bodyFilePath;
+        seenHeaders = spec.headers;
+        return response(TransportStatus::Ok, 200, "{}");
+    }));
+
+    ASSERT_TRUE(compressing.submit("sess-1", reinterpret_cast<const uint8_t*>("body"), 4));
+    EXPECT_TRUE(compressing.step(m_waiter));
+
+    EXPECT_EQ(originalPath, seenBodyFilePath);
+    EXPECT_THAT(seenHeaders, Not(Contains("Content-Encoding: zstd")));
+}
+
+TEST_F(StatefulStreamTest, GateAlreadyDisabledSkipsCompressionEntirely)
+{
+    m_compressionGate.reportRejected(); // E.g. another stream already saw a 415.
+
+    ModuleConfig compressingConfig = makeCompressingConfig();
+    StatefulStream compressing {compressingConfig,  m_performer,        m_signer,
+                                m_clock,            m_random,           m_spoolFactory,
+                                m_sink,             m_authGate,         m_compressionGate,
+                                m_fileCompressor};
+
+    EXPECT_CALL(m_fileCompressor, compress(_, _, _, _)).Times(0);
+    EXPECT_CALL(m_performer, perform(_)).WillOnce(Return(response(TransportStatus::Ok, 200, "{}")));
+
+    ASSERT_TRUE(compressing.submit("sess-1", reinterpret_cast<const uint8_t*>("body"), 4));
+    EXPECT_TRUE(compressing.step(m_waiter));
 }

--- a/src/client-agent/https_client/tests/unit/statefulStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/statefulStream_test.cpp
@@ -60,7 +60,7 @@ namespace
                 , m_config(makeConfig())
                 , m_authGate(m_sink, [] {})
             , m_stream(m_config, m_performer, m_signer, m_clock, m_random, m_spoolFactory, m_sink,
-                       m_authGate)
+                       m_authGate, m_compressionGate)
             {
                 // By default the spool factory writes the bytes to a unique temp
                 // file (submit spools now, so every submit needs a real file).
@@ -96,6 +96,7 @@ namespace
             NiceMock<MockCallbackSink> m_sink;
             MockHttpPerformer m_performer;
             AuthGate m_authGate;
+            CompressionGate m_compressionGate;
             FakeWaiter m_waiter;
             StatefulStream m_stream;
             int m_spoolCounter {0};

--- a/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
@@ -685,7 +685,7 @@ TEST_F(StatelessStreamTest, DropNewestReturnsFalseAtCap)
 
 TEST_F(StatelessStreamTest, CompressionRejectionRecoversAndDeliversEventExactlyOnce)
 {
-    // End-to-end proof (#38308) that the RetrySender-level 415 recovery is
+    // End-to-end proof that the RetrySender-level 415 recovery is
     // invisible to StatelessStream: handleOutcome() only ever sees the final
     // OutcomeClass, so a compressed-then-rejected-then-uncompressed-retry
     // success looks exactly like any other Ok -- consumed once, not dropped,

--- a/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
@@ -19,6 +19,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <zstd.h>
+
 #include <algorithm>
 #include <chrono>
 #include <cstring>
@@ -26,8 +28,10 @@
 #include <vector>
 
 using ::testing::_;
+using ::testing::Contains;
 using ::testing::Invoke;
 using ::testing::NiceMock;
+using ::testing::Not;
 using ::testing::Return;
 
 namespace
@@ -68,7 +72,7 @@ namespace
             {
             }
 
-            static ModuleConfig makeConfig()
+            static ModuleConfig makeConfig(bool compressionEnabled = false)
             {
                 hc_config_t config {};
                 std::strncpy(config.server_host, "127.0.0.1", sizeof(config.server_host) - 1);
@@ -78,6 +82,7 @@ namespace
                 config.batch_size_bytes = 51;
                 config.batch_interval_ms = 5000;
                 config.buffer_cap_multiplier = 4;
+                config.https_compression_enabled = compressionEnabled;
                 return ModuleConfig::fromC(config);
             }
 
@@ -676,4 +681,88 @@ TEST_F(StatelessStreamTest, DropNewestReturnsFalseAtCap)
 
     EXPECT_GT(dropped, 0u);
     EXPECT_EQ(dropped, m_stream.droppedEvents());
+}
+
+TEST_F(StatelessStreamTest, CompressionRejectionRecoversAndDeliversEventExactlyOnce)
+{
+    // End-to-end proof (#38308) that the RetrySender-level 415 recovery is
+    // invisible to StatelessStream: handleOutcome() only ever sees the final
+    // OutcomeClass, so a compressed-then-rejected-then-uncompressed-retry
+    // success looks exactly like any other Ok -- consumed once, not dropped,
+    // not left behind for a duplicate resend.
+    const ModuleConfig config = makeConfig(/*compressionEnabled=*/true);
+    StatelessStream stream {config, m_performer, m_signer, m_clock, m_random, m_sink, m_authGate,
+                            m_compressionGate};
+
+    std::vector<std::vector<std::string>> headersPerCall;
+    EXPECT_CALL(m_performer, perform(_))
+    .Times(2)
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & spec)
+    {
+        headersPerCall.push_back(spec.headers);
+        return response(TransportStatus::Ok, 415);
+    }))
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & spec)
+    {
+        headersPerCall.push_back(spec.headers);
+        return response(TransportStatus::Ok, 200);
+    }));
+
+    const std::string frame = "e1";
+    stream.submit(reinterpret_cast<const uint8_t*>(frame.data()), frame.size());
+    stream.tick(m_waiter, true);
+
+    ASSERT_EQ(2u, headersPerCall.size());
+    EXPECT_THAT(headersPerCall[0], Contains("Content-Encoding: zstd"));
+    EXPECT_THAT(headersPerCall[1], Not(Contains("Content-Encoding: zstd")));
+    EXPECT_EQ(0u, stream.droppedEvents());
+
+    // Delivered exactly once: nothing left behind to resend on the next tick.
+    EXPECT_CALL(m_performer, perform(_)).Times(0);
+    stream.tick(m_waiter, true);
+}
+
+TEST_F(StatelessStreamTest, CompressionDoesNotChangeEventBatchingBudget)
+{
+    // AdaptivePayload/eventBytesBudgetLocked() must stay keyed off uncompressed
+    // content bytes: compression must only shrink the final wire bytes, never
+    // feed back into how much content one flush includes. Same 16-byte event
+    // budget as PayloadTooLargeKeepsEventsInOrderAndHalves above, but with
+    // compression on -- two "E aaaa\n" (7 bytes each) fit; a third must not be
+    // pulled into the same flush just because it would compress smaller.
+    const ModuleConfig config = makeConfig(/*compressionEnabled=*/true);
+    StatelessStream stream {config, m_performer, m_signer, m_clock, m_random, m_sink, m_authGate,
+                            m_compressionGate};
+
+    std::vector<std::string> decompressedBodies;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillRepeatedly(Invoke(
+                        [&](const HttpRequestSpec & spec)
+    {
+        std::vector<uint8_t> decompressed(4096);
+        const size_t size = ZSTD_decompress(decompressed.data(), decompressed.size(), spec.body, spec.bodyLength);
+        EXPECT_FALSE(ZSTD_isError(size));
+        decompressedBodies.emplace_back(reinterpret_cast<const char*>(decompressed.data()), size);
+        return response(TransportStatus::Ok, 200);
+    }));
+
+    const std::string frame = "aaaa"; // "E aaaa\n" = 7 bytes.
+    stream.submit(reinterpret_cast<const uint8_t*>(frame.data()), frame.size());
+    stream.submit(reinterpret_cast<const uint8_t*>(frame.data()), frame.size()); // 14: fits the 16-byte budget.
+    stream.submit(reinterpret_cast<const uint8_t*>(frame.data()), frame.size()); // Would make 21: must wait.
+    stream.tick(m_waiter, true);
+
+    ASSERT_EQ(1u, decompressedBodies.size());
+    size_t eventCount = 0;
+    for (size_t pos = 0; (pos = decompressedBodies[0].find("E aaaa\n", pos)) != std::string::npos;
+         pos += 7, eventCount++) {}
+    EXPECT_EQ(2u, eventCount); // Only two events fit the uncompressed budget.
+
+    // The third event is still pending, not dropped: a further tick sends it.
+    stream.tick(m_waiter, true);
+    ASSERT_EQ(2u, decompressedBodies.size());
+    EXPECT_NE(std::string::npos, decompressedBodies[1].find("E aaaa\n"));
+    EXPECT_EQ(0u, stream.droppedEvents());
 }

--- a/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
@@ -19,7 +19,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+// zstd isn't vendored for winagent (see src/Makefile / src/external/CMakeLists.txt);
+// only the two tests below that actually round-trip real compressed bytes need it.
+#ifndef WIN32
 #include <zstd.h>
+#endif
 
 #include <algorithm>
 #include <chrono>
@@ -683,6 +687,10 @@ TEST_F(StatelessStreamTest, DropNewestReturnsFalseAtCap)
     EXPECT_EQ(dropped, m_stream.droppedEvents());
 }
 
+// Compression is compiled out of retrySender.cpp on winagent (#ifndef WIN32
+// there); these two tests assert real compression happened, so they're
+// excluded here too rather than failing on a platform that never compresses.
+#ifndef WIN32
 TEST_F(StatelessStreamTest, CompressionRejectionRecoversAndDeliversEventExactlyOnce)
 {
     // End-to-end proof that the RetrySender-level 415 recovery is
@@ -766,3 +774,4 @@ TEST_F(StatelessStreamTest, CompressionDoesNotChangeEventBatchingBudget)
     EXPECT_NE(std::string::npos, decompressedBodies[1].find("E aaaa\n"));
     EXPECT_EQ(0u, stream.droppedEvents());
 }
+#endif // WIN32

--- a/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
@@ -19,11 +19,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-// zstd isn't vendored for winagent (see src/Makefile / src/external/CMakeLists.txt);
-// only the two tests below that actually round-trip real compressed bytes need it.
-#ifndef WIN32
 #include <zstd.h>
-#endif
 
 #include <algorithm>
 #include <chrono>
@@ -687,10 +683,6 @@ TEST_F(StatelessStreamTest, DropNewestReturnsFalseAtCap)
     EXPECT_EQ(dropped, m_stream.droppedEvents());
 }
 
-// Compression is compiled out of retrySender.cpp on winagent (#ifndef WIN32
-// there); these two tests assert real compression happened, so they're
-// excluded here too rather than failing on a platform that never compresses.
-#ifndef WIN32
 TEST_F(StatelessStreamTest, CompressionRejectionRecoversAndDeliversEventExactlyOnce)
 {
     // End-to-end proof that the RetrySender-level 415 recovery is
@@ -774,4 +766,3 @@ TEST_F(StatelessStreamTest, CompressionDoesNotChangeEventBatchingBudget)
     EXPECT_NE(std::string::npos, decompressedBodies[1].find("E aaaa\n"));
     EXPECT_EQ(0u, stream.droppedEvents());
 }
-#endif // WIN32

--- a/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
@@ -63,7 +63,8 @@ namespace
                 : m_signer("001", m_keyProvider)
                 , m_config(makeConfig())
                 , m_authGate(m_sink, [] {})
-            , m_stream(m_config, m_performer, m_signer, m_clock, m_random, m_sink, m_authGate)
+            , m_stream(m_config, m_performer, m_signer, m_clock, m_random, m_sink, m_authGate,
+                       m_compressionGate)
             {
             }
 
@@ -98,6 +99,7 @@ namespace
             NiceMock<MockCallbackSink> m_sink;
             MockHttpPerformer m_performer;
             AuthGate m_authGate;
+            CompressionGate m_compressionGate;
             FakeWaiter m_waiter;
             StatelessStream m_stream;
     };
@@ -159,7 +161,7 @@ TEST_F(StatelessStreamTest, TheHeaderLineEscapesTheAgentId)
     raw.verify_mode = HC_VERIFY_NONE;
     const ModuleConfig config = ModuleConfig::fromC(raw);
     StatelessStream stream {config,   m_performer, m_signer, m_clock,
-                            m_random, m_sink,      m_authGate};
+                            m_random, m_sink,      m_authGate, m_compressionGate};
 
     std::string sentBody;
     EXPECT_CALL(m_performer, perform(_))
@@ -190,7 +192,7 @@ TEST_F(StatelessStreamTest, HeaderLineMergesHostBlockFromCollectHost)
         R"("host":{"hostname":"h1","architecture":"x86_64"}},)"
         R"("cluster":{"name":"c1","node":"n1"}})";
     StatelessStream stream {m_config,  m_performer, m_signer, m_clock, m_random,
-                            m_sink,    m_authGate, [&hostJson] { return hostJson; }};
+                            m_sink,    m_authGate, m_compressionGate, [&hostJson] { return hostJson; }};
 
     std::string sentBody;
     EXPECT_CALL(m_performer, perform(_))
@@ -229,7 +231,7 @@ TEST_F(StatelessStreamTest, HeaderLineFallsBackToAgentIdWhenCollectHostIsEmpty)
     // metadata_provider has nothing yet (e.g. before the first /control
     // handshake): the H line must still be well-formed, carrying only id.
     StatelessStream stream {m_config,  m_performer, m_signer, m_clock, m_random,
-                            m_sink,    m_authGate, [] { return std::string(); }};
+                            m_sink,    m_authGate, m_compressionGate, [] { return std::string(); }};
 
     std::string sentBody;
     EXPECT_CALL(m_performer, perform(_))
@@ -255,7 +257,7 @@ TEST_F(StatelessStreamTest, HeaderLineIgnoresAMalformedCollectHostResult)
     // A torn shared-memory read or an unexpected shape must degrade to
     // "agent.id only", never corrupt the H line or crash the stream.
     StatelessStream stream {m_config,  m_performer, m_signer,  m_clock, m_random,
-                            m_sink,    m_authGate, [] { return std::string("not json"); }};
+                            m_sink,    m_authGate, m_compressionGate, [] { return std::string("not json"); }};
 
     std::string sentBody;
     EXPECT_CALL(m_performer, perform(_))
@@ -283,7 +285,7 @@ TEST_F(StatelessStreamTest, HeaderLineIsRefreshedOnEveryFlushNotCachedAtConstruc
     std::string clusterName = "";
     StatelessStream stream
     {
-        m_config,   m_performer, m_signer, m_clock, m_random, m_sink, m_authGate,
+        m_config,   m_performer, m_signer, m_clock, m_random, m_sink, m_authGate, m_compressionGate,
         [&clusterName]
         {
             return clusterName.empty() ? std::string() : R"({"cluster":{"name":")" + clusterName + "\"}}";
@@ -421,7 +423,7 @@ TEST_F(StatelessStreamTest, ASingleOversized413DoesNotShrinkTheBudget)
     raw.buffer_cap_multiplier = 4;
     const ModuleConfig config = ModuleConfig::fromC(raw);
     StatelessStream stream {config,   m_performer, m_signer, m_clock,
-                            m_random, m_sink,      m_authGate};
+                            m_random, m_sink,      m_authGate, m_compressionGate};
 
     const auto push = [&stream](const std::string & frame)
     {

--- a/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/statelessStream_test.cpp
@@ -756,8 +756,10 @@ TEST_F(StatelessStreamTest, CompressionDoesNotChangeEventBatchingBudget)
 
     ASSERT_EQ(1u, decompressedBodies.size());
     size_t eventCount = 0;
+
     for (size_t pos = 0; (pos = decompressedBodies[0].find("E aaaa\n", pos)) != std::string::npos;
-         pos += 7, eventCount++) {}
+            pos += 7, eventCount++) {}
+
     EXPECT_EQ(2u, eventCount); // Only two events fit the uncompressed budget.
 
     // The third event is still pending, not dropped: a further tick sends it.

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -1633,10 +1633,10 @@ static bool bridge_build_config(hc_config_t *config)
     config->buffer_normal_level = (uint32_t)g_buffer_normal_level;
     config->buffer_flood_tolerance_s = (uint32_t)getDefine_Int("agent", "tolerance", 0, 600);
 
-    /* internal_options.conf toggle (#38308), not a <client> XML setting --
-     * request-body compression is an opt-in tuning knob, not user-facing
-     * config. getDefine_Int_default (not getDefine_Int) so a missing key
-     * defaults to off instead of aborting the agent. */
+    /* internal_options.conf toggle, not a <client> XML setting -- request-
+     * body compression is an opt-in tuning knob, not user-facing config.
+     * getDefine_Int_default (not getDefine_Int) so a missing key defaults to
+     * off instead of aborting the agent. */
     config->https_compression_enabled = (bool)getDefine_Int_default("agent", "https_compression_enabled", 0, 1, 0);
 
     /* Bug found during real-package validation: this used to be

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -1633,6 +1633,12 @@ static bool bridge_build_config(hc_config_t *config)
     config->buffer_normal_level = (uint32_t)g_buffer_normal_level;
     config->buffer_flood_tolerance_s = (uint32_t)getDefine_Int("agent", "tolerance", 0, 600);
 
+    /* internal_options.conf toggle (#38308), not a <client> XML setting --
+     * request-body compression is an opt-in tuning knob, not user-facing
+     * config. getDefine_Int_default (not getDefine_Int) so a missing key
+     * defaults to off instead of aborting the agent. */
+    config->https_compression_enabled = (bool)getDefine_Int_default("agent", "https_compression_enabled", 0, 1, 0);
+
     /* Bug found during real-package validation: this used to be
      * getsharedfiles() (client-agent/src/notify.c), which is an MD5 (OS_MD5_File) -- the legacy
      * merged_sum format. config->config_checksum seeds ConfigHashState's initial value

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -1081,8 +1081,8 @@ endif()
 # <BINARY_DIR>/lib/libzstd.a because upstream's lib/CMakeLists.txt is pulled
 # in via add_subdirectory(lib).
 #
-# Was manager-only; the agent now needs it too (#38308, request-body
-# compression). IS_WINDOWS stays excluded here -- winagent's MinGW
+# Was manager-only; the agent now needs it too, for request-body
+# compression. IS_WINDOWS stays excluded here -- winagent's MinGW
 # cross-compile toolchain args (mirroring curl/openssl's CMAKE_ARGS
 # CC=${MINGW_CC} --host=${MINGW_HOST} pattern above) are a dedicated
 # follow-up, verified against packages/windows/Dockerfile.

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -1071,49 +1071,85 @@ if(IS_LINUX AND NOT IS_AGENT)
 endif()
 
 # ------------------------------------------------------------------------------
-# zstd (manager + Linux/macOS agent; winagent cross-compile is a follow-up)
+# zstd (manager + agent, all platforms incl. winagent)
 # ------------------------------------------------------------------------------
 #
 # Upstream ships its CMake project under build/cmake (not at the repo root),
 # so SOURCE_DIR points there. BINARY_DIR is kept out of that tree (as
-# build/cmake-build) to avoid colliding with the vendored build/{cmake,meson,
-# VS2010,single_file_libs} directories. The static archive lands under
-# <BINARY_DIR>/lib/libzstd.a because upstream's lib/CMakeLists.txt is pulled
-# in via add_subdirectory(lib).
+# build/cmake-build, or build/cmake-build-win when cross-compiling for
+# Windows) to avoid colliding with the vendored build/{cmake,meson,VS2010,
+# single_file_libs} directories. The Windows BINARY_DIR is intentionally
+# distinct from the non-Windows one -- a Linux/macOS libzstd.a already built
+# on disk must never satisfy the Windows precompiled-artifact fast path
+# below (or vice versa); each platform gets its own EXISTS check. The static
+# archive lands under <BINARY_DIR>/lib/libzstd.a because upstream's
+# lib/CMakeLists.txt is pulled in via add_subdirectory(lib).
 #
-# Was manager-only; the agent now needs it too, for request-body
-# compression. IS_WINDOWS stays excluded here -- winagent's MinGW
-# cross-compile toolchain args (mirroring curl/openssl's CMAKE_ARGS
-# CC=${MINGW_CC} --host=${MINGW_HOST} pattern above) are a dedicated
-# follow-up, verified against packages/windows/Dockerfile.
-if(NOT IS_WINDOWS)
-  if(EXISTS ${EXTERNAL_DIR}/zstd/build/cmake-build/lib/libzstd.a)
-    message(STATUS "Using precompiled zstd library")
-    add_custom_target(zstd_external)
-  else()
-    ExternalProject_Add(
-      zstd_external
-      SOURCE_DIR ${EXTERNAL_DIR}/zstd/build/cmake
-      BINARY_DIR ${EXTERNAL_DIR}/zstd/build/cmake-build
-      CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release
-                 -DBUILD_SHARED_LIBS=OFF
-                 -DZSTD_BUILD_STATIC=ON
-                 -DZSTD_BUILD_SHARED=OFF
-                 -DZSTD_BUILD_PROGRAMS=OFF
-                 -DZSTD_BUILD_TESTS=OFF
-                 -DZSTD_LEGACY_SUPPORT=OFF
-                 -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-      INSTALL_COMMAND ""
-      BUILD_BYPRODUCTS ${EXTERNAL_DIR}/zstd/build/cmake-build/lib/libzstd.a)
-  endif()
-
-  add_library(ext_zstd STATIC IMPORTED GLOBAL)
-  set_target_properties(
-    ext_zstd PROPERTIES IMPORTED_LOCATION
-                        ${EXTERNAL_DIR}/zstd/build/cmake-build/lib/libzstd.a)
-  add_dependencies(ext_zstd zstd_external)
-  target_include_directories(ext_zstd INTERFACE ${EXTERNAL_DIR}/zstd/lib)
+# Windows (winagent) cross-compiles via a nested ExternalProject_Add whose
+# own CMAKE_ARGS re-declare CMAKE_SYSTEM_NAME=Windows and forward the
+# already-cross-compiling top-level CMAKE_C_COMPILER/CMAKE_CXX_COMPILER/
+# CMAKE_AR/CMAKE_RANLIB (mirrors the GoogleTest Windows block below) instead
+# of re-deriving a MinGW prefix independently -- this file's own
+# MINGW_PREFIX is a second, non-synchronized source of truth vs.
+# src/Makefile's MING_BASE, so forwarding what the top-level configure
+# already resolved avoids adding to that split.
+#
+# CMAKE_CXX_COMPILER is required even though zstd's own library is C-only:
+# CMake's project() call, with no explicit LANGUAGES restriction, enables
+# CXX by default, so the nested configure's own compiler sanity-check tries
+# to find a C++ compiler regardless. Without forwarding it, that check falls
+# back to the HOST's /usr/bin/c++ (not the MinGW cross compiler), which
+# fails immediately on a MinGW-only linker flag -- confirmed empirically,
+# not just theorized.
+if(IS_WINDOWS)
+  set(ZSTD_BINARY_DIR ${EXTERNAL_DIR}/zstd/build/cmake-build-win)
+  find_program(FULL_RANLIB ${CMAKE_RANLIB} REQUIRED)
+  set(ZSTD_CMAKE_ARGS
+      -DCMAKE_SYSTEM_NAME=Windows
+      -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+      -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+      -DCMAKE_AR=${CMAKE_AR}
+      -DCMAKE_RANLIB=${FULL_RANLIB}
+      -DZSTD_MULTITHREAD_SUPPORT=OFF)
+else()
+  set(ZSTD_BINARY_DIR ${EXTERNAL_DIR}/zstd/build/cmake-build)
+  set(ZSTD_CMAKE_ARGS "")
 endif()
+
+if(EXISTS ${ZSTD_BINARY_DIR}/lib/libzstd.a)
+  message(STATUS "Using precompiled zstd library")
+  add_custom_target(zstd_external)
+else()
+  ExternalProject_Add(
+    zstd_external
+    SOURCE_DIR ${EXTERNAL_DIR}/zstd/build/cmake
+    BINARY_DIR ${ZSTD_BINARY_DIR}
+    CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release
+               -DBUILD_SHARED_LIBS=OFF
+               -DZSTD_BUILD_STATIC=ON
+               -DZSTD_BUILD_SHARED=OFF
+               -DZSTD_BUILD_PROGRAMS=OFF
+               -DZSTD_BUILD_TESTS=OFF
+               -DZSTD_LEGACY_SUPPORT=OFF
+               -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+               ${ZSTD_CMAKE_ARGS}
+    INSTALL_COMMAND ""
+    BUILD_BYPRODUCTS ${ZSTD_BINARY_DIR}/lib/libzstd.a)
+
+  if(IS_WINDOWS)
+    ExternalProject_Add_Step(
+      zstd_external ranlib_libs
+      COMMAND ${FULL_RANLIB} ${ZSTD_BINARY_DIR}/lib/libzstd.a
+      DEPENDEES build
+      COMMENT "Running ranlib on zstd library")
+  endif()
+endif()
+
+add_library(ext_zstd STATIC IMPORTED GLOBAL)
+set_target_properties(
+  ext_zstd PROPERTIES IMPORTED_LOCATION ${ZSTD_BINARY_DIR}/lib/libzstd.a)
+add_dependencies(ext_zstd zstd_external)
+target_include_directories(ext_zstd INTERFACE ${EXTERNAL_DIR}/zstd/lib)
 
 # ------------------------------------------------------------------------------
 # popt (Linux agent only)

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -1071,7 +1071,7 @@ if(IS_LINUX AND NOT IS_AGENT)
 endif()
 
 # ------------------------------------------------------------------------------
-# zstd (server only)
+# zstd (manager + Linux/macOS agent; winagent cross-compile is a follow-up)
 # ------------------------------------------------------------------------------
 #
 # Upstream ships its CMake project under build/cmake (not at the repo root),
@@ -1080,7 +1080,13 @@ endif()
 # VS2010,single_file_libs} directories. The static archive lands under
 # <BINARY_DIR>/lib/libzstd.a because upstream's lib/CMakeLists.txt is pulled
 # in via add_subdirectory(lib).
-if(NOT IS_AGENT AND NOT IS_WINDOWS)
+#
+# Was manager-only; the agent now needs it too (#38308, request-body
+# compression). IS_WINDOWS stays excluded here -- winagent's MinGW
+# cross-compile toolchain args (mirroring curl/openssl's CMAKE_ARGS
+# CC=${MINGW_CC} --host=${MINGW_HOST} pattern above) are a dedicated
+# follow-up, verified against packages/windows/Dockerfile.
+if(NOT IS_WINDOWS)
   if(EXISTS ${EXTERNAL_DIR}/zstd/build/cmake-build/lib/libzstd.a)
     message(STATUS "Using precompiled zstd library")
     add_custom_target(zstd_external)

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -1083,6 +1083,17 @@ bool AgentSyncProtocol::applyHttpResult(int httpCode, std::string_view body, uin
             m_logger(LOG_DEBUG, "Manager reported not ready (503): " + std::string(body));
             break;
 
+        case 415: // Compression rejected. The agent's own RetrySender already reports this
+            // to the shared CompressionGate and retries once, uncompressed, within the same
+            // send() call -- this case is defense-in-depth for the rare compound failure
+            // where that one-shot retry doesn't land within the attempt budget. Treated as
+            // retryable, not a protocol violation: the manager will accept the next attempt
+            // once RetrySender's gate has disabled compression agent-wide.
+            m_syncState.lastSyncResult = SyncResult::COMMUNICATION_ERROR;
+            m_syncState.lastSyncManagerNotReady = true;
+            m_logger(LOG_DEBUG, "Manager rejected the compressed encoding (415): " + std::string(body));
+            break;
+
         case 0: // No HTTP response at all (timeout/connect/TLS failure/abort).
             m_syncState.lastSyncResult = SyncResult::COMMUNICATION_ERROR;
             m_syncState.lastSyncManagerNotReady = true;

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -1494,6 +1494,51 @@ TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckOffline)
     logCapture.expectDebugNotError("Manager reported not ready (503)");
 }
 
+TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckCompressionRejected)
+{
+    mockQueue = std::make_shared<MockPersistentQueue>();
+    LogCapture logCapture;
+    LoggerFunc testLogger = logCapture.logger();
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
+
+    // Enter in WaitingEndAck phase
+    std::thread syncThread([this]()
+    {
+        std::vector<PersistedData> testData =
+        {
+            {0, "test_id_1", "test_index_1", "test_data_1", Operation::CREATE, 1}
+        };
+
+        EXPECT_CALL(*mockQueue, fetchAndMarkForSync(_) )
+        .WillOnce(Return(testData));
+
+        protocol->synchronizeModule(
+            Mode::DELTA
+        );
+    });
+
+    // Wait for WaitingStartAck phase
+    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+
+    // StartAck
+
+    // Wait for WaitingEndAck phase
+    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+
+    // EndAck with 415: the manager rejected Content-Encoding: zstd. RetrySender's
+    // own one-shot retry already absorbs this in the common case; this is the
+    // rare compound-failure path where a raw 415 reaches the protocol layer.
+    bool response = feedHttpResult(415);
+
+    EXPECT_TRUE(response);
+
+    syncThread.join();
+
+    // Treated like 503 -- transient, retried next cycle, not a hard protocol
+    // violation that would drop the session's data.
+    logCapture.expectDebugNotError("Manager rejected the compressed encoding (415)");
+}
+
 TEST_F(AgentSyncProtocolTest, ParseResponseBufferWithEndAckSuccess)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -104,6 +104,7 @@ list(APPEND client-agent_flags "-Wl,--wrap,wurl_free_response -Wl,--wrap,wurl_ht
                                 -Wl,--wrap,try_enroll_to_server \
                                 -Wl,--wrap,CreateThread -Wl,--wrap,sleep -Wl,--wrap,getpid \
                                 -Wl,--wrap,w_agentd_state_update -Wl,--wrap,getDefine_Int \
+                                -Wl,--wrap,getDefine_Int_default \
                                 -Wl,--wrap,w_copy_file -Wl,--wrap,UnmergeFiles -Wl,--wrap,cldir_ex_ignore \
                                 -Wl,--wrap,wfopen \
                                 -Wl,--wrap,verifyRemoteConf -Wl,--wrap,reloadAgent \

--- a/src/unit_tests/client-agent/test_https_client_bridge.c
+++ b/src/unit_tests/client-agent/test_https_client_bridge.c
@@ -177,6 +177,23 @@ int __wrap_getDefine_Int(const char *high_name, const char *low_name, int min, i
     return 0;
 }
 
+/* bridge_build_config() also reads the compression toggle (#38308) via
+ * getDefine_Int_default(), which -- unlike getDefine_Int() above -- returns
+ * default_val instead of merror_exit()ing when the key is missing. No case
+ * here exercises it either, so answer with the shipped default. */
+int __wrap_getDefine_Int_default(const char *high_name, const char *low_name, int min, int max, int default_val)
+{
+    (void)high_name;
+    (void)min;
+    (void)max;
+
+    if (strcmp(low_name, "https_compression_enabled") == 0) {
+        return 0;
+    }
+
+    return default_val;
+}
+
 /* bridge_reenroll_thread is not static (see its own comment) precisely so it
  * can be called directly here, synchronously, bypassing w_create_thread.
  * g_https_client_stopping is likewise not static: setup_test() below resets

--- a/src/unit_tests/client-agent/test_https_client_bridge.c
+++ b/src/unit_tests/client-agent/test_https_client_bridge.c
@@ -177,7 +177,7 @@ int __wrap_getDefine_Int(const char *high_name, const char *low_name, int min, i
     return 0;
 }
 
-/* bridge_build_config() also reads the compression toggle (#38308) via
+/* bridge_build_config() also reads the compression toggle via
  * getDefine_Int_default(), which -- unlike getDefine_Int() above -- returns
  * default_val instead of merror_exit()ing when the key is missing. No case
  * here exercises it either, so answer with the shipped default. */


### PR DESCRIPTION
## Description

Adds optional zstd request-body compression (`Content-Encoding: zstd`) to the agent's outbound HTTPS traffic, mirroring the manager-side decode already merged in #38129. Every agent-to-manager send path — `/stateless`, `/control`, `/download` (WPK + config fetch), the periodic `/stats`+`/config` push, and now `/stateful` too — flows through one shared choke point (`RetrySender::attemptOnce()`), so compression is implemented once, there, instead of six times. `/stateful`'s body is a spool file read twice, independently, by the signer and the performer, which is why it needed its own design: a new `ZstdFileCompressor` compresses the spooled session once, up front (not per retry attempt), and hands `RetrySender` a precompressed sibling file it swaps in per attempt exactly like it already does for in-memory bodies — no changes to the shared retry loop itself.

The toggle is off by default and lives in `internal_options.conf` (`agent.https_compression_enabled`), not `client.conf` XML — this is an opt-in tuning knob, not user-facing configuration. On a `415` (the manager rejects `Content-Encoding: zstd`), the agent falls back permanently for the rest of its run: the in-flight request retries once, uncompressed, and a shared gate disables compression for every send path from then on — not a per-request retry, and not per-stream. zstd is vendored for every agent platform, including the Windows agent (winagent) — cross-compiled via MinGW, not stubbed out; publishing precompiled build artifacts for the packaging pipeline is the one piece still deferred to a follow-up.

Closes #38308.

## Proposed Changes

- **Build enablement**
  - `src/Makefile`: zstd moves out of the manager-only `EXTERNAL_RES` block into the base list every target already builds from — manager, Linux/macOS agent, and winagent alike.
  - `src/external/CMakeLists.txt`: zstd's build guard widens from `NOT IS_AGENT AND NOT IS_WINDOWS` to unconditional, with a Windows-specific branch that cross-compiles it via a nested `ExternalProject_Add` forwarding the already-cross-compiling top-level `CMAKE_C_COMPILER`/`CMAKE_CXX_COMPILER`/`CMAKE_AR`/`CMAKE_RANLIB` (mirrors this file's own GoogleTest Windows block) — its own `BINARY_DIR` so a Linux-built `libzstd.a` already on disk can never satisfy the Windows precompiled-artifact check or vice versa.
  - `src/client-agent/https_client/CMakeLists.txt`: links `ext_zstd` into `https_client`, the same target `remoted_module` already links for the manager-side decode. Also adds `-Wl,--exclude-libs,libzstd.a` to the winagent link flags: MinGW auto-exports every global symbol from a DLL by default (unlike ELF), so without this, zstd's own public API leaks into `https_client`'s export table and collides with the same symbols the unit test binary links directly (needed there to independently decompress and verify compressed bytes) — a real `multiple definition` link error without the fix, not a theoretical one.

- **Config toggle**
  - `etc/internal_options.conf`: new `agent.https_compression_enabled` (default `0`).
  - `src/client-agent/src/https_client_bridge.c`: reads it via `getDefine_Int_default` (defaults to off instead of aborting if the key is ever missing) into `hc_config_t`.
  - `include/https_client.h`, `moduleConfig.{hpp,cpp}`: threads the new field through to the C++ side.

- **Compression mechanism**
  - `retrySender.cpp/hpp`: `attemptOnce()` zstd-compresses in-memory bodies (level 3) immediately before signing, so the CMAC covers the compressed wire bytes, and adds the `Content-Encoding: zstd` header. A one-shot `ZSTD_compress()` failure — never expected, given the buffer is sized with `ZSTD_compressBound()` — falls through to sending uncompressed rather than losing the request. File-backed bodies (`/stateful`) take a parallel branch: if the caller populated `HttpRequestSpec::precompressedBodyFilePath` (see below), that file/size is swapped in instead, fresh on every attempt — so a `415` disabling the gate makes the very next attempt fall through to the original, untouched file automatically, with zero changes to `send()`'s retry loop.
  - `outcomeClassifier.cpp` / `httpTypes.hpp`: new `OutcomeClass::CompressionRejected` for HTTP `415`.
  - `compressionGate.hpp` (new): a one-way latch, shaped like the existing `AuthGate` — `reportRejected()` disables compression agent-wide; no `release()`, since the manager's lack of zstd support doesn't change without a restart.
  - `httpsClientFacade.cpp/hpp`: one `CompressionGate` per agent, shared into every stream's `RetrySender` (`statelessStream`, `statefulStream`, `controlStream`, `reporterStream`, `wpkFetcher`, `configFetcher`) — a `415` on any one of them disables compression on all of them.
  - `retrySender.cpp`'s `send()`: on `CompressionRejected`, reports to the shared gate first, then retries once — `attemptOnce()`'s own gate check means that retry is naturally uncompressed, with no separate "forced" parameter needed.
  - `fileCompressor.cpp/hpp` (new): `ZstdFileCompressor` streams a spool file through zstd in bounded 64 KiB chunks (matching `cmacSigner.cpp::signFile()`'s own chunking) into a new temp file, so a multi-MB `/stateful` session never sits fully in memory either as source or as compressed output. Checks a cooperative abort flag between chunks so compressing a large session can't stall agent shutdown.
  - `exclusiveTempFile.cpp/hpp` (new): the atomic, owner-only-permissions, symlink-attack-resistant temp file creation `TempSpoolFactory` already had, extracted into a primitive both it and `ZstdFileCompressor` share — including a fallback to `TMPDIR`/`TEMP`/`TMP`/`/tmp` when the caller's directory is empty, since nothing populates `ModuleConfig::spoolDir` today (a real bug this caught live — see Results and Evidence below).
  - `httpTypes.hpp`: `HttpRequestSpec` gains `precompressedBodyFilePath`/`precompressedBodyFileSize`, populated only by `/stateful` — every other send path leaves them empty/0, unaffected.
  - `statefulStream.cpp/hpp`: `sendSession()` compresses the spooled session once, up front, when enabled and the gate still allows it, holding the compressed `SpoolFile` alive for exactly the duration of the `send()` call.
  - `agent_sync_protocol.cpp`: `/stateful`'s own contract is interpreted from the raw HTTP status, not the shared `OutcomeClass` classifier above — it had no case for `415` at all, falling into a non-retryable `PROTOCOL_ERROR`. Added one, mapped like the existing `503` case, as defense-in-depth for the rare compound failure where `RetrySender`'s own one-shot retry doesn't land within the attempt budget.

- **Tests**
  - `retrySender_test.cpp`: 6 new cases covering compression on/off leaving body/headers untouched appropriately, the CMAC signing the compressed bytes, file-backed bodies being skipped, a `415` retrying once uncompressed and succeeding, that rejection disabling the shared gate for *other* senders, and a second rejection not looping.
  - `statelessStream_test.cpp`: 2 new cases — a compression rejection recovers and still delivers the event exactly once, and compression doesn't change the event-batching budget accounting.
  - `outcomeClassifier_test.cpp`: `415` → `CompressionRejected` added to the parameterized outcome table.
  - `moduleConfig_test.cpp`, `test_https_client_bridge.c`: default-off coverage for the new toggle.
  - `fileCompressor_test.cpp` (new, 7 cases): round-trip compress/decompress correctness, the pledged content size lands in the frame header, unreadable source, unwritable spool dir, empty spool dir (the bug above), mid-stream abort, and an empty source producing a valid minimal frame.
  - `retrySender_test.cpp`: 4 more new cases for the file-backed path — the precompressed-file swap signs over the compressed bytes, a `415` falls back to the original file and retries successfully, a second rejection with no gate still terminates without looping, and a file-backed sender correctly skips compression once another sender's `415` already disabled the shared gate.
  - `statefulStream_test.cpp`: 3 new cases — compression happens once and the temp file is deleted after `send()` returns, a compression failure falls back to the original file, and an already-disabled gate skips the compressor entirely.
  - `httpsClient_component_test.cpp`: a real curl request against the fake manager proves a compressed `/stateful` session shrinks on the wire and decompresses back to the original spooled bytes (needed linking `ext_zstd` into this test target, which didn't have it before).
  - `test_agent_sync_protocol.cpp`: the new `415` case, mirroring the existing `503` test.

- **Packaging**
  - `.github/actions/check_files/deb_linux_agent_amd64.csv`: `libhttps_client.so`'s expected installed size updated (zstd is now statically linked into it), measured from a real CI build of this branch rather than estimated. Only this one manifest was touched — the other platform manifests either use a different baseline or have no size check at all, so they're left alone pending their own measured evidence.

- **Cleanup**
  - Comments across the above files no longer reference this issue's own number — kept as durable explanations of *why*, not a changelog entry that rots once the issue closes. References to other, already-completed issues (e.g. prior `/stateless` and auth-gate work) are left as-is, since they still describe relevant prior design decisions.

### Results and Evidence

#### Automated test suites, by platform

<details>
<summary>Linux — 327/327 unit tests, 39/39 component tests (includes the `/stateful` file-backed compression work)</summary>

**Unit tests**

327/327 passing — 8 compression-specific cases on the original 5 send paths (6 in `RetrySenderTest`, 2 in `StatelessStreamTest`) plus the new `outcomeClassifier`/`moduleConfig`/bridge coverage, and 13 more for `/stateful`'s file-backed path (7 in `FileCompressorTest`, 4 more in `RetrySenderTest`, 3 in `StatefulStreamTest`; one of those 4 `RetrySenderTest` cases, `AuthFailureFromTheCompressionRetryStillGetsItsOwnGraceRetry`, predates `/stateful` and is listed here for completeness).

Reproduce from the repo root:

```
cd src
make deps TARGET=agent -j"$(nproc)"          # first build only
make TARGET=agent TEST=1 -j"$(nproc)"
./build/bin/https_client_unit_test
```

```
[==========] Running 327 tests from 31 test suites.
[==========] 327 tests from 31 test suites ran. (203 ms total)
[  PASSED  ] 327 tests.
```

The compression-specific subset in isolation:

```
./build/bin/https_client_unit_test --gtest_filter='RetrySenderTest.*Compress*:RetrySenderTest.*CompressionRejection*:RetrySenderTest.SecondCompressionRejectionTerminatesWithoutLooping:*OutcomeClassifier*:StatelessStreamTest.Compression*:StatefulStreamTest.*Compress*:FileCompressorTest.*'
```

```
[----------] 7 tests from FileCompressorTest
[       OK ] FileCompressorTest.RoundTripCompressesAndDecompressesBackToTheSource
[       OK ] FileCompressorTest.CompressedFrameDeclaresThePledgedContentSize
[       OK ] FileCompressorTest.UnreadableSourceReturnsNullopt
[       OK ] FileCompressorTest.UnwritableSpoolDirReturnsNullopt
[       OK ] FileCompressorTest.EmptySpoolDirFallsBackToADefaultTempDirectory
[       OK ] FileCompressorTest.AbortFlagStopsCompressionAndReturnsNullopt
[       OK ] FileCompressorTest.EmptySourceProducesAValidMinimalFrame
[----------] 2 tests from OutcomeClassifierTest
[----------] 10 tests from RetrySenderTest
[       OK ] RetrySenderTest.CompressionDisabledLeavesBodyAndHeadersUnchanged
[       OK ] RetrySenderTest.CompressedBodyIsSignedOverTheCompressedBytes
[       OK ] RetrySenderTest.CompressionEnabledSkipsFileBackedBodies
[       OK ] RetrySenderTest.CompressedAttemptRejectedWith415RetriesOnceUncompressedAndSucceeds
[       OK ] RetrySenderTest.CompressionRejectionDisablesTheSharedGateForOtherSenders
[       OK ] RetrySenderTest.SecondCompressionRejectionTerminatesWithoutLooping
[       OK ] RetrySenderTest.AuthFailureFromTheCompressionRetryStillGetsItsOwnGraceRetry
[       OK ] RetrySenderTest.CompressedFileBackedAttemptRejectedWith415RetriesOnceUncompressedAndSucceeds
[       OK ] RetrySenderTest.SecondFileBackedCompressionRejectionTerminatesWithoutLooping
[       OK ] RetrySenderTest.FileBackedSenderSkipsCompressionOnceTheSharedGateIsAlreadyDisabled
[----------] 3 tests from StatefulStreamTest
[       OK ] StatefulStreamTest.CompressionEnabledCompressesOnceAndCleansUpTheTempFile
[       OK ] StatefulStreamTest.CompressionFailureFallsBackToTheOriginalFileUncompressed
[       OK ] StatefulStreamTest.GateAlreadyDisabledSkipsCompressionEntirely
[----------] 2 tests from StatelessStreamTest
[       OK ] StatelessStreamTest.CompressionRejectionRecoversAndDeliversEventExactlyOnce
[       OK ] StatelessStreamTest.CompressionDoesNotChangeEventBatchingBudget
[----------] 20 tests from D9Table/OutcomeClassifierTable
[==========] 44 tests from 6 test suites ran. (3 ms total)
[  PASSED  ] 44 tests.
```

**Component tests**

39/39 passing:

```
./build/bin/https_client_component_test
```

```
[==========] Running 39 tests from 6 test suites.
[==========] 39 tests from 6 test suites ran. (22126 ms total)
[  PASSED  ] 39 tests.
```

(One earlier run, before the `/stateful` work landed, showed a single failure, `FacadeE2eTest.AHeldStatefulRequestDoesNotStallStatelessOrControl` — a pre-existing timing-based e2e test for a prior, unrelated `/stateful` concurrency guarantee, in a file this PR never touches. It passed 3/3 in isolation and cleanly on every subsequent full-suite run, including the one above, consistent with contention-driven flakiness under parallel test execution rather than a regression from this change.)

</details>

<details>
<summary>Windows (winagent, cross-compiled via MinGW) — 310/310 unit tests, verified both under Wine and on a real Windows 11 machine</summary>

Cross-compiling for winagent isn't just "does it build" — the full chain was verified: the zstd library itself cross-compiles and links into `libhttps_client.dll` (confirmed via `nm`: real `ZSTD_compress`/`ZSTD_compressBound` symbols present in the binary, and via `strings`: the literal `Content-Encoding: zstd` string is embedded in it), and the same gtest suite that runs on Linux was built and actually *executed* for Windows, twice, independently:

- Once emulated, via Wine (`i686`, run on the Linux build host).
- Once on a real, native Windows 11 machine — no emulation at all.

Both runs: **310/310 passing**, including all 8 compression-specific tests (the two-fewer-than-Linux's-312 gap is a pre-existing, unrelated platform exclusion elsewhere in the suite, not something this PR introduced or touches).

Reproduce (needs a MinGW cross-compile toolchain, e.g. `gcc-mingw-w64 g++-mingw-w64`, and `wine`+`wine32`/i386 multiarch to run the tests without real Windows hardware):

```
cd src
make deps TARGET=winagent -j"$(nproc)"
make TARGET=winagent TEST=1 -j"$(nproc)"
wine ./build/bin/https_client_unit_test.exe        # or copy it to a real Windows machine and run it directly
```

```
[==========] Running 310 tests from 30 test suites.
[==========] 310 tests from 30 test suites ran. (8511 ms total)
[  PASSED  ] 310 tests.
```

```
[ RUN      ] RetrySenderTest.CompressionDisabledLeavesBodyAndHeadersUnchanged
[       OK ] RetrySenderTest.CompressionDisabledLeavesBodyAndHeadersUnchanged (0 ms)
[ RUN      ] RetrySenderTest.CompressedBodyIsSignedOverTheCompressedBytes
[       OK ] RetrySenderTest.CompressedBodyIsSignedOverTheCompressedBytes (12 ms)
[ RUN      ] RetrySenderTest.CompressionEnabledSkipsFileBackedBodies
[       OK ] RetrySenderTest.CompressionEnabledSkipsFileBackedBodies (4 ms)
[ RUN      ] RetrySenderTest.CompressedAttemptRejectedWith415RetriesOnceUncompressedAndSucceeds
[       OK ] RetrySenderTest.CompressedAttemptRejectedWith415RetriesOnceUncompressedAndSucceeds (0 ms)
[ RUN      ] RetrySenderTest.CompressionRejectionDisablesTheSharedGateForOtherSenders
[       OK ] RetrySenderTest.CompressionRejectionDisablesTheSharedGateForOtherSenders (8 ms)
[ RUN      ] RetrySenderTest.SecondCompressionRejectionTerminatesWithoutLooping
[       OK ] RetrySenderTest.SecondCompressionRejectionTerminatesWithoutLooping (7 ms)
[ RUN      ] StatelessStreamTest.CompressionRejectionRecoversAndDeliversEventExactlyOnce
[       OK ] StatelessStreamTest.CompressionRejectionRecoversAndDeliversEventExactlyOnce (411 ms)
[ RUN      ] StatelessStreamTest.CompressionDoesNotChangeEventBatchingBudget
[       OK ] StatelessStreamTest.CompressionDoesNotChangeEventBatchingBudget (168 ms)
```

**Operational note for anyone deploying the raw agent binaries manually (outside the installer):** `libhttps_client.dll` depends on `libwazuhext.dll` at runtime — not obvious from the build output, easy to miss if you're only copying the two files you'd expect.

**Known gap — this Windows run predates the `/stateful` work.** Everything above (zstd cross-compiling into the DLL, both Wine and real-Windows-11 runs, the 310/310 count) covers the original 5 send paths only. `fileCompressor.cpp/hpp`, `exclusiveTempFile.cpp/hpp`, and the `/stateful`-side changes have **not** been cross-compiled or run for `winagent` — this follow-up round only had a Linux Docker environment available, with no MinGW toolchain. Nothing in the new code is platform-specific (no `#ifdef _WIN32` branches, same `ZSTD_compressStream2` API already proven to cross-compile above), but that's an expectation, not evidence. Flagging this explicitly rather than letting the 310/310 count above imply coverage it doesn't have; a winagent build+test run for these specific files is still owed before merge.

</details>

#### Live agent↔manager evidence

Self-comparison on one real agent build from this branch, enrolled against a real manager: `agent.https_compression_enabled` toggled OFF vs. ON, same build, same config, same workload, restarting the agent between phases so the change actually takes effect.

Bandwidth is measured with a `tcpdump` capture scoped to the manager's host and HTTPS port, running for the duration of each workload window; the reported byte count sums the frame lengths of packets sourced from the agent's own IP (egress-only, isolated from any other traffic on the interface):

| Send path | OFF (bytes) | ON (bytes) | Reduction |
|---|---|---|---|
| `/stateless` (500× a compressible test event) | 130886 | 23317 | 82.2% |
| `/control` (restart handshake, 3s window) | 11676 | 11281 | 3.4% |
| `/stats` + `/config` (periodic push, 25s window) | 43529 | 30497 | 29.9% |
| `/download` (WPK + config fetch) | not exercised live — needs a deliberate config-hash mismatch or a remote-upgrade task; not attempted in this run | | |
| `/stateful` | see the dedicated section below | | |

Reproduce (against any manager + agent pair with this build installed on the agent, HTTPS port `1517`):

```
# On the agent, toggle and restart:
echo 'agent.https_compression_enabled=1' >> /var/ossec/etc/local_internal_options.conf   # or =0 for the baseline
systemctl restart wazuh-agent

# Capture for the duration of a workload window (a burst of log lines for
# /stateless, the restart itself for /control, or a plain wait for the
# periodic /stats+/config push):
tcpdump -i eth0 -w capture.pcap 'host <manager-address> and tcp port 1517'
# ... let the workload run, then stop tcpdump ...

# Sum egress-only bytes:
tshark -r capture.pcap -Y 'ip.src==<agent-ip>' -T fields -e frame.len \
  | awk '{s+=$1} END{print s+0}'
```

**Regression check:** the agent's HTTPS client stayed connected throughout, including immediately after enabling compression and restarting — no repeated "failed to communicate with the manager" in the log.

#### TLS-decrypted mechanism proof

Byte-count deltas prove the wire payload shrank; to prove *why*, the same captures were decrypted and the actual HTTP headers inspected. The agent process was started with `SSLKEYLOGFILE` set (a `systemd` drop-in `Environment=SSLKEYLOGFILE=<path>` on the `wazuh-agent` service is enough — the agent's vendored, statically-linked curl+OpenSSL honors it with no code change), and `tshark` decrypted each capture with that keylog:

| Phase | Decrypted `Content-Encoding` values seen | Sample decrypted request |
|---|---|---|
| OFF | none | `POST /stateless` — no `Content-Encoding` header, 99836-byte body |
| ON | `zstd` | `POST /stateless` — `Content-Encoding: zstd`, 388-byte body |

Reproduce, against the same capture used above:

```
tshark -r capture.pcap -o tls.keylog_file:<sslkeylogfile-path> \
  -Y 'http.request and http.content_encoding' \
  -T fields -e http.request.uri -e http.content_encoding
```

Decrypting every send path's ON-phase capture together (not just `/stateless`) shows the same `Content-Encoding` applied uniformly, confirming compression really does happen once, at one shared point, rather than being duplicated per endpoint:

| Request URI | Content-Encoding |
|---|---|
| `/config` | zstd |
| `/control` | zstd |
| `/stateless` | zstd |
| `/stats` | zstd |

#### `/stateful` file-backed compression

The 327/39 Linux counts above already include this work's 13 new unit tests and 1 new component test. Also run clean under ASan + LeakSanitizer + UBSan (`FSANITIZE=1`) — only a pre-existing, unrelated `moduleConfig.cpp` UBSan finding remains (undefined behavior in `verify_mode` validation, nothing to do with compression). Not yet cross-compiled or run for `winagent` — see the Windows section's own caveat above.

Live, against the real manager — same self-comparison method as above:

Before (captured with the `spoolDir`-empty bug still live, so it's a real "compression silently not happening" sample, not a synthetic baseline):
```
$ tshark -r cap_stateful_compress.pcap -o tls.keylog_file:agent_sslkeylog.txt \
    -Y 'http.request and http.request.uri == "/stateful"' \
    -T fields -e http.request.method -e http.request.uri -e http.content_encoding -e http.content_length

POST	/stateful		440
POST	/stateful		610656
POST	/stateful		610656
POST	/stateful		610656
POST	/stateful		610656
POST	/stateful		610656
```

After (same agent, same workload, only the `spoolDir` fallback fix applied):
```
$ tshark -r cap_stateful_fix.pcap -o tls.keylog_file:agent_sslkeylog.txt \
    -Y 'http.request and http.request.uri == "/stateful"' \
    -T fields -e http.request.method -e http.request.uri -e http.content_encoding -e http.content_length

POST	/stateful	zstd	288
POST	/stateful	zstd	79123
POST	/stateful	zstd	79123
POST	/stateful	zstd	79123
POST	/stateful	zstd	79123
POST	/stateful	zstd	79123
```

Not just a header — the wire bytes are genuinely valid, correct zstd. Pulled the actual request body for one of the `79123`-byte frames out of the decrypted capture and decompressed it with the real zstd library:
```
$ tshark -r cap_stateful_fix.pcap -o tls.keylog_file:agent_sslkeylog.txt \
    -Y 'frame.number==315' -T pdml | grep -o 'name="data" value="[a-f0-9]*"'
# extracted 79123 bytes, first 4 bytes: 28 b5 2f fd  (the real zstd magic number)

$ python3 -c "
import ctypes
zstd = ctypes.CDLL('libzstd.so.1')
data = open('frame315_body.zst','rb').read()
zstd.ZSTD_getFrameContentSize.restype = ctypes.c_ulonglong
print('declared decompressed size:', zstd.ZSTD_getFrameContentSize(data, len(data)))
buf = ctypes.create_string_buffer(610656)
zstd.ZSTD_decompress.restype = ctypes.c_size_t
print('actually decompressed:', zstd.ZSTD_decompress(buf, 610656, data, len(data)), 'bytes')
"

declared decompressed size: 610656
actually decompressed: 610656 bytes
```
`610656` is exactly the uncompressed byte count from the "before" capture — the compressed frame that actually went out on the wire decompresses back to precisely the original session size, byte for byte.

**One real bug this caught:** the first live attempt sent uncompressed despite everything passing in tests — traced to `ModuleConfig::spoolDir` being empty in production (nothing populates it) with no fallback in the new compressor, unlike `TempSpoolFactory`'s own constructor. Fixed by moving the fallback into the shared `exclusiveTempFile` primitive, added a regression test (`EmptySpoolDirFallsBackToADefaultTempDirectory`), reconfirmed live (the "after" capture above).

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows — true for the original 5 send paths (see the Windows evidence section above), but the `/stateful` file-backed compression files added in this round have not yet been cross-compiled for `winagent`; unchecking until that run happens
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer (+ LeakSanitizer + UBSan, `FSANITIZE=1` -- whole `https_client` suite, not just `/stateful`)
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - N/A

- Engine _(Wazuh v5.x and above)_
  - N/A

- Wazuh server API/Framework
  - N/A

### Artifacts Affected

- `libhttps_client.so` (Linux agent, amd64): grows because zstd is now statically linked in — packaging manifest (`deb_linux_agent_amd64.csv`) updated with the real measured size.
- `libhttps_client.dll` (winagent): same growth, zstd statically linked in; no Windows packaging manifest currently checks this library's size, so no manifest update needed there.
- No new executables or packages.

### Configuration Changes

- New `internal_options.conf` key: `agent.https_compression_enabled` (`0`/`1`, default `0`). This is an internal tuning knob, not a `client.conf`/XML setting, and is fully backward-compatible — an agent with no opinion on it behaves exactly as before.

### Tests Introduced

- 6 new `RetrySenderTest` cases and 2 new `StatelessStreamTest` cases directly exercising compress/retry/gate behavior, plus a new `outcomeClassifier` parameterized case and default-off coverage in `moduleConfig`/bridge tests — see Results and Evidence above for the full run.
- The shared-gate-across-streams behavior (one `415` disabling compression for every send path) is covered at the unit level via direct constructor injection of a shared `CompressionGate`, rather than a new component/e2e test — it doesn't depend on real sockets, so the unit-level test is the more direct proof.
- `/stateful`: a new `fileCompressor_test.cpp` (7 cases) plus 4 more `RetrySenderTest` cases, 3 more `StatefulStreamTest` cases, a new component test proving a real compressed session decompresses correctly, and a new `test_agent_sync_protocol.cpp` case for the `415` handling — see the dedicated evidence section above.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes (module header/Doxygen comments updated for the affected files, per this codebase's convention -- no separate README exists for this module)
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

