### PR TITLE
Agent-side: new verification_mode=system to validate the manager's certificate against the OS CA store

### DIFF
--- a/docs/ref/modules/client/configuration.md
+++ b/docs/ref/modules/client/configuration.md
@@ -482,7 +482,7 @@ Automatic agent registration:
 </agent>
 ```
 
-Enrollment dials the address/port from `<server>` above (and, if configured,
+Enrollment dials the address/port from `<manager>` above (and, if configured,
 presents the TLS material from `<ssl>`) — there is no separate
 `manager_address`/`port` to set under `<enrollment>` any more.
 

--- a/docs/ref/modules/client/configuration.md
+++ b/docs/ref/modules/client/configuration.md
@@ -75,6 +75,72 @@ Network interface index to bind for manager connection.
 - **Allowed values:** Positive integer (interface index number)
 - **Note:** Platform-specific; forces agent to use specific network interface
 
+### ssl
+
+TLS configuration for the agent's HTTPS connection to the manager. Controls how the agent
+verifies the manager's certificate and, optionally, presents its own client certificate.
+
+**Sub-options:**
+
+#### certificate
+
+Path to an optional client (mTLS) certificate the agent presents to the manager.
+
+- **Default value:** None (no client certificate presented)
+- **Allowed values:** Path to a PEM-encoded certificate file, readable by the agent
+- **Note:** Must be set together with `<key>`; setting only one of the two is rejected.
+
+#### key
+
+Path to the private key matching `<certificate>`.
+
+- **Default value:** None
+- **Allowed values:** Path to a PEM-encoded private key file, readable by the agent
+- **Note:** Must be set together with `<certificate>`; setting only one of the two is rejected.
+
+#### certificate_authorities
+
+Path to the CA bundle used to verify the manager's certificate.
+
+- **Default value:** None
+- **Allowed values:** Path to a PEM-encoded CA bundle file, readable by the agent
+- **Required:** Yes, when `<verification_mode>` is `full` or `certificate` -- the agent fails
+  closed (refuses to start) without a readable CA file in that case.
+- **Note:** Must NOT be set when `<verification_mode>` is `system` -- the agent fails closed if
+  it is, since the OS trust store is used as the anchor instead and a configured CA would go
+  silently unused. Ignored (with a warning if set but unreadable) when `<verification_mode>` is
+  `none`.
+
+#### verification_mode
+
+How strictly the agent verifies the manager's TLS certificate.
+
+- **Default value:** `none`
+- **Allowed values:**
+  - `full` — verify the certificate against `<certificate_authorities>` AND check that it
+    matches the manager's hostname (strictest).
+  - `certificate` — verify the certificate against `<certificate_authorities>`, but do not
+    check the hostname.
+  - `none` — no TLS verification at all. Insecure; intended for quick testing only.
+  - `system` — verify the certificate (and hostname, like `full`) against the operating
+    system's own trusted CA store instead of `<certificate_authorities>`, the way a web
+    browser trusts a public website. Useful when the manager's certificate is issued by a
+    publicly (or OS-) trusted CA, so a CA bundle does not need to be distributed to every
+    agent by hand. On Windows and macOS this uses the native certificate store (Windows
+    Certificate Store / Keychain); on Linux it probes a fixed set of well-known distribution
+    paths (e.g. `/etc/ssl/certs/ca-certificates.crt` on Debian-family systems,
+    `/etc/pki/tls/certs/ca-bundle.crt` on RHEL-family systems) and fails closed at startup if
+    none is found on the host.
+- **Note:** Any value other than the four above is rejected at config-parse time.
+
+#### ciphers
+
+TLS 1.3 ciphersuite list to offer during the handshake.
+
+- **Default value:** None (libcurl/OpenSSL default TLS 1.3 ciphersuites)
+- **Allowed values:** Colon-separated list of TLS 1.3 ciphersuite names
+- **Example:** `TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256`
+
 ### ip_update_interval
 
 Interval in seconds for updating agent's IP address with the manager.

--- a/src/client-agent/https_client/CMakeLists.txt
+++ b/src/client-agent/https_client/CMakeLists.txt
@@ -26,6 +26,18 @@ target_compile_options(
   https_client PRIVATE -Wall -Wextra -Wshadow -Wnon-virtual-dtor
                        -Woverloaded-virtual -Wunused -Wcast-align -fPIC)
 
+# os_cert_bundle.c (vendored above) also compiles into libwazuh.so via
+# shared/CMakeLists.txt's src/*.c glob, so with default visibility os_find_ca_bundle is a
+# global symbol duplicated across two .so's loaded into the same agentd process -- harmless
+# today (identical source both places) but fragile if one copy is ever patched without the
+# other. uds_http_server hides its whole vendored target the same way for the same reason
+# (shared_modules/uds_http_server/CMakeLists.txt); a target-wide hide isn't an option here,
+# though -- tests/component/tlsVerification_component_test.cpp links straight against
+# https_client's internal C++ classes (CurlPerformer, ConfigKeyProvider, ...), which aren't
+# HC_EXPORTED and would go unresolved. Scoped to just this one file instead.
+set_source_files_properties(${SRC_FOLDER}/shared/src/os_cert_bundle.c
+                            PROPERTIES COMPILE_OPTIONS "-fvisibility=hidden")
+
 target_include_directories(
   https_client
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/src/client-agent/https_client/CMakeLists.txt
+++ b/src/client-agent/https_client/CMakeLists.txt
@@ -14,7 +14,13 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 file(GLOB_RECURSE HTTPS_CLIENT_SRC "src/*.cpp")
 
-add_library(https_client SHARED ${HTTPS_CLIENT_SRC} ${RESOURCE_OBJ_DLL})
+# Compiled directly (not linked via libwazuh, which this module otherwise avoids
+# entirely -- see the wazuhext/pthread/ext_zstd link list below): os_cert_bundle.c
+# is a dependency-free leaf (plain POSIX stat(), no shared.h), so vendoring this one
+# translation unit costs nothing and keeps the CA bundle candidate list a single
+# source of truth shared with src/shared/src/url.c's WPK/upgrade download path.
+add_library(https_client SHARED ${HTTPS_CLIENT_SRC}
+            ${SRC_FOLDER}/shared/src/os_cert_bundle.c ${RESOURCE_OBJ_DLL})
 
 target_compile_options(
   https_client PRIVATE -Wall -Wextra -Wshadow -Wnon-virtual-dtor
@@ -29,7 +35,8 @@ target_include_directories(
           ${SRC_FOLDER}/shared_modules/common # commonDefs.h
           ${SRC_FOLDER}/external/cJSON # cJSON.h (pulled by commonDefs.h)
           ${SRC_FOLDER}/external/curl/include
-          ${SRC_FOLDER}/external/openssl/include)
+          ${SRC_FOLDER}/external/openssl/include
+          ${SRC_FOLDER}/shared/include) # os_cert_bundle.h only -- not shared.h's full surface
 
 # wazuhext carries the vendored libcurl + OpenSSL symbols for agent targets.
 # ext_zstd: request-body compression, same target remoted_module

--- a/src/client-agent/https_client/include/https_client.h
+++ b/src/client-agent/https_client/include/https_client.h
@@ -50,9 +50,10 @@ extern "C"
  * fails closed instead of silently disabling verification. */
 typedef enum hc_verify_mode_t
 {
-    HC_VERIFY_FULL = 0, ///< Verify peer against the CA and check the hostname.
-    HC_VERIFY_CERT = 1, ///< Verify peer against the CA only.
-    HC_VERIFY_NONE = 2  ///< No TLS verification (explicit opt-out).
+    HC_VERIFY_FULL = 0,  ///< Verify peer against the CA and check the hostname.
+    HC_VERIFY_CERT = 1,  ///< Verify peer against the CA only.
+    HC_VERIFY_NONE = 2,  ///< No TLS verification (explicit opt-out).
+    HC_VERIFY_SYSTEM = 3 ///< Verify peer + hostname against the OS trust store, not ca_path.
 } hc_verify_mode_t;
 
 /* Connection state, surfaced to the C core (feeds the .state metrics). */

--- a/src/client-agent/https_client/src/curlPerformer.cpp
+++ b/src/client-agent/https_client/src/curlPerformer.cpp
@@ -74,9 +74,26 @@ namespace
 }
 
 CurlPerformer::CurlPerformer(const ModuleConfig& config, CurlHandleFactory factory)
+    : CurlPerformer(config, std::move(factory), FsProbe {})
+{
+}
+
+CurlPerformer::CurlPerformer(const ModuleConfig& config, CurlHandleFactory factory, const IFsProbe& fsProbe)
     : m_config(config)
     , m_factory(std::move(factory))
 {
+#if !defined(WIN32) && !defined(__APPLE__)
+
+    // Resolved once, here, instead of in applyTrustAnchors(): that runs on every perform(),
+    // which would mean probing the filesystem on every single request. A config that fails
+    // this (no bundle found) is rejected by ModuleConfig::validateTls before the client ever
+    // starts, so an empty result here is inert -- perform() is never reached in that case.
+    if (m_config.verifyMode == HC_VERIFY_SYSTEM && m_config.caPath.empty())
+    {
+        m_config.caPath = fsProbe.findSystemCaBundle();
+    }
+
+#endif
 }
 
 HttpResponse CurlPerformer::perform(const HttpRequestSpec& spec)
@@ -273,7 +290,9 @@ bool CurlPerformer::configureRequest(ICurlHandle& handle, const HttpRequestSpec&
 bool CurlPerformer::applyTls(ICurlHandle& handle) const
 {
     const bool verifyPeer = m_config.verifyMode != HC_VERIFY_NONE;
-    const bool verifyHost = m_config.verifyMode == HC_VERIFY_FULL;
+    // system trusts a different anchor (the OS store instead of a configured CA) but is
+    // otherwise as strict as full: it checks the hostname too, the way a browser would.
+    const bool verifyHost = m_config.verifyMode == HC_VERIFY_FULL || m_config.verifyMode == HC_VERIFY_SYSTEM;
 
     // The manager's HTTPS listener sets a TLS 1.3 floor of its own
     // (SSL_CTX_set_min_proto_version in RestinioHttpServer), so match it instead
@@ -298,18 +317,25 @@ bool CurlPerformer::applyTrustAnchors(ICurlHandle& handle) const
     if (!m_config.caPath.empty())
     {
         // An explicit <ca> is the whole trust set; adding the machine's stores
-        // on top of it would widen what the agent accepts.
+        // on top of it would widen what the agent accepts. (verify_mode=system's
+        // Linux trust anchor also flows through here: the constructor resolves it
+        // into caPath once, up front, so this branch needs no mode-awareness.)
         return setMandatoryOption(handle, CurlOption::CaInfo, m_config.caPath);
     }
 
-#ifdef WIN32
-    // Windows curl is built against our OpenSSL (src/external/CMakeLists.txt),
-    // which carries no CA bundle there, so without this nothing is trusted at
-    // all. Schannel used to consult the Windows stores implicitly; this asks
-    // OpenSSL for the same ROOT+CA stores through the Win32 crypto API.
+#if defined(WIN32) || defined(__APPLE__)
+    // Windows/macOS curl is built against our OpenSSL (src/external/CMakeLists.txt),
+    // which carries no CA bundle there, so without this nothing is trusted at all
+    // under verify_mode=system. Schannel/SecTrust used to consult the native store
+    // implicitly; this asks OpenSSL for the same store through the platform's own
+    // crypto API (Win32 CryptoAPI / Apple SecTrust). Reached under NONE too (caPath
+    // is also empty there), but harmless: applyTls() already turned off verifyPeer.
     return setMandatoryOption(handle, CurlOption::SslOptions, TLS_NATIVE_CA_STORE);
 #else
-    // Elsewhere libcurl already defaults to the system bundle it was built with.
+    // Elsewhere (verify_mode=none with no configured CA) libcurl already defaults
+    // to the system bundle it was built with. Not reached under verify_mode=system:
+    // the constructor's resolution guarantees caPath is non-empty there once
+    // validateTls has passed, so the branch above always handles that case.
     return true;
 #endif
 }

--- a/src/client-agent/https_client/src/curlPerformer.hpp
+++ b/src/client-agent/https_client/src/curlPerformer.hpp
@@ -16,6 +16,7 @@
 #include "iHttpPerformer.hpp"
 #include "moduleConfig.hpp"
 #include "moduleLog.hpp"
+#include "sysSeams.hpp"
 
 /**
  * @brief Maps an HttpRequestSpec onto option calls of an injected
@@ -26,7 +27,16 @@
 class CurlPerformer final : public IHttpPerformer
 {
     public:
+        /// Convenience overload for production and for tests that do not care
+        /// about verify_mode=system's Linux trust-anchor resolution: uses a
+        /// real FsProbe internally.
         CurlPerformer(const ModuleConfig& config, CurlHandleFactory factory);
+
+        /// @param fsProbe Used ONLY during construction (never stored) to resolve
+        ///        verify_mode=system's trust anchor once, up front -- not on every
+        ///        perform(), which would probe the filesystem on every request.
+        ///        Irrelevant for every other verify_mode.
+        CurlPerformer(const ModuleConfig& config, CurlHandleFactory factory, const IFsProbe& fsProbe);
 
         HttpResponse perform(const HttpRequestSpec& spec) override;
 

--- a/src/client-agent/https_client/src/httpsClientFacade.cpp
+++ b/src/client-agent/https_client/src/httpsClientFacade.cpp
@@ -61,7 +61,7 @@ HttpsClientFacade::HttpsClientFacade(const hc_config_t& config, const hc_callbac
     , m_keyProvider(m_config.agentKeyHex)
     , m_signer(m_config.agentId, m_keyProvider)
     , m_spoolFactory(m_config.spoolDir)
-    , m_performer(m_config, defaultCurlHandleFactory())
+    , m_performer(m_config, defaultCurlHandleFactory(), m_fsProbe)
     , m_dispatcher(callbacks)
     , m_configHash(m_config.configChecksum)
     , m_taskStore(callbacks.check_and_record_task, callbacks.user_data)

--- a/src/client-agent/https_client/src/moduleConfig.cpp
+++ b/src/client-agent/https_client/src/moduleConfig.cpp
@@ -159,7 +159,7 @@ bool ModuleConfig::validateTls(const IFsProbe& fsProbe, const LogFn& logFn) cons
 
     // Fail closed (H1): a verifying mode without a readable CA never sends. This can never
     // self-resolve without an operator fixing the config (mirrors main.c's hard exit on a
-    // missing/invalid <server><address>) -- CRITICAL terminates the daemon via the bridge's log
+    // missing/invalid <manager><address>) -- CRITICAL terminates the daemon via the bridge's log
     // callback instead of leaving it running with a permanently dead transport.
     if (caPath.empty() || !fsProbe.isReadableFile(caPath))
     {

--- a/src/client-agent/https_client/src/moduleConfig.cpp
+++ b/src/client-agent/https_client/src/moduleConfig.cpp
@@ -110,7 +110,8 @@ bool ModuleConfig::validateTransport(const IFsProbe& fsProbe, const LogFn& logFn
 
 bool ModuleConfig::validateTls(const IFsProbe& fsProbe, const LogFn& logFn) const
 {
-    if (verifyMode != HC_VERIFY_FULL && verifyMode != HC_VERIFY_CERT && verifyMode != HC_VERIFY_NONE)
+    if (verifyMode != HC_VERIFY_FULL && verifyMode != HC_VERIFY_CERT && verifyMode != HC_VERIFY_NONE
+            && verifyMode != HC_VERIFY_SYSTEM)
     {
         LOGFN_ERROR(logFn, "Config rejected: unknown verify_mode %d.", verifyMode);
         return false;
@@ -121,6 +122,38 @@ bool ModuleConfig::validateTls(const IFsProbe& fsProbe, const LogFn& logFn) cons
         // The agent's own configured default (client-config.h's agent_verify_mode_t),
         // not an operator opt-out to flag -- informational, not a WARNING.
         LOGFN_INFO(logFn, "TLS verification is DISABLED (verify_mode=none).");
+        return true;
+    }
+
+    if (verifyMode == HC_VERIFY_SYSTEM)
+    {
+        // A configured CA would simply be unused under 'system' (the OS store is the trust
+        // anchor instead); failing closed here surfaces that mismatch instead of silently
+        // ignoring an operator's certificate_authorities.
+        if (!caPath.empty())
+        {
+            LOGFN_CRITICAL(logFn,
+                           "https_client config rejected: verify_mode=system must not set "
+                           "certificate_authorities (got '%s').",
+                           caPath.c_str());
+            return false;
+        }
+
+#if !defined(WIN32) && !defined(__APPLE__)
+
+        // Windows/macOS ask their native certificate store (CurlPerformer), which this
+        // process cannot introspect at validation time; Linux's trust anchor is a probed
+        // file, so fail closed now rather than at the first handshake if none is found.
+        if (fsProbe.findSystemCaBundle().empty())
+        {
+            LOGFN_CRITICAL(logFn,
+                           "https_client config rejected: verify_mode=system found no OS CA "
+                           "bundle in any known location.");
+            return false;
+        }
+
+#endif
+
         return true;
     }
 

--- a/src/client-agent/https_client/src/sysSeams.cpp
+++ b/src/client-agent/https_client/src/sysSeams.cpp
@@ -11,6 +11,8 @@
 
 #include "sysSeams.hpp"
 
+#include "os_cert_bundle.h"
+
 #include <cstdio>
 
 std::time_t SystemClock::wallSeconds() const
@@ -45,4 +47,17 @@ bool FsProbe::isReadableFile(const std::string& path) const
 
     std::fclose(file);
     return true;
+}
+
+std::string FsProbe::findSystemCaBundle() const
+{
+#if !defined(WIN32) && !defined(__APPLE__)
+    const char* found = os_find_ca_bundle(nullptr);
+    return found != nullptr ? std::string {found} :
+           std::string {};
+#else
+    // Windows/macOS ask their native certificate store instead (CurlPerformer's
+    // CURLSSLOPT_NATIVE_CA branch); there is no file to probe for here.
+    return {};
+#endif
 }

--- a/src/client-agent/https_client/src/sysSeams.hpp
+++ b/src/client-agent/https_client/src/sysSeams.hpp
@@ -65,6 +65,11 @@ class IFsProbe
     public:
         virtual ~IFsProbe() = default;
         virtual bool isReadableFile(const std::string& path) const = 0;
+
+        /// verify_mode=system's trust anchor: the first well-known OS CA bundle
+        /// path that exists on this host (Linux only -- Windows/macOS ask their
+        /// native store instead and never call this). Empty when none is found.
+        virtual std::string findSystemCaBundle() const = 0;
 };
 
 class SystemClock final : public IClock
@@ -138,6 +143,7 @@ class FsProbe final : public IFsProbe
 {
     public:
         bool isReadableFile(const std::string& path) const override;
+        std::string findSystemCaBundle() const override;
 };
 
 #endif // _HC_SYS_SEAMS_HPP

--- a/src/client-agent/https_client/tests/component/tlsVerification_component_test.cpp
+++ b/src/client-agent/https_client/tests/component/tlsVerification_component_test.cpp
@@ -168,6 +168,49 @@ namespace
         return ModuleConfig::fromC(config); // scheme stays "https".
     }
 
+    // verify_mode=system never sets ca_path (validateTls rejects a config that
+    // does, see moduleConfig_test.cpp) -- the trust anchor comes from an
+    // injected IFsProbe instead, below.
+    ModuleConfig tlsSystemConfig(uint16_t port)
+    {
+        hc_config_t config {};
+        std::strncpy(config.server_host, "127.0.0.1", sizeof(config.server_host) - 1);
+        config.server_port = port;
+        std::strncpy(config.agent_id, "001", sizeof(config.agent_id) - 1);
+        config.verify_mode = HC_VERIFY_SYSTEM;
+        config.request_timeout_ms = 3000;
+        config.backoff_base_ms = 10;
+        config.backoff_cap_ms = 50;
+        return ModuleConfig::fromC(config);
+    }
+
+    // Stands in for "the OS trust store" without touching the real one: points
+    // findSystemCaBundle() at a file this test controls, so the real curl/OpenSSL
+    // handshake exercises the actual verify_mode=system code path end to end
+    // (CurlPerformer's constructor resolution -> applyTrustAnchors -> CURLOPT_CAINFO)
+    // without needing root or mutating the test machine's real CA store.
+    class FixedFsProbe final : public IFsProbe
+    {
+        public:
+            explicit FixedFsProbe(std::string bundlePath)
+                : m_bundlePath(std::move(bundlePath))
+            {
+            }
+
+            bool isReadableFile(const std::string&) const override
+            {
+                return true;
+            }
+
+            std::string findSystemCaBundle() const override
+            {
+                return m_bundlePath;
+            }
+
+        private:
+            std::string m_bundlePath;
+    };
+
     HttpResponse sendSigned(CurlPerformer& performer, const CmacSigner& signer,
                             const std::string& body)
     {
@@ -241,3 +284,74 @@ TEST(TlsVerificationTest, FullVerificationRejectsAnUntrustedCertificate)
 
     std::remove(wrongCaPath.c_str());
 }
+
+// verify_mode=system's Linux path (an injected OS-bundle stand-in, per FixedFsProbe
+// above) is not meaningful on Windows/macOS, which trust their native store instead
+// (see openssl-vendoring.md / questions.md: proven there by manual VM evidence, not
+// a component test that would otherwise have to fake out a real OS certificate store).
+#if !defined(WIN32) && !defined(__APPLE__)
+
+TEST(TlsVerificationTest, SystemVerificationAgainstAnOsTrustedCaCompletesTheHandshake)
+{
+    constexpr uint16_t port = 44859;
+    EVP_PKEY* key = nullptr;
+    X509* cert = nullptr;
+    makeSelfSigned(&key, &cert);
+    const std::string bundlePath = writeCertPem(cert, "system_trusted");
+    ASSERT_FALSE(bundlePath.empty());
+
+    TlsServer server {cert, key, port};
+    X509_free(cert);
+    EVP_PKEY_free(key);
+
+    const auto config = tlsSystemConfig(port);
+    ConfigKeyProvider keyProvider {KEY_HEX};
+    CmacSigner signer {"001", keyProvider};
+    FixedFsProbe fsProbe {bundlePath};
+    CurlPerformer performer {config, defaultCurlHandleFactory(), fsProbe};
+
+    const auto response = sendSigned(performer, signer, "H {}\nE 1:l:tls\n");
+    // Proves the real code path, not just the config: no certificate_authorities was
+    // ever set (tlsSystemConfig leaves ca_path empty) -- the CA came entirely from
+    // CurlPerformer resolving it through the injected "OS bundle" at construction.
+    EXPECT_EQ(TransportStatus::Ok, response.status);
+    EXPECT_EQ(200, response.httpCode);
+
+    std::remove(bundlePath.c_str());
+}
+
+TEST(TlsVerificationTest, SystemVerificationRejectsACertificateNotInTheOsBundle)
+{
+    constexpr uint16_t port = 44860;
+    // Same shape as FullVerificationRejectsAnUntrustedCertificate: the server
+    // presents cert A, but the "OS bundle" the agent is told to trust only has
+    // unrelated cert B -- system must fail closed exactly like full does.
+    EVP_PKEY* serverKey = nullptr;
+    X509* serverCert = nullptr;
+    makeSelfSigned(&serverKey, &serverCert);
+
+    EVP_PKEY* otherKey = nullptr;
+    X509* otherCert = nullptr;
+    makeSelfSigned(&otherKey, &otherCert);
+    const std::string bundlePath = writeCertPem(otherCert, "system_untrusted");
+    ASSERT_FALSE(bundlePath.empty());
+
+    TlsServer server {serverCert, serverKey, port};
+    X509_free(serverCert);
+    EVP_PKEY_free(serverKey);
+    X509_free(otherCert);
+    EVP_PKEY_free(otherKey);
+
+    const auto config = tlsSystemConfig(port);
+    ConfigKeyProvider keyProvider {KEY_HEX};
+    CmacSigner signer {"001", keyProvider};
+    FixedFsProbe fsProbe {bundlePath};
+    CurlPerformer performer {config, defaultCurlHandleFactory(), fsProbe};
+
+    const auto response = sendSigned(performer, signer, "H {}\nE 1:l:tls\n");
+    EXPECT_EQ(TransportStatus::TlsFail, response.status);
+
+    std::remove(bundlePath.c_str());
+}
+
+#endif // !defined(WIN32) && !defined(__APPLE__)

--- a/src/client-agent/https_client/tests/unit/curlPerformer_test.cpp
+++ b/src/client-agent/https_client/tests/unit/curlPerformer_test.cpp
@@ -322,8 +322,8 @@ TEST(CurlPerformerTest, TrustAnchorsWithoutConfiguredCa)
     allowOtherOptions(*handle);
 
     EXPECT_CALL(*handle, setOptionString(CurlOption::CaInfo, _)).Times(0);
-#ifdef WIN32
-    // Our OpenSSL-backed Windows curl has no bundle of its own to fall back on.
+#if defined(WIN32) || defined(__APPLE__)
+    // Our OpenSSL-backed Windows/macOS curl has no bundle of its own to fall back on.
     EXPECT_CALL(*handle, setOptionLong(CurlOption::SslOptions, TLS_NATIVE_CA_STORE));
 #else
     EXPECT_CALL(*handle, setOptionLong(CurlOption::SslOptions, _)).Times(0);

--- a/src/client-agent/https_client/tests/unit/curlPerformer_test.cpp
+++ b/src/client-agent/https_client/tests/unit/curlPerformer_test.cpp
@@ -17,6 +17,7 @@
 
 #include "curlPerformer.hpp"
 #include "mockCurlHandle.hpp"
+#include "mockFsProbe.hpp"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -331,6 +332,60 @@ TEST(CurlPerformerTest, TrustAnchorsWithoutConfiguredCa)
     auto performer = makePerformer(makeConfig(HC_VERIFY_FULL), std::move(mock));
     performer.perform(HttpRequestSpec {});
 }
+
+TEST(CurlPerformerTest, TlsSystemModeVerifiesPeerAndHost)
+{
+    auto mock = std::make_unique<NiceMock<MockCurlHandle>>();
+    auto* handle = mock.get();
+    allowOtherOptions(*handle);
+    auto config = makeConfig(HC_VERIFY_SYSTEM);
+    NiceMock<MockFsProbe> fsProbe;
+
+    EXPECT_CALL(*handle, setOptionLong(CurlOption::VerifyPeer, 1L));
+    EXPECT_CALL(*handle, setOptionLong(CurlOption::VerifyHost, 2L)); // Same strictness as full.
+
+#if defined(WIN32) || defined(__APPLE__)
+    EXPECT_CALL(*handle, setOptionLong(CurlOption::SslOptions, TLS_NATIVE_CA_STORE));
+    EXPECT_CALL(*handle, setOptionString(CurlOption::CaInfo, _)).Times(0);
+#else
+    ON_CALL(fsProbe, findSystemCaBundle()).WillByDefault(Return("/etc/ssl/certs/ca-certificates.crt"));
+    EXPECT_CALL(*handle, setOptionString(CurlOption::CaInfo, "/etc/ssl/certs/ca-certificates.crt"));
+    EXPECT_CALL(*handle, setOptionLong(CurlOption::SslOptions, _)).Times(0);
+#endif
+
+    auto shared = std::make_shared<std::unique_ptr<ICurlHandle>>(std::move(mock));
+    CurlPerformer performer {config,
+                             [shared]() -> std::unique_ptr<ICurlHandle> { return std::move(*shared); },
+                             fsProbe};
+    performer.perform(HttpRequestSpec {});
+}
+
+#if !defined(WIN32) && !defined(__APPLE__)
+TEST(CurlPerformerTest, TlsSystemModeResolvesTrustAnchorOnceNotPerRequest)
+{
+    auto config = makeConfig(HC_VERIFY_SYSTEM);
+    NiceMock<MockFsProbe> fsProbe;
+
+    // Resolved once at construction; perform() below runs twice and must not
+    // probe the filesystem again on the second request.
+    EXPECT_CALL(fsProbe, findSystemCaBundle())
+    .Times(1)
+    .WillOnce(Return("/etc/ssl/certs/ca-certificates.crt"));
+
+    CurlHandleFactory factory = [&]() -> std::unique_ptr<ICurlHandle>
+    {
+        auto handle = std::make_unique<NiceMock<MockCurlHandle>>();
+        allowOtherOptions(*handle);
+        ON_CALL(*handle, perform()).WillByDefault(Return(TransportStatus::Ok));
+        EXPECT_CALL(*handle, setOptionString(CurlOption::CaInfo, "/etc/ssl/certs/ca-certificates.crt"));
+        return handle;
+    };
+
+    CurlPerformer performer {config, factory, fsProbe};
+    performer.perform(HttpRequestSpec {});
+    performer.perform(HttpRequestSpec {});
+}
+#endif
 
 TEST(CurlPerformerTest, FileBodyStreamsInsteadOfPostFields)
 {

--- a/src/client-agent/https_client/tests/unit/mocks/mockFsProbe.hpp
+++ b/src/client-agent/https_client/tests/unit/mocks/mockFsProbe.hpp
@@ -20,6 +20,7 @@ class MockFsProbe : public IFsProbe
 {
     public:
         MOCK_METHOD(bool, isReadableFile, (const std::string& path), (const, override));
+        MOCK_METHOD(std::string, findSystemCaBundle, (), (const, override));
 };
 
 #endif // _HC_MOCK_FS_PROBE_HPP

--- a/src/client-agent/https_client/tests/unit/moduleConfig_test.cpp
+++ b/src/client-agent/https_client/tests/unit/moduleConfig_test.cpp
@@ -212,6 +212,37 @@ TEST(ModuleConfigTest, NoneModeIsValidWithoutCa)
     EXPECT_TRUE(ModuleConfig::fromC(minimalConfig()).validate(fsProbe, TEST_LOG));
 }
 
+TEST(ModuleConfigTest, SystemModeValidWithoutCaWhenBundleFound)
+{
+    MockFsProbe fsProbe;
+    auto config = minimalConfig();
+    config.verify_mode = HC_VERIFY_SYSTEM;
+#if !defined(WIN32) && !defined(__APPLE__)
+    EXPECT_CALL(fsProbe, findSystemCaBundle()).WillOnce(Return("/etc/ssl/certs/ca-certificates.crt"));
+#endif
+    EXPECT_TRUE(ModuleConfig::fromC(config).validate(fsProbe, TEST_LOG));
+}
+
+TEST(ModuleConfigTest, SystemModeFailsClosedWhenCaIsSet)
+{
+    ::testing::StrictMock<MockFsProbe> fsProbe; // Probe must not even be asked.
+    auto config = minimalConfig();
+    config.verify_mode = HC_VERIFY_SYSTEM;
+    std::strncpy(config.ca_path, "/etc/ca.pem", sizeof(config.ca_path) - 1);
+    EXPECT_FALSE(ModuleConfig::fromC(config).validate(fsProbe, TEST_LOG));
+}
+
+#if !defined(WIN32) && !defined(__APPLE__)
+TEST(ModuleConfigTest, SystemModeFailsClosedWhenNoBundleFound)
+{
+    MockFsProbe fsProbe;
+    auto config = minimalConfig();
+    config.verify_mode = HC_VERIFY_SYSTEM;
+    EXPECT_CALL(fsProbe, findSystemCaBundle()).WillOnce(Return(""));
+    EXPECT_FALSE(ModuleConfig::fromC(config).validate(fsProbe, TEST_LOG));
+}
+#endif
+
 // -----------------------------------------------------------------------------
 // Paired timing options. getDefine_Int_default() range-checks each option on its
 // own, so an inverted pair is reachable from two individually valid values --

--- a/src/client-agent/src/config.c
+++ b/src/client-agent/src/config.c
@@ -170,6 +170,8 @@ static const char *w_agent_verify_mode_str(int verification_mode)
         return "certificate";
     case AGENT_VERIFY_NONE:
         return "none";
+    case AGENT_VERIFY_SYSTEM:
+        return "system";
     default:
         return "unknown";
     }

--- a/src/client-agent/src/config.c
+++ b/src/client-agent/src/config.c
@@ -116,22 +116,43 @@ int ClientConf(const char *cfgfile)
 bool w_agent_validate_ssl_ca(const agent *cfg)
 {
     const char *ca = cfg->ssl.certificate_authorities;
-    const bool readable = ca && w_is_file(ca);
 
     /* Under 'none' the CA is never read, so a wrong path stays invisible until someone
      * enables verification -- and then the agent refuses to start. Warn while it is
      * still harmless rather than accepting it in silence. */
     if (cfg->ssl.verification_mode == AGENT_VERIFY_NONE) {
-        if (ca && !readable) {
+        if (ca && !w_is_file(ca)) {
             mwarn(AG_UNUSED_SSL_CA, ca);
         }
 
         return true;
     }
 
+    /* 'system' trusts the OS store instead of an operator-supplied file: a configured CA
+     * would be silently unused, which is worth failing closed on rather than guessing which
+     * one the operator actually meant. On Windows/macOS the OS store is asked for natively
+     * (no file to probe for); on Linux the https_client module itself fails closed if no
+     * known OS bundle is found (moduleConfig.cpp's validateTls), mirroring this same check
+     * one layer up so a bad config is caught before the module ever spins up threads. */
+    if (cfg->ssl.verification_mode == AGENT_VERIFY_SYSTEM) {
+        if (ca) {
+            merror(AG_SSL_CA_FORBIDDEN_SYSTEM, ca);
+            return false;
+        }
+
+#if !defined(WIN32) && !defined(__APPLE__)
+        if (os_find_ca_bundle(NULL) == NULL) {
+            merror(AG_SSL_SYSTEM_NO_BUNDLE);
+            return false;
+        }
+#endif
+
+        return true;
+    }
+
     /* A verifying mode without a readable CA can never connect: the https_client module
      * fails closed on this, per its own validation. */
-    if (!readable) {
+    if (!ca || !w_is_file(ca)) {
         merror(AG_INV_SSL_CA, ca ? ca : "");
         return false;
     }

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -1514,6 +1514,8 @@ static int bridge_map_verify_mode(int agent_verify_mode)
         return HC_VERIFY_CERT;
     case AGENT_VERIFY_NONE:
         return HC_VERIFY_NONE;
+    case AGENT_VERIFY_SYSTEM:
+        return HC_VERIFY_SYSTEM;
     case AGENT_VERIFY_FULL:
     default:
         return HC_VERIFY_FULL;

--- a/src/config/include/client-config.h
+++ b/src/config/include/client-config.h
@@ -35,9 +35,10 @@ typedef struct agent_server {
  * goes through the agent's own default-setting path (ClientConf) still fails
  * closed. The agent's own default, applied when <ssl> is absent, is NONE. */
 typedef enum agent_verify_mode_t {
-    AGENT_VERIFY_FULL = 0, ///< Verify peer against the CA and check the hostname.
-    AGENT_VERIFY_CERT = 1, ///< Verify peer against the CA only.
-    AGENT_VERIFY_NONE = 2  ///< No TLS verification (the agent's own configured default).
+    AGENT_VERIFY_FULL = 0,   ///< Verify peer against the CA and check the hostname.
+    AGENT_VERIFY_CERT = 1,   ///< Verify peer against the CA only.
+    AGENT_VERIFY_NONE = 2,   ///< No TLS verification (the agent's own configured default).
+    AGENT_VERIFY_SYSTEM = 3  ///< Verify peer (+ hostname) against the OS trust store, not a configured CA.
 } agent_verify_mode_t;
 
 /* Agent-side HTTPS transport TLS settings: the <agent><ssl> block (FR10 / #37702 §10). */

--- a/src/config/src/client-config.c
+++ b/src/config/src/client-config.c
@@ -669,6 +669,8 @@ int Read_Agent_SSL(XML_NODE node, agent * logr)
                 logr->ssl.verification_mode = AGENT_VERIFY_CERT;
             } else if (strcmp(node[j]->content, "none") == 0) {
                 logr->ssl.verification_mode = AGENT_VERIFY_NONE;
+            } else if (strcmp(node[j]->content, "system") == 0) {
+                logr->ssl.verification_mode = AGENT_VERIFY_SYSTEM;
             } else {
                 merror(XML_VALUEERR, node[j]->element, node[j]->content);
                 return (OS_INVALID);

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -329,6 +329,7 @@ else() # Darwin
       "LIBS=-lpthread"
       ${EXTERNAL_DIR}/curl/configure
       --with-openssl=${EXTERNAL_DIR}/openssl
+      --with-apple-sectrust
       --disable-ldap
       --without-libidn2
       --without-brotli
@@ -1530,10 +1531,15 @@ if(IS_DARWIN)
                BUILD_WITH_INSTALL_RPATH TRUE
                INSTALL_NAME_DIR "@rpath"
                MACOSX_RPATH TRUE)
+  # -framework CoreServices: required by curl's --with-apple-sectrust (enabled
+  # above) alongside CoreFoundation/Security -- see m4/curl-apple-sectrust.m4's
+  # APPLE_SECTRUST_LDFLAGS. A static libcurl.a doesn't drag its own configure-time
+  # LDFLAGS into whatever finally links it, so this has to be declared here too.
   target_link_libraries(
     wazuhext
     PRIVATE "-Wl,-all_load" ${WAZUHEXT_WHOLE_LIBS} "-framework Security"
-            "-framework CoreFoundation" "-framework SystemConfiguration")
+            "-framework CoreFoundation" "-framework CoreServices"
+            "-framework SystemConfiguration")
 
 elseif(IS_WINDOWS)
   # Windows (MinGW cross-compile): DLL + delay-import lib

--- a/src/shared/include/error_messages/error_messages.h
+++ b/src/shared/include/error_messages/error_messages.h
@@ -296,6 +296,8 @@
 #define AG_API_ERROR_CODE  "(4116): Unexpected status code in Wazuh agent package uninstallation request: %ld\n"
 #define AG_REQUEST_FAIL    "(4117): Failed validation request to uninstall Wazuh agent package."
 #define AG_INV_SSL_CA      "(4118): <ssl><verification_mode> is not 'none' but <certificate_authorities> is missing or unreadable: '%s'."
+#define AG_SSL_CA_FORBIDDEN_SYSTEM "(4120): <ssl><verification_mode> is 'system' but <certificate_authorities> is set: '%s'. Remove it, or choose a different verification_mode; the OS trust store is used instead."
+#define AG_SSL_SYSTEM_NO_BUNDLE    "(4121): <ssl><verification_mode> is 'system' but no OS CA bundle was found on this host."
 
 /* Rules reading errors */
 #define RL_INV_ROOT     "(5101): Invalid root element: '%s'."

--- a/src/shared/include/os_cert_bundle.h
+++ b/src/shared/include/os_cert_bundle.h
@@ -1,0 +1,49 @@
+/*
+ * OS CA bundle discovery
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#ifndef OS_CERT_BUNDLE_H
+#define OS_CERT_BUNDLE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef WIN32
+
+/**
+ * @brief Well-known OS CA bundle locations, probed in priority order by
+ *        os_find_ca_bundle()'s default (candidates == NULL) behavior.
+ */
+extern const char* os_ca_bundle_candidates[];
+
+/**
+ * @brief Return the first candidate CA bundle path that exists on this host.
+ *
+ * The dependency (curl/OpenSSL) is precompiled, so the bundle path it was built
+ * against may not exist on the host it actually runs on; this looks the file up
+ * at run time instead of trusting the compiled-in default.
+ *
+ * @param candidates NULL-terminated array of paths to probe, in priority order.
+ *        Pass NULL to probe the built-in os_ca_bundle_candidates list (the real
+ *        production behavior); a test may pass its own list to point the probe
+ *        at a temporary file.
+ * @return The first candidate that exists on disk, or NULL if none do. Points
+ *         into `candidates` (or the built-in list); never allocated, never
+ *         owned by the caller.
+ */
+const char* os_find_ca_bundle(const char* const* candidates);
+
+#endif // !WIN32
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // OS_CERT_BUNDLE_H

--- a/src/shared/include/shared.h
+++ b/src/shared/include/shared.h
@@ -256,6 +256,7 @@ extern const char *__local_name;
 #include "information_messages.h"
 #include "warning_messages.h"
 #include "custom_output_search.h"
+#include "os_cert_bundle.h"
 #include "url.h"
 #include "yaml2json.h"
 #include "cluster_utils.h"

--- a/src/shared/src/os_cert_bundle.c
+++ b/src/shared/src/os_cert_bundle.c
@@ -1,0 +1,49 @@
+/*
+ * OS CA bundle discovery
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+/* Deliberately dependency-free (plain POSIX stat(), no shared.h): the
+ * https_client C++ module compiles this file directly rather than linking all
+ * of libwazuh, so it must not pull in anything beyond libc. */
+#include "os_cert_bundle.h"
+
+#ifndef WIN32
+
+#include <stddef.h>
+#include <sys/stat.h>
+
+/*
+ * These values were taken from how libcurl looks for the paths at compilation time,
+ * here it is modified to be able to support the precompiled deps.
+ *
+ * https://github.com/curl/curl/blob/5930cb1c465ef5f0de6f1b91a843bb6f0bed1f23/acinclude.m4#L2182
+ */
+const char* os_ca_bundle_candidates[] = {
+    "/etc/ssl/certs/ca-certificates.crt",       // Debian systems
+    "/etc/pki/tls/certs/ca-bundle.crt",         // Redhat and Mandriva
+    "/usr/share/ssl/certs/ca-bundle.crt",       // RedHat
+    "/usr/local/share/certs/ca-root-nss.crt",   // FreeBSD
+    "/etc/ssl/cert.pem",                        // OpenBSD, FreeBSD, MacOS
+    NULL
+};
+
+const char* os_find_ca_bundle(const char* const* candidates) {
+    const char* const* list = candidates ? candidates : os_ca_bundle_candidates;
+    struct stat st;
+
+    for (size_t i = 0; list[i] != NULL; ++i) {
+        if (stat(list[i], &st) == 0) {
+            return list[i];
+        }
+    }
+
+    return NULL;
+}
+
+#endif // !WIN32

--- a/src/shared/src/url.c
+++ b/src/shared/src/url.c
@@ -52,34 +52,6 @@ static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, voi
 }
 
 #ifndef WIN32
-/*
- * These values ​​were taken from how libcurl looks for the paths at compilation time,
- * here it is modified to be able to support the precompiled deps.
- *
- * https://github.com/curl/curl/blob/5930cb1c465ef5f0de6f1b91a843bb6f0bed1f23/acinclude.m4#L2182
- */
-const char* certs_list[] = {
-    "/etc/ssl/certs/ca-certificates.crt",       // Debian systems
-    "/etc/pki/tls/certs/ca-bundle.crt",         // Redhat and Mandriva
-    "/usr/share/ssl/certs/ca-bundle.crt",       // RedHat
-    "/usr/local/share/certs/ca-root-nss.crt",   // FreeBSD
-    "/etc/ssl/cert.pem",                        // OpenBSD, FreeBSD, MacOS
-    NULL
-};
-
-char const * find_cert_list() {
-    char const * ret_val = NULL;
-
-    for (size_t i = 0; NULL != certs_list[i]; ++i) {
-        if (-1 != FileSize(certs_list[i])) {
-            ret_val = certs_list[i];
-            break;
-        }
-    }
-
-    return ret_val;
-}
-
 int wurl_get(const char * url, const char * dest, const char * header, const char *data, const long timeout) {
     CURL *curl;
     FILE *fp;
@@ -90,7 +62,7 @@ int wurl_get(const char * url, const char * dest, const char * header, const cha
     int old_mask;
 
     if (curl) {
-        char const *cert = find_cert_list();
+        char const *cert = os_find_ca_bundle(NULL);
 
         old_mask = umask(0006);
         fp = wfopen(dest, "wb");
@@ -239,7 +211,7 @@ char * wurl_http_get(const char * url, size_t max_size, const long timeout) {
     chunk.max_size_error = false;
 
     if (curl) {
-        char const *cert = find_cert_list();
+        char const *cert = os_find_ca_bundle(NULL);
 
         res = curl_easy_setopt(curl, CURLOPT_URL, url);
         res += curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback);
@@ -355,7 +327,7 @@ static CURLcode wurl_set_trust_anchors(CURL *curl, const char *url) {
 #ifdef WIN32
     return curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, (long)CURLSSLOPT_NATIVE_CA);
 #else
-    char const *cert = find_cert_list();
+    char const *cert = os_find_ca_bundle(NULL);
 
     return cert ? curl_easy_setopt(curl, CURLOPT_CAINFO, cert) : CURLE_OK;
 #endif

--- a/src/unit_tests/client-agent/CMakeLists.txt
+++ b/src/unit_tests/client-agent/CMakeLists.txt
@@ -96,7 +96,7 @@ list(APPEND client-agent_names "test_startup_gate")
 list(APPEND client-agent_flags "-Wl,--wrap,OS_SHA256_File ${DEBUG_OP_WRAPPERS}")
 
 list(APPEND client-agent_names "test_agent_ssl_ca")
-list(APPEND client-agent_flags "-Wl,--wrap,w_is_file ${DEBUG_OP_WRAPPERS}")
+list(APPEND client-agent_flags "-Wl,--wrap,w_is_file -Wl,--wrap,os_find_ca_bundle ${DEBUG_OP_WRAPPERS}")
 
 # getAgentConfig() reads the agt globals and builds cJSON, nothing else: no wrappers.
 list(APPEND client-agent_names "test_agent_config")

--- a/src/unit_tests/client-agent/test_agent_config.c
+++ b/src/unit_tests/client-agent/test_agent_config.c
@@ -340,6 +340,18 @@ static void test_reports_full_verification_mode(void **state)
     cJSON_Delete(root);
 }
 
+static void test_reports_system_verification_mode(void **state)
+{
+    (void)state;
+    cJSON *root = NULL;
+
+    test_agt.ssl.verification_mode = AGENT_VERIFY_SYSTEM;
+
+    assert_string_field(cJSON_GetObjectItem(get_agent_section(&root), "ssl"), "verification_mode", "system");
+
+    cJSON_Delete(root);
+}
+
 static void test_reports_configured_batch_limits(void **state)
 {
     (void)state;
@@ -416,6 +428,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_reports_every_configured_ssl_field, setup_agent, teardown_agent),
         cmocka_unit_test_setup_teardown(test_reports_default_ssl_posture, setup_agent, teardown_agent),
         cmocka_unit_test_setup_teardown(test_reports_full_verification_mode, setup_agent, teardown_agent),
+        cmocka_unit_test_setup_teardown(test_reports_system_verification_mode, setup_agent, teardown_agent),
         cmocka_unit_test_setup_teardown(test_reports_configured_batch_limits, setup_agent, teardown_agent),
         cmocka_unit_test_setup_teardown(test_reports_batch_defaults, setup_agent, teardown_agent),
         cmocka_unit_test_setup_teardown(test_reports_both_periodic_pushes, setup_agent, teardown_agent),

--- a/src/unit_tests/client-agent/test_agent_ssl_ca.c
+++ b/src/unit_tests/client-agent/test_agent_ssl_ca.c
@@ -17,6 +17,7 @@
 #include "agentd.h"
 #include "../wrappers/wazuh/shared/debug_op_wrappers.h"
 #include "../wrappers/wazuh/shared/os_utils_wrappers.h"
+#include "../wrappers/wazuh/shared/os_cert_bundle_wrappers.h"
 
 /* w_agent_validate_ssl_ca() decides whether the agent may start with the
  * <ssl><certificate_authorities> it was given. Two behaviours matter and they
@@ -128,6 +129,46 @@ static void test_certificate_with_unreadable_ca_fails(void **state)
     assert_false(w_agent_validate_ssl_ca(&cfg));
 }
 
+/* --- verification_mode system: trusts the OS store, never a configured CA --- */
+
+static void test_system_without_ca_starts_when_bundle_found(void **state)
+{
+    (void)state;
+    agent cfg = make_config(AGENT_VERIFY_SYSTEM, NULL);
+
+    expect_os_find_ca_bundle("/etc/ssl/certs/ca-certificates.crt");
+
+    assert_true(w_agent_validate_ssl_ca(&cfg));
+}
+
+static void test_system_without_ca_fails_when_no_bundle_found(void **state)
+{
+    (void)state;
+    agent cfg = make_config(AGENT_VERIFY_SYSTEM, NULL);
+
+    expect_os_find_ca_bundle(NULL);
+    expect_string(__wrap__merror, formatted_msg,
+                  "(4121): <ssl><verification_mode> is 'system' but no OS CA bundle was found "
+                  "on this host.");
+
+    assert_false(w_agent_validate_ssl_ca(&cfg));
+}
+
+/* A configured CA would simply go unused under 'system' -- reject rather than
+ * silently ignore what looks like a real operator intent. */
+static void test_system_with_ca_set_fails(void **state)
+{
+    (void)state;
+    agent cfg = make_config(AGENT_VERIFY_SYSTEM, "etc/certs/root-ca.pem");
+
+    expect_string(__wrap__merror, formatted_msg,
+                  "(4120): <ssl><verification_mode> is 'system' but <certificate_authorities> is "
+                  "set: 'etc/certs/root-ca.pem'. Remove it, or choose a different "
+                  "verification_mode; the OS trust store is used instead.");
+
+    assert_false(w_agent_validate_ssl_ca(&cfg));
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -138,6 +179,9 @@ int main(void)
         cmocka_unit_test(test_full_with_unreadable_ca_fails),
         cmocka_unit_test(test_full_without_ca_fails),
         cmocka_unit_test(test_certificate_with_unreadable_ca_fails),
+        cmocka_unit_test(test_system_without_ca_starts_when_bundle_found),
+        cmocka_unit_test(test_system_without_ca_fails_when_no_bundle_found),
+        cmocka_unit_test(test_system_with_ca_set_fails),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/unit_tests/client-agent/test_https_client_bridge.c
+++ b/src/unit_tests/client-agent/test_https_client_bridge.c
@@ -486,6 +486,31 @@ static void test_compression_defaults_to_enabled(void **state)
     w_https_client_stop();
 }
 
+static void test_system_verify_mode_maps_to_hc_verify_system(void **state)
+{
+    (void)state;
+    agt->ssl.verification_mode = AGENT_VERIFY_SYSTEM;
+
+    expect_string(__wrap__minfo, formatted_msg, "https_client: starting.");
+    expect_string(__wrap_OS_SHA256_File, fname, SHAREDCFG_FILE);
+    expect_value(__wrap_OS_SHA256_File, mode, OS_BINARY);
+    will_return(__wrap_OS_SHA256_File, NULL);
+    expect_any(__wrap_hc_create, callbacks);
+    will_return(__wrap_hc_create, FAKE_HANDLE);
+    expect_value(__wrap_hc_start, handle, FAKE_HANDLE);
+    will_return(__wrap_hc_start, true);
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+
+    w_https_client_start();
+
+    /* The bridge maps the enum unconditionally; whether an OS CA bundle
+     * actually exists is https_client's own (module-level) concern. */
+    assert_int_equal(g_captured_config.verify_mode, HC_VERIFY_SYSTEM);
+    assert_string_equal(g_captured_config.ca_path, "");
+
+    w_https_client_stop();
+}
+
 static void test_client_cert_key_and_ciphers_are_copied(void **state)
 {
     (void)state;
@@ -2331,6 +2356,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_full_verify_mode_and_ca_reach_the_module, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_certificate_verify_mode_maps_to_hc_verify_cert, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_none_verify_mode_maps_to_hc_verify_none, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_system_verify_mode_maps_to_hc_verify_system, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_compression_defaults_to_enabled, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_client_cert_key_and_ciphers_are_copied, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_configured_endpoint_reaches_the_module, setup_test, teardown_test),

--- a/src/unit_tests/config/test_client-config_https.c
+++ b/src/unit_tests/config/test_client-config_https.c
@@ -253,7 +253,7 @@ static void test_ssl_system_verification_mode(void **state) {
     agent cfg;
 
     const char *xml_str =
-        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<manager><address>10.0.0.1</address><port>1517</port></manager>"
         "<ssl><verification_mode>system</verification_mode></ssl>";
 
     expect_valid_ip("10.0.0.1");

--- a/src/unit_tests/config/test_client-config_https.c
+++ b/src/unit_tests/config/test_client-config_https.c
@@ -247,6 +247,22 @@ static void test_ssl_none_verification_mode(void **state) {
     cleanup(&xml, nodes, &cfg);
 }
 
+static void test_ssl_system_verification_mode(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str =
+        "<server><address>10.0.0.1</address><port>1517</port></server>"
+        "<ssl><verification_mode>system</verification_mode></ssl>";
+
+    expect_valid_ip("10.0.0.1");
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
+    assert_int_equal(cfg.ssl.verification_mode, AGENT_VERIFY_SYSTEM);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
 static void test_ssl_zero_initialized_reads_as_full(void **state) {
     OS_XML xml = {0};
     xml_node **nodes;
@@ -1430,6 +1446,7 @@ int main(void) {
         cmocka_unit_test(test_ssl_full_verification_mode),
         cmocka_unit_test(test_ssl_certificate_verification_mode),
         cmocka_unit_test(test_ssl_none_verification_mode),
+        cmocka_unit_test(test_ssl_system_verification_mode),
         cmocka_unit_test(test_ssl_zero_initialized_reads_as_full),
         cmocka_unit_test(test_ssl_absent_keeps_the_default_the_caller_set),
         cmocka_unit_test(test_ssl_invalid_verification_mode_is_rejected),

--- a/src/unit_tests/shared/CMakeLists.txt
+++ b/src/unit_tests/shared/CMakeLists.txt
@@ -350,7 +350,10 @@ list(APPEND shared_tests_names "test_url")
 list(APPEND shared_tests_flags "-Wl,--wrap,curl_slist_free_all -Wl,--wrap,curl_easy_cleanup \
                                 -Wl,--wrap,curl_easy_init -Wl,--wrap,curl_easy_setopt -Wl,--wrap,wfopen \
                                 -Wl,--wrap,curl_slist_append -Wl,--wrap,curl_easy_perform \
-                                -Wl,--wrap,curl_easy_getinfo -Wl,--wrap,FileSize ${DEBUG_OP_WRAPPERS}")
+                                -Wl,--wrap,curl_easy_getinfo -Wl,--wrap,os_find_ca_bundle ${DEBUG_OP_WRAPPERS}")
+
+list(APPEND shared_tests_names "test_os_cert_bundle")
+list(APPEND shared_tests_flags " ")
 
 list(APPEND shared_tests_names "test_sysinfo_utils")
 

--- a/src/unit_tests/shared/test_os_cert_bundle.c
+++ b/src/unit_tests/shared/test_os_cert_bundle.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+
+#include "os_cert_bundle.h"
+
+#ifndef WIN32
+
+static void test_returns_null_when_no_candidate_exists(void **state) {
+    (void) state;
+    const char *candidates[] = {
+        "/nonexistent/hc-ca-bundle-a.pem",
+        "/nonexistent/hc-ca-bundle-b.pem",
+        NULL
+    };
+
+    assert_null(os_find_ca_bundle(candidates));
+}
+
+static void test_returns_first_existing_candidate(void **state) {
+    (void) state;
+    const char *path = "/tmp/hc_test_ca_bundle_first.pem";
+    FILE *f = fopen(path, "w");
+    assert_non_null(f);
+    fclose(f);
+
+    const char *candidates[] = {
+        "/nonexistent/hc-ca-bundle-a.pem",
+        path,
+        "/nonexistent/hc-ca-bundle-b.pem",
+        NULL
+    };
+
+    assert_string_equal(os_find_ca_bundle(candidates), path);
+
+    remove(path);
+}
+
+static void test_stops_at_the_first_match_in_priority_order(void **state) {
+    (void) state;
+    const char *first = "/tmp/hc_test_ca_bundle_priority_1.pem";
+    const char *second = "/tmp/hc_test_ca_bundle_priority_2.pem";
+    FILE *f1 = fopen(first, "w");
+    FILE *f2 = fopen(second, "w");
+    assert_non_null(f1);
+    assert_non_null(f2);
+    fclose(f1);
+    fclose(f2);
+
+    const char *candidates[] = {first, second, NULL};
+
+    assert_string_equal(os_find_ca_bundle(candidates), first);
+
+    remove(first);
+    remove(second);
+}
+
+static void test_null_candidates_uses_the_builtin_list(void **state) {
+    (void) state;
+    // Not asserting a specific outcome (the built-in list's paths may or may
+    // not exist on the machine running this test) -- only that passing NULL
+    // does not crash and probes the module's own default list rather than an
+    // empty one.
+    os_find_ca_bundle(NULL);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_returns_null_when_no_candidate_exists),
+        cmocka_unit_test(test_returns_first_existing_candidate),
+        cmocka_unit_test(test_stops_at_the_first_match_in_priority_order),
+        cmocka_unit_test(test_null_candidates_uses_the_builtin_list),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}
+
+#else
+
+int main(void) {
+    return 0;
+}
+
+#endif

--- a/src/unit_tests/shared/test_url.c
+++ b/src/unit_tests/shared/test_url.c
@@ -16,6 +16,7 @@
 #include "shared.h"
 #include "../wrappers/common.h"
 #include "../wrappers/wazuh/shared/file_op_wrappers.h"
+#include "../wrappers/wazuh/shared/os_cert_bundle_wrappers.h"
 
 /* setup/teardown */
 static int group_setup(void ** state) {
@@ -95,7 +96,7 @@ void test_wurl_http_request_headers_list_null(void **state)
         expect_value(__wrap_curl_easy_setopt, curl, curl);
         will_return(__wrap_curl_easy_setopt, CURLE_OK);
 
-        expect_FileSize("/etc/ssl/certs/ca-certificates.crt", 1);
+        expect_os_find_ca_bundle("/etc/ssl/certs/ca-certificates.crt");
 
         expect_value(__wrap_curl_easy_setopt, option, CURLOPT_CAINFO);
         expect_value(__wrap_curl_easy_setopt, curl, curl);

--- a/src/unit_tests/wrappers/wazuh/shared/os_cert_bundle_wrappers.c
+++ b/src/unit_tests/wrappers/wazuh/shared/os_cert_bundle_wrappers.c
@@ -1,0 +1,26 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include "os_cert_bundle_wrappers.h"
+
+const char* __wrap_os_find_ca_bundle(const char* const* candidates) {
+    check_expected_ptr(candidates);
+    return mock_type(const char*);
+}
+
+void expect_os_find_ca_bundle(const char *path) {
+    expect_any(__wrap_os_find_ca_bundle, candidates);
+    will_return(__wrap_os_find_ca_bundle, path);
+}

--- a/src/unit_tests/wrappers/wazuh/shared/os_cert_bundle_wrappers.h
+++ b/src/unit_tests/wrappers/wazuh/shared/os_cert_bundle_wrappers.h
@@ -1,0 +1,19 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#ifndef OS_CERT_BUNDLE_WRAPPERS_H
+#define OS_CERT_BUNDLE_WRAPPERS_H
+
+const char* __wrap_os_find_ca_bundle(const char* const* candidates);
+
+/// Convenience: arrange for the next os_find_ca_bundle() call to return `path`
+/// (pass NULL to simulate "no OS CA bundle found").
+void expect_os_find_ca_bundle(const char *path);
+
+#endif


### PR DESCRIPTION
## Description

Cloud has asked for a fourth agent-side TLS verification mode: validate the manager's
certificate against the operating system's trusted CA store — like a browser does — instead
of requiring `<certificate_authorities>` to point at an operator-distributed CA file. This
removes the need to distribute a CA bundle to every agent when the manager holds a certificate
issued by a publicly (or OS-) trusted CA.

Scoped to the agent side only (the manager's own, separate `verification_mode` mechanism for
`<remote><https>` is untouched).

Closes #38495

## Proposed Changes

- New `AGENT_VERIFY_SYSTEM` / `HC_VERIFY_SYSTEM` enum value, threaded through the full existing
  chain: `Read_Agent_SSL` (config parsing) → the C→C++ bridge (`bridge_map_verify_mode`) →
  `ModuleConfig::validateTls` (fail-closed validation) → `CurlPerformer::applyTrustAnchors`
  (curl trust-anchor wiring).
- `system` behaves like `full` (verifies peer **and** hostname — "like a browser does", per the
  ask), the only difference being the trust anchor: the OS store instead of a configured file.
- **Config-conflict fail-closed**: setting `certificate_authorities` together with
  `verification_mode=system` is rejected at startup (a configured CA would simply go unused
  under `system`, which is worth failing closed on rather than silently ignoring).
- **No-bundle fail-closed (Linux)**: if no known OS CA bundle is found at startup, the agent
  refuses to start, the same fail-closed principle already applied to a missing/unreadable
  `certificate_authorities` file.
- **Linux**: trust anchor resolved via a new shared, testable helper (`os_find_ca_bundle`,
  `src/shared/include/os_cert_bundle.h` / `src/shared/src/os_cert_bundle.c`) extracted from
  `src/shared/src/url.c`'s existing WPK/agent-upgrade/API-download logic — avoids a second,
  independently-drifting copy of the known distro CA-bundle paths. Compiled directly into
  `https_client` (not linked via the legacy `libwazuh`, which this module otherwise avoids
  entirely) since it's a dependency-free leaf (plain POSIX `stat()`, no `shared.h`).
- **Windows and macOS**: both use the platform's native certificate store
  (`CURLSSLOPT_NATIVE_CA`) — this mechanism already existed and worked for Windows (previously
  wired only under `verification_mode=none`, where it was reachable but inert since peer
  verification is already off there); this change extends it to `system` and to macOS, whose
  vendored curl build already has Apple SecTrust support compiled in but previously unused.
- Documents the full four-mode `<ssl><verification_mode>` reference in
  `docs/ref/modules/client/configuration.md` — previously undocumented in-repo and upstream
  for any of the modes, not just the new one.

### Results and Evidence

Real logs and manager-API responses from live agent/manager pairs (Docker containers running
source-built binaries from this branch — not a mock server), covering both Ubuntu 22.04 and
AlmaLinux 8.10 (Debian-family and RHEL-family CA-bundle paths respectively). No Windows/macOS
host was available to reproduce the same live pass there; that platform coverage rests on the
code paths described above, which reuse the exact mechanism already shipped and working for
Windows under other modes.

<details>
<summary><b>Before: today's 3-mode behavior (verification_mode=system doesn't exist yet)</b></summary>

```
2026/08/21 15:41:30 wazuh-agentd[51098] client-config.c:568 at Read_Agent_SSL(): ERROR: (1235): Invalid value for element 'verification_mode': system.
2026/08/21 15:41:30 wazuh-agentd[51098] config.c:464 at PrintErrorAcordingToModules(): ERROR: (1202): Configuration error at 'etc/ossec.conf'.
2026/08/21 15:41:30 wazuh-agentd[51098] main.c:187 at main(): ERROR: (1215): No client configured. Exiting.

