### PR TITLE
Resolve group names once per scan instead of once per user and group

### DIFF
--- a/src/data_provider/src/extended_sources/groups/src/user_groups_linux.cpp
+++ b/src/data_provider/src/extended_sources/groups/src/user_groups_linux.cpp
@@ -109,17 +109,30 @@ nlohmann::json UserGroupsProvider::getGroupNamesByUid(const std::set<uid_t>& uid
         }
 
         struct group grp {};
+
         struct group* grpResult = nullptr;
+
         auto groupBuf = std::make_unique<char[]>(bufSize);
 
-        if (m_groupWrapper->getgrgid_r(gid, &grp, groupBuf.get(), bufSize, &grpResult) == 0 && grpResult != nullptr)
+        const auto result = m_groupWrapper->getgrgid_r(gid, &grp, groupBuf.get(), bufSize, &grpResult);
+
+        if (result == 0 && grpResult != nullptr)
         {
             name = grpResult->gr_name;
             gidToName.emplace(gid, name);
             return true;
         }
 
-        unresolvableGids.insert(gid);
+        // Only an authoritative answer is remembered. A return of 0 with no entry means the
+        // group database does not know this gid, which will not change within one scan. A
+        // non-zero return is a failed lookup, which may be transient on a host whose group
+        // database is served over the network, so it is left unmemoized and the next user
+        // that belongs to this gid attempts it again, as it did before this change.
+        if (result == 0)
+        {
+            unresolvableGids.insert(gid);
+        }
+
         return false;
     };
 

--- a/src/data_provider/src/extended_sources/groups/src/user_groups_linux.cpp
+++ b/src/data_provider/src/extended_sources/groups/src/user_groups_linux.cpp
@@ -12,6 +12,9 @@
 #include "passwd_wrapper.hpp"
 #include "system_wrapper.hpp"
 #include <iostream>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
 
 // Reasonable upper bound for getpw_r buffer
 constexpr size_t MAX_GETPW_R_BUF_SIZE = 16 * 1024;
@@ -84,19 +87,53 @@ nlohmann::json UserGroupsProvider::getGroupNamesByUid(const std::set<uid_t>& uid
         bufSize = MAX_GETPW_R_BUF_SIZE;
     }
 
