### PR TITLE
Unify wazuh.schema.version across the /stats and /config agent reports

### DIFF
--- a/src/client-agent/https_client/tests/unit/reporterStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/reporterStream_test.cpp
@@ -171,7 +171,8 @@ TEST_F(ReporterStreamTest, NullCollectorReturnRetriesSoonNotAfterFullInterval)
     // short backoff as a send failure, not wait out the full (60 s here) interval.
     m_collectors.m_stats = std::nullopt;
     const auto config = makeConfig(true, false);
-    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate, m_cluster, m_collectors};
+    ReporterStream reporter {config, m_performer, m_signer, m_clock, m_random, m_authGate, m_compressionGate,
+                             m_cluster, m_collectors};
     EXPECT_CALL(m_performer, perform(_)).Times(0);
 
     reporter.tick(m_waiter, true); // First attempt: nothing collected yet.

--- a/src/wazuh_modules/inventory_sync_server/src/endpoints/configEndpoint.cpp
+++ b/src/wazuh_modules/inventory_sync_server/src/endpoints/configEndpoint.cpp
@@ -31,10 +31,10 @@ namespace
     // deletion scope rather than re-spelled here, so DELETE /agents can never miss this index.
     constexpr std::string_view AGENT_CONFIG_INDEX_NAME {invsync::sync::AGENT_CONFIG_INDEX};
 
-    // WCS (Wazuh Common Schema) field naming convention, per docs/ref/glossary.md. Local to this
-    // module: there is no shared cross-module constant for it (vulnerability_scanner defines its
-    // own the same way).
-    constexpr auto WAZUH_SCHEMA_VERSION {"1.0.0"};
+    // `wazuh.schema.version` marker, a string keyword per WCS (docs/ref/glossary.md). The value
+    // matches `/stats` and the stateful `wazuh-states-*` indices so the marker keeps one format
+    // across agent-scoped indices. Local to this module: there is no shared cross-module constant.
+    constexpr auto WAZUH_SCHEMA_VERSION {"1.0"};
 
     // Generation of the *layout* this handler produces under `wazuh.agent.configuration` -- bump
     // this if that shape ever changes, not on every report. Always 1 today: this is the first

