### PR TITLE
Adopt issued enrollment credentials into the remoted keystore before answering /enroll

### DIFF
--- a/src/remoted/remoted_module/src/auth/keystore.cpp
+++ b/src/remoted/remoted_module/src/auth/keystore.cpp
@@ -577,6 +577,38 @@ namespace remoted::auth
         return kReloadUnstable;
     }
 
+    bool Keystore::upsert(const std::string& id, const std::string& ip, const std::string& keyHex)
+    {
+        const auto agentId = parseAgentId(id);
+        if (!agentId)
+        {
+            return false;
+        }
+
+        auto addressRule = AddressRule::parse(ip);
+        if (!addressRule)
+        {
+            return false;
+        }
+
+        auto decoded = decodeKey(keyHex);
+        if (decoded.empty())
+        {
+            return false;
+        }
+
+        std::lock_guard<std::mutex> lock(m_mutex);
+        // The level tracks agents with a USABLE key (see agentsLoaded()); a brand-new entry and a
+        // previously key-less one both gain one here, an overwrite of a usable key changes nothing.
+        const auto it = m_keys.find(*agentId);
+        if (it == m_keys.end() || it->second.key.empty())
+        {
+            m_agentsLoaded.fetch_add(1, std::memory_order_relaxed);
+        }
+        m_keys.insert_or_assign(*agentId, AgentEntry {std::move(decoded), std::move(*addressRule)});
+        return true;
+    }
+
     std::optional<AgentLookup> Keystore::lookup(AgentId agentId, std::string_view peerIp) const
     {
         std::lock_guard<std::mutex> lock(m_mutex);

--- a/src/remoted/remoted_module/src/auth/keystore.hpp
+++ b/src/remoted/remoted_module/src/auth/keystore.hpp
@@ -122,6 +122,13 @@ namespace remoted::auth
          * unless all three parse -- an entry that cannot authenticate is not worth adopting early,
          * and the file remains the source of truth for it.
          *
+         * Known benign race: a reload that READ the file before authd wrote this entry but adopts
+         * its table after this upsert drops the entry until the next reload -- which the file
+         * change that preceded this call has already triggered. The window is the tail of one
+         * in-flight reload, strictly smaller than the reload-lag window this method removes, and
+         * it self-heals; protecting against it would mean versioning every upsert against every
+         * snapshot for no observable gain.
+         *
          * @param id     Agent id, as authd returned it (numeric string).
          * @param ip     The entry's ip column ("any", a fixed address, or a range).
          * @param keyHex The key column: lowercase hex decoding to 16, 24 or 32 bytes.

--- a/src/remoted/remoted_module/src/auth/keystore.hpp
+++ b/src/remoted/remoted_module/src/auth/keystore.hpp
@@ -106,6 +106,29 @@ namespace remoted::auth
          */
         int reload();
 
+        /**
+         * @brief Adopt one just-issued enrollment credential without waiting for a reload.
+         *
+         * The /enroll endpoint answers with a key authd has already persisted to client.keys,
+         * but this table only learns it when the watcher next adopts a stable snapshot -- and
+         * reload() deliberately refuses snapshots caught mid-write, so under enrollment churn
+         * (many agents re-enrolling, the file rewritten continuously) that can take long enough
+         * for the manager to 401 the very credential it just issued; the agent's recovery
+         * re-enrollment is then rejected as a duplicate of itself. Upserting the issued entry
+         * here closes that window. File reloads and upserts converge: authd wrote the entry
+         * before replying, so the next adopted snapshot contains it too.
+         *
+         * Columns are validated exactly like reload() validates a file line; nothing is stored
+         * unless all three parse -- an entry that cannot authenticate is not worth adopting early,
+         * and the file remains the source of truth for it.
+         *
+         * @param id     Agent id, as authd returned it (numeric string).
+         * @param ip     The entry's ip column ("any", a fixed address, or a range).
+         * @param keyHex The key column: lowercase hex decoding to 16, 24 or 32 bytes.
+         * @return true if the entry was adopted; false if any column failed to parse.
+         */
+        bool upsert(const std::string& id, const std::string& ip, const std::string& keyHex);
+
         /// reload() failure reasons. Distinguished because they need different operator messages:
         /// an unreadable file is an install/permissions problem the caller must report, while an
         /// unstable one is transient and already reported by reload() itself.

--- a/src/remoted/remoted_module/src/enrollment/enrollmentEndpoint.cpp
+++ b/src/remoted/remoted_module/src/enrollment/enrollmentEndpoint.cpp
@@ -354,6 +354,7 @@ namespace remoted::enrollment
                                             const Config& config,
                                             EnrollmentMetrics& metrics,
                                             std::shared_ptr<const remoted::decoding::IBodyDecoder> bodyDecoder,
+                                            KeyUpsertFn keyUpsert,
                                             remoted::metrics::EndpointHttpMetrics httpMetrics)
     {
         return [&authenticator,
@@ -361,6 +362,7 @@ namespace remoted::enrollment
                 config,
                 &metrics,
                 bodyDecoder = std::move(bodyDecoder),
+                keyUpsert = std::move(keyUpsert),
                 httpMetrics = std::move(httpMetrics)](std::shared_ptr<const remoted::http::HttpRequest> request,
                                                       std::shared_ptr<remoted::http::IHttpResponder> responder)
         {
@@ -443,8 +445,24 @@ namespace remoted::enrollment
             addRequest.keyHash = parsed.keyHash;
 
             authdClient.addAgent(std::move(addRequest),
-                                 [responder, &metrics](AuthdResult result)
-                                 { responder->send(mapAuthdResult(result, metrics)); });
+                                 [responder, &metrics, keyUpsert](AuthdResult result)
+                                 {
+                                     // Adopted BEFORE the 200 leaves: the agent may use the key the
+                                     // instant it has it, and this manager's own keystore must honor
+                                     // it by then -- waiting for the client.keys reload leaves a
+                                     // window where the fresh credential answers 401 and the agent's
+                                     // recovery re-enrollment collides with its own registration.
+                                     if (result.errorCode == 0 && keyUpsert &&
+                                         !keyUpsert(result.id, result.ip, result.key))
+                                     {
+                                         LOGFN_WARN(logFn(),
+                                                    "Enrolled agent %s but its credential could not be adopted into "
+                                                    "the keystore; it will authenticate after the next client.keys "
+                                                    "reload.",
+                                                    result.id.c_str());
+                                     }
+                                     responder->send(mapAuthdResult(result, metrics));
+                                 });
         };
     }
 

