### PR TITLE
Allow Windows agent MSI upgrade to proceed despite an unrelated pending-reboot flag

### DIFF
--- a/src/win32/wazuh-installer.wxs
+++ b/src/win32/wazuh-installer.wxs
@@ -8,9 +8,13 @@
         <Property Id="REBOOT" Value="ReallySuppress" />
 
         <!-- Do not run while a system restart is pending: abort before making any change so the
-             install is never left half-committed and later broken by the pending restart. Uninstall
-             and repair of an already-installed product are still allowed. -->
-        <Condition Message="A system restart is pending on this computer. Please reboot and run the Wazuh agent installer again."><![CDATA[Installed OR NOT MsiSystemRebootPending]]></Condition>
+             install is never left half-committed and later broken by the pending restart. Uninstall,
+             repair of an already-installed product, and a detected upgrade of a prior Wazuh install
+             are still allowed. MsiSystemRebootPending is a machine-wide flag (set by msiexec itself
+             from PendingFileRenameOperations/Component Based Servicing/Windows Update reboot markers)
+             and does not distinguish a Wazuh-caused pending restart from an unrelated one (e.g. a
+             third-party auto-updater), so a genuine version upgrade should not be blocked by it. -->
+        <Condition Message="A system restart is pending on this computer. Please reboot and run the Wazuh agent installer again."><![CDATA[Installed OR WIX_UPGRADE_DETECTED OR NOT MsiSystemRebootPending]]></Condition>
 
         <!-- Default configuration values -->
         <Property Id="WAZUH_MANAGER" Secure="yes"/>


### PR DESCRIPTION
# Description

The Windows agent installer refuses to upgrade an existing installation whenever Windows' machine-wide "system restart pending" flag is set — even when that pending restart has nothing to do with Wazuh. In the reported nightly build failure, upgrading an existing 4.14.7 agent to 5.0.0 failed with exit code `1603` solely because of an unrelated pending-reboot marker left behind by a third-party auto-updater on the target machine; a fresh, from-scratch install of the same 5.0.0 package on the same machine succeeded moments earlier, ruling out the package itself, signing, or infrastructure.

The installer's `LaunchConditions` check aborts before touching any files if `MsiSystemRebootPending` is true, unless the product is already installed (a repair). It did not treat "this is a detected upgrade of an existing Wazuh install" as an equally valid exemption, even though the installer's own `FindRelatedProducts` step had already confirmed exactly that a moment earlier.

Closes #38504

## Proposed Changes

- Widened the `LaunchConditions` condition in the Windows agent's WiX installer definition from `Installed OR NOT MsiSystemRebootPending` to `Installed OR WIX_UPGRADE_DETECTED OR NOT MsiSystemRebootPending`.
- `WIX_UPGRADE_DETECTED` is set internally by Windows Installer's own major-upgrade detection (`FindRelatedProducts`) only when a prior installation sharing this product's upgrade code is actually found on the machine — it cannot be set from the command line, so this does not weaken the guard for a genuine first-time install onto a machine with a pending reboot; that case is still blocked exactly as before.
- No compiled agent code changed — this is a change to the installer definition only.

### Results and Evidence

**Reproduction.** With an existing 4.14.7 agent installed and running, attempting to install the (unpatched) 5.0.0 package directly over it — without uninstalling first, matching the exact sequence used by the automated upgrade test that originally reported this — failed with `1603`. The verbose installer log shows the installer correctly detecting the existing installation (`WIX_UPGRADE_DETECTED`, `WAZUHINSTALLED`, `WAZUHRUNNING=Running` all set), then aborting in `LaunchConditions` before any files were touched:

<details>
<summary>Raw log — unpatched install, real ambient pending-reboot flag (LaunchConditions aborts)</summary>

