### PR TITLE
Log transport-level errors

### DIFF
--- a/src/client-agent/https_client/include/https_client.h
+++ b/src/client-agent/https_client/include/https_client.h
@@ -373,7 +373,10 @@ typedef struct hc_callbacks_t
     /// number of consecutive attempts (paused=true), or has succeeded again
     /// (paused=false). The consumer arms/disarms its producer lock so modules
     /// stop generating events they cannot deliver.
-    void (*on_producer_pause)(bool paused, void* user_data);
+    /// reason: why the transport failed, in libcurl's own words. Empty when
+    /// there is none to give -- always on paused=false, and whenever the manager
+    /// answered and refused rather than going silent.
+    void (*on_producer_pause)(bool paused, const char* reason, void* user_data);
     void* user_data;
 } hc_callbacks_t;
 
@@ -482,6 +485,10 @@ HC_EXPORTED int hc_get_state(const hc_handle* handle);
 
 #define HC_MAX_ENROLL_BODY 4096
 #define HC_MAX_ENROLL_PASSWORD 256
+/// Sized so a transport reason never needs truncating: libcurl's longest error
+/// string is around 60 bytes and the detail it appends is capped by
+/// CURL_ERROR_SIZE (256), leaving room to spare.
+#define HC_MAX_TRANSPORT_ERROR 512
 
 /**
  * @brief One /enroll request (#38438's contract), built entirely by the C
@@ -507,6 +514,11 @@ typedef struct hc_enroll_result_t
     ///< failure -- see hc_enroll()'s return value).
     long retry_after_seconds; ///< Parsed Retry-After header (0 = absent).
     char body[HC_MAX_ENROLL_BODY]; ///< Raw response body (success or error JSON).
+    /// Why the request never reached the manager, in libcurl's own words (same
+    /// contract as on_producer_pause's reason). Only ever set alongside
+    /// http_code == 0, and empty even then when the attempt never got as far as
+    /// libcurl -- notably a transport config the fail-closed TLS policy rejected.
+    char transport_error[HC_MAX_TRANSPORT_ERROR];
 } hc_enroll_result_t;
 
 /**

--- a/src/client-agent/https_client/include/https_client.h
+++ b/src/client-agent/https_client/include/https_client.h
@@ -514,10 +514,11 @@ typedef struct hc_enroll_result_t
     ///< failure -- see hc_enroll()'s return value).
     long retry_after_seconds; ///< Parsed Retry-After header (0 = absent).
     char body[HC_MAX_ENROLL_BODY]; ///< Raw response body (success or error JSON).
-    /// Why the request never reached the manager, in libcurl's own words (same
-    /// contract as on_producer_pause's reason). Only ever set alongside
-    /// http_code == 0, and empty even then when the attempt never got as far as
-    /// libcurl -- notably a transport config the fail-closed TLS policy rejected.
+    /// Why the request failed below HTTP, in libcurl's own words (same contract as
+    /// on_producer_pause's reason). Usually paired with http_code == 0, but a
+    /// failure after the status line (a dropped body, a response-size cap) leaves
+    /// both this and a real http_code set. Empty when the attempt never got as far
+    /// as libcurl -- notably a transport config the fail-closed TLS policy rejected.
     char transport_error[HC_MAX_TRANSPORT_ERROR];
 } hc_enroll_result_t;
 

--- a/src/client-agent/https_client/src/callbackDispatcher.cpp
+++ b/src/client-agent/https_client/src/callbackDispatcher.cpp
@@ -243,12 +243,18 @@ void CallbackDispatcher::onBufferLevel(hc_buffer_level_t level)
     enqueue([this, level] { m_callbacks.on_buffer_level(level, m_callbacks.user_data); });
 }
 
-void CallbackDispatcher::onProducerPause(bool paused)
+void CallbackDispatcher::onProducerPause(bool paused, const std::string& reason)
 {
     if (m_callbacks.on_producer_pause == nullptr)
     {
         return;
     }
 
-    enqueue([this, paused] { m_callbacks.on_producer_pause(paused, m_callbacks.user_data); });
+    // Captured by value, and c_str() deferred to the body: the worker thread runs
+    // this after the caller's string may already be destroyed, so the pointer the
+    // C callback gets has to be into storage the task itself owns.
+    enqueue([this, paused, reason]
+    {
+        m_callbacks.on_producer_pause(paused, reason.c_str(), m_callbacks.user_data);
+    });
 }

--- a/src/client-agent/https_client/src/callbackDispatcher.hpp
+++ b/src/client-agent/https_client/src/callbackDispatcher.hpp
@@ -58,7 +58,7 @@ class CallbackDispatcher final : public ICallbackSink
         void onSyncResponse(const std::string& sessionId, int result, const std::string& body) override;
         void onStateChange(hc_conn_state_t state) override;
         void onBufferLevel(hc_buffer_level_t level) override;
-        void onProducerPause(bool paused) override;
+        void onProducerPause(bool paused, const std::string& reason) override;
 
     private:
         void run();

--- a/src/client-agent/https_client/src/callbackSink.hpp
+++ b/src/client-agent/https_client/src/callbackSink.hpp
@@ -58,7 +58,9 @@ class ICallbackSink
         virtual void onBufferLevel(hc_buffer_level_t level) = 0;
         /// /control is confirmed unreachable (true) or reachable again (false);
         /// the core arms/disarms its producer lock. Emitted on transitions only.
-        virtual void onProducerPause(bool paused) = 0;
+        /// reason carries the transport-level cause for the consumer's own log
+        /// line, empty when there is none to add.
+        virtual void onProducerPause(bool paused, const std::string& reason) = 0;
 };
 
 #endif // _HC_CALLBACK_SINK_HPP

--- a/src/client-agent/https_client/src/configFetcher.cpp
+++ b/src/client-agent/https_client/src/configFetcher.cpp
@@ -83,9 +83,10 @@ std::shared_ptr<SpoolFile> ConfigFetcher::fetch(const std::string& expectedHash,
         // resolve to real content -- e.g. its "0" sentinel for "nothing resolved yet for this
         // group set" right after a group membership change (confirmed with the manager team)
         // -- and the next notify simply re-triggers it either way.
-        LOGFN_DEBUG1(m_logFn, "Config download for group '%s' failed (%s); "
+        LOGFN_DEBUG1(m_logFn, "Config download for group '%s' failed (%s%s); "
                      "the next notify re-triggers it.", group.c_str(),
-                     outcomeName(result.outcome));
+                     outcomeName(result.outcome),
+                     transportReason(result.response.curlError).c_str());
         return nullptr;
     }
 

--- a/src/client-agent/https_client/src/configFetcher.cpp
+++ b/src/client-agent/https_client/src/configFetcher.cpp
@@ -83,7 +83,7 @@ std::shared_ptr<SpoolFile> ConfigFetcher::fetch(const std::string& expectedHash,
         // resolve to real content -- e.g. its "0" sentinel for "nothing resolved yet for this
         // group set" right after a group membership change (confirmed with the manager team)
         // -- and the next notify simply re-triggers it either way.
-        LOGFN_DEBUG1(m_logFn, "Config download for group '%s' failed (%s%s); "
+        LOGFN_DEBUG1(m_logFn, "Config download for group '%s' failed (%s)%s; "
                      "the next notify re-triggers it.", group.c_str(),
                      outcomeName(result.outcome),
                      transportReason(result.response.curlError).c_str());

--- a/src/client-agent/https_client/src/controlStream.cpp
+++ b/src/client-agent/https_client/src/controlStream.cpp
@@ -242,7 +242,7 @@ void ControlStream::sendShutdown(Waiter& waiter)
 
     if (result.outcome != OutcomeClass::Ok)
     {
-        LOGFN_WARN(m_logFn, "Shutdown notification to the manager failed (%s)%s",
+        LOGFN_WARN(m_logFn, "Shutdown notification to the manager failed (%s)%s.",
                    outcomeName(result.outcome),
                    transportReason(result.response.curlError).c_str());
     }
@@ -640,7 +640,7 @@ void ControlStream::updateProducerPause(OutcomeClass outcome)
 
     if (++m_undeliverableStreak < m_config.producerPauseThreshold)
     {
-        LOGFN_DEBUG1(m_logFn, "/control undeliverable (%s) (%u/%u)%s",
+        LOGFN_DEBUG1(m_logFn, "/control undeliverable (%s) (%u/%u)%s.",
                      outcomeName(outcome), m_undeliverableStreak,
                      m_config.producerPauseThreshold, transportReason(reason).c_str());
         return;
@@ -649,7 +649,7 @@ void ControlStream::updateProducerPause(OutcomeClass outcome)
     m_producersPaused = true;
     // Debug: the consumer emits the operator-facing line, and the reason rides
     // along so that line can name the cause instead of just "unreachable".
-    LOGFN_DEBUG1(m_logFn, "/control undeliverable (%s) (%u/%u); pausing event production%s",
+    LOGFN_DEBUG1(m_logFn, "/control undeliverable (%s) (%u/%u); pausing event production%s.",
                  outcomeName(outcome), m_undeliverableStreak,
                  m_config.producerPauseThreshold, transportReason(reason).c_str());
     m_sink.onProducerPause(true, reason);
@@ -747,8 +747,9 @@ void ControlStream::joinUpgradeWork()
     }
 }
 
-/* What one attempt told us about the connection itself, kept for the next Notify
- * and for the pause decision -- neither of which still has the response. */
+/* What the last attempt of one send told us about the connection itself, kept for
+ * the next Notify and for the pause decision -- neither of which still has the
+ * response. */
 void ControlStream::updateConnectionInfo(const HttpResponse& response)
 {
     // curl reports the local address only after a connection was established;
@@ -758,9 +759,9 @@ void ControlStream::updateConnectionInfo(const HttpResponse& response)
         m_localIp = response.localIp;
     }
 
