### PR TITLE
Sign HTTPS request body before compression, not after

### DIFF
--- a/src/client-agent/https_client/src/retrySender.cpp
+++ b/src/client-agent/https_client/src/retrySender.cpp
@@ -134,9 +134,24 @@ RetrySender::Result RetrySender::attemptOnce(const HttpRequestSpec& base)
 {
     HttpRequestSpec attempt = base; // Fresh copy: the auth pair differs per attempt.
 
+    // Sign the plaintext first, against base's untouched fields, before
+    // compression below mutates attempt (#38494).
+    const auto timestamp = m_clock.wallSeconds();
+    // Bind by reference: both branches return std::optional<SignedHeaders> by
+    // value, and `headers` is only read locally below, well within the
+    // ternary temporary's extended lifetime -- no need to copy it. (CID 562606)
+    const auto& headers =
+        base.bodyFilePath.empty()
+        ? m_signer.sign("POST", base.target, base.body, base.bodyLength, timestamp)
+        : m_signer.signFile("POST", base.target, base.bodyFilePath, timestamp);
+
+    if (!headers)
+    {
+        return {OutcomeClass::Permanent, {}}; // Unusable credentials: retrying cannot help.
+    }
+
     // In-memory bodies: compressed here, per attempt (cheap for the small
-    // buffers every other send path uses). Compressed before signing so the
-    // CMAC covers the wire bytes.
+    // buffers every other send path uses), for the wire only.
     std::vector<uint8_t> compressedBody;
     const bool gateAllowsCompression = m_compressionGate == nullptr || !m_compressionGate->disabled();
 
@@ -171,20 +186,6 @@ RetrySender::Result RetrySender::attemptOnce(const HttpRequestSpec& base)
         attempt.bodyFilePath = attempt.precompressedBodyFilePath;
         attempt.bodyFileSize = attempt.precompressedBodyFileSize;
         attempt.headers.push_back("Content-Encoding: zstd");
-    }
-
-    const auto timestamp = m_clock.wallSeconds();
-    // Bind by reference: both branches return std::optional<SignedHeaders> by
-    // value, and `headers` is only read locally below, well within the
-    // ternary temporary's extended lifetime -- no need to copy it. (CID 562606)
-    const auto& headers =
-        attempt.bodyFilePath.empty()
-        ? m_signer.sign("POST", attempt.target, attempt.body, attempt.bodyLength, timestamp)
-        : m_signer.signFile("POST", attempt.target, attempt.bodyFilePath, timestamp);
-
-    if (!headers)
-    {
-        return {OutcomeClass::Permanent, {}}; // Unusable credentials: retrying cannot help.
     }
 
     attempt.headers.push_back(headers->protocolVersion);

--- a/src/client-agent/https_client/src/retrySender.hpp
+++ b/src/client-agent/https_client/src/retrySender.hpp
@@ -43,8 +43,8 @@ class RetrySender final
         };
 
         /// compressionEnabled: zstd-compress in-memory bodies (Content-Encoding:
-        /// zstd) before signing, so the CMAC covers the wire bytes. File-backed
-        /// bodies (/stateful) are compressed once by the caller, not here --
+        /// zstd) for the wire, after signing (#38494). File-backed bodies
+        /// (/stateful) are compressed once by the caller, not here --
         /// attemptOnce() swaps in HttpRequestSpec::precompressedBodyFilePath
         /// when the caller set one and the gate currently allows compression.
         /// compressionGate (optional, shared across every RetrySender on this

--- a/src/client-agent/https_client/tests/unit/retrySender_test.cpp
+++ b/src/client-agent/https_client/tests/unit/retrySender_test.cpp
@@ -482,7 +482,7 @@ TEST_F(RetrySenderTest, CompressionDisabledLeavesBodyAndHeadersUnchanged)
     EXPECT_TRUE(std::equal(receivedBody.begin(), receivedBody.end(), spec.body));
 }
 
