### PR TITLE
Windows agent HTTPS 401 clock-skew

### DIFF
--- a/src/client-agent/https_client/src/curlHandle.cpp
+++ b/src/client-agent/https_client/src/curlHandle.cpp
@@ -116,15 +116,38 @@ namespace
         return wrote;
     }
 
+    /// Bundles both headers this trampoline cares about: libcurl allows only
+    /// one HEADERFUNCTION/HEADERDATA pair per handle, so both live behind one
+    /// userData pointer instead of two.
+    struct HeaderCapture
+    {
+        long* retryAfter {nullptr};
+        std::time_t* serverDate {nullptr};
+    };
+
     size_t headerTrampoline(char* data, size_t size, size_t nmemb, void* userData)
     {
         const size_t total = size * nmemb;
-        auto* retryAfter = static_cast<long*>(userData);
-        constexpr size_t prefixLength = 12; // "Retry-After:"
+        auto* capture = static_cast<HeaderCapture*>(userData);
+        constexpr size_t retryAfterPrefixLength = 12; // "Retry-After:"
+        constexpr size_t datePrefixLength = 5;        // "Date:"
 
-        if (total > prefixLength && strncasecmp(data, "Retry-After:", prefixLength) == 0)
+        if (total > retryAfterPrefixLength && strncasecmp(data, "Retry-After:", retryAfterPrefixLength) == 0)
         {
-            *retryAfter = std::strtol(data + prefixLength, nullptr, 10);
+            *capture->retryAfter = std::strtol(data + retryAfterPrefixLength, nullptr, 10);
+        }
+        else if (total > datePrefixLength && strncasecmp(data, "Date:", datePrefixLength) == 0)
+        {
+            // curl_getdate() parses RFC 1123/850 and asctime formats and
+            // returns -1 on failure; a null-terminated copy is required since
+            // the header line is not itself nul-terminated by libcurl.
+            const std::string value(data + datePrefixLength, total - datePrefixLength);
+            const time_t parsed = curl_getdate(value.c_str(), nullptr);
+
+            if (parsed != -1)
+            {
+                *capture->serverDate = parsed;
+            }
         }
 
         return total;
@@ -237,10 +260,11 @@ namespace
                        curl_easy_setopt(m_handle, CURLOPT_WRITEDATA, &m_fileSink) == CURLE_OK;
             }
 
-            bool captureRetryAfter(long* output) override
+            bool captureResponseHeaders(long* retryAfter, std::time_t* serverDate) override
             {
+                m_headerCapture = HeaderCapture {retryAfter, serverDate};
                 return curl_easy_setopt(m_handle, CURLOPT_HEADERFUNCTION, headerTrampoline) == CURLE_OK &&
-                       curl_easy_setopt(m_handle, CURLOPT_HEADERDATA, output) == CURLE_OK;
+                       curl_easy_setopt(m_handle, CURLOPT_HEADERDATA, &m_headerCapture) == CURLE_OK;
             }
 
             bool streamBodyFromFile(std::FILE* file, uint64_t size) override
@@ -291,6 +315,7 @@ namespace
             CURL* m_handle {nullptr};
             curl_slist* m_headers {nullptr};
             FileSink m_fileSink {};
+            HeaderCapture m_headerCapture {};
     };
 } // namespace
 

--- a/src/client-agent/https_client/src/curlHandle.cpp
+++ b/src/client-agent/https_client/src/curlHandle.cpp
@@ -65,7 +65,8 @@ namespace
             {CurlOption::SslCiphers, CURLOPT_TLS13_CIPHERS},
             {CurlOption::SslOptions, CURLOPT_SSL_OPTIONS},
             {CurlOption::FollowLocation, CURLOPT_FOLLOWLOCATION},
-            {CurlOption::NoSignal, CURLOPT_NOSIGNAL}
+            {CurlOption::NoSignal, CURLOPT_NOSIGNAL},
+            {CurlOption::SuppressConnectHeaders, CURLOPT_SUPPRESS_CONNECT_HEADERS}
         };
         return *map;
     }
@@ -138,15 +139,26 @@ namespace
         }
         else if (total > datePrefixLength && strncasecmp(data, "Date:", datePrefixLength) == 0)
         {
-            // curl_getdate() parses RFC 1123/850 and asctime formats and
-            // returns -1 on failure; a null-terminated copy is required since
-            // the header line is not itself nul-terminated by libcurl.
-            const std::string value(data + datePrefixLength, total - datePrefixLength);
-            const time_t parsed = curl_getdate(value.c_str(), nullptr);
-
-            if (parsed != -1)
+            // curl callbacks are C: nothing may throw across them (see
+            // writeTrampoline above) -- std::string construction from
+            // unvalidated header bytes can throw std::bad_alloc under memory
+            // pressure, so guard it the same way.
+            try
             {
-                *capture->serverDate = parsed;
+                // curl_getdate() parses RFC 1123/850 and asctime formats and
+                // returns -1 on failure; a null-terminated copy is required
+                // since the header line is not itself nul-terminated by libcurl.
+                const std::string value(data + datePrefixLength, total - datePrefixLength);
+                const time_t parsed = curl_getdate(value.c_str(), nullptr);
+
+                if (parsed != -1)
+                {
+                    *capture->serverDate = parsed;
+                }
+            }
+            catch (...)
+            {
+                return 0; // LCOV_EXCL_LINE: allocation failure aborts the transfer.
             }
         }
 

--- a/src/client-agent/https_client/src/curlHandle.cpp
+++ b/src/client-agent/https_client/src/curlHandle.cpp
@@ -117,15 +117,6 @@ namespace
         return wrote;
     }
 
-    /// Bundles both headers this trampoline cares about: libcurl allows only
-    /// one HEADERFUNCTION/HEADERDATA pair per handle, so both live behind one
-    /// userData pointer instead of two.
-    struct HeaderCapture
-    {
-        long* retryAfter {nullptr};
-        std::time_t* serverDate {nullptr};
-    };
-
     size_t headerTrampoline(char* data, size_t size, size_t nmemb, void* userData)
     {
         const size_t total = size * nmemb;
@@ -272,9 +263,9 @@ namespace
                        curl_easy_setopt(m_handle, CURLOPT_WRITEDATA, &m_fileSink) == CURLE_OK;
             }
 
-            bool captureResponseHeaders(long* retryAfter, std::time_t* serverDate) override
+            bool captureResponseHeaders(HeaderCapture capture) override
             {
-                m_headerCapture = HeaderCapture {retryAfter, serverDate};
+                m_headerCapture = capture;
                 return curl_easy_setopt(m_handle, CURLOPT_HEADERFUNCTION, headerTrampoline) == CURLE_OK &&
                        curl_easy_setopt(m_handle, CURLOPT_HEADERDATA, &m_headerCapture) == CURLE_OK;
             }

--- a/src/client-agent/https_client/src/curlPerformer.cpp
+++ b/src/client-agent/https_client/src/curlPerformer.cpp
@@ -64,6 +64,9 @@ namespace
             case CurlOption::NoSignal:
                 return "NOSIGNAL";
 
+            case CurlOption::SuppressConnectHeaders:
+                return "SUPPRESS_CONNECT_HEADERS";
+
             default:
                 return "unknown"; // LCOV_EXCL_LINE: applyTls sets none of the rest.
         }
@@ -283,7 +286,11 @@ bool CurlPerformer::applyTls(ICurlHandle& handle) const
            && applyClientCertificate(handle)
            && applyCiphers(handle)
            && setMandatoryOption(handle, CurlOption::FollowLocation, 0L) // H4: no redirects.
-           && setMandatoryOption(handle, CurlOption::NoSignal, 1L);      // H6.
+           && setMandatoryOption(handle, CurlOption::NoSignal, 1L)       // H6.
+           // Never let a forward-proxy's CONNECT-tunnel response headers reach
+           // headerTrampoline: without this, a proxy's own Date could be
+           // captured as if it were the manager's (#38439 clock-skew fix).
+           && setMandatoryOption(handle, CurlOption::SuppressConnectHeaders, 1L);
 }
 
 bool CurlPerformer::applyTrustAnchors(ICurlHandle& handle) const

