### PR TITLE
Enable zstd compression by default on the agent

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -130,7 +130,7 @@ agent.normal_level=70
 # Compress HTTPS request bodies with zstd
 # 0. Disabled
 # 1. Enabled
-agent.https_compression_enabled=0
+agent.https_compression_enabled=1
 # Minimum events per second, configurable at XML settings [1..1000]
 agent.min_eps=50
 # Interval for agent status file updating (seconds) [0..86400]

--- a/src/client-agent/https_client/include/https_client.h
+++ b/src/client-agent/https_client/include/https_client.h
@@ -174,7 +174,7 @@ typedef struct hc_config_t
 
     /// zstd-compress in-memory request bodies before signing/sending.
     /// internal_options.conf (agent.https_compression_enabled), not a <client>
-    /// XML setting -- OFF by default.
+    /// XML setting -- ON by default.
     bool https_compression_enabled;
 } hc_config_t;
 

--- a/src/client-agent/https_client/src/compressionGate.hpp
+++ b/src/client-agent/https_client/src/compressionGate.hpp
@@ -12,6 +12,9 @@
 #ifndef _HC_COMPRESSION_GATE_HPP
 #define _HC_COMPRESSION_GATE_HPP
 
+#include "loggerHelper.h"
+#include "moduleLog.hpp"
+
 #include <atomic>
 
 /**
@@ -30,7 +33,10 @@ class CompressionGate final
         /// A compressed attempt got a 415. Idempotent; safe from any thread.
         void reportRejected()
         {
-            m_disabled.store(true, std::memory_order_relaxed);
+            if (!m_disabled.exchange(true, std::memory_order_relaxed))
+            {
+                LOGFN_WARN(m_logFn, "Manager rejected 'zstd' compression. HTTPS traffic will be uncompressed until the next restart.");
+            }
         }
 
         bool disabled() const
@@ -39,6 +45,7 @@ class CompressionGate final
         }
 
     private:
+        const LogFn m_logFn {HTTPS_CLIENT_LOGTAG};
         std::atomic<bool> m_disabled {false};
 };
 

--- a/src/client-agent/https_client/src/compressionGate.hpp
+++ b/src/client-agent/https_client/src/compressionGate.hpp
@@ -35,7 +35,7 @@ class CompressionGate final
         {
             if (!m_disabled.exchange(true, std::memory_order_relaxed))
             {
-                LOGFN_WARN(m_logFn, "Manager rejected 'zstd' compression. HTTPS traffic will be uncompressed until the next restart.");
+                LOGFN_INFO(m_logFn, "Manager rejected 'zstd' compression. HTTPS traffic will be uncompressed until the next restart.");
             }
         }
 

--- a/src/client-agent/https_client/src/httpsClientFacade.cpp
+++ b/src/client-agent/https_client/src/httpsClientFacade.cpp
@@ -108,10 +108,11 @@ bool HttpsClientFacade::start()
     }
 
     LOGFN_INFO(m_logFn,
-               "Starting https_client (server=%s:%u, agent=%s).",
+               "Starting https_client (server=%s:%u, agent=%s, body compression %s).",
                m_config.serverHost.c_str(),
                m_config.serverPort,
-               m_config.agentId.c_str());
+               m_config.agentId.c_str(),
+               m_config.httpsCompressionEnabled ? "enabled" : "disabled");
     m_started = true;
     m_dispatcher.start();
     m_dispatcher.onStateChange(HC_STATE_STARTING);

--- a/src/client-agent/https_client/src/moduleConfig.hpp
+++ b/src/client-agent/https_client/src/moduleConfig.hpp
@@ -77,8 +77,8 @@ struct ModuleConfig
         std::string syncSocketPath; ///< Stateful sync-intake STREAM socket; empty = disabled.
 
         // zstd-compress in-memory request bodies before signing/sending.
-        // internal_options.conf (agent.https_compression_enabled), off by default.
-        bool httpsCompressionEnabled {false};
+        // internal_options.conf (agent.https_compression_enabled), on by default.
+        bool httpsCompressionEnabled {true};
 
         // Always "https" in production (fromC never changes it); the component
         // test overrides it to "http" to drive the real curl path against a

--- a/src/client-agent/https_client/src/statefulStream.cpp
+++ b/src/client-agent/https_client/src/statefulStream.cpp
@@ -178,10 +178,21 @@ StatefulStream::SendResult StatefulStream::sendSession(const Session& session, W
     // "Sending /stateless batch" one): logged before the request so the size is on record
     // even if the POST never completes, and so it can be lined up against what the manager
     // received.
-    LOGFN_DEBUG2(m_logFn,
-                 "Sending /stateful session %s (%llu bytes).",
-                 session.id.c_str(),
-                 static_cast<unsigned long long>(session.size));
+    if (spec.precompressedBodyFileSize > 0)
+    {
+        LOGFN_DEBUG2(m_logFn,
+                     "Sending /stateful session %s (%llu bytes raw, %llu compressed).",
+                     session.id.c_str(),
+                     static_cast<unsigned long long>(session.size),
+                     static_cast<unsigned long long>(spec.precompressedBodyFileSize));
+    }
+    else
+    {
+        LOGFN_DEBUG2(m_logFn,
+                     "Sending /stateful session %s (%llu bytes raw, uncompressed).",
+                     session.id.c_str(),
+                     static_cast<unsigned long long>(session.size));
+    }
 
     const auto result = m_sender.send(spec, waiter, STATEFUL_MAX_ATTEMPTS);
     // The /stateful contract is interpreted from the raw HTTP status code and body by

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -1628,8 +1628,8 @@ static bool bridge_build_config(hc_config_t *config)
     /* internal_options.conf toggle, not a <client> XML setting -- request-
      * body compression is an opt-in tuning knob, not user-facing config.
      * getDefine_Int_default (not getDefine_Int) so a missing key defaults to
-     * off instead of aborting the agent. */
-    config->https_compression_enabled = (bool)getDefine_Int_default("agent", "https_compression_enabled", 0, 1, 0);
+     * on instead of aborting the agent. */
+    config->https_compression_enabled = (bool)getDefine_Int_default("agent", "https_compression_enabled", 0, 1, 1);
 
     /* Bug found during real-package validation: this used to be
      * getsharedfiles() (client-agent/src/notify.c), which is an MD5 (OS_MD5_File) -- the legacy

--- a/src/unit_tests/client-agent/test_https_client_bridge.c
+++ b/src/unit_tests/client-agent/test_https_client_bridge.c
@@ -177,19 +177,12 @@ int __wrap_getDefine_Int(const char *high_name, const char *low_name, int min, i
     return 0;
 }
 
-/* bridge_build_config() also reads the compression toggle via
- * getDefine_Int_default(), which -- unlike getDefine_Int() above -- returns
- * default_val instead of merror_exit()ing when the key is missing. No case
- * here exercises it either, so answer with the shipped default. */
 int __wrap_getDefine_Int_default(const char *high_name, const char *low_name, int min, int max, int default_val)
 {
     (void)high_name;
+    (void)low_name;
     (void)min;
     (void)max;
-
-    if (strcmp(low_name, "https_compression_enabled") == 0) {
-        return 0;
-    }
 
     return default_val;
 }
