### PR TITLE
Rename the agent's connection block to `<agent><manager>`

### DIFF
--- a/docs/guide/migration/upgrade-4x-to-5x.md
+++ b/docs/guide/migration/upgrade-4x-to-5x.md
@@ -60,9 +60,9 @@ The following changes were identified during agent startup validation after upgr
 
 | 4.X configuration element | 5.0 status | Agent log message (observed) | Required action |
 |---|---|---|---|
-| `<client>...</client>` | Renamed | `INFO: <agent><server><address> is not configured. Using <client><server><address> 'MANAGER_IP' with the default port 1517.` | Rename the block to `<agent>`. A 5.0 agent still starts without the rename: it reads `<server><address>` from the old block and defaults the port to `1517`. Nothing else inside `<client>` is read. |
-| `<client><manager>...</manager></client>` | Invalid | `INFO: (1230): Invalid element in the configuration: 'manager'.` | Rename `<manager>` to `<server>` inside `<agent>`. The 4.14 templates already ship `<server>`. |
-| `<client><server><port>1514</port></server></client>` | Changed default | — | The agent talks HTTPS to the manager on `1517`. Inside `<agent>`, remove the port to take the new default or set `1517` explicitly; inside a legacy `<client>` block the port is not read at all. |
+| `<client>...</client>` | Renamed | `INFO: <agent><manager><address> is not configured. Using <client><server><address> 'MANAGER_IP' with the default port 1517.` | Rename the block to `<agent>` and its inner `<server>` to `<manager>`. A 5.0 agent still starts without the rename: it reads `<client><server><address>` and defaults the port to `1517`. Nothing else inside `<client>` is read. |
+| `<client><server>...</server></client>` | Renamed | `ERROR: (1230): Invalid element in the configuration: 'server'.` | Rename `<server>` to `<manager>`. This message appears when the root tag was renamed to `<agent>` but the inner block was left as `<server>`, which 5.0 rejects. |
+| `<client><server><port>1514</port></server></client>` | Changed default | — | The agent talks HTTPS to the manager on `1517`. Inside `<agent><manager>`, remove the port to take the new default or set `1517` explicitly; inside a legacy `<client>` block the port is not read at all. |
 | `<client><server><protocol>...</protocol></server></client>` | Ignored | `INFO: Ignoring the 'protocol' option. Switching to TCP.` | Remove `<protocol>`. TCP is used. |
 | `<client><crypto_method>...</crypto_method></client>` | Ignored | `INFO: Ignoring the 'crypto_method' option. Switching to AES.` | Remove `<crypto_method>`. |
 | `<syscheck><scan_on_start>...</scan_on_start></syscheck>` | Invalid | `INFO: (1230): Invalid element in the configuration: 'scan_on_start'.` | Remove this element from `syscheck` (Always executed on start). |
@@ -106,17 +106,17 @@ After (5.0 compatible):
 
 ```xml
 <agent>
-	<server>
+	<manager>
 		<address>MANAGER_IP</address>
 		<port>1517</port>
-	</server>
+	</manager>
 </agent>
 ```
 
-`<client>` is renamed to `<agent>` in 5.0: one block under two names, never both. Options for an agent that is already on 5.0 with the old block:
+`<client>` is renamed to `<agent>` in 5.0 and its inner `<server>` to `<manager>`: one block under two names, never both. Options for an agent that is already on 5.0 with the old block:
 
-- **Leave it.** The agent reads `<server><address>` from `<client>` and uses port `1517`. It connects, and logs which value it inherited. Nothing else in the block is read, so options such as `<enrollment>` or `<config-profile>` stop having an effect.
-- **Rename it** to `<agent>`, which is what a fresh 5.0 install ships. Every option in the block is read again.
+- **Leave it.** The agent reads `<client><server><address>` and uses port `1517`. It connects, and logs which value it inherited. Nothing else in the block is read, so options such as `<enrollment>` or `<config-profile>` stop having an effect.
+- **Rename it** to `<agent><manager>`, which is what a fresh 5.0 install ships. Every option in the block is read again. Renaming only the root tag is not enough: `<agent><server>` is rejected.
 
 Recommended: rename it. The fallback exists so a remote upgrade cannot strand an agent, not as a configuration to keep.
 
@@ -190,7 +190,7 @@ Workaround checklist:
 - Confirm manager is up and reachable from the agent host.
 - Confirm manager has been migrated to a compatible 5.0 deployment.
 - Confirm firewall/network rules allow `1517/tcp` (agent to manager) and `1515/tcp` (enrollment).
-- Confirm the agent points to the correct manager address in `<agent><server><address>`.
+- Confirm the agent points to the correct manager address in `<agent><manager><address>`.
 - Confirm enrollment credentials: if enrollment fails with `Invalid password (from manager)`, verify that the password in `/var/ossec/etc/authd.pass` on the agent matches `/var/wazuh-manager/etc/authd.pass` on the manager.
 
 ## Remote upgrade (WPK)
@@ -206,7 +206,7 @@ Before installing anything, the WPK installer checks that the manager accepts co
 
 The abort happens before the package manager runs, so the agent stays on 4.14.X, keeps running, and the upgrade can be retried once `1517` is reachable. `upgrade_result` is `2`.
 
-The target address and port come from the same place the agent reads them: `<agent><server>` first, then `<client><server><address>`, with `1517` as the port default.
+The target address and port come from the same place the agent reads them: `<agent><manager>` first, then `<client><server><address>`, with `1517` as the port default.
 
 ## TLS 1.3 enrollment enforcement (`wazuh-authd`)
 
@@ -258,7 +258,7 @@ Migration is complete when all conditions below are met:
 
 - Agent was upgraded using the required version path.
 - No invalid `syscheck`/`rootcheck` element warnings remain.
-- The connection block is `<agent>`, and no `<client>` fallback message remains in `ossec.log`.
+- The connection block is `<agent><manager>`, and no `<client>` fallback message remains in `ossec.log`.
 - No deprecated `protocol` or `crypto_method` messages remain.
 - Agent stays connected to the manager and sends events normally.
 - No TLS 1.3 enrollment errors (`Invalid TLS 1.3 cipher suite...`, `Could not set up SSL connection...`) appear in `wazuh-authd` or agent logs, and enrollment against the 5.0 manager succeeds.

--- a/docs/guide/migration/upgrade-4x-to-5x.md
+++ b/docs/guide/migration/upgrade-4x-to-5x.md
@@ -60,8 +60,8 @@ The following changes were identified during agent startup validation after upgr
 
 | 4.X configuration element | 5.0 status | Agent log message (observed) | Required action |
 |---|---|---|---|
-| `<client>...</client>` | Renamed | `INFO: <agent><manager><address> is not configured. Using <client><server><address> 'MANAGER_IP' with the default port 1517.` | Rename the block to `<agent>` and its inner `<server>` to `<manager>`. A 5.0 agent still starts without the rename: it reads `<client><server><address>` and defaults the port to `1517`. Nothing else inside `<client>` is read. |
-| `<client><server>...</server></client>` | Renamed | `ERROR: (1230): Invalid element in the configuration: 'server'.` | Rename `<server>` to `<manager>`. This message appears when the root tag was renamed to `<agent>` but the inner block was left as `<server>`, which 5.0 rejects. |
+| `<client>...</client>` | Renamed | — | Rename the block to `<agent>` and its inner `<server>` to `<manager>`. Only `<server><address>` is read out of a `<client>` block, so every other option in it (`<enrollment>`, `<config-profile>`, `<notify_time>`) stops taking effect until the block is renamed. |
+| `<client><server><address>` | Read as fallback | `INFO: <agent><manager><address> is not configured. Using <client><server><address> 'MANAGER_IP' with the default port 1517.` | None, to keep connecting: this is the one value a 5.0 agent still takes from a legacy block, with the port defaulted to `1517`. Move it to `<agent><manager><address>` for the supported end state. |
 | `<client><server><port>1514</port></server></client>` | Changed default | — | The agent talks HTTPS to the manager on `1517`. Inside `<agent><manager>`, remove the port to take the new default or set `1517` explicitly; inside a legacy `<client>` block the port is not read at all. |
 | `<client><server><protocol>...</protocol></server></client>` | Ignored | `INFO: Ignoring the 'protocol' option. Switching to TCP.` | Remove `<protocol>`. TCP is used. |
 | `<client><crypto_method>...</crypto_method></client>` | Ignored | `INFO: Ignoring the 'crypto_method' option. Switching to AES.` | Remove `<crypto_method>`. |

