### PR TITLE
Fix Windows module threads created after shutdown

### DIFF
--- a/src/logcollector/src/main.c
+++ b/src/logcollector/src/main.c
@@ -192,7 +192,10 @@ int main(int argc, char **argv)
         merror_exit(QUEUE_FATAL, DEFAULTQUEUE);
     }
 
-    startup_gate_wait_for_ready(ARGV0);
+    if (startup_gate_wait_for_ready(ARGV0) != STARTUP_GATE_READY) {
+        mdebug1("'%s' shutdown requested while waiting for the startup gate; exiting without starting.", ARGV0);
+        exit(0);
+    }
 
     /* Main loop */
     LogCollectorStart();

--- a/src/os_execd/src/execd.c
+++ b/src/os_execd/src/execd.c
@@ -662,7 +662,9 @@ int WinExecdStart()
 
 // Create a thread to run windows AR simultaneous
 DWORD WINAPI win_exec_main(__attribute__((unused)) void * args) {
-    startup_gate_wait_for_ready("wazuh-execd");
+    if (startup_gate_wait_for_ready("wazuh-execd") != STARTUP_GATE_READY) {
+        return 0;
+    }
 
     while(1) {
         char* exec_msg = queue_pop_ex(winexec_queue);

--- a/src/os_execd/src/main.c
+++ b/src/os_execd/src/main.c
@@ -172,7 +172,10 @@ int main(int argc, char **argv)
         merror_exit(QUEUE_ERROR, EXECQUEUE, strerror(errno));
     }
 
-    startup_gate_wait_for_ready(ARGV0);
+    if (startup_gate_wait_for_ready(ARGV0) != STARTUP_GATE_READY) {
+        mdebug1("'%s' shutdown requested while waiting for the startup gate; exiting without starting.", ARGV0);
+        exit(0);
+    }
 
     // STARTUP_MSG is emitted after the startup hash gate releases. The
     // previous order logged "wazuh-execd: INFO: Started" before the gate

--- a/src/shared/include/startup_gate_op.h
+++ b/src/shared/include/startup_gate_op.h
@@ -12,12 +12,30 @@
 #define STARTUP_GATE_OP_H
 
 /**
+ * @brief Why startup_gate_wait_for_ready() returned.
+ *
+ * A caller MUST check this before running its module's actual start routine:
+ * STARTUP_GATE_SHUTDOWN_REQUESTED means a shutdown is already in progress, and
+ * the module must abort its startup cleanly instead of starting (issue 38428
+ * - previously the gate released on shutdown exactly as if it had opened
+ * normally, with no way for the caller to tell the two apart).
+ */
+typedef enum startup_gate_wait_result {
+    STARTUP_GATE_READY = 0,             /**< Gate opened normally; proceed with startup. */
+    STARTUP_GATE_SHUTDOWN_REQUESTED = 1 /**< Shutdown already in progress; abort startup, do not run the module. */
+} startup_gate_wait_result_t;
+
+/**
  * @brief Block a daemon startup until agentd startup hash validation is ready.
  *
- * This function is a no-op when startup hash blocking is disabled.
+ * This function is a no-op (always returns STARTUP_GATE_READY) when startup
+ * hash blocking is disabled, or on a non-CLIENT (manager) build.
  *
  * @param module_name Daemon name for logs.
+ * @return STARTUP_GATE_READY if the caller should proceed with its normal
+ *         startup, or STARTUP_GATE_SHUTDOWN_REQUESTED if a shutdown is
+ *         already in progress and the caller must abort cleanly instead.
  */
-void startup_gate_wait_for_ready(const char *module_name);
+startup_gate_wait_result_t startup_gate_wait_for_ready(const char *module_name);
 
 #endif /* STARTUP_GATE_OP_H */

--- a/src/shared/src/startup_gate_op.c
+++ b/src/shared/src/startup_gate_op.c
@@ -111,7 +111,7 @@ static bool startup_gate_query_status(bool *ready, char *reason, size_t reason_s
 // wazuh_modules/ - the type must match the original declaration exactly.
 extern volatile sig_atomic_t wm_shutdown_requested;
 
-void startup_gate_wait_for_ready(const char *module_name) {
+startup_gate_wait_result_t startup_gate_wait_for_ready(const char *module_name) {
 #if defined(CLIENT)
     bool waiting_logged = false;
     unsigned int waiting_loops = 0;
@@ -125,8 +125,8 @@ void startup_gate_wait_for_ready(const char *module_name) {
         char reason[OS_SIZE_128] = {0};
 
         if (wm_shutdown_requested) {
-            mdebug1("Startup hash gate: shutdown requested, releasing '%s' without waiting for handshake.", name);
-            return;
+            mdebug1("Startup hash gate: shutdown requested, aborting startup for '%s' without waiting for handshake.", name);
+            return STARTUP_GATE_SHUTDOWN_REQUESTED;
         }
 
         got_status = startup_gate_query_status(&ready, reason, sizeof(reason));
@@ -138,7 +138,7 @@ void startup_gate_wait_for_ready(const char *module_name) {
              * gate release itself is real either way, only the audit trail
              * for it was missing. */
             mdebug1("Startup hash gate released for '%s' (%s).", name, reason[0] ? reason : "unknown");
-            return;
+            return STARTUP_GATE_READY;
         }
 
         should_log = !waiting_logged || (waiting_loops % STARTUP_GATE_LOG_INTERVAL == 0);
@@ -162,5 +162,6 @@ void startup_gate_wait_for_ready(const char *module_name) {
     }
 #else
     (void)module_name;
+    return STARTUP_GATE_READY;
 #endif
 }

--- a/src/syscheckd/src/main.c
+++ b/src/syscheckd/src/main.c
@@ -356,7 +356,10 @@ int main(int argc, char **argv)
         merror_exit(PID_ERROR);
     }
 
-    startup_gate_wait_for_ready(ARGV0);
+    if (startup_gate_wait_for_ready(ARGV0) != STARTUP_GATE_READY) {
+        mdebug1("'%s' shutdown requested while waiting for the startup gate; exiting without starting.", ARGV0);
+        exit(0);
+    }
 
     // Rootcheck initialization is deferred until after the startup hash
     // gate releases. rootcheck_init() emits STARTUP_MSG ("wazuh-rootcheck:

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -184,6 +184,15 @@ else()
 list(APPEND shared_tests_flags " ")
 endif()
 
+list(APPEND shared_tests_names "test_startup_gate_op")
+if(${TARGET} STREQUAL "winagent")
+list(APPEND shared_tests_flags "-Wl,--wrap,syscom_dispatch -Wl,--wrap,Start_win32_Syscheck \
+                                -Wl,--wrap=is_fim_shutdown -Wl,--wrap=_imp__dbsync_initialize \
+                                -Wl,--wrap=fim_db_teardown ${DEBUG_OP_WRAPPERS}")
+else()
+list(APPEND shared_tests_flags "${DEBUG_OP_WRAPPERS}")
+endif()
+
 list(APPEND shared_tests_names "test_utf8_op")
 if(${TARGET} STREQUAL "winagent")
 list(APPEND shared_tests_flags "-Wl,--wrap,syscom_dispatch -Wl,--wrap,Start_win32_Syscheck \
@@ -411,6 +420,16 @@ foreach(counter RANGE ${count})
             ${SRC_FOLDER}/shared/src/read-alert.c
             ${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/debug_op_wrappers.c
         )
+    endif()
+
+    # startup_gate_wait_for_ready()'s real logic only exists under #if
+    # defined(CLIENT) (shared/src/startup_gate_op.c) -- CLIENT isn't defined
+    # globally in this standalone unit_tests project the way it is in the
+    # main build (src/CMakeLists.txt), so it must be added here explicitly
+    # for agent/winagent, matching how the real agent/winagent build compiles
+    # this file. Left undefined for manager, exercising the no-op fallback.
+    if("${test_name}" STREQUAL "test_startup_gate_op" AND NOT ${TARGET} STREQUAL "manager")
+        target_compile_definitions(${test_name} PRIVATE CLIENT)
     endif()
 
     if(${TARGET} STREQUAL "manager")

--- a/src/unit_tests/shared/test_startup_gate_op.c
+++ b/src/unit_tests/shared/test_startup_gate_op.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <signal.h>
+
+#include "../wrappers/common.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+#include "startup_gate_op.h"
+
+/* startup_gate_wait_for_ready() is only meaningful on a CLIENT (agent) build;
+ * on a manager build it must stay the no-op it always was. */
+#if defined(CLIENT)
+
+/* Real definition lives in wazuh_modules/src/wmodules.c. On agent/manager
+ * this test binary doesn't link that object, so it provides its own stand-in
+ * -- exactly what stop_wmodules()/local_start() flip in the real agent
+ * (issue 38428). winagent's unit tests all link a monolithic aggregate of the
+ * main build's object files (see winagent.cmake's DEPENDENCIES_O), which
+ * already pulls in the real definition -- a second one here would conflict
+ * with it at link time, so just reuse it. */
+#if defined(TEST_WINAGENT)
+extern volatile sig_atomic_t wm_shutdown_requested;
+#else
+volatile sig_atomic_t wm_shutdown_requested = 0;
+#endif
+
+static int teardown_shutdown_flag(void **state) {
+    (void)state;
+    wm_shutdown_requested = 0;
+    return 0;
+}
+
+/* This is the core of the 38428 fix: a shutdown already in progress must be
+ * reported back distinctly from "the gate genuinely opened", so every caller
+ * (win_module_thread(), skthread(), the POSIX daemons' main()) can abort
+ * startup instead of racing ahead into a module that's about to be torn
+ * down. Before the fix this path returned void -- indistinguishable from a
+ * real release. */
+static void test_wait_for_ready_returns_shutdown_requested_without_polling(void **state) {
+    (void)state;
+    wm_shutdown_requested = 1;
+
+    expect_string(__wrap__mdebug1, formatted_msg,
+                  "Startup hash gate: shutdown requested, aborting startup for 'wazuh-sca' without waiting for handshake.");
+
+    startup_gate_wait_result_t result = startup_gate_wait_for_ready("wazuh-sca");
+
+    assert_int_equal(result, STARTUP_GATE_SHUTDOWN_REQUESTED);
+}
+
+/* A NULL/empty module name must not crash the log line -- falls back to "module". */
+static void test_wait_for_ready_shutdown_requested_defaults_module_name(void **state) {
+    (void)state;
+    wm_shutdown_requested = 1;
+
+    expect_string(__wrap__mdebug1, formatted_msg,
+                  "Startup hash gate: shutdown requested, aborting startup for 'module' without waiting for handshake.");
+
+    startup_gate_wait_result_t result = startup_gate_wait_for_ready(NULL);
+
+    assert_int_equal(result, STARTUP_GATE_SHUTDOWN_REQUESTED);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_teardown(test_wait_for_ready_returns_shutdown_requested_without_polling, teardown_shutdown_flag),
+        cmocka_unit_test_teardown(test_wait_for_ready_shutdown_requested_defaults_module_name, teardown_shutdown_flag),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}
+
+#else
+
+int main(void) {
+    return 0;
+}
+
+#endif

--- a/src/unit_tests/win32/CMakeLists.txt
+++ b/src/unit_tests/win32/CMakeLists.txt
@@ -1,3 +1,8 @@
+# Needed by test_win_utils.c/test_win_agent.c's #include "os_win.h" -- this
+# directory is otherwise absent from the standalone unit_tests project's
+# include path (unlike the main build's src/CMakeLists.txt).
+include_directories(${SRC_FOLDER}/win32)
+
 # Generate win32 library
 file(GLOB win32_files
     ${SRC_FOLDER}/build/win32/CMakeFiles/win32_common.dir/*.obj)
@@ -33,7 +38,14 @@ list(APPEND win32_flags "-Wl,--wrap,cJSON_GetObjectItem -Wl,--wrap,cJSON_GetArra
                         -Wl,--wrap,fim_db_get_path -Wl,--wrap,fim_db_transaction_start -Wl,--wrap,fim_db_transaction_deleted_rows \
                         -Wl,--wrap,fim_db_transaction_sync_row -Wl,--wrap,fim_db_file_update -Wl,--wrap,fim_db_file_pattern_search \
                         -Wl,--wrap,fim_db_init -Wl,--wrap,w_query_agentd \
-                        -Wl,--wrap,w_https_client_submit_event ${DEBUG_OP_WRAPPERS}")
+                        -Wl,--wrap,w_https_client_submit_event -Wl,--wrap,startup_gate_wait_for_ready \
+                        -Wl,--wrap,wm_config -Wl,--wrap,wm_check \
+                        ${DEBUG_OP_WRAPPERS}")
+
+list(APPEND win32_names "test_win_agent")
+list(APPEND win32_flags "-Wl,--wrap,syscom_dispatch -Wl,--wrap,Start_win32_Syscheck \
+                        -Wl,--wrap=is_fim_shutdown -Wl,--wrap=_imp__dbsync_initialize \
+                        -Wl,--wrap=fim_db_teardown ${DEBUG_OP_WRAPPERS}")
 
 list(LENGTH win32_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/win32/test_win_agent.c
+++ b/src/unit_tests/win32/test_win_agent.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include "os_win.h"
+#include "../wrappers/windows/winsvc_wrappers.h"
+
+#ifdef TEST_WINAGENT
+
+/* --- CheckServiceRunning(): issue 38428 defect #6 ------------------------
+ *
+ * Before the fix, this returned 1 only for SERVICE_RUNNING, so the
+ * service-restart wait loop in win_agent.c gave up the instant the SCM
+ * reported SERVICE_STOP_PENDING -- long before the old process had actually
+ * finished stop_wmodules() -- and started a new process over it, racing for
+ * the same SQLite files ("database is locked"). It must now treat anything
+ * other than SERVICE_STOPPED as still running. */
+
+static void test_check_service_running_true_for_running(void **state) {
+    (void)state;
+    expect_CheckServiceRunning_query(SERVICE_RUNNING);
+    assert_int_equal(CheckServiceRunning(), 1);
+}
+
+static void test_check_service_running_true_for_stop_pending(void **state) {
+    (void)state;
+    expect_CheckServiceRunning_query(SERVICE_STOP_PENDING);
+    assert_int_equal(CheckServiceRunning(), 1);
+}
+
+static void test_check_service_running_true_for_start_pending(void **state) {
+    (void)state;
+    expect_CheckServiceRunning_query(SERVICE_START_PENDING);
+    assert_int_equal(CheckServiceRunning(), 1);
+}
+
+static void test_check_service_running_false_for_stopped(void **state) {
+    (void)state;
+    expect_CheckServiceRunning_query(SERVICE_STOPPED);
+    assert_int_equal(CheckServiceRunning(), 0);
+}
+
+static void test_check_service_running_false_when_service_missing(void **state) {
+    (void)state;
+    will_return(wrap_OpenSCManager, (SC_HANDLE)0x1);
+    will_return(wrap_OpenService, (SC_HANDLE)NULL);
+    will_return(wrap_CloseServiceHandle, TRUE);
+
+    assert_int_equal(CheckServiceRunning(), 0);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_check_service_running_true_for_running),
+        cmocka_unit_test(test_check_service_running_true_for_stop_pending),
+        cmocka_unit_test(test_check_service_running_true_for_start_pending),
+        cmocka_unit_test(test_check_service_running_false_for_stopped),
+        cmocka_unit_test(test_check_service_running_false_when_service_missing),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}
+
+#else
+
+int main(void) {
+    return 0;
+}
+
+#endif

--- a/src/unit_tests/win32/test_win_utils.c
+++ b/src/unit_tests/win32/test_win_utils.c
@@ -17,6 +17,9 @@
 #include "../wrappers/common.h"
 #include "../../data_provider/include/sysInfo.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+#include "startup_gate_op.h"
+#include "os_win.h"
+#include "../wrappers/windows/handleapi_wrappers.h"
 
 #ifdef TEST_WINAGENT
 
@@ -90,11 +93,19 @@ void mock_sysinfo_free_result_func(cJSON **object) {
     return;
 }
 
+/* Defined in win_utils.c; in the real agent it's called from
+ * OssecServiceStart() before the SCM can invoke stop_wmodules(). The tests
+ * below call stop_wmodules()/wm_start_modules_unless_shutting_down()
+ * directly, so wm_lifecycle_lock must be initialized here first -- entering
+ * an uninitialized CRITICAL_SECTION is undefined behavior (issue 38428). */
+extern void wm_lifecycle_lock_init(void);
+
 static int setup_group(void **state) {
     agt = &global_config;
     time_mock_value = 0;
     sysinfo_network_ptr = mock_sysinfo_networks_func;
     sysinfo_free_result_ptr = mock_sysinfo_free_result_func;
+    wm_lifecycle_lock_init();
 
     return 0;
 }
@@ -376,6 +387,175 @@ static void test_SendBinaryMSGAction_submits_the_binary_frame(void **state) {
     assert_int_equal(ret, 0);
 }
 
+/* --- issue 38428: startup vs. shutdown mutual exclusion ------------------ */
+
+extern volatile sig_atomic_t wm_shutdown_requested;
+extern wmodule *wmodules;
+extern void wm_start_modules_unless_shutting_down(void);
+extern void stop_wmodules(void);
+
+startup_gate_wait_result_t __wrap_startup_gate_wait_for_ready(const char *module_name) {
+    check_expected(module_name);
+    return mock_type(startup_gate_wait_result_t);
+}
+
+int __wrap_wm_config(void) {
+    return mock_type(int);
+}
+
+int __wrap_wm_check(void) {
+    return mock_type(int);
+}
+
+static int teardown_wm_lifecycle(void **state) {
+    (void)state;
+    wm_shutdown_requested = 0;
+    wmodules = NULL;
+    return 0;
+}
+
+/* --- skthread(): must not start syscheck once a shutdown is in flight --- */
+
+static void test_skthread_skips_start_on_shutdown_requested(void **state) {
+    (void)state;
+    expect_string(__wrap_startup_gate_wait_for_ready, module_name, "wazuh-syscheckd");
+    will_return(__wrap_startup_gate_wait_for_ready, STARTUP_GATE_SHUTDOWN_REQUESTED);
+
+    /* No expect_function_call(__wrap_Start_win32_Syscheck) queued: cmocka
+     * fails this test if skthread() calls it anyway. */
+    skthread(NULL);
+}
+
+static void test_skthread_starts_syscheck_when_gate_ready(void **state) {
+    (void)state;
+    expect_string(__wrap_startup_gate_wait_for_ready, module_name, "wazuh-syscheckd");
+    will_return(__wrap_startup_gate_wait_for_ready, STARTUP_GATE_READY);
+
+    expect_function_call(__wrap_Start_win32_Syscheck);
+    will_return(__wrap_Start_win32_Syscheck, 0);
+
+    skthread(NULL);
+}
+
+/* --- win_module_thread(): must not run a module's start routine once a
+ * shutdown is in flight -- this is the exact mechanism behind issue 38428's
+ * SCA scan_on_start being silently dropped: the thread had already been
+ * spawned before the shutdown was requested, so closing the race requires
+ * this check to happen here, not just at spawn time. */
+
+static int test_routine_call_count = 0;
+
+DWORD WINAPI test_module_routine(__attribute__((unused)) void *data) {
+    test_routine_call_count++;
+    return 0;
+}
+
+static int setup_module_routine_counter(void **state) {
+    (void)state;
+    test_routine_call_count = 0;
+    return 0;
+}
+
+static void test_win_module_thread_skips_routine_on_shutdown_requested(void **state) {
+    (void)state;
+    win_module_start_ctx_t *ctx = NULL;
+    os_calloc(1, sizeof(win_module_start_ctx_t), ctx);
+    ctx->routine = test_module_routine;
+    ctx->data = NULL;
+    snprintf(ctx->name, sizeof(ctx->name), "wazuh-modulesd/test");
+
+    expect_string(__wrap_startup_gate_wait_for_ready, module_name, "wazuh-modulesd/test");
+    will_return(__wrap_startup_gate_wait_for_ready, STARTUP_GATE_SHUTDOWN_REQUESTED);
+
+    win_module_thread(ctx);
+
+    assert_int_equal(test_routine_call_count, 0);
+}
+
+static void test_win_module_thread_runs_routine_when_gate_ready(void **state) {
+    (void)state;
+    win_module_start_ctx_t *ctx = NULL;
+    os_calloc(1, sizeof(win_module_start_ctx_t), ctx);
+    ctx->routine = test_module_routine;
+    ctx->data = NULL;
+    snprintf(ctx->name, sizeof(ctx->name), "wazuh-modulesd/test");
+
+    expect_string(__wrap_startup_gate_wait_for_ready, module_name, "wazuh-modulesd/test");
+    will_return(__wrap_startup_gate_wait_for_ready, STARTUP_GATE_READY);
+
+    win_module_thread(ctx);
+
+    assert_int_equal(test_routine_call_count, 1);
+}
+
+/* --- wm_start_modules_unless_shutting_down(): the lock-guarded region that
+ * replaces local_start()'s old unconditional wm_config()+spawn-loop. */
+
+static void test_wm_start_modules_skips_everything_when_shutdown_already_requested(void **state) {
+    (void)state;
+    wm_shutdown_requested = 1;
+
+    expect_string(__wrap__mdebug1, formatted_msg, "Shutdown already in progress; skipping wodle startup.");
+
+    /* No will_return(__wrap_wm_config, ...) queued: cmocka fails this test
+     * if wm_config() is called despite the shutdown flag already being set. */
+    wm_start_modules_unless_shutting_down();
+
+    assert_null(wmodules);
+}
+
+static void test_wm_start_modules_spawns_a_thread_per_module_when_not_shutting_down(void **state) {
+    (void)state;
+    wm_context ctx = {
+        .name = "test-module",
+        .start = test_module_routine,
+    };
+    wmodule mod = { .context = &ctx, .data = NULL, .next = NULL };
+    wmodules = &mod;
+
+    will_return(__wrap_wm_config, 0);
+    will_return(__wrap_wm_check, 0);
+    will_return(wrap_CreateThread, (HANDLE)0x1234);
+
+    wm_start_modules_unless_shutting_down();
+
+    assert_ptr_equal(mod.win_thread, (HANDLE)0x1234);
+}
+
+/* --- stop_wmodules(): sets the shutdown flag and joins every spawned module,
+ * even when it never got a real thread (mid-startup race, issue 38428 §2). */
+
+static void test_stop_wmodules_sets_shutdown_flag_and_skips_join_without_a_thread(void **state) {
+    (void)state;
+    wm_context ctx = { .name = "test-module" };
+    wmodule mod = { .context = &ctx, .data = NULL, .win_thread = NULL, .next = NULL };
+    wmodules = &mod;
+    wm_shutdown_requested = 0;
+
+    stop_wmodules();
+
+    assert_int_equal(wm_shutdown_requested, 1);
+}
+
+static void test_stop_wmodules_joins_a_spawned_thread(void **state) {
+    (void)state;
+    wm_context ctx = { .name = "test-module" };
+    wmodule mod = { .context = &ctx, .data = NULL, .win_thread = (HANDLE)0x5678, .next = NULL };
+    wmodules = &mod;
+    wm_shutdown_requested = 0;
+
+    expect_any(wrap_WaitForSingleObject, hMutex);
+    expect_any(wrap_WaitForSingleObject, value);
+    will_return(wrap_WaitForSingleObject, WAIT_OBJECT_0);
+
+    expect_CloseHandle_call((HANDLE)0x5678, 1);
+
+    stop_wmodules();
+
+    assert_int_equal(wm_shutdown_requested, 1);
+    assert_null(mod.win_thread);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_get_agent_ip_legacy_win32_update_ip_success), cmocka_unit_test(test_get_agent_ip_legacy_win32_sysinfo_error),
@@ -391,6 +571,14 @@ int main(void) {
         cmocka_unit_test(test_SendBinaryMSGAction_mutex_abandoned),
         cmocka_unit_test(test_SendBinaryMSGAction_message_too_large),
         cmocka_unit_test(test_SendBinaryMSGAction_submits_the_binary_frame),
+        cmocka_unit_test(test_skthread_skips_start_on_shutdown_requested),
+        cmocka_unit_test(test_skthread_starts_syscheck_when_gate_ready),
+        cmocka_unit_test_setup(test_win_module_thread_skips_routine_on_shutdown_requested, setup_module_routine_counter),
+        cmocka_unit_test_setup(test_win_module_thread_runs_routine_when_gate_ready, setup_module_routine_counter),
+        cmocka_unit_test_teardown(test_wm_start_modules_skips_everything_when_shutdown_already_requested, teardown_wm_lifecycle),
+        cmocka_unit_test_teardown(test_wm_start_modules_spawns_a_thread_per_module_when_not_shutting_down, teardown_wm_lifecycle),
+        cmocka_unit_test_teardown(test_stop_wmodules_sets_shutdown_flag_and_skips_join_without_a_thread, teardown_wm_lifecycle),
+        cmocka_unit_test_teardown(test_stop_wmodules_joins_a_spawned_thread, teardown_wm_lifecycle),
     };
 
     return cmocka_run_group_tests(tests, setup_group, NULL);

--- a/src/unit_tests/wrappers/wazuh/remoted/request_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/remoted/request_wrappers.c
@@ -14,6 +14,7 @@
 #include <cmocka.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include "request_wrappers.h"
 
 int __wrap_req_save(const char * counter, const char * buffer, size_t length) {

--- a/src/unit_tests/wrappers/windows/winsvc_wrappers.c
+++ b/src/unit_tests/wrappers/windows/winsvc_wrappers.c
@@ -1,0 +1,47 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include "winsvc_wrappers.h"
+#include <stddef.h>
+#include <stdarg.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+SC_HANDLE wrap_OpenSCManager(__attribute__((unused)) LPCSTR lpMachineName,
+                             __attribute__((unused)) LPCSTR lpDatabaseName,
+                             __attribute__((unused)) DWORD dwDesiredAccess) {
+    return mock_type(SC_HANDLE);
+}
+
+SC_HANDLE wrap_OpenService(__attribute__((unused)) SC_HANDLE hSCManager,
+                           __attribute__((unused)) LPCSTR lpServiceName,
+                           __attribute__((unused)) DWORD dwDesiredAccess) {
+    return mock_type(SC_HANDLE);
+}
+
+WINBOOL wrap_QueryServiceStatus(__attribute__((unused)) SC_HANDLE hService, LPSERVICE_STATUS lpServiceStatus) {
+    WINBOOL ok = mock_type(WINBOOL);
+    if (ok) {
+        lpServiceStatus->dwCurrentState = mock_type(DWORD);
+    }
+    return ok;
+}
+
+WINBOOL wrap_CloseServiceHandle(__attribute__((unused)) SC_HANDLE hSCObject) {
+    return mock_type(WINBOOL);
+}
+
+void expect_CheckServiceRunning_query(DWORD current_state) {
+    will_return(wrap_OpenSCManager, (SC_HANDLE)0x1);
+    will_return(wrap_OpenService, (SC_HANDLE)0x2);
+    will_return(wrap_QueryServiceStatus, TRUE);
+    will_return(wrap_QueryServiceStatus, current_state);
+    will_return(wrap_CloseServiceHandle, TRUE);
+    will_return(wrap_CloseServiceHandle, TRUE);
+}

--- a/src/unit_tests/wrappers/windows/winsvc_wrappers.h
+++ b/src/unit_tests/wrappers/windows/winsvc_wrappers.h
@@ -1,0 +1,38 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#ifndef WINSVC_WRAPPERS_H
+#define WINSVC_WRAPPERS_H
+
+#include <windows.h>
+#include <winsvc.h>
+
+#undef OpenSCManager
+#define OpenSCManager wrap_OpenSCManager
+#undef OpenService
+#define OpenService wrap_OpenService
+#undef QueryServiceStatus
+#define QueryServiceStatus wrap_QueryServiceStatus
+#undef CloseServiceHandle
+#define CloseServiceHandle wrap_CloseServiceHandle
+
+SC_HANDLE wrap_OpenSCManager(LPCSTR lpMachineName, LPCSTR lpDatabaseName, DWORD dwDesiredAccess);
+
+SC_HANDLE wrap_OpenService(SC_HANDLE hSCManager, LPCSTR lpServiceName, DWORD dwDesiredAccess);
+
+WINBOOL wrap_QueryServiceStatus(SC_HANDLE hService, LPSERVICE_STATUS lpServiceStatus);
+
+WINBOOL wrap_CloseServiceHandle(SC_HANDLE hSCObject);
+
+/** @brief Load the full happy-path sequence for CheckServiceRunning(): a
+ * valid SC manager handle, a valid service handle, and a QueryServiceStatus
+ * result reporting the given state. */
+void expect_CheckServiceRunning_query(DWORD current_state);
+
+#endif

--- a/src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp
+++ b/src/wazuh_modules/sca/sca_impl/include/sca_impl.hpp
@@ -171,6 +171,13 @@ class SecurityConfigurationAssessment
         /// @brief Cached first-sync completion state used to gate initial stateful publication.
         std::atomic<bool> m_firstSyncCompleted {false};
 
+        /// @brief Cached first-scan completion state, persisted independent of
+        /// first_sync_completed. Its absence means a scan_on_start scan is still
+        /// owed -- e.g. an earlier Run() got interrupted before completing one
+        /// (issue 38428) -- so the next opportunity retries it immediately
+        /// instead of waiting a full m_scanInterval.
+        std::atomic<bool> m_firstScanCompleted {false};
+
         /// @brief In-memory flag set after each complete scan iteration, cleared at Run() startup.
         /// Polled by the C sync thread (via get_scan_completed query) to avoid triggering the
         /// first snapshot before any check has had a chance to run. Note that "Not run" rows
@@ -227,6 +234,9 @@ class SecurityConfigurationAssessment
 
         /// @brief Refresh the cached first-sync completion flag from metadata.
         void refreshFirstSyncCompletedState();
+
+        /// @brief Refresh the cached first-scan completion flag from metadata.
+        void refreshFirstScanCompletedState();
 
         /// @brief Synchronize the current DB snapshot using FULL mode.
         /// @param increaseVersions Whether to bump versions before building the snapshot.

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -65,6 +65,13 @@ constexpr auto METADATA_SQL_STATEMENT
 
 constexpr auto SCA_LAST_INTEGRITY_CHECK_METADATA_KEY {"last_integrity_check"};
 constexpr auto SCA_FIRST_SYNC_COMPLETED_METADATA_KEY {"first_sync_completed"};
+// Persists across restarts, independent of first_sync_completed: whether SCA
+// has ever completed a full scan. Its absence IS "a scan is still owed" --
+// checked so a scan_on_start scan that got interrupted (issue 38428: the
+// Windows startup/shutdown race, or being paused right at the first
+// opportunity) is retried on the next chance instead of silently waiting a
+// full <interval>.
+constexpr auto SCA_FIRST_SCAN_COMPLETED_METADATA_KEY {"first_scan_completed"};
 
 SecurityConfigurationAssessment::SecurityConfigurationAssessment(std::string dbPath,
                                                                  std::shared_ptr<IDBSync> dbSync,
@@ -121,7 +128,14 @@ void SecurityConfigurationAssessment::Run()
         return;
     }
 
-    m_keepRunning = true;
+    {
+        // Sharing m_pauseMutex with quiesce()'s own m_keepRunning write closes
+        // a TOCTOU: without it, a quiesce() landing between this reset and the
+        // loop's first check below could still be overwritten back to true by
+        // this line racing it (issue 38428, code-map.md §3 row 2).
+        std::lock_guard<std::mutex> lock(m_pauseMutex);
+        m_keepRunning = true;
+    }
 
     // Reset sync protocol stop flag to allow restarting operations
     if (m_spSyncProtocol)
@@ -132,6 +146,7 @@ void SecurityConfigurationAssessment::Run()
     LoggingHelper::getInstance().log(LOG_DEBUG, "SCA module running.");
 
     refreshFirstSyncCompletedState();
+    refreshFirstScanCompletedState();
 
     if (m_syncManager)
     {
@@ -180,10 +195,31 @@ void SecurityConfigurationAssessment::Run()
         }
     };
 
+    // A scan_on_start scan that gets interrupted before it runs (issue 38428)
+    // must not be silent, and must not just be lost until the next full
+    // <interval> -- log it, once, right where each early exit happens.
+    auto logSkippedFirstScanIfNeeded = [this]()
+    {
+        if (m_scanOnStart && !m_firstScanCompleted.load())
+        {
+            LoggingHelper::getInstance().log(LOG_DEBUG,
+                                             "SCA module stopped before its scan_on_start scan could run; "
+                                             "will retry automatically on the next opportunity.");
+        }
+    };
+
     while (m_keepRunning)
     {
-        // If scan on start is enabled and this is the first iteration, scan immediately
-        // Otherwise, wait for the scan interval before scanning
+        // Scan immediately if scan_on_start is enabled and no real scan has
+        // completed yet this run -- whether this is the very first iteration,
+        // or a scan_on_start scan is still owed after being interrupted one or
+        // more times by a pause/resume cycle (issue 38428) -- otherwise wait
+        // for the interval before scanning. Deliberately NOT gated on the
+        // persisted m_firstScanCompleted: that marker is write-once for the
+        // installation's whole lifetime, so on any agent already past its
+        // first-ever scan it would make this condition permanently true and
+        // silently swallow the retry for a scan_on_start dropped by a later
+        // interruption, waiting the full interval instead (issue 38428).
         if (!m_scanOnStart || !firstScan)
         {
             std::unique_lock<std::mutex> lock(m_mutex);
@@ -192,6 +228,7 @@ void SecurityConfigurationAssessment::Run()
 
         if (!m_keepRunning)
         {
+            logSkippedFirstScanIfNeeded();
             return;
         }
 
@@ -200,7 +237,20 @@ void SecurityConfigurationAssessment::Run()
         {
             // LCOV_EXCL_START
             LoggingHelper::getInstance().log(LOG_DEBUG, "SCA scanning paused, skipping scan iteration");
-            firstScan = false;  // Clear first scan flag even when paused
+            // firstScan is deliberately left untouched here: no scan actually ran, so a
+            // scan_on_start attempt interrupted by a pause is still owed once resumed
+            // (issue 38428). It is only cleared below, after policy->Run() actually
+            // completes.
+
+            // Block here instead of looping straight back to the top: the wait above is
+            // skipped whenever a scan_on_start scan is still owed (issue 38428), so a pause
+            // landing in exactly that window would otherwise busy-spin this thread at 100%
+            // CPU -- m_paused and firstScan both stay true, so the loop condition above
+            // never becomes true on its own. resume() only calls
+            // m_cv.notify_one(), so waiting on the same condition variable here is what
+            // actually wakes this back up promptly once coordination clears.
+            std::unique_lock<std::mutex> pauseLock(m_mutex);
+            m_cv.wait(pauseLock, [this] { return !m_paused.load() || !m_keepRunning.load(); });
             continue;
             // LCOV_EXCL_STOP
         }
@@ -257,6 +307,7 @@ void SecurityConfigurationAssessment::Run()
             // LCOV_EXCL_START
             // Mark scan as complete before returning
             setScanInProgress(false);
+            logSkippedFirstScanIfNeeded();
             return;
             // LCOV_EXCL_STOP
         }
@@ -286,6 +337,7 @@ void SecurityConfigurationAssessment::Run()
                 // LCOV_EXCL_START
                 // Mark scan as complete before returning
                 setScanInProgress(false);
+                logSkippedFirstScanIfNeeded();
                 return;
                 // LCOV_EXCL_STOP
             }
@@ -300,6 +352,16 @@ void SecurityConfigurationAssessment::Run()
         // Mark scan as complete
         setScanInProgress(false);
 
+        // A full scan has now genuinely completed at least once: persist that
+        // (once) so a future interrupted scan_on_start attempt knows a first
+        // scan was never lost, and so this one -- if it was the delayed retry
+        // of one -- isn't retried again (issue 38428).
+        if (!m_firstScanCompleted.load())
+        {
+            updateMetadataValue(SCA_FIRST_SCAN_COMPLETED_METADATA_KEY, 1);
+            m_firstScanCompleted.store(true);
+        }
+
         // Signal that a full scan iteration has completed. Only written until the first
         // sync completes — after that the sync thread no longer polls this flag.
         if (!m_firstSyncCompleted.load())
@@ -307,6 +369,8 @@ void SecurityConfigurationAssessment::Run()
             m_scanCompleted.store(Utils::getSecondsFromEpoch());
         }
     }
+
+    logSkippedFirstScanIfNeeded();
 }
 
 void SecurityConfigurationAssessment::Setup(bool enabled,
@@ -1415,6 +1479,16 @@ void SecurityConfigurationAssessment::refreshFirstSyncCompletedState()
     if (getMetadataValue(SCA_FIRST_SYNC_COMPLETED_METADATA_KEY, firstSyncCompleted))
     {
         m_firstSyncCompleted.store(firstSyncCompleted > 0);
+    }
+}
+
+void SecurityConfigurationAssessment::refreshFirstScanCompletedState()
+{
+    int64_t firstScanCompleted = 0;
+
+    if (getMetadataValue(SCA_FIRST_SCAN_COMPLETED_METADATA_KEY, firstScanCompleted))
+    {
+        m_firstScanCompleted.store(firstScanCompleted > 0);
     }
 }
 

