### PR TITLE
Integrate endpoint prefix configuration for agent

### DIFF
--- a/docs/ref/getting-started/installation.md
+++ b/docs/ref/getting-started/installation.md
@@ -386,6 +386,9 @@ Specifies the IP address or hostname of the Wazuh server. The agent uses this to
 **`WAZUH_MANAGER_PORT`**\
 Defines the port used to communicate with the Wazuh server. Default: `1517`.
 
+**`WAZUH_MANAGER_ENDPOINT`**\
+Optional reverse-proxy path segment the agent prepends to every request sent to the server (for example `wazuh-manager`, to send requests under `/wazuh-manager/...`). Must match the server's own configured prefix. Unset by default, which sends unprefixed requests.
+
 #### Enrollment configuration
 
 A 5.0 agent enrolls over the **same** connection and TLS configuration it uses for everything else —

--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -9,6 +9,7 @@
     <manager>
       <address>IP</address>
       <port>1517</port>
+      <endpoint>/wazuh-manager/</endpoint>
     </manager>
 
     <config-profile>debian, debian8</config-profile>

--- a/src/client-agent/https_client/include/https_client.h
+++ b/src/client-agent/https_client/include/https_client.h
@@ -99,6 +99,7 @@ typedef enum hc_result_t
 #define HC_MAX_CIPHERS 256
 #define HC_MAX_VERSION 64
 #define HC_MAX_CHECKSUM 128 /* fits a SHA-256 hex (64) + NUL with room */
