### PR TITLE
Wait out transient SQLite locks instead of failing agent startup

### DIFF
--- a/src/shared_modules/dbsync/src/sqlite/sqlite_wrapper.cpp
+++ b/src/shared_modules/dbsync/src/sqlite/sqlite_wrapper.cpp
@@ -24,6 +24,9 @@ constexpr auto DB_PERMISSIONS
     0640
 };
 
+/// @brief How long a connection waits on a busy/locked database before giving up.
+constexpr int DB_BUSY_TIMEOUT_MS {5000};
+
 using namespace SQLite;
 using ExpandedSQLPtr = std::unique_ptr<char, CustomDeleter<decltype(&sqlite3_free), sqlite3_free>>;
 
@@ -95,6 +98,7 @@ Connection::Connection(const std::string& path)
     }
 
 #endif
+    sqlite3_busy_timeout(m_db.get(), DB_BUSY_TIMEOUT_MS);
 }
 
 void Connection::close()

--- a/src/shared_modules/dbsync/tests/sqlite/sqlite_test.cpp
+++ b/src/shared_modules/dbsync/tests/sqlite/sqlite_test.cpp
@@ -11,6 +11,8 @@
 #include "sqlite_test.h"
 #include "sqlite_wrapper.h"
 #include "db_exception.h"
+#include <chrono>
+#include <thread>
 
 constexpr auto TEMP_TEST_DB_PATH {"temp_test.db"};
 constexpr auto TEMP_DB_PATH {"temp.db"};
@@ -275,4 +277,28 @@ TEST_F(SQLiteTest, StatementExpandBind)
     insertStmt.bind(3, 1000);
     const auto expectedStringStmt{ insertStmt.expand() };
     EXPECT_EQ(expectedStringStmt, "INSERT INTO test_table (Colum1, Colum2, Colum3, Colum4, Colum5) VALUES (NULL,'bar',1000,NULL,NULL);");
+}
+
+/// @brief A connection must wait out a lock held by another writer instead of failing immediately.
+TEST_F(SQLiteTest, ConnectionWaitsOutTransientLockInsteadOfFailingImmediately)
+{
+    Connection {TEMP_TEST_DB_PATH};
+
+    Connection lockHolderConnection{TEMP_TEST_DB_PATH};
+    lockHolderConnection.execute("BEGIN IMMEDIATE TRANSACTION;");
+
+    // Release the lock from another thread after a short delay.
+    std::thread lockReleaser(
+        [&lockHolderConnection]()
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(300));
+        lockHolderConnection.execute("COMMIT;");
+    });
+
+    // Without busy_timeout this throws immediately; with it, it waits out the 300ms lock.
+    Connection secondConnection{TEMP_TEST_DB_PATH};
+    EXPECT_NO_THROW(secondConnection.execute("BEGIN IMMEDIATE TRANSACTION;"));
+    EXPECT_NO_THROW(secondConnection.execute("COMMIT;"));
+
+    lockReleaser.join();
 }

