### PR TITLE
FIM - Skip unnecessary steps when module is disabled

### DIFF
--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -517,14 +517,19 @@ void fim_initialize() {
     syscheck.file_limit = 0;
     syscheck.registry_key_limit = 0;
     syscheck.registry_value_limit = 0;
-    while (!fetch_document_limits_from_agentd())
-    {
-        mdebug1("Trying to fetch limits from agentd...");
+
+    // Only document promotion and the scan paths read these limits, and neither runs when the
+    // module is disabled: retrying here would hold back the DataClean notification.
+    if (!syscheck.disabled) {
+        while (!fetch_document_limits_from_agentd())
+        {
+            mdebug1("Trying to fetch limits from agentd...");
 #ifdef WIN32
-        Sleep(1000);
+            Sleep(1000);
 #else
-        sleep(1);
+            sleep(1);
 #endif // WIN32
+        }
     }
 
     // Initialize locks before sync handle creation
@@ -546,102 +551,104 @@ void fim_initialize() {
         merror_exit("Failed to initialize AgentSyncProtocol");
     }
 
-// Check for limit changes
+// Check for limit changes.
+    if (!syscheck.disabled) {
 #ifdef WIN32
-    int table_count = 3;
-    char* table_names[3] = {FIMDB_FILE_TABLE_NAME, FIMDB_REGISTRY_KEY_TABLENAME, FIMDB_REGISTRY_VALUE_TABLENAME};
+        int table_count = 3;
+        char* table_names[3] = {FIMDB_FILE_TABLE_NAME, FIMDB_REGISTRY_KEY_TABLENAME, FIMDB_REGISTRY_VALUE_TABLENAME};
 #else
-    int table_count = 1;
-    char* table_names[1] = {FIMDB_FILE_TABLE_NAME};
+        int table_count = 1;
+        char* table_names[1] = {FIMDB_FILE_TABLE_NAME};
 #endif
 
-    for (int i = 0; i < table_count; i++) {
-        char* table_name = table_names[i];
+        for (int i = 0; i < table_count; i++) {
+            char* table_name = table_names[i];
 
-        // Get the appropriate limit and synced_docs pointer for this table
-        int limit = 0;
-        int* synced_docs_ptr = NULL;
-        if (strcmp(table_name, FIMDB_FILE_TABLE_NAME) == 0) {
-            limit = syscheck.file_limit;
-            synced_docs_ptr = &synced_docs_files;
-        } else if (strcmp(table_name, FIMDB_REGISTRY_KEY_TABLENAME) == 0) {
-            limit = syscheck.registry_key_limit;
-            synced_docs_ptr = &synced_docs_registry_keys;
-        } else if (strcmp(table_name, FIMDB_REGISTRY_VALUE_TABLENAME) == 0) {
-            limit = syscheck.registry_value_limit;
-            synced_docs_ptr = &synced_docs_registry_values;
-        }
-
-        if (synced_docs_ptr == NULL) {
-            mwarn("fim_initialize: unknown table name '%s', skipping limit check.", table_name);
-            continue;
-        }
-
-        *synced_docs_ptr = fim_db_count_synced_docs(table_name);
-        if (*synced_docs_ptr != 0) { // No need to check if no scans have been run
-            if (limit == 0) { // If moving from limited agent to unlimited, promote everything
-                limit = INT_MAX;
+            // Get the appropriate limit and synced_docs pointer for this table
+            int limit = 0;
+            int* synced_docs_ptr = NULL;
+            if (strcmp(table_name, FIMDB_FILE_TABLE_NAME) == 0) {
+                limit = syscheck.file_limit;
+                synced_docs_ptr = &synced_docs_files;
+            } else if (strcmp(table_name, FIMDB_REGISTRY_KEY_TABLENAME) == 0) {
+                limit = syscheck.registry_key_limit;
+                synced_docs_ptr = &synced_docs_registry_keys;
+            } else if (strcmp(table_name, FIMDB_REGISTRY_VALUE_TABLENAME) == 0) {
+                limit = syscheck.registry_value_limit;
+                synced_docs_ptr = &synced_docs_registry_values;
             }
-            if (*synced_docs_ptr < limit) { // Limit might have increased
-                int document_count = limit - *synced_docs_ptr;
-                cJSON* docs_to_promote = fim_db_get_documents_to_promote(table_name, document_count);
 
-                if (docs_to_promote) { // Limit has increased
-                    // Drop rows whose path is no longer covered by the current FIM
-                    // configuration (e.g. a group with a realtime rule was removed).
-                    // The scheduled scan that follows handles them via the orphan-delete path.
-                    drop_orphaned_promoted_documents(table_name, docs_to_promote);
+            if (synced_docs_ptr == NULL) {
+                mwarn("fim_initialize: unknown table name '%s', skipping limit check.", table_name);
+                continue;
+            }
 
-                    // Send promoted documents to persistent queue as CREATE events
-                    mdebug1("Document limit increased from  %d to %d for index %s. Currently synced documents: %d", *synced_docs_ptr, limit, table_name, *synced_docs_ptr + cJSON_GetArraySize(docs_to_promote));
-                    persist_sync_documents(table_name, docs_to_promote, OPERATION_CREATE);
-
-                    OSList* pending_sync_updates = OSList_Create();
-                    if (pending_sync_updates) {
-                        OSList_SetFreeDataPointer(pending_sync_updates, free_pending_sync_item);
-
-                        // Iterate through full documents and extract primary keys for sync flag update
-                        cJSON* full_doc = NULL;
-                        cJSON_ArrayForEach(full_doc, docs_to_promote) {
-                            cJSON* primary_keys = extract_primary_keys(table_name, full_doc);
-                            if (primary_keys) {
-                                add_pending_sync_item(pending_sync_updates, primary_keys, 1);
-                                cJSON_Delete(primary_keys);
-                                (*synced_docs_ptr)++;
-                            }
-                        }
-
-                        // Process pending sync updates
-                        process_pending_sync_updates(table_name, pending_sync_updates);
-                        OSList_Destroy(pending_sync_updates);
-                    }
-                    cJSON_Delete(docs_to_promote);
+            *synced_docs_ptr = fim_db_count_synced_docs(table_name);
+            if (*synced_docs_ptr != 0) { // No need to check if no scans have been run
+                if (limit == 0) { // If moving from limited agent to unlimited, promote everything
+                    limit = INT_MAX;
                 }
-            } else if (*synced_docs_ptr > limit) { // Limit might have decreased
-                int document_count = *synced_docs_ptr - limit;
-                cJSON* docs_to_demote = fim_db_get_documents_to_demote(table_name, document_count);
+                if (*synced_docs_ptr < limit) { // Limit might have increased
+                    int document_count = limit - *synced_docs_ptr;
+                    cJSON* docs_to_promote = fim_db_get_documents_to_promote(table_name, document_count);
 
-                if (docs_to_demote) { // Limit has decreased
-                    minfo("Document limit decreased from %d to %d for table %s. Currently synced documents: %d", document_count, limit, table_name, limit);
-                    // Send demoted documents to persistent queue as DELETE events
-                    persist_sync_documents(table_name, docs_to_demote, OPERATION_DELETE);
+                    if (docs_to_promote) { // Limit has increased
+                        // Drop rows whose path is no longer covered by the current FIM
+                        // configuration (e.g. a group with a realtime rule was removed).
+                        // The scheduled scan that follows handles them via the orphan-delete path.
+                        drop_orphaned_promoted_documents(table_name, docs_to_promote);
 
-                    OSList* pending_sync_updates = OSList_Create();
-                    if (pending_sync_updates) {
-                        OSList_SetFreeDataPointer(pending_sync_updates, free_pending_sync_item);
+                        // Send promoted documents to persistent queue as CREATE events
+                        mdebug1("Document limit increased from  %d to %d for index %s. Currently synced documents: %d", *synced_docs_ptr, limit, table_name, *synced_docs_ptr + cJSON_GetArraySize(docs_to_promote));
+                        persist_sync_documents(table_name, docs_to_promote, OPERATION_CREATE);
 
-                        // Iterate through the cJSON array and add to pending list
-                        cJSON* item = NULL;
-                        cJSON_ArrayForEach(item, docs_to_demote) {
-                            add_pending_sync_item(pending_sync_updates, item, 0);
-                            (*synced_docs_ptr)--;
+                        OSList* pending_sync_updates = OSList_Create();
+                        if (pending_sync_updates) {
+                            OSList_SetFreeDataPointer(pending_sync_updates, free_pending_sync_item);
+
+                            // Iterate through full documents and extract primary keys for sync flag update
+                            cJSON* full_doc = NULL;
+                            cJSON_ArrayForEach(full_doc, docs_to_promote) {
+                                cJSON* primary_keys = extract_primary_keys(table_name, full_doc);
+                                if (primary_keys) {
+                                    add_pending_sync_item(pending_sync_updates, primary_keys, 1);
+                                    cJSON_Delete(primary_keys);
+                                    (*synced_docs_ptr)++;
+                                }
+                            }
+
+                            // Process pending sync updates
+                            process_pending_sync_updates(table_name, pending_sync_updates);
+                            OSList_Destroy(pending_sync_updates);
                         }
-
-                        // Process pending sync updates
-                        process_pending_sync_updates(table_name, pending_sync_updates);
-                        OSList_Destroy(pending_sync_updates);
+                        cJSON_Delete(docs_to_promote);
                     }
-                    cJSON_Delete(docs_to_demote);
+                } else if (*synced_docs_ptr > limit) { // Limit might have decreased
+                    int document_count = *synced_docs_ptr - limit;
+                    cJSON* docs_to_demote = fim_db_get_documents_to_demote(table_name, document_count);
+
+                    if (docs_to_demote) { // Limit has decreased
+                        minfo("Document limit decreased from %d to %d for table %s. Currently synced documents: %d", document_count, limit, table_name, limit);
+                        // Send demoted documents to persistent queue as DELETE events
+                        persist_sync_documents(table_name, docs_to_demote, OPERATION_DELETE);
+
+                        OSList* pending_sync_updates = OSList_Create();
+                        if (pending_sync_updates) {
+                            OSList_SetFreeDataPointer(pending_sync_updates, free_pending_sync_item);
+
+                            // Iterate through the cJSON array and add to pending list
+                            cJSON* item = NULL;
+                            cJSON_ArrayForEach(item, docs_to_demote) {
+                                add_pending_sync_item(pending_sync_updates, item, 0);
+                                (*synced_docs_ptr)--;
+                            }
+
+                            // Process pending sync updates
+                            process_pending_sync_updates(table_name, pending_sync_updates);
+                            OSList_Destroy(pending_sync_updates);
+                        }
+                        cJSON_Delete(docs_to_demote);
+                    }
                 }
             }
         }

--- a/src/unit_tests/syscheckd/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/CMakeLists.txt
@@ -252,6 +252,7 @@ set(SYSCHECK_BASE_FLAGS "-Wl,--wrap,fim_db_init -Wl,--wrap,getDefine_Int -Wl,--w
                          -Wl,--wrap,fim_recovery_integrity_interval_has_elapsed -Wl,--wrap,fim_db_update_last_sync_time \
                          -Wl,--wrap,schema_validator_is_initialized -Wl,--wrap,schema_validator_initialize -Wl,--wrap,schema_validator_validate \
                          -Wl,--wrap,w_query_agentd -Wl,--wrap,OS_ConnectUnixDomain \
+                         -Wl,--wrap,fim_db_count_synced_docs \
                          ${DEBUG_OP_WRAPPERS}")
 list(APPEND syscheckd_tests_names "syscheck")
 if(${TARGET} STREQUAL "winagent")

--- a/src/unit_tests/syscheckd/test_syscheck.c
+++ b/src/unit_tests/syscheckd/test_syscheck.c
@@ -103,6 +103,8 @@ void test_fim_initialize(void **state)
     syscheck_config *syscheck_conf = *state;
     syscheck.sync_end_delay = 1;
     syscheck.sync_max_eps = 3;
+    // Read_Syscheck_Config() always runs first in production and resolves syscheck.disabled to 0 or 1.
+    syscheck.disabled = 0;
 
 #ifdef TEST_WINAGENT
     expect_wrapper_fim_db_init(FIM_DB_DISK,
@@ -120,6 +122,10 @@ void test_fim_initialize(void **state)
     will_return(__wrap_w_query_agentd, "{}");  // Empty JSON
     will_return(__wrap_w_query_agentd, true);
 
+    // Document promotion runs while the module is enabled; nothing is synced yet.
+    expect_any_always(__wrap_fim_db_count_synced_docs, table_name);
+    will_return_always(__wrap_fim_db_count_synced_docs, 0);
+
     expect_string(__wrap_asp_create, module, "fim");
 
     will_return(__wrap_asp_create, (AgentSyncProtocolHandle*)0xABCD1234);
@@ -131,6 +137,42 @@ void test_fim_initialize(void **state)
     expect_string(__wrap__mdebug1, formatted_msg, "Schema validator initialized successfully from embedded resources");
 
     fim_initialize();
+}
+
+void test_fim_initialize_disabled(void **state)
+{
+    syscheck_config *syscheck_conf = *state;
+    syscheck.sync_end_delay = 1;
+    syscheck.sync_max_eps = 3;
+    syscheck.disabled = 1;
+
+#ifdef TEST_WINAGENT
+    expect_wrapper_fim_db_init(FIM_DB_DISK,
+                               syscheck_conf->file_entry_limit,
+                               syscheck_conf->db_entry_registry_limit);
+#else
+    expect_wrapper_fim_db_init(FIM_DB_DISK,
+                               syscheck_conf->file_entry_limit,
+                               0);
+#endif
+
+    // The point of this test: while disabled, neither the document limits query nor document
+    // promotion may run. Queuing no expectations for w_query_agentd or fim_db_count_synced_docs
+    // means cmocka fails this test if either is called.
+
+    expect_string(__wrap_asp_create, module, "fim");
+
+    will_return(__wrap_asp_create, (AgentSyncProtocolHandle*)0xABCD1234);
+
+    // Schema validator initialization
+    will_return(__wrap_schema_validator_is_initialized, false);
+    will_return(__wrap_schema_validator_initialize, true);
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Schema validator initialized successfully from embedded resources");
+
+    fim_initialize();
+
+    syscheck.disabled = 0;
 }
 
 void test_read_internal(void **state)
@@ -220,16 +262,19 @@ void test_Start_win32_Syscheck_corrupted_config_file(void **state) {
     will_return(__wrap_schema_validator_initialize, true);
     expect_string(__wrap__mdebug1, formatted_msg, "Schema validator initialized successfully from embedded resources");
 
-    expect_string(__wrap_w_query_agentd, module, SYSCHECK);
-    expect_string(__wrap_w_query_agentd, query, "getdoclimits fim");
-    will_return(__wrap_w_query_agentd, "{}");  // Empty JSON
-    will_return(__wrap_w_query_agentd, true);
+    // A corrupted configuration disables the module, so neither the document limits query
+    // nor document promotion run: no expectations are queued for w_query_agentd or
+    // fim_db_count_synced_docs, which makes calling either one fail this test.
 
     expect_function_call(__wrap_start_daemon);
     assert_int_equal(Start_win32_Syscheck(), 0);
 }
 
 void test_Start_win32_Syscheck_syscheck_disabled_1(void **state) {
+    // Document promotion runs while the module is enabled; nothing is synced yet.
+    expect_any_always(__wrap_fim_db_count_synced_docs, table_name);
+    will_return_always(__wrap_fim_db_count_synced_docs, 0);
+
     syscheck.directories = NULL;
     syscheck.registry = NULL;
     syscheck.disabled = 0;
@@ -277,6 +322,10 @@ void test_Start_win32_Syscheck_syscheck_disabled_1(void **state) {
 }
 
 void test_Start_win32_Syscheck_syscheck_disabled_2(void **state) {
+    // Document promotion runs while the module is enabled; nothing is synced yet.
+    expect_any_always(__wrap_fim_db_count_synced_docs, table_name);
+    will_return_always(__wrap_fim_db_count_synced_docs, 0);
+
     directory_t EMPTY = { 0 };
     char info_msg[OS_MAXSTR];
 
@@ -322,6 +371,10 @@ void test_Start_win32_Syscheck_syscheck_disabled_2(void **state) {
 }
 
 void test_Start_win32_Syscheck_dirs_and_registry(void **state) {
+    // Document promotion runs while the module is enabled; nothing is synced yet.
+    expect_any_always(__wrap_fim_db_count_synced_docs, table_name);
+    will_return_always(__wrap_fim_db_count_synced_docs, 0);
+
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
@@ -407,6 +460,10 @@ void test_Start_win32_Syscheck_dirs_and_registry(void **state) {
 }
 
 void test_Start_win32_Syscheck_whodata_active(void **state) {
+    // Document promotion runs while the module is enabled; nothing is synced yet.
+    expect_any_always(__wrap_fim_db_count_synced_docs, table_name);
+    will_return_always(__wrap_fim_db_count_synced_docs, 0);
+
     expect_function_call_any(__wrap_pthread_rwlock_wrlock);
     expect_function_call_any(__wrap_pthread_mutex_lock);
     expect_function_call_any(__wrap_pthread_mutex_unlock);
@@ -631,6 +688,7 @@ int main(void) {
     int ret;
     const struct CMUnitTest tests[] = {
             cmocka_unit_test_setup_teardown(test_fim_initialize, setup_syscheck_config, teardown_syscheck_config),
+            cmocka_unit_test_setup_teardown(test_fim_initialize_disabled, setup_syscheck_config, teardown_syscheck_config),
             cmocka_unit_test(test_read_internal),
             cmocka_unit_test(test_read_internal_debug),
             cmocka_unit_test(test_fetch_document_limits_success),


### PR DESCRIPTION
### Description
There are portions of FIM's initilization's code that are currently running regardless of whether `syscheck.disabled` is on. Some of these are necesary, ie for producing `DataClean` events, but others are not. This PR adds guards around two mechanisms that don't have any reason to run when `syscheck.disabled` is on. This fixes a bug that arose from that, one of these portions was de-referecing the config's null pointer and producing the module to crash on Windows when `syscheck.disabled` was on.

### Proposed Changes
Guard the limits-fetching and document promotion parts of the code with `syscheck.disabled`. Since both of them are un-needed when the module is disabled. This fixes the crash and allows the module to continue and produce the `DataClean` message. 

### Results and Evidence

The Windows agent log showed startup reaching the document-preparation stage, with none of the DataClean messages that follow it:

```sql
2026/08/13 18:04:36 wazuh-agent[3568] syscheck.c:543 at fim_initialize(): DEBUG: Document limit increased from  10 to 30000 for index file_entry. Currently synced documents: 10
2026/08/13 18:04:36 wazuh-agent[3568] syscheck.c:372 at persist_sync_documents(): DEBUG: Sent 0 promoted documents to persistent queue for table file_entry
2026/08/13 18:04:36 wazuh-agent[3568] syscheck.c:147 at process_pending_sync_updates(): DEBUG: Processed 0 pending sync flag updates
```

Now it correctly shows the Dataclean notification and no mention of document promotion:
``` sql
2026/08/14 11:24:59 wazuh-agent[2328] run_check.c:329 at handle_fim_disabled(): INFO: Syscheck is disabled, FIM database has entries. Proceeding with data clean notification
2026/08/14 11:24:59 wazuh-agent[2328] run_check.c:666 at start_daemon(): INFO: Syscheck is disabled. Exiting

```

Both warnings are gone after the change and the `winagent` build completes successfully.

### Artifacts Affected

- `wazuh-agent.exe` (Windows agent)
- `wazuh-syscheckd` (Linux agent)

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues

