### PR TITLE
Fix workflow syntax and S3 upload call in VD Scanner tools Delivery

### DIFF
--- a/.github/workflows/5_builderprecompiled_vdscanner-testtools.yml
+++ b/.github/workflows/5_builderprecompiled_vdscanner-testtools.yml
@@ -7,7 +7,7 @@ on:
       - "src/wazuh_modules/vulnerability_scanner/src/**"
       - "src/wazuh_modules/vulnerability_scanner/include/**"
       - "src/wazuh_modules/vulnerability_scanner/qa/**"
-      - "src/wazuh_modules/inventory_sync/**"
+      - "src/wazuh_modules/inventory_sync_server/**"
       - ".github/workflows/5_builderprecompiled_vdscanner-testtools.yml"
   workflow_dispatch:
 
@@ -48,10 +48,10 @@ jobs:
       - name: Build external dependencies
         uses: ./.github/actions/build_external_deps
 
-      - name: Build inventory_sync testtool
+      - name: Build inventory_sync_server testtool
         uses: ./.github/actions/build_target_cpp
         with:
-          target: "inventory_sync_testtool"
+          target: "inventory_sync_server_testtool"
           test: "false"
           asan: "false"
 
@@ -61,13 +61,12 @@ jobs:
           mkdir -p ${TOOLS_STAGING}/scanner
 
           # Copy binaries
-          cp ${{ env.BUILD_DIR }}/bin/inventory_sync_testtool ${TOOLS_STAGING}/scanner/
+          cp ${{ env.BUILD_DIR }}/bin/inventory_sync_server_testtool ${TOOLS_STAGING}/scanner/
 
           # Copy shared libraries from build/lib
           for lib in \
-            libinventory_sync.so \
+            libinventory_sync_server.so \
             libvulnerability_scanner.so \
-            librouter.so \
             libindexer_connector.so \
             libwazuhext.so \
             libcontent_manager.so \

--- a/.github/workflows/5_builderprecompiled_vdscanner-testtools.yml
+++ b/.github/workflows/5_builderprecompiled_vdscanner-testtools.yml
@@ -11,15 +11,13 @@ on:
       - ".github/workflows/5_builderprecompiled_vdscanner-testtools.yml"
   workflow_dispatch:
 
-inputs:
-  aws_region:
-    description: 'AWS region to upload the artifact'
-    required: true
-    default: 'us-east-1'
-
 # Ensures only one instance of this workflow is running per PR
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  id-token: write
+  contents: read
 
 env:
   BUILD_DIR: ${{ github.workspace }}/src/build
@@ -108,10 +106,12 @@ jobs:
 
       # Upload vdscanner tools
       - name: Upload vdscanner tools