-TEST_F(RetrySenderTest, CompressedBodyIsSignedOverTheCompressedBytes)
+TEST_F(RetrySenderTest, CompressedBodyIsSignedOverThePlaintextBytes)
 {
     RetrySender compressing {m_performer, m_signer, m_clock, m_backoff, true};
 
@@ -517,13 +517,16 @@ TEST_F(RetrySenderTest, CompressedBodyIsSignedOverTheCompressedBytes)
     ASSERT_EQ(plain.size(), decompressedSize);
     EXPECT_EQ(plain, std::string(decompressed.begin(), decompressed.end()));
 
-    // The CMAC must cover the wire (compressed) bytes, not the original --
-    // re-signing the exact received bytes at the same timestamp (the clock
-    // never advanced) must reproduce the exact Authorization header sent.
+    // The CMAC must cover the plaintext, not the wire (compressed) bytes.
     const auto expected =
-        m_signer.sign("POST", spec.target, receivedBody.data(), receivedBody.size(), m_clock.wallSeconds());
+        m_signer.sign("POST", spec.target, spec.body, spec.bodyLength, m_clock.wallSeconds());
     ASSERT_TRUE(expected.has_value());
     EXPECT_THAT(receivedHeaders, Contains(expected->authorization));
+
+    const auto overCompressed =
+        m_signer.sign("POST", spec.target, receivedBody.data(), receivedBody.size(), m_clock.wallSeconds());
+    ASSERT_TRUE(overCompressed.has_value());
+    EXPECT_THAT(receivedHeaders, Not(Contains(overCompressed->authorization)));
 }
 
 TEST_F(RetrySenderTest, CompressionEnabledSkipsFileBackedBodies)
@@ -647,11 +650,11 @@ TEST_F(RetrySenderTest, AuthFailureFromTheCompressionRetryStillGetsItsOwnGraceRe
     EXPECT_FALSE(authGate.paused()); // Recovered by its own grace retry: never escalated.
 }
 
-TEST_F(RetrySenderTest, PrecompressedFileBodyIsUsedAndSignedOverItsBytes)
+TEST_F(RetrySenderTest, PrecompressedFileBodyIsSentButSignedOverTheOriginalBytes)
 {
     // /stateful's own caller (StatefulStream) compresses once, up front, and
-    // hands the sibling's path/size here -- attemptOnce() must swap it in and
-    // sign over ITS bytes, not the original file's.
+    // hands the sibling's path/size here -- attemptOnce() swaps it in for the
+    // wire only; the CMAC must still cover the original file.
     RetrySender compressing {m_performer, m_signer, m_clock, m_backoff, true};
 
     const std::string originalPath = writeTempFile("hc_rs_original.bin", "the original body");
@@ -684,10 +687,14 @@ TEST_F(RetrySenderTest, PrecompressedFileBodyIsUsedAndSignedOverItsBytes)
     EXPECT_EQ(14u, seenBodyFileSize);
     EXPECT_THAT(seenHeaders, Contains("Content-Encoding: zstd"));
 
-    // The CMAC must cover the compressed file's bytes, not the original's.
-    const auto expected = m_signer.signFile("POST", spec.target, compressedPath, m_clock.wallSeconds());
+    // The CMAC must cover the original file, not the compressed sibling.
+    const auto expected = m_signer.signFile("POST", spec.target, originalPath, m_clock.wallSeconds());
     ASSERT_TRUE(expected.has_value());
     EXPECT_THAT(seenHeaders, Contains(expected->authorization));
+
+    const auto overCompressed = m_signer.signFile("POST", spec.target, compressedPath, m_clock.wallSeconds());
+    ASSERT_TRUE(overCompressed.has_value());
+    EXPECT_THAT(seenHeaders, Not(Contains(overCompressed->authorization)));
 }
 
 TEST_F(RetrySenderTest, CompressedFileBackedAttemptRejectedWith415RetriesOnceUncompressedAndSucceeds)