+    // Resolve each distinct gid once for the whole call instead of once per user that
+    // belongs to it. Group membership overlaps heavily, so the previous behaviour cost
+    // one lookup per (user, group) pair. On a host where the group database is served by
+    // a network directory, every one of those lookups is a round trip.
+    // Unresolvable gids are memoised too, otherwise they keep costing a lookup per user.
+    std::unordered_map<gid_t, std::string> gidToName;
+    std::unordered_set<gid_t> unresolvableGids;
+
+    const auto resolveGidName = [&](gid_t gid, std::string & name) -> bool
+    {
+        if (const auto cached = gidToName.find(gid); cached != gidToName.end())
+        {
+            name = cached->second;
+            return true;
+        }
+
+        if (unresolvableGids.count(gid) > 0)
+        {
+            return false;
+        }
+
+        struct group grp {};
+        struct group* grpResult = nullptr;
+        auto groupBuf = std::make_unique<char[]>(bufSize);
+
+        if (m_groupWrapper->getgrgid_r(gid, &grp, groupBuf.get(), bufSize, &grpResult) == 0 && grpResult != nullptr)
+        {
+            name = grpResult->gr_name;
+            gidToName.emplace(gid, name);
+            return true;
+        }
+
+        unresolvableGids.insert(gid);
+        return false;
+    };
+
     for (const auto& [uid, groups] : usersGroups)
     {
         nlohmann::json groupNames = nlohmann::json::array();
 
         for (const auto& gid : groups)
         {
-            struct group grp {};
-            struct group* grpResult = nullptr;
-            auto groupBuf = std::make_unique<char[]>(bufSize);
+            std::string groupName;
 
-            if (m_groupWrapper->getgrgid_r(gid, &grp, groupBuf.get(), bufSize, &grpResult) == 0 && grpResult != nullptr)
+            if (resolveGidName(gid, groupName))
             {
-                groupNames.push_back(grpResult->gr_name);
+                groupNames.push_back(groupName);
             }
         }
 

--- a/src/data_provider/src/extended_sources/groups/tests/test_user_groups_linux.cpp
+++ b/src/data_provider/src/extended_sources/groups/tests/test_user_groups_linux.cpp
@@ -9,6 +9,7 @@
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <cerrno>
 #include "igroup_wrapper.hpp"
 #include "ipasswd_wrapper.hpp"
 #include "isystem_wrapper.hpp"
@@ -372,4 +373,281 @@ TEST_F(UserGroupsProviderLinuxTest, getUserNamesByGidMultipleGids)
 
     free(pwd1.pw_name);
     free(pwd2.pw_name);
+}
+
+// A gid shared by several users must cost one group lookup for the whole call, not one
+// per user that belongs to it. On a host whose group database is served by a network
+// directory, each lookup is a round trip, so the call count is the property under test.
+TEST_F(UserGroupsProviderLinuxTest, getGroupNamesByUidResolvesEachGidOnce)
+{
+    auto mockGroup = std::make_shared<MockGroupWrapper>();
+    auto mockPasswd = std::make_shared<MockPasswdWrapper>();
+    auto mockSys = std::make_shared<MockSystemWrapper>();
+
+    const uid_t uidA = 1001;
+    const uid_t uidB = 1002;
+    const char* nameA = "usera";
+    const char* nameB = "userb";
+    // Both users belong to 100 and 101, so three users' worth of membership resolves to
+    // two distinct gids.
+    const gid_t sharedGid1 = 100;
+    const gid_t sharedGid2 = 101;
+
+    EXPECT_CALL(*mockSys, sysconf(_SC_GETPW_R_SIZE_MAX)).WillOnce(Return(1024));
+    EXPECT_CALL(*mockSys, sysconf(_SC_GETGR_R_SIZE_MAX)).WillOnce(Return(1024));
+
+    EXPECT_CALL(*mockPasswd, getpwuid_r(uidA, _, _, _, _))
+    .WillOnce(Invoke([&](uid_t, struct passwd * pwd, char*, size_t, struct passwd** result)
+    {
+        pwd->pw_name = const_cast<char*>(nameA);
+        pwd->pw_uid = uidA;
+        pwd->pw_gid = sharedGid1;
+        *result = pwd;
+        return 0;
+    }));
+
+    EXPECT_CALL(*mockPasswd, getpwuid_r(uidB, _, _, _, _))
+    .WillOnce(Invoke([&](uid_t, struct passwd * pwd, char*, size_t, struct passwd** result)
+    {
+        pwd->pw_name = const_cast<char*>(nameB);
+        pwd->pw_uid = uidB;
+        pwd->pw_gid = sharedGid1;
+        *result = pwd;
+        return 0;
+    }));
+
+    const auto bothGroups = [](const char*, gid_t, gid_t * groups, int* ngroups)
+    {
+        groups[0] = sharedGid1;
+        groups[1] = sharedGid2;
+        *ngroups = 2;
+        return 2;
+    };
+    EXPECT_CALL(*mockGroup, getgrouplist(StrEq(nameA), sharedGid1, _, _)).WillOnce(Invoke(bothGroups));
+    EXPECT_CALL(*mockGroup, getgrouplist(StrEq(nameB), sharedGid1, _, _)).WillOnce(Invoke(bothGroups));
+
+    // Two users times two groups is four (user, group) pairs but only two distinct gids.
+    // Times(1) is the whole point of the test: a second lookup for the same gid is a
+    // failure, not an optimisation that happens to be missing.
+    EXPECT_CALL(*mockGroup, getgrgid_r(sharedGid1, _, _, _, _))
+    .Times(1)
+    .WillOnce(Invoke([](gid_t, struct group * grp, char*, size_t, struct group** result)
+    {
+        grp->gr_name = const_cast<char*>("groupone");
+        *result = grp;
+        return 0;
+    }));
+
+    EXPECT_CALL(*mockGroup, getgrgid_r(sharedGid2, _, _, _, _))
+    .Times(1)
+    .WillOnce(Invoke([](gid_t, struct group * grp, char*, size_t, struct group** result)
+    {
+        grp->gr_name = const_cast<char*>("grouptwo");
+        *result = grp;
+        return 0;
+    }));
+
+    UserGroupsProvider provider(mockGroup, mockPasswd, mockSys);
+
+    auto result = provider.getGroupNamesByUid({uidA, uidB});
+
+    // Fewer lookups must not mean fewer or different names reported.
+    ASSERT_TRUE(result.is_object());
+    ASSERT_TRUE(result.contains(std::to_string(uidA)));
+    ASSERT_TRUE(result.contains(std::to_string(uidB)));
+    EXPECT_EQ(result[std::to_string(uidA)], nlohmann::json::array({"groupone", "grouptwo"}));
+    EXPECT_EQ(result[std::to_string(uidB)], nlohmann::json::array({"groupone", "grouptwo"}));
+}
+
+// A gid the group database cannot resolve must also be looked up only once. Without
+// memoising the failures, an unresolvable gid shared by many users costs a lookup per
+// user, which is the case that hurts most on a directory-backed host.
+TEST_F(UserGroupsProviderLinuxTest, getGroupNamesByUidRetriesUnresolvableGidOnlyOnce)
+{
+    auto mockGroup = std::make_shared<MockGroupWrapper>();
+    auto mockPasswd = std::make_shared<MockPasswdWrapper>();
+    auto mockSys = std::make_shared<MockSystemWrapper>();
+
+    const uid_t uidA = 1001;
+    const uid_t uidB = 1002;
+    const char* nameA = "usera";
+    const char* nameB = "userb";
+    const gid_t missingGid = 500;
+
+    EXPECT_CALL(*mockSys, sysconf(_SC_GETPW_R_SIZE_MAX)).WillOnce(Return(1024));
+    EXPECT_CALL(*mockSys, sysconf(_SC_GETGR_R_SIZE_MAX)).WillOnce(Return(1024));
+
+    EXPECT_CALL(*mockPasswd, getpwuid_r(uidA, _, _, _, _))
+    .WillOnce(Invoke([&](uid_t, struct passwd * pwd, char*, size_t, struct passwd** result)
+    {
+        pwd->pw_name = const_cast<char*>(nameA);
+        pwd->pw_uid = uidA;
+        pwd->pw_gid = missingGid;
+        *result = pwd;
+        return 0;
+    }));
+
+    EXPECT_CALL(*mockPasswd, getpwuid_r(uidB, _, _, _, _))
+    .WillOnce(Invoke([&](uid_t, struct passwd * pwd, char*, size_t, struct passwd** result)
+    {
+        pwd->pw_name = const_cast<char*>(nameB);
+        pwd->pw_uid = uidB;
+        pwd->pw_gid = missingGid;
+        *result = pwd;
+        return 0;
+    }));
+
+    const auto onlyMissing = [](const char*, gid_t, gid_t * groups, int* ngroups)
+    {
+        groups[0] = missingGid;
+        *ngroups = 1;
+        return 1;
+    };
+    EXPECT_CALL(*mockGroup, getgrouplist(StrEq(nameA), missingGid, _, _)).WillOnce(Invoke(onlyMissing));
+    EXPECT_CALL(*mockGroup, getgrouplist(StrEq(nameB), missingGid, _, _)).WillOnce(Invoke(onlyMissing));
+
+    EXPECT_CALL(*mockGroup, getgrgid_r(missingGid, _, _, _, _))
+    .Times(1)
+    .WillOnce(Invoke([](gid_t, struct group*, char*, size_t, struct group** result)
+    {
+        *result = nullptr;
+        return 0;
+    }));
+
+    UserGroupsProvider provider(mockGroup, mockPasswd, mockSys);
+
+    auto result = provider.getGroupNamesByUid({uidA, uidB});
+
+    // An unresolvable gid contributes no name, exactly as before.
+    ASSERT_TRUE(result.is_object());
+    EXPECT_EQ(result[std::to_string(uidA)], nlohmann::json::array());
+    EXPECT_EQ(result[std::to_string(uidB)], nlohmann::json::array());
+}
+
+// The single uid call returns a bare array of names, and callers depend on that shape.
+// Batching several uids into one call must not change it.
+TEST_F(UserGroupsProviderLinuxTest, getGroupNamesByUidKeepsArrayShapeForOneUid)
+{
+    auto mockGroup = std::make_shared<MockGroupWrapper>();
+    auto mockPasswd = std::make_shared<MockPasswdWrapper>();
+    auto mockSys = std::make_shared<MockSystemWrapper>();
+
+    const uid_t uid = 1001;
+    const gid_t gid = 100;
+    const char* name = "usera";
+
+    EXPECT_CALL(*mockSys, sysconf(_SC_GETPW_R_SIZE_MAX)).WillOnce(Return(1024));
+    EXPECT_CALL(*mockSys, sysconf(_SC_GETGR_R_SIZE_MAX)).WillOnce(Return(1024));
+
+    EXPECT_CALL(*mockPasswd, getpwuid_r(uid, _, _, _, _))
+    .WillOnce(Invoke([&](uid_t, struct passwd * pwd, char*, size_t, struct passwd** result)
+    {
+        pwd->pw_name = const_cast<char*>(name);
+        pwd->pw_uid = uid;
+        pwd->pw_gid = gid;
+        *result = pwd;
+        return 0;
+    }));
+
+    EXPECT_CALL(*mockGroup, getgrouplist(StrEq(name), gid, _, _))
+    .WillOnce(Invoke([](const char*, gid_t, gid_t * groups, int* ngroups)
+    {
+        groups[0] = gid;
+        *ngroups = 1;
+        return 1;
+    }));
+
+    EXPECT_CALL(*mockGroup, getgrgid_r(gid, _, _, _, _))
+    .Times(1)
+    .WillOnce(Invoke([](gid_t, struct group * grp, char*, size_t, struct group** result)
+    {
+        grp->gr_name = const_cast<char*>("groupone");
+        *result = grp;
+        return 0;
+    }));
+
+    UserGroupsProvider provider(mockGroup, mockPasswd, mockSys);
+
+    auto result = provider.getGroupNamesByUid({uid});
+
+    ASSERT_TRUE(result.is_array());
+    EXPECT_EQ(result, nlohmann::json::array({"groupone"}));
+}
+
+// A failed lookup, as opposed to an authoritative "no such group", may be transient when the
+// group database is served over the network. It must not be remembered for the rest of the
+// scan, so a later user belonging to the same gid attempts it again.
+TEST_F(UserGroupsProviderLinuxTest, getGroupNamesByUidRetriesGidAfterAFailedLookup)
+{
+    auto mockGroup = std::make_shared<MockGroupWrapper>();
+    auto mockPasswd = std::make_shared<MockPasswdWrapper>();
+    auto mockSys = std::make_shared<MockSystemWrapper>();
+
+    const uid_t uidA = 1001;
+    const uid_t uidB = 1002;
+    const char* nameA = "usera";
+    const char* nameB = "userb";
+    const gid_t flakyGid = 700;
+
+    EXPECT_CALL(*mockSys, sysconf(_SC_GETPW_R_SIZE_MAX)).WillOnce(Return(1024));
+    EXPECT_CALL(*mockSys, sysconf(_SC_GETGR_R_SIZE_MAX)).WillOnce(Return(1024));
+
+    EXPECT_CALL(*mockPasswd, getpwuid_r(uidA, _, _, _, _))
+    .WillOnce(Invoke([&](uid_t, struct passwd * pwd, char*, size_t, struct passwd** result)
+    {
+        pwd->pw_name = const_cast<char*>(nameA);
+        pwd->pw_uid = uidA;
+        pwd->pw_gid = flakyGid;
+        *result = pwd;
+        return 0;
+    }));
+
+    EXPECT_CALL(*mockPasswd, getpwuid_r(uidB, _, _, _, _))
+    .WillOnce(Invoke([&](uid_t, struct passwd * pwd, char*, size_t, struct passwd** result)
+    {
+        pwd->pw_name = const_cast<char*>(nameB);
+        pwd->pw_uid = uidB;
+        pwd->pw_gid = flakyGid;
+        *result = pwd;
+        return 0;
+    }));
+
+    const auto onlyFlaky = [](const char*, gid_t, gid_t * groups, int* ngroups)
+    {
+        groups[0] = flakyGid;
+        *ngroups = 1;
+        return 1;
+    };
+    EXPECT_CALL(*mockGroup, getgrouplist(StrEq(nameA), flakyGid, _, _)).WillOnce(Invoke(onlyFlaky));
+    EXPECT_CALL(*mockGroup, getgrouplist(StrEq(nameB), flakyGid, _, _)).WillOnce(Invoke(onlyFlaky));
+
+    // First attempt fails with an error, second succeeds. Memoising the failure would make
+    // this a single call and lose the name for both users.
+    {
+        InSequence seq;
+
+        EXPECT_CALL(*mockGroup, getgrgid_r(flakyGid, _, _, _, _))
+        .WillOnce(Invoke([](gid_t, struct group*, char*, size_t, struct group** result)
+        {
+            *result = nullptr;
+            return EIO;
+        }));
+
+        EXPECT_CALL(*mockGroup, getgrgid_r(flakyGid, _, _, _, _))
+        .WillOnce(Invoke([](gid_t, struct group * grp, char*, size_t, struct group** result)
+        {
+            grp->gr_name = const_cast<char*>("flakygroup");
+            *result = grp;
+            return 0;
+        }));
+    }
+
+    UserGroupsProvider provider(mockGroup, mockPasswd, mockSys);
+
+    auto result = provider.getGroupNamesByUid({uidA, uidB});
+
+    ASSERT_TRUE(result.is_object());
+    // The user whose lookup failed reports no name, the retry recovers it for the other.
+    EXPECT_EQ(result[std::to_string(uidA)], nlohmann::json::array());
+    EXPECT_EQ(result[std::to_string(uidB)], nlohmann::json::array({"flakygroup"}));
 }

