### PR TITLE
Sanitize invalid UTF-8 before serializing events for the indexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 | [#37521](https://github.com/wazuh/wazuh/issues/37521) | Fixed `GET /cluster/{node_id}/daemons/stats` always returning error 1014 for `wazuh-manager-analysisd` due to a protocol mismatch between `WazuhSocketJSON` and the engine's HTTP API socket. |
 | [#38511](https://github.com/wazuh/wazuh/issues/38511) | Fixed world-writable permissions on bundled Python files after DEB installation, caused by the permission restoration script following symlinks. |
 | [#38547](https://github.com/wazuh/wazuh/issues/38547) | Fixed the API serving its OpenAPI specification and exact version at `/openapi.json` and `/openapi.yaml` without authentication. |
+| [#38561](https://github.com/wazuh/wazuh/issues/38561) | Fixed events with invalid UTF-8 bytes being dropped, along with their alerts, when the indexer rejected the malformed JSON the manager sent. |
 
 ### Agent
 

--- a/src/engine/source/base/include/base/json.hpp
+++ b/src/engine/source/base/include/base/json.hpp
@@ -86,6 +86,18 @@ constexpr bool RECURSIVE {true};
 constexpr bool NOT_RECURSIVE {false};
 
 /**
+ * @brief Outcome of the invalid-UTF-8 sanitization Json::str() performs. Describes the first
+ * offending field found, not every occurrence.
+ */
+struct SanitizeReport
+{
+    bool sanitized {false};      ///< True if at least one invalid UTF-8 byte sequence was replaced.
+    std::string path;            ///< Dotted path to the first offending field (e.g. "event.original").
+    unsigned char badByte {0};   ///< First offending raw byte.
+    size_t byteOffset {0};       ///< Byte offset of that byte within the field's raw value.
+};
+
+/**
  * @brief JSON document wrapper around RapidJSON.
  *
  * Provides a high-level, type-safe API for creating, querying and manipulating
@@ -687,6 +699,14 @@ public:
      * @return std::string The Json string.
      */
     std::string str() const;
+
+    /**
+     * @brief Get Json string, reporting whether invalid UTF-8 bytes had to be sanitized.
+     *
+     * @param report Set to describe the first invalid-UTF-8 field found and fixed, if any.
+     * @return std::string The Json string. Always valid, parseable JSON.
+     */
+    std::string str(SanitizeReport& report) const;
 
     /**
      * @brief Get Json string from an object.

--- a/src/engine/source/base/src/json.cpp
+++ b/src/engine/source/base/src/json.cpp
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "rapidjson/memorystream.h"
 #include "rapidjson/schema.h"
 
 #include <base/logging.hpp>
@@ -13,6 +14,107 @@ namespace
 {
 constexpr auto INVALID_POINTER_TYPE_MSG = "Invalid pointer path '{}'";
 constexpr auto PATH_NOT_FOUND_MSG = "Path '{}' not found";
+
+constexpr char UTF8_REPLACEMENT[] = "\xEF\xBF\xBD"; // UTF-8 encoding of U+FFFD
+
+struct FirstBadByte
+{
+    unsigned char value {0};
+    size_t offset {0};
+};
+
+// Replaces invalid UTF-8 (per the same rapidjson::UTF8<>::Decode() the Writer uses) with U+FFFD.
+// std::nullopt if `input` was already valid.
+std::optional<std::string> sanitizeUtf8(std::string_view input, FirstBadByte* firstBad = nullptr)
+{
+    rapidjson::MemoryStream is(input.data(), input.size());
+    std::string out;
+    out.reserve(input.size());
+    bool changed = false;
+
+    while (is.Tell() < input.size())
+    {
+        const size_t start = is.Tell();
+        unsigned codepoint = 0;
+        if (rapidjson::UTF8<>::Decode(is, &codepoint))
+        {
+            out.append(input.data() + start, is.Tell() - start);
+            continue;
+        }
+
+        if (!changed && firstBad)
+        {
+            *firstBad = FirstBadByte {static_cast<unsigned char>(input[start]), start};
+        }
+        changed = true;
+        out.append(UTF8_REPLACEMENT, sizeof(UTF8_REPLACEMENT) - 1);
+    }
+
+    return changed ? std::optional<std::string> {std::move(out)} : std::nullopt;
+}
+
+// Sanitizes every string leaf under `value`; records the first offending field's path into `report`.
+bool sanitizeInvalidUtf8(rapidjson::Value& value,
+                         rapidjson::Document::AllocatorType& alloc,
+                         std::string& pathAccum,
+                         json::SanitizeReport* report)
+{
+    bool changed = false;
+
+    if (value.IsObject())
+    {
+        for (auto it = value.MemberBegin(); it != value.MemberEnd(); ++it)
+        {
+            if (auto fixed = sanitizeUtf8({it->name.GetString(), it->name.GetStringLength()}))
+            {
+                it->name.SetString(fixed->data(), static_cast<rapidjson::SizeType>(fixed->size()), alloc);
+                changed = true;
+            }
+            const auto depth = pathAccum.size();
+            if (!pathAccum.empty())
+            {
+                pathAccum += '.';
+            }
+            pathAccum.append(it->name.GetString(), it->name.GetStringLength());
+            changed |= sanitizeInvalidUtf8(it->value, alloc, pathAccum, report);
+            pathAccum.resize(depth);
+        }
+    }
+    else if (value.IsArray())
+    {
+        rapidjson::SizeType idx = 0;
+        for (auto it = value.Begin(); it != value.End(); ++it, ++idx)
+        {
+            const auto depth = pathAccum.size();
+            if (!pathAccum.empty())
+            {
+                pathAccum += '.';
+            }
+            pathAccum += std::to_string(idx);
+            changed |= sanitizeInvalidUtf8(*it, alloc, pathAccum, report);
+            pathAccum.resize(depth);
+        }
+    }
+    else if (value.IsString())
+    {
+        FirstBadByte bad;
+        if (auto fixed = sanitizeUtf8({value.GetString(), value.GetStringLength()}, &bad))
+        {
+            value.SetString(fixed->data(), static_cast<rapidjson::SizeType>(fixed->size()), alloc);
+            changed = true;
+            if (report && !report->sanitized)
+            {
+                report->sanitized = true;
+                report->path = pathAccum;
+                report->badByte = bad.value;
+                report->byteOffset = bad.offset;
+            }
+        }
+    }
+
+    return changed;
+}
+
 } // namespace
 
 namespace json
@@ -623,9 +725,34 @@ std::string Json::prettyStr() const
 
 std::string Json::str() const
 {
+    SanitizeReport report;
+    return str(report);
+}
+
+std::string Json::str(SanitizeReport& report) const
+{
+    report = SanitizeReport {};
+
     rapidjson::StringBuffer buffer;
-    rapidjson::Writer<rapidjson::StringBuffer, rapidjson::Document::EncodingType, rapidjson::ASCII<>> writer(buffer);
-    this->m_document.Accept(writer);
+    {
+        rapidjson::Writer<rapidjson::StringBuffer, rapidjson::Document::EncodingType, rapidjson::ASCII<>> writer(
+            buffer);
+        if (m_document.Accept(writer))
+        {
+            return buffer.GetString();
+        }
+    }
+
+    // Accept() failed: invalid UTF-8 left `buffer` truncated (wazuh/wazuh#38561). Sanitize a copy and retry.
+    rapidjson::Document sanitizedDoc;
+    sanitizedDoc.CopyFrom(m_document, sanitizedDoc.GetAllocator());
+    std::string pathAccum;
+    sanitizeInvalidUtf8(sanitizedDoc, sanitizedDoc.GetAllocator(), pathAccum, &report);
+
+    buffer.Clear();
+    rapidjson::Writer<rapidjson::StringBuffer, rapidjson::Document::EncodingType, rapidjson::ASCII<>> retryWriter(
+        buffer);
+    sanitizedDoc.Accept(retryWriter); // guaranteed to succeed: every string leaf was scanned/fixed above
     return buffer.GetString();
 }
 

--- a/src/engine/source/base/test/src/unit/json_test.cpp
+++ b/src/engine/source/base/test/src/unit/json_test.cpp
@@ -758,6 +758,72 @@ TEST_F(JsonRuntime, strFromPathNestedObjects)
     ASSERT_EQ(doc.str("/D"), std::nullopt);
 }
 
+// Regression tests for wazuh/wazuh#38561: an invalid UTF-8 byte in a field must not make str() return a
+// truncated JSON fragment. It must be sanitized (replaced with U+FFFD) so the event still serializes.
+
+TEST_F(JsonRuntime, StrSanitizesInvalidUtf8AndReportsIt)
+{
+    Json doc {"{}"};
+    doc.setString(std::string {"before-\xFF"
+                               "-after"},
+                  "/event/original");
+
+    SanitizeReport report;
+    const auto out = doc.str(report);
+
+    ASSERT_TRUE(report.sanitized);
+    ASSERT_EQ(report.badByte, 0xFF);
+    ASSERT_EQ(report.byteOffset, 7u);
+    ASSERT_EQ(report.path, "event.original");
+
+    ASSERT_NO_THROW(Json reparsed {out.c_str()});
+    Json reparsed {out.c_str()};
+    std::string original;
+    ASSERT_EQ(reparsed.getString(original, "/event/original"), RetGet::Success);
+    ASSERT_EQ(original, "before-\xEF\xBF\xBD-after");
+}
+
+TEST_F(JsonRuntime, StrNoArgOverloadNeverReturnsTruncatedJson)
+{
+    Json doc {"{}"};
+    doc.setString(std::string {"before-\xFF"
+                               "-after"},
+                  "/event/original");
+
+    ASSERT_NO_THROW(Json reparsed {doc.str().c_str()});
+}
+
+// [label, shouldSanitize, raw bytes to embed in a field] -- mirrors the issue's own OK/MISSING probe table.
+using StrSanitizeCaseT = std::tuple<std::string, bool, std::string>;
+class StrSanitizeCaseTest : public ::testing::TestWithParam<StrSanitizeCaseT>
+{
+};
+
+TEST_P(StrSanitizeCaseTest, Sanitizes)
+{
+    const auto& [label, shouldSanitize, rawBytes] = GetParam();
+    Json doc {"{}"};
+    doc.setString("X" + rawBytes + "X", "/field");
+
+    SanitizeReport report;
+    const auto out = doc.str(report);
+    ASSERT_EQ(report.sanitized, shouldSanitize) << label;
+    ASSERT_NO_THROW(Json reparsed {out.c_str()}) << label;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Json,
+    StrSanitizeCaseTest,
+    ::testing::Values(StrSanitizeCaseT("clean value", false, ""),
+                       StrSanitizeCaseT("control chars", false, "\x01\x02"),
+                       StrSanitizeCaseT("DEL", false, "\x7f"),
+                       StrSanitizeCaseT("valid 2-byte utf-8", false, "\xc3\xa9"),
+                       StrSanitizeCaseT("valid 3-byte utf-8", false, "\xe4\xb8\xad"),
+                       StrSanitizeCaseT("invalid byte 0xFF", true, "\xff"),
+                       StrSanitizeCaseT("overlong encoding", true, "\xc0\xaf"),
+                       StrSanitizeCaseT("encoded surrogate", true, "\xed\xa0\x80"),
+                       StrSanitizeCaseT("lone continuation byte", true, "\x80")));
+
 /****************************************************************************************/
 // QUERY
 /****************************************************************************************/

--- a/src/engine/source/builder/src/builders/stage/indexerOutput.cpp
+++ b/src/engine/source/builder/src/builders/stage/indexerOutput.cpp
@@ -4,6 +4,9 @@
 #include <regex>
 #include <stdexcept>
 
+#include <base/logging.hpp>
+#include <fastmetrics/registry.hpp>
+
 #include "builders/utils.hpp"
 
 namespace builder::builders
@@ -98,11 +101,16 @@ base::Expression indexerOutputBuilder(const json::Json& definition,
         throw std::runtime_error("Indexer connector is not available");
     }
 
+    // Counts events whose serialized JSON contained invalid UTF-8 and had to be sanitized before
+    // indexing (see wazuh/wazuh#38561).
+    auto sanitizedCounter = fastmetrics::manager().getOrCreateCounter(fastmetrics::names::INDEXER_EVENTS_SANITIZED);
+
     return base::Term<base::EngineOp>::create(
         name,
         [indexName,
          placeholderPPVec,
          wic,
+         sanitizedCounter,
          successTrace,
          failureTrace,
          failureTrace2,
@@ -132,7 +140,22 @@ base::Expression indexerOutputBuilder(const json::Json& definition,
                 RETURN_FAILURE(isTestMode, event, fmt::format(failureTrace3, finalIndexName));
             }
 
-            wic->index(finalIndexName, event->str());
+            json::SanitizeReport sanitizeReport;
+            const auto serializedEvent = event->str(sanitizeReport);
+            if (sanitizeReport.sanitized)
+            {
+                if (sanitizedCounter)
+                {
+                    sanitizedCounter->add(1);
+                }
+                LOG_WARNING("[indexerOutput] Sanitized invalid UTF-8 byte 0x{:02X} at offset {} in field '{}' "
+                            "before indexing into '{}'; event and alert were still indexed.",
+                            sanitizeReport.badByte,
+                            sanitizeReport.byteOffset,
+                            sanitizeReport.path,
+                            finalIndexName);
+            }
+            wic->index(finalIndexName, serializedEvent);
 
             RETURN_SUCCESS(isTestMode, event, successTrace);
         });

--- a/src/engine/source/builder/test/src/unit/builders/stage/indexerOutput_test.cpp
+++ b/src/engine/source/builder/test/src/unit/builders/stage/indexerOutput_test.cpp
@@ -3,6 +3,7 @@
 #include "builders/baseBuilders_test.hpp"
 #include "builders/stage/indexerOutput.hpp"
 
+#include <fastmetrics/mockCounter.hpp>
 #include <wiconnector/mockswindexerconnector.hpp>
 
 using namespace builder::builders;
@@ -458,6 +459,51 @@ TEST_F(IndexerOutputOperationTest, validate_access_management_category)
     auto result = operation(event);
     ASSERT_TRUE(result.success());
     ASSERT_EQ(*result.payload(), *event);
+}
+
+// Regression test for wazuh/wazuh#38561: an event whose event.original contains a raw invalid UTF-8
+// byte must still be indexed (not lost), with the byte sanitized in the payload actually sent, and the
+// sanitization counted.
+TEST_F(IndexerOutputOperationTest, output_sanitizes_invalid_utf8_and_still_indexes)
+{
+    auto iConnector = std::shared_ptr<wiconnector::IWIndexerConnector>(&mockConnector, [](auto*) {});
+    auto builder = getIndexerOutputBuilder(iConnector);
+
+    EXPECT_CALL(*(mocks->ctx), isTestMode());
+
+    auto mockCounter = std::make_shared<fastmetrics::MockCounter>();
+    EXPECT_CALL(dynamic_cast<fastmetrics::MockManager&>(fastmetrics::manager()),
+                getOrCreateCounter(std::string(fastmetrics::names::INDEXER_EVENTS_SANITIZED),
+                                   ::testing::_,
+                                   ::testing::_))
+        .WillOnce(::testing::Return(mockCounter));
+    EXPECT_CALL(*mockCounter, add(1)).Times(1);
+
+    auto definition = json::Json(R"({"index": "wazuh-events-v5-applications"})");
+    auto expression = builder(definition, this->mocks->ctx);
+
+    // Raw invalid UTF-8 byte (0xFF) inside event.original, matching the reported failure mode.
+    const std::string badMessageStr {R"({"event":{"original":"bad-)"
+                                     "\xFF"
+                                     R"(-byte"}})"};
+    auto event = std::make_shared<json::Json>(badMessageStr.c_str());
+
+    auto term = expression->getPtr<base::Term<base::EngineOp>>();
+    auto operation = term->getFn();
+    ASSERT_TRUE(operation);
+
+    std::string indexedData;
+    EXPECT_CALL(mockConnector, index("wazuh-events-v5-applications", ::testing::_))
+        .WillOnce(::testing::DoAll(::testing::SaveArg<1>(&indexedData)));
+
+    auto result = operation(event);
+    ASSERT_TRUE(result.success());
+
+    ASSERT_NO_THROW(json::Json reparsed {indexedData.c_str()});
+    json::Json reparsed {indexedData.c_str()};
+    std::string original;
+    ASSERT_EQ(reparsed.getString(original, "/event/original"), json::RetGet::Success);
+    ASSERT_EQ(original.find('\xFF'), std::string::npos);
 }
 
 } // namespace indexeroutputtest

