### PR TITLE
Prevent Linux audit plugin starvation when the Wazuh agent starts during a manager outage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 - Fixed WPK upgrade failing on agents without the `find` binary. ([#38431](https://github.com/wazuh/wazuh/pull/38431))
 - Bounded the `snort-full` log record appends to the available buffer space and sized the queued preprocessor message from its own line in `wazuh-logcollector`. ([#38472](https://github.com/wazuh/wazuh/pull/38472))
 - Restricted the GitHub, Office 365 and MS Graph wodles pagination and content retrieval to the configured API host, so the authentication token is not sent to another host. ([#38688](https://github.com/wazuh/wazuh/pull/38688))
+- Fixed whodata (audit) holding the audisp socket undrained at startup when the manager is unreachable, starving other audit plugins. ([#38382](https://github.com/wazuh/wazuh/pull/38382))
 
 ## [v4.14.8]
 

--- a/src/syscheckd/include/syscheck.h
+++ b/src/syscheckd/include/syscheck.h
@@ -24,6 +24,7 @@
 /* Audit defs */
 #define WDATA_DEFAULT_INTERVAL_SCAN 300
 #define AUDIT_SOCKET                "queue/sockets/audit"
+#define MAX_CONN_RETRIES            5          // Max retries to reconnect to Audit socket
 #define AUDIT_CONF_FILE             "tmp/af_wazuh.conf"
 #define AUDIT_HEALTHCHECK_DIR       "tmp"
 #define AUDIT_HEALTHCHECK_KEY       "wazuh_hc"
@@ -545,6 +546,14 @@ int set_auditd_config(void);
  * @return File descriptor of the socket, -1 on error
  */
 int init_auditd_socket(void);
+
+/**
+ * @brief Reconnect to the Auditd socket, retrying up to MAX_CONN_RETRIES times
+ *
+ * @param audit_sock Output: file descriptor of the reconnected socket, -1 on failure
+ * @return File descriptor of the socket, -1 on error
+ */
+int audit_reconnect_with_retries(int *audit_sock);
 
 /**
  * @brief Reloads audit rules every RELOAD_RULES_INTERVAL seconds

--- a/src/syscheckd/src/whodata/syscheck_audit.c
+++ b/src/syscheckd/src/whodata/syscheck_audit.c
@@ -536,9 +536,9 @@ void *audit_main(audit_data_t *audit_data) {
         audit_data->socket = init_auditd_socket();
     }
     if (audit_data->socket < 0) {
-        merror(FIM_ERROR_WHODATA_SOCKET_CONNECT, AUDIT_SOCKET);
+        mwarn(FIM_WARN_AUDIT_THREAD_NOSTARTED);
         atomic_int_set(&audit_thread_active, 0);
-        return NULL;
+        goto whodata_teardown;
     }
 
     if (audit_data->mode == AUDIT_ENABLED) {
@@ -555,6 +555,7 @@ void *audit_main(audit_data_t *audit_data) {
     mdebug1(FIM_AUDIT_THREAD_STOPED);
     close(audit_data->socket);
 
+whodata_teardown:
     // Clean regexes used for parsing events
     clean_regex();
 

--- a/src/syscheckd/src/whodata/syscheck_audit.c
+++ b/src/syscheckd/src/whodata/syscheck_audit.c
@@ -24,7 +24,6 @@
 #define PLUGINS_DIR_AUDIT           "/etc/audit/plugins.d"
 #define AUDIT_CONF_LINK             "af_wazuh.conf"
 #define BUF_SIZE OS_MAXSTR
-#define MAX_CONN_RETRIES 5          // Max retries to reconnect to Audit socket
 
 // Global variables
 pthread_mutex_t audit_mutex;
@@ -504,6 +503,20 @@ void audit_set_db_consistency(void) {
 }
 // LCOV_EXCL_STOP
 
+// Reconnect to the Auditd socket, retrying up to MAX_CONN_RETRIES times.
+int audit_reconnect_with_retries(int *audit_sock) {
+    int conn_retries = 0;
+
+    *audit_sock = init_auditd_socket();
+    while (*audit_sock < 0 && conn_retries < MAX_CONN_RETRIES) {
+        sleep(1);
+        minfo(FIM_AUDIT_RECONNECT, ++conn_retries);
+        *audit_sock = init_auditd_socket();
+    }
+
+    return *audit_sock;
+}
+
 // LCOV_EXCL_START
 void *audit_main(audit_data_t *audit_data) {
     char *path = NULL;
@@ -528,14 +541,7 @@ void *audit_main(audit_data_t *audit_data) {
     w_mutex_unlock(&audit_mutex);
 
     // Reconnect once the gate is lifted
-    int conn_retries = 0;
-    audit_data->socket = init_auditd_socket();
-    while (audit_data->socket < 0 && conn_retries < MAX_CONN_RETRIES) {
-        sleep(1);
-        minfo(FIM_AUDIT_RECONNECT, ++conn_retries);
-        audit_data->socket = init_auditd_socket();
-    }
-    if (audit_data->socket < 0) {
+    if (audit_reconnect_with_retries(&audit_data->socket) < 0) {
         mwarn(FIM_WARN_AUDIT_THREAD_NOSTARTED);
         atomic_int_set(&audit_thread_active, 0);
         goto whodata_teardown;

--- a/src/syscheckd/src/whodata/syscheck_audit.c
+++ b/src/syscheckd/src/whodata/syscheck_audit.c
@@ -516,11 +516,30 @@ void *audit_main(audit_data_t *audit_data) {
     atomic_int_set(&audit_thread_active, 1);
     w_cond_signal(&audit_thread_started);
 
+    if (audit_data->socket >= 0) {
+        close(audit_data->socket);
+        audit_data->socket = -1;
+    }
+
     while (!audit_db_consistency_flag) {
         w_cond_wait(&audit_db_consistency, &audit_mutex);
     }
 
     w_mutex_unlock(&audit_mutex);
+
+    // Reconnect once the gate is lifted
+    int conn_retries = 0;
+    audit_data->socket = init_auditd_socket();
+    while (audit_data->socket < 0 && conn_retries < MAX_CONN_RETRIES) {
+        sleep(1);
+        minfo(FIM_AUDIT_RECONNECT, ++conn_retries);
+        audit_data->socket = init_auditd_socket();
+    }
+    if (audit_data->socket < 0) {
+        merror(FIM_ERROR_WHODATA_SOCKET_CONNECT, AUDIT_SOCKET);
+        atomic_int_set(&audit_thread_active, 0);
+        return NULL;
+    }
 
     if (audit_data->mode == AUDIT_ENABLED) {
         // Start rules reloading thread

--- a/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
+++ b/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
@@ -1167,6 +1167,54 @@ void test_audit_read_events_select_success_recv_error_audit_reconnect(void **sta
     audit_read_events(audit_sock, &audit_thread_active);
 }
 
+void test_audit_reconnect_with_retries_success(void **state) {
+    (void) state;
+    int audit_sock = -1;
+    char merror_msg[OS_SIZE_128] = {0};
+    snprintf(merror_msg, OS_SIZE_128, FIM_ERROR_WHODATA_SOCKET_CONNECT, AUDIT_SOCKET);
+
+    // First init_auditd_socket() attempt fails
+    expect_any(__wrap_OS_ConnectUnixDomain, path);
+    expect_any(__wrap_OS_ConnectUnixDomain, type);
+    expect_any(__wrap_OS_ConnectUnixDomain, max_msg_size);
+    will_return(__wrap_OS_ConnectUnixDomain, -1);
+    expect_string(__wrap__merror, formatted_msg, merror_msg);
+
+    // Retry sleeps, logs the reconnect and succeeds
+    expect_value(__wrap_sleep, seconds, 1);
+    expect_any(__wrap__minfo, formatted_msg);
+    expect_any(__wrap_OS_ConnectUnixDomain, path);
+    expect_any(__wrap_OS_ConnectUnixDomain, type);
+    expect_any(__wrap_OS_ConnectUnixDomain, max_msg_size);
+    will_return(__wrap_OS_ConnectUnixDomain, 124);
+
+    assert_int_equal(audit_reconnect_with_retries(&audit_sock), 124);
+    assert_int_equal(audit_sock, 124);
+}
+
+void test_audit_reconnect_with_retries_exhausted(void **state) {
+    (void) state;
+    int audit_sock = -1;
+    char merror_msg[OS_SIZE_128] = {0};
+    snprintf(merror_msg, OS_SIZE_128, FIM_ERROR_WHODATA_SOCKET_CONNECT, AUDIT_SOCKET);
+
+    // 1 initial attempt + MAX_CONN_RETRIES retries, all failing -> returns -1
+    for (int i = 0; i <= MAX_CONN_RETRIES; i++) {
+        if (i > 0) {
+            expect_value(__wrap_sleep, seconds, 1);
+            expect_any(__wrap__minfo, formatted_msg);
+        }
+        expect_any(__wrap_OS_ConnectUnixDomain, path);
+        expect_any(__wrap_OS_ConnectUnixDomain, type);
+        expect_any(__wrap_OS_ConnectUnixDomain, max_msg_size);
+        will_return(__wrap_OS_ConnectUnixDomain, -1);
+        expect_string(__wrap__merror, formatted_msg, merror_msg);
+    }
+
+    assert_int_equal(audit_reconnect_with_retries(&audit_sock), -1);
+    assert_int_equal(audit_sock, -1);
+}
+
 void test_audit_read_events_select_success_recv_success(void **state) {
     (void) state;
     int *audit_sock = *state;
@@ -1697,6 +1745,8 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_audit_read_events_select_case_0, test_audit_read_events_setup, test_audit_read_events_teardown),
         cmocka_unit_test_setup_teardown(test_audit_read_events_select_success_recv_error_audit_connection_closed, test_audit_read_events_setup, test_audit_read_events_teardown),
         cmocka_unit_test_setup_teardown(test_audit_read_events_select_success_recv_error_audit_reconnect, test_audit_read_events_setup, test_audit_read_events_teardown),
+        cmocka_unit_test(test_audit_reconnect_with_retries_success),
+        cmocka_unit_test(test_audit_reconnect_with_retries_exhausted),
         cmocka_unit_test_setup_teardown(test_audit_read_events_select_success_recv_success, test_audit_read_events_setup, test_audit_read_events_teardown),
         cmocka_unit_test_setup_teardown(test_audit_read_events_select_success_recv_success_no_endline, test_audit_read_events_setup, test_audit_read_events_teardown),
         cmocka_unit_test_setup_teardown(test_audit_read_events_select_success_recv_success_no_id, test_audit_read_events_setup, test_audit_read_events_teardown),


### PR DESCRIPTION
## Description

This PR fixes a defect where a Wazuh agent using FIM whodata with the **audit** provider leaves the audisp socket connected but undrained when it (re)starts while the manager is unreachable. On systems whose audit userspace is older than 3.1.1 (the blocking builtin `af_unix` plugin), this stalls `audispd`'s single-threaded dispatch loop and **starves every other audit plugin on the host** until the manager reconnects. On newer audit the agent still silently drops its own whodata events for the whole outage.

The root cause: the audit socket is connected in `audit_init()` before the reader is allowed to drain it, and the reader is gated behind `audit_db_consistency_flag`, which is only set after the initial baseline scan. When the manager is down, `fim_scan()` blocks on the agent's `.wait` lock, so `fim_whodata_initialize()` is never reached, the flag is never set, and `audit_main()` parks in `w_cond_wait()` **before** `audit_read_events()` — never calling `recv()`. The socket buffer fills and the builtin `af_unix` `write()` (blocking, recovers only on `EPIPE`) stalls the whole dispatcher.

The fix does not hold the socket connected while gated: it closes the socket before waiting on the flag and reconnects (with retries) right before `audit_read_events()`. While gated no client is attached, so `audispd`'s `write()` fails fast (`EPIPE`) and keeps servicing the other plugins.

**Proposed Release:** [v4.14.9]
**Issue:** wazuh/wazuh#38310
**Internal Reference:** N/A

## Proposed Changes

- Updated `src/syscheckd/src/whodata/syscheck_audit.c`: in `audit_main()`, close `audit_data->socket` before the `while (!audit_db_consistency_flag) w_cond_wait(...)` gate, and reconnect via `init_auditd_socket()` (retrying up to `MAX_CONN_RETRIES`) immediately before `audit_read_events()`. If the reconnect fails, mark the thread inactive and exit cleanly instead of running the reader on an invalid socket.
- Updated `CHANGELOG.md` with the fix entry under `v4.14.9`.

### Results and Evidence

Validated end-to-end on **Ubuntu 20.04.6 LTS, audit 2.8.5 (blocking builtin `af_unix`)** — the reporter's platform — with the agent pointed at an unreachable manager (`240.0.0.1`) and (re)started while it is down. A second, independent audisp plugin (`plugin2`, appends every event to a log) measures whether the dispatcher is starved. Same host, same manager-down condition, same event churn; the only difference between runs is this one-file patch (`wazuh-syscheckd` rebuilt from `v4.14.7` + the patch).

```bash
# Reproduction driver (per run): install a 2nd audisp plugin, force whodata=audit on
# /etc, point the agent at a dead manager, restart, churn /etc, then measure.
sudo bash repro_38310_e2e.sh <stock|patched>

# --- STOCK 4.14.7 ---
# ss -xp on the audit socket during the outage:
u_str ESTAB 0 213248 /var/ossec/queue/sockets/audit ... users:(("audispd",pid=21189,fd=8))
#   -> Send-Q = 213248 (full): audispd's builtin write to the undraining Wazuh client is blocked
SECOND-PLUGIN lines received during 20s churn window: 0
VERDICT[stock]: STARVED (bug reproduced)

# --- PATCHED (v4.14.7 + this fix) ---
# ss -xp on the audit socket during the outage:
#   (no ESTAB connection to queue/sockets/audit -> the socket is not held while gated)
SECOND-PLUGIN lines received during 20s churn window: 10650
VERDICT[patched]: FLOWING (not starved)
```

The mechanism was additionally proven from the vendored audit userspace source (`src/external/audit-userspace/audisp/audispd.c` single-threaded `event_loop` calling the builtin `af_unix` write inline; `audispd-builtins.c` `send_af_unix_string` blocking, recovering only on `EPIPE`), and the agent-side undrained-socket state was reproduced on Ubuntu 24.04 (audit 3.1.2) via `ss -xp` (syscheckd Recv-Q backlog + peer Send-Q full).

### Artifacts Affected

- `src/syscheckd/src/whodata/syscheck_audit.c`
- `CHANGELOG.md`

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Manual Integration Test.
- **Details:** Built `wazuh-syscheckd` from `v4.14.7` with and without the patch and swapped only that binary on the same Ubuntu 20.04 host. Confirmed that a second audisp plugin receives 0 events with the stock binary (starved) and continues receiving events with the patched binary (not starved), while the manager stays unreachable. `audit_main()` is a thread entry point excluded from unit-test coverage (`LCOV_EXCL`), so no unit test is added.

## Review Checklist

**Manual tests with their corresponding evidence:**

- Compilation without warnings on every supported platform

    - [ ] Linux
    - [ ] Windows
    - [ ] MAC OS X

- [ ] Log syntax and correct language review

- Memory tests for Linux

    - [ ] Coverity
    - [ ] Valgrind (memcheck and descriptor leaks check)
    - [ ] AddressSanitizer

**General Checklist:**

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
