### PR TITLE
Port deferred 4.14.7 cluster security fixes to 5.0.0 (confinement, decompression cap, config masking)

### DIFF
--- a/framework/wazuh/cluster.py
+++ b/framework/wazuh/cluster.py
@@ -11,11 +11,12 @@ from wazuh.core.cluster.control import get_health, get_nodes
 from wazuh.core.cluster.utils import get_cluster_status, read_config
 from wazuh.core.exception import WazuhError, WazuhResourceNotFound
 from wazuh.core.results import AffectedItemsWazuhResult, WazuhResult
-from wazuh.rbac.decorators import expose_resources, async_list_handler
+from wazuh.rbac.decorators import expose_resources, async_list_handler, mask_sensitive_config
 
 node_id = get_node().get('node')
 
 
+@mask_sensitive_config()
 @expose_resources(actions=['cluster:read'], resources=[f'node:id:{node_id}'])
 def read_config_wrapper() -> AffectedItemsWazuhResult:
     """Wrapper for read_config.
@@ -29,7 +30,7 @@ def read_config_wrapper() -> AffectedItemsWazuhResult:
                                       none_msg='No information was returned'
                                       )
     try:
-        result.affected_items.append(read_config())
+        result.affected_items.append(dict(read_config()))
     except WazuhError as e:
         result.add_failed_item(id_=node_id, error=e)
     result.total_affected_items = len(result.affected_items)

--- a/framework/wazuh/core/cluster/cluster.py
+++ b/framework/wazuh/core/cluster/cluster.py
@@ -415,6 +415,49 @@ async def async_decompress_files(zip_path, ko_files_name="files_metadata.json"):
     return decompress_files(zip_path, ko_files_name)
 
 
+def decompress_to_file(content, full_path, max_size):
+    """Decompress a single archive member to disk, bounding the decompressed size.
+
+    The compressed content is decompressed in fixed-size chunks that are written to disk
+    as they are produced, so the peak memory usage is limited to one chunk regardless of
+    the decompressed size. This prevents a peer-supplied member from forcing the whole
+    decompressed payload to be materialised in memory at once. If the decompressed output
+    exceeds 'max_size', or the compressed stream is truncated or corrupted, an exception is
+    raised; the partial output is cleaned up by the caller.
+
+    Parameters
+    ----------
+    content : bytes
+        Compressed content of the archive member.
+    full_path : str
+        Destination path where the decompressed content is written.
+    max_size : int
+        Maximum allowed decompressed size, in bytes.
+
+    Returns
+    -------
+    int
+        Number of decompressed bytes written.
+    """
+    decompressor = zlib.decompressobj()
+    chunk_size = 1024 * 1024  # 1 MiB
+    total = 0
+    with open(full_path, 'wb') as f:
+        chunk = decompressor.decompress(content, chunk_size)
+        while chunk:
+            total += len(chunk)
+            if total > max_size:
+                raise WazuhInternalError(3053)
+            f.write(chunk)
+            chunk = decompressor.decompress(decompressor.unconsumed_tail, chunk_size)
+        # A complete zlib stream sets 'eof' after its trailing checksum is validated.
+        # Reject truncated or corrupted members, mirroring the check zlib.decompress() does.
+        if not decompressor.eof:
+            raise zlib.error('Error -5 while decompressing data: incomplete or truncated stream')
+
+    return total
+
+
 def decompress_files(compress_path, ko_files_name="files_metadata.json"):
     """Decompress files in a directory and load the files_metadata.json as a dict.
 
@@ -439,6 +482,8 @@ def decompress_files(compress_path, ko_files_name="files_metadata.json"):
     compressed_data = b''
     window_size = 1024 * 1024 * 10  # 10 MiB
     decompress_dir = compress_path + 'dir'
+    max_zip_size = get_cluster_items()['intervals']['communication']['max_zip_size']
+    total_decompressed = 0
 
     try:
         mkdir_with_mode(decompress_dir)
@@ -454,7 +499,6 @@ def decompress_files(compress_path, ko_files_name="files_metadata.json"):
 
                 for file in files:
                     filepath, content = file.split(PATH_SEP.encode(), 1)
