### PR TITLE
fix(syscollector): read Windows package names through the Unicode registry API

### DIFF
--- a/src/data_provider/src/packages/appxWindowsWrapper.h
+++ b/src/data_provider/src/packages/appxWindowsWrapper.h
@@ -296,7 +296,7 @@ class TAppxWindowsWrapper final : public IPackageWrapper
 
             try
             {
-                if (!registry.string("DisplayName", name))
+                if (!registry.stringUtf8("DisplayName", name))
                 {
                     name.clear();
                 }
@@ -364,7 +364,7 @@ class TAppxWindowsWrapper final : public IPackageWrapper
                         std::string value;
                         const TRegistry nameReg(m_key, m_userId  + "\\" + APPLICATION_STORE_REGISTRY + "\\" + m_appName + "\\" + folder + "\\Capabilities");
 
-                        if (nameReg.string("ApplicationName", value))
+                        if (nameReg.stringUtf8("ApplicationName", value))
                         {
                             name = value;
                             break;
@@ -476,7 +476,7 @@ class TAppxWindowsWrapper final : public IPackageWrapper
             std::string value;
             const TRegistry registry(m_key, path);
 
-            if (!registry.string(key, value))
+            if (!registry.stringUtf8(key, value))
             {
                 for (const auto& folder : TRegistry(m_key, path).enumerate())
                 {
@@ -509,10 +509,12 @@ class TAppxWindowsWrapper final : public IPackageWrapper
                 std::string data;
                 std::string vendorRegistry;
 
+                // Not reported data: this is a ProgID used as a subkey of the path opened below.
+                // The registry is opened through the ANSI API, so it must stay ANSI encoded.
                 registry.string(value, vendorRegistry);
                 const TRegistry pubRegistry(m_key, m_userId  + "\\" + APPLICATION_VENDOR_REGISTRY + "\\" + vendorRegistry + "\\Application");
 
-                if (pubRegistry.string("ApplicationCompany", data))
+                if (pubRegistry.stringUtf8("ApplicationCompany", data))
                 {
                     if (!Utils::startsWith(data, PREFIX_LOCALIZATION))
                     {

--- a/src/data_provider/src/sysInfoWin.cpp
+++ b/src/data_provider/src/sysInfoWin.cpp
@@ -439,17 +439,17 @@ static void getPackagesFromReg(const HKEY key, const std::string& subKey, std::f
                 std::string location;
                 std::string architecture;
 
-                if (packageReg.string("DisplayName", value))
+                if (packageReg.stringUtf8("DisplayName", value))
                 {
                     name = value;
                 }
 
-                if (packageReg.string("DisplayVersion", value))
+                if (packageReg.stringUtf8("DisplayVersion", value))
                 {
                     version = value;
                 }
 
-                if (packageReg.string("Publisher", value))
+                if (packageReg.stringUtf8("Publisher", value))
                 {
                     vendor = value;
                 }
@@ -470,7 +470,7 @@ static void getPackagesFromReg(const HKEY key, const std::string& subKey, std::f
                     install_time = Utils::timestampToISO8601(packageReg.keyModificationDate());
                 }
 
-                if (packageReg.string("InstallLocation", value))
+                if (packageReg.stringUtf8("InstallLocation", value))
                 {
                     location = value;
                 }

--- a/src/data_provider/tests/sysInfoWin/sysInfoWinAppx_test.cpp
+++ b/src/data_provider/tests/sysInfoWin/sysInfoWinAppx_test.cpp
@@ -88,7 +88,33 @@ class FakeRegistry
             return ret;
         }
 
+        /*
+         * Mimics Registry::string(): the ANSI registry API hands the caller data already
+         * transcoded to the system ANSI code page, so every character missing from that code
+         * page is lost before the caller sees it. Replacing each non-ASCII byte reproduces
+         * that loss, so a test using non-ASCII data fails if a call site goes back to the
+         * ANSI path.
+         */
         bool string(const std::string& valueName, std::string& value) const
+        {
+            if (!stringUtf8(valueName, value))
+            {
+                return false;
+            }
+
+            for (auto& character : value)
+            {
+                if (static_cast<unsigned char>(character) > 0x7F)
+                {
+                    character = '?';
+                }
+            }
+
+            return true;
+        }
+
+        // Mimics Registry::stringUtf8(): the stored data is returned as UTF-8, untouched.
+        bool stringUtf8(const std::string& valueName, std::string& value) const
         {
             const auto key { data.find(m_path) };
 
@@ -374,4 +400,68 @@ TEST_F(SysInfoWinAppxTest, MalformedPackageNameIsDiscarded)
 
     EXPECT_TRUE(wrapper.name().empty());
     EXPECT_TRUE(wrapper.version().empty());
+}
+
+/*
+ * Package names, sub-application names and publishers can hold characters that the system
+ * ANSI code page cannot represent, so they must be read through the Unicode registry API.
+ * FakeRegistry::string() drops non-ASCII characters exactly like the ANSI API does, so these
+ * tests fail if any of those values is read through it again. The expected data is written as
+ * hex escapes to keep this file ASCII.
+ */
+TEST_F(SysInfoWinAppxTest, NonAsciiDisplayNameAndPublisherAreReadAsUtf8)
+{
+    constexpr auto wechatPackage { "Tencent.WeChat_3.9.10.19_x64__a1b2c3d4e5f6" };
+    // U+5FAE U+4FE1 ("WeChat" in Chinese), UTF-8 encoded.
+    constexpr auto displayName { "\xE5\xBE\xAE\xE4\xBF\xA1" };
+    // U+9A30 U+8A0A U+79D1 U+6280 ("Tencent Technology" in Chinese), UTF-8 encoded.
+    constexpr auto publisher { "\xE9\xA8\xB0\xE8\xA8\x8A\xE7\xA7\x91\xE6\x8A\x80" };
+    const auto root { packagePath(wechatPackage) };
+
+    FakeRegistry::data[root].strings["PackageRootFolder"] = std::string{ "C:\\Program Files\\WindowsApps\\" } + wechatPackage;
+    FakeRegistry::data[root].strings["DisplayName"] = displayName;
+    FakeRegistry::data[root + "\\App\\Capabilities"].strings["ApplicationName"] = displayName;
+    FakeRegistry::data[root + "\\App\\Capabilities\\FileAssociations"].strings[".wxwork"] = "Tencent.WeChat.wxwork";
+    FakeRegistry::data[std::string{ TEST_USER_SID } + "\\" + TEST_CLASSES_REGISTRY + "\\Tencent.WeChat.wxwork\\Application"]
+    .strings["ApplicationCompany"] = publisher;
+
+    TestAppxWrapper wrapper(HKEY_USERS, TEST_USER_SID, wechatPackage, {});
+
+    EXPECT_EQ(displayName, wrapper.name());
+    EXPECT_EQ(publisher, wrapper.vendor());
+}
+
+TEST_F(SysInfoWinAppxTest, NonAsciiApplicationNameFallbackIsReadAsUtf8)
+{
+    constexpr auto notepadPackage { "Microsoft.WindowsNotepad_11.2402.22.0_x64__8wekyb3d8bbwe" };
+    // U+8A18 U+4E8B U+672C ("Notepad" in Chinese), UTF-8 encoded.
+    constexpr auto applicationName { "\xE8\xA8\x98\xE4\xBA\x8B\xE6\x9C\xAC" };
+    const auto root { packagePath(notepadPackage) };
+
+    FakeRegistry::data[root].strings["PackageRootFolder"] = std::string{ "C:\\Program Files\\WindowsApps\\" } + notepadPackage;
+    // No DisplayName: the name comes from the sub-application capabilities.
+    FakeRegistry::data[root + "\\App\\Capabilities"].strings["ApplicationName"] = applicationName;
+
+    TestAppxWrapper wrapper(HKEY_USERS, TEST_USER_SID, notepadPackage, {});
+
+    EXPECT_EQ(applicationName, wrapper.name());
+}
+
+TEST_F(SysInfoWinAppxTest, NonAsciiLocalizedNameFromCacheRegistryIsReadAsUtf8)
+{
+    constexpr auto calculatorPackage { "Microsoft.WindowsCalculator_11.2401.0.0_x64__8wekyb3d8bbwe" };
+    constexpr auto resourceKey { "@{Microsoft.WindowsCalculator?ms-resource://AppName}" };
+    // U+8A08 U+7B97 U+6A5F ("Calculator" in Chinese), UTF-8 encoded.
+    constexpr auto localizedName { "\xE8\xA8\x88\xE7\xAE\x97\xE6\xA9\x9F" };
+    const auto root { packagePath(calculatorPackage) };
+    const auto cacheFolder { "Microsoft.WindowsCalculator_8wekyb3d8bbwe" };
+
+    FakeRegistry::data[root].strings["PackageRootFolder"] = std::string{ "C:\\Program Files\\WindowsApps\\" } + calculatorPackage;
+    FakeRegistry::data[root].strings["DisplayName"] = resourceKey;
+    FakeRegistry::data[root + "\\App\\Capabilities"].strings["ApplicationName"] = resourceKey;
+    FakeRegistry::data[std::string{ TEST_USER_SID } + "\\" + TEST_CACHE_REGISTRY + "\\" + cacheFolder].strings[resourceKey] = localizedName;
+
+    TestAppxWrapper wrapper(HKEY_USERS, TEST_USER_SID, calculatorPackage, { cacheFolder });
+
+    EXPECT_EQ(localizedName, wrapper.name());
 }

--- a/src/shared_modules/utils/registryHelper.h
+++ b/src/shared_modules/utils/registryHelper.h
@@ -321,6 +321,51 @@ namespace Utils
                 return ret;
             }
 
+            /*
+             * @brief Reads a string value as UTF-8 through the Unicode registry API.
+             *
+             * Registry strings are stored as UTF-16. Reading them with the ANSI API makes
+             * Windows transcode them to the system ANSI code page before handing them to the
+             * caller, so every character missing from that code page is already lost when it
+             * arrives: replaced by '?' or by a best-fit approximation of a different
+             * character. Going through RegQueryValueExW keeps the stored characters and
+             * converts them to UTF-8 without loss, so this is the method to use for any value
+             * whose data is reported as text (names, publishers, paths).
+             *
+             * @param[in]  valueName Name of the value to read, UTF-8 encoded.
+             * @param[out] value     Value data, UTF-8 encoded. Left untouched on failure.
+             *
+             * @return True if the value exists and holds a string, false otherwise.
+             */
+            bool stringUtf8(const std::string& valueName, std::string& value) const
+            {
+                const auto wideName {EncodingWindowsHelper::stringToWStringUTF8(valueName)};
+                DWORD type {0};
+                DWORD size {0};
+
+                if (RegQueryValueExW(m_registryKey, wideName.c_str(), nullptr, &type, nullptr, &size) != ERROR_SUCCESS)
+                {
+                    return false;
+                }
+
+                if ((REG_SZ != type && REG_EXPAND_SZ != type) || 0 == size)
+                {
+                    return false;
+                }
+
+                // The extra character guarantees a terminator even if the stored data lacks one.
+                const auto spBuff {std::make_unique<wchar_t[]>((size / sizeof(wchar_t)) + 1)};
+
+                if (RegQueryValueExW(m_registryKey, wideName.c_str(), nullptr, nullptr, reinterpret_cast<LPBYTE>(spBuff.get()), &size) != ERROR_SUCCESS)
+                {
+                    return false;
+                }
+
+                value = EncodingWindowsHelper::wstringToStringUTF8(std::wstring {spBuff.get()});
+
+                return true;
+            }
+
             std::string HandleRegMultiSZ(const BYTE* data, DWORD size) const
             {
                 if (size == 0)

--- a/src/shared_modules/utils/tests/registryHelper_test.cpp
+++ b/src/shared_modules/utils/tests/registryHelper_test.cpp
@@ -14,6 +14,10 @@
 
 constexpr auto CENTRAL_PROCESSOR_REGISTRY {"HARDWARE\\DESCRIPTION\\System\\CentralProcessor"};
 constexpr auto CENTRAL_PROCESSOR_REGISTRY_0 {"HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0"};
+constexpr auto UTF8_TEST_SUBKEY {"WazuhTestUtf8"};
+constexpr auto UTF8_TEST_SUBKEY_W {L"WazuhTestUtf8"};
+constexpr auto UTF8_TEST_VALUE {"DisplayName"};
+constexpr auto UTF8_TEST_VALUE_W {L"DisplayName"};
 
 void RegistryUtilsTest::SetUp() {};
 
@@ -33,6 +37,78 @@ TEST_F(RegistryUtilsTest, RegistryStringNoThrow)
     const auto result {reg.string("SomeWrongValue", value)};
     EXPECT_TRUE(value.empty());
     EXPECT_FALSE(result);
+}
+
+/*
+ * Writes a REG_SZ value holding UTF-16 data, so the tests below can read back data that the
+ * system ANSI code page cannot represent.
+ */
+static bool writeWideTestValue(const std::wstring& data)
+{
+    HKEY handler {nullptr};
+
+    if (RegCreateKeyExW(HKEY_CURRENT_USER, UTF8_TEST_SUBKEY_W, 0, nullptr, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS,
+                        nullptr, &handler, nullptr) != ERROR_SUCCESS)
+    {
+        return false;
+    }
+
+    const auto result {RegSetValueExW(handler, UTF8_TEST_VALUE_W, 0, REG_SZ,
+                                      reinterpret_cast<const BYTE*>(data.c_str()),
+                                      static_cast<DWORD>((data.size() + 1) * sizeof(wchar_t)))};
+    RegCloseKey(handler);
+
+    return ERROR_SUCCESS == result;
+}
+
+TEST_F(RegistryUtilsTest, RegistryStringUtf8KeepsCharactersOutsideTheSystemCodePage)
+{
+    /*
+     * U+6DF1 U+5733 (Han), U+6C49 (simplified-only Han), U+D55C (Hangul) and U+00E9 (Latin
+     * letter with diacritic): no Windows ANSI code page can represent all of them at once,
+     * so reading this value with the ANSI API always loses characters, either replaced by
+     * '?' or best-fitted to a different character.
+     */
+    const std::wstring wideData {L"\u6DF1\u5733\u6C49\uD55C\u00E9"};
+    const std::string expectedUtf8 {"\xE6\xB7\xB1\xE5\x9C\xB3\xE6\xB1\x89\xED\x95\x9C\xC3\xA9"};
+
+    ASSERT_TRUE(writeWideTestValue(wideData));
+
+    std::string utf8Value;
+    std::string ansiValue;
+    {
+        Utils::Registry reg(HKEY_CURRENT_USER, UTF8_TEST_SUBKEY);
+        EXPECT_TRUE(reg.stringUtf8(UTF8_TEST_VALUE, utf8Value));
+        EXPECT_TRUE(reg.string(UTF8_TEST_VALUE, ansiValue));
+    }
+
+    RegDeleteKeyExW(HKEY_CURRENT_USER, UTF8_TEST_SUBKEY_W, KEY_WOW64_64KEY, 0);
+
+    EXPECT_EQ(expectedUtf8, utf8Value);
+
+    // Unless the system code page is UTF-8 itself, the ANSI path cannot return the same data.
+    if (CP_UTF8 != GetACP())
+    {
+        EXPECT_NE(expectedUtf8, ansiValue);
+    }
+}
+
+TEST_F(RegistryUtilsTest, RegistryStringUtf8NoThrow)
+{
+    std::string value;
+    Utils::Registry reg(HKEY_LOCAL_MACHINE, CENTRAL_PROCESSOR_REGISTRY_0);
+    EXPECT_FALSE(reg.stringUtf8("SomeWrongValue", value));
+    EXPECT_TRUE(value.empty());
+}
+
+TEST_F(RegistryUtilsTest, RegistryStringUtf8RejectsNonStringValues)
+{
+    std::string value;
+    Utils::Registry reg(HKEY_LOCAL_MACHINE, CENTRAL_PROCESSOR_REGISTRY_0);
+
+    // "~MHz" is a REG_DWORD: it holds no text, so it must not be reported as a string.
+    EXPECT_FALSE(reg.stringUtf8("~MHz", value));
+    EXPECT_TRUE(value.empty());
 }
 
 TEST_F(RegistryUtilsTest, RegistryDWORD)


### PR DESCRIPTION
## Description

Syscollector reports corrupted package names, versions, publishers and install
locations on Windows whenever those values contain characters that the system ANSI
code page cannot represent. The data is already damaged when the agent writes it to
`local.db`, so every consumer downstream (the manager, exports, dashboards) faithfully
renders data that was lost on the endpoint.

Registry strings are stored as UTF-16. `Utils::Registry::string()` reads them with
`RegQueryValueEx`, and because the agent is not built with `UNICODE` defined, that
resolves to `RegQueryValueExA`. The ANSI variant makes Windows transcode the value to
the system ANSI code page *before returning it to the caller*, so the loss happens
inside the OS, before any Wazuh code runs. The subsequent
`EncodingWindowsHelper::stringAnsiToStringUTF8()` call in the two-argument `string()`
overload cannot undo it — it re-encodes data that no longer holds the original
characters.

The conversion loses data in two distinct ways, and the second one is the reason this
goes unnoticed:

1. Characters with no mapping in the code page become a literal `?` (byte `0x3F`) —
   not a rendering artifact, an actual replacement in the stored bytes.
2. Characters that have a *visually similar* mapping are silently best-fitted to a
   different character (`WC_NO_BEST_FIT_CHARS` is not in play here). There is no `?`
   to grep for, so the value looks plausible while being wrong.

Measured on a machine with ACP 950, reading a `REG_SZ` that holds `深圳汉한é`:

| path | bytes returned | renders as |
|---|---|---|
| stored value (UTF-16) | — | `深圳汉한é` |
| `string()` — ANSI API | `E6 B7 B1 E5 9C B3 3F 3F 65` | `深圳??e` |
| `stringUtf8()` — Unicode API | `E6 B7 B1 E5 9C B3 E6 B1 89 ED 95 9C C3 A9` | `深圳汉한é` |

Both failure modes appear in that single line: `汉` and `한` were replaced by `?`,
and `é` was best-fitted to a plain `e` with no marker at all.

Deleting `local.db` and rescanning does not recover the data: the conversion is
deterministic, so the rescan reproduces the same corrupted values.

Related: #29885 reports the same root-cause family (ANSI-vs-Unicode Windows API
handling of non-ASCII data) in the FIM module. Different module and different code
path, so it is not fixed here, but the two share the underlying cause and are worth
looking at together.

## Proposed Changes

- **`src/shared_modules/utils/registryHelper.h`** — add
  `Registry::stringUtf8(valueName, value)`, which reads the value with
  `RegQueryValueExW` and converts the UTF-16 result to UTF-8 via the existing
  `EncodingWindowsHelper`. The existing `Registry::string()` is left untouched so no
  current caller changes behaviour; call sites opt in explicitly.
  - Rejects values that are not `REG_SZ`/`REG_EXPAND_SZ`, so a numeric value is
    reported as a failure instead of as empty text.
  - Allocates one `wchar_t` beyond the reported size, so a stored value that lacks
    its terminator cannot cause an over-read.

- **`src/data_provider/src/sysInfoWin.cpp`** — `getPackagesFromReg()` now uses
  `stringUtf8()` for `DisplayName`, `DisplayVersion`, `Publisher` and
  `InstallLocation`. `InstallDate` is left on `string()`: it is a numeric timestamp
  fed to `Utils::normalizeTimestamp()`, never text.

- **`src/data_provider/src/packages/appxWindowsWrapper.h`** — `stringUtf8()` for the
  four reported text values: `DisplayName`, the `ApplicationName` fallback,
  the MRT `MrtCache` localized-name lookup in `searchKeyOnSubRegistries()`, and
  `ApplicationCompany` in `searchPublisher()`.
  - The ProgID read in `searchPublisher()` deliberately stays on `string()`: it is not
    reported data, it is used to build the subkey path opened right below through
    `RegOpenKeyEx` (the ANSI variant), so it must stay ANSI-encoded. A comment records
    this.
  - `PackageRootFolder` stays on `string()`: `WindowsApps` paths are ASCII, and the
    value is later passed to `GetFileVersionInfoSizeA`.

Values read elsewhere through `Registry::string()` were reviewed and left alone
because they cannot carry non-ASCII text: the `KB######` strings in
`packagesWindowsParserHelper.h` (matched against a `KB[0-9]{6,}` regex) and
`ProcessorNameString` in `sysInfoWin.cpp` (ASCII by vendor convention). Values in
`osinfo/sysOsInfoWin.cpp` and the `RegQueryValueExA` call inside
`Registry::getValue()` (used by `sca_policy_check_win.cpp`) have the same latent
issue but are outside the scope of this fix.

### Results and Evidence

Standalone check compiled against the real `registryHelper.h` on Windows (ACP 950).
It writes `L"深圳汉한é"` as a UTF-16 `REG_SZ` under `HKCU`, reads it back through both
paths, and deletes the key:

```
system ANSI code page: 950
expected UTF-8               len=14 bytes=E6 B7 B1 E5 9C B3 E6 B1 89 ED 95 9C C3 A9
string()   [ANSI path]       len= 9 bytes=E6 B7 B1 E5 9C B3 3F 3F 65
stringUtf8() [Unicode]       len=14 bytes=E6 B7 B1 E5 9C B3 E6 B1 89 ED 95 9C C3 A9
PASS: stringUtf8() returned the stored characters as UTF-8
PASS: string() lost data, reproducing the reported corruption
PASS: missing value rejected
PASS: REG_DWORD value rejected
PASS: ProcessorNameString = "Intel(R) Core(TM) Ultra 7 155H"
ALL CHECKS PASSED
```

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux — N/A, the changed code is inside `#ifdef WIN32`
  - [ ] Windows — not verified locally, no MinGW toolchain available on the
        contributor's machine; needs CI
  - [ ] MAC OS X — N/A, the changed code is inside `#ifdef WIN32`
- [x] Log syntax and correct language review — no log messages changed

Memory tests: N/A. The new method adds one `std::unique_ptr<wchar_t[]>` allocation
per read, sized from the value length `RegQueryValueExW` reports, with the handle
lifetime unchanged.

Decoder/Rule tests: N/A.
Engine: N/A.
Wazuh server API/Framework: N/A.

### Artifacts Affected

- Windows agent executable (`wazuh-agent`), syscollector package inventory.
- No configuration files, no schema changes. The `packages` records emitted for
  affected software change content only: the same fields, now holding the characters
  actually stored on the endpoint.

### Configuration Changes

N/A.

### Tests Introduced

- `src/shared_modules/utils/tests/registryHelper_test.cpp`
  - `RegistryStringUtf8KeepsCharactersOutsideTheSystemCodePage` — writes a `REG_SZ`
    holding U+6DF1 U+5733 (Han), U+6C49 (simplified-only Han), U+D55C (Hangul) and
    U+00E9 (Latin with diacritic); no single Windows ANSI code page can hold all four,
    so the test is code-page independent. Asserts `stringUtf8()` returns the exact
    UTF-8 bytes, and that `string()` returns something different unless the ACP is
    UTF-8 itself. Cleans up its own key.
  - `RegistryStringUtf8NoThrow` — a missing value returns false and leaves the output
    untouched.
  - `RegistryStringUtf8RejectsNonStringValues` — `~MHz` is a `REG_DWORD` and must be
    rejected rather than reported as empty text.

- `src/data_provider/tests/sysInfoWin/sysInfoWinAppx_test.cpp`
  - `FakeRegistry::string()` now reproduces the ANSI loss (every non-ASCII byte
    becomes `?`) and delegates to a new lossless `stringUtf8()`. This makes the
    regression permanent: if any of these call sites goes back to `string()`, the
    tests below fail.
  - `NonAsciiDisplayNameAndPublisherAreReadAsUtf8` — non-ASCII `DisplayName` and
    `ApplicationCompany` resolved through the FileAssociations ProgID.
  - `NonAsciiApplicationNameFallbackIsReadAsUtf8` — no `DisplayName`, so the name
    comes from the sub-application `ApplicationName` fallback.
  - `NonAsciiLocalizedNameFromCacheRegistryIsReadAsUtf8` — an `@{...}` MRT resource
    reference resolved to a non-ASCII localized name through `MrtCache`.

All test sources stay pure ASCII: expected data is written as `\xNN` escapes with the
code points named in a comment above each constant.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented — N/A, no configuration change
- [ ] Developer documentation reflects the changes — N/A, internal helper only
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues