### PR TITLE
Add HTTPS agent enrollment endpoint (POST /enroll) bridging to authd

### DIFF
--- a/.github/actions/check_files/manager_base.csv
+++ b/.github/actions/check_files/manager_base.csv
@@ -39,8 +39,6 @@ full_filename,owner_name,group_name,mode,type,prot_permissions,size_bytes,size_e
 /var/wazuh-manager/etc/shared/default,wazuh-manager,wazuh-manager,770,directory,drwxrwx---,,
 /var/wazuh-manager/etc/shared/default/agent.conf,wazuh-manager,wazuh-manager,660,file,-rw-rw----,,
 /var/wazuh-manager/etc/certs,root,wazuh-manager,1770,directory,drwxrwx--T,,
-/var/wazuh-manager/etc/certs/authd.pem,wazuh-manager,wazuh-manager,640,file,-rw-r-----,,
-/var/wazuh-manager/etc/certs/authd-key.pem,wazuh-manager,wazuh-manager,640,file,-rw-r-----,,
 /var/wazuh-manager/etc/certs/remoted.pem,wazuh-manager,wazuh-manager,640,file,-rw-r-----,,
 /var/wazuh-manager/etc/certs/remoted-key.pem,wazuh-manager,wazuh-manager,640,file,-rw-r-----,,
 /var/wazuh-manager/etc/wazuh-manager.conf,root,wazuh-manager,660,file,-rw-rw----,,

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -6109,8 +6109,8 @@ paths:
                         use_password: "no"
                         ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256"
                         ssl_verify_host: "no"
-                        ssl_manager_cert: "etc/certs/authd.pem"
-                        ssl_manager_key: "etc/certs/authd-key.pem"
+                        ssl_manager_cert: "etc/certs/remoted.pem"
+                        ssl_manager_key: "etc/certs/remoted-key.pem"
                       cluster:
                         name: "wazuh"
                         node_name: "master-node"

--- a/docs/guide/migration/manager-configuration-migration.md
+++ b/docs/guide/migration/manager-configuration-migration.md
@@ -201,12 +201,17 @@ The section is preserved, but `wazuh-authd` now enforces TLS 1.3 as the minimum 
 ```xml
 <auth>
   ...
-  <ssl_manager_cert>/var/wazuh-manager/etc/certs/authd.pem</ssl_manager_cert>
-  <ssl_manager_key>/var/wazuh-manager/etc/certs/authd-key.pem</ssl_manager_key>
+  <ssl_manager_cert>/var/wazuh-manager/etc/certs/remoted.pem</ssl_manager_cert>
+  <ssl_manager_key>/var/wazuh-manager/etc/certs/remoted-key.pem</ssl_manager_key>
   <ciphers>TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256</ciphers>
   ...
 </auth>
 ```
+
+`ssl_manager_cert`/`ssl_manager_key` now point at the same certificate the HTTPS agent server
+(`remoted_module`) presents, not a separate `authd.pem`/`authd-key.pem` pair -- authd no longer
+generates or owns a certificate of its own (see `ssl_manager_cert` in
+[authd/configuration.md](../../ref/modules/authd/configuration.md#ssl_manager_cert)).
 
 ### Sections to remove from `wazuh-manager.conf`
 

--- a/docs/ref/modules/authd/README.md
+++ b/docs/ref/modules/authd/README.md
@@ -89,11 +89,15 @@ registration endpoints, and `remoted_module`'s `POST /enroll` bridge (see
 [HTTPS enrollment](../remoted/https-events-api.md#enrollment-endpoint-post-enroll)) all use to add,
 remove, and query agents without going through TLS or the enrollment password directly.
 
-On a cluster **worker** node: `add` requests are forwarded to the master over the same cluster
-protocol port 1515's own worker-to-master enrollment forwarding already uses, and answered with the
-master's result — a transport failure during that forward answers `9016` ("Cannot communicate with
-master node"). `remove` and `get` are **not** forwarded: a worker rejects both outright with `9015`
-("Cannot execute this request on a worker node").
+On a cluster **worker** node: a self-enrollment-shaped `add` request (no caller-supplied `id` or
+`key` — the only shape `/enroll` and port 1515 ever produce) is forwarded to the master over the
+same cluster protocol port 1515's own worker-to-master enrollment forwarding already uses, and
+answered with the master's result — a transport failure during that forward answers `9016` ("Cannot
+communicate with master node"). An `add` that DOES carry a caller-chosen `id` and/or `key` (an
+admin/restore-style add — `manage_agents`/the API can send this shape, self-enrollment never does)
+is rejected outright with `9015`, same as `remove`/`get`: there is no cluster RPC to honor a
+caller-chosen identity on a worker, so this is an explicit rejection rather than silently returning a
+different id/key than the one requested.
 
 A request is a single-line JSON object:
 
@@ -106,6 +110,15 @@ A request is a single-line JSON object:
 - **`add`** — register a new agent (or replace an existing one, subject to the same duplicate
   ID/IP/name and `force` checks used by the network enrollment path). Arguments:
   - `name` (required), `ip` (required, or `"any"`)
+
+    The name must be *storable* in `client.keys`: non-empty, at most 128 characters, no whitespace
+    or control bytes, and not starting with `#` or `!`. A name violating any of these is rejected
+    with `9017` ("Invalid agent name") — distinct from `9005` ("No such name"), which means the
+    argument was absent. This is deliberately a narrower rule than the `OS_IsValidName()` charset
+    the two *enrollment* paths (port 1515 and `POST /enroll`) enforce on the names they mint: it
+    refuses only what the `<id> <name> <ip> <key>` line format cannot represent, so names that
+    `manage_agents` and the API have always accepted — containing `%`, a single character, or a
+    leading `.` — keep working.
   - `id` (optional) — request a specific agent ID instead of letting authd assign the next one
   - `groups` (optional) — comma-separated centralized group(s) to assign
   - `key` (optional) — a caller-supplied key instead of a randomly generated one

--- a/docs/ref/modules/authd/README.md
+++ b/docs/ref/modules/authd/README.md
@@ -2,6 +2,14 @@
 
 `wazuh-manager-authd` handles agent enrollment. It listens for agent registration requests over TLS, validates credentials, generates cryptographic keys, and writes the resulting entries to the agent keystore.
 
+Agents can also enroll over HTTPS, through `remoted_module`'s `POST /enroll` (port 1517) — see
+[HTTPS enrollment](../remoted/https-events-api.md#enrollment-endpoint-post-enroll). That endpoint
+is a bridge, not a second implementation: it forwards to this same daemon's local socket (see
+[Local socket enrollment protocol](#local-socket-enrollment-protocol) below), so every enrollment —
+however it arrives — goes through the one business-logic path documented on this page. Port 1515
+(this document) remains fully supported for legacy 4.x agents; `/enroll` is the manager's intended
+long-term enrollment path going forward.
+
 Source: `src/os_auth/`
 
 For configuration options see [Authd Configuration](configuration.md).
@@ -34,7 +42,7 @@ For configuration options see [Authd Configuration](configuration.md).
 
 | Thread | Role |
 |--------|------|
-| Remote server | Accepts TLS connections on port 1515 (when `remote_enrollment` is `yes`) |
+| Remote server | Accepts TLS connections on port 1515 (when `remote_enrollment` and [`legacy_enrollment`](configuration.md#legacy_enrollment) are both `yes`) |
 | Local server | Handles enrollment via the local Unix socket `queue/sockets/auth` |
 | Writer | Periodically flushes the in-memory key queue to `client.keys` on disk, and — for each removed agent — asks the [Inventory Sync Server](../inventory-sync-server/README.md) to delete that agent's documents from the indexer |
 
@@ -76,10 +84,16 @@ The `<force>` sub-block controls when an agent may overwrite an existing registr
 ## Local socket enrollment protocol
 
 In addition to the TLS enrollment path on port 1515, authd exposes a local-only enrollment API over
-the Unix domain socket `queue/sockets/auth`. This is what `manage_agents` and the API's agent
-registration endpoints use to add, remove, and query agents without going through TLS or the
-enrollment password. It is only served on the master node — a worker rejects any JSON request here
-(error `9015`, "Cannot execute this request on a worker node").
+the Unix domain socket `queue/sockets/auth`. This is what `manage_agents`, the API's agent
+registration endpoints, and `remoted_module`'s `POST /enroll` bridge (see
+[HTTPS enrollment](../remoted/https-events-api.md#enrollment-endpoint-post-enroll)) all use to add,
+remove, and query agents without going through TLS or the enrollment password directly.
+
+On a cluster **worker** node: `add` requests are forwarded to the master over the same cluster
+protocol port 1515's own worker-to-master enrollment forwarding already uses, and answered with the
+master's result — a transport failure during that forward answers `9016` ("Cannot communicate with
+master node"). `remove` and `get` are **not** forwarded: a worker rejects both outright with `9015`
+("Cannot execute this request on a worker node").
 
 A request is a single-line JSON object:
 

--- a/docs/ref/modules/authd/configuration.md
+++ b/docs/ref/modules/authd/configuration.md
@@ -105,7 +105,30 @@ The agent reads the password from `etc/authd.pass` (relative to its install dire
 
 ### remote_enrollment
 
-Accept enrollment requests over the network (port 1515). Disable to restrict enrollment to the local socket only.
+Master switch for **all** remote (network) self-enrollment — both this daemon's own TCP/TLS
+listener on port 1515 and the HTTPS `POST /enroll` bridge served by `remoted_module` (see
+[HTTPS enrollment](../remoted/https-events-api.md#enrollment-endpoint-post-enroll)). Disabling it
+turns off both at once; use [`legacy_enrollment`](#legacy_enrollment) to turn off only port 1515
+while keeping `/enroll`. Either way, the local socket (`queue/sockets/auth`) used by
+`manage_agents`/the API stays available regardless of this setting.
+
+- **Default value:** `yes`
+- **Allowed values:** `yes`, `no`
+
+### legacy_enrollment
+
+Narrows `remote_enrollment` further, without affecting it: when `remote_enrollment` is `yes`, this
+flag controls whether port 1515's TCP/TLS listener specifically starts. Set to `no` to retire
+legacy 1515 while keeping `/enroll` — the manager's intended long-term enrollment path — available.
+Has no effect when `remote_enrollment` is `no` (both paths are already off), and no effect on
+`/enroll` at all, which this flag exists specifically to leave alone.
+
+| `disabled` | `remote_enrollment` | `legacy_enrollment`  | Port 1515 | `POST /enroll` |
+| ---------- | -------------------- | --------------------- | --------- | -------------- |
+| `yes`      | –                    | –                     | off       | off            |
+| `no`       | `no`                 | –                     | off       | off            |
+| `no`       | `yes`                | `yes` (default)       | on        | on             |
+| `no`       | `yes`                | `no`                  | off       | **on**         |
 
 - **Default value:** `yes`
 - **Allowed values:** `yes`, `no`

--- a/docs/ref/modules/authd/configuration.md
+++ b/docs/ref/modules/authd/configuration.md
@@ -133,16 +133,18 @@ Verify that the CN of the agent certificate matches the agent's IP address. Requ
 
 ### ssl_manager_cert
 
-Path to the manager's TLS certificate presented to agents during enrollment.
+Path to the manager's TLS certificate presented to agents during enrollment. Shared with the
+HTTPS agent server (`remoted_module`'s `POST /enroll`): both listeners present the same manager
+identity, since `/enroll`'s mTLS mode treats this certificate as the enrollment credential.
 
-- **Default value:** `etc/certs/authd.pem` (resolved relative to the Wazuh install directory, e.g. `/var/wazuh-manager/etc/certs/authd.pem`)
+- **Default value:** `etc/certs/remoted.pem` (resolved relative to the Wazuh install directory, e.g. `/var/wazuh-manager/etc/certs/remoted.pem`) -- authd no longer generates or owns a separate certificate of its own
 - **Allowed values:** Path to a PEM-encoded certificate (relative paths resolved from the Wazuh install directory)
 
 ### ssl_manager_key
 
 Path to the private key corresponding to `ssl_manager_cert`.
 
-- **Default value:** `etc/certs/authd-key.pem` (resolved relative to the Wazuh install directory)
+- **Default value:** `etc/certs/remoted-key.pem` (resolved relative to the Wazuh install directory)
 - **Allowed values:** Path to a PEM-encoded private key (relative paths resolved from the Wazuh install directory)
 
 ### force
@@ -257,8 +259,8 @@ Mutual TLS with client certificate verification:
   <use_password>yes</use_password>
   <ssl_agent_ca>/var/wazuh-manager/etc/rootCA.pem</ssl_agent_ca>
   <ssl_verify_host>yes</ssl_verify_host>
-  <ssl_manager_cert>/var/wazuh-manager/etc/certs/authd.pem</ssl_manager_cert>
-  <ssl_manager_key>/var/wazuh-manager/etc/certs/authd-key.pem</ssl_manager_key>
+  <ssl_manager_cert>/var/wazuh-manager/etc/certs/remoted.pem</ssl_manager_cert>
+  <ssl_manager_key>/var/wazuh-manager/etc/certs/remoted-key.pem</ssl_manager_key>
   <ciphers>TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256</ciphers>
   <force>
     <enabled>yes</enabled>

--- a/docs/ref/modules/remoted/https-events-api.md
+++ b/docs/ref/modules/remoted/https-events-api.md
@@ -995,6 +995,30 @@ python3 send_scan_vd.py --all
 # options: --url (default https://127.0.0.1:9443), --agent-id, --client-keys
 ```
 
+`src/remoted/remoted_module/tools/send_enroll.py` does the same for `POST /enroll` — but since an
+enrolling agent has no `client.keys` entry to sign with, it works from whatever credential you give
+it directly (a password, a client certificate, or neither) rather than reading one from a file:
+
+```bash
+# Open mode -- no credential at all
+python3 send_enroll.py --name web-01
+
+# Password mode -- signs with the manager's actual enrollment password
+python3 send_enroll.py --name web-01 --password Secret123
+
+# tamper the body after signing -> 401 (invalid MAC)
+python3 send_enroll.py --name web-01 --password Secret123 --tamper
+
+# mTLS mode -- the client certificate presented during the handshake is the credential
+python3 send_enroll.py --name web-01 --client-cert agent.pem --client-key agent.key
+
+# run every scenario this script can drive without knowing the manager's configured mode in
+# advance (body validation always; signature/timing scenarios too if --password is given)
+python3 send_enroll.py --password Secret123 --all
+# options: --url (default https://127.0.0.1:1517), --version, --groups, --ip, --key-hash,
+#          --password-file (reads /var/wazuh-manager/etc/authd.pass by default)
+```
+
 ## References
 
 - [Event Protocol Specification](event-protocol.md) — the `H`/`E` wire format for event batches.

--- a/docs/ref/modules/remoted/https-events-api.md
+++ b/docs/ref/modules/remoted/https-events-api.md
@@ -433,6 +433,7 @@ struct.
 | `authd` local-socket connect timeout          | `2 s`                                                   | `remoted.authd_connect_timeout`            |
 | `authd` local-socket response timeout         | `5 s` on a master, `15 s` on a cluster worker           | `remoted.authd_response_timeout`           |
 | Bridge request queue high-water mark          | `256`                                                   | `remoted.authd_max_queue_size`             |
+| Concurrent bridge worker threads              | `8`                                                      | `remoted.authd_worker_threads`             |
 
 The response timeout's worker default is longer than the master's on purpose: on a worker, `authd`'s
 own forward to the master can retry internally for several seconds before answering, and a shorter
@@ -441,6 +442,15 @@ spurious `503`. All other enrollment behavior (whether it's enabled, whether a p
 certificate is required, which agent versions are accepted) is deliberately **not** a separate
 `remoted`-owned setting — it's read from `authd`'s own `<auth>` block so the two enrollment paths
 can never disagree; see [Enrollment endpoint](#enrollment-endpoint-post-enroll) below.
+
+**Why more than one worker, when `authd`'s own local-socket accept loop is single-threaded.** A
+pool doesn't raise `authd`'s own processing rate — that ceiling is fixed by `authd`'s business
+logic regardless. What it removes is the connection-setup round trip (connect + send + await reply
++ close) sitting on the critical path *in addition to* `authd`'s processing time, for every single
+request, when only one worker exists: with several workers, another connection is normally already
+waiting in `authd`'s listen backlog (128 slots) by the time it finishes the current one and calls
+`accept()` again, so `authd` is essentially never left idle waiting on `remoted`. Keep this well
+under 128 — there's no benefit to more workers than that backlog can hold.
 
 ### client.keys hot-reload
 

--- a/docs/ref/modules/remoted/https-events-api.md
+++ b/docs/ref/modules/remoted/https-events-api.md
@@ -240,10 +240,10 @@ On rejection the body is `{"error":"<message>","code":<status>}`. Credential-rel
 collapse to a **single generic `401`** so a client cannot tell which specific check failed.
 
 | Condition                                                                                                                                                                               | HTTP  | `error` message                             |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| ----- | ------------------------------------------- |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- | ------------------------------------------- |
 | Missing `protocol-version` header                                                                                                                                                       | `400` | `Missing required header: protocol-version` |
 | Unsupported `protocol-version`                                                                                                                                                          | `400` | `Unsupported protocol-version`              |
-| Missing / malformed `Authorization`, unknown agent, unusable key, peer address not allowed by the agent's `ip` column, expired or future timestamp, invalid MAC                        | `401` | `Invalid client authentication`             |
+| Missing / malformed `Authorization`, unknown agent, unusable key, peer address not allowed by the agent's `ip` column, expired or future timestamp, invalid MAC                         | `401` | `Invalid client authentication`             |
 | Body exceeds the auth body limit (10 MiB) -- or, for `Content-Encoding: zstd`, the decoder's buffers or the decompressed output don't fit in the in-flight capacity free at that moment | `413` | `Request payload is too large`              |
 | `Content-Encoding` present but not (case-insensitively) `zstd`                                                                                                                          | `415` | `Unsupported Content-Encoding`              |
 | `Content-Encoding: zstd`, but the body isn't a valid/complete zstd frame                                                                                                                | `400` | `Malformed compressed body`                 |
@@ -443,13 +443,16 @@ certificate is required, which agent versions are accepted) is deliberately **no
 `remoted`-owned setting — it's read from `authd`'s own `<auth>` block so the two enrollment paths
 can never disagree; see [Enrollment endpoint](#enrollment-endpoint-post-enroll) below.
 
-**Why more than one worker, when `authd`'s own local-socket accept loop is single-threaded.** A
-pool doesn't raise `authd`'s own processing rate — that ceiling is fixed by `authd`'s business
-logic regardless. What it removes is the connection-setup round trip (connect + send + await reply
-+ close) sitting on the critical path *in addition to* `authd`'s processing time, for every single
-request, when only one worker exists: with several workers, another connection is normally already
-waiting in `authd`'s listen backlog (128 slots) by the time it finishes the current one and calls
-`accept()` again, so `authd` is essentially never left idle waiting on `remoted`. Keep this well
+**Why more than one worker.** `authd`'s local-socket accept loop hands each accepted connection to
+its own detached thread (`os_auth/src/local-server.c`'s `handle_local_client`), so several `add`
+requests -- including a worker's cluster-forwarded ones, which can legitimately take several
+seconds -- now genuinely run concurrently on `authd`'s side too, not just queue one-at-a-time behind
+a single dispatcher. A single-worker `remoted` would still only ever have ONE such request in
+flight at a time no matter how parallel `authd` itself can go, and would still pay the
+connection-setup round trip (connect + send + await reply + close) sitting on the critical path *in
+addition to* `authd`'s processing time, for every single request. With several workers, `authd` can
+actually work on more than one at once, and another connection is normally already waiting in its
+listen backlog (128 slots) by the time it finishes one and calls `accept()` again. Keep this well
 under 128 — there's no benefit to more workers than that backlog can hold.
 
 ### client.keys hot-reload
@@ -869,9 +872,13 @@ entry yet to sign with. Two credential checks apply instead, decided once at man
   `<mac>` is a 32-character lowercase-hex AES-256-CMAC, keyed by a 32-byte key derived from
   `authd`'s enrollment password (`etc/authd.pass`) via **HKDF-SHA256** (empty salt,
   `info = "WAZUH-ENROLL-CMAC-KEY" + 0x01`) — never the password bytes themselves. The timestamp
-  accepts the same window as the AES-CMAC scheme above (300 s past, 30 s future). The MAC covers a
-  canonical byte sequence deliberately similar to the AES-CMAC scheme's, minus the agent-id field
-  (an enrolling agent doesn't have one):
+  accepts the same window as the AES-CMAC scheme above (300 s past, 30 s future) -- tunable via the
+  SAME two internal options, `remoted.auth_max_request_age`/`remoted.auth_max_future_skew` (see the
+  table under [Authentication (AES-CMAC)](#authentication-aes-cmac) above). The request body is
+  also capped by the same `remoted.auth_max_body_size` (10 MiB default) that scheme enforces --
+  checked before anything else, in **every** mode including Open, so an oversized body is rejected
+  with `413` before it is ever hashed. The MAC covers a canonical byte sequence deliberately similar
+  to the AES-CMAC scheme's, minus the agent-id field (an enrolling agent doesn't have one):
 
   ```text
   WAZUH-ENROLL\n
@@ -920,10 +927,10 @@ already accepts, with TLS protecting the transport either way.
 
 | Field | Required | Notes |
 | --- | --- | --- |
-| `name` | yes | Non-empty, ≤128 chars; `authd` re-validates independently and more strictly. |
+| `name` | yes | 2-128 chars, no leading `.`, charset `[A-Za-z0-9._-]` only — `OS_IsValidName()`, the same rule the legacy port-1515 path applies, so both enrollment paths accept exactly the same names. `authd`'s local socket separately enforces a looser *storage-safety* floor (no whitespace/control bytes, no leading `#`/`!`, ≤128 chars) for all of its callers, `manage_agents` and the API included; this endpoint holds the tighter line itself rather than relying on that floor. |
 | `version` | yes | Rejected if newer than the manager's unless `<remote><agents><allow_higher_versions>` is `yes` — `authd`'s local socket performs no version check of its own, so this endpoint enforces it. |
 | `groups` | no | Comma-separated, passed through unchanged. |
-| `ip` | no | Syntactic IPv4/IPv6/CIDR check, or the literal `any`; see IP resolution below. |
+| `ip` | no | Syntactic IPv4/IPv6/CIDR check, or one of two sentinels: `any` (no override), or `src` — mirrors legacy port 1515's own wire sentinel (an agent configured with its own client-side `use_source_ip` sends this instead of a literal address); see IP resolution below. |
 | `key_hash` | no | Opaque hash of the agent's current key, if it has one — drives `authd`'s force/key-mismatch decision, same as port 1515's `K:` field. |
 
 `force`, `id`, and a raw `key` are never sent, even though `authd`'s local socket accepts all three
@@ -931,8 +938,11 @@ for admin/restore use (`manage_agents`): `/enroll` is exclusively for a brand-ne
 self-enrolling, which always gets an auto-assigned ID and an `authd`-generated key.
 
 **IP resolution** mirrors `authd`'s own [`use_source_ip`](../authd/configuration.md#use_source_ip):
-if enabled, the HTTPS connection's observed peer address is used, overriding anything the body
-claims; otherwise the body's `ip` is used if present; otherwise `any`.
+if enabled (manager-side), the HTTPS connection's observed peer address is used, overriding
+anything the body claims. Otherwise, a body `ip` of `src` (agent-side sentinel) also resolves to
+the observed peer address — never forwarded to `authd` literally, since its local socket has no
+notion of that sentinel at all (only port 1515's own wire parser does) and would reject it as an
+invalid IP. Otherwise the body's `ip` is used if present; otherwise `any`.
 
 ### Responses
 
@@ -956,18 +966,27 @@ Verbatim from `authd` — the `key` the agent must store and use to sign every s
 | --- | --- | --- |
 | Enrollment administratively disabled | `403` | Route always exists; see above. |
 | Missing/invalid credential | `401` | Collapsed to one generic message; see Authentication above. |
+| Body exceeds `remoted.auth_max_body_size` (10 MiB default) | `413` | Checked BEFORE the CMAC runs (and before a credential check, in Open mode too) -- an oversized body is rejected without ever being hashed or reaching `parseAndValidateBody()`'s own smaller (16 KiB) schema check. |
 | Malformed body, missing `name`/`version`, invalid `ip` | `400` | Rejected before `authd` is ever contacted. |
 | Agent version newer than allowed | `400` | See `version` in the request table above. |
-| `authd` bad function/args/name/ip/groups (9003–9006, 9014) | `400` | Passed through with `authd`'s own message. |
+| `authd` bad function/args/name/ip/groups (9003–9006, 9014, 9017) | `400` | Passed through with `authd`'s own message. `9017` ("Invalid agent name") is unreachable from this endpoint in practice: `isValidName()` above is strictly tighter than the local socket's storage-safety floor, so any name `authd` would reject with `9017` was already refused locally with a `400`. It is mapped for completeness, not as a path clients should expect. |
 | `authd` duplicate ip/name/id (9007/9008/9012) | `409` | |
 | `authd` internal/parse/key-generation failure (9001/9002/9009) | `500` | |
 | `authd` `max_agents` reached (9013) | `503` | Server-wide capacity condition, not a per-client rate limit. |
 | Worker rejected the request (9015), or its forward to the master failed (9016, new in 5.0) | `503` | Only reachable via the local-socket bridge — see [Authd's local socket protocol](../authd/README.md#local-socket-enrollment-protocol). |
 | `authd` unreachable, or its reply was unparseable/timed out | `503` | `{"error":{"code":-1,"message":"Enrollment service temporarily unavailable"}}` |
 
-Every business-rejection error body has the shape `{"error":{"code":<authd-code>,"message":"<text>"}}`
-— distinct from every other endpoint's flat `{"error":"<message>","code":<status>}` shape, since
-this one passes through `authd`'s own numeric codes for diagnostics.
+Every error the `/enroll` **endpoint itself** produces — every row in the table above, disabled/
+credential/body-size/validation/`authd` business and transport failures alike — has the shape
+`{"error":{"code":<code>,"message":"<text>"}}`, distinct from every other endpoint's flat
+`{"error":"<message>","code":<status>}` shape, since this one passes through `authd`'s own numeric
+codes for diagnostics (`code` is `0` for the non-`authd` rows, which carry no numeric code).
+
+A few conditions never reach the endpoint's own code at all — the shared HTTP transport rejects them
+first, in the same flat shape it uses for every route, `/enroll` included: an uncaught exception
+(`500`), capacity-based load shedding once the module's in-flight byte budget is exhausted (`503`),
+or (mTLS mode) a client certificate that doesn't match the connecting peer's address (`403`). These
+are the exception to the "always nested" rule above, not a second business-error shape.
 
 ## Testing
 

--- a/docs/ref/modules/remoted/https-events-api.md
+++ b/docs/ref/modules/remoted/https-events-api.md
@@ -70,10 +70,9 @@ with no extra configuration). A few things to know before choosing one:
   without either side having to handle the mapped form.
 
 A self-signed certificate/key pair is generated automatically at install time (source install,
-`.deb` and `.rpm` all wire this in), using the same self-signed `generate_cert()` routine that
-`authd` uses for `authd.pem`/`authd-key.pem` — now shared code, invoked through remoted's
-own binary, and chowned to `wazuh-manager:wazuh-manager` afterward so the module can read it once
-`remoted` drops privileges:
+`.deb` and `.rpm` all wire this in) via the shared `generate_cert()` routine, invoked through
+remoted's own binary, and chowned to `wazuh-manager:wazuh-manager` afterward so the module can read
+it once `remoted` drops privileges:
 
 ```bash
 wazuh-manager-remoted -C 365 -B 2048 \
@@ -182,12 +181,12 @@ its default level zstd beats gzip's default on all three axes at once, so there 
 weigh — and decompression speed is the side that matters here, since agents compress while the
 manager decompresses:
 
-| Codec | Compressed | Compress | Decompress |
-|---|---|---|---|
-| `gzip-6` (default) | 4.25 MB | 224 ms | 44.2 ms |
-| `gzip-9` (max) | 4.10 MB | 429 ms | 43.1 ms |
+| Codec                  | Compressed  | Compress  | Decompress  |
+| ---------------------- | ----------- | --------- | ----------- |
+| `gzip-6` (default)     | 4.25 MB     | 224 ms    | 44.2 ms     |
+| `gzip-9` (max)         | 4.10 MB     | 429 ms    | 43.1 ms     |
 | **`zstd-3` (default)** | **3.66 MB** | **55 ms** | **24.0 ms** |
-| `zstd-9` | 3.44 MB | 157 ms | 24.3 ms |
+| `zstd-9`               | 3.44 MB     | 157 ms    | 24.3 ms     |
 
 Supporting both was considered and dropped: it would mean two decoders, two dependency chains and
 two test matrices for a codec that is dominated on this workload.
@@ -234,18 +233,18 @@ two test matrices for a codec that is dominated on this workload.
 On rejection the body is `{"error":"<message>","code":<status>}`. Credential-related failures all
 collapse to a **single generic `401`** so a client cannot tell which specific check failed.
 
-| Condition | HTTP | `error` message |
-|---|---|---|
-| Missing `protocol-version` header | `400` | `Missing required header: protocol-version` |
-| Unsupported `protocol-version` | `400` | `Unsupported protocol-version` |
-| Missing / malformed `Authorization`, unknown agent, unusable key, peer address not allowed by the agent's `ip` column, expired or future timestamp, invalid MAC | `401` | `Invalid client authentication` |
-| Body exceeds the auth body limit (10 MiB) -- or, for `Content-Encoding: zstd`, the decoder's buffers or the decompressed output don't fit in the in-flight capacity free at that moment | `413` | `Request payload is too large` |
-| `Content-Encoding` present but not (case-insensitively) `zstd` | `415` | `Unsupported Content-Encoding` |
-| `Content-Encoding: zstd`, but the body isn't a valid/complete zstd frame | `400` | `Malformed compressed body` |
-| Payload's `wazuh.agent.id` (H line) missing/malformed/non-numeric, or doesn't match the authenticated `agent-id` | `400` | `Invalid event batch` |
-| Downstream rejected the batch (bad H/E) | `400` | `Invalid event batch` |
-| Out of capacity, or downstream unreachable/errored | `503` | `Service unavailable` |
-| Endpoint handler raised an unexpected error | `500` | `Internal server error` |
+| Condition                                                                                                                                                                               | HTTP  | `error` message                             |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| ----- | ------------------------------------------- |
+| Missing `protocol-version` header                                                                                                                                                       | `400` | `Missing required header: protocol-version` |
+| Unsupported `protocol-version`                                                                                                                                                          | `400` | `Unsupported protocol-version`              |
+| Missing / malformed `Authorization`, unknown agent, unusable key, peer address not allowed by the agent's `ip` column, expired or future timestamp, invalid MAC                        | `401` | `Invalid client authentication`             |
+| Body exceeds the auth body limit (10 MiB) -- or, for `Content-Encoding: zstd`, the decoder's buffers or the decompressed output don't fit in the in-flight capacity free at that moment | `413` | `Request payload is too large`              |
+| `Content-Encoding` present but not (case-insensitively) `zstd`                                                                                                                          | `415` | `Unsupported Content-Encoding`              |
+| `Content-Encoding: zstd`, but the body isn't a valid/complete zstd frame                                                                                                                | `400` | `Malformed compressed body`                 |
+| Payload's `wazuh.agent.id` (H line) missing/malformed/non-numeric, or doesn't match the authenticated `agent-id`                                                                        | `400` | `Invalid event batch`                       |
+| Downstream rejected the batch (bad H/E)                                                                                                                                                 | `400` | `Invalid event batch`                       |
+| Out of capacity, or downstream unreachable/errored                                                                                                                                      | `503` | `Service unavailable`                       |
+| Endpoint handler raised an unexpected error                                                                                                                                             | `500` | `Internal server error`                     |
 
 The payload-identity check runs **before** the batch is forwarded: a mismatch never reaches the
 engine at all, and (by design) shares the same `400 Invalid event batch` message as a batch the
@@ -312,21 +311,21 @@ non-numeric) prevents `remoted` from starting, same as every other internal opti
 [Internal Options](configuration.md#internal-options) for the full reference (allowed ranges,
 notes).
 
-| Setting | Default | Internal option |
-|---|---|---|
-| I/O threads | `cpp_get_nproc()` | `remoted.http_io_threads` |
-| Handler worker threads | `2 * cpp_get_nproc()` | `remoted.http_worker_threads` |
-| Read / handshake timeout | `10 s` | `remoted.http_read_timeout` |
-| Write timeout | `10 s` | `remoted.http_write_timeout` |
-| Request timeout | `30 s` | `remoted.http_request_timeout` |
-| Max URL size | `2048 B` | `remoted.http_max_url_size` |
-| Max header name size | `256 B` | `remoted.http_max_header_name_size` |
-| Max header value size | `8192 B` | `remoted.http_max_header_value_size` |
-| Max header count | `64` | `remoted.http_max_header_count` |
-| Max pipelined requests per connection | `4` | `remoted.http_max_pipelined_requests` |
-| Concurrent TCP accepts | `2` | `remoted.http_concurrent_accepts` |
-| Socket read buffer size | `8192 B` | `remoted.http_buffer_size` |
-| Accept `Content-Encoding: zstd` | enabled | `remoted.http_content_encoding_enabled` |
+| Setting                               | Default               | Internal option                         |
+| ------------------------------------- | --------------------- | --------------------------------------- |
+| I/O threads                           | `cpp_get_nproc()`     | `remoted.http_io_threads`               |
+| Handler worker threads                | `2 * cpp_get_nproc()` | `remoted.http_worker_threads`           |
+| Read / handshake timeout              | `10 s`                | `remoted.http_read_timeout`             |
+| Write timeout                         | `10 s`                | `remoted.http_write_timeout`            |
+| Request timeout                       | `30 s`                | `remoted.http_request_timeout`          |
+| Max URL size                          | `2048 B`              | `remoted.http_max_url_size`             |
+| Max header name size                  | `256 B`               | `remoted.http_max_header_name_size`     |
+| Max header value size                 | `8192 B`              | `remoted.http_max_header_value_size`    |
+| Max header count                      | `64`                  | `remoted.http_max_header_count`         |
+| Max pipelined requests per connection | `4`                   | `remoted.http_max_pipelined_requests`   |
+| Concurrent TCP accepts                | `2`                   | `remoted.http_concurrent_accepts`       |
+| Socket read buffer size               | `8192 B`              | `remoted.http_buffer_size`              |
+| Accept `Content-Encoding: zstd`       | enabled               | `remoted.http_content_encoding_enabled` |
 
 I/O threads and handler worker threads are thread-count settings: a `<=0` value (including "not
 set" in `wazuh-manager-internal-options.conf`) resolves via `cpp_get_nproc()`
@@ -345,17 +344,17 @@ built-in default below. See
 `http_worker_threads`) is not exposed in `<https>` and remains an internal option (see the table
 above).
 
-| Setting | `<https>` tag | Default |
-|---|---|---|
-| Bind address (IPv4 or IPv6, see [above](#bind-address-ipv4-ipv6-and-dual-stack)) | `bind_addr` | `127.0.0.1` |
-| Dual-stack override (IPv6 `bind_addr` only) | `dual_stack` | `no` (force IPv6-only) |
-| Port | `port` | `1517` |
-| Transport max body size | `max_body_size` | `20 MiB` |
-| TLS certificate chain | `certificate` | `etc/certs/remoted.pem` |
-| TLS private key | `key` | `etc/certs/remoted-key.pem` |
-| Client CA bundle | `ca` | `etc/certs/root-ca.pem` |
-| Client verification mode | `verification_mode` | `none` (auto-upgraded to `certificate` if `<ca>` is set in XML without `<verification_mode>`) |
-| TLS 1.3 ciphersuites | `ciphers` | `TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256` |
+| Setting                                                                          | `<https>` tag       | Default                                                                                       |
+| -------------------------------------------------------------------------------- | ------------------- | --------------------------------------------------------------------------------------------- |
+| Bind address (IPv4 or IPv6, see [above](#bind-address-ipv4-ipv6-and-dual-stack)) | `bind_addr`         | `127.0.0.1`                                                                                   |
+| Dual-stack override (IPv6 `bind_addr` only)                                      | `dual_stack`        | `no` (force IPv6-only)                                                                        |
+| Port                                                                             | `port`              | `1517`                                                                                        |
+| Transport max body size                                                          | `max_body_size`     | `20 MiB`                                                                                      |
+| TLS certificate chain                                                            | `certificate`       | `etc/certs/remoted.pem`                                                                       |
+| TLS private key                                                                  | `key`               | `etc/certs/remoted-key.pem`                                                                   |
+| Client CA bundle                                                                 | `ca`                | `etc/certs/root-ca.pem`                                                                       |
+| Client verification mode                                                         | `verification_mode` | `none` (auto-upgraded to `certificate` if `<ca>` is set in XML without `<verification_mode>`) |
+| TLS 1.3 ciphersuites                                                             | `ciphers`           | `TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256`                  |
 
 > There is no `enabled` toggle: the listener always attempts to start and self-gates on the
 > presence of a valid certificate/key, same as before this configuration surface existed.
@@ -366,11 +365,11 @@ deliberately **not** internal options -- they bound in-memory resource usage rat
 transport, so they don't go through `remoted_module_https_config()`/the internal-options table
 above.
 
-| Setting | Default | Source |
-|---|---|---|
-| Max in-flight payload bytes (→ `503`) | `256 MiB` | remoted config `max_inflight_bytes` |
-| Max simultaneous connections | `512` | remoted config `max_parallel_connections` |
-| Max deferred requests awaiting downstream (→ `503`) | `256` | remoted config `max_deferred_requests` |
+| Setting                                             | Default   | Source                                    |
+| --------------------------------------------------- | --------- | ----------------------------------------- |
+| Max in-flight payload bytes (→ `503`)               | `256 MiB` | remoted config `max_inflight_bytes`       |
+| Max simultaneous connections                        | `512`     | remoted config `max_parallel_connections` |
+| Max deferred requests awaiting downstream (→ `503`) | `256`     | remoted config `max_deferred_requests`    |
 
 The capacity limits are **layered**: the transport max body size caps a single request's peak
 (RESTinio rejects an oversized `Content-Length` early by closing the connection), the max connections
@@ -389,17 +388,17 @@ reads each `remoted.*` option and passes it through the C-ABI struct;
 built-in default on `<=0`. The three timeouts are configured in **seconds** and converted to
 milliseconds internally.
 
-| Setting | Default | Internal option |
-|---|---|---|
-| Downstream connect timeout | `2 s` | `remoted.downstream_connect_timeout` |
-| Downstream write timeout | `5 s` | `remoted.downstream_write_timeout` |
-| Downstream response timeout | `5 s` | `remoted.downstream_response_timeout` |
-| Downstream client I/O threads | `cpp_get_nproc()` | `remoted.downstream_io_threads` |
-| Downstream post-processing threads | `cpp_get_nproc()` | `remoted.downstream_post_process_threads` |
-| Max downstream response body | `10 MiB` | `remoted.downstream_max_response_body_size` |
-| Auth max request age | `300 s` | `remoted.auth_max_request_age` |
-| Auth max future skew | `30 s` | `remoted.auth_max_future_skew` |
-| Auth max body size | `10 MiB` | `remoted.auth_max_body_size` |
+| Setting                            | Default           | Internal option                             |
+| ---------------------------------- | ----------------- | ------------------------------------------- |
+| Downstream connect timeout         | `2 s`             | `remoted.downstream_connect_timeout`        |
+| Downstream write timeout           | `5 s`             | `remoted.downstream_write_timeout`          |
+| Downstream response timeout        | `5 s`             | `remoted.downstream_response_timeout`       |
+| Downstream client I/O threads      | `cpp_get_nproc()` | `remoted.downstream_io_threads`             |
+| Downstream post-processing threads | `cpp_get_nproc()` | `remoted.downstream_post_process_threads`   |
+| Max downstream response body       | `10 MiB`          | `remoted.downstream_max_response_body_size` |
+| Auth max request age               | `300 s`           | `remoted.auth_max_request_age`              |
+| Auth max future skew               | `30 s`            | `remoted.auth_max_future_skew`              |
+| Auth max body size                 | `10 MiB`          | `remoted.auth_max_body_size`                |
 
 The two thread-count fields above resolve a `<=0` value via `cpp_get_nproc()` the same way
 `http_io_threads`/`http_worker_threads` do (no `2x` oversubscription here -- both pools are either
@@ -433,15 +432,15 @@ request(s) with 503 in the last 90 s. Consider increasing the value of 'max_defe
 investigate why the downstream service is not keeping up.
 ```
 
-| Symptom in `wazuh-manager.log ` | Setting to review |
-|---|---|
-| In-flight request memory budget exhausted | `max_inflight_bytes` |
-| Deferred-work slots exhausted | `max_deferred_requests` |
-| Timed out connecting to / sending to / waiting for the downstream service | `remoted.downstream_connect_timeout`, `_write_timeout`, `_response_timeout` |
-| Downstream response exceeded the configured cap | `remoted.downstream_max_response_body_size` |
-| Timestamps outside the accepted window (agent clock drift) | `remoted.auth_max_request_age`, `remoted.auth_max_future_skew` |
-| Body exceeded the authenticated-body cap (413) | `remoted.auth_max_body_size` (uncompressed body), or `max_inflight_bytes` (`Content-Encoding: zstd`) |
-| Downstream timeouts add up past `http_request_timeout` | `remoted.http_request_timeout` |
+| Symptom in `wazuh-manager.log `                                           | Setting to review                                                                                    |
+| ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| In-flight request memory budget exhausted                                 | `max_inflight_bytes`                                                                                 |
+| Deferred-work slots exhausted                                             | `max_deferred_requests`                                                                              |
+| Timed out connecting to / sending to / waiting for the downstream service | `remoted.downstream_connect_timeout`, `_write_timeout`, `_response_timeout`                          |
+| Downstream response exceeded the configured cap                           | `remoted.downstream_max_response_body_size`                                                          |
+| Timestamps outside the accepted window (agent clock drift)                | `remoted.auth_max_request_age`, `remoted.auth_max_future_skew`                                       |
+| Body exceeded the authenticated-body cap (413)                            | `remoted.auth_max_body_size` (uncompressed body), or `max_inflight_bytes` (`Content-Encoding: zstd`) |
+| Downstream timeouts add up past `http_request_timeout`                    | `remoted.http_request_timeout`                                                                       |
 
 Two more, about a registered address that no longer matches, both collapsed on the same 90-second
 window as everything above:
@@ -664,15 +663,15 @@ timestamp, last keepalive update timestamp) to minimize wazuh-db round-trips dur
 Errors follow the same pattern as `/stateless` (see [Error responses](#error-responses) above).
 Control-specific conditions:
 
-| Condition | HTTP | `error` message |
-|---|---|---|
-| Body empty or exceeds 64 KiB | `400` | `invalid_body` |
-| Malformed JSON body | `400` | `invalid_json` |
-| Invalid agent ID format | `400` | `invalid_agent_id` |
-| Unknown message type | `400` | `unknown_message_type` |
-| Invalid agent version (startup only) | `400` | `invalid_version` |
-| Invalid host info format (notify only) | `400` | `invalid_host_info` |
-| wazuh-db error during startup (get groups) | `500` | `database_error` |
+| Condition                                  | HTTP  | `error` message        |
+| ------------------------------------------ | ----- | ---------------------- |
+| Body empty or exceeds 64 KiB               | `400` | `invalid_body`         |
+| Malformed JSON body                        | `400` | `invalid_json`         |
+| Invalid agent ID format                    | `400` | `invalid_agent_id`     |
+| Unknown message type                       | `400` | `unknown_message_type` |
+| Invalid agent version (startup only)       | `400` | `invalid_version`      |
+| Invalid host info format (notify only)     | `400` | `invalid_host_info`    |
+| wazuh-db error during startup (get groups) | `500` | `database_error`       |
 
 Auth failures (`401`) and body-too-large at transport layer (`413`) reuse the same responses as
 `/stateless`. Throttled logging (one message per 90 seconds per condition) prevents log flooding
@@ -733,19 +732,19 @@ local value with an older `current_version`.
 
 ### Error handling
 
-| Condition | HTTP | `error` message |
-|---|---|---|
-| Body empty or exceeds 4 KiB | `400` | `invalid_body` |
-| Malformed JSON body | `400` | `invalid_json` |
-| Invalid agent ID format | `400` | `invalid_agent_id` |
-| Missing or non-string `type` | `400` | `missing_type` |
-| `type` other than `"feed_update"` | `400` | `invalid_type` |
-| Missing or non-unsigned `feed_offset` | `400` | `missing_feed_offset` |
-| `feed_offset` != current offset | `409` | `version_mismatch` (carries `current_version`) |
-| VD's scan dispatch lane at capacity | `503` | `scan_queue_full` |
-| Indexer not usable (no healthy host) | `503` | `indexer_unavailable` |
+| Condition                                        | HTTP  | `error` message                                               |
+| ------------------------------------------------ | ----- | ------------------------------------------------------------- |
+| Body empty or exceeds 4 KiB                      | `400` | `invalid_body`                                                |
+| Malformed JSON body                              | `400` | `invalid_json`                                                |
+| Invalid agent ID format                          | `400` | `invalid_agent_id`                                            |
+| Missing or non-string `type`                     | `400` | `missing_type`                                                |
+| `type` other than `"feed_update"`                | `400` | `invalid_type`                                                |
+| Missing or non-unsigned `feed_offset`            | `400` | `missing_feed_offset`                                         |
+| `feed_offset` != current offset                  | `409` | `version_mismatch` (carries `current_version`)                |
+| VD's scan dispatch lane at capacity              | `503` | `scan_queue_full`                                             |
+| Indexer not usable (no healthy host)             | `503` | `indexer_unavailable`                                         |
 | VD not ready (feed mid-update, scanner starting) | `503` | `feed_not_ready` / `scanner_not_ready` / `vd_not_initialized` |
-| VD stopping or unreachable, or the relay failed | `503` | `shutting_down` / `vd_unreachable` / `vd_error` |
+| VD stopping or unreachable, or the relay failed  | `503` | `shutting_down` / `vd_unreachable` / `vd_error`               |
 
 Every `503` means the same thing to the agent — not accepted, retry on the next notify cycle —
 and its pending state survives; the `error` code exists so an operator reading the exchange sees

--- a/docs/ref/modules/remoted/https-events-api.md
+++ b/docs/ref/modules/remoted/https-events-api.md
@@ -90,7 +90,13 @@ the `wazuh-manager` user (e.g. via the same ownership/mode) or the module fails 
 
 ## Authentication (AES-CMAC)
 
-Every request MUST carry two headers:
+**Single exception: `POST /enroll`.** Every other endpoint on this page requires the agent<->manager
+AES-CMAC scheme described in this section, keyed by an agent's pre-shared `client.keys` entry. An
+enrolling agent has no such entry yet, so `/enroll` cannot use it — it authenticates with an
+independent, per-listener credential instead (a client certificate, a shared password, or neither).
+See [Enrollment endpoint](#enrollment-endpoint-post-enroll) below.
+
+Every other request MUST carry two headers:
 
 ```text
 protocol-version: 1
@@ -297,6 +303,13 @@ awaiting the downstream service. The liveness `GET /` is exempt from the byte bu
   malformed requests, **`401`** on auth failures, or **`503`** when VD did not queue it (dispatch
   lane full, feed mid-update, module stopping or unreachable, no indexer host available). See
   [Scan endpoint](#scan-endpoint-post-scanvd) below for details.
+- **`POST /enroll`** — bridges a new agent's self-enrollment request to `authd` (see
+  [Authd](../authd/README.md)), which owns all enrollment business logic. Unlike every other
+  authenticated endpoint above, it does **not** use the agent<->manager AES-CMAC scheme — the agent
+  has no key yet — and it is **always registered**, answering **`403`** rather than a bare `404`
+  when enrollment is administratively disabled. Returns **`200 OK`** with the new agent's
+  `{id,name,ip,key}` on success, or a mapped `4xx`/`5xx` on failure. See
+  [Enrollment endpoint](#enrollment-endpoint-post-enroll) below for details.
 
 The machine-readable contract is published as OpenAPI — see the
 [endpoint reference](stateless-api-reference.html) (source: [`stateless-api.yaml`](stateless-api.yaml)).
@@ -406,6 +419,28 @@ a purely async I/O reactor or documented as non-blocking work). The downstream c
 socket path (`eventsSocketPath`) and the auth middleware's `supportedProtocolVersion` are not
 internal options -- the former is an installation detail (mirrors the classic C forwarder's
 socket), the latter a protocol constant.
+
+### Enrollment bridge (`POST /enroll`)
+
+A fifth, small group of internal options tunes the `/enroll`-to-`authd` bridge
+(`AuthdClient`/`PasswordKeySource`, see [Enrollment endpoint](#enrollment-endpoint-post-enroll)
+below). Same resolution pattern: `secure.c` reads each option and passes it through the C-ABI
+struct.
+
+| Setting                                     | Default                                                | Internal option                          |
+| -------------------------------------------- | ------------------------------------------------------ | ----------------------------------------- |
+| `etc/authd.pass` hot-reload poll interval     | `10 s`                                                  | `remoted.enroll_password_refresh_interval` |
+| `authd` local-socket connect timeout          | `2 s`                                                   | `remoted.authd_connect_timeout`            |
+| `authd` local-socket response timeout         | `5 s` on a master, `15 s` on a cluster worker           | `remoted.authd_response_timeout`           |
+| Bridge request queue high-water mark          | `256`                                                   | `remoted.authd_max_queue_size`             |
+
+The response timeout's worker default is longer than the master's on purpose: on a worker, `authd`'s
+own forward to the master can retry internally for several seconds before answering, and a shorter
+client-side timeout here would cut off a legitimate, still-in-progress worker enrollment as a
+spurious `503`. All other enrollment behavior (whether it's enabled, whether a password/client
+certificate is required, which agent versions are accepted) is deliberately **not** a separate
+`remoted`-owned setting — it's read from `authd`'s own `<auth>` block so the two enrollment paths
+can never disagree; see [Enrollment endpoint](#enrollment-endpoint-post-enroll) below.
 
 ### client.keys hot-reload
 
@@ -783,6 +818,147 @@ endpoint themselves) are not covered by `/scan/vd` at all — they're swept sepa
 update, by the cluster's master node only (`VulnerabilityScannerFacade::rescanDisconnectedAgents()`
 in the `vulnerability_scanner` module).
 
+## Enrollment endpoint (`POST /enroll`)
+
+`/enroll` lets a new agent register over the same HTTPS channel (port 1517) it uses for everything
+else afterward, instead of falling back to legacy `authd` on port 1515. It is a **bridge, not a
+second implementation**: `authd` keeps 100% of enrollment business logic (name/version/group
+validation, key generation, duplicate handling, cluster forwarding on a worker); this endpoint only
+authenticates the request and relays it to `authd`'s existing local socket
+(`queue/sockets/auth`) — the same interface `manage_agents` and the API's agent-registration
+endpoints already use. See [Authd](../authd/README.md) for what happens once a request reaches
+that socket, and [`legacy_enrollment`](../authd/configuration.md#legacy_enrollment) for how an
+operator can retire port 1515 while keeping `/enroll` (or disable both together via
+`remote_enrollment`).
+
+**The route is always registered**, regardless of configuration. When enrollment is
+administratively disabled (`<auth><disabled>yes</disabled>`, or `<auth><remote_enrollment>no</auth>`),
+it answers **`403`** rather than disappearing — a missing route (`404`) would mean "this manager
+doesn't support enrollment at all," which is a different, more permanent statement than "an operator
+turned this off."
+
+### Authentication
+
+Unlike every other endpoint on this page, `/enroll` cannot use the agent<->manager AES-CMAC scheme
+(see [Authentication](#authentication-aes-cmac) above) — an enrolling agent has no `client.keys`
+entry yet to sign with. Two credential checks apply instead, decided once at manager startup and
+**independently** of each other (an operator can require either, both, or neither — see below):
+
+- **Client certificate** — purely a property of the HTTPS listener's own `verification_mode`
+  (`certificate` or `full`; see [Configuration](configuration.md#https-configuration)). When
+  configured, the TLS handshake validates the agent's certificate against the manager's CA
+  **before the request ever reaches this endpoint** — there is nothing further for `/enroll` itself
+  to check.
+- **Password** — required whenever `authd`'s [`use_password`](../authd/configuration.md#use_password)
+  is enabled. The request must carry:
+
+  ```text
+  Authorization: WazuhEnroll <unix-timestamp>:<mac>
+  ```
+
+  `<mac>` is a 32-character lowercase-hex AES-256-CMAC, keyed by a 32-byte key derived from
+  `authd`'s enrollment password (`etc/authd.pass`) via **HKDF-SHA256** (empty salt,
+  `info = "WAZUH-ENROLL-CMAC-KEY" + 0x01`) — never the password bytes themselves. The timestamp
+  accepts the same window as the AES-CMAC scheme above (300 s past, 30 s future). The MAC covers a
+  canonical byte sequence deliberately similar to the AES-CMAC scheme's, minus the agent-id field
+  (an enrolling agent doesn't have one):
+
+  ```text
+  WAZUH-ENROLL\n
+  1\n
+  <uppercase-method>\n
+  <request-target>\n      (raw path + query, exactly as sent)
+  <unix-timestamp>\n
+  <request-body>          (exact body bytes, no trailing newline)
+  ```
+
+  A missing/unreadable/invalid password file fails **closed** — every request is rejected, never
+  silently treated as if no password were required.
+
+Both checks failing to apply (no client-certificate requirement, no password configured) means the
+request needs no credential at all, matching `authd`'s own behavior on port 1515 in that
+configuration.
+
+Every auth rejection collapses to the same generic response, so a client cannot tell which check
+failed: `401` with `{"error":{"code":0,"message":"Invalid client authentication"}}`.
+
+**Worked example** (verified known-answer vector, useful as a cross-implementation test):
+
+| Input | Value |
+| --- | --- |
+| Password | `MyEnrollmentSecret123` |
+| HKDF-SHA256 derived key | `2ea29504f294bce5039bdb4fb78747dec59866204dc2588dc59f3b8cd5875a9e` |
+| Canonical string | `WAZUH-ENROLL\n1\nPOST\n/enroll\n1739999999\n{"name":"web-server-01","version":"5.0.0","groups":"default,web-servers","ip":"10.0.0.15"}` |
+| AES-256-CMAC | `dc07d78fc156a1944f4fb02b91da7d01` |
+| Resulting header | `Authorization: WazuhEnroll 1739999999:dc07d78fc156a1944f4fb02b91da7d01` |
+
+There is no per-request nonce, so a captured request could in principle be replayed inside its
+freshness window — bounded in practice by `authd`'s own duplicate-name/IP rejection (unless
+force-replace is configured to permit it). This mirrors the threat model the AES-CMAC scheme above
+already accepts, with TLS protecting the transport either way.
+
+### Request
+
+```json
+{
+  "name": "web-server-01",
+  "version": "5.0.0",
+  "groups": "default,web-servers",
+  "ip": "10.0.0.15"
+}
+```
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `name` | yes | Non-empty, ≤128 chars; `authd` re-validates independently and more strictly. |
+| `version` | yes | Rejected if newer than the manager's unless `<remote><agents><allow_higher_versions>` is `yes` — `authd`'s local socket performs no version check of its own, so this endpoint enforces it. |
+| `groups` | no | Comma-separated, passed through unchanged. |
+| `ip` | no | Syntactic IPv4/IPv6/CIDR check, or the literal `any`; see IP resolution below. |
+| `key_hash` | no | Opaque hash of the agent's current key, if it has one — drives `authd`'s force/key-mismatch decision, same as port 1515's `K:` field. |
+
+`force`, `id`, and a raw `key` are never sent, even though `authd`'s local socket accepts all three
+for admin/restore use (`manage_agents`): `/enroll` is exclusively for a brand-new agent
+self-enrolling, which always gets an auto-assigned ID and an `authd`-generated key.
+
+**IP resolution** mirrors `authd`'s own [`use_source_ip`](../authd/configuration.md#use_source_ip):
+if enabled, the HTTPS connection's observed peer address is used, overriding anything the body
+claims; otherwise the body's `ip` is used if present; otherwise `any`.
+
+### Responses
+
+**Success (`200 OK`):**
+
+```json
+{
+  "id": "003",
+  "name": "web-server-01",
+  "ip": "10.0.0.15",
+  "key": "675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915"
+}
+```
+
+Verbatim from `authd` — the `key` the agent must store and use to sign every subsequent request
+(via the AES-CMAC scheme above) with its new numeric `id`.
+
+### Error handling
+
+| Condition | HTTP | Notes |
+| --- | --- | --- |
+| Enrollment administratively disabled | `403` | Route always exists; see above. |
+| Missing/invalid credential | `401` | Collapsed to one generic message; see Authentication above. |
+| Malformed body, missing `name`/`version`, invalid `ip` | `400` | Rejected before `authd` is ever contacted. |
+| Agent version newer than allowed | `400` | See `version` in the request table above. |
+| `authd` bad function/args/name/ip/groups (9003–9006, 9014) | `400` | Passed through with `authd`'s own message. |
+| `authd` duplicate ip/name/id (9007/9008/9012) | `409` | |
+| `authd` internal/parse/key-generation failure (9001/9002/9009) | `500` | |
+| `authd` `max_agents` reached (9013) | `503` | Server-wide capacity condition, not a per-client rate limit. |
+| Worker rejected the request (9015), or its forward to the master failed (9016, new in 5.0) | `503` | Only reachable via the local-socket bridge — see [Authd's local socket protocol](../authd/README.md#local-socket-enrollment-protocol). |
+| `authd` unreachable, or its reply was unparseable/timed out | `503` | `{"error":{"code":-1,"message":"Enrollment service temporarily unavailable"}}` |
+
+Every business-rejection error body has the shape `{"error":{"code":<authd-code>,"message":"<text>"}}`
+— distinct from every other endpoint's flat `{"error":"<message>","code":<status>}` shape, since
+this one passes through `authd`'s own numeric codes for diagnostics.
+
 ## Testing
 
 `src/remoted/remoted_module/tools/send_stateless.py` signs and sends `POST /stateless` requests the
@@ -824,5 +1000,8 @@ python3 send_scan_vd.py --all
 - [Event Protocol Specification](event-protocol.md) — the `H`/`E` wire format for event batches.
 - [Configuration](configuration.md) — classic `remoted` (`<remote>`) options and internal options.
 - [Architecture](architecture.md) — where the HTTPS listener sits in the `remoted` pipeline.
+- [Authd](../authd/README.md) / [Authd Configuration](../authd/configuration.md) — the enrollment
+  service `/enroll` bridges to, and the `remote_enrollment`/`legacy_enrollment` flags that gate
+  both enrollment paths.
 - Endpoint contract: [`stateless-api.yaml`](stateless-api.yaml) /
   [ReDoc reference](stateless-api-reference.html).

--- a/etc/templates/config/generic/auth.template
+++ b/etc/templates/config/generic/auth.template
@@ -8,6 +8,6 @@
     <ciphers>TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256</ciphers>
     <!-- <ssl_agent_ca></ssl_agent_ca> -->
     <ssl_verify_host>no</ssl_verify_host>
-    <ssl_manager_cert>etc/certs/remoted.pem</ssl_manager_cert>
-    <ssl_manager_key>etc/certs/remoted-key.pem</ssl_manager_key>
+    <ssl_manager_cert>${WAZUH_AUTHD_SSL_MANAGER_CERT}</ssl_manager_cert>
+    <ssl_manager_key>${WAZUH_AUTHD_SSL_MANAGER_KEY}</ssl_manager_key>
   </auth>

--- a/etc/templates/config/generic/auth.template
+++ b/etc/templates/config/generic/auth.template
@@ -8,6 +8,6 @@
     <ciphers>TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256</ciphers>
     <!-- <ssl_agent_ca></ssl_agent_ca> -->
     <ssl_verify_host>no</ssl_verify_host>
-    <ssl_manager_cert>etc/certs/authd.pem</ssl_manager_cert>
-    <ssl_manager_key>etc/certs/authd-key.pem</ssl_manager_key>
+    <ssl_manager_cert>etc/certs/remoted.pem</ssl_manager_cert>
+    <ssl_manager_key>etc/certs/remoted-key.pem</ssl_manager_key>
   </auth>

--- a/etc/wazuh-manager.conf
+++ b/etc/wazuh-manager.conf
@@ -47,8 +47,8 @@
     <use_password>yes</use_password>
     <!-- <ssl_agent_ca></ssl_agent_ca> -->
     <ssl_verify_host>no</ssl_verify_host>
-    <ssl_manager_cert>etc/certs/authd.pem</ssl_manager_cert>
-    <ssl_manager_key>etc/certs/authd-key.pem</ssl_manager_key>
+    <ssl_manager_cert>etc/certs/remoted.pem</ssl_manager_cert>
+    <ssl_manager_key>etc/certs/remoted-key.pem</ssl_manager_key>
   </auth>
 
 </wazuh_config>

--- a/framework/wazuh/rbac/tests/test_decorators.py
+++ b/framework/wazuh/rbac/tests/test_decorators.py
@@ -134,7 +134,7 @@ def _conf_payload():
     return {
         "auth": {
             "use_password": "yes",
-            "ssl_manager_key": "etc/certs/authd-key.pem"
+            "ssl_manager_key": "etc/certs/remoted-key.pem"
         },
         "integration": {
             "secret": "topsecret",
@@ -147,7 +147,7 @@ def _conf_payload():
 def _conf_result_payload():
     r = AffectedItemsWazuhResult(all_msg="ok", some_msg="ok", none_msg="ok")
     r.affected_items.append({
-        "auth": {"use_password": "no", "ssl_manager_key": "etc/certs/authd-key.pem"},
+        "auth": {"use_password": "no", "ssl_manager_key": "etc/certs/remoted-key.pem"},
         "integration": {"secret": "topsecret"},
         "authd.pass": "P4ssW0rd!"
     })

--- a/packages/debs/SPECS/wazuh-manager/debian/postinst
+++ b/packages/debs/SPECS/wazuh-manager/debian/postinst
@@ -135,14 +135,13 @@ case "$1" in
     # bit keeps them from replacing the root-owned indexer trust material that shares the dir.
     mkdir -p ${DIR}/etc/certs
 
-    # Generation auto-signed certificate if not exists
-    if [ ! -f "${DIR}/etc/certs/authd-key.pem" ] && [ ! -f "${DIR}/etc/certs/authd.pem" ]; then
-        ${DIR}/bin/wazuh-manager-authd -C 365 -B 2048 -S "/C=US/ST=California/CN=Wazuh/" -K ${DIR}/etc/certs/authd-key.pem -X ${DIR}/etc/certs/authd.pem 2>/dev/null
-    fi
-
     # Generate auto-signed certificate for the HTTPS agent server (remoted_module) if not
     # exists. Skipped when the admin supplied their own certificate/key paths through the
-    # WAZUH_REMOTE_HTTPS_CERTIFICATE / WAZUH_REMOTE_HTTPS_KEY installation variables.
+    # WAZUH_REMOTE_HTTPS_CERTIFICATE / WAZUH_REMOTE_HTTPS_KEY installation variables. This is
+    # the manager's ONLY self-signed cert/key pair: authd no longer generates its own (its
+    # <ssl_manager_cert>/<ssl_manager_key> point here too), so both listeners present the same
+    # manager identity -- required now that /enroll's mTLS mode treats this certificate as the
+    # enrollment credential.
     if [ -z "${WAZUH_REMOTE_HTTPS_CERTIFICATE}" ] && [ -z "${WAZUH_REMOTE_HTTPS_KEY}" ]; then
         if [ ! -f "${DIR}/etc/certs/remoted-key.pem" ] && [ ! -f "${DIR}/etc/certs/remoted.pem" ]; then
             ${DIR}/bin/wazuh-manager-remoted -C 365 -B 2048 -S "/C=US/ST=California/CN=Wazuh/" -K ${DIR}/etc/certs/remoted-key.pem -X ${DIR}/etc/certs/remoted.pem 2>/dev/null
@@ -151,7 +150,7 @@ case "$1" in
 
     # The server certificates each daemon self-generates are owned by ${USER} (the daemon must
     # write them). Re-applied unconditionally so upgrades that left them root-owned get corrected.
-    for CERT_FILE in authd.pem authd-key.pem remoted.pem remoted-key.pem apid.pem apid-key.pem; do
+    for CERT_FILE in remoted.pem remoted-key.pem apid.pem apid-key.pem; do
         if [ -f "${DIR}/etc/certs/${CERT_FILE}" ]; then
             chown ${USER}:${GROUP} ${DIR}/etc/certs/${CERT_FILE} > /dev/null 2>&1 || true
             chmod 640 ${DIR}/etc/certs/${CERT_FILE} > /dev/null 2>&1 || true

--- a/packages/rpms/SPECS/wazuh-manager.spec
+++ b/packages/rpms/SPECS/wazuh-manager.spec
@@ -349,14 +349,13 @@ fi
 # sticky bit keeps them from replacing the root-owned indexer trust material in the dir.
 mkdir -p %{_localstatedir}/etc/certs
 
-# Generation auto-signed certificate if not exists
-if [ ! -f "%{_localstatedir}/etc/certs/authd-key.pem" ] && [ ! -f "%{_localstatedir}/etc/certs/authd.pem" ]; then
-  %{_localstatedir}/bin/wazuh-manager-authd -C 365 -B 2048 -S "/C=US/ST=California/CN=Wazuh/" -K %{_localstatedir}/etc/certs/authd-key.pem -X %{_localstatedir}/etc/certs/authd.pem 2>/dev/null
-fi
-
 # Generate auto-signed certificate for the HTTPS agent server (remoted_module) if not
 # exists. Skipped when the admin supplied their own certificate/key paths through the
-# WAZUH_REMOTE_HTTPS_CERTIFICATE / WAZUH_REMOTE_HTTPS_KEY installation variables.
+# WAZUH_REMOTE_HTTPS_CERTIFICATE / WAZUH_REMOTE_HTTPS_KEY installation variables. This is
+# the manager's ONLY self-signed cert/key pair: authd no longer generates its own (its
+# <ssl_manager_cert>/<ssl_manager_key> point here too), so both listeners present the same
+# manager identity -- required now that /enroll's mTLS mode treats this certificate as the
+# enrollment credential.
 if [ -z "${WAZUH_REMOTE_HTTPS_CERTIFICATE}" ] && [ -z "${WAZUH_REMOTE_HTTPS_KEY}" ]; then
   if [ ! -f "%{_localstatedir}/etc/certs/remoted-key.pem" ] && [ ! -f "%{_localstatedir}/etc/certs/remoted.pem" ]; then
     %{_localstatedir}/bin/wazuh-manager-remoted -C 365 -B 2048 -S "/C=US/ST=California/CN=Wazuh/" -K %{_localstatedir}/etc/certs/remoted-key.pem -X %{_localstatedir}/etc/certs/remoted.pem 2>/dev/null
@@ -365,7 +364,7 @@ fi
 
 # The server certificates each daemon self-generates are owned by wazuh-manager (the daemon
 # must write them). Re-applied unconditionally so upgrades that left them root-owned get corrected.
-for CERT_FILE in authd.pem authd-key.pem remoted.pem remoted-key.pem apid.pem apid-key.pem; do
+for CERT_FILE in remoted.pem remoted-key.pem apid.pem apid-key.pem; do
   if [ -f "%{_localstatedir}/etc/certs/${CERT_FILE}" ]; then
     chown wazuh-manager:wazuh-manager %{_localstatedir}/etc/certs/${CERT_FILE} > /dev/null 2>&1 || true
     chmod 640 %{_localstatedir}/etc/certs/${CERT_FILE} > /dev/null 2>&1 || true
@@ -454,15 +453,8 @@ if [ $1 = 0 ];then
     find %{_localstatedir}/etc/ -type f ! -name "*shared*" ! -name "*rpmsave" -exec mv {} {}.save \;
   fi
 
-  # Backup registration service certificates (authd.pem, authd-key.pem)
-  if [ -f %{_localstatedir}/etc/certs/authd.pem ]; then
-      mv %{_localstatedir}/etc/certs/authd.pem %{_localstatedir}/etc/certs/authd.pem.save
-  fi
-  if [ -f %{_localstatedir}/etc/certs/authd-key.pem ]; then
-      mv %{_localstatedir}/etc/certs/authd-key.pem %{_localstatedir}/etc/certs/authd-key.pem.save
-  fi
-
-  # Backup HTTPS agent server certificates (remoted.pem, remoted-key.pem)
+  # Backup HTTPS agent server certificates (remoted.pem, remoted-key.pem) -- also authd's manager
+  # identity now (see ssl_manager_cert/ssl_manager_key in auth.template)
   if [ -f %{_localstatedir}/etc/certs/remoted.pem ]; then
       mv %{_localstatedir}/etc/certs/remoted.pem %{_localstatedir}/etc/certs/remoted.pem.save
   fi
@@ -588,8 +580,6 @@ rm -fr %{buildroot}
 %dir %attr(770, root, wazuh-manager) %{_localstatedir}/etc
 %attr(660, root, wazuh-manager) %ghost %{_localstatedir}/etc/wazuh-manager.conf
 %dir %attr(1770, root, wazuh-manager) %{_localstatedir}/etc/certs
-%attr(640, wazuh-manager, wazuh-manager) %ghost %{_localstatedir}/etc/certs/authd.pem
-%attr(640, wazuh-manager, wazuh-manager) %ghost %{_localstatedir}/etc/certs/authd-key.pem
 %attr(640, wazuh-manager, wazuh-manager) %ghost %{_localstatedir}/etc/certs/remoted.pem
 %attr(640, wazuh-manager, wazuh-manager) %ghost %{_localstatedir}/etc/certs/remoted-key.pem
 %attr(660, wazuh-manager, wazuh-manager) %{_localstatedir}/etc/client.keys

--- a/src/config/include/authd-config.h
+++ b/src/config/include/authd-config.h
@@ -38,6 +38,9 @@ typedef struct authd_flags_t {
     unsigned short use_password:1;
     unsigned short verify_host:1;
     unsigned short remote_enrollment:1;
+    unsigned short legacy_enrollment:1;  ///< Gates only the legacy TCP/TLS listener (port 1515);
+                                          ///< remote_enrollment is the master switch for all remote
+                                          ///< self-enrollment. Defaults to enabled.
 } authd_flags_t;
 
 typedef struct authd_config_t {

--- a/src/config/src/authd-config.c
+++ b/src/config/src/authd-config.c
@@ -101,6 +101,7 @@ int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
     static const char *xml_ssl_manager_cert = "ssl_manager_cert";
     static const char *xml_ssl_manager_key = "ssl_manager_key";
     static const char *xml_remote_enrollment = "remote_enrollment";
+    static const char *xml_legacy_enrollment = "legacy_enrollment";
     static const char *xml_agents = "agents";
 
     authd_config_t *config = (authd_config_t *)d1;
@@ -127,6 +128,7 @@ int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
     config->manager_cert = strdup(manager_cert);
     config->manager_key = strdup(manager_key);
     config->flags.remote_enrollment = 1;
+    config->flags.legacy_enrollment = 1;
     config->force_options.enabled = true;
     config->force_options.key_mismatch = true;
     config->force_options.disconnected_time_enabled = true;
@@ -217,6 +219,15 @@ int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
             }
 
             config->flags.remote_enrollment = b;
+        } else if (!strcmp(node[i]->element, xml_legacy_enrollment)) {
+            short b = eval_bool(node[i]->content);
+
+            if (b < 0) {
+                merror(XML_VALUEERR, node[i]->element, node[i]->content);
+                return OS_INVALID;
+            }
+
+            config->flags.legacy_enrollment = b;
         } else if (!strcmp(node[i]->element, xml_ciphers)) {
             if (w_authd_validate_ciphers(node[i]->content) == OS_INVALID) {
                 return OS_INVALID;

--- a/src/config/src/authd-config.c
+++ b/src/config/src/authd-config.c
@@ -110,8 +110,13 @@ int Read_Authd(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
     char manager_cert[OS_SIZE_1024];
     char manager_key[OS_SIZE_1024];
 
-    snprintf(manager_cert, OS_SIZE_1024 - 1, "etc/certs/authd.pem");
-    snprintf(manager_key, OS_SIZE_1024 - 1, "etc/certs/authd-key.pem");
+    /* Manager's unified TLS identity (see shared/include/ssl_op.h's CERTFILE/KEYFILE): authd no
+     * longer generates or owns a separate certificate, so this default now matches the one
+     * remoted_module's HTTPS server (/enroll's mTLS mode) presents. Read_Authd() is only ever
+     * called from manager binaries (wazuh-manager-authd, wazuh-manager-remoted) -- there is no
+     * agent-side caller this default would need to serve differently. */
+    snprintf(manager_cert, OS_SIZE_1024 - 1, "etc/certs/remoted.pem");
+    snprintf(manager_key, OS_SIZE_1024 - 1, "etc/certs/remoted-key.pem");
 
     // config->flags.disabled = AD_CONF_UNPARSED;
     /* If authd is defined, enable it by default */

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -77,9 +77,10 @@ DisableAuthd()
     # Unified manager certificate (see GenerateHttpsManagerCert()): authd no longer generates or
     # owns its own cert/key pair, so even in this <disabled>yes</disabled> block these point at
     # remoted's, keeping the value valid in the (rare) case an operator later flips <disabled> back
-    # to "no" by hand instead of regenerating the whole file.
-    echo "    <ssl_manager_cert>etc/certs/remoted.pem</ssl_manager_cert>" >> $NEWCONFIG
-    echo "    <ssl_manager_key>etc/certs/remoted-key.pem</ssl_manager_key>" >> $NEWCONFIG
+    # to "no" by hand instead of regenerating the whole file. Same custom-certificate override as
+    # the enabled path (see WriteAuthd's AUTH_TEMPLATE substitution above), for the same reason.
+    echo "    <ssl_manager_cert>${WAZUH_REMOTE_HTTPS_CERTIFICATE:-etc/certs/remoted.pem}</ssl_manager_cert>" >> $NEWCONFIG
+    echo "    <ssl_manager_key>${WAZUH_REMOTE_HTTPS_KEY:-etc/certs/remoted-key.pem}</ssl_manager_key>" >> $NEWCONFIG
     echo "  </auth>" >> $NEWCONFIG
     echo "" >> $NEWCONFIG
 }
@@ -756,7 +757,18 @@ WriteManager()
 
     # Writting auth configuration
     if [ "X${AUTHD}" = "Xyes" ]; then
-        sed -e "s|\${INSTALLDIR}|$INSTALLDIR|g" "${AUTH_TEMPLATE}" >> $NEWCONFIG
+        # Same custom-certificate override WriteRemote()'s <https> block already honors (see
+        # GenerateHttpsManagerCert() above): authd's <ssl_manager_cert>/<ssl_manager_key> must
+        # point at whatever file the manager's HTTPS listener actually loads, or authd fails to
+        # start (ENOENT) whenever a custom certificate is supplied -- GenerateHttpsManagerCert()
+        # correctly skips generating the default etc/certs/remoted.pem in that case, but
+        # auth.template's cert paths used to stay hardcoded to it regardless.
+        WAZUH_AUTHD_SSL_MANAGER_CERT="${WAZUH_REMOTE_HTTPS_CERTIFICATE:-etc/certs/remoted.pem}"
+        WAZUH_AUTHD_SSL_MANAGER_KEY="${WAZUH_REMOTE_HTTPS_KEY:-etc/certs/remoted-key.pem}"
+        sed -e "s|\${INSTALLDIR}|$INSTALLDIR|g" \
+            -e "s|\${WAZUH_AUTHD_SSL_MANAGER_CERT}|$WAZUH_AUTHD_SSL_MANAGER_CERT|g" \
+            -e "s|\${WAZUH_AUTHD_SSL_MANAGER_KEY}|$WAZUH_AUTHD_SSL_MANAGER_KEY|g" \
+            "${AUTH_TEMPLATE}" >> $NEWCONFIG
         echo "" >> $NEWCONFIG
     else
         DisableAuthd

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -74,8 +74,12 @@ DisableAuthd()
     echo "    <ciphers>TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256</ciphers>" >> $NEWCONFIG
     echo "    <!-- <ssl_agent_ca></ssl_agent_ca> -->" >> $NEWCONFIG
     echo "    <ssl_verify_host>no</ssl_verify_host>" >> $NEWCONFIG
-    echo "    <ssl_manager_cert>etc/certs/authd.pem</ssl_manager_cert>" >> $NEWCONFIG
-    echo "    <ssl_manager_key>etc/certs/authd-key.pem</ssl_manager_key>" >> $NEWCONFIG
+    # Unified manager certificate (see GenerateHttpsManagerCert()): authd no longer generates or
+    # owns its own cert/key pair, so even in this <disabled>yes</disabled> block these point at
+    # remoted's, keeping the value valid in the (rare) case an operator later flips <disabled> back
+    # to "no" by hand instead of regenerating the whole file.
+    echo "    <ssl_manager_cert>etc/certs/remoted.pem</ssl_manager_cert>" >> $NEWCONFIG
+    echo "    <ssl_manager_key>etc/certs/remoted-key.pem</ssl_manager_key>" >> $NEWCONFIG
     echo "  </auth>" >> $NEWCONFIG
     echo "" >> $NEWCONFIG
 }
@@ -159,49 +163,16 @@ InstallSecurityConfigurationAssessmentFiles()
 }
 
 ##########
-# GenerateAuthCert()
-##########
-GenerateAuthCert()
-{
-    if [ "X$SSL_CERT" = "Xyes" ]; then
-        # Unified certificate directory: root-owned and sticky (drwxrwx--T). The server
-        # daemons run as ${WAZUH_USER} and regenerate their own self-signed certs here
-        # (group write), while the sticky bit keeps them from replacing the root-owned
-        # indexer trust material that shares the directory.
-        ${INSTALL} -d -m 1770 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/etc/certs
-
-        # Generation auto-signed certificate if not exists
-        if [ ! -f "${INSTALLDIR}/etc/certs/authd-key.pem" ] && [ ! -f "${INSTALLDIR}/etc/certs/authd.pem" ]; then
-            if [ ! "X${USER_GENERATE_AUTHD_CERT}" = "Xn" ]; then
-                    if [ "X${INSTYPE}" = "Xagent" ]; then
-                        AUTHD_BIN="wazuh-authd"
-                    else
-                        AUTHD_BIN="wazuh-manager-authd"
-                    fi
-                    echo "Generating self-signed certificate for ${AUTHD_BIN}..."
-                    ${INSTALLDIR}/bin/${AUTHD_BIN} -C 365 -B 2048 -K ${INSTALLDIR}/etc/certs/authd-key.pem -X ${INSTALLDIR}/etc/certs/authd.pem -S "/C=US/ST=California/CN=wazuh/"
-            fi
-        fi
-
-        # Owned by ${WAZUH_USER}: authd drops privileges to that user and regenerates this
-        # cert/key at runtime, so it must own them. Re-applied unconditionally so upgrades
-        # from installs that left them root-owned also get corrected.
-        if [ -f "${INSTALLDIR}/etc/certs/authd-key.pem" ] && [ -f "${INSTALLDIR}/etc/certs/authd.pem" ]; then
-            chown ${WAZUH_USER}:${WAZUH_GROUP} ${INSTALLDIR}/etc/certs/authd-key.pem
-            chown ${WAZUH_USER}:${WAZUH_GROUP} ${INSTALLDIR}/etc/certs/authd.pem
-            chmod 640 ${INSTALLDIR}/etc/certs/authd-key.pem
-            chmod 640 ${INSTALLDIR}/etc/certs/authd.pem
-        fi
-    fi
-}
-
-##########
 # GenerateHttpsManagerCert()
 ##########
 # Self-signed certificate for the HTTPS agent server (remoted_module). Manager
 # only -- the listener doesn't exist on agents. Uses wazuh-manager-remoted's own
-# -C/-B/-K/-X/-S flags (same generate_cert() used for authd cert/key, now
-# in shared/, exposed through remoted's own binary instead of authd's).
+# -C/-B/-K/-X/-S flags (same generate_cert() used for authd's cert/key, now in
+# shared/). This is now the manager's ONLY self-signed cert/key pair: authd no
+# longer generates or owns one of its own (its <ssl_manager_cert>/<ssl_manager_key>
+# point here too -- see auth.template and DisableAuthd() above), since /enroll's
+# mTLS mode treats "this certificate validated" as the enrollment credential and
+# both listeners must therefore present the same manager identity.
 GenerateHttpsManagerCert()
 {
     if [ "X${INSTYPE}" = "Xagent" ]; then
@@ -216,6 +187,14 @@ GenerateHttpsManagerCert()
     fi
 
     if [ "X$SSL_CERT" = "Xyes" ]; then
+        # Unified certificate directory: root-owned and sticky (drwxrwx--T). The server
+        # daemons run as ${WAZUH_USER} and regenerate their own self-signed certs here
+        # (group write), while the sticky bit keeps them from replacing the root-owned
+        # indexer trust material that shares the directory. Created here (rather than in a
+        # separate authd-specific step, now removed) since this is the first cert-generating
+        # step that runs on a manager install.
+        ${INSTALL} -d -m 1770 -o root -g ${WAZUH_GROUP} ${INSTALLDIR}/etc/certs
+
         # Generation auto-signed certificate if not exists
         if [ ! -f "${INSTALLDIR}/etc/certs/remoted-key.pem" ] && [ ! -f "${INSTALLDIR}/etc/certs/remoted.pem" ]; then
             if [ ! "X${USER_GENERATE_AUTHD_CERT}" = "Xn" ]; then
@@ -225,8 +204,8 @@ GenerateHttpsManagerCert()
         fi
 
         # Owned by ${WAZUH_USER}: remoted drops to that user and regenerates these files at
-        # runtime (same reasoning as GenerateAuthCert() above for authd's cert/key). Re-applied
-        # unconditionally so upgrades from installs that left them root-owned also get corrected.
+        # runtime. Re-applied unconditionally so upgrades from installs that left them
+        # root-owned also get corrected.
         if [ -f "${INSTALLDIR}/etc/certs/remoted-key.pem" ] && [ -f "${INSTALLDIR}/etc/certs/remoted.pem" ]; then
             chown ${WAZUH_USER}:${WAZUH_GROUP} ${INSTALLDIR}/etc/certs/remoted-key.pem
             chown ${WAZUH_USER}:${WAZUH_GROUP} ${INSTALLDIR}/etc/certs/remoted.pem
@@ -1553,7 +1532,6 @@ InstallServer()
         ${INSTALL} -m 0660 -o ${WAZUH_USER} -g ${WAZUH_GROUP} ../etc/agent.conf ${INSTALLDIR}/etc/shared/agent-template.conf
     fi
 
-    GenerateAuthCert
     GenerateHttpsManagerCert
     SetIndexerCertsOwnership
 

--- a/src/os_auth/include/auth.h
+++ b/src/os_auth/include/auth.h
@@ -193,6 +193,22 @@ cJSON* local_add(const char *id,
                         authd_force_options_t *force_options);
 
 /**
+ * @brief Forwards an "add" request to the master node over the cluster (worker nodes only).
+ *        Any caller-supplied id/key/force are ignored -- the master always assigns the ID,
+ *        generates the key, and decides force-replace using its own configuration, matching
+ *        the network (port 1515) enrollment path's worker behavior.
+ * @param name Name of the agent to be registered
+ * @param ip IP of the agent to be registered
+ * @param groups Groups to which the agent belongs
+ * @param key_hash Hash of the agent key, used for the force/key-mismatch decision
+ * @return JSON object with the response
+ * */
+cJSON* local_add_clustered(const char *name,
+                           const char *ip,
+                           const char *groups,
+                           const char *key_hash);
+
+/**
  * @brief Returns a MD5 hash of some random data collected from different sources.
  *        The result must be freed by the caller.
  *

--- a/src/os_auth/src/config.c
+++ b/src/os_auth/src/config.c
@@ -53,6 +53,7 @@ cJSON *getAuthdConfig(void) {
     cJSON_AddNumberToObject(auth,"port",config.port);
     if (config.flags.disabled) cJSON_AddStringToObject(auth,"disabled","yes"); else cJSON_AddStringToObject(auth,"disabled","no");
     if (config.flags.remote_enrollment) cJSON_AddStringToObject(auth,"remote_enrollment","yes"); else cJSON_AddStringToObject(auth,"remote_enrollment","no");
+    if (config.flags.legacy_enrollment) cJSON_AddStringToObject(auth,"legacy_enrollment","yes"); else cJSON_AddStringToObject(auth,"legacy_enrollment","no");
     if (config.ipv6) cJSON_AddStringToObject(auth,"ipv6","yes"); else cJSON_AddStringToObject(auth,"ipv6","no");
     if (config.flags.use_source_ip) cJSON_AddStringToObject(auth,"use_source_ip","yes"); else cJSON_AddStringToObject(auth,"use_source_ip","no");
     if (config.flags.clear_removed) cJSON_AddStringToObject(auth,"purge","yes"); else cJSON_AddStringToObject(auth,"purge","no");

--- a/src/os_auth/src/local-server.c
+++ b/src/os_auth/src/local-server.c
@@ -31,7 +31,8 @@ typedef enum auth_local_err {
     EDUPID,
     EAGLIM,
     EINVGROUP,
-    ENOMASTER
+    ENOMASTER,
+    ENOMASTERCOMM
 } auth_local_err;
 
 
@@ -53,11 +54,15 @@ static const struct {
     { 9012, "Duplicate ID" },
     { 9013, "Maximum number of agents reached" },
     { 9014, "Invalid Group(s) Name(s)" },
-    { 9015, "Cannot execute this request on a worker node" }
+    { 9015, "Cannot execute this request on a worker node" },
+    { 9016, "Cannot communicate with master node" }
 };
 
 // Dispatch local request
 static char* local_dispatch(const char *input);
+
+// local_add_clustered() is declared in auth.h (like local_add()) since it's genuinely
+// externally linked -- see the definition below for details.
 
 // Remove an agent
 static cJSON* local_remove(const char *id, int purge);
@@ -178,11 +183,6 @@ char* local_dispatch(const char *input) {
     char *groups = NULL;
 
     if (input[0] == '{') {
-        if (config.worker_node) {
-            ierror = ENOMASTER;
-            goto fail;
-        }
-
         const char *jsonErrPtr;
         if (request = cJSON_ParseWithOpts(input, &jsonErrPtr, 0), !request) {
             ierror = EJSON;
@@ -278,12 +278,25 @@ char* local_dispatch(const char *input) {
                 }
             }
 
-            response = local_add(id, name, ip, groups, key, key_hash, force ? &force_options : &config.force_options);
+            if (config.worker_node) {
+                // The force registration settings (and any caller-supplied id/key) are
+                // ignored for workers, exactly like the network (port 1515) enrollment
+                // path -- the master always assigns the ID, generates the key, and
+                // decides force-replace using its own configuration.
+                response = local_add_clustered(name, ip, groups, key_hash);
+            } else {
+                response = local_add(id, name, ip, groups, key, key_hash, force ? &force_options : &config.force_options);
+            }
 
             os_free(groups);
         } else if (!strcmp(function->valuestring, "remove")) {
             cJSON *item;
             int purge;
+
+            if (config.worker_node) {
+                ierror = ENOMASTER;
+                goto fail;
+            }
 
             if (arguments = cJSON_GetObjectItem(request, "arguments"), !arguments) {
                 ierror = ENOARGUMENT;
@@ -300,6 +313,11 @@ char* local_dispatch(const char *input) {
             response = local_remove(item->valuestring, purge);
         } else if (!strcmp(function->valuestring, "get")) {
             cJSON *item;
+
+            if (config.worker_node) {
+                ierror = ENOMASTER;
+                goto fail;
+            }
 
             if (arguments = cJSON_GetObjectItem(request, "arguments"), !arguments) {
                 ierror = ENOARGUMENT;
@@ -462,6 +480,46 @@ fail:
     w_mutex_unlock(&mutex_keys);
     response = local_create_error_response(ERRORS[ierror].code, ERRORS[ierror].message);
     os_free(str_result);
+    return response;
+}
+
+// Forward an "add" request to the master node over the cluster (worker nodes only)
+cJSON* local_add_clustered(const char *name, const char *ip, const char *groups, const char *key_hash) {
+    char *new_id = NULL;
+    char *new_key = NULL;
+    char err_response[OS_SIZE_2048] = {0};
+    int master_error_code = 0;
+    int result;
+    cJSON *response = NULL;
+
+    mdebug2("add_clustered(%s)", name);
+    minfo("Dispatching enrollment request to master node");
+
+    result = w_request_agent_add_clustered(err_response, name, ip, groups, key_hash,
+                                            &new_id, &new_key, NULL, NULL, &master_error_code);
+
+    if (result == 0) {
+        response = local_create_agent_response(new_id, name, ip, new_key);
+    } else if (master_error_code > 0) {
+        // The master responded with a well-formed business rejection; surface its exact code
+        // so the bridge can map it precisely instead of a generic failure. err_response always
+        // carries a "ERROR: " prefix here (see w_parse_agent_add_response) -- drop it, since the
+        // numeric code already conveys the outcome.
+        const char *message = err_response;
+        if (!strncmp(message, "ERROR: ", 7)) {
+            message += 7;
+        }
+        merror("ERROR %d: %s.", master_error_code, message);
+        response = local_create_error_response(master_error_code, message);
+    } else {
+        // Transport failure, or a malformed/unparseable response from the master -- either
+        // way, the cluster forward did not produce a clean answer.
+        merror("ERROR %d: %s.", ERRORS[ENOMASTERCOMM].code, ERRORS[ENOMASTERCOMM].message);
+        response = local_create_error_response(ERRORS[ENOMASTERCOMM].code, ERRORS[ENOMASTERCOMM].message);
+    }
+
+    os_free(new_id);
+    os_free(new_key);
     return response;
 }
 

--- a/src/os_auth/src/local-server.c
+++ b/src/os_auth/src/local-server.c
@@ -16,6 +16,13 @@
 #include "os_err.h"
 #include "authd-config.h"
 
+#ifdef WAZUH_UNIT_TESTING
+// Remove STATIC qualifier from tests
+#define STATIC
+#else
+#define STATIC static
+#endif
+
 typedef enum auth_local_err {
     EINTERNAL = 0,
     EJSON,
@@ -32,7 +39,9 @@ typedef enum auth_local_err {
     EAGLIM,
     EINVGROUP,
     ENOMASTER,
-    ENOMASTERCOMM
+    ENOMASTERCOMM,
+    EINVALIDNAME // Appended, not inserted: ERRORS[] below is indexed directly by this enum's
+                 // value, so every existing entry must keep its current index.
 } auth_local_err;
 
 
@@ -55,11 +64,104 @@ static const struct {
     { 9013, "Maximum number of agents reached" },
     { 9014, "Invalid Group(s) Name(s)" },
     { 9015, "Cannot execute this request on a worker node" },
-    { 9016, "Cannot communicate with master node" }
+    { 9016, "Cannot communicate with master node" },
+    // Distinct from 9005 ("No such name", raised when the "name" argument is missing entirely):
+    // this is a NAME THAT IS PRESENT but fails OS_IsValidName()'s charset/length/leading-dot rules
+    // (e.g. contains a space). Collapsing the two under 9005 left an API/manage_agents caller
+    // seeing "No such name" for a name it very much did supply, with nothing to point at the
+    // actual problem.
+    { 9017, "Invalid agent name" }
 };
 
 // Dispatch local request
 static char* local_dispatch(const char *input);
+
+// Per-connection thread body: recv, dispatch, send, close. See run_local_server()'s comment on
+// why this now runs on its own detached thread instead of inline on the accept loop.
+static void* handle_local_client(void *arg);
+
+struct local_client_ctx {
+    int peer;
+};
+
+// Caps how many connections handle_local_client() may service CONCURRENTLY via a detached
+// thread. Without this, a burst of connections (e.g. many cluster workers enrolling against one
+// master's authd at once, or any local caller not otherwise rate-limited) would spawn one thread
+// per connection with no ceiling at all. 128 matches AUTH_LOCAL_SOCK's own listen backlog
+// (OS_BindUnixDomainWithPerms, shared/os_net/os_net.c) -- there is no benefit to servicing more
+// connections concurrently than that many could ever be queued at once to begin with.
+#define MAX_LOCAL_CLIENT_THREADS 128
+
+// How long run_local_server() waits, and how often it re-checks, for detached client threads to
+// finish once it has been told to stop. The timeout only has to cover a dispatch already in
+// progress -- the longest of which is a worker's cluster-forwarded "add" (see local_add_clustered())
+// -- not a new one, since the accept loop has already exited by then.
+#define LOCAL_CLIENT_DRAIN_TIMEOUT_MS 5000
+#define LOCAL_CLIENT_DRAIN_POLL_MS 50
+
+static int local_client_thread_count = 0;
+static pthread_mutex_t mutex_local_client_count = PTHREAD_MUTEX_INITIALIZER;
+
+// Returns 1 and reserves a slot if under the cap, 0 (no slot reserved) if at it.
+static int try_reserve_local_client_slot(void) {
+    int reserved;
+    w_mutex_lock(&mutex_local_client_count);
+    if (reserved = (local_client_thread_count < MAX_LOCAL_CLIENT_THREADS), reserved) {
+        local_client_thread_count++;
+    }
+    w_mutex_unlock(&mutex_local_client_count);
+    return reserved;
+}
+
+static void release_local_client_slot(void) {
+    w_mutex_lock(&mutex_local_client_count);
+    local_client_thread_count--;
+    w_mutex_unlock(&mutex_local_client_count);
+}
+
+// Longest storable agent name. Matches both OS_IsValidName()'s own bound and the API's
+// `agent_name` maxLength, so this adds no new limit of its own.
+#define MAX_STORABLE_AGENT_NAME_LEN 128
+
+// Rejects only names that would actually corrupt client.keys (or fail to round-trip back out of
+// it) -- deliberately NOT the stricter agent-name charset OS_IsValidName() enforces.
+//
+// This socket's established callers are manage_agents and the API, and the API's own documented
+// contract is `^[\w\-.%]+$` with no minimum length (api/api/validator.py). Names it has always
+// accepted -- containing '%', a single character, or a leading '.' -- are all rejected by
+// OS_IsValidName() yet cannot corrupt anything, so enforcing that charset here would break
+// working POST /agents calls for no storage-safety gain at all.
+//
+// What genuinely must be refused is what the client.keys line format cannot represent:
+//   - whitespace and control bytes: the record is whitespace-delimited, so a space or tab splits
+//     the name into extra fields and shifts every later column (remoted's keystore reader, which
+//     does `tokens >> id >> name >> ip >> key`, would then take the name's tail as the IP and the
+//     IP as the key, leaving the agent with an undecodable key and a 401 on every request it ever
+//     makes); '\n' or '\r' ends the record outright.
+//   - a leading '#' or '!': both OS_ReadKeys() and remoted's keystore treat that as the
+//     removed/disabled-entry marker and skip the line, silently dropping the agent.
+//
+// The two ENROLLMENT paths -- port 1515 in auth.c, and POST /enroll in enrollmentEndpoint.cpp --
+// additionally apply OS_IsValidName() to the names they mint, where there is no back-compatibility
+// obligation and agreeing with each other matters more than being permissive.
+STATIC int is_storable_agent_name(const char *name) {
+    if (!name || !*name || strlen(name) > MAX_STORABLE_AGENT_NAME_LEN) {
+        return 0;
+    }
+
+    if (name[0] == '#' || name[0] == '!') {
+        return 0;
+    }
+
+    for (const char *c = name; *c; c++) {
+        // Covers every control byte (0x00-0x1F) and the space itself in one comparison, plus DEL.
+        if ((unsigned char)*c <= ' ' || (unsigned char)*c == 0x7F) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
 
 // local_add_clustered() is declared in auth.h (like local_add()) since it's genuinely
 // externally linked -- see the definition below for details.
@@ -79,13 +181,98 @@ static cJSON* local_create_agent_delete_response(void);
 // Generates an error json response
 static cJSON* local_create_error_response(int code, const char *message);
 
+// Services one already-accepted local-socket connection: set its recv timeout, read one request,
+// dispatch it, send the reply, close. Shared by both the threaded and the at-the-cap synchronous
+// fallback path below (see run_local_server()) -- the logic is identical either way, only WHERE it
+// runs (a detached thread vs inline on the accept loop) differs.
+static void service_local_client(int peer) {
+    char *buffer = NULL;
+    char *response;
+    ssize_t length;
+
+    if (config.timeout_sec || config.timeout_usec) {
+        if (OS_SetRecvTimeout(peer, config.timeout_sec, config.timeout_usec) < 0) {
+            // Log-once latch. Guarded now that this function also runs on concurrent client
+            // threads: an unsynchronized static read-modify-write is a data race even when the
+            // worst visible outcome is a duplicated line.
+            static int reported = 0;
+            static pthread_mutex_t mutex_reported = PTHREAD_MUTEX_INITIALIZER;
+            int error = errno;
+            int should_report = 0;
+
+            w_mutex_lock(&mutex_reported);
+            if (!reported) {
+                reported = 1;
+                should_report = 1;
+            }
+            w_mutex_unlock(&mutex_reported);
+
+            if (should_report) {
+                merror("Could not set timeout to internal socket: %s (%d)", strerror(error), error);
+            }
+        }
+    }
+
+    os_calloc(OS_MAXSTR, sizeof(char), buffer);
+    switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
+    case OS_SOCKTERR:
+        merror("OS_RecvSecureTCP(): response size is bigger than expected");
+        break;
+
+    case -1:
+        merror("OS_RecvSecureTCP(): %s", strerror(errno));
+        break;
+
+    case 0:
+        mdebug2("Empty message from local client.");
+        break;
+
+    case OS_MAXLEN:
+        merror("Received message > %i", MAX_DYN_STR);
+        break;
+
+    default:
+        if (response = local_dispatch(buffer), response) {
+            OS_SendSecureTCP(peer, strlen(response), response);
+            free(response);
+        }
+    }
+
+    // Closed exactly once, here, on every arm. The "empty message" and OS_MAXLEN arms used to
+    // close it themselves and then fall through to this close as well: harmless while dispatch ran
+    // inline on the accept loop, but a genuine hazard now that each connection is serviced on its
+    // own thread -- between the two closes another thread can be handed the same descriptor number
+    // by accept()/open(), and the second close would silently destroy ITS connection (a truncated
+    // client.keys write from the writer thread, or a dropped cluster/wdb socket, with nothing
+    // logged). The empty-message arm is not a rare path either: OS_RecvSecureTCP() returns 0
+    // whenever the peer closes before the length header arrives, which is exactly what remoted's
+    // /enroll bridge does every time one of its own connect/response timeouts fires.
+    close(peer);
+    free(buffer);
+}
+
+// Runs on its own detached thread (see run_local_server()) so a single slow dispatch -- most
+// notably a worker's cluster-forwarded "add", which can legitimately take several seconds, see
+// local_add_clustered() -- never blocks any OTHER local-socket caller (manage_agents, the API, or
+// another concurrently queued /enroll request) behind it. Safe to run concurrently:
+// local_add()/local_remove()/local_get() already serialize access to the shared `keys` keystore
+// (and write_pending/cond_pending) through mutex_keys. Releases the slot try_reserve_local_client_slot()
+// reserved for it, so run_local_server() can admit another thread once this one finishes.
+static void* handle_local_client(void *arg) {
+    struct local_client_ctx *ctx = (struct local_client_ctx *)arg;
+    int peer = ctx->peer;
+    os_free(ctx);
+
+    authd_sigblock();
+    service_local_client(peer);
+    release_local_client_slot();
+    return NULL;
+}
+
 // Thread for internal server
 void* run_local_server(__attribute__((unused)) void *arg) {
     int sock;
     int peer;
-    char *buffer = NULL;
-    char *response;
-    ssize_t length;
     fd_set fdset;
     struct timeval timeout;
 
@@ -123,48 +310,63 @@ void* run_local_server(__attribute__((unused)) void *arg) {
             continue;
         }
 
-        if (config.timeout_sec || config.timeout_usec) {
-            if (OS_SetRecvTimeout(peer, config.timeout_sec, config.timeout_usec) < 0) {
-                static int reported = 0;
-
-                if (!reported) {
-                    int error = errno;
-                    merror("Could not set timeout to internal socket: %s (%d)", strerror(error), error);
-                    reported = 1;
-                }
-            }
+        if (!try_reserve_local_client_slot()) {
+            // At MAX_LOCAL_CLIENT_THREADS already-in-flight connections: fall back to the
+            // original synchronous behavior for this ONE connection (service it right here,
+            // inline, before accepting the next) instead of either spawning past the cap or
+            // dropping this client outright. Self-limiting by construction, exactly like the
+            // pre-existing behavior this whole function used to have unconditionally.
+            service_local_client(peer);
+            continue;
         }
 
-        os_calloc(OS_MAXSTR, sizeof(char), buffer);
-        switch (length = OS_RecvSecureTCP(peer, buffer,OS_MAXSTR), length) {
-        case OS_SOCKTERR:
-            merror("OS_RecvSecureTCP(): response size is bigger than expected");
-            break;
+        struct local_client_ctx *ctx;
+        os_malloc(sizeof(struct local_client_ctx), ctx);
+        ctx->peer = peer;
 
-        case -1:
-            merror("OS_RecvSecureTCP(): %s", strerror(errno));
-            break;
-
-        case 0:
-            mdebug2("Empty message from local client.");
+        pthread_t tid;
+        if (pthread_create(&tid, NULL, handle_local_client, ctx) != 0) {
+            merror("at run_local_server(): could not create a client thread: %s", strerror(errno));
+            release_local_client_slot();
             close(peer);
-            break;
-
-        case OS_MAXLEN:
-            merror("Received message > %i", MAX_DYN_STR);
-            close(peer);
-            break;
-
-        default:
-            if (response = local_dispatch(buffer), response) {
-                OS_SendSecureTCP(peer, strlen(response), response);
-                free(response);
-            }
+            os_free(ctx);
+            continue;
         }
-
-        close(peer);
-        free(buffer);
+        pthread_detach(tid);
     }
+
+    // Drain in-flight client threads before returning. They are DETACHED, so nobody ever joins
+    // them, and main-server.c joins only this accept thread -- returning while one is still inside
+    // local_add() would let process teardown (atexit cleanup, then exit()) run concurrently with an
+    // OS_WriteKeys(), which is how client.keys ends up truncated on a restart. Bounded rather than
+    // unconditional: a client that connected and never sent holds its thread for as long as its
+    // recv timeout allows (and indefinitely if auth.timeout_seconds is set to 0), and a stuck
+    // client must not be able to block shutdown forever -- wazuh-control would escalate to SIGKILL
+    // anyway, which is strictly worse than proceeding deliberately.
+    for (int waited_ms = 0; waited_ms < LOCAL_CLIENT_DRAIN_TIMEOUT_MS; waited_ms += LOCAL_CLIENT_DRAIN_POLL_MS) {
+        int in_flight;
+
+        w_mutex_lock(&mutex_local_client_count);
+        in_flight = local_client_thread_count;
+        w_mutex_unlock(&mutex_local_client_count);
+
+        if (in_flight == 0) {
+            break;
+        }
+
+        if (waited_ms == 0) {
+            mdebug1("Waiting for %d in-flight local client thread(s) to finish.", in_flight);
+        }
+
+        usleep(LOCAL_CLIENT_DRAIN_POLL_MS * 1000);
+    }
+
+    w_mutex_lock(&mutex_local_client_count);
+    if (local_client_thread_count > 0) {
+        mwarn("%d local client thread(s) still in flight after %d ms; proceeding with shutdown.",
+              local_client_thread_count, LOCAL_CLIENT_DRAIN_TIMEOUT_MS);
+    }
+    w_mutex_unlock(&mutex_local_client_count);
 
     mdebug1("Local server thread finished");
 
@@ -217,6 +419,22 @@ char* local_dispatch(const char *input) {
                 goto fail;
             }
             name = item->valuestring;
+
+            // This local socket historically trusted every caller to have already validated the
+            // name -- true enough for manage_agents/the API, but not for /enroll, which bridges an
+            // arbitrary remote agent-supplied string straight here. An unstorable name silently
+            // corrupts client.keys once written, so it has to be refused before
+            // local_add()/local_add_clustered() ever runs, for every caller alike. See
+            // is_storable_agent_name() for why this is the storage-safety invariant and not
+            // OS_IsValidName()'s stricter charset (which would reject names the API has always
+            // accepted). EINVALIDNAME (9017), not ENONAME (9005, "No such name" -- for the
+            // argument being absent, checked just above): a caller that DID supply a name, just
+            // not a storable one, needs a message that says so rather than one reading as if it
+            // forgot the field entirely.
+            if (!is_storable_agent_name(name)) {
+                ierror = EINVALIDNAME;
+                goto fail;
+            }
 
             if (item = cJSON_GetObjectItem(arguments, "ip"), !item) {
                 ierror = ENOIP;
@@ -279,10 +497,24 @@ char* local_dispatch(const char *input) {
             }
 
             if (config.worker_node) {
-                // The force registration settings (and any caller-supplied id/key) are
-                // ignored for workers, exactly like the network (port 1515) enrollment
-                // path -- the master always assigns the ID, generates the key, and
-                // decides force-replace using its own configuration.
+                if (id || key) {
+                    // A caller-supplied id and/or key means this is an admin/restore-style add
+                    // (manage_agents/the API can send both; self-enrollment -- /enroll included --
+                    // never does), not the self-enrollment shape local_add_clustered() forwards.
+                    // There is no cluster RPC to honor a caller-chosen id/key on a worker, and
+                    // silently ignoring them (as local_add_clustered() itself does -- it has no
+                    // id/key parameters at all) would return 200 with a DIFFERENT id/key than the
+                    // one requested: a caller restoring or importing a specific agent would believe
+                    // it succeeded as asked while a different agent record was actually created.
+                    // Reject with the same code this request got before cluster forwarding was
+                    // added for "add", rather than complete it with the wrong identity.
+                    ierror = ENOMASTER;
+                    goto fail;
+                }
+                // No id/key: a genuine self-enrollment-shaped request (the only shape /enroll ever
+                // sends). The force registration settings are ignored for workers too, exactly like
+                // the network (port 1515) enrollment path -- the master always assigns the ID,
+                // generates the key, and decides force-replace using its own configuration.
                 response = local_add_clustered(name, ip, groups, key_hash);
             } else {
                 response = local_add(id, name, ip, groups, key, key_hash, force ? &force_options : &config.force_options);

--- a/src/os_auth/src/main-server.c
+++ b/src/os_auth/src/main-server.c
@@ -546,6 +546,42 @@ int main(int argc, char **argv)
     }
     fclose(fp);
 
+    /* Enrollment password: loaded here -- and, on a master, GENERATED here if absent -- whenever
+     * shared-password enrollment is enabled, deliberately OUTSIDE the <legacy_enrollment> gate
+     * below. etc/authd.pass is a manager-wide enrollment credential, not a property of the legacy
+     * port-1515 listener: remoted's POST /enroll bridge reads the file directly (see
+     * PasswordKeySource in remoted_module). w_authd_load_password() is the only thing anywhere in
+     * the product that creates it -- no installer, package or framework step writes it -- so
+     * gating this on legacy_enrollment would leave an HTTPS-only manager (<legacy_enrollment>no,
+     * the very configuration that flag exists to enable) with a password file nothing ever
+     * creates, and every Password-mode /enroll request failing 401 permanently, cluster-wide.
+     * Gated on remote_enrollment alone: with that off, both enrollment paths are closed and no
+     * password is needed by either. */
+    if (config.flags.remote_enrollment && config.flags.use_password) {
+        if (config.worker_node) {
+            /* Owned by the master and synced to workers; never generated here.
+             * If not synced yet, picked up later in process_message. */
+            authpass = w_authd_read_password(AUTHD_PASS);
+
+            if (authpass) {
+                authpass_mtime = File_DateofChange(AUTHD_PASS);
+                minfo("Using the enrollment password synchronized from the master node.");
+            } else {
+                minfo("Shared-password enrollment is enabled but '%s' has not been synchronized from the master node yet. Enrollment requests will be rejected until it is available.", AUTHD_PASS);
+            }
+        } else {
+            bool pass_generated = false;
+
+            authpass = w_authd_load_password(AUTHD_PASS, &pass_generated);
+
+            if (pass_generated) {
+                minfo("A new enrollment password was generated and written to '%s'", AUTHD_PASS);
+            } else {
+                minfo("Using the existing enrollment password from '%s'. To rotate the password, delete the file and restart.", AUTHD_PASS);
+            }
+        }
+    }
+
     if (config.flags.remote_enrollment && config.flags.legacy_enrollment) {
         g_epfd = epoll_create1(0);
 
@@ -597,30 +633,11 @@ int main(int argc, char **argv)
             exit(1);
         }
 
-        /* Check if password is enabled */
+        /* The password itself was already loaded/generated above, before this block: it serves
+         * POST /enroll too, so it must not depend on this listener existing. Only the
+         * listener-specific announcement belongs here. */
         if (config.flags.use_password) {
-            if (config.worker_node) {
-                /* Owned by the master and synced to workers; never generated here.
-                 * If not synced yet, picked up later in process_message. */
-                authpass = w_authd_read_password(AUTHD_PASS);
-
-                if (authpass) {
-                    authpass_mtime = File_DateofChange(AUTHD_PASS);
-                    minfo("Accepting connections on port %hu. Using password synchronized from the master node.", config.port);
-                } else {
-                    minfo("Shared-password enrollment is enabled but '%s' has not been synchronized from the master node yet. Enrollment requests will be rejected until it is available.", AUTHD_PASS);
-                }
-            } else {
-                bool pass_generated = false;
-
-                authpass = w_authd_load_password(AUTHD_PASS, &pass_generated);
-
-                if (pass_generated) {
-                    minfo("Accepting connections on port %hu. A new authentication password was generated and written to '%s'", config.port, AUTHD_PASS);
-                } else {
-                    minfo("Accepting connections on port %hu. Using existing authentication password from '%s'. To rotate the password, delete the file and restart.", config.port, AUTHD_PASS);
-                }
-            }
+            minfo("Accepting connections on port %hu. Shared-password enrollment is required.", config.port);
         } else {
             mdebug1("Accepting connections on port %hu. No password required.", config.port);
         }

--- a/src/os_auth/src/main-server.c
+++ b/src/os_auth/src/main-server.c
@@ -546,7 +546,7 @@ int main(int argc, char **argv)
     }
     fclose(fp);
 
-    if (config.flags.remote_enrollment) {
+    if (config.flags.remote_enrollment && config.flags.legacy_enrollment) {
         g_epfd = epoll_create1(0);
 
         if (g_epfd < 0) {
@@ -662,7 +662,7 @@ int main(int argc, char **argv)
         return EXIT_FAILURE;
     }
 
-    if (config.flags.remote_enrollment) {
+    if (config.flags.remote_enrollment && config.flags.legacy_enrollment) {
 
         if (status = pthread_create(&thread_remote_server, NULL, (void *)&run_remote_server, NULL), status != 0) {
             merror("Couldn't create thread: %s", strerror(status));
@@ -689,7 +689,7 @@ int main(int argc, char **argv)
 
     /* Join threads */
     pthread_join(thread_local_server, NULL);
-    if (config.flags.remote_enrollment) {
+    if (config.flags.remote_enrollment && config.flags.legacy_enrollment) {
         pthread_join(thread_remote_server, NULL);
     }
     if (!config.worker_node) {
@@ -797,7 +797,7 @@ static void process_message(struct client *client) {
         if (config.worker_node) {
             minfo("Dispatching request to master node");
             // The force registration settings are ignored for workers. The master decides.
-            if (0 == w_request_agent_add_clustered(response, client->agentname, client->ip, client->centralized_group, key_hash, &client->new_id, &new_key, NULL, NULL)) {
+            if (0 == w_request_agent_add_clustered(response, client->agentname, client->ip, client->centralized_group, key_hash, &client->new_id, &new_key, NULL, NULL, NULL)) {
                 client->enrollment_ok = TRUE;
             }
         }

--- a/src/remoted/remoted_module/README.md
+++ b/src/remoted/remoted_module/README.md
@@ -21,6 +21,7 @@ remoted_module/
 │   ├── remotedModule.cpp           # extern "C" shims + facade delegation + log sink definition
 │   ├── remotedModuleFacade.hpp     # worker thread + lifecycle; owns the HTTP server + auth + endpoints
 │   ├── auth/                       # ns remoted::auth — framework-agnostic AES-CMAC auth (see below)
+│   │   └── passwordKeySource.hpp/.cpp  # etc/authd.pass -> HKDF-CMAC key, see Agent enrollment below
 │   ├── common/                     # ns remoted::common — leaf utilities with no layer of their own:
 │   │                               #   logThrottle.hpp (rate-limited logging), zstdDecoder.hpp/.cpp,
 │   │                               #   vdClient.hpp/.cpp (cached VD feed-offset UDS client, see below)
@@ -31,6 +32,7 @@ remoted_module/
 │   │   └── scanVdEndpoint.hpp/.cpp     # POST /scan/vd JSON dispatch (see below)
 │   ├── control/                    # ns remoted::control — 5.x agent control messages (/control)
 │   ├── scanvd/                     # ns remoted::scanvd — on-demand VD re-scan passthrough (/scan/vd, see below)
+│   ├── enrollment/                 # ns remoted::enrollment — POST /enroll, bridges to authd (see below)
 │   └── downstream/                 # ns remoted::downstream — async UDS forwarding + limiter (see below)
 ├── test/unit/                      # GoogleTest tests (C-ABI black-box + HTTP server + auth + gateway)
 └── tools/
@@ -44,7 +46,8 @@ remoted_module/
 
 Each internal concern is a folder under `src/` (namespaced, PRIVATE, reachable by prefix —
 `"auth/...`", `"decoding/...`", `"http_server/...`", `"endpoints/...`", `"control/...`",
-`"downstream/...`" — since `src/` is on the include path). New endpoints get their own folder under `src/endpoints/<name>/`.
+`"downstream/...`", and `"enrollment/...`" — since `src/` is on the include path). New
+endpoints get their own folder under `src/endpoints/<name>/`.
 
 ## HTTP(S) server sub-layer (`src/http_server/`)
 
@@ -406,8 +409,9 @@ agent includes host metadata in the notify request; lightweight keepalives (`upd
 sent otherwise. Both respect the `keepaliveThrottleSec` window (default 60s), except the first
 host-carrying notify (`hostPersisted` in `AgentEntry`), which always triggers a full update.
 
-Version comparison uses a local `compareVersions()` function for semantic versioning (e.g., `"v5.0.0"`
-vs `"v4.9.2"`), stripping leading `v`/`V` and ignoring everything after `-` or `+`.
+Version comparison uses `compareVersions()` (`control/controlTypes.hpp`, shared with `/enroll` -- see
+below) for semantic versioning (e.g., `"v5.0.0"` vs `"v4.9.2"`), stripping leading `v`/`V` and
+ignoring everything after `-` or `+`.
 
 #### AgentRegistry (`agentRegistry.hpp/.cpp`)
 
@@ -664,6 +668,374 @@ outcome per agent).
 `ScanVdHandlerImpl` shares its `VdClient` instance with `ControlHandler` (constructed once in
 `RemotedModuleFacade::start()` and passed to both), so the two endpoints never see different
 offsets due to independent cache state. It owns no threads and no queue — teardown is trivial.
+
+## Agent enrollment (`POST /enroll`) — `src/enrollment/`
+
+Every other authenticated route on this server requires the caller to already be a known agent with
+an entry in `etc/client.keys` — there is no such entry for an agent that has never enrolled. Today
+that agent falls back to a second protocol on a second port: legacy `wazuh-authd` on 1515, speaking
+the plaintext-inside-TLS `OSSEC A:'...'`/`OSSEC K:'...'` line format. `/enroll` lets it enroll over
+the same HTTPS channel (1517) it uses for everything else afterward.
+
+This is a **bridge, not a rewrite**: authd keeps owning every piece of enrollment business logic —
+name/IP/group validation, key generation, agent-ID assignment, force-replace decisions, `client.keys`
+and `wazuh-db` persistence, cluster forwarding. `enrollmentEndpoint` only authenticates the request,
+validates the handful of things authd's *local* interface doesn't check for it (see below), and
+relays the request to authd over its existing local Unix-domain socket — the same one `manage_agents`
+and the framework already use. Port 1515 is untouched and keeps working exactly as it does today, for
+legacy 4.x agents that never speak HTTPS. **`/enroll` is the intended long-term enrollment path**;
+1515 stays alive only for that backward-compatibility window, not as a permanent second design.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Ag as New agent (no client.keys entry)
+    participant EP as POST /enroll<br/>(enrollmentEndpoint)
+    participant EA as EnrollmentAuthenticator
+    participant PK as PasswordKeySource<br/>(etc/authd.pass)
+    participant AC as AuthdClient
+    participant AD as authd<br/>(queue/sockets/auth UDS)
+
+    Ag->>EP: POST /enroll {"name":...,"version":...,"groups":...}
+    Note over EP: enrollment_enabled? -- 403 immediately if not, before auth/bridge
+    Note over EP: If the listener requires a client cert, TLS already rejected the<br/>connection before this request could ever arrive here
+    EP->>EA: authenticate(authorizationHeader, method, target, body, now)
+    alt requirePassword
+        EA->>PK: currentKey()
+        PK-->>EA: HKDF-derived AES key (or nullopt)
+        Note over EA: recompute CMAC over WAZUH-ENROLL canonical string
+    else not requirePassword
+        Note over EA: always-pass -- nothing left for THIS class to check
+    end
+    EA-->>EP: ok / AuthError
+    Note over EP: parse JSON, validate name/version/groups/ip
+    EP->>AC: addAgent({name, ip, groups, key_hash})
+    AC->>AD: {"function":"add","arguments":{...}} (SizeHeaderProtocol)
+    AD-->>AC: {"error":0,"data":{id,name,ip,key}} or {"error":90xx,...}
+    AC-->>EP: AuthdResult
+    EP-->>Ag: 200 {id,name,ip,key} / mapped 4xx/5xx
+```
+
+### Two independent authentication gates
+
+Unlike every other route, `/enroll` cannot be gated by `AuthGateway`'s `client.keys` lookup — the
+caller has no key yet. Two checks apply instead, decided once at facade startup from how the HTTPS
+listener and authd are each configured — never per request — and, critically, **independently of
+each other**:
+
+- **Client certificate** — purely a property of the HTTPS listener's `ClientVerificationMode`
+  (`Certificate` or `Full`). When set, the TLS handshake validates the agent's client certificate
+  against `root-ca.pem` **before the request ever reaches a handler** — `EnrollmentAuthenticator`
+  is never even consulted for this; it has no notion of a client certificate at all. Mirrors
+  authd's own `agent_ca`/`ssl_verify_host` mode.
+- **Password (`EnrollmentAuthConfig::requirePassword`)** — set whenever authd's `use_password`
+  flag is on, regardless of whether the listener also requires a client certificate. When set, the
+  request must carry `Authorization: WazuhEnroll <unix-ts>:<mac>`
+  (`<mac>` = 32 lowercase hex chars, AES-256-CMAC = 16 bytes), verified against the canonical string:
+
+  ```
+  "WAZUH-ENROLL\n" + "1" + "\n" + METHOD + "\n" + requestTarget + "\n" + timestamp + "\n" + <raw wire body bytes>
+  ```
+
+  Deliberately shaped like the existing `Wazuh <agent-id>:<ts>:<mac>` scheme used everywhere else in
+  this module — same freshness windows (300 s max age, 30 s max future skew), same incremental-CMAC
+  construction over the *wire* bytes, same `AuthError` taxonomy — minus the `agent-id` segment, since
+  an enrolling agent doesn't have one. A distinct scheme name (`WazuhEnroll` vs `Wazuh`) means the two
+  can never be confused by a parser.
+
+  The signing key is not the password itself: `PasswordKeySource` derives a 32-byte AES key from it
+  via **HKDF-SHA256** (empty salt, `info = "WAZUH-ENROLL-CMAC-KEY\x01"`), because `Cmac` needs an
+  exact 16/24/32-byte key and a password is arbitrary length. HKDF is deterministic and salt-free on
+  purpose, so a future agent-side implementation can reproduce it in a handful of OpenSSL calls; the
+  version byte in `info` reserves room to change the construction later without ambiguity. A memory-
+  hard KDF would add nothing here — the derived key is never persisted, so the offline-guessing
+  surface already matches authd's own plaintext-password-over-TLS on 1515.
+
+  **Worked, verified example** (a real computed vector, not just an illustrative shape — useful as a
+  cross-implementation known-answer test for the agent team):
+  - Password: `MyEnrollmentSecret123`
+  - Canonical string:
+    ```
+    WAZUH-ENROLL
+    1
+    POST
+    /enroll
+    1739999999
+    {"name":"web-server-01","version":"5.0.0","groups":"default,web-servers","ip":"10.0.0.15"}
+    ```
+  - HKDF-SHA256 derived key: `2ea29504f294bce5039bdb4fb78747dec59866204dc2588dc59f3b8cd5875a9e`
+  - AES-256-CBC-CMAC of the canonical string: `dc07d78fc156a1944f4fb02b91da7d01`
+  - Resulting header: `Authorization: WazuhEnroll 1739999999:dc07d78fc156a1944f4fb02b91da7d01`
+
+  (This vector is confirmed by three independent implementations: `PasswordKeySource`'s actual
+  C++/OpenSSL `EVP_KDF` code — see `passwordKeySource_test.cpp`'s
+  `HkdfMatchesTheVerifiedKnownAnswerVector` — Python's stdlib `hashlib`/`hmac` computing RFC 5869
+  HKDF-SHA256 from scratch, and the Python `cryptography` library's AES-CMAC. An earlier version of
+  this vector, computed via the `openssl kdf` CLI tool, did not match and has been corrected.)
+
+  There is no per-request nonce: a captured request could in principle be replayed inside its 300 s
+  window, bounded in practice by authd's own duplicate-name/IP rejection (unless force-replace is
+  configured to permit it). Accepted for v1 — the same threat model the existing agent CMAC scheme
+  already carries, with TLS protecting the transport — not something a nonce cache closes now.
+
+When `requirePassword` is false — whether because the listener requires a client certificate
+instead, or requires nothing at all — `EnrollmentAuthenticator` runs an always-pass check with no
+header required. This is not a new exposure: it reproduces authd's own behavior today, where a
+NULL password makes `w_auth_parse_data` skip the `PASS:` check entirely.
+
+**Both gates apply simultaneously when both are configured**, exactly as legacy authd already
+behaves: authd's own `check_x509_cert()` (at the TLS handshake) and its `use_password` check (while
+parsing the enrollment message, `main-server.c:601`/`:886`) are two independent checks on the same
+connection today, not a mutually-exclusive choice. `EnrollmentAuthConfig` models this the same way
+— `requirePassword` says nothing about client certificates, and the listener's
+`ClientVerificationMode` says nothing about passwords — so an operator who wants both enforced
+together (defense in depth for the endpoint that mints new agent identities and keys) simply
+configures both, and gets both. See `enrollmentMtlsE2E_test.cpp` for the combined case exercised
+end-to-end over a real TLS listener.
+
+A missing or unreadable `etc/authd.pass` while `requirePassword` is true fails **closed** — every
+enrollment attempt gets `401`, never silently falls back to skipping the password check. This
+mirrors authd itself: `etc/authd.pass` is one of the files the cluster's own integrity sync already
+replicates from master to every worker (`framework/wazuh/core/cluster/cluster.json`, alongside
+`client.keys`), and authd treats "password required but not yet synced" as a hard rejection, never
+as a fallback to the NULL-password path (`main-server.c:777-790`) — conflating the two would let an
+unsynced worker accept anyone. `PasswordKeySource` is **strictly read-only** on every node, master
+or worker alike: only authd's master ever generates the password file (`w_authd_load_password`); a
+worker only reads it, exactly as authd's own `run_authpass_watcher` does.
+
+### Components
+
+#### `PasswordKeySource` (`auth/passwordKeySource.hpp/.cpp`)
+
+Turns the authd password file into a CMAC-usable key, hot-reloaded without a restart. Mirrors
+`Keystore`'s watcher exactly (inotify + a poll fallback + content-hash change detection, so a rewrite
+landing mid-read can never be adopted torn) — the two files have the same operational shape, an
+operator-managed secret a running process must notice without a bounce. Parsing must byte-match
+authd's own `read_password_line()`: first line only, trailing `\r`/`\n` stripped, length `<= 2` or
+all-whitespace rejected, a 4096-byte cap — otherwise the manager's two enrollment paths could disagree
+about which password is valid. Derivation runs once per file change and is cached — never per
+request.
+
+#### `EnrollmentAuthenticator` (`enrollment/enrollmentAuthenticator.hpp/.cpp`)
+
+Implements the Password gate above, and nothing about client certificates at all — that's the TLS
+listener's exclusive concern, checked before any handler runs, which is exactly why this class'
+only configuration knob is `requirePassword` rather than a "mode" spanning both. Reuses `Cmac`, the
+timestamp/hex parsing, and the `AuthError` taxonomy from `auth/authTypes.hpp`, so a bad signature, a
+stale or future timestamp, and an oversized body all collapse through the same `publicErrorFor()` →
+`401`/`413` path every other route already uses. Because `AuthGateway` bakes the `client.keys`
+`Keystore` into its middleware with no per-route key-source hook, `/enroll` does **not** go through
+`AuthGateway` at all — it registers directly on `IHttpServer::addRoute` (the same pattern the
+unauthenticated `GET /` liveness probe already uses) and drives this authenticator itself, with
+`countAgainstBudget=true` since, unlike the liveness probe, an enrollment request carries a real
+body and does real work.
+
+**No credential re-validation happens on authd's side, by design.** authd's local socket has never
+validated passwords or certificates for any caller, including today's `manage_agents`/API caller — it
+has always been "trust the caller, validate only business rules." Credential checking lives
+exclusively at each front door (1515's TLS+`PASS:` line, or here). authd structurally *can't*
+re-check either credential even if it wanted to: the plaintext password never leaves remoted, and no
+TLS session reaches the local socket. remoted and authd already run as the same OS service account
+(`Privsep_SetUser()` against the shared default `USER "wazuh"`), so the bridge crosses no new
+privilege boundary — it joins the same trust domain `manage_agents` already sits in.
+
+#### `AuthdClient` (`enrollment/authdClient.hpp/.cpp`)
+
+The bridge to authd's local socket `queue/sockets/auth`, built the way `control/taskClient.cpp` and
+`control/wazuhDBClient.cpp` already talk to their own UDS peers — `shared_modules/utils`'s
+`Socket<OSPrimitives, SizeHeaderProtocol>` (a 4-byte little-endian length prefix, the exact framing
+`OS_SendSecureTCP`/`OS_RecvSecureTCP` use). The one way it differs from those two clients: authd
+closes the connection after **every** reply, so `AuthdClient` connects, sends one frame, awaits one
+frame, and closes — per request — rather than keeping a persistent, reconnect-on-error connection.
+
+Wire request: `{"function":"add","arguments":{"name":...,"ip":...,"groups":...,"key_hash":...}}`.
+**`force`, `id`, and `key` are never sent** — self-enrollment always gets an auto-assigned ID and an
+authd-generated key, never a caller-supplied one; `force` stays a manager-config decision, exactly as
+authd's local path already falls back to `config.force_options` from `ossec.conf` when it's absent.
+This matches 1515's own agent-facing protocol exactly, not a new restriction: `w_auth_parse_data`
+(`os_auth/src/auth.c`) recognizes only `PASS:`, `A:` (name), `V:` (version), `G:` (groups), `IP:`, and
+`K:` — a **key hash**, feeding only the force/key-mismatch decision, never a raw key. There is no
+`ID:` token and no raw-key token in that parser either, and no wire field for `force` at all. This
+module's optional `key_hash` field is the direct equivalent of 1515's `K:` token.
+
+**Response timeout is worker-aware.** authd's own worker→master forward can legitimately take several
+seconds on a flaky cluster link: `w_request_agent_add_clustered` → `w_send_clustered_message` retries
+up to `CLUSTER_SEND_MESSAGE_ATTEMPTS = 10` times with a 1 s sleep between failures
+(`shared/src/agent_op.c`). If `AuthdClient`'s response timeout were shorter than that, a worker-node
+enrollment authd is legitimately still retrying would be cut off early as a spurious `503`. It reads
+the same `isWorkerNode` flag already plumbed into `ControlConfig` and uses a longer default (~15 s,
+covering the worst-case retry budget) on workers versus a short default (~5 s, matching
+`WazuhDBClient`/`TaskClient`, since there's no cluster hop on the master).
+
+#### `enrollmentEndpoint` (`enrollment/enrollmentEndpoint.hpp/.cpp`)
+
+The HTTP registration and glue: checks `enrollment_enabled` first (see *Enrollment scoping* below),
+runs the authenticator, parses the JSON body, validates fields authd's local interface does not (see
+below), resolves the agent's IP, calls `AuthdClient::addAgent`, and maps the result to an HTTP
+response.
+
+**Request** — `POST /enroll`, `application/json`:
+
+| field | required | notes |
+|---|---|---|
+| `name` | yes | non-empty, ≤128 chars, restricted charset checked here; authd re-validates independently |
+| `version` | yes | authd's local `add` path has no version check at all, so remoted enforces `allow_higher_versions` itself, reusing `compareVersions()` (`control/controlTypes.hpp`) rather than duplicating it |
+| `groups` | no | comma-separated string, passed through unchanged — matches authd's own wire format and `w_auth_validate_groups` with zero transformation |
+| `ip` | no | syntactic IPv4/IPv6/CIDR check; see IP resolution below |
+| `key_hash` | no | opaque passthrough that drives authd's own force/key-mismatch decision |
+
+**IP resolution** mirrors authd's `use_source_ip` flag: if it's set, the connection's observed peer
+address wins over anything the body claims — read from `HttpRequest::remoteIp`
+(`http_server/IHttpServer.hpp`), which already exists (populated from RESTinio's
+`remote_endpoint().address()`) and is already unused by any handler today; otherwise the body's `ip`
+is used if present; if neither applies, `"any"` is sent, matching authd's own literal handling of
+that value.
+
+**Success — `200`**: `{"id":"...","name":"...","ip":"...","key":"..."}`, verbatim from authd's `data`.
+**Failure**: `{"error":{"code":<authd-code-or-0-or--1>,"message":"..."}}`.
+
+| authd code | meaning | HTTP |
+|---|---|---|
+| 9001 / 9002 / 9009 | internal / JSON-parse / key-generation failure | 500 |
+| 9003 / 9004 / 9005 / 9006 / 9014 | bad function/args/name/ip/groups | 400 |
+| 9007 / 9008 / 9012 | duplicate ip/name/id | 409 |
+| 9013 | `max_agents` reached | 503 |
+| 9015 | worker rejection (after the authd-side fix below, only `remove`/`get` still hit this) | 503 |
+| 9016 (new) | clustered forward to master failed (transport leg of `w_request_agent_add_clustered`) | 503 |
+| transport failure (authd unreachable) | — | 503 |
+| bad/missing/stale credential | — | 401 |
+| local schema or version validation failure | — | 400 |
+| enrollment administratively disabled | — | 403 |
+
+`9013`/`9016` map to `503` rather than `429`: both are server-side conditions an operator resolves
+(raise `max_agents`, fix the cluster link), not something the caller can fix by slowing down — `429`
+would suggest the wrong remedy. `9016` exists because a failed clustered forward previously had no
+dedicated code and fell through to generic `9001`/`500`, misrepresenting a transient cluster hiccup as
+a server bug.
+
+**`/enroll` is always registered — disabled enrollment answers `403`, never a missing route.**
+Considered making registration itself conditional on `enrollment_enabled` (404 when off), rejected
+because a 404 conflates two very different situations for both operators and an agent's own fallback
+logic: "this manager is too old to have `/enroll`" versus "this manager has it but an admin turned it
+off." `403` is also the more semantically precise status here: it signals a persistent policy decision
+("understood, not authorized, won't change without a config edit"), unlike this design's own `503`
+usage elsewhere (authd down, `max_agents`) which implies a transient condition that might resolve on
+its own — disabling enrollment via config isn't that. It also matches this module's existing
+philosophy of never letting a capability silently vanish, the same way `/scan/vd` always answers with
+an explicit rejection reason rather than disappearing when VD isn't ready.
+
+### authd-side change: cluster workers
+
+authd's local socket rejects every JSON function on a worker node (`error 9015`) before it even parses
+the request — only the 1515 network path knows how to forward enrollment to the master, via
+`w_request_agent_add_clustered` (`os_auth/src/main-server.c`). The fix lives in authd itself:
+`os_auth/src/local-server.c`'s worker gate moves to after the request is parsed, and on a worker,
+`"add"` specifically takes the same `w_request_agent_add_clustered` path 1515 already uses, returning
+the new `9016` when its transport leg fails; `"remove"`/`"get"` keep returning `9015` unchanged.
+remoted stays completely unaware of cluster topology — it always just talks to the local socket.
+
+This is a real, currently-hit gap for this bridge, but a **net-new capability that regresses nothing
+else**: the API's `POST /agents`/`POST /agents/insert` dispatch through `DistributedAPI` with
+`request_type='local_master'`, which forwards the *entire HTTP request* to the master node first
+whenever the local node isn't the master (`core/cluster/dapi/dapi.py`) — so `core/agent.py`'s call
+into this same local socket only ever executes **on the master** today. The API never actually
+reaches a worker's local authd socket, which is why the existing 9015 block has never been hit by that
+caller, confirmed by `tests/integration/test_authd/test_cluster/data/test_cases/cases_authd_worker.yaml`
+exercising only the 1515 network path's worker→master forwarding, never the local socket. Mirroring
+DAPI's approach in remoted (detect worker, forward the whole HTTP request to the master's remoted) was
+considered and rejected: it would mean remoted reimplementing cross-node request forwarding — with its
+own auth — in C, for a problem the cluster's existing low-level socket protocol already solves more
+cheaply by fixing authd once.
+
+### Enrollment scoping — independent of legacy 1515
+
+Three flags in the existing `<auth>` config block, in order of precedence:
+
+| `disabled` | `remote_enrollment` | `legacy_enrollment` (new) | Port 1515 | `/enroll` |
+|---|---|---|---|---|
+| yes | – | – | off | off |
+| no | no | – | off | off |
+| no | yes | yes (default) | on | on |
+| no | yes | no | off | **on** |
+
+`<remote_enrollment>` is broadened from its current, narrower meaning ("start authd's TCP 1515
+listener") to a master switch for **all** remote self-enrollment, `/enroll` included — a deliberate,
+release-noted behavior change for any deployment already running with `remote_enrollment=no`. The new
+`<legacy_enrollment>` flag (default `yes`, so nothing changes for anyone who doesn't set it) is what
+lets an operator retire 1515 specifically while keeping HTTPS enrollment: `main-server.c`'s
+`thread_remote_server` (the 1515 listener) becomes gated by `remote_enrollment && legacy_enrollment`;
+`thread_local_server` (the UDS socket this bridge uses) stays gated only by `disabled`, unconditional
+otherwise — the bridge always has something to talk to as long as authd is running at all.
+`enrollment_enabled` on the remoted side is `!disabled && remote_enrollment`; `legacy_enrollment` has
+no bearing on it whatsoever, and neither flag ever unregisters the route (see above) — only its `403`.
+
+`authd_config_t.flags.disabled` looks tri-state in its header (`AD_CONF_UNPARSED`/`AD_CONF_UNDEFINED`
+sentinels), but a repo-wide search shows nothing ever sets it to `AD_CONF_UNPARSED` — the one line
+that used to is commented out — so the tri-state switch in `os_auth/src/config.c` is dead code today.
+It behaves as a plain boolean, defaulting to enabled (`0`) unless `<disabled>yes</disabled>` is
+explicit. `secure.c` needs no special resolution logic: zero-initialize a local `authd_config_t` the
+normal way, call `ReadConfig(CAUTHD, OSSECCONF, &authd_cfg, NULL)`, and read `flags.disabled` directly.
+
+### Manager certificate unification
+
+authd used to serve its own certificate pair (`etc/certs/authd.pem`/`authd-key.pem`), a separate
+manager identity from the one this module's HTTPS server presents (`etc/certs/remoted.pem`/
+`remoted-key.pem`, CA `etc/certs/root-ca.pem`). Since a client certificate on `/enroll` (when the
+listener requires one) treats "this certificate validated" as an enrollment credential, both
+listeners now present the *same* identity: the install-time generation step
+(`GenerateAuthCert()` in `init/inst-functions.sh`, plus its RPM/DEB packaging equivalents) that used
+to create `authd.pem`/`authd-key.pem` has been removed, and the generated `<auth>` config
+(`auth.template`, and the `<disabled>yes</disabled>` fallback written by `DisableAuthd()`) now
+points `<ssl_manager_cert>`/`<ssl_manager_key>` at `remoted.pem`/`remoted-key.pem` instead — the
+same certificate `GenerateHttpsManagerCert()` already generates for the HTTPS listener. Explicit
+`<auth>` certificate overrides in `ossec.conf` keep working unchanged — only the generated
+defaults change. Port 1515 keeps running with the unified certificate.
+
+Two compiled-in defaults exist alongside the generated config, both now updated to match:
+`shared/include/ssl_op.h`'s `CERTFILE`/`KEYFILE` macros (read only by `main-server.c`'s `-h` help
+text) and `config/src/authd-config.c`'s `Read_Authd()`, which hardcodes the same path as the actual
+runtime default `<ssl_manager_cert>`/`<ssl_manager_key>` fall back to when absent from
+`ossec.conf`. Both are manager-only in practice: `os_auth/CMakeLists.txt` builds exactly one
+executable (`wazuh-manager-authd`) from this module -- there is no separate agent-side `authd`
+binary, despite `ARGV0`/the CMake project name still being spelled `wazuh-authd` as a historical
+label, and every caller of `Read_Authd()`/`CAUTHD` (`os_auth/src/config.c`,
+`remoted/src/secure.c`) is itself a manager-only binary. So there was no agent-vs-manager
+conflict to avoid here, and no reason to leave a stale default in place. In practice this fallback
+is never reached on a fresh manager install anyway: `auth.template` always writes
+`<ssl_manager_cert>`/`<ssl_manager_key>` explicitly.
+
+### Configuration
+
+Unlike every other subsystem's tunables in this module, enrollment's *behavioral* flags do not come
+from a new `<https>` block or a new internal option: remoted's C side calls
+`ReadConfig(CAUTHD, OSSECCONF, &authd_cfg, NULL)` — the `config` library is already linked into
+`remoted_lib` — and copies fields straight out of authd's own `<auth>` config (`use_password`,
+`use_source_ip`, `allow_higher_versions`, `remote_enrollment`). This is deliberate: `/enroll` and
+1515 must agree on whether password auth is required and which versions are acceptable, and reading
+the *same* config block is what guarantees that rather than two settings that can drift apart. Only
+operational knobs (password-file poll interval, authd-socket connect/response timeouts, queue size)
+are new C-ABI fields with their own defaults, following this module's usual "`<=0` means default"
+convention. `enrollment_enabled` gates only the response the endpoint gives, never whether the route
+exists (see *Two independent authentication gates* above's `403` discussion).
+
+### Metrics
+
+Following `ControlMetrics`/`ScanVdMetrics`'s pattern (relaxed atomics on the shared `wazuh_metrics`
+registry, a silent no-op on a null-object instance): `remoted.enrollment.requests`,
+`remoted.enrollment.accepted`, `remoted.enrollment.auth_rejected` (401s — a spike here means a
+password rollout is out of sync between managers and agents), `remoted.enrollment.disabled` (403s —
+useful to notice an agent still trying an enrollment path an operator turned off),
+`remoted.enrollment.authd_error` (any 90xx), `remoted.enrollment.authd_unreachable` (transport
+failures).
+
+### Lifecycle
+
+Constructed in `RemotedModuleFacade::startHttpServer()` alongside the other endpoint dependencies:
+`PasswordKeySource` only when `requirePassword` is set, `AuthdClient` always (the route is always
+registered, so the client always exists even if `enrollment_enabled` is currently false — it simply
+goes unused while the endpoint short-circuits to `403`). Torn down in the same phase as
+`m_downstreamClient` — `AuthdClient::stop()` before the HTTP transport's final `stop()` releases its
+I/O runtime, matching the ordering documented in *Deferred forwarding* above.
 
 ## Streamed responses — `POST /download`
 

--- a/src/remoted/remoted_module/README.md
+++ b/src/remoted/remoted_module/README.md
@@ -841,12 +841,25 @@ privilege boundary — it joins the same trust domain `manage_agents` already si
 
 #### `AuthdClient` (`enrollment/authdClient.hpp/.cpp`)
 
-The bridge to authd's local socket `queue/sockets/auth`, built the way `control/taskClient.cpp` and
-`control/wazuhDBClient.cpp` already talk to their own UDS peers — `shared_modules/utils`'s
-`Socket<OSPrimitives, SizeHeaderProtocol>` (a 4-byte little-endian length prefix, the exact framing
-`OS_SendSecureTCP`/`OS_RecvSecureTCP` use). The one way it differs from those two clients: authd
-closes the connection after **every** reply, so `AuthdClient` connects, sends one frame, awaits one
-frame, and closes — per request — rather than keeping a persistent, reconnect-on-error connection.
+The bridge to authd's local socket `queue/sockets/auth`, framed with `shared_modules/utils`'s
+`Socket<OSPrimitives, SizeHeaderProtocol>` — a 4-byte little-endian length prefix, the exact framing
+`OS_SendSecureTCP`/`OS_RecvSecureTCP` use. Unlike `control/taskClient.cpp`/`control/wazuhDBClient.cpp`,
+it does **not** use `shared_modules/utils`'s `SocketClient` async wrapper, even though it drives the
+same underlying `Socket` class: authd closes the connection after **every** reply, so `AuthdClient`
+connects, sends one frame, awaits one frame, and closes — per request, on its own dedicated worker
+thread — rather than keeping a persistent, multi-request connection the way `SocketClient` is built
+for. `SocketClient::connect()` is asynchronous (it starts a background thread and returns before the
+connection exists), which is fine for `TaskClient`/`WazuhDBClient` — they connect once and only send
+much later, well after that thread has settled — but is exactly wrong for a connect-then-immediately-
+send-every-time client: an earlier version of this class did use `SocketClient` and lost that race
+far more often than not, so `authd` would receive and successfully process a request while the reply
+arrived on a connection nothing was listening on anymore, and the caller saw a spurious timeout for an
+enrollment that had actually already succeeded. `AuthdClient` instead calls `Socket::connect()`
+directly in **blocking** mode: it returns only once genuinely connected, or throws immediately on a
+real failure, with no race and no background thread — and, as a side effect, an absent authd is now
+distinguishable from a slow one (a fast "could not connect" instead of waiting out the full response
+timeout). The response wait itself is bounded the same way authd's own `OS_SetRecvTimeout` bounds its
+side: `SO_RCVTIMEO`/`SO_SNDTIMEO` set directly on the connected socket.
 
 Wire request: `{"function":"add","arguments":{"name":...,"ip":...,"groups":...,"key_hash":...}}`.
 **`force`, `id`, and `key` are never sent** — self-enrollment always gets an auto-assigned ID and an

--- a/src/remoted/remoted_module/README.md
+++ b/src/remoted/remoted_module/README.md
@@ -819,10 +819,15 @@ request.
 #### `EnrollmentAuthenticator` (`enrollment/enrollmentAuthenticator.hpp/.cpp`)
 
 Implements the Password gate above, and nothing about client certificates at all — that's the TLS
-listener's exclusive concern, checked before any handler runs, which is exactly why this class'
-only configuration knob is `requirePassword` rather than a "mode" spanning both. Reuses `Cmac`, the
-timestamp/hex parsing, and the `AuthError` taxonomy from `auth/authTypes.hpp`, so a bad signature, a
-stale or future timestamp, and an oversized body all collapse through the same `publicErrorFor()` →
+listener's exclusive concern, checked before any handler runs, which is exactly why this class has
+no "mode" spanning both: `requirePassword` gates the Password check alone, and is independent of
+`maxRequestAgeSeconds`/`maxFutureSkewSeconds`/`maxBodySize` (the freshness window and body-size cap,
+sourced from the SAME `auth_max_request_age`/`auth_max_future_skew`/`auth_max_body_size` internal
+options the agent<->manager scheme reads, so the two never silently disagree). The body-size check
+runs first and unconditionally — in Open mode too — so an unauthenticated peer can never make this
+endpoint hash an arbitrarily large body before being rejected. Reuses `Cmac`, the timestamp/hex
+parsing, and the `AuthError` taxonomy from `auth/authTypes.hpp`, so a bad signature, a stale or
+future timestamp, and an oversized body all collapse through the same `publicErrorFor()` →
 `401`/`413` path every other route already uses. Because `AuthGateway` bakes the `client.keys`
 `Keystore` into its middleware with no per-route key-source hook, `/enroll` does **not** go through
 `AuthGateway` at all — it registers directly on `IHttpServer::addRoute` (the same pattern the
@@ -880,6 +885,36 @@ the same `isWorkerNode` flag already plumbed into `ControlConfig` and uses a lon
 covering the worst-case retry budget) on workers versus a short default (~5 s, matching
 `WazuhDBClient`/`TaskClient`, since there's no cluster hop on the master).
 
+**Fixed: this retry no longer serializes behind authd's local-socket dispatch.** `run_local_server`
+(`os_auth/src/local-server.c`) used to be a plain accept→recv→dispatch→send→close loop with no
+per-connection thread, so while one worker-node `add` was inside
+`w_request_agent_add_clustered`'s up-to-10-second retry budget, that ONE thread could not accept or
+serve ANY other local-socket client -- another queued `/enroll` request, `manage_agents`, or the
+API -- for the same window. This was not a risk this bridge introduced on its own: port 1515's own
+worker-node enrollment forwarding calls the exact same `w_request_agent_add_clustered` inline on its
+own single event loop (`run_remote_server`'s epoll thread, `main-server.c`), blocking every other
+concurrent 1515 connection the same way -- but the local socket previously had no such exposure at
+all (every `add` on a worker failed instantly with `9015`, before cluster forwarding existed for
+it), so `manage_agents`/the API/`/enroll` would have been newly subject to a latency class 1515 has
+already lived with. `run_local_server` now hands each accepted connection to its own detached
+thread (`handle_local_client`) instead of dispatching inline, so a single slow or stuck cluster
+forward only holds up the ONE connection waiting on it. This is safe to parallelize without any
+further locking changes: every `local_add()`/`local_remove()`/`local_get()` call already serializes
+access to the shared `keys` keystore (and `write_pending`/`cond_pending`) through the existing
+`mutex_keys`, which every one of those functions already takes. Port 1515's own equivalent blocking
+window (its epoll loop, not this one) is unchanged -- fixing that would be a separate, larger change
+to `run_remote_server`'s connection model and is out of scope here.
+
+**Bounded, not unbounded.** The number of connections serviced concurrently via a detached thread
+is capped at `MAX_LOCAL_CLIENT_THREADS` (128, matching `AUTH_LOCAL_SOCK`'s own listen backlog --
+there is no benefit to servicing more concurrently than that many could ever be queued at once).
+Without this cap, a burst of connections -- e.g. many cluster workers enrolling against one
+master's `authd` at the same time (`N` workers × up to `authd_worker_threads` each), or any local
+caller not otherwise rate-limited -- would spawn one thread per connection with no ceiling at all.
+At the cap, `run_local_server` falls back to servicing the connection synchronously, inline on the
+accept loop, exactly like every connection was handled before this change -- self-limiting by
+construction, rather than either growing the thread count without bound or dropping the client.
+
 #### `enrollmentEndpoint` (`enrollment/enrollmentEndpoint.hpp/.cpp`)
 
 The HTTP registration and glue: checks `enrollment_enabled` first (see *Enrollment scoping* below),
@@ -891,17 +926,22 @@ response.
 
 | field | required | notes |
 |---|---|---|
-| `name` | yes | non-empty, ≤128 chars, restricted charset checked here; authd re-validates independently |
+| `name` | yes | 2-128 chars, no leading `.`, charset `[A-Za-z0-9._-]` only -- byte-for-byte `OS_IsValidName()` (`shared/src/agent_validate_op.c`), the same rule the legacy port-1515 path applies, so both enrollment paths accept exactly the same set of names. authd's local socket (`local-server.c`) separately enforces a deliberately looser *storage-safety* floor for all of its callers (`is_storable_agent_name()`: no whitespace or control bytes, no leading `#`/`!`, non-empty, <=128 chars) -- historically it trusted every caller to have validated the name, which was never true for /enroll, but it cannot adopt `OS_IsValidName()` itself without breaking `manage_agents`/API names that predate this endpoint (`%`, single-character, leading `.`). /enroll therefore holds the tighter line here rather than relying on that floor |
 | `version` | yes | authd's local `add` path has no version check at all, so remoted enforces `allow_higher_versions` itself, reusing `compareVersions()` (`control/controlTypes.hpp`) rather than duplicating it |
 | `groups` | no | comma-separated string, passed through unchanged — matches authd's own wire format and `w_auth_validate_groups` with zero transformation |
-| `ip` | no | syntactic IPv4/IPv6/CIDR check; see IP resolution below |
+| `ip` | no | syntactic IPv4/IPv6/CIDR check, or one of two sentinels (`any`, `src`); see IP resolution below |
 | `key_hash` | no | opaque passthrough that drives authd's own force/key-mismatch decision |
 
-**IP resolution** mirrors authd's `use_source_ip` flag: if it's set, the connection's observed peer
-address wins over anything the body claims — read from `HttpRequest::remoteIp`
+**IP resolution** mirrors authd's `use_source_ip` flag: if it's set (manager-side), the connection's
+observed peer address wins over anything the body claims — read from `HttpRequest::remoteIp`
 (`http_server/IHttpServer.hpp`), which already exists (populated from RESTinio's
-`remote_endpoint().address()`) and is already unused by any handler today; otherwise the body's `ip`
-is used if present; if neither applies, `"any"` is sent, matching authd's own literal handling of
+`remote_endpoint().address()`) and is already unused by any handler today. Otherwise, a body `ip` of
+`"src"` (the agent-side sentinel — mirrors legacy port 1515's own `IP:'src'` wire convention,
+os_auth/src/auth.c:208, sent by an agent configured with its own client-side `<use_source_ip>`) ALSO
+resolves to the observed peer address, and is never forwarded to authd as the literal string "src":
+authd's local `add` path has no notion of that sentinel at all (only port 1515's TEXT-protocol
+parser does) and would reject it as an invalid IP (9006). Otherwise the body's `ip` is used if
+present; if none of the above applies, `"any"` is sent, matching authd's own literal handling of
 that value.
 
 **Success — `200`**: `{"id":"...","name":"...","ip":"...","key":"..."}`, verbatim from authd's `data`.
@@ -910,10 +950,10 @@ that value.
 | authd code | meaning | HTTP |
 |---|---|---|
 | 9001 / 9002 / 9009 | internal / JSON-parse / key-generation failure | 500 |
-| 9003 / 9004 / 9005 / 9006 / 9014 | bad function/args/name/ip/groups | 400 |
+| 9003 / 9004 / 9005 / 9006 / 9014 / 9017 (new) | bad function/args/name/ip/groups | 400 |
 | 9007 / 9008 / 9012 | duplicate ip/name/id | 409 |
 | 9013 | `max_agents` reached | 503 |
-| 9015 | worker rejection (after the authd-side fix below, only `remove`/`get` still hit this) | 503 |
+| 9015 | worker rejection (`remove`/`get`, or an `add` that supplied a caller-chosen `id`/`key` -- see below) | 503 |
 | 9016 (new) | clustered forward to master failed (transport leg of `w_request_agent_add_clustered`) | 503 |
 | transport failure (authd unreachable) | — | 503 |
 | bad/missing/stale credential | — | 401 |
@@ -947,18 +987,31 @@ the request — only the 1515 network path knows how to forward enrollment to th
 the new `9016` when its transport leg fails; `"remove"`/`"get"` keep returning `9015` unchanged.
 remoted stays completely unaware of cluster topology — it always just talks to the local socket.
 
-This is a real, currently-hit gap for this bridge, but a **net-new capability that regresses nothing
-else**: the API's `POST /agents`/`POST /agents/insert` dispatch through `DistributedAPI` with
-`request_type='local_master'`, which forwards the *entire HTTP request* to the master node first
-whenever the local node isn't the master (`core/cluster/dapi/dapi.py`) — so `core/agent.py`'s call
-into this same local socket only ever executes **on the master** today. The API never actually
-reaches a worker's local authd socket, which is why the existing 9015 block has never been hit by that
-caller, confirmed by `tests/integration/test_authd/test_cluster/data/test_cases/cases_authd_worker.yaml`
-exercising only the 1515 network path's worker→master forwarding, never the local socket. Mirroring
-DAPI's approach in remoted (detect worker, forward the whole HTTP request to the master's remoted) was
-considered and rejected: it would mean remoted reimplementing cross-node request forwarding — with its
-own auth — in C, for a problem the cluster's existing low-level socket protocol already solves more
-cheaply by fixing authd once.
+**Cluster forwarding is gated on the request SHAPE, not just the function name.** `local_add_clustered()`
+has no `id`/`key` parameters at all -- it only ever produces a self-enrollment-shaped result (an
+auto-assigned ID, an authd-generated key), the same contract `/enroll` and port 1515 already have.
+`manage_agents`/`framework/wazuh/core/agent.py`, on the other hand, can supply a caller-chosen `id`
+and/or `key` on this same local socket (an admin/restore-style add, e.g. importing a specific agent
+record) -- before this fix, EVERY `add` on a worker got a blanket `9015`, so that shape was rejected
+too, just not distinguished from any other. Forwarding it through `local_add_clustered()` unchanged
+would silently drop the caller's `id`/`key` and return `200` with a DIFFERENT identity than the one
+requested, since nothing in that function's signature has anywhere to put them. So the gate now
+checks: if the parsed request carries an `id` or a `key`, it still gets the original `9015` (an
+honest "can't do this here" rather than a wrong answer); only the self-enrollment shape (`id`/`key`
+absent) reaches `local_add_clustered()`.
+
+This is a real, currently-hit gap for the self-enrollment shape specifically -- and a **net-new
+capability that regresses nothing else**: the API's `POST /agents`/`POST /agents/insert` dispatch
+through `DistributedAPI` with `request_type='local_master'`, which forwards the *entire HTTP request*
+to the master node first whenever the local node isn't the master (`core/cluster/dapi/dapi.py`) for
+that specific REST path -- but `core/agent.py`'s `add()` (the function that can attach `id`/`key`) is
+also reachable through other, non-DAPI-gated callers on a worker (`manage_agents`, or any future
+internal caller), which is exactly why the id/key-present shape keeps its own explicit `9015` above
+rather than assuming DAPI already filtered every possible caller. Mirroring DAPI's approach in
+remoted (detect worker, forward the whole HTTP request to the master's remoted) was considered and
+rejected: it would mean remoted reimplementing cross-node request forwarding — with its own auth — in
+C, for a problem the cluster's existing low-level socket protocol already solves more cheaply by
+fixing authd once.
 
 ### Enrollment scoping — independent of legacy 1515
 

--- a/src/remoted/remoted_module/include/remoted_module.h
+++ b/src/remoted/remoted_module/include/remoted_module.h
@@ -194,6 +194,12 @@ extern "C"
                                               ///< worker-to-master retry budget).
         int authd_max_queue_size;             ///< AuthdClient request queue high-water mark; QueueFull over it
                                               ///< (<=0 -> default).
+        int authd_worker_threads;             ///< Number of concurrent connect-per-request workers bridging to
+                                              ///< authd's local socket. <=0 -> default. authd's own accept loop
+                                              ///< is single-threaded, so this does not raise authd's processing
+                                              ///< rate -- it overlaps remoted's own connect+send latency with
+                                              ///< authd's turnaround so authd is never left idle waiting on
+                                              ///< remoted for the next request.
     } remoted_module_config_t;
 
     /**

--- a/src/remoted/remoted_module/include/remoted_module.h
+++ b/src/remoted/remoted_module/include/remoted_module.h
@@ -123,8 +123,8 @@ extern "C"
         /// "unset" sentinel: getDefine_Int_default() always resolves the final 0/1 value (defaulting
         /// to enabled) on the C side, so this field always carries the real value.
         bool http_content_encoding_enabled;
-        long long max_inflight_bytes;    ///< Max in-flight request payload bytes; 503 over it (<=0 -> module default).
-        int max_parallel_connections;    ///< HTTPS max simultaneous connections (<=0 -> module default).
+        long long max_inflight_bytes; ///< Max in-flight request payload bytes; 503 over it (<=0 -> module default).
+        int max_parallel_connections; ///< HTTPS max simultaneous connections (<=0 -> module default).
         int max_deferred_requests; ///< Max requests parked awaiting a downstream service; 503 over it (<=0 -> default).
 
         // Downstream (async UDS client to the engine's event ingress) tunables. <=0 -> module default
@@ -166,9 +166,34 @@ extern "C"
         int wdb_max_queue_size;          ///< Wazuh-DB request queue high-water mark; QueueFull over it (<=0 -> 10000).
         int tm_concurrency;              ///< Task Manager concurrency limit (<=0 -> 10).
         int tm_deadline_ms;              ///< Task Manager per-request deadline in milliseconds (<=0 -> 200).
-        int tm_max_queue_size; ///< Task Manager request queue high-water mark; QueueFull over it (<=0 -> 10000).
+        int tm_max_queue_size;      ///< Task Manager request queue high-water mark; QueueFull over it (<=0 -> 10000).
         int keepalive_throttle_sec; ///< Minimum seconds between two wazuh-db keepalive writes for the same agent;
                                     ///< notifies arriving faster are absorbed in memory (<=0 -> 60).
+
+        // Enrollment (POST /enroll bridging to authd) configuration. Unlike every other group
+        // above, the behavioral flags here are NOT sourced from <remote><https> or a dedicated
+        // XML tag: they are copied verbatim from authd's own <auth> config block, so /enroll and
+        // legacy port 1515 can never disagree on whether password auth is required or which
+        // agent versions are acceptable. Only the operational knobs are remoted-owned internal
+        // options.
+        bool enrollment_enabled;              ///< !authd's <disabled> && authd's <remote_enrollment>.
+                                              ///< Gates only the /enroll response (403 when false) --
+                                              ///< the route itself is always registered.
+        bool enroll_use_password;             ///< authd's <use_password>: Password mode requires this.
+        bool enroll_use_source_ip;            ///< authd's <use_source_ip>: governs /enroll's IP resolution.
+        bool enroll_allow_higher_versions;    ///< authd's OWN <agents><allow_higher_versions> --
+                                              ///< deliberately NOT the allow_higher_versions field
+                                              ///< above, which is a separate, independently
+                                              ///< configured <remote> setting used by /control.
+        int enroll_password_refresh_interval; ///< Seconds between etc/authd.pass change checks
+                                              ///< (hot-reload poll fallback). <=0 -> module default.
+        int authd_connect_timeout;            ///< Seconds to wait for the authd local-socket connect. <=0 -> default.
+        int authd_response_timeout;           ///< Seconds to wait for authd's reply to an enrollment request.
+                                              ///< <=0 -> module default, which is worker-aware (longer on a
+                                              ///< cluster worker, to outlast authd's own internal
+                                              ///< worker-to-master retry budget).
+        int authd_max_queue_size;             ///< AuthdClient request queue high-water mark; QueueFull over it
+                                              ///< (<=0 -> default).
     } remoted_module_config_t;
 
     /**

--- a/src/remoted/remoted_module/src/auth/authMiddleware.cpp
+++ b/src/remoted/remoted_module/src/auth/authMiddleware.cpp
@@ -71,6 +71,7 @@ namespace remoted::auth
             case AuthError::BodyTooLarge: return "body_too_large";
             case AuthError::UnsupportedContentEncoding: return "unsupported_content_encoding";
             case AuthError::MalformedContentEncoding: return "malformed_content_encoding";
+            case AuthError::EnrollmentKeyUnavailable: return "enrollment_key_unavailable";
         }
         return "unknown";
     }
@@ -87,8 +88,8 @@ namespace remoted::auth
             case AuthError::UnsupportedContentEncoding: return {415, "Unsupported Content-Encoding"};
             case AuthError::None: return {200, ""};
             // MissingAuthorization, MalformedAuthorization, UnknownAgent, MissingKey,
-            // AddressNotAllowed, ExpiredRequest, FutureRequest, InvalidMac: collapse to one
-            // generic 401 so the client can never distinguish the reason.
+            // AddressNotAllowed, ExpiredRequest, FutureRequest, InvalidMac, EnrollmentKeyUnavailable:
+            // collapse to one generic 401 so the client can never distinguish the reason.
             default: return {401, "Invalid client authentication"};
         }
     }

--- a/src/remoted/remoted_module/src/auth/authTypes.hpp
+++ b/src/remoted/remoted_module/src/auth/authTypes.hpp
@@ -134,6 +134,15 @@ namespace remoted::auth
         UnsupportedContentEncoding, ///< Content-Encoding present but not (case-insensitively) "zstd".
         MalformedContentEncoding,   ///< Content-Encoding: zstd, but the body isn't a valid/complete
                                     ///< zstd frame (bad magic, truncated, oversized window, ...).
+        EnrollmentKeyUnavailable,   ///< Raised ONLY by EnrollmentAuthenticator's Password mode
+                                    ///< (enrollmentAuthenticator.cpp): etc/authd.pass is missing,
+                                    ///< unreadable, invalid, or not yet synced from the master to this
+                                    ///< node, OR AES-CMAC is unavailable manager-wide. Deliberately
+                                    ///< distinct from MissingKey (a client.keys decode failure for an
+                                    ///< ALREADY-enrolled agent) -- collapsing the two would have
+                                    ///< logRejection() tell an operator to "re-enroll the affected
+                                    ///< agent(s)" for a condition where no agent, and no client.keys
+                                    ///< entry, exists yet at all.
     };
 
     /**

--- a/src/remoted/remoted_module/src/auth/keystore.cpp
+++ b/src/remoted/remoted_module/src/auth/keystore.cpp
@@ -206,6 +206,12 @@ namespace remoted::auth
         // join() below can throw std::system_error, and the logging call allocates.
         try
         {
+            // Set unconditionally, BEFORE the eventfd write: the only reliable stop signal when
+            // eventfd() failed at construction (m_stopEventFd stays -1, so there's no fd to wake
+            // poll() early). In that case the loop still notices this within one more poll()
+            // timeout (at most m_refreshIntervalSeconds) instead of never -- see watcherLoopBody().
+            m_stopping.store(true);
+
             if (m_stopEventFd >= 0)
             {
                 const std::uint64_t one {1};
@@ -290,11 +296,34 @@ namespace remoted::auth
             {
                 if (errno == EINTR)
                 {
+                    // Checked here too, not just after a real poll() failure below: under a
+                    // persistent signal storm, every poll() call could keep returning EINTR
+                    // forever, and this `continue` would otherwise loop back to poll() again
+                    // without ever reaching the m_stopping checks further down -- the only way
+                    // this thread would then ever notice a pending stop is if the signal storm
+                    // happens to end at the exact moment a poll() call completes normally.
+                    if (m_stopping.load())
+                    {
+                        break;
+                    }
                     continue;
+                }
+                if (m_stopping.load())
+                {
+                    break;
                 }
                 LOGFN_WARN(logFn(), "poll() on the client.keys watcher failed (errno=%d).", errno);
                 std::this_thread::sleep_for(std::chrono::seconds(m_refreshIntervalSeconds));
                 continue;
+            }
+
+            // Checked on EVERY wakeup, not just the eventfd-signaled one: this is the fallback
+            // path when eventfd() failed at construction (m_stopEventFd stays -1, stopIdx stays -1
+            // below) -- poll() then has no fd to wake it early and just times out every
+            // m_refreshIntervalSeconds, which is enough to notice this flag within one more cycle.
+            if (m_stopping.load())
+            {
+                break;
             }
 
             if (stopIdx >= 0 && (fds[stopIdx].revents & POLLIN))

--- a/src/remoted/remoted_module/src/auth/keystore.hpp
+++ b/src/remoted/remoted_module/src/auth/keystore.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include <mutex>
 #include <string>
@@ -167,6 +168,14 @@ namespace remoted::auth
         int m_watchDescriptor {-1};
         int m_stopEventFd {-1}; ///< Written by the destructor for an immediate cooperative wakeup.
         std::thread m_watcherThread;
+
+        /// Fallback stop signal, checked every loop iteration independent of m_stopEventFd: if
+        /// eventfd() failed at construction (m_stopEventFd stays -1), poll() has no fd to wake it
+        /// early, but this flag still gets noticed the next time poll()'s own timeout elapses (at
+        /// most m_refreshIntervalSeconds later) -- so the watcher thread is always joinable within
+        /// a bounded time, never permanently, which the destructor's join() would otherwise wait
+        /// on forever.
+        std::atomic<bool> m_stopping {false};
 
         // Serializes reload() (so at most one parse runs at a time, whether triggered by the
         // watcher or called directly) and guards the last-known content hash below, which

--- a/src/remoted/remoted_module/src/auth/passwordKeySource.cpp
+++ b/src/remoted/remoted_module/src/auth/passwordKeySource.cpp
@@ -441,7 +441,13 @@ namespace remoted::auth
         const auto currentHash = hashFileOrNullopt(m_path);
         if (!currentHash)
         {
-            return false;
+            // Unlike Keystore (whose backing file is expected to always exist once created),
+            // authd.pass going missing/unreadable is an expected admin action -- revoking
+            // Password-mode enrollment -- and must invalidate any cached key right away rather
+            // than waiting for the file to reappear. reload() below clears m_hasBaseline in this
+            // same case so a later reload isn't skipped just because the file comes back with
+            // byte-identical content.
+            return true;
         }
         return !m_hasBaseline || *currentHash != m_lastHash;
     }
@@ -457,6 +463,10 @@ namespace remoted::auth
             {
                 std::lock_guard<std::mutex> lock(m_mutex);
                 m_derivedKey.reset();
+                // Clear the baseline: if the file later reappears with content that hashes the
+                // same as what we saw before it vanished, fileLooksChanged() must still treat
+                // that as a change (there's no other signal that the key needs re-deriving).
+                m_hasBaseline = false;
                 return false;
             }
 

--- a/src/remoted/remoted_module/src/auth/passwordKeySource.cpp
+++ b/src/remoted/remoted_module/src/auth/passwordKeySource.cpp
@@ -132,8 +132,10 @@ namespace remoted::auth
          *
          * Empty salt, info = "WAZUH-ENROLL-CMAC-KEY" + 0x01 -- see the Agent enrollment chapter
          * of remoted_module/README.md for a verified known-answer vector (password
-         * "MyEnrollmentSecret123" -> key 0ddc6f7f...667635). The version byte in `info` reserves
-         * room to change this construction later without an ambiguous transition.
+         * "MyEnrollmentSecret123" -> key 2ea29504...5a9e, confirmed against three independent
+         * implementations -- see passwordKeySource_test.cpp's HkdfMatchesTheVerifiedKnownAnswerVector).
+         * The version byte in `info` reserves room to change this construction later without an
+         * ambiguous transition.
          *
          * @throws std::runtime_error on an OpenSSL provider failure (missing/misconfigured HKDF
          *         provider, FIPS mode, etc.) -- global and permanent, same distinction Cmac makes
@@ -266,6 +268,12 @@ namespace remoted::auth
     {
         try
         {
+            // Set unconditionally, BEFORE the eventfd write: this is the only reliable stop signal
+            // when eventfd() failed at construction (m_stopEventFd stays -1) and there is no fd to
+            // wake poll() early. In that case the loop still notices this within one more
+            // poll() timeout (at most m_refreshIntervalSeconds), rather than never.
+            m_stopping.store(true);
+
             if (m_stopEventFd >= 0)
             {
                 const std::uint64_t one {1};
@@ -341,11 +349,34 @@ namespace remoted::auth
             {
                 if (errno == EINTR)
                 {
+                    // Checked here too, not just after a real poll() failure below: under a
+                    // persistent signal storm, every poll() call could keep returning EINTR
+                    // forever, and this `continue` would otherwise loop back to poll() again
+                    // without ever reaching the m_stopping checks further down -- the only way
+                    // this thread would then ever notice a pending stop is if the signal storm
+                    // happens to end at the exact moment a poll() call completes normally.
+                    if (m_stopping.load())
+                    {
+                        break;
+                    }
                     continue;
+                }
+                if (m_stopping.load())
+                {
+                    break;
                 }
                 LOGFN_WARN(logFn(), "poll() on the authd.pass watcher failed (errno=%d).", errno);
                 std::this_thread::sleep_for(std::chrono::seconds(m_refreshIntervalSeconds));
                 continue;
+            }
+
+            // Checked on EVERY wakeup, not just the eventfd-signaled one: this is the fallback
+            // path when eventfd() failed at construction (m_stopEventFd stays -1, stopIdx stays
+            // -1 below) -- poll() then has no fd to wake it early and just times out every
+            // m_refreshIntervalSeconds, which is enough to notice this flag within one more cycle.
+            if (m_stopping.load())
+            {
+                break;
             }
 
             if (stopIdx >= 0 && (fds[stopIdx].revents & POLLIN))

--- a/src/remoted/remoted_module/src/auth/passwordKeySource.cpp
+++ b/src/remoted/remoted_module/src/auth/passwordKeySource.cpp
@@ -1,0 +1,523 @@
+/*
+ * Wazuh auth middleware (framework-agnostic)
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 19, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "passwordKeySource.hpp"
+
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+
+#include <cctype>
+#include <cerrno>
+#include <poll.h>
+#include <sys/eventfd.h>
+#include <sys/inotify.h>
+#include <unistd.h>
+
+#include <openssl/core_names.h>
+#include <openssl/kdf.h>
+#include <openssl/params.h>
+
+#include "hashHelper.h"
+#include "loggerHelper.h"
+
+namespace remoted::auth
+{
+
+    namespace
+    {
+        // Same rationale as keystore.cpp: keeping loggerHelper.h out of the header avoids pulling
+        // its DSO-hidden global into every translation unit that includes passwordKeySource.hpp.
+        constexpr auto PASSWORD_KEY_SOURCE_LOGTAG {"wazuh-manager-remoted:passwordKeySource"};
+
+        const LogFn& logFn()
+        {
+            static const LogFn instance {PASSWORD_KEY_SOURCE_LOGTAG};
+            return instance;
+        }
+
+        constexpr int kMaxReadAttempts {3};
+        constexpr auto kRetryBackoff {std::chrono::milliseconds(20)};
+
+        constexpr std::uint32_t kWatchMask {IN_MODIFY | IN_CLOSE_WRITE | IN_MOVE_SELF | IN_DELETE_SELF};
+
+        std::optional<std::vector<unsigned char>> hashFileOrNullopt(const std::string& path)
+        {
+            try
+            {
+                return Utils::hashFile(path);
+            }
+            catch (const std::exception&)
+            {
+                return std::nullopt;
+            }
+        }
+
+        /// Maximum bytes read for the first line, matching authd's read_password_line() buffer
+        /// (4096 + 1 for the null terminator) exactly.
+        constexpr std::size_t kMaxLineBytes {4096};
+
+        /**
+         * @brief Read and validate the first line of the password file, byte-matching authd's
+         *        own read_password_line() (os_auth/src/auth.c).
+         *
+         * @return The password string on success, std::nullopt on any of: file not open, no
+         *         line read, line filled the buffer without a trailing newline (too long),
+         *         length <= 2 after stripping trailing '\r'/'\n', or the remainder is entirely
+         *         whitespace.
+         */
+        std::optional<std::string> readPasswordLine(const std::string& path)
+        {
+            std::FILE* fp = std::fopen(path.c_str(), "r");
+            if (!fp)
+            {
+                return std::nullopt;
+            }
+
+            std::vector<char> buf(kMaxLineBytes + 1);
+            const bool gotLine = std::fgets(buf.data(), static_cast<int>(buf.size()), fp) != nullptr;
+            std::fclose(fp);
+
+            if (!gotLine)
+            {
+                return std::nullopt;
+            }
+
+            std::size_t len = std::strlen(buf.data());
+
+            // fgets filled the buffer without a newline: the line exceeds the maximum length.
+            if (len == kMaxLineBytes && buf[len - 1] != '\n')
+            {
+                return std::nullopt;
+            }
+
+            while (len > 0 && (buf[len - 1] == '\n' || buf[len - 1] == '\r'))
+            {
+                buf[--len] = '\0';
+            }
+
+            if (len <= 2)
+            {
+                return std::nullopt;
+            }
+
+            bool allSpace = true;
+            for (std::size_t i = 0; i < len; ++i)
+            {
+                if (!std::isspace(static_cast<unsigned char>(buf[i])))
+                {
+                    allSpace = false;
+                    break;
+                }
+            }
+            if (allSpace)
+            {
+                return std::nullopt;
+            }
+
+            return std::string(buf.data(), len);
+        }
+
+        /**
+         * @brief HKDF-SHA256 derive a 32-byte AES-256 key from the password.
+         *
+         * Empty salt, info = "WAZUH-ENROLL-CMAC-KEY" + 0x01 -- see the Agent enrollment chapter
+         * of remoted_module/README.md for a verified known-answer vector (password
+         * "MyEnrollmentSecret123" -> key 0ddc6f7f...667635). The version byte in `info` reserves
+         * room to change this construction later without an ambiguous transition.
+         *
+         * @throws std::runtime_error on an OpenSSL provider failure (missing/misconfigured HKDF
+         *         provider, FIPS mode, etc.) -- global and permanent, same distinction Cmac makes
+         *         between a bad key (per-agent) and a provider failure (everyone fails). Never
+         *         thrown for a merely-short-or-empty password; that is rejected earlier by
+         *         readPasswordLine().
+         */
+        std::vector<std::uint8_t> deriveKeyFromPassword(const std::string& password)
+        {
+            static constexpr unsigned char kInfo[] = {'W', 'A', 'Z', 'U', 'H', '-', 'E', 'N', 'R', 'O', 'L',
+                                                      'L', '-', 'C', 'M', 'A', 'C', '-', 'K', 'E', 'Y', 0x01};
+            constexpr std::size_t kKeyLen = 32; // AES-256
+
+            EVP_KDF* kdf = EVP_KDF_fetch(nullptr, "HKDF", nullptr);
+            if (!kdf)
+            {
+                throw std::runtime_error("EVP_KDF_fetch(HKDF) failed");
+            }
+
+            EVP_KDF_CTX* kctx = EVP_KDF_CTX_new(kdf);
+            EVP_KDF_free(kdf);
+            if (!kctx)
+            {
+                throw std::runtime_error("EVP_KDF_CTX_new failed");
+            }
+
+            int mode = EVP_KDF_HKDF_MODE_EXTRACT_AND_EXPAND;
+            OSSL_PARAM params[5];
+            params[0] = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST, const_cast<char*>("SHA2-256"), 0);
+            params[1] = OSSL_PARAM_construct_octet_string(
+                OSSL_KDF_PARAM_KEY, const_cast<char*>(password.data()), password.size());
+            params[2] = OSSL_PARAM_construct_octet_string(
+                OSSL_KDF_PARAM_INFO, const_cast<unsigned char*>(kInfo), sizeof(kInfo));
+            params[3] = OSSL_PARAM_construct_int(OSSL_KDF_PARAM_MODE, &mode);
+            params[4] = OSSL_PARAM_construct_end();
+            // No salt param -- empty salt, matching the verified known-answer vector.
+
+            std::vector<std::uint8_t> derived(kKeyLen);
+            const int rc = EVP_KDF_derive(kctx, derived.data(), derived.size(), params);
+            EVP_KDF_CTX_free(kctx);
+
+            if (rc != 1)
+            {
+                throw std::runtime_error("EVP_KDF_derive(HKDF) failed");
+            }
+            return derived;
+        }
+    } // namespace
+
+    PasswordKeySource::PasswordKeySource(std::string path, int refreshIntervalSeconds)
+        : m_path(std::move(path))
+        , m_refreshIntervalSeconds(refreshIntervalSeconds > 0 ? refreshIntervalSeconds : kDefaultRefreshIntervalSeconds)
+    {
+        // Report the initial state unconditionally: if Password mode is selected but this file
+        // isn't readable yet (e.g. not synced from the master to a worker), every enrollment
+        // attempt will be rejected 401 until it becomes available -- otherwise invisible.
+        if (reload())
+        {
+            LOGFN_INFO(logFn(), "Enrollment password loaded from '%s'.", m_path.c_str());
+        }
+        else
+        {
+            LOGFN_WARN(logFn(),
+                       "Could not load a usable enrollment password from '%s' at startup; "
+                       "Password-mode enrollment requests will be rejected until it is available.",
+                       m_path.c_str());
+        }
+
+        m_inotifyFd = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
+        if (m_inotifyFd < 0)
+        {
+            LOGFN_WARN(logFn(),
+                       "inotify_init1 failed (errno=%d); authd.pass hot-reload falls back to the %d s poll only.",
+                       errno,
+                       m_refreshIntervalSeconds);
+        }
+        else
+        {
+            m_watchDescriptor = inotify_add_watch(m_inotifyFd, m_path.c_str(), kWatchMask);
+            if (m_watchDescriptor < 0)
+            {
+                LOGFN_WARN(logFn(),
+                           "Could not watch '%s' for changes (errno=%d); hot-reload falls back to the %d s poll only.",
+                           m_path.c_str(),
+                           errno,
+                           m_refreshIntervalSeconds);
+            }
+        }
+
+        m_stopEventFd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+        if (m_stopEventFd < 0)
+        {
+            LOGFN_WARN(logFn(),
+                       "eventfd failed (errno=%d); destruction may block up to %d s.",
+                       errno,
+                       m_refreshIntervalSeconds);
+        }
+
+        try
+        {
+            m_watcherThread = std::thread(&PasswordKeySource::watcherLoop, this);
+        }
+        catch (...)
+        {
+            closeWatchFds();
+            throw;
+        }
+    }
+
+    void PasswordKeySource::closeWatchFds() noexcept
+    {
+        if (m_watchDescriptor >= 0 && m_inotifyFd >= 0)
+        {
+            inotify_rm_watch(m_inotifyFd, m_watchDescriptor);
+            m_watchDescriptor = -1;
+        }
+        if (m_inotifyFd >= 0)
+        {
+            close(m_inotifyFd);
+            m_inotifyFd = -1;
+        }
+        if (m_stopEventFd >= 0)
+        {
+            close(m_stopEventFd);
+            m_stopEventFd = -1;
+        }
+    }
+
+    PasswordKeySource::~PasswordKeySource()
+    {
+        try
+        {
+            if (m_stopEventFd >= 0)
+            {
+                const std::uint64_t one {1};
+                if (write(m_stopEventFd, &one, sizeof(one)) < 0)
+                {
+                    LOGFN_DEBUG1(logFn(), "Could not signal the authd.pass watcher to stop (errno=%d).", errno);
+                }
+            }
+
+            if (m_watcherThread.joinable())
+            {
+                m_watcherThread.join();
+            }
+        }
+        catch (...) // NOLINT(bugprone-empty-catch)
+        {
+        }
+
+        closeWatchFds();
+    }
+
+    void PasswordKeySource::watcherLoop()
+    {
+        try
+        {
+            watcherLoopBody();
+        }
+        catch (const std::exception& e)
+        {
+            LOGFN_ERROR(logFn(),
+                        "The authd.pass watcher thread stopped on an unexpected exception: %s. The enrollment "
+                        "password will not be hot-reloaded until wazuh-remoted is restarted.",
+                        e.what());
+        }
+        catch (...)
+        {
+            LOGFN_ERROR(logFn(),
+                        "The authd.pass watcher thread stopped on a non-standard exception. The enrollment "
+                        "password will not be hot-reloaded until wazuh-remoted is restarted.");
+        }
+    }
+
+    void PasswordKeySource::watcherLoopBody()
+    {
+        LOGFN_DEBUG1(logFn(), "authd.pass watcher thread started (refresh interval %d s).", m_refreshIntervalSeconds);
+
+        while (true)
+        {
+            struct pollfd fds[2] {};
+            int nfds = 0;
+            int inotifyIdx = -1;
+            int stopIdx = -1;
+
+            if (m_inotifyFd >= 0)
+            {
+                inotifyIdx = nfds;
+                fds[nfds].fd = m_inotifyFd;
+                fds[nfds].events = POLLIN;
+                ++nfds;
+            }
+            if (m_stopEventFd >= 0)
+            {
+                stopIdx = nfds;
+                fds[nfds].fd = m_stopEventFd;
+                fds[nfds].events = POLLIN;
+                ++nfds;
+            }
+
+            const int timeoutMs = m_refreshIntervalSeconds * 1000;
+            const int ready = poll(fds, static_cast<nfds_t>(nfds), timeoutMs);
+
+            if (ready < 0)
+            {
+                if (errno == EINTR)
+                {
+                    continue;
+                }
+                LOGFN_WARN(logFn(), "poll() on the authd.pass watcher failed (errno=%d).", errno);
+                std::this_thread::sleep_for(std::chrono::seconds(m_refreshIntervalSeconds));
+                continue;
+            }
+
+            if (stopIdx >= 0 && (fds[stopIdx].revents & POLLIN))
+            {
+                break;
+            }
+
+            if (inotifyIdx >= 0 && (fds[inotifyIdx].revents & POLLIN))
+            {
+                drainInotifyEvents();
+            }
+
+            if (fileLooksChanged())
+            {
+                if (reload())
+                {
+                    LOGFN_INFO(logFn(), "Enrollment password reloaded from '%s'.", m_path.c_str());
+                }
+                else if (const auto d = m_unreadableThrottle.record())
+                {
+                    LOGFN_WARN(logFn(),
+                               "'%s' is not readable or its content is invalid (errno=%d); Password-mode "
+                               "enrollment requests will be rejected. %llu failed attempt(s) in the last %d s.",
+                               m_path.c_str(),
+                               errno,
+                               static_cast<unsigned long long>(d.total),
+                               remoted::common::LogThrottle::kDefaultWindowSeconds);
+                }
+            }
+        }
+
+        LOGFN_DEBUG1(logFn(), "authd.pass watcher thread stopped.");
+    }
+
+    void PasswordKeySource::drainInotifyEvents()
+    {
+        if (m_inotifyFd < 0)
+        {
+            return;
+        }
+
+        alignas(struct inotify_event) char buffer[4096];
+        bool watchInvalidated = false;
+
+        while (true)
+        {
+            const ssize_t bytesRead = read(m_inotifyFd, buffer, sizeof(buffer));
+            if (bytesRead <= 0)
+            {
+                break;
+            }
+
+            ssize_t offset = 0;
+            while (offset < bytesRead)
+            {
+                const auto* event = reinterpret_cast<const struct inotify_event*>(buffer + offset);
+                if (event->mask & (IN_IGNORED | IN_MOVE_SELF | IN_DELETE_SELF))
+                {
+                    watchInvalidated = true;
+                }
+                offset += static_cast<ssize_t>(sizeof(struct inotify_event) + event->len);
+            }
+        }
+
+        if (!watchInvalidated)
+        {
+            return;
+        }
+
+        if (m_watchDescriptor >= 0)
+        {
+            inotify_rm_watch(m_inotifyFd, m_watchDescriptor);
+        }
+        m_watchDescriptor = inotify_add_watch(m_inotifyFd, m_path.c_str(), kWatchMask);
+        if (m_watchDescriptor < 0)
+        {
+            LOGFN_WARN(logFn(),
+                       "Could not re-arm the authd.pass watch after it was invalidated (errno=%d); "
+                       "falling back to the %d s poll only.",
+                       errno,
+                       m_refreshIntervalSeconds);
+        }
+        else
+        {
+            LOGFN_DEBUG1(logFn(), "authd.pass watch re-armed after the file was replaced.");
+        }
+    }
+
+    bool PasswordKeySource::fileLooksChanged()
+    {
+        std::lock_guard<std::mutex> lock(m_reloadMutex);
+
+        const auto currentHash = hashFileOrNullopt(m_path);
+        if (!currentHash)
+        {
+            return false;
+        }
+        return !m_hasBaseline || *currentHash != m_lastHash;
+    }
+
+    bool PasswordKeySource::reload()
+    {
+        std::lock_guard<std::mutex> reloadLock(m_reloadMutex);
+
+        for (int attempt = 0; attempt < kMaxReadAttempts; ++attempt)
+        {
+            const auto preHash = hashFileOrNullopt(m_path);
+            if (!preHash)
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                m_derivedKey.reset();
+                return false;
+            }
+
+            auto password = readPasswordLine(m_path);
+
+            const auto postHash = hashFileOrNullopt(m_path);
+            if (postHash && *postHash == *preHash)
+            {
+                if (!password)
+                {
+                    std::lock_guard<std::mutex> lock(m_mutex);
+                    m_derivedKey.reset();
+                    m_hasBaseline = true;
+                    m_lastHash = *preHash;
+                    return false;
+                }
+
+                std::optional<std::vector<std::uint8_t>> derived;
+                try
+                {
+                    derived = deriveKeyFromPassword(*password);
+                }
+                catch (const std::exception& e)
+                {
+                    // Global/permanent (OpenSSL provider failure), not per-attempt -- log loudly
+                    // and fail closed, same as Cmac's CmacProviderError distinction.
+                    LOGFN_ERROR(logFn(), "Could not derive the enrollment CMAC key: %s.", e.what());
+                    std::lock_guard<std::mutex> lock(m_mutex);
+                    m_derivedKey.reset();
+                    m_hasBaseline = true;
+                    m_lastHash = *preHash;
+                    return false;
+                }
+
+                {
+                    std::lock_guard<std::mutex> lock(m_mutex);
+                    m_derivedKey = std::move(derived);
+                }
+                m_hasBaseline = true;
+                m_lastHash = *preHash;
+                return true;
+            }
+
+            LOGFN_DEBUG1(logFn(),
+                         "authd.pass changed while reloading (attempt %d/%d), retrying.",
+                         attempt + 1,
+                         kMaxReadAttempts);
+            if (attempt + 1 < kMaxReadAttempts)
+            {
+                std::this_thread::sleep_for(kRetryBackoff);
+            }
+        }
+
+        LOGFN_WARN(logFn(), "authd.pass kept changing across %d attempts; keeping the previous key.", kMaxReadAttempts);
+        return static_cast<bool>(currentKey());
+    }
+
+    std::optional<std::vector<std::uint8_t>> PasswordKeySource::currentKey() const
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_derivedKey;
+    }
+
+} // namespace remoted::auth

--- a/src/remoted/remoted_module/src/auth/passwordKeySource.hpp
+++ b/src/remoted/remoted_module/src/auth/passwordKeySource.hpp
@@ -1,0 +1,127 @@
+/*
+ * Wazuh auth middleware (framework-agnostic)
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 19, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "common/logThrottle.hpp" // Safe in a header: LogThrottle deliberately does not log.
+
+namespace remoted::auth
+{
+
+    /**
+     * @brief Turns authd's enrollment password (etc/authd.pass) into a CMAC-usable AES key,
+     *        hot-reloaded on change. Backs Password-mode enrollment auth (see EnrollmentAuthenticator).
+     *
+     * Strictly read-only, on every node -- master or worker alike. authd itself is asymmetric:
+     * only the master ever generates the password file (w_authd_load_password); a worker only
+     * reads it, and a background watcher (run_authpass_watcher, os_auth/src/main-server.c) picks
+     * it up once the cluster's own file sync delivers it (framework/wazuh/core/cluster/cluster.json
+     * already lists authd.pass alongside client.keys). This class must never create or write the
+     * file -- generation stays authd's exclusive job.
+     *
+     * Parsing byte-matches authd's own read_password_line() (os_auth/src/auth.c): first line
+     * only, up to 4096 bytes, trailing '\r'/'\n' stripped, rejected if the remaining length is
+     * <= 2 or entirely whitespace. This must stay exact: the manager's two enrollment paths
+     * (this one and legacy port 1515) have to agree on which passwords are valid, or an operator
+     * could set a password that authd accepts but remoted silently treats as absent (or vice
+     * versa) -- either way, a fail-closed contract that's supposed to be consistent stops being
+     * one.
+     *
+     * The signing key is not the password itself: currentKey() returns a 32-byte AES-256 key
+     * derived via HKDF-SHA256 (empty salt, info = "WAZUH-ENROLL-CMAC-KEY" + 0x01), since Cmac
+     * needs an exact 16/24/32-byte key and a password is arbitrary length. Derivation runs once
+     * per file change and is cached -- never per request. See the Agent enrollment chapter of
+     * remoted_module/README.md for a verified worked example (known-answer vector).
+     *
+     * Hot-reload mirrors Keystore exactly (inotify + a periodic fallback poll + content-hash
+     * change detection, so a rewrite caught mid-read can never be adopted torn) -- the two files
+     * have the same operational shape: an operator/cluster-sync-managed secret a running process
+     * must notice without a restart.
+     */
+    class PasswordKeySource
+    {
+    public:
+        /// Path to authd's enrollment password file, relative to the manager's home directory.
+        static constexpr const char* kDefaultPath = "etc/authd.pass";
+
+        /// Built-in refresh interval when the caller passes <=0 (matches Keystore's own default).
+        static constexpr int kDefaultRefreshIntervalSeconds = 10;
+
+        /**
+         * @param path Path to authd's password file. An initial reload() runs synchronously in
+         *             the constructor; a missing or invalid file is not an error -- currentKey()
+         *             simply starts at nullopt (fail closed for Password mode).
+         * @param refreshIntervalSeconds How often the background watcher re-checks the file as a
+         *             fallback to the inotify subscription (seconds). <=0 -> kDefaultRefreshIntervalSeconds.
+         */
+        explicit PasswordKeySource(std::string path = kDefaultPath,
+                                   int refreshIntervalSeconds = kDefaultRefreshIntervalSeconds);
+
+        ~PasswordKeySource();
+
+        PasswordKeySource(const PasswordKeySource&) = delete;
+        PasswordKeySource& operator=(const PasswordKeySource&) = delete;
+
+        /**
+         * @brief Re-read the password file and re-derive the key.
+         *
+         * Always re-reads when called (the background watcher decides separately whether calling
+         * this is warranted -- see the class comment). Guarded against a concurrent rewrite the
+         * same way Keystore::reload() is: the file's content hash is captured before and after
+         * reading, and the read is retried (a few times, briefly) if they don't match.
+         *
+         * @return true if a usable key is cached after this call, false otherwise (missing,
+         *         unreadable, invalid content, an unstable/torn read across every retry, or an
+         *         OpenSSL-level HKDF failure). false always means currentKey() will return
+         *         nullopt until the next successful reload.
+         */
+        bool reload();
+
+        /**
+         * @return The cached derived key (32 bytes), or nullopt if the password file is missing,
+         *         unreadable, or its content fails authd's own password-validity rules.
+         */
+        std::optional<std::vector<std::uint8_t>> currentKey() const;
+
+    private:
+        void watcherLoop();
+        void watcherLoopBody();
+        void closeWatchFds() noexcept;
+        void drainInotifyEvents();
+        bool fileLooksChanged();
+
+        std::string m_path;
+        mutable std::mutex m_mutex;
+        std::optional<std::vector<std::uint8_t>> m_derivedKey;
+
+        int m_refreshIntervalSeconds;
+        int m_inotifyFd {-1};
+        int m_watchDescriptor {-1};
+        int m_stopEventFd {-1};
+        std::thread m_watcherThread;
+
+        std::mutex m_reloadMutex;
+        bool m_hasBaseline {false};
+        std::vector<std::uint8_t> m_lastHash;
+
+        /// Throttles the "authd.pass is unreadable" warning: the watcher retries every
+        /// m_refreshIntervalSeconds, so an unreadable file would otherwise flood wazuh-manager.log.
+        remoted::common::LogThrottle m_unreadableThrottle;
+    };
+
+} // namespace remoted::auth

--- a/src/remoted/remoted_module/src/auth/passwordKeySource.hpp
+++ b/src/remoted/remoted_module/src/auth/passwordKeySource.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include <mutex>
 #include <optional>
@@ -114,6 +115,14 @@ namespace remoted::auth
         int m_watchDescriptor {-1};
         int m_stopEventFd {-1};
         std::thread m_watcherThread;
+
+        /// Fallback stop signal, checked every loop iteration independent of m_stopEventFd: if
+        /// eventfd() failed at construction (m_stopEventFd stays -1), poll() has no fd to wake it
+        /// early, but this flag still gets noticed the next time poll()'s own timeout elapses (at
+        /// most m_refreshIntervalSeconds later) -- so the watcher thread is always joinable within
+        /// a bounded time, never permanently, which the destructor's join() would otherwise wait
+        /// on forever.
+        std::atomic<bool> m_stopping {false};
 
         std::mutex m_reloadMutex;
         bool m_hasBaseline {false};

--- a/src/remoted/remoted_module/src/common/zstdDecoder.cpp
+++ b/src/remoted/remoted_module/src/common/zstdDecoder.cpp
@@ -30,6 +30,17 @@ namespace remoted::common
     namespace
     {
         constexpr std::size_t kChunkSize = 64U * 1024U;
+
+        // Hard ceiling on the window size a frame may DECLARE, independent of how much in-flight
+        // budget happens to be free. The window size is attacker-chosen in a ~50-byte frame header
+        // and drives the decoder's up-front allocation, so without this a tiny request could make
+        // the manager reserve zstd's own limit (windowLog 27 = 128 MiB) of the budget shared with
+        // every other route. 8 MiB is windowLog 23, what zstd itself uses at its highest normal
+        // compression levels and far above anything an agent compressing an event batch or an
+        // enrollment body produces -- a frame declaring more is refused with TooLarge (413) rather
+        // than served. This is the equivalent of zstd's own recommended ZSTD_d_windowLogMax for
+        // untrusted input, applied before any allocation happens.
+        constexpr unsigned long long kMaxDeclaredWindowSize = 8ULL * 1024ULL * 1024ULL;
     } // namespace
 
     std::variant<std::string, ZstdDecodeError>
@@ -52,14 +63,21 @@ namespace remoted::common
             return ZstdDecodeError::Malformed;
         }
 
+        // Refuse an over-large DECLARED window before sizing or reserving anything: see
+        // kMaxDeclaredWindowSize. Checked against the header's own value rather than the sizing
+        // helper's output so the bound stays a statement about what the frame claims, which is the
+        // attacker-controlled quantity.
+        if (header.windowSize > kMaxDeclaredWindowSize)
+        {
+            return ZstdDecodeError::TooLarge;
+        }
+
         // What the decoder will really allocate for its window/output buffers, per zstd's own
         // sizing helper -- not just header.windowSize, which is only part of that total. Guard the
         // 64-bit -> size_t narrowing: on a 32-bit build a frame could legitimately declare more
         // than size_t can hold, which we can't satisfy regardless.
-        const unsigned long long bufferSize =
-            ZSTD_decodingBufferSize_min(header.windowSize, header.frameContentSize);
-        if (ZSTD_isError(static_cast<std::size_t>(bufferSize)) ||
-            bufferSize > std::numeric_limits<std::size_t>::max())
+        const unsigned long long bufferSize = ZSTD_decodingBufferSize_min(header.windowSize, header.frameContentSize);
+        if (ZSTD_isError(static_cast<std::size_t>(bufferSize)) || bufferSize > std::numeric_limits<std::size_t>::max())
         {
             return ZstdDecodeError::TooLarge;
         }
@@ -162,7 +180,18 @@ namespace remoted::common
                     // reserving bytes of their own), so this is a live contention point.
                     if (!growOutputCapacity(target))
                     {
-                        return ZstdDecodeError::TooLarge;
+                        // The doubling target is only an allocation-granularity optimization, so a
+                        // refusal of it is NOT by itself "this frame is too large": retry at exactly
+                        // the bytes needed. This matters for a caller enforcing a ceiling smaller
+                        // than kChunkSize (/enroll caps the decoded body at 16 KiB) -- without the
+                        // retry, the very first growth of any frame that declares no decompressed
+                        // size asks for a full 64 KiB and every such request would be rejected 413
+                        // no matter how few bytes it really decodes to. The ceiling has to bound
+                        // real decoded size, not the growth step used to get there.
+                        if (target == needed || !growOutputCapacity(needed))
+                        {
+                            return ZstdDecodeError::TooLarge;
+                        }
                     }
                 }
                 output.append(chunk.data(), out.pos);

--- a/src/remoted/remoted_module/src/control/controlHandler.cpp
+++ b/src/remoted/remoted_module/src/control/controlHandler.cpp
@@ -14,12 +14,10 @@
 #include "common/vdClient.hpp"
 #include "json.hpp"
 #include "loggerHelper.h"
-#include <array>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <mutex>
-#include <sstream>
 #include <string>
 #include <thread>
 #include <utility>
@@ -68,54 +66,6 @@ namespace remoted::control
         {
             return std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch())
                 .count();
-        }
-
-        // Numeric-only version comparison of MAJOR.MINOR.PATCH[.EXTRA]. Everything
-        // after '-'/'+' is discarded, matching the legacy behavior of
-        // compare_wazuh_versions(..., ignore_stage=false).
-        int compareVersions(const std::string& v1, const std::string& v2)
-        {
-            auto parseParts = [](const std::string& v) -> std::array<int, 4>
-            {
-                std::array<int, 4> parts {0, 0, 0, 0};
-                // Strip leading 'v' or 'V' if present
-                std::string version = v;
-                if (!version.empty() && (version[0] == 'v' || version[0] == 'V'))
-                {
-                    version = version.substr(1);
-                }
-
-                size_t pos = version.find_first_of("+-");
-                std::string numericPart = (pos != std::string::npos) ? version.substr(0, pos) : version;
-
-                std::istringstream iss(numericPart);
-                std::string token;
-                int i = 0;
-                while (std::getline(iss, token, '.') && i < static_cast<int>(parts.size()))
-                {
-                    try
-                    {
-                        parts[i++] = std::stoi(token);
-                    }
-                    catch (...)
-                    {
-                        break;
-                    }
-                }
-                return parts;
-            };
-
-            auto p1 = parseParts(v1);
-            auto p2 = parseParts(v2);
-
-            for (size_t i = 0; i < p1.size(); ++i)
-            {
-                if (p1[i] < p2[i])
-                    return -1;
-                if (p1[i] > p2[i])
-                    return 1;
-            }
-            return 0;
         }
 
         // Rebuild the raw group CSV wdb returned (no URL-encoding, matches wdb).
@@ -181,9 +131,8 @@ namespace remoted::control
             incStartup(m_metrics);
 
             const bool versionMalformed = !isValidVersion(data.version);
-            const bool versionTooHigh =
-                !versionMalformed && !m_config.allowHigherVersions &&
-                compareVersions(m_config.managerVersion, data.version) < 0;
+            const bool versionTooHigh = !versionMalformed && !m_config.allowHigherVersions &&
+                                        compareVersions(m_config.managerVersion, data.version) < 0;
 
             if (versionMalformed || versionTooHigh)
             {

--- a/src/remoted/remoted_module/src/control/controlTypes.hpp
+++ b/src/remoted/remoted_module/src/control/controlTypes.hpp
@@ -13,11 +13,13 @@
 #define _REMOTED_CONTROL_TYPES_HPP
 
 #include "json.hpp"
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <optional>
 #include <regex>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -84,6 +86,62 @@ namespace remoted::control
 
         static const std::regex versionRegex(R"(^[vV]?\d+(\.\d+){0,3}([+\-][A-Za-z0-9.\-]+)?$)");
         return std::regex_match(version, versionRegex);
+    }
+
+    /**
+     * @brief Numeric-only comparison of MAJOR.MINOR.PATCH[.EXTRA] version strings.
+     *
+     * Everything after '-'/'+' is discarded, matching the legacy behavior of
+     * compare_wazuh_versions(..., ignore_stage=false). Shared by /control (its own
+     * allow_higher_versions check) and /enroll (authd's local `add` path has no version check
+     * at all, so remoted enforces it itself) -- kept in one place so the two enrollment paths
+     * can never silently diverge on what "too new" means.
+     *
+     * @return -1 if v1 < v2, 1 if v1 > v2, 0 if equal (each unparsed/missing part treated as 0).
+     */
+    inline int compareVersions(const std::string& v1, const std::string& v2)
+    {
+        auto parseParts = [](const std::string& v) -> std::array<int, 4>
+        {
+            std::array<int, 4> parts {0, 0, 0, 0};
+            // Strip leading 'v' or 'V' if present
+            std::string version = v;
+            if (!version.empty() && (version[0] == 'v' || version[0] == 'V'))
+            {
+                version = version.substr(1);
+            }
+
+            size_t pos = version.find_first_of("+-");
+            std::string numericPart = (pos != std::string::npos) ? version.substr(0, pos) : version;
+
+            std::istringstream iss(numericPart);
+            std::string token;
+            int i = 0;
+            while (std::getline(iss, token, '.') && i < static_cast<int>(parts.size()))
+            {
+                try
+                {
+                    parts[i++] = std::stoi(token);
+                }
+                catch (...)
+                {
+                    break;
+                }
+            }
+            return parts;
+        };
+
+        auto p1 = parseParts(v1);
+        auto p2 = parseParts(v2);
+
+        for (size_t i = 0; i < p1.size(); ++i)
+        {
+            if (p1[i] < p2[i])
+                return -1;
+            if (p1[i] > p2[i])
+                return 1;
+        }
+        return 0;
     }
 
     struct Task

--- a/src/remoted/remoted_module/src/decoding/bodyDecoder.cpp
+++ b/src/remoted/remoted_module/src/decoding/bodyDecoder.cpp
@@ -69,14 +69,14 @@ namespace remoted::decoding
         return ContentEncoding::Unsupported;
     }
 
-    BodyDecoder::BodyDecoder(remoted::http::IHttpServer& server, bool enabled)
+    BodyDecoder::BodyDecoder(remoted::http::IHttpServer& server, bool enabled, std::size_t maxDecodedSize)
         : m_server {server}
         , m_enabled {enabled}
+        , m_maxDecodedSize {maxDecodedSize}
     {
     }
 
-    remoted::auth::AuthError BodyDecoder::decode(ContentEncoding encoding,
-                                                     remoted::auth::Payload& payload) const
+    remoted::auth::AuthError BodyDecoder::decode(ContentEncoding encoding, remoted::auth::Payload& payload) const
     {
         switch (encoding)
         {
@@ -108,14 +108,39 @@ namespace remoted::decoding
             // already freed the buffers it stood for, and holding it longer would starve the budget
             // for memory nobody is using.
             std::optional<remoted::http::InFlightBudget::Reservation> windowReservation;
+            // Tracked independently of outputReservation's own (shared-budget) size: m_maxDecodedSize
+            // is a SEPARATE, smaller ceiling this instance imposes on itself (see the constructor's
+            // doc comment) -- refusing growth here means the shared budget never sees the request at
+            // all past this point, not just that this decoder declines to use more of what's free.
+            std::size_t decodedSoFar = 0;
             decoded = remoted::common::zstdDecode(
                 payload.bytes(),
+                // Deliberately NOT bounded by m_maxDecodedSize: the window is the decoder's working
+                // buffer, whose size a streaming compressor picks from its compression level and
+                // not from how few bytes it happens to emit (zstd level 3 declares a 2 MiB window
+                // for a 200-byte body when the input size isn't pledged up front). Capping it at a
+                // 16 KiB decoded ceiling would reject every streaming-compressed /enroll request.
+                // The attacker-controlled part -- an arbitrarily large DECLARED window driving the
+                // reservation from a ~50-byte frame header -- is bounded instead by
+                // kMaxDeclaredWindowSize in zstdDecoder.cpp, before any allocation happens.
                 [this, &windowReservation](std::size_t bytes)
                 {
                     windowReservation = m_server.tryReserveInFlightBytes(bytes);
                     return windowReservation.has_value();
                 },
-                [&outputReservation](std::size_t more) { return outputReservation->grow(more); });
+                [this, &outputReservation, &decodedSoFar](std::size_t more)
+                {
+                    if (m_maxDecodedSize != 0 && decodedSoFar + more > m_maxDecodedSize)
+                    {
+                        return false;
+                    }
+                    if (!outputReservation->grow(more))
+                    {
+                        return false;
+                    }
+                    decodedSoFar += more;
+                    return true;
+                });
         }
 
         if (std::holds_alternative<remoted::common::ZstdDecodeError>(decoded))

--- a/src/remoted/remoted_module/src/decoding/bodyDecoder.hpp
+++ b/src/remoted/remoted_module/src/decoding/bodyDecoder.hpp
@@ -12,8 +12,10 @@
 #ifndef _REMOTED_DECODING_BODY_DECODER_HPP
 #define _REMOTED_DECODING_BODY_DECODER_HPP
 
-#include "iBodyDecoder.hpp"             // ContentEncoding, IBodyDecoder
 #include "http_server/IHttpServer.hpp" // remoted::http::IHttpServer
+#include "iBodyDecoder.hpp"            // ContentEncoding, IBodyDecoder
+
+#include <cstddef>
 
 namespace remoted::decoding
 {
@@ -54,22 +56,33 @@ namespace remoted::decoding
     {
     public:
         /**
-         * @param server  Transport owning the in-flight byte budget. Must outlive this decoder (both
-         *                are owned by the module facade).
-         * @param enabled Whether `Content-Encoding: zstd` is accepted at all. Takes the ALREADY
-         *                RESOLVED value of `remoted.http_content_encoding_enabled`, read in
-         *                secure.c and carried on the C-ABI config struct. This class deliberately does
-         *                NOT read configuration itself: nothing in the C++ module does, so all config
-         *                keeps entering through the single C-ABI door and this stays testable with a
-         *                plain bool.
+         * @param server        Transport owning the in-flight byte budget. Must outlive this decoder
+         *                      (both are owned by the module facade).
+         * @param enabled       Whether `Content-Encoding: zstd` is accepted at all. Takes the ALREADY
+         *                      RESOLVED value of `remoted.http_content_encoding_enabled`, read in
+         *                      secure.c and carried on the C-ABI config struct. This class deliberately
+         *                      does NOT read configuration itself: nothing in the C++ module does, so
+         *                      all config keeps entering through the single C-ABI door and this stays
+         *                      testable with a plain bool.
+         * @param maxDecodedSize 0 (default) -> no cap beyond whatever the shared in-flight byte budget
+         *                      allows -- what every AuthGateway route uses, since each one already
+         *                      requires a verified credential before decode() ever runs, closing the
+         *                      amplification lever this cap exists for. A nonzero value additionally
+         *                      refuses to grow the decoded output past it, regardless of how much
+         *                      budget is free -- for a route (namely /enroll's Open mode, which has NO
+         *                      credential check by design) where an unauthenticated peer can reach
+         *                      decode() and a small, highly-compressed frame could otherwise hold a
+         *                      large chunk of the SHARED budget (the same one /stateless and friends
+         *                      draw from) for as long as decompression takes.
          */
-        BodyDecoder(remoted::http::IHttpServer& server, bool enabled);
+        explicit BodyDecoder(remoted::http::IHttpServer& server, bool enabled, std::size_t maxDecodedSize = 0);
 
         remoted::auth::AuthError decode(ContentEncoding encoding, remoted::auth::Payload& payload) const override;
 
     private:
         remoted::http::IHttpServer& m_server;
         bool m_enabled;
+        std::size_t m_maxDecodedSize;
     };
 
 } // namespace remoted::decoding

--- a/src/remoted/remoted_module/src/endpoints/authGateway.cpp
+++ b/src/remoted/remoted_module/src/endpoints/authGateway.cpp
@@ -11,9 +11,9 @@
 
 #include "authGateway.hpp"
 
+#include "http_server/headerUtils.hpp"
 #include "loggerHelper.h"
 
-#include <cctype>
 #include <cstdint>
 #include <ctime>
 #include <exception>
@@ -22,6 +22,8 @@
 #include <string_view>
 #include <utility>
 #include <variant>
+
+using remoted::http::headerValue;
 
 namespace
 {
@@ -68,32 +70,6 @@ namespace
             case remoted::http::Method::Patch: return "PATCH";
         }
         return "GET";
-    }
-
-    // Case-insensitive header lookup (HTTP header names are case-insensitive).
-    std::string headerValue(const std::unordered_map<std::string, std::string>& headers, const std::string& lowerName)
-    {
-        for (const auto& [name, value] : headers)
-        {
-            if (name.size() != lowerName.size())
-            {
-                continue;
-            }
-            bool equal = true;
-            for (std::size_t i = 0; i < name.size(); ++i)
-            {
-                if (static_cast<char>(std::tolower(static_cast<unsigned char>(name[i]))) != lowerName[i])
-                {
-                    equal = false;
-                    break;
-                }
-            }
-            if (equal)
-            {
-                return value;
-            }
-        }
-        return {};
     }
 
 } // namespace

--- a/src/remoted/remoted_module/src/endpoints/endpoint.cpp
+++ b/src/remoted/remoted_module/src/endpoints/endpoint.cpp
@@ -47,11 +47,14 @@ namespace
      */
     enum class RejectionKind
     {
-        ClientFault,   ///< Malformed/unauthenticated request. DEBUG2, unthrottled.
-        ClockSkew,     ///< Timestamp outside the accepted window -> auth_max_request_age/_future_skew.
-        BodyTooLarge,  ///< Over the authenticated-body cap -> auth_max_body_size.
-        UnusableKey,   ///< The agent exists but its client.keys key does not decode.
-        AgentMismatch, ///< An authenticated agent claimed a different agent's id (security signal).
+        ClientFault,              ///< Malformed/unauthenticated request. DEBUG2, unthrottled.
+        ClockSkew,                ///< Timestamp outside the accepted window -> auth_max_request_age/_future_skew.
+        BodyTooLarge,             ///< Over the authenticated-body cap -> auth_max_body_size.
+        UnusableKey,              ///< The agent exists but its client.keys key does not decode.
+        AgentMismatch,            ///< An authenticated agent claimed a different agent's id (security signal).
+        EnrollmentKeyUnavailable, ///< /enroll's Password mode: etc/authd.pass unavailable, or AES-CMAC
+                                  ///< unavailable manager-wide. Deliberately NOT UnusableKey -- there
+                                  ///< is no agent and no client.keys entry yet to "re-enroll".
     };
 
     RejectionKind classify(remoted::auth::AuthError err)
@@ -62,6 +65,7 @@ namespace
             case remoted::auth::AuthError::FutureRequest: return RejectionKind::ClockSkew;
             case remoted::auth::AuthError::BodyTooLarge: return RejectionKind::BodyTooLarge;
             case remoted::auth::AuthError::MissingKey: return RejectionKind::UnusableKey;
+            case remoted::auth::AuthError::EnrollmentKeyUnavailable: return RejectionKind::EnrollmentKeyUnavailable;
             case remoted::auth::AuthError::PayloadAgentMismatch: return RejectionKind::AgentMismatch;
             // Already reported by AuthMiddleware's own throttled WARN, which names the agent id and
             // the peer address (neither reaches this funnel). Kept at DEBUG2 to avoid a second line.
@@ -79,6 +83,7 @@ namespace
         static LogThrottle bodyTooLargeThrottle;
         static LogThrottle unusableKeyThrottle;
         static LogThrottle agentMismatchThrottle;
+        static LogThrottle enrollmentKeyUnavailableThrottle;
 
         // NOTE: every argument below must stay allocation-free (literals and integers only). This
         // function runs on every rejected request, and LOGFN_DEBUG2's guard does NOT currently
@@ -117,6 +122,20 @@ namespace
                                "Rejected %llu request(s) in the last %d s from agent(s) whose key could not be used: "
                                "the key column in client.keys did not decode to a 16, 24 or 32-byte AES key. "
                                "Re-enroll the affected agent(s).",
+                               static_cast<unsigned long long>(d.total),
+                               LogThrottle::kDefaultWindowSeconds);
+                }
+                break;
+
+            case RejectionKind::EnrollmentKeyUnavailable:
+                if (const auto d = enrollmentKeyUnavailableThrottle.record())
+                {
+                    LOGFN_WARN(logFn(),
+                               "Rejected %llu Password-mode /enroll request(s) in the last %d s: the enrollment "
+                               "password key is unavailable (etc/authd.pass is missing, unreadable, invalid, or -- "
+                               "on a cluster worker -- not yet synced from the master). Password-mode enrollment "
+                               "will keep failing until it becomes available; this is NOT an agent credential "
+                               "problem, so re-enrolling will not fix it.",
                                static_cast<unsigned long long>(d.total),
                                LogThrottle::kDefaultWindowSeconds);
                 }

--- a/src/remoted/remoted_module/src/enrollment/authdClient.cpp
+++ b/src/remoted/remoted_module/src/enrollment/authdClient.cpp
@@ -219,7 +219,29 @@ namespace remoted::enrollment
                 m_queue.pop();
                 lock.unlock();
 
-                req.callback(performRequest(req.request));
+                // This runs on a bare std::thread (m_workers), not on the HTTP transport's own
+                // worker pool -- RestinioHttpServer's own try/catch around a route handler's
+                // SYNCHRONOUS call (see its comment about asio::thread_pool terminating on any
+                // escaping exception) does NOT cover this: addAgent() already returned by the
+                // time this runs, later, on a different thread entirely. An uncaught exception
+                // here -- from performRequest() itself (e.g. nlohmann::json::dump()/bad_alloc
+                // building the wire request, before its own try blocks even start) or from
+                // req.callback() (e.g. mapAuthdResult()'s JSON building, or IHttpResponder::send()
+                // racing an already-torn-down connection) -- would escape this thread's entry
+                // function and std::terminate the entire remoted daemon, taking down every other
+                // agent's connection along with the one enrollment request that triggered it.
+                try
+                {
+                    req.callback(performRequest(req.request));
+                }
+                catch (const std::exception& e)
+                {
+                    LOGFN_ERROR(logFn(), "AuthdClient worker thread caught an exception: %s", e.what());
+                }
+                catch (...)
+                {
+                    LOGFN_ERROR(logFn(), "AuthdClient worker thread caught a non-standard exception.");
+                }
             }
         }
 

--- a/src/remoted/remoted_module/src/enrollment/authdClient.cpp
+++ b/src/remoted/remoted_module/src/enrollment/authdClient.cpp
@@ -11,18 +11,20 @@
 
 #include "authdClient.hpp"
 
+#include <sys/socket.h>
+#include <sys/time.h>
+
 #include <condition_variable>
 #include <cstring>
 #include <mutex>
 #include <queue>
 #include <string_view>
 #include <thread>
+#include <vector>
 
 #include "common/logThrottle.hpp"
-#include "epollWrapper.hpp"
 #include "json.hpp"
 #include "loggerHelper.h"
-#include "socketClient.hpp"
 #include "socketWrapper.hpp"
 
 namespace remoted::enrollment
@@ -89,13 +91,19 @@ namespace remoted::enrollment
              bool isWorkerNode,
              std::uint32_t connectTimeoutMs,
              std::uint32_t responseTimeoutMs,
-             std::uint32_t maxQueueSize)
+             std::uint32_t maxQueueSize,
+             std::uint32_t workerThreads)
             : m_socketPath(std::move(socketPath))
             , m_connectTimeoutMs(connectTimeoutMs != 0 ? connectTimeoutMs : AuthdClient::kDefaultConnectTimeoutMs)
             , m_responseTimeoutMs(AuthdClient::resolveResponseTimeoutMs(responseTimeoutMs, isWorkerNode))
             , m_maxQueueSize(maxQueueSize != 0 ? maxQueueSize : AuthdClient::kDefaultMaxQueueSize)
         {
-            m_worker = std::thread([this] { workerLoop(); });
+            const auto poolSize = workerThreads != 0 ? workerThreads : AuthdClient::kDefaultWorkerThreads;
+            m_workers.reserve(poolSize);
+            for (std::uint32_t i = 0; i < poolSize; ++i)
+            {
+                m_workers.emplace_back([this] { workerLoop(); });
+            }
         }
 
         ~Impl()
@@ -114,9 +122,12 @@ namespace remoted::enrollment
                 m_stopping = true;
             }
             m_cv.notify_all();
-            if (m_worker.joinable())
+            for (auto& worker : m_workers)
             {
-                m_worker.join();
+                if (worker.joinable())
+                {
+                    worker.join();
+                }
             }
 
             std::queue<Request> pending;
@@ -211,7 +222,6 @@ namespace remoted::enrollment
         AuthdResult performRequest(const AuthdAddRequest& request)
         {
             using SocketType = Socket<OSPrimitives, SizeHeaderProtocol>;
-            using ClientType = SocketClient<SocketType, EpollWrapper>;
 
             AuthdResult result;
             result.errorCode = -1;
@@ -233,25 +243,29 @@ namespace remoted::enrollment
             payload["arguments"] = std::move(arguments);
             const std::string requestStr = payload.dump();
 
-            std::string response;
-            std::mutex responseMutex;
-            std::condition_variable responseCv;
-            bool responseReady = false;
-
-            std::unique_ptr<ClientType> client;
+            // Deliberately the bare Socket, not shared_modules/utils's SocketClient: SocketClient's
+            // connect() only starts a background thread that connects asynchronously and returns
+            // immediately, with no hook to learn when (or whether) it actually succeeded. An
+            // earlier version of this method called SocketClient::connect() and then send() on the
+            // very next line with no synchronization between them -- almost always losing the race
+            // against that background thread, which queued the request until a later, unrelated
+            // event flushed it (or didn't). Since this method already runs on this class's own
+            // dedicated worker thread (never an I/O thread), a plain BLOCKING connect() is both
+            // simpler and correct: it returns only once truly connected, or throws immediately on a
+            // real failure -- no race, no background thread, no epoll needed.
+            SocketType socket;
             try
             {
-                // Connect-per-request by construction: a fresh ClientType every call, dropped at
-                // the end of this function -- there is no persistent connection to reconnect.
-                client = std::make_unique<ClientType>(m_socketPath);
-                client->connect(
-                    [&](const char* body, uint32_t bodySize, const char*, uint32_t)
-                    {
-                        std::lock_guard<std::mutex> lock(responseMutex);
-                        response.assign(body, bodySize);
-                        responseReady = true;
-                        responseCv.notify_one();
-                    });
+                // Deliberately inlined into one expression, not split into a named UnixAddress
+                // local first: UnixAddress::builder()/.address()/.build() build up and hand back a
+                // reference into a temporary object whose SocketAddress::addr member self-points at
+                // its OWN sun_path buffer. Binding that through a `const auto` copy first would
+                // copy the SocketAddress struct's pointer value byte-for-byte -- still pointing at
+                // the ORIGINAL (about-to-be-destroyed) temporary's buffer, not the copy's own --
+                // turning connect()'s later dereference into a read of freed stack memory. Kept as
+                // one expression, the temporary stays alive for its whole evaluation, including
+                // this connect() call.
+                socket.connect(UnixAddress::builder().address(m_socketPath).build().data(), SOCK_STREAM);
                 LOGFN_DEBUG2(logFn(), "Connected to authd socket at %s.", m_socketPath.c_str());
             }
             catch (const std::exception& e)
@@ -268,25 +282,20 @@ namespace remoted::enrollment
                 return result;
             }
 
+            // Bounds both the send and the reply wait. Socket/OSPrimitives don't expose
+            // setsockopt() publicly (it's used internally for the send/receive buffer sizes only),
+            // so this is set directly on the raw fd via the standard POSIX call.
+            const struct timeval timeout
+            {
+                static_cast<time_t>(m_responseTimeoutMs / 1000),
+                    static_cast<suseconds_t>((m_responseTimeoutMs % 1000) * 1000)
+            };
+            ::setsockopt(socket.fileDescriptor(), SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+            ::setsockopt(socket.fileDescriptor(), SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
+
             try
             {
-                client->send(requestStr.data(), requestStr.size());
-
-                std::unique_lock<std::mutex> respLock(responseMutex);
-                if (!responseCv.wait_for(
-                        respLock, std::chrono::milliseconds(m_responseTimeoutMs), [&]() { return responseReady; }))
-                {
-                    result.message = "Timed out waiting for authd's reply";
-                    if (const auto throttle = timeoutThrottle().record())
-                    {
-                        LOGFN_WARN(logFn(),
-                                   "authd response timeout (deadline=%u ms): %llu timeout(s) in the last %d s.",
-                                   m_responseTimeoutMs,
-                                   throttle.total,
-                                   remoted::common::LogThrottle::kDefaultWindowSeconds);
-                    }
-                    return result;
-                }
+                socket.send(requestStr.data(), requestStr.size());
             }
             catch (const std::exception& e)
             {
@@ -295,6 +304,54 @@ namespace remoted::enrollment
                 {
                     LOGFN_WARN(logFn(),
                                "authd socket I/O error: %llu error(s) in the last %d s.",
+                               throttle.total,
+                               remoted::common::LogThrottle::kDefaultWindowSeconds);
+                }
+                return result;
+            }
+
+            std::string response;
+            bool responseReceived = false;
+            try
+            {
+                // One call, blocking (bounded by SO_RCVTIMEO above) between the header and body
+                // reads. authd closes its end of the socket right after this one reply (see
+                // run_local_server's accept loop, os_auth/src/local-server.c), so the loop inside
+                // read() continuing on to look for a NEXT frame hits EOF and throws -- expected,
+                // not an error, once the callback below has already fired (see the catch below).
+                socket.read(
+                    [&](int, const char* body, uint32_t bodySize, const char*, uint32_t)
+                    {
+                        response.assign(body, bodySize);
+                        responseReceived = true;
+                    });
+            }
+            catch (const std::exception& e)
+            {
+                if (!responseReceived)
+                {
+                    result.message = std::string("I/O error talking to authd: ") + e.what();
+                    if (const auto throttle = ioErrorThrottle().record())
+                    {
+                        LOGFN_WARN(logFn(),
+                                   "authd socket I/O error: %llu error(s) in the last %d s.",
+                                   throttle.total,
+                                   remoted::common::LogThrottle::kDefaultWindowSeconds);
+                    }
+                    return result;
+                }
+                // else: the reply was already captured above; this is just authd closing the
+                // connection right afterward, surfacing as EOF on the next (never-coming) frame.
+            }
+
+            if (!responseReceived)
+            {
+                result.message = "Timed out waiting for authd's reply";
+                if (const auto throttle = timeoutThrottle().record())
+                {
+                    LOGFN_WARN(logFn(),
+                               "authd response timeout (deadline=%u ms): %llu timeout(s) in the last %d s.",
+                               m_responseTimeoutMs,
                                throttle.total,
                                remoted::common::LogThrottle::kDefaultWindowSeconds);
                 }
@@ -353,7 +410,7 @@ namespace remoted::enrollment
         std::uint32_t m_responseTimeoutMs;
         std::uint32_t m_maxQueueSize;
 
-        std::thread m_worker;
+        std::vector<std::thread> m_workers;
         std::queue<Request> m_queue;
         std::mutex m_mutex;
         std::condition_variable m_cv;
@@ -364,9 +421,10 @@ namespace remoted::enrollment
                              bool isWorkerNode,
                              std::uint32_t connectTimeoutMs,
                              std::uint32_t responseTimeoutMs,
-                             std::uint32_t maxQueueSize)
+                             std::uint32_t maxQueueSize,
+                             std::uint32_t workerThreads)
         : m_impl(std::make_unique<Impl>(
-              std::move(socketPath), isWorkerNode, connectTimeoutMs, responseTimeoutMs, maxQueueSize))
+              std::move(socketPath), isWorkerNode, connectTimeoutMs, responseTimeoutMs, maxQueueSize, workerThreads))
     {
     }
 

--- a/src/remoted/remoted_module/src/enrollment/authdClient.cpp
+++ b/src/remoted/remoted_module/src/enrollment/authdClient.cpp
@@ -11,14 +11,18 @@
 
 #include "authdClient.hpp"
 
+#include <fcntl.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <sys/time.h>
 
+#include <cerrno>
 #include <condition_variable>
 #include <cstring>
 #include <mutex>
 #include <queue>
 #include <string_view>
+#include <system_error>
 #include <thread>
 #include <vector>
 
@@ -250,9 +254,9 @@ namespace remoted::enrollment
             // very next line with no synchronization between them -- almost always losing the race
             // against that background thread, which queued the request until a later, unrelated
             // event flushed it (or didn't). Since this method already runs on this class's own
-            // dedicated worker thread (never an I/O thread), a plain BLOCKING connect() is both
-            // simpler and correct: it returns only once truly connected, or throws immediately on a
-            // real failure -- no race, no background thread, no epoll needed.
+            // dedicated worker thread (never an I/O thread), a deterministic, bounded connect is
+            // both simpler and correct: it returns only once truly connected, or throws on a real
+            // failure or timeout -- no race, no background thread, no epoll needed.
             SocketType socket;
             try
             {
@@ -265,7 +269,65 @@ namespace remoted::enrollment
                 // turning connect()'s later dereference into a read of freed stack memory. Kept as
                 // one expression, the temporary stays alive for its whole evaluation, including
                 // this connect() call.
-                socket.connect(UnixAddress::builder().address(m_socketPath).build().data(), SOCK_STREAM);
+                //
+                // SOCK_NONBLOCK so a saturated authd accept() backlog can't block this worker
+                // thread indefinitely (the one scenario a plain blocking connect() can't bound):
+                // Socket::connect() already tolerates EINPROGRESS/EAGAIN and returns immediately in
+                // that case instead of throwing.
+                socket.connect(UnixAddress::builder().address(m_socketPath).build().data(),
+                               SOCK_STREAM | SOCK_NONBLOCK);
+
+                // Wait for the connect to complete (or fail) within m_connectTimeoutMs. For a
+                // Unix-domain socket this resolves near-instantly in practice -- this bound only
+                // matters when authd's own accept() backlog is full.
+                struct pollfd pfd
+                {
+                    socket.fileDescriptor(), POLLOUT, 0
+                };
+                const int ready = ::poll(&pfd, 1, static_cast<int>(m_connectTimeoutMs));
+                if (ready == 0)
+                {
+                    throw std::system_error(ETIMEDOUT, std::generic_category(), "Timed out connecting to authd");
+                }
+                if (ready < 0)
+                {
+                    throw std::system_error(errno, std::generic_category(), "poll() failed while connecting to authd");
+                }
+
+                // AF_UNIX quirk verified against the real kernel behavior: when the peer's listen()
+                // backlog is full, a non-blocking connect() fails synchronously with EAGAIN -- there
+                // is no async "still connecting" state the way there is for TCP, so poll() comes
+                // back ready almost immediately with POLLHUP set, and SO_ERROR below misleadingly
+                // reports 0 ("success") even though the socket was never actually connected (a
+                // subsequent send()/read() would fail with ENOTCONN). POLLHUP/POLLERR must be
+                // checked directly -- SO_ERROR alone cannot distinguish this from a real success.
+                if (pfd.revents & (POLLHUP | POLLERR))
+                {
+                    throw std::system_error(
+                        EAGAIN, std::generic_category(), "authd's accept backlog is full (connect rejected)");
+                }
+
+                int connectErr = 0;
+                socklen_t connectErrLen = sizeof(connectErr);
+                if (::getsockopt(socket.fileDescriptor(), SOL_SOCKET, SO_ERROR, &connectErr, &connectErrLen) < 0)
+                {
+                    throw std::system_error(errno, std::generic_category(), "getsockopt(SO_ERROR) failed");
+                }
+                if (connectErr != 0)
+                {
+                    throw std::system_error(connectErr, std::generic_category(), "Error connecting to socket");
+                }
+
+                // Back to blocking mode: SO_RCVTIMEO/SO_SNDTIMEO (set below) only bound a blocking
+                // call -- on a non-blocking fd, send()/read() would instead fail immediately with
+                // EAGAIN rather than waiting up to m_responseTimeoutMs.
+                const int flags = ::fcntl(socket.fileDescriptor(), F_GETFL, 0);
+                if (flags < 0 || ::fcntl(socket.fileDescriptor(), F_SETFL, flags & ~O_NONBLOCK) < 0)
+                {
+                    throw std::system_error(
+                        errno, std::generic_category(), "Could not restore blocking mode on authd socket");
+                }
+
                 LOGFN_DEBUG2(logFn(), "Connected to authd socket at %s.", m_socketPath.c_str());
             }
             catch (const std::exception& e)
@@ -405,8 +467,7 @@ namespace remoted::enrollment
         }
 
         std::string m_socketPath;
-        // Currently unenforced -- see the constructor's doc comment in authdClient.hpp.
-        [[maybe_unused]] std::uint32_t m_connectTimeoutMs;
+        std::uint32_t m_connectTimeoutMs;
         std::uint32_t m_responseTimeoutMs;
         std::uint32_t m_maxQueueSize;
 

--- a/src/remoted/remoted_module/src/enrollment/authdClient.cpp
+++ b/src/remoted/remoted_module/src/enrollment/authdClient.cpp
@@ -1,0 +1,394 @@
+/*
+ * Wazuh remoted module - authd enrollment bridge client
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 19, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "authdClient.hpp"
+
+#include <condition_variable>
+#include <cstring>
+#include <mutex>
+#include <queue>
+#include <string_view>
+#include <thread>
+
+#include "common/logThrottle.hpp"
+#include "epollWrapper.hpp"
+#include "json.hpp"
+#include "loggerHelper.h"
+#include "socketClient.hpp"
+#include "socketWrapper.hpp"
+
+namespace remoted::enrollment
+{
+    namespace
+    {
+        constexpr auto AUTHD_CLIENT_LOGTAG {"wazuh-manager-remoted:authd-client"};
+
+        const LogFn& logFn()
+        {
+            static const LogFn instance {AUTHD_CLIENT_LOGTAG};
+            return instance;
+        }
+
+        remoted::common::LogThrottle& queueFullThrottle()
+        {
+            static remoted::common::LogThrottle instance;
+            return instance;
+        }
+
+        remoted::common::LogThrottle& connectFailThrottle()
+        {
+            static remoted::common::LogThrottle instance;
+            return instance;
+        }
+
+        remoted::common::LogThrottle& timeoutThrottle()
+        {
+            static remoted::common::LogThrottle instance;
+            return instance;
+        }
+
+        remoted::common::LogThrottle& ioErrorThrottle()
+        {
+            static remoted::common::LogThrottle instance;
+            return instance;
+        }
+
+        remoted::common::LogThrottle& protocolErrorThrottle()
+        {
+            static remoted::common::LogThrottle instance;
+            return instance;
+        }
+
+        // authd's local-server.c strips a leading "ERROR: " off nothing -- that prefix is only
+        // ever added by the CLUSTER-forwarded path (shared/src/agent_op.c's
+        // w_parse_agent_add_response), never by local_add()'s own error responses. Strip it
+        // defensively either way so the message is clean regardless of which path answered.
+        std::string stripErrorPrefix(std::string message)
+        {
+            constexpr std::string_view kPrefix {"ERROR: "};
+            if (message.rfind(kPrefix, 0) == 0)
+            {
+                message.erase(0, kPrefix.size());
+            }
+            return message;
+        }
+    } // namespace
+
+    class AuthdClient::Impl
+    {
+    public:
+        Impl(std::string socketPath,
+             bool isWorkerNode,
+             std::uint32_t connectTimeoutMs,
+             std::uint32_t responseTimeoutMs,
+             std::uint32_t maxQueueSize)
+            : m_socketPath(std::move(socketPath))
+            , m_connectTimeoutMs(connectTimeoutMs != 0 ? connectTimeoutMs : AuthdClient::kDefaultConnectTimeoutMs)
+            , m_responseTimeoutMs(AuthdClient::resolveResponseTimeoutMs(responseTimeoutMs, isWorkerNode))
+            , m_maxQueueSize(maxQueueSize != 0 ? maxQueueSize : AuthdClient::kDefaultMaxQueueSize)
+        {
+            m_worker = std::thread([this] { workerLoop(); });
+        }
+
+        ~Impl()
+        {
+            stop();
+        }
+
+        void stop()
+        {
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                if (m_stopping)
+                {
+                    return;
+                }
+                m_stopping = true;
+            }
+            m_cv.notify_all();
+            if (m_worker.joinable())
+            {
+                m_worker.join();
+            }
+
+            std::queue<Request> pending;
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                std::swap(pending, m_queue);
+            }
+            while (!pending.empty())
+            {
+                AuthdResult result;
+                result.errorCode = -1;
+                result.message = "AuthdClient is stopping";
+                pending.front().callback(std::move(result));
+                pending.pop();
+            }
+        }
+
+        void addAgent(AuthdAddRequest request, std::function<void(AuthdResult)> callback)
+        {
+            std::function<void(AuthdResult)> reject;
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                if (m_stopping)
+                {
+                    reject = std::move(callback);
+                }
+                else if (m_queue.size() >= m_maxQueueSize)
+                {
+                    reject = std::move(callback);
+                }
+                else
+                {
+                    m_queue.push({std::move(request), std::move(callback)});
+                    m_cv.notify_one();
+                }
+            }
+            if (reject)
+            {
+                if (const auto throttle = queueFullThrottle().record())
+                {
+                    LOGFN_WARN(logFn(),
+                               "AuthdClient queue full (max=%u): dropped %llu request(s) in the last %d s.",
+                               m_maxQueueSize,
+                               throttle.total,
+                               remoted::common::LogThrottle::kDefaultWindowSeconds);
+                }
+                AuthdResult result;
+                result.errorCode = -1;
+                result.message = "Enrollment request queue is full";
+                reject(std::move(result));
+            }
+        }
+
+    private:
+        struct Request
+        {
+            AuthdAddRequest request;
+            std::function<void(AuthdResult)> callback;
+        };
+
+        void workerLoop()
+        {
+            while (true)
+            {
+                std::unique_lock<std::mutex> lock(m_mutex);
+                m_cv.wait(lock, [this]() { return m_stopping || !m_queue.empty(); });
+
+                // Unlike TaskClient's equivalent loop, stopping here does NOT drain the rest of
+                // the queue first: any request not already in flight is abandoned immediately
+                // and left for stop()'s own cleanup to reject with "stopping" (see stop()). A
+                // slow or hung authd could otherwise make stop() take arbitrarily long --
+                // proportional to queue depth times the response timeout -- which risks
+                // delaying RemotedModuleFacade's own bounded teardown sequence. Only the request
+                // already popped and in flight (if any) is allowed to finish naturally.
+                if (m_stopping)
+                {
+                    break;
+                }
+                if (m_queue.empty())
+                {
+                    continue;
+                }
+
+                auto req = std::move(m_queue.front());
+                m_queue.pop();
+                lock.unlock();
+
+                req.callback(performRequest(req.request));
+            }
+        }
+
+        AuthdResult performRequest(const AuthdAddRequest& request)
+        {
+            using SocketType = Socket<OSPrimitives, SizeHeaderProtocol>;
+            using ClientType = SocketClient<SocketType, EpollWrapper>;
+
+            AuthdResult result;
+            result.errorCode = -1;
+
+            nlohmann::json arguments;
+            arguments["name"] = request.name;
+            arguments["ip"] = request.ip;
+            if (request.groups)
+            {
+                arguments["groups"] = *request.groups;
+            }
+            if (request.keyHash)
+            {
+                arguments["key_hash"] = *request.keyHash;
+            }
+
+            nlohmann::json payload;
+            payload["function"] = "add";
+            payload["arguments"] = std::move(arguments);
+            const std::string requestStr = payload.dump();
+
+            std::string response;
+            std::mutex responseMutex;
+            std::condition_variable responseCv;
+            bool responseReady = false;
+
+            std::unique_ptr<ClientType> client;
+            try
+            {
+                // Connect-per-request by construction: a fresh ClientType every call, dropped at
+                // the end of this function -- there is no persistent connection to reconnect.
+                client = std::make_unique<ClientType>(m_socketPath);
+                client->connect(
+                    [&](const char* body, uint32_t bodySize, const char*, uint32_t)
+                    {
+                        std::lock_guard<std::mutex> lock(responseMutex);
+                        response.assign(body, bodySize);
+                        responseReady = true;
+                        responseCv.notify_one();
+                    });
+                LOGFN_DEBUG2(logFn(), "Connected to authd socket at %s.", m_socketPath.c_str());
+            }
+            catch (const std::exception& e)
+            {
+                result.message = std::string("Could not connect to authd: ") + e.what();
+                if (const auto throttle = connectFailThrottle().record())
+                {
+                    LOGFN_WARN(logFn(),
+                               "Failed to connect to authd socket at %s: %llu failure(s) in the last %d s.",
+                               m_socketPath.c_str(),
+                               throttle.total,
+                               remoted::common::LogThrottle::kDefaultWindowSeconds);
+                }
+                return result;
+            }
+
+            try
+            {
+                client->send(requestStr.data(), requestStr.size());
+
+                std::unique_lock<std::mutex> respLock(responseMutex);
+                if (!responseCv.wait_for(
+                        respLock, std::chrono::milliseconds(m_responseTimeoutMs), [&]() { return responseReady; }))
+                {
+                    result.message = "Timed out waiting for authd's reply";
+                    if (const auto throttle = timeoutThrottle().record())
+                    {
+                        LOGFN_WARN(logFn(),
+                                   "authd response timeout (deadline=%u ms): %llu timeout(s) in the last %d s.",
+                                   m_responseTimeoutMs,
+                                   throttle.total,
+                                   remoted::common::LogThrottle::kDefaultWindowSeconds);
+                    }
+                    return result;
+                }
+            }
+            catch (const std::exception& e)
+            {
+                result.message = std::string("I/O error talking to authd: ") + e.what();
+                if (const auto throttle = ioErrorThrottle().record())
+                {
+                    LOGFN_WARN(logFn(),
+                               "authd socket I/O error: %llu error(s) in the last %d s.",
+                               throttle.total,
+                               remoted::common::LogThrottle::kDefaultWindowSeconds);
+                }
+                return result;
+            }
+
+            return parseResponse(response);
+        }
+
+        AuthdResult parseResponse(const std::string& response)
+        {
+            AuthdResult result;
+            result.errorCode = -1;
+
+            try
+            {
+                const auto json = nlohmann::json::parse(response);
+                const int errorCode = json.value("error", -1);
+
+                if (errorCode == 0)
+                {
+                    const auto& data = json.at("data");
+                    result.errorCode = 0;
+                    result.id = data.value("id", "");
+                    result.name = data.value("name", "");
+                    result.ip = data.value("ip", "");
+                    result.key = data.value("key", "");
+                }
+                else
+                {
+                    // A well-formed business rejection from authd (e.g. 9008 Duplicate name):
+                    // surface its exact code so the endpoint can map it precisely.
+                    result.errorCode = errorCode;
+                    result.message = stripErrorPrefix(json.value("message", ""));
+                }
+            }
+            catch (const std::exception& e)
+            {
+                result.errorCode = -1;
+                result.message = std::string("Malformed response from authd: ") + e.what();
+                if (const auto throttle = protocolErrorThrottle().record())
+                {
+                    LOGFN_WARN(logFn(),
+                               "authd returned an unparseable response: %llu error(s) in the last %d s.",
+                               throttle.total,
+                               remoted::common::LogThrottle::kDefaultWindowSeconds);
+                }
+            }
+
+            return result;
+        }
+
+        std::string m_socketPath;
+        // Currently unenforced -- see the constructor's doc comment in authdClient.hpp.
+        [[maybe_unused]] std::uint32_t m_connectTimeoutMs;
+        std::uint32_t m_responseTimeoutMs;
+        std::uint32_t m_maxQueueSize;
+
+        std::thread m_worker;
+        std::queue<Request> m_queue;
+        std::mutex m_mutex;
+        std::condition_variable m_cv;
+        bool m_stopping {false};
+    };
+
+    AuthdClient::AuthdClient(std::string socketPath,
+                             bool isWorkerNode,
+                             std::uint32_t connectTimeoutMs,
+                             std::uint32_t responseTimeoutMs,
+                             std::uint32_t maxQueueSize)
+        : m_impl(std::make_unique<Impl>(
+              std::move(socketPath), isWorkerNode, connectTimeoutMs, responseTimeoutMs, maxQueueSize))
+    {
+    }
+
+    AuthdClient::~AuthdClient() = default;
+
+    void AuthdClient::addAgent(AuthdAddRequest request, std::function<void(AuthdResult)> callback)
+    {
+        m_impl->addAgent(std::move(request), std::move(callback));
+    }
+
+    std::uint32_t AuthdClient::resolveResponseTimeoutMs(std::uint32_t configuredMs, bool isWorkerNode) noexcept
+    {
+        if (configuredMs != 0)
+        {
+            return configuredMs;
+        }
+        return isWorkerNode ? kWorkerDefaultResponseTimeoutMs : kMasterDefaultResponseTimeoutMs;
+    }
+
+    void AuthdClient::stop()
+    {
+        m_impl->stop();
+    }
+
+} // namespace remoted::enrollment

--- a/src/remoted/remoted_module/src/enrollment/authdClient.hpp
+++ b/src/remoted/remoted_module/src/enrollment/authdClient.hpp
@@ -62,9 +62,27 @@ namespace remoted::enrollment
      * Connect-per-request, unlike WazuhDBClient/TaskClient's persistent connection: authd closes
      * its end of the socket after every single reply (see run_local_server's accept loop in
      * os_auth/src/local-server.c), so treating a post-reply disconnect as an error would
-     * misreport every successful call. A single dedicated worker thread pulls from a bounded
-     * queue, connecting fresh for each request in turn -- authd's own accept loop is
-     * single-threaded anyway, so a larger client-side pool would only queue up behind it.
+     * misreport every successful call.
+     *
+     * A small pool of dedicated worker threads (see workerThreads) pulls from one shared, bounded
+     * queue, each connecting fresh for each request it picks up. authd's own local-socket accept
+     * loop is single-threaded and fully synchronous (accept -> recv -> dispatch -> send -> close,
+     * one client at a time), so a pool does NOT raise authd's own processing rate -- that stays
+     * whatever authd's business logic costs per request, an upper bound this class cannot move.
+     * What a pool buys instead: with only one worker, authd's accept loop sits idle between
+     * closing one connection and this class noticing, reconnecting, and sending the next request
+     * -- a round trip of pure connection-setup latency added on top of authd's own processing time,
+     * for every single request, serialized. With several workers, by the time authd finishes one
+     * request and calls accept() again, another worker's connection (already sent, already
+     * awaiting a reply) is normally already sitting in authd's listen backlog (128 slots -- see
+     * OS_BindUnixDomainWithPerms in shared/os_net/os_net.c), so authd is essentially never left
+     * waiting on remoted for the next request. That closes the gap between this bridge's real
+     * throughput and authd's own dispatch-rate ceiling, without needing any change to authd itself.
+     *
+     * Because of this, addAgent()'s callback can now run on ANY of the pool's threads, including
+     * concurrently with another addAgent() call's callback on a different thread -- callers must
+     * be safe under that (the enrollment endpoint's own callback already is: IHttpResponder::send()
+     * is thread-safe by contract, and the metrics counters it also touches are relaxed atomics).
      *
      * The response timeout is worker-aware when the caller passes 0 (see
      * resolveResponseTimeoutMs()): authd's own worker-to-master cluster forward
@@ -72,13 +90,19 @@ namespace remoted::enrollment
      * (10) times with a 1 s sleep between failures on a flaky link, so a timeout shorter than
      * that would cut off a legitimate, still-in-progress worker enrollment as a spurious failure.
      *
-     * NOTE: an absent authd (nothing listening on socketPath at all) is NOT distinguishable from
-     * a slow/unresponsive one -- shared_modules/utils's SocketClient retries a failed connect()
-     * silently on its own background thread rather than surfacing it, so there is no synchronous
-     * "could not connect" signal to catch here. Both cases resolve only once the response timeout
-     * above elapses, with the same errorCode (-1) and a "timed out" message. This is a limitation
-     * of the shared primitive, not specific to AuthdClient -- WazuhDBClient/TaskClient have the
-     * same exposure and have simply never been tested against a truly absent server.
+     * Connect() is a plain, fully BLOCKING call (see authdClient.cpp's performRequest()) -- not
+     * shared_modules/utils's SocketClient, whose async connect() starts a background thread and
+     * returns before the connection exists. An earlier version of this class used SocketClient and
+     * called send() immediately after connect() with no synchronization between them, which lost
+     * the race against that background thread far more often than not: authd would receive and
+     * successfully process the request, but the reply arrived on a connection this class was no
+     * longer the one listening on (SocketClient had silently reconnected after treating the
+     * original attempt as merely "still pending"), producing a client-visible timeout for a request
+     * that actually succeeded. Blocking connect() has no such race: it returns only once truly
+     * connected, or throws immediately on a real failure (e.g. ENOENT if socketPath doesn't exist)
+     * -- so, unlike before, an absent authd IS now distinguishable from a slow/unresponsive one: it
+     * fails fast with a "could not connect" message rather than waiting out the full response
+     * timeout.
      */
     class AuthdClient
     {
@@ -88,40 +112,54 @@ namespace remoted::enrollment
         static constexpr std::uint32_t kMasterDefaultResponseTimeoutMs = 5000;
         static constexpr std::uint32_t kWorkerDefaultResponseTimeoutMs = 15000;
         static constexpr std::uint32_t kDefaultMaxQueueSize = 256;
+        /// Deliberately a small, fixed number, not CPU-scaled like this module's other worker
+        /// pools (e.g. http_worker_threads): authd's own accept loop is single-threaded regardless
+        /// of how many CPUs the manager has, so scaling this with core count would just leave
+        /// surplus workers unable to help. See the class comment for what this pool actually buys.
+        static constexpr std::uint32_t kDefaultWorkerThreads = 8;
 
         /**
          * @param socketPath Path to authd's local socket.
          * @param isWorkerNode Selects the worker-aware default when responseTimeoutMs is 0.
          * @param connectTimeoutMs 0 -> kDefaultConnectTimeoutMs. NOTE: currently accepted but not
-         *        enforced -- shared_modules/utils's SocketClient::connect() has no timeout hook,
-         *        the same limitation WazuhDBClient/TaskClient already live with for the identical
-         *        primitive. Kept in the signature so the ABI field it's sourced from
-         *        (authd_connect_timeout) has somewhere to go if that primitive gains one later.
+         *        enforced -- connect() is a plain blocking call (see the class comment) with no
+         *        per-call deadline hook short of a non-blocking-connect-plus-poll() rewrite. In
+         *        practice a Unix-domain connect() either resolves near-instantly or fails
+         *        near-instantly; the one scenario this doesn't bound is authd's accept() backlog
+         *        being saturated, which blocks the connecting side until a slot frees, with no
+         *        fixed limit. Kept in the signature so the ABI field it's sourced from
+         *        (authd_connect_timeout) has somewhere to go if that gap is closed later.
          * @param responseTimeoutMs 0 -> worker-aware default (see class comment and
          *        resolveResponseTimeoutMs()).
          * @param maxQueueSize 0 -> kDefaultMaxQueueSize; requests beyond this are rejected
          *        immediately with errorCode -1 rather than queued.
+         * @param workerThreads 0 -> kDefaultWorkerThreads. Keep well under authd's local-socket
+         *        listen backlog (128) -- see the class comment; there is no benefit to more
+         *        workers than that backlog can hold anyway.
          */
         explicit AuthdClient(std::string socketPath = kDefaultSocketPath,
                              bool isWorkerNode = false,
                              std::uint32_t connectTimeoutMs = 0,
                              std::uint32_t responseTimeoutMs = 0,
-                             std::uint32_t maxQueueSize = 0);
+                             std::uint32_t maxQueueSize = 0,
+                             std::uint32_t workerThreads = 0);
         ~AuthdClient();
 
         AuthdClient(const AuthdClient&) = delete;
         AuthdClient& operator=(const AuthdClient&) = delete;
 
-        /// Enqueues an "add" request; callback runs on the internal worker thread, exactly once,
-        /// even if the client is stopping or the queue is full (errorCode -1 in both cases).
+        /// Enqueues an "add" request; the callback runs exactly once, on whichever pool thread
+        /// picks the request up (see the class comment: with more than one worker, this may run
+        /// concurrently with another call's callback on a different thread) -- even if the client
+        /// is stopping or the queue is full (errorCode -1 in both cases).
         void addAgent(AuthdAddRequest request, std::function<void(AuthdResult)> callback);
 
         /// Resolves the effective response timeout for a configured value (0 = worker-aware
         /// default). A pure function of its arguments; exposed for unit testing.
         static std::uint32_t resolveResponseTimeoutMs(std::uint32_t configuredMs, bool isWorkerNode) noexcept;
 
-        /// Stops the worker thread and fails any still-queued requests with errorCode -1. Safe to
-        /// call more than once, and safe to skip -- the destructor calls it too.
+        /// Stops every worker thread and fails any still-queued requests with errorCode -1. Safe
+        /// to call more than once, and safe to skip -- the destructor calls it too.
         void stop();
 
     private:

--- a/src/remoted/remoted_module/src/enrollment/authdClient.hpp
+++ b/src/remoted/remoted_module/src/enrollment/authdClient.hpp
@@ -1,0 +1,132 @@
+/*
+ * Wazuh remoted module - authd enrollment bridge client
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 19, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace remoted::enrollment
+{
+
+    /// Fields forwarded to authd's local socket "add" function. Deliberately does not include
+    /// id/key/force: self-enrollment always gets an auto-assigned ID and an authd-generated key,
+    /// and force-replace stays a manager-config decision -- see the Agent enrollment chapter of
+    /// remoted_module/README.md.
+    struct AuthdAddRequest
+    {
+        std::string name;
+        std::string ip;
+        std::optional<std::string> groups;
+        std::optional<std::string> keyHash;
+    };
+
+    /**
+     * @brief Outcome of an AuthdClient::addAgent() call.
+     *
+     * errorCode:
+     *   - 0: success -- id/name/ip/key are populated, message is empty.
+     *   - a positive authd error code (e.g. 9008 "Duplicate name"): authd responded with a
+     *     well-formed business rejection -- message carries its (prefix-stripped) text.
+     *   - -1: no well-formed answer was obtained at all -- connect/send/receive failure, a
+     *     response timeout, or a malformed/unparseable reply. The endpoint layer maps this to
+     *     the same HTTP status as authd's own 9016 (clustered-forward failure): both mean
+     *     "the bridge did not get a clean answer", not a specific business outcome.
+     */
+    struct AuthdResult
+    {
+        int errorCode {-1};
+        std::string message;
+        std::string id;
+        std::string name;
+        std::string ip;
+        std::string key;
+    };
+
+    /**
+     * @brief Bridges an enrollment "add" request to authd's local Unix-domain socket
+     *        (queue/sockets/auth by default), the same interface `manage_agents`/the framework
+     *        already use. authd owns all enrollment business logic; this class only forwards.
+     *
+     * Connect-per-request, unlike WazuhDBClient/TaskClient's persistent connection: authd closes
+     * its end of the socket after every single reply (see run_local_server's accept loop in
+     * os_auth/src/local-server.c), so treating a post-reply disconnect as an error would
+     * misreport every successful call. A single dedicated worker thread pulls from a bounded
+     * queue, connecting fresh for each request in turn -- authd's own accept loop is
+     * single-threaded anyway, so a larger client-side pool would only queue up behind it.
+     *
+     * The response timeout is worker-aware when the caller passes 0 (see
+     * resolveResponseTimeoutMs()): authd's own worker-to-master cluster forward
+     * (w_request_agent_add_clustered) can legitimately retry up to CLUSTER_SEND_MESSAGE_ATTEMPTS
+     * (10) times with a 1 s sleep between failures on a flaky link, so a timeout shorter than
+     * that would cut off a legitimate, still-in-progress worker enrollment as a spurious failure.
+     *
+     * NOTE: an absent authd (nothing listening on socketPath at all) is NOT distinguishable from
+     * a slow/unresponsive one -- shared_modules/utils's SocketClient retries a failed connect()
+     * silently on its own background thread rather than surfacing it, so there is no synchronous
+     * "could not connect" signal to catch here. Both cases resolve only once the response timeout
+     * above elapses, with the same errorCode (-1) and a "timed out" message. This is a limitation
+     * of the shared primitive, not specific to AuthdClient -- WazuhDBClient/TaskClient have the
+     * same exposure and have simply never been tested against a truly absent server.
+     */
+    class AuthdClient
+    {
+    public:
+        static constexpr const char* kDefaultSocketPath = "queue/sockets/auth";
+        static constexpr std::uint32_t kDefaultConnectTimeoutMs = 2000;
+        static constexpr std::uint32_t kMasterDefaultResponseTimeoutMs = 5000;
+        static constexpr std::uint32_t kWorkerDefaultResponseTimeoutMs = 15000;
+        static constexpr std::uint32_t kDefaultMaxQueueSize = 256;
+
+        /**
+         * @param socketPath Path to authd's local socket.
+         * @param isWorkerNode Selects the worker-aware default when responseTimeoutMs is 0.
+         * @param connectTimeoutMs 0 -> kDefaultConnectTimeoutMs. NOTE: currently accepted but not
+         *        enforced -- shared_modules/utils's SocketClient::connect() has no timeout hook,
+         *        the same limitation WazuhDBClient/TaskClient already live with for the identical
+         *        primitive. Kept in the signature so the ABI field it's sourced from
+         *        (authd_connect_timeout) has somewhere to go if that primitive gains one later.
+         * @param responseTimeoutMs 0 -> worker-aware default (see class comment and
+         *        resolveResponseTimeoutMs()).
+         * @param maxQueueSize 0 -> kDefaultMaxQueueSize; requests beyond this are rejected
+         *        immediately with errorCode -1 rather than queued.
+         */
+        explicit AuthdClient(std::string socketPath = kDefaultSocketPath,
+                             bool isWorkerNode = false,
+                             std::uint32_t connectTimeoutMs = 0,
+                             std::uint32_t responseTimeoutMs = 0,
+                             std::uint32_t maxQueueSize = 0);
+        ~AuthdClient();
+
+        AuthdClient(const AuthdClient&) = delete;
+        AuthdClient& operator=(const AuthdClient&) = delete;
+
+        /// Enqueues an "add" request; callback runs on the internal worker thread, exactly once,
+        /// even if the client is stopping or the queue is full (errorCode -1 in both cases).
+        void addAgent(AuthdAddRequest request, std::function<void(AuthdResult)> callback);
+
+        /// Resolves the effective response timeout for a configured value (0 = worker-aware
+        /// default). A pure function of its arguments; exposed for unit testing.
+        static std::uint32_t resolveResponseTimeoutMs(std::uint32_t configuredMs, bool isWorkerNode) noexcept;
+
+        /// Stops the worker thread and fails any still-queued requests with errorCode -1. Safe to
+        /// call more than once, and safe to skip -- the destructor calls it too.
+        void stop();
+
+    private:
+        class Impl;
+        std::unique_ptr<Impl> m_impl;
+    };
+
+} // namespace remoted::enrollment

--- a/src/remoted/remoted_module/src/enrollment/authdClient.hpp
+++ b/src/remoted/remoted_module/src/enrollment/authdClient.hpp
@@ -65,24 +65,30 @@ namespace remoted::enrollment
      * misreport every successful call.
      *
      * A small pool of dedicated worker threads (see workerThreads) pulls from one shared, bounded
-     * queue, each connecting fresh for each request it picks up. authd's own local-socket accept
-     * loop is single-threaded and fully synchronous (accept -> recv -> dispatch -> send -> close,
-     * one client at a time), so a pool does NOT raise authd's own processing rate -- that stays
-     * whatever authd's business logic costs per request, an upper bound this class cannot move.
-     * What a pool buys instead: with only one worker, authd's accept loop sits idle between
-     * closing one connection and this class noticing, reconnecting, and sending the next request
-     * -- a round trip of pure connection-setup latency added on top of authd's own processing time,
-     * for every single request, serialized. With several workers, by the time authd finishes one
-     * request and calls accept() again, another worker's connection (already sent, already
-     * awaiting a reply) is normally already sitting in authd's listen backlog (128 slots -- see
-     * OS_BindUnixDomainWithPerms in shared/os_net/os_net.c), so authd is essentially never left
-     * waiting on remoted for the next request. That closes the gap between this bridge's real
-     * throughput and authd's own dispatch-rate ceiling, without needing any change to authd itself.
+     * queue, each connecting fresh for each request it picks up. authd's local-socket accept loop
+     * (run_local_server, os_auth/src/local-server.c) hands each accepted connection to its own
+     * detached thread rather than dispatching inline, so authd itself can now process several
+     * requests concurrently too -- a single-worker AuthdClient would still only ever have ONE
+     * request in flight, no matter how parallel authd can go, and would still pay a round trip of
+     * pure connection-setup latency (connect + send + await reply + close) sitting on the critical
+     * path *in addition to* authd's processing time, for every single request, serialized. With
+     * several workers, authd can genuinely work on more than one at once, and another worker's
+     * connection (already sent, already awaiting a reply) is normally already sitting in authd's
+     * listen backlog (128 slots -- see OS_BindUnixDomainWithPerms in shared/os_net/os_net.c) by
+     * the time authd finishes one and calls accept() again, so authd is essentially never left
+     * idle waiting on remoted for the next request.
      *
      * Because of this, addAgent()'s callback can now run on ANY of the pool's threads, including
      * concurrently with another addAgent() call's callback on a different thread -- callers must
      * be safe under that (the enrollment endpoint's own callback already is: IHttpResponder::send()
      * is thread-safe by contract, and the metrics counters it also touches are relaxed atomics).
+     *
+     * Each worker thread also guards its own callback invocation with a catch-all (see
+     * authdClient.cpp's workerLoop()): this runs on a bare std::thread that RestinioHttpServer's
+     * own per-request try/catch never sees (addAgent() already returned by the time this fires,
+     * on a different thread), so an uncaught exception here -- from performRequest() itself or
+     * from the callback -- would otherwise std::terminate the entire remoted daemon instead of
+     * just failing the one request.
      *
      * The response timeout is worker-aware when the caller passes 0 (see
      * resolveResponseTimeoutMs()): authd's own worker-to-master cluster forward
@@ -115,9 +121,9 @@ namespace remoted::enrollment
         static constexpr std::uint32_t kWorkerDefaultResponseTimeoutMs = 15000;
         static constexpr std::uint32_t kDefaultMaxQueueSize = 256;
         /// Deliberately a small, fixed number, not CPU-scaled like this module's other worker
-        /// pools (e.g. http_worker_threads): authd's own accept loop is single-threaded regardless
-        /// of how many CPUs the manager has, so scaling this with core count would just leave
-        /// surplus workers unable to help. See the class comment for what this pool actually buys.
+        /// pools (e.g. http_worker_threads): bounded by authd's listen backlog (128 slots), not by
+        /// the manager's CPU count, so scaling this with core count would just leave surplus
+        /// workers unable to help. See the class comment for what this pool actually buys.
         static constexpr std::uint32_t kDefaultWorkerThreads = 8;
 
         /**

--- a/src/remoted/remoted_module/src/enrollment/authdClient.hpp
+++ b/src/remoted/remoted_module/src/enrollment/authdClient.hpp
@@ -90,7 +90,7 @@ namespace remoted::enrollment
      * (10) times with a 1 s sleep between failures on a flaky link, so a timeout shorter than
      * that would cut off a legitimate, still-in-progress worker enrollment as a spurious failure.
      *
-     * Connect() is a plain, fully BLOCKING call (see authdClient.cpp's performRequest()) -- not
+     * Connect() is deterministic and bounded (see authdClient.cpp's performRequest()) -- not
      * shared_modules/utils's SocketClient, whose async connect() starts a background thread and
      * returns before the connection exists. An earlier version of this class used SocketClient and
      * called send() immediately after connect() with no synchronization between them, which lost
@@ -98,11 +98,13 @@ namespace remoted::enrollment
      * successfully process the request, but the reply arrived on a connection this class was no
      * longer the one listening on (SocketClient had silently reconnected after treating the
      * original attempt as merely "still pending"), producing a client-visible timeout for a request
-     * that actually succeeded. Blocking connect() has no such race: it returns only once truly
-     * connected, or throws immediately on a real failure (e.g. ENOENT if socketPath doesn't exist)
-     * -- so, unlike before, an absent authd IS now distinguishable from a slow/unresponsive one: it
-     * fails fast with a "could not connect" message rather than waiting out the full response
-     * timeout.
+     * that actually succeeded. This class's connect() has no such race: internally it does a
+     * non-blocking connect() plus poll() bounded by connectTimeoutMs, then restores the fd to
+     * blocking mode before send()/read() -- it returns only once truly connected, or throws on a
+     * real failure (e.g. ENOENT if socketPath doesn't exist) or on the connect timeout expiring
+     * (e.g. authd's accept() backlog staying saturated) -- so an absent, refused, or overloaded
+     * authd IS distinguishable from a slow/unresponsive one: it fails fast with a "could not
+     * connect" message rather than waiting out the full response timeout.
      */
     class AuthdClient
     {
@@ -121,14 +123,11 @@ namespace remoted::enrollment
         /**
          * @param socketPath Path to authd's local socket.
          * @param isWorkerNode Selects the worker-aware default when responseTimeoutMs is 0.
-         * @param connectTimeoutMs 0 -> kDefaultConnectTimeoutMs. NOTE: currently accepted but not
-         *        enforced -- connect() is a plain blocking call (see the class comment) with no
-         *        per-call deadline hook short of a non-blocking-connect-plus-poll() rewrite. In
-         *        practice a Unix-domain connect() either resolves near-instantly or fails
-         *        near-instantly; the one scenario this doesn't bound is authd's accept() backlog
-         *        being saturated, which blocks the connecting side until a slot frees, with no
-         *        fixed limit. Kept in the signature so the ABI field it's sourced from
-         *        (authd_connect_timeout) has somewhere to go if that gap is closed later.
+         * @param connectTimeoutMs 0 -> kDefaultConnectTimeoutMs. Enforced via a non-blocking
+         *        connect() plus poll() on the fd (see performRequest()): bounds the one scenario a
+         *        plain blocking connect() couldn't -- authd's accept() backlog being saturated --
+         *        so a stuck connect attempt fails with a timeout error after this many
+         *        milliseconds instead of blocking the worker thread indefinitely.
          * @param responseTimeoutMs 0 -> worker-aware default (see class comment and
          *        resolveResponseTimeoutMs()).
          * @param maxQueueSize 0 -> kDefaultMaxQueueSize; requests beyond this are rejected

--- a/src/remoted/remoted_module/src/enrollment/enrollmentAuthenticator.cpp
+++ b/src/remoted/remoted_module/src/enrollment/enrollmentAuthenticator.cpp
@@ -98,6 +98,17 @@ namespace remoted::enrollment
                                           std::string_view body,
                                           std::int64_t currentUnixTimeSeconds) const
     {
+        // Checked first, in EVERY mode (including Open): otherwise an unauthenticated peer could
+        // make this endpoint hold an arbitrarily large body -- up to the transport's own cap, not
+        // this class's -- in the in-flight budget shared with every other route, for however long
+        // parseAndValidateBody() takes to notice and reject it. Checking here also means an
+        // oversized body gets the same 413 every other endpoint returns, instead of falling
+        // through to parseAndValidateBody()'s own (much smaller) cap and a 400.
+        if (body.size() > m_config.maxBodySize)
+        {
+            return remoted::auth::AuthError::BodyTooLarge;
+        }
+
         if (!m_config.requirePassword)
         {
             return std::nullopt;
@@ -143,10 +154,14 @@ namespace remoted::enrollment
         // Fail-closed: Password mode active but the key is unavailable (file missing/unreadable/
         // invalid, or not yet synced from the master to a worker) -- never fall back to Open mode.
         // See PasswordKeySource's class comment for why conflating the two would be a security bug.
+        // EnrollmentKeyUnavailable, deliberately NOT MissingKey: MissingKey means an already-
+        // enrolled agent's client.keys entry doesn't decode, and logRejection() tells the operator
+        // to "re-enroll" for that -- nonsensical advice here, where there is no agent and no
+        // client.keys entry yet at all.
         const auto key = m_keySource ? m_keySource->currentKey() : std::nullopt;
         if (!key)
         {
-            return remoted::auth::AuthError::MissingKey;
+            return remoted::auth::AuthError::EnrollmentKeyUnavailable;
         }
 
         std::array<std::uint8_t, remoted::auth::Cmac::kMacSize> expectedMac {};
@@ -160,13 +175,13 @@ namespace remoted::enrollment
         {
             // The key is always exactly 32 bytes (HKDF's fixed output length -- see
             // PasswordKeySource), so CmacKeyError cannot fire here; a CmacProviderError means
-            // AES-CMAC itself is unavailable manager-wide, which collapses to the same
-            // MissingKey/401 AuthMiddleware uses for that condition.
+            // AES-CMAC itself is unavailable manager-wide -- same EnrollmentKeyUnavailable as
+            // above, since either way there is no usable key to check the MAC against.
             cmac = std::make_unique<remoted::auth::Cmac>(*key);
         }
         catch (const std::exception&)
         {
-            return remoted::auth::AuthError::MissingKey;
+            return remoted::auth::AuthError::EnrollmentKeyUnavailable;
         }
 
         cmac->update("WAZUH-ENROLL\n");

--- a/src/remoted/remoted_module/src/enrollment/enrollmentAuthenticator.cpp
+++ b/src/remoted/remoted_module/src/enrollment/enrollmentAuthenticator.cpp
@@ -1,0 +1,191 @@
+/*
+ * Wazuh remoted module - agent enrollment authenticator
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 19, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "enrollmentAuthenticator.hpp"
+
+#include "auth/cmac.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <charconv>
+#include <memory>
+#include <string>
+
+namespace remoted::enrollment
+{
+    namespace
+    {
+        bool isAllDigits(std::string_view s)
+        {
+            return !s.empty() && std::all_of(s.begin(), s.end(), [](char c) { return c >= '0' && c <= '9'; });
+        }
+
+        bool isLowerHex32(std::string_view s)
+        {
+            if (s.size() != 32)
+            {
+                return false;
+            }
+            return std::all_of(
+                s.begin(), s.end(), [](char c) { return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'); });
+        }
+
+        struct ParsedWazuhEnroll
+        {
+            std::string_view timestamp;
+            std::string_view mac;
+        };
+
+        // Parses "WazuhEnroll <timestamp>:<mac>" -- no agent-id field, unlike the "Wazuh
+        // <agent-id>:<timestamp>:<mac>" scheme AuthMiddleware parses (see class comment).
+        std::optional<ParsedWazuhEnroll> parseAuthorization(std::string_view header)
+        {
+            constexpr std::string_view kScheme = "WazuhEnroll ";
+            if (header.size() <= kScheme.size() || header.substr(0, kScheme.size()) != kScheme)
+            {
+                return std::nullopt;
+            }
+
+            const std::string_view rest = header.substr(kScheme.size());
+            const auto colon = rest.find(':');
+            if (colon == std::string_view::npos)
+            {
+                return std::nullopt;
+            }
+            const std::string_view timestamp = rest.substr(0, colon);
+            const std::string_view mac = rest.substr(colon + 1);
+
+            if (!isAllDigits(timestamp))
+            {
+                return std::nullopt;
+            }
+            if (!isLowerHex32(mac))
+            {
+                return std::nullopt;
+            }
+
+            return ParsedWazuhEnroll {timestamp, mac};
+        }
+
+        std::string toUpper(std::string_view s)
+        {
+            std::string out(s);
+            std::transform(out.begin(), out.end(), out.begin(), [](unsigned char c) { return std::toupper(c); });
+            return out;
+        }
+    } // namespace
+
+    EnrollmentAuthenticator::EnrollmentAuthenticator(EnrollmentAuthConfig config,
+                                                     std::shared_ptr<remoted::auth::PasswordKeySource> keySource)
+        : m_config(std::move(config))
+        , m_keySource(std::move(keySource))
+    {
+    }
+
+    std::optional<remoted::auth::AuthError>
+    EnrollmentAuthenticator::authenticate(std::string_view authorizationHeader,
+                                          std::string_view method,
+                                          std::string_view requestTarget,
+                                          std::string_view body,
+                                          std::int64_t currentUnixTimeSeconds) const
+    {
+        if (!m_config.requirePassword)
+        {
+            return std::nullopt;
+        }
+        return authenticatePassword(authorizationHeader, method, requestTarget, body, currentUnixTimeSeconds);
+    }
+
+    std::optional<remoted::auth::AuthError>
+    EnrollmentAuthenticator::authenticatePassword(std::string_view authorizationHeader,
+                                                  std::string_view method,
+                                                  std::string_view requestTarget,
+                                                  std::string_view body,
+                                                  std::int64_t currentUnixTimeSeconds) const
+    {
+        if (authorizationHeader.empty())
+        {
+            return remoted::auth::AuthError::MissingAuthorization;
+        }
+
+        const auto parsed = parseAuthorization(authorizationHeader);
+        if (!parsed)
+        {
+            return remoted::auth::AuthError::MalformedAuthorization;
+        }
+
+        std::int64_t timestamp = 0;
+        const auto [ptr, ec] =
+            std::from_chars(parsed->timestamp.data(), parsed->timestamp.data() + parsed->timestamp.size(), timestamp);
+        if (ec != std::errc {} || ptr != parsed->timestamp.data() + parsed->timestamp.size())
+        {
+            return remoted::auth::AuthError::MalformedAuthorization;
+        }
+
+        if (timestamp < currentUnixTimeSeconds - m_config.maxRequestAgeSeconds)
+        {
+            return remoted::auth::AuthError::ExpiredRequest;
+        }
+        if (timestamp > currentUnixTimeSeconds + m_config.maxFutureSkewSeconds)
+        {
+            return remoted::auth::AuthError::FutureRequest;
+        }
+
+        // Fail-closed: Password mode active but the key is unavailable (file missing/unreadable/
+        // invalid, or not yet synced from the master to a worker) -- never fall back to Open mode.
+        // See PasswordKeySource's class comment for why conflating the two would be a security bug.
+        const auto key = m_keySource ? m_keySource->currentKey() : std::nullopt;
+        if (!key)
+        {
+            return remoted::auth::AuthError::MissingKey;
+        }
+
+        std::array<std::uint8_t, remoted::auth::Cmac::kMacSize> expectedMac {};
+        if (!remoted::auth::fromLowerHex(parsed->mac, expectedMac.data(), expectedMac.size()))
+        {
+            return remoted::auth::AuthError::MalformedAuthorization;
+        }
+
+        std::unique_ptr<remoted::auth::Cmac> cmac;
+        try
+        {
+            // The key is always exactly 32 bytes (HKDF's fixed output length -- see
+            // PasswordKeySource), so CmacKeyError cannot fire here; a CmacProviderError means
+            // AES-CMAC itself is unavailable manager-wide, which collapses to the same
+            // MissingKey/401 AuthMiddleware uses for that condition.
+            cmac = std::make_unique<remoted::auth::Cmac>(*key);
+        }
+        catch (const std::exception&)
+        {
+            return remoted::auth::AuthError::MissingKey;
+        }
+
+        cmac->update("WAZUH-ENROLL\n");
+        cmac->update("1\n");
+        cmac->update(toUpper(method));
+        cmac->update("\n");
+        cmac->update(requestTarget);
+        cmac->update("\n");
+        cmac->update(parsed->timestamp);
+        cmac->update("\n");
+        cmac->update(body);
+
+        const auto mac = cmac->finalize();
+        if (!remoted::auth::constantTimeEquals(mac.data(), expectedMac.data(), mac.size()))
+        {
+            return remoted::auth::AuthError::InvalidMac;
+        }
+
+        return std::nullopt;
+    }
+
+} // namespace remoted::enrollment

--- a/src/remoted/remoted_module/src/enrollment/enrollmentAuthenticator.hpp
+++ b/src/remoted/remoted_module/src/enrollment/enrollmentAuthenticator.hpp
@@ -1,0 +1,98 @@
+/*
+ * Wazuh remoted module - agent enrollment authenticator
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 19, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#pragma once
+
+#include "auth/authTypes.hpp" // remoted::auth::AuthError
+#include "auth/passwordKeySource.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace remoted::enrollment
+{
+
+    struct EnrollmentAuthConfig
+    {
+        /// Whether the WazuhEnroll CMAC header is required, mirroring authd's own <use_password>.
+        /// Deliberately independent of whatever client-certificate requirement the TLS listener
+        /// separately enforces (HttpServerConfig::verificationMode) -- legacy authd already treats
+        /// its own <ssl_verify_host> (cert) and <use_password> checks as two independent gates on
+        /// the same connection (main-server.c: check_x509_cert() at the TLS handshake, the `PASS:`
+        /// line separately while parsing the enrollment message), so an operator who configures
+        /// both today already gets both enforced. Modeling this as a single mutually-exclusive
+        /// "mode" (mTLS XOR Password) would have silently dropped the password check whenever a
+        /// client certificate was also required -- this flag exists so that can't happen.
+        bool requirePassword {false};
+        std::int64_t maxRequestAgeSeconds {300};
+        std::int64_t maxFutureSkewSeconds {30};
+    };
+
+    /**
+     * @brief Authenticates POST /enroll requests.
+     *
+     * /enroll is registered directly on IHttpServer, bypassing AuthGateway/AuthMiddleware: an
+     * enrolling agent has no client.keys entry yet, so the agent<->manager AES-CMAC protocol
+     * (keyed by an agent id) structurally cannot apply here. When requirePassword is set, this
+     * class runs a deliberately similar but distinct scheme -- same Cmac primitive, same
+     * freshness-window check, same remoted::auth::AuthError taxonomy (so it collapses through the
+     * same publicErrorFor()/errorResponseFor() as every other endpoint) -- but with no agent-id
+     * field, since the agent doesn't have one yet.
+     *
+     * A client-certificate requirement is NOT this class's concern at all: the TLS listener
+     * enforces it (or doesn't) entirely on its own, before any handler -- including this one --
+     * ever runs. That's why requirePassword=false passes unconditionally regardless of whether
+     * the listener also requires mTLS: from here, "mTLS-only" and "Open" are indistinguishable,
+     * and correctly so.
+     */
+    class EnrollmentAuthenticator
+    {
+    public:
+        /**
+         * @param config    requirePassword + freshness window (same defaults as the agent<->manager
+         *                  scheme: 300s max age, 30s max future skew).
+         * @param keySource Password signing key; ignored (may be null) when requirePassword is false.
+         */
+        EnrollmentAuthenticator(EnrollmentAuthConfig config,
+                                std::shared_ptr<remoted::auth::PasswordKeySource> keySource);
+
+        /**
+         * @brief Authenticate one /enroll request.
+         *
+         * @param authorizationHeader    Value of the Authorization header (empty if absent).
+         *                               Ignored when requirePassword is false.
+         * @param method                 Raw HTTP method, as received (case-insensitive).
+         * @param requestTarget          Raw path + query, exactly as received.
+         * @param body                   Raw request body bytes, exactly as sent on the wire.
+         * @param currentUnixTimeSeconds Current time, for the timestamp-window check.
+         * @return std::nullopt on success, or the AuthError that rejected the request.
+         */
+        std::optional<remoted::auth::AuthError> authenticate(std::string_view authorizationHeader,
+                                                             std::string_view method,
+                                                             std::string_view requestTarget,
+                                                             std::string_view body,
+                                                             std::int64_t currentUnixTimeSeconds) const;
+
+    private:
+        std::optional<remoted::auth::AuthError> authenticatePassword(std::string_view authorizationHeader,
+                                                                     std::string_view method,
+                                                                     std::string_view requestTarget,
+                                                                     std::string_view body,
+                                                                     std::int64_t currentUnixTimeSeconds) const;
+
+        EnrollmentAuthConfig m_config;
+        std::shared_ptr<remoted::auth::PasswordKeySource> m_keySource;
+    };
+
+} // namespace remoted::enrollment

--- a/src/remoted/remoted_module/src/enrollment/enrollmentAuthenticator.hpp
+++ b/src/remoted/remoted_module/src/enrollment/enrollmentAuthenticator.hpp
@@ -14,6 +14,7 @@
 #include "auth/authTypes.hpp" // remoted::auth::AuthError
 #include "auth/passwordKeySource.hpp"
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -37,6 +38,14 @@ namespace remoted::enrollment
         bool requirePassword {false};
         std::int64_t maxRequestAgeSeconds {300};
         std::int64_t maxFutureSkewSeconds {30};
+
+        /// Same `auth_max_body_size` internal option (and the same 10 MiB default) the
+        /// agent<->manager AES-CMAC scheme's AuthConfig enforces (authTypes.cpp) -- checked BEFORE
+        /// the CMAC runs, in BOTH Open and Password mode, so an unauthenticated peer can't make
+        /// this endpoint hash an arbitrarily large body (up to the transport's own cap) and hold
+        /// that many in-flight bytes reserved, and so an oversized body gets the same 413 every
+        /// other endpoint returns instead of falling through to parseAndValidateBody()'s 400.
+        std::size_t maxBodySize {10U * 1024U * 1024U};
     };
 
     /**
@@ -75,6 +84,8 @@ namespace remoted::enrollment
          * @param method                 Raw HTTP method, as received (case-insensitive).
          * @param requestTarget          Raw path + query, exactly as received.
          * @param body                   Raw request body bytes, exactly as sent on the wire.
+         *                               Checked against maxBodySize FIRST, in every mode
+         *                               (including Open) -- see the field's own doc comment.
          * @param currentUnixTimeSeconds Current time, for the timestamp-window check.
          * @return std::nullopt on success, or the AuthError that rejected the request.
          */

--- a/src/remoted/remoted_module/src/enrollment/enrollmentConfig.cpp
+++ b/src/remoted/remoted_module/src/enrollment/enrollmentConfig.cpp
@@ -26,6 +26,13 @@ namespace remoted::enrollment
 
         cfg.passwordRefreshIntervalSec = c.enroll_password_refresh_interval;
 
+        // Same two ABI fields (and the same >0-else-default resolution) authTypes.cpp already
+        // applies for the agent<->manager scheme's AuthConfig -- see the field comment above.
+        cfg.maxRequestAgeSeconds = c.auth_max_request_age > 0 ? c.auth_max_request_age : 300;
+        cfg.maxFutureSkewSeconds = c.auth_max_future_skew > 0 ? c.auth_max_future_skew : 30;
+        cfg.maxBodySize =
+            c.auth_max_body_size > 0 ? static_cast<std::size_t>(c.auth_max_body_size) : (10U * 1024U * 1024U);
+
         cfg.authdConnectTimeoutMs =
             c.authd_connect_timeout > 0 ? static_cast<std::uint32_t>(c.authd_connect_timeout) * 1000U : 0U;
         cfg.authdResponseTimeoutMs =

--- a/src/remoted/remoted_module/src/enrollment/enrollmentConfig.cpp
+++ b/src/remoted/remoted_module/src/enrollment/enrollmentConfig.cpp
@@ -31,6 +31,7 @@ namespace remoted::enrollment
         cfg.authdResponseTimeoutMs =
             c.authd_response_timeout > 0 ? static_cast<std::uint32_t>(c.authd_response_timeout) * 1000U : 0U;
         cfg.authdMaxQueueSize = c.authd_max_queue_size > 0 ? static_cast<std::uint32_t>(c.authd_max_queue_size) : 0U;
+        cfg.authdWorkerThreads = c.authd_worker_threads > 0 ? static_cast<std::uint32_t>(c.authd_worker_threads) : 0U;
 
         return cfg;
     }

--- a/src/remoted/remoted_module/src/enrollment/enrollmentConfig.cpp
+++ b/src/remoted/remoted_module/src/enrollment/enrollmentConfig.cpp
@@ -1,0 +1,38 @@
+/*
+ * Wazuh remoted module - Enrollment endpoint configuration
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 19, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "enrollmentConfig.hpp"
+
+namespace remoted::enrollment
+{
+    Config buildEnrollmentConfig(const remoted_module_config_t& c)
+    {
+        Config cfg;
+
+        cfg.enrollmentEnabled = c.enrollment_enabled;
+        cfg.usePassword = c.enroll_use_password;
+        cfg.useSourceIp = c.enroll_use_source_ip;
+        cfg.allowHigherVersions = c.enroll_allow_higher_versions;
+        cfg.managerVersion = c.manager_version;
+        cfg.isWorkerNode = c.worker_node;
+
+        cfg.passwordRefreshIntervalSec = c.enroll_password_refresh_interval;
+
+        cfg.authdConnectTimeoutMs =
+            c.authd_connect_timeout > 0 ? static_cast<std::uint32_t>(c.authd_connect_timeout) * 1000U : 0U;
+        cfg.authdResponseTimeoutMs =
+            c.authd_response_timeout > 0 ? static_cast<std::uint32_t>(c.authd_response_timeout) * 1000U : 0U;
+        cfg.authdMaxQueueSize = c.authd_max_queue_size > 0 ? static_cast<std::uint32_t>(c.authd_max_queue_size) : 0U;
+
+        return cfg;
+    }
+
+} // namespace remoted::enrollment

--- a/src/remoted/remoted_module/src/enrollment/enrollmentConfig.hpp
+++ b/src/remoted/remoted_module/src/enrollment/enrollmentConfig.hpp
@@ -13,6 +13,7 @@
 
 #include "remoted_module.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 
@@ -36,6 +37,18 @@ namespace remoted::enrollment
         bool allowHigherVersions {false};
         std::string managerVersion;
         bool isWorkerNode {false};
+
+        /// Same ABI fields (auth_max_request_age/auth_max_future_skew) and the same defaults (300 /
+        /// 30) the agent<->manager AES-CMAC scheme's AuthConfig resolves (authTypes.cpp) -- /enroll's
+        /// WazuhEnroll scheme reuses the identical freshness-window check, so it must not silently
+        /// diverge from these two already-documented, already-tunable internal options.
+        std::int64_t maxRequestAgeSeconds {300};
+        std::int64_t maxFutureSkewSeconds {30};
+
+        /// Same `auth_max_body_size` ABI field (and the same 10 MiB default) authTypes.cpp
+        /// resolves for the agent<->manager scheme's AuthConfig -- see EnrollmentAuthConfig's own
+        /// field comment for why /enroll must not silently exempt itself from this cap.
+        std::size_t maxBodySize {10U * 1024U * 1024U};
 
         /// Seconds between etc/authd.pass change checks. Passed straight to PasswordKeySource,
         /// which itself treats <=0 as "use its own built-in default" -- no resolution needed here.

--- a/src/remoted/remoted_module/src/enrollment/enrollmentConfig.hpp
+++ b/src/remoted/remoted_module/src/enrollment/enrollmentConfig.hpp
@@ -1,0 +1,54 @@
+/*
+ * Wazuh remoted module - Enrollment endpoint configuration
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 19, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#pragma once
+
+#include "remoted_module.h"
+
+#include <cstdint>
+#include <string>
+
+namespace remoted::enrollment
+{
+
+    /**
+     * @brief Resolved /enroll configuration, translated from the C ABI.
+     *
+     * The behavioral flags (enrollmentEnabled/usePassword/useSourceIp/allowHigherVersions) are
+     * copied verbatim from authd's own <auth> block (see remoted_module.h's comment on the ABI
+     * fields this reads) -- they are not remoted-owned tuning knobs, so /enroll and legacy port
+     * 1515 can never disagree on whether password auth is required or which agent versions are
+     * acceptable.
+     */
+    struct Config
+    {
+        bool enrollmentEnabled {false};
+        bool usePassword {false};
+        bool useSourceIp {false};
+        bool allowHigherVersions {false};
+        std::string managerVersion;
+        bool isWorkerNode {false};
+
+        /// Seconds between etc/authd.pass change checks. Passed straight to PasswordKeySource,
+        /// which itself treats <=0 as "use its own built-in default" -- no resolution needed here.
+        int passwordRefreshIntervalSec {0};
+
+        /// Milliseconds, already converted from the ABI's seconds-denominated fields. 0 means "let
+        /// AuthdClient apply its own built-in default" -- the same sentinel AuthdClient's
+        /// constructor itself documents, so this is a unit conversion, not a default resolution.
+        std::uint32_t authdConnectTimeoutMs {0};
+        std::uint32_t authdResponseTimeoutMs {0};
+        std::uint32_t authdMaxQueueSize {0};
+    };
+
+    Config buildEnrollmentConfig(const remoted_module_config_t& c);
+
+} // namespace remoted::enrollment

--- a/src/remoted/remoted_module/src/enrollment/enrollmentConfig.hpp
+++ b/src/remoted/remoted_module/src/enrollment/enrollmentConfig.hpp
@@ -47,6 +47,11 @@ namespace remoted::enrollment
         std::uint32_t authdConnectTimeoutMs {0};
         std::uint32_t authdResponseTimeoutMs {0};
         std::uint32_t authdMaxQueueSize {0};
+
+        /// Number of concurrent AuthdClient workers bridging to authd's local socket. 0 -> let
+        /// AuthdClient apply its own built-in default. See authdClient.hpp's class comment for why
+        /// more than one is worth having even though authd's own accept loop is single-threaded.
+        std::uint32_t authdWorkerThreads {0};
     };
 
     Config buildEnrollmentConfig(const remoted_module_config_t& c);

--- a/src/remoted/remoted_module/src/enrollment/enrollmentEndpoint.cpp
+++ b/src/remoted/remoted_module/src/enrollment/enrollmentEndpoint.cpp
@@ -138,8 +138,16 @@ namespace remoted::enrollment
             {
                 return false;
             }
-            const int prefix = std::stoi(std::string(prefixPart));
-            return prefix >= 0 && prefix <= maxPrefix;
+            try
+            {
+                const int prefix = std::stoi(std::string(prefixPart));
+                return prefix >= 0 && prefix <= maxPrefix;
+            }
+            catch (const std::exception&)
+            {
+                // All-digit but out of range for int (e.g. a huge prefix string) -> not a valid prefix.
+                return false;
+            }
         }
 
         struct ParsedBody

--- a/src/remoted/remoted_module/src/enrollment/enrollmentEndpoint.cpp
+++ b/src/remoted/remoted_module/src/enrollment/enrollmentEndpoint.cpp
@@ -1,0 +1,360 @@
+/*
+ * Wazuh remoted module - POST /enroll endpoint
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 19, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "enrollmentEndpoint.hpp"
+
+#include "common/logThrottle.hpp"
+#include "control/controlTypes.hpp"    // isValidVersion(), compareVersions() -- shared with /control (D8)
+#include "endpoints/endpoint.hpp"      // remoted::endpoints::errorResponseFor() -- shared auth-rejection logging
+#include "http_server/headerUtils.hpp" // remoted::http::headerValue() -- case-insensitive lookup
+#include "json.hpp"
+#include "loggerHelper.h"
+
+#include <arpa/inet.h>
+#include <sys/socket.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <ctime>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+
+using remoted::http::headerValue;
+
+namespace remoted::enrollment
+{
+    namespace
+    {
+        constexpr auto ENROLLMENT_ENDPOINT_LOGTAG {"wazuh-manager-remoted:enrollment-endpoint"};
+
+        const LogFn& logFn()
+        {
+            static const LogFn instance {ENROLLMENT_ENDPOINT_LOGTAG};
+            return instance;
+        }
+
+        remoted::common::LogThrottle& invalidBodyThrottle()
+        {
+            static remoted::common::LogThrottle instance;
+            return instance;
+        }
+
+        remoted::common::LogThrottle& authdErrorThrottle()
+        {
+            static remoted::common::LogThrottle instance;
+            return instance;
+        }
+
+        remoted::common::LogThrottle& authdUnavailableThrottle()
+        {
+            static remoted::common::LogThrottle instance;
+            return instance;
+        }
+
+        // Cap on the /enroll JSON body actually parsed -- an endpoint-local guard on top of the
+        // transport's own hard cap, same rationale as /control's kMaxControlBodySize.
+        constexpr std::size_t kMaxEnrollBodySize = 16U * 1024U;
+        constexpr std::size_t kMaxNameLength = 128;
+
+        remoted::http::HttpResponse errorResponse(int status, int code, std::string_view message)
+        {
+            nlohmann::json j;
+            j["error"]["code"] = code;
+            j["error"]["message"] = std::string(message);
+            return remoted::http::HttpResponse::json(status, j.dump());
+        }
+
+        // Bridges an EnrollmentAuthenticator rejection to /enroll's own error envelope, while
+        // reusing errorResponseFor()'s shared logging discipline (throttled WARN for clock skew,
+        // DEBUG2 for plain client faults) so an unauthenticated peer can't flood the log any more
+        // here than it could against any other endpoint. code is always 0: none of the AuthError
+        // values EnrollmentAuthenticator can return carry a numeric authd code.
+        remoted::http::HttpResponse authErrorResponse(remoted::auth::AuthError err)
+        {
+            const auto logged = remoted::endpoints::errorResponseFor(err);
+            return errorResponse(logged.status, 0, remoted::auth::publicErrorFor(err).message);
+        }
+
+        bool isValidName(std::string_view name)
+        {
+            if (name.empty() || name.size() > kMaxNameLength)
+            {
+                return false;
+            }
+            // Reject control characters (wire-framing safety); authd re-validates independently
+            // and far more strictly -- this is only a cheap, local guard.
+            return std::none_of(name.begin(), name.end(), [](unsigned char c) { return c < 0x20 || c == 0x7F; });
+        }
+
+        // Syntactic IPv4/IPv6/CIDR check, plus authd's own "any" sentinel (used when the manager
+        // should fall back to config.use_source_ip / no override). Not a semantic check -- authd's
+        // local `add` path re-validates independently.
+        bool isValidIpOrCidr(std::string_view value)
+        {
+            if (value == "any")
+            {
+                return true;
+            }
+
+            std::string addr(value);
+            std::string_view prefixPart;
+            if (const auto slash = addr.find('/'); slash != std::string::npos)
+            {
+                prefixPart = std::string_view {addr}.substr(slash + 1);
+                addr.resize(slash);
+            }
+
+            int maxPrefix = 0;
+            unsigned char buf[16];
+            if (inet_pton(AF_INET, addr.c_str(), buf) == 1)
+            {
+                maxPrefix = 32;
+            }
+            else if (inet_pton(AF_INET6, addr.c_str(), buf) == 1)
+            {
+                maxPrefix = 128;
+            }
+            else
+            {
+                return false;
+            }
+
+            if (prefixPart.empty())
+            {
+                return true;
+            }
+            if (!std::all_of(prefixPart.begin(), prefixPart.end(), [](char c) { return c >= '0' && c <= '9'; }))
+            {
+                return false;
+            }
+            const int prefix = std::stoi(std::string(prefixPart));
+            return prefix >= 0 && prefix <= maxPrefix;
+        }
+
+        struct ParsedBody
+        {
+            std::string name;
+            std::string version;
+            std::optional<std::string> groups;
+            std::optional<std::string> ip;
+            std::optional<std::string> keyHash;
+        };
+
+        // Local validation only -- never authd's own rules. On failure, the string is the (fixed,
+        // quote-free) message placed in the response's "message" field.
+        std::variant<ParsedBody, std::string> parseAndValidateBody(const std::string& body)
+        {
+            if (body.empty() || body.size() > kMaxEnrollBodySize)
+            {
+                return std::string("Missing or invalid request body");
+            }
+
+            nlohmann::json j = nlohmann::json::parse(body.data(), body.data() + body.size(), nullptr, false);
+            if (j.is_discarded() || !j.is_object())
+            {
+                return std::string("Malformed JSON body");
+            }
+
+            ParsedBody parsed;
+
+            const auto nameIt = j.find("name");
+            if (nameIt == j.end() || !nameIt->is_string() || !isValidName(nameIt->get<std::string>()))
+            {
+                return std::string("Missing or invalid field: name");
+            }
+            parsed.name = nameIt->get<std::string>();
+
+            const auto versionIt = j.find("version");
+            if (versionIt == j.end() || !versionIt->is_string() ||
+                !remoted::control::isValidVersion(versionIt->get<std::string>()))
+            {
+                return std::string("Missing or invalid field: version");
+            }
+            parsed.version = versionIt->get<std::string>();
+
+            if (const auto it = j.find("groups"); it != j.end() && !it->is_null())
+            {
+                if (!it->is_string())
+                {
+                    return std::string("Invalid field: groups");
+                }
+                parsed.groups = it->get<std::string>();
+            }
+
+            if (const auto it = j.find("ip"); it != j.end() && !it->is_null())
+            {
+                if (!it->is_string() || !isValidIpOrCidr(it->get<std::string>()))
+                {
+                    return std::string("Invalid field: ip");
+                }
+                parsed.ip = it->get<std::string>();
+            }
+
+            if (const auto it = j.find("key_hash"); it != j.end() && !it->is_null())
+            {
+                if (!it->is_string())
+                {
+                    return std::string("Invalid field: key_hash");
+                }
+                parsed.keyHash = it->get<std::string>();
+            }
+
+            return parsed;
+        }
+
+        std::string resolveIp(bool useSourceIp, const std::string& remoteIp, const std::optional<std::string>& bodyIp)
+        {
+            if (useSourceIp)
+            {
+                return remoteIp;
+            }
+            if (bodyIp)
+            {
+                return *bodyIp;
+            }
+            return "any";
+        }
+
+        int httpStatusForAuthdError(int code)
+        {
+            switch (code)
+            {
+                case 9001:
+                case 9002:
+                case 9009: return 500;
+                case 9003:
+                case 9004:
+                case 9005:
+                case 9006:
+                case 9014: return 400;
+                case 9007:
+                case 9008:
+                case 9012: return 409;
+                case 9013: // max_agents reached
+                case 9015: // worker rejection (remove/get, post cluster-forwarding fix)
+                case 9016: // clustered forward to master failed
+                    return 503;
+                default: return 500;
+            }
+        }
+
+        remoted::http::HttpResponse mapAuthdResult(const AuthdResult& result, EnrollmentMetrics& metrics)
+        {
+            if (result.errorCode == 0)
+            {
+                incAccepted(metrics);
+                nlohmann::json j;
+                j["id"] = result.id;
+                j["name"] = result.name;
+                j["ip"] = result.ip;
+                j["key"] = result.key;
+                return remoted::http::HttpResponse::json(200, j.dump());
+            }
+
+            if (result.errorCode > 0)
+            {
+                incAuthdError(metrics);
+                if (const auto throttle = authdErrorThrottle().record())
+                {
+                    LOGFN_DEBUG1(logFn(),
+                                 "authd rejected %llu /enroll request(s) in the last %d s (last code=%d: %s).",
+                                 throttle.total,
+                                 remoted::common::LogThrottle::kDefaultWindowSeconds,
+                                 result.errorCode,
+                                 result.message.c_str());
+                }
+                return errorResponse(httpStatusForAuthdError(result.errorCode), result.errorCode, result.message);
+            }
+
+            incAuthdUnavailable(metrics);
+            if (const auto throttle = authdUnavailableThrottle().record())
+            {
+                LOGFN_WARN(logFn(),
+                           "%llu /enroll request(s) got no clean answer from authd in the last %d s (last: %s). Is "
+                           "authd running and enrollment reachable at its local socket?",
+                           throttle.total,
+                           remoted::common::LogThrottle::kDefaultWindowSeconds,
+                           result.message.c_str());
+            }
+            return errorResponse(503, -1, "Enrollment service temporarily unavailable");
+        }
+
+    } // namespace
+
+    remoted::http::RouteHandler makeHandler(const EnrollmentAuthenticator& authenticator,
+                                            AuthdClient& authdClient,
+                                            const Config& config,
+                                            EnrollmentMetrics& metrics)
+    {
+        return
+            [&authenticator, &authdClient, config, &metrics](std::shared_ptr<const remoted::http::HttpRequest> request,
+                                                             std::shared_ptr<remoted::http::IHttpResponder> responder)
+        {
+            if (!config.enrollmentEnabled)
+            {
+                incDisabled(metrics);
+                responder->send(errorResponse(403, 0, "Enrollment is disabled on this manager"));
+                return;
+            }
+
+            const auto now = static_cast<std::int64_t>(std::time(nullptr));
+            const auto authErr = authenticator.authenticate(
+                headerValue(request->headers, "authorization"), "POST", request->target, request->body, now);
+            if (authErr)
+            {
+                incRejectedAuth(metrics);
+                responder->send(authErrorResponse(*authErr));
+                return;
+            }
+
+            const auto parsedOrError = parseAndValidateBody(request->body);
+            if (std::holds_alternative<std::string>(parsedOrError))
+            {
+                incRejectedValidation(metrics);
+                if (const auto throttle = invalidBodyThrottle().record())
+                {
+                    LOGFN_DEBUG2(logFn(),
+                                 "Rejected %llu invalid /enroll request(s) in the last %d s (last reason: %s).",
+                                 throttle.total,
+                                 remoted::common::LogThrottle::kDefaultWindowSeconds,
+                                 std::get<std::string>(parsedOrError).c_str());
+                }
+                responder->send(errorResponse(400, 0, std::get<std::string>(parsedOrError)));
+                return;
+            }
+            const auto& parsed = std::get<ParsedBody>(parsedOrError);
+
+            // authd's local `add` path performs no version check at all, so remoted enforces
+            // allow_higher_versions itself here, reusing compareVersions() rather than duplicating it.
+            if (!config.allowHigherVersions &&
+                remoted::control::compareVersions(config.managerVersion, parsed.version) < 0)
+            {
+                incRejectedValidation(metrics);
+                responder->send(errorResponse(400, 0, "Agent version is newer than this manager allows"));
+                return;
+            }
+
+            AuthdAddRequest addRequest;
+            addRequest.name = parsed.name;
+            addRequest.ip = resolveIp(config.useSourceIp, request->remoteIp, parsed.ip);
+            addRequest.groups = parsed.groups;
+            addRequest.keyHash = parsed.keyHash;
+
+            authdClient.addAgent(std::move(addRequest),
+                                 [responder, &metrics](AuthdResult result)
+                                 { responder->send(mapAuthdResult(result, metrics)); });
+        };
+    }
+
+} // namespace remoted::enrollment

--- a/src/remoted/remoted_module/src/enrollment/enrollmentEndpoint.cpp
+++ b/src/remoted/remoted_module/src/enrollment/enrollmentEndpoint.cpp
@@ -63,7 +63,9 @@ namespace remoted::enrollment
         }
 
         // Cap on the /enroll JSON body actually parsed -- an endpoint-local guard on top of the
-        // transport's own hard cap, same rationale as /control's kMaxControlBodySize.
+        // transport's own hard cap, same rationale as /control's kMaxControlBodySize. Applied
+        // AFTER decoding, so it bounds the decompressed size a decompression-bomb could otherwise
+        // produce, not just the (already zstd-bomb-guarded) compressed wire size.
         constexpr std::size_t kMaxEnrollBodySize = 16U * 1024U;
         constexpr std::size_t kMaxNameLength = 128;
 
@@ -160,8 +162,9 @@ namespace remoted::enrollment
         };
 
         // Local validation only -- never authd's own rules. On failure, the string is the (fixed,
-        // quote-free) message placed in the response's "message" field.
-        std::variant<ParsedBody, std::string> parseAndValidateBody(const std::string& body)
+        // quote-free) message placed in the response's "message" field. Takes a string_view since
+        // the caller passes the (possibly decompressed) Payload's view, not necessarily a std::string.
+        std::variant<ParsedBody, std::string> parseAndValidateBody(std::string_view body)
         {
             if (body.empty() || body.size() > kMaxEnrollBodySize)
             {
@@ -303,11 +306,12 @@ namespace remoted::enrollment
     remoted::http::RouteHandler makeHandler(const EnrollmentAuthenticator& authenticator,
                                             AuthdClient& authdClient,
                                             const Config& config,
-                                            EnrollmentMetrics& metrics)
+                                            EnrollmentMetrics& metrics,
+                                            std::shared_ptr<const remoted::decoding::IBodyDecoder> bodyDecoder)
     {
-        return
-            [&authenticator, &authdClient, config, &metrics](std::shared_ptr<const remoted::http::HttpRequest> request,
-                                                             std::shared_ptr<remoted::http::IHttpResponder> responder)
+        return [&authenticator, &authdClient, config, &metrics, bodyDecoder = std::move(bodyDecoder)](
+                   std::shared_ptr<const remoted::http::HttpRequest> request,
+                   std::shared_ptr<remoted::http::IHttpResponder> responder)
         {
             if (!config.enrollmentEnabled)
             {
@@ -315,6 +319,12 @@ namespace remoted::enrollment
                 responder->send(errorResponse(403, 0, "Enrollment is disabled on this manager"));
                 return;
             }
+
+            // Parsed here (before authentication), acted on only after it succeeds below -- same
+            // ordering AuthGateway uses: the MAC must cover the wire bytes exactly as sent,
+            // compressed or not, so decoding can never run against an unauthenticated body.
+            const auto contentEncoding =
+                remoted::decoding::parseContentEncoding(headerValue(request->headers, "content-encoding"));
 
             const auto now = static_cast<std::int64_t>(std::time(nullptr));
             const auto authErr = authenticator.authenticate(
@@ -326,7 +336,19 @@ namespace remoted::enrollment
                 return;
             }
 
-            const auto parsedOrError = parseAndValidateBody(request->body);
+            // Zero-copy view into request->body, kept alive by the request itself -- same
+            // technique AuthGateway uses (authGateway.cpp) for the same reason: one physical copy
+            // of the wire body, decoding replaces the view in place only on the Zstd path.
+            remoted::auth::Payload payload {std::string_view {request->body}, request};
+            const auto decodeError = bodyDecoder->decode(contentEncoding, payload);
+            if (decodeError != remoted::auth::AuthError::None)
+            {
+                incRejectedValidation(metrics);
+                responder->send(authErrorResponse(decodeError));
+                return;
+            }
+
+            const auto parsedOrError = parseAndValidateBody(payload.bytes());
             if (std::holds_alternative<std::string>(parsedOrError))
             {
                 incRejectedValidation(metrics);

--- a/src/remoted/remoted_module/src/enrollment/enrollmentEndpoint.cpp
+++ b/src/remoted/remoted_module/src/enrollment/enrollmentEndpoint.cpp
@@ -22,6 +22,7 @@
 #include <sys/socket.h>
 
 #include <algorithm>
+#include <cctype>
 #include <cstdint>
 #include <ctime>
 #include <optional>
@@ -62,11 +63,11 @@ namespace remoted::enrollment
             return instance;
         }
 
-        // Cap on the /enroll JSON body actually parsed -- an endpoint-local guard on top of the
-        // transport's own hard cap, same rationale as /control's kMaxControlBodySize. Applied
-        // AFTER decoding, so it bounds the decompressed size a decompression-bomb could otherwise
-        // produce, not just the (already zstd-bomb-guarded) compressed wire size.
-        constexpr std::size_t kMaxEnrollBodySize = 16U * 1024U;
+        // kMaxEnrollBodySize itself lives in enrollmentEndpoint.hpp now (public): remotedModuleFacade.hpp
+        // needs the SAME value to cap BodyDecoder's decoded-size for /enroll's dedicated instance
+        // (see makeHandler()'s doc comment on why Open mode needs that extra cap). Applied AFTER
+        // decoding here too, so together with that cap this bounds both the compressed wire size
+        // AND the decompressed size a decompression-bomb could otherwise produce.
         constexpr std::size_t kMaxNameLength = 128;
 
         remoted::http::HttpResponse errorResponse(int status, int code, std::string_view message)
@@ -90,30 +91,59 @@ namespace remoted::enrollment
 
         bool isValidName(std::string_view name)
         {
-            if (name.empty() || name.size() > kMaxNameLength)
+            // Mirrors OS_IsValidName() (shared/src/agent_validate_op.c) exactly, which is what the
+            // network (port 1515) enrollment path applies (auth.c) -- so both ways an agent can
+            // enroll accept exactly the same set of names, and neither mints a name the other
+            // would have refused.
+            //
+            // Note this is STRICTER than what authd's local socket enforces: that socket checks
+            // only the storage-safety invariant (is_storable_agent_name() in local-server.c),
+            // because its established callers -- manage_agents and the API -- have a longer-
+            // standing, more permissive contract that predates this endpoint and must keep
+            // working. Enrollment has no such obligation, so it holds the tighter line here rather
+            // than relying on the socket's floor. Rejecting locally also means never opening a
+            // connection to authd for a name it could not accept anyway.
+            //
+            // A name outside this charset could corrupt client.keys once written (a space splits
+            // into extra fields; a leading '#'/'!' collides with the removed-entry marker
+            // convention), or simply never round-trip to a name authd itself would accept.
+            if (name.size() < 2 || name.size() > kMaxNameLength)
             {
                 return false;
             }
-            // Reject control characters (wire-framing safety); authd re-validates independently
-            // and far more strictly -- this is only a cheap, local guard.
-            return std::none_of(name.begin(), name.end(), [](unsigned char c) { return c < 0x20 || c == 0x7F; });
+            if (name.front() == '.')
+            {
+                return false;
+            }
+            return std::all_of(name.begin(),
+                               name.end(),
+                               [](unsigned char c) { return std::isalnum(c) || c == '-' || c == '_' || c == '.'; });
         }
 
-        // Syntactic IPv4/IPv6/CIDR check, plus authd's own "any" sentinel (used when the manager
-        // should fall back to config.use_source_ip / no override). Not a semantic check -- authd's
-        // local `add` path re-validates independently.
+        // Syntactic IPv4/IPv6/CIDR check, plus two sentinels neither of which is a real address:
+        // "any" (authd's own "no override" value) and "src" (the legacy port 1515 wire protocol's
+        // "use the connection's actual source IP instead of whatever I put here" sentinel --
+        // os_auth/src/auth.c:208, `IP:'src'`; sent by an agent configured with <use_source_ip> on
+        // its own side, mirrored here for the same client-side setting). Not a semantic check --
+        // authd's local `add` path re-validates independently (and does NOT understand "src"
+        // itself -- see resolveIp() below, which must resolve it before ever reaching authd).
         bool isValidIpOrCidr(std::string_view value)
         {
-            if (value == "any")
+            if (value == "any" || value == "src")
             {
                 return true;
             }
 
             std::string addr(value);
-            std::string_view prefixPart;
+            std::string prefixPart;
             if (const auto slash = addr.find('/'); slash != std::string::npos)
             {
-                prefixPart = std::string_view {addr}.substr(slash + 1);
+                // Copied BEFORE resize(), not a string_view into addr's own buffer: resize() to a
+                // smaller size does not guarantee the bytes past the new length stay valid (it must
+                // rewrite the byte at the new size to '\0', and the standard leaves what's beyond
+                // that unspecified) -- a view taken first would work by accident on some libstdc++
+                // builds and read invalidated/annotated memory under ASan or a hardened one.
+                prefixPart = addr.substr(slash + 1);
                 addr.resize(slash);
             }
 
@@ -230,6 +260,14 @@ namespace remoted::enrollment
             {
                 return remoteIp;
             }
+            // "src" is never forwarded to authd literally: it is not an IP, and authd's local
+            // `add` path has no notion of it at all (that sentinel only exists in port 1515's own
+            // wire parser, auth.c:208) -- it means "use this HTTPS connection's actual peer
+            // address", the one thing /enroll always already knows.
+            if (bodyIp == "src")
+            {
+                return remoteIp;
+            }
             if (bodyIp)
             {
                 return *bodyIp;
@@ -248,7 +286,13 @@ namespace remoted::enrollment
                 case 9004:
                 case 9005:
                 case 9006:
-                case 9014: return 400;
+                case 9014:
+                case 9017: // invalid name format. Unreachable from here in practice: isValidName()
+                           // is strictly tighter than the local socket's storage-safety floor, so
+                           // any name authd would reject with 9017 was already refused locally with
+                           // a 400. Mapped for completeness, and so the status stays right if the
+                           // two checks ever diverge.
+                    return 400;
                 case 9007:
                 case 9008:
                 case 9012: return 409;

--- a/src/remoted/remoted_module/src/enrollment/enrollmentEndpoint.hpp
+++ b/src/remoted/remoted_module/src/enrollment/enrollmentEndpoint.hpp
@@ -12,10 +12,13 @@
 #pragma once
 
 #include "authdClient.hpp"
+#include "decoding/iBodyDecoder.hpp" // remoted::decoding::IBodyDecoder
 #include "enrollmentAuthenticator.hpp"
 #include "enrollmentConfig.hpp"
 #include "http_server/IHttpServer.hpp" // remoted::http::RouteHandler
 #include "metrics.hpp"
+
+#include <memory>
 
 namespace remoted::enrollment
 {
@@ -30,24 +33,33 @@ namespace remoted::enrollment
      *      authenticator or the bridge -- the route always exists (never a 404); this is what
      *      lets an operator/agent tell "unsupported" apart from "administratively off".
      *   2. Runs @p authenticator against the raw request (mode fixed at facade-construction time
-     *      by the listener's client-certificate requirement and authd's <use_password>).
-     *   3. Parses and locally validates the JSON body (name/version/groups/ip/key_hash); rejects
-     *      malformed input with 400 without ever reaching authd. `force`/`id`/`key` are never
-     *      read from the body even if present -- self-enrollment always gets an auto-assigned ID
-     *      and an authd-generated key.
-     *   4. Resolves the enrollment IP (config.useSourceIp -> the HTTPS peer address; else the
+     *      by the listener's client-certificate requirement and authd's <use_password>). The MAC
+     *      always covers the wire bytes exactly as sent, compressed or not -- same principle as
+     *      AuthGateway (see authGateway.cpp).
+     *   3. Runs @p bodyDecoder over the now-verified body, so /enroll honors the manager's
+     *      `Content-Encoding: zstd` policy exactly like every other endpoint (`remoted.
+     *      http_content_encoding_enabled`) -- decoding only ever happens AFTER authentication, so
+     *      an unauthenticated peer can never spend CPU/memory on it.
+     *   4. Parses and locally validates the (decoded) JSON body (name/version/groups/ip/key_hash);
+     *      rejects malformed input with 400 without ever reaching authd. `force`/`id`/`key` are
+     *      never read from the body even if present -- self-enrollment always gets an
+     *      auto-assigned ID and an authd-generated key.
+     *   5. Resolves the enrollment IP (config.useSourceIp -> the HTTPS peer address; else the
      *      body's `ip`; else "any") and forwards to authd via @p authdClient, deferring the
      *      response until its callback fires.
-     *   5. Maps authd's result to the HTTP response (200 + {id,name,ip,key}; a mapped status for
+     *   6. Maps authd's result to the HTTP response (200 + {id,name,ip,key}; a mapped status for
      *      a business-rejection authd code; 503 for a transport failure/timeout).
      *
      * @warning The returned handler stores references to @p authenticator, @p authdClient and
      * @p metrics. The caller must guarantee all three outlive every route registered with this
-     * handler, exactly like controlEndpoint::makeHandler()'s ControlHandler& contract.
+     * handler, exactly like controlEndpoint::makeHandler()'s ControlHandler& contract. @p
+     * bodyDecoder is captured as a shared_ptr copy instead (the same instance AuthGateway holds,
+     * per remotedModuleFacade.hpp -- BodyDecoder is stateless, so sharing it is safe).
      */
     remoted::http::RouteHandler makeHandler(const EnrollmentAuthenticator& authenticator,
                                             AuthdClient& authdClient,
                                             const Config& config,
-                                            EnrollmentMetrics& metrics);
+                                            EnrollmentMetrics& metrics,
+                                            std::shared_ptr<const remoted::decoding::IBodyDecoder> bodyDecoder);
 
 } // namespace remoted::enrollment

--- a/src/remoted/remoted_module/src/enrollment/enrollmentEndpoint.hpp
+++ b/src/remoted/remoted_module/src/enrollment/enrollmentEndpoint.hpp
@@ -1,0 +1,53 @@
+/*
+ * Wazuh remoted module - POST /enroll endpoint
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 19, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#pragma once
+
+#include "authdClient.hpp"
+#include "enrollmentAuthenticator.hpp"
+#include "enrollmentConfig.hpp"
+#include "http_server/IHttpServer.hpp" // remoted::http::RouteHandler
+#include "metrics.hpp"
+
+namespace remoted::enrollment
+{
+
+    /**
+     * @brief Builds the `POST /enroll` route handler.
+     *
+     * Registered directly on IHttpServer (see remotedModuleFacade.hpp) -- NOT through AuthGateway --
+     * because an enrolling agent has no client.keys entry yet, so the agent<->manager AES-CMAC
+     * protocol cannot authenticate it. The returned handler:
+     *   1. Answers 403 immediately if @p config.enrollmentEnabled is false, before touching the
+     *      authenticator or the bridge -- the route always exists (never a 404); this is what
+     *      lets an operator/agent tell "unsupported" apart from "administratively off".
+     *   2. Runs @p authenticator against the raw request (mode fixed at facade-construction time
+     *      by the listener's client-certificate requirement and authd's <use_password>).
+     *   3. Parses and locally validates the JSON body (name/version/groups/ip/key_hash); rejects
+     *      malformed input with 400 without ever reaching authd. `force`/`id`/`key` are never
+     *      read from the body even if present -- self-enrollment always gets an auto-assigned ID
+     *      and an authd-generated key.
+     *   4. Resolves the enrollment IP (config.useSourceIp -> the HTTPS peer address; else the
+     *      body's `ip`; else "any") and forwards to authd via @p authdClient, deferring the
+     *      response until its callback fires.
+     *   5. Maps authd's result to the HTTP response (200 + {id,name,ip,key}; a mapped status for
+     *      a business-rejection authd code; 503 for a transport failure/timeout).
+     *
+     * @warning The returned handler stores references to @p authenticator, @p authdClient and
+     * @p metrics. The caller must guarantee all three outlive every route registered with this
+     * handler, exactly like controlEndpoint::makeHandler()'s ControlHandler& contract.
+     */
+    remoted::http::RouteHandler makeHandler(const EnrollmentAuthenticator& authenticator,
+                                            AuthdClient& authdClient,
+                                            const Config& config,
+                                            EnrollmentMetrics& metrics);
+
+} // namespace remoted::enrollment

--- a/src/remoted/remoted_module/src/enrollment/enrollmentEndpoint.hpp
+++ b/src/remoted/remoted_module/src/enrollment/enrollmentEndpoint.hpp
@@ -18,10 +18,18 @@
 #include "http_server/IHttpServer.hpp" // remoted::http::RouteHandler
 #include "metrics.hpp"
 
+#include <cstddef>
 #include <memory>
 
 namespace remoted::enrollment
 {
+
+    /// Cap on the /enroll JSON body actually parsed, post-decode -- an endpoint-local guard on
+    /// top of the transport's own hard cap and EnrollmentAuthConfig::maxBodySize (the WIRE/
+    /// pre-decode size). Public so remotedModuleFacade.hpp can pass the SAME value as the decoded-
+    /// size cap on the dedicated BodyDecoder instance /enroll uses -- see makeHandler()'s doc
+    /// comment on why /enroll needs its own (smaller) cap there, unlike AuthGateway's shared one.
+    inline constexpr std::size_t kMaxEnrollBodySize = 16U * 1024U;
 
     /**
      * @brief Builds the `POST /enroll` route handler.
@@ -38,8 +46,13 @@ namespace remoted::enrollment
      *      AuthGateway (see authGateway.cpp).
      *   3. Runs @p bodyDecoder over the now-verified body, so /enroll honors the manager's
      *      `Content-Encoding: zstd` policy exactly like every other endpoint (`remoted.
-     *      http_content_encoding_enabled`) -- decoding only ever happens AFTER authentication, so
-     *      an unauthenticated peer can never spend CPU/memory on it.
+     *      http_content_encoding_enabled`) -- decoding only ever happens AFTER the freshness/MAC
+     *      check in Password mode, so an unauthenticated peer can't reach it THERE. Open mode has
+     *      no credential check at all by design, so decoding still runs for anonymous requests in
+     *      that mode -- @p bodyDecoder must therefore be an instance capped at kMaxEnrollBodySize
+     *      (see remotedModuleFacade.hpp), not the larger shared-budget-sized one AuthGateway's
+     *      routes use, so a small, highly-compressed frame can't hold much of the in-flight byte
+     *      budget (shared with /stateless and friends) even briefly during decompression.
      *   4. Parses and locally validates the (decoded) JSON body (name/version/groups/ip/key_hash);
      *      rejects malformed input with 400 without ever reaching authd. `force`/`id`/`key` are
      *      never read from the body even if present -- self-enrollment always gets an

--- a/src/remoted/remoted_module/src/enrollment/metrics.hpp
+++ b/src/remoted/remoted_module/src/enrollment/metrics.hpp
@@ -41,9 +41,10 @@ namespace remoted::enrollment
         return EnrollmentMetrics {
             manager.getOrCreateCounter(METRIC_ACCEPTED, "Enrollment requests that succeeded", "count"),
             manager.getOrCreateCounter(METRIC_REJECTED_AUTH, "Enrollment requests rejected on authentication", "count"),
-            manager.getOrCreateCounter(METRIC_REJECTED_VALIDATION,
-                                       "Enrollment requests rejected on local validation (schema/version)",
-                                       "count"),
+            manager.getOrCreateCounter(
+                METRIC_REJECTED_VALIDATION,
+                "Enrollment requests rejected on local validation (Content-Encoding/schema/version)",
+                "count"),
             manager.getOrCreateCounter(METRIC_DISABLED,
                                        "Enrollment requests rejected because enrollment is administratively disabled",
                                        "count"),

--- a/src/remoted/remoted_module/src/enrollment/metrics.hpp
+++ b/src/remoted/remoted_module/src/enrollment/metrics.hpp
@@ -1,0 +1,106 @@
+/*
+ * Wazuh remoted module - Enrollment endpoint metrics
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 19, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _REMOTED_ENROLLMENT_METRICS_HPP
+#define _REMOTED_ENROLLMENT_METRICS_HPP
+
+#include <memory>
+
+#include <wazuh_metrics/iManager.hpp>
+
+namespace remoted::enrollment
+{
+    // The remoted.enroll.* name catalog.
+    constexpr auto METRIC_ACCEPTED {"remoted.enroll.accepted"};
+    constexpr auto METRIC_REJECTED_AUTH {"remoted.enroll.rejected_auth"};
+    constexpr auto METRIC_REJECTED_VALIDATION {"remoted.enroll.rejected_validation"};
+    constexpr auto METRIC_DISABLED {"remoted.enroll.disabled"};
+    constexpr auto METRIC_AUTHD_ERROR {"remoted.enroll.authd_error"};
+    constexpr auto METRIC_AUTHD_UNAVAILABLE {"remoted.enroll.authd_unavailable"};
+
+    struct EnrollmentMetrics
+    {
+        std::shared_ptr<wazuh::metrics::ICounter> accepted;
+        std::shared_ptr<wazuh::metrics::ICounter> rejectedAuth;
+        std::shared_ptr<wazuh::metrics::ICounter> rejectedValidation;
+        std::shared_ptr<wazuh::metrics::ICounter> disabled;
+        std::shared_ptr<wazuh::metrics::ICounter> authdError;
+        std::shared_ptr<wazuh::metrics::ICounter> authdUnavailable;
+    };
+
+    inline EnrollmentMetrics makeEnrollmentMetrics(wazuh::metrics::IManager& manager)
+    {
+        return EnrollmentMetrics {
+            manager.getOrCreateCounter(METRIC_ACCEPTED, "Enrollment requests that succeeded", "count"),
+            manager.getOrCreateCounter(METRIC_REJECTED_AUTH, "Enrollment requests rejected on authentication", "count"),
+            manager.getOrCreateCounter(METRIC_REJECTED_VALIDATION,
+                                       "Enrollment requests rejected on local validation (schema/version)",
+                                       "count"),
+            manager.getOrCreateCounter(METRIC_DISABLED,
+                                       "Enrollment requests rejected because enrollment is administratively disabled",
+                                       "count"),
+            manager.getOrCreateCounter(
+                METRIC_AUTHD_ERROR, "Enrollment requests rejected by authd's own business rules", "count"),
+            manager.getOrCreateCounter(
+                METRIC_AUTHD_UNAVAILABLE, "Enrollment requests that got no clean answer from authd", "count")};
+    }
+
+    inline void incAccepted(EnrollmentMetrics& m)
+    {
+        if (m.accepted)
+        {
+            m.accepted->add();
+        }
+    }
+
+    inline void incRejectedAuth(EnrollmentMetrics& m)
+    {
+        if (m.rejectedAuth)
+        {
+            m.rejectedAuth->add();
+        }
+    }
+
+    inline void incRejectedValidation(EnrollmentMetrics& m)
+    {
+        if (m.rejectedValidation)
+        {
+            m.rejectedValidation->add();
+        }
+    }
+
+    inline void incDisabled(EnrollmentMetrics& m)
+    {
+        if (m.disabled)
+        {
+            m.disabled->add();
+        }
+    }
+
+    inline void incAuthdError(EnrollmentMetrics& m)
+    {
+        if (m.authdError)
+        {
+            m.authdError->add();
+        }
+    }
+
+    inline void incAuthdUnavailable(EnrollmentMetrics& m)
+    {
+        if (m.authdUnavailable)
+        {
+            m.authdUnavailable->add();
+        }
+    }
+
+} // namespace remoted::enrollment
+
+#endif // _REMOTED_ENROLLMENT_METRICS_HPP

--- a/src/remoted/remoted_module/src/http_server/IHttpServer.hpp
+++ b/src/remoted/remoted_module/src/http_server/IHttpServer.hpp
@@ -48,9 +48,15 @@ namespace remoted::http
     struct HttpRequest
     {
         Method method {Method::Get};
-        std::string target;                                   ///< Request path (without query).
-        std::string body;                                     ///< Raw request body.
-        std::unordered_map<std::string, std::string> headers; ///< Lower-cased header name -> value.
+        std::string target; ///< Request path (without query).
+        std::string body;   ///< Raw request body.
+        /// Header name -> value, EXACTLY as the transport reports it (a well-known field name like
+        /// "Authorization" or "Content-Type" is NOT necessarily lowercased -- see
+        /// RestinioHttpServer.cpp's makeHttpRequest()). Always look these up via
+        /// http_server/headerUtils.hpp's headerValue() (case-insensitive), never an exact-match
+        /// find(): an exact match only happens to work against a handcrafted request that inserted
+        /// an already-lowercase key directly, never having gone through the real transport.
+        std::unordered_map<std::string, std::string> headers;
         std::string remoteIp; ///< Client's connection IP (textual form; IPv4-mapped-IPv6 addresses
                               ///< are unmapped to plain IPv4 first). The auth gateway hands it to
                               ///< AuthMiddleware, which matches it against the agent's authorized

--- a/src/remoted/remoted_module/src/http_server/headerUtils.hpp
+++ b/src/remoted/remoted_module/src/http_server/headerUtils.hpp
@@ -1,0 +1,68 @@
+/*
+ * Wazuh remoted module (C++ worker bridge)
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 19, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _REMOTED_HTTP_SERVER_HEADER_UTILS_HPP
+#define _REMOTED_HTTP_SERVER_HEADER_UTILS_HPP
+
+#include <cctype>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace remoted::http
+{
+
+    /**
+     * @brief Case-insensitive header lookup.
+     *
+     * HTTP header names are case-insensitive (RFC 7230 3.2), and RestinioHttpServer's
+     * makeHttpRequest() (RestinioHttpServer.cpp) stores each header under whatever case RESTinio's
+     * parser hands back for it -- a well-known field name (e.g. "Authorization", "Content-Type")
+     * comes back canonicalized to its RFC spelling, NOT lowercased. Every reader of
+     * HttpRequest::headers must look up this way rather than an exact-match `find()`: an
+     * exact-match lookup happens to work only against a handcrafted test request that inserted an
+     * already-lowercase key directly (never having gone through the real transport), which masks
+     * the exact bug a real HTTP client would trip over the wire -- discovered via
+     * enrollmentMtlsE2E_test.cpp's real-TLS test failing while its direct-dispatch sibling passed.
+     *
+     * @param headers   The request's header map, as delivered by the transport.
+     * @param lowerName The header name to find, already lowercase.
+     * @return The header's value, or an empty string if absent.
+     */
+    inline std::string headerValue(const std::unordered_map<std::string, std::string>& headers,
+                                   std::string_view lowerName)
+    {
+        for (const auto& [name, value] : headers)
+        {
+            if (name.size() != lowerName.size())
+            {
+                continue;
+            }
+            bool equal = true;
+            for (std::size_t i = 0; i < name.size(); ++i)
+            {
+                if (static_cast<char>(std::tolower(static_cast<unsigned char>(name[i]))) != lowerName[i])
+                {
+                    equal = false;
+                    break;
+                }
+            }
+            if (equal)
+            {
+                return value;
+            }
+        }
+        return {};
+    }
+
+} // namespace remoted::http
+
+#endif // _REMOTED_HTTP_SERVER_HEADER_UTILS_HPP

--- a/src/remoted/remoted_module/src/remotedModuleFacade.hpp
+++ b/src/remoted/remoted_module/src/remotedModuleFacade.hpp
@@ -510,7 +510,8 @@ private:
                                                                m_config.worker_node,
                                                                enrollConfig.authdConnectTimeoutMs,
                                                                enrollConfig.authdResponseTimeoutMs,
-                                                               enrollConfig.authdMaxQueueSize);
+                                                               enrollConfig.authdMaxQueueSize,
+                                                               enrollConfig.authdWorkerThreads);
 
         m_httpServer->addRoute(remoted::http::Method::Post,
                                "/enroll",

--- a/src/remoted/remoted_module/src/remotedModuleFacade.hpp
+++ b/src/remoted/remoted_module/src/remotedModuleFacade.hpp
@@ -313,13 +313,23 @@ private:
             std::make_shared<remoted::auth::Keystore>(remoted::auth::Keystore::kDefaultPath, keystoreRefreshSeconds);
         // The Content-Encoding contract is composed in here rather than built into the gateway, so
         // the auth layer stays about authentication only. Built ONCE and shared (BodyDecoder is
-        // stateless -- see its own class comment) between AuthGateway (every client.keys-backed
-        // endpoint) and /enroll's own handler below, so every authenticated endpoint gets the same
-        // policy and none can accidentally opt out or drift out of sync with the others.
+        // stateless -- see its own class comment) across every AuthGateway route, so they all get
+        // the same policy and none can accidentally opt out or drift out of sync with each other.
         const auto authConfig = remoted::auth::buildAuthConfig(m_config);
         const auto bodyDecoder = std::make_shared<const remoted::decoding::BodyDecoder>(
             *m_httpServer, m_config.http_content_encoding_enabled);
         m_authGateway = std::make_unique<remoted::endpoints::AuthGateway>(authConfig, m_keystore, bodyDecoder);
+
+        // /enroll gets its OWN BodyDecoder instance, not the shared one above: every AuthGateway
+        // route requires a verified credential before decode() ever runs, which closes the
+        // amplification lever a decoded-size cap exists for -- but /enroll's Open mode has NO
+        // credential check at all by design, so an unauthenticated peer CAN reach decode() there.
+        // Capped at kMaxEnrollBodySize (the same cap parseAndValidateBody() applies post-decode,
+        // enrollmentEndpoint.hpp) so a small, highly-compressed frame can't hold much of the
+        // shared in-flight byte budget (the same one /stateless and friends draw from) even
+        // briefly while decompressing -- see makeHandler()'s and BodyDecoder's own doc comments.
+        const auto enrollBodyDecoder = std::make_shared<const remoted::decoding::BodyDecoder>(
+            *m_httpServer, m_config.http_content_encoding_enabled, remoted::enrollment::kMaxEnrollBodySize);
 
         // Deferred-work limiter: bounds requests parked awaiting a downstream service. A slot is
         // held from the moment a request enters the deferred stage until its reply is delivered;
@@ -503,7 +513,11 @@ private:
         }
 
         m_enrollmentAuthenticator = std::make_unique<remoted::enrollment::EnrollmentAuthenticator>(
-            remoted::enrollment::EnrollmentAuthConfig {enrollConfig.usePassword}, enrollPasswordKeySource);
+            remoted::enrollment::EnrollmentAuthConfig {enrollConfig.usePassword,
+                                                       enrollConfig.maxRequestAgeSeconds,
+                                                       enrollConfig.maxFutureSkewSeconds,
+                                                       enrollConfig.maxBodySize},
+            enrollPasswordKeySource);
 
         m_authdClient =
             std::make_unique<remoted::enrollment::AuthdClient>(remoted::enrollment::AuthdClient::kDefaultSocketPath,
@@ -517,7 +531,26 @@ private:
             remoted::http::Method::Post,
             "/enroll",
             remoted::enrollment::makeHandler(
-                *m_enrollmentAuthenticator, *m_authdClient, enrollConfig, m_enrollmentMetrics, bodyDecoder));
+                *m_enrollmentAuthenticator, *m_authdClient, enrollConfig, m_enrollmentMetrics, enrollBodyDecoder));
+
+        // Same sanity check the other four endpoints get (see warnIfDownstreamBudgetExceedsRequestTimeout's
+        // own comment) -- /enroll's downstream is AuthdClient, not the DeferredForwarder pair those
+        // use, so it needs its own budget computed from AuthdClient's own (already worker-aware-
+        // resolved) timeouts rather than DownstreamConfig's. At MAXIMUM configured values
+        // (authd_connect_timeout=60s, authd_response_timeout=120s) this reaches 180s against a 30s
+        // http_request_timeout default -- silent with the defaults (2s + 5s/15s), so this only fires
+        // when an operator has pushed these up without also raising http_request_timeout.
+        const auto resolvedAuthdConnectTimeoutMs =
+            enrollConfig.authdConnectTimeoutMs != 0
+                ? static_cast<long long>(enrollConfig.authdConnectTimeoutMs)
+                : static_cast<long long>(remoted::enrollment::AuthdClient::kDefaultConnectTimeoutMs);
+        const auto resolvedAuthdResponseTimeoutMs =
+            static_cast<long long>(remoted::enrollment::AuthdClient::resolveResponseTimeoutMs(
+                enrollConfig.authdResponseTimeoutMs, enrollConfig.isWorkerNode));
+        warnIfBudgetExceedsRequestTimeout("/enroll",
+                                          "authd_connect_timeout'/'authd_response_timeout",
+                                          resolvedAuthdConnectTimeoutMs + resolvedAuthdResponseTimeoutMs,
+                                          static_cast<long long>(config.requestTimeoutSec) * 1000);
 
         m_httpServer->start(config);
     }
@@ -715,17 +748,34 @@ private:
                                    downstreamConfig.writeTimeoutMs + responseTimeoutMs;
         const long long requestCapMs = static_cast<long long>(serverConfig.requestTimeoutSec) * 1000;
 
+        warnIfBudgetExceedsRequestTimeout(
+            path,
+            "downstream_connect_timeout'/'downstream_write_timeout'/'downstream_response_timeout",
+            budgetMs,
+            requestCapMs);
+    }
+
+    /// Shared core of warnIfDownstreamBudgetExceedsRequestTimeout(): pulled out so /enroll, whose
+    /// downstream is AuthdClient (a completely different config shape -- authd_connect_timeout +
+    /// authd_response_timeout, no write phase) rather than the DeferredForwarder/DownstreamConfig
+    /// pair every other endpoint here shares, can run the same sanity check without forcing that
+    /// shape onto it.
+    void warnIfBudgetExceedsRequestTimeout(const char* path,
+                                           const char* tunablesToReduce,
+                                           long long budgetMs,
+                                           long long requestCapMs)
+    {
         if (budgetMs > requestCapMs)
         {
             LOGFN_WARN(moduleLogFn(),
                        "Endpoint '%s': the downstream timeouts add up to %lld ms, which exceeds "
                        "'http_request_timeout' (%lld ms); the HTTP server will cut a slow request off before the "
                        "downstream deadline is reached. Consider increasing the value of 'http_request_timeout', or "
-                       "reducing 'downstream_connect_timeout'/'downstream_write_timeout'/"
-                       "'downstream_response_timeout'.",
+                       "reducing '%s'.",
                        path,
                        budgetMs,
-                       requestCapMs);
+                       requestCapMs,
+                       tunablesToReduce);
         }
     }
 

--- a/src/remoted/remoted_module/src/remotedModuleFacade.hpp
+++ b/src/remoted/remoted_module/src/remotedModuleFacade.hpp
@@ -312,14 +312,14 @@ private:
         m_keystore =
             std::make_shared<remoted::auth::Keystore>(remoted::auth::Keystore::kDefaultPath, keystoreRefreshSeconds);
         // The Content-Encoding contract is composed in here rather than built into the gateway, so
-        // the auth layer stays about authentication only. Configured once on the gateway (not per
-        // route), so every authenticated endpoint gets it and none can accidentally opt out.
+        // the auth layer stays about authentication only. Built ONCE and shared (BodyDecoder is
+        // stateless -- see its own class comment) between AuthGateway (every client.keys-backed
+        // endpoint) and /enroll's own handler below, so every authenticated endpoint gets the same
+        // policy and none can accidentally opt out or drift out of sync with the others.
         const auto authConfig = remoted::auth::buildAuthConfig(m_config);
-        m_authGateway = std::make_unique<remoted::endpoints::AuthGateway>(
-            authConfig,
-            m_keystore,
-            std::make_shared<const remoted::decoding::BodyDecoder>(*m_httpServer,
-                                                                   m_config.http_content_encoding_enabled));
+        const auto bodyDecoder = std::make_shared<const remoted::decoding::BodyDecoder>(
+            *m_httpServer, m_config.http_content_encoding_enabled);
+        m_authGateway = std::make_unique<remoted::endpoints::AuthGateway>(authConfig, m_keystore, bodyDecoder);
 
         // Deferred-work limiter: bounds requests parked awaiting a downstream service. A slot is
         // held from the moment a request enters the deferred stage until its reply is delivered;
@@ -513,10 +513,11 @@ private:
                                                                enrollConfig.authdMaxQueueSize,
                                                                enrollConfig.authdWorkerThreads);
 
-        m_httpServer->addRoute(remoted::http::Method::Post,
-                               "/enroll",
-                               remoted::enrollment::makeHandler(
-                                   *m_enrollmentAuthenticator, *m_authdClient, enrollConfig, m_enrollmentMetrics));
+        m_httpServer->addRoute(
+            remoted::http::Method::Post,
+            "/enroll",
+            remoted::enrollment::makeHandler(
+                *m_enrollmentAuthenticator, *m_authdClient, enrollConfig, m_enrollmentMetrics, bodyDecoder));
 
         m_httpServer->start(config);
     }

--- a/src/remoted/remoted_module/src/remotedModuleFacade.hpp
+++ b/src/remoted/remoted_module/src/remotedModuleFacade.hpp
@@ -45,6 +45,11 @@
 #include "endpoints/statefulEndpoint.hpp"
 #include "endpoints/statelessEndpoint.hpp"
 #include "endpoints/statsEndpoint.hpp"
+#include "enrollment/authdClient.hpp"
+#include "enrollment/enrollmentAuthenticator.hpp"
+#include "enrollment/enrollmentConfig.hpp"
+#include "enrollment/enrollmentEndpoint.hpp"
+#include "enrollment/metrics.hpp"
 #include "http_server/IHttpServer.hpp"
 #include "http_server/httpServerConfig.hpp"
 #include "http_server/httpServerFactory.hpp"
@@ -214,11 +219,22 @@ public:
             // the same io_context runtime via the response send path.
             m_controlHandler.reset();
             m_scanVdHandler.reset();
+            // /enroll has no async callback machinery of its own to race with a wdb-worker join
+            // (unlike ControlHandler above) -- reset here anyway, alongside every other
+            // per-request handler object, once stopAccepting() guarantees nothing can still call in.
+            m_enrollmentAuthenticator.reset();
 
             // Phase 2: abort in-flight downstream UDS sessions (no new completions can arrive).
+            // m_authdClient->stop() belongs in this phase for the same reason: it fails any
+            // queued/in-flight /enroll->authd request right away rather than let it linger, and
+            // the resulting responder->send() calls are still safe here (phase 4 hasn't run).
             if (m_downstreamClient)
             {
                 m_downstreamClient->stop();
+            }
+            if (m_authdClient)
+            {
+                m_authdClient->stop();
             }
 
             // Phase 3: drain the post-processing pool. Anything that was mid-flight when phase 1
@@ -227,6 +243,7 @@ public:
             m_forwarder.reset();
             m_downstreamClient.reset();
             m_deferredLimiter.reset();
+            m_authdClient.reset();
 
             // Phase 4: NOW it's safe to fully tear down the transport (releases the I/O
             // runtime). Nothing can still be touching a responder: worker pool B was drained in
@@ -459,6 +476,47 @@ private:
                                              "/scan/vd",
                                              remoted::endpoints::scanvd::makeHandler(*m_scanVdHandler));
 
+        // /enroll: bridges to authd's local socket (see the Agent enrollment chapter of this
+        // module's README). Registered directly on m_httpServer -- NOT through m_authGateway --
+        // because an enrolling agent has no client.keys entry yet, so the agent<->manager
+        // AES-CMAC protocol cannot authenticate it. Always registered, regardless of
+        // enrollment_enabled: the handler itself answers 403 when enrollment is administratively
+        // disabled, so the route is never a bare 404.
+        //
+        // The listener's own client-certificate requirement (config.verificationMode, set below
+        // via buildHttpServerConfig()) and authd's <use_password> are independent gates -- exactly
+        // like legacy authd, which already enforces its own <ssl_verify_host> at the TLS handshake
+        // and <use_password> while parsing the enrollment message as two separate checks on the
+        // same connection (main-server.c). So EnrollmentAuthenticator only ever needs to know
+        // whether it must additionally require the WazuhEnroll CMAC; it has no notion of "mTLS
+        // mode" at all, because a client certificate is never its concern -- the TLS listener
+        // enforces (or doesn't) that entirely on its own, before any handler runs. PasswordKeySource
+        // (constructed only when required) is owned by m_enrollmentAuthenticator from here on -- its
+        // background watcher thread's lifetime is tied to the authenticator's.
+        const auto enrollConfig = remoted::enrollment::buildEnrollmentConfig(m_config);
+
+        std::shared_ptr<remoted::auth::PasswordKeySource> enrollPasswordKeySource;
+        if (enrollConfig.usePassword)
+        {
+            enrollPasswordKeySource = std::make_shared<remoted::auth::PasswordKeySource>(
+                remoted::auth::PasswordKeySource::kDefaultPath, enrollConfig.passwordRefreshIntervalSec);
+        }
+
+        m_enrollmentAuthenticator = std::make_unique<remoted::enrollment::EnrollmentAuthenticator>(
+            remoted::enrollment::EnrollmentAuthConfig {enrollConfig.usePassword}, enrollPasswordKeySource);
+
+        m_authdClient =
+            std::make_unique<remoted::enrollment::AuthdClient>(remoted::enrollment::AuthdClient::kDefaultSocketPath,
+                                                               m_config.worker_node,
+                                                               enrollConfig.authdConnectTimeoutMs,
+                                                               enrollConfig.authdResponseTimeoutMs,
+                                                               enrollConfig.authdMaxQueueSize);
+
+        m_httpServer->addRoute(remoted::http::Method::Post,
+                               "/enroll",
+                               remoted::enrollment::makeHandler(
+                                   *m_enrollmentAuthenticator, *m_authdClient, enrollConfig, m_enrollmentMetrics));
+
         m_httpServer->start(config);
     }
 
@@ -683,13 +741,19 @@ private:
         // ScanVdHandlerImpl is stateless (a synchronous passthrough of VD's admission), but the
         // next retry constructs a fresh one, so drop the old instance alongside its siblings.
         m_scanVdHandler.reset();
+        m_enrollmentAuthenticator.reset();
         if (m_downstreamClient)
         {
             m_downstreamClient->stop();
         }
+        if (m_authdClient)
+        {
+            m_authdClient->stop();
+        }
         m_forwarder.reset();
         m_downstreamClient.reset();
         m_deferredLimiter.reset();
+        m_authdClient.reset();
         m_authGateway.reset();
         m_keystore.reset();
     }
@@ -790,6 +854,15 @@ private:
     remoted::scanvd::ScanVdMetrics m_scanVdMetrics {
         remoted::scanvd::makeScanVdMetrics(*m_metricsManager)};          ///< /scan/vd counters.
     std::unique_ptr<remoted::scanvd::ScanVdHandlerImpl> m_scanVdHandler; ///< VD scan handler.
+
+    // /enroll lifecycle: bridges agent self-enrollment to authd's local socket. Metric struct on
+    // the facade for the same reason as m_controlMetrics/m_scanVdMetrics. m_enrollmentAuthenticator
+    // owns the PasswordKeySource (Password mode only; null otherwise) constructed for it in
+    // startHttpServer() -- its background watcher thread's lifetime is tied to the authenticator's.
+    remoted::enrollment::EnrollmentMetrics m_enrollmentMetrics {
+        remoted::enrollment::makeEnrollmentMetrics(*m_metricsManager)};                      ///< /enroll counters.
+    std::unique_ptr<remoted::enrollment::EnrollmentAuthenticator> m_enrollmentAuthenticator; ///< /enroll auth.
+    std::unique_ptr<remoted::enrollment::AuthdClient> m_authdClient;                         ///< Bridge to authd.
 };
 
 #endif // _REMOTED_MODULE_FACADE_HPP

--- a/src/remoted/remoted_module/test/unit/authdClient_test.cpp
+++ b/src/remoted/remoted_module/test/unit/authdClient_test.cpp
@@ -1,0 +1,297 @@
+/*
+ * Wazuh remoted module - authd enrollment bridge client - unit tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 19, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "enrollment/authdClient.hpp"
+#include "fakeUdsServer.hpp"
+#include "json.hpp"
+
+using namespace remoted::enrollment;
+using remoted::test::FakeUdsServer;
+using remoted::test::makeUniqueSocketPath;
+
+namespace
+{
+    // Blocks the calling test thread until callback() has fired, then hands back the result.
+    class ResultWaiter
+    {
+    public:
+        std::function<void(AuthdResult)> callback()
+        {
+            return [this](AuthdResult result)
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                m_result = std::move(result);
+                m_ready = true;
+                m_cv.notify_one();
+            };
+        }
+
+        AuthdResult wait(std::chrono::milliseconds timeout = std::chrono::seconds(2))
+        {
+            std::unique_lock<std::mutex> lock(m_mutex);
+            EXPECT_TRUE(m_cv.wait_for(lock, timeout, [this] { return m_ready; })) << "callback never fired";
+            return m_result;
+        }
+
+    private:
+        std::mutex m_mutex;
+        std::condition_variable m_cv;
+        bool m_ready {false};
+        AuthdResult m_result;
+    };
+
+    AuthdAddRequest makeRequest()
+    {
+        AuthdAddRequest req;
+        req.name = "agent1";
+        req.ip = "any";
+        return req;
+    }
+} // namespace
+
+TEST(AuthdClientTest, SuccessfulAddReturnsAgentData)
+{
+    const std::string path = makeUniqueSocketPath("authd_client_success");
+    FakeUdsServer server(
+        path,
+        [](const std::string&)
+        {
+            return R"({"error":0,"data":{"id":"003","name":"agent1","ip":"any","key":"675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915"}})";
+        });
+
+    AuthdClient client(path);
+    ResultWaiter waiter;
+    client.addAgent(makeRequest(), waiter.callback());
+
+    const auto result = waiter.wait();
+    EXPECT_EQ(result.errorCode, 0);
+    EXPECT_EQ(result.id, "003");
+    EXPECT_EQ(result.name, "agent1");
+    EXPECT_EQ(result.ip, "any");
+    EXPECT_EQ(result.key, "675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915");
+    EXPECT_TRUE(result.message.empty());
+}
+
+TEST(AuthdClientTest, BusinessRejectionPreservesCodeAndStripsPrefix)
+{
+    const std::string path = makeUniqueSocketPath("authd_client_business_error");
+    FakeUdsServer server(path,
+                         [](const std::string&) { return R"({"error":9008,"message":"ERROR: Duplicate name"})"; });
+
+    AuthdClient client(path);
+    ResultWaiter waiter;
+    client.addAgent(makeRequest(), waiter.callback());
+
+    const auto result = waiter.wait();
+    EXPECT_EQ(result.errorCode, 9008);
+    EXPECT_EQ(result.message, "Duplicate name"); // "ERROR: " prefix stripped
+    EXPECT_TRUE(result.id.empty());
+    EXPECT_TRUE(result.key.empty());
+}
+
+TEST(AuthdClientTest, ServerAbsentIsATransportFailure)
+{
+    // No FakeUdsServer bound at this path at all. SocketClient::connect() retries a failed
+    // connect() silently in its own background thread rather than surfacing it -- there is no
+    // synchronous "could not connect" signal to catch (see authdClient.hpp's class comment) --
+    // so this resolves only via the response timeout, exactly like ServerDroppingTheResponseTimesOut.
+    // Short response timeout so the test doesn't wait the full worker-aware default.
+    const std::string path = makeUniqueSocketPath("authd_client_absent");
+
+    AuthdClient client(path, /*isWorkerNode=*/false, /*connectTimeoutMs=*/0, /*responseTimeoutMs=*/200);
+    ResultWaiter waiter;
+    client.addAgent(makeRequest(), waiter.callback());
+
+    const auto result = waiter.wait(std::chrono::seconds(2));
+    EXPECT_EQ(result.errorCode, -1);
+    EXPECT_NE(result.message.find("Timed out"), std::string::npos);
+}
+
+TEST(AuthdClientTest, ServerDroppingTheResponseTimesOut)
+{
+    const std::string path = makeUniqueSocketPath("authd_client_timeout");
+    FakeUdsServer server(path, [](const std::string&) { return "{}"; });
+    server.setDropResponses(true);
+
+    // Short response timeout so the test doesn't wait the full worker-aware default.
+    AuthdClient client(path, /*isWorkerNode=*/false, /*connectTimeoutMs=*/0, /*responseTimeoutMs=*/200);
+    ResultWaiter waiter;
+    client.addAgent(makeRequest(), waiter.callback());
+
+    const auto result = waiter.wait(std::chrono::seconds(2));
+    EXPECT_EQ(result.errorCode, -1);
+    EXPECT_NE(result.message.find("Timed out"), std::string::npos);
+}
+
+TEST(AuthdClientTest, MalformedResponseIsATransportFailure)
+{
+    const std::string path = makeUniqueSocketPath("authd_client_malformed");
+    FakeUdsServer server(path, [](const std::string&) { return "not valid json{{{"; });
+
+    AuthdClient client(path);
+    ResultWaiter waiter;
+    client.addAgent(makeRequest(), waiter.callback());
+
+    const auto result = waiter.wait();
+    EXPECT_EQ(result.errorCode, -1);
+}
+
+TEST(AuthdClientTest, MissingDataOnSuccessIsATransportFailure)
+{
+    // error:0 but no "data" object -- authd's own contract violated; must not crash or
+    // fabricate a success result.
+    const std::string path = makeUniqueSocketPath("authd_client_missing_data");
+    FakeUdsServer server(path, [](const std::string&) { return R"({"error":0})"; });
+
+    AuthdClient client(path);
+    ResultWaiter waiter;
+    client.addAgent(makeRequest(), waiter.callback());
+
+    const auto result = waiter.wait();
+    EXPECT_EQ(result.errorCode, -1);
+}
+
+TEST(AuthdClientTest, RequestOmitsForceIdAndKeyAndIncludesOptionalFieldsWhenProvided)
+{
+    const std::string path = makeUniqueSocketPath("authd_client_wire_shape");
+    std::string capturedRequest;
+    std::mutex captureMutex;
+
+    FakeUdsServer server(path,
+                         [&](const std::string& request)
+                         {
+                             std::lock_guard<std::mutex> lock(captureMutex);
+                             capturedRequest = request;
+                             return R"({"error":0,"data":{"id":"1","name":"n","ip":"i","key":"k"}})";
+                         });
+
+    AuthdClient client(path);
+    AuthdAddRequest req;
+    req.name = "agent1";
+    req.ip = "10.0.0.15";
+    req.groups = "default,web-servers";
+    req.keyHash = "abc123";
+
+    ResultWaiter waiter;
+    client.addAgent(req, waiter.callback());
+    ASSERT_EQ(waiter.wait().errorCode, 0);
+
+    std::string captured;
+    {
+        std::lock_guard<std::mutex> lock(captureMutex);
+        captured = capturedRequest;
+    }
+    const auto json = nlohmann::json::parse(captured);
+    EXPECT_EQ(json.at("function"), "add");
+    const auto& arguments = json.at("arguments");
+    EXPECT_EQ(arguments.at("name"), "agent1");
+    EXPECT_EQ(arguments.at("ip"), "10.0.0.15");
+    EXPECT_EQ(arguments.at("groups"), "default,web-servers");
+    EXPECT_EQ(arguments.at("key_hash"), "abc123");
+    EXPECT_FALSE(arguments.contains("force"));
+    EXPECT_FALSE(arguments.contains("id"));
+    EXPECT_FALSE(arguments.contains("key"));
+}
+
+TEST(AuthdClientTest, OptionalFieldsAreOmittedWhenNotProvided)
+{
+    const std::string path = makeUniqueSocketPath("authd_client_wire_shape_minimal");
+    std::string capturedRequest;
+    std::mutex captureMutex;
+
+    FakeUdsServer server(path,
+                         [&](const std::string& request)
+                         {
+                             std::lock_guard<std::mutex> lock(captureMutex);
+                             capturedRequest = request;
+                             return R"({"error":0,"data":{"id":"1","name":"n","ip":"i","key":"k"}})";
+                         });
+
+    AuthdClient client(path);
+    ResultWaiter waiter;
+    client.addAgent(makeRequest(), waiter.callback()); // no groups/keyHash
+    ASSERT_EQ(waiter.wait().errorCode, 0);
+
+    std::string captured;
+    {
+        std::lock_guard<std::mutex> lock(captureMutex);
+        captured = capturedRequest;
+    }
+    const auto json = nlohmann::json::parse(captured);
+    const auto& arguments = json.at("arguments");
+    EXPECT_FALSE(arguments.contains("groups"));
+    EXPECT_FALSE(arguments.contains("key_hash"));
+}
+
+TEST(AuthdClientTest, QueueFullRejectsBeyondCapacity)
+{
+    const std::string path = makeUniqueSocketPath("authd_client_queue_full");
+    FakeUdsServer server(path, [](const std::string&) { return "{}"; });
+    server.setDropResponses(true); // keep the single worker thread busy on the first request
+
+    AuthdClient client(
+        path, /*isWorkerNode=*/false, /*connectTimeoutMs=*/0, /*responseTimeoutMs=*/300, /*maxQueueSize=*/1);
+
+    ResultWaiter first;
+    ResultWaiter second;
+    ResultWaiter third;
+
+    client.addAgent(makeRequest(), first.callback());           // picked up by the worker immediately
+    std::this_thread::sleep_for(std::chrono::milliseconds(30)); // let the worker actually start it
+    client.addAgent(makeRequest(), second.callback());          // queued (queue size 1, at max)
+    client.addAgent(makeRequest(), third.callback());           // queue already full -> rejected now
+
+    const auto thirdResult = third.wait();
+    EXPECT_EQ(thirdResult.errorCode, -1);
+    EXPECT_NE(thirdResult.message.find("queue is full"), std::string::npos);
+
+    // Both first and second eventually fail on the drop-response timeout -- not the assertion
+    // of this test, but must still complete so the fixture can tear down cleanly.
+    first.wait();
+    second.wait();
+}
+
+TEST(AuthdClientTest, StopFailsQueuedRequestsAndIsIdempotent)
+{
+    const std::string path = makeUniqueSocketPath("authd_client_stop");
+    FakeUdsServer server(path, [](const std::string&) { return "{}"; });
+    server.setDropResponses(true);
+
+    // Short response timeout: the worker is blocked inside performRequest(), not workerLoop()'s
+    // own wait, while handling the in-flight request -- stop()'s join() can only complete once
+    // that call returns (same limitation TaskClient's own stop/destroy already has), so this must
+    // resolve quickly for the test to be fast rather than technically-wrong-but-slow.
+    auto client = std::make_unique<AuthdClient>(
+        path, /*isWorkerNode=*/false, /*connectTimeoutMs=*/0, /*responseTimeoutMs=*/200, /*maxQueueSize=*/4);
+
+    ResultWaiter inFlight;
+    ResultWaiter queued;
+    client->addAgent(makeRequest(), inFlight.callback());
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    client->addAgent(makeRequest(), queued.callback());
+
+    client->stop();
+    client->stop(); // must not crash or double-join
+
+    const auto queuedResult = queued.wait();
+    EXPECT_EQ(queuedResult.errorCode, -1);
+    EXPECT_NE(queuedResult.message.find("stopping"), std::string::npos);
+
+    inFlight.wait(); // times out on the drop-response server; just must not hang the fixture
+}

--- a/src/remoted/remoted_module/test/unit/authdClient_test.cpp
+++ b/src/remoted/remoted_module/test/unit/authdClient_test.cpp
@@ -12,10 +12,15 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstring>
 #include <memory>
 #include <mutex>
 #include <thread>
 #include <vector>
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
 
 #include <gtest/gtest.h>
 
@@ -114,9 +119,10 @@ TEST(AuthdClientTest, BusinessRejectionPreservesCodeAndStripsPrefix)
 
 TEST(AuthdClientTest, ServerAbsentIsATransportFailure)
 {
-    // No FakeUdsServer bound at this path at all. connect() is a plain blocking call (see
-    // authdClient.hpp's class comment), so this fails FAST with ENOENT -- distinct from
-    // ServerDroppingTheResponseTimesOut below, which genuinely waits out the response timeout.
+    // No FakeUdsServer bound at this path at all: connect() itself fails synchronously with
+    // ENOENT (a real failure, not "would block"), so this never reaches the connect-timeout
+    // poll() at all -- it fails FAST, distinct from ServerDroppingTheResponseTimesOut below,
+    // which genuinely waits out the response timeout.
     const std::string path = makeUniqueSocketPath("authd_client_absent");
 
     AuthdClient client(path, /*isWorkerNode=*/false, /*connectTimeoutMs=*/0, /*responseTimeoutMs=*/5000);
@@ -128,6 +134,57 @@ TEST(AuthdClientTest, ServerAbsentIsATransportFailure)
     const auto result = waiter.wait(std::chrono::milliseconds(500));
     EXPECT_EQ(result.errorCode, -1);
     EXPECT_NE(result.message.find("Could not connect"), std::string::npos);
+}
+
+TEST(AuthdClientTest, SaturatedAcceptBacklogIsAFastConnectFailureNotAHang)
+{
+    // A real listener exists at this path, but its accept() backlog is fully saturated by other
+    // (never-accepted) connections -- the one scenario connectTimeoutMs/the POLLHUP check in
+    // performRequest() exist for. Verified against the real kernel (see authdClient.cpp's comment
+    // at the POLLHUP/POLLERR check): AF_UNIX's non-blocking connect() fails synchronously with
+    // EAGAIN when the backlog is full -- there's no async "still connecting" state -- so poll()
+    // comes back immediately with POLLHUP set, and SO_ERROR alone would misleadingly read 0.
+    const std::string path = makeUniqueSocketPath("authd_client_backlog_full");
+
+    const int listenFd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+    ASSERT_GE(listenFd, 0);
+    sockaddr_un addr {};
+    addr.sun_family = AF_UNIX;
+    std::strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
+    ASSERT_EQ(::bind(listenFd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)), 0);
+    ASSERT_EQ(::listen(listenFd, 1), 0); // tiny backlog, saturated below
+
+    // Never accept() any of these: fills the listen backlog and keeps it full for the whole test.
+    std::vector<int> fillers;
+    for (int i = 0; i < 8; ++i)
+    {
+        const int fd = ::socket(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0);
+        ASSERT_GE(fd, 0);
+        ::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)); // may succeed or EAGAIN; either is fine
+        fillers.push_back(fd);
+    }
+
+    // Generous timeouts on both axes: the assertion below (well under either) is what proves this
+    // resolves via the fast POLLHUP-detected failure, not by waiting either deadline out.
+    AuthdClient client(path,
+                       /*isWorkerNode=*/false,
+                       /*connectTimeoutMs=*/2000,
+                       /*responseTimeoutMs=*/5000,
+                       /*maxQueueSize=*/0,
+                       /*workerThreads=*/1);
+    ResultWaiter waiter;
+    client.addAgent(makeRequest(), waiter.callback());
+
+    const auto result = waiter.wait(std::chrono::milliseconds(500));
+    EXPECT_EQ(result.errorCode, -1);
+    EXPECT_NE(result.message.find("Could not connect"), std::string::npos);
+
+    for (const int fd : fillers)
+    {
+        ::close(fd);
+    }
+    ::close(listenFd);
+    ::unlink(path.c_str());
 }
 
 TEST(AuthdClientTest, ServerDroppingTheResponseTimesOut)

--- a/src/remoted/remoted_module/test/unit/authdClient_test.cpp
+++ b/src/remoted/remoted_module/test/unit/authdClient_test.cpp
@@ -12,8 +12,10 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 #include <thread>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -74,6 +76,10 @@ TEST(AuthdClientTest, SuccessfulAddReturnsAgentData)
         {
             return R"({"error":0,"data":{"id":"003","name":"agent1","ip":"any","key":"675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915"}})";
         });
+    // Real authd closes the connection right after its one reply (see FakeUdsServer's
+    // setCloseAfterReply doc comment) -- without this, AuthdClient's read() loop blocks trying to
+    // read a second, never-coming frame until the full response timeout elapses.
+    server.setCloseAfterReply(true);
 
     AuthdClient client(path);
     ResultWaiter waiter;
@@ -93,6 +99,7 @@ TEST(AuthdClientTest, BusinessRejectionPreservesCodeAndStripsPrefix)
     const std::string path = makeUniqueSocketPath("authd_client_business_error");
     FakeUdsServer server(path,
                          [](const std::string&) { return R"({"error":9008,"message":"ERROR: Duplicate name"})"; });
+    server.setCloseAfterReply(true);
 
     AuthdClient client(path);
     ResultWaiter waiter;
@@ -107,20 +114,20 @@ TEST(AuthdClientTest, BusinessRejectionPreservesCodeAndStripsPrefix)
 
 TEST(AuthdClientTest, ServerAbsentIsATransportFailure)
 {
-    // No FakeUdsServer bound at this path at all. SocketClient::connect() retries a failed
-    // connect() silently in its own background thread rather than surfacing it -- there is no
-    // synchronous "could not connect" signal to catch (see authdClient.hpp's class comment) --
-    // so this resolves only via the response timeout, exactly like ServerDroppingTheResponseTimesOut.
-    // Short response timeout so the test doesn't wait the full worker-aware default.
+    // No FakeUdsServer bound at this path at all. connect() is a plain blocking call (see
+    // authdClient.hpp's class comment), so this fails FAST with ENOENT -- distinct from
+    // ServerDroppingTheResponseTimesOut below, which genuinely waits out the response timeout.
     const std::string path = makeUniqueSocketPath("authd_client_absent");
 
-    AuthdClient client(path, /*isWorkerNode=*/false, /*connectTimeoutMs=*/0, /*responseTimeoutMs=*/200);
+    AuthdClient client(path, /*isWorkerNode=*/false, /*connectTimeoutMs=*/0, /*responseTimeoutMs=*/5000);
     ResultWaiter waiter;
     client.addAgent(makeRequest(), waiter.callback());
 
-    const auto result = waiter.wait(std::chrono::seconds(2));
+    // Well under the response timeout: proves this resolves via the fast connect failure, not by
+    // waiting the deadline out.
+    const auto result = waiter.wait(std::chrono::milliseconds(500));
     EXPECT_EQ(result.errorCode, -1);
-    EXPECT_NE(result.message.find("Timed out"), std::string::npos);
+    EXPECT_NE(result.message.find("Could not connect"), std::string::npos);
 }
 
 TEST(AuthdClientTest, ServerDroppingTheResponseTimesOut)
@@ -143,6 +150,7 @@ TEST(AuthdClientTest, MalformedResponseIsATransportFailure)
 {
     const std::string path = makeUniqueSocketPath("authd_client_malformed");
     FakeUdsServer server(path, [](const std::string&) { return "not valid json{{{"; });
+    server.setCloseAfterReply(true);
 
     AuthdClient client(path);
     ResultWaiter waiter;
@@ -158,6 +166,7 @@ TEST(AuthdClientTest, MissingDataOnSuccessIsATransportFailure)
     // fabricate a success result.
     const std::string path = makeUniqueSocketPath("authd_client_missing_data");
     FakeUdsServer server(path, [](const std::string&) { return R"({"error":0})"; });
+    server.setCloseAfterReply(true);
 
     AuthdClient client(path);
     ResultWaiter waiter;
@@ -180,6 +189,7 @@ TEST(AuthdClientTest, RequestOmitsForceIdAndKeyAndIncludesOptionalFieldsWhenProv
                              capturedRequest = request;
                              return R"({"error":0,"data":{"id":"1","name":"n","ip":"i","key":"k"}})";
                          });
+    server.setCloseAfterReply(true);
 
     AuthdClient client(path);
     AuthdAddRequest req;
@@ -222,6 +232,7 @@ TEST(AuthdClientTest, OptionalFieldsAreOmittedWhenNotProvided)
                              capturedRequest = request;
                              return R"({"error":0,"data":{"id":"1","name":"n","ip":"i","key":"k"}})";
                          });
+    server.setCloseAfterReply(true);
 
     AuthdClient client(path);
     ResultWaiter waiter;
@@ -243,10 +254,17 @@ TEST(AuthdClientTest, QueueFullRejectsBeyondCapacity)
 {
     const std::string path = makeUniqueSocketPath("authd_client_queue_full");
     FakeUdsServer server(path, [](const std::string&) { return "{}"; });
-    server.setDropResponses(true); // keep the single worker thread busy on the first request
+    server.setDropResponses(true); // keep the (single) worker thread busy on the first request
 
-    AuthdClient client(
-        path, /*isWorkerNode=*/false, /*connectTimeoutMs=*/0, /*responseTimeoutMs=*/300, /*maxQueueSize=*/1);
+    // workerThreads=1: this test is specifically about the QUEUE filling up once the worker(s)
+    // are all busy, which needs a known, small worker count to trigger deterministically -- the
+    // pool's default (kDefaultWorkerThreads) would just pick up "second" immediately too.
+    AuthdClient client(path,
+                       /*isWorkerNode=*/false,
+                       /*connectTimeoutMs=*/0,
+                       /*responseTimeoutMs=*/300,
+                       /*maxQueueSize=*/1,
+                       /*workerThreads=*/1);
 
     ResultWaiter first;
     ResultWaiter second;
@@ -277,8 +295,14 @@ TEST(AuthdClientTest, StopFailsQueuedRequestsAndIsIdempotent)
     // own wait, while handling the in-flight request -- stop()'s join() can only complete once
     // that call returns (same limitation TaskClient's own stop/destroy already has), so this must
     // resolve quickly for the test to be fast rather than technically-wrong-but-slow.
-    auto client = std::make_unique<AuthdClient>(
-        path, /*isWorkerNode=*/false, /*connectTimeoutMs=*/0, /*responseTimeoutMs=*/200, /*maxQueueSize=*/4);
+    // workerThreads=1: "queued" must land in the QUEUE (not get picked up by an idle second
+    // worker) for this test's "queued.wait() sees the stopping rejection" assertion to hold.
+    auto client = std::make_unique<AuthdClient>(path,
+                                                /*isWorkerNode=*/false,
+                                                /*connectTimeoutMs=*/0,
+                                                /*responseTimeoutMs=*/200,
+                                                /*maxQueueSize=*/4,
+                                                /*workerThreads=*/1);
 
     ResultWaiter inFlight;
     ResultWaiter queued;
@@ -294,4 +318,52 @@ TEST(AuthdClientTest, StopFailsQueuedRequestsAndIsIdempotent)
     EXPECT_NE(queuedResult.message.find("stopping"), std::string::npos);
 
     inFlight.wait(); // times out on the drop-response server; just must not hang the fixture
+}
+
+TEST(AuthdClientTest, WorkerPoolProcessesRequestsConcurrently)
+{
+    // Proves the pool actually parallelizes: FakeUdsServer serves each connection on its own
+    // thread already (see its class comment), so an artificial per-request delay here measures
+    // AuthdClient's OWN concurrency, not anything the fake server would have serialized for it.
+    const std::string path = makeUniqueSocketPath("authd_client_pool_concurrency");
+    constexpr auto kPerRequestDelay = std::chrono::milliseconds(150);
+    FakeUdsServer server(path,
+                         [kPerRequestDelay](const std::string&)
+                         {
+                             std::this_thread::sleep_for(kPerRequestDelay);
+                             return std::string(R"({"error":0,"data":{"id":"1","name":"n","ip":"i","key":"k"}})");
+                         });
+    // Without this, AuthdClient's read() loop would sit waiting on a second, never-coming frame
+    // until the 5 s response timeout below elapses -- dwarfing the artificial per-request delay
+    // this test is actually trying to measure concurrency against.
+    server.setCloseAfterReply(true);
+
+    constexpr std::uint32_t kWorkers = 4;
+    AuthdClient client(path,
+                       /*isWorkerNode=*/false,
+                       /*connectTimeoutMs=*/0,
+                       /*responseTimeoutMs=*/5000,
+                       /*maxQueueSize=*/0,
+                       /*workerThreads=*/kWorkers);
+
+    std::vector<std::unique_ptr<ResultWaiter>> waiters;
+    const auto start = std::chrono::steady_clock::now();
+    for (std::uint32_t i = 0; i < kWorkers; ++i)
+    {
+        waiters.push_back(std::make_unique<ResultWaiter>());
+        client.addAgent(makeRequest(), waiters.back()->callback());
+    }
+    for (auto& waiter : waiters)
+    {
+        const auto result = waiter->wait(std::chrono::seconds(2));
+        EXPECT_EQ(result.errorCode, 0);
+    }
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    // Serialized (one worker), kWorkers requests at kPerRequestDelay each would take roughly
+    // kWorkers * kPerRequestDelay (~600 ms here). Run concurrently across kWorkers workers, they
+    // should all finish close to a SINGLE request's delay. A comfortable margin below 2x one
+    // request's delay is enough to distinguish "ran in parallel" from "ran serialized" without
+    // being flaky under scheduling jitter.
+    EXPECT_LT(elapsed, kPerRequestDelay * 2);
 }

--- a/src/remoted/remoted_module/test/unit/authdClient_test.cpp
+++ b/src/remoted/remoted_module/test/unit/authdClient_test.cpp
@@ -15,6 +15,7 @@
 #include <cstring>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <thread>
 #include <vector>
 
@@ -423,4 +424,34 @@ TEST(AuthdClientTest, WorkerPoolProcessesRequestsConcurrently)
     // request's delay is enough to distinguish "ran in parallel" from "ran serialized" without
     // being flaky under scheduling jitter.
     EXPECT_LT(elapsed, kPerRequestDelay * 2);
+}
+
+TEST(AuthdClientTest, WorkerThreadSurvivesACallbackThatThrows)
+{
+    // Regression guard: workerLoop() runs req.callback(performRequest(...)) with no try/catch of
+    // its own, on a bare std::thread RestinioHttpServer's per-request exception guard never sees
+    // (that guard only covers the synchronous handler call; this callback fires later, from a
+    // different thread entirely). An uncaught exception escaping a std::thread's entry function
+    // terminates the whole process -- this proves the worker instead survives and keeps serving
+    // later requests, which it could only do if the exception was caught inside the loop.
+    const std::string path = makeUniqueSocketPath("authd_client_callback_throws");
+    FakeUdsServer server(
+        path, [](const std::string&) { return R"({"error":0,"data":{"id":"1","name":"n","ip":"i","key":"k"}})"; });
+    server.setCloseAfterReply(true);
+
+    // workerThreads=1: guarantees the SAME worker thread that ran the throwing callback is the one
+    // that must still be alive and looping to pick up the second request below.
+    AuthdClient client(path,
+                       /*isWorkerNode=*/false,
+                       /*connectTimeoutMs=*/0,
+                       /*responseTimeoutMs=*/2000,
+                       /*maxQueueSize=*/0,
+                       /*workerThreads=*/1);
+
+    client.addAgent(makeRequest(), [](AuthdResult) { throw std::runtime_error("boom"); });
+
+    ResultWaiter waiter;
+    client.addAgent(makeRequest(), waiter.callback());
+    const auto result = waiter.wait(std::chrono::seconds(2));
+    EXPECT_EQ(result.errorCode, 0);
 }

--- a/src/remoted/remoted_module/test/unit/bodyDecoder_test.cpp
+++ b/src/remoted/remoted_module/test/unit/bodyDecoder_test.cpp
@@ -22,9 +22,9 @@
 
 using remoted::auth::AuthError;
 using remoted::auth::Payload;
+using remoted::decoding::BodyDecoder;
 using remoted::decoding::ContentEncoding;
 using remoted::decoding::parseContentEncoding;
-using remoted::decoding::BodyDecoder;
 using remoted::testutil::FakeHttpServer;
 using remoted::testutil::zstdCompress;
 
@@ -247,4 +247,95 @@ TEST(BodyDecoderTest, AmpleBudgetAllowsTheSameLargeFrame)
 
     EXPECT_EQ(decoder.decode(ContentEncoding::Zstd, payload), AuthError::None);
     EXPECT_EQ(payload.bytes().size(), plain.size());
+}
+
+// ---------------------------------------------------------------------------
+// maxDecodedSize -- a SEPARATE, smaller self-imposed ceiling on top of the shared in-flight
+// budget, for routes (namely /enroll's Open mode) where an unauthenticated peer can reach
+// decode() at all. Regression guard: without this, a small, highly-compressed frame could hold as
+// much of the SHARED budget as it has room for, not just the tiny amount this route ever
+// legitimately needs.
+// ---------------------------------------------------------------------------
+
+TEST(BodyDecoderTest, MaxDecodedSizeRejectsOutputThatWouldExceedItEvenWithBudgetToSpare)
+{
+    // A huge shared budget -- the shared-budget checks above would all pass easily -- but a tiny
+    // self-imposed cap. The cap alone must be what rejects this, proving it is enforced
+    // independently of (and can be stricter than) the shared budget.
+    FakeHttpServer server {10U * 1024U * 1024U};
+    constexpr std::size_t kMaxDecodedSize = 1024;
+    const BodyDecoder decoder {server, /*enabled=*/true, kMaxDecodedSize};
+
+    const std::string plain(kMaxDecodedSize + 1, 'a'); // one byte over the cap
+    auto bytes = std::make_shared<std::string>(zstdCompress(plain));
+    auto payload = payloadOver(bytes);
+
+    EXPECT_EQ(decoder.decode(ContentEncoding::Zstd, payload), AuthError::BodyTooLarge);
+    // Refused before ever charging the shared budget for it.
+    EXPECT_EQ(server.m_budget.availableBytes(), 10U * 1024U * 1024U);
+}
+
+TEST(BodyDecoderTest, MaxDecodedSizeAllowsOutputAtOrUnderTheCap)
+{
+    FakeHttpServer server {10U * 1024U * 1024U};
+    constexpr std::size_t kMaxDecodedSize = 1024;
+    const BodyDecoder decoder {server, /*enabled=*/true, kMaxDecodedSize};
+
+    const std::string plain(kMaxDecodedSize, 'a'); // exactly at the cap
+    auto bytes = std::make_shared<std::string>(zstdCompress(plain));
+    auto payload = payloadOver(bytes);
+
+    EXPECT_EQ(decoder.decode(ContentEncoding::Zstd, payload), AuthError::None);
+    EXPECT_EQ(payload.bytes().size(), kMaxDecodedSize);
+}
+
+TEST(BodyDecoderTest, DefaultMaxDecodedSizeOfZeroMeansNoExtraCapBeyondTheSharedBudget)
+{
+    // The default (no third constructor argument) must behave exactly as it did before this
+    // parameter existed -- every other test in this file relies on that already; this test states
+    // it explicitly for a body large enough that a mistakenly-nonzero default would reject it.
+    FakeHttpServer server;
+    const BodyDecoder decoder {server, /*enabled=*/true};
+
+    const std::string plain(256 * 1024, 'a');
+    auto bytes = std::make_shared<std::string>(zstdCompress(plain));
+    auto payload = payloadOver(bytes);
+
+    EXPECT_EQ(decoder.decode(ContentEncoding::Zstd, payload), AuthError::None);
+}
+
+TEST(BodyDecoderTest, MaxDecodedSizeAcceptsASmallStreamingCompressedBodyWithNoDeclaredSize)
+{
+    // Regression guard for the exact shape /enroll sees. A frame that declares no decompressed
+    // size takes zstdDecode()'s block-growth path, whose first growth request is a full 64 KiB
+    // regardless of how little the body really decodes to. With a cap smaller than that step
+    // (kMaxEnrollBodySize is 16 KiB) every such request used to come back BodyTooLarge -> 413,
+    // so an agent compressing its enrollment body on the fly could never enroll at all, while the
+    // same body compressed one-shot went through. The cap has to bound real decoded size, not the
+    // growth step.
+    FakeHttpServer server {10U * 1024U * 1024U};
+    constexpr std::size_t kMaxDecodedSize = 16U * 1024U;
+    const BodyDecoder decoder {server, /*enabled=*/true, kMaxDecodedSize};
+
+    const std::string plain = R"({"name":"agent1","version":"5.0.0"})";
+    auto bytes = std::make_shared<std::string>(remoted::testutil::zstdCompressWithoutDeclaredSize(plain));
+    auto payload = payloadOver(bytes);
+
+    EXPECT_EQ(decoder.decode(ContentEncoding::Zstd, payload), AuthError::None);
+    EXPECT_EQ(payload.bytes(), plain);
+}
+
+TEST(BodyDecoderTest, MaxDecodedSizeStillRejectsAnOverCapBodyWithNoDeclaredSize)
+{
+    // The other half: accepting the small streaming case must not have turned the cap off for the
+    // block-growth path.
+    FakeHttpServer server {10U * 1024U * 1024U};
+    constexpr std::size_t kMaxDecodedSize = 16U * 1024U;
+    const BodyDecoder decoder {server, /*enabled=*/true, kMaxDecodedSize};
+
+    const std::string plain(kMaxDecodedSize * 8, 'a');
+    auto bytes = std::make_shared<std::string>(remoted::testutil::zstdCompressWithoutDeclaredSize(plain));
+    auto payload = payloadOver(bytes);
+
+    EXPECT_EQ(decoder.decode(ContentEncoding::Zstd, payload), AuthError::BodyTooLarge);
 }

--- a/src/remoted/remoted_module/test/unit/controlTypes_test.cpp
+++ b/src/remoted/remoted_module/test/unit/controlTypes_test.cpp
@@ -75,6 +75,39 @@ TEST(ControlTypesTest, IsValidVersionRejectsMalformed)
 }
 
 // -----------------------------------------------------------------------------
+// compareVersions
+//
+// Shared by /control (allow_higher_versions) and /enroll (D8: reused, not
+// duplicated, since authd's own local `add` path performs no version check at all).
+// -----------------------------------------------------------------------------
+
+TEST(ControlTypesTest, CompareVersionsEqualIsZero)
+{
+    EXPECT_EQ(compareVersions("5.0.0", "5.0.0"), 0);
+    EXPECT_EQ(compareVersions("v5.0.0", "5.0.0"), 0); // leading 'v' ignored on either side
+    EXPECT_EQ(compareVersions("5", "5.0.0"), 0);      // missing parts treated as 0
+}
+
+TEST(ControlTypesTest, CompareVersionsOrdersNumerically)
+{
+    EXPECT_LT(compareVersions("5.0.0", "5.0.1"), 0);
+    EXPECT_LT(compareVersions("4.9.0", "5.0.0"), 0);
+    EXPECT_GT(compareVersions("5.1.0", "5.0.9"), 0); // per-component, not lexicographic
+    EXPECT_GT(compareVersions("5.0.10", "5.0.9"), 0);
+}
+
+TEST(ControlTypesTest, CompareVersionsIgnoresSuffix)
+{
+    EXPECT_EQ(compareVersions("5.0.0-alpha0", "5.0.0"), 0);
+    EXPECT_EQ(compareVersions("5.0.0+build.42", "5.0.0"), 0);
+}
+
+TEST(ControlTypesTest, CompareVersionsTreatsUnparsablePartsAsZero)
+{
+    EXPECT_EQ(compareVersions("not-a-version", "0.0.0"), 0);
+}
+
+// -----------------------------------------------------------------------------
 // isValidHostInfo
 //
 // Bounds-only check (no charset). Any field over its cap fails; sizes at the

--- a/src/remoted/remoted_module/test/unit/enrollmentAuthenticator_test.cpp
+++ b/src/remoted/remoted_module/test/unit/enrollmentAuthenticator_test.cpp
@@ -172,7 +172,10 @@ TEST_F(PasswordFixture, FutureTimestampIsRejected)
 TEST(EnrollmentAuthenticatorTest, PasswordModeMissingKeyFileFailsClosed)
 {
     // Points at a file that was never written: PasswordKeySource::currentKey() stays nullopt.
-    // Fail-closed is security-critical here -- must be MissingKey/401, never treated as Open mode.
+    // Fail-closed is security-critical here -- must be rejected/401, never treated as Open mode.
+    // EnrollmentKeyUnavailable, deliberately NOT MissingKey: MissingKey means an already-enrolled
+    // agent's client.keys entry doesn't decode (logRejection() tells the operator to "re-enroll"
+    // for that) -- nonsensical here, where no agent and no client.keys entry exist yet at all.
     auto keySource = std::make_shared<PasswordKeySource>("/tmp/enrollmentAuthenticator_test_absent.pass");
     EnrollmentAuthenticator authenticator {EnrollmentAuthConfig {true}, keySource};
 
@@ -180,7 +183,7 @@ TEST(EnrollmentAuthenticatorTest, PasswordModeMissingKeyFileFailsClosed)
     const auto err =
         authenticator.authenticate("WazuhEnroll " + std::to_string(kNow) + ":" + mac, "POST", "/enroll", "{}", kNow);
     ASSERT_TRUE(err.has_value());
-    EXPECT_EQ(*err, AuthError::MissingKey);
+    EXPECT_EQ(*err, AuthError::EnrollmentKeyUnavailable);
 }
 
 // -----------------------------------------------------------------------------
@@ -195,4 +198,44 @@ TEST(EnrollmentAuthenticatorTest, RequirePasswordFalseAlwaysPasses)
     EnrollmentAuthenticator authenticator {EnrollmentAuthConfig {false}, nullptr};
     EXPECT_EQ(authenticator.authenticate("", "POST", "/enroll", "{}", kNow), std::nullopt);
     EXPECT_EQ(authenticator.authenticate("garbage", "POST", "/enroll", "{}", kNow), std::nullopt);
+}
+
+// -----------------------------------------------------------------------------
+// maxBodySize -- checked before anything else, in every mode. Regression guard: this class used
+// to have no body-size cap at all, so an unauthenticated peer could make it CMAC an arbitrarily
+// large body (up to the transport's own cap) before ever being rejected.
+// -----------------------------------------------------------------------------
+
+TEST(EnrollmentAuthenticatorTest, OversizedBodyIsRejectedBeforeAnythingElseInOpenMode)
+{
+    EnrollmentAuthConfig config {false};
+    config.maxBodySize = 10;
+    EnrollmentAuthenticator authenticator {config, nullptr};
+
+    const auto err = authenticator.authenticate("", "POST", "/enroll", std::string(11, 'a'), kNow);
+    ASSERT_TRUE(err.has_value());
+    EXPECT_EQ(*err, AuthError::BodyTooLarge);
+}
+
+TEST(EnrollmentAuthenticatorTest, BodyAtOrUnderTheCapIsNotRejectedOnSizeAloneInOpenMode)
+{
+    EnrollmentAuthConfig config {false};
+    config.maxBodySize = 10;
+    EnrollmentAuthenticator authenticator {config, nullptr};
+
+    EXPECT_EQ(authenticator.authenticate("", "POST", "/enroll", std::string(10, 'a'), kNow), std::nullopt);
+}
+
+TEST(EnrollmentAuthenticatorTest, OversizedBodyIsRejectedBeforeTheCmacRunsInPasswordMode)
+{
+    // No Authorization header at all, AND an oversized body: if this returned
+    // MissingAuthorization instead, the size check would be running after (or not at all before)
+    // the rest of authenticatePassword() -- BodyTooLarge proves it runs first.
+    EnrollmentAuthConfig config {true};
+    config.maxBodySize = 10;
+    EnrollmentAuthenticator authenticator {config, nullptr};
+
+    const auto err = authenticator.authenticate("", "POST", "/enroll", std::string(11, 'a'), kNow);
+    ASSERT_TRUE(err.has_value());
+    EXPECT_EQ(*err, AuthError::BodyTooLarge);
 }

--- a/src/remoted/remoted_module/test/unit/enrollmentAuthenticator_test.cpp
+++ b/src/remoted/remoted_module/test/unit/enrollmentAuthenticator_test.cpp
@@ -1,0 +1,198 @@
+/*
+ * Wazuh remoted module - EnrollmentAuthenticator unit tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 19, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+// Exercises EnrollmentAuthenticator in isolation -- no sockets, no transport -- covering the
+// per-mode pass/deny matrix and the WazuhEnroll CMAC tamper scenarios a real E2E test re-runs
+// over the wire.
+
+#include <cstdio>
+#include <fstream>
+#include <string>
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+#include "auth/cmac.hpp"
+#include "enrollment/enrollmentAuthenticator.hpp"
+
+using namespace remoted::enrollment;
+using remoted::auth::AuthError;
+using remoted::auth::Cmac;
+using remoted::auth::PasswordKeySource;
+using remoted::auth::toLowerHex;
+
+namespace
+{
+    constexpr std::int64_t kNow = 1'784'238'000;
+
+    std::string writePasswordFile(const std::string& password)
+    {
+        const std::string path = "/tmp/enrollmentAuthenticator_test_" + std::to_string(getpid()) + ".pass";
+        std::ofstream file(path);
+        file << password << "\n";
+        return path;
+    }
+
+    // Builds the same canonical byte sequence EnrollmentAuthenticator verifies in Password mode,
+    // so tests can sign a request without a production signer.
+    std::string sign(const std::vector<std::uint8_t>& key,
+                     std::string_view method,
+                     std::string_view target,
+                     std::string_view body,
+                     std::int64_t ts)
+    {
+        Cmac cmac(key);
+        cmac.update("WAZUH-ENROLL\n");
+        cmac.update("1\n");
+        cmac.update(method);
+        cmac.update("\n");
+        cmac.update(target);
+        cmac.update("\n");
+        cmac.update(std::to_string(ts));
+        cmac.update("\n");
+        cmac.update(body);
+        const auto mac = cmac.finalize();
+        return "WazuhEnroll " + std::to_string(ts) + ":" + toLowerHex(mac.data(), mac.size());
+    }
+
+    struct PasswordFixture : public ::testing::Test
+    {
+        std::string path = writePasswordFile("MyEnrollmentSecret123");
+        std::shared_ptr<PasswordKeySource> keySource = std::make_shared<PasswordKeySource>(path);
+        EnrollmentAuthenticator authenticator {EnrollmentAuthConfig {true}, keySource};
+
+        void TearDown() override
+        {
+            std::remove(path.c_str());
+        }
+
+        std::string signValid(std::string_view method = "POST",
+                              std::string_view target = "/enroll",
+                              std::string_view body = R"({"name":"agent1"})",
+                              std::int64_t ts = kNow)
+        {
+            const auto key = keySource->currentKey();
+            return sign(*key, method, target, body, ts);
+        }
+    };
+} // namespace
+
+// -----------------------------------------------------------------------------
+// Password mode
+// -----------------------------------------------------------------------------
+
+TEST_F(PasswordFixture, ValidSignatureIsAccepted)
+{
+    const std::string auth = signValid();
+    EXPECT_EQ(authenticator.authenticate(auth, "POST", "/enroll", R"({"name":"agent1"})", kNow), std::nullopt);
+}
+
+TEST_F(PasswordFixture, MissingAuthorizationHeaderIsRejected)
+{
+    const auto err = authenticator.authenticate("", "POST", "/enroll", R"({"name":"agent1"})", kNow);
+    ASSERT_TRUE(err.has_value());
+    EXPECT_EQ(*err, AuthError::MissingAuthorization);
+}
+
+TEST_F(PasswordFixture, WrongSchemeIsRejected)
+{
+    const auto err =
+        authenticator.authenticate("Wazuh 001:1739999999:deadbeef", "POST", "/enroll", R"({"name":"agent1"})", kNow);
+    ASSERT_TRUE(err.has_value());
+    EXPECT_EQ(*err, AuthError::MalformedAuthorization);
+}
+
+TEST_F(PasswordFixture, NonHexMacIsRejected)
+{
+    const auto err = authenticator.authenticate(
+        "WazuhEnroll 1784238000:not-a-valid-mac-hex-string-000", "POST", "/enroll", "{}", kNow);
+    ASSERT_TRUE(err.has_value());
+    EXPECT_EQ(*err, AuthError::MalformedAuthorization);
+}
+
+TEST_F(PasswordFixture, NonNumericTimestampIsRejected)
+{
+    const std::string mac(32, 'a');
+    const auto err = authenticator.authenticate("WazuhEnroll notanumber:" + mac, "POST", "/enroll", "{}", kNow);
+    ASSERT_TRUE(err.has_value());
+    EXPECT_EQ(*err, AuthError::MalformedAuthorization);
+}
+
+TEST_F(PasswordFixture, TamperedBodyIsRejected)
+{
+    const std::string auth = signValid("POST", "/enroll", R"({"name":"agent1"})", kNow);
+    const auto err = authenticator.authenticate(auth, "POST", "/enroll", R"({"name":"agent2"})", kNow);
+    ASSERT_TRUE(err.has_value());
+    EXPECT_EQ(*err, AuthError::InvalidMac);
+}
+
+TEST_F(PasswordFixture, TamperedTargetIsRejected)
+{
+    const std::string auth = signValid("POST", "/enroll", R"({"name":"agent1"})", kNow);
+    const auto err = authenticator.authenticate(auth, "POST", "/other", R"({"name":"agent1"})", kNow);
+    ASSERT_TRUE(err.has_value());
+    EXPECT_EQ(*err, AuthError::InvalidMac);
+}
+
+TEST_F(PasswordFixture, WrongKeyIsRejected)
+{
+    const std::vector<std::uint8_t> otherKey(32, 0x42);
+    const std::string auth = sign(otherKey, "POST", "/enroll", R"({"name":"agent1"})", kNow);
+    const auto err = authenticator.authenticate(auth, "POST", "/enroll", R"({"name":"agent1"})", kNow);
+    ASSERT_TRUE(err.has_value());
+    EXPECT_EQ(*err, AuthError::InvalidMac);
+}
+
+TEST_F(PasswordFixture, ExpiredTimestampIsRejected)
+{
+    const std::int64_t oldTs = kNow - 301; // just past the 300s default window
+    const std::string auth = signValid("POST", "/enroll", "{}", oldTs);
+    const auto err = authenticator.authenticate(auth, "POST", "/enroll", "{}", kNow);
+    ASSERT_TRUE(err.has_value());
+    EXPECT_EQ(*err, AuthError::ExpiredRequest);
+}
+
+TEST_F(PasswordFixture, FutureTimestampIsRejected)
+{
+    const std::int64_t futureTs = kNow + 31; // just past the 30s default skew
+    const std::string auth = signValid("POST", "/enroll", "{}", futureTs);
+    const auto err = authenticator.authenticate(auth, "POST", "/enroll", "{}", kNow);
+    ASSERT_TRUE(err.has_value());
+    EXPECT_EQ(*err, AuthError::FutureRequest);
+}
+
+TEST(EnrollmentAuthenticatorTest, PasswordModeMissingKeyFileFailsClosed)
+{
+    // Points at a file that was never written: PasswordKeySource::currentKey() stays nullopt.
+    // Fail-closed is security-critical here -- must be MissingKey/401, never treated as Open mode.
+    auto keySource = std::make_shared<PasswordKeySource>("/tmp/enrollmentAuthenticator_test_absent.pass");
+    EnrollmentAuthenticator authenticator {EnrollmentAuthConfig {true}, keySource};
+
+    const std::string mac(32, 'a');
+    const auto err =
+        authenticator.authenticate("WazuhEnroll " + std::to_string(kNow) + ":" + mac, "POST", "/enroll", "{}", kNow);
+    ASSERT_TRUE(err.has_value());
+    EXPECT_EQ(*err, AuthError::MissingKey);
+}
+
+// -----------------------------------------------------------------------------
+// requirePassword=false: passes unconditionally, regardless of whether the listener separately
+// requires a client certificate ("mTLS-only") or not ("Open") -- this class has no notion of
+// mTLS at all, since a client certificate is the TLS listener's concern, never this one's (see
+// the class comment in enrollmentAuthenticator.hpp).
+// -----------------------------------------------------------------------------
+
+TEST(EnrollmentAuthenticatorTest, RequirePasswordFalseAlwaysPasses)
+{
+    EnrollmentAuthenticator authenticator {EnrollmentAuthConfig {false}, nullptr};
+    EXPECT_EQ(authenticator.authenticate("", "POST", "/enroll", "{}", kNow), std::nullopt);
+    EXPECT_EQ(authenticator.authenticate("garbage", "POST", "/enroll", "{}", kNow), std::nullopt);
+}

--- a/src/remoted/remoted_module/test/unit/enrollmentConfig_test.cpp
+++ b/src/remoted/remoted_module/test/unit/enrollmentConfig_test.cpp
@@ -45,6 +45,11 @@ TEST(EnrollmentConfigTest, ZeroedAbiMeansEverythingOffAndTimeoutsAtSentinel)
     EXPECT_EQ(cfg.authdResponseTimeoutMs, 0u);
     EXPECT_EQ(cfg.authdMaxQueueSize, 0u);
     EXPECT_EQ(cfg.authdWorkerThreads, 0u);
+
+    // Same fallback defaults authTypes.cpp resolves for the agent<->manager scheme's AuthConfig --
+    // /enroll's WazuhEnroll freshness-window check must not silently diverge from them.
+    EXPECT_EQ(cfg.maxRequestAgeSeconds, 300);
+    EXPECT_EQ(cfg.maxFutureSkewSeconds, 30);
 }
 
 TEST(EnrollmentConfigTest, BooleanAndStringFieldsCopiedVerbatim)
@@ -106,4 +111,50 @@ TEST(EnrollmentConfigTest, NegativeAuthdKnobsFallBackToZeroSentinel)
     EXPECT_EQ(cfg.authdResponseTimeoutMs, 0u);
     EXPECT_EQ(cfg.authdMaxQueueSize, 0u);
     EXPECT_EQ(cfg.authdWorkerThreads, 0u);
+}
+
+TEST(EnrollmentConfigTest, ConfiguredRequestAgeAndFutureSkewArePassedThrough)
+{
+    // Regression guard: buildEnrollmentConfig() used to drop these two entirely -- remoted's own
+    // `auth_max_request_age`/`auth_max_future_skew` internal options had no effect on /enroll at
+    // all, silently contradicting send_enroll.py/https-events-api.md, which both document them as
+    // applying here too.
+    auto c = zeroedConfig();
+    c.auth_max_request_age = 600;
+    c.auth_max_future_skew = 60;
+
+    const auto cfg = buildEnrollmentConfig(c);
+    EXPECT_EQ(cfg.maxRequestAgeSeconds, 600);
+    EXPECT_EQ(cfg.maxFutureSkewSeconds, 60);
+}
+
+TEST(EnrollmentConfigTest, NonPositiveRequestAgeAndFutureSkewFallBackToDefaults)
+{
+    auto c = zeroedConfig();
+    c.auth_max_request_age = -1;
+    c.auth_max_future_skew = 0;
+
+    const auto cfg = buildEnrollmentConfig(c);
+    EXPECT_EQ(cfg.maxRequestAgeSeconds, 300);
+    EXPECT_EQ(cfg.maxFutureSkewSeconds, 30);
+}
+
+TEST(EnrollmentConfigTest, ConfiguredMaxBodySizeIsPassedThrough)
+{
+    // Regression guard: EnrollmentAuthConfig used to have no body-size cap counterpart to
+    // AuthConfig's at all, so /enroll never honored auth_max_body_size.
+    auto c = zeroedConfig();
+    c.auth_max_body_size = 1024 * 1024;
+
+    const auto cfg = buildEnrollmentConfig(c);
+    EXPECT_EQ(cfg.maxBodySize, 1024u * 1024u);
+}
+
+TEST(EnrollmentConfigTest, NonPositiveMaxBodySizeFallsBackToTenMebibytes)
+{
+    auto c = zeroedConfig();
+    c.auth_max_body_size = 0;
+
+    const auto cfg = buildEnrollmentConfig(c);
+    EXPECT_EQ(cfg.maxBodySize, 10u * 1024u * 1024u);
 }

--- a/src/remoted/remoted_module/test/unit/enrollmentConfig_test.cpp
+++ b/src/remoted/remoted_module/test/unit/enrollmentConfig_test.cpp
@@ -44,6 +44,7 @@ TEST(EnrollmentConfigTest, ZeroedAbiMeansEverythingOffAndTimeoutsAtSentinel)
     EXPECT_EQ(cfg.authdConnectTimeoutMs, 0u);
     EXPECT_EQ(cfg.authdResponseTimeoutMs, 0u);
     EXPECT_EQ(cfg.authdMaxQueueSize, 0u);
+    EXPECT_EQ(cfg.authdWorkerThreads, 0u);
 }
 
 TEST(EnrollmentConfigTest, BooleanAndStringFieldsCopiedVerbatim)
@@ -83,11 +84,13 @@ TEST(EnrollmentConfigTest, AuthdTimeoutsConvertedFromSecondsToMilliseconds)
     c.authd_connect_timeout = 3;
     c.authd_response_timeout = 7;
     c.authd_max_queue_size = 128;
+    c.authd_worker_threads = 6;
 
     const auto cfg = buildEnrollmentConfig(c);
     EXPECT_EQ(cfg.authdConnectTimeoutMs, 3000u);
     EXPECT_EQ(cfg.authdResponseTimeoutMs, 7000u);
     EXPECT_EQ(cfg.authdMaxQueueSize, 128u);
+    EXPECT_EQ(cfg.authdWorkerThreads, 6u); // seconds/ms conversion does NOT apply here -- a plain count
 }
 
 TEST(EnrollmentConfigTest, NegativeAuthdKnobsFallBackToZeroSentinel)
@@ -96,9 +99,11 @@ TEST(EnrollmentConfigTest, NegativeAuthdKnobsFallBackToZeroSentinel)
     c.authd_connect_timeout = -1;
     c.authd_response_timeout = -1;
     c.authd_max_queue_size = -1;
+    c.authd_worker_threads = -1;
 
     const auto cfg = buildEnrollmentConfig(c);
     EXPECT_EQ(cfg.authdConnectTimeoutMs, 0u);
     EXPECT_EQ(cfg.authdResponseTimeoutMs, 0u);
     EXPECT_EQ(cfg.authdMaxQueueSize, 0u);
+    EXPECT_EQ(cfg.authdWorkerThreads, 0u);
 }

--- a/src/remoted/remoted_module/test/unit/enrollmentConfig_test.cpp
+++ b/src/remoted/remoted_module/test/unit/enrollmentConfig_test.cpp
@@ -1,0 +1,104 @@
+/*
+ * Wazuh remoted module - Enrollment config unit tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 19, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "enrollment/enrollmentConfig.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+
+using namespace remoted::enrollment;
+
+namespace
+{
+    remoted_module_config_t zeroedConfig()
+    {
+        remoted_module_config_t c;
+        std::memset(&c, 0, sizeof(c));
+        return c;
+    }
+} // namespace
+
+TEST(EnrollmentConfigTest, ZeroedAbiMeansEverythingOffAndTimeoutsAtSentinel)
+{
+    const auto cfg = buildEnrollmentConfig(zeroedConfig());
+
+    EXPECT_FALSE(cfg.enrollmentEnabled);
+    EXPECT_FALSE(cfg.usePassword);
+    EXPECT_FALSE(cfg.useSourceIp);
+    EXPECT_FALSE(cfg.allowHigherVersions);
+    EXPECT_FALSE(cfg.isWorkerNode);
+    EXPECT_EQ(cfg.managerVersion, "");
+
+    // 0 in seconds (ABI) round-trips to 0 in ms -- both PasswordKeySource and AuthdClient treat 0
+    // as "apply your own built-in default", so no resolution happens here.
+    EXPECT_EQ(cfg.passwordRefreshIntervalSec, 0);
+    EXPECT_EQ(cfg.authdConnectTimeoutMs, 0u);
+    EXPECT_EQ(cfg.authdResponseTimeoutMs, 0u);
+    EXPECT_EQ(cfg.authdMaxQueueSize, 0u);
+}
+
+TEST(EnrollmentConfigTest, BooleanAndStringFieldsCopiedVerbatim)
+{
+    auto c = zeroedConfig();
+    c.enrollment_enabled = true;
+    c.enroll_use_password = true;
+    c.enroll_use_source_ip = true;
+    c.enroll_allow_higher_versions = true;
+    c.worker_node = true;
+    std::strncpy(c.manager_version, "5.0.0", sizeof(c.manager_version) - 1);
+
+    const auto cfg = buildEnrollmentConfig(c);
+
+    EXPECT_TRUE(cfg.enrollmentEnabled);
+    EXPECT_TRUE(cfg.usePassword);
+    EXPECT_TRUE(cfg.useSourceIp);
+    EXPECT_TRUE(cfg.allowHigherVersions);
+    EXPECT_TRUE(cfg.isWorkerNode);
+    EXPECT_EQ(cfg.managerVersion, "5.0.0");
+}
+
+TEST(EnrollmentConfigTest, PasswordRefreshIntervalPassedThroughUnconverted)
+{
+    // Seconds in the ABI, seconds in Config -- PasswordKeySource's own constructor resolves <=0,
+    // so buildEnrollmentConfig must not apply any resolution of its own.
+    auto c = zeroedConfig();
+    c.enroll_password_refresh_interval = 42;
+
+    const auto cfg = buildEnrollmentConfig(c);
+    EXPECT_EQ(cfg.passwordRefreshIntervalSec, 42);
+}
+
+TEST(EnrollmentConfigTest, AuthdTimeoutsConvertedFromSecondsToMilliseconds)
+{
+    auto c = zeroedConfig();
+    c.authd_connect_timeout = 3;
+    c.authd_response_timeout = 7;
+    c.authd_max_queue_size = 128;
+
+    const auto cfg = buildEnrollmentConfig(c);
+    EXPECT_EQ(cfg.authdConnectTimeoutMs, 3000u);
+    EXPECT_EQ(cfg.authdResponseTimeoutMs, 7000u);
+    EXPECT_EQ(cfg.authdMaxQueueSize, 128u);
+}
+
+TEST(EnrollmentConfigTest, NegativeAuthdKnobsFallBackToZeroSentinel)
+{
+    auto c = zeroedConfig();
+    c.authd_connect_timeout = -1;
+    c.authd_response_timeout = -1;
+    c.authd_max_queue_size = -1;
+
+    const auto cfg = buildEnrollmentConfig(c);
+    EXPECT_EQ(cfg.authdConnectTimeoutMs, 0u);
+    EXPECT_EQ(cfg.authdResponseTimeoutMs, 0u);
+    EXPECT_EQ(cfg.authdMaxQueueSize, 0u);
+}

--- a/src/remoted/remoted_module/test/unit/enrollmentE2E_test.cpp
+++ b/src/remoted/remoted_module/test/unit/enrollmentE2E_test.cpp
@@ -33,6 +33,7 @@
 #include <gtest/gtest.h>
 
 #include "auth/cmac.hpp"
+#include "decoding/iBodyDecoder.hpp"
 #include "enrollment/enrollmentEndpoint.hpp"
 #include "fakeUdsServer.hpp"
 #include "json.hpp"
@@ -43,6 +44,8 @@ using namespace remoted::enrollment;
 using remoted::auth::Cmac;
 using remoted::auth::PasswordKeySource;
 using remoted::auth::toLowerHex;
+using remoted::decoding::ContentEncoding;
+using remoted::decoding::IBodyDecoder;
 using remoted::http::HttpRequest;
 using remoted::http::HttpResponse;
 using remoted::http::IHttpResponder;
@@ -54,6 +57,23 @@ using namespace std::chrono_literals;
 namespace
 {
     const std::string kBody = R"({"name":"agent1","version":"5.0.0"})";
+
+    // Inert stand-in for the real BodyDecoder (see enrollmentEndpoint_test.cpp's identical stub):
+    // these tests are about the auth/validation/authd pipeline, not Content-Encoding, so this
+    // just passes every body through untouched.
+    class PassthroughBodyDecoder final : public IBodyDecoder
+    {
+    public:
+        remoted::auth::AuthError decode(ContentEncoding, remoted::auth::Payload&) const override
+        {
+            return remoted::auth::AuthError::None;
+        }
+    };
+
+    std::shared_ptr<const IBodyDecoder> passthroughDecoder()
+    {
+        return std::make_shared<const PassthroughBodyDecoder>();
+    }
 
     // These tests drive the REAL endpoint handler, which checks the signed timestamp against the
     // actual wall clock (std::time(nullptr) in enrollmentEndpoint.cpp) -- unlike
@@ -151,7 +171,7 @@ TEST(EnrollmentE2ETest, PasswordModeCorrectlySignedRequestEnrollsSuccessfully)
     AuthdClient authdClient(authdPath, /*isWorkerNode=*/false, 0, baseConfig().authdResponseTimeoutMs, 0);
     wazuh::metrics::Manager metricsManager;
     EnrollmentMetrics metrics = makeEnrollmentMetrics(metricsManager);
-    auto handler = makeHandler(authenticator, authdClient, baseConfig(), metrics);
+    auto handler = makeHandler(authenticator, authdClient, baseConfig(), metrics, passthroughDecoder());
 
     const auto key = keySource->currentKey();
     ASSERT_TRUE(key.has_value());
@@ -179,7 +199,7 @@ TEST(EnrollmentE2ETest, PasswordModeWrongSignatureIsRejected)
     AuthdClient authdClient(makeUniqueSocketPath("enrollment_e2e_password_reject"));
     wazuh::metrics::Manager metricsManager;
     EnrollmentMetrics metrics = makeEnrollmentMetrics(metricsManager);
-    auto handler = makeHandler(authenticator, authdClient, baseConfig(), metrics);
+    auto handler = makeHandler(authenticator, authdClient, baseConfig(), metrics, passthroughDecoder());
 
     HttpRequest request;
     request.method = Method::Post;
@@ -205,7 +225,7 @@ TEST(EnrollmentE2ETest, OpenModeUnauthenticatedRequestEnrollsSuccessfully)
     AuthdClient authdClient(authdPath, /*isWorkerNode=*/false, 0, baseConfig().authdResponseTimeoutMs, 0);
     wazuh::metrics::Manager metricsManager;
     EnrollmentMetrics metrics = makeEnrollmentMetrics(metricsManager);
-    auto handler = makeHandler(authenticator, authdClient, baseConfig(), metrics);
+    auto handler = makeHandler(authenticator, authdClient, baseConfig(), metrics, passthroughDecoder());
 
     HttpRequest request;
     request.method = Method::Post;
@@ -228,7 +248,7 @@ TEST(EnrollmentE2ETest, AuthdDownMapsTo503)
         makeUniqueSocketPath("enrollment_e2e_authd_down"), /*isWorkerNode=*/false, 0, config.authdResponseTimeoutMs, 0);
     wazuh::metrics::Manager metricsManager;
     EnrollmentMetrics metrics = makeEnrollmentMetrics(metricsManager);
-    auto handler = makeHandler(authenticator, authdClient, config, metrics);
+    auto handler = makeHandler(authenticator, authdClient, config, metrics, passthroughDecoder());
 
     HttpRequest request;
     request.method = Method::Post;
@@ -269,7 +289,7 @@ TEST(EnrollmentE2ETest, ReplayedSignedRequestWithinWindowIsNotStoppedByRemotedIt
     AuthdClient authdClient(authdPath, /*isWorkerNode=*/false, 0, baseConfig().authdResponseTimeoutMs, 0);
     wazuh::metrics::Manager metricsManager;
     EnrollmentMetrics metrics = makeEnrollmentMetrics(metricsManager);
-    auto handler = makeHandler(authenticator, authdClient, baseConfig(), metrics);
+    auto handler = makeHandler(authenticator, authdClient, baseConfig(), metrics, passthroughDecoder());
 
     const auto key = keySource->currentKey();
     ASSERT_TRUE(key.has_value());

--- a/src/remoted/remoted_module/test/unit/enrollmentE2E_test.cpp
+++ b/src/remoted/remoted_module/test/unit/enrollmentE2E_test.cpp
@@ -1,0 +1,293 @@
+/*
+ * Wazuh remoted module - POST /enroll end-to-end tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 19, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ *
+ * Drives the FULL /enroll pipeline (EnrollmentAuthenticator + the endpoint's own validation/IP
+ * resolution + a real AuthdClient talking to a FakeUdsServer standing in for authd) for the
+ * scenarios the design's test plan calls out explicitly: a correctly signed Password-mode
+ * request, Open mode, authd down, and a replayed signed request inside the freshness window
+ * (D12: an accepted limitation, not something this code defends against -- authd's own
+ * duplicate-name/IP rejection is what actually stops a meaningful replay from doing anything).
+ * mTLS has nothing left to test here: EnrollmentAuthenticator has no notion of a client
+ * certificate at all -- with requirePassword=false it always passes unconditionally (unit-tested
+ * in enrollmentAuthenticator_test.cpp), so the interesting behavior for mTLS is the TLS listener's
+ * own certificate verification -- transport-layer, not this code's (see enrollmentMtlsE2E_test.cpp).
+ */
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <ctime>
+#include <fstream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+#include "auth/cmac.hpp"
+#include "enrollment/enrollmentEndpoint.hpp"
+#include "fakeUdsServer.hpp"
+#include "json.hpp"
+
+#include <wazuh_metrics/manager.hpp>
+
+using namespace remoted::enrollment;
+using remoted::auth::Cmac;
+using remoted::auth::PasswordKeySource;
+using remoted::auth::toLowerHex;
+using remoted::http::HttpRequest;
+using remoted::http::HttpResponse;
+using remoted::http::IHttpResponder;
+using remoted::http::Method;
+using remoted::test::FakeUdsServer;
+using remoted::test::makeUniqueSocketPath;
+using namespace std::chrono_literals;
+
+namespace
+{
+    const std::string kBody = R"({"name":"agent1","version":"5.0.0"})";
+
+    // These tests drive the REAL endpoint handler, which checks the signed timestamp against the
+    // actual wall clock (std::time(nullptr) in enrollmentEndpoint.cpp) -- unlike
+    // enrollmentAuthenticator_test.cpp's unit tests, which pass a fixed "now" straight into
+    // authenticate() and so can use a fixed constant safely. A hardcoded timestamp here would
+    // start failing the moment real time drifted more than 300s past it.
+    std::int64_t nowTs()
+    {
+        return static_cast<std::int64_t>(std::time(nullptr));
+    }
+
+    class CapturingResponder : public IHttpResponder
+    {
+    public:
+        void send(HttpResponse response) override
+        {
+            std::lock_guard<std::mutex> lock(m_mu);
+            if (m_done)
+            {
+                return;
+            }
+            m_response = std::move(response);
+            m_done = true;
+            m_cv.notify_all();
+        }
+
+        HttpResponse wait(std::chrono::milliseconds timeout = 2s)
+        {
+            std::unique_lock<std::mutex> lock(m_mu);
+            EXPECT_TRUE(m_cv.wait_for(lock, timeout, [&] { return m_done; })) << "responder never called";
+            return m_response;
+        }
+
+    private:
+        std::mutex m_mu;
+        std::condition_variable m_cv;
+        bool m_done {false};
+        HttpResponse m_response;
+    };
+
+    std::string writePasswordFile(const std::string& password)
+    {
+        const std::string path = "/tmp/enrollmentE2E_test_" + std::to_string(::getpid()) + ".pass";
+        std::ofstream file(path);
+        file << password << "\n";
+        return path;
+    }
+
+    std::string signWazuhEnroll(const std::vector<std::uint8_t>& key,
+                                std::string_view target,
+                                std::string_view body,
+                                std::int64_t ts)
+    {
+        Cmac cmac(key);
+        cmac.update("WAZUH-ENROLL\n");
+        cmac.update("1\n");
+        cmac.update("POST\n");
+        cmac.update(target);
+        cmac.update("\n");
+        cmac.update(std::to_string(ts));
+        cmac.update("\n");
+        cmac.update(body);
+        const auto mac = cmac.finalize();
+        return "WazuhEnroll " + std::to_string(ts) + ":" + toLowerHex(mac.data(), mac.size());
+    }
+
+    Config baseConfig()
+    {
+        Config cfg;
+        cfg.enrollmentEnabled = true;
+        cfg.managerVersion = "5.0.0";
+        cfg.authdResponseTimeoutMs = 500;
+        return cfg;
+    }
+
+    HttpResponse dispatch(const remoted::http::RouteHandler& handler, const HttpRequest& request)
+    {
+        auto responder = std::make_shared<CapturingResponder>();
+        handler(std::make_shared<const HttpRequest>(request), responder);
+        return responder->wait();
+    }
+} // namespace
+
+TEST(EnrollmentE2ETest, PasswordModeCorrectlySignedRequestEnrollsSuccessfully)
+{
+    const std::string passwordPath = writePasswordFile("MyEnrollmentSecret123");
+    auto keySource = std::make_shared<PasswordKeySource>(passwordPath);
+    EnrollmentAuthenticator authenticator {EnrollmentAuthConfig {true}, keySource};
+
+    const std::string authdPath = makeUniqueSocketPath("enrollment_e2e_password");
+    FakeUdsServer authd(authdPath,
+                        [](const std::string&)
+                        { return R"({"error":0,"data":{"id":"003","name":"agent1","ip":"any","key":"deadbeef"}})"; });
+
+    AuthdClient authdClient(authdPath, /*isWorkerNode=*/false, 0, baseConfig().authdResponseTimeoutMs, 0);
+    wazuh::metrics::Manager metricsManager;
+    EnrollmentMetrics metrics = makeEnrollmentMetrics(metricsManager);
+    auto handler = makeHandler(authenticator, authdClient, baseConfig(), metrics);
+
+    const auto key = keySource->currentKey();
+    ASSERT_TRUE(key.has_value());
+
+    HttpRequest request;
+    request.method = Method::Post;
+    request.target = "/enroll";
+    request.body = kBody;
+    request.headers.emplace("authorization", signWazuhEnroll(*key, "/enroll", kBody, nowTs()));
+
+    const auto response = dispatch(handler, request);
+    EXPECT_EQ(response.status, 200);
+    EXPECT_EQ(nlohmann::json::parse(response.body)["id"], "003");
+
+    std::remove(passwordPath.c_str());
+}
+
+TEST(EnrollmentE2ETest, PasswordModeWrongSignatureIsRejected)
+{
+    const std::string passwordPath = writePasswordFile("MyEnrollmentSecret123");
+    auto keySource = std::make_shared<PasswordKeySource>(passwordPath);
+    EnrollmentAuthenticator authenticator {EnrollmentAuthConfig {true}, keySource};
+
+    // authd must never be reached -- rejection happens at the auth layer.
+    AuthdClient authdClient(makeUniqueSocketPath("enrollment_e2e_password_reject"));
+    wazuh::metrics::Manager metricsManager;
+    EnrollmentMetrics metrics = makeEnrollmentMetrics(metricsManager);
+    auto handler = makeHandler(authenticator, authdClient, baseConfig(), metrics);
+
+    HttpRequest request;
+    request.method = Method::Post;
+    request.target = "/enroll";
+    request.body = kBody;
+    request.headers.emplace("authorization", "WazuhEnroll " + std::to_string(nowTs()) + ":" + std::string(32, 'a'));
+
+    const auto response = dispatch(handler, request);
+    EXPECT_EQ(response.status, 401);
+
+    std::remove(passwordPath.c_str());
+}
+
+TEST(EnrollmentE2ETest, OpenModeUnauthenticatedRequestEnrollsSuccessfully)
+{
+    EnrollmentAuthenticator authenticator {EnrollmentAuthConfig {false}, nullptr};
+
+    const std::string authdPath = makeUniqueSocketPath("enrollment_e2e_open");
+    FakeUdsServer authd(authdPath,
+                        [](const std::string&)
+                        { return R"({"error":0,"data":{"id":"004","name":"agent2","ip":"any","key":"cafef00d"}})"; });
+
+    AuthdClient authdClient(authdPath, /*isWorkerNode=*/false, 0, baseConfig().authdResponseTimeoutMs, 0);
+    wazuh::metrics::Manager metricsManager;
+    EnrollmentMetrics metrics = makeEnrollmentMetrics(metricsManager);
+    auto handler = makeHandler(authenticator, authdClient, baseConfig(), metrics);
+
+    HttpRequest request;
+    request.method = Method::Post;
+    request.target = "/enroll";
+    request.body = kBody;
+    // No Authorization header at all -- Open mode requires none.
+
+    const auto response = dispatch(handler, request);
+    EXPECT_EQ(response.status, 200);
+}
+
+TEST(EnrollmentE2ETest, AuthdDownMapsTo503)
+{
+    EnrollmentAuthenticator authenticator {EnrollmentAuthConfig {false}, nullptr};
+
+    Config config = baseConfig();
+    config.authdResponseTimeoutMs = 300; // short: no FakeUdsServer is ever bound below
+
+    AuthdClient authdClient(
+        makeUniqueSocketPath("enrollment_e2e_authd_down"), /*isWorkerNode=*/false, 0, config.authdResponseTimeoutMs, 0);
+    wazuh::metrics::Manager metricsManager;
+    EnrollmentMetrics metrics = makeEnrollmentMetrics(metricsManager);
+    auto handler = makeHandler(authenticator, authdClient, config, metrics);
+
+    HttpRequest request;
+    request.method = Method::Post;
+    request.target = "/enroll";
+    request.body = kBody;
+
+    const auto response = dispatch(handler, request);
+    EXPECT_EQ(response.status, 503);
+}
+
+TEST(EnrollmentE2ETest, ReplayedSignedRequestWithinWindowIsNotStoppedByRemotedItself)
+{
+    // D12 (accepted limitation): the WazuhEnroll scheme has no nonce, so an identical, still-valid
+    // signed request replayed inside the freshness window passes OUR authentication a second time
+    // too -- exactly like the first. Whatever stops a meaningful replay is authd's own business
+    // rule (typically duplicate-name/IP rejection), which this test's fake authd emulates by
+    // answering the second identical call with 9008 (Duplicate name), not by remoted itself.
+    const std::string passwordPath = writePasswordFile("MyEnrollmentSecret123");
+    auto keySource = std::make_shared<PasswordKeySource>(passwordPath);
+    EnrollmentAuthenticator authenticator {EnrollmentAuthConfig {true}, keySource};
+
+    const std::string authdPath = makeUniqueSocketPath("enrollment_e2e_replay");
+    int callCount = 0;
+    std::mutex mu;
+    FakeUdsServer authd(authdPath,
+                        [&](const std::string&)
+                        {
+                            std::lock_guard<std::mutex> lock(mu);
+                            ++callCount;
+                            if (callCount == 1)
+                            {
+                                return std::string(
+                                    R"({"error":0,"data":{"id":"003","name":"agent1","ip":"any","key":"deadbeef"}})");
+                            }
+                            return std::string(R"({"error":9008,"message":"ERROR: Duplicate name"})");
+                        });
+
+    AuthdClient authdClient(authdPath, /*isWorkerNode=*/false, 0, baseConfig().authdResponseTimeoutMs, 0);
+    wazuh::metrics::Manager metricsManager;
+    EnrollmentMetrics metrics = makeEnrollmentMetrics(metricsManager);
+    auto handler = makeHandler(authenticator, authdClient, baseConfig(), metrics);
+
+    const auto key = keySource->currentKey();
+    ASSERT_TRUE(key.has_value());
+
+    HttpRequest request;
+    request.method = Method::Post;
+    request.target = "/enroll";
+    request.body = kBody;
+    request.headers.emplace("authorization", signWazuhEnroll(*key, "/enroll", kBody, nowTs()));
+
+    const auto first = dispatch(handler, request);
+    EXPECT_EQ(first.status, 200);
+
+    // Identical request, byte-for-byte, dispatched again -- our own auth accepts it again (no
+    // nonce cache); authd's business rule is what actually rejects the replay.
+    const auto second = dispatch(handler, request);
+    EXPECT_EQ(second.status, 409);
+    EXPECT_EQ(nlohmann::json::parse(second.body)["error"]["code"], 9008);
+
+    std::remove(passwordPath.c_str());
+}

--- a/src/remoted/remoted_module/test/unit/enrollmentEndpoint_test.cpp
+++ b/src/remoted/remoted_module/test/unit/enrollmentEndpoint_test.cpp
@@ -237,6 +237,40 @@ TEST(EnrollmentEndpointTest, MissingNameIsRejectedWith400)
     EXPECT_NE(parseBody(response)["error"]["message"].get<std::string>().find("name"), std::string::npos);
 }
 
+// Mirrors OS_IsValidName() (shared/src/agent_validate_op.c): a name outside this charset must
+// never reach authd, since a space would split into extra client.keys fields on write (name/IP/key
+// all shift) and a leading '#'/'!' would collide with the removed-entry marker convention -- both
+// silently corrupt the agent record rather than producing a visible error.
+class EnrollmentEndpointNameValidationTest : public ::testing::TestWithParam<std::string>
+{
+};
+
+TEST_P(EnrollmentEndpointNameValidationTest, InvalidNameIsRejectedWith400)
+{
+    nlohmann::json body;
+    body["name"] = GetParam();
+    body["version"] = "5.0.0";
+    const auto response = run(openModeConfig(), body.dump(), makeUniqueSocketPath("enrollment_endpoint_invalid_name"));
+    EXPECT_EQ(response.status, 400);
+}
+
+INSTANTIATE_TEST_SUITE_P(InvalidNames,
+                         EnrollmentEndpointNameValidationTest,
+                         ::testing::Values("web 01",                // space -- would split client.keys fields
+                                           "#web01",                // leading '#' -- removed-entry marker
+                                           "!web01",                // leading '!' -- removed-entry marker
+                                           ".web01",                // leading '.' -- OS_IsValidName() rejects
+                                           "a",                     // length 1 -- below OS_IsValidName()'s minimum
+                                           "",                      // empty
+                                           std::string(129, 'a'))); // over the 128-char cap
+
+TEST(EnrollmentEndpointTest, NameWithAllowedPunctuationIsAccepted)
+{
+    auto stub = fixedAuthdServer(R"({"error":0,"data":{"id":"1","name":"web-01.prod_a","ip":"any","key":"k"}})");
+    const auto response = run(openModeConfig(), R"({"name":"web-01.prod_a","version":"5.0.0"})", stub.path);
+    EXPECT_EQ(response.status, 200);
+}
+
 TEST(EnrollmentEndpointTest, MissingVersionIsRejectedWith400)
 {
     const auto response = run(openModeConfig(), R"({"name":"agent1"})", makeUniqueSocketPath("enrollment_endpoint_v4"));
@@ -461,6 +495,33 @@ TEST(EnrollmentEndpointTest, AnyUsedWhenNeitherSourceIpNorBodyIpPresent)
     EXPECT_EQ(j["arguments"]["ip"], "any");
 }
 
+TEST(EnrollmentEndpointTest, SrcSentinelResolvesToThePeerAddressNotForwardedLiterally)
+{
+    // "src" mirrors legacy port 1515's own wire sentinel (os_auth/src/auth.c's `IP:'src'`, sent by
+    // an agent configured with its own client-side <use_source_ip>) -- it must resolve to the
+    // HTTPS connection's actual peer address, never reach authd as the literal string "src" (which
+    // local_add() has no notion of and would reject as an invalid IP).
+    std::string captured;
+    std::mutex mu;
+    const std::string path = makeUniqueSocketPath("enrollment_endpoint_ip_src");
+    FakeUdsServer server(path,
+                         [&](const std::string& req)
+                         {
+                             std::lock_guard<std::mutex> lock(mu);
+                             captured = req;
+                             return R"({"error":0,"data":{"id":"1","name":"n","ip":"i","key":"k"}})";
+                         });
+
+    Config config = openModeConfig();
+    config.useSourceIp = false; // manager-side flag off: the body's "src" is what must be honored
+    const auto response = run(config, R"({"name":"agent1","version":"5.0.0","ip":"src"})", path, "203.0.113.7");
+    EXPECT_EQ(response.status, 200);
+
+    std::lock_guard<std::mutex> lock(mu);
+    const auto j = nlohmann::json::parse(captured);
+    EXPECT_EQ(j["arguments"]["ip"], "203.0.113.7");
+}
+
 // -----------------------------------------------------------------------------
 // Wire shape: force/id/key never sent (mirrors AuthdClient's own coverage of this, exercised here
 // end-to-end through the endpoint instead of a hand-built AuthdAddRequest).
@@ -542,6 +603,7 @@ INSTANTIATE_TEST_SUITE_P(AuthdCodes,
                                            AuthdErrorCase {9005, 400},
                                            AuthdErrorCase {9006, 400},
                                            AuthdErrorCase {9014, 400},
+                                           AuthdErrorCase {9017, 400}, // invalid agent name (new)
                                            AuthdErrorCase {9007, 409},
                                            AuthdErrorCase {9008, 409},
                                            AuthdErrorCase {9012, 409},

--- a/src/remoted/remoted_module/test/unit/enrollmentEndpoint_test.cpp
+++ b/src/remoted/remoted_module/test/unit/enrollmentEndpoint_test.cpp
@@ -1,0 +1,402 @@
+/*
+ * Wazuh remoted module - POST /enroll endpoint unit tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 19, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ *
+ * Exercises the JSON/validation/IP-resolution/authd-error-mapping layer of `POST /enroll`, with a
+ * real AuthdClient wired to FakeUdsServer instances standing in for authd. The auth-rejection
+ * matrix itself (mode pass/deny, CMAC tamper scenarios) is covered by enrollmentAuthenticator_test.cpp;
+ * these tests all use Open mode so the handler's OWN logic is what's under test.
+ */
+
+#include <chrono>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "enrollment/enrollmentEndpoint.hpp"
+#include "fakeUdsServer.hpp"
+#include "json.hpp"
+
+#include <wazuh_metrics/manager.hpp>
+
+using namespace remoted::enrollment;
+using remoted::http::HttpRequest;
+using remoted::http::HttpResponse;
+using remoted::http::IHttpResponder;
+using remoted::http::Method;
+using remoted::test::FakeUdsServer;
+using remoted::test::makeUniqueSocketPath;
+using namespace std::chrono_literals;
+
+namespace
+{
+    class CapturingResponder : public IHttpResponder
+    {
+    public:
+        void send(HttpResponse response) override
+        {
+            std::lock_guard<std::mutex> lock(m_mu);
+            if (m_done)
+            {
+                return;
+            }
+            m_response = std::move(response);
+            m_done = true;
+            m_cv.notify_all();
+        }
+
+        HttpResponse wait(std::chrono::milliseconds timeout = 2s)
+        {
+            std::unique_lock<std::mutex> lock(m_mu);
+            EXPECT_TRUE(m_cv.wait_for(lock, timeout, [&] { return m_done; })) << "responder never called";
+            return m_response;
+        }
+
+    private:
+        std::mutex m_mu;
+        std::condition_variable m_cv;
+        bool m_done {false};
+        HttpResponse m_response;
+    };
+
+    HttpRequest makeRequest(const std::string& body, const std::string& remoteIp = "")
+    {
+        HttpRequest req;
+        req.method = Method::Post;
+        req.target = "/enroll";
+        req.body = body;
+        req.remoteIp = remoteIp;
+        return req;
+    }
+
+    Config openModeConfig()
+    {
+        Config cfg;
+        cfg.enrollmentEnabled = true;
+        cfg.usePassword = false;
+        cfg.useSourceIp = false;
+        cfg.allowHigherVersions = false;
+        cfg.managerVersion = "5.0.0";
+        cfg.authdResponseTimeoutMs = 500; // short: tests exercising "authd absent" resolve via this timeout
+        return cfg;
+    }
+
+    const std::string kValidBody = R"({"name":"agent1","version":"5.0.0"})";
+
+    // Runs one dispatch through a freshly built handler (fresh authenticator/AuthdClient every
+    // call -- AuthdClient's worker thread must not be shared across tests). authdPath need not
+    // have a FakeUdsServer bound at all -- that's how the "authd unreachable" tests are expressed.
+    HttpResponse
+    run(const Config& config, const std::string& body, const std::string& authdPath, const std::string& remoteIp = "")
+    {
+        EnrollmentAuthenticator authenticator {EnrollmentAuthConfig {false}, nullptr};
+        wazuh::metrics::Manager metricsManager;
+        EnrollmentMetrics metrics = makeEnrollmentMetrics(metricsManager);
+
+        AuthdClient authdClient(authdPath,
+                                /*isWorkerNode=*/false,
+                                /*connectTimeoutMs=*/0,
+                                config.authdResponseTimeoutMs,
+                                /*maxQueueSize=*/0);
+
+        auto handler = makeHandler(authenticator, authdClient, config, metrics);
+
+        auto request = std::make_shared<const HttpRequest>(makeRequest(body, remoteIp));
+        auto responder = std::make_shared<CapturingResponder>();
+        handler(request, responder);
+        return responder->wait();
+    }
+
+    nlohmann::json parseBody(const HttpResponse& response)
+    {
+        return nlohmann::json::parse(response.body, nullptr, false);
+    }
+
+    // An authd stand-in that echoes a fixed response regardless of the request, plus the path it
+    // was bound to (FakeUdsServer itself exposes no accessor for its own path).
+    struct AuthdStub
+    {
+        std::string path;
+        std::unique_ptr<FakeUdsServer> server;
+    };
+
+    AuthdStub fixedAuthdServer(const std::string& response)
+    {
+        AuthdStub stub;
+        stub.path = makeUniqueSocketPath("enrollment_endpoint");
+        stub.server = std::make_unique<FakeUdsServer>(stub.path, [response](const std::string&) { return response; });
+        return stub;
+    }
+} // namespace
+
+// -----------------------------------------------------------------------------
+// Administrative disable -- checked before authentication or the authd bridge.
+// -----------------------------------------------------------------------------
+
+TEST(EnrollmentEndpointTest, DisabledEnrollmentReturns403WithoutTouchingAuthOrAuthd)
+{
+    Config config = openModeConfig();
+    config.enrollmentEnabled = false;
+
+    // Password mode with a null key source would reject with 401 if authentication ever ran --
+    // getting 403 instead proves the disabled check short-circuits before that.
+    EnrollmentAuthenticator authenticator {EnrollmentAuthConfig {true}, nullptr};
+    wazuh::metrics::Manager metricsManager;
+    EnrollmentMetrics metrics = makeEnrollmentMetrics(metricsManager);
+    AuthdClient authdClient(makeUniqueSocketPath("enrollment_endpoint_disabled"));
+
+    auto handler = makeHandler(authenticator, authdClient, config, metrics);
+    auto request = std::make_shared<const HttpRequest>(makeRequest(kValidBody));
+    auto responder = std::make_shared<CapturingResponder>();
+    handler(request, responder);
+    const auto response = responder->wait();
+
+    EXPECT_EQ(response.status, 403);
+    EXPECT_EQ(parseBody(response)["error"]["message"], "Enrollment is disabled on this manager");
+}
+
+// -----------------------------------------------------------------------------
+// Local validation -- never reaches authd.
+// -----------------------------------------------------------------------------
+
+TEST(EnrollmentEndpointTest, EmptyBodyIsRejectedWith400)
+{
+    const auto response = run(openModeConfig(), "", makeUniqueSocketPath("enrollment_endpoint_v1"));
+    EXPECT_EQ(response.status, 400);
+}
+
+TEST(EnrollmentEndpointTest, MalformedJsonIsRejectedWith400)
+{
+    const auto response = run(openModeConfig(), "not json{{{", makeUniqueSocketPath("enrollment_endpoint_v2"));
+    EXPECT_EQ(response.status, 400);
+}
+
+TEST(EnrollmentEndpointTest, MissingNameIsRejectedWith400)
+{
+    const auto response =
+        run(openModeConfig(), R"({"version":"5.0.0"})", makeUniqueSocketPath("enrollment_endpoint_v3"));
+    EXPECT_EQ(response.status, 400);
+    EXPECT_NE(parseBody(response)["error"]["message"].get<std::string>().find("name"), std::string::npos);
+}
+
+TEST(EnrollmentEndpointTest, MissingVersionIsRejectedWith400)
+{
+    const auto response = run(openModeConfig(), R"({"name":"agent1"})", makeUniqueSocketPath("enrollment_endpoint_v4"));
+    EXPECT_EQ(response.status, 400);
+}
+
+TEST(EnrollmentEndpointTest, InvalidIpIsRejectedWith400)
+{
+    const auto response = run(openModeConfig(),
+                              R"({"name":"agent1","version":"5.0.0","ip":"not-an-ip"})",
+                              makeUniqueSocketPath("enrollment_endpoint_v5"));
+    EXPECT_EQ(response.status, 400);
+}
+
+TEST(EnrollmentEndpointTest, ValidCidrIpIsAccepted)
+{
+    auto stub = fixedAuthdServer(R"({"error":0,"data":{"id":"1","name":"agent1","ip":"i","key":"k"}})");
+    const auto response = run(openModeConfig(), R"({"name":"agent1","version":"5.0.0","ip":"10.0.0.0/24"})", stub.path);
+    EXPECT_EQ(response.status, 200);
+}
+
+TEST(EnrollmentEndpointTest, VersionTooNewIsRejectedWhenNotAllowed)
+{
+    Config config = openModeConfig();
+    config.managerVersion = "4.9.0";
+    config.allowHigherVersions = false;
+
+    const auto response =
+        run(config, R"({"name":"agent1","version":"5.0.0"})", makeUniqueSocketPath("enrollment_endpoint_v6"));
+    EXPECT_EQ(response.status, 400);
+}
+
+TEST(EnrollmentEndpointTest, VersionTooNewIsAcceptedWhenAllowed)
+{
+    Config config = openModeConfig();
+    config.managerVersion = "4.9.0";
+    config.allowHigherVersions = true;
+
+    auto stub = fixedAuthdServer(R"({"error":0,"data":{"id":"1","name":"agent1","ip":"any","key":"k"}})");
+    const auto response = run(config, R"({"name":"agent1","version":"5.0.0"})", stub.path);
+    EXPECT_EQ(response.status, 200);
+}
+
+// -----------------------------------------------------------------------------
+// IP resolution matrix
+// -----------------------------------------------------------------------------
+
+TEST(EnrollmentEndpointTest, UseSourceIpOverridesBodyIp)
+{
+    std::string captured;
+    std::mutex mu;
+    const std::string path = makeUniqueSocketPath("enrollment_endpoint_ip1");
+    FakeUdsServer server(path,
+                         [&](const std::string& req)
+                         {
+                             std::lock_guard<std::mutex> lock(mu);
+                             captured = req;
+                             return R"({"error":0,"data":{"id":"1","name":"n","ip":"i","key":"k"}})";
+                         });
+
+    Config config = openModeConfig();
+    config.useSourceIp = true;
+    run(config, R"({"name":"agent1","version":"5.0.0","ip":"10.0.0.1"})", path, "203.0.113.7");
+
+    std::lock_guard<std::mutex> lock(mu);
+    const auto j = nlohmann::json::parse(captured);
+    EXPECT_EQ(j["arguments"]["ip"], "203.0.113.7");
+}
+
+TEST(EnrollmentEndpointTest, BodyIpUsedWhenSourceIpDisabledAndPresent)
+{
+    std::string captured;
+    std::mutex mu;
+    const std::string path = makeUniqueSocketPath("enrollment_endpoint_ip2");
+    FakeUdsServer server(path,
+                         [&](const std::string& req)
+                         {
+                             std::lock_guard<std::mutex> lock(mu);
+                             captured = req;
+                             return R"({"error":0,"data":{"id":"1","name":"n","ip":"i","key":"k"}})";
+                         });
+
+    Config config = openModeConfig();
+    config.useSourceIp = false;
+    run(config, R"({"name":"agent1","version":"5.0.0","ip":"10.0.0.1"})", path, "203.0.113.7");
+
+    std::lock_guard<std::mutex> lock(mu);
+    const auto j = nlohmann::json::parse(captured);
+    EXPECT_EQ(j["arguments"]["ip"], "10.0.0.1");
+}
+
+TEST(EnrollmentEndpointTest, AnyUsedWhenNeitherSourceIpNorBodyIpPresent)
+{
+    std::string captured;
+    std::mutex mu;
+    const std::string path = makeUniqueSocketPath("enrollment_endpoint_ip3");
+    FakeUdsServer server(path,
+                         [&](const std::string& req)
+                         {
+                             std::lock_guard<std::mutex> lock(mu);
+                             captured = req;
+                             return R"({"error":0,"data":{"id":"1","name":"n","ip":"i","key":"k"}})";
+                         });
+
+    Config config = openModeConfig();
+    config.useSourceIp = false;
+    run(config, kValidBody, path, "203.0.113.7");
+
+    std::lock_guard<std::mutex> lock(mu);
+    const auto j = nlohmann::json::parse(captured);
+    EXPECT_EQ(j["arguments"]["ip"], "any");
+}
+
+// -----------------------------------------------------------------------------
+// Wire shape: force/id/key never sent (mirrors AuthdClient's own coverage of this, exercised here
+// end-to-end through the endpoint instead of a hand-built AuthdAddRequest).
+// -----------------------------------------------------------------------------
+
+TEST(EnrollmentEndpointTest, RequestNeverIncludesForceIdOrKey)
+{
+    std::string captured;
+    std::mutex mu;
+    const std::string path = makeUniqueSocketPath("enrollment_endpoint_wireshape");
+    FakeUdsServer server(path,
+                         [&](const std::string& req)
+                         {
+                             std::lock_guard<std::mutex> lock(mu);
+                             captured = req;
+                             return R"({"error":0,"data":{"id":"1","name":"n","ip":"i","key":"k"}})";
+                         });
+
+    run(openModeConfig(), kValidBody, path);
+
+    std::lock_guard<std::mutex> lock(mu);
+    const auto j = nlohmann::json::parse(captured);
+    EXPECT_EQ(j["function"], "add");
+    EXPECT_FALSE(j["arguments"].contains("force"));
+    EXPECT_FALSE(j["arguments"].contains("id"));
+    EXPECT_FALSE(j["arguments"].contains("key"));
+}
+
+// -----------------------------------------------------------------------------
+// Success + authd error-code -> HTTP status mapping
+// -----------------------------------------------------------------------------
+
+TEST(EnrollmentEndpointTest, SuccessReturns200WithAgentData)
+{
+    auto stub = fixedAuthdServer(
+        R"({"error":0,"data":{"id":"003","name":"agent1","ip":"any","key":"675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915"}})");
+    const auto response = run(openModeConfig(), kValidBody, stub.path);
+
+    EXPECT_EQ(response.status, 200);
+    const auto j = parseBody(response);
+    EXPECT_EQ(j["id"], "003");
+    EXPECT_EQ(j["name"], "agent1");
+    EXPECT_EQ(j["key"], "675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915");
+}
+
+struct AuthdErrorCase
+{
+    int authdCode;
+    int expectedStatus;
+};
+
+class EnrollmentEndpointAuthdErrorTest : public ::testing::TestWithParam<AuthdErrorCase>
+{
+};
+
+TEST_P(EnrollmentEndpointAuthdErrorTest, MapsToExpectedHttpStatus)
+{
+    const auto param = GetParam();
+    nlohmann::json body;
+    body["error"] = param.authdCode;
+    body["message"] = "ERROR: some authd message";
+    auto stub = fixedAuthdServer(body.dump());
+
+    const auto response = run(openModeConfig(), kValidBody, stub.path);
+
+    EXPECT_EQ(response.status, param.expectedStatus) << "authd code " << param.authdCode;
+    const auto j = parseBody(response);
+    EXPECT_EQ(j["error"]["code"], param.authdCode);
+    EXPECT_EQ(j["error"]["message"], "some authd message"); // "ERROR: " prefix stripped by AuthdClient
+}
+
+INSTANTIATE_TEST_SUITE_P(AuthdCodes,
+                         EnrollmentEndpointAuthdErrorTest,
+                         ::testing::Values(AuthdErrorCase {9001, 500},
+                                           AuthdErrorCase {9002, 500},
+                                           AuthdErrorCase {9009, 500},
+                                           AuthdErrorCase {9003, 400},
+                                           AuthdErrorCase {9004, 400},
+                                           AuthdErrorCase {9005, 400},
+                                           AuthdErrorCase {9006, 400},
+                                           AuthdErrorCase {9014, 400},
+                                           AuthdErrorCase {9007, 409},
+                                           AuthdErrorCase {9008, 409},
+                                           AuthdErrorCase {9012, 409},
+                                           AuthdErrorCase {9013, 503},
+                                           AuthdErrorCase {9015, 503},
+                                           AuthdErrorCase {9016, 503},
+                                           AuthdErrorCase {9999, 500})); // unknown code -> safe default
+
+TEST(EnrollmentEndpointTest, AuthdUnreachableMapsTo503)
+{
+    // No FakeUdsServer bound at all -- resolves via the (short, test-configured)
+    // authdResponseTimeoutMs, same reasoning as AuthdClientTest.ServerAbsentIsATransportFailure.
+    const auto response = run(openModeConfig(), kValidBody, makeUniqueSocketPath("enrollment_endpoint_absent"));
+
+    EXPECT_EQ(response.status, 503);
+    const auto j = parseBody(response);
+    EXPECT_EQ(j["error"]["code"], -1);
+}

--- a/src/remoted/remoted_module/test/unit/enrollmentEndpoint_test.cpp
+++ b/src/remoted/remoted_module/test/unit/enrollmentEndpoint_test.cpp
@@ -209,6 +209,17 @@ TEST(EnrollmentEndpointTest, ValidCidrIpIsAccepted)
     EXPECT_EQ(response.status, 200);
 }
 
+TEST(EnrollmentEndpointTest, OverlongCidrPrefixIsRejectedWith400NotAnUncaughtException)
+{
+    // All-digit but too many digits to fit in an int -- isValidIpOrCidr()'s std::stoi() call used
+    // to let std::out_of_range escape uncaught for input like this; it must be rejected as an
+    // ordinary invalid request, not crash or bubble up as an unhandled exception.
+    const auto response = run(openModeConfig(),
+                              R"({"name":"agent1","version":"5.0.0","ip":"10.0.0.0/99999999999999999999"})",
+                              makeUniqueSocketPath("enrollment_endpoint_overlong_prefix"));
+    EXPECT_EQ(response.status, 400);
+}
+
 TEST(EnrollmentEndpointTest, VersionTooNewIsRejectedWhenNotAllowed)
 {
     Config config = openModeConfig();

--- a/src/remoted/remoted_module/test/unit/enrollmentEndpoint_test.cpp
+++ b/src/remoted/remoted_module/test/unit/enrollmentEndpoint_test.cpp
@@ -22,6 +22,7 @@
 
 #include <gtest/gtest.h>
 
+#include "decoding/iBodyDecoder.hpp"
 #include "enrollment/enrollmentEndpoint.hpp"
 #include "fakeUdsServer.hpp"
 #include "json.hpp"
@@ -29,6 +30,8 @@
 #include <wazuh_metrics/manager.hpp>
 
 using namespace remoted::enrollment;
+using remoted::decoding::ContentEncoding;
+using remoted::decoding::IBodyDecoder;
 using remoted::http::HttpRequest;
 using remoted::http::HttpResponse;
 using remoted::http::IHttpResponder;
@@ -78,6 +81,13 @@ namespace
         return req;
     }
 
+    HttpRequest makeRequestWithContentEncoding(const std::string& body, const std::string& encoding)
+    {
+        auto req = makeRequest(body);
+        req.headers.emplace("content-encoding", encoding);
+        return req;
+    }
+
     Config openModeConfig()
     {
         Config cfg;
@@ -92,11 +102,49 @@ namespace
 
     const std::string kValidBody = R"({"name":"agent1","version":"5.0.0"})";
 
+    // IBodyDecoder stub backed by a lambda, mirroring authGateway_test.cpp's StubBodyDecoder: each
+    // test states just the decode behavior it cares about. The REAL zstd decoder is exercised in
+    // bodyDecoder_test.cpp -- these tests are only about how the endpoint WIRES the step in (order
+    // relative to auth, and how a decode failure maps to an HTTP status), not about zstd itself.
+    class StubBodyDecoder final : public IBodyDecoder
+    {
+    public:
+        using Fn = std::function<remoted::auth::AuthError(ContentEncoding, remoted::auth::Payload&)>;
+
+        explicit StubBodyDecoder(Fn fn)
+            : m_fn {std::move(fn)}
+        {
+        }
+
+        remoted::auth::AuthError decode(ContentEncoding encoding, remoted::auth::Payload& payload) const override
+        {
+            return m_fn(encoding, payload);
+        }
+
+    private:
+        Fn m_fn;
+    };
+
+    std::shared_ptr<const IBodyDecoder> stubDecoder(StubBodyDecoder::Fn fn)
+    {
+        return std::make_shared<const StubBodyDecoder>(std::move(fn));
+    }
+
+    // Default for tests that aren't about Content-Encoding at all: present (a required dependency)
+    // but inert.
+    std::shared_ptr<const IBodyDecoder> passthroughDecoder()
+    {
+        return stubDecoder([](ContentEncoding, remoted::auth::Payload&) { return remoted::auth::AuthError::None; });
+    }
+
     // Runs one dispatch through a freshly built handler (fresh authenticator/AuthdClient every
     // call -- AuthdClient's worker thread must not be shared across tests). authdPath need not
     // have a FakeUdsServer bound at all -- that's how the "authd unreachable" tests are expressed.
-    HttpResponse
-    run(const Config& config, const std::string& body, const std::string& authdPath, const std::string& remoteIp = "")
+    HttpResponse run(const Config& config,
+                     const std::string& body,
+                     const std::string& authdPath,
+                     const std::string& remoteIp = "",
+                     std::shared_ptr<const IBodyDecoder> bodyDecoder = nullptr)
     {
         EnrollmentAuthenticator authenticator {EnrollmentAuthConfig {false}, nullptr};
         wazuh::metrics::Manager metricsManager;
@@ -108,7 +156,8 @@ namespace
                                 config.authdResponseTimeoutMs,
                                 /*maxQueueSize=*/0);
 
-        auto handler = makeHandler(authenticator, authdClient, config, metrics);
+        auto handler =
+            makeHandler(authenticator, authdClient, config, metrics, bodyDecoder ? bodyDecoder : passthroughDecoder());
 
         auto request = std::make_shared<const HttpRequest>(makeRequest(body, remoteIp));
         auto responder = std::make_shared<CapturingResponder>();
@@ -154,7 +203,7 @@ TEST(EnrollmentEndpointTest, DisabledEnrollmentReturns403WithoutTouchingAuthOrAu
     EnrollmentMetrics metrics = makeEnrollmentMetrics(metricsManager);
     AuthdClient authdClient(makeUniqueSocketPath("enrollment_endpoint_disabled"));
 
-    auto handler = makeHandler(authenticator, authdClient, config, metrics);
+    auto handler = makeHandler(authenticator, authdClient, config, metrics, passthroughDecoder());
     auto request = std::make_shared<const HttpRequest>(makeRequest(kValidBody));
     auto responder = std::make_shared<CapturingResponder>();
     handler(request, responder);
@@ -240,6 +289,106 @@ TEST(EnrollmentEndpointTest, VersionTooNewIsAcceptedWhenAllowed)
     auto stub = fixedAuthdServer(R"({"error":0,"data":{"id":"1","name":"agent1","ip":"any","key":"k"}})");
     const auto response = run(config, R"({"name":"agent1","version":"5.0.0"})", stub.path);
     EXPECT_EQ(response.status, 200);
+}
+
+// -----------------------------------------------------------------------------
+// Content-Encoding wiring -- how the endpoint composes IBodyDecoder, not zstd itself (see
+// bodyDecoder_test.cpp for the real codec). These prove the decoded bytes are what actually
+// reaches JSON parsing/authd, and that a decode failure maps to the same status codes AuthGateway
+// uses for every other endpoint (415/400/413).
+// -----------------------------------------------------------------------------
+
+TEST(EnrollmentEndpointTest, ContentEncodingHeaderIsParsedAndPassedToTheDecoder)
+{
+    ContentEncoding observed = ContentEncoding::None;
+    auto decoder = stubDecoder(
+        [&](ContentEncoding encoding, remoted::auth::Payload&)
+        {
+            observed = encoding;
+            return remoted::auth::AuthError::None;
+        });
+
+    EnrollmentAuthenticator authenticator {EnrollmentAuthConfig {false}, nullptr};
+    wazuh::metrics::Manager metricsManager;
+    EnrollmentMetrics metrics = makeEnrollmentMetrics(metricsManager);
+    AuthdClient authdClient(makeUniqueSocketPath("enrollment_endpoint_content_encoding_header"));
+
+    auto handler = makeHandler(authenticator, authdClient, openModeConfig(), metrics, decoder);
+    auto request = std::make_shared<const HttpRequest>(makeRequestWithContentEncoding(kValidBody, "zstd"));
+    auto responder = std::make_shared<CapturingResponder>();
+    handler(request, responder);
+    responder->wait(); // authd is unreachable here; only the decoder's observed value matters
+
+    EXPECT_EQ(observed, ContentEncoding::Zstd);
+}
+
+TEST(EnrollmentEndpointTest, DecodedBodyIsWhatGetsParsedAndForwardedToAuthd)
+{
+    // The wire body is deliberately NOT valid JSON on its own -- if the endpoint ever parsed
+    // request->body directly instead of the decoder's output, this would fail with 400 and authd
+    // would never be reached.
+    std::string capturedRequest;
+    std::mutex captureMutex;
+    const std::string path = makeUniqueSocketPath("enrollment_endpoint_decode_success");
+    FakeUdsServer server(path,
+                         [&](const std::string& request)
+                         {
+                             std::lock_guard<std::mutex> lock(captureMutex);
+                             capturedRequest = request;
+                             return R"({"error":0,"data":{"id":"1","name":"decoded-agent","ip":"any","key":"k"}})";
+                         });
+
+    auto decoder = stubDecoder(
+        [](ContentEncoding, remoted::auth::Payload& payload)
+        {
+            auto replacement = std::make_shared<const std::string>(R"({"name":"decoded-agent","version":"5.0.0"})");
+            payload = remoted::auth::Payload {std::string_view {*replacement}, replacement};
+            return remoted::auth::AuthError::None;
+        });
+
+    const auto response = run(openModeConfig(), "this is not json", path, "", decoder);
+    EXPECT_EQ(response.status, 200);
+
+    std::string captured;
+    {
+        std::lock_guard<std::mutex> lock(captureMutex);
+        captured = capturedRequest;
+    }
+    const auto json = nlohmann::json::parse(captured);
+    EXPECT_EQ(json.at("arguments").at("name"), "decoded-agent");
+}
+
+TEST(EnrollmentEndpointTest, UnsupportedContentEncodingIsRejectedWith415)
+{
+    auto decoder = stubDecoder([](ContentEncoding, remoted::auth::Payload&)
+                               { return remoted::auth::AuthError::UnsupportedContentEncoding; });
+
+    const auto response = run(openModeConfig(),
+                              kValidBody,
+                              makeUniqueSocketPath("enrollment_endpoint_415"), // never actually reached
+                              "",
+                              decoder);
+    EXPECT_EQ(response.status, 415);
+}
+
+TEST(EnrollmentEndpointTest, MalformedContentEncodingIsRejectedWith400)
+{
+    auto decoder = stubDecoder([](ContentEncoding, remoted::auth::Payload&)
+                               { return remoted::auth::AuthError::MalformedContentEncoding; });
+
+    const auto response =
+        run(openModeConfig(), kValidBody, makeUniqueSocketPath("enrollment_endpoint_decode_400"), "", decoder);
+    EXPECT_EQ(response.status, 400);
+}
+
+TEST(EnrollmentEndpointTest, BodyTooLargeDuringDecodeIsRejectedWith413)
+{
+    auto decoder =
+        stubDecoder([](ContentEncoding, remoted::auth::Payload&) { return remoted::auth::AuthError::BodyTooLarge; });
+
+    const auto response =
+        run(openModeConfig(), kValidBody, makeUniqueSocketPath("enrollment_endpoint_413"), "", decoder);
+    EXPECT_EQ(response.status, 413);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/remoted/remoted_module/test/unit/enrollmentMtlsE2E_test.cpp
+++ b/src/remoted/remoted_module/test/unit/enrollmentMtlsE2E_test.cpp
@@ -36,6 +36,7 @@
 #include <gtest/gtest.h>
 
 #include "auth/cmac.hpp"
+#include "decoding/iBodyDecoder.hpp"
 #include "enrollment/enrollmentEndpoint.hpp"
 #include "fakeUdsServer.hpp"
 #include "http_server/httpServerFactory.hpp"
@@ -46,6 +47,8 @@ using namespace remoted::enrollment;
 using remoted::auth::Cmac;
 using remoted::auth::PasswordKeySource;
 using remoted::auth::toLowerHex;
+using remoted::decoding::ContentEncoding;
+using remoted::decoding::IBodyDecoder;
 using remoted::http::ClientVerificationMode;
 using remoted::http::HttpServerConfig;
 using remoted::http::Method;
@@ -54,6 +57,22 @@ using remoted::test::makeUniqueSocketPath;
 
 namespace
 {
+    // Inert stand-in for the real BodyDecoder (see enrollmentEndpoint_test.cpp's identical stub):
+    // this test is about the TLS listener's own client-certificate gate, not Content-Encoding.
+    class PassthroughBodyDecoder final : public IBodyDecoder
+    {
+    public:
+        remoted::auth::AuthError decode(ContentEncoding, remoted::auth::Payload&) const override
+        {
+            return remoted::auth::AuthError::None;
+        }
+    };
+
+    std::shared_ptr<const IBodyDecoder> passthroughDecoder()
+    {
+        return std::make_shared<const PassthroughBodyDecoder>();
+    }
+
     struct MtlsPki
     {
         std::string dir;
@@ -196,7 +215,8 @@ namespace
                                                                       EnrollmentMetrics& metrics)
     {
         auto server = remoted::http::makeHttpServer();
-        server->addRoute(Method::Post, "/enroll", makeHandler(authenticator, authdClient, config, metrics));
+        server->addRoute(
+            Method::Post, "/enroll", makeHandler(authenticator, authdClient, config, metrics, passthroughDecoder()));
         return server;
     }
 

--- a/src/remoted/remoted_module/test/unit/enrollmentMtlsE2E_test.cpp
+++ b/src/remoted/remoted_module/test/unit/enrollmentMtlsE2E_test.cpp
@@ -1,0 +1,428 @@
+/*
+ * Wazuh remoted module - POST /enroll mTLS end-to-end test
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 19, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ *
+ * Drives a REAL RestinioHttpServer (via makeHttpServer()) with /enroll registered exactly as
+ * RemotedModuleFacade::startHttpServer() wires it. EnrollmentAuthenticator has no notion of a
+ * client certificate at all -- that's enforced entirely by the TLS listener's own verificationMode,
+ * independently of whatever EnrollmentAuthConfig::requirePassword says (see the class comment in
+ * enrollmentAuthenticator.hpp for why these two are deliberately independent, not a mutually
+ * exclusive "mode"). What this test proves is the piece nothing else covers: that a real TLS
+ * listener configured the way the facade configures it actually gates /enroll on a client
+ * certificate before the handler ever runs -- plus, in the last test below, that a listener
+ * configured to require BOTH a client certificate AND a password enforces both simultaneously.
+ */
+
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
+#include <fstream>
+#include <optional>
+#include <string>
+#include <unistd.h>
+
+#include <asio/connect.hpp>
+#include <asio/io_context.hpp>
+#include <asio/ip/tcp.hpp>
+#include <asio/ssl.hpp>
+#include <asio/write.hpp>
+
+#include <gtest/gtest.h>
+
+#include "auth/cmac.hpp"
+#include "enrollment/enrollmentEndpoint.hpp"
+#include "fakeUdsServer.hpp"
+#include "http_server/httpServerFactory.hpp"
+
+#include <wazuh_metrics/manager.hpp>
+
+using namespace remoted::enrollment;
+using remoted::auth::Cmac;
+using remoted::auth::PasswordKeySource;
+using remoted::auth::toLowerHex;
+using remoted::http::ClientVerificationMode;
+using remoted::http::HttpServerConfig;
+using remoted::http::Method;
+using remoted::test::FakeUdsServer;
+using remoted::test::makeUniqueSocketPath;
+
+namespace
+{
+    struct MtlsPki
+    {
+        std::string dir;
+        std::string caCert, caKey;
+        std::string serverCert, serverKey;
+        std::string clientCert, clientKey;
+    };
+
+    bool runQuiet(const std::string& command)
+    {
+        return std::system((command + " >/dev/null 2>&1").c_str()) == 0;
+    }
+
+    // Minimal CA + one server cert + one client cert, all signed by the same throwaway CA. No SAN
+    // extension is needed for either: ClientVerificationMode::Certificate (unlike ::Full) never
+    // checks a SAN against the peer address, and the test client never verifies the server's cert
+    // at all (set_verify_mode(verify_none) below), matching this file's siblings' convention.
+    std::optional<MtlsPki> generateMtlsPki()
+    {
+        char dirTemplate[] = "/tmp/enrollmentMtlsE2EXXXXXX";
+        const char* dir = ::mkdtemp(dirTemplate);
+        if (!dir)
+        {
+            return std::nullopt;
+        }
+
+        MtlsPki pki;
+        pki.dir = dir;
+        pki.caCert = pki.dir + "/ca.crt";
+        pki.caKey = pki.dir + "/ca.key";
+        pki.serverCert = pki.dir + "/server.crt";
+        pki.serverKey = pki.dir + "/server.key";
+        pki.clientCert = pki.dir + "/client.crt";
+        pki.clientKey = pki.dir + "/client.key";
+
+        if (!runQuiet("openssl req -x509 -newkey rsa:2048 -nodes -days 1 -subj /CN=test-ca -keyout " + pki.caKey +
+                      " -out " + pki.caCert))
+        {
+            return std::nullopt;
+        }
+
+        auto issue = [&](const std::string& commonName, const std::string& keyOut, const std::string& certOut) -> bool
+        {
+            const std::string csr = pki.dir + "/" + commonName + ".csr";
+            if (!runQuiet("openssl req -newkey rsa:2048 -nodes -subj /CN=" + commonName + " -keyout " + keyOut +
+                          " -out " + csr))
+            {
+                return false;
+            }
+            const bool ok = runQuiet("openssl x509 -req -in " + csr + " -days 1 -CA " + pki.caCert + " -CAkey " +
+                                     pki.caKey + " -CAcreateserial -out " + certOut);
+            std::remove(csr.c_str());
+            return ok;
+        };
+
+        if (!issue("test-server", pki.serverKey, pki.serverCert) ||
+            !issue("test-client", pki.clientKey, pki.clientCert))
+        {
+            return std::nullopt;
+        }
+
+        return pki;
+    }
+
+    void cleanupMtlsPki(const MtlsPki& pki)
+    {
+        for (const auto& path : {pki.caCert, pki.caKey, pki.serverCert, pki.serverKey, pki.clientCert, pki.clientKey})
+        {
+            std::remove(path.c_str());
+        }
+        std::remove((pki.dir + "/ca.srl").c_str());
+        ::rmdir(pki.dir.c_str());
+    }
+
+    // Sends one POST /enroll, optionally signed with a WazuhEnroll header when requirePassword is
+    // set (authorizationHeader empty otherwise), and reads the response until the server closes.
+    // clientCert/clientKey null means "present no client certificate at all", to exercise the
+    // listener's own rejection.
+    std::string sendEnrollRequest(std::uint16_t port,
+                                  const std::string& body,
+                                  const std::string* clientCert,
+                                  const std::string* clientKey,
+                                  const std::string& authorizationHeader = {})
+    {
+        std::string received;
+        try
+        {
+            asio::io_context ioc;
+            asio::ssl::context sslContext {asio::ssl::context::tls_client};
+            sslContext.set_verify_mode(asio::ssl::verify_none); // this test doesn't care about server identity
+            if (clientCert && clientKey)
+            {
+                sslContext.use_certificate_file(*clientCert, asio::ssl::context::pem);
+                sslContext.use_private_key_file(*clientKey, asio::ssl::context::pem);
+            }
+
+            asio::ssl::stream<asio::ip::tcp::socket> stream {ioc, sslContext};
+            asio::ip::tcp::resolver resolver {ioc};
+            const auto endpoints = resolver.resolve("127.0.0.1", std::to_string(port));
+            asio::connect(stream.next_layer(), endpoints);
+            stream.handshake(asio::ssl::stream_base::client); // throws if the server rejects us
+
+            std::string request = "POST /enroll HTTP/1.1\r\n";
+            request += "Host: 127.0.0.1\r\n";
+            request += "Content-Type: application/json\r\n";
+            if (!authorizationHeader.empty())
+            {
+                request += "Authorization: " + authorizationHeader + "\r\n";
+            }
+            request += "Content-Length: " + std::to_string(body.size()) + "\r\n";
+            request += "Connection: close\r\n\r\n";
+            request += body;
+            asio::write(stream, asio::buffer(request));
+
+            std::vector<char> buffer(64 * 1024);
+            while (true)
+            {
+                asio::error_code ec;
+                const auto n = stream.read_some(asio::buffer(buffer), ec);
+                if (ec)
+                {
+                    break;
+                }
+                received.append(buffer.data(), n);
+            }
+        }
+        catch (const std::exception&)
+        {
+            // Best-effort: an empty result IS the expected outcome for the no-cert test below.
+        }
+        return received;
+    }
+
+    // Builds the /enroll route exactly as RemotedModuleFacade wires it: an AuthdClient bridging
+    // to a real FakeUdsServer standing in for authd, plus whatever authenticator the caller built
+    // (with or without requirePassword, independently of the listener's own cert requirement).
+    std::unique_ptr<remoted::http::IHttpServer> buildMtlsEnrollServer(EnrollmentAuthenticator& authenticator,
+                                                                      AuthdClient& authdClient,
+                                                                      const Config& config,
+                                                                      EnrollmentMetrics& metrics)
+    {
+        auto server = remoted::http::makeHttpServer();
+        server->addRoute(Method::Post, "/enroll", makeHandler(authenticator, authdClient, config, metrics));
+        return server;
+    }
+
+    std::string writePasswordFile(const std::string& password)
+    {
+        const std::string path = "/tmp/enrollmentMtlsE2E_test_" + std::to_string(::getpid()) + ".pass";
+        std::ofstream file(path);
+        file << password << "\n";
+        return path;
+    }
+
+    // Same WazuhEnroll canonicalization EnrollmentAuthenticator verifies -- see
+    // enrollmentAuthenticator_test.cpp's own copy of this helper for the byte-exact construction.
+    std::string signWazuhEnroll(const std::vector<std::uint8_t>& key,
+                                const std::string& target,
+                                const std::string& body,
+                                std::int64_t ts)
+    {
+        Cmac cmac(key);
+        cmac.update("WAZUH-ENROLL\n");
+        cmac.update("1\n");
+        cmac.update("POST\n");
+        cmac.update(target);
+        cmac.update("\n");
+        cmac.update(std::to_string(ts));
+        cmac.update("\n");
+        cmac.update(body);
+        const auto mac = cmac.finalize();
+        return "WazuhEnroll " + std::to_string(ts) + ":" + toLowerHex(mac.data(), mac.size());
+    }
+} // namespace
+
+TEST(EnrollmentMtlsE2ETest, ValidClientCertificateEnrollsSuccessfully)
+{
+    if (!runQuiet("openssl version"))
+    {
+        GTEST_SKIP() << "openssl not available to generate the test PKI";
+    }
+    const auto pki = generateMtlsPki();
+    ASSERT_TRUE(pki.has_value());
+
+    const std::string authdPath = makeUniqueSocketPath("enrollment_mtls_e2e_ok");
+    FakeUdsServer authd(authdPath,
+                        [](const std::string&)
+                        { return R"({"error":0,"data":{"id":"005","name":"agent1","ip":"any","key":"deadbeef"}})"; });
+
+    EnrollmentAuthenticator authenticator {EnrollmentAuthConfig {false}, nullptr};
+    AuthdClient authdClient(authdPath, /*isWorkerNode=*/false, 0, 2000, 0);
+    wazuh::metrics::Manager metricsManager;
+    EnrollmentMetrics metrics = makeEnrollmentMetrics(metricsManager);
+    Config config;
+    config.enrollmentEnabled = true;
+    config.managerVersion = "5.0.0";
+
+    auto server = buildMtlsEnrollServer(authenticator, authdClient, config, metrics);
+
+    HttpServerConfig serverConfig;
+    serverConfig.bindAddress = "127.0.0.1";
+    serverConfig.port = static_cast<std::uint16_t>(40000 + (::getpid() % 5000));
+    serverConfig.certificatePath = pki->serverCert;
+    serverConfig.privateKeyPath = pki->serverKey;
+    serverConfig.caPath = pki->caCert;
+    serverConfig.verificationMode = ClientVerificationMode::Certificate;
+
+    ASSERT_NO_THROW(server->start(serverConfig));
+
+    const std::string body = R"({"name":"agent1","version":"5.0.0"})";
+    const std::string raw = sendEnrollRequest(serverConfig.port, body, &pki->clientCert, &pki->clientKey);
+
+    EXPECT_NE(raw.find("200"), std::string::npos) << "response was: " << raw;
+    EXPECT_NE(raw.find(R"("id":"005")"), std::string::npos) << "response was: " << raw;
+
+    server->stopAccepting();
+    server->stop();
+    cleanupMtlsPki(*pki);
+}
+
+TEST(EnrollmentMtlsE2ETest, MissingClientCertificateIsRejectedByTheListenerBeforeTheHandlerRuns)
+{
+    if (!runQuiet("openssl version"))
+    {
+        GTEST_SKIP() << "openssl not available to generate the test PKI";
+    }
+    const auto pki = generateMtlsPki();
+    ASSERT_TRUE(pki.has_value());
+
+    // authd must never be reached: the TLS handshake itself is expected to fail.
+    const std::string authdPath = makeUniqueSocketPath("enrollment_mtls_e2e_reject");
+
+    EnrollmentAuthenticator authenticator {EnrollmentAuthConfig {false}, nullptr};
+    AuthdClient authdClient(authdPath, /*isWorkerNode=*/false, 0, 2000, 0);
+    wazuh::metrics::Manager metricsManager;
+    EnrollmentMetrics metrics = makeEnrollmentMetrics(metricsManager);
+    Config config;
+    config.enrollmentEnabled = true;
+    config.managerVersion = "5.0.0";
+
+    auto server = buildMtlsEnrollServer(authenticator, authdClient, config, metrics);
+
+    HttpServerConfig serverConfig;
+    serverConfig.bindAddress = "127.0.0.1";
+    serverConfig.port = static_cast<std::uint16_t>(45000 + (::getpid() % 5000));
+    serverConfig.certificatePath = pki->serverCert;
+    serverConfig.privateKeyPath = pki->serverKey;
+    serverConfig.caPath = pki->caCert;
+    serverConfig.verificationMode = ClientVerificationMode::Certificate;
+
+    ASSERT_NO_THROW(server->start(serverConfig));
+
+    const std::string body = R"({"name":"agent1","version":"5.0.0"})";
+    const std::string raw = sendEnrollRequest(serverConfig.port, body, nullptr, nullptr);
+
+    EXPECT_TRUE(raw.empty()) << "expected the handshake to fail with no client certificate, got: " << raw;
+
+    server->stopAccepting();
+    server->stop();
+    cleanupMtlsPki(*pki);
+}
+
+// -----------------------------------------------------------------------------
+// Combined requirement: a listener configured to require BOTH a client certificate AND a
+// password must enforce both -- this is the scenario the mode-vs-independent-flags fix exists
+// for (see this file's header comment and EnrollmentAuthConfig's doc comment).
+// -----------------------------------------------------------------------------
+
+TEST(EnrollmentMtlsE2ETest, ValidCertificateWithCorrectPasswordEnrollsSuccessfully)
+{
+    if (!runQuiet("openssl version"))
+    {
+        GTEST_SKIP() << "openssl not available to generate the test PKI";
+    }
+    const auto pki = generateMtlsPki();
+    ASSERT_TRUE(pki.has_value());
+
+    const std::string passwordPath = writePasswordFile("MyEnrollmentSecret123");
+    auto keySource = std::make_shared<PasswordKeySource>(passwordPath);
+    const auto key = keySource->currentKey();
+    ASSERT_TRUE(key.has_value());
+
+    const std::string authdPath = makeUniqueSocketPath("enrollment_mtls_e2e_both_ok");
+    FakeUdsServer authd(authdPath,
+                        [](const std::string&)
+                        { return R"({"error":0,"data":{"id":"006","name":"agent1","ip":"any","key":"deadbeef"}})"; });
+
+    EnrollmentAuthenticator authenticator {EnrollmentAuthConfig {true}, keySource};
+    AuthdClient authdClient(authdPath, /*isWorkerNode=*/false, 0, 2000, 0);
+    wazuh::metrics::Manager metricsManager;
+    EnrollmentMetrics metrics = makeEnrollmentMetrics(metricsManager);
+    Config config;
+    config.enrollmentEnabled = true;
+    config.managerVersion = "5.0.0";
+
+    auto server = buildMtlsEnrollServer(authenticator, authdClient, config, metrics);
+
+    HttpServerConfig serverConfig;
+    serverConfig.bindAddress = "127.0.0.1";
+    serverConfig.port = static_cast<std::uint16_t>(50000 + (::getpid() % 5000));
+    serverConfig.certificatePath = pki->serverCert;
+    serverConfig.privateKeyPath = pki->serverKey;
+    serverConfig.caPath = pki->caCert;
+    serverConfig.verificationMode = ClientVerificationMode::Certificate;
+
+    ASSERT_NO_THROW(server->start(serverConfig));
+
+    const std::string body = R"({"name":"agent1","version":"5.0.0"})";
+    // Must be the real wall clock: the request goes through the actual handler, which checks the
+    // timestamp against std::time(nullptr), not a fixed value (see enrollmentE2E_test.cpp's nowTs()
+    // comment for why a hardcoded constant here would start failing as soon as real time moved on).
+    const std::int64_t ts = static_cast<std::int64_t>(std::time(nullptr));
+    const std::string raw = sendEnrollRequest(
+        serverConfig.port, body, &pki->clientCert, &pki->clientKey, signWazuhEnroll(*key, "/enroll", body, ts));
+
+    EXPECT_NE(raw.find("200"), std::string::npos) << "response was: " << raw;
+    EXPECT_NE(raw.find(R"("id":"006")"), std::string::npos) << "response was: " << raw;
+
+    server->stopAccepting();
+    server->stop();
+    cleanupMtlsPki(*pki);
+    std::remove(passwordPath.c_str());
+}
+
+TEST(EnrollmentMtlsE2ETest, ValidCertificateButWrongPasswordSignatureIsRejected)
+{
+    if (!runQuiet("openssl version"))
+    {
+        GTEST_SKIP() << "openssl not available to generate the test PKI";
+    }
+    const auto pki = generateMtlsPki();
+    ASSERT_TRUE(pki.has_value());
+
+    const std::string passwordPath = writePasswordFile("MyEnrollmentSecret123");
+    auto keySource = std::make_shared<PasswordKeySource>(passwordPath);
+
+    // authd must never be reached: a valid client certificate alone must not be enough once
+    // requirePassword is also set.
+    const std::string authdPath = makeUniqueSocketPath("enrollment_mtls_e2e_both_reject");
+
+    EnrollmentAuthenticator authenticator {EnrollmentAuthConfig {true}, keySource};
+    AuthdClient authdClient(authdPath, /*isWorkerNode=*/false, 0, 2000, 0);
+    wazuh::metrics::Manager metricsManager;
+    EnrollmentMetrics metrics = makeEnrollmentMetrics(metricsManager);
+    Config config;
+    config.enrollmentEnabled = true;
+    config.managerVersion = "5.0.0";
+
+    auto server = buildMtlsEnrollServer(authenticator, authdClient, config, metrics);
+
+    HttpServerConfig serverConfig;
+    serverConfig.bindAddress = "127.0.0.1";
+    serverConfig.port = static_cast<std::uint16_t>(55000 + (::getpid() % 5000));
+    serverConfig.certificatePath = pki->serverCert;
+    serverConfig.privateKeyPath = pki->serverKey;
+    serverConfig.caPath = pki->caCert;
+    serverConfig.verificationMode = ClientVerificationMode::Certificate;
+
+    ASSERT_NO_THROW(server->start(serverConfig));
+
+    const std::string body = R"({"name":"agent1","version":"5.0.0"})";
+    // Valid client certificate, but no Authorization header at all -- the TLS handshake succeeds,
+    // and the request must still be rejected by EnrollmentAuthenticator's password check.
+    const std::string raw = sendEnrollRequest(serverConfig.port, body, &pki->clientCert, &pki->clientKey);
+
+    EXPECT_NE(raw.find("401"), std::string::npos) << "response was: " << raw;
+
+    server->stopAccepting();
+    server->stop();
+    cleanupMtlsPki(*pki);
+    std::remove(passwordPath.c_str());
+}

--- a/src/remoted/remoted_module/test/unit/fakeUdsServer.hpp
+++ b/src/remoted/remoted_module/test/unit/fakeUdsServer.hpp
@@ -114,6 +114,18 @@ namespace remoted::test
             m_dropResponses.store(drop);
         }
 
+        // When true, the connection is closed right after the reply is written, instead of
+        // looping to await another request on it. Off by default so existing persistent-connection
+        // clients (WazuhDBClient, TaskClient) keep serving many requests over one connection; turn
+        // this on to emulate authd's real local socket, which closes after every single reply (see
+        // run_local_server's accept loop, os_auth/src/local-server.c) -- AuthdClient relies on that
+        // close to distinguish "got the reply" from "waiting out the full response timeout" (its
+        // read() call's inner loop otherwise blocks on a next frame that will never arrive).
+        void setCloseAfterReply(bool close)
+        {
+            m_closeAfterReply.store(close);
+        }
+
         size_t requestCount() const
         {
             return m_requestCount.load();
@@ -176,6 +188,10 @@ namespace remoted::test
                 {
                     break;
                 }
+                if (m_closeAfterReply.load())
+                {
+                    break;
+                }
             }
             ::close(fd);
         }
@@ -234,6 +250,7 @@ namespace remoted::test
         std::thread m_thread;
         std::atomic<bool> m_stopping {false};
         std::atomic<bool> m_dropResponses {false};
+        std::atomic<bool> m_closeAfterReply {false};
         std::atomic<size_t> m_requestCount {0};
     };
 

--- a/src/remoted/remoted_module/test/unit/headerUtils_test.cpp
+++ b/src/remoted/remoted_module/test/unit/headerUtils_test.cpp
@@ -1,0 +1,56 @@
+/*
+ * Wazuh remoted module - header lookup unit tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 19, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "http_server/headerUtils.hpp"
+
+#include <gtest/gtest.h>
+
+using remoted::http::headerValue;
+
+TEST(HeaderUtilsTest, FindsAnAlreadyLowercaseName)
+{
+    std::unordered_map<std::string, std::string> headers {{"authorization", "WazuhEnroll 1:deadbeef"}};
+    EXPECT_EQ(headerValue(headers, "authorization"), "WazuhEnroll 1:deadbeef");
+}
+
+TEST(HeaderUtilsTest, FindsTheRfcCanonicalMixedCaseName)
+{
+    // The real-transport case (RestinioHttpServer.cpp's makeHttpRequest()): a well-known field
+    // name comes back in its canonical spelling, not lowercased. This is the exact scenario an
+    // exact-match find() misses -- see this header's own class comment for the bug it was written
+    // to prevent.
+    std::unordered_map<std::string, std::string> headers {{"Authorization", "WazuhEnroll 1:deadbeef"}};
+    EXPECT_EQ(headerValue(headers, "authorization"), "WazuhEnroll 1:deadbeef");
+}
+
+TEST(HeaderUtilsTest, FindsAnUppercaseName)
+{
+    std::unordered_map<std::string, std::string> headers {{"AUTHORIZATION", "value"}};
+    EXPECT_EQ(headerValue(headers, "authorization"), "value");
+}
+
+TEST(HeaderUtilsTest, MissingHeaderReturnsEmpty)
+{
+    std::unordered_map<std::string, std::string> headers {{"content-type", "application/json"}};
+    EXPECT_EQ(headerValue(headers, "authorization"), "");
+}
+
+TEST(HeaderUtilsTest, EmptyMapReturnsEmpty)
+{
+    std::unordered_map<std::string, std::string> headers;
+    EXPECT_EQ(headerValue(headers, "authorization"), "");
+}
+
+TEST(HeaderUtilsTest, DoesNotMatchADifferentLengthName)
+{
+    std::unordered_map<std::string, std::string> headers {{"authorization-extra", "value"}};
+    EXPECT_EQ(headerValue(headers, "authorization"), "");
+}

--- a/src/remoted/remoted_module/test/unit/passwordKeySource_test.cpp
+++ b/src/remoted/remoted_module/test/unit/passwordKeySource_test.cpp
@@ -11,10 +11,12 @@
 
 #include <cstdio>
 #include <fstream>
+#include <sys/resource.h>
 #include <unistd.h>
 
 #include <chrono>
 #include <functional>
+#include <memory>
 #include <thread>
 
 #include <gtest/gtest.h>
@@ -254,6 +256,95 @@ namespace
                 const auto key = source.currentKey();
                 return key.has_value() && *key != *originalKey;
             }));
+    }
+
+    // Restores RLIMIT_NOFILE to whatever it was at construction, even if the test body throws --
+    // a test that lowers the process-wide fd limit must never leak that to the rest of the suite.
+    class RlimitNofileGuard
+    {
+    public:
+        RlimitNofileGuard()
+        {
+            if (::getrlimit(RLIMIT_NOFILE, &m_original) != 0)
+            {
+                m_valid = false;
+            }
+        }
+
+        ~RlimitNofileGuard()
+        {
+            restore();
+        }
+
+        bool lowerTo(rlim_t n)
+        {
+            if (!m_valid)
+            {
+                return false;
+            }
+            struct rlimit lowered = m_original;
+            lowered.rlim_cur = n;
+            return ::setrlimit(RLIMIT_NOFILE, &lowered) == 0;
+        }
+
+        // Idempotent -- callable explicitly to restore early, and safe to call again (or not at
+        // all) from the destructor.
+        void restore()
+        {
+            if (m_valid && !m_restored)
+            {
+                ::setrlimit(RLIMIT_NOFILE, &m_original);
+                m_restored = true;
+            }
+        }
+
+    private:
+        struct rlimit m_original
+        {
+        };
+        bool m_valid {true};
+        bool m_restored {false};
+    };
+
+    TEST_F(PasswordKeySourceTest, DestructorDoesNotHangWhenEventfdCreationFails)
+    {
+        // Regression guard: eventfd() failing at construction (fd exhaustion) must not make the
+        // watcher thread unjoinable forever -- the destructor's join() would then block the
+        // process's shutdown indefinitely. Forces that exact failure by dropping the process's own
+        // fd limit low enough that eventfd()/inotify_init1() both fail (stdin/stdout/stderr, at fds
+        // 0-2, stay open regardless -- RLIMIT_NOFILE only blocks NEW fds beyond the limit), then
+        // asserts destruction completes within a bounded time instead of hanging.
+        writeFile("MyEnrollmentSecret123\n");
+
+        RlimitNofileGuard guard;
+        ASSERT_TRUE(guard.lowerTo(3));
+
+        constexpr int kRefreshSeconds = 1;
+        std::unique_ptr<PasswordKeySource> source;
+        try
+        {
+            source = std::make_unique<PasswordKeySource>(m_path, kRefreshSeconds);
+        }
+        catch (...)
+        {
+            // Restore before letting a construction failure fail the test loudly below.
+        }
+
+        // Restore immediately: everything after this point should run with a normal fd budget.
+        guard.restore();
+
+        ASSERT_TRUE(static_cast<bool>(source)) << "construction itself must still succeed "
+                                                  "(eventfd/inotify failures are handled, logged, "
+                                                  "and fallen back on, not fatal)";
+
+        const auto start = std::chrono::steady_clock::now();
+        source.reset();
+        const auto elapsed = std::chrono::steady_clock::now() - start;
+
+        // Generous margin over kRefreshSeconds (the worst-case bound via the poll() timeout
+        // fallback) to absorb scheduling jitter without being flaky, while still being far below
+        // "hung forever".
+        EXPECT_LT(elapsed, std::chrono::seconds(kRefreshSeconds * 5));
     }
 
     TEST_F(PasswordKeySourceTest, HotReloadPicksUpFileAppearingAfterStartup)

--- a/src/remoted/remoted_module/test/unit/passwordKeySource_test.cpp
+++ b/src/remoted/remoted_module/test/unit/passwordKeySource_test.cpp
@@ -1,0 +1,272 @@
+/*
+ * Wazuh auth middleware (framework-agnostic) - unit tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 19, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <cstdio>
+#include <fstream>
+#include <unistd.h>
+
+#include <chrono>
+#include <functional>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "auth/cmac.hpp" // toLowerHex(), for the known-answer-vector assertion
+#include "auth/passwordKeySource.hpp"
+
+using namespace remoted::auth;
+
+namespace
+{
+
+    class PasswordKeySourceTest : public ::testing::Test
+    {
+    protected:
+        void SetUp() override
+        {
+            const auto* testInfo = ::testing::UnitTest::GetInstance()->current_test_info();
+            m_path = "/tmp/" + std::string(testInfo->test_suite_name()) + "_" + testInfo->name() + "_" +
+                     std::to_string(getpid()) + ".pass";
+        }
+
+        void TearDown() override
+        {
+            std::remove(m_path.c_str());
+        }
+
+        void writeFile(const std::string& contents)
+        {
+            std::ofstream file(m_path);
+            file << contents;
+        }
+
+        static bool waitFor(const std::function<bool()>& predicate,
+                            std::chrono::milliseconds timeout = std::chrono::seconds(2))
+        {
+            const auto deadline = std::chrono::steady_clock::now() + timeout;
+            while (std::chrono::steady_clock::now() < deadline)
+            {
+                if (predicate())
+                {
+                    return true;
+                }
+                std::this_thread::sleep_for(std::chrono::milliseconds(20));
+            }
+            return predicate();
+        }
+
+        std::string m_path;
+    };
+
+    TEST_F(PasswordKeySourceTest, MissingFileHasNoKey)
+    {
+        PasswordKeySource source(m_path);
+        EXPECT_FALSE(source.currentKey().has_value());
+    }
+
+    TEST_F(PasswordKeySourceTest, ValidPasswordProducesA32ByteKey)
+    {
+        writeFile("MyEnrollmentSecret123\n");
+        PasswordKeySource source(m_path);
+
+        const auto key = source.currentKey();
+        ASSERT_TRUE(key.has_value());
+        EXPECT_EQ(key->size(), 32u);
+    }
+
+    TEST_F(PasswordKeySourceTest, KeyIsStableAcrossRepeatedReads)
+    {
+        writeFile("MyEnrollmentSecret123\n");
+        PasswordKeySource source(m_path);
+
+        const auto first = source.currentKey();
+        const auto second = source.currentKey();
+        ASSERT_TRUE(first.has_value());
+        ASSERT_TRUE(second.has_value());
+        EXPECT_EQ(*first, *second);
+    }
+
+    // Verified known-answer vector (see the Agent enrollment chapter of remoted_module/README.md):
+    // computed independently via `openssl kdf ... HKDF` against the exact construction this class
+    // implements (HKDF-SHA256, empty salt, info = "WAZUH-ENROLL-CMAC-KEY" + 0x01, 32-byte output).
+    TEST_F(PasswordKeySourceTest, HkdfMatchesTheVerifiedKnownAnswerVector)
+    {
+        writeFile("MyEnrollmentSecret123\n");
+        PasswordKeySource source(m_path);
+
+        const auto key = source.currentKey();
+        ASSERT_TRUE(key.has_value());
+        EXPECT_EQ(toLowerHex(key->data(), key->size()),
+                  "2ea29504f294bce5039bdb4fb78747dec59866204dc2588dc59f3b8cd5875a9e");
+    }
+
+    TEST_F(PasswordKeySourceTest, DifferentPasswordsProduceDifferentKeys)
+    {
+        writeFile("MyEnrollmentSecret123\n");
+        PasswordKeySource source(m_path);
+        const auto key1 = source.currentKey();
+        ASSERT_TRUE(key1.has_value());
+
+        writeFile("SomeOtherSecret456\n");
+        ASSERT_TRUE(source.reload());
+        const auto key2 = source.currentKey();
+        ASSERT_TRUE(key2.has_value());
+
+        EXPECT_NE(*key1, *key2);
+    }
+
+    TEST_F(PasswordKeySourceTest, TrailingCrlfIsStrippedBeforeDerivation)
+    {
+        writeFile("MyEnrollmentSecret123\r\n");
+        PasswordKeySource withCrlf(m_path);
+
+        const std::string otherPath = m_path + ".nocrlf";
+        {
+            std::ofstream file(otherPath);
+            file << "MyEnrollmentSecret123";
+        }
+        PasswordKeySource withoutCrlf(otherPath);
+
+        const auto key1 = withCrlf.currentKey();
+        const auto key2 = withoutCrlf.currentKey();
+        ASSERT_TRUE(key1.has_value());
+        ASSERT_TRUE(key2.has_value());
+        EXPECT_EQ(*key1, *key2);
+
+        std::remove(otherPath.c_str());
+    }
+
+    TEST_F(PasswordKeySourceTest, LengthTwoOrLessIsRejected)
+    {
+        writeFile("ab\n");
+        PasswordKeySource source(m_path);
+        EXPECT_FALSE(source.currentKey().has_value());
+    }
+
+    TEST_F(PasswordKeySourceTest, LengthThreeIsAccepted)
+    {
+        writeFile("abc\n");
+        PasswordKeySource source(m_path);
+        EXPECT_TRUE(source.currentKey().has_value());
+    }
+
+    TEST_F(PasswordKeySourceTest, AllWhitespaceIsRejected)
+    {
+        writeFile("      \n");
+        PasswordKeySource source(m_path);
+        EXPECT_FALSE(source.currentKey().has_value());
+    }
+
+    TEST_F(PasswordKeySourceTest, EmptyFileIsRejected)
+    {
+        writeFile("");
+        PasswordKeySource source(m_path);
+        EXPECT_FALSE(source.currentKey().has_value());
+    }
+
+    TEST_F(PasswordKeySourceTest, LineExceedingBufferIsRejected)
+    {
+        // 4096 non-newline characters: fgets fills the whole buffer without ever seeing '\n',
+        // matching authd's own read_password_line() "too long" rejection.
+        writeFile(std::string(4096, 'a'));
+        PasswordKeySource source(m_path);
+        EXPECT_FALSE(source.currentKey().has_value());
+    }
+
+    TEST_F(PasswordKeySourceTest, OnlyFirstLineIsUsed)
+    {
+        writeFile("MyEnrollmentSecret123\nSomeOtherSecret456\n");
+        PasswordKeySource firstLineOnly(m_path);
+
+        const std::string otherPath = m_path + ".single";
+        {
+            std::ofstream file(otherPath);
+            file << "MyEnrollmentSecret123\n";
+        }
+        PasswordKeySource singleLine(otherPath);
+
+        const auto key1 = firstLineOnly.currentKey();
+        const auto key2 = singleLine.currentKey();
+        ASSERT_TRUE(key1.has_value());
+        ASSERT_TRUE(key2.has_value());
+        EXPECT_EQ(*key1, *key2);
+
+        std::remove(otherPath.c_str());
+    }
+
+    TEST_F(PasswordKeySourceTest, ManualReloadPicksUpChanges)
+    {
+        writeFile("MyEnrollmentSecret123\n");
+        PasswordKeySource source(m_path);
+        ASSERT_TRUE(source.currentKey().has_value());
+
+        writeFile("  \n"); // now invalid (all-whitespace)
+        EXPECT_FALSE(source.reload());
+        EXPECT_FALSE(source.currentKey().has_value());
+    }
+
+    // ---------------------------------------------------------------------------
+    // Hot-reload: background watcher (inotify + fallback poll)
+    // ---------------------------------------------------------------------------
+
+    TEST_F(PasswordKeySourceTest, HotReloadPicksUpRewriteAutomatically)
+    {
+        writeFile("MyEnrollmentSecret123\n");
+        PasswordKeySource source(m_path, /*refreshIntervalSeconds=*/1);
+        const auto originalKey = source.currentKey();
+        ASSERT_TRUE(originalKey.has_value());
+
+        writeFile("SomeOtherSecret456\n");
+
+        EXPECT_TRUE(waitFor(
+            [&]
+            {
+                const auto key = source.currentKey();
+                return key.has_value() && *key != *originalKey;
+            }));
+    }
+
+    TEST_F(PasswordKeySourceTest, HotReloadSurvivesAtomicReplace)
+    {
+        writeFile("MyEnrollmentSecret123\n");
+        PasswordKeySource source(m_path, /*refreshIntervalSeconds=*/1);
+        const auto originalKey = source.currentKey();
+        ASSERT_TRUE(originalKey.has_value());
+
+        const std::string tmpPath = m_path + ".tmp";
+        {
+            std::ofstream file(tmpPath);
+            file << "SomeOtherSecret456\n";
+        }
+        ASSERT_EQ(rename(tmpPath.c_str(), m_path.c_str()), 0);
+
+        EXPECT_TRUE(waitFor(
+            [&]
+            {
+                const auto key = source.currentKey();
+                return key.has_value() && *key != *originalKey;
+            }));
+    }
+
+    TEST_F(PasswordKeySourceTest, HotReloadPicksUpFileAppearingAfterStartup)
+    {
+        // File absent at construction (Password mode active but authd.pass not yet synced from
+        // the master to a worker) -- currentKey() must start at nullopt and recover once the
+        // file appears, without restarting remoted.
+        PasswordKeySource source(m_path, /*refreshIntervalSeconds=*/1);
+        ASSERT_FALSE(source.currentKey().has_value());
+
+        writeFile("MyEnrollmentSecret123\n");
+
+        EXPECT_TRUE(waitFor([&] { return source.currentKey().has_value(); }));
+    }
+
+} // namespace

--- a/src/remoted/remoted_module/test/unit/passwordKeySource_test.cpp
+++ b/src/remoted/remoted_module/test/unit/passwordKeySource_test.cpp
@@ -269,4 +269,26 @@ namespace
         EXPECT_TRUE(waitFor([&] { return source.currentKey().has_value(); }));
     }
 
+    TEST_F(PasswordKeySourceTest, ReappearingWithIdenticalContentAfterDisappearingIsReloaded)
+    {
+        // Regression guard: a file that goes missing (revoking Password-mode enrollment) and then
+        // comes back with the EXACT same content it had before must still be re-derived, not left
+        // stuck at nullopt forever. Before this was fixed, fileLooksChanged() compared the
+        // reappeared file's hash against the stale m_lastHash from before the disappearance, saw
+        // no difference, and never called reload() again -- even though reload()'s own
+        // missing-file branch had already cleared m_derivedKey to nullopt in the meantime.
+        writeFile("MyEnrollmentSecret123\n");
+        PasswordKeySource source(m_path, /*refreshIntervalSeconds=*/1);
+        const auto originalKey = source.currentKey();
+        ASSERT_TRUE(originalKey.has_value());
+
+        std::remove(m_path.c_str());
+        ASSERT_TRUE(waitFor([&] { return !source.currentKey().has_value(); }));
+
+        writeFile("MyEnrollmentSecret123\n"); // byte-identical to the pre-disappearance content
+
+        ASSERT_TRUE(waitFor([&] { return source.currentKey().has_value(); }));
+        EXPECT_EQ(*source.currentKey(), *originalKey);
+    }
+
 } // namespace

--- a/src/remoted/remoted_module/test/unit/zstdDecoder_test.cpp
+++ b/src/remoted/remoted_module/test/unit/zstdDecoder_test.cpp
@@ -339,3 +339,71 @@ TEST(ZstdDecoder, AFrameWithoutADeclaredSizeIsCutOffWhenTheBudgetRefusesMidway)
     ASSERT_TRUE(std::holds_alternative<ZstdDecodeError>(result));
     EXPECT_EQ(std::get<ZstdDecodeError>(result), ZstdDecodeError::TooLarge);
 }
+
+TEST(ZstdDecoder, ACeilingSmallerThanTheGrowthStepStillAcceptsABodyThatFitsUnderIt)
+{
+    // Regression guard. The block-growth path asks for kChunkSize (64 KiB) on its FIRST growth,
+    // whatever the frame really decodes to, because doubling from a smaller base would mean a
+    // reservation call per chunk. A caller whose ceiling is smaller than that step -- /enroll caps
+    // the decoded body at 16 KiB -- must not have every streaming-compressed request rejected
+    // because of the step size: when the doubling target is refused, zstdDecode() retries at
+    // exactly the bytes needed. Without that retry this body (a few hundred bytes) came back
+    // TooLarge, surfacing as a 413 no matter how small it was.
+    const std::string plain(200, 'z');
+    const auto compressed = remoted::testutil::zstdCompressWithoutDeclaredSize(plain);
+
+    const auto result = zstdDecode(compressed, alwaysReserve, reserveUpTo(16 * 1024));
+
+    ASSERT_TRUE(std::holds_alternative<std::string>(result));
+    EXPECT_EQ(std::get<std::string>(result), plain);
+}
+
+TEST(ZstdDecoder, ACeilingSmallerThanTheGrowthStepStillRejectsABodyOverIt)
+{
+    // The other half of the guard above: the retry must not turn the ceiling into a suggestion.
+    // 64 KiB of output against a 16 KiB ceiling still has to be refused.
+    const std::string plain(64 * 1024, 'z');
+    const auto compressed = remoted::testutil::zstdCompressWithoutDeclaredSize(plain);
+
+    const auto result = zstdDecode(compressed, alwaysReserve, reserveUpTo(16 * 1024));
+
+    ASSERT_TRUE(std::holds_alternative<ZstdDecodeError>(result));
+    EXPECT_EQ(std::get<ZstdDecodeError>(result), ZstdDecodeError::TooLarge);
+}
+
+TEST(ZstdDecoder, AFrameDeclaringAWindowOverTheHardCeilingIsRefusedWithoutReserving)
+{
+    // The window size is attacker-chosen in a ~50-byte header and drives the decoder's up-front
+    // allocation, so it is bounded by a hard constant (kMaxDeclaredWindowSize, 8 MiB) rather than
+    // by whatever budget happens to be free. windowLog 24 = 16 MiB, over that ceiling.
+    const std::string plain(128, 'q');
+    const auto compressed = remoted::testutil::zstdCompressWithDeclaredWindowLog(plain, 24);
+
+    bool reserveWindowCalled = false;
+    const auto result = zstdDecode(
+        compressed,
+        [&reserveWindowCalled](std::size_t)
+        {
+            reserveWindowCalled = true;
+            return true;
+        },
+        alwaysReserve);
+
+    ASSERT_TRUE(std::holds_alternative<ZstdDecodeError>(result));
+    EXPECT_EQ(std::get<ZstdDecodeError>(result), ZstdDecodeError::TooLarge);
+    // Rejected from the header alone -- the budget is never even consulted.
+    EXPECT_FALSE(reserveWindowCalled);
+}
+
+TEST(ZstdDecoder, AFrameDeclaringAWindowUnderTheHardCeilingIsStillAccepted)
+{
+    // The ceiling has to sit above what real compressors emit: windowLog 23 (8 MiB) is what zstd
+    // itself uses at its highest normal levels, so it must round-trip.
+    const std::string plain(128, 'q');
+    const auto compressed = remoted::testutil::zstdCompressWithDeclaredWindowLog(plain, 23);
+
+    const auto result = zstdDecode(compressed, alwaysReserve, alwaysReserve);
+
+    ASSERT_TRUE(std::holds_alternative<std::string>(result));
+    EXPECT_EQ(std::get<std::string>(result), plain);
+}

--- a/src/remoted/remoted_module/test/unit/zstdTestHelper.hpp
+++ b/src/remoted/remoted_module/test/unit/zstdTestHelper.hpp
@@ -95,7 +95,66 @@ namespace remoted::testutil
             if (ZSTD_isError(remaining))
             {
                 throw std::runtime_error(std::string("ZSTD_compressStream2 (end) failed: ") +
-                                        ZSTD_getErrorName(remaining));
+                                         ZSTD_getErrorName(remaining));
+            }
+        } while (remaining != 0);
+
+        out.resize(output.pos);
+        return out;
+    }
+
+    /**
+     * @brief Like zstdCompressWithoutDeclaredSize(), but forces the frame header to DECLARE a
+     *        window of 2^windowLog bytes.
+     *
+     * The window size is what drives the decoder's up-front allocation, and it is attacker-chosen:
+     * a tiny frame can claim a huge window. Used to exercise zstdDecode()'s kMaxDeclaredWindowSize
+     * guard, which must refuse such a frame before reserving anything. The size is deliberately
+     * left undeclared, since zstd sizes the window down to the content size when it knows it.
+     */
+    inline std::string zstdCompressWithDeclaredWindowLog(std::string_view plain, int windowLog)
+    {
+        ZSTD_CCtx* cctx = ZSTD_createCCtx();
+        if (cctx == nullptr)
+        {
+            throw std::runtime_error("ZSTD_createCCtx failed");
+        }
+        struct Guard
+        {
+            ZSTD_CCtx* ctx;
+            ~Guard()
+            {
+                ZSTD_freeCCtx(ctx);
+            }
+        } guard {cctx};
+
+        ZSTD_CCtx_setParameter(cctx, ZSTD_c_windowLog, windowLog);
+
+        std::string out(ZSTD_compressBound(plain.size()) + 1024, '\0');
+        ZSTD_outBuffer output {out.data(), out.size(), 0};
+
+        // Fed and ended in two separate calls, for the same reason as
+        // zstdCompressWithoutDeclaredSize(): the frame header must be written before zstd has seen
+        // the whole input, or it records the content size and sizes the window down to match.
+        ZSTD_inBuffer in {plain.data(), plain.size(), 0};
+        while (in.pos < in.size)
+        {
+            const std::size_t ret = ZSTD_compressStream2(cctx, &output, &in, ZSTD_e_continue);
+            if (ZSTD_isError(ret))
+            {
+                throw std::runtime_error(std::string("ZSTD_compressStream2 failed: ") + ZSTD_getErrorName(ret));
+            }
+        }
+
+        ZSTD_inBuffer end {nullptr, 0, 0};
+        std::size_t remaining = 0;
+        do
+        {
+            remaining = ZSTD_compressStream2(cctx, &output, &end, ZSTD_e_end);
+            if (ZSTD_isError(remaining))
+            {
+                throw std::runtime_error(std::string("ZSTD_compressStream2 (end) failed: ") +
+                                         ZSTD_getErrorName(remaining));
             }
         } while (remaining != 0);
 

--- a/src/remoted/remoted_module/tools/send_enroll.py
+++ b/src/remoted/remoted_module/tools/send_enroll.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""
+Sends POST /enroll requests to remoted's HTTPS enrollment bridge, in any of the three modes
+the manager can be configured for (see the "Enrollment endpoint" chapter of remoted_module/README.md
+and docs/ref/modules/remoted/https-events-api.md#enrollment-endpoint-post-enroll):
+
+  - Open        -- no credential at all. Just send the request.
+  - Password    -- Authorization: WazuhEnroll <unix-ts>:<mac>, where
+                   mac = AES-256-CMAC(hkdf_key, canonical_bytes) and
+                   hkdf_key = HKDF-SHA256(password, salt=b"", info=b"WAZUH-ENROLL-CMAC-KEY"+0x01, 32 bytes):
+
+                     canonical_bytes = b"WAZUH-ENROLL\n"
+                                      + b"1\n"
+                                      + method.upper()  + b"\n"
+                                      + request_target  + b"\n"   (raw path+query, exactly as sent)
+                                      + str(timestamp)  + b"\n"
+                                      + body                       (exact request body bytes, no trailing \\n)
+
+                   Deliberately similar to send_control.py's "Wazuh <agent-id>:..." scheme, minus the
+                   agent-id field -- an enrolling agent doesn't have one yet.
+  - mTLS        -- a client certificate presented during the TLS handshake IS the credential; pass
+                   --client-cert/--client-key and this script sends no Authorization header at all.
+
+Unlike every other tool in this directory, there is no agent already enrolled to borrow a key
+from: for Password mode, pass the manager's actual enrollment password (--password, or
+--password-file to read it from wherever the operator copied /var/wazuh-manager/etc/authd.pass).
+
+Requires: pip install requests cryptography
+
+Examples:
+  python3 send_enroll.py --name web-01                                    # Open mode
+  python3 send_enroll.py --name web-01 --password Secret123               # Password mode
+  python3 send_enroll.py --name web-01 --password Secret123 --tamper      # -> 401 InvalidMac
+  python3 send_enroll.py --name web-01 --client-cert agent.pem --client-key agent.key  # mTLS mode
+  python3 send_enroll.py --password Secret123 --all                       # run every scenario
+"""
+import argparse
+import json
+import sys
+import time
+
+import requests
+import urllib3
+from cryptography.hazmat.primitives import cmac
+from cryptography.hazmat.primitives.ciphers import algorithms
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives import hashes
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+DEFAULT_PASSWORD_FILE = "/var/wazuh-manager/etc/authd.pass"
+HKDF_INFO = b"WAZUH-ENROLL-CMAC-KEY" + bytes([1])
+
+# Must match EnrollmentAuthConfig's defaults (enrollmentAuthenticator.hpp) unless the manager
+# overrides them via remoted.auth_max_request_age/_future_skew -- only used to pick timestamps
+# that reliably land on the wrong side of each window.
+MAX_REQUEST_AGE_SECONDS = 300
+MAX_FUTURE_SKEW_SECONDS = 30
+
+
+def derive_key(password: str) -> bytes:
+    """HKDF-SHA256(password, salt=b"", info=HKDF_INFO, 32 bytes) -- see PasswordKeySource."""
+    hkdf = HKDF(algorithm=hashes.SHA256(), length=32, salt=b"", info=HKDF_INFO)
+    return hkdf.derive(password.encode())
+
+
+def sign_request(key: bytes, method: str, request_target: str, timestamp: int, body: bytes) -> str:
+    """Builds the WazuhEnroll canonical byte sequence and returns its lowercase-hex AES-CMAC."""
+    c = cmac.CMAC(algorithms.AES(key))
+    c.update(b"WAZUH-ENROLL\n")
+    c.update(b"1\n")
+    c.update(method.upper().encode() + b"\n")
+    c.update(request_target.encode() + b"\n")
+    c.update(str(timestamp).encode() + b"\n")
+    c.update(body)
+    return c.finalize().hex()
+
+
+def _auth_header(key: bytes, method: str, target: str, timestamp: int, body: bytes) -> dict:
+    mac = sign_request(key, method, target, timestamp, body)
+    return {"Authorization": f"WazuhEnroll {timestamp}:{mac}"}
+
+
+def read_password(args) -> str:
+    if args.password is not None:
+        return args.password
+    path = args.password_file or DEFAULT_PASSWORD_FILE
+    with open(path, "r") as f:
+        return f.readline().rstrip("\r\n")
+
+
+def build_body(name: str, version: str, groups: str = None, ip: str = None, key_hash: str = None) -> bytes:
+    body = {"name": name, "version": version}
+    if groups is not None:
+        body["groups"] = groups
+    if ip is not None:
+        body["ip"] = ip
+    if key_hash is not None:
+        body["key_hash"] = key_hash
+    return json.dumps(body).encode()
+
+
+def send(base_url, body, headers, cert=None, timeout=10):
+    url = base_url.rstrip("/") + "/enroll"
+    headers = {**headers, "Content-Type": "application/json"}
+    return requests.post(url, headers=headers, data=body, cert=cert, verify=False, timeout=timeout)
+
+
+# --- Scenarios (Password mode only -- these all need a key to sign/tamper with) -------------
+
+def scenario_valid(key, name, timestamp):
+    body = build_body(name, "5.0.0")
+    return _auth_header(key, "POST", "/enroll", timestamp, body), body
+
+
+def scenario_tampered_body(key, name, timestamp):
+    signed_body = build_body(name, "5.0.0")
+    headers = _auth_header(key, "POST", "/enroll", timestamp, signed_body)
+    tampered_body = build_body(name + "-tampered", "5.0.0")
+    return headers, tampered_body
+
+
+def scenario_wrong_key(_key, name, timestamp):
+    wrong_key = bytes(32)  # all-zero key -- never the real derived key
+    body = build_body(name, "5.0.0")
+    return _auth_header(wrong_key, "POST", "/enroll", timestamp, body), body
+
+
+def scenario_missing_authorization(_key, name, _timestamp):
+    body = build_body(name, "5.0.0")
+    return {}, body
+
+
+def scenario_malformed_authorization(_key, name, _timestamp):
+    body = build_body(name, "5.0.0")
+    return {"Authorization": "WazuhEnroll not-a-valid-header"}, body
+
+
+def scenario_expired(key, name, _timestamp):
+    ts = int(time.time()) - (MAX_REQUEST_AGE_SECONDS + 5)
+    body = build_body(name, "5.0.0")
+    return _auth_header(key, "POST", "/enroll", ts, body), body
+
+
+def scenario_future(key, name, _timestamp):
+    ts = int(time.time()) + (MAX_FUTURE_SKEW_SECONDS + 5)
+    body = build_body(name, "5.0.0")
+    return _auth_header(key, "POST", "/enroll", ts, body), body
+
+
+def scenario_missing_name(key, _name, timestamp):
+    body = json.dumps({"version": "5.0.0"}).encode()
+    headers = _auth_header(key, "POST", "/enroll", timestamp, body) if key else {}
+    return headers, body
+
+
+def scenario_invalid_ip(key, name, timestamp):
+    body = build_body(name, "5.0.0", ip="not-an-ip")
+    headers = _auth_header(key, "POST", "/enroll", timestamp, body) if key else {}
+    return headers, body
+
+
+def scenario_malformed_json(key, _name, timestamp):
+    body = b"not valid json{{{"
+    headers = _auth_header(key, "POST", "/enroll", timestamp, body) if key else {}
+    return headers, body
+
+
+AUTH_SCENARIOS = [
+    ("valid_signature", 200, scenario_valid),
+    ("tampered_body", 401, scenario_tampered_body),
+    ("wrong_key", 401, scenario_wrong_key),
+    ("missing_authorization", 401, scenario_missing_authorization),
+    ("malformed_authorization", 401, scenario_malformed_authorization),
+    ("expired_request", 401, scenario_expired),
+    ("future_request", 401, scenario_future),
+]
+
+VALIDATION_SCENARIOS = [
+    ("missing_name", 400, scenario_missing_name),
+    ("invalid_ip", 400, scenario_invalid_ip),
+    ("malformed_json", 400, scenario_malformed_json),
+]
+
+
+def run_scenario(base_url, key, name, scenario_name, expected_status, build):
+    headers, body = build(key, name, int(time.time()))
+    response = send(base_url, body, headers)
+    ok = response.status_code == expected_status
+    label = "PASS" if ok else "FAIL"
+    print(f"[{label}] {scenario_name}: expected {expected_status}, got {response.status_code} "
+          f"-- {response.text[:200]}")
+    return ok
+
+
+def run_all(base_url, key, name):
+    scenarios = AUTH_SCENARIOS + VALIDATION_SCENARIOS if key else VALIDATION_SCENARIOS
+    if not key:
+        print("No --password given: skipping the signature/timing scenarios (they need a key to "
+              "sign or tamper with) and running only the body-validation ones, which work "
+              "regardless of the manager's configured auth mode -- as long as this manager "
+              "doesn't itself require a credential.\n")
+    print(f"Running {len(scenarios)} scenario(s) against {base_url}/enroll\n")
+    results = [run_scenario(base_url, key, name, scenario_name, expected, build)
+               for scenario_name, expected, build in scenarios]
+    passed, total = sum(results), len(results)
+    print(f"\n{passed}/{total} scenarios passed.")
+    return passed == total
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--url", default="https://127.0.0.1:1517", help="Base URL of the HTTPS server.")
+    parser.add_argument("--name", default="test-agent", help="Agent name to enroll.")
+    parser.add_argument("--version", default="5.0.0", help="Agent version to report.")
+    parser.add_argument("--groups", help="Comma-separated centralized group(s).")
+    parser.add_argument("--ip", help="Agent IP override (or 'any').")
+    parser.add_argument("--key-hash", help="Hash of the agent's current key, if re-enrolling.")
+    parser.add_argument("--password", help="Enrollment password -- signs the request (Password mode). "
+                                            "Omit entirely for Open mode.")
+    parser.add_argument("--password-file", help=f"Read the password from this file instead of "
+                                                 f"--password (default {DEFAULT_PASSWORD_FILE}).")
+    parser.add_argument("--client-cert", help="Client certificate PEM (mTLS mode).")
+    parser.add_argument("--client-key", help="Client private key PEM (mTLS mode).")
+    parser.add_argument("--tamper", action="store_true",
+                        help="Sign the body, then send a different one -> 401 InvalidMac "
+                             "(Password mode only).")
+    parser.add_argument("--all", action="store_true",
+                        help="Run every scenario instead of sending one request. Uses --password "
+                             "if given (adds signature/timing scenarios on top of the body-"
+                             "validation ones); otherwise runs only the auth-agnostic ones.")
+    args = parser.parse_args()
+
+    if args.password_file and args.password is not None:
+        parser.error("--password and --password-file are mutually exclusive")
+
+    key = None
+    if args.password is not None or args.password_file:
+        key = derive_key(read_password(args))
+
+    if args.all:
+        return 0 if run_all(args.url, key, args.name) else 1
+
+    cert = (args.client_cert, args.client_key) if args.client_cert or args.client_key else None
+    if cert and (not args.client_cert or not args.client_key):
+        parser.error("--client-cert and --client-key must be given together")
+
+    timestamp = int(time.time())
+    signed_body = build_body(args.name, args.version, args.groups, args.ip, args.key_hash)
+
+    headers = {}
+    if key:
+        headers = _auth_header(key, "POST", "/enroll", timestamp, signed_body)
+
+    sent_body = signed_body
+    if args.tamper:
+        if not key:
+            parser.error("--tamper only makes sense with --password (nothing to tamper against otherwise)")
+        sent_body = build_body(args.name + "-tampered", args.version, args.groups, args.ip, args.key_hash)
+
+    print(f"--> POST {args.url.rstrip('/')}/enroll")
+    if headers:
+        print(f"    Authorization: {headers['Authorization']}")
+    elif cert:
+        print(f"    (mTLS: presenting {args.client_cert})")
+    else:
+        print("    (Open mode: no credential)")
+    print(f"    body sent ({len(sent_body)} bytes): {sent_body.decode()}")
+
+    response = send(args.url, sent_body, headers, cert=cert)
+
+    print(f"<-- {response.status_code} {response.reason}")
+    print(f"    {response.text}")
+    return 0 if response.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/remoted/remoted_module/tools/send_enroll.py
+++ b/src/remoted/remoted_module/tools/send_enroll.py
@@ -100,7 +100,16 @@ def build_body(name: str, version: str, groups: str = None, ip: str = None, key_
     return json.dumps(body).encode()
 
 
-def send(base_url, body, headers, cert=None, timeout=10):
+# A worker-node manager's AuthdClient can legitimately take up to authd_response_timeout's
+# worker-aware default (15 s, authdClient.hpp) before answering -- and much longer than that if an
+# operator raised authd_connect_timeout/authd_response_timeout. 10 s used to be below even the
+# unconfigured worker default, so this tool could report a local timeout for a request the server
+# was still legitimately processing. 20 s covers the default comfortably; --timeout raises it
+# further for a manager configured with non-default (larger) authd_* timeouts.
+DEFAULT_TIMEOUT_SECONDS = 20
+
+
+def send(base_url, body, headers, cert=None, timeout=DEFAULT_TIMEOUT_SECONDS):
     url = base_url.rstrip("/") + "/enroll"
     headers = {**headers, "Content-Type": "application/json"}
     return requests.post(url, headers=headers, data=body, cert=cert, verify=False, timeout=timeout)
@@ -109,7 +118,12 @@ def send(base_url, body, headers, cert=None, timeout=10):
 # --- Scenarios (Password mode only -- these all need a key to sign/tamper with) -------------
 
 def scenario_valid(key, name, timestamp):
-    body = build_body(name, "5.0.0")
+    # Unique per run: this is the one scenario that can actually SUCCEED and persist an agent
+    # record. Reusing a fixed name would make every run after the first collide with the previous
+    # run's own agent and get rejected 409 (EDUPNAME) instead of the 200 this scenario expects --
+    # a tool meant for repeatable testing must not require a fresh client.keys between runs.
+    unique_name = f"{name}-{timestamp}"
+    body = build_body(unique_name, "5.0.0")
     return _auth_header(key, "POST", "/enroll", timestamp, body), body
 
 
@@ -183,9 +197,9 @@ VALIDATION_SCENARIOS = [
 ]
 
 
-def run_scenario(base_url, key, name, scenario_name, expected_status, build):
+def run_scenario(base_url, key, name, scenario_name, expected_status, build, cert=None, timeout=DEFAULT_TIMEOUT_SECONDS):
     headers, body = build(key, name, int(time.time()))
-    response = send(base_url, body, headers)
+    response = send(base_url, body, headers, cert=cert, timeout=timeout)
     ok = response.status_code == expected_status
     label = "PASS" if ok else "FAIL"
     print(f"[{label}] {scenario_name}: expected {expected_status}, got {response.status_code} "
@@ -193,15 +207,17 @@ def run_scenario(base_url, key, name, scenario_name, expected_status, build):
     return ok
 
 
-def run_all(base_url, key, name):
+def run_all(base_url, key, name, cert=None, timeout=DEFAULT_TIMEOUT_SECONDS):
     scenarios = AUTH_SCENARIOS + VALIDATION_SCENARIOS if key else VALIDATION_SCENARIOS
     if not key:
         print("No --password given: skipping the signature/timing scenarios (they need a key to "
               "sign or tamper with) and running only the body-validation ones, which work "
               "regardless of the manager's configured auth mode -- as long as this manager "
               "doesn't itself require a credential.\n")
+    if cert:
+        print(f"Presenting client certificate {cert[0]} on every request (mTLS mode).\n")
     print(f"Running {len(scenarios)} scenario(s) against {base_url}/enroll\n")
-    results = [run_scenario(base_url, key, name, scenario_name, expected, build)
+    results = [run_scenario(base_url, key, name, scenario_name, expected, build, cert=cert, timeout=timeout)
                for scenario_name, expected, build in scenarios]
     passed, total = sum(results), len(results)
     print(f"\n{passed}/{total} scenarios passed.")
@@ -228,7 +244,14 @@ def main():
     parser.add_argument("--all", action="store_true",
                         help="Run every scenario instead of sending one request. Uses --password "
                              "if given (adds signature/timing scenarios on top of the body-"
-                             "validation ones); otherwise runs only the auth-agnostic ones.")
+                             "validation ones); otherwise runs only the auth-agnostic ones. If "
+                             "--client-cert/--client-key are also given, every scenario request "
+                             "presents that certificate too (mTLS mode).")
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT_SECONDS,
+                        help=f"Per-request timeout, seconds (default {DEFAULT_TIMEOUT_SECONDS}, "
+                             "comfortably above authd_response_timeout's unconfigured worker-node "
+                             "default of 15s -- raise this if the manager's authd_connect_timeout/"
+                             "authd_response_timeout were themselves raised).")
     args = parser.parse_args()
 
     if args.password_file and args.password is not None:
@@ -238,12 +261,14 @@ def main():
     if args.password is not None or args.password_file:
         key = derive_key(read_password(args))
 
-    if args.all:
-        return 0 if run_all(args.url, key, args.name) else 1
-
+    # Computed BEFORE the --all branch: --all used to return early here, so --client-cert/
+    # --client-key were silently ignored and mTLS was never actually exercised by --all.
     cert = (args.client_cert, args.client_key) if args.client_cert or args.client_key else None
     if cert and (not args.client_cert or not args.client_key):
         parser.error("--client-cert and --client-key must be given together")
+
+    if args.all:
+        return 0 if run_all(args.url, key, args.name, cert=cert, timeout=args.timeout) else 1
 
     timestamp = int(time.time())
     signed_body = build_body(args.name, args.version, args.groups, args.ip, args.key_hash)
@@ -267,7 +292,7 @@ def main():
         print("    (Open mode: no credential)")
     print(f"    body sent ({len(sent_body)} bytes): {sent_body.decode()}")
 
-    response = send(args.url, sent_body, headers, cert=cert)
+    response = send(args.url, sent_body, headers, cert=cert, timeout=args.timeout)
 
     print(f"<-- {response.status_code} {response.reason}")
     print(f"    {response.text}")

--- a/src/remoted/src/secure.c
+++ b/src/remoted/src/secure.c
@@ -22,6 +22,8 @@
 #include "batch_queue_op.h"
 #include "http_op.h"
 #include "legacy_task_delivery.h"
+#include "config.h"
+#include "authd-config.h"
 
 // REMOTED_HTTPS_VERIFY_* (remote-config.h, via remoted.h) and REMOTED_MODULE_HTTPS_VERIFY_*
 // (remoted_module.h) are two independently-maintained mirrors of the same values, since
@@ -323,6 +325,52 @@ STATIC void remoted_module_https_config(remoted_module_config_t *rm_config) {
 }
 
 /**
+ * @brief Read authd's own <auth> config block (NOT logr's <remote> settings) into the
+ *        enrollment fields of the C-ABI struct, plus the `remoted.enroll_*`/`remoted.authd_*`
+ *        internal options for the bridge's operational knobs.
+ *
+ *        Deliberately sources the behavioral flags from authd's config rather than remoted's
+ *        own, so POST /enroll and legacy port 1515 can never disagree on whether password
+ *        auth is required or which agent versions are acceptable.
+ */
+STATIC void remoted_enrollment_config(remoted_module_config_t *rm_config) {
+    authd_config_t authd_cfg;
+    memset(&authd_cfg, 0, sizeof(authd_cfg));
+
+    if (ReadConfig(CAUTHD, WAZUHCONF, &authd_cfg, NULL) == 0) {
+        // authd_cfg.flags.disabled behaves as a plain boolean in current authd builds: 0
+        // (enabled) unless <auth><disabled>yes</disabled> is explicit -- see the Agent
+        // enrollment chapter of remoted_module/README.md for the verified analysis.
+        rm_config->enrollment_enabled = !authd_cfg.flags.disabled && authd_cfg.flags.remote_enrollment;
+        rm_config->enroll_use_password = authd_cfg.flags.use_password;
+        rm_config->enroll_use_source_ip = authd_cfg.flags.use_source_ip;
+        // NOT logr->allow_higher_versions: that is a separate, independently configured
+        // <remote> setting used by /control. /enroll reads authd's own <agents> setting so
+        // it agrees with legacy port 1515 on which agent versions are acceptable.
+        rm_config->enroll_allow_higher_versions = authd_cfg.allow_higher_versions;
+    } else {
+        // authd's <auth> block could not be parsed at all -- fail closed rather than
+        // silently enabling enrollment with unknown password/version requirements.
+        rm_config->enrollment_enabled = false;
+    }
+
+    os_free(authd_cfg.ciphers);
+    os_free(authd_cfg.agent_ca);
+    os_free(authd_cfg.manager_cert);
+    os_free(authd_cfg.manager_key);
+
+    rm_config->enroll_password_refresh_interval =
+        getDefine_Int_default("remoted", "enroll_password_refresh_interval", 1, 3600, 10);
+    rm_config->authd_connect_timeout = getDefine_Int_default("remoted", "authd_connect_timeout", 1, 60, 2);
+    // authd_response_timeout: <=0 here means "worker-aware default", resolved on the C++ side
+    // (short on the master, long enough to outlast authd's own internal worker-to-master
+    // cluster retry budget on a worker) -- not a fixed constant, since the right default
+    // depends on rm_config->worker_node.
+    rm_config->authd_response_timeout = getDefine_Int_default("remoted", "authd_response_timeout", 0, 120, 0);
+    rm_config->authd_max_queue_size = getDefine_Int_default("remoted", "authd_max_queue_size", 1, 65536, 256);
+}
+
+/**
  * @brief Build the config struct passed to remoted_module_start(), combining the
  *        `remoted.http_*` internal options (see remoted_module_https_config()) with
  *        the `<remote><https>` settings parsed into `logr`, plus the memory-management
@@ -338,6 +386,7 @@ STATIC void w_remoted_build_module_config(const remoted *logr, remoted_module_co
     // back to its own default.
     rm_config->port = logr->https.port;
     remoted_module_https_config(rm_config);
+    remoted_enrollment_config(rm_config);
     rm_config->keystore_refresh_interval = keyupdate_interval;
     rm_config->worker_node = logr->worker_node;
     rm_config->verification_mode = logr->https.verification_mode;

--- a/src/remoted/src/secure.c
+++ b/src/remoted/src/secure.c
@@ -368,6 +368,10 @@ STATIC void remoted_enrollment_config(remoted_module_config_t *rm_config) {
     // depends on rm_config->worker_node.
     rm_config->authd_response_timeout = getDefine_Int_default("remoted", "authd_response_timeout", 0, 120, 0);
     rm_config->authd_max_queue_size = getDefine_Int_default("remoted", "authd_max_queue_size", 1, 65536, 256);
+    // Capped well under authd's own local-socket listen backlog (128, OS_BindUnixDomainWithPerms)
+    // -- authd's accept loop is single-threaded regardless, so a pool larger than the backlog can
+    // hold gains nothing and just leaves surplus workers unable to even connect.
+    rm_config->authd_worker_threads = getDefine_Int_default("remoted", "authd_worker_threads", 1, 32, 8);
 }
 
 /**

--- a/src/remoted/src/secure.c
+++ b/src/remoted/src/secure.c
@@ -369,8 +369,8 @@ STATIC void remoted_enrollment_config(remoted_module_config_t *rm_config) {
     rm_config->authd_response_timeout = getDefine_Int_default("remoted", "authd_response_timeout", 0, 120, 0);
     rm_config->authd_max_queue_size = getDefine_Int_default("remoted", "authd_max_queue_size", 1, 65536, 256);
     // Capped well under authd's own local-socket listen backlog (128, OS_BindUnixDomainWithPerms)
-    // -- authd's accept loop is single-threaded regardless, so a pool larger than the backlog can
-    // hold gains nothing and just leaves surplus workers unable to even connect.
+    // -- a pool larger than the backlog can hold gains nothing and just leaves surplus workers
+    // unable to even connect.
     rm_config->authd_worker_threads = getDefine_Int_default("remoted", "authd_worker_threads", 1, 32, 8);
 }
 

--- a/src/shared/include/agent_op.h
+++ b/src/shared/include/agent_op.h
@@ -83,6 +83,10 @@ int w_request_agent_add_local(int sock,
  * @param key KEY of the newly generated key.
  * @param force Force option to be used during the registration. -1 means disabled. 0 or a positive value means enabled.
  * @param agent_id ID of the agent when requesting a new key for a specific ID.
+ * @param master_error_code If not NULL, receives the master's own numeric error code when it responds with a
+ *        well-formed business rejection (e.g. duplicate name/IP). Left untouched on success, on a transport
+ *        failure, or on a malformed/unparseable response from the master -- callers must not assume it was
+ *        written unless the return value indicates that specific case.
  * @return 0 on success or a negative code on error.
  */
 int w_request_agent_add_clustered(char *err_response,
@@ -93,7 +97,8 @@ int w_request_agent_add_clustered(char *err_response,
                                   char **id,
                                   char **key,
                                   authd_force_options_t *force_options,
-                                  const char *agent_id);
+                                  const char *agent_id,
+                                  int *master_error_code);
 
 // Send a clustered agent remove request.
 int w_request_agent_remove_clustered(char *err_response, const char* agent_id, int purge);

--- a/src/shared/include/ssl_op.h
+++ b/src/shared/include/ssl_op.h
@@ -30,8 +30,14 @@
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 
-#define KEYFILE             "etc/certs/authd-key.pem"
-#define CERTFILE            "etc/certs/authd.pem"
+/* Manager's unified TLS identity: authd and remoted_module's HTTPS server (/enroll's mTLS mode)
+ * present the same certificate, generated once by wazuh-manager-remoted. Only used as the -h
+ * help-text default in os_auth/src/main-server.c -- manager-only, no separate agent-side authd
+ * binary exists. Keep in sync with config/src/authd-config.c's Read_Authd(), which hardcodes the
+ * same path as the actual <ssl_manager_cert>/<ssl_manager_key> default (a separate literal, not
+ * sourced from these macros). */
+#define KEYFILE             "etc/certs/remoted-key.pem"
+#define CERTFILE            "etc/certs/remoted.pem"
 /* TLS 1.3 ciphersuite names (SSL_CTX_set_ciphersuites), not a legacy OpenSSL cipher list */
 #define DEFAULT_CIPHERS     "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256"
 #define MAX_SSL_PACKET_SIZE 16384

--- a/src/shared/src/agent_op.c
+++ b/src/shared/src/agent_op.c
@@ -44,7 +44,8 @@ static int w_parse_agent_add_response(const char* buffer,
                                       char* id,
                                       char* key,
                                       const int json_format,
-                                      const int exit_on_error);
+                                      const int exit_on_error,
+                                      int *error_code);
 
 //Alloc and create an agent addition command payload
 static cJSON* w_create_agent_add_payload(const char *name,
@@ -347,7 +348,7 @@ static cJSON* w_create_agent_add_payload(const char *name,
     return request;
 }
 
-static int w_parse_agent_add_response(const char* buffer, char *err_response, char* id, char* key, const int json_format, const int exit_on_error) {
+static int w_parse_agent_add_response(const char* buffer, char *err_response, char* id, char* key, const int json_format, const int exit_on_error, int *error_code) {
     int result = 0;
     cJSON* response = NULL;
     cJSON * error = NULL;
@@ -380,6 +381,9 @@ static int w_parse_agent_add_response(const char* buffer, char *err_response, ch
                 }
                 else {
                     mwarn("%d: %s", error->valueint, message ? message->valuestring : "(undefined)");
+                }
+                if (error_code) {
+                    *error_code = error->valueint;
                 }
                 result = -1;
             }
@@ -579,7 +583,8 @@ int w_request_agent_add_clustered(char *err_response,
                                   char **id,
                                   char **key,
                                   authd_force_options_t *force_options,
-                                  const char *agent_id) {
+                                  const char *agent_id,
+                                  int *master_error_code) {
     int result;
     char response[OS_MAXSTR + 1];
     char new_id[FILE_SIZE+1] = { '\0' };
@@ -592,7 +597,7 @@ int w_request_agent_add_clustered(char *err_response,
     cJSON_Delete(payload);
 
     if (result = w_send_clustered_message("sendsync", output, response), result == 0) {
-        result = w_parse_agent_add_response(response, err_response, new_id, new_key, FALSE, FALSE);
+        result = w_parse_agent_add_response(response, err_response, new_id, new_key, FALSE, FALSE, master_error_code);
     }
     else if (err_response) {
         snprintf(err_response, 2048, "ERROR: Cannot comunicate with master");
@@ -665,7 +670,7 @@ int w_request_agent_add_local(int sock, char *id, const char *name, const char *
         return result;
     } else {
         response[length] = '\0';
-        result = w_parse_agent_add_response(response, NULL, id, NULL, json_format, exit_on_error);
+        result = w_parse_agent_add_response(response, NULL, id, NULL, json_format, exit_on_error, NULL);
     }
 
     return result;

--- a/src/unit_tests/os_auth/CMakeLists.txt
+++ b/src/unit_tests/os_auth/CMakeLists.txt
@@ -19,6 +19,8 @@ list(APPEND os_auth_flags "${DEBUG_OP_WRAPPERS} ${STDIO_OP_WRAPPERS} \
                            -Wl,--wrap,fprintf -Wl,--wrap,popen -Wl,--wrap,pclose")
 list(APPEND os_auth_names "test_authd-config")
 list(APPEND os_auth_flags "${DEBUG_OP_WRAPPERS}")
+list(APPEND os_auth_names "test_local-server")
+list(APPEND os_auth_flags "${DEBUG_OP_WRAPPERS} -Wl,--wrap,w_request_agent_add_clustered")
 
 list(LENGTH os_auth_names count)
 math(EXPR count "${count} - 1")

--- a/src/unit_tests/os_auth/test_authd-config.c
+++ b/src/unit_tests/os_auth/test_authd-config.c
@@ -147,6 +147,88 @@ static void test_authd_ciphers_default_is_tls13(void **state) {
     os_free(local_config.manager_key);
 }
 
+// Test <legacy_enrollment> parsing/defaults
+
+static void test_authd_legacy_enrollment_default(void **state) {
+    authd_config_t local_config = {0};
+
+    /* With no <auth> children, legacy_enrollment defaults to enabled -- unlike use_password,
+     * nothing should change for a deployment that never touches this new setting. */
+    assert_int_equal(Read_Authd(NULL, NULL, &local_config, NULL), 0);
+    assert_int_equal(local_config.flags.legacy_enrollment, 1);
+
+    os_free(local_config.ciphers);
+    os_free(local_config.manager_cert);
+    os_free(local_config.manager_key);
+}
+
+static void test_read_authd_legacy_enrollment_yes(void **state) {
+    authd_config_t local_config = {0};
+
+    XML_NODE node;
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), node[0]);
+    os_strdup("legacy_enrollment", node[0]->element);
+    os_strdup("yes", node[0]->content);
+    node[1] = NULL;
+
+    assert_int_equal(Read_Authd(NULL, node, &local_config, NULL), 0);
+    assert_int_equal(local_config.flags.legacy_enrollment, 1);
+
+    os_free(node[0]->element);
+    os_free(node[0]->content);
+    os_free(node[0]);
+    os_free(node);
+    os_free(local_config.ciphers);
+    os_free(local_config.manager_cert);
+    os_free(local_config.manager_key);
+}
+
+static void test_read_authd_legacy_enrollment_no(void **state) {
+    authd_config_t local_config = {0};
+
+    XML_NODE node;
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), node[0]);
+    os_strdup("legacy_enrollment", node[0]->element);
+    os_strdup("no", node[0]->content);
+    node[1] = NULL;
+
+    assert_int_equal(Read_Authd(NULL, node, &local_config, NULL), 0);
+    assert_int_equal(local_config.flags.legacy_enrollment, 0);
+
+    os_free(node[0]->element);
+    os_free(node[0]->content);
+    os_free(node[0]);
+    os_free(node);
+    os_free(local_config.ciphers);
+    os_free(local_config.manager_cert);
+    os_free(local_config.manager_key);
+}
+
+static void test_read_authd_legacy_enrollment_invalid(void **state) {
+    authd_config_t local_config = {0};
+
+    XML_NODE node;
+    os_calloc(2, sizeof(xml_node *), node);
+    os_calloc(1, sizeof(xml_node), node[0]);
+    os_strdup("legacy_enrollment", node[0]->element);
+    os_strdup("invalid_value", node[0]->content);
+    node[1] = NULL;
+
+    expect_string(__wrap__merror, formatted_msg,
+                  "(1235): Invalid value for element 'legacy_enrollment': invalid_value.");
+    assert_int_equal(Read_Authd(NULL, node, &local_config, NULL), OS_INVALID);
+
+    os_free(node[0]->element);
+    os_free(node[0]->content);
+    os_free(node[0]);
+    os_free(node);
+    os_free(local_config.ciphers);
+    os_free(local_config.manager_cert);
+    os_free(local_config.manager_key);
+}
+
 // Test ssl_auto_negotiate removal (issue #38091)
 
 static void test_read_authd_ssl_auto_negotiate_removed(void **state) {
@@ -260,6 +342,10 @@ int main(void)
         cmocka_unit_test(test_w_authd_parse_agents_invalid_element),
         cmocka_unit_test(test_authd_use_password_default),
         cmocka_unit_test(test_authd_ciphers_default_is_tls13),
+        cmocka_unit_test(test_authd_legacy_enrollment_default),
+        cmocka_unit_test(test_read_authd_legacy_enrollment_yes),
+        cmocka_unit_test(test_read_authd_legacy_enrollment_no),
+        cmocka_unit_test(test_read_authd_legacy_enrollment_invalid),
         cmocka_unit_test(test_read_authd_ssl_auto_negotiate_removed),
         cmocka_unit_test(test_read_authd_ciphers_valid),
         cmocka_unit_test(test_read_authd_ciphers_invalid),

--- a/src/unit_tests/os_auth/test_local-server.c
+++ b/src/unit_tests/os_auth/test_local-server.c
@@ -158,11 +158,89 @@ static void test_local_add_clustered_transport_failure_maps_to_9016(void **state
     cJSON_Delete(response);
 }
 
+/* is_storable_agent_name() is STATIC in local-server.c (visible here under WAZUH_UNIT_TESTING).
+ * It guards the ONE invariant every caller of the local socket must satisfy: the name has to
+ * survive a round trip through client.keys' `<id> <name> <ip> <key>` line format. It is
+ * deliberately NOT OS_IsValidName()'s charset -- see the tests below for the names that
+ * distinction keeps working. */
+int is_storable_agent_name(const char *name);
+
+static void test_storable_agent_name_accepts_ordinary_names(void **state) {
+    (void) state;
+
+    assert_int_equal(is_storable_agent_name("agent1"), 1);
+    assert_int_equal(is_storable_agent_name("web-01.example.com"), 1);
+    assert_int_equal(is_storable_agent_name("host_name.2"), 1);
+}
+
+static void test_storable_agent_name_accepts_names_os_isvalidname_rejects(void **state) {
+    (void) state;
+
+    /* The whole point of not reusing OS_IsValidName() here: the API's own documented contract for
+     * `agent_name` is `^[\w\-.%]+$` with no minimum length, so all three of these have always been
+     * accepted through this socket by manage_agents/the API. None of them can corrupt client.keys,
+     * so rejecting them would be a regression for existing callers with no safety gain. */
+    assert_int_equal(is_storable_agent_name("a"), 1);          // single character
+    assert_int_equal(is_storable_agent_name("100%cpu"), 1);    // '%' is outside OS_IsValidName()
+    assert_int_equal(is_storable_agent_name(".hidden"), 1);    // leading '.'
+}
+
+static void test_storable_agent_name_rejects_whitespace_and_control_bytes(void **state) {
+    (void) state;
+
+    /* client.keys is whitespace-delimited, so any of these would split the name into extra fields
+     * and shift every later column -- the agent would be stored with a bogus IP and an undecodable
+     * key, then get 401 on every request it ever made. */
+    assert_int_equal(is_storable_agent_name("web 01"), 0);
+    assert_int_equal(is_storable_agent_name("web\t01"), 0);
+    assert_int_equal(is_storable_agent_name("web\n01"), 0);
+    assert_int_equal(is_storable_agent_name("web\r01"), 0);
+    assert_int_equal(is_storable_agent_name("web\x01" "01"), 0);
+    assert_int_equal(is_storable_agent_name("web\x7f" "01"), 0);
+    assert_int_equal(is_storable_agent_name(" leading"), 0);
+    assert_int_equal(is_storable_agent_name("trailing "), 0);
+}
+
+static void test_storable_agent_name_rejects_removed_entry_markers(void **state) {
+    (void) state;
+
+    /* Both OS_ReadKeys() and remoted's keystore treat a leading '#'/'!' on this field as the
+     * removed/disabled-entry marker and skip the line, silently dropping the agent. */
+    assert_int_equal(is_storable_agent_name("#agent"), 0);
+    assert_int_equal(is_storable_agent_name("!agent"), 0);
+
+    /* Only in the FIRST position -- these are storable. */
+    assert_int_equal(is_storable_agent_name("agent#1"), 1);
+    assert_int_equal(is_storable_agent_name("agent!1"), 1);
+}
+
+static void test_storable_agent_name_rejects_empty_and_overlong(void **state) {
+    (void) state;
+    char overlong[130];
+    char at_limit[129];
+
+    assert_int_equal(is_storable_agent_name(NULL), 0);
+    assert_int_equal(is_storable_agent_name(""), 0);
+
+    memset(at_limit, 'a', 128);
+    at_limit[128] = '\0';
+    assert_int_equal(is_storable_agent_name(at_limit), 1); // exactly 128 is allowed
+
+    memset(overlong, 'a', 129);
+    overlong[129] = '\0';
+    assert_int_equal(is_storable_agent_name(overlong), 0);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_local_add_clustered_success),
         cmocka_unit_test(test_local_add_clustered_business_rejection_preserves_master_code),
         cmocka_unit_test(test_local_add_clustered_transport_failure_maps_to_9016),
+        cmocka_unit_test(test_storable_agent_name_accepts_ordinary_names),
+        cmocka_unit_test(test_storable_agent_name_accepts_names_os_isvalidname_rejects),
+        cmocka_unit_test(test_storable_agent_name_rejects_whitespace_and_control_bytes),
+        cmocka_unit_test(test_storable_agent_name_rejects_removed_entry_markers),
+        cmocka_unit_test(test_storable_agent_name_rejects_empty_and_overlong),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/os_auth/test_local-server.c
+++ b/src/unit_tests/os_auth/test_local-server.c
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "auth.h"
+#include "shared.h"
+#include "../wrappers/common.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+
+#include "cJSON.h"
+
+/* local_add_clustered() bridges a worker's local-socket "add" request to the master over the
+ * cluster. It is declared (non-static) in auth.h and defined in local-server.c; these tests
+ * exercise its three outcomes by mocking its only external dependency,
+ * w_request_agent_add_clustered(). */
+
+/* authd_lib (see os_auth/CMakeLists.txt) deliberately excludes main-server.c from the unit-test
+ * library, since it owns main(). Linking any symbol out of local-server.c.o pulls in the whole
+ * object file, including run_local_server()/local_add()/local_remove()/local_get() -- none of
+ * which this suite calls -- and those reference globals that normally live in main-server.c.
+ * Stub them here purely to satisfy the linker; their values are never exercised. */
+volatile int write_pending = 0;
+volatile int running = 0;
+pthread_mutex_t mutex_keys = PTHREAD_MUTEX_INITIALIZER;
+pthread_cond_t cond_pending = PTHREAD_COND_INITIALIZER;
+void authd_sigblock(void) {}
+
+/* wraps */
+
+int __wrap_w_request_agent_add_clustered(char *err_response,
+                                         const char *name,
+                                         const char *ip,
+                                         __attribute__((unused)) const char *groups,
+                                         __attribute__((unused)) const char *key_hash,
+                                         char **id,
+                                         char **key,
+                                         authd_force_options_t *force_options,
+                                         const char *agent_id,
+                                         int *master_error_code) {
+    check_expected(name);
+    check_expected(ip);
+
+    // Mirrors local_add_clustered()'s contract: no caller-supplied id/key/force is ever
+    // forwarded on a worker.
+    assert_null(force_options);
+    assert_null(agent_id);
+
+    int result = mock_type(int);
+
+    if (result == 0) {
+        const char *mock_id = mock_ptr_type(const char *);
+        const char *mock_key = mock_ptr_type(const char *);
+        os_strdup(mock_id, *id);
+        os_strdup(mock_key, *key);
+    } else {
+        int code = mock_type(int);
+        if (code > 0) {
+            *master_error_code = code;
+        }
+        const char *message = mock_ptr_type(const char *);
+        if (message) {
+            strncpy(err_response, message, OS_SIZE_2048 - 1);
+        }
+    }
+
+    return result;
+}
+
+/* tests */
+
+static void test_local_add_clustered_success(void **state) {
+    (void) state;
+    cJSON *response;
+    cJSON *data;
+
+    expect_any_always(__wrap__mdebug2, formatted_msg);
+    expect_any_always(__wrap__minfo, formatted_msg);
+    expect_string(__wrap_w_request_agent_add_clustered, name, "agent1");
+    expect_string(__wrap_w_request_agent_add_clustered, ip, "any");
+    will_return(__wrap_w_request_agent_add_clustered, 0);
+    will_return(__wrap_w_request_agent_add_clustered, "003");
+    will_return(__wrap_w_request_agent_add_clustered, "675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915");
+
+    response = local_add_clustered("agent1", "any", NULL, NULL);
+    assert_non_null(response);
+
+    assert_int_equal(cJSON_GetObjectItem(response, "error")->valueint, 0);
+    data = cJSON_GetObjectItem(response, "data");
+    assert_non_null(data);
+    assert_string_equal(cJSON_GetObjectItem(data, "id")->valuestring, "003");
+    assert_string_equal(cJSON_GetObjectItem(data, "name")->valuestring, "agent1");
+    assert_string_equal(cJSON_GetObjectItem(data, "ip")->valuestring, "any");
+    assert_string_equal(cJSON_GetObjectItem(data, "key")->valuestring,
+                        "675aaf366e6827ee7a77b2f7b4d89e603a21333c09afbb02c40191f199d7c915");
+
+    cJSON_Delete(response);
+}
+
+static void test_local_add_clustered_business_rejection_preserves_master_code(void **state) {
+    (void) state;
+    cJSON *response;
+
+    expect_any_always(__wrap__mdebug2, formatted_msg);
+    expect_any_always(__wrap__minfo, formatted_msg);
+    expect_any_always(__wrap__merror, formatted_msg);
+    expect_string(__wrap_w_request_agent_add_clustered, name, "agent1");
+    expect_string(__wrap_w_request_agent_add_clustered, ip, "any");
+    will_return(__wrap_w_request_agent_add_clustered, -1);
+    will_return(__wrap_w_request_agent_add_clustered, 9008);
+    will_return(__wrap_w_request_agent_add_clustered, "ERROR: Duplicate name");
+
+    response = local_add_clustered("agent1", "any", NULL, NULL);
+    assert_non_null(response);
+
+    // The master's own numeric code (9008, Duplicate name) must be surfaced verbatim --
+    // not collapsed into the generic 9016 -- and the redundant "ERROR: " prefix stripped.
+    assert_int_equal(cJSON_GetObjectItem(response, "error")->valueint, 9008);
+    assert_string_equal(cJSON_GetObjectItem(response, "message")->valuestring, "Duplicate name");
+
+    cJSON_Delete(response);
+}
+
+static void test_local_add_clustered_transport_failure_maps_to_9016(void **state) {
+    (void) state;
+    cJSON *response;
+
+    expect_any_always(__wrap__mdebug2, formatted_msg);
+    expect_any_always(__wrap__minfo, formatted_msg);
+    expect_any_always(__wrap__merror, formatted_msg);
+    expect_string(__wrap_w_request_agent_add_clustered, name, "agent1");
+    expect_string(__wrap_w_request_agent_add_clustered, ip, "any");
+    will_return(__wrap_w_request_agent_add_clustered, -2);
+    will_return(__wrap_w_request_agent_add_clustered, 0); // master_error_code left untouched
+    will_return(__wrap_w_request_agent_add_clustered, "ERROR: Cannot comunicate with master");
+
+    response = local_add_clustered("agent1", "any", NULL, NULL);
+    assert_non_null(response);
+
+    // No well-formed business code came back -- transport failure and a malformed/unparseable
+    // master response are indistinguishable from here, and both map to the new 9016.
+    assert_int_equal(cJSON_GetObjectItem(response, "error")->valueint, 9016);
+    assert_string_equal(cJSON_GetObjectItem(response, "message")->valuestring,
+                        "Cannot communicate with master node");
+
+    cJSON_Delete(response);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_local_add_clustered_success),
+        cmocka_unit_test(test_local_add_clustered_business_rejection_preserves_master_code),
+        cmocka_unit_test(test_local_add_clustered_transport_failure_maps_to_9016),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/unit_tests/remoted/CMakeLists.txt
+++ b/src/unit_tests/remoted/CMakeLists.txt
@@ -63,7 +63,8 @@ list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,accep
                             -Wl,--wrap,rem_inc_recv_upgrade_ack \
                             -Wl,--wrap,OS_DupKeyEntry -Wl,--wrap,OS_FreeKey ${DEBUG_OP_WRAPPERS} \
                             -Wl,--wrap,remoted_module_start -Wl,--wrap,remoted_module_stop \
-                            -Wl,--wrap,w_query_agentd -Wl,--wrap,legacy_task_process_upgrade_ack ${HASH_OP_WRAPPERS}")
+                            -Wl,--wrap,w_query_agentd -Wl,--wrap,legacy_task_process_upgrade_ack ${HASH_OP_WRAPPERS} \
+                            -Wl,--wrap,ReadConfig")
 
 list(APPEND remoted_names "test_save_ctrlmsg_thread")
 list(APPEND remoted_flags "-Wl,--wrap,_merror -Wl,--wrap,_mwarn -Wl,--wrap,accept -Wl,--wrap,close \

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -153,6 +153,27 @@ int __wrap_close(int __fd)
     return mock();
 }
 
+/* remoted_enrollment_config() calls ReadConfig(CAUTHD, ...) to read authd's own <auth> block.
+ * The mock returns a caller-queued status; on success it also populates the fields
+ * remoted_enrollment_config() actually reads, mirroring what Read_Authd() would have filled in. */
+int __wrap_ReadConfig(int modules, const char *cfgfile, void *d1, void *d2)
+{
+    check_expected(modules);
+    check_expected(cfgfile);
+    (void) d2;
+
+    int result = mock_type(int);
+    if (result == 0) {
+        authd_config_t *authd_cfg = (authd_config_t *) d1;
+        authd_cfg->flags.disabled = mock_type(int);
+        authd_cfg->flags.remote_enrollment = mock_type(int);
+        authd_cfg->flags.use_password = mock_type(int);
+        authd_cfg->flags.use_source_ip = mock_type(int);
+        authd_cfg->allow_higher_versions = mock_type(int);
+    }
+    return result;
+}
+
 /*****************WRAPS********************/
 int __wrap_w_mutex_lock(pthread_mutex_t* mutex)
 {
@@ -3385,13 +3406,127 @@ void test_remoted_module_https_config_custom_values(void** state)
     assert_false(rm_config.http_content_encoding_enabled);
 }
 
+// Tests remoted_enrollment_config
+//
+// Reads authd's own <auth> block via ReadConfig(CAUTHD, ...) -- deliberately NOT logr's
+// <remote> settings -- so /enroll and legacy port 1515 can never disagree on whether
+// password auth is required or which agent versions are acceptable.
+
+void test_remoted_enrollment_config_enabled_and_flags_passed_through(void** state)
+{
+    (void) state;
+    remoted_module_config_t rm_config = {0};
+
+    expect_value(__wrap_ReadConfig, modules, CAUTHD);
+    expect_string(__wrap_ReadConfig, cfgfile, WAZUHCONF);
+    will_return(__wrap_ReadConfig, 0); // ReadConfig() succeeds
+    will_return(__wrap_ReadConfig, 0); // flags.disabled = 0 (enabled)
+    will_return(__wrap_ReadConfig, 1); // flags.remote_enrollment = 1
+    will_return(__wrap_ReadConfig, 1); // flags.use_password = 1
+    will_return(__wrap_ReadConfig, 0); // flags.use_source_ip = 0
+    will_return(__wrap_ReadConfig, 1); // allow_higher_versions = true
+    will_return(__wrap_getDefine_Int_default, 20);  // enroll_password_refresh_interval
+    will_return(__wrap_getDefine_Int_default, 3);   // authd_connect_timeout
+    will_return(__wrap_getDefine_Int_default, 15);  // authd_response_timeout
+    will_return(__wrap_getDefine_Int_default, 128); // authd_max_queue_size
+
+    remoted_enrollment_config(&rm_config);
+
+    assert_true(rm_config.enrollment_enabled);
+    assert_true(rm_config.enroll_use_password);
+    assert_false(rm_config.enroll_use_source_ip);
+    assert_true(rm_config.enroll_allow_higher_versions);
+    assert_int_equal(rm_config.enroll_password_refresh_interval, 20);
+    assert_int_equal(rm_config.authd_connect_timeout, 3);
+    assert_int_equal(rm_config.authd_response_timeout, 15);
+    assert_int_equal(rm_config.authd_max_queue_size, 128);
+}
+
+void test_remoted_enrollment_config_authd_disabled_wins(void** state)
+{
+    (void) state;
+    remoted_module_config_t rm_config = {0};
+
+    // flags.disabled=1 must disable enrollment even though remote_enrollment=1 --
+    // <disabled> is authd's global kill switch, taking precedence over everything else.
+    expect_value(__wrap_ReadConfig, modules, CAUTHD);
+    expect_string(__wrap_ReadConfig, cfgfile, WAZUHCONF);
+    will_return(__wrap_ReadConfig, 0);
+    will_return(__wrap_ReadConfig, 1); // flags.disabled = 1
+    will_return(__wrap_ReadConfig, 1); // flags.remote_enrollment = 1
+    will_return(__wrap_ReadConfig, 0);
+    will_return(__wrap_ReadConfig, 0);
+    will_return(__wrap_ReadConfig, 0);
+    will_return(__wrap_getDefine_Int_default, 10);
+    will_return(__wrap_getDefine_Int_default, 2);
+    will_return(__wrap_getDefine_Int_default, 0);
+    will_return(__wrap_getDefine_Int_default, 256);
+
+    remoted_enrollment_config(&rm_config);
+
+    assert_false(rm_config.enrollment_enabled);
+}
+
+void test_remoted_enrollment_config_remote_enrollment_off(void** state)
+{
+    (void) state;
+    remoted_module_config_t rm_config = {0};
+
+    // remote_enrollment=0 (the broadened master switch) disables /enroll even though authd
+    // itself is not <disabled> -- legacy_enrollment plays no part in this decision.
+    expect_value(__wrap_ReadConfig, modules, CAUTHD);
+    expect_string(__wrap_ReadConfig, cfgfile, WAZUHCONF);
+    will_return(__wrap_ReadConfig, 0);
+    will_return(__wrap_ReadConfig, 0); // flags.disabled = 0
+    will_return(__wrap_ReadConfig, 0); // flags.remote_enrollment = 0
+    will_return(__wrap_ReadConfig, 0);
+    will_return(__wrap_ReadConfig, 0);
+    will_return(__wrap_ReadConfig, 0);
+    will_return(__wrap_getDefine_Int_default, 10);
+    will_return(__wrap_getDefine_Int_default, 2);
+    will_return(__wrap_getDefine_Int_default, 0);
+    will_return(__wrap_getDefine_Int_default, 256);
+
+    remoted_enrollment_config(&rm_config);
+
+    assert_false(rm_config.enrollment_enabled);
+}
+
+void test_remoted_enrollment_config_read_config_fails_closed(void** state)
+{
+    (void) state;
+    remoted_module_config_t rm_config = {0};
+    // Poison the field with a value ReadConfig() succeeding would never produce, so a bug
+    // that skips the fail-closed assignment shows up as a mismatched assert.
+    rm_config.enrollment_enabled = true;
+
+    expect_value(__wrap_ReadConfig, modules, CAUTHD);
+    expect_string(__wrap_ReadConfig, cfgfile, WAZUHCONF);
+    will_return(__wrap_ReadConfig, OS_INVALID);
+    // The operational knobs are read unconditionally, regardless of ReadConfig()'s outcome.
+    will_return(__wrap_getDefine_Int_default, 10);
+    will_return(__wrap_getDefine_Int_default, 2);
+    will_return(__wrap_getDefine_Int_default, 0);
+    will_return(__wrap_getDefine_Int_default, 256);
+
+    remoted_enrollment_config(&rm_config);
+
+    assert_false(rm_config.enrollment_enabled);
+    assert_int_equal(rm_config.enroll_password_refresh_interval, 10);
+    assert_int_equal(rm_config.authd_connect_timeout, 2);
+    assert_int_equal(rm_config.authd_response_timeout, 0);
+    assert_int_equal(rm_config.authd_max_queue_size, 256);
+}
+
 /* Tests w_remoted_build_module_config */
 //
 // w_remoted_build_module_config() calls remoted_module_https_config() internally, so
 // each test below must queue the same 25 __wrap_getDefine_Int_default return values
 // (13 http_*, then 3 memory-management, then 6 downstream_*, then 3 auth_*, in that
 // fixed order) as the remoted_module_https_config tests above, even though these
-// tests assert on the <https>-driven fields instead.
+// tests assert on the <https>-driven fields instead. Each also queues one
+// __wrap_ReadConfig scenario (see remoted_enrollment_config tests above) plus its 4
+// getDefine_Int_default calls.
 
 void test_w_remoted_build_module_config_all_fields_populated(void** state)
 {
@@ -3441,6 +3576,21 @@ void test_w_remoted_build_module_config_all_fields_populated(void** state)
     will_return(__wrap_getDefine_Int_default, 30);
     will_return(__wrap_getDefine_Int_default, 10485760);
 
+    // remoted_enrollment_config(): ReadConfig(CAUTHD, ...) succeeds with a "normally enabled"
+    // authd config, then its own 4 getDefine_Int_default calls.
+    expect_value(__wrap_ReadConfig, modules, CAUTHD);
+    expect_string(__wrap_ReadConfig, cfgfile, WAZUHCONF);
+    will_return(__wrap_ReadConfig, 0);  // ReadConfig() succeeds
+    will_return(__wrap_ReadConfig, 0);  // flags.disabled = 0 (enabled)
+    will_return(__wrap_ReadConfig, 1);  // flags.remote_enrollment = 1
+    will_return(__wrap_ReadConfig, 1);  // flags.use_password = 1
+    will_return(__wrap_ReadConfig, 1);  // flags.use_source_ip = 1
+    will_return(__wrap_ReadConfig, 1);  // allow_higher_versions = true
+    will_return(__wrap_getDefine_Int_default, 10);  // enroll_password_refresh_interval
+    will_return(__wrap_getDefine_Int_default, 2);   // authd_connect_timeout
+    will_return(__wrap_getDefine_Int_default, 0);   // authd_response_timeout (0 = worker-aware default)
+    will_return(__wrap_getDefine_Int_default, 256); // authd_max_queue_size
+
     remoted_module_config_t rm_config;
     w_remoted_build_module_config(&test_logr, &rm_config);
 
@@ -3456,6 +3606,15 @@ void test_w_remoted_build_module_config_all_fields_populated(void** state)
     assert_string_equal(rm_config.ciphers, "HIGH:!ADH");
     // cluster_name is populated by HandleSecure() itself, not this helper.
     assert_string_equal(rm_config.cluster_name, "");
+
+    assert_true(rm_config.enrollment_enabled);
+    assert_true(rm_config.enroll_use_password);
+    assert_true(rm_config.enroll_use_source_ip);
+    assert_true(rm_config.enroll_allow_higher_versions);
+    assert_int_equal(rm_config.enroll_password_refresh_interval, 10);
+    assert_int_equal(rm_config.authd_connect_timeout, 2);
+    assert_int_equal(rm_config.authd_response_timeout, 0);
+    assert_int_equal(rm_config.authd_max_queue_size, 256);
 }
 
 void test_w_remoted_build_module_config_null_https_strings_leave_buffers_empty(void** state)
@@ -3494,6 +3653,16 @@ void test_w_remoted_build_module_config_null_https_strings_leave_buffers_empty(v
     will_return(__wrap_getDefine_Int_default, 30);
     will_return(__wrap_getDefine_Int_default, 10485760);
 
+    // remoted_enrollment_config(): ReadConfig(CAUTHD, ...) fails outright here (e.g. a
+    // malformed <auth> block) -- enrollment_enabled must fail closed, not default to enabled.
+    expect_value(__wrap_ReadConfig, modules, CAUTHD);
+    expect_string(__wrap_ReadConfig, cfgfile, WAZUHCONF);
+    will_return(__wrap_ReadConfig, OS_INVALID);
+    will_return(__wrap_getDefine_Int_default, 10);  // enroll_password_refresh_interval
+    will_return(__wrap_getDefine_Int_default, 2);   // authd_connect_timeout
+    will_return(__wrap_getDefine_Int_default, 0);   // authd_response_timeout
+    will_return(__wrap_getDefine_Int_default, 256); // authd_max_queue_size
+
     remoted_module_config_t rm_config;
     w_remoted_build_module_config(&test_logr, &rm_config);
 
@@ -3505,6 +3674,8 @@ void test_w_remoted_build_module_config_null_https_strings_leave_buffers_empty(v
     assert_string_equal(rm_config.private_key_path, "");
     assert_string_equal(rm_config.ca_path, "");
     assert_string_equal(rm_config.ciphers, "");
+
+    assert_false(rm_config.enrollment_enabled);
 }
 
 int main(void)
@@ -3575,6 +3746,11 @@ int main(void)
         // Tests remoted_module_https_config
         cmocka_unit_test(test_remoted_module_https_config_defaults),
         cmocka_unit_test(test_remoted_module_https_config_custom_values),
+        // Tests remoted_enrollment_config
+        cmocka_unit_test(test_remoted_enrollment_config_enabled_and_flags_passed_through),
+        cmocka_unit_test(test_remoted_enrollment_config_authd_disabled_wins),
+        cmocka_unit_test(test_remoted_enrollment_config_remote_enrollment_off),
+        cmocka_unit_test(test_remoted_enrollment_config_read_config_fails_closed),
         // Tests w_remoted_build_module_config
         cmocka_unit_test(test_w_remoted_build_module_config_all_fields_populated),
         cmocka_unit_test(test_w_remoted_build_module_config_null_https_strings_leave_buffers_empty)};

--- a/src/unit_tests/remoted/test_secure.c
+++ b/src/unit_tests/remoted/test_secure.c
@@ -3429,6 +3429,7 @@ void test_remoted_enrollment_config_enabled_and_flags_passed_through(void** stat
     will_return(__wrap_getDefine_Int_default, 3);   // authd_connect_timeout
     will_return(__wrap_getDefine_Int_default, 15);  // authd_response_timeout
     will_return(__wrap_getDefine_Int_default, 128); // authd_max_queue_size
+    will_return(__wrap_getDefine_Int_default, 4);   // authd_worker_threads
 
     remoted_enrollment_config(&rm_config);
 
@@ -3440,6 +3441,7 @@ void test_remoted_enrollment_config_enabled_and_flags_passed_through(void** stat
     assert_int_equal(rm_config.authd_connect_timeout, 3);
     assert_int_equal(rm_config.authd_response_timeout, 15);
     assert_int_equal(rm_config.authd_max_queue_size, 128);
+    assert_int_equal(rm_config.authd_worker_threads, 4);
 }
 
 void test_remoted_enrollment_config_authd_disabled_wins(void** state)
@@ -3461,6 +3463,7 @@ void test_remoted_enrollment_config_authd_disabled_wins(void** state)
     will_return(__wrap_getDefine_Int_default, 2);
     will_return(__wrap_getDefine_Int_default, 0);
     will_return(__wrap_getDefine_Int_default, 256);
+    will_return(__wrap_getDefine_Int_default, 8);
 
     remoted_enrollment_config(&rm_config);
 
@@ -3486,6 +3489,7 @@ void test_remoted_enrollment_config_remote_enrollment_off(void** state)
     will_return(__wrap_getDefine_Int_default, 2);
     will_return(__wrap_getDefine_Int_default, 0);
     will_return(__wrap_getDefine_Int_default, 256);
+    will_return(__wrap_getDefine_Int_default, 8);
 
     remoted_enrollment_config(&rm_config);
 
@@ -3508,6 +3512,7 @@ void test_remoted_enrollment_config_read_config_fails_closed(void** state)
     will_return(__wrap_getDefine_Int_default, 2);
     will_return(__wrap_getDefine_Int_default, 0);
     will_return(__wrap_getDefine_Int_default, 256);
+    will_return(__wrap_getDefine_Int_default, 8);
 
     remoted_enrollment_config(&rm_config);
 
@@ -3516,6 +3521,7 @@ void test_remoted_enrollment_config_read_config_fails_closed(void** state)
     assert_int_equal(rm_config.authd_connect_timeout, 2);
     assert_int_equal(rm_config.authd_response_timeout, 0);
     assert_int_equal(rm_config.authd_max_queue_size, 256);
+    assert_int_equal(rm_config.authd_worker_threads, 8);
 }
 
 /* Tests w_remoted_build_module_config */
@@ -3525,7 +3531,7 @@ void test_remoted_enrollment_config_read_config_fails_closed(void** state)
 // (13 http_*, then 3 memory-management, then 6 downstream_*, then 3 auth_*, in that
 // fixed order) as the remoted_module_https_config tests above, even though these
 // tests assert on the <https>-driven fields instead. Each also queues one
-// __wrap_ReadConfig scenario (see remoted_enrollment_config tests above) plus its 4
+// __wrap_ReadConfig scenario (see remoted_enrollment_config tests above) plus its 5
 // getDefine_Int_default calls.
 
 void test_w_remoted_build_module_config_all_fields_populated(void** state)
@@ -3590,6 +3596,7 @@ void test_w_remoted_build_module_config_all_fields_populated(void** state)
     will_return(__wrap_getDefine_Int_default, 2);   // authd_connect_timeout
     will_return(__wrap_getDefine_Int_default, 0);   // authd_response_timeout (0 = worker-aware default)
     will_return(__wrap_getDefine_Int_default, 256); // authd_max_queue_size
+    will_return(__wrap_getDefine_Int_default, 8);   // authd_worker_threads
 
     remoted_module_config_t rm_config;
     w_remoted_build_module_config(&test_logr, &rm_config);
@@ -3615,6 +3622,7 @@ void test_w_remoted_build_module_config_all_fields_populated(void** state)
     assert_int_equal(rm_config.authd_connect_timeout, 2);
     assert_int_equal(rm_config.authd_response_timeout, 0);
     assert_int_equal(rm_config.authd_max_queue_size, 256);
+    assert_int_equal(rm_config.authd_worker_threads, 8);
 }
 
 void test_w_remoted_build_module_config_null_https_strings_leave_buffers_empty(void** state)
@@ -3662,6 +3670,7 @@ void test_w_remoted_build_module_config_null_https_strings_leave_buffers_empty(v
     will_return(__wrap_getDefine_Int_default, 2);   // authd_connect_timeout
     will_return(__wrap_getDefine_Int_default, 0);   // authd_response_timeout
     will_return(__wrap_getDefine_Int_default, 256); // authd_max_queue_size
+    will_return(__wrap_getDefine_Int_default, 8);   // authd_worker_threads
 
     remoted_module_config_t rm_config;
     w_remoted_build_module_config(&test_logr, &rm_config);

--- a/src/unit_tests/shared/test_agent_op.c
+++ b/src/unit_tests/shared/test_agent_op.c
@@ -39,7 +39,7 @@
 extern cJSON* w_create_agent_add_payload(const char *name, const char *ip, const char *groups, const char *key_hash, const char *key, const char *id, authd_force_options_t *force_options);
 extern cJSON* w_create_agent_remove_payload(const char *id, const int purge);
 extern cJSON* w_create_sendsync_payload(const char *daemon_name, cJSON *message);
-extern int w_parse_agent_add_response(const char* buffer, char *err_response, char* id, char* key, const int json_format, const int exit_on_error);
+extern int w_parse_agent_add_response(const char* buffer, char *err_response, char* id, char* key, const int json_format, const int exit_on_error, int *error_code);
 extern int w_parse_agent_remove_response(const char* buffer, char *err_response, const int json_format, const int exit_on_error);
 
 #ifndef WIN32
@@ -540,46 +540,60 @@ static void test_parse_agent_add_response(void **state) {
     char new_key[KEYSIZE+1] = { '\0' };
     int err = 0;
     char err_response[OS_MAXSTR + 1];
+    int error_code = 0;
 
     // Remove _mwarn checks
     expect_any_always(__wrap__mwarn, formatted_msg);
 
     /* Success parse */
-    err = w_parse_agent_add_response(success_response, err_response, new_id, new_key, FALSE, FALSE);
+    err = w_parse_agent_add_response(success_response, err_response, new_id, new_key, FALSE, FALSE, NULL);
     assert_int_equal(err, 0);
     assert_string_equal(new_id, "001");
     assert_string_equal(new_key, "347e2dc688148aec8544c9777ff291b8868b885");
 
-    err = w_parse_agent_add_response(success_response, err_response, new_id, NULL, FALSE, FALSE);
+    err = w_parse_agent_add_response(success_response, err_response, new_id, NULL, FALSE, FALSE, NULL);
     assert_int_equal(err, 0);
     assert_string_equal(new_id, "001");
 
-    err = w_parse_agent_add_response(success_response, err_response, NULL, new_key, FALSE, FALSE);
+    err = w_parse_agent_add_response(success_response, err_response, NULL, new_key, FALSE, FALSE, NULL);
     assert_int_equal(err, 0);
     assert_string_equal(new_key, "347e2dc688148aec8544c9777ff291b8868b885");
 
     /* Error parse */
-    err = w_parse_agent_add_response(error_response, err_response, new_id, new_key, FALSE, FALSE);
+    err = w_parse_agent_add_response(error_response, err_response, new_id, new_key, FALSE, FALSE, NULL);
     assert_int_equal(err, -1);
     assert_string_equal(err_response, "ERROR: ERROR_MESSAGE");
 
+    /* Error parse: the master's own numeric code is captured when the caller asks for it */
+    error_code = 0;
+    err = w_parse_agent_add_response(error_response, err_response, new_id, new_key, FALSE, FALSE, &error_code);
+    assert_int_equal(err, -1);
+    assert_int_equal(error_code, 9009);
+    assert_string_equal(err_response, "ERROR: ERROR_MESSAGE");
+
     /* Unknown parse */
-    err = w_parse_agent_add_response(unknown_response, err_response, new_id, new_key, FALSE, FALSE);
+    err = w_parse_agent_add_response(unknown_response, err_response, new_id, new_key, FALSE, FALSE, NULL);
     assert_int_equal(err, -2);
     assert_string_equal(err_response, "ERROR: Invalid message format");
 
+    /* Unknown parse: error_code must stay untouched on a non-business failure */
+    error_code = 0;
+    err = w_parse_agent_add_response(unknown_response, err_response, new_id, new_key, FALSE, FALSE, &error_code);
+    assert_int_equal(err, -2);
+    assert_int_equal(error_code, 0);
+
     /* Missing Data parse */
-    err = w_parse_agent_add_response(missingdata_response, err_response, new_id, new_key, FALSE, FALSE);
+    err = w_parse_agent_add_response(missingdata_response, err_response, new_id, new_key, FALSE, FALSE, NULL);
     assert_int_equal(err, -2);
     assert_string_equal(err_response, "ERROR: Invalid message format");
 
     /* Missing ID parse */
-    err = w_parse_agent_add_response(missingid_response, err_response, new_id, new_key, FALSE, FALSE);
+    err = w_parse_agent_add_response(missingid_response, err_response, new_id, new_key, FALSE, FALSE, NULL);
     assert_int_equal(err, -2);
     assert_string_equal(err_response, "ERROR: Invalid message format");
 
     /* Missing key parse */
-    err = w_parse_agent_add_response(missingkey_response, err_response, new_id, new_key, FALSE, FALSE);
+    err = w_parse_agent_add_response(missingkey_response, err_response, new_id, new_key, FALSE, FALSE, NULL);
     assert_int_equal(err, -2);
     assert_string_equal(err_response, "ERROR: Invalid message format");
 }

--- a/tests/integration/test_authd/test_cluster/data/configuration_templates/config_authd_worker.yaml
+++ b/tests/integration/test_authd/test_cluster/data/configuration_templates/config_authd_worker.yaml
@@ -28,9 +28,9 @@
       - ssl_verify_host:
           value: 'no'
       - ssl_manager_cert:
-          value: '/var/wazuh-manager/etc/certs/authd.pem'
+          value: '/var/wazuh-manager/etc/certs/remoted.pem'
       - ssl_manager_key:
-          value: '/var/wazuh-manager/etc/certs/authd-key.pem'
+          value: '/var/wazuh-manager/etc/certs/remoted-key.pem'
     - section: cluster
       elements:
       - name:

--- a/tests/integration/test_authd/test_common/data/configuration_templates/config_authd_common.yaml
+++ b/tests/integration/test_authd/test_common/data/configuration_templates/config_authd_common.yaml
@@ -28,6 +28,6 @@
     - ssl_verify_host:
         value: 'no'
     - ssl_manager_cert:
-        value: '/var/wazuh-manager/etc/certs/authd.pem'
+        value: '/var/wazuh-manager/etc/certs/remoted.pem'
     - ssl_manager_key:
-        value: '/var/wazuh-manager/etc/certs/authd-key.pem'
+        value: '/var/wazuh-manager/etc/certs/remoted-key.pem'

--- a/tests/integration/test_authd/test_force_options/data/configuration_templates/config_authd_force_options.yaml
+++ b/tests/integration/test_authd/test_force_options/data/configuration_templates/config_authd_force_options.yaml
@@ -28,6 +28,6 @@
     - ssl_verify_host:
         value: 'no'
     - ssl_manager_cert:
-        value: '/var/wazuh-manager/etc/certs/authd.pem'
+        value: '/var/wazuh-manager/etc/certs/remoted.pem'
     - ssl_manager_key:
-        value: '/var/wazuh-manager/etc/certs/authd-key.pem'
+        value: '/var/wazuh-manager/etc/certs/remoted-key.pem'

--- a/tests/integration/test_authd/test_remote_enrollment/data/configuration_templates/config_remote_enrollment.yaml
+++ b/tests/integration/test_authd/test_remote_enrollment/data/configuration_templates/config_remote_enrollment.yaml
@@ -28,9 +28,9 @@
       - ssl_verify_host:
           value: 'no'
       - ssl_manager_cert:
-          value: '/var/wazuh-manager/etc/certs/authd.pem'
+          value: '/var/wazuh-manager/etc/certs/remoted.pem'
       - ssl_manager_key:
-          value: '/var/wazuh-manager/etc/certs/authd-key.pem'
+          value: '/var/wazuh-manager/etc/certs/remoted-key.pem'
       - remote_enrollment:
           value: REMOTE_ENROLLMENT
     - section: cluster

--- a/tests/integration/test_authd/test_ssl/data/configuration_templates/config_authd_ssl_certs.yaml
+++ b/tests/integration/test_authd/test_ssl/data/configuration_templates/config_authd_ssl_certs.yaml
@@ -28,8 +28,8 @@
     - ssl_verify_host:
         value: SSL_VERIFY_HOST
     - ssl_manager_cert:
-        value: '/var/wazuh-manager/etc/certs/authd.pem'
+        value: '/var/wazuh-manager/etc/certs/remoted.pem'
     - ssl_manager_key:
-        value: '/var/wazuh-manager/etc/certs/authd-key.pem'
+        value: '/var/wazuh-manager/etc/certs/remoted-key.pem'
     - ssl_agent_ca:
         value: '/var/wazuh-manager/etc/test_rootCA.pem'

--- a/tests/integration/test_authd/test_ssl/data/configuration_templates/config_authd_ssl_options.yaml
+++ b/tests/integration/test_authd/test_ssl/data/configuration_templates/config_authd_ssl_options.yaml
@@ -28,6 +28,6 @@
     - ssl_verify_host:
         value: 'no'
     - ssl_manager_cert:
-        value: '/var/wazuh-manager/etc/certs/authd.pem'
+        value: '/var/wazuh-manager/etc/certs/remoted.pem'
     - ssl_manager_key:
-        value: '/var/wazuh-manager/etc/certs/authd-key.pem'
+        value: '/var/wazuh-manager/etc/certs/remoted-key.pem'

--- a/tests/integration/test_authd/test_use_password/data/configuration_templates/config_authd_use_password.yaml
+++ b/tests/integration/test_authd/test_use_password/data/configuration_templates/config_authd_use_password.yaml
@@ -26,6 +26,6 @@
       - ssl_verify_host:
           value: 'no'
       - ssl_manager_cert:
-          value: '/var/wazuh-manager/etc/certs/authd.pem'
+          value: '/var/wazuh-manager/etc/certs/remoted.pem'
       - ssl_manager_key:
-          value: '/var/wazuh-manager/etc/certs/authd-key.pem'
+          value: '/var/wazuh-manager/etc/certs/remoted-key.pem'

--- a/tests/integration/test_authd/test_use_password/data/configuration_templates/config_authd_use_password_invalid.yaml
+++ b/tests/integration/test_authd/test_use_password/data/configuration_templates/config_authd_use_password_invalid.yaml
@@ -16,6 +16,6 @@
     - ssl_verify_host:
         value: 'no'
     - ssl_manager_cert:
-        value: /var/wazuh-manager/etc/certs/authd.pem
+        value: /var/wazuh-manager/etc/certs/remoted.pem
     - ssl_manager_key:
-        value: /var/wazuh-manager/etc/certs/authd-key.pem
+        value: /var/wazuh-manager/etc/certs/remoted-key.pem

--- a/tests/integration/test_authd/test_use_source_ip/data/configuration_templates/config_authd_use_source_ip.yaml
+++ b/tests/integration/test_authd/test_use_source_ip/data/configuration_templates/config_authd_use_source_ip.yaml
@@ -28,6 +28,6 @@
     - ssl_verify_host:
         value: 'no'
     - ssl_manager_cert:
-        value: '/var/wazuh-manager/etc/certs/authd.pem'
+        value: '/var/wazuh-manager/etc/certs/remoted.pem'
     - ssl_manager_key:
-        value: '/var/wazuh-manager/etc/certs/authd-key.pem'
+        value: '/var/wazuh-manager/etc/certs/remoted-key.pem'


### PR DESCRIPTION
## Description
Adds `POST /enroll` to `remoted_module`'s HTTPS agent server (port 1517), letting agents enroll over the same channel they use for everything else instead of falling back to legacy `authd` on port 1515. The endpoint is a bridge, not a rewrite: `authd` keeps 100% of enrollment business logic (validation, key generation, persistence, cluster forwarding); `remoted` only authenticates the request and relays it to `authd`'s existing local socket (`queue/sockets/auth`). Port 1515 remains fully functional for legacy 4.x agents. Certificate handling is also unified so `authd` and `remoted` present the same manager identity.

Closes #38438

## Proposed Changes
- **New `POST /enroll` endpoint** (`remoted_module/src/enrollment/`): validates the request body (name/version/groups/ip/key_hash), resolves the enrollment IP (`use_source_ip` vs body `ip` vs `any`), forwards to `authd`'s local socket, and maps `authd`'s numeric error codes to HTTP statuses. The route is always registered; it answers `403` (not `404`) when enrollment is administratively disabled, so operators/agents can tell "unsupported" from "administratively off".
- **Two independent authentication gates**, decided once at startup and composable (both, either, or neither can be required):
  - **Client certificate** — purely the HTTPS listener's own `verification_mode`; enforced entirely by the TLS layer before any handler runs.
  - **Password** — `Authorization: WazuhEnroll <unix-ts>:<mac>`, an AES-CMAC keyed by a 32-byte key derived from `authd`'s enrollment password via HKDF-SHA256 (`PasswordKeySource`, hot-reloads `etc/authd.pass`). Fails closed if the password file is missing/invalid.
- **`AuthdClient`**: bridges to `authd`'s local socket. Connect-per-request (authd closes the connection after every reply), using a small pool of worker threads (default 8, `remoted.authd_worker_threads`) sharing one bounded queue, so `authd`'s single-threaded accept loop is rarely left idle waiting on `remoted` under bursty enrollment load. Uses a plain blocking `connect()`/`send()`/`recv()` sequence (bounded by `SO_RCVTIMEO`/`SO_SNDTIMEO`) rather than the shared `SocketClient` async wrapper — an earlier version used the latter and had a real race (send() right after an async connect() that hadn't finished yet), which could report a spurious timeout for an enrollment that had actually already succeeded in `authd`.
- **`authd` changes**: on a cluster worker node, the local socket's `add` function now forwards to the master via the existing `w_request_agent_add_clustered` mechanism (previously any local-socket JSON request was rejected outright on a worker with `9015`); a new error code `9016` ("Cannot communicate with master node") distinguishes a failed cluster forward from a generic internal error. `remove`/`get` still reject on a worker.
- **Three-flag enrollment gating hierarchy**: `<auth><disabled>` (kills `authd` entirely) > `<auth><remote_enrollment>` (now the master switch for *all* remote self-enrollment, both 1515 and `/enroll` — a deliberate, release-noted broadening) > new `<auth><legacy_enrollment>` (default `yes`) narrows further to disable *only* port 1515 while keeping `/enroll`.
- **Certificate unification**: `authd` no longer generates or owns a separate `authd.pem`/`authd-key.pem`; its `<ssl_manager_cert>`/`<ssl_manager_key>` default to the same certificate `remoted_module`'s HTTPS listener already generates (`remoted.pem`/`remoted-key.pem`). Packaging (`inst-functions.sh`, RPM/DEB specs) no longer generates or backs up `authd.pem`/`authd-key.pem`.
- **Shared-code cleanups**: extracted `compareVersions()` (now shared between `/control` and `/enroll` instead of duplicated) and a case-insensitive HTTP header lookup (`headerUtils.hpp`) into shared, unit-tested helpers — the latter fixed a real bug where `/enroll`'s Password mode would reject every real HTTP client's request (which sends `Authorization` in standard RFC casing) because the endpoint did an exact-case header lookup.

### Results and Evidence
Verified manually against a running manager (real `wazuh-manager-authd`/`wazuh-manager-remoted`), which is what surfaced the `AuthdClient` connect-race bug described above — the full hand-written unit/component/E2E suite passed throughout but never happened to trigger the race, since every test double responds fast enough for the (buggy) async connect to consistently win the race in practice.

### Artifacts Affected
- Binaries: `wazuh-manager-remoted` (new enrollment code), `wazuh-manager-authd` (worker-forwarding fix, new error code, new `legacy_enrollment` flag).
- Default config: `etc/wazuh-manager.conf`, `etc/templates/config/generic/auth.template` (cert paths now point at `remoted.pem`/`remoted-key.pem`).
- Packaging: RPM spec and DEB `postinst` no longer generate/own `authd.pem`/`authd-key.pem`; `.github/actions/check_files/manager_base.csv` updated to match.
- New CLI tool: `src/remoted/remoted_module/tools/send_enroll.py`.

### Configuration Changes
- New `<auth><legacy_enrollment>` flag (default `yes`; set to `no` to disable port 1515 while keeping `/enroll`).
- **Behavior change**: `<auth><remote_enrollment>` now gates `/enroll` in addition to port 1515 (previously 1515-only). Any deployment already running `remote_enrollment=no` to lock down 1515 will also have `/enroll` disabled once this ships.
- New `remoted` internal options: `enroll_password_refresh_interval`, `authd_connect_timeout`, `authd_response_timeout`, `authd_max_queue_size`, `authd_worker_threads`.
- Compiled-in cert defaults (`shared/include/ssl_op.h`, `config/src/authd-config.c`) changed from `etc/certs/authd.pem`/`authd-key.pem` to `etc/certs/remoted.pem`/`remoted-key.pem`. Explicit `<ssl_manager_cert>`/`<ssl_manager_key>` overrides keep working unchanged.
- Out of scope: no 4.x→5.0 manager upgrade path is designed or supported here — fresh installs and packaging only.

### Tests Introduced
- C (cmocka): `test_local-server.c` (new — worker-node `add` forwarding, business-rejection code passthrough, transport-failure mapping to `9016`), `test_authd-config.c` additions (`legacy_enrollment` parsing/defaults), `test_agent_op.c` additions (`master_error_code` passthrough), `test_secure.c` additions (enrollment ABI field population from authd's config).
- C++ (GoogleTest), all new: `passwordKeySource_test.cpp`, `authdClient_test.cpp` (incl. a concurrency test proving the worker pool parallelizes), `enrollmentAuthenticator_test.cpp`, `enrollmentConfig_test.cpp`, `enrollmentEndpoint_test.cpp`, `enrollmentE2E_test.cpp`, `enrollmentMtlsE2E_test.cpp` (real-TLS end-to-end, including the combined mTLS+password case), `headerUtils_test.cpp`; plus additions to `controlTypes_test.cpp` for the extracted `compareVersions()`.
- Integration test fixtures updated: 9 `test_authd` configuration templates repointed at `remoted.pem`/`remoted-key.pem`.

## Review Checklist
- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...