@@ -444,6 +437,31 @@ static void test_none_verify_mode_maps_to_hc_verify_none(void **state)
     w_https_client_start();
 
     assert_int_equal(g_captured_config.verify_mode, HC_VERIFY_NONE);
+
+    w_https_client_stop();
+}
+
+/* With agent.https_compression_enabled absent from both defines files
+ * (what __wrap_getDefine_Int_default answers above), the module must still come
+ * up compressing. */
+static void test_compression_defaults_to_enabled(void **state)
+{
+    (void)state;
+
+    expect_string(__wrap__minfo, formatted_msg, "https_client: starting.");
+    expect_string(__wrap_OS_SHA256_File, fname, SHAREDCFG_FILE);
+    expect_value(__wrap_OS_SHA256_File, mode, OS_BINARY);
+    will_return(__wrap_OS_SHA256_File, NULL);
+    expect_any(__wrap_hc_create, callbacks);
+    will_return(__wrap_hc_create, FAKE_HANDLE);
+    expect_value(__wrap_hc_start, handle, FAKE_HANDLE);
+    will_return(__wrap_hc_start, true);
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+
+    w_https_client_start();
+
+    assert_true(g_captured_config_valid);
+    assert_true(g_captured_config.https_compression_enabled);
 
     w_https_client_stop();
 }
@@ -2201,6 +2219,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_full_verify_mode_and_ca_reach_the_module, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_certificate_verify_mode_maps_to_hc_verify_cert, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_none_verify_mode_maps_to_hc_verify_none, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_compression_defaults_to_enabled, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_client_cert_key_and_ciphers_are_copied, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_config_checksum_is_sha256_of_local_merged_file, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_config_checksum_is_empty_when_local_file_unreadable, setup_test, teardown_test),


### PR DESCRIPTION
## Description

Zstd compression will now come enabled by default in the agents. Closes #38434

## Proposed Changes
#### Defaults
Sets `agent.https_compression_enabled` to `1` inside the agent's default `internal_options.conf`. If no default configuration value is set (Would need to remove `agent.https_compression_enabled` from the configuration) the agent will pick up `enabled` as the default.

#### Log improvements
Added some logs for the `zstd` compression feature:

* Body compression enabled/disabled on https start message:
`INFO  Starting https_client (server=10.0.0.1:8443, agent=001, body compression enabled).`

* Compression disabled when manager rejects it:
`WARN  Manager rejected 'zstd' compression. HTTPS traffic will be uncompressed until the next restart.`

* Raw/compressed bytes distinction on https messages with debug=2
`DEBUG2 Sending /stateful session sess-01 (1048576 bytes, 214003 compressed).`

### Results and Evidence

Checked that, after a fresh install, the compression value is set to one by default in `internal_options.conf`:

``` bash
# Compress HTTPS request bodies with zstd
# 0. Disabled
# 1. Enabled
agent.https_compression_enabled=1
```

And that `body compression enabled` shows up in the https client start message. Also we can see the `compressed bytes` distinction on some DEBUG=2 messages:

``` sql
2026/08/18 16:21:10 wazuh-agentd:https-client[308063] httpsClientFacade.cpp:110 at start(): INFO: Starting https_client (server=192.168.0.60:1517, agent=001, body compression enabled).
2026/08/18 16:27:05 wazuh-agentd:https-client[308063] statefulStream.cpp:183 at sendSession(): DEBUG: Sending /stateful session syscollector-7319884700684550144 (740688 bytes raw, 117845 compressed).
```

On a new fresh install, if we delete the `agent.https_compression_enabled` option entirely, we still see the agent picks up `enabled` as the default: 

``` sql
2026/08/18 16:36:22 wazuh-agentd:https-client[325942] httpsClientFacade.cpp:110 at start(): INFO: Starting https_client (server=192.168.0.60:1517, agent=002, body compression enabled).
```

### Artifacts Affected

None.

### Configuration Changes

None.

### Documentation Updates

None

### Tests Introduced

A single unit test (test_compression_defaults_to_enabled) to validate no compression configuration leads to `enabled` by default.

## Review Checklist


- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

