### PR TITLE
Add Azure Artifact Signing dlib support to the MSI signer (4.14.8)

### DIFF
--- a/packages/windows/generate_wazuh_msi.ps1
+++ b/packages/windows/generate_wazuh_msi.ps1
@@ -92,13 +92,15 @@ function BuildWazuhMsi(){
             "..\syscheckd\build\bin\libfimdb.dll"
         )
 
-        # Expand each pattern ourselves so a zero-match glob is a deliberate skip,
-        # not an ambiguous signtool exit code.
         foreach ($pattern in $filesToSign) {
             $matchedFiles = @(Get-ChildItem -Path $pattern -ErrorAction SilentlyContinue)
             if ($matchedFiles.Count -eq 0) {
-                Write-Host "No files matched $pattern, skipping."
-                continue
+                if ($pattern -match '[*?]') {
+                    Write-Host "No files matched $pattern, skipping."
+                    continue
+                } else {
+                    throw "SignTool Error: expected file not found: $pattern"
+                }
             }
             foreach ($file in $matchedFiles) {
                 Write-Host "Signing $($file.FullName)..."

--- a/packages/windows/generate_wazuh_msi.ps1
+++ b/packages/windows/generate_wazuh_msi.ps1
@@ -8,6 +8,8 @@ param (
     [string]$SIGN_TOOLS_PATH = "",
     [string]$CERTIFICATE_PATH = "",
     [string]$CERTIFICATE_PASSWORD = "",
+    [string]$DLIB_PATH = "",
+    [string]$DLIB_METADATA = "",
     [switch]$help
     )
 
@@ -26,6 +28,10 @@ if(($help.isPresent)) {
         4. SIGN_TOOLS_PATH: sign tools path.
         5. CERTIFICATE_PATH: Path to the .pfx certificate file.
         6. CERTIFICATE_PASSWORD: Password for the .pfx certificate file.
+        7. DLIB_PATH: Full path to the x64 Azure.CodeSigning.Dlib.dll from the Artifact Signing Client Tools
+           (e.g. C:\Program Files\Artifact Signing Client Tools\bin\x64\Azure.CodeSigning.Dlib.dll).
+           Overrides CERTIFICATE_PATH/`/a` when set together with DLIB_METADATA.
+        8. DLIB_METADATA: Path to the dlib metadata.json (Endpoint/CodeSigningAccountName/CertificateProfileName).
 
     USAGE:
 
@@ -56,9 +62,15 @@ function BuildWazuhMsi(){
     }
 
     if($SIGN -eq "yes"){
-        # Determine signing command options
         $signOptions = @()
-        if ($CERTIFICATE_PATH -ne "" -and $CERTIFICATE_PASSWORD -ne "") {
+        $tsaUrl = "http://timestamp.digicert.com"
+        if ($DLIB_PATH -ne "" -and $DLIB_METADATA -ne "") {
+            $signOptions += "/dlib"
+            $signOptions += "`"$DLIB_PATH`""
+            $signOptions += "/dmdf"
+            $signOptions += "`"$DLIB_METADATA`""
+            $tsaUrl = "http://timestamp.acs.microsoft.com"
+        } elseif ($CERTIFICATE_PATH -ne "" -and $CERTIFICATE_PASSWORD -ne "") {
             $signOptions += "/f"
             $signOptions += "`"$CERTIFICATE_PATH`""
             $signOptions += "/p"
@@ -80,21 +92,47 @@ function BuildWazuhMsi(){
             "..\syscheckd\build\bin\libfimdb.dll"
         )
 
-        # Sign the files
-        foreach ($file in $filesToSign) {
-            Write-Host "Signing $file..."
-            & $SIGNTOOL_EXE sign $signOptions /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 $file
+        # Expand each pattern ourselves so a zero-match glob is a deliberate skip,
+        # not an ambiguous signtool exit code.
+        foreach ($pattern in $filesToSign) {
+            $matchedFiles = @(Get-ChildItem -Path $pattern -ErrorAction SilentlyContinue)
+            if ($matchedFiles.Count -eq 0) {
+                Write-Host "No files matched $pattern, skipping."
+                continue
+            }
+            foreach ($file in $matchedFiles) {
+                Write-Host "Signing $($file.FullName)..."
+                & $SIGNTOOL_EXE sign /v /debug $signOptions /tr $tsaUrl /fd SHA256 /td SHA256 $file.FullName
+                if ($LASTEXITCODE -ne 0) {
+                    throw "SignTool Error: signing failed for $($file.FullName) (exit code $LASTEXITCODE)"
+                }
+            }
         }
     }
 
     Write-Host "Building MSI installer..."
 
     & $CANDLE_EXE -nologo .\wazuh-installer.wxs -out "wazuh-installer.wixobj" -ext WixUtilExtension -ext WixUiExtension
+    if ($LASTEXITCODE -ne 0) {
+        throw "candle.exe failed with exit code $LASTEXITCODE"
+    }
     & $LIGHT_EXE ".\wazuh-installer.wixobj" -out $MSI_NAME -ext WixUtilExtension -ext WixUiExtension
+    if ($LASTEXITCODE -ne 0) {
+        throw "light.exe failed with exit code $LASTEXITCODE"
+    }
 
     if($SIGN -eq "yes"){
         Write-Host "Signing $MSI_NAME..."
-        & $SIGNTOOL_EXE sign $signOptions /tr http://timestamp.digicert.com /d $MSI_NAME /fd SHA256 /td SHA256 $MSI_NAME
+        & $SIGNTOOL_EXE sign /v /debug $signOptions /tr $tsaUrl /d $MSI_NAME /fd SHA256 /td SHA256 $MSI_NAME
+        if ($LASTEXITCODE -ne 0) {
+            throw "SignTool Error: signing failed for $MSI_NAME (exit code $LASTEXITCODE)"
+        }
+
+        Write-Host "Verifying $MSI_NAME signature..."
+        & $SIGNTOOL_EXE verify /v /debug /pa $MSI_NAME
+        if ($LASTEXITCODE -ne 0) {
+            throw "SignTool Error: signature verification failed for $MSI_NAME (exit code $LASTEXITCODE)"
+        }
     }
 }
 

--- a/src/win32/wazuh-installer-build-msi.bat
+++ b/src/win32/wazuh-installer-build-msi.bat
@@ -12,8 +12,26 @@ IF [%REVISION%] == [] set /p REVISION=Enter the revision of the Wazuh agent:
 SET MSI_NAME=wazuh-agent-%VERSION%-%REVISION%.msi
 
 candle.exe -nologo "wazuh-installer.wxs" -out "wazuh-installer.wixobj" -ext WixUtilExtension -ext WixUiExtension
+if %ERRORLEVEL% NEQ 0 (
+    echo candle.exe failed with exit code %ERRORLEVEL%
+    EXIT /B 1
+)
 light.exe "wazuh-installer.wixobj" -out "%MSI_NAME%"  -ext WixUtilExtension -ext WixUiExtension
+if %ERRORLEVEL% NEQ 0 (
+    echo light.exe failed with exit code %ERRORLEVEL%
+    EXIT /B 1
+)
 
 signtool sign /a /tr http://timestamp.digicert.com /fd SHA256 /d "%MSI_NAME%" /td SHA256 "%MSI_NAME%"
+if %ERRORLEVEL% NEQ 0 (
+    echo SignTool Error: signing failed for %MSI_NAME% with exit code %ERRORLEVEL%
+    EXIT /B 1
+)
+
+signtool verify /v /pa "%MSI_NAME%"
+if %ERRORLEVEL% NEQ 0 (
+    echo SignTool Error: signature verification failed for %MSI_NAME% with exit code %ERRORLEVEL%
+    EXIT /B 1
+)
 
 pause

--- a/src/win32/wazuh-installer-sign-exes.bat
+++ b/src/win32/wazuh-installer-sign-exes.bat
@@ -1,15 +1,24 @@
-SETLOCAL
+SETLOCAL EnableExtensions
 SET PATH=%PATH%;C:\Program Files\Microsoft SDKs\Windows\v7.0\Bin
 SET PATH=%PATH%;C:\Program Files (x86)\WiX Toolset v3.11\bin
 
 REM Fix all .exe and .dll files
-signtool.exe sign /a /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 "*.exe"
-signtool.exe sign /a /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 "..\*.dll"
-signtool.exe sign /a /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 "*.dll"
-signtool.exe sign /a /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 "..\data_provider\build\bin\sysinfo.dll"
-signtool.exe sign /a /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 "..\shared_modules\dbsync\build\bin\dbsync.dll"
-signtool.exe sign /a /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 "..\shared_modules\rsync\build\bin\rsync.dll"
-signtool.exe sign /a /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 "..\wazuh_modules\syscollector\build\bin\syscollector.dll"
-signtool.exe sign /a /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 "..\syscheckd\build\bin\libfimdb.dll"
-signtool.exe sign /a /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 "InstallerScripts.vbs"
+call :sign "*.exe"
+call :sign "..\*.dll"
+call :sign "*.dll"
+call :sign "..\data_provider\build\bin\sysinfo.dll"
+call :sign "..\shared_modules\dbsync\build\bin\dbsync.dll"
+call :sign "..\shared_modules\rsync\build\bin\rsync.dll"
+call :sign "..\wazuh_modules\syscollector\build\bin\syscollector.dll"
+call :sign "..\syscheckd\build\bin\libfimdb.dll"
+call :sign "InstallerScripts.vbs"
 pause
+EXIT /B 0
+
+:sign
+signtool.exe sign /a /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 %1
+if %ERRORLEVEL% NEQ 0 (
+    echo SignTool Error: signing failed for %1 with exit code %ERRORLEVEL%
+    EXIT /B 1
+)
+EXIT /B 0


### PR DESCRIPTION
## Summary
Same change as wazuh/wazuh#38513 (5.0.0), adapted to this branch's older `generate_wazuh_msi.ps1`/`.bat` file layout (pre `build\bin`/`build\lib` reorganization - different explicit per-module DLL paths).

- `generate_wazuh_msi.ps1` gains `-DLIB_PATH`/`-DLIB_METADATA` to sign via `signtool /dlib /dmdf` (Azure Artifact Signing) instead of `/a` (DigiCert). Default behaviour unchanged.
- Every `signtool`/`candle`/`light` call now checks its exit code and throws on failure, plus a final `signtool verify /pa` pass.
- Same exit-code fix applied to the two legacy `.bat` scripts.

## Context
Part of [wazuh-agent-packages#922](https://github.com/wazuh/wazuh-agent-packages/issues/922). Companion PRs: wazuh/wazuh#38513 (5.0.0), and wazuh-agent-packages#943 / the 4.14.8 workflow PR wiring this in.

## Not done yet
Unverified end-to-end - no Azure account/certificate profile exists yet.

## Test plan
- [ ] `-SIGN no` path (default) still builds an MSI identically to before.
- [ ] `-SIGN yes` without DLIB_PATH still signs via DigiCert `/a` as today.
- [ ] Once an Azure Artifact Signing account exists: `-DLIB_PATH`/`-DLIB_METADATA` produces a validly signed MSI/exe/dll.