### PR TITLE
Stop broadcasting token revocation to worker nodes

### DIFF
--- a/api/api/controllers/security_controller.py
+++ b/api/api/controllers/security_controller.py
@@ -20,7 +20,6 @@ from api.models.security_model import (CreateUserModel, PolicyModel, RoleModel,
                                        RuleModel, UpdateUserModel)
 from api.util import parse_api_param, raise_if_exc, remove_nones_to_dict
 from wazuh import security
-from wazuh.core.cluster.control import get_system_nodes_or_none
 from wazuh.core.cluster.dapi.dapi import DistributedAPI
 from wazuh.core.exception import WazuhException, WazuhPermissionError
 from wazuh.core.results import AffectedItemsWazuhResult, WazuhResult
@@ -1159,16 +1158,13 @@ async def revoke_all_tokens(pretty: bool = False) -> ConnexionResponse:
     """
     f_kwargs = {}
 
-    nodes = await get_system_nodes_or_none()
     dapi = DistributedAPI(f=security.wrapper_revoke_tokens,
                           f_kwargs=remove_nones_to_dict(f_kwargs),
-                          request_type='distributed_master' if nodes is not None else 'local_any',
+                          request_type='local_master',
                           is_async=False,
-                          broadcasting=nodes is not None,
                           wait_for_complete=True,
                           logger=logger,
-                          rbac_permissions=request.context['token_info']['rbac_policies'],
-                          nodes=nodes
+                          rbac_permissions=request.context['token_info']['rbac_policies']
                           )
     data = raise_if_exc(await dapi.distribute_function())
     if type(data) == AffectedItemsWazuhResult and len(data.affected_items) == 0:
@@ -1209,15 +1205,16 @@ async def get_security_config(pretty: bool = False, wait_for_complete: bool = Fa
 
 
 async def security_revoke_tokens():
-    """Revokes all tokens on all nodes after a change in security configuration."""
-    nodes = await get_system_nodes_or_none()
+    """Revokes all tokens after a change in security configuration.
+
+    Tokens only exist on the master node, since the API daemon does not run on
+    worker nodes and their RBAC database is never initialized.
+    """
     dapi = DistributedAPI(f=revoke_tokens,
-                          request_type='distributed_master' if nodes is not None else 'local_any',
+                          request_type='local_master',
                           is_async=False,
                           wait_for_complete=True,
-                          broadcasting=nodes is not None,
-                          logger=logger,
-                          nodes=nodes
+                          logger=logger
                           )
     raise_if_exc(await dapi.distribute_function())
 

--- a/api/api/controllers/test/test_security_controller.py
+++ b/api/api/controllers/test/test_security_controller.py
@@ -897,25 +897,21 @@ async def test_get_rbac_actions(mock_exc, mock_dapi, mock_remove, mock_dfunc, mo
 @patch('api.controllers.security_controller.remove_nones_to_dict')
 @patch('api.controllers.security_controller.DistributedAPI.__init__', return_value=None)
 @patch('api.controllers.security_controller.raise_if_exc', return_value=CustomAffectedItems())
-@pytest.mark.parametrize('mock_snodes', [None, AsyncMock()])
-async def test_revoke_all_tokens(mock_exc, mock_dapi, mock_remove, mock_dfunc, mock_snodes,
+async def test_revoke_all_tokens(mock_exc, mock_dapi, mock_remove, mock_dfunc,
                                  mock_request):
     """Verify 'revoke_all_tokens' endpoint is working as expected."""
-    with patch('api.controllers.security_controller.get_system_nodes_or_none', return_value=mock_snodes):
-        result = await revoke_all_tokens()
-        mock_dapi.assert_called_once_with(f=security.wrapper_revoke_tokens,
-                                          f_kwargs=mock_remove.return_value,
-                                          request_type='distributed_master' if mock_snodes is not None else 'local_any',
-                                          is_async=False,
-                                          broadcasting=mock_snodes is not None,
-                                          logger=ANY,
-                                          wait_for_complete=True,
-                                          rbac_permissions=mock_request.context['token_info']['rbac_policies'],
-                                          nodes=mock_snodes
-                                          )
-        mock_exc.assert_called_once_with(mock_dfunc.return_value)
-        mock_remove.assert_called_once_with({})
-        assert isinstance(result, ConnexionResponse)
+    result = await revoke_all_tokens()
+    mock_dapi.assert_called_once_with(f=security.wrapper_revoke_tokens,
+                                      f_kwargs=mock_remove.return_value,
+                                      request_type='local_master',
+                                      is_async=False,
+                                      logger=ANY,
+                                      wait_for_complete=True,
+                                      rbac_permissions=mock_request.context['token_info']['rbac_policies']
+                                      )
+    mock_exc.assert_called_once_with(mock_dfunc.return_value)
+    mock_remove.assert_called_once_with({})
+    assert isinstance(result, ConnexionResponse)
 
 
 @pytest.mark.asyncio
@@ -928,23 +924,20 @@ async def test_revoke_all_tokens(mock_exc, mock_dapi, mock_remove, mock_dfunc, m
 async def test_revoke_all_tokens_ko(mock_type, mock_len, mock_exc, mock_dapi, mock_remove, mock_dfunc,
                                     mock_request):
     """Verify 'revoke_all_tokens' endpoint is handling WazuhPermissionError as expected."""
-    with patch('api.controllers.security_controller.get_system_nodes_or_none', return_value=AsyncMock()) as mock_snodes:
-        result = await revoke_all_tokens()
-        mock_dapi.assert_called_once_with(f=security.wrapper_revoke_tokens,
-                                          f_kwargs=mock_remove.return_value,
-                                          request_type='distributed_master',
-                                          is_async=False,
-                                          broadcasting=True,
-                                          logger=ANY,
-                                          wait_for_complete=True,
-                                          rbac_permissions=mock_request.context['token_info']['rbac_policies'],
-                                          nodes=mock_snodes.return_value
-                                          )
-        mock_exc.assert_has_calls([call(mock_dfunc.return_value),
-                                   call(WazuhPermissionError(4000, mock_exc.return_value.message))])
-        assert mock_exc.call_count == 2
-        mock_remove.assert_called_once_with({})
-        assert isinstance(result, ConnexionResponse)
+    result = await revoke_all_tokens()
+    mock_dapi.assert_called_once_with(f=security.wrapper_revoke_tokens,
+                                      f_kwargs=mock_remove.return_value,
+                                      request_type='local_master',
+                                      is_async=False,
+                                      logger=ANY,
+                                      wait_for_complete=True,
+                                      rbac_permissions=mock_request.context['token_info']['rbac_policies']
+                                      )
+    mock_exc.assert_has_calls([call(mock_dfunc.return_value),
+                               call(WazuhPermissionError(4000, mock_exc.return_value.message))])
+    assert mock_exc.call_count == 2
+    mock_remove.assert_called_once_with({})
+    assert isinstance(result, ConnexionResponse)
 
 
 @pytest.mark.asyncio
@@ -972,20 +965,16 @@ async def test_get_security_config(mock_exc, mock_dapi, mock_remove, mock_dfunc,
 @patch('api.controllers.security_controller.DistributedAPI.distribute_function', return_value=AsyncMock())
 @patch('api.controllers.security_controller.DistributedAPI.__init__', return_value=None)
 @patch('api.controllers.security_controller.raise_if_exc', return_value=CustomAffectedItems())
-@pytest.mark.parametrize('mock_snodes', [None, AsyncMock()])
-async def test_security_revoke_tokens(mock_exc, mock_dapi, mock_dfunc, mock_snodes):
+async def test_security_revoke_tokens(mock_exc, mock_dapi, mock_dfunc):
     """Verify 'security_revoke_tokens' endpoint is working as expected."""
-    with patch('api.controllers.security_controller.get_system_nodes_or_none', return_value=mock_snodes):
-        await security_revoke_tokens()
-        mock_dapi.assert_called_once_with(f=security.revoke_tokens,
-                                          request_type='distributed_master' if mock_snodes is not None else 'local_any',
-                                          is_async=False,
-                                          wait_for_complete=True,
-                                          broadcasting=mock_snodes is not None,
-                                          logger=ANY,
-                                          nodes=mock_snodes
-                                          )
-        mock_exc.assert_called_once_with(mock_dfunc.return_value)
+    await security_revoke_tokens()
+    mock_dapi.assert_called_once_with(f=security.revoke_tokens,
+                                      request_type='local_master',
+                                      is_async=False,
+                                      wait_for_complete=True,
+                                      logger=ANY
+                                      )
+    mock_exc.assert_called_once_with(mock_dfunc.return_value)
 
 
 @pytest.mark.asyncio

--- a/framework/wazuh/core/cluster/control.py
+++ b/framework/wazuh/core/cluster/control.py
@@ -178,17 +178,3 @@ async def get_system_nodes():
         return [node['name'] for node in result['items']]
     except WazuhInternalError as e:
         raise e
-
-async def get_system_nodes_or_none() -> list | None:
-    """Get the list of system nodes or None if an exception occurs.
-
-    Returns
-    -------
-    nodes : list or None
-        List of node names or None if an exception is raised.
-    """
-    nodes = await get_system_nodes()
-    if isinstance(nodes, Exception):
-        nodes = None
-
-    return nodes

--- a/framework/wazuh/core/cluster/tests/test_control.py
+++ b/framework/wazuh/core/cluster/tests/test_control.py
@@ -137,14 +137,3 @@ async def test_get_system_nodes():
 
         with pytest.raises(json.JSONDecodeError):
             await control.get_system_nodes()
-
-
-@pytest.mark.asyncio
-async def test_get_system_nodes_or_none():
-    """Verify that get_system_nodes_or_none function returns the name of all cluster nodes."""
-    with patch('wazuh.core.cluster.local_client.LocalClient.execute', side_effect=async_local_client):
-        expected_result = [{'items': [{'name': 'master'}]}]
-        for expected in expected_result:
-            with patch('wazuh.core.cluster.control.get_nodes', return_value=expected):
-                result = await control.get_system_nodes_or_none()
-                assert result == [expected['items'][0]['name']]


### PR DESCRIPTION
## Description

Closes #38423

In 5.0.0 the API daemon (`wazuh-manager-apid`) only starts on the master node, so the RBAC database is never initialized on workers. However, `DELETE /security/user/authenticate` and `PUT`/`DELETE /security/config` still broadcast the `revoke_tokens` DAPI request to every worker. Each worker executes it in `clusterd`, SQLAlchemy creates an empty `rbac.db` on connect, and the query fails with `Corrupted RBAC database: no such table: users_token_blacklist`, dumping a full traceback in `cluster.log` of every worker. This is deterministic in any multi-node cluster, since the DIT provisioning itself triggers it with `PUT /security/config`.

## Proposed Changes

- `revoke_all_tokens` and `security_revoke_tokens` now use `request_type='local_master'` without broadcasting. Tokens are only issued and validated on the master, so there is nothing to revoke on workers.
- Removed the now unused `get_system_nodes_or_none` helper and its test.
- Updated the affected unit tests.

### Results and Evidence

Unit tests (python 3.12, `framework/requirements-dev.txt`, as in CI):

```
$ python -m pytest api/api -q
443 passed, 2877 warnings in 8.66s

$ python -m pytest framework/wazuh/core/cluster/tests -q
446 passed, 1 skipped, 11 warnings in 37.09s
```

Failure being fixed, on all 9 workers of the DIT-CC 5.0.0-rc1 run (build 1420), triggered by the provisioning `PUT /security/config {"auth_token_exp_timeout": 3600}`:

```
2026/08/06 11:21:04 INFO: [Worker worker-redhat-9-amd64] [D API] Receiving request: revoke_tokens from master (854589)
2026/08/06 11:21:04 ERROR: [Worker worker-redhat-9-amd64] [D API] Corrupted RBAC database: no such table: users_token_blacklist
```

After this change the master handles the revocation locally and no request reaches the workers.

### Artifacts Affected

- `wazuh-manager` packages (Python framework and API code).

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

No new tests; `test_revoke_all_tokens`, `test_revoke_all_tokens_ko` and `test_security_revoke_tokens` were updated to the new request type, and the test for the removed helper was deleted.

## Review Checklist
- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