```
MSI (s) (F8:24) [20:19:22:045]: Doing action: FindRelatedProducts
MSI (s) (F8:24) [20:19:22:045]: Note: 1: 2205 2:  3: ActionText 
Action start 20:19:22: FindRelatedProducts.
MSI (s) (F8:24) [20:19:22:092]: PROPERTY CHANGE: Adding IS_UPGRADING_FROM_PRIOR_TO_5X property. Its value is '{D9770AF7-8335-4FEB-927C-C575B11A1F7B}'.
MSI (s) (F8:24) [20:19:22:092]: PROPERTY CHANGE: Adding WIX_UPGRADE_DETECTED property. Its value is '{D9770AF7-8335-4FEB-927C-C575B11A1F7B}'.
MSI (s) (F8:24) [20:19:22:092]: PROPERTY CHANGE: Adding MIGRATE property. Its value is '{D9770AF7-8335-4FEB-927C-C575B11A1F7B}'.
MSI (s) (F8:24) [20:19:22:092]: Skipping action: PreventUnsupportedUpgrade (condition is false)
MSI (s) (F8:24) [20:19:22:092]: Doing action: CheckSvcRunning
MSI (s) (F8:24) [20:19:22:092]: Note: 1: 2205 2:  3: ActionText 
Action ended 20:19:22: FindRelatedProducts. Return value 1.
MSI (s) (F8:6C) [20:19:22:125]: Generating random cookie.
MSI (s) (F8:6C) [20:19:22:188]: Created Custom Action Server with PID 1472 (0x5C0).
MSI (s) (F8:18) [20:19:22:659]: Running as a service.
MSI (s) (F8:18) [20:19:22:688]: Hello, I'm your 32bit Impersonated custom action server.
MSI (s) (F8!24) [20:19:23:336]: PROPERTY CHANGE: Adding WAZUHRUNNING property. Its value is 'Running'.
Action start 20:19:22: CheckSvcRunning.
MSI (s) (F8:24) [20:19:23:343]: Doing action: AppSearch
MSI (s) (F8:24) [20:19:23:343]: Note: 1: 2205 2:  3: ActionText 
Action ended 20:19:23: CheckSvcRunning. Return value 0.
Action start 20:19:23: AppSearch.
MSI (s) (F8:24) [20:19:23:343]: Note: 1: 2262 2: Signature 3: -2147287038 
MSI (s) (F8:24) [20:19:23:343]: PROPERTY CHANGE: Modifying MAJORVERSION property. Its current value is '0'. Its new value: '#10'.
MSI (s) (F8:24) [20:19:23:370]: Note: 1: 2262 2: Signature 3: -2147287038 
MSI (s) (F8:24) [20:19:23:370]: PROPERTY CHANGE: Modifying BUILDVERSION property. Its current value is '0'. Its new value: '22000'.
MSI (s) (F8:24) [20:19:23:370]: Note: 1: 2262 2: Signature 3: -2147287038 
MSI (s) (F8:24) [20:19:23:370]: PROPERTY CHANGE: Adding APPLICATIONFOLDER property. Its value is 'C:\Program Files (x86)\ossec-agent\'.
MSI (s) (F8:24) [20:19:23:370]: Note: 1: 2262 2: Signature 3: -2147287038 
MSI (s) (F8:24) [20:19:23:370]: Note: 1: 1402 2: HKEY_LOCAL_MACHINE32\System\CurrentControlSet\Services\OssecSvc 3: 2 
MSI (s) (F8:24) [20:19:23:370]: Note: 1: 2262 2: Signature 3: -2147287038 
MSI (s) (F8:24) [20:19:23:370]: PROPERTY CHANGE: Adding WAZUHINSTALLED property. Its value is 'Wazuh'.
MSI (s) (F8:24) [20:19:23:370]: Doing action: SetCustomActionDataCleanupLegacyDBs
MSI (s) (F8:24) [20:19:23:370]: Note: 1: 2205 2:  3: ActionText 
Action ended 20:19:23: AppSearch. Return value 1.
MSI (s) (F8:24) [20:19:23:370]: PROPERTY CHANGE: Adding CleanupLegacyDatabases property. Its value is '"C:\Program Files (x86)\ossec-agent\"'.
Action start 20:19:23: SetCustomActionDataCleanupLegacyDBs.
MSI (s) (F8:24) [20:19:23:370]: Doing action: LaunchConditions
MSI (s) (F8:24) [20:19:23:370]: Note: 1: 2205 2:  3: ActionText 
Action ended 20:19:23: SetCustomActionDataCleanupLegacyDBs. Return value 1.
Action start 20:19:23: LaunchConditions.
MSI (s) (F8:24) [20:19:23:370]: Product: Wazuh Agent -- A system restart is pending on this computer. Please reboot and run the Wazuh agent installer again.

A system restart is pending on this computer. Please reboot and run the Wazuh agent installer again.
Action ended 20:19:23: LaunchConditions. Return value 3.
Action ended 20:19:23: INSTALL. Return value 3.
[... intervening property-table dump omitted, not diagnostic ...]
Property(S): WAZUHRUNNING = Running
MSI (s) (F8:24) [20:19:23:811]: Note: 1: 1708 
MSI (s) (F8:24) [20:19:23:811]: Product: Wazuh Agent -- Installation failed.

MSI (s) (F8:24) [20:19:23:811]: Windows Installer installed the product. Product Name: Wazuh Agent. Product Version: 5.0.0. Product Language: 1033. Manufacturer: Wazuh, Inc.. Installation success or error status: 1603.

MSI (s) (F8:24) [20:19:23:811]: Deferring clean up of packages/files, if any exist
MSI (s) (F8:24) [20:19:23:811]: MainEngineThread is returning 1603
MSI (s) (F8:C4) [20:19:23:811]: RESTART MANAGER: Session closed.
```

