### PR TITLE
Fixed the parameter for debug symbols used in package generation

### DIFF
--- a/packages/windows/generate_wazuh_msi.ps1
+++ b/packages/windows/generate_wazuh_msi.ps1
@@ -114,7 +114,7 @@ function ExtractDebugSymbols(){
 		$procArgs += $file.BaseName
 		$procArgs += ".pdb"
 
-		$processes += Start-Process -FilePath "cv2pdb.exe" -ArgumentList $procArgs -WindowStyle Hidden -PassThru
+		$processes += Start-Process -FilePath ".\cv2pdb.exe" -ArgumentList $procArgs -NoNewWindow -PassThru
 	}
 
   Write-Host "Waiting for processes to finish"

--- a/packages/windows/generate_wazuh_msi.ps1
+++ b/packages/windows/generate_wazuh_msi.ps1
@@ -8,6 +8,7 @@ param (
     [string]$SIGN_TOOLS_PATH = "",
     [string]$CERTIFICATE_PATH = "",
     [string]$CERTIFICATE_PASSWORD = "",
+    [string]$ALLOCATOR = "no",
     [switch]$help
     )
 
@@ -26,7 +27,7 @@ if(($help.isPresent)) {
         4. SIGN_TOOLS_PATH: sign tools path.
         5. CERTIFICATE_PATH: Path to the .pfx certificate file.
         6. CERTIFICATE_PASSWORD: Password for the .pfx certificate file.
-
+        7. ALLOCATOR: yes or no. By default 'yes'.
     USAGE:
 
         * WAZUH:
@@ -114,7 +115,11 @@ function ExtractDebugSymbols(){
 		$procArgs += $file.BaseName
 		$procArgs += ".pdb"
 
-		$processes += Start-Process -FilePath ".\cv2pdb.exe" -ArgumentList $procArgs -NoNewWindow -PassThru
+        if($ALLOCATOR -eq "no") {
+		    $processes += Start-Process -FilePath ".\cv2pdb.exe" -ArgumentList $procArgs -NoNewWindow -PassThru
+        } else {
+            $processes += Start-Process -FilePath "cv2pdb.exe" -ArgumentList $procArgs -NoNewWindow -PassThru
+        }
 	}
 
   Write-Host "Waiting for processes to finish"


### PR DESCRIPTION


## Description

A parameter has been corrected in the extraction of debug symbols during MSI build, as it previously used a hidden window. Now, following the changes made to the base image for package generation, this has had to be modified so that no window is displayed when extracting the debug symbols.

`-WindowStyle Hidden` -> `-NoNewWindow`

## Evidence

- https://github.com/wazuh/wazuh-agent-packages/actions/runs/32367075511/job/96418812765 :green_circle: 
- https://github.com/wazuh/wazuh-agent-packages/actions/runs/32383723141/job/96472950503 :green_circle: 