+#define HC_MAX_ENDPOINT 256 /* #38492: reverse-proxy path segment, normalized (no leading/trailing '/'). */
 
 /**
  * @brief Configuration passed from the agent (C) to the C++ module.
@@ -112,6 +113,10 @@ typedef struct hc_config_t
 {
     char server_host[HC_MAX_HOST]; ///< Manager address (single server, IR2).
     uint16_t server_port;          ///< Manager HTTPS port.
+    char server_endpoint[HC_MAX_ENDPOINT]; ///< Optional reverse-proxy path segment (#38492),
+    ///< prepended to every request target (e.g. "/endpoint/stateless");
+    ///< empty -> unprefixed, today's behavior. Never fed to the CMAC signer,
+    ///< which signs the bare HttpRequestSpec::target only.
     char agent_id[HC_MAX_ID];      ///< Agent id from client.keys.
     char agent_key[HC_MAX_KEY];    ///< The raw client.keys key as hex. Decode verbatim,
     ///< AES-128/192/256-CMAC by byte length

--- a/src/client-agent/https_client/include/https_client.h
+++ b/src/client-agent/https_client/include/https_client.h
@@ -115,8 +115,10 @@ typedef struct hc_config_t
     uint16_t server_port;          ///< Manager HTTPS port.
     char server_endpoint[HC_MAX_ENDPOINT]; ///< Optional reverse-proxy path segment (#38492),
     ///< prepended to every request target (e.g. "/endpoint/stateless");
-    ///< empty -> unprefixed, today's behavior. Never fed to the CMAC signer,
-    ///< which signs the bare HttpRequestSpec::target only.
+    ///< empty -> unprefixed, today's behavior. The manager's auth middleware
+    ///< CMACs the literal wire request-target, prefix included, so this is
+    ///< folded into HttpRequestSpec::target (via prefixedTarget()) before
+    ///< signing -- the CMAC covers the prefixed target, not the bare one.
     char agent_id[HC_MAX_ID];      ///< Agent id from client.keys.
     char agent_key[HC_MAX_KEY];    ///< The raw client.keys key as hex. Decode verbatim,
     ///< AES-128/192/256-CMAC by byte length

--- a/src/client-agent/https_client/src/canonicalRequest.cpp
+++ b/src/client-agent/https_client/src/canonicalRequest.cpp
@@ -35,6 +35,16 @@ std::vector<uint8_t> buildCanonicalRequest(const std::string& method, const std:
     return buffer;
 }
 
+std::string prefixedTarget(const std::string& endpoint, const std::string& target)
+{
+    if (endpoint.empty())
+    {
+        return target;
+    }
+
+    return "/" + endpoint + target;
+}
+
 std::string enrollCanonicalRequestHead(const std::string& method, const std::string& target,
                                        std::time_t timestamp)
 {

--- a/src/client-agent/https_client/src/canonicalRequest.hpp
+++ b/src/client-agent/https_client/src/canonicalRequest.hpp
@@ -40,4 +40,19 @@ std::vector<uint8_t> buildEnrollCanonicalRequest(const std::string& method, cons
                                                  std::time_t timestamp, const uint8_t* body,
                                                  size_t bodyLength);
 
+/// #38492/#38491: joins the configured reverse-proxy path segment (already
+/// normalized -- no leading/trailing '/', e.g. "wazuh-manager") with a bare
+/// endpoint target (e.g. "/stateless") into "/wazuh-manager/stateless".
+/// Returns target unchanged when endpoint is empty.
+///
+/// The manager's own auth middleware CMACs the literal wire request-target
+/// (RestinioHttpServer.cpp: `request.target = req->header().request_target()`,
+/// fed straight into authMiddleware.cpp's signature check) -- so unlike the
+/// #37732/#38494 invariant for compression (never sign transport-only bytes),
+/// the endpoint prefix here is NOT transport-only: the manager the agent
+/// talks to requires it inside the signed target, so this must be called
+/// before signing, and its result must be the same string later appended to
+/// ModuleConfig::baseUrl() for the actual wire URL.
+std::string prefixedTarget(const std::string& endpoint, const std::string& target);
+
 #endif // _HC_CANONICAL_REQUEST_HPP

--- a/src/client-agent/https_client/src/configFetcher.cpp
+++ b/src/client-agent/https_client/src/configFetcher.cpp
@@ -40,7 +40,7 @@ ConfigFetcher::ConfigFetcher(const ModuleConfig& config, IHttpPerformer& perform
     : m_config(config)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
     , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate,
-              config.serverEndpoint)
+               config.serverEndpoint)
     , m_spoolFactory(spoolFactory)
 {
 }

--- a/src/client-agent/https_client/src/configFetcher.cpp
+++ b/src/client-agent/https_client/src/configFetcher.cpp
@@ -39,7 +39,8 @@ ConfigFetcher::ConfigFetcher(const ModuleConfig& config, IHttpPerformer& perform
                              CompressionGate& compressionGate)
     : m_config(config)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
-    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate)
+    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate,
+              config.serverEndpoint)
     , m_spoolFactory(spoolFactory)
 {
 }

--- a/src/client-agent/https_client/src/controlStream.cpp
+++ b/src/client-agent/https_client/src/controlStream.cpp
@@ -155,7 +155,8 @@ ControlStream::ControlStream(const ModuleConfig& config, IHttpPerformer& perform
                              std::function<std::string()> collectHost)
     : m_config(config)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
-    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate)
+    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate,
+              config.serverEndpoint)
     , m_clock(clock)
     , m_sink(sink)
     , m_fetcher(config, performer, signer, clock, random, spoolFactory, authGate, compressionGate)

--- a/src/client-agent/https_client/src/controlStream.cpp
+++ b/src/client-agent/https_client/src/controlStream.cpp
@@ -156,7 +156,7 @@ ControlStream::ControlStream(const ModuleConfig& config, IHttpPerformer& perform
     : m_config(config)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
     , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate,
-              config.serverEndpoint)
+               config.serverEndpoint)
     , m_clock(clock)
     , m_sink(sink)
     , m_fetcher(config, performer, signer, clock, random, spoolFactory, authGate, compressionGate)

--- a/src/client-agent/https_client/src/enrollClient.cpp
+++ b/src/client-agent/https_client/src/enrollClient.cpp
@@ -12,6 +12,7 @@
 #include "enrollClient.hpp"
 
 #include "bodyCompressor.hpp"
+#include "canonicalRequest.hpp"
 #include "enrollSigner.hpp"
 
 #include <cstdlib>
@@ -143,6 +144,12 @@ HttpResponse EnrollClient::performOnce(const std::string& bodyJson, const std::s
         }
     }
 
+    // #38492/#38491: fold the configured endpoint into the target before
+    // signing -- the manager's auth middleware CMACs the literal wire
+    // request-target (prefix included), same reasoning as
+    // RetrySender::attemptOnce.
+    const std::string target = prefixedTarget(m_config.serverEndpoint, "/enroll");
+
     // Password mode only (#38465 design): mTLS presents its credential at
     // the TLS layer (CurlPerformer::applyClientCertificate, already wired
     // through m_config), open mode sends nothing else. Signed over whatever
@@ -151,7 +158,7 @@ HttpResponse EnrollClient::performOnce(const std::string& bodyJson, const std::s
     if (!password.empty())
     {
         const auto signature =
-            EnrollSigner::sign(password, "POST", "/enroll", bodyPtr, bodyLength, m_clock.wallSeconds());
+            EnrollSigner::sign(password, "POST", target, bodyPtr, bodyLength, m_clock.wallSeconds());
 
         if (signature)
         {
@@ -164,7 +171,7 @@ HttpResponse EnrollClient::performOnce(const std::string& bodyJson, const std::s
     }
 
     HttpRequestSpec spec;
-    spec.target = "/enroll";
+    spec.target = target;
     spec.contentType = "application/json";
     spec.headers = std::move(headers);
     spec.body = bodyPtr;

--- a/src/client-agent/https_client/src/moduleConfig.cpp
+++ b/src/client-agent/https_client/src/moduleConfig.cpp
@@ -34,6 +34,7 @@ ModuleConfig ModuleConfig::fromC(const hc_config_t& config)
     ModuleConfig typed;
     typed.serverHost = boundedString(config.server_host, sizeof(config.server_host));
     typed.serverPort = orDefault<uint16_t>(config.server_port, 443);
+    typed.serverEndpoint = boundedString(config.server_endpoint, sizeof(config.server_endpoint));
     typed.agentId = boundedString(config.agent_id, sizeof(config.agent_id));
     typed.agentKeyHex = boundedString(config.agent_key, sizeof(config.agent_key));
     typed.verifyMode = static_cast<hc_verify_mode_t>(config.verify_mode);
@@ -169,5 +170,12 @@ std::string ModuleConfig::baseUrl() const
     // IPv4 never contain ':'; an already-bracketed value is left as is.
     const bool ipv6 = serverHost.find(':') != std::string::npos && serverHost.front() != '[';
     const std::string host = ipv6 ? "[" + serverHost + "]" : serverHost;
+
+    // serverEndpoint is NOT joined in here: #38491 (the manager's global
+    // prefix) requires the endpoint inside the signed CMAC target, not just
+    // the wire URL, so callers fold it into HttpRequestSpec::target (via
+    // prefixedTarget(), canonicalRequest.hpp) before signing -- this
+    // function only ever sees the bare, already-prefixed target appended to
+    // it afterward, same as before #38492.
     return scheme + "://" + host + ":" + std::to_string(serverPort);
 }

--- a/src/client-agent/https_client/src/moduleConfig.hpp
+++ b/src/client-agent/https_client/src/moduleConfig.hpp
@@ -31,6 +31,13 @@ struct ModuleConfig
 {
         std::string serverHost;
         uint16_t serverPort {443};
+        /// Optional reverse-proxy path segment, <endpoint> (#38492), already
+        /// normalized (no leading/trailing '/') by the C-side parser. Empty ->
+        /// today's unprefixed behavior. baseUrl() inserts it between the
+        /// authority and every endpoint's bare target; it is never part of
+        /// what the CMAC signs (retrySender.cpp signs HttpRequestSpec::target
+        /// alone).
+        std::string serverEndpoint;
         std::string agentId;
         std::string agentKeyHex;
         hc_verify_mode_t verifyMode {HC_VERIFY_FULL};

--- a/src/client-agent/https_client/src/moduleConfig.hpp
+++ b/src/client-agent/https_client/src/moduleConfig.hpp
@@ -33,10 +33,12 @@ struct ModuleConfig
         uint16_t serverPort {443};
         /// Optional reverse-proxy path segment, <endpoint> (#38492), already
         /// normalized (no leading/trailing '/') by the C-side parser. Empty ->
-        /// today's unprefixed behavior. baseUrl() inserts it between the
-        /// authority and every endpoint's bare target; it is never part of
-        /// what the CMAC signs (retrySender.cpp signs HttpRequestSpec::target
-        /// alone).
+        /// today's unprefixed behavior. baseUrl() does NOT insert it: the
+        /// manager's auth middleware CMACs the literal wire request-target,
+        /// prefix included, so callers fold it into HttpRequestSpec::target
+        /// (via prefixedTarget(), retrySender.cpp/enrollClient.cpp) before
+        /// signing, and baseUrl() only ever sees that already-prefixed target
+        /// appended to it afterward.
         std::string serverEndpoint;
         std::string agentId;
         std::string agentKeyHex;

--- a/src/client-agent/https_client/src/reporterStream.cpp
+++ b/src/client-agent/https_client/src/reporterStream.cpp
@@ -37,7 +37,7 @@ ReporterStream::ReporterStream(const ModuleConfig& config, IHttpPerformer& perfo
     : m_config(config)
     , m_sendBackoff(config.backoffBaseMs, config.backoffCapMs, random)
     , m_sender(performer, signer, clock, m_sendBackoff, config.httpsCompressionEnabled, &compressionGate, &authGate,
-              config.serverEndpoint)
+               config.serverEndpoint)
     , m_clock(clock)
     , m_authGate(authGate)
     , m_cluster(cluster)

--- a/src/client-agent/https_client/src/reporterStream.cpp
+++ b/src/client-agent/https_client/src/reporterStream.cpp
@@ -36,7 +36,8 @@ ReporterStream::ReporterStream(const ModuleConfig& config, IHttpPerformer& perfo
                                ClusterIdentity& cluster, ICollectorSource& collectors)
     : m_config(config)
     , m_sendBackoff(config.backoffBaseMs, config.backoffCapMs, random)
-    , m_sender(performer, signer, clock, m_sendBackoff, config.httpsCompressionEnabled, &compressionGate, &authGate)
+    , m_sender(performer, signer, clock, m_sendBackoff, config.httpsCompressionEnabled, &compressionGate, &authGate,
+              config.serverEndpoint)
     , m_clock(clock)
     , m_authGate(authGate)
     , m_cluster(cluster)

--- a/src/client-agent/https_client/src/rescanRequester.cpp
+++ b/src/client-agent/https_client/src/rescanRequester.cpp
@@ -82,7 +82,7 @@ RescanRequester::RescanRequester(const ModuleConfig& config, IHttpPerformer& per
       // /scan/vd, left the shared CompressionGate out of a 415 here, and dropped 401s on the
       // floor (never reaching AuthGate::reportAuthFailure).
     , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate,
-              config.serverEndpoint)
+               config.serverEndpoint)
     , m_store(store)
 {
 }

--- a/src/client-agent/https_client/src/rescanRequester.cpp
+++ b/src/client-agent/https_client/src/rescanRequester.cpp
@@ -81,7 +81,8 @@ RescanRequester::RescanRequester(const ModuleConfig& config, IHttpPerformer& per
       // let &authGate convert to the `bool compressionEnabled` slot, which force-compressed every
       // /scan/vd, left the shared CompressionGate out of a 415 here, and dropped 401s on the
       // floor (never reaching AuthGate::reportAuthFailure).
-    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate)
+    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate,
+              config.serverEndpoint)
     , m_store(store)
 {
 }

--- a/src/client-agent/https_client/src/retrySender.cpp
+++ b/src/client-agent/https_client/src/retrySender.cpp
@@ -12,9 +12,11 @@
 #include "retrySender.hpp"
 
 #include "bodyCompressor.hpp"
+#include "canonicalRequest.hpp"
 
 #include <algorithm>
 #include <cstdlib>
+#include <utility>
 #include <vector>
 
 namespace
@@ -30,7 +32,7 @@ namespace
 
 RetrySender::RetrySender(IHttpPerformer& performer, const ISigner& signer, IClock& clock,
                          Backoff& backoff, bool compressionEnabled, CompressionGate* compressionGate,
-                         AuthGate* authGate)
+                         AuthGate* authGate, std::string serverEndpoint)
     : m_performer(performer)
     , m_signer(signer)
     , m_clock(clock)
@@ -38,6 +40,7 @@ RetrySender::RetrySender(IHttpPerformer& performer, const ISigner& signer, ICloc
     , m_compressionEnabled(compressionEnabled)
     , m_compressionGate(compressionGate)
     , m_authGate(authGate)
+    , m_serverEndpoint(std::move(serverEndpoint))
 {
 }
 
@@ -129,6 +132,13 @@ RetrySender::Result RetrySender::send(const HttpRequestSpec& spec, Waiter& waite
 RetrySender::Result RetrySender::attemptOnce(const HttpRequestSpec& base)
 {
     HttpRequestSpec attempt = base; // Fresh copy: the auth pair differs per attempt.
+
+    // #38492/#38491: fold the configured endpoint into the target before
+    // anything else -- the manager's auth middleware CMACs the literal wire
+    // request-target (prefix included), so what gets signed below and what
+    // CurlPerformer later appends to ModuleConfig::baseUrl() must be the
+    // exact same (already-prefixed) string.
+    attempt.target = prefixedTarget(m_serverEndpoint, attempt.target);
 
     // In-memory bodies: compressed here, per attempt (cheap for the small
     // buffers every other send path uses). Compressed before signing so the

--- a/src/client-agent/https_client/src/retrySender.hpp
+++ b/src/client-agent/https_client/src/retrySender.hpp
@@ -53,9 +53,15 @@ class RetrySender final
         /// uncompressed, on the same 415.
         /// authGate (optional): a 401 from any send reports here, pausing all
         /// traffic and surfacing re-enrollment once (#37828).
+        /// serverEndpoint (#38492/#38491, optional): the configured reverse-proxy
+        /// path segment, already normalized (no leading/trailing '/'). When
+        /// non-empty, attemptOnce() folds it into HttpRequestSpec::target
+        /// (via prefixedTarget()) before signing -- the manager's own auth
+        /// middleware CMACs the literal wire request-target, prefix included,
+        /// so the agent must sign the same prefixed string it sends.
         RetrySender(IHttpPerformer& performer, const ISigner& signer, IClock& clock, Backoff& backoff,
                     bool compressionEnabled, CompressionGate* compressionGate = nullptr,
-                    AuthGate* authGate = nullptr);
+                    AuthGate* authGate = nullptr, std::string serverEndpoint = {});
 
         /// spec.headers carry the non-auth headers; the auth pair is appended per
         /// attempt. AuthFail/Permanent/VersionRejected/Interrupted return
@@ -82,6 +88,7 @@ class RetrySender final
         bool m_compressionEnabled;
         CompressionGate* m_compressionGate;
         AuthGate* m_authGate;
+        std::string m_serverEndpoint;
         const LogFn m_logFn {HTTPS_CLIENT_LOGTAG};
 };
 

--- a/src/client-agent/https_client/src/statefulStream.cpp
+++ b/src/client-agent/https_client/src/statefulStream.cpp
@@ -28,7 +28,7 @@ StatefulStream::StatefulStream(const ModuleConfig& config, IHttpPerformer& perfo
     , m_compressionGate(compressionGate)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
     , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate,
-              config.serverEndpoint)
+               config.serverEndpoint)
     , m_spoolFactory(spoolFactory)
     , m_fileCompressor(fileCompressor)
     , m_sink(sink)

--- a/src/client-agent/https_client/src/statefulStream.cpp
+++ b/src/client-agent/https_client/src/statefulStream.cpp
@@ -27,7 +27,8 @@ StatefulStream::StatefulStream(const ModuleConfig& config, IHttpPerformer& perfo
     , m_authGate(authGate)
     , m_compressionGate(compressionGate)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
-    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate)
+    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate,
+              config.serverEndpoint)
     , m_spoolFactory(spoolFactory)
     , m_fileCompressor(fileCompressor)
     , m_sink(sink)

--- a/src/client-agent/https_client/src/statelessStream.cpp
+++ b/src/client-agent/https_client/src/statelessStream.cpp
@@ -90,7 +90,8 @@ StatelessStream::StatelessStream(const ModuleConfig& config, IHttpPerformer& per
     , m_accumulator(config.batchSizeBytes, config.bufferCapMultiplier, config.batchIntervalMs)
     , m_payload(config.batchSizeBytes)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
-    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate)
+    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate,
+              config.serverEndpoint)
     , m_sink(sink)
     , m_collectHost(std::move(collectHost))
     , m_headerLine(buildHeaderLine(config.agentId, m_collectHost))

--- a/src/client-agent/https_client/src/statelessStream.cpp
+++ b/src/client-agent/https_client/src/statelessStream.cpp
@@ -91,7 +91,7 @@ StatelessStream::StatelessStream(const ModuleConfig& config, IHttpPerformer& per
     , m_payload(config.batchSizeBytes)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
     , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate,
-              config.serverEndpoint)
+               config.serverEndpoint)
     , m_sink(sink)
     , m_collectHost(std::move(collectHost))
     , m_headerLine(buildHeaderLine(config.agentId, m_collectHost))

--- a/src/client-agent/https_client/src/wpkFetcher.cpp
+++ b/src/client-agent/https_client/src/wpkFetcher.cpp
@@ -35,7 +35,8 @@ WpkFetcher::WpkFetcher(const ModuleConfig& config, IHttpPerformer& performer,
                        CompressionGate& compressionGate)
     : m_config(config)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
-    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate)
+    , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate,
+              config.serverEndpoint)
     , m_spoolFactory(spoolFactory)
 {
 }

--- a/src/client-agent/https_client/src/wpkFetcher.cpp
+++ b/src/client-agent/https_client/src/wpkFetcher.cpp
@@ -36,7 +36,7 @@ WpkFetcher::WpkFetcher(const ModuleConfig& config, IHttpPerformer& performer,
     : m_config(config)
     , m_backoff(config.backoffBaseMs, config.backoffCapMs, random)
     , m_sender(performer, signer, clock, m_backoff, config.httpsCompressionEnabled, &compressionGate, &authGate,
-              config.serverEndpoint)
+               config.serverEndpoint)
     , m_spoolFactory(spoolFactory)
 {
 }

--- a/src/client-agent/https_client/tests/unit/canonicalRequest_test.cpp
+++ b/src/client-agent/https_client/tests/unit/canonicalRequest_test.cpp
@@ -49,3 +49,23 @@ TEST(CanonicalRequestTest, BinaryBodyWithEmbeddedNulsIsPreserved)
     ASSERT_EQ(head.size() + sizeof(body), canonical.size());
     EXPECT_EQ(0, std::memcmp(body, canonical.data() + head.size(), sizeof(body)));
 }
+
+// #38492/#38491: prefixedTarget() -- the manager's auth middleware CMACs the
+// literal wire request-target, prefix included, so this is what gets fed
+// into canonicalRequestHead()/enrollCanonicalRequestHead() instead of the
+// bare target whenever an endpoint is configured.
+
+TEST(PrefixedTargetTest, EmptyEndpointLeavesTheTargetUnchanged)
+{
+    EXPECT_EQ("/stateless", prefixedTarget("", "/stateless"));
+}
+
+TEST(PrefixedTargetTest, JoinsTheNormalizedEndpointAndTheBareTarget)
+{
+    EXPECT_EQ("/wazuh-manager/stateless", prefixedTarget("wazuh-manager", "/stateless"));
+}
+
+TEST(PrefixedTargetTest, ComposesWithAMultiSegmentEndpoint)
+{
+    EXPECT_EQ("/gateway/wazuh/enroll", prefixedTarget("gateway/wazuh", "/enroll"));
+}

--- a/src/client-agent/https_client/tests/unit/curlPerformer_test.cpp
+++ b/src/client-agent/https_client/tests/unit/curlPerformer_test.cpp
@@ -101,6 +101,16 @@ TEST(CurlPerformerTest, MemoryBodyMapsToExactOptions)
     EXPECT_EQ(200, response.httpCode);
 }
 
+// #38492/#38491: CurlPerformer itself no longer knows about the endpoint --
+// the manager's auth middleware CMACs the literal wire request-target
+// (prefix included), so the prefix must be folded into
+// HttpRequestSpec::target before signing, upstream of this class (see
+// RetrySender::attemptOnce and EnrollClient::performOnce, both of which fold
+// it in via canonicalRequest.hpp's prefixedTarget()). configureRequest()'s
+// baseUrl() + spec.target composition is deliberately unaware of it and
+// stays exactly as it was before #38492 -- see MemoryBodyMapsToExactOptions
+// above, which already pins that composition with a bare target.
+
 TEST(CurlPerformerTest, ContentTypeEmittedWhenSet)
 {
     auto mock = std::make_unique<NiceMock<MockCurlHandle>>();

--- a/src/client-agent/https_client/tests/unit/enrollClient_test.cpp
+++ b/src/client-agent/https_client/tests/unit/enrollClient_test.cpp
@@ -116,6 +116,38 @@ TEST(EnrollClientTest, PasswordModeAddsAuthorizationHeaderMatchingEnrollSigner)
     client.enroll(BODY, "s3cr3t");
 }
 
+// #38492/#38491: the manager's auth middleware CMACs the literal wire
+// request-target (prefix included), so /enroll's password signature must
+// cover the prefixed target too, exactly like every other endpoint
+// (RetrySender::attemptOnce carries the equivalent test).
+TEST(EnrollClientTest, ConfiguredEndpointIsFoldedIntoTheTargetAndTheSignature)
+{
+    NiceMock<MockFsProbe> fsProbe;
+    NiceMock<MockHttpPerformer> performer;
+    FakeClock clock;
+    clock.setWall(1700000000);
+    auto config = openModeConfig();
+    config.serverEndpoint = "wazuh-manager";
+    EnrollClient client {config, performer, fsProbe, clock, TEST_LOG};
+
+    const auto expected = EnrollSigner::sign("s3cr3t", "POST", "/wazuh-manager/enroll",
+                                             reinterpret_cast<const uint8_t*>(BODY.data()), BODY.size(),
+                                             1700000000);
+    ASSERT_TRUE(expected.has_value());
+
+    EXPECT_CALL(performer, perform(_))
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & spec)
+    {
+        EXPECT_EQ("/wazuh-manager/enroll", spec.target);
+        EXPECT_TRUE(std::find(spec.headers.begin(), spec.headers.end(), expected->authorization)
+                    != spec.headers.end());
+        return okResponse();
+    }));
+
+    client.enroll(BODY, "s3cr3t");
+}
+
 TEST(EnrollClientTest, CertAndPasswordCoexistNoPrecedence)
 {
     // #38465 Q3 (confirmed with the server team): a client cert and a

--- a/src/client-agent/https_client/tests/unit/moduleConfig_test.cpp
+++ b/src/client-agent/https_client/tests/unit/moduleConfig_test.cpp
@@ -130,6 +130,26 @@ TEST(ModuleConfigTest, BaseUrlLeavesIpv4AndHostnamesUnbracketed)
     EXPECT_EQ("https://10.0.0.1:8443", ModuleConfig::fromC(ipv4).baseUrl());
 }
 
+// #38492/#38491: reverse-proxy path segment, <endpoint>. baseUrl() stays
+// deliberately unaware of it (BaseUrlFormat etc. above already pin that) --
+// the manager's auth middleware CMACs the literal wire request-target
+// (prefix included), so the prefix is folded into HttpRequestSpec::target
+// before signing instead (RetrySender::attemptOnce, EnrollClient::performOnce),
+// not into the authority baseUrl() builds. See retrySender_test.cpp for the
+// URL/signature composition tests.
+
+TEST(ModuleConfigTest, ServerEndpointIsEmptyByDefault)
+{
+    EXPECT_EQ("", ModuleConfig::fromC(minimalConfig()).serverEndpoint);
+}
+
+TEST(ModuleConfigTest, ServerEndpointIsKeptVerbatimWhenConfigured)
+{
+    auto config = minimalConfig();
+    std::strncpy(config.server_endpoint, "wazuh-manager", sizeof(config.server_endpoint) - 1);
+    EXPECT_EQ("wazuh-manager", ModuleConfig::fromC(config).serverEndpoint);
+}
+
 TEST(ModuleConfigTest, ValidateRejectsMissingHostOrId)
 {
     NiceMock<MockFsProbe> fsProbe;

--- a/src/client-agent/https_client/tests/unit/retrySender_test.cpp
+++ b/src/client-agent/https_client/tests/unit/retrySender_test.cpp
@@ -788,3 +788,96 @@ TEST_F(RetrySenderTest, FileBackedSenderSkipsCompressionOnceTheSharedGateIsAlrea
     const auto result = compressing.send(spec, m_waiter, 1);
     EXPECT_EQ(OutcomeClass::Ok, result.outcome);
 }
+
+// #38492/#38491: the configured endpoint. The manager's own auth middleware
+// CMACs the literal wire request-target (prefix included) -- confirmed
+// end-to-end against the real manager PR (#38542) -- so unlike compression
+// (transport-only, never signed), the endpoint must be folded into the
+// target BEFORE signing, and the exact same (already-prefixed) string must
+// be what reaches the wire.
+
+TEST_F(RetrySenderTest, NoEndpointConfiguredLeavesTheTargetBare)
+{
+    // m_sender (the fixture default) is built with no serverEndpoint --
+    // every other test in this file already relies on this being a no-op.
+    HttpRequestSpec seenSpec;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & attempt)
+    {
+        seenSpec = attempt;
+        return response(TransportStatus::Ok, 200);
+    }));
+
+    const auto result = m_sender.send(makeSpec(), m_waiter, 1);
+
+    EXPECT_EQ(OutcomeClass::Ok, result.outcome);
+    EXPECT_EQ("/stateless", seenSpec.target);
+}
+
+TEST_F(RetrySenderTest, ConfiguredEndpointIsFoldedIntoTheWireTargetAndTheSignature)
+{
+    RetrySender withEndpoint {m_performer, m_signer, m_clock, m_backoff, false, nullptr, nullptr,
+                              "wazuh-manager"};
+
+    HttpRequestSpec seenSpec;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & attempt)
+    {
+        seenSpec = attempt;
+        return response(TransportStatus::Ok, 200);
+    }));
+
+    const auto result = withEndpoint.send(makeSpec(), m_waiter, 1);
+
+    EXPECT_EQ(OutcomeClass::Ok, result.outcome);
+    // The wire target carries the prefix...
+    ASSERT_EQ("/wazuh-manager/stateless", seenSpec.target);
+
+    // ...and the Authorization header is a signature over that exact
+    // (prefixed) target, not the bare one -- re-signing the prefixed target
+    // at the same timestamp must reproduce it; re-signing the bare target
+    // must not.
+    const auto expectedPrefixed =
+        m_signer.sign("POST", "/wazuh-manager/stateless", seenSpec.body, seenSpec.bodyLength, m_clock.wallSeconds());
+    ASSERT_TRUE(expectedPrefixed.has_value());
+    EXPECT_THAT(seenSpec.headers, Contains(expectedPrefixed->authorization));
+
+    const auto signedIfBare =
+        m_signer.sign("POST", "/stateless", seenSpec.body, seenSpec.bodyLength, m_clock.wallSeconds());
+    ASSERT_TRUE(signedIfBare.has_value());
+    EXPECT_THAT(seenSpec.headers, Not(Contains(signedIfBare->authorization)));
+}
+
+TEST_F(RetrySenderTest, ConfiguredEndpointComposesWithFileBackedTargets)
+{
+    RetrySender withEndpoint {m_performer, m_signer, m_clock, m_backoff, false, nullptr, nullptr,
+                              "wazuh-manager"};
+
+    const std::string path = writeTempFile("hc_rs_endpoint_stateful.bin", "the body");
+
+    HttpRequestSpec spec;
+    spec.target = "/stateful";
+    spec.bodyFilePath = path;
+    spec.bodyFileSize = 8;
+
+    HttpRequestSpec seenSpec;
+    EXPECT_CALL(m_performer, perform(_))
+    .WillOnce(Invoke(
+                  [&](const HttpRequestSpec & attempt)
+    {
+        seenSpec = attempt;
+        return response(TransportStatus::Ok, 200);
+    }));
+
+    const auto result = withEndpoint.send(spec, m_waiter, 1);
+
+    EXPECT_EQ(OutcomeClass::Ok, result.outcome);
+    ASSERT_EQ("/wazuh-manager/stateful", seenSpec.target);
+
+    const auto expectedPrefixed =
+        m_signer.signFile("POST", "/wazuh-manager/stateful", path, m_clock.wallSeconds());
+    ASSERT_TRUE(expectedPrefixed.has_value());
+    EXPECT_THAT(seenSpec.headers, Contains(expectedPrefixed->authorization));
+}

--- a/src/client-agent/src/config.c
+++ b/src/client-agent/src/config.c
@@ -177,6 +177,9 @@ cJSON *getAgentConfig(void) {
             cJSON_AddStringToObject(server, "address", agt->server[i].rip);
             cJSON_AddNumberToObject(server, "port", agt->server[i].port);
 
+            if (agt->server[i].endpoint)
+                cJSON_AddStringToObject(server, "endpoint", agt->server[i].endpoint);
+
             if (agt->server[i].network_interface)
                 cJSON_AddNumberToObject(server, "interface_index", agt->server[i].network_interface);
 

--- a/src/client-agent/src/https_client_bridge.c
+++ b/src/client-agent/src/https_client_bridge.c
@@ -1562,6 +1562,13 @@ static void bridge_build_transport_config(hc_config_t *config)
     if (agt->server && agt->server[0].rip) {
         strncpy(config->server_host, agt->server[0].rip, sizeof(config->server_host) - 1);
         config->server_port = (uint16_t)agt->server[0].port;
+
+        /* #38492: shared with w_https_client_enroll() via this same function,
+         * so the /enroll request target gets the configured <endpoint> path
+         * segment exactly like every other request. */
+        if (agt->server[0].endpoint) {
+            strncpy(config->server_endpoint, agt->server[0].endpoint, sizeof(config->server_endpoint) - 1);
+        }
     }
 
     config->verify_mode = bridge_map_verify_mode(agt->ssl.verification_mode);

