### PR TITLE
Ignore obsolete 4.x configuration elements instead of rejecting them

### DIFF
--- a/src/config/src/config.c
+++ b/src/config/src/config.c
@@ -14,6 +14,78 @@
 #include "os_xml.h"
 #include "config.h"
 
+#ifdef CLIENT
+#define IS_AGENT_BUILD 1
+#else
+#define IS_AGENT_BUILD 0
+#endif
+
+/* Where an element stopped being valid */
+#define OBS_ALWAYS      0   /* Everywhere it can appear */
+#define OBS_SERVER_CONF 1   /* Only in the manager's own configuration file */
+
+typedef struct obsolete_element_t {
+    const char *element;
+    int scope;
+    const char *hint;
+} obsolete_element_t;
+
+/* Top-level elements that 4.x accepted and 5.0.0 no longer has a parser for.
+ *
+ * An element with no parser reaches the end of read_main_elements() and is fatal,
+ * so a configuration file carried over from 4.x stops the daemon from starting at
+ * all. An agent upgrade is supported and never rewrites ossec.conf, and a manager
+ * still distributes agent.conf files written for 4.x, so these are accepted and
+ * ignored with a warning instead of rejected. Anything not listed here is still
+ * fatal: the point is to be lenient with settings that were removed on purpose,
+ * not with typos.
+ *
+ * <active-response> is the one element whose validity depends on who is reading
+ * it. It is live configuration on an agent -- execd reads it straight from the
+ * file, see os_execd/src/config.c -- and the manager parses agent.conf on the
+ * agent's behalf, so it is obsolete only when the manager reads its own file. */
+static const obsolete_element_t OBSOLETE_ELEMENTS[] = {
+    {"active-response", OBS_SERVER_CONF, "Active Response is not configured on the manager. This block only applies to agents."},
+    {"agent-key-polling", OBS_ALWAYS,    "The agent key polling module was removed in 5.0.0."},
+    {"agentless",       OBS_ALWAYS,      "The wazuh-agentlessd daemon was removed in 5.0.0."},
+    {"alerts",          OBS_ALWAYS,      "Alert output is not configured in the configuration file."},
+    {"client_buffer",   OBS_ALWAYS,      "Event batching is configured under <agent><batch>."},
+    {"command",         OBS_ALWAYS,      "Active Response commands are not defined in the configuration file."},
+    {"database_output", OBS_ALWAYS,      "The wazuh-dbd daemon was removed in 5.0.0."},
+    {"email_alerts",    OBS_ALWAYS,      "The wazuh-maild daemon was removed in 5.0.0."},
+    {"fluent-forward",  OBS_ALWAYS,      "The fluent forwarder module was removed in 5.0.0."},
+    {"integration",     OBS_ALWAYS,      "The wazuh-integratord daemon was removed in 5.0.0."},
+    {"labels",          OBS_ALWAYS,      "Agent labels were removed in 5.0.0."},
+    {"reports",         OBS_ALWAYS,      "The wazuh-reportd daemon was removed in 5.0.0."},
+    {"rule_test",       OBS_ALWAYS,      "Rule testing is provided by the engine."},
+    {"ruleset",         OBS_ALWAYS,      "Rules and decoders are managed by the engine."},
+    {"syslog_output",   OBS_ALWAYS,      "The wazuh-csyslogd daemon was removed in 5.0.0."},
+    {NULL,              0,               NULL}
+};
+
+/* Return the explanation for an element that is obsolete in this context, or NULL
+ * if the element is either still valid here or not one we know about. */
+static const char *get_obsolete_hint(const char *element, int modules)
+{
+    /* True only while reading the manager's own configuration: an agent build
+     * never qualifies, and neither does a manager reading a remote agent.conf. */
+    const int server_conf = !IS_AGENT_BUILD && !(modules & CAGENT_CONFIG);
+    int i;
+
+    for (i = 0; OBSOLETE_ELEMENTS[i].element != NULL; i++) {
+        if (strcmp(element, OBSOLETE_ELEMENTS[i].element) != 0) {
+            continue;
+        }
+
+        if (OBSOLETE_ELEMENTS[i].scope == OBS_SERVER_CONF && !server_conf) {
+            return NULL;
+        }
+
+        return OBSOLETE_ELEMENTS[i].hint;
+    }
+
+    return NULL;
+}
 
 /* Read the main elements of the configuration */
 static int read_main_elements(const OS_XML *xml, int modules,
@@ -28,7 +100,6 @@ static int read_main_elements(const OS_XML *xml, int modules,
     const char *oslocalfile = "localfile";                      /* Agent Config  */
     const char *osremote = "remote";                            /* Agent Config  */
     const char *osclient = "client";                            /* Agent Config  */
-    const char *osbuffer = "client_buffer";                     /* Removed in 5.0.0 (#38030) */
     const char *osagent = "agent";                              /* Agent Config (HTTPS endpoint) */
     const char *osactiveresponse = "active-response";           /* Agent Active Response Config  */
     const char *oswmodule = "wodle";                            /* Wodle - Wazuh Module  */
@@ -57,10 +128,21 @@ static int read_main_elements(const OS_XML *xml, int modules,
 
     while (node[i]) {
         XML_NODE chld_node = NULL;
+        const char *obsolete_hint = NULL;
 
         if (!node[i]->element) {
             merror(XML_ELEMNULL);
             goto fail;
+        }
+
+        /* Checked before anything else so a removed element is never mistaken for
+         * an unknown one, which is fatal further down. */
+        obsolete_hint = get_obsolete_hint(node[i]->element, modules);
+
+        if (obsolete_hint != NULL) {
+            mwarn(XML_OBSOLETE, node[i]->element, obsolete_hint);
+            i++;
+            continue;
         }
 
         chld_node = OS_GetElementsbyNode(xml, node[i]);
@@ -120,14 +202,7 @@ static int read_main_elements(const OS_XML *xml, int modules,
                 goto fail;
             }
 #endif
-        } else if (strcmp(node[i]->element, osbuffer) == 0) {
-            /* Accepted and ignored rather than rejected (an unknown element is
-             * fatal here), so an ossec.conf or a pushed agent.conf still
-             * carrying it does not stop the agent from starting. */
-            minfo("'%s' is no longer used and will be ignored. Event batching is configured "
-                  "under <agent><batch>.", node[i]->element);
-        }
-        else if (strcmp(node[i]->element, oswmodule) == 0) {
+        } else if (strcmp(node[i]->element, oswmodule) == 0) {
             if ((modules & CWMODULE) && (Read_WModule(xml, node[i], d1, d2) < 0)) {
                 goto fail;
             }
@@ -238,7 +313,9 @@ static int read_main_elements(const OS_XML *xml, int modules,
         }
 #endif
         else if (strcmp(node[i]->element, osactiveresponse) == 0) {
-            /* Active response config is only for agents, parsed by execd */
+            /* Agent Active Response settings. Only reached when the block is
+             * valid here (see OBSOLETE_ELEMENTS): execd reads it from the file
+             * itself, so there is nothing to parse at this point. */
         } else {
             merror(XML_INVELEM, node[i]->element);
             goto fail;

--- a/src/shared/include/error_messages/error_messages.h
+++ b/src/shared/include/error_messages/error_messages.h
@@ -83,6 +83,7 @@
 #define RULES_ERROR     "(1220): Error loading the rules: '%s'."
 #define LISTS_ERROR     "(1221): Error loading the list: '%s'."
 #define IMSG_ERROR      "(1222): Invalid msg: %s"
+#define XML_OBSOLETE    "(1223): '%s' is no longer supported and will be ignored. %s"
 #define QUEUE_SEND      "(1224): Error sending message to queue."
 #define SIGNAL_RECV     "(1225): SIGNAL [(%d)-(%s)] Received. Exit Cleaning..."
 #define XML_ERROR       "(1226): Error reading XML file '%s': %s (line %d)."

--- a/src/unit_tests/config/CMakeLists.txt
+++ b/src/unit_tests/config/CMakeLists.txt
@@ -33,8 +33,23 @@ include(${SRC_FOLDER}/unit_tests/wrappers/wazuh/shared/shared.cmake)
 
 # Generate config tests
 if(NOT ${TARGET} STREQUAL "manager")
+    # The unit-test build does not define CLIENT, but the config library these
+    # tests link was built with it for agent targets. A test that needs to know
+    # which one it is linked against cannot ask CLIENT, nor anything derived from
+    # it such as WAZUHCONFIG, so the target is passed in explicitly.
+    add_definitions(-DTEST_AGENT_TARGET)
+
     list(APPEND config_names "test_client-config_validate_ipv6_link_local_interface")
     list(APPEND config_flags "-Wl,--wrap,OS_GetHost -Wl,--wrap=Start_win32_Syscheck -Wl,--wrap,syscom_dispatch \
+                              -Wl,--wrap=is_fim_shutdown -Wl,--wrap=_imp__dbsync_initialize \
+                              -Wl,--wrap=fim_db_teardown -Wl,--wrap,w_query_agentd ${DEBUG_OP_WRAPPERS}")
+
+    # Named test_config-elements, not test_config: CMake target names are global
+    # and syscheckd already builds a test_config out of syscheck_config.c.
+    list(APPEND config_names "test_config-elements")
+    # Same wraps as the sibling tests below: this binary links CONFIG_O, which on
+    # winagent drags win_utils.obj and win_service.obj out of DEPENDENCIES_O.
+    list(APPEND config_flags "-Wl,--wrap=Start_win32_Syscheck -Wl,--wrap,syscom_dispatch \
                               -Wl,--wrap=is_fim_shutdown -Wl,--wrap=_imp__dbsync_initialize \
                               -Wl,--wrap=fim_db_teardown -Wl,--wrap,w_query_agentd ${DEBUG_OP_WRAPPERS}")
 
@@ -49,6 +64,10 @@ if(NOT ${TARGET} STREQUAL "manager")
 endif()
 
 if(${TARGET} STREQUAL "manager")
+    # See the note above on the target name.
+    list(APPEND config_names "test_config-elements")
+    list(APPEND config_flags "${DEBUG_OP_WRAPPERS}")
+
     list(APPEND config_names "test_indexer")
     list(APPEND config_flags "-Wl,--wrap,Read_Indexer -Wl,--wrap,get_indexer_cnf ${DEBUG_OP_WRAPPERS}")
 

--- a/src/unit_tests/config/test_config-elements.c
+++ b/src/unit_tests/config/test_config-elements.c
@@ -1,0 +1,205 @@
+/* Copyright (C) 2015, Wazuh Inc.
+ *
+ * This program is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "shared.h"
+#include "os_xml.h"
+#include "config.h"
+#include "../wrappers/wazuh/shared/debug_op_wrappers.h"
+
+static const char *TEST_CONF_PATH = "test_config-elements.conf";
+
+/* The root element and the treatment of <active-response> both depend on whether
+ * the config library under test was built for an agent, and the test cannot ask
+ * CLIENT: the unit-test build never defines it, while the library it links does
+ * for agent targets. WAZUHCONFIG is derived from CLIENT, so it is unusable here
+ * for the same reason -- it would expand to the manager's root element in a
+ * binary linked against an agent library. TEST_AGENT_TARGET comes from
+ * CMakeLists.txt, which does know the target. */
+#ifdef TEST_AGENT_TARGET
+#define CONF_ROOT "ossec_config"
+#else
+#define CONF_ROOT "wazuh_config"
+#endif
+
+#define CONF_OPEN  "<" CONF_ROOT ">"
+#define CONF_CLOSE "</" CONF_ROOT ">"
+
+static int write_conf(const char *body) {
+    FILE *fp = fopen(TEST_CONF_PATH, "w");
+
+    if (!fp) {
+        return -1;
+    }
+
+    fputs(CONF_OPEN, fp);
+    fputs(body, fp);
+    fputs(CONF_CLOSE, fp);
+    fclose(fp);
+
+    return 0;
+}
+
+static int teardown_conf_file(void **state) {
+    unlink(TEST_CONF_PATH);
+    return 0;
+}
+
+/* A top-level element that was valid in 4.x and has no parser left must be
+ * ignored with a warning. Rejecting it is fatal, which is what took the whole
+ * daemon down when a configuration file was carried over from 4.x. */
+static void test_obsolete_element_is_ignored(void **state) {
+    if (write_conf("<command>"
+                   "<name>ar-test</name>"
+                   "<executable>block-ip</executable>"
+                   "</command>") != 0) {
+        fail();
+    }
+
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "(1223): 'command' is no longer supported and will be ignored. "
+                  "Active Response commands are not defined in the configuration file.");
+
+    assert_int_equal(ReadConfig(CGLOBAL, TEST_CONF_PATH, NULL, NULL), 0);
+}
+
+/* Every entry of the table warns with its own explanation, and one obsolete
+ * element does not stop the rest of the file from being read. */
+static void test_several_obsolete_elements_are_ignored(void **state) {
+    if (write_conf("<labels><label key=\"test\">value</label></labels>"
+                   "<ruleset><rule_dir>etc/rules</rule_dir></ruleset>"
+                   "<syslog_output><server>192.0.2.1</server></syslog_output>") != 0) {
+        fail();
+    }
+
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "(1223): 'labels' is no longer supported and will be ignored. "
+                  "Agent labels were removed in 5.0.0.");
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "(1223): 'ruleset' is no longer supported and will be ignored. "
+                  "Rules and decoders are managed by the engine.");
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "(1223): 'syslog_output' is no longer supported and will be ignored. "
+                  "The wazuh-csyslogd daemon was removed in 5.0.0.");
+
+    assert_int_equal(ReadConfig(CGLOBAL, TEST_CONF_PATH, NULL, NULL), 0);
+}
+
+/* An empty obsolete element has no children, so it takes a different path
+ * through the reader than the ones above. It must be ignored just the same. */
+static void test_empty_obsolete_element_is_ignored(void **state) {
+    if (write_conf("<client_buffer></client_buffer>") != 0) {
+        fail();
+    }
+
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "(1223): 'client_buffer' is no longer supported and will be ignored. "
+                  "Event batching is configured under <agent><batch>.");
+
+    assert_int_equal(ReadConfig(CGLOBAL, TEST_CONF_PATH, NULL, NULL), 0);
+}
+
+/* Leniency is limited to the elements that were removed on purpose. An element
+ * nobody ever supported is still an error, so typos keep being caught. */
+static void test_unknown_element_is_still_fatal(void **state) {
+    if (write_conf("<not_a_wazuh_element>x</not_a_wazuh_element>") != 0) {
+        fail();
+    }
+
+    expect_string(__wrap__merror, formatted_msg,
+                  "(1230): Invalid element in the configuration: 'not_a_wazuh_element'.");
+    expect_string(__wrap__merror, formatted_msg,
+                  "(1202): Configuration error at 'test_config-elements.conf'.");
+
+    assert_int_equal(ReadConfig(CGLOBAL, TEST_CONF_PATH, NULL, NULL), OS_INVALID);
+}
+
+#ifdef TEST_AGENT_TARGET
+
+/* <active-response> is live configuration on an agent -- execd reads it from the
+ * file itself -- so it must be accepted without a word. */
+static void test_active_response_is_valid_on_agent(void **state) {
+    if (write_conf("<active-response>"
+                   "<disabled>no</disabled>"
+                   "<ca_verification>yes</ca_verification>"
+                   "</active-response>") != 0) {
+        fail();
+    }
+
+    assert_int_equal(ReadConfig(CGLOBAL, TEST_CONF_PATH, NULL, NULL), 0);
+}
+
+#else
+
+/* Nothing on the manager reads <active-response>. It used to be dropped without
+ * a word, which left an operator with a block that parses, looks configured and
+ * never fires. It is obsolete here, and says so. */
+static void test_active_response_is_obsolete_on_manager(void **state) {
+    if (write_conf("<active-response>"
+                   "<disabled>no</disabled>"
+                   "<command>ar-test</command>"
+                   "<location>local</location>"
+                   "</active-response>") != 0) {
+        fail();
+    }
+
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "(1223): 'active-response' is no longer supported and will be ignored. "
+                  "Active Response is not configured on the manager. This block only applies to agents.");
+
+    assert_int_equal(ReadConfig(CGLOBAL, TEST_CONF_PATH, NULL, NULL), 0);
+}
+
+/* Both halves of the 4.x Active Response configuration behave the same way now:
+ * the block that defined a response and the block that referenced it are both
+ * ignored with a warning, instead of one being fatal and the other silent. */
+static void test_active_response_pair_is_symmetric(void **state) {
+    if (write_conf("<command>"
+                   "<name>ar-test</name>"
+                   "<executable>block-ip</executable>"
+                   "</command>"
+                   "<active-response>"
+                   "<command>ar-test</command>"
+                   "<location>local</location>"
+                   "</active-response>") != 0) {
+        fail();
+    }
+
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "(1223): 'command' is no longer supported and will be ignored. "
+                  "Active Response commands are not defined in the configuration file.");
+    expect_string(__wrap__mwarn, formatted_msg,
+                  "(1223): 'active-response' is no longer supported and will be ignored. "
+                  "Active Response is not configured on the manager. This block only applies to agents.");
+
+    assert_int_equal(ReadConfig(CGLOBAL, TEST_CONF_PATH, NULL, NULL), 0);
+}
+
+#endif
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_teardown(test_obsolete_element_is_ignored, teardown_conf_file),
+        cmocka_unit_test_teardown(test_several_obsolete_elements_are_ignored, teardown_conf_file),
+        cmocka_unit_test_teardown(test_empty_obsolete_element_is_ignored, teardown_conf_file),
+        cmocka_unit_test_teardown(test_unknown_element_is_still_fatal, teardown_conf_file),
+#ifdef TEST_AGENT_TARGET
+        cmocka_unit_test_teardown(test_active_response_is_valid_on_agent, teardown_conf_file),
+#else
+        cmocka_unit_test_teardown(test_active_response_is_obsolete_on_manager, teardown_conf_file),
+        cmocka_unit_test_teardown(test_active_response_pair_is_symmetric, teardown_conf_file),
+#endif
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## Description

