### PR TITLE
Scanhotfixes wmi timeout

### DIFF
--- a/src/data_provider/src/utilsWrapperWin.cpp
+++ b/src/data_provider/src/utilsWrapperWin.cpp
@@ -26,9 +26,34 @@ HRESULT ComHelper::CreateWmiLocator(IWbemLocator*& pLoc)
     return CoCreateInstance(CLSID_WbemLocator, 0, CLSCTX_INPROC_SERVER, IID_IWbemLocator, (LPVOID*)&pLoc);
 }
 
-HRESULT ComHelper::ConnectToWmiServer(IWbemLocator* pLoc, IWbemServices*& pSvc)
+HRESULT ComHelper::ConnectToWmiServer(IWbemLocator* pLoc, IWbemServices*& pSvc, long maxWaitMs)
 {
-    return pLoc->ConnectServer(_bstr_t(L"ROOT\\CIMV2"), NULL, NULL, 0, 0, 0, 0, &pSvc);
+    // ConnectServer() has no timeout parameter of its own; WBEM_FLAG_CONNECT_USE_MAX_WAIT
+    // plus an IWbemContext __MAX_WAIT property is WMI's own documented mechanism for
+    // bounding it instead of blocking indefinitely on an unresponsive Winmgmt (#38370).
+    IWbemContext* pCtx = NULL;
+    HRESULT hres = CoCreateInstance(CLSID_WbemContext, 0, CLSCTX_INPROC_SERVER, IID_IWbemContext, (LPVOID*)&pCtx);
+
+    if (FAILED(hres))
+    {
+        return hres;
+    }
+
+    VARIANT var;
+    var.vt = VT_I4;
+    var.lVal = maxWaitMs;
+    hres = pCtx->SetValue(L"__MAX_WAIT", 0, &var);
+
+    if (FAILED(hres))
+    {
+        pCtx->Release();
+        return hres;
+    }
+
+    hres = pLoc->ConnectServer(_bstr_t(L"ROOT\\CIMV2"), NULL, NULL, NULL,
+                               WBEM_FLAG_CONNECT_USE_MAX_WAIT, NULL, pCtx, &pSvc);
+    pCtx->Release();
+    return hres;
 }
 
 HRESULT ComHelper::SetProxyBlanket(IWbemServices* pSvc)
@@ -98,7 +123,7 @@ std::string BstrToString(BSTR bstr)
 }
 
 void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper,
-                      long perCallTimeoutMs, long overallTimeoutMs)
+                      long perCallTimeoutMs, long overallTimeoutMs, long connectMaxWaitMs)
 {
     HRESULT hres;
     IWbemLocator* pLoc = NULL;
@@ -113,7 +138,7 @@ void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper,
         throw std::runtime_error(oss.str());
     }
 
-    hres = comHelper.ConnectToWmiServer(pLoc, pSvc);
+    hres = comHelper.ConnectToWmiServer(pLoc, pSvc, connectMaxWaitMs);
 
     if (FAILED(hres))
     {
@@ -207,6 +232,7 @@ void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper,
         }
 
         VARIANT vtProp;
+        VariantInit(&vtProp);
         HRESULT hr = pclsObj->Get(L"HotFixID", 0, &vtProp, 0, 0);
 
         if (SUCCEEDED(hr) && vtProp.vt == VT_BSTR)

--- a/src/data_provider/src/utilsWrapperWin.cpp
+++ b/src/data_provider/src/utilsWrapperWin.cpp
@@ -150,30 +150,36 @@ void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper,
 
     IWbemClassObject* pclsObj = NULL;
     ULONG uReturn = 0;
-    const auto enumStart = std::chrono::steady_clock::now();
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(overallTimeoutMs);
 
     while (pEnumerator)
     {
-        const HRESULT nextRes = pEnumerator->Next(perCallTimeoutMs, 1, &pclsObj, &uReturn);
+        // Re-checked every iteration (success or timeout) so a Winmgmt that keeps
+        // returning objects without ever finishing can't block forever either
+        // (see #38370: previously WBEM_INFINITE let this block forever).
+        const auto now = std::chrono::steady_clock::now();
+
+        if (now >= deadline)
+        {
+            pEnumerator->Release();
+            pSvc->Release();
+            pLoc->Release();
+            oss << "WMI: hotfix enumeration did not respond within " << overallTimeoutMs
+                << " ms (Winmgmt unresponsive); aborting this cycle's hotfix collection.";
+            throw std::runtime_error(oss.str());
+        }
+
+        // Clamp the per-call wait to whatever time remains so a single Next() call
+        // can never push total elapsed time past overallTimeoutMs.
+        const auto remainingMs = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now).count();
+        const long callTimeoutMs = static_cast<long>(std::min<long long>(perCallTimeoutMs, remainingMs));
+
+        const HRESULT nextRes = pEnumerator->Next(callTimeoutMs, 1, &pclsObj, &uReturn);
 
         if (nextRes == WBEM_S_TIMEDOUT)
         {
-            // No object was ready within perCallTimeoutMs -- Winmgmt is slow, not
-            // necessarily done enumerating. Keep retrying until overallTimeoutMs is
-            // exhausted (see #38370: previously WBEM_INFINITE let this block forever).
-            const auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                       std::chrono::steady_clock::now() - enumStart).count();
-
-            if (elapsedMs >= overallTimeoutMs)
-            {
-                pEnumerator->Release();
-                pSvc->Release();
-                pLoc->Release();
-                oss << "WMI: hotfix enumeration did not respond within " << overallTimeoutMs
-                    << " ms (Winmgmt unresponsive); aborting this cycle's hotfix collection.";
-                throw std::runtime_error(oss.str());
-            }
-
+            // No object was ready within callTimeoutMs -- Winmgmt is slow, not
+            // necessarily done enumerating. Loop head re-checks the deadline.
             continue;
         }
 

--- a/src/data_provider/src/utilsWrapperWin.cpp
+++ b/src/data_provider/src/utilsWrapperWin.cpp
@@ -9,6 +9,7 @@
  * Foundation
  */
 
+#include <algorithm>      // For std::min/std::max
 #include <regex>
 #include <sstream>        // For std::ostringstream
 #include <iomanip>        // For std::hex
@@ -19,6 +20,33 @@
 
 #include "utilsWrapperWin.hpp"
 #include <shellapi.h>
+
+namespace
+{
+    // Releases a COM interface pointer (if non-null) when it goes out of scope, once,
+    // from whichever throw site or normal return exits the function that owns it.
+    // Centralizes the per-throw-site "if (p) p->Release();" pattern that would
+    // otherwise be duplicated at every early-exit point.
+    template <typename T>
+    class ComReleaseGuard
+    {
+        public:
+            explicit ComReleaseGuard(T*& ptr) : m_ptr(ptr) {}
+            ~ComReleaseGuard()
+            {
+                if (m_ptr)
+                {
+                    m_ptr->Release();
+                    m_ptr = nullptr;
+                }
+            }
+            ComReleaseGuard(const ComReleaseGuard&) = delete;
+            ComReleaseGuard& operator=(const ComReleaseGuard&) = delete;
+
+        private:
+            T*& m_ptr;
+    };
+}
 
 // Implement WMI functions
 HRESULT ComHelper::CreateWmiLocator(IWbemLocator*& pLoc)
