### PR TITLE
Restrict wazuh-manager-apid status reporting to master nodes

### DIFF
--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -5850,7 +5850,7 @@ paths:
       tags:
         - Cluster
       summary: "Get node readiness"
-      description: "Return whether the node is ready to process events. Each daemon reports running (PID check) and ready; analysisd embeds the engine resources (spaces/IOC/geo) and modulesd embeds vulnerability-detector. The node-level ready is true only when every daemon is ready."
+      description: "Return whether the node is ready to process events. Each daemon reports running (PID check) and ready; analysisd embeds the engine resources (spaces/IOC/geo) and modulesd embeds vulnerability-detector. The node-level ready is true only when every daemon is ready. wazuh-manager-apid is only reported on the master node, as it does not run on workers."
       operationId: api.controllers.cluster_controller.get_status_node
       x-rbac-actions:
         - $ref: '#/x-rbac-catalog/actions/cluster:read'

--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -69,7 +69,8 @@ def test_read_cluster_config():
             utils.read_cluster_config()
 
 
-def test_get_manager_status():
+@patch('wazuh.core.cluster.utils.read_config', return_value={'node_type': 'master'})
+def test_get_manager_status(mock_read_config):
     """Check that get_manager_status function returns the manager status.
 
     For this test, the status can be stopped or failed.
@@ -118,6 +119,25 @@ def test_get_manager_status():
             status = utils.get_manager_status()
             for value in status.values():
                 assert value == 'running'
+
+
+@pytest.mark.parametrize('node_type, apid_reported', [
+    ('master', True),
+    ('worker', False)
+])
+def test_get_manager_status_apid(node_type, apid_reported):
+    """Check that the API daemon is only reported on master nodes.
+
+    Parameters
+    ----------
+    node_type : str
+        Cluster node type of the reporting node.
+    apid_reported : bool
+        Whether the API daemon is expected in the returned status.
+    """
+    with patch('wazuh.core.cluster.utils.read_config', return_value={'node_type': node_type}):
+        assert ('wazuh-manager-apid' in utils.get_manager_status()) == apid_reported
+
 
 @pytest.mark.parametrize('exc', [
     PermissionError,

--- a/framework/wazuh/core/cluster/tests/test_utils.py
+++ b/framework/wazuh/core/cluster/tests/test_utils.py
@@ -68,6 +68,10 @@ def test_read_cluster_config():
         with pytest.raises(WazuhError, match='.* 3004 .*'):
             utils.read_cluster_config()
 
+    # The cached entry aliases default_cluster_config, mutated above. Evict it so the rest of the
+    # session does not read a config with node_type 'client'.
+    utils.read_config.cache_clear()
+
 
 @patch('wazuh.core.cluster.utils.read_config', return_value={'node_type': 'master'})
 def test_get_manager_status(mock_read_config):

--- a/framework/wazuh/core/cluster/utils.py
+++ b/framework/wazuh/core/cluster/utils.py
@@ -96,7 +96,7 @@ def get_manager_status(cache=False) -> typing.Dict:
     Returns
     -------
     data : dict
-        Dict whose keys are daemons and the values are the status.
+        Dict whose keys are daemons and the values are the status. The API daemon is only included on master nodes.
     """
     # Check /proc directory availability
     proc_path = "/proc"
@@ -107,7 +107,11 @@ def get_manager_status(cache=False) -> typing.Dict:
 
     processes = ['wazuh-manager-analysisd', 'wazuh-manager-authd', 'wazuh-manager-monitord',
                  'wazuh-manager-remoted', 'wazuh-manager-clusterd',
-                 'wazuh-manager-modulesd', 'wazuh-manager-db', 'wazuh-manager-apid']
+                 'wazuh-manager-modulesd', 'wazuh-manager-db']
+
+    # The API daemon is only started on the master node (src/init/wazuh-server.sh).
+    if read_config()['node_type'] == 'master':
+        processes.append('wazuh-manager-apid')
 
     data, pidfile_regex, run_dir = {}, re.compile(r'.+\-(\d+)\.pid$'), os.path.join(common.WAZUH_PATH, "var", "run")
     for process in processes:

--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -170,6 +170,11 @@ disable()
     fi
 }
 