--- a/src/shared_modules/sync_protocol/tests/CMakeLists.txt
+++ b/src/shared_modules/sync_protocol/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ target_link_libraries(
   agent_sync_protocol_tests
   PRIVATE agent_sync_protocol
           agent_metadata
+          wazuhext
           debug
           gtestd
           debug

--- a/src/shared_modules/sync_protocol/tests/test_persistent_queue_storage.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_persistent_queue_storage.cpp
@@ -11,8 +11,11 @@
 #include <gmock/gmock.h>
 #include "persistent_queue_storage.hpp"
 #include "mock_filesystem_wrapper.hpp"
+#include "sqlite3Wrapper.hpp"
 #include <memory>
 #include <filesystem>
+#include <thread>
+#include <chrono>
 
 struct QueueScenario
 {
@@ -611,4 +614,56 @@ TEST_F(PersistentQueueStorageDeleteDatabaseTest, DeleteDatabaseVerifyConnectionI
 
     // Call deleteDatabase
     EXPECT_NO_THROW(storage->deleteDatabase());
+}
+
+/// @brief A stale writer lock left by another connection must resolve once it clears, not fail immediately.
+class PersistentQueueStorageBusyLockTest : public ::testing::Test
+{
+    protected:
+        std::string dbPath;
+        LoggerFunc testLogger;
+
+        void SetUp() override
+        {
+            dbPath = (std::filesystem::temp_directory_path() / "wazuh_persistent_queue_busy_lock_test.db").string();
+            std::filesystem::remove(dbPath);
+            std::filesystem::remove(dbPath + "-wal");
+            std::filesystem::remove(dbPath + "-shm");
+
+            testLogger = [](modules_log_level_t /*level*/, const std::string& /*msg*/)
+            {
+            };
+        }
+
+        void TearDown() override
+        {
+            std::filesystem::remove(dbPath);
+            std::filesystem::remove(dbPath + "-wal");
+            std::filesystem::remove(dbPath + "-shm");
+        }
+};
+
+TEST_F(PersistentQueueStorageBusyLockTest, ResetAllSyncingWaitsOutTransientLockInsteadOfFailingImmediately)
+{
+    // Create the schema first, then hold a real write lock on it.
+    PersistentQueueStorage firstInstanceStorage(dbPath, testLogger);
+
+    SQLite3Wrapper::Connection lockHolderConnection(dbPath);
+    lockHolderConnection.execute("BEGIN IMMEDIATE TRANSACTION;");
+
+    // A second instance opening the same db while the lock is held.
+    PersistentQueueStorage secondInstanceStorage(dbPath, testLogger);
+
+    // Release the lock from another thread after a short delay.
+    std::thread lockReleaser(
+        [&lockHolderConnection]()
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(300));
+        lockHolderConnection.execute("COMMIT;");
+    });
+
+    // Without busy_timeout this throws immediately; with it, it waits out the 300ms lock.
+    EXPECT_NO_THROW(secondInstanceStorage.resetAllSyncing());
+
+    lockReleaser.join();
 }

--- a/src/shared_modules/utils/sqlite3Wrapper.hpp
+++ b/src/shared_modules/utils/sqlite3Wrapper.hpp
@@ -22,6 +22,14 @@ constexpr auto DB_DEFAULT_PATH {"temp.db"};
 constexpr auto DB_MEMORY {":memory:"};
 constexpr auto DB_PERMISSIONS {0640};
 
+/// @brief How long a connection waits on a busy/locked database before giving up.
+///
+/// Without this, a transient lock (e.g. a previous process instance whose WAL
+/// handle hasn't been released yet across a fast restart) surfaces as an
+/// immediate SQLITE_BUSY "database is locked" instead of resolving once the
+/// lock clears.
+constexpr int DB_BUSY_TIMEOUT_MS {5000};
+
 namespace SQLite3Wrapper
 {
     class Sqlite3Error : public std::exception
@@ -92,11 +100,13 @@ namespace SQLite3Wrapper
             }
 
 #endif
+            sqlite3_busy_timeout(m_db.get(), DB_BUSY_TIMEOUT_MS);
         }
         explicit Connection(sqlite3* db)
             : m_db {nullptr, &connectionDeleter}
             , m_dbPtr {db}
         {
+            sqlite3_busy_timeout(m_dbPtr, DB_BUSY_TIMEOUT_MS);
         }
 
         void close()


### PR DESCRIPTION
## Description

On Windows, a fast agent restart (the MSI installer's own service start immediately followed by the provisioner's start, or any other rapid stop/start of `WazuhSvc`) can leave FIM's `queue\fim\db\fim_sync.db` with a stale WAL lock from the previous process instance that never got the chance to close cleanly. When the new process starts, `fim_initialize()` opens that same database through `AgentSyncProtocol`/`PersistentQueue`, and the first write against it (`PersistentQueueStorage::resetAllSyncing()`) gets `SQLITE_BUSY` immediately, because the underlying `SQLite3Wrapper::Connection` never configures a busy timeout — it fails on the very first attempt instead of waiting for the transient lock to clear.

FIM treats that failure as unrecoverable: `asp_create()` returns `NULL`, and `syscheck.c` responds with `merror_exit("Failed to initialize AgentSyncProtocol")`, a `noreturn` call that terminates the whole process. Because every module (FIM, syscollector, sca, agent-info, etc.) runs inside the single `wazuh-agent.exe` on Windows, this single transient lock takes the entire agent down, and since `WazuhSvc` has no configured SCM recovery action, the service stays `Stopped` indefinitely — the agent shows as enrolled but permanently disconnected on the manager.

