### PR TITLE
Bound the control message copy to the source string length in remoted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## [v4.14.9]
 
+### Manager
+
+#### Fixed
+
+- Bounded the agent control message copy to the source string length in `wazuh-remoted`. ([#38427](https://github.com/wazuh/wazuh/pull/38427))
+
 ### Agent
 
 #### Fixed

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -886,7 +886,8 @@ STATIC void HandleSecureMessage(const message_t *message, w_indexed_queue_t * co
 
                 os_calloc(msg_length, sizeof(char), ctrl_msg_data->message);
                 // Use cleaned message from validation if available, otherwise use original
-                memcpy(ctrl_msg_data->message, cleaned_msg ? cleaned_msg : tmp_msg, tmp_msg_length);
+                const char * src_msg = cleaned_msg ? cleaned_msg : tmp_msg;
+                memcpy(ctrl_msg_data->message, src_msg, strnlen(src_msg, tmp_msg_length));
 
                 // Store validation results in the control message data structure
                 ctrl_msg_data->is_startup = is_startup;

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -639,6 +639,99 @@ void test_HandleSecureMessage_shutdown_message(void** state)
     indexed_queue_free(control_msg_queue);
 }
 
+void test_HandleSecureMessage_shutdown_message_embedded_null(void** state)
+{
+    char buffer[OS_MAXSTR + 1] = "#!-agent shutdown ";
+    message_t message = {.buffer = buffer, .size = 18, .sock = 1, .counter = 10};
+    struct sockaddr_in peer_info;
+    w_indexed_queue_t * control_msg_queue = indexed_queue_init(10);
+
+    /* Decrypted payload holding trailing bytes after its string terminator */
+    char decrypted[64] = "#!-agent shutdown ";
+    memset(decrypted + 19, 'A', 32);
+    const size_t decrypted_length = 51;
+    const size_t body_length = decrypted_length - 3;
+    const size_t body_strlen = strlen("agent shutdown ");
+
+    keyentry** keyentries;
+    os_calloc(1, sizeof(keyentry*), keyentries);
+    keys.keyentries = keyentries;
+
+    keyentry* key = NULL;
+    os_calloc(1, sizeof(keyentry), key);
+
+    key->id = strdup("009");
+    key->name = strdup("test_agent");
+    key->sock = 1;
+    key->keyid = 1;
+
+    keys.keyentries[0] = key;
+
+    global_counter = 0;
+
+    peer_info.sin_family = AF_INET;
+    peer_info.sin_addr.s_addr = 0x0100007F;
+    memcpy(&message.addr, &peer_info, sizeof(peer_info));
+
+    expect_function_call(__wrap_key_lock_read);
+
+    expect_string(__wrap_OS_IsAllowedIP, srcip, "127.0.0.1");
+    will_return(__wrap_OS_IsAllowedIP, 0);
+
+    expect_value(__wrap_ReadSecMSG, keys, &keys);
+    expect_string(__wrap_ReadSecMSG, buffer, "#!-agent shutdown ");
+    expect_value(__wrap_ReadSecMSG, id, 0);
+    expect_string(__wrap_ReadSecMSG, srcip, "127.0.0.1");
+    will_return(__wrap_ReadSecMSG, decrypted_length);
+    will_return(__wrap_ReadSecMSG, decrypted);
+    will_return(__wrap_ReadSecMSG, KS_VALID);
+
+    expect_value(__wrap_rem_getCounter, fd, 1);
+    will_return(__wrap_rem_getCounter, 10);
+
+    // OS_DupKeyEntry
+    expect_value(__wrap_OS_DupKeyEntry, key, key);
+    will_return(__wrap_OS_DupKeyEntry, key);
+
+    expect_value(__wrap_rem_getCounter, fd, 1);
+    will_return(__wrap_rem_getCounter, 10);
+
+    expect_function_call(__wrap_key_unlock);
+
+    expect_string(__wrap_rem_inc_recv_ctrl, agent_id, key->id);
+
+    // Should be added to the queue
+    expect_value(__wrap_validate_control_msg, key, key);
+    expect_string(__wrap_validate_control_msg, r_msg, "agent shutdown ");
+    expect_value(__wrap_validate_control_msg, msg_length, body_length);
+    will_return(__wrap_validate_control_msg, 1);
+
+    // OS_FreeKey
+    expect_value(__wrap_OS_FreeKey, key, key);
+
+    HandleSecureMessage(&message, control_msg_queue);
+
+    // Expect the control message to be added to the queue
+    w_ctrl_msg_data_t * node = indexed_queue_pop(control_msg_queue);
+    assert_non_null(node);
+    assert_string_equal(node->message, "agent shutdown ");
+
+    // Only the string is copied, the trailing bytes are not
+    for (size_t i = body_strlen; i < body_length; i++) {
+        assert_int_equal(node->message[i], '\0');
+    }
+
+    OS_FreeKey(node->key);
+    os_free(node->message);
+    os_free(node);
+
+    os_free(key->id);
+    os_free(key->name);
+    os_free(key);
+    os_free(keyentries);
+    indexed_queue_free(control_msg_queue);
+}
+
 void test_HandleSecureMessage_HC_req_message(void** state)
 {
     char buffer[OS_MAXSTR + 1] = "#!-req payload";
@@ -2552,6 +2645,7 @@ int main(void)
         cmocka_unit_test(test_HandleSecureMessage_invalid_family_address_not_found),
         cmocka_unit_test(test_HandleSecureMessage_invalid_message),
         cmocka_unit_test(test_HandleSecureMessage_shutdown_message),
+        cmocka_unit_test(test_HandleSecureMessage_shutdown_message_embedded_null),
         cmocka_unit_test(test_HandleSecureMessage_HC_req_message),
         cmocka_unit_test(test_HandleSecureMessage_invalid_HC_req_message),
         cmocka_unit_test(test_HandleSecureMessage_NewMessage_NoShutdownMessage),


### PR DESCRIPTION
## Description
When `wazuh-remoted` queued an agent control message for database processing, the
`memcpy()` size came from the raw decrypted byte count while the source buffer had been
allocated from the string length of the same data, so a message carrying an embedded NUL
byte made the copy read past the end of that allocation. The fix bounds the copy with
`strnlen()`, which stops at the source's terminator and therefore never reads outside the
allocation. Well-formed messages are copied byte-for-byte as before.

## Proposed Changes
- `src/remoted/secure.c`: in `HandleSecureMessage()`, hoist the copy source into a local
  and bound the `memcpy()` length with `strnlen(src_msg, tmp_msg_length)` instead of
  passing `tmp_msg_length` directly. The destination allocation is unchanged, so the
  copied message remains NUL-terminated.
- `src/unit_tests/remoted/test_secure.c`: add
  `test_HandleSecureMessage_shutdown_message_embedded_null`, which feeds
  `HandleSecureMessage()` a decrypted payload whose reported length runs past its string
  terminator and asserts that nothing beyond the terminator is copied.

### Results and Evidence

**Out-of-bounds read confirmed under AddressSanitizer, before the fix.** The existing
CMocka suite already builds with `-fsanitize=address,undefined`. Driving the real
`HandleSecureMessage()` with an `agent shutdown ` control message whose reported length
is `OS_MAXSTR` produces:

```
ERROR: AddressSanitizer: heap-buffer-overflow on address 0x502000000500
READ of size 65533 at 0x502000000500 thread T0
    #0 memcpy
    #1 HandleSecureMessage remoted/secure.c:889

0x502000000500 is located 0 bytes after 16-byte region [0x5020000004f0,0x502000000500)
allocated by thread T0 here:
    #0 strdup
    #1 w_utf8_filter shared/utf8_op.c:81
    #3 HandleSecureMessage remoted/secure.c:862
```

65533 bytes read past a 16-byte allocation. The 16 bytes are `w_utf8_filter()`'s
`strlen + 1` result for the 15-character message; the 65533 is the raw byte count the
unpatched `memcpy` used instead.

**After the fix, ASAN reports nothing** on the same input, with the suite green:

```
grep -c 'AddressSanitizer: heap-buffer-overflow'  ->  0
[==========] tests: 52 test(s) run.
[  PASSED  ] 52 test(s).
```

**The regression test fails before the change and passes after.** It does not depend on
ASAN or on heap layout: the trailing bytes stay inside the test's own array, so the
assertion is deterministic on any allocator. Before:

```
[ RUN      ] test_HandleSecureMessage_shutdown_message_embedded_null
[  ERROR   ] --- 0x41 != 0
[   LINE   ] --- src/unit_tests/remoted/test_secure.c:721: error: Failure!
[  FAILED  ] test_HandleSecureMessage_shutdown_message_embedded_null
```

After:

```
[ RUN      ] test_HandleSecureMessage_shutdown_message_embedded_null
[       OK ] test_HandleSecureMessage_shutdown_message_embedded_null
```

**Server build is clean** from a `make clean-internals` starting point:

```
Done building server
```

**Remoted suites pass**, including the two others that exercise the control-message path:

```
1/5 Test #28: test_manager .....................   Passed
2/5 Test #29: test_secure ......................   Passed
3/5 Test #30: test_save_ctrlmsg_thread .........   Passed
4/5 Test #31: test_netbuffer ...................   Passed
5/5 Test #32: test_sendmsg .....................   Passed

100% tests passed, 0 tests failed out of 5
```

Note for reviewers: `test_remcom`, `test_remote-config`, `test_remote-state` and
`test_syslogtcp` do not link in this environment (undefined references to
`remcom_dispatch`, `w_authd_parse_agents` and similar). This reproduces identically with
the change reverted, so it is unrelated to this PR. The shipped build and the `TEST=1`
build cannot coexist in one tree, so each was verified separately.

### Artifacts Affected
`wazuh-remoted` (manager only). No agent-side component is affected.

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
`test_HandleSecureMessage_shutdown_message_embedded_null` in
`src/unit_tests/remoted/test_secure.c`.

## Credits
Reported by @jh4nks.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