--- a/src/client-agent/https_client/src/curlPerformer.cpp
+++ b/src/client-agent/https_client/src/curlPerformer.cpp
@@ -255,7 +255,7 @@ bool CurlPerformer::configureRequest(ICurlHandle& handle, const HttpRequestSpec&
 
     handle.appendHeader("Expect:"); // Disable 100-continue; keep a fixed Content-Length.
 
-    if (!handle.captureResponseHeaders(&response.retryAfterSeconds, &response.serverDateSeconds))
+    if (!handle.captureResponseHeaders({&response.retryAfterSeconds, &response.serverDateSeconds}))
     {
         return false;
     }

--- a/src/client-agent/https_client/src/curlPerformer.cpp
+++ b/src/client-agent/https_client/src/curlPerformer.cpp
@@ -252,7 +252,7 @@ bool CurlPerformer::configureRequest(ICurlHandle& handle, const HttpRequestSpec&
 
     handle.appendHeader("Expect:"); // Disable 100-continue; keep a fixed Content-Length.
 
-    if (!handle.captureRetryAfter(&response.retryAfterSeconds))
+    if (!handle.captureResponseHeaders(&response.retryAfterSeconds, &response.serverDateSeconds))
     {
         return false;
     }

--- a/src/client-agent/https_client/src/httpTypes.hpp
+++ b/src/client-agent/https_client/src/httpTypes.hpp
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <ctime>
 #include <string>
 #include <vector>
 
@@ -167,6 +168,11 @@ struct HttpResponse
     TransportStatus status {TransportStatus::OtherError};
     long httpCode {0};
     long retryAfterSeconds {0}; ///< Parsed Retry-After header (0 = absent).
+    std::time_t serverDateSeconds {0}; ///< Parsed Date header, manager's clock at
+    ///< response time (0 = absent/unparsed). Every response the manager's
+    ///< transport builds carries one, including every 401 -- RetrySender's
+    ///< one-shot auth retry uses it to detect and correct clock skew before
+    ///< assuming a 401 means a dead credential (#37828 follow-up).
     std::string localIp;        ///< Local IP of the connection (CURLINFO_LOCAL_IP);
     ///< the agent's own address toward the manager.
     std::string body;

--- a/src/client-agent/https_client/src/httpsClientFacade.hpp
+++ b/src/client-agent/https_client/src/httpsClientFacade.hpp
@@ -88,7 +88,14 @@ class HttpsClientFacade final
         const LogFn m_logFn {HTTPS_CLIENT_LOGTAG};
 
         // Seams (built once; stable references handed to the streams).
-        SystemClock m_clock;
+        // m_clock wraps m_systemClock with a runtime-correctable offset: every
+        // stream below is handed IClock& m_clock, so a skew RetrySender learns
+        // from any one manager response corrects every sender's signing
+        // timestamp from the next request on (#37828 follow-up). Declaration
+        // order matters here -- m_systemClock must construct before m_clock,
+        // which holds a reference to it.
+        SystemClock m_systemClock;
+        SkewCorrectedClock m_clock {m_systemClock};
         Mt19937Random m_random;
         FsProbe m_fsProbe;
         ConfigKeyProvider m_keyProvider;

--- a/src/client-agent/https_client/src/iCurlHandle.hpp
+++ b/src/client-agent/https_client/src/iCurlHandle.hpp
@@ -63,6 +63,15 @@ inline constexpr long TLS_MIN_VERSION_1_3 {7};
 /// like the version above.
 inline constexpr long TLS_NATIVE_CA_STORE {1L << 4};
 
+/// Output slots for captureResponseHeaders(): libcurl allows only one
+/// HEADERFUNCTION/HEADERDATA pair per handle, so both captured headers live
+/// behind one struct instead of two separate parameters.
+struct HeaderCapture
+{
+    long* retryAfter {nullptr};
+    std::time_t* serverDate {nullptr};
+};
+
 /**
  * @brief One HTTP transfer, at the option level.
  *
@@ -91,13 +100,15 @@ class ICurlHandle
         virtual bool captureResponseToFile(std::FILE* file, uint64_t maxBytes) = 0;
 
         /// Installs the one HEADERFUNCTION/HEADERDATA pair libcurl allows per
-        /// handle: retryAfter receives the parsed Retry-After header (0 =
-        /// absent), serverDate receives the parsed Date header (0 =
-        /// absent/unparsed) -- the manager's own transport stamps Date on
-        /// every response it builds, including every 401, which is what lets
-        /// the agent detect and correct clock skew instead of assuming a 401
-        /// always means a dead credential.
-        virtual bool captureResponseHeaders(long* retryAfter, std::time_t* serverDate) = 0;
+        /// handle: capture.retryAfter receives the parsed Retry-After header
+        /// (0 = absent), capture.serverDate receives the parsed Date header
+        /// (0 = absent/unparsed) -- the manager's own transport stamps Date
+        /// on every response it builds, including every 401, which is what
+        /// lets the agent detect and correct clock skew instead of assuming
+        /// a 401 always means a dead credential.
+        /// @return false if the underlying option(s) were rejected by libcurl;
+        ///         the caller must not proceed to perform() in that case.
+        virtual bool captureResponseHeaders(HeaderCapture capture) = 0;
 
         virtual bool streamBodyFromFile(std::FILE* file, uint64_t size) = 0;
         virtual bool wireAbort(const std::atomic<bool>* abortFlag) = 0;

--- a/src/client-agent/https_client/src/iCurlHandle.hpp
+++ b/src/client-agent/https_client/src/iCurlHandle.hpp
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <cstdint>
 #include <cstdio>
+#include <ctime>
 #include <functional>
 #include <memory>
 #include <string>
@@ -81,7 +82,16 @@ class ICurlHandle
         ///         silently not be in effect.
         virtual bool captureResponseBody(std::string* output) = 0;
         virtual bool captureResponseToFile(std::FILE* file, uint64_t maxBytes) = 0;
-        virtual bool captureRetryAfter(long* output) = 0;
+
+        /// Installs the one HEADERFUNCTION/HEADERDATA pair libcurl allows per
+        /// handle: retryAfter receives the parsed Retry-After header (0 =
+        /// absent), serverDate receives the parsed Date header (0 =
+        /// absent/unparsed) -- the manager's own transport stamps Date on
+        /// every response it builds, including every 401, which is what lets
+        /// the agent detect and correct clock skew instead of assuming a 401
+        /// always means a dead credential.
+        virtual bool captureResponseHeaders(long* retryAfter, std::time_t* serverDate) = 0;
+
         virtual bool streamBodyFromFile(std::FILE* file, uint64_t size) = 0;
         virtual bool wireAbort(const std::atomic<bool>* abortFlag) = 0;
 

--- a/src/client-agent/https_client/src/iCurlHandle.hpp
+++ b/src/client-agent/https_client/src/iCurlHandle.hpp
@@ -40,7 +40,14 @@ enum class CurlOption
     SslCiphers,     ///< string TLS 1.3 ciphersuite list
     SslOptions,     ///< long, the TLS behaviour bitmask
     FollowLocation, ///< long, always 0 (H4: no redirects)
-    NoSignal        ///< long, always 1 (H6)
+    NoSignal,       ///< long, always 1 (H6)
+    /// long, always 1: never deliver a forward-proxy's CONNECT-tunnel
+    /// response headers to the header callback. Without this, a proxy's own
+    /// Date could be captured as if it were the manager's (headerTrampoline
+    /// in curlHandle.cpp does not distinguish which hop a header block came
+    /// from), undermining the clock-skew correction's premise of trusting
+    /// only whoever completed the TLS handshake to the manager.
+    SuppressConnectHeaders
 };
 
 /// Value for CurlOption::SslVersion: refuse to negotiate below TLS 1.3.

--- a/src/client-agent/https_client/src/retrySender.cpp
+++ b/src/client-agent/https_client/src/retrySender.cpp
@@ -230,6 +230,13 @@ void RetrySender::correctClockIfSkewed(const HttpResponse& response)
         return; // No Date captured/parsed: nothing to measure skew against.
     }
 
+    // This read is only a heuristic pre-check (noise floor + log message):
+    // it can race against another sender's concurrent correction and see a
+    // stale wallSeconds(), but that only risks skipping/duplicating a log
+    // line or a redundant call below -- m_clock.correctToServerTime()
+    // recomputes the actual offset itself, from its own raw clock read
+    // taken at commit time, so a stale `delta` here never corrupts the
+    // applied correction (see IClock::correctToServerTime's contract).
     const auto delta = static_cast<std::int64_t>(response.serverDateSeconds) -
                        static_cast<std::int64_t>(m_clock.wallSeconds());
 
@@ -238,7 +245,7 @@ void RetrySender::correctClockIfSkewed(const HttpResponse& response)
         return; // Aligned enough: leave the clock alone, the 401 is likely a dead key.
     }
 
-    m_clock.applyOffsetSeconds(delta);
+    m_clock.correctToServerTime(response.serverDateSeconds);
     LOGFN_INFO(m_logFn,
                "https_client: clock skew of %lld s detected against the manager's response "
                "(Date header); correcting the signing timestamp for this and future requests.",

--- a/src/client-agent/https_client/src/retrySender.cpp
+++ b/src/client-agent/https_client/src/retrySender.cpp
@@ -12,6 +12,7 @@
 #include "retrySender.hpp"
 
 #include <algorithm>
+#include <cstdlib>
 #include <vector>
 
 #include <zstd.h>
@@ -21,6 +22,14 @@ namespace
     // Matches the level the manager's own test-only compressor
     // (zstdTestHelper.hpp's zstdCompress()) uses to build its zstd fixtures.
     constexpr int kCompressionLevel = 3;
+
+    // Below this, a Date-vs-local gap is plausibly network latency or Date's
+    // 1 s granularity, not real clock skew -- applying a correction for noise
+    // this small would only ever matter within the 300 s CMAC window this
+    // agent already tolerates, so it is not worth perturbing signing over.
+    // The clock-skew failures this targets (VM snapshot restore, dead CMOS
+    // battery, no NTP) are minutes to hours off, far above this floor.
+    constexpr std::int64_t kSkewNoiseFloorSeconds = 5;
 } // namespace
 
 RetrySender::RetrySender(IHttpPerformer& performer, const ISigner& signer, IClock& clock,
@@ -57,12 +66,17 @@ RetrySender::Result RetrySender::send(const HttpRequestSpec& spec, Waiter& waite
         // skip its own auth grace-retry and escalate straight to reportAuthFailure().
         for (;;)
         {
-            // One-shot 401 retry: a 401 can be a just-expired/edge timestamp as
-            // easily as a dead key. Resign with a fresh timestamp (attemptOnce
-            // re-signs) and try once more; only a second 401 escalates below.
+            // One-shot 401 retry: a 401 can be a just-expired/edge timestamp,
+            // a clock-skewed agent, or a dead key -- the manager deliberately
+            // answers all three identically (#37828). Correct for
+            // measurable skew (if the response carried the manager's Date)
+            // and resign with a fresh timestamp (attemptOnce re-signs); only
+            // a second 401 -- now on a timestamp already skew-corrected --
+            // escalates below as a genuine credential failure.
             if (result.outcome == OutcomeClass::AuthFail && !authRetried)
             {
                 authRetried = true;
+                correctClockIfSkewed(result.response);
                 result = attemptOnce(base);
                 continue;
             }
@@ -200,4 +214,33 @@ bool RetrySender::isRetryable(OutcomeClass outcome)
 {
     return outcome == OutcomeClass::Unreachable || outcome == OutcomeClass::ServerError ||
            outcome == OutcomeClass::BackPressure;
+}
+
+void RetrySender::correctClockIfSkewed(const HttpResponse& response)
+{
+    // Date is not itself authenticated (it isn't covered by any signature),
+    // so this trusts whoever answered the TLS handshake -- no different from
+    // trusting the 401 status/body it arrived with. Under the required TLS
+    // verification modes this is the real manager; under verify_mode=none
+    // (opt-in, insecure) a MITM could already forge the entire response, so
+    // feeding it a bogus Date is not a new capability, only a new use of an
+    // existing one.
+    if (response.serverDateSeconds == 0)
+    {
+        return; // No Date captured/parsed: nothing to measure skew against.
+    }
+
+    const auto delta = static_cast<std::int64_t>(response.serverDateSeconds) -
+                       static_cast<std::int64_t>(m_clock.wallSeconds());
+
+    if (std::abs(delta) < kSkewNoiseFloorSeconds)
+    {
+        return; // Aligned enough: leave the clock alone, the 401 is likely a dead key.
+    }
+
+    m_clock.applyOffsetSeconds(delta);
+    LOGFN_INFO(m_logFn,
+               "https_client: clock skew of %lld s detected against the manager's response "
+               "(Date header); correcting the signing timestamp for this and future requests.",
+               static_cast<long long>(delta));
 }

--- a/src/client-agent/https_client/src/retrySender.hpp
+++ b/src/client-agent/https_client/src/retrySender.hpp
@@ -17,6 +17,7 @@
 #include "cmacSigner.hpp"
 #include "compressionGate.hpp"
 #include "iHttpPerformer.hpp"
+#include "moduleLog.hpp"
 #include "outcomeClassifier.hpp"
 #include "stopToken.hpp"
 #include "sysSeams.hpp"
@@ -66,6 +67,14 @@ class RetrySender final
         std::chrono::milliseconds delayFor(const Result& result);
         static bool isRetryable(OutcomeClass outcome);
 
+        /// Measures skew from the failed attempt's response against this
+        /// clock's current wallSeconds() and, if it exceeds a noise floor,
+        /// pushes the correction into m_clock before the auth grace-retry
+        /// re-signs. A no-op when the response carries no Date (old manager,
+        /// or a proxy that stripped it) or when the measured gap is small
+        /// enough to be latency/rounding rather than real skew.
+        void correctClockIfSkewed(const HttpResponse& response);
+
         IHttpPerformer& m_performer;
         const ISigner& m_signer;
         IClock& m_clock;
@@ -73,6 +82,7 @@ class RetrySender final
         bool m_compressionEnabled;
         CompressionGate* m_compressionGate;
         AuthGate* m_authGate;
+        const LogFn m_logFn {HTTPS_CLIENT_LOGTAG};
 };
 
 #endif // _HC_RETRY_SENDER_HPP

--- a/src/client-agent/https_client/src/sysSeams.hpp
+++ b/src/client-agent/https_client/src/sysSeams.hpp
@@ -29,22 +29,26 @@ class IClock
         virtual std::time_t wallSeconds() const = 0;
         virtual std::chrono::steady_clock::time_point steadyNow() const = 0;
 
-        /// Pushes a measured clock-skew correction (signed seconds) into this
-        /// clock, applied to every wallSeconds() call from here on;
+        /// Corrects this clock so wallSeconds() reports serverWallSeconds
+        /// "now" and every subsequent wallSeconds() call from here on;
         /// steadyNow() (cadence) is never affected. Default no-op: only a
         /// clock that supports runtime correction (SkewCorrectedClock) needs
         /// to override it -- SystemClock and every test double that does not
         /// care about skew correction inherit this and stay unaffected.
         ///
-        /// Contract for an overriding clock: the correction MUST accumulate,
-        /// not replace. The caller always measures its delta against THIS
-        /// clock's own (possibly already-corrected) wallSeconds(), so a
-        /// second, independent skew event landing on top of an existing
-        /// correction must fold its delta onto the prior offset rather than
-        /// overwrite it -- replacing would silently undo the earlier
-        /// correction by exactly its own magnitude. See SkewCorrectedClock's
+        /// Contract for an overriding clock: this MUST be safe to call
+        /// concurrently from multiple threads (every HTTPS sender shares one
+        /// SkewCorrectedClock instance, and a real clock jump can make more
+        /// than one of them observe a 401 around the same moment). The
+        /// implementation must derive the new correction from its OWN raw
+        /// clock read taken at commit time, not from a delta the caller
+        /// computed earlier against a (possibly already stale, or
+        /// concurrently-corrected) wallSeconds() reading -- otherwise two
+        /// racing callers each read the same pre-correction time, each
+        /// compute ~the same delta, and both apply it, overcorrecting by
+        /// roughly double instead of converging. See SkewCorrectedClock's
         /// implementation comment for the algebra.
-        virtual void applyOffsetSeconds(std::int64_t /*offsetSeconds*/) {}
+        virtual void correctToServerTime(std::time_t /*serverWallSeconds*/) {}
 };
 
 /// Uniform randomness source for the full-jitter backoff.
