### PR TITLE
Merge 4.14.8 into 4.14.9

### DIFF
--- a/.github/actions/check_files/action.yml
+++ b/.github/actions/check_files/action.yml
@@ -77,7 +77,17 @@ runs:
       ignore=""
       if [ -n "${{ inputs.ignore }}" ]; then ignore="--ignore ${{ inputs.ignore }}"; fi
 
-      venv/bin/python3 check_files.py -b '${{ inputs.current_status }}' --wazuh_gid ${{ inputs.wazuh_gid }} --wazuh_uid ${{ inputs.wazuh_uid }} --directory '${{ inputs.installation_directory }}' ${size_check} ${ignore}
+      # check_files must be able to stat every file under the installation
+      # directory, which the package creates root/wazuh-owned with restrictive
+      # permissions. Self-hosted and CodeBuild runners execute as root, so no
+      # elevation was needed there. GitHub-hosted runners execute as an unprivileged
+      # user, where an unreadable file is reported as a missing one. Elevate
+      # only when needed, so behaviour on root runners is unchanged and no
+      # dependency on `sudo` being installed is introduced.
+      SUDO=""
+      if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1; then SUDO="sudo"; fi
+
+      $SUDO venv/bin/python3 check_files.py -b '${{ inputs.current_status }}' --wazuh_gid ${{ inputs.wazuh_gid }} --wazuh_uid ${{ inputs.wazuh_uid }} --directory '${{ inputs.installation_directory }}' ${size_check} ${ignore}
 
   - name: Upload current stats
     if: success()
@@ -100,7 +110,17 @@ runs:
       ignore=""
       if [ -n "${{ inputs.ignore }}" ]; then ignore="--ignore ${{ inputs.ignore }}"; fi
 
