### PR TITLE
Allow skipping the manager connectivity check during WPK upgrade for testing

### DIFF
--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -112,12 +112,14 @@ fi
 
 echo "$(date +"%Y/%m/%d %H:%M:%S") - Checking connectivity to ${SERVER_ADDRESS}:${SERVER_PORT}." >> ./logs/upgrade.log
 
-if ! probe_server "${SERVER_ADDRESS}" "${SERVER_PORT}"; then
+if [ "${WAZUH_UPGRADE_TEST_SKIP_MANAGER_CHECK}" = "1" ]; then
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Manager connectivity check skipped (test mode)." >> ./logs/upgrade.log
+elif ! probe_server "${SERVER_ADDRESS}" "${SERVER_PORT}"; then
     echo "$(date +"%Y/%m/%d %H:%M:%S") - Upgrade failed. The manager is not reachable at ${SERVER_ADDRESS}:${SERVER_PORT}, interrupting upgrade." >> ./logs/upgrade.log
     abort_upgrade "2"
+else
+    echo "$(date +"%Y/%m/%d %H:%M:%S") - Manager reachable at ${SERVER_ADDRESS}:${SERVER_PORT}." >> ./logs/upgrade.log
 fi
-
-echo "$(date +"%Y/%m/%d %H:%M:%S") - Manager reachable at ${SERVER_ADDRESS}:${SERVER_PORT}." >> ./logs/upgrade.log
 
 if [[ "$OS" == "Darwin" ]]; then
     installer -pkg ./var/upgrade/wazuh-agent* -target / >> ./logs/upgrade.log 2>&1

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # Copyright (C) 2015, Wazuh Inc.
 
+# Testing-only flag to bypass the manager reachability check (used by WPK
+# smoke tests that upgrade without a real manager available).
+if [ "$1" = "--skip-manager-check" ]; then
+    export WAZUH_UPGRADE_TEST_SKIP_MANAGER_CHECK=1
+fi
+
 # validate OS, linux or macos
 if [ "X$(uname)" = "XLinux" ] ; then
     # Get Wazuh installation path


### PR DESCRIPTION
## Description

This PR adds a testing-only flag to `upgrade.sh` / `pkg_installer.sh` that lets the WPK upgrade smoke tests bypass the pre-upgrade manager connectivity check, without changing the real upgrade behavior for actual agents.

**Proposed Release:** 5.0.0
**Issue:** wazuh/wazuh-agent-packages#932
**Internal Reference:** N/A

## Proposed Changes

- Updated `upgrade.sh`: accepts an optional `--skip-manager-check` argument that exports `WAZUH_UPGRADE_TEST_SKIP_MANAGER_CHECK=1` before backgrounding `pkg_installer.sh`.
- Updated `src/init/pkg_installer.sh`: skips the `probe_server` manager reachability check when that variable is set to `1`, logging "Manager connectivity check skipped (test mode)" instead. Default upgrade path (no flag) is unchanged.

### Results and Evidence

Validated on a real VM (AlmaLinux 9, VirtualBox), reproducing wazuh/wazuh-agent-packages#932 end to end: installed a real published `wazuh-agent-4.14.7-1.x86_64.rpm` with `WAZUH_MANAGER=1.1.1.1` (unreachable on purpose, same as the smoke test), then ran the real `upgrade.sh` / `pkg_installer.sh` targeting a real `wazuh-agent-5.0.0-1.x86_64.rpm` build.

Before the fix (unpatched, no flag):

```bash
$ ./var/upgrade/upgrade.sh
$ cat logs/upgrade.log
2026/08/19 07:04:51 - Upgrade started.
2026/08/19 07:04:51 - Checking execution path.
2026/08/19 07:04:51 - Checking connectivity to 1.1.1.1:1517.
2026/08/19 07:04:56 - Upgrade failed. The manager is not reachable at 1.1.1.1:1517, interrupting upgrade.
$ ./bin/wazuh-control info | grep WAZUH_VERSION
WAZUH_VERSION="v4.14.7"
```

After the fix (patched, with the flag):

```bash
$ ./var/upgrade/upgrade.sh --skip-manager-check
$ cat logs/upgrade.log
2026/08/19 07:06:07 - Upgrade started.
2026/08/19 07:06:07 - Checking execution path.
2026/08/19 07:06:07 - Checking connectivity to 1.1.1.1:1517.
2026/08/19 07:06:07 - Manager connectivity check skipped (test mode).
2026/08/19 07:06:33 - Installation result = 0
$ ./bin/wazuh-control info | grep WAZUH_VERSION
WAZUH_VERSION="v5.0.0"
```

### Artifacts Affected

- `upgrade.sh`
- `src/init/pkg_installer.sh`

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Manual validation on a real VM.
- **Details:** Reproduced the real upgrade failure and verified the fix end to end (real rpm packages 4.14.7 -> 5.0.0) on a real AlmaLinux 9 VM. Full evidence in wazuh/wazuh-agent-packages#932.

## Review Checklist

**Manual tests with their corresponding evidence:**

- Compilation without warnings on every supported platform

  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X

- [ ] Log syntax and correct language review

- Memory tests for Linux

  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

**General Checklist:**

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues