### PR TITLE
Fix documentation build failure due to missing manager coordinator migration guide

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -28,7 +28,6 @@
   - [Filebeat to Indexer Connector](guide/migration/filebeat-to-indexer-connector.md)
   - [Upgrade 4.X to 5.X](guide/migration/upgrade-4x-to-5x.md)
   - [Migration Manager Configuration from 4.x to 5.x](guide/migration/manager-configuration-migration.md)
-  - [Migrating Manager Coordinator from 4.x to 5.x](guide/migration/manager-coordinator-migration.md)
   - [VirusTotal migration](guide/migration/virustotal-migration.md)
   - [Vulnerability Detection to CTI-Based Feeds](guide/migration/vulnerability-detection-cti-feeds.md)
   - [Remote Agent Upgrade Migration](guide/migration/remote-agent-upgrade.md)


### PR DESCRIPTION
## Description

Closes #38407

The 5.0.0 nightly documentation build fails while parsing the mdBook table of contents:

```
ERROR failed to read chapter `guide/migration/manager-coordinator-migration.md`
	Caused by: No such file or directory (os error 2)
```

Commit `f67e90ac6a` ("fix: remove deprecated task status, force reconnect endpoints and haproxy") deleted `docs/guide/migration/manager-coordinator-migration.md` and removed its link from `docs/guide/migration/README.md`, but left the entry in `docs/SUMMARY.md`. mdBook reads `SUMMARY.md`, tries to open the missing chapter, and aborts the build.

## Proposed Changes

- Remove the dangling `Migrating Manager Coordinator from 4.x to 5.x` entry from `docs/SUMMARY.md`. It is the only remaining reference to the deleted file (verified with `git grep`).

### Results and Evidence

Before the fix (reproduces the nightly failure, mdBook v0.5.4):

```
$ mdbook build
ERROR failed to read chapter `guide/migration/manager-coordinator-migration.md`
	Caused by: No such file or directory (os error 2)
```

After the fix, the book builds successfully:

```
$ mdbook build
 INFO Book building has started
 INFO Running the html backend
 INFO HTML book written to `.../book`
```

Only pre-existing, unrelated warnings remain (unclosed inline HTML tags in `remote-syslog-output.md`, `active-response.md`, `ref-parser.md`). No reference to `manager-coordinator-migration` remains in `SUMMARY.md` or in the generated output.

### Artifacts Affected

- `docs/SUMMARY.md`

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
