### PR TITLE
Allow skipping the manager connectivity check during Windows WPK upgrade for testing

### DIFF
--- a/src/win32/do_upgrade.ps1
+++ b/src/win32/do_upgrade.ps1
@@ -357,12 +357,14 @@ if ([string]::IsNullOrEmpty($server_address)) {
 
 write-output "$(Get-Date -format u) - Checking connectivity to $($server_address):$($server_port)." >> .\upgrade\upgrade.log
 
-if (-Not (probe_server $server_address $server_port)) {
+if ($env:WAZUH_UPGRADE_TEST_SKIP_MANAGER_CHECK -eq "1") {
+    write-output "$(Get-Date -format u) - Manager connectivity check skipped (test mode)." >> .\upgrade\upgrade.log
+} elseif (-Not (probe_server $server_address $server_port)) {
     write-output "$(Get-Date -format u) - Upgrade failed: the manager is not reachable at $($server_address):$($server_port), interrupting upgrade." >> .\upgrade\upgrade.log
     abort_upgrade "2"
+} else {
+    write-output "$(Get-Date -format u) - Manager reachable at $($server_address):$($server_port)." >> .\upgrade\upgrade.log
 }
-
-write-output "$(Get-Date -format u) - Manager reachable at $($server_address):$($server_port)." >> .\upgrade\upgrade.log
 
 # Ensure no other instance of msiexec is running by stopping them
 try {

--- a/src/win32/upgrade.bat
+++ b/src/win32/upgrade.bat
@@ -1,6 +1,7 @@
 @ECHO off
 
 IF "%1"=="B" GOTO background
+IF "%1"=="--skip-manager-check" SET WAZUH_UPGRADE_TEST_SKIP_MANAGER_CHECK=1
 
 COPY upgrade\upgrade.bat . > NUL
 COPY upgrade\do_upgrade.ps1 . > NUL


### PR DESCRIPTION
## Description

This PR updates the Windows agent WPK upgrade script to allow the pre-upgrade manager-reachability check to be bypassed in test mode, mirroring the equivalent fix already shipped for Linux/macOS (wazuh/wazuh#38453).

**Proposed Release:** 5.0.0
**Issue:** wazuh/wazuh-agent-packages#951
**Internal Reference:** N/A

`src/win32/do_upgrade.ps1` aborts the WPK upgrade whenever the configured manager is unreachable (`probe_server`). This check has no equivalent skip mechanism on Windows, unlike `src/init/pkg_installer.sh`, which already reads `WAZUH_UPGRADE_TEST_SKIP_MANAGER_CHECK` for exactly this purpose. As a result, the Windows WPK smoke test (which uses a placeholder, unreachable manager) always fails, while the Linux/macOS ones pass.

## Proposed Changes

- Updated `src/win32/upgrade.bat`: accepts an optional `--skip-manager-check` argument that sets `WAZUH_UPGRADE_TEST_SKIP_MANAGER_CHECK=1` before backgrounding the upgrade, inherited by the child processes down to `do_upgrade.ps1`.
- Updated `src/win32/do_upgrade.ps1`: skips the `probe_server` manager-reachability check when that variable is set to `1`, logging "Manager connectivity check skipped (test mode)." Default upgrade path (no flag) is unchanged.

### Results and Evidence

Validated end to end on the real allocator Windows VM (`windows_sign-10-amd64`), via a manual dispatch of `wazuh-agent-packages` `5_builderpackage_agent-wpk.yml` built from this branch: [run 32824570606](https://github.com/wazuh/wazuh-agent-packages/actions/runs/32824570606) - success.

Before (unpatched, from the original #951 nightly failure):

```
2026/08/22... - Checking connectivity to 1.1.1.1:1517.
2026/08/22... - Upgrade failed: the manager is not reachable at 1.1.1.1:1517, interrupting upgrade.
```

After (this branch, real VM, `upgrade.log`):

```
2026-08-25 08:10:25Z - Checking connectivity to 1.1.1.1:1517.
2026-08-25 08:10:25Z - Manager connectivity check skipped (test mode).
2026-08-25 08:10:25Z - Killed msiexec process(es).
2026-08-25 08:10:30Z - Installing MSI to: C:\Program Files (x86)\ossec-agent\ (msiexec.exe /i wazuh-agent_5.0.0-0_windows_2869294.msi APPLICATIONFOLDER="C:\Program Files (x86)\ossec-agent\" WIXUI_INSTALLDIR=APPLICATIONFOLDER REBOOT=ReallySuppress /qn /l*v installer.log)
2026-08-25 08:10:35Z - msiexec finished with exit code: 0.
2026-08-25 08:10:35Z - Extracted version from VERSION.json : 5.0.0.
2026-08-25 08:10:36Z - Installation finished.
Wazuh service is running.
Version check successful, expected version: '5.0.0'. Found version: 5.0.0
```

### Artifacts Affected

- `src/win32/upgrade.bat`
- `src/win32/do_upgrade.ps1`

### Configuration Changes

N/A

### Documentation Updates

N/A

### Tests Introduced

- **Scope:** Manual validation on the real allocator Windows VM, via the `wazuh-agent-packages` WPK smoke upgrade test.
- **Details:** Reproduced the real nightly failure (manager unreachable aborts the upgrade) and verified the fix end to end (real WPK upgrade 4.14.7 -> 5.0.0) on a real allocator VM. Full evidence above and in wazuh/wazuh-agent-packages#951.

## Review Checklist

**Manual tests with their corresponding evidence:**

- Compilation without warnings on every supported platform

  - [ ] Linux
  - [x] Windows
  - [ ] MAC OS X

- [ ] Log syntax and correct language review

- Memory tests for Linux

  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer

**General Checklist:**

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
