### PR TITLE
Restore username validation in the active response framework

### DIFF
--- a/src/active-response/include/active_responses.h
+++ b/src/active-response/include/active_responses.h
@@ -85,11 +85,24 @@ const cJSON* get_alert_from_json(const cJSON *input);
 const char* get_srcip_from_json(const cJSON *input);
 
 /**
- * Get username from input (WCS-compliant: user.name at root level)
+ * Get username from input (WCS-compliant: user.name at root level) and validate its format
  * @param input Input
- * @return char * with the username or NULL on fail
+ * @return char * with the username or NULL on fail or invalid username
  * */
 const char* get_username_from_json(const cJSON *input);
+
+/**
+ * Validate username format
+ * Follows Debian adduser constraints:
+ * - Must not start with dash, plus, or tilde
+ * - Must not contain colon, comma, or whitespace
+ * - Should not contain slash (may break home directory paths)
+ * Rejects: reserved names (root), empty strings, null
+ * @param username Username to validate
+ * @retval 1 If username is valid
+ * @retval 0 If username is invalid
+ * */
+int is_valid_username(const char *username);
 
 /**
  * Get extra_args from input

--- a/src/active-response/src/active_responses.c
+++ b/src/active-response/src/active_responses.c
@@ -212,6 +212,61 @@ const char* get_srcip_from_json(const cJSON *input) {
 }
 
 
+int is_valid_username(const char *username) {
+    if (!username || !*username) {
+        return 0;
+    }
+
+    // Reject reserved names
+    if (strcmp(username, "root") == 0) {
+        return 0;
+    }
+
+    size_t len = strlen(username);
+
+    // Maximum username length (typical limit is 32, but we allow up to 256 for compatibility)
+    if (len > 256) {
+        return 0;
+    }
+
+    // Must not start with dash, plus, or tilde (Debian constraint)
+    if (username[0] == '-' || username[0] == '+' || username[0] == '~') {
+        return 0;
+    }
+
+    // Check for prohibited characters
+    for (size_t i = 0; i < len; i++) {
+        char c = username[i];
+
+        // Reject colon (used as field separator in /etc/passwd)
+        if (c == ':') {
+            return 0;
+        }
+
+        // Reject comma (used in GECOS field)
+        if (c == ',') {
+            return 0;
+        }
+
+        // Reject whitespace characters
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+            return 0;
+        }
+
+        // Reject slash (breaks home directory paths)
+        if (c == '/' || c == '\\') {
+            return 0;
+        }
+    }
+
+    // Reject directory traversal sequence
+    if (strstr(username, "..") != NULL) {
+        return 0;
+    }
+
+    return 1;
+}
+
 const char* get_username_from_json(const cJSON *input) {
     cJSON *user_json = NULL;
     cJSON *username_json = NULL;
@@ -225,7 +280,14 @@ const char* get_username_from_json(const cJSON *input) {
 
     username_json = cJSON_GetObjectItem(user_json, "name");
     if (cJSON_IsString(username_json)) {
-        return username_json->valuestring;
+        const char *username = username_json->valuestring;
+
+        // Validate username format
+        if (!is_valid_username(username)) {
+            return NULL;
+        }
+
+        return username;
     }
 
     return NULL;

--- a/src/active-response/src/disable-account.c
+++ b/src/active-response/src/disable-account.c
@@ -23,10 +23,10 @@ int main (int argc, char **argv) {
         return OS_INVALID;
     }
 
-    // Detect username
+    // Detect username (now validated automatically by get_username_from_json)
     const char *user = get_username_from_json(input_json);
     if (!user) {
-        write_debug_file(argv[0], "Cannot read 'user.name' from data");
+        write_debug_file(argv[0], "Cannot read 'user.name' from data or invalid username format");
         cJSON_Delete(input_json);
         return OS_INVALID;
     }
@@ -54,12 +54,6 @@ int main (int argc, char **argv) {
                 return OS_INVALID;
             }
         }
-    }
-
-    if (!strcmp("root", user)) {
-        write_debug_file(argv[0], "Invalid username");
-        cJSON_Delete(input_json);
-        return OS_INVALID;
     }
 
     if (uname(&uname_buffer) < 0) {

--- a/src/unit_tests/active-response/test_active-response.c
+++ b/src/unit_tests/active-response/test_active-response.c
@@ -164,6 +164,113 @@ void test_validate_srcip_rejects_hostname(void **state) {
     assert_int_equal(validate_srcip("google.com"), OS_INVALID);
 }
 
+// Tests for is_valid_username (Debian adduser constraints)
+
+void test_is_valid_username_valid_simple(void **state) {
+    (void) state;
+    assert_int_equal(is_valid_username("testuser"), 1);
+}
+
+void test_is_valid_username_valid_with_numbers(void **state) {
+    (void) state;
+    assert_int_equal(is_valid_username("user123"), 1);
+    assert_int_equal(is_valid_username("1testuser"), 1);
+}
+
+void test_is_valid_username_valid_with_underscore(void **state) {
+    (void) state;
+    assert_int_equal(is_valid_username("_testuser"), 1);
+    assert_int_equal(is_valid_username("test_user"), 1);
+}
+
+void test_is_valid_username_valid_with_hyphen(void **state) {
+    (void) state;
+    assert_int_equal(is_valid_username("test-user"), 1);
+}
+
+void test_is_valid_username_valid_with_dollar(void **state) {
+    (void) state;
+    assert_int_equal(is_valid_username("machine$"), 1);
+    assert_int_equal(is_valid_username("test$user"), 1);
+}
+
+void test_is_valid_username_valid_uppercase(void **state) {
+    (void) state;
+    assert_int_equal(is_valid_username("TestUser"), 1);
+    assert_int_equal(is_valid_username("TESTUSER"), 1);
+}
+
+void test_is_valid_username_valid_with_dot(void **state) {
+    (void) state;
+    assert_int_equal(is_valid_username("test.user"), 1);
+}
+
+void test_is_valid_username_invalid_root(void **state) {
+    (void) state;
+    assert_int_equal(is_valid_username("root"), 0);
+}
+
+void test_is_valid_username_invalid_null(void **state) {
+    (void) state;
+    assert_int_equal(is_valid_username(NULL), 0);
+}
+
+void test_is_valid_username_invalid_empty(void **state) {
+    (void) state;
+    assert_int_equal(is_valid_username(""), 0);
+}
+
+void test_is_valid_username_invalid_starts_with_dash(void **state) {
+    (void) state;
+    assert_int_equal(is_valid_username("-testuser"), 0);
+}
+
+void test_is_valid_username_invalid_starts_with_plus(void **state) {
+    (void) state;
+    assert_int_equal(is_valid_username("+testuser"), 0);
+}
+
+void test_is_valid_username_invalid_starts_with_tilde(void **state) {
+    (void) state;
+    assert_int_equal(is_valid_username("~testuser"), 0);
+}
+
+void test_is_valid_username_invalid_with_colon(void **state) {
+    (void) state;
+    assert_int_equal(is_valid_username("test:user"), 0);
+}
+
+void test_is_valid_username_invalid_with_comma(void **state) {
+    (void) state;
+    assert_int_equal(is_valid_username("test,user"), 0);
+}
+
+void test_is_valid_username_invalid_with_whitespace(void **state) {
+    (void) state;
+    assert_int_equal(is_valid_username("test user"), 0);
+    assert_int_equal(is_valid_username("test\tuser"), 0);
+}
+
+void test_is_valid_username_invalid_with_slash(void **state) {
+    (void) state;
+    assert_int_equal(is_valid_username("test/user"), 0);
+    assert_int_equal(is_valid_username("test\\user"), 0);
+}
+
+void test_is_valid_username_invalid_path_traversal(void **state) {
+    (void) state;
+    assert_int_equal(is_valid_username("../root"), 0);
+    assert_int_equal(is_valid_username("test/../user"), 0);
+}
+
+void test_is_valid_username_invalid_too_long(void **state) {
+    (void) state;
+    char long_username[300];
+    memset(long_username, 'a', 257);
+    long_username[257] = '\0';
+    assert_int_equal(is_valid_username(long_username), 0);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown(test_get_ip_version_success_ipv4, test_setup, test_teardown),
@@ -177,6 +284,25 @@ int main(void) {
         cmocka_unit_test(test_validate_srcip_rejects_cidr),
         cmocka_unit_test(test_validate_srcip_rejects_argument_injection),
         cmocka_unit_test(test_validate_srcip_rejects_hostname),
+        cmocka_unit_test(test_is_valid_username_valid_simple),
+        cmocka_unit_test(test_is_valid_username_valid_with_numbers),
+        cmocka_unit_test(test_is_valid_username_valid_with_underscore),
+        cmocka_unit_test(test_is_valid_username_valid_with_hyphen),
+        cmocka_unit_test(test_is_valid_username_valid_with_dollar),
+        cmocka_unit_test(test_is_valid_username_valid_uppercase),
+        cmocka_unit_test(test_is_valid_username_valid_with_dot),
+        cmocka_unit_test(test_is_valid_username_invalid_root),
+        cmocka_unit_test(test_is_valid_username_invalid_null),
+        cmocka_unit_test(test_is_valid_username_invalid_empty),
+        cmocka_unit_test(test_is_valid_username_invalid_starts_with_dash),
+        cmocka_unit_test(test_is_valid_username_invalid_starts_with_plus),
+        cmocka_unit_test(test_is_valid_username_invalid_starts_with_tilde),
+        cmocka_unit_test(test_is_valid_username_invalid_with_colon),
+        cmocka_unit_test(test_is_valid_username_invalid_with_comma),
+        cmocka_unit_test(test_is_valid_username_invalid_with_whitespace),
+        cmocka_unit_test(test_is_valid_username_invalid_with_slash),
+        cmocka_unit_test(test_is_valid_username_invalid_path_traversal),
+        cmocka_unit_test(test_is_valid_username_invalid_too_long),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
## Description
The `disable-account` active response takes the username from the `user.name` field of the event and passes
it straight to `passwd -l` / `passwd -u`, so a value starting with `-` is parsed by `passwd` as an option
instead of as the account to act on and the account is never locked. The centralized validation added in
4.14.7 was lost when the active response tree was restructured for 5.x. This restores it: usernames are now
validated in `get_username_from_json()`, so every consumer of the field is covered.

## Proposed Changes
- `src/active-response/include/active_responses.h`: declare `is_valid_username()` and document that
  `get_username_from_json()` now validates its result.
- `src/active-response/src/active_responses.c`: add `is_valid_username()` and call it from
  `get_username_from_json()`, which returns `NULL` for a malformed username.
- `src/active-response/src/disable-account.c`: drop the now-redundant `root` comparison (covered by
  `is_valid_username()`) and reword the debug message to mention an invalid username format.
- `src/unit_tests/active-response/test_active-response.c`: 19 test cases for `is_valid_username()`.

### Results and Evidence

`test_active-response` CMocka suite — 30 tests (11 pre-existing, 19 new), all passing:

```
[==========] tests: 30 test(s) run.
[  PASSED  ] 30 test(s).
```

The new cases fail before the change: `is_valid_username()` does not exist, so the suite does not link
(5 × `undefined reference to 'is_valid_username'`).

End-to-end check of `get_username_from_json()` against the built library, before and after the change:

| `user.name` | Before | After |
|---|---|---|
| `--help` | returned `--help` | rejected (`NULL`) |
| `-S` | returned `-S` | rejected (`NULL`) |
| `--root=/tmp` | returned `--root=/tmp` | rejected (`NULL`) |
| `root` | returned `root` | rejected (`NULL`) |
| `alice` | returned `alice` | returned `alice` |
| `test-user` | returned `test-user` | returned `test-user` |

With the reporter's `--help` value now rejected, `disable-account` aborts before reaching `passwd` instead of
running `passwd -l --help`, which exited 0 without locking the account.

### Artifacts Affected
`disable-account` and `block-ip` active response binaries, shipped in the `wazuh-agent` and `wazuh-manager`
packages.

### Configuration Changes
None.

### Documentation Updates
None.

### Tests Introduced
`src/unit_tests/active-response/test_active-response.c` — 19 cases registered in the `test_active-response`
CMocka suite, covering accepted usernames (letters, digits, `_`, `-`, `$`, `.`, uppercase) and rejected ones
(`root`, `NULL`, empty, leading `-`/`+`/`~`, `:`, `,`, whitespace, `/`, `\`, `..`, over 256 bytes).

## Credits
Reported by Rafael Honorato (@honorato0). The original centralized validation this change restores was
reported by TristanInSec.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