@@ -94,27 +98,29 @@ class SkewCorrectedClock final : public IClock
             return m_base.steadyNow(); // Cadence timing is never skew-corrected.
         }
 
-        void applyOffsetSeconds(std::int64_t offsetSeconds) override
+        void correctToServerTime(std::time_t serverWallSeconds) override
         {
-            // Accumulate, don't replace: the caller (RetrySender) measures
-            // its delta against THIS clock's own wallSeconds() -- i.e.
-            // against a reading that already includes any prior offset. A
-            // second, independent skew event (further drift, or a second
-            // clock jump, after the agent has already self-corrected once)
-            // therefore yields a delta relative to the already-corrected
-            // baseline, not to the raw one. Replacing here would discard the
-            // earlier correction and leave the clock off by exactly its
-            // magnitude; accumulating folds the new delta on top and lands
-            // on the same result as re-measuring from the raw clock and
-            // overwriting, algebraically: offset_new = offset_old + (server
-            // - corrected) = offset_old + (server - raw - offset_old) =
-            // server - raw.
-            m_offsetSeconds.fetch_add(offsetSeconds, std::memory_order_relaxed);
+            // Recompute the offset from the RAW base clock read at commit
+            // time, under a lock, rather than accepting a delta the caller
+            // measured earlier against wallSeconds() (this clock's own,
+            // possibly already-corrected or concurrently-changing reading).
+            // That makes every call idempotent and race-safe: no matter how
+            // many threads call this at nearly the same moment (a real clock
+            // jump can make more than one of the shared HTTPS senders 401
+            // around the same time), each one lands on essentially the same
+            // offset_new = serverWallSeconds - raw -- never a sum of two
+            // callers' deltas. The lock only serializes rare correction
+            // events; wallSeconds() stays lock-free.
+            const std::lock_guard<std::mutex> lock(m_mutex);
+            const auto raw = static_cast<std::int64_t>(m_base.wallSeconds());
+            m_offsetSeconds.store(static_cast<std::int64_t>(serverWallSeconds) - raw,
+                                  std::memory_order_relaxed);
         }
 
     private:
         IClock& m_base;
         std::atomic<std::int64_t> m_offsetSeconds {0};
+        std::mutex m_mutex;
 };
 
 class Mt19937Random final : public IRandom

--- a/src/client-agent/https_client/src/sysSeams.hpp
+++ b/src/client-agent/https_client/src/sysSeams.hpp
@@ -12,7 +12,9 @@
 #ifndef _HC_SYS_SEAMS_HPP
 #define _HC_SYS_SEAMS_HPP
 
+#include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <ctime>
 #include <mutex>
 #include <random>
@@ -26,6 +28,23 @@ class IClock
         virtual ~IClock() = default;
         virtual std::time_t wallSeconds() const = 0;
         virtual std::chrono::steady_clock::time_point steadyNow() const = 0;
+
+        /// Pushes a measured clock-skew correction (signed seconds) into this
+        /// clock, applied to every wallSeconds() call from here on;
+        /// steadyNow() (cadence) is never affected. Default no-op: only a
+        /// clock that supports runtime correction (SkewCorrectedClock) needs
+        /// to override it -- SystemClock and every test double that does not
+        /// care about skew correction inherit this and stay unaffected.
+        ///
+        /// Contract for an overriding clock: the correction MUST accumulate,
+        /// not replace. The caller always measures its delta against THIS
+        /// clock's own (possibly already-corrected) wallSeconds(), so a
+        /// second, independent skew event landing on top of an existing
+        /// correction must fold its delta onto the prior offset rather than
+        /// overwrite it -- replacing would silently undo the earlier
+        /// correction by exactly its own magnitude. See SkewCorrectedClock's
+        /// implementation comment for the algebra.
+        virtual void applyOffsetSeconds(std::int64_t /*offsetSeconds*/) {}
 };
 
 /// Uniform randomness source for the full-jitter backoff.
@@ -49,6 +68,53 @@ class SystemClock final : public IClock
     public:
         std::time_t wallSeconds() const override;
         std::chrono::steady_clock::time_point steadyNow() const override;
+};
+
+/// Decorates a base IClock with a runtime-correctable offset applied to
+/// wallSeconds() only. All seven HTTPS senders share one instance of this
+/// (HttpsClientFacade::m_clock) by reference, so a skew learned from any one
+/// manager response (RetrySender's one-shot 401 retry, per #37828)
+/// corrects every subsequent signing timestamp agent-wide, starting with the
+/// very next request -- not just the sender that observed the 401.
+class SkewCorrectedClock final : public IClock
+{
+    public:
+        explicit SkewCorrectedClock(IClock& base)
+            : m_base(base)
+        {
+        }
+
+        std::time_t wallSeconds() const override
+        {
+            return m_base.wallSeconds() + m_offsetSeconds.load(std::memory_order_relaxed);
+        }
+
+        std::chrono::steady_clock::time_point steadyNow() const override
+        {
+            return m_base.steadyNow(); // Cadence timing is never skew-corrected.
+        }
+
+        void applyOffsetSeconds(std::int64_t offsetSeconds) override
+        {
+            // Accumulate, don't replace: the caller (RetrySender) measures
+            // its delta against THIS clock's own wallSeconds() -- i.e.
+            // against a reading that already includes any prior offset. A
+            // second, independent skew event (further drift, or a second
+            // clock jump, after the agent has already self-corrected once)
+            // therefore yields a delta relative to the already-corrected
+            // baseline, not to the raw one. Replacing here would discard the
+            // earlier correction and leave the clock off by exactly its
+            // magnitude; accumulating folds the new delta on top and lands
+            // on the same result as re-measuring from the raw clock and
+            // overwriting, algebraically: offset_new = offset_old + (server
+            // - corrected) = offset_old + (server - raw - offset_old) =
+            // server - raw.
+            m_offsetSeconds.fetch_add(offsetSeconds, std::memory_order_relaxed);
+        }
+
+    private:
+        IClock& m_base;
+        std::atomic<std::int64_t> m_offsetSeconds {0};
 };
 
 class Mt19937Random final : public IRandom