</details>

**Re-validating after the environment's pending-reboot state cleared.** The pending-reboot marker present during the original reproduction was consumed by an intervening reboot of the test machine, so it no longer occurred naturally. To validate the fix under the exact same condition rather than an unpredictable ambient state, a synthetic-but-realistic pending-reboot marker was set directly (a standard Windows "pending file rename operation" entry pointing at a nonexistent file — Windows Installer treats its mere presence as "a restart is pending" regardless of whether the referenced file is real, so this recreates the exact trigger condition without touching any real file; the entry was removed again immediately after testing).

**Sanity check — unpatched package still fails under the recreated condition.** Confirms the synthetic marker faithfully reproduces the real failure:

<details>
<summary>Raw log — unpatched install, synthetic pending-reboot marker (LaunchConditions aborts, same as production)</summary>

```
MSI (s) (A4:54) [00:13:18:348]: Doing action: INSTALL
MSI (s) (A4:54) [00:13:18:348]: Note: 1: 2205 2:  3: ActionText 
Action start 0:13:18: INSTALL.
MSI (s) (A4:54) [00:13:18:348]: Running ExecuteSequence
MSI (s) (A4:54) [00:13:18:348]: Doing action: FindRelatedProducts
MSI (s) (A4:54) [00:13:18:348]: Note: 1: 2205 2:  3: ActionText 
Action start 0:13:18: FindRelatedProducts.
MSI (s) (A4:54) [00:13:18:380]: PROPERTY CHANGE: Adding IS_UPGRADING_FROM_PRIOR_TO_5X property. Its value is '{D9770AF7-8335-4FEB-927C-C575B11A1F7B}'.
MSI (s) (A4:54) [00:13:18:380]: PROPERTY CHANGE: Adding WIX_UPGRADE_DETECTED property. Its value is '{D9770AF7-8335-4FEB-927C-C575B11A1F7B}'.
MSI (s) (A4:54) [00:13:18:380]: PROPERTY CHANGE: Adding MIGRATE property. Its value is '{D9770AF7-8335-4FEB-927C-C575B11A1F7B}'.
MSI (s) (A4:54) [00:13:18:380]: Skipping action: PreventUnsupportedUpgrade (condition is false)
MSI (s) (A4:54) [00:13:18:380]: Doing action: CheckSvcRunning
MSI (s) (A4:54) [00:13:18:380]: Note: 1: 2205 2:  3: ActionText 
Action ended 0:13:18: FindRelatedProducts. Return value 1.
MSI (s) (A4:F0) [00:13:18:414]: Generating random cookie.
MSI (s) (A4:F0) [00:13:18:472]: Created Custom Action Server with PID 6012 (0x177C).
MSI (s) (A4:28) [00:13:19:330]: Running as a service.
MSI (s) (A4:28) [00:13:19:330]: Hello, I'm your 32bit Impersonated custom action server.
MSI (s) (A4!54) [00:13:20:804]: PROPERTY CHANGE: Adding WAZUHRUNNING property. Its value is 'Running'.
Action start 0:13:18: CheckSvcRunning.
MSI (s) (A4:54) [00:13:20:851]: Doing action: AppSearch
MSI (s) (A4:54) [00:13:20:851]: Note: 1: 2205 2:  3: ActionText 
Action ended 0:13:20: CheckSvcRunning. Return value 0.
Action start 0:13:20: AppSearch.
[... AppSearch property-discovery lines omitted, identical shape to the run above ...]
Action ended 0:13:20: AppSearch. Return value 1.
MSI (s) (A4:54) [00:13:21:026]: PROPERTY CHANGE: Adding CleanupLegacyDatabases property. Its value is '"C:\Program Files (x86)\ossec-agent\"'.
Action start 0:13:20: SetCustomActionDataCleanupLegacyDBs.
MSI (s) (A4:54) [00:13:21:026]: Doing action: LaunchConditions
MSI (s) (A4:54) [00:13:21:026]: Note: 1: 2205 2:  3: ActionText 
Action ended 0:13:21: SetCustomActionDataCleanupLegacyDBs. Return value 1.
Action start 0:13:21: LaunchConditions.
MSI (s) (A4:54) [00:13:21:104]: Product: Wazuh Agent -- A system restart is pending on this computer. Please reboot and run the Wazuh agent installer again.

A system restart is pending on this computer. Please reboot and run the Wazuh agent installer again.
Action ended 0:13:21: LaunchConditions. Return value 3.
Action ended 0:13:21: INSTALL. Return value 3.
[... intervening property-table dump omitted, not diagnostic ...]
Property(S): ACTION = INSTALL
Property(S): MIGRATE = {D9770AF7-8335-4FEB-927C-C575B11A1F7B}
Property(S): WAZUHRUNNING = Running
MSI (s) (A4:54) [00:13:22:152]: Note: 1: 1708 
MSI (s) (A4:54) [00:13:22:152]: Product: Wazuh Agent -- Installation failed.

MSI (s) (A4:54) [00:13:22:163]: Windows Installer installed the product. Product Name: Wazuh Agent. Product Version: 5.0.0. Product Language: 1033. Manufacturer: Wazuh, Inc.. Installation success or error status: 1603.

MSI (s) (A4:54) [00:13:22:163]: Deferring clean up of packages/files, if any exist
```