-        if: ${{ success() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+        if: ${{ success() && github.event_name == 'workflow_dispatch' }}
         uses: ./.github/actions/upload_s3_artifact
         with:
-          aws_region: ${{ inputs.aws_region }}
+          aws_region: ${{ secrets.CI_AWS_REGION }}
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: ${{ env.TOOLS_FILE_NAME }}
           path: ${{ env.TOOLS_FILE_NAME }}.tar.xz
 

--- a/.github/workflows/5_builderprecompiled_vdscanner-testtools.yml
+++ b/.github/workflows/5_builderprecompiled_vdscanner-testtools.yml
@@ -1,5 +1,15 @@
 name: 5.X - VD Scanner tools Delivery
 on:
+  push:
+    branches:
+      - 5.0.0
+    paths:
+      - "src/wazuh_modules/vulnerability_scanner/testtool/**"
+      - "src/wazuh_modules/vulnerability_scanner/src/**"
+      - "src/wazuh_modules/vulnerability_scanner/include/**"
+      - "src/wazuh_modules/vulnerability_scanner/qa/**"
+      - "src/wazuh_modules/inventory_sync_server/**"
+      - ".github/workflows/5_builderprecompiled_vdscanner-testtools.yml"
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
     paths:
@@ -105,7 +115,7 @@ jobs:
 
       # Upload vdscanner tools
       - name: Upload vdscanner tools
-        if: ${{ success() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ success() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
         uses: ./.github/actions/upload_s3_artifact
         with:
           aws_region: ${{ secrets.CI_AWS_REGION }}


### PR DESCRIPTION
## Description

The `5.X - VD Scanner tools Delivery` workflow has failed on every run since 2026-06-29 because commit 0f237ab32 placed the `workflow_dispatch` `inputs:` block at the top level of the file, which is invalid workflow syntax. GitHub cannot parse the file and records a failed run on every push to any branch containing it. The same commit migrated the upload step to `.github/actions/upload_s3_artifact` without following the action's call convention, so the upload would keep failing even with valid syntax.

Closes #38454

## Proposed Changes

- Remove the invalid top-level `inputs:` block. No region input is needed: the region comes from the `CI_AWS_REGION` secret, as in every other caller of the action.
- Align the `upload_s3_artifact` call with the convention used by the rest of the workflows (e.g. `5_testcomponent_sca-rtr.yml`): pass `aws_region`, `bucket` and `aws_role` from the `CI_AWS_REGION`, `CI_INTERNAL_S3_BUCKET` and `CI_OIDC_ROLE_ARN` secrets, and grant `permissions: id-token: write, contents: read`, required by the action's OIDC credentials step.
- Add a `push` trigger on `5.0.0` with the same paths filter, so every merge touching the scanner or `inventory_sync_server` publishes a fresh artifact. The upload condition already checked `github.event_name == 'push'`, inherited from `4_builderprecompiled_vdscanner-testtools.yml`, which triggered on push to `main`; the 5.X port dropped the trigger but kept the check, so nothing published automatically. This gap has a consumer impact today: the `vd-efficacy-tests` job in wazuh/intelligence-data is disabled (`if: false`) because "its test-tool artifact is no longer published", and fell back to the deprecated 4.X legacy suite.
- Update the workflow content that went stale while it could not run. The `inventory_sync` module was renamed to `inventory_sync_server`: the build target and binary are now `inventory_sync_server_testtool` ("replaces the legacy inventory_sync_testtool", per its CMakeLists), the module library is `libinventory_sync_server.so`, and the `paths` filter points to `src/wazuh_modules/inventory_sync_server/**`. `librouter.so` is dropped from the staged libraries: `shared_modules/router` no longer exists and `vulnerability_scanner` does not link it. The remaining staged libraries match the testtool's current link graph (`vulnerability_scanner`, `wazuhext` direct; `content_manager`, `indexer_connector`, `schema_validator`, `librocksdb.so.8` transitive shared deps; the rest of the scanner's deps are static).

### Results and Evidence

Before: 100/100 recent runs failed on all branches, including `5.0.0`. Failed runs have 0 jobs and their name is the raw file path instead of the workflow name, the signature of a workflow parse error (example: https://github.com/wazuh/wazuh/actions/runs/32235644441). Last successful run: 2026-06-29 15:08 UTC, 13 minutes before 0f237ab32 was merged.

This PR touches the workflow file, which is in the workflow's own `paths` filter, so the runs on this PR exercise the fix end to end:

- With the syntax fix alone, the workflow parses and runs, and the build surfaces a second breakage that the parse error had been masking since June: `gmake: *** No rule to make target 'inventory_sync_testtool'` (https://github.com/wazuh/wazuh/actions/runs/32238737380). The target was renamed with the `inventory_sync` → `inventory_sync_server` module rename.
- Run on the final version: **success** in 17 minutes, https://github.com/wazuh/wazuh/actions/runs/32239533609. The tarball stages the expected content:

  ```
  vdscanner tools successfully compressed: 31M  vdscanner_testtools.tar.xz
  libcontent_manager.so
  libindexer_connector.so
  libinventory_sync_server.so
  librocksdb.so.8
  libschema_validator.so
  libvulnerability_scanner.so
  libwazuhext.so
  scanner/
  scanner/inventory_sync_server_testtool
  scanner/vd_reduced_feed.json
  schemas/
  ```

The S3 upload path (skipped on pull_request events) was exercised with a `workflow_dispatch` on this branch: **success**, https://github.com/wazuh/wazuh/actions/runs/32241705231. OIDC credentials resolve and the artifact lands at the expected key:

```
Uploaded artifact 'vdscanner_testtools' to <bucket>/wazuh/5_builderprecompiled_vdscanner-testtools/32241705231/vdscanner_testtools.zip
```

The tool itself still works on current `5.0.0`: a `workflow_dispatch` of `5_testintegration_vulnerability-scanner.yml` on the branch head (which builds `inventory_sync_server_testtool` and runs the full `test_efficacy_log.py` suite against a seeded OpenSearch) passed with 12/12 tests: https://github.com/wazuh/wazuh/actions/runs/32241702831.

Local validation of the fixed file:

```
$ ruby -ryaml -e 'YAML.load(File.read(".github/workflows/5_builderprecompiled_vdscanner-testtools.yml"))'
YAML OK, top-level keys: ['concurrency', 'env', 'jobs', 'name', 'permissions', 'true']
```

### Artifacts Affected

`vdscanner_testtools.tar.xz` (CI-only artifact for QA): the staged binary and module library follow the rename (`inventory_sync_server_testtool`, `libinventory_sync_server.so`) and `librouter.so` is no longer included.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None.

## Review Checklist
- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