--- a/src/client-agent/https_client/tests/unit/curlPerformer_test.cpp
+++ b/src/client-agent/https_client/tests/unit/curlPerformer_test.cpp
@@ -26,7 +26,9 @@
 #include <fstream>
 
 using ::testing::_;
+using ::testing::AllOf;
 using ::testing::DoAll;
+using ::testing::Field;
 using ::testing::Invoke;
 using ::testing::NiceMock;
 using ::testing::NotNull;
@@ -88,7 +90,8 @@ TEST(CurlPerformerTest, MemoryBodyMapsToExactOptions)
     EXPECT_CALL(*handle, appendHeader("Authorization: Wazuh 001:1:aa"));
     EXPECT_CALL(*handle, setOptionLong(CurlOption::TimeoutMs, 1234L));
     EXPECT_CALL(*handle, captureResponseBody(NotNull()));
-    EXPECT_CALL(*handle, captureResponseHeaders(NotNull(), NotNull()));
+    EXPECT_CALL(*handle, captureResponseHeaders(AllOf(Field(&HeaderCapture::retryAfter, NotNull()),
+                                                      Field(&HeaderCapture::serverDate, NotNull()))));
     EXPECT_CALL(*handle, perform()).WillOnce(Return(TransportStatus::Ok));
     EXPECT_CALL(*handle, responseCode()).WillOnce(Return(200));
 
@@ -145,18 +148,16 @@ TEST(CurlPerformerTest, ResponseBodyAndRetryAfterFlowBack)
     auto* handle = mock.get();
 
     std::string* bodyOut = nullptr;
-    long* retryAfterOut = nullptr;
-    std::time_t* serverDateOut = nullptr;
+    HeaderCapture captureOut {};
     EXPECT_CALL(*handle, captureResponseBody(_)).WillOnce(DoAll(SaveArg<0>(&bodyOut), Return(true)));
-    EXPECT_CALL(*handle, captureResponseHeaders(_, _))
-    .WillOnce(DoAll(SaveArg<0>(&retryAfterOut), SaveArg<1>(&serverDateOut), Return(true)));
+    EXPECT_CALL(*handle, captureResponseHeaders(_)).WillOnce(DoAll(SaveArg<0>(&captureOut), Return(true)));
     EXPECT_CALL(*handle, perform())
     .WillOnce(Invoke(
                   [&]() -> TransportStatus
     {
         *bodyOut = "{\"ok\":true}";
-        *retryAfterOut = 7;
-        *serverDateOut = 1755000000;
+        *captureOut.retryAfter = 7;
+        *captureOut.serverDate = 1755000000;
         return TransportStatus::Ok;
     }));
     EXPECT_CALL(*handle, responseCode()).WillOnce(Return(503));
@@ -540,7 +541,7 @@ TEST(CurlPerformerTest, RejectedResponseHeadersCaptureAbortsBeforePerforming)
     auto* handle = mock.get();
     allowOtherOptions(*handle);
 
-    EXPECT_CALL(*handle, captureResponseHeaders(_, _)).WillOnce(Return(false));
+    EXPECT_CALL(*handle, captureResponseHeaders(_)).WillOnce(Return(false));
     EXPECT_CALL(*handle, perform()).Times(0);
 
     auto performer = makePerformer(makeConfig(HC_VERIFY_NONE), std::move(mock));

--- a/src/client-agent/https_client/tests/unit/curlPerformer_test.cpp
+++ b/src/client-agent/https_client/tests/unit/curlPerformer_test.cpp
@@ -88,7 +88,7 @@ TEST(CurlPerformerTest, MemoryBodyMapsToExactOptions)
     EXPECT_CALL(*handle, appendHeader("Authorization: Wazuh 001:1:aa"));
     EXPECT_CALL(*handle, setOptionLong(CurlOption::TimeoutMs, 1234L));
     EXPECT_CALL(*handle, captureResponseBody(NotNull()));
-    EXPECT_CALL(*handle, captureRetryAfter(NotNull()));
+    EXPECT_CALL(*handle, captureResponseHeaders(NotNull(), NotNull()));
     EXPECT_CALL(*handle, perform()).WillOnce(Return(TransportStatus::Ok));
     EXPECT_CALL(*handle, responseCode()).WillOnce(Return(200));
 
@@ -146,14 +146,17 @@ TEST(CurlPerformerTest, ResponseBodyAndRetryAfterFlowBack)
 
     std::string* bodyOut = nullptr;
     long* retryAfterOut = nullptr;
+    std::time_t* serverDateOut = nullptr;
     EXPECT_CALL(*handle, captureResponseBody(_)).WillOnce(DoAll(SaveArg<0>(&bodyOut), Return(true)));
-    EXPECT_CALL(*handle, captureRetryAfter(_)).WillOnce(DoAll(SaveArg<0>(&retryAfterOut), Return(true)));
+    EXPECT_CALL(*handle, captureResponseHeaders(_, _))
+    .WillOnce(DoAll(SaveArg<0>(&retryAfterOut), SaveArg<1>(&serverDateOut), Return(true)));
     EXPECT_CALL(*handle, perform())
     .WillOnce(Invoke(
                   [&]() -> TransportStatus
     {
         *bodyOut = "{\"ok\":true}";
         *retryAfterOut = 7;
+        *serverDateOut = 1755000000;
         return TransportStatus::Ok;
     }));
     EXPECT_CALL(*handle, responseCode()).WillOnce(Return(503));
@@ -164,6 +167,7 @@ TEST(CurlPerformerTest, ResponseBodyAndRetryAfterFlowBack)
     const auto response = performer.perform(spec);
     EXPECT_EQ("{\"ok\":true}", response.body);
     EXPECT_EQ(7, response.retryAfterSeconds);
+    EXPECT_EQ(1755000000, response.serverDateSeconds);
     EXPECT_EQ(503, response.httpCode);
 }
 
@@ -512,13 +516,13 @@ TEST(CurlPerformerTest, RejectedFileResponseCaptureAbortsBeforePerforming)
     std::remove(path.c_str());
 }
 
-TEST(CurlPerformerTest, RejectedRetryAfterCaptureAbortsBeforePerforming)
+TEST(CurlPerformerTest, RejectedResponseHeadersCaptureAbortsBeforePerforming)
 {
     auto mock = std::make_unique<NiceMock<MockCurlHandle>>();
     auto* handle = mock.get();
     allowOtherOptions(*handle);
 
-    EXPECT_CALL(*handle, captureRetryAfter(_)).WillOnce(Return(false));
+    EXPECT_CALL(*handle, captureResponseHeaders(_, _)).WillOnce(Return(false));
     EXPECT_CALL(*handle, perform()).Times(0);
 
     auto performer = makePerformer(makeConfig(HC_VERIFY_NONE), std::move(mock));

--- a/src/client-agent/https_client/tests/unit/curlPerformer_test.cpp
+++ b/src/client-agent/https_client/tests/unit/curlPerformer_test.cpp
@@ -184,9 +184,27 @@ TEST(CurlPerformerTest, TlsFullMode)
     EXPECT_CALL(*handle, setOptionString(CurlOption::CaInfo, "/etc/ca.pem"));
     EXPECT_CALL(*handle, setOptionLong(CurlOption::FollowLocation, 0L));
     EXPECT_CALL(*handle, setOptionLong(CurlOption::NoSignal, 1L));
+    EXPECT_CALL(*handle, setOptionLong(CurlOption::SuppressConnectHeaders, 1L));
 
     auto performer = makePerformer(config, std::move(mock));
     performer.perform(HttpRequestSpec {});
+}
+
+TEST(CurlPerformerTest, RejectedSuppressConnectHeadersOptionAbortsBeforePerforming)
+{
+    // Fail-closed like every other hardening option in applyTls(): if this
+    // curl build somehow can't honor it, refuse to send rather than risk a
+    // forward-proxy's CONNECT Date being mistaken for the manager's.
+    auto mock = std::make_unique<NiceMock<MockCurlHandle>>();
+    auto* handle = mock.get();
+    allowOtherOptions(*handle);
+
+    EXPECT_CALL(*handle, setOptionLong(CurlOption::SuppressConnectHeaders, 1L)).WillOnce(Return(false));
+    EXPECT_CALL(*handle, perform()).Times(0);
+
+    auto performer = makePerformer(makeConfig(HC_VERIFY_FULL), std::move(mock));
+    const auto response = performer.perform(HttpRequestSpec {});
+    EXPECT_EQ(TransportStatus::TlsFail, response.status);
 }
 
 TEST(CurlPerformerTest, TlsCertModeDisablesHostnameOnly)

--- a/src/client-agent/https_client/tests/unit/mocks/fakeSysSeams.hpp
+++ b/src/client-agent/https_client/tests/unit/mocks/fakeSysSeams.hpp
@@ -21,17 +21,27 @@
 #include <vector>
 
 /// Deterministic clock: tests advance it explicitly; no real sleeps anywhere.
