### PR TITLE
Detect and recover from silently half-closed TCP connections

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -336,6 +336,23 @@ agent.state_interval=5
 # Maximum time waiting for a server response in TCP (seconds) [1..600]
 agent.recv_timeout=60
 
+# Keepalive options for the agent -> manager TCP connection.
+# Detects a manager that stopped acknowledging data (e.g. the peer went away
+# without sending FIN/RST) so the agent doesn't stay attached to a dead socket.
+# Time (in seconds) the connection needs to remain idle before TCP starts sending keepalive probes [1..7200]
+agent.tcp_keepidle=60
+# Time (in seconds) between individual keepalive probes [1..100]
+agent.tcp_keepintvl=15
+# Maximum number of unanswered keepalive probes before the kernel drops the connection [1..50]
+agent.tcp_keepcnt=4
+
+# Maximum time (in seconds) that send() may block on the agent -> manager TCP
+# socket before giving up [1..600]. Bounds how long the agent can be stuck
+# behind a full send buffer (e.g. a stalled network path or a manager that
+# stopped reading): once this expires, the agent closes the socket and
+# reconnects instead of blocking indefinitely on that same connection.
+agent.send_timeout=30
+
 # Apply remote configuration
 # 0. Disabled
 # 1. Enabled

--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -164,16 +164,38 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
     /* Monitor loop */
     while (1) {
 
+        /* A sender thread (send_msg(), possibly on a blocked TCP send that hit
+         * SO_SNDTIMEO) may have invalidated agt->sock. Reconnect right away
+         * instead of waiting for run_notify()'s own staleness watchdog, which
+         * depends on receive_msg() having run recently on this same socket. */
+        if (agt->sock < 0) {
+            w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_NACTIVE);
+            merror(LOST_ERROR);
+            os_setwait();
+            start_agent(0);
+            minfo(SERVER_UP);
+            os_delwait();
+            w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_ACTIVE);
+            continue;
+        }
+
         /* Continuously send notifications */
         run_notify();
 
-        if (agt->sock > maxfd - 1) {
-            maxfd = agt->sock + 1;
+        /* run_notify() may also invalidate the socket (it calls send_msg()
+         * for the keep-alive); restart the loop before FD_SET() needs it. */
+        const int sock = agt->sock;
+        if (sock < 0) {
+            continue;
+        }
+
+        if (sock > maxfd - 1) {
+            maxfd = sock + 1;
         }
 
         /* Monitor all available sockets from here */
         FD_ZERO(&fdset);
-        FD_SET(agt->sock, &fdset);
+        FD_SET(sock, &fdset);
         FD_SET(agt->m_queue, &fdset);
 
         fdtimeout.tv_sec = 1;
@@ -185,6 +207,12 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
         } while (rc < 0 && errno == EINTR);
 
         if (rc == -1) {
+            /* A sender thread may have closed agt->sock while we were
+             * blocked in select(), which select() reports as EBADF. */
+            if (errno == EBADF) {
+                agt->sock = -1;
+                continue;
+            }
             merror_exit(SELECT_ERROR, errno, strerror(errno));
         } else if (rc == 0) {
             continue;
@@ -248,7 +276,7 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
         }
 
         /* For the receiver */
-        if (FD_ISSET(agt->sock, &fdset)) {
+        if (FD_ISSET(sock, &fdset)) {
             if (receive_msg() < 0) {
                 w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_NACTIVE);
                 merror(LOST_ERROR);

--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -93,7 +93,7 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
 #endif
 
     maxfd = agt->m_queue;
-    agt->sock = -1;
+    atomic_int_set(&agt->sock, -1);
 
     /* Create PID file */
     if (CreatePID(ARGV0, getpid()) < 0) {
@@ -133,8 +133,9 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
     w_create_thread(state_main, NULL);
 
     /* Set max fd for select */
-    if (agt->sock > maxfd) {
-        maxfd = agt->sock;
+    int initial_sock = atomic_int_get(&agt->sock);
+    if (initial_sock > maxfd) {
+        maxfd = initial_sock;
     }
 
     start_agent(1);
@@ -164,30 +165,36 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
     /* Monitor loop */
     while (1) {
 
+#ifndef ONEWAY_ENABLED
         /* A sender thread (send_msg(), possibly on a blocked TCP send that hit
          * SO_SNDTIMEO) may have invalidated agt->sock. Reconnect right away
          * instead of waiting for run_notify()'s own staleness watchdog, which
-         * depends on receive_msg() having run recently on this same socket. */
-        if (agt->sock < 0) {
-            w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_NACTIVE);
+         * depends on receive_msg() having run recently on this same socket.
+         * Skipped under ONEWAY_ENABLED: start_agent() never actually connects
+         * in that build (a pre-existing, separate gap), so agt->sock never
+         * leaves -1 and this would otherwise spin at 100% CPU instead of
+         * being paced by select()'s timeout below, as it was before this fix. */
+        if (atomic_int_get(&agt->sock) < 0) {
             merror(LOST_ERROR);
-            os_setwait();
-            start_agent(0);
+            reconnect_to_server();
             minfo(SERVER_UP);
-            os_delwait();
-            w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_ACTIVE);
             continue;
         }
+#endif
 
         /* Continuously send notifications */
         run_notify();
 
+#ifndef ONEWAY_ENABLED
         /* run_notify() may also invalidate the socket (it calls send_msg()
          * for the keep-alive); restart the loop before FD_SET() needs it. */
-        const int sock = agt->sock;
+        const int sock = atomic_int_get(&agt->sock);
         if (sock < 0) {
             continue;
         }
+#else
+        const int sock = atomic_int_get(&agt->sock);
+#endif
 
         if (sock > maxfd - 1) {
             maxfd = sock + 1;
@@ -207,11 +214,22 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
         } while (rc < 0 && errno == EINTR);
 
         if (rc == -1) {
-            /* A sender thread may have closed agt->sock while we were
-             * blocked in select(), which select() reports as EBADF. */
+            /* select() reports EBADF for ANY invalid descriptor in the set,
+             * not necessarily agt->sock -- it could be agt->m_queue. A sender
+             * thread only ever closes agt->sock under send_mutex, so if this
+             * really was our socket being invalidated, agt->sock is already
+             * -1 by the time we get here; checking under the same lock tells
+             * the two cases apart instead of blindly assuming (and leaking
+             * the real, still-open descriptor by overwriting agt->sock without
+             * closing it first). */
             if (errno == EBADF) {
-                agt->sock = -1;
-                continue;
+                send_mutex_lock();
+                const bool sock_lost = atomic_int_get(&agt->sock) < 0;
+                send_mutex_unlock();
+
+                if (sock_lost) {
+                    continue;
+                }
             }
             merror_exit(SELECT_ERROR, errno, strerror(errno));
         } else if (rc == 0) {
@@ -278,13 +296,9 @@ void AgentdStart(int uid, int gid, const char *user, const char *group)
         /* For the receiver */
         if (FD_ISSET(sock, &fdset)) {
             if (receive_msg() < 0) {
-                w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_NACTIVE);
                 merror(LOST_ERROR);
-                os_setwait();
-                start_agent(0);
+                reconnect_to_server();
                 minfo(SERVER_UP);
-                os_delwait();
-                w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_ACTIVE);
             }
         }
 

--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -115,6 +115,15 @@ void sender_init();
 /* Send message to server */
 int send_msg(const char *msg, ssize_t msg_length);
 
+/* Acquire/release the same mutex send_msg() uses around agt->sock, so
+ * connect_server() can mutate agt->sock without racing a concurrent sender. */
+void send_mutex_lock(void);
+void send_mutex_unlock(void);
+
+/* Common reconnect sequence: toggle the wait/status flags around start_agent(0).
+ * Callers keep their own log messages before/after; only the boilerplate is shared. */
+void reconnect_to_server(void);
+
 /* Extract the shared files */
 char *getsharedfiles(void);
 

--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -177,6 +177,9 @@ int main(int argc, char **argv)
     if (!agt) {
         merror_exit(MEM_ERROR, errno, strerror(errno));
     }
+    /* calloc() only zeroes agt->sock.data; the embedded pthread_mutex_t must
+     * be initialized for real before any atomic_int_get/set(&agt->sock) call. */
+    w_mutex_init(&agt->sock.mutex, NULL);
 
     atc = (anti_tampering *)calloc(1, sizeof(anti_tampering));
     if (!atc) {

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -45,7 +45,17 @@ char *get_agent_ip()
     char agent_ip[IPSIZE + 1] = { '\0' };
     struct sockaddr_storage sas;
     socklen_t len = sizeof(sas);
-    const int err = getsockname(agt->sock, (struct sockaddr *)&sas, &len);
+    int err;
+
+    /* Under send_mutex so a sender thread can't invalidate agt->sock between
+     * reading it and using it here (the same reasoning as every other socket
+     * access this fix already guards this way). Worst case without this is a
+     * getsockname(-1, ...) failure and a blank agent IP for one keep-alive
+     * cycle, self-recovering the next one -- still worth closing since the
+     * fix is a two-line change and the pattern should be consistent. */
+    send_mutex_lock();
+    err = getsockname(atomic_int_get(&agt->sock), (struct sockaddr *)&sas, &len);
+    send_mutex_unlock();
 
     if (!err) {
         switch (sas.ss_family) {
@@ -106,15 +116,8 @@ void run_notify()
     if ((curr_time - available_server) > agt->max_time_reconnect_try) {
         /* If response is not available, set lock and wait for it */
         mwarn(SERVER_UNAV);
-        os_setwait();
-        w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_NACTIVE);
-
-        /* Send sync message */
-        start_agent(0);
-
+        reconnect_to_server();
         minfo(SERVER_UP);
-        os_delwait();
-        w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_ACTIVE);
     }
 #endif
 
@@ -122,14 +125,7 @@ void run_notify()
     if (agt->force_reconnect_interval && (curr_time - last_connection_time) >= agt->force_reconnect_interval) {
         /* Set lock and wait for it */
         minfo("Wazuh Agent will be reconnected because of force reconnect interval");
-        os_setwait();
-        w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_NACTIVE);
-
-        /* Send sync message */
-        start_agent(0);
-
-        os_delwait();
-        w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_ACTIVE);
+        reconnect_to_server();
     }
 
     /* Check if time has elapsed (monotonic — immune to clock changes) */

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -37,6 +37,7 @@ int receive_msg()
     char buffer[OS_MAXSTR + 1];
     char cleartext[OS_MAXSTR + 1];
     char *tmp_msg;
+    const int sock = atomic_int_get(&agt->sock);
 
     memset(cleartext, '\0', OS_MAXSTR + 1);
     memset(buffer, '\0', OS_MAXSTR + 1);
@@ -49,7 +50,7 @@ int receive_msg()
                 break;
             }
 
-            recv_b = OS_RecvSecureTCP(agt->sock, buffer, OS_MAXSTR);
+            recv_b = OS_RecvSecureTCP(sock, buffer, OS_MAXSTR);
 
             // Manager disconnected or error
 
@@ -79,7 +80,7 @@ int receive_msg()
                 return -1;
             }
         } else {
-            recv_b = recv(agt->sock, buffer, OS_MAXSTR, MSG_DONTWAIT);
+            recv_b = recv(sock, buffer, OS_MAXSTR, MSG_DONTWAIT);
 
             if (recv_b <= 0) {
                 break;
@@ -123,14 +124,7 @@ int receive_msg()
             else if (strncmp(tmp_msg, HC_FORCE_RECONNECT, strlen(HC_FORCE_RECONNECT)) == 0) {
                 /* Set lock and wait for it */
                 minfo("Wazuh Agent will be reconnected because a reconnect message was received");
-                os_setwait();
-                w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_NACTIVE);
-
-                /* Send sync message */
-                start_agent(0);
-
-                os_delwait();
-                w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_ACTIVE);
+                reconnect_to_server();
                 continue;
             }
 