--- a/src/wazuh_modules/sca/sca_impl/tests/mocks/sca_sca_mock.hpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/mocks/sca_sca_mock.hpp
@@ -59,4 +59,11 @@ class SCAMock : public SecurityConfigurationAssessment
         {
             return executeFlushSync();
         }
+
+        /// @brief Whether a scan has ever completed (issue 38428's persisted
+        /// "first scan owed" tracking) -- exposed for tests.
+        bool getFirstScanCompletedForTest() const
+        {
+            return m_firstScanCompleted.load();
+        }
 };

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_dataclean_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_dataclean_test.cpp
@@ -78,6 +78,7 @@ class SCADataCleanTest : public ::testing::Test
             EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
             .WillOnce(::testing::Return()) // Sync manager initialization query
             .WillOnce(::testing::Return()) // first_sync_completed metadata lookup
+            .WillOnce(::testing::Return()) // first_scan_completed metadata lookup (issue 38428)
             .WillOnce(::testing::Invoke([](const nlohmann::json& /* query */,
                                            std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
             {
@@ -156,6 +157,7 @@ TEST_F(SCADataCleanTest, AllPoliciesRemovedAtStartup_DataCleanFailure_Retries)
     EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
     .WillOnce(::testing::Return()) // Sync manager initialization query
     .WillOnce(::testing::Return()) // first_sync_completed metadata lookup
+    .WillOnce(::testing::Return()) // first_scan_completed metadata lookup (issue 38428)
     .WillOnce(::testing::Invoke([](const nlohmann::json& /* query */,
                                    std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
     {
@@ -200,6 +202,7 @@ TEST_F(SCADataCleanTest, NoPoliciesNoData_ExitsCleanly)
     EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
     .WillOnce(::testing::Return()) // Sync manager initialization query
     .WillOnce(::testing::Return()) // first_sync_completed metadata lookup
+    .WillOnce(::testing::Return()) // first_scan_completed metadata lookup (issue 38428)
     .WillOnce(::testing::Invoke([](const nlohmann::json& /* query */,
                                    std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
     {
@@ -239,6 +242,7 @@ TEST_F(SCADataCleanTest, HandleAllPoliciesRemoved_SendsDataCleanAndExits)
     EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
     .WillOnce(::testing::Return()) // Sync manager initialization query
     .WillOnce(::testing::Return()) // first_sync_completed metadata lookup
+    .WillOnce(::testing::Return()) // first_scan_completed metadata lookup (issue 38428)
     .WillOnce(::testing::Invoke([](const nlohmann::json& /* query */,
                                    std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
     {
@@ -346,6 +350,7 @@ TEST_F(SCADataCleanTest, DataClean_WithoutSyncProtocol_Fails)
     EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
     .WillOnce(::testing::Return()) // Sync manager initialization query
     .WillOnce(::testing::Return()) // first_sync_completed metadata lookup
+    .WillOnce(::testing::Return()) // first_scan_completed metadata lookup (issue 38428)
     .WillOnce(::testing::Invoke([](const nlohmann::json& /* query */,
                                    std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
     {
@@ -381,6 +386,7 @@ TEST_F(SCADataCleanTest, DataClean_WaitsForSyncInProgress)
     EXPECT_CALL(*m_mockDBSync, selectRows(::testing::_, ::testing::_))
     .WillOnce(::testing::Return()) // Sync manager initialization query
     .WillOnce(::testing::Return()) // first_sync_completed metadata lookup
+    .WillOnce(::testing::Return()) // first_scan_completed metadata lookup (issue 38428)
     .WillOnce(::testing::Invoke(
                   [](const nlohmann::json& /* query */,
                      std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)

--- a/src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp
+++ b/src/wazuh_modules/sca/sca_impl/tests/sca_test.cpp
@@ -555,6 +555,160 @@ TEST_F(ScaTest, Run_WithPausedState_SkipsScanIteration)
     EXPECT_NE(m_logOutput.find("SCA module running"), std::string::npos);
 }
 
+// issue 38428: a first scan that silently never ran used to have no
+// persisted trace, so a skipped scan_on_start scan waited a full
+// m_scanInterval before the next attempt. first_scan_completed (in-memory
+// mirror: m_firstScanCompleted) closes that: false until a scan genuinely
+// finishes, true from then on -- checked by Run() to force an immediate
+// retry instead of waiting out the interval.
+TEST_F(ScaTest, Run_SetsFirstScanCompletedAfterFirstSuccessfulScan)
+{
+    auto mockDBSync = std::make_shared<MockDBSync>();
+    auto mockFileSystem = std::make_shared<MockFileSystemWrapper>();
+    auto scaMock = std::make_shared<SCAMock>(mockDBSync, mockFileSystem);
+
+    std::vector<sca::PolicyData> policyData = {{"test_policy.yaml", true, false}};
+
+    EXPECT_CALL(*mockFileSystem, exists(::testing::_))
+    .WillRepeatedly(::testing::Return(true));
+
+    EXPECT_CALL(*mockDBSync, selectRows(::testing::_, ::testing::_))
+    .WillRepeatedly(::testing::Invoke([](const nlohmann::json&,
+                                         std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
+    {
+        nlohmann::json result = {{"count", 0}};
+        callback(SELECTED, result);
+    }));
+
+    EXPECT_CALL(*mockDBSync, handle())
+    .WillRepeatedly(::testing::Return(nullptr));
+    EXPECT_CALL(*mockDBSync, syncRow(::testing::_, ::testing::_))
+    .WillRepeatedly(::testing::Return());
+
+    auto yamlToJsonFunc = [](const std::string&) -> nlohmann::json
+    {
+        nlohmann::json result;
+        result["variables"] = {{"$test_var", "/etc"}};
+        result["policy"] = {{"id", "test_policy"}, {"name", "Test Policy"}};
+        result["checks"] = nlohmann::json::array({
+            {   {"id", "check1"}, {"title", "Test Check"}, {"condition", "all"},
+                {"rules", nlohmann::json::array({"f:$test_var/passwd exists"})}
+            }
+        });
+        return result;
+    };
+
+    ASSERT_FALSE(scaMock->getFirstScanCompletedForTest());
+
+    scaMock->Setup(true, true, std::chrono::seconds(100), 30, false, policyData, yamlToJsonFunc);
+
+    std::thread runThread([&scaMock]()
+    {
+        scaMock->Run();
+    });
+
+    // Give the scan_on_start scan time to actually complete.
+    std::this_thread::sleep_for(std::chrono::milliseconds(150));
+
+    scaMock->Stop();
+    runThread.join();
+
+    EXPECT_NE(m_logOutput.find("Scan ended."), std::string::npos);
+    EXPECT_TRUE(scaMock->getFirstScanCompletedForTest());
+}
+
+// issue 38428: first_scan_completed is write-once for the installation's whole
+// lifetime, so on an agent already past its first-ever scan it must NOT be
+// the thing that decides whether a scan_on_start retry is still owed --
+// otherwise a scan interrupted by a pause on such an agent would silently
+// wait out the full m_scanInterval instead of retrying once resumed. This
+// simulates that agent by driving Run() to completion once first (so
+// first_scan_completed is already true, as on a long-lived agent), then
+// calling Run() again -- as a fresh restart would -- and pausing before that
+// second scan_on_start attempt can complete.
+TEST_F(ScaTest, Run_RetriesScanOnStartAfterPauseEvenPastFirstScan)
+{
+    auto mockDBSync = std::make_shared<MockDBSync>();
+    auto mockFileSystem = std::make_shared<MockFileSystemWrapper>();
+    auto scaMock = std::make_shared<SCAMock>(mockDBSync, mockFileSystem);
+
+    std::vector<sca::PolicyData> policyData = {{"test_policy.yaml", true, false}};
+
+    EXPECT_CALL(*mockFileSystem, exists(::testing::_))
+    .WillRepeatedly(::testing::Return(true));
+
+    EXPECT_CALL(*mockDBSync, selectRows(::testing::_, ::testing::_))
+    .WillRepeatedly(::testing::Invoke([](const nlohmann::json&,
+                                         std::function<void(ReturnTypeCallback, const nlohmann::json&)> callback)
+    {
+        nlohmann::json result = {{"count", 0}};
+        callback(SELECTED, result);
+    }));
+
+    EXPECT_CALL(*mockDBSync, handle())
+    .WillRepeatedly(::testing::Return(nullptr));
+    EXPECT_CALL(*mockDBSync, syncRow(::testing::_, ::testing::_))
+    .WillRepeatedly(::testing::Return());
+
+    auto yamlToJsonFunc = [](const std::string&) -> nlohmann::json
+    {
+        nlohmann::json result;
+        result["variables"] = {{"$test_var", "/etc"}};
+        result["policy"] = {{"id", "test_policy"}, {"name", "Test Policy"}};
+        result["checks"] = nlohmann::json::array({
+            {   {"id", "check1"}, {"title", "Test Check"}, {"condition", "all"},
+                {"rules", nlohmann::json::array({"f:$test_var/passwd exists"})}
+            }
+        });
+        return result;
+    };
+
+    // Long interval: if the retry-after-pause guard is broken, the second scan
+    // would only happen after this interval elapses, which this test's window
+    // will not reach -- turning the bug into a reliable failure, not a flake.
+    scaMock->Setup(true, true, std::chrono::seconds(100), 30, false, policyData, yamlToJsonFunc);
+
+    // First Run(): let scan_on_start complete normally so first_scan_completed
+    // becomes true, matching an agent well past its first-ever scan.
+    {
+        std::thread runThread([&scaMock]()
+        {
+            scaMock->Run();
+        });
+        std::this_thread::sleep_for(std::chrono::milliseconds(150));
+        scaMock->Stop();
+        runThread.join();
+    }
+    ASSERT_TRUE(scaMock->getFirstScanCompletedForTest());
+
+    // Second Run(): simulates a fresh restart (Run() resets m_keepRunning and
+    // its local firstScan). Pause *before* starting this Run() call at all --
+    // pause() blocks until any in-progress scan/sync clears, which is
+    // immediately true here since the first Run() already fully stopped -- so
+    // the very first loop iteration is guaranteed to see m_paused already set,
+    // deterministically landing the pause before this scan_on_start attempt
+    // can do any work (racing it via a sleep_for() after starting the thread
+    // is not reliable: the mocked scan below can complete in far under a
+    // millisecond, so a real interruption-before-completion is not
+    // guaranteed to be observed).
+    m_logOutput.clear();
+    scaMock->pause();
+    std::thread runThread2([&scaMock]()
+    {
+        scaMock->Run();
+    });
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    scaMock->resume();
+
+    // Give the retried scan_on_start scan time to actually complete.
+    std::this_thread::sleep_for(std::chrono::milliseconds(150));
+    scaMock->Stop();
+    runThread2.join();
+
+    EXPECT_NE(m_logOutput.find("Scan started."), std::string::npos);
+    EXPECT_NE(m_logOutput.find("Scan ended."), std::string::npos);
+}
+
 TEST_F(ScaTest, SyncModule_PerformsInitialFullSnapshotBeforeFirstSync)
 {
     const auto dbPath = makeTempPath();

--- a/src/wazuh_modules/src/main.c
+++ b/src/wazuh_modules/src/main.c
@@ -149,7 +149,10 @@ int main(int argc, char **argv)
         }
     }
 
-    startup_gate_wait_for_ready(ARGV0);
+    if (startup_gate_wait_for_ready(ARGV0) != STARTUP_GATE_READY) {
+        mdebug1("'%s' shutdown requested while waiting for the startup gate; exiting without starting.", ARGV0);
+        exit(0);
+    }
 
     // Run modules
 

--- a/src/wazuh_modules/src/wm_sca.c
+++ b/src/wazuh_modules/src/wm_sca.c
@@ -597,6 +597,16 @@ void * wm_sca_main(wm_sca_t * data) {
             // on this early-exit path too, so the next process does not find them
             // locked.
             wm_sca_release_resources();
+
+            // Never reached wm_sca_start()/Run(): if scan_on_start was
+            // configured, that scan is still owed. Persisting the "not yet
+            // completed" state is Run()'s job (it never got a chance to run
+            // this time); this is just the observability half -- not silent
+            // (issue 38428).
+            if (data->scan_on_start) {
+                mdebug1("SCA exiting before Run() due to shutdown while waiting for agentd; "
+                        "scan_on_start scan will retry automatically on the next opportunity.");
+            }
 #ifdef WIN32
             return 0;
 #else

--- a/src/win32/os_win.h
+++ b/src/win32/os_win.h
@@ -11,6 +11,25 @@
 #ifndef OS_WIN_H
 #define OS_WIN_H
 
+#include "defs.h"
+#include "wmodules_def.h"
+
+/* Context handed to win_module_thread(): boxes a module's start routine and
+ * data so the thread entry point can wait on the startup gate before
+ * invoking it. Exposed here (rather than kept private to win_utils.c) so
+ * unit tests can construct one directly. */
+typedef struct win_module_start_ctx {
+    wm_routine routine;
+    void *data;
+    char name[OS_SIZE_128];
+} win_module_start_ctx_t;
+
+#ifdef WIN32
+DWORD WINAPI skthread(LPVOID arg);
+DWORD WINAPI logcollector_thread(LPVOID arg);
+DWORD WINAPI win_module_thread(void *arg);
+#endif
+
 /* Install the WAZUH-HIDS agent service */
 int InstallService(char *path);
 
@@ -33,5 +52,13 @@ int os_WinMain(int argc, char **argv);
 
 /* Locally start the process (after the services initialization) */
 int local_start();
+
+#ifdef WAZUH_UNIT_TESTING
+/* Stop the running service and start a fresh one (the "service-restart" CLI
+ * subcommand's implementation). Only declared here under test: in a real
+ * build it stays STATIC to win_agent.c, so this prototype would otherwise
+ * conflict with that static definition. */
+int run_service_restart(void);
+#endif
 
 #endif /* OS_WIN_H */

--- a/src/win32/win_agent.c
+++ b/src/win32/win_agent.c
@@ -25,6 +25,16 @@
 #define ARGV0 "wazuh-agent"
 #endif
 
+#ifdef WAZUH_UNIT_TESTING
+// Remove STATIC qualifier from tests
+#define STATIC
+#else
+#define STATIC static
+#endif
+
+/* Defined in win_utils.c; idempotent (issue 38428). */
+extern void wm_lifecycle_lock_init(void);
+
 /**************************************************************************************
     WARNING: all the logging functions of this file must use the plain_ variant
     to avoid calling any external library that could be loaded before the signature
@@ -45,16 +55,93 @@ void agent_help()
     exit(1);
 }
 
+/* Stop the running service and start a fresh one, invoked either by
+ * control_run_detached() as a detached process (manager-pushed shared-config
+ * reload) or directly as the "service-restart" CLI subcommand. Extracted out
+ * of main() so it can be unit-tested without a real argv/process exit.
+ *
+ * Serializes concurrent invocations on a named, cross-process mutex: without
+ * this, N overlapping restarts each independently fall through
+ * os_stop_service()'s "already stopping"/"already stopped" soft-success
+ * cases into their own stop-wait-start sequence, with nothing coordinating
+ * which one's stop/start actually wins. Observed live to leave the service
+ * permanently SERVICE_STOPPED with no self-recovery and no error logged
+ * anywhere (issue 38428). The mutex is held for the rest of this process's
+ * life -- released automatically on exit, whichever return below is taken. */
+STATIC int run_service_restart(void)
+{
+    DWORD startTime = 0;
+    // Comfortably above the real worst case for a single restart: stop_wmodules()'s
+    // own 20 s module-join budget, plus fim_db_teardown() (unbounded, runs right
+    // after stop_wmodules() in OssecServiceCtrlHandler) and wm_kill_children(), both
+    // of which used to happen inside the old process's own shutdown window but are
+    // not covered by any timeout of their own. 30 s left no margin for either -- a
+    // shutdown that legitimately used all of stop_wmodules()'s budget plus a slow
+    // fim_db_teardown() would trip this timeout and return without ever calling
+    // os_start_service(), leaving the service permanently stopped (issue 38428).
+    const DWORD timeoutMs = 45000;           // 45 seconds
+    const DWORD sleepIntervalMs = 500;       // 0.5 seconds
+    const DWORD waitForServiceStopMs = 1000; // 1 second
+    // ~2-3x the normal worst case for a single restart (20 s module-join budget
+    // + 10 s SCA wait + overhead), so a second concurrent restart request only
+    // ever times out here if something is already badly wrong (issue 38428).
+    const DWORD restartMutexWaitMs = 60000;  // 60 seconds
+
+    HANDLE restart_mutex = CreateMutex(NULL, FALSE, "Global\\WazuhAgentServiceRestart");
+    if (restart_mutex == NULL) {
+        plain_merror("service-restart: CreateMutex failed (error %lu); proceeding unsynchronized.", GetLastError());
+    } else {
+        const DWORD restart_mutex_wait_result = WaitForSingleObject(restart_mutex, restartMutexWaitMs);
+        if (restart_mutex_wait_result == WAIT_TIMEOUT) {
+            plain_merror("service-restart: another restart has been in progress for over %lu ms "
+                         "(expected well under that) -- the agent may be stuck; not starting a "
+                         "second concurrent restart attempt.", restartMutexWaitMs);
+            CloseHandle(restart_mutex);
+            return 1;
+        }
+        /* WAIT_ABANDONED: a previous restart's process exited (or crashed)
+         * while still holding the mutex -- treat that the same as a clean
+         * acquisition and proceed; it's ours now. */
+    }
+
+    /* Sleep briefly so the calling service has time to send its "ok"
+     * response before we stop it, then perform stop + start. */
+    Sleep(waitForServiceStopMs);
+    /* Attempt to send the SERVICE_CONTROL_STOP command.
+     * If this fails, the stop signal was not delivered to the SCM,
+     * so there is no point in waiting for the service to stop. */
+    int stop_rc = os_stop_service();
+    if (stop_rc == 0) {
+        plain_merror("Failure running stop service.");
+        return 1;
+    }
+    /* Wait until the service fully transitions to the STOPPED state --
+     * not just "not RUNNING": CheckServiceRunning() now also treats
+     * every pending/paused state as still-running, so this correctly
+     * keeps waiting through the old process's own shutdown instead of
+     * starting a new one over it (issue 38428, defect #6). */
+    startTime = GetTickCount();
+    while (CheckServiceRunning()) {
+        if (GetTickCount() - startTime > timeoutMs) {
+            plain_merror("Failure service did not stop within the expected time.");
+            return 1;
+        }
+        Sleep(sleepIntervalMs);
+    }
+    int start_rc = os_start_service();
+    if (start_rc == 0) {
+        plain_merror("Failure running start service.");
+        return 1;
+    }
+    return 0;
+}
+
 int main(int argc, char **argv)
 {
     char *tmpstr;
     char mypath[OS_MAXSTR + 1];
     char myfinalpath[OS_MAXSTR + 1];
     char myfile[OS_MAXSTR + 1];
-    DWORD startTime = 0;
-    const DWORD timeoutMs = 30000;           // 30 seconds
-    const DWORD sleepIntervalMs = 500;       // 0.5 seconds
-    const DWORD waitForServiceStopMs = 1000; // 1 second
 
     /* Set the name */
     OS_SetName(ARGV0);
@@ -89,33 +176,17 @@ int main(int argc, char **argv)
         } else if (strcmp(argv[1], "uninstall-service") == 0) {
             return (UninstallService());
         } else if (strcmp(argv[1], "start") == 0) {
+            /* local_start() -> wm_start_modules_unless_shutting_down() takes
+             * wm_lifecycle_lock. OssecServiceStart() (the SCM-invoked path)
+             * initializes it before calling local_start(); this direct CLI
+             * path bypasses OssecServiceStart() entirely, so it must
+             * initialize the lock itself. wm_lifecycle_lock_init() is
+             * idempotent, so this is safe even though it's also called from
+             * win_service.c (issue 38428). */
+            wm_lifecycle_lock_init();
             return (local_start());
         } else if (strcmp(argv[1], "service-restart") == 0) {
-            /* Invoked by control_run_detached() as a detached process.
-             * Sleep briefly so the calling service has time to send its "ok"
-             * response before we stop it, then perform stop + start. */
-            Sleep(waitForServiceStopMs);
-            /* Attempt to send the SERVICE_CONTROL_STOP command.
-             * If this fails, the stop signal was not delivered to the SCM,
-             * so there is no point in waiting for the service to stop. */
-            if (os_stop_service() == 0) {
-                plain_merror("Failure running stop service.");
-                return 1;
-            }
-            /* Wait until the service fully transitions to the STOPPED state. */
-            startTime = GetTickCount();
-            while (CheckServiceRunning()) {
-                if (GetTickCount() - startTime > timeoutMs) {
-                    plain_merror("Failure service did not stop within the expected time.");
-                    return 1;
-                }
-                Sleep(sleepIntervalMs);
-            }
-            if (os_start_service() == 0) {
-                plain_merror("Failure running start service.");
-                return 1;
-            }
-            return 0;
+            return run_service_restart();
         } else if (strcmp(argv[1], "/?") == 0) {
             agent_help();
         } else if (strcmp(argv[1], "-h") == 0) {

--- a/src/win32/win_service.c
+++ b/src/win32/win_service.c
@@ -18,6 +18,10 @@
 #define ARGV0 "wazuh-agent"
 #endif
 
+#ifdef WAZUH_UNIT_TESTING
+#include "unit_tests/wrappers/windows/winsvc_wrappers.h"
+#endif
+
 /**************************************************************************************
     WARNING: all the logging functions of this file must use the plain_ variant
     to avoid calling any external library that could be loaded before the signature
@@ -34,6 +38,21 @@ static SERVICE_STATUS_HANDLE   ossecServiceStatusHandle;
 void WINAPI OssecServiceStart (DWORD argc, LPTSTR *argv);
 void wm_kill_children();
 extern void stop_wmodules();
+extern void wm_lifecycle_lock_init(void);
+
+/* Reports shutdown progress to the SCM so a slow stop_wmodules() (module
+ * joins, each up to their own budget) doesn't read as hung (issue 38428,
+ * defect #7). No-op before RegisterServiceCtrlHandler() has succeeded. */
+void report_stop_progress(DWORD checkpoint, DWORD wait_hint_ms)
+{
+    if (!ossecServiceStatusHandle) {
+        return;
+    }
+
+    ossecServiceStatus.dwCheckPoint = checkpoint;
+    ossecServiceStatus.dwWaitHint = wait_hint_ms;
+    SetServiceStatus(ossecServiceStatusHandle, &ossecServiceStatus);
+}
 
 /* Start OSSEC-HIDS service */
 int os_start_service()
@@ -108,9 +127,18 @@ int os_stop_service()
     return (rc);
 }
 
-/* Check if the OSSEC-HIDS agent service is running
- * Returns 1 on success (running) or 0 if not running
- */
+/* Check if the OSSEC-HIDS agent service is running, or in any state other
+ * than fully stopped.
+ *
+ * Returns 1 if the service exists and is anything other than SERVICE_STOPPED
+ * (this includes SERVICE_STOP_PENDING/SERVICE_START_PENDING/etc.), or 0 if
+ * it's stopped or doesn't exist.
+ *
+ * Before issue 38428's fix this only returned 1 for SERVICE_RUNNING, which
+ * made the "wait for the old process to actually die" loop in win_agent.c's
+ * service-restart give up the instant the SCM reported SERVICE_STOP_PENDING
+ * -- long before stop_wmodules() had actually finished -- so the new process
+ * started up over the still-shutting-down old one. */
 int CheckServiceRunning()
 {
     int rc = 0;
@@ -126,7 +154,7 @@ int CheckServiceRunning()
             SERVICE_STATUS lpServiceStatus;
 
             if (QueryServiceStatus(schService, &lpServiceStatus)) {
-                if (lpServiceStatus.dwCurrentState == SERVICE_RUNNING) {
+                if (lpServiceStatus.dwCurrentState != SERVICE_STOPPED) {
                     rc = 1;
                 }
             }
@@ -226,9 +254,38 @@ int UninstallService()
     /* Remove from the service database */
     schSCManager = OpenSCManager(NULL, NULL, SC_MANAGER_ALL_ACCESS);
     if (schSCManager) {
-        schService = OpenService(schSCManager, g_lpszServiceName, SERVICE_STOP | DELETE);
+        schService = OpenService(schSCManager, g_lpszServiceName, SERVICE_STOP | DELETE | SERVICE_QUERY_STATUS);
         if (schService) {
-            if (CheckServiceRunning()) {
+            /* Query the raw state directly instead of CheckServiceRunning(): that
+             * helper now treats anything but SERVICE_STOPPED as "running" (issue
+             * 38428, to fix the restart-wait loop giving up too early), but here a
+             * SERVICE_STOP_PENDING service can't accept a fresh SERVICE_CONTROL_STOP
+             * -- ControlService() would fail with ERROR_SERVICE_CANNOT_ACCEPT_CTRL,
+             * skipping DeleteService() below and reporting the whole uninstall as
+             * failed even though the service was already on its way out. */
+            SERVICE_STATUS currentStatus;
+            BOOL queried = QueryServiceStatus(schService, &currentStatus);
+            DWORD currentState = queried ? currentStatus.dwCurrentState : SERVICE_RUNNING;
+
+            if (queried && currentState == SERVICE_STOPPED) {
+                plain_minfo("Found (%s) service is not running.", g_lpszServiceName);
+                ret = 1;
+            } else if (queried && currentState == SERVICE_STOP_PENDING) {
+                plain_minfo("Found (%s) service is already stopping; waiting for it to finish.", g_lpszServiceName);
+
+                const DWORD stopWaitTimeoutMs = 45000;
+                const DWORD waitStart = GetTickCount();
+                ret = 1;
+
+                while (QueryServiceStatus(schService, &currentStatus) && currentStatus.dwCurrentState != SERVICE_STOPPED) {
+                    if (GetTickCount() - waitStart > stopWaitTimeoutMs) {
+                        plain_merror("Failure waiting for (%s) to finish stopping before removing it.", g_lpszServiceName);
+                        ret = 0;
+                        break;
+                    }
+                    Sleep(500);
+                }
+            } else {
                 plain_minfo("Found (%s) service is running going to try and stop it.", g_lpszServiceName);
                 ret = ControlService(schService, SERVICE_CONTROL_STOP, &lpServiceStatus);
                 if (!ret) {
@@ -236,9 +293,6 @@ int UninstallService()
                 } else {
                     plain_minfo("Successfully stopped (%s).", g_lpszServiceName);
                 }
-            } else {
-                plain_minfo("Found (%s) service is not running.", g_lpszServiceName);
-                ret = 1;
             }
 
             if (ret && DeleteService(schService)) {
@@ -292,11 +346,23 @@ VOID WINAPI OssecServiceCtrlHandler(DWORD dwOpcode)
                 // Kill children processes spawned by modules, only in wazuh-agent
                 wm_kill_children();
                 stop_wmodules();
+                // stop_wmodules()'s own join loop (win_utils.c) drives dwWaitHint down to a few
+                // seconds at a time via report_stop_progress() -- appropriate while it's still
+                // actively reporting every couple of seconds, but fim_db_teardown() below has no
+                // progress reporting of its own and can run up to FIM_TEARDOWN_BUDGET_MS. Without
+                // re-widening the hint here first, the SCM would only be covered for the last few
+                // seconds stop_wmodules() reported, not this next phase (issue 38428).
+                report_stop_progress(ossecServiceStatus.dwCheckPoint + 1, FIM_TEARDOWN_BUDGET_MS + 5000);
                 fim_db_teardown();
 #endif
-                // A stopped service has no transition left to describe.
-                ossecServiceStatus.dwWaitHint               = 0;
+                // report_stop_progress() (called from stop_wmodules()'s join loop, above)
+                // leaves dwCheckPoint/dwWaitHint at whatever it last wrote to signal an
+                // in-progress stop; a terminal state has no pending operation left to
+                // report, so both must go back to zero here rather than being left stale
+                // (issue 38428).
                 ossecServiceStatus.dwCurrentState           = SERVICE_STOPPED;
+                ossecServiceStatus.dwCheckPoint              = 0;
+                ossecServiceStatus.dwWaitHint                = 0;
                 SetServiceStatus (ossecServiceStatusHandle, &ossecServiceStatus);
                 plain_minfo("Exit completed successfully.");
                 break;
@@ -329,6 +395,16 @@ int os_WinMain(__attribute__((unused)) int argc, __attribute__((unused)) char **
 /* Start OSSEC service */
 void WINAPI OssecServiceStart (__attribute__((unused)) DWORD argc, __attribute__((unused)) LPTSTR *argv)
 {
+#ifdef OSSECHIDS
+    /* Must run before RegisterServiceCtrlHandler() below: from that point on,
+     * the SCM can invoke OssecServiceCtrlHandler() -> stop_wmodules(), which
+     * takes wm_lifecycle_lock (issue 38428). wm_lifecycle_lock_init() is only
+     * defined in win_utils.c (win32_common), which this file is also compiled
+     * without (win32_service_rk, for the setup/UI tools) -- so this call must
+     * stay inside the same OSSECHIDS guard as stop_wmodules()/local_start(). */
+    wm_lifecycle_lock_init();
+#endif
+
     ossecServiceStatus.dwServiceType            = SERVICE_WIN32;
     ossecServiceStatus.dwCurrentState           = SERVICE_START_PENDING;
     ossecServiceStatus.dwControlsAccepted       = SERVICE_ACCEPT_STOP;

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -21,13 +21,51 @@
 #include "dll_load_notify.h"
 #include "startup_gate_op.h"
 #include "agent_sync_protocol_c_interface.h"
+#include "os_win.h"
 
 #ifdef WAZUH_UNIT_TESTING
 #include "unit_tests/wrappers/windows/libc/kernel32_wrappers.h"
+#include "unit_tests/wrappers/windows/processthreadsapi_wrappers.h"
+#include "unit_tests/wrappers/windows/handleapi_wrappers.h"
+// Remove STATIC qualifier from tests
+#define STATIC
+#else
+#define STATIC static
 #endif
 
 HANDLE hMutex;
 int win_debug_level;
+
+/* Guards the "is a shutdown already in progress" decision against the actual
+ * mutation it gates: wm_config() building the wmodules list and each module
+ * thread being spawned (local_start(), below) versus stop_wmodules() setting
+ * wm_shutdown_requested and walking that same list. Without this, a stop
+ * landing mid-startup could run stop_wmodules() against an empty/half-built
+ * list, or local_start() could keep spawning module threads after a shutdown
+ * was already requested (issue 38428). Initialized once, from
+ * wm_lifecycle_lock_init(), before OssecServiceStart() registers the ctrl
+ * handler that can call stop_wmodules() -- see win_service.c. */
+static CRITICAL_SECTION wm_lifecycle_lock;
+static volatile LONG wm_lifecycle_lock_initialized = 0;
+
+/* Idempotent: local_start() (and therefore wm_start_modules_unless_shutting_down(),
+ * which takes wm_lifecycle_lock) is reachable both from OssecServiceStart() -- which
+ * calls this first -- and directly from "wazuh-agent.exe start" (win_agent.c), which
+ * never goes through OssecServiceStart() at all. Without the guard below, the "start"
+ * CLI path would enter wm_start_modules_unless_shutting_down()'s EnterCriticalSection()
+ * on a never-initialized CRITICAL_SECTION (issue 38428). Safe to call from both paths:
+ * InterlockedCompareExchange ensures InitializeCriticalSection() only actually runs once. */
+void wm_lifecycle_lock_init(void)
+{
+    if (InterlockedCompareExchange(&wm_lifecycle_lock_initialized, 1, 0) == 0) {
+        InitializeCriticalSection(&wm_lifecycle_lock);
+    }
+}
+
+/* Defined in win_service.c: pumps dwCheckPoint/dwWaitHint back to the SCM
+ * while stop_wmodules() is still joining module threads, so a slow shutdown
+ * doesn't look hung to the SCM (issue 38428, defect #7). */
+extern void report_stop_progress(DWORD checkpoint, DWORD wait_hint_ms);
 
 void *sysinfo_module = NULL;
 sysinfo_networks_func sysinfo_network_ptr = NULL;
@@ -36,12 +74,6 @@ sysinfo_free_result_func sysinfo_free_result_ptr = NULL;
 /** Prototypes **/
 int Start_win32_Syscheck();
 
-typedef struct win_module_start_ctx {
-    wm_routine routine;
-    void *data;
-    char name[OS_SIZE_128];
-} win_module_start_ctx_t;
-
 /* syscheck main thread */
 #ifdef WIN32
 DWORD WINAPI skthread(__attribute__((unused)) LPVOID arg)
@@ -49,8 +81,9 @@ DWORD WINAPI skthread(__attribute__((unused)) LPVOID arg)
 void *skthread()
 #endif
 {
-    startup_gate_wait_for_ready("wazuh-syscheckd");
-    Start_win32_Syscheck();
+    if (startup_gate_wait_for_ready("wazuh-syscheckd") == STARTUP_GATE_READY) {
+        Start_win32_Syscheck();
+    }
 #ifdef WIN32
     return 0;
 #else
@@ -65,8 +98,9 @@ DWORD WINAPI logcollector_thread(__attribute__((unused)) LPVOID arg)
 void *logcollector_thread()
 #endif
 {
-    startup_gate_wait_for_ready("wazuh-logcollector");
-    LogCollectorStart();
+    if (startup_gate_wait_for_ready("wazuh-logcollector") == STARTUP_GATE_READY) {
+        LogCollectorStart();
+    }
 #ifdef WIN32
     return 0;
 #else
@@ -91,32 +125,37 @@ void *win_module_thread(void *arg)
 #endif
     }
 
-    startup_gate_wait_for_ready(ctx->name[0] ? ctx->name : "wazuh-modulesd");
+    startup_gate_wait_result_t gate_result = startup_gate_wait_for_ready(ctx->name[0] ? ctx->name : "wazuh-modulesd");
 
     // The gate also releases when shutdown is requested, so getting here does not mean
     // the agent is starting -- it may already be stopping. Starting a module then is
     // never useful: it opens databases and runs a scan that the join below is about to
     // interrupt anyway. Each module also refuses to start under a stop it already
     // received (wm_sys_stop() records it before returning, SCA sets g_shutting_down,
-    // agent-info consults the injected predicate), but this check keeps the whole
-    // routine from running in the first place.
-    if (wm_shutdown_requested) {
-        mdebug1("Shutdown requested before '%s' started; skipping module start.",
-                ctx->name[0] ? ctx->name : "wazuh-modulesd");
-        os_free(ctx);
+    // agent-info consults the injected predicate), but checking gate_result here keeps
+    // the whole routine from running in the first place -- and unlike a bare
+    // wm_shutdown_requested re-check, the same STARTUP_GATE_SHUTDOWN_REQUESTED result
+    // also covers every other gated entry point (wazuh-syscheckd, wazuh-logcollector,
+    // execd), not just this one (issue 38428).
+    //
+    // gate_result is a snapshot from the moment startup_gate_wait_for_ready() last
+    // queried the gate -- a real IPC round trip, not an instantaneous check -- so a
+    // stop can still land between that query returning "ready" and ctx->routine()
+    // actually running below. Re-reading wm_shutdown_requested here is a cheap,
+    // near-zero-latency second look that closes almost all of that window.
+    const bool shutdown_before_start = (gate_result != STARTUP_GATE_READY) || wm_shutdown_requested;
 #ifdef WIN32
-        return 0;
-#else
-        return NULL;
-#endif
+    DWORD result = 0;
+    if (!shutdown_before_start) {
+        result = ctx->routine(ctx->data);
     }
-
-#ifdef WIN32
-    DWORD result = ctx->routine(ctx->data);
     os_free(ctx);
     return result;
 #else
-    void *result = ctx->routine(ctx->data);
+    void *result = NULL;
+    if (!shutdown_before_start) {
+        result = ctx->routine(ctx->data);
+    }
     os_free(ctx);
     return result;
 #endif
@@ -127,7 +166,18 @@ void stop_wmodules()
     // Signal the agent-wide shutdown so dispatchers (e.g. modulesSync) skip work
     // that targets modules already being torn down. On POSIX the modulesd SIGTERM
     // handler sets this; on Windows shutdown flows through here instead.
+    //
+    // Set under wm_lifecycle_lock, atomically with the check local_start() makes
+    // before building the wmodules list / spawning module threads (issue 38428):
+    // whichever of the two gets there first, the other sees a consistent state --
+    // either the list is untouched and local_start() is about to skip it entirely,
+    // or local_start() already finished spawning everything and this walk below
+    // sees the complete, stable list. The lock is released immediately after,
+    // deliberately NOT held through the (potentially many-second) join loop below,
+    // so it never makes a pending stop wait any longer than it has to.
+    EnterCriticalSection(&wm_lifecycle_lock);
     wm_shutdown_requested = 1;
+    LeaveCriticalSection(&wm_lifecycle_lock);
 
     // Two passes, mirroring the POSIX SIGTERM handler (wazuh_modules/src/main.c):
     // signal every module first, then join every module against one shared budget.
@@ -149,7 +199,12 @@ void stop_wmodules()
     // with no timeout of their own. Each module runs its own teardown before its thread
     // returns, so the join is what guarantees that teardown completed.
     const DWORD MODULE_JOIN_BUDGET_MS = 20000;
+    // Upper bound on how long any single wait slice blocks, so report_stop_progress()
+    // gets called often enough that the SCM never sees a stale checkpoint for more
+    // than this long, even while waiting on one slow module (issue 38428, defect #7).
+    const DWORD CHECKPOINT_SLICE_MS = 2000;
     const ULONGLONG budget_start = GetTickCount64();
+    DWORD checkpoint = 1;
 
     for (cur_module = wmodules; cur_module; cur_module = cur_module->next) {
         if (cur_module->context->stop) {
@@ -173,15 +228,25 @@ void stop_wmodules()
                 continue;
             }
 
-            const ULONGLONG elapsed = GetTickCount64() - budget_start;
-            const DWORD remaining = (elapsed < MODULE_JOIN_BUDGET_MS) ? (DWORD)(MODULE_JOIN_BUDGET_MS - elapsed) : 0;
+            DWORD wait_result;
 
-            // Always ask, even with the budget spent: a zero timeout still reports
-            // WAIT_OBJECT_0 for a thread that already finished. Asserting a timeout
-            // without looking at the handle logged the error below for modules that
-            // had shut down cleanly and were merely charged for a budget an earlier
-            // module had spent.
-            const DWORD wait_result = WaitForSingleObject(cur_module->win_thread, remaining);
+            while (1) {
+                const ULONGLONG elapsed = GetTickCount64() - budget_start;
+                const DWORD remaining = (elapsed < MODULE_JOIN_BUDGET_MS) ? (DWORD)(MODULE_JOIN_BUDGET_MS - elapsed) : 0;
+                const DWORD slice = remaining < CHECKPOINT_SLICE_MS ? remaining : CHECKPOINT_SLICE_MS;
+
+                // Always ask, even with the budget spent: a zero-length wait still
+                // reports WAIT_OBJECT_0 for a thread that already finished. Asserting
+                // a timeout without looking at the handle logged the error below for
+                // modules that had shut down cleanly and were merely charged for a
+                // budget an earlier module had spent.
+                wait_result = WaitForSingleObject(cur_module->win_thread, slice);
+                report_stop_progress(checkpoint++, CHECKPOINT_SLICE_MS * 2);
+
+                if (wait_result != WAIT_TIMEOUT || remaining == 0) {
+                    break;
+                }
+            }
 
             if (wait_result == WAIT_TIMEOUT) {
                 merror("Module '%s' worker thread did not exit within the %lu ms shutdown budget; "
@@ -198,6 +263,64 @@ void stop_wmodules()
     }
 }
 
+/* Loads the wodle configuration and spawns a module thread per configured
+ * wodle -- unless a shutdown is already in progress, in which case it skips
+ * both entirely. Extracted out of local_start() so this specific check can be
+ * unit-tested without dragging in local_start()'s enrollment/HTTPS-client/
+ * syscheck/logcollector setup.
+ *
+ * Shares wm_lifecycle_lock with stop_wmodules(): holding it across
+ * "check the flag, then build the list, then spawn every thread" makes that
+ * whole sequence atomic with respect to a concurrent stop_wmodules() call, so
+ * a stop landing mid-startup either sees the pre-startup empty list (and
+ * local_start() then sees the flag and skips out) or the fully-spawned list
+ * (issue 38428, defects #2/#3/#5). The lock is only held across
+ * w_create_thread() itself (fast, non-blocking) -- never across a module's
+ * own subsequent Run(), which happens on that module's own thread. */
+STATIC void wm_start_modules_unless_shutting_down(void)
+{
+    DWORD threadID2;
+
+    EnterCriticalSection(&wm_lifecycle_lock);
+
+    if (wm_shutdown_requested) {
+        LeaveCriticalSection(&wm_lifecycle_lock);
+        mdebug1("Shutdown already in progress; skipping wodle startup.");
+        return;
+    }
+
+    /* Read wodle configuration */
+    if (wm_config() < 0) {
+        LeaveCriticalSection(&wm_lifecycle_lock);
+        mlerror_exit(LOGLEVEL_ERROR, CONFIG_ERROR, WAZUHCONF);
+    }
+
+    /* Start modules */
+    if (!wm_check()) {
+        wmodule * cur_module;
+
+        for (cur_module = wmodules; cur_module; cur_module = cur_module->next) {
+            win_module_start_ctx_t *start_ctx = NULL;
+            const char *module_name = NULL;
+
+            os_calloc(1, sizeof(win_module_start_ctx_t), start_ctx);
+            start_ctx->routine = cur_module->context->start;
+            start_ctx->data = cur_module->data;
+            module_name = (cur_module->context && cur_module->context->name) ? cur_module->context->name : "module";
+            snprintf(start_ctx->name, sizeof(start_ctx->name), "wazuh-modulesd/%s", module_name);
+
+            cur_module->win_thread = w_create_thread(NULL,
+                                                      0,
+                                                      win_module_thread,
+                                                      start_ctx,
+                                                      0,
+                                                      (LPDWORD)&threadID2);
+        }
+    }
+
+    LeaveCriticalSection(&wm_lifecycle_lock);
+}
+
 /* Locally start (after service/win init) */
 int local_start()
 {
@@ -207,7 +330,6 @@ int local_start()
     char *cfg = WAZUHCONF;
     WSADATA wsaData;
     DWORD  threadID;
-    DWORD  threadID2;
 
     win_debug_level = getDefine_Int("windows", "debug", 0, 2);
 
@@ -390,33 +512,9 @@ int local_start()
     /* Initialize children pool */
     wm_children_pool_init();
 
-    /* Read wodle configuration */
-    if (wm_config() < 0) {
-        mlerror_exit(LOGLEVEL_ERROR, CONFIG_ERROR, cfg);
-    }
-
-    /* Start modules */
-    if (!wm_check()) {
-        wmodule * cur_module;
-
-        for (cur_module = wmodules; cur_module; cur_module = cur_module->next) {
-            win_module_start_ctx_t *start_ctx = NULL;
-            const char *module_name = NULL;
-
-            os_calloc(1, sizeof(win_module_start_ctx_t), start_ctx);
-            start_ctx->routine = cur_module->context->start;
-            start_ctx->data = cur_module->data;
-            module_name = (cur_module->context && cur_module->context->name) ? cur_module->context->name : "module";
-            snprintf(start_ctx->name, sizeof(start_ctx->name), "wazuh-modulesd/%s", module_name);
-
-            cur_module->win_thread = w_create_thread(NULL,
-                                                      0,
-                                                      win_module_thread,
-                                                      start_ctx,
-                                                      0,
-                                                      (LPDWORD)&threadID2);
-        }
-    }
+    /* Read wodle configuration and spawn a thread per configured module --
+     * unless a shutdown has already been requested (issue 38428). */
+    wm_start_modules_unless_shutting_down();
 
     /* Initialize random numbers */
     srandom(time(0));


### PR DESCRIPTION
## Description

On Windows, `OssecServiceStart()` reports `SERVICE_RUNNING` before `local_start()` finishes building the `wmodules` list and spawning module threads, so the SCM can deliver `SERVICE_CONTROL_STOP` on its own thread at any point during startup, with nothing serializing it against `local_start()`. Depending on timing, this lets module threads (including SCA) start after a shutdown was already requested, and SCA's `scan_on_start` is driven by a `Run()`-local flag with no persisted marker, so a scan skipped this way is silently lost until the next `<interval>` (12h by default). Separately, overlapping/concurrent `service-restart` invocations could race each other's stop/start and leave the service permanently `SERVICE_STOPPED` with no self-recovery.

Closes #38428

## Proposed Changes

Three commits:

1. **`startup_gate_wait_for_ready()` distinguishes shutdown-requested from ready.** It now returns an enum (`STARTUP_GATE_READY` / `STARTUP_GATE_SHUTDOWN_REQUESTED`) instead of releasing the same way either way, and every daemon entry point that gates on it (`syscheckd`, `wazuh-modulesd`, `wazuh-execd`, `wazuh-logcollector`) exits without starting when a shutdown is already in flight. SCA additionally persists a `first_scan_completed` marker (alongside the existing `first_sync_completed`/`last_integrity_check` pattern), so an interrupted first scan is retried on the next start instead of waiting a full `<interval>`, and logs a debug-level line noting the skip (expected occurrence, not an error).
2. **A Windows lifecycle lock (`CRITICAL_SECTION`) makes module-thread creation and `stop_wmodules()` mutually exclusive**, closing the race where a stop could run against an empty/half-built module list, or `local_start()` could keep spawning threads after shutdown was requested. Every Windows thread-based module entry point (`skthread`, `logcollector_thread`, `win_module_thread`, execd's `win_exec_main`) now checks the gate result. `CheckServiceRunning()` is broadened from "only true for `SERVICE_RUNNING`" to "true for anything but `SERVICE_STOPPED`", fixing a related race where the restart-wait loop gave up while the old process was still mid-shutdown, and the stop handler now reports its checkpoint to the SCM every 2s so a slow shutdown doesn't read as hung.
3. **A named, cross-process mutex serializes concurrent `service-restart` invocations**, with a bounded ~60s wait and a loud error log if exceeded, instead of N overlapping restarts independently racing `os_stop_service()`/`os_start_service()` against each other.

### Results and Evidence

- Native Linux (`TARGET=agent`) build clean with and without `TEST=1`; all touched shared code compiles and runs there (the Windows-only pieces are entirely `#ifdef WIN32`, so they have zero Linux surface).
- SCA gtest suite: 10/10 passing, both natively on Linux and cross-compiled for `winagent`, including a real RED→GREEN TDD demonstration for the new first-scan-completed marker.
- New unit tests: `test_startup_gate_op` (cmocka, 2/2, both shared-code paths), `test_win_agent` (cmocka, 5/5, `CheckServiceRunning` behavior), plus ~10 new `test_win_utils` cases covering the lifecycle lock and gate-check wiring.
- Real Windows VM regression (Vagrant/VirtualBox, real manager): 8/8 sequential `service-restart` cycles clean; 3 batches of 5 concurrent/overlapping restarts all end with the service `RUNNING`; SCA's `Scan started`/`Scan ended` pair fires on every single restart with zero silent drops across 23 restart invocations, zero `service-restart` failures logged.
- Live Linux agent in the repo's `wazuh-testenv` Docker setup, built from this branch and enrolled against a real manager: 5/5 sequential restarts clean, 7/7 SCA scan-start/end pairs matched with no gaps, zero startup-gate log lines (expected — Linux's `wazuh-control restart` is a plain sequential script, unrelated to the Windows SCM race), and no new errors/warnings introduced (the one warning present is a pre-existing, unrelated VD-feed message).
- A scare during development turned out to be a test-harness artifact, not a code bug: an early concurrent-restart run showed the service getting stuck `SERVICE_STOPPED`, root-caused to WinRM's one-shot session killing the detached restart-helper processes via its own job-object cleanup, not the fix. Re-running inside one continuous session showed the mutex serializing correctly every time.

Full raw evidence (build/test logs, VM transcripts, per-run diagnostics) will follow in a comment on this PR rather than being committed to the repo.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X — not tested in this environment (no macOS toolchain available); the shared code touched here (startup gate, SCA) is cross-platform and unchanged in logic on that path, but this wasn't independently verified.
- [x] Log syntax and correct language review — the new debug-level SCA log and the restart-mutex timeout error were specifically reviewed for severity/wording during design.

- Memory tests for Windows
  - [ ] Coverity — not run
  - [ ] UMDH — not run
- Memory tests for Linux
  - [ ] Coverity — not run
  - [ ] Valgrind — not run
  - [ ] AddressSanitizer — not run

### Artifacts Affected

- `wazuh-agent.exe` / `wazuh-agent-eventchannel.exe` (Windows agent binary and service control)
- `wazuh-modulesd` (SCA module, all platforms)
- `wazuh-syscheckd`, `wazuh-execd`, `wazuh-logcollector` daemon entry points (all platforms, startup gate check)

### Configuration Changes

N/A — no new configuration parameters, no default value changes.

### Tests Introduced

- `unit_tests/shared/test_startup_gate_op.c` (new): validates `STARTUP_GATE_SHUTDOWN_REQUESTED` is returned and logged correctly, including a NULL/empty module name edge case.
- `unit_tests/win32/test_win_agent.c` (new): 5 cases for `CheckServiceRunning()`'s broadened state handling (`SERVICE_RUNNING`, `SERVICE_STOP_PENDING`, `SERVICE_START_PENDING`, `SERVICE_STOPPED`, missing service).
- `unit_tests/win32/test_win_utils.c`: ~10 new cases for the lifecycle lock and gate-check wiring in `skthread`/`logcollector_thread`/`win_module_thread`/`stop_wmodules`.
- SCA gtest: `Run_SetsFirstScanCompletedAfterFirstSuccessfulScan`, plus fixed mock sequences in `SCADataCleanTest` for the new metadata lookup.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented (N/A, none)
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues