### PR TITLE
fix(api): bound search length and harden wazuh-db error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 | [#37521](https://github.com/wazuh/wazuh/issues/37521) | Fixed `GET /cluster/{node_id}/daemons/stats` always returning error 1014 for `wazuh-manager-analysisd` due to a protocol mismatch between `WazuhSocketJSON` and the engine's HTTP API socket. |
 | [#38511](https://github.com/wazuh/wazuh/issues/38511) | Fixed world-writable permissions on bundled Python files after DEB installation, caused by the permission restoration script following symlinks. |
 | [#38547](https://github.com/wazuh/wazuh/issues/38547) | Fixed the API serving its OpenAPI specification and exact version at `/openapi.json` and `/openapi.yaml` without authentication. |
+| [#38565](https://github.com/wazuh/wazuh/issues/38565) | Bounded the `search` query parameter to 1024 characters across every endpoint that accepts it, fixed the API's `wazuh-db` socket client raising an unhandled error instead of a clean `500` when `wazuh-db` closes the connection on an oversized request, and stopped the API from returning `wazuh-db`'s raw backend error text (including SQL fragments) to the caller. |
 
 ### Agent
 

--- a/api/api/spec/spec.yaml
+++ b/api/api/spec/spec.yaml
@@ -3070,6 +3070,7 @@ components:
       schema:
         type: string
         format: search
+        maxLength: 1024
     select:
       in: query
       name: select

--- a/api/api/test/test_agents_search_length.py
+++ b/api/api/test/test_agents_search_length.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2015, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+"""Verify the `agents_search` spec parameter rejects an oversized `search` value on GET /agents
+before the request ever reaches wazuh-db, mirroring how `limit`'s `maximum` is enforced."""
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+with patch('wazuh.common.wazuh_uid'), patch('wazuh.common.wazuh_gid'):
+    sys.modules['wazuh.rbac.orm'] = MagicMock()
+
+from connexion import AsyncApp  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
+
+from api.uri_parser import APIUriParser  # noqa: E402
+import api.authentication as authentication  # noqa: E402
+
+SPEC_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'spec')
+MAX_LENGTH = 1024
+
+
+def _build_client():
+    """Build a minimal connexion app serving the real spec.yaml, with authentication bypassed."""
+    app = AsyncApp(__name__, specification_dir=SPEC_DIR, pythonic_params=True, uri_parser_class=APIUriParser)
+    app.add_api('spec.yaml', strict_validation=True, validate_responses=False)
+    return TestClient(app)
+
+
+def test_agents_search_too_long_is_rejected_before_reaching_wdb():
+    """GET /agents?search=<1025 chars> must be rejected with 400 by the spec validator, naming the
+    maxLength limit, instead of reaching wazuh-db (which is what let it hit the socket's 65536-byte cap)."""
+    with patch.object(authentication, 'decode_token', new=AsyncMock(return_value={'sub': 'wazuh', 'rbac_policies': {}})):
+        client = _build_client()
+        response = client.get('/agents', params={'search': 'a' * (MAX_LENGTH + 1)},
+                               headers={'Authorization': 'Bearer test-token'})
+
+    assert response.status_code == 400
+    body = response.text
+    assert 'maxLength' in body
+    assert str(MAX_LENGTH) in body
+
+
+def test_agents_search_at_max_length_is_not_rejected_by_the_validator():
+    """A `search` value exactly at the 1024-char limit must not be rejected by the schema validator
+    (any failure past that point belongs to a different layer, not the maxLength check)."""
+    with patch.object(authentication, 'decode_token', new=AsyncMock(return_value={'sub': 'wazuh', 'rbac_policies': {}})):
+        client = _build_client()
+        response = client.get('/agents', params={'search': 'a' * MAX_LENGTH},
+                               headers={'Authorization': 'Bearer test-token'})
+
+    assert not (response.status_code == 400 and 'maxLength' in response.text)

--- a/api/api/test/test_authentication.py
+++ b/api/api/test/test_authentication.py
@@ -111,8 +111,11 @@ def test_generate_keypair_ko():
     """Verify expected exception is raised when IOError"""
     with patch('builtins.open'):
         with patch('os.chmod'):
-            with patch('os.chown', side_effect=PermissionError):
-                assert generate_keypair()
+            with patch('api.authentication.wazuh_uid', return_value=0):
+                with patch('api.authentication.wazuh_gid', return_value=0):
+                    with patch('os.chown', side_effect=PermissionError):
+                        assert generate_keypair()
+
 
 @patch("api.authentication._write_new_keypair", return_value=("priv", "pub"))
 @patch("os.path.exists", return_value=False)
@@ -293,7 +296,7 @@ def test_check_token_runas_valid(mock_optimize):
 @patch('api.authentication.raise_if_exc', side_effect=None)
 async def test_decode_token(mock_raise_if_exc, mock_distribute_function, mock_dapi, mock_generate_keypair,
                       mock_decode):
-    
+
     mock_decode.return_value = deepcopy(original_payload)
     mock_raise_if_exc.side_effect = [WazuhResult({'valid': True, 'policies': {'value': 'test'}}),
                                      WazuhResult(security_conf)]

--- a/api/test/integration/test_agent_GET_endpoints.tavern.yaml
+++ b/api/test/integration/test_agent_GET_endpoints.tavern.yaml
@@ -240,6 +240,54 @@ stages:
       status_code: 400
       json:
         error: 2003
+        # wazuh-db's raw backend error text (e.g. SQL fragments) must never reach the caller;
+        # only the generic wazuhdb-request message is expected here.
+        detail: 'Error in wazuhdb request'
+
+  - name: Try to show agents with a search value over the 1024-char limit
+    request:
+      verify: False
+      <<: *get_agents
+      params:
+        search: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    response:
+      status_code: 400
+
+  - name: Try to show agents with a NUL byte in search
+    request:
+      verify: False
+      <<: *get_agents
+      params:
+        search: "a\0b"
+    response:
+      status_code: 400
+      json:
+        error: 2003
+        detail: 'Error in wazuhdb request'
+
+  - name: Try to show agents with a stray semicolon in q
+    request:
+      verify: False
+      <<: *get_agents
+      params:
+        q: 'name=a;drop'
+    response:
+      status_code: 400
+      json:
+        error: 2003
+        detail: 'Error in wazuhdb request'
+
+  - name: Try to show agents with a stray closing parenthesis in q
+    request:
+      verify: False
+      <<: *get_agents
+      params:
+        q: 'name=a)'
+    response:
+      status_code: 400
+      json:
+        error: 2003
+        detail: 'Error in wazuhdb request'
 
   - name: Try to show agents with limit 0
     request:
@@ -1630,6 +1678,18 @@ stages:
         error: 0
         data:
           <<: *affected_empty_answer
+
+  - name: Try show groups with a search value over the 1024-char limit
+    request:
+      verify: False
+      <<: *get_agents_groups
+      params:
+        search: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    # Regression check for the global `search` maxLength bound: /groups shares
+    # the same spec component as /agents, so an oversized value here must
+    # also be rejected before ever reaching wazuh-db.
+    response:
+      status_code: 400
 
   - name: Try show agents with wrong hash
     request:

--- a/framework/wazuh/core/tests/test_wdb.py
+++ b/framework/wazuh/core/tests/test_wdb.py
@@ -145,7 +145,7 @@ def test_wrong_character_encodings_wdb(send_mock, connect_mock):
     """
     Tests receiving a text with a bad character encoding from wazuh db
     """
-    def recv_mock(size_to_receive):
+    def recv_mock(size_to_receive, flags=0):
         bad_string = b' {"bad": "\x96bad"}'
         return format_msg(bad_string) if size_to_receive == 4 else bad_string
 
@@ -161,7 +161,7 @@ def test_null_values_are_removed(send_mock, connect_mock):
     """
     Tests '(null)' values are removed from the resulting dictionary
     """
-    def recv_mock(size_to_receive):
+    def recv_mock(size_to_receive, flags=0):
         nulls_string = b' [{"a": "a", "b": "(null)", "c": [1, 2, 3], "d": {"e": "(null)"}}]'
         return format_msg(nulls_string) if size_to_receive == 4 else nulls_string
 
@@ -177,18 +177,37 @@ def test_failed_send_private(send_mock, connect_mock):
     """
         Tests an exception is properly raised when it's not possible to send a msg to the wdb socket
     """
-    def recv_mock(size_to_receive):
+    def recv_mock(size_to_receive, flags=0):
         error_string = b'err {"agents": {"001": "Error"}}'
         return format_msg(error_string) if size_to_receive == 4 else error_string
 
     with patch('socket.socket.recv', side_effect=recv_mock):
         mywdb = WazuhDBConnection()
-        with pytest.raises(exception.WazuhException, match=".* 2003 .*"):
+        with pytest.raises(exception.WazuhException, match=".* 2003 .*") as exc_info:
             mywdb._send('test_msg')
+        # The raw backend error text must not leak into the exception message.
+        assert '{"agents": {"001": "Error"}}' not in str(exc_info.value)
+        assert exc_info.value.message == exception.WazuhException.ERRORS[2003]['message']
 
     with patch('socket.socket.recv', return_value=b'a' * (MAX_SOCKET_BUFFER_SIZE + 1)):
         mywdb = WazuhDBConnection()
         with pytest.raises(exception.WazuhException, match=".* 2009 .*"):
+            mywdb._send('test_msg')
+
+
+@patch("socket.socket.connect")
+@patch("socket.socket.send")
+def test_send_private_closed_connection(send_mock, connect_mock):
+    """Test that a closed/reset connection while reading the response header raises WazuhInternalError(2010)
+    instead of the unhandled struct.error/ConnectionResetError that used to escape `_send`."""
+    with patch('socket.socket.recv', return_value=b''):
+        mywdb = WazuhDBConnection()
+        with pytest.raises(exception.WazuhInternalError, match=r'\b2010\b'):
+            mywdb._send('test_msg')
+
+    with patch('socket.socket.recv', side_effect=ConnectionResetError):
+        mywdb = WazuhDBConnection()
+        with pytest.raises(exception.WazuhInternalError, match=r'\b2010\b'):
             mywdb._send('test_msg')
 
 

--- a/framework/wazuh/core/wdb.py
+++ b/framework/wazuh/core/wdb.py
@@ -6,6 +6,7 @@ import contextlib
 import asyncio
 import datetime
 import json
+import logging
 import re
 import socket
 import struct
@@ -16,6 +17,8 @@ from wazuh.core.common import MAX_SOCKET_BUFFER_SIZE
 from wazuh.core.exception import WazuhInternalError, WazuhError
 
 DATE_FORMAT = re.compile(r'\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2}')
+
+logger = logging.getLogger('wazuh')
 
 
 class AsyncWazuhDBConnection:
@@ -212,6 +215,8 @@ class WazuhDBConnection:
         ------
         WazuhInternalError(2009)
             Pagination error. Response from wazuh-manager-db was over the maximum socket buffer size.
+        WazuhInternalError(2010)
+            The response header could not be read in full (connection closed/reset by wazuh-manager-db).
         WazuhError(2003)
             Error in wdb request.
 
@@ -226,8 +231,13 @@ class WazuhDBConnection:
         self.__conn.send(packed_msg)
 
         # Get the data size (4 bytes)
-        data = self.__conn.recv(4)
-        data_size = struct.unpack('<I', data[0:4])[0]
+        try:
+            data = self.__conn.recv(4, socket.MSG_WAITALL)
+            if len(data) < 4:
+                raise OSError("Connection closed by wazuh-manager-db while reading the response header")
+            data_size = struct.unpack('<I', data[0:4])[0]
+        except (OSError, struct.error) as e:
+            raise WazuhInternalError(2010, extra_message=e)
 
         data = self._recvall(data_size).decode(encoding='utf-8', errors='ignore').split(" ", 1)
 
@@ -236,7 +246,8 @@ class WazuhDBConnection:
             raise WazuhInternalError(2009)
 
         if data[0] == "err":
-            raise WazuhError(2003, data[1])
+            logger.error(f"wazuh-db returned an error: {data[1]}")
+            raise WazuhError(2003)
         elif raw:
             return data
         else:


### PR DESCRIPTION
## Description

Closes #38565

`GET /agents`'s `search` query parameter (and the same shared parameter on
18 other endpoints) had no length bound. Past ~3000 characters the request
was accepted, expanded into a query, and refused by `wazuh-db` once the
resulting message crossed its 65536-byte socket cap. The API's `wazuh-db`
socket client had no handling for that refusal: it raised an unhandled
`struct.error`/`ConnectionResetError`, surfaced to the caller as an opaque
`500 Wazuh Internal Error` with a Python traceback in `api.log`. Separately,
several malformed inputs (a NUL byte, a stray `;`/`)`, an out-of-range
`offset`) caused `wazuh-db`'s/SQLite's own error text — including SQL
fragments — to be returned to the caller verbatim.

## Proposed Changes

- Bounded the `search` query parameter to 1024 characters across every
  endpoint that accepts it (`agents`, `agents/no_group`, `agents/outdated`,
  `agents/stats/distinct`, `groups`, `groups/{group_id}/agents`,
  `groups/{group_id}/files`, `cluster/nodes`, `cluster/{node_id}/logs`, the
  `mitre/*` and `security/*` search endpoints) — oversized values are now
  rejected with `400` at the schema layer, before ever reaching `wazuh-db`.
- Fixed `WazuhDBConnection._send()` (`framework/wazuh/core/wdb.py`) raising
  an unhandled error instead of a clean exception when `wazuh-db` closes
  the connection on a refused (oversized) request. It now reads the
  response header with `socket.MSG_WAITALL` plus an explicit short-read
  check and raises `WazuhInternalError(2010)` — mirroring the equivalent
  handling already present in the async sibling class in the same file.
- Stopped the API from returning `wazuh-db`'s raw backend error text
  (including SQL fragments) to the caller. The detail is now logged
  server-side and the caller gets the existing generic
  `"Error in wazuhdb request"` message.

## Results and Evidence

### Long queries 

Rejected with 400 error code 
```console
root@noble:/home/vagrant/wazuh-5.x# bash  repro_search_length.sh
chars=100  http=200  body_head={"data": {"affected_items": [], "total_affected_items": 0, "total_failed_items": 0, "failed_items": []}, "message": "No agent information was returned
chars=500  http=200  body_head={"data": {"affected_items": [], "total_affected_items": 0, "total_failed_items": 0, "failed_items": []}, "message": "No agent information was returned
chars=1000  http=200  body_head={"data": {"affected_items": [], "total_affected_items": 0, "total_failed_items": 0, "failed_items": []}, "message": "No agent information was returned
chars=2000  http=400  body_head={"title": "Bad Request", "detail": "'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
chars=3000  http=400  body_head={"title": "Bad Request", "detail": "'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
chars=4000  http=400  body_head={"title": "Bad Request", "detail": "'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
chars=4500  http=400  body_head={"title": "Bad Request", "detail": "'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
chars=5000  http=400  body_head={"title": "Bad Request", "detail": "'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
chars=8000  http=400  body_head={"title": "Bad Request", "detail": "'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
chars=20000  http=400  body_head={"title": "Bad Request", "detail": "'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
```

### Raw database errors 

Generic `Error in wazuhdb request`, no SQL errors 

```console
root@noble:/home/vagrant/wazuh-5.x# bash raw_db_errors.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   429  100   429    0     0   3197      0 --:--:-- --:--:-- --:--:--  3201
--- NUL byte ---
{"title": "Bad Request", "detail": "Error in wazuhdb request", "remediation": "Make sure the request is correct", "dapi_errors": {"node01": {"error": "Error in wazuhdb request"}}, "error": 2003}--- q with a stray ; ---
{"title": "Bad Request", "detail": "Error in wazuhdb request", "remediation": "Make sure the request is correct", "dapi_errors": {"node01": {"error": "Error in wazuhdb request"}}, "error": 2003}--- q with a stray ) ---
{"title": "Bad Request", "detail": "Error in wazuhdb request", "remediation": "Make sure the request is correct", "dapi_errors": {"node01": {"error": "Error in wazuhdb request"}}, "error": 2003}--- absurd offset ---
{"title": "Bad Request", "detail": "Error in wazuhdb request", "remediation": "Make sure the request is correct", "dapi_errors": {"node01": {"error": "Error in wazuhdb request"}}, "error": 2003}
``` 

### No manager outage

Error 400 

```console
root@noble:/home/vagrant/wazuh-5.x# bash no_manager_outage.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   429  100   429    0     0   3079      0 --:--:-- --:--:-- --:--:--  3086
400 400 400 400 400 400 400 400 400 400
{"data": {"affected_items": [{"ip": "any", "dateAdd": "2026-08-25T15:44:10+00:00", "registerIP": "any", "id": "001", "group": ["default"], "name": "174a02b7d54c", "lastKeepAlive": "2026-08-25T18:28:27+00:00", "status": "pending", "status_code": 0}], "total_affected_items": 1, "total_failed_items": 0, "failed_items": []}, "message": "All selected agents information was returned", "error": 0}wazuh-manager-clusterd is running...
wazuh-manager-modulesd is running...
wazuh-manager-monitord is running...
wazuh-manager-remoted is running...
wazuh-manager-analysisd is running...
wazuh-manager-db is running...
wazuh-manager-authd is running...
wazuh-manager-apid is running...
```

### Long query different endpoints

Error 400 instead of 200 

```console
root@noble:/home/vagrant/wazuh-5.x# bash long_query_different_endpoints.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   429  100   429    0     0   3358      0 --:--:-- --:--:-- --:--:--  3377
--- /groups?search= ---
400
--- /agents?select= (should be correctly rejected) ---
{"title": "Bad Request", "detail": "Not a valid select field: Allowed select fields: dateAdd, disconnection_time, group, id, ip, lastKeepAlive, name, os.arch, os.major, os.minor, os.name, os.platform, os.type, os.version, registerIP, status, status_code, version. Fields: aaaaaaaaaaaaaaaaaaaaaaaaaaaaroot@noble:/home/vagrant/wazuh-5.x#
```