--- a/src/engine/source/fastmetrics/interface/fastmetrics/metric_names.hpp
+++ b/src/engine/source/fastmetrics/interface/fastmetrics/metric_names.hpp
@@ -15,6 +15,7 @@ constexpr auto INDEXER_QUEUE_USAGE_PERCENT = "indexer.queue.usage.percent";
 
 // Indexer event metrics
 constexpr auto INDEXER_EVENTS_DROPPED = "indexer.events.dropped";
+constexpr auto INDEXER_EVENTS_SANITIZED = "indexer.events.sanitized";
 
 // Router queue metrics
 constexpr auto ROUTER_QUEUE_SIZE = "router.queue.size";


### PR DESCRIPTION
## Description

Closes #38561.

`json::Json::str()` ignores the boolean `rapidjson::Document::Accept()` returns. When a field contains invalid UTF-8, `Accept()` fails partway through and `str()` still returns the partially-written buffer, a truncated JSON fragment. The indexer's parser hits that truncation, throws `json_e_o_f_exception`, and rejects the whole document, so the event and its alert are both lost.

## Proposed Changes

- `json::Json::str()`: on `Accept()` failure, sanitize the invalid UTF-8 (replace with U+FFFD) and retry instead of returning the truncated fragment. New `str(SanitizeReport&)` overload reports whether/where sanitization happened.
- `indexerOutput.cpp`: on sanitization, increments a new `indexer.events.sanitized` counter and logs one bounded `WARNING` (byte, offset, field, index) instead of losing the event with no trace.
- Tests covering the byte patterns from the issue (invalid byte, overlong, surrogate, lone continuation) plus the control-char/valid-multibyte cases that must not be touched, and an end-to-end test confirming a poisoned event still reaches the indexer connector.

Not covered: the NUL-byte case from the issue doesn't reproduce at this layer (`Accept()` succeeds for NUL); it has a different, upstream root cause.

### Results and Evidence

Standalone verification against the vendored rapidjson headers confirmed the failure: `Accept()` returns `false` and the buffer is left truncated for invalid-byte, overlong, surrogate, and lone-continuation sequences, matching the issue's probe results.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review
- Engine (Wazuh v5.x and above)
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)

N/A: Windows/macOS builds, Coverity/Valgrind/UMDH/Leaks, decoder/rule .ini tests (4.x), API integration tests.

### Artifacts Affected

`wazuh-manager` (engine: `base`, `builder`, `fastmetrics`).

### Configuration Changes

N/A.

### Tests Introduced

- `json_test.cpp`: StrSanitizesInvalidUtf8AndReportsIt, StrNoArgOverloadNeverReturnsTruncatedJson, StrSanitizeCaseTest (parameterized).
- `indexerOutput_test.cpp`: output_sanitizes_invalid_utf8_and_still_indexes.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented (N/A)
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...

Opened as draft pending CI validation.
