### PR TITLE
Probe the audisp plugin configuration instead of trusting the audit version

### DIFF
--- a/src/shared/include/error_messages/information_messages.h
+++ b/src/shared/include/error_messages/information_messages.h
@@ -70,6 +70,7 @@
 #define FIM_EBPF_LSM_ACTIVE                 "(6051): BPF LSM is active in the running kernel; using LSM hooks for create/modify/delete events."
 #define FIM_EBPF_LSM_INACTIVE               "(6052): BPF LSM is not active (not present in /sys/kernel/security/lsm); falling back to kprobe hooks. To enable LSM-based capture append 'bpf' to the kernel boot parameter 'lsm=' and reboot."
 #define FIM_EBPF_LSM_DPATH_FALLBACK         "(6053): BPF LSM load failed with the bpf_d_path-based variants; retrying with the manual path walker (some kernels, e.g. Amazon Linux 2/2023, disallow bpf_d_path for these hooks)."
+#define FIM_AUDIT_FALLBACK_CONFIGURATION    "(6054): The audisp plugin configuration expected for the installed audit version did not create the socket '%s'. Who-data started with an alternative plugin configuration."
 
 /* wazuh-logtest information messages */
 #define LOGTEST_INITIALIZED                 "(7200): Logtest started"

--- a/src/syscheckd/include/syscheck.h
+++ b/src/syscheckd/include/syscheck.h
@@ -530,11 +530,40 @@ void audit_create_rules_file();
 void audit_rules_to_realtime();
 
 /**
- * @brief Set Auditd socket configuration
+ * @brief Build the list of audisp plugin configurations to try, ordered by preference
  *
- * @return 0 on success, -1 on error
+ * @param plugin_dir [out] Directory holding the audisp plugin configuration files
+ * @param templates [out] Array to fill with the configuration templates, most preferred first
+ * @param max Size of the templates array
+ * @return Number of candidates written to templates, 0 if no known plugins directory was found
  */
-int set_auditd_config(void);
+int audisp_get_candidates(const char **plugin_dir, const char **templates, int max);
+
+/**
+ * @brief Move the configuration already on disk to the front of the candidate list
+ *
+ * @param plugin_dir Directory holding the audisp plugin configuration files
+ * @param templates Candidate list to reorder in place
+ * @param count Number of candidates in the list
+ */
+void audisp_prefer_configuration_on_disk(const char *plugin_dir, const char **templates, int count);
+
+/**
+ * @brief Configure the audisp plugin and connect to the who-data socket, probing the known
+ *        configurations until one of them yields a socket that can be connected to
+ *
+ * @return File descriptor of the connected socket, -1 on error
+ */
+int configure_and_connect_audit_socket(void);
+
+/**
+ * @brief Write the given audisp plugin configuration and restart Auditd if it changed
+ *
+ * @param plugin_dir Directory holding the audisp plugin configuration files
+ * @param audisp_config Configuration template to render
+ * @return 0 on success, -1 on error, 1 if Auditd could not be restarted
+ */
+int set_auditd_config_template(const char *plugin_dir, const char *audisp_config);
 
 /**
  * @brief Initialize Audit evsents socket

--- a/src/syscheckd/include/syscheck.h
+++ b/src/syscheckd/include/syscheck.h
@@ -540,13 +540,14 @@ void audit_rules_to_realtime();
 int audisp_get_candidates(const char **plugin_dir, const char **templates, int max);
 
 /**
- * @brief Move the configuration already on disk to the front of the candidate list
+ * @brief Whether the audisp plugin configuration on disk is one of the known templates
  *
  * @param plugin_dir Directory holding the audisp plugin configuration files
- * @param templates Candidate list to reorder in place
- * @param count Number of candidates in the list
+ * @param templates Known configuration templates
+ * @param count Number of templates
+ * @return 1 when the file on disk matches one of them, 0 otherwise
  */
-void audisp_prefer_configuration_on_disk(const char *plugin_dir, const char **templates, int count);
+int audisp_configuration_is_known(const char *plugin_dir, const char **templates, int count);
 
 /**
  * @brief Configure the audisp plugin and connect to the who-data socket, probing the known

--- a/src/syscheckd/include/syscheck.h
+++ b/src/syscheckd/include/syscheck.h
@@ -562,7 +562,9 @@ int configure_and_connect_audit_socket(void);
  *
  * @param plugin_dir Directory holding the audisp plugin configuration files
  * @param audisp_config Configuration template to render
- * @return 0 on success, -1 on error, 1 if Auditd could not be restarted
+ * @return 0 when the configuration is in place, 1 when it was written but Auditd was not
+ *         restarted because restart_audit is disabled, -1 on error (a failed Auditd restart
+ *         included)
  */
 int set_auditd_config_template(const char *plugin_dir, const char *audisp_config);
 

--- a/src/syscheckd/src/whodata/syscheck_audit.c
+++ b/src/syscheckd/src/whodata/syscheck_audit.c
@@ -25,6 +25,8 @@
 #define AUDIT_CONF_LINK             "af_wazuh.conf"
 #define BUF_SIZE OS_MAXSTR
 #define MAX_CONN_RETRIES 5          // Max retries to reconnect to Audit socket
+#define AUDIT_SOCKET_WAIT_MS 5000   // Max time to wait for the audisp plugin to create the socket
+#define AUDIT_SOCKET_POLL_MS 100    // Polling interval while waiting for the socket
 
 // Global variables
 pthread_mutex_t audit_mutex;
@@ -156,51 +158,156 @@ int configure_audisp(const char *audisp_path, const char *abs_path_socket, const
     }
 }
 
