### PR TITLE
Serialize sca.policies and package_uninstallation as objects in the agent config report

### DIFF
--- a/src/client-agent/src/config.c
+++ b/src/client-agent/src/config.c
@@ -209,7 +209,7 @@ cJSON *getAntiTamperingConfig(void) {
     }
 
     cJSON *root = cJSON_CreateObject();
-    cJSON *package_uninstallation = cJSON_CreateArray();
+    cJSON *package_uninstallation = cJSON_CreateObject();
 
     if (atc->package_uninstallation) cJSON_AddStringToObject(package_uninstallation,"package_uninstallation","yes"); else cJSON_AddStringToObject(package_uninstallation,"package_uninstallation","no");
 

--- a/src/wazuh_modules/src/wm_sca.c
+++ b/src/wazuh_modules/src/wm_sca.c
@@ -799,7 +799,9 @@ cJSON *wm_sca_dump(const wm_sca_t * data) {
         int i;
         for (i=0;data->policies[i];i++) {
             if(data->policies[i]->enabled == 1){
-                cJSON_AddStringToObject(policies, "policy", data->policies[i]->policy_path);
+                cJSON *policy_entry = cJSON_CreateObject();
+                cJSON_AddStringToObject(policy_entry, "policy", data->policies[i]->policy_path);
+                cJSON_AddItemToArray(policies, policy_entry);
             }
         }
         cJSON_AddItemToObject(wm_wd,"policies", policies);


### PR DESCRIPTION
## Description

Closes #38341

Two fields of the agent's reported configuration are built as a cJSON **array** and then filled with
`cJSON_AddStringToObject`. That call attaches a key to the item, but cJSON drops the key when the parent is an
array, so the key only ever exists in the source. What leaves the agent is a bare list of strings.

```c
/* src/wazuh_modules/src/wm_sca.c:796 */
if (data->policies && *data->policies) {
    cJSON *policies = cJSON_CreateArray();
    int i;
    for (i=0;data->policies[i];i++) {
        if(data->policies[i]->enabled == 1){
            cJSON_AddStringToObject(policies, "policy", data->policies[i]->policy_path);
        }
    }
    cJSON_AddItemToObject(wm_wd,"policies", policies);
}
```

```c
/* src/client-agent/src/config.c:211 */
cJSON *package_uninstallation = cJSON_CreateArray();

if (atc->package_uninstallation) cJSON_AddStringToObject(package_uninstallation,"package_uninstallation","yes");
else                             cJSON_AddStringToObject(package_uninstallation,"package_uninstallation","no");
```

On the wire:

```json
"policies": ["/var/ossec/ruleset/sca/cis_ubuntu24-04.yml"]
"package_uninstallation": ["no"]
```

This was harmless while nothing typed the output. It stops being harmless with the periodic `POST /config`
push: the `wazuh-agent-config` index template created in
[wazuh-indexer-plugins#1419](https://github.com/wazuh/wazuh-indexer-plugins/issues/1419) declares both paths as
objects (`content.sca.policies.policy` and `content.agent.package_uninstallation.package_uninstallation`, in
`wcs/stateful/agent-config/fields/custom/wazuh.yml` lines 1890 and 323) - exactly the names this code intends
to write. The indexer rejects the **whole document** on every cycle:

```
2026/08/12 07:22:41 wazuh-manager-modulesd:inventory-sync-server:async(indexer-connector): WARNING:
  Error indexing document (type mapper_parsing_exception - reason: 'object mapping for
  [wazuh.agent.configuration.content.agent.package_uninstallation] tried to parse field [null] as object,
  but found a concrete value') - Associated event: {"index":{"_index":"wazuh-agent-config","_id":"001"}}
```

`GET wazuh-agent-config/_count` stays at `0` indefinitely, so no agent configuration is ever stored.

This is not a regression of the HTTPS work. The SCA line dates back to 680560e502 (2019) and the
anti-tampering one to d2e2e0dee0 (2024), and both are identical in `5.0.0`. The HTTPS periodic report is just
the first consumer that types the output.

`src/shared/include/module_report.h:14-28` and the manager's `configEndpoint` only fix the **envelope**: a
report keyed by module name, which the manager moves under `wazuh.agent.configuration.content` after sanitising
the outer `{module, config}` pair, never the fields inside `config` itself. Nothing in the agent or the manager
declares the shape of the fields inside a module, so the only written-down description of those inner fields is
the indexer's WCS, modelled from the intent rather than from captured traffic. The two drifted apart without
anyone noticing.

## Proposed Changes

Emit the object shape the code already intended. No indexer-side change is needed.

- `src/wazuh_modules/src/wm_sca.c`: build one object per enabled policy and append it to the array with
  `cJSON_AddItemToArray`, so the `policy` key survives.
- `src/client-agent/src/config.c`: create `package_uninstallation` as an object instead of an array, so the
  single `cJSON_AddStringToObject` keeps its key.

```diff
--- a/src/wazuh_modules/src/wm_sca.c
+++ b/src/wazuh_modules/src/wm_sca.c
@@ -799,7 +799,9 @@ cJSON *wm_sca_dump(const wm_sca_t * data) {
             if(data->policies[i]->enabled == 1){
-                cJSON_AddStringToObject(policies, "policy", data->policies[i]->policy_path);
+                cJSON *policy_entry = cJSON_CreateObject();
+                cJSON_AddStringToObject(policy_entry, "policy", data->policies[i]->policy_path);
+                cJSON_AddItemToArray(policies, policy_entry);
             }
--- a/src/client-agent/src/config.c
+++ b/src/client-agent/src/config.c
@@ -209,7 +209,7 @@ cJSON *getAntiTamperingConfig(void) {
     cJSON *root = cJSON_CreateObject();
-    cJSON *package_uninstallation = cJSON_CreateArray();
+    cJSON *package_uninstallation = cJSON_CreateObject();
```

The same getters serve the legacy `getconfig` path, so two API responses change shape:

| Endpoint | Before | After |
|---|---|---|
| `GET /agents/{id}/config/sca/sca` | `"policies": ["/path"]` | `"policies": [{"policy": "/path"}]` |
| `GET /agents/{id}/config/agent/anti_tampering` | `"package_uninstallation": ["no"]` | `"package_uninstallation": {"package_uninstallation": "no"}` |

The second one only affects Linux and macOS agents (the block is `#ifndef WIN32`). Nothing inside this
repository consumes either field: no C/C++ code parses them back (both getters are write-only producers),
`wm_sca_dump` is wired only as `.dump` (`src/wazuh_modules/src/wm_sca.c:110`), `getAntiTamperingConfig` is
stubbed out in `src/unit_tests/client-agent/test_agcom.c:47` so no test asserts its shape,
`src/config/src/wmodules-sca.c:19` is the `ossec.conf` parser on the input side, and the `"policies"` handled by
`sca_impl` and the engine's `scaInternal` builders belong to SCA **events**, a different structure that is
already an array of objects. The Python framework builds its file-based configuration view straight from the
XML (`framework/wazuh/core/configuration.py:73` and `:192`), so `GET /manager/configuration` is unaffected.
Any external integration reading those two routes and expecting the flat list would need to adapt, but no
changelog entry is added: the whole agent-manager transport is being reworked in `5.0.0-https` and these two
routes change with it.

### Results and Evidence

Same environment in both runs: manager and agent packages built from `5.0.0-https` @ `1e8c01b0b7` with
`packages/generate_package.sh`, and the `wazuh-agent-config` template exactly as merged in
wazuh-indexer-plugins#1426, never relaxed. Agent configured with
`<config_report><enabled>yes</enabled><interval>20s</interval></config_report>`.

**Before.** Every cycle rejected, index empty:

```
2026/08/12 07:22:41 wazuh-manager-modulesd:inventory-sync-server:async(indexer-connector): WARNING:
  Error indexing document (type mapper_parsing_exception - reason: 'object mapping for
  [wazuh.agent.configuration.content.agent.package_uninstallation] tried to parse field [null] as object,
  but found a concrete value')
2026/08/12 07:23:01 ... (same, every 20s)

$ curl -s localhost:9201/wazuh-agent-config/_count
{"count":0,...}
```

Removing the first offender surfaces the second, which fails identically:

```
... 'object mapping for [wazuh.agent.configuration.content.sca.policies] tried to parse field [null]
    as object, but found a concrete value'
```

**After.** Agent rebuilt with the patch and installed over the running one, nothing else changed:

```
$ curl -s localhost:9201/wazuh-agent-config/_doc/001
_version 2   modules 10
agent.package_uninstallation = {"package_uninstallation": "no"}
sca.policies                 = [{"policy": "/var/ossec/ruleset/sca/cis_ubuntu24-04.yml"}]
modified_at 2026-08-12T08:42:38.888Z
```

Last `mapper_parsing_exception` in the manager log: `08:41:42`. First document stored: `08:42:38`, already with
the patched agent. No further mapping errors, and the ten reporting modules are all present.

A shape check of the full document against the template shows no other mismatch:

```
modules reported: 10 -> ['agent', 'agent-info', 'agent-upgrade', 'execd', 'fim', 'logcollector',
                         'sca', 'syscollector', 'wazuh_control', 'wmodules']
SHAPE MISMATCHES (document rejected by the mapping): 2   <- the two above, none left after the patch
PATHS NOT IN THE TEMPLATE: 4
  content.wmodules.internal_options.wazuh_modules.{debug,kill_timeout,max_eps,task_nice}
```

The four unmapped paths are stored but not indexed (the template is `dynamic: true`). They are an indexer-side
gap, not a blocker, and are reported separately.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

`wazuh-modulesd` and `wazuh-agentd` (Linux and macOS agent packages; the anti-tampering block is `#ifndef WIN32`).

### Configuration Changes

N/A

### Tests Introduced

N/A

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