</details>

**Patched package — same recreated condition, upgrade now succeeds.** With the identical synthetic pending-reboot marker still present and the identical prior installation state, installing the patched package completes successfully — `LaunchConditions` now returns `1` (pass) instead of `3` (abort) at the exact same point in the sequence:

<details>
<summary>Raw log — patched install, same synthetic pending-reboot marker (LaunchConditions passes, install completes)</summary>

```
MSI (s) (A4:AC) [00:13:58:174]: Doing action: INSTALL
MSI (s) (A4:AC) [00:13:58:174]: Note: 1: 2205 2:  3: ActionText 
Action start 0:13:58: INSTALL.
MSI (s) (A4:AC) [00:13:58:174]: Running ExecuteSequence
MSI (s) (A4:AC) [00:13:58:174]: Doing action: FindRelatedProducts
MSI (s) (A4:AC) [00:13:58:174]: Note: 1: 2205 2:  3: ActionText 
Action start 0:13:58: FindRelatedProducts.
MSI (s) (A4:AC) [00:13:58:174]: PROPERTY CHANGE: Adding IS_UPGRADING_FROM_PRIOR_TO_5X property. Its value is '{D9770AF7-8335-4FEB-927C-C575B11A1F7B}'.
MSI (s) (A4:AC) [00:13:58:174]: PROPERTY CHANGE: Adding WIX_UPGRADE_DETECTED property. Its value is '{D9770AF7-8335-4FEB-927C-C575B11A1F7B}'.
MSI (s) (A4:AC) [00:13:58:174]: PROPERTY CHANGE: Adding MIGRATE property. Its value is '{D9770AF7-8335-4FEB-927C-C575B11A1F7B}'.
MSI (s) (A4:AC) [00:13:58:174]: Skipping action: PreventUnsupportedUpgrade (condition is false)
MSI (s) (A4:AC) [00:13:58:174]: Doing action: CheckSvcRunning
MSI (s) (A4:AC) [00:13:58:174]: Note: 1: 2205 2:  3: ActionText 
Action ended 0:13:58: FindRelatedProducts. Return value 1.
MSI (s) (A4:58) [00:13:58:174]: Generating random cookie.
MSI (s) (A4:58) [00:13:58:203]: Created Custom Action Server with PID 8920 (0x22D8).
MSI (s) (A4:28) [00:13:58:292]: Running as a service.
MSI (s) (A4:28) [00:13:58:330]: Hello, I'm your 32bit Impersonated custom action server.
MSI (s) (A4!AC) [00:13:59:160]: PROPERTY CHANGE: Adding WAZUHRUNNING property. Its value is 'Running'.
Action start 0:13:58: CheckSvcRunning.
MSI (s) (A4:AC) [00:13:59:190]: Doing action: AppSearch
MSI (s) (A4:AC) [00:13:59:190]: Note: 1: 2205 2:  3: ActionText 
Action ended 0:13:59: CheckSvcRunning. Return value 0.
Action start 0:13:59: AppSearch.
[... AppSearch property-discovery lines omitted, identical shape to the runs above ...]
Action ended 0:13:59: AppSearch. Return value 1.
MSI (s) (A4:AC) [00:13:59:239]: PROPERTY CHANGE: Adding CleanupLegacyDatabases property. Its value is '"C:\Program Files (x86)\ossec-agent\"'.
Action start 0:13:59: SetCustomActionDataCleanupLegacyDBs.
MSI (s) (A4:AC) [00:13:59:239]: Doing action: LaunchConditions
MSI (s) (A4:AC) [00:13:59:239]: Note: 1: 2205 2:  3: ActionText 
Action ended 0:13:59: SetCustomActionDataCleanupLegacyDBs. Return value 1.
Action start 0:13:59: LaunchConditions.
MSI (s) (A4:AC) [00:13:59:274]: Doing action: ValidateProductID
MSI (s) (A4:AC) [00:13:59:274]: Note: 1: 2205 2:  3: ActionText 
Action ended 0:13:59: LaunchConditions. Return value 1.
[... remainder of the install sequence omitted (file installation, service stop/start, registration) — ran to completion with no further errors, ~95 seconds total ...]
MSI (s) (A4:AC) [00:15:33:438]: Note: 1: 1707 
MSI (s) (A4:AC) [00:15:33:438]: Product: Wazuh Agent -- Installation completed successfully.

MSI (s) (A4:AC) [00:15:33:438]: Windows Installer installed the product. Product Name: Wazuh Agent. Product Version: 5.0.0. Product Language: 1033. Manufacturer: Wazuh, Inc.. Installation success or error status: 0.
```

