### PR TITLE
Resolve symlink target before registering FIM whodata audit rule

### DIFF
--- a/src/syscheckd/src/run_realtime.c
+++ b/src/syscheckd/src/run_realtime.c
@@ -120,7 +120,9 @@ int realtime_adddir(const char *dir, directory_t *configuration) {
 
 #ifdef ENABLE_AUDIT
     if ((mode == FIM_WHODATA) && syscheck.whodata_provider == AUDIT_PROVIDER) {
-        add_whodata_directory(dir);
+        char *real_path = fim_get_real_path(configuration);
+        add_whodata_directory(*real_path == '\0' ? dir : real_path);
+        os_free(real_path);
         return 1;
     }
 #endif


### PR DESCRIPTION
## Description

FIM whodata stopped detecting modify/delete events for files reached through a monitored symlink (`follow_symbolic_link="yes"`) on systems with newer auditd/kernel (reported on Ubuntu 24.04, auditd 3.1.2, kernel 6.8).

Root cause is in `src/syscheckd/src/run_realtime.c:118-125`, `realtime_adddir()`:

```c
int realtime_adddir(const char *dir, directory_t *configuration) {
    int mode = FIM_MODE(configuration->options);

#ifdef ENABLE_AUDIT
    if ((mode == FIM_WHODATA) && syscheck.whodata_provider == AUDIT_PROVIDER) {
        add_whodata_directory(dir);
```

`dir` here is the raw, as-configured directory path — the symlink itself, not its target. `add_whodata_directory()` stores that string verbatim and `fim_audit_reload_rules()` (`src/syscheckd/src/whodata/audit_rule_handling.c:201`) later hands it straight to `audit_add_rule()`, so the kernel watch (`auditctl -w`) ends up registered on the symlink path.

This is inconsistent with `fim_rules_initial_load()` (`audit_rule_handling.c:108`), which already resolves the monitored path through `fim_get_real_path()` before registering its rule — `realtime_adddir()` is the one call site that skipped that resolution.

Reproduced directly at the kernel/auditd level, independent of Wazuh (Ubuntu 24.04, auditd 3.1.2, kernel 6.8):

```
# auditctl -w /tmp/symlink -p wa -k probe_symlink   (symlink -> /tmp/target)
# echo x > /tmp/symlink/probe.txt
# cat /var/log/audit/audit.log
                                                      <-- no record at all

# auditctl -w /tmp/target -p wa -k probe_symlink     (real path)
# echo x > /tmp/symlink/probe.txt
type=SYSCALL msg=audit(...): ... key="probe_symlink" ... SYSCALL=openat ...
type=PATH msg=audit(...): item=0 name="/tmp/target/" ... nametype=PARENT
type=PATH msg=audit(...): item=1 name="/tmp/target/probe.txt" ... nametype=CREATE
```

A watch registered on a symlink path never fires for operations reached through it on this auditd/kernel combination — the rule looks "added" (`auditctl -l` happily prints `-w /tmp/symlink ...`), but the kernel never delivers events for it. Since `fim_rules_initial_load()` resolves correctly, `create` (routed through the initial load path in some configurations) could still work while `modify`/`delete` — driven through `realtime_adddir()` on the real-time re-scan path — silently stopped generating events, matching the symptom reported in #35481.

Closes #35481

## Proposed Changes

- `src/syscheckd/src/run_realtime.c`: `realtime_adddir()` now resolves the directory through `fim_get_real_path(configuration)` (same helper already used by `fim_rules_initial_load()`) before calling `add_whodata_directory()`, falling back to the raw `dir` only when the link is broken (`fim_get_real_path()` returns an empty string in that case).

```c
char *real_path = fim_get_real_path(configuration);
add_whodata_directory(*real_path == '\0' ? dir : real_path);
os_free(real_path);
```

### Results and Evidence

Built `wazuh-agent` and a minimal `wazuh-manager` (authd + remoted + wdb) from this branch, ran a real enrolled agent with `whodata="yes" realtime="yes" follow_symbolic_link="yes"` on `/tmp/symlink` (-> `/tmp/target`), on an Ubuntu 24.04 / auditd 3.1.2 / kernel 6.8 VM.

**Before the fix** — rule lands on the symlink path, create/modify/delete via the symlink produce nothing:

```
wazuh-syscheckd: DEBUG: Audit rule loaded: -w /tmp/symlink -p wa -k wazuh_fim
```
```
$ echo hello > /tmp/symlink/testie.txt   # (and modify / delete afterwards)
$ grep 'Sending FIM event' ossec.log
                                          <-- no output, for all three operations
```

**After the fix** — rule lands on the resolved target, all three operations are reported:

```
wazuh-syscheckd: DEBUG: Audit rule loaded: -w /tmp/target -p wa -k wazuh_fim
```
```
run_check.c:367 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"data":{"event":{"type":"added"},"file":{"path":"/tmp/target/testie.txt","mode":"whodata", ...}}}
run_check.c:367 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"data":{"event":{"type":"modified", ...},"file":{"path":"/tmp/target/testie.txt","mode":"whodata", ...}}}
run_check.c:367 at send_syscheck_msg(): DEBUG: (6321): Sending FIM event: {"data":{"event":{"type":"deleted"},"file":{"path":"/tmp/target/testie.txt","mode":"whodata", ...}}}
```

Legacy unit test suite (`src/unit_tests/build`, `TARGET=agent`) passes in full, 102/102, including the directly affected suites:

```
Start 46: test_run_realtime ................   Passed    0.03 sec
Start 49: test_run_check ...................   Passed    0.02 sec
Start 56: test_audit_rule_handling .........   Passed    0.01 sec
Start 57: test_syscheck_audit ..............   Passed    0.07 sec
...
100% tests passed, 0 tests failed out of 102
```

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

`wazuh-agent` binary (Linux, `wazuh-syscheckd` — code is under `#ifdef ENABLE_AUDIT`, Linux-only).

### Configuration Changes

N/A

### Tests Introduced

N/A

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