2026/08/21 15:41:45 wazuh-agentd[51132] client-config.c:168 at Read_Agent(): WARNING: The <time-reconnect> option is deprecated and no longer has any effect.
2026/08/21 15:41:45 wazuh-agentd[51132] config.c:129 at w_agent_validate_ssl_ca(): ERROR: (4118): <ssl><verification_mode> is not 'none' but <certificate_authorities> is missing or unreadable: ''.
2026/08/21 15:41:45 wazuh-agentd[51132] main.c:210 at main(): ERROR: (1215): No client configured. Exiting.
```

</details>

<details>
<summary><b>After — Ubuntu 22.04: verification_mode=system connects via the real OS trust store</b></summary>

Manager's self-signed cert installed into the container's real OS trust store
(`update-ca-certificates`), `certificate_authorities` left unset:

```
2026/08/21 21:20:11 wazuh-agentd: INFO: https_client: starting.
2026/08/21 21:20:11 wazuh-agentd:https-client: INFO: Starting https_client (server=wazuh-server:1517, agent=001, body compression enabled).
```

Independently confirmed via the manager's own REST API (not just the agent's self-report):

```json
{
    "status": "active",
    "id": "001",
    "lastKeepAlive": "2026-08-21T21:21:19+00:00",
    "ip": "172.18.0.4",
    "name": "final-ubuntu-agent"
}
```

</details>

<details>
<summary><b>After — AlmaLinux 8.10: verification_mode=system connects via the real OS trust store</b></summary>

Same manager cert installed via the RHEL-family path (`update-ca-trust extract`,
`/etc/pki/tls/certs/ca-bundle.crt`):

```
2026/08/21 21:20:20 wazuh-agentd: INFO: https_client: starting.
2026/08/21 21:20:20 wazuh-agentd:https-client: INFO: Starting https_client (server=wazuh-server:1517, agent=002, body compression enabled).
```

```json
{
    "status": "active",
    "id": "002",
    "lastKeepAlive": "2026-08-21T21:21:29+00:00",
    "ip": "172.18.0.3",
    "name": "final-centos8-agent"
}
```

</details>

<details>
<summary><b>After — fails closed on both platforms once the cert is removed from the OS store</b></summary>

Same config, same manager, cert removed from each OS trust store (re-verified untrusted with
`openssl verify` immediately before restarting):

Ubuntu:
```
2026/08/21 21:22:19 wazuh-agentd: INFO: https_client: starting.
2026/08/21 21:22:19 wazuh-agentd:https-client: INFO: Starting https_client (server=wazuh-server:1517, agent=001, body compression enabled).
2026/08/21 21:23:02 wazuh-agentd: WARNING: Manager unreachable. Pausing module event production.
```

AlmaLinux:
```
2026/08/21 21:22:28 wazuh-agentd: INFO: https_client: starting.
2026/08/21 21:22:28 wazuh-agentd:https-client: INFO: Starting https_client (server=wazuh-server:1517, agent=002, body compression enabled).
2026/08/21 21:23:00 wazuh-agentd: WARNING: Manager unreachable. Pausing module event production.
```

Manager-API confirmation: `lastKeepAlive` for both agents stays frozen at the exact timestamp
of the last successful handshake before trust was removed (`2026-08-21T21:21:19+00:00` /
`2026-08-21T21:21:29+00:00`) — over a minute later, across a full agent restart each, the
manager has received zero new keepalives from either agent.

</details>

<details>
<summary><b>After — config-conflict fails closed identically on both platforms</b></summary>

`verification_mode=system` with `certificate_authorities` also set:

```
2026/08/21 21:23:54 wazuh-agentd: ERROR: (4120): <ssl><verification_mode> is 'system' but <certificate_authorities> is set: '/tmp/some-ca.pem'. Remove it, or choose a different verification_mode; the OS trust store is used instead.
2026/08/21 21:23:54 wazuh-agentd: ERROR: (1215): No client configured. Exiting.
```

(AlmaLinux: identical error one second later.)

</details>

<details>
<summary><b>Manager-side corroboration (independent of anything the agents themselves report)</b></summary>

```
2026/08/21 21:19:21 wazuh-manager-remoted:http-server: INFO: HTTP server listening on https://0.0.0.0:1517 (32 I/O thread(s), 64 worker thread(s), max body 20971520 bytes, in-flight budget 268435456 bytes, max 512 connection(s)).
2026/08/21 21:19:21 wazuh-manager-remoted: INFO: Started (pid: 37589). Listening on port 1514/TCP (secure).
2026/08/21 21:19:51 wazuh-manager-remoted:keystore: INFO: Reloaded 1 agent key(s) from 'etc/client.keys'.
2026/08/21 21:20:00 wazuh-manager-remoted:keystore: INFO: Reloaded 2 agent key(s) from 'etc/client.keys'.
```

</details>

<details>
<summary><b>Full automated test suite (all green, fresh build from a completely clean environment — no cached containers/images/deps)</b></summary>

```
https_client_unit_test:      388 tests, 388 passed
https_client_component_test:  49 tests,  49 passed
  (includes 2 new real-TLS-handshake tests for system mode: success against
   an injected OS-trust-store stand-in, and fails-closed against an untrusted
   cert — and 6 pre-existing enrollment-flow component tests, unaffected)
