### PR TITLE
fix(sync-protocol): publish agent metadata in test tool to stop RTR hang

### DIFF
--- a/src/shared_modules/sync_protocol/testtool/CMakeLists.txt
+++ b/src/shared_modules/sync_protocol/testtool/CMakeLists.txt
@@ -13,6 +13,7 @@ include_directories(${SRC_FOLDER}/shared/include/)
 include_directories(${SRC_FOLDER})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../src)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../agent_metadata/include)
 include_directories(${CMAKE_BINARY_DIR}/shared_modules/sync_protocol)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -26,7 +27,16 @@ set_target_properties(
   sync_protocol_test_tool PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                                      "${CMAKE_BINARY_DIR}/bin")
 
+target_link_directories(
+  sync_protocol_test_tool PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../agent_metadata/build/lib)
+
+# main.cpp calls metadata_provider_update()/_reset() directly (to stand in for
+# agent-info, which normally publishes this) -- agent_sync_protocol links
+# agent_metadata PRIVATE, so that symbol isn't guaranteed to reach this
+# executable's link line transitively; link it explicitly.
 target_link_libraries(sync_protocol_test_tool PRIVATE agent_sync_protocol
+                                                      agent_metadata
                                                       pthread)
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows" AND NOT CMAKE_SYSTEM_NAME STREQUAL

--- a/src/shared_modules/sync_protocol/testtool/main.cpp
+++ b/src/shared_modules/sync_protocol/testtool/main.cpp
@@ -3,12 +3,15 @@
  */
 
 #include <chrono>
+#include <cstring>
+#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <string>
 
 #include "agent_sync_protocol.hpp"
 #include "agent_sync_protocol_types.hpp"
+#include "metadata_provider.h"
 
 static AgentSyncProtocol* g_proto = nullptr;
 const unsigned int retries = 1;
@@ -33,6 +36,44 @@ class LoopbackTransport final : public ISyncSessionTransport
         }
 };
 
