### PR TITLE
Accept obsolete 4.x Active Response and labels config instead of failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 | [#37521](https://github.com/wazuh/wazuh/issues/37521) | Fixed `GET /cluster/{node_id}/daemons/stats` always returning error 1014 for `wazuh-manager-analysisd` due to a protocol mismatch between `WazuhSocketJSON` and the engine's HTTP API socket. |
 | [#38511](https://github.com/wazuh/wazuh/issues/38511) | Fixed world-writable permissions on bundled Python files after DEB installation, caused by the permission restoration script following symlinks. |
 | [#38547](https://github.com/wazuh/wazuh/issues/38547) | Fixed the API serving its OpenAPI specification and exact version at `/openapi.json` and `/openapi.yaml` without authentication. |
+| [#38563](https://github.com/wazuh/wazuh/issues/38563) | Fixed the manager refusing to start when its configuration still carried a 4.x `<command>` (Active Response definition) or `<active-response>` block; both are now accepted with a warning instead of aborting startup or being silently ignored. `wazuh-manager-control status` also now reports the on-disk configuration as invalid after a failed restart, instead of reporting stale daemons as healthy. |
 
 ### Agent
 
@@ -139,4 +140,5 @@
 | [#38163](https://github.com/wazuh/wazuh/issues/38163) | Fixed `wazuh-agentd` crashing on start when the agent metadata segment could only be opened read-only, which happens whenever a root process creates it before the daemon drops privileges. |
 | [#38065](https://github.com/wazuh/wazuh/issues/38065) | Fixed SCA and Syscollector sync threads not blocking `SIGTERM`, which could cause the shutdown handler to run on a module thread instead of the main thread and time out joining it. |
 | [#38212](https://github.com/wazuh/wazuh/issues/38212) | Fixed the Windows agent leaving the FIM synchronization database open when the service stopped, which left the `queue\` directory behind after an uninstall without purge. |
+| [#38563](https://github.com/wazuh/wazuh/issues/38563) | Fixed a 4.x `<labels>` block aborting an agent restart without stopping the running daemons: it is now accepted with a warning, and `wazuh-control status` reports the on-disk configuration as invalid after a failed restart instead of reporting stale daemons as healthy. |
 

--- a/src/config/src/config.c
+++ b/src/config/src/config.c
@@ -30,6 +30,8 @@ static int read_main_elements(const OS_XML *xml, int modules,
     const char *osclient = "client";                            /* Agent Config  */
     const char *osbuffer = "client_buffer";                     /* Removed in 5.0.0 (#38030) */
     const char *osagent = "agent";                              /* Agent Config (HTTPS endpoint) */
+    const char *oscommand = "command";                          /* Removed in 5.0.0 (#38563) */
+    const char *oslabels = "labels";                            /* Removed in 5.0.0 (#38563) */
     const char *osactiveresponse = "active-response";           /* Agent Active Response Config  */
     const char *oswmodule = "wodle";                            /* Wodle - Wazuh Module  */
     const char *oslogging = "logging";                          /* Logging Config */
@@ -126,6 +128,19 @@ static int read_main_elements(const OS_XML *xml, int modules,
              * carrying it does not stop the agent from starting. */
             minfo("'%s' is no longer used and will be ignored. Event batching is configured "
                   "under <client><batch>.", node[i]->element);
+        } else if (strcmp(node[i]->element, oscommand) == 0) {
+            /* Accepted and ignored rather than rejected (an unknown element is
+             * fatal here), so a manager configuration carried over from 4.x
+             * with Active Response command definitions does not stop the
+             * manager from starting. */
+            mwarn("'%s' is no longer used and will be ignored. Active Response is no longer "
+                  "configured through ossec.conf.", node[i]->element);
+        } else if (strcmp(node[i]->element, oslabels) == 0) {
+            /* Accepted and ignored rather than rejected (an unknown element is
+             * fatal here), so a configuration carried over from 4.x with
+             * global label injection does not stop the daemon from starting. */
+            mwarn("'%s' is no longer used and will be ignored. Use <localfile><label key=\"...\"> "
+                  "to add labels to a specific log source instead.", node[i]->element);
         }
         else if (strcmp(node[i]->element, oswmodule) == 0) {
             if ((modules & CWMODULE) && (Read_WModule(xml, node[i], d1, d2) < 0)) {
@@ -238,7 +253,13 @@ static int read_main_elements(const OS_XML *xml, int modules,
         }
 #endif
         else if (strcmp(node[i]->element, osactiveresponse) == 0) {
-            /* Active response config is only for agents, parsed by execd */
+            /* Active response config is only for agents, parsed by execd. Warn only on the
+             * manager, where the block is accepted but has no effect: on the agent it is
+             * legitimately re-read and applied separately by ExecdConfig(). */
+#ifndef CLIENT
+            mwarn("'%s' configuration has no effect on the manager and will be ignored. Active "
+                  "Response is no longer configured through ossec.conf.", node[i]->element);
+#endif
         } else {
             merror(XML_INVELEM, node[i]->element);
             goto fail;

--- a/src/init/wazuh-client.sh
+++ b/src/init/wazuh-client.sh
@@ -107,6 +107,9 @@ status()
         if [ $? = 0 ]; then
             RETVAL=1
             echo "${i} not running..."
+        elif [ -f ${DIR}/var/run/${i}.failed ]; then
+            RETVAL=1
+            echo "${i} is running... (configuration on disk is invalid, running with previous configuration)"
         else
             echo "${i} is running..."
         fi
@@ -120,6 +123,7 @@ testconfig()
         ${DIR}/bin/${i} -t;
         if [ $? != 0 ]; then
             echo "${i}: Configuration error. Exiting"
+            touch ${DIR}/var/run/${i}.failed
             unlock;
             exit 1;
         fi
@@ -187,6 +191,7 @@ start_service()
         pstatus ${i};
         if [ $? = 0 ]; then
             failed=false
+            rm -f ${DIR}/var/run/${i}.failed
 
             if [ ! -z "$LEGACY_SYSTEMD_VERSION" ]; then
                 if command -v systemd-run >/dev/null 2>&1; then

--- a/src/init/wazuh-server.sh
+++ b/src/init/wazuh-server.sh
@@ -206,6 +206,13 @@ status()
                 echo "${i} not running..."
             fi
             RETVAL=1
+        elif [ -f ${DIR}/var/run/${i}.failed ]; then
+            if [ $USE_JSON = true ]; then
+                echo -n '{"daemon":"'${i}'","status":"running","configuration":"invalid"}'
+            else
+                echo "${i} is running... (configuration on disk is invalid, running with previous configuration)"
+            fi
+            RETVAL=1
         else
             if [ $USE_JSON = true ]; then
                 echo -n '{"daemon":"'${i}'","status":"running"}'
@@ -231,9 +238,7 @@ testconfig()
             else
                 echo "${i}: Configuration error. Exiting"
             fi
-            if [ ! -f ${DIR}/var/run/.restart ]; then
-                touch ${DIR}/var/run/${i}.failed
-            fi
+            touch ${DIR}/var/run/${i}.failed
             rm -f ${DIR}/var/run/*.start
             rm -f ${DIR}/var/run/.restart
             unlock;


### PR DESCRIPTION
## Description

Closes #38563

A manager configuration carried over from 4.x with a `<command>` block (an Active Response definition) is rejected as an invalid element and the manager does not start at all. An `<active-response>` block (a reference to one) is accepted but has no effect, and gives no indication of that. The same class of bug exists on the agent with `<labels>`: an invalid restart aborts before stopping the running daemons, and `wazuh-control status` still reports them as healthy even though the on-disk configuration was never applied.

## Proposed Changes

- `src/config/src/config.c`: `command`, `labels`, and `active-response` are now recognized as obsolete top-level elements. Instead of aborting the config parser (`command`, `labels`) or being silently discarded (`active-response` on the manager), they log a warning naming the element and stating that it no longer has an effect.
- `src/init/wazuh-server.sh`: `testconfig()` now always writes the `<daemon>.failed` marker on a failed config test, instead of only doing so on a cold `start` (it was previously skipped whenever a `restart` was in progress, which is exactly when the bug in the issue happens). `status()` checks that marker and reports the on-disk configuration as invalid instead of a plain "is running...".
- `src/init/wazuh-client.sh`: same `<daemon>.failed` marker mechanism, which did not exist here at all, added to `testconfig()`, `start_service()`, and `status()`.
- `CHANGELOG.md`: added a `Fixed` entry under Manager and under Agent.

## Results and Evidence

Reproduced on VM `indexer2` (manager at `/var/wazuh-manager`, agent at `/var/ossec`), configs backed up and restored afterward.

**Manager, `<command>` + `<active-response>` (4.x block from the issue) appended to `wazuh-manager.conf`, then `wazuh-manager-control restart`:**

```
WARNING: 'command' is no longer used and will be ignored. Active Response is no longer configured through ossec.conf.
WARNING: 'active-response' configuration has no effect on the manager and will be ignored. Active Response is no longer configured through ossec.conf.
...
Completed.
EXIT: 0
```

All 8 manager daemons report `is running...` afterward. Before the fix, the same block made `wazuh-manager-authd -t` fail with `(1230): Invalid element in the configuration: 'command'.` and the manager never started.

**Agent, `<labels>` appended to `ossec.conf`, agent already running, then `wazuh-control restart`:**

```
WARNING: 'labels' is no longer used and will be ignored. Use <localfile><label key="..."> to add labels to a specific log source instead.
...
Completed.
EXIT: 0
```

All 5 agent daemon PIDs changed after the restart. Before the fix, the restart aborted with `(1230)` before `stop_service` ran, and the old PIDs survived indefinitely (the "three restarts, sixteen minutes, nothing changed" scenario from the issue).

**`status` reporting invalid config, tested separately with a genuinely invalid element (`<totally_bogus_element/>`) so it isn't masked by the elements above no longer being fatal:**

```
ERROR: (1230): Invalid element in the configuration: 'totally_bogus_element'.
wazuh-agentd: Configuration error. Exiting
EXIT: 1

--- PIDs after restart attempt: unchanged ---
--- status ---
wazuh-agentd is running... (configuration on disk is invalid, running with previous configuration)
```

Same result reproduced on the manager. Fixing the config and restarting again clears the `.failed` marker and `status` goes back to a plain `is running...`.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
