### PR TITLE
Confine worker file sync destinations for non-merged and extra files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Improved cluster merged file parameter validation to prevent directory escape. ([#38375](https://github.com/wazuh/wazuh/pull/38375))
 - Improved `tmp_file` path validation in cluster DAPI. ([#38376](https://github.com/wazuh/wazuh/pull/38376))
 - Improved cluster non-merged file path validation during worker file processing. ([#38377](https://github.com/wazuh/wazuh/pull/38377))
+- Improved cluster worker file path validation. ([#38378](https://github.com/wazuh/wazuh/pull/38378))
 
 
 ## [v4.10.4]

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -1113,8 +1113,10 @@ async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, w
                                              call(core_common.WAZUH_PATH, 'queue/TYPE/name'),
                                              call(core_common.WAZUH_PATH, 'cluster_item_key'),
                                              call(core_common.WAZUH_PATH, 'filename1'),
+                                             call(core_common.WAZUH_PATH, 'cluster_item_key'),
                                              call('/zip/path', 'filename1'),
-                                             call(core_common.WAZUH_PATH, 'filename3')])
+                                             call(core_common.WAZUH_PATH, 'filename3'),
+                                             call(core_common.WAZUH_PATH, 'cluster_item_key')])
             wazuh_uid_mock.assert_called_with()
             wazuh_gid_mock.assert_called_with()
             mkdir_with_mode_mock.assert_any_call("queue/testing")
@@ -1211,6 +1213,7 @@ async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, w
                                                            "File filename3 doesn't exist."]}
             assert result_logs['generic_errors'] == []
             path_join_mock.assert_has_calls([call(core_common.WAZUH_PATH, "filename3"),
+                                             call(core_common.WAZUH_PATH, "cluster_item_key"),
                                              call(core_common.WAZUH_PATH, "")])
             wazuh_uid_mock.assert_not_called()
             wazuh_gid_mock.assert_not_called()
@@ -1237,6 +1240,7 @@ async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, w
     assert result_logs['generic_errors'] == ["Found errors: 0 overwriting, 0 creating and 1 removing"]
 
     path_join_mock.assert_has_calls([call(core_common.WAZUH_PATH, "filename3"),
+                                     call(core_common.WAZUH_PATH, "cluster_item_key"),
                                      call(core_common.WAZUH_PATH, "")])
     wazuh_uid_mock.assert_not_called()
     wazuh_gid_mock.assert_not_called()

--- a/framework/wazuh/core/cluster/tests/test_worker.py
+++ b/framework/wazuh/core/cluster/tests/test_worker.py
@@ -1127,10 +1127,11 @@ async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, w
                 mock.reset_mock()
 
     # Test the first for: for -> if -> for -> except AND for -> elif -> for -> try -> except -> if
-    result_logs = worker_handler.update_master_files_in_worker(
-        {"shared": {"filename1": "data1"}, "missing": {"filename2": "data2"},
-         "extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
-        cluster_items=cluster_items)
+    with patch("os.path.commonpath", return_value="queue/testing/"):
+        result_logs = worker_handler.update_master_files_in_worker(
+            {"shared": {"filename1": "data1"}, "missing": {"filename2": "data2"},
+             "extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
+            cluster_items=cluster_items)
 
     assert result_logs['error'] == {'shared': ["Error processing shared file 'filename1': "
                                                "string indices must be integers"],
@@ -1161,10 +1162,11 @@ async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, w
     # Test the first for: for -> if -> for -> except AND for -> elif -> for -> try -> except -> else AND
     # for -> elif -> for -> except
     path_join_mock.return_value = "queue/testing_mock/"
-    result_logs = worker_handler.update_master_files_in_worker(
-        {"shared": {"filename1": "data1"}, "missing": {"filename2": "data2"},
-         "extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
-        cluster_items=cluster_items)
+    with patch("os.path.commonpath", return_value="queue/testing_mock/"):
+        result_logs = worker_handler.update_master_files_in_worker(
+            {"shared": {"filename1": "data1"}, "missing": {"filename2": "data2"},
+             "extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
+            cluster_items=cluster_items)
 
     assert result_logs['error'] == {'shared': ["Error processing shared file 'filename1': "
                                                "string indices must be integers"],
@@ -1197,9 +1199,10 @@ async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, w
     # Test the try
     with patch("os.listdir", return_value="dir_files") as listdir_mock:
         with patch("shutil.rmtree") as rmtree_mock:
-            result_logs = worker_handler.update_master_files_in_worker(
-                {"extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
-                cluster_items=cluster_items)
+            with patch("os.path.commonpath", return_value="queue/testing_mock/"):
+                result_logs = worker_handler.update_master_files_in_worker(
+                    {"extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
+                    cluster_items=cluster_items)
             rmtree_mock.assert_called_once()
             listdir_mock.assert_called_once()
 
@@ -1221,9 +1224,10 @@ async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, w
                 mock.reset_mock()
 
     # Test the exception
-    result_logs = worker_handler.update_master_files_in_worker(
-        {"extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
-        cluster_items=cluster_items)
+    with patch("os.path.commonpath", return_value="queue/testing_mock/"):
+        result_logs = worker_handler.update_master_files_in_worker(
+            {"extra": {"filename3": {"cluster_item_key": "cluster_item_key"}}}, "/zip/path",
+            cluster_items=cluster_items)
 
     assert result_logs['error'] == defaultdict(list)
     assert result_logs['debug2'] == {'filename3': ["Remove file: 'filename3'",
@@ -1240,6 +1244,48 @@ async def test_worker_handler_update_master_files_in_worker_ok(wazuh_gid_mock, w
     safe_move_mock.assert_not_called()
     open_mock.assert_not_called()
     path_exists_mock.assert_not_called()
+
+
+def test_worker_handler_update_master_files_in_worker_security_checks():
+    """Verify that confinement checks block non-merged and extra files outside their declared directory."""
+    worker_handler = get_worker_handler(MagicMock())
+    sec_cluster_items = {
+        'files': {
+            'etc/': {'permissions': '0o640', 'remove_subdirs_if_empty': False},
+            'etc/shared/': {'permissions': '0o660', 'remove_subdirs_if_empty': False},
+            'excluded_files': ['ar.conf', 'ossec.conf'],
+        }
+    }
+
+    # Non-merged: invalid cluster_item_key
+    result = worker_handler.update_master_files_in_worker(
+        {'shared': {'etc/shared/agent.conf': {'merged': False, 'cluster_item_key': 'nonexistent/'}},
+         'missing': {}, 'extra': {}},
+        '/tmp', sec_cluster_items)
+    assert any("Invalid cluster_item_key: nonexistent/" in e for e in result['error']['shared'])
+
+    # Non-merged: path outside declared cluster_item_key directory
+    result = worker_handler.update_master_files_in_worker(
+        {'shared': {'active-response/bin/evil.sh': {'merged': False, 'cluster_item_key': 'etc/shared/'}},
+         'missing': {}, 'extra': {}},
+        '/tmp', sec_cluster_items)
+    assert any("outside allowed directory" in e for e in result['error']['shared'])
+
+    # Extra: invalid cluster_item_key (must not crash on directories_to_check generator)
+    result = worker_handler.update_master_files_in_worker(
+        {'shared': {}, 'missing': {},
+         'extra': {'etc/shared/agent.conf': {'cluster_item_key': 'nonexistent/'}}},
+        '/tmp', sec_cluster_items)
+    assert any("Invalid cluster_item_key: nonexistent/" in e
+               for e in result['debug2']['etc/shared/agent.conf'])
+
+    # Extra: path outside declared cluster_item_key directory
+    result = worker_handler.update_master_files_in_worker(
+        {'shared': {}, 'missing': {},
+         'extra': {'active-response/bin/evil.sh': {'cluster_item_key': 'etc/shared/'}}},
+        '/tmp', sec_cluster_items)
+    assert any("outside allowed directory" in e
+               for e in result['debug2']['active-response/bin/evil.sh'])
 
 
 @pytest.mark.asyncio

--- a/framework/wazuh/core/cluster/worker.py
+++ b/framework/wazuh/core/cluster/worker.py
@@ -747,17 +747,25 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                               ownership=(common.wazuh_uid(), common.wazuh_gid())
                               )
             else:
+                item_key = data_['cluster_item_key']
+                if item_key not in cluster_items['files']:
+                    raise WazuhClusterError(3022, extra_message=f"Invalid cluster_item_key: {item_key}")
+                expected_base = safe_join(common.WAZUH_PATH, item_key)
+                if not os.path.commonpath([full_filename_path, expected_base]).startswith(expected_base):
+                    raise WazuhClusterError(3022,
+                        extra_message=f"File path outside allowed directory: {filename_}")
                 # Create destination dir if it doesn't exist.
                 if not os.path.exists(os.path.dirname(full_filename_path)):
                     utils.mkdir_with_mode(os.path.dirname(full_filename_path))
                 # Move the file from zipdir (directory containing unzipped files) to <wazuh_path>/filename.
                 safe_move(safe_join(zip_path, filename_), full_filename_path,
-                          permissions=cluster_items['files'][data_['cluster_item_key']]['permissions'],
+                          permissions=cluster_items['files'][item_key]['permissions'],
                           ownership=(common.wazuh_uid(), common.wazuh_gid())
                           )
 
         errors = {'shared': 0, 'missing': 0, 'extra': 0}
         result_logs = {'debug2': defaultdict(list), 'error': defaultdict(list), 'generic_errors': []}
+        validated_extra = {}  # extra entries that cleared all security checks, used for dir cleanup
 
         for filetype, files in ko_files.items():
             # Overwrite local files marked as shared or missing.
@@ -773,14 +781,24 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                         continue
             # Remove local files marked as extra.
             elif filetype == 'extra':
-                for file_to_remove in files:
+                for file_to_remove, file_data in files.items():
                     try:
                         result_logs['debug2'][file_to_remove].append(f"Remove file: '{file_to_remove}'")
+                        item_key = file_data['cluster_item_key']
+                        if item_key not in cluster_items['files']:
+                            raise WazuhClusterError(3022,
+                                extra_message=f"Invalid cluster_item_key: {item_key}")
                         file_path = safe_join(common.WAZUH_PATH, file_to_remove)
+                        expected_base = safe_join(common.WAZUH_PATH, item_key)
+                        if not os.path.commonpath([file_path, expected_base]).startswith(expected_base):
+                            raise WazuhClusterError(3022,
+                                extra_message=f"File path outside allowed directory: {file_to_remove}")
                         try:
                             os.remove(file_path)
+                            validated_extra[file_to_remove] = file_data
                         except OSError as e:
                             if e.errno == errno.ENOENT:
+                                validated_extra[file_to_remove] = file_data
                                 result_logs['debug2'][file_to_remove].append(f"File {file_to_remove} "
                                                                              f"doesn't exist.")
                                 continue
@@ -793,7 +811,7 @@ class WorkerHandler(client.AbstractClient, c_common.WazuhCommon):
                         continue
 
         # Once files are deleted, check and remove subdirectories which are now empty, as specified in cluster.json.
-        directories_to_check = set(os.path.dirname(f) for f, data in ko_files['extra'].items()
+        directories_to_check = set(os.path.dirname(f) for f, data in validated_extra.items()
                                    if cluster_items['files'][data['cluster_item_key']]['remove_subdirs_if_empty'])
         for directory in directories_to_check:
             try:


### PR DESCRIPTION
## Description

Backport of #36998 to `4.10.5`. It confines the destination path of the non-merged and extra
(delete) branches of `update_master_files_in_worker()` to the directory declared by the file's
`cluster_item_key`, so a file received from the master cannot be written to or removed from an
arbitrary location under the installation directory. The change had to be adapted: `4.10.5` did not
import `WazuhClusterError` in `worker.py` (that import arrives with #36204, backported in
wazuh/internal-devel-requests#5874), so the import was added here, and the dead `except` clause that
the original pull request removed does not exist on `4.10.5`. The follow-up test fix #37314 is
included because it corrects the assertions this change breaks.

- Backport issue: wazuh/internal-devel-requests#5877
- Original issue: wazuh/internal-devel-requests#5244
- Original pull request: #36998 (`4.14.7`), plus follow-up #37314 (`4.14.7`)

## Proposed Changes

- `framework/wazuh/core/cluster/worker.py`: validate `cluster_item_key` and confine the resolved
  destination path with `expected_base` + `os.path.commonpath` in the non-merged branch of
  `overwrite_or_create_files()` and in the `extra` removal loop; only entries that cleared the checks
  are considered for the empty-subdirectory cleanup; import `WazuhClusterError`.
- `framework/wazuh/core/cluster/tests/test_worker.py`: patch `os.path.commonpath` and update the
  `safe_join` call expectations in the existing sub-tests that reach these paths; add
  `test_worker_handler_update_master_files_in_worker_security_checks`.

### Results and Evidence

```
$ PYTHONPATH=/root/wazuh-4.10.5/api:/root/wazuh-4.10.5/framework \
    /root/.cache/wazuh-fixvuln-venv/bin/python -m pytest \
    framework/wazuh/core/cluster/tests/test_worker.py -q
35 passed, 9 warnings in 3.52s

$ PYTHONPATH=/root/wazuh-4.10.5/api:/root/wazuh-4.10.5/framework \
    /root/.cache/wazuh-fixvuln-venv/bin/python -m pytest \
    framework/wazuh/core/cluster/tests/ -q
391 passed, 9 warnings in 9.06s
```

Baseline on `origin/4.10.5` without these commits: `390 passed` (the extra test is the one added
here).

### Artifacts Affected

`wazuh-clusterd` (worker node file synchronization). Python only, no binaries rebuilt.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

`test_worker_handler_update_master_files_in_worker_security_checks`, carried over from #36998: it
covers an invalid `cluster_item_key` and an out-of-directory destination in both the non-merged and
the extra branches.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
