### PR TITLE
Stop serving the OpenAPI spec unauthenticated at /openapi.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 | [#35638](https://github.com/wazuh/wazuh/issues/35638) | Handled the stop signal during vulnerability feed download. |
 | [#37521](https://github.com/wazuh/wazuh/issues/37521) | Fixed `GET /cluster/{node_id}/daemons/stats` always returning error 1014 for `wazuh-manager-analysisd` due to a protocol mismatch between `WazuhSocketJSON` and the engine's HTTP API socket. |
 | [#38511](https://github.com/wazuh/wazuh/issues/38511) | Fixed world-writable permissions on bundled Python files after DEB installation, caused by the permission restoration script following symlinks. |
+| [#38547](https://github.com/wazuh/wazuh/issues/38547) | Fixed the API serving its OpenAPI specification and exact version at `/openapi.json` and `/openapi.yaml` without authentication. |
 
 ### Agent
 

--- a/api/scripts/wazuh_manager_apid.py
+++ b/api/scripts/wazuh_manager_apid.py
@@ -139,7 +139,9 @@ def start(params: dict):
     app = AsyncApp(
         __name__,
         specification_dir=os.path.join(api_path[0], 'spec'),
-        swagger_ui_options=SwaggerUIOptions(swagger_ui=False),
+        # serve_spec=False avoids exposing the API specification and version at
+        # /openapi.json and /openapi.yaml, which connexion serves unauthenticated by default
+        swagger_ui_options=SwaggerUIOptions(swagger_ui=False, serve_spec=False),
         pythonic_params=True,
         lifespan=lifespan_handler,
         uri_parser_class=APIUriParser


### PR DESCRIPTION
## Description

The API serves its full OpenAPI specification at `GET /openapi.json` (and `/openapi.yaml`) without authentication, disclosing the exact server version and the complete endpoint map to any unauthenticated client that can reach port 55000.

Connexion serves the raw spec by default (`SwaggerUIOptions.serve_spec=True`) and registers those routes outside the operations defined in `spec.yaml`, so they never go through the security handlers. We only disabled the Swagger UI, not the spec serving.

Closes #38547

## Proposed Changes

- Pass `serve_spec=False` to `SwaggerUIOptions` in `wazuh_manager_apid.py`, so connexion no longer registers the `/openapi.json` and `/openapi.yaml` routes. Both now return 404 like any other unknown path.
- Changelog entry under 5.0.0 / Manager / Fixed.

The spec remains available to legitimate users in the repository and in the published API reference documentation. No product component consumes this endpoint (checked wazuh/wazuh, qa-integration-framework and the rest of the organization).

### Results and Evidence

Before/after comparison mounting the real `spec.yaml` with `connexion==3.1.0` (the version pinned in `framework/requirements.txt`), requesting both routes with no credentials:

```
== BEFORE (5.0.0 current): SwaggerUIOptions(swagger_ui=False)
GET /openapi.json -> 200  (info.title='Wazuh API REST', info.version='5.0.0', paths=72)
GET /openapi.yaml -> 200

== AFTER  (fix): SwaggerUIOptions(swagger_ui=False, serve_spec=False)
GET /openapi.json -> 404
GET /openapi.yaml -> 404
```

The BEFORE output matches the report in #38547 exactly (title, version and 72 documented endpoints).

### Artifacts Affected

- `wazuh-manager` packages (API daemon script).

### Configuration Changes

None.

### Documentation Updates

None required; the endpoint was never documented.

### Tests Introduced

None. The change removes two routes registered internally by connexion; there is no existing unit test suite for `wazuh_manager_apid.py` app setup.

## Review Checklist
- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
