### PR TITLE
Close idle pre-authentication connections in the cluster server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 #### Fixed
 
 - Bounded the agent control message copy to the source string length in `wazuh-remoted`. ([#38427](https://github.com/wazuh/wazuh/pull/38427))
+- Fixed the cluster server keeping pre-authentication connections open indefinitely by adding a handshake deadline and a global connection limit. ([#38449](https://github.com/wazuh/wazuh/pull/38449))
 
 ### Agent
 

--- a/framework/wazuh/core/cluster/server.py
+++ b/framework/wazuh/core/cluster/server.py
@@ -23,6 +23,9 @@ from wazuh.core.cluster.utils import ClusterFilter, context_tag
 # Maximum simultaneous cluster TCP connections accepted from a single source IP.
 MAX_CONNECTIONS_PER_IP = 10
 
+# Maximum simultaneous cluster TCP connections accepted from all source IPs.
+MAX_TOTAL_CONNECTIONS = 1024
+
 
 class AbstractServerHandler(c_common.Handler):
     """
@@ -62,6 +65,8 @@ class AbstractServerHandler(c_common.Handler):
         self.broadcast_queue = asyncio.Queue()
         # Tracks whether this handler was counted in server.connection_counts.
         self._counted_connection = False
+        # Handle for the handshake-completion deadline timer.
+        self._handshake_deadline = None
 
     def to_dict(self) -> Dict:
         """Get basic info from AbstractServerHandler instance.
@@ -88,10 +93,37 @@ class AbstractServerHandler(c_common.Handler):
             self.logger.warning(f"Too many connections from {self.ip} ({count}), rejecting.")
             transport.close()
             return
+        if self.server.total_connections >= MAX_TOTAL_CONNECTIONS:
+            self.logger.warning(f"Too many total connections ({self.server.total_connections}), "
+                                f"rejecting connection from {self.ip}.")
+            transport.close()
+            return
         self.server.connection_counts[self.ip] = count + 1
+        self.server.total_connections += 1
         self._counted_connection = True
         self.logger.info(f'Connection from {peername}')
         self.transport = transport
+        self._start_handshake_deadline()
+
+    def _start_handshake_deadline(self) -> None:
+        """Arm a timer that closes this connection if the handshake is never completed."""
+        self._cancel_handshake_deadline()
+        self._handshake_deadline = self.loop.call_later(c_common.PRE_AUTH_PAYLOAD_TIMEOUT,
+                                                        self._close_on_handshake_deadline)
+
+    def _cancel_handshake_deadline(self) -> None:
+        """Cancel an armed handshake deadline, if any."""
+        if self._handshake_deadline is not None:
+            self._handshake_deadline.cancel()
+            self._handshake_deadline = None
+
+    def _close_on_handshake_deadline(self) -> None:
+        """Close the transport when the handshake is not completed within the deadline."""
+        self._handshake_deadline = None
+        if self.name is None:
+            self.logger.warning("Closing connection: handshake not completed within deadline.")
+            if self.transport is not None:
+                self.transport.close()
 
     def process_request(self, command: bytes, data: bytes) -> Tuple[bytes, bytes]:
         """Define commands for servers.
@@ -159,6 +191,7 @@ class AbstractServerHandler(c_common.Handler):
             raise exception.WazuhClusterError(3029)
         else:
             self.name = node_name
+            self._cancel_handshake_deadline()
             self.server.clients[self.name] = self
             self.tag = f'{self.tag} {self.name}'
             context_tag.set(self.tag)
@@ -196,12 +229,14 @@ class AbstractServerHandler(c_common.Handler):
             In case the connection was lost due to an exception, it will be contained in this variable.
         """
         self._cancel_payload_deadline()
+        self._cancel_handshake_deadline()
         if self._counted_connection:
             count = self.server.connection_counts.get(self.ip, 0)
             if count <= 1:
                 self.server.connection_counts.pop(self.ip, None)
             else:
                 self.server.connection_counts[self.ip] = count - 1
+            self.server.total_connections = max(0, self.server.total_connections - 1)
         if self.name:
             if exc is None:
                 self.logger.debug(f"Disconnected {self.name}.")
@@ -302,6 +337,8 @@ class AbstractServer:
         self.broadcast_results = {}
         # Per-source-IP connection counts; bounded by MAX_CONNECTIONS_PER_IP.
         self.connection_counts = {}
+        # Total accepted connections; bounded by MAX_TOTAL_CONNECTIONS.
+        self.total_connections = 0
 
     def broadcast(self, f, *args, **kwargs):
         """Add a function to the broadcast_queue of each server handler.

--- a/framework/wazuh/core/cluster/tests/test_server.py
+++ b/framework/wazuh/core/cluster/tests/test_server.py
@@ -67,6 +67,7 @@ def test_AbstractServerHandler_connection_made(event_loop):
     class ServerMock:
         def __init__(self):
             self.connection_counts = {}
+            self.total_connections = 0
 
     def get_extra_info(self, name):
         return ["peername", "mock"]
@@ -85,6 +86,7 @@ def test_AbstractServerHandler_connection_made(event_loop):
                 assert abstract_server_handler.transport == transport
                 assert abstract_server_handler._counted_connection is True
                 assert server_mock.connection_counts == {"peername": 1}
+                assert server_mock.total_connections == 1
                 mock_logger.assert_called_once_with("Connection from ['peername', 'mock']")
 
     # Verify that a second handler from the same IP up to the limit is accepted,
@@ -103,6 +105,105 @@ def test_AbstractServerHandler_connection_made(event_loop):
         assert rejected_handler._counted_connection is False
         # Count must not have been incremented for the rejected connection.
         assert server_mock2.connection_counts["1.2.3.4"] == MAX_CONNECTIONS_PER_IP
+        assert server_mock2.total_connections == 0
+
+
+def test_AbstractServerHandler_connection_made_total_limit(event_loop):
+    """Check that a connection is rejected when the global connection limit is reached."""
+
+    class ServerMock:
+        def __init__(self):
+            self.connection_counts = {}
+            self.total_connections = MAX_TOTAL_CONNECTIONS
+
+    logger = Logger("test_connection_made_total_limit")
+    server_mock = ServerMock()
+    with patch("logging.getLogger", return_value=logger):
+        handler = AbstractServerHandler(server=server_mock, loop=event_loop, fernet_key=fernet_key,
+                                        cluster_items={"test": "server"})
+        transport = Mock()
+        transport.get_extra_info = lambda name: ["5.6.7.8", 9999]
+        handler.connection_made(transport=transport)
+
+        transport.close.assert_called_once()
+        assert handler._counted_connection is False
+        # A source IP under its own limit must not be counted when the global limit is reached.
+        assert server_mock.connection_counts == {}
+        assert server_mock.total_connections == MAX_TOTAL_CONNECTIONS
+        assert handler._handshake_deadline is None
+
+
+def test_AbstractServerHandler_handshake_deadline(event_loop):
+    """Check that a connection that never completes the handshake is closed by the deadline."""
+
+    class ServerMock:
+        def __init__(self):
+            self.connection_counts = {}
+            self.total_connections = 0
+            self.clients = {}
+            self.configuration = {"node_name": "master"}
+
+    logger = Logger("test_handshake_deadline")
+    with patch("logging.getLogger", return_value=logger):
+        handler = AbstractServerHandler(server=ServerMock(), loop=event_loop, fernet_key=fernet_key,
+                                        cluster_items={"test": "server"})
+        assert handler._handshake_deadline is None
+
+        handler.loop = Mock()
+        transport = Mock()
+        transport.get_extra_info = lambda name: ["1.2.3.4", 9999]
+        handler.connection_made(transport=transport)
+
+        # The deadline is armed as soon as the connection is accepted.
+        handler.loop.call_later.assert_called_once_with(c_common.PRE_AUTH_PAYLOAD_TIMEOUT,
+                                                        handler._close_on_handshake_deadline)
+        assert handler._handshake_deadline is not None
+
+        # A connection with no completed handshake is closed when the deadline expires.
+        handler._close_on_handshake_deadline()
+        transport.close.assert_called_once()
+        assert handler._handshake_deadline is None
+
+        # A connection that completed the handshake is not closed.
+        handler.name = "worker1"
+        transport.close.reset_mock()
+        handler._close_on_handshake_deadline()
+        transport.close.assert_not_called()
+
+
+def test_AbstractServerHandler_handshake_deadline_cancelled(event_loop):
+    """Check that the handshake deadline is cancelled after 'hello' and when the connection is lost."""
+
+    class ServerMock:
+        def __init__(self):
+            self.connection_counts = {"1.2.3.4": 1}
+            self.total_connections = 1
+            self.clients = {}
+            self.configuration = {"node_name": "master"}
+
+    logger = Logger("test_handshake_deadline_cancelled")
+    with patch("logging.getLogger", return_value=logger):
+        handler = AbstractServerHandler(server=ServerMock(), loop=event_loop, fernet_key=fernet_key,
+                                        cluster_items={"test": "server"})
+        handler.loop = Mock()
+        handler.broadcast_reader = Mock()
+        handler.ip = "1.2.3.4"
+        handler._counted_connection = True
+        deadline = Mock()
+        handler._handshake_deadline = deadline
+
+        # A completed handshake disarms the deadline.
+        handler.hello(b"worker1")
+        deadline.cancel.assert_called_once()
+        assert handler._handshake_deadline is None
+
+        # A lost connection disarms the deadline and releases the global slot.
+        handler._handshake_deadline = deadline = Mock()
+        handler.connection_lost(exc=None)
+        deadline.cancel.assert_called_once()
+        assert handler._handshake_deadline is None
+        assert handler.server.total_connections == 0
+        assert "1.2.3.4" not in handler.server.connection_counts
 
 
 @pytest.mark.asyncio
@@ -242,6 +343,7 @@ async def test_AbstractServerHandler_connection_lost(event_loop):
             self.clients = {}
             self.configuration = {"node_name": "elif_test"}
             self.connection_counts = {"1.2.3.4": 3}
+            self.total_connections = 3
 
     with patch("logging.getLogger", return_value=logger):
         counted_handler = AbstractServerHandler(server=ServerMockCounts(), loop=event_loop,
@@ -251,12 +353,14 @@ async def test_AbstractServerHandler_connection_lost(event_loop):
         counted_handler._counted_connection = True
         counted_handler.connection_lost(exc=None)
         assert counted_handler.server.connection_counts["1.2.3.4"] == 2
+        assert counted_handler.server.total_connections == 2
 
         # When count reaches 1, the key is removed entirely.
         counted_handler.server.connection_counts["1.2.3.4"] = 1
         counted_handler._counted_connection = True
         counted_handler.connection_lost(exc=None)
         assert "1.2.3.4" not in counted_handler.server.connection_counts
+        assert counted_handler.server.total_connections == 1
 
 
 @pytest.mark.asyncio
@@ -326,6 +430,7 @@ def test_AbstractServer_init(AbstractServerHandler_mock, keepalive_mock):
         assert abstract_server.logger == logger
         assert abstract_server.broadcast_results == {}
         assert abstract_server.connection_counts == {}
+        assert abstract_server.total_connections == 0
 
 
 @patch("asyncio.get_running_loop", new=Mock())


### PR DESCRIPTION
## Description
The cluster server accepted TCP connections on the cluster port and never closed those that
did not complete the `hello` handshake: the only reaper, `check_clients_keepalive()`, iterates
the post-handshake `clients` registry, and the existing pre-authentication deadline is armed
only after a partial message header is read, so a connection sending zero bytes stayed open
indefinitely. This change arms a handshake deadline as soon as a connection is accepted and
adds a global limit on simultaneous connections, complementing the existing per-source-IP cap.

Closes https://github.com/wazuh/wazuh/issues/38448

## Proposed Changes
- `framework/wazuh/core/cluster/server.py`:
  - New `MAX_TOTAL_CONNECTIONS = 1024` constant and `AbstractServer.total_connections` counter,
    incremented in `connection_made()` and decremented in `connection_lost()` under the existing
    `_counted_connection` guard; connections beyond the cap are rejected with a warning.
  - `connection_made()` arms a handshake deadline (`PRE_AUTH_PAYLOAD_TIMEOUT`, 30 s) that closes
    the transport if the handshake has not completed when it fires.
  - The deadline is cancelled in the success branch of `hello()` and in `connection_lost()`.
- `framework/wazuh/core/cluster/tests/test_server.py`: tests for the new behaviour and updated
  server mocks for the global counter.

### Results and Evidence
- Unit tests: `453 passed` for `framework/wazuh/core/cluster/tests/`. The six tests covering the
  new behaviour fail against the unpatched `server.py` and pass with it.
- Functional check against a real `AbstractServer` instance on `127.0.0.1`, with the deadline
  shortened to 3 s and the cap to 25 for the test: 60 connection attempts from 6 source
  addresses were admitted up to 25 (`Too many total connections (25), rejecting connection
  from ...`), and every idle connection was closed once the deadline expired
  (`Closing connection: handshake not completed within deadline.`), leaving
  `total_connections: 0` and `connection_counts: {}`.
- Server build with `make TARGET=server`: successful.

### Artifacts Affected
`wazuh-manager` — the `wazuh-clusterd` daemon (master node cluster server).

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
In `framework/wazuh/core/cluster/tests/test_server.py`:
- `test_AbstractServerHandler_connection_made_total_limit`
- `test_AbstractServerHandler_handshake_deadline`
- `test_AbstractServerHandler_handshake_deadline_cancelled`
- Extended: `test_AbstractServerHandler_connection_made`,
  `test_AbstractServerHandler_connection_lost`, `test_AbstractServer_init`

## Credits
Found and reported by @akhatkulov.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
