### PR TITLE
Handle Windows event field names as literal JSON keys

### DIFF
--- a/src/engine/source/hlp/src/parsers/xml.cpp
+++ b/src/engine/source/hlp/src/parsers/xml.cpp
@@ -28,6 +28,15 @@ bool xmlWinModule(pugi::xml_node& node, json::Json& docJson, std::string path)
         }
         else
         {
+            // Make sure the parent node is an object before adding the member: a JSON pointer token
+            // is only guaranteed to be read as a member name when the node it is resolved against
+            // already is an object. Otherwise an all-decimal Name is taken as an array index and the
+            // pointer reserves index + 1 elements.
+            if (!docJson.isObject(path))
+            {
+                docJson.setObject(path);
+            }
+
             path.append(json::Json::formatJsonPath(name.as_string(), true));
             docJson.setString(node.text().as_string(), path);
         }

--- a/src/engine/source/hlp/src/parsers/xml.cpp
+++ b/src/engine/source/hlp/src/parsers/xml.cpp
@@ -28,7 +28,7 @@ bool xmlWinModule(pugi::xml_node& node, json::Json& docJson, std::string path)
         }
         else
         {
-            path.append("/").append(name.as_string());
+            path.append(json::Json::formatJsonPath(name.as_string(), true));
             docJson.setString(node.text().as_string(), path);
         }
 

--- a/src/engine/source/hlp/test/src/unit/xml_test.cpp
+++ b/src/engine/source/hlp/test/src/unit/xml_test.cpp
@@ -262,4 +262,25 @@ Name='IpAddress'>::1</Data><Data Name='IpPort'>0</Data></EventData>)",
 )")),
                1573,
                getXMLParser,
-               {NAME, TARGET, {""}})));
+               {NAME, TARGET, {""}}),
+        // An all-decimal Data name must stay a member name even when there is no enclosing object
+        ParseT(SUCCESS,
+               R"(<Event><Data Name="3">v</Data></Event>)",
+               j(fmt::format(R"({{"{}":{}}})", TARGET.substr(1), R"({"3":"v"})")),
+               38,
+               getXMLParser,
+               {NAME, TARGET, {""}, {"windows"}}),
+        // ... and when the enclosing node was turned into an array by a previous unnamed Data
+        ParseT(SUCCESS,
+               R"(<EventData><Data>a</Data><Data Name="3">v</Data></EventData>)",
+               j(fmt::format(R"({{"{}":{}}})", TARGET.substr(1), R"({"EventData":{"3":"v"}})")),
+               60,
+               getXMLParser,
+               {NAME, TARGET, {""}, {"windows"}}),
+        // Same as a name that cannot be read as an index: the named Data replaces the array
+        ParseT(SUCCESS,
+               R"(<EventData><Data>a</Data><Data Name="b">v</Data></EventData>)",
+               j(fmt::format(R"({{"{}":{}}})", TARGET.substr(1), R"({"EventData":{"b":"v"}})")),
+               60,
+               getXMLParser,
+               {NAME, TARGET, {""}, {"windows"}})));

--- a/src/engine/source/hlp/test/src/unit/xml_test.cpp
+++ b/src/engine/source/hlp/test/src/unit/xml_test.cpp
@@ -57,6 +57,12 @@ xmlns="http://manifests.microsoft.com/win/2004/08/windows/eventlog" /></UserData
                67,
                getXMLParser,
                {NAME, TARGET, {""}, {}}),
