### PR TITLE
Cluster file processing parameter validation for non-merged files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Hardened RSA decryption to reject malformed ciphertext blobs. ([#36243](https://github.com/wazuh/wazuh/issues/36243))
 - Improved cluster merged file parameter validation to prevent directory escape. ([#38375](https://github.com/wazuh/wazuh/pull/38375))
 - Improved `tmp_file` path validation in cluster DAPI. ([#38376](https://github.com/wazuh/wazuh/pull/38376))
+- Improved cluster non-merged file path validation during worker file processing. ([#38377](https://github.com/wazuh/wazuh/pull/38377))
 
 
 ## [v4.10.4]

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -937,6 +937,16 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                     # If the file is not 'merged' type, move it directly to the destination path.
                     else:
                         try:
+                            expected_base = safe_join(common.WAZUH_PATH, item_key)
+                            if not os.path.commonpath([full_path, expected_base]).startswith(expected_base):
+                                raise exception.WazuhClusterError(3022,
+                                    extra_message=f"File path outside allowed directory: {file_path}")
+
+                            file_basename = os.path.basename(file_path)
+                            if file_basename in cluster_items['files'].get('excluded_files', []):
+                                raise exception.WazuhClusterError(3022,
+                                    extra_message=f"File is in excluded list: {file_path}")
+
                             zip_path = safe_join(decompressed_files_path, file_path)
                             utils.safe_move(zip_path, full_path, ownership=(common.wazuh_uid(), common.wazuh_gid()),
                                             permissions=cluster_items['files'][item_key]['permissions'])

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -1385,6 +1385,7 @@ def test_master_handler_process_files_from_worker_ok(gid_mock, uid_mock, basenam
     assert result == {'errors_per_folder': defaultdict(list),
                       'generic_errors': [], 'total_updated': 0}
     path_join_mock.assert_has_calls([call(common.WAZUH_PATH, 'data'),
+                                     call(common.WAZUH_PATH, 'queue/testing/'),
                                      call(decompressed_files_path, 'data')])
 
     safe_move_mock.side_effect = TimeoutError
@@ -1832,3 +1833,56 @@ def test_master_handler_process_files_from_worker_validates_path_confinement(gid
             assert len(result['errors_per_folder']['queue/testing/']) > 0
             assert any('outside allowed directory' in str(e) or '3022' in str(e)
                       for e in result['errors_per_folder']['queue/testing/'])
+
+
+@patch("os.path.basename")
+@patch("wazuh.core.common.wazuh_uid", return_value="wazuh_uid")
+@patch("wazuh.core.common.wazuh_gid", return_value="wazuh_gid")
+@patch("wazuh.core.cluster.master.utils.safe_move")
+def test_master_handler_process_files_from_worker_validates_non_merged_path(safe_move_mock, gid_mock, uid_mock,
+                                                                             basename_mock):
+    """Test that process_files_from_worker validates path confinement for non-merged files."""
+    master_handler = get_master_handler()
+    cluster_items_with_testing = {**cluster_items,
+                                  'files': {**cluster_items['files'],
+                                            'queue/testing/': {'remove_subdirs_if_empty': True,
+                                                               'permissions': 'value'}}}
+
+    basename_mock.return_value = "file.txt"
+    files_metadata = {"queue/testing/file.txt": {"merged": False, "cluster_item_key": "queue/testing/"}}
+    result = master_handler.process_files_from_worker(
+        files_metadata=files_metadata,
+        decompressed_files_path='/decompressed',
+        cluster_items=cluster_items_with_testing,
+        worker_name='worker1',
+        timeout=0
+    )
+    assert result['errors_per_folder'] == defaultdict(list)
+
+    files_metadata = {"etc/ossec.conf": {"merged": False, "cluster_item_key": "queue/testing/"}}
+    result = master_handler.process_files_from_worker(
+        files_metadata=files_metadata,
+        decompressed_files_path='/decompressed',
+        cluster_items=cluster_items_with_testing,
+        worker_name='worker1',
+        timeout=0
+    )
+    assert len(result['errors_per_folder']['queue/testing/']) > 0
+    assert any('outside allowed directory' in str(e) or '3022' in str(e)
+              for e in result['errors_per_folder']['queue/testing/'])
+
+    basename_mock.return_value = "excluded.txt"
+    cluster_items_with_excluded = dict(cluster_items_with_testing)
+    cluster_items_with_excluded['files'] = {**cluster_items_with_testing['files'],
+                                            'excluded_files': ['excluded.txt']}
+    files_metadata = {"queue/testing/excluded.txt": {"merged": False, "cluster_item_key": "queue/testing/"}}
+    result = master_handler.process_files_from_worker(
+        files_metadata=files_metadata,
+        decompressed_files_path='/decompressed',
+        cluster_items=cluster_items_with_excluded,
+        worker_name='worker1',
+        timeout=0
+    )
+    assert len(result['errors_per_folder']['queue/testing/']) > 0
+    assert any('excluded list' in str(e) or '3022' in str(e)
+              for e in result['errors_per_folder']['queue/testing/'])


### PR DESCRIPTION
## Description

Backport of #36296 to `4.10.5`. It adds parameter validation to the non-merged file branch of
`MasterHandler.process_files_from_worker`, so the destination path of a received file must stay
inside the directory declared by its cluster item key and the file must not be one of the excluded
files. The source change applied unmodified; only the new unit test had to be adapted, because the
`cluster_items` fixture of `4.10.5` does not yet declare the `queue/testing/` entry that the test
relies on.

- Backport issue: wazuh/internal-devel-requests#5876
- Original issue: wazuh/internal-devel-requests#4907
- Original pull request: #36296 (`4.14.6`)

## Proposed Changes

- `framework/wazuh/core/cluster/master.py`: in `process_files_from_worker`, validate that the
  destination path of a non-merged file is confined to the directory of its `cluster_item_key`, and
  reject file names listed in `excluded_files`.
- `framework/wazuh/core/cluster/tests/test_master.py`: extend
  `test_master_handler_process_files_from_worker_ok` with the new `safe_join` call, and add
  `test_master_handler_process_files_from_worker_validates_non_merged_path`.

### Results and Evidence

```
PYTHONPATH=api:framework python -m pytest framework/wazuh/core/cluster/tests/test_master.py -q
49 passed, 9 warnings in 2.49s

PYTHONPATH=api:framework python -m pytest framework/wazuh/core/cluster/tests/ -q
391 passed, 9 warnings in 9.29s
```

Both `test_master_handler_process_files_from_worker_ok` and
`test_master_handler_process_files_from_worker_validates_non_merged_path` fail when
`framework/wazuh/core/cluster/master.py` is reverted to the branch version, which confirms the new
test covers the change.

### Artifacts Affected

- wazuh-clusterd

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

`test_master_handler_process_files_from_worker_validates_non_merged_path`, carried over from #36296.
It checks that a file inside the allowed directory is processed, that a file pointing outside it is
rejected, and that an excluded file name is rejected. The test builds its own `cluster_items` copy
containing the `queue/testing/` entry, instead of relying on the global fixture as upstream does.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