-                    content = zlib.decompress(content)
                     full_path = safe_join(decompress_dir, filepath.decode())
                     if not os.path.exists(os.path.dirname(full_path)):
                         try:
@@ -462,8 +506,10 @@ def decompress_files(compress_path, ko_files_name="files_metadata.json"):
                         except OSError as exc:  # Guard against race condition
                             if exc.errno != errno.EEXIST:
                                 raise
-                    with open(full_path, 'wb') as f:
-                        f.write(content)
+                    # Bound the aggregate decompressed size across all members, not just per
+                    # member, so an archive cannot exceed max_zip_size by stacking entries.
+                    total_decompressed += decompress_to_file(content, full_path,
+                                                             max_zip_size - total_decompressed)
 
                 if not new_data:
                     break

--- a/framework/wazuh/core/cluster/tests/test_cluster.py
+++ b/framework/wazuh/core/cluster/tests/test_cluster.py
@@ -343,14 +343,16 @@ async def test_async_decompress_files(decompress_files_mock):
 
 
 @pytest.mark.asyncio
-@patch('zlib.decompress')
+@patch('wazuh.core.cluster.cluster.get_cluster_items',
+       return_value={'intervals': {'communication': {'max_zip_size': 1073741824}}})
+@patch('wazuh.core.cluster.cluster.decompress_to_file', side_effect=[100, 200])
 @patch('os.makedirs')
 @patch('os.path.exists', side_effect=[False, True, True])
 @patch('wazuh.core.cluster.cluster.remove')
 @patch('wazuh.core.cluster.cluster.mkdir_with_mode')
 @patch('json.loads', return_value="some string with files")
 async def test_decompress_files_ok(json_loads_mock, mkdir_with_mode_mock, remove_mock, os_path_exists_mock,
-                                   mock_makedirs, zlib_mock):
+                                   mock_makedirs, decompress_to_file_mock, get_cluster_items_mock):
     """Check if the decompressing function is working properly."""
     zip_path = '/foo/bar/'
     compress_data = f'path{cluster.PATH_SEP}content{cluster.FILE_SEP}path2{cluster.PATH_SEP}content2'.encode()
