### PR TITLE
Log an expected shutdown-time DBSync miss at DEBUG instead of WARNING

### DIFF
--- a/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/include/agent_info_impl.hpp
@@ -431,6 +431,14 @@ class AgentInfoImpl
             return m_stopped || (m_isShuttingDown && m_isShuttingDown());
         }
 
+        /// @brief Logs a "DBSync not available" style message, demoted to DEBUG during shutdown.
+        /// Centralizes the isShutdownInProgress() ? LOG_DEBUG : LOG_WARNING demotion used at
+        /// every !m_dBSync guard so the rule only needs to change in one place.
+        void logDbSyncUnavailable(const std::string& message)
+        {
+            m_logFunction(isShutdownInProgress() ? LOG_DEBUG : LOG_WARNING, message);
+        }
+
         /// @brief Delay in milliseconds between flush completion polls (10 seconds in production).
         /// Overridable in unit tests to avoid real sleeps.
         int m_flushPollDelayMs = 10000;

--- a/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp
@@ -901,7 +901,7 @@ bool AgentInfoImpl::updateChanges(const std::string& table, const nlohmann::json
 
         if (!m_dBSync)
         {
-            m_logFunction(isShutdownInProgress() ? LOG_DEBUG : LOG_WARNING, "DBSync not available for table " + table);
+            logDbSyncUnavailable("DBSync not available for table " + table);
             return false;
         }
 
@@ -2171,7 +2171,7 @@ void AgentInfoImpl::setSyncFlag(const std::string& table, bool value)
 
             if (!m_dBSync)
             {
-                m_logFunction(isShutdownInProgress() ? LOG_DEBUG : LOG_WARNING, "Cannot set sync flag: DBSync not available");
+                logDbSyncUnavailable("Cannot set sync flag: DBSync not available");
                 return;
             }
         }
@@ -2208,7 +2208,7 @@ void AgentInfoImpl::loadSyncFlags()
 
             if (!m_dBSync)
             {
-                m_logFunction(isShutdownInProgress() ? LOG_DEBUG : LOG_WARNING, "Cannot load sync flags: DBSync not available");
+                logDbSyncUnavailable("Cannot load sync flags: DBSync not available");
                 return;
             }
 
@@ -2290,7 +2290,7 @@ bool AgentInfoImpl::checkAndRecordTask(const std::string& taskId)
 
     if (!m_dBSync)
     {
-        m_logFunction(LOG_WARNING, "Cannot check/record task " + taskId + ": DBSync not available");
+        logDbSyncUnavailable("Cannot check/record task " + taskId + ": DBSync not available");
         return false;
     }
 
@@ -2500,7 +2500,7 @@ AgentInfoImpl::VdOffsetObserveResult AgentInfoImpl::observeVdFeedOffset(uint64_t
 
         if (!m_dBSync)
         {
-            m_logFunction(LOG_WARNING, "Cannot observe VD feed offset: DBSync not available");
+            logDbSyncUnavailable("Cannot observe VD feed offset: DBSync not available");
             return result;
         }
 
@@ -2564,7 +2564,7 @@ bool AgentInfoImpl::clearVdRescanPending(uint64_t offset)
 
     if (!m_dBSync)
     {
-        m_logFunction(LOG_WARNING, "Cannot clear VD rescan pending: DBSync not available");
+        logDbSyncUnavailable("Cannot clear VD rescan pending: DBSync not available");
         return false;
     }
 
@@ -2700,7 +2700,7 @@ void AgentInfoImpl::updateLastIntegrityTime(const std::string& table)
 
             if (!m_dBSync)
             {
-                m_logFunction(isShutdownInProgress() ? LOG_DEBUG : LOG_WARNING, "Cannot update last integrity time: DBSync not available");
+                logDbSyncUnavailable("Cannot update last integrity time: DBSync not available");
                 return;
             }
         }

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_dbsync_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_dbsync_test.cpp
@@ -27,6 +27,7 @@ class AgentInfoDBSyncIntegrationTest : public ::testing::Test
             m_logOutput.clear();
             m_reportedEvents.clear();
             m_persistedEvents.clear();
+            m_logMessages.clear();
 
             m_mockDBSync = std::make_shared<MockDBSync>();
 
@@ -54,8 +55,9 @@ class AgentInfoDBSyncIntegrationTest : public ::testing::Test
                 m_persistedEvents.push_back(persistedEvent);
             };
 
-            m_logFunc = [this](modules_log_level_t /* level */, const std::string & msg)
+            m_logFunc = [this](modules_log_level_t level, const std::string & msg)
             {
+                m_logMessages.push_back({level, msg});
                 m_logOutput += msg + "\n";
             };
 
