### PR TITLE
Quote interpolated paths before passing them to the shell in the engine tools

### DIFF
--- a/src/engine/tools/engine-bench/src/engine_bench/__main__.py
+++ b/src/engine/tools/engine-bench/src/engine_bench/__main__.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -53,7 +54,7 @@ def main(environment, output):
 
         engine_pid = engine_handler.get_pid()
 
-        command = f"perf record -g -p {engine_pid} -o {perf_report.as_posix()} "
+        command = f"perf record -g -p {engine_pid} -o {shlex.quote(perf_report.as_posix())} "
         click.echo(f"Running: {command}")
         result = subprocess.Popen(command, shell=True)
 
@@ -70,15 +71,18 @@ def main(environment, output):
         click.echo(f"Output written to {output}/perf.data")
 
         click.echo("Generating flamegraph")
-        stack_collapse_script = files('engine_bench.scripts').joinpath('stackcollapse-perf.pl')
-        flamegraph_script = files('engine_bench.scripts').joinpath('flamegraph.pl')
-        command = f"perf script -i {perf_report.as_posix()} > {output}/perf.script"
+        stack_collapse_script = shlex.quote(str(files('engine_bench.scripts').joinpath('stackcollapse-perf.pl')))
+        flamegraph_script = shlex.quote(str(files('engine_bench.scripts').joinpath('flamegraph.pl')))
+        perf_script = shlex.quote((output / 'perf.script').as_posix())
+        perf_folded = shlex.quote((output / 'perf.folded').as_posix())
+        flamegraph_svg = shlex.quote((output / 'flamegraph.svg').as_posix())
+        command = f"perf script -i {shlex.quote(perf_report.as_posix())} > {perf_script}"
 
         subprocess.run(command, shell=True, check=True)
         subprocess.run(
-            f"perl {stack_collapse_script} {output}/perf.script > {output}/perf.folded", shell=True, check=True)
+            f"perl {stack_collapse_script} {perf_script} > {perf_folded}", shell=True, check=True)
         subprocess.run(
-            f"perl {flamegraph_script} {output}/perf.folded > {output}/flamegraph.svg", shell=True, check=True)
+            f"perl {flamegraph_script} {perf_folded} > {flamegraph_svg}", shell=True, check=True)
         click.echo(f"Flamegraph generated at {output}/flamegraph.svg")
 
     except subprocess.CalledProcessError as e:

--- a/src/engine/tools/update_expected.py
+++ b/src/engine/tools/update_expected.py
@@ -22,6 +22,9 @@ def get_executor(test_command: str, output: Path):
         # Set up command
         output_file = output / file.with_name(
             file.stem.replace('input', 'expected') + '.json').name
+        if output.resolve() not in output_file.resolve().parents:
+            print(f'{file.name} -> output path outside {output}, skipped')
+            return
         command = f'cat {shlex.quote(str(file))} | {test_command}'
 
         try:

--- a/src/engine/tools/update_expected.py
+++ b/src/engine/tools/update_expected.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from argparse import ArgumentParser
 from typing import Callable
+import shlex
 import subprocess
 import time
 from json import dumps, loads
@@ -21,7 +22,7 @@ def get_executor(test_command: str, output: Path):
         # Set up command
         output_file = output / file.with_name(
             file.stem.replace('input', 'expected') + '.json').name
-        command = f'cat {file} | {test_command}'
+        command = f'cat {shlex.quote(str(file))} | {test_command}'
 
         try:
             # Execute command


### PR DESCRIPTION

## Description
`src/engine/tools/update_expected.py` built its command line by interpolating a
`pathlib.Path` obtained from `Path.rglob()` into a string and running it through a
shell, so a file name containing characters meaningful to the shell was not handled
as a single argument: in the benign case the run failed on a name with a space, and
in the worst case the shell evaluated part of the name. The interpolated paths are
now quoted with `shlex.quote()`, the output path is kept inside the `--output`
directory, and the same unquoted-interpolation pattern in `engine-bench` is quoted
as well.

## Proposed Changes
- `src/engine/tools/update_expected.py`: import `shlex` and wrap the interpolated
  input path in `shlex.quote(str(file))` when building the `cat ... | engine-test ...`
  command.
- `src/engine/tools/update_expected.py`: skip any input file whose derived output
  path would not resolve inside the `--output` directory, reporting it like the
  other per-file errors instead of writing outside.
- `src/engine/tools/engine-bench/src/engine_bench/__main__.py`: import `shlex` and
  quote every interpolated path in the `perf record`, `perf script` and two `perl`
  command lines. Shell redirections are left unquoted; only the path operands are
  quoted.
- `src/engine/tools/compare_expected.py`: no change. It invokes no subprocess.

### Results and Evidence
`update_expected.py`, exercising the executor over a range of file names. Every case
produces the correct expected-results file and no injected command runs:

| Input file name | Result |
|---|---|
| `input.json` | `expected.json` |
| `input with space.json` | `expected with space.json` |
| `input's quote.json` | `expected's quote.json` |
| `input$(touch INJECTED).json` | `expected$(touch INJECTED).json`, no command run |
| ``input`touch INJECTED`.json`` | quoted, no command run |
| `input; touch INJECTED; echo .json` | quoted, no command run |
| `input \| touch INJECTED \| cat .json` | quoted, no command run |
| `input && touch INJECTED && echo .json` | quoted, no command run |
| `...json` | `...json`, stays inside `--output` |

The name with a space, which previously made the run fail, now works. The reporter's
proof of concept no longer executes its payload: before the change it created
`pwned_cmd_injection` (containing the output of `id`) and `INJECTED_MARKER`; after it
creates neither, and the path reaches the shell quoted:

```
Running: cat '/…/corpus/input$(id > pwned_cmd_injection ; touch INJECTED_MARKER).json' | engine-test -c /dev/null run dummy_integration --api-socket /…/queue/sockets/engine-api -j
```

The tool still reports `engine-test` exit 127 because `engine-test` is not installed
in the test environment; that is unrelated to the change.

`engine-bench`, command lines generated with a space in `--output` and in the
packaged script path — operands quoted, redirections untouched:

```
perf record -g -p 123 -o '/tmp/my out dir/perf.data'
perf script -i '/tmp/my out dir/perf.data' > '/tmp/my out dir/perf.script'
perl '/opt/a b/stackcollapse-perf.pl' '/tmp/my out dir/perf.script' > '/tmp/my out dir/perf.folded'
perl '/opt/a b/flamegraph.pl' '/tmp/my out dir/perf.folded' > '/tmp/my out dir/flamegraph.svg'
```

### Artifacts Affected
None for `update_expected.py`: it is a standalone developer script under
`src/engine/tools/`, not installed by `src/init/inst-functions.sh` and not part of the
`wazuh-internal-tools` deb/rpm. `engine-bench` is a Python tool under the same
directory and is likewise not shipped in the `wazuh-internal-tools` package, which
installs only `api-communication`, `engine-suite`, `engine-metrics` and
`engine-test-utils`. No compiled component changes.

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
None. Development tools under `src/engine/tools/` are not covered by an automated
test suite in this repository. The changes were verified manually with the runs shown
above.

## Credits
Reported by @ZemarKhos.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)

Closes #38452

🤖 Generated with [Claude Code](https://claude.com/claude-code)
