### PR TITLE
Added ssl and batch block to agent's configuration report

### DIFF
--- a/src/client-agent/src/config.c
+++ b/src/client-agent/src/config.c
@@ -72,6 +72,8 @@ int ClientConf(const char *cfgfile)
     agt->stats_report.interval = 60;
     agt->config_report.interval = 3600;
 
+    agt->batch.interval = 10;
+
 #ifndef WIN32
     atc->package_uninstallation = false;
 #endif
@@ -131,6 +133,21 @@ bool w_agent_validate_ssl_ca(const agent *cfg)
     }
 
     return true;
+}
+
+// Helper for translating the verification_mode enum to a string for JSON output.
+static const char *w_agent_verify_mode_str(int verification_mode)
+{
+    switch (verification_mode) {
+    case AGENT_VERIFY_FULL:
+        return "full";
+    case AGENT_VERIFY_CERT:
+        return "certificate";
+    case AGENT_VERIFY_NONE:
+        return "none";
+    default:
+        return "unknown";
+    }
 }
 
 cJSON *getAgentConfig(void) {
@@ -198,6 +215,21 @@ cJSON *getAgentConfig(void) {
 
         cJSON_AddItemToObject(agent_config,"enrollment",enrollment_cfg);
     }
+    // <ssl>
+    cJSON *ssl = cJSON_CreateObject();
+    cJSON_AddStringToObject(ssl, "verification_mode", w_agent_verify_mode_str(agt->ssl.verification_mode));
+    if (agt->ssl.certificate) cJSON_AddStringToObject(ssl, "certificate", agt->ssl.certificate);
+    if (agt->ssl.key) cJSON_AddStringToObject(ssl, "key", agt->ssl.key);
+    if (agt->ssl.certificate_authorities) cJSON_AddStringToObject(ssl, "certificate_authorities", agt->ssl.certificate_authorities);
+    if (agt->ssl.ciphers) cJSON_AddStringToObject(ssl, "ciphers", agt->ssl.ciphers);
+    cJSON_AddItemToObject(agent_config, "ssl", ssl);
+
+    // <batch>
+    cJSON *batch = cJSON_CreateObject();
+    cJSON_AddNumberToObject(batch, "size", agt->batch.size);
+    cJSON_AddNumberToObject(batch, "interval", agt->batch.interval);
+    cJSON_AddItemToObject(agent_config, "batch", batch);
+
     /* The two periodic report pushes (#37843). Reported so the /config document
      * says whether the agent is reporting, and on what cadence. */
     cJSON *stats_report = cJSON_CreateObject();

--- a/src/client-agent/src/config.c
+++ b/src/client-agent/src/config.c
@@ -72,6 +72,7 @@ int ClientConf(const char *cfgfile)
     agt->stats_report.interval = 60;
     agt->config_report.interval = 3600;
 
+    agt->batch.size = 1024 * 1024;
     agt->batch.interval = 10;
 
 #ifndef WIN32

--- a/src/client-agent/src/config.c
+++ b/src/client-agent/src/config.c
@@ -72,7 +72,6 @@ int ClientConf(const char *cfgfile)
     agt->stats_report.interval = 60;
     agt->config_report.interval = 3600;
 
-    agt->batch.size = 1024 * 1024;
     agt->batch.interval = 10;
 
 #ifndef WIN32
@@ -227,7 +226,12 @@ cJSON *getAgentConfig(void) {
 
     // <batch>
     cJSON *batch = cJSON_CreateObject();
-    cJSON_AddNumberToObject(batch, "size", agt->batch.size);
+    /* Zero means <size> was never configured, and every reader of that zero applies
+     * DEFAULT_BATCH_SIZE_BYTES, so the report states the cap actually in force rather
+     * than the sentinel. Not seeded into agt: that value is passed on to
+     * asp_set_session_max_bytes(), where a seed would read as an explicit setting. */
+    cJSON_AddNumberToObject(batch, "size",
+                            agt->batch.size > 0 ? agt->batch.size : DEFAULT_BATCH_SIZE_BYTES);
     cJSON_AddNumberToObject(batch, "interval", agt->batch.interval);
     cJSON_AddItemToObject(agent_config, "batch", batch);
 

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -1599,10 +1599,12 @@ static bool bridge_build_config(hc_config_t *config)
     config->notify_interval_s = (uint32_t)agt->notify_time;
     strncpy(config->version, __wazuh_version, sizeof(config->version) - 1);
 
-    /* <client><batch>: the /stateless payload limit and flush window. Left at
-     * zero when unset, which the module reads as "use the default" (1 MiB,
-     * 10 s). buffer_cap_multiplier has no configuration surface yet, so the
-     * accumulator keeps its own 4x default. */
+    /* <client><batch>: the /stateless payload limit and flush window. <interval>
+     * defaults to its effective value (10 s) in ClientConf(), so this copy is never
+     * zero; <size> is left at zero when unset and the module applies the same
+     * DEFAULT_BATCH_SIZE_BYTES the rest of the agent expands it to.
+     * buffer_cap_multiplier has no configuration surface yet, so the accumulator
+     * keeps its own 4x default. */
     config->batch_size_bytes = (uint64_t)agt->batch.size;
     config->batch_interval_ms = (uint32_t)(agt->batch.interval * 1000);
 

--- a/src/config/include/client-config.h
+++ b/src/config/include/client-config.h
@@ -138,6 +138,11 @@ void w_read_agent_batch(const char *cfgfile, const char *sharedcfg, agent_batch 
 #define DEFAULT_MAX_RETRIES 5
 #define DEFAULT_RETRY_INTERVAL 10
 
+/* The /stateless payload cap that applies when <agent><batch><size> is unset. Both
+ * readers of that zero expand it to this same number: the transport module
+ * (https_client/src/moduleConfig.cpp) and the sync protocol (FULLSESSION_MAX_BYTES). */
+#define DEFAULT_BATCH_SIZE_BYTES (1024 * 1024)
+
 /* Port used when <server><port> is unspecified. Must mirror the manager's
  * DEFAULT_HTTPS_PORT (src/remoted/remoted_module/src/http_server/httpServerConfig.cpp)
  * since the agent has no legacy-transport fallback to default to instead. */

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
@@ -355,8 +355,8 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         std::atomic<unsigned int> m_consecutiveSyncFailures{0};
 
         /// Built-in ceiling on one session, used until a daemon calls
-        /// setSessionMaxBytes() with what <agent><batch><size> says.
-        static constexpr size_t FULLSESSION_MAX_BYTES = 5U * 1024U * 1024U;
+        /// Same 1 MiB the HTTPS transport applies to a /stateless request by default.
+        static constexpr size_t FULLSESSION_MAX_BYTES = 1U * 1024U * 1024U;
 
         /// Process-wide, because the limit is one agent-wide decision and the modules
         /// that build these instances have no configuration of their own to carry it.

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
@@ -354,8 +354,10 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         /// resetting the streak on it is correct regardless of which flow observed it.
         std::atomic<unsigned int> m_consecutiveSyncFailures{0};
 
-        /// Built-in ceiling on one session, used until a daemon calls
-        /// Same 1 MiB the HTTPS transport applies to a /stateless request by default.
+        /// Built-in ceiling on one session, used until a daemon calls setSessionMaxBytes()
+        /// with what <agent><batch><size> says. Same 1 MiB the HTTPS transport applies to
+        /// a /stateless request when that option is unset, so the limit is one number
+        /// agent-wide however it is reached.
         static constexpr size_t FULLSESSION_MAX_BYTES = 1U * 1024U * 1024U;
 
         /// Process-wide, because the limit is one agent-wide decision and the modules

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -771,7 +771,7 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleDeltaUsesBytePrefilterBudgetForSy
     LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
     protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
 
-    constexpr size_t FULLSESSION_MAX_BYTES = 5U * 1024U * 1024U;
+    constexpr size_t FULLSESSION_MAX_BYTES = 1U * 1024U * 1024U;
     constexpr size_t FULLSESSION_PREFILTER_GRACE_BYTES = 64U * 1024U;
     constexpr size_t EXPECTED_BUDGET = FULLSESSION_MAX_BYTES - FULLSESSION_PREFILTER_GRACE_BYTES;
 
@@ -814,7 +814,7 @@ class SessionMaxBytesGuard final
 
         ~SessionMaxBytesGuard()
         {
-            AgentSyncProtocol::setSessionMaxBytes(5U * 1024U * 1024U);
+            AgentSyncProtocol::setSessionMaxBytes(1U * 1024U * 1024U);
         }
 
         SessionMaxBytesGuard(const SessionMaxBytesGuard&) = delete;
@@ -824,8 +824,8 @@ class SessionMaxBytesGuard final
 TEST_F(AgentSyncProtocolTest, SessionByteBudgetFollowsTheConfiguredSessionMax)
 {
     // <agent><batch><size> bounds a sync session the same way it bounds a
-    // /stateless request; before it was configurable this budget was fixed at
-    // 5 MiB whatever the agent had been told.
+    // /stateless request; before it was configurable this budget was fixed
+    // whatever the agent had been told.
     constexpr size_t CONFIGURED_MAX_BYTES = 512U * 1024U;
     constexpr size_t FULLSESSION_PREFILTER_GRACE_BYTES = 64U * 1024U;
     constexpr size_t EXPECTED_BUDGET = CONFIGURED_MAX_BYTES - FULLSESSION_PREFILTER_GRACE_BYTES;
@@ -865,7 +865,7 @@ TEST_F(AgentSyncProtocolTest, AnUnsetSessionMaxKeepsTheBuiltInDefault)
 {
     // Zero is what an absent <batch><size> reaches the module as, so it has to
     // read as "leave the default alone" rather than as a zero-byte session.
-    constexpr size_t FULLSESSION_MAX_BYTES = 5U * 1024U * 1024U;
+    constexpr size_t FULLSESSION_MAX_BYTES = 1U * 1024U * 1024U;
     constexpr size_t FULLSESSION_PREFILTER_GRACE_BYTES = 64U * 1024U;
     constexpr size_t EXPECTED_BUDGET = FULLSESSION_MAX_BYTES - FULLSESSION_PREFILTER_GRACE_BYTES;
 

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -98,6 +98,10 @@ list(APPEND client-agent_flags "-Wl,--wrap,OS_SHA256_File ${DEBUG_OP_WRAPPERS}")
 list(APPEND client-agent_names "test_agent_ssl_ca")
 list(APPEND client-agent_flags "-Wl,--wrap,w_is_file ${DEBUG_OP_WRAPPERS}")
 
+# getAgentConfig() reads the agt globals and builds cJSON, nothing else: no wrappers.
+list(APPEND client-agent_names "test_agent_config")
+list(APPEND client-agent_flags " ")
+
 list(APPEND client-agent_names "test_https_client_bridge")
 list(APPEND client-agent_flags "-Wl,--wrap,wurl_free_response -Wl,--wrap,wurl_http_request \
                                 -Wl,--wrap,hc_create -Wl,--wrap,hc_start -Wl,--wrap,hc_destroy \

--- a/src/unit_tests/client-agent/test_agent_config.c
+++ b/src/unit_tests/client-agent/test_agent_config.c
@@ -41,7 +41,6 @@ static int setup_agent(void **state)
      * is the same struct an agent with an untouched ossec.conf ends up running on. */
     test_agt.flags.auto_restart = 1;
     test_agt.ssl.verification_mode = AGENT_VERIFY_NONE;
-    test_agt.batch.size = 1024 * 1024;
     test_agt.batch.interval = 10;
     test_agt.stats_report.interval = 60;
     test_agt.config_report.enabled = 1;
@@ -369,9 +368,9 @@ static void test_reports_configured_batch_limits(void **state)
     cJSON_Delete(root);
 }
 
-/* Unconfigured is the pair ClientConf() seeds, and it is what both readers of <size>
- * apply: 1 MiB for a /stateless request and for one sync session. */
-static void test_reports_seeded_batch_defaults(void **state)
+/* Unconfigured <size> is reported as the cap every reader applies to its zero, 1 MiB,
+ * without seeding it into agt; <interval> is the value ClientConf() seeds. */
+static void test_reports_batch_defaults(void **state)
 {
     (void)state;
     cJSON *root = NULL;
@@ -429,7 +428,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_reports_default_ssl_posture, setup_agent, teardown_agent),
         cmocka_unit_test_setup_teardown(test_reports_full_verification_mode, setup_agent, teardown_agent),
         cmocka_unit_test_setup_teardown(test_reports_configured_batch_limits, setup_agent, teardown_agent),
-        cmocka_unit_test_setup_teardown(test_reports_seeded_batch_defaults, setup_agent, teardown_agent),
+        cmocka_unit_test_setup_teardown(test_reports_batch_defaults, setup_agent, teardown_agent),
         cmocka_unit_test_setup_teardown(test_reports_both_periodic_pushes, setup_agent, teardown_agent),
         cmocka_unit_test_setup_teardown(test_no_config_returns_null, setup_agent, teardown_agent),
     };

--- a/src/unit_tests/client-agent/test_agent_config.c
+++ b/src/unit_tests/client-agent/test_agent_config.c
@@ -1,0 +1,438 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "agentd.h"
+
+/* getAgentConfig() is the whole answer to "getconfig agent" and the payload of the
+ * periodic /config push, so anything it leaves out is invisible to the manager even
+ * though the agent is running on it. These tests pin the entire reported section:
+ * which keys it carries, which optional ones it omits, and the value of every one. */
+
+static agent test_agt;
+static agent_server test_servers[3];
+static w_enrollment_ctx test_enrollment;
+static w_enrollment_target test_target;
+static w_enrollment_cert test_cert;
+
+static int setup_agent(void **state)
+{
+    (void)state;
+
+    memset(&test_agt, 0, sizeof(test_agt));
+    memset(test_servers, 0, sizeof(test_servers));
+    memset(&test_enrollment, 0, sizeof(test_enrollment));
+    memset(&test_target, 0, sizeof(test_target));
+    memset(&test_cert, 0, sizeof(test_cert));
+
+    /* The defaults ClientConf() seeds before parsing, so an "unconfigured" case here
+     * is the same struct an agent with an untouched ossec.conf ends up running on. */
+    test_agt.flags.auto_restart = 1;
+    test_agt.ssl.verification_mode = AGENT_VERIFY_NONE;
+    test_agt.batch.size = 1024 * 1024;
+    test_agt.batch.interval = 10;
+    test_agt.stats_report.interval = 60;
+    test_agt.config_report.enabled = 1;
+    test_agt.config_report.interval = 3600;
+
+    test_enrollment.target_cfg = &test_target;
+    test_enrollment.cert_cfg = &test_cert;
+    test_enrollment.enabled = true;
+    test_enrollment.delay_after_enrollment = 20;
+    test_target.port = 1515;
+    test_cert.ciphers = "TLS_AES_256_GCM_SHA384";
+
+    agt = &test_agt;
+
+    return 0;
+}
+
+static int teardown_agent(void **state)
+{
+    (void)state;
+    agt = NULL;
+
+    return 0;
+}
+
+static void with_servers(void)
+{
+    test_servers[0].rip = "192.168.0.1";
+    test_servers[0].port = 1517;
+    test_servers[0].max_retries = 5;
+    test_servers[0].retry_interval = 10;
+
+    test_servers[1].rip = "192.168.0.2";
+    test_servers[1].port = 1518;
+    test_servers[1].network_interface = 3;
+    test_servers[1].max_retries = 7;
+    test_servers[1].retry_interval = 20;
+
+    test_agt.server = test_servers;
+    test_agt.server_count = 2;
+}
+
+static cJSON *get_agent_section(cJSON **root)
+{
+    *root = getAgentConfig();
+    assert_non_null(*root);
+
+    cJSON *section = cJSON_GetObjectItem(*root, "agent");
+    assert_non_null(section);
+
+    return section;
+}
+
+static void assert_string_field(const cJSON *object, const char *field, const char *expected)
+{
+    cJSON *item = cJSON_GetObjectItem(object, field);
+
+    assert_non_null(item);
+    assert_string_equal(cJSON_GetStringValue(item), expected);
+}
+
+static void assert_number_field(const cJSON *object, const char *field, double expected)
+{
+    cJSON *item = cJSON_GetObjectItem(object, field);
+
+    assert_non_null(item);
+    assert_true(cJSON_IsNumber(item));
+    assert_true(item->valuedouble == expected);
+}
+
+static void assert_has_exactly(const cJSON *object, const char *const *expected, size_t count)
+{
+    size_t reported = 0;
+
+    for (const cJSON *item = object->child; item; item = item->next) {
+        reported++;
+    }
+
+    assert_int_equal(reported, count);
+
+    for (size_t i = 0; i < count; i++) {
+        assert_non_null(cJSON_GetObjectItem(object, expected[i]));
+    }
+}
+
+/* The document as a whole: a key silently dropped from the report is the defect this
+ * whole issue is about, so the key set is asserted, not just the values. */
+static void test_reports_every_section(void **state)
+{
+    (void)state;
+    cJSON *root = NULL;
+
+    with_servers();
+    test_agt.profile = "ubuntu, ubuntu24";
+
+    const char *const expected[] = {
+        "config-profile", "notify_time", "time-reconnect", "ip_update_interval",
+        "auto_restart", "remote_conf", "manager", "enrollment", "ssl", "batch",
+        "stats_report", "config_report"
+    };
+    test_agt.enrollment_cfg = &test_enrollment;
+
+    cJSON *section = get_agent_section(&root);
+
+    assert_has_exactly(section, expected, sizeof(expected) / sizeof(*expected));
+
+    cJSON_Delete(root);
+}
+
+static void test_reports_scalars_and_flags(void **state)
+{
+    (void)state;
+    cJSON *root = NULL;
+
+    test_agt.profile = "ubuntu, ubuntu24";
+    test_agt.notify_time = 10;
+    test_agt.max_time_reconnect_try = 60;
+    test_agt.main_ip_update_interval = 30;
+    test_agt.flags.remote_conf = 1;
+
+    cJSON *section = get_agent_section(&root);
+
+    assert_string_field(section, "config-profile", "ubuntu, ubuntu24");
+    assert_number_field(section, "notify_time", 10);
+    assert_number_field(section, "time-reconnect", 60);
+    assert_number_field(section, "ip_update_interval", 30);
+    assert_string_field(section, "auto_restart", "yes");
+    assert_string_field(section, "remote_conf", "yes");
+
+    cJSON_Delete(root);
+}
+
+static void test_reports_disabled_flags_as_no(void **state)
+{
+    (void)state;
+    cJSON *root = NULL;
+
+    test_agt.flags.auto_restart = 0;
+    test_agt.flags.remote_conf = 0;
+
+    cJSON *section = get_agent_section(&root);
+
+    assert_string_field(section, "auto_restart", "no");
+    assert_string_field(section, "remote_conf", "no");
+    assert_null(cJSON_GetObjectItem(section, "config-profile"));
+
+    cJSON_Delete(root);
+}
+
+static void test_reports_every_manager(void **state)
+{
+    (void)state;
+    cJSON *root = NULL;
+
+    with_servers();
+
+    cJSON *managers = cJSON_GetObjectItem(get_agent_section(&root), "manager");
+
+    assert_non_null(managers);
+    assert_int_equal(cJSON_GetArraySize(managers), 2);
+
+    cJSON *first = cJSON_GetArrayItem(managers, 0);
+    assert_string_field(first, "address", "192.168.0.1");
+    assert_number_field(first, "port", 1517);
+    assert_number_field(first, "max_retries", 5);
+    assert_number_field(first, "retry_interval", 10);
+    assert_null(cJSON_GetObjectItem(first, "interface_index"));
+
+    cJSON *second = cJSON_GetArrayItem(managers, 1);
+    assert_string_field(second, "address", "192.168.0.2");
+    assert_number_field(second, "port", 1518);
+    assert_number_field(second, "interface_index", 3);
+
+    cJSON_Delete(root);
+}
+
+static void test_omits_manager_without_servers(void **state)
+{
+    (void)state;
+    cJSON *root = NULL;
+
+    assert_null(cJSON_GetObjectItem(get_agent_section(&root), "manager"));
+
+    cJSON_Delete(root);
+}
+
+static void test_reports_enrollment_with_every_optional_field(void **state)
+{
+    (void)state;
+    cJSON *root = NULL;
+
+    test_agt.enrollment_cfg = &test_enrollment;
+    test_target.manager_name = "192.168.0.1";
+    test_target.network_interface = 4;
+    test_target.agent_name = "agent-01";
+    test_target.centralized_group = "default";
+    test_cert.ca_cert = "etc/root-ca.pem";
+    test_cert.agent_cert = "etc/agent.cert";
+    test_cert.agent_key = "etc/agent.key";
+    test_cert.authpass = "secret";
+    test_cert.authpass_file = "etc/authd.pass";
+
+    cJSON *enrollment = cJSON_GetObjectItem(get_agent_section(&root), "enrollment");
+
+    assert_non_null(enrollment);
+    assert_string_field(enrollment, "enabled", "yes");
+    assert_number_field(enrollment, "delay_after_enrollment", 20);
+    assert_string_field(enrollment, "manager_address", "192.168.0.1");
+    assert_number_field(enrollment, "interface_index", 4);
+    assert_number_field(enrollment, "port", 1515);
+    assert_string_field(enrollment, "agent_name", "agent-01");
+    assert_string_field(enrollment, "group", "default");
+    assert_string_field(enrollment, "ssl_cipher", "TLS_AES_256_GCM_SHA384");
+    assert_string_field(enrollment, "server_certificate_path", "etc/root-ca.pem");
+    assert_string_field(enrollment, "agent_certificate_path", "etc/agent.cert");
+    assert_string_field(enrollment, "agent_key_path", "etc/agent.key");
+    assert_string_field(enrollment, "authorization_pass_path", "etc/authd.pass");
+
+    cJSON_Delete(root);
+}
+
+static void test_reports_enrollment_without_optional_fields(void **state)
+{
+    (void)state;
+    cJSON *root = NULL;
+
+    test_agt.enrollment_cfg = &test_enrollment;
+    test_enrollment.enabled = false;
+
+    cJSON *enrollment = cJSON_GetObjectItem(get_agent_section(&root), "enrollment");
+
+    assert_non_null(enrollment);
+    assert_string_field(enrollment, "enabled", "no");
+    assert_number_field(enrollment, "port", 1515);
+    assert_null(cJSON_GetObjectItem(enrollment, "manager_address"));
+    assert_null(cJSON_GetObjectItem(enrollment, "interface_index"));
+    assert_null(cJSON_GetObjectItem(enrollment, "agent_name"));
+    assert_null(cJSON_GetObjectItem(enrollment, "group"));
+    assert_null(cJSON_GetObjectItem(enrollment, "server_certificate_path"));
+    assert_null(cJSON_GetObjectItem(enrollment, "agent_certificate_path"));
+    assert_null(cJSON_GetObjectItem(enrollment, "agent_key_path"));
+    assert_null(cJSON_GetObjectItem(enrollment, "authorization_pass_path"));
+
+    cJSON_Delete(root);
+}
+
+static void test_omits_enrollment_when_unset(void **state)
+{
+    (void)state;
+    cJSON *root = NULL;
+
+    assert_null(cJSON_GetObjectItem(get_agent_section(&root), "enrollment"));
+
+    cJSON_Delete(root);
+}
+
+static void test_reports_every_configured_ssl_field(void **state)
+{
+    (void)state;
+    cJSON *root = NULL;
+
+    test_agt.ssl.verification_mode = AGENT_VERIFY_CERT;
+    test_agt.ssl.certificate = "etc/agent.cert";
+    test_agt.ssl.key = "etc/agent.key";
+    test_agt.ssl.certificate_authorities = "etc/root-ca.pem";
+    test_agt.ssl.ciphers = "TLS_AES_256_GCM_SHA384";
+
+    cJSON *ssl = cJSON_GetObjectItem(get_agent_section(&root), "ssl");
+
+    assert_non_null(ssl);
+    assert_string_field(ssl, "verification_mode", "certificate");
+    assert_string_field(ssl, "certificate", "etc/agent.cert");
+    assert_string_field(ssl, "key", "etc/agent.key");
+    assert_string_field(ssl, "certificate_authorities", "etc/root-ca.pem");
+    assert_string_field(ssl, "ciphers", "TLS_AES_256_GCM_SHA384");
+
+    cJSON_Delete(root);
+}
+
+/* An agent with no <ssl> block still runs with a posture, so the block is still
+ * reported -- with the optional paths absent rather than empty. */
+static void test_reports_default_ssl_posture(void **state)
+{
+    (void)state;
+    cJSON *root = NULL;
+
+    cJSON *ssl = cJSON_GetObjectItem(get_agent_section(&root), "ssl");
+
+    assert_non_null(ssl);
+    assert_string_field(ssl, "verification_mode", "none");
+    assert_null(cJSON_GetObjectItem(ssl, "certificate"));
+    assert_null(cJSON_GetObjectItem(ssl, "key"));
+    assert_null(cJSON_GetObjectItem(ssl, "certificate_authorities"));
+    assert_null(cJSON_GetObjectItem(ssl, "ciphers"));
+
+    cJSON_Delete(root);
+}
+
+static void test_reports_full_verification_mode(void **state)
+{
+    (void)state;
+    cJSON *root = NULL;
+
+    test_agt.ssl.verification_mode = AGENT_VERIFY_FULL;
+
+    assert_string_field(cJSON_GetObjectItem(get_agent_section(&root), "ssl"), "verification_mode", "full");
+
+    cJSON_Delete(root);
+}
+
+static void test_reports_configured_batch_limits(void **state)
+{
+    (void)state;
+    cJSON *root = NULL;
+
+    test_agt.batch.size = 2097152;
+    test_agt.batch.interval = 15;
+
+    cJSON *batch = cJSON_GetObjectItem(get_agent_section(&root), "batch");
+
+    assert_non_null(batch);
+    assert_number_field(batch, "size", 2097152);
+    assert_number_field(batch, "interval", 15);
+
+    cJSON_Delete(root);
+}
+
+/* Unconfigured is the pair ClientConf() seeds, and it is what both readers of <size>
+ * apply: 1 MiB for a /stateless request and for one sync session. */
+static void test_reports_seeded_batch_defaults(void **state)
+{
+    (void)state;
+    cJSON *root = NULL;
+
+    cJSON *batch = cJSON_GetObjectItem(get_agent_section(&root), "batch");
+
+    assert_non_null(batch);
+    assert_number_field(batch, "size", 1048576);
+    assert_number_field(batch, "interval", 10);
+
+    cJSON_Delete(root);
+}
+
+static void test_reports_both_periodic_pushes(void **state)
+{
+    (void)state;
+    cJSON *root = NULL;
+
+    cJSON *section = get_agent_section(&root);
+    cJSON *stats = cJSON_GetObjectItem(section, "stats_report");
+    cJSON *config = cJSON_GetObjectItem(section, "config_report");
+
+    assert_non_null(stats);
+    assert_string_field(stats, "enabled", "no");
+    assert_number_field(stats, "interval", 60);
+
+    assert_non_null(config);
+    assert_string_field(config, "enabled", "yes");
+    assert_number_field(config, "interval", 3600);
+
+    cJSON_Delete(root);
+}
+
+static void test_no_config_returns_null(void **state)
+{
+    (void)state;
+
+    agt = NULL;
+
+    assert_null(getAgentConfig());
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_reports_every_section, setup_agent, teardown_agent),
+        cmocka_unit_test_setup_teardown(test_reports_scalars_and_flags, setup_agent, teardown_agent),
+        cmocka_unit_test_setup_teardown(test_reports_disabled_flags_as_no, setup_agent, teardown_agent),
+        cmocka_unit_test_setup_teardown(test_reports_every_manager, setup_agent, teardown_agent),
+        cmocka_unit_test_setup_teardown(test_omits_manager_without_servers, setup_agent, teardown_agent),
+        cmocka_unit_test_setup_teardown(test_reports_enrollment_with_every_optional_field, setup_agent, teardown_agent),
+        cmocka_unit_test_setup_teardown(test_reports_enrollment_without_optional_fields, setup_agent, teardown_agent),
+        cmocka_unit_test_setup_teardown(test_omits_enrollment_when_unset, setup_agent, teardown_agent),
+        cmocka_unit_test_setup_teardown(test_reports_every_configured_ssl_field, setup_agent, teardown_agent),
+        cmocka_unit_test_setup_teardown(test_reports_default_ssl_posture, setup_agent, teardown_agent),
+        cmocka_unit_test_setup_teardown(test_reports_full_verification_mode, setup_agent, teardown_agent),
+        cmocka_unit_test_setup_teardown(test_reports_configured_batch_limits, setup_agent, teardown_agent),
+        cmocka_unit_test_setup_teardown(test_reports_seeded_batch_defaults, setup_agent, teardown_agent),
+        cmocka_unit_test_setup_teardown(test_reports_both_periodic_pushes, setup_agent, teardown_agent),
+        cmocka_unit_test_setup_teardown(test_no_config_returns_null, setup_agent, teardown_agent),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/config/test_client-config_https.c
+++ b/src/unit_tests/config/test_client-config_https.c
@@ -612,7 +612,7 @@ static void test_fresh_install_template_shape(void **state) {
     assert_int_equal(cfg.server[0].port, DEFAULT_HTTPS_REMOTE_PORT);
     assert_string_equal(cfg.profile, "debian, debian8");
     assert_int_equal(cfg.notify_time, 0);        /* ClientConf turns 0 into NOTIFY_TIME. */
-    assert_int_equal(cfg.batch.size, 0);         /* Module default (1 MiB / 5 MiB). */
+    assert_int_equal(cfg.batch.size, 0);         /* Reported and applied as 1 MiB. */
     assert_int_equal(cfg.batch.interval, 0);     /* ClientConf turns 0 into 10 s. */
 
     cleanup(&xml, nodes, &cfg);

--- a/src/unit_tests/config/test_client-config_https.c
+++ b/src/unit_tests/config/test_client-config_https.c
@@ -613,7 +613,7 @@ static void test_fresh_install_template_shape(void **state) {
     assert_string_equal(cfg.profile, "debian, debian8");
     assert_int_equal(cfg.notify_time, 0);        /* ClientConf turns 0 into NOTIFY_TIME. */
     assert_int_equal(cfg.batch.size, 0);         /* Module default (1 MiB / 5 MiB). */
-    assert_int_equal(cfg.batch.interval, 0);
+    assert_int_equal(cfg.batch.interval, 0);     /* ClientConf turns 0 into 10 s. */
 
     cleanup(&xml, nodes, &cfg);
 }


### PR DESCRIPTION
## Description

The agent's configuration report leaves out two of the blocks it actually runs with. `getAgentConfig()` (`src/client-agent/src/config.c`) never reads `agt->ssl` or `agt->batch`, even though both are parsed (`Read_Agent_SSL`, `Read_Agent_Batch`) and applied by the transport bridge, so `<agent><ssl>` and `<agent><batch>` are missing from `getconfig agent`, from `getallconfig`, and therefore from the periodic `/config` push and the `wazuh-agent-config` document the Server API reads.

The indexer's `wazuh-agent-config` template (`plugins/setup/src/main/resources/templates/states/agent-config.json`) already declares both blocks under `content.agent.agent`, so the field names and types were settled by the contract; only the agent was not filling them in.

Closes #38398

## Proposed Changes

- **Report `<ssl>`** — `src/client-agent/src/config.c`: `getAgentConfig()` now emits an `ssl` object carrying `verification_mode` plus `certificate`, `key`, `certificate_authorities` and `ciphers`. The block is always present, because `verification_mode` always has a value (`ClientConf()` defaults it to `none`); the four optional strings follow the function's existing convention and appear only when configured. A small `w_agent_verify_mode_str()` maps `agent_verify_mode_t` back to the XML vocabulary (`full` / `certificate` / `none`), so the document reads like the block it came from.
- **Report `<batch>`** — same function: a `batch` object with `size` (bytes) and `interval` (seconds).
- **Report the `<batch>` defaults in force** — `ClientConf()` seeds `interval` with its effective default (10 s), the same way #38367 seeded the two report intervals. `size` is not seeded: it is expanded at report time, `agt->batch.size > 0 ? agt->batch.size : DEFAULT_BATCH_SIZE_BYTES`, so an agent with no `<batch>` block reports the cap actually in force without `agt` claiming the option was configured. The new `DEFAULT_BATCH_SIZE_BYTES` lives in `src/config/include/client-config.h` next to the other client defaults.
- **One `<batch><size>` default agent-wide** — `FULLSESSION_MAX_BYTES` in `shared_modules/sync_protocol/include/agent_sync_protocol.hpp` goes from 5 MiB to 1 MiB, matching what the HTTPS transport already applied to a `/stateless` request for the same unset option (`https_client/src/moduleConfig.cpp:44`).

Practical effect on an agent that never configured `<batch>`: one inventory sync session is now bounded at 1 MiB instead of 5 MiB, so a large first inventory is split across more sessions. The per-session block ceiling (`FULLSESSION_MAX_BLOCKS_PER_SYNC`) and the prefilter grace (64 KiB) are unchanged.

### Results and Evidence

Agent `agent-ubuntu24-arm` (Ubuntu 24.04, arm64), built from sources on this branch with a 5.0.0 AIO manager at `192.168.18.238`.

`/var/ossec/etc/ossec.conf`, blocks configured with default values:

```xml
  <agent>
    <server>
      <address>192.168.18.238</address>
      <port>1517</port>
    </server>
    <config-profile>ubuntu, ubuntu24, ubuntu24.04</config-profile>
  </agent>
```

```bash
root@aio-ubuntu-arm:~# curl -sk -u admin:admin "https://127.0.0.1:9200/wazuh-agent-config/_doc/001?pretty"
{
  "_index" : "wazuh-agent-config",
  "_id" : "001",
  "_version" : 8,
  "_seq_no" : 7,
  "_primary_term" : 31,
  "found" : true,
  "_source" : {
    "state" : {
      "document_version" : 1,
      "modified_at" : "2026-08-18T18:05:22.747Z"
    },
    "wazuh" : {
      "agent" : {
        "configuration" : {
          "content" : {
            "agent" : {
              "agent" : {
                "auto_restart" : "yes",
                "batch" : {
                  "interval" : 10,
                  "size" : 1048576
                },
                "config-profile" : "ubuntu, ubuntu24, ubuntu24.04",
                "config_report" : {
                  "enabled" : "yes",
                  "interval" : 3600
                },
                "enrollment" : {
                  "delay_after_enrollment" : 20,
                  "enabled" : "yes",
                  "port" : 1515,
                  "ssl_cipher" : "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256"
                },
                "ip_update_interval" : 0,
                "manager" : [
                  {
                    "address" : "192.168.18.238",
                    "max_retries" : 5,
                    "port" : 1517,
                    "retry_interval" : 10
                  }
                ],
                "notify_time" : 10,
                "remote_conf" : "yes",
                "ssl" : {
                  "verification_mode" : "none"
                },
                "stats_report" : {
                  "enabled" : "no",
                  "interval" : 60
                },
                "time-reconnect" : 60
              },
 ...
```

`/var/ossec/etc/ossec.conf`, blocks configured with non-default values:

```xml
  <agent>
    <server>
      <address>192.168.18.238</address>
      <port>1517</port>
    </server>
    <config-profile>ubuntu, ubuntu24, ubuntu24.04</config-profile>

    <ssl>
      <verification_mode>none</verification_mode>
      <certificate_authorities>/var/ossec/etc/manager-ca.pem</certificate_authorities>
      <ciphers>TLS_AES_256_GCM_SHA384</ciphers>
    </ssl>
    <batch>
      <size>2MB</size>
      <interval>15s</interval>
    </batch>

  </agent>
```

```bash
root@aio-ubuntu-arm:~# curl -sk -u admin:admin "https://127.0.0.1:9200/wazuh-agent-config/_doc/001?pretty"
{
  "_index" : "wazuh-agent-config",
  "_id" : "001",
  "_version" : 7,
  "_seq_no" : 6,
  "_primary_term" : 4,
  "found" : true,
  "_source" : {
    "state" : {
      "document_version" : 1,
      "modified_at" : "2026-08-18T17:26:16.406Z"
    },
    "wazuh" : {
      "agent" : {
        "configuration" : {
          "content" : {
            "agent" : {
              "agent" : {
                "auto_restart" : "yes",
                "batch" : {
                  "interval" : 15,
                  "size" : 2097152
                },
                "config-profile" : "ubuntu, ubuntu24, ubuntu24.04",
                "config_report" : {
                  "enabled" : "yes",
                  "interval" : 3600
                },
                "enrollment" : {
                  "delay_after_enrollment" : 20,
                  "enabled" : "yes",
                  "port" : 1515,
                  "ssl_cipher" : "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256"
                },
                "ip_update_interval" : 0,
                "manager" : [
                  {
                    "address" : "192.168.18.238",
                    "max_retries" : 5,
                    "port" : 1517,
                    "retry_interval" : 10
                  }
                ],
                "notify_time" : 10,
                "remote_conf" : "yes",
                "ssl" : {
                  "certificate_authorities" : "/var/ossec/etc/manager-ca.pem",
                  "ciphers" : "TLS_AES_256_GCM_SHA384",
                  "verification_mode" : "none"
                },
                "stats_report" : {
                  "enabled" : "no",
                  "interval" : 60
                },
                "time-reconnect" : 60
              },
...
```

### Artifacts Affected

`wazuh-agentd` on every platform. The `FULLSESSION_MAX_BYTES` change reaches `wazuh-modulesd` and `wazuh-syscheckd` on Linux and macOS, and the single agent process on Windows.

### Configuration Changes

None.

### Documentation Updates

None required.

### Tests Introduced

`src/unit_tests/client-agent/test_agent_config.c` (new, plus its target in `src/unit_tests/client-agent/CMakeLists.txt`). It covers the whole of `getAgentConfig()` in 15 cases:

- The reported section carries exactly the twelve expected keys — the guard against another block going missing.
- Scalars and flags: `config-profile`, `notify_time`, `time-reconnect`, `ip_update_interval`, `auto_restart`, `remote_conf`, including their `no` form and an absent `config-profile`.
- `manager[]`: every server with its port and retry settings, `interface_index` only on the entry that has one, and the whole array omitted when no server is configured.
- `enrollment`: every optional field reported when set, all of them absent when unset, and the object omitted when there is no enrollment configuration.
- `ssl`: every configured field including the mTLS pair; the default posture with the four optional strings absent; `verification_mode` mapping to `full`, `certificate` and `none`.
- `batch`: the configured limits, and the pair `ClientConf()` seeds (1 MiB, 10 s) when nothing is configured.
- `stats_report` / `config_report`: both objects with their enabled flag and interval.
- A null `agt` still returns `NULL`.

`shared_modules/sync_protocol` keeps its own suite green with the new default; its three hard-coded 5 MiB constants were updated with it.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