@@ -31,27 +59,26 @@ HRESULT ComHelper::ConnectToWmiServer(IWbemLocator* pLoc, IWbemServices*& pSvc, 
     // ConnectServer() has no timeout parameter of its own; WBEM_FLAG_CONNECT_USE_MAX_WAIT
     // plus an IWbemContext __MAX_WAIT property is WMI's own documented mechanism for
     // bounding it instead of blocking indefinitely on an unresponsive Winmgmt (#38370).
+    // Creating/configuring that context object is a COM/WMI registration concern
+    // unrelated to Winmgmt being hung; if it fails, fall back to the pre-existing
+    // unbounded ConnectServer() call instead of failing hotfix collection outright, so
+    // that this narrow COM failure mode doesn't become a hard new dependency.
     IWbemContext* pCtx = NULL;
-    HRESULT hres = CoCreateInstance(CLSID_WbemContext, 0, CLSCTX_INPROC_SERVER, IID_IWbemContext, (LPVOID*)&pCtx);
+    ComReleaseGuard<IWbemContext> ctxGuard(pCtx);
 
-    if (FAILED(hres))
+    bool contextUsable = SUCCEEDED(CoCreateInstance(CLSID_WbemContext, 0, CLSCTX_INPROC_SERVER,
+                                                    IID_IWbemContext, (LPVOID*)&pCtx));
+
+    if (contextUsable)
     {
-        return hres;
+        _variant_t var(static_cast<long>(maxWaitMs));
+        contextUsable = SUCCEEDED(pCtx->SetValue(L"__MAX_WAIT", 0, &var));
     }
 
-    _variant_t var(static_cast<long>(maxWaitMs));
-    hres = pCtx->SetValue(L"__MAX_WAIT", 0, &var);
-
-    if (FAILED(hres))
-    {
-        pCtx->Release();
-        return hres;
-    }
-
-    hres = pLoc->ConnectServer(_bstr_t(L"ROOT\\CIMV2"), NULL, NULL, NULL,
-                               WBEM_FLAG_CONNECT_USE_MAX_WAIT, NULL, pCtx, &pSvc);
-    pCtx->Release();
-    return hres;
+    const long connectFlags = contextUsable ? WBEM_FLAG_CONNECT_USE_MAX_WAIT : 0;
+    IWbemContext* const ctxArg = contextUsable ? pCtx : NULL;
+    return pLoc->ConnectServer(_bstr_t(L"ROOT\\CIMV2"), NULL, NULL, NULL,
+                               connectFlags, NULL, ctxArg, &pSvc);
 }
 
 HRESULT ComHelper::SetProxyBlanket(IWbemServices* pSvc)
@@ -120,35 +147,8 @@ std::string BstrToString(BSTR bstr)
     return converter.to_bytes(wstr);
 }
 
-namespace
-{
-    // Releases a COM interface pointer (if non-null) when it goes out of scope, once,
-    // from whichever throw site or normal return exits QueryWMIHotFixes. Centralizes the
-    // per-throw-site "if (p) p->Release();" pattern that used to be duplicated at every
-    // early-exit point in that function.
-    template <typename T>
-    class ComReleaseGuard
-    {
-        public:
-            explicit ComReleaseGuard(T*& ptr) : m_ptr(ptr) {}
-            ~ComReleaseGuard()
-            {
-                if (m_ptr)
-                {
-                    m_ptr->Release();
-                    m_ptr = nullptr;
-                }
-            }
-            ComReleaseGuard(const ComReleaseGuard&) = delete;
-            ComReleaseGuard& operator=(const ComReleaseGuard&) = delete;
-
-        private:
-            T*& m_ptr;
-    };
-}
-
-void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper,
-                      long perCallTimeoutMs, long overallTimeoutMs, long connectMaxWaitMs)
+void QueryWMIHotFixesBounded(std::set<std::string>& hotfixSet, IComHelper& comHelper,
+                             long perCallTimeoutMs, long overallTimeoutMs, long connectMaxWaitMs)
 {
     HRESULT hres;
     IWbemLocator* pLoc = NULL;
@@ -211,9 +211,12 @@ void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper,
         }
 
         // Clamp the per-call wait to whatever time remains so a single Next() call
-        // can never push total elapsed time past overallTimeoutMs.
+        // can never push total elapsed time past overallTimeoutMs. The millisecond
+        // truncation in duration_cast can round remainingMs down to 0 even though
+        // now < deadline still holds; per WMI's docs, Next(0, ...) is a non-blocking
+        // poll rather than a wait, so clamp to at least 1 ms to keep this an actual wait.
         const auto remainingMs = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now).count();
-        const long callTimeoutMs = static_cast<long>(std::min<long long>(perCallTimeoutMs, remainingMs));
+        const long callTimeoutMs = static_cast<long>(std::max<long long>(1, std::min<long long>(perCallTimeoutMs, remainingMs)));
 
         // Declared fresh each iteration so a provider that fails without touching
         // these out-params can't leave a stale, already-Release()'d pclsObj or a
@@ -261,6 +264,12 @@ void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper,
 
     // pLoc/pSvc/pEnumerator are released automatically by their guards on scope exit,
     // including the case where ExecuteWmiQuery reported success but left pEnumerator NULL.
+}
+
+void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper)
+{
+    QueryWMIHotFixesBounded(hotfixSet, comHelper, WMI_HOTFIX_NEXT_TIMEOUT_MS,
+                            WMI_HOTFIX_ENUM_OVERALL_TIMEOUT_MS, WMI_CONNECT_MAX_WAIT_MS);
 }
 
 ProcessCmdLine parseProcessCommandLine(const std::wstring& fullCmdLineW)

--- a/src/data_provider/src/utilsWrapperWin.cpp
+++ b/src/data_provider/src/utilsWrapperWin.cpp
@@ -39,9 +39,7 @@ HRESULT ComHelper::ConnectToWmiServer(IWbemLocator* pLoc, IWbemServices*& pSvc, 
         return hres;
     }
 
-    VARIANT var;
-    var.vt = VT_I4;
-    var.lVal = maxWaitMs;
+    _variant_t var(static_cast<long>(maxWaitMs));
     hres = pCtx->SetValue(L"__MAX_WAIT", 0, &var);
 
     if (FAILED(hres))
@@ -122,13 +120,47 @@ std::string BstrToString(BSTR bstr)
     return converter.to_bytes(wstr);
 }
 
+namespace
+{
+    // Releases a COM interface pointer (if non-null) when it goes out of scope, once,
+    // from whichever throw site or normal return exits QueryWMIHotFixes. Centralizes the
+    // per-throw-site "if (p) p->Release();" pattern that used to be duplicated at every
+    // early-exit point in that function.
+    template <typename T>
+    class ComReleaseGuard
+    {
+        public:
+            explicit ComReleaseGuard(T*& ptr) : m_ptr(ptr) {}
+            ~ComReleaseGuard()
+            {
+                if (m_ptr)
+                {
+                    m_ptr->Release();
+                    m_ptr = nullptr;
+                }
+            }
+            ComReleaseGuard(const ComReleaseGuard&) = delete;
+            ComReleaseGuard& operator=(const ComReleaseGuard&) = delete;
+
+        private:
+            T*& m_ptr;
+    };
+}
+
 void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper,
                       long perCallTimeoutMs, long overallTimeoutMs, long connectMaxWaitMs)
 {
     HRESULT hres;
     IWbemLocator* pLoc = NULL;
     IWbemServices* pSvc = NULL;
+    IEnumWbemClassObject* pEnumerator = NULL;
     std::ostringstream oss;
+
+    // Declared in this order so their destructors run in reverse (enumerator, then
+    // service, then locator) at every throw site and at normal function exit alike.
+    ComReleaseGuard<IWbemLocator> locatorGuard(pLoc);
+    ComReleaseGuard<IWbemServices> serviceGuard(pSvc);
+    ComReleaseGuard<IEnumWbemClassObject> enumeratorGuard(pEnumerator);
 
     hres = comHelper.CreateWmiLocator(pLoc);
 
@@ -142,8 +174,6 @@ void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper,
 
     if (FAILED(hres))
     {
-        if (pLoc) pLoc->Release();
-
         oss << "WMI: connection failed. Code: " << std::hex << hres;
         throw std::runtime_error(oss.str());
     }
@@ -152,23 +182,14 @@ void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper,
 
     if (FAILED(hres))
     {
-        if (pSvc) pSvc->Release();
-
-        if (pLoc) pLoc->Release();
-
         oss << "WMI: security error. Code: " << std::hex << hres;
         throw std::runtime_error(oss.str());
     }
 
-    IEnumWbemClassObject* pEnumerator = NULL;
     hres = comHelper.ExecuteWmiQuery(pSvc, pEnumerator);
 
     if (FAILED(hres))
     {
-        if (pLoc) pLoc->Release();
-
-        if (pSvc) pSvc->Release();
-
         oss << "WMI: query error. Code: " << std::hex << hres;
         throw std::runtime_error(oss.str());
     }
@@ -184,12 +205,6 @@ void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper,
 
         if (now >= deadline)
         {
-            pEnumerator->Release();
-
-            if (pSvc) pSvc->Release();
-
-            if (pLoc) pLoc->Release();
-
             oss << "WMI: hotfix enumeration did not respond within " << overallTimeoutMs
                 << " ms (Winmgmt unresponsive); aborting this cycle's hotfix collection.";
             throw std::runtime_error(oss.str());
@@ -216,12 +231,6 @@ void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper,
 
         if (FAILED(nextRes))
         {
-            pEnumerator->Release();
-
-            if (pSvc) pSvc->Release();
-
-            if (pLoc) pLoc->Release();
-
             oss << "WMI: hotfix enumeration failed. Code: " << std::hex << nextRes;
             throw std::runtime_error(oss.str());
         }
@@ -250,15 +259,8 @@ void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper,
         pclsObj->Release();
     }
 
-    pSvc->Release();
-    pLoc->Release();
-
-    // ExecuteWmiQuery may report success yet leave a NULL enumerator; guard the release
-    // to avoid dereferencing NULL on the syscollector scan thread.
-    if (pEnumerator)
-    {
-        pEnumerator->Release();
-    }
+    // pLoc/pSvc/pEnumerator are released automatically by their guards on scope exit,
+    // including the case where ExecuteWmiQuery reported success but left pEnumerator NULL.
 }
 
 ProcessCmdLine parseProcessCommandLine(const std::wstring& fullCmdLineW)

