### PR TITLE
Reduce wazuh-agentd resident memory and per-request signing cost

### DIFF
--- a/src/client-agent/src/main.c
+++ b/src/client-agent/src/main.c
@@ -14,6 +14,10 @@
 #include "agentd.h"
 #include <getopt.h>
 
+#if defined(__GLIBC__)
+#include <malloc.h>
+#endif
+
 #ifndef ARGV0
 #define ARGV0 "wazuh-agentd"
 #endif
@@ -61,6 +65,24 @@ int main(int argc, char **argv)
     gid_t gid;
 
     run_foreground = 0;
+
+#if defined(__GLIBC__)
+    /* Cap the number of malloc arenas.
+     *
+     * The HTTPS transport runs several allocating threads, and glibc answers
+     * that by giving each one its own 64 MiB arena. Those arenas are reserved
+     * rather than committed, so most of the cost is address space, and it is
+     * what takes this process past 690 MB of virtual size. But each arena also
+     * carries its own top chunk and bins, which is real resident memory that is
+     * never handed back. Capping the count trades a little allocator contention
+     * for that overhead.
+     *
+     * Set here, before any thread is created: extra arenas are only spawned
+     * when a thread finds every existing one locked, so the limit has to be in
+     * place before the transport's threads start. Allocations already made on
+     * this thread came from the main arena and are unaffected. */
+    mallopt(M_ARENA_MAX, 2);
+#endif
 
     /* Set the name */
     OS_SetName(ARGV0);

--- a/src/client-agent/src/main.c
+++ b/src/client-agent/src/main.c
@@ -77,11 +77,29 @@ int main(int argc, char **argv)
      * never handed back. Capping the count trades a little allocator contention
      * for that overhead.
      *
-     * Set here, before any thread is created: extra arenas are only spawned
-     * when a thread finds every existing one locked, so the limit has to be in
-     * place before the transport's threads start. Allocations already made on
-     * this thread came from the main arena and are unaffected. */
-    mallopt(M_ARENA_MAX, 2);
+     * Set here, before any thread is created: extra arenas are only spawned when
+     * a thread finds every existing one locked, so the limit has to be in place
+     * before the transport's threads start. Allocations already made on this
+     * thread came from the main arena and are unaffected.
+     *
+     * Skipped when an operator has already chosen a limit. glibc applies
+     * MALLOC_ARENA_MAX and the glibc.malloc.arena_max tunable at process start,
+     * and mallopt() overrides either of them silently: with MALLOC_ARENA_MAX=1
+     * in the environment, an unconditional mallopt(2) leaves the process running
+     * two arenas. Honouring the environment keeps the knob usable for tuning and
+     * for diagnosing allocator behaviour in the field.
+     *
+     * The return value is checked rather than discarded, since an unchecked
+     * mallopt() is the pattern Coverity reports. Failing startup over an
+     * allocator hint would be wrong, so a debug line is the right level. */
+    const char *tunables = getenv("GLIBC_TUNABLES");
+
+    if (getenv("MALLOC_ARENA_MAX") == NULL &&
+        (tunables == NULL || strstr(tunables, "glibc.malloc.arena_max") == NULL)) {
+        if (mallopt(M_ARENA_MAX, 2) != 1) {
+            mdebug1("Could not cap the malloc arena count; using the allocator default.");
+        }
+    }
 #endif
 
     /* Set the name */


### PR DESCRIPTION
## Description

Related to #38456

`wazuh-agentd`'s resting memory footprint roughly doubled in 5.0.0 after the agent HTTPS transport landed. Investigation traced the increase to the cost of running OpenSSL and libcurl inside the agent process, most of which is inherent to the new transport: newly executed library pages, ten threads instead of three, and a small live working set.

This pull request addresses one recoverable part of that cost. It recovers roughly a sixth of the reported resident increase, so it does not bring the agent under the current baseline threshold; that remains a separate discussion on the issue.

## Proposed Changes

Cap `wazuh-agentd`'s glibc malloc arena count with `mallopt(M_ARENA_MAX, 2)` in `main()`.

glibc gives each allocating thread its own 64 MiB arena, and the transport runs several. Most of that is reserved address space rather than committed memory, and it is what takes agentd past 690 MB of virtual size, but each arena also carries its own top chunk and bins, which is resident memory never handed back.

The call is placed before any thread is created, since extra arenas are only spawned when a thread finds every existing one locked. A limit of 2 rather than 1 leaves a second arena available so the transport's threads do not all serialise on a single allocator lock. Compiled in only for glibc, so the Windows and macOS agents are unaffected.