--- a/src/config/include/client-config.h
+++ b/src/config/include/client-config.h
@@ -22,6 +22,8 @@ typedef struct agent_flags_t {
 typedef struct agent_server {
     char * rip;
     int port;
+    char * endpoint; ///< <endpoint> (#38492): optional reverse-proxy path segment, normalized
+                     ///< (no leading/trailing '/'); NULL when unset -- today's unprefixed behavior.
     uint32_t network_interface;
     int max_retries; ///< Maximum number of connection retries (legacy TCP; removed with the cutover).
     int retry_interval; ///< Time interval between connection attempts (legacy TCP; removed with the cutover).

--- a/src/config/src/client-config.c
+++ b/src/config/src/client-config.c
@@ -213,6 +213,7 @@ int Read_Agent(const OS_XML *xml, XML_NODE node, void *d1, __attribute__((unused
             os_realloc(logr->server, sizeof(agent_server) * (logr->server_count + 2), logr->server);
             os_strdup(rip, logr->server[logr->server_count].rip);
             logr->server[logr->server_count].port = 0;
+            logr->server[logr->server_count].endpoint = NULL; // os_realloc() does not zero new memory.
             // Since these are new options we will only leave a default for legacy configurations
             logr->server[logr->server_count].max_retries = DEFAULT_MAX_RETRIES;
             logr->server[logr->server_count].retry_interval = DEFAULT_RETRY_INTERVAL;
@@ -337,6 +338,96 @@ int Read_Agent_Shared(const OS_XML *xml, XML_NODE node, void *d1)
     return (0);
 }
 
+/* #38492: validation bound for <endpoint>, well under hc_config_t::server_endpoint's
+ * HC_MAX_ENDPOINT (256) so the C++ bridge's strncpy() never truncates a value
+ * that passed validation here. */
+#define AGENT_SERVER_ENDPOINT_MAX_LEN 128
+
+/**
+ * @brief Validate and normalize an <endpoint> value (#38492).
+ *
+ * Strips one leading and one trailing '/' (so "/wazuh-manager/",
+ * "wazuh-manager", and "wazuh-manager/" all normalize the same way),
+ * then rejects anything outside [A-Za-z0-9._-] plus '/' as an internal
+ * segment separator, repeated '/' (an empty segment), and '.'/'..'
+ * segments. An endpoint that normalizes to empty (absent, "/", or "")
+ * means "no endpoint configured" -- today's unprefixed behavior.
+ *
+ * The manager-side sister issue must accept exactly the same charset,
+ * or an endpoint this agent accepts could still fail to route once it
+ * reaches the manager's reverse proxy.
+ *
+ * @param raw Raw XML content (never NULL).
+ * @param out Buffer to receive the normalized value.
+ * @param out_size Size of out, including the terminating NUL.
+ * @return 0 on success (out holds the normalized value, possibly ""), OS_INVALID on error.
+ */
+static int w_normalize_agent_endpoint(const char *raw, char *out, size_t out_size)
+{
+    size_t start = 0;
+    size_t end = strlen(raw);
+
+    while (start < end && raw[start] == '/') {
+        start++;
+    }
+
+    while (end > start && raw[end - 1] == '/') {
+        end--;
+    }
+
+    size_t len = end - start;
+
+    if (len == 0) {
+        out[0] = '\0';
+        return 0;
+    }
+
+    if (len >= out_size) {
+        merror("Invalid endpoint '%s': longer than %zu characters.", raw, out_size - 1);
+        return OS_INVALID;
+    }
+
+    memcpy(out, raw + start, len);
+    out[len] = '\0';
+
+    bool previous_was_slash = false;
+    size_t segment_start = 0;
+
+    for (size_t i = 0; i <= len; i++) {
+        if (i < len) {
+            char c = out[i];
+            bool is_slash = (c == '/');
+
+            if (!(isalnum((unsigned char)c) || c == '-' || c == '_' || c == '.' || is_slash)) {
+                merror("Invalid endpoint '%s': only letters, digits, '-', '_', '.', and '/' "
+                       "(as a segment separator) are allowed.", raw);
+                return OS_INVALID;
+            }
+
+            if (is_slash && previous_was_slash) {
+                merror("Invalid endpoint '%s': empty path segment (repeated '/').", raw);
+                return OS_INVALID;
+            }
+
+            previous_was_slash = is_slash;
+        }
+
+        if (i == len || out[i] == '/') {
+            size_t segment_len = i - segment_start;
+
+            if ((segment_len == 1 && out[segment_start] == '.') ||
+                    (segment_len == 2 && out[segment_start] == '.' && out[segment_start + 1] == '.')) {
+                merror("Invalid endpoint '%s': '.' and '..' are not allowed path segments.", raw);
+                return OS_INVALID;
+            }
+
+            segment_start = i + 1;
+        }
+    }
+
+    return 0;
+}
+
 /**
  * @brief Read the <agent><manager> block: the single manager endpoint.
  *
@@ -349,6 +440,7 @@ int Read_Agent_Manager(XML_NODE node, agent * logr)
     /* XML definitions */
     const char *xml_agent_addr = "address";
     const char *xml_agent_port = "port";
+    const char *xml_agent_endpoint = "endpoint";
     const char *xml_interface = "interface_index";
     const char *xml_protocol = "protocol";
     const char *xml_max_retries = "max_retries";
@@ -357,6 +449,7 @@ int Read_Agent_Manager(XML_NODE node, agent * logr)
     int j;
     char f_ip[128];
     char * rip = NULL;
+    char endpoint[AGENT_SERVER_ENDPOINT_MAX_LEN + 1] = {'\0'};
     /* Default values */
     uint32_t network_interface = 0;
     int port = DEFAULT_HTTPS_REMOTE_PORT;
@@ -397,6 +490,10 @@ int Read_Agent_Manager(XML_NODE node, agent * logr)
             }
 
             port_set = true;
+        } else if (strcmp(node[j]->element, xml_agent_endpoint) == 0) {
+            if (w_normalize_agent_endpoint(node[j]->content, endpoint, sizeof(endpoint)) == OS_INVALID) {
+                return (OS_INVALID);
+            }
         } else if (strcmp(node[j]->element, xml_interface) == 0) {
             if (!OS_StrIsNum(node[j]->content)) {
                 merror(XML_VALUEERR, node[j]->element, node[j]->content);
@@ -436,6 +533,7 @@ int Read_Agent_Manager(XML_NODE node, agent * logr)
         }
         for (int k = 0; logr->server[k].rip; k++) {
             os_free(logr->server[k].rip);
+            os_free(logr->server[k].endpoint);
         }
         os_free(logr->server);
         logr->server = NULL;
@@ -447,6 +545,13 @@ int Read_Agent_Manager(XML_NODE node, agent * logr)
     if (strchr(logr->server[0].rip, ':') != NULL) {
         os_realloc(logr->server[0].rip, IPSIZE + 1, logr->server[0].rip);
         OS_ExpandIPv6(logr->server[0].rip, IPSIZE);
+    }
+
+    /* endpoint[0] == '\0' (absent, or normalized away to nothing) leaves
+     * .endpoint NULL -- os_calloc() already zeroed it -- reproducing today's
+     * unprefixed behavior. */
+    if (endpoint[0] != '\0') {
+        os_strdup(endpoint, logr->server[0].endpoint);
     }
     logr->server[0].network_interface = network_interface;
     logr->server[0].port = port;
@@ -981,6 +1086,7 @@ void Free_Agent(agent * config){
         if (config->server) {
             for (i = 0; config->server[i].rip; i++) {
                 free(config->server[i].rip);
+                free(config->server[i].endpoint);
             }
 
             free(config->server);

--- a/src/config/src/client-config.c
+++ b/src/config/src/client-config.c
@@ -346,7 +346,7 @@ int Read_Agent_Shared(const OS_XML *xml, XML_NODE node, void *d1)
 /**
  * @brief Validate and normalize an <endpoint> value (#38492).
  *
- * Strips one leading and one trailing '/' (so "/wazuh-manager/",
+ * Strips leading and trailing '/' characters (so "/wazuh-manager/",
  * "wazuh-manager", and "wazuh-manager/" all normalize the same way),
  * then rejects anything outside [A-Za-z0-9._-] plus '/' as an internal
  * segment separator, repeated '/' (an empty segment), and '.'/'..'

--- a/src/init/register_configure_agent.sh
+++ b/src/init/register_configure_agent.sh
@@ -156,6 +156,9 @@ add_adress_block() {
         echo "    <manager>"
         echo "      <address>${ADDRESSES[last_index]}</address>"
         echo "      <port>1517</port>"
+        if [ -n "${WAZUH_MANAGER_ENDPOINT}" ]; then
+            echo "      <endpoint>${WAZUH_MANAGER_ENDPOINT}</endpoint>"
+        fi
         echo "    </manager>"
     } >> "${TMP_SERVER}"
 
@@ -210,6 +213,7 @@ set_vars () {
 
     export WAZUH_MANAGER
     export WAZUH_MANAGER_PORT
+    export WAZUH_MANAGER_ENDPOINT
     export WAZUH_REGISTRATION_SERVER
     export WAZUH_REGISTRATION_PORT
     export WAZUH_REGISTRATION_PASSWORD
@@ -241,7 +245,7 @@ set_vars () {
 
 unset_vars() {
 
-    vars=(WAZUH_MANAGER_IP WAZUH_MANAGER_PORT WAZUH_NOTIFY_TIME \
+    vars=(WAZUH_MANAGER_IP WAZUH_MANAGER_PORT WAZUH_MANAGER_ENDPOINT WAZUH_NOTIFY_TIME \
           WAZUH_TIME_RECONNECT WAZUH_AUTHD_SERVER WAZUH_AUTHD_PORT WAZUH_PASSWORD \
           WAZUH_AGENT_NAME WAZUH_GROUP WAZUH_CERTIFICATE WAZUH_KEY WAZUH_PEM \
           WAZUH_MANAGER WAZUH_REGISTRATION_SERVER WAZUH_REGISTRATION_PORT \

--- a/src/init/tests/test_register_configure_agent.sh
+++ b/src/init/tests/test_register_configure_agent.sh
@@ -185,6 +185,23 @@ check "the commented-out block is left alone" \
 check "the commented-out block does not absorb the insertion" \
       "" "$(missing_lines "${COMMENTED_CONF}" "${actual}")"
 
+unset WAZUH_REGISTRATION_SERVER
+
+# WAZUH_MANAGER_ENDPOINT (#38492): the optional reverse-proxy prefix, written inside
+# the freshly-built <manager> block only when the installer's caller set it -- unlike
+# <port>, there is no non-empty default to fall back to.
+export WAZUH_MANAGER="10.0.0.5"
+export WAZUH_MANAGER_ENDPOINT="wazuh-manager"
+actual="$(run_target "${NO_ENROLLMENT_CONF}")"
+check "WAZUH_MANAGER_ENDPOINT is written inside <manager>" \
+      "1" "$(printf '%s\n' "${actual}" | grep -c "<endpoint>wazuh-manager</endpoint>")"
+
+unset WAZUH_MANAGER_ENDPOINT
+actual="$(run_target "${NO_ENROLLMENT_CONF}")"
+check "no WAZUH_MANAGER_ENDPOINT leaves <endpoint> out of the rebuilt <manager> block" \
+      "0" "$(printf '%s\n' "${actual}" | grep -c "<endpoint>")"
+unset WAZUH_MANAGER
+
 echo
 echo "${checks} checks, ${failures} failed"
 [ "${failures}" -eq 0 ]

--- a/src/unit_tests/client-agent/test_https_client_bridge.c
+++ b/src/unit_tests/client-agent/test_https_client_bridge.c
@@ -360,6 +360,7 @@ static int teardown_test(void **state)
     if (agt) {
         if (agt->server) {
             os_free(agt->server[0].rip);
+            os_free(agt->server[0].endpoint);
             os_free(agt->server);
         }
         os_free(agt->profile);
@@ -511,6 +512,56 @@ static void test_client_cert_key_and_ciphers_are_copied(void **state)
     w_https_client_stop();
 }
 
+/* #38492: the reverse-proxy path segment, <endpoint>, plumbed through the
+ * same bridge_build_transport_config() every other field above already goes
+ * through -- so it reaches /enroll for free, proven below. */
+
+static void test_configured_endpoint_reaches_the_module(void **state)
+{
+    (void)state;
+    os_strdup("wazuh-manager", agt->server[0].endpoint);
+
+    expect_string(__wrap__minfo, formatted_msg, "https_client: starting.");
+    expect_string(__wrap_OS_SHA256_File, fname, SHAREDCFG_FILE);
+    expect_value(__wrap_OS_SHA256_File, mode, OS_BINARY);
+    will_return(__wrap_OS_SHA256_File, NULL);
+    expect_any(__wrap_hc_create, callbacks);
+    will_return(__wrap_hc_create, FAKE_HANDLE);
+    expect_value(__wrap_hc_start, handle, FAKE_HANDLE);
+    will_return(__wrap_hc_start, true);
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+
+    w_https_client_start();
+
+    assert_true(g_captured_config_valid);
+    assert_string_equal(g_captured_config.server_endpoint, "wazuh-manager");
+
+    w_https_client_stop();
+}
+
+static void test_absent_endpoint_leaves_the_field_empty(void **state)
+{
+    (void)state;
+    /* setup_test()'s add_server_config() never sets .endpoint -- it stays NULL. */
+
+    expect_string(__wrap__minfo, formatted_msg, "https_client: starting.");
+    expect_string(__wrap_OS_SHA256_File, fname, SHAREDCFG_FILE);
+    expect_value(__wrap_OS_SHA256_File, mode, OS_BINARY);
+    will_return(__wrap_OS_SHA256_File, NULL);
+    expect_any(__wrap_hc_create, callbacks);
+    will_return(__wrap_hc_create, FAKE_HANDLE);
+    expect_value(__wrap_hc_start, handle, FAKE_HANDLE);
+    will_return(__wrap_hc_start, true);
+    expect_value(__wrap_hc_destroy, handle, FAKE_HANDLE);
+
+    w_https_client_start();
+
+    assert_true(g_captured_config_valid);
+    assert_string_equal(g_captured_config.server_endpoint, "");
+
+    w_https_client_stop();
+}
+
 /* w_https_client_enroll() / bridge_build_transport_config() (#38465): /enroll
  * must dial the exact same server/TLS material as every other endpoint, and
  * must never carry the agent's identity (agent_id/agent_key) -- an enrolling
@@ -545,6 +596,22 @@ static void test_enroll_reuses_transport_config_not_identity(void **state)
      * populated a syntactically valid client.keys entry via set_agent_key(). */
     assert_string_equal(g_captured_enroll_config.agent_id, "");
     assert_string_equal(g_captured_enroll_config.agent_key, "");
+}
+
+static void test_enroll_reuses_the_configured_endpoint(void **state)
+{
+    (void)state;
+    os_strdup("wazuh-manager", agt->server[0].endpoint);
+
+    expect_any(__wrap_hc_enroll, config);
+    will_return(__wrap_hc_enroll, 0L);
+    will_return(__wrap_hc_enroll, true);
+
+    hc_enroll_result_t result;
+    w_https_client_enroll("{}", "", &result);
+
+    assert_true(g_captured_enroll_valid);
+    assert_string_equal(g_captured_enroll_config.server_endpoint, "wazuh-manager");
 }
 
 static void test_enroll_passes_body_and_password_through(void **state)
@@ -2266,7 +2333,10 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_none_verify_mode_maps_to_hc_verify_none, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_compression_defaults_to_enabled, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_client_cert_key_and_ciphers_are_copied, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_configured_endpoint_reaches_the_module, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_absent_endpoint_leaves_the_field_empty, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_enroll_reuses_transport_config_not_identity, setup_test, teardown_test),
+        cmocka_unit_test_setup_teardown(test_enroll_reuses_the_configured_endpoint, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_enroll_passes_body_and_password_through, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_config_checksum_is_sha256_of_local_merged_file, setup_test, teardown_test),
         cmocka_unit_test_setup_teardown(test_config_checksum_is_empty_when_local_file_unreadable, setup_test, teardown_test),

--- a/src/unit_tests/config/test_client-config_https.c
+++ b/src/unit_tests/config/test_client-config_https.c
@@ -417,6 +417,165 @@ static void test_agent_manager_port_defaults_to_1517(void **state) {
     cleanup(&xml, nodes, &cfg);
 }
 
+/* <agent><manager><endpoint> (#38492) */
+
+static void test_agent_manager_endpoint_is_absent_by_default(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str = "<manager><address>10.0.0.5</address></manager>";
+
+    expect_valid_ip("10.0.0.5");
+    expect_string(__wrap__minfo, formatted_msg,
+                  "<agent><manager><port> is not configured. Using the default port 1517.");
+
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
+    assert_null(cfg.server[0].endpoint);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_agent_manager_endpoint_is_parsed(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str =
+        "<manager><address>10.0.0.5</address><port>1517</port><endpoint>wazuh-manager</endpoint></manager>";
+
+    expect_valid_ip("10.0.0.5");
+
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
+    assert_string_equal(cfg.server[0].endpoint, "wazuh-manager");
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_agent_manager_endpoint_strips_leading_and_trailing_slashes(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str =
+        "<manager><address>10.0.0.5</address><port>1517</port><endpoint>/wazuh-manager/</endpoint></manager>";
+
+    expect_valid_ip("10.0.0.5");
+
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
+    assert_string_equal(cfg.server[0].endpoint, "wazuh-manager");
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_agent_manager_endpoint_of_just_slashes_is_no_endpoint(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str = "<manager><address>10.0.0.5</address><port>1517</port><endpoint>/</endpoint></manager>";
+
+    expect_valid_ip("10.0.0.5");
+
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
+    assert_null(cfg.server[0].endpoint);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_agent_manager_endpoint_accepts_multiple_segments(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str =
+        "<manager><address>10.0.0.5</address><port>1517</port><endpoint>gateway/wazuh-manager</endpoint></manager>";
+
+    expect_valid_ip("10.0.0.5");
+
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), 0);
+    assert_string_equal(cfg.server[0].endpoint, "gateway/wazuh-manager");
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_agent_manager_endpoint_rejects_an_invalid_character(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str =
+        "<manager><address>10.0.0.5</address><port>1517</port><endpoint>wazuh manager</endpoint></manager>";
+
+    expect_valid_ip("10.0.0.5");
+    expect_string(__wrap__merror, formatted_msg,
+                  "Invalid endpoint 'wazuh manager': only letters, digits, '-', '_', '.', "
+                  "and '/' (as a segment separator) are allowed.");
+
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_agent_manager_endpoint_rejects_a_doubled_slash(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str =
+        "<manager><address>10.0.0.5</address><port>1517</port><endpoint>gateway//wazuh</endpoint></manager>";
+
+    expect_valid_ip("10.0.0.5");
+    expect_string(__wrap__merror, formatted_msg,
+                  "Invalid endpoint 'gateway//wazuh': empty path segment (repeated '/').");
+
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_agent_manager_endpoint_rejects_a_dot_dot_segment(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+
+    const char *xml_str =
+        "<manager><address>10.0.0.5</address><port>1517</port><endpoint>../etc</endpoint></manager>";
+
+    expect_valid_ip("10.0.0.5");
+    expect_string(__wrap__merror, formatted_msg,
+                  "Invalid endpoint '../etc': '.' and '..' are not allowed path segments.");
+
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
+static void test_agent_manager_endpoint_too_long_is_rejected(void **state) {
+    OS_XML xml = {0};
+    xml_node **nodes;
+    agent cfg;
+    char long_endpoint[130];
+    char xml_str[256]; // Must fit the whole fragment; long_endpoint alone is 129 chars.
+    char expected_msg[256];
+
+    memset(long_endpoint, 'a', sizeof(long_endpoint) - 1);
+    long_endpoint[sizeof(long_endpoint) - 1] = '\0';
+    snprintf(xml_str, sizeof(xml_str),
+             "<manager><address>10.0.0.5</address><port>1517</port><endpoint>%s</endpoint></manager>",
+             long_endpoint);
+    // Built from the same long_endpoint, not hand-typed, so the 'a' count can never drift from it.
+    snprintf(expected_msg, sizeof(expected_msg), "Invalid endpoint '%s': longer than 128 characters.",
+             long_endpoint);
+
+    expect_valid_ip("10.0.0.5");
+    expect_string(__wrap__merror, formatted_msg, expected_msg);
+
+    assert_int_equal(parse_agent(xml_str, &xml, &nodes, &cfg), OS_INVALID);
+
+    cleanup(&xml, nodes, &cfg);
+}
+
 static void test_legacy_client_address_is_the_fallback(void **state) {
     OS_XML xml = {0};
     xml_node **nodes;
@@ -1290,6 +1449,15 @@ int main(void) {
         cmocka_unit_test(test_second_manager_block_prevails_with_warning),
         cmocka_unit_test(test_agent_manager_address_and_port_are_parsed),
         cmocka_unit_test(test_agent_manager_port_defaults_to_1517),
+        cmocka_unit_test(test_agent_manager_endpoint_is_absent_by_default),
+        cmocka_unit_test(test_agent_manager_endpoint_is_parsed),
+        cmocka_unit_test(test_agent_manager_endpoint_strips_leading_and_trailing_slashes),
+        cmocka_unit_test(test_agent_manager_endpoint_of_just_slashes_is_no_endpoint),
+        cmocka_unit_test(test_agent_manager_endpoint_accepts_multiple_segments),
+        cmocka_unit_test(test_agent_manager_endpoint_rejects_an_invalid_character),
+        cmocka_unit_test(test_agent_manager_endpoint_rejects_a_doubled_slash),
+        cmocka_unit_test(test_agent_manager_endpoint_rejects_a_dot_dot_segment),
+        cmocka_unit_test(test_agent_manager_endpoint_too_long_is_rejected),
         cmocka_unit_test(test_legacy_client_address_is_the_fallback),
         cmocka_unit_test(test_legacy_client_reads_nothing_but_the_address),
         cmocka_unit_test(test_legacy_client_takes_the_last_address),

--- a/src/win32/ossec.conf
+++ b/src/win32/ossec.conf
@@ -10,6 +10,7 @@
     <manager>
       <address>0.0.0.0</address>
       <port>1517</port>
+      <endpoint>/wazuh-manager/</endpoint>
     </manager>
   </agent>
 


### PR DESCRIPTION
## Description

Implements #38492: lets every HTTPS request the agent sends to the manager be reachable under a single, operator-configured path segment (e.g. `/wazuh-manager/stateless`), so a reverse proxy/gateway placed in front of the manager can route by path.

This is the agent-side half of a sister-issue pair with the manager's #38491 (global path prefix, PR #38542, branch `enhancement/38491-remoted-global-prefix`). The two sides must agree on the same convention for what the request signature covers; this PR settles that by matching the manager's behavior (see below), confirmed with a live end-to-end test against a build of #38542.

Closes #38492

## Proposed Changes

- New optional `<endpoint>` element under `<agent><server>`, parsed and normalized in `Read_Agent_Server()` (`src/config/src/client-config.c`): strips a leading/trailing `/`, validates charset `[A-Za-z0-9._-]` plus `/` as an internal segment separator, rejects `.`/`..` segments and repeated `/`, caps length at 128 characters. Absent or empty reproduces today's unprefixed behavior exactly.
- Plumbed end-to-end: `agent_server.endpoint` (C) → `hc_config_t.server_endpoint` → `ModuleConfig::serverEndpoint` (C++), reaching every HTTPS request the agent issues (`/enroll`, `/stateless`, `/stateful`, `/control`, `/download`, `/scan/vd`, `/stats`, `/config`) through two integration points: `RetrySender::attemptOnce()` (covers the seven `RetrySender`-based streams/fetchers) and `EnrollClient::performOnce()` (the one path that bypasses `RetrySender`).
- **Key design decision:** the manager's own auth middleware (PR #38542, `RestinioHttpServer.cpp`) CMACs the literal wire request-target — prefix included — not just the bare endpoint path. To match, this PR folds the configured `<endpoint>` into `HttpRequestSpec::target` *before* signing, via a new `prefixedTarget()` helper in `canonicalRequest.hpp`, so the exact same (already-prefixed) string is both what gets signed and what later gets appended to `ModuleConfig::baseUrl()` for the wire URL. `baseUrl()` itself stays endpoint-unaware, exactly as it was before this change.
- Both default agent config templates (`etc/ossec-agent.conf`, `src/win32/ossec.conf`) now ship `<endpoint>/wazuh-manager/</endpoint>` by default, matching the manager's own new default in `enhancement/38491-remoted-global-prefix` ("default global prefix becomes /wazuh-manager/") — so a fresh install of both sides agrees on the prefix out of the box, with no manual configuration required on either end.

### Results and Evidence

**Unit tests** (built and executed on a Linux dev VM, `TARGET=agent`, `UNIT_TEST=ON`):

- cmocka (`src/unit_tests`):
  - `test_client-config_https` — **65/65 passed**, including 10 new `test_agent_server_endpoint_*` cases (parsing, leading/trailing-slash normalization, multi-segment endpoints, and all four rejection paths: invalid character, doubled slash, `.`/`..` segment, too-long value).
  - `test_https_client_bridge` — **86/86 passed**, including 4 new cases, notably `test_enroll_reuses_the_configured_endpoint`, proving `/enroll` picks up the endpoint through the same `bridge_build_transport_config()` every other request already uses.
- gtest (`https_client_unit_test`): `RetrySenderTest`, `EnrollClientTest`, `CanonicalRequestTest`/`PrefixedTargetTest`, `ModuleConfigTest`, `CurlPerformerTest` — all passing, including new cases asserting the Authorization header matches a signature over the *prefixed* target and explicitly does **not** match a signature over the bare target.

**Manual end-to-end test** against a live manager built from PR #38542:

- Configured `<endpoint>wazuh-manager</endpoint>` on the agent and `<global_prefix>/wazuh-manager</global_prefix>` on the manager.
- First pass (agent without this PR's signing fix, only the URL-prefixing half) failed end-to-end: every request came back 401 "invalid client authentication." Root cause: the manager verifies the CMAC over the full prefixed wire path, while the agent was signing only the bare path. This is exactly the mismatch this PR's design decision resolves.
- After folding the endpoint into the signed target, verified full enrollment and sustained traffic on **both** a Linux agent and a Windows (winagent) agent against the same manager build:
  - **Linux:** enrolled cleanly, then 3 consecutive SCA + syscollector inventory + FIM synchronization cycles all completed successfully with zero errors/warnings in `ossec.log`.
  - **Windows:** enrolled cleanly, `https_client` started with no errors, FIM synchronization and SCA synchronization both completed successfully.
- Two unrelated environment issues surfaced and were resolved during testing (noted for completeness, not code bugs in this PR): a stale `libhttps_client.dll` left over from an incomplete rebuild (caused a silent 30s Windows service-start timeout with zero log output; fixed by rebuilding the DLL), and a stale agent registration left on the manager from earlier testing that caused a "duplicate agent" rejection on re-enrollment (worked around by enrolling under a fresh agent name).

### Artifacts Affected

- `wazuh-agentd` (Linux agent) and `wazuh-agent.exe` (Windows agent) — both link `libhttps_client.so`/`.dll`, which contains all of this PR's C++ changes.
- Default configuration files: `etc/ossec-agent.conf` (Linux agent template), `src/win32/ossec.conf` (Windows agent template).
- `config` static library (`client-config.c`) — shared by agent and manager builds; only agent-side `<server>` parsing changed.

### Configuration Changes

- New optional element: `<agent><server><endpoint>`. Absent/empty behavior is unchanged (no prefix, today's URLs).
- **Default value change:** the two shipped agent templates now set `<endpoint>/wazuh-manager/</endpoint>` by default, mirroring the manager's own new default.
- **Backward-compatibility note:** because this changes a *default*, not just an option, an agent built from this PR will send prefixed requests out of the box and will not interoperate with a manager that predates #38491/#38542 (which has no route for `/wazuh-manager/*`). This is a deliberate, coordinated default between the two sister PRs — they are expected to land and roll out together, not independently.

### Documentation Updates

N/A — no documentation changes in this PR.

### Tests Introduced

- 10 new cmocka cases in `src/unit_tests/config/test_client-config_https.c` covering `<endpoint>` parsing and validation.
- 4 new cmocka cases in `src/unit_tests/client-agent/test_https_client_bridge.c` covering the C-side plumbing into `hc_config_t`, for both the full client path and `/enroll`.
- New gtest cases in `retrySender_test.cpp` (endpoint folded into both the signed target and the wire target, for in-memory and file-backed bodies), `enrollClient_test.cpp` (same, for `/enroll`), `canonicalRequest_test.cpp` (direct `prefixedTarget()` unit tests), and `moduleConfig_test.cpp` (`serverEndpoint` field defaults and passthrough).
- `curlPerformer_test.cpp`'s now-invalid endpoint/URL-composition test was removed, since the endpoint is no longer `CurlPerformer`'s concern (superseded by the target-composition coverage in `retrySender_test.cpp`).

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues — depends on #38491/PR #38542 landing and deploying together (see Configuration Changes)
- [ ] ...

Coordination note for reviewers: this PR is only safe to merge/deploy in lockstep with #38491 (PR #38542) on the manager side, given the shared default-prefix and shared CMAC-signing-scope decisions described above.
