### PR TITLE
Enforce client.keys source address and harden HTTPS config validation in remoted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,6 @@
 | [#38091](https://github.com/wazuh/wazuh/issues/38091) | Raised the minimum TLS protocol version accepted by `wazuh-manager-authd` (agent enrollment) to TLS 1.3, removed the `ssl_auto_negotiate` fallback and its `-a` CLI flag, and changed `<auth><ciphers>` to a TLS 1.3 ciphersuite list. |
 | [#32698](https://github.com/wazuh/wazuh/issues/32698) | Adapted API integration tests. |
 | [#36453](https://github.com/wazuh/wazuh/issues/36453) | Increased the minimum API user password length from 8 to 12 characters to align with PCI DSS. |
-| [#38280](https://github.com/wazuh/wazuh/issues/38280) | Renamed the communications metrics data stream to `wazuh-metrics-comms-v4`. It holds the statistics of the legacy communication protocol, which only agents below v5.0.0 use. |
 
 #### Removed
 
@@ -57,7 +56,6 @@
 | [#28425](https://github.com/wazuh/wazuh/issues/28425) | Removed legacy API security configuration endpoints. |
 | [#35908](https://github.com/wazuh/wazuh/issues/35908) | Removed SELinux integration from the manager. |
 | [#38024](https://github.com/wazuh/wazuh/issues/38024) | Removed the `GET /agents/{agent_id}/stats/{component}` API endpoint. Agent statistics are read from the `wazuh-agent-stats` index. |
-| [#38280](https://github.com/wazuh/wazuh/issues/38280) | Removed the `states`, `sent_breakdown.ar` and `sent_breakdown.request` counters from the `wazuh-manager-remoted` statistics served by `GET /cluster/{node_id}/daemons/stats`. None of them has a writer left in 5.0, so all three reported a constant zero. |
 
 #### Fixed
 
@@ -69,7 +67,6 @@
 | [#35043](https://github.com/wazuh/wazuh/issues/35043) | Fixed token validation race condition after revoke. |
 | [#35638](https://github.com/wazuh/wazuh/issues/35638) | Handled the stop signal during vulnerability feed download. |
 | [#37521](https://github.com/wazuh/wazuh/issues/37521) | Fixed `GET /cluster/{node_id}/daemons/stats` always returning error 1014 for `wazuh-manager-analysisd` due to a protocol mismatch between `WazuhSocketJSON` and the engine's HTTP API socket. |
-| [#38280](https://github.com/wazuh/wazuh/issues/38280) | Fixed the `upgrade_ack` counter in `wazuh-manager-remoted` statistics, which reported a constant zero because its increment function was missing. |
 
 ### Agent
 

--- a/docs/ref/modules/remoted/configuration.md
+++ b/docs/ref/modules/remoted/configuration.md
@@ -138,7 +138,8 @@ Whether an IPv6 `bind_addr` (e.g. `::`) also accepts IPv4 clients on the same so
 (the `IPV6_V6ONLY` socket option).
 
 - **Default value:** `no` (force IPv6-only)
-- **Allowed values:** `yes` (force dual-stack on), `no` (force IPv6-only)
+- **Allowed values:** `yes` (force dual-stack on), `no` (force IPv6-only); any other value is
+  rejected as a configuration error
 - **Note:** Only meaningful when `bind_addr` is IPv6; ignored (with a warning) for an IPv4
   `bind_addr`. See [HTTPS Events API: Bind address](https-events-api.md#bind-address-ipv4-ipv6-and-dual-stack).
 
@@ -186,8 +187,8 @@ Client-certificate verification strictness.
   connect from, not where agents may. It fits a direct deployment, or one where the balancer
   preserves the client address at network level. It also requires every agent certificate to
   carry the agent's address in its SAN, which has to be reissued whenever that address changes.
-- **Note:** any other value is ignored with a warning, leaving `verification_mode` as if it had
-  not been configured.
+- **Note:** any other value is rejected as a configuration error (the config test fails), so a
+  typo cannot silently leave client-certificate verification disabled.
 - **Special case:** if `<ca>` is explicitly configured in XML but `<verification_mode>` is not, the manager defaults `verification_mode` to `certificate` instead of `none`, and logs a warning explaining the override. An explicit `<verification_mode>` (including `none`) always wins over this inference.
 
 ### https.ciphers
@@ -197,7 +198,10 @@ scheme, e.g. `TLS_AES_256_GCM_SHA384`). The listener requires TLS 1.3 as its min
 protocol version.
 
 - **Default value:** `TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256`
-- **Allowed values:** colon-separated TLS 1.3 ciphersuite name string
+- **Allowed values:** colon-separated TLS 1.3 ciphersuite name string. The value is validated at
+  configuration-parse time: a name that is not a TLS 1.3 suite (for example a TLS 1.2 string such
+  as `HIGH:!ADH`) is rejected so the config test catches it, instead of the listener failing to
+  start at runtime.
 
 ### https.max_body_size
 

--- a/docs/ref/modules/remoted/configuration.md
+++ b/docs/ref/modules/remoted/configuration.md
@@ -148,6 +148,8 @@ Whether an IPv6 `bind_addr` (e.g. `::`) also accepts IPv4 clients on the same so
 Path to the TLS certificate chain (PEM) presented by the server.
 
 - **Default value:** `etc/certs/remoted.pem` (relative to the manager's chroot)
+- **Note:** at startup the manager warns if this certificate has expired or expires within 30 days,
+  so a silent outage for verifying agents can be prevented before it happens.
 
 ### https.key
 

--- a/docs/ref/modules/remoted/https-events-api.md
+++ b/docs/ref/modules/remoted/https-events-api.md
@@ -188,6 +188,7 @@ collapse to a **single generic `401`** so a client cannot tell which specific ch
 | Missing `protocol-version` header | `400` | `Missing required header: protocol-version` |
 | Unsupported `protocol-version` | `400` | `Unsupported protocol-version` |
 | Missing / malformed `Authorization`, unknown agent, unusable key, expired or future timestamp, invalid MAC | `401` | `Invalid client authentication` |
+| Authenticated, but the peer address is outside the agent's authorized range in `client.keys` (third column) | `403` | `Source address not authorized` |
 | Body exceeds the auth body limit (10 MiB) -- or, for `Content-Encoding: zstd`, the decoder's buffers or the decompressed output don't fit in the in-flight capacity free at that moment | `413` | `Request payload is too large` |
 | `Content-Encoding` present but not (case-insensitively) `zstd` | `415` | `Unsupported Content-Encoding` |
 | `Content-Encoding: zstd`, but the body isn't a valid/complete zstd frame | `400` | `Malformed compressed body` |
@@ -199,6 +200,13 @@ collapse to a **single generic `401`** so a client cannot tell which specific ch
 The payload-identity check runs **before** the batch is forwarded: a mismatch never reaches the
 engine at all, and (by design) shares the same `400 Invalid event batch` message as a batch the
 engine itself rejects, so a client cannot distinguish the two causes.
+
+The source-address check runs **after** the MAC is verified, so it never reveals the ACL to an
+unauthenticated peer. It mirrors the legacy listener's `OS_IsAllowedIP`: the third `client.keys`
+column restricts the address an agent id may connect from — a single IP, a CIDR (`10.99.0.0/16`),
+or `any` (unrestricted, the default). An authenticated agent connecting from outside its range is
+answered `403 Source address not authorized`. The address is compared against the peer as remoted
+sees it, with IPv4-mapped IPv6 already unmapped to plain IPv4.
 
 Requests larger than the 20 MiB transport cap are dropped at the TLS/HTTP layer (the connection is
 closed) before authentication runs, so they never receive a clean `413`.

--- a/docs/ref/modules/remoted/stateless-api.yaml
+++ b/docs/ref/modules/remoted/stateless-api.yaml
@@ -154,6 +154,18 @@ paths:
               examples:
                 invalidAuthentication:
                   value: { error: "Invalid client authentication", code: 401 }
+        "403":
+          description: |
+            The request authenticated, but the peer connects from an address outside the range
+            authorized for this agent in `client.keys` (the third column: a single IP, a CIDR, or
+            `any`). Checked only after the MAC verifies, so it never reveals the ACL to an
+            unauthenticated peer.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorResponse" }
+              examples:
+                sourceAddressNotAuthorized:
+                  value: { error: "Source address not authorized", code: 403 }
         "413":
           description: |
             The request body exceeds the configured auth body limit (10 MiB). For

--- a/src/client-agent/https_client/src/outcomeClassifier.cpp
+++ b/src/client-agent/https_client/src/outcomeClassifier.cpp
@@ -66,10 +66,10 @@ OutcomeClass classifyOutcome(const HttpResponse& response)
         return OutcomeClass::BackPressure;
     }
 
-    // 403/426 are not part of the manager contract: they reach the agent only
-    // from an intermediary (reverse proxy, WAF, mTLS gateway). Transient so a
-    // /stateless batch is retried rather than consumed as Permanent, and not
-    // Unreachable because something did answer.
+    // 403: the manager's source-address ACL (client.keys) refused this peer, or an intermediary
+    // (reverse proxy, WAF, mTLS gateway) blocked it; 426 only from an intermediary. Transient so the
+    // batch is retried and kept (not dropped) rather than consumed as Permanent, and not Unreachable
+    // because something answered.
     if (code == 403 || code == 426)
     {
         return OutcomeClass::ServerError;

--- a/src/config/src/remote-config.c
+++ b/src/config/src/remote-config.c
@@ -64,6 +64,15 @@ STATIC int w_remoted_parse_https(XML_NODE node, remoted * logr);
  */
 STATIC int w_remoted_https_check_max_len(const char * element, const char * content, size_t max_len);
 
+/**
+ * @brief validates <remote><https><ciphers> as a TLS 1.3 suite list, so 'remoted -t' rejects a
+ *        TLS 1.2 string instead of the HTTPS server failing to start at runtime.
+ *
+ * @param ciphers raw <ciphers> content
+ * @return OS_SUCCESS when every element is a known suite, OS_INVALID otherwise
+ */
+STATIC int w_remoted_validate_tls13_ciphers(const char * ciphers);
+
 /* Reads remote config */
 int Read_Remote(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused)) void *d2)
 {
@@ -326,10 +335,16 @@ STATIC int w_remoted_parse_https(XML_NODE node, remoted * logr) {
             } else if (strcasecmp(node[i]->content, "full") == 0) {
                 logr->https.verification_mode = REMOTED_HTTPS_VERIFY_FULL;
             } else {
-                mwarn(REMOTED_INV_VALUE_IGNORE, node[i]->content, xml_https_verification_mode);
+                // Reject, don't fall back: a typo must not silently disable certificate verification.
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                return (OS_INVALID);
             }
         } else if (strcasecmp(node[i]->element, xml_https_ciphers) == 0) {
             if (w_remoted_https_check_max_len(xml_https_ciphers, node[i]->content, REMOTED_HTTPS_CIPHERS_MAX_LEN) == OS_INVALID) {
+                return (OS_INVALID);
+            }
+
+            if (w_remoted_validate_tls13_ciphers(node[i]->content) == OS_INVALID) {
                 return (OS_INVALID);
             }
 
@@ -350,7 +365,8 @@ STATIC int w_remoted_parse_https(XML_NODE node, remoted * logr) {
             } else if (strcasecmp(node[i]->content, "no") == 0) {
                 logr->https.dual_stack = REMOTED_HTTPS_DUAL_STACK_NO;
             } else {
-                mwarn(REMOTED_INV_VALUE_IGNORE, node[i]->content, xml_https_dual_stack);
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                return (OS_INVALID);
             }
         } else {
             merror(XML_INVELEM, node[i]->element);
@@ -388,6 +404,56 @@ STATIC int w_remoted_https_check_max_len(const char * element, const char * cont
     }
 
     return OS_SUCCESS;
+}
+
+STATIC int w_remoted_validate_tls13_ciphers(const char * ciphers) {
+    // Same TLS 1.3 suite names OpenSSL's SSL_CTX_set_ciphersuites() accepts (RFC 8446 section B.4).
+    static const char * VALID_TLS13_CIPHERSUITES[] = {
+        "TLS_AES_128_GCM_SHA256",
+        "TLS_AES_256_GCM_SHA384",
+        "TLS_CHACHA20_POLY1305_SHA256",
+        "TLS_AES_128_CCM_SHA256",
+        "TLS_AES_128_CCM_8_SHA256",
+        NULL
+    };
+
+    if (ciphers == NULL || *ciphers == '\0') {
+        merror("Invalid '<remote><https><ciphers>' option: expected TLS 1.3 cipher suite names.");
+        return (OS_INVALID);
+    }
+
+    // Hand-walked, not strtok: strtok collapses separators, so ':X' and 'X::Y' would wrongly pass.
+    const char * element = ciphers;
+
+    for (;;) {
+        const char * separator = strchr(element, ':');
+        const size_t length = separator ? (size_t)(separator - element) : strlen(element);
+
+        if (length == 0) {
+            merror("Invalid '<remote><https><ciphers>' option: '%s' has an empty cipher suite name.", ciphers);
+            return (OS_INVALID);
+        }
+
+        int valid = 0;
+        for (int i = 0; VALID_TLS13_CIPHERSUITES[i]; i++) {
+            if (strlen(VALID_TLS13_CIPHERSUITES[i]) == length &&
+                strncmp(element, VALID_TLS13_CIPHERSUITES[i], length) == 0) {
+                valid = 1;
+                break;
+            }
+        }
+
+        if (!valid) {
+            merror("Invalid TLS 1.3 cipher suite '%.*s' in the '<remote><https><ciphers>' option.", (int)length, element);
+            return (OS_INVALID);
+        }
+
+        if (!separator) {
+            return OS_SUCCESS;
+        }
+
+        element = separator + 1;
+    }
 }
 
 STATIC int w_remoted_get_net_protocol(const char * content) {

--- a/src/remoted/remoted_module/src/auth/authMiddleware.cpp
+++ b/src/remoted/remoted_module/src/auth/authMiddleware.cpp
@@ -13,6 +13,7 @@
 
 #include "common/logThrottle.hpp"
 #include "loggerHelper.h"
+#include "sourceAddress.hpp"
 
 #include <algorithm>
 #include <charconv>
@@ -61,6 +62,7 @@ namespace remoted::auth
             case AuthError::BodyTooLarge: return "body_too_large";
             case AuthError::UnsupportedContentEncoding: return "unsupported_content_encoding";
             case AuthError::MalformedContentEncoding: return "malformed_content_encoding";
+            case AuthError::SourceIpNotAllowed: return "source_ip_not_allowed";
         }
         return "unknown";
     }
@@ -75,6 +77,8 @@ namespace remoted::auth
             case AuthError::BodyTooLarge: return {413, "Request payload is too large"};
             case AuthError::MalformedContentEncoding: return {400, "Malformed compressed body"};
             case AuthError::UnsupportedContentEncoding: return {415, "Unsupported Content-Encoding"};
+            // 403, not the generic 401: credentials are valid, the source address is what is refused.
+            case AuthError::SourceIpNotAllowed: return {403, "Source address not authorized"};
             case AuthError::None: return {200, ""};
             // MissingAuthorization, MalformedAuthorization, UnknownAgent, MissingKey,
             // ExpiredRequest, FutureRequest, InvalidMac: collapse to one generic 401
@@ -324,6 +328,27 @@ namespace remoted::auth
         session.m_cmac->update("\n");
 
         return session;
+    }
+
+    std::optional<AuthError> AuthMiddleware::checkSourceAddress(std::string_view agentId,
+                                                               std::string_view peerAddress) const
+    {
+        AgentId numericAgentId = 0;
+        const auto [end, ec] = std::from_chars(agentId.data(), agentId.data() + agentId.size(), numericAgentId);
+        if (ec != std::errc {} || end != agentId.data() + agentId.size())
+        {
+            return AuthError::SourceIpNotAllowed; // unparseable id (can't happen post-auth): fail closed
+        }
+
+        // A now-absent entry (client.keys reloaded) is treated as unrestricted: the key lookup is
+        // the authoritative gate, so don't lock out a just-verified agent.
+        const auto allowed = m_keystore->allowedAddressFor(numericAgentId);
+        if (!allowed || sourceAddressAllowed(*allowed, peerAddress))
+        {
+            return std::nullopt;
+        }
+
+        return AuthError::SourceIpNotAllowed;
     }
 
     AuthError AuthMiddleware::Session::update(const std::uint8_t* data, std::size_t len)

--- a/src/remoted/remoted_module/src/auth/authMiddleware.hpp
+++ b/src/remoted/remoted_module/src/auth/authMiddleware.hpp
@@ -135,6 +135,17 @@ namespace remoted::auth
                                                       std::string_view requestTarget,
                                                       std::int64_t currentUnixTimeSeconds) const;
 
+        /**
+         * @brief Authorize the peer against the agent's client.keys source-address column.
+         *
+         * Call only after finish() verified the MAC, so the ACL is never exposed to an unauthenticated peer.
+         *
+         * @param agentId     The authenticated agent id.
+         * @param peerAddress The peer's connection address (see HttpRequest::remoteIp).
+         * @return nullopt when allowed, or AuthError::SourceIpNotAllowed.
+         */
+        std::optional<AuthError> checkSourceAddress(std::string_view agentId, std::string_view peerAddress) const;
+
         /// @return The auth-protocol configuration this middleware was constructed with.
         const AuthConfig& config() const
         {

--- a/src/remoted/remoted_module/src/auth/authTypes.hpp
+++ b/src/remoted/remoted_module/src/auth/authTypes.hpp
@@ -131,6 +131,7 @@ namespace remoted::auth
         UnsupportedContentEncoding, ///< Content-Encoding present but not (case-insensitively) "zstd".
         MalformedContentEncoding,   ///< Content-Encoding: zstd, but the body isn't a valid/complete
                                     ///< zstd frame (bad magic, truncated, oversized window, ...).
+        SourceIpNotAllowed, ///< Authenticated, but the peer is outside the agent's client.keys address range.
     };
 
     /**

--- a/src/remoted/remoted_module/src/auth/iAgentKeystore.hpp
+++ b/src/remoted/remoted_module/src/auth/iAgentKeystore.hpp
@@ -13,6 +13,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include "authTypes.hpp" // remoted::auth::AgentId
@@ -38,6 +39,13 @@ namespace remoted::auth
          *         is known but its on-disk key could not be used as-is.
          */
         virtual std::optional<std::vector<std::uint8_t>> keyFor(AgentId agentId) const = 0;
+
+        /**
+         * @brief The agent's `client.keys` source-address column; nullopt if absent (unrestricted).
+         *
+         * Pure virtual like keyFor(): a security control must not inherit a silent "unrestricted" default.
+         */
+        virtual std::optional<std::string> allowedAddressFor(AgentId agentId) const = 0;
     };
 
 } // namespace remoted::auth

--- a/src/remoted/remoted_module/src/auth/keystore.cpp
+++ b/src/remoted/remoted_module/src/auth/keystore.cpp
@@ -429,7 +429,7 @@ namespace remoted::auth
                 return kReloadUnreadable;
             }
 
-            std::unordered_map<AgentId, std::vector<std::uint8_t>> loaded;
+            std::unordered_map<AgentId, AgentEntry> loaded;
             std::string line;
             int count = 0;
             int lineNumber = 0;
@@ -478,11 +478,11 @@ namespace remoted::auth
                                "agent's requests will be rejected. Re-enroll it.",
                                lineNumber,
                                *agentId);
-                    loaded[*agentId] = std::move(decoded);
+                    loaded[*agentId] = AgentEntry {std::move(decoded), std::move(ip)};
                     continue;
                 }
 
-                loaded[*agentId] = std::move(decoded);
+                loaded[*agentId] = AgentEntry {std::move(decoded), std::move(ip)};
                 ++count;
             }
             file.close();
@@ -526,7 +526,18 @@ namespace remoted::auth
         {
             return std::nullopt;
         }
-        return it->second;
+        return it->second.key;
+    }
+
+    std::optional<std::string> Keystore::allowedAddressFor(AgentId agentId) const
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        const auto it = m_keys.find(agentId);
+        if (it == m_keys.end())
+        {
+            return std::nullopt;
+        }
+        return it->second.address;
     }
 
 } // namespace remoted::auth

