### PR TITLE
Fix WPK agent upgrade silently failing on systems without the find binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 - Fixed the Windows agent MSI upgrade leaving the agent broken after the next reboot, and the silent `/q` upgrade hanging, when a system restart was pending. ([#38277](https://github.com/wazuh/wazuh/pull/38277))
 - Fixed `wazuh-execd` crashing when more active response commands than supported are defined. ([#38410](https://github.com/wazuh/wazuh/pull/38410))
+- Fixed WPK upgrade failing on agents without the `find` binary. ([#38431](https://github.com/wazuh/wazuh/pull/38431))
 
 ## [v4.14.8]
 

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -19,6 +19,15 @@ echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade started." >> ./logs/upgrade.log
 OS=$(uname)
 WAZUH_HOME=$(pwd)
 
+# Pure-shell check for a matching package, so branch selection does not depend on
+# an external tool like `find` (absent on minimal container/cloud images).
+pkg_exists() {
+    for f in "$@"; do
+        [ -f "$f" ] && return 0
+    done
+    return 1
+}
+
 echo "$(date +"%Y/%m/%d %H:%M:%S") - Checking execution path." >> ./logs/upgrade.log
 
 if [[ "$OS" == "Darwin" ]]; then
@@ -45,7 +54,7 @@ fi
 if [[ "$OS" == "Darwin" ]]; then
     installer -pkg ./var/upgrade/wazuh-agent* -target / >> ./logs/upgrade.log 2>&1
 elif [[ "$OS" == "Linux" ]]; then
-    if find ./var/upgrade/ -mindepth 1 -maxdepth 1 -type f -name "*.rpm" | read; then
+    if pkg_exists ./var/upgrade/*.rpm; then
         if command -v rpm >/dev/null 2>&1; then
             rpm -UFvh ./var/upgrade/wazuh-agent* >> ./logs/upgrade.log 2>&1
         else
@@ -54,7 +63,7 @@ elif [[ "$OS" == "Linux" ]]; then
             rm -f $LOCK
             exit 1
         fi
-    elif find ./var/upgrade/ -mindepth 1 -maxdepth 1 -type f -name "*.deb" | read; then
+    elif pkg_exists ./var/upgrade/*.deb; then
         if command -v dpkg >/dev/null 2>&1; then
             dpkg -i --force-confdef ./var/upgrade/wazuh-agent* >> ./logs/upgrade.log 2>&1
         else
@@ -63,7 +72,7 @@ elif [[ "$OS" == "Linux" ]]; then
             rm -f $LOCK
             exit 1
         fi
-    elif find ./var/upgrade/ -mindepth 1 -maxdepth 1 -type f -name "*.apk" | read; then
+    elif pkg_exists ./var/upgrade/*.apk; then
         if command -v apk >/dev/null 2>&1; then
             apk add --allow-untrusted --force ./var/upgrade/wazuh-agent* >> ./logs/upgrade.log 2>&1
         else

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -19,11 +19,9 @@ echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade started." >> ./logs/upgrade.log
 OS=$(uname)
 WAZUH_HOME=$(pwd)
 
-# Pure-shell check for a matching package, so branch selection does not depend on
-# an external tool like `find` (absent on minimal container/cloud images).
 pkg_exists() {
-    for f in "$@"; do
-        [ -f "$f" ] && return 0
+    for file in "$@"; do
+        [ -f "$file" ] && return 0
     done
     return 1
 }

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 # Copyright (C) 2015, Wazuh Inc.
 
-# Pure-shell cleanup of the upgrade directory (keeps upgrade_result), so it does
-# not depend on `find`, which may be absent on minimal images.
 clean_upgrade_dir() {
-    for f in ./var/upgrade/*; do
-        [ "$f" = "./var/upgrade/upgrade_result" ] && continue
-        rm -rf "$f"
+    for file in ./var/upgrade/*; do
+        [ "$file" = "./var/upgrade/upgrade_result" ] && continue
+        rm -rf "$file"
     done
 }
 

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,13 +1,22 @@
 #!/bin/bash
 # Copyright (C) 2015, Wazuh Inc.
 
+# Pure-shell cleanup of the upgrade directory (keeps upgrade_result), so it does
+# not depend on `find`, which may be absent on minimal images.
+clean_upgrade_dir() {
+    for f in ./var/upgrade/*; do
+        [ "$f" = "./var/upgrade/upgrade_result" ] && continue
+        rm -rf "$f"
+    done
+}
+
 # validate OS, linux or macos
 if [ "X$(uname)" = "XLinux" ] ; then
     # Get Wazuh installation path
     SCRIPT=$(readlink -f "$0")
     WAZUH_HOME=$(dirname $(dirname $(dirname "$SCRIPT")))
     cd "${WAZUH_HOME}"
-    (sleep 5 && chmod +x ./var/upgrade/*.sh && ./var/upgrade/pkg_installer.sh && find ./var/upgrade/* -not -name upgrade_result -delete) >/dev/null 2>&1 &
+    (sleep 5 && chmod +x ./var/upgrade/*.sh && ./var/upgrade/pkg_installer.sh && clean_upgrade_dir) >> ./logs/upgrade.log 2>&1 &
 else
-    (sleep 5 && chmod +x ./var/upgrade/*.sh && ./var/upgrade/pkg_installer.sh && find ./var/upgrade/ -mindepth 1 -not -name upgrade_result -delete) >/dev/null 2>&1 &
+    (sleep 5 && chmod +x ./var/upgrade/*.sh && ./var/upgrade/pkg_installer.sh && clean_upgrade_dir) >> ./logs/upgrade.log 2>&1 &
 fi


### PR DESCRIPTION
## Description

This PR fixes the WPK upgrade scripts so they no longer depend on the external `find` binary, which is absent on minimal container/cloud images. Previously, on an agent without `find`, every WPK upgrade failed with the misleading `Upgrade failed. No package or sources found.` in `logs/upgrade.log` while the real cause (`find: command not found`) was discarded to `/dev/null`, leaving no trace on the agent or the manager. Branch selection now uses a pure-shell POSIX glob, cleanup no longer relies on `find`, and the installer chain's output is captured in `upgrade.log` instead of being discarded.

**Proposed Release:** [v4.14.9]
**Issue:** wazuh/wazuh#38349
**Internal Reference:** N/A

## Proposed Changes

- Updated `src/init/pkg_installer.sh`: replaced the three `find ./var/upgrade/ ... | read` branch selectors with a pure-shell helper `pkg_exists()` (POSIX glob + `[ -f ]`), so package-type detection no longer calls `find`.
- Updated `upgrade.sh`: the installer chain now redirects to `./logs/upgrade.log 2>&1` instead of `>/dev/null 2>&1`, so any unexpected output (including a missing tool) is logged; the post-install cleanup `find ... -delete` was replaced with a pure-shell `clean_upgrade_dir()`.
- No external tool is required for branch selection or cleanup anymore; the specific `command -v rpm/dpkg/apk` guards already present keep reporting the exact missing package manager.

### Results and Evidence

Validated on a real environment (not emulated): AlmaLinux 8 with a real Wazuh agent (`wazuh-agent-4.14.3`) installed from packages.wazuh.com, `findutils` removed with the real package manager, and a real `wazuh-agent-4.14.7` RPM delivered into `var/upgrade/`. The real shipped `upgrade.sh` / `pkg_installer.sh` were run exactly as the agent's upgrade module runs them.

**Before the fix (find absent) - the bug:**

```bash
# yum remove -y findutils ; command -v find || echo MISSING  -> MISSING
# bash ./var/upgrade/upgrade.sh   (stock 4.14.9 scripts)

--- logs/upgrade.log ---
2026/08/18 11:39:54 - Upgrade started.
2026/08/18 11:39:54 - Checking execution path.
2026/08/18 11:39:54 - Upgrade failed. No package or sources found.
--- upgrade_result ---
2
--- agent version (unchanged, upgrade did NOT happen) ---
WAZUH_VERSION="v4.14.3"
--- rpm left unmerged in var/upgrade ---
-rw-rw-rw- 1 root root 11148029 wazuh-agent_v4.14.7_linux_x86_64.rpm
```

**After the fix (find still absent) - upgrade succeeds:**

```bash
# command -v find || echo MISSING  -> MISSING
# bash ./var/upgrade/upgrade.sh   (fixed 4.14.9 scripts)

--- logs/upgrade.log ---
2026/08/18 11:54:43 - Upgrade started.
2026/08/18 11:54:43 - Checking execution path.
Verifying...                          ########################################
Preparing...                          ########################################
Updating / installing...
wazuh-agent-4.14.7-1                  ########################################
Cleaning up / removing...
wazuh-agent-4.14.3-1                  ########################################
2026/08/18 11:54:44 - Installation result = 0
--- agent version (REAL upgrade happened) ---
WAZUH_VERSION="v4.14.7"
```

**No regression (find present):**

```bash
# command -v find  -> /usr/bin/find
# empty var/upgrade (genuine no-package):
2026/08/18 11:50:13 - Upgrade failed. No package or sources found.   # result=2, correct
# rpm present:
2026/08/18 11:50:14 - Installation result = 0                        # correct branch selected
```

**DEB branch (real Ubuntu 22.04 agent, findutils removed):** before -> `No package or sources found.` and agent stays `4.14.3`; after -> dpkg branch selected, `4.14.7` unpacked over `4.14.3` (`wazuh-control info` = `v4.14.7`).

Note: already-published WPKs keep the old behavior, since these scripts travel inside the WPK; only WPKs built after this fix carry it.

### Artifacts Affected

- `src/init/pkg_installer.sh`
- `upgrade.sh`

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Manual integration test (real agent, real package managers).
- **Details:** Installed a real Wazuh agent on AlmaLinux 8 (RPM) and Ubuntu 22.04 (DEB), removed `findutils` with the real package manager, delivered a real target package into `var/upgrade/`, and ran the real WPK upgrade scripts. Verified that without `find` the stock scripts fail with the misleading message and the agent is not upgraded, while the fixed scripts perform the real upgrade (4.14.3 -> 4.14.7) and log any unexpected output; verified no regression with `find` present.

## Review Checklist

**Manual tests with their corresponding evidence:**

- Compilation without warnings on every supported platform (N/A - shell scripts, not compiled)

    - [ ] Linux
    - [ ] Windows
    - [ ] MAC OS X

- [ ] Log syntax and correct language review

- Memory tests for Linux (N/A - shell scripts)

    - [ ] Coverity
    - [ ] Valgrind (memcheck and descriptor leaks check)
    - [ ] AddressSanitizer

**General Checklist:**

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