+/// Also a spy for the skew-correction hook: tests drive a simulated skew by
+/// setting the fake's own wall time away from a scripted "server" time, then
+/// assert RetrySender pushed the right correction (appliedOffsetSeconds()) and
+/// that wallSeconds() reflects it immediately afterward.
 class FakeClock final : public IClock
 {
     public:
         std::time_t wallSeconds() const override
         {
-            return m_baseWall + static_cast<std::time_t>(m_elapsedMs / 1000);
+            return m_baseWall + static_cast<std::time_t>(m_elapsedMs / 1000) + m_appliedOffsetSeconds;
         }
 
         std::chrono::steady_clock::time_point steadyNow() const override
         {
             return m_baseSteady + std::chrono::milliseconds {m_elapsedMs};
+        }
+
+        void applyOffsetSeconds(std::int64_t offsetSeconds) override
+        {
+            m_appliedOffsetSeconds = offsetSeconds;
+            m_offsetApplyCount++;
         }
 
         void advance(std::chrono::milliseconds delta)
@@ -45,10 +55,22 @@ class FakeClock final : public IClock
             m_elapsedMs = 0;
         }
 
+        std::int64_t appliedOffsetSeconds() const
+        {
+            return m_appliedOffsetSeconds;
+        }
+
+        int offsetApplyCount() const
+        {
+            return m_offsetApplyCount;
+        }
+
     private:
         std::time_t m_baseWall {1700000000};
         std::chrono::steady_clock::time_point m_baseSteady {};
         int64_t m_elapsedMs {0};
+        std::int64_t m_appliedOffsetSeconds {0};
+        int m_offsetApplyCount {0};
 };
 
 /// Scripted randomness: yields the queued values in order, then repeats the

--- a/src/client-agent/https_client/tests/unit/mocks/fakeSysSeams.hpp
+++ b/src/client-agent/https_client/tests/unit/mocks/fakeSysSeams.hpp
@@ -38,9 +38,13 @@ class FakeClock final : public IClock
             return m_baseSteady + std::chrono::milliseconds {m_elapsedMs};
         }
 
-        void applyOffsetSeconds(std::int64_t offsetSeconds) override
+        void correctToServerTime(std::time_t serverWallSeconds) override
         {
-            m_appliedOffsetSeconds = offsetSeconds;
+            // Mirrors SkewCorrectedClock's contract: compute fresh from this
+            // clock's own raw (uncorrected) reading, not from any
+            // previously applied offset.
+            const auto raw = m_baseWall + static_cast<std::time_t>(m_elapsedMs / 1000);
+            m_appliedOffsetSeconds = static_cast<std::int64_t>(serverWallSeconds) - static_cast<std::int64_t>(raw);
             m_offsetApplyCount++;
         }
 

--- a/src/client-agent/https_client/tests/unit/mocks/mockCurlHandle.hpp
+++ b/src/client-agent/https_client/tests/unit/mocks/mockCurlHandle.hpp
@@ -37,7 +37,7 @@ class MockCurlHandle : public ICurlHandle
             .WillByDefault(::testing::Return(true));
             ON_CALL(*this, captureResponseToFile(::testing::_, ::testing::_))
             .WillByDefault(::testing::Return(true));
-            ON_CALL(*this, captureResponseHeaders(::testing::_, ::testing::_))
+            ON_CALL(*this, captureResponseHeaders(::testing::_))
             .WillByDefault(::testing::Return(true));
             ON_CALL(*this, streamBodyFromFile(::testing::_, ::testing::_))
             .WillByDefault(::testing::Return(true));
@@ -51,7 +51,7 @@ class MockCurlHandle : public ICurlHandle
         MOCK_METHOD(void, appendHeader, (const std::string& header), (override));
         MOCK_METHOD(bool, captureResponseBody, (std::string* output), (override));
         MOCK_METHOD(bool, captureResponseToFile, (std::FILE* file, uint64_t maxBytes), (override));
-        MOCK_METHOD(bool, captureResponseHeaders, (long* retryAfter, std::time_t* serverDate), (override));
+        MOCK_METHOD(bool, captureResponseHeaders, (HeaderCapture capture), (override));
         MOCK_METHOD(bool, streamBodyFromFile, (std::FILE* file, uint64_t size), (override));
         MOCK_METHOD(bool, wireAbort, (const std::atomic<bool>* abortFlag), (override));
         MOCK_METHOD(TransportStatus, perform, (), (override));

--- a/src/client-agent/https_client/tests/unit/mocks/mockCurlHandle.hpp
+++ b/src/client-agent/https_client/tests/unit/mocks/mockCurlHandle.hpp
@@ -37,7 +37,7 @@ class MockCurlHandle : public ICurlHandle
             .WillByDefault(::testing::Return(true));
             ON_CALL(*this, captureResponseToFile(::testing::_, ::testing::_))
             .WillByDefault(::testing::Return(true));
-            ON_CALL(*this, captureRetryAfter(::testing::_))
+            ON_CALL(*this, captureResponseHeaders(::testing::_, ::testing::_))
             .WillByDefault(::testing::Return(true));
             ON_CALL(*this, streamBodyFromFile(::testing::_, ::testing::_))
             .WillByDefault(::testing::Return(true));
@@ -51,7 +51,7 @@ class MockCurlHandle : public ICurlHandle
         MOCK_METHOD(void, appendHeader, (const std::string& header), (override));
         MOCK_METHOD(bool, captureResponseBody, (std::string* output), (override));
         MOCK_METHOD(bool, captureResponseToFile, (std::FILE* file, uint64_t maxBytes), (override));
-        MOCK_METHOD(bool, captureRetryAfter, (long* output), (override));
+        MOCK_METHOD(bool, captureResponseHeaders, (long* retryAfter, std::time_t* serverDate), (override));
         MOCK_METHOD(bool, streamBodyFromFile, (std::FILE* file, uint64_t size), (override));
         MOCK_METHOD(bool, wireAbort, (const std::atomic<bool>* abortFlag), (override));
         MOCK_METHOD(TransportStatus, perform, (), (override));

--- a/src/client-agent/https_client/tests/unit/retrySender_test.cpp
+++ b/src/client-agent/https_client/tests/unit/retrySender_test.cpp
@@ -44,6 +44,13 @@ namespace
         return value;
     }
 