Closes #38563

`read_main_elements()` has exactly two outcomes for a top-level configuration element: a parser runs, or it falls through to `merror(XML_INVELEM)` and aborts. There is no third state for "known element, removed in 5.0.0". Every 4.x element that lost its parser is therefore fatal, and a configuration file carried over from 4.x stops the daemon from starting.

Exactly one element got that third state, hand-coded: `client_buffer`, added in 52b9bf7af3 with the reasoning that an agent upgrade never rewrites `ossec.conf`, so the block must not be fatal. That reasoning applies to ten other elements that never received the same treatment.

The Active Response surface shows the resulting asymmetry. `<command>` — how a response was *defined* in 4.x — is rejected and the manager refuses to start. `<active-response>` — how a response was *referenced* — reaches an empty branch and is discarded with no message at all, on the manager where nothing reads it. An operator who removes the `<command>` block to get the manager up is left with an `<active-response>` block that parses, looks configured, and never fires.

On the agent the same class of bug is worse in practice. `wazuh-control restart` runs `testconfig` before stopping anything, so a rejected element aborts the restart and leaves the previous daemons running with the previous configuration, while `wazuh-control status` keeps reporting them as healthy. That is how a `<labels>` block carried over from 4.x turns into an agent that silently ignores every subsequent configuration change.