--- a/docs/ref/modules/client/README.md
+++ b/docs/ref/modules/client/README.md
@@ -60,11 +60,11 @@ Quick configuration example:
 
 ```xml
 <agent>
-  <server>
+  <manager>
     <address>manager.example.com</address>
     <port>1517</port>
     <protocol>tcp</protocol>
-  </server>
+  </manager>
   <config-profile>web-servers</config-profile>
   <auto_restart>yes</auto_restart>
 </agent>

--- a/docs/ref/modules/client/configuration.md
+++ b/docs/ref/modules/client/configuration.md
@@ -18,11 +18,11 @@ For module overview and architecture, see [Client Module](index.html).
 
 Configures the agent's connection to the Wazuh manager.
 
-`<client>` is the 4.X name of this block and is renamed to `<agent>` in 5.0. A configuration left by a 4.X agent still starts: `<server><address>` is read from `<client>` and the port defaults to `1517`. No other option inside `<client>` is read, so rename the block to `<agent>` to keep them all.
+`<client>` is the 4.X name of this block and is renamed to `<agent>` in 5.0; the inner block is `<manager>`. A configuration left by a 4.X agent still starts: `<client><server><address>` is read and the port defaults to `1517`. No other option inside `<client>` is read, so rename the block to `<agent><manager>` to keep them all.
 
-### server
+### manager
 
-Manager server configuration block.
+Manager connection configuration block.
 
 **Sub-options:**
 
@@ -30,7 +30,7 @@ Manager server configuration block.
 
 Manager IP address or hostname.
 
-- **Required:** Yes (at least one server must be defined)
+- **Required:** Yes (at least one manager must be defined)
 - **Allowed values:** Valid IPv4, IPv6 address, or hostname
 - **Example:** `192.168.1.100`, `manager.example.com`, `::1`
 
@@ -129,7 +129,7 @@ Automatically restart agent when receiving configuration updates from manager.
 
 Agent auto-enrollment configuration block (optional). Since 5.0.0 (#38465),
 enrollment runs over the same HTTPS channel and TLS material as every other
-manager endpoint — it dials `<agent><server>` and presents `<agent><ssl>`,
+manager endpoint — it dials `<agent><manager>` and presents `<agent><ssl>`,
 instead of opening a second connection to `authd` on port 1515. There is no
 longer a separate address/port/certificate/key/CA/cipher configuration for
 enrollment: the options that used to duplicate that (see **Removed options**
@@ -195,7 +195,7 @@ Use agent's source IP address for enrollment instead of configured address.
 #### Removed options
 
 The following options are **no longer used**: `manager_address`, `port`,
-`interface_index` (superseded by `<agent><server>`) and `ssl_cipher`,
+`interface_index` (superseded by `<agent><manager>`) and `ssl_cipher`,
 `server_ca_path`, `agent_certificate_path`, `agent_key_path` (superseded by
 `<agent><ssl>`). A configuration carrying them — e.g. left over from a 4.x
 `ossec.conf`, which an in-place upgrade does not rewrite — still starts the
@@ -383,11 +383,11 @@ Single manager, standard settings:
 
 ```xml
 <agent>
-  <server>
+  <manager>
     <address>10.0.0.10</address>
     <port>1517</port>
     <protocol>tcp</protocol>
-  </server>
+  </manager>
   <config-profile>webserver,production</config-profile>
   <notify_time>60</notify_time>
   <time-reconnect>60</time-reconnect>
@@ -408,11 +408,11 @@ Automatic agent registration:
     <groups>webservers,production</groups>
     <authorization_pass_path>/var/ossec/etc/authd.pass</authorization_pass_path>
   </enrollment>
-  <server>
+  <manager>
     <address>manager.example.com</address>
     <port>1517</port>
     <protocol>tcp</protocol>
-  </server>
+  </manager>
 </agent>
 ```
 
@@ -450,10 +450,10 @@ Full example with all sections:
 ```xml
 <ossec_config>
   <agent>
-    <server>
+    <manager>
       <address>manager1.example.com</address>
       <port>1517</port>
-    </server>
+    </manager>
     <config-profile>webserver,production,linux</config-profile>
     <notify_time>60</notify_time>
     <time-reconnect>60</time-reconnect>

--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -6,10 +6,10 @@
 
 <ossec_config>
   <agent>
-    <server>
+    <manager>
       <address>IP</address>
       <port>1517</port>
-    </server>
+    </manager>
 
     <config-profile>debian, debian8</config-profile>
   </agent>

--- a/etc/templates/config/README.md
+++ b/etc/templates/config/README.md
@@ -44,10 +44,10 @@
 
     <ossec_config>
         <agent>
-          <server>
+          <manager>
             <address>192.168.10.100</address>
             <port>1517</port>
-          </server>
+          </manager>
           <config-profile>distribution, distributionVersion</config-profile>
         </agent>
 

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -17,7 +17,7 @@
  * see w_https_client_start()'s comment) and no alternative transport is
  * offered.
  *
- * The config surface (<server>/<ssl>, parsed by Read_Agent/Read_Agent_SSL
+ * The config surface (<manager>/<ssl>, parsed by Read_Agent/Read_Agent_SSL
  * in src/config/src/client-config.c) and the real TLS wiring are done: the
  * module's own fail-closed validation (ModuleConfig::validateTls) now gets a
  * real verify_mode/CA/cert/key/ciphers instead of a forced HC_VERIFY_NONE.
@@ -1548,7 +1548,7 @@ static bool bridge_key_is_valid(const char *raw_key)
 }
 
 /* Fills the transport-only fields of a hc_config_t from the parsed
- * <server>/<ssl> block (agt->server, agt->ssl) -- everything hc_enroll()
+ * <manager>/<ssl> block (agt->server, agt->ssl) -- everything hc_enroll()
  * needs (#38465) and nothing more: no identity (agent_id/agent_key, which an
  * enrolling agent has neither yet) and none of the full-client-only fields
  * (batch/stats/buffer ladder/sync_socket_path/config_checksum) bridge_build_

--- a/src/client-agent/src/https_client_bridge.h
+++ b/src/client-agent/src/https_client_bridge.h
@@ -38,7 +38,7 @@ int w_https_client_submit_event(const char *frame, size_t length);
 /**
  * @brief Perform exactly one /enroll HTTP request (#38465), against the same
  *        manager/TLS material already configured for every other HTTPS
- *        endpoint (<agent><server>, <agent><ssl>). Handle-less: usable before
+ *        endpoint (<agent><manager>, <agent><ssl>). Handle-less: usable before
  *        the module is started (first-boot enrollment has no handle yet) or
  *        standalone (re-enrollment after a 401). No retry loop -- the caller
  *        (client-agent/src/start_agent.c's try_enroll_to_server()) already

--- a/src/config/include/client-config.h
+++ b/src/config/include/client-config.h
@@ -143,7 +143,7 @@ void Free_Agent(agent * config);
 bool Validate_Address(agent_server *servers);
 
 /**
- * @brief Checks if at least one <server> block is not a link-local ipv6 address or it has a network interface configured.
+ * @brief Checks if at least one <manager> block is not a link-local ipv6 address or it has a network interface configured.
  * @param servers Server(s) configuration block in agent ossec.conf
  * @return Returns true if successful and false if not success.
  */