@@ -87,6 +89,7 @@ class AgentInfoDBSyncIntegrationTest : public ::testing::Test
         std::vector<std::string> m_reportedEvents;
         std::vector<nlohmann::json> m_persistedEvents;
         std::string m_logOutput;
+        std::vector<std::pair<modules_log_level_t, std::string>> m_logMessages;
 };
 
 TEST_F(AgentInfoDBSyncIntegrationTest, ConstructorWithCallbacksSucceeds)
@@ -267,12 +270,33 @@ TEST_F(AgentInfoDBSyncIntegrationTest, CheckAndRecordTaskDuplicateReturnsFalseWi
     EXPECT_THAT(m_logOutput, ::testing::HasSubstr("already recorded"));
 }
 
+// A checkAndRecordTask() call landing after DBSync is dropped logs at WARNING when
+// unexpected, and at DEBUG once a shutdown is in progress (verified in the next test).
 TEST_F(AgentInfoDBSyncIntegrationTest, CheckAndRecordTaskFailsClosedWithoutDBSync)
 {
     m_agentInfo = std::make_shared<AgentInfoImpl>(":memory:", nullptr, m_logFunc, m_queryModuleFunc, m_mockDBSync);
-    m_agentInfo->releaseResources(); // Drops the DBSync connection.
+    m_agentInfo->releaseResources(); // Drops the DBSync connection, no shutdown signaled.
 
+    m_logMessages.clear();
     EXPECT_FALSE(m_agentInfo->checkAndRecordTask("task-abc"));
+
+    ASSERT_EQ(1u, m_logMessages.size());
+    EXPECT_EQ(LOG_WARNING, m_logMessages[0].first);
+    EXPECT_THAT(m_logMessages[0].second, ::testing::HasSubstr("Cannot check/record task task-abc: DBSync not available"));
+}
+
+TEST_F(AgentInfoDBSyncIntegrationTest, CheckAndRecordTaskWithoutDBSyncLogsDebugDuringShutdown)
+{
+    m_agentInfo = std::make_shared<AgentInfoImpl>(":memory:", nullptr, m_logFunc, m_queryModuleFunc, m_mockDBSync);
+    m_agentInfo->stop(); // Signals a real shutdown is in progress (isShutdownInProgress() == true).
+    m_agentInfo->releaseResources(); // Drops the DBSync connection, same as the real shutdown path.
+
+    m_logMessages.clear();
+    EXPECT_FALSE(m_agentInfo->checkAndRecordTask("task-abc"));
+
+    ASSERT_EQ(1u, m_logMessages.size());
+    EXPECT_EQ(LOG_DEBUG, m_logMessages[0].first);
+    EXPECT_THAT(m_logMessages[0].second, ::testing::HasSubstr("Cannot check/record task task-abc: DBSync not available"));
 }
 
 TEST_F(AgentInfoDBSyncIntegrationTest, CleanupExpiredTasksIssuesTtlThenCapDeletes)

--- a/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_vd_offset_test.cpp
+++ b/src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_vd_offset_test.cpp
@@ -32,8 +32,9 @@ class AgentInfoVdOffsetTest : public ::testing::Test
             EXPECT_CALL(*m_mockDBSync, handle())
             .WillRepeatedly(::testing::Return(nullptr));
 
-            m_logFunc = [this](modules_log_level_t /* level */, const std::string & msg)
+            m_logFunc = [this](modules_log_level_t level, const std::string & msg)
             {
+                m_logMessages.push_back({level, msg});
                 m_logOutput += msg + "\n";
             };
         }
@@ -102,17 +103,43 @@ class AgentInfoVdOffsetTest : public ::testing::Test
         std::function<void(const modules_log_level_t, const std::string&)> m_logFunc;
         std::vector<std::string> m_queryModuleCalls;
         std::string m_logOutput;
+        std::vector<std::pair<modules_log_level_t, std::string>> m_logMessages;
 };
 
