### PR TITLE
Persist the agent version at startup and stop throttling the first host-carrying notify

### DIFF
--- a/src/remoted/remoted_module/README.md
+++ b/src/remoted/remoted_module/README.md
@@ -313,8 +313,8 @@ sequenceDiagram
     WDB-->>CH: groups
     CH->>AR: update(id, metadata)
     Note over AR: Sharded map insert/update
-    CH->>WDB: updateAgentData(id, version, groups, ...)
-    Note over WDB: Fire-and-forget async write
+    CH->>WDB: updateKeepalive(id, "pending") + updateStatusCode(id, Ok, version)
+    Note over WDB: Fire-and-forget async writes
     CH->>TC: getPendingTasks(id)
     TC-->>TM: async UDS query
     TM-->>TC: [task1, task2, ...]
@@ -328,7 +328,8 @@ sequenceDiagram
 1. **`startup`** — agent sends on connect or after config reload
    - **Request**: `{"type":"startup","version":"5.0.0"}`
    - Validates agent version (rejects if `< manager` when `allow_higher_versions=false`)
-   - Marks agent as connected in wazuh-db (global.db)
+   - Marks agent as `pending` in wazuh-db (global.db); the first notify promotes it to `active`
+   - Persists the accepted agent version and resets `status_code` (host/os data arrives later via notify)
    - Records connection timestamp
    - Fetches agent groups from wazuh-db
    - **Response**:
@@ -361,8 +362,10 @@ sequenceDiagram
      ```
    - Optional host metadata (OS, architecture, hostname, IP) — sent on first keepalive or when values change
    - Updates agent registry with last activity timestamp
-   - Conditionally writes to wazuh-db (throttled by `keepaliveThrottleSec`, default 300s):
-     - **Full update** (`updateAgentData`): when host metadata is present in the request
+   - Conditionally writes to wazuh-db (throttled by `keepaliveThrottleSec`, default 60s):
+     - **Full update** (`updateAgentData`): when host metadata is present in the request. The first
+       host-carrying notify bypasses the throttle, so host/os data lands as soon as the agent reports it
+       even if an earlier metadata-less notify already consumed the window
      - **Lightweight keepalive** (`updateKeepalive`): when no host metadata in the request
    - Calculates `settings_hash` (SHA256 of limits + cluster + groups from agent's startup data)
    - Calculates `config_hash` (SHA256 of agent's `merged.mg` shared config file)
@@ -400,7 +403,8 @@ Implements `handleStartup()`, `handleNotify()`, `handleShutdown()` with the logi
 Wazuh-db writes are throttled per agent via `lastKeepaliveUpdateSec` (in `AgentRegistry`) to avoid
 flooding wazuh-db with writes every 10 seconds. Full updates (`updateAgentData`) are sent when the
 agent includes host metadata in the notify request; lightweight keepalives (`updateKeepalive`) are
-sent otherwise. Both respect the `keepaliveThrottleSec` window (default 300s).
+sent otherwise. Both respect the `keepaliveThrottleSec` window (default 60s), except the first
+host-carrying notify (`hostPersisted` in `AgentEntry`), which always triggers a full update.
 
 Version comparison uses a local `compareVersions()` function for semantic versioning (e.g., `"v5.0.0"`
 vs `"v4.9.2"`), stripping leading `v`/`V` and ignoring everything after `-` or `+`.

--- a/src/remoted/remoted_module/README.md
+++ b/src/remoted/remoted_module/README.md
@@ -313,8 +313,8 @@ sequenceDiagram
     WDB-->>CH: groups
     CH->>AR: update(id, metadata)
     Note over AR: Sharded map insert/update
-    CH->>WDB: updateKeepalive(id, "pending") + updateStatusCode(id, Ok, version)
-    Note over WDB: Fire-and-forget async writes
+    CH->>WDB: updateStatusCode(id, Ok, version, "pending")
+    Note over WDB: Fire-and-forget async write (version + pending keepalive)
     CH->>TC: getPendingTasks(id)
     TC-->>TM: async UDS query
     TM-->>TC: [task1, task2, ...]

--- a/src/remoted/remoted_module/src/control/agentRegistry.hpp
+++ b/src/remoted/remoted_module/src/control/agentRegistry.hpp
@@ -31,6 +31,7 @@ namespace remoted::control
         uint64_t lastKeepaliveUpdateSec = 0;
         uint64_t lastActivitySec = 0;
         uint64_t createdAtSec = 0;
+        bool hostPersisted = false;
     };
 
     class AgentRegistry

--- a/src/remoted/remoted_module/src/control/controlHandler.cpp
+++ b/src/remoted/remoted_module/src/control/controlHandler.cpp
@@ -208,7 +208,7 @@ namespace remoted::control
                 // this manager's policy is safe to persist as-is and worth keeping visible.
                 const std::string& versionToStore = versionMalformed ? UNKNOWN_VERSION_PLACEHOLDER : data.version;
                 m_wdbClient->updateStatusCode(
-                    id, AgentStatusCode::InvalidVersion, versionToStore, syncStatus, [](SocketError) {});
+                    id, AgentStatusCode::InvalidVersion, versionToStore, "", syncStatus, [](SocketError) {});
 
                 HttpResponse response;
                 response.status = 400;
@@ -269,17 +269,16 @@ namespace remoted::control
                                                                    return updated;
                                                                });
 
+                                            // A single write persists the accepted version together with the
+                                            // pending keepalive. The version is not left to the notify path:
+                                            // notify only writes it alongside host metadata, which the agent
+                                            // omits until agent_info populates it, so the agent would otherwise
+                                            // be visible through the API without a version for the first
+                                            // keepalives.
                                             const std::string syncStatus =
                                                 m_config.isWorkerNode ? "syncreq_status" : "synced";
-                                            m_wdbClient->updateKeepalive(id, "pending", syncStatus, [](SocketError) {});
-
-                                            // The accepted version is persisted here and not left to the notify
-                                            // path: notify only writes it alongside host metadata, which the agent
-                                            // omits until agent_info populates it, so the agent would otherwise be
-                                            // visible through the API without a version for the first keepalives.
-                                            // This also clears any status_code left by a previously rejected startup.
                                             m_wdbClient->updateStatusCode(
-                                                id, AgentStatusCode::Ok, version, syncStatus, [](SocketError) {});
+                                                id, AgentStatusCode::Ok, version, "pending", syncStatus, [](SocketError) {});
 
                                             nlohmann::json response;
                                             response["limits"] = m_config.limits;

--- a/src/remoted/remoted_module/src/control/controlHandler.cpp
+++ b/src/remoted/remoted_module/src/control/controlHandler.cpp
@@ -273,6 +273,14 @@ namespace remoted::control
                                                 m_config.isWorkerNode ? "syncreq_status" : "synced";
                                             m_wdbClient->updateKeepalive(id, "pending", syncStatus, [](SocketError) {});
 
+                                            // The accepted version is persisted here and not left to the notify
+                                            // path: notify only writes it alongside host metadata, which the agent
+                                            // omits until agent_info populates it, so the agent would otherwise be
+                                            // visible through the API without a version for the first keepalives.
+                                            // This also clears any status_code left by a previously rejected startup.
+                                            m_wdbClient->updateStatusCode(
+                                                id, AgentStatusCode::Ok, version, syncStatus, [](SocketError) {});
+
                                             nlohmann::json response;
                                             response["limits"] = m_config.limits;
                                             response["cluster"]["name"] = m_config.clusterName;
@@ -431,10 +439,15 @@ namespace remoted::control
 
                     if (data.host)
                     {
-                        // Always write host info if throttle has expired
-                        if (now - e->lastKeepaliveUpdateSec >= m_config.keepaliveThrottleSec)
+                        // The first host-carrying notify bypasses the throttle: the agent may
+                        // send its first notifies without host metadata (agent_info populates
+                        // it asynchronously), and those lightweight writes must not delay the
+                        // first full update, or the agent stays without os data in the API for
+                        // a whole throttle window.
+                        if (!e->hostPersisted || now - e->lastKeepaliveUpdateSec >= m_config.keepaliveThrottleSec)
                         {
                             e->lastKeepaliveUpdateSec = now;
+                            e->hostPersisted = true;
                             doWrite = true;
                             doFullUpdate = true;
                         }

--- a/src/remoted/remoted_module/src/control/controlTypes.hpp
+++ b/src/remoted/remoted_module/src/control/controlTypes.hpp
@@ -95,6 +95,7 @@ namespace remoted::control
 
     enum class AgentStatusCode : int
     {
+        Ok = 0,
         InvalidVersion = 1,
         ErrVersionRecv = 2,
         HcShutdownRecv = 3,

--- a/src/remoted/remoted_module/src/control/wazuhDBClient.cpp
+++ b/src/remoted/remoted_module/src/control/wazuhDBClient.cpp
@@ -480,6 +480,7 @@ namespace remoted::control
     void WazuhDBClient::updateStatusCode(AgentId id,
                                          AgentStatusCode statusCode,
                                          const std::string& version,
+                                         const std::string& connectionStatus,
                                          const std::string& syncStatus,
                                          std::function<void(SocketError)> callback)
     {
@@ -487,6 +488,10 @@ namespace remoted::control
         params["id"] = id;
         params["status_code"] = static_cast<int>(statusCode);
         params["version"] = version;
+        if (!connectionStatus.empty())
+        {
+            params["connection_status"] = connectionStatus;
+        }
         params["sync_status"] = syncStatus;
 
         globalQuery("update-status-code", params, std::move(callback));

--- a/src/remoted/remoted_module/src/control/wazuhDBClient.hpp
+++ b/src/remoted/remoted_module/src/control/wazuhDBClient.hpp
@@ -48,9 +48,12 @@ namespace remoted::control
                              const std::string& syncStatus,
                              std::function<void(SocketError)> callback);
 
+        /// When connectionStatus is non-empty, the same write also updates the connection
+        /// status, stamps the last keepalive and resets the disconnection time.
         void updateStatusCode(AgentId id,
                               AgentStatusCode statusCode,
                               const std::string& version,
+                              const std::string& connectionStatus,
                               const std::string& syncStatus,
                               std::function<void(SocketError)> callback);
 

--- a/src/remoted/remoted_module/test/unit/controlHandler_test.cpp
+++ b/src/remoted/remoted_module/test/unit/controlHandler_test.cpp
@@ -184,9 +184,15 @@ namespace
         std::shared_ptr<remoted::common::VdClient> vdClient;
         std::unique_ptr<ControlHandler> handler;
 
-        HandlerFixture(std::shared_ptr<WdbRouter> wdb, std::function<std::string(const std::string&)> taskResp)
+        HandlerFixture(std::shared_ptr<WdbRouter> wdb,
+                       std::function<std::string(const std::string&)> taskResp,
+                       std::function<void(Config&)> tweakCfg = {})
             : cfg(makeConfig(env))
         {
+            if (tweakCfg)
+            {
+                tweakCfg(cfg);
+            }
             wdbServer = std::make_unique<FakeUdsServer>(env.wdbPath, [wdb](const std::string& r) { return (*wdb)(r); });
             taskServer = std::make_unique<FakeUdsServer>(env.taskPath, std::move(taskResp));
 
@@ -308,6 +314,48 @@ TEST(ControlHandlerTest, StartupHappyPathReturns200WithGroupsAndClusterEnvelope)
     auto entry = h.registry->get(42);
     ASSERT_TRUE(entry);
     EXPECT_EQ(entry->groups.size(), 2U);
+}
+
+TEST(ControlHandlerTest, StartupPersistsAcceptedVersionWithOkStatusCode)
+{
+    auto wdb = std::make_shared<WdbRouter>();
+    wdb->onSelectAgentGroup([](const std::string&) { return "ok [{\"group\":\"default\"}]"; });
+    HandlerFixture h(wdb, [](const std::string&) { return "{\"status\":\"ok\",\"tasks\":[]}"; });
+
+    StartupData data;
+    data.version = "5.0.0";
+    Waiter<HttpResponse> w;
+    h.handler->handleStartup(7, data, [&](const HttpResponse& r) { w.complete(r); });
+    ASSERT_TRUE(w.wait(3000ms));
+    EXPECT_EQ(w.value.status, 200);
+
+    // Three commands expected: select-agent-group plus the two fire-and-forget
+    // writes (pending keepalive and status-code/version persistence).
+    for (int i = 0; i < 200 && wdb->commands().size() < 3; ++i)
+    {
+        std::this_thread::sleep_for(5ms);
+    }
+    bool sawPendingKeepalive = false;
+    bool sawVersionPersist = false;
+    for (const auto& c : wdb->commands())
+    {
+        if (c.find("global update-keepalive") != std::string::npos &&
+            c.find("\"connection_status\":\"pending\"") != std::string::npos)
+        {
+            sawPendingKeepalive = true;
+        }
+        // The accepted version must land in wdb at startup: the notify path only
+        // persists it together with host metadata, which the agent may take a
+        // while to report, and GET /agents must not show a versionless agent.
+        if (c.find("global update-status-code") != std::string::npos &&
+            c.find("\"status_code\":0") != std::string::npos &&
+            c.find("\"version\":\"5.0.0\"") != std::string::npos)
+        {
+            sawVersionPersist = true;
+        }
+    }
+    EXPECT_TRUE(sawPendingKeepalive);
+    EXPECT_TRUE(sawVersionPersist);
 }
 
 TEST(ControlHandlerTest, StartupFallsBackToDefaultGroupOnEmptyWdbCsv)
@@ -440,6 +488,79 @@ TEST(ControlHandlerTest, NotifyReturnsRealConfigHashWhenMergedMgExists)
     auto j = nlohmann::json::parse(w.value.body);
     // sha256("hello") -- verifies the hash cache picks up the file we wrote.
     EXPECT_EQ(j["agent"]["config_hash"], "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+}
+
+TEST(ControlHandlerTest, NotifyFirstHostMetadataBypassesKeepaliveThrottle)
+{
+    auto wdb = std::make_shared<WdbRouter>();
+    wdb->onSelectAgentGroup([](const std::string&) { return "ok {\"group\":\"default\"}"; });
+    HandlerFixture h(
+        wdb,
+        [](const std::string&) { return "{\"status\":\"ok\",\"tasks\":[]}"; },
+        [](Config& c) { c.keepaliveThrottleSec = 3600; });
+
+    // First notify carries no host metadata (agent_info has not populated it
+    // yet): a lightweight keepalive is written and stamps the throttle window.
+    NotifyData bare;
+    bare.version = "5.0.0";
+    Waiter<HttpResponse> w1;
+    h.handler->handleNotify(1, bare, [&](const HttpResponse& r) { w1.complete(r); });
+    ASSERT_TRUE(w1.wait(3000ms));
+    EXPECT_EQ(w1.value.status, 200);
+
+    NotifyData withHost;
+    withHost.version = "5.0.0";
+    HostInfo host;
+    host.hostname = "mac01";
+    host.ip = "127.0.0.1";
+    host.osName = "macOS";
+    host.osVersion = "26.0";
+    host.osPlatform = "darwin";
+    host.architecture = "arm64";
+    host.osType = "macos";
+    withHost.host = host;
+
+    // Second notify brings host metadata inside the throttle window: it must
+    // still produce a full update, or the agent stays without version/os data
+    // in the API until the window expires.
+    Waiter<HttpResponse> w2;
+    h.handler->handleNotify(1, withHost, [&](const HttpResponse& r) { w2.complete(r); });
+    ASSERT_TRUE(w2.wait(3000ms));
+    EXPECT_EQ(w2.value.status, 200);
+
+    // Third notify with host inside the window: host data is persisted now, so
+    // the throttle applies again and no further write is issued.
+    Waiter<HttpResponse> w3;
+    h.handler->handleNotify(1, withHost, [&](const HttpResponse& r) { w3.complete(r); });
+    ASSERT_TRUE(w3.wait(3000ms));
+    EXPECT_EQ(w3.value.status, 200);
+
+    // Expected wdb traffic: one select per notify (groupsRefreshIntervalSec=0),
+    // one lightweight keepalive and exactly one full update.
+    for (int i = 0; i < 200 && wdb->commands().size() < 5; ++i)
+    {
+        std::this_thread::sleep_for(5ms);
+    }
+    std::this_thread::sleep_for(50ms); // settle so a stray extra write would be visible
+
+    size_t fullUpdates = 0;
+    size_t lightweightKeepalives = 0;
+    for (const auto& c : wdb->commands())
+    {
+        if (c.find("global update-agent-data") != std::string::npos)
+        {
+            ++fullUpdates;
+            EXPECT_NE(c.find("\"version\":\"5.0.0\""), std::string::npos);
+            EXPECT_NE(c.find("\"os_name\":\"macOS\""), std::string::npos);
+        }
+        if (c.find("global update-keepalive") != std::string::npos &&
+            c.find("\"connection_status\":\"active\"") != std::string::npos)
+        {
+            ++lightweightKeepalives;
+        }
+    }
+    EXPECT_EQ(fullUpdates, 1U);
+    EXPECT_EQ(lightweightKeepalives, 1U);
 }
 
 // =============================================================================

--- a/src/remoted/remoted_module/test/unit/controlHandler_test.cpp
+++ b/src/remoted/remoted_module/test/unit/controlHandler_test.cpp
@@ -329,32 +329,28 @@ TEST(ControlHandlerTest, StartupPersistsAcceptedVersionWithOkStatusCode)
     ASSERT_TRUE(w.wait(3000ms));
     EXPECT_EQ(w.value.status, 200);
 
-    // Three commands expected: select-agent-group plus the two fire-and-forget
-    // writes (pending keepalive and status-code/version persistence).
-    for (int i = 0; i < 200 && wdb->commands().size() < 3; ++i)
+    // Two commands expected: select-agent-group plus a single fire-and-forget
+    // write persisting the version, the pending status and the keepalive.
+    for (int i = 0; i < 200 && wdb->commands().size() < 2; ++i)
     {
         std::this_thread::sleep_for(5ms);
     }
-    bool sawPendingKeepalive = false;
     bool sawVersionPersist = false;
     for (const auto& c : wdb->commands())
     {
-        if (c.find("global update-keepalive") != std::string::npos &&
-            c.find("\"connection_status\":\"pending\"") != std::string::npos)
-        {
-            sawPendingKeepalive = true;
-        }
         // The accepted version must land in wdb at startup: the notify path only
         // persists it together with host metadata, which the agent may take a
         // while to report, and GET /agents must not show a versionless agent.
         if (c.find("global update-status-code") != std::string::npos &&
             c.find("\"status_code\":0") != std::string::npos &&
-            c.find("\"version\":\"5.0.0\"") != std::string::npos)
+            c.find("\"version\":\"5.0.0\"") != std::string::npos &&
+            c.find("\"connection_status\":\"pending\"") != std::string::npos)
         {
             sawVersionPersist = true;
         }
+        EXPECT_EQ(c.find("global update-keepalive"), std::string::npos)
+            << "startup must issue a single wdb write, got: " << c;
     }
-    EXPECT_TRUE(sawPendingKeepalive);
     EXPECT_TRUE(sawVersionPersist);
 }
 

--- a/src/remoted/remoted_module/test/unit/wazuhDBClient_test.cpp
+++ b/src/remoted/remoted_module/test/unit/wazuhDBClient_test.cpp
@@ -395,7 +395,7 @@ TEST(WazuhDBClientTest, UpdateStatusCodeSerializesInteger)
     WazuhDBClient client(path, 1, 1000, 100, metrics);
 
     Waiter<SocketError> w;
-    client.updateStatusCode(3, AgentStatusCode::InvalidVersion, "v0", "synced", [&](SocketError e) { w.complete(e); });
+    client.updateStatusCode(3, AgentStatusCode::InvalidVersion, "v0", "", "synced", [&](SocketError e) { w.complete(e); });
     ASSERT_TRUE(w.wait(3000ms));
 
     std::string got;
@@ -407,6 +407,20 @@ TEST(WazuhDBClientTest, UpdateStatusCodeSerializesInteger)
     // InvalidVersion == 1.
     EXPECT_NE(got.find("\"status_code\":1"), std::string::npos);
     EXPECT_NE(got.find("\"version\":\"v0\""), std::string::npos);
+    // An empty connectionStatus must not reach the wire: without the key, wdb
+    // keeps the plain status-code statement and does not touch the keepalive.
+    EXPECT_EQ(got.find("connection_status"), std::string::npos);
+
+    Waiter<SocketError> w2;
+    client.updateStatusCode(3, AgentStatusCode::Ok, "v5.0.0", "pending", "synced", [&](SocketError e) { w2.complete(e); });
+    ASSERT_TRUE(w2.wait(3000ms));
+    {
+        std::lock_guard<std::mutex> lock(mu);
+        got = received;
+    }
+    EXPECT_NE(got.find("\"status_code\":0"), std::string::npos);
+    EXPECT_NE(got.find("\"version\":\"v5.0.0\""), std::string::npos);
+    EXPECT_NE(got.find("\"connection_status\":\"pending\""), std::string::npos);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/unit_tests/wazuh_db/test_wdb_global.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global.c
@@ -3664,7 +3664,7 @@ void test_wdb_global_update_agent_status_code_transaction_fail(void **state) {
     will_return(__wrap_wdb_stmt_cache, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot cache statement");
 
-    result = wdb_global_update_agent_status_code(data->wdb, 1, status_code, version, sync_status);
+    result = wdb_global_update_agent_status_code(data->wdb, 1, status_code, version, NULL, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -3679,7 +3679,7 @@ void test_wdb_global_update_agent_status_code_cache_fail(void **state) {
     will_return(__wrap_wdb_begin2, -1);
     expect_string(__wrap__mdebug1, formatted_msg, "Cannot begin transaction");
 
-    result = wdb_global_update_agent_status_code(data->wdb, 1, status_code, version, sync_status);
+    result = wdb_global_update_agent_status_code(data->wdb, 1, status_code, version, NULL, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -3701,7 +3701,7 @@ void test_wdb_global_update_agent_status_code_bind1_fail(void **state) {
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_status_code(data->wdb, 1, status_code, version, sync_status);
+    result = wdb_global_update_agent_status_code(data->wdb, 1, status_code, version, NULL, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -3727,7 +3727,7 @@ void test_wdb_global_update_agent_status_code_bind2_fail(void **state) {
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_status_code(data->wdb, 1, status_code, version, sync_status);
+    result = wdb_global_update_agent_status_code(data->wdb, 1, status_code, version, NULL, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -3756,7 +3756,7 @@ void test_wdb_global_update_agent_status_code_bind3_fail(void **state) {
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_text(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_status_code(data->wdb, 1, status_code, version, sync_status);
+    result = wdb_global_update_agent_status_code(data->wdb, 1, status_code, version, NULL, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -3789,7 +3789,7 @@ void test_wdb_global_update_agent_status_code_bind4_fail(void **state) {
     will_return(__wrap_sqlite3_errmsg, "ERROR MESSAGE");
     expect_string(__wrap__merror, formatted_msg, "DB(global) sqlite3_bind_int(): ERROR MESSAGE");
 
-    result = wdb_global_update_agent_status_code(data->wdb, 1, status_code, version, sync_status);
+    result = wdb_global_update_agent_status_code(data->wdb, 1, status_code, version, NULL, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -3822,7 +3822,7 @@ void test_wdb_global_update_agent_status_code_step_fail(void **state) {
 
     will_return(__wrap_wdb_exec_stmt_silent, OS_INVALID);
 
-    result = wdb_global_update_agent_status_code(data->wdb, 1, status_code, version, sync_status);
+    result = wdb_global_update_agent_status_code(data->wdb, 1, status_code, version, NULL, sync_status);
 
     assert_int_equal(result, OS_INVALID);
 }
@@ -3855,7 +3855,43 @@ void test_wdb_global_update_agent_status_code_success(void **state) {
 
     will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
 
-    result = wdb_global_update_agent_status_code(data->wdb, 1, status_code, version, sync_status);
+    result = wdb_global_update_agent_status_code(data->wdb, 1, status_code, version, NULL, sync_status);
+
+    assert_int_equal(result, OS_SUCCESS);
+}
+
+void test_wdb_global_update_agent_status_code_connection_status_success(void **state) {
+    int result = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    int status_code = 0;
+    const char *version = "v4.5.0";
+    const char *connection_status = "pending";
+    const char *sync_status = "synced";
+
+    will_return(__wrap_wdb_begin2, 1);
+    will_return(__wrap_wdb_stmt_cache, 1);
+
+    expect_value(__wrap_sqlite3_bind_int, index, 1);
+    expect_value(__wrap_sqlite3_bind_int, value, status_code);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+
+    expect_value(__wrap_sqlite3_bind_text, pos, 2);
+    expect_value(__wrap_sqlite3_bind_text, buffer, version);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 3);
+    expect_string(__wrap_sqlite3_bind_text, buffer, sync_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+    expect_value(__wrap_sqlite3_bind_text, pos, 4);
+    expect_string(__wrap_sqlite3_bind_text, buffer, connection_status);
+    will_return(__wrap_sqlite3_bind_text, SQLITE_OK);
+
+    expect_value(__wrap_sqlite3_bind_int, index, 5);
+    expect_value(__wrap_sqlite3_bind_int, value, 1);
+    will_return(__wrap_sqlite3_bind_int, SQLITE_OK);
+
+    will_return(__wrap_wdb_exec_stmt_silent, OS_SUCCESS);
+
+    result = wdb_global_update_agent_status_code(data->wdb, 1, status_code, version, connection_status, sync_status);
 
     assert_int_equal(result, OS_SUCCESS);
 }
@@ -8532,6 +8568,9 @@ int main()
                                         test_setup,
                                         test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_status_code_success,
+                                        test_setup,
+                                        test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_global_update_agent_status_code_connection_status_success,
                                         test_setup,
                                         test_teardown),
         /* Tests wdb_global_delete_agent */

--- a/src/unit_tests/wazuh_db/test_wdb_global_parser.c
+++ b/src/unit_tests/wazuh_db/test_wdb_global_parser.c
@@ -1067,6 +1067,7 @@ void test_wdb_parse_global_update_status_code_query_error(void **state)
     expect_value(__wrap_wdb_global_update_agent_status_code, id, 1);
     expect_value(__wrap_wdb_global_update_agent_status_code, status_code, 0);
     expect_string(__wrap_wdb_global_update_agent_status_code, version, "v4.5.0");
+    expect_value(__wrap_wdb_global_update_agent_status_code, connection_status, NULL);
     expect_string(__wrap_wdb_global_update_agent_status_code, sync_status, "syncreq");
     will_return(__wrap_wdb_global_update_agent_status_code, OS_INVALID);
 
@@ -1109,10 +1110,50 @@ void test_wdb_parse_global_update_status_code_success(void **state)
     expect_value(__wrap_wdb_global_update_agent_status_code, id, 1);
     expect_value(__wrap_wdb_global_update_agent_status_code, status_code, 0);
     expect_string(__wrap_wdb_global_update_agent_status_code, version, "v4.5.0");
+    expect_value(__wrap_wdb_global_update_agent_status_code, connection_status, NULL);
     expect_string(__wrap_wdb_global_update_agent_status_code, sync_status, "syncreq");
     will_return(__wrap_wdb_global_update_agent_status_code, OS_SUCCESS);
 
     expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-status-code {\"id\":1,\"status_code\":0,\"version\":\"v4.5.0\",\"sync_status\":\"syncreq\"}");
+
+    expect_function_call(__wrap_w_inc_queries_total);
+    expect_function_call(__wrap_w_inc_global);
+    will_return(__wrap_gettimeofday, NULL);
+    will_return(__wrap_gettimeofday, NULL);
+    expect_function_call(__wrap_w_inc_global_open_time);
+    expect_function_call(__wrap_w_inc_global_agent_update_status_code);
+    will_return(__wrap_gettimeofday, NULL);
+    will_return(__wrap_gettimeofday, NULL);
+    expect_function_call(__wrap_w_inc_global_agent_update_status_code_time);
+
+    expect_function_call(__wrap_wdb_pool_leave);
+
+    ret = wdb_parse(query, data->output, 0);
+
+    assert_string_equal(data->output, "ok");
+    assert_int_equal(ret, OS_SUCCESS);
+}
+
+void test_wdb_parse_global_update_status_code_connection_status_success(void **state)
+{
+    int ret = 0;
+    test_struct_t *data  = (test_struct_t *)*state;
+    char query[OS_BUFFER_SIZE] = "global update-status-code {\"id\":1,\"status_code\":0,\"version\":\"v5.0.0\",\"connection_status\":\"pending\",\"sync_status\":\"syncreq\"}";
+
+    will_return(__wrap_wdb_open_global, data->wdb);
+
+    expect_value(__wrap_wdb_global_validate_sync_status, id, 1);
+    expect_string(__wrap_wdb_global_validate_sync_status, requested_sync_status, "syncreq");
+    will_return(__wrap_wdb_global_validate_sync_status, "syncreq");
+
+    expect_value(__wrap_wdb_global_update_agent_status_code, id, 1);
+    expect_value(__wrap_wdb_global_update_agent_status_code, status_code, 0);
+    expect_string(__wrap_wdb_global_update_agent_status_code, version, "v5.0.0");
+    expect_string(__wrap_wdb_global_update_agent_status_code, connection_status, "pending");
+    expect_string(__wrap_wdb_global_update_agent_status_code, sync_status, "syncreq");
+    will_return(__wrap_wdb_global_update_agent_status_code, OS_SUCCESS);
+
+    expect_string(__wrap__mdebug2, formatted_msg, "Global query: update-status-code {\"id\":1,\"status_code\":0,\"version\":\"v5.0.0\",\"connection_status\":\"pending\",\"sync_status\":\"syncreq\"}");
 
     expect_function_call(__wrap_w_inc_queries_total);
     expect_function_call(__wrap_w_inc_global);
@@ -4668,6 +4709,7 @@ int main()
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_status_code_invalid_data, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_status_code_query_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_status_code_success, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_wdb_parse_global_update_status_code_connection_status_success, test_setup, test_teardown),
         /* Tests wdb_parse_global_delete_agent */
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_delete_agent_syntax_error, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_wdb_parse_global_delete_agent_query_error, test_setup, test_teardown),

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.c
@@ -87,10 +87,12 @@ int __wrap_wdb_global_update_agent_status_code(__attribute__((unused)) wdb_t *wd
                                                    int id,
                                                    int status_code,
                                                    const char *version,
+                                                   const char *connection_status,
                                                    const char *sync_status) {
     check_expected(id);
     check_expected(status_code);
     check_expected(version);
+    check_expected_ptr(connection_status);
     check_expected(sync_status);
     return mock();
 }

--- a/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/wazuh_db/wdb_global_wrappers.h
@@ -35,7 +35,7 @@ int __wrap_wdb_global_update_agent_connection_status(
     wdb_t* wdb, int id, char* connection_status, char* sync_status, int status_code);
 
 int __wrap_wdb_global_update_agent_status_code(
-    wdb_t* wdb, int id, int status_code, const char* version, const char* sync_status);
+    wdb_t* wdb, int id, int status_code, const char* version, const char* connection_status, const char* sync_status);
 
 int __wrap_wdb_global_delete_agent(wdb_t* wdb, int id);
 

--- a/src/wazuh_db/include/wdb.h
+++ b/src/wazuh_db/include/wdb.h
@@ -72,6 +72,7 @@ typedef enum wdb_stmt {
     WDB_STMT_GLOBAL_UPDATE_AGENT_KEEPALIVE,
     WDB_STMT_GLOBAL_UPDATE_AGENT_CONNECTION_STATUS,
     WDB_STMT_GLOBAL_UPDATE_AGENT_STATUS_CODE,
+    WDB_STMT_GLOBAL_UPDATE_AGENT_STATUS_CODE_KEEPALIVE,
     WDB_STMT_GLOBAL_DELETE_AGENT,
     WDB_STMT_GLOBAL_FIND_AGENT,
     WDB_STMT_GLOBAL_FIND_GROUP,
@@ -954,9 +955,12 @@ int wdb_global_update_agent_connection_status(wdb_t *wdb, int id, const char* co
  * @param [in] id The agent ID.
  * @param [in] status_code The status code to be set.
  * @param [in] version The agent version to be set.
+ * @param [in] connection_status The connection status to be set. When not NULL, the last keepalive
+ *                               is stamped and the disconnection time is reset as well.
+ * @param [in] sync_status The value of sync_status.
  * @return Returns 0 on success or -1 on error.
  */
-int wdb_global_update_agent_status_code(wdb_t *wdb, int id, int status_code, const char *version, const char *sync_status);
+int wdb_global_update_agent_status_code(wdb_t *wdb, int id, int status_code, const char *version, const char *connection_status, const char *sync_status);
 
 /**
  * @brief Function to delete an agent from the agent table.

--- a/src/wazuh_db/src/wdb.c
+++ b/src/wazuh_db/src/wdb.c
@@ -46,6 +46,7 @@ static const char *SQL_STMT[] = {
     [WDB_STMT_GLOBAL_UPDATE_AGENT_KEEPALIVE] = "UPDATE agent SET last_keepalive = STRFTIME('%s', 'NOW'), connection_status = ?, sync_status = ?, disconnection_time = 0, status_code = 0 WHERE id = ?;",
     [WDB_STMT_GLOBAL_UPDATE_AGENT_CONNECTION_STATUS] = "UPDATE agent SET connection_status = ?, sync_status = ?, disconnection_time = ?, status_code = ? WHERE id = ?;",
     [WDB_STMT_GLOBAL_UPDATE_AGENT_STATUS_CODE] = "UPDATE agent SET status_code = ?, version = ?, sync_status = ? WHERE id = ?;",
+    [WDB_STMT_GLOBAL_UPDATE_AGENT_STATUS_CODE_KEEPALIVE] = "UPDATE agent SET status_code = ?, version = ?, sync_status = ?, connection_status = ?, last_keepalive = STRFTIME('%s', 'NOW'), disconnection_time = 0 WHERE id = ?;",
     [WDB_STMT_GLOBAL_DELETE_AGENT] = "DELETE FROM agent WHERE id = ?;",
     [WDB_STMT_GLOBAL_FIND_AGENT] = "SELECT id FROM agent WHERE name = ? AND (register_ip = ? OR register_ip LIKE ? || '/_%');",
     [WDB_STMT_GLOBAL_FIND_GROUP] = "SELECT id FROM `group` WHERE name = ?;",

--- a/src/wazuh_db/src/wdb_global.c
+++ b/src/wazuh_db/src/wdb_global.c
@@ -272,20 +272,22 @@ int wdb_global_update_agent_connection_status(wdb_t *wdb, int id, const char *co
     return wdb_exec_stmt_silent(stmt);
 }
 
-int wdb_global_update_agent_status_code(wdb_t *wdb, int id, int status_code, const char *version, const char *sync_status) {
+int wdb_global_update_agent_status_code(wdb_t *wdb, int id, int status_code, const char *version, const char *connection_status, const char *sync_status) {
     sqlite3_stmt *stmt = NULL;
+    const wdb_stmt stmt_index = connection_status ? WDB_STMT_GLOBAL_UPDATE_AGENT_STATUS_CODE_KEEPALIVE
+                                                  : WDB_STMT_GLOBAL_UPDATE_AGENT_STATUS_CODE;
 
     if (!wdb->transaction && wdb_begin2(wdb) < 0) {
         mdebug1("Cannot begin transaction");
         return OS_INVALID;
     }
 
-    if (wdb_stmt_cache(wdb, WDB_STMT_GLOBAL_UPDATE_AGENT_STATUS_CODE) < 0) {
+    if (wdb_stmt_cache(wdb, stmt_index) < 0) {
         mdebug1("Cannot cache statement");
         return OS_INVALID;
     }
 
-    stmt = wdb->stmt[WDB_STMT_GLOBAL_UPDATE_AGENT_STATUS_CODE];
+    stmt = wdb->stmt[stmt_index];
 
     if (sqlite3_bind_int(stmt, 1, status_code) != SQLITE_OK) {
         merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
@@ -302,7 +304,17 @@ int wdb_global_update_agent_status_code(wdb_t *wdb, int id, int status_code, con
         return OS_INVALID;
     }
 
-    if (sqlite3_bind_int(stmt, 4, id) != SQLITE_OK) {
+    if (connection_status) {
+        if (sqlite3_bind_text(stmt, 4, connection_status, -1, NULL) != SQLITE_OK) {
+            merror("DB(%s) sqlite3_bind_text(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+            return OS_INVALID;
+        }
+
+        if (sqlite3_bind_int(stmt, 5, id) != SQLITE_OK) {
+            merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
+            return OS_INVALID;
+        }
+    } else if (sqlite3_bind_int(stmt, 4, id) != SQLITE_OK) {
         merror("DB(%s) sqlite3_bind_int(): %s", wdb->id, sqlite3_errmsg(wdb->db));
         return OS_INVALID;
     }

--- a/src/wazuh_db/src/wdb_parser.c
+++ b/src/wazuh_db/src/wdb_parser.c
@@ -1102,8 +1102,10 @@ int wdb_parse_global_update_status_code(wdb_t * wdb, char * input, char * output
         j_status_code = cJSON_GetObjectItem(agent_data, "status_code");
         j_version = cJSON_GetObjectItem(agent_data, "version");
         j_sync_status = cJSON_GetObjectItem(agent_data, "sync_status");
+        cJSON *j_connection_status = cJSON_GetObjectItem(agent_data, "connection_status");
 
-        if (cJSON_IsNumber(j_id) && cJSON_IsNumber(j_status_code) && (j_version == NULL || cJSON_IsString(j_version)) && cJSON_IsString(j_sync_status)) {
+        if (cJSON_IsNumber(j_id) && cJSON_IsNumber(j_status_code) && (j_version == NULL || cJSON_IsString(j_version)) &&
+            (j_connection_status == NULL || cJSON_IsString(j_connection_status)) && cJSON_IsString(j_sync_status)) {
             // Getting each field
             int id = j_id->valueint;
             int status_code = j_status_code->valueint;
@@ -1111,11 +1113,16 @@ int wdb_parse_global_update_status_code(wdb_t * wdb, char * input, char * output
             if (j_version != NULL) {
                 version = j_version->valuestring;
             }
+            // Optional: when present, the keepalive is stamped along with the status code.
+            char *connection_status = NULL;
+            if (j_connection_status != NULL) {
+                connection_status = j_connection_status->valuestring;
+            }
             char *sync_status = j_sync_status->valuestring;
 
             char *validated_sync_status = wdb_global_validate_sync_status(wdb, id, sync_status);
 
-            if (OS_SUCCESS != wdb_global_update_agent_status_code(wdb, id, status_code, version, validated_sync_status)) {
+            if (OS_SUCCESS != wdb_global_update_agent_status_code(wdb, id, status_code, version, connection_status, validated_sync_status)) {
                 mdebug1("Global DB Cannot execute SQL query; err database %s/%s.db: %s", WDB2_DIR, WDB_GLOB_NAME, sqlite3_errmsg(wdb->db));
                 snprintf(output, OS_MAXSTR + 1, "err Cannot execute Global database query; %s", sqlite3_errmsg(wdb->db));
                 cJSON_Delete(agent_data);


### PR DESCRIPTION
## Description

Closes #38458.

In the 5.x `/control` flow the agent version only reaches `global.db` through a notify that carries host metadata (`updateAgentData`). The startup handler validates the version but never persists it, and the agent omits the host block until the `agent_info` module populates the shared metadata segment (initial 5s delay plus SysInfo collection). When the first notify arrives without host metadata, the lightweight keepalive write stamps the per-agent throttle (`kKeepaliveThrottleSec`, 60s), and the next notify that does carry host metadata is discarded. The result is an agent reported `active` by `GET /agents` with no `version` or OS data for up to ~70 seconds after enrollment.

The macOS agent loses this race consistently, which is what the nightly deployability test `test_agent_version_from_manager` hit on `macos-26-arm64` (Jenkins `deployability_testing/1476`): the test queries the API ~67s after enrollment, inside the window.

## Proposed Changes

- `handleStartup` now persists the accepted version through the existing `update-status-code` wazuh-db command (which also resets `status_code` after a previous rejection). The version is visible in the API from the startup, independently of the host metadata race. `AgentStatusCode::Ok = 0` is added for this.
- The first host-carrying notify bypasses the keepalive throttle (new `hostPersisted` flag in `AgentEntry`), so OS data lands as soon as the agent reports it instead of waiting a full throttle window. Subsequent notifies keep the current throttled behavior.
- `remoted_module` README updated to match the actual behavior (the startup sequence diagram showed an `updateAgentData` call that never existed, and the documented throttle default was 300s while the code uses 60s).

### Results and Evidence

Failure from the 2026-08-19 nightly (first run of the HTTPS deployability suite on macOS): agent enrolled at `08:21:36`, lightweight keepalive written at `08:22:00`, API queried at `08:22:43` still inside the throttle window:

```
KeyError: "Version key not found for agent: {'ip': 'any', 'status': 'active',
'lastKeepAlive': '2026-08-19T08:22:00+00:00', 'registerIP': 'any', 'status_code': 0,
'id': '001', 'name': 'agent-macos-26-arm64', 'dateAdd': '2026-08-19T08:21:36+00:00',
'group': ['default']}"
```

Unit test run (`remoted_module_utest`, ubuntu 24.04, same target as the `5.X - Remoted Module - Component tests` workflow):

```
(pending: full run output to be attached)
```

### Artifacts Affected

- `remoted_module.so` (manager, all platforms)

### Configuration Changes

None.

### Documentation Updates

- `src/remoted/remoted_module/README.md`: startup persistence, throttle default and first-host bypass.

### Tests Introduced

- `ControlHandlerTest.StartupPersistsAcceptedVersionWithOkStatusCode`: an accepted startup must fire `update-status-code` with `status_code: 0` and the agent version, in addition to the `pending` keepalive.
- `ControlHandlerTest.NotifyFirstHostMetadataBypassesKeepaliveThrottle`: with the throttle armed by a metadata-less notify, the first host-carrying notify still produces exactly one `update-agent-data`, and later host-carrying notifies inside the window are throttled again.

## Review Checklist
- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [x] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
