### PR TITLE
Fix world-writable bundled Python files introduced by the DEB permission restoration script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 | [#35043](https://github.com/wazuh/wazuh/issues/35043) | Fixed token validation race condition after revoke. |
 | [#35638](https://github.com/wazuh/wazuh/issues/35638) | Handled the stop signal during vulnerability feed download. |
 | [#37521](https://github.com/wazuh/wazuh/issues/37521) | Fixed `GET /cluster/{node_id}/daemons/stats` always returning error 1014 for `wazuh-manager-analysisd` due to a protocol mismatch between `WazuhSocketJSON` and the engine's HTTP API socket. |
+| [#38511](https://github.com/wazuh/wazuh/issues/38511) | Fixed world-writable permissions on bundled Python files after DEB installation, caused by the permission restoration script following symlinks. |
 
 ### Agent
 

--- a/packages/debs/utils/gen_permissions.sh
+++ b/packages/debs/utils/gen_permissions.sh
@@ -15,7 +15,10 @@
 
 set -euo pipefail
 
-find $1 -depth -printf '%m:%u:%g:%p\0' | awk -v RS='\0' -F: '
+# Symlinks are excluded: find reports them as mode 777 and chmod/chown on a
+# symlink path dereference it, so restoring them would reset the target's
+# permissions to 777 whenever the symlink entry follows the target's own.
+find $1 -depth ! -type l -printf '%m:%u:%g:%p\0' | awk -v RS='\0' -F: '
 BEGIN {
     print "#!/bin/sh";
     q = "\047";


### PR DESCRIPTION
## Description

Closes #38511

On a fresh 5.0.0 manager DEB install, several bundled Python files under `/var/wazuh-manager/framework/python/` end up world-writable (`0777`), including `bin/python3.12` and `lib/libpython3.12.so.1.0`, which root-run daemons load and execute. The package payload itself is clean (`dh_fixperms` strips the write bits): the bad modes are introduced at install time by `restore-permissions.sh`, executed from the postinst.

That script is generated at build time by `packages/debs/utils/gen_permissions.sh`, which walks the build root with `find -depth -printf '%m:...'` without excluding symlinks. On Linux, `find` reports mode `777` for every symlink, and `chmod`/`chown` on a symlink path dereference it, so each symlink entry rewrites its target. Whenever the symlink's line lands after the target's own line in the `find -depth` output, the target is left at `0777`. The five files reported in the issue are exactly the targets whose symlink entry comes last (`python3 -> python3.12`, `pydoc3 -> pydoc3.12`, `2to3 -> 2to3-3.12`, `libpython3.12.so -> libpython3.12.so.1.0`, `python3-embed.pc -> python-3.12-embed.pc`); the pairs emitted in the opposite order (`idle3`, `python3-config`, `python3.pc`, the man page) stay clean, which is why the affected set can vary between builds.

The same defect exists in 4.x DEB packages: #28251 reports the same symptom on 4.10.1 (`python3.10`, `.pc` files) from a Nessus CIS scan.

## Proposed Changes

- Exclude symlinks from the `find` walk in `gen_permissions.sh` (`! -type l`). Restoring a symlink's mode is meaningless on Linux, and dropping the entries removes both the `chmod 777` dereference and the `chown` dereference. Symlink ownership is already set correctly by `dpkg` when unpacking the payload.
- Added the changelog entry.

The script is shared by the manager and agent DEB builds. The current agent payload contains no symlinks (its generated `restore-permissions.sh` has zero `chmod 777` lines), so only the manager package is affected today; the fix protects both.

Since the regenerated `restore-permissions.sh` runs on every install and upgrade and now applies the correct modes (`750`/`640`) to the previously affected files, upgrading heals installations that are already exposed.

### Results and Evidence

All evidence was produced against the real nightly package `wazuh-manager_5.0.0-latest_amd64.deb` (built 2026-08-21 03:00 UTC, 5.0.0 @ `139747b0bf`, same revision as the issue) in an `ubuntu:24.04` container.

**1. The payload ships clean; the shipped restore script introduces the bug.** Extracting `data.tar.xz` with modes preserved and running the embedded `restore-permissions.sh` (what postinst does) reproduces the report exactly:

```
--- world-writable regular files BEFORE running shipped restore-permissions.sh:
(empty)
--- running shipped restore-permissions.sh (as postinst does)
--- world-writable regular files AFTER (bug reproduction):
777 /var/wazuh-manager/framework/python/bin/2to3-3.12
777 /var/wazuh-manager/framework/python/bin/pydoc3.12
777 /var/wazuh-manager/framework/python/bin/python3.12
777 /var/wazuh-manager/framework/python/lib/libpython3.12.so.1.0
777 /var/wazuh-manager/framework/python/lib/pkgconfig/python-3.12-embed.pc
```

**2. The patched generator removes exactly the symlink entries.** Diff between the scripts generated by the current and the patched `gen_permissions.sh` over the same extracted tree (18 lines removed, all symlinks, nothing else changes):

```
< chown -- 'root:root' '/var/wazuh-manager/framework/python/share/man/man1/python3.1'  > /dev/null 2>&1 || :
< chmod 777 '/var/wazuh-manager/framework/python/share/man/man1/python3.1'  > /dev/null 2>&1 || :
< chown -- 'root:root' '/var/wazuh-manager/framework/python/bin/2to3'  > /dev/null 2>&1 || :
< chmod 777 '/var/wazuh-manager/framework/python/bin/2to3'  > /dev/null 2>&1 || :
< chown -- 'root:root' '/var/wazuh-manager/framework/python/bin/python3-config'  > /dev/null 2>&1 || :
< chmod 777 '/var/wazuh-manager/framework/python/bin/python3-config'  > /dev/null 2>&1 || :
< chown -- 'root:root' '/var/wazuh-manager/framework/python/bin/python3'  > /dev/null 2>&1 || :
< chmod 777 '/var/wazuh-manager/framework/python/bin/python3'  > /dev/null 2>&1 || :
< chown -- 'root:root' '/var/wazuh-manager/framework/python/bin/pydoc3'  > /dev/null 2>&1 || :
< chmod 777 '/var/wazuh-manager/framework/python/bin/pydoc3'  > /dev/null 2>&1 || :
< chown -- 'root:root' '/var/wazuh-manager/framework/python/bin/idle3'  > /dev/null 2>&1 || :
< chmod 777 '/var/wazuh-manager/framework/python/bin/idle3'  > /dev/null 2>&1 || :
< chown -- 'root:root' '/var/wazuh-manager/framework/python/lib/pkgconfig/python3.pc'  > /dev/null 2>&1 || :
< chmod 777 '/var/wazuh-manager/framework/python/lib/pkgconfig/python3.pc'  > /dev/null 2>&1 || :
< chown -- 'root:root' '/var/wazuh-manager/framework/python/lib/pkgconfig/python3-embed.pc'  > /dev/null 2>&1 || :
< chmod 777 '/var/wazuh-manager/framework/python/lib/pkgconfig/python3-embed.pc'  > /dev/null 2>&1 || :
< chown -- 'root:root' '/var/wazuh-manager/framework/python/lib/libpython3.12.so'  > /dev/null 2>&1 || :
< chmod 777 '/var/wazuh-manager/framework/python/lib/libpython3.12.so'  > /dev/null 2>&1 || :
```

**3. After running the regenerated script, the hardening check passes:**

```
--- chmod 777 lines in patched output: 0
--- running patched restore script
--- world-writable files of any type AFTER patched restore (expect empty):
(empty)
```

The final modes in this simulation reflect the extracted payload (the generator ran over it); in a real build the generator runs over the build root, where `src/Makefile` `install_framework` already applies `chmod -R o=-`, so the shipped script keeps restoring `750`/`640` for these files, as the current nightly's own entries show:

```
chmod 750 '/var/wazuh-manager/framework/python/bin/python3.12'
chmod 750 '/var/wazuh-manager/framework/python/lib/libpython3.12.so.1.0'
chmod 640 '/var/wazuh-manager/framework/python/lib/pkgconfig/python-3.12-embed.pc'
```

### Artifacts Affected

- `wazuh-manager` DEB packages (amd64/arm64): regenerated `restore-permissions.sh`.
- `wazuh-agent` DEB packages (amd64/arm64): same script, no observable change with the current payload (no symlinks in the tree).
- RPM packages are not affected (they do not use this mechanism).

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None. Validation was performed manually against the nightly package as described above. The regression is already covered by the QA host-hardening scenario `wazuh_tree_no_world_writable` (wazuh-qa-automation#8400).

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