--- a/src/wazuh_modules/inventory_sync_server/src/endpoints/configEndpoint.hpp
+++ b/src/wazuh_modules/inventory_sync_server/src/endpoints/configEndpoint.hpp
@@ -33,7 +33,7 @@ namespace invsync::endpoints::config
      * {
      *   "state": { "modified_at": "...", "document_version": 1 },
      *   "wazuh": {
-     *     "schema": { "version": "1.0.0" },
+     *     "schema": { "version": "1.0" },
      *     "agent": { "id": "<authenticated id>",
      *                "configuration": { "modules": ["fim", "logcollector", ...],
      *                                   "content": { "fim": {...}, "logcollector": {...}, ... } } },

--- a/src/wazuh_modules/inventory_sync_server/src/endpoints/statsEndpoint.cpp
+++ b/src/wazuh_modules/inventory_sync_server/src/endpoints/statsEndpoint.cpp
@@ -31,10 +31,11 @@ namespace
     /// to the envelope.
     constexpr int STATS_DOCUMENT_VERSION {1};
 
-    /// `wazuh.schema.version` is the schema-wide marker, kept as a string because that is how
-    /// `wazuh-metrics-agents` declares it (keyword, not a number). Distinct from the layout version
-    /// above: this one tracks the schema the document claims to follow.
-    constexpr auto STATS_SCHEMA_VERSION {"1"};
+    /// `wazuh.schema.version` is the schema-wide marker, a string keyword (not a number). The value
+    /// matches `/config` and the stateful `wazuh-states-*` indices so the marker keeps one format
+    /// across agent-scoped indices. Distinct from the layout version above: this one tracks the
+    /// schema the document claims to follow.
+    constexpr auto STATS_SCHEMA_VERSION {"1.0"};
 
     // One shared instance rather than a per-call temporary: this runs on EVERY request.
     // loggerHelper.h stays out of statsEndpoint.hpp, which the tests include.

--- a/src/wazuh_modules/inventory_sync_server/src/endpoints/statsEndpoint.hpp
+++ b/src/wazuh_modules/inventory_sync_server/src/endpoints/statsEndpoint.hpp
@@ -37,7 +37,7 @@ namespace invsync::endpoints::stats
      *
      * ```json
      * {"state": {"modified_at": …, "document_version": 1},
-     *  "wazuh": {"schema": {"version": "1"}, "cluster": {…},
+     *  "wazuh": {"schema": {"version": "1.0"}, "cluster": {…},
      *            "agent": {"id": …, "statistics": {"agent": {…}, …}}}}
      * ```
      *

--- a/src/wazuh_modules/inventory_sync_server/test/unit/configEndpoint_test.cpp
+++ b/src/wazuh_modules/inventory_sync_server/test/unit/configEndpoint_test.cpp
@@ -239,7 +239,7 @@ TEST(ConfigEndpointTest, IndexedDocumentStampsTheWcsSchemaVersion)
     ASSERT_EQ(200, run(makeRequest(R"({"modules":{"fim":{}}})", "001"), connector).status);
 
     const auto document = soleIndexedDocument(*connector);
-    EXPECT_EQ("1.0.0", document["/wazuh/schema/version"_json_pointer].get<std::string>());
+    EXPECT_EQ("1.0", document["/wazuh/schema/version"_json_pointer].get<std::string>());
 }
 
 /**

--- a/src/wazuh_modules/inventory_sync_server/test/unit/statsEndpoint_test.cpp
+++ b/src/wazuh_modules/inventory_sync_server/test/unit/statsEndpoint_test.cpp
@@ -294,7 +294,7 @@ TEST(StatsEndpointTest, NothingTheAgentClaimsAboutItsIdentityIsIndexed)
     EXPECT_FALSE(document.contains("cluster")) << "the reporter's root cluster object must not survive";
     EXPECT_EQ("001", document["/wazuh/agent/id"_json_pointer].get<std::string>()) << "claimed 999";
     EXPECT_EQ("test-cluster", document["/wazuh/cluster/name"_json_pointer].get<std::string>());
-    EXPECT_EQ("1", document["/wazuh/schema/version"_json_pointer].get<std::string>()) << "claimed 999";
+    EXPECT_EQ("1.0", document["/wazuh/schema/version"_json_pointer].get<std::string>()) << "claimed 999";
     EXPECT_EQ(1, document["/state/document_version"_json_pointer].get<int>()) << "claimed 999";
 }
 
@@ -318,15 +318,16 @@ TEST(StatsEndpointTest, StampsStateModifiedAtIso8601WithMillisecondsAndZulu)
 }
 
 /**
- * `wazuh.schema.version` is a string, not a number: `wazuh-metrics-agents` declares it `keyword`, and
- * this index follows it so one schema marker does not come back in two types depending on the index.
+ * `wazuh.schema.version` is a string, not a number: it is declared `keyword`, so one schema marker
+ * does not come back in two types depending on the index. The value matches `/config` and the
+ * stateful `wazuh-states-*` indices.
  */
 TEST(StatsEndpointTest, StampsTheSchemaVersionAsAKeyword)
 {
     const auto version = indexedDocument(kAgentReport, "001")["/wazuh/schema/version"_json_pointer];
 
     ASSERT_TRUE(version.is_string()) << version.dump();
-    EXPECT_EQ("1", version.get<std::string>());
+    EXPECT_EQ("1.0", version.get<std::string>());
 }
 
 TEST(StatsEndpointTest, NonObjectBodiesAreRejected)


### PR DESCRIPTION
## Description

During the E2E validation of the periodic `/stats` and `/config` push (#38164), the `wazuh.schema.version` field came back with a different value in each index: `"1"` in `wazuh-agent-stats` and `"1.0.0"` in `wazuh-agent-config`.

The field is stamped manager-side, not by the agent: modulesd's inventory-sync-server rebuilds the `wazuh` envelope from scratch on every push and overrides whatever the agent claims. The two endpoint handlers hardcoded different literals, so the same WCS field was emitted in two formats depending on the index, and a consumer reading it uniformly could not parse it.

Closes #38386
Related to #38164.

## Proposed Changes

- Set `wazuh.schema.version` to `"1.0"` in both endpoints, matching the stateful `wazuh-states-*` inventory indices (the largest agent-scoped family, already on `"1.0"`).
  - `statsEndpoint.cpp`: `STATS_SCHEMA_VERSION` `"1"` -> `"1.0"`
  - `configEndpoint.cpp`: `WAZUH_SCHEMA_VERSION` `"1.0.0"` -> `"1.0"`
- Update the unit tests that pin the value and the doc-comment examples.


## Additional fix: unblock the agent build on 5.0.0-https

`5.0.0-https` does not compile the agent since 2026-08-14: PR #38355 added the compression gate as a 9th `ReporterStream` constructor parameter, and PR #38367 later merged a new startup-race test that still constructed it with the 8-argument signature. Both PRs were green in isolation; the combination has no textual conflict but breaks the `Unit-Tests (agent)`, `Unit-Tests (winagent)` and `build-sonoma` builds.

This PR's own change is manager-only (modulesd) and cannot cause that break, but every build off this branch inherits it. Fixed here so this PR's checks are green: `reporterStream_test.cpp` now passes `m_compressionGate` like the other constructions.

### Results and Evidence

Before (`origin/5.0.0-https`):

| Index | Endpoint | `wazuh.schema.version` |
|---|---|---|
| `wazuh-agent-stats` | `statsEndpoint.cpp` | `"1"` |
| `wazuh-agent-config` | `configEndpoint.cpp` | `"1.0.0"` |

After (this PR): both `"1.0"`.

The mismatch was observed in the E2E run for #38164 (indexed documents of `wazuh-agent-stats` vs `wazuh-agent-config`). The unit tests `StatsEndpointTest.StampsTheSchemaVersionAsAKeyword` / `NothingTheAgentClaimsAboutItsIdentityIsIndexed` and `ConfigEndpointTest.IndexedDocumentStampsTheWcsSchemaVersion` are updated to assert `"1.0"`. Not compiled locally (modulesd unit tests need the full deps toolchain); relying on CI.

### Artifacts Affected

- `wazuh-modulesd` (inventory-sync-server endpoints).

### Configuration Changes

None.

### Documentation Updates

None (endpoint doc-comment JSON examples updated in-code).

### Tests Introduced

No new tests; existing unit tests updated to assert the unified value.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