### PR DESCRIPTION
## Description

`RetrySender::attemptOnce()` (`retrySender.cpp`) currently compresses the request body or file first, then signs whatever `attempt` holds at that point. The CMAC ends up covering the compressed bytes instead of the original payload. For `/stateful` it goes further, the precompressed file path overwrites `bodyFilePath` before `signFile()` runs, so the plaintext spool file never reaches the signer at all, even though it's still sitting untouched in the caller's original spec.

Closes #38494

## Proposed Changes

- Moved the `sign()` / `signFile()` call in `attemptOnce()` to run first, against `base`'s untouched fields, before the compression block ever touches `attempt`.
- Compression logic itself is unchanged, same zstd path, same 415 fallback, same precompressed-sibling swap for `/stateful`, it now only affects what goes on the wire, not what gets signed.
- Updated the doc comment on `RetrySender`'s constructor (`retrySender.hpp`) that described the old compress-then-sign order.
- Renamed and rewrote the two existing unit tests that had the old order baked in as the expected behavior, listed below with their old and new names.
  - `CompressedBodyIsSignedOverTheCompressedBytes` renamed to `CompressedBodyIsSignedOverThePlaintextBytes`
  - `PrecompressedFileBodyIsUsedAndSignedOverItsBytes` renamed to `PrecompressedFileBodyIsSentButSignedOverTheOriginalBytes`

  Both now also assert the old (compressed-bytes) signature no longer matches what's sent, not just that the new one does.

This covers `/stateless`, `/stateful`, `/control` and `/download`, all four route through `RetrySender::attemptOnce`.

`/enroll` is explicitly out of scope here. `EnrollClient`/`EnrollSigner` don't exist on `5.0.0` yet, they're new files in the still-open PR #38470, which signs the already-compressed body (see `EnrollClient::performOnce`). That endpoint will need this same reorder once #38470 merges.

### Results and Evidence

Full local build (not a CI run) on WSL Ubuntu 26.04, GCC 15.2, via `make deps TARGET=agent` and `make https_client_unit_test`. `retrySender.cpp` compiled clean, no warnings, and the same for `retrySender_test.cpp`. Full `https_client_unit_test` suite filtered to `RetrySenderTest`, output below.

