### PR TITLE
Report local sync intake unreachable as deferred instead of a hard failure

### DIFF
--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
@@ -155,11 +155,17 @@ class AgentSyncProtocol : public IAgentSyncProtocol
 
         /// @brief Bumps (or, if a stop was requested, just reads) the consecutive-failure streak
         ///        for the local sync intake being unreachable.
+        /// @param stopped Whether it was aborted because a stop was requested. Takes this as an
+        ///        already-computed parameter, mirroring trackSyncOutcome(), instead of calling
+        ///        shouldStop() again here: a second, independent read of m_stopRequested could
+        ///        observe a stop() that landed after the caller's own read, leaving the returned
+        ///        SyncModuleResult's "stopped" field and this streak disagreeing about whether one
+        ///        was in flight.
         /// @return Consecutive checkStatus() failures in a row, including this one.
         ///
         /// Separate from @ref m_consecutiveSyncFailures: this fires before the handshake is even
         /// attempted, and that counter is reserved for outcomes that reach it.
-        unsigned int trackLocalTransportFailure();
+        unsigned int trackLocalTransportFailure(bool stopped);
 
         /// @brief Waits for agent metadata to become available - indefinitely,
         ///        unless a stop is requested - then builds the Start table into

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol.hpp
@@ -153,6 +153,14 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         /// A stop-induced abort leaves the streak untouched: it reports nothing about the manager.
         unsigned int trackSyncOutcome(bool success, bool stopped);
 
+        /// @brief Bumps (or, if a stop was requested, just reads) the consecutive-failure streak
+        ///        for the local sync intake being unreachable.
+        /// @return Consecutive checkStatus() failures in a row, including this one.
+        ///
+        /// Separate from @ref m_consecutiveSyncFailures: this fires before the handshake is even
+        /// attempted, and that counter is reserved for outcomes that reach it.
+        unsigned int trackLocalTransportFailure();
+
         /// @brief Waits for agent metadata to become available - indefinitely,
         ///        unless a stop is requested - then builds the Start table into
         ///        an existing FlatBuffer builder. Owns the metadata lifetime end
@@ -353,6 +361,13 @@ class AgentSyncProtocol : public IAgentSyncProtocol
         /// managerNotReady is a manager-wide condition: a real success means the manager is ready, and
         /// resetting the streak on it is correct regardless of which flow observed it.
         std::atomic<unsigned int> m_consecutiveSyncFailures{0};
+
+        /// @brief Consecutive checkStatus() failures in a row, reset the moment it succeeds again.
+        ///
+        /// Deliberately not @ref m_consecutiveSyncFailures: this measures failures to reach the
+        /// local sync intake, which happens before any handshake is attempted, so it says nothing
+        /// about the manager and must not share a counter that is reserved for outcomes that do.
+        std::atomic<unsigned int> m_consecutiveLocalTransportFailures{0};
 
         /// Built-in ceiling on one session, used until a daemon calls setSessionMaxBytes()
         /// with what <agent><batch><size> says. Same 1 MiB the HTTPS transport applies to

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface_types.h
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_c_interface_types.h
@@ -52,6 +52,9 @@ typedef struct SyncModuleResult_t
     /// first (assigned groups, or a VD feed offset) has not arrived yet. See
     /// SyncModuleResult::awaitingPrerequisite (agent_sync_protocol_types.hpp) for the full doc.
     bool awaiting_prerequisite;
+    /// @brief True when the local sync intake itself could not be reached. See
+    /// SyncModuleResult::localTransportUnavailable (agent_sync_protocol_types.hpp) for the full doc.
+    bool local_transport_unavailable;
 } SyncModuleResult_t;
 
 /// @brief Defines the type of modification operation.

--- a/src/shared_modules/sync_protocol/include/agent_sync_protocol_types.hpp
+++ b/src/shared_modules/sync_protocol/include/agent_sync_protocol_types.hpp
@@ -56,4 +56,10 @@ struct SyncModuleResult
     /// since it is expected and normally clears within the next cycle or two (e.g. right after
     /// an agent restart, before the first /control round trip completes).
     bool awaitingPrerequisite{false};
+    /// @brief True when the local sync intake itself could not be reached (wazuh-agentd's
+    /// https_client not done starting yet). Deliberately distinct from @ref managerNotReady: this
+    /// never got far enough to hear anything from the manager, so it must not be described as a
+    /// manager-side condition. Same idea as managerNotReady otherwise -- use it together with
+    /// @ref consecutiveFailures to tell a restart hiccup from a lasting local problem.
+    bool localTransportUnavailable{false};
 };

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -155,8 +155,19 @@ SyncModuleResult AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
         // Propagate the reason so the calling module emits a single, informative message at the
         // right level (WARNING on a real failure, INFO "aborted" during shutdown). The transport
         // itself only logs the low-level detail at debug.