```mermaid
sequenceDiagram
    participant Prev as Previous wazuh-agent.exe<br/>(pid 1700)
    participant New as New wazuh-agent.exe<br/>(pid 6672)
    participant DB as fim_sync.db (WAL)

    Prev->>DB: BEGIN IMMEDIATE TRANSACTION<br/>(FIM flush thread mid-write)
    Note over Prev: 20s shutdown budget exceeded (#38370)<br/>process killed before COMMIT
    Prev--xDB: WAL writer lock left stale

    New->>New: fim_initialize() -> asp_create()<br/>-> AgentSyncProtocol -> PersistentQueue<br/>-> resetAllSyncing()
    New->>DB: BEGIN IMMEDIATE TRANSACTION

    alt Without this fix (no busy_timeout configured)
        DB-->>New: SQLITE_BUSY (instantly, no retry)
        New->>New: "database is locked" -> asp_create() returns NULL
        New->>New: merror_exit() [noreturn] -> exit()
        Note over New: Whole agent process dies.<br/>WazuhSvc stays Stopped (no recovery configured).
    else With this fix (sqlite3_busy_timeout(pDb, 5000))
        DB-->>New: SQLITE_BUSY (1st attempt)
        New->>DB: internal busy-handler retries<br/>(up to 5000ms)
        Prev-->>DB: lock finally released
        DB-->>New: SQLITE_OK
        New->>New: resetAllSyncing() succeeds -> FIM initializes normally
        Note over New: Agent stays up.<br/>WazuhSvc stays Running.
    end
```

Closes #38486

## Proposed Changes

- `SQLite3Wrapper::Connection` (used by `PersistentQueueStorage` for every module's persistent sync queue — FIM, syscollector, sca — and by `wazuh_db`'s HTTP server endpoints) now calls `sqlite3_busy_timeout()` right after opening the database, with a 5-second ceiling. A transient lock left by a previous process instance is now waited out instead of surfacing as an immediate, fatal `SQLITE_BUSY`. This is applied consistently across both of this class's constructors — the path-based one used by `PersistentQueueStorage`, and the raw-handle one used directly by `wazuh_db`'s HTTP server (`wdb_http.cpp`), which previously fell through without the timeout.
- DBSync — used by syscollector, sca, agent_info, and vulnerability_scanner — implements its own separate SQLite connection wrapper (`shared_modules/dbsync/src/sqlite/sqlite_wrapper.cpp`) rather than going through `SQLite3Wrapper::Connection`. It now gets the identical `sqlite3_busy_timeout()` fix, so the `sqlite: database is locked` / `cannot commit transaction` noise from syscollector's own persistent queue (quoted in the log evidence below) is now actually resolved by this PR, not just a coincidentally similar class of error.
- Added unit tests that exercise the exact production code path and SQL statement involved in the reported collision, for both wrapper implementations (see Tests Introduced below).

### Results and Evidence

**Root cause traced against the reporter's own log, line by line.** Below is the raw `ossec.log` capture from the affected host, covering the full incident from the agent's initial enrollment through the fatal restart and final shutdown. Every line kept is quoted exactly as it appears in the log (full timestamp, module tag, level); only large blocks of identically-shaped, non-diagnostic repetition are omitted, each explicitly marked with what was removed and how many lines:

<details>
<summary>ossec.log excerpt (raw, timestamps as recorded on the host) — click to expand</summary>