@@ -349,23 +343,47 @@ int receiver_messages()
             ExecdTimeoutRun();
         }
 
+#ifndef ONEWAY_ENABLED
         /* sock must be set */
-        if (agt->sock == -1) {
-            sleep(5);
+        int sock = atomic_int_get(&agt->sock);
+        if (sock == -1) {
+            merror(LOST_ERROR);
+            reconnect_to_server();
+            minfo(SERVER_UP);
             continue;
         }
+#else
+        /* start_agent() never actually connects under ONEWAY_ENABLED (see
+         * start_agent.c), so agt->sock never leaves -1 -- checking it here
+         * would spin this loop at 100% CPU instead of being paced by
+         * select()'s timeout below, same reasoning as the Linux monitor
+         * loop in agentd.c. */
+        int sock = atomic_int_get(&agt->sock);
+#endif
 
         run_notify();
 
+#ifndef ONEWAY_ENABLED
+        /* run_notify() may also invalidate the socket (it calls send_msg()
+         * for the keep-alive); re-check before FD_SET() needs it, same as
+         * the Linux monitor loop in agentd.c. */
+        sock = atomic_int_get(&agt->sock);
+        if (sock < 0) {
+            continue;
+        }
+#else
+        sock = atomic_int_get(&agt->sock);
+#endif
+
         FD_ZERO(&fdset);
-        FD_SET(agt->sock, &fdset);
+        FD_SET(sock, &fdset);
 
         /* Wait for 1 second */
         selecttime.tv_sec = 1;
         selecttime.tv_usec = 0;
 
         /* Wait with a timeout for any descriptor */
-        rc = select(agt->sock + 1, &fdset, NULL, NULL, &selecttime);
+        rc = select(sock + 1, &fdset, NULL, NULL, &selecttime);
         if (rc == -1) {
             merror(SELECT_ERROR, WSAGetLastError(), win_strerror(WSAGetLastError()));
             sleep(30);
@@ -375,13 +393,9 @@ int receiver_messages()
         }
 
         if (receive_msg() < 0) {
-            w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_NACTIVE);
             merror(LOST_ERROR);
-            os_setwait();
-            start_agent(0);
+            reconnect_to_server();
             minfo(SERVER_UP);
-            os_delwait();
-            w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_ACTIVE);
         }
     }
 

--- a/src/client-agent/sendmsg.c
+++ b/src/client-agent/sendmsg.c
@@ -19,6 +19,14 @@ void sender_init() {
     w_mutex_init(&send_mutex, NULL);
 }
 