+get_node_type()
+{
+    grep '<node_type>' ${DIR}/etc/${WAZUH_CONF} 2>/dev/null | sed 's/<node_type>\(.*\)<\/node_type>/\1/' | tr -d ' '
+}
+
 status()
 {
     RETVAL=0
@@ -177,10 +182,17 @@ status()
 
     checkpid;
 
+    node_type=$(get_node_type);
+
     if [ $USE_JSON = true ]; then
         echo -n '{"error":0,"data":['
     fi
     for i in ${DAEMONS}; do
+        ## The API daemon only runs on the master node
+        if [ X"$i" = "Xwazuh-manager-apid" ] && [ "$node_type" != "master" ]; then
+            continue
+        fi
+
         if [ $USE_JSON = true ] && [ $first = false ]; then
             echo -n ','
         else
@@ -326,7 +338,7 @@ start_service()
     TO_DELETE="$DIR/tmp"
     find "$TO_DELETE" -mindepth 1 -delete
 
-    node_type=$(grep '<node_type>' ${DIR}/etc/${WAZUH_CONF} | sed 's/<node_type>\(.*\)<\/node_type>/\1/' | tr -d ' ');
+    node_type=$(get_node_type);
     if [ -z $node_type ]; then
         echo "Invalid cluster configuration, check the $DIR/etc/${WAZUH_CONF} file."
         unlock;

--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -172,7 +172,7 @@ disable()
 
 get_node_type()
 {
-    grep '<node_type>' ${DIR}/etc/${WAZUH_CONF} 2>/dev/null | sed 's/<node_type>\(.*\)<\/node_type>/\1/' | tr -d ' '
+    sed -n 's/.*<node_type>\([^<]*\)<\/node_type>.*/\1/p' ${DIR}/etc/${WAZUH_CONF} 2>/dev/null | tr -d ' '
 }
 
 status()


### PR DESCRIPTION
## Description

Closes #38390

The API daemon runs only on the master node since #32067, but the node-type guard was added only to `start_service()` in `src/init/wazuh-server.sh`. Every code path that *reports* daemon status kept iterating the full daemon list, so a worker reports `wazuh-manager-apid` as `stopped` even though it is never supposed to start it.

Two independent reporting surfaces are affected:

- `src/init/wazuh-server.sh::status`, so `wazuh-server status` and `wazuh-server -j status` list the daemon on a worker.
- `framework/wazuh/core/cluster/utils.py::get_manager_status`, which keeps its own hardcoded process list and reads the pidfiles directly. It feeds `GET /cluster/{node_id}/status`, where #36989 turned the daemon list into a readiness report: the node-level `ready` is the AND over every daemon, so a `stopped` apid marks the whole worker as `not ready`.

That second surface is what the dashboard renders, hence the red daemon and the yellow `not ready` worker in the issue screenshots. Both surfaces get the same guard, so the CLI and the API agree.

## Proposed Changes

- `src/init/wazuh-server.sh`: extract the node type parsing into a `get_node_type()` helper, reused by `start_service()`, and skip `wazuh-manager-apid` in `status()` when the node is not a master. The guard sits before the JSON separator bookkeeping so the `-j` output stays well formed. An unreadable configuration yields an empty node type, so `status()` skips the daemon and keeps working, while `start_service()` still refuses to start.
- `framework/wazuh/core/cluster/utils.py`: append `wazuh-manager-apid` to the reported processes only when `read_config()['node_type']` is `master`.
- `framework/wazuh/core/cluster/tests/test_utils.py`: pin `read_config` in `test_get_manager_status`, add a master/worker case for the reported daemon list, and evict the `read_config` cache entry that `test_read_cluster_config` leaves aliasing a mutated dict.
- `api/api/spec/spec.yaml`: state in the `/cluster/{node_id}/status` description that the daemon is reported only on the master node.

`get_node_type()` also replaces the previous in-place substitution with an anchored extraction. The old expression was a `sed s///`, which leaves the rest of the line untouched, so anything around the tag leaked into the parsed value. That was pre-existing in `start_service()`, where the consequence is worse than the bug this PR fixes: a master whose `<node_type>` line carries a trailing comment parses as non-master, and the API daemon silently never starts.

`stop_service()` is deliberately left iterating the full daemon list. Its kill pass must stay exhaustive so a node demoted from master to worker still gets a leftover apid process stopped, and `wazuh-manager-authd` already sets the precedent: its guard exists only in `start_service()`, so `stop` names it too when enrollment is disabled.

### Results and Evidence

#### Two-node cluster

`manager` (10.2.0.9) as `master-node` and `manager2` (10.2.0.11) as `worker-node`, both installed from the same package. A Wazuh indexer and a Wazuh dashboard run on the master (`wazuh-indexer`, `wazuh-manager` and `wazuh-dashboard` all active, indexer cluster health `green`), so every daemon reaches `ready` and the node-level `ready` is meaningful rather than blocked by missing content.

<details><summary>Package under test and provenance</summary>

The control script the package installs is byte-identical to the one in this branch.

```console
root@manager:~# md5sum /var/wazuh-manager/bin/wazuh-manager-control
e2f117a48784b199f52cafcae33a08d7  /var/wazuh-manager/bin/wazuh-manager-control
```

```console
$ md5sum src/init/wazuh-server.sh
e2f117a48784b199f52cafcae33a08d7  src/init/wazuh-server.sh
```

`framework/wazuh/core/cluster/utils.py` extracted from the package also matches this branch byte for byte (`diff` reports no difference).

</details>

<details><summary>Cluster formed</summary>

```console
root@manager:~# /var/wazuh-manager/bin/cluster_control -l
NAME         TYPE    VERSION  ADDRESS
master-node  master  5.0.0    10.2.0.9
worker-node  worker  5.0.0    10.2.0.11
```

</details>

#### Dashboard, Server management > Status

<details><summary>Worker node, before and after</summary>

Before, from the issue report: `wazuh-manager-apid` in red and the worker flagged `not ready`.

![before](https://github.com/user-attachments/assets/7e3ca617-ddb9-4568-9939-a83d53e97c0b)

After, same page and same node selected, with this branch installed. The daemon is not in the list at all, and the node reports ready.

<img width="1920" height="612" alt="2-dashboard-worker-node" src="https://github.com/user-attachments/assets/1165dc70-e67e-4269-9fa9-f78afff1d3be" />


</details>

<details><summary>Master node, the daemon is still reported there</summary>

<img width="1920" height="612" alt="1-dashboard-master-node" src="https://github.com/user-attachments/assets/d1ae1728-2fca-4667-b5a6-ce1a48e025f8" />

</details>

<details><summary>Same data from the dashboard Dev Tools console</summary>

`GET /cluster/master-node/status`, the daemon present with `ready` and `running` true:

<img width="1917" height="996" alt="3-devtools-master-node" src="https://github.com/user-attachments/assets/046253ca-9cee-485f-b179-eb3274ae463a" />

`GET /cluster/worker-node/status`, the daemon absent and the node `ready: true`:

<img width="1917" height="996" alt="4-devtools-worker-node" src="https://github.com/user-attachments/assets/e3b69d96-1211-44b2-bdeb-9aceffa2cdc0" />

</details>

#### Control script and API

<details><summary>Control script on the master: apid reported</summary>

```console
root@manager:~# hostname
manager
root@manager:~# grep --color=never -E "node_name|node_type" /var/wazuh-manager/etc/wazuh-manager.conf
    <node_name>master-node</node_name>
    <node_type>master</node_type>
root@manager:~# /var/wazuh-manager/bin/wazuh-manager-control status
wazuh-manager-clusterd is running...
wazuh-manager-modulesd is running...
wazuh-manager-monitord is running...
wazuh-manager-remoted is running...
wazuh-manager-analysisd is running...
wazuh-manager-db is running...
wazuh-manager-authd is running...
wazuh-manager-apid is running...
root@manager:~# /var/wazuh-manager/bin/wazuh-manager-control -j status | jq -Mc "[.data[].daemon]"
["wazuh-manager-clusterd","wazuh-manager-modulesd","wazuh-manager-monitord","wazuh-manager-remoted","wazuh-manager-analysisd","wazuh-manager-db","wazuh-manager-authd","wazuh-manager-apid"]
```

</details>

<details><summary>Control script on the worker: apid absent, JSON still well formed</summary>

```console
root@manager2:~# hostname
manager2
root@manager2:~# grep --color=never -E "node_name|node_type" /var/wazuh-manager/etc/wazuh-manager.conf
    <node_name>worker-node</node_name>
    <node_type>worker</node_type>
root@manager2:~# /var/wazuh-manager/bin/wazuh-manager-control status
wazuh-manager-clusterd is running...
wazuh-manager-modulesd is running...
wazuh-manager-monitord is running...
wazuh-manager-remoted is running...
wazuh-manager-analysisd is running...
wazuh-manager-db is running...
wazuh-manager-authd is running...
root@manager2:~# /var/wazuh-manager/bin/wazuh-manager-control -j status | jq -Mc "[.data[].daemon]"
["wazuh-manager-clusterd","wazuh-manager-modulesd","wazuh-manager-monitord","wazuh-manager-remoted","wazuh-manager-analysisd","wazuh-manager-db","wazuh-manager-authd"]
```

`jq` parsing the `-j` output is also the well-formedness check: it errors on a stray separator, which is what skipping the last element of the list could have produced.

</details>

<details><summary>GET /cluster/{node_id}/status: both symptoms gone</summary>

```console
root@manager:~# TOKEN=$(curl -sk -u wazuh:wazuh -X POST "https://10.2.0.9:55000/security/user/authenticate" | jq -r .data.token)
root@manager:~# curl -sk -H "Authorization: Bearer $TOKEN" "https://10.2.0.9:55000/cluster/master-node/status" | jq -Mc "{ready: .data.affected_items[0].ready, daemons: (.data.affected_items[0] | del(.ready) | keys)}"
{"ready":true,"daemons":["wazuh-manager-analysisd","wazuh-manager-apid","wazuh-manager-authd","wazuh-manager-clusterd","wazuh-manager-db","wazuh-manager-modulesd","wazuh-manager-monitord","wazuh-manager-remoted"]}
root@manager:~# curl -sk -H "Authorization: Bearer $TOKEN" "https://10.2.0.9:55000/cluster/worker-node/status" | jq -Mc "{ready: .data.affected_items[0].ready, daemons: (.data.affected_items[0] | del(.ready) | keys)}"
{"ready":true,"daemons":["wazuh-manager-analysisd","wazuh-manager-authd","wazuh-manager-clusterd","wazuh-manager-db","wazuh-manager-modulesd","wazuh-manager-monitord","wazuh-manager-remoted"]}
```

The worker no longer reports `wazuh-manager-apid`, so the daemon can no longer render red, and the node reports `ready: true` instead of being dragged to `not ready` by a daemon it never starts. The master keeps reporting it.

</details>

#### Node type parsing

<details><summary>Substitution vs extraction in get_node_type()</summary>

Each line fed as the `<node_type>` line of `wazuh-manager.conf`, parsed with the previous expression and with the one in this PR:

```
line in wazuh-manager.conf                                 before (substitution)        after (extraction)
---------------------------------------------------------- ---------------------------- ----------------------------
<node_type>master</node_type>                              master                       master
<node_type>master</node_type> <!-- node role -->           master<!--noderole-->        master
<cluster><node_type>master</node_type></cluster>           <cluster>master</cluster>    master
<node_type>worker</node_type>                              worker                       worker
```

The two middle cases compared unequal to `master`, so a master node hid the daemon from `status()` and, through the same helper in `start_service()`, never started it.

</details>

#### Unit tests and static analysis

CI is green on the head commit: 69 successful checks, 2 skipped, none failed. Run locally with the same invocation as the corresponding workflows:

- `5_testunit_framework.yml`: 1958 passed, 6 skipped.
- `5_testunit_api.yml`: 445 passed.
- `5_codeanalysis_python_bandit_pr.yml`: no finding on the changed module, before or after the change.


<details><summary>read_config cache leak fixed by the test change</summary>

`test_read_cluster_config` mocks `get_ossec_conf` with the module-level `default_cluster_config` object, `read_cluster_config` mutates and returns that same object without copying, `read_config` caches it, and the test then sets `node_type` to `client`. Every later caller in the same session read that. `get_manager_status` now depends on `read_config`, so the leak silently removed the suite's ability to notice a wrong daemon list:

```console
before:  node_type: client  | port: None    -> get_manager_status: 7 daemons, apid absent
after:   node_type: master  | port: 1516    -> get_manager_status: 8 daemons, apid present
```

</details>

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Log syntax and correct language review
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer
- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors
- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.
- Wazuh server API/Framework
  - [ ] Run API Integration Tests

No compiled code is touched, so the compilation and memory checks do not apply. The API integration tests need the containerized cluster environment and were not run; `test_cluster_endpoints.tavern.yaml` asserts `affected_items: !anything` for this endpoint, so it does not constrain the reported daemon list either way.

### Artifacts Affected

- `src/init/wazuh-server.sh`, installed as `bin/wazuh-manager-control`.
- The `framework` Python package.
- `api/api/spec/spec.yaml`, the API specification shipped with the manager.

No packaging or default configuration file changes.

### Configuration Changes

N/A

### Tests Introduced

`test_get_manager_status_apid` in `framework/wazuh/core/cluster/tests/test_utils.py`, parametrized over `master` and `worker`, asserting that `wazuh-manager-apid` is in the reported daemons only on a master node. `test_get_manager_status` now pins `read_config` instead of inheriting whatever the module cache held, and `test_read_cluster_config` evicts the cache entry it poisons.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues

The same pattern applies to `wazuh-manager-authd`: `start_service()` skips it when `<auth><disabled>yes`, and neither reporting surface knows, so a deployment with enrollment disabled reports it `stopped` and the node `not ready`. Different daemon and different trigger, so it is left out of this pull request and deserves its own issue.