--- a/src/data_provider/src/utilsWrapperWin.cpp
+++ b/src/data_provider/src/utilsWrapperWin.cpp
@@ -15,6 +15,7 @@
 #include <stdexcept>      // For std::runtime_error
 #include <string>         // For std::string and std::wstring
 #include <locale>         // For localization utilities (if needed for string conversion)
+#include <chrono>         // For the bounded WMI enumeration wait (issue #38370)
 
 #include "utilsWrapperWin.hpp"
 #include <shellapi.h>
@@ -96,7 +97,8 @@ std::string BstrToString(BSTR bstr)
     return converter.to_bytes(wstr);
 }
 
-void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper)
+void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper,
+                       long perCallTimeoutMs, long overallTimeoutMs)
 {
     HRESULT hres;
     IWbemLocator* pLoc = NULL;
@@ -148,10 +150,32 @@ void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper)
 
     IWbemClassObject* pclsObj = NULL;
     ULONG uReturn = 0;
+    const auto enumStart = std::chrono::steady_clock::now();
 
     while (pEnumerator)
     {
-        pEnumerator->Next(WBEM_INFINITE, 1, &pclsObj, &uReturn);
+        const HRESULT nextRes = pEnumerator->Next(perCallTimeoutMs, 1, &pclsObj, &uReturn);
+
+        if (nextRes == WBEM_S_TIMEDOUT)
+        {
+            // No object was ready within perCallTimeoutMs -- Winmgmt is slow, not
+            // necessarily done enumerating. Keep retrying until overallTimeoutMs is
+            // exhausted (see #38370: previously WBEM_INFINITE let this block forever).
+            const auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                       std::chrono::steady_clock::now() - enumStart).count();
+
+            if (elapsedMs >= overallTimeoutMs)
+            {
+                pEnumerator->Release();
+                pSvc->Release();
+                pLoc->Release();
+                oss << "WMI: hotfix enumeration did not respond within " << overallTimeoutMs
+                    << " ms (Winmgmt unresponsive); aborting this cycle's hotfix collection.";
+                throw std::runtime_error(oss.str());
+            }
+
+            continue;
+        }
 
         if (0 == uReturn)
         {

--- a/src/data_provider/src/utilsWrapperWin.cpp
+++ b/src/data_provider/src/utilsWrapperWin.cpp
@@ -98,7 +98,7 @@ std::string BstrToString(BSTR bstr)
 }
 
 void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper,
-                       long perCallTimeoutMs, long overallTimeoutMs)
+                      long perCallTimeoutMs, long overallTimeoutMs)
 {
     HRESULT hres;
     IWbemLocator* pLoc = NULL;
@@ -148,8 +148,6 @@ void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper,
         throw std::runtime_error(oss.str());
     }
 
-    IWbemClassObject* pclsObj = NULL;
-    ULONG uReturn = 0;
     const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(overallTimeoutMs);
 
     while (pEnumerator)
@@ -162,8 +160,11 @@ void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper,
         if (now >= deadline)
         {
             pEnumerator->Release();
-            pSvc->Release();
-            pLoc->Release();
+
+            if (pSvc) pSvc->Release();
+
+            if (pLoc) pLoc->Release();
+
             oss << "WMI: hotfix enumeration did not respond within " << overallTimeoutMs
                 << " ms (Winmgmt unresponsive); aborting this cycle's hotfix collection.";
             throw std::runtime_error(oss.str());
@@ -174,6 +175,11 @@ void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper,
         const auto remainingMs = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now).count();
         const long callTimeoutMs = static_cast<long>(std::min<long long>(perCallTimeoutMs, remainingMs));
 
+        // Declared fresh each iteration so a provider that fails without touching
+        // these out-params can't leave a stale, already-Release()'d pclsObj or a
+        // stale nonzero uReturn behind from the previous iteration.
+        IWbemClassObject* pclsObj = NULL;
+        ULONG uReturn = 0;
         const HRESULT nextRes = pEnumerator->Next(callTimeoutMs, 1, &pclsObj, &uReturn);
 
         if (nextRes == WBEM_S_TIMEDOUT)
@@ -181,6 +187,18 @@ void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper,
             // No object was ready within callTimeoutMs -- Winmgmt is slow, not
             // necessarily done enumerating. Loop head re-checks the deadline.
             continue;
+        }
+
+        if (FAILED(nextRes))
+        {
+            pEnumerator->Release();
+
+            if (pSvc) pSvc->Release();
+
+            if (pLoc) pLoc->Release();
+
+            oss << "WMI: hotfix enumeration failed. Code: " << std::hex << nextRes;
+            throw std::runtime_error(oss.str());
         }
 
         if (0 == uReturn)

--- a/src/data_provider/src/utilsWrapperWin.hpp
+++ b/src/data_provider/src/utilsWrapperWin.hpp
@@ -84,10 +84,12 @@ constexpr long WMI_HOTFIX_NEXT_TIMEOUT_MS = 5000;
 // Cumulative ceiling (milliseconds) across the whole enumeration loop, enforced as an
 // absolute deadline: each IEnumWbemClassObject::Next() call is clamped to whatever time
 // remains, so total blocking time can never exceed this value regardless of whether
-// individual calls time out or keep succeeding without finishing. Comfortably under
-// stop_wmodules()'s 20 s join budget so this can never itself become the dominant cause
-// of a shutdown timeout.
-constexpr long WMI_HOTFIX_ENUM_OVERALL_TIMEOUT_MS = 15000;
+// individual calls time out or keep succeeding without finishing. Combined with
+// WMI_CONNECT_MAX_WAIT_MS, this bounds QueryWMIHotFixes to at most 12000 ms, leaving a
+// real ~8 s margin under stop_wmodules()'s 20 s join budget (src/win32/win_utils.c,
+// MODULE_JOIN_BUDGET_MS) -- that margin still has to absorb CreateWmiLocator,
+// SetProxyBlanket, and ExecuteWmiQuery, which remain unbounded (tracked as follow-up work).
+constexpr long WMI_HOTFIX_ENUM_OVERALL_TIMEOUT_MS = 9000;
 
 // Queries Windows Management Instrumentation (WMI) to retrieve installed hotfixes
 //  and stores them in the provided set. Bounded: gives up and throws std::runtime_error

--- a/src/data_provider/src/utilsWrapperWin.hpp
+++ b/src/data_provider/src/utilsWrapperWin.hpp
@@ -88,8 +88,8 @@ constexpr long WMI_HOTFIX_ENUM_OVERALL_TIMEOUT_MS = 15000;
 //  Default arguments are what production code should use; the timeout parameters exist
 //  so tests can exercise the timeout path without a real multi-second wait.
 EXPORTED void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper,
-                                long perCallTimeoutMs = WMI_HOTFIX_NEXT_TIMEOUT_MS,
-                                long overallTimeoutMs = WMI_HOTFIX_ENUM_OVERALL_TIMEOUT_MS);
+                               long perCallTimeoutMs = WMI_HOTFIX_NEXT_TIMEOUT_MS,
+                               long overallTimeoutMs = WMI_HOTFIX_ENUM_OVERALL_TIMEOUT_MS);
 
 
 // Queries Windows Update Agent (WUA) for installed update history,

