### PR TITLE
Fix memory leak in the analysisd JSON decoder when an event repeats a field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 - Bounded the agent control message copy to the source string length in `wazuh-remoted`. ([#38427](https://github.com/wazuh/wazuh/pull/38427))
 - Fixed the cluster server keeping pre-authentication connections open indefinitely by adding a handshake deadline and a global connection limit. ([#38449](https://github.com/wazuh/wazuh/pull/38449))
+- Fixed a memory leak in the `wazuh-analysisd` JSON decoder when an event repeats a static field. ([#38548](https://github.com/wazuh/wazuh/pull/38548))
 
 ### Agent
 

--- a/src/analysisd/decoders/plugins/json_decoder.c
+++ b/src/analysisd/decoders/plugins/json_decoder.c
@@ -22,6 +22,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
         return;
 
     if (strcmp(key, "srcip") == 0){
+        os_free(lf->srcip);
         os_strdup(value, lf->srcip);
 #ifdef TESTRULE
         if (!alert_only) {
@@ -43,6 +44,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     }
 
     if (strcmp(key, "dstip") == 0){
+        os_free(lf->dstip);
         os_strdup(value, lf->dstip);
 #ifdef TESTRULE
         if (!alert_only) {
@@ -63,6 +65,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     }
 
     if (strcmp(key, "dstport") == 0){
+        os_free(lf->dstport);
         os_strdup(value, lf->dstport);
 #ifdef TESTRULE
         if (!alert_only) {
@@ -73,6 +76,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     }
 
     if (strcmp(key, "srcport") == 0){
+        os_free(lf->srcport);
         os_strdup(value, lf->srcport);
 #ifdef TESTRULE
         if (!alert_only) {
@@ -83,6 +87,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     }
 
     if (strcmp(key, "protocol") == 0){
+        os_free(lf->protocol);
         os_strdup(value, lf->protocol);
 #ifdef TESTRULE
         if (!alert_only) {
@@ -93,6 +98,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     }
 
     if (strcmp(key, "action") == 0){
+        os_free(lf->action);
         os_strdup(value, lf->action);
 #ifdef TESTRULE
         if (!alert_only) {
@@ -103,6 +109,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     }
 
     if (strcmp(key, "srcuser") == 0){
+        os_free(lf->srcuser);
         os_strdup(value, lf->srcuser);
 #ifdef TESTRULE
         if (!alert_only) {
@@ -131,6 +138,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     */
     if (strcmp(key, "user") == 0){
         if (!lf->dstuser || !*lf->dstuser) {
+            os_free(lf->dstuser);
             os_strdup(value, lf->dstuser);
 #ifdef TESTRULE
         if (!alert_only) {
@@ -142,6 +150,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     }
 
     if (strcmp(key, "id") == 0){
+        os_free(lf->id);
         os_strdup(value, lf->id);
 #ifdef TESTRULE
         if (!alert_only) {
@@ -152,6 +161,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     }
 
     if (strcmp(key, "status") == 0){
+        os_free(lf->status);
         os_strdup(value, lf->status);
 #ifdef TESTRULE
         if (!alert_only) {
@@ -162,6 +172,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     }
 
     if (strcmp(key, "url") == 0){
+        os_free(lf->url);
         os_strdup(value, lf->url);
 #ifdef TESTRULE
         if (!alert_only) {
@@ -172,6 +183,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     }
 
     if (strcmp(key, "data") == 0){
+        os_free(lf->data);
         os_strdup(value, lf->data);
 #ifdef TESTRULE
         if (!alert_only) {
@@ -182,6 +194,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     }
 
     if (strcmp(key, "extra_data") == 0){
+        os_free(lf->extra_data);
         os_strdup(value, lf->extra_data);
 #ifdef TESTRULE
         if (!alert_only) {
@@ -192,6 +205,7 @@ void fillData(Eventinfo *lf, const char *key, const char *value)
     }
 
     if (strcmp(key, "systemname") == 0){
+        os_free(lf->systemname);
         os_strdup(value, lf->systemname);
 #ifdef TESTRULE
         if (!alert_only) {

--- a/src/unit_tests/analysisd/CMakeLists.txt
+++ b/src/unit_tests/analysisd/CMakeLists.txt
@@ -189,6 +189,9 @@ LIST(APPEND analysisd_flags "-Wl,--wrap,_minfo -Wl,--wrap,_mwarn")
 list(APPEND analysisd_names "test_json_extended")
 list(APPEND analysisd_flags "${DEBUG_OP_WRAPPERS}")
 
+list(APPEND analysisd_names "test_json_decoder")
+list(APPEND analysisd_flags "-Wl,--wrap,strdup -Wl,--wrap,free")
+
 list(APPEND analysisd_names "test_analysisd_upgrade_module")
 list(APPEND analysisd_flags "-Wl,--wrap,OS_ConnectUnixDomain -Wl,--wrap,OS_SendSecureTCP ${DEBUG_OP_WRAPPERS}")
 

--- a/src/unit_tests/analysisd/test_json_decoder.c
+++ b/src/unit_tests/analysisd/test_json_decoder.c
@@ -1,0 +1,275 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../analysisd/eventinfo.h"
+#include "../../analysisd/config.h"
+#include "../../analysisd/decoders/plugin_decoders.h"
+
+/* Global configuration required by the decoder under test */
+_Config Config;
+
+#define TRACKED_MAX 64
+
+/* Allocation tracking, used to detect values that fillData() replaces without releasing */
+
+static void * tracked[TRACKED_MAX];
+static int tracked_released[TRACKED_MAX];
+static int tracked_count = 0;
+static int tracking = 0;
+
+extern char * __real_strdup(const char *s);
+extern void __real_free(void *ptr);
+
+char * __wrap_strdup(const char *s) {
+    char * ptr = __real_strdup(s);
+
+    if (tracking && ptr != NULL && tracked_count < TRACKED_MAX) {
+        tracked[tracked_count] = ptr;
+        tracked_released[tracked_count] = 0;
+        tracked_count++;
+    }
+
+    return ptr;
+}
+
+void __wrap_free(void *ptr) {
+    for (int i = 0; i < tracked_count; i++) {
+        if (tracked[i] == ptr) {
+            tracked_released[i] = 1;
+        }
+    }
+
+    __real_free(ptr);
+}
+
+static void tracking_reset(void) {
+    tracked_count = 0;
+    tracking = 0;
+}
+
+static void track(void *ptr) {
+    assert_true(tracked_count < TRACKED_MAX);
+    tracked[tracked_count] = ptr;
+    tracked_released[tracked_count] = 0;
+    tracked_count++;
+}
+
+static int released(const void *ptr) {
+    for (int i = 0; i < tracked_count; i++) {
+        if (tracked[i] == ptr && tracked_released[i]) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+static int pending(void) {
+    int count = 0;
+
+    for (int i = 0; i < tracked_count; i++) {
+        if (!tracked_released[i]) {
+            count++;
+        }
+    }
+
+    return count;
+}
+
+/* Static fields handled by fillData() */
+
+typedef struct {
+    const char * key;
+    size_t offset;
+} static_field_t;
+
+static const static_field_t STATIC_FIELDS[] = {
+    { "srcip", offsetof(Eventinfo, srcip) },
+    { "dstip", offsetof(Eventinfo, dstip) },
+    { "srcport", offsetof(Eventinfo, srcport) },
+    { "dstport", offsetof(Eventinfo, dstport) },
+    { "protocol", offsetof(Eventinfo, protocol) },
+    { "action", offsetof(Eventinfo, action) },
+    { "srcuser", offsetof(Eventinfo, srcuser) },
+    { "dstuser", offsetof(Eventinfo, dstuser) },
+    { "id", offsetof(Eventinfo, id) },
+    { "status", offsetof(Eventinfo, status) },
+    { "url", offsetof(Eventinfo, url) },
+    { "data", offsetof(Eventinfo, data) },
+    { "extra_data", offsetof(Eventinfo, extra_data) },
+    { "systemname", offsetof(Eventinfo, systemname) },
+};
+
+#define STATIC_FIELDS_COUNT (sizeof(STATIC_FIELDS) / sizeof(STATIC_FIELDS[0]))
+
+/* Setup / teardown */
+
+static OSDecoderInfo decoder_info;
+
+/* Releases the fields that fillData() owns. Mirrors the static field cleanup of
+ * Free_Eventinfo(), which cannot be linked here because analysisd provides main().
+ */
+static void free_event(Eventinfo *lf) {
+    for (unsigned int i = 0; i < STATIC_FIELDS_COUNT; i++) {
+        char ** field = (char **) ((char *) lf + STATIC_FIELDS[i].offset);
+        free(*field);
+    }
+
+    for (int i = 0; i < lf->nfields; i++) {
+        free(lf->fields[i].key);
+        free(lf->fields[i].value);
+    }
+
+    free(lf->fields);
+    free(lf);
+}
+
+static int setup_group(void **state) {
+    (void) state;
+
+    memset(&Config, 0, sizeof(Config));
+    Config.decoder_order_size = 32;
+
+    memset(&decoder_info, 0, sizeof(decoder_info));
+    decoder_info.plugin_offset = 0;
+    decoder_info.name = "json";
+
+    return 0;
+}
+
+static int setup_event(void **state) {
+    tracking_reset();
+
+    Eventinfo * lf = calloc(1, sizeof(Eventinfo));
+    assert_non_null(lf);
+
+    lf->fields = calloc(Config.decoder_order_size, sizeof(DynamicField));
+    assert_non_null(lf->fields);
+    lf->decoder_info = &decoder_info;
+
+    *state = lf;
+
+    return 0;
+}
+
+static int teardown_event(void **state) {
+    Eventinfo * lf = *state;
+
+    if (lf != NULL) {
+        free_event(lf);
+        *state = NULL;
+    }
+
+    tracking_reset();
+
+    return 0;
+}
+
+/* Tests */
+
+static void test_fillData_duplicate_static_field_releases_previous(void **state) {
+    Eventinfo * lf = *state;
+
+    for (unsigned int i = 0; i < STATIC_FIELDS_COUNT; i++) {
+        char ** field = (char **) ((char *) lf + STATIC_FIELDS[i].offset);
+
+        fillData(lf, STATIC_FIELDS[i].key, "first");
+        assert_non_null(*field);
+        assert_string_equal(*field, "first");
+
+        char * previous = *field;
+        track(previous);
+
+        fillData(lf, STATIC_FIELDS[i].key, "second");
+
+        assert_true(released(previous));
+        assert_string_equal(*field, "second");
+    }
+
+    assert_int_equal(lf->nfields, 0);
+}
+
+static void test_fillData_duplicate_user_alias_releases_previous(void **state) {
+    Eventinfo * lf = *state;
+
+    fillData(lf, "user", "");
+    assert_non_null(lf->dstuser);
+    assert_string_equal(lf->dstuser, "");
+
+    char * previous = lf->dstuser;
+    track(previous);
+
+    fillData(lf, "user", "root");
+
+    assert_true(released(previous));
+    assert_string_equal(lf->dstuser, "root");
+    assert_int_equal(lf->nfields, 0);
+}
+
+static void test_JSON_Decoder_Exec_duplicate_static_fields_keeps_one_copy(void **state) {
+    Eventinfo * lf = *state;
+    static char event[] = "{\"id\":\"aaa\",\"id\":\"bbb\",\"id\":\"ccc\","
+                          "\"srcip\":\"1.1.1.1\",\"srcip\":\"2.2.2.2\"}";
+
+    lf->log = event;
+
+    tracking = 1;
+    JSON_Decoder_Exec(lf, NULL, NULL);
+    tracking = 0;
+
+    assert_string_equal(lf->id, "ccc");
+    assert_string_equal(lf->srcip, "2.2.2.2");
+    assert_int_equal(lf->nfields, 0);
+
+    /* One key and one value allocated per member */
+    assert_int_equal(tracked_count, 10);
+    /* Only the surviving id and srcip must still be held */
+    assert_int_equal(pending(), 2);
+}
+
+static void test_JSON_Decoder_Exec_unique_fields_keeps_every_value(void **state) {
+    Eventinfo * lf = *state;
+    static char event[] = "{\"id\":\"aaa\",\"srcip\":\"1.1.1.1\",\"custom\":\"value\"}";
+
+    lf->log = event;
+
+    tracking = 1;
+    JSON_Decoder_Exec(lf, NULL, NULL);
+    tracking = 0;
+
+    assert_string_equal(lf->id, "aaa");
+    assert_string_equal(lf->srcip, "1.1.1.1");
+    assert_int_equal(lf->nfields, 1);
+    assert_string_equal(lf->fields[0].key, "custom");
+    assert_string_equal(lf->fields[0].value, "value");
+
+    /* One key per member plus the values of id, srcip and the dynamic field, and its key */
+    assert_int_equal(tracked_count, 7);
+    /* id, srcip and the key and value of the dynamic field */
+    assert_int_equal(pending(), 4);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_fillData_duplicate_static_field_releases_previous, setup_event, teardown_event),
+        cmocka_unit_test_setup_teardown(test_fillData_duplicate_user_alias_releases_previous, setup_event, teardown_event),
+        cmocka_unit_test_setup_teardown(test_JSON_Decoder_Exec_duplicate_static_fields_keeps_one_copy, setup_event, teardown_event),
+        cmocka_unit_test_setup_teardown(test_JSON_Decoder_Exec_unique_fields_keeps_every_value, setup_event, teardown_event),
+    };
+
+    return cmocka_run_group_tests(tests, setup_group, NULL);
+}


### PR DESCRIPTION

## Description
The generic JSON decoder in `wazuh-analysisd` overwrote the pointer of a static event
field (`id`, `srcip`, `url`, ...) with a new copy of the value every time the field
appeared in the event, without releasing the copy it already held. Because the bundled
cJSON parser keeps duplicate object members and the decoder processes all of them, an
agent event that repeats a static field made `wazuh-analysisd` grow its memory usage on
every event until the process was terminated. The fix releases the previous value before
storing the new one, so only the last occurrence is retained and every earlier copy is
freed.

## Proposed Changes
- `src/analysisd/decoders/plugins/json_decoder.c`: `fillData()` now releases the current
  value of each static field before storing a new one. Covers `srcip`, `dstip`, `srcport`,
  `dstport`, `protocol`, `action`, `srcuser`, `id`, `status`, `url`, `data`, `extra_data`
  and `systemname`, plus the `user` alias when `dstuser` holds an empty string. The
  `dstuser` branch already released its previous value and is unchanged.
- `src/unit_tests/analysisd/test_json_decoder.c`: new unit test suite for the decoder.
- `src/unit_tests/analysisd/CMakeLists.txt`: registers the new `test_json_decoder` target.

### Results and Evidence
The new suite fails against the unpatched decoder and passes with the fix.

Before the fix:

```
[ RUN      ] test_fillData_duplicate_static_field_releases_previous
[  ERROR   ] --- released(previous)
[  FAILED  ] test_fillData_duplicate_static_field_releases_previous
[ RUN      ] test_fillData_duplicate_user_alias_releases_previous
[  ERROR   ] --- released(previous)
[  FAILED  ] test_fillData_duplicate_user_alias_releases_previous
[ RUN      ] test_JSON_Decoder_Exec_duplicate_static_fields_keeps_one_copy
[  ERROR   ] --- 0x5 != 0x2
[  FAILED  ] test_JSON_Decoder_Exec_duplicate_static_fields_keeps_one_copy
[ RUN      ] test_JSON_Decoder_Exec_unique_fields_keeps_every_value
[       OK ] test_JSON_Decoder_Exec_unique_fields_keeps_every_value
[  PASSED  ] 1 test(s).
[  FAILED  ] tests: 3 test(s)
```

The unit tests are built with AddressSanitizer, which reported the leaked copies on the
same run:

```
ERROR: LeakSanitizer: detected memory leaks

Direct leak of 8 byte(s) in 2 object(s) allocated from:
    #2 in fillData analysisd/decoders/plugins/json_decoder.c:145
    #3 in readJSON analysisd/decoders/plugins/json_decoder.c:251
    #5 in JSON_Decoder_Exec analysisd/decoders/plugins/json_decoder.c:418
```

After the fix:

```
Start 27: test_json_decoder
1/1 Test #27: test_json_decoder ................   Passed    0.01 sec

100% tests passed, 0 tests failed out of 1
```

The server also builds clean with `make TARGET=server DEBUG=1 TEST=1`.

### Artifacts Affected
`wazuh-analysisd` and `wazuh-logtest-legacy`, both shipped in the `wazuh-manager` package.

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
`src/unit_tests/analysisd/test_json_decoder.c`, target `test_json_decoder`:

- `test_fillData_duplicate_static_field_releases_previous`: every static field releases its
  previous value when the key is repeated.
- `test_fillData_duplicate_user_alias_releases_previous`: the `user` alias releases the
  empty `dstuser` value it replaces.
- `test_JSON_Decoder_Exec_duplicate_static_fields_keeps_one_copy`: decoding an event with
  repeated `id` and `srcip` members retains only one copy of each.
- `test_JSON_Decoder_Exec_unique_fields_keeps_every_value`: an event with unique members
  keeps its static and dynamic values, guarding against premature releases.

## Credits
Reported by @n01e0.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
