### PR TITLE
Fix timeout waiting for SCA to complete shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,4 +133,5 @@
 | [#37993](https://github.com/wazuh/wazuh/issues/37993) | Fixed `wazuh-syscheckd` failing the `file_entry.checksum` NOT NULL constraint when the deferred sync-flag update ran for an entry deleted during the scan. |
 | [#37993](https://github.com/wazuh/wazuh/issues/37993) | Fixed `wazuh-syscheckd` failure on shutdown, which logged "Invalid handle value", crashed the process and left a stale PID file. |
 | [#38163](https://github.com/wazuh/wazuh/issues/38163) | Fixed `wazuh-agentd` crashing on start when the agent metadata segment could only be opened read-only, which happens whenever a root process creates it before the daemon drops privileges. |
+| [#38065](https://github.com/wazuh/wazuh/issues/38065) | Fixed SCA and Syscollector sync threads not blocking `SIGTERM`, which could cause the shutdown handler to run on a module thread instead of the main thread and time out joining it. |
 

--- a/src/wazuh_modules/src/wm_sca.c
+++ b/src/wazuh_modules/src/wm_sca.c
@@ -14,6 +14,7 @@
 #include "wmodules.h"
 #include "module_query_errors.h"
 #include "os_net.h"
+#include <csignal>
 #include <sys/stat.h>
 #include "sha256_op.h"
 #include "expression.h"
@@ -899,6 +900,10 @@ int wm_sca_sync_message(const char *command, size_t command_len) {
 DWORD WINAPI wm_sca_sync_module(__attribute__((unused)) void * args) {
 #else
 void * wm_sca_sync_module(__attribute__((unused)) void * args) {
+    sigset_t sigset;
+    sigemptyset(&sigset);
+    sigaddset(&sigset, SIGTERM);
+    pthread_sigmask(SIG_BLOCK, &sigset, NULL);
 #endif
     bool first_sync_completed = false;
     bool wait_before_sync = true;

--- a/src/wazuh_modules/src/wm_sca.c
+++ b/src/wazuh_modules/src/wm_sca.c
@@ -14,7 +14,7 @@
 #include "wmodules.h"
 #include "module_query_errors.h"
 #include "os_net.h"
-#include <csignal>
+#include <signal.h>
 #include <sys/stat.h>
 #include "sha256_op.h"
 #include "expression.h"

--- a/src/wazuh_modules/src/wm_syscollector.c
+++ b/src/wazuh_modules/src/wm_syscollector.c
@@ -8,7 +8,7 @@
  * License (version 2) as published by the FSF - Free Software
  * Foundation.
  */
-#include <csignal>
+#include <signal.h>
 #include <stdlib.h>
 #include "wmodules_def.h"
 #include "syscollector.h"

--- a/src/wazuh_modules/src/wm_syscollector.c
+++ b/src/wazuh_modules/src/wm_syscollector.c
@@ -8,6 +8,7 @@
  * License (version 2) as published by the FSF - Free Software
  * Foundation.
  */
+#include <csignal>
 #include <stdlib.h>
 #include "wmodules_def.h"
 #include "syscollector.h"
@@ -976,6 +977,10 @@ DWORD WINAPI wm_sync_module(__attribute__((unused)) void* args)
 #else
 void* wm_sync_module(__attribute__((unused)) void* args)
 {
+    sigset_t sigset;
+    sigemptyset(&sigset);
+    sigaddset(&sigset, SIGTERM);
+    pthread_sigmask(SIG_BLOCK, &sigset, NULL);
 #endif
     bool first_sync_completed = false;
     bool wait_before_sync = true;


### PR DESCRIPTION
## Description

This PR fixes a rare shutdown deadlock in `wazuh-modulesd`. Backport of #38421 to `5.0.0`.

`wazuh-modulesd` installs its SIGTERM/SIGINT/SIGHUP handler process-wide in `wm_signals_configure()` (`src/wazuh_modules/src/main.c:138`), before any module thread is spawned. The handler itself, `wm_handler()` (`main.c:324`), runs the orderly shutdown: it calls every module's `stop()` callback synchronously and then `pthread_timedjoin_np()`s every module thread against a shared 30s deadline.

POSIX delivers a process-directed signal like SIGTERM to any thread in the process that has it unblocked, not necessarily the main thread. Threads inherit their creator's signal mask, and since the main thread never blocks SIGTERM, every thread spawned afterwards (including each module's own worker threads) is also eligible to receive it.

`wm_sca_sync_module()` (`src/wazuh_modules/src/wm_sca.c:902`) and `wm_sync_module()` (`src/wazuh_modules/src/wm_syscollector.c`) are the periodic DBSync threads for SCA and Syscollector. Neither blocked SIGTERM at startup. When the kernel happened to route the shutdown SIGTERM to one of these threads instead of the main thread, `wm_handler()` ran on that same worker thread, calling the module's own `stop()` from inside the very thread that was supposed to finish its teardown. That thread was now stuck inside the signal handler instead of running its normal loop, so the module's own stop/join sequence could never complete, and `main.c`'s `pthread_timedjoin_np()` loop also failed to cleanly join it, logging `Module 'sca' did not stop within the shutdown timeout. (rc=35: Resource deadlock avoided)`.

This matches the exact log sequence reported in the issue.

**Proposed Release:** 5.0.0
**Issue:** wazuh/wazuh#38065
**Internal Reference:** N/A

## Proposed Changes

- Updated `src/wazuh_modules/src/wm_sca.c`: block SIGTERM at the start of `wm_sca_sync_module()`.
- Updated `src/wazuh_modules/src/wm_syscollector.c`: block SIGTERM at the start of `wm_sync_module()`.
- Added the corresponding `CHANGELOG.md` entry under Agent / Fixed for `5.0.0`.

```c
sigset_t sigset;
sigemptyset(&sigset);
sigaddset(&sigset, SIGTERM);
pthread_sigmask(SIG_BLOCK, &sigset, NULL);
```

With SIGTERM blocked in these threads, the kernel can no longer route the shutdown signal to them, so `wm_handler()` always runs on the main thread as intended, and the module's own stop/join sequence is never re-entered from within itself.

`<signal.h>` is used instead of `<csignal>` since both files are plain C translation units (`.c`), not C++.

### Results and Evidence

The changes were validated in two environments: root cause traced from the reported log directly, and the fix reproduced/verified on a real legacy-glibc VM.

Original reported log (`wazuh-modulesd`, agent):

```sql
2026/07/29 04:38:09 wazuh-modulesd:sca: INFO: SCA module stopped.
2026/07/29 04:38:19 wazuh-modulesd:sca: WARNING: Timeout waiting for SCA to complete shutdown.
2026/07/29 04:38:19 wazuh-modulesd: WARNING: Module 'sca' did not stop within the shutdown timeout. (rc=35: Resource deadlock avoided)
```

Also reproduced the failure mode deterministically on a CentOS 7 VM (glibc 2.17, same family as Oracle Linux 7 from the original report), with a minimal harness mirroring the exact thread relationship and signal-handling code from this codebase: a worker thread joined by its own module's main thread, plus a SIGTERM handler doing the same `pthread_timedjoin_np()` with a shared deadline as `wm_handler()`. `pthread_kill()` targets the worker thread directly so the race is deterministic instead of depending on the kernel's arbitrary thread selection.

```bash
# Before (no fix), 10 runs:
for i in $(seq 1 10); do ./repro; done
RESULT handler_ran_on=worker join(t_sca) rc=35 (Resource deadlock avoided)
# ... 10/10 runs

# After (this PR's fix), same 10 runs:
for i in $(seq 1 10); do ./repro; done
NO_DEADLOCK: pthread_join(worker) returned rc=110 (Connection timed out) -- handler never fired on worker
# ... 10/10 runs
```

The handler never runs on the worker thread once SIGTERM is blocked there, so the mutual-join path to EDEADLK never triggers. On modern glibc (2.39, Ubuntu 24.04) the same before-fix scenario returns `ETIMEDOUT` instead of `EDEADLK`: same underlying race, less visible symptom, consistent with this only being reported on legacy-glibc platforms.

### Artifacts Affected

- `src/wazuh_modules/src/wm_sca.c`
- `src/wazuh_modules/src/wm_syscollector.c`
- `CHANGELOG.md`

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Manual reproduction (deterministic signal-race harness on a real legacy-glibc VM).
- **Details:** Verified that forcing SIGTERM onto the module's sync worker thread while the main thread is blocked joining it no longer triggers `EDEADLK`, on 10/10 runs, with the fix applied.

## Review Checklist

**Manual tests with their corresponding evidence:**

- Compilation without warnings on every supported platform

  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X

- [ ] Log syntax and correct language review

- Memory tests for Linux

  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

**General Checklist:**

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