+        ParseT(SUCCESS,
+               R"(<EventData><Data Name="x/3~label">value</Data></EventData>)",
+               j(fmt::format(R"({{"{}":{}}})", TARGET.substr(1), R"({"EventData":{"x/3~label":"value"}})")),
+               58,
+               getXMLParser,
+               {NAME, TARGET, {""}, {"windows"}}),
         ParseT(
             SUCCESS,
             R"(<EventData><Data


### PR DESCRIPTION
## Description

The `windows` module of the Engine XML parser builds its output document with RFC 6901 JSON pointers, and it
used the `Name` attribute of a `<Data>` element as a raw fragment of that pointer. The value was therefore not
treated as one field name:

- a `/` in the name split it into several pointer tokens, so `Name="a/b"` produced the nested object
  `{"a":{"b":…}}` instead of the key `"a/b"`;
- a `~` made the pointer invalid, so `Json::setString()` threw, the exception left `hlp::parser::run()` and
  the event was dropped with an error log;
- a name made only of decimal digits was read as an **array index**, so `Name="3"` produced
  `[null,null,null,"v"]` instead of `{"3":"v"}`. For a large value the pointer reserves `index + 1` elements
  before filling them, and `Name="4294967294"` asks for 4,294,967,295 elements (64 GiB). RapidJSON's
  `Reserve()` does not check the failed `Realloc()`: it records the requested capacity with a null element
  pointer, and the following `PushBack()` writes through it, so the Engine process ends with `SIGSEGV`. With a
  smaller but still large value the reservation succeeds and the fill loop consumes CPU and RSS instead.

The Engine only handles `SIGINT`/`SIGTERM`/`SIGPIPE`, and a `catch` block cannot recover from `SIGSEGV` or an
out-of-memory kill, so a single event carrying such a field name stops the whole decoding process.

This pull request makes `Data@Name` one literal JSON key in every case. The first commit was contributed by
@n01e0.

Related issue: #\<issue\>

## Proposed Changes

**1. Escape the name (`55feee4fa0`)** — encode `Data@Name` as exactly one RFC 6901 reference token with
`json::Json::formatJsonPath(name, true)`, which escapes `/` as `~1` and `~` as `~0` and keeps dots literal:

```diff
-            path.append("/").append(name.as_string());
+            path.append(json::Json::formatJsonPath(name.as_string(), true));
             docJson.setString(node.text().as_string(), path);
```

**2. Add it as an object member (`87b6a541b0`)** — escaping is not enough on its own, because a token made
only of decimal digits is still read as an index whenever the node it is resolved against is not already an
object (`GenericPointer::Create()`, `pointer.h:463-470`). Creating that parent as an object first removes the
ambiguity:

```diff
+            // Make sure the parent node is an object before adding the member: a JSON pointer token
+            // is only guaranteed to be read as a member name when the node it is resolved against
+            // already is an object. Otherwise an all-decimal Name is taken as an array index and the
+            // pointer reserves index + 1 elements.
+            if (!docJson.isObject(path))
+            {
+                docJson.setObject(path);
+            }
+
             path.append(json::Json::formatJsonPath(name.as_string(), true));
             docJson.setString(node.text().as_string(), path);
```

Three well-formed documents still reached the index interpretation after the first commit alone, because in
all of them the node the member is added to is not an object:

| Document | State of the parent node |
| --- | --- |
| `<Data Name="4294967294">v</Data>` | the document root is still `null` |
| `<Event><Data Name="4294967294">v</Data></Event>` | `xmlWinModule()` takes `path` by value while `xmlModule` declares a reference, so its `path += "/Event"` is discarded and `<Event>` children resolve against the root |
| `<EventData><Data>a</Data><Data Name="4294967294">v</Data></EventData>` | a preceding unnamed `<Data>` turned `EventData` into an array |

Neither commit covers the other: the escaping is what makes the name one token, the object insertion is what
keeps that token from being read as an index. An index limit instead of the escaping would not have been
enough either, as it would leave the `/` and `~` handling broken.

### Results and Evidence

| Item | Value |
| --- | --- |
| Version | `{"version": "5.0.0", "stage": "rc1"}` |
| Dependencies | `DEPS_VERSION = 99-37702` (bundled `src/external`, RapidJSON 1.1.0, pugixml) |
| Compiler | gcc 13.3.0, C++17, ccache |
| CMake / Valgrind | cmake 3.28.3 / valgrind 3.22.0 |
| Host | Linux 6.6.87.2-microsoft-standard-WSL2 x86_64 |

```bash
cmake -S src -B <build> -DTARGET=server -DCMAKE_BUILD_TYPE=Debug -DENGINE_BUILD_TEST=ON \
      [-DENGINE_ENABLE_ASAN=ON | -DENGINE_ENABLE_UBSAN=ON | -DENGINE_ENABLE_TSAN=ON] \
      -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
cmake --build <build> --target hlp_utest -j8
```

| Build | Target | Result | Notes |
| --- | --- | --- | --- |
| Debug (plain) | `hlp_utest` | **3072 / 3072 passed** | 0 compiler warnings |
| Debug (plain) | `ctest` (hlp) | **3072 / 3072 passed** | 44.45 s, `-j8` |
| Debug (plain) | `builder_utest` | **3120 / 3120 passed** | covers `parse_xml` through the builder |
| ASAN | `hlp_utest` | **3072 / 3072 passed**, exit 0 | `detect_leaks=1`, no ASAN/LSAN report |
| ASAN | `hlp_utest --gtest_filter=Xml*` | **68 / 68 passed**, exit 0 | `max_allocation_size_mb=2048:allocator_may_return_null=0` |
| UBSAN | `hlp_utest` | **3072 / 3072 passed**, exit 0 | **0** `runtime error` lines |
| TSAN | `hlp_utest` | **3072 / 3072 passed**, exit 0 | **0** `WARNING: ThreadSanitizer` |
| Valgrind memcheck | `hlp_utest --gtest_filter=*Xml*` | **68 / 68 passed** | 0 leaks, 3 std descriptors at exit |

Valgrind reports `91010 errors from 4 contexts`, all inside GoogleTest's own
`PrintBytesInObjectTo` / `RawBytesPrinter::PrintValue<hlp::Params>`, which hex-dumps the uninitialised padding
of `hlp::Params` while generating parameterized test names. Re-running with a filter matching no test at all
reports the same four contexts, so they come from test-name generation and not from the parser.

#### Decoded output, before and after

```text
Name="a/b"                        {"a":{"b":"v"}}                   ->  {"a/b":"v"}
Name="x/3~label"                  error: Invalid pointer path       ->  {"x/3~label":"value"}
Name="3"                          [null,null,null,"v"]              ->  {"3":"v"}
Name="3" after an unnamed <Data>   {"EventData":["a",null,null,"v"]}  ->  {"EventData":{"3":"v"}}
```

#### Large field names

Each of the three documents listed above was added as a temporary parameterized case and run in its own
process with `ulimit -v 2097152`. With the second commit reverted, all three end the process:

```text
<Data Name="4294967294">v</Data>                                        -> Segmentation fault (rc=139)
<Event><Data Name="4294967294">v</Data></Event>                         -> Segmentation fault (rc=139)
<EventData><Data>a</Data><Data Name="4294967294">v</Data></EventData>   -> Segmentation fault (rc=139)
```

Under ASAN with `max_allocation_size_mb=2048:allocator_may_return_null=0` all three show the same
reservation:

```text
==268578==ERROR: AddressSanitizer: requested allocation size 0x1000000008 (0x1000001008 after adjustments
for alignment, red zones etc.) exceeds maximum supported size of 0x80000000 (thread T0)
    #4  rapidjson::MemoryPoolAllocator<...>::Realloc(void*, ulong, ulong)  rapidjson/allocators.h:339
    #5  rapidjson::GenericValue<...>::Reserve(unsigned int, ...)           rapidjson/document.h:1697
    #6  rapidjson::GenericPointer<...>::Create(...)                        rapidjson/pointer.h:474
    #9  json::Json::setString(string_view, string_view)                    base/src/json.cpp:1078
    #10 xmlWinModule                                                       hlp/src/parsers/xml.cpp:32
```

`0x1000000008` is 68,719,476,744 bytes for a single field name. Letting the allocator return `NULL` instead,
as an unsanitized build does, gives the null write:

```text
==268659==WARNING: AddressSanitizer failed to allocate 0x1000000008 bytes
AddressSanitizer:DEADLYSIGNAL
==268659==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000
==268659==The signal is caused by a WRITE memory access.
    #0 rapidjson::GenericValue<...>::RawAssign(...)   rapidjson/document.h:2460
    #1 rapidjson::GenericValue<...>::PushBack(...)    rapidjson/document.h:1717
    #2 rapidjson::GenericPointer<...>::Create(...)    rapidjson/pointer.h:476
    #6 xmlWinModule                                   hlp/src/parsers/xml.cpp:32
```

With both commits applied the three documents decode to literal keys and no oversized allocation is
attempted, so the whole XML suite passes under the same 2 GiB allocation cap:

```text
[==========] 83 tests from 2 test suites ran.
[  PASSED  ] 83 tests.
```

(83 = the 68 XML cases of this branch plus the 15 instantiations of the three temporary documents, which were
removed again.) Reverting either commit and rebuilding restores its own failures, so both are necessary.

#### Scope and formatting

`xmlToJson()` also concatenates element and attribute names into pointers on the generic (non-`windows`)
path. Those cannot carry pointer metacharacters, because pugixml rejects the document — checked directly
against the bundled version:

```text
<a/4294967294>v</a>       -> Error parsing start element tag
<a~b>v</a~b>              -> Error parsing start element tag
<n a/4294967294="v"/>     -> Error parsing element attribute
<n a~b="v"/>              -> Error parsing element attribute
```

`getSemParser()` already reports those as `Invalid XML`. XML names cannot be all-decimal either, so
`Data@Name` is the only name that needed both changes.

```text
clang-format --dry-run --Werror src/engine/source/hlp/src/parsers/xml.cpp \
                                src/engine/source/hlp/test/src/unit/xml_test.cpp   -> clean (exit 0)
git diff --check                                                                   -> clean
```

### Artifacts Affected

- `wazuh-manager` — the `wazuh-engine` binary, in the XML decoding path (`parse_xml(..., windows)`).

No other package, default configuration file, ruleset asset or agent artifact is affected.

### Configuration Changes

None. No configuration parameter or default value is added or changed.

Two behaviour changes are worth noting for reviewers, both on `Data@Name` values that genuine Windows Event
and Sysmon records do not produce — their field names are NCNames, so they contain neither `/` nor `~` and are
never all-decimal:

1. `Name="a/b"` produced the nested object `{"a":{"b":…}}` and now produces the flat key `"a/b"`. Dots are
   unaffected: they were already literal.
2. An all-decimal `Name="3"` produced an array, and now produces the member `{"3":"v"}`. Where the enclosing
   node had already been turned into an array by a preceding unnamed `<Data>`, that array is replaced by an
   object, which is what already happened for any name that cannot be read as an index.

Any ruleset relying on the previous splitting or array behaviour would need review.

### Documentation Updates

None required. The `parse_xml` helper description
([parse_xml.yml](src/engine/test/helper_tests/helpers_description/transformation/parse_xml.yml)) documents
the `windows` module without specifying how `Data@Name` is mapped, and no public interface changes.

### Tests Introduced

Four parameterized `HlpParseTest` cases in
[xml_test.cpp](src/engine/source/hlp/test/src/unit/xml_test.cpp), none of them reaching the large-index path
inside the test process:

| Input | Expected | Covers |
| --- | --- | --- |
| `<EventData><Data Name="x/3~label">value</Data></EventData>` | `{"EventData":{"x/3~label":"value"}}` | both escape characters in one name |
| `<Event><Data Name="3">v</Data></Event>` | `{"3":"v"}` | an all-decimal name with no enclosing object |
| `<EventData><Data>a</Data><Data Name="3">v</Data></EventData>` | `{"EventData":{"3":"v"}}` | an all-decimal name whose parent is an array |
| `<EventData><Data>a</Data><Data Name="b">v</Data></EventData>` | `{"EventData":{"b":"v"}}` | the unchanged behaviour for a name that cannot be read as an index |

The first case fails if the first commit is reverted, the second and third if the second one is. All use a
small index deliberately, so a regression fails an assertion instead of ending the test process. The fourth
passes either way and pins the behaviour the new guard reuses.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
