### PR TITLE
Address first-party Coverity findings

### DIFF
--- a/src/client-agent/https_client/src/fileCompressor.cpp
+++ b/src/client-agent/https_client/src/fileCompressor.cpp
@@ -64,7 +64,9 @@ std::optional<std::pair<std::unique_ptr<SpoolFile>, uint64_t>>
     if (!dest)
     {
         closeExclusiveTempFile(destFd); // fdopen() failed: the fd is still ours to close.
-        std::remove(destPath.c_str());
+        // Best-effort cleanup on every error path below (CID 562795): a failed remove()
+        // just leaves a stale temp file behind, nothing worth failing the caller over.
+        (void)std::remove(destPath.c_str());
         return std::nullopt; // LCOV_EXCL_LINE: fdopen() on a just-opened fd doesn't fail in practice.
     }
 
@@ -72,7 +74,7 @@ std::optional<std::pair<std::unique_ptr<SpoolFile>, uint64_t>>
 
     if (cctx == nullptr)
     {
-        std::remove(destPath.c_str());
+        (void)std::remove(destPath.c_str());
         return std::nullopt; // LCOV_EXCL_LINE: allocation failure only.
     }
 
@@ -81,7 +83,7 @@ std::optional<std::pair<std::unique_ptr<SpoolFile>, uint64_t>>
     if (ZSTD_isError(ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, kCompressionLevel)) ||
             ZSTD_isError(ZSTD_CCtx_setPledgedSrcSize(cctx, sourceSize)))
     {
-        std::remove(destPath.c_str());
+        (void)std::remove(destPath.c_str());
         return std::nullopt; // LCOV_EXCL_LINE: cannot fail on a freshly created CCtx.
     }
 
@@ -111,7 +113,7 @@ std::optional<std::pair<std::unique_ptr<SpoolFile>, uint64_t>>
     {
         if (abortFlag != nullptr && abortFlag->load())
         {
-            std::remove(destPath.c_str());
+            (void)std::remove(destPath.c_str());
             return std::nullopt;
         }
 
@@ -124,7 +126,7 @@ std::optional<std::pair<std::unique_ptr<SpoolFile>, uint64_t>>
 
             if (ZSTD_isError(ret) || !flushOutput(output))
             {
-                std::remove(destPath.c_str());
+                (void)std::remove(destPath.c_str());
                 return std::nullopt;
             }
         }
@@ -132,7 +134,7 @@ std::optional<std::pair<std::unique_ptr<SpoolFile>, uint64_t>>
 
     if (std::ferror(source.get()))
     {
-        std::remove(destPath.c_str());
+        (void)std::remove(destPath.c_str());
         return std::nullopt;
     }
 
@@ -150,7 +152,7 @@ std::optional<std::pair<std::unique_ptr<SpoolFile>, uint64_t>>
 
         if (ZSTD_isError(remaining) || !flushOutput(output))
         {
-            std::remove(destPath.c_str());
+            (void)std::remove(destPath.c_str());
             return std::nullopt;
         }
     }

--- a/src/client-agent/https_client/src/fileCompressor.cpp
+++ b/src/client-agent/https_client/src/fileCompressor.cpp
@@ -64,8 +64,6 @@ std::optional<std::pair<std::unique_ptr<SpoolFile>, uint64_t>>
     if (!dest)
     {
         closeExclusiveTempFile(destFd); // fdopen() failed: the fd is still ours to close.
-        // Best-effort cleanup on every error path below (CID 562795): a failed remove()
-        // just leaves a stale temp file behind, nothing worth failing the caller over.
         (void)std::remove(destPath.c_str());
         return std::nullopt; // LCOV_EXCL_LINE: fdopen() on a just-opened fd doesn't fail in practice.
     }