-    // Overwritten on every attempt, success included: the pause is armed off a
-    // streak of failures, so a stale reason from an earlier incident would be
-    // more misleading than none at all.
+    // Overwritten on every step, success included, and always before that step's
+    // outcome reaches updateProducerPause() -- so the pause never quotes a reason
+    // from an earlier incident.
     m_lastCurlError = response.curlError;
 }
 

--- a/src/client-agent/https_client/src/controlStream.cpp
+++ b/src/client-agent/https_client/src/controlStream.cpp
@@ -242,8 +242,9 @@ void ControlStream::sendShutdown(Waiter& waiter)
 
     if (result.outcome != OutcomeClass::Ok)
     {
-        LOGFN_WARN(m_logFn, "Shutdown notification to the manager failed (%s).",
-                   outcomeName(result.outcome));
+        LOGFN_WARN(m_logFn, "Shutdown notification to the manager failed (%s)%s",
+                   outcomeName(result.outcome),
+                   transportReason(result.response.curlError).c_str());
     }
     else
     {
@@ -274,7 +275,7 @@ OutcomeClass ControlStream::sendStartup(Waiter& waiter)
 
     const auto result = m_sender.send(controlSpec(body, m_config.requestTimeoutMs), waiter,
                                       m_config.controlMaxAttempts);
-    updateLocalIp(result.response);
+    updateConnectionInfo(result.response);
 
     if (result.outcome == OutcomeClass::Ok)
     {
@@ -336,7 +337,7 @@ OutcomeClass ControlStream::sendNotify(Waiter& waiter)
 
     const auto result = m_sender.send(controlSpec(body, m_config.requestTimeoutMs), waiter,
                                       m_config.controlMaxAttempts);
-    updateLocalIp(result.response);
+    updateConnectionInfo(result.response);
     const auto effects = m_machine.onEvent(eventFor(result.outcome));
     applyEffects(effects, {});
 
@@ -598,7 +599,7 @@ void ControlStream::updateProducerPause(OutcomeClass outcome)
             // Debug: the consumer emits the operator-facing line, so logging
             // louder here would double every transition.
             LOGFN_DEBUG1(m_logFn, "/control deliverable again; releasing the producer pause.");
-            m_sink.onProducerPause(false);
+            m_sink.onProducerPause(false, {}); // Nothing failed: no 'reason' to carry.
         }
 
         return;
@@ -629,19 +630,29 @@ void ControlStream::updateProducerPause(OutcomeClass outcome)
         return;
     }
 
+    // Only Unreachable has a transport reason behind it: the other two mean the
+    // manager answered, so a stored curl error there is from an earlier and
+    // unrelated incident -- and the auth-gate path reaches here having sent
+    // nothing at all.
+    const std::string reason = (outcome == OutcomeClass::Unreachable)
+                               ? m_lastCurlError
+                               : std::string();
+
     if (++m_undeliverableStreak < m_config.producerPauseThreshold)
     {
-        LOGFN_DEBUG1(m_logFn, "/control undeliverable (%s) (%u/%u).",
+        LOGFN_DEBUG1(m_logFn, "/control undeliverable (%s) (%u/%u)%s",
                      outcomeName(outcome), m_undeliverableStreak,
-                     m_config.producerPauseThreshold);
+                     m_config.producerPauseThreshold, transportReason(reason).c_str());
         return;
     }
 
     m_producersPaused = true;
-    LOGFN_DEBUG1(m_logFn, "/control undeliverable (%s) (%u/%u); pausing event production.",
+    // Debug: the consumer emits the operator-facing line, and the reason rides
+    // along so that line can name the cause instead of just "unreachable".
+    LOGFN_DEBUG1(m_logFn, "/control undeliverable (%s) (%u/%u); pausing event production%s",
                  outcomeName(outcome), m_undeliverableStreak,
-                 m_config.producerPauseThreshold);
-    m_sink.onProducerPause(true);
+                 m_config.producerPauseThreshold, transportReason(reason).c_str());
+    m_sink.onProducerPause(true, reason);
 }
 
 void ControlStream::dispatchPlannedTasks(std::vector<NotifyTask> batch, Waiter& waiter)
@@ -736,7 +747,9 @@ void ControlStream::joinUpgradeWork()
     }
 }
 