--- a/src/remoted/remoted_module/src/enrollment/enrollmentEndpoint.hpp
+++ b/src/remoted/remoted_module/src/enrollment/enrollmentEndpoint.hpp
@@ -20,7 +20,9 @@
 #include "metrics.hpp"
 
 #include <cstddef>
+#include <functional>
 #include <memory>
+#include <string>
 
 namespace remoted::enrollment
 {
@@ -31,6 +33,16 @@ namespace remoted::enrollment
     /// size cap on the dedicated BodyDecoder instance /enroll uses -- see makeHandler()'s doc
     /// comment on why /enroll needs its own (smaller) cap there, unlike AuthGateway's shared one.
     inline constexpr std::size_t kMaxEnrollBodySize = 16U * 1024U;
+
+    /**
+     * @brief Adopts one issued credential (id, ip column, key column) into remoted's own keystore.
+     *
+     * Wired to Keystore::upsert() by the facade. Returns whether the entry was adopted; a false is
+     * an anomaly worth logging (authd issued a credential this manager cannot parse), never a
+     * reason to fail the enrollment -- the agent's copy is valid and the keystore's file reload
+     * remains the fallback.
+     */
+    using KeyUpsertFn = std::function<bool(const std::string& id, const std::string& ip, const std::string& keyHex)>;
 
     /**
      * @brief Builds the `POST /enroll` route handler.
@@ -71,6 +83,11 @@ namespace remoted::enrollment
      * -- including the one authd's callback delivers on another thread. Defaulted, so a caller that
      * does not care (the module's own tests) counts nothing.
      *
+     * @p keyUpsert, when set, is invoked on every accepted enrollment with the id/ip/key authd
+     * answered, BEFORE the 200 is sent: the credential must be honored by the time the agent can
+     * first use it, or the file-reload lag turns the manager's own answer into a 401 (see
+     * Keystore::upsert()). Captured by value; a default-constructed one disables the step.
+     *
      * @warning The returned handler stores references to @p authenticator, @p authdClient and
      * @p metrics. The caller must guarantee all three outlive every route registered with this
      * handler, exactly like controlEndpoint::makeHandler()'s ControlHandler& contract. @p
@@ -82,6 +99,7 @@ namespace remoted::enrollment
                                             const Config& config,
                                             EnrollmentMetrics& metrics,
                                             std::shared_ptr<const remoted::decoding::IBodyDecoder> bodyDecoder,
+                                            KeyUpsertFn keyUpsert = {},
                                             remoted::metrics::EndpointHttpMetrics httpMetrics = {});
 
 } // namespace remoted::enrollment

--- a/src/remoted/remoted_module/src/remotedModuleFacade.hpp
+++ b/src/remoted/remoted_module/src/remotedModuleFacade.hpp
@@ -554,12 +554,18 @@ private:
 
         m_httpServer->addRoute(remoted::http::Method::Post,
                                "/enroll",
-                               remoted::enrollment::makeHandler(*m_enrollmentAuthenticator,
-                                                                *m_authdClient,
-                                                                enrollConfig,
-                                                                m_enrollmentMetrics,
-                                                                enrollBodyDecoder,
-                                                                m_enrollHttpMetrics));
+                               remoted::enrollment::makeHandler(
+                                   *m_enrollmentAuthenticator,
+                                   *m_authdClient,
+                                   enrollConfig,
+                                   m_enrollmentMetrics,
+                                   enrollBodyDecoder,
+                                   // Strong capture on purpose: m_httpServer (and with it every
+                                   // route) is reset before m_keystore in stop(), so this only
+                                   // extends the keystore's life until the routes are gone.
+                                   [keystore](const std::string& id, const std::string& ip, const std::string& key)
+                                   { return keystore->upsert(id, ip, key); },
+                                   m_enrollHttpMetrics));
 
         // Same sanity check the other four endpoints get (see warnIfDownstreamBudgetExceedsRequestTimeout's
         // own comment) -- /enroll's downstream is AuthdClient, not the DeferredForwarder pair those

--- a/src/remoted/remoted_module/test/unit/enrollmentEndpoint_test.cpp
+++ b/src/remoted/remoted_module/test/unit/enrollmentEndpoint_test.cpp
@@ -17,6 +17,7 @@
 #include <chrono>
 #include <condition_variable>
 #include <memory>
+#include <atomic>
 #include <mutex>
 #include <string>
 
@@ -229,7 +230,7 @@ TEST(EnrollmentEndpointTest, HttpMetricsCountEveryStatusAndTimeEveryAnswer)
         EnrollmentMetrics outcomes = makeEnrollmentMetrics(outcomeManager);
         AuthdClient authdClient(authdPath, /*isWorkerNode=*/false, /*connectTimeoutMs=*/0, 300, /*maxQueueSize=*/0);
 
