### PR TITLE
Make module stop() callbacks signal-only so modules do not deadlock each other on shutdown

### DIFF
--- a/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
@@ -89,6 +89,15 @@ class AgentInfoImpl
         void start(int interval, int integrityInterval = 86400, std::function<bool()> shouldContinue = nullptr);
         void stop();
 
+        /**
+         * @brief Closes the DBSync connection and the sync protocol.
+         *
+         * Runs on the module thread once start()'s run loop has returned, so a caller
+         * that joins that thread is guaranteed the handles are closed. Idempotent, so
+         * the destructor can also call it for the case where start() never ran.
+         */
+        void releaseResources();
+
         /// @brief Override the flush poll delay (milliseconds). Only used in unit tests to avoid real sleeps.
         /// Negative values are clamped to 0.
         void setFlushPollDelayMs(int delayMs)
@@ -403,6 +412,13 @@ class AgentInfoImpl
         /// stop() writes it from another thread (avoids a data race).
         std::atomic<bool> m_stopped{false};
 
+        /// @brief True only while start()'s run loop is executing.
+        /// Read by releaseResources() to refuse tearing down members the loop may still
+        /// be using. The join in stop_wmodules() / wm_handler() is not authoritative --
+        /// both only log when the budget expires and then continue to process exit -- so
+        /// the destructor can be reached with this loop still running.
+        std::atomic<bool> m_runLoopActive{false};
+
         /// @brief Predicate reporting whether a shutdown is in progress (may be null).
         /// Injected from the module wrapper; reports the *global* agent shutdown, which is
         /// signaled before this module's own stop() runs.
@@ -463,15 +479,9 @@ class AgentInfoImpl
         /// @brief Mutex for synchronizing access to m_dBSync (prevents race conditions during cleanup/transactions)
         std::mutex m_dbSyncMutex;
 
-        /// @brief Serializes destruction of m_spSyncProtocol in stop()
+        /// @brief Serializes destruction of m_spSyncProtocol in releaseResources()
+        /// against the readers that run on other threads (parseResponseBuffer()).
         std::mutex m_syncProtocolMutex;
-
-        /// @brief Clean-stop handshake: stop() blocks until the run loop (start()) has
-        /// exited, so the sync-protocol connection can be closed with no other thread
-        /// using it.
-        std::mutex m_shutdownMutex;
-        std::condition_variable m_shutdownCv;
-        bool m_runLoopActive = false;
 
         /// @brief Flag set during updateChanges callback when cluster_name changed
         bool m_clusterNameChanged = false;

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -187,6 +187,9 @@ AgentInfoImpl::AgentInfoImpl(std::string dbPath,
 AgentInfoImpl::~AgentInfoImpl()
 {
     stop();
+    // Covers the case where start() never ran, so its run loop never reached the
+    // teardown. Idempotent, so it is a no-op when the run loop already did it.
+    releaseResources();
     m_logFunction(LOG_INFO, "AgentInfo destroyed.");
 }
 
@@ -196,16 +199,31 @@ void AgentInfoImpl::start(int interval, int integrityInterval, std::function<boo
                   "AgentInfo module started with interval: " + std::to_string(interval) +
                   " seconds, integrity interval: " + std::to_string(integrityInterval) + " seconds.");
 
-    {
-        std::lock_guard<std::mutex> lock(m_shutdownMutex);
-        m_runLoopActive = true;
-    }
-
     // Load sync flags from database at startup
     loadSyncFlags();
 
     std::unique_lock<std::mutex> lock(m_mutex);
-    m_stopped = false;
+
+    // Do NOT clear a stop that arrived while the module was still starting up. The
+    // shutdown loop signals every module before joining any of them, so a stop can
+    // land before this point; clearing it here would leave the run loop below with no
+    // exit condition at all -- callers pass no shouldContinue -- and the module thread
+    // would never become joinable.
+    //
+    // m_stopped is therefore sticky for the life of the instance. That is fine today --
+    // one start() per process -- but a future hot-restart path must distinguish "stopped"
+    // from "shutting down" (an explicit reset here would bring back the lost stop above).
+    //
+    // The check is isShutdownInProgress() rather than m_stopped alone because
+    // agent_info_stop() null-checks the instance: a stop arriving before this object
+    // exists never reaches stop() at all. The module wrapper does set the global flag
+    // in that case, and the injected predicate is the only way to observe it.
+    if (isShutdownInProgress())
+    {
+        lock.unlock();
+        m_logFunction(LOG_INFO, "AgentInfo start aborted: shutdown already in progress.");
+        return;
+    }
 
     // Reset sync protocol stop flag to allow restarting operations
     if (m_spSyncProtocol)
@@ -217,6 +235,8 @@ void AgentInfoImpl::start(int interval, int integrityInterval, std::function<boo
     m_cv.wait_for(lock, std::chrono::seconds(5), [this] { return m_stopped.load(); });
 
     // Run at least once
+    m_runLoopActive.store(true);
+
     do
     {
         lock.unlock();
@@ -287,24 +307,57 @@ void AgentInfoImpl::start(int interval, int integrityInterval, std::function<boo
         // If no shouldContinue function provided, use default behavior (continue until stopped)
         bool shouldLoop = shouldContinue ? shouldContinue() : !m_stopped;
 
-        if (shouldLoop && !m_stopped)
+        if (shouldLoop && !isShutdownInProgress())
         {
             // Wait for the interval or until stop is signaled
             m_cv.wait_for(lock, std::chrono::seconds(interval), [this] { return m_stopped.load(); });
         }
 
     }
-    while (!m_stopped && (shouldContinue ? shouldContinue() : true));
+
+    // Same reason as the guard above: without the global predicate a stop lost to that
+    // null check, or arriving between it and here, would leave this loop with no exit.
+    while (!isShutdownInProgress() && (shouldContinue ? shouldContinue() : true));
+
+    m_runLoopActive.store(false);
 
     m_logFunction(LOG_INFO, "AgentInfo module loop ended.");
+}
 
-    // Publish that the run loop has fully exited so stop() can tear down the sync
-    // protocol without racing synchronizeMetadataOrGroups().
+void AgentInfoImpl::releaseResources()
+{
+    // Never free while the run loop may still be using these members. The join that is
+    // supposed to guarantee the loop finished is not authoritative: stop_wmodules() and
+    // wm_handler() only log when the shutdown budget expires and then carry on to
+    // process exit, so the destructor can reach here with the loop still running.
+    // Freeing then is a use-after-free, so skip it and let process teardown reclaim the
+    // handles -- the same trade-off the removed run-loop wait used to make, minus the
+    // blocking wait.
+    if (m_runLoopActive.load())
     {
-        std::lock_guard<std::mutex> shutdownLock(m_shutdownMutex);
-        m_runLoopActive = false;
+        m_logFunction(LOG_WARNING, "AgentInfo run loop still active; skipping database teardown.");
+        return;
     }
-    m_shutdownCv.notify_all();
+
+    // Idempotent: runs from the module thread when the run loop ends, and again from
+    // the destructor for the case where the run loop never started.
+    {
+        std::lock_guard<std::mutex> dbLock(m_dbSyncMutex);
+
+        if (m_dBSync)
+        {
+            m_logFunction(LOG_DEBUG, "Closing DBSync connection...");
+            m_dBSync.reset();
+            m_logFunction(LOG_DEBUG, "DBSync connection closed");
+        }
+    }
+
+    // Destroy the sync protocol so its SQLite connection to the persistent-queue db
+    // is closed. Guarded against parseResponseBuffer(), which runs on another thread.
+    {
+        std::lock_guard<std::mutex> lock(m_syncProtocolMutex);
+        m_spSyncProtocol.reset();
+    }
 }
 
 void AgentInfoImpl::stop()
@@ -332,46 +385,12 @@ void AgentInfoImpl::stop()
         }
     }
 
