### PR TITLE
fix compression agent configuration

### DIFF
--- a/src/client-agent/https_client/src/controlStream.cpp
+++ b/src/client-agent/https_client/src/controlStream.cpp
@@ -165,7 +165,7 @@ ControlStream::ControlStream(const ModuleConfig& config, IHttpPerformer& perform
     , m_authGate(authGate)
     , m_taskStore(taskStore)
     , m_vdOffsetStore(vdOffsetStore)
-    , m_rescanRequester(config, performer, signer, clock, random, authGate, vdOffsetStore)
+    , m_rescanRequester(config, performer, signer, clock, random, authGate, compressionGate, vdOffsetStore)
     , m_collectHost(std::move(collectHost))
 {
 }

--- a/src/client-agent/https_client/src/rescanRequester.cpp
+++ b/src/client-agent/https_client/src/rescanRequester.cpp
@@ -73,10 +73,15 @@ namespace
 
 RescanRequester::RescanRequester(const ModuleConfig& config, IHttpPerformer& performer,
                                  const ISigner& signer, IClock& clock, IRandom& random,
-                                 AuthGate& authGate, IVdOffsetStore& store)
+                                 AuthGate& authGate, CompressionGate& compressionGate,
+                                 IVdOffsetStore& store)
     : m_config(config)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
-    , m_sender(performer, signer, clock, m_backoff, &authGate)
+    // All seven arguments, like every other RetrySender in this module: the old 5-argument form
+    // let &authGate convert to the `bool compressionEnabled` slot, which force-compressed every
+    // /scan/vd, left the shared CompressionGate out of a 415 here, and dropped 401s on the
+    // floor (never reaching AuthGate::reportAuthFailure).
+    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate)
     , m_store(store)
 {
 }

--- a/src/client-agent/https_client/src/rescanRequester.cpp
+++ b/src/client-agent/https_client/src/rescanRequester.cpp
@@ -77,10 +77,10 @@ RescanRequester::RescanRequester(const ModuleConfig& config, IHttpPerformer& per
                                  IVdOffsetStore& store)
     : m_config(config)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
-    // All seven arguments, like every other RetrySender in this module: the old 5-argument form
-    // let &authGate convert to the `bool compressionEnabled` slot, which force-compressed every
-    // /scan/vd, left the shared CompressionGate out of a 415 here, and dropped 401s on the
-    // floor (never reaching AuthGate::reportAuthFailure).
+      // All seven arguments, like every other RetrySender in this module: the old 5-argument form
+      // let &authGate convert to the `bool compressionEnabled` slot, which force-compressed every
+      // /scan/vd, left the shared CompressionGate out of a 415 here, and dropped 401s on the
+      // floor (never reaching AuthGate::reportAuthFailure).
     , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate)
     , m_store(store)
 {

--- a/src/client-agent/https_client/src/rescanRequester.hpp
+++ b/src/client-agent/https_client/src/rescanRequester.hpp
@@ -48,7 +48,8 @@ class RescanRequester final
     public:
         RescanRequester(const ModuleConfig& config, IHttpPerformer& performer,
                         const ISigner& signer, IClock& clock, IRandom& random,
-                        AuthGate& authGate, IVdOffsetStore& store);
+                        AuthGate& authGate, CompressionGate& compressionGate,
+                        IVdOffsetStore& store);
 
         /// Attempts to satisfy the pending re-scan for `offset` (as reported by
         /// IVdOffsetStore::observe()). Returns true if the request succeeded

--- a/src/client-agent/https_client/tests/unit/controlStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/controlStream_test.cpp
@@ -1349,6 +1349,50 @@ TEST_F(ControlStreamTest, PendingRescanAdvancesOffsetAndRetriesOn409WithNewerVer
     EXPECT_FALSE(m_vdOffsetStore.pending());
 }
 