@@ -362,20 +364,78 @@ async def test_decompress_files_ok(json_loads_mock, mkdir_with_mode_mock, remove
         ko_files, zip_dir = cluster.decompress_files(compress_path=zip_path)
         assert ko_files == "some string with files"
         assert zip_dir == zip_path + 'dir'
-        zlib_mock.assert_has_calls([call(b'content'), call(b'content2')])
+        # The second member's budget must be reduced by the first member's decompressed size,
+        # exercising the rolling 'max_zip_size - total_decompressed' aggregate budget.
+        decompress_to_file_mock.assert_has_calls([call(b'content', '/foo/bar/dir/path', 1073741824),
+                                                  call(b'content2', '/foo/bar/dir/path2', 1073741824 - 100)])
         mock_makedirs.assert_called_once_with(zip_path + 'dir')
         json_loads_mock.assert_called_once()
         mkdir_with_mode_mock.assert_called_once_with(zip_dir)
         remove_mock.assert_called_once_with(zip_path)
-        assert open_mock.call_args_list == [call('/foo/bar/', 'rb'), call('/foo/bar/dir/path', 'wb'),
-                                            call('/foo/bar/dir/path2', 'wb'), call('/foo/bar/dir/files_metadata.json')]
+        assert open_mock.call_args_list == [call('/foo/bar/', 'rb'), call('/foo/bar/dir/files_metadata.json')]
+
+
+def test_decompress_to_file_ok(tmp_path):
+    """Check that a compressed member is decompressed and written to disk."""
+    content = b'A' * 1024
+    dest = str(tmp_path / 'out.bin')
+
+    written = cluster.decompress_to_file(zlib.compress(content), dest, max_size=1024 * 1024)
+
+    assert written == len(content)
+    with open(dest, 'rb') as f:
+        assert f.read() == content
+
+
+def test_decompress_to_file_exceeds_limit(tmp_path):
+    """Check that a decompression bomb is rejected once the size cap is exceeded."""
+    # ~100 MiB of 'A' compresses to a few KiB but must be rejected when the cap is lower.
+    co = zlib.compressobj(9)
+    parts = [co.compress(b'A' * (1024 * 1024)) for _ in range(100)]
+    parts.append(co.flush())
+    bomb = b''.join(parts)
+    dest = str(tmp_path / 'bomb.bin')
+
+    with pytest.raises(WazuhInternalError, match=r'.* 3053 .*'):
+        cluster.decompress_to_file(bomb, dest, max_size=10 * 1024 * 1024)
+
+
+def test_decompress_to_file_truncated(tmp_path):
+    """Check that a truncated/corrupted member is rejected instead of silently accepted."""
+    compressed = zlib.compress(b'Z' * 4096)
+    dest = str(tmp_path / 'trunc.bin')
+
+    with pytest.raises(zlib.error):
+        cluster.decompress_to_file(compressed[:-2], dest, max_size=1024 * 1024)
+
+
+@patch('wazuh.core.cluster.cluster.get_cluster_items',
+       return_value={'intervals': {'communication': {'max_zip_size': 1500}}})
+def test_decompress_files_aggregate_limit(get_cluster_items_mock, tmp_path):
+    """Two members each under the cap but exceeding it in aggregate must be rejected."""
+    path_sep = cluster.PATH_SEP.encode()
+    file_sep = cluster.FILE_SEP.encode()
+    archive = (b'a.txt' + path_sep + zlib.compress(b'A' * 1000) + file_sep +
+               b'b.txt' + path_sep + zlib.compress(b'B' * 1000) + file_sep +
+               b'pad' + path_sep + zlib.compress(b''))
+    zip_path = str(tmp_path / 'agg.zip')
+    with open(zip_path, 'wb') as f:
+        f.write(archive)
+
+    with pytest.raises(WazuhInternalError, match=r'.* 3053 .*'):
+        cluster.decompress_files(zip_path)
+
+    # On rejection, decompress_files must remove the partial decompressed output.
+    assert not os.path.exists(zip_path + 'dir')
 
 
 @pytest.mark.asyncio
+@patch('wazuh.core.cluster.cluster.get_cluster_items',
+       return_value={'intervals': {'communication': {'max_zip_size': 1073741824}}})
 @patch('shutil.rmtree')
-@patch('zlib.decompress', return_value=Exception)
+@patch('wazuh.core.cluster.cluster.decompress_to_file', side_effect=Exception)
 @patch('wazuh.core.cluster.cluster.mkdir_with_mode')
-async def test_decompress_files_ko(mkdir_with_mode_mock, zlib_mock, rmtree_mock):
+async def test_decompress_files_ko(mkdir_with_mode_mock, decompress_to_file_mock, rmtree_mock, get_cluster_items_mock):
     """Check if the decompressing function is raising the necessary exceptions."""
 
     # Raising the expected Exception
@@ -385,7 +445,7 @@ async def test_decompress_files_ko(mkdir_with_mode_mock, zlib_mock, rmtree_mock)
         with patch('os.path.exists', return_value=True) as os_path_exists_mock:
             assert cluster.decompress_files(zip_dir) == "some string with files", zip_dir + "dir"
             mkdir_with_mode_mock.assert_called_once_with(zip_dir)
-            zlib_mock.assert_called_once()
+            decompress_to_file_mock.assert_called_once()
             os_path_exists_mock.assert_called_once()
             rmtree_mock.assert_called_once()
 

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -1166,8 +1166,10 @@ async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, w
                                              call(core_common.WAZUH_PATH, 'queue/TYPE/name'),
                                              call(core_common.WAZUH_PATH, 'cluster_item_key'),
                                              call(core_common.WAZUH_PATH, 'filename1'),
+                                             call(core_common.WAZUH_PATH, 'cluster_item_key'),
                                              call('/zip/path', 'filename1'),
-                                             call(core_common.WAZUH_PATH, 'filename3')])
+                                             call(core_common.WAZUH_PATH, 'filename3'),
+                                             call(core_common.WAZUH_PATH, 'cluster_item_key')])
             wazuh_uid_mock.assert_called_with()
             wazuh_gid_mock.assert_called_with()
             mkdir_with_mode_mock.assert_any_call("queue/testing")
