### PR TITLE
Replace invalid UTF-8 bytes before forwarding a log line

### DIFF
--- a/src/shared/include/mq_op.h
+++ b/src/shared/include/mq_op.h
@@ -89,7 +89,9 @@ int StartMQPredicated(const char *key, short int type, short int n_attempts, boo
  * Notes: (UNIX) If the socket is busy when trying to send a message a DEBUG2 message will be loggeed but the return code will be 0
  */
 
-int SendMSGPredicated(int queue, const char *message, const char *locmsg, char loc, bool (*fn_ptr)()) __attribute__((nonnull));
+/* message (arg 2) is excluded on purpose: SendMSGAction() guards it, and declaring it
+ * non-null lets the optimizer propagate that through and delete the guard. */
+int SendMSGPredicated(int queue, const char *message, const char *locmsg, char loc, bool (*fn_ptr)()) __attribute__((nonnull(3, 5)));
 
 /**
  * Sends a message string through a message queue
@@ -105,7 +107,9 @@ int SendMSGPredicated(int queue, const char *message, const char *locmsg, char l
  * Notes: (UNIX) If the socket is busy when trying to send a message a DEBUG2 message will be loggeed but the return code will be 0
  */
 
-int SendMSG(int queue, const char *message, const char *locmsg, char loc) __attribute__((nonnull));
+/* message (arg 2) is excluded on purpose: SendMSGAction() guards it, and declaring it
+ * non-null lets the optimizer propagate that through and delete the guard. */
+int SendMSG(int queue, const char *message, const char *locmsg, char loc) __attribute__((nonnull(3)));
 
 /**
  * Sends a message binary through a message queue

--- a/src/shared/include/utf8_op.h
+++ b/src/shared/include/utf8_op.h
@@ -48,8 +48,12 @@ char * w_utf8_filter(const char * string, bool replacement);
  * so the whole trailing sequence is dropped instead. It does not write, so the
  * caller can hand the result to a precision specifier.
  *
- * @param string String to be measured.
+ * The string must already be valid UTF-8. A run of continuation bytes longer than
+ * any real character cannot be walked back past, so there the cut falls where asked
+ * and the result is only as valid as the input was.
+ *
+ * @param string String to be measured. Must already be valid UTF-8.
  * @param max_length Maximum length in bytes, excluding the null terminator.
- * @return Length in bytes that keeps every character whole.
+ * @return Length in bytes that keeps every character whole, given valid input.
  */
 size_t w_utf8_truncate_len(const char * string, size_t max_length);

--- a/src/shared/include/utf8_op.h
+++ b/src/shared/include/utf8_op.h
@@ -10,6 +10,7 @@
  */
 
 #include <stdbool.h>
+#include <stddef.h>
 
 /**
  * @brief Return whether a string is UTF-8.
@@ -37,3 +38,18 @@ const char * w_utf8_drop(const char * string);
  * @return Return a new string with valid UTF-8 characters only.
  */
 char * w_utf8_filter(const char * string, bool replacement);
+
+
+/**
+ * @brief Get the length a string may be cut to without splitting a UTF-8 character.
+ *
+ * Cutting at a fixed byte offset can fall inside a multi-byte sequence and leave
+ * a partial character behind, which is invalid UTF-8. This reports where to stop
+ * so the whole trailing sequence is dropped instead. It does not write, so the
+ * caller can hand the result to a precision specifier.
+ *
+ * @param string String to be measured.
+ * @param max_length Maximum length in bytes, excluding the null terminator.
+ * @return Length in bytes that keeps every character whole.
+ */
+size_t w_utf8_truncate_len(const char * string, size_t max_length);

--- a/src/shared/src/mq_op.c
+++ b/src/shared/src/mq_op.c
@@ -224,6 +224,11 @@ STATIC int SendMSGAction(int queue, const char *message, const char *locmsg, cha
         return (0);
     }
 
+    if (message == NULL) {
+        merror(FORMAT_ERROR);
+        return (0);
+    }
+
     if (loc == SECURE_MQ) {
         loc = message[0];
         message++;
@@ -267,6 +272,10 @@ STATIC int SendMSGAction(int queue, const char *message, const char *locmsg, cha
      * Measure it and hand snprintf a length that keeps every character whole. */
     header_length = strlen(loc_buff) + (secure ? 4 : 3); /* "%c:" + loc_buff + "->" or ":" */
     message_length = w_utf8_truncate_len(message, OS_MAXSTR - 1 - header_length);
+
+    if (message[message_length] != '\0') {
+        mdebug2("Message from '%s' cut to %zu bytes to fit the queue.", locmsg, message_length);
+    }
 
     if (secure) {
         snprintf(tmpstr, OS_MAXSTR, "%c:%s->%.*s", loc, loc_buff, (int)message_length, message);

--- a/src/shared/src/mq_op.c
+++ b/src/shared/src/mq_op.c
@@ -212,6 +212,10 @@ STATIC int SendMSGAction(int queue, const char *message, const char *locmsg, cha
     char tmpstr[OS_MAXSTR + 1] = {0};
     char loc_buff[OS_SIZE_8192 + 1] = {0};
     static int reported = 0;
+    char *sanitized = NULL;
+    size_t header_length;
+    size_t message_length;
+    bool secure = false;
 
     tmpstr[OS_MAXSTR] = '\0';
 
@@ -234,10 +238,43 @@ STATIC int SendMSGAction(int queue, const char *message, const char *locmsg, cha
             return (0);
         }
 
-        snprintf(tmpstr, OS_MAXSTR, "%c:%s->%s", loc, loc_buff, message);
-    } else {
-        snprintf(tmpstr, OS_MAXSTR, "%c:%s:%s", loc, loc_buff, message);
+        secure = true;
     }
+
+    /* The engine puts this message in a JSON document, and Json::str() aborts
+     * the whole document on any invalid byte, so the event and the alert it
+     * would have raised are both lost. Filtering here covers every producer
+     * that sends an event, on every platform, instead of one reader at a time.
+     * The framing bytes above are already past, so only the payload is touched. */
+    if (!w_utf8_valid(message)) {
+        static int utf8_reported = 0;
+
+        sanitized = w_utf8_filter(message, true);
+        message = sanitized;
+
+        if (!utf8_reported) {
+            mwarn("Invalid UTF-8 byte in a message from '%s'. Replacing it with U+FFFD.", locmsg);
+            utf8_reported = 1;
+        } else {
+            mdebug2("Invalid UTF-8 byte in a message from '%s'. Replacing it with U+FFFD.", locmsg);
+        }
+    }
+
+    /* The snprintf below cuts at a byte offset, which can split a multi-byte
+     * character, including an EF BF BD just written above. The header is the
+     * only thing standing between the payload and OS_MAXSTR, and its real
+     * length is the escaped location, up to OS_SIZE_8192, not OS_LOG_HEADER.
+     * Measure it and hand snprintf a length that keeps every character whole. */
+    header_length = strlen(loc_buff) + (secure ? 4 : 3); /* "%c:" + loc_buff + "->" or ":" */
+    message_length = w_utf8_truncate_len(message, OS_MAXSTR - 1 - header_length);
+
+    if (secure) {
+        snprintf(tmpstr, OS_MAXSTR, "%c:%s->%.*s", loc, loc_buff, (int)message_length, message);
+    } else {
+        snprintf(tmpstr, OS_MAXSTR, "%c:%s:%.*s", loc, loc_buff, (int)message_length, message);
+    }
+
+    os_free(sanitized);
 
     /* Queue not available */
     if (queue < 0) {

--- a/src/shared/src/utf8_op.c
+++ b/src/shared/src/utf8_op.c
@@ -126,3 +126,33 @@ char * w_utf8_filter(const char * string, bool replacement) {
     copy[i] = '\0';
     return copy;
 }
+
+size_t w_utf8_truncate_len(const char * string, size_t max_length) {
+    assert(string != NULL);
+
+    /* Only whether the string exceeds max_length matters, and past that point
+     * the length itself is never used, so stop counting there. */
+    size_t length = strnlen(string, max_length + 1);
+
+    if (length <= max_length) {
+        return length;
+    }
+
+    /* string[max_length] is the first byte dropped. While it is a continuation
+     * byte (10xxxxxx) the cut falls inside a character, so walk back to its
+     * leading byte and drop the sequence whole. */
+    size_t cut = max_length;
+    size_t steps = 0;
+
+    /* No UTF-8 character is longer than four bytes, so a leading byte is at
+     * most three steps back. */
+    while (cut > 0 && steps < 3 && ((unsigned char)string[cut] & 0xC0) == 0x80) {
+        cut--;
+        steps++;
+    }
+
+    /* A longer run of continuation bytes is not a character at all. The string
+     * was already malformed there, so cut where asked instead of discarding an
+     * unbounded run of it. */
+    return (((unsigned char)string[cut] & 0xC0) == 0x80) ? max_length : cut;
+}

--- a/src/unit_tests/shared/test_mq_op.c
+++ b/src/unit_tests/shared/test_mq_op.c
@@ -503,6 +503,96 @@ void test_SendMSGAction_secure_msg_keepalive(void ** state){
     assert_int_equal(ret, 0);
 }
 
+void test_SendMSGAction_replaces_an_invalid_utf8_byte_in_the_message(void ** state){
+    (void)state;
+    int queue = 0;
+
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "Invalid UTF-8 byte in a message from '/var/log/test.log'. Replacing it with U+FFFD.");
+
+    expect_value(__wrap_OS_SendUnix, socket, queue);
+    expect_string(__wrap_OS_SendUnix, msg, "1:/var/log/test.log:caf\xEF\xBF\xBD");
+    expect_value(__wrap_OS_SendUnix, size, 0);
+    will_return(__wrap_OS_SendUnix, 1);
+
+    int ret = SendMSG(queue, "caf\xE9", "/var/log/test.log", LOCALFILE_MQ);
+
+    assert_int_equal(ret, 0);
+}
+
+void test_SendMSGAction_cuts_an_oversize_message_on_a_character_boundary(void ** state){
+    (void)state;
+    int queue = 0;
+    char location[300];
+    char message[OS_MAXSTR];
+    char expected[OS_MAXSTR];
+
+    memset(location, 'a', sizeof(location) - 1);
+    location[sizeof(location) - 1] = '\0';
+
+    size_t budget = OS_MAXSTR - 1 - (strlen(location) + 3);
+
+    memset(message, 'b', budget - 1);
+    memcpy(message + budget - 1, "\xE2\x82\xAC", 3);
+    message[budget + 2] = '\0';
+
+    int header = snprintf(expected, sizeof(expected), "1:%s:", location);
+    memset(expected + header, 'b', budget - 1);
+    expected[header + budget - 1] = '\0';
+
+    expect_value(__wrap_OS_SendUnix, socket, queue);
+    expect_string(__wrap_OS_SendUnix, msg, expected);
+    expect_value(__wrap_OS_SendUnix, size, 0);
+    will_return(__wrap_OS_SendUnix, 1);
+
+    int ret = SendMSG(queue, message, location, LOCALFILE_MQ);
+
+    assert_int_equal(ret, 0);
+
+    /* Independent of the header formula above: OS_MAXSTR - 1 is what snprintf
+     * can write, the header takes 302 bytes of it, and the trailing three-byte
+     * character does not fit in the remainder, so the line stops one byte short
+     * of a full buffer. A header off by any amount moves this. */
+    assert_int_equal(strlen(expected), 65534);
+}
+
+void test_SendMSGAction_cuts_an_oversize_secure_message_on_a_character_boundary(void ** state){
+    (void)state;
+    int queue = 0;
+    char location[300];
+    char raw[OS_MAXSTR];
+    char expected[OS_MAXSTR];
+
+    memset(location, 'a', sizeof(location) - 1);
+    location[sizeof(location) - 1] = '\0';
+
+    size_t budget = OS_MAXSTR - 1 - (strlen(location) + 4);
+
+    int prefix = snprintf(raw, sizeof(raw), "4:");
+    memset(raw + prefix, 'b', budget - 1);
+    memcpy(raw + prefix + budget - 1, "\xE2\x82\xAC", 3);
+    raw[prefix + budget + 2] = '\0';
+
+    int header = snprintf(expected, sizeof(expected), "4:%s->", location);
+    memset(expected + header, 'b', budget - 1);
+    expected[header + budget - 1] = '\0';
+
+    expect_value(__wrap_OS_SendUnix, socket, queue);
+    expect_string(__wrap_OS_SendUnix, msg, expected);
+    expect_value(__wrap_OS_SendUnix, size, 0);
+    will_return(__wrap_OS_SendUnix, 1);
+
+    int ret = SendMSG(queue, raw, location, SECURE_MQ);
+
+    assert_int_equal(ret, 0);
+
+    /* Independent of the header formula above: OS_MAXSTR - 1 is what snprintf
+     * can write, the header takes 303 bytes of it, and the trailing three-byte
+     * character does not fit in the remainder, so the line stops one byte short
+     * of a full buffer. A header off by any amount moves this. */
+    assert_int_equal(strlen(expected), 65534);
+}
+
 void test_SendBinaryMSGAction_secure_mq_not_supported(void **state) {
     (void)state;
 
@@ -622,6 +712,9 @@ int main(void){
        cmocka_unit_test(test_SendMSGAction_socket_busy),
        cmocka_unit_test(test_SendMSGAction_non_secure_msg),
        cmocka_unit_test(test_SendMSGAction_secure_msg_keepalive),
+       cmocka_unit_test(test_SendMSGAction_replaces_an_invalid_utf8_byte_in_the_message),
+       cmocka_unit_test(test_SendMSGAction_cuts_an_oversize_message_on_a_character_boundary),
+       cmocka_unit_test(test_SendMSGAction_cuts_an_oversize_secure_message_on_a_character_boundary),
        // Test test_SendBinaryMSG
        cmocka_unit_test(test_SendBinaryMSGAction_secure_mq_not_supported),
        cmocka_unit_test(test_SendBinaryMSGAction_message_too_large),

--- a/src/unit_tests/shared/test_mq_op.c
+++ b/src/unit_tests/shared/test_mq_op.c
@@ -503,6 +503,19 @@ void test_SendMSGAction_secure_msg_keepalive(void ** state){
     assert_int_equal(ret, 0);
 }
 
+void test_SendMSGAction_rejects_a_null_message(void ** state){
+    (void)state;
+
+    expect_string(__wrap__merror, formatted_msg, "(1106): String not correctly formatted.");
+
+    int ret = SendMSG(0, NULL, "/var/log/test.log", LOCALFILE_MQ);
+
+    assert_int_equal(ret, 0);
+}
+
+/* utf8_reported in SendMSGAction() is process-global and cmocka runs every test in one
+ * process, so this must stay the first registered test that sends invalid UTF-8. A later
+ * one reaches the mdebug2 arm instead and this mwarn expectation fails. */
 void test_SendMSGAction_replaces_an_invalid_utf8_byte_in_the_message(void ** state){
     (void)state;
     int queue = 0;
@@ -540,6 +553,11 @@ void test_SendMSGAction_cuts_an_oversize_message_on_a_character_boundary(void **
     memset(expected + header, 'b', budget - 1);
     expected[header + budget - 1] = '\0';
 
+    char expected_debug[512];
+    snprintf(expected_debug, sizeof(expected_debug),
+             "Message from '%s' cut to %zu bytes to fit the queue.", location, budget - 1);
+    expect_string(__wrap__mdebug2, formatted_msg, expected_debug);
+
     expect_value(__wrap_OS_SendUnix, socket, queue);
     expect_string(__wrap_OS_SendUnix, msg, expected);
     expect_value(__wrap_OS_SendUnix, size, 0);
@@ -576,6 +594,11 @@ void test_SendMSGAction_cuts_an_oversize_secure_message_on_a_character_boundary(
     int header = snprintf(expected, sizeof(expected), "4:%s->", location);
     memset(expected + header, 'b', budget - 1);
     expected[header + budget - 1] = '\0';
+
+    char expected_debug[512];
+    snprintf(expected_debug, sizeof(expected_debug),
+             "Message from '%s' cut to %zu bytes to fit the queue.", location, budget - 1);
+    expect_string(__wrap__mdebug2, formatted_msg, expected_debug);
 
     expect_value(__wrap_OS_SendUnix, socket, queue);
     expect_string(__wrap_OS_SendUnix, msg, expected);
@@ -712,6 +735,7 @@ int main(void){
        cmocka_unit_test(test_SendMSGAction_socket_busy),
        cmocka_unit_test(test_SendMSGAction_non_secure_msg),
        cmocka_unit_test(test_SendMSGAction_secure_msg_keepalive),
+       cmocka_unit_test(test_SendMSGAction_rejects_a_null_message),
        cmocka_unit_test(test_SendMSGAction_replaces_an_invalid_utf8_byte_in_the_message),
        cmocka_unit_test(test_SendMSGAction_cuts_an_oversize_message_on_a_character_boundary),
        cmocka_unit_test(test_SendMSGAction_cuts_an_oversize_secure_message_on_a_character_boundary),

--- a/src/unit_tests/shared/test_utf8_op.c
+++ b/src/unit_tests/shared/test_utf8_op.c
@@ -332,8 +332,25 @@ void test_special_unicode_characters(void **state) {
     }
 }
 
+void test_utf8_truncate_len_keeps_characters_whole(void **state) {
+    (void)state;
+
+    assert_int_equal(w_utf8_truncate_len("hello", 10), 5);
+    assert_int_equal(w_utf8_truncate_len("hello", 5), 5);
+    assert_int_equal(w_utf8_truncate_len("a\xC3\xA9", 2), 1);
+    assert_int_equal(w_utf8_truncate_len("a\xC3\xA9", 3), 3);
+    assert_int_equal(w_utf8_truncate_len("ab\xEF\xBF\xBD", 4), 2);
+    assert_int_equal(w_utf8_truncate_len("\xE2\x82\xAC", 1), 0);
+    assert_int_equal(w_utf8_truncate_len("a\x80\x80\x80\x80\x80", 5), 5);
+
+    char pair[] = "\xE2\x82\xAC\xE2\x82\xAC";
+    pair[w_utf8_truncate_len(pair, 4)] = '\0';
+    assert_true(w_utf8_valid(pair));
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_utf8_truncate_len_keeps_characters_whole),
         cmocka_unit_test(test_valid_utf8_sequences),
         cmocka_unit_test(test_invalid_utf8_sequences),
         cmocka_unit_test(test_utf8_random_replace),

--- a/src/unit_tests/win32/test_win_utils.c
+++ b/src/unit_tests/win32/test_win_utils.c
@@ -322,6 +322,94 @@ static void test_SendMSGAction_multi_escape(void **state) {
     assert_int_equal(ret, 0);
 }
 
+static void test_SendMSGAction_rejects_a_null_message(void **state) {
+    (void) state;
+
+    expect_any(wrap_WaitForSingleObject, hMutex);
+    expect_value(wrap_WaitForSingleObject, value, 1000000L);
+    will_return(wrap_WaitForSingleObject, WAIT_OBJECT_0);
+
+    expect_string(__wrap__merror, formatted_msg, "(1106): String not correctly formatted.");
+
+    expect_any(wrap_ReleaseMutex, hMutex);
+    will_return(wrap_ReleaseMutex, 1);
+
+    int ret = SendMSG(0, NULL, "locmsg", LOCALFILE_MQ);
+
+    assert_int_equal(ret, -1);
+}
+
+/* utf8_reported in SendMSGAction() is process-global and cmocka runs every test in one
+ * process, so this must stay the first registered test that sends invalid UTF-8. A later
+ * one reaches the mdebug2 arm instead and this mwarn expectation fails. */
+static void test_SendMSGAction_replaces_an_invalid_utf8_byte_in_the_message(void **state) {
+    (void) state;
+
+    expect_any(wrap_WaitForSingleObject, hMutex);
+    expect_value(wrap_WaitForSingleObject, value, 1000000L);
+    will_return(wrap_WaitForSingleObject, WAIT_OBJECT_0);
+
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "Invalid UTF-8 byte in a message from 'test.log'. Replacing it with U+FFFD.");
+
+    expect_string(__wrap_w_https_client_submit_event, frame, "1:test.log:caf\xEF\xBF\xBD");
+    expect_value(__wrap_w_https_client_submit_event, length, strlen("1:test.log:caf\xEF\xBF\xBD"));
+    will_return(__wrap_w_https_client_submit_event, 0);
+
+    expect_any(wrap_ReleaseMutex, hMutex);
+    will_return(wrap_ReleaseMutex, 1);
+
+    int ret = SendMSG(0, "caf\xE9", "test.log", LOCALFILE_MQ);
+
+    assert_int_equal(ret, 0);
+}
+
+static void test_SendMSGAction_cuts_an_oversize_message_on_a_character_boundary(void **state) {
+    (void) state;
+    static char location[300];
+    static char message[OS_MAXSTR];
+    static char expected[OS_MAXSTR];
+    char expected_debug[512];
+
+    memset(location, 'a', sizeof(location) - 1);
+    location[sizeof(location) - 1] = '\0';
+
+    size_t budget = OS_MAXSTR - 1 - (strlen(location) + 3);
+
+    memset(message, 'b', budget - 1);
+    memcpy(message + budget - 1, "\xE2\x82\xAC", 3);
+    message[budget + 2] = '\0';
+
+    int header = snprintf(expected, sizeof(expected), "1:%s:", location);
+    memset(expected + header, 'b', budget - 1);
+    expected[header + budget - 1] = '\0';
+
+    expect_any(wrap_WaitForSingleObject, hMutex);
+    expect_value(wrap_WaitForSingleObject, value, 1000000L);
+    will_return(wrap_WaitForSingleObject, WAIT_OBJECT_0);
+
+    snprintf(expected_debug, sizeof(expected_debug),
+             "Message from '%s' cut to %zu bytes to fit the queue.", location, budget - 1);
+    expect_string(__wrap__mdebug2, formatted_msg, expected_debug);
+
+    expect_string(__wrap_w_https_client_submit_event, frame, expected);
+    expect_value(__wrap_w_https_client_submit_event, length, strlen(expected));
+    will_return(__wrap_w_https_client_submit_event, 0);
+
+    expect_any(wrap_ReleaseMutex, hMutex);
+    will_return(wrap_ReleaseMutex, 1);
+
+    int ret = SendMSG(0, message, location, LOCALFILE_MQ);
+
+    assert_int_equal(ret, 0);
+
+    /* Independent of the header formula above: OS_MAXSTR - 1 is what snprintf
+     * can write, the header takes 302 bytes of it, and the trailing three-byte
+     * character does not fit in the remainder, so the line stops one byte short
+     * of a full buffer. A header off by any amount moves this. */
+    assert_int_equal(strlen(expected), 65534);
+}
+
 static void test_SendBinaryMSGAction_mutex_abandoned(void **state) {
     (void) state;
 
@@ -568,6 +656,9 @@ int main(void) {
         cmocka_unit_test(test_SendMSGAction_mutex_abandoned), cmocka_unit_test(test_SendMSGAction_mutex_error),
         cmocka_unit_test(test_SendMSGAction_non_escape), cmocka_unit_test(test_SendMSGAction_escape),
         cmocka_unit_test(test_SendMSGAction_multi_escape),
+        cmocka_unit_test(test_SendMSGAction_rejects_a_null_message),
+        cmocka_unit_test(test_SendMSGAction_replaces_an_invalid_utf8_byte_in_the_message),
+        cmocka_unit_test(test_SendMSGAction_cuts_an_oversize_message_on_a_character_boundary),
         cmocka_unit_test(test_SendBinaryMSGAction_mutex_abandoned),
         cmocka_unit_test(test_SendBinaryMSGAction_message_too_large),
         cmocka_unit_test(test_SendBinaryMSGAction_submits_the_binary_frame),

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -605,6 +605,12 @@ int SendMSGAction(__attribute__((unused)) int queue, const char *message, const 
         return retval;
     }
 
+    if (message == NULL) {
+        merror(FORMAT_ERROR);
+        ReleaseMutex(hMutex);
+        return retval;
+    }
+
     /* The engine puts this message in a JSON document, and Json::str() aborts
      * the whole document on any invalid byte, so the event and the alert it
      * would have raised are both lost. Filtering here covers every producer
@@ -630,6 +636,10 @@ int SendMSGAction(__attribute__((unused)) int queue, const char *message, const 
      * Measure it and hand snprintf a length that keeps every character whole. */
     header_length = strlen(loc_buff) + 3; /* "%c:" + loc_buff + ":" */
     message_length = w_utf8_truncate_len(message, OS_MAXSTR - 1 - header_length);
+
+    if (message[message_length] != '\0') {
+        mdebug2("Message from '%s' cut to %zu bytes to fit the queue.", locmsg, message_length);
+    }
 
     snprintf(tmpstr, OS_MAXSTR, "%c:%s:%.*s", loc, loc_buff, (int)message_length, message);
 

--- a/src/win32/win_utils.c
+++ b/src/win32/win_utils.c
@@ -571,6 +571,9 @@ int SendMSGAction(__attribute__((unused)) int queue, const char *message, const 
     char tmpstr[OS_MAXSTR + 2];
     DWORD dwWaitResult;
     int retval = -1;
+    char *sanitized = NULL;
+    size_t header_length;
+    size_t message_length;
     tmpstr[OS_MAXSTR + 1] = '\0';
 
     /* Using a mutex to synchronize the writes */
@@ -598,10 +601,39 @@ int SendMSGAction(__attribute__((unused)) int queue, const char *message, const 
 
     if (OS_INVALID == wstr_escape(loc_buff, sizeof(loc_buff), (char *) locmsg, '|', ':')) {
         merror(FORMAT_ERROR);
+        ReleaseMutex(hMutex);
         return retval;
     }
 
-    snprintf(tmpstr, OS_MAXSTR, "%c:%s:%s", loc, loc_buff, message);
+    /* The engine puts this message in a JSON document, and Json::str() aborts
+     * the whole document on any invalid byte, so the event and the alert it
+     * would have raised are both lost. Filtering here covers every producer
+     * that sends an event, instead of one reader at a time. */
+    if (!w_utf8_valid(message)) {
+        static int utf8_reported = 0;
+
+        sanitized = w_utf8_filter(message, true);
+        message = sanitized;
+
+        if (!utf8_reported) {
+            mwarn("Invalid UTF-8 byte in a message from '%s'. Replacing it with U+FFFD.", locmsg);
+            utf8_reported = 1;
+        } else {
+            mdebug2("Invalid UTF-8 byte in a message from '%s'. Replacing it with U+FFFD.", locmsg);
+        }
+    }
+
+    /* The snprintf below cuts at a byte offset, which can split a multi-byte
+     * character, including an EF BF BD just written above. The header is the
+     * only thing standing between the payload and OS_MAXSTR, and its real
+     * length is the escaped location, up to OS_SIZE_8192, not OS_LOG_HEADER.
+     * Measure it and hand snprintf a length that keeps every character whole. */
+    header_length = strlen(loc_buff) + 3; /* "%c:" + loc_buff + ":" */
+    message_length = w_utf8_truncate_len(message, OS_MAXSTR - 1 - header_length);
+
+    snprintf(tmpstr, OS_MAXSTR, "%c:%s:%.*s", loc, loc_buff, (int)message_length, message);
+
+    os_free(sanitized);
 
     /* Every event goes to the HTTPS /stateless accumulator; sync sessions are
      * handed to the module in-process (bridge_submit_sync_session).


### PR DESCRIPTION
## Description

An agent event that carries a byte which is not valid UTF-8 is lost, along with the alert it would have raised. A log line read from a file written in ISO-8859-1 does it, and so does a Windows classic Eventlog record on a host whose ANSI codepage is not UTF-8.

The manager serialises the event into JSON. At `src/engine/source/base/src/json.cpp:628`, `m_document.Accept(writer)` returns `false` for a string it cannot transcode, the return value is discarded, and `buffer.GetString()` hands back a truncated fragment. The indexer's parser then reaches end-of-input inside an unterminated string and throws `json_e_o_f_exception`, rejecting that action of the bulk request. The surrounding actions still land, which is why the evidence below (Path 1) loses six of eleven lines rather than all of them.

The fix is on the agent, at the point every event passes through: replace the offending bytes before the event is sent. Replacement rather than conversion is deliberate, because a log file carries no encoding declaration. `0xE9` is `é` in ISO-8859-1 and Windows-1252, `ι` in ISO-8859-7, `щ` in ISO-8859-5 and `И` in KOI8-R. Choosing one would write a plausible but wrong character into a security event.

Closes #38561

**Scope.** Three failures in this area look alike, an invalid byte and a lost event, but they die in different places and want different answers. They are split by where the event dies, and for the ones that die inside the agent, by whose data caused it. This pull request implements the first row only.

| Issue | Where the event dies | Whose data | Answer |
|---|---|---|---|
| #38561, this one | leaves the agent, the indexer rejects it | external | replace the bytes before sending |
| #38754 | dropped inside the agent | the agent's own configuration | validate and reject at parse time |
| #38755 | dropped inside the agent | external, as read from the source | recover in the reader |

The answers differ because the data does. For a log line the encoding is undeclared and unknowable, as above, so replacement is all that is left. A configuration value is written by an operator into a file whose schema the agent owns, so the agent can state which characters it supports and reject the value where it is parsed, rather than silently storing a path nobody typed; replacement is not reversible, and that matters more for a path than for a message, because a path is an identifier. An event a reader threw away never reaches the send path at all, so no amount of filtering there can bring it back.

The issue also asks that a loss be "accounted for somewhere an operator can total up, not only as one `WARNING` per occurrence". On this path there is no longer a loss to total: the event lands. What remains is the arithmetic, so the truncating branch reports at `mdebug2` naming the location and the length kept, and the filter itself reports once at `WARNING` and at `mdebug2` afterwards, following the rate-limiting pattern already in the same function. The two cases that still drop an event whole are the NUL line and the reader-side drops, both #38755, and the unfiltered location, #38754.

## Proposed Changes

One change, in the one place every event passes through.

**`SendMSGAction()` in `src/shared/src/mq_op.c` and `src/win32/win_utils.c`**

Every daemon that emits an event calls `SendMSG()`, which reaches `SendMSGAction()`. There are two implementations, because `mq_op.c` is entirely inside `#ifndef WIN32` (`:24` to `:532`) and the Windows agent uses its own copy at `win_utils.c:568`. Both now do the same three things.

*Replace.* When `w_utf8_valid()` fails on the payload, `w_utf8_filter()` rewrites each invalid byte as U+FFFD. `w_utf8_filter()` already existed in `src/shared/src/utf8_op.c`; before this change its only caller was `src/remoted/src/manager.c:259`, which filters agent-info control messages and not events. Reported once per process at `WARNING` naming `locmsg`, and at `mdebug2` afterwards, following the rate-limiting pattern already in the same function. `locmsg` is the log file path for a logcollector event and the module name for everything else, so the operator gets the source without a per-reader message.

On the `SECURE_MQ` path the filter runs after the `X:` framing prefix has been stepped over, so only the payload is touched.

*Cut on a character boundary.* Each replacement grows the payload by two bytes, so `snprintf(tmpstr, OS_MAXSTR, "%c:%s:%s", ...)` could now cut inside an `EF BF BD` it had just written and put invalid UTF-8 back on the wire. The header's real length is the escaped location, up to `OS_SIZE_8192`, not `OS_LOG_HEADER`, so it is measured and the payload goes through a `%.*s` precision from the new `w_utf8_truncate_len()` (`src/shared/src/utf8_op.c:130`). That helper walks back at most three bytes, because no UTF-8 character is longer than four; a longer run of continuation bytes is not a character at all and the string was already malformed there, so it cuts where asked rather than discarding an unbounded run of the payload.

Putting this in the send primitive rather than in each reader is the point of the change. One filter covers all 21 logcollector readers, both Windows Eventlog readers, and the FIM, rootcheck, SCA and syscollector payloads that no reader-level fix would have touched. Filtering in `w_msg_hash_queues_push()` instead would have covered logcollector only, and would still have needed separate code in `read_win_el.c`, which does not route through that funnel, and again in `win_utils.c` for the Windows agent.

The trade is replacement rather than conversion. On the Windows classic Eventlog path the bytes are known to be CP_ACP, so `é` could in principle be transcoded back to `é` instead of becoming U+FFFD. Doing that needs the origin of every field, and `final_msg` there mixes the configured channel name with ANSI API output, so one codepage for the whole buffer mistranscodes one half or the other. Getting it right needs a per-field composition in the legacy Windows reader, which is a large amount of code for a cosmetic gain; the modern Event Channel reader already emits UTF-8 and is unaffected. The event lands either way, which is what the issue asks for.

**Notes**

- For an affected event, `event.original` and `message` no longer carry the exact source bytes. The replacement is not reversible, so the identity of the offending byte is not recoverable from the stored document.
- The event *location* is escaped by `wstr_escape()` but not filtered, so a clean log line read from a file whose **name** carries an invalid byte still loses the event. That is #38754, and #38561 is closed with it open. See the scope table above for why a path is not treated like a message.
- Each replacement grows the payload by two bytes, so a payload within a few bytes of `OS_MAXSTR` can now be cut where it previously fitted. Truncation at this boundary was always silent; it is now reported at `mdebug2` naming the location and the length kept. For a raw log line the result is a shortened line. For a `cJSON`-printed payload the cut can break the document, and the engine rejects it instead of the indexer.
- FIM reaches this filter through `send_syscheck_msg()` (`src/syscheckd/src/file/file.c:477`), which runs before any validation, so a file path carrying an invalid byte is replaced and the alert lands where it previously did not. The matching inventory document is rejected regardless, by the schema validator at `src/shared_modules/schema_validator/src/schemaValidator.cpp:390` and skipped at `src/syscheckd/src/run_check.c:637`, and on the route where DBSync's own `dump()` throws first (`src/shared_modules/dbsync/src/dbsync.cpp:150`) the row callback never runs and both are lost. Neither of those is changed here; they are #38755.
- `read_syslog.c:63` truncates a line longer than 65279 bytes at a fixed byte offset and can split a multi-byte character. This change repairs the result, because the filter runs after the cut, but the truncation itself is unchanged.
- A NUL never reaches the manager: `read_syslog.c:55` compares `strlen(str)` against `rbytes - 1` and drops the whole line, logging at `mdebug2`. Deliberate, pre-existing, unrelated to encoding, and tracked as #38755.
- `__attribute__((nonnull))` on `SendMSG()` and `SendMSGPredicated()` covered every pointer argument, `message` included. That is now `nonnull(3)` and `nonnull(3, 5)`, keeping `locmsg` and `fn_ptr`.

### Results and Evidence

Tested environment: two 5.x Linux agents, with (010) and without (006) the fix, and one Windows 11 agent (009) with `ACP = 1252`, all against a single AIO manager. Three paths: a log line, a Windows classic Eventlog record, and the send primitive's own arithmetic.

**Path 1, log lines**

Eleven lines, identical `sshd` authentication failures differing only in the bytes inside the username, so any difference in outcome is attributable to those bytes.

`ossec.conf`

```text
  <localfile>
    <log_format>syslog</log_format>
    <location>/testlogs/plain.log</location>
  </localfile>
```

Appending the test logs

```bash
printf 'Aug 24 17:10:00 agent-11 sshd[4242]: Failed password for ${T}CLEANXX from 198.51.100.201 port 22 ssh2\n' >> /testlogs/plain.log
printf 'Aug 24 17:10:00 agent-11 sshd[4242]: Failed password for ${T}CTLXX\x01\x02X from 198.51.100.201 port 22 ssh2\n' >> /testlogs/plain.log
printf 'Aug 24 17:10:00 agent-11 sshd[4242]: Failed password for ${T}U2XXX\xc3\xa9X from 198.51.100.201 port 22 ssh2\n' >> /testlogs/plain.log
printf 'Aug 24 17:10:00 agent-11 sshd[4242]: Failed password for ${T}U3XXX\xe4\xb8\xadX from 198.51.100.201 port 22 ssh2\n' >> /testlogs/plain.log
printf 'Aug 24 17:10:00 agent-11 sshd[4242]: Failed password for ${T}FFXX\xffX from 198.51.100.201 port 22 ssh2\n' >> /testlogs/plain.log
printf 'Aug 24 17:10:00 agent-11 sshd[4242]: Failed password for ${T}OVLXX\xc0\xafX from 198.51.100.201 port 22 ssh2\n' >> /testlogs/plain.log
printf 'Aug 24 17:10:00 agent-11 sshd[4242]: Failed password for ${T}SURXX\xed\xa0\x80X from 198.51.100.201 port 22 ssh2\n' >> /testlogs/plain.log
printf 'Aug 24 17:10:00 agent-11 sshd[4242]: Failed password for ${T}CONXX\x80X from 198.51.100.201 port 22 ssh2\n' >> /testlogs/plain.log
printf 'Aug 24 17:10:00 agent-11 sshd[4242]: Failed password for ${T}LATXX\xe9X from 198.51.100.201 port 22 ssh2\n' >> /testlogs/plain.log
printf 'Aug 24 17:10:00 agent-11 sshd[4242]: Failed password for ${T}TRUNC\xe4\xb8X from 198.51.100.201 port 22 ssh2\n' >> /testlogs/plain.log
printf 'Aug 24 17:10:00 agent-11 sshd[4242]: Failed password for ${T}NULXX\x00X from 198.51.100.201 port 22 ssh2\n' >> /testlogs/plain.log
```

Agent 010 (with fix)

<img width="2429" height="1368" alt="Screenshot 2026-08-31 at 11 00 00 PM" src="https://github.com/user-attachments/assets/87bc08b6-9ab9-4986-bd62-211b40f16dac" />

Agent-side report, once for the whole probe rather than once per line:

```text
2026/08/31 22:54:21 wazuh-logcollector: WARNING: Invalid UTF-8 byte in a message from '/testlogs/plain.log'. Replacing it with U+FFFD.
```

Agent 006 (without fix)

<img width="2439" height="978" alt="Screenshot 2026-08-25 at 7 14 56 PM" src="https://github.com/user-attachments/assets/8eb38a51-2d38-4a07-b5dd-553976db4e71" />

| case | bytes | 006 | 004 |
|---|---|---|---|
| plain ASCII | - | 🟢 | 🟢 |
| control characters | `01 02` | 🟢 | 🟢 |
| valid 2-byte sequence | `c3 a9` | 🟢 | 🟢 |
| valid 3-byte sequence | `e4 b8 ad` | 🟢 | 🟢 |
| byte legal in no position | `ff` | 🔴 | 🟢 |
| overlong encoding | `c0 af` | 🔴 | 🟢 |
| UTF-16 surrogate half | `ed a0 80` | 🔴 | 🟢 |
| lone continuation byte | `80` | 🔴 | 🟢 |
| ISO-8859-1 accent | `e9` | 🔴 | 🟢 |
| truncated 3-byte sequence | `e4 b8` | 🔴 | 🟢 |
| NULL | `00` | 🟡  | 🟡  |

`json_e_o_f_exception` in `wazuh-manager.log` over the probe: 6 on 006, 0 on 010. One occurrence per lost line.

> A NUL never reaches the manager, `read_syslog.c:55` compares `strlen(str)` against `rbytes - 1` and drops the whole line, logging at `mdebug2`. Deliberate, pre-existing, unrelated to encoding.

**Path 2, Windows classic Eventlog**

The same `é`, delivered by Windows as the single byte `0xE9` because the host ANSI codepage is 1252. The Event Channel reader is the control: it carries the same characters correctly in the same deployment.

`ossec.conf`

```text
  <localfile>
    <location>Application</location>
    <log_format>eventlog</log_format>
  </localfile>
```

Writing the test events

```powershell
New-EventLog -LogName Application -Source "Wazuh38561"
Write-EventLog -LogName Application -Source "Wazuh38561" -EventId 999 -EntryType Information -Message "${T}CLEAN plain ascii only end"
Write-EventLog -LogName Application -Source "Wazuh38561" -EventId 999 -EntryType Information -Message "${T}LATIN cafe accent café end"
Write-EventLog -LogName Application -Source "Wazuh38561" -EventId 999 -EntryType Information -Message "${T}MIXED senor naive uber señor naïve über end"
Write-EventLog -LogName Application -Source "Wazuh38561" -EventId 999 -EntryType Information -Message "${T}EURO euro sign € end"
```

Agent 007 (without fix)

Without the fix, one event of the four is indexed and `json_e_o_f_exception` rises by three. The manager dumps each lost payload, truncated at the offending byte.

<img width="2438" height="576" alt="Screenshot 2026-08-26 at 7 28 40 PM" src="https://github.com/user-attachments/assets/8bc2d1e4-126d-4b9f-971c-13a71ddd9655" />

```text
2026/08/26 09:45:42 wazuh-manager-analysisd(indexer-connector): WARNING: Error indexing
document (type mapper_parsing_exception - reason: 'failed to parse field [event.original] of type [keyword] in document with id '4kOIPqABcNTFHVh2tTLx'. Preview of field's value: ''' - caused by: json_e_o_f_exception - 'Unexpected end-of-input in VALUE_STRING
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 742]') - Associated event: {"create":{"_index":"wazuh-events-v5-unclassified"}}
{"wazuh":{"protocol":{"queue":49,"location":"WinEvtLog"},"agent":{"groups":["default"],"host":{"architecture":"x86_64","hostname":"AGENT-WIN11-ARM","os":{"name":"Microsoft Windows 11 IoT Enterprise LTSC 2024 Evaluation","platform":"windows","type":"windows","version":"10.0.26100.9168"}},"id":"007","name":"windows-agent","version":"v5.0.0"},"cluster":{"name":"wazuh","node":"node01"},"event":{"id":"5e112396-b073-4d7a-9568-a57878676d39"},"integration":{"category":"unclassified","name":"wazuh-core","decoders":["decoder/core-wazuh-message/0"]},"space":{"name":"standard"}},"event":{"original":"2026 Aug 26 09:45:29 WinEvtLog: Application: INFORMATION(999): Wazuh38561: (no user): no domain: agent-win11-arm: G094528MIXED senor naive uber se
2026/08/26 09:45:42 wazuh-manager-analysisd(indexer-connector): WARNING: Error indexing document (type mapper_parsing_exception - reason: 'failed to parse field [event.original
] of type [keyword] in document with id '40OIPqABcNTFHVh2tTLx'. Preview of field's value: ''' - caused by: json_e_o_f_exception - 'Unexpected end-of-input in VALUE_STRING
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 738]') - Associated event: {"create":{"_index":"wazuh-events-v5-unclassified"}}
{"wazuh":{"protocol":{"queue":49,"location":"WinEvtLog"},"agent":{"groups":["default"],"host":{"architecture":"x86_64","hostname":"AGENT-WIN11-ARM","os":{"name":"Microsoft Windows 11 IoT Enterprise LTSC 2024 Evaluation","platform":"windows","type":"windows","version":"10.0.26100.9168"}},"id":"007","name":"windows-agent","version":"v5.0.0"},"cluster":{"name":"wazuh","node":"node01"},"event":{"id":"f6f46720-137c-43b2-b79f-e97d79f4359f"},"integration":{"category":"unclassified","name":"wazuh-core","decoders":["decoder/core-wazuh-message/0"]},"space":{"name":"standard"}},"event":{"original":"2026 Aug 26 09:45:29 WinEvtLog: Application: INFORMATION(999): Wazuh38561: (no user): no domain: agent-win11-arm: G094528LATIN cafe accent caf
2026/08/26 09:45:42 wazuh-manager-analysisd(indexer-connector): WARNING: Error indexing document (type mapper_parsing_exception - reason: 'failed to parse field [event.original] of type [keyword] in document with id '5EOIPqABcNTFHVh2tTLx'. Preview of field's value: ''' - caused by: json_e_o_f_exception - 'Unexpected end-of-input in VALUE_STRING
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 732]') - Associated event: {"create":{"_index":"wazuh-events-v5-unclassified"}}
{"wazuh":{"protocol":{"queue":49,"location":"WinEvtLog"},"agent":{"groups":["default"],"host":{"architecture":"x86_64","hostname":"AGENT-WIN11-ARM","os":{"name":"Microsoft Windows 11 IoT Enterprise LTSC 2024 Evaluation","platform":"windows","type":"windows","version":"10.0.26100.9168"}},"id":"007","name":"windows-agent","version":"v5.0.0"},"cluster":{"name":"wazuh","node":"node01"},"event":{"id":"f5b6a49d-93d6-4772-9070-5b9579f41b7e"},"integration":{"category":"unclassified","name":"wazuh-core","decoders":["decoder/core-wazuh-message/0"]},"space":{"name":"standard"}},"event":{"original":"2026 Aug 26 09:45:29 WinEvtLog: Application: INFORMATION(999): Wazuh38561: (no user): no domain: agent-win11-arm: G094528EURO euro sign
```

Agent 009 (with fix)

With the fix, all four are indexed and `json_e_o_f_exception` does not appear. The accented characters do not survive: each byte the ANSI codepage delivered becomes `U+FFFD`, so `café` is stored as `caf<?>` and `€` as a single replacement character.

<img width="2429" height="920" alt="Screenshot 2026-08-31 at 11 03 38 PM" src="https://github.com/user-attachments/assets/ac4296e2-12fc-42a0-8f3e-0350a6b94d95" />

Agent-side report, once for the whole probe rather than once per line:

```text
2026/08/31 22:56:12 wazuh-agent: WARNING: Invalid UTF-8 byte in a message from 'WinEvtLog'. Replacing it with U+FFFD.
```

| case | bytes as delivered by Windows | without fix | with fix |
|---|---|---|---|
| plain ASCII | - | 🟢 | 🟢 |
| ISO-8859-1 accent, `é` | `e9` | 🔴 | 🟢 |
| several accents, `ñ` `ï` `ü` | `f1` `ef` `fc` | 🔴 | 🟢 |
| euro sign, `€` | `80` | 🔴 | 🟢 |
| Event Channel control, same characters | already UTF-8 after conversion | 🟢 | 🟢 |

The last row is the contrast worth keeping in view: the Event Channel reader carries these characters correctly in the same deployment, because `EvtRender` hands it UTF-16 and the conversion is unambiguous. Only the classic Eventlog reader loses them, and only because a byte in the system codepage cannot be told apart from a byte in any other single-byte encoding once it is in a `char[]`.

**Path 3, the send primitive**

The boundary cut has no before and after at the indexer: a payload long enough to overflow is rejected on `event.original` length whichever way it is cut. The evidence is the unit tests.

### Artifacts Affected

The change is in the shared send primitive, so every binary that links `src/shared` and emits an event is rebuilt: `wazuh-logcollector`, `wazuh-syscheckd`, `wazuh-modulesd`, `wazuh-agentd` and `wazuh-execd` on every agent platform, `wazuh-agent.exe` on Windows, and the manager-side daemons that call `SendMSG()`. Behaviour changes only for a payload that is not already valid UTF-8.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

Eight cases across three files.

`src/unit_tests/shared/test_mq_op.c`

- `test_SendMSGAction_rejects_a_null_message` — a `NULL` payload is rejected with `FORMAT_ERROR` rather than reaching `w_utf8_valid()`, whose `assert()` a release build removes.
- `test_SendMSGAction_replaces_an_invalid_utf8_byte_in_the_message` — a payload carrying a raw `0xE9` reaches `OS_SendUnix()` as `EF BF BD`, and the warning names the location it came from.
- `test_SendMSGAction_cuts_an_oversize_message_on_a_character_boundary` — a payload whose cut point falls inside a three-byte character stops before it. The sent length is pinned to a literal, so a change to the header arithmetic cannot pass unnoticed by producing an equally plausible string.
- `test_SendMSGAction_cuts_an_oversize_secure_message_on_a_character_boundary` — the same for the `SECURE_MQ` branch, whose header is two bytes longer.

`src/unit_tests/shared/test_utf8_op.c`

- `test_utf8_truncate_len_keeps_characters_whole` — the boundary arithmetic directly, on the function `SendMSGAction()` actually calls: no truncation needed, exact fit, a cut inside a two-byte sequence, a cut inside `EF BF BD`, a cut that lands before any character start, and a run of continuation bytes longer than any real character, which must cut where asked instead of discarding the run.

`src/unit_tests/win32/test_win_utils.c`

- `test_SendMSGAction_rejects_a_null_message` — the same guard, additionally asserting the mutex is released rather than leaked.
- `test_SendMSGAction_replaces_an_invalid_utf8_byte_in_the_message` — a raw `0xE9` reaches `w_https_client_submit_event()` as `EF BF BD`.
- `test_SendMSGAction_cuts_an_oversize_message_on_a_character_boundary` — the boundary cut, with the frame length pinned to a literal.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