```
[==========] Running 34 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 34 tests from RetrySenderTest
[ RUN      ] RetrySenderTest.SuccessOnFirstAttemptSignsAndResetsBackoff
[       OK ] RetrySenderTest.SuccessOnFirstAttemptSignsAndResetsBackoff (3 ms)
[ RUN      ] RetrySenderTest.EveryRetryIsFreshlySigned
[       OK ] RetrySenderTest.EveryRetryIsFreshlySigned (0 ms)
[ RUN      ] RetrySenderTest.ServerRetryAfterWinsWhenLonger
[       OK ] RetrySenderTest.ServerRetryAfterWinsWhenLonger (0 ms)
[ RUN      ] RetrySenderTest.BackoffWinsOverShorterRetryAfter
[       OK ] RetrySenderTest.BackoffWinsOverShorterRetryAfter (0 ms)
[ RUN      ] RetrySenderTest.PermanentOutcomeNeverRetries
[       OK ] RetrySenderTest.PermanentOutcomeNeverRetries (0 ms)
[ RUN      ] RetrySenderTest.PayloadTooLargeReturnsImmediately
[       OK ] RetrySenderTest.PayloadTooLargeReturnsImmediately (0 ms)
[ RUN      ] RetrySenderTest.RepeatedAuthFailureReturnsAuthFail
[       OK ] RetrySenderTest.RepeatedAuthFailureReturnsAuthFail (0 ms)
[ RUN      ] RetrySenderTest.AuthFailureRecoversWithAFreshTimestamp
[       OK ] RetrySenderTest.AuthFailureRecoversWithAFreshTimestamp (0 ms)
[ RUN      ] RetrySenderTest.SkewedClockIsCorrectedFromServerDateAndRetrySucceeds
[       OK ] RetrySenderTest.SkewedClockIsCorrectedFromServerDateAndRetrySucceeds (0 ms)
[ RUN      ] RetrySenderTest.BehindClockIsCorrectedForwardFromServerDateAndRetrySucceeds
[       OK ] RetrySenderTest.BehindClockIsCorrectedForwardFromServerDateAndRetrySucceeds (0 ms)
[ RUN      ] RetrySenderTest.SmallDateGapWithinNoiseFloorIsNotTreatedAsSkew
[       OK ] RetrySenderTest.SmallDateGapWithinNoiseFloorIsNotTreatedAsSkew (0 ms)
[ RUN      ] RetrySenderTest.MissingServerDateNeverAppliesACorrection
[       OK ] RetrySenderTest.MissingServerDateNeverAppliesACorrection (0 ms)
[ RUN      ] RetrySenderTest.CorrectedRetryStillFailingEscalatesAsKeyFailure
[       OK ] RetrySenderTest.CorrectedRetryStillFailingEscalatesAsKeyFailure (0 ms)
[ RUN      ] RetrySenderTest.CorrectionPersistsForSubsequentSendsAfterTheIncidentEnds
[       OK ] RetrySenderTest.CorrectionPersistsForSubsequentSendsAfterTheIncidentEnds (0 ms)
[ RUN      ] RetrySenderTest.SecondIndependentSkewEventConvergesOnTopOfAnExistingCorrection
[       OK ] RetrySenderTest.SecondIndependentSkewEventConvergesOnTopOfAnExistingCorrection (0 ms)
[ RUN      ] RetrySenderTest.AuthGateEscalatesOnlyAfterTheRetryAlsoFails
[       OK ] RetrySenderTest.AuthGateEscalatesOnlyAfterTheRetryAlsoFails (0 ms)
[ RUN      ] RetrySenderTest.VersionRejectionReturnsImmediately
[       OK ] RetrySenderTest.VersionRejectionReturnsImmediately (0 ms)
[ RUN      ] RetrySenderTest.StopDuringTheDelayInterrupts
[       OK ] RetrySenderTest.StopDuringTheDelayInterrupts (0 ms)
[ RUN      ] RetrySenderTest.AbortedTransferSurfacesAsInterrupted
[       OK ] RetrySenderTest.AbortedTransferSurfacesAsInterrupted (0 ms)
[ RUN      ] RetrySenderTest.MaxAttemptsBoundsTheLoop
[       OK ] RetrySenderTest.MaxAttemptsBoundsTheLoop (0 ms)
[ RUN      ] RetrySenderTest.WaiterStopFlagIsWiredAsTheAbortFlag
[       OK ] RetrySenderTest.WaiterStopFlagIsWiredAsTheAbortFlag (0 ms)
[ RUN      ] RetrySenderTest.UnusableCredentialsArePermanentWithoutSending
[       OK ] RetrySenderTest.UnusableCredentialsArePermanentWithoutSending (0 ms)
[ RUN      ] RetrySenderTest.FileBackedSpecsAreSignedThroughSignFile
[       OK ] RetrySenderTest.FileBackedSpecsAreSignedThroughSignFile (2 ms)
[ RUN      ] RetrySenderTest.CompressionDisabledLeavesBodyAndHeadersUnchanged
[       OK ] RetrySenderTest.CompressionDisabledLeavesBodyAndHeadersUnchanged (0 ms)
[ RUN      ] RetrySenderTest.CompressedBodyIsSignedOverThePlaintextBytes
[       OK ] RetrySenderTest.CompressedBodyIsSignedOverThePlaintextBytes (51 ms)
[ RUN      ] RetrySenderTest.CompressionEnabledSkipsFileBackedBodies
[       OK ] RetrySenderTest.CompressionEnabledSkipsFileBackedBodies (0 ms)
[ RUN      ] RetrySenderTest.CompressedAttemptRejectedWith415RetriesOnceUncompressedAndSucceeds
[       OK ] RetrySenderTest.CompressedAttemptRejectedWith415RetriesOnceUncompressedAndSucceeds (0 ms)
[ RUN      ] RetrySenderTest.CompressionRejectionDisablesTheSharedGateForOtherSenders
[       OK ] RetrySenderTest.CompressionRejectionDisablesTheSharedGateForOtherSenders (0 ms)
[ RUN      ] RetrySenderTest.SecondCompressionRejectionTerminatesWithoutLooping
[       OK ] RetrySenderTest.SecondCompressionRejectionTerminatesWithoutLooping (0 ms)
[ RUN      ] RetrySenderTest.AuthFailureFromTheCompressionRetryStillGetsItsOwnGraceRetry
[       OK ] RetrySenderTest.AuthFailureFromTheCompressionRetryStillGetsItsOwnGraceRetry (0 ms)
[ RUN      ] RetrySenderTest.PrecompressedFileBodyIsSentButSignedOverTheOriginalBytes
[       OK ] RetrySenderTest.PrecompressedFileBodyIsSentButSignedOverTheOriginalBytes (0 ms)
[ RUN      ] RetrySenderTest.CompressedFileBackedAttemptRejectedWith415RetriesOnceUncompressedAndSucceeds
[       OK ] RetrySenderTest.CompressedFileBackedAttemptRejectedWith415RetriesOnceUncompressedAndSucceeds (0 ms)
[ RUN      ] RetrySenderTest.SecondFileBackedCompressionRejectionTerminatesWithoutLooping
[       OK ] RetrySenderTest.SecondFileBackedCompressionRejectionTerminatesWithoutLooping (0 ms)
[ RUN      ] RetrySenderTest.FileBackedSenderSkipsCompressionOnceTheSharedGateIsAlreadyDisabled
[       OK ] RetrySenderTest.FileBackedSenderSkipsCompressionOnceTheSharedGateIsAlreadyDisabled (1 ms)
[----------] 34 tests from RetrySenderTest (62 ms total)

[----------] Global test environment tear-down
[==========] 34 tests from 1 test suite ran. (62 ms total)
[  PASSED  ] 34 tests.
```

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux (WSL Ubuntu 26.04, GCC 15.2, `make https_client_unit_test`, see above)
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review, N/A, no log strings were added or changed by this fix

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_, N/A, this change is in the agent's C++ HTTPS transport, not decoders/rules

