### PR TITLE
Fix remote-command configuration validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Improved destination path validation when uploading CDB list, rule, and decoder files. ([#38379](https://github.com/wazuh/wazuh/pull/38379))
 - Improved cluster master validation of the files received from worker nodes. ([#38380](https://github.com/wazuh/wazuh/pull/38380))
 - Fixed a remote-command configuration validation bypass where upper- or mixed-case XML element names let command `localfile` and `wodle` blocks pass the `remote_commands` restriction. ([#38239](https://github.com/wazuh/wazuh/pull/38239))
+- Fixed a remote-command configuration validation bypass where upper- or mixed-case XML element names let command `localfile` and `wodle` blocks pass the `remote_commands` restriction. ([#38381](https://github.com/wazuh/wazuh/pull/38381))
 
 
 ## [v4.10.4]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Improved cluster worker file path validation. ([#38378](https://github.com/wazuh/wazuh/pull/38378))
 - Improved destination path validation when uploading CDB list, rule, and decoder files. ([#38379](https://github.com/wazuh/wazuh/pull/38379))
 - Improved cluster master validation of the files received from worker nodes. ([#38380](https://github.com/wazuh/wazuh/pull/38380))
+- Fixed a remote-command configuration validation bypass where upper- or mixed-case XML element names let command `localfile` and `wodle` blocks pass the `remote_commands` restriction. ([#38239](https://github.com/wazuh/wazuh/pull/38239))
 
 
 ## [v4.10.4]

--- a/framework/wazuh/core/tests/test_utils.py
+++ b/framework/wazuh/core/tests/test_utils.py
@@ -713,6 +713,29 @@ def test_plain_dict_to_nested_dict():
      {'localfile': {'allow': False, 'exceptions': []},
       'wodle_command': {'allow': False, 'exceptions': []}},
      False),
+
+    # Test case where the command log_format tag name is uppercased with a lowercase decoy (should raise when not allowed)
+    ("<ossec_config><localfile><log_format>syslog</log_format><LOG_FORMAT>full_command</LOG_FORMAT>"
+     "<command>id</command></localfile></ossec_config>",
+     "<ossec_config><localfile><log_format>syslog</log_format><location>/var/log/test.log</location></localfile></ossec_config>",
+     {'localfile': {'allow': False, 'exceptions': []},
+      'wodle_command': {'allow': True, 'exceptions': []}},
+     True),
+
+    # Test case where the command log_format tag name uses mixed case (should raise when not allowed)
+    ("<ossec_config><localfile><log_format>syslog</log_format><Log_Format>command</Log_Format>"
+     "<command>echo test</command></localfile></ossec_config>",
+     "<ossec_config><localfile><log_format>syslog</log_format><location>/var/log/test.log</location></localfile></ossec_config>",
+     {'localfile': {'allow': False, 'exceptions': []},
+      'wodle_command': {'allow': True, 'exceptions': []}},
+     True),
+
+    # Test case where the wodle command tag name is uppercased (should raise when not allowed)
+    ('<ossec_config><wodle name="command"><COMMAND>ls -la</COMMAND></wodle></ossec_config>',
+     '<ossec_config><wodle name="command"><tag>value</tag></wodle></ossec_config>',
+     {'localfile': {'allow': True, 'exceptions': []},
+      'wodle_command': {'allow': False, 'exceptions': []}},
+     True),
 ])
 def test_check_remote_commands(new_conf, original_conf, allow_config, should_raise):
     """Tests check_remote_commands with different remote command inputs."""

--- a/framework/wazuh/core/utils.py
+++ b/framework/wazuh/core/utils.py
@@ -969,7 +969,7 @@ def xml_to_dict(root, section_path: list):
 
         if len(element):
             for child in element:
-                result[child.tag] = element_to_dict(child)
+                result[child.tag.lower()] = element_to_dict(child)
         else:
             result = {
                 'attrib': element.attrib,


### PR DESCRIPTION
## Description

Backport of #38239 to `4.10.5`. `element_to_dict` now builds each dictionary key from the
lower-cased XML element tag, so the upload-configuration validators classify `localfile` and `wodle`
elements the same way `wazuh-logcollector` does (case-insensitively) and command blocks written with
upper- or mixed-case tag names are no longer invisible to `check_remote_commands`. The code change
applied without adaptation; only the `CHANGELOG.md` entry had to be moved to the `v4.10.5` section.

- Backport issue: wazuh/internal-devel-requests#5880
- Original issue: wazuh/internal-devel-requests#5812
- Original pull request: #38239 (`4.14.8`)

## Proposed Changes

- `framework/wazuh/core/utils.py`: in `element_to_dict` (used by `xml_to_dict`), key the result on
  `child.tag.lower()` instead of the verbatim tag, so upper- and mixed-case element names collapse
  onto their canonical key for every validator that shares `xml_to_dict`.
- `framework/wazuh/core/tests/test_utils.py`: three parametrized cases added to
  `test_check_remote_commands` covering upper- and mixed-case tag names.
- `CHANGELOG.md`: entry added under `v4.10.5` / Manager / Fixed.

### Results and Evidence

Python-only change, so no build was run.

- `pytest framework/wazuh/core/tests/test_utils.py -k test_check_remote_commands` — 10 passed,
  300 deselected.
- `pytest framework/wazuh/core/tests/test_utils.py` — 310 passed.
- `pytest framework/wazuh/core/tests framework/wazuh/tests/test_manager.py` — 1003 passed
  (all the sibling validators that share `xml_to_dict` live in `utils.py`; no regressions).
- Negative control: with `utils.py` restored to `4.10.5`, the three new cases fail
  (3 failed, 7 passed), confirming they cover the change.

### Artifacts Affected

Wazuh manager framework / API (`wazuh-apid`), bundled in the `wazuh-manager` package. No agent-side
or C binaries are affected.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

Three cases added to `test_check_remote_commands` in `framework/wazuh/core/tests/test_utils.py`:

- `localfile` with a lowercase `<log_format>` decoy plus an uppercase
  `<LOG_FORMAT>full_command</LOG_FORMAT>`.
- `localfile` with a mixed-case `<Log_Format>command</Log_Format>`.
- `wodle` command block with an uppercase `<COMMAND>` element.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