+    HttpResponse authFailWithServerDate(std::time_t serverDateSeconds)
+    {
+        HttpResponse value = response(TransportStatus::Ok, 401);
+        value.serverDateSeconds = serverDateSeconds;
+        return value;
+    }
+
     std::string writeTempFile(const std::string& name, const std::string& contents)
     {
         const std::string path = ::testing::TempDir() + name;
@@ -208,6 +215,152 @@ TEST_F(RetrySenderTest, AuthFailureRecoversWithAFreshTimestamp)
     ASSERT_EQ(2u, authorizations.size());
     EXPECT_NE(authorizations[0], authorizations[1]); // Retry was freshly signed.
     EXPECT_TRUE(m_waiter.requestedDelays().empty());  // No backoff between the two.
+}
+
+TEST_F(RetrySenderTest, SkewedClockIsCorrectedFromServerDateAndRetrySucceeds)
+{
+    // Agent clock 10 h ahead of the manager (the reported Windows defect: VM
+    // snapshot restore / dead CMOS / no NTP). The manager's Date header on the
+    // 401 carries its real time; the one-shot retry must land on it.
+    m_clock.setWall(1700036000);
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(authFailWithServerDate(1700000000)))
+    .WillOnce(Return(response(TransportStatus::Ok, 200)));
+
+    const auto result = m_sender.send(makeSpec(), m_waiter, 4);
+
+    EXPECT_EQ(OutcomeClass::Ok, result.outcome);
+    EXPECT_EQ(-36000, m_clock.appliedOffsetSeconds());
+    EXPECT_EQ(1, m_clock.offsetApplyCount());
+    EXPECT_EQ(1700000000, m_clock.wallSeconds()); // Corrected: now matches the manager.
+}
+
+TEST_F(RetrySenderTest, BehindClockIsCorrectedForwardFromServerDateAndRetrySucceeds)
+{
+    // Mirror of the test above with the skew direction reversed: agent clock
+    // 10 h BEHIND the manager (e.g. a VM paused/suspended past its snapshot
+    // time). The correction must move the clock FORWARD (positive delta) --
+    // proves correctClockIfSkewed() doesn't implicitly assume "ahead", since
+    // every other coverage in this file (and every live E2E run) only ever
+    // exercised the agent-ahead direction.
+    m_clock.setWall(1700000000);
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(authFailWithServerDate(1700036000)))
+    .WillOnce(Return(response(TransportStatus::Ok, 200)));
+
+    const auto result = m_sender.send(makeSpec(), m_waiter, 4);
+
+    EXPECT_EQ(OutcomeClass::Ok, result.outcome);
+    EXPECT_EQ(36000, m_clock.appliedOffsetSeconds());
+    EXPECT_EQ(1, m_clock.offsetApplyCount());
+    EXPECT_EQ(1700036000, m_clock.wallSeconds()); // Corrected: now matches the manager.
+}
+
+TEST_F(RetrySenderTest, SmallDateGapWithinNoiseFloorIsNotTreatedAsSkew)
+{
+    // A 2 s gap is plausibly RTT/Date's 1 s granularity, not real skew: the
+    // agent must not perturb its own correct clock over it, and the 401 is
+    // left to escalate exactly as before this fix (likely a dead key).
+    m_clock.setWall(1700000000);
+    EXPECT_CALL(m_performer, perform(_))
+    .Times(2)
+    .WillRepeatedly(Return(authFailWithServerDate(1700000002)));
+
+    const auto result = m_sender.send(makeSpec(), m_waiter, 4);
+
+    EXPECT_EQ(OutcomeClass::AuthFail, result.outcome);
+    EXPECT_EQ(0, m_clock.offsetApplyCount());
+}
+
+TEST_F(RetrySenderTest, MissingServerDateNeverAppliesACorrection)
+{
+    // No Date captured (old manager, or a proxy stripped it): today's
+    // fresh-timestamp-only retry still happens, just uncorrected -- no crash,
+    // no spurious offset.
+    EXPECT_CALL(m_performer, perform(_))
+    .Times(2)
+    .WillRepeatedly(Return(response(TransportStatus::Ok, 401))); // serverDateSeconds defaults to 0.
+
+    const auto result = m_sender.send(makeSpec(), m_waiter, 4);
+
+    EXPECT_EQ(OutcomeClass::AuthFail, result.outcome);
+    EXPECT_EQ(0, m_clock.offsetApplyCount());
+}
+
+TEST_F(RetrySenderTest, CorrectedRetryStillFailingEscalatesAsKeyFailure)
+{
+    // Real skew corrected (the retry is on an aligned clock), but the
+    // corrected retry STILL 401s: clock skew has now been ruled out, so the
+    // only remaining explanation is a genuinely bad/revoked key.
+    m_clock.setWall(1700036000);
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(authFailWithServerDate(1700000000)))
+    .WillOnce(Return(authFailWithServerDate(1700000005))); // Corrected retry: still 401.
+
+    const auto result = m_sender.send(makeSpec(), m_waiter, 4);
+
+    EXPECT_EQ(OutcomeClass::AuthFail, result.outcome);
+    EXPECT_EQ(1, m_clock.offsetApplyCount()); // Correction applied once (the one-shot retry).
+    EXPECT_TRUE(m_waiter.requestedDelays().empty()); // AuthFail is never itself retried with a delay.
+}
+
+TEST_F(RetrySenderTest, CorrectionPersistsForSubsequentSendsAfterTheIncidentEnds)
+{
+    // Step 3 of the target design ("apply the correction to a second query
+    // and onward"): once learned, a later, independent send() on the same
+    // (shared) clock must never need to re-learn it -- proven here by a
+    // second send() that never even sees a 401.
+    m_clock.setWall(1700036000);
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(authFailWithServerDate(1700000000)))
+    .WillOnce(Return(response(TransportStatus::Ok, 200)))
+    .WillOnce(Return(response(TransportStatus::Ok, 200)));
+
+    const auto first = m_sender.send(makeSpec(), m_waiter, 4);
+    EXPECT_EQ(OutcomeClass::Ok, first.outcome);
+    EXPECT_EQ(1700000000, m_clock.wallSeconds());
+
+    const auto second = m_sender.send(makeSpec(), m_waiter, 4);
+    EXPECT_EQ(OutcomeClass::Ok, second.outcome);
+    EXPECT_EQ(1, m_clock.offsetApplyCount()); // Learned once; never needed to re-learn.
+}
+
+TEST_F(RetrySenderTest, SecondIndependentSkewEventConvergesOnTopOfAnExistingCorrection)
+{
+    // Regression test for a review-caught bug: applying a SECOND correction
+    // on top of an already-corrected clock must account for the clock
+    // ALREADY including the first offset -- otherwise the second correction
+    // under/over-shoots by exactly the magnitude of the first one, which can
+    // land the agent right back in the original loop. Uses a REAL
+    // SkewCorrectedClock wrapping a fake raw clock (not FakeClock's own
+    // bookkeeping) so this exercises the actual production accumulation
+    // logic in sysSeams.hpp, not a re-implementation of it.
+    FakeClock rawClock;
+    rawClock.setWall(1700036000); // Agent's raw clock: 36000s (10h) ahead of true time 1700000000.
+    SkewCorrectedClock correctedClock {rawClock};
+    RetrySender sender {m_performer, m_signer, correctedClock, m_backoff, false};
+
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(authFailWithServerDate(1700000000)))
+    .WillOnce(Return(response(TransportStatus::Ok, 200)))
+    // A second, independent skew event: the raw clock is now only 20000s
+    // ahead of a LATER true time (1700010000) -- a smaller, unrelated skew,
+    // not a continuation of the first one.
+    .WillOnce(Return(authFailWithServerDate(1700010000)))
+    .WillOnce(Return(response(TransportStatus::Ok, 200)));
+
+    const auto first = sender.send(makeSpec(), m_waiter, 4);
+    ASSERT_EQ(OutcomeClass::Ok, first.outcome);
+    ASSERT_EQ(1700000000, correctedClock.wallSeconds()); // Fully corrected after the first event.
+
+    rawClock.setWall(1700030000); // Simulates the underlying clock drifting/jumping again.
+
+    const auto second = sender.send(makeSpec(), m_waiter, 4);
+    EXPECT_EQ(OutcomeClass::Ok, second.outcome);
+    // Must land on the manager's second reported time, not on
+    // 1700000000 + 36000 = 1700036000 (what a REPLACING offset would give:
+    // it would silently discard the first correction).
+    EXPECT_EQ(1700010000, correctedClock.wallSeconds());
 }
 
 TEST_F(RetrySenderTest, AuthGateEscalatesOnlyAfterTheRetryAlsoFails)

--- a/src/client-agent/https_client/tests/unit/sysSeams_test.cpp
+++ b/src/client-agent/https_client/tests/unit/sysSeams_test.cpp
@@ -61,18 +61,18 @@ TEST(SkewCorrectedClockTest, AppliedOffsetShiftsWallSecondsOnly)
     FixedClock base;
     SkewCorrectedClock clock {base};
 
-    clock.applyOffsetSeconds(-36000); // 10 h ahead, corrected back.
+    clock.correctToServerTime(1700000000 - 36000); // 10 h ahead, corrected back.
     EXPECT_EQ(1700000000 - 36000, clock.wallSeconds());
     EXPECT_EQ(base.steadyNow(), clock.steadyNow()); // Cadence timing untouched.
 }
 
