### PR TITLE
Prevent cluster worker from overwriting protected master files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Improved cluster non-merged file path validation during worker file processing. ([#38377](https://github.com/wazuh/wazuh/pull/38377))
 - Improved cluster worker file path validation. ([#38378](https://github.com/wazuh/wazuh/pull/38378))
 - Improved destination path validation when uploading CDB list, rule, and decoder files. ([#38379](https://github.com/wazuh/wazuh/pull/38379))
+- Improved cluster master validation of the files received from worker nodes. ([#38380](https://github.com/wazuh/wazuh/pull/38380))
 
 
 ## [v4.10.4]

--- a/framework/wazuh/core/cluster/master.py
+++ b/framework/wazuh/core/cluster/master.py
@@ -886,8 +886,13 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                     if item_key not in cluster_items['files']:
                         raise exception.WazuhClusterError(3022, extra_message=f"Invalid cluster_item_key: {item_key}")
 
+                    # Workers may only send files whose cluster item is explicitly marked as extra valid.
+                    if not cluster_items['files'][item_key].get('extra_valid', False):
+                        raise exception.WazuhClusterError(3022,
+                            extra_message=f"File not allowed to be synced from worker: {file_path}")
+
                     # Only valid client.keys is the local one (master).
-                    if os.path.basename(file_path) == 'client.keys':
+                    if os.path.basename(full_path) == 'client.keys':
                         raise exception.WazuhClusterError(3007)
 
                     # If the file is merged, create individual files from it.
@@ -942,7 +947,7 @@ class MasterHandler(server.AbstractServerHandler, c_common.WazuhCommon):
                                 raise exception.WazuhClusterError(3022,
                                     extra_message=f"File path outside allowed directory: {file_path}")
 
-                            file_basename = os.path.basename(file_path)
+                            file_basename = os.path.basename(full_path)
                             if file_basename in cluster_items['files'].get('excluded_files', []):
                                 raise exception.WazuhClusterError(3022,
                                     extra_message=f"File is in excluded list: {file_path}")

--- a/framework/wazuh/core/cluster/tests/test_master.py
+++ b/framework/wazuh/core/cluster/tests/test_master.py
@@ -43,8 +43,10 @@ cluster_items = {'node': 'master-node',
                                           'timeout_extra_valid': 0, 'process_pool_size': 10,
                                           'recalculate_integrity': 0, 'sync_agent_groups': 1,
                                           'agent_group_start_delay': 1}},
-                 "files": {"cluster_item_key": {"remove_subdirs_if_empty": True, "permissions": "value"},
-                           "queue/testing/": {"remove_subdirs_if_empty": True, "permissions": "value"}}}
+                 "files": {"cluster_item_key": {"remove_subdirs_if_empty": True, "permissions": "value",
+                                                "extra_valid": True},
+                           "queue/testing/": {"remove_subdirs_if_empty": True, "permissions": "value",
+                                              "extra_valid": True}}}
 
 fernet_key = "0" * 32
 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
@@ -1267,7 +1269,7 @@ def test_master_handler_process_files_from_worker_ok(gid_mock, uid_mock, basenam
                                                       cluster_items=cluster_items, worker_name=worker_name,
                                                       timeout=timeout)
 
-    basename_mock.assert_called_with('data')
+    basename_mock.assert_called_with('/some/path')
     path_join_mock.assert_called_once_with(common.WAZUH_PATH, "data")
     assert result == {'total_updated': 0, 'errors_per_folder': defaultdict(list), 'generic_errors':
                       ["Error updating worker files (extra valid): 'Error 3007 - Client.keys file received in master node'."]}
@@ -1286,7 +1288,7 @@ def test_master_handler_process_files_from_worker_ok(gid_mock, uid_mock, basenam
                                                                   cluster_items=cluster_items, worker_name=worker_name,
                                                                   timeout=timeout)
 
-                basename_mock.assert_has_calls([call('data'), call('/file/path')])
+                basename_mock.assert_has_calls([call('/some/path'), call('/file/path')])
                 path_join_mock.assert_has_calls([call(common.WAZUH_PATH, 'data'),
                                                  call(common.WAZUH_PATH, '/file/path'),
                                                  call(common.WAZUH_PATH, 'queue/testing/'),
@@ -1308,7 +1310,7 @@ def test_master_handler_process_files_from_worker_ok(gid_mock, uid_mock, basenam
                                                                   cluster_items=cluster_items, worker_name=worker_name,
                                                                   timeout=timeout)
 
-                basename_mock.assert_has_calls([call('data'), call('/file/path')])
+                basename_mock.assert_has_calls([call('/some/path'), call('/file/path')])
                 path_join_mock.assert_has_calls([call(common.WAZUH_PATH, 'data'),
                                                  call(common.WAZUH_PATH, '/file/path'),
                                                  call(common.WAZUH_PATH, 'queue/testing/'),
@@ -1335,7 +1337,7 @@ def test_master_handler_process_files_from_worker_ok(gid_mock, uid_mock, basenam
 
                 assert result == {'errors_per_folder': defaultdict(list),
                                   'generic_errors': [], 'total_updated': 1}
-                basename_mock.assert_has_calls([call('data'), call('/file/path')])
+                basename_mock.assert_has_calls([call('/some/path'), call('/file/path')])
                 path_join_mock.assert_has_calls([call(common.WAZUH_PATH, 'data'),
                                                  call(common.WAZUH_PATH, '/file/path'),
                                                  call(common.WAZUH_PATH, 'queue/testing/'),
@@ -1846,7 +1848,8 @@ def test_master_handler_process_files_from_worker_validates_non_merged_path(safe
     cluster_items_with_testing = {**cluster_items,
                                   'files': {**cluster_items['files'],
                                             'queue/testing/': {'remove_subdirs_if_empty': True,
-                                                               'permissions': 'value'}}}
+                                                               'permissions': 'value',
+                                                               'extra_valid': True}}}
 
     basename_mock.return_value = "file.txt"
     files_metadata = {"queue/testing/file.txt": {"merged": False, "cluster_item_key": "queue/testing/"}}
@@ -1886,3 +1889,65 @@ def test_master_handler_process_files_from_worker_validates_non_merged_path(safe
     assert len(result['errors_per_folder']['queue/testing/']) > 0
     assert any('excluded list' in str(e) or '3022' in str(e)
               for e in result['errors_per_folder']['queue/testing/'])
+
+
+@patch("wazuh.core.common.wazuh_uid", return_value="wazuh_uid")
+@patch("wazuh.core.common.wazuh_gid", return_value="wazuh_gid")
+@patch("wazuh.core.cluster.master.utils.safe_move")
+def test_master_handler_process_files_from_worker_rejects_non_extra_valid_item(safe_move_mock, gid_mock, uid_mock):
+    """Test that process_files_from_worker rejects files whose cluster item is not marked as extra valid.
+
+    Every entry in cluster.json is 'source: master, extra_valid: False', so a worker must never be
+    able to push those files to the master.
+    """
+    master_handler = get_master_handler()
+    cluster_items_not_extra_valid = dict(cluster_items)
+    cluster_items_not_extra_valid['files'] = {
+        **cluster_items['files'],
+        'queue/testing/': {'remove_subdirs_if_empty': True, 'permissions': 'value', 'extra_valid': False}
+    }
+    files_metadata = {"queue/testing/file.txt": {"merged": False, "cluster_item_key": "queue/testing/"}}
+
+    result = master_handler.process_files_from_worker(
+        files_metadata=files_metadata,
+        decompressed_files_path='/decompressed',
+        cluster_items=cluster_items_not_extra_valid,
+        worker_name='worker1',
+        timeout=0
+    )
+
+    safe_move_mock.assert_not_called()
+    assert any('not allowed to be synced' in str(e) or '3022' in str(e) for e in result['generic_errors'])
+
+
+@patch("wazuh.core.common.wazuh_uid", return_value="wazuh_uid")
+@patch("wazuh.core.common.wazuh_gid", return_value="wazuh_gid")
+@patch("wazuh.core.cluster.master.utils.safe_move")
+def test_master_handler_process_files_from_worker_normalizes_path_before_excluded_check(safe_move_mock, gid_mock,
+                                                                                        uid_mock):
+    """Test that the excluded_files/client.keys checks use the normalized path, not the raw worker-supplied key.
+
+    A raw key of "etc/ossec.conf/" has an empty os.path.basename() ('' != 'ossec.conf'), so it
+    escapes the excluded_files guard even though it resolves (via safe_join/normpath, which strips
+    the trailing slash) to the real ossec.conf.
+    """
+    master_handler = get_master_handler()
+    cluster_items_etc = dict(cluster_items)
+    cluster_items_etc['files'] = {
+        **cluster_items['files'],
+        'etc/': {'remove_subdirs_if_empty': True, 'permissions': 'value', 'extra_valid': True},
+        'excluded_files': ['ossec.conf']
+    }
+    files_metadata = {"etc/ossec.conf/": {"merged": False, "cluster_item_key": "etc/"}}
+
+    result = master_handler.process_files_from_worker(
+        files_metadata=files_metadata,
+        decompressed_files_path='/decompressed',
+        cluster_items=cluster_items_etc,
+        worker_name='worker1',
+        timeout=0
+    )
+
+    safe_move_mock.assert_not_called()
+    assert len(result['errors_per_folder']['etc/']) > 0
+    assert any('excluded list' in str(e) or '3022' in str(e) for e in result['errors_per_folder']['etc/'])


### PR DESCRIPTION
## Description

Backport of #37694 to `4.10.5`. `MasterHandler.process_files_from_worker` now rejects any file whose
cluster item is not explicitly marked as eligible for worker-to-master sync, and derives the
`client.keys` and `excluded_files` basenames from the already-normalized destination path instead of
the raw key supplied by the worker. The change had to be adapted: `4.10.5` does not yet carry the
`cluster_item_key` membership check nor the non-merged path-confinement check that the original pull
request used as context, so only the guards introduced by #37694 were applied, and the
`excluded_files` guard is added here in its normalized-path form.

- Backport issue: wazuh/internal-devel-requests#5879
- Original issue: wazuh/internal-devel-requests#5533
- Original pull request: #37694 (`4.14.8`)

## Proposed Changes

- `framework/wazuh/core/cluster/master.py`: reject files whose `cluster_items['files'][item_key]`
  is not marked `extra_valid`; compute the `client.keys` basename from the normalized `full_path`;
  add the `excluded_files` guard on the non-merged branch, also using `full_path`.
- `framework/wazuh/core/cluster/tests/test_master.py`: mark the fixture cluster items as
  `extra_valid`, add the `queue/testing/` fixture entry the affected test needs, realign the
  existing `process_files_from_worker` assertions, and add the two regression tests from #37694.

### Results and Evidence

Python-only change, so no build was run.

- `pytest framework/wazuh/core/cluster/tests/test_master.py` — 50 passed.
- `pytest framework/wazuh/core/cluster/tests/` — 392 passed (baseline on `4.10.5` without these
  commits: 390 passed, so the two new tests are the only difference and nothing regressed).
- Negative control: with `master.py` restored to `4.10.5`, both new tests fail
  (`safe_move` reached and called), confirming they cover the change.

### Artifacts Affected

`wazuh-clusterd` (master-side cluster file sync).

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

- `test_master_handler_process_files_from_worker_rejects_non_extra_valid_item`
- `test_master_handler_process_files_from_worker_normalizes_path_before_excluded_check`

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