-void ControlStream::updateLocalIp(const HttpResponse& response)
+/* What one attempt told us about the connection itself, kept for the next Notify
+ * and for the pause decision -- neither of which still has the response. */
+void ControlStream::updateConnectionInfo(const HttpResponse& response)
 {
     // curl reports the local address only after a connection was established;
     // keep the last known value so a transient failure does not blank host.ip.
@@ -744,6 +757,11 @@ void ControlStream::updateLocalIp(const HttpResponse& response)
     {
         m_localIp = response.localIp;
     }
+
+    // Overwritten on every attempt, success included: the pause is armed off a
+    // streak of failures, so a stale reason from an earlier incident would be
+    // more misleading than none at all.
+    m_lastCurlError = response.curlError;
 }
 
 ControlStateMachine::Event ControlStream::eventFor(OutcomeClass outcome) const

--- a/src/client-agent/https_client/src/controlStream.hpp
+++ b/src/client-agent/https_client/src/controlStream.hpp
@@ -118,7 +118,7 @@ class ControlStream final
                                  Waiter& waiter);
         void maybeReportAgentGroups(const std::string& csv);
         void maybeRequestVdRescan(uint64_t offset, Waiter& waiter);
-        void updateLocalIp(const HttpResponse& response);
+        void updateConnectionInfo(const HttpResponse& response);
         ControlStateMachine::Event eventFor(OutcomeClass outcome) const;
 
         const ModuleConfig& m_config;
@@ -141,6 +141,10 @@ class ControlStream final
         /// The agent's own IP (CURLINFO_LOCAL_IP), captured from the last
         /// /control connection and reported as host.ip on the next Notify.
         std::string m_localIp;
+        /// The last /control attempt's transport reason, empty whenever that
+        /// attempt reached the manager at all. Handed to the consumer when the
+        /// producer pause is armed.
+        std::string m_lastCurlError;
         const LogFn m_logFn {HTTPS_CLIENT_LOGTAG};
 
         /// SHA-256 of the exact startup-response bytes (the local settings

--- a/src/client-agent/https_client/src/curlHandle.cpp
+++ b/src/client-agent/https_client/src/curlHandle.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "curlHandle.hpp"
+#include "moduleLog.hpp"
 
 #include <curl/curl.h>
 
@@ -297,7 +298,40 @@ namespace
                     return TransportStatus::OtherError;
                 }
 
-                return statusFromCurlCode(curl_easy_perform(m_handle));
+                // The CURLcode collapses into a coarse TransportStatus, so this is
+                // the only place the real cause exists: keep libcurl's own message.
+                char errorBuffer[CURL_ERROR_SIZE] {};
+                m_lastError.clear();
+                curl_easy_setopt(m_handle, CURLOPT_ERRORBUFFER, errorBuffer);
+
+                const CURLcode code = curl_easy_perform(m_handle);
+
+                if (code != CURLE_OK)
+                {
+                    // strerror() names the error class and is always available; the
+                    // error buffer carries the TLS/OpenSSL detail, but libcurl only
+                    // fills it for some errors, so it cannot be the sole reason.
+                    m_lastError = "(" + std::to_string(static_cast<int>(code)) + ") " +
+                                  curl_easy_strerror(code);
+
+                    if (errorBuffer[0] != '\0')
+                    {
+                        m_lastError += ": ";
+                        m_lastError += errorBuffer;
+                    }
+
+                    char* url = nullptr;
+                    curl_easy_getinfo(m_handle, CURLINFO_EFFECTIVE_URL, &url);
+                    LOGFN_DEBUG1(m_logFn,
+                                 "libcurl failed on %s: %s",
+                                 url != nullptr ? url : "unknown URL",
+                                 m_lastError.c_str());
+                }
+
+                // libcurl kept the pointer rather than copying it, so drop it
+                // before the buffer goes out of scope.
+                curl_easy_setopt(m_handle, CURLOPT_ERRORBUFFER, nullptr);
+                return statusFromCurlCode(code);
             }
 
             long responseCode() override
@@ -314,11 +348,18 @@ namespace
                 return ip != nullptr ? std::string(ip) : std::string();
             }
 
+            std::string curlError() override
+            {
+                return m_lastError;
+            }
+
         private:
             CURL* m_handle {nullptr};
             curl_slist* m_headers {nullptr};
             FileSink m_fileSink {};
             HeaderCapture m_headerCapture {};
+            std::string m_lastError {}; ///< Last perform()'s reason, empty when it succeeded.
+            const LogFn m_logFn {HTTPS_CLIENT_LOGTAG};
     };
 } // namespace
 

--- a/src/client-agent/https_client/src/curlHandle.cpp
+++ b/src/client-agent/https_client/src/curlHandle.cpp
@@ -41,6 +41,16 @@ namespace
     static_assert(TLS_NATIVE_CA_STORE == CURLSSLOPT_NATIVE_CA,
                   "TLS_NATIVE_CA_STORE must stay equal to libcurl's CURLSSLOPT_NATIVE_CA");
 
+    /// One tag for the whole process: a handle is built per request, and LogFn owns a
+    /// std::string too long for the small-string buffer, so a member would cost an
+    /// allocation per request on the /stateless path. Never destroyed for the same
+    /// reason as optionMap() below.
+    const LogFn& handleLogFn()
+    {
+        static const LogFn* const logFn = new const LogFn {HTTPS_CLIENT_LOGTAG};
+        return *logFn;
+    }
+
     const std::map<CurlOption, CURLoption>& optionMap()
     {
         // Never destroyed, like the global curl init above: the shutdown drain reads
@@ -292,6 +302,8 @@ namespace
 
             TransportStatus perform() override
             {
+                m_lastError.clear();
+
                 if (m_headers != nullptr &&
                         curl_easy_setopt(m_handle, CURLOPT_HTTPHEADER, m_headers) != CURLE_OK)
                 {
@@ -301,12 +313,15 @@ namespace
                 // The CURLcode collapses into a coarse TransportStatus, so this is
                 // the only place the real cause exists: keep libcurl's own message.
                 char errorBuffer[CURL_ERROR_SIZE] {};
-                m_lastError.clear();
                 curl_easy_setopt(m_handle, CURLOPT_ERRORBUFFER, errorBuffer);
 
                 const CURLcode code = curl_easy_perform(m_handle);
 
-                if (code != CURLE_OK)
+                // A shutdown tripping the abort flag is not a transport failure, and
+                // Interrupted already says so: reporting "(42) Operation was aborted
+                // by callback" would only add libcurl's wording for what the caller
+                // asked for.
+                if (code != CURLE_OK && code != CURLE_ABORTED_BY_CALLBACK)
                 {
                     // strerror() names the error class and is always available; the
                     // error buffer carries the TLS/OpenSSL detail, but libcurl only
@@ -322,7 +337,7 @@ namespace
 
                     char* url = nullptr;
                     curl_easy_getinfo(m_handle, CURLINFO_EFFECTIVE_URL, &url);
-                    LOGFN_DEBUG1(m_logFn,
+                    LOGFN_DEBUG1(handleLogFn(),
                                  "libcurl failed on %s: %s",
                                  url != nullptr ? url : "unknown URL",
                                  m_lastError.c_str());
@@ -359,7 +374,6 @@ namespace
             FileSink m_fileSink {};
             HeaderCapture m_headerCapture {};
             std::string m_lastError {}; ///< Last perform()'s reason, empty when it succeeded.
-            const LogFn m_logFn {HTTPS_CLIENT_LOGTAG};
     };
 } // namespace
 

--- a/src/client-agent/https_client/src/curlPerformer.cpp
+++ b/src/client-agent/https_client/src/curlPerformer.cpp
@@ -140,6 +140,7 @@ HttpResponse CurlPerformer::perform(const HttpRequestSpec& spec)
     response.status = handle->perform();
     response.httpCode = handle->responseCode();
     response.localIp = handle->localIp();
+    response.curlError = handle->curlError();
     return response;
 }
 

--- a/src/client-agent/https_client/src/hcInterface.cpp
+++ b/src/client-agent/https_client/src/hcInterface.cpp
@@ -329,6 +329,8 @@ extern "C"
             result->http_code = response.httpCode;
             result->retry_after_seconds = response.retryAfterSeconds;
             std::strncpy(result->body, response.body.c_str(), sizeof(result->body) - 1);
+            std::strncpy(result->transport_error, response.curlError.c_str(),
+                         sizeof(result->transport_error) - 1);
 
             return response.httpCode != 0;
         }

--- a/src/client-agent/https_client/src/httpTypes.hpp
+++ b/src/client-agent/https_client/src/httpTypes.hpp
@@ -94,6 +94,13 @@ inline const char* outcomeName(OutcomeClass outcome)
     }
 }
 