-        return {false, "Failed to reach the sync intake socket.", shouldStop()};
+        //
+        // Reported as localTransportUnavailable, not managerNotReady: nothing was sent, so this
+        // says nothing about the manager. It shares the same restart-hiccup-vs-lasting-problem
+        // shape (the module started before wazuh-agentd's https_client finished binding
+        // queue/sockets/queue-sync), but on its own dedicated streak: this never reaches the
+        // handshake, and m_consecutiveSyncFailures is reserved for outcomes that do (see its doc).
+        return {false, "Failed to reach the sync intake socket.", shouldStop(), false,
+                trackLocalTransportFailure(), false, true};
     }
+
+    // Reaching past the check above means the local transport is currently available; whatever
+    // streak of failures to reach it was building has ended.
+    m_consecutiveLocalTransportFailures.store(0, std::memory_order_relaxed);
 
     // Guard against concurrent calls. The timer thread and the AsyncFlushController
     // background thread may both call this method on the same instance. When a sync is
@@ -332,7 +343,7 @@ SyncModuleResult AgentSyncProtocol::synchronizeDeltaByBlocks(Option option)
     const bool stopped = shouldStop();
     const unsigned int consecutiveFailures = trackSyncOutcome(success, stopped);
     clearSyncState();
-    return {success, std::move(failureReason), stopped, managerNotReady, consecutiveFailures, awaitingPrerequisite};
+    return {success, std::move(failureReason), stopped, managerNotReady, consecutiveFailures, awaitingPrerequisite, false};
 }
 
 unsigned int AgentSyncProtocol::trackSyncOutcome(bool success, bool stopped)
@@ -351,6 +362,18 @@ unsigned int AgentSyncProtocol::trackSyncOutcome(bool success, bool stopped)
     }
 
     return m_consecutiveSyncFailures.fetch_add(1, std::memory_order_relaxed) + 1;
