### PR TITLE
Add missing null-check for m_spDBSync in Syscollector::updateMetadataValue()

### DIFF
--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -4634,6 +4634,14 @@ bool Syscollector::getMetadataValue(const std::string& key, int64_t& value)
 
 bool Syscollector::updateMetadataValue(const std::string& key, int64_t value)
 {
+    // See getMetadataValue()'s identical guard above: init() can leave m_spDBSync null (e.g. a
+    // locked/unopenable db), and a null dereference here raises an SEH access violation on
+    // Windows, which the catch below cannot handle, and it takes the whole agent process down.
+    if (!m_spDBSync)
+    {
+        return false;
+    }
+
     auto emptyCallback = [](ReturnTypeCallback, const nlohmann::json&) {};
 
     try

--- a/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
+++ b/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp
@@ -5818,3 +5818,84 @@ TEST_F(SyscollectorImpTest, queryCommandGetVDFirstSyncCompletedIgnoresZeroTimest
 
     Syscollector::instance().destroy();
 }
+
+// Test-only access to Syscollector's private getMetadataValue()/updateMetadataValue(), without
+// modifying Syscollector itself. Naming a private member as the non-type template argument of an
+// explicit template instantiation is not access-checked at that point (a long-standing, widely
+// used C++ idiom for reaching private members from test code with zero production-code changes).
+namespace syscollector_test_access
+{
+    template <typename Tag, typename Tag::type Member>
+    struct Rob
+    {
+        friend typename Tag::type stealAccess(Tag)
+        {
+            return Member;
+        }
+    };
+
+    struct GetMetadataValueTag
+    {
+        using type = bool (Syscollector::*)(const std::string&, int64_t&);
+        friend type stealAccess(GetMetadataValueTag);
+    };
+
+    struct UpdateMetadataValueTag
+    {
+        using type = bool (Syscollector::*)(const std::string&, int64_t);
+        friend type stealAccess(UpdateMetadataValueTag);
+    };
+
+    template struct Rob<GetMetadataValueTag, &Syscollector::getMetadataValue>;
+    template struct Rob<UpdateMetadataValueTag, &Syscollector::updateMetadataValue>;
+}
+
+// init() leaves m_spDBSync null if constructing DBSync fails (e.g. an unopenable db path,
+// mirroring a locked database file in the field) -- its very first statement constructs DBSync,
+// before any member is assigned, so a throw there leaves the object in exactly that state.
+// Calling both metadata accessors directly here bypasses syncModule()/persistVDFirstSyncIfNeeded(),
+// their only two production callers -- both currently skip this path via m_stopping, but that's an
+// accidental side effect of init()'s statement order, not a deliberate safeguard.
+TEST_F(SyscollectorImpTest, updateMetadataValueNullDBSyncAfterFailedInit)
+{
+#ifdef WIN32
+    GTEST_SKIP() << "Skipping updateMetadataValueNullDBSyncAfterFailedInit test on Windows: opening "
+                 "an unopenable db path crashes the process at a lower level than a catchable "
+                 "std::exception under Wine, instead of the clean throw this test relies on";
+#endif
+    const auto spInfoWrapper {std::make_shared<MockSysInfo>()};
+    EXPECT_CALL(*spInfoWrapper, releaseThreadResources()).Times(testing::AnyNumber());
+
+    bool initThrew = false;
+
+    try
+    {
+        Syscollector::instance().init(spInfoWrapper,
+                                      reportFunction,
+                                      persistFunction,
+                                      logFunction,
+                                      "/nonexistent-dir/local.db",
+                                      "",
+                                      "",
+                                      3600, false);
+    }
+    catch (const std::exception&)
+    {
+        initThrew = true;
+    }
+
+    ASSERT_TRUE(initThrew) << "Expected DBSync construction to throw for an unopenable db path";
+
+    // Unqualified on purpose: stealAccess() is a hidden friend, only reachable via ADL on its
+    // Tag argument's namespace -- explicit qualification (syscollector_test_access::stealAccess)
+    // does not find it.
+    const auto getMetadataValuePtr = stealAccess(syscollector_test_access::GetMetadataValueTag{});
+    const auto updateMetadataValuePtr = stealAccess(syscollector_test_access::UpdateMetadataValueTag{});
+
+    int64_t value = -1;
+    // Guarded: returns false safely instead of dereferencing a null m_spDBSync.
+    EXPECT_FALSE((Syscollector::instance().*getMetadataValuePtr)("test_key", value));
+
+    // Unguarded: dereferences a null m_spDBSync -- crashes without the fix applied above.
+    EXPECT_FALSE((Syscollector::instance().*updateMetadataValuePtr)("test_key", 1));
+}


### PR DESCRIPTION
## Description

`Syscollector::updateMetadataValue()` dereferences `m_spDBSync` without checking it for null, unlike its sibling `getMetadataValue()`, which was given exactly that guard in #38312 (fix for #38203, a Windows SEH access violation). `m_spDBSync` is left null whenever `Syscollector::init()` fails to construct `DBSync` (e.g. an unopenable or locked database file) — `init()`'s very first statement constructs `DBSync`, before any member is assigned, so a throw there leaves the object in exactly that state.

This doesn't currently crash in the field: `updateMetadataValue()`'s only two callers, `syncModule()` and `persistVDFirstSyncIfNeeded()`, both bail out early whenever the module is marked as stopping, and that flag happens to stay at its default "stopping" value whenever `init()` fails — purely because `init()` clears it only after constructing `DBSync`, not before. That's an accidental side effect of statement ordering, not an intentional safeguard, and several independent, locally-reasonable future changes to either caller or to `init()` itself would each silently reopen this null-pointer crash.

Closes #38352

## Proposed Changes

- Added a null-check on `m_spDBSync` at the top of `updateMetadataValue()`, returning `false` safely instead of dereferencing a null pointer — the same pattern already used by `getMetadataValue()` and every other `m_spDBSync` consumer in this file.
- Added a unit test (`SyscollectorImpTest.updateMetadataValueNullDBSyncAfterFailedInit`) that deliberately fails `init()` (pointing it at an unopenable database path) and then calls `getMetadataValue()`/`updateMetadataValue()` directly, independent of whichever production callers currently happen to gate them. This closes the test-coverage gap explicitly called out in the issue.

## Results and Evidence

Verification procedure:
1. Deliberately failed `Syscollector::init()` by pointing it at a database path that cannot be opened, reproducing the same "left with a null `m_spDBSync`" state that a locked database file produces in the field.
2. Called `getMetadataValue()` directly on the resulting instance — confirmed it returns `false` safely (already fixed by #38312).
3. Called `updateMetadataValue()` directly on the same instance — before this fix, this dereferences the null pointer.
4. Ran the module's standard CI-mirroring test/quality pipeline (the same one `.github/workflows` runs for this module: cppcheck, style check, unit tests, coverage, Valgrind memory-leak check, AddressSanitizer) twice: once before the fix, once after.

Before the fix, the new test crashed the test binary with a real, sanitizer-caught null-pointer dereference at the exact unguarded line:

```
[ RUN      ] SyscollectorImpTest.updateMetadataValueNullDBSyncAfterFailedInit
/workspace/src/wazuh_modules/syscollector/src/syscollectorImp.cpp:4659:31: runtime error: member access within null pointer of type 'struct DBSync'
AddressSanitizer:DEADLYSIGNAL
=================================================================
==9616==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x000000ca3b7d bp 0x7ffd71759c80 sp 0x7ffd71759590 T0)
==9616==The signal is caused by a READ memory access.
==9616==Hint: address points to the zero page.
    #0 0xca3b7d in Syscollector::updateMetadataValue(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, long) /workspace/src/wazuh_modules/syscollector/src/syscollectorImp.cpp:4659
    #1 0x813539 in SyscollectorImpTest_updateMetadataValueNullDBSyncAfterFailedInit_Test::TestBody() /workspace/src/wazuh_modules/syscollector/tests/sysCollectorImp/syscollectorImp_test.cpp:5898
SUMMARY: AddressSanitizer: SEGV /workspace/src/wazuh_modules/syscollector/src/syscollectorImp.cpp:4659 in Syscollector::updateMetadataValue(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, long)
==9616==ABORTING
1/2 Test #33: syscollectorimp_unit_test ........***Failed  233.65 sec
```

All other tests in the same suite that ran before this one (77 tests, `defaultCtor` through `queryCommandGetVDFirstSyncCompletedIgnoresZeroTimestamp`) passed cleanly, confirming the crash is specific to this exact scenario and not an artifact of the test setup. The crash terminated the test binary outright, so the pipeline's test stage failed and stopped there — the later coverage/memory/sanitizer stages never ran in this pass.

After applying the fix, the full pipeline passed end-to-end, including the stages that couldn't run before:

```
[MakeTarget: PASSED]
<wazuh_modules/syscollector>[All tests: PASSED]<wazuh_modules/syscollector>
[Lines Coverage 90.1%: PASSED]
[Functions Coverage 90.1%: PASSED]
[syscollectorimp_unit_test : PASSED]
<wazuh_modules/syscollector>[Memory leak check: PASSED]<wazuh_modules/syscollector>
[ASAN: PASSED]
<wazuh_modules/syscollector>[RTR: PASSED]<wazuh_modules/syscollector>
```

No coverage regression (90.1% lines/functions, matching the pre-existing baseline for this module), and both the Valgrind memory-leak check and AddressSanitizer pass cleanly with the guard in place.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review
- Memory tests for Linux
  - [ ] Coverity
  - [x] Valgrind (memcheck and descriptor leaks check)
  - [x] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer
- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors
- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.
- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

N/A — agent-side module source and its unit tests only; no new executables, default configuration files, or packages.

### Configuration Changes

N/A

### Tests Introduced

Added `SyscollectorImpTest.updateMetadataValueNullDBSyncAfterFailedInit` to `syscollectorImp_test.cpp`. Scope: constructs `Syscollector`, deliberately fails `init()` so `m_spDBSync` is left null, then exercises `getMetadataValue()` and `updateMetadataValue()` directly — independent of `syncModule()`/`persistVDFirstSyncIfNeeded()`, the only two production callers, since both currently happen to gate this scenario off and would mask the defect if the test went through them instead. This closes the coverage gap the issue identifies: no existing test previously exercised an `init()`-failure path for either metadata accessor.

Note on platform coverage: the fix itself is plain C++ with no platform-conditional code, so the same guard runs identically on every supported platform. The new test, however, is skipped on Windows — the technique it uses to force `init()` into the failed state (pointing it at a database path that cannot be opened) does not fail cleanly there; it crashes at a lower level than a catchable exception under the Windows test environment, so the test can't set up the scenario safely on that platform. That means this specific scenario — `init()` failing and leaving `m_spDBSync` null — is verified by automated test on Linux only; Windows coverage relies on the fix being the same code path, not on direct test evidence for this platform. Low-severity, non-blocking, but worth flagging as the one real gap left by this change. 

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