--- a/src/data_provider/src/utilsWrapperWin.hpp
+++ b/src/data_provider/src/utilsWrapperWin.hpp
@@ -74,6 +74,9 @@ class EXPORTED ComHelper : public IComHelper
 // -- the same failure mode as the enumeration loop below, just one step earlier in the
 // same call chain (issue #38370). Enforced via WMI's own WBEM_FLAG_CONNECT_USE_MAX_WAIT
 // + an IWbemContext __MAX_WAIT property, not a detached watchdog thread.
+// This value has only been exercised against a healthy-and-fast WMI connect, not a
+// legitimately slow-but-not-hung one (e.g. shortly after a Winmgmt/CIM repository
+// rebuild); treat it as a provisional estimate until it's validated against that case.
 constexpr long WMI_CONNECT_MAX_WAIT_MS = 3000;
 
 // Per-call timeout passed to IEnumWbemClassObject::Next() (milliseconds) -- replaces
@@ -85,21 +88,31 @@ constexpr long WMI_HOTFIX_NEXT_TIMEOUT_MS = 5000;
 // absolute deadline: each IEnumWbemClassObject::Next() call is clamped to whatever time
 // remains, so total blocking time can never exceed this value regardless of whether
 // individual calls time out or keep succeeding without finishing. Combined with
-// WMI_CONNECT_MAX_WAIT_MS, this bounds QueryWMIHotFixes to at most 12000 ms, leaving a
-// real ~8 s margin under stop_wmodules()'s 20 s join budget (src/win32/win_utils.c,
-// MODULE_JOIN_BUDGET_MS) -- that margin still has to absorb CreateWmiLocator,
-// SetProxyBlanket, and ExecuteWmiQuery, which remain unbounded (tracked as follow-up work).
+// WMI_CONNECT_MAX_WAIT_MS, this bounds only 2 of the 5 blocking WMI/COM calls in this
+// chain to at most 12000 ms total. CreateWmiLocator, SetProxyBlanket, and
+// ExecuteWmiQuery remain fully unbounded (tracked as follow-up work) and can, on their
+// own, still consume all of stop_wmodules()'s 20 s join budget (src/win32/win_utils.c,
+// MODULE_JOIN_BUDGET_MS) -- this narrows issue #38370's reproduction window rather than
+// closing it.
+// This ceiling has only been exercised against a healthy-and-fast enumeration (a
+// handful of hotfixes, no load); a host with a large hotfix count or under load could
+// legitimately take longer to enumerate than this even with a fully responsive
+// Winmgmt. Treat it as a provisional estimate until it's validated against that case.
 constexpr long WMI_HOTFIX_ENUM_OVERALL_TIMEOUT_MS = 9000;
 
 // Queries Windows Management Instrumentation (WMI) to retrieve installed hotfixes
-//  and stores them in the provided set. Bounded: gives up and throws std::runtime_error
-//  if Winmgmt does not respond within overallTimeoutMs, instead of blocking forever.
-//  Default arguments are what production code should use; the timeout parameters exist
-//  so tests can exercise the timeout path without a real multi-second wait.
-EXPORTED void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper,
-                               long perCallTimeoutMs = WMI_HOTFIX_NEXT_TIMEOUT_MS,
-                               long overallTimeoutMs = WMI_HOTFIX_ENUM_OVERALL_TIMEOUT_MS,
-                               long connectMaxWaitMs = WMI_CONNECT_MAX_WAIT_MS);
+// and stores them in the provided set. Bounded: gives up and throws std::runtime_error
+// if Winmgmt does not respond within overallTimeoutMs, instead of blocking forever.
+// Not EXPORTED -- not part of sysinfo.dll's public ABI -- so the timeout parameters
+// stay a whitebox test seam (the unit test target compiles this translation unit
+// directly, see tests/sysInfoWin/CMakeLists.txt) rather than a permanent public knob.
+// Production code should call QueryWMIHotFixes() below instead.
+void QueryWMIHotFixesBounded(std::set<std::string>& hotfixSet, IComHelper& comHelper,
+                             long perCallTimeoutMs, long overallTimeoutMs, long connectMaxWaitMs);
+
+// Production entry point: same as QueryWMIHotFixesBounded() above, fixed to the
+// production timeout constants.
+EXPORTED void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper);
 
 
 // Queries Windows Update Agent (WUA) for installed update history,

--- a/src/data_provider/src/utilsWrapperWin.hpp
+++ b/src/data_provider/src/utilsWrapperWin.hpp
@@ -74,11 +74,12 @@ class EXPORTED ComHelper : public IComHelper
 // syscollector worker thread forever (issue #38370).
 constexpr long WMI_HOTFIX_NEXT_TIMEOUT_MS = 5000;
 
-// Cumulative ceiling (milliseconds) across the whole enumeration loop: a Winmgmt that
-// answers just slowly enough to always return within WMI_HOTFIX_NEXT_TIMEOUT_MS on each
-// individual call, but never actually finishes, would otherwise still block forever one
-// bounded call at a time. Comfortably under stop_wmodules()'s 20 s join budget so this
-// can never itself become the dominant cause of a shutdown timeout.
+// Cumulative ceiling (milliseconds) across the whole enumeration loop, enforced as an
+// absolute deadline: each IEnumWbemClassObject::Next() call is clamped to whatever time
+// remains, so total blocking time can never exceed this value regardless of whether
+// individual calls time out or keep succeeding without finishing. Comfortably under
+// stop_wmodules()'s 20 s join budget so this can never itself become the dominant cause
+// of a shutdown timeout.
 constexpr long WMI_HOTFIX_ENUM_OVERALL_TIMEOUT_MS = 15000;
 
 // Queries Windows Management Instrumentation (WMI) to retrieve installed hotfixes

--- a/src/data_provider/src/utilsWrapperWin.hpp
+++ b/src/data_provider/src/utilsWrapperWin.hpp
@@ -38,7 +38,7 @@ class EXPORTED IComHelper
 
         // Abstracted methods for WMI functions
         virtual HRESULT CreateWmiLocator(IWbemLocator*& pLoc) = 0;
-        virtual HRESULT ConnectToWmiServer(IWbemLocator* pLoc, IWbemServices*& pSvc) = 0;
+        virtual HRESULT ConnectToWmiServer(IWbemLocator* pLoc, IWbemServices*& pSvc, long maxWaitMs) = 0;
         virtual HRESULT SetProxyBlanket(IWbemServices* pSvc) = 0;
         virtual HRESULT ExecuteWmiQuery(IWbemServices* pSvc, IEnumWbemClassObject*& pEnumerator) = 0;
 
@@ -56,7 +56,7 @@ class EXPORTED ComHelper : public IComHelper
     public:
         // Implement WMI functions
         HRESULT CreateWmiLocator(IWbemLocator*& pLoc) override;
-        HRESULT ConnectToWmiServer(IWbemLocator* pLoc, IWbemServices*& pSvc) override;
+        HRESULT ConnectToWmiServer(IWbemLocator* pLoc, IWbemServices*& pSvc, long maxWaitMs) override;
         HRESULT SetProxyBlanket(IWbemServices* pSvc) override;
         HRESULT ExecuteWmiQuery(IWbemServices* pSvc, IEnumWbemClassObject*& pEnumerator) override;
 
@@ -68,6 +68,13 @@ class EXPORTED ComHelper : public IComHelper
         HRESULT GetItem(IUpdateHistoryEntryCollection* pHistory, LONG index, IUpdateHistoryEntry** pEntry) override;
         HRESULT GetTitle(IUpdateHistoryEntry* pEntry, BSTR& title) override;
 };
+
+// Bounds ComHelper::ConnectToWmiServer's IWbemLocator::ConnectServer() call, which has
+// no timeout parameter of its own and can block indefinitely if Winmgmt is unresponsive
+// -- the same failure mode as the enumeration loop below, just one step earlier in the
+// same call chain (issue #38370). Enforced via WMI's own WBEM_FLAG_CONNECT_USE_MAX_WAIT
+// + an IWbemContext __MAX_WAIT property, not a detached watchdog thread.
+constexpr long WMI_CONNECT_MAX_WAIT_MS = 3000;
 
 // Per-call timeout passed to IEnumWbemClassObject::Next() (milliseconds) -- replaces
 // the previous WBEM_INFINITE, which let a slow/unresponsive Winmgmt block the
@@ -89,7 +96,8 @@ constexpr long WMI_HOTFIX_ENUM_OVERALL_TIMEOUT_MS = 15000;
 //  so tests can exercise the timeout path without a real multi-second wait.
 EXPORTED void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper,
                                long perCallTimeoutMs = WMI_HOTFIX_NEXT_TIMEOUT_MS,