- Engine _(Wazuh v5.x and above)_, N/A, wazuh-engine is untouched by this change

- Wazuh server API/Framework, N/A, this is agent-side transport code, not the server API/Framework

### Artifacts Affected

- `libhttps_client.so` (Linux) / `libhttps_client.dll` (Windows), the agent's HTTPS client shared library, rebuilt with the reordered signing logic. No new binaries, no packaging or installer changes.

### Configuration Changes

N/A, no configuration parameters added or changed.

### Tests Introduced

No new test files. Two existing tests in `retrySender_test.cpp` were renamed and rewritten, see Proposed Changes above for the exact names and what changed in their assertions.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented (N/A, none)
- [x] Developer documentation reflects the changes (in-code doc comment on `RetrySender`'s constructor updated)
- [ ] Meets requirements and/or definition of done, partial. Covers `/stateless`, `/stateful`, `/control`, `/download` as scoped above. `/enroll` is intentionally out of scope pending PR #38470
- [ ] No unresolved dependencies with other issues, depends on PR #38470 landing before `/enroll` gets the same fix, and on #38491 for the matching manager-side decompress-before-validate change

Flagging both of the unchecked items above deliberately rather than checking them off, they're real, known gaps in scope, not oversights. Also, #38491 already documents the matching manager-side requirement (decompress before validating the CMAC), so this PR lines up with what's already planned there.