--- a/src/remoted/remoted_module/src/auth/keystore.hpp
+++ b/src/remoted/remoted_module/src/auth/keystore.hpp
@@ -114,6 +114,9 @@ namespace remoted::auth
          */
         std::optional<std::vector<std::uint8_t>> keyFor(AgentId agentId) const override;
 
+        /// @brief The agent's client.keys source-address column; nullopt if the id is absent.
+        std::optional<std::string> allowedAddressFor(AgentId agentId) const override;
+
     private:
         /// Watcher thread entry point: an exception barrier around watcherLoopBody(). A throw
         /// escaping a bare std::thread would terminate the whole remoted daemon.
@@ -140,7 +143,14 @@ namespace remoted::auth
 
         std::string m_path;
         mutable std::mutex m_mutex;
-        std::unordered_map<AgentId, std::vector<std::uint8_t>> m_keys;
+
+        /// One client.keys entry: AES key + authorized source-address column (3rd field).
+        struct AgentEntry
+        {
+            std::vector<std::uint8_t> key;
+            std::string address;
+        };
+        std::unordered_map<AgentId, AgentEntry> m_keys;
 
         // Hot-reload: background watcher (inotify + periodic fallback poll via poll()'s timeout).
         int m_refreshIntervalSeconds;

--- a/src/remoted/remoted_module/src/auth/sourceAddress.cpp
+++ b/src/remoted/remoted_module/src/auth/sourceAddress.cpp
@@ -1,0 +1,195 @@
+/*
+ * Wazuh remoted HTTPS source-address authorization
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "sourceAddress.hpp"
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+namespace
+{
+    // Parse an address to raw bytes, matching OS_IsValidIP's forms: strips an IPv6 zone id
+    // ("fe80::1%eth0") and unmaps "::ffff:x.x.x.x" to plain IPv4. Returns the family, or AF_UNSPEC.
+    int parseAddress(std::string text, std::array<std::uint8_t, 16>& out, std::size_t& length)
+    {
+        const auto zone = text.find('%');
+        if (zone != std::string::npos)
+        {
+            text.erase(zone);
+        }
+
+        in_addr v4 {};
+        if (inet_pton(AF_INET, text.c_str(), &v4) == 1)
+        {
+            std::memcpy(out.data(), &v4, sizeof(v4));
+            length = sizeof(v4);
+            return AF_INET;
+        }
+
+        in6_addr v6 {};
+        if (inet_pton(AF_INET6, text.c_str(), &v6) == 1)
+        {
+            if (IN6_IS_ADDR_V4MAPPED(&v6))
+            {
+                std::memcpy(out.data(), &v6.s6_addr[12], 4); // trailing 4 bytes are the IPv4 address
+                length = 4;
+                return AF_INET;
+            }
+
+            std::memcpy(out.data(), &v6, sizeof(v6));
+            length = sizeof(v6);
+            return AF_INET6;
+        }
+
+        return AF_UNSPEC;
+    }
+
+    // Dotted IPv4 netmask ("255.255.0.0") to prefix length. False if not a contiguous mask.
+    bool ipv4NetmaskToPrefix(const std::string& text, std::size_t& prefixBits)
+    {
+        in_addr mask {};
+        if (inet_pton(AF_INET, text.c_str(), &mask) != 1)
+        {
+            return false;
+        }
+
+        std::uint32_t host = ntohl(mask.s_addr);
+        std::size_t bits = 0;
+        while (host & 0x80000000u)
+        {
+            ++bits;
+            host <<= 1;
+        }
+
+        if (host != 0)
+        {
+            return false; // ones after the first zero -> non-contiguous, not a valid netmask
+        }
+
+        prefixBits = bits;
+        return true;
+    }
+
+    // Whether the first prefixBits of a and b (same length) are equal.
+    bool prefixesEqual(const std::array<std::uint8_t, 16>& a,
+                       const std::array<std::uint8_t, 16>& b,
+                       std::size_t length,
+                       std::size_t prefixBits)
+    {
+        if (prefixBits > length * 8)
+        {
+            return false;
+        }
+
+        const std::size_t fullBytes = prefixBits / 8;
+        for (std::size_t i = 0; i < fullBytes; ++i)
+        {
+            if (a[i] != b[i])
+            {
+                return false;
+            }
+        }
+
+        const std::size_t remainingBits = prefixBits % 8;
+        if (remainingBits != 0)
+        {
+            const std::uint8_t mask = static_cast<std::uint8_t>(0xFF << (8 - remainingBits));
+            if ((a[fullBytes] & mask) != (b[fullBytes] & mask))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}
+
+namespace remoted::auth
+{
+
+    bool sourceAddressAllowed(std::string_view allowedSpec, std::string_view peerAddress)
+    {
+        // "any" or an empty column: unrestricted (case-insensitive).
+        const bool isAny = allowedSpec.size() == 3 && (allowedSpec[0] == 'a' || allowedSpec[0] == 'A') &&
+                           (allowedSpec[1] == 'n' || allowedSpec[1] == 'N') &&
+                           (allowedSpec[2] == 'y' || allowedSpec[2] == 'Y');
+        if (allowedSpec.empty() || isAny)
+        {
+            return true;
+        }
+
+        std::array<std::uint8_t, 16> peerBytes {};
+        std::size_t peerLength = 0;
+        const int peerFamily = parseAddress(std::string {peerAddress}, peerBytes, peerLength);
+        if (peerFamily == AF_UNSPEC)
+        {
+            return false; // Can't identify the peer -> can't say it's allowed.
+        }
+
+        // Split an optional "/prefix" or "/netmask" suffix off the spec.
+        const std::string spec {allowedSpec};
+        const auto slash = spec.find('/');
+        const std::string netText = slash == std::string::npos ? spec : spec.substr(0, slash);
+
+        std::array<std::uint8_t, 16> netBytes {};
+        std::size_t netLength = 0;
+        const int netFamily = parseAddress(netText, netBytes, netLength);
+        if (netFamily == AF_UNSPEC || netFamily != peerFamily)
+        {
+            return false; // Malformed spec, or a different family than the peer (v4 vs v6).
+        }
+
+        std::size_t prefixBits = netLength * 8; // A bare address is a host route (/32 or /128).
+        if (slash != std::string::npos)
+        {
+            const std::string prefixText = spec.substr(slash + 1);
+            if (prefixText.empty())
+            {
+                return false;
+            }
+
+            // "/16" (prefix) first, then "/255.255.0.0" (netmask).
+            std::size_t consumed = 0;
+            bool havePrefix = false;
+            try
+            {
+                const auto value = std::stoul(prefixText, &consumed);
+                if (consumed == prefixText.size())
+                {
+                    prefixBits = static_cast<std::size_t>(value);
+                    havePrefix = true;
+                }
+            }
+            catch (const std::exception&)
+            {
+                // not an integer -> try the netmask form below
+            }
+
+            if (!havePrefix && !(netFamily == AF_INET && ipv4NetmaskToPrefix(prefixText, prefixBits)))
+            {
+                return false;
+            }
+
+            if (prefixBits > netLength * 8)
+            {
+                return false;
+            }
+        }
+
+        return prefixesEqual(peerBytes, netBytes, peerLength, prefixBits);
+    }
+
+} // namespace remoted::auth

--- a/src/remoted/remoted_module/src/auth/sourceAddress.hpp
+++ b/src/remoted/remoted_module/src/auth/sourceAddress.hpp
@@ -1,0 +1,28 @@
+/*
+ * Wazuh remoted HTTPS source-address authorization
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#pragma once
+
+#include <string_view>
+
+namespace remoted::auth
+{
+
+    /**
+     * @brief Whether a peer is allowed by an agent's `client.keys` address column (the HTTPS
+     *        equivalent of the legacy OS_IsAllowedIP).
+     *
+     * @param allowedSpec The column: `any` (or empty), an IP, or CIDR/netmask. Fail-closed if unparseable.
+     * @param peerAddress The peer address as remoted sees it (see HttpRequest::remoteIp).
+     * @return true when the peer is allowed.
+     */
+    bool sourceAddressAllowed(std::string_view allowedSpec, std::string_view peerAddress);
+
+} // namespace remoted::auth