-                               long overallTimeoutMs = WMI_HOTFIX_ENUM_OVERALL_TIMEOUT_MS);
+                               long overallTimeoutMs = WMI_HOTFIX_ENUM_OVERALL_TIMEOUT_MS,
+                               long connectMaxWaitMs = WMI_CONNECT_MAX_WAIT_MS);
 
 
 // Queries Windows Update Agent (WUA) for installed update history,

--- a/src/data_provider/src/utilsWrapperWin.hpp
+++ b/src/data_provider/src/utilsWrapperWin.hpp
@@ -69,9 +69,26 @@ class EXPORTED ComHelper : public IComHelper
         HRESULT GetTitle(IUpdateHistoryEntry* pEntry, BSTR& title) override;
 };
 
+// Per-call timeout passed to IEnumWbemClassObject::Next() (milliseconds) -- replaces
+// the previous WBEM_INFINITE, which let a slow/unresponsive Winmgmt block the
+// syscollector worker thread forever (issue #38370).
+constexpr long WMI_HOTFIX_NEXT_TIMEOUT_MS = 5000;
+
+// Cumulative ceiling (milliseconds) across the whole enumeration loop: a Winmgmt that
+// answers just slowly enough to always return within WMI_HOTFIX_NEXT_TIMEOUT_MS on each
+// individual call, but never actually finishes, would otherwise still block forever one
+// bounded call at a time. Comfortably under stop_wmodules()'s 20 s join budget so this
+// can never itself become the dominant cause of a shutdown timeout.
+constexpr long WMI_HOTFIX_ENUM_OVERALL_TIMEOUT_MS = 15000;
+
 // Queries Windows Management Instrumentation (WMI) to retrieve installed hotfixes
-//  and stores them in the provided set.
-EXPORTED void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper);
+//  and stores them in the provided set. Bounded: gives up and throws std::runtime_error
+//  if Winmgmt does not respond within overallTimeoutMs, instead of blocking forever.
+//  Default arguments are what production code should use; the timeout parameters exist
+//  so tests can exercise the timeout path without a real multi-second wait.
+EXPORTED void QueryWMIHotFixes(std::set<std::string>& hotfixSet, IComHelper& comHelper,
+                                long perCallTimeoutMs = WMI_HOTFIX_NEXT_TIMEOUT_MS,
+                                long overallTimeoutMs = WMI_HOTFIX_ENUM_OVERALL_TIMEOUT_MS);
 
 
 // Queries Windows Update Agent (WUA) for installed update history,

--- a/src/data_provider/tests/sysInfoWin/sysInfoWin_test.cpp
+++ b/src/data_provider/tests/sysInfoWin/sysInfoWin_test.cpp
@@ -204,6 +204,35 @@ TEST_F(SysInfoWinTest, WmiHotfixEnumerationTimeoutThrows)
                  std::runtime_error);
 }
 
+// Regression test: a hard COM failure from Next() (e.g. a dropped remote WMI transport
+// mid-enumeration) must make QueryWMIHotFixes give up and throw immediately, not fall
+// through to the uReturn==0 check with stale state from a prior iteration.
+TEST_F(SysInfoWinTest, WmiHotfixEnumerationNextFailureThrows)
+{
+    MockComHelper mockComHelper;
+    MockEnumWbemClassObject mockEnum;
+    std::set<std::string> hotfixSet;
+
+    EXPECT_CALL(mockComHelper, CreateWmiLocator(testing::_))
+    .WillOnce(testing::Return(S_OK));
+
+    EXPECT_CALL(mockComHelper, ConnectToWmiServer(testing::_, testing::_))
+    .WillOnce(testing::Return(S_OK));
+
+    EXPECT_CALL(mockComHelper, SetProxyBlanket(testing::_))
+    .WillOnce(testing::Return(S_OK));
+
+    EXPECT_CALL(mockComHelper, ExecuteWmiQuery(testing::_, testing::_))
+    .WillOnce(testing::DoAll(
+                  testing::SetArgReferee<1>(&mockEnum),
+                  testing::Return(S_OK)));
+
+    EXPECT_CALL(mockEnum, Next(testing::_, testing::_, testing::_, testing::_))
+    .WillOnce(testing::Return(WBEM_E_TRANSPORT_FAILURE));
+
+    EXPECT_THROW(QueryWMIHotFixes(hotfixSet, mockComHelper), std::runtime_error);
+}
+
 TEST_F(SysInfoWinTest, WmiPopulatesWMIHotfixSetCorrectly)
 {
     std::set<std::string> hotfixSet;

--- a/src/data_provider/tests/sysInfoWin/sysInfoWin_test.cpp
+++ b/src/data_provider/tests/sysInfoWin/sysInfoWin_test.cpp
@@ -200,7 +200,8 @@ TEST_F(SysInfoWinTest, WmiHotfixEnumerationTimeoutThrows)
     EXPECT_CALL(mockEnum, Next(testing::_, testing::_, testing::_, testing::_))
     .WillRepeatedly(testing::Return(WBEM_S_TIMEDOUT));
 
-    EXPECT_THROW(QueryWMIHotFixes(hotfixSet, mockComHelper, /*perCallTimeoutMs*/ 1, /*overallTimeoutMs*/ 5),
+    EXPECT_THROW(QueryWMIHotFixesBounded(hotfixSet, mockComHelper, /*perCallTimeoutMs*/ 1, /*overallTimeoutMs*/ 5,
+                                         WMI_CONNECT_MAX_WAIT_MS),
                  std::runtime_error);
 }
 

--- a/src/data_provider/tests/sysInfoWin/sysInfoWin_test.cpp
+++ b/src/data_provider/tests/sysInfoWin/sysInfoWin_test.cpp
@@ -126,7 +126,7 @@ TEST_F(SysInfoWinTest, WmiConnectToWmiServerFailure)
     EXPECT_CALL(mockComHelper, CreateWmiLocator(testing::_))
     .WillOnce(testing::Return(S_OK));
 
-    EXPECT_CALL(mockComHelper, ConnectToWmiServer(testing::_, testing::_))
+    EXPECT_CALL(mockComHelper, ConnectToWmiServer(testing::_, testing::_, testing::_))
     .WillOnce(testing::Return(E_FAIL));
 
     EXPECT_THROW(QueryWMIHotFixes(hotfixSet, mockComHelper), std::runtime_error);
@@ -140,7 +140,7 @@ TEST_F(SysInfoWinTest, WmiSetProxyBlanket)
     EXPECT_CALL(mockComHelper, CreateWmiLocator(testing::_))
     .WillOnce(testing::Return(S_OK));
 
-    EXPECT_CALL(mockComHelper, ConnectToWmiServer(testing::_, testing::_))
+    EXPECT_CALL(mockComHelper, ConnectToWmiServer(testing::_, testing::_, testing::_))
     .WillOnce(testing::Return(S_OK));
 
     EXPECT_CALL(mockComHelper, SetProxyBlanket(testing::_))
@@ -157,7 +157,7 @@ TEST_F(SysInfoWinTest, WmiExecuteQuery)
     EXPECT_CALL(mockComHelper, CreateWmiLocator(testing::_))
     .WillOnce(testing::Return(S_OK));
 
-    EXPECT_CALL(mockComHelper, ConnectToWmiServer(testing::_, testing::_))
+    EXPECT_CALL(mockComHelper, ConnectToWmiServer(testing::_, testing::_, testing::_))
     .WillOnce(testing::Return(S_OK));
 
     EXPECT_CALL(mockComHelper, SetProxyBlanket(testing::_))
@@ -183,7 +183,7 @@ TEST_F(SysInfoWinTest, WmiHotfixEnumerationTimeoutThrows)
     EXPECT_CALL(mockComHelper, CreateWmiLocator(testing::_))
     .WillOnce(testing::Return(S_OK));
 
-    EXPECT_CALL(mockComHelper, ConnectToWmiServer(testing::_, testing::_))
+    EXPECT_CALL(mockComHelper, ConnectToWmiServer(testing::_, testing::_, testing::_))
     .WillOnce(testing::Return(S_OK));
 
     EXPECT_CALL(mockComHelper, SetProxyBlanket(testing::_))
@@ -216,7 +216,7 @@ TEST_F(SysInfoWinTest, WmiHotfixEnumerationNextFailureThrows)
     EXPECT_CALL(mockComHelper, CreateWmiLocator(testing::_))
     .WillOnce(testing::Return(S_OK));
 
-    EXPECT_CALL(mockComHelper, ConnectToWmiServer(testing::_, testing::_))
+    EXPECT_CALL(mockComHelper, ConnectToWmiServer(testing::_, testing::_, testing::_))
     .WillOnce(testing::Return(S_OK));
 
     EXPECT_CALL(mockComHelper, SetProxyBlanket(testing::_))

--- a/src/data_provider/tests/sysInfoWin/sysInfoWin_test.cpp
+++ b/src/data_provider/tests/sysInfoWin/sysInfoWin_test.cpp
@@ -169,6 +169,41 @@ TEST_F(SysInfoWinTest, WmiExecuteQuery)
     EXPECT_THROW(QueryWMIHotFixes(hotfixSet, mockComHelper), std::runtime_error);
 }
 
