### PR TITLE
Avoid holding exec_sock_mutex while connecting to the exec queue

### DIFF
--- a/src/analysisd/alerts/exec.c
+++ b/src/analysisd/alerts/exec.c
@@ -420,15 +420,28 @@ void send_exec_msg(int *socket, const char *queue_path, const char *exec_msg) {
     w_mutex_lock(&exec_sock_mutex);
 
     if (*socket < 0) {
-        if ((*socket = connect_exec_queue(queue_path)) < 0) {
+        /* Connect with the mutex released: connecting may block, and a thread waiting
+         * inside connect_exec_queue must not stall the rest of the rule matching threads */
+        w_mutex_unlock(&exec_sock_mutex);
+        int new_socket = connect_exec_queue(queue_path);
+        int conn_errno = errno;
+        w_mutex_lock(&exec_sock_mutex);
+
+        if (*socket >= 0) {
+            /* Another thread reconnected while the mutex was released: keep its socket */
+            if (new_socket >= 0) {
+                OS_CloseSocket(new_socket);
+            }
+        } else if (new_socket < 0) {
             if (conn_error_sent == 0){
-                merror(QUEUE_ERROR, queue_path, strerror(errno));
+                merror(QUEUE_ERROR, queue_path, strerror(conn_errno));
                 conn_error_sent = 1;
             }
 
             w_mutex_unlock(&exec_sock_mutex);
             return;
         } else {
+            *socket = new_socket;
             conn_error_sent = 0;
         }
     }

--- a/src/unit_tests/analysisd/test_exec.c
+++ b/src/unit_tests/analysisd/test_exec.c
@@ -831,6 +831,8 @@ void test_send_exec_msg_reconnect_socket(void **state){
     expect_OS_SendUnix_call(new_socket, exec_msg, 0, 0);
 
     send_exec_msg(&socket, queue_path, exec_msg);
+
+    assert_int_equal(socket, new_socket);
 }
 
 void test_send_exec_msg_reconnect_socket_fail(void **state){
@@ -843,6 +845,8 @@ void test_send_exec_msg_reconnect_socket_fail(void **state){
     expect_string(__wrap__merror, formatted_msg, "(1210): Queue '/path/to/queue' not accessible: 'Operation not permitted'");
 
     send_exec_msg(&socket, queue_path, exec_msg);
+
+    assert_int_equal(socket, -1);
 }
 
 void test_send_exec_msg_OS_SOCKBUSY(void **state){


### PR DESCRIPTION
## Description

Closes #38138

Coverity (CID 1676619, *Waiting while holding a lock*) reported that `send_exec_msg()` in `src/analysisd/alerts/exec.c` calls `connect_exec_queue()` while holding `exec_sock_mutex`. `connect_exec_queue()` reaches `StartMQ()`, whose retry loop contains a `sleep()`, so Coverity flags the lock as held across a wait that could stall every rule matching thread contending for the mutex.

### Root cause analysis

The mutex was introduced by #37764 to serialize the check/send/close/reconnect cycle on the socket shared by the rule matching threads. The reconnection call was left inside the critical section, so any wait inside the connection path (the `sleep()` in `StartMQ()`'s retry loop, or the `connect()` system call itself) would be served while every other thread blocks on `exec_sock_mutex`. In the current code the wait is bounded (`connect_exec_queue()` uses a single attempt, which never reaches the `sleep()`, and `connect()` on a `SOCK_DGRAM` UNIX socket does not block), so the defect cannot hang the daemon today, but the lock is still held across the whole connection path and any future change to the retry policy would turn it into a real stall.

## Proposed Changes

- Release `exec_sock_mutex` around `connect_exec_queue()` and re-acquire it before touching the shared descriptor.
- Re-check the descriptor after re-acquiring the lock: if another thread reconnected in the meantime, the redundant socket is closed and the already installed one is used; otherwise the new descriptor is installed (or the connection error is reported once, as before).
- `errno` is captured right after the connection attempt so the reported message is not affected by the re-lock.

The send itself stays inside the critical section: the descriptor can be closed and replaced by a concurrent thread, and the send timeout added by #37764 already bounds that wait.

### Results and Evidence

`test_exec` unit tests built and run on Linux (Ubuntu 22.04, `make TARGET=server DEBUG=1 TEST=1`):

```
Test project /wazuh/src/unit_tests/build
    Start   4: test_exec
1/1 Test   #4: test_exec ........................   Passed    0.58 sec
```

```
[ RUN      ] test_send_exec_msg
[       OK ] test_send_exec_msg
[ RUN      ] test_send_exec_msg_reconnect_socket
[       OK ] test_send_exec_msg_reconnect_socket
[ RUN      ] test_send_exec_msg_reconnect_socket_fail
[       OK ] test_send_exec_msg_reconnect_socket_fail
[ RUN      ] test_send_exec_msg_OS_SOCKBUSY
[       OK ] test_send_exec_msg_OS_SOCKBUSY
[ RUN      ] test_send_exec_msg_send_timeout_drops_message
[       OK ] test_send_exec_msg_send_timeout_drops_message
[ RUN      ] test_connect_exec_queue
[       OK ] test_connect_exec_queue
[ RUN      ] test_connect_exec_queue_fail
[       OK ] test_connect_exec_queue_fail
[ RUN      ] test_connect_exec_queue_set_timeout_fail
[       OK ] test_connect_exec_queue_set_timeout_fail
[==========] 24 test(s) run.
[  PASSED  ] 24 test(s).
```

A new Coverity run over this branch is pending to confirm CID 1676619 is no longer reported.

### Artifacts Affected

- `wazuh-analysisd` (manager)

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

Extended the existing `send_exec_msg` unit tests to assert the state of the shared descriptor after the restructured reconnection path: the new socket is installed on success and the descriptor stays invalid on failure.

## Review Checklist
- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