-    // Wait for the run loop to exit before freeing shared resources, so we don't
-    // free m_dBSync / the sync protocol while synchronizeMetadataOrGroups() is
-    // still using them. Time-bounded so a stuck loop can't hang shutdown.
-    constexpr auto SHUTDOWN_WAIT_SECONDS = std::chrono::seconds(10);  // max wait for the run loop to finish teardown
-    bool runLoopExited = false;
-    {
-        std::unique_lock<std::mutex> lock(m_shutdownMutex);
-        runLoopExited = m_shutdownCv.wait_for(lock, SHUTDOWN_WAIT_SECONDS, [this] { return !m_runLoopActive; });
-    }
-
-    if (!runLoopExited)
-    {
-        // The run loop is still active. Freeing m_dBSync / the sync protocol now
-        // would be a use-after-free (the loop can still call synchronizeMetadataOrGroups()),
-        // so skip the teardown and let process exit reclaim the handles instead.
-        m_logFunction(LOG_WARNING, "Timeout waiting for AgentInfo run loop to exit; skipping database teardown.");
-        m_logFunction(LOG_INFO, "AgentInfo module stopped.");
-        return;
-    }
-
-    // Close the main DB connection.
-    {
-        std::lock_guard<std::mutex> dbLock(m_dbSyncMutex);
-
-        if (m_dBSync)
-        {
-            m_logFunction(LOG_DEBUG, "Closing DBSync connection...");
-            m_dBSync.reset();
-            m_logFunction(LOG_DEBUG, "DBSync connection closed");
-        }
-    }
-
-    // Destroy the sync protocol so its SQLite connection to the persistent-queue
-    // db is closed BEFORE stop() returns. Guarded against parseResponseBuffer(),
-    // which runs on another thread.
-    {
-        std::lock_guard<std::mutex> lock(m_syncProtocolMutex);
-        m_spSyncProtocol.reset();
-    }
-
+    // Signal only. The teardown of m_dBSync and the sync protocol happens in
+    // releaseResources(), on the module thread, once the run loop has returned --
+    // so joining that thread is what guarantees the handles are closed. Waiting
+    // here instead blocked this callback for up to 10 s, and because the shutdown
+    // loop stops modules one at a time it also withheld the stop signal from the
+    // very modules this run loop can be parked on.
     m_logFunction(LOG_INFO, "AgentInfo module stopped.");
 }
 

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_basic_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_basic_test.cpp
@@ -293,15 +293,16 @@ TEST_F(AgentInfoImplTest, ConstructorThrowsWhenQueryModuleFunctionIsNull)
 
 // Regression test for the clean-stop ordering fix (issues #37629 / #37714).
 //
-// stop() must not return until the run loop has exited, so that shared resources
-// (the main DBSync connection and the sync-protocol SQLite connection) are only
-// torn down once no other thread is using them.
+// stop() is signal-only: it must return promptly even with the run loop mid-iteration,
+// so the shutdown loop can reach the sibling modules this loop may be waiting on.
+// The teardown of the shared resources is not skipped, it just stops
+// being stop()'s job: releaseResources() performs it, and the module thread calls it on
+// its way out (wm_agent_info_main), so joining that thread is what guarantees no other
+// thread is still using them.
 //
-// The run loop calls ISysInfo::os() near the top of populateAgentMetadata(). We
-// hold it there for a fixed window so the loop is provably still active when
-// stop() is called: stop() blocks for that window; before it, stop()
-// returned immediately.
-TEST_F(AgentInfoImplTest, StopWaitsForRunLoopToExit)
+// The run loop calls ISysInfo::os() near the top of populateAgentMetadata(). We hold it
+// there for a fixed window so the loop is provably still active when stop() is called.
+TEST_F(AgentInfoImplTest, StopSignalsWithoutWaitingAndReleaseIsSeparate)
 {
     constexpr auto HOLD = std::chrono::milliseconds(300);
 
@@ -334,18 +335,82 @@ TEST_F(AgentInfoImplTest, StopWaitsForRunLoopToExit)
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
 
+    clearLogOutput();
     const auto start = std::chrono::steady_clock::now();
     agentInfo->stop();
     const auto elapsed = std::chrono::steady_clock::now() - start;
 
-    // AFTER the fix stop() blocks until the in-flight run-loop iteration finishes;
-    // BEFORE the fix it returned immediately (< 1 ms).
-    EXPECT_GE(elapsed, HOLD / 2) << "stop() returned before the run loop had exited";
+    // stop() only signals, so it must not sit out the in-flight iteration.
+    EXPECT_LT(elapsed, HOLD / 2) << "stop() blocked instead of only signalling";
 
+    // The signal still ends the loop promptly.
     loopThread.join();
+    EXPECT_THAT(getLogOutput(), ::testing::HasSubstr("AgentInfo module loop ended"))
+            << "stop() did not make the run loop exit";
+
+    // And the teardown stop() used to perform is now a separate, explicit step, which
+    // the module thread runs on its way out. It must actually close the connection.
+    clearLogOutput();
+    agentInfo->releaseResources();
+    EXPECT_THAT(getLogOutput(), ::testing::HasSubstr("DBSync connection closed"))
+            << "releaseResources() did not close the DBSync connection";
 }
 
-// After stop() tears down the sync protocol, the asynchronous response path
+TEST_F(AgentInfoImplTest, ReleaseResourcesRefusesWhileRunLoopIsActive)
+{
+    // stop() no longer waits for the run loop, and the join that is supposed to guarantee
+    // the loop finished is not authoritative: stop_wmodules() and wm_handler() only log
+    // when their shutdown budget expires and then carry on to process exit, which runs
+    // ~AgentInfoImpl() -> releaseResources(). Freeing m_dBSync / the sync protocol with the
+    // loop still inside synchronizeMetadataOrGroups() would be a use-after-free, so the
+    // teardown has to decline and leave the handles to process teardown.
+    constexpr auto HOLD = std::chrono::milliseconds(400);
+
+    auto mockSysInfo = std::make_shared<MockSysInfo>();
+    std::atomic<bool> loopInBody{false};
+
+    EXPECT_CALL(*mockSysInfo, os())
+    .WillRepeatedly(::testing::Invoke([&]() -> nlohmann::json
+    {
+        loopInBody.store(true, std::memory_order_release);
+        std::this_thread::sleep_for(HOLD);
+        return nlohmann::json::object();
+    }));
+
+    auto agentInfo =
+        std::make_shared<AgentInfoImpl>("test_path", nullptr, m_logFunction, m_queryModuleFunction, m_mockDBSync, mockSysInfo);
+
+    std::thread loopThread([&]()
+    {
+        agentInfo->start(3600, 86400, []()
+        {
+            return true;
+        });
+    });
+
+    while (!loopInBody.load(std::memory_order_acquire))
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    clearLogOutput();
+    agentInfo->releaseResources();
+    EXPECT_THAT(getLogOutput(), ::testing::HasSubstr("run loop still active"))
+            << "releaseResources() tore down while the run loop was running";
+    EXPECT_THAT(getLogOutput(), ::testing::Not(::testing::HasSubstr("DBSync connection closed")))
+            << "releaseResources() closed DBSync under a live run loop";
+
+    agentInfo->stop();
+    loopThread.join();
+
+    // Once the loop has exited, the same call must do the teardown it just refused.
+    clearLogOutput();
+    agentInfo->releaseResources();
+    EXPECT_THAT(getLogOutput(), ::testing::HasSubstr("DBSync connection closed"))
+            << "releaseResources() did not close the DBSync connection after the loop ended";
+}
+
+// After the sync protocol is torn down, the asynchronous response path
 // (parseResponseBuffer, called on the dispatch thread) must fail gracefully
 // instead of dereferencing the freed sync protocol.
 TEST_F(AgentInfoImplTest, ParseResponseBufferAfterStopIsSafe)
@@ -357,8 +422,10 @@ TEST_F(AgentInfoImplTest, ParseResponseBufferAfterStopIsSafe)
 
     const uint8_t data[] = {0x01, 0x02, 0x03};
 
-    // stop() destroys the sync protocol under m_syncProtocolMutex.
+    // stop() signals; releaseResources() destroys the sync protocol under
+    // m_syncProtocolMutex. On the module thread these run in that order.
     m_agentInfo->stop();