--- a/src/shared/src/file_op.c
+++ b/src/shared/src/file_op.c
@@ -2657,9 +2657,6 @@ FILE * w_fopen_nofollow(const char * basedir, const char * filename, const char 
 
     // O_NONBLOCK has no effect on a regular file, but the stream is expected to behave like fopen's.
     if (flags = fcntl(fd, F_GETFL), flags != -1) {
-        // Best-effort (CID 562796): failure here would just leave O_NONBLOCK set on a
-        // regular file, which has no observable effect on the stdio stream fdopen() builds
-        // below, so there is nothing to fail this call over.
         (void)fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
     }
 

--- a/src/shared/src/file_op.c
+++ b/src/shared/src/file_op.c
@@ -2657,7 +2657,10 @@ FILE * w_fopen_nofollow(const char * basedir, const char * filename, const char 
 
     // O_NONBLOCK has no effect on a regular file, but the stream is expected to behave like fopen's.
     if (flags = fcntl(fd, F_GETFL), flags != -1) {
-        fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
+        // Best-effort (CID 562796): failure here would just leave O_NONBLOCK set on a
+        // regular file, which has no observable effect on the stdio stream fdopen() builds
+        // below, so there is nothing to fail this call over.
+        (void)fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
     }
 
     if (fp = fdopen(fd, mode), fp == NULL) {

--- a/src/wazuh_modules/syscollector/include/syscollector.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector.hpp
@@ -431,9 +431,6 @@ class EXPORTED Syscollector final
 
         AgentdQueryFunc                                                          m_agentdQuery;
         unsigned int                                                             m_intervalValue;
-        // Written under m_resourcesMutex (initSyncProtocol), read without any lock from the
-        // recovery path (runRecoveryProcess/recoveryIntervalHasEllapsed) -- atomic instead of
-        // adding a lock there, to avoid a new cross-mutex dependency (CID 562797).
         std::atomic<uint32_t>                                                    m_integrityIntervalValue;
         bool                                                                     m_scanOnStart;
         bool                                                                     m_hardware;
@@ -454,9 +451,6 @@ class EXPORTED Syscollector final
         bool                                                                     m_users;
         bool                                                                     m_services;
         bool                                                                     m_browserExtensions;
-        // Written under m_scan_mutex (init) and under m_resourcesMutex (initSyncProtocol), read
-        // without any lock from handleNotifyDataClean -- atomic instead of picking one of the
-        // two mutexes (which would leave the other writer still racing) (CID 562800/562799).
         std::atomic<unsigned int>                                                m_dataCleanRetries;
         std::atomic<bool>                                                        m_allCollectorsDisabled;
         bool                                                                     m_vdSyncEnabled;

--- a/src/wazuh_modules/syscollector/include/syscollector.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector.hpp
@@ -431,7 +431,10 @@ class EXPORTED Syscollector final
 
         AgentdQueryFunc                                                          m_agentdQuery;
         unsigned int                                                             m_intervalValue;
-        uint32_t                                                                 m_integrityIntervalValue;
+        // Written under m_resourcesMutex (initSyncProtocol), read without any lock from the
+        // recovery path (runRecoveryProcess/recoveryIntervalHasEllapsed) -- atomic instead of
+        // adding a lock there, to avoid a new cross-mutex dependency (CID 562797).
+        std::atomic<uint32_t>                                                    m_integrityIntervalValue;
         bool                                                                     m_scanOnStart;
         bool                                                                     m_hardware;
         bool                                                                     m_os;
@@ -451,8 +454,11 @@ class EXPORTED Syscollector final
         bool                                                                     m_users;
         bool                                                                     m_services;
         bool                                                                     m_browserExtensions;
-        unsigned int                                                             m_dataCleanRetries;
-        bool                                                                     m_allCollectorsDisabled;
+        // Written under m_scan_mutex (init) and under m_resourcesMutex (initSyncProtocol), read
+        // without any lock from handleNotifyDataClean -- atomic instead of picking one of the
+        // two mutexes (which would leave the other writer still racing) (CID 562800/562799).
+        std::atomic<unsigned int>                                                m_dataCleanRetries;
+        std::atomic<bool>                                                        m_allCollectorsDisabled;
         bool                                                                     m_vdSyncEnabled;
         std::unique_ptr<DBSync>                                                  m_spDBSync;
         std::condition_variable                                                  m_cv;

--- a/src/wazuh_modules/syscollector/include/syscollector.hpp
+++ b/src/wazuh_modules/syscollector/include/syscollector.hpp
@@ -296,6 +296,14 @@ class EXPORTED Syscollector final
         bool recoveryIntervalHasEllapsed(const std::string& tableName, int64_t integrityInterval);
 
         /**
+         * @brief Get the configured document limit for a given index, thread-safely.
+         *
+         * @param index Index name to look up (e.g. "wazuh-states-inventory-packages").
+         * @return The configured limit, or 0 if unlimited/not configured.
+         */
+        size_t getDocumentLimit(const std::string& index);
+
+        /**
          * @brief Validates a JSON message against schema and logs validation errors
          *
          * This helper function encapsulates the common pattern of schema validation

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -503,6 +503,14 @@ void Syscollector::init(const std::shared_ptr<ISysInfo>& spInfo,
                         const bool browserExtensions,
                         const bool notifyOnFirstScan)
 {
+    auto dbSync = std::make_unique<DBSync>(HostType::AGENT, DbEngineType::SQLITE3, dbPath, getCreateStatement(), DbManagement::PERSISTENT);
+    auto normalizer = std::make_unique<SysNormalizer>(normalizerConfigPath, normalizerType);
+
+    // Locked from here on (CID 562800): scanHardware()/scanOs()/.../runRecoveryProcess()
+    // read these same fields while the scan/recovery paths hold m_scan_mutex, so every write
+    // below has to happen under it too, not just the ones that used to follow this point.
+    std::unique_lock<std::mutex> lock{m_scan_mutex};
+
     m_spInfo = spInfo;
     m_reportDiffFunction = std::move(reportDiffFunction);
     m_persistDiffFunction = std::move(persistDiffFunction);
@@ -522,11 +530,6 @@ void Syscollector::init(const std::shared_ptr<ISysInfo>& spInfo,
     m_users = users;
     m_services = services;
     m_browserExtensions = browserExtensions;
-
-    auto dbSync = std::make_unique<DBSync>(HostType::AGENT, DbEngineType::SQLITE3, dbPath, getCreateStatement(), DbManagement::PERSISTENT);
-    auto normalizer = std::make_unique<SysNormalizer>(normalizerConfigPath, normalizerType);
-
-    std::unique_lock<std::mutex> lock{m_scan_mutex};
     m_stopping = false;
 
     m_spDBSync      = std::move(dbSync);
@@ -4543,7 +4546,12 @@ bool Syscollector::checkIfFullSyncRequired(const std::string& tableName)
     if (indexIt != INDEX_MAP.end())
     {
         const std::string& index = indexIt->second;
-        size_t documentLimit = m_documentLimits[index];
+        size_t documentLimit = 0;
+        {
+            // m_documentLimits is written under m_limitsMutex by setDocumentLimits() (CID 562797).
+            std::lock_guard<std::mutex> limitsLock(m_limitsMutex);
+            documentLimit = m_documentLimits[index];
+        }
 
         if (documentLimit > 0)
         {
@@ -4781,7 +4789,12 @@ void Syscollector::runRecoveryProcess()
                 // Determine if we need to filter by sync=1
                 // Only filter when document limits are configured (limit > 0)
                 // If limit == 0 (unlimited), recover all items without filtering
-                size_t documentLimit = m_documentLimits[index];
+                size_t documentLimit = 0;
+                {
+                    // m_documentLimits is written under m_limitsMutex by setDocumentLimits() (CID 562797).
+                    std::lock_guard<std::mutex> limitsLock(m_limitsMutex);
+                    documentLimit = m_documentLimits[index];
+                }
                 std::string rowFilterClause;
 
                 try

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -506,9 +506,6 @@ void Syscollector::init(const std::shared_ptr<ISysInfo>& spInfo,
     auto dbSync = std::make_unique<DBSync>(HostType::AGENT, DbEngineType::SQLITE3, dbPath, getCreateStatement(), DbManagement::PERSISTENT);
     auto normalizer = std::make_unique<SysNormalizer>(normalizerConfigPath, normalizerType);
 
-    // Locked from here on (CID 562800): scanHardware()/scanOs()/.../runRecoveryProcess()
-    // read these same fields while the scan/recovery paths hold m_scan_mutex, so every write
-    // below has to happen under it too, not just the ones that used to follow this point.
     std::unique_lock<std::mutex> lock{m_scan_mutex};
 
     m_spInfo = spInfo;
@@ -4548,7 +4545,6 @@ bool Syscollector::checkIfFullSyncRequired(const std::string& tableName)
         const std::string& index = indexIt->second;
         size_t documentLimit = 0;
         {
-            // m_documentLimits is written under m_limitsMutex by setDocumentLimits() (CID 562797).
             std::lock_guard<std::mutex> limitsLock(m_limitsMutex);
             documentLimit = m_documentLimits[index];
         }
@@ -4791,7 +4787,6 @@ void Syscollector::runRecoveryProcess()
                 // If limit == 0 (unlimited), recover all items without filtering
                 size_t documentLimit = 0;
                 {
-                    // m_documentLimits is written under m_limitsMutex by setDocumentLimits() (CID 562797).
                     std::lock_guard<std::mutex> limitsLock(m_limitsMutex);
                     documentLimit = m_documentLimits[index];
                 }

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -2587,7 +2587,11 @@ std::vector<nlohmann::json> Syscollector::fetchAllFromTable(const std::string& t
         else if (indexIt != INDEX_MAP.end())
         {
             const std::string& index = indexIt->second;
-            size_t documentLimit = m_documentLimits[index];
+            size_t documentLimit = 0;
+            {
+                std::lock_guard<std::mutex> limitsLock(m_limitsMutex);
+                documentLimit = m_documentLimits[index];
+            }
 
             if (documentLimit > 0)
             {

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -2587,11 +2587,7 @@ std::vector<nlohmann::json> Syscollector::fetchAllFromTable(const std::string& t
         else if (indexIt != INDEX_MAP.end())
         {
             const std::string& index = indexIt->second;
-            size_t documentLimit = 0;
-            {
-                std::lock_guard<std::mutex> limitsLock(m_limitsMutex);
-                documentLimit = m_documentLimits[index];
-            }
+            size_t documentLimit = getDocumentLimit(index);
 
             if (documentLimit > 0)
             {
@@ -4534,6 +4530,12 @@ void Syscollector::clearTablesForIndices(const std::vector<std::string>& indices
     }
 }
 
+size_t Syscollector::getDocumentLimit(const std::string& index)
+{
+    std::lock_guard<std::mutex> limitsLock(m_limitsMutex);
+    return m_documentLimits[index];
+}
+
 // LCOV_EXCL_START
 bool Syscollector::checkIfFullSyncRequired(const std::string& tableName)
 {
@@ -4547,11 +4549,7 @@ bool Syscollector::checkIfFullSyncRequired(const std::string& tableName)
     if (indexIt != INDEX_MAP.end())
     {
         const std::string& index = indexIt->second;
-        size_t documentLimit = 0;
-        {
-            std::lock_guard<std::mutex> limitsLock(m_limitsMutex);
-            documentLimit = m_documentLimits[index];
-        }
+        size_t documentLimit = getDocumentLimit(index);
 
         if (documentLimit > 0)
         {
@@ -4789,11 +4787,7 @@ void Syscollector::runRecoveryProcess()
                 // Determine if we need to filter by sync=1
                 // Only filter when document limits are configured (limit > 0)
                 // If limit == 0 (unlimited), recover all items without filtering
-                size_t documentLimit = 0;
-                {
-                    std::lock_guard<std::mutex> limitsLock(m_limitsMutex);
-                    documentLimit = m_documentLimits[index];
-                }
+                size_t documentLimit = getDocumentLimit(index);
                 std::string rowFilterClause;
 
                 try


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Fixes the 5 first-party Coverity findings from #38462 (new findings surfaced by a follow-up
5.0.0-HTTPS validation scan, after #38397 closed out the original 16 from #38323): two
unchecked-return-value findings, and three data races in the Syscollector module.

The other 38 findings in #38462 are in bundled third-party `zstd` code and are out of scope for
this PR.

Closes #38462.

## Proposed Changes

### Unchecked-return-value fixes

- **`ZstdFileCompressor::compress()`** (CID 562795): every error path in this function calls
  `std::remove(destPath.c_str())` to clean up the partially-written temp file (7 call sites),
  ignoring the return value. Wrapped each in `(void)`, matching the idiom already used elsewhere
  in this module (`syncIntake.cpp`) -- a failed `remove()` here just leaves a stale temp file
  behind, nothing worth failing the caller over.

- **`w_fopen_nofollow()`** (CID 562796): the POSIX branch calls `fcntl(fd, F_SETFL, ...)` to clear
  `O_NONBLOCK` before handing the descriptor to `fdopen()`, ignoring the return value. Wrapped in
  `(void)` -- a failure here would just leave `O_NONBLOCK` set on a regular file, which has no
  observable effect once wrapped in a stdio `FILE*`.

### Data race fixes (`syscollectorImp.cpp`)

Three related, real races (not false positives) around configuration state shared between the
scan/recovery threads and whichever thread calls `init()`/`initSyncProtocol()`:

- **CID 562799 / 562800**: `m_dataCleanRetries` and `m_allCollectorsDisabled` were written under
  `m_scan_mutex` in `init()` **and** under a different mutex (`m_resourcesMutex`) in
  `initSyncProtocol()`, then read under no lock at all in `handleNotifyDataClean()`. Two
  unrelated mutexes guarding the same variable is not real mutual exclusion. Made both
  `std::atomic`, mirroring the pattern this class already uses for `m_stopping`.

- **CID 562797**: `m_integrityIntervalValue` had the same problem -- written under
  `m_resourcesMutex` in `initSyncProtocol()`, read with no lock in `runRecoveryProcess()`. Same
  fix: made it `std::atomic`.

- **CID 562797 (continued)**: `m_documentLimits` (a `std::map`, already correctly guarded by
  `m_limitsMutex` in `setDocumentLimits()`/`promoteItemsAfterScan()`) was read without that lock
  in both `runRecoveryProcess()` and the `checkIfFullSyncRequired()` it calls. Added
  `std::lock_guard<std::mutex>` around both reads.

- **CID 562800 (continued)**: `init()` wrote several scan-config fields (`m_hardware`, `m_os`,
  `m_network`, ..., `m_reportDiffFunction`, `m_logFunction`, `m_intervalValue`, `m_scanOnStart`)
  *before* acquiring `m_scan_mutex`, while `scanHardware()`/`scanOs()`/`runRecoveryProcess()`/etc.
  read those same fields while the scan/recovery path holds that mutex. Moved the lock
  acquisition to the top of `init()` so every write happens under it (the two `std::make_unique`
  calls that don't touch shared state were moved ahead of the lock instead, so nothing expensive
  runs while it's held).

None of these change behavior on the non-racing path: same values, same threads, only the
synchronization discipline around them changed.

### Results and Evidence

No writable local build directory was available (the existing one was root-owned from an earlier
session) to do a full incremental build. Verified instead by extracting the exact compiler
invocations `cmake` generates for each touched file from `compile_commands.json` (same include
paths, defines, and warning flags -- `-Wall -Wextra -Wshadow -Wnon-virtual-dtor
-Woverloaded-virtual -Wunused -Wcast-align`, plus `-Wformat=2` for `syscollectorImp.cpp`) and
running each with `-fsyntax-only`:

- `src/client-agent/https_client/src/fileCompressor.cpp`: compiles clean. One pre-existing
  warning unrelated to this change (`-Wignored-attributes` on an untouched line) is still present.
- `src/shared/src/file_op.c`: compiles clean, zero warnings.
- `src/wazuh_modules/syscollector/src/syscollectorImp.cpp`: compiles clean, zero warnings.
- `src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp` (existing test
  file, exercises `init()`/`handleNotifyDataClean()`/`runRecoveryProcess()`): also compiles clean
  against the updated header -- the atomic-type changes don't break any existing test.
- Grepped the rest of the repo for the three renamed-to-atomic members
  (`m_integrityIntervalValue`, `m_dataCleanRetries`, `m_allCollectorsDisabled`): all uses are
  confined to `syscollectorImp.cpp`/`.hpp` and are simple reads/assignments (no
  reference-passing, no compound-assignment operators), so the type change is safe everywhere
  it's used.

This branch's CI has since run a real build and the Legacy Unit Test suites on Linux, Windows and
macOS (agent and manager targets), plus the `syscollector`/`https_client` RTR jobs and the
`agentd`/`enrollment`/`syscollector` integration tests, all green -- satisfying the "real build"
and "tests actually run" items below.

**Fresh Coverity re-scan (2026-08-20):** confirms all 5 first-party CIDs from #38462 are resolved
-- each reports `status="Fixed"` and `comparison="Absent"` against the prior scan:

| CID | Function | File | Status |
|---|---|---|---|
| 562795 | `compress` (all 7 call sites) | `fileCompressor.cpp` | Fixed / Absent |
| 562796 | `w_fopen_nofollow` | `file_op.c` | Fixed / Absent |
| 562797 | `runRecoveryProcess` | `syscollectorImp.cpp` | Fixed / Absent |
| 562799 | `handleNotifyDataClean` | `syscollectorImp.cpp` | Fixed / Absent |
| 562800 | `init` | `syscollectorImp.cpp` | Fixed / Absent |

None of the pre-merge verification items previously listed here remain outstanding.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [x] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_: N/A -- no decoder/rule changes.

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine -- particularly relevant here: TSAN is the tool most
        likely to independently confirm the three `syscollectorImp.cpp` races are real and
        closed by this PR.

- Wazuh server API/Framework: N/A -- agent-side code only.

### Artifacts Affected

- `wazuh-agent` executable (the `https_client` static library it links, and `libwazuh`/`shared`
  via `file_op.c`).
- `wazuh-modulesd` (the `syscollector` shared module).

No new binaries, no packaging changes.

### Configuration Changes

N/A -- no new/changed configuration parameters. `m_integrityIntervalValue`, `m_dataCleanRetries`
and `m_allCollectorsDisabled` change C++ type only (`std::atomic<...>` instead of the plain type);
they are private members with no external callers.

### Tests Introduced

None added. The two unchecked-return-value fixes are behavior-preserving by construction (the
ignored return values were already never checked). The three data-race fixes close timing
windows that aren't deterministically reproducible in a unit test without dedicated timing
hooks; a TSAN run against the existing Syscollector test suite (called out above) is the more
meaningful signal for these.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->