+// Regression test for issue #38370: a Winmgmt that never signals end-of-enumeration
+// (previously: Next(WBEM_INFINITE, ...) blocking the syscollector worker thread forever)
+// must make QueryWMIHotFixes give up and throw once the overall ceiling is exceeded,
+// not hang. Tiny timeouts keep this test fast instead of waiting on the multi-second
+// production defaults.
+TEST_F(SysInfoWinTest, WmiHotfixEnumerationTimeoutThrows)
+{
+    MockComHelper mockComHelper;
+    MockEnumWbemClassObject mockEnum;
+    std::set<std::string> hotfixSet;
+
+    EXPECT_CALL(mockComHelper, CreateWmiLocator(testing::_))
+    .WillOnce(testing::Return(S_OK));
+
+    EXPECT_CALL(mockComHelper, ConnectToWmiServer(testing::_, testing::_))
+    .WillOnce(testing::Return(S_OK));
+
+    EXPECT_CALL(mockComHelper, SetProxyBlanket(testing::_))
+    .WillOnce(testing::Return(S_OK));
+
+    EXPECT_CALL(mockComHelper, ExecuteWmiQuery(testing::_, testing::_))
+    .WillOnce(testing::DoAll(
+                  testing::SetArgReferee<1>(&mockEnum),
+                  testing::Return(S_OK)));
+
+    // Every call times out with no object ready -- never signals completion
+    // (uReturn == 0 with a non-timeout HRESULT), so the only way out is the new
+    // cumulative-elapsed-time ceiling.
+    EXPECT_CALL(mockEnum, Next(testing::_, testing::_, testing::_, testing::_))
+    .WillRepeatedly(testing::Return(WBEM_S_TIMEDOUT));
+
+    EXPECT_THROW(QueryWMIHotFixes(hotfixSet, mockComHelper, /*perCallTimeoutMs*/ 1, /*overallTimeoutMs*/ 5),
+                 std::runtime_error);
+}
+
 TEST_F(SysInfoWinTest, WmiPopulatesWMIHotfixSetCorrectly)
 {
     std::set<std::string> hotfixSet;

--- a/src/data_provider/tests/sysInfoWin/sysInfoWin_test.h
+++ b/src/data_provider/tests/sysInfoWin/sysInfoWin_test.h
@@ -32,7 +32,7 @@ class MockComHelper : public IComHelper
 {
     public:
         MOCK_METHOD(HRESULT, CreateWmiLocator, (IWbemLocator*& pLoc), (override));
-        MOCK_METHOD(HRESULT, ConnectToWmiServer, (IWbemLocator* pLoc, IWbemServices*& pSvc), (override));
+        MOCK_METHOD(HRESULT, ConnectToWmiServer, (IWbemLocator* pLoc, IWbemServices*& pSvc, long maxWaitMs), (override));
         MOCK_METHOD(HRESULT, SetProxyBlanket, (IWbemServices* pSvc), (override));
         MOCK_METHOD(HRESULT, ExecuteWmiQuery, (IWbemServices* pSvc, IEnumWbemClassObject*& pEnumerator), (override));
         MOCK_METHOD(HRESULT, CreateUpdateSearcher, (IUpdateSearcher*& pUpdateSearcher), (override));

--- a/src/data_provider/tests/sysInfoWin/sysInfoWin_test.h
+++ b/src/data_provider/tests/sysInfoWin/sysInfoWin_test.h
@@ -60,16 +60,37 @@ class MockEnumWbemClassObject : public IEnumWbemClassObject
 
             return E_NOTIMPL;
         }
-        ULONG STDMETHODCALLTYPE AddRef() override { return 1; }
-        ULONG STDMETHODCALLTYPE Release() override { return 1; }
+        ULONG STDMETHODCALLTYPE AddRef() override
+        {
+            return 1;
+        }
+        ULONG STDMETHODCALLTYPE Release() override
+        {
+            return 1;
+        }
 
         // IEnumWbemClassObject -- only Next() is exercised by QueryWMIHotFixes.
+        // Calltype(STDMETHODCALLTYPE) is required: IEnumWbemClassObject::Next is declared
+        // STDMETHODCALLTYPE (__stdcall), and without a matching call type here the mock's
+        // override has a conflicting calling convention -- a hard compile error under mingw.
         MOCK_METHOD(HRESULT, Next, (long lTimeout, ULONG uCount, IWbemClassObject** apObjects, ULONG* puReturned),
-                    (override));
-        HRESULT STDMETHODCALLTYPE NextAsync(ULONG, IWbemObjectSink*) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE Clone(IEnumWbemClassObject**) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE Skip(long, ULONG) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE Reset() override { return E_NOTIMPL; }
+                    (Calltype(STDMETHODCALLTYPE), override));
+        HRESULT STDMETHODCALLTYPE NextAsync(ULONG, IWbemObjectSink*) override
+        {
+            return E_NOTIMPL;
+        }
+        HRESULT STDMETHODCALLTYPE Clone(IEnumWbemClassObject**) override
+        {
+            return E_NOTIMPL;
+        }
+        HRESULT STDMETHODCALLTYPE Skip(long, ULONG) override
+        {
+            return E_NOTIMPL;
+        }
+        HRESULT STDMETHODCALLTYPE Reset() override
+        {
+            return E_NOTIMPL;
+        }
 };
 
 

--- a/src/data_provider/tests/sysInfoWin/sysInfoWin_test.h
+++ b/src/data_provider/tests/sysInfoWin/sysInfoWin_test.h
@@ -43,5 +43,34 @@ class MockComHelper : public IComHelper
         MOCK_METHOD(HRESULT, GetTitle, (IUpdateHistoryEntry* pEntry, BSTR& title), (override));
 };
 
+// IComHelper::ExecuteWmiQuery hands back a raw IEnumWbemClassObject*, so exercising
+// QueryWMIHotFixes' enumeration loop (in particular the #38370 bounded-timeout path)
+// needs a fake of that COM interface itself, not just of IComHelper.
+class MockEnumWbemClassObject : public IEnumWbemClassObject
+{
+    public:
+        // IUnknown -- trivial stubs; refcounting/QI behavior is irrelevant to these tests,
+        // and this instance's lifetime is owned by the test, not COM.
+        HRESULT STDMETHODCALLTYPE QueryInterface(REFIID, void** ppvObject) override
+        {
+            if (ppvObject)
+            {
+                *ppvObject = nullptr;
+            }
+
+            return E_NOTIMPL;
+        }
+        ULONG STDMETHODCALLTYPE AddRef() override { return 1; }
+        ULONG STDMETHODCALLTYPE Release() override { return 1; }
+
+        // IEnumWbemClassObject -- only Next() is exercised by QueryWMIHotFixes.
+        MOCK_METHOD(HRESULT, Next, (long lTimeout, ULONG uCount, IWbemClassObject** apObjects, ULONG* puReturned),
+                    (override));
+        HRESULT STDMETHODCALLTYPE NextAsync(ULONG, IWbemObjectSink*) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE Clone(IEnumWbemClassObject**) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE Skip(long, ULONG) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE Reset() override { return E_NOTIMPL; }
+};
+
 
 #endif //_SYSINFO_WIN_TEST_H


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

