### PR TITLE
Backport: Free rpm macro context to stop unbounded growth

### DIFF
--- a/src/data_provider/src/packages/rpmPackageManager.cpp
+++ b/src/data_provider/src/packages/rpmPackageManager.cpp
@@ -40,6 +40,11 @@ RpmPackageManager::RpmPackageManager(std::shared_ptr<IRpmLibWrapper>&& wrapper)
 
 RpmPackageManager::~RpmPackageManager()
 {
+    // the constructor's rpmReadConfigFiles() call loads macros into rpm's
+    // process-global macro context (rpmInitMacros()), which is never cleared automatically.
+    // rpmFreeRpmrc() alone does not free it (different subsystem) — without this, every
+    // construct/destruct cycle of RpmPackageManager permanently grows that global table.
+    m_rpmlib->rpmFreeMacros();
     m_rpmlib->rpmFreeRpmrc();
     ms_instantiated = false;
 }

--- a/src/data_provider/src/packages/rpmlib.h
+++ b/src/data_provider/src/packages/rpmlib.h
@@ -27,6 +27,19 @@ class RpmLib final : public IRpmLibWrapper
             ::rpmFreeRpmrc();
         }
 
+        void rpmFreeMacros() override
+        {
+            // rpmReadConfigFiles() (called from RpmPackageManager's constructor,
+            // once per scanPackages() cycle) calls rpmInitMacros() internally, which PUSHES
+            // built-in + config-file macros onto rpm's process-global macro context every time,
+            // without clearing it first (confirmed in rpm/rpmio/macro.c). rpmFreeRpmrc() alone
+            // does not undo this — it's a different subsystem (platform/arch tables). Only
+            // rpmFreeMacros() empties the macro table; rpm's own reference CLI (poptALL.c) calls
+            // both together on exit. Without this, every scan cycle permanently grows rpm's
+            // global macro table — a genuine accumulating leak in third-party library state.
+            ::rpmFreeMacros(nullptr);
+        }
+
         rpmtd rpmtdNew() override
         {
             return ::rpmtdNew();

--- a/src/data_provider/src/packages/rpmlibWrapper.h
+++ b/src/data_provider/src/packages/rpmlibWrapper.h
@@ -15,6 +15,7 @@
 #include <rpm/header.h>
 #include <rpm/rpmdb.h>
 #include <rpm/rpmlib.h>
+#include <rpm/rpmmacro.h>
 #include <rpm/rpmts.h>
 
 class IRpmLibWrapper
@@ -25,6 +26,7 @@ class IRpmLibWrapper
         // LCOV_EXCL_STOP
         virtual int rpmReadConfigFiles(const char* file, const char* target) = 0;
         virtual void rpmFreeRpmrc() = 0;
+        virtual void rpmFreeMacros() = 0;
         virtual rpmtd rpmtdNew() = 0;
         virtual void rpmtdFree(rpmtd td) = 0;
         virtual rpmts rpmtsCreate() = 0;

--- a/src/data_provider/tests/sysInfoPackageLinuxParserRpm/sysInfoPackageLinuxParserRPM_test.cpp
+++ b/src/data_provider/tests/sysInfoPackageLinuxParserRpm/sysInfoPackageLinuxParserRPM_test.cpp
@@ -16,6 +16,7 @@
 #include <rpm/rpmdb.h>
 #include <rpm/rpmlib.h>
 #include <rpm/rpmts.h>
+#include <rpm/rpmmacro.h>
 #include <db.h>
 
 
@@ -48,6 +49,7 @@ class RpmLibMock
     public:
         MOCK_METHOD(int, rpmReadConfigFiles, (const char* file, const char* target));
         MOCK_METHOD(void, rpmFreeRpmrc, ());
+        MOCK_METHOD(void, rpmFreeMacros, ());
         MOCK_METHOD(rpmtd, rpmtdNew, ());
         MOCK_METHOD(rpmtd, rpmtdFree, (rpmtd td));
         MOCK_METHOD(rpmts, rpmtsCreate, ());
@@ -78,6 +80,11 @@ int rpmReadConfigFiles(const char* file, const char* target)
 void rpmFreeRpmrc()
 {
     gs_rpm_mock->rpmFreeRpmrc();
+}
+void rpmFreeMacros(rpmMacroContext mc)
+{
+    (void)mc;
+    gs_rpm_mock->rpmFreeMacros();
 }
 rpmtd rpmtdNew()
 {
@@ -402,6 +409,7 @@ TEST(SysInfoPackageLinuxParserRPM_test, rpmFromLibRPM)
     EXPECT_CALL(*rpm_mock, rpmtdFree(_)).Times(1).WillOnce(Return(nullptr));
     EXPECT_CALL(*rpm_mock, rpmdbFreeIterator(_)).Times(1).WillOnce(Return(nullptr));
     EXPECT_CALL(*rpm_mock, rpmFreeRpmrc());
+    EXPECT_CALL(*rpm_mock, rpmFreeMacros());
 
     EXPECT_CALL(*rpm_mock, headerGet(_, _, _, _)).Times(AnyNumber()).WillRepeatedly(Return(1));
 

--- a/src/data_provider/tests/sysInfoRpmPackageManager/RpmPackageManager_test.cpp
+++ b/src/data_provider/tests/sysInfoRpmPackageManager/RpmPackageManager_test.cpp
@@ -34,6 +34,7 @@ class RpmLibMock : public IRpmLibWrapper
         virtual ~RpmLibMock() override {};
         MOCK_METHOD(int, rpmReadConfigFiles, (const char* file, const char* target), (override));
         MOCK_METHOD(void, rpmFreeRpmrc, (), (override));
+        MOCK_METHOD(void, rpmFreeMacros, (), (override));
         MOCK_METHOD(rpmtd, rpmtdNew, (), (override));
         MOCK_METHOD(void, rpmtdFree, (rpmtd td), (override));
         MOCK_METHOD(rpmts, rpmtsCreate, (), (override));
@@ -96,6 +97,7 @@ TEST(RpmLibTest, RAII)
 {
     auto mock {std::make_shared<NiceMock<RpmLibMock>>()};
     EXPECT_CALL(*mock, rpmReadConfigFiles(_, _)).WillOnce(Return(0));
+    EXPECT_CALL(*mock, rpmFreeMacros());
     EXPECT_CALL(*mock, rpmFreeRpmrc());
     {
         RpmPackageManager rpm{mock};


### PR DESCRIPTION
## Description

Related to #38364.

- Backport of #37758 to the 4.14 line.
The fix was merged into `5.0.0` on 2026-07-20 and never backported, so it is present in every 4.14.x release published so far.

This PR addresses only the first of the three findings tracked in #38364, which is why it does not close it. The remaining two are handled in their own PRs and the issue stays open until all three are merged.

## Proposed Changes

Cherry-pick of the source and test changes from #37758, without the changelog entry:

- `rpmPackageManager.cpp`: Release rpm's macro table in the destructor, alongside the existing `rpmFreeRpmrc()`.
- `rpmlibWrapper.h`: Declare `rpmFreeMacros()` on `IRpmLibWrapper`, plus the `<rpm/rpmmacro.h>` include it needs.
- `rpmlib.h`: Implement it as a thin wrapper over `::rpmFreeMacros(nullptr)`.
- `RpmPackageManager_test.cpp` and `sysInfoPackageLinuxParserRPM_test.cpp`: Add the mock method and assert the destructor calls it.

The patch applied to `4.14.9` with no adaptation, so the change is identical to the one on `5.0.0`, comments included.

### Results and Evidence

Measured on the shipped packages, both built from the same base commit through the same pipeline, on
`rockylinux:9` (rpm 4.16.1.3, sqlite backend), driving `sysinfo_packages()` from the installed `libsysinfo.so`,
300 s per run.

| Package | Scans | Growth | Per scan |
|---|---:|---:|---:|
| Baseline, `4.14.9` at `7bacb80` | 1,022 | 70,312 KB | **68.80 KB** |
| This fix, at `9dec562` | 1,029 | -60 KB | **-0.06 KB** |

The growth is gone rather than reduced: the patched package ends below where it started. The baseline figure
matches earlier independent measurements within 0.6% (68.60 KB per scan on the published 4.14.1 package, 69.01 KB
over a 53 minute soak).


### Artifacts Affected

- `libsysinfo.so`. No change to inventory data or scan semantics.

### Configuration Changes

None.

### Documentation Updates

None

### Tests Introduced

- Extended the existing `RpmLibTest.RAII` test to assert `rpmFreeMacros()` is called on destruction, and added the mock method in both RPM test suites. No new test files.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