</details>

Post-install verification confirmed the agent was actually upgraded and functional, not just that the installer returned `0`: the installed version file reported the new version and build commit, and the Wazuh service was running immediately afterward.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux — N/A, this change only touches the Windows-specific installer definition.
  - [ ] Windows — the Windows package was built successfully from this change and produced a working installer (see evidence above), but compiler/build warning output was not separately captured, so this is left unchecked rather than assumed.
  - [ ] MAC OS X — N/A, not affected.
- [ ] Log syntax and correct language review — N/A, no product log message text was added or changed.
- Memory tests for Linux — N/A, no compiled code changed.
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows — N/A, no compiled code changed (installer definition only).
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS — N/A, not affected.
  - [ ] Leaks
  - [ ] AddressSanitizer
- Decoder/Rule tests _(Wazuh v4.x)_ — N/A, not related to decoders/rules.
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors
- Engine _(Wazuh v5.x and above)_ — N/A, not related to the wazuh-engine component.
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.
- Wazuh server API/Framework — N/A, not related to the server API/framework.
  - [ ] Run API Integration Tests

The functional verification for this change is the manual install/upgrade reproduction documented under Results and Evidence above: reproduced the reported failure, confirmed it under a controlled, repeatable condition, and confirmed the fix resolves it while leaving the rest of the install sequence (file installation, service handling, registration) completing normally.

### Artifacts Affected

- Windows agent installer package (`.msi`) — only the WiX installer definition changed; no compiled binary/source code was modified.

### Configuration Changes

N/A — no new configuration parameters, no default value changes.

### Tests Introduced

No new automated unit/integration test was added. Verification was a manual reproduction and fix validation directly against a live installation, documented above with raw installer log evidence for the failing case, a controlled re-creation of the same failure condition, and the fix resolving it under that same condition.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented — N/A, none
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...
