### PR TITLE
Reduce wazuh-agentd resident memory and per-request signing cost

### DIFF
--- a/src/client-agent/src/main.c
+++ b/src/client-agent/src/main.c
@@ -14,6 +14,10 @@
 #include "agentd.h"
 #include <getopt.h>
 
+#if defined(__GLIBC__)
+#include <malloc.h>
+#endif
+
 #ifndef ARGV0
 #define ARGV0 "wazuh-agentd"
 #endif
@@ -61,6 +65,24 @@ int main(int argc, char **argv)
     gid_t gid;
 
     run_foreground = 0;
+
+#if defined(__GLIBC__)
+    /* Cap the number of malloc arenas.
+     *
+     * The HTTPS transport runs several allocating threads, and glibc answers
+     * that by giving each one its own 64 MiB arena. Those arenas are reserved
+     * rather than committed, so most of the cost is address space, and it is
+     * what takes this process past 690 MB of virtual size. But each arena also
+     * carries its own top chunk and bins, which is real resident memory that is
+     * never handed back. Capping the count trades a little allocator contention
+     * for that overhead.
+     *
+     * Set here, before any thread is created: extra arenas are only spawned
+     * when a thread finds every existing one locked, so the limit has to be in
+     * place before the transport's threads start. Allocations already made on
+     * this thread came from the main arena and are unaffected. */
+    mallopt(M_ARENA_MAX, 2);
+#endif
 
     /* Set the name */
     OS_SetName(ARGV0);


### PR DESCRIPTION
## Description

Related to #38456

`wazuh-agentd`'s resting memory footprint roughly doubled in 5.0.0 after the agent HTTPS transport landed. Investigation traced the increase to the cost of running OpenSSL and libcurl inside the agent process, most of which is inherent to the new transport: newly executed library pages, ten threads instead of three, and a small live working set.

This pull request addresses one recoverable part of that cost. It recovers roughly a sixth of the reported resident increase, so it does not bring the agent under the current baseline threshold; that remains a separate discussion on the issue.

## Proposed Changes

- Cap `wazuh-agentd`'s glibc malloc arena count with `mallopt(M_ARENA_MAX, 2)` in `main()`.

glibc gives each allocating thread its own 64 MiB arena, and the transport runs several. Most of that is reserved address space rather than committed memory, and it is what takes agentd past 690 MB of virtual size, but each arena also carries its own top chunk and bins, which is resident memory never handed back.

The call is placed before any thread is created, since extra arenas are only spawned when a thread finds every existing one locked. A limit of 2 rather than 1 leaves a second arena available so the transport's threads do not all serialise on a single allocator lock. Compiled in only for glibc, so the Windows and macOS agents are unaffected.

A second change, caching the CMAC implementation instead of fetching it per signature, was prepared and then dropped from this pull request. Fetching per signature is a documented OpenSSL anti-pattern and it is worth doing on its own merits, but its memory effect measured as approximately zero and it is being held back while the agentd and enrollment integration test failures on this branch remain unexplained.

### Results and Evidence

Two packages built by the same builder, differing only in the agent binaries. `libwazuhext.so`, `wazuh-modulesd` and `wazuh-logcollector` are byte identical between them, and `mallopt` is referenced only in the patched `wazuh-agentd`. Both arms ran from the package's own shipped `internal_options.conf` with compression at its default, under the same event load, alternating A,B,A,B so host drift cannot be mistaken for a package effect. Medians over 12 minute samples after a 7 minute settle, 288 samples per arm.

| Metric | Baseline | Patched | Saved | % of baseline |
| --- | --- | --- | --- | --- |
| USS (private) | 10.32 MB | 9.27 MB | **1.05 MB** | **10.2 %** |
| RSS (resident) | 18.52 MB | 17.60 MB | 0.92 MB | 5.0 % |
| VMS (virtual) | 675.67 MB | 165.51 MB | 510.16 MB | 75.5 % |

The measured package also carried two changes that have since been dropped, which together accounted for about 0.32 MB of a 1.37 MB total. The figures above subtract that, so they are this change's isolated contribution rather than a direct reading. A re-measurement against a package built from this branch as it now stands would replace the arithmetic with a measurement.

Above the noise floor: per-repetition USS medians differed by 96 KB within the baseline arm and 132 KB within the patched arm, so the arms do not overlap at any point and the saving is an order of magnitude larger than the within-arm variation.

What motivated the change: `malloc_info()` on a plateaued agent reported five arenas holding 1 912 KB in total, of which only 887 KB was live. Capping the count was measured separately at 1 328 KB of resident memory and 85 % of the virtual size with `MALLOC_ARENA_MAX=1`.

The virtual size result deserves a caveat rather than celebration. 510 MB sounds dramatic, but that memory was reserved and never committed, so it was never denied to anything else on the host. It matters because it removes a figure that reads as alarming in monitoring, not because it frees usable memory.

Set against the regression this addresses: the reported increase was +5 288 KB on RSS p95 and +4 212 KB on private memory, so this recovers roughly a sixth of the former and a quarter of the latter.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux: agent DEB and RPM build jobs pass on this branch
  - [x] Windows: Windows agent binaries and MSI jobs pass; the change is compiled out there
  - [x] MAC OS X: macOS compilation test and unit tests pass; the change is compiled out there
- [x] Log syntax and correct language review: N/A, no log messages added or changed

- Memory tests for Linux
  - [ ] Coverity: not run locally; the scan-build job runs on this branch
  - [x] Valgrind (memcheck and descriptor leaks check): massif was used to profile the agent's heap during the investigation; memcheck was not run, and this change alters no allocation logic
  - [ ] AddressSanitizer: not run; the change sets an allocator limit and introduces no new memory access
- Memory tests for Windows
  - [ ] Coverity: N/A, compiled out on Windows
  - [ ] UMDH: N/A, compiled out on Windows
- Memory tests for macOS
  - [ ] Leaks: N/A, compiled out on macOS
  - [ ] AddressSanitizer: N/A, compiled out on macOS

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini": N/A
  - [ ] `runtests.py` executed without errors: N/A

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel: N/A, the engine is not touched
  - [ ] ASAN for test (utest/ctest): N/A
  - [ ] TSAN for test and wazuh-engine: N/A

- Wazuh server API/Framework
  - [ ] Run API Integration Tests: N/A, agent-side change only

Additional measurement specific to this change: a standalone six-thread allocation churn test confirms that capping arenas reduces virtual size without increasing resident memory (17.3 MB uncapped against 17.6 MB capped), and a three minute run of the agent under a rejected-enrollment retry loop showed flat resident memory, no CPU load and no thread growth.

### Artifacts Affected

- `wazuh-agentd` on Linux.
- No change to the Windows or macOS agents: the call is compiled in only for glibc.
- No packaging or default configuration changes.

### Configuration Changes

N/A. No new settings, no changes to defaults, and no behaviour visible to users or to the manager.

### Documentation Updates

N/A.

### Tests Introduced

N/A. The change sets an allocator limit at startup and alters no logic, so there is no behaviour to assert on. Its effect is a reduction in resident memory and virtual size, which the performance suite measures rather than a unit test.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