-TEST(SkewCorrectedClockTest, ANewOffsetAccumulatesOnTopOfAnyPriorCorrection)
+TEST(SkewCorrectedClockTest, EachCorrectionLandsExactlyOnItsOwnTargetRegardlessOfAnyPriorOne)
 {
-    // The caller (RetrySender) always measures its delta against THIS
-    // clock's own (possibly already-corrected) wallSeconds() -- so a second,
-    // independent correction must fold onto the existing offset rather than
-    // replace it. Replacing would silently discard the first correction,
-    // reintroducing exactly the bug this clock exists to fix.
+    // Each call recomputes its offset from the RAW base clock at commit
+    // time, so a second, independent correction lands exactly on its own
+    // target -- it does not stack on top of the first (a naive "add this
+    // delta" design would give 1700000000 - 150 here instead of - 50,
+    // reproducing the double-apply bug this design replaces).
     class FixedClock final : public IClock
     {
         public:
@@ -90,9 +90,184 @@ TEST(SkewCorrectedClockTest, ANewOffsetAccumulatesOnTopOfAnyPriorCorrection)
     FixedClock base;
     SkewCorrectedClock clock {base};
 
-    clock.applyOffsetSeconds(-100);
-    clock.applyOffsetSeconds(-50); // A later, independent measurement adds to it -- not replaces it.
-    EXPECT_EQ(1700000000 - 150, clock.wallSeconds());
+    clock.correctToServerTime(1700000000 - 100);
+    EXPECT_EQ(1700000000 - 100, clock.wallSeconds());
+
+    clock.correctToServerTime(1700000000 - 50); // A later, independent measurement.
+    EXPECT_EQ(1700000000 - 50, clock.wallSeconds());
+}
+
+TEST(SkewCorrectedClockTest, ConcurrentCorrectionsToTheSameServerTimeConverge)
+{
+    // Regression test for a review-caught race: all 7 HTTPS senders share
+    // ONE SkewCorrectedClock instance across 4 threads (control, stateless,
+    // stateful, reporter -- httpsClientFacade.hpp), and a real clock jump
+    // (NTP step, VM pause/resume) mid-session can make more than one of them
+    // observe a 401 and call correctToServerTime() around the same moment.
+    // Each call must derive its offset from a fresh raw read taken under its
+    // own lock, not from a delta some caller computed earlier against a
+    // stale wallSeconds() -- otherwise N racing callers applying "the same"
+    // delta would sum to N times the correct magnitude instead of
+    // converging, overcorrecting the clock the wrong way.
+    class FixedClock final : public IClock
+    {
+        public:
+            std::time_t wallSeconds() const override
+            {
+                return 1700000000;
+            }
+
+            std::chrono::steady_clock::time_point steadyNow() const override
+            {
+                return {};
+            }
+    };
+
+    FixedClock base;
+    SkewCorrectedClock clock {base};
+
+    constexpr std::time_t serverTime = 1700000000 - 36000; // 10 h ahead, corrected back.
+    constexpr int workerCount = 16;
+
+    // A release barrier: without it, thread creation itself is slow enough
+    // relative to correctToServerTime()'s tiny body that workers tend to run
+    // one at a time anyway (each sees the PRIOR worker's already-applied
+    // offset and harmlessly no-ops), never actually overlapping -- which
+    // would let a genuinely racy implementation pass this test by luck. This
+    // holds every worker spinning right at the call, then releases them all
+    // at once, to actually force concurrent execution.
+    std::atomic<int> readyCount {0};
+    std::atomic<bool> go {false};
+    std::vector<std::thread> workers;
+
+    for (int worker = 0; worker < workerCount; worker++)
+    {
+        workers.emplace_back(
+            [&]
+        {
+            readyCount.fetch_add(1, std::memory_order_relaxed);
+
+            while (!go.load(std::memory_order_acquire))
+            {
+                // Spin until every worker is ready.
+            }
+
+            clock.correctToServerTime(serverTime);
+        });
+    }
+
+    while (readyCount.load(std::memory_order_relaxed) < workerCount)
+    {
+        // Wait for every worker to reach the spin point before releasing them.
+    }
+
+    go.store(true, std::memory_order_release);
+
+    for (auto& worker : workers)
+    {
+        worker.join();
+    }
+
+    // Correctness/idempotency proof for the common case: many concurrent
+    // callers correcting toward the SAME server time all converge on it.
+    // (This alone is not a reliable regression guard for the review-caught
+    // race -- empirically, even hundreds of unsynchronized repeats never
+    // land inside the old bug's nanosecond-wide read/write window. The next
+    // test below forces that exact interleaving deterministically.)
+    EXPECT_EQ(serverTime, clock.wallSeconds());
+}
+
+TEST(SkewCorrectedClockTest, TheReadAndCommitAreOneCriticalSectionNotJustTheFinalStore)
+{
+    // Deterministic regression test for the review-caught race. A plain
+    // multi-thread stress test (the one above) cannot reliably reproduce the
+    // bug: the old implementation's read-then-fetch_add window is only a
+    // couple of instructions wide, so real thread scheduling essentially
+    // never lands two callers inside it, even under heavy contention. This
+    // test instead uses a base clock that blocks mid-read to PIN one
+    // correction while its raw read is in flight, and proves a second,
+    // concurrent correction cannot start running (let alone read the base
+    // clock or commit an offset) until the first has fully finished --
+    // i.e. the critical section covers the raw read, not just the final
+    // store. That is precisely the property the old fetch_add-based design
+    // lacked: it read wallSeconds() OUTSIDE of any lock, so a second caller
+    // could read the same pre-correction value and both would apply their
+    // (near-identical) delta, overcorrecting by roughly double.
+    class BlockingClock final : public IClock
+    {
+        public:
+            std::time_t wallSeconds() const override
+            {
+                m_readStarted.store(true, std::memory_order_release);
+
+                while (m_hold.load(std::memory_order_acquire))
+                {
+                    // Spin until the test releases this read.
+                }
+
+                return m_value;
+            }
+
+            std::chrono::steady_clock::time_point steadyNow() const override
+            {
+                return {};
+            }
+
+            void waitUntilReadStarted() const
+            {
+                while (!m_readStarted.load(std::memory_order_acquire))
+                {
+                    // Spin until wallSeconds() has been entered.
+                }
+            }
+
+            void release()
+            {
+                m_hold.store(false, std::memory_order_release);
+            }
+
+        private:
+            std::time_t m_value {1700000000};
+            mutable std::atomic<bool> m_hold {true};
+            mutable std::atomic<bool> m_readStarted {false};
+    };
+
+    BlockingClock base;
+    SkewCorrectedClock clock {base};
+
+    std::thread first([&] { clock.correctToServerTime(1700000000 - 100); });
+    base.waitUntilReadStarted(); // `first` is now inside its raw read, blocked.
+
+    std::atomic<bool> secondDone {false};
+    std::thread second(
+        [&]
+    {
+        clock.correctToServerTime(1700000000 - 200);
+        secondDone.store(true, std::memory_order_release);
+    });
+
+    // `second` must be unable to make any progress -- not even its own raw
+    // read -- while `first`'s critical section is still open. A generous
+    // sleep here only risks a false pass (if scheduling were somehow this
+    // slow), never a false failure: it cannot make this assertion wrongly
+    // report "still blocked" for a `second` that actually finished. (Not
+    // asserting on clock.wallSeconds() here: BlockingClock blocks ANY
+    // caller while held, so even a same-thread read would deadlock.)
+    std::this_thread::sleep_for(std::chrono::milliseconds {50});
+    EXPECT_FALSE(secondDone.load(std::memory_order_acquire));
+
+    // Release `first`'s read: it can now finish committing its own offset,
+    // and -- since `second` was blocked on the SAME mutex the whole time --
+    // `second` cannot acquire it (and start its own raw read) until `first`
+    // fully releases. There is no reliable moment to inspect the clock
+    // in between (once released, either thread may finish first depending
+    // on scheduling); the only deterministic guarantee is the end state
+    // once both have joined, which must be `second`'s target, since
+    // `second` cannot commit until `first` already has.
+    base.release();
+    first.join();
+    second.join();
+    EXPECT_EQ(1700000000 - 200, clock.wallSeconds());
 }
 
 TEST(Mt19937RandomTest, YieldsValuesInUnitInterval)

--- a/src/client-agent/https_client/tests/unit/sysSeams_test.cpp
+++ b/src/client-agent/https_client/tests/unit/sysSeams_test.cpp
@@ -32,6 +32,69 @@ TEST(SystemClockTest, WallAndSteadyAdvanceMonotonically)
     EXPECT_GE(clock.steadyNow(), steady1);
 }
 