-        auto handler = makeHandler(authenticator, authdClient, config, outcomes, passthroughDecoder(), http);
+        auto handler = makeHandler(authenticator, authdClient, config, outcomes, passthroughDecoder(), {}, http);
         auto request = std::make_shared<const HttpRequest>(makeRequest(body, ""));
         auto responder = std::make_shared<CapturingResponder>();
         handler(request, responder);
@@ -690,4 +691,94 @@ TEST(EnrollmentEndpointTest, AuthdUnreachableMapsTo503)
     EXPECT_EQ(response.status, 503);
     const auto j = parseBody(response);
     EXPECT_EQ(j["error"]["code"], -1);
+}
+
+// -----------------------------------------------------------------------------
+// Keystore upsert -- an accepted enrollment is adopted before the 200 is sent,
+// so the manager honors the credential the instant the agent holds it.
+// -----------------------------------------------------------------------------
+
+namespace
+{
+    // Builds a handler wired with `keyUpsert` and runs one dispatch, mirroring run() above.
+    HttpResponse runWithUpsert(const Config& config, const std::string& authdPath, KeyUpsertFn keyUpsert)
+    {
+        EnrollmentAuthenticator authenticator {EnrollmentAuthConfig {false}, nullptr};
+        wazuh::metrics::Manager metricsManager;
+        EnrollmentMetrics metrics = makeEnrollmentMetrics(metricsManager);
+
+        AuthdClient authdClient(authdPath,
+                                /*isWorkerNode=*/false,
+                                /*connectTimeoutMs=*/0,
+                                config.authdResponseTimeoutMs,
+                                /*maxQueueSize=*/0);
+
+        auto handler = makeHandler(
+            authenticator, authdClient, config, metrics, passthroughDecoder(), std::move(keyUpsert));
+
+        auto request = std::make_shared<const HttpRequest>(makeRequest(R"({"name":"agent1","version":"5.0.0"})", ""));
+        auto responder = std::make_shared<CapturingResponder>();
+        handler(request, responder);
+        return responder->wait();
+    }
+} // namespace
+
+TEST(EnrollmentEndpointTest, AcceptedEnrollmentIsUpsertedWithAuthdsIdIpAndKey)
+{
+    auto stub = fixedAuthdServer(
+        R"({"error":0,"data":{"id":"067","name":"agent1","ip":"any","key":"ab3193e717865907fc0d347fe49f854699d497e441dd7f4d4c48052334363751"}})");
+
+    std::mutex mu;
+    int calls = 0;
+    std::string id, ip, key;
+    const auto response = runWithUpsert(openModeConfig(),
+                                        stub.path,
+                                        [&](const std::string& i, const std::string& a, const std::string& k)
+                                        {
+                                            std::lock_guard<std::mutex> lock(mu);
+                                            ++calls;
+                                            id = i;
+                                            ip = a;
+                                            key = k;
+                                            return true;
+                                        });
+
+    EXPECT_EQ(response.status, 200);
+    std::lock_guard<std::mutex> lock(mu);
+    EXPECT_EQ(calls, 1);
+    EXPECT_EQ(id, "067");
+    EXPECT_EQ(ip, "any");
+    EXPECT_EQ(key, "ab3193e717865907fc0d347fe49f854699d497e441dd7f4d4c48052334363751");
+}
+
+TEST(EnrollmentEndpointTest, RejectedEnrollmentNeverReachesTheUpsert)
+{
+    auto stub = fixedAuthdServer(R"({"error":9008,"message":"ERROR: Duplicate agent name: agent1"})");
+
+    std::atomic<int> calls {0};
+    const auto response = runWithUpsert(openModeConfig(),
+                                        stub.path,
+                                        [&](const std::string&, const std::string&, const std::string&)
+                                        {
+                                            ++calls;
+                                            return true;
+                                        });
+
+    EXPECT_EQ(response.status, 409);
+    EXPECT_EQ(calls.load(), 0);
+}
+
+TEST(EnrollmentEndpointTest, UpsertFailureStillAnswers200)
+{
+    // The agent's copy of the key is valid and the file reload remains the fallback, so a keystore
+    // that cannot adopt the entry must never turn a successful enrollment into an error.
+    auto stub = fixedAuthdServer(
+        R"({"error":0,"data":{"id":"067","name":"agent1","ip":"any","key":"ab3193e717865907fc0d347fe49f854699d497e441dd7f4d4c48052334363751"}})");
+
+    const auto response = runWithUpsert(openModeConfig(),
+                                        stub.path,
+                                        [](const std::string&, const std::string&, const std::string&)
+                                        { return false; });
+
+    EXPECT_EQ(response.status, 200);
 }