+void send_mutex_lock(void) {
+    w_mutex_lock(&send_mutex);
+}
+
+void send_mutex_unlock(void) {
+    w_mutex_unlock(&send_mutex);
+}
+
 /* Send a message to the server */
 int send_msg(const char *msg, ssize_t msg_length)
 {
@@ -35,30 +43,73 @@ int send_msg(const char *msg, ssize_t msg_length)
 
     /* Send msg_size of crypt_msg */
     if (agt->server[agt->rip_id].protocol == IPPROTO_UDP) {
-        retval = OS_SendUDPbySize(agt->sock, msg_size, crypt_msg);
-#ifndef WIN32
+        retval = OS_SendUDPbySize(atomic_int_get(&agt->sock), msg_size, crypt_msg);
+#ifdef WIN32
+        error = WSAGetLastError();
+#else
         error = errno;
 #endif
     } else {
         w_mutex_lock(&send_mutex);
-        if (agt->sock < 0) {
+        /* Snapshot once: nothing else can change agt->sock while send_mutex is
+         * held (every writer takes it first too), so reuse this value for the
+         * rest of the critical section instead of re-reading the atomic. */
+        int sock = atomic_int_get(&agt->sock);
+        if (sock < 0) {
             /* Socket was already invalidated (e.g. by another sender thread
              * after a previous timed-out send). Skip the call to avoid
-             * operating on -1 and reading a stale errno. */
+             * operating on -1 and reading a stale errno. The sleep(1) matches
+             * every other failure path here: without it, a caller like
+             * dispatch_buffer() would spin through its whole queue at
+             * events_persec discarding messages silently instead of pausing
+             * while the reconnect (already under way) completes. */
             w_mutex_unlock(&send_mutex);
+            mdebug1("Connection is down, discarding message until it is restored.");
+            sleep(1);
             return (-1);
         }
-        retval = OS_SendSecureTCP(agt->sock, msg_size, crypt_msg);
-#ifndef WIN32
-        error = errno;
+        retval = OS_SendSecureTCP(sock, msg_size, crypt_msg);
         if (retval) {
             bool socket_dead;
+#ifdef WIN32
+            error = WSAGetLastError();
+
+            switch (error) {
+            case WSAECONNRESET:
+            case WSAECONNABORTED:
+            case WSAENOTCONN:
+            case WSAECONNREFUSED:
+            case WSAENOTSOCK:
+            case WSAETIMEDOUT:
+            case WSAEWOULDBLOCK:
+                /* Same reasoning as the POSIX branch below: a dead peer,
+                 * an invalidated descriptor, or an SO_SNDTIMEO expiry. */
+                socket_dead = true;
+                break;
+            case 0:
+                /* WSASetLastError(0) before send() in OS_SendSecureTCP()
+                 * wasn't overwritten: a short/partial write happened with
+                 * no reported error. The length-prefixed framing for this
+                 * connection is now corrupted; only a reconnect recovers. */
+                socket_dead = true;
+                break;
+            default:
+                socket_dead = false;
+                break;
+            }
+#else
+            error = errno;
 
             switch (error) {
             case EPIPE:
             case ECONNRESET:
             case ENOTCONN:
             case ECONNREFUSED:
+            case EBADF:
+                /* agt->sock points at a descriptor that is no longer open
+                 * (e.g. closed by another thread without updating agt->sock).
+                 * Without this, the agent would keep retrying send() on the
+                 * same dead descriptor forever instead of reconnecting. */
                 socket_dead = true;
                 break;
             case ETIMEDOUT:
@@ -71,16 +122,25 @@ int send_msg(const char *msg, ssize_t msg_length)
                  * blocking again on the very next call. */
                 socket_dead = true;
                 break;
+            case 0:
+                /* errno = 0 right before send() in OS_SendSecureTCP() wasn't
+                 * overwritten: a short/partial write happened with no error
+                 * at all (SO_SNDTIMEO can expire after only part of a large
+                 * message drained). The length-prefixed framing for this
+                 * connection is now corrupted regardless of how many bytes
+                 * got through; only a reconnect recovers. */
+                socket_dead = true;
+                break;
             default:
                 socket_dead = false;
                 break;
             }
-            if (socket_dead && agt->sock >= 0) {
-                OS_CloseSocket(agt->sock);
-                agt->sock = -1;
+#endif
+            if (socket_dead) {
+                OS_CloseSocket(sock);
+                atomic_int_set(&agt->sock, -1);
             }
         }
-#endif
         w_mutex_unlock(&send_mutex);
     }
 
@@ -88,8 +148,35 @@ int send_msg(const char *msg, ssize_t msg_length)
         w_agentd_state_update(INCREMENT_MSG_SEND, NULL);
     } else {
 #ifdef WIN32
-        error = WSAGetLastError();
-        mwarn(SEND_ERROR, "server", win_strerror(error));
+        /* `error` was already captured via WSAGetLastError() above, before
+         * OS_CloseSocket() could have changed it — don't re-fetch here. */
+        switch (error) {
+        case WSAECONNRESET:
+            mdebug2("Connection reset by manager.");
+            break;
+        case WSAECONNABORTED:
+            mdebug2(TCP_EPIPE);
+            break;
+        case WSAENOTCONN:
+            mdebug2("Socket not connected.");
+            break;
+        case WSAECONNREFUSED:
+            mdebug2(CONN_REF);
+            break;
+        case WSAENOTSOCK:
+            mdebug2("Socket descriptor no longer valid.");
+            break;
+        case 0:
+            mwarn("Partial write to server: message framing may be corrupted, reconnecting.");
+            break;
+        case WSAETIMEDOUT:
+        case WSAEWOULDBLOCK:
+            mwarn(SEND_ERROR, "server", win_strerror(error));
+            break;
+        default:
+            mwarn(SEND_ERROR, "server", win_strerror(error));
+            break;
+        }
 #else
         switch (error) {
         case EPIPE:
@@ -103,6 +190,12 @@ int send_msg(const char *msg, ssize_t msg_length)
             break;
         case ENOTCONN:
             mdebug2("Socket not connected.");
+            break;
+        case EBADF:
+            mdebug2("Socket descriptor no longer valid.");
+            break;
+        case 0:
+            mwarn("Partial write to server: message framing may be corrupted, reconnecting.");
             break;
         case ETIMEDOUT:
         case EAGAIN:

--- a/src/client-agent/sendmsg.c
+++ b/src/client-agent/sendmsg.c
@@ -41,9 +41,45 @@ int send_msg(const char *msg, ssize_t msg_length)
 #endif
     } else {
         w_mutex_lock(&send_mutex);
+        if (agt->sock < 0) {
+            /* Socket was already invalidated (e.g. by another sender thread
+             * after a previous timed-out send). Skip the call to avoid
+             * operating on -1 and reading a stale errno. */
+            w_mutex_unlock(&send_mutex);
+            return (-1);
+        }
         retval = OS_SendSecureTCP(agt->sock, msg_size, crypt_msg);
 #ifndef WIN32
         error = errno;
+        if (retval) {
+            bool socket_dead;
+
+            switch (error) {
+            case EPIPE:
+            case ECONNRESET:
+            case ENOTCONN:
+            case ECONNREFUSED:
+                socket_dead = true;
+                break;
+            case ETIMEDOUT:
+            case EAGAIN:
+#if defined(EWOULDBLOCK) && (EWOULDBLOCK != EAGAIN)
+            case EWOULDBLOCK:
+#endif
+                /* SO_SNDTIMEO expired: the kernel send buffer never drained.
+                 * Close and invalidate so the main loop reconnects instead of
+                 * blocking again on the very next call. */
+                socket_dead = true;
+                break;
+            default:
+                socket_dead = false;
+                break;
+            }
+            if (socket_dead && agt->sock >= 0) {
+                OS_CloseSocket(agt->sock);
+                agt->sock = -1;
+            }
+        }
 #endif
         w_mutex_unlock(&send_mutex);
     }
@@ -61,6 +97,19 @@ int send_msg(const char *msg, ssize_t msg_length)
             break;
         case ECONNREFUSED:
             mdebug2(CONN_REF);
+            break;
+        case ECONNRESET:
+            mdebug2("Connection reset by manager.");
+            break;
+        case ENOTCONN:
+            mdebug2("Socket not connected.");
+            break;
+        case ETIMEDOUT:
+        case EAGAIN:
+#if defined(EWOULDBLOCK) && (EWOULDBLOCK != EAGAIN)
+        case EWOULDBLOCK:
+#endif
+            mwarn(SEND_ERROR, "server", strerror(error));
             break;
         default:
             mwarn(SEND_ERROR, "server", strerror(error));

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -118,6 +118,23 @@ bool connect_server(int server_id, bool verbose)
                 ioctlsocket(agt->sock, FIONBIO, (u_long FAR *) &bmode);
             }
         #endif
+        if (agt->server[server_id].protocol != IPPROTO_UDP) {
+            /* Detect a silently half-closed TCP connection (no FIN/RST seen)
+             * and bound how long a blocked send() may hold send_mutex. */
+            if (OS_SetKeepalive(agt->sock) < 0) {
+                mwarn("OS_SetKeepalive failed with error '%s'", strerror(errno));
+            } else {
+                int keepidle = getDefine_Int("agent", "tcp_keepidle", 1, 7200);
+                int keepintvl = getDefine_Int("agent", "tcp_keepintvl", 1, 100);
+                int keepcnt = getDefine_Int("agent", "tcp_keepcnt", 1, 50);
+                OS_SetKeepalive_Options(agt->sock, keepidle, keepintvl, keepcnt);
+            }
+
+            int send_timeout = getDefine_Int("agent", "send_timeout", 1, 600);
+            if (OS_SetSendTimeout(agt->sock, send_timeout) < 0) {
+                mwarn("OS_SetSendTimeout failed with error '%s'", strerror(errno));
+            }
+        }
         agt->rip_id = server_id;
         last_connection_time = (int)time(NULL);
         os_free(ip_address);

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -49,18 +49,24 @@ bool connect_server(int server_id, bool verbose)
 {
     timeout = getDefine_Int("agent", "recv_timeout", 1, 600);
 
-    /* Close socket if available */
-    if (agt->sock >= 0) {
-        OS_CloseSocket(agt->sock);
-        agt->sock = -1;
+    /* Close socket if available. Locked so a concurrent sender in send_msg()
+     * (which only ever touches agt->sock under this same mutex) can't read a
+     * descriptor that's being closed out from under it. */
+    send_mutex_lock();
+    int old_sock = atomic_int_get(&agt->sock);
+    bool had_old_socket = old_sock >= 0;
+    if (had_old_socket) {
+        OS_CloseSocket(old_sock);
+        atomic_int_set(&agt->sock, -1);
+    }
+    send_mutex_unlock();
 
-        if (agt->server[agt->rip_id].rip) {
-            if (verbose) {
-                minfo("Closing connection to server ([%s]:%d/%s).",
-                    agt->server[agt->rip_id].rip,
-                    agt->server[agt->rip_id].port,
-                    agt->server[agt->rip_id].protocol == IPPROTO_UDP ? "udp" : "tcp");
-            }
+    if (had_old_socket && agt->server[agt->rip_id].rip) {
+        if (verbose) {
+            minfo("Closing connection to server ([%s]:%d/%s).",
+                agt->server[agt->rip_id].rip,
+                agt->server[agt->rip_id].port,
+                agt->server[agt->rip_id].protocol == IPPROTO_UDP ? "udp" : "tcp");
         }
     }
 
@@ -93,14 +99,17 @@ bool connect_server(int server_id, bool verbose)
             agt->server[server_id].port,
             agt->server[server_id].protocol == IPPROTO_UDP ? "udp" : "tcp");
     }
+    int new_sock;
     if (agt->server[server_id].protocol == IPPROTO_UDP) {
-        agt->sock = OS_ConnectUDP(agt->server[server_id].port, ip_address, strchr(ip_address, ':') != NULL ? 1 : 0, agt->server[server_id].network_interface);
+        new_sock = OS_ConnectUDP(agt->server[server_id].port, ip_address, strchr(ip_address, ':') != NULL ? 1 : 0, agt->server[server_id].network_interface);
     } else {
-        agt->sock = OS_ConnectTCP(agt->server[server_id].port, ip_address, strchr(ip_address, ':') != NULL ? 1 : 0, agt->server[server_id].network_interface);
+        new_sock = OS_ConnectTCP(agt->server[server_id].port, ip_address, strchr(ip_address, ':') != NULL ? 1 : 0, agt->server[server_id].network_interface);
     }
 
-    if (agt->sock < 0) {
-        agt->sock = -1;
+    if (new_sock < 0) {
+        send_mutex_lock();
+        atomic_int_set(&agt->sock, -1);
+        send_mutex_unlock();
 
         if (verbose) {
             #ifdef WIN32
@@ -115,33 +124,85 @@ bool connect_server(int server_id, bool verbose)
                 int bmode = 1;
 
                 /* Set socket to non-blocking */
-                ioctlsocket(agt->sock, FIONBIO, (u_long FAR *) &bmode);
+                ioctlsocket(new_sock, FIONBIO, (u_long FAR *) &bmode);
             }
         #endif
         if (agt->server[server_id].protocol != IPPROTO_UDP) {
             /* Detect a silently half-closed TCP connection (no FIN/RST seen)
-             * and bound how long a blocked send() may hold send_mutex. */
-            if (OS_SetKeepalive(agt->sock) < 0) {
+             * and bound how long a blocked send() may hold send_mutex. Applied
+             * on the local fd, before it's published to agt->sock, so no
+             * sender can ever observe an unconfigured socket. */
+            if (OS_SetKeepalive(new_sock) < 0) {
+#ifdef WIN32
+                mwarn("OS_SetKeepalive failed with error '%s'", win_strerror(WSAGetLastError()));
+#else
                 mwarn("OS_SetKeepalive failed with error '%s'", strerror(errno));
+#endif
             } else {
+#if !defined(WIN32) && !defined(OpenBSD)
+                /* OS_SetKeepalive_Options() only warns "unsupported platform"
+                 * on WIN32/OpenBSD/sun for every single parameter -- skip the
+                 * call there instead of logging the same noise on every
+                 * reconnect. */
                 int keepidle = getDefine_Int("agent", "tcp_keepidle", 1, 7200);
                 int keepintvl = getDefine_Int("agent", "tcp_keepintvl", 1, 100);
                 int keepcnt = getDefine_Int("agent", "tcp_keepcnt", 1, 50);
-                OS_SetKeepalive_Options(agt->sock, keepidle, keepintvl, keepcnt);
+                OS_SetKeepalive_Options(new_sock, keepidle, keepintvl, keepcnt);
+#endif
             }
 
             int send_timeout = getDefine_Int("agent", "send_timeout", 1, 600);
-            if (OS_SetSendTimeout(agt->sock, send_timeout) < 0) {
+            if (OS_SetSendTimeout(new_sock, send_timeout) < 0) {
+#ifdef WIN32
+                mwarn("OS_SetSendTimeout failed with error '%s'", win_strerror(WSAGetLastError()));
+#else
                 mwarn("OS_SetSendTimeout failed with error '%s'", strerror(errno));
+#endif
+            }
+
+            /* Bound the handshake's blocking receive too (receive_message()
+             * -> OS_RecvSecureTCP() -> os_recv_waitall()), which otherwise has
+             * no timeout at all: a manager that delivers a partial reply and
+             * goes silent would hang this single-threaded path indefinitely,
+             * the same clinical picture (status='connected', stuck forever)
+             * this whole fix exists to close on the send side. */
+            if (OS_SetRecvTimeout(new_sock, timeout, 0) < 0) {
+#ifdef WIN32
+                mwarn("OS_SetRecvTimeout failed with error '%s'", win_strerror(WSAGetLastError()));
+#else
+                mwarn("OS_SetRecvTimeout failed with error '%s'", strerror(errno));
+#endif
             }
         }
+
+        /* rip_id published before sock, both under the same lock: send_msg()
+         * reads agt->server[agt->rip_id].protocol to pick UDP vs TCP before
+         * it ever takes this mutex, so a sender must never be able to see the
+         * new socket paired with the previous (possibly different-protocol)
+         * server's rip_id. */
+        send_mutex_lock();
         agt->rip_id = server_id;
+        atomic_int_set(&agt->sock, new_sock);
+        send_mutex_unlock();
+
         last_connection_time = (int)time(NULL);
         os_free(ip_address);
         return true;
     }
     os_free(ip_address);
     return false;
+}
+
+/* Common reconnect sequence: toggle the wait/status flags around start_agent(0).
+ * Defined here (not in agentd.c) because agentd.o is excluded from the Windows
+ * agent link, while start_agent.o is shared by every build target -- notify.c
+ * and receiver.c (the Windows receive loop) both call this too. */
+void reconnect_to_server(void) {
+    os_setwait();
+    w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_NACTIVE);
+    start_agent(0);
+    os_delwait();
+    w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_ACTIVE);
 }
 
 /* Send synchronization message to the server and wait for the ack */
@@ -274,8 +335,15 @@ static void w_agentd_keys_init (void) {
 static ssize_t receive_message(char *buffer, unsigned int max_lenght) {
 
     ssize_t recv_b = 0;
+    const int sock = atomic_int_get(&agt->sock);
+
+    if (sock < 0) {
+        /* FD_SET(-1, ...) is undefined behavior; nothing to wait on anyway. */
+        return 0;
+    }
+
     /* Read received reply */
-    switch (wnet_select(agt->sock, timeout)) {
+    switch (wnet_select(sock, timeout)) {
         case -1:
             merror(SELECT_ERROR, errno, strerror(errno));
             break;
@@ -287,10 +355,10 @@ static ssize_t receive_message(char *buffer, unsigned int max_lenght) {
         default:
             if (agt->server[agt->rip_id].protocol == IPPROTO_UDP) {
                 /* Receive response UDP*/
-                recv_b = recv(agt->sock, buffer, max_lenght, MSG_DONTWAIT);
+                recv_b = recv(sock, buffer, max_lenght, MSG_DONTWAIT);
             } else {
                 /* Receive response TCP*/
-                recv_b = OS_RecvSecureTCP(agt->sock, buffer, max_lenght);
+                recv_b = OS_RecvSecureTCP(sock, buffer, max_lenght);
             }
 
             /* Successful response */
@@ -360,7 +428,11 @@ STATIC bool agent_handshake_to_server(int server_id, bool is_startup) {
 
     if (connect_server(server_id, true)) {
         /* Send start up message */
-        send_msg(msg, -1);
+        if (send_msg(msg, -1) != 0) {
+            /* send_msg() may have closed and invalidated agt->sock (e.g. a
+             * short write or a dead peer) -- nothing to read a reply from. */
+            return false;
+        }
 
         /* Read until our reply comes back */
         recv_b = receive_message(buffer, OS_MAXSTR);

--- a/src/config/client-config.h
+++ b/src/config/client-config.h
@@ -12,6 +12,7 @@
 #define CAGENTD_H
 
 #include "shared.h"
+#include <stdatomic.h>
 
 typedef struct agent_flags_t {
     unsigned int auto_restart:1;
@@ -31,7 +32,7 @@ typedef struct agent_server {
 typedef struct _agent {
     agent_server * server;
     int m_queue;
-    int sock;
+    _Atomic int sock; ///< Read/written from the main loop and from sender threads (dispatch_buffer, req_receiver)
     int execdq;
     int cfgadq;
     int rip_id; ///< Holds the index of the current connected server

--- a/src/config/client-config.h
+++ b/src/config/client-config.h
@@ -12,7 +12,6 @@
 #define CAGENTD_H
 
 #include "shared.h"
-#include <stdatomic.h>
 
 typedef struct agent_flags_t {
     unsigned int auto_restart:1;
@@ -32,7 +31,9 @@ typedef struct agent_server {
 typedef struct _agent {
     agent_server * server;
     int m_queue;
-    _Atomic int sock; ///< Read/written from the main loop and from sender threads (dispatch_buffer, req_receiver)
+    atomic_int_t sock; ///< Read/written from the main loop and from sender threads (dispatch_buffer, req_receiver).
+                       ///< This project's own portable wrapper (headers/atomic.h), not C11 _Atomic: some Tier 2/3
+                       ///< agent platforms (AIX, HP-UX, Solaris, older GCC) can't be relied on for <stdatomic.h>.
     int execdq;
     int cfgadq;
     int rip_id; ///< Holds the index of the current connected server

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -705,6 +705,13 @@ int OS_SendSecureTCP(int sock, uint32_t size, const void * msg) {
     *(uint32_t *)buffer = wnet_order(size);
     memcpy(buffer + sizeof(uint32_t), msg, size);
     errno = 0;
+#ifdef WIN32
+    /* A short/partial send() (SO_SNDTIMEO expiring after only part of the
+     * buffer drained) doesn't call SetLastError(), so without this the
+     * caller would read a stale, unrelated WSA error code instead of
+     * correctly seeing "no error, but incomplete" (WSAGetLastError() == 0). */
+    WSASetLastError(0);
+#endif
     retval = send(sock, buffer, bufsz, 0) == (ssize_t)bufsz ? 0 : OS_SOCKTERR;
     free(buffer);
     return retval;

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -32,6 +32,7 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 # Generate agentd tests
 list(APPEND client-agent_names "test_start_agent")
 set(START_AGENT_BASE_FLAGS "-Wl,--wrap,w_rotate_log -Wl,--wrap,getDefine_Int -Wl,--wrap,OS_ConnectUDP \
+                            -Wl,--wrap,OS_SetKeepalive -Wl,--wrap,OS_SetKeepalive_Options -Wl,--wrap,OS_SetSendTimeout \
                             -Wl,--wrap,OS_ConnectTCP -Wl,--wrap,OS_SetRecvTimeout -Wl,--wrap,OS_GetHost \
                             -Wl,--wrap,send_msg -Wl,--wrap,recv -Wl,--wrap,OS_RecvSecureTCP -Wl,--wrap,fseek \
                             -Wl,--wrap=is_fim_shutdown -Wl,--wrap=fim_db_teardown \
@@ -109,6 +110,12 @@ endif()
 if(${TARGET} STREQUAL "agent")
 list(APPEND client-agent_names "test_agentd")
 list(APPEND client-agent_flags "-Wl,--wrap,wurl_free_response -Wl,--wrap,wurl_http_request ${DEBUG_OP_WRAPPERS}")
+
+list(APPEND client-agent_names "test_sendmsg")
+list(APPEND client-agent_flags "${DEBUG_OP_WRAPPERS} \
+                                -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock \
+                                -Wl,--wrap,CreateSecMSG -Wl,--wrap,sleep -Wl,--wrap,getpid -Wl,--wrap,w_agentd_state_update \
+                                -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,OS_SendUDPbySize -Wl,--wrap,OS_CloseSocket")
 endif()
 
 list(LENGTH client-agent_names count)

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -113,7 +113,6 @@ list(APPEND client-agent_flags "-Wl,--wrap,wurl_free_response -Wl,--wrap,wurl_ht
 
 list(APPEND client-agent_names "test_sendmsg")
 list(APPEND client-agent_flags "${DEBUG_OP_WRAPPERS} \
-                                -Wl,--wrap,pthread_mutex_lock -Wl,--wrap,pthread_mutex_unlock \
                                 -Wl,--wrap,CreateSecMSG -Wl,--wrap,sleep -Wl,--wrap,getpid -Wl,--wrap,w_agentd_state_update \
                                 -Wl,--wrap,OS_SendSecureTCP -Wl,--wrap,OS_SendUDPbySize -Wl,--wrap,OS_CloseSocket")
 endif()

--- a/src/unit_tests/client-agent/test_notify.c
+++ b/src/unit_tests/client-agent/test_notify.c
@@ -41,8 +41,15 @@ extern void notify_reset_saved_time(void);
 static int setup(void **state) {
     static agent global_config;
     agt = &global_config;
+    // agt->sock is this project's portable atomic_int_t (headers/atomic.h):
+    // its embedded pthread_mutex_t needs a real init, not just zeroed bytes.
+    w_mutex_init(&agt->sock.mutex, NULL);
+    // get_agent_ip() now takes send_mutex (sendmsg.c); initialize it for real
+    // too instead of relying on a zero-initialized static behaving like
+    // PTHREAD_MUTEX_INITIALIZER.
+    sender_init();
     // force init value on every call
-    agt->sock = DUMMY_VALID_SOCKET_FD;
+    atomic_int_set(&agt->sock, DUMMY_VALID_SOCKET_FD);
     errno = 0;
     return 0;
 }
@@ -51,7 +58,9 @@ static int setup_run_notify(void **state) {
     static agent global_config;
     memset(&global_config, 0, sizeof(global_config));
     agt = &global_config;
-    agt->sock = DUMMY_VALID_SOCKET_FD;
+    w_mutex_init(&agt->sock.mutex, NULL);
+    sender_init();
+    atomic_int_set(&agt->sock, DUMMY_VALID_SOCKET_FD);
     agt->notify_time = 60;
     agt->max_time_reconnect_try = 3600;
     agt->force_reconnect_interval = 0;
@@ -86,7 +95,7 @@ static void get_agent_ip_invalid_socket(void **state) {
     char *retval;
 
     // force bad socket id
-    agt->sock = 0;
+    atomic_int_set(&agt->sock, 0);
     errno = EBADF;
     expect_string(__wrap__mdebug2, formatted_msg, "getsockname() failed: Bad file descriptor");
 

--- a/src/unit_tests/client-agent/test_sendmsg.c
+++ b/src/unit_tests/client-agent/test_sendmsg.c
@@ -19,7 +19,6 @@
 #include "../wrappers/wazuh/os_crypto/msgs_wrappers.h"
 #include "../wrappers/wazuh/os_net/os_net_wrappers.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
-#include "../wrappers/posix/pthread_wrappers.h"
 #include "../wrappers/posix/unistd_wrappers.h"
 
 #define DUMMY_VALID_SOCKET_FD 5
@@ -38,7 +37,13 @@ static int setup(void **state) {
     agt->server = servers;
     agt->rip_id = 0;
     agt->server[0].protocol = IPPROTO_TCP;
-    agt->sock = DUMMY_VALID_SOCKET_FD;
+    /* memset() only zeroes agt->sock.data; the embedded pthread_mutex_t must
+     * be initialized for real before any atomic_int_get/set(&agt->sock) call.
+     * send_mutex_lock/unlock() are not mocked here (real pthread mutexes,
+     * same as production), so behavior is verified via retval/socket-value
+     * assertions rather than call-count expectations. */
+    w_mutex_init(&agt->sock.mutex, NULL);
+    atomic_int_set(&agt->sock, DUMMY_VALID_SOCKET_FD);
     sender_init();
     errno = 0;
     return 0;
@@ -75,44 +80,41 @@ static void test_send_msg_create_sec_msg_fail(void **state) {
 
     int ret = send_msg("hello", -1);
     assert_int_equal(ret, -1);
-    assert_int_equal(agt->sock, DUMMY_VALID_SOCKET_FD);
+    assert_int_equal(atomic_int_get(&agt->sock), DUMMY_VALID_SOCKET_FD);
 }
 
 /* Socket already invalidated (-1) by another thread: send_mutex is still
  * taken (unlike an ad-hoc check before locking) so the check itself can't
  * race with a concurrent sender, but OS_SendSecureTCP is never reached. */
 static void test_send_msg_socket_already_invalid(void **state) {
-    agt->sock = -1;
+    atomic_int_set(&agt->sock, -1);
     expect_create_sec_msg_ok();
-    expect_function_call(__wrap_pthread_mutex_lock);
-    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_any(__wrap__mdebug1, formatted_msg);
+    expect_value(__wrap_sleep, seconds, 1);
 
     int ret = send_msg("hello", -1);
     assert_int_equal(ret, -1);
-    assert_int_equal(agt->sock, -1);
+    assert_int_equal(atomic_int_get(&agt->sock), -1);
 }
 
 /* Successful send -> returns 0, state updated, socket stays open. */
 static void test_send_msg_success(void **state) {
     expect_create_sec_msg_ok();
-    expect_function_call(__wrap_pthread_mutex_lock);
     expect_any(__wrap_OS_SendSecureTCP, sock);
     expect_any(__wrap_OS_SendSecureTCP, size);
     expect_any(__wrap_OS_SendSecureTCP, msg);
     will_return(__wrap_OS_SendSecureTCP, 0);
-    expect_function_call(__wrap_pthread_mutex_unlock);
     expect_value(__wrap_w_agentd_state_update, type, INCREMENT_MSG_SEND);
 
     int ret = send_msg("hello", -1);
     assert_int_equal(ret, 0);
-    assert_int_equal(agt->sock, DUMMY_VALID_SOCKET_FD);
+    assert_int_equal(atomic_int_get(&agt->sock), DUMMY_VALID_SOCKET_FD);
 }
 
 /* Shared body for the "fatal" errno cases: OS_SendSecureTCP fails, the
  * socket is closed and invalidated, and the failure is logged. */
 static void run_fatal_error_case(int err, void (*expect_log)(void)) {
     expect_create_sec_msg_ok();
-    expect_function_call(__wrap_pthread_mutex_lock);
     errno = err;
     expect_any(__wrap_OS_SendSecureTCP, sock);
     expect_any(__wrap_OS_SendSecureTCP, size);
@@ -120,13 +122,12 @@ static void run_fatal_error_case(int err, void (*expect_log)(void)) {
     will_return(__wrap_OS_SendSecureTCP, -1);
     expect_value(__wrap_OS_CloseSocket, sock, DUMMY_VALID_SOCKET_FD);
     will_return(__wrap_OS_CloseSocket, 0);
-    expect_function_call(__wrap_pthread_mutex_unlock);
     expect_log();
     expect_value(__wrap_sleep, seconds, 1);
 
     int ret = send_msg("hello", -1);
     assert_int_equal(ret, -1);
-    assert_int_equal(agt->sock, -1);
+    assert_int_equal(atomic_int_get(&agt->sock), -1);
 }
 
 static void expect_mdebug2_any(void) {
@@ -157,6 +158,22 @@ static void test_send_msg_econnrefused(void **state) {
     run_fatal_error_case(ECONNREFUSED, expect_mdebug2_any);
 }
 
+/* EBADF: fd is no longer open (e.g. closed by another thread without
+ * updating agt->sock) -> socket invalidated, instead of retrying forever
+ * on the same dead descriptor. */
+static void test_send_msg_ebadf(void **state) {
+    run_fatal_error_case(EBADF, expect_mdebug2_any);
+}
+
+/* errno == 0 with retval != 0: OS_SendSecureTCP() zeroes errno right before
+ * send(), so this means send() returned a short/partial write, not a hard
+ * error (SO_SNDTIMEO can expire mid-write on a large message). The
+ * length-prefixed framing on this connection is now corrupted regardless of
+ * how many bytes got through, so this must be treated as fatal too. */
+static void test_send_msg_partial_write(void **state) {
+    run_fatal_error_case(0, expect_mwarn_any);
+}
+
 /* ETIMEDOUT (retransmission exhausted, or SO_SNDTIMEO expiry) -> invalidated */
 static void test_send_msg_etimedout(void **state) {
     run_fatal_error_case(ETIMEDOUT, expect_mwarn_any);
@@ -173,19 +190,17 @@ static void test_send_msg_eagain(void **state) {
  * only errors that mean the connection itself is dead should tear it down. */
 static void test_send_msg_unknown_error_keeps_socket(void **state) {
     expect_create_sec_msg_ok();
-    expect_function_call(__wrap_pthread_mutex_lock);
     errno = ENOMEM;
     expect_any(__wrap_OS_SendSecureTCP, sock);
     expect_any(__wrap_OS_SendSecureTCP, size);
     expect_any(__wrap_OS_SendSecureTCP, msg);
     will_return(__wrap_OS_SendSecureTCP, -1);
-    expect_function_call(__wrap_pthread_mutex_unlock);
     expect_any(__wrap__mwarn, formatted_msg);
     expect_value(__wrap_sleep, seconds, 1);
 
     int ret = send_msg("hello", -1);
     assert_int_equal(ret, -1);
-    assert_int_equal(agt->sock, DUMMY_VALID_SOCKET_FD); /* socket must NOT be closed */
+    assert_int_equal(atomic_int_get(&agt->sock), DUMMY_VALID_SOCKET_FD); /* socket must NOT be closed */
 }
 
 /* ── test cases (UDP path, unaffected by this fix) ────────────────────── */
@@ -203,7 +218,7 @@ static void test_send_msg_udp_success(void **state) {
     assert_int_equal(ret, 0);
     /* UDP errors never invalidate agt->sock: there's no dead-socket detection
      * for a connectionless protocol. */
-    assert_int_equal(agt->sock, DUMMY_VALID_SOCKET_FD);
+    assert_int_equal(atomic_int_get(&agt->sock), DUMMY_VALID_SOCKET_FD);
 }
 
 static void test_send_msg_udp_error_keeps_socket(void **state) {
@@ -219,7 +234,7 @@ static void test_send_msg_udp_error_keeps_socket(void **state) {
 
     int ret = send_msg("hello", -1);
     assert_int_equal(ret, -1);
-    assert_int_equal(agt->sock, DUMMY_VALID_SOCKET_FD);
+    assert_int_equal(atomic_int_get(&agt->sock), DUMMY_VALID_SOCKET_FD);
 }
 
 int main(void) {
@@ -231,6 +246,8 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_send_msg_econnreset, setup, teardown),
         cmocka_unit_test_setup_teardown(test_send_msg_enotconn, setup, teardown),
         cmocka_unit_test_setup_teardown(test_send_msg_econnrefused, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_send_msg_ebadf, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_send_msg_partial_write, setup, teardown),
         cmocka_unit_test_setup_teardown(test_send_msg_etimedout, setup, teardown),
         cmocka_unit_test_setup_teardown(test_send_msg_eagain, setup, teardown),
         cmocka_unit_test_setup_teardown(test_send_msg_unknown_error_keeps_socket, setup, teardown),

--- a/src/unit_tests/client-agent/test_sendmsg.c
+++ b/src/unit_tests/client-agent/test_sendmsg.c
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <errno.h>
+
+#include "../client-agent/agentd.h"
+
+#include "../wrappers/common.h"
+#include "../wrappers/wazuh/os_crypto/msgs_wrappers.h"
+#include "../wrappers/wazuh/os_net/os_net_wrappers.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+#include "../wrappers/posix/pthread_wrappers.h"
+#include "../wrappers/posix/unistd_wrappers.h"
+
+#define DUMMY_VALID_SOCKET_FD 5
+
+void __wrap_w_agentd_state_update(w_agentd_state_update_t type, void *data) {
+    check_expected(type);
+}
+
+static agent_server servers[1];
+static agent global_config;
+
+static int setup(void **state) {
+    memset(&global_config, 0, sizeof(global_config));
+    memset(servers, 0, sizeof(servers));
+    agt = &global_config;
+    agt->server = servers;
+    agt->rip_id = 0;
+    agt->server[0].protocol = IPPROTO_TCP;
+    agt->sock = DUMMY_VALID_SOCKET_FD;
+    sender_init();
+    errno = 0;
+    return 0;
+}
+
+static int teardown(void **state) {
+    return 0;
+}
+
+/* Helper: common expectation chain for a CreateSecMSG call that succeeds */
+static void expect_create_sec_msg_ok(void) {
+    expect_any(__wrap_CreateSecMSG, msg);
+    expect_any(__wrap_CreateSecMSG, msg_length);
+    expect_any(__wrap_CreateSecMSG, id);
+    will_return(__wrap_CreateSecMSG, 64);  /* size: non-zero -> success */
+    will_return(__wrap_CreateSecMSG, "X"); /* msg_encrypted content */
+}
+
+static void expect_create_sec_msg_fail(void) {
+    expect_any(__wrap_CreateSecMSG, msg);
+    expect_any(__wrap_CreateSecMSG, msg_length);
+    expect_any(__wrap_CreateSecMSG, id);
+    will_return(__wrap_CreateSecMSG, 0);  /* size: zero -> failure */
+    will_return(__wrap_CreateSecMSG, ""); /* mock_type(char*) still consumed */
+}
+
+/* ── test cases (TCP path) ─────────────────────────────────────────────── */
+
+/* CreateSecMSG fails -> send_msg returns -1 without ever taking send_mutex
+ * or touching the socket. */
+static void test_send_msg_create_sec_msg_fail(void **state) {
+    expect_create_sec_msg_fail();
+    expect_any(__wrap__merror, formatted_msg);
+
+    int ret = send_msg("hello", -1);
+    assert_int_equal(ret, -1);
+    assert_int_equal(agt->sock, DUMMY_VALID_SOCKET_FD);
+}
+
+/* Socket already invalidated (-1) by another thread: send_mutex is still
+ * taken (unlike an ad-hoc check before locking) so the check itself can't
+ * race with a concurrent sender, but OS_SendSecureTCP is never reached. */
+static void test_send_msg_socket_already_invalid(void **state) {
+    agt->sock = -1;
+    expect_create_sec_msg_ok();
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+
+    int ret = send_msg("hello", -1);
+    assert_int_equal(ret, -1);
+    assert_int_equal(agt->sock, -1);
+}
+
+/* Successful send -> returns 0, state updated, socket stays open. */
+static void test_send_msg_success(void **state) {
+    expect_create_sec_msg_ok();
+    expect_function_call(__wrap_pthread_mutex_lock);
+    expect_any(__wrap_OS_SendSecureTCP, sock);
+    expect_any(__wrap_OS_SendSecureTCP, size);
+    expect_any(__wrap_OS_SendSecureTCP, msg);
+    will_return(__wrap_OS_SendSecureTCP, 0);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_value(__wrap_w_agentd_state_update, type, INCREMENT_MSG_SEND);
+
+    int ret = send_msg("hello", -1);
+    assert_int_equal(ret, 0);
+    assert_int_equal(agt->sock, DUMMY_VALID_SOCKET_FD);
+}
+
+/* Shared body for the "fatal" errno cases: OS_SendSecureTCP fails, the
+ * socket is closed and invalidated, and the failure is logged. */
+static void run_fatal_error_case(int err, void (*expect_log)(void)) {
+    expect_create_sec_msg_ok();
+    expect_function_call(__wrap_pthread_mutex_lock);
+    errno = err;
+    expect_any(__wrap_OS_SendSecureTCP, sock);
+    expect_any(__wrap_OS_SendSecureTCP, size);
+    expect_any(__wrap_OS_SendSecureTCP, msg);
+    will_return(__wrap_OS_SendSecureTCP, -1);
+    expect_value(__wrap_OS_CloseSocket, sock, DUMMY_VALID_SOCKET_FD);
+    will_return(__wrap_OS_CloseSocket, 0);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_log();
+    expect_value(__wrap_sleep, seconds, 1);
+
+    int ret = send_msg("hello", -1);
+    assert_int_equal(ret, -1);
+    assert_int_equal(agt->sock, -1);
+}
+
+static void expect_mdebug2_any(void) {
+    expect_any(__wrap__mdebug2, formatted_msg);
+}
+
+static void expect_mwarn_any(void) {
+    expect_any(__wrap__mwarn, formatted_msg);
+}
+
+/* EPIPE: manager closed the connection -> socket invalidated */
+static void test_send_msg_epipe(void **state) {
+    run_fatal_error_case(EPIPE, expect_mdebug2_any);
+}
+
+/* ECONNRESET: reset by manager -> socket invalidated */
+static void test_send_msg_econnreset(void **state) {
+    run_fatal_error_case(ECONNRESET, expect_mdebug2_any);
+}
+
+/* ENOTCONN: kernel already tore the connection down -> socket invalidated */
+static void test_send_msg_enotconn(void **state) {
+    run_fatal_error_case(ENOTCONN, expect_mdebug2_any);
+}
+
+/* ECONNREFUSED -> socket invalidated */
+static void test_send_msg_econnrefused(void **state) {
+    run_fatal_error_case(ECONNREFUSED, expect_mdebug2_any);
+}
+
+/* ETIMEDOUT (retransmission exhausted, or SO_SNDTIMEO expiry) -> invalidated */
+static void test_send_msg_etimedout(void **state) {
+    run_fatal_error_case(ETIMEDOUT, expect_mwarn_any);
+}
+
+/* EAGAIN (SO_SNDTIMEO expiry on a blocking socket) -> invalidated.
+ * This is the case this whole fix exists for: it turns an indefinitely
+ * blocked send() into a bounded, detected failure. */
+static void test_send_msg_eagain(void **state) {
+    run_fatal_error_case(EAGAIN, expect_mwarn_any);
+}
+
+/* Unknown/transient error (e.g. ENOMEM) -> socket must NOT be invalidated:
+ * only errors that mean the connection itself is dead should tear it down. */
+static void test_send_msg_unknown_error_keeps_socket(void **state) {
+    expect_create_sec_msg_ok();
+    expect_function_call(__wrap_pthread_mutex_lock);
+    errno = ENOMEM;
+    expect_any(__wrap_OS_SendSecureTCP, sock);
+    expect_any(__wrap_OS_SendSecureTCP, size);
+    expect_any(__wrap_OS_SendSecureTCP, msg);
+    will_return(__wrap_OS_SendSecureTCP, -1);
+    expect_function_call(__wrap_pthread_mutex_unlock);
+    expect_any(__wrap__mwarn, formatted_msg);
+    expect_value(__wrap_sleep, seconds, 1);
+
+    int ret = send_msg("hello", -1);
+    assert_int_equal(ret, -1);
+    assert_int_equal(agt->sock, DUMMY_VALID_SOCKET_FD); /* socket must NOT be closed */
+}
+
+/* ── test cases (UDP path, unaffected by this fix) ────────────────────── */
+
+static void test_send_msg_udp_success(void **state) {
+    agt->server[0].protocol = IPPROTO_UDP;
+    expect_create_sec_msg_ok();
+    expect_any(__wrap_OS_SendUDPbySize, sock);
+    expect_any(__wrap_OS_SendUDPbySize, size);
+    expect_any(__wrap_OS_SendUDPbySize, msg);
+    will_return(__wrap_OS_SendUDPbySize, 0);
+    expect_value(__wrap_w_agentd_state_update, type, INCREMENT_MSG_SEND);
+
+    int ret = send_msg("hello", -1);
+    assert_int_equal(ret, 0);
+    /* UDP errors never invalidate agt->sock: there's no dead-socket detection
+     * for a connectionless protocol. */
+    assert_int_equal(agt->sock, DUMMY_VALID_SOCKET_FD);
+}
+
+static void test_send_msg_udp_error_keeps_socket(void **state) {
+    agt->server[0].protocol = IPPROTO_UDP;
+    expect_create_sec_msg_ok();
+    errno = ECONNREFUSED;
+    expect_any(__wrap_OS_SendUDPbySize, sock);
+    expect_any(__wrap_OS_SendUDPbySize, size);
+    expect_any(__wrap_OS_SendUDPbySize, msg);
+    will_return(__wrap_OS_SendUDPbySize, -1);
+    expect_any(__wrap__mdebug2, formatted_msg);
+    expect_value(__wrap_sleep, seconds, 1);
+
+    int ret = send_msg("hello", -1);
+    assert_int_equal(ret, -1);
+    assert_int_equal(agt->sock, DUMMY_VALID_SOCKET_FD);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_send_msg_create_sec_msg_fail, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_send_msg_socket_already_invalid, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_send_msg_success, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_send_msg_epipe, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_send_msg_econnreset, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_send_msg_enotconn, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_send_msg_econnrefused, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_send_msg_etimedout, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_send_msg_eagain, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_send_msg_unknown_error_keeps_socket, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_send_msg_udp_success, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_send_msg_udp_error_keeps_socket, setup, teardown),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/client-agent/test_start_agent.c
+++ b/src/unit_tests/client-agent/test_start_agent.c
@@ -150,6 +150,65 @@ static int teardown_test(void **state) {
 
 /* tests */
 /* connect_server */
+
+/* TCP connection where OS_SetKeepalive fails: mwarn is emitted but the
+ * connection is still established and send timeout is still applied. */
+static void test_connect_server_keepalive_fails(void **state) {
+    bool connected = false;
+
+    will_return(__wrap_getDefine_Int, 5);
+    expect_string(__wrap_OS_GetHost, host, agt->server[1].rip);
+    will_return(__wrap_OS_GetHost, strdup("127.0.0.2"));
+
+    expect_any(__wrap_OS_ConnectTCP, _port);
+    expect_any(__wrap_OS_ConnectTCP, _ip);
+    expect_any(__wrap_OS_ConnectTCP, ipv6);
+    will_return(__wrap_OS_ConnectTCP, 10);
+    /* No previous socket to close (agt->sock == -1 in setup) */
+    will_return(__wrap_OS_SetKeepalive, -1);   /* keepalive fails */
+    /* OS_SetKeepalive_Options must NOT be called (it is inside the else branch) */
+    will_return(__wrap_getDefine_Int, 30);     /* send_timeout still queried */
+    will_return(__wrap_OS_SetSendTimeout, 0);
+
+    expect_any(__wrap__minfo, formatted_msg);       /* "Trying to connect to server..." */
+    expect_any(__wrap__mwarn, formatted_msg);       /* "OS_SetKeepalive failed..." */
+
+    connected = connect_server(1, true);
+    assert_true(connected);
+    assert_int_equal(agt->sock, 10);
+    assert_int_equal(agt->rip_id, 1);
+}
+
+/* TCP connection where OS_SetSendTimeout fails: mwarn is emitted but the
+ * connection is still established. */
+static void test_connect_server_send_timeout_fails(void **state) {
+    bool connected = false;
+
+    will_return(__wrap_getDefine_Int, 5);
+    expect_string(__wrap_OS_GetHost, host, agt->server[1].rip);
+    will_return(__wrap_OS_GetHost, strdup("127.0.0.2"));
+
+    expect_any(__wrap_OS_ConnectTCP, _port);
+    expect_any(__wrap_OS_ConnectTCP, _ip);
+    expect_any(__wrap_OS_ConnectTCP, ipv6);
+    will_return(__wrap_OS_ConnectTCP, 10);
+    will_return(__wrap_OS_SetKeepalive, 0);
+    expect_function_call(__wrap_OS_SetKeepalive_Options);
+    will_return(__wrap_getDefine_Int, 60);   /* tcp_keepidle */
+    will_return(__wrap_getDefine_Int, 15);   /* tcp_keepintvl */
+    will_return(__wrap_getDefine_Int, 4);    /* tcp_keepcnt */
+    will_return(__wrap_getDefine_Int, 30);   /* send_timeout */
+    will_return(__wrap_OS_SetSendTimeout, -1);  /* send timeout fails */
+
+    expect_any(__wrap__minfo, formatted_msg);       /* "Trying to connect to server..." */
+    expect_any(__wrap__mwarn, formatted_msg);       /* "OS_SetSendTimeout failed..." */
+
+    connected = connect_server(1, true);
+    assert_true(connected);
+    assert_int_equal(agt->sock, 10);
+    assert_int_equal(agt->rip_id, 1);
+}
+
 static void test_connect_server(void **state) {
     bool connected = false;
     expect_any(__wrap__minfo, formatted_msg);
@@ -177,6 +236,13 @@ static void test_connect_server(void **state) {
     will_return(__wrap_OS_ConnectTCP, 12);
     expect_value(__wrap_OS_CloseSocket, sock, 11);
     will_return(__wrap_OS_CloseSocket, 0);
+    will_return(__wrap_OS_SetKeepalive, 0);
+    expect_function_call(__wrap_OS_SetKeepalive_Options);
+    will_return(__wrap_getDefine_Int, 60);  /* tcp_keepidle */
+    will_return(__wrap_getDefine_Int, 15);  /* tcp_keepintvl */
+    will_return(__wrap_getDefine_Int, 4);   /* tcp_keepcnt */
+    will_return(__wrap_getDefine_Int, 30);  /* send_timeout */
+    will_return(__wrap_OS_SetSendTimeout, 0);
 
     expect_any_count(__wrap__minfo, formatted_msg, 2);
 
@@ -256,6 +322,13 @@ static void test_agent_handshake_to_server(void **state) {
     will_return(__wrap_OS_ConnectTCP, 22);
     expect_value(__wrap_OS_CloseSocket, sock, 21);
     will_return(__wrap_OS_CloseSocket, 0);
+    will_return(__wrap_OS_SetKeepalive, 0);
+    expect_function_call(__wrap_OS_SetKeepalive_Options);
+    will_return(__wrap_getDefine_Int, 60);  /* tcp_keepidle */
+    will_return(__wrap_getDefine_Int, 15);  /* tcp_keepintvl */
+    will_return(__wrap_getDefine_Int, 4);   /* tcp_keepcnt */
+    will_return(__wrap_getDefine_Int, 30);  /* send_timeout */
+    will_return(__wrap_OS_SetSendTimeout, 0);
     will_return(__wrap_wnet_select, 1);
     expect_any(__wrap_OS_RecvSecureTCP, sock);
     expect_any(__wrap_OS_RecvSecureTCP, size);
@@ -282,6 +355,13 @@ static void test_agent_handshake_to_server(void **state) {
     will_return(__wrap_OS_ConnectTCP, 23);
     expect_value(__wrap_OS_CloseSocket, sock, 22);
     will_return(__wrap_OS_CloseSocket, 0);
+    will_return(__wrap_OS_SetKeepalive, 0);
+    expect_function_call(__wrap_OS_SetKeepalive_Options);
+    will_return(__wrap_getDefine_Int, 60);  /* tcp_keepidle */
+    will_return(__wrap_getDefine_Int, 15);  /* tcp_keepintvl */
+    will_return(__wrap_getDefine_Int, 4);   /* tcp_keepcnt */
+    will_return(__wrap_getDefine_Int, 30);  /* send_timeout */
+    will_return(__wrap_OS_SetSendTimeout, 0);
     will_return(__wrap_wnet_select, 1);
     expect_any(__wrap_OS_RecvSecureTCP, sock);
     expect_any(__wrap_OS_RecvSecureTCP, size);
@@ -448,6 +528,8 @@ static void test_send_agent_stopped_message(void **state) {
 
 int main(void) {
     const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_connect_server_keepalive_fails, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_connect_server_send_timeout_fails, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_connect_server, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_agent_handshake_to_server, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_agent_handshake_to_server_invalid_version, setup_test, teardown_test),

--- a/src/unit_tests/client-agent/test_start_agent.c
+++ b/src/unit_tests/client-agent/test_start_agent.c
@@ -116,8 +116,14 @@ static int setup_test(void **state) {
     agt->events_persec = 500;
     agt->flags.auto_restart = 1;
     agt->crypto_method = W_METH_AES;
+    /* connect_server() now takes send_mutex, and agt->sock is this project's
+     * portable atomic_int_t (headers/atomic.h), not a plain int: initialize
+     * both mutexes for real instead of relying on calloc()'s zero bytes
+     * behaving like PTHREAD_MUTEX_INITIALIZER (a glibc-specific assumption). */
+    sender_init();
+    w_mutex_init(&agt->sock.mutex, NULL);
     /* Connected sock */
-    agt->sock = -1;
+    atomic_int_set(&agt->sock, -1);
     /* Server */
     add_server_config("127.0.0.1", IPPROTO_UDP);
     add_server_config("127.0.0.2", IPPROTO_TCP);
@@ -169,13 +175,14 @@ static void test_connect_server_keepalive_fails(void **state) {
     /* OS_SetKeepalive_Options must NOT be called (it is inside the else branch) */
     will_return(__wrap_getDefine_Int, 30);     /* send_timeout still queried */
     will_return(__wrap_OS_SetSendTimeout, 0);
+    will_return(__wrap_OS_SetRecvTimeout, 0);
 
     expect_any(__wrap__minfo, formatted_msg);       /* "Trying to connect to server..." */
     expect_any(__wrap__mwarn, formatted_msg);       /* "OS_SetKeepalive failed..." */
 
     connected = connect_server(1, true);
     assert_true(connected);
-    assert_int_equal(agt->sock, 10);
+    assert_int_equal(atomic_int_get(&agt->sock), 10);
     assert_int_equal(agt->rip_id, 1);
 }
 
@@ -193,19 +200,22 @@ static void test_connect_server_send_timeout_fails(void **state) {
     expect_any(__wrap_OS_ConnectTCP, ipv6);
     will_return(__wrap_OS_ConnectTCP, 10);
     will_return(__wrap_OS_SetKeepalive, 0);
+#ifndef TEST_WINAGENT
     expect_function_call(__wrap_OS_SetKeepalive_Options);
     will_return(__wrap_getDefine_Int, 60);   /* tcp_keepidle */
     will_return(__wrap_getDefine_Int, 15);   /* tcp_keepintvl */
     will_return(__wrap_getDefine_Int, 4);    /* tcp_keepcnt */
+#endif
     will_return(__wrap_getDefine_Int, 30);   /* send_timeout */
     will_return(__wrap_OS_SetSendTimeout, -1);  /* send timeout fails */
+    will_return(__wrap_OS_SetRecvTimeout, 0);
 
     expect_any(__wrap__minfo, formatted_msg);       /* "Trying to connect to server..." */
     expect_any(__wrap__mwarn, formatted_msg);       /* "OS_SetSendTimeout failed..." */
 
     connected = connect_server(1, true);
     assert_true(connected);
-    assert_int_equal(agt->sock, 10);
+    assert_int_equal(atomic_int_get(&agt->sock), 10);
     assert_int_equal(agt->rip_id, 1);
 }
 
@@ -222,7 +232,7 @@ static void test_connect_server(void **state) {
 
     connected = connect_server(0, true);
     assert_int_equal(agt->rip_id, 0);
-    assert_int_equal(agt->sock, 11);
+    assert_int_equal(atomic_int_get(&agt->sock), 11);
     assert_true(connected);
 
     /* Connect to second server (TCP), previous connection must be closed*/
@@ -237,18 +247,21 @@ static void test_connect_server(void **state) {
     expect_value(__wrap_OS_CloseSocket, sock, 11);
     will_return(__wrap_OS_CloseSocket, 0);
     will_return(__wrap_OS_SetKeepalive, 0);
+#ifndef TEST_WINAGENT
     expect_function_call(__wrap_OS_SetKeepalive_Options);
     will_return(__wrap_getDefine_Int, 60);  /* tcp_keepidle */
     will_return(__wrap_getDefine_Int, 15);  /* tcp_keepintvl */
     will_return(__wrap_getDefine_Int, 4);   /* tcp_keepcnt */
+#endif
     will_return(__wrap_getDefine_Int, 30);  /* send_timeout */
     will_return(__wrap_OS_SetSendTimeout, 0);
+    will_return(__wrap_OS_SetRecvTimeout, 0);
 
     expect_any_count(__wrap__minfo, formatted_msg, 2);
 
     connected = connect_server(1, true);
     assert_int_equal(agt->rip_id, 1);
-    assert_int_equal(agt->sock, 12);
+    assert_int_equal(atomic_int_get(&agt->sock), 12);
     assert_true(connected);
 
     /* Connect to third server (UDP), valid host name*/
@@ -261,7 +274,7 @@ static void test_connect_server(void **state) {
 
     connected = connect_server(2, true);
     assert_int_equal(agt->rip_id, 2);
-    assert_int_equal(agt->sock, 13);
+    assert_int_equal(atomic_int_get(&agt->sock), 13);
     assert_true(connected);
 
     /* Connect to fourth server (UDP), invalid host name*/
@@ -323,12 +336,15 @@ static void test_agent_handshake_to_server(void **state) {
     expect_value(__wrap_OS_CloseSocket, sock, 21);
     will_return(__wrap_OS_CloseSocket, 0);
     will_return(__wrap_OS_SetKeepalive, 0);
+#ifndef TEST_WINAGENT
     expect_function_call(__wrap_OS_SetKeepalive_Options);
     will_return(__wrap_getDefine_Int, 60);  /* tcp_keepidle */
     will_return(__wrap_getDefine_Int, 15);  /* tcp_keepintvl */
     will_return(__wrap_getDefine_Int, 4);   /* tcp_keepcnt */
+#endif
     will_return(__wrap_getDefine_Int, 30);  /* send_timeout */
     will_return(__wrap_OS_SetSendTimeout, 0);
+    will_return(__wrap_OS_SetRecvTimeout, 0);
     will_return(__wrap_wnet_select, 1);
     expect_any(__wrap_OS_RecvSecureTCP, sock);
     expect_any(__wrap_OS_RecvSecureTCP, size);
@@ -356,12 +372,15 @@ static void test_agent_handshake_to_server(void **state) {
     expect_value(__wrap_OS_CloseSocket, sock, 22);
     will_return(__wrap_OS_CloseSocket, 0);
     will_return(__wrap_OS_SetKeepalive, 0);
+#ifndef TEST_WINAGENT
     expect_function_call(__wrap_OS_SetKeepalive_Options);
     will_return(__wrap_getDefine_Int, 60);  /* tcp_keepidle */
     will_return(__wrap_getDefine_Int, 15);  /* tcp_keepintvl */
     will_return(__wrap_getDefine_Int, 4);   /* tcp_keepcnt */
+#endif
     will_return(__wrap_getDefine_Int, 30);  /* send_timeout */
     will_return(__wrap_OS_SetSendTimeout, 0);
+    will_return(__wrap_OS_SetRecvTimeout, 0);
     will_return(__wrap_wnet_select, 1);
     expect_any(__wrap_OS_RecvSecureTCP, sock);
     expect_any(__wrap_OS_RecvSecureTCP, size);

--- a/src/unit_tests/wrappers/wazuh/os_crypto/msgs_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/os_crypto/msgs_wrappers.h
@@ -11,6 +11,7 @@
 #define MSGS_WRAPPERS_H
 
 #include <sys/types.h>
+#include "sec.h"
 
 size_t __wrap_CreateSecMSG(__attribute__((unused)) keystore *keys, const char *msg, size_t msg_length, char *msg_encrypted, unsigned int id);
 int __wrap_ReadSecMSG(keystore *keys, char *buffer, __attribute__((unused)) char *cleartext, int id, __attribute__((unused)) unsigned int buffer_size, size_t *final_size, const char *srcip, char **output);

--- a/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.c
@@ -119,6 +119,16 @@ int __wrap_OS_SetSendTimeout(__attribute__((unused)) int socket,
     return mock();
 }
 
+int __wrap_OS_SetKeepalive(__attribute__((unused)) int socket) {
+    return mock();
+}
+
+void __wrap_OS_SetKeepalive_Options(__attribute__((unused)) int socket,
+                                    __attribute__((unused)) int idle,
+                                    __attribute__((unused)) int intvl,
+                                    __attribute__((unused)) int cnt) {
+    function_called();
+}
 
 int __wrap_wnet_select(__attribute__((unused)) int sock,
                        __attribute__((unused)) int timeout) {

--- a/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/os_net/os_net_wrappers.h
@@ -48,6 +48,10 @@ int __wrap_OS_SetRecvTimeout(int socket, long seconds, long useconds);
 
 int __wrap_OS_SetSendTimeout(int socket, int seconds);
 
+int __wrap_OS_SetKeepalive(int socket);
+
+void __wrap_OS_SetKeepalive_Options(int socket, int idle, int intvl, int cnt);
+
 int __wrap_wnet_select(int sock, int timeout);
 
 uint32_t __wrap_wnet_order(uint32_t value);

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -109,6 +109,9 @@ int local_start()
 
     /* Start agent */
     os_calloc(1, sizeof(agent), agt);
+    /* os_calloc() only zeroes agt->sock.data; the embedded pthread_mutex_t
+     * must be initialized for real before any atomic_int_get/set(&agt->sock). */
+    w_mutex_init(&agt->sock.mutex, NULL);
 
     /* Configuration file not present */
     if (File_DateofChange(cfg) < 0) {
@@ -268,7 +271,7 @@ int local_start()
     }
 
     /* Socket connection */
-    agt->sock = -1;
+    atomic_int_set(&agt->sock, -1);
 
     /* Initialize random numbers */
     srandom(time(0));


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Backport of #36790 (fix for #36743) to the `4.14.9` branch.

When the TCP connection between `wazuh-agentd` and the manager is silently torn down at the network layer (a middlebox evicting the flow, a NAT/conntrack flush, an overlay/IPSec glitch, or the peer stopping to read and advertising a zero window), the agent can get stuck indefinitely: `status='connected'` in `wazuh-agentd.state` forever, `last_keepalive`/`last_ack` frozen, and no reconnection attempt — because the blocking `send()` in `send_msg()` never returns, and it holds `send_mutex` while it's stuck. This also blocks the same single-threaded monitor loop that would otherwise notice the staleness and reconnect (`run_notify()`'s own watchdog never gets to run again either), so the existing `time-reconnect`/`force_reconnect_interval` settings can't kick in.

Closes #38388

## Proposed Changes

Same three changes as #36790, ported to the pre-refactor 4.14.x code (this branch still has the UDP transport path in `send_msg()`, which `main` no longer has, and uses the original `src/client-agent/*.c` layout, so this is a manual port rather than a clean cherry-pick):

- `start_agent.c` (`connect_server()`): after a successful TCP connect, enable `SO_KEEPALIVE` (+ `TCP_KEEPIDLE`/`TCP_KEEPINTVL`/`TCP_KEEPCNT`) and `SO_SNDTIMEO` on `agt->sock`, so a `send()` cannot block forever.
- `sendmsg.c` (`send_msg()`): on `EPIPE`/`ECONNRESET`/`ENOTCONN`/`ECONNREFUSED`/`ETIMEDOUT`/`EAGAIN`/`EWOULDBLOCK`, close and invalidate the socket (`agt->sock = -1`) instead of just logging and sleeping, so the connection isn't reused in a broken state. Also added an early return under `send_mutex` when `agt->sock` was already invalidated by another thread, avoiding a stale-`errno` log.
- `agentd.c` (monitor loop): reconnect immediately when `agt->sock < 0`, instead of relying solely on `run_notify()`'s staleness watchdog (which requires `receive_msg()` to have run recently on the same socket — exactly what doesn't happen while the loop is stuck). Also snapshots the descriptor once per iteration before `FD_SET`/`select`/`FD_ISSET` to avoid a TOCTOU if a sender thread invalidates `agt->sock` mid-iteration, and treats `EBADF` from `select()` as a lost connection instead of a fatal error.
- `client-config.h`: `agt->sock` is now `_Atomic int`, since it's read/written from the main loop and from sender threads (`dispatch_buffer`, `req_receiver`).
- `internal_options.conf`: new `agent.tcp_keepidle` (60), `agent.tcp_keepintvl` (15), `agent.tcp_keepcnt` (4), `agent.send_timeout` (30) — documented inline, following the same convention as the existing `remoted.tcp_keepidle/intvl/cnt` entries.

Two additional fixes on top of the above, found during self-review of this port and confirmed to also be present, unmodified, in `origin/main`'s current `sendmsg.c`/`start_agent.c` (i.e. not something this port introduced — the original fix has the same gaps):

- `sendmsg.c`: `EBADF` was missing from the fatal-error classification. A `send()` on an invalid/closed descriptor fell into `default: socket_dead = false`, so the agent would keep retrying `send()` + `sleep(1)` forever on a dead fd instead of ever reconnecting. Added `case EBADF:` alongside the other fatal errnos, both in the classification switch and the logging switch.
- `start_agent.c`: `connect_server()` closed the old socket and assigned the new one directly on `agt->sock`, with no locking at all — while `send_msg()` only ever touches `agt->sock` under `send_mutex`. Since this PR makes `connect_server()` run immediately in reaction to any sender's own send failure (the new `agentd.c` block above), that unsynchronized write is exercised far more often than before. Added `send_mutex_lock()`/`send_mutex_unlock()` (new, exposed from `sendmsg.c`/`agentd.h`) and moved every `agt->sock` mutation in `connect_server()` inside that same lock; the slow parts (DNS resolution, `connect()`, keepalive/timeout `setsockopt`s) now operate on a local `new_sock` variable and are published to `agt->sock` only once fully configured, so senders are never blocked waiting on them and never observe a half-configured socket either.

Since these two gaps are also live on `main` today, worth raising separately against #36743/#36790 so 5.0.0 gets the same fix, not just this backport.

Further fixes from review feedback (Luis + a follow-up self/automated review), all in `sendmsg.c`/`start_agent.c`/`agentd.c`/`receiver.c`/`notify.c`:

- **Partial write not detected** — `OS_SendSecureTCP()` zeroes `errno`/`WSASetLastError` right before `send()`, so a short write under `SO_SNDTIMEO` (data partially queued, then the timeout fires) reports `retval != 0` with no errno set at all, previously falling into `default: socket_dead = false`. That leaves the connection "alive" with the length-prefixed framing already corrupted for every later message. Added `case 0:` to both the POSIX and the new Windows classification (see below), tested by `test_send_msg_partial_write`.
- **Windows had no dead-socket detection at all** — the whole classification/close block was `#ifndef WIN32`-only, so on Windows the bounded `SO_SNDTIMEO` fired but the socket was never invalidated, and `receiver.c`'s receive loop (`if (agt->sock == -1) { sleep(5); continue; }`) never actually reconnected either. Added the `WSAGetLastError()`-mapped equivalent classification, `WSASetLastError(0)` in `OS_SendSecureTCP()`, and fixed the Windows loop to call the shared reconnect helper instead of just sleeping. Compiles clean with `i686-w64-mingw32-gcc`; not runtime-tested (no Windows box here).
- **Handshake fed an invalidated socket into `select()`** — `agent_handshake_to_server()` didn't check `send_msg()`'s return before calling `receive_message()`, which did `FD_SET(agt->sock, ...)` with `agt->sock` possibly `-1` (UB — negative shift) and then `select(0, ...)`, i.e. a plain `recv_timeout`-long (60 s default) sleep per handshake attempt. Now checks the return and bails out early; `receive_message()` also snapshots `agt->sock` once and guards against `-1` defensively.
- **`EBADF` handling could misattribute and leak an fd** — `select()` returns `EBADF` for *any* invalid descriptor in the set, not necessarily `agt->sock` (could be `agt->m_queue`). The handler blindly set `agt->sock = -1` without closing it first and without `send_mutex`, contradicting the locking this PR establishes everywhere else, and leaking the real descriptor if it wasn't actually the culprit. Now checks under `send_mutex` whether `agt->sock` is already `-1` (meaning a sender really did invalidate it) before deciding to reconnect vs. treat it as the pre-existing fatal case.
- **Fast-path silently dropped events at full throughput** — the early return when `agt->sock` is already `-1` had no `sleep(1)`/log unlike every other failure path, so during an outage `dispatch_buffer()` could drain its whole queue at `events_persec` (500/s default) discarding messages silently instead of at the ~1/s every other path is throttled to.
- **`rip_id`/`sock` publish order** — `connect_server()` published `agt->sock` before `agt->rip_id`, while `send_msg()` reads `agt->server[agt->rip_id].protocol` to pick UDP vs. TCP before ever taking the mutex; a failover between differently-configured servers could race a sender into using the wrong transport for the new fd. Reordered so `rip_id` is set first, both under the same lock.
- **No timeout on the handshake's receive path** — added `OS_SetRecvTimeout()` alongside `SO_SNDTIMEO`; before this, a manager delivering a partial reply and going silent hung the single-threaded handshake indefinitely (the same clinical picture as the send-side bug, just from the receive side).
- **`reconnect_to_server()` de-duplication** — the same `os_setwait()`/`GA_STATUS_NACTIVE`/`start_agent(0)`/`os_delwait()`/`GA_STATUS_ACTIVE` sequence was copy-pasted 5 times across `agentd.c`/`receiver.c`/`notify.c`; extracted into one shared helper. It lives in `start_agent.c` (not `agentd.c`) specifically because `agentd.o` is excluded from the Windows agent link (Windows uses `receiver.c`'s loop instead), which is exactly what broke CI the first time this was attempted — `start_agent.o` is linked into every target.
- **Log-spam and `errno` correctness on unsupported platforms** — `OS_SetKeepalive_Options()` warns 3x per reconnect on Windows/OpenBSD ("unsupported platform") since none of its parameters apply there; skipped the call entirely on those platforms instead. Also fixed `OS_SetKeepalive`/`OS_SetSendTimeout`/`OS_SetRecvTimeout` failure logs to use `win_strerror(WSAGetLastError())` on Windows instead of `strerror(errno)` (Winsock doesn't touch `errno`).
- **`ONEWAY_ENABLED` build regression** — under `make ONEWAY=yes`, `start_agent()` returns without ever connecting, so `agt->sock` stays `-1` forever; the new immediate-reconnect block in `agentd.c` would have spun at 100% CPU with a `LOST_ERROR`/`SERVER_UP` log flood instead of the old (already-broken, but at least paced) behavior. Guarded the new block with `#ifndef ONEWAY_ENABLED`. Compiles clean with `make ONEWAY=yes`.

### Results and Evidence

- Verified against the real 4.14.5/4.14.9 source (byte-identical between the two tags for every file this PR touches) that the gap exists: `OS_SetKeepalive`/`OS_SetSendTimeout` were already used by `remoted` and `wm_fluent`, but never applied to the agent's own outbound socket (`OS_ConnectTCP` → `OS_Connect` only sizes the send/recv buffers).
- Full `client-agent` unit test suite built and run locally (`-DTARGET=agent -DUNIT_TEST=ON`, ASan/UBSan enabled): **82/82 passing**, 0 failures, across all 7 targets — see breakdown below. Added `test_send_msg_ebadf` and `test_send_msg_partial_write` (same shape as the existing errno cases). No dedicated test for the `connect_server()` locking fix, the `EBADF`/`m_queue` disambiguation, or the `rip_id`/`sock` ordering fix: the current mock-based unit tests have no concurrent harness to exercise cross-thread ordering with, so these are covered by code inspection and the full suite still passing (no regression), not by new assertions.
- CI (`Unit-Tests (winagent)`) caught a real bug this local Linux-only testing couldn't: `reconnect_to_server()` initially lived in `agentd.c`, which is excluded from the Windows agent link, causing an `undefined reference` when linking `win32/wazuh-agent.exe` (`notify.c`/`receiver.c` call it and are linked there). Confirmed the fix by cross-compiling every touched file with `i686-w64-mingw32-gcc` and checking the symbol table directly (`start_agent.o` now exports `reconnect_to_server` as `T`; `notify.o`/`receiver.o` reference it as `U`), plus a full production link of the Linux `wazuh-agentd` binary — both clean. Did not attempt a full Windows `.exe` link locally (this checkout never had a prior Windows build, so it would mean building the whole agent from scratch); relying on CI for that final confirmation.
- Reproduced the original stuck-connection scenario against this exact patched binary (see "Manual tests" below for the full setup/timeline): the agent detected the stalled connection, stayed paced (no busy-loop) while retrying, and reconnected cleanly once the manager recovered.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux — built `client-agent/{sendmsg,agentd,start_agent,notify,receiver}.o` (and their transitive includers: `buffer.o`, `config.o`, `event-forward.o`, `main.o`, `request.o`) via the project `Makefile`, zero warnings/errors.
  - [x] Windows
  - [x] MAC OS X
- [ ] Log syntax and correct language review
- [x] Unit tests (Linux, `-DTARGET=agent -DUNIT_TEST=ON`) — 82/82 passing, ASan/UBSan clean:

  | Target | Result |
  | --- | --- |
  | `test_sendmsg` (new) | 14/14 |
  | `test_start_agent` | 9/9 (2 new: keepalive-fails, send_timeout-fails) |
  | `test_notify` | 7/7 |
  | `test_agentd_state` | 19/19 |
  | `test_buffer` | 8/8 |
  | `test_agcom` | 10/10 |
  | `test_agentd` | 15/15 |
- [x] Reproduced the silently-half-closed scenario against this patched agent (`SIGSTOP` on the manager's `remoted`) and confirmed it reconnects instead of freezing. Full setup and timeline:

  **Setup:** official `wazuh-manager` 4.14.7 installed natively (protocol-compatible within the 4.14.x line; 4.14.9 itself isn't published yet). `wazuh-agentd` compiled from this branch (with the fix) running in a container on `--network host`, enrolled and connected against the manager over loopback. Golden path confirmed first: `status='connected'` in `wazuh-agentd.state`, manager shows the agent `Active` (`agent_control -l`), keepalives/events flowing normally.

  **Timeline:**

  | Time | Event |
  | --- | --- |
  | T+0s | `kill -STOP` on `wazuh-remoted` (simulates a silently half-closed TCP connection: socket stays "up", peer stops reading/responding) |
  | T+~63s | Agent's watchdog logs `Server unavailable. Setting lock.` (`max_time_reconnect_try`=60s) and enters the reconnect loop — **before this fix, this never happened: the agent stayed `status='connected'` forever** |
  | during outage | `status='disconnected'`; agent CPU stayed at ~1% (paced retries, no busy-loop); each failed handshake attempt bounded to ~60s by the new `OS_SetRecvTimeout()`, then retried — never hung |
  | ~8 min later | `kill -CONT` on `wazuh-remoted` |
  | same second | Agent logs `Connected to the server` / `Server responded. Releasing lock.`; `wazuh-agentd.state` back to `status='connected'`; manager shows the agent `Active` again |

  Also observed, unprompted: two transient `Corrupt payload (exceeding size) received` / `Lost connection with manager` blips immediately after the manager resumed (framing desync from bytes buffered during the freeze) — both self-healed with a reconnect in the same second, rather than leaving the connection stuck in a corrupted state.

  No CPU spin, no growth in RSS or open file descriptors observed across the full stall/reconnect cycle.

### Artifacts Affected

- `wazuh-agentd` binary (Linux/Windows/macOS).
- `etc/internal_options.conf` — new keys, see below.

### Configuration Changes

New `internal_options.conf` keys (not exposed in `ossec.conf`, internal tuning only):
- `agent.tcp_keepidle=60`, `agent.tcp_keepintvl=15`, `agent.tcp_keepcnt=4` — TCP keepalive timing for the agent → manager connection.
- `agent.send_timeout=30` — bounds how long `send()` may block before the agent closes and reconnects.

No backward-compatibility concerns: these are new internal options with defaults baked into the binary (`getDefine_Int`), so an agent upgraded without a matching `internal_options.conf` still starts (the shipped `internal_options.conf` is replaced on package upgrade, consistent with how `remoted`'s equivalent keys are already handled).

### Tests Introduced

Ported from #36790 (`main`'s `test_sendmsg.c`/`test_start_agent.c`), adapted to this branch's pre-refactor code (the TCP-path-only classification in `send_msg()`, the still-present UDP branch, and the original file layout):

- `test_sendmsg.c` (14 cases): `CreateSecMSG` failure, socket-already-invalidated early return (now also asserting the log + `sleep(1)` backoff), a clean success path, each of the 8 invalidating cases (`EPIPE`/`ECONNRESET`/`ENOTCONN`/`ECONNREFUSED`/`ETIMEDOUT`/`EAGAIN`/`EBADF`/partial-write-with-`errno==0`) individually asserting the socket is closed and set to `-1`, an unrelated errno (`ENOMEM`) asserting the socket is **not** touched, and 2 UDP-path smoke tests confirming that transport is unaffected by this fix.
- `test_start_agent.c`: added `test_connect_server_keepalive_fails` and `test_connect_server_send_timeout_fails` (connection still succeeds, failure only warns), updated the 3 existing TCP-success paths (`test_connect_server`, `test_agent_handshake_to_server` x2) to expect the new `OS_SetKeepalive`/`OS_SetKeepalive_Options`/`OS_SetSendTimeout`/`OS_SetRecvTimeout` calls, and `setup_test()` now calls `sender_init()` for real instead of relying on a zero-initialized `pthread_mutex_t` behaving like `PTHREAD_MUTEX_INITIALIZER` (a glibc-specific assumption, not portable C).
- Supporting wrapper additions: `__wrap_OS_SetKeepalive`/`__wrap_OS_SetKeepalive_Options` in `os_net_wrappers.c/h` (`OS_SetSendTimeout` was already wrapped, reused from `wazuh_db`/`analysisd`), and `#include "sec.h"` in `msgs_wrappers.h` (needed once it's included before `agentd.h` in a translation unit — same fix `main` already carries).

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [x] Port unit tests from #36790 (`test_sendmsg.c`, `test_start_agent.c`)
- [x] Reproduce the original stuck-connection scenario against this patched build





