### PR TITLE
Reject symlinks when reading and staging files during agent upgrade

### DIFF
--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -19,6 +19,7 @@
 #include <sys/stat.h>
 #include <cJSON.h>
 #include <dirent.h>
+#include "../external/zlib/zlib.h"
 
 #ifdef WIN32
 #include <winsock2.h>
@@ -524,6 +525,27 @@ FILE * wfopen(const char * pathname, const char * mode);
  * @return File pointer on success, NULL on error (sets errno).
  */
 FILE * w_fopen_nofollow(const char * basedir, const char * filename, const char * mode);
+
+
+/**
+ * @brief Open a compressed file inside a base directory for reading, without following symlinks.
+ *
+ * Read-side counterpart of w_fopen_nofollow(): intended for directories that may contain files planted
+ * by another party (var/incoming and friends), where a symlink, hard link, FIFO, device or directory
+ * found at the target path must be rejected instead of read through. @p filename must be a bare file
+ * name; it is rejected if it is empty, "." or "..", if it refers to a parent folder, or if it contains a
+ * path separator, so the resulting open cannot escape @p basedir.
+ *
+ * On Linux/macOS the open is relative to a descriptor of @p basedir and uses O_NOFOLLOW; on Windows it
+ * skips reparse-point processing. In both cases the descriptor must turn out to be a regular file with a
+ * link count of exactly 1 before it is handed to zlib.
+ *
+ * @param basedir Base directory holding the file. Not created by this function.
+ * @param filename Bare file name inside @p basedir.
+ * @param mode Open mode, either "r" or "rb".
+ * @return Compressed file handle on success, NULL on error (sets errno).
+ */
+gzFile w_gzopen_nofollow(const char * basedir, const char * filename, const char * mode);
 
 
 /**

--- a/src/os_execd/wcom.c
+++ b/src/os_execd/wcom.c
@@ -153,8 +153,14 @@ size_t wcom_uncompress(const char * source, const char * target, char ** output)
         return strlen(*output);
     }
 
-    if (fsource = gzopen(final_source, "rb"), !fsource) {
-        merror("At WCOM uncompress: Unable to open '%s'", final_source);
+    // Not gzopen(): a symlink left at final_source would be followed, disclosing whatever it points to.
+    if (fsource = w_gzopen_nofollow(INCOMING_DIR, source, "rb"), !fsource) {
+        const int open_errno = errno;
+        if (open_errno == ELOOP) {
+            merror("At WCOM uncompress: Refused to open '%s': the path is a symbolic link", final_source);
+        } else {
+            merror("At WCOM uncompress: Unable to open '%s'", final_source);
+        }
         os_strdup("err Unable to open source", *output);
         return strlen(*output);
     }

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2602,6 +2602,138 @@ static int w_win32_to_errno(DWORD error) {
 #endif
 
 
+#ifdef WIN32
+/**
+ * Opens @p filename inside @p basedir on Windows without following symlinks or junctions, and vets the
+ * resulting handle as a lone regular file — rejecting reparse points, directories, and NTFS hard links
+ * (which need no privilege to create and carry neither attribute above) — before handing it back.
+ * Shared by w_fopen_nofollow() and w_gzopen_nofollow() so a future hardening fix only has to be applied
+ * once instead of needing to be kept in sync across both.
+ *
+ * @param basedir Base directory holding the file.
+ * @param filename Bare file name inside @p basedir.
+ * @param access GENERIC_READ or GENERIC_WRITE.
+ * @param disposition OPEN_EXISTING for reading, or OPEN_ALWAYS for writing. OPEN_ALWAYS never truncates
+ *                     by itself: the caller must only truncate after the handle has been vetted here,
+ *                     since truncating up front would destroy the target of a hard link before it could
+ *                     be told apart from a regular file.
+ * @return A vetted handle on success, or INVALID_HANDLE_VALUE on error (sets errno).
+ */
+static HANDLE w_createfile_nofollow_vetted(const char * basedir, const char * filename, DWORD access, DWORD disposition) {
+    char final_path[PATH_MAX + 1];
+    BY_HANDLE_FILE_INFORMATION file_info;
+    HANDLE hFile;
+
+    if (snprintf(final_path, sizeof(final_path), "%s\\%s", basedir, filename) > PATH_MAX) {
+        errno = ENAMETOOLONG;
+        return INVALID_HANDLE_VALUE;
+    }
+
+    // FILE_FLAG_OPEN_REPARSE_POINT makes the handle refer to a symlink or junction itself instead of to
+    // its target, so the target is never opened nor modified.
+    hFile = wCreateFile(final_path, access, FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
+                        NULL, disposition, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
+
+    if (hFile == INVALID_HANDLE_VALUE) {
+        errno = w_win32_to_errno(GetLastError());
+        return INVALID_HANDLE_VALUE;
+    }
+
+    if (!GetFileInformationByHandle(hFile, &file_info)) {
+        errno = w_win32_to_errno(GetLastError());
+        CloseHandle(hFile);
+        return INVALID_HANDLE_VALUE;
+    }
+
+    if (file_info.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
+        CloseHandle(hFile);
+        errno = ELOOP;
+        return INVALID_HANDLE_VALUE;
+    }
+
+    if (file_info.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+        CloseHandle(hFile);
+        errno = EISDIR;
+        return INVALID_HANDLE_VALUE;
+    }
+
+    if (file_info.nNumberOfLinks != 1) {
+        CloseHandle(hFile);
+        errno = EMLINK;
+        return INVALID_HANDLE_VALUE;
+    }
+
+    return hFile;
+}
+#else
+/**
+ * Opens @p filename inside @p basedir without following symlinks, and vets the resulting descriptor as
+ * a lone regular file — rejecting hard links, FIFOs, devices, and directories — before handing it back.
+ * Shared by w_fopen_nofollow() and w_gzopen_nofollow() so a future hardening fix only has to be applied
+ * once instead of needing to be kept in sync across both.
+ *
+ * @param basedir Base directory holding the file.
+ * @param filename Bare file name inside @p basedir.
+ * @param oflags open()/openat() flags; must include O_NOFOLLOW | O_CLOEXEC | O_NONBLOCK (the latter to
+ *               keep a FIFO from blocking the open) on top of whichever of O_RDONLY/O_WRONLY/O_CREAT the
+ *               caller needs. Deliberately never includes O_TRUNC: truncating at open time would destroy
+ *               the target before anything about it can be checked, which is precisely how a hard link
+ *               slips through — it is a regular file, so no file type test can tell it apart. A caller
+ *               that needs the file truncated must do so only after this returns a vetted descriptor.
+ * @param mode Permission bits, used only when oflags includes O_CREAT.
+ * @return A vetted file descriptor, with O_NONBLOCK already cleared, on success; -1 on error (sets errno).
+ */
+static int w_openat_nofollow_vetted(const char * basedir, const char * filename, int oflags, mode_t mode) {
+    struct stat statbuf;
+    int dirfd;
+    int fd;
+    int saved_errno;
+    int flags;
+
+    if (dirfd = open(basedir, O_RDONLY | O_DIRECTORY | O_CLOEXEC), dirfd < 0) {
+        return -1;
+    }
+
+    fd = openat(dirfd, filename, oflags, mode);
+    saved_errno = errno;
+    close(dirfd);
+
+    if (fd < 0) {
+        errno = saved_errno;
+        return -1;
+    }
+
+    // Rules out anything O_NOFOLLOW does not, such as a block or character device.
+    if (fstat(fd, &statbuf) < 0) {
+        saved_errno = errno;
+        close(fd);
+        errno = saved_errno;
+        return -1;
+    }
+
+    if (!S_ISREG(statbuf.st_mode)) {
+        close(fd);
+        errno = EINVAL;
+        return -1;
+    }
+
+    // A hard link is a regular file by every other measure; the link count is what gives it away.
+    if (statbuf.st_nlink != 1) {
+        close(fd);
+        errno = EMLINK;
+        return -1;
+    }
+
+    // O_NONBLOCK only mattered while checking for a FIFO above; clear it so reads/writes behave normally.
+    if (flags = fcntl(fd, F_GETFL), flags != -1) {
+        fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
+    }
+
+    return fd;
+}
+#endif
+
+
 FILE * w_fopen_nofollow(const char * basedir, const char * filename, const char * mode) {
     if (!basedir || !mode || (strcmp(mode, "w") && strcmp(mode, "wb")) || !w_is_bare_filename(filename)) {
         errno = EINVAL;
@@ -2609,57 +2741,20 @@ FILE * w_fopen_nofollow(const char * basedir, const char * filename, const char 
     }
 
 #ifdef WIN32
-    char final_path[PATH_MAX + 1];
-    BY_HANDLE_FILE_INFORMATION file_info;
-    HANDLE hFile;
     int flags = strchr(mode, 'b') ? 0 : _O_TEXT;
     int fd;
     FILE * fp;
 
-    if (snprintf(final_path, sizeof(final_path), "%s\\%s", basedir, filename) > PATH_MAX) {
-        errno = ENAMETOOLONG;
-        return NULL;
-    }
-
     // OPEN_ALWAYS rather than CREATE_ALWAYS: the file must not be truncated before the handle has been
-    // confirmed to be a regular file. FILE_FLAG_OPEN_REPARSE_POINT makes the handle refer to a symlink
-    // or junction itself instead of to its target, so the target is never opened nor modified.
-    hFile = wCreateFile(final_path, GENERIC_WRITE, FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
-                        NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
+    // confirmed to be a regular file.
+    HANDLE hFile = w_createfile_nofollow_vetted(basedir, filename, GENERIC_WRITE, OPEN_ALWAYS);
 
     if (hFile == INVALID_HANDLE_VALUE) {
-        errno = w_win32_to_errno(GetLastError());
         return NULL;
     }
 
-    if (!GetFileInformationByHandle(hFile, &file_info)) {
-        errno = w_win32_to_errno(GetLastError());
-        CloseHandle(hFile);
-        return NULL;
-    }
-
-    if (file_info.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
-        CloseHandle(hFile);
-        errno = ELOOP;
-        return NULL;
-    }
-
-    if (file_info.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-        CloseHandle(hFile);
-        errno = EISDIR;
-        return NULL;
-    }
-
-    // An NTFS hard link carries neither of the attributes above, and unlike a symlink it needs no
-    // privilege to create (mklink /H), so it is the easier of the two to plant. The link count is the
-    // only thing that distinguishes it.
-    if (file_info.nNumberOfLinks != 1) {
-        CloseHandle(hFile);
-        errno = EMLINK;
-        return NULL;
-    }
-
-    // The file pointer sits at the beginning of the file, so this truncates it.
+    // The file pointer sits at the beginning of the file, so this truncates it. Safe now: the handle is
+    // known to refer to a lone regular file, so this can no longer destroy a hard link's target early.
     if (!SetEndOfFile(hFile)) {
         errno = w_win32_to_errno(GetLastError());
         CloseHandle(hFile);
@@ -2684,64 +2779,21 @@ FILE * w_fopen_nofollow(const char * basedir, const char * filename, const char 
 
     return fp;
 #else
-    struct stat statbuf;
     FILE * fp;
-    int dirfd;
-    int fd;
     int saved_errno;
-    int flags;
-
-    if (dirfd = open(basedir, O_RDONLY | O_DIRECTORY | O_CLOEXEC), dirfd < 0) {
-        return NULL;
-    }
-
-    // O_NOFOLLOW makes the open fail with ELOOP if the target is a symlink, and O_NONBLOCK keeps it from
-    // blocking on a FIFO waiting for a reader. Deliberately NOT O_TRUNC: truncating at open time would
-    // destroy the target before anything about it can be checked, which is precisely how a hard link
-    // slips through — it is a regular file, so no file type test can tell it apart. The file is
-    // truncated below instead, once the descriptor has been vetted, mirroring what the Windows branch
-    // does with OPEN_ALWAYS plus SetEndOfFile().
-    fd = openat(dirfd, filename, O_WRONLY | O_CREAT | O_NOFOLLOW | O_CLOEXEC | O_NONBLOCK, 0640);
-    saved_errno = errno;
-    close(dirfd);
+    int fd = w_openat_nofollow_vetted(basedir, filename, O_WRONLY | O_CREAT | O_NOFOLLOW | O_CLOEXEC | O_NONBLOCK, 0640);
 
     if (fd < 0) {
-        errno = saved_errno;
         return NULL;
     }
 
-    // Rules out anything O_NOFOLLOW does not, such as a block or character device.
-    if (fstat(fd, &statbuf) < 0) {
-        saved_errno = errno;
-        close(fd);
-        errno = saved_errno;
-        return NULL;
-    }
-
-    if (!S_ISREG(statbuf.st_mode)) {
-        close(fd);
-        errno = EINVAL;
-        return NULL;
-    }
-
-    // A hard link is a regular file by every other measure; the link count is what gives it away.
-    if (statbuf.st_nlink != 1) {
-        close(fd);
-        errno = EMLINK;
-        return NULL;
-    }
-
-    // Safe now: the descriptor is known to point at a lone regular file.
+    // Safe now: the descriptor is known to point at a lone regular file. Mirrors what the Windows branch
+    // does with OPEN_ALWAYS plus SetEndOfFile() — the file is truncated only once vetted, not at open time.
     if (ftruncate(fd, 0) < 0) {
         saved_errno = errno;
         close(fd);
         errno = saved_errno;
         return NULL;
-    }
-
-    // O_NONBLOCK has no effect on a regular file, but the stream is expected to behave like fopen's.
-    if (flags = fcntl(fd, F_GETFL), flags != -1) {
-        fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
     }
 
     if (fp = fdopen(fd, mode), fp == NULL) {
@@ -2762,50 +2814,12 @@ gzFile w_gzopen_nofollow(const char * basedir, const char * filename, const char
     }
 
 #ifdef WIN32
-    char final_path[PATH_MAX + 1];
-    BY_HANDLE_FILE_INFORMATION file_info;
-    HANDLE hFile;
     int fd;
     gzFile gzfp;
 
-    if (snprintf(final_path, sizeof(final_path), "%s\\%s", basedir, filename) > PATH_MAX) {
-        errno = ENAMETOOLONG;
-        return NULL;
-    }
-
-    // FILE_FLAG_OPEN_REPARSE_POINT makes the handle refer to a symlink or junction itself instead of to
-    // its target, so a planted symlink is never followed for reading either.
-    hFile = wCreateFile(final_path, GENERIC_READ, FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
-                        NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
+    HANDLE hFile = w_createfile_nofollow_vetted(basedir, filename, GENERIC_READ, OPEN_EXISTING);
 
     if (hFile == INVALID_HANDLE_VALUE) {
-        errno = w_win32_to_errno(GetLastError());
-        return NULL;
-    }
-
-    if (!GetFileInformationByHandle(hFile, &file_info)) {
-        errno = w_win32_to_errno(GetLastError());
-        CloseHandle(hFile);
-        return NULL;
-    }
-
-    if (file_info.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
-        CloseHandle(hFile);
-        errno = ELOOP;
-        return NULL;
-    }
-
-    if (file_info.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-        CloseHandle(hFile);
-        errno = EISDIR;
-        return NULL;
-    }
-
-    // Same reasoning as w_fopen_nofollow(): an NTFS hard link needs no privilege to create and carries
-    // neither attribute checked above, so the link count is what gives it away.
-    if (file_info.nNumberOfLinks != 1) {
-        CloseHandle(hFile);
-        errno = EMLINK;
         return NULL;
     }
 
@@ -2823,52 +2837,12 @@ gzFile w_gzopen_nofollow(const char * basedir, const char * filename, const char
 
     return gzfp;
 #else
-    struct stat statbuf;
     gzFile gzfp;
-    int dirfd;
-    int fd;
     int saved_errno;
-    int flags;
-
-    if (dirfd = open(basedir, O_RDONLY | O_DIRECTORY | O_CLOEXEC), dirfd < 0) {
-        return NULL;
-    }
-
-    // O_NOFOLLOW makes the open fail with ELOOP if the target is a symlink, and O_NONBLOCK keeps it from
-    // blocking on a FIFO waiting for a writer.
-    fd = openat(dirfd, filename, O_RDONLY | O_NOFOLLOW | O_CLOEXEC | O_NONBLOCK);
-    saved_errno = errno;
-    close(dirfd);
+    int fd = w_openat_nofollow_vetted(basedir, filename, O_RDONLY | O_NOFOLLOW | O_CLOEXEC | O_NONBLOCK, 0);
 
     if (fd < 0) {
-        errno = saved_errno;
         return NULL;
-    }
-
-    // Rules out anything O_NOFOLLOW does not, such as a block or character device.
-    if (fstat(fd, &statbuf) < 0) {
-        saved_errno = errno;
-        close(fd);
-        errno = saved_errno;
-        return NULL;
-    }
-
-    if (!S_ISREG(statbuf.st_mode)) {
-        close(fd);
-        errno = EINVAL;
-        return NULL;
-    }
-
-    // A hard link is a regular file by every other measure; the link count is what gives it away.
-    if (statbuf.st_nlink != 1) {
-        close(fd);
-        errno = EMLINK;
-        return NULL;
-    }
-
-    // O_NONBLOCK only mattered while checking for a FIFO above; clear it so reads behave normally.
-    if (flags = fcntl(fd, F_GETFL), flags != -1) {
-        fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
     }
 
     if (gzfp = gzdopen(fd, mode), gzfp == NULL) {

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -2755,6 +2755,134 @@ FILE * w_fopen_nofollow(const char * basedir, const char * filename, const char 
 }
 
 
+gzFile w_gzopen_nofollow(const char * basedir, const char * filename, const char * mode) {
+    if (!basedir || !mode || (strcmp(mode, "r") && strcmp(mode, "rb")) || !w_is_bare_filename(filename)) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+#ifdef WIN32
+    char final_path[PATH_MAX + 1];
+    BY_HANDLE_FILE_INFORMATION file_info;
+    HANDLE hFile;
+    int fd;
+    gzFile gzfp;
+
+    if (snprintf(final_path, sizeof(final_path), "%s\\%s", basedir, filename) > PATH_MAX) {
+        errno = ENAMETOOLONG;
+        return NULL;
+    }
+
+    // FILE_FLAG_OPEN_REPARSE_POINT makes the handle refer to a symlink or junction itself instead of to
+    // its target, so a planted symlink is never followed for reading either.
+    hFile = wCreateFile(final_path, GENERIC_READ, FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
+                        NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
+
+    if (hFile == INVALID_HANDLE_VALUE) {
+        errno = w_win32_to_errno(GetLastError());
+        return NULL;
+    }
+
+    if (!GetFileInformationByHandle(hFile, &file_info)) {
+        errno = w_win32_to_errno(GetLastError());
+        CloseHandle(hFile);
+        return NULL;
+    }
+
+    if (file_info.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
+        CloseHandle(hFile);
+        errno = ELOOP;
+        return NULL;
+    }
+
+    if (file_info.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+        CloseHandle(hFile);
+        errno = EISDIR;
+        return NULL;
+    }
+
+    // Same reasoning as w_fopen_nofollow(): an NTFS hard link needs no privilege to create and carries
+    // neither attribute checked above, so the link count is what gives it away.
+    if (file_info.nNumberOfLinks != 1) {
+        CloseHandle(hFile);
+        errno = EMLINK;
+        return NULL;
+    }
+
+    if (fd = _open_osfhandle((intptr_t)hFile, _O_RDONLY), fd < 0) {
+        CloseHandle(hFile);
+        return NULL;
+    }
+
+    // From here on the descriptor owns the handle: closing it through zlib/CRT is enough, CloseHandle()
+    // would release the handle while leaving the descriptor allocated forever.
+    if (gzfp = gzdopen(fd, mode), gzfp == NULL) {
+        _close(fd);
+        return NULL;
+    }
+
+    return gzfp;
+#else
+    struct stat statbuf;
+    gzFile gzfp;
+    int dirfd;
+    int fd;
+    int saved_errno;
+    int flags;
+
+    if (dirfd = open(basedir, O_RDONLY | O_DIRECTORY | O_CLOEXEC), dirfd < 0) {
+        return NULL;
+    }
+
+    // O_NOFOLLOW makes the open fail with ELOOP if the target is a symlink, and O_NONBLOCK keeps it from
+    // blocking on a FIFO waiting for a writer.
+    fd = openat(dirfd, filename, O_RDONLY | O_NOFOLLOW | O_CLOEXEC | O_NONBLOCK);
+    saved_errno = errno;
+    close(dirfd);
+
+    if (fd < 0) {
+        errno = saved_errno;
+        return NULL;
+    }
+
+    // Rules out anything O_NOFOLLOW does not, such as a block or character device.
+    if (fstat(fd, &statbuf) < 0) {
+        saved_errno = errno;
+        close(fd);
+        errno = saved_errno;
+        return NULL;
+    }
+
+    if (!S_ISREG(statbuf.st_mode)) {
+        close(fd);
+        errno = EINVAL;
+        return NULL;
+    }
+
+    // A hard link is a regular file by every other measure; the link count is what gives it away.
+    if (statbuf.st_nlink != 1) {
+        close(fd);
+        errno = EMLINK;
+        return NULL;
+    }
+
+    // O_NONBLOCK only mattered while checking for a FIFO above; clear it so reads behave normally.
+    if (flags = fcntl(fd, F_GETFL), flags != -1) {
+        fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
+    }
+
+    if (gzfp = gzdopen(fd, mode), gzfp == NULL) {
+        saved_errno = errno;
+        close(fd);
+        errno = saved_errno;
+        return NULL;
+    }
+
+    return gzfp;
+#endif
+}
+
+
 int w_compress_gzfile(const char *filesrc, const char *filedst) {
     FILE *fd;
     gzFile gz_fd;

--- a/src/unit_tests/wazuh_modules/agent_upgrade/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/CMakeLists.txt
@@ -79,9 +79,9 @@ else()
 
     list(APPEND upgrade_names "test_wm_agent_upgrade_com")
     list(APPEND upgrade_flags "-Wl,--wrap,w_ref_parent_folder -Wl,--wrap,w_wpk_unsign -Wl,--wrap,unlink -Wl,--wrap,getpid -Wl,--wrap,gzopen \
-                               -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove \
+                               -Wl,--wrap,fopen -Wl,--wrap,fdopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove \
                                -Wl,--wrap,gzclose -Wl,--wrap,gzread -Wl,--wrap,mkstemp -Wl,--wrap,atexit -Wl,--wrap,chmod -Wl,--wrap,stat -Wl,--wrap,wfopen \
-                               -Wl,--wrap,w_fopen_nofollow \
+                               -Wl,--wrap,w_fopen_nofollow -Wl,--wrap,w_gzopen_nofollow \
                                -Wl,--wrap,OS_SHA1_File -Wl,--wrap,getDefine_Int -Wl,--wrap,cldir_ex -Wl,--wrap,UnmergeFiles -Wl,--wrap,wm_exec -Wl,--wrap,remove \
                                -Wl,--wrap,fgetpos -Wl,--wrap=fgetc  -Wl,--wrap,popen ${DEBUG_OP_WRAPPERS}")
 

--- a/src/unit_tests/wazuh_modules/agent_upgrade/CMakeLists.txt
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/CMakeLists.txt
@@ -80,7 +80,7 @@ else()
     list(APPEND upgrade_names "test_wm_agent_upgrade_com")
     list(APPEND upgrade_flags "-Wl,--wrap,w_ref_parent_folder -Wl,--wrap,w_wpk_unsign -Wl,--wrap,unlink -Wl,--wrap,getpid -Wl,--wrap,gzopen \
                                -Wl,--wrap,fopen -Wl,--wrap,fdopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove \
-                               -Wl,--wrap,gzclose -Wl,--wrap,gzread -Wl,--wrap,mkstemp -Wl,--wrap,atexit -Wl,--wrap,chmod -Wl,--wrap,stat -Wl,--wrap,wfopen \
+                               -Wl,--wrap,gzclose -Wl,--wrap,gzread -Wl,--wrap,mkstemp -Wl,--wrap,atexit -Wl,--wrap,chmod -Wl,--wrap,fchmod -Wl,--wrap,stat -Wl,--wrap,wfopen \
                                -Wl,--wrap,w_fopen_nofollow -Wl,--wrap,w_gzopen_nofollow \
                                -Wl,--wrap,OS_SHA1_File -Wl,--wrap,getDefine_Int -Wl,--wrap,cldir_ex -Wl,--wrap,UnmergeFiles -Wl,--wrap,wm_exec -Wl,--wrap,remove \
                                -Wl,--wrap,fgetpos -Wl,--wrap=fgetc  -Wl,--wrap,popen ${DEBUG_OP_WRAPPERS}")

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_com.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_com.c
@@ -233,8 +233,9 @@ void test_unsign_wpk_using_fail(void **state) {
 #else
     expect_string(__wrap_w_wpk_unsign, source, "var/incoming/test_filename");
     will_return(__wrap_mkstemp, 8);
-    expect_any(__wrap_chmod, path);
-    will_return(__wrap_chmod, 0);
+    expect_value(__wrap_fchmod, fd, 8);
+    expect_value(__wrap_fchmod, mode, 0640);
+    will_return(__wrap_fchmod, 0);
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:agent-upgrade");
     expect_string(__wrap__mterror, formatted_msg, "(8139): At unsign(): Could not unsign package file 'var/incoming/test_filename'");
@@ -257,8 +258,9 @@ void test_unsign_temp_chmod_fail(void **state) {
     will_return(__wrap_w_ref_parent_folder, 0);
 
     will_return(__wrap_mkstemp, 8);
-    expect_any(__wrap_chmod, path);
-    will_return(__wrap_chmod, -1);
+    expect_value(__wrap_fchmod, fd, 8);
+    expect_value(__wrap_fchmod, mode, 0640);
+    will_return(__wrap_fchmod, -1);
 
     expect_any_count(__wrap_unlink, file, 2);
     will_return_count(__wrap_unlink, 0, 2);
@@ -286,8 +288,9 @@ void test_unsign_success(void **state) {
     expect_string(__wrap_w_wpk_unsign, source, "var/incoming/test_filename");
 
     will_return(__wrap_mkstemp, 8);
-    expect_any(__wrap_chmod, path);
-    will_return(__wrap_chmod, 0);
+    expect_value(__wrap_fchmod, fd, 8);
+    expect_value(__wrap_fchmod, mode, 0640);
+    will_return(__wrap_fchmod, 0);
 #endif
     will_return(__wrap_w_wpk_unsign, 0);
     expect_any(__wrap_unlink, file);
@@ -365,8 +368,9 @@ void test_uncompress_fopen_fail(void **state) {
     expect_w_fopen_nofollow(TMP_DIR, "test_filename.mg.XXXXXX", "wb", NULL);
 #else
     will_return(__wrap_mkstemp, 8);
-    expect_any(__wrap_chmod, path);
-    will_return(__wrap_chmod, 0);
+    expect_value(__wrap_fchmod, fd, 8);
+    expect_value(__wrap_fchmod, mode, 0640);
+    will_return(__wrap_fchmod, 0);
     expect_fdopen(8, "wb", 0);
 
     expect_any(__wrap_unlink, file);
@@ -403,8 +407,9 @@ void test_uncompress_fwrite_fail(void **state) {
     expect_w_fopen_nofollow(TMP_DIR, "test_filename.mg.XXXXXX", "wb", (FILE *)5);
 #else
     will_return(__wrap_mkstemp, 8);
-    expect_any(__wrap_chmod, path);
-    will_return(__wrap_chmod, 0);
+    expect_value(__wrap_fchmod, fd, 8);
+    expect_value(__wrap_fchmod, mode, 0640);
+    will_return(__wrap_fchmod, 0);
     expect_fdopen(8, "wb", (FILE *)5);
 #endif
 
@@ -450,8 +455,9 @@ void test_uncompress_gzread_fail(void **state) {
     expect_w_fopen_nofollow(TMP_DIR, "test_filename.mg.XXXXXX", "wb", (FILE *)5);
 #else
     will_return(__wrap_mkstemp, 8);
-    expect_any(__wrap_chmod, path);
-    will_return(__wrap_chmod, 0);
+    expect_value(__wrap_fchmod, fd, 8);
+    expect_value(__wrap_fchmod, mode, 0640);
+    will_return(__wrap_fchmod, 0);
     expect_fdopen(8, "wb", (FILE *)5);
 #endif
 
@@ -494,8 +500,9 @@ void test_uncompress_success(void **state) {
     expect_w_fopen_nofollow(TMP_DIR, "test_filename.mg.XXXXXX", "wb", (FILE *)5);
 #else
     will_return(__wrap_mkstemp, 8);
-    expect_any(__wrap_chmod, path);
-    will_return(__wrap_chmod, 0);
+    expect_value(__wrap_fchmod, fd, 8);
+    expect_value(__wrap_fchmod, mode, 0640);
+    will_return(__wrap_fchmod, 0);
     expect_fdopen(8, "wb", (FILE *)5);
 #endif
 
@@ -963,8 +970,9 @@ void test_wm_agent_upgrade_com_upgrade_uncompress_error(void **state) {
             expect_string(__wrap_w_wpk_unsign, source, "var/incoming/test_file");
 
             will_return(__wrap_mkstemp, 8);
-            expect_any(__wrap_chmod, path);
-            will_return(__wrap_chmod, 0);
+            expect_value(__wrap_fchmod, fd, 8);
+            expect_value(__wrap_fchmod, mode, 0640);
+            will_return(__wrap_fchmod, 0);
         #endif
         will_return(__wrap_w_wpk_unsign, 0);
         expect_any(__wrap_unlink, file);
@@ -1012,8 +1020,9 @@ void test_wm_agent_upgrade_com_upgrade_clean_directory_error(void **state) {
             expect_string(__wrap_w_wpk_unsign, source, "var/incoming/test_file");
 
             will_return(__wrap_mkstemp, 8);
-            expect_any(__wrap_chmod, path);
-            will_return(__wrap_chmod, 0);
+            expect_value(__wrap_fchmod, fd, 8);
+            expect_value(__wrap_fchmod, mode, 0640);
+            will_return(__wrap_fchmod, 0);
         #endif
         will_return(__wrap_w_wpk_unsign, 0);
         expect_any(__wrap_unlink, file);
@@ -1083,8 +1092,9 @@ void test_wm_agent_upgrade_com_unmerge_error(void **state) {
             expect_string(__wrap_w_wpk_unsign, source, "var/incoming/test_file");
 
             will_return(__wrap_mkstemp, 8);
-            expect_any(__wrap_chmod, path);
-            will_return(__wrap_chmod, 0);
+            expect_value(__wrap_fchmod, fd, 8);
+            expect_value(__wrap_fchmod, mode, 0640);
+            will_return(__wrap_fchmod, 0);
         #endif
         will_return(__wrap_w_wpk_unsign, 0);
         expect_any(__wrap_unlink, file);
@@ -1161,8 +1171,9 @@ void test_wm_agent_upgrade_com_installer_error(void **state) {
             expect_string(__wrap_w_wpk_unsign, source, "var/incoming/test_file");
 
             will_return(__wrap_mkstemp, 8);
-            expect_any(__wrap_chmod, path);
-            will_return(__wrap_chmod, 0);
+            expect_value(__wrap_fchmod, fd, 8);
+            expect_value(__wrap_fchmod, mode, 0640);
+            will_return(__wrap_fchmod, 0);
         #endif
         will_return(__wrap_w_wpk_unsign, 0);
         expect_any(__wrap_unlink, file);
@@ -1242,8 +1253,9 @@ void test_wm_agent_upgrade_com_chmod_error(void **state) {
             expect_string(__wrap_w_wpk_unsign, source, "var/incoming/test_file");
 
             will_return(__wrap_mkstemp, 8);
-            expect_any(__wrap_chmod, path);
-            will_return(__wrap_chmod, 0);
+            expect_value(__wrap_fchmod, fd, 8);
+            expect_value(__wrap_fchmod, mode, 0640);
+            will_return(__wrap_fchmod, 0);
         #endif
         will_return(__wrap_w_wpk_unsign, 0);
         expect_any(__wrap_unlink, file);
@@ -1329,8 +1341,9 @@ void test_wm_agent_upgrade_com_execute_error(void **state) {
             expect_string(__wrap_w_wpk_unsign, source, "var/incoming/test_file");
 
             will_return(__wrap_mkstemp, 8);
-            expect_any(__wrap_chmod, path);
-            will_return(__wrap_chmod, 0);
+            expect_value(__wrap_fchmod, fd, 8);
+            expect_value(__wrap_fchmod, mode, 0640);
+            will_return(__wrap_fchmod, 0);
         #endif
         will_return(__wrap_w_wpk_unsign, 0);
         expect_any(__wrap_unlink, file);
@@ -1433,8 +1446,9 @@ void test_wm_agent_upgrade_com_success(void **state) {
             expect_string(__wrap_w_wpk_unsign, source, "var/incoming/test_file");
 
             will_return(__wrap_mkstemp, 8);
-            expect_any(__wrap_chmod, path);
-            will_return(__wrap_chmod, 0);
+            expect_value(__wrap_fchmod, fd, 8);
+            expect_value(__wrap_fchmod, mode, 0640);
+            will_return(__wrap_fchmod, 0);
         #endif
         will_return(__wrap_w_wpk_unsign, 0);
         expect_any(__wrap_unlink, file);
@@ -1834,8 +1848,9 @@ void test_wm_agent_upgrade_process_upgrade_command(void **state) {
                 expect_string(__wrap_w_wpk_unsign, source, "var/incoming/test_file");
 
                 will_return(__wrap_mkstemp, 8);
-                expect_any(__wrap_chmod, path);
-                will_return(__wrap_chmod, 0);
+                expect_value(__wrap_fchmod, fd, 8);
+                expect_value(__wrap_fchmod, mode, 0640);
+                will_return(__wrap_fchmod, 0);
             #endif
             will_return(__wrap_w_wpk_unsign, 0);
             expect_any(__wrap_unlink, file);

--- a/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_com.c
+++ b/src/unit_tests/wazuh_modules/agent_upgrade/test_wm_agent_upgrade_com.c
@@ -330,30 +330,51 @@ void test_uncompress_invalid_file_len(void **state) {
 void test_uncompress_gzopen_fail(void **state) {
     char merged[PATH_MAX + 1];
     char *package =  *state;
+#ifdef TEST_WINAGENT
+    const char * source = "tmp\\compressed_test";
+#else
+    const char * source = "tmp/compressed_test";
+#endif
 
-    expect_string(__wrap_w_ref_parent_folder, path, package);
-    will_return(__wrap_w_ref_parent_folder, 0);
+    expect_w_gzopen_nofollow(TMP_DIR, "compressed_test", "rb", NULL);
 
-    expect_string(__wrap_gzopen, path, "compressed_test");
-    expect_string(__wrap_gzopen, mode, "rb");
-    will_return(__wrap_gzopen, NULL);
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:agent-upgrade");
-    expect_string(__wrap__mterror, formatted_msg, "(8140): At uncompress(): Unable to open 'compressed_test'");
+#ifdef TEST_WINAGENT
+    expect_string(__wrap__mterror, formatted_msg, "(8140): At uncompress(): Unable to open 'tmp\\compressed_test'");
+#else
+    expect_string(__wrap__mterror, formatted_msg, "(8140): At uncompress(): Unable to open 'tmp/compressed_test'");
+#endif
 
-    int ret = _uncompress("compressed_test", package, merged);
+    int ret = _uncompress(source, package, merged);
     assert_int_equal(ret, -1);
 }
 
 void test_uncompress_fopen_fail(void **state) {
     char merged[PATH_MAX + 1];
     char *package =  *state;
+#ifdef TEST_WINAGENT
+    const char * source = "tmp\\compressed_test";
+#else
+    const char * source = "tmp/compressed_test";
+#endif
 
-    expect_string(__wrap_w_ref_parent_folder, path, package);
-    will_return(__wrap_w_ref_parent_folder, 0);
+    expect_w_gzopen_nofollow(TMP_DIR, "compressed_test", "rb", (gzFile)4);
 
-    expect_string(__wrap_gzopen, path, "compressed_test");
-    expect_string(__wrap_gzopen, mode, "rb");
-    will_return(__wrap_gzopen, 4);
+#ifdef TEST_WINAGENT
+    will_return(wrap_mktemp_s, NULL);
+    expect_w_fopen_nofollow(TMP_DIR, "test_filename.mg.XXXXXX", "wb", NULL);
+#else
+    will_return(__wrap_mkstemp, 8);
+    expect_any(__wrap_chmod, path);
+    will_return(__wrap_chmod, 0);
+    expect_fdopen(8, "wb", 0);
+
+    expect_any(__wrap_unlink, file);
+    will_return(__wrap_unlink, 0);
+#endif
+
+    expect_value(__wrap_gzclose, file, 4);
+    will_return(__wrap_gzclose, 0);
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:agent-upgrade");
 #ifdef TEST_WINAGENT
@@ -361,31 +382,31 @@ void test_uncompress_fopen_fail(void **state) {
 #else
     expect_string(__wrap__mterror, formatted_msg, "(8140): At uncompress(): Unable to open 'tmp/test_filename.mg.XXXXXX'");
 #endif
-    expect_any(__wrap_wfopen, path);
-    expect_string(__wrap_wfopen, mode, "wb");
-    will_return(__wrap_wfopen, 0);
 
-    expect_value(__wrap_gzclose, file, 4);
-    will_return(__wrap_gzclose, 0);
-
-    int ret = _uncompress("compressed_test", package, merged);
+    int ret = _uncompress(source, package, merged);
     assert_int_equal(ret, -1);
 }
 
 void test_uncompress_fwrite_fail(void **state) {
     char merged[PATH_MAX + 1];
     char *package =  *state;
+#ifdef TEST_WINAGENT
+    const char * source = "tmp\\compressed_test";
+#else
+    const char * source = "tmp/compressed_test";
+#endif
 
-    expect_string(__wrap_w_ref_parent_folder, path, package);
-    will_return(__wrap_w_ref_parent_folder, 0);
+    expect_w_gzopen_nofollow(TMP_DIR, "compressed_test", "rb", (gzFile)4);
 
-    expect_string(__wrap_gzopen, path, "compressed_test");
-    expect_string(__wrap_gzopen, mode, "rb");
-    will_return(__wrap_gzopen, 4);
-
-    expect_any(__wrap_wfopen, path);
-    expect_string(__wrap_wfopen, mode, "wb");
-    will_return(__wrap_wfopen, 5);
+#ifdef TEST_WINAGENT
+    will_return(wrap_mktemp_s, NULL);
+    expect_w_fopen_nofollow(TMP_DIR, "test_filename.mg.XXXXXX", "wb", (FILE *)5);
+#else
+    will_return(__wrap_mkstemp, 8);
+    expect_any(__wrap_chmod, path);
+    will_return(__wrap_chmod, 0);
+    expect_fdopen(8, "wb", (FILE *)5);
+#endif
 
     expect_value(__wrap_gzread, gz_fd, 4);
     will_return(__wrap_gzread, 4);
@@ -403,26 +424,36 @@ void test_uncompress_fwrite_fail(void **state) {
     will_return(__wrap_fclose, 0);
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:agent-upgrade");
-    expect_string(__wrap__mterror, formatted_msg, "(8129): At uncompress(): Cannot write on 'compressed_test'");
+#ifdef TEST_WINAGENT
+    expect_string(__wrap__mterror, formatted_msg, "(8129): At uncompress(): Cannot write on 'tmp\\compressed_test'");
+#else
+    expect_string(__wrap__mterror, formatted_msg, "(8129): At uncompress(): Cannot write on 'tmp/compressed_test'");
+#endif
 
-    int ret = _uncompress("compressed_test", package, merged);
+    int ret = _uncompress(source, package, merged);
     assert_int_equal(ret, -1);
 }
 
 void test_uncompress_gzread_fail(void **state) {
     char merged[PATH_MAX + 1];
     char *package =  *state;
+#ifdef TEST_WINAGENT
+    const char * source = "tmp\\compressed_test";
+#else
+    const char * source = "tmp/compressed_test";
+#endif
 
-    expect_string(__wrap_w_ref_parent_folder, path, package);
-    will_return(__wrap_w_ref_parent_folder, 0);
+    expect_w_gzopen_nofollow(TMP_DIR, "compressed_test", "rb", (gzFile)4);
 
-    expect_string(__wrap_gzopen, path, "compressed_test");
-    expect_string(__wrap_gzopen, mode, "rb");
-    will_return(__wrap_gzopen, 4);
-
-    expect_any(__wrap_wfopen, path);
-    expect_string(__wrap_wfopen, mode, "wb");
-    will_return(__wrap_wfopen, 5);
+#ifdef TEST_WINAGENT
+    will_return(wrap_mktemp_s, NULL);
+    expect_w_fopen_nofollow(TMP_DIR, "test_filename.mg.XXXXXX", "wb", (FILE *)5);
+#else
+    will_return(__wrap_mkstemp, 8);
+    expect_any(__wrap_chmod, path);
+    will_return(__wrap_chmod, 0);
+    expect_fdopen(8, "wb", (FILE *)5);
+#endif
 
     expect_value(__wrap_gzread, gz_fd, 4);
     will_return(__wrap_gzread, -1);
@@ -437,26 +468,36 @@ void test_uncompress_gzread_fail(void **state) {
     will_return(__wrap_unlink, 0);
 
     expect_string(__wrap__mterror, tag, "wazuh-modulesd:agent-upgrade");
-    expect_string(__wrap__mterror, formatted_msg, "(8141): At uncompress(): Unable to read 'compressed_test'");
+#ifdef TEST_WINAGENT
+    expect_string(__wrap__mterror, formatted_msg, "(8141): At uncompress(): Unable to read 'tmp\\compressed_test'");
+#else
+    expect_string(__wrap__mterror, formatted_msg, "(8141): At uncompress(): Unable to read 'tmp/compressed_test'");
+#endif
 
-    int ret = _uncompress("compressed_test", package, merged);
+    int ret = _uncompress(source, package, merged);
     assert_int_equal(ret, -1);
 }
 
 void test_uncompress_success(void **state) {
     char merged[PATH_MAX + 1];
     char *package =  *state;
+#ifdef TEST_WINAGENT
+    const char * source = "tmp\\compressed_test";
+#else
+    const char * source = "tmp/compressed_test";
+#endif
 
-    expect_string(__wrap_w_ref_parent_folder, path, package);
-    will_return(__wrap_w_ref_parent_folder, 0);
+    expect_w_gzopen_nofollow(TMP_DIR, "compressed_test", "rb", (gzFile)4);
 
-    expect_string(__wrap_gzopen, path, "compressed_test");
-    expect_string(__wrap_gzopen, mode, "rb");
-    will_return(__wrap_gzopen, 4);
-
-    expect_any(__wrap_wfopen, path);
-    expect_string(__wrap_wfopen, mode, "wb");
-    will_return(__wrap_wfopen, 5);
+#ifdef TEST_WINAGENT
+    will_return(wrap_mktemp_s, NULL);
+    expect_w_fopen_nofollow(TMP_DIR, "test_filename.mg.XXXXXX", "wb", (FILE *)5);
+#else
+    will_return(__wrap_mkstemp, 8);
+    expect_any(__wrap_chmod, path);
+    will_return(__wrap_chmod, 0);
+    expect_fdopen(8, "wb", (FILE *)5);
+#endif
 
     expect_value(__wrap_gzread, gz_fd, 4);
     will_return(__wrap_gzread, 4);
@@ -476,7 +517,7 @@ void test_uncompress_success(void **state) {
     expect_any(__wrap_unlink, file);
     will_return(__wrap_unlink, 0);
 
-    int ret = _uncompress("compressed_test", package, merged);
+    int ret = _uncompress(source, package, merged);
     assert_int_equal(ret, 0);
 }
 

--- a/src/unit_tests/wrappers/externals/zlib/zlib_wrappers.c
+++ b/src/unit_tests/wrappers/externals/zlib/zlib_wrappers.c
@@ -34,6 +34,23 @@ gzFile __wrap_gzopen(const char * path,
     return mock_type(gzFile);
 }
 
+gzFile __wrap_w_gzopen_nofollow(const char * basedir,
+                                const char * filename,
+                                const char * mode) {
+    check_expected(basedir);
+    check_expected(filename);
+    check_expected(mode);
+
+    return mock_type(gzFile);
+}
+
+void expect_w_gzopen_nofollow(const char * basedir, const char * filename, const char * mode, gzFile ret) {
+    expect_string(__wrap_w_gzopen_nofollow, basedir, basedir);
+    expect_string(__wrap_w_gzopen_nofollow, filename, filename);
+    expect_string(__wrap_w_gzopen_nofollow, mode, mode);
+    will_return(__wrap_w_gzopen_nofollow, ret);
+}
+
 int __wrap_gzclose(gzFile file) {
     check_expected_ptr(file);
     return mock();

--- a/src/unit_tests/wrappers/externals/zlib/zlib_wrappers.h
+++ b/src/unit_tests/wrappers/externals/zlib/zlib_wrappers.h
@@ -20,6 +20,11 @@ int __wrap_gzread(gzFile gz_fd,
 gzFile __wrap_gzopen(const char * file,
                      const char * mode);
 
+gzFile __wrap_w_gzopen_nofollow(const char * basedir,
+                                const char * filename,
+                                const char * mode);
+void expect_w_gzopen_nofollow(const char * basedir, const char * filename, const char * mode, gzFile ret);
+
 int __wrap_gzclose(gzFile file);
 
 int __wrap_gzeof(gzFile file);

--- a/src/unit_tests/wrappers/libc/stdio_wrappers.c
+++ b/src/unit_tests/wrappers/libc/stdio_wrappers.c
@@ -88,6 +88,18 @@ void expect_fopen(const char* path, const char* mode, FILE *fp) {
     will_return(__wrap_fopen, fp);
 }
 
+FILE* __wrap_fdopen(int fd, const char* mode) {
+    check_expected(fd);
+    check_expected(mode);
+    return mock_ptr_type(FILE*);
+}
+
+void expect_fdopen(int fd, const char* mode, FILE *fp) {
+    expect_value(__wrap_fdopen, fd, fd);
+    expect_string(__wrap_fdopen, mode, mode);
+    will_return(__wrap_fdopen, fp);
+}
+
 int __wrap_fprintf(FILE *__stream, const char *__format, ...) {
     char formatted_msg[OS_MAXSTR];
     va_list args;

--- a/src/unit_tests/wrappers/libc/stdio_wrappers.h
+++ b/src/unit_tests/wrappers/libc/stdio_wrappers.h
@@ -25,6 +25,9 @@ char * __wrap_fgets (char * __s, int __n, FILE * __stream);
 FILE* __wrap_fopen(const char* path, const char* mode);
 void expect_fopen(const char* path, const char* mode, FILE *fp);
 
+FILE* __wrap_fdopen(int fd, const char* mode);
+void expect_fdopen(int fd, const char* mode, FILE *fp);
+
 int __wrap_fprintf (FILE *__stream, const char *__format, ...);
 void expect_fprintf(FILE *__stream, const char *formatted_msg, int ret);
 

--- a/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
+++ b/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
@@ -463,12 +463,17 @@ STATIC int _unsign(const char * source, char dest[PATH_MAX + 1]) {
     int fd;
 
     if (fd = mkstemp(dest), fd >= 0) {
-        close(fd);
-
-        if (chmod(dest, 0640) < 0) {
+        // Not chmod(dest, ...): between mkstemp() creating dest and a name-based chmod() looking
+        // it up again, dest could be unlinked and replaced with a symlink, making chmod() follow
+        // it and change an unrelated target's mode. fd is already open on the exact file mkstemp()
+        // created, so fchmod() skips that second lookup entirely.
+        if (fchmod(fd, 0640) < 0) {
+            close(fd);
             unlink(dest);
             mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_CHMOD_ERROR, "unsign()", dest);
             output = -1;
+        } else {
+            close(fd);
         }
     } else {
 #else
@@ -551,7 +556,11 @@ STATIC int _uncompress(const char * source, const char *package, char dest[PATH_
             return -1;
         }
 
-        if (chmod(dest, 0640) < 0) {
+        // Not chmod(dest, ...): between mkstemp() creating dest and a name-based chmod() looking
+        // it up again, dest could be unlinked and replaced with a symlink, making chmod() follow
+        // it and change an unrelated target's mode. fd is already open on the exact file mkstemp()
+        // created, so fchmod() skips that second lookup entirely.
+        if (fchmod(fd, 0640) < 0) {
             unlink(dest);
             close(fd);
             gzclose(fsource);

--- a/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
+++ b/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
@@ -156,6 +156,7 @@ STATIC char * wm_agent_upgrade_com_clear_result();
 STATIC int _jailfile(char finalpath[PATH_MAX + 1], const char * basedir, const char * filename);
 STATIC int _unsign(const char * source, char dest[PATH_MAX + 1]);
 STATIC int _uncompress(const char * source, const char *package, char dest[PATH_MAX + 1]);
+STATIC const char * _tmpBareName(const char * path);
 
 size_t wm_agent_upgrade_process_command(const char *buffer, char **output) {
     cJSON *buffer_obj = cJSON_Parse(buffer);
@@ -487,6 +488,25 @@ STATIC int _unsign(const char * source, char dest[PATH_MAX + 1]) {
     return output;
 }
 
+// _jailfile() always builds its output as TMP_DIR followed by a path separator and a bare filename;
+// this recovers that bare filename instead of blindly skipping strlen(TMP_DIR) + 1 bytes, which would
+// walk past the string's NUL terminator (and hand a garbage pointer to w_gzopen_nofollow/w_fopen_nofollow)
+// for any path that turns out not to actually start with that prefix.
+STATIC const char * _tmpBareName(const char * path) {
+    const size_t prefixLen = strlen(TMP_DIR) + 1;
+#ifndef WIN32
+    const char SEP = '/';
+#else
+    const char SEP = '\\';
+#endif
+
+    if (strlen(path) <= prefixLen || strncmp(path, TMP_DIR, strlen(TMP_DIR)) != 0 || path[strlen(TMP_DIR)] != SEP) {
+        return NULL;
+    }
+
+    return path + prefixLen;
+}
+
 STATIC int _uncompress(const char * source, const char *package, char dest[PATH_MAX + 1]) {
     const char TEMPLATE[] = ".mg.XXXXXX";
     char buffer[4096];
@@ -510,7 +530,9 @@ STATIC int _uncompress(const char * source, const char *package, char dest[PATH_
     }
 
     // Not gzopen(): a symlink left at source would be followed, disclosing whatever it points to.
-    if (fsource = w_gzopen_nofollow(TMP_DIR, source + strlen(TMP_DIR) + 1, "rb"), !fsource) {
+    const char * sourceBareName = _tmpBareName(source);
+
+    if (!sourceBareName || (fsource = w_gzopen_nofollow(TMP_DIR, sourceBareName, "rb"), !fsource)) {
         mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_FILE_OPEN_ERROR, "uncompress()", source);
         return -1;
     }
@@ -552,7 +574,9 @@ STATIC int _uncompress(const char * source, const char *package, char dest[PATH_
         return -1;
     }
 
-    if (ftarget = w_fopen_nofollow(TMP_DIR, dest + strlen(TMP_DIR) + 1, "wb"), !ftarget) {
+    const char * destBareName = _tmpBareName(dest);
+
+    if (!destBareName || (ftarget = w_fopen_nofollow(TMP_DIR, destBareName, "wb"), !ftarget)) {
         gzclose(fsource);
         mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_FILE_OPEN_ERROR, "uncompress()", dest);
         return -1;

--- a/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
+++ b/src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c
@@ -509,16 +509,55 @@ STATIC int _uncompress(const char * source, const char *package, char dest[PATH_
         memcpy(dest + length, TEMPLATE, sizeof(TEMPLATE));
     }
 
-    if (fsource = gzopen(source, "rb"), !fsource) {
+    // Not gzopen(): a symlink left at source would be followed, disclosing whatever it points to.
+    if (fsource = w_gzopen_nofollow(TMP_DIR, source + strlen(TMP_DIR) + 1, "rb"), !fsource) {
         mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_FILE_OPEN_ERROR, "uncompress()", source);
         return -1;
     }
 
-    if (ftarget = wfopen(dest, "wb"), !ftarget) {
+    // dest still holds the literal template here: unlike _unsign() above, it was never expanded into a
+    // unique name, leaving a predictable path a symlink could be pre-planted at before wfopen() opened
+    // it. Expand it now and, on POSIX, reuse the descriptor mkstemp() already vetted instead of a second,
+    // name-based open that would reintroduce the same race.
+#ifndef WIN32
+    {
+        int fd;
+
+        if (fd = mkstemp(dest), fd < 0) {
+            gzclose(fsource);
+            mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_COMPRESSED_FILE_ERROR, "uncompress()");
+            return -1;
+        }
+
+        if (chmod(dest, 0640) < 0) {
+            unlink(dest);
+            close(fd);
+            gzclose(fsource);
+            mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_CHMOD_ERROR, "uncompress()", dest);
+            return -1;
+        }
+
+        if (ftarget = fdopen(fd, "wb"), !ftarget) {
+            unlink(dest);
+            close(fd);
+            gzclose(fsource);
+            mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_FILE_OPEN_ERROR, "uncompress()", dest);
+            return -1;
+        }
+    }
+#else
+    if (_mktemp_s(dest, strlen(dest) + 1)) {
+        gzclose(fsource);
+        mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_COMPRESSED_FILE_ERROR, "uncompress()");
+        return -1;
+    }
+
+    if (ftarget = w_fopen_nofollow(TMP_DIR, dest + strlen(TMP_DIR) + 1, "wb"), !ftarget) {
         gzclose(fsource);
         mterror(WM_AGENT_UPGRADE_LOGTAG, WM_UPGRADE_FILE_OPEN_ERROR, "uncompress()", dest);
         return -1;
     }
+#endif
 
     {
         int length;


### PR DESCRIPTION
## Description

Two locations in the agent upgrade flow open files inside writable staging directories (`var/incoming`, `tmp`) without checking whether the target is a symlink first:

1. **`wcom_uncompress()`** (`src/os_execd/wcom.c`) opens `final_source` — a name jailed under `var/incoming` — with a plain `gzopen()`. If a symlink with that name is planted in `var/incoming`, `gzopen()` follows it and discloses the contents of whatever it points to. The write side of this same function was already hardened for the same issue in #38200 (`w_fopen_nofollow()`); the read side was left uncovered.

2. **`_uncompress()`** (`src/wazuh_modules/agent_upgrade/agent/wm_agent_upgrade_com.c`) builds a temporary destination path from a template (`tmp/<package>.mg.XXXXXX`) but — unlike the sibling function `_unsign()`, which calls `mkstemp()` — never expands it into a random name. The path is therefore predictable from the package name alone, and gets opened with a plain `wfopen()`. A symlink planted in advance at that exact path is followed, letting an attacker overwrite an arbitrary file with the decompressed package contents.

Both require the attacker to already have write access to the staging directory, so this is a hardening fix rather than a critical remote vulnerability — the same follow-up scope #38200 left open.

## Proposed Changes

- Added `w_gzopen_nofollow()` in `src/shared/file_op.c` (declared in `file_op.h`), the read-side counterpart of `w_fopen_nofollow()`: opens with `O_NOFOLLOW` on POSIX (via `openat()` on a directory descriptor) and rejects reparse points on Windows, then hands the vetted descriptor to `gzdopen()`.
- `wcom_uncompress()` now uses `w_gzopen_nofollow(INCOMING_DIR, source, "rb")` instead of `gzopen()`.
- `_uncompress()` now expands the temp-file template with `mkstemp()` on POSIX — reusing the descriptor it returns directly via `fdopen()`, rather than closing it and reopening by name — or `_mktemp_s()` + `w_fopen_nofollow()` on Windows, instead of opening the unexpanded, predictable path with `wfopen()`. The read side of the same function was switched to `w_gzopen_nofollow()` too, for consistency.


### Results and Evidence

### PoC 1 — `wcom_uncompress()` read side (symlink in `var/incoming` disclosing an outside file)

Setup: `sandbox/var/incoming/evil` is a symlink to a real `.gz` file living outside the jail, containing a secret string.

--- PRE-FIX pattern: gzopen(final_source, "rb") ---
gzopen() SUCCEEDED (followed the symlink). Bytes read: 43 Disclosed content from OUTSIDE the jail: "TOP-SECRET-AGENT-DATA-LAPTOP-J631ENT0-29721"

--- POST-FIX pattern: w_gzopen_nofollow(INCOMING_DIR, "evil", "rb") ---
w_gzopen_nofollow() correctly REJECTED the symlink. errno=40 (Too many levels of symbolic links) [ELOOP as expected]

### PoC 2 — `_uncompress()` write side (symlink at the predictable, unexpanded `tmp/<package>.mg.XXXXXX` path)

Setup: `sandbox/tmp/package.mg.XXXXXX` (the literal, never-expanded template) is a symlink to a "victim" file.

--- PRE-FIX pattern: wfopen(dest, "wb") on the never-expanded path ---
wfopen() SUCCEEDED (followed the symlink) and wrote attacker bytes through it.
victim file content is now: "ATTACKER-CONTROLLED-DECOMPRESSED-BYTES"

--- POST-FIX pattern: mkstemp(dest) expands the template before anything is opened ---
mkstemp() expanded the template to a fresh, unpredictable path: sandbox/tmp/package.mg.0NMAgF Write landed in the new randomized file, never touching the symlink's literal path.
victim file content is now: "IMPORTANT-CONFIG-DO-NOT-TOUCH"

Both harnesses use the real, modified functions extracted verbatim (via `sed`) from `file_op.c`, not reimplementations.

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

N-A

### Configuration Changes

N-A

### Tests Introduced

N-A

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