@@ -171,7 +171,7 @@ void w_read_agent_batch(const char *cfgfile, const char *sharedcfg, agent_batch 
  * (https_client/src/moduleConfig.cpp) and the sync protocol (FULLSESSION_MAX_BYTES). */
 #define DEFAULT_BATCH_SIZE_BYTES (1024 * 1024)
 
-/* Port used when <server><port> is unspecified. Must mirror the manager's
+/* Port used when <manager><port> is unspecified. Must mirror the manager's
  * DEFAULT_HTTPS_PORT (src/remoted/remoted_module/src/http_server/httpServerConfig.cpp)
  * since the agent has no legacy-transport fallback to default to instead. */
 #define DEFAULT_HTTPS_CLIENT_PORT 1517

--- a/src/config/include/client-config.h
+++ b/src/config/include/client-config.h
@@ -86,7 +86,7 @@ typedef struct agent_report {
  * test harness zero-inits the whole agent struct, and the old parser
  * dereferenced a lazily-allocated nested pointer with nothing there yet).
  *
- * `manager_address`/`port`/`interface_index` (superseded by <agent><server>)
+ * `manager_address`/`port`/`interface_index` (superseded by <agent><manager>)
  * and `agent_certificate_path`/`agent_key_path`/`server_ca_path`/`ssl_cipher`
  * (superseded by <agent><ssl>) are gone: enrollment dials the same target
  * and presents the same TLS material as every other HTTPS endpoint, by

--- a/src/config/src/client-config.c
+++ b/src/config/src/client-config.c
@@ -14,7 +14,7 @@
 #include "config.h"
 #include "sec.h"
 
-int Read_Agent_Server(XML_NODE node, agent *logr);
+int Read_Agent_Manager(XML_NODE node, agent *logr);
 int Read_Agent_SSL(XML_NODE node, agent *logr);
 int Read_Agent_Batch(XML_NODE node, agent *logr);
 int Read_Agent_Report(XML_NODE node, agent_report *report);
@@ -34,7 +34,7 @@ int Read_Agent(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
     char * rip = NULL;
 
     /* XML definitions */
-    const char *xml_agent_server = "server";
+    const char *xml_agent_manager = "manager";
     const char *xml_agent_ssl = "ssl";
     const char *xml_agent_batch = "batch";
     const char *xml_agent_stats_report = "stats_report";
@@ -72,7 +72,7 @@ int Read_Agent(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
         }
         /* Get manager IP */
         else if (strcmp(node[i]->element, xml_agent_ip) == 0) {
-            mwarn("The <%s> tag is deprecated, please use <server><address> instead.", xml_agent_ip);
+            mwarn("The <%s> tag is deprecated, please use <manager><address> instead.", xml_agent_ip);
 
             if (OS_IsValidIP(node[i]->content, NULL) != 1) {
                 merror(INVALID_IP, node[i]->content);
@@ -81,7 +81,7 @@ int Read_Agent(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
 
             rip = node[i]->content;
         } else if (strcmp(node[i]->element, xml_agent_hostname) == 0) {
-            mwarn("The <%s> tag is deprecated, please use <server><address> instead.", xml_agent_hostname);
+            mwarn("The <%s> tag is deprecated, please use <manager><address> instead.", xml_agent_hostname);
             if (strchr(node[i]->content, '/') ==  NULL) {
                 snprintf(f_ip, 127, "%s/", node[i]->content);
                 rip = f_ip;
@@ -91,19 +91,19 @@ int Read_Agent(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
             }
 
         }
-        /* Get parameters for the configured server block */
-        else if (strcmp(node[i]->element, xml_agent_server) == 0) {
+        /* Get parameters for the configured manager block */
+        else if (strcmp(node[i]->element, xml_agent_manager) == 0) {
             if (!(chld_node = OS_GetElementsbyNode(xml, node[i]))) {
                 merror(XML_INVELEM, node[i]->element);
                 return (OS_INVALID);
             }
-            if (Read_Agent_Server(chld_node, logr) < 0) {
+            if (Read_Agent_Manager(chld_node, logr) < 0) {
                 OS_ClearNode(chld_node);
                 return (OS_INVALID);
             }
             OS_ClearNode(chld_node);
         } else if (strcmp(node[i]->element, xml_agent_ssl) == 0) {
-            /* HTTPS transport TLS settings (sibling of <server>, #37702 §10). */
+            /* HTTPS transport TLS settings (sibling of <manager>, #37702 §10). */
             if ((chld_node = OS_GetElementsbyNode(xml, node[i]))) {
                 if (Read_Agent_SSL(chld_node, logr) < 0) {
                     OS_ClearNode(chld_node);
@@ -243,8 +243,8 @@ int Read_Agent(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
  */
 int Read_Legacy_Client_Address(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused)) void *d2)
 {
-    const char *xml_agent_server = "server";
-    const char *xml_agent_addr = "address";
+    const char *xml_client_server = "server";
+    const char *xml_client_addr = "address";
     char * address = NULL;
 
     agent * logr = (agent *)d1;
@@ -256,7 +256,7 @@ int Read_Legacy_Client_Address(const OS_XML *xml, XML_NODE node, void *d1, __att
     for (int i = 0; node[i]; i++) {
         XML_NODE chld_node = NULL;
 
-        if (!node[i]->element || strcmp(node[i]->element, xml_agent_server) != 0) {
+        if (!node[i]->element || strcmp(node[i]->element, xml_client_server) != 0) {
             continue;
         }
 
@@ -266,7 +266,7 @@ int Read_Legacy_Client_Address(const OS_XML *xml, XML_NODE node, void *d1, __att
 
         for (int j = 0; chld_node[j]; j++) {
             if (!chld_node[j]->element || !chld_node[j]->content ||
-                strcmp(chld_node[j]->element, xml_agent_addr) != 0) {
+                strcmp(chld_node[j]->element, xml_client_addr) != 0) {
                 continue;
             }
 
@@ -290,7 +290,7 @@ int Read_Legacy_Client_Address(const OS_XML *xml, XML_NODE node, void *d1, __att
     logr->server[0].port = DEFAULT_HTTPS_REMOTE_PORT;
     logr->server_count = 1;
 
-    minfo("<agent><server><address> is not configured. Using <client><server><address> '%s' "
+    minfo("<agent><manager><address> is not configured. Using <client><server><address> '%s' "
           "with the default port %d.", logr->server[0].rip, DEFAULT_HTTPS_REMOTE_PORT);
 
     return (0);
@@ -338,13 +338,13 @@ int Read_Agent_Shared(const OS_XML *xml, XML_NODE node, void *d1)
 }
 
 /**
- * @brief Read the <agent><server> block: the single manager endpoint.
+ * @brief Read the <agent><manager> block: the single manager endpoint.
  *
- * @param node Children of the <server> element.
+ * @param node Children of the <manager> element.
  * @param logr Agent configuration to fill.
  * @return 0 on success, OS_INVALID on error.
  */
-int Read_Agent_Server(XML_NODE node, agent * logr)
+int Read_Agent_Manager(XML_NODE node, agent * logr)
 {
     /* XML definitions */
     const char *xml_agent_addr = "address";
@@ -427,12 +427,12 @@ int Read_Agent_Server(XML_NODE node, agent * logr)
         return (OS_INVALID);
     }
 
-    /* Single <server> block: the last one prevails (#37702 restriction 2) and
+    /* Single <manager> block: the last one prevails (#37702 restriction 2) and
      * server rotation is removed (restriction 3), so replace any previous entry
      * instead of appending. The array keeps a NULL-rip sentinel at index 1. */
     if (logr->server) {
         if (logr->server_count > 0) {
-            mwarn("Only one <server> block is supported; the last one prevails.");
+            mwarn("Only one <manager> block is supported; the last one prevails.");
         }
         for (int k = 0; logr->server[k].rip; k++) {
             os_free(logr->server[k].rip);
@@ -455,7 +455,7 @@ int Read_Agent_Server(XML_NODE node, agent * logr)
     logr->server_count = 1;
 
     if (!port_set) {
-        minfo("<agent><server><port> is not configured. Using the default port %d.",
+        minfo("<agent><manager><port> is not configured. Using the default port %d.",
               DEFAULT_HTTPS_REMOTE_PORT);
     }
 

--- a/src/config/src/client-config.c
+++ b/src/config/src/client-config.c
@@ -836,7 +836,7 @@ int Read_Agent_Enrollment(XML_NODE node, agent * logr){
     const char *xml_delay_after_enrollment = "delay_after_enrollment";
     const char *xml_use_source_ip = "use_source_ip";
 
-    /* Superseded by <agent><server>/<agent><ssl> (#38465): enrollment now
+    /* Superseded by <agent><manager>/<agent><ssl> (#38465): enrollment now
      * dials the same target and presents the same TLS material as every
      * other HTTPS endpoint, so a second address/port/interface/cert/key/CA
      * for it is redundant by design. Recognized-but-ignored rather than
@@ -918,7 +918,7 @@ int Read_Agent_Enrollment(XML_NODE node, agent * logr){
                    strcmp(node[j]->element, xml_agent_certif_path) == 0 ||
                    strcmp(node[j]->element, xml_agent_key_path) == 0) {
             minfo("<%s> under <enrollment> is no longer used: enrollment reuses "
-                  "<agent><server>/<agent><ssl>. Ignoring.", node[j]->element);
+                  "<agent><manager>/<agent><ssl>. Ignoring.", node[j]->element);
         } else {
             merror(XML_INVELEM, node[j]->element);
             return (OS_INVALID);

--- a/src/config/src/config.c
+++ b/src/config/src/config.c
@@ -125,7 +125,7 @@ static int read_main_elements(const OS_XML *xml, int modules,
              * fatal here), so an ossec.conf or a pushed agent.conf still
              * carrying it does not stop the agent from starting. */
             minfo("'%s' is no longer used and will be ignored. Event batching is configured "
-                  "under <client><batch>.", node[i]->element);
+                  "under <agent><batch>.", node[i]->element);
         }
         else if (strcmp(node[i]->element, oswmodule) == 0) {
             if ((modules & CWMODULE) && (Read_WModule(xml, node[i], d1, d2) < 0)) {

--- a/src/config/src/config.c
+++ b/src/config/src/config.c
@@ -101,7 +101,7 @@ static int read_main_elements(const OS_XML *xml, int modules,
         } else if (chld_node && (strcmp(node[i]->element, osclient) == 0)) {
             /* 4.x spelled this block <client> (#38103). An upgrade never rewrites
              * ossec.conf, so the block is still accepted, but only <server><address>
-             * is read from it - as the fallback for <agent><server><address>. */
+             * is read from it - as the fallback for <agent><manager><address>. */
             if (modules & CCLIENT) {
                 if (modules & CAGENT_CONFIG) {
                     if (Read_Agent_Shared(xml, chld_node, d1) < 0){

--- a/src/init/inst-functions.sh
+++ b/src/init/inst-functions.sh
@@ -376,16 +376,16 @@ WriteAgent()
     echo "" >> $NEWCONFIG
 
     echo "<ossec_config>" >> $NEWCONFIG
-    # <client> is renamed to <agent> in 5.x: same options, new block name.
+    # <client> is renamed to <agent> in 5.x; the inner block stays <manager>.
     echo "  <agent>" >> $NEWCONFIG
-    echo "    <server>" >> $NEWCONFIG
+    echo "    <manager>" >> $NEWCONFIG
     if [ "X${HNAME}" = "X" ]; then
       echo "      <address>$SERVER_IP</address>" >> $NEWCONFIG
     else
       echo "      <address>$HNAME</address>" >> $NEWCONFIG
     fi
     echo "      <port>1517</port>" >> $NEWCONFIG
-    echo "    </server>" >> $NEWCONFIG
+    echo "    </manager>" >> $NEWCONFIG
     if [ "X${USER_AGENT_CONFIG_PROFILE}" != "X" ]; then
          PROFILE=${USER_AGENT_CONFIG_PROFILE}
          echo "    <config-profile>$PROFILE</config-profile>" >> $NEWCONFIG

--- a/src/init/pkg_installer.sh
+++ b/src/init/pkg_installer.sh
@@ -100,14 +100,14 @@ probe_server() {
     return $?
 }
 
-# The 5x agent reads the server address from the <agent> block, falling back to the <client> block when upgrading from 4x versions.
-SERVER_ADDRESS=$(xml_value agent server address)
+# The 5x agent reads the manager address from <agent><manager>, falling back to <client><server> when upgrading from 4x versions.
+SERVER_ADDRESS=$(xml_value agent manager address)
 if [ -z "${SERVER_ADDRESS}" ]; then
     SERVER_ADDRESS=$(xml_value client server address)
 fi
 
-# The 5x agent reads the server port from the <agent> block, falling back to 1517 when upgrading from 4x versions.
-SERVER_PORT=$(xml_value agent server port)
+# The 5x agent reads the manager port from <agent><manager>, falling back to 1517 when upgrading from 4x versions.
+SERVER_PORT=$(xml_value agent manager port)
 if [ -z "${SERVER_PORT}" ]; then
     SERVER_PORT=1517
 fi

--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -148,15 +148,15 @@ add_adress_block() {
     # Remove both server and legacy manager configuration blocks
     ${sed} "/<manager>/,/\/manager>/d; /<server>/,/\/server>/d" "${CONF_FILE}"
 
-    # Only one <server> block is supported; if WAZUH_MANAGER carries several
+    # Only one <manager> block is supported; if WAZUH_MANAGER carries several
     # comma-separated addresses, the last one prevails (server rotation was
     # removed, #37702 restrictions 2/3), matching the client parser.
     last_index=$(( ${#ADDRESSES[@]} - 1 ))
     {
-        echo "    <server>"
+        echo "    <manager>"
         echo "      <address>${ADDRESSES[last_index]}</address>"
         echo "      <port>1517</port>"
-        echo "    </server>"
+        echo "    </manager>"
     } >> "${TMP_SERVER}"
 
     insert_into_agent_block "${TMP_SERVER}"

--- a/src/init/tests/test_register_configure_agent.sh
+++ b/src/init/tests/test_register_configure_agent.sh
@@ -93,9 +93,9 @@ missing_lines() {
 
 MULTILINE_CONF='<ossec_config>
   <agent>
-    <server>
+    <manager>
       <address>MANAGER_IP</address>
-    </server>
+    </manager>
     <enrollment>
       <enabled>yes</enabled>
       <port>1515</port>
@@ -110,7 +110,7 @@ MULTILINE_CONF='<ossec_config>
 
 SINGLE_LINE_CONF='<ossec_config>
   <agent>
-    <server><address>MANAGER_IP</address></server>
+    <manager><address>MANAGER_IP</address></manager>
     <enrollment><enabled>yes</enabled><port>1515</port></enrollment>
     <config-profile>CONFIG_PROFILE</config-profile>
   </agent>
@@ -122,9 +122,9 @@ SINGLE_LINE_CONF='<ossec_config>
 
 NO_ENROLLMENT_CONF='<ossec_config>
   <agent>
-    <server>
+    <manager>
       <address>MANAGER_IP</address>
-    </server>
+    </manager>
   </agent>
   <rootcheck>
     <disabled>no</disabled>
@@ -141,9 +141,9 @@ COMMENTED_CONF='<ossec_config>
   </agent>
   -->
   <agent>
-    <server>
+    <manager>
       <address>MANAGER_IP</address>
-    </server>
+    </manager>
   </agent>
 </ossec_config>
 '

--- a/src/unit_tests/config/test_client-config_https.c
+++ b/src/unit_tests/config/test_client-config_https.c
@@ -20,7 +20,7 @@
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../wrappers/wazuh/shared/validate_op_wrappers.h"
 
-/* Read_Agent_Server validates every <address> through OS_IsValidIP; queue one
+/* Read_Agent_Manager validates every <address> through OS_IsValidIP; queue one
  * "valid IPv4, no expansion needed" expectation per <address> in the fragment
  * before calling parse_agent(). */
 static void expect_valid_ip(const char *ip) {
@@ -78,7 +78,7 @@ static void test_ssl_full_verification_mode(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<ssl>"
         "<certificate>/etc/wazuh/agent.pem</certificate>"
         "<key>/etc/wazuh/agent.key</key>"
@@ -110,7 +110,7 @@ static void test_ssl_ciphers_accepts_a_tls13_suite_list(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<ssl><ciphers>TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256</ciphers></ssl>";
 
     expect_valid_ip("10.0.0.1");
@@ -126,7 +126,7 @@ static void test_ssl_ciphers_rejects_a_tls12_cipher_string(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<ssl><ciphers>HIGH:!aNULL</ciphers></ssl>";
 
     expect_valid_ip("10.0.0.1");
@@ -145,7 +145,7 @@ static void test_ssl_ciphers_rejects_a_list_of_separators(void **state) {
 
     /* Every element is empty, so there is no suite at all. */
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<ssl><ciphers>:::</ciphers></ssl>";
 
     expect_valid_ip("10.0.0.1");
@@ -166,7 +166,7 @@ static void test_ssl_ciphers_rejects_a_leading_separator(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<ssl><ciphers>:TLS_AES_128_GCM_SHA256</ciphers></ssl>";
 
     expect_valid_ip("10.0.0.1");
@@ -184,7 +184,7 @@ static void test_ssl_ciphers_rejects_a_trailing_separator(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<ssl><ciphers>TLS_AES_128_GCM_SHA256:</ciphers></ssl>";
 
     expect_valid_ip("10.0.0.1");
@@ -202,7 +202,7 @@ static void test_ssl_ciphers_rejects_a_doubled_separator(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<ssl><ciphers>TLS_AES_128_GCM_SHA256::TLS_AES_256_GCM_SHA384</ciphers></ssl>";
 
     expect_valid_ip("10.0.0.1");
@@ -221,7 +221,7 @@ static void test_ssl_certificate_verification_mode(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<ssl><verification_mode>certificate</verification_mode></ssl>";
 
     expect_valid_ip("10.0.0.1");
@@ -237,7 +237,7 @@ static void test_ssl_none_verification_mode(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<ssl><verification_mode>none</verification_mode></ssl>";
 
     expect_valid_ip("10.0.0.1");
@@ -255,7 +255,7 @@ static void test_ssl_zero_initialized_reads_as_full(void **state) {
     /* No <ssl> block at all: a zero-initialized struct reads as FULL
      * (AGENT_VERIFY_FULL == 0), so a caller that never sets a default still
      * fails closed rather than silently disabling verification. */
-    const char *xml_str = "<server><address>10.0.0.1</address><port>1517</port></server>";
+    const char *xml_str = "<manager><address>10.0.0.1</address><port>1517</port></manager>";
 
     expect_valid_ip("10.0.0.1");
     assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
@@ -272,7 +272,7 @@ static void test_ssl_absent_keeps_the_default_the_caller_set(void **state) {
     /* The parser never invents a verification mode, which is what lets ClientConf
      * own the agent's own default of NONE: with no <ssl> block the value the
      * caller came in with is still there afterwards. */
-    const char *xml_str = "<server><address>10.0.0.1</address><port>1517</port></server>";
+    const char *xml_str = "<manager><address>10.0.0.1</address><port>1517</port></manager>";
 
     memset(&cfg, 0, sizeof(cfg));
     cfg.ssl.verification_mode = AGENT_VERIFY_NONE;
@@ -290,7 +290,7 @@ static void test_ssl_invalid_verification_mode_is_rejected(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<ssl><verification_mode>bogus</verification_mode></ssl>";
 
     expect_valid_ip("10.0.0.1");
@@ -308,7 +308,7 @@ static void test_ssl_invalid_tag_is_rejected(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<ssl><bogus_tag>x</bogus_tag></ssl>";
 
     expect_valid_ip("10.0.0.1");
@@ -320,14 +320,14 @@ static void test_ssl_invalid_tag_is_rejected(void **state) {
     cleanup(&xml, nodes, &cfg);
 }
 
-/* <server> naming and the endpoint it carries */
+/* <manager> naming and the endpoint it carries */
 
-static void test_server_address_and_explicit_port(void **state) {
+static void test_manager_address_and_explicit_port(void **state) {
     OS_XML xml = {0};
     xml_node **nodes;
     agent cfg;
 
-    const char *xml_str = "<server><address>10.0.0.1</address><port>8443</port></server>";
+    const char *xml_str = "<manager><address>10.0.0.1</address><port>8443</port></manager>";
 
     expect_valid_ip("10.0.0.1");
 
@@ -340,36 +340,36 @@ static void test_server_address_and_explicit_port(void **state) {
     cleanup(&xml, nodes, &cfg);
 }
 
-static void test_manager_tag_is_rejected(void **state) {
+static void test_server_tag_is_rejected(void **state) {
     OS_XML xml = {0};
     xml_node **nodes;
     agent cfg;
 
-    const char *xml_str = "<manager><address>10.0.0.1</address></manager>";
+    const char *xml_str = "<server><address>10.0.0.1</address></server>";
 
     expect_string(__wrap__merror, formatted_msg,
-                  "(1230): Invalid element in the configuration: 'manager'.");
+                  "(1230): Invalid element in the configuration: 'server'.");
 
     assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), OS_INVALID);
 
     cleanup(&xml, nodes, &cfg);
 }
 
-/* Single <server>: the last one prevails (#37702 restriction 2) */
+/* Single <manager>: the last one prevails (#37702 restriction 2) */
 
-static void test_second_server_block_prevails_with_warning(void **state) {
+static void test_second_manager_block_prevails_with_warning(void **state) {
     OS_XML xml = {0};
     xml_node **nodes;
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1514</port></server>"
-        "<server><address>10.0.0.2</address><port>8443</port></server>";
+        "<manager><address>10.0.0.1</address><port>1514</port></manager>"
+        "<manager><address>10.0.0.2</address><port>8443</port></manager>";
 
     expect_valid_ip("10.0.0.1");
     expect_valid_ip("10.0.0.2");
     expect_string(__wrap__mwarn, formatted_msg,
-                  "Only one <server> block is supported; the last one prevails.");
+                  "Only one <manager> block is supported; the last one prevails.");
 
     assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
 
@@ -380,14 +380,14 @@ static void test_second_server_block_prevails_with_warning(void **state) {
     cleanup(&xml, nodes, &cfg);
 }
 
-/* <agent><server> and the one value still read from a legacy <client> (#38103) */
+/* <agent><manager> and the one value still read from a legacy <client> (#38103) */
 
-static void test_agent_server_address_and_port_are_parsed(void **state) {
+static void test_agent_manager_address_and_port_are_parsed(void **state) {
     OS_XML xml = {0};
     xml_node **nodes;
     agent cfg;
 
-    const char *xml_str = "<server><address>10.0.0.5</address><port>1600</port></server>";
+    const char *xml_str = "<manager><address>10.0.0.5</address><port>1600</port></manager>";
 
     expect_valid_ip("10.0.0.5");
 
@@ -400,16 +400,16 @@ static void test_agent_server_address_and_port_are_parsed(void **state) {
     cleanup(&xml, nodes, &cfg);
 }
 
-static void test_agent_server_port_defaults_to_1517(void **state) {
+static void test_agent_manager_port_defaults_to_1517(void **state) {
     OS_XML xml = {0};
     xml_node **nodes;
     agent cfg;
 
-    const char *xml_str = "<server><address>10.0.0.5</address></server>";
+    const char *xml_str = "<manager><address>10.0.0.5</address></manager>";
 
     expect_valid_ip("10.0.0.5");
     expect_string(__wrap__minfo, formatted_msg,
-                  "<agent><server><port> is not configured. Using the default port 1517.");
+                  "<agent><manager><port> is not configured. Using the default port 1517.");
 
     assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
     assert_int_equal(cfg.server[0].port, DEFAULT_HTTPS_REMOTE_PORT);
@@ -425,7 +425,7 @@ static void test_legacy_client_address_is_the_fallback(void **state) {
     memset(&cfg, 0, sizeof(cfg));
 
     expect_string(__wrap__minfo, formatted_msg,
-                  "<agent><server><address> is not configured. Using <client><server><address> "
+                  "<agent><manager><address> is not configured. Using <client><server><address> "
                   "'10.0.0.1' with the default port 1517.");
 
     assert_int_equal(parse_legacy_client("<server><address>10.0.0.1</address><port>1517</port></server>",
@@ -453,7 +453,7 @@ static void test_legacy_client_reads_nothing_but_the_address(void **state) {
     memset(&cfg, 0, sizeof(cfg));
 
     expect_string(__wrap__minfo, formatted_msg,
-                  "<agent><server><address> is not configured. Using <client><server><address> "
+                  "<agent><manager><address> is not configured. Using <client><server><address> "
                   "'10.0.0.1' with the default port 1517.");
 
     assert_int_equal(parse_legacy_client(xml_str, &xml, &nodes, &cfg), 0);
@@ -481,7 +481,7 @@ static void test_legacy_client_takes_the_last_address(void **state) {
     memset(&cfg, 0, sizeof(cfg));
 
     expect_string(__wrap__minfo, formatted_msg,
-                  "<agent><server><address> is not configured. Using <client><server><address> "
+                  "<agent><manager><address> is not configured. Using <client><server><address> "
                   "'10.0.0.2' with the default port 1517.");
 
     assert_int_equal(parse_legacy_client(xml_str, &xml, &nodes, &cfg), 0);
@@ -518,7 +518,7 @@ static void test_agent_block_replaces_a_legacy_address(void **state) {
     memset(&cfg, 0, sizeof(cfg));
 
     expect_string(__wrap__minfo, formatted_msg,
-                  "<agent><server><address> is not configured. Using <client><server><address> "
+                  "<agent><manager><address> is not configured. Using <client><server><address> "
                   "'10.0.0.1' with the default port 1517.");
 
     assert_int_equal(parse_legacy_client("<server><address>10.0.0.1</address><port>1517</port></server>",
@@ -526,9 +526,9 @@ static void test_agent_block_replaces_a_legacy_address(void **state) {
 
     expect_valid_ip("10.0.0.5");
     expect_string(__wrap__mwarn, formatted_msg,
-                  "Only one <server> block is supported; the last one prevails.");
+                  "Only one <manager> block is supported; the last one prevails.");
 
-    assert_int_equal(parse_agent_into("<server><address>10.0.0.5</address><port>1600</port></server>",
+    assert_int_equal(parse_agent_into("<manager><address>10.0.0.5</address><port>1600</port></manager>",
                                       &agent_xml, &agent_nodes, &cfg), 0);
 
     assert_int_equal(cfg.server_count, 1);
@@ -549,7 +549,7 @@ static void test_legacy_client_is_ignored_once_agent_set_the_address(void **stat
 
     expect_valid_ip("10.0.0.5");
 
-    assert_int_equal(parse_agent("<server><address>10.0.0.5</address><port>1600</port></server>",
+    assert_int_equal(parse_agent("<manager><address>10.0.0.5</address><port>1600</port></manager>",
                                  &agent_xml, &agent_nodes, &cfg), 0);
 
     assert_int_equal(parse_legacy_client("<server><address>10.0.0.1</address><port>1517</port></server>",
@@ -572,7 +572,7 @@ static void test_agent_block_reads_the_legacy_client_options(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<ssl><verification_mode>full</verification_mode></ssl>"
         "<config-profile>debian, debian8</config-profile>"
         "<notify_time>20</notify_time>"
@@ -603,7 +603,7 @@ static void test_fresh_install_template_shape(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<config-profile>debian, debian8</config-profile>";
 
     expect_valid_ip("10.0.0.1");
@@ -645,7 +645,7 @@ static void test_enrollment_kept_options_are_parsed(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<enrollment>"
         "<enabled>no</enabled>"
         "<agent_name>my-agent</agent_name>"
@@ -677,7 +677,7 @@ static void test_enrollment_use_source_ip_yes(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<enrollment><use_source_ip>yes</use_source_ip></enrollment>";
 
     expect_valid_ip("10.0.0.1");
@@ -697,7 +697,7 @@ static void test_enrollment_legacy_options_are_ignored_not_rejected(void **state
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<enrollment>"
         "<manager_address>old-manager.example</manager_address>"
         "<port>1515</port>"
@@ -711,25 +711,25 @@ static void test_enrollment_legacy_options_are_ignored_not_rejected(void **state
     expect_valid_ip("10.0.0.1");
     expect_string(__wrap__minfo, formatted_msg,
                   "<manager_address> under <enrollment> is no longer used: enrollment reuses "
-                  "<agent><server>/<agent><ssl>. Ignoring.");
+                  "<agent><manager>/<agent><ssl>. Ignoring.");
     expect_string(__wrap__minfo, formatted_msg,
                   "<port> under <enrollment> is no longer used: enrollment reuses "
-                  "<agent><server>/<agent><ssl>. Ignoring.");
+                  "<agent><manager>/<agent><ssl>. Ignoring.");
     expect_string(__wrap__minfo, formatted_msg,
                   "<interface_index> under <enrollment> is no longer used: enrollment reuses "
-                  "<agent><server>/<agent><ssl>. Ignoring.");
+                  "<agent><manager>/<agent><ssl>. Ignoring.");
     expect_string(__wrap__minfo, formatted_msg,
                   "<ssl_cipher> under <enrollment> is no longer used: enrollment reuses "
-                  "<agent><server>/<agent><ssl>. Ignoring.");
+                  "<agent><manager>/<agent><ssl>. Ignoring.");
     expect_string(__wrap__minfo, formatted_msg,
                   "<server_ca_path> under <enrollment> is no longer used: enrollment reuses "
-                  "<agent><server>/<agent><ssl>. Ignoring.");
+                  "<agent><manager>/<agent><ssl>. Ignoring.");
     expect_string(__wrap__minfo, formatted_msg,
                   "<agent_certificate_path> under <enrollment> is no longer used: enrollment reuses "
-                  "<agent><server>/<agent><ssl>. Ignoring.");
+                  "<agent><manager>/<agent><ssl>. Ignoring.");
     expect_string(__wrap__minfo, formatted_msg,
                   "<agent_key_path> under <enrollment> is no longer used: enrollment reuses "
-                  "<agent><server>/<agent><ssl>. Ignoring.");
+                  "<agent><manager>/<agent><ssl>. Ignoring.");
 
     assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
 
@@ -750,7 +750,7 @@ static void test_enrollment_unknown_element_is_still_rejected(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<enrollment><nonsense>1</nonsense></enrollment>";
 
     expect_valid_ip("10.0.0.1");
@@ -769,7 +769,7 @@ static void test_batch_size_and_interval_are_parsed(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<batch><size>1MB</size><interval>10s</interval></batch>";
 
     expect_valid_ip("10.0.0.1");
@@ -787,7 +787,7 @@ static void test_batch_is_unset_when_absent(void **state) {
     agent cfg;
 
     /* Zero is what the transport module reads as "apply your own default". */
-    const char *xml_str = "<server><address>10.0.0.1</address><port>1517</port></server>";
+    const char *xml_str = "<manager><address>10.0.0.1</address><port>1517</port></manager>";
 
     expect_valid_ip("10.0.0.1");
 
@@ -804,7 +804,7 @@ static void test_batch_size_without_a_suffix_is_bytes(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<batch><size>2048</size></batch>";
 
     expect_valid_ip("10.0.0.1");
@@ -823,7 +823,7 @@ static void test_batch_zero_size_is_rejected(void **state) {
     /* A zero payload can never carry an event; refuse it rather than let it
      * read as "unset" and silently fall back to the default. */
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<batch><size>0</size></batch>";
 
     expect_valid_ip("10.0.0.1");
@@ -844,7 +844,7 @@ static void test_batch_size_beyond_the_cap_is_rejected(void **state) {
      * a 32-bit agent's size_t wraps past 4 GiB, and 4 GiB exactly wraps to zero,
      * which every reader downstream takes as "unset". */
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<batch><size>2GB</size></batch>";
 
     expect_valid_ip("10.0.0.1");
@@ -862,7 +862,7 @@ static void test_batch_interval_beyond_a_day_is_rejected(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<batch><interval>2d</interval></batch>";
 
     expect_valid_ip("10.0.0.1");
@@ -880,7 +880,7 @@ static void test_batch_invalid_tag_is_rejected(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<batch><nonsense>1</nonsense></batch>";
 
     expect_valid_ip("10.0.0.1");
@@ -973,11 +973,11 @@ static void test_read_agent_batch_takes_the_limits_from_the_file(void **state) {
     agent_batch batch = {0};
 
     write_conf("<ossec_config><agent>"
-               "<server><address>10.0.0.1</address></server>"
+               "<manager><address>10.0.0.1</address></manager>"
                "<batch><size>3MB</size><interval>45s</interval></batch>"
                "</agent></ossec_config>");
 
-    /* No <server> parsing, so no OS_IsValidIP expectation: the walk only opens
+    /* No <manager> parsing, so no OS_IsValidIP expectation: the walk only opens
      * <batch>, which is what keeps this off Read_Agent and its allocations. */
     w_read_agent_batch(BATCH_TEST_CONF, NULL, &batch);
 
@@ -991,7 +991,7 @@ static void test_read_agent_batch_leaves_the_caller_defaults_when_absent(void **
     agent_batch batch = { .size = 777, .interval = 42 };
 
     write_conf("<ossec_config><agent>"
-               "<server><address>10.0.0.1</address></server>"
+               "<manager><address>10.0.0.1</address></manager>"
                "</agent></ossec_config>");
 
     w_read_agent_batch(BATCH_TEST_CONF, NULL, &batch);
@@ -1104,7 +1104,7 @@ static void test_time_reconnect_is_deprecated(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<time-reconnect>60</time-reconnect>";
 
     expect_valid_ip("10.0.0.1");
@@ -1121,7 +1121,7 @@ static void test_max_retries_is_deprecated(void **state) {
     xml_node **nodes;
     agent cfg;
 
-    const char *xml_str = "<server><address>10.0.0.1</address><port>1517</port><max_retries>3</max_retries></server>";
+    const char *xml_str = "<manager><address>10.0.0.1</address><port>1517</port><max_retries>3</max_retries></manager>";
 
     expect_valid_ip("10.0.0.1");
     expect_string(__wrap__mwarn, formatted_msg,
@@ -1137,7 +1137,7 @@ static void test_retry_interval_is_deprecated(void **state) {
     xml_node **nodes;
     agent cfg;
 
-    const char *xml_str = "<server><address>10.0.0.1</address><port>1517</port><retry_interval>5</retry_interval></server>";
+    const char *xml_str = "<manager><address>10.0.0.1</address><port>1517</port><retry_interval>5</retry_interval></manager>";
 
     expect_valid_ip("10.0.0.1");
     expect_string(__wrap__mwarn, formatted_msg,
@@ -1162,7 +1162,7 @@ static void test_reports_are_off_when_absent(void **state) {
      * that field to 1 before parsing (see test_agentd.c), so a real agent with
      * no <config_report> block ships with it enabled. Only <stats_report> is
      * actually off by default end-to-end. */
-    const char *xml_str = "<server><address>10.0.0.1</address><port>1517</port></server>";
+    const char *xml_str = "<manager><address>10.0.0.1</address><port>1517</port></manager>";
 
     expect_valid_ip("10.0.0.1");
 
@@ -1183,7 +1183,7 @@ static void test_reports_are_independent_of_each_other(void **state) {
     /* The issue requires two separate toggles: enabling stats must leave the
      * config push alone. */
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<stats_report><enabled>yes</enabled><interval>30s</interval></stats_report>";
 
     expect_valid_ip("10.0.0.1");
@@ -1202,7 +1202,7 @@ static void test_reports_accept_time_suffixes(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<stats_report><enabled>yes</enabled><interval>2m</interval></stats_report>"
         "<config_report><enabled>yes</enabled><interval>1h</interval></config_report>";
 
@@ -1221,7 +1221,7 @@ static void test_report_enabled_rejects_a_non_boolean(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<config_report><enabled>maybe</enabled></config_report>";
 
     expect_valid_ip("10.0.0.1");
@@ -1238,7 +1238,7 @@ static void test_report_interval_beyond_a_day_is_rejected(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<stats_report><interval>2d</interval></stats_report>";
 
     expect_valid_ip("10.0.0.1");
@@ -1255,7 +1255,7 @@ static void test_report_invalid_tag_is_rejected(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<stats_report><cadence>30s</cadence></stats_report>";
 
     expect_valid_ip("10.0.0.1");
@@ -1285,11 +1285,11 @@ int main(void) {
         cmocka_unit_test(test_enrollment_use_source_ip_yes),
         cmocka_unit_test(test_enrollment_legacy_options_are_ignored_not_rejected),
         cmocka_unit_test(test_enrollment_unknown_element_is_still_rejected),
-        cmocka_unit_test(test_server_address_and_explicit_port),
-        cmocka_unit_test(test_manager_tag_is_rejected),
-        cmocka_unit_test(test_second_server_block_prevails_with_warning),
-        cmocka_unit_test(test_agent_server_address_and_port_are_parsed),
-        cmocka_unit_test(test_agent_server_port_defaults_to_1517),
+        cmocka_unit_test(test_manager_address_and_explicit_port),
+        cmocka_unit_test(test_server_tag_is_rejected),
+        cmocka_unit_test(test_second_manager_block_prevails_with_warning),
+        cmocka_unit_test(test_agent_manager_address_and_port_are_parsed),
+        cmocka_unit_test(test_agent_manager_port_defaults_to_1517),
         cmocka_unit_test(test_legacy_client_address_is_the_fallback),
         cmocka_unit_test(test_legacy_client_reads_nothing_but_the_address),
         cmocka_unit_test(test_legacy_client_takes_the_last_address),

--- a/src/unit_tests/config_files/test_config_report_custom_interval.conf
+++ b/src/unit_tests/config_files/test_config_report_custom_interval.conf
@@ -1,9 +1,9 @@
 <ossec_config>
   <agent>
-    <server>
+    <manager>
       <address>10.0.0.1</address>
       <port>1517</port>
-    </server>
+    </manager>
     <config_report>
       <interval>30m</interval>
     </config_report>

--- a/src/unit_tests/config_files/test_config_report_default.conf
+++ b/src/unit_tests/config_files/test_config_report_default.conf
@@ -1,8 +1,8 @@
 <ossec_config>
   <agent>
-    <server>
+    <manager>
       <address>10.0.0.1</address>
       <port>1517</port>
-    </server>
+    </manager>
   </agent>
 </ossec_config>

--- a/src/unit_tests/config_files/test_config_report_disabled.conf
+++ b/src/unit_tests/config_files/test_config_report_disabled.conf
@@ -1,9 +1,9 @@
 <ossec_config>
   <agent>
-    <server>
+    <manager>
       <address>10.0.0.1</address>
       <port>1517</port>
-    </server>
+    </manager>
     <config_report>
       <enabled>no</enabled>
     </config_report>

--- a/src/win32/InstallerScripts.vbs
+++ b/src/win32/InstallerScripts.vbs
@@ -84,18 +84,24 @@ public function config()
 
                 not_replaced = True
                 formatted_list = vbCrLf
-                ' <server> inside <agent> since 5.x: <agent> takes no other
-                ' element name, so writing back the legacy <manager> would make the
-                ' agent reject its own configuration.
+                ' A 5.x file is <agent><manager>; a 4.x file preserved across an upgrade
+                ' is <client><server>, and the 5.x parser reads an address out of that
+                ' one only under <server> -- writing <manager> there would strand the
+                ' agent with no manager address.
+                If InStr(strText, "<agent>") > 0 Then
+                    inner_tag = "manager"
+                Else
+                    inner_tag = "server"
+                End If
                 for i=0 to UBound(ip_list)
                     If ip_list(i) <> "" Then
-                        formatted_list = formatted_list & "    <server>" & vbCrLf
+                        formatted_list = formatted_list & "    <" & inner_tag & ">" & vbCrLf
                         formatted_list = formatted_list & "      <address>" & ip_list(i) & "</address>" & vbCrLf
                         formatted_list = formatted_list & "      <port>1517</port>" & vbCrLf
                         if i = UBound(ip_list) then
-                            formatted_list = formatted_list & "    </server>"
+                            formatted_list = formatted_list & "    </" & inner_tag & ">"
                         Else
-                            formatted_list = formatted_list & "    </server>" & vbCrLf
+                            formatted_list = formatted_list & "    </" & inner_tag & ">" & vbCrLf
                         End If
                     End If
                 next
@@ -232,11 +238,10 @@ public function config()
         Set file = objFSO.OpenTextFile(home_dir & "profile-" & OS_VERSION & ".template", ForReading)
         newline = file.ReadAll
         file.Close
-        ' The shipped template uses <server> (the deprecated <manager> tag only
-        ' survives on an upgraded ossec.conf that predates that migration), so
-        ' this must anchor on either closing tag to keep inserting the profile
-        ' block right after the server/manager block on both fresh installs
-        ' and upgrades.
+        ' The shipped template uses <manager>; <server> only survives on an
+        ' ossec.conf written by previous 5.x agents, so this must anchor on
+        ' either closing tag to keep inserting the profile block right after the
+        ' address block on both fresh installs and upgrades.
         re.Pattern = "(</server>|</manager>)"
         re.Global = False
         strNewText = re.Replace(strNewText, "$1" & vbCrLf & "    " & newline)

--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -339,13 +339,13 @@ function probe_server($server, $port) {
 }
 
 # The 5x agent reads the server address from the <agent> block, falling back to the <client> block when upgrading from 4x versions.
-$server_address = get_conf_value "agent" "server" "address"
+$server_address = get_conf_value "agent" "manager" "address"
 if ([string]::IsNullOrEmpty($server_address)) {
     $server_address = get_conf_value "client" "server" "address"
 }
 
 # The 5x agent reads the server port from the <agent> block, falling back to 1517 when upgrading from 4x versions.
-$server_port = get_conf_value "agent" "server" "port"
+$server_port = get_conf_value "agent" "manager" "port"
 if ([string]::IsNullOrEmpty($server_port)) {
     $server_port = "1517"
 }

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -7,10 +7,10 @@
 <ossec_config>
 
   <agent>
-    <server>
+    <manager>
       <address>0.0.0.0</address>
       <port>1517</port>
-    </server>
+    </manager>
   </agent>
 
   <!-- Log analysis -->

--- a/src/win32/ui/common.c
+++ b/src/win32/ui/common.c
@@ -331,11 +331,10 @@ int get_ossec_server()
     char *str = NULL;
     int success = 0;
 
-    /* Definitions. <agent> is the 5.x name of the block; the <client> paths are kept
-     * because a WPK upgrade never rewrites ossec.conf
+    /* Definitions. <agent><manager> is the 5.x shape; the <client> paths are kept
+     * because a WPK upgrade never rewrites ossec.conf.
      */
-    const char *(xml_agentaddr[]) = {"ossec_config", "agent", "server", "address", NULL};
-    const char *(xml_manageraddr[]) = {"ossec_config", "client", "manager", "address", NULL};
+    const char *(xml_agentaddr[]) = {"ossec_config", "agent", "manager", "address", NULL};
     const char *(xml_serverip[]) = {"ossec_config", "client", "server-ip", NULL};
     const char *(xml_serverhost[]) = {"ossec_config", "client", "server-hostname", NULL};
     const char *(xml_serveraddr[]) = {"ossec_config", "client", "server", "address", NULL};
@@ -358,19 +357,6 @@ int get_ossec_server()
         config_inst.server = str;
         success = 1;
         goto ret;
-    }
-    if (str = OS_GetOneContentforElement(&xml, xml_manageraddr), str) {
-        if (OS_IsValidIP(str, NULL) == 1) {
-            config_inst.server_type = SERVER_IP_USED;
-            config_inst.server = str;
-            success = 1;
-            goto ret;
-        } else {
-            config_inst.server_type = SERVER_HOST_USED;
-            config_inst.server = str;
-            success = 1;
-            goto ret;
-        }
     }
     if (str = OS_GetOneContentforElement(&xml, xml_serveraddr), str) {
         if (OS_IsValidIP(str, NULL) == 1) {
@@ -462,13 +448,12 @@ int set_ossec_server(char *ip, HWND hwnd)
 {
     OS_XML xml;
     char *str = NULL;
-    const char *(xml_agentaddr[]) = {"ossec_config", "agent", "server", "address", NULL};
-    const char *(xml_manageraddr[]) = {"ossec_config", "client", "manager", "address", NULL};
+    const char *(xml_agentaddr[]) = {"ossec_config", "agent", "manager", "address", NULL};
     const char *(xml_serveraddr[]) = {"ossec_config", "client", "server", "address", NULL};
     /* Write order. The block that already holds an address is tried first so an
-     * upgraded 4.x file keeps its <client> shape and a 5.x file gets <agent>.
-     * The remaining paths are the fallback for a config that has neither. */
-    const char **xml_paths[] = {xml_agentaddr, xml_manageraddr, xml_serveraddr};
+     * upgraded 4.x file keeps its <client><server> shape and a 5.x file gets
+     * <agent><manager>. The other path is the fallback for a config with neither. */
+    const char **xml_paths[] = {xml_agentaddr, xml_serveraddr};
     const size_t xml_paths_len = sizeof(xml_paths) / sizeof(xml_paths[0]);
     size_t i;
     char config_tmp[] = CONFIG;
@@ -492,7 +477,7 @@ int set_ossec_server(char *ip, HWND hwnd)
         config_inst.server_type = SERVER_IP_USED;
     }
 
-    /* Keep agent/manager/server tag compatibility depending on current config: move the
+    /* Keep <agent>/<client> block compatibility depending on current config: move the
      * block that already carries an address to the front of the write order. */
     if (OS_ReadXML(CONFIG, &xml) == 0) {
         for (i = 0; i < xml_paths_len; i++) {

--- a/tests/integration/test_agentd/test_reconnection/data/configuration_templates/wazuh_conf.yaml
+++ b/tests/integration/test_agentd/test_reconnection/data/configuration_templates/wazuh_conf.yaml
@@ -1,7 +1,7 @@
     - sections:
       - section: agent
         elements:
-            - server:
+            - manager:
                 elements:
                 - address:
                     value: '127.0.0.1'

--- a/tests/integration/test_agentd/test_startup_hash_validation/data/configuration_templates/wazuh_conf.yaml
+++ b/tests/integration/test_agentd/test_startup_hash_validation/data/configuration_templates/wazuh_conf.yaml
@@ -1,7 +1,7 @@
     - sections:
       - section: agent
         elements:
-            - server:
+            - manager:
                 elements:
                 - address:
                     value: '127.0.0.1'

--- a/tests/integration/test_agentd/test_state/data/configuration_templates/wazuh_conf.yaml
+++ b/tests/integration/test_agentd/test_state/data/configuration_templates/wazuh_conf.yaml
@@ -1,7 +1,7 @@
     - sections:
       - section: agent
         elements:
-            - server:
+            - manager:
                 elements:
                 - address:
                     value: '127.0.0.1'

--- a/tests/integration/test_agentd/test_state_config/data/configuration_templates/wazuh_conf.yaml
+++ b/tests/integration/test_agentd/test_state_config/data/configuration_templates/wazuh_conf.yaml
@@ -1,7 +1,7 @@
     - sections:
       - section: agent
         elements:
-            - server:
+            - manager:
                 elements:
                 - address:
                     value: '127.0.0.1'

--- a/tests/integration/test_enrollment/test_agent/data/configuration_templates/config_wazuh_enrollment.yaml
+++ b/tests/integration/test_enrollment/test_agent/data/configuration_templates/config_wazuh_enrollment.yaml
@@ -5,7 +5,7 @@
                 value: 10
             - auto_restart:
                 value: 'yes'
-            - server:
+            - manager:
                 elements:
                 - address:
                     value: 127.0.0.1

--- a/tests/integration/test_enrollment/test_options/data/configuration_templates/config_server_address.yaml
+++ b/tests/integration/test_enrollment/test_options/data/configuration_templates/config_server_address.yaml
@@ -7,7 +7,7 @@
   - sections:
     - section: agent
       elements:
-          - server:
+          - manager:
               elements:
               - address:
                   value: SERVER_ADDRESS

--- a/tests/integration/test_execd/test_run_active_response/data/configuration_templates/config_run_active_response.yaml
+++ b/tests/integration/test_execd/test_run_active_response/data/configuration_templates/config_run_active_response.yaml
@@ -7,7 +7,7 @@
             value: 60
         - auto_restart:
             value: "yes"
-        - server:
+        - manager:
             elements:
                 - address:
                     value: 127.0.0.1

--- a/tests/integration/test_fim/conftest.py
+++ b/tests/integration/test_fim/conftest.py
@@ -112,12 +112,12 @@ def set_agent_config(request: pytest.FixtureRequest):
 
     configurations = getattr(request.module, "test_configuration")
     # <agent> is the 5.x name for what 4.x spelled <client> (#38103) -- the legacy tag is only
-    # read for <server><address> as a fallback, so <port> would be silently ignored under it.
+    # read for <client><server><address> as a fallback, so <port> would be silently ignored under it.
     agent_conf = {
         "section": "agent",
         "elements": [
             {
-                "server": {
+                "manager": {
                     "elements": [
                         {"address": {"value": "127.0.0.1"}},
                         {"port": {"value": 1517}},


### PR DESCRIPTION
## Description

This pull request keeps the root tag `<agent>` and takes the inner one back to `<manager>`, so the block reads `<agent><manager>`. `<agent><server>` becomes invalid.

The 4.x compatibility path is untouched: a configuration left behind by a 4.x agent is still read for `<client><server><address>`, with the port defaulted to `1517`.

No 5.x -> 5.x fallback is added, and none is needed. `<agent><server>` is in no release tag, `v5.0.0-beta4` (the newest tag) still shipped `<client><manager>`. It has no installed population.

Closes #38464

## Proposed Changes

**Parser**

`Read_Agent()` now dispatches on `"manager"` (`client-config.c:37,95`), and `Read_Agent_Server()` follows the block to `Read_Agent_Manager()`. The second `"server"` literal in the file stays exactly as it was: it lives in `Read_Legacy_Client_Address()` and reads the 4.x `<client><server><address>`, so it was renamed `xml_client_server` to stop it reading as an `<agent>` symbol. Log and warning text carrying the tag name moved with it, including the deprecation hints for `<server-ip>` and `<server-hostname>`.

The data model keeps its names. `agent_server`, `logr->server`, `server_count` and `Validate_Address(agent_server *)` describe the runtime struct rather than the XML tag and reach across agentd and the HTTPS bridge, so they are out of scope here, as the issue says of `SERVER_UNAV` / `SERVER_UP`.

**Everything that writes the block**

Both shipped templates (`etc/ossec-agent.conf`, `src/win32/ossec.conf`), the source installer (`inst-functions.sh`), the `WAZUH_MANAGER` rewrite used by the deb/rpm/macOS packages (`register_configure_agent.sh`), and the MSI custom action (`InstallerScripts.vbs`).

`add_adress_block()` still strips both `<manager>` and `<server>` before writing. That sed runs before the write, so keeping both patterns is what lets a pre-rename 5.x file be re-registered rather than accumulating two blocks.

**MSI upgrades pick the inner tag from the root already in the file**

`InstallerScripts.vbs` rewrites only the inner block and never the root — its pattern is `\s+<(server|manager)>(.|\n)+?</\1>`, which matches wherever the block sits. On a Windows 4.x -> 5.x MSI upgrade with `WAZUH_MANAGER=` passed, `ossec.conf` is preserved with a `<client>` root, so writing the new canonical `<manager>` would have produced `<client><manager>` — a shape `Read_Legacy_Client_Address()` does not match, leaving the agent with no manager address. The tag is now chosen from the root in the file: `<manager>` when it contains `<agent>`, `<server>` otherwise.

**WPK pre-flight, both platforms**

`pkg_installer.sh` (Linux/macOS) and `do_upgrade.ps1` (Windows) resolve the endpoint before installing anything and abort with `upgrade_result` = `2` if the manager is unreachable. Both now read `<agent><manager>` first and keep `<client><server><address>` as the 4.x fallback. Missing either one would abort every upgrade on that platform with "no manager address found in the configuration".

**Manage-Agent (`win32ui`)**

`get_ossec_server()` and `set_ossec_server()` keep an ordered list of candidate XPaths. The rule they now follow is that every candidate must be one the agent parser also accepts, otherwise the tray reports an address the agent cannot start with — and, worse, `set_ossec_server()` promotes whichever candidate already holds an address and writes the user's new value straight back into it.

`{agent,server}` was therefore replaced by `{agent,manager}` rather than demoted, and `{client,manager}` was deleted outright.

## Results and Evidence

Installation from sources (`ossec.conf`):

macOS

```text
  <agent>
    <manager>
      <address>192.168.18.238</address>
      <port>1517</port>
    </manager>
    <config-profile>darwin, darwin24, darwin24.6</config-profile>
  </agent>
```

Linux

```text
  <agent>
    <manager>
      <address>192.168.18.238</address>
      <port>1517</port>
    </manager>
    <config-profile>ubuntu, ubuntu24, ubuntu24.04</config-profile>
  </agent>
```

Windows

```text
  <agent>
    <manager>
      <address>192.168.18.238</address>
      <port>1517</port>
    </manager>
    <config-profile>windows, windows10</config-profile>
    <enrollment>
      <enabled>yes</enabled>
      <authorization_pass_path>authd.pass</authorization_pass_path>
      <agent_name>windows-agent</agent_name>
    </enrollment>
  </agent>
```

<img width="2434" height="632" alt="Screenshot 2026-08-22 at 2 01 16 AM" src="https://github.com/user-attachments/assets/65897134-3632-4873-ade0-66de54f6d230" />

Installation from packages (`ossec.conf`):

macOS

```text
  <agent>
    <enrollment>
      <enabled>yes</enabled>
      <agent_name>macos-agent</agent_name>
      <authorization_pass_path>etc/authd.pass</authorization_pass_path>
    </enrollment>
    <manager>
      <address>192.168.18.238</address>
      <port>1517</port>
    </manager>
    <config-profile>darwin, darwin24, darwin24.6</config-profile>
  </agent>
```

Linux

```text
  <agent>
    <enrollment>
      <enabled>yes</enabled>
      <agent_name>linux-agent</agent_name>
      <authorization_pass_path>etc/authd.pass</authorization_pass_path>
    </enrollment>
    <manager>
      <address>192.168.18.238</address>
      <port>1517</port>
    </manager>
    <config-profile>ubuntu, ubuntu24, ubuntu24.04</config-profile>
  </agent>
```

Windows

```text
  <agent>
    <manager>
      <address>192.168.18.238</address>
      <port>1517</port>
    </manager>
    <config-profile>windows, windows10</config-profile>
    <enrollment>
      <enabled>yes</enabled>
      <authorization_pass_path>authd.pass</authorization_pass_path>
      <agent_name>windows-agent</agent_name>
    </enrollment>
  </agent>
```

<img width="2436" height="633" alt="Screenshot 2026-08-21 at 3 49 27 PM" src="https://github.com/user-attachments/assets/7fd45a8c-a0fc-4491-9cfc-abdff1539102" />

Upgrade 4x -> 5x (`ossec.conf`):

<img width="2435" height="633" alt="Screenshot 2026-08-21 at 11 48 10 PM" src="https://github.com/user-attachments/assets/8fa99621-7861-426c-b81a-74b85078982b" />

macOS

```text
  <client>
    <server>
      <address>192.168.18.238</address>
      <port>1514</port>
      <protocol>tcp</protocol>
    </server>
    <config-profile>darwin, darwin24, darwin24.6</config-profile>
    <notify_time>20</notify_time>
    <time-reconnect>60</time-reconnect>
    <auto_restart>yes</auto_restart>
    <crypto_method>aes</crypto_method>
    <enrollment>
      <enabled>yes</enabled>
      <agent_name>macos-agent</agent_name>
      <authorization_pass_path>etc/authd.pass</authorization_pass_path>
    </enrollment>
  </client>
```

Linux

```text
  <client>
    <server>
      <address>192.168.18.238</address>
      <port>1514</port>
      <protocol>tcp</protocol>
    </server>
    <config-profile>ubuntu, ubuntu24, ubuntu24.04</config-profile>
    <notify_time>20</notify_time>
    <time-reconnect>60</time-reconnect>
    <auto_restart>yes</auto_restart>
    <crypto_method>aes</crypto_method>
    <enrollment>
      <enabled>yes</enabled>
      <agent_name>linux-agent</agent_name>
      <authorization_pass_path>etc/authd.pass</authorization_pass_path>
    </enrollment>
  </client>
```

Windows

```text
  <client>
    <server>
      <address>192.168.18.238</address>
      <port>1514</port>
      <protocol>tcp</protocol>
    </server>
    <config-profile>windows, windows10</config-profile>
    <crypto_method>aes</crypto_method>
    <notify_time>20</notify_time>
    <time-reconnect>60</time-reconnect>
    <auto_restart>yes</auto_restart>
    <enrollment>
      <enabled>yes</enabled>
      <authorization_pass_path>authd.pass</authorization_pass_path>
      <agent_name>windows-agent</agent_name>
    </enrollment>
  </client>
```

<img width="2435" height="644" alt="Screenshot 2026-08-22 at 12 16 00 AM" src="https://github.com/user-attachments/assets/5d70aedd-f285-44d8-8bb5-baf914d440cd" />

Upgrade 5x-beta4 -> 5x (`ossec.conf`):

Unable to upgrade due to the `<client><manager><address>` configuration, fresh installation is required.

> This does not re-introduce the pre-HTTPS <client><manager> layout — that one stays invalid, since <client> itself was already retired as the root tag. (#38464)

### Artifacts Affected

- Agent executables: `wazuh-agentd` (configuration reader) and `win32ui.exe` (Manage-Agent).
- Default configuration files: `etc/ossec-agent.conf` and `src/win32/ossec.conf`.
- Packages: every agent package, through `inst-functions.sh`, `register_configure_agent.sh` and `InstallerScripts.vbs`.
- WPK contents: `pkg_installer.sh` and `do_upgrade.ps1` ship inside the WPK.

### Configuration Changes

- The agent connection block is `<agent><manager>`. `<agent><server>` is rejected with `(1230): Invalid element in the configuration: 'server'.`
- 4.x compatibility is unchanged: a `<client>` block is still read for `<server><address>` alone, with the port defaulted to `1517`. Renaming only the root tag is not enough — `<agent><server>` is invalid, so both tags move together.
- `<client><manager>` remains invalid, and is no longer read by Manage-Agent either.

### Documentation Updates

- `docs/guide/migration/upgrade-4x-to-5x.md`: the `<manager>` -> `<server>` row reversed, a new row for the half-renamed `<agent><server>` case, the before/after example, the WPK address-lookup paragraph and the validation checklist.
- `docs/ref/modules/client/configuration.md`: `### server` becomes `### manager`, plus the examples and the `<client>` fallback paragraph.
- `docs/ref/modules/client/README.md`: quick-configuration example.
- `etc/templates/config/README.md`: template example.

### Tests Introduced

No new test binaries. `src/unit_tests/config/test_client-config_https.c` was updated in place:

- `test_manager_tag_is_rejected` inverts into `test_server_tag_is_rejected`, asserting the parser now rejects `<server>` under `<agent>`.
- Four cases renamed to follow the tag: `test_manager_address_and_explicit_port`, `test_second_manager_block_prevails_with_warning`, `test_agent_manager_address_and_port_are_parsed`, `test_agent_manager_port_defaults_to_1517`.
- The `parse_legacy_client()` inputs deliberately keep `<server>`, since they exercise the 4.x `<client>` contract, which this change does not touch.
 
## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