```
2026/08/20 05:48:17 wazuh-agent: INFO: (1410): Reading authentication keys file.
2026/08/20 05:48:17 wazuh-agent: INFO: Using notify time: 10 and max time to reconnect: 60
2026/08/20 05:48:17 wazuh-agent: INFO: Started (pid: 1700).
2026/08/20 05:48:17 wazuh-agent: INFO: Requesting a key from server: 172.31.47.12
2026/08/20 05:48:17 wazuh-agent: INFO: Using password specified on file: authd.pass
2026/08/20 05:48:17 wazuh-agent: INFO: Using agent name as: demo-env-windows-agent
2026/08/20 05:48:17 wazuh-agent: INFO: Waiting for server reply
2026/08/20 05:48:17 wazuh-agent: INFO: Valid key received
2026/08/20 05:48:37 wazuh-agent: INFO: (1410): Reading authentication keys file.
2026/08/20 05:48:37 wazuh-agent: INFO: https_client: starting.
2026/08/20 05:48:37 wazuh-agentd:https-client: INFO: TLS verification is DISABLED (verify_mode=none).
2026/08/20 05:48:37 wazuh-agentd:https-client: INFO: Starting https_client (server=172.31.47.12:1517, agent=005).
2026/08/20 05:48:38 wazuh-agent: INFO: Agent is reloading due to shared configuration changes.
2026/08/20 05:48:38 wazuh-agent: INFO: Agent control: reload command received.
2026/08/20 05:48:38 wazuh-agent: INFO: Agent control: 'reload' command received, detached restart process spawned.
2026/08/20 05:48:39 wazuh-agent: INFO: Received exit signal. Starting exit process.
2026/08/20 05:48:39 wazuh-agent: INFO: Set pending exit signal.
2026/08/20 05:48:40 wazuh-rootcheck: INFO: Started (pid: 1700).

[... 33 identical-shaped "wazuh-agent: INFO: (6002): Monitoring registry entry: '<path>', with options '...'" lines omitted (FIM's registry-monitoring setup log, one per configured registry path, no diagnostic value here) ...]

2026/08/20 05:48:40 wazuh-agent: INFO: Started (pid: 1700).
2026/08/20 05:48:40 wazuh-agent: INFO: (1951): Analyzing event log: 'Application'.
2026/08/20 05:48:40 wazuh-agent: INFO: (1951): Analyzing event log: 'Security'.
2026/08/20 05:48:40 wazuh-agent: INFO: (1951): Analyzing event log: 'System'.
2026/08/20 05:48:40 wazuh-modulesd:agent-upgrade: INFO: Started (pid: 1700).
2026/08/20 05:48:40 wazuh-agent: INFO: (6000): Starting daemon...
2026/08/20 05:48:40 wazuh-agent: INFO: (6010): File integrity monitoring scan frequency: 43200 seconds
2026/08/20 05:48:40 wazuh-agent: INFO: (6008): File integrity monitoring scan started.
2026/08/20 05:48:40 wazuh-modulesd:syscollector: INFO: Started (pid: 1700).
2026/08/20 05:48:40 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/08/20 05:48:40 wazuh-modulesd:sca: INFO: Started (pid: 1700).
2026/08/20 05:48:41 wazuh-rootcheck: INFO: Starting rootcheck scan.
2026/08/20 05:48:41 wazuh-modulesd:sca: INFO: SCA module stopped.
2026/08/20 05:48:41 wazuh-agent: INFO: Started (pid: 1700).
2026/08/20 05:48:41 wazuh-agent: INFO: Startup completed. Runtime-discovered files will be read from beginning.
2026/08/20 05:48:42 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2026/08/20 05:48:46 wazuh-rootcheck: INFO: Rootcheck scan ended.
2026/08/20 05:48:52 wazuh-modulesd:syscollector: INFO: Syscollector did not confirm shutdown within 10 seconds; releasing resources and continuing.
2026/08/20 05:48:56 wazuh-agent: INFO: (6009): File integrity monitoring scan ended.
2026/08/20 05:48:56 wazuh-agent: INFO: Starting FIM synchronization.
2026/08/20 05:48:56 wazuh-agent: INFO: (6012): Real-time file integrity monitoring started.
2026/08/20 05:48:59 wazuh-agent: ERROR: Module 'syscollector' worker thread did not exit within the 20000 ms shutdown budget; shutdown will proceed while it may still be running.
2026/08/20 05:48:59 wazuh-agent: INFO: Exit completed successfully.
2026/08/20 05:48:59 wazuh-agentd:https-client: INFO: Stopping https_client.
2026/08/20 05:49:00 wazuh-agent: INFO: (1314): Shutdown received. Deleting responses.
2026/08/20 05:49:00 wazuh-modulesd:agent-info: INFO: AgentInfo module stopped.
2026/08/20 05:49:00 wazuh-modulesd:agent-info: INFO: AgentInfo destroyed.
2026/08/20 05:49:00 wazuh-agent: INFO: (1410): Reading authentication keys file.
2026/08/20 05:49:00 wazuh-agent: INFO: Using notify time: 10 and max time to reconnect: 60
2026/08/20 05:49:00 wazuh-agent: INFO: Started (pid: 6672).
2026/08/20 05:49:00 wazuh-agent: INFO: https_client: starting.
2026/08/20 05:49:00 wazuh-agentd:https-client: INFO: TLS verification is DISABLED (verify_mode=none).
2026/08/20 05:49:00 wazuh-agentd:https-client: INFO: Starting https_client (server=172.31.47.12:1517, agent=005).
2026/08/20 05:49:02 wazuh-rootcheck: INFO: Started (pid: 6672).

[... 33 identical-shaped "wazuh-agent: INFO: (6002): Monitoring registry entry: '<path>', with options '...'" lines omitted (same FIM registry-monitoring setup log, this time for pid 6672's own startup) ...]

2026/08/20 05:49:02 wazuh-agent: INFO: Started (pid: 6672).
2026/08/20 05:49:02 wazuh-modulesd:agent-upgrade: INFO: Started (pid: 6672).
2026/08/20 05:49:02 wazuh-agent: INFO: (1951): Analyzing event log: 'Application'.
2026/08/20 05:49:02 wazuh-agent: INFO: (1951): Analyzing event log: 'Security'.
2026/08/20 05:49:02 wazuh-agent: INFO: (1951): Analyzing event log: 'System'.
2026/08/20 05:49:02 wazuh-modulesd:agent-info: INFO: Started (pid: 6672).
2026/08/20 05:49:02 wazuh-agent: ERROR: PersistentQueue: Error on DB: database is locked
2026/08/20 05:49:02 wazuh-agent: ERROR: Failed to initialize PersistentQueue: database is locked
2026/08/20 05:49:02 wazuh-agent: CRITICAL: Failed to initialize AgentSyncProtocol
2026/08/20 05:49:02 wazuh-modulesd:sca: INFO: Started (pid: 6672).
2026/08/20 05:49:02 wazuh-agent: INFO: Received exit signal. Starting exit process.
2026/08/20 05:49:02 wazuh-agent: INFO: Set pending exit signal.
2026/08/20 05:49:02 wazuh-modulesd:syscollector: INFO: Started (pid: 6672).
2026/08/20 05:49:02 wazuh-modulesd:syscollector: ERROR: Failed to delete row: sqlite: database is locked
2026/08/20 05:49:02 wazuh-modulesd:syscollector: ERROR: Failed to update sync flag: sqlite: COMMIT TRANSACTION. cannot commit transaction - SQL statements in progress

[... 63 more raw ERROR lines at this same 2026/08/20 05:49:02 timestamp omitted — a mix of "Failed to delete row: sqlite: database is locked" and "Failed to update sync flag: sqlite: COMMIT TRANSACTION. cannot commit transaction - SQL statements in progress", 69 occurrences total in this window (this is syscollector's own persistent queue hitting the identical lock, the sibling #38372/#38373 signature, non-fatal here since syscollector degrades instead of exiting) ...]

2026/08/20 05:49:02 wazuh-modulesd:syscollector: INFO: Starting evaluation.
2026/08/20 05:49:02 wazuh-modulesd:syscollector: ERROR: sqlite: database is locked
2026/08/20 05:49:02 wazuh-modulesd:syscollector: ERROR: sqlite: database is locked
2026/08/20 05:49:02 wazuh-modulesd:syscollector: ERROR: sqlite: database is locked
2026/08/20 05:49:02 wazuh-agent: INFO: Started (pid: 6672).
2026/08/20 05:49:02 wazuh-modulesd:syscollector: ERROR: sqlite: database is locked
2026/08/20 05:49:02 wazuh-agent: INFO: Startup completed. Runtime-discovered files will be read from beginning.
2026/08/20 05:49:02 wazuh-modulesd:agent-info: INFO: AgentInfo module loop ended.
2026/08/20 05:49:02 wazuh-modulesd:agent-info: INFO: AgentInfo module stopped.
2026/08/20 05:49:02 wazuh-modulesd:sca: INFO: SCA module stopped.
2026/08/20 05:49:03 wazuh-modulesd:syscollector: INFO: Stop received for Syscollector.
2026/08/20 05:49:12 wazuh-modulesd:agent-info: WARNING: Cannot observe VD feed offset: DBSync not available
2026/08/20 05:49:13 wazuh-modulesd:syscollector: INFO: Syscollector did not confirm shutdown within 10 seconds; releasing resources and continuing.
2026/08/20 05:49:22 wazuh-modulesd:agent-info: WARNING: Cannot observe VD feed offset: DBSync not available
2026/08/20 05:49:22 wazuh-agent: ERROR: Module 'syscollector' worker thread did not exit within the 20000 ms shutdown budget; shutdown will proceed while it may still be running.
2026/08/20 05:49:22 wazuh-agent: INFO: Exit completed successfully.
2026/08/20 05:49:22 wazuh-agentd:https-client: INFO: Stopping https_client.
2026/08/20 05:49:22 wazuh-agent: INFO: (1314): Shutdown received. Deleting responses.
```