--- a/src/remoted/remoted_module/src/endpoints/authGateway.cpp
+++ b/src/remoted/remoted_module/src/endpoints/authGateway.cpp
@@ -190,6 +190,14 @@ namespace remoted::endpoints
                     // -- dropping it (or calling payload.release()) then frees the buffer
                     // and restores the budget while the responder lives on to reply.
                     auto authRequest = std::get<remoted::auth::AuthenticatedRequest>(std::move(finished));
+
+                    // Step 8: source-address authorization (only reached once the MAC has verified).
+                    if (const auto ipError = middleware->checkSourceAddress(authRequest.agentId, request->remoteIp))
+                    {
+                        responder->send(errorResponseFor(*ipError, authRequest.agentId));
+                        return;
+                    }
+
                     const std::string_view bodyView {request->body}; // capture BEFORE moving request
                     authRequest.payload = remoted::auth::Payload {bodyView, std::move(request)};
 

--- a/src/remoted/remoted_module/src/endpoints/endpoint.cpp
+++ b/src/remoted/remoted_module/src/endpoints/endpoint.cpp
@@ -47,11 +47,12 @@ namespace
      */
     enum class RejectionKind
     {
-        ClientFault,   ///< Malformed/unauthenticated request. DEBUG2, unthrottled.
-        ClockSkew,     ///< Timestamp outside the accepted window -> auth_max_request_age/_future_skew.
-        BodyTooLarge,  ///< Over the authenticated-body cap -> auth_max_body_size.
-        UnusableKey,   ///< The agent exists but its client.keys key does not decode.
-        AgentMismatch, ///< An authenticated agent claimed a different agent's id (security signal).
+        ClientFault,        ///< Malformed/unauthenticated request. DEBUG2, unthrottled.
+        ClockSkew,          ///< Timestamp outside the accepted window -> auth_max_request_age/_future_skew.
+        BodyTooLarge,       ///< Over the authenticated-body cap -> auth_max_body_size.
+        UnusableKey,        ///< The agent exists but its client.keys key does not decode.
+        AgentMismatch,      ///< An authenticated agent claimed a different agent's id (security signal).
+        SourceNotAuthorized, ///< Authenticated agent connecting from outside its client.keys range (security signal).
     };
 
     RejectionKind classify(remoted::auth::AuthError err)