-      venv/bin/python3 check_files.py --report '${{ inputs.report_file }}' --file_csv_path '${{ inputs.expected_files }}' --wazuh_uid ${{ inputs.wazuh_uid }} --wazuh_gid ${{ inputs.wazuh_gid }} --directory '${{ inputs.installation_directory }}' ${size_check} ${ignore}
+      # check_files must be able to stat every file under the installation
+      # directory, which the package creates root/wazuh-owned with restrictive
+      # permissions. Self-hosted and CodeBuild runners execute as root, so no
+      # elevation was needed there. GitHub-hosted runners execute as an unprivileged
+      # user, where an unreadable file is reported as a missing one. Elevate
+      # only when needed, so behaviour on root runners is unchanged and no
+      # dependency on `sudo` being installed is introduced.
+      SUDO=""
+      if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1; then SUDO="sudo"; fi
+
+      $SUDO venv/bin/python3 check_files.py --report '${{ inputs.report_file }}' --file_csv_path '${{ inputs.expected_files }}' --wazuh_uid ${{ inputs.wazuh_uid }} --wazuh_gid ${{ inputs.wazuh_gid }} --directory '${{ inputs.installation_directory }}' ${size_check} ${ignore}
 
   - name: Upload validation results
     if: always()

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -1,0 +1,141 @@
+name: "Setup sccache"
+description: >
+  Installs sccache with the Amazon S3 backend and transparently wraps every
+  compiler present on the runner (gcc/g++, clang, the mingw crosses) through
+  PATH masquerade, so make- and cmake-based builds get compilation caching
+  with no build-system changes. Requires AWS credentials already present in
+  the environment (aws-actions/configure-aws-credentials) with read/write
+  access to the cache prefix. If a probe write to the prefix fails, the
+  action disables itself with a warning and the build runs uncached.
+
+inputs:
+  bucket:
+    description: S3 bucket that stores the compilation cache
+    required: true
+  region:
+    description: AWS region of the bucket
+    required: true
+  key-prefix:
+    description: Key prefix for cache objects inside the bucket
+    required: false
+    default: "sccache"
+  version:
+    description: sccache release to install
+    required: false
+    default: "0.8.1"
+
+runs:
+  using: composite
+  steps:
+    - name: Install sccache
+      shell: bash
+      run: |
+        case "$(uname -m)" in
+          aarch64|arm64) arch="aarch64" ;;
+          *) arch="x86_64" ;;
+        esac
+        v="v${{ inputs.version }}"
+        curl -sSL --retry 3 \
+          "https://github.com/mozilla/sccache/releases/download/${v}/sccache-${v}-${arch}-unknown-linux-musl.tar.gz" \
+          | tar xz -C /tmp
+        sudo install -m 0755 "/tmp/sccache-${v}-${arch}-unknown-linux-musl/sccache" /usr/local/bin/sccache
+        sccache --version
+
+    - name: Probe cache prefix access
+      shell: bash
+      run: |
+        # The bucket input may arrive as "s3://name[/base/path]" (that is how
+        # the CI secret is stored and how upload_s3_artifact consumes it) or
+        # as a bare bucket name. Normalize to name + effective key prefix.
+        # The derived bare name is not covered by secret masking, so no S3
+        # output may reach the log: verdicts only.
+        raw="${{ inputs.bucket }}"
+        raw="${raw#s3://}"
+        bucket_name="${raw%%/*}"
+        base=""
+        case "$raw" in */*) base="${raw#*/}" ;; esac
+        prefix="${base:+${base%/}/}${{ inputs.key-prefix }}"
+        # State travels between steps in a file, never through GITHUB_ENV:
+        # job-level env is echoed into the env block of any later step that
+        # declares env:, which would print the bucket name in a public log.
+        envfile="${RUNNER_TEMP}/sccache.env"
+        {
+          echo "SCCACHE_BUCKET_NAME='$bucket_name'"
+          echo "SCCACHE_EFFECTIVE_PREFIX='$prefix'"
+        } > "$envfile"
+        # The bucket may live in a different region than the CI default; the
+        # AWS CLI follows the S3 301 redirect transparently but sccache's S3
+        # client does not, so resolve the real region from the unauthenticated
+        # x-amz-bucket-region header and fall back to the input.
+        detected=$(curl -sI --max-time 10 "https://${bucket_name}.s3.amazonaws.com/" \
+          | tr -d '\r' | awk -F': ' 'tolower($1)=="x-amz-bucket-region"{print $2}')
+        region="${detected:-${{ inputs.region }}}"
+        echo "SCCACHE_RESOLVED_REGION='$region'" >> "$envfile"
+        echo "bucket region resolved: $region"
+        probe="s3://${bucket_name}/${prefix}/.probe-${GITHUB_RUN_ID}"
+        if echo ok | aws s3 cp - "$probe" --region "$region" >/dev/null 2>&1; then
+          aws s3 rm "$probe" --region "$region" >/dev/null 2>&1 || true
+          echo "SCCACHE_PROBE_OK=1" >> "$envfile"
+          echo "probe OK: read/write available on the cache prefix"
+        else
+          echo "SCCACHE_PROBE_OK=0" >> "$envfile"
+          echo "::warning title=sccache disabled::the CI role cannot write to the cache prefix; building uncached"
+        fi
+
+    - name: Configure environment and wrap compilers
+      shell: bash
+      run: |
+        . "${RUNNER_TEMP}/sccache.env"
+        [ "$SCCACHE_PROBE_OK" = "1" ] || exit 0
+
+        # PATH masquerade instead of CC/CXX overrides: src/Makefile hardcodes
+        # CC=gcc, cmake discovers compilers from PATH, and the winagent target
+        # uses the mingw crosses — one wrapper directory ahead of PATH covers
+        # all of them. Real paths are resolved here, before the wrapper dir
+        # enters PATH, so a wrapper can never recurse into itself.
+        wrapdir="${RUNNER_TEMP}/sccache-wrappers"
+        mkdir -p "$wrapdir"
+        candidates="cc c++ gcc g++ gcc-14 g++-14 clang clang++ \
+          x86_64-w64-mingw32-gcc x86_64-w64-mingw32-g++ \
+          x86_64-w64-mingw32-gcc-posix x86_64-w64-mingw32-g++-posix \
+          i686-w64-mingw32-gcc i686-w64-mingw32-g++ \
+          i686-w64-mingw32-gcc-posix i686-w64-mingw32-g++-posix"
+        for name in $candidates; do
+          real="$(command -v "$name" 2>/dev/null)" || continue
+          [ -n "$real" ] || continue
+          printf '#!/bin/sh\nexec /usr/local/bin/sccache %s "$@"\n' "$real" > "$wrapdir/$name"
+          chmod +x "$wrapdir/$name"
+          echo "wrapped $name -> $real"
+        done
+        echo "$wrapdir" >> "$GITHUB_PATH"
+
+    - name: Start sccache server
+      shell: bash
+      run: |
+        . "${RUNNER_TEMP}/sccache.env"
+        [ "$SCCACHE_PROBE_OK" = "1" ] || exit 0
+        # A cache problem must never fail the job: on any startup error,
+        # sanitize the output (it can carry the unmasked bucket name),
+        # remove the compiler wrappers and continue uncached.
+        set +e
+        out=$(SCCACHE_BUCKET="$SCCACHE_BUCKET_NAME" \
+              SCCACHE_REGION="$SCCACHE_RESOLVED_REGION" \
+              SCCACHE_S3_KEY_PREFIX="$SCCACHE_EFFECTIVE_PREFIX" \
+              SCCACHE_IDLE_TIMEOUT=0 \
+              SCCACHE_LOG=debug \
+              SCCACHE_ERROR_LOG=/tmp/sccache_server.log \
+              sccache --start-server 2>&1)
+        rc=$?
+        set -e
+        if [ "$rc" -ne 0 ]; then
+          echo "$out" | sed "s/${SCCACHE_BUCKET_NAME}/<bucket>/g" | head -20
+          if [ -f /tmp/sccache_server.log ]; then
+            echo "── server debug log (sanitized):"
+            sed "s/${SCCACHE_BUCKET_NAME}/<bucket>/g" /tmp/sccache_server.log | grep -iE "error|stat|check|403|404|denied|response" | head -30
+          fi
+          echo "::warning title=sccache disabled::server failed to start (rc=$rc); building uncached"
+          rm -rf "${RUNNER_TEMP}/sccache-wrappers"
+          exit 0
+        fi
+        sccache --zero-stats >/dev/null 2>&1 || true
+        echo "sccache server started"

--- a/.github/workflows/4_builderpackage_manager-multiples.yml
+++ b/.github/workflows/4_builderpackage_manager-multiples.yml
@@ -39,7 +39,7 @@ jobs:
   select-targets:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     name: Select build targets (Wazuh Managers)
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.result }}
     steps:

--- a/.github/workflows/4_builderpackage_manager.yml
+++ b/.github/workflows/4_builderpackage_manager.yml
@@ -107,7 +107,7 @@ jobs:
       SHOULD_UPLOAD: ${{ inputs.upload_package }}
       SHOULD_UPLOAD_CHECKSUM: ${{ inputs.checksum && inputs.upload_package }}
 