</details>

The failure sequence maps exactly to `fim_initialize()` (`syscheck.c`) → `asp_create()` → `AgentSyncProtocol` ctor → `PersistentQueue` ctor → `PersistentQueueStorage::resetAllSyncing()`'s `BEGIN IMMEDIATE TRANSACTION;`, which is the first statement to actually touch the previous instance's still-open WAL handle:

- `2026/08/20 05:49:02 wazuh-agent: ERROR: PersistentQueue: Error on DB: database is locked` — logged by `PersistentQueue`'s constructor when `resetAllSyncing()` throws.
- `2026/08/20 05:49:02 wazuh-agent: ERROR: Failed to initialize PersistentQueue: database is locked` — logged one level up, by `AgentSyncProtocol`'s constructor catching the re-thrown exception.
- `2026/08/20 05:49:02 wazuh-agent: CRITICAL: Failed to initialize AgentSyncProtocol` — `syscheck.c`'s `merror_exit()` on `asp_create()` returning `NULL`, which terminates the whole process (note every module — syscollector, sca, agent-info — is also mid-startup on `pid 6672` at this exact moment, and all disappear together at the final `2026/08/20 05:49:22 wazuh-agent: INFO: Exit completed successfully.`).
- `2026/08/20 05:48:59 wazuh-agent: ERROR: Module 'syscollector' worker thread did not exit within the 20000 ms shutdown budget; shutdown will proceed while it may still be running.` and its `2026/08/20 05:49:22` repeat show the same host also hitting the sibling #38372/#38373 signature (`sqlite: database is locked` / `cannot commit transaction`, visible throughout `pid 6672`'s syscollector startup between `2026/08/20 05:49:02` and `2026/08/20 05:49:03`) in the same run — consistent with the issue's own framing of this as a more severe member of that same family.