-// Set Auditd socket configuration
-int set_auditd_config(void) {
+/**
+ * @brief Build the list of audisp plugin configurations to try, ordered by preference.
+ *
+ * The installed audit version tells which configuration is the most likely to work, but it cannot
+ * tell a vendor rebuild that lacks the event format propagation apart from the upstream release it
+ * is based on: Amazon Linux 2023 ships an audit 3.1.5 whose audisp-af_unix still takes two
+ * arguments, so the three argument form rendered for that version makes the plugin fall back to
+ * its own default socket. The configurations that were not selected are appended as fallbacks so
+ * the caller can probe them when the preferred one does not yield a working socket.
+ *
+ * @param plugin_dir [out] Directory holding the audisp plugin configuration files.
+ * @param templates [out] Array to fill with the configuration templates, most preferred first.
+ * @param max Size of the templates array.
+ * @return Number of candidates written to templates, 0 if no known plugins directory was found.
+ */
+int audisp_get_candidates(const char **plugin_dir, const char **templates, int max) {
+    int count = 0;
+
+#define ADD_CANDIDATE(template) do { if (count < max) { templates[count++] = (template); } } while (0)
+
+    if (IsDir(PLUGINS_DIR_AUDIT) == 0) {
+        unsigned vcode;
+        *plugin_dir = PLUGINS_DIR_AUDIT;
+
+        if (get_audit_version_code(&vcode) != 0) {
+            mdebug2("Could not get audit version code. Using default configuration.");
+            ADD_CANDIDATE(AUDISP_CONFIGURATION_2);
+            ADD_CANDIDATE(AUDISP_CONFIGURATION_1);
+        } else {
+            mdebug2("Audit version detected: %u.%u.%u", (vcode >> 16) & 0xFF, (vcode >> 8) & 0xFF, vcode & 0xFF);
+
+            if (vcode < VERCODE(3, 1, 1)) {
+                // Before audit version 3.1.1 old code worked with builtin_af_unix. The event format
+                // argument only exists from 3.1.5 on, so it is not offered as a fallback here.
+                ADD_CANDIDATE(AUDISP_CONFIGURATION_0);
+                ADD_CANDIDATE(AUDISP_CONFIGURATION_1);
+            } else if (vcode < VERCODE(3, 1, 5)) {
+                // Audit version 3.1.1 includes changes for audispd af_unix plugin to a standalone program
+                ADD_CANDIDATE(AUDISP_CONFIGURATION_1);
+                ADD_CANDIDATE(AUDISP_CONFIGURATION_2);
+            } else if (vcode < VERCODE(4, 0, 0)) {
+                // Audit version 3.1.5 includes changes to propagate event format to the audisp-af_unix plugin
+                ADD_CANDIDATE(AUDISP_CONFIGURATION_2);
+                ADD_CANDIDATE(AUDISP_CONFIGURATION_1);
+            } else if (vcode < VERCODE(4, 0, 3)) {
+                // From audit version 4.0.0 to 4.0.2 format changes are not included
+                ADD_CANDIDATE(AUDISP_CONFIGURATION_1);
+                ADD_CANDIDATE(AUDISP_CONFIGURATION_2);
+            } else {
+                // From audit version 4.0.3 format changes are included
+                ADD_CANDIDATE(AUDISP_CONFIGURATION_2);
+                ADD_CANDIDATE(AUDISP_CONFIGURATION_1);
+            }
+        }
+    } else if (IsDir(PLUGINS_OLD_DIR_AUDISP) == 0) {
+        *plugin_dir = PLUGINS_OLD_DIR_AUDISP;
+        ADD_CANDIDATE(AUDISP_CONFIGURATION_0);
+    }
+
+#undef ADD_CANDIDATE
+
+    return count;
+}
+
+/**
+ * @brief Render an audisp plugin configuration and report whether it matches a given SHA1.
+ *
+ * @param audisp_config Configuration template to render.
+ * @param abs_path_socket Absolute path of the who-data socket, rendered into the template.
+ * @param sha1 Digest to compare the rendered configuration against.
+ * @return 1 when the rendered configuration matches, 0 otherwise.
+ */
+static int audisp_configuration_matches(const char *audisp_config, const char *abs_path_socket, const char *sha1) {
+    char *configuration = NULL;
+    os_sha1 configuration_sha1;
+    int configuration_length;
+    int matches;
+
+    configuration_length = snprintf(NULL, 0, audisp_config, abs_path_socket);
+    if (configuration_length <= 0) {
+        return 0; // LCOV_EXCL_LINE
+    }
+
+    os_calloc((size_t)configuration_length + 1, sizeof(char), configuration);
+    snprintf(configuration, (size_t)configuration_length + 1, audisp_config, abs_path_socket);
+    OS_SHA1_Str(configuration, configuration_length, configuration_sha1);
+    os_free(configuration);
+
+    matches = strcmp(sha1, configuration_sha1) == 0;
+
+    return matches;
+}
+
+/**
+ * @brief Move the configuration already on disk to the front of the candidate list.
+ *
+ * Whichever configuration a previous probe settled on is the one Auditd is currently running, so
+ * trying it first means no Auditd restart on subsequent agent starts. A file that matches none of
+ * the known templates -- tampered with, or written by an older agent -- is deliberately left
+ * behind the version order, so that the normal flow rewrites it.
+ *
+ * @param plugin_dir Directory holding the audisp plugin configuration files.
+ * @param templates Candidate list to reorder in place.
+ * @param count Number of candidates in the list.
+ */
+void audisp_prefer_configuration_on_disk(const char *plugin_dir, const char **templates, int count) {
+    char audisp_path[PATH_MAX] = {'\0'};
+    char abs_path_socket[PATH_MAX] = {'\0'};
+    os_sha1 file_sha1;
+    int i;
+
+    if (snprintf(audisp_path, sizeof(audisp_path), "%s/%s", plugin_dir, AUDIT_CONF_LINK) >= (int)sizeof(audisp_path)) {
+        return; // LCOV_EXCL_LINE
+    }
+
+    if (OS_SHA1_File(audisp_path, file_sha1, OS_TEXT) != 0) {
+        // No configuration in place yet: keep the order the audit version dictates
+        return;
+    }
+
+    abspath(AUDIT_SOCKET, abs_path_socket, PATH_MAX);
+
+    for (i = 0; i < count; i++) {
+        if (audisp_configuration_matches(templates[i], abs_path_socket, file_sha1) == 0) {
+            continue;
+        }
+
+        if (i > 0) {
+            const char *in_place = templates[i];
+
+            for (; i > 0; i--) {
+                templates[i] = templates[i - 1];
+            }
+
+            templates[0] = in_place;
+            mdebug1("The audisp plugin configuration already in place will be tried first.");
+        }
+
+        return;
+    }
+}
+
+// Write the given audisp plugin configuration and restart Auditd if it changed
+int set_auditd_config_template(const char *plugin_dir, const char *audisp_config) {
     char audisp_path[PATH_MAX] = {'\0'};
     char abs_path_socket[PATH_MAX] = {'\0'};
     char *configuration = NULL;
     int configuration_length;
     int retval = 1;
     os_sha1 file_sha1, configuration_sha1;
-    const char *plugin_dir = NULL;
-    const char *audisp_config = NULL;
-
-    if (IsDir(PLUGINS_DIR_AUDIT) == 0) {
-        unsigned vcode;
-        plugin_dir = PLUGINS_DIR_AUDIT;
-
-        if (get_audit_version_code(&vcode) != 0) {
-            mdebug2("Could not get audit version code. Using default configuration.");
-            audisp_config = AUDISP_CONFIGURATION_2;
-        } else {
-            mdebug2("Audit version detected: %u.%u.%u", (vcode >> 16) & 0xFF, (vcode >> 8) & 0xFF, vcode & 0xFF);
-
-            if (vcode < VERCODE(3, 1, 1)) {
-                // Before audit version 3.1.1 old code worked with builtin_af_unix
-                audisp_config = AUDISP_CONFIGURATION_0;
-            } else if (vcode < VERCODE(3, 1, 5)) {
-                // Audit version 3.1.1 includes changes for audispd af_unix plugin to a standalone program
-                audisp_config = AUDISP_CONFIGURATION_1;
-            } else if (vcode < VERCODE(4, 0, 0)) {
-                // Audit version 3.1.5 includes changes to propagate event format to the audisp-af_unix plugin
-                audisp_config = AUDISP_CONFIGURATION_2;
-            } else if (vcode < VERCODE(4, 0, 3)) {
-                // From audit version 4.0.0 to 4.0.2 format changes are not included
-                audisp_config = AUDISP_CONFIGURATION_1;
-            } else {
-                // From audit version 4.0.3 format changes are included
-                audisp_config = AUDISP_CONFIGURATION_2;
-            }
-        }
-    } else if (IsDir(PLUGINS_OLD_DIR_AUDISP) == 0) {
-        plugin_dir = PLUGINS_OLD_DIR_AUDISP;
-        audisp_config = AUDISP_CONFIGURATION_0;
-    } else {
-        // No known plugins directory found
-        return 0;
-    }
 
     // Build the config file path safely
     if (snprintf(audisp_path, sizeof(audisp_path), "%s/%s", plugin_dir, AUDIT_CONF_LINK) >= (int)sizeof(audisp_path)) {
@@ -254,17 +361,23 @@ end:
     return retval;
 }
 
-
-// Init Audit events socket
-int init_auditd_socket(void) {
+// Connect to the Audit events socket
+static int audit_socket_connect(int quiet) {
     int sfd;
 
     if (sfd = OS_ConnectUnixDomain(AUDIT_SOCKET, SOCK_STREAM, OS_MAXSTR), sfd < 0) {
-        merror(FIM_ERROR_WHODATA_SOCKET_CONNECT, AUDIT_SOCKET);
+        if (!quiet) {
+            merror(FIM_ERROR_WHODATA_SOCKET_CONNECT, AUDIT_SOCKET);
+        }
         return (-1);
     }
 
     return sfd;
+}
+
+// Init Audit events socket
+int init_auditd_socket(void) {
+    return audit_socket_connect(0);
 }
 
 void audit_create_rules_file() {
@@ -389,6 +502,102 @@ void audit_rules_to_realtime() {
     }
 }
 
+/**
+ * @brief Wait for the audisp plugin to create the who-data socket.
+ *
+ * configure_audisp() removes the socket before rewriting the plugin configuration, so its
+ * reappearance is what tells that Auditd came back with a plugin that honoured the configured
+ * path. A misconfigured plugin binds its own default path instead and the socket never shows up.
+ *
+ * @return 0 if the socket is present, -1 if it did not appear before the timeout.
+ */
+static int wait_for_audit_socket(void) {
+    int waited_ms;
+
+    for (waited_ms = 0; waited_ms < AUDIT_SOCKET_WAIT_MS; waited_ms += AUDIT_SOCKET_POLL_MS) {
+        if (IsSocket(AUDIT_SOCKET) == 0) {
+            return 0;
+        }
+
+        usleep(AUDIT_SOCKET_POLL_MS * 1000);
+    }
+
+    return -1;
+}
+
+/**
+ * @brief Configure the audisp plugin and connect to the who-data socket.
+ *
+ * The configuration expected for the installed audit version is applied first. If it does not
+ * yield a socket that can be connected to, the remaining known configurations are probed, since
+ * the audit version alone cannot tell whether the installed audisp-af_unix understands the event
+ * format argument.
+ *
+ * @return The connected socket descriptor, or -1 if no configuration worked.
+ */
+int configure_and_connect_audit_socket(void) {
+    const char *templates[MAX_AUDISP_CANDIDATES] = {NULL};
+    const char *plugin_dir = NULL;
+    int count;
+    int sfd;
+    int i;
+
+    count = audisp_get_candidates(&plugin_dir, templates, MAX_AUDISP_CANDIDATES);
+
+    if (count == 0) {
+        // No known plugins directory found, so there is nothing to configure
+        return init_auditd_socket();
+    }
+
+    // A socket left behind by a dead plugin would make the probe believe a candidate took effect,
+    // so it is removed before configuring anything.
+    if (IsSocket(AUDIT_SOCKET) == 0) {
+        if (sfd = audit_socket_connect(1), sfd >= 0) {
+            close(sfd);
+        } else if (unlink(AUDIT_SOCKET) < 0 && errno != ENOENT) {
+            merror(UNLINK_ERROR, AUDIT_SOCKET, errno, strerror(errno)); // LCOV_EXCL_LINE
+        }
+    }
+
+    // Trying whatever is already in place first keeps Auditd untouched when it is already serving
+    // the socket, while a configuration that matches no known template is rewritten below.
+    audisp_prefer_configuration_on_disk(plugin_dir, templates, count);
+
+    for (i = 0; i < count; i++) {
+        if (i > 0) {
+            mdebug1("Could not establish the who-data socket '%s' with the current audisp plugin "
+                    "configuration. Trying an alternative one.", AUDIT_SOCKET);
+        }
+
+        switch (set_auditd_config_template(plugin_dir, templates[i])) {
+        case -1:
+            // This candidate could not be written or Auditd failed to restart with it. The next
+            // one may still work, which is the whole point of probing.
+            mdebug1(FIM_AUDIT_NOCONF);
+            continue;
+        case 0:
+            break;
+        default:
+            // Auditd cannot be restarted, so no configuration can be probed
+            return -1;
+        }
+
+        if (wait_for_audit_socket() != 0) {
+            continue;
+        }
+
+        if (sfd = audit_socket_connect(1), sfd >= 0) {
+            if (i > 0) {
+                minfo(FIM_AUDIT_FALLBACK_CONFIGURATION, AUDIT_SOCKET);
+            }
+            return sfd;
+        }
+    }
+
+    merror(FIM_ERROR_WHODATA_SOCKET_CONNECT, AUDIT_SOCKET);
+    return -1;
+}
+
 // LCOV_EXCL_START
 int audit_init(void) {
     static audit_data_t audit_data = { .socket = -1, .mode = AUDIT_DISABLED };
@@ -403,19 +612,8 @@ int audit_init(void) {
         return (-1);
     }
 
-    // Check audit socket configuration
-    switch (set_auditd_config()) {
-    case -1:
-        mdebug1(FIM_AUDIT_NOCONF);
-        return (-1);
-    case 0:
-        break;
-    default:
-        return (-1);
-    }
-
-    // Initialize Audit socket
-    audit_data.socket = init_auditd_socket();
+    // Check audit socket configuration and initialize the Audit socket
+    audit_data.socket = configure_and_connect_audit_socket();
     if (audit_data.socket < 0) {
         merror("Can't init auditd socket in 'init_auditd_socket()'");
         return -1;

--- a/src/syscheckd/src/whodata/syscheck_audit.c
+++ b/src/syscheckd/src/whodata/syscheck_audit.c
@@ -25,9 +25,6 @@
 #define AUDIT_CONF_LINK             "af_wazuh.conf"
 #define BUF_SIZE OS_MAXSTR
 #define MAX_CONN_RETRIES 5          // Max retries to reconnect to Audit socket
-#define AUDIT_SOCKET_WAIT_MS 5000   // Max time to wait for the audisp plugin to create the socket
-#define AUDIT_SOCKET_POLL_MS 100    // Polling interval while waiting for the socket
-#define AUDIT_SOCKET_CONNECT_RETRIES 3  // Connection attempts before deeming the socket stale
 
 // Global variables
 pthread_mutex_t audit_mutex;
@@ -608,8 +605,10 @@ int configure_and_connect_audit_socket(void) {
         case 0:
             previous_applied = 1;
             break;
+        case 1:
         default:
-            // Auditd cannot be restarted, so no configuration can be probed
+            // The configuration was written but Auditd was not restarted, because restart_audit is
+            // disabled, so no candidate can be probed.
             return -1;
         }
 

--- a/src/syscheckd/src/whodata/syscheck_audit.c
+++ b/src/syscheckd/src/whodata/syscheck_audit.c
@@ -27,6 +27,7 @@
 #define MAX_CONN_RETRIES 5          // Max retries to reconnect to Audit socket
 #define AUDIT_SOCKET_WAIT_MS 5000   // Max time to wait for the audisp plugin to create the socket
 #define AUDIT_SOCKET_POLL_MS 100    // Polling interval while waiting for the socket
+#define AUDIT_SOCKET_CONNECT_RETRIES 3  // Connection attempts before deeming the socket stale
 
 // Global variables
 pthread_mutex_t audit_mutex;
@@ -190,10 +191,10 @@ int audisp_get_candidates(const char **plugin_dir, const char **templates, int m
             mdebug2("Audit version detected: %u.%u.%u", (vcode >> 16) & 0xFF, (vcode >> 8) & 0xFF, vcode & 0xFF);
 
             if (vcode < VERCODE(3, 1, 1)) {
-                // Before audit version 3.1.1 old code worked with builtin_af_unix. The event format
-                // argument only exists from 3.1.5 on, so it is not offered as a fallback here.
+                // Before audit version 3.1.1 af_unix is builtin into Auditd and /sbin/audisp-af_unix
+                // does not exist, so the standalone configurations are not offered as fallbacks:
+                // probing them would only cost a useless Auditd restart.
                 ADD_CANDIDATE(AUDISP_CONFIGURATION_0);
-                ADD_CANDIDATE(AUDISP_CONFIGURATION_1);
             } else if (vcode < VERCODE(3, 1, 5)) {
                 // Audit version 3.1.1 includes changes for audispd af_unix plugin to a standalone program
                 ADD_CANDIDATE(AUDISP_CONFIGURATION_1);
@@ -252,52 +253,40 @@ static int audisp_configuration_matches(const char *audisp_config, const char *a
 }
 
 /**
- * @brief Move the configuration already on disk to the front of the candidate list.
+ * @brief Whether the audisp plugin configuration on disk is one of the known templates.
  *
- * Whichever configuration a previous probe settled on is the one Auditd is currently running, so
- * trying it first means no Auditd restart on subsequent agent starts. A file that matches none of
- * the known templates -- tampered with, or written by an older agent -- is deliberately left
- * behind the version order, so that the normal flow rewrites it.
+ * Used to decide if a socket that is already up can be trusted: Auditd serving a socket with a
+ * configuration this agent could have written is a working setup and must not be disturbed, while
+ * a file that matches nothing -- tampered with, or written by an older agent -- has to be rewritten.
  *
  * @param plugin_dir Directory holding the audisp plugin configuration files.
- * @param templates Candidate list to reorder in place.
- * @param count Number of candidates in the list.
+ * @param templates Known configuration templates.
+ * @param count Number of templates.
+ * @return 1 when the file on disk matches one of them, 0 otherwise.
  */
-void audisp_prefer_configuration_on_disk(const char *plugin_dir, const char **templates, int count) {
+int audisp_configuration_is_known(const char *plugin_dir, const char **templates, int count) {
     char audisp_path[PATH_MAX] = {'\0'};
     char abs_path_socket[PATH_MAX] = {'\0'};
     os_sha1 file_sha1;
     int i;
 
     if (snprintf(audisp_path, sizeof(audisp_path), "%s/%s", plugin_dir, AUDIT_CONF_LINK) >= (int)sizeof(audisp_path)) {
-        return; // LCOV_EXCL_LINE
+        return 0; // LCOV_EXCL_LINE
     }
 
     if (OS_SHA1_File(audisp_path, file_sha1, OS_TEXT) != 0) {
-        // No configuration in place yet: keep the order the audit version dictates
-        return;
+        return 0;
     }
 
     abspath(AUDIT_SOCKET, abs_path_socket, PATH_MAX);
 
     for (i = 0; i < count; i++) {
-        if (audisp_configuration_matches(templates[i], abs_path_socket, file_sha1) == 0) {
-            continue;
+        if (audisp_configuration_matches(templates[i], abs_path_socket, file_sha1)) {
+            return 1;
         }
-
-        if (i > 0) {
-            const char *in_place = templates[i];
-
-            for (; i > 0; i--) {
-                templates[i] = templates[i - 1];
-            }
-
-            templates[0] = in_place;
-            mdebug1("The audisp plugin configuration already in place will be tried first.");
-        }
-
-        return;
     }
+
+    return 0;
 }
 
 // Write the given audisp plugin configuration and restart Auditd if it changed
@@ -503,6 +492,32 @@ void audit_rules_to_realtime() {
 }
 
 /**
+ * @brief Connect to the who-data socket, retrying a few times before giving up.
+ *
+ * A socket that refuses connections is usually one left behind by a plugin that is no longer
+ * running, but a transient failure -- no file descriptors left, a saturated backlog -- looks the
+ * same from here, and the caller unlinks the socket on failure. A single refusal is not enough.
+ *
+ * @return The connected socket descriptor, or -1 if every attempt failed.
+ */
+static int audit_socket_connect_retry(void) {
+    int attempt;
+    int sfd;
+
+    for (attempt = 0; attempt < AUDIT_SOCKET_CONNECT_RETRIES; attempt++) {
+        if (sfd = audit_socket_connect(1), sfd >= 0) {
+            return sfd;
+        }
+
+        if (attempt + 1 < AUDIT_SOCKET_CONNECT_RETRIES) {
+            usleep(AUDIT_SOCKET_POLL_MS * 1000);
+        }
+    }
+
+    return -1;
+}
+
+/**
  * @brief Wait for the audisp plugin to create the who-data socket.
  *
  * configure_audisp() removes the socket before rewriting the plugin configuration, so its
@@ -549,19 +564,22 @@ int configure_and_connect_audit_socket(void) {
         return init_auditd_socket();
     }
 
-    // A socket left behind by a dead plugin would make the probe believe a candidate took effect,
-    // so it is removed before configuring anything.
     if (IsSocket(AUDIT_SOCKET) == 0) {
-        if (sfd = audit_socket_connect(1), sfd >= 0) {
+        if (sfd = audit_socket_connect_retry(), sfd >= 0) {
+            // Auditd is already serving the socket. A configuration this agent could have written
+            // is a working setup, and restarting Auditd to rewrite it would be gratuitous.
+            if (audisp_configuration_is_known(plugin_dir, templates, count)) {
+                return sfd;
+            }
+
             close(sfd);
+            mdebug1("The audisp plugin configuration in place is not one of the known ones. Rewriting it.");
         } else if (unlink(AUDIT_SOCKET) < 0 && errno != ENOENT) {
+            // Nothing is listening: the socket was left behind by a plugin that is gone, and it
+            // would otherwise make a candidate look like it took effect.
             merror(UNLINK_ERROR, AUDIT_SOCKET, errno, strerror(errno)); // LCOV_EXCL_LINE
         }
     }
-
-    // Trying whatever is already in place first keeps Auditd untouched when it is already serving
-    // the socket, while a configuration that matches no known template is rewritten below.
-    audisp_prefer_configuration_on_disk(plugin_dir, templates, count);
 
     for (i = 0; i < count; i++) {
         if (i > 0) {

--- a/src/syscheckd/src/whodata/syscheck_audit.c
+++ b/src/syscheckd/src/whodata/syscheck_audit.c
@@ -556,6 +556,7 @@ int configure_and_connect_audit_socket(void) {
     int count;
     int sfd;
     int i;
+    int previous_applied = 0;
 
     count = audisp_get_candidates(&plugin_dir, templates, MAX_AUDISP_CANDIDATES);
 
@@ -574,18 +575,29 @@ int configure_and_connect_audit_socket(void) {
 
             close(sfd);
             mdebug1("The audisp plugin configuration in place is not one of the known ones. Rewriting it.");
-        } else if (unlink(AUDIT_SOCKET) < 0 && errno != ENOENT) {
+        } else if (syscheck.restart_audit) {
             // Nothing is listening: the socket was left behind by a plugin that is gone, and it
-            // would otherwise make a candidate look like it took effect.
-            merror(UNLINK_ERROR, AUDIT_SOCKET, errno, strerror(errno)); // LCOV_EXCL_LINE
+            // would otherwise make a candidate look like it took effect. It is only removed when
+            // Auditd can be restarted to recreate it, so that a connection failure this agent
+            // cannot recover from does not leave who-data permanently without a socket.
+            if (unlink(AUDIT_SOCKET) < 0 && errno != ENOENT) {
+                merror(UNLINK_ERROR, AUDIT_SOCKET, errno, strerror(errno)); // LCOV_EXCL_LINE
+            }
         }
     }
 
     for (i = 0; i < count; i++) {
         if (i > 0) {
-            mdebug1("Could not establish the who-data socket '%s' with the current audisp plugin "
-                    "configuration. Trying an alternative one.", AUDIT_SOCKET);
+            if (previous_applied) {
+                mdebug1("Could not establish the who-data socket '%s' with the current audisp plugin "
+                        "configuration. Trying an alternative one.", AUDIT_SOCKET);
+            } else {
+                mdebug1("The current audisp plugin configuration could not be applied. Trying an "
+                        "alternative one.");
+            }
         }
+
+        previous_applied = 0;
 
         switch (set_auditd_config_template(plugin_dir, templates[i])) {
         case -1:
@@ -594,6 +606,7 @@ int configure_and_connect_audit_socket(void) {
             mdebug1(FIM_AUDIT_NOCONF);
             continue;
         case 0:
+            previous_applied = 1;
             break;
         default:
             // Auditd cannot be restarted, so no configuration can be probed
@@ -604,7 +617,9 @@ int configure_and_connect_audit_socket(void) {
             continue;
         }
 
-        if (sfd = audit_socket_connect(1), sfd >= 0) {
+        // Retried for the same reason the stale socket check is: one refusal may be transient,
+        // and discarding a working candidate here would settle on the wrong configuration.
+        if (sfd = audit_socket_connect_retry(), sfd >= 0) {
             if (i > 0) {
                 minfo(FIM_AUDIT_FALLBACK_CONFIGURATION, AUDIT_SOCKET);
             }

--- a/src/syscheckd/src/whodata/syscheck_audit.h
+++ b/src/syscheckd/src/whodata/syscheck_audit.h
@@ -21,6 +21,12 @@
 // candidate costs an Auditd restart when it has to be probed, so the list is deliberately short.
 #define MAX_AUDISP_CANDIDATES 2
 
+// Max time to wait for the audisp plugin to create the who-data socket, and how often to look
+#define AUDIT_SOCKET_WAIT_MS 5000
+#define AUDIT_SOCKET_POLL_MS 100
+// Connection attempts before deeming the socket stale
+#define AUDIT_SOCKET_CONNECT_RETRIES 3
+
 #define VERCODE(M,m,p)  ((((unsigned)(M) & 0xFF) << 16) | (((unsigned)(m) & 0xFF) << 8) | ((unsigned)(p) & 0xFF))
 #define AUDIT_HEALTHCHECK_KEY "wazuh_hc"
 #define AUDIT_KEY "wazuh_fim"

--- a/src/syscheckd/src/whodata/syscheck_audit.h
+++ b/src/syscheckd/src/whodata/syscheck_audit.h
@@ -17,6 +17,10 @@
 #include "audit_op.h"
 
 #define WHODATA_PERMS (AUDIT_PERM_WRITE | AUDIT_PERM_ATTR)
+// Max number of audisp plugin configurations that audisp_get_candidates() may return. Each extra
+// candidate costs an Auditd restart when it has to be probed, so the list is deliberately short.
+#define MAX_AUDISP_CANDIDATES 2
+
 #define VERCODE(M,m,p)  ((((unsigned)(M) & 0xFF) << 16) | (((unsigned)(m) & 0xFF) << 8) | ((unsigned)(p) & 0xFF))
 #define AUDIT_HEALTHCHECK_KEY "wazuh_hc"
 #define AUDIT_KEY "wazuh_fim"

--- a/src/unit_tests/syscheckd/whodata/CMakeLists.txt
+++ b/src/unit_tests/syscheckd/whodata/CMakeLists.txt
@@ -81,7 +81,7 @@ if(NOT ${TARGET} STREQUAL "winagent")
                               -Wl,--wrap,IsLink -Wl,--wrap,IsFile -Wl,--wrap,IsSocket -Wl,--wrap,fprintf -Wl,--wrap,wfopen \
                               -Wl,--wrap,fopen -Wl,--wrap,fclose -Wl,--wrap,fflush -Wl,--wrap,fgets -Wl,--wrap,fgetpos \
                               -Wl,--wrap,fread -Wl,--wrap,fseek -Wl,--wrap,fwrite -Wl,--wrap,remove -Wl,--wrap,fgetc \
-                              -Wl,--wrap,getpid -Wl,--wrap,sleep -Wl,--wrap,unlink -Wl,--wrap,audit_delete_rule \
+                              -Wl,--wrap,getpid -Wl,--wrap,sleep -Wl,--wrap,usleep -Wl,--wrap,unlink -Wl,--wrap,audit_delete_rule \
                               -Wl,--wrap,select -Wl,--wrap,audit_parse -Wl,--wrap,symlink -Wl,--wrap,SendMSG \
                               -Wl,--wrap,audit_get_rule_list -Wl,--wrap,fim_audit_reload_rules -Wl,--wrap,OS_MoveFile \
                               -Wl,--wrap,search_audit_rule -Wl,--wrap,abspath -Wl,--wrap,atomic_int_get \

--- a/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
+++ b/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
@@ -39,6 +39,8 @@ extern w_queue_t * audit_queue;
 
 #define AUDIT_RULES_FILE            "etc/audit_rules_wazuh.rules"
 #define AUDIT_RULES_LINK            "/etc/audit/rules.d/audit_rules_wazuh.rules"
+#define PLUGINS_OLD_DIR_AUDISP      "/etc/audisp/plugins.d"
+#define PLUGINS_DIR_AUDIT           "/etc/audit/plugins.d"
 
 int hc_success = 0;
 
@@ -336,17 +338,486 @@ void test_init_auditd_socket_failure(void **state) {
 }
 
 
-void test_set_auditd_config_audit3_plugin_created(void **state) {
-    // Audit 3
+/* Copies of the audisp plugin configuration templates defined in syscheck_audit.c, so the tests can
+   pass a concrete one to set_auditd_config_template(). */
+#define AUDISP_CONFIGURATION_0_TPL "active = yes\ndirection = out\npath = builtin_af_unix\n" \
+                                   "type = builtin\nargs = 0640 %s\nformat = string\n"
+#define AUDISP_CONFIGURATION_1_TPL "active = yes\ndirection = out\npath = /sbin/audisp-af_unix\n" \
+                                   "type = always\nargs = 0640 %s\nformat = string\n"
+#define AUDISP_CONFIGURATION_2_TPL "active = yes\ndirection = out\npath = /sbin/audisp-af_unix\n" \
+                                   "type = always\nargs = 0640 %s string\nformat = binary\n"
+
+
+static void expect_audit_version(const char *version_output, const char *debug_msg) {
+    FILE *fp = tmpfile_with_content(version_output);
+
+    expect_popen("auditctl -v 2>/dev/null", "r", fp);
+    expect_string(__wrap__mdebug2, formatted_msg, debug_msg);
+}
+
+static void expect_audit_plugins_dir(void) {
     expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
     will_return(__wrap_IsDir, 0);
+}
 
-    // get_audit_version_code
-    const char *payload = "auditctl version 3.1.0\n";
-    FILE * fp = tmpfile_with_content(payload);
-    expect_popen("auditctl -v 2>/dev/null", "r", fp);
-    expect_string(__wrap__mdebug2, formatted_msg, "Audit version detected: 3.1.0");
+void test_audisp_get_candidates_audit_3_1_5_prefers_format_propagation(void **state) {
+    const char *templates[MAX_AUDISP_CANDIDATES] = {NULL};
+    const char *plugin_dir = NULL;
+    int count;
 
+    expect_audit_plugins_dir();
+    expect_audit_version("auditctl version 3.1.5\n", "Audit version detected: 3.1.5");
+
+    count = audisp_get_candidates(&plugin_dir, templates, MAX_AUDISP_CANDIDATES);
+
+    assert_int_equal(count, 2);
+    assert_string_equal(plugin_dir, "/etc/audit/plugins.d");
+    assert_string_equal(templates[0], AUDISP_CONFIGURATION_2_TPL);
+    // Vendor rebuilds of 3.1.5 without the format propagation need the two argument form
+    assert_string_equal(templates[1], AUDISP_CONFIGURATION_1_TPL);
+}
+
+void test_audisp_get_candidates_audit_3_1_2_prefers_two_arguments(void **state) {
+    const char *templates[MAX_AUDISP_CANDIDATES] = {NULL};
+    const char *plugin_dir = NULL;
+    int count;
+
+    expect_audit_plugins_dir();
+    expect_audit_version("auditctl version 3.1.2\n", "Audit version detected: 3.1.2");
+
+    count = audisp_get_candidates(&plugin_dir, templates, MAX_AUDISP_CANDIDATES);
+
+    assert_int_equal(count, 2);
+    assert_string_equal(templates[0], AUDISP_CONFIGURATION_1_TPL);
+    assert_string_equal(templates[1], AUDISP_CONFIGURATION_2_TPL);
+}
+
+void test_audisp_get_candidates_audit_3_0_6_prefers_builtin(void **state) {
+    const char *templates[MAX_AUDISP_CANDIDATES] = {NULL};
+    const char *plugin_dir = NULL;
+    int count;
+
+    expect_audit_plugins_dir();
+    expect_audit_version("auditctl version 3.0.6\n", "Audit version detected: 3.0.6");
+
+    count = audisp_get_candidates(&plugin_dir, templates, MAX_AUDISP_CANDIDATES);
+
+    // The event format argument only exists from 3.1.5 on, so it is not offered here
+    assert_int_equal(count, 2);
+    assert_string_equal(templates[0], AUDISP_CONFIGURATION_0_TPL);
+    assert_string_equal(templates[1], AUDISP_CONFIGURATION_1_TPL);
+}
+
+void test_audisp_get_candidates_audit_4_0_0_prefers_two_arguments(void **state) {
+    const char *templates[MAX_AUDISP_CANDIDATES] = {NULL};
+    const char *plugin_dir = NULL;
+    int count;
+
+    expect_audit_plugins_dir();
+    expect_audit_version("auditctl version 4.0.0\n", "Audit version detected: 4.0.0");
+
+    count = audisp_get_candidates(&plugin_dir, templates, MAX_AUDISP_CANDIDATES);
+
+    assert_int_equal(count, 2);
+    assert_string_equal(templates[0], AUDISP_CONFIGURATION_1_TPL);
+    assert_string_equal(templates[1], AUDISP_CONFIGURATION_2_TPL);
+}
+
+void test_audisp_get_candidates_audit_4_0_3_prefers_format_propagation(void **state) {
+    const char *templates[MAX_AUDISP_CANDIDATES] = {NULL};
+    const char *plugin_dir = NULL;
+    int count;
+
+    expect_audit_plugins_dir();
+    expect_audit_version("auditctl version 4.0.3\n", "Audit version detected: 4.0.3");
+
+    count = audisp_get_candidates(&plugin_dir, templates, MAX_AUDISP_CANDIDATES);
+
+    assert_int_equal(count, 2);
+    assert_string_equal(templates[0], AUDISP_CONFIGURATION_2_TPL);
+    assert_string_equal(templates[1], AUDISP_CONFIGURATION_1_TPL);
+}
+
+void test_audisp_get_candidates_unknown_version(void **state) {
+    const char *templates[MAX_AUDISP_CANDIDATES] = {NULL};
+    const char *plugin_dir = NULL;
+    int count;
+
+    expect_audit_plugins_dir();
+    expect_popen("auditctl -v 2>/dev/null", "r", NULL);
+    expect_string(__wrap__mdebug2, formatted_msg, "Could not get audit version code. Using default configuration.");
+
+    count = audisp_get_candidates(&plugin_dir, templates, MAX_AUDISP_CANDIDATES);
+
+    assert_int_equal(count, 2);
+    assert_string_equal(templates[0], AUDISP_CONFIGURATION_2_TPL);
+    assert_string_equal(templates[1], AUDISP_CONFIGURATION_1_TPL);
+}
+
+void test_audisp_get_candidates_audit2_dir(void **state) {
+    const char *templates[MAX_AUDISP_CANDIDATES] = {NULL};
+    const char *plugin_dir = NULL;
+    int count;
+
+    // Not Audit 3
+    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
+    will_return(__wrap_IsDir, 1);
+    // Audit 2
+    expect_string(__wrap_IsDir, file, "/etc/audisp/plugins.d");
+    will_return(__wrap_IsDir, 0);
+
+    count = audisp_get_candidates(&plugin_dir, templates, MAX_AUDISP_CANDIDATES);
+
+    assert_int_equal(count, 1);
+    assert_string_equal(plugin_dir, "/etc/audisp/plugins.d");
+    assert_string_equal(templates[0], AUDISP_CONFIGURATION_0_TPL);
+}
+
+void test_audisp_get_candidates_no_plugins_dir(void **state) {
+    const char *templates[MAX_AUDISP_CANDIDATES] = {NULL};
+    const char *plugin_dir = NULL;
+    int count;
+
+    // Not Audit 3
+    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
+    will_return(__wrap_IsDir, 1);
+    // Not Audit 2
+    expect_string(__wrap_IsDir, file, "/etc/audisp/plugins.d");
+    will_return(__wrap_IsDir, 1);
+
+    count = audisp_get_candidates(&plugin_dir, templates, MAX_AUDISP_CANDIDATES);
+
+    assert_int_equal(count, 0);
+    assert_null(plugin_dir);
+}
+
+void test_audisp_get_candidates_honours_max(void **state) {
+    const char *templates[MAX_AUDISP_CANDIDATES] = {NULL};
+    const char *plugin_dir = NULL;
+    int count;
+
+    expect_audit_plugins_dir();
+    expect_audit_version("auditctl version 3.0.6\n", "Audit version detected: 3.0.6");
+
+    // The version would yield three candidates, but only one fits
+    count = audisp_get_candidates(&plugin_dir, templates, 1);
+
+    assert_int_equal(count, 1);
+    assert_string_equal(templates[0], AUDISP_CONFIGURATION_0_TPL);
+    assert_null(templates[1]);
+}
+
+/* Helpers for the probe tests: the mock queues below mirror what configure_and_connect_audit_socket()
+   walks through for each candidate it tries. */
+
+static void expect_audit_socket_connect(int ret) {
+    expect_any(__wrap_OS_ConnectUnixDomain, path);
+    expect_any(__wrap_OS_ConnectUnixDomain, type);
+    expect_any(__wrap_OS_ConnectUnixDomain, max_msg_size);
+    will_return(__wrap_OS_ConnectUnixDomain, ret);
+}
+
+/* wait_for_audit_socket() polls IsSocket() every 100 ms for 5 s, so a timeout is 50 misses. The
+   calls to usleep() in between are ignored: how often it polls is an implementation detail. */
+#define AUDIT_SOCKET_POLL_ATTEMPTS 50
+
+static void expect_wait_for_audit_socket(int found) {
+    int i;
+
+    if (found) {
+        expect_string(__wrap_IsSocket, sock, AUDIT_SOCKET);
+        will_return(__wrap_IsSocket, 0);
+        return;
+    }
+
+    for (i = 0; i < AUDIT_SOCKET_POLL_ATTEMPTS; i++) {
+        expect_string(__wrap_IsSocket, sock, AUDIT_SOCKET);
+        will_return(__wrap_IsSocket, 1);
+    }
+
+}
+
+/* A candidate that is not on disk yet: it gets written and Auditd restarted. */
+static void expect_candidate_written(int restart_ret) {
+    const char *audisp_path = "/etc/audit/plugins.d/af_wazuh.conf";
+
+    expect_abspath(AUDIT_SOCKET, 1);
+
+    expect_any(__wrap_OS_SHA1_Str, str);
+    expect_any(__wrap_OS_SHA1_Str, length);
+    will_return(__wrap_OS_SHA1_Str, "6e3a100fc85241f04ed9686d37738e7d08086fb4");
+
+    expect_string(__wrap_OS_SHA1_File, fname, audisp_path);
+    expect_value(__wrap_OS_SHA1_File, mode, OS_TEXT);
+    will_return(__wrap_OS_SHA1_File, "0000000000000000000000000000000000000000");
+    will_return(__wrap_OS_SHA1_File, -1);
+
+    expect_string(__wrap__minfo, formatted_msg,
+                  "(6024): Generating Auditd socket configuration file: 'tmp/af_wazuh.conf'");
+
+    expect_string(__wrap_unlink, file, audisp_path);
+    will_return(__wrap_unlink, 0);
+    expect_string(__wrap_unlink, file, AUDIT_SOCKET);
+    will_return(__wrap_unlink, 0);
+
+    expect_abspath(AUDIT_CONF_FILE, 1);
+
+    expect_string(__wrap_wfopen, path, "tmp/af_wazuh.conf");
+    expect_string(__wrap_wfopen, mode, "w");
+    will_return(__wrap_wfopen, 1);
+
+    will_return(__wrap_fwrite, 256);
+
+    expect_value(__wrap_fclose, _File, 1);
+    will_return(__wrap_fclose, 0);
+
+    expect_string(__wrap_OS_MoveFile, src, "tmp/af_wazuh.conf");
+    expect_string(__wrap_OS_MoveFile, dst, audisp_path);
+    will_return(__wrap_OS_MoveFile, 0);
+
+    expect_string(__wrap__minfo, formatted_msg,
+                  "(6025): Audit plugin configuration (/etc/audit/plugins.d/af_wazuh.conf) was modified. "
+                  "Restarting Auditd service.");
+
+    will_return(__wrap_audit_restart, restart_ret);
+}
+
+/* audisp_prefer_configuration_on_disk() when no configuration file is readable. */
+static void expect_no_configuration_on_disk(void) {
+    expect_string(__wrap_OS_SHA1_File, fname, "/etc/audit/plugins.d/af_wazuh.conf");
+    expect_value(__wrap_OS_SHA1_File, mode, OS_TEXT);
+    will_return(__wrap_OS_SHA1_File, "0000000000000000000000000000000000000000");
+    will_return(__wrap_OS_SHA1_File, -1);
+}
+
+void test_audisp_prefer_configuration_on_disk_moves_match_to_front(void **state) {
+    const char *templates[MAX_AUDISP_CANDIDATES] = {AUDISP_CONFIGURATION_2_TPL, AUDISP_CONFIGURATION_1_TPL};
+
+    expect_string(__wrap_OS_SHA1_File, fname, "/etc/audit/plugins.d/af_wazuh.conf");
+    expect_value(__wrap_OS_SHA1_File, mode, OS_TEXT);
+    will_return(__wrap_OS_SHA1_File, "1111111111111111111111111111111111111111");
+    will_return(__wrap_OS_SHA1_File, 0);
+
+    expect_abspath(AUDIT_SOCKET, 1);
+
+    // First candidate does not match what is on disk, the second one does
+    expect_any(__wrap_OS_SHA1_Str, str);
+    expect_any(__wrap_OS_SHA1_Str, length);
+    will_return(__wrap_OS_SHA1_Str, "2222222222222222222222222222222222222222");
+    expect_any(__wrap_OS_SHA1_Str, str);
+    expect_any(__wrap_OS_SHA1_Str, length);
+    will_return(__wrap_OS_SHA1_Str, "1111111111111111111111111111111111111111");
+
+    expect_string(__wrap__mdebug1, formatted_msg,
+                  "The audisp plugin configuration already in place will be tried first.");
+
+    audisp_prefer_configuration_on_disk(PLUGINS_DIR_AUDIT, templates, 2);
+
+    // The configuration already in place is tried first, so Auditd is not restarted for nothing
+    assert_string_equal(templates[0], AUDISP_CONFIGURATION_1_TPL);
+    assert_string_equal(templates[1], AUDISP_CONFIGURATION_2_TPL);
+}
+
+void test_audisp_prefer_configuration_on_disk_keeps_order_when_unknown(void **state) {
+    const char *templates[MAX_AUDISP_CANDIDATES] = {AUDISP_CONFIGURATION_2_TPL, AUDISP_CONFIGURATION_1_TPL};
+
+    // A tampered or outdated file matches no known template and must not be preferred
+    expect_string(__wrap_OS_SHA1_File, fname, "/etc/audit/plugins.d/af_wazuh.conf");
+    expect_value(__wrap_OS_SHA1_File, mode, OS_TEXT);
+    will_return(__wrap_OS_SHA1_File, "9999999999999999999999999999999999999999");
+    will_return(__wrap_OS_SHA1_File, 0);
+
+    expect_abspath(AUDIT_SOCKET, 1);
+
+    expect_any(__wrap_OS_SHA1_Str, str);
+    expect_any(__wrap_OS_SHA1_Str, length);
+    will_return(__wrap_OS_SHA1_Str, "2222222222222222222222222222222222222222");
+    expect_any(__wrap_OS_SHA1_Str, str);
+    expect_any(__wrap_OS_SHA1_Str, length);
+    will_return(__wrap_OS_SHA1_Str, "1111111111111111111111111111111111111111");
+
+    audisp_prefer_configuration_on_disk(PLUGINS_DIR_AUDIT, templates, 2);
+
+    assert_string_equal(templates[0], AUDISP_CONFIGURATION_2_TPL);
+    assert_string_equal(templates[1], AUDISP_CONFIGURATION_1_TPL);
+}
+
+void test_configure_and_connect_audit_socket_no_plugins_dir(void **state) {
+    int ret;
+
+    // Neither plugins directory exists: nothing to configure, just try the socket
+    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
+    will_return(__wrap_IsDir, 1);
+    expect_string(__wrap_IsDir, file, "/etc/audisp/plugins.d");
+    will_return(__wrap_IsDir, 1);
+
+    expect_audit_socket_connect(124);
+
+    ret = configure_and_connect_audit_socket();
+
+    assert_int_equal(ret, 124);
+}
+
+void test_configure_and_connect_audit_socket_removes_stale_socket(void **state) {
+    int ret;
+
+    syscheck.restart_audit = 1;
+
+    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
+    will_return(__wrap_IsDir, 0);
+    expect_audit_version("auditctl version 3.1.2\n", "Audit version detected: 3.1.2");
+
+    // The socket is there but nobody is listening: it must be removed, otherwise the probe would
+    // believe the candidate took effect without ever applying it
+    expect_string(__wrap_IsSocket, sock, AUDIT_SOCKET);
+    will_return(__wrap_IsSocket, 0);
+    expect_audit_socket_connect(-1);
+    expect_string(__wrap_unlink, file, AUDIT_SOCKET);
+    will_return(__wrap_unlink, 0);
+
+    expect_no_configuration_on_disk();
+
+    expect_candidate_written(0);
+    expect_wait_for_audit_socket(1);
+    expect_audit_socket_connect(77);
+
+    ret = configure_and_connect_audit_socket();
+
+    assert_int_equal(ret, 77);
+}
+
+void test_configure_and_connect_audit_socket_probes_fallback(void **state) {
+    int ret;
+
+    syscheck.restart_audit = 1;
+    ignore_function_calls(__wrap_usleep);
+
+    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
+    will_return(__wrap_IsDir, 0);
+    expect_audit_version("auditctl version 3.1.5\n", "Audit version detected: 3.1.5");
+
+    // No socket in place
+    expect_string(__wrap_IsSocket, sock, AUDIT_SOCKET);
+    will_return(__wrap_IsSocket, 1);
+
+    expect_no_configuration_on_disk();
+
+    // The configuration expected for this version does not bring the socket up
+    expect_candidate_written(0);
+    expect_wait_for_audit_socket(0);
+
+    // The fallback does
+    expect_string(__wrap__mdebug1, formatted_msg,
+                  "Could not establish the who-data socket 'queue/sockets/audit' with the current "
+                  "audisp plugin configuration. Trying an alternative one.");
+    expect_candidate_written(0);
+    expect_wait_for_audit_socket(1);
+    expect_audit_socket_connect(88);
+
+    expect_string(__wrap__minfo, formatted_msg,
+                  "(6054): The audisp plugin configuration expected for the installed audit version "
+                  "did not create the socket 'queue/sockets/audit'. Who-data started with an "
+                  "alternative plugin configuration.");
+
+    ret = configure_and_connect_audit_socket();
+
+    assert_int_equal(ret, 88);
+}
+
+void test_configure_and_connect_audit_socket_all_candidates_fail(void **state) {
+    int ret;
+
+    syscheck.restart_audit = 1;
+    ignore_function_calls(__wrap_usleep);
+
+    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
+    will_return(__wrap_IsDir, 0);
+    expect_audit_version("auditctl version 3.1.5\n", "Audit version detected: 3.1.5");
+
+    expect_string(__wrap_IsSocket, sock, AUDIT_SOCKET);
+    will_return(__wrap_IsSocket, 1);
+
+    expect_no_configuration_on_disk();
+
+    expect_candidate_written(0);
+    expect_wait_for_audit_socket(0);
+
+    expect_string(__wrap__mdebug1, formatted_msg,
+                  "Could not establish the who-data socket 'queue/sockets/audit' with the current "
+                  "audisp plugin configuration. Trying an alternative one.");
+    expect_candidate_written(0);
+    expect_wait_for_audit_socket(0);
+
+    expect_string(__wrap__merror, formatted_msg,
+                  "(6636): Cannot connect to socket 'queue/sockets/audit'.");
+
+    ret = configure_and_connect_audit_socket();
+
+    assert_int_equal(ret, -1);
+}
+
+void test_configure_and_connect_audit_socket_keeps_probing_after_write_error(void **state) {
+    int ret;
+
+    syscheck.restart_audit = 1;
+
+    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
+    will_return(__wrap_IsDir, 0);
+    expect_audit_version("auditctl version 3.1.5\n", "Audit version detected: 3.1.5");
+
+    expect_string(__wrap_IsSocket, sock, AUDIT_SOCKET);
+    will_return(__wrap_IsSocket, 1);
+
+    expect_no_configuration_on_disk();
+
+    // Auditd fails to restart with the first candidate: the next one must still be tried
+    expect_candidate_written(-1);
+    expect_string(__wrap__mdebug1, formatted_msg, "(6273): Cannot apply Audit config.");
+
+    expect_string(__wrap__mdebug1, formatted_msg,
+                  "Could not establish the who-data socket 'queue/sockets/audit' with the current "
+                  "audisp plugin configuration. Trying an alternative one.");
+    expect_candidate_written(0);
+    expect_wait_for_audit_socket(1);
+    expect_audit_socket_connect(99);
+
+    expect_string(__wrap__minfo, formatted_msg,
+                  "(6054): The audisp plugin configuration expected for the installed audit version "
+                  "did not create the socket 'queue/sockets/audit'. Who-data started with an "
+                  "alternative plugin configuration.");
+
+    ret = configure_and_connect_audit_socket();
+
+    assert_int_equal(ret, 99);
+}
+
+void test_set_auditd_config_template_writes_the_given_configuration(void **state) {
+    const char *audisp_config = "active = yes\ndirection = out\npath = /sbin/audisp-af_unix\n"
+                                "type = always\nargs = 0640 %s\nformat = string\n";
+    const char *audisp_path = "/etc/audit/plugins.d/af_wazuh.conf";
+    int ret;
+
+    expect_abspath(AUDIT_SOCKET, 0);
+
+    expect_any(__wrap_OS_SHA1_Str, str);
+    expect_any(__wrap_OS_SHA1_Str, length);
+    will_return(__wrap_OS_SHA1_Str, "6e3a100fc85241f04ed9686d37738e7d08086fb4");
+
+    expect_string(__wrap_OS_SHA1_File, fname, audisp_path);
+    expect_value(__wrap_OS_SHA1_File, mode, OS_TEXT);
+    will_return(__wrap_OS_SHA1_File, "6e3a100fc85241f04ed9686d37738e7d08086fb4");
+    will_return(__wrap_OS_SHA1_File, 0);
+
+    // Configuration already in place and socket present: nothing to do
+    expect_string(__wrap_IsSocket, sock, AUDIT_SOCKET);
+    will_return(__wrap_IsSocket, 0);
+
+    ret = set_auditd_config_template("/etc/audit/plugins.d", audisp_config);
+
+    assert_int_equal(ret, 0);
+}
+
+void test_set_auditd_config_template_audit3_plugin_created(void **state) {
     expect_abspath(AUDIT_SOCKET, 0);
 
     // Plugin already created
@@ -365,37 +836,13 @@ void test_set_auditd_config_audit3_plugin_created(void **state) {
     will_return(__wrap_IsSocket, 0);
 
     int ret;
-    ret = set_auditd_config();
+    ret = set_auditd_config_template(PLUGINS_DIR_AUDIT, AUDISP_CONFIGURATION_0_TPL);
 
     assert_int_equal(ret, 0);
 }
 
 
-void test_set_auditd_config_wrong_audit_version(void **state) {
-    (void) state;
-
-    // Not Audit 3
-    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
-    will_return(__wrap_IsDir, 1);
-    // Not Audit 2
-    expect_string(__wrap_IsDir, file, "/etc/audisp/plugins.d");
-    will_return(__wrap_IsDir, 1);
-
-    int ret;
-    ret = set_auditd_config();
-
-    assert_int_equal(ret, 0);
-}
-
-
-void test_set_auditd_config_audit2_plugin_created(void **state) {
-    // Not Audit 3
-    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
-    will_return(__wrap_IsDir, 1);
-    // Audit 2
-    expect_string(__wrap_IsDir, file, "/etc/audisp/plugins.d");
-    will_return(__wrap_IsDir, 0);
-
+void test_set_auditd_config_template_audit2_plugin_created(void **state) {
     expect_abspath(AUDIT_SOCKET, 0);
 
     // Plugin already created
@@ -414,25 +861,15 @@ void test_set_auditd_config_audit2_plugin_created(void **state) {
     will_return(__wrap_IsSocket, 0);
 
     int ret;
-    ret = set_auditd_config();
+    ret = set_auditd_config_template(PLUGINS_OLD_DIR_AUDISP, AUDISP_CONFIGURATION_0_TPL);
 
     assert_int_equal(ret, 0);
 }
 
 
-void test_set_auditd_config_audit_socket_not_created(void **state) {
+void test_set_auditd_config_template_audit_socket_not_created(void **state) {
     char buffer[OS_SIZE_128] = {0};
     syscheck.restart_audit = 0;
-
-    // Audit 3
-    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
-    will_return(__wrap_IsDir, 0);
-
-    // get_audit_version_code
-    const char *payload = "auditctl version 3.1.2\n";
-    FILE * fp = tmpfile_with_content(payload);
-    expect_popen("auditctl -v 2>/dev/null", "r", fp);
-    expect_string(__wrap__mdebug2, formatted_msg, "Audit version detected: 3.1.2");
 
     expect_abspath(AUDIT_SOCKET, 0);
 
@@ -456,25 +893,15 @@ void test_set_auditd_config_audit_socket_not_created(void **state) {
     expect_string(__wrap__mwarn, formatted_msg, buffer);
 
     int ret;
-    ret = set_auditd_config();
+    ret = set_auditd_config_template(PLUGINS_DIR_AUDIT, AUDISP_CONFIGURATION_1_TPL);
 
     assert_int_equal(ret, 1);
 }
 
 
-void test_set_auditd_config_audit_socket_not_created_restart(void **state) {
+void test_set_auditd_config_template_audit_socket_not_created_restart(void **state) {
     char buffer[OS_SIZE_128] = {0};
     syscheck.restart_audit = 1;
-
-    // Audit 3
-    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
-    will_return(__wrap_IsDir, 0);
-
-    // get_audit_version_code
-    const char *payload = "auditctl version 3.1.3\n";
-    FILE * fp = tmpfile_with_content(payload);
-    expect_popen("auditctl -v 2>/dev/null", "r", fp);
-    expect_string(__wrap__mdebug2, formatted_msg, "Audit version detected: 3.1.3");
 
     expect_abspath(AUDIT_SOCKET, 0);
 
@@ -498,23 +925,13 @@ void test_set_auditd_config_audit_socket_not_created_restart(void **state) {
     will_return(__wrap_audit_restart, 99);
 
     int ret;
-    ret = set_auditd_config();
+    ret = set_auditd_config_template(PLUGINS_DIR_AUDIT, AUDISP_CONFIGURATION_1_TPL);
 
     assert_int_equal(ret, 99);
 }
 
 
-void test_set_auditd_config_audit_plugin_tampered_configuration(void **state) {
-    // Audit 3
-    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
-    will_return(__wrap_IsDir, 0);
-
-    // get_audit_version_code
-    const char *payload = "auditctl version 3.1.2\n";
-    FILE * fp = tmpfile_with_content(payload);
-    expect_popen("auditctl -v 2>/dev/null", "r", fp);
-    expect_string(__wrap__mdebug2, formatted_msg, "Audit version detected: 3.1.2");
-
+void test_set_auditd_config_template_audit_plugin_tampered_configuration(void **state) {
     expect_string(__wrap__minfo, formatted_msg, "(6024): Generating Auditd socket configuration file: 'tmp/af_wazuh.conf'");
 
     // Plugin not created
@@ -559,26 +976,15 @@ void test_set_auditd_config_audit_plugin_tampered_configuration(void **state) {
     will_return(__wrap_audit_restart, 99);
 
     int ret;
-    ret = set_auditd_config();
+    ret = set_auditd_config_template(PLUGINS_DIR_AUDIT, AUDISP_CONFIGURATION_1_TPL);
 
     errno = 0;
     assert_int_equal(ret, 99);
 }
 
 
-void test_set_auditd_config_audit_plugin_not_created(void **state) {
-    // Audit 3
-    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
-    will_return(__wrap_IsDir, 0);
-
-    // get_audit_version_code
-    const char *payload = "auditctl version 3.1.5\n";
+void test_set_auditd_config_template_audit_plugin_not_created(void **state) {
     const char *audit3_socket = "/etc/audit/plugins.d/af_wazuh.conf";
-    FILE * fp = tmpfile_with_content(payload);
-
-    expect_popen("auditctl -v 2>/dev/null", "r", fp);
-    expect_string(__wrap__mdebug2, formatted_msg, "Audit version detected: 3.1.5");
-
     expect_any(__wrap_OS_SHA1_Str, str);
     expect_any(__wrap_OS_SHA1_Str, length);
     will_return(__wrap_OS_SHA1_Str, "6e3a100fc85241f04ed9686d37738e7d08086fb4");
@@ -621,23 +1027,13 @@ void test_set_auditd_config_audit_plugin_not_created(void **state) {
     will_return(__wrap_audit_restart, 99);
 
     int ret;
-    ret = set_auditd_config();
+    ret = set_auditd_config_template(PLUGINS_DIR_AUDIT, AUDISP_CONFIGURATION_2_TPL);
 
     assert_int_equal(ret, 99);
 }
 
 
-void test_set_auditd_config_audit_plugin_not_created_fopen_error(void **state) {
-    // Audit 3
-    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
-    will_return(__wrap_IsDir, 0);
-
-    // get_audit_version_code
-    const char *payload = "auditctl version 4.0.0\n";
-    FILE * fp = tmpfile_with_content(payload);
-    expect_popen("auditctl -v 2>/dev/null", "r", fp);
-    expect_string(__wrap__mdebug2, formatted_msg, "Audit version detected: 4.0.0");
-
+void test_set_auditd_config_template_audit_plugin_not_created_fopen_error(void **state) {
     expect_string(__wrap__minfo, formatted_msg, "(6024): Generating Auditd socket configuration file: 'tmp/af_wazuh.conf'");
 
     // Plugin not created
@@ -670,13 +1066,13 @@ void test_set_auditd_config_audit_plugin_not_created_fopen_error(void **state) {
     errno = 0;
 
     int ret;
-    ret = set_auditd_config();
+    ret = set_auditd_config_template(PLUGINS_DIR_AUDIT, AUDISP_CONFIGURATION_1_TPL);
 
     assert_int_equal(ret, -1);
 }
 
 
-void test_set_auditd_config_audit_plugin_not_created_fclose_error(void **state) {
+void test_set_auditd_config_template_audit_plugin_not_created_fclose_error(void **state) {
     expect_string(__wrap__minfo, formatted_msg, "(6024): Generating Auditd socket configuration file: 'tmp/af_wazuh.conf'");
 
     // Plugin not created
@@ -687,16 +1083,6 @@ void test_set_auditd_config_audit_plugin_not_created_fclose_error(void **state) 
 
     expect_string(__wrap_unlink, file, AUDIT_SOCKET);
     will_return(__wrap_unlink, 0);
-
-    // Audit 3
-    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
-    will_return(__wrap_IsDir, 0);
-
-    // get_audit_version_code
-    const char *payload = "auditctl version 4.0.1\n";
-    FILE * fp = tmpfile_with_content(payload);
-    expect_popen("auditctl -v 2>/dev/null", "r", fp);
-    expect_string(__wrap__mdebug2, formatted_msg, "Audit version detected: 4.0.1");
 
     expect_abspath(AUDIT_SOCKET, 1);
     expect_abspath(AUDIT_CONF_FILE, 1);
@@ -724,13 +1110,13 @@ void test_set_auditd_config_audit_plugin_not_created_fclose_error(void **state) 
     errno = 0;
 
     int ret;
-    ret = set_auditd_config();
+    ret = set_auditd_config_template(PLUGINS_DIR_AUDIT, AUDISP_CONFIGURATION_1_TPL);
 
     assert_int_equal(ret, -1);
 }
 
 
-void test_set_auditd_config_audit_plugin_not_created_recreate_hardlink(void **state) {
+void test_set_auditd_config_template_audit_plugin_not_created_recreate_hardlink(void **state) {
     expect_string(__wrap__minfo, formatted_msg, "(6024): Generating Auditd socket configuration file: 'tmp/af_wazuh.conf'");
 
     // Plugin not created
@@ -741,16 +1127,6 @@ void test_set_auditd_config_audit_plugin_not_created_recreate_hardlink(void **st
 
     expect_string(__wrap_unlink, file, AUDIT_SOCKET);
     will_return(__wrap_unlink, 0);
-
-    // Audit 3
-    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
-    will_return(__wrap_IsDir, 0);
-
-    // get_audit_version_code
-    const char *payload = "auditctl version 4.0.2\n";
-    FILE * fp = tmpfile_with_content(payload);
-    expect_popen("auditctl -v 2>/dev/null", "r", fp);
-    expect_string(__wrap__mdebug2, formatted_msg, "Audit version detected: 4.0.2");
 
     expect_abspath(AUDIT_SOCKET, 1);
     expect_abspath(AUDIT_CONF_FILE, 1);
@@ -784,23 +1160,13 @@ void test_set_auditd_config_audit_plugin_not_created_recreate_hardlink(void **st
     expect_string(__wrap__mwarn, formatted_msg, "(6910): Audit plugin configuration was modified. You need to restart Auditd. Who-data will be disabled.");
 
     int ret;
-    ret = set_auditd_config();
+    ret = set_auditd_config_template(PLUGINS_DIR_AUDIT, AUDISP_CONFIGURATION_1_TPL);
 
     assert_int_equal(ret, 1);
 }
 
 
-void test_set_auditd_config_audit_plugin_not_created_recreate_hardlink_restart(void **state) {
-    // Audit 3
-    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
-    will_return(__wrap_IsDir, 0);
-
-    // get_audit_version_code
-    const char *payload = "auditctl version 4.0.3\n";
-    FILE * fp = tmpfile_with_content(payload);
-    expect_popen("auditctl -v 2>/dev/null", "r", fp);
-    expect_string(__wrap__mdebug2, formatted_msg, "Audit version detected: 4.0.3");
-
+void test_set_auditd_config_template_audit_plugin_not_created_recreate_hardlink_restart(void **state) {
     expect_string(__wrap__minfo, formatted_msg, "(6024): Generating Auditd socket configuration file: 'tmp/af_wazuh.conf'");
 
     // Plugin not created
@@ -845,23 +1211,13 @@ void test_set_auditd_config_audit_plugin_not_created_recreate_hardlink_restart(v
     will_return(__wrap_audit_restart, 99);
 
     int ret;
-    ret = set_auditd_config();
+    ret = set_auditd_config_template(PLUGINS_DIR_AUDIT, AUDISP_CONFIGURATION_2_TPL);
 
     assert_int_equal(ret, 99);
 }
 
 
-void test_set_auditd_config_audit_plugin_not_created_recreate_hardlink_error(void **state) {
-    // Audit 3
-    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
-    will_return(__wrap_IsDir, 0);
-
-    // get_audit_version_code
-    const char *payload = "auditctl version 4.0.4\n";
-    FILE * fp = tmpfile_with_content(payload);
-    expect_popen("auditctl -v 2>/dev/null", "r", fp);
-    expect_string(__wrap__mdebug2, formatted_msg, "Audit version detected: 4.0.4");
-
+void test_set_auditd_config_template_audit_plugin_not_created_recreate_hardlink_error(void **state) {
     expect_string(__wrap__minfo, formatted_msg, "(6024): Generating Auditd socket configuration file: 'tmp/af_wazuh.conf'");
 
     // Plugin not created
@@ -902,23 +1258,13 @@ void test_set_auditd_config_audit_plugin_not_created_recreate_hardlink_error(voi
     expect_string(__wrap__merror, formatted_msg, "Failed to move 'tmp/af_wazuh.conf' to '/etc/audit/plugins.d/af_wazuh.conf'");
 
     int ret;
-    ret = set_auditd_config();
+    ret = set_auditd_config_template(PLUGINS_DIR_AUDIT, AUDISP_CONFIGURATION_2_TPL);
 
     assert_int_equal(ret, -1);
 }
 
 
-void test_set_auditd_config_audit_plugin_not_created_recreate_hardlink_unlink_error(void **state) {
-    // Audit 3
-    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
-    will_return(__wrap_IsDir, 0);
-
-    // get_audit_version_code
-    const char *payload = "auditctl version 4.0.5\n";
-    FILE * fp = tmpfile_with_content(payload);
-    expect_popen("auditctl -v 2>/dev/null", "r", fp);
-    expect_string(__wrap__mdebug2, formatted_msg, "Audit version detected: 4.0.5");
-
+void test_set_auditd_config_template_audit_plugin_not_created_recreate_hardlink_unlink_error(void **state) {
     expect_string(__wrap__minfo, formatted_msg, "(6024): Generating Auditd socket configuration file: 'tmp/af_wazuh.conf'");
 
     // Plugin not created
@@ -959,7 +1305,7 @@ void test_set_auditd_config_audit_plugin_not_created_recreate_hardlink_unlink_er
     expect_string(__wrap__merror, formatted_msg, "Failed to move 'tmp/af_wazuh.conf' to '/etc/audit/plugins.d/af_wazuh.conf'");
 
     int ret;
-    ret = set_auditd_config();
+    ret = set_auditd_config_template(PLUGINS_DIR_AUDIT, AUDISP_CONFIGURATION_2_TPL);
 
     assert_int_equal(ret, -1);
 }
@@ -1676,19 +2022,35 @@ int main(void) {
         cmocka_unit_test(test_check_auditd_enabled_readproc_error),
         cmocka_unit_test(test_init_auditd_socket_success),
         cmocka_unit_test(test_init_auditd_socket_failure),
-        cmocka_unit_test(test_set_auditd_config_wrong_audit_version),
-        cmocka_unit_test(test_set_auditd_config_audit2_plugin_created),
-        cmocka_unit_test(test_set_auditd_config_audit3_plugin_created),
-        cmocka_unit_test(test_set_auditd_config_audit_socket_not_created),
-        cmocka_unit_test(test_set_auditd_config_audit_socket_not_created_restart),
-        cmocka_unit_test(test_set_auditd_config_audit_plugin_tampered_configuration),
-        cmocka_unit_test(test_set_auditd_config_audit_plugin_not_created),
-        cmocka_unit_test(test_set_auditd_config_audit_plugin_not_created_fopen_error),
-        cmocka_unit_test(test_set_auditd_config_audit_plugin_not_created_fclose_error),
-        cmocka_unit_test(test_set_auditd_config_audit_plugin_not_created_recreate_hardlink),
-        cmocka_unit_test(test_set_auditd_config_audit_plugin_not_created_recreate_hardlink_restart),
-        cmocka_unit_test(test_set_auditd_config_audit_plugin_not_created_recreate_hardlink_error),
-        cmocka_unit_test(test_set_auditd_config_audit_plugin_not_created_recreate_hardlink_unlink_error),
+        cmocka_unit_test(test_audisp_get_candidates_audit_3_1_5_prefers_format_propagation),
+        cmocka_unit_test(test_audisp_get_candidates_audit_3_1_2_prefers_two_arguments),
+        cmocka_unit_test(test_audisp_get_candidates_audit_3_0_6_prefers_builtin),
+        cmocka_unit_test(test_audisp_get_candidates_audit_4_0_0_prefers_two_arguments),
+        cmocka_unit_test(test_audisp_get_candidates_audit_4_0_3_prefers_format_propagation),
+        cmocka_unit_test(test_audisp_get_candidates_unknown_version),
+        cmocka_unit_test(test_audisp_get_candidates_audit2_dir),
+        cmocka_unit_test(test_audisp_get_candidates_no_plugins_dir),
+        cmocka_unit_test(test_audisp_get_candidates_honours_max),
+        cmocka_unit_test(test_set_auditd_config_template_writes_the_given_configuration),
+        cmocka_unit_test(test_audisp_prefer_configuration_on_disk_moves_match_to_front),
+        cmocka_unit_test(test_audisp_prefer_configuration_on_disk_keeps_order_when_unknown),
+        cmocka_unit_test(test_configure_and_connect_audit_socket_no_plugins_dir),
+        cmocka_unit_test(test_configure_and_connect_audit_socket_removes_stale_socket),
+        cmocka_unit_test(test_configure_and_connect_audit_socket_probes_fallback),
+        cmocka_unit_test(test_configure_and_connect_audit_socket_all_candidates_fail),
+        cmocka_unit_test(test_configure_and_connect_audit_socket_keeps_probing_after_write_error),
+        cmocka_unit_test(test_set_auditd_config_template_audit2_plugin_created),
+        cmocka_unit_test(test_set_auditd_config_template_audit3_plugin_created),
+        cmocka_unit_test(test_set_auditd_config_template_audit_socket_not_created),
+        cmocka_unit_test(test_set_auditd_config_template_audit_socket_not_created_restart),
+        cmocka_unit_test(test_set_auditd_config_template_audit_plugin_tampered_configuration),
+        cmocka_unit_test(test_set_auditd_config_template_audit_plugin_not_created),
+        cmocka_unit_test(test_set_auditd_config_template_audit_plugin_not_created_fopen_error),
+        cmocka_unit_test(test_set_auditd_config_template_audit_plugin_not_created_fclose_error),
+        cmocka_unit_test(test_set_auditd_config_template_audit_plugin_not_created_recreate_hardlink),
+        cmocka_unit_test(test_set_auditd_config_template_audit_plugin_not_created_recreate_hardlink_restart),
+        cmocka_unit_test(test_set_auditd_config_template_audit_plugin_not_created_recreate_hardlink_error),
+        cmocka_unit_test(test_set_auditd_config_template_audit_plugin_not_created_recreate_hardlink_unlink_error),
         cmocka_unit_test_teardown(test_audit_get_id, free_string),
         cmocka_unit_test(test_audit_get_id_begin_error),
         cmocka_unit_test(test_audit_get_id_end_error),

--- a/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
+++ b/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
@@ -402,10 +402,10 @@ void test_audisp_get_candidates_audit_3_0_6_prefers_builtin(void **state) {
 
     count = audisp_get_candidates(&plugin_dir, templates, MAX_AUDISP_CANDIDATES);
 
-    // The event format argument only exists from 3.1.5 on, so it is not offered here
-    assert_int_equal(count, 2);
+    // /sbin/audisp-af_unix does not exist before 3.1.1, so there is no fallback worth probing
+    assert_int_equal(count, 1);
     assert_string_equal(templates[0], AUDISP_CONFIGURATION_0_TPL);
-    assert_string_equal(templates[1], AUDISP_CONFIGURATION_1_TPL);
+    assert_null(templates[1]);
 }
 
 void test_audisp_get_candidates_audit_4_0_0_prefers_two_arguments(void **state) {
@@ -497,13 +497,13 @@ void test_audisp_get_candidates_honours_max(void **state) {
     int count;
 
     expect_audit_plugins_dir();
-    expect_audit_version("auditctl version 3.0.6\n", "Audit version detected: 3.0.6");
+    expect_audit_version("auditctl version 3.1.5\n", "Audit version detected: 3.1.5");
 
-    // The version would yield three candidates, but only one fits
+    // The version would yield two candidates, but only one fits
     count = audisp_get_candidates(&plugin_dir, templates, 1);
 
     assert_int_equal(count, 1);
-    assert_string_equal(templates[0], AUDISP_CONFIGURATION_0_TPL);
+    assert_string_equal(templates[0], AUDISP_CONFIGURATION_2_TPL);
     assert_null(templates[1]);
 }
 
@@ -520,6 +520,8 @@ static void expect_audit_socket_connect(int ret) {
 /* wait_for_audit_socket() polls IsSocket() every 100 ms for 5 s, so a timeout is 50 misses. The
    calls to usleep() in between are ignored: how often it polls is an implementation detail. */
 #define AUDIT_SOCKET_POLL_ATTEMPTS 50
+/* audit_socket_connect_retry() attempts before treating the socket as stale. */
+#define AUDIT_SOCKET_CONNECT_ATTEMPTS 3
 
 static void expect_wait_for_audit_socket(int found) {
     int i;
@@ -582,16 +584,9 @@ static void expect_candidate_written(int restart_ret) {
     will_return(__wrap_audit_restart, restart_ret);
 }
 
-/* audisp_prefer_configuration_on_disk() when no configuration file is readable. */
-static void expect_no_configuration_on_disk(void) {
-    expect_string(__wrap_OS_SHA1_File, fname, "/etc/audit/plugins.d/af_wazuh.conf");
-    expect_value(__wrap_OS_SHA1_File, mode, OS_TEXT);
-    will_return(__wrap_OS_SHA1_File, "0000000000000000000000000000000000000000");
-    will_return(__wrap_OS_SHA1_File, -1);
-}
-
-void test_audisp_prefer_configuration_on_disk_moves_match_to_front(void **state) {
+void test_audisp_configuration_is_known_matches_a_template(void **state) {
     const char *templates[MAX_AUDISP_CANDIDATES] = {AUDISP_CONFIGURATION_2_TPL, AUDISP_CONFIGURATION_1_TPL};
+    int ret;
 
     expect_string(__wrap_OS_SHA1_File, fname, "/etc/audit/plugins.d/af_wazuh.conf");
     expect_value(__wrap_OS_SHA1_File, mode, OS_TEXT);
@@ -600,7 +595,7 @@ void test_audisp_prefer_configuration_on_disk_moves_match_to_front(void **state)
 
     expect_abspath(AUDIT_SOCKET, 1);
 
-    // First candidate does not match what is on disk, the second one does
+    // The first template does not match what is on disk, the second one does
     expect_any(__wrap_OS_SHA1_Str, str);
     expect_any(__wrap_OS_SHA1_Str, length);
     will_return(__wrap_OS_SHA1_Str, "2222222222222222222222222222222222222222");
@@ -608,20 +603,16 @@ void test_audisp_prefer_configuration_on_disk_moves_match_to_front(void **state)
     expect_any(__wrap_OS_SHA1_Str, length);
     will_return(__wrap_OS_SHA1_Str, "1111111111111111111111111111111111111111");
 
-    expect_string(__wrap__mdebug1, formatted_msg,
-                  "The audisp plugin configuration already in place will be tried first.");
+    ret = audisp_configuration_is_known(PLUGINS_DIR_AUDIT, templates, 2);
 
-    audisp_prefer_configuration_on_disk(PLUGINS_DIR_AUDIT, templates, 2);
-
-    // The configuration already in place is tried first, so Auditd is not restarted for nothing
-    assert_string_equal(templates[0], AUDISP_CONFIGURATION_1_TPL);
-    assert_string_equal(templates[1], AUDISP_CONFIGURATION_2_TPL);
+    assert_int_equal(ret, 1);
 }
 
-void test_audisp_prefer_configuration_on_disk_keeps_order_when_unknown(void **state) {
+void test_audisp_configuration_is_known_rejects_unknown_file(void **state) {
     const char *templates[MAX_AUDISP_CANDIDATES] = {AUDISP_CONFIGURATION_2_TPL, AUDISP_CONFIGURATION_1_TPL};
+    int ret;
 
-    // A tampered or outdated file matches no known template and must not be preferred
+    // A tampered or outdated file matches no known template and must be rewritten
     expect_string(__wrap_OS_SHA1_File, fname, "/etc/audit/plugins.d/af_wazuh.conf");
     expect_value(__wrap_OS_SHA1_File, mode, OS_TEXT);
     will_return(__wrap_OS_SHA1_File, "9999999999999999999999999999999999999999");
@@ -636,10 +627,23 @@ void test_audisp_prefer_configuration_on_disk_keeps_order_when_unknown(void **st
     expect_any(__wrap_OS_SHA1_Str, length);
     will_return(__wrap_OS_SHA1_Str, "1111111111111111111111111111111111111111");
 
-    audisp_prefer_configuration_on_disk(PLUGINS_DIR_AUDIT, templates, 2);
+    ret = audisp_configuration_is_known(PLUGINS_DIR_AUDIT, templates, 2);
 
-    assert_string_equal(templates[0], AUDISP_CONFIGURATION_2_TPL);
-    assert_string_equal(templates[1], AUDISP_CONFIGURATION_1_TPL);
+    assert_int_equal(ret, 0);
+}
+
+void test_audisp_configuration_is_known_no_file(void **state) {
+    const char *templates[MAX_AUDISP_CANDIDATES] = {AUDISP_CONFIGURATION_2_TPL, AUDISP_CONFIGURATION_1_TPL};
+    int ret;
+
+    expect_string(__wrap_OS_SHA1_File, fname, "/etc/audit/plugins.d/af_wazuh.conf");
+    expect_value(__wrap_OS_SHA1_File, mode, OS_TEXT);
+    will_return(__wrap_OS_SHA1_File, "0000000000000000000000000000000000000000");
+    will_return(__wrap_OS_SHA1_File, -1);
+
+    ret = audisp_configuration_is_known(PLUGINS_DIR_AUDIT, templates, 2);
+
+    assert_int_equal(ret, 0);
 }
 
 void test_configure_and_connect_audit_socket_no_plugins_dir(void **state) {
@@ -671,11 +675,15 @@ void test_configure_and_connect_audit_socket_removes_stale_socket(void **state) 
     // believe the candidate took effect without ever applying it
     expect_string(__wrap_IsSocket, sock, AUDIT_SOCKET);
     will_return(__wrap_IsSocket, 0);
+
+    // A single refusal is not enough: the connection is retried before deeming the socket stale
     expect_audit_socket_connect(-1);
+    expect_audit_socket_connect(-1);
+    expect_audit_socket_connect(-1);
+    expect_function_calls(__wrap_usleep, AUDIT_SOCKET_CONNECT_ATTEMPTS - 1);
+
     expect_string(__wrap_unlink, file, AUDIT_SOCKET);
     will_return(__wrap_unlink, 0);
-
-    expect_no_configuration_on_disk();
 
     expect_candidate_written(0);
     expect_wait_for_audit_socket(1);
@@ -699,8 +707,6 @@ void test_configure_and_connect_audit_socket_probes_fallback(void **state) {
     // No socket in place
     expect_string(__wrap_IsSocket, sock, AUDIT_SOCKET);
     will_return(__wrap_IsSocket, 1);
-
-    expect_no_configuration_on_disk();
 
     // The configuration expected for this version does not bring the socket up
     expect_candidate_written(0);
@@ -737,8 +743,6 @@ void test_configure_and_connect_audit_socket_all_candidates_fail(void **state) {
     expect_string(__wrap_IsSocket, sock, AUDIT_SOCKET);
     will_return(__wrap_IsSocket, 1);
 
-    expect_no_configuration_on_disk();
-
     expect_candidate_written(0);
     expect_wait_for_audit_socket(0);
 
@@ -767,8 +771,6 @@ void test_configure_and_connect_audit_socket_keeps_probing_after_write_error(voi
 
     expect_string(__wrap_IsSocket, sock, AUDIT_SOCKET);
     will_return(__wrap_IsSocket, 1);
-
-    expect_no_configuration_on_disk();
 
     // Auditd fails to restart with the first candidate: the next one must still be tried
     expect_candidate_written(-1);
@@ -2032,8 +2034,9 @@ int main(void) {
         cmocka_unit_test(test_audisp_get_candidates_no_plugins_dir),
         cmocka_unit_test(test_audisp_get_candidates_honours_max),
         cmocka_unit_test(test_set_auditd_config_template_writes_the_given_configuration),
-        cmocka_unit_test(test_audisp_prefer_configuration_on_disk_moves_match_to_front),
-        cmocka_unit_test(test_audisp_prefer_configuration_on_disk_keeps_order_when_unknown),
+        cmocka_unit_test(test_audisp_configuration_is_known_matches_a_template),
+        cmocka_unit_test(test_audisp_configuration_is_known_rejects_unknown_file),
+        cmocka_unit_test(test_audisp_configuration_is_known_no_file),
         cmocka_unit_test(test_configure_and_connect_audit_socket_no_plugins_dir),
         cmocka_unit_test(test_configure_and_connect_audit_socket_removes_stale_socket),
         cmocka_unit_test(test_configure_and_connect_audit_socket_probes_fallback),

--- a/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
+++ b/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
@@ -694,6 +694,56 @@ void test_configure_and_connect_audit_socket_removes_stale_socket(void **state) 
     assert_int_equal(ret, 77);
 }
 
+void test_configure_and_connect_audit_socket_keeps_socket_when_restart_disabled(void **state) {
+    int ret;
+
+    // Auditd cannot be restarted, so a socket removed here could never be recreated. Any call to
+    // __wrap_unlink in this test is unexpected and makes cmocka fail, which is the point.
+    syscheck.restart_audit = 0;
+
+    // A version with a single candidate keeps the probe short
+    expect_string(__wrap_IsDir, file, "/etc/audit/plugins.d");
+    will_return(__wrap_IsDir, 0);
+    expect_audit_version("auditctl version 3.0.6\n", "Audit version detected: 3.0.6");
+
+    // The socket is there but refuses every attempt
+    expect_string(__wrap_IsSocket, sock, AUDIT_SOCKET);
+    will_return(__wrap_IsSocket, 0);
+    expect_audit_socket_connect(-1);
+    expect_audit_socket_connect(-1);
+    expect_audit_socket_connect(-1);
+
+    // The configuration on disk already matches, so nothing is written
+    expect_abspath(AUDIT_SOCKET, 1);
+    expect_any(__wrap_OS_SHA1_Str, str);
+    expect_any(__wrap_OS_SHA1_Str, length);
+    will_return(__wrap_OS_SHA1_Str, "6e3a100fc85241f04ed9686d37738e7d08086fb4");
+    expect_string(__wrap_OS_SHA1_File, fname, "/etc/audit/plugins.d/af_wazuh.conf");
+    expect_value(__wrap_OS_SHA1_File, mode, OS_TEXT);
+    will_return(__wrap_OS_SHA1_File, "6e3a100fc85241f04ed9686d37738e7d08086fb4");
+    will_return(__wrap_OS_SHA1_File, 0);
+    expect_string(__wrap_IsSocket, sock, AUDIT_SOCKET);
+    will_return(__wrap_IsSocket, 0);
+
+    // wait_for_audit_socket() sees the socket that was never removed
+    expect_string(__wrap_IsSocket, sock, AUDIT_SOCKET);
+    will_return(__wrap_IsSocket, 0);
+
+    expect_audit_socket_connect(-1);
+    expect_audit_socket_connect(-1);
+    expect_audit_socket_connect(-1);
+
+    ignore_function_calls(__wrap_usleep);
+
+    expect_string(__wrap__merror, formatted_msg, "(6636): Cannot connect to socket 'queue/sockets/audit'.");
+
+    ret = configure_and_connect_audit_socket();
+
+    assert_int_equal(ret, -1);
+
+    syscheck.restart_audit = 1;
+}
+
 void test_configure_and_connect_audit_socket_probes_fallback(void **state) {
     int ret;
 
@@ -776,9 +826,10 @@ void test_configure_and_connect_audit_socket_keeps_probing_after_write_error(voi
     expect_candidate_written(-1);
     expect_string(__wrap__mdebug1, formatted_msg, "(6273): Cannot apply Audit config.");
 
+    // The candidate was never applied, so the message must not claim it produced no socket
     expect_string(__wrap__mdebug1, formatted_msg,
-                  "Could not establish the who-data socket 'queue/sockets/audit' with the current "
-                  "audisp plugin configuration. Trying an alternative one.");
+                  "The current audisp plugin configuration could not be applied. Trying an "
+                  "alternative one.");
     expect_candidate_written(0);
     expect_wait_for_audit_socket(1);
     expect_audit_socket_connect(99);
@@ -2039,6 +2090,7 @@ int main(void) {
         cmocka_unit_test(test_audisp_configuration_is_known_no_file),
         cmocka_unit_test(test_configure_and_connect_audit_socket_no_plugins_dir),
         cmocka_unit_test(test_configure_and_connect_audit_socket_removes_stale_socket),
+        cmocka_unit_test(test_configure_and_connect_audit_socket_keeps_socket_when_restart_disabled),
         cmocka_unit_test(test_configure_and_connect_audit_socket_probes_fallback),
         cmocka_unit_test(test_configure_and_connect_audit_socket_all_candidates_fail),
         cmocka_unit_test(test_configure_and_connect_audit_socket_keeps_probing_after_write_error),

--- a/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
+++ b/src/unit_tests/syscheckd/whodata/test_syscheck_audit.c
@@ -517,11 +517,10 @@ static void expect_audit_socket_connect(int ret) {
     will_return(__wrap_OS_ConnectUnixDomain, ret);
 }
 
-/* wait_for_audit_socket() polls IsSocket() every 100 ms for 5 s, so a timeout is 50 misses. The
-   calls to usleep() in between are ignored: how often it polls is an implementation detail. */
-#define AUDIT_SOCKET_POLL_ATTEMPTS 50
-/* audit_socket_connect_retry() attempts before treating the socket as stale. */
-#define AUDIT_SOCKET_CONNECT_ATTEMPTS 3
+/* Derived from the real constants in syscheck_audit.h: a timeout is a full sweep of the polling
+   window. The usleep() calls in between are ignored, since how often it polls is an
+   implementation detail. */
+#define AUDIT_SOCKET_POLL_ATTEMPTS (AUDIT_SOCKET_WAIT_MS / AUDIT_SOCKET_POLL_MS)
 
 static void expect_wait_for_audit_socket(int found) {
     int i;
@@ -680,7 +679,7 @@ void test_configure_and_connect_audit_socket_removes_stale_socket(void **state) 
     expect_audit_socket_connect(-1);
     expect_audit_socket_connect(-1);
     expect_audit_socket_connect(-1);
-    expect_function_calls(__wrap_usleep, AUDIT_SOCKET_CONNECT_ATTEMPTS - 1);
+    expect_function_calls(__wrap_usleep, AUDIT_SOCKET_CONNECT_RETRIES - 1);
 
     expect_string(__wrap_unlink, file, AUDIT_SOCKET);
     will_return(__wrap_unlink, 0);


### PR DESCRIPTION
## Description

Closes #38536.

FIM who-data never starts on an Amazon Linux 2023 agent with the `audit` provider. `wazuh-syscheckd` logs `(6636): Cannot connect to socket 'queue/sockets/audit'` and permanently falls back to real-time, so file events under the monitored directory carry `file.mode: realtime` and no `user.*` fields.

The root cause is the version-based selection of the audisp plugin configuration in `set_auditd_config()`. Audit 3.1.5 is bucketed into `AUDISP_CONFIGURATION_2`, which renders a **three token** `args` line plus `format = binary`:

```
args = 0640 /var/ossec/queue/sockets/audit string
format = binary
```

Amazon Linux 2023 ships `audit-3.1.5-1.amzn2023.0.2`, a rebuild whose `audisp-af_unix` still takes only two arguments (mode, path). It logs `Missing arguments, using defaults`, binds its own default socket instead of the configured one, and `init_auditd_socket()` has nothing to connect to. The `>= 3.1.5` bucket was introduced in #30215 / #28984 on the assumption that every 3.1.5 build carries the event format propagation change; a plain version comparison cannot tell a vendor rebuild that lacks it apart from the upstream release it is based on.

The fix stops treating the version as proof. The configuration expected for the installed version is still applied first, but the agent now verifies that it actually produced a usable socket before accepting it, and probes the remaining known configuration when it did not.

## Proposed Changes

- **`audisp_get_candidates()`** replaces the single-configuration choice: it returns the known configurations **ordered by preference**, keeping today's version table as the first choice and appending the others as fallbacks. Preference is unchanged for every version, so no working system changes the configuration it ends up with.
- **`set_auditd_config_template(plugin_dir, template)`** holds what `set_auditd_config()` used to do — render, compare by SHA1, write, restart Auditd — but for a caller-supplied configuration. `set_auditd_config()` is gone; the version lookup and the write step are now separate concerns.
- **`wait_for_audit_socket()`** waits up to 5 s (polling every 100 ms) for the audisp plugin to create the socket. `configure_audisp()` unlinks the socket before rewriting the configuration, so its reappearance is a reliable signal: a misconfigured plugin binds its own default path and the socket never shows up.
- **`configure_and_connect_audit_socket()`** drives the sequence from `audit_init()`: apply a candidate, wait for the socket, connect. On success it stops; otherwise it moves to the next candidate and logs the new `(6054)` ("...did not create the socket... Who-data started with an alternative plugin configuration") when a fallback is what got who-data running. When no known plugins directory exists it connects directly, without waiting.
- **A socket that is up and accepts connections decides.** Before configuring anything, if the socket is there and connects, the agent keeps it untouched when `audisp_configuration_is_known()` says the file behind it is one this agent could have written — Auditd is already serving a working setup and restarting it would be gratuitous. If the file matches no known template — tampered with, or written by an older agent — the connection is dropped and the normal flow rewrites it. This is what keeps Auditd from being restarted on every agent start, and it relies on a live socket rather than on the contents of a file, which after a probe that failed on every candidate would hold the last and least preferred one.
- **A socket that refuses connections is retried before being treated as stale, and is only removed when it can be recreated.** A plugin that is gone and a transient failure (no file descriptors left, a saturated backlog) look identical from here, so a single refusal is not taken as proof: it takes `AUDIT_SOCKET_CONNECT_RETRIES` attempts. Even then it is only unlinked when `restart_audit` is enabled — with it disabled the agent cannot restart Auditd to bring the socket back, and removing it would turn one failed start into who-data being broken on every start from then on. The same retry is used after a candidate is applied, so a transient refusal there cannot discard a configuration that works.
- **The candidate list is always walked in version order**, so `(6054)` past the first candidate keeps meaning exactly what it says: the configuration expected for the installed audit version did not work.
- **A candidate that fails to be written, or that Auditd refuses to restart with, no longer aborts the probe** — the next one is tried, which is the whole point of probing.
- **At most two candidates**, and fewer where a fallback makes no sense. Each extra candidate costs an Auditd restart when probed, and every restart reloads the host's audit rules and bounces the other audisp consumers. `format = binary` is not offered below audit 3.1.5, where it does not exist, and below 3.1.1 the standalone configuration is not offered either, since `/sbin/audisp-af_unix` does not exist there — that bucket has a single candidate.
- **`audit_socket_connect(int quiet)`** carries the connect logic so the probe can attempt it without logging `(6636): Cannot connect to socket` on each candidate; the error is reported once, at the end, with the same message text as before. `init_auditd_socket()` remains as the public entry point used by the reconnection path in `audit_read_events()`.
- New message `(6054)` in `information_messages.h`, and `MAX_AUDISP_CANDIDATES` moved to `syscheck_audit.h` since it is now part of a public function's contract.

### Results and Evidence

The message IDs quoted throughout this section:

| ID | Message |
|---|---|
| `(6019)` | File integrity monitoring real-time Whodata engine started. |
| `(6024)` | Generating Auditd socket configuration file: '%s' |
| `(6025)` | Audit plugin configuration (%s) was modified. Restarting Auditd service. |
| `(6054)` | *(new)* The audisp plugin configuration expected for the installed audit version did not create the socket '%s'. Who-data started with an alternative plugin configuration. |
| `(6636)` | Cannot connect to socket '%s'. |
| `(6642)` | Audit health check couldn't be completed correctly. |
| `(6910)` | Audit plugin configuration was modified. You need to restart Auditd. Who-data will be disabled. |
| `(6913)` | Who-data engine could not start. Switching who-data to real-time. |

A configuration cycle is one `(6024)` + `(6025)` pair: the agent writing `af_wazuh.conf` and restarting Auditd. One cycle means the configuration expected for the installed audit version worked; two means the probe had to fall back.

Environment: agent `wazuh-agent-5.0.0-latest.x86_64` on Amazon Linux 2023 (x86_64), manager 5.0.0-latest. Who-data with `<provider>audit</provider>` over `/home/fim/whodata`. `syscheck.debug=2` to make the version bucket visible.

**Before the fix** — `audit-3.1.5-1.amzn2023.0.2`:

```
DEBUG: Audit version detected: 3.1.5
ERROR: (6636): Cannot connect to socket 'queue/sockets/audit'.
ERROR: Can't init auditd socket in 'init_auditd_socket()'
WARNING: (6913): Who-data engine could not start. Switching who-data to real-time.
```
`journalctl -u auditd`: `audisp-af_unix[…]: Missing arguments, using defaults`. No socket, no `wazuh_fim` rule.

**After the fix** — same host, same audit version:

```
DEBUG: Audit version detected: 3.1.5
INFO: (6024): Generating Auditd socket configuration file: 'tmp/af_wazuh.conf'
INFO: (6025): Audit plugin configuration (…/af_wazuh.conf) was modified. Restarting Auditd service.
DEBUG: Could not establish the who-data socket 'queue/sockets/audit' with the current audisp
       plugin configuration. Trying an alternative one.
INFO: (6024): Generating Auditd socket configuration file: 'tmp/af_wazuh.conf'
INFO: (6025): Audit plugin configuration (…/af_wazuh.conf) was modified. Restarting Auditd service.
INFO: (6054): The audisp plugin configuration expected for the installed audit version did not
      create the socket 'queue/sockets/audit'. Who-data started with an alternative plugin configuration.
INFO: (6019): File integrity monitoring real-time Whodata engine started.
```
`journalctl -u auditd` on the second restart: `audisp-af_unix[…]: Client connected`. Socket created, `auditctl -l` shows `-w /home/fim/whodata -p wa -k wazuh_fim`, and the FIM event carries the who-data identity:

```json
{"file": {"path": "/home/fim/whodata/wd_old_file_02.txt", "mode": "whodata",
  "audit": {"user_name": "root", "user_id": "0", "group_name": "root",
            "audit_name": "vagrant", "process_name": "/usr/bin/bash", "process_id": 8934}}}
```

| Scenario | Result |
|---|---|
| AL2023, audit 3.1.5 (the bug) | `(6054)` + `(6019)`, ends on the two argument configuration |
| AL2023, audit 3.0.6 (non-regression, builtin bucket) | `(6019)` directly, **zero** `(6054)`, one Auditd restart |
| Second agent start, Auditd already serving the socket | only `(6019)`; **zero** configuration cycles and Auditd **not** restarted (`Init complete` count unchanged) — `af_wazuh.conf` is not touched at all |
| Auditd restarted on its own (reboot equivalent) | socket returns with the probed configuration; agent connects directly, no `(6054)` |
| Tampered `af_wazuh.conf` (matches no known template) | rewritten on the next agent start and who-data comes up, so the self-repair the unconditional rewrite used to provide is preserved |
| **AlmaLinux 9.3, upstream audit 3.1.5-8.el9** | `(6019)` directly with the three argument configuration: **one** configuration cycle, **zero** `(6054)` — the probe does not kick in where the expected configuration works |
| **Ubuntu 26.04, audit 4.1.2** | `(6019)` directly with the three argument configuration: one cycle, **zero** `(6054)` — covers the `>= 4.0.3` bucket on audit 4.x |
| **Ubuntu 22.04, audit 3.0.7** | `(6019)` directly with `builtin_af_unix`: one cycle, **zero** `(6054)` — the builtin bucket on the Debian family, where `/sbin/audisp-af_unix` does not even exist |
| **Amazon Linux 2, audit 2.8.1** | `(6019)` directly with `builtin_af_unix` written to `/etc/audisp/plugins.d`: one cycle, **zero** `(6054)` — the audit 2.x path, where the version is never consulted because the legacy plugins directory decides |

Unit tests: **64/64 passing** in `test_syscheck_audit`, in 74 ms.

The AlmaLinux 9 run is the one that shows the probe is the exception and not the new normal: on `audit-3.1.5-8.el9` the same three token `args` line that breaks on Amazon Linux works fine (`audisp-af_unix … Client connected`, no `Missing arguments`), so the agent stops at the first candidate. Same audit version string, opposite outcome — which is exactly why the version alone cannot be the decision.

Every configuration template and both plugin directories have now been exercised on a real system, and four of the five version buckets have been validated on a VM. The two that have not — `3.1.1-3.1.4` and `4.0.0-4.0.2` — both select the two argument template, which is exactly the one Amazon Linux 2023 ends up running successfully, so what is left untested there is the version comparison itself, covered by the unit tests.

**Cost of the probe when who-data cannot work at all.** Measured on Ubuntu 26.04 by removing `/sbin/audisp-af_unix`, which is the situation a stock Fedora is in (`audispd-plugins` is not installed by default, see #35986): the agent takes **14 s** to give up instead of the current **4 s**, and restarts Auditd **twice** instead of once. The outcome is the same as today — a single `(6636)` and a clean fallback to real-time — and Auditd is left healthy and running. Audit rules defined in `rules.d` survive the restarts; rules added at runtime with `auditctl` do not, but that is already true of the single restart the agent does today, verified with the stock binary on the same host.

**On re-probing when the socket is missing.** When Auditd is running but the socket is absent, the probe starts over from the version-preferred candidate instead of reusing the configuration already on disk, which costs an extra Auditd restart on a host that had already been probed. This is deliberate: after a probe that failed on every candidate, the file on disk holds the last and least preferred one, so preferring it would make the agent latch onto the wrong template as soon as the host becomes viable — and "the socket exists and accepts connections" cannot detect a wrong event format. The case is narrow (with Auditd stopped the agent exits earlier with `(6923)`, and with the socket up the live-socket path takes over), so the extra restart is preferred over the risk.

**Note on a separate blocker.** Amazon Linux 2023 ships `-a task,never` by default, which suppresses syscall auditing and makes the who-data health check fail with `(6642): Audit health check couldn't be completed correctly.` — independently of this bug. The `(6636)` failure was reproduced and fixed with that rule already removed, so the two are orthogonal, but on a stock AL2023 host this fix alone does not yield working who-data until that rule is dealt with (same as #35986).

### Artifacts Affected

`wazuh-syscheckd` on the Linux agent only. The whole change is inside `#ifdef __linux__` + `#ifdef ENABLE_AUDIT`, which is enabled for `TARGET=agent` on Linux; the manager does not build `syscheckd`. Windows who-data and the eBPF provider are untouched.

### Configuration Changes

None. No new or changed `ossec.conf` options; `restart_audit` keeps its current meaning, and with it disabled the behaviour is the same as before the fix (`(6910): Audit plugin configuration was modified. You need to restart Auditd. Who-data will be disabled.`, no probing, since Auditd cannot be restarted).

### Documentation Updates

None required in this repository — no user-facing configuration changed. Worth considering separately: the who-data documentation does not mention that a distribution's audit rebuild may not accept the event format argument, nor that `-a task,never` blocks who-data on Amazon Linux 2023 and Fedora.

### Tests Introduced

`src/unit_tests/syscheckd/whodata/test_syscheck_audit.c`:

- 9 new cases for `audisp_get_candidates()`, one per version bucket — including **3.1.5, the one this issue is about** — plus unknown version, the legacy `/etc/audisp/plugins.d` directory, no plugins directory at all, and that `max` is honoured. They compare each candidate against a full copy of the expected template, rather than matching a fragment: the two argument template is a suffix of the builtin one, so a substring check cannot tell them apart and would pass on a wrong result.
- 1 new case for `set_auditd_config_template()` with an explicitly supplied configuration.
- 3 new cases for `audisp_configuration_is_known()`: the file on disk matches one of the templates, it matches none of them, and there is no file at all.
- `-Wl,--wrap,usleep` added to `SYSCHECK_AUDIT_FLAGS`. Without it the `usleep` mock was never linked, so the two timeout tests slept for real: the binary took 15.1 s of wall clock for 0.07 s of user time while still passing. It now runs in 74 ms.
- 6 new cases for `configure_and_connect_audit_socket()`: no plugins directory, a stale socket being unlinked before probing, a socket that is **not** unlinked when `restart_audit` is disabled (any unexpected `unlink` fails the test), the fallback path with its `(6054)`, every candidate failing with a single `(6636)`, and the probe carrying on after a candidate could not be applied. The function was moved out of the `LCOV_EXCL` region to make this possible.
- The 13 existing `set_auditd_config()` cases now call `set_auditd_config_template()` with the configuration the code would pick for the version each of them was mocking, and drop the `IsDir` + `auditctl -v` mocks that the new `audisp_get_candidates()` cases cover. Renamed to `test_set_auditd_config_template_*` so the names match what they exercise.
- `test_set_auditd_config_wrong_audit_version` removed: it is now covered by `test_audisp_get_candidates_no_plugins_dir`.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