+// The invariant the manager side leans on for every /scan/vd 503 (scan_queue_full,
+// indexer_unavailable, shutting_down): shedding at admission loses no work, because the pending
+// flag survives anything but a 200 and the next notify re-requests it. One attempt per cycle
+// here -- the fixture's FakeWaiter interrupts in-request backoff waits; the in-request retry
+// ladder is RetrySender's own contract.
+TEST_F(ControlStreamTest, PendingRescanSurvivesA503AndReRequestsOnTheNextNotify)
+{
+    const std::string notify = R"({"status":"ok","vd_feed_offset":100})";
+    int scanVdCalls = 0;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}"))) // Startup.
+    .WillRepeatedly(Invoke([&](const HttpRequestSpec & spec)
+    {
+        if (spec.target == "/control")
+        {
+            return response(TransportStatus::Ok, 200, notify);
+        }
+
+        // /scan/vd: the first request cycle fails, as it would during an indexer outage;
+        // the re-request on the next notify succeeds.
+        ++scanVdCalls;
+
+        if (scanVdCalls == 1)
+        {
+            return response(TransportStatus::Ok, 503, R"({"error":"indexer_unavailable","retryable":true})");
+        }
+
+        return response(TransportStatus::Ok, 200, "{}");
+    }));
+
+    m_stream.step(m_waiter); // Startup.
+    m_stream.step(m_waiter); // Notify -> pending(100) -> /scan/vd 503.
+
+    EXPECT_EQ(1, scanVdCalls);
+    EXPECT_TRUE(m_vdOffsetStore.pending()) << "a 503 must NOT clear the pending flag";
+    EXPECT_TRUE(m_vdOffsetStore.clearPendingCalls().empty());
+
+    m_stream.step(m_waiter); // Same-offset notify: observe() re-reports pending -> re-request -> 200.
+
+    EXPECT_EQ(2, scanVdCalls) << "the next notify re-fires the request without any new offset";
+    EXPECT_FALSE(m_vdOffsetStore.pending());
+    EXPECT_THAT(m_vdOffsetStore.clearPendingCalls(), ::testing::ElementsAre(100u));
+}
+
 TEST_F(ControlStreamTest, NoPendingRescanMeansNoScanVdRequest)
 {
     // VDFirst not done: observe() persists the offset but never marks pending, so no


### PR DESCRIPTION
## Description

`RescanRequester` (the agent-side sender of `POST /scan/vd`, `src/client-agent/https_client/src/rescanRequester.cpp`) constructed its `RetrySender` with only 5 of the 7 constructor arguments:

```cpp
, m_sender(performer, signer, clock, m_backoff, &authGate)
```

`RetrySender`'s constructor takes **seven** parameters:

```cpp
RetrySender(IHttpPerformer& performer, const ISigner& signer, IClock& clock, Backoff& backoff,
            bool compressionEnabled, CompressionGate* compressionGate = nullptr,
            AuthGate* authGate = nullptr);
```

With only five arguments supplied, `&authGate` (an `AuthGate*`) silently converted to the fifth parameter — `bool compressionEnabled` — via an implicit pointer→bool conversion, which always evaluates `true`. The two trailing pointer parameters then fell back to their `nullptr` defaults. This compiled without a single warning, and every effect was silent:

1. **`/scan/vd` bodies were always zstd-compressed**, regardless of the `httpsCompressionEnabled` module configuration.
2. **The shared `CompressionGate` was never wired** (`compressionGate == nullptr`). The gate's contract is fleet-wide: a `415` on any send path is supposed to disable compression for all of the agent's senders for the rest of the run. With `/scan/vd` unwired, it could neither disable compression for other paths, nor be disabled *by* them — after another path's `415` tripped the gate, `/scan/vd` kept sending compressed bodies regardless.
3. **The `AuthGate` was never wired** (`authGate == nullptr`). A persistent `401` on `/scan/vd` never reached `AuthGate::reportAuthFailure()`, so the "pause all traffic and surface re-enrollment" escalation (#37828) never triggered from this path.

Every other `RetrySender` construction site in the module (`controlStream.cpp`, `statefulStream.cpp`, `reporterStream.cpp`, `wpkFetcher.cpp`, `statelessStream.cpp`, `configFetcher.cpp`) passes all seven arguments — `RescanRequester` was the single outlier.

Closes #38442

## Proposed Changes

Pass the full seven-argument list to `RetrySender`, mirroring every other call site in the module:

- `rescanRequester.hpp`/`.cpp`: added a `CompressionGate&` parameter to `RescanRequester`'s constructor, and the `RetrySender` member is now built with `config.httpsCompressionEnabled, &compressionGate, &authGate` instead of the old 5-argument form.
- `controlStream.cpp`: `RescanRequester`'s only caller (`ControlStream`, which already owns a `compressionGate` reference) now threads it through, the same way it already does for `m_fetcher`/`m_wpkFetcher`.

No behavior changes to any of the six already-correctly-wired `RetrySender` sites.

### Results and Evidence

**Unit tests** — full `https_client_unit_test` suite green on a `TARGET=agent` build (`make deps/build TARGET=agent TEST=yes` + `ctest -R https_client_unit_test`): `100% tests passed, 0 tests failed out of 1`. The new regression test (`PendingRescanSurvivesA503AndReRequestsOnTheNextNotify`) passes standalone as well, pinning the invariant that a `503` on `/scan/vd` never clears the durable pending flag and the next notify re-requests it.

**Live end-to-end validation** on a real manager+agent pair (both rebuilt from this branch):
- Reset the agent's local `vd_feed_state` (`has_offset=0`) and restarted it. The state round-tripped from the manual reset back to `has_offset=1, last_offset=849527, pending=0, pending_offset=849527` with no further intervention — only possible if `observeVdFeedOffset()` → `RescanRequester` → `POST /scan/vd` → `clearVdRescanPending()` executed successfully end-to-end through the fixed 7-argument wiring.
- Installed a package with real, current CVEs (`p7zip-full`, uninvolved in any other test) and let the manager's normal `package_delta`/`VDSync` scan path run. It correctly reported `1 vulnerable package, 2 new` and indexed `CVE-2023-52169` and `CVE-2023-52168` (both High severity) for the test agent — confirming the fix doesn't just avoid crashing, it produces a real, correct rescan.
- Verified the compression-negotiation matrix live, using temporary debug instrumentation in `retrySender.cpp` (reverted before this diff) to log `target/compressed/httpCode/outcome` per attempt, across all 4 combinations of the manager's `remoted.http_content_encoding_enabled` and the agent's `agent.https_compression_enabled`:

  | Manager | Agent | Observed |
  |---|---|---|
  | supports | enabled | Every request compressed, all succeed (200/202) |
  | rejects | enabled | First request compressed → `415` → same-call uncompressed retry succeeds → every subsequent request on *every* endpoint (`/control`, `/stateless`, `/config`) sent uncompressed from the start (shared `CompressionGate` trips once, fleet-wide, for the rest of the run) |
  | supports | disabled | Agent never attempts compression; all succeed uncompressed |
  | rejects | disabled | Same as above — the manager's rejection is never triggered since nothing arrives compressed |

  This confirms the exact bug being fixed: before this change, `RescanRequester`'s own `RetrySender` had a null `CompressionGate`, so it would never observe another endpoint's `415`-triggered gate trip and would keep compressing `/scan/vd` regardless — and its own `415`s never reported back to the gate either, so it would repeat the same 415-then-uncompressed-retry cycle on every single `/scan/vd` call, forever, instead of converging after one.

### Artifacts Affected

- Agent executable (`TARGET=agent`, `TARGET=winagent`) — `https_client` static lib linked into `wazuh-agentd`.
- No manager-side artifacts affected; no default configuration files changed.

### Configuration Changes

N/A — no new configuration parameters, no default value changes. This fix makes `RescanRequester` correctly honor the *existing* `httpsCompressionEnabled` module config and the existing shared `CompressionGate`/`AuthGate`, which it was silently ignoring.

### Documentation Updates

N/A — no user-facing documentation changes; the fix corrects an internal wiring bug with no observable API/config surface change.

### Tests Introduced

Added `ControlStreamTest.PendingRescanSurvivesA503AndReRequestsOnTheNextNotify` to `src/client-agent/https_client/tests/unit/controlStream_test.cpp`: the first agent-side `/scan/vd` `503` regression case, pinning the invariant the manager's admission-time `503` design relies on — the durable pending flag survives any non-`200` response, and the next notify cycle re-requests it rather than silently dropping the rescan.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented — N/A, no configuration changes
- [ ] Developer documentation reflects the changes — N/A, no doc changes needed
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...