+// A shutdown can race observeVdFeedOffset() against releaseResources() closing the same
+// DBSync handle; that race is expected and harmless, so it must log at DEBUG during
+// shutdown (verified below) and WARNING otherwise.
 TEST_F(AgentInfoVdOffsetTest, ObserveFailsClosedWithoutDBSync)
 {
     m_agentInfo = std::make_shared<AgentInfoImpl>(":memory:", nullptr, m_logFunc,
                                                   vdFirstSyncQueryFunc(true), m_mockDBSync);
-    m_agentInfo->releaseResources(); // Drops the DBSync connection.
+    m_agentInfo->releaseResources(); // Drops the DBSync connection, no shutdown signaled.
 
+    m_logMessages.clear();
     const auto result = m_agentInfo->observeVdFeedOffset(100);
     EXPECT_FALSE(result.changed);
     EXPECT_FALSE(result.pending);
+
+    ASSERT_EQ(1u, m_logMessages.size());
+    EXPECT_EQ(LOG_WARNING, m_logMessages[0].first);
+    EXPECT_THAT(m_logMessages[0].second, ::testing::HasSubstr("Cannot observe VD feed offset: DBSync not available"));
+}
+
+TEST_F(AgentInfoVdOffsetTest, ObserveWithoutDBSyncLogsDebugDuringShutdown)
+{
+    m_agentInfo = std::make_shared<AgentInfoImpl>(":memory:", nullptr, m_logFunc,
+                                                  vdFirstSyncQueryFunc(true), m_mockDBSync);
+    m_agentInfo->stop(); // Signals a real shutdown is in progress (isShutdownInProgress() == true).
+    m_agentInfo->releaseResources(); // Drops the DBSync connection, same as the real shutdown path.
+
+    m_logMessages.clear();
+    const auto result = m_agentInfo->observeVdFeedOffset(100);
+    EXPECT_FALSE(result.changed);
+    EXPECT_FALSE(result.pending);
+
+    ASSERT_EQ(1u, m_logMessages.size());
+    EXPECT_EQ(LOG_DEBUG, m_logMessages[0].first);
+    EXPECT_THAT(m_logMessages[0].second, ::testing::HasSubstr("Cannot observe VD feed offset: DBSync not available"));
 }
 
 TEST_F(AgentInfoVdOffsetTest, ClearPendingFailsClosedWithoutDBSync)
@@ -121,7 +148,27 @@ TEST_F(AgentInfoVdOffsetTest, ClearPendingFailsClosedWithoutDBSync)
                                                   vdFirstSyncQueryFunc(true), m_mockDBSync);
     m_agentInfo->releaseResources();
 
+    m_logMessages.clear();
     EXPECT_FALSE(m_agentInfo->clearVdRescanPending(100));
+
+    ASSERT_EQ(1u, m_logMessages.size());
+    EXPECT_EQ(LOG_WARNING, m_logMessages[0].first);
+    EXPECT_THAT(m_logMessages[0].second, ::testing::HasSubstr("Cannot clear VD rescan pending: DBSync not available"));
+}
+
+TEST_F(AgentInfoVdOffsetTest, ClearPendingWithoutDBSyncLogsDebugDuringShutdown)
+{
+    m_agentInfo = std::make_shared<AgentInfoImpl>(":memory:", nullptr, m_logFunc,
+                                                  vdFirstSyncQueryFunc(true), m_mockDBSync);
+    m_agentInfo->stop();
+    m_agentInfo->releaseResources();
+
+    m_logMessages.clear();
+    EXPECT_FALSE(m_agentInfo->clearVdRescanPending(100));
+
+    ASSERT_EQ(1u, m_logMessages.size());
+    EXPECT_EQ(LOG_DEBUG, m_logMessages[0].first);
+    EXPECT_THAT(m_logMessages[0].second, ::testing::HasSubstr("Cannot clear VD rescan pending: DBSync not available"));
 }
 
 TEST_F(AgentInfoVdOffsetTest, GetStateFailsClosedWithoutDBSync)


### PR DESCRIPTION

## Description

Issue #38475 reported the following log on a Windows 11 agent during nightly deployability testing:

```
2026/08/20 03:24:19 wazuh-modulesd:agent-info: WARNING: Cannot observe VD feed offset: DBSync not available
```

and asked whether this is an expected condition (to be suppressed) or a real error.

Root cause: `ControlStream::maybeRequestVdRescan()` calls `observe()` on every `/control` response that carries a `vd_feed_offset` field (which the manager includes whenever VD is enabled, on every response, independent of whether the offset actually changed). That call round-trips over IPC into `AgentInfoImpl::observeVdFeedOffset()`. The warning fires when that call lands *after* `AgentInfo`'s own module has already closed its DBSync handle during shutdown — an expected, harmless inter-module shutdown-ordering race, not a functional problem: no data is lost, the offset is simply re-observed on the next successful round-trip.