-    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && format('codebuild-github-actions-codebuild-runner-server-arm-{0}-{1}', github.run_id, github.run_attempt) || format('codebuild-github-actions-codebuild-runner-server-amd-{0}-{1}', github.run_id, github.run_attempt) }}
+    runs-on: ${{ (inputs.architecture == 'arm64' || inputs.architecture == 'aarch64') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     timeout-minutes: 35
     name: Build ${{ inputs.system }} wazuh-manager on ${{ inputs.architecture }}
 
@@ -171,14 +171,6 @@ jobs:
       - name: CodeBuild workarounds
         # TODO: Remove once DevOps exposes host Docker socket or configures DinD in CodeBuild
         run: |
-          # 1. Docker daemon: CodeBuild has no systemd; VFS driver avoids overlay-on-overlay.
-          if ! docker info &>/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y docker.io
-            sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
-            timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
-            sudo chmod 666 /var/run/docker.sock
-          fi
           # 2. Git repo format: actions/checkout on newer git writes repositoryformatversion=1
           #    which the older git inside builder Docker images cannot read.
           git config core.repositoryformatversion 0

--- a/.github/workflows/4_builderprecompiled_docker-images-retag.yml
+++ b/.github/workflows/4_builderprecompiled_docker-images-retag.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   Upload-package-building-images:
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     name: Package - Retag Docker images
 

--- a/.github/workflows/4_builderprecompiled_docker-images-upload-manager.yml
+++ b/.github/workflows/4_builderprecompiled_docker-images-upload-manager.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   Upload-package-building-images:
-    runs-on: ${{ inputs.architecture == 'arm64' && format('codebuild-github-actions-codebuild-runner-server-arm-{0}-{1}', github.run_id, github.run_attempt) || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.architecture == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-22.04' }}
     timeout-minutes: 140
     name: Package - Upload pkg_${{ inputs.system }}_manager_builder_${{ inputs.architecture }} with tag ${{ inputs.docker_image_tag }}
 
@@ -73,14 +73,6 @@ jobs:
       - name: CodeBuild workarounds
         # TODO: Remove once DevOps exposes host Docker socket or configures DinD in CodeBuild
         run: |
-          # 1. Docker daemon: CodeBuild has no systemd; VFS driver avoids overlay-on-overlay.
-          if ! docker info &>/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y docker.io
-            sudo nohup dockerd --storage-driver vfs > /var/log/dockerd.log 2>&1 &
-            timeout 60 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
-            sudo chmod 666 /var/run/docker.sock
-          fi
           # 2. Git repo format: actions/checkout on newer git writes repositoryformatversion=1
           #    which the older git inside builder Docker images cannot read.
           git config core.repositoryformatversion 0

--- a/.github/workflows/4_builderprecompiled_docker-images-upload.yml
+++ b/.github/workflows/4_builderprecompiled_docker-images-upload.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   Upload-package-building-images:
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Cancel previous runs

--- a/.github/workflows/4_builderprecompiled_vdscanner-testtools.yml
+++ b/.github/workflows/4_builderprecompiled_vdscanner-testtools.yml
@@ -45,7 +45,7 @@ jobs:
 
     # Runs only if the PR status is different to Draft
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml
+++ b/.github/workflows/4_builderprecompiled_vulnerability-scanner-database.yml
@@ -90,7 +90,7 @@ jobs:
   vulnerability_scanner_database_workflow_changes:
     if: github.event_name == 'pull_request' && !github.event.pull_request.draft
 
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/4_codeanalysis_python.yml
+++ b/.github/workflows/4_codeanalysis_python.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   bandit-scan:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/4_codequality_changelog.yml
+++ b/.github/workflows/4_codequality_changelog.yml
@@ -12,7 +12,7 @@ jobs:
   # Enforces the update of a changelog file on every pull request
   verify-changelog:
     if: ${{ !github.event.pull_request.draft && github.repository == 'wazuh/wazuh' }}
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/4_testcomponent_elasticsearch-template.yml
+++ b/.github/workflows/4_testcomponent_elasticsearch-template.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   wazuh-template-elasticsearch:
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.11

--- a/.github/workflows/4_testcomponent_indexer-connector.yml
+++ b/.github/workflows/4_testcomponent_indexer-connector.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   indexer_connector-qa:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/4_testcomponent_indexer-connector.yml
+++ b/.github/workflows/4_testcomponent_indexer-connector.yml
@@ -31,6 +31,21 @@ jobs:
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
 
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       - name: Project dependencies
         uses: ./.github/actions/indexer_connector_deps
 
@@ -76,3 +91,6 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: QA log files
           path: ${{ github.workspace }}/qa_logs
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testcomponent_inventory-harvester.yml
+++ b/.github/workflows/4_testcomponent_inventory-harvester.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   inventory-harvester-modules:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     steps:
       - name: Cancel previous runs
         uses: fkirc/skip-duplicate-actions@master

--- a/.github/workflows/4_testcomponent_inventory-harvester.yml
+++ b/.github/workflows/4_testcomponent_inventory-harvester.yml
@@ -15,6 +15,9 @@ jobs:
   inventory-harvester-modules:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Cancel previous runs
         uses: fkirc/skip-duplicate-actions@master
@@ -34,6 +37,21 @@ jobs:
       - name: Project dependencies
         uses: ./.github/actions/vulnerability_scanner_deps
 
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       - name: Inventory harvester - Build tests
         uses: ./.github/actions/build_target_cpp
         with:
@@ -46,6 +64,9 @@ jobs:
         with:
           target: "inventory_harvester_ctest"
           valgrind: "true"
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
 
   inventory-harvester-asan:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -53,6 +74,9 @@ jobs:
       matrix:
         os: [ubuntu-24.04, ubuntu-22.04]
     runs-on: ${{ matrix.os }}
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Cancel previous runs
         uses: fkirc/skip-duplicate-actions@master
@@ -69,6 +93,21 @@ jobs:
       - name: Project dependencies
         uses: ./.github/actions/vulnerability_scanner_deps
 
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       - name: Inventory harvester - Build tests
         uses: ./.github/actions/build_target_cpp
         with:
@@ -81,3 +120,6 @@ jobs:
         with:
           target: "inventory_harvester_ctest"
           valgrind: "false"
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testcomponent_keystore.yml
+++ b/.github/workflows/4_testcomponent_keystore.yml
@@ -14,6 +14,9 @@ jobs:
   wazuh-keystore-qa:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -23,6 +26,21 @@ jobs:
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
 
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       - name: Compile keystore
         run: |
           make deps TARGET=server -j2 -C src/
@@ -39,3 +57,6 @@ jobs:
       - name: Run tests
         run: |
           python -m pytest -vv src/shared_modules/keystore/qa/ --log-cli-level=DEBUG
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testcomponent_keystore.yml
+++ b/.github/workflows/4_testcomponent_keystore.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   wazuh-keystore-qa:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/4_testcomponent_syscheck-rtr.yml
+++ b/.github/workflows/4_testcomponent_syscheck-rtr.yml
@@ -36,6 +36,21 @@ jobs:
         uses: ./.github/actions/install_build_deps
         with:
           target: ${{ matrix.target }}
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -54,3 +69,6 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: coverage_report ${{ matrix.target }}
           path: ./**/coverage_report/**
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testcomponent_syscollector-rtr.yml
+++ b/.github/workflows/4_testcomponent_syscollector-rtr.yml
@@ -39,6 +39,21 @@ jobs:
         uses: ./.github/actions/install_build_deps
         with:
           target: ${{ matrix.target }}
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -63,3 +78,6 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: coverage_report ${{ env.ARTIFACT_NAME }} ${{ matrix.target }}
           path: ./**/coverage_report/**
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testcomponent_sysinfo-linux.yml
+++ b/.github/workflows/4_testcomponent_sysinfo-linux.yml
@@ -15,6 +15,9 @@ jobs:
   build:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -22,6 +25,21 @@ jobs:
           submodules: recursive
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh agent for linux.
       - name: Build wazuh agent for linux
         run: |
@@ -37,3 +55,6 @@ jobs:
           # hardware DMI data. test_hardware.py validates fields like serial number and
           # manufacturer that are empty strings in EC2 VMs, failing schema validation.
           python -m pytest -vv qa/ --ignore=qa/test_hardware.py
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testcomponent_sysinfo-linux.yml
+++ b/.github/workflows/4_testcomponent_sysinfo-linux.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testcomponent_sysinfo-windows.yml
+++ b/.github/workflows/4_testcomponent_sysinfo-windows.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   build:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - name: Install mingw

--- a/.github/workflows/4_testcomponent_sysinfo-windows.yml
+++ b/.github/workflows/4_testcomponent_sysinfo-windows.yml
@@ -25,6 +25,21 @@ jobs:
         run: sudo apt install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 nsis -y
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       - name: make deps
         run: make -C src deps TARGET=winagent -j2
       - name: make
@@ -85,6 +100,9 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: syscollector
           path: src/wazuh_modules/syscollector/build/bin
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
   run-on-windows:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build

--- a/.github/workflows/4_testcomponent_vulnerability-scanner.yml
+++ b/.github/workflows/4_testcomponent_vulnerability-scanner.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   style-and-documentation:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository
@@ -157,7 +157,7 @@ jobs:
   vulnerability-scanner-modules:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: style-and-documentation
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository
@@ -308,7 +308,7 @@ jobs:
 
   vulnerability-scanner-modules-qa:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     env:
       OFFLINE_CONFIG_FILE: config.content_generation.json
       VD_REDUCED_CONTENT_PATH: file://./src/wazuh_modules/vulnerability_scanner/testtool/scanner/vd_reduced_feed.json

--- a/.github/workflows/4_testcomponent_vulnerability-scanner.yml
+++ b/.github/workflows/4_testcomponent_vulnerability-scanner.yml
@@ -168,6 +168,21 @@ jobs:
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
 
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       - name: Project dependencies
         uses: ./.github/actions/vulnerability_scanner_deps
 
@@ -245,6 +260,9 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/wazuh_modules/vulnerability_scanner
           id: vulnerability_scanner
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
 
   vulnerability-scanner-modules-asan:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -263,6 +281,21 @@ jobs:
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
 
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       - name: Project dependencies
         uses: ./.github/actions/vulnerability_scanner_deps
 
@@ -305,6 +338,9 @@ jobs:
         with:
           path: src/wazuh_modules/vulnerability_scanner
           asan: "true"
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
 
   vulnerability-scanner-modules-qa:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -329,6 +365,21 @@ jobs:
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
 
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       - name: Project dependencies
         uses: ./.github/actions/vulnerability_scanner_deps
 
@@ -427,3 +478,6 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: QA log files
           path: ${{ github.workspace }}/qa_logs
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testcomponent_windows-dll-hijack.yml
+++ b/.github/workflows/4_testcomponent_windows-dll-hijack.yml
@@ -22,6 +22,21 @@ jobs:
         run: sudo apt install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 nsis -y
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       - name: make deps
         run: make -C src deps TARGET=winagent -j2
       - name: make
@@ -60,6 +75,9 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: configuration
           path: src/configuration_files
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
   check_dll_on_windows:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     # NOTE: stays on the GitHub-hosted Windows runners. This test drives Process Monitor, which

--- a/.github/workflows/4_testcomponent_windows-files.yml
+++ b/.github/workflows/4_testcomponent_windows-files.yml
@@ -21,6 +21,21 @@ jobs:
         run: sudo apt install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 nsis -y
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       - name: make deps
         run: make -C src deps TARGET=winagent -j2
       - name: make
@@ -46,6 +61,9 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: binaries
           path: src/bin_files
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
   check_binaries_details:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: windows-2025

--- a/.github/workflows/4_testcomponent_windows-installer-upgrade.yml
+++ b/.github/workflows/4_testcomponent_windows-installer-upgrade.yml
@@ -23,6 +23,21 @@ jobs:
       - uses: actions/checkout@v3
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       - name: make deps
         run: make -C src deps TARGET=winagent -j2
       - name: make
@@ -43,6 +58,9 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: win-agent-base.zip
           path: win-agent-base.zip
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
 
   check_upgrade_result:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}

--- a/.github/workflows/4_testintegration_agentd-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_agentd-tier-0-1-lin.yml
@@ -26,6 +26,9 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -39,6 +42,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh agent for linux.
       - name: Build wazuh agent for linux
         run: |
@@ -96,3 +114,6 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 0 --tier 1 test_agentd/
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testintegration_agentd-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_agentd-tier-0-1-win.yml
@@ -36,6 +36,21 @@ jobs:
         run: sudo apt install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 nsis -y
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build winagent.
       - name: Build wazuh agent for windows
         run: |
@@ -59,6 +74,9 @@ jobs:
           name: winagent
           path: src/winagent
   # Execute the tests on windows.
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
   run-test:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build

--- a/.github/workflows/4_testintegration_analysisd-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_analysisd-tier-0-1.yml
@@ -27,6 +27,9 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -40,6 +43,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh server for linux.
       - name: Build wazuh server for linux
         run: |
@@ -97,3 +115,6 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 0 --tier 1 test_analysisd/
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testintegration_analysisd-tier-2.yml
+++ b/.github/workflows/4_testintegration_analysisd-tier-2.yml
@@ -14,6 +14,9 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -27,6 +30,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh server for linux.
       - name: Build wazuh server for linux
         run: |
@@ -84,3 +102,6 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 2 test_analysisd/
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testintegration_api-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_api-tier-0-1.yml
@@ -41,6 +41,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh server for linux.
       - name: Build wazuh server for linux
         run: |
@@ -125,3 +140,6 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: wazuh-logs-${{ github.job }}
           path: /tmp/wazuh-logs
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testintegration_api-tier-2.yml
+++ b/.github/workflows/4_testintegration_api-tier-2.yml
@@ -31,6 +31,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh server for linux.
       - name: Build wazuh server for linux
         run: |
@@ -109,3 +124,6 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: wazuh-logs-${{ github.job }}
           path: /tmp/wazuh-logs
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testintegration_authd-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_authd-tier-0-1.yml
@@ -26,6 +26,9 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -39,6 +42,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh server for linux.
       - name: Build wazuh server for linux
         run: |
@@ -105,3 +123,6 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 0 --tier 1 test_authd/
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testintegration_aws-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_aws-tier-0-1.yml
@@ -32,7 +32,7 @@ jobs:
       # Manifest of every S3 key the tests upload, so the always() cleanup step can delete them
       # even if the job is cancelled before pytest teardown runs.
       AWS_IT_CLEANUP_MANIFEST: ${{ github.workspace }}/aws_it_uploaded_keys.txt
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_aws-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_aws-tier-0-1.yml
@@ -124,6 +124,21 @@ jobs:
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
 
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh server for linux.
       - name: Build wazuh server for linux
         run: |
@@ -313,3 +328,6 @@ jobs:
             sudo aws s3 rm "s3://${AWS_BUCKET_NAME}/${key}" --profile default || true
           done
           sudo rm -f "$MANIFEST" || true
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testintegration_enrollment-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_enrollment-tier-0-1-lin.yml
@@ -27,6 +27,9 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -48,6 +51,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh agent for linux.
       - name: Build wazuh agent for linux
         run: |
@@ -105,3 +123,6 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 0 --tier 1 test_enrollment/
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testintegration_enrollment-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_enrollment-tier-0-1-win.yml
@@ -37,6 +37,21 @@ jobs:
         run: sudo apt install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 nsis -y
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build winagent.
       - name: Build wazuh agent for windows
         run: |
@@ -60,6 +75,9 @@ jobs:
           name: winagent
           path: src/winagent
   # Execute the tests on windows.
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
   run-test:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build

--- a/.github/workflows/4_testintegration_execd-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_execd-tier-0-1-lin.yml
@@ -25,6 +25,9 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -38,6 +41,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh agent for linux.
       - name: Build wazuh agent for linux
         run: |
@@ -95,3 +113,6 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 0 --tier 1 test_execd/
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testintegration_execd-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_execd-tier-0-1-win.yml
@@ -35,6 +35,21 @@ jobs:
         run: sudo apt install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 nsis -y
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build winagent.
       - name: Build wazuh agent for windows
         run: |
@@ -58,6 +73,9 @@ jobs:
           name: winagent
           path: src/winagent
   # Execute the tests on windows.
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
   run-test:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build

--- a/.github/workflows/4_testintegration_fim-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_fim-tier-0-1-lin.yml
@@ -25,6 +25,9 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -38,6 +41,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh agent for linux.
       - name: Build wazuh agent for linux
         run: |
@@ -107,3 +125,6 @@ jobs:
           sudo python -m pytest --tier 0 --tier 1 test_fim/ \
             -k "not whodata and not Who-data" \
             --ignore=test_fim/test_files/test_follow_symbolic_link/test_audit_rules_with_symlink.py
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testintegration_fim-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_fim-tier-0-1-win.yml
@@ -34,6 +34,21 @@ jobs:
         run: sudo apt install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 nsis -y
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build winagent.
       - name: Build wazuh agent for windows
         run: |
@@ -57,6 +72,9 @@ jobs:
           name: winagent
           path: src/winagent
   # Execute the tests on windows.
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
   run-test:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build

--- a/.github/workflows/4_testintegration_fim-tier-2-lin.yml
+++ b/.github/workflows/4_testintegration_fim-tier-2-lin.yml
@@ -14,6 +14,9 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -27,6 +30,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh agent for linux.
       - name: Build wazuh agent for linux
         run: |
@@ -90,3 +108,6 @@ jobs:
           cd tests/integration
           sudo python -m pytest --tier 2 test_fim/ \
             -k "not whodata and not Who-data"
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testintegration_fim-tier-2-win.yml
+++ b/.github/workflows/4_testintegration_fim-tier-2-win.yml
@@ -23,6 +23,21 @@ jobs:
         run: sudo apt install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 nsis -y
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build winagent.
       - name: Build wazuh agent for windows
         run: |
@@ -46,6 +61,9 @@ jobs:
           name: winagent
           path: src/winagent
   # Execute the tests on windows.
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
   run-test:
     needs: build
     env:

--- a/.github/workflows/4_testintegration_github-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_github-tier-0-1-lin.yml
@@ -25,6 +25,9 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -38,6 +41,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh agent for linux.
       - name: Build wazuh agent for linux
         run: |
@@ -95,3 +113,6 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 0 --tier 1 test_github/
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testintegration_github-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_github-tier-0-1-win.yml
@@ -35,6 +35,21 @@ jobs:
         run: sudo apt install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 nsis -y
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build winagent.
       - name: Build wazuh agent for windows
         run: |
@@ -58,6 +73,9 @@ jobs:
           name: winagent
           path: src/winagent
   # Execute the tests on windows.
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
   run-test:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build

--- a/.github/workflows/4_testintegration_integratord-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_integratord-tier-0-1.yml
@@ -25,6 +25,9 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -38,6 +41,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh server for linux.
       - name: Build wazuh server for linux
         run: |
@@ -95,3 +113,6 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 0 --tier 1 test_integratord/
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testintegration_inventory-harvester.yml
+++ b/.github/workflows/4_testintegration_inventory-harvester.yml
@@ -3,7 +3,6 @@ name: 4.X - Inventory Harvester - Integration tests
 on:
   workflow_dispatch:
   pull_request:
-    types: [synchronize, opened, reopened, ready_for_review]
   # Pull request events
     types: [synchronize, opened, reopened, ready_for_review]
   # Path filtering

--- a/.github/workflows/4_testintegration_inventory-harvester.yml
+++ b/.github/workflows/4_testintegration_inventory-harvester.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   inventory-harvester-qa:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Cancel previous runs

--- a/.github/workflows/4_testintegration_inventory-harvester.yml
+++ b/.github/workflows/4_testintegration_inventory-harvester.yml
@@ -20,6 +20,9 @@ jobs:
   inventory-harvester-qa:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Cancel previous runs
@@ -40,6 +43,21 @@ jobs:
       - name: Project dependencies
         uses: ./.github/actions/vulnerability_scanner_deps
 
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       - name: Inventory harvester - Build tooling
         uses: ./.github/actions/build_target_cpp
         with:
@@ -66,3 +84,6 @@ jobs:
           cd src
           echo "{}" > states_update_mappings.json
           python -m pytest -vv wazuh_modules/inventory_harvester/qa/ --log-cli-level=DEBUG
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testintegration_logcollector-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_logcollector-tier-0-1-lin.yml
@@ -25,6 +25,9 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -38,6 +41,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh agent for linux.
       - name: Build wazuh agent for linux
         run: |
@@ -100,3 +118,6 @@ jobs:
           sudo python -m pytest --tier 0 --tier 1 test_logcollector/ \
             --ignore=test_logcollector/test_read/test_read_journald_basic.py \
             --ignore=test_logcollector/test_read/test_read_journald_ofe.py
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testintegration_logcollector-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_logcollector-tier-0-1-win.yml
@@ -34,6 +34,21 @@ jobs:
         run: sudo apt install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 nsis -y
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build winagent.
       - name: Build wazuh agent for windows
         run: |
@@ -57,6 +72,9 @@ jobs:
           name: winagent
           path: src/winagent
   # Execute the tests on windows.
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
   run-test:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build

--- a/.github/workflows/4_testintegration_logtest-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_logtest-tier-0-1.yml
@@ -26,6 +26,9 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -39,6 +42,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh server for linux.
       - name: Build wazuh server for linux
         run: |
@@ -96,3 +114,6 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 0 --tier 1 test_logtest/
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testintegration_msgraph-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_msgraph-tier-0-1-lin.yml
@@ -25,6 +25,9 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -41,6 +44,21 @@ jobs:
           tar zvx -C /tmp/
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh agent for linux.
       - name: Build wazuh agent for linux
         run: |
@@ -102,3 +120,6 @@ jobs:
         run: |
           cd tests/integration
           sudo -E python -m pytest --tier 0 --tier 1 test_msgraph/
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testintegration_office365-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_office365-tier-0-1-lin.yml
@@ -25,6 +25,9 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -38,6 +41,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh agent for linux.
       - name: Build wazuh agent for linux
         run: |
@@ -95,3 +113,6 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 0 --tier 1 test_office365/
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testintegration_office365-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_office365-tier-0-1-win.yml
@@ -35,6 +35,21 @@ jobs:
         run: sudo apt install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 nsis -y
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build winagent.
       - name: Build wazuh agent for windows
         run: |
@@ -58,6 +73,9 @@ jobs:
           name: winagent
           path: src/winagent
   # Execute the tests on windows.
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
   run-test:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build

--- a/.github/workflows/4_testintegration_rbac-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_rbac-tier-0-1.yml
@@ -40,6 +40,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh server for linux.
       - name: Build wazuh server for linux
         run: |
@@ -116,3 +131,6 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           name: wazuh-logs-${{ github.job }}
           path: /tmp/wazuh-logs
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testintegration_remoted-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_remoted-tier-0-1.yml
@@ -26,6 +26,9 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -39,6 +42,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh server for linux.
       - name: Build wazuh server for linux
         run: |
@@ -104,3 +122,6 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 0 --tier 1 test_remoted/
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testintegration_remoted-tier-2.yml
+++ b/.github/workflows/4_testintegration_remoted-tier-2.yml
@@ -14,6 +14,9 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -27,6 +30,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh server for linux.
       - name: Build wazuh server for linux
         run: |
@@ -92,3 +110,6 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 2 test_remoted/
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testintegration_ruleset.yml
+++ b/.github/workflows/4_testintegration_ruleset.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/4_testintegration_ruleset.yml
+++ b/.github/workflows/4_testintegration_ruleset.yml
@@ -16,6 +16,9 @@ jobs:
   build:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -29,6 +32,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh server for linux.
       - name: Build wazuh server for linux
         run: |
@@ -70,3 +88,6 @@ jobs:
         run: |
           cd ruleset/testing
           sudo python runtests.py --path /var/ossec
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testintegration_sca-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_sca-tier-0-1-lin.yml
@@ -25,6 +25,9 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -38,6 +41,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh agent for linux.
       - name: Build wazuh agent for linux
         run: |
@@ -99,3 +117,6 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 0 --tier 1 test_sca/
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testintegration_sca-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_sca-tier-0-1-win.yml
@@ -36,6 +36,21 @@ jobs:
         run: sudo apt install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 nsis -y
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build winagent.
       - name: Build wazuh agent for windows
         run: |
@@ -59,6 +74,9 @@ jobs:
           name: winagent
           path: src/winagent
   # Execute the tests on windows.
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
   run-test:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build

--- a/.github/workflows/4_testintegration_syscollector-tier-0-1-lin.yml
+++ b/.github/workflows/4_testintegration_syscollector-tier-0-1-lin.yml
@@ -24,6 +24,9 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -37,6 +40,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh agent for linux.
       - name: Build wazuh agent for linux
         run: |
@@ -98,3 +116,6 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 0 --tier 1 test_syscollector/
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testintegration_syscollector-tier-0-1-win.yml
+++ b/.github/workflows/4_testintegration_syscollector-tier-0-1-win.yml
@@ -34,6 +34,21 @@ jobs:
         run: sudo apt install gcc-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 nsis -y
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build winagent.
       - name: Build wazuh agent for windows
         run: |
@@ -57,6 +72,9 @@ jobs:
           name: winagent
           path: src/winagent
   # Execute the tests on windows.
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
   run-test:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     needs: build

--- a/.github/workflows/4_testintegration_wazuh_db-tier-0-1.yml
+++ b/.github/workflows/4_testintegration_wazuh_db-tier-0-1.yml
@@ -25,6 +25,9 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -38,6 +41,21 @@ jobs:
           architecture: x64
       - name: "Install a compatible CMake"
         uses: ./.github/actions/reinstall_cmake
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       # Build wazuh server for linux.
       - name: Build wazuh server for linux
         run: |
@@ -95,3 +113,6 @@ jobs:
         run: |
           cd tests/integration
           sudo python -m pytest --tier 0 --tier 1 test_wazuh_db/
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testunit_api.yml
+++ b/.github/workflows/4_testunit_api.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   build: 
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/4_testunit_external-integrations.yml
+++ b/.github/workflows/4_testunit_external-integrations.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   build: 
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/4_testunit_framework.yml
+++ b/.github/workflows/4_testunit_framework.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   build:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/4_testunit_inventory-harvester.yml
+++ b/.github/workflows/4_testunit_inventory-harvester.yml
@@ -3,7 +3,6 @@ name: 4.X - Inventory Harvester - Unit tests
 on:
   workflow_dispatch:
   pull_request:
-    types: [synchronize, opened, reopened, ready_for_review]
   # Pull request events
     types: [synchronize, opened, reopened, ready_for_review]
   # Path filtering

--- a/.github/workflows/4_testunit_inventory-harvester.yml
+++ b/.github/workflows/4_testunit_inventory-harvester.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   inventory-harvester-modules:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     steps:
       - name: Cancel previous runs
         uses: fkirc/skip-duplicate-actions@master

--- a/.github/workflows/4_testunit_inventory-harvester.yml
+++ b/.github/workflows/4_testunit_inventory-harvester.yml
@@ -39,6 +39,21 @@ jobs:
       - name: Project dependencies
         uses: ./.github/actions/vulnerability_scanner_deps
 
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       - name: Inventory harvester - Build tests
         uses: ./.github/actions/build_target_cpp
         with:
@@ -59,6 +74,9 @@ jobs:
           aws_role: ${{ secrets.CI_OIDC_ROLE_ARN }}
           path: src/wazuh_modules/inventory_harvester
           id: inventory_harvester
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true
 
   inventory-harvester-asan:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -75,6 +93,21 @@ jobs:
       - name: Project dependencies
         uses: ./.github/actions/vulnerability_scanner_deps
 
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       - name: Inventory harvester - Build tests
         uses: ./.github/actions/build_target_cpp
         with:
@@ -87,3 +120,6 @@ jobs:
         with:
           target: "inventory_harvester_utest"
           valgrind: "false"
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testunit_linux-win.yml
+++ b/.github/workflows/4_testunit_linux-win.yml
@@ -21,6 +21,9 @@ jobs:
           matrix:
               target: [agent, winagent, server]
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -30,6 +33,21 @@ jobs:
         uses: ./.github/actions/install_build_deps
         with:
           target: ${{ matrix.target }}
+      # Compilation cache (issue 38139). Skipped on fork PRs (no credentials).
+      - name: "Configure AWS credentials for the compilation cache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.CI_OIDC_ROLE_ARN }}
+          aws-region: ${{ secrets.CI_AWS_REGION }}
+          role-duration-seconds: 7200
+      - name: "Set up sccache"
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: ./.github/actions/setup-sccache
+        with:
+          bucket: ${{ secrets.CI_INTERNAL_S3_BUCKET }}
+          region: ${{ secrets.CI_AWS_REGION }}
+          key-prefix: sccache/4.14.8
       - name: "Build wazuh"
         uses: ./.github/actions/build_test_flags
         with:
@@ -42,3 +60,6 @@ jobs:
         uses: ./.github/actions/legacy_unit_tests_run
         with:
           target: ${{ matrix.target }}
+      - name: "Compilation cache statistics"
+        if: always()
+        run: sccache --show-stats 2>/dev/null | grep -viE "cache location|bucket" || true

--- a/.github/workflows/4_testunit_python-coverage.yml
+++ b/.github/workflows/4_testunit_python-coverage.yml
@@ -17,7 +17,7 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       BRANCH_BASE: ${{ github.base_ref || inputs.base_branch }}
       PYTHONPATH: ${{ github.workspace }}/api:${{ github.workspace }}/framework
-    runs-on: codebuild-github-actions-codebuild-runner-server-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Improved SCA policy source validation to correctly enforce the `sca.remote_commands` restriction. ([#37953](https://github.com/wazuh/wazuh/pull/37953))
 - Added a minimum length check for legacy-format agent messages in `wazuh-remoted`. ([#38099](https://github.com/wazuh/wazuh/pull/38099))
 - Fixed a spurious `StarletteDeprecationWarning` printed by `agent_upgrade` at startup. ([#38085](https://github.com/wazuh/wazuh/pull/38085))
+- Fixed a spurious `StarletteDeprecationWarning` printed by `cluster_control` and other framework CLI tools at startup. ([#38412](https://github.com/wazuh/wazuh/pull/38412))
 - Fixed the API login attempt limit not being applied consistently under concurrent requests. ([#38135](https://github.com/wazuh/wazuh/pull/38135))
 - Fixed a heap buffer write in `wazuh-analysisd` when generating FIM alerts by resizing `full_log` before writing. ([#38145](https://github.com/wazuh/wazuh/pull/38145))
 - Fixed password validation not being enforced for empty passwords in the `update_user` API endpoint. ([#38180](https://github.com/wazuh/wazuh/pull/38180))

--- a/api/api/__init__.py
+++ b/api/api/__init__.py
@@ -1,3 +1,21 @@
 # Copyright (C) 2015, Wazuh Inc.
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+import warnings
+
+try:
+    from starlette.exceptions import StarletteDeprecationWarning
+except ImportError:
+    # StarletteDeprecationWarning was removed in newer versions of starlette
+    StarletteDeprecationWarning = None
+
+# Connexion unconditionally imports `starlette.testclient` to offer a test helper we never use,
+# which warns when only `httpx` (and not `httpx2`) is installed. Not fixed as of connexion 3.3.0.
+# Starlette raises this with stacklevel=2, so it is attributed to the importing module rather
+# than to starlette.testclient itself; match on the message instead of `module`.
+if StarletteDeprecationWarning is not None:
+    warnings.filterwarnings(
+        'ignore', category=StarletteDeprecationWarning,
+        message=r'Using `httpx` with `starlette\.testclient` is deprecated',
+    )

--- a/src/analysisd/alerts/exec.c
+++ b/src/analysisd/alerts/exec.c
@@ -420,15 +420,28 @@ void send_exec_msg(int *socket, const char *queue_path, const char *exec_msg) {
     w_mutex_lock(&exec_sock_mutex);
 
     if (*socket < 0) {
-        if ((*socket = connect_exec_queue(queue_path)) < 0) {
+        /* Connect with the mutex released: connecting may block, and a thread waiting
+         * inside connect_exec_queue must not stall the rest of the rule matching threads */
+        w_mutex_unlock(&exec_sock_mutex);
+        int new_socket = connect_exec_queue(queue_path);
+        int conn_errno = errno;
+        w_mutex_lock(&exec_sock_mutex);
+
+        if (*socket >= 0) {
+            /* Another thread reconnected while the mutex was released: keep its socket */
+            if (new_socket >= 0) {
+                OS_CloseSocket(new_socket);
+            }
+        } else if (new_socket < 0) {
             if (conn_error_sent == 0){
-                merror(QUEUE_ERROR, queue_path, strerror(errno));
+                merror(QUEUE_ERROR, queue_path, strerror(conn_errno));
                 conn_error_sent = 1;
             }
 
             w_mutex_unlock(&exec_sock_mutex);
             return;
         } else {
+            *socket = new_socket;
             conn_error_sent = 0;
         }
     }

--- a/src/unit_tests/analysisd/test_exec.c
+++ b/src/unit_tests/analysisd/test_exec.c
@@ -831,6 +831,8 @@ void test_send_exec_msg_reconnect_socket(void **state){
     expect_OS_SendUnix_call(new_socket, exec_msg, 0, 0);
 
     send_exec_msg(&socket, queue_path, exec_msg);
+
+    assert_int_equal(socket, new_socket);
 }
 
 void test_send_exec_msg_reconnect_socket_fail(void **state){
@@ -843,6 +845,8 @@ void test_send_exec_msg_reconnect_socket_fail(void **state){
     expect_string(__wrap__merror, formatted_msg, "(1210): Queue '/path/to/queue' not accessible: 'Operation not permitted'");
 
     send_exec_msg(&socket, queue_path, exec_msg);
+
+    assert_int_equal(socket, -1);
 }
 
 void test_send_exec_msg_OS_SOCKBUSY(void **state){


### PR DESCRIPTION
## Description

Scheduled weekly upward merge. Part of #38519 (Week #34).

Merges branch `4.14.8` into `4.14.9`.

## Proposed Changes

- Merge `origin/4.14.8` into `4.14.9`.

### Results and Evidence

Merged with no conflicts (10 incoming commits). Incoming changes: StarletteDeprecationWarning suppression for the framework CLI tools (#38412), CI move of the 4.14.8 server-fleet workflows to GitHub-hosted runners with sccache compilation caching (#38460), and the analysisd fix to avoid holding exec_sock_mutex while connecting to the exec queue (#38510).
