### PR TITLE
Raise the number of Active Response commands the agent can load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
 
 ### Agent
 
+#### Changed
+
+- Raised from 64 to 1024 the number of active response commands that `wazuh-execd` can load from `etc/shared/ar.conf`. ([#38509](https://github.com/wazuh/wazuh/pull/38509))
+
 #### Fixed
 
 - Fixed the Windows agent MSI upgrade leaving the agent broken after the next reboot, and the silent `/q` upgrade hanging, when a system restart was pending. ([#38277](https://github.com/wazuh/wazuh/pull/38277))

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -198,7 +198,7 @@
 #define EXEC_INV_CMD    "(1316): Invalid AR command: '%s'"
 #define EXEC_CMD_FAIL   "(1317): Could not launch command %s (%d)"
 #define EXEC_BAD_NAME   "(1318): Command name truncated %s"
-#define EXEC_MAX_AR     "(1319): Reached the maximum of %d active response commands. Ignoring the remaining entries of '%s'."
+#define EXEC_MAX_AR     "(1319): Reached the limit of %d active response commands. Ignoring the remaining entries of '%s'."
 
 #define AR_NOAGENT_ERROR                "(1320): Agent '%s' not found."
 #define EXEC_QUEUE_CONNECTION_ERROR     "(1321): Error communicating with queue '%s'."

--- a/src/error_messages/warning_messages.h
+++ b/src/error_messages/warning_messages.h
@@ -13,7 +13,7 @@
 
 /* Active Response */
 #define AR_SERVER_AGENT "(1306): Invalid agent ID. Use location=server to run AR on the manager."
-#define AR_MAX_COMMANDS "(1307): Defined %d active response commands, more than the maximum of %d. The exceeding entries of '%s' may not be loaded by the agents."
+#define AR_MAX_COMMANDS "(1307): Defined %d active response commands, more than the %d supported by previous agent versions. Those agents may fail to run active responses until the exceeding entries of '%s' are removed."
 
 /* File integrity monitoring warning messages*/
 #define FIM_WARN_ACCESS                         "(6900): Accessing  '%s': [(%d) - (%s)]"

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -161,8 +161,10 @@ https://www.gnu.org/licenses/gpl.html\n"
 /* Active Response files */
 #define DEFAULTAR_FILE  "ar.conf"
 #define AR_BINDIR       "active-response/bin"
-/* Maximum number of active response commands that an agent can load */
+/* Number of active response commands that previous agent versions can load */
 #define MAX_AR          64
+/* Maximum number of active response commands that an agent loads */
+#define MAX_AR_COMMANDS 1024
 #ifndef WIN32
 #define DEFAULTAR       "etc/shared/" DEFAULTAR_FILE
 #define AGENTCONFIG     "etc/shared/agent.conf"

--- a/src/os_execd/exec.c
+++ b/src/os_execd/exec.c
@@ -12,13 +12,56 @@
 #include "os_regex/os_regex.h"
 #include "execd.h"
 
-static char exec_names[MAX_AR + 1][OS_FLSIZE + 1];
-static char exec_cmd[MAX_AR + 1][OS_FLSIZE + 1];
-static int  exec_timeout[MAX_AR + 1];
-static int  exec_size = 0;
-static int  f_time_reading = 1;
-static int  f_max_reported = 0;
+/* Number of command slots the table grows by */
+#define EXEC_TABLE_CHUNK 32
 
+typedef struct exec_entry {
+    char *name;
+    char *cmd;
+    int timeout;
+} exec_entry_t;
+
+static exec_entry_t *exec_table = NULL;
+static int exec_size = 0;
+static int exec_capacity = 0;
+static int f_time_reading = 1;
+static int f_max_reported = 0;
+
+/* Discard the loaded commands, keeping the allocated slots for the next read */
+static void ClearExecTable()
+{
+    int i;
+
+    for (i = 0; i < exec_size; i++) {
+        os_free(exec_table[i].name);
+        os_free(exec_table[i].cmd);
+        exec_table[i].timeout = 0;
+    }
+
+    exec_size = 0;
+}
+
+/* Append a command to the table, growing it when there is no slot left */
+static void AddExecEntry(const char *name, const char *cmd, int timeout)
+{
+    if (exec_size == exec_capacity) {
+        exec_capacity += EXEC_TABLE_CHUNK;
+        os_realloc(exec_table, exec_capacity * sizeof(exec_entry_t), exec_table);
+    }
+
+    os_strdup(name, exec_table[exec_size].name);
+    os_strdup(cmd, exec_table[exec_size].cmd);
+    exec_table[exec_size].timeout = timeout;
+    exec_size++;
+}
+
+/* Release the command table */
+void FreeExecConfig()
+{
+    ClearExecTable();
+    os_free(exec_table);
+    exec_capacity = 0;
+}
 
 /* Read the shared exec config
  * Returns 1 on success or 0 on failure
@@ -26,18 +69,15 @@ static int  f_max_reported = 0;
  */
 int ReadExecConfig()
 {
-    int i = 0, j = 0, dup_entry = 0, truncated = 0;
+    int j = 0, dup_entry = 0, truncated = 0;
     FILE *fp;
     FILE *process_file;
     char buffer[OS_MAXSTR + 1];
+    char name[OS_FLSIZE + 1];
+    char cmd[OS_FLSIZE + 1];
 
     /* Clean up */
-    for (i = 0; i <= MAX_AR; i++) {
-        memset(exec_names[i], '\0', OS_FLSIZE + 1);
-        memset(exec_cmd[i], '\0', OS_FLSIZE + 1);
-        exec_timeout[i] = 0;
-    }
-    exec_size = 0;
+    ClearExecTable();
 
     /* Open file */
     fp = wfopen(DEFAULTAR, "r");
@@ -52,6 +92,8 @@ int ReadExecConfig()
         char *tmp_str;
 
         str_pt = buffer;
+        name[0] = '\0';
+        cmd[0] = '\0';
 
         // The command name must not start with '!'
 
@@ -70,12 +112,12 @@ int ReadExecConfig()
         tmp_str += 3;
 
         /* Set the name */
-        const int bytes_written = snprintf(exec_names[exec_size], sizeof(exec_names[exec_size]), "%s", str_pt);
+        const int bytes_written = snprintf(name, sizeof(name), "%s", str_pt);
 
         if (bytes_written < 0) {
-            merror(EXEC_BAD_NAME " Error %d (%s).", exec_names[exec_size], errno, strerror(errno));
-        } else if ((size_t)bytes_written >= sizeof(exec_names[exec_size])) {
-            merror(EXEC_BAD_NAME, exec_names[exec_size]);
+            merror(EXEC_BAD_NAME " Error %d (%s).", name, errno, strerror(errno));
+        } else if ((size_t)bytes_written >= sizeof(name)) {
+            merror(EXEC_BAD_NAME, name);
         }
 
         str_pt = tmp_str;
@@ -93,22 +135,21 @@ int ReadExecConfig()
 
         if (w_ref_parent_folder(str_pt)) {
             merror("Active response command '%s' vulnerable to directory traversal attack. Ignoring.", str_pt);
-            exec_cmd[exec_size][0] = '\0';
         } else {
             /* Write the full command path */
-            snprintf(exec_cmd[exec_size], OS_FLSIZE,
+            snprintf(cmd, OS_FLSIZE,
                      "%s/%s",
                      AR_BINDIR,
                      str_pt);
-            process_file = wfopen(exec_cmd[exec_size], "r");
+            process_file = wfopen(cmd, "r");
             if (!process_file) {
                 if (f_time_reading) {
                     minfo("Active response command not present: '%s'. "
                             "Not using it on this system.",
-                            exec_cmd[exec_size]);
+                            cmd);
                 }
 
-                exec_cmd[exec_size][0] = '\0';
+                cmd[0] = '\0';
             } else {
                 fclose(process_file);
             }
@@ -120,37 +161,31 @@ int ReadExecConfig()
             *tmp_str = '\0';
         }
 
-        /* Get the exec timeout */
-        exec_timeout[exec_size] = atoi(str_pt);
-
         /* Check if name is duplicated */
         dup_entry = 0;
         for (j = 0; j < exec_size; j++) {
-            if (strcmp(exec_names[j], exec_names[exec_size]) == 0) {
-                if (exec_cmd[j][0] == '\0') {
-                    snprintf(exec_cmd[j], sizeof(exec_cmd[j]), "%s", exec_cmd[exec_size]);
+            if (strcmp(exec_table[j].name, name) == 0) {
+                if (exec_table[j].cmd[0] == '\0') {
+                    os_free(exec_table[j].cmd);
+                    os_strdup(cmd, exec_table[j].cmd);
                     dup_entry = 1;
                     break;
-                } else if (exec_cmd[exec_size][0] == '\0') {
+                } else if (cmd[0] == '\0') {
                     dup_entry = 1;
                 }
             }
         }
 
-        if (dup_entry) {
-            exec_cmd[exec_size][0] = '\0';
-            exec_names[exec_size][0] = '\0';
-            exec_timeout[exec_size] = 0;
-        } else if (exec_size < MAX_AR) {
-            exec_size++;
-        } else {
-            // No room left in the command table
+        if (!dup_entry) {
+            if (exec_size == MAX_AR_COMMANDS) {
+                // No room left in the command table
 
-            exec_cmd[exec_size][0] = '\0';
-            exec_names[exec_size][0] = '\0';
-            exec_timeout[exec_size] = 0;
-            truncated = 1;
-            break;
+                truncated = 1;
+                break;
+            }
+
+            /* Get the exec timeout */
+            AddExecEntry(name, cmd, atoi(str_pt));
         }
     }
 
@@ -159,7 +194,7 @@ int ReadExecConfig()
 
     /* Report only when the configuration starts being truncated */
     if (truncated && !f_max_reported) {
-        merror(EXEC_MAX_AR, MAX_AR, DEFAULTAR);
+        merror(EXEC_MAX_AR, MAX_AR_COMMANDS, DEFAULTAR);
     }
 
     f_max_reported = truncated;
@@ -168,6 +203,7 @@ int ReadExecConfig()
 }
 
 /* Returns a pointer to the command name (full path)
+ * The pointer is only valid until the next call to ReadExecConfig()
  * Returns NULL if name cannot be found
  * If timeout is not NULL, write the timeout for that
  * command to it
@@ -196,9 +232,9 @@ char *GetCommandbyName(const char *name, int *timeout)
     }
 
     for (; i < exec_size; i++) {
-        if (strcmp(name, exec_names[i]) == 0) {
-            *timeout = exec_timeout[i];
-            return (exec_cmd[i]);
+        if (strcmp(name, exec_table[i].name) == 0) {
+            *timeout = exec_table[i].timeout;
+            return (exec_table[i].cmd);
         }
     }
 

--- a/src/os_execd/execd.h
+++ b/src/os_execd/execd.h
@@ -36,6 +36,7 @@ extern int max_restart_lock;
 /** Function prototypes **/
 
 int ReadExecConfig(void);
+void FreeExecConfig(void);
 cJSON *getARConfig(void);
 cJSON *getExecdInternalOptions(void);
 cJSON *getClusterConfig(void);

--- a/src/unit_tests/os_execd/test_read_exec_config.c
+++ b/src/unit_tests/os_execd/test_read_exec_config.c
@@ -23,12 +23,22 @@
 #define TEST_AR_SCRIPT  "test-ar.sh"
 #define TEST_AR_COMMAND AR_BINDIR "/" TEST_AR_SCRIPT
 
+/* Number of commands used to check that the table grows past any fixed size */
+#define TEST_AR_LARGE   500
+
 static char test_dir[PATH_MAX + 1];
 static char previous_dir[PATH_MAX + 1];
 
 /* Build the name of the entry number 'index' of the generated ar.conf */
 static void ar_entry_name(char *buffer, size_t size, int index) {
     snprintf(buffer, size, "ar-cmd-%03d", index);
+}
+
+/* Every entry carries a distinct timeout, so that the value cannot be
+ * confused with the one of another entry
+ */
+static int ar_entry_timeout(int index) {
+    return index + 1;
 }
 
 /* Write an ar.conf holding 'entries' distinct active response commands */
@@ -41,7 +51,7 @@ static void write_ar_conf(int entries) {
 
     for (i = 0; i < entries; i++) {
         ar_entry_name(name, sizeof(name), i);
-        assert_true(fprintf(fp, "%s - %s - 0\n", name, TEST_AR_SCRIPT) > 0);
+        assert_true(fprintf(fp, "%s - %s - %d\n", name, TEST_AR_SCRIPT, ar_entry_timeout(i)) > 0);
     }
 
     fclose(fp);
@@ -57,9 +67,10 @@ static void append_ar_line(const char *line) {
 }
 
 static void expect_max_ar_error(void) {
-    char expected_msg[OS_MAXSTR];
+    /* expect_string() keeps the pointer, so the buffer must outlive this call */
+    static char expected_msg[OS_MAXSTR];
 
-    snprintf(expected_msg, sizeof(expected_msg), EXEC_MAX_AR, MAX_AR, DEFAULTAR);
+    snprintf(expected_msg, sizeof(expected_msg), EXEC_MAX_AR, MAX_AR_COMMANDS, DEFAULTAR);
     expect_string(__wrap__merror, formatted_msg, expected_msg);
 }
 
@@ -74,7 +85,7 @@ static void assert_entry_loaded(int index) {
 
     assert_non_null(command);
     assert_string_equal(command, TEST_AR_COMMAND);
-    assert_int_equal(timeout, 0);
+    assert_int_equal(timeout, ar_entry_timeout(index));
 }
 
 /* Assert that the entry number 'index' was not loaded */
@@ -113,6 +124,8 @@ static int group_setup(void **state) {
 static int group_teardown(void **state) {
     (void)state;
 
+    FreeExecConfig();
+
     remove(DEFAULTAR);
     remove(TEST_AR_COMMAND);
     remove(AR_BINDIR);
@@ -127,7 +140,7 @@ static int group_teardown(void **state) {
 }
 
 /* A regular configuration is loaded in full */
-static void test_read_exec_config_below_limit(void **state) {
+static void test_read_exec_config_small(void **state) {
     (void)state;
 
     write_ar_conf(10);
@@ -139,25 +152,90 @@ static void test_read_exec_config_below_limit(void **state) {
     assert_entry_not_loaded(10);
 }
 
-/* Exactly MAX_AR commands still fit, and no entry is reported as ignored */
+/* The table holds as many commands as the file defines */
+static void test_read_exec_config_large(void **state) {
+    (void)state;
+    int i;
+
+    write_ar_conf(TEST_AR_LARGE);
+
+    assert_int_equal(ReadExecConfig(), 1);
+
+    for (i = 0; i < TEST_AR_LARGE; i++) {
+        assert_entry_loaded(i);
+    }
+
+    assert_entry_not_loaded(TEST_AR_LARGE);
+}
+
+/* The commands around the number supported by previous agent versions are
+ * loaded like any other one
+ */
+static void test_read_exec_config_past_legacy_limit(void **state) {
+    (void)state;
+
+    write_ar_conf(MAX_AR + 32);
+
+    assert_int_equal(ReadExecConfig(), 1);
+
+    assert_entry_loaded(MAX_AR - 1);
+    assert_entry_loaded(MAX_AR);
+    assert_entry_loaded(MAX_AR + 31);
+    assert_entry_not_loaded(MAX_AR + 32);
+}
+
+/* A shorter configuration replaces the previous one, leaving no entry behind */
+static void test_read_exec_config_reload_shrinks(void **state) {
+    (void)state;
+
+    write_ar_conf(TEST_AR_LARGE);
+    assert_int_equal(ReadExecConfig(), 1);
+    assert_entry_loaded(TEST_AR_LARGE - 1);
+
+    write_ar_conf(10);
+    assert_int_equal(ReadExecConfig(), 1);
+
+    assert_entry_loaded(0);
+    assert_entry_loaded(9);
+    assert_entry_not_loaded(10);
+    assert_entry_not_loaded(TEST_AR_LARGE - 1);
+}
+
+/* Exactly MAX_AR_COMMANDS commands still fit, and nothing is reported */
 static void test_read_exec_config_at_limit(void **state) {
     (void)state;
 
-    write_ar_conf(MAX_AR);
+    write_ar_conf(MAX_AR_COMMANDS);
 
     assert_int_equal(ReadExecConfig(), 1);
 
     assert_entry_loaded(0);
-    assert_entry_loaded(MAX_AR - 1);
-    assert_entry_not_loaded(MAX_AR);
+    assert_entry_loaded(MAX_AR_COMMANDS - 1);
+    assert_entry_not_loaded(MAX_AR_COMMANDS);
 }
 
-/* A line that consumes no slot must not be reported as an exceeding entry */
+/* Beyond MAX_AR_COMMANDS the remaining entries are reported and discarded */
+static void test_read_exec_config_above_limit(void **state) {
+    (void)state;
+
+    write_ar_conf(MAX_AR_COMMANDS + 32);
+
+    expect_max_ar_error();
+
+    assert_int_equal(ReadExecConfig(), 1);
+
+    assert_entry_loaded(0);
+    assert_entry_loaded(MAX_AR_COMMANDS - 1);
+    assert_entry_not_loaded(MAX_AR_COMMANDS);
+    assert_entry_not_loaded(MAX_AR_COMMANDS + 31);
+}
+
+/* A line that consumes no entry must not be taken for an exceeding one */
 static void test_read_exec_config_at_limit_trailing_junk(void **state) {
     (void)state;
     char expected_msg[OS_MAXSTR];
 
-    write_ar_conf(MAX_AR);
+    write_ar_conf(MAX_AR_COMMANDS);
     append_ar_line("\n");
 
     snprintf(expected_msg, sizeof(expected_msg), EXEC_INV_CONF, DEFAULTAR);
@@ -165,32 +243,20 @@ static void test_read_exec_config_at_limit_trailing_junk(void **state) {
 
     assert_int_equal(ReadExecConfig(), 1);
 
-    assert_entry_loaded(MAX_AR - 1);
-    assert_entry_not_loaded(MAX_AR);
+    assert_entry_loaded(MAX_AR_COMMANDS - 1);
+    assert_entry_not_loaded(MAX_AR_COMMANDS);
 }
 
-/* Beyond MAX_AR commands the remaining entries are reported and discarded */
-static void test_read_exec_config_above_limit(void **state) {
-    (void)state;
-
-    write_ar_conf(MAX_AR + 32);
-
-    expect_max_ar_error();
-
-    assert_int_equal(ReadExecConfig(), 1);
-
-    assert_entry_loaded(0);
-    assert_entry_loaded(MAX_AR - 1);
-    assert_entry_not_loaded(MAX_AR);
-    assert_entry_not_loaded(MAX_AR + 31);
-}
-
-/* The table is reloaded on every unresolved command, so the condition is
+/* The table is reloaded on every unresolved command, so the truncation is
  * reported once and not again until the configuration is corrected
  */
 static void test_read_exec_config_reported_once(void **state) {
     (void)state;
     int i;
+
+    write_ar_conf(MAX_AR_COMMANDS + 1);
+    expect_max_ar_error();
+    assert_int_equal(ReadExecConfig(), 1);
 
     /* Still truncated: no further report */
     for (i = 0; i < 3; i++) {
@@ -198,25 +264,71 @@ static void test_read_exec_config_reported_once(void **state) {
     }
 
     /* Corrected configuration: nothing to report, and the condition is re-armed */
-    write_ar_conf(MAX_AR);
+    write_ar_conf(MAX_AR_COMMANDS);
     assert_int_equal(ReadExecConfig(), 1);
 
     /* Truncated again: reported again */
-    write_ar_conf(MAX_AR + 1);
+    write_ar_conf(MAX_AR_COMMANDS + 1);
     expect_max_ar_error();
     assert_int_equal(ReadExecConfig(), 1);
 
-    assert_entry_loaded(MAX_AR - 1);
-    assert_entry_not_loaded(MAX_AR);
+    assert_entry_loaded(MAX_AR_COMMANDS - 1);
+    assert_entry_not_loaded(MAX_AR_COMMANDS);
+}
+
+/* A duplicated name whose first definition holds no command is back-filled
+ * with the command of the second one
+ */
+static void test_read_exec_config_duplicated_name(void **state) {
+    (void)state;
+    int timeout = -1;
+    char *command;
+
+    write_ar_conf(0);
+    append_ar_line("dup-cmd - ../" TEST_AR_SCRIPT " - 7\n");
+    append_ar_line("dup-cmd - " TEST_AR_SCRIPT " - 7\n");
+
+    expect_string(__wrap__merror, formatted_msg,
+                  "Active response command '../" TEST_AR_SCRIPT "' vulnerable to directory traversal attack. Ignoring.");
+
+    assert_int_equal(ReadExecConfig(), 1);
+
+    command = GetCommandbyName("dup-cmd", &timeout);
+
+    assert_non_null(command);
+    assert_string_equal(command, TEST_AR_COMMAND);
+    assert_int_equal(timeout, 7);
+}
+
+/* A malformed line is reported and consumes no entry */
+static void test_read_exec_config_invalid_line(void **state) {
+    (void)state;
+    char expected_msg[OS_MAXSTR];
+
+    write_ar_conf(10);
+    append_ar_line("\n");
+
+    snprintf(expected_msg, sizeof(expected_msg), EXEC_INV_CONF, DEFAULTAR);
+    expect_string(__wrap__merror, formatted_msg, expected_msg);
+
+    assert_int_equal(ReadExecConfig(), 1);
+
+    assert_entry_loaded(9);
+    assert_entry_not_loaded(10);
 }
 
 int main(void) {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test(test_read_exec_config_below_limit),
+        cmocka_unit_test(test_read_exec_config_small),
+        cmocka_unit_test(test_read_exec_config_large),
+        cmocka_unit_test(test_read_exec_config_past_legacy_limit),
+        cmocka_unit_test(test_read_exec_config_reload_shrinks),
         cmocka_unit_test(test_read_exec_config_at_limit),
-        cmocka_unit_test(test_read_exec_config_at_limit_trailing_junk),
         cmocka_unit_test(test_read_exec_config_above_limit),
+        cmocka_unit_test(test_read_exec_config_at_limit_trailing_junk),
         cmocka_unit_test(test_read_exec_config_reported_once),
+        cmocka_unit_test(test_read_exec_config_duplicated_name),
+        cmocka_unit_test(test_read_exec_config_invalid_line),
     };
 
     return cmocka_run_group_tests(tests, group_setup, group_teardown);


### PR DESCRIPTION
## Description

`wazuh-execd` kept the Active Response command table of `etc/shared/ar.conf` in three static arrays sized
for `MAX_AR` (64) entries. Since #38410 the extra entries are discarded in a controlled way instead of
being written past the end of the table, but they are still discarded: a command defined beyond the 64th
position never runs on the agent, even though `ar.conf` is distributed in full to every agent.

@nimra1923 confirmed that fix and asked for the limit itself to be reconsidered: their
deployment needs more than 90 command definitions, combining Windows Active Response scripts that are
still in production with a growing set of custom Linux ones.

The table is now loaded into a dynamically grown array, so it takes only the memory that the file actually
defines, and the limit is raised from 64 to 1024 commands. A limit is kept, rather than removed
altogether, because the agent parses `ar.conf` again on every command it cannot resolve: an arbitrarily
large file would otherwise grow the table and make each Active Response event re-parse the whole file.
1024 is about eleven times what the largest reported deployment needs, so no legitimate configuration
reaches it.

Related to #38358.

## Proposed Changes

- `src/os_execd/exec.c`: replace `exec_names`, `exec_cmd` and `exec_timeout` with a dynamically grown
  array of `{name, cmd, timeout}` entries, each one holding its own allocation. The table grows in blocks
  of 32 entries, is released on every reload, and can be freed through the new `FreeExecConfig()`. The
  limit is now `MAX_AR_COMMANDS`, and the entries beyond it keep being reported once per state change.
- `src/os_execd/execd.h`: declare `FreeExecConfig()`.
- `src/headers/defs.h`: add `MAX_AR_COMMANDS` (1024), the number of commands an agent loads. `MAX_AR`
  stays as the number that previous agent versions support, which is what the manager warning reports.
- `src/error_messages/error_messages.h`: reword `(1319)` for the new limit.
- `src/error_messages/warning_messages.h`: `wazuh-analysisd` still warns about the number of defined
  commands, because agents of previous versions keep the limit of 64. Message `(1307)` is reworded to
  state that those agents will not run the exceeding entries, instead of describing a limit of the
  current agent.

Commands are loaded, resolved and executed exactly as before. Duplicated names, missing command files,
directory traversal checks and malformed lines keep their previous behaviour.

### Results and Evidence

Agent v4.14.9 with an `etc/shared/ar.conf` holding 100 command definitions, each one pointing to its own
script:

```
# wc -l < /var/ossec/etc/shared/ar.conf
100
# head -2 /var/ossec/etc/shared/ar.conf
test-ar-001 - test-ar-001.sh - 0
test-ar-002 - test-ar-002.sh - 0
# tail -1 /var/ossec/etc/shared/ar.conf
test-ar-100 - test-ar-100.sh - 0
```

**Before the change** (branch base, which already includes #38410). Triggering the commands 1, 64, 65 and
100 loads the table, discards everything past the 64th entry and rejects the last two commands:

```
2026/08/21 11:46:27 wazuh-execd: INFO: Started (pid: 20393).
2026/08/21 11:46:29 wazuh-execd: ERROR: (1319): Reached the maximum of 64 active response commands. Ignoring the remaining entries of 'etc/shared/ar.conf'.
2026/08/21 11:46:30 wazuh-execd: ERROR: (1311): Invalid command name 'test-ar-065' provided.
2026/08/21 11:46:30 wazuh-execd: ERROR: (1311): Invalid command name 'test-ar-100' provided.
```

Only the commands within the limit run:

```
2026/08/21 11:46:29 test-ar-001.sh executed
2026/08/21 11:46:29 test-ar-064.sh executed
```

**After the change** — same agent, same 100-entry `ar.conf`. The daemon starts, loads the whole file and
reports nothing:

```
2026/08/21 12:20:32 wazuh-execd: INFO: Started (pid: 57745).
```

Triggering the 100 commands runs the 100 of them, each one its own script:

```
# 100-entry ar.conf: executed 100 of 100, distinct scripts 100
2026/08/21 12:20:34 test-ar-001.sh executed
2026/08/21 12:20:36 test-ar-064.sh executed
2026/08/21 12:20:36 test-ar-065.sh executed
2026/08/21 12:20:37 test-ar-100.sh executed
```

`ossec.log` holds no error or warning, and the daemon stays up.

**Past the new limit** — same agent with an `ar.conf` of 1100 definitions. The first 1024 are loaded, the
condition is reported once even though the table is reloaded on each unresolved command, and the daemon
survives:

```
2026/08/21 12:17:43 wazuh-execd: INFO: Started (pid: 56385).
2026/08/21 12:17:45 wazuh-execd: ERROR: (1319): Reached the limit of 1024 active response commands. Ignoring the remaining entries of 'etc/shared/ar.conf'.
2026/08/21 12:17:46 wazuh-execd: ERROR: (1311): Invalid command name 'cap-ar-1025' provided.
2026/08/21 12:17:46 wazuh-execd: ERROR: (1311): Invalid command name 'cap-ar-1100' provided.
```

The commands 1 and 1024 run, and 1025 and 1100 are reported as unknown, which is the same behaviour as
any other command name that does not exist.

Memory held by the same daemon after loading the table, so that the cost of the higher limit is visible:

```
100 entries:  RSS 4476 kB
1024 entries: RSS 4504 kB
```

Full unit test suite for the agent target, built with AddressSanitizer and LeakSanitizer:

```
100% tests passed, 0 tests failed out of 86
```

The reworded manager warning, rendered from its call site in `AR_ReadConfig()`:

```
(1307): Defined 91 active response commands, more than the 64 supported by previous agent versions. Those agents may fail to run active responses until the exceeding entries of 'etc/shared/ar.conf' are removed.
```

### Artifacts Affected

- `wazuh-execd` (all agent packages, and the manager package since the same daemon runs there).
- `wazuh-analysisd` (manager packages), for the wording of the warning.

### Configuration Changes

None. No setting is introduced and no existing one changes its meaning. The number of Active Response
command definitions an agent loads goes from 64 to 1024, which needs no configuration.

### Documentation Updates

None required.

### Tests Introduced

`src/unit_tests/os_execd/test_read_exec_config.c` is extended, and now covers `ReadExecConfig()` with:

- A configuration of 10 commands, loaded in full.
- A configuration of 500 commands, loaded in full and checked entry by entry.
- A 96-command configuration, where the entries at the positions 64, 65 and 96 — the last one supported
  by previous agent versions, the first one they discarded, and the last one of the file — are loaded
  like any other one.
- A reload with a shorter configuration, which leaves no entry of the previous one behind.
- A configuration of exactly `MAX_AR_COMMANDS` commands, which fits with nothing reported.
- A configuration past `MAX_AR_COMMANDS`, where the exceeding entries are reported and discarded.
- A line that consumes no entry after a full table, which must not be taken for an exceeding entry.
- Several reloads of a truncated configuration, reported once and re-armed when the file is corrected.
- A duplicated name whose first definition holds no command, back-filled with the command of the second
  one.
- A malformed line, reported and consuming no entry.

Every entry carries a distinct timeout, so the values are verified to survive the growth of the table,
and the teardown releases it through `FreeExecConfig()` so that the suite stays clean under
LeakSanitizer.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