--- a/src/remoted/remoted_module/test/unit/keystore_test.cpp
+++ b/src/remoted/remoted_module/test/unit/keystore_test.cpp
@@ -363,6 +363,79 @@ namespace
     }
 
     // ---------------------------------------------------------------------------
+    // upsert(): a just-issued enrollment credential is honored without a reload
+    // ---------------------------------------------------------------------------
+
+    TEST_F(KeystoreTest, UpsertMakesTheEntryVisibleToLookupImmediately)
+    {
+        Keystore keystore(m_path); // No file at all: the store starts empty.
+
+        ASSERT_TRUE(keystore.upsert("067", "any", "ab3193e717865907fc0d347fe49f854699d497e441dd7f4d4c48052334363751"));
+
+        const auto key = keyOf(keystore, 67);
+        ASSERT_TRUE(key.has_value());
+        EXPECT_EQ(key->size(), 32u);
+        EXPECT_TRUE(allowed(keystore, 67, "10.0.0.9"));
+        EXPECT_EQ(keystore.agentsLoaded(), 1u);
+    }
+
+    TEST_F(KeystoreTest, UpsertHonorsTheAddressColumn)
+    {
+        Keystore keystore(m_path);
+
+        ASSERT_TRUE(
+            keystore.upsert("067", "10.0.0.7", "ab3193e717865907fc0d347fe49f854699d497e441dd7f4d4c48052334363751"));
+
+        EXPECT_TRUE(allowed(keystore, 67, "10.0.0.7"));
+        EXPECT_FALSE(allowed(keystore, 67, "10.0.0.8"));
+    }
+
+    TEST_F(KeystoreTest, UpsertReplacesAnExistingEntry)
+    {
+        writeFile("67 agent1 any 00000000000000000000000000000000000000000000000000000000000000ff\n");
+        Keystore keystore(m_path);
+        const auto before = keyOf(keystore, 67);
+        ASSERT_TRUE(before.has_value());
+
+        ASSERT_TRUE(keystore.upsert("67", "any", "ab3193e717865907fc0d347fe49f854699d497e441dd7f4d4c48052334363751"));
+
+        const auto after = keyOf(keystore, 67);
+        ASSERT_TRUE(after.has_value());
+        EXPECT_NE(*after, *before);
+        // Overwriting a usable key does not double-count the agent.
+        EXPECT_EQ(keystore.agentsLoaded(), 1u);
+    }
+
+    TEST_F(KeystoreTest, UpsertRejectsUnparseableColumnsAndStoresNothing)
+    {
+        Keystore keystore(m_path);
+
+        EXPECT_FALSE(
+            keystore.upsert("abc", "any", "ab3193e717865907fc0d347fe49f854699d497e441dd7f4d4c48052334363751"));
+        EXPECT_FALSE(keystore.upsert(
+            "067", "not-an-address", "ab3193e717865907fc0d347fe49f854699d497e441dd7f4d4c48052334363751"));
+        EXPECT_FALSE(keystore.upsert("067", "any", "not-hex"));
+
+        EXPECT_FALSE(keystore.lookup(67, "127.0.0.1").has_value());
+        EXPECT_EQ(keystore.agentsLoaded(), 0u);
+    }
+
+    TEST_F(KeystoreTest, ReloadRemainsTheSourceOfTruthAfterAnUpsert)
+    {
+        writeFile("3824 debian10 any ab3193e717865907fc0d347fe49f854699d497e441dd7f4d4c48052334363751\n");
+        Keystore keystore(m_path);
+
+        ASSERT_TRUE(keystore.upsert("067", "any", "ab3193e717865907fc0d347fe49f854699d497e441dd7f4d4c48052334363751"));
+        ASSERT_TRUE(keyOf(keystore, 67).has_value());
+
+        // The file never held agent 67, so a reload drops it: upserts only ever bridge the gap
+        // until the next adopted snapshot, they do not fork the table away from the file.
+        EXPECT_EQ(keystore.reload(), 1);
+        EXPECT_FALSE(keyOf(keystore, 67).has_value());
+        EXPECT_TRUE(keyOf(keystore, 3824).has_value());
+    }
+
+    // ---------------------------------------------------------------------------
     // Hot-reload: background watcher (inotify + fallback poll)
     // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

