### PR TITLE
Allow enrolling an agent whose name matches the manager hostname over the local socket

### DIFF
--- a/src/os_auth/src/local-server.c
+++ b/src/os_auth/src/local-server.c
@@ -663,12 +663,6 @@ cJSON* local_add(const char *id,
         strncpy(_ip, ip, IPSIZE);
     }
 
-    /* Check whether the agent name is the same as the manager */
-    if (!strcmp(name, shost)) {
-        ierror = EDUPNAME;
-        goto fail;
-    }
-
     /* Check for duplicate names */
     if (index = OS_IsAllowedName(&keys, name), index >= 0) {
         os_free(str_result); // see the duplicate-ID check above


### PR DESCRIPTION
## Description

Closes #38568.

#34175 allowed enrolled agents to share the manager's hostname, but the rejection was only removed from `w_auth_validate_data()` (`auth.c`, the legacy 1515 path). The copy in `local_add()` (`local-server.c`) survived, and in 5.0.0 the HTTPS `POST /enroll` endpoint reaches authd precisely through the local socket, so a 5.x agent named like the manager — the default on any AIO, where both take the host's hostname — is rejected forever with `409 duplicate agent. Duplicate name`, with nothing logged on the manager side.

## Proposed Changes

- Remove the manager-hostname rejection from `local_add()`, aligning the local-socket add path with `w_auth_validate_data()` and the #34175 decision.

### Results and Evidence

Reproduced on a fresh 5.0.0 AIO (agent installed on the manager host, shared-password enrollment):

```
2026/08/25 09:26:20 wazuh-agentd: INFO: Started (pid: 26935).
2026/08/25 09:26:20 wazuh-agentd: INFO: Using password specified on file: etc/authd.pass
2026/08/25 09:26:20 wazuh-agentd: ERROR: Enrollment rejected by the manager: duplicate agent. Duplicate name
```

The manager keystore held 0 keys (`Loaded 0 agent key(s) from 'etc/client.keys'`) and authd logged no rejection: the failing branch is the silent `strcmp(name, shost)` check, not a real duplicate. CI results on this PR will be attached once available.

### Artifacts Affected

- `wazuh-manager-authd` (all manager platforms)

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None: `local_add()` has no direct unit-test harness (`test_local-server.c` covers only the clustered bridge). The equivalent accepted-manager-hostname case for the shared validation is already covered in `test_auth_validate.c` since #34318.

## Review Checklist
- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
