### PR TITLE
Fix invalid UTF-8 event loss in engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 | Issue | Comment |
 |-------|---------|
+| [#38561](https://github.com/wazuh/wazuh/issues/38561) | Preserve events containing invalid UTF-8 by replacing invalid bytes before JSON serialization. |
 
 ### Agent
 

--- a/src/engine/source/base/src/eventParser.cpp
+++ b/src/engine/source/base/src/eventParser.cpp
@@ -18,6 +18,69 @@ namespace
 
 constexpr size_t LOCATION_OFFSET = 2; // Given the "q:" prefix.
 
+constexpr std::string_view UTF8_REPLACEMENT = "\xEF\xBF\xBD";
+
+std::string sanitizeUtf8(std::string_view input)
+{
+    std::string output;
+    output.reserve(input.size());
+
+    for (size_t i = 0; i < input.size();)
+    {
+        const auto byte = static_cast<unsigned char>(input[i]);
+        size_t length = 0;
+
+        if (byte > 0 && byte <= 0x7F)
+        {
+            length = 1;
+        }
+        else if (byte >= 0xC2 && byte <= 0xDF && i + 1 < input.size() &&
+                 (static_cast<unsigned char>(input[i + 1]) & 0xC0) == 0x80)
+        {
+            length = 2;
+        }
+        else if (byte >= 0xE0 && byte <= 0xEF && i + 2 < input.size())
+        {
+            const auto second = static_cast<unsigned char>(input[i + 1]);
+            const auto third = static_cast<unsigned char>(input[i + 2]);
+            if ((third & 0xC0) == 0x80 &&
+                ((byte == 0xE0 && second >= 0xA0 && second <= 0xBF) ||
+                 (byte == 0xED && second >= 0x80 && second <= 0x9F) ||
+                 (((byte >= 0xE1 && byte <= 0xEC) || (byte >= 0xEE && byte <= 0xEF)) &&
+                  (second & 0xC0) == 0x80)))
+            {
+                length = 3;
+            }
+        }
+        else if (byte >= 0xF0 && byte <= 0xF4 && i + 3 < input.size())
+        {
+            const auto second = static_cast<unsigned char>(input[i + 1]);
+            const auto third = static_cast<unsigned char>(input[i + 2]);
+            const auto fourth = static_cast<unsigned char>(input[i + 3]);
+            if ((third & 0xC0) == 0x80 && (fourth & 0xC0) == 0x80 &&
+                ((byte == 0xF0 && second >= 0x90 && second <= 0xBF) ||
+                 (byte == 0xF4 && second >= 0x80 && second <= 0x8F) ||
+                 (byte >= 0xF1 && byte <= 0xF3 && (second & 0xC0) == 0x80)))
+            {
+                length = 4;
+            }
+        }
+
+        if (length > 0)
+        {
+            output.append(input.substr(i, length));
+            i += length;
+        }
+        else
+        {
+            output.append(UTF8_REPLACEMENT);
+            ++i;
+        }
+    }
+
+    return output;
+}
+
 } // namespace
 
 Event parseLegacyEvent(std::string_view rawEvent, const json::Json& agentMetadata)
@@ -83,11 +146,11 @@ Event parseLegacyEvent(std::string_view rawEvent, const json::Json& agentMetadat
         throw std::runtime_error(fmt::format("Agent metadata merge failed: {}", ex.what()));
     }
 
-    parseEvent->setString(rawLocation, EVENT_LOCATION_ID);
+    parseEvent->setString(sanitizeUtf8(rawLocation), EVENT_LOCATION_ID);
 
     // Set the original event message.
     auto msgView = rawEvent.substr(separatorPos + 1);
-    parseEvent->setString(msgView, EVENT_MESSAGE_ID);
+    parseEvent->setString(sanitizeUtf8(msgView), EVENT_MESSAGE_ID);
 
     return parseEvent;
 }
@@ -113,10 +176,10 @@ Event parsePublicEvent(uint8_t queue, std::string& location, std::string_view me
         throw std::runtime_error(fmt::format("merge failed: {}", ex.what()));
     }
 
-    parseEvent->setString(location, EVENT_LOCATION_ID);
+    parseEvent->setString(sanitizeUtf8(location), EVENT_LOCATION_ID);
 
     // Raw message/payload.
-    parseEvent->setString(message, EVENT_MESSAGE_ID);
+    parseEvent->setString(sanitizeUtf8(message), EVENT_MESSAGE_ID);
 
     return parseEvent;
 }

--- a/src/engine/source/base/test/src/unit/eventParser_test.cpp
+++ b/src/engine/source/base/test/src/unit/eventParser_test.cpp
@@ -58,6 +58,10 @@ INSTANTIATE_TEST_SUITE_P(
         EventParserParam{"1:|:|:ffff|:0.0.0.0:3", R"({"agent":{"name":"test"}})", R"({"wazuh":{"protocol":{"queue":49,"location":"::ffff:0.0.0.0"}},"agent":{"name":"test"},"event":{"original":"3"}})"},
         // Empty agent metadata
         EventParserParam{"1:loc:msg", R"({})", R"({"wazuh":{"protocol":{"queue":49,"location":"loc"}},"event":{"original":"msg"}})"},
+        EventParserParam{
+            std::string("1:loc:valid") + '\0' + "X\xFF\xC0\xAF\xED\xA0\x80\x80\xC3\xA9\xE4\xB8\xAD",
+            R"({})",
+            R"({"wazuh":{"protocol":{"queue":49,"location":"loc"}},"event":{"original":"valid\uFFFDX\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFD\uFFFDé中"}})"},
         // Agent metadata with extra fields
         EventParserParam{"1:loc:msg", R"({"agent":{"name":"test"},"extra":{"field":"value"}})", R"({"wazuh":{"protocol":{"queue":49,"location":"loc"}},"agent":{"name":"test"},"extra":{"field":"value"},"event":{"original":"msg"}})"},
         // Invalid format


### PR DESCRIPTION
## Description

Closes #38561.

Invalid UTF-8 or embedded NUL bytes in a raw log could make RapidJSON serialization fail, so the indexer rejected the event and its generated alert.

## Proposed Changes

Sanitize untrusted event location and message fields at the legacy/public parser boundary. Valid UTF-8 is preserved; each invalid byte or NUL is replaced with U+FFFD before JSON serialization.

### Results and Evidence

The engine now produces valid JSON for malformed input instead of losing the event. Valid multibyte characters remain unchanged.

### Manual tests with their corresponding evidence

- [x] Linux compilation
- [x] Log syntax and correct language review
- [x] Engine unit test run
- [ ] Windows (not applicable to this Linux engine test run)
- [ ] macOS (not applicable to this Linux engine test run)
- [ ] ASAN/TSAN (left to repository CI)

Built the Wazuh base unit-test target with GCC 14 and ran the EventParser filter: 28/28 tests passed.

### Artifacts Affected

Wazuh 5.x engine event parser and indexed event JSON.

### Configuration Changes

N/A.

### Tests Introduced

A parameterized legacy-event case covers embedded NUL, invalid lead/continuation bytes, overlong and surrogate sequences, and preservation of valid two- and three-byte UTF-8.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented as N/A
- [x] Changelog updated
- [x] No unresolved dependencies with other issues