This was independently confirmed against the already-running host the issue was filed from: `WazuhSvc` was still `Stopped`, and the on-disk WAL file sizes for `fim_sync.db-wal` (8,833,312 bytes) and `syscollector_sync.db-wal` (20,632 bytes) matched the issue's own reported numbers exactly, byte for byte — confirming this is the same frozen incident state, not a coincidental re-occurrence.

**Unit-level reproduction of the exact collision, proving both the bug and the fix against the real production code.** A new test opens two real, file-backed connections to the same on-disk WAL-mode database: one holds a genuine `BEGIN IMMEDIATE TRANSACTION;` write lock (standing in for a previous process instance's unreleased WAL handle), the other calls the actual `PersistentQueueStorage::resetAllSyncing()` used in production, while a background thread releases the held lock 300ms later.

- Without the fix (verified by temporarily reverting it), the test fails with:
  ```
  Expected: secondInstanceStorage.resetAllSyncing() doesn't throw an exception.
    Actual: it throws SQLite3Wrapper::Sqlite3Error with description "database is locked".
  ```
  — the identical error string from the real incident.
- With the fix restored, the test passes in ~350ms, waiting out the 300ms simulated lock via the new busy timeout.
- The full existing test suite for this module (181 tests) passes with the fix applied — no regressions.

Live end-to-end reproduction (forcing the originating rapid-restart race against a real, running Windows agent) was also attempted, including replicating the specific shutdown-timing conditions that produce the stale lock. The exact race is timing-sensitive enough that it wasn't reliably reproduced end-to-end in that pass; the unit-level test above instead reproduces the actual failing SQL collision directly against the real classes involved, which is what verifies this fix.

**Coverage gap found in review, closed with a matching fix and test for DBSync.** An earlier version of this PR only fixed `SQLite3Wrapper::Connection`, leaving two paths still exposed to the same immediate-`SQLITE_BUSY` failure: `wazuh_db`'s HTTP server (which constructs `Connection` from a raw handle opened directly in `wdb.c`, bypassing the code path the fix was added to), and DBSync's own separate connection wrapper (the actual source of the syscollector `database is locked` / `cannot commit transaction` lines quoted above). Both are now fixed the same way, and a new test mirroring the `sync_protocol` one was added directly against DBSync's `Connection` class (see Tests Introduced below).

**Full verification pass on this exact commit (`7d76272563`), both at the unit level and on the real host.** Ran both test suites inside the same Docker build image used elsewhere in this repo (`wazuh-cpp-unittest-builder`): `agent_sync_protocol_tests` — 181/181 passed, including the busy-lock test at 357ms (matches the ~350ms reported above); `sqlite_unit_test` (DBSync) — 17/17 passed, including the new DBSync busy-lock test at 337ms. Also built a real Windows package from this commit (`wazuh-agent_5.0.0-0_windows_7d76272.msi`) and installed it as an in-place upgrade over the already-enrolled agent on the same real host used for the original triage (`demo-env-windows-agent`) — enrollment was preserved, the upgrade's own stop/replace/start cycle completed with zero `database is locked` / `CRITICAL:` / `Failed to initialize AgentSyncProtocol` occurrences anywhere in the log, and FIM/registry scans finished cleanly. Re-ran the same live reproduction script used during triage (WMI-provider-host stall) against the patched build for 3 cycles — still `REPRO_NOT_ACHIEVED`, but that's not a meaningful signal either way: checking every historical reproduction log from the original triage shows this exact technique never once reproduced the crash, including a 15-cycle run against the *original unpatched* build. No timing regression observed on normal (non-contended) operation, consistent with `sqlite3_busy_timeout` being a no-op unless an actual lock conflict occurs.

### Manual tests with their corresponding evidence

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [x] Linux
  - [x] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - N/A

- Engine _(Wazuh v5.x and above)_
  - N/A

- Wazuh server API/Framework
  - N/A

### Artifacts Affected

- `src/shared_modules/utils/sqlite3Wrapper.hpp` — shared SQLite connection wrapper used by the agent's persistent sync queues (FIM, syscollector, sca) and by `wazuh_db`'s HTTP server endpoints. No new executables or packages; affects agent and manager builds that link this header.
- `src/shared_modules/dbsync/src/sqlite/sqlite_wrapper.cpp` — DBSync's own separate SQLite connection wrapper, used by syscollector, sca, agent_info, and vulnerability_scanner. No new executables or packages; affects the `dbsync` shared library and anything linking it.

### Configuration Changes

N/A — no new configuration parameters; the busy-timeout value is an internal constant (`DB_BUSY_TIMEOUT_MS`, 5000ms), not user-configurable.

### Tests Introduced

Added `PersistentQueueStorageBusyLockTest.ResetAllSyncingWaitsOutTransientLockInsteadOfFailingImmediately` to the `sync_protocol` test suite. Scope: verifies that `PersistentQueueStorage::resetAllSyncing()` waits out a transient writer lock held by another connection on the same on-disk WAL-mode database instead of failing immediately with `SQLITE_BUSY`, using real (non-mocked) `SQLite3Wrapper::Connection` and `PersistentQueueStorage` instances against a temporary file-backed database. This directly covers the collision reported in this issue at the exact call site (`resetAllSyncing()`'s `BEGIN IMMEDIATE TRANSACTION;`).

Added `SQLiteTest.ConnectionWaitsOutTransientLockInsteadOfFailingImmediately` to DBSync's `sqlite_unit_test` suite (`shared_modules/dbsync/tests/sqlite/sqlite_test.cpp`). Scope: mirrors the test above but against DBSync's own separate `Connection` implementation — opens a second connection while another connection holds a real `BEGIN IMMEDIATE TRANSACTION;` write lock on the same database, releases that lock from a background thread 300ms later, and verifies the second connection waits it out via `sqlite3_busy_timeout()` instead of failing immediately. This directly covers the code path behind syscollector's/sca's/agent_info's `database is locked` / `cannot commit transaction` log noise.

Both suites confirmed passing on this exact commit (181/181 and 17/17 respectively) — see "Full verification pass" under Results and Evidence above.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

Related, same-family issues referenced in the original report (closed previously without a code fix, but relevant to this same underlying SQLite-locking behavior): #37191, #37629, #37742, #36250.

