### PR TITLE
Implement parallel Vulnerability Detector scans

### DIFF
--- a/docs/ref/modules/inventory-sync-server/configuration.md
+++ b/docs/ref/modules/inventory-sync-server/configuration.md
@@ -318,7 +318,7 @@ wazuh_modules.inventory_sync_server_vd_workers=0
 ```
 
 - **Default value:** `0` (half the host's cores, minimum 1)
-- **Allowed values:** 0 to 16
+- **Allowed values:** 0 to 64
 - **Note:** More workers let scans for different agents run at the same time instead of queueing
   behind each other. Lane occupancy and end-to-end time are `vd.lane.depth` and `vd.lane.time` in
   [`GET /metrics`](metrics.md#vulnerability-detection-lane--vd).

--- a/docs/ref/modules/inventory-sync-server/configuration.md
+++ b/docs/ref/modules/inventory-sync-server/configuration.md
@@ -317,11 +317,11 @@ Workers on the vulnerability-detection scan lane.
 wazuh_modules.inventory_sync_server_vd_workers=0
 ```
 
-- **Default value:** `0` (resolves to 1)
+- **Default value:** `0` (half the host's cores, minimum 1)
 - **Allowed values:** 0 to 16
-- **Note:** The scanner serializes scans internally today, so values above 1 only help once the
-  scanner gains real scan parallelism. Lane occupancy and end-to-end time are `vd.lane.depth` and
-  `vd.lane.time` in [`GET /metrics`](metrics.md#vulnerability-detection-lane--vd).
+- **Note:** More workers let scans for different agents run at the same time instead of queueing
+  behind each other. Lane occupancy and end-to-end time are `vd.lane.depth` and `vd.lane.time` in
+  [`GET /metrics`](metrics.md#vulnerability-detection-lane--vd).
 
 ### wazuh_modules.inventory_sync_server_vd_scan_queue_slots
 

--- a/docs/ref/modules/vulnerability-scanner/architecture.md
+++ b/docs/ref/modules/vulnerability-scanner/architecture.md
@@ -151,6 +151,82 @@ The orchestrator builds the following chains (via `FactoryOrchestrator`) and sel
 - **FullScan** (VDSync FullScanWithDiff, triggered when OS or hotfix indices are present):
   `EventGetContext -> OsScanner -> PackageScanner -> EventDetailsBuilder -> EventSendReport -> ResultIndexer`
 
+## Concurrency
+
+`VulnerabilityScannerFacade` owns one `std::shared_mutex`, shared by reference with both
+`DatabaseFeedManager` and `ScanOrchestrator`. `DatabaseFeedManager` takes it exclusively only
+while a feed update is being applied (`reloadGlobalMaps()`) and shares it for read-only feed
+queries; `ScanOrchestrator` takes the *shared* side for the whole duration of a scan
+(`runScanFromViews()`/`runScanAfterFeedUpdate()`), so any number of scans may run concurrently,
+but never at the same time as a feed reload. Every read a scan performs against the feed
+database and its global maps (vendor/CPE/CNA mappings, the L2 translation cache) is therefore
+safe only because those reads happen while *some* side of this one mutex is held, and because the
+L2 translation cache's own read path stays read-only (no LRU-order mutation) on the scan path.
+
+A shared lock alone is not sufficient for real concurrency: `ScanOrchestrator` keeps a small pool
+of `Slot`s (one per concurrent scan slot), each bundling its own
+`PackageDelta`/`FirstFullScan`/`FullScan` orchestration chains and its own `IndexerConnectorSync`.
+This exists because `PackageScanner` (a stage shared by every chain) carries per-instance mutable
+state — running statistics and its own L1 translation cache — and because `IndexerConnectorSync`
+serializes bulk writes internally; sharing either across concurrent scans would race. A scan call
+checks out a free slot for its duration and returns it afterward. The slot count (the
+`scanWorkers` setting, mirroring `inventory_sync_server`'s `vd_workers`) is what actually lets
+scans of different agents run at once; it defaults to half the host's cores (minimum 1) and an
+explicit value always overrides that default. `DatabaseFeedManager` and its global maps remain
+the one collaborator every slot shares.
+
+RocksDB read concurrency (the feed database's `get`/`seek` calls, used by every slot) relies on
+RocksDB's own documented guarantee that concurrent reads against one `DB*` handle are safe with
+no concurrent writer — an external-library assumption this module does not itself enforce.
+
+### Scan concurrency across callers
+
+Three independent paths can trigger a scan at the same time — a session scan from `VdScanLane`
+(`inventory_sync_server`), an on-demand `/scan/vd` request (`triggerAgentScan()`), and the
+master-only disconnected-agent sweep (`rescanDisconnectedAgents()`, see
+[Feed-update rescan](#feed-update-rescan-scanvd--rescandisconnectedagents) above). All three read
+inventory through the same fixed slot-0 connector (`m_indexerConnector`, i.e.
+`m_scanConnectors.front()`) via `ScanAgentList`, then compete for the slot pool described above:
+
+```mermaid
+sequenceDiagram
+    participant Session as Session scan<br/>(VdScanLane worker)
+    participant OnDemand as On-demand scan<br/>(POST /scan/vd)
+    participant Sweep as Disconnected-agent sweep
+    participant SAL as ScanAgentList<br/>(reads via slot 0 only)
+    participant SO as ScanOrchestrator.checkoutSlot<br/>(m_slots / m_slotBusy)
+
+    OnDemand->>SAL: fetch agent inventory
+    Sweep->>SAL: fetch inventory for N disconnected agents
+    SAL->>SAL: fetchInventoryDocuments through m_indexerConnector, slot 0, read-only
+
+    par a session arrives for one agent
+        Session->>SO: checkoutSlot(agentId)
+        SO-->>Session: first free slot i, hands out its own connector
+        Session->>Session: run scan, index results, flush
+        Session->>SO: releaseSlot(i)
+    and an agent requests a rescan
+        OnDemand->>SO: checkoutSlot(agentId)
+        SO-->>OnDemand: first free slot j, hands out its own connector
+        OnDemand->>OnDemand: run scan, index results, flush
+        OnDemand->>SO: releaseSlot(j)
+    and the feed updates, master sweeps disconnected agents
+        loop for each disconnected agent
+            Sweep->>SO: checkoutSlot(agentId)
+            SO-->>Sweep: first free slot k, hands out its own connector
+            Sweep->>Sweep: run scan, index results, flush
+            Sweep->>SO: releaseSlot(k)
+        end
+    end
+
+    Note over SO: m_slots has scanWorkers entries. checkoutSlot blocks on m_poolCv<br/>until some index frees, so a slot busy on one path delays the others<br/>regardless of which agent each one is scanning.
+```
+
+A separate, per-agent mutual-exclusion fence (`ScanCoordinatorRegistry`, unrelated to this slot
+pool) also stops a session scan and a feed-update rescan from targeting the SAME agent at once —
+see [inventory-sync-server's architecture.md](../inventory-sync-server/architecture.md#the-vulnerability-detection-scan-lane)
+for that mechanism.
+
 ## Data models used by VD
 
 ### ScanContext

--- a/docs/ref/modules/vulnerability-scanner/configuration.md
+++ b/docs/ref/modules/vulnerability-scanner/configuration.md
@@ -133,6 +133,10 @@ vulnerability-detection.remediation_lru_size=2048
 # Default: 0 (half the host's cores, minimum 1)
 vulnerability-detection.scan_workers=0
 
+# Depth of the on-demand /scan/vd dispatch queue (0 to 256)
+# Default: 0 (64 slots)
+vulnerability-detection.scan_dispatch_queue_slots=0
+
 # Disable vulnerability scanning of the manager node itself (0 or 1)
 # Default: 1 (disabled — the manager is NOT scanned by default)
 vulnerability-detection.disable_scan_manager=1
@@ -189,6 +193,18 @@ Number of vulnerability scans that can run at the same time, for different agent
 - **Allowed values:** `0` to `64`
 - **Note:** For this to have an effect, `inventory_sync_server`'s `vd_workers` setting should be
   raised to a similar value — otherwise scans still queue up before reaching the scanner.
+
+### scan_dispatch_queue_slots
+
+Depth of the bounded queue behind the on-demand `POST /scan/vd` endpoint (the lane `remoted` uses
+to trigger a rescan for one agent, separate from `inventory_sync_server`'s session-sync path).
+A request beyond this depth is answered `503 scan_queue_full` immediately; the agent retries on
+its next notify.
+
+- **Default value:** `0` (64 slots)
+- **Allowed values:** `0` to `256`
+- **Note:** Current depth and rejection count are visible as `vd.dispatch.queue.depth` and
+  `vd.dispatch.queue.full.total` in [`GET /metrics`](metrics.md#on-demand-dispatch-queue--vddispatchqueue).
 
 ### disable_scan_manager
 

--- a/docs/ref/modules/vulnerability-scanner/configuration.md
+++ b/docs/ref/modules/vulnerability-scanner/configuration.md
@@ -129,6 +129,10 @@ vulnerability-detection.osdata_lru_size=1000
 # Default: 2048
 vulnerability-detection.remediation_lru_size=2048
 
+# Concurrent scan slots (0 to 64)
+# Default: 0 (half the host's cores, minimum 1)
+vulnerability-detection.scan_workers=0
+
 # Disable vulnerability scanning of the manager node itself (0 or 1)
 # Default: 1 (disabled — the manager is NOT scanned by default)
 vulnerability-detection.disable_scan_manager=1
@@ -176,6 +180,15 @@ Size of the LRU cache used to memoize remediation lookups.
 
 - **Default value:** `2048` (entries)
 - **Allowed values:** `1` to `100000`
+
+### scan_workers
+
+Number of vulnerability scans that can run at the same time, for different agents.
+
+- **Default value:** `0` (half the host's cores, minimum 1)
+- **Allowed values:** `0` to `64`
+- **Note:** For this to have an effect, `inventory_sync_server`'s `vd_workers` setting should be
+  raised to a similar value — otherwise scans still queue up before reaching the scanner.
 
 ### disable_scan_manager
 

--- a/docs/ref/modules/vulnerability-scanner/metrics.md
+++ b/docs/ref/modules/vulnerability-scanner/metrics.md
@@ -1,0 +1,68 @@
+# Metrics
+
+The vulnerability scanner keeps its runtime statistics in a `wazuh_metrics` registry (the same
+shared library at `src/shared_modules/metrics/` that `remoted` and `inventory_sync_server` use
+for their own `/metrics`) and serves a JSON dump of the whole registry on **`GET /metrics` over
+its local socket**, `queue/sockets/vd.sock`. The route is UDS-local (agents can never reach it —
+remoted exposes nothing that forwards to it) and **budget-exempt**, like the module's other
+liveness routes (`/vulnerability-detector/status`, `/vulnerability-detector/offset`).
+
+These metrics cover the **on-demand `POST /scan/vd` dispatch lane** (`VdScanDispatcher`) —
+the path `remoted` uses to trigger a rescan for one agent. They are a different call path from
+`inventory_sync_server`'s own session-sync lane, whose `vd.lane.depth`, `vd.lane.time`, and
+`vd.scan.duration` cover the *other* path (`VDFirst`/`VDSync`); see that module's
+[metrics page](../inventory-sync-server/metrics.md#vulnerability-detection-lane--vd). The
+`vd.dispatch.` prefix keeps the two from being confused when both `/metrics` endpoints are
+scraped together.
+
+## Querying
+
+```bash
+curl -s --unix-socket /var/wazuh-manager/queue/sockets/vd.sock http://localhost/metrics
+```
+
+The dump is one JSON document: an envelope with the daemon name and a UTC timestamp, plus one
+entry per metric, sorted by name (compact on the wire; pretty-printed here):
+
+```json
+{
+  "name": "vulnerability_scanner",
+  "timestamp": "2026-08-21T18:00:00Z",
+  "metrics": [
+    {"name": "vd.dispatch.queue.depth", "type": "gauge_int", "enabled": true, "value": 0,
+     "description": "VD sessions queued in the on-demand dispatch lane", "unit": "items"},
+    {"name": "vd.dispatch.queue.full.total", "type": "counter", "enabled": true, "value": 0,
+     "description": "On-demand scan requests refused because the dispatch queue was full",
+     "unit": "count"}
+  ]
+}
+```
+
+Reading notes:
+
+- **The counter accumulates for the life of the process** and survives the module's own
+  restart retries. There is no reset endpoint: derive events-per-second by diffing counters
+  between polls.
+- `GET /metrics` itself answers `503` if the registry is gone (module shutting down); that
+  response is not counted anywhere.
+
+## Catalog
+
+### On-demand dispatch queue — `vd.dispatch.queue.*`
+
+The bounded queue behind `POST /scan/vd`: one worker drains it into the scanner, so this is
+where a burst of rescan requests (e.g. a fleet-wide feed update) actually waits.
+
+| Metric | Type | Unit | Meaning | Tuning |
+|---|---|---|---|---|
+| `vd.dispatch.queue.depth` | gauge_int | items | Requests currently queued, not counting the one in flight | [`scan_dispatch_queue_slots`](configuration.md#scan_dispatch_queue_slots) sets the ceiling |
+| `vd.dispatch.queue.full.total` | counter | count | Requests answered `503 scan_queue_full` because the queue was already at its ceiling | [`scan_dispatch_queue_slots`](configuration.md#scan_dispatch_queue_slots); drain rate is one worker regardless (see `architecture.md`'s Concurrency section) |
+
+A steadily nonzero `vd.dispatch.queue.full.total` under normal load is the signal to raise
+`scan_dispatch_queue_slots` — or investigate why scans are draining slower than requests
+arrive, since a bigger queue alone does not fix a lane that cannot keep up.
+
+`remoted`'s own `remoted.scanvd.queue_full` counter (its `/metrics`, relay side) observes the
+*same* underlying rejections from the caller's vantage point — it only tells you a request was
+told the queue was full, not the live depth. Use this page's `vd.dispatch.queue.depth` to see
+the queue trending toward its ceiling before it starts rejecting.

--- a/docs/ref/modules/vulnerability-scanner/metrics.md
+++ b/docs/ref/modules/vulnerability-scanner/metrics.md
@@ -7,13 +7,20 @@ its local socket**, `queue/sockets/vd.sock`. The route is UDS-local (agents can 
 remoted exposes nothing that forwards to it) and **budget-exempt**, like the module's other
 liveness routes (`/vulnerability-detector/status`, `/vulnerability-detector/offset`).
 
-These metrics cover the **on-demand `POST /scan/vd` dispatch lane** (`VdScanDispatcher`) —
-the path `remoted` uses to trigger a rescan for one agent. They are a different call path from
-`inventory_sync_server`'s own session-sync lane, whose `vd.lane.depth`, `vd.lane.time`, and
-`vd.scan.duration` cover the *other* path (`VDFirst`/`VDSync`); see that module's
+These metrics cover this module's own two call paths into the scanner:
+
+- The **on-demand `POST /scan/vd` dispatch lane** (`VdScanDispatcher`) — the path `remoted` uses
+  to trigger a rescan for one agent. Names prefixed `vd.dispatch.`.
+- The **disconnected-agent sweep** (`ScanAgentList`, driven by `rescanDisconnectedAgents()`) —
+  the manager-initiated rescan of every disconnected agent after a feed update. Names prefixed
+  `vd.sweep.`.
+
+Both are different call paths from `inventory_sync_server`'s own session-sync lane, whose
+`vd.lane.depth`, `vd.lane.time`, and `vd.scan.duration` cover the *third* path
+(`VDFirst`/`VDSync`); see that module's
 [metrics page](../inventory-sync-server/metrics.md#vulnerability-detection-lane--vd). The
-`vd.dispatch.` prefix keeps the two from being confused when both `/metrics` endpoints are
-scraped together.
+`vd.dispatch.`/`vd.sweep.` prefixes keep all three from being confused when multiple `/metrics`
+endpoints are scraped together.
 
 ## Querying
 
@@ -27,22 +34,32 @@ entry per metric, sorted by name (compact on the wire; pretty-printed here):
 ```json
 {
   "name": "vulnerability_scanner",
-  "timestamp": "2026-08-21T18:00:00Z",
+  "timestamp": "2026-08-24T18:00:00Z",
   "metrics": [
     {"name": "vd.dispatch.queue.depth", "type": "gauge_int", "enabled": true, "value": 0,
      "description": "VD sessions queued in the on-demand dispatch lane", "unit": "items"},
     {"name": "vd.dispatch.queue.full.total", "type": "counter", "enabled": true, "value": 0,
      "description": "On-demand scan requests refused because the dispatch queue was full",
-     "unit": "count"}
+     "unit": "count"},
+    {"name": "vd.dispatch.scan.duration", "type": "histogram", "enabled": true, "value": 0,
+     "description": "Time inside the vulnerability scanner (on-demand path)",
+     "unit": "microseconds",
+     "summary": {"count": 0, "sum": 0, "min": 0, "max": 0, "p50": 0, "p90": 0, "p99": 0}}
   ]
 }
 ```
 
 Reading notes:
 
-- **The counter accumulates for the life of the process** and survives the module's own
-  restart retries. There is no reset endpoint: derive events-per-second by diffing counters
-  between polls.
+- **Counters accumulate for the life of the process** and survive the module's own restart
+  retries. There is no reset endpoint: derive events-per-second by diffing counters between
+  polls.
+- **The catalog is dynamic**: `vd.sweep.*` only appears once `rescanDisconnectedAgents()` has
+  actually constructed its `ScanAgentList` at least once — which only happens after a feed
+  update cycle completes with genuinely new CVE data (not a restart with an unchanged feed) on
+  a node that isn't a cluster worker. A manager whose feed hasn't changed since it last started,
+  or a worker node, legitimately answers `200` with only `vd.dispatch.*` present — that is not
+  an error. `vd.dispatch.*`, by contrast, is created at module startup and always present.
 - `GET /metrics` itself answers `503` if the registry is gone (module shutting down); that
   response is not counted anywhere.
 
@@ -66,3 +83,30 @@ arrive, since a bigger queue alone does not fix a lane that cannot keep up.
 *same* underlying rejections from the caller's vantage point — it only tells you a request was
 told the queue was full, not the live depth. Use this page's `vd.dispatch.queue.depth` to see
 the queue trending toward its ceiling before it starts rejecting.
+
+### On-demand scan duration — `vd.dispatch.scan.duration`
+
+| Metric | Type | Unit | Meaning | Tuning |
+|---|---|---|---|---|
+| `vd.dispatch.scan.duration` | histogram | microseconds | Time inside the scan call itself for one on-demand request, observed on every attempt (success or exception alike) | — diagnostic; compare against `inventory_sync_server`'s `vd.scan.duration` to see whether the two call paths cost the same per scan |
+
+This is the on-demand path's own cost, separate from queue wait — a request can show a fast
+`vd.dispatch.scan.duration` while still waiting a long time in the queue first (see
+`vd.dispatch.queue.depth` above for that half of the picture).
+
+### Disconnected-agent sweep — `vd.sweep.*`
+
+The manager-initiated rescan of every disconnected agent, triggered after a feed update on the
+cluster master (or a standalone node) only — see the dynamic-catalog note above for when these
+first appear.
+
+| Metric | Type | Unit | Meaning | Tuning |
+|---|---|---|---|---|
+| `vd.sweep.scan.duration` | histogram | microseconds | Time inside the scan call itself, per disconnected agent, observed on every attempt | — diagnostic |
+| `vd.sweep.scans.ok` | counter | count | Disconnected agents the sweep scanned without the call throwing | — diagnostic |
+| `vd.sweep.scans.failed` | counter | count | Disconnected agents whose scan threw during the sweep (added to the sweep's own retry list) | — diagnostic; a nonzero rate here is also visible in the manager log's per-sweep summary line |
+
+These three count and time only sweep-driven scans. The on-demand path's own single-agent calls
+run through the same underlying `ScanAgentList` code but deliberately do not feed `vd.sweep.*` —
+that call's cost is `vd.dispatch.scan.duration` above, not this family, so the two never double-count
+the same scan.

--- a/src/wazuh_modules/inventory_sync_server/README.md
+++ b/src/wazuh_modules/inventory_sync_server/README.md
@@ -94,7 +94,7 @@ pipeline satisfies it structurally rather than by discipline:
 | REQ-VDQ-4 | No silent drop; degrade with explicit coalescing | **superseded by D22** — the lane is short and synchronous; a full lane answers `503` and the agent re-POSTs (nothing to coalesce) |
 | REQ-VDQ-5 | Redefine the ack contract for VD sessions (scan decoupled from ack) | **superseded by D22** — the OPPOSITE was chosen: the scan gates the response; `200` guarantees scan + ingest |
 | REQ-VDQ-6 | Two-phase shutdown: stop admitting → drain/abort → reset the orchestrator | kept (lane stop before scanner reset; coordinator unregisters first) |
-| REQ-VDQ-7 | REAL scan parallelism needs scanner work (shared_lock + per-worker chains), not just a queue | **pending** — `vd_workers` defaults to 1 until the scanner stops serializing scans globally |
+| REQ-VDQ-7 | REAL scan parallelism needs scanner work (shared_lock + per-worker chains), not just a queue | **kept** — `ScanOrchestrator` now takes a `shared_lock` and checks out a per-slot `Slot` (its own chains + its own `IndexerConnectorSync`) for each scan; `vd_workers`/the scanner's `scanWorkers` both default to half the host's cores (minimum 1) and can be overridden with an explicit value |
 | REQ-VDQ-8 | Feed-update coordination reformulated over queue state, not module internals | kept (`ServerScanCoordinator` answers from lane + registry state) |
 | REQ-VDQ-9 | No RocksDB in the VD path (or at all) | kept (D9 — the module has NO local store) |
 | REQ-VDQ-10 | Queue observability: depth, ages, outcomes, durations | kept (`vd.lane.*`, `vd.scans.*` metrics — see [Statistics](#statistics-d18)) |

--- a/src/wazuh_modules/inventory_sync_server/include/inventory_sync_server.h
+++ b/src/wazuh_modules/inventory_sync_server/include/inventory_sync_server.h
@@ -164,23 +164,24 @@ extern "C"
 
 
         /* ---- Sync pipeline (the POST /stateful ingestion path) ---- */
-        int sync_workers;           ///< Worker threads applying sessions to the indexer, sharded by
-                                    ///< agent id (FIFO per agent). Each worker owns one
-                                    ///< IndexerConnectorSync built on the shared session.
-                                    ///< Range 0..64. <=0 -> nproc/2, minimum 1.
-        long long sync_queue_bytes; ///< Early-rejection cap on payload bytes queued in the pipeline;
-                                    ///< over it -> 503. A refinement UNDER max_inflight_bytes (which
-                                    ///< already bounds the memory): this one sheds before the
-                                    ///< transport budget is exhausted so probes/other routes keep
-                                    ///< admitting. Range 1048576..1073741824. <=0 -> 64 MiB.
+        int sync_workers;                ///< Worker threads applying sessions to the indexer, sharded by
+                                         ///< agent id (FIFO per agent). Each worker owns one
+                                         ///< IndexerConnectorSync built on the shared session.
+                                         ///< Range 0..64. <=0 -> nproc/2, minimum 1.
+        long long sync_queue_bytes;      ///< Early-rejection cap on payload bytes queued in the pipeline;
+                                         ///< over it -> 503. A refinement UNDER max_inflight_bytes (which
+                                         ///< already bounds the memory): this one sheds before the
+                                         ///< transport budget is exhausted so probes/other routes keep
+                                         ///< admitting. Range 1048576..1073741824. <=0 -> 64 MiB.
         int vd_feed_retry_after_seconds; ///< Value of the `Retry-After` header attached to the 503
                                          ///< returned for vulnerability-detection sessions while
                                          ///< the CVE feed is still downloading.
                                          ///< Range 10..1800. <=0 -> 60.
         int vd_workers;                  ///< Workers of the vulnerability-detection scan lane
                                          ///< (scan -> index -> respond, one connector each). The
-                                         ///< scanner serializes scans globally, so more than 1
-                                         ///< only helps once that changes. Range 0..16. <=0 -> 1.
+                                         ///< scanner has its own matching per-slot pool (REQ-VDQ-7),
+                                         ///< so raising this is safe. Range 0..16. <=0 -> nproc/2,
+                                         ///< minimum 1 -- same convention as sync_workers above.
         int vd_scan_queue_slots;         ///< Short admission queue of the scan lane; full -> 503
                                          ///< "scan capacity exhausted". Range 0..256.
                                          ///< <=0 -> 2x vd_workers.

--- a/src/wazuh_modules/inventory_sync_server/include/inventory_sync_server.h
+++ b/src/wazuh_modules/inventory_sync_server/include/inventory_sync_server.h
@@ -179,9 +179,10 @@ extern "C"
                                          ///< Range 10..1800. <=0 -> 60.
         int vd_workers;                  ///< Workers of the vulnerability-detection scan lane
                                          ///< (scan -> index -> respond, one connector each). The
-                                         ///< scanner has its own matching per-slot pool (REQ-VDQ-7),
-                                         ///< so raising this is safe. Range 0..16. <=0 -> nproc/2,
-                                         ///< minimum 1 -- same convention as sync_workers above.
+                                         ///< scanner has its own matching per-slot pool, so
+                                         ///< raising this is safe. An explicit value is clamped
+                                         ///< to 0..64; <=0 resolves to nproc/2, minimum 1 and
+                                         ///< uncapped -- same convention as sync_workers above.
         int vd_scan_queue_slots;         ///< Short admission queue of the scan lane; full -> 503
                                          ///< "scan capacity exhausted". Range 0..256.
                                          ///< <=0 -> 2x vd_workers.

--- a/src/wazuh_modules/inventory_sync_server/src/inventorySyncServerFacade.hpp
+++ b/src/wazuh_modules/inventory_sync_server/src/inventorySyncServerFacade.hpp
@@ -100,9 +100,6 @@ namespace invsync
     /// The demoted flush timer of the pipeline's connectors -- see the overlay in
     /// tryStartHttpServer() for why this is a correctness requirement rather than tuning.
     constexpr int PIPELINE_CONNECTOR_FLUSH_INTERVAL_SECS {3600};
-    /// VD scan lane worker fallback: 1 until the scanner gains real scan parallelism (its global
-    /// mutex serializes scans anyway -- REQ-VDQ-7).
-    constexpr std::size_t DEFAULT_VD_WORKERS {1};
 
     /**
      * @brief RocksDB store path, RESERVED for the ingestion pipeline. Nothing opens it yet.
@@ -676,6 +673,19 @@ namespace invsync
             return cores / 2 > 0 ? cores / 2 : 1;
         }
 
+        /// vd_workers <= 0 follows the same "half the cores, at least one" convention as
+        /// sync_workers above -- the scanner's own per-slot pool (REQ-VDQ-7) makes
+        /// raising this safe.
+        static std::size_t resolveVdWorkers(const inventory_sync_server_config_t& config)
+        {
+            if (config.vd_workers > 0)
+            {
+                return static_cast<std::size_t>(config.vd_workers);
+            }
+            const auto cores = static_cast<std::size_t>(cpp_get_nproc());
+            return cores / 2 > 0 ? cores / 2 : 1;
+        }
+
         /// Diagnostic text for a stage. `label` appears in EVERY escalation branch; `settingHint`
         /// only in the first-attempt ERROR. One switch so a new stage cannot be half-added.
         struct StageDiagnostics
@@ -793,7 +803,7 @@ namespace invsync
             std::size_t pipelineWorkers {1};
             std::string pipelineClusterName;
             invsync::vd::VdScanLaneConfig laneConfig;
-            std::size_t laneWorkers {DEFAULT_VD_WORKERS};
+            std::size_t laneWorkers {1};
             VdScannerFactory scannerFactory;
             std::uint64_t generation {0};
             bool needSession {false};
@@ -839,8 +849,7 @@ namespace invsync
                     m_agentRegistry = std::make_shared<invsync::vd::AgentInFlightRegistry>();
                 }
 
-                laneWorkers =
-                    m_config.vd_workers > 0 ? static_cast<std::size_t>(m_config.vd_workers) : DEFAULT_VD_WORKERS;
+                laneWorkers = resolveVdWorkers(m_config);
                 laneConfig.workers = laneWorkers;
                 laneConfig.queueSlots =
                     m_config.vd_scan_queue_slots > 0 ? static_cast<std::size_t>(m_config.vd_scan_queue_slots) : 0;

--- a/src/wazuh_modules/inventory_sync_server/src/vd/vdScanLane.hpp
+++ b/src/wazuh_modules/inventory_sync_server/src/vd/vdScanLane.hpp
@@ -33,8 +33,11 @@ namespace invsync::vd
 
     struct VdScanLaneConfig
     {
-        /// Scan workers. 1 until VD gains real scan parallelism (its global mutex serializes scans
-        /// anyway -- REQ-VDQ-7); each worker owns one IndexerConnectorSync.
+        /// Scan workers; each worker owns one IndexerConnectorSync. Raising this above 1 is safe
+        /// -- VD's own ScanOrchestrator has a matching per-slot pool (REQ-VDQ-7, its
+        /// "scanWorkers" setting). Placeholder default; the facade overwrites it with
+        /// resolveVdWorkers()'s resolved value (vd_workers, or half the host's cores) before the
+        /// lane starts.
         std::size_t workers {1};
         /// Short admission queue; full => the strand answers 503 "scan capacity exhausted" (D22).
         /// 0 resolves to 2x workers.

--- a/src/wazuh_modules/inventory_sync_server/test/unit/indexerGating_test.cpp
+++ b/src/wazuh_modules/inventory_sync_server/test/unit/indexerGating_test.cpp
@@ -45,9 +45,11 @@ namespace
         std::snprintf(config.socket_path, sizeof(config.socket_path), "%s", socketPath.c_str());
         config.io_threads = 1;
         config.drain_timeout = 1;
-        // One pipeline worker, deterministically: 0 would resolve to half the machine's cores and
-        // these tests count connector builds (the pipeline builds one per EXTRA worker).
+        // One pipeline worker and one VD scan-lane worker, deterministically: 0 would resolve to
+        // half the machine's cores on both knobs, and these tests count connector builds (the
+        // pipeline builds one per EXTRA worker, the VD lane builds one per worker of its own).
         config.sync_workers = 1;
+        config.vd_workers = 1;
         return config;
     }
 

--- a/src/wazuh_modules/src/wm_inventory_sync_server.c
+++ b/src/wazuh_modules/src/wm_inventory_sync_server.c
@@ -205,7 +205,7 @@ static void wm_inventory_sync_server_read_tunables(inventory_sync_server_config_
                                          64 * 1024 * 1024);
     config->vd_feed_retry_after_seconds =
         getDefine_Int_default("wazuh_modules", "inventory_sync_server_vd_feed_retry_after_seconds", 10, 1800, 60);
-    config->vd_workers = getDefine_Int_default("wazuh_modules", "inventory_sync_server_vd_workers", 0, 16, 0);
+    config->vd_workers = getDefine_Int_default("wazuh_modules", "inventory_sync_server_vd_workers", 0, 64, 0);
     config->vd_scan_queue_slots =
         getDefine_Int_default("wazuh_modules", "inventory_sync_server_vd_scan_queue_slots", 0, 256, 0);
 

--- a/src/wazuh_modules/src/wm_vulnerability_scanner.c
+++ b/src/wazuh_modules/src/wm_vulnerability_scanner.c
@@ -89,6 +89,10 @@ void* wm_vulnerability_scanner_main(wm_vulnerability_scanner_t* data) {
                                     getDefine_Int_default("vulnerability-detection", "scan_workers", 0, 64, 0));
 
             cJSON_AddNumberToObject(config_json,
+                                    "scanDispatchQueueSlots",
+                                    getDefine_Int_default("vulnerability-detection", "scan_dispatch_queue_slots", 0, 256, 0));
+
+            cJSON_AddNumberToObject(config_json,
                                     "reportQueueSize",
                                     getDefine_Int_default("vulnerability-detection", "report_queue_size", 0, 2147483647, 262144));
 

--- a/src/wazuh_modules/src/wm_vulnerability_scanner.c
+++ b/src/wazuh_modules/src/wm_vulnerability_scanner.c
@@ -82,6 +82,12 @@ void* wm_vulnerability_scanner_main(wm_vulnerability_scanner_t* data) {
                                     "managerDisabledScan",
                                     getDefine_Int_default("vulnerability-detection", "disable_scan_manager", 0, 1, 1));
 
+            // Concurrent scan slots (REQ-VDQ-7). 0 (unset) tells the C++ side to size the pool at
+            // half the host's cores (minimum 1); an explicit value here always wins.
+            cJSON_AddNumberToObject(config_json,
+                                    "scanWorkers",
+                                    getDefine_Int_default("vulnerability-detection", "scan_workers", 0, 64, 0));
+
             cJSON_AddNumberToObject(config_json,
                                     "reportQueueSize",
                                     getDefine_Int_default("vulnerability-detection", "report_queue_size", 0, 2147483647, 262144));

--- a/src/wazuh_modules/vulnerability_scanner/CMakeLists.txt
+++ b/src/wazuh_modules/vulnerability_scanner/CMakeLists.txt
@@ -162,6 +162,7 @@ target_link_libraries(
          urlrequest
          schema_validator
          wazuh_uds_http_server
+         wazuh_metrics
          gcc_s
          flatbuffers)
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanDispatcher.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanDispatcher.hpp
@@ -12,6 +12,7 @@
 #define _VD_SCAN_DISPATCHER_HPP
 
 #include "loggerHelper.h"
+#include "scanDispatcherMetrics.hpp"
 #include "vulnerabilityScannerDefs.hpp"
 #include "vulnerabilityScannerFacade.hpp"
 
@@ -89,15 +90,21 @@ public:
      *        hold logic out of the way for callers that have no indexer to watch.
      * @param retryInterval Hold re-check cadence; tests shrink it so hold cases run in
      *        milliseconds. Production keeps the default.
+     * @param metrics Registry to resolve this lane's queue instruments from. Null (the default,
+     *        and what most unit tests pass) leaves the instruments null too -- see
+     *        scanDispatcherMetrics.hpp's null-object note -- so every op below is then a no-op.
      */
     explicit VdScanDispatcher(ScanFn scanFn,
                               std::size_t queueSlots = DEFAULT_QUEUE_SLOTS,
                               AvailabilityFn indexerAvailable = {},
-                              std::chrono::milliseconds retryInterval = INDEXER_RETRY_INTERVAL)
+                              std::chrono::milliseconds retryInterval = INDEXER_RETRY_INTERVAL,
+                              const std::shared_ptr<wazuh::metrics::IManager>& metrics = nullptr)
         : m_scan(std::move(scanFn))
         , m_indexerAvailable(std::move(indexerAvailable))
         , m_queueSlots(queueSlots)
         , m_retryInterval(retryInterval)
+        , m_metrics(metrics ? vulnscan::scandispatcher::makeScanDispatcherMetrics(*metrics)
+                            : vulnscan::scandispatcher::ScanDispatcherMetrics {})
         , m_worker([this] { run(); })
     {
     }
@@ -130,6 +137,7 @@ public:
     Admission tryEnqueue(const std::string& agentId)
     {
         auto admission = Admission::Accepted;
+        bool enqueued = false;
         {
             std::lock_guard<std::mutex> lock {m_mutex};
             if (m_stopping)
@@ -147,7 +155,13 @@ public:
             else
             {
                 m_queue.emplace_back(agentId);
+                enqueued = true;
             }
+        }
+
+        if (enqueued)
+        {
+            vulnscan::scandispatcher::addQueueDepth(m_metrics, 1);
         }
 
         if (admission == Admission::Accepted)
@@ -156,6 +170,7 @@ public:
         }
         else if (admission == Admission::Full)
         {
+            vulnscan::scandispatcher::incQueueFull(m_metrics);
             // Deliberately outside the lock: the caller is a transport I/O thread, and a burst
             // that fills the lane is exactly when holding m_mutex to format a message hurts
             // most. Throttled because the peer is agent-driven -- a fleet-wide feed update
@@ -194,6 +209,10 @@ public:
             }
             m_stopping = true;
             abandoned.swap(m_queue);
+        }
+        if (!abandoned.empty())
+        {
+            vulnscan::scandispatcher::setQueueDepth(m_metrics, 0);
         }
         m_wake.notify_one();
         if (!abandoned.empty())
@@ -334,6 +353,7 @@ private:
                 agentId = std::move(m_queue.front());
                 m_queue.pop_front();
             }
+            vulnscan::scandispatcher::addQueueDepth(m_metrics, -1);
 
             try
             {
@@ -348,6 +368,7 @@ private:
                     if (!m_stopping)
                     {
                         m_queue.push_front(std::move(agentId));
+                        vulnscan::scandispatcher::addQueueDepth(m_metrics, 1);
                         deferredByScan = true;
                         continue;
                     }
@@ -365,6 +386,7 @@ private:
     AvailabilityFn m_indexerAvailable;
     std::size_t m_queueSlots;
     std::chrono::milliseconds m_retryInterval;
+    vulnscan::scandispatcher::ScanDispatcherMetrics m_metrics;
     std::mutex m_mutex;
     std::condition_variable m_wake;
     std::deque<std::string> m_queue;

--- a/src/wazuh_modules/vulnerability_scanner/src/scanDispatcher.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanDispatcher.hpp
@@ -38,9 +38,14 @@
  * this path structurally immune to the abandoned-responder bug class. The scan's own outcome is
  * observable in this module's log, never on this wire.
  *
- * ONE worker on purpose: ScanOrchestrator serializes every scan behind a process-wide exclusive
- * lock anyway, so more workers would only hide requests inside blocked threads. The bounded
- * queue is the actual backpressure this path never had: beyond it, an immediate 503
+ * ONE worker for now, not because more would be wasted: ScanOrchestrator no longer serializes
+ * every scan behind a single process-wide exclusive lock (REQ-VDQ-7) -- it takes a shared_lock
+ * and checks out one of a small per-slot pool ("scanWorkers", <=0 -> half the host's cores,
+ * minimum 1), so additional dispatcher workers WOULD let independent agents' scans run
+ * concurrently. This lane stays at one until real benchmark data justifies raising it in step
+ * with "scanWorkers" -- a perf-tuning decision, not a safety one; see the module's
+ * architecture.md "Concurrency" section.
+ * The bounded queue is the actual backpressure this path never had: beyond it, an immediate 503
  * `scan_queue_full` the peers already treat as retry-next-notify.
  *
  * The one thing that pauses the drain is an indexer outage: a scan can neither read inventory

--- a/src/wazuh_modules/vulnerability_scanner/src/scanDispatcher.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanDispatcher.hpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <chrono>
 #include <condition_variable>
+#include <cstdint>
 #include <deque>
 #include <functional>
 #include <mutex>
@@ -355,9 +356,18 @@ private:
             }
             vulnscan::scandispatcher::addQueueDepth(m_metrics, -1);
 
+            const auto scanStart = std::chrono::steady_clock::now();
+            const auto observeScanDuration = [this, &scanStart]
+            {
+                const auto elapsed =
+                    std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - scanStart)
+                        .count();
+                vulnscan::scandispatcher::observeScanDuration(m_metrics, static_cast<std::uint64_t>(elapsed));
+            };
             try
             {
                 const auto result = m_scan(agentId);
+                observeScanDuration();
                 if (result == ScanResult::IndexerUnavailable)
                 {
                     // The outage started -- or was finally observed -- mid-scan. The promise
@@ -377,6 +387,7 @@ private:
             }
             catch (const std::exception& e)
             {
+                observeScanDuration();
                 logWarn(WM_VULNSCAN_LOGTAG, "Failed to process scan request: %s", e.what());
             }
         }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanDispatcherMetrics.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanDispatcherMetrics.hpp
@@ -39,6 +39,7 @@ namespace vulnscan::scandispatcher
     // coherent namespace and no two components invent competing names for the same thing.
     constexpr auto METRIC_QUEUE_DEPTH {"vd.dispatch.queue.depth"};
     constexpr auto METRIC_QUEUE_FULL {"vd.dispatch.queue.full.total"};
+    constexpr auto METRIC_SCAN_DURATION {"vd.dispatch.scan.duration"};
 
     /**
      * @brief The dispatch queue's instrument set, pre-resolved from one manager.
@@ -49,6 +50,9 @@ namespace vulnscan::scandispatcher
         std::shared_ptr<wazuh::metrics::IGaugeInt> queueDepth;
         /// 503s: a request arrived while the queue was already at its ceiling.
         std::shared_ptr<wazuh::metrics::ICounter> queueFull;
+        /// Time inside the scan call itself (m_scan()), on every attempt -- success or
+        /// exception alike. Same convention as inventory_sync_server's vd.scan.duration.
+        std::shared_ptr<wazuh::metrics::IHistogram> scanDuration;
     };
 
     /// Resolves the vd.dispatch.* family on @p manager (creating it on first call; totals carry
@@ -59,7 +63,9 @@ namespace vulnscan::scandispatcher
             manager.getOrCreateGaugeInt(
                 METRIC_QUEUE_DEPTH, "VD sessions queued in the on-demand dispatch lane", "items"),
             manager.getOrCreateCounter(
-                METRIC_QUEUE_FULL, "On-demand scan requests refused because the dispatch queue was full", "count")};
+                METRIC_QUEUE_FULL, "On-demand scan requests refused because the dispatch queue was full", "count"),
+            manager.getOrCreateHistogram(
+                METRIC_SCAN_DURATION, "Time inside the vulnerability scanner (on-demand path)", "microseconds")};
     }
 
     /// Moves the depth gauge by @p delta (positive on enqueue/requeue, negative on dequeue).
@@ -85,6 +91,16 @@ namespace vulnscan::scandispatcher
         if (m.queueFull)
         {
             m.queueFull->add();
+        }
+    }
+
+    /// Records one m_scan() attempt's duration, in microseconds. Call on both the success and
+    /// the exception path -- see the class comment on the observe-unconditionally convention.
+    inline void observeScanDuration(const ScanDispatcherMetrics& m, std::uint64_t micros)
+    {
+        if (m.scanDuration)
+        {
+            m.scanDuration->observe(micros);
         }
     }
 

--- a/src/wazuh_modules/vulnerability_scanner/src/scanDispatcherMetrics.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanDispatcherMetrics.hpp
@@ -1,0 +1,93 @@
+/*
+ * Wazuh Vulnerability scanner
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _VULNSCAN_SCAN_DISPATCHER_METRICS_HPP
+#define _VULNSCAN_SCAN_DISPATCHER_METRICS_HPP
+
+/**
+ * @file scanDispatcherMetrics.hpp
+ * @brief The on-demand `POST /scan/vd` dispatch queue's metric catalog (`vd.dispatch.*`) on the
+ * shared `wazuh_metrics` registry.
+ *
+ * Same shape as remoted's per-subsystem metrics files (control/metrics.hpp,
+ * scanvd/scanVdMetrics.hpp): the instruments live in the facade's metric manager, this struct
+ * only caches the resolved shared_ptrs (resolve once via makeScanDispatcherMetrics(), then every
+ * op afterwards is a single relaxed atomic call), and a default-constructed struct is the null
+ * object that counts nothing -- so a bare `ScanDispatcherMetrics {}` stays a valid collaborator
+ * for VdScanDispatcher in tests that pass no manager.
+ *
+ * Separate prefix from inventory_sync_server's own vd.* names (vd.lane.depth,
+ * vd.capacity.503.total): those measure the session-sync path through VdScanLane, this measures
+ * the different, on-demand path through VdScanDispatcher.
+ */
+
+#include <cstdint>
+#include <memory>
+
+#include <wazuh_metrics/iManager.hpp>
+
+namespace vulnscan::scandispatcher
+{
+    // The vd.dispatch.* name catalog. Kept here (not per call-site) so the dump reads as one
+    // coherent namespace and no two components invent competing names for the same thing.
+    constexpr auto METRIC_QUEUE_DEPTH {"vd.dispatch.queue.depth"};
+    constexpr auto METRIC_QUEUE_FULL {"vd.dispatch.queue.full.total"};
+
+    /**
+     * @brief The dispatch queue's instrument set, pre-resolved from one manager.
+     */
+    struct ScanDispatcherMetrics
+    {
+        /// Items currently queued, not counting the one in flight.
+        std::shared_ptr<wazuh::metrics::IGaugeInt> queueDepth;
+        /// 503s: a request arrived while the queue was already at its ceiling.
+        std::shared_ptr<wazuh::metrics::ICounter> queueFull;
+    };
+
+    /// Resolves the vd.dispatch.* family on @p manager (creating it on first call; totals carry
+    /// over on later calls because getOrCreate* dedupes by name).
+    inline ScanDispatcherMetrics makeScanDispatcherMetrics(wazuh::metrics::IManager& manager)
+    {
+        return ScanDispatcherMetrics {
+            manager.getOrCreateGaugeInt(
+                METRIC_QUEUE_DEPTH, "VD sessions queued in the on-demand dispatch lane", "items"),
+            manager.getOrCreateCounter(
+                METRIC_QUEUE_FULL, "On-demand scan requests refused because the dispatch queue was full", "count")};
+    }
+
+    /// Moves the depth gauge by @p delta (positive on enqueue/requeue, negative on dequeue).
+    inline void addQueueDepth(const ScanDispatcherMetrics& m, std::int64_t delta)
+    {
+        if (m.queueDepth)
+        {
+            m.queueDepth->add(delta);
+        }
+    }
+
+    /// Snaps the depth gauge to an exact value (used only when the whole queue is dropped at once).
+    inline void setQueueDepth(const ScanDispatcherMetrics& m, std::int64_t value)
+    {
+        if (m.queueDepth)
+        {
+            m.queueDepth->set(value);
+        }
+    }
+
+    inline void incQueueFull(const ScanDispatcherMetrics& m)
+    {
+        if (m.queueFull)
+        {
+            m.queueFull->add();
+        }
+    }
+
+} // namespace vulnscan::scandispatcher
+
+#endif // _VULNSCAN_SCAN_DISPATCHER_METRICS_HPP

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentList.hpp
@@ -17,10 +17,12 @@
 #include "indexerConnector.hpp"
 #include "json.hpp"
 #include "loggerHelper.h"
+#include "scanAgentListMetrics.hpp"
 #include "scanContext.hpp"
 #include "stringHelper.h"
 #include "vulnerabilityScannerSync.hpp"
 #include <chrono>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
@@ -42,6 +44,7 @@ public:
 private:
     std::shared_ptr<TIndexerConnector> m_indexerConnector;
     ScanRunner m_scanRunner;
+    vulnscan::scanagentlist::ScanAgentListMetrics m_metrics;
     static constexpr size_t DEFAULT_PAGE_SIZE = 1000;
 
     static nlohmann::json buildInventoryQuery(const std::string& agentId,
@@ -514,10 +517,19 @@ public:
      *
      * @param indexerConnector Indexer connector instance.
      * @param scanRunner Function that executes the scan for a prepared ScanContext.
+     * @param metrics Registry to resolve the vd.sweep.* instruments from. Null (the default)
+     *        leaves them null too, so every op is a no-op -- pass a real manager ONLY from the
+     *        disconnected-agent sweep's construction site (rescanDisconnectedAgents()), not
+     *        from the on-demand single-agent one (triggerAgentScan()), so these metrics count
+     *        sweep-driven scans exclusively; see scanAgentListMetrics.hpp.
      */
-    explicit TScanAgentList(std::shared_ptr<TIndexerConnector> indexerConnector, ScanRunner scanRunner)
+    explicit TScanAgentList(std::shared_ptr<TIndexerConnector> indexerConnector,
+                            ScanRunner scanRunner,
+                            const std::shared_ptr<wazuh::metrics::IManager>& metrics = nullptr)
         : m_indexerConnector(std::move(indexerConnector))
         , m_scanRunner(std::move(scanRunner))
+        , m_metrics(metrics ? vulnscan::scanagentlist::makeScanAgentListMetrics(*metrics)
+                            : vulnscan::scanagentlist::ScanAgentListMetrics {})
     {
     }
 
@@ -543,13 +555,25 @@ public:
 
         for (const auto& agent : data->m_agents)
         {
+            const auto scanStart = std::chrono::steady_clock::now();
+            const auto observeScanDuration = [this, &scanStart]
+            {
+                const auto elapsed =
+                    std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - scanStart)
+                        .count();
+                vulnscan::scanagentlist::observeScanDuration(m_metrics, static_cast<std::uint64_t>(elapsed));
+            };
             try
             {
                 logDebug2(WM_VULNSCAN_LOGTAG, "Processing agent %s", agent.id.c_str());
                 scanAgent(agent, data->isNoIndex(), std::string(data->managerClusterName()));
+                observeScanDuration();
+                vulnscan::scanagentlist::incScansOk(m_metrics);
             }
             catch (const std::exception& e)
             {
+                observeScanDuration();
+                vulnscan::scanagentlist::incScansFailed(m_metrics);
                 logWarn(WM_VULNSCAN_LOGTAG, "Error executing scan for agent %s: %s.", agent.id.c_str(), e.what());
                 data->m_agentsWithIncompletedScan.push_back(agent);
             }

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentListMetrics.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanAgentListMetrics.hpp
@@ -1,0 +1,99 @@
+/*
+ * Wazuh Vulnerability scanner - Scan Orchestrator
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef _SCAN_AGENT_LIST_METRICS_HPP
+#define _SCAN_AGENT_LIST_METRICS_HPP
+
+/**
+ * @file scanAgentListMetrics.hpp
+ * @brief The disconnected-agent sweep's metric catalog (`vd.sweep.*`) on the shared
+ * `wazuh_metrics` registry.
+ *
+ * Same shape as scanDispatcherMetrics.hpp (itself mirroring remoted's per-subsystem metrics
+ * files): a resolved struct-of-shared_ptrs, a make*Metrics() resolver, free wrapper functions,
+ * and a null-object default so a bare `ScanAgentListMetrics {}` stays a valid collaborator for
+ * TScanAgentList in tests that pass no manager.
+ *
+ * TScanAgentList is ALSO used, unmetered, by the on-demand single-agent path
+ * (VulnerabilityScannerFacade::triggerAgentScan) -- that call site passes no manager here on
+ * purpose, since its own timing is already vd.dispatch.scan.duration (scanDispatcherMetrics.hpp)
+ * at the VdScanDispatcher level. Only the sweep's construction site
+ * (rescanDisconnectedAgents()) passes a real manager, so these vd.sweep.* metrics count
+ * sweep-driven scans exclusively, never on-demand ones.
+ */
+
+#include <cstdint>
+#include <memory>
+
+#include <wazuh_metrics/iManager.hpp>
+
+namespace vulnscan::scanagentlist
+{
+    // The vd.sweep.* name catalog.
+    constexpr auto METRIC_SCAN_DURATION {"vd.sweep.scan.duration"};
+    constexpr auto METRIC_SCANS_OK {"vd.sweep.scans.ok"};
+    constexpr auto METRIC_SCANS_FAILED {"vd.sweep.scans.failed"};
+
+    /**
+     * @brief The sweep's instrument set, pre-resolved from one manager.
+     */
+    struct ScanAgentListMetrics
+    {
+        /// Time inside the scan call itself, per disconnected agent, on every attempt --
+        /// success or exception alike. Same convention as inventory_sync_server's
+        /// vd.scan.duration and this module's own vd.dispatch.scan.duration.
+        std::shared_ptr<wazuh::metrics::IHistogram> scanDuration;
+        /// Disconnected agents the sweep scanned without the per-agent call throwing.
+        std::shared_ptr<wazuh::metrics::ICounter> scansOk;
+        /// Disconnected agents whose scan threw (added to the sweep's incomplete-scan retry list).
+        std::shared_ptr<wazuh::metrics::ICounter> scansFailed;
+    };
+
+    /// Resolves the vd.sweep.* family on @p manager (creating it on first call; totals carry
+    /// over on later calls because getOrCreate* dedupes by name).
+    inline ScanAgentListMetrics makeScanAgentListMetrics(wazuh::metrics::IManager& manager)
+    {
+        return ScanAgentListMetrics {
+            manager.getOrCreateHistogram(METRIC_SCAN_DURATION,
+                                         "Time inside the vulnerability scanner (disconnected-agent sweep)",
+                                         "microseconds"),
+            manager.getOrCreateCounter(METRIC_SCANS_OK, "Disconnected-agent sweep scans that completed", "count"),
+            manager.getOrCreateCounter(METRIC_SCANS_FAILED, "Disconnected-agent sweep scans that failed", "count")};
+    }
+
+    /// Records one per-agent scan attempt's duration, in microseconds. Call on both the success
+    /// and the exception path.
+    inline void observeScanDuration(const ScanAgentListMetrics& m, std::uint64_t micros)
+    {
+        if (m.scanDuration)
+        {
+            m.scanDuration->observe(micros);
+        }
+    }
+
+    inline void incScansOk(const ScanAgentListMetrics& m)
+    {
+        if (m.scansOk)
+        {
+            m.scansOk->add();
+        }
+    }
+
+    inline void incScansFailed(const ScanAgentListMetrics& m)
+    {
+        if (m.scansFailed)
+        {
+            m.scansFailed->add();
+        }
+    }
+
+} // namespace vulnscan::scanagentlist
+
+#endif // _SCAN_AGENT_LIST_METRICS_HPP

--- a/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/scanOrchestrator/scanOrchestrator.hpp
@@ -14,13 +14,16 @@
 
 #include <algorithm>
 #include <chrono>
+#include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
 #include <simdjson.h>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <variant>
+#include <vector>
 
 #include "databaseFeedManager/databaseFeedManager.hpp"
 #include "factoryOrchestrator.hpp"
@@ -47,7 +50,7 @@ class TScanOrchestrator final
 {
 public:
     /**
-     * @brief Class constructor.
+     * @brief Class constructor (single-slot convenience overload; pool size 1).
      *
      * @param indexerConnector Indexer connector.
      * @param databaseFeedManager Database feed manager.
@@ -56,19 +59,56 @@ public:
     explicit TScanOrchestrator(std::shared_ptr<TIndexerConnector> indexerConnector,
                                std::shared_ptr<TDatabaseFeedManager> databaseFeedManager,
                                std::shared_mutex& mutex)
-        : m_indexerConnector(std::move(indexerConnector))
-        , m_databaseFeedManager(std::move(databaseFeedManager))
-        , m_mutex(mutex)
+        : TScanOrchestrator(std::vector<std::shared_ptr<TIndexerConnector>> {std::move(indexerConnector)},
+                            std::move(databaseFeedManager),
+                            mutex)
     {
-        // Build orchestration chains once (reusable across scans)
-        m_packageDeltaOrchestration =
-            TFactoryOrchestrator::create(ScannerType::PackagesDelta, m_databaseFeedManager, m_indexerConnector);
+    }
 
-        m_firstFullScanOrchestration =
-            TFactoryOrchestrator::create(ScannerType::FirstFullScan, m_databaseFeedManager, m_indexerConnector);
+    /**
+     * @brief Class constructor with an explicit pool of indexer connectors (REQ-VDQ-7).
+     *
+     * One Slot -- its own orchestration chains plus its own indexer connector -- is built per
+     * vector entry, so concurrent scans that check out different slots never share PackageScanner's
+     * per-instance statistics/cache (scanOrchestrator_test.cpp's package-scanner hazard) nor an
+     * IndexerConnectorSync's own internal mutex (the second bottleneck REQ-VDQ-7 calls out).
+     * DatabaseFeedManager and its global maps stay the ONE shared, shared_lock-protected
+     * collaborator every slot reads from -- see the class-level comment on m_mutex.
+     *
+     * @param indexerConnectors One connector per pool slot. Must not be empty; callers typically
+     *                          share a single IndexerSession across all of them (see
+     *                          VulnerabilityScannerFacade::start()) so raising pool size costs no
+     *                          extra health-check round-trips.
+     * @param databaseFeedManager Database feed manager.
+     * @param mutex Mutex to protect the access to the internal databases.
+     */
+    explicit TScanOrchestrator(std::vector<std::shared_ptr<TIndexerConnector>> indexerConnectors,
+                               std::shared_ptr<TDatabaseFeedManager> databaseFeedManager,
+                               std::shared_mutex& mutex)
+        : m_databaseFeedManager(std::move(databaseFeedManager))
+        , m_mutex(mutex)
+        , m_slotBusy(indexerConnectors.size(), false)
+    {
+        if (indexerConnectors.empty())
+        {
+            throw std::invalid_argument("ScanOrchestrator needs at least one indexer connector");
+        }
 
-        m_fullScanOrchestration =
-            TFactoryOrchestrator::create(ScannerType::FullScan, m_databaseFeedManager, m_indexerConnector);
+        m_slots.reserve(indexerConnectors.size());
+        for (auto& connector : indexerConnectors)
+        {
+            // Build each slot's orchestration chains once (reusable across scans that land on
+            // this slot); a different slot's PackageScanner is a different instance.
+            Slot slot;
+            slot.indexerConnector = std::move(connector);
+            slot.packageDeltaOrchestration =
+                TFactoryOrchestrator::create(ScannerType::PackagesDelta, m_databaseFeedManager, slot.indexerConnector);
+            slot.firstFullScanOrchestration =
+                TFactoryOrchestrator::create(ScannerType::FirstFullScan, m_databaseFeedManager, slot.indexerConnector);
+            slot.fullScanOrchestration =
+                TFactoryOrchestrator::create(ScannerType::FullScan, m_databaseFeedManager, slot.indexerConnector);
+            m_slots.push_back(std::move(slot));
+        }
     }
 
     ~TScanOrchestrator() = default;
@@ -88,7 +128,13 @@ public:
         const char* optionName = info.vdFirst ? "VDFirst" : "VDSync";
         const std::string agentId {info.agentId};
 
-        std::unique_lock<std::shared_mutex> lock(m_mutex, std::defer_lock);
+        // Checked out before the shared lock so a caller stuck waiting for a free slot never
+        // holds a reader on m_mutex meanwhile -- otherwise a saturated pool would make a
+        // pending DatabaseFeedManager::reloadGlobalMaps() (the exclusive side of this same
+        // mutex) wait out the slot queue on top of every scan already in progress.
+        auto slotHandle = checkoutSlot(agentId, optionName);
+
+        std::shared_lock<std::shared_mutex> lock(m_mutex, std::defer_lock);
         if (!lock.try_lock())
         {
             logDebug2(WM_VULNSCAN_LOGTAG,
@@ -106,7 +152,7 @@ public:
         }
 
         return executeSessionScan(
-            scanContext, info.vdFirst, info.indices, agentId, std::string {info.agentVersion}, optionName);
+            *slotHandle, scanContext, info.vdFirst, info.indices, agentId, std::string {info.agentVersion}, optionName);
     }
 
     /**
@@ -122,7 +168,11 @@ public:
             return;
         }
 
-        std::unique_lock<std::shared_mutex> lock(m_mutex, std::defer_lock);
+        // Checked out before the shared lock for the same reason as runScanFromViews(): a
+        // caller stuck waiting for a free slot must never hold a reader on m_mutex meanwhile.
+        auto slotHandle = checkoutSlot(std::string {scanContext->agentId()}, "feed_update");
+
+        std::shared_lock<std::shared_mutex> lock(m_mutex, std::defer_lock);
         if (lockScan)
         {
             if (!lock.try_lock())
@@ -140,10 +190,10 @@ public:
                 scanContext->agentVersion().data());
 
         {
-            auto indexerLock = m_indexerConnector->scopeLock();
-            m_fullScanOrchestration->handleRequest(scanContext);
+            auto indexerLock = slotHandle->indexerConnector->scopeLock();
+            slotHandle->fullScanOrchestration->handleRequest(scanContext);
         }
-        m_indexerConnector->flush();
+        slotHandle->indexerConnector->flush();
 
         logInfo(WM_VULNSCAN_LOGTAG,
                 "Vulnerability scan completed: agent='%s' type=full reason=feed_update",
@@ -154,17 +204,123 @@ private:
     SCAN_ORCHESTRATOR_FRIEND_TEST_DECLARATIONS;
 
     /**
+     * @brief One pool slot: its own orchestration chains and its own indexer connector.
+     *
+     * Kept together because both hold per-scan mutable state (PackageScanner's statistics/L1
+     * cache; IndexerConnectorSync's staged bulk buffer) that must never be touched by two scans
+     * at once -- see the constructor comment above and REQ-VDQ-7 in
+     * inventory_sync_server/README.md.
+     */
+    struct Slot
+    {
+        std::shared_ptr<TIndexerConnector> indexerConnector;
+        std::shared_ptr<TOrchestrationNode> packageDeltaOrchestration;
+        std::shared_ptr<TOrchestrationNode> firstFullScanOrchestration;
+        std::shared_ptr<TOrchestrationNode> fullScanOrchestration;
+    };
+
+    /**
+     * @brief RAII handle over one checked-out slot; returns it to the pool on destruction.
+     */
+    class SlotHandle final
+    {
+    public:
+        SlotHandle(const TScanOrchestrator& owner, std::size_t index)
+            : m_owner(&owner)
+            , m_index(index)
+        {
+        }
+        ~SlotHandle()
+        {
+            if (m_owner)
+            {
+                m_owner->releaseSlot(m_index);
+            }
+        }
+
+        SlotHandle(const SlotHandle&) = delete;
+        SlotHandle& operator=(const SlotHandle&) = delete;
+        SlotHandle(SlotHandle&& other) noexcept
+            : m_owner(other.m_owner)
+            , m_index(other.m_index)
+        {
+            other.m_owner = nullptr;
+        }
+        SlotHandle& operator=(SlotHandle&&) = delete;
+
+        const Slot& operator*() const
+        {
+            return m_owner->m_slots[m_index];
+        }
+        const Slot* operator->() const
+        {
+            return &m_owner->m_slots[m_index];
+        }
+
+    private:
+        const TScanOrchestrator* m_owner;
+        std::size_t m_index;
+    };
+
+    /**
+     * @brief Check out a free slot, blocking (with a debug log, like the outer VD lock above)
+     *        while every slot is busy.
+     */
+    SlotHandle checkoutSlot(const std::string& agentId, const char* optionName) const
+    {
+        std::unique_lock<std::mutex> poolLock(m_poolMutex);
+        auto findFreeSlot = [this]() -> std::size_t
+        {
+            for (std::size_t i = 0; i < m_slotBusy.size(); ++i)
+            {
+                if (!m_slotBusy[i])
+                {
+                    return i;
+                }
+            }
+            return m_slotBusy.size();
+        };
+
+        auto index = findFreeSlot();
+        if (index == m_slotBusy.size())
+        {
+            logDebug2(WM_VULNSCAN_LOGTAG,
+                      "Vulnerability scan waiting for a free scan slot: agent='%s' option=%s",
+                      agentId.c_str(),
+                      optionName);
+            m_poolCv.wait(poolLock, [&]() { return (index = findFreeSlot()) != m_slotBusy.size(); });
+        }
+
+        m_slotBusy[index] = true;
+        return SlotHandle(*this, index);
+    }
+
+    /**
+     * @brief Return a checked-out slot to the free pool and wake one waiter, if any.
+     */
+    void releaseSlot(std::size_t index) const
+    {
+        {
+            std::lock_guard<std::mutex> poolLock(m_poolMutex);
+            m_slotBusy[index] = false;
+        }
+        m_poolCv.notify_one();
+    }
+
+    /**
      * @brief The one session-scan execution path.
      *
-     * The caller holds m_mutex (exclusive) and provides an already-populated context. Behavior is
-     * byte-for-byte the legacy switch: VDFirst = empty-inventory guard, pre-rescan deleteByQuery
-     * scoped to agent+cluster, FirstFullScan chain; VDSync = full when Start.index carries the OS
-     * or hotfix index, package delta otherwise, empty inventory warns and proceeds. Both flush the
-     * scanner's own connector before returning.
+     * The caller holds m_mutex (shared) and a checked-out Slot, and provides an
+     * already-populated context. Behavior is byte-for-byte the legacy switch: VDFirst =
+     * empty-inventory guard, pre-rescan deleteByQuery scoped to agent+cluster, FirstFullScan
+     * chain; VDSync = full when Start.index carries the OS or hotfix index, package delta
+     * otherwise, empty inventory warns and proceeds. Both flush the checked-out connector before
+     * returning.
      *
      * @return true when a scan executed; false when the VDFirst guard aborted it.
      */
-    bool executeSessionScan(std::shared_ptr<TScanContext>& scanContext,
+    bool executeSessionScan(const Slot& slot,
+                            std::shared_ptr<TScanContext>& scanContext,
                             bool vdFirst,
                             const std::vector<std::string>& indices,
                             const std::string& agentId,
@@ -203,13 +359,13 @@ private:
             }
 
             {
-                auto indexerLock = m_indexerConnector->scopeLock();
+                auto indexerLock = slot.indexerConnector->scopeLock();
                 // Scope the pre-rescan delete by agent.id and the manager cluster.
-                m_indexerConnector->deleteByQuery(
+                slot.indexerConnector->deleteByQuery(
                     "wazuh-states-vulnerabilities", agentId, std::string(scanContext->managerClusterName()));
-                m_firstFullScanOrchestration->handleRequest(scanContext);
+                slot.firstFullScanOrchestration->handleRequest(scanContext);
             }
-            m_indexerConnector->flush();
+            slot.indexerConnector->flush();
             logInfo(WM_VULNSCAN_LOGTAG,
                     "Agent '%s' - First vulnerability scan completed: vulnerabilities indexed, "
                     "no security alerts generated (alerts are suppressed on first scan)",
@@ -243,17 +399,17 @@ private:
             }
 
             {
-                auto indexerLock = m_indexerConnector->scopeLock();
+                auto indexerLock = slot.indexerConnector->scopeLock();
                 if (hasOsOrHotfixChange)
                 {
-                    m_fullScanOrchestration->handleRequest(scanContext);
+                    slot.fullScanOrchestration->handleRequest(scanContext);
                 }
                 else
                 {
-                    m_packageDeltaOrchestration->handleRequest(scanContext);
+                    slot.packageDeltaOrchestration->handleRequest(scanContext);
                 }
             }
-            m_indexerConnector->flush();
+            slot.indexerConnector->flush();
 
             scanExecuted = true;
         }
@@ -960,14 +1116,14 @@ private:
     }
 
     // Dependencies
-    std::shared_ptr<TIndexerConnector> m_indexerConnector;
     std::shared_ptr<TDatabaseFeedManager> m_databaseFeedManager;
     std::shared_mutex& m_mutex;
 
-    // Orchestration chains (built once, reused)
-    std::shared_ptr<TOrchestrationNode> m_packageDeltaOrchestration;
-    std::shared_ptr<TOrchestrationNode> m_firstFullScanOrchestration;
-    std::shared_ptr<TOrchestrationNode> m_fullScanOrchestration;
+    // Pool of per-slot chains + connectors (REQ-VDQ-7); index 0 is the only slot at pool size 1.
+    std::vector<Slot> m_slots;
+    mutable std::mutex m_poolMutex;           ///< Guards m_slotBusy only; m_mutex above is separate.
+    mutable std::condition_variable m_poolCv; ///< Wakes a waiter when checkoutSlot() releases a slot.
+    mutable std::vector<bool> m_slotBusy;
 };
 
 using ScanOrchestrator = TScanOrchestrator<>;

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScanner.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScanner.cpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <uds_http_server/IUdsHttpServer.hpp>
 #include <uds_http_server/udsHttpServerFactory.hpp>
+#include <wazuh_metrics/jsonDump.hpp>
 
 namespace Log
 {
@@ -90,11 +91,26 @@ extern "C"
         // $WAZUH_HOME/queue/sockets/vd.sock.
         try
         {
+            // internal-options first; 0 (unset) falls back to VdScanDispatcher's own default --
+            // the same convention "scanWorkers" already uses.
+            std::size_t scanDispatchQueueSlots = 0;
+            if (configurationNlohmann.contains("scanDispatchQueueSlots") &&
+                configurationNlohmann.at("scanDispatchQueueSlots").is_number())
+            {
+                scanDispatchQueueSlots = configurationNlohmann.at("scanDispatchQueueSlots").get<std::size_t>();
+            }
+            if (scanDispatchQueueSlots == 0)
+            {
+                scanDispatchQueueSlots = VdScanDispatcher::DEFAULT_QUEUE_SLOTS;
+            }
+
             g_scanDispatcher = std::make_unique<VdScanDispatcher>(
                 [](const std::string& agentId)
                 { return VulnerabilityScannerFacade::instance().triggerAgentScan(agentId); },
-                VdScanDispatcher::DEFAULT_QUEUE_SLOTS,
-                []() { return VulnerabilityScannerFacade::instance().isIndexerAvailable(); });
+                scanDispatchQueueSlots,
+                []() { return VulnerabilityScannerFacade::instance().isIndexerAvailable(); },
+                VdScanDispatcher::INDEXER_RETRY_INTERVAL,
+                VulnerabilityScannerFacade::instance().metricsManager());
 
             g_vdServer = wazuh::uds_http::makeUdsHttpServer();
 
@@ -117,6 +133,34 @@ extern "C"
                 {
                     responder->send(wazuh::uds_http::HttpResponse::json(
                         200, VulnerabilityScannerFacade::instance().getReadinessStatus().dump()));
+                },
+                wazuh::uds_http::RouteOptions {wazuh::uds_http::RouteClass::Liveness});
+
+            // GET /metrics: dump the module's whole registry (vd.dispatch.*, and whatever else
+            // registers on this manager later). Budget-exempt like the two probes above --
+            // reading metrics is most valuable exactly when the byte budget is under pressure.
+            // The manager is captured weakly for consistency with remoted's and
+            // inventory_sync_server's own /metrics (503 when gone), even though this facade
+            // never resets its manager -- counters survive restart retries on purpose.
+            g_vdServer->addRoute(
+                wazuh::uds_http::Method::Get,
+                "/metrics",
+                [weakManager =
+                     std::weak_ptr<wazuh::metrics::IManager>(VulnerabilityScannerFacade::instance().metricsManager())](
+                    std::shared_ptr<const wazuh::uds_http::HttpRequest>,
+                    std::shared_ptr<wazuh::uds_http::IHttpResponder> responder)
+                {
+                    const auto manager = weakManager.lock();
+                    if (!manager)
+                    {
+                        responder->send(
+                            wazuh::uds_http::HttpResponse::json(503, R"({"error":"Service unavailable","code":503})"));
+                        return;
+                    }
+                    wazuh::metrics::DumpOptions options;
+                    options.daemonName = "vulnerability_scanner";
+                    responder->send(
+                        wazuh::uds_http::HttpResponse::json(200, wazuh::metrics::dumpJson(*manager, options)));
                 },
                 wazuh::uds_http::RouteOptions {wazuh::uds_http::RouteClass::Liveness});
 

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -513,16 +513,20 @@ void VulnerabilityScannerFacade::rescanDisconnectedAgents()
     }
 
     auto buildDisconnected = std::make_shared<BuildDisconnectedAgentListContext>();
-    auto scanAgents =
-        std::make_shared<ScanAgentList>(m_indexerConnector,
-                                        [this](std::shared_ptr<ScanContext> agentContext)
-                                        {
-                                            if (m_shouldStop.load(std::memory_order_acquire))
-                                            {
-                                                return;
-                                            }
-                                            m_scanOrchestrator->runScanAfterFeedUpdate(std::move(agentContext));
-                                        });
+    // The metrics manager is passed here (the sweep's own construction site) and ONLY here --
+    // see scanAgentListMetrics.hpp's doc comment on why triggerAgentScan()'s ScanAgentList below
+    // stays unmetered, so vd.sweep.* counts sweep-driven scans exclusively.
+    auto scanAgents = std::make_shared<ScanAgentList>(
+        m_indexerConnector,
+        [this](std::shared_ptr<ScanContext> agentContext)
+        {
+            if (m_shouldStop.load(std::memory_order_acquire))
+            {
+                return;
+            }
+            m_scanOrchestrator->runScanAfterFeedUpdate(std::move(agentContext));
+        },
+        m_metricsManager);
 
     buildDisconnected->setLast(scanAgents);
 

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -13,6 +13,7 @@
 #include "defs.h"
 #include "indexerConnector.hpp"
 #include "loggerHelper.h"
+#include "proc.hpp"
 #include "scanOrchestrator.hpp"
 #include "scanOrchestrator/agentReScanListException.hpp"
 #include "scanOrchestrator/buildAgentContext.hpp"
@@ -27,6 +28,7 @@
 #include <mutex>
 #include <string>
 #include <string_view>
+#include <vector>
 
 constexpr auto STATES_VD_INDEX_NAME_PREFIX {"wazuh-states-vulnerabilities"};
 
@@ -345,8 +347,37 @@ void VulnerabilityScannerFacade::start(
             return updaterConfig;
         };
 
-        m_indexerConnector = std::make_shared<IndexerConnectorSync>(buildIndexerConfig(),
-                                                                    LoggingContext {WM_VULNSCAN_LOGTAG, logFunction});
+        // internal-options first; 0 (unset) falls back to half the host's cores, at least one --
+        // the same convention inventory_sync_server's sync_workers already uses.
+        uint32_t scanWorkers = 0;
+        if (configuration.contains("scanWorkers") && configuration.at("scanWorkers").is_number())
+        {
+            scanWorkers = configuration.at("scanWorkers").get<uint32_t>();
+        }
+        if (scanWorkers == 0)
+        {
+            const auto cores = cpp_get_nproc();
+            scanWorkers = cores / 2 > 0 ? cores / 2 : 1;
+        }
+
+        {
+            // One shared IndexerSession health-monitors the hosts once regardless of how many
+            // connectors are built from it (REQ-VDQ-7): scanWorkers > 1 costs no extra
+            // network round-trips at startup -- see IndexerSession's own doc comment.
+            const auto indexerConfig = buildIndexerConfig();
+            const IndexerSession indexerSession(indexerConfig, LoggingContext {WM_VULNSCAN_LOGTAG, logFunction});
+
+            m_scanConnectors.clear();
+            m_scanConnectors.reserve(scanWorkers);
+            for (uint32_t i = 0; i < scanWorkers; ++i)
+            {
+                m_scanConnectors.push_back(std::make_shared<IndexerConnectorSync>(
+                    indexerConfig, indexerSession, LoggingContext {WM_VULNSCAN_LOGTAG, logFunction}));
+            }
+        }
+        // Slot 0 doubles as ScanAgentList's read-only connector (fetchInventoryDocuments -- no
+        // scopeLock()/bulk calls there, so sharing it with the pool's first slot is safe).
+        m_indexerConnector = m_scanConnectors.front();
 
         uint32_t translationLruSize = DEFAULT_TRANSLATION_LRU_SIZE;
         if (configuration.contains("translationLRUSize") && configuration.at("translationLRUSize").is_number())
@@ -395,7 +426,7 @@ void VulnerabilityScannerFacade::start(
             [this]() { m_feedStatus.store(FeedStatus::FAILED, std::memory_order_release); });
 
         m_scanOrchestrator =
-            std::make_shared<ScanOrchestrator>(m_indexerConnector, m_databaseFeedManager, m_internalMutex);
+            std::make_shared<ScanOrchestrator>(m_scanConnectors, m_databaseFeedManager, m_internalMutex);
 
         // If the feed database already contains the global-map column families (incremental
         // update scenario) the feed is immediately usable for per-agent scans.  On a fresh
@@ -445,6 +476,7 @@ void VulnerabilityScannerFacade::stop()
     m_shouldStop.store(true, std::memory_order_release);
 
     m_indexerConnector.reset();
+    m_scanConnectors.clear();
     if (m_databaseFeedManager)
     {
         m_databaseFeedManager->teardown();

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.cpp
@@ -396,11 +396,6 @@ void VulnerabilityScannerFacade::start(
             initContentUpdater,
             [this](bool changed)
             {
-                m_lastSuccessfulUpdate.store(static_cast<uint64_t>(std::time(nullptr)), std::memory_order_release);
-                m_feedStatus.store(FeedStatus::READY, std::memory_order_release);
-                m_feedReady.store(true, std::memory_order_release);
-                logInfo(WM_VULNSCAN_LOGTAG, "CVE feed fully loaded — per-agent scans unblocked.");
-
                 // Connected agents detect the offset change themselves and request their own
                 // rescan via /scan/vd; only disconnected agents still need a manager-initiated
                 // sweep (see rescanDisconnectedAgents()). No reason to run either when the feed
@@ -410,16 +405,20 @@ void VulnerabilityScannerFacade::start(
                     logDebug2(WM_VULNSCAN_LOGTAG,
                               "Feed update cycle completed with no new CVE data — skipping disconnected-agent "
                               "rescan.");
-                    return;
                 }
-
-                if (shouldSkipPostUpdateScan())
+                else if (shouldSkipPostUpdateScan())
                 {
                     logDebug1(WM_VULNSCAN_LOGTAG, "Disconnected-agent rescan skipped: testtool override enabled.");
-                    return;
+                }
+                else
+                {
+                    rescanDisconnectedAgents();
                 }
 
-                rescanDisconnectedAgents();
+                m_lastSuccessfulUpdate.store(static_cast<uint64_t>(std::time(nullptr)), std::memory_order_release);
+                m_feedStatus.store(FeedStatus::READY, std::memory_order_release);
+                m_feedReady.store(true, std::memory_order_release);
+                logInfo(WM_VULNSCAN_LOGTAG, "CVE feed fully loaded — per-agent scans unblocked.");
             },
             nullptr,
             [this]() { m_feedStatus.store(FeedStatus::UPDATING, std::memory_order_release); },

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
@@ -24,6 +24,7 @@
 #include <shared_mutex>
 #include <string>
 #include <unordered_set>
+#include <vector>
 
 /**
  * @brief VulnerabilityScannerFacade class.
@@ -225,7 +226,10 @@ private:
     };
 
     std::shared_ptr<DatabaseFeedManager> m_databaseFeedManager;
-    std::shared_ptr<IndexerConnectorSync> m_indexerConnector;
+    std::shared_ptr<IndexerConnectorSync> m_indexerConnector; ///< Slot 0; also ScanAgentList's read-only connector.
+    /// One connector per ScanOrchestrator pool slot (REQ-VDQ-7); m_indexerConnector is entry 0.
+    /// Sized by the "scanWorkers" setting (<=0 -> half the host's cores, minimum 1) see ScanOrchestrator's slot pool.
+    std::vector<std::shared_ptr<IndexerConnectorSync>> m_scanConnectors;
     std::atomic<bool> m_shouldStop {false};
     std::shared_mutex m_internalMutex;
     std::atomic<bool> m_initialized {false};

--- a/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
+++ b/src/wazuh_modules/vulnerability_scanner/src/vulnerabilityScannerFacade.hpp
@@ -25,6 +25,7 @@
 #include <string>
 #include <unordered_set>
 #include <vector>
+#include <wazuh_metrics/manager.hpp>
 
 /**
  * @brief VulnerabilityScannerFacade class.
@@ -103,6 +104,19 @@ public:
     uint64_t currentFeedOffset() const
     {
         return m_databaseFeedManager ? m_databaseFeedManager->getLastOffset() : 0;
+    }
+
+    /**
+     * @brief This module's metrics registry, shared with anything that registers an instrument
+     * against it (currently VdScanDispatcher) and with the `GET /metrics` route.
+     *
+     * No process-wide singleton (mirrors inventory_sync_server's own IManager doc comment): the
+     * facade owns the one instance for this module's lifetime, so counters survive a restart
+     * retry on purpose.
+     */
+    std::shared_ptr<wazuh::metrics::IManager> metricsManager() const
+    {
+        return m_metricsManager;
     }
 
     /**
@@ -226,6 +240,7 @@ private:
     };
 
     std::shared_ptr<DatabaseFeedManager> m_databaseFeedManager;
+    const std::shared_ptr<wazuh::metrics::IManager> m_metricsManager {std::make_shared<wazuh::metrics::Manager>()};
     std::shared_ptr<IndexerConnectorSync> m_indexerConnector; ///< Slot 0; also ScanAgentList's read-only connector.
     /// One connector per ScanOrchestrator pool slot (REQ-VDQ-7); m_indexerConnector is entry 0.
     /// Sized by the "scanWorkers" setting (<=0 -> half the host's cores, minimum 1) see ScanOrchestrator's slot pool.

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanDispatcher_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanDispatcher_test.cpp
@@ -10,6 +10,10 @@
 
 #include "scanDispatcher.hpp"
 
+#include "scanDispatcherMetrics.hpp"
+
+#include <wazuh_metrics/manager.hpp>
+
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -225,6 +229,55 @@ TEST(VdScanDispatcherTest, AQueuedAgentCoalescesButTheInFlightOneDoesNot)
     const std::vector<std::string> expected {"A", "A", "B"};
     EXPECT_EQ(expected, scan.served)
         << "one in-flight run, ONE coalesced queued run, and the other agent -- nothing else";
+}
+
+TEST(VdScanDispatcherTest, QueueDepthGaugeTracksQueuedWorkAndDrainsToZero)
+{
+    const auto metrics = std::make_shared<wazuh::metrics::Manager>();
+    const auto depth = metrics->getOrCreateGaugeInt(vulnscan::scandispatcher::METRIC_QUEUE_DEPTH);
+
+    GatedScan scan;
+    VdScanDispatcher dispatcher {scan.fn(), 3, {}, VdScanDispatcher::INDEXER_RETRY_INTERVAL, metrics};
+
+    ASSERT_EQ(VdScanDispatcher::Admission::Accepted, dispatcher.tryEnqueue("0"));
+    ASSERT_TRUE(scan.waitForWaiters(1)) << "the first accepted request must be in flight before we measure depth";
+    EXPECT_EQ(0, depth->get()) << "the one in-flight scan was already popped -- nothing left queued yet";
+
+    ASSERT_EQ(VdScanDispatcher::Admission::Accepted, dispatcher.tryEnqueue("1"));
+    ASSERT_EQ(VdScanDispatcher::Admission::Accepted, dispatcher.tryEnqueue("2"));
+    ASSERT_EQ(VdScanDispatcher::Admission::Accepted, dispatcher.tryEnqueue("3"));
+    EXPECT_EQ(3, depth->get()) << "three genuinely queued behind the one in-flight scan";
+
+    scan.release();
+    ASSERT_TRUE(scan.waitForServed(4));
+    dispatcher.stop();
+    EXPECT_EQ(0, depth->get()) << "everything drained -- the gauge must return to zero, not linger";
+}
+
+TEST(VdScanDispatcherTest, QueueFullCounterTracksOnlyGenuineRejections)
+{
+    const auto metrics = std::make_shared<wazuh::metrics::Manager>();
+    const auto full = metrics->getOrCreateCounter(vulnscan::scandispatcher::METRIC_QUEUE_FULL);
+
+    GatedScan scan;
+    VdScanDispatcher dispatcher {scan.fn(), 1, {}, VdScanDispatcher::INDEXER_RETRY_INTERVAL, metrics};
+
+    ASSERT_EQ(VdScanDispatcher::Admission::Accepted, dispatcher.tryEnqueue("0"));
+    ASSERT_TRUE(scan.waitForWaiters(1)); // "0" now in flight, freeing the one queue slot
+    ASSERT_EQ(VdScanDispatcher::Admission::Accepted, dispatcher.tryEnqueue("1")); // fills that one slot
+    EXPECT_EQ(0U, full->get());
+
+    ASSERT_EQ(VdScanDispatcher::Admission::Full, dispatcher.tryEnqueue("2"));
+    ASSERT_EQ(VdScanDispatcher::Admission::Full, dispatcher.tryEnqueue("3"));
+    EXPECT_EQ(2U, full->get()) << "exactly the two genuinely-rejected requests, not the accepted ones";
+
+    // A repeat of an already-queued agent coalesces -- must not count as a rejection.
+    ASSERT_EQ(VdScanDispatcher::Admission::Accepted, dispatcher.tryEnqueue("1"));
+    EXPECT_EQ(2U, full->get());
+
+    scan.release();
+    ASSERT_TRUE(scan.waitForServed(2));
+    dispatcher.stop();
 }
 
 TEST(VdScanDispatcherTest, EveryOutcomeLeavesItsTerminalLogLine)

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_concurrency_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_concurrency_test.cpp
@@ -137,7 +137,12 @@ TEST_F(ScanOrchestratorTest, PoolBoundsConcurrencyToItsSlotCount)
                !maxObserved.compare_exchange_weak(previousMax, active, std::memory_order_relaxed))
         {
         }
-        std::this_thread::sleep_for(std::chrono::milliseconds(40));
+        // 300ms, not the original 40ms: under a TSAN build, thread-creation/scheduling
+        // latency alone can exceed 40ms, so 6 threads racing a 2-slot pool no longer
+        // reliably overlap and maxObserved never reaches 2 -- a false failure, not a
+        // real concurrency bug (confirmed by re-running this test standalone under
+        // -fsanitize=thread: 40ms fails every time, 300ms and 500ms both pass 5/5).
+        std::this_thread::sleep_for(std::chrono::milliseconds(300));
         activeCount.fetch_sub(1, std::memory_order_relaxed);
         return data;
     };
@@ -203,13 +208,15 @@ TEST_F(ScanOrchestratorTest, PoolCheckoutBlocksUntilASlotIsReleased)
     std::thread first(
         [&]()
         {
-            const auto info = makePackageDeltaInfo("agent-A");
+            const std::string agentId = "agent-A";
+            const auto info = makePackageDeltaInfo(agentId);
             orchestrator->runScanFromViews(info, items);
         });
     std::thread second(
         [&]()
         {
-            const auto info = makePackageDeltaInfo("agent-B");
+            const std::string agentId = "agent-B";
+            const auto info = makePackageDeltaInfo(agentId);
             orchestrator->runScanFromViews(info, items);
         });
 
@@ -223,7 +230,8 @@ TEST_F(ScanOrchestratorTest, PoolCheckoutBlocksUntilASlotIsReleased)
     std::thread third(
         [&]()
         {
-            const auto info = makePackageDeltaInfo("agent-C");
+            const std::string agentId = "agent-C";
+            const auto info = makePackageDeltaInfo(agentId);
             orchestrator->runScanFromViews(info, items);
             thirdScanReturned.store(true, std::memory_order_release);
         });

--- a/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_concurrency_test.cpp
+++ b/src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_concurrency_test.cpp
@@ -1,0 +1,243 @@
+/*
+ * Wazuh Vulnerability Scanner - Unit Tests
+ * Copyright (C) 2015, Wazuh Inc.
+ * August 18, 2026.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "../scanOrchestrator/scanOrchestrator.hpp"
+#include "MockFactoryOrchestrator.hpp"
+#include "TrampolineFactoryOrchestrator.hpp"
+#include "TrampolineOsDataCache.hpp"
+#include "TrampolineScanContext.hpp"
+#include "json.hpp"
+#include "scanOrchestrator_test.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <shared_mutex>
+#include <thread>
+#include <vector>
+
+// The global mock is declared extern by TrampolineFactoryOrchestrator.hpp and defined once in
+// scanOrchestrator_test.cpp; every translation unit in this test binary shares it (gtest's
+// per-test SetUp/TearDown resets it between cases regardless of which .cpp file the TEST_F is
+// written in).
+
+using ::testing::_;
+using testing::Invoke;
+using testing::Return;
+
+namespace
+{
+    using ConcurrencyScanOrchestrator = TScanOrchestrator<TrampolineTScanContext,
+                                                          TrampolineFactoryOrchestrator,
+                                                          MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>,
+                                                          MockIndexerConnector,
+                                                          MockDatabaseFeedManager>;
+
+    constexpr auto TEST_PACKAGE_INDEX {"wazuh-states-inventory-packages"};
+
+    const std::string PACKAGE_UPSERT_JSON = R"({
+        "package": {
+            "architecture": "amd64",
+            "name": "libgif7",
+            "version": "5.1.9-1"
+        }
+    })";
+
+    // Builds a pool of `poolSize` slots; every slot's PackagesDelta chain shares the same
+    // handleRequest action so a single test can bound total observed concurrency across ALL
+    // slots. The factory is asked for 3 chains per slot (PackagesDelta/FirstFullScan/FullScan);
+    // only the PackagesDelta handlers are wired to `onHandleRequest`. `mutex` must outlive the
+    // returned orchestrator (it is stored by reference) -- callers keep it alive as a local.
+    std::unique_ptr<ConcurrencyScanOrchestrator>
+    buildPool(std::size_t poolSize,
+              const std::function<std::shared_ptr<TrampolineTScanContext>(std::shared_ptr<TrampolineTScanContext>)>&
+                  onHandleRequest,
+              std::vector<std::shared_ptr<MockIndexerConnector>>& connectorsOut,
+              std::shared_mutex& mutex)
+    {
+        spFactoryOrchestratorMock = std::make_shared<MockFactoryOrchestrator>();
+
+        // `createOrder` sequences ONLY the create() expectations (each .InSequence() call below
+        // retires it once satisfied AND a later one in this SAME sequence fires, so all 3*poolSize
+        // calls are consumed in declaration order, matching the constructor's actual call order).
+        // handleRequest() is deliberately left OUTSIDE this sequence: putting it in the same
+        // testing::InSequence scope as create() retired it the moment a later create() call fired
+        // during construction (gmock retires a trivially-satisfied, AtLeast(0) expectation as soon
+        // as a later-in-sequence expectation is used) -- long before any scan thread could call it.
+        testing::Sequence createOrder;
+        for (std::size_t slot = 0; slot < poolSize; ++slot)
+        {
+            auto packageDelta = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+            auto firstFullScan = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+            auto fullScan = std::make_shared<MockAbstractHandler<std::shared_ptr<TrampolineTScanContext>>>();
+
+            EXPECT_CALL(*packageDelta, handleRequest(_)).WillRepeatedly(Invoke(onHandleRequest));
+
+            EXPECT_CALL(*spFactoryOrchestratorMock, create()).InSequence(createOrder).WillOnce(Return(packageDelta));
+            EXPECT_CALL(*spFactoryOrchestratorMock, create()).InSequence(createOrder).WillOnce(Return(firstFullScan));
+            EXPECT_CALL(*spFactoryOrchestratorMock, create()).InSequence(createOrder).WillOnce(Return(fullScan));
+
+            connectorsOut.push_back(std::make_shared<MockIndexerConnector>());
+        }
+
+        auto spDatabaseFeedManagerMock = std::make_shared<MockDatabaseFeedManager>();
+
+        return std::make_unique<ConcurrencyScanOrchestrator>(connectorsOut, spDatabaseFeedManagerMock, mutex);
+    }
+
+    vd_sync::SessionInfoView makePackageDeltaInfo(const std::string& agentId)
+    {
+        vd_sync::SessionInfoView info;
+        info.vdFirst = false;
+        info.agentId = agentId;
+        info.agentName = "test-agent";
+        info.agentVersion = "5.0.0";
+        info.architecture = "x86_64";
+        info.hostname = "test-host";
+        info.osname = "Ubuntu";
+        info.osplatform = "ubuntu";
+        info.ostype = "linux";
+        info.osversion = "20.04";
+        info.groups = {"default"};
+        info.indices = {TEST_PACKAGE_INDEX};
+        return info;
+    }
+} // namespace
+
+// Proves the checkout pool actually bounds concurrency to the configured slot count: with
+// poolSize=2 and 6 concurrent scans each holding its slot for a short, deliberate delay, the
+// number of scans simultaneously inside handleRequest() must never exceed 2 (the pool's whole
+// purpose), and — since 6 threads with a 40ms hold reliably overlap — must reach at least 2, so
+// the test cannot pass by accident via full serialization. Run under the workspace's
+// thread-sanitizer build task for the actual data-race proof; this test only checks the
+// observable concurrency bound.
+TEST_F(ScanOrchestratorTest, PoolBoundsConcurrencyToItsSlotCount)
+{
+    constexpr std::size_t poolSize = 2;
+    constexpr int threadCount = 6;
+
+    std::atomic<int> activeCount {0};
+    std::atomic<int> maxObserved {0};
+
+    auto onHandleRequest = [&](std::shared_ptr<TrampolineTScanContext> data)
+    {
+        const int active = activeCount.fetch_add(1, std::memory_order_relaxed) + 1;
+        int previousMax = maxObserved.load(std::memory_order_relaxed);
+        while (active > previousMax &&
+               !maxObserved.compare_exchange_weak(previousMax, active, std::memory_order_relaxed))
+        {
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(40));
+        activeCount.fetch_sub(1, std::memory_order_relaxed);
+        return data;
+    };
+
+    std::vector<std::shared_ptr<MockIndexerConnector>> connectors;
+    std::shared_mutex mutexScanOrchestrator;
+    auto orchestrator = buildPool(poolSize, onHandleRequest, connectors, mutexScanOrchestrator);
+
+    std::vector<std::thread> threads;
+    threads.reserve(threadCount);
+    for (int i = 0; i < threadCount; ++i)
+    {
+        threads.emplace_back(
+            [&, i]()
+            {
+                const std::string agentId = "agent-" + std::to_string(i);
+                std::vector<vd_sync::SyncItemView> items;
+                items.push_back({vd_sync::ItemOperation::Upsert, "pkg001", TEST_PACKAGE_INDEX, PACKAGE_UPSERT_JSON});
+                const auto info = makePackageDeltaInfo(agentId);
+                EXPECT_NO_THROW(orchestrator->runScanFromViews(info, items));
+            });
+    }
+
+    for (auto& thread : threads)
+    {
+        thread.join();
+    }
+
+    EXPECT_LE(maxObserved.load(), static_cast<int>(poolSize))
+        << "checkoutSlot() let more scans run concurrently than the pool has slots for";
+    EXPECT_GE(maxObserved.load(), 2) << "test setup did not actually exercise concurrent scans -- "
+                                        "increase the hold delay or thread count if this is flaky";
+}
+
+// A third scan requesting a slot while both of the pool's slots are held must block until one is
+// released -- proving checkoutSlot() actually waits rather than, e.g., silently reusing a
+// busy slot (which would race) or throwing.
+TEST_F(ScanOrchestratorTest, PoolCheckoutBlocksUntilASlotIsReleased)
+{
+    constexpr std::size_t poolSize = 2;
+
+    std::atomic<int> activeCount {0};
+    std::atomic<bool> releaseFirstTwo {false};
+
+    auto onHandleRequest = [&](std::shared_ptr<TrampolineTScanContext> data)
+    {
+        activeCount.fetch_add(1, std::memory_order_relaxed);
+        while (!releaseFirstTwo.load(std::memory_order_acquire))
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        activeCount.fetch_sub(1, std::memory_order_relaxed);
+        return data;
+    };
+
+    std::vector<std::shared_ptr<MockIndexerConnector>> connectors;
+    std::shared_mutex mutexScanOrchestrator;
+    auto orchestrator = buildPool(poolSize, onHandleRequest, connectors, mutexScanOrchestrator);
+
+    std::vector<vd_sync::SyncItemView> items;
+    items.push_back({vd_sync::ItemOperation::Upsert, "pkg001", TEST_PACKAGE_INDEX, PACKAGE_UPSERT_JSON});
+
+    std::thread first(
+        [&]()
+        {
+            const auto info = makePackageDeltaInfo("agent-A");
+            orchestrator->runScanFromViews(info, items);
+        });
+    std::thread second(
+        [&]()
+        {
+            const auto info = makePackageDeltaInfo("agent-B");
+            orchestrator->runScanFromViews(info, items);
+        });
+
+    // Wait for both slots to be occupied before racing the third scan against them.
+    while (activeCount.load(std::memory_order_acquire) < 2)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    std::atomic<bool> thirdScanReturned {false};
+    std::thread third(
+        [&]()
+        {
+            const auto info = makePackageDeltaInfo("agent-C");
+            orchestrator->runScanFromViews(info, items);
+            thirdScanReturned.store(true, std::memory_order_release);
+        });
+
+    // Both slots are busy and held open; the third scan must still be waiting.
+    std::this_thread::sleep_for(std::chrono::milliseconds(60));
+    EXPECT_FALSE(thirdScanReturned.load(std::memory_order_acquire))
+        << "checkoutSlot() let a third scan proceed while both pool slots were still busy";
+
+    releaseFirstTwo.store(true, std::memory_order_release);
+
+    first.join();
+    second.join();
+    third.join();
+
+    EXPECT_TRUE(thirdScanReturned.load());
+}


### PR DESCRIPTION
## Description

`vulnerability_scanner`'s `ScanOrchestrator` used to serialize every scan behind one process-wide exclusive lock, regardless of how many caller threads existed — so raising `inventory_sync_server`'s `vd_workers` above 1 bought nothing, since only one scan could ever actually run at a time. This PR implements the parallel scan execution requested in the issue.

Closes #38289

## Proposed Changes

- `ScanOrchestrator`'s two scan entry points (`runScanFromViews`, `runScanAfterFeedUpdate`) now take the *shared* side of the mutex instead of an exclusive lock, and check out a `Slot` — its own orchestration chains plus its own `IndexerConnectorSync` — from an internal pool, so independent agents' scans can run concurrently instead of queueing behind each other. The pool is a plain mutex + condition_variable + busy-list, wrapped in a move-only RAII `SlotHandle` so a slot is always returned, including on exception paths. The slot is checked out *before* the shared lock is acquired, so a caller waiting for a free slot never holds a reader that could starve a pending `DatabaseFeedManager::reloadGlobalMaps()` (the exclusive side of that same mutex).
- Pool size comes from a new internal option, `vulnerability-detection.scan_workers` (0–64). `<=0` (unset) falls back to half the host's real cores (`cpp_get_nproc()/2`, minimum 1) — no upper clamp on that auto default, matching the existing, already-shipped `sync_workers` convention.
- `inventory_sync_server`'s `vd_workers` (its own scan-lane worker-thread pool, a separate concept from the scanner's slot pool) now defaults the same way (half the cores, minimum 1) instead of staying fixed at 1 — raising it is now actually safe, since the scanner side can keep up.
- The connector pool shares one `IndexerSession` across all its `IndexerConnectorSync` instances, so raising the pool size costs no extra health-check round-trips at startup.
- Explicitly out of scope (tracked separately): parallelizing `ScanAgentList`'s sequential disconnected-agent rescan loop, and raising the dispatcher lane behind the on-demand `/scan/vd` endpoint above its current single worker.


```mermaid
sequenceDiagram
    participant Session as Session scan<br/>(VdScanLane worker)
    participant OnDemand as On-demand scan<br/>(POST /scan/vd)
    participant Sweep as Disconnected-agent sweep
    participant SAL as ScanAgentList<br/>(reads via slot 0 only)
    participant SO as ScanOrchestrator.checkoutSlot<br/>(m_slots / m_slotBusy)

    OnDemand->>SAL: fetch agent inventory
    Sweep->>SAL: fetch inventory for N disconnected agents
    SAL->>SAL: fetchInventoryDocuments through m_indexerConnector, slot 0, read-only

    par a session arrives for one agent
        Session->>SO: checkoutSlot(agentId)
        SO-->>Session: first free slot i, hands out its own connector
        Session->>Session: run scan, index results, flush
        Session->>SO: releaseSlot(i)
    and an agent requests a rescan
        OnDemand->>SO: checkoutSlot(agentId)
        SO-->>OnDemand: first free slot j, hands out its own connector
        OnDemand->>OnDemand: run scan, index results, flush
        OnDemand->>SO: releaseSlot(j)
    and the feed updates, master sweeps disconnected agents
        loop for each disconnected agent
            Sweep->>SO: checkoutSlot(agentId)
            SO-->>Sweep: first free slot k, hands out its own connector
            Sweep->>Sweep: run scan, index results, flush
            Sweep->>SO: releaseSlot(k)
        end
    end

    Note over SO: m_slots has scanWorkers entries. checkoutSlot blocks on m_poolCv<br/>until some index frees, so a slot busy on one path delays the others<br/>regardless of which agent each one is scanning.
```

### Results and Evidence

#### Scenario
Two load levels, same scenario file, only fleet size and repeat cadence changed:

| Load level | Simulated agents | Request cadence | Sessions requested |
|---|---|---|---|
| Initial | 8 (4 Windows + 4 Linux) | every 3s | 168 |
| Increased | 16 (8 Windows + 8 Linux) | every 1.5s | 336 |

`wazuh_modules.inventory_sync_server_vd_workers` and `vulnerability-detection.scan_workers` were set together (1/1 vs 4/4) for each pair of runs; the scan queue depth was left at its default (`2 × workers`, so 2 slots at 1 worker, 8 at 4 workers).

The file as currently checked in is the increased-load version:

```json
{
  "name": "vd_scan_type_full_rescan",
  "description": "VD-only scenario isolating type=full reason=os_or_hotfix_changed (VDSync with the OS index -> fullScanOrchestration). One VDFirst seeds each agent's inventory, then many VDSync repeats carrying the OS index -- each resolves to the full-rescan chain (the same one feed_update/ScanAgentList uses), so vd.scan.duration/vd.lane.time collected during this run are dominated by full rescans. Run against a freshly restarted manager (empty histograms) for a clean reading.",
  "mode": "agent",
  "defaults": {
    "module": "syscollector",
    "option": "Sync",
    "cluster_name": "cluster01",
    "control": { "enabled": true, "keepalive_interval": "10s", "send_host_info": true, "startup_version": "5.0.0" }
  },
  "lanes": {
    "vd_full": [
      { "kind": "delta", "module": "syscollector", "option": "VDFirst",
        "indices": ["wazuh-states-inventory-packages"], "documents": { "count": 300, "size_bytes": 256 } },
      { "kind": "delta", "option": "VDSync", "indices": ["wazuh-states-inventory-system"],
        "documents": { "count": 30 }, "repeat_count": 20, "repeat_delay": "1.5s", "initial_delay": "5s" }
    ]
  },
  "fleets": [
    { "name": "windows", "agents": 8, "first_id": 9000, "lanes": ["vd_full"],
      "start": { "osname": "Windows 11", "osplatform": "windows", "ostype": "windows", "osversion": "10.0.22631", "architecture": "x86_64", "agentversion": "5.0.0" } },
    { "name": "linux", "agents": 8, "first_id": 9500, "lanes": ["vd_full"],
      "start": { "osname": "Ubuntu", "osplatform": "ubuntu", "ostype": "linux", "osversion": "22.04", "architecture": "x86_64", "agentversion": "5.0.0" } }
  ],
  "pacing": { "concurrent_agents": 0, "requests_per_second": 0, "repeat_until": "0", "drain_timeout": "300s" }
}
```

#### Timing: scan cost vs. queueing cost

Two histograms matter here, and they answer different questions: `vd_scan_duration` is the cost of one scan's own work (mutex-independent), `vd_lane_time` is queue wait + scan (what a caller actually feels). "Scans completed" is the manager's own count of scans it finished (the authoritative figure — a few late completions can land after the metrics snapshot, which is why it's occasionally a little under the client-reported `ok` count).

| Load level | Workers | Sessions ok/sent | Scans completed | scan_duration p50/p90/p99/max | lane_time p50/p90/p99/max |
|---|---|---|---|---|---|
| Initial | 1 | 168/168 | 164 | 2.8 / 4.6 / 294.9 / 275.4 | 11.3 / 15.4 / **1441.8** / **1483.6** |
| Initial | 4 | 168/168 | 160 | 3.3 / 6.7 / 294.9 / 293.9 | 13.3 / 18.4 / **491.5** / **494.3** |
| Increased | 1 | 311/336 | 308 | 2.8 / 3.8 / 294.9 / 288.4 | 11.3 / 18.4 / **1179.6** / **2045.2** |
| Increased | 4 | 326/336 | 314 | 2.8 / 4.6 / 294.9 / 310.9 | 11.3 / 15.4 / **589.8** / **742.3** |
<img width="1500" height="919" alt="image" src="https://github.com/user-attachments/assets/d647a503-f887-4221-be7e-64f80d45883b" />
<img width="1500" height="919" alt="image" src="https://github.com/user-attachments/assets/cd131584-d8e4-4189-a636-f41df3bce598" />


- **A single scan's own cost does not depend on worker count** (p50/p90/p99 are within noise between 1 and 4 workers, at both load levels) — expected, since that work is per-request and doesn't contend with anything once a slot is checked out.
- **The tail of end-to-end lane time collapses with more workers, and the gap widens as load increases**:
  - Initial load: p99 1441.8ms → 491.5ms (**−66%**), max 1483.6ms → 494.3ms (**−67%**).
  - Increased load: p99 1179.6ms → 589.8ms (**−50%**), max 2045.2ms → 742.3ms (**−64%**).
  - Going from initial to increased load, the 1-worker max got *worse* (1483.6ms → 2045.2ms) while the 4-worker max stayed essentially flat (494.3ms → 742.3ms, still well under half of the 1-worker figure) — the pool absorbs added contention instead of queueing it all behind a single lock.

#### Memory: cost of one `IndexerConnectorSync` per slot

`wazuh-manager-modulesd` is the process hosting both `vulnerability_scanner` and `inventory_sync_server`, so its RSS reflects the full connector pool (1 connector at 1 worker, 4 at 4 workers).

| Load level | Workers (connectors) | RSS min/max/final (MB) | RSS growth (MB) | CPU avg/max (%) |
|---|---|---|---|---|
| Initial | 1 | 66.7 / 74.8 / 74.8 | 1.15 | 4.4 / 99.0 |
| Initial | 4 | 65.3 / 76.5 / 76.2 | 0.95 | 4.8 / 156.0 |
| Increased | 1 | 67.3 / 77.4 / 77.4 | 0.50 | 11.5 / 95.0 |
| Increased | 4 | 69.4 / 81.6 / 81.3 | 0.52 | 14.2 / 251.0 |
<img width="1500" height="919" alt="image" src="https://github.com/user-attachments/assets/9be77457-bde0-4f9f-a4e9-7a157c310a2c" />

- Going from 1 to 4 connectors costs **1.7 MB** of peak RSS at initial load and **4.1 MB** at increased load — a few MB, not a per-connector step change worth worrying about. `IndexerSession` (the HTTP client/health-check machinery) is shared across the pool's connectors by design (see Proposed Changes), so the extra connectors mostly add bookkeeping, not sockets or client state.
- RSS growth over the run (not just peak) stays flat and small (≤1.5 MB) regardless of worker count — no leak-shaped accumulation from running 4 connectors instead of 1.
- CPU max rises with worker count (99%→156% initial load, 95%→251% increased load), which is the expected cost of doing more real concurrent work, not a memory concern.

#### Vulnerability Scanner dispatch metrics
```bash
curl -s --unix-socket /var/wazuh-manager/queue/sockets/vd.sock http://localhost/metrics | jq .
  
{
  "name": "vulnerability_scanner",
  "timestamp": "2026-08-24T18:39:08Z",
  "metrics": [
    {
      "name": "vd.dispatch.queue.depth",
      "type": "gauge_int",
      "enabled": true,
      "value": 0,
      "description": "VD sessions queued in the on-demand dispatch lane",
      "unit": "items"
    },
    {
      "name": "vd.dispatch.queue.full.total",
      "type": "counter",
      "enabled": true,
      "value": 0,
      "description": "On-demand scan requests refused because the dispatch queue was full",
      "unit": "count"
    },
    {
      "name": "vd.dispatch.scan.duration",
      "type": "histogram",
      "enabled": true,
      "value": 0,
      "description": "Time inside the vulnerability scanner (on-demand path)",
      "unit": "microseconds",
      "summary": {
        "count": 0,
        "sum": 0,
        "min": 0,
        "max": 0,
        "p50": 0,
        "p90": 0,
        "p99": 0
      }
    },
    {
      "name": "vd.sweep.scan.duration",
      "type": "histogram",
      "enabled": true,
      "value": 0,
      "description": "Time inside the vulnerability scanner (disconnected-agent sweep)",
      "unit": "microseconds",
      "summary": {
        "count": 0,
        "sum": 0,
        "min": 0,
        "max": 0,
        "p50": 0,
        "p90": 0,
        "p99": 0
      }
    },
    {
      "name": "vd.sweep.scans.failed",
      "type": "counter",
      "enabled": true,
      "value": 0,
      "description": "Disconnected-agent sweep scans that failed",
      "unit": "count"
    },
    {
      "name": "vd.sweep.scans.ok",
      "type": "counter",
      "enabled": true,
      "value": 0,
      "description": "Disconnected-agent sweep scans that completed",
      "unit": "count"
    }
  ]
}
```

### Manual tests with their corresponding evidence

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- `wazuh-manager-modulesd`
- `libvulnerability_scanner.so`
- `libinventory_sync_server.so`

### Configuration Changes

- **New:** `vulnerability-detection.scan_workers` (internal option, range 0–64). `<=0` (unset) → half the host's cores, minimum 1. An explicit value always wins.
- **Changed default behavior:** `wazuh_modules.inventory_sync_server_vd_workers` (range 0–16, unchanged) now resolves `<=0` to half the host's cores, minimum 1, instead of a fixed 1.

### Tests Introduced

`src/wazuh_modules/vulnerability_scanner/tests/unit/scanOrchestrator_concurrency_test.cpp` (new):
- `PoolBoundsConcurrencyToItsSlotCount`: drives more concurrent callers than the pool has slots and asserts the observed maximum concurrency never exceeds the configured slot count.
- `PoolCheckoutBlocksUntilASlotIsReleased`: proves a caller blocks when every slot is busy, and proceeds only once a slot is released.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...