**Scope.** This PR addresses the parser: the elements the issue reports are no longer rejected, so they no longer abort an agent restart, and the two halves of the Active Response configuration stop behaving differently. It does **not** change what `wazuh-control status` reports. An agent whose configuration is invalid for some other reason will still abort its restart and still be reported as healthy; that half of the issue remains open.

## Proposed Changes

**Obsolete elements are ignored with a warning instead of being fatal** (`src/config/src/config.c`)

- Added a table of top-level elements that 4.x accepted and 5.0.0 no longer parses, checked before anything else in the element loop so a removed element can never reach the fatal branch: `active-response` (manager only), `agent-key-polling`, `agentless`, `alerts`, `client_buffer`, `command`, `database_output`, `email_alerts`, `fluent-forward`, `integration`, `labels`, `reports`, `rule_test`, `ruleset`, `syslog_output`.
- The list is the complete set difference between v4.14.7's top-level elements and the ones 5.0.0 still parses, computed from both versions of `read_main_elements` rather than assembled by hand: 39 elements in 4.x, 26 still parsed, 15 in the table (`active-response` appears in both, since it stays valid on the agent). Nothing removed in 5.0.0 is left out, and nothing in the table is an element 4.x never had.
- Each entry carries its own explanation — the daemon that was removed, or where the setting went — so message 1230's bare `Invalid element in the configuration: 'command'` is replaced by something an operator migrating from 4.x can act on.
- Elements not in the table are still rejected exactly as before, so typos keep being caught.
- Each entry has a scope. `<active-response>` is live configuration on an agent — `execd` reads it straight from the file, see `os_execd/src/config.c` — and the manager parses `agent.conf` on the agent's behalf, so it is obsolete only when the manager reads its own file. This makes the two halves of the 4.x Active Response configuration behave identically and closes the silent-discard case.
- Replaced the hand-coded `client_buffer` branch with its table entry (`minfo` becomes `mwarn`: a block that parses and silently stops working warrants a warning).