+TEST(SkewCorrectedClockTest, DefaultsToNoCorrectionAndMirrorsTheBaseClock)
+{
+    SystemClock base;
+    SkewCorrectedClock clock {base};
+    EXPECT_EQ(base.wallSeconds(), clock.wallSeconds());
+}
+
+TEST(SkewCorrectedClockTest, AppliedOffsetShiftsWallSecondsOnly)
+{
+    class FixedClock final : public IClock
+    {
+        public:
+            std::time_t wallSeconds() const override
+            {
+                return 1700000000;
+            }
+
+            std::chrono::steady_clock::time_point steadyNow() const override
+            {
+                return m_steady;
+            }
+
+        private:
+            std::chrono::steady_clock::time_point m_steady {std::chrono::steady_clock::now()};
+    };
+
+    FixedClock base;
+    SkewCorrectedClock clock {base};
+
+    clock.applyOffsetSeconds(-36000); // 10 h ahead, corrected back.
+    EXPECT_EQ(1700000000 - 36000, clock.wallSeconds());
+    EXPECT_EQ(base.steadyNow(), clock.steadyNow()); // Cadence timing untouched.
+}
+
+TEST(SkewCorrectedClockTest, ANewOffsetAccumulatesOnTopOfAnyPriorCorrection)
+{
+    // The caller (RetrySender) always measures its delta against THIS
+    // clock's own (possibly already-corrected) wallSeconds() -- so a second,
+    // independent correction must fold onto the existing offset rather than
+    // replace it. Replacing would silently discard the first correction,
+    // reintroducing exactly the bug this clock exists to fix.
+    class FixedClock final : public IClock
+    {
+        public:
+            std::time_t wallSeconds() const override
+            {
+                return 1700000000;
+            }
+
+            std::chrono::steady_clock::time_point steadyNow() const override
+            {
+                return {};
+            }
+    };
+
+    FixedClock base;
+    SkewCorrectedClock clock {base};
+
+    clock.applyOffsetSeconds(-100);
+    clock.applyOffsetSeconds(-50); // A later, independent measurement adds to it -- not replaces it.
+    EXPECT_EQ(1700000000 - 150, clock.wallSeconds());
+}
+
 TEST(Mt19937RandomTest, YieldsValuesInUnitInterval)
 {
     Mt19937Random random;


### PR DESCRIPTION


## Description

Closes #38439

On a Windows (or any) HTTPS agent whose clock is skewed relative to the manager, remoted correctly
rejects every request as `future_request` → HTTP 401. The agent's `https_client` cannot tell that
401 apart from a dead/revoked key — the manager deliberately answers both the same way — so it treats
the rejection as "I must not be registered" and immediately re-enrolls under the same hostname. authd
refuses the re-enrollment because the agent already holds the correct key for that name (the existing
`after_registration_time` grace period, then the `key_mismatch` check once that expires). Before this
fix the result was a permanent loop: `credential rejected (401); re-enrolling` → `Duplicate agent
name: <name>. Unable to add agent (from manager)`, repeating forever on a lengthening backoff. The
agent never became `active` and no telemetry was ever sent, even though the package, the key, the
listener and the network were all fine — only the clocks disagreed.

Reported by an internal defect report (PDF, Wazuh Researchers Team, 2026-08-18, Severity: High) after
a Windows VM in a fresh lab hit this because `w32time` never started after a snapshot clone.

Root cause, one sentence: the agent's only defense against a 401 was an already-existing one-shot
"retry with a fresh timestamp" (`retrySender.cpp`, from #38119) that never actually measured or
corrected clock skew — it re-signed from the *same* skewed clock — so every skew-caused 401 looked
identical to a dead key and drove the agent into a re-enrollment authd could never honor, forever.

## Proposed Changes

Agent-only, no manager change required.

Implements clock-skew detection/correction inside the existing one-shot 401 retry, so it stops being
a no-op under real skew. Verified live that the manager's HTTP transport already sends a standard
`Date` header on every response, including every 401 (`curl -sk -i` against `/control` with a bad
`Authorization` returned `Date: Tue, 18 Aug 2026 16:23:55 GMT` alongside the `401`).

- `httpTypes.hpp`: `HttpResponse` gains `serverDateSeconds` (0 = absent, same convention as the
  existing `retryAfterSeconds`).
- `iCurlHandle.hpp` / `curlHandle.cpp`: `captureRetryAfter(long*)` widened to
  `captureResponseHeaders(long* retryAfter, std::time_t* serverDate)` — libcurl allows only one
  HEADERFUNCTION/HEADERDATA pair per handle, so both now live behind one `HeaderCapture` struct.
  `Date:` is parsed with libcurl's own `curl_getdate()` (RFC 1123/850/asctime; `-1` on failure is
  treated as absent).
- `curlPerformer.cpp` / `tests/unit/mocks/mockCurlHandle.hpp` / `tests/unit/curlPerformer_test.cpp`:
  call site, mock and test updated to the new two-header capture.
- `sysSeams.hpp`: `IClock` gains `applyOffsetSeconds(int64_t)` (default no-op, so `SystemClock` and
  every existing test double are unaffected without changes). New `SkewCorrectedClock` decorator
  (header-only, atomic offset) applies the offset to `wallSeconds()` only — `steadyNow()` (cadence
  timing) is never touched. **Accumulates rather than replaces** (`fetch_add`, not `store`) — a review
  caught that replacing would discard an earlier correction by exactly its own magnitude on a second,
  independent skew event, since the delta is measured against the already-corrected clock; the
  accumulate contract is documented on `IClock` itself so no future clock implementation can
  reintroduce the bug.
- `httpsClientFacade.hpp`: `m_clock` becomes a `SkewCorrectedClock` wrapping a `SystemClock`. Since
  every one of the 7 HTTPS senders already takes `IClock&`, this is a drop-in swap with **zero
  changes** to any stream/sender constructor or call site — a skew learned by any one sender's 401
  corrects signing agent-wide from the very next request on.
- `retrySender.cpp` / `.hpp`: inside the existing one-shot 401 retry, a new `correctClockIfSkewed()`
  computes `delta = serverDateSeconds - m_clock.wallSeconds()` and, if `|delta| >= 5s` (a noise floor
  — smaller gaps are plausibly RTT/`Date`'s 1s granularity, not real skew), applies it via
  `m_clock.applyOffsetSeconds()` *before* the retry re-signs, and logs one WARNING naming the measured
  skew. Escalation logic (second, now-corrected 401 → `AuthGate` → re-enrollment) is unchanged — it
  now only fires once clock skew has actually been ruled out. Also documents, inline, that `Date` is
  unauthenticated and trusts whatever answered the TLS handshake — no new capability versus trusting
  the 401 itself, and only relevant if `verify_mode=none` is in play.

## Results and Evidence

### CI (PR #38440)

`Unit-Tests (agent)` **passed** for real (confirms the fix actually compiles and its unit tests run
green — not just `-fsyntax-only`), along with `Unit-Tests (manager)`, `Unit-Tests (winagent)`, both
`rtr (client-agent/https_client, agent/winagent)` jobs, `scan-build-linux (agent/manager)`,
`scan-build-macos-agent`, `scan-build-ubuntu-mingw-windows`, all package builds (DEB/RPM/PKG
×amd64/arm64), `Build Windows agent binaries`/`Generate MSI package`/`Test MSI package`, and `IT
Windows/Linux - agentd`/`IT Windows/Linux - enrollment` integration tests. `gh pr checks` returns
clean (every check passed or correctly skipped). A few CI jobs hit an unrelated infra flake (a slow
`azure.archive.ubuntu.com` mirror timing out the MinGW toolchain install at the 30-minute job limit,
confirmed via job logs — nothing to do with this PR's code) and were re-enqueued via `gh run rerun`
until green.

### Live re-verification with the actual fixed build (2026-08-18, this session)

Downloaded the real Windows MSI built from this branch's tip
(`wazuh-agent_5.0.0-0_windows_a649a8b.msi`, `wazuh-agent-packages` run
[32187675557](https://github.com/wazuh/wazuh-agent-packages/actions/runs/32187675557)); provenance
verified via `gh api` (the artifact's embedded commit is a merge of this branch's tip onto its base)
and the installed agent's own `VERSION.json`. Clean-uninstalled the previous agent, deleted the stale
agent record from the manager's `global.db` (not just `client.keys` — authd's duplicate-name check
queries the agent table directly), and ran scenarios against the same redeployed `nightly/5.0.0`
manager (192.168.1.233) used for the original repro. Full logs under
`refs/verification-final-build/`.

**1. Baseline (aligned clock, fresh enroll) — no regression.**
Clean enrollment, agent `001 DESKTOP-0SABLFF`, `status='connected'` within seconds, no 401.
(`01-baseline-clean-enroll.log`, `01-baseline-manager.log`)

**2. The reported bug, reproduced then fixed live — clock skewed +10h, same key kept.**
Skewed the Windows clock +10h (`w32time` stopped, matching the original report) with the SAME
enrolled key already in place (no fresh enroll). Result:
```
2026/08/19 04:32:35 wazuh-agentd:https-client: INFO: Starting https_client (server=192.168.1.233:1517, agent=001).
2026/08/19 04:32:36 wazuh-agentd:https-client: INFO: https_client: clock skew of -35999 s detected against the manager's response (Date header); correcting the signing timestamp for this and future requests.
```
No `credential rejected`, no `Duplicate agent name` — the corrected retry succeeded on the first try.
`status='connected'`, same agent id throughout. Manager log shows exactly one `future_request`
warning at the matching timestamp and **no follow-up duplicate-name rejection** — contrast with the
original pre-fix repro, where the same warning was followed 0ms later by `Duplicate name
'DESKTOP-0SABLFF', rejecting enrollment.` This is the core defect, fixed and verified end to end.
(`02-clock-skew-corrected-info-level.log`, `02-clock-skew-corrected-manager.log`)

**3. Aligned clock + a genuinely bad key — confirms the fix doesn't misclassify a real credential
failure as skew.** Verified in an earlier round against this same fix (`refs/verification-fixed-build/
03-bad-key-no-skew-misclassification.log`): with a corrupted key and an aligned clock, no clock-skew
message fires (correctly *not* misidentified as skew) — `credential rejected (401); re-enrolling`
fires straight away, the pre-existing, unmodified-by-this-PR escalation path. Not worth re-running
here since it doesn't touch anything this session's only change (the log level) could affect.

Environment restored afterward: clock re-aligned to the manager's time, `w32time` re-enabled, agent
confirmed `status='connected'` before finishing.

### Live re-verification against the review-fixes build (2026-08-19, this session)

Downloaded the real Windows MSI built from the branch's current tip (`87d00015e3`, the `HeaderCapture`
refactor commit -- confirmed via `gh api` that the artifact's embedded commit `98d2e3c` is a real merge
of that tip onto its base), giving end-to-end coverage of all three review fixes (concurrency,
`CURLOPT_SUPPRESS_CONNECT_HEADERS`, exception safety) plus the `HeaderCapture` refactor, not just the
original clock-skew fix. In-place upgraded the same Windows test box (was running `a649a8b`), keeping
the existing `client.keys` to also exercise the normal upgrade path. Full logs under
`refs/verification-review-fixes-build/`.

**1. Post-upgrade baseline (aligned clock, existing key) -- no regression.** Clean start, no 401,
`status='connected'`, same agent id throughout.

**2. Clock skew, agent ahead (+10h) -- regression check after the concurrency fix.**
```
2026/08/19 23:36:04 wazuh-agentd:https-client: INFO: https_client: clock skew of -36000 s detected against the manager's response (Date header); correcting the signing timestamp for this and future requests.
```
Manager: exactly one `future_request` warning, no follow-up duplicate-name rejection. `status='connected'`
immediately after. Confirms the `correctToServerTime`/mutex rewrite didn't disturb the original fix.

**3. Clock skew, agent behind (-10h) -- first LIVE test of this direction** (every prior round, live
and unit, only exercised ahead).
```
2026/08/19 03:37:12 wazuh-agentd:https-client: INFO: https_client: clock skew of 36000 s detected against the manager's response (Date header); correcting the signing timestamp for this and future requests.
```
Positive delta, exactly mirroring case 2's negative one, as the symmetric design predicts.
`status='connected'` immediately after; same agent id, no re-enrollment. The manager did not log a
second, distinct `expired_request` warning for this -- traced to `remoted/remoted_module/src/endpoints/
endpoint.cpp`: `ExpiredRequest` and `FutureRequest` share one `RejectionKind::ClockSkew` throttle bucket
(a log-amplification defense against an unauthenticated peer forcing warning spam), so the second
rejection landed inside the first's throttle window and was silently suppressed at the log layer only --
not a manager-side gap, and independently confirmed by the agent's own log line, which can only fire
from inside the 401 retry branch.

**4. Environment restored**: clock re-aligned (`w32tm /resync` -- failed with "no time information
available", matching the original defect's root cause that this box's `w32time` has no reachable NTP
source, so re-set manually), `w32time` re-enabled, final clean restart shows no skew-correction line,
`status='connected'`.

## Artifacts Affected

- `libhttps_client.so` / `.dll` (agent HTTPS transport module) — Linux, Windows, macOS agents.
- No manager artifacts changed; no protocol/wire format changed (`Date` is a standard HTTP header the
  manager's transport already emits).

## Configuration Changes

## Documentation Updates

## Tests Introduced

- `tests/unit/retrySender_test.cpp` (+7 cases): a real skew corrected from the `Date` header and the
  retry recovers; the **mirror case with the agent clock behind the manager** (positive delta),
  confirming the correction isn't direction-specific — every other case here and every live E2E run
  only ever exercised the agent-ahead direction, so this closes that gap; a small (2s) gap is treated
  as noise, not skew; a missing `Date` header is a safe no-op; a corrected retry that still 401s
  escalates as a genuine key failure; the learned correction persists across a later, independent
  `send()` without re-learning it; a **second, independent skew event on top of an already-applied
  correction** converges on the manager's newly-reported time using a real `SkewCorrectedClock` (not
  the test double's own bookkeeping) — the regression test for the accumulate-vs-replace bug a
  reviewer caught.
- `tests/unit/sysSeams_test.cpp` (+3 cases): `SkewCorrectedClock` defaults to no correction and
  mirrors the base clock; an applied offset shifts `wallSeconds()` only; a new offset **accumulates**
  on top of a prior one (inverted from an earlier, incorrect "replaces" assertion).
- `tests/unit/curlPerformer_test.cpp`: existing test extended to assert `serverDateSeconds` flows back
  from the widened header capture.

## Review Checklist

- [x] Code changes reviewed (self-review passes caught and fixed an incorrect citation and an
      overclaimed comment about a timeout gap that isn't actually closed)
- [x] Relevant evidence provided — live repro before the fix, live-verified `Date` header assumption,
      clean CI (`gh pr checks` all green), and a live re-verification with the actual fixed build
      (see Results and Evidence)
- [x] Tests cover the new functionality (10 tests for the clock-skew fix itself, both directions
      covered, plus new tests for the review follow-up's concurrency fix and proxy-header fix)
- [x] Configuration changes documented (none introduced)
- [ ] Developer documentation reflects the changes (troubleshooting-doc note not yet written)
- [x] Meets requirements and/or definition of done — the reported defect is live-verified fixed
      against the real build, and CI is fully green
- [x] No unresolved dependencies with other issues (agent-only fix; no manager change required)