+    m_agentInfo->releaseResources();
 
     // The now-torn-down protocol must be rejected safely (no use-after-free).
     clearLogOutput();

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_dbsync_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_dbsync_test.cpp
@@ -270,7 +270,7 @@ TEST_F(AgentInfoDBSyncIntegrationTest, CheckAndRecordTaskDuplicateReturnsFalseWi
 TEST_F(AgentInfoDBSyncIntegrationTest, CheckAndRecordTaskFailsClosedWithoutDBSync)
 {
     m_agentInfo = std::make_shared<AgentInfoImpl>(":memory:", nullptr, m_logFunc, m_queryModuleFunc, m_mockDBSync);
-    m_agentInfo->stop(); // Resets the DBSync connection (see AgentInfoImpl::stop()).
+    m_agentInfo->releaseResources(); // Drops the DBSync connection.
 
     EXPECT_FALSE(m_agentInfo->checkAndRecordTask("task-abc"));
 }
@@ -299,7 +299,7 @@ TEST_F(AgentInfoDBSyncIntegrationTest, CleanupExpiredTasksIssuesTtlThenCapDelete
 TEST_F(AgentInfoDBSyncIntegrationTest, CleanupExpiredTasksIsNoOpWithoutDBSync)
 {
     m_agentInfo = std::make_shared<AgentInfoImpl>(":memory:", nullptr, m_logFunc, m_queryModuleFunc, m_mockDBSync);
-    m_agentInfo->stop();
+    m_agentInfo->releaseResources();
 
     EXPECT_NO_THROW(m_agentInfo->cleanupExpiredTasks(86400, 4096));
 }

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_vd_offset_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_vd_offset_test.cpp
@@ -108,7 +108,7 @@ TEST_F(AgentInfoVdOffsetTest, ObserveFailsClosedWithoutDBSync)
 {
     m_agentInfo = std::make_shared<AgentInfoImpl>(":memory:", nullptr, m_logFunc,
                                                   vdFirstSyncQueryFunc(true), m_mockDBSync);
-    m_agentInfo->stop(); // Resets the DBSync connection (see AgentInfoImpl::stop()).
+    m_agentInfo->releaseResources(); // Drops the DBSync connection.
 
     const auto result = m_agentInfo->observeVdFeedOffset(100);
     EXPECT_FALSE(result.changed);
@@ -119,7 +119,7 @@ TEST_F(AgentInfoVdOffsetTest, ClearPendingFailsClosedWithoutDBSync)
 {
     m_agentInfo = std::make_shared<AgentInfoImpl>(":memory:", nullptr, m_logFunc,
                                                   vdFirstSyncQueryFunc(true), m_mockDBSync);
-    m_agentInfo->stop();
+    m_agentInfo->releaseResources();
 
     EXPECT_FALSE(m_agentInfo->clearVdRescanPending(100));
 }
@@ -128,7 +128,7 @@ TEST_F(AgentInfoVdOffsetTest, GetStateFailsClosedWithoutDBSync)
 {
     m_agentInfo = std::make_shared<AgentInfoImpl>(":memory:", nullptr, m_logFunc,
                                                   vdFirstSyncQueryFunc(true), m_mockDBSync);
-    m_agentInfo->stop();
+    m_agentInfo->releaseResources();
 
     const auto state = m_agentInfo->getVdFeedState();
     EXPECT_FALSE(state.hasOffset);

--- a/src/wazuh_modules/agent_info/include/agent_info.h
+++ b/src/wazuh_modules/agent_info/include/agent_info.h
@@ -39,6 +39,18 @@ EXPORTED void agent_info_stop();
 
 EXPORTED void agent_info_cleanup();
 
+/**
+ * @brief Close the module's database and sync-protocol connections, keeping the
+ *        instance alive.
+ *
+ * Unlike agent_info_cleanup(), which destroys the instance, this only releases what it
+ * holds. Safe to call from the module thread while other threads may still dispatch
+ * into the module: the readers null-check the instance without a lock, so destroying
+ * it underneath them is a use-after-free, whereas the resources themselves are
+ * released under the mutexes those readers take. Idempotent.
+ */
+EXPORTED void agent_info_release_resources();
+
 EXPORTED void agent_info_set_log_function(log_callback_t log_callback);
 
 EXPORTED void agent_info_set_report_function(report_callback_t report_callback);
@@ -233,6 +245,7 @@ EXPORTED void agent_info_ensure_database(void);
 typedef void (*agent_info_start_func)(const struct wm_agent_info_t* agent_info_config);
 typedef void (*agent_info_stop_func)();
 typedef void (*agent_info_cleanup_func)();
+typedef void (*agent_info_release_resources_func)();
 typedef void (*agent_info_set_log_function_func)(log_callback_t log_callback);
 typedef void (*agent_info_set_report_function_func)(report_callback_t report_callback);
 typedef void (*agent_info_init_sync_protocol_func)(const char* module_name);

--- a/src/wazuh_modules/agent_info/src/agent_info.cpp
+++ b/src/wazuh_modules/agent_info/src/agent_info.cpp
@@ -378,6 +378,14 @@ void agent_info_cleanup()
     g_agent_info_impl.reset();
 }
 
+void agent_info_release_resources()
+{
+    if (g_agent_info_impl)
+    {
+        g_agent_info_impl->releaseResources();
+    }
+}
+
 void agent_info_init_sync_protocol(const char* module_name)
 {
     g_module_name = module_name;

--- a/src/wazuh_modules/src/wm_agent_info.c
+++ b/src/wazuh_modules/src/wm_agent_info.c
@@ -62,6 +62,7 @@ void* agent_info_module = NULL;
 agent_info_start_func agent_info_start_ptr = NULL;
 agent_info_stop_func agent_info_stop_ptr = NULL;
 agent_info_cleanup_func agent_info_cleanup_ptr = NULL;
+agent_info_release_resources_func agent_info_release_resources_ptr = NULL;
 agent_info_set_log_function_func agent_info_set_log_function_ptr = NULL;
 agent_info_set_report_function_func agent_info_set_report_function_ptr = NULL;
 agent_info_init_sync_protocol_func agent_info_init_sync_protocol_ptr = NULL;
@@ -814,6 +815,28 @@ int wm_agent_info_sync_message(const char* command, size_t command_len)
 }
 
 // Main module function
+// Release the agent-info instance's resources from the module thread, so the DBSync
+// and sync-protocol connections are closed before this thread returns and therefore
+// before whoever joins it observes the module as stopped. Must cover the early-exit
+// paths too: agent_info_task_registry_init() may have already constructed the
+// instance (and opened agent_info.db) before the handshake wait, so returning from
+// those paths without this would leave the database open until process teardown --
+// i.e. past the point where the replacement agent starts.
+//
+// Releases the resources, it does NOT destroy the instance: agent_info_cleanup()
+// resets the global with no lock, while agent_info_parse_response() (sync dispatcher
+// thread) and agent_info_task_check_and_record() (/control thread) only null-check it
+// before use, so destroying it from here would be a check-then-use use-after-free.
+// The destruction stays in wm_agent_info_destroy(), which runs after those threads
+// are gone.
+static void wm_agent_info_release(void)
+{
+    if (agent_info_release_resources_ptr)
+    {
+        agent_info_release_resources_ptr();
+    }
+}
+
 #ifdef WIN32
 DWORD WINAPI wm_agent_info_main(void* arg)
 {
@@ -857,6 +880,8 @@ void* wm_agent_info_main(wm_agent_info_t* agent_info)
         agent_info_start_ptr = so_get_function_sym(agent_info_module, "agent_info_start");
         agent_info_stop_ptr = so_get_function_sym(agent_info_module, "agent_info_stop");
         agent_info_cleanup_ptr = so_get_function_sym(agent_info_module, "agent_info_cleanup");
+        agent_info_release_resources_ptr =
+            so_get_function_sym(agent_info_module, "agent_info_release_resources");
         agent_info_set_log_function_ptr = so_get_function_sym(agent_info_module, "agent_info_set_log_function");
         agent_info_set_report_function_ptr = so_get_function_sym(agent_info_module, "agent_info_set_report_function");
         agent_info_init_sync_protocol_ptr = so_get_function_sym(agent_info_module, "agent_info_init_sync_protocol");
@@ -975,6 +1000,7 @@ void* wm_agent_info_main(wm_agent_info_t* agent_info)
     if (wm_agent_info_is_shutting_down())
     {
         mdebug1("Shutdown requested during handshake wait, exiting.");
+        wm_agent_info_release();
         return NULL;
     }
 
@@ -988,11 +1014,13 @@ void* wm_agent_info_main(wm_agent_info_t* agent_info)
     else
     {
         merror("agent_info_start function not available.");
+        wm_agent_info_release();
         return NULL;
     }
 
-    // The module has completed its initialization and metadata collection
-    // The thread will now exit as agent-info is a one-time collection module
+    // The module has completed its initialization and metadata collection.
+    // Release before returning: the thread exit is what the shutdown loop joins on.
+    wm_agent_info_release();
     return NULL;
 }
 

--- a/src/wazuh_modules/src/wm_sca.c
+++ b/src/wazuh_modules/src/wm_sca.c
@@ -45,13 +45,6 @@ static HANDLE sca_sync_worker_thread = NULL;
 #endif
 static bool sca_sync_worker_thread_initialized = false;
 
-// Clean stop mechanism variables
-static pthread_cond_t sca_stop_condition = PTHREAD_COND_INITIALIZER;
-static pthread_mutex_t sca_stop_mutex = PTHREAD_MUTEX_INITIALIZER;
-static bool sca_need_shutdown_wait = false;
-static pthread_t sca_main_thread;
-static bool sca_main_thread_initialized = false;
-
 // SCA message queue variables
 static int g_shutting_down = 0;
 static int g_sca_queue = 0;
@@ -96,7 +89,7 @@ static void * wm_sca_sync_module(__attribute__((unused)) void * args);
 static void wm_sca_destroy(wm_sca_t * data);  // Destroy data
 static int wm_sca_start(wm_sca_t * data);  // Start
 static void wm_sca_stop(wm_sca_t* data);   // Stop
-static void wm_sca_release_and_signal(void);  // Release resources and wake wm_sca_stop()
+static void wm_sca_release_resources(void);  // Release resources on the module thread
 
 cJSON *wm_sca_dump(const wm_sca_t * data);     // Read config
 
@@ -510,10 +503,6 @@ DWORD WINAPI wm_sca_main(void *arg) {
 #else
 void * wm_sca_main(wm_sca_t * data) {
 #endif
-    w_mutex_lock(&sca_stop_mutex);
-    sca_main_thread = pthread_self();
-    sca_main_thread_initialized = true;
-    w_mutex_unlock(&sca_stop_mutex);
 
     // If module is disabled, exit
     if (data->enabled) {
@@ -585,13 +574,6 @@ void * wm_sca_main(wm_sca_t * data) {
     data->commands_timeout = getDefine_Int_default("sca", "commands_timeout", 1, 300, 30);
     data->remote_commands = getDefine_Int_default("sca", "remote_commands", 0, 1, 0);
 
-    // Arm the shutdown wait before sca_init() opens the databases, so that a
-    // concurrent wm_sca_stop() blocks until they are released on every exit path
-    // below (not only the normal wm_sca_start() teardown).
-    w_mutex_lock(&sca_stop_mutex);
-    sca_need_shutdown_wait = true;
-    w_mutex_unlock(&sca_stop_mutex);
-
     if (sca_init_ptr) {
         sca_init_ptr();
     }
@@ -611,10 +593,10 @@ void * wm_sca_main(wm_sca_t * data) {
 
         if (wm_sca_is_shutting_down())
         {
-            // sca_init() already opened the databases; release them and wake any
-            // waiting wm_sca_stop() before returning, so the next process does not
-            // find them locked.
-            wm_sca_release_and_signal();
+            // sca_init() already opened the databases; release them before returning
+            // on this early-exit path too, so the next process does not find them
+            // locked.
+            wm_sca_release_resources();
 #ifdef WIN32
             return 0;
 #else
@@ -635,20 +617,17 @@ void * wm_sca_main(wm_sca_t * data) {
 #endif
 }
 
-// Release SCA resources and wake any wm_sca_stop() blocked on the shutdown
-// condition.
-static void wm_sca_release_and_signal(void)
+// Release SCA resources. Always called from the SCA module thread.
+static void wm_sca_release_resources(void)
 {
-    w_mutex_lock(&sca_stop_mutex);
-    sca_need_shutdown_wait = false;
-    sca_main_thread_initialized = false;
+    // Runs on the SCA module thread, before it returns, so whoever joins that
+    // thread is guaranteed the teardown already completed. wm_sca_stop() does not
+    // need to wait for it a second time.
     if (sca_release_resources_ptr)
     {
         sca_release_resources_ptr();
         sca_release_resources_ptr = NULL;
     }
-    w_cond_signal(&sca_stop_condition);
-    w_mutex_unlock(&sca_stop_mutex);
 }
 
 static int wm_sca_start(wm_sca_t *sca) {
@@ -657,14 +636,21 @@ static int wm_sca_start(wm_sca_t *sca) {
     if (g_sca_queue < 0) {
         merror("Cannot initialize SCA message queue.");
         // sca_init() already opened the databases, and StartMQPredicated only
-        // gives up when shutdown started mid-startup (a wm_sca_stop() is already
-        // waiting). Release the connections and signal, instead of leaking them
-        // and blocking the waiter for the full timeout.
-        wm_sca_release_and_signal();
+        // gives up when shutdown started mid-startup. Release the connections here
+        // instead of leaking them until process teardown.
+        wm_sca_release_resources();
         return -1;
     }
 
-    g_shutting_down = 0;
+    // g_shutting_down is deliberately NOT reset here. The shutdown loop signals every
+    // module before joining any of them, so wm_sca_stop() can have run before this
+    // point; since wm_sca_is_shutting_down() reads only this flag, clearing it would
+    // erase that stop and the module would run on through shutdown.
+    //
+    // Nothing is released here either. wm_sca_stop() sets the flag before calling
+    // quiesce(), which reads m_spSyncProtocol and m_asyncFlushController without
+    // m_resourcesMutex, so releasing from this thread could race it. The teardown stays
+    // on the normal exit path, after sca_start_ptr() has returned.
     atomic_int_set(&g_n_msg_sent, 0);
 
     mdebug1("SCA message queue initialized successfully.");
@@ -729,7 +715,7 @@ static int wm_sca_start(wm_sca_t *sca) {
 
     // Safe to release resources now that both the sync worker and the main SCA
     // run loop have exited.  m_dBSync is no longer referenced by any thread.
-    wm_sca_release_and_signal();
+    wm_sca_release_resources();
 
     return 0;
 }
@@ -747,42 +733,15 @@ void wm_sca_stop(__attribute__((unused)) wm_sca_t* data)
     g_shutting_down = 1;
     sca_sync_module_running = 0;
 
-    // Quiesce the sync protocol and the main SCA loop, then block until
-    // wm_sca_start()'s teardown (join + releaseResources(), deferred until
-    // after sca_start_ptr() returns so we don't free m_dBSync while the SCA
-    // run loop is still using it) has actually finished, so the caller can't
-    // observe "stopped" before the sync-protocol SQLite connection is closed.
+    // Signal only: quiesce the sync protocol and the main SCA loop and return.
+    // wm_sca_main() runs the teardown (join + releaseResources(), deferred until
+    // after sca_start_ptr() returns so we don't free m_dBSync while the SCA run
+    // loop is still using it) before its thread exits, so the caller's join of
+    // that thread is what guarantees the SQLite connection is closed.
 
     if (sca_stop_ptr) {
         sca_stop_ptr();
     }
-
-    w_mutex_lock(&sca_stop_mutex);
-    const bool called_from_sca_main_thread = sca_main_thread_initialized && pthread_equal(pthread_self(), sca_main_thread);
-
-    if (called_from_sca_main_thread)
-    {
-        mdebug1("Stop called from SCA worker thread. Skipping synchronous shutdown wait.");
-    }
-
-    if (sca_need_shutdown_wait && !called_from_sca_main_thread)
-    {
-        const time_t SHUTDOWN_WAIT_SECONDS = 10;  // max wait for the run loop to finish teardown
-        struct timespec ts;
-        clock_gettime(CLOCK_REALTIME, &ts);
-        ts.tv_sec += SHUTDOWN_WAIT_SECONDS;
-
-        while (sca_need_shutdown_wait)
-        {
-            if (pthread_cond_timedwait(&sca_stop_condition, &sca_stop_mutex, &ts) == ETIMEDOUT)
-            {
-                mwarn("Timeout waiting for SCA to complete shutdown.");
-                break;
-            }
-        }
-    }
-
-    w_mutex_unlock(&sca_stop_mutex);
 }
 
 cJSON *wm_sca_dump(const wm_sca_t * data) {

--- a/src/wazuh_modules/src/wm_syscollector.c
+++ b/src/wazuh_modules/src/wm_syscollector.c
@@ -49,11 +49,6 @@ static void wm_sys_stop(wm_sys_t* sys);         // Module stopper
 const char* WM_SYS_LOCATION = "syscollector";   // Location field for event sending
 cJSON* wm_sys_dump(const wm_sys_t* sys);
 int wm_sync_message(const char* command, size_t command_len);
-static pthread_cond_t sys_stop_condition = PTHREAD_COND_INITIALIZER;
-static pthread_mutex_t sys_stop_mutex = PTHREAD_MUTEX_INITIALIZER;
-static bool need_shutdown_wait = false;
-static pthread_t sys_main_thread;
-static bool sys_main_thread_initialized = false;
 #ifndef WIN32
 static pthread_t sync_worker_thread;
 #else
@@ -61,7 +56,14 @@ static HANDLE sync_worker_thread = NULL;
 #endif
 static bool sync_worker_thread_initialized = false;
 pthread_mutex_t sys_reconnect_mutex = PTHREAD_MUTEX_INITIALIZER;
-bool shutdown_process_started = false;
+// volatile sig_atomic_t, not a plain bool: this is written from wm_sys_stop(), which on
+// POSIX runs inside the SIGTERM handler (wm_handler, wazuh_modules/src/main.c), and read
+// from the module thread's polling loops below. sig_atomic_t is what a signal handler is
+// allowed to write, and volatile is what stops the compiler from hoisting the reads out of
+// those loops -- is_shutdown_process_started() is static and trivially inlinable, so the
+// function call is no barrier. Same idiom as wm_shutdown_requested (wmodules.h) and as
+// sync_module_running above.
+volatile sig_atomic_t shutdown_process_started = 0;
 
 static size_t wm_sys_query_handler(void* data, char* query, char** output); // Query handler
 
@@ -128,8 +130,7 @@ int queue_fd = 0;                        // Output queue file descriptor
 
 static bool is_shutdown_process_started()
 {
-    bool ret_val = shutdown_process_started;
-    return ret_val;
+    return shutdown_process_started != 0;
 }
 
 bool wm_sys_query_agentd(const char* command, char* output_buffer, size_t buffer_size)
@@ -566,11 +567,6 @@ void* wm_sys_main(wm_sys_t* sys)
 
     sys->flags.running = true;
 
-    w_mutex_lock(&sys_stop_mutex);
-    sys_main_thread = pthread_self();
-    sys_main_thread_initialized = true;
-    w_mutex_unlock(&sys_stop_mutex);
-
     if (!sys->flags.enabled)
     {
         wm_handle_sys_disabled_and_notify_data_clean(sys);
@@ -625,13 +621,17 @@ void* wm_sys_main(wm_sys_t* sys)
         pthread_exit(NULL);
     }
 
-    if (syscollector_init_ptr && syscollector_start_ptr)
+    if (is_shutdown_process_started())
+    {
+        // A stop arrived while this thread was still getting here. Do not initialise:
+        // that would open the databases and clear m_stopping, and the teardown below
+        // would then have to race wm_sys_stop()'s quiesce() to put them back. Nothing
+        // was opened, so that teardown is a no-op on this path.
+        mtinfo(WM_SYS_LOGTAG, "Shutdown requested before Syscollector started; skipping startup.");
+    }
+    else if (syscollector_init_ptr && syscollector_start_ptr)
     {
         mtdebug1(WM_SYS_LOGTAG, "Starting module.");
-        w_mutex_lock(&sys_stop_mutex);
-        need_shutdown_wait = true;
-        w_mutex_unlock(&sys_stop_mutex);
-
         enable_synchronization = sys->sync.enable_synchronization;
 
         if (enable_synchronization)
@@ -717,6 +717,14 @@ void* wm_sys_main(wm_sys_t* sys)
             mtdebug1(WM_SYS_LOGTAG, "Inventory synchronization is disabled or function not available");
         }
 
+        // No second check here, deliberately. A stop landing *during* initialisation is
+        // still lost (init() cleared m_stopping), but skipping the scan at this point
+        // would send this thread straight into releaseResources() while wm_sys_stop() is
+        // inside quiesce(), which reads m_spSyncProtocol/m_spSyncProtocolVD without
+        // m_resourcesMutex -- with the databases already open, so there is something to
+        // pull from under it. Closing that window needs quiesce() and releaseResources()
+        // serialized first; until then, running the scan and letting it notice m_stopping
+        // is the safer of the two failure modes.
         mtinfo(WM_SYS_LOGTAG, STARTUP_MSG, (int)getpid());
         syscollector_start_ptr();
     }
@@ -759,17 +767,16 @@ void* wm_sys_main(wm_sys_t* sys)
 #endif
 
     mtinfo(WM_SYS_LOGTAG, "Module finished.");
-    w_mutex_lock(&sys_stop_mutex);
-    need_shutdown_wait = false;
-    sys_main_thread_initialized = false;
-    // Safe to release resources now that the sync worker has exited.
+
+    // Safe to release resources now that the sync worker has exited. This runs on
+    // the module thread and before it returns, so whoever joins this thread is
+    // guaranteed the teardown already completed -- wm_sys_stop() does not need to
+    // wait for it a second time.
     if (syscollector_release_resources_ptr)
     {
         syscollector_release_resources_ptr();
         syscollector_release_resources_ptr = NULL;
     }
-    w_cond_signal(&sys_stop_condition);
-    w_mutex_unlock(&sys_stop_mutex);
 
     return 0;
 }
@@ -781,6 +788,15 @@ void wm_sys_destroy(wm_sys_t* data)
 
 void wm_sys_stop(__attribute__((unused))wm_sys_t* data)
 {
+    // Record the stop before anything else, including the early return below. The
+    // shutdown loop signals every module before joining any of them, so this can
+    // arrive while wm_sys_main() is still starting up -- and both Syscollector::init()
+    // and Syscollector::start() clear m_stopping, so a stop delivered in that window
+    // would be erased and the module would scan on through the shutdown, burning the
+    // shared join budget and leaving its database locked for the successor process.
+    // wm_sys_main() checks this flag before initialising and before starting the scan.
+    shutdown_process_started = 1;
+
     if (!data->flags.running)
     {
         // Already stopped
@@ -794,40 +810,22 @@ void wm_sys_stop(__attribute__((unused))wm_sys_t* data)
 
     mtinfo(WM_SYS_LOGTAG, "Stop received for Syscollector.");
 
-    if (syscollector_stop_ptr)
+    // Read the pointer once: the module thread clears syscollector_stop_ptr on its way
+    // out (see wm_sys_main), so testing the global and then calling through it can land
+    // on a NULL between the two. The worst case with a local copy is that this call
+    // arrives after the module already tore itself down, which is harmless.
+    const syscollector_stop_func stop_fn = syscollector_stop_ptr;
+
+    if (stop_fn)
     {
-        shutdown_process_started = true;
-        syscollector_stop_ptr();
+        stop_fn();
     }
 
-    w_mutex_lock(&sys_stop_mutex);
-    const bool called_from_sys_main_thread = sys_main_thread_initialized && pthread_equal(pthread_self(), sys_main_thread);
-
-    if (called_from_sys_main_thread)
-    {
-        mtdebug1(WM_SYS_LOGTAG, "Stop called from syscollector worker thread. Skipping synchronous shutdown wait.");
-    }
-
-    if (need_shutdown_wait && !called_from_sys_main_thread)
-    {
-        const time_t SHUTDOWN_WAIT_SECONDS = 10;  // max wait for the run loop to finish teardown
-        struct timespec ts;
-        clock_gettime(CLOCK_REALTIME, &ts);
-        ts.tv_sec += SHUTDOWN_WAIT_SECONDS;
-
-        while (need_shutdown_wait)
-        {
-            if (pthread_cond_timedwait(&sys_stop_condition, &sys_stop_mutex, &ts) == ETIMEDOUT)
-            {
-                mtinfo(WM_SYS_LOGTAG,
-                       "Syscollector did not confirm shutdown within %ld seconds; releasing resources and continuing.",
-                       (long)SHUTDOWN_WAIT_SECONDS);
-                break;
-            }
-        }
-    }
-
-    w_mutex_unlock(&sys_stop_mutex);
+    // Signal only. The module thread runs its own teardown (releaseResources())
+    // before returning, so the caller's join of that thread already guarantees it
+    // finished; waiting here as well only stacked a second per-module timeout on
+    // top of that guarantee and delayed the stop signal to the modules after this
+    // one in the shutdown loop.
 }
 
 cJSON* wm_sys_dump(const wm_sys_t* sys)
@@ -905,7 +903,7 @@ cJSON* wm_sys_dump(const wm_sys_t* sys)
 
 int wm_sync_message(const char* command, size_t command_len)
 {
-    if (shutdown_process_started)
+    if (is_shutdown_process_started())
     {
         mtdebug1(WM_SYS_LOGTAG, "Sync message received during shutdown, ignoring");
         return 0;

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -93,6 +93,24 @@ void *win_module_thread(void *arg)
 
     startup_gate_wait_for_ready(ctx->name[0] ? ctx->name : "wazuh-modulesd");
 
+    // The gate also releases when shutdown is requested, so getting here does not mean
+    // the agent is starting -- it may already be stopping. Starting a module then is
+    // never useful: it opens databases and runs a scan that the join below is about to
+    // interrupt anyway. Each module also refuses to start under a stop it already
+    // received (wm_sys_stop() records it before returning, SCA sets g_shutting_down,
+    // agent-info consults the injected predicate), but this check keeps the whole
+    // routine from running in the first place.
+    if (wm_shutdown_requested) {
+        mdebug1("Shutdown requested before '%s' started; skipping module start.",
+                ctx->name[0] ? ctx->name : "wazuh-modulesd");
+        os_free(ctx);
+#ifdef WIN32
+        return 0;
+#else
+        return NULL;
+#endif
+    }
+
 #ifdef WIN32
     DWORD result = ctx->routine(ctx->data);
     os_free(ctx);
@@ -111,25 +129,59 @@ void stop_wmodules()
     // handler sets this; on Windows shutdown flows through here instead.
     wm_shutdown_requested = 1;
 
-    // Generous relative to each module's own internal shutdown-wait timeout (e.g.
-    // syscollector's 10 s), so this join is the actual gate and not a race against it.
-    // Shared across every module in the loop below (not reset per module), so total
-    // time spent in stop_wmodules() is bounded regardless of how many wodles are
-    // configured -- otherwise N modules could each burn a fresh timeout and the sum
-    // could outlast the SCM's own patience (WaitToKillServiceTimeout).
+    // Two passes, mirroring the POSIX SIGTERM handler (wazuh_modules/src/main.c):
+    // signal every module first, then join every module against one shared budget.
+    //
+    // The passes must not be interleaved. A module's stop() only tells that module
+    // to wind down; some modules cannot finish winding down until a *sibling* has
+    // been told too -- agent-info's run loop, for instance, can sit in
+    // Syscollector::pause() until syscollector's stop() clears its scan/sync state.
+    // Stopping and joining one module at a time therefore deadlocked agent-info
+    // against syscollector for the length of its own timeout.
+    wmodule * cur_module;
+
+    // Shared across every module and started before the signal pass, so the budget
+    // covers everything done here and not just the joins -- otherwise N modules could
+    // each burn a fresh timeout, or a slow stop() callback could spend minutes off the
+    // clock, and either way the total could outlast the SCM's own patience
+    // (WaitToKillServiceTimeout). The stops are signalling only, but not instantaneous:
+    // syscollector's and SCA's quiesce() both wait for an in-flight flush to finish,
+    // with no timeout of their own. Each module runs its own teardown before its thread
+    // returns, so the join is what guarantees that teardown completed.
     const DWORD MODULE_JOIN_BUDGET_MS = 20000;
     const ULONGLONG budget_start = GetTickCount64();
 
-    wmodule * cur_module;
     for (cur_module = wmodules; cur_module; cur_module = cur_module->next) {
         if (cur_module->context->stop) {
             cur_module->context->stop(cur_module->data);
         }
+    }
 
+    for (cur_module = wmodules; cur_module; cur_module = cur_module->next) {
         if (cur_module->win_thread) {
+            // Never wait on our own thread. merror_exit() from a module thread routes
+            // through WinSetError() -> OssecServiceCtrlHandler() -> here, so without this
+            // the pass would wait on its own handle for the whole budget, log a timeout
+            // that never happened and leave nothing left for the modules after it. The
+            // POSIX handler skips the same way (wazuh_modules/src/main.c: thread ==
+            // pthread_self()).
+            if (GetThreadId(cur_module->win_thread) == GetCurrentThreadId()) {
+                mdebug1("Module '%s' is the thread requesting the shutdown; not joining it.",
+                        cur_module->context->name);
+                CloseHandle(cur_module->win_thread);
+                cur_module->win_thread = NULL;
+                continue;
+            }
+
             const ULONGLONG elapsed = GetTickCount64() - budget_start;
             const DWORD remaining = (elapsed < MODULE_JOIN_BUDGET_MS) ? (DWORD)(MODULE_JOIN_BUDGET_MS - elapsed) : 0;
-            const DWORD wait_result = remaining ? WaitForSingleObject(cur_module->win_thread, remaining) : WAIT_TIMEOUT;
+
+            // Always ask, even with the budget spent: a zero timeout still reports
+            // WAIT_OBJECT_0 for a thread that already finished. Asserting a timeout
+            // without looking at the handle logged the error below for modules that
+            // had shut down cleanly and were merely charged for a budget an earlier
+            // module had spent.
+            const DWORD wait_result = WaitForSingleObject(cur_module->win_thread, remaining);
 
             if (wait_result == WAIT_TIMEOUT) {
                 merror("Module '%s' worker thread did not exit within the %lu ms shutdown budget; "


### PR DESCRIPTION
## Description

On the Windows agent, `wazuh-modulesd`'s agent-info module logs `WARNING: Timeout waiting for AgentInfo run loop to exit; skipping database teardown.` on shutdown and then leaves its DBSync connection open. This was reproduced on Windows 11 against `0d85377`, with the same shape as the 2026-08-13 nightly: `Pausing syscollector module for synchronization coordination` at 08:24:19, exit signal at 08:24:23, the warning at 08:24:34 (10 s later, to the second), and the coordination only unblocking at 08:24:44 when syscollector's evaluation finished.

The root cause is an ordering deadlock between two modules. `AgentInfoImpl::stop()` waited up to 10 s for its run loop to exit, but that loop parks inside `Syscollector::pause()`, whose predicate is `(!m_scanning && !m_syncing) || m_stopping`. `stop_wmodules()` walked the module list stopping and joining one module at a time, and stopped agent-info **before** syscollector — so at the moment agent-info began its 10 s wait, syscollector's `m_stopping` was still `false` and the `m_pauseCv.notify_all()` added by PR #38050 could not arrive in time. This is the residual that PR #38050's own description flagged as "Sequencing issue (identified, not yet fixed)", so #38001 was closed with half the problem outstanding.

Reading the whole shutdown path showed the waits were redundant for two of the three modules: syscollector and SCA already run their teardown on the module thread just before it returns (`wm_sys_main` calls `releaseResources()` right after `Module finished`; `wm_sca_main` calls `wm_sca_release_and_signal()` after joining its own sync worker), so joining that thread already carries the guarantee, under one shared budget rather than a per-module timeout stacked on top of it. agent-info was the asymmetric one: `wm_agent_info_main` just runs the loop and returns, and the teardown lived in `AgentInfoImpl::stop()` on the *stopping* thread, which is exactly why only agent-info produced this warning.

The same defect exists on POSIX, where `wm_handler` gets the join right (signal all, then join all against one absolute deadline) but pass 1 still calls the same blocking callbacks sequentially, with the 30 s deadline computed *after* that loop. Since the three callbacks are shared code, this fixes both platforms; only the Windows side needed the `stop_wmodules()` restructuring on top.

This supersedes #38221, whose premise is that the blocking `stop()` callbacks need to overlap: once they are signal-only there is nothing left to overlap, so the per-module thread it proposed is no longer needed. The one item from #38221 not covered here — reporting shutdown progress to the SCM via `dwCheckPoint`/`dwWaitHint` — is covered by PR #38469 (`report_stop_progress()`), so nothing is lost when #38221 is closed as a duplicate.

**Interaction with #38428 / PR #38469, and why this PR guards against it.** Signalling every module before joining any of them makes it likelier for a stop to arrive while a module thread is still inside `startup_gate_wait_for_ready()`, and that gate *releases* rather than aborts when shutdown is requested — so the thread goes on to run its start routine during shutdown. For syscollector that is not merely wasteful: `wm_sys_stop()` returns early while `flags.running` is still `false`, and that flag is only set further down `wm_sys_main()`, so the stop is discarded outright and the module is never told again. Measured on Windows 11 with the guard removed: **8 of 16 stops issued 1-2 s after start burned the whole 20 s join budget** (`Stop-Service` took 20.0 s, against 1.47 s max with the guard), and on the enrollment-triggered restart the successor process logged `sqlite: database is locked` ten times. `win_module_thread()` therefore checks `wm_shutdown_requested` after the gate returns and skips the start.

That guard is deliberately a stopgap: PR #38469 fixes it at the gate itself — `startup_gate_wait_for_ready()` returns why it released, so every caller can abort, including `wazuh-syscheckd`, `wazuh-logcollector` and `execd`, which this guard does not cover. **Merge order agreed with that PR's author: this one goes first, and #38469's rebase removes the guard**, since both touch the same lines in `win_module_thread()` and doing it that way leaves no window where the stop can be lost between the two merges. Two things that rebase has to account for: #38469 currently keeps `stop_wmodules()` stopping and joining one module at a time, which is the sequencing deadlock this PR exists to fix, so the two-pass split has to survive (its checkpoint slicing fits inside the join pass); and its sliced wait asserts `if (!remaining) wait_result = WAIT_TIMEOUT;`, reintroducing the false timeout removed here — a zero-timeout `WaitForSingleObject` is legal and reports `WAIT_OBJECT_0` for a thread that already finished.


## Proposed Changes

- **`wm_syscollector.c`** — `wm_sys_stop()` is now signal-only: the `need_shutdown_wait` block, its condition variable and mutex, the `sys_main_thread`/`sys_main_thread_initialized` bookkeeping and the `called_from_sys_main_thread` self-stop special case are all removed. The teardown stays where it already was, in `wm_sys_main`, before the thread returns. This deletes the `Syscollector did not confirm shutdown within N seconds` message along with the wait that emitted it.
- **`wm_sca.c`** — the equivalent removal in `wm_sca_stop()`, deleting the `Timeout waiting for SCA to complete shutdown` message. `wm_sca_release_and_signal()` is renamed `wm_sca_release_resources()` since it no longer wakes anyone. `wm_sca_start()` no longer resets `g_shutting_down`, because `wm_sca_is_shutting_down()` reads only that flag and clearing it would erase a stop that already arrived. It deliberately does not release anything on that path either: `wm_sca_stop()` sets the flag before calling `quiesce()`, which reads `m_spSyncProtocol` and `m_asyncFlushController` without `m_resourcesMutex`, so releasing from the module thread there could race it — the teardown stays on the normal exit path, after `sca_start_ptr()` has returned.
- **`agent_info_impl.cpp` / `.hpp`** — `AgentInfoImpl::stop()` becomes signal-only. A new `releaseResources()` performs the teardown (DBSync connection, then sync protocol, each under its existing mutex) and is idempotent so the destructor can also call it. `start()` no longer clears the stop, and it consults `isShutdownInProgress()` rather than `m_stopped` alone — `agent_info_stop()` null-checks the instance, so a stop arriving before the object exists never reaches `stop()` at all, and the injected global predicate is the only way to observe it. The run loop and its interval wait use the same predicate, which matters because callers supply no `shouldContinue` and it is therefore the loop's only exit condition. `m_runLoopActive`, `m_shutdownMutex` and `m_shutdownCv` are gone.
- **`wm_agent_info.c`, `agent_info.cpp`, `agent_info.h`** — new `wm_agent_info_release()` invoked on every exit path of the module thread, including the early `return` during the handshake wait. That path matters because `agent_info_task_registry_init()` may already have constructed the instance and opened `agent_info.db` before the wait, so returning without it would leave the database open until process teardown — i.e. past the point where the replacement agent starts (see #38069, #38372). It goes through a new `agent_info_release_resources()` export rather than the existing `agent_info_cleanup()`: cleanup resets the global instance with no lock, while `agent_info_parse_response()` (sync dispatcher thread) and `agent_info_task_check_and_record()` (`/control` thread) only null-check it, so destroying the instance from the module thread mid-shutdown would be a check-then-use use-after-free. Releasing the resources instead keeps the instance alive and does the teardown under the mutexes those callers take.
- **`win_utils.c`** — `stop_wmodules()` is split into two passes: signal every module, then join every module against one shared budget, mirroring the POSIX SIGTERM handler. The passes must not be interleaved, since a module can only finish winding down after a sibling has also been told to.
- **`win_utils.c`** — `win_module_thread()` does not start its module when `wm_shutdown_requested` is already set on return from `startup_gate_wait_for_ready()`. See the interaction with #38428 in the Description for the measurement that justifies it and for why it is a stopgap.
- **`wm_syscollector.c`** — `wm_sys_stop()` now records the stop before its `!flags.running` early return, and reads `syscollector_stop_ptr` into a local before calling through it (the module thread clears that global on its way out, so testing the global and then calling it could land on a NULL). `wm_sys_main()` checks the recorded stop once, **before** `syscollector_init_ptr()`: both `Syscollector::init()` and `Syscollector::start()` clear `m_stopping`, so a stop that arrived before this thread got there used to be erased, and the module would scan on through the shutdown, burn the shared join budget and leave its database locked for the successor. The check is before initialisation on purpose — nothing is open on that path, so the teardown has nothing to release and cannot race `quiesce()`. See the hazard note below for the window that stays open and why closing it does not belong here.
- **`win_utils.c`** — the shared budget now starts before the signal pass, so it covers everything `stop_wmodules()` does rather than the joins alone. The stops only signal, but they are not instantaneous: syscollector's and SCA's `quiesce()` both wait for an in-flight flush with no timeout of their own, and that time was previously off the clock, which left the total unbounded against the SCM's `WaitToKillServiceTimeout`.
- **`win_utils.c`** — the join pass skips the calling thread (`GetThreadId(handle) == GetCurrentThreadId()`), as the POSIX handler does with `pthread_self()`. `merror_exit()` from a module thread reaches `stop_wmodules()` through `WinSetError()`, so without this the pass waited on its own handle for the whole budget, logged a timeout that never happened, and left nothing for the modules after it.
- **`win_utils.c`** — the join no longer reports a timeout without checking the thread. `remaining ? WaitForSingleObject(...) : WAIT_TIMEOUT` asserted a timeout blindly once the shared budget was spent, so the error was logged for modules that had already exited cleanly; a zero timeout is legal and returns `WAIT_OBJECT_0` for a finished thread.

One pre-existing hazard was noticed while doing this and deliberately left alone, because fixing it properly means changing SCA's teardown locking and PR #38469 already modifies `sca_impl.cpp`. `quiesce()` reads `m_spSyncProtocol` and `m_asyncFlushController` **without** `m_resourcesMutex`, while `releaseResources()` moves and resets them under the exclusive lock — so the two running concurrently can dereference a destroyed object. Two paths in `wm_sca.c` reach `wm_sca_release_resources()` from the module thread before `sca_start_ptr()` has run, while `wm_sca_stop()` may be inside `quiesce()`: the agentd doclimits wait (`wm_sca.c:599`, reached whenever the agent is disconnected and a stop arrives, so the likelier of the two) and the `Cannot initialize SCA message queue` path (`wm_sca.c:641`). Syscollector has the same shape — its `releaseResources()` resets `m_spSyncProtocol`/`m_spSyncProtocolVD`, which its own `quiesce()` reads unlocked — on the ordinary teardown path. Two more items belong to that same issue rather than to this PR. SCA never refuses to start under a stop it already received: `SecurityConfigurationAssessment::Run()` sets `m_keepRunning = true` unconditionally and then calls `m_spSyncProtocol->reset()`, actively undoing the `stop()` `quiesce()` had just issued, so a stop landing between `wm_sca.c:594` and `sca_start_ptr()` is erased and the thread parks in its interval wait. And on the syscollector side a stop arriving *during* `init()` is still lost, because the only safe place to refuse is before anything is opened — skipping the scan after initialisation would send the module thread into `releaseResources()` precisely while `quiesce()` is running, with the databases open. None of this is introduced here, but making the stops signal-only lets the module thread reach its teardown sooner, so the windows are wider than before. All of it needs `quiesce()` and `releaseResources()` serialized first, which is a change to SCA's and syscollector's own teardown locking.

### Results and Evidence

Unit tests were built for the `winagent` target and run under wine:

```
agent_info_dbsync_test.exe   ->  [  PASSED  ] 12 tests.
agent_info_basic_test.exe    ->  [  PASSED  ] 14 tests.
```

All modified files compile clean with the MinGW cross-compiler used by the `winagent` build. `wm_agent_info.c` emits six pre-existing `-Wint-conversion` warnings for `return NULL` in the `DWORD WINAPI` variant; an A/B compile confirms the same six exist without this change, only at shifted line numbers.

#### The reported scenario

Before, on `0d85377` — the build the issue was filed against — with a metadata delta forced on `queue\agent_info\db\agent_info.db` so agent-info enters coordination, a throttled syscollector wodle so the first evaluation outlasts the 10 s wait, and `Restart-Service` once `Pausing syscollector module for synchronization coordination` appears:

```
08:24:19  agent-info:   INFO: Pausing syscollector module for synchronization coordination
08:24:23  wazuh-agent:  INFO: Received exit signal. Starting exit process.
08:24:34  agent-info:   WARNING: Timeout waiting for AgentInfo run loop to exit; skipping database teardown.
08:24:34  agent-info:   INFO: AgentInfo module stopped.
08:24:43  wazuh-agent:  ERROR: Module 'agent-info' worker thread did not exit within the 20000 ms shutdown budget
08:24:44  wazuh-agent:  ERROR: Module 'sca' worker thread did not exit within the 20000 ms shutdown budget
08:24:44  wazuh-agent:  ERROR: Module 'syscollector' worker thread did not exit within the 20000 ms shutdown budget
08:24:44  agent-info:   INFO: Agent stopping, aborting module coordination during pause phase
08:24:44  syscollector: INFO: Evaluation finished.
```

After, on `08d0a52`, same host and same scenario:

```
14:26:26  agent-info:   INFO: Pausing syscollector module for synchronization coordination
14:26:26  wazuh-agent:  INFO: Received exit signal. Starting exit process.
14:26:26  agent-info:   INFO: AgentInfo module stopped.
14:26:26  sca:          INFO: SCA module stopped.
14:26:26  syscollector: INFO: Stop received for Syscollector.
14:26:26  agent-info:   INFO: Agent stopping, aborting query to syscollector
14:26:26  agent-info:   INFO: AgentInfo module loop ended.
14:26:27  syscollector: INFO: Evaluation finished.
14:26:27  syscollector: INFO: Module finished.
```

Exit signal to `Exit completed successfully`: **1 s**, against ~21 s before. `Stop-Service` returned in 0.60 s and the process was gone 0.87 s after it was asked to stop. Zero ERROR and zero WARNING in the window. Two lines are worth reading: `AgentInfo module stopped.` now lands in the *same second* as the exit signal instead of eleven seconds later, which is the signal-only `stop()` doing its job; and `Module finished.` is present for syscollector, so its teardown ran and the DBSync connection was released before the join returned — the guarantee that used to depend on the deleted wait.

#### Regression matrix on Windows 11

Beyond the reported scenario, three suites were run against the same host to look for regressions elsewhere in the shutdown path. They replicate the assertions QA automation makes in `test_agents_install/test_04_restart.py` and `test_05_stop.py` (service state, PID change, no surviving process, and its zero-tolerance ERROR/WARNING log gate), plus 20 stop/start cycles from steady state and 16 stops issued 0/1/2/4 s after start.

| suite | result on `08d0a52` |
|---|---|
| QA parity — `test_04_restart` | PASS: service `Running`, PID changed, 0 errors, 0 warnings |
| QA parity — `test_05_stop` | PASS: service `Stopped`, no surviving process, 0 errors, 0 warnings |
| 20 cycles from steady state | shutdown 2 s max / 1.16 s mean; `Stop-Service` 1.25 s max; process gone 1.51 s max; 0 budget ERRORs; 0 `database is locked`; none of the three deleted messages; handles 637 → 645 |
| 16 stops during startup | 0 budget ERRORs; `Stop-Service` 1.47 s max |
| reported scenario | PASS (trace above) |
| `wazuh-agent` crash in the Windows Application log | none |

Two measurement details, in case anyone reproduces this. The CI package is not production-signed, so the agent emits 45 `Trust verification of a module failed` / `is not signed` warnings per start; they are counted separately and excluded, and do not occur with the signed packages QA uses. And the log gate must run at the default debug level: with `windows.debug` raised, DEBUG lines whose *text* contains "error" or "Warning" (SCA rules over `Windows Error Reporting`, `PasswordExpiryWarning`, `WarningLevel`) match the gate's regexes and produce false positives.

#### The same suites on four Windows versions

The three suites were then run on four systems, with the package each one had at the time. PowerShell 4.0 on 2012 R2 required the harness to avoid anything newer, and two of the hosts had no OpenSSH, so they were driven over WinRM.

| measure | Windows 11 | Server 2012 R2 | Server 2022 | Windows 10 |
|---|---|---|---|---|
| package | `08d0a52` | `08d0a52` | `4622806` | `659c0ea` |
| QA `test_04` / `test_05` | PASS / PASS | PASS / PASS | PASS / PASS | FAIL / FAIL (see below) |
| shutdown, max / mean (20 cycles) | 2 s / 1.16 s | 1 s / 1 s | 2 s / 1 s | 1 s / 0.89 s |
| `Stop-Service`, max | 1.25 s | 1.23 s | 1.91 s | 1.25 s |
| budget ERRORs, 20 cycles | 0 | 0 | 0 | 0 |
| budget ERRORs, 16 stops during startup | **0** | **0** | **0** | **0** |
| `database is locked` | 0 | 0 | 0 | 0 |
| any of the three deleted messages | 0 | 0 | 0 | 0 |
| handles, first → last cycle | 637 → 645 | 535 → 546 | 619 → 617 | 516 → 517 |
| reported scenario | **PASS** (1 s) | not exercised | **PASS** (2 s) | not exercised |
| `wazuh-agent` crash in the Application log | none | none | none | none |

Windows 10's `FAIL` is a single WARNING, not a shutdown defect: every assertion the QA tests make passes there — service state, PID change, no surviving process, zero errors, shutdown within the same second — and what trips the zero-tolerance gate is `wazuh-modulesd:sca: WARNING: Failed to clear SCA index before initial synchronization`. That is a manager-side failure: the agent's own log says `SCA synchronization deferred: Failed to communicate with the manager`, the session having taken ~4 min 45 s before giving up. The same `/stateful` session latency stopped the reported scenario from being exercised on 2012 R2 and Windows 10 (agent-info logs `Deferring coordination until FIM first sync completes` and never reaches the pause), and on Windows 10 it was confirmed to be the environment rather than the setup: the metadata delta was applied and there were still 18 deferrals in 600 s, with the manager healthy on resources and processing other agents' sessions. It is unrelated to this change and deserves its own issue.

Signature noise takes two forms depending on the host and is excluded from the gate in both: where the DigiCert CA is present the agent emits 45 `not signed` warnings per start, and where it is not — the Windows 10 image — it emits 44 `The dynamic signature validation is not available` instead. Neither occurs with the signed packages QA uses.

#### What the startup-gate guard is worth, measured

The same 16-stop suite was run on a build of this branch with the guard removed, which is what justifies keeping it until PR #38469 lands:

| 16 stops during startup | with guard (`08d0a52`) | without guard |
|---|---|---|
| budget ERRORs | **0** | **8** (4/4 at 1 s, 4/4 at 2 s) |
| `Stop-Service`, max | **1.47 s** | **20.02 s** |
| process gone, max | 30.62 s | 50.22 s |

On the same build without the guard, the enrollment-triggered restart also had syscollector start *after* the exit signal, blow the join budget, and leave the successor process logging `sqlite: database is locked` ten times.

One pre-existing behaviour, unrelated to this change and present in every build measured: when the agent is stopped 1-4 s after starting, `wazuh-agent.exe` sometimes outlives the SCM's `Stopped` by ~30.5 s (6 of 16 stops here, 5 of 16 on an earlier build of this branch, 1 of 4 on an ad-hoc run). Sampling every 2 s shows processor time and `ossec.log` frozen, so the process is blocked rather than working, and `Exit completed successfully` is already written. No 30 s constant exists in `src/win32`, `src/shared` or the agent's exit path; it deserves its own issue.


### Artifacts Affected

- `wazuh-agent.exe` (Windows agent) — contains `stop_wmodules()`, the module thread wrapper and the `wm_*` module wrappers.
- `wazuh-modulesd` (Linux/macOS agent and manager) — `wm_syscollector.c`, `wm_sca.c` and `wm_agent_info.c` are shared code, so the removal of the blocking waits applies to POSIX too.
- `agent_info.dll` / `libagent_info` — `AgentInfoImpl`.

No changes to `wazuh-syscheckd`, `wazuh-agentd`, `wazuh-logcollector` or any manager-only daemon.

### Configuration Changes

None. No option is added, removed or reinterpreted.

### Documentation Updates

None required for user-facing documentation: no configuration or behaviour visible to the user changes, beyond three warning messages that no longer occur.

Note that two of the deleted messages are tracked in the known-messages epic #37780 and in #38065; they can be dropped from that list once this is merged.

### Tests Introduced

No new test binaries. Existing agent-info unit tests were updated to the new contract:

- `AgentInfoImplTest.StopWaitsForRunLoopToExit` asserted the behaviour this change removes (`EXPECT_GE(elapsed, HOLD / 2)`, i.e. that `stop()` blocks). It is rewritten as `StopSignalsWithoutWaitingAndReleaseIsSeparate`, which asserts the new contract instead: `stop()` returns promptly while the run loop is mid-iteration, the loop then exits, and `releaseResources()` actually closes the DBSync connection.
- `AgentInfoImplTest.ParseResponseBufferAfterStopIsSafe` now calls `stop()` followed by `releaseResources()`, matching the order the module thread uses.
- Five `...FailsClosedWithoutDBSync` cases in `agent_info_dbsync_test.cpp` and `agent_info_vd_offset_test.cpp` used `stop()` as a shortcut to drop the DBSync connection; they now call `releaseResources()`, which is what performs that teardown.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues — merge order agreed with #38469 (this PR first, its rebase drops the startup-gate guard).