**New message** (`src/shared/include/error_messages/error_messages.h`)

- `(1223): '%s' is no longer supported and will be ignored. %s`

### Results and Evidence

The table logic was extracted and compiled standalone under `-Wall -Wextra`, both with and without `-DCLIENT`, to confirm the scope rule resolves correctly on each build:

```
                        manager build                              agent build
command             ->  Active Response commands are not ...   |   Active Response commands are not ...
labels              ->  Agent labels were removed in 5.0.0.    |   Agent labels were removed in 5.0.0.
ar (manager conf)   ->  Active Response is not configured ...  |   (null: still valid)
ar (agent.conf)     ->  (null: still valid)                    |   (null: still valid)
global              ->  (null: still valid)                    |   (null: still valid)
typo 'commnd'       ->  (null: still fatal)                    |   (null: still fatal)
```

Table completeness was checked by extracting the top-level element list from `read_main_elements` in both `v4.14.7` and this branch and diffing them against the table. Every element 4.x accepted is either still parsed or covered, and every table entry is an element 4.x actually had. Three entries — `rule_test`, `fluent-forward` and `agent-key-polling` — were added as a result of that audit; they had been missed when the list was first assembled by reading the diff.

The unit tests introduced below have been through two CI rounds, each of which found a real problem in the test harness rather than in the parser:

- The first run failed at CMake configure time with a duplicate target name — `unit_tests/syscheckd` already builds a `test_config`, and CMake target names are global. The test was renamed to `test_config-elements`.
- The second run failed all six cases on the agent target with `Invalid element in the configuration: 'wazuh_config'`. The unit-test build never defines `CLIENT`, while the `config` library it links is built with it for agent targets, so `WAZUHCONFIG` in the test expanded to the manager's root element inside a binary linked against an agent library — and the same bad inference selected the manager test set. The test now takes the target from a `TEST_AGENT_TARGET` definition supplied by `CMakeLists.txt`, which is the only place that knows it.

A green run has not been observed yet. Both fixes were reasoned through against the library's compile-time configuration for every target, but the evidence for them is the two failures above, not a passing run.

### Artifacts Affected

- `config.c` is part of the shared configuration library, so the change reaches every daemon that reads a configuration file, on the manager and on the agent, across Linux, macOS and Windows.
- No default configuration file was modified. The shipped manager configuration contains no `<command>` or `<active-response>` block, and the shipped agent configuration keeps its `<active-response>` block, which stays valid.

### Configuration Changes

- No new configuration parameters, and no changed defaults.
- Behaviour change: configuration elements listed in the table no longer prevent a daemon from starting. They now produce a `(1223)` warning and are ignored. This is what makes an in-place agent upgrade from 4.x survive an `ossec.conf` that still carries `<labels>` or `<command>`.
- Behaviour change: `<active-response>` in the manager's own configuration file now warns instead of being silently discarded. It is unchanged everywhere it is still valid — an agent's `ossec.conf`, and an `agent.conf` the manager parses on the agent's behalf.
- No backward-compatibility concern in the other direction: a 5.0.0 configuration file contains none of these elements, so nothing that parses cleanly today starts warning.

### Tests Introduced

`src/unit_tests/config/test_config-elements.c`, registered for both the manager and agent targets in `src/unit_tests/config/CMakeLists.txt`.

Two harness details worth knowing when reading it:

- It is named `test_config-elements`, not `test_config`, because CMake target names are global across the project and `unit_tests/syscheckd` already builds a `test_config` out of `syscheck_config.c`.
- Both the root element it writes and the `<active-response>` case it selects come from `TEST_AGENT_TARGET`, passed in by `CMakeLists.txt`. The test cannot use `CLIENT` — the unit-test build does not define it, while the library under test does for agent targets — nor anything derived from it, such as `WAZUHCONFIG`.

Cases, run against both the manager and the agent build of the library:

- An obsolete element is ignored, and warns with its own explanation.
- Several obsolete elements in one file each warn with their own text, and one does not stop the rest of the file from being read.
- An obsolete element with no children is ignored too, since it takes a different path through the reader.
- An element nobody ever supported is still fatal, with 1230 followed by 1202.

Agent build only:

- `<active-response>` is accepted without a word.

Manager build only:

- `<active-response>` warns as obsolete.
- `<command>` and `<active-response>` together warn identically, covering the asymmetry the issue reports.

## Review Checklist
- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [ ] ...