A second change, caching the CMAC implementation instead of fetching it per signature, was prepared and then dropped from this pull request. Fetching per signature is a documented OpenSSL anti-pattern and it is worth doing on its own merits, but its memory effect measured as approximately zero and it is being held back while the agentd and enrollment integration test failures on this branch remain unexplained.

### Results and Evidence

Two packages built by the same builder, differing only in the agent binaries. `libwazuhext.so`, `wazuh-modulesd` and `wazuh-logcollector` are byte identical between them, and `mallopt` is referenced only in the patched `wazuh-agentd`. Both arms ran from the package's own shipped `internal_options.conf` with compression at its default, under the same event load, alternating A,B,A,B so host drift cannot be mistaken for a package effect. Medians over 12 minute samples after a 7 minute settle, 288 samples per arm.

| Metric | Baseline | Patched | Saved | % of baseline |
| --- | --- | --- | --- | --- |
| USS (private) | 10.32 MB | 9.27 MB | **1.05 MB** | **10.2 %** |
| RSS (resident) | 18.52 MB | 17.60 MB | 0.92 MB | 5.0 % |
| VMS (virtual) | 675.67 MB | 165.51 MB | 510.16 MB | 75.5 % |

The measured package also carried two changes that have since been dropped, which together accounted for about 0.32 MB of a 1.37 MB total. The figures above subtract that, so they are this change's isolated contribution rather than a direct reading. A re-measurement against a package built from this branch as it now stands would replace the arithmetic with a measurement.

Above the noise floor: per-repetition USS medians differed by 96 KB within the baseline arm and 132 KB within the patched arm, so the arms do not overlap at any point and the saving is an order of magnitude larger than the within-arm variation.

What motivated the change: `malloc_info()` on a plateaued agent reported five arenas holding 1 912 KB in total, of which only 887 KB was live. Capping the count was measured separately at 1 328 KB of resident memory and 85 % of the virtual size with `MALLOC_ARENA_MAX=1`.

The virtual size result deserves a caveat rather than celebration. 510 MB sounds dramatic, but that memory was reserved and never committed, so it was never denied to anything else on the host. It matters because it removes a figure that reads as alarming in monitoring, not because it frees usable memory.

Set against the regression this addresses: the reported increase was +5 288 KB on RSS p95 and +4 212 KB on private memory, so this recovers roughly a sixth of the former and a quarter of the latter.

### Manual tests with their corresponding evidence

**Multi-agent validation.** Ten containerised agents per arm, each running the full agent stack and generating its own event load of roughly 50 events per second, all enrolled over HTTPS against a real 5.0.0 manager on the same host. Both arms used packages built by the same builder from the same base, differing only in `wazuh-agentd`. Every agent was sampled every 10 seconds for 30 minutes after a 7 minute settle, giving 168 samples per agent and 1 680 per arm. Health was checked before and after sampling: process alive, transport started, enrollment confirmed, thread count, and zero `CRITICAL` log lines. All ten agents passed in both arms, before and after.

| Metric | Baseline | Patched | Saved | % of baseline |
| --- | --- | --- | --- | --- |
| RSS (resident) | 17.23 MB | 16.30 MB | **0.93 MB** | **5.37 %** |
| VMS (virtual) | 675.45 MB | 163.46 MB | 512.00 MB | 75.80 % |
| Threads | 10 | 10 | 0 | |
| File descriptors | 12 | 12 | 0 | |

Medians across the ten agents. Threads and file descriptors are unchanged, so the cap introduces no resource drift under concurrency.

This corroborates the single-agent measurement closely: 0.93 MB of resident memory saved here against 0.92 MB there, with baseline virtual size at 675.45 MB against 675.67 MB. Two independent harnesses agreeing to within 10 KB on the saving.

Reading the spread honestly. Per-agent RSS medians ranged 16.82 to 17.80 MB on the baseline and 16.12 to 17.03 MB patched, so the ranges overlap and the 0.93 MB saving is about the size of the cross-agent spread. What supports it is consistency rather than separation: every patched agent sits below the baseline median, and the result matches the single-agent A/B. The virtual size result needs no such hedging, at 675.45 MB on all ten baseline agents against 163.45 to 163.71 MB on all ten patched.

### Artifacts Affected

- `wazuh-agentd` on Linux.
- No change to the Windows or macOS agents: the call is compiled in only for glibc.
- No packaging or default configuration changes.

### Configuration Changes

N/A

### Documentation Updates

N/A.

### Tests Introduced

N/A

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality: N/A, see Tests Introduced
- [x] Configuration changes documented: N/A, no configuration changes
- [x] Developer documentation reflects the changes: N/A
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues: the agentd and enrollment integration test failures on this branch are still unexplained
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