@@ -1180,10 +1182,11 @@ async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, w
                 mock.reset_mock()
 
     # Test the first for: for -> if -> for -> except AND for -> elif -> for -> try -> except -> if
-    result_logs = worker_handler.update_master_files_in_worker(
-        {"shared": {"filename1": "data1"}, "missing": {"filename2": "data2"},
-         "extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
-        cluster_items=cluster_items)
+    with patch("os.path.commonpath", return_value="queue/testing/"):
+        result_logs = worker_handler.update_master_files_in_worker(
+            {"shared": {"filename1": "data1"}, "missing": {"filename2": "data2"},
+             "extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
+            cluster_items=cluster_items)
 
     assert result_logs["error"]["shared"][0].startswith(
         "Error processing shared file 'filename1': string indices must be integers"
@@ -1215,10 +1218,11 @@ async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, w
     # Test the first for: for -> if -> for -> except AND for -> elif -> for -> try -> except -> else AND
     # for -> elif -> for -> except
     path_join_mock.return_value = "queue/testing_mock/"
-    result_logs = worker_handler.update_master_files_in_worker(
-        {"shared": {"filename1": "data1"}, "missing": {"filename2": "data2"},
-         "extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
-        cluster_items=cluster_items)
+    with patch("os.path.commonpath", return_value="queue/testing_mock/"):
+        result_logs = worker_handler.update_master_files_in_worker(
+            {"shared": {"filename1": "data1"}, "missing": {"filename2": "data2"},
+             "extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
+            cluster_items=cluster_items)
 
     assert result_logs["error"]["shared"][0].startswith(
         "Error processing shared file 'filename1': string indices must be integers"
@@ -1253,9 +1257,10 @@ async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, w
     # Test the try
     with patch("os.listdir", return_value="dir_files") as listdir_mock:
         with patch("shutil.rmtree") as rmtree_mock:
-            result_logs = worker_handler.update_master_files_in_worker(
-                {"extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
-                cluster_items=cluster_items)
+            with patch("os.path.commonpath", return_value="queue/testing_mock/"):
+                result_logs = worker_handler.update_master_files_in_worker(
+                    {"extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
+                    cluster_items=cluster_items)
             rmtree_mock.assert_called_once()
             listdir_mock.assert_called_once()
 
@@ -1264,6 +1269,7 @@ async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, w
                                                            "File filename3 doesn't exist."]}
             assert result_logs['generic_errors'] == []
             path_join_mock.assert_has_calls([call(core_common.WAZUH_PATH, "filename3"),
+                                             call(core_common.WAZUH_PATH, "cluster_item_key"),
                                              call(core_common.WAZUH_PATH, "")])
             wazuh_uid_mock.assert_not_called()
             wazuh_gid_mock.assert_not_called()
@@ -1277,9 +1283,10 @@ async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, w
                 mock.reset_mock()
 
     # Test the exception
-    result_logs = worker_handler.update_master_files_in_worker(
-        {"extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
-        cluster_items=cluster_items)
+    with patch("os.path.commonpath", return_value="queue/testing_mock/"):
+        result_logs = worker_handler.update_master_files_in_worker(
+            {"extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
+            cluster_items=cluster_items)
 
     assert result_logs['error'] == defaultdict(list)
     assert result_logs['debug2'] == {'filename3': ["Remove file: 'filename3'",
@@ -1289,6 +1296,7 @@ async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, w
     assert result_logs['generic_errors'] == ["Found errors: 0 overwriting, 0 creating and 1 removing"]
 
     path_join_mock.assert_has_calls([call(core_common.WAZUH_PATH, "filename3"),
+                                     call(core_common.WAZUH_PATH, "cluster_item_key"),
                                      call(core_common.WAZUH_PATH, "")])
     wazuh_uid_mock.assert_not_called()
     wazuh_gid_mock.assert_not_called()
@@ -1296,6 +1304,48 @@ async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, w
     safe_move_mock.assert_not_called()
     open_mock.assert_not_called()
     path_exists_mock.assert_not_called()
+
+
+def test_worker_handler_update_master_files_in_worker_security_checks():
+    """Verify that confinement checks block non-merged and extra files outside their declared directory."""
+    worker_handler = get_worker_handler(MagicMock())
+    sec_cluster_items = {
+        'files': {
+            'etc/': {'permissions': '0o640', 'remove_subdirs_if_empty': False},
+            'etc/shared/': {'permissions': '0o660', 'remove_subdirs_if_empty': False},
+            'excluded_files': ['ar.conf', 'ossec.conf'],
+        }
+    }
+
+    # Non-merged: invalid cluster_item_key
+    result = worker_handler.update_master_files_in_worker(
+        {'shared': {'etc/shared/agent.conf': {'merged': False, 'cluster_item_key': 'nonexistent/'}},
+         'missing': {}, 'extra': {}},
+        '/tmp', sec_cluster_items)
+    assert any("Invalid cluster_item_key: nonexistent/" in e for e in result['error']['shared'])
+
+    # Non-merged: path outside declared cluster_item_key directory
+    result = worker_handler.update_master_files_in_worker(
+        {'shared': {'active-response/bin/evil.sh': {'merged': False, 'cluster_item_key': 'etc/shared/'}},
+         'missing': {}, 'extra': {}},
+        '/tmp', sec_cluster_items)
+    assert any("outside allowed directory" in e for e in result['error']['shared'])
+
+    # Extra: invalid cluster_item_key (must not crash on directories_to_check generator)
+    result = worker_handler.update_master_files_in_worker(
+        {'shared': {}, 'missing': {},
+         'extra': {'etc/shared/agent.conf': {'cluster_item_key': 'nonexistent/'}}},
+        '/tmp', sec_cluster_items)
+    assert any("Invalid cluster_item_key: nonexistent/" in e
+               for e in result['debug2']['etc/shared/agent.conf'])
+
+    # Extra: path outside declared cluster_item_key directory
+    result = worker_handler.update_master_files_in_worker(
+        {'shared': {}, 'missing': {},
+         'extra': {'active-response/bin/evil.sh': {'cluster_item_key': 'etc/shared/'}}},
+        '/tmp', sec_cluster_items)
+    assert any("outside allowed directory" in e
+               for e in result['debug2']['active-response/bin/evil.sh'])
 
 
 @pytest.mark.asyncio

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -751,17 +751,25 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                               ownership=(common.wazuh_uid(), common.wazuh_gid())
                               )
             else:
+                item_key = data_['cluster_item_key']
+                if item_key not in cluster_items['files']:
+                    raise exception.WazuhClusterError(3022, extra_message=f"Invalid cluster_item_key: {item_key}")
+                expected_base = safe_join(common.WAZUH_PATH, item_key)
+                if not os.path.commonpath([full_filename_path, expected_base]).startswith(expected_base):
+                    raise exception.WazuhClusterError(3022,
+                        extra_message=f"File path outside allowed directory: {filename_}")
                 # Create destination dir if it doesn't exist.
                 if not os.path.exists(os.path.dirname(full_filename_path)):
                     utils.mkdir_with_mode(os.path.dirname(full_filename_path))
                 # Move the file from zipdir (directory containing unzipped files) to <wazuh_path>/filename.
                 safe_move(safe_join(zip_path, filename_), full_filename_path,
-                          permissions=cluster_items['files'][data_['cluster_item_key']]['permissions'],
+                          permissions=cluster_items['files'][item_key]['permissions'],
                           ownership=(common.wazuh_uid(), common.wazuh_gid())
                           )
 
         errors = {'shared': 0, 'missing': 0, 'extra': 0}
         result_logs = {'debug2': defaultdict(list), 'error': defaultdict(list), 'generic_errors': []}
+        validated_extra = {}  # extra entries that cleared all security checks, used for dir cleanup
 
         for filetype, files in ko_files.items():
             # Overwrite local files marked as shared or missing.
@@ -777,14 +785,24 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                         continue
             # Remove local files marked as extra.
             elif filetype == 'extra':
-                for file_to_remove in files:
+                for file_to_remove, file_data in files.items():
                     try:
                         result_logs['debug2'][file_to_remove].append(f"Remove file: '{file_to_remove}'")
+                        item_key = file_data['cluster_item_key']
+                        if item_key not in cluster_items['files']:
+                            raise exception.WazuhClusterError(3022,
+                                extra_message=f"Invalid cluster_item_key: {item_key}")
                         file_path = safe_join(common.WAZUH_PATH, file_to_remove)
+                        expected_base = safe_join(common.WAZUH_PATH, item_key)
+                        if not os.path.commonpath([file_path, expected_base]).startswith(expected_base):
+                            raise exception.WazuhClusterError(3022,
+                                extra_message=f"File path outside allowed directory: {file_to_remove}")
                         try:
                             os.remove(file_path)
+                            validated_extra[file_to_remove] = file_data
                         except OSError as e:
                             if e.errno == errno.ENOENT:
+                                validated_extra[file_to_remove] = file_data
                                 result_logs['debug2'][file_to_remove].append(f"File {file_to_remove} "
                                                                              f"doesn't exist.")
                                 continue
@@ -797,7 +815,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                         continue
 
         # Once files are deleted, check and remove subdirectories which are now empty, as specified in cluster.json.
-        directories_to_check = set(os.path.dirname(f) for f, data in ko_files['extra'].items()
+        directories_to_check = set(os.path.dirname(f) for f, data in validated_extra.items()
                                    if cluster_items['files'][data['cluster_item_key']]['remove_subdirs_if_empty'])
         for directory in directories_to_check:
             try:
@@ -809,9 +827,6 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                 errors['extra'] += 1
                 result_logs["debug2"][directory].append(f"Error removing directory '{directory}': {e}")
                 continue
-
-            except Exception as e:
-                result_logs['generic_errors'].append(f"Error reloading ruleset {e}")
 
         if sum(errors.values()) > 0:
             result_logs['generic_errors'].append(f"Found errors: {errors['shared']} overwriting, "

--- a/framework/wazuh/core/exception.py
+++ b/framework/wazuh/core/exception.py
@@ -357,6 +357,7 @@ class WazuhException(Exception):
         3050: "Payload size exceeds maximum allowed limit",
         3051: "Too many concurrent divided messages",
         3052: "Invalid cluster file parameter",
+        3053: "Decompressed file exceeds the maximum allowed size",
         3060: {'message': "Invalid node name format",
                'remediation': f"Check and fix [worker names](https://documentation.wazuh.com/{DOCU_VERSION}/"
                               f"user-manual/reference/ossec-conf/cluster.html#node-name)"

--- a/framework/wazuh/tests/test_cluster.py
+++ b/framework/wazuh/tests/test_cluster.py
@@ -27,11 +27,14 @@ default_config = {'node_type': 'master', 'name': 'wazuh', 'node_name': 'node01',
                   'key': '', 'port': 1516, 'bind_addr': '127.0.0.1', 'nodes': ['127.0.0.1'], 'hidden': 'no'}
 
 
-@patch('wazuh.cluster.read_config', return_value=default_config)
-def test_read_config_wrapper(mock_read_config):
+@patch('wazuh.rbac.decorators._has_update_permissions', return_value=True)
+def test_read_config_wrapper(mock_perms):
     """Verify that the read_config_wrapper returns the default configuration."""
-    result = cluster.read_config_wrapper()
-    assert result.affected_items == [default_config]
+    fresh_config = dict(default_config)
+    with patch('wazuh.cluster.read_config', return_value=fresh_config):
+        result = cluster.read_config_wrapper()
+    # Admin (has update perms) is not masked: the full config must be returned unchanged.
+    assert result.affected_items[0] == default_config
 
 
 @patch('wazuh.cluster.read_config', side_effect=WazuhError(1001))
@@ -39,6 +42,61 @@ def test_read_config_wrapper_exception(mock_read_config):
     """Verify the exceptions raised in read_config_wrapper."""
     result = cluster.read_config_wrapper()
     assert list(result.failed_items.keys())[0] == WazuhError(1001)
+
+
+def _cluster_config_with_key():
+    """Return a fresh cluster config dict carrying a real key.
+
+    A new dict is built on every call so tests stay isolated even if a future
+    change masks the affected item in place instead of a copy.
+    """
+    return {'disabled': False, 'node_type': 'master', 'name': 'wazuh', 'node_name': 'master-node',
+            'key': 'REAL_CLUSTER_SECRET', 'port': 1516, 'bind_addr': '0.0.0.0',
+            'nodes': ['wazuh-master'], 'hidden': 'no'}
+
+
+@pytest.mark.parametrize('has_perms,expected_key', [
+    (False, '*****'),
+    (True, 'REAL_CLUSTER_SECRET'),
+])
+def test_read_config_wrapper_key_visibility(has_perms, expected_key):
+    """Key is masked for readonly users and exposed for admins."""
+    with patch('wazuh.rbac.decorators._has_update_permissions', return_value=has_perms):
+        with patch('wazuh.cluster.read_config', return_value=_cluster_config_with_key()):
+            result = cluster.read_config_wrapper()
+    assert result.affected_items[0]['key'] == expected_key
+
+
+@patch('wazuh.rbac.decorators._has_update_permissions', return_value=False)
+def test_read_config_wrapper_masking_preserves_other_fields(mock_perms):
+    """Masking only touches the key field, not other config fields."""
+    with patch('wazuh.cluster.read_config', return_value=_cluster_config_with_key()):
+        result = cluster.read_config_wrapper()
+    item = result.affected_items[0]
+    assert item['key'] == '*****'
+    assert item['name'] == 'wazuh'
+    assert item['node_name'] == 'master-node'
+    assert item['port'] == 1516
+    assert item['nodes'] == ['wazuh-master']
+
+
+def test_read_config_wrapper_no_cache_poisoning():
+    """Masking must not mutate the shared read_config() source dict (in-place-mutation regression guard)."""
+    shared_config = _cluster_config_with_key()
+
+    with patch('wazuh.cluster.read_config', return_value=shared_config):
+        # Readonly: the response is masked, but the shared (cached) dict must stay intact
+        with patch('wazuh.rbac.decorators._has_update_permissions', return_value=False):
+            ro_result = cluster.read_config_wrapper()
+
+        assert ro_result.affected_items[0]['key'] == '*****'
+        assert shared_config['key'] == 'REAL_CLUSTER_SECRET'
+
+        # A subsequent admin read still sees the real key (cache was not poisoned).
+        with patch('wazuh.rbac.decorators._has_update_permissions', return_value=True):
+            result = cluster.read_config_wrapper()
+
+        assert result.affected_items[0]['key'] == 'REAL_CLUSTER_SECRET'
 
 
 @patch('wazuh.cluster.get_node', return_value={'cluster': default_config["name"],


### PR DESCRIPTION
## Description

Three cluster-framework security fixes merged into 4.14.7 were deliberately reverted out of 5.0.0 during the 4.14.7 -> 5.0.0 upward merge in 4dc00665f0 ("keep 5.0.0 cluster framework, defer 4.14.7 cluster fixes"), because 5.0.0's cluster framework had diverged and the auto-applied changes broke its tests. They were meant to be re-evaluated against 5.0.0 separately, but that never happened, so 5.0.0 still ships without them. This PR ports all three to 5.0.0's cluster code.

An audit of that merge confirmed these are the only cluster/RBAC security fixes still missing: the deny-rule RBAC fix (#37076) was correctly kept and is present, and the other cluster security fixes of the 4.14.x line (#37694, #37034, #37280) are already in 5.0.0. The ruleset path-traversal fixes of that period do not apply because ruleset management moved to the engine in 5.0.0 and the affected Python modules no longer exist.

Ports #36998, #37119 and #37039 to 5.0.0.

Resolves wazuh/internal-devel-requests#5244
Related: wazuh/internal-devel-requests#4975

## Proposed Changes

Each fix is a separate commit.

**Worker file-sync confinement (#36998)** - `framework/wazuh/core/cluster/worker.py`

The base CVE-2026-30893 fix confined the merged branch and the master side, but the non-merged `else` branch and the `extra` delete loop of `update_master_files_in_worker()` stayed unconfined: a sync file was written/removed under `/var/ossec` without checking it stayed within the directory declared by its `cluster_item_key`. A compromised master (or any holder of the cluster key) could therefore write, overwrite, or delete arbitrary files on every worker, including root-executed locations (`active-response/bin`, `wodles`, `integrations`). Apply the same three-check pattern already on the master side (valid `cluster_item_key`, resolved path within `expected_base`, enforced before write/remove) to both paths; directory cleanup now iterates the entries that cleared the checks.

**Bound decompressed size in sync archives (#37119)** - `framework/wazuh/core/cluster/cluster.py`, `framework/wazuh/core/exception.py`

`decompress_files()` decompressed each peer-supplied member with a single unbounded `zlib.decompress()`, so a small "zip bomb" member (amplification ~1000:1) could force the receiving daemon to allocate gigabytes and OOM. Add `decompress_to_file()`, which streams decompression to disk in 1 MiB chunks and raises `WazuhInternalError(3053)` once the cumulative output exceeds the budget (and `zlib.error` on a truncated stream). `decompress_files()` now enforces an aggregate `max_zip_size` budget across members. Restore exception 3053.

**Mask sensitive fields in local cluster config reads (#37039)** - `framework/wazuh/cluster.py`

`GET /cluster/local/config` returned the raw cluster configuration, including the cluster `key`, to users with `cluster:read` but without `*:update_config`, while `GET /manager/configuration` already masked those fields. Apply `@mask_sensitive_config()` to `read_config_wrapper` and return a copy of `read_config()` so masking never mutates the cached source. The deny-rule RBAC fix (#37076) that gates the masking is already present in 5.0.0.

### Results and Evidence

Unit tests (Python 3.11, framework suite). All ported tests pass:

```
# Confinement (#36998)
$ pytest wazuh/core/cluster/tests/test_worker.py -k update_master_files_in_worker
2 passed, 34 deselected

# Decompression cap (#37119)
$ pytest wazuh/core/cluster/tests/test_cluster.py -k decompress
7 passed, 45 deselected
    test_decompress_files_ok               PASSED
    test_decompress_to_file_ok             PASSED
    test_decompress_to_file_exceeds_limit  PASSED   # 3053 raised on bomb
    test_decompress_to_file_truncated      PASSED   # zlib.error on truncated stream
    test_decompress_files_aggregate_limit  PASSED   # aggregate cap + partial-output cleanup
    test_decompress_files_ko               PASSED

# Field masking (#37039)
$ pytest wazuh/tests/test_cluster.py -k read_config_wrapper
6 passed, 5 deselected
    test_read_config_wrapper_key_visibility[False-*****]              PASSED
    test_read_config_wrapper_key_visibility[True-REAL_CLUSTER_SECRET] PASSED
    test_read_config_wrapper_masking_preserves_other_fields          PASSED
    test_read_config_wrapper_no_cache_poisoning                      PASSED
```

The rest of `test_worker.py` / `test_cluster.py` passes; the only failure in a full run is `test_worker_handler_sync_integrity`, an async test that hangs on the event-loop selector in the local environment and is unrelated to these changes.

### Artifacts Affected

- `wazuh-manager` framework (`framework/wazuh/cluster.py`, `framework/wazuh/core/cluster/cluster.py`, `framework/wazuh/core/cluster/worker.py`, `framework/wazuh/core/exception.py`). No configuration, packaging, or API-surface changes; `max_zip_size` (default 1 GiB) already exists in `cluster.json`.

### Tests Introduced

- `test_worker_handler_update_master_files_in_worker_security_checks`
- `test_decompress_to_file_ok`, `test_decompress_to_file_exceeds_limit`, `test_decompress_to_file_truncated`, `test_decompress_files_aggregate_limit`
- `test_read_config_wrapper_key_visibility`, `test_read_config_wrapper_masking_preserves_other_fields`, `test_read_config_wrapper_no_cache_poisoning`

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