+/// Suffix quoting libcurl's reason in a failure log, or nothing when there is
+/// none: an attempt the manager answered, or one that failed before libcurl ran.
+inline std::string transportReason(const std::string& curlError)
+{
+    return curlError.empty() ? std::string() : ": " + curlError;
+}
+
 /// Maps an OutcomeClass onto the hc_result_t that crosses the C ABI.
 inline int toHcResult(OutcomeClass outcome)
 {
@@ -176,6 +183,8 @@ struct HttpResponse
     std::string localIp;        ///< Local IP of the connection (CURLINFO_LOCAL_IP);
     ///< the agent's own address toward the manager.
     std::string body;
+    std::string curlError;      ///< libcurl's own wording for a failed attempt, empty
+    ///< otherwise (success, or a failure that never reached libcurl).
 };
 
 #endif // _HC_HTTP_TYPES_HPP

--- a/src/client-agent/https_client/src/iCurlHandle.hpp
+++ b/src/client-agent/https_client/src/iCurlHandle.hpp
@@ -116,6 +116,10 @@ class ICurlHandle
         virtual TransportStatus perform() = 0;
         virtual long responseCode() = 0;
         virtual std::string localIp() = 0; ///< CURLINFO_LOCAL_IP after perform().
+        /// libcurl's own reason for the last perform(), empty when it succeeded.
+        /// The error class plus, when libcurl supplied one, the TLS/OpenSSL detail
+        /// behind it -- the part TransportStatus cannot carry.
+        virtual std::string curlError() = 0;
 };
 
 using CurlHandleFactory = std::function<std::unique_ptr<ICurlHandle>()>;

