### PR TITLE
Prevent the agent from stopping Active Response when too many commands are defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 #### Fixed
 
 - Fixed the Windows agent MSI upgrade leaving the agent broken after the next reboot, and the silent `/q` upgrade hanging, when a system restart was pending. ([#38277](https://github.com/wazuh/wazuh/pull/38277))
+- Fixed `wazuh-execd` crashing when more active response commands than supported are defined. ([#38358](https://github.com/wazuh/wazuh/issues/38358))
 
 ## [v4.14.8]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 #### Fixed
 
 - Fixed the Windows agent MSI upgrade leaving the agent broken after the next reboot, and the silent `/q` upgrade hanging, when a system restart was pending. ([#38277](https://github.com/wazuh/wazuh/pull/38277))
-- Fixed `wazuh-execd` crashing when more active response commands than supported are defined. ([#38358](https://github.com/wazuh/wazuh/issues/38358))
+- Fixed `wazuh-execd` crashing when more active response commands than supported are defined. ([#38410](https://github.com/wazuh/wazuh/pull/38410))
 
 ## [v4.14.8]
 

--- a/src/analysisd/active-response.c
+++ b/src/analysisd/active-response.c
@@ -16,6 +16,13 @@
 #include <grp.h>
 #endif
 
+/* The lines that AR_ReadConfig() always writes hold two distinct names, and every
+ * platform ships at most one of the executables of each, so the agents keep two
+ * entries out of them. Should a platform ever ship two executables of the same
+ * name, that name would take one further entry.
+ */
+#define AR_DEFAULT_COMMANDS 2
+
 /* Active response commands */
 OSList *ar_commands;
 OSList *active_responses;
@@ -75,6 +82,13 @@ int AR_ReadConfig(const char *cfgfile)
     /* Read configuration */
     if (ReadConfig(modules, cfgfile, ar_commands, active_responses) < 0) {
         return (OS_INVALID);
+    }
+
+    /* The entries above plus one per active response make up the shared file */
+    const int total_commands = AR_DEFAULT_COMMANDS + active_responses->currently_size;
+
+    if (total_commands > MAX_AR) {
+        mwarn(AR_MAX_COMMANDS, total_commands, MAX_AR, DEFAULTAR);
     }
 
     return (0);

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -198,6 +198,7 @@
 #define EXEC_INV_CMD    "(1316): Invalid AR command: '%s'"
 #define EXEC_CMD_FAIL   "(1317): Could not launch command %s (%d)"
 #define EXEC_BAD_NAME   "(1318): Command name truncated %s"
+#define EXEC_MAX_AR     "(1319): Reached the maximum of %d active response commands. Ignoring the remaining entries of '%s'."
 
 #define AR_NOAGENT_ERROR                "(1320): Agent '%s' not found."
 #define EXEC_QUEUE_CONNECTION_ERROR     "(1321): Error communicating with queue '%s'."

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -13,6 +13,7 @@
 
 /* Active Response */
 #define AR_SERVER_AGENT "(1306): Invalid agent ID. Use location=server to run AR on the manager."
+#define AR_MAX_COMMANDS "(1307): Defined %d active response commands, more than the maximum of %d. The exceeding entries of '%s' may not be loaded by the agents."
 
 /* File integrity monitoring warning messages*/
 #define FIM_WARN_ACCESS                         "(6900): Accessing  '%s': [(%d) - (%s)]"

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -161,6 +161,8 @@ https://www.gnu.org/licenses/gpl.html\n"
 /* Active Response files */
 #define DEFAULTAR_FILE  "ar.conf"
 #define AR_BINDIR       "active-response/bin"
+/* Maximum number of active response commands that an agent can load */
+#define MAX_AR          64
 #ifndef WIN32
 #define DEFAULTAR       "etc/shared/" DEFAULTAR_FILE
 #define AGENTCONFIG     "etc/shared/agent.conf"

--- a/src/os_execd/exec.c
+++ b/src/os_execd/exec.c
@@ -17,6 +17,7 @@ static char exec_cmd[MAX_AR + 1][OS_FLSIZE + 1];
 static int  exec_timeout[MAX_AR + 1];
 static int  exec_size = 0;
 static int  f_time_reading = 1;
+static int  f_max_reported = 0;
 
 
 /* Read the shared exec config
@@ -25,7 +26,7 @@ static int  f_time_reading = 1;
  */
 int ReadExecConfig()
 {
-    int i = 0, j = 0, dup_entry = 0;
+    int i = 0, j = 0, dup_entry = 0, truncated = 0;
     FILE *fp;
     FILE *process_file;
     char buffer[OS_MAXSTR + 1];
@@ -49,13 +50,6 @@ int ReadExecConfig()
     while (fgets(buffer, OS_MAXSTR, fp) != NULL) {
         char *str_pt;
         char *tmp_str;
-
-        // No room left in the command table
-
-        if (exec_size >= MAX_AR) {
-            merror(EXEC_MAX_AR, MAX_AR, DEFAULTAR);
-            break;
-        }
 
         str_pt = buffer;
 
@@ -147,13 +141,28 @@ int ReadExecConfig()
             exec_cmd[exec_size][0] = '\0';
             exec_names[exec_size][0] = '\0';
             exec_timeout[exec_size] = 0;
-        } else {
+        } else if (exec_size < MAX_AR) {
             exec_size++;
+        } else {
+            // No room left in the command table
+
+            exec_cmd[exec_size][0] = '\0';
+            exec_names[exec_size][0] = '\0';
+            exec_timeout[exec_size] = 0;
+            truncated = 1;
+            break;
         }
     }
 
     fclose(fp);
     f_time_reading = 0;
+
+    /* Report only when the configuration starts being truncated */
+    if (truncated && !f_max_reported) {
+        merror(EXEC_MAX_AR, MAX_AR, DEFAULTAR);
+    }
+
+    f_max_reported = truncated;
 
     return (1);
 }

--- a/src/os_execd/exec.c
+++ b/src/os_execd/exec.c
@@ -31,7 +31,7 @@ int ReadExecConfig()
     char buffer[OS_MAXSTR + 1];
 
     /* Clean up */
-    for (i = 0; i <= exec_size + 1; i++) {
+    for (i = 0; i <= MAX_AR; i++) {
         memset(exec_names[i], '\0', OS_FLSIZE + 1);
         memset(exec_cmd[i], '\0', OS_FLSIZE + 1);
         exec_timeout[i] = 0;
@@ -49,6 +49,13 @@ int ReadExecConfig()
     while (fgets(buffer, OS_MAXSTR, fp) != NULL) {
         char *str_pt;
         char *tmp_str;
+
+        // No room left in the command table
+
+        if (exec_size >= MAX_AR) {
+            merror(EXEC_MAX_AR, MAX_AR, DEFAULTAR);
+            break;
+        }
 
         str_pt = buffer;
 

--- a/src/os_execd/execd.h
+++ b/src/os_execd/execd.h
@@ -21,9 +21,6 @@
 #define CONTINUE_ENTRY  "continue"
 #define ABORT_ENTRY     "abort"
 
-/* Maximum number of active responses active */
-#define MAX_AR      64
-
 /* Maximum number of command arguments */
 #define MAX_ARGS    32
 

--- a/src/unit_tests/os_execd/CMakeLists.txt
+++ b/src/unit_tests/os_execd/CMakeLists.txt
@@ -51,6 +51,9 @@ else()
 
     list(APPEND execd_names "test_get_command_by_name")
     list(APPEND execd_flags "${DEBUG_OP_WRAPPERS}")
+
+    list(APPEND execd_names "test_read_exec_config")
+    list(APPEND execd_flags "${DEBUG_OP_WRAPPERS}")
 endif()
 
 list(LENGTH execd_names count)

--- a/src/unit_tests/os_execd/test_read_exec_config.c
+++ b/src/unit_tests/os_execd/test_read_exec_config.c
@@ -47,6 +47,22 @@ static void write_ar_conf(int entries) {
     fclose(fp);
 }
 
+/* Append a raw line to the generated ar.conf */
+static void append_ar_line(const char *line) {
+    FILE *fp = fopen(DEFAULTAR, "a");
+
+    assert_non_null(fp);
+    assert_true(fprintf(fp, "%s", line) > 0);
+    fclose(fp);
+}
+
+static void expect_max_ar_error(void) {
+    char expected_msg[OS_MAXSTR];
+
+    snprintf(expected_msg, sizeof(expected_msg), EXEC_MAX_AR, MAX_AR, DEFAULTAR);
+    expect_string(__wrap__merror, formatted_msg, expected_msg);
+}
+
 /* Assert that the entry number 'index' was loaded */
 static void assert_entry_loaded(int index) {
     char name[OS_FLSIZE];
@@ -136,15 +152,30 @@ static void test_read_exec_config_at_limit(void **state) {
     assert_entry_not_loaded(MAX_AR);
 }
 
-/* Beyond MAX_AR commands the remaining entries are reported and discarded */
-static void test_read_exec_config_above_limit(void **state) {
+/* A line that consumes no slot must not be reported as an exceeding entry */
+static void test_read_exec_config_at_limit_trailing_junk(void **state) {
     (void)state;
     char expected_msg[OS_MAXSTR];
 
+    write_ar_conf(MAX_AR);
+    append_ar_line("\n");
+
+    snprintf(expected_msg, sizeof(expected_msg), EXEC_INV_CONF, DEFAULTAR);
+    expect_string(__wrap__merror, formatted_msg, expected_msg);
+
+    assert_int_equal(ReadExecConfig(), 1);
+
+    assert_entry_loaded(MAX_AR - 1);
+    assert_entry_not_loaded(MAX_AR);
+}
+
+/* Beyond MAX_AR commands the remaining entries are reported and discarded */
+static void test_read_exec_config_above_limit(void **state) {
+    (void)state;
+
     write_ar_conf(MAX_AR + 32);
 
-    snprintf(expected_msg, sizeof(expected_msg), EXEC_MAX_AR, MAX_AR, DEFAULTAR);
-    expect_string(__wrap__merror, formatted_msg, expected_msg);
+    expect_max_ar_error();
 
     assert_int_equal(ReadExecConfig(), 1);
 
@@ -154,11 +185,38 @@ static void test_read_exec_config_above_limit(void **state) {
     assert_entry_not_loaded(MAX_AR + 31);
 }
 
+/* The table is reloaded on every unresolved command, so the condition is
+ * reported once and not again until the configuration is corrected
+ */
+static void test_read_exec_config_reported_once(void **state) {
+    (void)state;
+    int i;
+
+    /* Still truncated: no further report */
+    for (i = 0; i < 3; i++) {
+        assert_int_equal(ReadExecConfig(), 1);
+    }
+
+    /* Corrected configuration: nothing to report, and the condition is re-armed */
+    write_ar_conf(MAX_AR);
+    assert_int_equal(ReadExecConfig(), 1);
+
+    /* Truncated again: reported again */
+    write_ar_conf(MAX_AR + 1);
+    expect_max_ar_error();
+    assert_int_equal(ReadExecConfig(), 1);
+
+    assert_entry_loaded(MAX_AR - 1);
+    assert_entry_not_loaded(MAX_AR);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_read_exec_config_below_limit),
         cmocka_unit_test(test_read_exec_config_at_limit),
+        cmocka_unit_test(test_read_exec_config_at_limit_trailing_junk),
         cmocka_unit_test(test_read_exec_config_above_limit),
+        cmocka_unit_test(test_read_exec_config_reported_once),
     };
 
     return cmocka_run_group_tests(tests, group_setup, group_teardown);

--- a/src/unit_tests/os_execd/test_read_exec_config.c
+++ b/src/unit_tests/os_execd/test_read_exec_config.c
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+#include "shared.h"
+#include "../../os_execd/execd.h"
+
+#define TEST_AR_SCRIPT  "test-ar.sh"
+#define TEST_AR_COMMAND AR_BINDIR "/" TEST_AR_SCRIPT
+
+static char test_dir[PATH_MAX + 1];
+static char previous_dir[PATH_MAX + 1];
+
+/* Build the name of the entry number 'index' of the generated ar.conf */
+static void ar_entry_name(char *buffer, size_t size, int index) {
+    snprintf(buffer, size, "ar-cmd-%03d", index);
+}
+
+/* Write an ar.conf holding 'entries' distinct active response commands */
+static void write_ar_conf(int entries) {
+    char name[OS_FLSIZE];
+    FILE *fp = fopen(DEFAULTAR, "w");
+    int i;
+
+    assert_non_null(fp);
+
+    for (i = 0; i < entries; i++) {
+        ar_entry_name(name, sizeof(name), i);
+        assert_true(fprintf(fp, "%s - %s - 0\n", name, TEST_AR_SCRIPT) > 0);
+    }
+
+    fclose(fp);
+}
+
+/* Assert that the entry number 'index' was loaded */
+static void assert_entry_loaded(int index) {
+    char name[OS_FLSIZE];
+    int timeout = -1;
+    char *command;
+
+    ar_entry_name(name, sizeof(name), index);
+    command = GetCommandbyName(name, &timeout);
+
+    assert_non_null(command);
+    assert_string_equal(command, TEST_AR_COMMAND);
+    assert_int_equal(timeout, 0);
+}
+
+/* Assert that the entry number 'index' was not loaded */
+static void assert_entry_not_loaded(int index) {
+    char name[OS_FLSIZE];
+    int timeout = -1;
+
+    ar_entry_name(name, sizeof(name), index);
+    assert_null(GetCommandbyName(name, &timeout));
+}
+
+static int group_setup(void **state) {
+    (void)state;
+    FILE *fp;
+
+    assert_non_null(getcwd(previous_dir, sizeof(previous_dir)));
+
+    snprintf(test_dir, sizeof(test_dir), "/tmp/wazuh_execd_arconf_XXXXXX");
+    assert_non_null(mkdtemp(test_dir));
+    assert_int_equal(chdir(test_dir), 0);
+
+    /* ReadExecConfig() resolves DEFAULTAR and AR_BINDIR relative to the working directory */
+    assert_int_equal(mkdir("etc", 0700), 0);
+    assert_int_equal(mkdir("etc/shared", 0700), 0);
+    assert_int_equal(mkdir("active-response", 0700), 0);
+    assert_int_equal(mkdir(AR_BINDIR, 0700), 0);
+
+    /* The command must exist, otherwise ReadExecConfig() discards it */
+    fp = fopen(TEST_AR_COMMAND, "w");
+    assert_non_null(fp);
+    fclose(fp);
+
+    return 0;
+}
+
+static int group_teardown(void **state) {
+    (void)state;
+
+    remove(DEFAULTAR);
+    remove(TEST_AR_COMMAND);
+    remove(AR_BINDIR);
+    remove("active-response");
+    remove("etc/shared");
+    remove("etc");
+
+    assert_int_equal(chdir(previous_dir), 0);
+    remove(test_dir);
+
+    return 0;
+}
+
+/* A regular configuration is loaded in full */
+static void test_read_exec_config_below_limit(void **state) {
+    (void)state;
+
+    write_ar_conf(10);
+
+    assert_int_equal(ReadExecConfig(), 1);
+
+    assert_entry_loaded(0);
+    assert_entry_loaded(9);
+    assert_entry_not_loaded(10);
+}
+
+/* Exactly MAX_AR commands still fit, and no entry is reported as ignored */
+static void test_read_exec_config_at_limit(void **state) {
+    (void)state;
+
+    write_ar_conf(MAX_AR);
+
+    assert_int_equal(ReadExecConfig(), 1);
+
+    assert_entry_loaded(0);
+    assert_entry_loaded(MAX_AR - 1);
+    assert_entry_not_loaded(MAX_AR);
+}
+
+/* Beyond MAX_AR commands the remaining entries are reported and discarded */
+static void test_read_exec_config_above_limit(void **state) {
+    (void)state;
+    char expected_msg[OS_MAXSTR];
+
+    write_ar_conf(MAX_AR + 32);
+
+    snprintf(expected_msg, sizeof(expected_msg), EXEC_MAX_AR, MAX_AR, DEFAULTAR);
+    expect_string(__wrap__merror, formatted_msg, expected_msg);
+
+    assert_int_equal(ReadExecConfig(), 1);
+
+    assert_entry_loaded(0);
+    assert_entry_loaded(MAX_AR - 1);
+    assert_entry_not_loaded(MAX_AR);
+    assert_entry_not_loaded(MAX_AR + 31);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_read_exec_config_below_limit),
+        cmocka_unit_test(test_read_exec_config_at_limit),
+        cmocka_unit_test(test_read_exec_config_above_limit),
+    };
+
+    return cmocka_run_group_tests(tests, group_setup, group_teardown);
+}


### PR DESCRIPTION
## Description

`wazuh-execd` loads the Active Response command table from `etc/shared/ar.conf` into fixed-size arrays
sized for `MAX_AR` (64) commands, but `ReadExecConfig()` never checked the entry counter against that
limit. When the manager distributed an `ar.conf` holding more entries than the table can store, the
function kept writing past the end of the table until the process reached unmapped memory and was
terminated by the operating system.

The table is loaded lazily, on the first Active Response the agent is asked to run, so the effect was that
Active Response stopped working on every affected agent as soon as any command was triggered, regardless
of which command it was. `ar.conf` is merged into the shared configuration of every group, so all agents
receive the full list of definitions.

Closes #38358.

## Proposed Changes

- `src/os_execd/exec.c`: stop reading `ar.conf` once `MAX_AR` commands have been loaded, reporting the
  ignored entries with the new message `(1319)`, so the truncation is visible in `ossec.log` instead of
  being silent.
- `src/os_execd/exec.c`: reset the whole command table on reload instead of one row past the last one
  used.
- `src/error_messages/error_messages.h`: add the `EXEC_MAX_AR` message.

Commands defined within the limit keep being loaded and executed exactly as before. Commands beyond the
limit are now reported as invalid, which is the same behaviour as any other unknown command name.

### Results and Evidence

**Before the change** — agent v4.14.7 with an `ar.conf` holding 120 entries. Triggering the first command
terminates the daemon:

```
# wazuh-execd is running, then an Active Response is triggered
=== process alive? ===
wazuh-execd IS GONE
```

```
wazuh-execd[55119]: segfault at 6c209b ip 0000763c1788fd94 sp 00007fff2eace070 error 6 in libc.so.6[...]
wazuh-execd: wazuh-execd: potentially unexpected fatal signal 11.
```

The same condition reproduced under AddressSanitizer through the unit tests, with the fix reverted:

```
ERROR: AddressSanitizer: global-buffer-overflow on address 0x59cf60d2ea01
WRITE of size 257 at 0x59cf60d2ea01 thread T0
    #1 ReadExecConfig os_execd/exec.c:35
0x59cf60d2ea01 is located 0 bytes after global variable 'exec_names'
defined in 'os_execd/exec.c:15:13' (0x59cf60d2a8c0) of size 16705
```

**After the change** — same agent updated to this branch (v4.14.9), same 120-entry `ar.conf`. The daemon
survives and reports the ignored entries:

```
2026/08/17 09:28:39 wazuh-execd: INFO: Started (pid: 55853).
2026/08/17 09:28:41 wazuh-execd: ERROR: (1319): Reached the maximum of 64 active response commands. Ignoring the remaining entries of 'etc/shared/ar.conf'.

=== process alive? ===
55853 /var/ossec/bin/wazuh-execd
```

Triggering the last command within the limit (entry 64) runs normally, and triggering the first one beyond
it (entry 65) is reported as an unknown command instead of stopping the daemon:

```
2026/08/17 09:29:00 wazuh-execd: ERROR: (1311): Invalid command name 'test-ar-0640' provided.
```

Full unit test suite for the agent target:

```
100% tests passed, 0 tests failed out of 84
```

### Artifacts Affected

- `wazuh-execd` (all agent packages, and the manager package since the same daemon runs there).

### Configuration Changes

None. No new setting is introduced and no existing one changes its meaning. The supported number of
Active Response command definitions is unchanged at 64; it is now enforced and reported instead of being
left undefined.

### Documentation Updates

The documentation does not currently state a maximum number of Active Response command definitions.
Documenting the 64-command limit, and the fact that `ar.conf` is distributed in full to every agent, would
be worth a follow-up documentation issue.

### Tests Introduced

New test binary `src/unit_tests/os_execd/test_read_exec_config.c` covering `ReadExecConfig()` against a
real `ar.conf`:

- Below the limit: every command is loaded and resolvable.
- Exactly `MAX_AR` entries: every command is loaded, nothing is reported as ignored.
- Above the limit: the commands within the limit are loaded, the message `(1319)` is reported, and the
  remaining entries are discarded.

The third case is what reproduces the failure: with the change reverted it aborts under AddressSanitizer,
as shown above.

## Credit

Thanks to @nimra1923 for reporting this issue.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
