### PR TITLE
Suppress StarletteDeprecationWarning for cluster_control and all framework CLI tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Improved SCA policy source validation to correctly enforce the `sca.remote_commands` restriction. ([#37953](https://github.com/wazuh/wazuh/pull/37953))
 - Added a minimum length check for legacy-format agent messages in `wazuh-remoted`. ([#38099](https://github.com/wazuh/wazuh/pull/38099))
 - Fixed a spurious `StarletteDeprecationWarning` printed by `agent_upgrade` at startup. ([#38085](https://github.com/wazuh/wazuh/pull/38085))
+- Fixed a spurious `StarletteDeprecationWarning` printed by `cluster_control` and other framework CLI tools at startup. ([#38412](https://github.com/wazuh/wazuh/pull/38412))
 - Fixed the API login attempt limit not being applied consistently under concurrent requests. ([#38135](https://github.com/wazuh/wazuh/pull/38135))
 - Fixed a heap buffer write in `wazuh-analysisd` when generating FIM alerts by resizing `full_log` before writing. ([#38145](https://github.com/wazuh/wazuh/pull/38145))
 - Fixed password validation not being enforced for empty passwords in the `update_user` API endpoint. ([#38180](https://github.com/wazuh/wazuh/pull/38180))

--- a/api/api/__init__.py
+++ b/api/api/__init__.py
@@ -1,3 +1,21 @@
 # Copyright (C) 2015, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import warnings
+
+try:
+    from starlette.exceptions import StarletteDeprecationWarning
+except ImportError:
+    # StarletteDeprecationWarning was removed in newer versions of starlette
+    StarletteDeprecationWarning = None
+
+# Connexion unconditionally imports `starlette.testclient` to offer a test helper we never use,
+# which warns when only `httpx` (and not `httpx2`) is installed. Not fixed as of connexion 3.3.0.
+# Starlette raises this with stacklevel=2, so it is attributed to the importing module rather
+# than to starlette.testclient itself; match on the message instead of `module`.
+if StarletteDeprecationWarning is not None:
+    warnings.filterwarnings(
+        'ignore', category=StarletteDeprecationWarning,
+        message=r'Using `httpx` with `starlette\.testclient` is deprecated',
+    )


### PR DESCRIPTION
## Description

Closes #38116.

`cluster_control` (and any framework CLI tool that touches the RBAC/`Agent` layer) still prints a `StarletteDeprecationWarning` at startup on 4.14.x:

```
/var/ossec/framework/python/lib/python3.10/site-packages/connexion/apps/abstract.py:9: StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.
  from starlette.testclient import TestClient
```

This is the same warning fixed in 5.0.0 by #37509 and partially fixed in 4.14.8 by #38085. #38085 only added a local `warnings` filter to `agent_upgrade.py`, on the premise that `cluster_control` does not load `connexion` in 4.x. That premise is incorrect: `cluster_control` reaches `connexion` through the `api` package:

```
cluster_control.py
  -> wazuh.core.cluster.control
    -> wazuh.core.agent (Agent)
      -> wazuh.rbac.utils            (agent.py)
        -> api.configuration          (from api.configuration import security_conf)
          -> api.api_exception         (from connexion.exceptions import ProblemException)
```

So the local filter in `agent_upgrade.py` does not cover `cluster_control`, and 4.14.8 as merged still shows the warning there.

## Proposed Changes

- Register the `warnings` filter for this specific upstream message in `api/__init__.py`, the same place and approach as the 5.0.0 fix (#37509). Because Python imports the `api` package `__init__.py` before any `api.*` submodule, the filter is registered before `api.api_exception` pulls in `connexion`, so it covers every tool whose import chain loads the `api` package (`cluster_control`, `agent_upgrade`, the API server, tests).
- The `agent_upgrade.py` local filter added by #38085 is left in place; it is harmless and keeps that script covered even when invoked in isolation.

### Results and Evidence

Import chain traced on the `v4.14.7` tag (see the paths above). `api/api/__init__.py` on the `4.14.8` branch is empty (no filter), which is why `cluster_control -l` still emits the warning; the 5.0.0 `api/__init__.py` carries this exact filter and does not.

Before (4.14.8 branch, as merged):

```
# /var/ossec/bin/cluster_control -l
/var/ossec/framework/python/lib/python3.10/site-packages/connexion/apps/abstract.py:9: StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.
  from starlette.testclient import TestClient
NAME     TYPE    VERSION  ADDRESS
manager  master  4.14.8   127.0.0.1
```

After (this PR): the warning is gone; command output is unchanged.

### Artifacts Affected

- `api/__init__.py` (wazuh-manager packages)

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None. The change only registers a warnings filter at package import.

## Review Checklist
- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