On Windows, `scanHotfixes()`'s WMI query (`QueryWMIHotFixes()`, `src/data_provider/src/utilsWrapperWin.cpp`) called `IEnumWbemClassObject::Next()` with `WBEM_INFINITE` — no timeout at all. If `Winmgmt` (the WMI service) is slow or busy when syscollector's worker thread reaches the hotfixes task, the thread parks there indefinitely, unreachable by the module's own stop flag. When the agent is stopped while that call is still blocked, `wm_sys_stop()`'s 10s internal wait and then `stop_wmodules()`'s 20s join budget (`src/win32/win_utils.c`) both expire waiting on a thread that cannot respond, producing the reported `ERROR: Module 'syscollector' worker thread did not exit within the 20000 ms shutdown budget`. The abandoned thread's still-open SQLite/dbsync handles are the most likely source of the related `database is locked` / `cannot commit transaction` errors (#38372/#38373) seen on the *next* process's startup, and the same 20s-budget mechanism affecting other modules (e.g. `agent-info`) explains #38371.

Closes #38370

Related: #38371, #38372, #38373 (same root-cause family, per the investigation comment on #38370). Sibling PR #38400 fixes a different, independent contributing cause (an untimed flush wait in `releaseResources()` double-charging the shutdown budget) and explicitly defers this WMI call as follow-up work — this PR is that follow-up, scoped narrowly to avoid touching the same files.

## Proposed Changes

- `QueryWMIHotFixes()` (`src/data_provider/src/utilsWrapperWin.cpp`/`.hpp`) now calls `pEnumerator->Next()` with a bounded per-call timeout (`WMI_HOTFIX_NEXT_TIMEOUT_MS`, 5000ms) instead of `WBEM_INFINITE`, enforced against an absolute deadline (`WMI_HOTFIX_ENUM_OVERALL_TIMEOUT_MS`, 15000ms from enumeration start) that is re-checked at the top of every loop iteration — not only when a call times out — and each individual `Next()` call is clamped to whatever time remains until that deadline. This closes a gap in an earlier iteration of this fix where the deadline was only checked inside the `WBEM_S_TIMEDOUT` branch: a `Winmgmt` that kept returning objects successfully without ever finishing enumeration (never itself timing out) could otherwise still block past the ceiling one successful call at a time. Once the deadline passes, it releases its COM objects and throws `std::runtime_error` instead of continuing to block.
- No change needed in `syscollectorImp.cpp`/`scanHotfixes()`: `SysInfo::getHotfixes()` (`sysInfoWin.cpp`) already wraps this call in a silent `catch (...)` that falls through to registry-based hotfix collection — once the WMI call throws instead of hanging, that existing fallback handles it exactly as intended.
- `QueryWUHotFixes()` (the Windows-Update-history path, same class of problem) is deliberately left out of scope — it has no native timeout parameter at all, and bounding it safely would need the same thread-lifecycle discipline as the #38111/#38241 fix (a naive "spawn a thread and give up waiting" risks reintroducing that access-violation bug class). Flagged as a separate follow-up.
- Added `SysInfoWinTest.WmiHotfixEnumerationTimeoutThrows` (`src/data_provider/tests/sysInfoWin/sysInfoWin_test.cpp`), with a new `MockEnumWbemClassObject : public IEnumWbemClassObject` (`sysInfoWin_test.h`) whose `Next()` always returns `WBEM_S_TIMEDOUT`, asserting `QueryWMIHotFixes()` throws `std::runtime_error` within the (test-shortened) bound instead of hanging.
- `QueryWMIHotFixes()` now explicitly checks `FAILED(nextRes)` after each `Next()` call and throws immediately (with the specific `HRESULT`) on a hard COM/WMI failure (e.g. `WBEM_E_TRANSPORT_FAILURE`), instead of silently falling through to the `uReturn==0` check as before. Covered by `SysInfoWinTest.WmiHotfixEnumerationNextFailureThrows`.
- `ComHelper::ConnectToWmiServer()` now also bounds `IWbemLocator::ConnectServer()` itself — the same failure mode as the enumeration loop, just one step earlier in the same call chain, and previously entirely unbounded. Enforced via WMI's own `WBEM_FLAG_CONNECT_USE_MAX_WAIT` plus an `IWbemContext` `__MAX_WAIT` property (new `WMI_CONNECT_MAX_WAIT_MS`, 3000ms) rather than a detached watchdog thread. Combined with the enumeration ceiling (now `WMI_HOTFIX_ENUM_OVERALL_TIMEOUT_MS` = 9000ms, reduced from 15000ms to make room), `QueryWMIHotFixes()` is now bounded to at most 12000ms total — a real ~8s margin under `stop_wmodules()`'s 20s join budget. `CreateWmiLocator`, `SetProxyBlanket`, and `ExecuteWmiQuery` remain unbounded and are tracked as follow-up work (documented inline at the `WMI_HOTFIX_ENUM_OVERALL_TIMEOUT_MS` definition).
- Introduced `ComReleaseGuard<T>`, a small RAII wrapper releasing a COM interface pointer (if non-null) exactly once on scope exit. Replaces the repeated `if (p) p->Release();` at every throw site in `QueryWMIHotFixes()` with three guard declarations at the top of the function (destructed in reverse declaration order: enumerator, then service, then locator), covering every throw site and the normal-return path uniformly. Pure cleanup, no behavior change.
- Manual-VARIANT construction for the `__MAX_WAIT` context property (`ConnectToWmiServer`) replaced with `_variant_t`, matching this file's existing use of the ATL/COM support wrapper types elsewhere.
- `ConnectToWmiServer()` no longer fails hotfix collection outright if creating/configuring the `IWbemContext` object itself fails: it now falls back to the pre-existing unbounded `ConnectServer()` call (dropping `WBEM_FLAG_CONNECT_USE_MAX_WAIT`) instead, since that COM/WMI registration failure is an unrelated concern from Winmgmt being hung and shouldn't become a hard new dependency.
- `QueryWMIHotFixes()` is now the fixed-arguments `EXPORTED` production entry point (no timeout parameters, so it's no longer part of the public ABI's tunable surface); the parameterized version used by tests is a separate, non-exported `QueryWMIHotFixesBounded()` — a whitebox test seam rather than a permanent public knob.
- Fixed a rounding edge case in the per-call clamp: millisecond truncation could round the remaining time down to exactly `0` even while `now < deadline` still held, and WMI treats `Next(0, ...)` as a non-blocking poll rather than an actual wait. The clamp now floors at `1`.
- Two of the new constants' doc comments were revised to be explicit that they're provisional/unvalidated estimates (not yet exercised against a slow-but-not-hung WMI connect, nor a host with a large hotfix count under load), and that only 2 of the 5 blocking WMI/COM calls in this chain are now bounded — `CreateWmiLocator`, `SetProxyBlanket`, and `ExecuteWmiQuery` remain fully unbounded, so this narrows #38370's reproduction window rather than closing it outright.

### Results and Evidence

**Reproduced before the fix** — two independent lines of evidence:

1. **Live, real-world occurrence** on a real AWS-hosted Windows 11 host (`agent-windows-11-amd64`) running an unpatched 5.0.0 nightly, captured entirely from that host's own `ossec.log` during its normal deployability-testing install/restart cycle — no synthetic manipulation. Three separate syscollector process instances got stuck in `hotfixes` and never recovered:

   | Syscollector PID | Starting hotfixes scan | Ending hotfixes scan | Stop signal received | 20s shutdown-budget ERROR |
   |---|---|---|---|---|
   | 5852 | 07:06:57 | never | 07:06:58 (+1s) | 07:07:15 |
   | 3884 | 07:07:19 | never | 07:08:04 (+45s) | 07:08:24 |
   | 1740 | 07:08:51 | never | 07:11:36 (+165s) | 07:11:46 |

   PID `1740`'s shutdown independently produced all four issues in the family together:
   ```
   2026/08/19 07:08:51 wazuh-modulesd:syscollector[1740] ... DEBUG: Starting hotfixes scan
   2026/08/19 07:11:25 wazuh-modulesd:agent-info[1740] wm_agent_info.c:212 ...: WARNING: Timeout waiting for AgentInfo run loop to exit; skipping database teardown.
   2026/08/19 07:11:35 wazuh-agent[1740] win_utils.c:135 at stop_wmodules(): ERROR: Module 'agent-info' worker thread did not exit within the 20000 ms shutdown budget; shutdown will proceed while it may still be running.
   2026/08/19 07:11:36 wazuh-agent[1740] win_utils.c:135 at stop_wmodules(): ERROR: Module 'sca' worker thread did not exit within the 20000 ms shutdown budget; shutdown will proceed while it may still be running.
   2026/08/19 07:11:36 wazuh-modulesd:syscollector[1740] wm_syscollector.c:795 at wm_sys_stop(): INFO: Stop received for Syscollector.
   2026/08/19 07:11:46 wazuh-modulesd:syscollector[1740] wm_syscollector.c:822 at wm_sys_stop(): INFO: Syscollector did not confirm shutdown within 10 seconds; releasing resources and continuing.
   2026/08/19 07:11:46 wazuh-agent[1740] win_utils.c:135 at stop_wmodules(): ERROR: Module 'syscollector' worker thread did not exit within the 20000 ms shutdown budget; shutdown will proceed while it may still be running.
   ```
   Across the full capture window: 5 shutdown-budget `ERROR`s, 1 `AgentInfo` timeout `WARNING`, 78 `database is locked`, 6 `cannot commit transaction` — the full #38370/#38371/#38372/#38373 family, entirely unforced.

2. **Isolated, standalone A/B binaries** (not linked against the wazuh-agent codebase at all — same COM/WMI call sequence extracted into two minimal console programs, one with `WBEM_INFINITE`, one with the bounded-timeout fix) confirm the two implementations are behaviorally and timing-identical when WMI is healthy (20 runs each, ~980ms avg, no measurable difference) — the divergence is specifically gated on WMI actually stalling, not on repetition or load alone.

**Verified after the fix**, on the *same real AWS host*, across four separate builds from this branch as it evolved:

- Commit `5014d00e0d` (initial fix + test): 1 install + 5 rapid `Restart-Service` cycles, 6 syscollector process instances, all completed `hotfixes` in 1-2s, zero `stop_wmodules()` shutdown-budget `ERROR`s (one unrelated `AgentInfo` `WARNING` was the only hit out of the same 5-signature search that returned 93 hits before the fix), zero `database is locked`/`cannot commit transaction` errors.
- Commit `55fa0d2d86` (hardened to an absolute, every-iteration deadline check + the `FAILED(nextRes)` hard-failure check, see Proposed Changes): same test repeated end to end (fresh install over the previous build + 5 rapid `Restart-Service` cycles), 6 more syscollector process instances:

  ```
  PID 4256: Starting hotfixes scan 15:03:59 -> Ending hotfixes scan 15:04:01  (2s)
  PID 6596: Starting hotfixes scan 15:04:22 -> Ending hotfixes scan 15:04:23  (1s)
  PID 9508: Starting hotfixes scan 15:04:30 -> Ending hotfixes scan 15:04:31  (1s)
  PID 3856: Starting hotfixes scan 15:04:38 -> Ending hotfixes scan 15:04:39  (1s)
  PID 4088: Starting hotfixes scan 15:04:46 -> Ending hotfixes scan 15:04:47  (1s)
  PID 5280: Starting hotfixes scan 15:04:54 -> Ending hotfixes scan 15:04:55  (1s)
  ```

  6/6 clean completions, **zero** hits at all out of the same 5-signature search (not even the one unrelated `AgentInfo` `WARNING` seen on the previous commit's run).

- Commit `b155756d87` (adds the `WMI_CONNECT_MAX_WAIT_MS` connect-step bounding and the `ComReleaseGuard`/`_variant_t` cleanup, see Proposed Changes): same test repeated again (fresh install over the previous build + 5 rapid `Restart-Service` cycles), 6 more syscollector process instances:

  ```
  PID 10444: Starting hotfixes scan 19:22:45 -> Ending hotfixes scan 19:22:47  (2s)
  PID 8572:  Starting hotfixes scan 19:23:32 -> Ending hotfixes scan 19:23:34  (2s)
  PID 10332: Starting hotfixes scan 19:23:41 -> Ending hotfixes scan 19:23:42  (1s)
  PID 7312:  Starting hotfixes scan 19:23:49 -> Ending hotfixes scan 19:23:50  (1s)
  PID 4472:  Starting hotfixes scan 19:23:57 -> Ending hotfixes scan 19:23:58  (1s)
  PID 12948: Starting hotfixes scan 19:24:05 -> Ending hotfixes scan 19:24:06  (1s)
  ```

  6/6 clean completions, again **zero** hits out of the 5-signature search.

- Commit `99544f4388` (current HEAD — adds the `QueryWMIHotFixes`/`QueryWMIHotFixesBounded` ABI split, the `IWbemContext`-creation fallback, and the remaining-time-clamped-to-1ms rounding fix, see Proposed Changes): same test repeated a third time, 6 more syscollector process instances:

  ```
  PID 10272: Starting hotfixes scan 04:34:39 -> Ending hotfixes scan 04:34:41  (2s)
  PID 8508:  Starting hotfixes scan 04:35:00 -> Ending hotfixes scan 04:35:02  (2s)
  PID 8700:  Starting hotfixes scan 04:35:09 -> Ending hotfixes scan 04:35:10  (1s)
  PID 9628:  Starting hotfixes scan 04:35:17 -> Ending hotfixes scan 04:35:18  (1s)
  PID 12340: Starting hotfixes scan 04:35:24 -> Ending hotfixes scan 04:35:26  (2s)
  PID 3224:  Starting hotfixes scan 04:35:34 -> Ending hotfixes scan 04:35:35  (1s)
  ```

  6/6 clean completions, again **zero** hits out of the 5-signature search.

24/24 clean completions total across all four builds, zero shutdown-budget `ERROR`s in any run. Note the same honest caveat applies to all four: `hotfixes` completed unusually fast every time (1-2s, vs. up to 16s in the best pre-fix case) — WMI simply wasn't under enough contention during any of these runs for a restart to land mid-scan (nor slow enough to exercise the new connect-step bounding, the hard-failure check, or the context-creation fallback), so none of these passes exercised the new bounded-retry/throw code paths themselves (those paths are what `SysInfoWinTest.WmiHotfixEnumerationTimeoutThrows` and `WmiHotfixEnumerationNextFailureThrows` cover directly, deterministically, via the mock). What these real-host runs confirm is a clean non-regression across all four iterations of the fix: the same install+restart pattern that reliably broke on this exact host before the fix now completes without error every time, on every commit tested.

### Manual tests with their corresponding evidence

Live functional verification on a real AWS-hosted Windows 11 host — before/after comparison of the exact same install+restart cycle, plus isolated standalone-binary A/B timing (see above) — rather than the specific tooling listed below; please run/confirm the applicable ones before merge.

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

Note: a Windows agent package was built from this branch through the project's standard package-build pipeline and completed successfully, producing an installable `.msi` that was installed and run on a real host — this confirms the branch compiles, links, and runs correctly for Windows, but build-warning output was not specifically audited, so "Compilation without warnings" is left unchecked pending that review.

### Artifacts Affected

- `sysinfo.dll` (Windows `data_provider` library) — houses the changed `QueryWMIHotFixes()`/`QueryWMIHotFixesBounded()` logic.
- `wazuh-agent.exe` / the syscollector module inside the Windows agent package — calls the bounded query during every hotfixes inventory scan.
- Windows agent installer package (`.msi`) — rebuilt and manually verified for this fix; no other platform's package output changes (this code path is Windows-only).

### Configuration Changes

N/A — no configuration parameters were added, removed, or changed. The three new timeout constants (`WMI_HOTFIX_NEXT_TIMEOUT_MS`, `WMI_HOTFIX_ENUM_OVERALL_TIMEOUT_MS`, `WMI_CONNECT_MAX_WAIT_MS`) are compile-time, not user-configurable.

### Tests Introduced

Added `SysInfoWinTest.WmiHotfixEnumerationTimeoutThrows` (`src/data_provider/tests/sysInfoWin/sysInfoWin_test.cpp`), with a new `MockEnumWbemClassObject : public IEnumWbemClassObject` (`sysInfoWin_test.h`) whose mocked `Next()` always returns `WBEM_S_TIMEDOUT`. Asserts `QueryWMIHotFixesBounded()` throws `std::runtime_error` within a test-shortened bound rather than hanging — this deterministically exercises the retry/ceiling logic itself (the part the real-host runs above did not happen to trigger), independent of actual WMI timing.

Also added `SysInfoWinTest.WmiHotfixEnumerationNextFailureThrows`, using the same mock with `Next()` returning `WBEM_E_TRANSPORT_FAILURE` instead, asserting the hard-COM-failure path also throws immediately rather than falling through to the `uReturn==0` check.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
