### PR TITLE
Bound Snort full record appends to the available buffer space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Fixed the Windows agent MSI upgrade leaving the agent broken after the next reboot, and the silent `/q` upgrade hanging, when a system restart was pending. ([#38277](https://github.com/wazuh/wazuh/pull/38277))
 - Fixed `wazuh-execd` crashing when more active response commands than supported are defined. ([#38410](https://github.com/wazuh/wazuh/pull/38410))
 - Fixed WPK upgrade failing on agents without the `find` binary. ([#38431](https://github.com/wazuh/wazuh/pull/38431))
+- Bounded the `snort-full` log record appends to the available buffer space in `wazuh-logcollector`. ([#38472](https://github.com/wazuh/wazuh/pull/38472))
 
 ## [v4.14.8]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this project will be documented in this file.
 - Fixed the Windows agent MSI upgrade leaving the agent broken after the next reboot, and the silent `/q` upgrade hanging, when a system restart was pending. ([#38277](https://github.com/wazuh/wazuh/pull/38277))
 - Fixed `wazuh-execd` crashing when more active response commands than supported are defined. ([#38410](https://github.com/wazuh/wazuh/pull/38410))
 - Fixed WPK upgrade failing on agents without the `find` binary. ([#38431](https://github.com/wazuh/wazuh/pull/38431))
-- Bounded the `snort-full` log record appends to the available buffer space in `wazuh-logcollector`. ([#38472](https://github.com/wazuh/wazuh/pull/38472))
+- Bounded the `snort-full` log record appends to the available buffer space and sized the queued preprocessor message from its own line in `wazuh-logcollector`. ([#38472](https://github.com/wazuh/wazuh/pull/38472))
 
 ## [v4.14.8]
 

--- a/src/logcollector/read_snortfull.c
+++ b/src/logcollector/read_snortfull.c
@@ -16,7 +16,6 @@
 
 /* Read snort_full files */
 void *read_snortfull(logreader *lf, int *rc, int drop_it) {
-    int f_msg_size = OS_MAX_LOG_SIZE - 1;
     const char *one = "one";
     const char *two = "two";
     const char *p = NULL;
@@ -51,19 +50,16 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
         if (p == NULL) {
             if (strncmp(str, "[**] [", 6) == 0) {
                 snprintf(f_msg, sizeof(f_msg), "%s", str);
-                f_msg_size -= strlen(str);
                 p = one;
             }
         } else {
             if (p == one) {
                 /* Second line has the [Classification: */
                 if (strncmp(str, "[Classification: ", 16) == 0) {
-                    strncat(f_msg, str, f_msg_size);
-                    f_msg_size -= strlen(str);
+                    strncat(f_msg, str, sizeof(f_msg) - strlen(f_msg) - 1);
                     p = two;
                 } else if (strncmp(str, "[Priority: ", 10) == 0) {
-                    strncat(f_msg, LABEL_PREPROCESSOR_MESSAGE, f_msg_size);
-                    f_msg_size -= sizeof(LABEL_PREPROCESSOR_MESSAGE) - 1;
+                    strncat(f_msg, LABEL_PREPROCESSOR_MESSAGE, sizeof(f_msg) - strlen(f_msg) - 1);
                     p = two;
                 }
 
@@ -71,9 +67,8 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
                  * the classification.
                  */
                 else if ((str[2] == '/') && (str[5] == '-') && (q = strchr(str, ' '))) {
-                    strncat(f_msg, LABEL_PREPROCESSOR_MESSAGE, f_msg_size);
-                    f_msg_size -= sizeof(LABEL_PREPROCESSOR_MESSAGE) - 1;
-                    strncat(f_msg, ++q, f_msg_size - 40);
+                    strncat(f_msg, LABEL_PREPROCESSOR_MESSAGE, sizeof(f_msg) - strlen(f_msg) - 1);
+                    strncat(f_msg, ++q, sizeof(f_msg) - strlen(f_msg) - 1);
 
                     /* Clean for next event */
                     p = NULL;
@@ -85,7 +80,6 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
                     }
 
                     f_msg[0] = '\0';
-                    f_msg_size = OS_MAX_LOG_SIZE - 1;
                     str[0] = '\0';
                 } else {
                     goto file_error;
@@ -93,7 +87,7 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
             } else if (p == two) {
                 /* Third line has the 01/13-15 (date) */
                 if ((str[2] == '/') && (str[5] == '-') && (q = strchr(str, ' '))) {
-                    strncat(f_msg, ++q, f_msg_size);
+                    strncat(f_msg, ++q, sizeof(f_msg) - strlen(f_msg) - 1);
                     p = NULL;
 
                     /* Check ignore and restrict log regex, if configured. */
@@ -103,7 +97,6 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
                     }
 
                     f_msg[0] = '\0';
-                    f_msg_size = OS_MAX_LOG_SIZE - 1;
                     str[0] = '\0';
                 } else {
                     goto file_error;

--- a/src/logcollector/read_snortfull.c
+++ b/src/logcollector/read_snortfull.c
@@ -76,7 +76,7 @@ void *read_snortfull(logreader *lf, int *rc, int drop_it) {
                     /* Check ignore and restrict log regex, if configured. */
                     if (drop_it == 0 && !check_ignore_and_restrict(lf->regex_ignore, lf->regex_restrict, str)) {
                         /* Send message to queue */
-                        w_msg_hash_queues_push(str, lf->file, strlen(f_msg), lf->log_target, LOCALFILE_MQ);
+                        w_msg_hash_queues_push(str, lf->file, strlen(str) + 1, lf->log_target, LOCALFILE_MQ);
                     }
 
                     f_msg[0] = '\0';

--- a/src/unit_tests/logcollector/CMakeLists.txt
+++ b/src/unit_tests/logcollector/CMakeLists.txt
@@ -154,6 +154,14 @@ else()
                                     -Wl,--wrap,wfopen -Wl,--wrap,w_msg_hash_queues_push -Wl,--wrap,check_ignore_and_restrict \
                                     -Wl,--wrap,_merror ${DEBUG_OP_WRAPPERS}")
 
+    list(APPEND logcollector_names "test_read_snortfull")
+    list(APPEND logcollector_flags "-Wl,--wrap,fopen -Wl,--wrap,popen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets \
+                                    -Wl,--wrap,fread -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fseek -Wl,--wrap=fgetc \
+                                    -Wl,--wrap,can_read -Wl,--wrap,w_ftell -Wl,--wrap,fgetpos -Wl,--wrap=w_update_file_status \
+                                    -Wl,--wrap=w_get_hash_context -Wl,--wrap=OS_SHA1_Stream -Wl,--wrap=w_fseek \
+                                    -Wl,--wrap,wfopen -Wl,--wrap,w_msg_hash_queues_push -Wl,--wrap,check_ignore_and_restrict \
+                                    -Wl,--wrap,_merror ${DEBUG_OP_WRAPPERS}")
+
 endif()
 
 list(LENGTH logcollector_names count)

--- a/src/unit_tests/logcollector/test_read_snortfull.c
+++ b/src/unit_tests/logcollector/test_read_snortfull.c
@@ -90,6 +90,25 @@ static char * build_line(const char *prefix, char filler, size_t len) {
     return line;
 }
 
+/* Builds a date line whose first space sits at index space_idx. */
+static char * build_date_line(size_t space_idx, const char *tail) {
+    size_t tail_len = strlen(tail);
+    char *line;
+
+    assert_true(space_idx >= 6);
+
+    line = calloc(space_idx + tail_len + 3, sizeof(char));
+    assert_non_null(line);
+
+    memcpy(line, "01/13-", 6);
+    memset(line + 6, 'Z', space_idx - 6);
+    line[space_idx] = ' ';
+    memcpy(line + space_idx + 1, tail, tail_len);
+    line[space_idx + 1 + tail_len] = '\n';
+
+    return line;
+}
+
 static void expect_line(char *line) {
     will_return(__wrap_can_read, 1);
     expect_any(__wrap_fgets, __stream);
@@ -153,8 +172,7 @@ void test_read_snortfull_complete_record(void **state) {
 /**
  * Test: preprocessor record whose first line already fills f_msg.
  * The free space left after the first line is smaller than the preprocessor
- * label, so the second append must be bounded to zero bytes and f_msg must stay
- * at OS_MAX_LOG_SIZE - 1.
+ * label, so both appends must be bounded to what is left.
  */
 void test_read_snortfull_preprocessor_full_buffer(void **state) {
     logreader lf = {0};
@@ -171,7 +189,7 @@ void test_read_snortfull_preprocessor_full_buffer(void **state) {
     expect_line(line2);
 
     will_return(__wrap_check_ignore_and_restrict, false);
-    expect_value(__wrap_w_msg_hash_queues_push, size, OS_MAX_LOG_SIZE - 1);
+    expect_value(__wrap_w_msg_hash_queues_push, size, strlen(line2));
     will_return(__wrap_w_msg_hash_queues_push, 0);
 
     expect_epilogue();
@@ -220,6 +238,39 @@ void test_read_snortfull_third_line_full_buffer(void **state) {
 }
 
 /**
+ * Test: preprocessor record shorter than its own date line.
+ * The queued message must be sized from the line that is actually queued, so
+ * that the copy carries its terminator regardless of how long the composed
+ * record is.
+ */
+void test_read_snortfull_preprocessor_message_length(void **state) {
+    logreader lf = {0};
+    lf.file = "test.log";
+    lf.fp = (FILE *) 1;
+    int rc;
+
+    char line1[] = "[**] [\n";
+    char *line2 = build_date_line(50, "abcde");
+
+    expect_prologue();
+
+    expect_line(line1);
+    expect_line(line2);
+
+    will_return(__wrap_check_ignore_and_restrict, false);
+    expect_value(__wrap_w_msg_hash_queues_push, size, strlen(line2));
+    will_return(__wrap_w_msg_hash_queues_push, 0);
+
+    expect_epilogue();
+
+    read_snortfull(&lf, &rc, 0);
+
+    assert_int_equal(rc, 0);
+
+    free(line2);
+}
+
+/**
  * Test: several oversized records in a row.
  * Verifies the buffer state is reset between records and every append stays
  * within bounds when the sequence is repeated.
@@ -263,6 +314,7 @@ int main(void) {
         cmocka_unit_test(test_read_snortfull_complete_record),
         cmocka_unit_test(test_read_snortfull_preprocessor_full_buffer),
         cmocka_unit_test(test_read_snortfull_third_line_full_buffer),
+        cmocka_unit_test(test_read_snortfull_preprocessor_message_length),
         cmocka_unit_test(test_read_snortfull_consecutive_full_records),
     };
 

--- a/src/unit_tests/logcollector/test_read_snortfull.c
+++ b/src/unit_tests/logcollector/test_read_snortfull.c
@@ -1,0 +1,270 @@
+/* Copyright (C) 2026, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "../../logcollector/logcollector.h"
+#include "../../headers/shared.h"
+#include "../wrappers/common.h"
+#include "../wrappers/wazuh/shared/file_op_wrappers.h"
+#include "../wrappers/libc/stdio_wrappers.h"
+#include "../wrappers/libc/string_wrappers.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+
+/* Globals */
+extern int maximum_lines;
+
+/* Setup & Teardown */
+
+static int group_setup(void **state) {
+    test_mode = 1;
+    return 0;
+}
+
+static int group_teardown(void **state) {
+    test_mode = 0;
+    return 0;
+}
+
+/* Wraps */
+
+int __wrap_can_read() {
+    return mock_type(int);
+}
+
+bool __wrap_w_get_hash_context(logreader *lf, EVP_MD_CTX **context, int64_t position) {
+    return mock_type(bool);
+}
+
+int __wrap_w_update_file_status(const char *path, int64_t pos, EVP_MD_CTX *context) {
+    bool free_context = mock_type(bool);
+    if (free_context) {
+        EVP_MD_CTX_free(context);
+    }
+    return mock_type(int);
+}
+
+void __wrap_OS_SHA1_Stream(EVP_MD_CTX *c, os_sha1 output, char *buf) {
+    function_called();
+    return;
+}
+
+int __wrap_w_msg_hash_queues_push(const char *str, char *file, unsigned long size, logtarget *log_target, char queue_mq) {
+    check_expected(size);
+    return mock_type(int);
+}
+
+bool __wrap_check_ignore_and_restrict(const char *ignore_regex, const char *restrict_regex, const char *str) {
+    return mock_type(bool);
+}
+
+/* Helpers */
+
+/* Builds "<prefix><filler repeated>\n" of total length len plus the newline. */
+static char * build_line(const char *prefix, char filler, size_t len) {
+    size_t prefix_len = strlen(prefix);
+    char *line;
+
+    assert_true(len >= prefix_len);
+
+    line = calloc(len + 2, sizeof(char));
+    assert_non_null(line);
+
+    memcpy(line, prefix, prefix_len);
+    memset(line + prefix_len, filler, len - prefix_len);
+    line[len] = '\n';
+
+    return line;
+}
+
+static void expect_line(char *line) {
+    will_return(__wrap_can_read, 1);
+    expect_any(__wrap_fgets, __stream);
+    will_return(__wrap_fgets, line);
+    expect_function_call(__wrap_OS_SHA1_Stream);
+}
+
+static void expect_prologue(void) {
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) 0);
+    will_return(__wrap_w_get_hash_context, true);
+}
+
+static void expect_epilogue(void) {
+    will_return(__wrap_can_read, 1);
+    expect_any(__wrap_fgets, __stream);
+    will_return(__wrap_fgets, NULL);
+
+    expect_any(__wrap_w_ftell, x);
+    will_return(__wrap_w_ftell, (int64_t) 0);
+
+    will_return(__wrap_w_update_file_status, true);
+    will_return(__wrap_w_update_file_status, 0);
+
+    expect_any(__wrap__mdebug2, formatted_msg);
+}
+
+/* Tests */
+
+/**
+ * Test: well-formed three-line record.
+ * Verifies the normal path is unaffected: the record is composed and pushed.
+ */
+void test_read_snortfull_complete_record(void **state) {
+    logreader lf = {0};
+    lf.file = "test.log";
+    lf.fp = (FILE *) 1;
+    int rc;
+
+    char line1[] = "[**] [1:1000001:0] Test alert [**]\n";
+    char line2[] = "[Classification: Attempted Information Leak] [Priority: 2]\n";
+    char line3[] = "01/13-15:30:00.000000 10.0.0.1:1234 -> 10.0.0.2:80\n";
+
+    expect_prologue();
+
+    expect_line(line1);
+    expect_line(line2);
+    expect_line(line3);
+
+    will_return(__wrap_check_ignore_and_restrict, false);
+    expect_value(__wrap_w_msg_hash_queues_push, size, strlen(line3));
+    will_return(__wrap_w_msg_hash_queues_push, 0);
+
+    expect_epilogue();
+
+    read_snortfull(&lf, &rc, 0);
+
+    assert_int_equal(rc, 0);
+}
+
+/**
+ * Test: preprocessor record whose first line already fills f_msg.
+ * The free space left after the first line is smaller than the preprocessor
+ * label, so the second append must be bounded to zero bytes and f_msg must stay
+ * at OS_MAX_LOG_SIZE - 1.
+ */
+void test_read_snortfull_preprocessor_full_buffer(void **state) {
+    logreader lf = {0};
+    lf.file = "test.log";
+    lf.fp = (FILE *) 1;
+    int rc;
+
+    char *line1 = build_line("[**] [", 'A', OS_MAX_LOG_SIZE - 10);
+    char *line2 = build_line("01/13-15:30:00.000000 ", 'C', 2022);
+
+    expect_prologue();
+
+    expect_line(line1);
+    expect_line(line2);
+
+    will_return(__wrap_check_ignore_and_restrict, false);
+    expect_value(__wrap_w_msg_hash_queues_push, size, OS_MAX_LOG_SIZE - 1);
+    will_return(__wrap_w_msg_hash_queues_push, 0);
+
+    expect_epilogue();
+
+    read_snortfull(&lf, &rc, 0);
+
+    assert_int_equal(rc, 0);
+
+    free(line1);
+    free(line2);
+}
+
+/**
+ * Test: three-line record whose first two lines fill f_msg.
+ * The third append must be bounded to zero bytes.
+ */
+void test_read_snortfull_third_line_full_buffer(void **state) {
+    logreader lf = {0};
+    lf.file = "test.log";
+    lf.fp = (FILE *) 1;
+    int rc;
+
+    char *line1 = build_line("[**] [", 'A', 60024);
+    char *line2 = build_line("[Classification: ", 'B', 40017);
+    char *line3 = build_line("01/13-15:30:00.000000 ", 'C', 2022);
+
+    expect_prologue();
+
+    expect_line(line1);
+    expect_line(line2);
+    expect_line(line3);
+
+    will_return(__wrap_check_ignore_and_restrict, false);
+    expect_value(__wrap_w_msg_hash_queues_push, size, strlen(line3));
+    will_return(__wrap_w_msg_hash_queues_push, 0);
+
+    expect_epilogue();
+
+    read_snortfull(&lf, &rc, 0);
+
+    assert_int_equal(rc, 0);
+
+    free(line1);
+    free(line2);
+    free(line3);
+}
+
+/**
+ * Test: several oversized records in a row.
+ * Verifies the buffer state is reset between records and every append stays
+ * within bounds when the sequence is repeated.
+ */
+void test_read_snortfull_consecutive_full_records(void **state) {
+    logreader lf = {0};
+    lf.file = "test.log";
+    lf.fp = (FILE *) 1;
+    int rc;
+    int i;
+
+    char *line1 = build_line("[**] [", 'A', 60024);
+    char *line2 = build_line("[Classification: ", 'B', 40017);
+    char *line3 = build_line("01/13-15:30:00.000000 ", 'C', 2022);
+
+    expect_prologue();
+
+    for (i = 0; i < 3; i++) {
+        expect_line(line1);
+        expect_line(line2);
+        expect_line(line3);
+
+        will_return(__wrap_check_ignore_and_restrict, false);
+        expect_value(__wrap_w_msg_hash_queues_push, size, strlen(line3));
+        will_return(__wrap_w_msg_hash_queues_push, 0);
+    }
+
+    expect_epilogue();
+
+    read_snortfull(&lf, &rc, 0);
+
+    assert_int_equal(rc, 0);
+
+    free(line1);
+    free(line2);
+    free(line3);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_read_snortfull_complete_record),
+        cmocka_unit_test(test_read_snortfull_preprocessor_full_buffer),
+        cmocka_unit_test(test_read_snortfull_third_line_full_buffer),
+        cmocka_unit_test(test_read_snortfull_consecutive_full_records),
+    };
+
+    return cmocka_run_group_tests(tests, group_setup, group_teardown);
+}


### PR DESCRIPTION
## Description
When `read_snortfull()` assembles a multi-line Snort "full" alert, it tracked the free space left in
the destination buffer with a counter that was decremented by the whole length of every appended
line, even when `strncat()` had already truncated the copy to the space actually available. The
counter could therefore drift away from the real free space on records that fill the buffer. Each
append is now bounded by the space computed from the buffer itself, with unsigned arithmetic.

## Proposed Changes
- `src/logcollector/read_snortfull.c`: replaced the `f_msg_size` counter with
  `sizeof(f_msg) - strlen(f_msg) - 1` at the five `strncat()` call sites, and removed the counter
  along with its updates. This also removes the `f_msg_size - 40` bound. The preprocessor branch now
  sizes its queued message from the line being queued, `strlen(str) + 1`, matching the other branch
  and every other caller in `src/logcollector`.
- `src/unit_tests/logcollector/test_read_snortfull.c`: new CMocka suite for `read_snortfull()`.
- `src/unit_tests/logcollector/CMakeLists.txt`: registered the new test with the wrappers it needs.

### Results and Evidence
The new tests cover both append sites with records that fill the destination buffer completely, plus
the queued-message length in the preprocessor branch. Each one fails without this change and passes
with it, verified independently. A well-formed record produces an identical message before and
after, so the normal path is unchanged.

```
11/13 Test #119: test_read_syslog .................   Passed    0.04 sec
12/13 Test #120: test_read_audit ..................   Passed    0.04 sec
13/13 Test #121: test_read_snortfull ..............   Passed    0.04 sec

100% tests passed, 0 tests failed out of 13
```

One note for the reviewer: release builds emit a single new `-Wstringop-truncation` warning at
`read_snortfull.c:59`, stating that the append may be truncated. That is the intended behaviour for
records larger than the buffer, and the warning class already appears elsewhere in the tree.

### Artifacts Affected
`wazuh-logcollector`, on every platform.

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
`src/unit_tests/logcollector/test_read_snortfull.c`:
- `test_read_snortfull_complete_record` — well-formed three-line record, normal path unchanged.
- `test_read_snortfull_preprocessor_full_buffer` — preprocessor record whose first line already
  fills the buffer.
- `test_read_snortfull_third_line_full_buffer` — three-line record whose first two lines fill the
  buffer.
- `test_read_snortfull_preprocessor_message_length` — preprocessor record shorter than its own date
  line, checking the queued length comes from the queued line.
- `test_read_snortfull_consecutive_full_records` — several oversized records in sequence, checking
  the buffer state is reset between records.

## Credits
Reported by ZemarKhos.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