test_agent_ssl_ca:            10 tests,  10 passed
test_client-config_https.c:   57 tests,  57 passed
test_https_client_bridge.c:   84 tests,  84 passed
test_url.c:                    9 tests,   9 passed
test_os_cert_bundle.c:         4 tests,   4 passed
```

</details>

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X

  <details>
  <summary>Linux build log (tail)</summary>

  ```
  [32;1mDone building agent
  ```

  Full `make TARGET=agent DEBUG=1 TEST=1` build from a fresh checkout, fresh
  `make deps`, no cached artifacts — see the automated test suite results above for the
  accompanying test run.
  </details>

  Windows and macOS were not build-verified in this PR — no such host was available in the
  development environment. The new platform-specific code paths (`__APPLE__`/`WIN32` guards in
  `curlPerformer.cpp`) are minimal, mechanical extensions of an existing, already-compiling
  branch (the Windows `CURLSSLOPT_NATIVE_CA` wiring), reviewed but not independently
  cross-compiled here. Flagging for CI/reviewer verification on those platforms.

- [x] Log syntax and correct language review

### Artifacts Affected

- `wazuh-agent` binary (Linux, Windows, macOS) — new config value accepted, no ABI/CLI change.
- No packages, installers, or default configuration files changed (the new mode is opt-in; the
  agent's shipped default remains `verification_mode` unset → `none`).

### Configuration Changes

- **New allowed value** for the existing `<agent><ssl><verification_mode>` option: `system`
  (alongside `full`, `certificate`, `none`). Fully backward compatible — no existing config
  changes behavior.
- **New constraint**: `verification_mode=system` must not be combined with
  `<certificate_authorities>` — the agent fails closed at startup if both are set (new error
  `(4120)`).
- **New failure mode (Linux only)**: `verification_mode=system` fails closed at startup if no
  known OS CA bundle path is found on the host (new error `(4121)`).

### Tests Introduced

- **Unit** (`moduleConfig_test.cpp`, `curlPerformer_test.cpp`): `system` mode's validation
  (valid-without-CA-when-bundle-found, fails-closed-when-CA-set, fails-closed-when-no-bundle)
  and trust-anchor wiring (peer+host verification, native-store vs. resolved-file-path per
  platform, resolved once at construction rather than per-request).
- **Component** (`tlsVerification_component_test.cpp`): two new tests doing a **real TLS
  handshake** for `system` mode — success against an injected OS-trust-store stand-in, and
  fails-closed against an untrusted cert — using a dependency-injected `IFsProbe` seam so
  neither test touches the real OS trust store or needs root, following the file's existing
  pattern for `full` mode.
- **C/cmocka** (`test_client-config_https.c`, `test_https_client_bridge.c`,
  `test_agent_ssl_ca.c`): config parsing, the C→C++ bridge mapping, and the early startup
  fail-closed gate (`w_agent_validate_ssl_ca`), including both new fail-closed rules.
- **New shared helper's own tests** (`test_os_cert_bundle.c`, `test_url.c` regression check):
  the extracted `os_find_ca_bundle()` helper is tested directly (injectable candidate list, no
  mocking needed), and `url.c`'s existing WPK-download test is confirmed unaffected by the
  extraction.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done — pending Windows/macOS verification
- [ ] No unresolved dependencies with other issues
- [ ] ...

Windows and macOS live verification, and a decision on whether documentation.wazuh.com needs a
matching update now vs. once the broader v5.0 HTTPS-transport docs land, are open items for
this PR before merge.