@@ -63,6 +64,7 @@ namespace
             case remoted::auth::AuthError::BodyTooLarge: return RejectionKind::BodyTooLarge;
             case remoted::auth::AuthError::MissingKey: return RejectionKind::UnusableKey;
             case remoted::auth::AuthError::PayloadAgentMismatch: return RejectionKind::AgentMismatch;
+            case remoted::auth::AuthError::SourceIpNotAllowed: return RejectionKind::SourceNotAuthorized;
             default: return RejectionKind::ClientFault;
         }
     }
@@ -76,6 +78,7 @@ namespace
         static LogThrottle bodyTooLargeThrottle;
         static LogThrottle unusableKeyThrottle;
         static LogThrottle agentMismatchThrottle;
+        static LogThrottle sourceNotAuthorizedThrottle;
 
         // NOTE: every argument below must stay allocation-free (literals and integers only). This
         // function runs on every rejected request, and LOGFN_DEBUG2's guard does NOT currently
@@ -127,6 +130,20 @@ namespace
                     LOGFN_WARN(logFn(),
                                "Rejected %llu authenticated request(s) in the last %d s whose payload claimed a "
                                "different agent id than the one that signed them (authenticated agent '%.*s').",
+                               static_cast<unsigned long long>(d.total),
+                               LogThrottle::kDefaultWindowSeconds,
+                               static_cast<int>(agentContext.size()),
+                               agentContext.data());
+                }
+                break;
+
+            case RejectionKind::SourceNotAuthorized:
+                if (const auto d = sourceNotAuthorizedThrottle.record())
+                {
+                    // Security signal: an authenticated agent connecting from outside its client.keys range.
+                    LOGFN_WARN(logFn(),
+                               "Rejected %llu authenticated request(s) with 403 in the last %d s from an address "
+                               "outside the agent's authorized range in client.keys (agent '%.*s').",
                                static_cast<unsigned long long>(d.total),
                                LogThrottle::kDefaultWindowSeconds,
                                static_cast<int>(agentContext.size()),

--- a/src/remoted/remoted_module/src/http_server/IHttpServer.hpp
+++ b/src/remoted/remoted_module/src/http_server/IHttpServer.hpp
@@ -52,8 +52,9 @@ namespace remoted::http
         std::string body;                                     ///< Raw request body.
         std::unordered_map<std::string, std::string> headers; ///< Lower-cased header name -> value.
         std::string remoteIp; ///< Client's connection IP (textual form; IPv4-mapped-IPv6 addresses
-                              ///< are unmapped to plain IPv4 first). Not currently used by any
-                              ///< handler; available for a future cross-check against client.keys.
+                              ///< are unmapped to plain IPv4 first). The auth gateway matches it
+                              ///< against the agent's authorized source address (client.keys third
+                              ///< column) once the request's MAC has verified.
     };
 
     /**

--- a/src/remoted/remoted_module/src/http_server/RestinioHttpServer.cpp
+++ b/src/remoted/remoted_module/src/http_server/RestinioHttpServer.cpp
@@ -451,6 +451,45 @@ namespace
         }
     }
 
+    // Warn (not fatal) when the served certificate is expired or near expiry: OpenSSL serves it
+    // silently, so only verifying agents would otherwise notice.
+    void warnIfCertificateExpiring(asio::ssl::context& context, const std::string& path)
+    {
+        X509* certificate = SSL_CTX_get0_certificate(context.native_handle());
+        if (certificate == nullptr)
+        {
+            return;
+        }
+
+        const ASN1_TIME* notAfter = X509_get0_notAfter(certificate);
+        if (notAfter == nullptr)
+        {
+            return;
+        }
+
+        // X509_cmp_current_time returns < 0 when the time is in the past.
+        if (X509_cmp_current_time(notAfter) < 0)
+        {
+            LOGFN_WARN(logFn(),
+                       "The TLS certificate '%s' has expired; agents that verify the manager certificate will "
+                       "reject the connection until it is renewed.",
+                       path.c_str());
+            return;
+        }
+
+        static constexpr int EXPIRY_WARNING_DAYS {30};
+        int days = 0;
+        int seconds = 0;
+        if (ASN1_TIME_diff(&days, &seconds, nullptr, notAfter) == 1 && days < EXPIRY_WARNING_DAYS)
+        {
+            LOGFN_WARN(logFn(),
+                       "The TLS certificate '%s' expires in %d day(s); renew it to avoid an outage for agents "
+                       "that verify the manager certificate.",
+                       path.c_str(),
+                       days);
+        }
+    }
+
     asio::ssl::context createTlsContext(const remoted::http::HttpServerConfig& config)
     {
         checkTlsFileReadable(config.certificatePath, "certificate");
@@ -474,6 +513,8 @@ namespace
 
         context.use_certificate_chain_file(config.certificatePath);
         context.use_private_key_file(config.privateKeyPath, asio::ssl::context::pem);
+
+        warnIfCertificateExpiring(context, config.certificatePath);
 
         if (SSL_CTX_check_private_key(context.native_handle()) != 1)
         {

--- a/src/remoted/remoted_module/test/unit/authGateway_test.cpp
+++ b/src/remoted/remoted_module/test/unit/authGateway_test.cpp
@@ -44,6 +44,8 @@ namespace
     class FakeKeystore final : public remoted::auth::IAgentKeystore
     {
     public:
+        std::optional<std::string> allowedAddressFor(remoted::auth::AgentId) const override { return std::nullopt; }
+
         std::optional<std::vector<std::uint8_t>> keyFor(remoted::auth::AgentId agentId) const override
         {
             if (agentId == 1)
@@ -60,6 +62,8 @@ namespace
     class ThrowingKeystore final : public remoted::auth::IAgentKeystore
     {
     public:
+        std::optional<std::string> allowedAddressFor(remoted::auth::AgentId) const override { return std::nullopt; }
+
         std::optional<std::vector<std::uint8_t>> keyFor(remoted::auth::AgentId) const override
         {
             throw std::runtime_error("simulated keystore I/O failure");

--- a/src/remoted/remoted_module/test/unit/authMiddleware_test.cpp
+++ b/src/remoted/remoted_module/test/unit/authMiddleware_test.cpp
@@ -37,11 +37,13 @@ namespace
 
     // Writes a one-agent client.keys to a scratch path so Keystore has
     // something real to parse, instead of a stub built just for tests.
-    std::string writeClientKeysFile(const std::string& agentId, const std::vector<std::uint8_t>& key)
+    std::string writeClientKeysFile(const std::string& agentId,
+                                    const std::vector<std::uint8_t>& key,
+                                    const std::string& address = "any")
     {
         const std::string path = "/tmp/authMiddleware_test_" + std::to_string(getpid()) + ".keys";
         std::ofstream file(path);
-        file << agentId << " test-agent any " << toLowerHex(key.data(), key.size()) << "\n";
+        file << agentId << " test-agent " << address << " " << toLowerHex(key.data(), key.size()) << "\n";
         return path;
     }
 
@@ -317,6 +319,58 @@ namespace
         // Both remain std::exception, so existing generic handlers keep working.
         EXPECT_TRUE((std::is_base_of_v<std::exception, CmacKeyError>));
         EXPECT_TRUE((std::is_base_of_v<std::exception, CmacProviderError>));
+    }
+
+    // --- Source-address authorization (checkSourceAddress) --------------------------------------
+
+    TEST(AuthMiddlewareSourceAddress, AnyAllowsEveryPeer)
+    {
+        const auto path = writeClientKeysFile("001", kKey, "any");
+        auto keyStore = std::make_shared<Keystore>(path);
+        AuthMiddleware middleware {AuthConfig {}, keyStore};
+
+        EXPECT_FALSE(middleware.checkSourceAddress("001", "10.0.0.5").has_value());
+        std::remove(path.c_str());
+    }
+
+    TEST(AuthMiddlewareSourceAddress, CidrRejectsPeerOutsideRange)
+    {
+        const auto path = writeClientKeysFile("001", kKey, "10.99.0.0/16");
+        auto keyStore = std::make_shared<Keystore>(path);
+        AuthMiddleware middleware {AuthConfig {}, keyStore};
+
+        EXPECT_FALSE(middleware.checkSourceAddress("001", "10.99.0.1").has_value());
+
+        const auto rejected = middleware.checkSourceAddress("001", "10.100.0.1");
+        ASSERT_TRUE(rejected.has_value());
+        EXPECT_EQ(*rejected, AuthError::SourceIpNotAllowed);
+        std::remove(path.c_str());
+    }
+
+    TEST(AuthMiddlewareSourceAddress, SingleIpRejectsOtherPeer)
+    {
+        const auto path = writeClientKeysFile("001", kKey, "192.168.1.10");
+        auto keyStore = std::make_shared<Keystore>(path);
+        AuthMiddleware middleware {AuthConfig {}, keyStore};
+
+        EXPECT_FALSE(middleware.checkSourceAddress("001", "192.168.1.10").has_value());
+
+        const auto rejected = middleware.checkSourceAddress("001", "192.168.1.11");
+        ASSERT_TRUE(rejected.has_value());
+        EXPECT_EQ(*rejected, AuthError::SourceIpNotAllowed);
+        std::remove(path.c_str());
+    }
+
+    TEST(AuthMiddlewareSourceAddress, UnknownAgentIsUnrestricted)
+    {
+        // A missing address (agent gone from client.keys after the key check) is not enforced --
+        // the key lookup is the authoritative gate; see AuthMiddleware::checkSourceAddress.
+        const auto path = writeClientKeysFile("001", kKey, "10.99.0.0/16");
+        auto keyStore = std::make_shared<Keystore>(path);
+        AuthMiddleware middleware {AuthConfig {}, keyStore};
+
+        EXPECT_FALSE(middleware.checkSourceAddress("999", "203.0.113.1").has_value());
+        std::remove(path.c_str());
     }
 
 } // namespace

--- a/src/remoted/remoted_module/test/unit/keystore_test.cpp
+++ b/src/remoted/remoted_module/test/unit/keystore_test.cpp
@@ -87,6 +87,29 @@ namespace
         EXPECT_FALSE(keystore.keyFor(9999).has_value());
     }
 
+    TEST_F(KeystoreTest, AllowedAddressForReturnsTheAddressColumn)
+    {
+        writeFile("3824 debian10 any ab3193e717865907fc0d347fe49f854699d497e441dd7f4d4c48052334363751\n"
+                  "3825 debian11 10.99.0.0/16 ab3193e717865907fc0d347fe49f854699d497e441dd7f4d4c48052334363751\n");
+        Keystore keystore(m_path);
+
+        const auto anyAddress = keystore.allowedAddressFor(3824);
+        ASSERT_TRUE(anyAddress.has_value());
+        EXPECT_EQ(*anyAddress, "any");
+
+        const auto cidrAddress = keystore.allowedAddressFor(3825);
+        ASSERT_TRUE(cidrAddress.has_value());
+        EXPECT_EQ(*cidrAddress, "10.99.0.0/16");
+    }
+
+    TEST_F(KeystoreTest, AllowedAddressForUnknownAgentIsNullopt)
+    {
+        writeFile("3824 debian10 any ab3193e717865907fc0d347fe49f854699d497e441dd7f4d4c48052334363751\n");
+        Keystore keystore(m_path);
+
+        EXPECT_FALSE(keystore.allowedAddressFor(9999).has_value());
+    }
+
     TEST_F(KeystoreTest, NonNumericIdLineIsSkipped)
     {
         writeFile("abc debian10 any ab3193e717865907fc0d347fe49f854699d497e441dd7f4d4c48052334363751\n");

--- a/src/remoted/remoted_module/test/unit/shutdownRace_test.cpp
+++ b/src/remoted/remoted_module/test/unit/shutdownRace_test.cpp
@@ -70,6 +70,8 @@ namespace
     class FakeKeystore final : public remoted::auth::IAgentKeystore
     {
     public:
+        std::optional<std::string> allowedAddressFor(remoted::auth::AgentId) const override { return std::nullopt; }
+
         std::optional<std::vector<std::uint8_t>> keyFor(remoted::auth::AgentId agentId) const override
         {
             if (agentId == 7)

--- a/src/remoted/remoted_module/test/unit/sourceAddress_test.cpp
+++ b/src/remoted/remoted_module/test/unit/sourceAddress_test.cpp
@@ -1,0 +1,131 @@
+/*
+ * Wazuh remoted HTTPS source-address authorization - unit tests
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <gtest/gtest.h>
+
+#include "auth/sourceAddress.hpp"
+
+using remoted::auth::sourceAddressAllowed;
+
+TEST(SourceAddressTest, AnyAllowsEverything)
+{
+    EXPECT_TRUE(sourceAddressAllowed("any", "10.0.0.5"));
+    EXPECT_TRUE(sourceAddressAllowed("any", "2001:db8::1"));
+    EXPECT_TRUE(sourceAddressAllowed("ANY", "192.168.1.1"));
+}
+
+TEST(SourceAddressTest, EmptySpecIsUnrestricted)
+{
+    // An agent registered without an address column imposes no restriction.
+    EXPECT_TRUE(sourceAddressAllowed("", "10.0.0.5"));
+    EXPECT_TRUE(sourceAddressAllowed("", "2001:db8::1"));
+}
+
+TEST(SourceAddressTest, SingleIPv4ExactMatch)
+{
+    EXPECT_TRUE(sourceAddressAllowed("10.0.0.5", "10.0.0.5"));
+    EXPECT_FALSE(sourceAddressAllowed("10.0.0.5", "10.0.0.6"));
+    EXPECT_FALSE(sourceAddressAllowed("10.0.0.5", "10.0.1.5"));
+}
+
+TEST(SourceAddressTest, SingleIPv6ExactMatch)
+{
+    EXPECT_TRUE(sourceAddressAllowed("2001:db8::1", "2001:db8::1"));
+    // Same address, different textual form.
+    EXPECT_TRUE(sourceAddressAllowed("2001:db8:0:0:0:0:0:1", "2001:db8::1"));
+    EXPECT_FALSE(sourceAddressAllowed("2001:db8::1", "2001:db8::2"));
+}
+
+TEST(SourceAddressTest, IPv4Cidr)
+{
+    EXPECT_TRUE(sourceAddressAllowed("10.99.0.0/16", "10.99.0.1"));
+    EXPECT_TRUE(sourceAddressAllowed("10.99.0.0/16", "10.99.255.254"));
+    EXPECT_FALSE(sourceAddressAllowed("10.99.0.0/16", "10.100.0.1"));
+    EXPECT_TRUE(sourceAddressAllowed("192.168.1.0/24", "192.168.1.42"));
+    EXPECT_FALSE(sourceAddressAllowed("192.168.1.0/24", "192.168.2.42"));
+}
+
+TEST(SourceAddressTest, IPv4CidrBoundaries)
+{
+    // /32 is a single host.
+    EXPECT_TRUE(sourceAddressAllowed("10.0.0.5/32", "10.0.0.5"));
+    EXPECT_FALSE(sourceAddressAllowed("10.0.0.5/32", "10.0.0.6"));
+    // /0 matches every IPv4 address.
+    EXPECT_TRUE(sourceAddressAllowed("0.0.0.0/0", "10.0.0.5"));
+    EXPECT_TRUE(sourceAddressAllowed("0.0.0.0/0", "203.0.113.9"));
+}
+
+TEST(SourceAddressTest, IPv6Cidr)
+{
+    EXPECT_TRUE(sourceAddressAllowed("2001:db8::/32", "2001:db8::1"));
+    EXPECT_TRUE(sourceAddressAllowed("2001:db8::/32", "2001:db8:ffff::abcd"));
+    EXPECT_FALSE(sourceAddressAllowed("2001:db8::/32", "2001:db9::1"));
+}
+
+TEST(SourceAddressTest, FamilyMismatchIsRejected)
+{
+    // A v4 spec never matches a v6 peer and vice versa.
+    EXPECT_FALSE(sourceAddressAllowed("10.0.0.0/8", "2001:db8::1"));
+    EXPECT_FALSE(sourceAddressAllowed("2001:db8::/32", "10.0.0.1"));
+}
+
+TEST(SourceAddressTest, MalformedSpecFailsClosed)
+{
+    EXPECT_FALSE(sourceAddressAllowed("not-an-ip", "10.0.0.1"));
+    EXPECT_FALSE(sourceAddressAllowed("10.0.0.0/", "10.0.0.1"));
+    EXPECT_FALSE(sourceAddressAllowed("10.0.0.0/33", "10.0.0.1"));   // prefix too long for IPv4
+    EXPECT_FALSE(sourceAddressAllowed("10.0.0.0/xx", "10.0.0.1"));
+    EXPECT_FALSE(sourceAddressAllowed("2001:db8::/129", "2001:db8::1"));
+}
+
+TEST(SourceAddressTest, MalformedPeerIsRejected)
+{
+    EXPECT_FALSE(sourceAddressAllowed("10.0.0.0/8", "not-an-ip"));
+}
+
+TEST(SourceAddressTest, IPv4DottedNetmaskIsAcceptedLikeOsIsValidIp)
+{
+    // OS_IsValidIP accepts the dotted-netmask form; the matcher must honour it too.
+    EXPECT_TRUE(sourceAddressAllowed("10.99.0.0/255.255.0.0", "10.99.0.1"));
+    EXPECT_TRUE(sourceAddressAllowed("10.99.0.0/255.255.0.0", "10.99.255.254"));
+    EXPECT_FALSE(sourceAddressAllowed("10.99.0.0/255.255.0.0", "10.100.0.1"));
+    EXPECT_TRUE(sourceAddressAllowed("192.168.1.0/255.255.255.0", "192.168.1.42"));
+    EXPECT_FALSE(sourceAddressAllowed("192.168.1.0/255.255.255.0", "192.168.2.42"));
+    // /0 and /32 equivalents.
+    EXPECT_TRUE(sourceAddressAllowed("0.0.0.0/0.0.0.0", "203.0.113.9"));
+    EXPECT_TRUE(sourceAddressAllowed("10.0.0.5/255.255.255.255", "10.0.0.5"));
+    EXPECT_FALSE(sourceAddressAllowed("10.0.0.5/255.255.255.255", "10.0.0.6"));
+}
+
+TEST(SourceAddressTest, NonContiguousNetmaskIsRejected)
+{
+    EXPECT_FALSE(sourceAddressAllowed("10.0.0.0/255.0.255.0", "10.0.0.1"));
+}
+
+TEST(SourceAddressTest, IPv4MappedIPv6SpecMatchesPlainIPv4Peer)
+{
+    // A "::ffff:x.x.x.x" column is accepted by OS_IsValidIP; the peer arrives as plain IPv4.
+    EXPECT_TRUE(sourceAddressAllowed("::ffff:10.0.0.5", "10.0.0.5"));
+    EXPECT_FALSE(sourceAddressAllowed("::ffff:10.0.0.5", "10.0.0.6"));
+}
+
+TEST(SourceAddressTest, ScopedIPv6PeerIsHandled)
+{
+    // A link-local peer can carry a zone id (fe80::1%eth0); it must not fail closed.
+    EXPECT_TRUE(sourceAddressAllowed("fe80::/10", "fe80::1%eth0"));
+    EXPECT_TRUE(sourceAddressAllowed("fe80::1", "fe80::1%2"));
+    EXPECT_FALSE(sourceAddressAllowed("fe80::1", "fe80::2%2"));
+}
+
+TEST(SourceAddressTest, AnyShortCircuitsBeforePeerParsing)
+{
+    // "any" is unrestricted, so it allows even a peer address that would not parse.
+    EXPECT_TRUE(sourceAddressAllowed("any", "not-an-ip"));
+}

--- a/src/remoted/remoted_module/test/unit/statefulEndpoint_test.cpp
+++ b/src/remoted/remoted_module/test/unit/statefulEndpoint_test.cpp
@@ -355,6 +355,8 @@ namespace
     class FakeKeystore final : public remoted::auth::IAgentKeystore
     {
     public:
+        std::optional<std::string> allowedAddressFor(remoted::auth::AgentId) const override { return std::nullopt; }
+
         std::optional<std::vector<std::uint8_t>> keyFor(remoted::auth::AgentId agentId) const override
         {
             if (agentId == 1)

--- a/src/remoted/remoted_module/test/unit/testTlsServer.hpp
+++ b/src/remoted/remoted_module/test/unit/testTlsServer.hpp
@@ -56,6 +56,8 @@ namespace remoted::test
     class FakeKeystore final : public remoted::auth::IAgentKeystore
     {
     public:
+        std::optional<std::string> allowedAddressFor(remoted::auth::AgentId) const override { return std::nullopt; }
+
         std::optional<std::vector<std::uint8_t>> keyFor(remoted::auth::AgentId agentId) const override
         {
             if (agentId == kTestAgentId)

--- a/src/unit_tests/remoted/test_remote-config.c
+++ b/src/unit_tests/remoted/test_remote-config.c
@@ -651,7 +651,7 @@ static void test_w_remoted_parse_https_valid_full(void **state) {
         create_xml_node("key", "etc/remoted-https/server.key"),
         create_xml_node("ca", "etc/remoted-https/ca.crt"),
         create_xml_node("verification_mode", "certificate"),
-        create_xml_node("ciphers", "HIGH:!ADH"),
+        create_xml_node("ciphers", "TLS_AES_256_GCM_SHA384"),
         create_xml_node("max_body_size", "50MB")
     );
 
@@ -668,7 +668,7 @@ static void test_w_remoted_parse_https_valid_full(void **state) {
     assert_string_equal(ts->logr->https.key, "etc/remoted-https/server.key");
     assert_string_equal(ts->logr->https.ca, "etc/remoted-https/ca.crt");
     assert_int_equal(ts->logr->https.verification_mode, REMOTED_HTTPS_VERIFY_CERTIFICATE);
-    assert_string_equal(ts->logr->https.ciphers, "HIGH:!ADH");
+    assert_string_equal(ts->logr->https.ciphers, "TLS_AES_256_GCM_SHA384");
     assert_int_equal(ts->logr->https.max_body_size, 50L * 1024 * 1024);
 
     free_node_array(nodes);
@@ -719,16 +719,50 @@ static void test_w_remoted_parse_https_invalid_verification_mode(void **state) {
         create_xml_node("verification_mode", "invalid_value")
     );
 
-    expect_string(__wrap__mwarn, formatted_msg,
-                  "(9001): Ignored invalid value 'invalid_value' for 'verification_mode'.");
+    // Rejected rather than ignored: silently defaulting an invalid verification_mode to 'none'
+    // would disable client-certificate verification on a typo.
+    expect_string(__wrap__merror, formatted_msg,
+                  "(1235): Invalid value for element 'verification_mode': invalid_value.");
 
     int result = w_remoted_parse_https(nodes, ts->logr);
 
-    assert_int_equal(result, OS_SUCCESS);
-    // Invalid input is ignored (mwarn above), leaving verification_mode exactly as it
-    // started -- UNSET, since this test never configures <ca> either (create_remoted()
-    // mirrors RemotedConfig()'s real pre-parse UNSET initialization).
-    assert_int_equal(ts->logr->https.verification_mode, REMOTED_HTTPS_VERIFY_UNSET);
+    assert_int_equal(result, OS_INVALID);
+
+    free_node_array(nodes);
+}
+
+static void test_w_remoted_parse_https_invalid_ciphers(void **state) {
+    test_state *ts = *state;
+
+    // A TLS 1.2-style cipher string is rejected at parse time; left unchecked it would make the
+    // HTTPS server fail to start at runtime, past the point 'wazuh-manager-remoted -t' could catch it.
+    xml_node **nodes = create_node_array(1,
+        create_xml_node("ciphers", "HIGH:!ADH")
+    );
+
+    expect_string(__wrap__merror, formatted_msg,
+                  "Invalid TLS 1.3 cipher suite 'HIGH' in the '<remote><https><ciphers>' option.");
+
+    int result = w_remoted_parse_https(nodes, ts->logr);
+
+    assert_int_equal(result, OS_INVALID);
+
+    free_node_array(nodes);
+}
+
+static void test_w_remoted_parse_https_invalid_dual_stack(void **state) {
+    test_state *ts = *state;
+
+    xml_node **nodes = create_node_array(1,
+        create_xml_node("dual_stack", "maybe")
+    );
+
+    expect_string(__wrap__merror, formatted_msg,
+                  "(1235): Invalid value for element 'dual_stack': maybe.");
+
+    int result = w_remoted_parse_https(nodes, ts->logr);
+
+    assert_int_equal(result, OS_INVALID);
 
     free_node_array(nodes);
 }
@@ -1128,6 +1162,8 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_w_remoted_parse_https_invalid_port, setup, teardown),
         cmocka_unit_test_setup_teardown(test_w_remoted_parse_https_invalid_bind_addr, setup, teardown),
         cmocka_unit_test_setup_teardown(test_w_remoted_parse_https_invalid_verification_mode, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_w_remoted_parse_https_invalid_ciphers, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_w_remoted_parse_https_invalid_dual_stack, setup, teardown),
         cmocka_unit_test_setup_teardown(test_w_remoted_parse_https_verification_mode_without_ca, setup, teardown),
         cmocka_unit_test_setup_teardown(test_w_remoted_parse_https_verification_mode_full, setup, teardown),
         cmocka_unit_test_setup_teardown(


### PR DESCRIPTION
## Description

Hardening fixes for the HTTPS agent-manager channel, from findings QA reported during the exploratory testing of the feature. Tracked in #38300.

Closes #38300

## Proposed Changes

- **F-02 — enforce the `client.keys` authorized-address column over HTTPS.** The third column (single IP, CIDR, or `any`) was parsed and discarded, so the HTTPS listener accepted an authenticated agent from any source, unlike the legacy listener (`OS_IsAllowedIP`). The keystore now keeps the address, and after the MAC verifies (so the ACL is never exposed to an unauthenticated peer) the peer address is matched against it; a peer outside the range gets `403 Source address not authorized`. The rejection is logged as a throttled WARN naming the agent (a security signal, handled like the payload-identity mismatch), rather than a silent debug line.
- **F-03 — validate `<remote><https><ciphers>` against the TLS 1.3 suite list at parse time.** A TLS 1.2-style string (e.g. `HIGH:!ADH`) passed the config test and only failed at runtime, taking the listener down. `authd` and the agent already validate this; `remoted` now does too.
- **F-05 — reject invalid `verification_mode`/`dual_stack` values instead of warning and falling back.** A typo in `verification_mode` silently disabled client-certificate verification; it is now a configuration error.
- **F-07 — warn at startup when the manager certificate has expired or expires within 30 days.** Previously served with no signal to the operator.

### Results and Evidence

Built and unit-tested in a Linux container (Ubuntu 24.04) against this branch. `remoted_module_utest` compiles cleanly and the suites covering the change all pass:

| Suite | Result | Covers |
|---|---|---|
| `SourceAddressTest` | 11/11 | IP/CIDR/`any` matcher (IPv4/IPv6, boundaries, family mismatch, malformed) |
| `KeystoreTest` | 19/19 | `allowedAddressFor` plus `keyFor` unchanged after the `AgentEntry` change |
| `AuthMiddlewareSourceAddress` | 4/4 | `checkSourceAddress` (any / CIDR / single IP / unknown agent) |
| `AuthGatewayTest` | 16/16 | auth pipeline with the source-address check integrated, no regression |
| `ControlHandlerTest` | 10/10 | `/control` path, no regression |

```
[  PASSED  ] 60 tests.
```

The TLS 1.3 cipher validator (F-03) and the source-address matcher were additionally compiled and run standalone (`-Wall -Wextra`, no warnings): 11/11 and 23/23, including the exact TLS 1.2 idiom the shipped `<auth>` block uses.

Not run locally and left to the PR CI: `test_remote-config` (C cmocka, F-03/F-05), which needs a full manager build, and the full `remoted_module_utest` suite, whose TLS-server/load tests hang under a plain Docker container.

### Artifacts Affected

- `wazuh-manager-remoted` (Linux). No package or default-configuration changes.

### Configuration Changes

- `<remote><https><ciphers>`: now validated as a TLS 1.3 suite list at parse time.
- `<remote><https><verification_mode>` / `<dual_stack>`: an invalid value is now a hard configuration error instead of a warning + fallback.
- New behaviour, no new options: the `client.keys` address column is now enforced on the HTTPS channel; a certificate-expiry warning is logged at startup.

### Documentation Updates

- `docs/ref/modules/remoted/configuration.md`: `verification_mode`, `dual_stack`, `ciphers`, `certificate` notes.
- `docs/ref/modules/remoted/https-events-api.md`: `403` source-address row in the status table plus a note on the source-address check.

### Tests Introduced

- `sourceAddress_test.cpp` (new): the IP/CIDR/`any` matcher across IPv4/IPv6, boundaries, family mismatch and malformed inputs.
- `authMiddleware_test.cpp`: `checkSourceAddress` for `any`, CIDR, single-IP and unknown-agent cases.
- `keystore_test.cpp`: `allowedAddressFor` returns the address column / nullopt for an unknown agent.
- `test_remote-config.c`: invalid ciphers and invalid `dual_stack` rejected; invalid `verification_mode` now returns `OS_INVALID`; the valid-parse test uses a real TLS 1.3 suite.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)