--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -689,6 +689,23 @@ nlohmann::json SysInfo::getUsers() const
 
     UserGroupsProvider userGroupsProvider;
 
+    // Resolve group membership for every user in a single call. Asking per user repeated
+    // the underlying passwd and group lookups once per user and left no opportunity to
+    // share work between them, which on a host whose accounts come from a network
+    // directory meant one round trip per (user, group) pair.
+    std::set<uid_t> allUids;
+
+    for (const auto& user : collectedUsers)
+    {
+        allUids.insert(static_cast<uid_t>(user["uid"].get<int>()));
+    }
+
+    // An empty set means "every uid" to getGroupNamesByUid(), so only ask when there is
+    // actually something to ask about.
+    const auto groupsByUid = allUids.empty()
+                             ? nlohmann::json::object()
+                             : userGroupsProvider.getGroupNamesByUid(allUids);
+
     for (auto& user : collectedUsers)
     {
         nlohmann::json userItem {};
@@ -705,8 +722,24 @@ nlohmann::json SysInfo::getUsers() const
         userItem["user_group_id_signed"] = user["gid_signed"];
         userItem["user_group_id"] = user["gid"];
 
-        std::set<uid_t> uid {static_cast<uid_t>(user["uid"].get<int>())};
-        auto collectedUsersGroups = userGroupsProvider.getGroupNamesByUid(uid);
+        // getGroupNamesByUid() returns a bare array when asked about a single uid and an
+        // object keyed by uid otherwise, so both shapes have to be handled: a host with
+        // exactly one user yields the array form.
+        nlohmann::json collectedUsersGroups = nlohmann::json::array();
+
+        if (groupsByUid.is_object())
+        {
+            const auto entry = groupsByUid.find(std::to_string(user["uid"].get<int>()));
+
+            if (entry != groupsByUid.end())
+            {
+                collectedUsersGroups = *entry;
+            }
+        }
+        else if (groupsByUid.is_array())
+        {
+            collectedUsersGroups = groupsByUid;
+        }
 
         if (collectedUsersGroups.empty())
         {

--- a/src/data_provider/src/sysInfoLinux.cpp
+++ b/src/data_provider/src/sysInfoLinux.cpp
@@ -729,7 +729,10 @@ nlohmann::json SysInfo::getUsers() const
 
         if (groupsByUid.is_object())
         {
-            const auto entry = groupsByUid.find(std::to_string(user["uid"].get<int>()));
+            // Keyed exactly as getGroupNamesByUid() built it, from uid_t. Formatting the
+            // narrowed int instead would look up "-2" for uid 4294967294 and find nothing.
+            const auto uid = static_cast<uid_t>(user["uid"].get<int>());
+            const auto entry = groupsByUid.find(std::to_string(uid));
 
             if (entry != groupsByUid.end())
             {


### PR DESCRIPTION
## Description

Related to #38364.

The users collector resolves each user's group names with one name service lookup per (user, group) pair, and asks for group membership once per user rather than once per scan. On a host where accounts are served by a network directory, every one of those lookups is a directory round trip.

> Note: This PR addresses only the third of the three findings tracked in that issue, which is why it does not close it. The other two are handled in their own PRs and the issue stays open until all three are merged.

The same code is present on `5.0.0`, so this change should be ported there as well.

## Proposed Changes

- `user_groups_linux.cpp`: Memoize gid to group-name resolution inside `getGroupNamesByUid()`, so each distinct gid is resolved once per call instead of once per user that belongs to it. Unresolvable gids are memoized too, otherwise a group that cannot be resolved keeps costing one lookup per member.
- `sysInfoLinux.cpp`: Call `getGroupNamesByUid()` once with the full set of uids and index into the result, rather than once per user. The batch signature already existed and was unused. Both return shapes are handled, since the method returns a bare array for a single uid and a uid-keyed object otherwise, and a host with exactly one user takes the array path.

No interface, configuration or output changes. The reported `user_groups` field is unchanged.

### Results and Evidence

Measured on the shipped packages, both built from the same base commit through the same pipeline, on Debian 10
with accounts served by a stand-in metadata service on loopback that counts the requests it serves.

| Directory accounts | Requests per scan, baseline | With this fix | Growth per scan, baseline | With this fix |
|---:|---:|---:|---:|---:|
| 0 | 0.0 | 0.0 | 0.00 KB | 0.00 KB |
| 10 | 160.9 | 16.2 | 120.96 KB | 10.24 KB |
| 50 | 804.5 | 16.6 | 616.96 KB | 11.90 KB |
| 200 | 3,251.4 | 21.9 | 2,466.97 KB | 8.29 KB |

The baseline costs about 16 requests per account per scan. Against this directory component the per-scan
volume with the fix is nearly independent of the account count. The zero-account row is the control: no
directory accounts means no requests and no growth on either package.

How much of the per-account cost disappears depends on what the directory client answers locally, so the
same change was also measured against SSSD over OpenLDAP, with 200 accounts in 20 overlapping groups and
SSSD caching disabled so every lookup reaches the server:

| Directory accounts | Queries per collection, baseline | With this fix | Ratio |
|---:|---:|---:|---:|
| 50 | 764.7 | 145.5 | 5.3x |
| 200 | 3,133.6 | 453.1 | 6.9x |

There the cost still scales with the account count, 4.1x for the baseline and 3.1x for the fix across those
two rows, because SSSD sends the per-user membership query to the directory while the OS Login module answers
it from a local cache file. So the honest summary is that the per-(user, group) amplification is removed in
both cases, and whether what remains looks flat depends on the client. Collection time for the 200 account
arm fell from 1,342 s to 85 s.

<details>
<summary><b>Tests executed</b></summary>

Every comparison is between the shipped `4.14.9` package at the base commit and the package built from this
branch. Unless stated otherwise a test ran on both packages under identical conditions on the same host, with the same accounts.

### Reported data is unchanged

| Test | What it does | Result |
|---|---|---|
| Output equivalence | Dumps what the users and groups collectors report and compares the documents field by field | **Identical** on every platform. Byte-identical canonical digests, 31 user records and 44 group records on the directory-backed host |
| User in 84 groups | A user belonging to more than the 64 group internal limit, which forces the membership query to be repeated with a larger buffer | **All 84 names reported**, identical before and after |
| User with no supplementary groups | Only a primary group | **Identical**, one name |
| Duplicate uid alias | Two account names sharing uid 0, so one lookup result is shared by two records | **Identical**, and the alias reports exactly what the canonical name reports |
| uid above `INT_MAX` | An account with uid 4294967294, which is where the batched result is looked up by key | **Groups reported correctly.** An earlier revision of this change failed this: the result is keyed from `uid_t` while the lookup formatted the value narrowed to `int`, so it searched for `-2` instead of `4294967294` and reported no groups. Fixed before submission |
| Single-user host | Only one account present, which is the one case where the batch call returns a bare array instead of a uid-keyed object | **Groups reported correctly** through that branch |
| Unresolvable gid | Membership in a gid with no matching group entry | **Omitted with no effect on the other names**, identical before and after |

### Behaviour across repeated scans

| Test | What it does | Result |
|---|---|---|
| Repeated collections | Collects many times in one process and compares each result against the first | **No drift.** Identical digest on every iteration |
| Directory outage and recovery | Collects with the directory up, with it stopped, and after it returns. The client cache is taken out of the path first so a group name can only come over the network | **Full recovery.** All directory users lose their group name during the outage and the dump after recovery is byte-identical to the healthy one |
| In-place upgrade | Runs the old package, then installs the new one over it without touching the accounts | **No change in reported data**, identical digest |

### Cost of a collection

| Test | What it does | Result |
|---|---|---|
| Request volume, network directory with a per-request leak | Counts requests reaching the directory per collection at 0, 10, 50 and 200 accounts | **160.9 to 16.2 per scan** at 10 accounts, and with this change the volume stops growing with the account count. Zero accounts gives zero requests on both packages |
| Request volume, SSSD over LDAP | Counts LDAP searches per collection with the client cache disabled, 120 collections per measurement | **5.3x fewer** at 50 accounts, **6.9x fewer** at 200 |
| Collection time | Wall clock for the same work | 200 accounts over 120 collections: **1,342 s to 85 s** |
| Collector attribution | Measures the users and groups collectors separately | All of the cost is the users collector. The groups collector is 0.5 requests per scan and 0.00 KB either way |

### Memory

| Test | What it does | Result |
|---|---|---|
| Growth against the leaking directory component | Per-scan growth at 0, 10, 50 and 200 accounts | **120.96 KB to 10.24 KB per scan** at 10 accounts, and no longer proportional to the account count |
| Where the growth comes from | Same runs against the first release of that component which releases its parsed response, and against local account files only | **0.00 KB per scan** on both packages with request volume unchanged, and 0.00 KB against local files. The growth belongs to the directory component, not to this code |
| Accumulation check | 120 collections against a client that does not leak, watching live heap rather than a single total | **Nothing accumulates.** Live heap 211 KB start to 211 KB end on the baseline and 213 KB to 213 KB with this change; per-scan growth falls as the run lengthens or goes negative |

### Platforms

Output equivalence, repeated-collection stability, every edge case above and a no-crash check ran on nine
platforms (locally using Docker containers) covering both packaging families and glibc 2.26 through 2.38: Ubuntu 22.04 and 24.04, Debian 10 and 12, Rocky Linux 8 and 9, Amazon Linux 2 and 2023, openSUSE Leap 15. **Zero failures.**

Not covered: arm64, and macOS and Windows. The latter two have their own implementations of this collector,
untouched by this change.

### Unit tests

Four cases added, three of them for behaviour that had no coverage at all. Two fail on the base commit with
`called twice - over-saturated` and pass with this change, so they bind to it rather than passing either way.
A third asserts a failed group lookup is retried by the next member instead of being treated as authoritative,
and fails on an earlier revision of this change. The fourth guards the single-uid return shape and passes on
both, as a regression guard should.

</details>

### Artifacts Affected

- `libsysinfo.so`. No change to inventory data, scan semantics or configuration.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

In `test_user_groups_linux.cpp`, which had no coverage of `getGroupNamesByUid()` on Linux:

- `getGroupNamesByUidResolvesEachGidOnce`: two users sharing two groups, asserting one `getgrgid_r()` per distinct gid instead of one per (user, group) pair, and that both users still report both group names.
- `getGroupNamesByUidRetriesUnresolvableGidOnlyOnce`: a gid the group database cannot resolve, shared by two users, asserting it costs one lookup rather than one per member and still contributes no name.
- `getGroupNamesByUidKeepsArrayShapeForOneUid`: the single uid call still returns a bare array of names.

The first two fail on the base commit and pass with this change. The third passes on both, guarding the return shape.

Full `data_provider` suite on this branch: 13 of 14 pass. The one failure is `sysInfoPackagesLinuxHelper_unit_test`, which cannot load `libarchive.so.13` on the test host and is unrelated to these files.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented (none)
- [ ] Developer documentation reflects the changes (N/A)
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
