### PR TITLE
Fix timeout waiting for SCA to complete shutdown

### DIFF
--- a/src/wazuh_modules/src/wm_sca.c
+++ b/src/wazuh_modules/src/wm_sca.c
@@ -14,6 +14,7 @@
 #include "wmodules.h"
 #include "module_query_errors.h"
 #include "os_net.h"
+#include <csignal>
 #include <sys/stat.h>
 #include "sha256_op.h"
 #include "expression.h"
@@ -899,6 +900,10 @@ int wm_sca_sync_message(const char *command, size_t command_len) {
 DWORD WINAPI wm_sca_sync_module(__attribute__((unused)) void * args) {
 #else
 void * wm_sca_sync_module(__attribute__((unused)) void * args) {
+    sigset_t sigset;
+    sigemptyset(&sigset);
+    sigaddset(&sigset, SIGTERM);
+    pthread_sigmask(SIG_BLOCK, &sigset, NULL);
 #endif
     bool first_sync_completed = false;
     bool wait_before_sync = true;

--- a/src/wazuh_modules/src/wm_sca.c
+++ b/src/wazuh_modules/src/wm_sca.c
@@ -14,7 +14,7 @@
 #include "wmodules.h"
 #include "module_query_errors.h"
 #include "os_net.h"
-#include <csignal>
+#include <signal.h>
 #include <sys/stat.h>
 #include "sha256_op.h"
 #include "expression.h"

--- a/src/wazuh_modules/src/wm_syscollector.c
+++ b/src/wazuh_modules/src/wm_syscollector.c
@@ -8,7 +8,7 @@
  * License (version 2) as published by the FSF - Free Software
  * Foundation.
  */
-#include <csignal>
+#include <signal.h>
 #include <stdlib.h>
 #include "wmodules_def.h"
 #include "syscollector.h"

--- a/src/wazuh_modules/src/wm_syscollector.c
+++ b/src/wazuh_modules/src/wm_syscollector.c
@@ -8,6 +8,7 @@
  * License (version 2) as published by the FSF - Free Software
  * Foundation.
  */
+#include <csignal>
 #include <stdlib.h>
 #include "wmodules_def.h"
 #include "syscollector.h"
@@ -976,6 +977,10 @@ DWORD WINAPI wm_sync_module(__attribute__((unused)) void* args)
 #else
 void* wm_sync_module(__attribute__((unused)) void* args)
 {
+    sigset_t sigset;
+    sigemptyset(&sigset);
+    sigaddset(&sigset, SIGTERM);
+    pthread_sigmask(SIG_BLOCK, &sigset, NULL);
 #endif
     bool first_sync_completed = false;
     bool wait_before_sync = true;


### PR DESCRIPTION
## Description

`wazuh-modulesd` installs its SIGTERM/SIGINT/SIGHUP handler process-wide in `wm_signals_configure()` (`src/wazuh_modules/src/main.c:138`), before any module thread is spawned (`main.c:156-164`). The handler itself, `wm_handler()` (`main.c:324`), runs the orderly shutdown: it calls every module's `stop()` callback synchronously (`main.c:354-358`) and then `pthread_timedjoin_np()`s every module thread against a shared 30s deadline (`main.c:363-380`).

POSIX delivers a process-directed signal like SIGTERM to any thread in the process that has it unblocked, not necessarily the main thread. Threads inherit their creator's signal mask, and since the main thread never blocks SIGTERM, every thread spawned afterwards (including each module's own worker threads) is also eligible to receive it.

`wm_sca_sync_module()` (`src/wazuh_modules/src/wm_sca.c:902`) and `wm_sync_module()` (`src/wazuh_modules/src/wm_syscollector.c`) are the periodic DBSync threads for SCA and Syscollector. Neither blocked SIGTERM at startup. When the kernel happened to route the shutdown SIGTERM to one of these threads instead of the main thread, `wm_handler()` ran on that same worker thread, calling the module's own `stop()` (e.g. `wm_sca_stop()`, `wm_sca.c:745`) from inside the very thread that was supposed to finish its teardown and release `sca_stop_condition`. That thread was now stuck inside the signal handler instead of running its normal loop, so:

- `wm_sca_stop()`'s `pthread_cond_timedwait()` (`wm_sca.c:775-782`) could never be satisfied and timed out after its own 10s budget, logging `Timeout waiting for SCA to complete shutdown.` (`wm_sca.c:779`).
- `main.c`'s `pthread_timedjoin_np()` loop then also failed to cleanly join that thread, logging `Module 'sca' did not stop within the shutdown timeout. (rc=35: Resource deadlock avoided)` (`main.c:374`).

This matches the exact log sequence reported in the issue.

Closes #38065

## Proposed Changes

Block SIGTERM at the start of both sync threads, right after they're spawned:

```c
sigset_t sigset;
sigemptyset(&sigset);
sigaddset(&sigset, SIGTERM);
pthread_sigmask(SIG_BLOCK, &sigset, NULL);
```

- `src/wazuh_modules/src/wm_sca.c` — `wm_sca_sync_module()`
- `src/wazuh_modules/src/wm_syscollector.c` — `wm_sync_module()`

With SIGTERM blocked in these threads, the kernel can no longer route the shutdown signal to them, so `wm_handler()` always runs on the main thread as intended, and the module's own stop/join sequence is never re-entered from within itself.

`<signal.h>` is used instead of `<csignal>` since both files are plain C translation units (`.c`), not C++.

### Results and Evidence

Root cause traced from the reported log sequence and the source directly (see Description above); no VM reproduction was run for this PR. The original report's log excerpt is the evidence for the failure mode this fixes:

```
2026/07/29 04:38:09 wazuh-modulesd:sca: INFO: SCA module stopped.
2026/07/29 04:38:19 wazuh-modulesd:sca: WARNING: Timeout waiting for SCA to complete shutdown.
2026/07/29 04:38:19 wazuh-modulesd: WARNING: Module 'sca' did not stop within the shutdown timeout. (rc=35: Resource deadlock avoided)
```

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

N/A

### Configuration Changes

N/A

### Tests Introduced

N/A

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