Part of #38572.

A freshly enrolled agent can be rejected with `401` on the very key the manager just issued: remoted's HTTPS keystore only learns new keys from `client.keys` reloads, and under an enrollment storm the reload can lag by tens of seconds (in the reported run, no snapshot was adopted for 27 s -- watcher starvation under load; see #38572). The agent then discards the credential and re-enrolls, which authd rejects as a duplicate of itself — a permanent lockout (see #38572 for the full nightly evidence, and wazuh/wazuh-qa-automation#8708 for the original report).

## Proposed Changes

- `Keystore::upsert()`: adopt one issued credential (id, ip column, key column) directly into the in-memory table, validating each column exactly like a reloaded file line. The file remains the source of truth: the next adopted snapshot contains the same entry, so reloads and upserts converge.
- `enrollment::makeHandler()` takes an optional `KeyUpsertFn` and invokes it with authd's accepted id/ip/key before sending the 200, so the manager honors the credential by the time the agent can first use it. An upsert failure is logged and never fails the enrollment — the agent's copy is valid and the reload remains the fallback.
- The facade wires the callback to the keystore it already owns. Teardown is safe by existing order: routes are reset before the keystore in `stop()`.

### Results and Evidence

Nightly evidence in #38572: `Reloaded 0 agent key(s)` at 07:38:09, no adopted snapshot until 07:38:36, and the agent's `Valid key received` (07:38:16) answered `credential rejected (401)` at 07:38:36, followed by the `Duplicate name` lockout loop. With this change the credential is in the keystore before the agent ever holds it, removing the window regardless of reload timing. CI results will be attached once available.

### Artifacts Affected

- `wazuh-manager-remoted` (manager, all platforms)

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

- `keystore_test.cpp`: upsert visibility and address enforcement, overwrite semantics and the `agentsLoaded` level, rejection of unparseable columns, and reload remaining the source of truth after an upsert.
- `enrollmentEndpoint_test.cpp`: an accepted enrollment invokes the upsert with authd's exact id/ip/key before the response; rejections never reach it; an upsert failure still answers 200.

## Review Checklist
- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)