--- a/src/client-agent/https_client/src/wpkFetcher.cpp
+++ b/src/client-agent/https_client/src/wpkFetcher.cpp
@@ -66,7 +66,7 @@ std::shared_ptr<SpoolFile> WpkFetcher::fetch(const std::string& wpkFile,
 
     if (result.outcome != OutcomeClass::Ok)
     {
-        LOGFN_WARN(m_logFn, "WPK download for '%s' failed (%s%s); aborting the upgrade "
+        LOGFN_WARN(m_logFn, "WPK download for '%s' failed (%s)%s; aborting the upgrade "
                    "(no /control response is sent; fire-and-forget).",
                    wpkFile.c_str(), outcomeName(result.outcome),
                    transportReason(result.response.curlError).c_str());

--- a/src/client-agent/https_client/src/wpkFetcher.cpp
+++ b/src/client-agent/https_client/src/wpkFetcher.cpp
@@ -66,9 +66,10 @@ std::shared_ptr<SpoolFile> WpkFetcher::fetch(const std::string& wpkFile,
 
     if (result.outcome != OutcomeClass::Ok)
     {
-        LOGFN_WARN(m_logFn, "WPK download for '%s' failed (%s); aborting the upgrade "
+        LOGFN_WARN(m_logFn, "WPK download for '%s' failed (%s%s); aborting the upgrade "
                    "(no /control response is sent; fire-and-forget).",
-                   wpkFile.c_str(), outcomeName(result.outcome));
+                   wpkFile.c_str(), outcomeName(result.outcome),
+                   transportReason(result.response.curlError).c_str());
         return nullptr;
     }
 

--- a/src/client-agent/https_client/tests/unit/callbackDispatcher_test.cpp
+++ b/src/client-agent/https_client/tests/unit/callbackDispatcher_test.cpp
@@ -85,6 +85,13 @@ namespace
         recordTag("buffer:" + std::to_string(level), static_cast<Record*>(userData));
     }
 
+    void recordProducerPause(bool paused, const char* reason, void* userData)
+    {
+        recordTag(std::string("pause:") + (paused ? "on:" : "off:") +
+                  (reason != nullptr ? reason : "(null)"),
+                  static_cast<Record*>(userData));
+    }
+
     hc_callbacks_t makeCallbacks(Record* record)
     {
         hc_callbacks_t callbacks {};
@@ -95,6 +102,7 @@ namespace
         callbacks.on_sync_response = recordSync;
         callbacks.on_state_change = recordState;
         callbacks.on_buffer_level = recordBuffer;
+        callbacks.on_producer_pause = recordProducerPause;
         callbacks.user_data = record;
         return callbacks;
     }
@@ -190,7 +198,8 @@ TEST(CallbackDispatcherTest, EveryCallbackKindIsForwarded)
     dispatcher.onSyncResponse("sess-1", 0, R"({"ok":true})");
     dispatcher.onStateChange(HC_STATE_REGISTERED);
     dispatcher.onBufferLevel(HC_BUFFER_WARNING);
-    waitForCount(record, 7);
+    dispatcher.onProducerPause(true, "(7) Couldn't connect to server");
+    waitForCount(record, 8);
     dispatcher.stop();
 
     EXPECT_NE(record.order.end(),
@@ -208,6 +217,11 @@ TEST(CallbackDispatcherTest, EveryCallbackKindIsForwarded)
     EXPECT_NE(record.order.end(),
               std::find(record.order.begin(), record.order.end(),
                         "buffer:" + std::to_string(HC_BUFFER_WARNING)));
+    // The reason crosses the ABI as const char*: assert the text survives the hop
+    // to the worker thread, not just that the callback fired.
+    EXPECT_NE(record.order.end(),
+              std::find(record.order.begin(), record.order.end(),
+                        "pause:on:(7) Couldn't connect to server"));
 }
 
 namespace

--- a/src/client-agent/https_client/tests/unit/controlStream_test.cpp
+++ b/src/client-agent/https_client/tests/unit/controlStream_test.cpp
@@ -34,13 +34,14 @@ using ::testing::Return;
 namespace
 {
     HttpResponse response(TransportStatus status, long code, const std::string& body = {},
-                          const std::string& localIp = {})
+                          const std::string& localIp = {}, const std::string& curlError = {})
     {
         HttpResponse value;
         value.status = status;
         value.httpCode = code;
         value.body = body;
         value.localIp = localIp;
+        value.curlError = curlError;
         return value;
     }
 
@@ -1029,7 +1030,7 @@ TEST_F(ControlStreamTest, ASingleUnreachableStepDoesNotPauseProducers)
     EXPECT_CALL(m_performer, perform(_))
     .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
     .WillRepeatedly(Return(response(TransportStatus::Timeout, 0)));
-    EXPECT_CALL(m_sink, onProducerPause(_)).Times(0);
+    EXPECT_CALL(m_sink, onProducerPause(_, _)).Times(0);
     m_waiter.script({true, true, true});
 
     m_stream.step(m_waiter); // Startup.
@@ -1067,13 +1068,13 @@ TEST_F(ControlStreamTest, ThresholdPausesOnceAndRecoveryReleasesWithoutAStateCha
 
     ::testing::InSequence sequence;
     EXPECT_CALL(m_sink, onStateChange(HC_STATE_REGISTERED)).Times(1);
-    EXPECT_CALL(m_sink, onProducerPause(true)).Times(1)
-    .WillOnce(Invoke([&](bool)
+    EXPECT_CALL(m_sink, onProducerPause(true, _)).Times(1)
+    .WillOnce(Invoke([&](bool, const std::string&)
     {
         pauses++;
     }));
-    EXPECT_CALL(m_sink, onProducerPause(false)).Times(1)
-    .WillOnce(Invoke([&](bool)
+    EXPECT_CALL(m_sink, onProducerPause(false, _)).Times(1)
+    .WillOnce(Invoke([&](bool, const std::string&)
     {
         resumes++;
     }));
@@ -1104,7 +1105,7 @@ TEST_F(ControlStreamTest, SelfClearingFailuresNeverPauseProducers)
     EXPECT_CALL(m_performer, perform(_))
     .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
     .WillRepeatedly(Return(response(TransportStatus::Ok, 500)));
-    EXPECT_CALL(m_sink, onProducerPause(_)).Times(0);
+    EXPECT_CALL(m_sink, onProducerPause(_, _)).Times(0);
     m_waiter.script({true, true, true, true, true, true, true, true, true});
 
     m_stream.step(m_waiter); // Startup.
@@ -1121,13 +1122,62 @@ TEST_F(ControlStreamTest, VersionRejectionPausesProducers)
     EXPECT_CALL(m_performer, perform(_))
     .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
     .WillRepeatedly(Return(response(TransportStatus::Ok, 409)));
-    EXPECT_CALL(m_sink, onProducerPause(true)).Times(1);
-    EXPECT_CALL(m_sink, onProducerPause(false)).Times(0);
+    EXPECT_CALL(m_sink, onProducerPause(true, _)).Times(1);
+    EXPECT_CALL(m_sink, onProducerPause(false, _)).Times(0);
 
     m_stream.step(m_waiter); // Startup accepted.
     m_stream.step(m_waiter); // 409: 1/2.
     m_stream.step(m_waiter); // 409: 2/2 -> pause.
     m_stream.step(m_waiter); // Still rejected: announced once only.
+}
+
+TEST_F(ControlStreamTest, PauseCarriesTheTransportReasonToTheConsumer)
+{
+    // Unreachable covers timeout/connect/DNS/TLS alike, so the consumer's own
+    // warning can only name the cause if the reason travels with the callback.
+    const std::string curlError = "(60) SSL peer certificate or SSH remote key was not OK";
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
+    .WillRepeatedly(Return(response(TransportStatus::TlsFail, 0, {}, {}, curlError)));
+
+    std::string reported;
+    EXPECT_CALL(m_sink, onProducerPause(true, _)).Times(1)
+    .WillOnce(Invoke([&](bool, const std::string & reason)
+    {
+        reported = reason;
+    }));
+    m_waiter.script({true, true, true, true, true, true, true});
+
+    m_stream.step(m_waiter); // Startup accepted.
+    m_stream.step(m_waiter); // 1/2.
+    m_stream.step(m_waiter); // 2/2 -> pause.
+
+    // Verbatim: the reason crosses as plain data, and each consumer decides how
+    // to word it into its own message.
+    EXPECT_EQ(curlError, reported);
+}
+
+TEST_F(ControlStreamTest, PauseFromAnAnsweredRejectionCarriesNoTransportReason)
+{
+    // A 409 means the manager answered, so any curl error still on the response
+    // is from an earlier, unrelated attempt -- quoting it would misattribute the
+    // pause to a transport problem that is not happening.
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
+    .WillRepeatedly(Return(response(TransportStatus::Ok, 409, {}, {}, "(7) Couldn't connect")));
+
+    std::string reported {"unset"};
+    EXPECT_CALL(m_sink, onProducerPause(true, _)).Times(1)
+    .WillOnce(Invoke([&](bool, const std::string & reason)
+    {
+        reported = reason;
+    }));
+
+    m_stream.step(m_waiter); // Startup accepted.
+    m_stream.step(m_waiter); // 409: 1/2.
+    m_stream.step(m_waiter); // 409: 2/2 -> pause.
+
+    EXPECT_TRUE(reported.empty());
 }
 
 TEST_F(ControlStreamTest, LatchedAuthFailurePausesProducersAcrossGatedCycles)
@@ -1143,12 +1193,12 @@ TEST_F(ControlStreamTest, LatchedAuthFailurePausesProducersAcrossGatedCycles)
     // is the whole claim: without counting gated cycles the streak would freeze
     // at 1 and never arm, and a total of one would not distinguish the two.
     int pauses = 0;
-    EXPECT_CALL(m_sink, onProducerPause(true)).Times(1)
-    .WillOnce(Invoke([&](bool)
+    EXPECT_CALL(m_sink, onProducerPause(true, _)).Times(1)
+    .WillOnce(Invoke([&](bool, const std::string&)
     {
         pauses++;
     }));
-    EXPECT_CALL(m_sink, onProducerPause(false)).Times(0);
+    EXPECT_CALL(m_sink, onProducerPause(false, _)).Times(0);
 
     m_stream.step(m_waiter); // Startup accepted.
 
@@ -1180,9 +1230,9 @@ TEST_F(ControlStreamTest, ANewKeyClearsTheAuthPauseAndResumesProducers)
     int resumes = 0;
 
     ::testing::InSequence sequence;
-    EXPECT_CALL(m_sink, onProducerPause(true)).Times(1);
-    EXPECT_CALL(m_sink, onProducerPause(false)).Times(1)
-    .WillOnce(Invoke([&](bool)
+    EXPECT_CALL(m_sink, onProducerPause(true, _)).Times(1);
+    EXPECT_CALL(m_sink, onProducerPause(false, _)).Times(1)
+    .WillOnce(Invoke([&](bool, const std::string&)
     {
         resumes++;
     }));
@@ -1207,7 +1257,7 @@ TEST_F(ControlStreamTest, AnInterruptedAttemptIsNotAConfirmedDisconnect)
     EXPECT_CALL(m_performer, perform(_))
     .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
     .WillRepeatedly(Return(response(TransportStatus::Timeout, 0)));
-    EXPECT_CALL(m_sink, onProducerPause(_)).Times(0);
+    EXPECT_CALL(m_sink, onProducerPause(_, _)).Times(0);
 
     m_stream.step(m_waiter); // Startup.
     m_stream.step(m_waiter); // Interrupted.
@@ -1229,12 +1279,12 @@ TEST_F(ControlStreamTest, AFailingShutdownDoesNotCountTowardTheThreshold)
     EXPECT_CALL(m_performer, perform(_))
     .WillOnce(Return(response(TransportStatus::Ok, 200, "{}")))
     .WillRepeatedly(Return(response(TransportStatus::Timeout, 0)));
-    EXPECT_CALL(m_sink, onProducerPause(true)).Times(1)
-    .WillOnce(Invoke([&](bool)
+    EXPECT_CALL(m_sink, onProducerPause(true, _)).Times(1)
+    .WillOnce(Invoke([&](bool, const std::string&)
     {
         pauses++;
     }));
-    EXPECT_CALL(m_sink, onProducerPause(false)).Times(0);
+    EXPECT_CALL(m_sink, onProducerPause(false, _)).Times(0);
     m_waiter.script({true, true, true, true, true, true});
 
     m_stream.step(m_waiter);      // Startup accepted.

--- a/src/client-agent/https_client/tests/unit/curlPerformer_test.cpp
+++ b/src/client-agent/https_client/tests/unit/curlPerformer_test.cpp
@@ -277,10 +277,14 @@ TEST(CurlPerformerTest, RejectedTlsOptionAbortsBeforePerforming)
     // What a backend that does not implement the option answers.
     EXPECT_CALL(*handle, setOptionLong(CurlOption::SslVersion, _)).WillOnce(Return(false));
     EXPECT_CALL(*handle, perform()).Times(0);
+    EXPECT_CALL(*handle, curlError()).Times(0);
 
     auto performer = makePerformer(makeConfig(HC_VERIFY_FULL), std::move(mock));
     const auto response = performer.perform(HttpRequestSpec {});
     EXPECT_EQ(TransportStatus::TlsFail, response.status);
+    // Nothing ran, so there is no libcurl reason: the log sites must render a
+    // bare outcome rather than a dangling separator.
+    EXPECT_TRUE(response.curlError.empty());
 }
 
 TEST(CurlPerformerTest, RejectedCipherListAbortsBeforePerforming)

--- a/src/client-agent/https_client/tests/unit/hcInterface_test.cpp
+++ b/src/client-agent/https_client/tests/unit/hcInterface_test.cpp
@@ -372,6 +372,11 @@ TEST(HcEnrollTest, UnreachableServerReturnsFalseWithZeroHttpCode)
     hc_enroll_result_t result {};
     EXPECT_FALSE(hc_enroll(&config, &request, &result));
     EXPECT_EQ(0, result.http_code);
+    // http_code == 0 says only "nothing answered", which an operator cannot act
+    // on: the reason is what separates a down manager from a rejected
+    // certificate. Not matched exactly -- libcurl and OpenSSL reword these
+    // between versions and platforms.
+    EXPECT_STRNE("", result.transport_error);
 }
 
 TEST(HcEnrollTest, InvalidTransportConfigIsRejectedBeforeSending)
@@ -385,4 +390,8 @@ TEST(HcEnrollTest, InvalidTransportConfigIsRejectedBeforeSending)
     hc_enroll_result_t result {};
     EXPECT_FALSE(hc_enroll(&config, &request, &result));
     EXPECT_EQ(0, result.http_code);
+    // libcurl never ran, so it has no opinion to report; validateTransport()
+    // logged the real reason itself, and the caller falls back to its own
+    // wording rather than printing an empty one.
+    EXPECT_STREQ("", result.transport_error);
 }

--- a/src/client-agent/https_client/tests/unit/mocks/mockCallbackSink.hpp
+++ b/src/client-agent/https_client/tests/unit/mocks/mockCallbackSink.hpp
@@ -40,7 +40,7 @@ class MockCallbackSink : public ICallbackSink
                     (const std::string& sessionId, int result, const std::string& body), (override));
         MOCK_METHOD(void, onStateChange, (hc_conn_state_t state), (override));
         MOCK_METHOD(void, onBufferLevel, (hc_buffer_level_t level), (override));
-        MOCK_METHOD(void, onProducerPause, (bool paused), (override));
+        MOCK_METHOD(void, onProducerPause, (bool paused, const std::string& reason), (override));
 };
 
 #endif // _HC_MOCK_CALLBACK_SINK_HPP

--- a/src/client-agent/https_client/tests/unit/mocks/mockCurlHandle.hpp
+++ b/src/client-agent/https_client/tests/unit/mocks/mockCurlHandle.hpp
@@ -57,6 +57,7 @@ class MockCurlHandle : public ICurlHandle
         MOCK_METHOD(TransportStatus, perform, (), (override));
         MOCK_METHOD(long, responseCode, (), (override));
         MOCK_METHOD(std::string, localIp, (), (override));
+        MOCK_METHOD(std::string, curlError, (), (override));
 };
 
 #endif // _HC_MOCK_CURL_HANDLE_HPP

--- a/src/client-agent/src/enrollment.c
+++ b/src/client-agent/src/enrollment.c
@@ -110,7 +110,7 @@ w_enroll_status_t w_enrollment_process_response(const hc_enroll_result_t *result
     if (result->http_code == 0) {
         /* Enrollment is the first thing an agent does, so a misconfigured CA or an
          * unreachable manager surfaces here before anything else. */
-        merror("Enrollment request could not be sent: %s",
+        merror("Enrollment request could not be sent: %s.",
                result->transport_error[0] != '\0' ? result->transport_error
                                                  : "transport or configuration error");
         return W_ENROLL_ERR_TRANSPORT;

--- a/src/client-agent/src/enrollment.c
+++ b/src/client-agent/src/enrollment.c
@@ -108,7 +108,11 @@ w_enroll_status_t w_enrollment_process_response(const hc_enroll_result_t *result
     assert(result != NULL);
 
     if (result->http_code == 0) {
-        merror("Enrollment request could not be sent (transport or configuration error).");
+        /* Enrollment is the first thing an agent does, so a misconfigured CA or an
+         * unreachable manager surfaces here before anything else. */
+        merror("Enrollment request could not be sent: %s",
+               result->transport_error[0] != '\0' ? result->transport_error
+                                                 : "transport or configuration error");
         return W_ENROLL_ERR_TRANSPORT;
     }
 

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -1261,12 +1261,16 @@ static char *bridge_collect_stats(void *user_data)
     return w_agent_collect_stats();
 }
 
-static void bridge_on_producer_pause(bool paused, void *user_data)
+static void bridge_on_producer_pause(bool paused, const char *reason, void *user_data)
 {
     (void)user_data;
 
     if (paused) {
-        mwarn(SERVER_UNAV);
+        if (reason && *reason) {
+            mwarn(SERVER_UNAV " Reason: %s", reason);
+        } else {
+            mwarn(SERVER_UNAV);
+        }
         os_setwait();
         w_agentd_state_update(UPDATE_STATUS, (void *) GA_STATUS_NACTIVE);
     } else {

--- a/src/unit_tests/client-agent/test_enrollment.c
+++ b/src/unit_tests/client-agent/test_enrollment.c
@@ -254,8 +254,25 @@ static void test_process_response_no_http_status_is_transport_error(void **state
     hc_enroll_result_t result = {0};
     result.http_code = 0;
 
+    /* No transport_error: the attempt never reached libcurl, so the module has
+     * already logged the real reason and the coarse wording is all that is left. */
     expect_string(__wrap__merror, formatted_msg,
-                  "Enrollment request could not be sent (transport or configuration error).");
+                  "Enrollment request could not be sent: transport or configuration error");
+
+    assert_int_equal(w_enrollment_process_response(&result), W_ENROLL_ERR_TRANSPORT);
+}
+
+static void test_process_response_transport_error_names_the_cause(void **state) {
+    (void)state;
+    hc_enroll_result_t result = {0};
+    result.http_code = 0;
+    strncpy(result.transport_error, "(60) SSL peer certificate or SSH remote key was not OK",
+            sizeof(result.transport_error) - 1);
+
+    /* The whole point: a misconfigured CA and an unreachable manager are both
+     * http_code == 0, and only this string tells them apart. */
+    expect_string(__wrap__merror, formatted_msg,
+                  "Enrollment request could not be sent: (60) SSL peer certificate or SSH remote key was not OK");
 
     assert_int_equal(w_enrollment_process_response(&result), W_ENROLL_ERR_TRANSPORT);
 }
@@ -348,6 +365,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_build_request_reads_password_from_file, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_build_request_no_password_file_yields_null_password, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_process_response_no_http_status_is_transport_error, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_process_response_transport_error_names_the_cause, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_process_response_400_is_invalid_request, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_process_response_401_is_auth_error, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_process_response_403_is_disabled_not_an_error, setup_test, teardown_test),

--- a/src/unit_tests/client-agent/test_enrollment.c
+++ b/src/unit_tests/client-agent/test_enrollment.c
@@ -257,7 +257,7 @@ static void test_process_response_no_http_status_is_transport_error(void **state
     /* No transport_error: the attempt never reached libcurl, so the module has
      * already logged the real reason and the coarse wording is all that is left. */
     expect_string(__wrap__merror, formatted_msg,
-                  "Enrollment request could not be sent: transport or configuration error");
+                  "Enrollment request could not be sent: transport or configuration error.");
 
     assert_int_equal(w_enrollment_process_response(&result), W_ENROLL_ERR_TRANSPORT);
 }
@@ -272,7 +272,7 @@ static void test_process_response_transport_error_names_the_cause(void **state) 
     /* The whole point: a misconfigured CA and an unreachable manager are both
      * http_code == 0, and only this string tells them apart. */
     expect_string(__wrap__merror, formatted_msg,
-                  "Enrollment request could not be sent: (60) SSL peer certificate or SSH remote key was not OK");
+                  "Enrollment request could not be sent: (60) SSL peer certificate or SSH remote key was not OK.");
 
     assert_int_equal(w_enrollment_process_response(&result), W_ENROLL_ERR_TRANSPORT);
 }

--- a/src/unit_tests/client-agent/test_https_client_bridge.c
+++ b/src/unit_tests/client-agent/test_https_client_bridge.c
@@ -1004,12 +1004,33 @@ static void test_producer_pause_arms_the_lock_and_reports_disconnected(void **st
     (void)state;
     start_client_successfully();
 
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "Manager unreachable. Pausing module event production. Reason: (60) SSL peer "
+                  "certificate or SSH remote key was not OK");
+    expect_function_call(__wrap_os_setwait);
+    expect_value(__wrap_w_agentd_state_update, type, UPDATE_STATUS);
+    expect_value(__wrap_w_agentd_state_update, data, GA_STATUS_NACTIVE);
+
+    g_captured_callbacks.on_producer_pause(true, "(60) SSL peer certificate or SSH remote key was not OK",
+                                          g_captured_callbacks.user_data);
+
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+    w_https_client_stop();
+}
+
+/* The reason is empty whenever the module has nothing to add -- a pause armed by
+ * an answered rejection rather than a transport failure. */
+static void test_producer_pause_without_a_reason_logs_the_bare_message(void **state)
+{
+    (void)state;
+    start_client_successfully();
+
     expect_string(__wrap__mwarn, formatted_msg, "Manager unreachable. Pausing module event production.");
     expect_function_call(__wrap_os_setwait);
     expect_value(__wrap_w_agentd_state_update, type, UPDATE_STATUS);
     expect_value(__wrap_w_agentd_state_update, data, GA_STATUS_NACTIVE);
 
-    g_captured_callbacks.on_producer_pause(true, g_captured_callbacks.user_data);
+    g_captured_callbacks.on_producer_pause(true, "", g_captured_callbacks.user_data);
 
     expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
     w_https_client_stop();
@@ -1027,7 +1048,7 @@ static void test_producer_pause_release_clears_the_lock_and_reports_connected(vo
     expect_value(__wrap_w_agentd_state_update, type, UPDATE_STATUS);
     expect_value(__wrap_w_agentd_state_update, data, GA_STATUS_ACTIVE);
 
-    g_captured_callbacks.on_producer_pause(false, g_captured_callbacks.user_data);
+    g_captured_callbacks.on_producer_pause(false, "", g_captured_callbacks.user_data);
 
     expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
     w_https_client_stop();
@@ -2382,6 +2403,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_registered_state_maps_to_active, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_registered_state_twice_clears_wait_file_each_time, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_producer_pause_arms_the_lock_and_reports_disconnected, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_producer_pause_without_a_reason_logs_the_bare_message, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_producer_pause_release_clears_the_lock_and_reports_connected, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_starting_state_maps_to_pending, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_stopped_state_maps_to_nactive, setup_test, teardown_test),

--- a/src/unit_tests/client-agent/test_https_client_bridge.c
+++ b/src/unit_tests/client-agent/test_https_client_bridge.c
@@ -998,8 +998,9 @@ static void test_registered_state_twice_clears_wait_file_each_time(void **state)
 }
 
 /* on_producer_pause: the confirmed-disconnect pause. Both directions move the
- * lock and the .state status together. */
-static void test_producer_pause_arms_the_lock_and_reports_disconnected(void **state)
+ * lock and the .state status together; the two pause cases below differ only in
+ * whether the module handed over a transport reason to name. */
+static void test_producer_pause_with_a_reason_names_the_cause(void **state)
 {
     (void)state;
     start_client_successfully();
@@ -2402,7 +2403,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_reenroll_thread_logs_error_when_new_key_fails_validation, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_registered_state_maps_to_active, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_registered_state_twice_clears_wait_file_each_time, setup_test, teardown_test),
-        cmocka_unit_test_setup_teardown(test_producer_pause_arms_the_lock_and_reports_disconnected, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_producer_pause_with_a_reason_names_the_cause, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_producer_pause_without_a_reason_logs_the_bare_message, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_producer_pause_release_clears_the_lock_and_reports_connected, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_starting_state_maps_to_pending, setup_test, teardown_test),


### PR DESCRIPTION
## Description
Adds logging for transport errors. During #38527 a TLS error was making the `/control` https connection fail, and the agent's logs only showed an `Unreachable` message. `Unreachable` in the current implementation can mean timeout / connect / DNS / TLS / or other transport error. We're logging the transport errors returned by CURL to help the user distinguish between each one of the error types.

## Proposed Changes
Log the errors returned by the CURL calls instead of swallowing them, and carry the reason all the way to the warning the operator already sees. Each individual attempt is logged at `DEBUG`, so the four `/control` retries stay out of a default-level log. When the retries are exhausted and the agent gives up and pauses event production, the existing `Manager unreachable. Pausing module event production.` warning now names the transport failure behind it, so no `agentd.debug=1` is needed to tell a TLS rejection apart from a timeout or a DNS failure.

The same reason is appended to the existing failure logs of the other endpoints that already reported an outcome without one: the `/control` shutdown notification, the WPK download, and the group-config download.

`/enroll` gets the same treatment, and it is the case that benefits most. A failed enrollment already logged at `ERROR`, but with a message that admitted it was guessing — `Enrollment request could not be sent (transport or configuration error).` — and enrollment is the first thing an agent does, so a misconfigured CA breaks it before `/control` ever runs. It now names the cause instead.

### Results and Evidence
Tested against a real manager by first setting inside the agent's `ossec.conf` the `<verification_mode>full</verification_mode>` and a certificate that the manager doesn't trust:
`<certificate_authorities>/etc/ssl/certs/ca-certificates.crt</certificate_authorities>`

#### /enroll
An `/enroll` failure will now include the libcurl failure reason: 
`ERROR: Enrollment request could not be sent: (60) SSL peer certificate or SSH remote key was not OK: SSL: no alternative certificate subject name matches target ipv4 address '192.168.0.60'`

<details> <summary>Full log section:</summary>

```
ossec.log         2026/08/25 12:31:52 wazuh-agentd:https-client[90741] curlHandle.cpp:325 at perform(): DEBUG: libcurl failed on https://192.168.0.60:1517/enroll: (60) SSL peer certificate or SSH remote key was not OK: SSL: no alternative certificate subject name matches target ipv4 address '192.168.0.60'
ossec.log         2026/08/25 12:31:52 wazuh-agentd[90741] enrollment.c:113 at w_enrollment_process_response(): ERROR: Enrollment request could not be sent: (60) SSL peer certificate or SSH remote key was not OK: SSL: no alternative certificate subject name matches target ipv4 address '192.168.0.60'
```
</details>

#### /control
The emmitted `WARN` now contains the libcurl failure reason: 
`WARNING: Manager unreachable. Pausing module event production. Reason: (60) SSL peer certificate or SSH remote key was not OK: SSL: no alternative certificate subject name matches target ipv4 address '192.168.0.60'`

And if we enable DEBUG=1, we see each libcurl attempt and the `/control` attemtps, both containing the libcurl reason also:
```
DEBUG: libcurl failed on https://192.168.0.60:1517/control: (60) SSL peer certificate or SSH remote key was not OK: SSL: no alternative certificate subject name matches target ipv4 address '192.168.0.60'
DEBUG: /control undeliverable (Unreachable) (1/2): (60) SSL peer certificate or SSH remote key was not OK: SSL: no alternative certificate subject name matches target ipv4 address '192.168.0.60'

```

<details> <summary>Full log section:</summary>

```
2026/08/25 12:43:25 wazuh-agentd:https-client[107767] curlHandle.cpp:325 at perform(): DEBUG: libcurl failed on https://192.168.0.60:1517/control: (60) SSL peer certificate or SSH remote key was not OK: SSL: no alternative certificate subject name matches target ipv4 address '192.168.0.60'
2026/08/25 12:43:26 wazuh-agentd:https-client[107767] curlHandle.cpp:325 at perform(): DEBUG: libcurl failed on https://192.168.0.60:1517/control: (60) SSL peer certificate or SSH remote key was not OK: SSL: no alternative certificate subject name matches target ipv4 address '192.168.0.60'
2026/08/25 12:43:28 wazuh-agentd:https-client[107767] curlHandle.cpp:325 at perform(): DEBUG: libcurl failed on https://192.168.0.60:1517/control: (60) SSL peer certificate or SSH remote key was not OK: SSL: no alternative certificate subject name matches target ipv4 address '192.168.0.60'
2026/08/25 12:43:31 wazuh-agentd:https-client[107767] curlHandle.cpp:325 at perform(): DEBUG: libcurl failed on https://192.168.0.60:1517/control: (60) SSL peer certificate or SSH remote key was not OK: SSL: no alternative certificate subject name matches target ipv4 address '192.168.0.60'
2026/08/25 12:43:31 wazuh-agentd:https-client[107767] controlStream.cpp:642 at updateProducerPause(): DEBUG: /control undeliverable (Unreachable) (1/2): (60) SSL peer certificate or SSH remote key was not OK: SSL: no alternative certificate subject name matches target ipv4 address '192.168.0.60'
2026/08/25 12:43:41 wazuh-agentd:https-client[107767] curlHandle.cpp:325 at perform(): DEBUG: libcurl failed on https://192.168.0.60:1517/control: (60) SSL peer certificate or SSH remote key was not OK: SSL: no alternative certificate subject name matches target ipv4 address '192.168.0.60'
2026/08/25 12:43:45 wazuh-agentd:https-client[107767] curlHandle.cpp:325 at perform(): DEBUG: libcurl failed on https://192.168.0.60:1517/control: (60) SSL peer certificate or SSH remote key was not OK: SSL: no alternative certificate subject name matches target ipv4 address '192.168.0.60'
2026/08/25 12:43:51 wazuh-agentd:https-client[107767] curlHandle.cpp:325 at perform(): DEBUG: libcurl failed on https://192.168.0.60:1517/control: (60) SSL peer certificate or SSH remote key was not OK: SSL: no alternative certificate subject name matches target ipv4 address '192.168.0.60'
2026/08/25 12:44:00 wazuh-agentd:https-client[107767] curlHandle.cpp:325 at perform(): DEBUG: libcurl failed on https://192.168.0.60:1517/control: (60) SSL peer certificate or SSH remote key was not OK: SSL: no alternative certificate subject name matches target ipv4 address '192.168.0.60'
2026/08/25 12:44:00 wazuh-agentd:https-client[107767] controlStream.cpp:651 at updateProducerPause(): DEBUG: /control undeliverable (Unreachable) (2/2); pausing event production: (60) SSL peer certificate or SSH remote key was not OK: SSL: no alternative certificate subject name matches target ipv4 address '192.168.0.60'
2026/08/25 12:44:00 wazuh-agentd[107767] https_client_bridge.c:1270 at bridge_on_producer_pause(): WARNING: Manager unreachable. Pausing module event production. Reason: (60) SSL peer certificate or SSH remote key was not OK: SSL: no alternative certificate subject name matches target ipv4 address '192.168.0.60'
```

</details>

### Artifacts Affected

None

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced
Unit tests covering that the reason reaches the response, that it survives the trip to both consumers (the producer-pause warning and the enrollment error), and that it is left out when the failure was not a transport one or never reached libcurl at all. Nothing asserts on strings produced by OpenSSL — those change between versions and OS's, so the tests either inject their own reason or assert only that one arrived.

## Review Checklist

<!--
List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