+}
+
+unsigned int AgentSyncProtocol::trackLocalTransportFailure()
+{
+    // Mirrors trackSyncOutcome()'s stopped guard: a stop in progress says nothing about the local
+    // transport itself, so it must not count towards this streak either.
+    if (shouldStop())
+    {
+        return m_consecutiveLocalTransportFailures.load(std::memory_order_relaxed);
+    }
+
+    return m_consecutiveLocalTransportFailures.fetch_add(1, std::memory_order_relaxed) + 1;
 }
 
 bool AgentSyncProtocol::requiresFullSync(const std::string& index,
@@ -452,8 +475,19 @@ SyncModuleResult AgentSyncProtocol::synchronizeMetadataOrGroups(Mode mode,
         // Propagate the reason so the calling module emits a single, informative message at the
         // right level (WARNING on a real failure, INFO "aborted" during shutdown). The transport
         // itself only logs the low-level detail at debug.
-        return {false, "Failed to reach the sync intake socket.", shouldStop()};
+        //
+        // Reported as localTransportUnavailable, not managerNotReady: nothing was sent, so this
+        // says nothing about the manager. It shares the same restart-hiccup-vs-lasting-problem
+        // shape (the module started before wazuh-agentd's https_client finished binding
+        // queue/sockets/queue-sync), but on its own dedicated streak: this never reaches the
+        // handshake, and m_consecutiveSyncFailures is reserved for outcomes that do (see its doc).
+        return {false, "Failed to reach the sync intake socket.", shouldStop(), false,
+                trackLocalTransportFailure(), false, true};
     }
+
+    // Reaching past the check above means the local transport is currently available; whatever
+    // streak of failures to reach it was building has ended.
+    m_consecutiveLocalTransportFailures.store(0, std::memory_order_relaxed);
 
     clearSyncState();
 
@@ -499,7 +533,7 @@ SyncModuleResult AgentSyncProtocol::synchronizeMetadataOrGroups(Mode mode,
     const bool stopped = shouldStop();
     const unsigned int consecutiveFailures = trackSyncOutcome(success, stopped);
     clearSyncState();
-    return {success, std::move(failureReason), stopped, managerNotReady, consecutiveFailures, awaitingPrerequisite};
+    return {success, std::move(failureReason), stopped, managerNotReady, consecutiveFailures, awaitingPrerequisite, false};
 }
 
 bool AgentSyncProtocol::notifyDataClean(const std::vector<std::string>& indices,

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol.cpp
@@ -152,6 +152,11 @@ SyncModuleResult AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
 
     if (!m_syncTransport->checkStatus())
     {
+        // Single read, reused below: trackLocalTransportFailure() must see the same "stopped" this
+        // result reports, or a stop() landing between two separate shouldStop() calls could leave
+        // the two disagreeing (see trackLocalTransportFailure()'s doc).
+        const bool stopped = shouldStop();
+
         // Propagate the reason so the calling module emits a single, informative message at the
         // right level (WARNING on a real failure, INFO "aborted" during shutdown). The transport
         // itself only logs the low-level detail at debug.
@@ -161,8 +166,8 @@ SyncModuleResult AgentSyncProtocol::synchronizeModule(Mode mode, Option option)
         // shape (the module started before wazuh-agentd's https_client finished binding
         // queue/sockets/queue-sync), but on its own dedicated streak: this never reaches the
         // handshake, and m_consecutiveSyncFailures is reserved for outcomes that do (see its doc).
-        return {false, "Failed to reach the sync intake socket.", shouldStop(), false,
-                trackLocalTransportFailure(), false, true};
+        return {false, "Failed to reach the sync intake socket.", stopped, false,
+                trackLocalTransportFailure(stopped), false, true};
     }
 
     // Reaching past the check above means the local transport is currently available; whatever
@@ -364,11 +369,14 @@ unsigned int AgentSyncProtocol::trackSyncOutcome(bool success, bool stopped)
     return m_consecutiveSyncFailures.fetch_add(1, std::memory_order_relaxed) + 1;
 }
 
-unsigned int AgentSyncProtocol::trackLocalTransportFailure()
+unsigned int AgentSyncProtocol::trackLocalTransportFailure(bool stopped)
 {
-    // Mirrors trackSyncOutcome()'s stopped guard: a stop in progress says nothing about the local
-    // transport itself, so it must not count towards this streak either.
-    if (shouldStop())
+    // Takes stopped as an already-computed parameter, mirroring trackSyncOutcome(): a stop in
+    // progress says nothing about the local transport itself, so it must not count towards this
+    // streak either. Reading shouldStop() again here (instead of reusing the caller's read) would
+    // race the single m_stopRequested load against a concurrent stop() -- the caller's "stopped"
+    // field and this streak could then disagree on whether a stop was in flight.
+    if (stopped)
     {
         return m_consecutiveLocalTransportFailures.load(std::memory_order_relaxed);
     }
@@ -472,6 +480,11 @@ SyncModuleResult AgentSyncProtocol::synchronizeMetadataOrGroups(Mode mode,
 
     if (!m_syncTransport->checkStatus())
     {
+        // Single read, reused below: trackLocalTransportFailure() must see the same "stopped" this
+        // result reports, or a stop() landing between two separate shouldStop() calls could leave
+        // the two disagreeing (see trackLocalTransportFailure()'s doc).
+        const bool stopped = shouldStop();
+
         // Propagate the reason so the calling module emits a single, informative message at the
         // right level (WARNING on a real failure, INFO "aborted" during shutdown). The transport
         // itself only logs the low-level detail at debug.
@@ -481,8 +494,8 @@ SyncModuleResult AgentSyncProtocol::synchronizeMetadataOrGroups(Mode mode,
         // shape (the module started before wazuh-agentd's https_client finished binding
         // queue/sockets/queue-sync), but on its own dedicated streak: this never reaches the
         // handshake, and m_consecutiveSyncFailures is reserved for outcomes that do (see its doc).
-        return {false, "Failed to reach the sync intake socket.", shouldStop(), false,
-                trackLocalTransportFailure(), false, true};
+        return {false, "Failed to reach the sync intake socket.", stopped, false,
+                trackLocalTransportFailure(stopped), false, true};
     }
 
     // Reaching past the check above means the local transport is currently available; whatever

--- a/src/shared_modules/sync_protocol/src/agent_sync_protocol_c_interface.cpp
+++ b/src/shared_modules/sync_protocol/src/agent_sync_protocol_c_interface.cpp
@@ -111,6 +111,8 @@ extern "C" {
 
             cResult.awaiting_prerequisite = cppResult.awaitingPrerequisite;
 
+            cResult.local_transport_unavailable = cppResult.localTransportUnavailable;
+
             return cResult;
         }
         catch (const std::exception& ex)
@@ -209,6 +211,8 @@ extern "C" {
             cResult.consecutive_failures = cppResult.consecutiveFailures;
 
             cResult.awaiting_prerequisite = cppResult.awaitingPrerequisite;
+
+            cResult.local_transport_unavailable = cppResult.localTransportUnavailable;
 
             return cResult;
         }

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -237,6 +237,57 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleTransportFailureReportsLocalTrans
     EXPECT_EQ(second.consecutiveFailures, 2U);
 }
 
+// Regression guard for a race trackLocalTransportFailure() used to have: it called shouldStop()
+// itself instead of taking the caller's already-computed value, so a stop() landing between the
+// caller's read (for the "stopped" field) and trackLocalTransportFailure()'s own read could leave
+// the two disagreeing -- stopped=false in the result, but the streak silently not incremented
+// (the internal read saw the stop and skipped the bump). A background thread hammers
+// stop()/reset() throughout to make that window likely to be hit at least once; with the caller's
+// single read now threaded through as a parameter, the two can no longer disagree regardless of
+// timing, so this passes deterministically post-fix and would fail intermittently pre-fix.
+TEST_F(AgentSyncProtocolTest, SynchronizeModuleStoppedAndStreakStayConsistentUnderConcurrentStop)
+{
+    mockQueue = std::make_shared<MockPersistentQueue>();
+
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
+    mockSyncTransport->setAvailable(false);
+
+    std::atomic<bool> keepToggling {true};
+    std::thread toggler(
+        [&]()
+    {
+        while (keepToggling.load(std::memory_order_relaxed))
+        {
+            protocol->stop();
+            protocol->reset();
+        }
+    });
+
+    unsigned int previousFailures = 0;
+    constexpr int ITERATIONS = 20000;
+
+    for (int i = 0; i < ITERATIONS; ++i)
+    {
+        const SyncModuleResult result = protocol->synchronizeModule(Mode::DELTA);
+
+        if (!result.stopped)
+        {
+            // Not reported as a shutdown-time abort, so this attempt must have been counted: the
+            // streak has to have grown. A streak that failed to grow here is exactly the
+            // inconsistency the pre-fix double read could produce.
+            EXPECT_GT(result.consecutiveFailures, previousFailures)
+                    << "iteration " << i << ": stopped=false but the local-transport-failure "
+                    "streak did not grow.";
+            previousFailures = result.consecutiveFailures;
+        }
+    }
+
+    keepToggling.store(false, std::memory_order_relaxed);
+    toggler.join();
+    protocol->reset();
+}
+
 // Exercises the C interface (asp_sync_module -> SyncModuleResult_t.stopped): this is the path
 // FIM depends on to distinguish a shutdown-aborted sync from a genuine failure.
 TEST_F(AgentSyncProtocolTest, CInterfacePropagatesStoppedFlag)

--- a/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
+++ b/src/shared_modules/sync_protocol/tests/test_agent_sync_protocol.cpp
@@ -196,7 +196,9 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleReportsStoppedWhenStopRequested)
 }
 
 // A local transport failure is not a "manager not ready yet" condition, so it must not be reported as
-// manager-not-ready: the calling module keeps it at WARNING.
+// manager-not-ready -- nothing was sent, so this says nothing about the manager. It is reported via
+// localTransportUnavailable instead (see SynchronizeModuleTransportFailureReportsLocalTransportUnavailable),
+// which the calling module demotes to INFO the same way, just under a distinct, accurate label.
 TEST_F(AgentSyncProtocolTest, SynchronizeModuleDoesNotReportTransientOnTransportFailure)
 {
     mockQueue = std::make_shared<MockPersistentQueue>();
@@ -211,6 +213,28 @@ TEST_F(AgentSyncProtocolTest, SynchronizeModuleDoesNotReportTransientOnTransport
 
     EXPECT_FALSE(result.success);
     EXPECT_FALSE(result.managerNotReady);
+}
+
+// Companion to SynchronizeModuleDoesNotReportTransientOnTransportFailure: checkStatus() failing never
+// reaches the handshake, so it is classified as localTransportUnavailable, on its own streak separate
+// from the manager-facing m_consecutiveSyncFailures -- and that streak grows across repeated failures.
+TEST_F(AgentSyncProtocolTest, SynchronizeModuleTransportFailureReportsLocalTransportUnavailable)
+{
+    mockQueue = std::make_shared<MockPersistentQueue>();
+
+    LoggerFunc testLogger = [](modules_log_level_t, const std::string&) {};
+    protocol = std::make_unique<AgentSyncProtocol>("test_module", ":memory:", testLogger, mockQueue, mockSyncTransport);
+    mockSyncTransport->setAvailable(false);
+
+    SyncModuleResult first = protocol->synchronizeModule(Mode::DELTA);
+    EXPECT_FALSE(first.success);
+    EXPECT_FALSE(first.managerNotReady);
+    EXPECT_TRUE(first.localTransportUnavailable);
+    EXPECT_EQ(first.consecutiveFailures, 1U);
+
+    SyncModuleResult second = protocol->synchronizeModule(Mode::DELTA);
+    EXPECT_TRUE(second.localTransportUnavailable);
+    EXPECT_EQ(second.consecutiveFailures, 2U);
 }
 
 // Exercises the C interface (asp_sync_module -> SyncModuleResult_t.stopped): this is the path

--- a/src/syscheckd/src/run_check.c
+++ b/src/syscheckd/src/run_check.c
@@ -1246,14 +1246,15 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
                 // yet, most commonly right after enrollment/restart. Expected to clear on its own.
                 minfo("FIM synchronization requested by agent-info deferred: %s",
                       sync_result.failure_reason);
-            } else if (sync_result.manager_not_ready
+            } else if ((sync_result.manager_not_ready || sync_result.local_transport_unavailable)
                        && sync_result.consecutive_failures <= SYNC_MANAGER_NOT_READY_TOLERANCE) {
-                // The manager is not ready for this agent yet, mostly right after a restart, and the
-                // sync has not failed enough times in a row to suspect it will not clear.
+                // Either the manager is not ready for this agent yet, or the local sync intake
+                // itself isn't reachable yet -- both mostly right after a restart -- and the sync
+                // has not failed enough times in a row to suspect it will not clear.
                 minfo("FIM synchronization requested by agent-info deferred: %s Will retry next cycle.",
                       sync_result.failure_reason);
-            } else if (sync_result.manager_not_ready) {
-                // Not a restart hiccup any more: the manager has not been ready for several cycles.
+            } else if (sync_result.manager_not_ready || sync_result.local_transport_unavailable) {
+                // Neither condition has cleared for several cycles in a row.
                 mwarn("FIM synchronization requested by agent-info failed %u times in a row: %s",
                       sync_result.consecutive_failures, sync_result.failure_reason);
             } else {
@@ -1305,13 +1306,14 @@ void * fim_run_integrity(__attribute__((unused)) void * args) {
                 // Not a real failure either: the manager hasn't synchronized this agent's groups
                 // yet, most commonly right after enrollment/restart. Expected to clear on its own.
                 minfo("FIM synchronization deferred: %s", sync_result.failure_reason);
-            } else if (sync_result.manager_not_ready
+            } else if ((sync_result.manager_not_ready || sync_result.local_transport_unavailable)
                        && sync_result.consecutive_failures <= SYNC_MANAGER_NOT_READY_TOLERANCE) {
-                // The manager is not ready for this agent yet, mostly right after a restart, and the
-                // sync has not failed enough times in a row to suspect it will not clear.
+                // Either the manager is not ready for this agent yet, or the local sync intake
+                // itself isn't reachable yet -- both mostly right after a restart -- and the sync
+                // has not failed enough times in a row to suspect it will not clear.
                 minfo("FIM synchronization deferred: %s Will retry next cycle.", sync_result.failure_reason);
-            } else if (sync_result.manager_not_ready) {
-                // Not a restart hiccup any more: the manager has not been ready for several cycles.
+            } else if (sync_result.manager_not_ready || sync_result.local_transport_unavailable) {
+                // Neither condition has cleared for several cycles in a row.
                 mwarn("FIM synchronization failed %u times in a row: %s",
                       sync_result.consecutive_failures, sync_result.failure_reason);
             } else {

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -2052,18 +2052,19 @@ AgentInfoImpl::CoordinationResult AgentInfoImpl::coordinateModules(const std::st
                     // Not a real failure: the sync was aborted because the module is stopping.
                     m_logFunction(LOG_DEBUG, "Synchronization of " + table + " aborted: the module is stopping.");
                 }
-                else if (syncResult.managerNotReady
+                else if ((syncResult.managerNotReady || syncResult.localTransportUnavailable)
                          && syncResult.consecutiveFailures <= SYNC_MANAGER_NOT_READY_TOLERANCE)
                 {
-                    // The manager is not ready for this agent yet, mostly right after a restart, and the
-                    // sync has not failed enough times in a row to suspect it will not clear. Agent-info
-                    // retries this table on the next coordination cycle.
+                    // Either the manager is not ready for this agent yet, or the local sync intake
+                    // itself isn't reachable yet -- both mostly right after a restart -- and the
+                    // sync has not failed enough times in a row to suspect it will not clear.
+                    // Agent-info retries this table on the next coordination cycle.
                     m_logFunction(LOG_INFO, "Synchronization of " + table + " deferred: " +
                                   syncResult.failureReason + " Will retry next cycle.");
                 }
-                else if (syncResult.managerNotReady)
+                else if (syncResult.managerNotReady || syncResult.localTransportUnavailable)
                 {
-                    // Not a restart hiccup any more: the manager has not been ready for several cycles.
+                    // Neither condition has cleared for several cycles in a row.
                     m_logFunction(LOG_WARNING, "Failed to synchronize " + table + " " +
                                   std::to_string(syncResult.consecutiveFailures) + " times in a row: " +
                                   syncResult.failureReason);
@@ -2831,18 +2832,19 @@ bool AgentInfoImpl::performIntegritySync(const std::string& table)
             // Not a real failure: the integrity check was aborted because the module is stopping.
             m_logFunction(LOG_DEBUG, "Integrity check for " + table + " aborted: the module is stopping.");
         }
-        else if (syncResult.managerNotReady
+        else if ((syncResult.managerNotReady || syncResult.localTransportUnavailable)
                  && syncResult.consecutiveFailures <= SYNC_MANAGER_NOT_READY_TOLERANCE)
         {
-            // The manager is not ready for this agent yet, mostly right after a restart, and the
-            // sync has not failed enough times in a row to suspect it will not clear. Agent-info
-            // retries this table on the next integrity cycle.
+            // Either the manager is not ready for this agent yet, or the local sync intake itself
+            // isn't reachable yet -- both mostly right after a restart -- and the sync has not
+            // failed enough times in a row to suspect it will not clear. Agent-info retries this
+            // table on the next integrity cycle.
             m_logFunction(LOG_INFO, "Integrity check for " + table + " deferred: " +
                           syncResult.failureReason + " Will retry next cycle.");
         }
-        else if (syncResult.managerNotReady)
+        else if (syncResult.managerNotReady || syncResult.localTransportUnavailable)
         {
-            // Not a restart hiccup any more: the manager has not been ready for several cycles.
+            // Neither condition has cleared for several cycles in a row.
             m_logFunction(LOG_WARNING, "Integrity check for " + table + " failed " +
                           std::to_string(syncResult.consecutiveFailures) + " times in a row: " +
                           syncResult.failureReason);

--- a/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
+++ b/src/wazuh_modules/sca/sca_impl/src/sca_impl.cpp
@@ -664,16 +664,18 @@ bool SecurityConfigurationAssessment::syncModule(Mode mode)
             // most commonly right after enrollment/restart. Expected to clear on its own.
             LoggingHelper::getInstance().log(LOG_INFO, "SCA synchronization deferred: " + result.failureReason);
         }
-        else if (result.managerNotReady && result.consecutiveFailures <= SYNC_MANAGER_NOT_READY_TOLERANCE)
+        else if ((result.managerNotReady || result.localTransportUnavailable) &&
+                 result.consecutiveFailures <= SYNC_MANAGER_NOT_READY_TOLERANCE)
         {
-            // The manager is not ready for this agent yet, mostly right after a restart, and the sync
-            // has not failed enough times in a row to suspect it will not clear. Not a WARNING yet.
+            // Either the manager is not ready for this agent yet, or the local sync intake itself
+            // isn't reachable yet -- both mostly right after a restart -- and the sync has not
+            // failed enough times in a row to suspect it will not clear. Not a WARNING yet.
             LoggingHelper::getInstance().log(LOG_INFO, "SCA synchronization deferred: " + result.failureReason +
                                              " Will retry next cycle.");
         }
-        else if (result.managerNotReady)
+        else if (result.managerNotReady || result.localTransportUnavailable)
         {
-            // The manager has not been ready for several cycles in a row: this is no longer a restart
+            // Neither condition has cleared for several cycles in a row: this is no longer a restart
             // hiccup, so it must stay visible.
             LoggingHelper::getInstance().log(LOG_WARNING, "SCA synchronization failed " +
                                              std::to_string(result.consecutiveFailures) + " times in a row: " +
@@ -936,17 +938,19 @@ int SecurityConfigurationAssessment::executeFlushSync()
         LoggingHelper::getInstance().log(LOG_INFO, "SCA flush deferred: " + result.failureReason);
         return -1;
     }
-    else if (result.managerNotReady && result.consecutiveFailures <= SYNC_MANAGER_NOT_READY_TOLERANCE)
+    else if ((result.managerNotReady || result.localTransportUnavailable) &&
+             result.consecutiveFailures <= SYNC_MANAGER_NOT_READY_TOLERANCE)
     {
-        // The manager is not ready for this agent yet, mostly right after a restart, and the sync
-        // has not failed enough times in a row to suspect it will not clear. Not an error yet.
+        // Either the manager is not ready for this agent yet, or the local sync intake itself
+        // isn't reachable yet -- both mostly right after a restart -- and the sync has not
+        // failed enough times in a row to suspect it will not clear. Not an error yet.
         LoggingHelper::getInstance().log(LOG_INFO, "SCA flush deferred: " + result.failureReason +
                                          " Will retry next cycle.");
         return -1;
     }
-    else if (result.managerNotReady)
+    else if (result.managerNotReady || result.localTransportUnavailable)
     {
-        // The manager has not been ready for several cycles in a row: this is no longer a restart
+        // Neither condition has cleared for several cycles in a row: this is no longer a restart
         // hiccup, so it must stay visible.
         LoggingHelper::getInstance().log(LOG_WARNING, "SCA flush failed " +
                                          std::to_string(result.consecutiveFailures) + " times in a row: " +

--- a/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
+++ b/src/wazuh_modules/syscollector/src/syscollectorImp.cpp
@@ -2405,16 +2405,18 @@ SyncModuleResult Syscollector::syncModule(Mode mode)
                 // yet, most commonly right after enrollment/restart. Expected to clear on its own.
                 m_logFunction(LOG_INFO, "Syscollector synchronization deferred: " + result.failureReason);
             }
-            else if (result.managerNotReady && result.consecutiveFailures <= SYNC_MANAGER_NOT_READY_TOLERANCE)
+            else if ((result.managerNotReady || result.localTransportUnavailable) &&
+                     result.consecutiveFailures <= SYNC_MANAGER_NOT_READY_TOLERANCE)
             {
-                // The manager is not ready for this agent yet, mostly right after a restart, and the
-                // sync has not failed enough times in a row to suspect it will not clear.
+                // Either the manager is not ready for this agent yet, or the local sync intake
+                // itself isn't reachable yet -- both mostly right after a restart -- and the sync
+                // has not failed enough times in a row to suspect it will not clear.
                 m_logFunction(LOG_INFO, "Syscollector synchronization deferred: " + result.failureReason +
                               " Will retry next cycle.");
             }
-            else if (result.managerNotReady)
+            else if (result.managerNotReady || result.localTransportUnavailable)
             {
-                // Not a restart hiccup any more: the manager has not been ready for several cycles.
+                // Neither condition has cleared for several cycles in a row.
                 m_logFunction(LOG_WARNING, "Syscollector synchronization failed " +
                               std::to_string(result.consecutiveFailures) + " times in a row: " + result.failureReason);
             }
@@ -2477,16 +2479,18 @@ SyncModuleResult Syscollector::syncModule(Mode mode)
                 // own within the next cycle or two.
                 m_logFunction(LOG_INFO, "Syscollector VD synchronization deferred: " + vdResult.failureReason);
             }
-            else if (vdResult.managerNotReady && vdResult.consecutiveFailures <= SYNC_MANAGER_NOT_READY_TOLERANCE)
+            else if ((vdResult.managerNotReady || vdResult.localTransportUnavailable) &&
+                     vdResult.consecutiveFailures <= SYNC_MANAGER_NOT_READY_TOLERANCE)
             {
-                // The manager is not ready for this agent yet, mostly right after a restart, and the
-                // sync has not failed enough times in a row to suspect it will not clear.
+                // Either the manager is not ready for this agent yet, or the local sync intake
+                // itself isn't reachable yet -- both mostly right after a restart -- and the sync
+                // has not failed enough times in a row to suspect it will not clear.
                 m_logFunction(LOG_INFO, "Syscollector VD synchronization deferred: " + vdResult.failureReason +
                               " Will retry next cycle.");
             }
-            else if (vdResult.managerNotReady)
+            else if (vdResult.managerNotReady || vdResult.localTransportUnavailable)
             {
-                // Not a restart hiccup any more: the manager has not been ready for several cycles.
+                // Neither condition has cleared for several cycles in a row.
                 m_logFunction(LOG_WARNING, "Syscollector VD synchronization failed " +
                               std::to_string(vdResult.consecutiveFailures) + " times in a row: " + vdResult.failureReason);
             }
@@ -3113,19 +3117,22 @@ int Syscollector::executeFlushSync()
 
             const std::string reasonSuffix = reason.empty() ? "" : ": " + reason;
 
-            // A queue that failed counts as "manager not ready" only if that specific sync said so;
-            // a queue that succeeded does not veto the deferral.
+            // A queue that failed counts as "manager not ready" only if that specific sync said so
+            // (either the manager itself, or the local sync intake being unreachable -- both share
+            // the same restart-hiccup shape); a queue that succeeded does not veto the deferral.
             const bool allFailuresManagerNotReady =
-                (result.success   || result.managerNotReady) &&
-                (vdResult.success || vdResult.managerNotReady);
+                (result.success   || result.managerNotReady || result.localTransportUnavailable) &&
+                (vdResult.success || vdResult.managerNotReady || vdResult.localTransportUnavailable);
 
             // Longest manager-not-ready streak among the queues that actually failed.
             unsigned int streak = 0;
 
-            if (!result.success && result.managerNotReady && result.consecutiveFailures > streak)
+            if (!result.success && (result.managerNotReady || result.localTransportUnavailable) &&
+                    result.consecutiveFailures > streak)
                 streak = result.consecutiveFailures;
 
-            if (!vdResult.success && vdResult.managerNotReady && vdResult.consecutiveFailures > streak)
+            if (!vdResult.success && (vdResult.managerNotReady || vdResult.localTransportUnavailable) &&
+                    vdResult.consecutiveFailures > streak)
                 streak = vdResult.consecutiveFailures;
 
             if (allFailuresManagerNotReady && streak <= SYNC_MANAGER_NOT_READY_TOLERANCE)


### PR DESCRIPTION
## Description
`wazuh-modulesd` and `wazuh-syscheckd` report a plain `WARNING` for a synchronization that fails only because the local sync intake socket (`queue/sockets/queue-sync`, `wazuh-agentd`'s `https_client`) wasn't reachable yet:

```
WARNING: Syscollector synchronization failed: Failed to reach the sync intake socket.
WARNING: Syscollector VD synchronization failed: Failed to reach the sync intake socket.
```
This is the same restart-time race #37827 already demotes to `INFO` (the module attempts to sync before the other side is ready) just caught one step earlier: the module starts before `wazuh-agentd`'s `https_client` has finished binding its own local socket, instead of before the manager is ready to answer. It self-recovers on the next cycle exactly like the cases #37827 covers, but wasn't classified as such because `checkStatus()` failing returns a `SyncModuleResult` with `managerNotReady` left at its default `false`, so every consumer module falls into the generic "real failure" branch.

This PR classifies it the same way, under its own label.

## Proposed Changes
- Add `localTransportUnavailable` to `SyncModuleResult` (C twin `local_transport_unavailable`): true when `checkStatus()` couldn't reach the local sync intake. Kept deliberately distinct from `managerNotReady` an existing test enforces that a local transport failure must not be reported as a manager-side condition, since nothing was ever sent to the manager.
- Add a dedicated `consecutiveFailures`-style streak (`trackLocalTransportFailure()` / `m_consecutiveLocalTransportFailures`) for this condition, separate from the manager-facing counter: `checkStatus()` failing never reaches the handshake, and the existing counter is documented as reserved for outcomes that do.
- Wire `localTransportUnavailable` into the same INFO-within-tolerance / WARNING-past-tolerance decision already used for `managerNotReady`, in all four consumer modules (SCA, Syscollector periodic, VD, and flush — FIM, agent-info).

## Results and Evidence

Ran the full `agent_sync_protocol` unit test suite (built standalone, including its `FilesystemWrapper`/`agent_metadata` dependencies) against the fix:

[==========] 182 tests from 10 test suites ran. (63872 ms total)
[  PASSED  ] 182 tests.

Including the new coverage for this fix:

[ RUN      ] AgentSyncProtocolTest.SynchronizeModuleDoesNotReportTransientOnTransportFailure
[       OK ] AgentSyncProtocolTest.SynchronizeModuleDoesNotReportTransientOnTransportFailure (38 ms)
[ RUN      ] AgentSyncProtocolTest.SynchronizeModuleTransportFailureReportsLocalTransportUnavailable
[       OK ] AgentSyncProtocolTest.SynchronizeModuleTransportFailureReportsLocalTransportUnavailable (2 ms)
[ RUN      ] AgentSyncProtocolTest.CInterfacePropagatesStoppedFlag
[       OK ] AgentSyncProtocolTest.CInterfacePropagatesStoppedFlag (7 ms)

**Confirmed the new test actually exercises new behavior** (not something that already passed for an unrelated reason): reverted `agent_sync_protocol.cpp`/`.hpp`/`agent_sync_protocol_types.hpp` to the pre-fix commit while keeping the new test, and it fails to compile against the old struct:

test_agent_sync_protocol.cpp:232:23: error: 'struct SyncModuleResult' has no member named 'localTransportUnavailable'
232 |     EXPECT_TRUE(first.localTransportUnavailable);

### Independent verification during review

**Race condition found and fixed.** `trackLocalTransportFailure()` originally called `shouldStop()` a second time internally, independently of the `stopped` already computed for the same return statement — a stop() landing between the two reads could leave the returned `stopped` field and the streak decision disagreeing. Reproduced with a stress test against the real `AgentSyncProtocol` class (one thread driving `synchronizeModule()` in a loop with `checkStatus()` forced to fail, a second thread hammering `stop()`/`reset()` concurrently): 3,000,000 iterations, run twice, produced 4,724 and 9,717 inconsistent observations respectively (first one at iteration 186 and 11,219). A control run with no concurrent `stop()`/`reset()` produced 0 inconsistencies over 200,000 iterations, confirming the detection logic itself was sound. Fixed in `a9017a1ebd` (`trackLocalTransportFailure(bool stopped)` now takes the caller's already-computed value, mirroring `trackSyncOutcome`). Re-ran the same stress test against the fix: 0 inconsistencies over 3,000,000 iterations, twice.

**Consumer-level fix verified for 3 of 4 modules, reproducing the actual reported bug.** This PR's own test suite covers the `AgentSyncProtocol` layer that produces `localTransportUnavailable`, but none of the four modules that branch on it. Built and ran real (not hypothetical) coverage for SCA, Syscollector, and agent-info against this PR's merged tip, each proving three things: (1) the pre-fix bug shape — neither `managerNotReady` nor `localTransportUnavailable` set — still produces a hard WARNING on the very first attempt if hit today; (2) the fix defers at INFO within `SYNC_MANAGER_NOT_READY_TOLERANCE`; (3) it escalates back to WARNING past tolerance. For Syscollector specifically, this exercises `Syscollector::syncModule()` — the exact function whose log line this PR's own description quotes verbatim — for the first time (it was wrapped in `LCOV_EXCL_START`/`LCOV_EXCL_STOP` with zero prior coverage). Full suites re-run after adding the new tests: SCA 35/35, Syscollector 83/83, agent-info 8/8, nothing broken.

FIM (`run_check.c`) could not be covered the same way: its C mock, `__wrap_asp_sync_module`, hardcodes the whole `SyncModuleResult_t` to zero except `success`, so a test cannot express `local_transport_unavailable=true` without extending that wrapper first — filed separately as #38621, along with the verified Syscollector/agent-info patches for anyone who wants to land that coverage.

### Manual tests with their corresponding evidence

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
The team currently has automated tests whose output should be thoroughly reviewed and contrasted.
-->

<!-- Minimum checks required depending on if it is Agent or Manager related -->
- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows 
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

### Configuration Changes
- N/A

<!--
If applicable, list any configuration changes introduced by this pull request, including:
- New configuration parameters
- Changes to default values
- Backward compatibility notes
-->

### Tests Introduced
- New `AgentSyncProtocolTest` cases covering `localTransportUnavailable` classification and the `stopped`/streak race fix (see "Independent verification during review" above for the consumer-module coverage gap tracked separately in #38621).

<!--
If applicable, describe any new unit or integration tests added as part of this pull request. Include:
- Scope of the tests
- Any relevant details about test coverage
-->

## Review Checklist
- N/A

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
