### PR TITLE
Own the systemd D-Bus connection so the services collector recovers after a bus restart

### DIFF
--- a/src/data_provider/src/extended_sources/services/src/systemd_units_linux.cpp
+++ b/src/data_provider/src/extended_sources/services/src/systemd_units_linux.cpp
@@ -12,6 +12,46 @@
 #include "systemd_units_linux.hpp"
 #include "stringHelper.h"
 
+namespace
+{
+    /// @brief Owns a private D-Bus connection for the duration of a scope.
+    ///
+    /// bus_get_private() transfers ownership to the caller, so the connection has to be closed
+    /// and unreferenced on every exit path. Doing that through a guard rather than by hand
+    /// keeps a future early return from reintroducing the leak.
+    class ScopedDBusConnection final
+    {
+        public:
+            ScopedDBusConnection(std::shared_ptr<IDBusWrapper> dbusWrapper, DBusConnection* connection)
+                : m_dbusWrapper(std::move(dbusWrapper))
+                , m_connection(connection)
+            {
+            }
+
+            ~ScopedDBusConnection()
+            {
+                if (m_connection)
+                {
+                    m_dbusWrapper->connection_close(m_connection);
+                    m_dbusWrapper->connection_unref(m_connection);
+                }
+            }
+
+            ScopedDBusConnection(const ScopedDBusConnection&) = delete;
+            ScopedDBusConnection& operator=(const ScopedDBusConnection&) = delete;
+
+            /// @brief Returns the owned connection, or nullptr if it could not be acquired.
+            DBusConnection* get() const
+            {
+                return m_connection;
+            }
+
+        private:
+            std::shared_ptr<IDBusWrapper> m_dbusWrapper;
+            DBusConnection* m_connection;
+    };
+}
+
 SystemdUnitsProvider::SystemdUnitsProvider(std::shared_ptr<IDBusWrapper> dbusWrapper)
     : m_dbusWrapper(std::move(dbusWrapper))
 {
@@ -62,7 +102,9 @@ bool SystemdUnitsProvider::getSystemdUnits(std::vector<SystemdUnit>& output)
     DBusError err;
     m_dbusWrapper->error_init(&err);
 
-    DBusConnection* conn = m_dbusWrapper->bus_get(DBUS_BUS_SYSTEM, &err);
+    // Owned for the rest of this scope, and released on every return path below.
+    ScopedDBusConnection scopedConnection {m_dbusWrapper, m_dbusWrapper->bus_get_private(DBUS_BUS_SYSTEM, &err)};
+    DBusConnection* conn = scopedConnection.get();
 
     if (!conn || m_dbusWrapper->error_is_set(&err))
     {

--- a/src/data_provider/src/extended_sources/services/tests/test_systemd_units_linux.cpp
+++ b/src/data_provider/src/extended_sources/services/tests/test_systemd_units_linux.cpp
@@ -24,7 +24,9 @@ class MockDBusWrapper : public IDBusWrapper
         MOCK_METHOD(void, error_init, (DBusError*), (override));
         MOCK_METHOD(bool, error_is_set, (const DBusError*), (override));
         MOCK_METHOD(void, error_free, (DBusError*), (override));
-        MOCK_METHOD(DBusConnection*, bus_get, (DBusBusType, DBusError*), (override));
+        MOCK_METHOD(DBusConnection*, bus_get_private, (DBusBusType, DBusError*), (override));
+        MOCK_METHOD(void, connection_close, (DBusConnection*), (override));
+        MOCK_METHOD(void, connection_unref, (DBusConnection*), (override));
         MOCK_METHOD(DBusMessage*, message_new_method_call, (const std::string&, const std::string&, const std::string&, const std::string&), (override));
         MOCK_METHOD(DBusMessage*, connection_send_with_reply_and_block, (DBusConnection*, DBusMessage*, int, DBusError*), (override));
         MOCK_METHOD(void, message_unref, (DBusMessage*), (override));
@@ -49,7 +51,7 @@ void SetUpTestMock(std::shared_ptr<MockDBusWrapper>& mockDbusWrapper)
     // Initialization
     EXPECT_CALL(*mockDbusWrapper, error_init(_));
 
-    EXPECT_CALL(*mockDbusWrapper, bus_get(DBUS_BUS_SYSTEM, _))
+    EXPECT_CALL(*mockDbusWrapper, bus_get_private(DBUS_BUS_SYSTEM, _))
     .WillOnce(DoAll(
                   Invoke([](DBusBusType, DBusError * err)
     {
@@ -57,6 +59,11 @@ void SetUpTestMock(std::shared_ptr<MockDBusWrapper>& mockDbusWrapper)
     }),
     Return(conn)
               ));
+
+    // The connection is acquired privately, so the provider owns it and must close and
+    // release it exactly once, on this path as on every other.
+    EXPECT_CALL(*mockDbusWrapper, connection_close(conn)).Times(1);
+    EXPECT_CALL(*mockDbusWrapper, connection_unref(conn)).Times(1);
 
     EXPECT_CALL(*mockDbusWrapper, error_is_set(_)).WillRepeatedly(Return(false));
 
@@ -419,7 +426,7 @@ TEST(SystemdUnitsProviderTest, FailsWhenBusConnectionFails)
     SystemdUnitsProvider provider(mockDbusWrapper);
 
     EXPECT_CALL(*mockDbusWrapper, error_init(_));
-    EXPECT_CALL(*mockDbusWrapper, bus_get(DBUS_BUS_SYSTEM, _))
+    EXPECT_CALL(*mockDbusWrapper, bus_get_private(DBUS_BUS_SYSTEM, _))
     .WillOnce(DoAll(
                   Invoke([](DBusBusType, DBusError * err)
     {
@@ -427,6 +434,10 @@ TEST(SystemdUnitsProviderTest, FailsWhenBusConnectionFails)
     }),
     Return(nullptr)
               ));
+
+    // Nothing was acquired, so nothing may be closed or released.
+    EXPECT_CALL(*mockDbusWrapper, connection_close(_)).Times(0);
+    EXPECT_CALL(*mockDbusWrapper, connection_unref(_)).Times(0);
 
     EXPECT_CALL(*mockDbusWrapper, error_free(_))
     .WillRepeatedly(Invoke([](auto)
@@ -450,7 +461,7 @@ TEST(SystemdUnitsProviderTest, FailsWhenMessageCreationFails)
     {
         // do nothing
     }));
-    EXPECT_CALL(*mockDbusWrapper, bus_get(DBUS_BUS_SYSTEM, _))
+    EXPECT_CALL(*mockDbusWrapper, bus_get_private(DBUS_BUS_SYSTEM, _))
     .WillOnce(DoAll(
                   Invoke([](DBusBusType, DBusError * err)
     {
@@ -458,6 +469,11 @@ TEST(SystemdUnitsProviderTest, FailsWhenMessageCreationFails)
     }),
     Return(conn)
               ));
+
+    // The connection is acquired privately, so the provider owns it and must close and
+    // release it exactly once, on this path as on every other.
+    EXPECT_CALL(*mockDbusWrapper, connection_close(conn)).Times(1);
+    EXPECT_CALL(*mockDbusWrapper, connection_unref(conn)).Times(1);
     EXPECT_CALL(*mockDbusWrapper, error_is_set(_)).WillOnce(Return(false));
     EXPECT_CALL(*mockDbusWrapper, message_new_method_call(_, _, _, _))
     .WillOnce(Return(nullptr));
@@ -477,8 +493,13 @@ TEST(SystemdUnitsProviderTest, FailsWhenReplyHasNoArguments)
 
     EXPECT_CALL(*mockDbusWrapper, error_init(_));
     EXPECT_CALL(*mockDbusWrapper, error_free(_));
-    EXPECT_CALL(*mockDbusWrapper, bus_get(DBUS_BUS_SYSTEM, _))
+    EXPECT_CALL(*mockDbusWrapper, bus_get_private(DBUS_BUS_SYSTEM, _))
     .WillOnce(Return(conn));
+
+    // The connection is acquired privately, so the provider owns it and must close and
+    // release it exactly once, on this path as on every other.
+    EXPECT_CALL(*mockDbusWrapper, connection_close(conn)).Times(1);
+    EXPECT_CALL(*mockDbusWrapper, connection_unref(conn)).Times(1);
     EXPECT_CALL(*mockDbusWrapper, error_is_set(_)).WillRepeatedly(Return(false));
     EXPECT_CALL(*mockDbusWrapper, message_new_method_call(_, _, _, _))
     .WillOnce(Return(msg));
@@ -504,8 +525,13 @@ TEST(SystemdUnitsProviderTest, FailsWhenReplyIsNotArray)
 
     EXPECT_CALL(*mockDbusWrapper, error_init(_));
     EXPECT_CALL(*mockDbusWrapper, error_free(_));
-    EXPECT_CALL(*mockDbusWrapper, bus_get(DBUS_BUS_SYSTEM, _))
+    EXPECT_CALL(*mockDbusWrapper, bus_get_private(DBUS_BUS_SYSTEM, _))
     .WillOnce(Return(conn));
+
+    // The connection is acquired privately, so the provider owns it and must close and
+    // release it exactly once, on this path as on every other.
+    EXPECT_CALL(*mockDbusWrapper, connection_close(conn)).Times(1);
+    EXPECT_CALL(*mockDbusWrapper, connection_unref(conn)).Times(1);
     EXPECT_CALL(*mockDbusWrapper, error_is_set(_)).WillRepeatedly(Return(false));
     EXPECT_CALL(*mockDbusWrapper, message_new_method_call(_, _, _, _))
     .WillOnce(Return(msg));

--- a/src/data_provider/src/extended_sources/wrappers/unix/linux/dbus_wrapper.hpp
+++ b/src/data_provider/src/extended_sources/wrappers/unix/linux/dbus_wrapper.hpp
@@ -38,13 +38,38 @@ class DBusWrapper : public IDBusWrapper
             ::dbus_error_free(error);
         }
 
-        /// @brief Gets a D-Bus connection for the specified bus type.
+        /// @brief Gets a private D-Bus connection for the specified bus type.
         /// @param type The type of bus (session, system, etc.).
         /// @param error Pointer to the DBusError structure.
         /// @return Pointer to the DBusConnection, or nullptr on failure.
-        DBusConnection* bus_get(DBusBusType type, DBusError* error) override
+        /// @note Private rather than shared, so the caller owns the connection and a dropped
+        /// bus does not leave a permanently unusable connection cached for the whole process.
+        DBusConnection* bus_get_private(DBusBusType type, DBusError* error) override
         {
-            return ::dbus_bus_get(type, error);
+            return ::dbus_bus_get_private(type, error);
+        }
+
+        /// @brief Closes a private D-Bus connection.
+        /// @param connection Pointer to the DBusConnection.
+        /// This function is safe to call with a nullptr.
+        void connection_close(DBusConnection* connection) override
+        {
+            if (connection)
+            {
+                ::dbus_connection_close(connection);
+            }
+        }
+
+        /// @brief Unreferences a D-Bus connection.
+        /// @param connection Pointer to the DBusConnection.
+        /// This function decrements the reference count and frees the connection if the count
+        /// reaches zero. It is safe to call this function with a nullptr.
+        void connection_unref(DBusConnection* connection) override
+        {
+            if (connection)
+            {
+                ::dbus_connection_unref(connection);
+            }
         }
 
         /// @brief Creates a new D-Bus method call message.

--- a/src/data_provider/src/extended_sources/wrappers/unix/linux/dbus_wrapper.hpp
+++ b/src/data_provider/src/extended_sources/wrappers/unix/linux/dbus_wrapper.hpp
@@ -44,9 +44,20 @@ class DBusWrapper : public IDBusWrapper
         /// @return Pointer to the DBusConnection, or nullptr on failure.
         /// @note Private rather than shared, so the caller owns the connection and a dropped
         /// bus does not leave a permanently unusable connection cached for the whole process.
+        /// @note libdbus binds every bus connection to the lifetime of the message bus by
+        /// default, which makes it call exit() once a "Disconnected" message is dispatched.
+        /// Nothing here dispatches today, so this is disabled defensively: the caller owns the
+        /// connection and a collector must never be able to terminate its host process.
         DBusConnection* bus_get_private(DBusBusType type, DBusError* error) override
         {
-            return ::dbus_bus_get_private(type, error);
+            DBusConnection* connection = ::dbus_bus_get_private(type, error);
+
+            if (connection)
+            {
+                ::dbus_connection_set_exit_on_disconnect(connection, FALSE);
+            }
+
+            return connection;
         }
 
         /// @brief Closes a private D-Bus connection.

--- a/src/data_provider/src/extended_sources/wrappers/unix/linux/idbus_wrapper.hpp
+++ b/src/data_provider/src/extended_sources/wrappers/unix/linux/idbus_wrapper.hpp
@@ -32,11 +32,30 @@ class IDBusWrapper
         /// @param error Pointer to the DBusError structure.
         virtual void error_free(DBusError* error) = 0;
 
-        /// @brief Gets a D-Bus connection for the specified bus type.
+        /// @brief Gets a private D-Bus connection for the specified bus type.
+        ///
+        /// The caller owns the returned connection and must release it with
+        /// connection_close() followed by connection_unref(). A private connection is
+        /// required rather than the shared one: libdbus caches the shared connection
+        /// process-wide, so once the bus drops, every later request is handed back the same
+        /// closed connection and the caller never recovers for the lifetime of the process.
+        ///
         /// @param type The type of bus (session, system, etc.).
         /// @param error Pointer to the DBusError structure.
         /// @return Pointer to the DBusConnection, or nullptr on failure.
-        virtual DBusConnection* bus_get(DBusBusType type, DBusError* error) = 0;
+        virtual DBusConnection* bus_get_private(DBusBusType type, DBusError* error) = 0;
+
+        /// @brief Closes a private D-Bus connection.
+        ///
+        /// Required before dropping the last reference to a connection obtained from
+        /// bus_get_private(). Dropping the reference alone leaves the connection open.
+        ///
+        /// @param connection Pointer to the DBusConnection.
+        virtual void connection_close(DBusConnection* connection) = 0;
+
+        /// @brief Unreferences a D-Bus connection.
+        /// @param connection Pointer to the DBusConnection.
+        virtual void connection_unref(DBusConnection* connection) = 0;
 
         /// @brief Creates a new D-Bus method call message.
         /// @param destination The destination bus name.


### PR DESCRIPTION
## Description

Related to #38364.

`SystemdUnitsProvider::getSystemdUnits()` acquires a system bus connection on every invocation and releases it on none of its return paths.

> Note: This PR addresses only the second of the three findings tracked in that issue, which is why it does not close it. The remaining two are handled in their own PRs and the issue stays open until all three are merged.

The same code is present on `5.0.0`, so this change should be ported there as well.

## Proposed Changes

- `idbus_wrapper.hpp`: Replace `bus_get()` with `bus_get_private()`, and add `connection_close()` and `connection_unref()`.
- `dbus_wrapper.hpp`: Implement the three methods over `dbus_bus_get_private()`, `dbus_connection_close()` and `dbus_connection_unref()`, with the same null guard the existing `message_unref()` uses.
- `systemd_units_linux.cpp`: Add a `ScopedDBusConnection` guard that closes and unreferences the connection when it goes out of scope, and use it to hold the connection for the whole of `getSystemdUnits()`.
- `test_systemd_units_linux.cpp`: Rename the mocked method, add the two new ones, and assert the connection is released exactly once on the success path and on each failure path, and never when acquisition itself failed.

The method was renamed because the ownership semantics change. The caller now owns the connection and is responsible for releasing it. A silent change of behavior behind `bus_get()` would be misleading at every call site.

Adding a release method and calling it on all return paths, while keeping the shared connection from `dbus_bus_get()`, does not fix the observable symptom. libdbus caches the shared connection process-wide and holds its own reference, so dropping ours changes nothing: after the bus goes away, every later acquisition is handed back the same closed connection and the collector never recovers for the lifetime of the process.

A connection the caller owns, closed explicitly, does recover. That is why the change switches to `dbus_bus_get_private()` and pairs it with `dbus_connection_close()`.

### Results and Evidence

Measured on the shipped packages, both built from the same base commit through the same pipeline, on Debian 10
with a live system bus, driving `sysinfo_services()` from the installed `libsysinfo.so`.

The package-level observable is the connection lifecycle: one connection for a whole run means the shared
connection is reused and never released, one per scan means it is acquired and released each time.

| Package | Scans | Bus connects | Per scan |
|---|---:|---:|---:|
| Baseline, `4.14.9` at `7bacb80` | 20 | 1 | **0.05** |
| This fix, at `21a9a37` | 20 | 21 | **1.05** |

**Recovery, on the shipped code.** One long-lived process spanning a restart of the system bus, since a fresh
process would reconnect trivially:

| Package | Connects before the restart | Connects after |
|---|---:|---:|
| Baseline | 1 | **0**, never recovers |
| This fix | 21 | **20**, recovers |

### Artifacts Affected

- `libsysinfo.so`. No change to inventory data, scan semantics or configuration.

### Configuration Changes

None.

### Documentation Updates

None
### Tests Introduced

- No new test files. Extended the existing suite so every path in `getSystemdUnits()` asserts the connection lifecycle: released once on the success path, released once on each of the failure paths that acquired a connection, and never released when acquisition returned `nullptr`.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality (built and run locally, and mutation checked: 4 of 5 tests fail if the release is removed)
- [x] Configuration changes documented (none)
- [ ] Developer documentation reflects the changes (N/A)
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