+/// Publishes the dummy agent metadata AgentSyncProtocol needs to build a Start
+/// message (agent-info's job in a real agent) and clears it back out on scope
+/// exit. Without this, waitMetadataAndBuildStart() has nothing to read and the
+/// synchronization defers to its own retry cycle instead of ever sending.
+class ScopedTestMetadata
+{
+    public:
+        ScopedTestMetadata()
+        {
+            // metadata_provider_update() opens SHM_PATH with O_CREAT but does not create
+            // its parent directory; without it the provider silently has no metadata to serve.
+            std::filesystem::create_directories("var/run");
+
+            agent_metadata_t metadata{};
+            std::strncpy(metadata.agent_id, "001", sizeof(metadata.agent_id) - 1);
+            std::strncpy(metadata.agent_name, "test-agent", sizeof(metadata.agent_name) - 1);
+            std::strncpy(metadata.agent_version, "5.0.0", sizeof(metadata.agent_version) - 1);
+            std::strncpy(metadata.architecture, "x86_64", sizeof(metadata.architecture) - 1);
+            std::strncpy(metadata.hostname, "test-host", sizeof(metadata.hostname) - 1);
+            std::strncpy(metadata.os_name, "Linux", sizeof(metadata.os_name) - 1);
+            std::strncpy(metadata.os_type, "linux", sizeof(metadata.os_type) - 1);
+            std::strncpy(metadata.os_platform, "ubuntu", sizeof(metadata.os_platform) - 1);
+            std::strncpy(metadata.os_version, "24.04", sizeof(metadata.os_version) - 1);
+            char* groups[] = {const_cast<char*>("default")};
+            metadata.groups = groups;
+            metadata.groups_count = 1;
+            metadata.vd_feed_offset = 1;
+            metadata_provider_update(&metadata);
+        }
+
+        ~ScopedTestMetadata()
+        {
+            metadata_provider_reset();
+            std::error_code ec;
+            std::filesystem::remove_all("var", ec);
+        }
+};
+
 int main()
 {
     try
@@ -42,6 +83,8 @@ int main()
         {
             std::cout << "[Test sync_protocol]: " << msg << std::endl;
         };
+
+        ScopedTestMetadata testMetadata;
 
         AgentSyncProtocol proto{"sync_protocol", ":memory:", std::move(testLogger),
                                 nullptr, std::make_shared<LoopbackTransport>()};


### PR DESCRIPTION
## Description

Since PR #38394, the `rtr (shared_modules/sync_protocol, agent)` CI job hangs indefinitely at its `Running TEST TOOL` step (the ASAN smoke-test stage of `python build.py --readytoreview shared_modules/sync_protocol`), eventually getting killed by the workflow's 60-minute `timeout-minutes` with no diagnostic output.

Root cause: PR #38394 switched `sync_protocol_test_tool`'s `main.cpp` from `synchronizeModule(Mode::FULL)` to `synchronizeModule(Mode::DELTA)`. `Mode::FULL` used to read an always-empty in-memory buffer and return early ("No items to synchronize"), so the tool passed vacuously without ever building a sync session. `Mode::DELTA` actually has items to send, so it reaches `AgentSyncProtocol::waitMetadataAndBuildStart()`, which blocks until `metadata_provider_get()` succeeds or `stop()` is called. In a real agent, `agent-info` publishes that metadata a few seconds after boot; the test tool never publishes it and never calls `stop()`, so the wait never ends.

Confirmed by direct reproduction (gdb thread backtrace stuck in `waitMetadataAndBuildStart()`, `strace` showing a repeated failed `stat()` on the metadata provider's backing file) — see analysis in `analysis.md` for the full trace.

## Proposed Changes

- `shared_modules/sync_protocol/testtool/main.cpp`: publish dummy agent metadata (agent id, host fields, one group) before calling `synchronizeModule()`, mirroring what the module's own unit tests already do in `SetUp()`. Wrapped in a small RAII helper (`ScopedTestMetadata`) that also creates the metadata provider's backing directory (`var/run`, which `metadata_provider_update()` does not create on its own) and cleans everything up (`metadata_provider_reset()` + removing the directory) when the tool exits.
- `shared_modules/sync_protocol/testtool/CMakeLists.txt`: add the `agent_metadata` include dir and link the tool against `agent_metadata` explicitly. `main.cpp` now calls `metadata_provider_update()`/`metadata_provider_reset()` directly, and `agent_sync_protocol` only links `agent_metadata` as `PRIVATE`, so the symbol isn't guaranteed to reach the executable's own link line otherwise.

No production code (`agent_sync_protocol.cpp`/`.hpp`) is touched — the indefinite metadata wait itself is left as-is, since a real agent's modules are not expected to start synchronizing before `agent-info` has published this metadata.

### Results and Evidence

Verified with a standalone reproduction build (not the full CMake/RTR pipeline) compiling the modified `main.cpp` against the real `agent_sync_protocol`/`persistent_queue`/`metadata_provider` sources:

- Before the fix (current `main.cpp`, `Mode::DELTA`, no metadata published): hangs; `timeout 20s` kills it (`exit=124`).
- After the fix: exits cleanly, actually exercising the real DELTA sync path end to end:
  ```
  [Test sync_protocol]: Metadata available. Proceed with synchronization.
  [Test sync_protocol]: Sending session 7318477623740973056 as one message (520 bytes).
  [Test sync_protocol]: Sync response received with success status:
  OK
  exit=0
  ```
- `var/` is created and removed by the tool itself; nothing is left behind in the source tree after the run.
- `astyle --options=ci/input/astyle.config --dry-run` and `cppcheck --force --std=c++17` (same invocations `run_check.py` uses) report no issues on the changed files (astyle doesn't even scan `testtool/*.cpp` for this module, only `include/*.hpp` and `src/*.cpp` — `ci/utils.py::getFoldersToAStyle`).
- Compiled with the exact same warning flags as `testtool/CMakeLists.txt` (`-Wall -Wextra -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wunused -Wcast-align -Wformat=2`): no new warnings.

Not yet verified: an actual CI run through the full `readytoreview` pipeline (cppcheck/astyle/build/tests/coverage/valgrind/ASAN) — the standalone reproduction was used instead to keep iteration fast; a CI run on this branch is the remaining step to fully confirm.

### Artifacts Affected

- `sync_protocol_test_tool` binary (agent target only; this tool is never built/run for `winagent`, so no Windows impact).

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None (no new automated tests) — this fix makes an *existing* smoke-test tool (`sync_protocol_test_tool`, run by the `shared_modules/sync_protocol` RTR's ASAN step) actually exercise the real `DELTA` sync path instead of hanging before it gets there.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality (N/A — fixes an existing smoke tool, no new test added)
- [ ] Configuration changes documented (N/A — none)
- [ ] Developer documentation reflects the changes (N/A — none)
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] CI green on `rtr (shared_modules/sync_protocol, agent)` — pending a real CI run

<!--
Considered but deliberately not included in this PR: bounding
AgentSyncProtocol::waitMetadataAndBuildStart()'s metadata wait (currently
indefinite, interruptible only by stop()) and adding a `timeout=` to
run_check.py's runTestTool() subprocess.run(). Both are reasonable
defense-in-depth (the other two sibling prerequisite gates in the same
function, NO_GROUPS_ERROR/NO_VD_OFFSET_ERROR, already return immediately
instead of blocking), but they change production/CI-infra behavior beyond
what's needed to fix this hang, so left for a separate discussion if wanted.
-->
