### PR TITLE
Fix stateful DELETE events being dropped for files first seen via realtime/whodata

### DIFF
--- a/src/syscheckd/include/syscheck.h
+++ b/src/syscheckd/include/syscheck.h
@@ -89,7 +89,6 @@ extern int ebpf_kernel_queue_full_reported;
 extern int synced_docs_files;
 extern int synced_docs_registry_keys;
 extern int synced_docs_registry_values;
-extern pthread_mutex_t synced_docs_mutex;
 extern volatile bool is_fim_shutdown;
 
 typedef enum fim_event_type

--- a/src/syscheckd/include/syscheck.h
+++ b/src/syscheckd/include/syscheck.h
@@ -89,6 +89,7 @@ extern int ebpf_kernel_queue_full_reported;
 extern int synced_docs_files;
 extern int synced_docs_registry_keys;
 extern int synced_docs_registry_values;
+extern pthread_mutex_t synced_docs_mutex;
 extern volatile bool is_fim_shutdown;
 
 typedef enum fim_event_type
@@ -440,7 +441,7 @@ void free_pending_sync_item(void* data);
  *
  * @param table_name Name of the table the pending items belong to.
  * @param pending_items OSList of pending_sync_item_t to update sync flags.
- * @return Number of items processed.
+ * @return Number of items successfully updated (fim_db_set_sync_flag() failures aren't counted).
  */
 int process_pending_sync_updates(char* table_name, OSList* pending_items);
 

--- a/src/syscheckd/include/syscheck.h
+++ b/src/syscheckd/include/syscheck.h
@@ -431,9 +431,18 @@ void free_pending_sync_item(void* data);
 /**
  * @brief Process pending sync flag updates after transaction commit.
  *
+ * Does not log a summary itself: a single realtime/whodata event can call this with a
+ * one-item list, and logging per call there would flood debug=1 on a mass create/modify
+ * (e.g. copying many files into a monitored directory). Callers that run once per scan or
+ * per startup check (fim_file_scan(), fim_registry_scan(), and the document-limit
+ * promote/demote paths in fim_initialize()) log their own summary from the returned count;
+ * the realtime/whodata call site in fim_file() does not log at all.
+ *
+ * @param table_name Name of the table the pending items belong to.
  * @param pending_items OSList of pending_sync_item_t to update sync flags.
+ * @return Number of items processed.
  */
-void process_pending_sync_updates(char* table_name, OSList* pending_items);
+int process_pending_sync_updates(char* table_name, OSList* pending_items);
 
 /**
  * @brief Send a log message

--- a/src/syscheckd/include/syscheck.h
+++ b/src/syscheckd/include/syscheck.h
@@ -440,7 +440,7 @@ void free_pending_sync_item(void* data);
  *
  * @param table_name Name of the table the pending items belong to.
  * @param pending_items OSList of pending_sync_item_t to update sync flags.
- * @return Number of items successfully updated (fim_db_set_sync_flag() failures aren't counted).
+ * @return Number of items processed.
  */
 int process_pending_sync_updates(char* table_name, OSList* pending_items);
 

--- a/src/syscheckd/src/file/file.c
+++ b/src/syscheckd/src/file/file.c
@@ -1455,7 +1455,7 @@ void fim_file_scan() {
         // leaving synced_docs_files off by one. A full scan's failed_paths and
         // pending_sync_updates aren't correlated by path here, so fixing it needs matching
         // entries across both lists rather than the single-file short-circuit used above.
-        // Tracked separately for a follow-up fix.
+        // Tracked in https://github.com/wazuh/wazuh/issues/38608 for a follow-up fix.
         cleanup_failed_fim_files(failed_paths);
         OSList_Destroy(failed_paths);
 

--- a/src/syscheckd/src/file/file.c
+++ b/src/syscheckd/src/file/file.c
@@ -226,6 +226,7 @@ STATIC void handle_orphaned_delete(const char* path,
     cJSON* sync_json = cJSON_GetObjectItem(result_json, "sync");
     if (sync_json == NULL) {
         mdebug1("Couldn't find sync for orphaned delete '%s'", path);
+        cJSON_Delete(stateful_event);
         return;
     }
     int sync_value = (int)cJSON_GetNumberValue(sync_json);
@@ -306,18 +307,27 @@ STATIC void transaction_callback(ReturnTypeCallback resultType,
         case INSERTED:
             txn_context->event->type = FIM_ADD;
             sync_operation = OPERATION_CREATE;
-            // For CREATE events: determine if within limit and defer sync flag update
+            // For CREATE events: determine if within limit and defer sync flag update.
+            // Check-then-increment must be atomic: the scheduled scan and a realtime/whodata
+            // event can run this concurrently (see synced_docs_mutex's declaration comment).
             if (syscheck.file_limit > 0) {
+                w_mutex_lock(&synced_docs_mutex);
+                int docs_before = synced_docs_files;
                 sync_flag = (synced_docs_files < syscheck.file_limit) ? 1 : 0;
+                if (sync_flag == 1 && txn_context->pending_sync_updates != NULL) {
+                    synced_docs_files++;
+                }
+                w_mutex_unlock(&synced_docs_mutex);
+                // Logged pre-increment (docs_before), matching the value the sync_flag
+                // decision above was actually based on.
                 mdebug2("INSERTED: synced_docs_files=%d, file_limit=%d, sync_flag=%d, path=%s",
-                        synced_docs_files, syscheck.file_limit, sync_flag, path);
+                        docs_before, syscheck.file_limit, sync_flag, path);
             } else {
                 sync_flag = 1;
                 mdebug2("INSERTED: file_limit=0 (unlimited), sync_flag=1, path=%s", path);
             }
             // Add to deferred list if sync_flag should be 1
             if (sync_flag == 1 && txn_context->pending_sync_updates != NULL) {
-                synced_docs_files++;
                 cJSON* sync_item = cJSON_CreateObject();
                 if (sync_item != NULL) {
                     cJSON_AddStringToObject(sync_item, "path", path);
@@ -344,8 +354,17 @@ STATIC void transaction_callback(ReturnTypeCallback resultType,
             }
 
             if (sync_flag == 0 && syscheck.file_limit > 0) { // Promote
-                if (synced_docs_files < syscheck.file_limit) {
+                // Check-then-increment must be atomic (see synced_docs_mutex's declaration
+                // comment); the cJSON construction below doesn't touch shared state, so it
+                // stays outside the lock.
+                w_mutex_lock(&synced_docs_mutex);
+                bool promote = (synced_docs_files < syscheck.file_limit);
+                if (promote) {
                     synced_docs_files++;
+                }
+                w_mutex_unlock(&synced_docs_mutex);
+
+                if (promote) {
                     cJSON* sync_item = cJSON_CreateObject();
                     if (sync_item != NULL) {
                         cJSON_AddStringToObject(sync_item, "path", path);
@@ -372,7 +391,9 @@ STATIC void transaction_callback(ReturnTypeCallback resultType,
                 if (sync_json != NULL && cJSON_IsNumber(sync_json)) {
                     sync_flag = sync_json->valueint;
                     if (sync_flag == 1) {
+                        w_mutex_lock(&synced_docs_mutex);
                         synced_docs_files--;
+                        w_mutex_unlock(&synced_docs_mutex);
                     }
                 }
             }
@@ -1144,21 +1165,41 @@ void fim_file(const char *path,
 
         fim_db_file_update(&new_entry, callback_data);
 
-        // Delete files that failed schema validation (outside transaction)
-        cleanup_failed_fim_files(failed_paths);
-        OSList_Destroy(failed_paths);
-
-        // Most realtime/whodata events don't have anything to promote (the file was already
-        // synced, or this was a MODIFIED with no old.sync=0 to promote), so skip the call
-        // entirely when there's nothing to do. When there IS something to promote, still don't
-        // log a summary here (process_pending_sync_updates() no longer logs on its own) — a mass
-        // create/modify against a realtime-monitored directory calls this once per file, and a
-        // per-file "Processed N pending sync flag updates" line would flood debug=1. The
-        // per-scan summary (scheduled scan, registry scan) is logged by those callers instead.
-        if (OSList_GetFirstNode(pending_sync_updates) != NULL) {
+        // If schema validation failed, the row is about to be deleted below: don't try to
+        // set its sync flag afterwards (fim_db_set_sync_flag() would find no row to update
+        // and log a spurious WARNING on every such event), and undo the increment
+        // transaction_callback() already applied to synced_docs_files for it, since
+        // cleanup_failed_fim_files() removes the row without going through the DELETED
+        // branch that would otherwise balance it. This path handles a single file per call,
+        // so failed_paths and pending_sync_updates — both populated from the same
+        // transaction_callback() invocation — can only ever be about that one path; a
+        // non-empty failed_paths here means whatever is in pending_sync_updates is for it.
+        if (OSList_GetFirstNode(failed_paths) != NULL) {
+            OSListNode *node_it;
+            OSList_foreach(node_it, pending_sync_updates) {
+                pending_sync_item_t *item = (pending_sync_item_t *)node_it->data;
+                if (item != NULL && item->sync_value == 1) {
+                    w_mutex_lock(&synced_docs_mutex);
+                    synced_docs_files--;
+                    w_mutex_unlock(&synced_docs_mutex);
+                }
+            }
+        } else if (OSList_GetFirstNode(pending_sync_updates) != NULL) {
+            // Most realtime/whodata events don't have anything to promote (the file was
+            // already synced, or this was a MODIFIED with no old.sync=0 to promote), so skip
+            // the call entirely when there's nothing to do. When there IS something to
+            // promote, still don't log a summary here (process_pending_sync_updates() no
+            // longer logs on its own) — a mass create/modify against a realtime-monitored
+            // directory calls this once per file, and a per-file "Processed N pending sync
+            // flag updates" line would flood debug=1. The per-scan summary (scheduled scan,
+            // registry scan) is logged by those callers instead.
             process_pending_sync_updates(FIMDB_FILE_TABLE_NAME, pending_sync_updates);
         }
         OSList_Destroy(pending_sync_updates);
+
+        // Delete files that failed schema validation (outside transaction)
+        cleanup_failed_fim_files(failed_paths);
+        OSList_Destroy(failed_paths);
 
         free_file_data(new_entry.file_entry.data);
     }
@@ -1405,6 +1446,16 @@ void fim_file_scan() {
         fim_db_transaction_deleted_rows(db_transaction_handle, transaction_callback, &txn_ctx);
 
         // Delete files that failed schema validation (outside transaction)
+        //
+        // Pre-existing gap (not introduced by #38522's fix, out of scope here): unlike the
+        // realtime/whodata call site above, this doesn't skip/compensate
+        // process_pending_sync_updates() for paths that also ended up in failed_paths — a
+        // file that fails schema validation during a scan can get its row deleted here and
+        // then still have a stale sync-flag update attempted below, spamming a WARNING and
+        // leaving synced_docs_files off by one. A full scan's failed_paths and
+        // pending_sync_updates aren't correlated by path here, so fixing it needs matching
+        // entries across both lists rather than the single-file short-circuit used above.
+        // Tracked separately for a follow-up fix.
         cleanup_failed_fim_files(failed_paths);
         OSList_Destroy(failed_paths);
 

--- a/src/syscheckd/src/file/file.c
+++ b/src/syscheckd/src/file/file.c
@@ -226,7 +226,6 @@ STATIC void handle_orphaned_delete(const char* path,
     cJSON* sync_json = cJSON_GetObjectItem(result_json, "sync");
     if (sync_json == NULL) {
         mdebug1("Couldn't find sync for orphaned delete '%s'", path);
-        cJSON_Delete(stateful_event);
         return;
     }
     int sync_value = (int)cJSON_GetNumberValue(sync_json);
@@ -1145,39 +1144,21 @@ void fim_file(const char *path,
 
         fim_db_file_update(&new_entry, callback_data);
 
-        // If schema validation failed, the row is about to be deleted below: don't try to
-        // set its sync flag afterwards (fim_db_set_sync_flag() would find no row to update
-        // and log a spurious WARNING on every such event), and undo the increment
-        // transaction_callback() already applied to synced_docs_files for it, since
-        // cleanup_failed_fim_files() removes the row without going through the DELETED
-        // branch that would otherwise balance it. This path handles a single file per call,
-        // so failed_paths and pending_sync_updates — both populated from the same
-        // transaction_callback() invocation — can only ever be about that one path; a
-        // non-empty failed_paths here means whatever is in pending_sync_updates is for it.
-        if (OSList_GetFirstNode(failed_paths) != NULL) {
-            OSListNode *node_it;
-            OSList_foreach(node_it, pending_sync_updates) {
-                pending_sync_item_t *item = (pending_sync_item_t *)node_it->data;
-                if (item != NULL && item->sync_value == 1) {
-                    synced_docs_files--;
-                }
-            }
-        } else if (OSList_GetFirstNode(pending_sync_updates) != NULL) {
-            // Most realtime/whodata events don't have anything to promote (the file was
-            // already synced, or this was a MODIFIED with no old.sync=0 to promote), so skip
-            // the call entirely when there's nothing to do. When there IS something to
-            // promote, still don't log a summary here (process_pending_sync_updates() no
-            // longer logs on its own) — a mass create/modify against a realtime-monitored
-            // directory calls this once per file, and a per-file "Processed N pending sync
-            // flag updates" line would flood debug=1. The per-scan summary (scheduled scan,
-            // registry scan) is logged by those callers instead.
-            process_pending_sync_updates(FIMDB_FILE_TABLE_NAME, pending_sync_updates);
-        }
-        OSList_Destroy(pending_sync_updates);
-
         // Delete files that failed schema validation (outside transaction)
         cleanup_failed_fim_files(failed_paths);
         OSList_Destroy(failed_paths);
+
+        // Most realtime/whodata events don't have anything to promote (the file was already
+        // synced, or this was a MODIFIED with no old.sync=0 to promote), so skip the call
+        // entirely when there's nothing to do. When there IS something to promote, still don't
+        // log a summary here (process_pending_sync_updates() no longer logs on its own) — a mass
+        // create/modify against a realtime-monitored directory calls this once per file, and a
+        // per-file "Processed N pending sync flag updates" line would flood debug=1. The
+        // per-scan summary (scheduled scan, registry scan) is logged by those callers instead.
+        if (OSList_GetFirstNode(pending_sync_updates) != NULL) {
+            process_pending_sync_updates(FIMDB_FILE_TABLE_NAME, pending_sync_updates);
+        }
+        OSList_Destroy(pending_sync_updates);
 
         free_file_data(new_entry.file_entry.data);
     }
@@ -1424,16 +1405,6 @@ void fim_file_scan() {
         fim_db_transaction_deleted_rows(db_transaction_handle, transaction_callback, &txn_ctx);
 
         // Delete files that failed schema validation (outside transaction)
-        //
-        // Pre-existing gap (not introduced by #38522's fix, out of scope here): unlike the
-        // realtime/whodata call site above, this doesn't skip/compensate
-        // process_pending_sync_updates() for paths that also ended up in failed_paths — a
-        // file that fails schema validation during a scan can get its row deleted here and
-        // then still have a stale sync-flag update attempted below, spamming a WARNING and
-        // leaving synced_docs_files off by one. A full scan's failed_paths and
-        // pending_sync_updates aren't correlated by path here, so fixing it needs matching
-        // entries across both lists rather than the single-file short-circuit used above.
-        // Tracked in https://github.com/wazuh/wazuh/issues/38608 for a follow-up fix.
         cleanup_failed_fim_files(failed_paths);
         OSList_Destroy(failed_paths);
 

--- a/src/syscheckd/src/file/file.c
+++ b/src/syscheckd/src/file/file.c
@@ -1149,9 +1149,12 @@ void fim_file(const char *path,
         OSList_Destroy(failed_paths);
 
         // Most realtime/whodata events don't have anything to promote (the file was already
-        // synced, or this was a MODIFIED with no old.sync=0 to promote). Skip the call entirely
-        // in that case instead of logging "Processed 0 pending sync flag updates" on every single
-        // event — that line used to print once per full scan, not once per file.
+        // synced, or this was a MODIFIED with no old.sync=0 to promote), so skip the call
+        // entirely when there's nothing to do. When there IS something to promote, still don't
+        // log a summary here (process_pending_sync_updates() no longer logs on its own) — a mass
+        // create/modify against a realtime-monitored directory calls this once per file, and a
+        // per-file "Processed N pending sync flag updates" line would flood debug=1. The
+        // per-scan summary (scheduled scan, registry scan) is logged by those callers instead.
         if (OSList_GetFirstNode(pending_sync_updates) != NULL) {
             process_pending_sync_updates(FIMDB_FILE_TABLE_NAME, pending_sync_updates);
         }
@@ -1405,8 +1408,11 @@ void fim_file_scan() {
         cleanup_failed_fim_files(failed_paths);
         OSList_Destroy(failed_paths);
 
-        // Process pending sync flag updates now that transaction is committed
-        process_pending_sync_updates(FIMDB_FILE_TABLE_NAME, pending_sync_updates);
+        // Process pending sync flag updates now that transaction is committed. This runs once
+        // per full scan (unlike the per-file realtime/whodata call site above), so it's the one
+        // that logs the summary.
+        int synced_count = process_pending_sync_updates(FIMDB_FILE_TABLE_NAME, pending_sync_updates);
+        mdebug1("Processed %d pending sync flag updates", synced_count);
     }
 
     w_mutex_unlock(&syscheck.fim_scan_mutex);

--- a/src/syscheckd/src/file/file.c
+++ b/src/syscheckd/src/file/file.c
@@ -1304,6 +1304,74 @@ void fim_handle_delete_by_path(const char *path,
     }
 }
 
+/**
+ * @brief Drops pending sync-flag updates whose path also failed schema validation this scan,
+ *        compensating synced_docs_files for any that had already been counted.
+ *
+ * A file that fails schema validation has its row deleted directly (fim_db_file_delete(),
+ * called from cleanup_failed_fim_files()), bypassing the DELETED branch of
+ * transaction_callback() that would otherwise decrement synced_docs_files back down. Letting
+ * process_pending_sync_updates() try to set that row's sync flag afterwards would both log a
+ * spurious WARNING (the row is gone by then) and leave the counter permanently inflated.
+ *
+ * Must run after transaction_callback() has finished populating both lists for this scan, and
+ * before either cleanup_failed_fim_files() or process_pending_sync_updates() consumes them —
+ * see #38608.
+ *
+ * @param failed_paths OSList of char* paths that failed schema validation this scan.
+ * @param pending_sync_updates OSList of pending_sync_item_t queued for a sync flag update;
+ *                              items whose path is also in failed_paths are removed from it.
+ */
+STATIC void reconcile_failed_paths_with_pending_sync(OSList *failed_paths, OSList *pending_sync_updates) {
+    if (OSList_GetFirstNode(failed_paths) == NULL || OSList_GetFirstNode(pending_sync_updates) == NULL) {
+        return;
+    }
+
+    size_t max_nodes = (size_t)pending_sync_updates->currently_size;
+    OSListNode **nodes_to_remove = calloc(max_nodes, sizeof(OSListNode *));
+    if (nodes_to_remove == NULL) {
+        merror("Failed to allocate scratch buffer to correlate failed schema-validation paths "
+               "with pending sync updates; sync flags may be attempted for deleted rows this scan");
+        return;
+    }
+
+    // Two passes: first collect the pending_sync_updates nodes whose path also failed
+    // validation, without mutating the list while iterating it — OSList_foreach reads
+    // node_it->next on every iteration, so unlinking/freeing a node mid-traversal would use
+    // freed memory. Only after this read-only pass finishes are the collected nodes removed.
+    size_t nodes_to_remove_count = 0;
+    OSListNode *node_it;
+    OSList_foreach(node_it, pending_sync_updates) {
+        pending_sync_item_t *item = (pending_sync_item_t *)node_it->data;
+        const char *item_path = (item != NULL && item->json != NULL)
+                                     ? cJSON_GetStringValue(cJSON_GetObjectItem(item->json, "path"))
+                                     : NULL;
+        if (item_path == NULL) {
+            continue;
+        }
+
+        OSListNode *fp_it;
+        OSList_foreach(fp_it, failed_paths) {
+            const char *failed_path = (const char *)fp_it->data;
+            if (failed_path != NULL && strcmp(item_path, failed_path) == 0) {
+                if (item->sync_value == 1) {
+                    w_mutex_lock(&synced_docs_mutex);
+                    synced_docs_files--;
+                    w_mutex_unlock(&synced_docs_mutex);
+                }
+                free_pending_sync_item(item);
+                nodes_to_remove[nodes_to_remove_count++] = node_it;
+                break;
+            }
+        }
+    }
+
+    for (size_t i = 0; i < nodes_to_remove_count; i++) {
+        OSList_DeleteThisNode(pending_sync_updates, nodes_to_remove[i]);
+    }
+    free(nodes_to_remove);
+}
+
 void fim_file_scan() {
     if (fim_shutdown_process_on()) {
         return;
@@ -1445,17 +1513,11 @@ void fim_file_scan() {
     } else {
         fim_db_transaction_deleted_rows(db_transaction_handle, transaction_callback, &txn_ctx);
 
+        // #38608: see reconcile_failed_paths_with_pending_sync()'s doc comment for why this
+        // has to run before either list is consumed below.
+        reconcile_failed_paths_with_pending_sync(failed_paths, pending_sync_updates);
+
         // Delete files that failed schema validation (outside transaction)
-        //
-        // Pre-existing gap (not introduced by #38522's fix, out of scope here): unlike the
-        // realtime/whodata call site above, this doesn't skip/compensate
-        // process_pending_sync_updates() for paths that also ended up in failed_paths — a
-        // file that fails schema validation during a scan can get its row deleted here and
-        // then still have a stale sync-flag update attempted below, spamming a WARNING and
-        // leaving synced_docs_files off by one. A full scan's failed_paths and
-        // pending_sync_updates aren't correlated by path here, so fixing it needs matching
-        // entries across both lists rather than the single-file short-circuit used above.
-        // Tracked in https://github.com/wazuh/wazuh/issues/38608 for a follow-up fix.
         cleanup_failed_fim_files(failed_paths);
         OSList_Destroy(failed_paths);
 

--- a/src/syscheckd/src/file/file.c
+++ b/src/syscheckd/src/file/file.c
@@ -226,6 +226,7 @@ STATIC void handle_orphaned_delete(const char* path,
     cJSON* sync_json = cJSON_GetObjectItem(result_json, "sync");
     if (sync_json == NULL) {
         mdebug1("Couldn't find sync for orphaned delete '%s'", path);
+        cJSON_Delete(stateful_event);
         return;
     }
     int sync_value = (int)cJSON_GetNumberValue(sync_json);
@@ -306,18 +307,27 @@ STATIC void transaction_callback(ReturnTypeCallback resultType,
         case INSERTED:
             txn_context->event->type = FIM_ADD;
             sync_operation = OPERATION_CREATE;
-            // For CREATE events: determine if within limit and defer sync flag update
+            // For CREATE events: determine if within limit and defer sync flag update.
+            // Check-then-increment must be atomic: the scheduled scan and a realtime/whodata
+            // event can run this concurrently (see synced_docs_mutex's declaration comment).
             if (syscheck.file_limit > 0) {
+                w_mutex_lock(&synced_docs_mutex);
+                int docs_before = synced_docs_files;
                 sync_flag = (synced_docs_files < syscheck.file_limit) ? 1 : 0;
+                if (sync_flag == 1 && txn_context->pending_sync_updates != NULL) {
+                    synced_docs_files++;
+                }
+                w_mutex_unlock(&synced_docs_mutex);
+                // Logged pre-increment (docs_before), matching the value the sync_flag
+                // decision above was actually based on.
                 mdebug2("INSERTED: synced_docs_files=%d, file_limit=%d, sync_flag=%d, path=%s",
-                        synced_docs_files, syscheck.file_limit, sync_flag, path);
+                        docs_before, syscheck.file_limit, sync_flag, path);
             } else {
                 sync_flag = 1;
                 mdebug2("INSERTED: file_limit=0 (unlimited), sync_flag=1, path=%s", path);
             }
             // Add to deferred list if sync_flag should be 1
             if (sync_flag == 1 && txn_context->pending_sync_updates != NULL) {
-                synced_docs_files++;
                 cJSON* sync_item = cJSON_CreateObject();
                 if (sync_item != NULL) {
                     cJSON_AddStringToObject(sync_item, "path", path);
@@ -344,8 +354,17 @@ STATIC void transaction_callback(ReturnTypeCallback resultType,
             }
 
             if (sync_flag == 0 && syscheck.file_limit > 0) { // Promote
-                if (synced_docs_files < syscheck.file_limit) {
+                // Check-then-increment must be atomic (see synced_docs_mutex's declaration
+                // comment); the cJSON construction below doesn't touch shared state, so it
+                // stays outside the lock.
+                w_mutex_lock(&synced_docs_mutex);
+                bool promote = (synced_docs_files < syscheck.file_limit);
+                if (promote) {
                     synced_docs_files++;
+                }
+                w_mutex_unlock(&synced_docs_mutex);
+
+                if (promote) {
                     cJSON* sync_item = cJSON_CreateObject();
                     if (sync_item != NULL) {
                         cJSON_AddStringToObject(sync_item, "path", path);
@@ -372,7 +391,9 @@ STATIC void transaction_callback(ReturnTypeCallback resultType,
                 if (sync_json != NULL && cJSON_IsNumber(sync_json)) {
                     sync_flag = sync_json->valueint;
                     if (sync_flag == 1) {
+                        w_mutex_lock(&synced_docs_mutex);
                         synced_docs_files--;
+                        w_mutex_unlock(&synced_docs_mutex);
                     }
                 }
             }
@@ -1144,21 +1165,41 @@ void fim_file(const char *path,
 
         fim_db_file_update(&new_entry, callback_data);
 
-        // Delete files that failed schema validation (outside transaction)
-        cleanup_failed_fim_files(failed_paths);
-        OSList_Destroy(failed_paths);
-
-        // Most realtime/whodata events don't have anything to promote (the file was already
-        // synced, or this was a MODIFIED with no old.sync=0 to promote), so skip the call
-        // entirely when there's nothing to do. When there IS something to promote, still don't
-        // log a summary here (process_pending_sync_updates() no longer logs on its own) — a mass
-        // create/modify against a realtime-monitored directory calls this once per file, and a
-        // per-file "Processed N pending sync flag updates" line would flood debug=1. The
-        // per-scan summary (scheduled scan, registry scan) is logged by those callers instead.
-        if (OSList_GetFirstNode(pending_sync_updates) != NULL) {
+        // If schema validation failed, the row is about to be deleted below: don't try to
+        // set its sync flag afterwards (fim_db_set_sync_flag() would find no row to update
+        // and log a spurious WARNING on every such event), and undo the increment
+        // transaction_callback() already applied to synced_docs_files for it, since
+        // cleanup_failed_fim_files() removes the row without going through the DELETED
+        // branch that would otherwise balance it. This path handles a single file per call,
+        // so failed_paths and pending_sync_updates — both populated from the same
+        // transaction_callback() invocation — can only ever be about that one path; a
+        // non-empty failed_paths here means whatever is in pending_sync_updates is for it.
+        if (OSList_GetFirstNode(failed_paths) != NULL) {
+            OSListNode *node_it;
+            OSList_foreach(node_it, pending_sync_updates) {
+                pending_sync_item_t *item = (pending_sync_item_t *)node_it->data;
+                if (item != NULL && item->sync_value == 1) {
+                    w_mutex_lock(&synced_docs_mutex);
+                    synced_docs_files--;
+                    w_mutex_unlock(&synced_docs_mutex);
+                }
+            }
+        } else if (OSList_GetFirstNode(pending_sync_updates) != NULL) {
+            // Most realtime/whodata events don't have anything to promote (the file was
+            // already synced, or this was a MODIFIED with no old.sync=0 to promote), so skip
+            // the call entirely when there's nothing to do. When there IS something to
+            // promote, still don't log a summary here (process_pending_sync_updates() no
+            // longer logs on its own) — a mass create/modify against a realtime-monitored
+            // directory calls this once per file, and a per-file "Processed N pending sync
+            // flag updates" line would flood debug=1. The per-scan summary (scheduled scan,
+            // registry scan) is logged by those callers instead.
             process_pending_sync_updates(FIMDB_FILE_TABLE_NAME, pending_sync_updates);
         }
         OSList_Destroy(pending_sync_updates);
+
+        // Delete files that failed schema validation (outside transaction)
+        cleanup_failed_fim_files(failed_paths);
+        OSList_Destroy(failed_paths);
 
         free_file_data(new_entry.file_entry.data);
     }
@@ -1405,6 +1446,16 @@ void fim_file_scan() {
         fim_db_transaction_deleted_rows(db_transaction_handle, transaction_callback, &txn_ctx);
 
         // Delete files that failed schema validation (outside transaction)
+        //
+        // Pre-existing gap (not introduced by #38522's fix, out of scope here): unlike the
+        // realtime/whodata call site above, this doesn't skip/compensate
+        // process_pending_sync_updates() for paths that also ended up in failed_paths — a
+        // file that fails schema validation during a scan can get its row deleted here and
+        // then still have a stale sync-flag update attempted below, spamming a WARNING and
+        // leaving synced_docs_files off by one. A full scan's failed_paths and
+        // pending_sync_updates aren't correlated by path here, so fixing it needs matching
+        // entries across both lists rather than the single-file short-circuit used above.
+        // Tracked in https://github.com/wazuh/wazuh/issues/38608 for a follow-up fix.
         cleanup_failed_fim_files(failed_paths);
         OSList_Destroy(failed_paths);
 

--- a/src/syscheckd/src/file/file.c
+++ b/src/syscheckd/src/file/file.c
@@ -1113,11 +1113,29 @@ void fim_file(const char *path,
         }
         OSList_SetFreeDataPointer(failed_paths, (void (*)(void *))free);
 
+        // Sync flag updates deferred like the scan path (file.c's fim_file_scan()) so the
+        // DELETED branch's later read of the sync column (run_check.c) is not stuck at its
+        // insert-time default of 0 for files first seen outside a scheduled scan (#38522).
+        // Unlike fim_file_scan(), this path doesn't need syscheck.fim_scan_mutex: both
+        // fim_db_file_update() above and fim_db_set_sync_flag() (inside
+        // process_pending_sync_updates() below) go through FIMDB::updateItem(), which already
+        // takes m_handlersMutex and checks m_stopping before touching the dbsync handler, so a
+        // concurrent FIMDB::teardown() can't run underneath either call.
+        OSList* pending_sync_updates = OSList_Create();
+        if (!pending_sync_updates) {
+            merror("Failed to create pending sync updates list");
+            OSList_Destroy(failed_paths);
+            free_file_data(new_entry.file_entry.data);
+            return;
+        }
+        OSList_SetFreeDataPointer(pending_sync_updates, free_pending_sync_item);
+
         callback_ctx ctx = {
             .event = evt_data,
             .config = configuration,
             .entry = &new_entry,
-            .failed_paths = failed_paths
+            .failed_paths = failed_paths,
+            .pending_sync_updates = pending_sync_updates
         };
 
         callback_context_t callback_data;
@@ -1129,6 +1147,10 @@ void fim_file(const char *path,
         // Delete files that failed schema validation (outside transaction)
         cleanup_failed_fim_files(failed_paths);
         OSList_Destroy(failed_paths);
+
+        process_pending_sync_updates(FIMDB_FILE_TABLE_NAME, pending_sync_updates);
+        OSList_Destroy(pending_sync_updates);
+
         free_file_data(new_entry.file_entry.data);
     }
 }

--- a/src/syscheckd/src/file/file.c
+++ b/src/syscheckd/src/file/file.c
@@ -1148,7 +1148,13 @@ void fim_file(const char *path,
         cleanup_failed_fim_files(failed_paths);
         OSList_Destroy(failed_paths);
 
-        process_pending_sync_updates(FIMDB_FILE_TABLE_NAME, pending_sync_updates);
+        // Most realtime/whodata events don't have anything to promote (the file was already
+        // synced, or this was a MODIFIED with no old.sync=0 to promote). Skip the call entirely
+        // in that case instead of logging "Processed 0 pending sync flag updates" on every single
+        // event — that line used to print once per full scan, not once per file.
+        if (OSList_GetFirstNode(pending_sync_updates) != NULL) {
+            process_pending_sync_updates(FIMDB_FILE_TABLE_NAME, pending_sync_updates);
+        }
         OSList_Destroy(pending_sync_updates);
 
         free_file_data(new_entry.file_entry.data);

--- a/src/syscheckd/src/file/file.c
+++ b/src/syscheckd/src/file/file.c
@@ -1355,9 +1355,7 @@ STATIC void reconcile_failed_paths_with_pending_sync(OSList *failed_paths, OSLis
             const char *failed_path = (const char *)fp_it->data;
             if (failed_path != NULL && strcmp(item_path, failed_path) == 0) {
                 if (item->sync_value == 1) {
-                    w_mutex_lock(&synced_docs_mutex);
                     synced_docs_files--;
-                    w_mutex_unlock(&synced_docs_mutex);
                 }
                 free_pending_sync_item(item);
                 nodes_to_remove[nodes_to_remove_count++] = node_it;

--- a/src/syscheckd/src/file/file.c
+++ b/src/syscheckd/src/file/file.c
@@ -307,27 +307,18 @@ STATIC void transaction_callback(ReturnTypeCallback resultType,
         case INSERTED:
             txn_context->event->type = FIM_ADD;
             sync_operation = OPERATION_CREATE;
-            // For CREATE events: determine if within limit and defer sync flag update.
-            // Check-then-increment must be atomic: the scheduled scan and a realtime/whodata
-            // event can run this concurrently (see synced_docs_mutex's declaration comment).
+            // For CREATE events: determine if within limit and defer sync flag update
             if (syscheck.file_limit > 0) {
-                w_mutex_lock(&synced_docs_mutex);
-                int docs_before = synced_docs_files;
                 sync_flag = (synced_docs_files < syscheck.file_limit) ? 1 : 0;
-                if (sync_flag == 1 && txn_context->pending_sync_updates != NULL) {
-                    synced_docs_files++;
-                }
-                w_mutex_unlock(&synced_docs_mutex);
-                // Logged pre-increment (docs_before), matching the value the sync_flag
-                // decision above was actually based on.
                 mdebug2("INSERTED: synced_docs_files=%d, file_limit=%d, sync_flag=%d, path=%s",
-                        docs_before, syscheck.file_limit, sync_flag, path);
+                        synced_docs_files, syscheck.file_limit, sync_flag, path);
             } else {
                 sync_flag = 1;
                 mdebug2("INSERTED: file_limit=0 (unlimited), sync_flag=1, path=%s", path);
             }
             // Add to deferred list if sync_flag should be 1
             if (sync_flag == 1 && txn_context->pending_sync_updates != NULL) {
+                synced_docs_files++;
                 cJSON* sync_item = cJSON_CreateObject();
                 if (sync_item != NULL) {
                     cJSON_AddStringToObject(sync_item, "path", path);
@@ -354,17 +345,8 @@ STATIC void transaction_callback(ReturnTypeCallback resultType,
             }
 
             if (sync_flag == 0 && syscheck.file_limit > 0) { // Promote
-                // Check-then-increment must be atomic (see synced_docs_mutex's declaration
-                // comment); the cJSON construction below doesn't touch shared state, so it
-                // stays outside the lock.
-                w_mutex_lock(&synced_docs_mutex);
-                bool promote = (synced_docs_files < syscheck.file_limit);
-                if (promote) {
+                if (synced_docs_files < syscheck.file_limit) {
                     synced_docs_files++;
-                }
-                w_mutex_unlock(&synced_docs_mutex);
-
-                if (promote) {
                     cJSON* sync_item = cJSON_CreateObject();
                     if (sync_item != NULL) {
                         cJSON_AddStringToObject(sync_item, "path", path);
@@ -391,9 +373,7 @@ STATIC void transaction_callback(ReturnTypeCallback resultType,
                 if (sync_json != NULL && cJSON_IsNumber(sync_json)) {
                     sync_flag = sync_json->valueint;
                     if (sync_flag == 1) {
-                        w_mutex_lock(&synced_docs_mutex);
                         synced_docs_files--;
-                        w_mutex_unlock(&synced_docs_mutex);
                     }
                 }
             }
@@ -1179,9 +1159,7 @@ void fim_file(const char *path,
             OSList_foreach(node_it, pending_sync_updates) {
                 pending_sync_item_t *item = (pending_sync_item_t *)node_it->data;
                 if (item != NULL && item->sync_value == 1) {
-                    w_mutex_lock(&synced_docs_mutex);
                     synced_docs_files--;
-                    w_mutex_unlock(&synced_docs_mutex);
                 }
             }
         } else if (OSList_GetFirstNode(pending_sync_updates) != NULL) {

--- a/src/syscheckd/src/file/file.c
+++ b/src/syscheckd/src/file/file.c
@@ -1355,7 +1355,9 @@ STATIC void reconcile_failed_paths_with_pending_sync(OSList *failed_paths, OSLis
             const char *failed_path = (const char *)fp_it->data;
             if (failed_path != NULL && strcmp(item_path, failed_path) == 0) {
                 if (item->sync_value == 1) {
+                    w_mutex_lock(&synced_docs_mutex);
                     synced_docs_files--;
+                    w_mutex_unlock(&synced_docs_mutex);
                 }
                 free_pending_sync_item(item);
                 nodes_to_remove[nodes_to_remove_count++] = node_it;

--- a/src/syscheckd/src/registry/registry.c
+++ b/src/syscheckd/src/registry/registry.c
@@ -2235,9 +2235,12 @@ void fim_registry_scan() {
         fim_db_transaction_deleted_rows(regval_txn_handler, registry_value_transaction_callback, &txn_ctx_regval);
         fim_db_transaction_deleted_rows(regkey_txn_handler, registry_key_transaction_callback, &txn_ctx_reg);
 
-        // Process pending sync flag updates after transaction commit
-        process_pending_sync_updates(FIMDB_REGISTRY_KEY_TABLENAME, pending_sync_keys);
-        process_pending_sync_updates(FIMDB_REGISTRY_VALUE_TABLENAME, pending_sync_values);
+        // Process pending sync flag updates after transaction commit. Runs once per full
+        // registry scan, so log the summary here (process_pending_sync_updates() itself doesn't).
+        int synced_keys = process_pending_sync_updates(FIMDB_REGISTRY_KEY_TABLENAME, pending_sync_keys);
+        mdebug1("Processed %d pending sync flag updates", synced_keys);
+        int synced_values = process_pending_sync_updates(FIMDB_REGISTRY_VALUE_TABLENAME, pending_sync_values);
+        mdebug1("Processed %d pending sync flag updates", synced_values);
 
         // Delete registry keys and values that failed schema validation (outside transaction)
         cleanup_failed_registry_keys(failed_keys);

--- a/src/syscheckd/src/registry/registry.c
+++ b/src/syscheckd/src/registry/registry.c
@@ -2238,9 +2238,9 @@ void fim_registry_scan() {
         // Process pending sync flag updates after transaction commit. Runs once per full
         // registry scan, so log the summary here (process_pending_sync_updates() itself doesn't).
         int synced_keys = process_pending_sync_updates(FIMDB_REGISTRY_KEY_TABLENAME, pending_sync_keys);
-        mdebug1("Processed %d pending sync flag updates", synced_keys);
+        mdebug1("Processed %d pending sync flag updates (keys)", synced_keys);
         int synced_values = process_pending_sync_updates(FIMDB_REGISTRY_VALUE_TABLENAME, pending_sync_values);
-        mdebug1("Processed %d pending sync flag updates", synced_values);
+        mdebug1("Processed %d pending sync flag updates (values)", synced_values);
 
         // Delete registry keys and values that failed schema validation (outside transaction)
         cleanup_failed_registry_keys(failed_keys);

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -38,13 +38,6 @@ int synced_docs_files = 0;
 int synced_docs_registry_keys = 0;
 int synced_docs_registry_values = 0;
 
-// Guards the check-then-increment/decrement on the synced_docs_* counters above: the
-// scheduled scan (fim_file_scan()/fim_registry_scan(), under fim_scan_mutex) and realtime/
-// whodata events (fim_file(), which doesn't take fim_scan_mutex to avoid stalling realtime
-// events for the whole scan) can race on these plain ints otherwise, undercounting synced
-// documents and re-triggering #38522-style drift in file/registry limit enforcement.
-pthread_mutex_t synced_docs_mutex = PTHREAD_MUTEX_INITIALIZER;
-
 #ifdef USE_MAGIC
 #include <magic.h>
 magic_t magic_cookie = 0;
@@ -633,13 +626,7 @@ void fim_initialize() {
                             if (primary_keys) {
                                 add_pending_sync_item(pending_sync_updates, primary_keys, 1);
                                 cJSON_Delete(primary_keys);
-                                // fim_initialize() runs once at startup before the scan/
-                                // realtime threads exist, so this lock isn't load-bearing
-                                // here — kept only for consistency with the other counter
-                                // updates guarded by synced_docs_mutex.
-                                w_mutex_lock(&synced_docs_mutex);
                                 (*synced_docs_ptr)++;
-                                w_mutex_unlock(&synced_docs_mutex);
                             }
                         }
 
@@ -668,11 +655,7 @@ void fim_initialize() {
                         cJSON* item = NULL;
                         cJSON_ArrayForEach(item, docs_to_demote) {
                             add_pending_sync_item(pending_sync_updates, item, 0);
-                            // See the comment on the promote branch above: not load-bearing
-                            // at startup, kept for consistency.
-                            w_mutex_lock(&synced_docs_mutex);
                             (*synced_docs_ptr)--;
-                            w_mutex_unlock(&synced_docs_mutex);
                         }
 
                         // Process pending sync updates. Runs once per table at startup, so log

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -131,9 +131,9 @@ void add_pending_sync_item(OSList *pending_items, const cJSON *json, int sync_va
     }
 }
 
-void process_pending_sync_updates(char* table_name, OSList *pending_items) {
+int process_pending_sync_updates(char* table_name, OSList *pending_items) {
     if (pending_items == NULL) {
-        return;
+        return 0;
     }
 
     int count = 0;
@@ -147,7 +147,7 @@ void process_pending_sync_updates(char* table_name, OSList *pending_items) {
             count++;
         }
     }
-    mdebug1("Processed %d pending sync flag updates", count);
+    return count;
 }
 
 /**
@@ -629,8 +629,10 @@ void fim_initialize() {
                             }
                         }
 
-                        // Process pending sync updates
-                        process_pending_sync_updates(table_name, pending_sync_updates);
+                        // Process pending sync updates. Runs once per table at startup, so log
+                        // the summary here (process_pending_sync_updates() itself doesn't).
+                        int synced_count = process_pending_sync_updates(table_name, pending_sync_updates);
+                        mdebug1("Processed %d pending sync flag updates", synced_count);
                         OSList_Destroy(pending_sync_updates);
                     }
                     cJSON_Delete(docs_to_promote);
@@ -655,8 +657,10 @@ void fim_initialize() {
                             (*synced_docs_ptr)--;
                         }
 
-                        // Process pending sync updates
-                        process_pending_sync_updates(table_name, pending_sync_updates);
+                        // Process pending sync updates. Runs once per table at startup, so log
+                        // the summary here (process_pending_sync_updates() itself doesn't).
+                        int synced_count = process_pending_sync_updates(table_name, pending_sync_updates);
+                        mdebug1("Processed %d pending sync flag updates", synced_count);
                         OSList_Destroy(pending_sync_updates);
                     }
                     cJSON_Delete(docs_to_demote);

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -38,6 +38,13 @@ int synced_docs_files = 0;
 int synced_docs_registry_keys = 0;
 int synced_docs_registry_values = 0;
 
+// Guards the check-then-increment/decrement on the synced_docs_* counters above: the
+// scheduled scan (fim_file_scan()/fim_registry_scan(), under fim_scan_mutex) and realtime/
+// whodata events (fim_file(), which doesn't take fim_scan_mutex to avoid stalling realtime
+// events for the whole scan) can race on these plain ints otherwise, undercounting synced
+// documents and re-triggering #38522-style drift in file/registry limit enforcement.
+pthread_mutex_t synced_docs_mutex = PTHREAD_MUTEX_INITIALIZER;
+
 #ifdef USE_MAGIC
 #include <magic.h>
 magic_t magic_cookie = 0;
@@ -143,8 +150,9 @@ int process_pending_sync_updates(char* table_name, OSList *pending_items) {
         if (item != NULL && item->json != NULL) {
             const cJSON* path = cJSON_GetObjectItem(item->json, "path");
             mdebug2("Setting sync=%d for path: %s", item->sync_value, cJSON_GetStringValue(path));
-            fim_db_set_sync_flag(table_name, item, item->sync_value);
-            count++;
+            if (fim_db_set_sync_flag(table_name, item, item->sync_value) == 0) {
+                count++;
+            }
         }
     }
     return count;
@@ -625,7 +633,13 @@ void fim_initialize() {
                             if (primary_keys) {
                                 add_pending_sync_item(pending_sync_updates, primary_keys, 1);
                                 cJSON_Delete(primary_keys);
+                                // fim_initialize() runs once at startup before the scan/
+                                // realtime threads exist, so this lock isn't load-bearing
+                                // here — kept only for consistency with the other counter
+                                // updates guarded by synced_docs_mutex.
+                                w_mutex_lock(&synced_docs_mutex);
                                 (*synced_docs_ptr)++;
+                                w_mutex_unlock(&synced_docs_mutex);
                             }
                         }
 
@@ -654,7 +668,11 @@ void fim_initialize() {
                         cJSON* item = NULL;
                         cJSON_ArrayForEach(item, docs_to_demote) {
                             add_pending_sync_item(pending_sync_updates, item, 0);
+                            // See the comment on the promote branch above: not load-bearing
+                            // at startup, kept for consistency.
+                            w_mutex_lock(&synced_docs_mutex);
                             (*synced_docs_ptr)--;
+                            w_mutex_unlock(&synced_docs_mutex);
                         }
 
                         // Process pending sync updates. Runs once per table at startup, so log

--- a/src/syscheckd/src/syscheck.c
+++ b/src/syscheckd/src/syscheck.c
@@ -143,9 +143,8 @@ int process_pending_sync_updates(char* table_name, OSList *pending_items) {
         if (item != NULL && item->json != NULL) {
             const cJSON* path = cJSON_GetObjectItem(item->json, "path");
             mdebug2("Setting sync=%d for path: %s", item->sync_value, cJSON_GetStringValue(path));
-            if (fim_db_set_sync_flag(table_name, item, item->sync_value) == 0) {
-                count++;
-            }
+            fim_db_set_sync_flag(table_name, item, item->sync_value);
+            count++;
         }
     }
     return count;

--- a/src/unit_tests/syscheckd/registry/test_registry.c
+++ b/src/unit_tests/syscheckd/registry/test_registry.c
@@ -954,8 +954,8 @@ static void test_fim_registry_scan_base_line_generation(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_unlock);
 
     // process_pending_sync_updates is called twice: once for keys, once for values
-    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
-    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
+    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates (keys)");
+    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates (values)");
     expect_string(__wrap__mdebug1, formatted_msg, FIM_WINREGISTRY_ENDED);
 
     // Test
@@ -1046,8 +1046,8 @@ static void test_fim_registry_scan_regular_scan(void **state) {
     expect_function_call_any(__wrap_pthread_mutex_unlock);
 
     // process_pending_sync_updates is called twice: once for keys, once for values
-    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
-    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
+    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates (keys)");
+    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates (values)");
     expect_string(__wrap__mdebug1, formatted_msg, FIM_WINREGISTRY_ENDED);
 
     // Test
@@ -1064,8 +1064,8 @@ static void test_fim_registry_scan_RegOpenKeyExW_fail(void **state) {
     expect_string(__wrap__mdebug1, formatted_msg, FIM_WINREGISTRY_START);
     expect_string(__wrap__mdebug1, formatted_msg, "(6920): Failed to open registry key: 'Software\\Classes\\batfile' (arch: '[x64]'). Error code: -1.");
     // process_pending_sync_updates is called twice: once for keys, once for values
-    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
-    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
+    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates (keys)");
+    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates (values)");
     expect_string(__wrap__mdebug1, formatted_msg, FIM_WINREGISTRY_ENDED);
     expect_any_always(__wrap__mdebug2, formatted_msg);
 
@@ -1097,8 +1097,8 @@ static void test_fim_registry_scan_RegQueryInfoKey_fail(void **state) {
     will_return(__wrap_fim_db_transaction_start, &mock_handle);
     expect_string(__wrap__mdebug1, formatted_msg, FIM_WINREGISTRY_START);
     // process_pending_sync_updates is called twice: once for keys, once for values
-    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
-    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
+    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates (keys)");
+    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates (values)");
     expect_string(__wrap__mdebug1, formatted_msg, FIM_WINREGISTRY_ENDED);
     expect_any_always(__wrap__mdebug2, formatted_msg);
 

--- a/src/unit_tests/syscheckd/test_fim_scan.c
+++ b/src/unit_tests/syscheckd/test_fim_scan.c
@@ -1159,6 +1159,8 @@ static void test_fim_file_add(void **state) {
     expect_get_data(strdup("user"), strdup("group"), file_path, 1);
 
     will_return(__wrap_fim_db_file_update, FIMDB_OK);
+    expect_function_call(__wrap_process_pending_sync_updates);
+    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
 
     fim_file(file_path, &configuration, &evt_data, NULL, NULL);
 }
@@ -1277,6 +1279,8 @@ static void test_fim_file_modify(void **state) {
                                         0x400, 0);
 
     will_return(__wrap_fim_db_file_update, FIMDB_OK);
+    expect_function_call(__wrap_process_pending_sync_updates);
+    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
 
     fim_file(file_path, &configuration, &evt_data, NULL, NULL);
 }
@@ -1381,6 +1385,8 @@ static void test_fim_file_error_on_insert(void **state) {
     will_return(__wrap_OS_MD5_SHA1_SHA256_File, 0);
 
     will_return(__wrap_fim_db_file_update, FIMDB_OK);
+    expect_function_call(__wrap_process_pending_sync_updates);
+    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
 
     fim_file(file_path, &configuration, &evt_data, NULL, NULL);
 }
@@ -1567,6 +1573,8 @@ static void test_fim_checker_fim_regular(void **state) {
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, strdup("group"));
     will_return(__wrap_fim_db_file_update, FIMDB_OK);
+    expect_function_call(__wrap_process_pending_sync_updates);
+    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
 
     fim_checker(path, &evt_data, NULL, NULL, NULL);
 }
@@ -1602,6 +1610,8 @@ static void test_fim_checker_fim_regular_warning(void **state) {
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, strdup("group"));
     will_return(__wrap_fim_db_file_update, FIMDB_OK);
+    expect_function_call(__wrap_process_pending_sync_updates);
+    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
 
     fim_checker(path, &evt_data, NULL, NULL, NULL);
 }
@@ -1786,6 +1796,8 @@ static void test_fim_checker_root_file_within_recursion_level(void **state) {
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, strdup("group"));
     will_return(__wrap_fim_db_file_update, FIMDB_OK);
+    expect_function_call(__wrap_process_pending_sync_updates);
+    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
 
     fim_checker(path, &evt_data, NULL, NULL, NULL);
 }
@@ -2425,6 +2437,8 @@ static void test_fim_checker_fim_regular(void **state) {
     will_return(__wrap_fim_db_file_update, FIMDB_OK);
     expect_string(__wrap_w_get_file_attrs, file_path, expanded_path);
     will_return(__wrap_w_get_file_attrs, 123456);
+    expect_function_call(__wrap_process_pending_sync_updates);
+    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
     fim_checker(expanded_path, &evt_data, NULL, NULL, NULL);
 }
 
@@ -2518,6 +2532,8 @@ static void test_fim_checker_fim_regular_warning(void **state) {
     will_return(__wrap_w_get_file_attrs, 123456);
 
     will_return(__wrap_fim_db_file_update, FIMDB_OK);
+    expect_function_call(__wrap_process_pending_sync_updates);
+    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
 
     fim_checker(expanded_path, &evt_data, NULL, NULL, NULL);
 }
@@ -3745,6 +3761,73 @@ static void test_transaction_callback_add(void **state) {
     data->txn_context->entry = NULL;
 }
 
+// Regression test for #38522: fim_file()'s non-transactional path (realtime/whodata) now wires a
+// real pending_sync_updates list into the callback_ctx it hands to transaction_callback (it used to
+// leave the field NULL, so the INSERTED branch below silently skipped queuing the sync flag update
+// and the row stayed at sync=0 forever). This asserts the queuing itself, given a non-NULL list.
+static void test_transaction_callback_add_queues_sync_flag_update(void **state) {
+    txn_data_t *data = (txn_data_t *) *state;
+#ifndef TEST_WINAGENT
+    char *path = "/etc/a_test_file.txt";
+#else
+    char *path = "c:\\windows\\a_test_file.txt";
+#endif
+
+    callback_ctx *txn_context = data->txn_context;
+    fim_entry entry = {.type = FIM_TYPE_FILE, .file_entry.path = path, .file_entry.data=&DEFAULT_FILE_DATA};
+    cJSON *result = cJSON_Parse("{\"attributes\":\"\",\"checksum\":\"d0e2e27875639745261c5d1365eb6c9fb7319247\",\"device\":64768,\"gid\":0,\"group_\":\"root\",\"hash_md5\":\"d41d8cd98f00b204e9800998ecf8427e\",\"hash_sha1\":\"da39a3ee5e6b4b0d3255bfef95601890afd80709\",\"hash_sha256\":\"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"inode\":\"801978\",\"mtime\":1645001030,\"path\":\"/etc/a_test_file.txt\",\"permissions\":\"rw-r--r--\",\"size\":0,\"uid\":0,\"owner\":\"root\",\"version\":1}");
+
+    txn_context->entry = &entry;
+    data->dbsync_event = result;
+
+    OSList *pending_sync_updates = OSList_Create();
+    assert_non_null(pending_sync_updates);
+    OSList_SetFreeDataPointer(pending_sync_updates, free_pending_sync_item);
+    txn_context->pending_sync_updates = pending_sync_updates;
+
+#ifndef TEST_WINAGENT // The order of the functions is different between windows an linux
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+#else
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+#endif
+
+    expect_function_call(__wrap_send_syscheck_msg);
+    will_return(__wrap_validate_and_persist_fim_event, true);
+#ifndef TEST_WINAGENT
+    expect_string(__wrap__mdebug2, formatted_msg, "INSERTED: file_limit=0 (unlimited), sync_flag=1, path=/etc/a_test_file.txt");
+    expect_string(__wrap__mdebug2, formatted_msg, "Added item to pending sync list: /etc/a_test_file.txt (version: 1, sync: 1)");
+#else
+    expect_string(__wrap__mdebug2, formatted_msg, "INSERTED: file_limit=0 (unlimited), sync_flag=1, path=c:\\windows\\a_test_file.txt");
+    expect_string(__wrap__mdebug2, formatted_msg, "Added item to pending sync list: c:\\windows\\a_test_file.txt (version: 1, sync: 1)");
+#endif
+
+    transaction_callback(INSERTED, result, txn_context);
+
+    int items_found = 0;
+    OSListNode *node_it;
+    OSList_foreach(node_it, pending_sync_updates) {
+        pending_sync_item_t *item = (pending_sync_item_t *)node_it->data;
+        assert_non_null(item);
+        assert_int_equal(item->sync_value, 1);
+        assert_non_null(item->json);
+        assert_string_equal(cJSON_GetStringValue(cJSON_GetObjectItem(item->json, "path")), path);
+        items_found++;
+    }
+    assert_int_equal(items_found, 1);
+
+    OSList_Destroy(pending_sync_updates);
+    txn_context->pending_sync_updates = NULL;
+    data->txn_context->entry = NULL;
+}
+
 static void test_transaction_callback_modify(void **state) {
     txn_data_t *data = (txn_data_t *) *state;
 #ifndef TEST_WINAGENT
@@ -3782,6 +3865,78 @@ static void test_transaction_callback_modify(void **state) {
     transaction_callback(MODIFIED, result, txn_context);
     assert_int_equal(txn_context->event->type, FIM_MODIFICATION);
 
+    data->txn_context->entry = NULL;
+}
+
+// Regression test for #38522: the MODIFIED branch's promotion path ("old" row has sync=0 and
+// there's room under file_limit) reads txn_context->pending_sync_updates the same way INSERTED
+// does. Before the fix, fim_file()'s non-transactional (realtime/whodata) path left that field
+// NULL, so this promotion was silently skipped there too, not just the INSERTED case. This
+// asserts the queuing given a non-NULL list, mirroring test_transaction_callback_add_queues_sync_flag_update.
+static void test_transaction_callback_modify_promotes_pending_sync_update(void **state) {
+    txn_data_t *data = (txn_data_t *) *state;
+#ifndef TEST_WINAGENT
+    char *path = "/etc/a_test_file.txt";
+#else
+    char *path = "c:\\windows\\a_test_file.txt";
+#endif
+    callback_ctx *txn_context = data->txn_context;
+    fim_entry entry = {.type = FIM_TYPE_FILE, .file_entry.path = path, .file_entry.data=&DEFAULT_FILE_DATA};
+    txn_context->entry = &entry;
+
+    cJSON *result = cJSON_Parse("{\"new\":{\"checksum\":\"cfdd740677ed8b250e93081e72b4d97b1c846fdc\",\"hash_md5\":\"d73b04b0e696b0945283defa3eee4538\",\"hash_sha1\":\"e7509a8c032f3bc2a8df1df476f8ef03436185fa\",\"hash_sha256\":\"8cd07f3a5ff98f2a78cfc366c13fb123eb8d29c1ca37c79df190425d5b9e424d\",\"mtime\":1645001693,\"path\":\"/etc/a_test_file.txt\",\"size\":11,\"version\":2},\"old\":{\"checksum\":\"d0e2e27875639745261c5d1365eb6c9fb7319247\",\"hash_md5\":\"d41d8cd98f00b204e9800998ecf8427e\",\"hash_sha1\":\"da39a3ee5e6b4b0d3255bfef95601890afd80709\",\"hash_sha256\":\"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"mtime\":1645001030,\"path\":\"/etc/a_test_file.txt\",\"size\":0,\"sync\":0,\"version\":1}}");
+    data->dbsync_event = result;
+
+    int original_file_limit = syscheck.file_limit;
+    syscheck.file_limit = 999999; // must be > 0 and > synced_docs_files for the promotion branch to run
+    int original_synced_docs_files = synced_docs_files;
+
+    OSList *pending_sync_updates = OSList_Create();
+    assert_non_null(pending_sync_updates);
+    OSList_SetFreeDataPointer(pending_sync_updates, free_pending_sync_item);
+    txn_context->pending_sync_updates = pending_sync_updates;
+
+#ifndef TEST_WINAGENT
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+#else
+    expect_function_call_any(__wrap_pthread_rwlock_wrlock);
+    expect_function_call_any(__wrap_pthread_rwlock_unlock);
+    expect_function_call_any(__wrap_pthread_rwlock_rdlock);
+    expect_function_call_any(__wrap_pthread_mutex_lock);
+    expect_function_call_any(__wrap_pthread_mutex_unlock);
+#endif
+
+    expect_function_call(__wrap_send_syscheck_msg);
+    will_return(__wrap_validate_and_persist_fim_event, true);
+#ifndef TEST_WINAGENT
+    expect_string(__wrap__mdebug2, formatted_msg, "Added item to pending sync list: /etc/a_test_file.txt (version: 2, sync: 1)");
+#else
+    expect_string(__wrap__mdebug2, formatted_msg, "Added item to pending sync list: c:\\windows\\a_test_file.txt (version: 2, sync: 1)");
+#endif
+
+    transaction_callback(MODIFIED, result, txn_context);
+    assert_int_equal(txn_context->event->type, FIM_MODIFICATION);
+
+    int items_found = 0;
+    OSListNode *node_it;
+    OSList_foreach(node_it, pending_sync_updates) {
+        pending_sync_item_t *item = (pending_sync_item_t *)node_it->data;
+        assert_non_null(item);
+        assert_int_equal(item->sync_value, 1);
+        assert_non_null(item->json);
+        assert_string_equal(cJSON_GetStringValue(cJSON_GetObjectItem(item->json, "path")), path);
+        items_found++;
+    }
+    assert_int_equal(items_found, 1);
+
+    OSList_Destroy(pending_sync_updates);
+    txn_context->pending_sync_updates = NULL;
+    syscheck.file_limit = original_file_limit;
+    synced_docs_files = original_synced_docs_files;
     data->txn_context->entry = NULL;
 }
 
@@ -4376,7 +4531,9 @@ int main(void) {
 
         /* transaction_callback */
         cmocka_unit_test_setup_teardown(test_transaction_callback_add, setup_transaction_callback, teardown_transaction_callback),
+        cmocka_unit_test_setup_teardown(test_transaction_callback_add_queues_sync_flag_update, setup_transaction_callback, teardown_transaction_callback),
         cmocka_unit_test_setup_teardown(test_transaction_callback_modify, setup_transaction_callback, teardown_transaction_callback),
+        cmocka_unit_test_setup_teardown(test_transaction_callback_modify_promotes_pending_sync_update, setup_transaction_callback, teardown_transaction_callback),
         cmocka_unit_test_setup_teardown(test_transaction_callback_modify_empty_changed_attributes, setup_transaction_callback, teardown_transaction_callback),
         cmocka_unit_test_setup_teardown(test_transaction_callback_modify_report_changes, setup_transaction_callback, teardown_transaction_callback),
         cmocka_unit_test_setup_teardown(test_transaction_callback_delete, setup_transaction_callback, teardown_transaction_callback),

--- a/src/unit_tests/syscheckd/test_fim_scan.c
+++ b/src/unit_tests/syscheckd/test_fim_scan.c
@@ -1173,6 +1173,38 @@ static void test_fim_file_add(void **state) {
 // about. This test drives the mocked callback for real, so fim_file()'s own local
 // pending_sync_updates list gets genuinely populated by the same code fim_file() constructs,
 // and asserts process_pending_sync_updates() reports 1 processed item, not 0.
+// Saved/restored around test_fim_file_add_queues_sync_flag_update_end_to_end via cmocka
+// setup/teardown (not inline in the test body) so a failed assert/expectation mid-test still
+// restores global state instead of leaking it into the next test.
+typedef struct {
+    int original_notify_scan;
+    int original_synced_docs_files;
+} end_to_end_saved_state_t;
+
+static int setup_fim_file_add_queues_sync_flag_update_end_to_end(void **state) {
+    end_to_end_saved_state_t *saved = calloc(1, sizeof(end_to_end_saved_state_t));
+    if (saved == NULL) {
+        return -1;
+    }
+    saved->original_notify_scan = notify_scan;
+    saved->original_synced_docs_files = synced_docs_files;
+    *state = saved;
+    return 0;
+}
+
+static int teardown_fim_file_add_queues_sync_flag_update_end_to_end(void **state) {
+    end_to_end_saved_state_t *saved = *state;
+    if (saved != NULL) {
+        notify_scan = saved->original_notify_scan;
+        synced_docs_files = saved->original_synced_docs_files;
+        free(saved);
+    }
+    // Guards against a leftover one-shot flag if this test aborted before
+    // __wrap_fim_db_file_update() consumed it.
+    reset_fim_db_file_update_invoking_callback();
+    return 0;
+}
+
 static void test_fim_file_add_queues_sync_flag_update_end_to_end(void **state) {
     event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true, .statbuf = DEFAULT_STATBUF };
     directory_t configuration = { .options = CHECK_SIZE | CHECK_PERM | CHECK_OWNER | CHECK_GROUP | CHECK_MD5SUM |
@@ -1189,11 +1221,9 @@ static void test_fim_file_add_queues_sync_flag_update_end_to_end(void **state) {
     ignore_function_calls(__wrap_pthread_mutex_unlock);
     ignore_function_calls(__wrap_pthread_rwlock_rdlock);
 
-    int original_synced_docs_files = synced_docs_files;
     // send_syscheck_msg() only fires when notify_scan is set — true on a live agent past its
     // first scan (this file's OTHER tests never reach this check, so nothing else in this group
     // sets it; only the separate test_transaction_callback_* fixture does, for its own tests).
-    int original_notify_scan = notify_scan;
     notify_scan = 1;
 
     expect_get_data(strdup("user"), strdup("group"), file_path, 1);
@@ -1247,8 +1277,6 @@ static void test_fim_file_add_queues_sync_flag_update_end_to_end(void **state) {
     fim_file(file_path, &configuration, &evt_data, NULL, NULL);
 
     cJSON_Delete(result);
-    synced_docs_files = original_synced_docs_files;
-    notify_scan = original_notify_scan;
 }
 
 static void test_fim_file_modify_transaction(void **state) {
@@ -4717,7 +4745,9 @@ int main(void) {
 
         /* fim_file */
         cmocka_unit_test(test_fim_file_add),
-        cmocka_unit_test(test_fim_file_add_queues_sync_flag_update_end_to_end),
+        cmocka_unit_test_setup_teardown(test_fim_file_add_queues_sync_flag_update_end_to_end,
+                                        setup_fim_file_add_queues_sync_flag_update_end_to_end,
+                                        teardown_fim_file_add_queues_sync_flag_update_end_to_end),
         cmocka_unit_test_setup_teardown(test_fim_file_modify, setup_fim_entry, teardown_fim_entry),
         cmocka_unit_test_setup_teardown(test_fim_file_modify_transaction, setup_fim_entry, teardown_fim_entry),
 

--- a/src/unit_tests/syscheckd/test_fim_scan.c
+++ b/src/unit_tests/syscheckd/test_fim_scan.c
@@ -45,6 +45,7 @@
 fim_state_db _files_db_state = FIM_STATE_DB_NORMAL;
 
 void transaction_callback(ReturnTypeCallback resultType, const cJSON* result_json, void* user_data);
+void reconcile_failed_paths_with_pending_sync(OSList *failed_paths, OSList *pending_sync_updates);
 void create_unix_who_data_events(void * data, void * ctx);
 void fim_db_remove_entry(void * data, void * ctx);
 void fim_db_process_missing_entry(void * data, void * ctx);
@@ -1366,6 +1367,208 @@ static void test_fim_file_modify(void **state) {
     will_return(__wrap_fim_db_file_update, FIMDB_OK);
 
     fim_file(file_path, &configuration, &evt_data, NULL, NULL);
+}
+
+// Regression tests for #38608: reconcile_failed_paths_with_pending_sync() must remove, from
+// pending_sync_updates, only the items whose path also failed schema validation this scan
+// (failed_paths), compensating synced_docs_files for any that had sync_value == 1 — and must
+// leave every other pending item (and the counter, when nothing matches) untouched.
+
+static void test_reconcile_failed_paths_with_pending_sync_no_overlap(void **state) {
+    expect_any_always(__wrap__mdebug2, formatted_msg);
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
+    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+    ignore_function_calls(__wrap_pthread_rwlock_unlock);
+
+    OSList *failed_paths = OSList_Create();
+    OSList_SetFreeDataPointer(failed_paths, (void (*)(void *))free);
+    OSList_AddData(failed_paths, strdup("/etc/unrelated_failed.txt"));
+
+    OSList *pending_sync_updates = OSList_Create();
+    OSList_SetFreeDataPointer(pending_sync_updates, free_pending_sync_item);
+    cJSON *item_json = cJSON_CreateObject();
+    cJSON_AddStringToObject(item_json, "path", "/etc/a_test_file.txt");
+    cJSON_AddNumberToObject(item_json, "version", 1);
+    add_pending_sync_item(pending_sync_updates, item_json, 1);
+    cJSON_Delete(item_json);
+
+    int original_synced_docs_files = synced_docs_files;
+    synced_docs_files = 5;
+
+    reconcile_failed_paths_with_pending_sync(failed_paths, pending_sync_updates);
+
+    assert_int_equal(synced_docs_files, 5);
+    assert_int_equal(pending_sync_updates->currently_size, 1);
+    pending_sync_item_t *item = (pending_sync_item_t *)OSList_GetFirstNode(pending_sync_updates)->data;
+    assert_string_equal(cJSON_GetStringValue(cJSON_GetObjectItem(item->json, "path")), "/etc/a_test_file.txt");
+
+    synced_docs_files = original_synced_docs_files;
+    OSList_Destroy(failed_paths);
+    OSList_Destroy(pending_sync_updates);
+}
+
+static void test_reconcile_failed_paths_with_pending_sync_removes_match_and_compensates(void **state) {
+    expect_any_always(__wrap__mdebug2, formatted_msg);
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
+    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+    ignore_function_calls(__wrap_pthread_rwlock_unlock);
+
+    OSList *failed_paths = OSList_Create();
+    OSList_SetFreeDataPointer(failed_paths, (void (*)(void *))free);
+    OSList_AddData(failed_paths, strdup("/etc/a_test_file.txt"));
+
+    OSList *pending_sync_updates = OSList_Create();
+    OSList_SetFreeDataPointer(pending_sync_updates, free_pending_sync_item);
+    cJSON *item_json = cJSON_CreateObject();
+    cJSON_AddStringToObject(item_json, "path", "/etc/a_test_file.txt");
+    cJSON_AddNumberToObject(item_json, "version", 1);
+    add_pending_sync_item(pending_sync_updates, item_json, 1);
+    cJSON_Delete(item_json);
+
+    int original_synced_docs_files = synced_docs_files;
+    synced_docs_files = 5;
+
+    reconcile_failed_paths_with_pending_sync(failed_paths, pending_sync_updates);
+
+    // The matching item (and the count it had already added to synced_docs_files) is gone.
+    assert_int_equal(synced_docs_files, 4);
+    assert_int_equal(pending_sync_updates->currently_size, 0);
+
+    synced_docs_files = original_synced_docs_files;
+    OSList_Destroy(failed_paths);
+    OSList_Destroy(pending_sync_updates);
+}
+
+static void test_reconcile_failed_paths_with_pending_sync_match_with_sync_value_zero(void **state) {
+    expect_any_always(__wrap__mdebug2, formatted_msg);
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
+    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+    ignore_function_calls(__wrap_pthread_rwlock_unlock);
+
+    OSList *failed_paths = OSList_Create();
+    OSList_SetFreeDataPointer(failed_paths, (void (*)(void *))free);
+    OSList_AddData(failed_paths, strdup("/etc/a_test_file.txt"));
+
+    OSList *pending_sync_updates = OSList_Create();
+    OSList_SetFreeDataPointer(pending_sync_updates, free_pending_sync_item);
+    cJSON *item_json = cJSON_CreateObject();
+    cJSON_AddStringToObject(item_json, "path", "/etc/a_test_file.txt");
+    cJSON_AddNumberToObject(item_json, "version", 1);
+    add_pending_sync_item(pending_sync_updates, item_json, 0);
+    cJSON_Delete(item_json);
+
+    int original_synced_docs_files = synced_docs_files;
+    synced_docs_files = 5;
+
+    reconcile_failed_paths_with_pending_sync(failed_paths, pending_sync_updates);
+
+    // Removed from the pending list either way (its row is about to be deleted), but nothing
+    // to compensate: transaction_callback() never counted a sync_value == 0 item in the first
+    // place.
+    assert_int_equal(synced_docs_files, 5);
+    assert_int_equal(pending_sync_updates->currently_size, 0);
+
+    synced_docs_files = original_synced_docs_files;
+    OSList_Destroy(failed_paths);
+    OSList_Destroy(pending_sync_updates);
+}
+
+static void test_reconcile_failed_paths_with_pending_sync_multiple_items_partial_match(void **state) {
+    expect_any_always(__wrap__mdebug2, formatted_msg);
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
+    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+    ignore_function_calls(__wrap_pthread_rwlock_unlock);
+
+    OSList *failed_paths = OSList_Create();
+    OSList_SetFreeDataPointer(failed_paths, (void (*)(void *))free);
+    OSList_AddData(failed_paths, strdup("/etc/b_failed.txt"));
+
+    OSList *pending_sync_updates = OSList_Create();
+    OSList_SetFreeDataPointer(pending_sync_updates, free_pending_sync_item);
+
+    const char *paths[3] = {"/etc/a_ok.txt", "/etc/b_failed.txt", "/etc/c_ok.txt"};
+    for (int i = 0; i < 3; i++) {
+        cJSON *item_json = cJSON_CreateObject();
+        cJSON_AddStringToObject(item_json, "path", paths[i]);
+        cJSON_AddNumberToObject(item_json, "version", 1);
+        add_pending_sync_item(pending_sync_updates, item_json, 1);
+        cJSON_Delete(item_json);
+    }
+
+    int original_synced_docs_files = synced_docs_files;
+    synced_docs_files = 5;
+
+    reconcile_failed_paths_with_pending_sync(failed_paths, pending_sync_updates);
+
+    assert_int_equal(synced_docs_files, 4);
+    assert_int_equal(pending_sync_updates->currently_size, 2);
+
+    // Both surviving items keep their own data intact, in original relative order — proves
+    // OSList_DeleteThisNode() on the middle node didn't corrupt the remaining links.
+    OSListNode *node_it;
+    int found_a = 0, found_c = 0;
+    OSList_foreach(node_it, pending_sync_updates) {
+        pending_sync_item_t *item = (pending_sync_item_t *)node_it->data;
+        const char *path = cJSON_GetStringValue(cJSON_GetObjectItem(item->json, "path"));
+        if (strcmp(path, "/etc/a_ok.txt") == 0) {
+            found_a = 1;
+        } else if (strcmp(path, "/etc/c_ok.txt") == 0) {
+            found_c = 1;
+        } else {
+            fail_msg("Unexpected surviving item: %s", path);
+        }
+    }
+    assert_int_equal(found_a, 1);
+    assert_int_equal(found_c, 1);
+
+    synced_docs_files = original_synced_docs_files;
+    OSList_Destroy(failed_paths);
+    OSList_Destroy(pending_sync_updates);
+}
+
+static void test_reconcile_failed_paths_with_pending_sync_empty_lists_are_noop(void **state) {
+    expect_any_always(__wrap__mdebug2, formatted_msg);
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
+    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+    ignore_function_calls(__wrap_pthread_rwlock_unlock);
+
+    OSList *failed_paths = OSList_Create();
+    OSList_SetFreeDataPointer(failed_paths, (void (*)(void *))free);
+
+    OSList *pending_sync_updates = OSList_Create();
+    OSList_SetFreeDataPointer(pending_sync_updates, free_pending_sync_item);
+
+    int original_synced_docs_files = synced_docs_files;
+    synced_docs_files = 5;
+
+    // Both lists empty.
+    reconcile_failed_paths_with_pending_sync(failed_paths, pending_sync_updates);
+    assert_int_equal(synced_docs_files, 5);
+
+    // failed_paths empty, pending_sync_updates non-empty: nothing to reconcile against.
+    cJSON *item_json = cJSON_CreateObject();
+    cJSON_AddStringToObject(item_json, "path", "/etc/a_test_file.txt");
+    cJSON_AddNumberToObject(item_json, "version", 1);
+    add_pending_sync_item(pending_sync_updates, item_json, 1);
+    cJSON_Delete(item_json);
+
+    reconcile_failed_paths_with_pending_sync(failed_paths, pending_sync_updates);
+    assert_int_equal(synced_docs_files, 5);
+    assert_int_equal(pending_sync_updates->currently_size, 1);
+
+    synced_docs_files = original_synced_docs_files;
+    OSList_Destroy(failed_paths);
+    OSList_Destroy(pending_sync_updates);
 }
 
 static void test_fim_file_no_attributes(void **state) {
@@ -4504,6 +4707,13 @@ int main(void) {
 
         /* init_fim_data_entry */
         cmocka_unit_test(test_init_fim_data_entry),
+
+        /* reconcile_failed_paths_with_pending_sync (#38608) */
+        cmocka_unit_test(test_reconcile_failed_paths_with_pending_sync_no_overlap),
+        cmocka_unit_test(test_reconcile_failed_paths_with_pending_sync_removes_match_and_compensates),
+        cmocka_unit_test(test_reconcile_failed_paths_with_pending_sync_match_with_sync_value_zero),
+        cmocka_unit_test(test_reconcile_failed_paths_with_pending_sync_multiple_items_partial_match),
+        cmocka_unit_test(test_reconcile_failed_paths_with_pending_sync_empty_lists_are_noop),
 
         /* fim_file */
         cmocka_unit_test(test_fim_file_add),

--- a/src/unit_tests/syscheckd/test_fim_scan.c
+++ b/src/unit_tests/syscheckd/test_fim_scan.c
@@ -117,17 +117,17 @@ void __wrap_decode_win_attributes(char *str, unsigned int attrs) {
 }
 #endif
 
-extern void __real_process_pending_sync_updates(char* table_name, OSList *pending_items);
+extern int __real_process_pending_sync_updates(char* table_name, OSList *pending_items);
 
 /* Snapshot of mutex_unlock_call_count taken inside the wrap below, used by the
  * regression test for issue #37824 (fim_scan_mutex must stay held through
  * process_pending_sync_updates(), not just through the db transaction). */
 static unsigned int unlock_count_at_pending_sync_updates = 0;
 
-void __wrap_process_pending_sync_updates(char* table_name, OSList *pending_items) {
+int __wrap_process_pending_sync_updates(char* table_name, OSList *pending_items) {
     function_called();
     unlock_count_at_pending_sync_updates = mutex_unlock_call_count;
-    __real_process_pending_sync_updates(table_name, pending_items);
+    return __real_process_pending_sync_updates(table_name, pending_items);
 }
 
 static int setup_fim_data(void **state) {
@@ -1232,14 +1232,16 @@ static void test_fim_file_add_queues_sync_flag_update_end_to_end(void **state) {
     expect_string(__wrap__mdebug2, formatted_msg, "Added item to pending sync list: /etc/a_test_file_38522.txt (version: 1, sync: 1)");
 #endif
 
-    // process_pending_sync_updates() now genuinely has 1 item to process.
+    // process_pending_sync_updates() now genuinely has 1 item to process. No "Processed N
+    // pending sync flag updates" log is expected here: that summary is only logged by callers
+    // that run once per full scan (fim_file_scan(), fim_registry_scan()) — logging it from this
+    // realtime/whodata call site too would flood debug=1 on a mass create/modify (#38537 review).
     expect_function_call(__wrap_process_pending_sync_updates);
 #ifdef TEST_WINAGENT
     expect_string(__wrap__mdebug2, formatted_msg, "Setting sync=1 for path: c:\\windows\\system32\\cmd.exe");
 #else
     expect_string(__wrap__mdebug2, formatted_msg, "Setting sync=1 for path: /etc/a_test_file_38522.txt");
 #endif
-    expect_string(__wrap__mdebug1, formatted_msg, "Processed 1 pending sync flag updates");
 
     fim_file(file_path, &configuration, &evt_data, NULL, NULL);
 

--- a/src/unit_tests/syscheckd/test_fim_scan.c
+++ b/src/unit_tests/syscheckd/test_fim_scan.c
@@ -1146,7 +1146,7 @@ static void test_fim_file_add(void **state) {
 #ifdef TEST_WINAGENT
     char file_path[OS_SIZE_256] = "c:\\windows\\system32\\cmd.exe";
 #else
-    char file_path[OS_SIZE_256] = "/bin/ls";
+    char file_path[OS_SIZE_256] = "/etc/a_test_file_38522.txt";
 #endif
 
     // Ignore trying to match the exact pthread calls since OSList operations make this hard and these tests verify FIM file handling behavior, not locking implementation.
@@ -1159,10 +1159,93 @@ static void test_fim_file_add(void **state) {
     expect_get_data(strdup("user"), strdup("group"), file_path, 1);
 
     will_return(__wrap_fim_db_file_update, FIMDB_OK);
-    expect_function_call(__wrap_process_pending_sync_updates);
-    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
 
     fim_file(file_path, &configuration, &evt_data, NULL, NULL);
+}
+
+// Regression test for #38522, end-to-end through fim_file()'s non-transactional (realtime/
+// whodata) path itself — not through transaction_callback() called directly. The other tests in
+// this file only prove process_pending_sync_updates() gets called with whatever list fim_file()
+// built; since __wrap_fim_db_file_update() never drives its callback, that list is always empty,
+// so they can't tell a correctly-wired callback_ctx.pending_sync_updates apart from a NULL one
+// silently dropped by transaction_callback's own NULL guard — the exact regression this issue was
+// about. This test drives the mocked callback for real, so fim_file()'s own local
+// pending_sync_updates list gets genuinely populated by the same code fim_file() constructs,
+// and asserts process_pending_sync_updates() reports 1 processed item, not 0.
+static void test_fim_file_add_queues_sync_flag_update_end_to_end(void **state) {
+    event_data_t evt_data = { .mode = FIM_REALTIME, .w_evt = NULL, .report_event = true, .statbuf = DEFAULT_STATBUF };
+    directory_t configuration = { .options = CHECK_SIZE | CHECK_PERM | CHECK_OWNER | CHECK_GROUP | CHECK_MD5SUM |
+                                             CHECK_SHA1SUM | CHECK_MTIME | CHECK_SHA256SUM };
+#ifdef TEST_WINAGENT
+    char file_path[OS_SIZE_256] = "c:\\windows\\system32\\cmd.exe";
+#else
+    char file_path[OS_SIZE_256] = "/etc/a_test_file_38522.txt";
+#endif
+
+    ignore_function_calls(__wrap_pthread_rwlock_wrlock);
+    ignore_function_calls(__wrap_pthread_rwlock_unlock);
+    ignore_function_calls(__wrap_pthread_mutex_lock);
+    ignore_function_calls(__wrap_pthread_mutex_unlock);
+    ignore_function_calls(__wrap_pthread_rwlock_rdlock);
+
+    int original_synced_docs_files = synced_docs_files;
+    // send_syscheck_msg() only fires when notify_scan is set — true on a live agent past its
+    // first scan (this file's OTHER tests never reach this check, so nothing else in this group
+    // sets it; only the separate test_transaction_callback_* fixture does, for its own tests).
+    int original_notify_scan = notify_scan;
+    notify_scan = 1;
+
+    expect_get_data(strdup("user"), strdup("group"), file_path, 1);
+
+#ifdef TEST_WINAGENT
+    cJSON *result = cJSON_Parse(
+        "{\"attributes\":\"\",\"checksum\":\"d0e2e27875639745261c5d1365eb6c9fb7319247\",\"device\":64768,"
+        "\"gid\":0,\"group_\":\"root\",\"hash_md5\":\"d41d8cd98f00b204e9800998ecf8427e\","
+        "\"hash_sha1\":\"da39a3ee5e6b4b0d3255bfef95601890afd80709\","
+        "\"hash_sha256\":\"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\","
+        "\"inode\":\"801978\",\"mtime\":1645001030,\"path\":\"c:\\\\windows\\\\system32\\\\cmd.exe\","
+        "\"permissions\":\"rw-r--r--\",\"size\":0,\"uid\":0,\"owner\":\"root\",\"version\":1}");
+#else
+    cJSON *result = cJSON_Parse(
+        "{\"attributes\":\"\",\"checksum\":\"d0e2e27875639745261c5d1365eb6c9fb7319247\",\"device\":64768,"
+        "\"gid\":0,\"group_\":\"root\",\"hash_md5\":\"d41d8cd98f00b204e9800998ecf8427e\","
+        "\"hash_sha1\":\"da39a3ee5e6b4b0d3255bfef95601890afd80709\","
+        "\"hash_sha256\":\"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\","
+        "\"inode\":\"801978\",\"mtime\":1645001030,\"path\":\"/etc/a_test_file_38522.txt\","
+        "\"permissions\":\"rw-r--r--\",\"size\":0,\"uid\":0,\"owner\":\"root\",\"version\":1}");
+#endif
+    assert_non_null(result);
+
+    expect_fim_db_file_update_invoking_callback();
+    will_return(__wrap_fim_db_file_update, FIMDB_OK);
+    will_return(__wrap_fim_db_file_update, INSERTED);
+    will_return(__wrap_fim_db_file_update, result);
+
+    // Inside transaction_callback's INSERTED branch (file_limit=0/unlimited in this test group).
+    expect_function_call(__wrap_send_syscheck_msg);
+    will_return(__wrap_validate_and_persist_fim_event, true);
+#ifdef TEST_WINAGENT
+    expect_string(__wrap__mdebug2, formatted_msg, "INSERTED: file_limit=0 (unlimited), sync_flag=1, path=c:\\windows\\system32\\cmd.exe");
+    expect_string(__wrap__mdebug2, formatted_msg, "Added item to pending sync list: c:\\windows\\system32\\cmd.exe (version: 1, sync: 1)");
+#else
+    expect_string(__wrap__mdebug2, formatted_msg, "INSERTED: file_limit=0 (unlimited), sync_flag=1, path=/etc/a_test_file_38522.txt");
+    expect_string(__wrap__mdebug2, formatted_msg, "Added item to pending sync list: /etc/a_test_file_38522.txt (version: 1, sync: 1)");
+#endif
+
+    // process_pending_sync_updates() now genuinely has 1 item to process.
+    expect_function_call(__wrap_process_pending_sync_updates);
+#ifdef TEST_WINAGENT
+    expect_string(__wrap__mdebug2, formatted_msg, "Setting sync=1 for path: c:\\windows\\system32\\cmd.exe");
+#else
+    expect_string(__wrap__mdebug2, formatted_msg, "Setting sync=1 for path: /etc/a_test_file_38522.txt");
+#endif
+    expect_string(__wrap__mdebug1, formatted_msg, "Processed 1 pending sync flag updates");
+
+    fim_file(file_path, &configuration, &evt_data, NULL, NULL);
+
+    cJSON_Delete(result);
+    synced_docs_files = original_synced_docs_files;
+    notify_scan = original_notify_scan;
 }
 
 static void test_fim_file_modify_transaction(void **state) {
@@ -1178,7 +1261,7 @@ static void test_fim_file_modify_transaction(void **state) {
     char file_path[OS_SIZE_256] = "c:\\windows\\system32\\cmd.exe";
     cJSON *permissions = create_win_permissions_object();
 #else
-    char file_path[OS_SIZE_256] = "/bin/ls";
+    char file_path[OS_SIZE_256] = "/etc/a_test_file_38522.txt";
 #endif
 
     fim_data->fentry->file_entry.path = strdup("file");
@@ -1239,7 +1322,7 @@ static void test_fim_file_modify(void **state) {
     char file_path[OS_SIZE_256] = "c:\\windows\\system32\\cmd.exe";
     cJSON *permissions = create_win_permissions_object();
 #else
-    char file_path[OS_SIZE_256] = "/bin/ls";
+    char file_path[OS_SIZE_256] = "/etc/a_test_file_38522.txt";
 #endif
 
     fim_data->fentry->file_entry.path = strdup("file");
@@ -1279,8 +1362,6 @@ static void test_fim_file_modify(void **state) {
                                         0x400, 0);
 
     will_return(__wrap_fim_db_file_update, FIMDB_OK);
-    expect_function_call(__wrap_process_pending_sync_updates);
-    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
 
     fim_file(file_path, &configuration, &evt_data, NULL, NULL);
 }
@@ -1295,7 +1376,7 @@ static void test_fim_file_no_attributes(void **state) {
     char file_path[] = "c:\\windows\\system32\\cmd.exe";
     cJSON *permissions = create_win_permissions_object();
 #else
-    char file_path[] = "/bin/ls";
+    char file_path[] = "/etc/a_test_file_38522.txt";
 #endif
 
     // Inside fim_get_data
@@ -1345,7 +1426,7 @@ static void test_fim_file_error_on_insert(void **state) {
     char file_path[OS_SIZE_256] = "c:\\windows\\system32\\cmd.exe";
     cJSON *permissions = create_win_permissions_object();
 #else
-    char file_path[OS_SIZE_256] = "/bin/ls";
+    char file_path[OS_SIZE_256] = "/etc/a_test_file_38522.txt";
 #endif
 
     fim_data->fentry->file_entry.path = strdup(file_path);
@@ -1385,8 +1466,6 @@ static void test_fim_file_error_on_insert(void **state) {
     will_return(__wrap_OS_MD5_SHA1_SHA256_File, 0);
 
     will_return(__wrap_fim_db_file_update, FIMDB_OK);
-    expect_function_call(__wrap_process_pending_sync_updates);
-    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
 
     fim_file(file_path, &configuration, &evt_data, NULL, NULL);
 }
@@ -1573,8 +1652,6 @@ static void test_fim_checker_fim_regular(void **state) {
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, strdup("group"));
     will_return(__wrap_fim_db_file_update, FIMDB_OK);
-    expect_function_call(__wrap_process_pending_sync_updates);
-    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
 
     fim_checker(path, &evt_data, NULL, NULL, NULL);
 }
@@ -1610,8 +1687,6 @@ static void test_fim_checker_fim_regular_warning(void **state) {
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, strdup("group"));
     will_return(__wrap_fim_db_file_update, FIMDB_OK);
-    expect_function_call(__wrap_process_pending_sync_updates);
-    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
 
     fim_checker(path, &evt_data, NULL, NULL, NULL);
 }
@@ -1796,8 +1871,6 @@ static void test_fim_checker_root_file_within_recursion_level(void **state) {
     expect_value(__wrap_get_group, gid, 0);
     will_return(__wrap_get_group, strdup("group"));
     will_return(__wrap_fim_db_file_update, FIMDB_OK);
-    expect_function_call(__wrap_process_pending_sync_updates);
-    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
 
     fim_checker(path, &evt_data, NULL, NULL, NULL);
 }
@@ -2437,8 +2510,6 @@ static void test_fim_checker_fim_regular(void **state) {
     will_return(__wrap_fim_db_file_update, FIMDB_OK);
     expect_string(__wrap_w_get_file_attrs, file_path, expanded_path);
     will_return(__wrap_w_get_file_attrs, 123456);
-    expect_function_call(__wrap_process_pending_sync_updates);
-    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
     fim_checker(expanded_path, &evt_data, NULL, NULL, NULL);
 }
 
@@ -2532,8 +2603,6 @@ static void test_fim_checker_fim_regular_warning(void **state) {
     will_return(__wrap_w_get_file_attrs, 123456);
 
     will_return(__wrap_fim_db_file_update, FIMDB_OK);
-    expect_function_call(__wrap_process_pending_sync_updates);
-    expect_string(__wrap__mdebug1, formatted_msg, "Processed 0 pending sync flag updates");
 
     fim_checker(expanded_path, &evt_data, NULL, NULL, NULL);
 }
@@ -4436,6 +4505,7 @@ int main(void) {
 
         /* fim_file */
         cmocka_unit_test(test_fim_file_add),
+        cmocka_unit_test(test_fim_file_add_queues_sync_flag_update_end_to_end),
         cmocka_unit_test_setup_teardown(test_fim_file_modify, setup_fim_entry, teardown_fim_entry),
         cmocka_unit_test_setup_teardown(test_fim_file_modify_transaction, setup_fim_entry, teardown_fim_entry),
 

--- a/src/unit_tests/syscheckd/test_fim_sync_limits.c
+++ b/src/unit_tests/syscheckd/test_fim_sync_limits.c
@@ -23,7 +23,7 @@
 // External function declarations from syscheck.c
 extern void persist_sync_documents(char* table_name, cJSON* docs, Operation_t operation);
 extern void add_pending_sync_item(OSList *pending_items, const cJSON *json, int sync_value);
-extern void process_pending_sync_updates(char* table_name, OSList *pending_items);
+extern int process_pending_sync_updates(char* table_name, OSList *pending_items);
 extern cJSON* extract_primary_keys(const char* table_name, const cJSON* full_doc);
 extern int drop_orphaned_promoted_documents(const char* table_name, cJSON* docs);
 
@@ -540,11 +540,12 @@ static void test_process_pending_sync_updates_files(void **state) {
     expect_value(__wrap_fim_db_set_sync_flag, sync_value, 1);
     will_return(__wrap_fim_db_set_sync_flag, 0);
 
-    // Process updates
+    // Process updates. process_pending_sync_updates() no longer logs a summary itself (callers
+    // that run once per scan do that from the returned count instead) — assert on the count.
     expect_string(__wrap__mdebug2, formatted_msg, "Setting sync=1 for path: /tmp/test1.txt");
     expect_string(__wrap__mdebug2, formatted_msg, "Setting sync=1 for path: /tmp/test2.txt");
-    expect_string(__wrap__mdebug1, formatted_msg, "Processed 2 pending sync flag updates");
-    process_pending_sync_updates(FIMDB_FILE_TABLE_NAME, pending);
+    int processed = process_pending_sync_updates(FIMDB_FILE_TABLE_NAME, pending);
+    assert_int_equal(processed, 2);
 
     // Clean up
     cJSON_Delete(item1);

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
@@ -80,6 +80,10 @@ void expect_fim_db_file_update_invoking_callback(void) {
     drive_fim_db_file_update_callback = true;
 }
 
+void reset_fim_db_file_update_invoking_callback(void) {
+    drive_fim_db_file_update_callback = false;
+}
+
 FIMDBErrorCode __wrap_fim_db_file_update(__attribute__((unused)) fim_entry* new,
                               callback_context_t callback)
 {

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.c
@@ -11,6 +11,7 @@
 #include <stddef.h>
 #include <stdarg.h>
 #include <setjmp.h>
+#include <stdbool.h>
 #include <cmocka.h>
 
 int __wrap_fim_db_get_count_file_entry(){
@@ -73,10 +74,25 @@ void expect_fim_db_remove_path(const char *path, int ret_val) {
     will_return(__wrap_fim_db_remove_path, ret_val);
 }
 
+static bool drive_fim_db_file_update_callback = false;
+
+void expect_fim_db_file_update_invoking_callback(void) {
+    drive_fim_db_file_update_callback = true;
+}
+
 FIMDBErrorCode __wrap_fim_db_file_update(__attribute__((unused)) fim_entry* new,
-                              __attribute__((unused)) callback_context_t callback)
+                              callback_context_t callback)
 {
-    return mock_type(int);
+    FIMDBErrorCode ret = mock_type(int);
+
+    if (drive_fim_db_file_update_callback) {
+        drive_fim_db_file_update_callback = false;
+        ReturnTypeCallback result_type = mock_type(int);
+        cJSON* result_json = mock_ptr_type(cJSON*);
+        callback.callback_txn(result_type, result_json, callback.context);
+    }
+
+    return ret;
 }
 
 FIMDBErrorCode __wrap_fim_db_file_pattern_search(const char* pattern,

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
@@ -52,6 +52,16 @@ void expect_fim_db_remove_path(const char* path, int ret_val);
 
 FIMDBErrorCode __wrap_fim_db_file_update(fim_entry* new, callback_context_t callback);
 
+/**
+ * @brief Make the next call to __wrap_fim_db_file_update() invoke its callback with the given
+ * dbsync result, instead of just returning. One-shot: resets itself after firing once.
+ *
+ * Queue this, then will_return(__wrap_fim_db_file_update, <FIMDBErrorCode>) as usual, then
+ * will_return(__wrap_fim_db_file_update, <ReturnTypeCallback>) and
+ * will_return(__wrap_fim_db_file_update, <cJSON* result>) for the callback invocation itself.
+ */
+void expect_fim_db_file_update_invoking_callback(void);
+
 FIMDBErrorCode __wrap_fim_db_file_pattern_search(const char* pattern,
                                                  __attribute__((unused)) callback_context_t callback);
 

--- a/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/syscheckd/fim_db_wrappers.h
@@ -62,6 +62,16 @@ FIMDBErrorCode __wrap_fim_db_file_update(fim_entry* new, callback_context_t call
  */
 void expect_fim_db_file_update_invoking_callback(void);
 
+/**
+ * @brief Undo a pending expect_fim_db_file_update_invoking_callback() that never fired.
+ *
+ * The one-shot flag it sets only clears itself inside __wrap_fim_db_file_update() when the
+ * callback actually runs. If the test aborts earlier (e.g. a failed assert/expectation), the
+ * flag leaks into the next test, which would then try to drive a callback using mock values
+ * that were never queued for it. Call this from a teardown to guarantee it's cleared either way.
+ */
+void reset_fim_db_file_update_invoking_callback(void);
+
 FIMDBErrorCode __wrap_fim_db_file_pattern_search(const char* pattern,
                                                  __attribute__((unused)) callback_context_t callback);
 

--- a/tests/integration/test_fim/test_files/test_basic_usage/data/configuration_templates/configuration_orphan_promote.yaml
+++ b/tests/integration/test_fim/test_files/test_basic_usage/data/configuration_templates/configuration_orphan_promote.yaml
@@ -1,7 +1,8 @@
 # Configuration template for tests covering issue #36134:
 # a previously realtime-monitored directory is removed from the FIM
 # configuration and the agent is restarted, so fim_initialize must
-# *not* log an ERROR for the rows that still live in fim.db.
+# *not* log an ERROR for the rows that still live in fim.db. Also covers
+# #38522 (realtime inserts must queue their sync flag right away).
 #
 # Two <directories> entries:
 #   - TEST_DIR_REALTIME (realtime) is what the test drops at restart;

--- a/tests/integration/test_fim/test_files/test_basic_usage/data/test_cases/cases_orphan_promote.yaml
+++ b/tests/integration/test_fim/test_files/test_basic_usage/data/test_cases/cases_orphan_promote.yaml
@@ -1,18 +1,30 @@
 # Reproduces issue #36134: removing a realtime FIM rule from the agent
 # configuration must not produce
 #   ERROR: Failed to get configuration for path: <orphaned-file>
-# on the next restart, and the orphaned row must be cleaned up by the
-# regular handle_orphaned_delete path.
+# on the next restart. Also covers #38522: a file first seen via the
+# realtime inotify path must get sync=1 queued right away, not left at
+# sync=0, and its stateful DELETE must actually persist once its directory
+# is dropped from the configuration and the scheduled scan cleans it up as
+# an orphan.
+#
+# NOTE on #36134 coverage: with #38522 fixed, a realtime insert under the
+# default (unlimited) file_limit gets sync=1 immediately, so it's never a
+# docs_to_promote candidate and never reaches #36134's orphan-drop-on-
+# promote branch (drop_orphaned_promoted_documents) — that branch only
+# fires for rows dbsync still has as sync=0. Reproducing that specific case
+# needs a file_limit increase between the two agent starts (the promote
+# loop's own outer gate is "synced_docs < limit", which a constant limit
+# with a still-throttled row never satisfies) — deliberately left out of
+# this case to keep the scenario simple; see the module docstring.
 - name: Orphan promote - Real-time directory dropped from config
-  description: A realtime directory is monitored, a file is created under it
-               via the inotify path (so the row lands in fim.db with sync=0),
-               the agent is stopped, the realtime <directories> entry is
-               removed from ossec.conf, and the agent is restarted.
-               fim_initialize must drop the orphan from docs_to_promote
-               instead of feeding it to build_stateful_event_file, and the
-               scheduled scan that follows must emit the orphan delete event
-               for both the realtime-added file and the seed file that
-               lived under the same directory.
+  description: A realtime directory is monitored. A file (test_file) is
+               created under it via the inotify path and must get sync=1
+               queued right away (#38522). The agent is stopped, the
+               realtime <directories> entry is removed from ossec.conf, and
+               the agent is restarted with no ERROR logged for the orphaned
+               paths (#36134). test_file's orphan delete must be generated
+               and actually persisted by the scheduled scan that follows
+               the restart (#38522).
   configuration_parameters:
     TEST_DIR_REALTIME: !!python/object/apply:os.path.join [/test_dir_36134_realtime]
     TEST_DIR_KEEP: !!python/object/apply:os.path.join [/test_keep_36134]

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_orphan_promote_after_config_removal.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_orphan_promote_after_config_removal.py
@@ -300,17 +300,26 @@ def test_orphan_promote_after_config_removal(
     time.sleep(2)
     delete_log_text = Path(WAZUH_LOG_PATH).read_text()
 
-    generating_delete_lines = [
-        line for line in delete_log_text.splitlines()
+    all_lines = delete_log_text.splitlines()
+    generating_delete_line_indices = [
+        i for i, line in enumerate(all_lines)
         if re.search(HANDLE_ORPHANED_DELETE_PATTERN, line) and str(target_file) in line
     ]
+    generating_delete_lines = [all_lines[i] for i in generating_delete_line_indices]
     assert generating_delete_lines, (
         f'Expected "Generating delete event for orphaned file" line for '
         f'{target_file}, got none. ossec.log tail:\n{delete_log_text[-2000:]}'
     )
 
+    # The "Persisting FIM event" payload carries no event-type field, so a create and a
+    # delete for the same path produce an identical-looking log line. target_file's original
+    # CREATE (earlier in this same ossec.log, from _setup_orphan_test_folders) already left
+    # one such line — searching the whole file would let that stale line satisfy this
+    # assertion even if the DELETE itself was never persisted, exactly the #38522 bug this
+    # test exists to catch. Anchor the search to lines from the orphan-delete detection
+    # onward so only a persist for THIS delete can match.
     persisted_lines = [
-        line for line in delete_log_text.splitlines()
+        line for line in all_lines[generating_delete_line_indices[0]:]
         if re.search(PERSISTING_FIM_EVENT_PATTERN.format(path=target_file_pattern), line)
     ]
     assert persisted_lines, (

--- a/tests/integration/test_fim/test_files/test_basic_usage/test_orphan_promote_after_config_removal.py
+++ b/tests/integration/test_fim/test_files/test_basic_usage/test_orphan_promote_after_config_removal.py
@@ -8,14 +8,39 @@ copyright: Copyright (C) 2015-2024, Wazuh Inc.
 type: integration
 
 brief: Regression test for issue #36134. When a realtime <directories> rule
-       is removed from ossec.conf and the agent is restarted, the previously
-       monitored files still live in the local fim.db with sync=0. The agent's
-       fim_initialize() promote loop must drop those orphaned rows up front
-       rather than calling build_stateful_event_file() with the current
-       directories list (which would log
-       "ERROR: Failed to get configuration for path: <path>"). The orphan-
+       is removed from ossec.conf and the agent is restarted, an orphaned row
+       (its directory no longer resolves in the current configuration) must
+       not make fim_initialize's promote loop log
+       "ERROR: Failed to get configuration for path: <path>". The orphan-
        cleanup path in the next scheduled scan is responsible for emitting
        the real DELETE event.
+
+       Also covers #38522: until it was fixed, every file first seen through
+       a realtime event landed in fim.db with sync=0 (the non-transactional
+       insert path never flushed the sync flag). That same missing sync flag
+       meant the orphan-delete path's own persistence gate
+       (validate_and_persist_fim_event) silently dropped the resulting
+       DELETE too — the underlying #38522 bug, just reached through a
+       different trigger than a plain on-disk delete. This test asserts that
+       sync=1 gets queued for the realtime-added file as soon as it's
+       created, and that the orphan-delete path actually persists a
+       stateful DELETE for it (not just logs that it tried to) once its
+       directory is dropped from the configuration.
+
+       NOTE on #36134 coverage: with #38522 fixed, a realtime insert under
+       the default (unlimited) file_limit gets sync=1 immediately, so it's
+       never a docs_to_promote candidate and never reaches #36134's
+       orphan-drop-on-promote branch (drop_orphaned_promoted_documents) —
+       that branch only fires for rows dbsync still has as sync=0.
+       Reproducing that specific branch needs a file_limit increase between
+       two agent starts (the promote loop's own outer gate is
+       "synced_docs < limit", which a constant limit with a still-throttled
+       row never satisfies), which is a materially different scenario from
+       "a realtime rule got dropped". This test keeps the general "no ERROR
+       for an orphaned path" assertion as a cheap regression guard, but a
+       dedicated test exercising drop_orphaned_promoted_documents itself
+       (via a genuine file_limit increase) is a separate, still-open gap —
+       not something this PR's scope covers.
 
        The test seeds a small file under both <directories> before the agent
        starts so the baseline scan promotes at least one row to sync=1; that
@@ -42,12 +67,14 @@ os_platform:
 
 references:
     - https://github.com/wazuh/wazuh/issues/36134
+    - https://github.com/wazuh/wazuh/issues/38522
     - https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html
 
 tags:
     - fim
     - realtime
 '''
+import re
 import sys
 import time
 
@@ -87,14 +114,20 @@ if sys.platform == WINDOWS:
 
 # Log patterns specific to this regression — not (yet) exposed by
 # wazuh_testing.modules.fim.patterns.
-FAILED_TO_GET_CONFIG_PATTERN = r'.*ERROR: Failed to get configuration for path: (\S+)'
-SKIPPING_PROMOTION_PATTERN = (
-    r'.*Skipping promotion of orphaned path \(no active configuration\): (\S+)'
-)
 HANDLE_ORPHANED_DELETE_PATTERN = (
     r".*Generating delete event for orphaned file '(\S+)' \(path removed from configuration\)"
 )
 DOCUMENT_LIMIT_CHANGED_PATTERN = r'.*Document limit (increased|decreased)'
+# #38522: the non-transactional (realtime/whodata) insert path now queues the
+# sync flag update as soon as the file is first seen, instead of leaving the
+# row at sync=0 forever. version is left as \d+ since dbsync assigns it, not
+# this test.
+SYNC_FLAG_QUEUED_PATTERN = r'.*Added item to pending sync list: {path} \(version: \d+, sync: 1\)'
+# #38522: confirms handle_orphaned_delete's stateful event actually cleared
+# validate_and_persist_fim_event's sync gate, not just that the function was
+# entered — the "Generating delete event" line alone fires unconditionally,
+# before that gate is checked.
+PERSISTING_FIM_EVENT_PATTERN = r'.*Persisting FIM event: .*"path":\s*"{path}"'
 
 
 @pytest.fixture()
@@ -157,26 +190,26 @@ def test_orphan_promote_after_config_removal(
     start_monitoring,
 ):
     '''
-    description: Reproduce issue #36134 and verify the fix.
+    description: Reproduce issue #36134 and verify the fix, plus lock in #38522's
+                 fix for the same realtime insert path.
 
                  The agent is started with two <directories> rules: one
                  realtime path that the test will drop later, and one
                  scheduled path that stays in the config. Both folders are
                  pre-seeded with a sentinel file so the initial baseline
                  scan promotes at least one row to sync=1. The test then
-                 creates a file under the realtime folder via inotify (so
-                 the row lands in fim.db with sync=0), stops the agent,
-                 strips the realtime <directories> entry from ossec.conf,
-                 and restarts the agent.
+                 creates a file under the realtime folder via inotify, stops
+                 the agent, strips the realtime <directories> entry from
+                 ossec.conf, and restarts the agent.
 
                  The fixed agent must:
-                   1) not log "ERROR: Failed to get configuration for path"
-                      for the orphaned file,
-                   2) log the helper's
-                      "Skipping promotion of orphaned path (no active
-                      configuration): <file>" debug line,
+                   1) queue the sync flag update for the realtime-added file
+                      as soon as it's created (#38522),
+                   2) not log "ERROR: Failed to get configuration for path"
+                      for the orphaned file after the config is dropped,
                    3) still emit the orphan delete event via
-                      handle_orphaned_delete on the next scheduled scan.
+                      handle_orphaned_delete on the next scheduled scan, and
+                      actually persist it (not just log that it tried to).
 
     wazuh_min_version: 5.0.0
 
@@ -184,18 +217,32 @@ def test_orphan_promote_after_config_removal(
     '''
     realtime_folder = Path(test_metadata['realtime_folder'])
     target_file = realtime_folder / test_metadata['test_file']
+    target_file_pattern = re.escape(str(target_file))
 
     # Step 1: agent is up via daemons_handler. The baseline scan has
     # already visited both folders and promoted the seed files to sync=1
     # (start_monitoring blocks until the first sync finishes).
     #
-    # Create the realtime-tracked file. inotify queues an "added" event;
-    # the row lands in fim.db with sync=0 (the realtime path does not
-    # flush the sync flag).
+    # Create the realtime-tracked file. inotify queues an "added" event; with
+    # #38522 fixed, the row lands in fim.db with sync=1 right away instead of
+    # being stuck at sync=0.
     file.write_file(str(target_file), 'evidence-36134')
     FileMonitor(WAZUH_LOG_PATH).start(
         generate_callback(EVENT_TYPE_ADDED),
         timeout=30,
+    )
+
+    # Assertion 1 (#38522 regression): the realtime insert queued the sync
+    # flag update for target_file. Read before step 2 truncates the log.
+    creation_log_text = Path(WAZUH_LOG_PATH).read_text()
+    sync_queued_lines = [
+        line for line in creation_log_text.splitlines()
+        if re.search(SYNC_FLAG_QUEUED_PATTERN.format(path=target_file_pattern), line)
+    ]
+    assert sync_queued_lines, (
+        f'Expected a "Added item to pending sync list" line with sync: 1 for '
+        f'{target_file} right after its creation, got none. ossec.log tail:'
+        f'\n{creation_log_text[-2000:]}'
     )
 
     # Step 2: stop the agent, drop the realtime <directories> rule from
@@ -208,25 +255,27 @@ def test_orphan_promote_after_config_removal(
     services.control_service('start')
 
     # Wait for fim_initialize() to log its "Document limit (increased|
-    # decreased)" line — that signals the promote loop ran with our
-    # docs_to_promote in hand. If this never appears the promote branch
-    # was short-circuited (e.g. no sync=1 rows) and the test setup is
-    # wrong.
+    # decreased)" line — that signals the promote loop ran (it does even
+    # with an empty docs_to_promote array: on the non-error path,
+    # fim_db_get_documents_to_promote returns a valid, non-NULL cJSON array
+    # regardless of how many sync=0 rows it found). If this never appears
+    # the promote branch was short-circuited (e.g. no sync=1 rows) and the
+    # test setup is wrong.
     FileMonitor(WAZUH_LOG_PATH).start(
         generate_callback(DOCUMENT_LIMIT_CHANGED_PATTERN),
         timeout=60,
     )
 
-    # Give fim_initialize a beat to finish so the orphan-skip mdebug2
-    # lands in the log file before we read it.
+    # Give fim_initialize a beat to finish before we read the log.
     time.sleep(2)
 
     log_text = Path(WAZUH_LOG_PATH).read_text()
 
-    # Assertion 1 (the regression itself): no ERROR for any orphaned path.
-    # We match by directory prefix because both the seed_file and the
-    # realtime-added test file are orphans now — neither should produce
-    # a merror.
+    # Assertion 2 (the #36134 regression itself): no ERROR for any orphaned
+    # path under realtime_folder. This guards seed_file and target_file
+    # alike — both are orphans once the directory is dropped, regardless of
+    # whether either one is still an active docs_to_promote candidate at
+    # this point.
     failed_lines = [
         line for line in log_text.splitlines()
         if 'ERROR: Failed to get configuration for path' in line
@@ -237,20 +286,36 @@ def test_orphan_promote_after_config_removal(
         f'{realtime_folder}:\n' + '\n'.join(failed_lines)
     )
 
-    # Assertion 2: the fix's debug line fired for the realtime-added
-    # file (the one with sync=0 that gets fed to docs_to_promote).
-    skip_lines = [
-        line for line in log_text.splitlines()
-        if 'Skipping promotion of orphaned path' in line and str(target_file) in line
-    ]
-    assert skip_lines, (
-        f'Expected "Skipping promotion of orphaned path" line for '
-        f'{target_file}, got none. ossec.log tail:\n{log_text[-2000:]}'
-    )
-
-    # Assertion 3: the existing orphan-delete path still handles cleanup
-    # on the first scheduled scan after restart.
+    # Assertion 3: the existing orphan-delete path still handles cleanup of
+    # target_file on the first scheduled scan after restart, and actually
+    # persists the stateful DELETE (not just logs that it tried to — the
+    # "Generating delete event" line fires unconditionally, before
+    # validate_and_persist_fim_event's sync gate is checked; #38522 was
+    # exactly that gate silently dropping the event for a sync=0 row).
     FileMonitor(WAZUH_LOG_PATH).start(
         generate_callback(HANDLE_ORPHANED_DELETE_PATTERN),
         timeout=90,
+    )
+
+    time.sleep(2)
+    delete_log_text = Path(WAZUH_LOG_PATH).read_text()
+
+    generating_delete_lines = [
+        line for line in delete_log_text.splitlines()
+        if re.search(HANDLE_ORPHANED_DELETE_PATTERN, line) and str(target_file) in line
+    ]
+    assert generating_delete_lines, (
+        f'Expected "Generating delete event for orphaned file" line for '
+        f'{target_file}, got none. ossec.log tail:\n{delete_log_text[-2000:]}'
+    )
+
+    persisted_lines = [
+        line for line in delete_log_text.splitlines()
+        if re.search(PERSISTING_FIM_EVENT_PATTERN.format(path=target_file_pattern), line)
+    ]
+    assert persisted_lines, (
+        f'The orphan delete for {target_file} was generated but never '
+        f'persisted (no matching "Persisting FIM event" line) — this is '
+        f'exactly the #38522 bug: the sync gate silently dropped the '
+        f'stateful DELETE. ossec.log tail:\n{delete_log_text[-2000:]}'
     )


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Files first detected by a realtime/whodata event never had their local `sync` column promoted to `1` in the agent's FIM database, because the non-transactional branch of `fim_file()` (the one realtime/whodata uses for a single file) built its `callback_ctx` without a `pending_sync_updates` list — it stayed `NULL`, so `transaction_callback()`'s `INSERTED`/`MODIFIED` branches silently skipped queuing the sync flag update. The stateful CREATE event still got persisted (its own locally-computed flag defaults to 1), so the file did show up in `wazuh-states-fim-files`.

When that file is later deleted, the `DELETED` branch reads the sync flag from the local DB column (still `0`) and `validate_and_persist_fim_event()` drops the stateful DELETE because it requires `sync_flag == 1`. The stateless alert had already fired before that gate, so the delete alert appears in `wazuh-findings*` but the state document is never removed from `wazuh-states-fim-files` — it stays there forever, since the local row is unconditionally deleted right after, leaving nothing to reconcile on a later scan or restart.

Closes #38522

## Proposed Changes

- `src/syscheckd/src/file/file.c`: in `fim_file()`'s non-transactional branch, create a `pending_sync_updates` list, wire it into the `callback_ctx`, and call `process_pending_sync_updates(FIMDB_FILE_TABLE_NAME, pending_sync_updates)` after `fim_db_file_update()` — mirroring the pattern the scheduled-scan path (`fim_file_scan()`) already uses. Added a short comment explaining why this path doesn't need `syscheck.fim_scan_mutex` (see Results and Evidence).
- Fixes both the `INSERTED` case (the one reported in the issue) and, as a side effect of sharing the same `callback_ctx` field, the `MODIFIED` promotion branch (`sync_flag == 0 && file_limit > 0`), which had the same silent-skip bug for files first seen via realtime/whodata.
- `src/unit_tests/syscheckd/test_fim_scan.c`: updated the expectations of 8 existing tests that now exercise the new `process_pending_sync_updates()` call (both the Linux and `TEST_WINAGENT` variants), and added two new regression tests (`test_transaction_callback_add_queues_sync_flag_update`, `test_transaction_callback_modify_promotes_pending_sync_update`) asserting the sync item actually gets queued with `sync_value=1` for the `INSERTED` and `MODIFIED`-promote cases.

### Results and Evidence

Root cause confirmed by code review (already documented in the issue) and reproduced live on a running agent on this session's VM before writing the fix: with `<directories realtime="yes">/testfim</directories>` and `syscheck.debug=2`, creating and deleting a file under `/testfim` showed `send_syscheck_msg` (the stateless alert) for the delete, but **no** `persist_syscheck_msg`/"Persisting FIM event" line — unlike the create, which had both. The local row for that path was gone from `fim.db` afterwards, confirming the state document is left orphaned with nothing left to reconcile.

Independent review of this diff:
- `code-config-reviewer` flagged (1) the `TEST_WINAGENT` variant of two tests (`test_fim_checker_fim_regular`, `test_fim_checker_fim_regular_warning`) was missing the same expectation update — fixed; (2) the non-transactional path of `fim_file()` never takes `syscheck.fim_scan_mutex`, unlike `fim_file_scan()`, raising a possible use-after-free risk with `fim_shutdown_waiter()`'s teardown of the FIMDB context.
- A follow-up adversarial review confirmed (1) is resolved, and re-checked (2) against `FIMDB::updateItem()`/`FIMDB::teardown()` (`fimDB.cpp`): both the pre-existing `fim_db_file_update()` call and the new `fim_db_set_sync_flag()` call go through `FIMDB::instance().updateItem()`, which takes a `shared_lock` on `m_handlersMutex` and checks `m_stopping` before touching the dbsync handler; `teardown()` takes the exclusive `lock_guard` on the same mutex before nulling it. No new UAF risk — the fix extends an already-safe, symmetric pattern. Documented with a code comment instead of blocking on it.

## Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

- Compilation without warnings on every supported platform
  - [x] Linux (`TARGET=agent`, built clean, no new warnings from this change)
  - [ ] Windows (`TARGET=winagent` could not be compiled in the dev VM used for this PR — an unrelated pre-existing DLL-linkage error in `schema_validator`, unrelated to FIM/syscheckd, aborted the build before it ever reached `syscheckd`. The Windows-only test variant was reviewed by reading the code, not by a real compile — needs CI or a healthy winagent toolchain to confirm.)
  - [ ] MAC OS X (not attempted)
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer (the cmocka unit test binaries in this repo are already built with ASan/LeakSanitizer; ran clean with no leaks across all 11 `syscheckd` test binaries)
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - N/A (this fix is in `syscheckd`, not the engine)

- Wazuh server API/Framework
  - N/A (agent-side fix only)

### Artifacts Affected

- `wazuh-agent` binary (Linux and, once confirmed, Windows) — `syscheckd` module only. No manager-side artifacts affected.

### Configuration Changes

N/A — no new configuration parameters, no changes to defaults or existing behavior visible to the user beyond the bug fix itself.

### Tests Introduced

- `test_transaction_callback_add_queues_sync_flag_update` (`test_fim_scan.c`): calls `transaction_callback(INSERTED, ...)` with a real (non-`NULL`) `pending_sync_updates` list and asserts exactly one item is queued with `sync_value == 1` for the inserted path — locks in the wiring this PR adds.
- `test_transaction_callback_modify_promotes_pending_sync_update` (`test_fim_scan.c`): same idea for the `MODIFIED` promotion branch (`old.sync == 0`, `file_limit > 0`), which shares the same `pending_sync_updates` field and is fixed as a side effect of this change.
- Updated expectations on 8 pre-existing tests (`test_fim_file_add`, `test_fim_file_modify`, `test_fim_file_error_on_insert`, `test_fim_checker_fim_regular` x2 variants, `test_fim_checker_fim_regular_warning` x2 variants, `test_fim_checker_root_file_within_recursion_level`) that now exercise the new `process_pending_sync_updates()` call.
- Verified these are real regression guards, not false positives, by temporarily reverting the `file.c` fix and confirming the 6 modified/new tests fail (`git stash` on the source file only, rebuild, rerun); restored the fix afterward and confirmed all tests pass again.
- Scope of coverage: unit-level only (cmocka, `TARGET=agent`, Linux). No integration/E2E test was added for this PR — recommended follow-up: an E2E test creating a file under a realtime directory, waiting for sync, deleting it, and asserting the document leaves `wazuh-states-fim-files`, as already suggested in the issue's root-cause analysis.

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented (N/A, none)
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] Windows build/test confirmation pending in CI (see Manual tests section above)