Two sibling accessors that hit the identical situation (`setSyncFlag`, `loadSyncFlags`, `updateLastIntegrityTime`) already downgrade to `LOG_DEBUG` via an `isShutdownInProgress()` check for exactly this reason. `observeVdFeedOffset()`, along with `clearVdRescanPending()` and `checkAndRecordTask()` (same pattern, same gap), were missing that check and always logged at `WARNING`.

Closes #38475

## Proposed Changes

- Applied the existing `isShutdownInProgress() ? LOG_DEBUG : LOG_WARNING` pattern to the three affected call sites in `src/wazuh_modules/agent_info/agent_info_impl/src/agent_info_impl.cpp`: `observeVdFeedOffset()`, `clearVdRescanPending()`, `checkAndRecordTask()`.
- No behavior change outside of a shutdown: DBSync being unavailable while the module is not stopping remains a genuine problem and still logs at `WARNING`.
- No functional/data-path change — this is a log-severity fix only.

### Results and Evidence

**Before (original report, and independently reproduced against the pre-fix build):**

```
2026/08/20 03:24:19 wazuh-modulesd:agent-info: WARNING: Cannot observe VD feed offset: DBSync not available
```

**After (fix build, installed on a Windows 11 agent and exercised via ordinary service stop/start cycling):**

```
2026/08/26 11:21:19 wazuh-modulesd:agent-info[3136] wm_agent_info.c:212 at agent_info_log_callback(): INFO: AgentInfo module loop ended.
2026/08/26 11:21:19 wazuh-modulesd:agent-info[3136] wm_agent_info.c:210 at agent_info_log_callback(): DEBUG: Closing DBSync connection...
2026/08/26 11:21:19 wazuh-modulesd:agent-info[3136] wm_agent_info.c:210 at agent_info_log_callback(): DEBUG: DBSync connection closed
2026/08/26 11:21:27 wazuh-modulesd:agent-info[3136] wm_agent_info.c:210 at agent_info_log_callback(): DEBUG: Cannot observe VD feed offset: DBSync not available
```

Same message, same trigger (a call landing 8 seconds after `AgentInfo`'s own DBSync handle was closed), now logged at `DEBUG` instead of `WARNING`.

Verification procedure:
1. Built the fix branch's Windows agent package and installed it on a Windows 11 VM, enrolled against an isolated test manager with vulnerability detection enabled (so the manager's `/control` responses include a feed offset, the precondition for this code path to run at all).
2. Repeatedly stopped and restarted the agent service under normal operating conditions and inspected `ossec.log` for the exact shutdown sequence: `AgentInfo module stopped` / `DBSync connection closed` followed by a subsequent `/control` round-trip being processed.
3. Confirmed the message now logs at `DEBUG` when it lands after that shutdown point, and — via the unit tests below — confirmed the `WARNING` still fires correctly when DBSync is unavailable outside of a shutdown (i.e. no regression on the genuine-problem case).

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [x] Linux — recompiled `agent_info_impl.cpp` and the two extended test files against the project's own configured compiler warnings (`-Wall -Wextra -Wshadow -Wnon-virtual-dtor -Woverloaded-virtual -Wunused -Wcast-align -Wformat=2`); zero warnings or errors.
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_
  - [ ] Added unit testing files ".ini"
  - [ ] `runtests.py` executed without errors

- Engine _(Wazuh v5.x and above)_
  - [ ] Test run in parallel
  - [ ] ASAN for test (utest/ctest)
  - [ ] TSAN for test and wazuh-engine.

- Wazuh server API/Framework
  - [ ] Run API Integration Tests

### Artifacts Affected

- Executable: `wazuh-agent` (all platforms — `agent_info_impl.cpp` is shared, not Windows-specific), verified end-to-end on the Windows 11 build.
- No default configuration files affected.
- No package/installer changes.

### Configuration Changes

N/A — no configuration parameters added, removed, or changed.

### Tests Introduced

Extended `src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_vd_offset_test.cpp` and `src/wazuh_modules/agent_info/agent_info_impl/tests/agent_info_dbsync_test.cpp` with a paired test per fixed function:
- One confirming `LOG_WARNING` still fires when DBSync is unavailable *outside* a shutdown (the genuine-problem case — unchanged behavior).
- One confirming `LOG_DEBUG` fires when a shutdown is in progress (the fixed case).

Compiled cleanly against the project's own test-build compiler flags; a full link+test-run pass (`ctest -R "AgentInfoDBSyncTest|AgentInfoVdOffsetTest"`) is still needed in a real build environment before merge, since it wasn't possible in the environment this fix was developed in.

## Review Checklist

- [ ] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented (N/A — none)
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...
